### PR TITLE
gc: `pin_root` returns its normalized word, the write-barrier order, and two `gc` module answers

### DIFF
--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -91,6 +91,14 @@ pub mod flags {
     /// queue enforce the contract for callers that cannot establish single
     /// registration statically.
     pub const FINALIZER_REGISTERED: u64 = 1 << 13;
+    /// The object's finalizer has already run (bit 14).
+    ///
+    /// Not an incminimark flag either — the queue delivers an object once and
+    /// incminimark never asks the question afterwards. `gc.is_finalized` does
+    /// ask it: an object its own finalizer resurrected reports
+    /// `_PyGC_FINALIZED`, and with nothing recorded the answer could only be a
+    /// constant `false`.
+    pub const FINALIZER_RUN: u64 = 1 << 14;
 }
 
 /// Low-level trigger stored in an RPython finalizer handler.  It must only
@@ -2804,6 +2812,22 @@ pub fn gc_owns_object(addr: usize) -> bool {
     match ACTIVE_GC_OWNS_OBJECT.get() {
         Some(f) => f(addr),
         None => false,
+    }
+}
+
+/// Whether the finalizer for the object at `addr` has already run.
+///
+/// `false` for an address the active backend's heap does not own, which is the
+/// answer [`GcAllocator::register_finalizer`] already implies for one: it
+/// declines to register a finalizer for such a pointer at all.
+pub fn gc_finalizer_has_run(addr: usize) -> bool {
+    gc_owns_object(addr) && unsafe { (*header::header_of(addr)).has_flag(flags::FINALIZER_RUN) }
+}
+
+/// Record that the finalizer for the object at `addr` has run.
+pub fn gc_mark_finalizer_run(addr: usize) {
+    if gc_owns_object(addr) {
+        unsafe { (*header::header_of(addr)).set_flag(flags::FINALIZER_RUN) };
     }
 }
 

--- a/pyre/extra_tests/snippets/gc_is_finalized_reports_a_resurrected_object.py
+++ b/pyre/extra_tests/snippets/gc_is_finalized_reports_a_resurrected_object.py
@@ -1,0 +1,34 @@
+# pyre-check: gate=1
+"""`gc.is_finalized` reports an object whose `__del__` already ran.
+
+A fresh object answers False, so the divergence is only visible once a
+finalizer has resurrected its own receiver: the object is reachable again and
+the answer has to be True.  The finalizer still runs at most once.
+"""
+
+import gc
+
+storage = []
+
+
+class Lazarus:
+    def __del__(self):
+        storage.append(self)
+
+
+lazarus = Lazarus()
+print(gc.is_finalized(lazarus))
+
+del lazarus
+gc.collect()
+
+lazarus = storage.pop()
+print(gc.is_finalized(lazarus))
+
+# The finalizer does not run a second time for the resurrected object.
+del lazarus
+gc.collect()
+print(len(storage))
+
+# An object no collector tracks is never finalized.
+print(gc.is_finalized(3))

--- a/pyre/extra_tests/snippets/gc_set_threshold_keeps_the_third_value.py
+++ b/pyre/extra_tests/snippets/gc_set_threshold_keeps_the_third_value.py
@@ -1,0 +1,22 @@
+# pyre-check: gate=1
+"""`gc.set_threshold` stores all three thresholds and `get_threshold` reports them.
+
+3.14's collector is incremental and sizes no third generation, but the value it
+is handed still round-trips, so a caller that saves the thresholds and restores
+them gets back what it saved.
+"""
+
+import gc
+
+saved = gc.get_threshold()
+print(len(saved))
+
+gc.set_threshold(1, 2, 3)
+print(gc.get_threshold())
+
+# An omitted trailing value keeps the threshold already there.
+gc.set_threshold(11, 22)
+print(gc.get_threshold())
+
+gc.set_threshold(*saved)
+print(gc.get_threshold() == saved)

--- a/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
+++ b/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
@@ -232,13 +232,13 @@ fn ga_call(args: &[PyObjectRef]) -> crate::PyResult {
     let origin = unsafe { w_generic_alias_get_origin(self_) };
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_);
-    pyre_object::gc_roots::pin_root(origin);
+    let _ = pyre_object::gc_roots::pin_root(self_);
+    let _ = pyre_object::gc_roots::pin_root(origin);
     let result = crate::builtins::call_forwarding_args(
         unsafe { pyre_object::gc_roots::shadow_stack_get(root_base + 1) },
         &args[1..],
     )?;
-    pyre_object::gc_roots::pin_root(result);
+    let _ = pyre_object::gc_roots::pin_root(result);
     crate::call::set_orig_class(
         unsafe { pyre_object::gc_roots::shadow_stack_get(root_base + 2) },
         unsafe { pyre_object::gc_roots::shadow_stack_get(root_base) },
@@ -263,15 +263,15 @@ fn ga_getattribute(args: &[PyObjectRef]) -> crate::PyResult {
 fn ga_iter(args: &[PyObjectRef]) -> crate::PyResult {
     let self_ = self_alias(args)?;
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(self_);
+    let self_ = pyre_object::gc_roots::pin_root(self_);
     let starred = make_starred(self_)?;
     let starred_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(starred);
+    let _ = pyre_object::gc_roots::pin_root(starred);
     let singleton = w_tuple_new(vec![unsafe {
         pyre_object::gc_roots::shadow_stack_get(starred_slot)
     }]);
     let singleton_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(singleton);
+    let _ = pyre_object::gc_roots::pin_root(singleton);
     crate::baseobjspace::iter(unsafe { pyre_object::gc_roots::shadow_stack_get(singleton_slot) })
 }
 
@@ -370,13 +370,13 @@ fn unpack_args(items: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     // and `items` is read back before each element fetch.
     let _roots = pyre_object::gc_roots::push_roots();
     let items_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(items);
+    let _ = pyre_object::gc_roots::pin_root(items);
     let items = || pyre_object::gc_roots::shadow_stack_get(items_slot);
     let n = unsafe { w_tuple_len(items()) };
     let mut newarg_slots: Vec<usize> = Vec::new();
     let mut push_newarg = |value: PyObjectRef, slots: &mut Vec<usize>| {
         slots.push(pyre_object::gc_roots::shadow_stack_len());
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
     };
     for i in 0..n {
         let Some(arg) = (unsafe { w_tuple_getitem(items(), i as i64) }) else {
@@ -467,10 +467,10 @@ pub(crate) fn subs_parameters(
     // reloads them afterwards; mirror that ownership explicitly.
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_);
-    pyre_object::gc_roots::pin_root(args);
-    pyre_object::gc_roots::pin_root(params);
-    pyre_object::gc_roots::pin_root(items);
+    let self_ = pyre_object::gc_roots::pin_root(self_);
+    let args = pyre_object::gc_roots::pin_root(args);
+    let params = pyre_object::gc_roots::pin_root(params);
+    let items = pyre_object::gc_roots::pin_root(items);
     let current_self = || pyre_object::gc_roots::shadow_stack_get(root_base);
     let current_args = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
     let current_params = || pyre_object::gc_roots::shadow_stack_get(root_base + 2);
@@ -489,17 +489,17 @@ pub(crate) fn subs_parameters(
     // argument live on the shadow stack and are reread after anything that
     // can collect.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(self_);
+    let _ = pyre_object::gc_roots::pin_root(self_);
     let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(args);
+    let _ = pyre_object::gc_roots::pin_root(args);
     let args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(params);
+    let _ = pyre_object::gc_roots::pin_root(params);
     let params_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // `items = _unpack_args(items)` flattens unpacked `tuple[...]` aliases.
     // `__typing_prepare_subst__` then reshapes `items` for
     // `ParamSpec`/`TypeVarTuple` parameters — honoured per param, missing
     // attribute (the `None` default) skips it.
-    pyre_object::gc_roots::pin_root(items);
+    let _ = pyre_object::gc_roots::pin_root(items);
     let items_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let unpacked = unpack_args(pyre_object::gc_roots::shadow_stack_get(items_slot))?;
     pyre_object::gc_roots::shadow_stack_set(items_slot, unpacked);
@@ -513,7 +513,7 @@ pub(crate) fn subs_parameters(
             continue;
         };
         let param_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(param);
+        let _ = pyre_object::gc_roots::pin_root(param);
         // `prepare = getattr(param, '__typing_prepare_subst__', None)` then
         // `if prepare is not None`: a missing attribute and an attribute
         // explicitly set to `None` both skip the reshape.
@@ -595,13 +595,13 @@ pub(crate) fn subs_parameters(
     } else {
         w_tuple_new(vec![pyre_object::gc_roots::shadow_stack_get(items_slot)])
     };
-    pyre_object::gc_roots::pin_root(argitems);
+    let _ = pyre_object::gc_roots::pin_root(argitems);
     let argitems_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // Slots rather than values: each entry has to survive every later
     // iteration's allocations before the caller builds the result from them.
     let mut newarg_slots: Vec<usize> = Vec::new();
     let mut push_newarg = |value: PyObjectRef, slots: &mut Vec<usize>| {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
         slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
     };
     let args_are_tuple = unsafe { is_tuple(pyre_object::gc_roots::shadow_stack_get(args_slot)) };
@@ -624,7 +624,7 @@ pub(crate) fn subs_parameters(
             push_newarg(old_arg, &mut newarg_slots);
             continue;
         }
-        pyre_object::gc_roots::pin_root(old_arg);
+        let old_arg = pyre_object::gc_roots::pin_root(old_arg);
         let old_arg_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         // CPython 3.14 `_Py_subs_parameters`: lists and tuples containing
         // parameters are recursively substituted, preserving their shape.
@@ -663,7 +663,7 @@ pub(crate) fn subs_parameters(
             Err(e) => return Err(e),
         };
         let arg = if !unsafe { pyre_object::is_none(meth) } {
-            pyre_object::gc_roots::pin_root(meth);
+            let _ = pyre_object::gc_roots::pin_root(meth);
             let meth_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let iparam = tuple_index(
                 pyre_object::gc_roots::shadow_stack_get(params_slot),
@@ -689,7 +689,7 @@ pub(crate) fn subs_parameters(
             )?
         };
         if unpack {
-            pyre_object::gc_roots::pin_root(arg);
+            let arg = pyre_object::gc_roots::pin_root(arg);
             let arg_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             // GH-138497: an unpacked `__typing_subst__` must return a tuple.
             // (authority = CPython 3.14)
@@ -767,7 +767,7 @@ fn subs_tvars(
             }
         } else {
             subarg_slots.push(pyre_object::gc_roots::shadow_stack_len());
-            pyre_object::gc_roots::pin_root(arg);
+            let _ = pyre_object::gc_roots::pin_root(arg);
         }
     }
     let subargs: Vec<PyObjectRef> = subarg_slots
@@ -883,8 +883,8 @@ pub(crate) fn create_union(x: PyObjectRef, y: PyObjectRef) -> crate::PyResult {
     }
     let _roots = pyre_object::gc_roots::push_roots();
     let input_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(x);
-    pyre_object::gc_roots::pin_root(y);
+    let _ = pyre_object::gc_roots::pin_root(x);
+    let _ = pyre_object::gc_roots::pin_root(y);
     // CPython 3.14 `_Py_union_type_or`: initialize a unionbuilder, then add
     // the operands in order.  The builder, rather than an eager `x == y`,
     // decides duplicates inside the construction-time hash partition.
@@ -892,7 +892,7 @@ pub(crate) fn create_union(x: PyObjectRef, y: PyObjectRef) -> crate::PyResult {
         pyre_object::gc_roots::shadow_stack_get(input_base),
         pyre_object::gc_roots::shadow_stack_get(input_base + 1),
     ]);
-    pyre_object::gc_roots::pin_root(raw_args);
+    let _ = pyre_object::gc_roots::pin_root(raw_args);
     let raw_args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let parameters = collect_parameters(pyre_object::gc_roots::shadow_stack_get(raw_args_slot))?;
     build_union(
@@ -919,7 +919,7 @@ pub(crate) fn union_from_items(items: &[PyObjectRef]) -> crate::PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let item_base = pyre_object::gc_roots::shadow_stack_len();
     for &item in items {
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
     }
     let current_items = || {
         (0..items.len())
@@ -927,7 +927,7 @@ pub(crate) fn union_from_items(items: &[PyObjectRef]) -> crate::PyResult {
             .collect::<Vec<_>>()
     };
     let raw_args = w_tuple_new(current_items());
-    pyre_object::gc_roots::pin_root(raw_args);
+    let _ = pyre_object::gc_roots::pin_root(raw_args);
     let raw_args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let parameters = collect_parameters(pyre_object::gc_roots::shadow_stack_get(raw_args_slot))?;
     build_union(&current_items(), parameters)
@@ -942,11 +942,11 @@ pub(crate) fn typing_type_convert(arg: PyObjectRef) -> crate::PyResult {
         return Ok(arg);
     }
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(arg);
+    let _ = pyre_object::gc_roots::pin_root(arg);
     let arg_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let typing = crate::importing::check_sys_modules("typing")
         .ok_or_else(|| crate::PyError::type_error("typing module is not initialized"))?;
-    pyre_object::gc_roots::pin_root(typing);
+    let _ = pyre_object::gc_roots::pin_root(typing);
     let typing_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // Module getattr may execute Python and collect.  Reload both the module
     // and operand from their PyPy-shaped roots before the call.
@@ -954,7 +954,7 @@ pub(crate) fn typing_type_convert(arg: PyObjectRef) -> crate::PyResult {
         pyre_object::gc_roots::shadow_stack_get(typing_slot),
         "_type_convert",
     )?;
-    pyre_object::gc_roots::pin_root(convert);
+    let _ = pyre_object::gc_roots::pin_root(convert);
     let convert_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     crate::call::call_function_impl_result(
         pyre_object::gc_roots::shadow_stack_get(convert_slot),
@@ -975,7 +975,7 @@ impl UnionBuilder {
     fn new() -> Self {
         let hashable_set = pyre_object::w_set_new();
         let hashable_set_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(hashable_set);
+        let _ = pyre_object::gc_roots::pin_root(hashable_set);
         Self {
             hashable_set_slot,
             member_slots: Vec::new(),
@@ -986,12 +986,12 @@ impl UnionBuilder {
     fn add(&mut self, arg: PyObjectRef) -> Result<(), crate::PyError> {
         let arg = normalize_none(arg);
         if unsafe { pyre_object::is_union(arg) } {
-            pyre_object::gc_roots::pin_root(arg);
+            let _ = pyre_object::gc_roots::pin_root(arg);
             let arg_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let inner = unsafe {
                 pyre_object::w_union_get_args(pyre_object::gc_roots::shadow_stack_get(arg_slot))
             };
-            pyre_object::gc_roots::pin_root(inner);
+            let _ = pyre_object::gc_roots::pin_root(inner);
             let inner_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let n = unsafe {
                 pyre_object::w_tuple_len(pyre_object::gc_roots::shadow_stack_get(inner_slot))
@@ -1014,7 +1014,7 @@ impl UnionBuilder {
         // duplicate leaves one unused slot, matching the temporary strong
         // reference held by CPython's builder call and avoiding a nested root
         // scope that would also discard newly accepted member slots.
-        pyre_object::gc_roots::pin_root(arg);
+        let arg = pyre_object::gc_roots::pin_root(arg);
         let arg_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let unhashable = match crate::builtins::try_hash_value(
             pyre_object::gc_roots::shadow_stack_get(arg_slot),
@@ -1107,11 +1107,11 @@ impl UnionBuilder {
 
 fn build_union(items: &[PyObjectRef], parameters: PyObjectRef) -> crate::PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(parameters);
+    let _ = pyre_object::gc_roots::pin_root(parameters);
     let parameters_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let item_base = pyre_object::gc_roots::shadow_stack_len();
     for &item in items {
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
     }
     let mut builder = UnionBuilder::new();
     for i in 0..items.len() {
@@ -1125,9 +1125,9 @@ fn build_union(items: &[PyObjectRef], parameters: PyObjectRef) -> crate::PyResul
 pub(crate) fn union_set_eq(a: PyObjectRef, b: PyObjectRef) -> Result<bool, crate::PyError> {
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(a);
+        let a = pyre_object::gc_roots::pin_root(a);
         let a_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        pyre_object::gc_roots::pin_root(b);
+        let b = pyre_object::gc_roots::pin_root(b);
         let b_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let ah = w_union_get_hashable_args(a);
         let bh = w_union_get_hashable_args(b);
@@ -1139,9 +1139,9 @@ pub(crate) fn union_set_eq(a: PyObjectRef, b: PyObjectRef) -> Result<bool, crate
         if aa.is_null() || bb.is_null() {
             return Ok(aa.is_null() && bb.is_null());
         }
-        pyre_object::gc_roots::pin_root(aa);
+        let _ = pyre_object::gc_roots::pin_root(aa);
         let aa_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        pyre_object::gc_roots::pin_root(bb);
+        let _ = pyre_object::gc_roots::pin_root(bb);
         let bb_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let na = w_tuple_len(pyre_object::gc_roots::shadow_stack_get(aa_slot));
         let nb = w_tuple_len(pyre_object::gc_roots::shadow_stack_get(bb_slot));
@@ -1196,11 +1196,11 @@ pub(crate) fn union_set_eq(a: PyObjectRef, b: PyObjectRef) -> Result<bool, crate
 pub(crate) fn union_hash_value(union: PyObjectRef) -> Result<i64, crate::PyError> {
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(union);
+        let union = pyre_object::gc_roots::pin_root(union);
         let union_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let unhashable = w_union_get_unhashable_args(union);
         if !unhashable.is_null() {
-            pyre_object::gc_roots::pin_root(unhashable);
+            let unhashable = pyre_object::gc_roots::pin_root(unhashable);
             let unhashable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let n = w_tuple_len(pyre_object::gc_roots::shadow_stack_get(unhashable_slot));
             for i in 0..n {
@@ -1444,13 +1444,13 @@ pub(crate) fn init_generic_alias_type(ns: PyObjectRef) {
 pub(crate) unsafe fn repr(obj: PyObjectRef) -> Result<rustpython_wtf8::Wtf8Buf, crate::PyError> {
     use rustpython_wtf8::Wtf8Buf;
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let origin = w_generic_alias_get_origin(pyre_object::gc_roots::shadow_stack_get(obj_slot));
-    pyre_object::gc_roots::pin_root(origin);
+    let _ = pyre_object::gc_roots::pin_root(origin);
     let origin_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let args = w_generic_alias_get_args(pyre_object::gc_roots::shadow_stack_get(obj_slot));
-    pyre_object::gc_roots::pin_root(args);
+    let _ = pyre_object::gc_roots::pin_root(args);
     let args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let current_args = || pyre_object::gc_roots::shadow_stack_get(args_slot);
     let n = w_tuple_len(current_args());
@@ -1531,7 +1531,7 @@ unsafe fn repr_items_list(list: PyObjectRef) -> Result<rustpython_wtf8::Wtf8Buf,
     // list is re-read from the shadow stack before every fetch.
     let _roots = pyre_object::gc_roots::push_roots();
     let list_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(list);
+    let _ = pyre_object::gc_roots::pin_root(list);
     let list = || pyre_object::gc_roots::shadow_stack_get(list_slot);
     let n = w_list_len(list());
     let mut parts = Vec::with_capacity(n);
@@ -1554,7 +1554,7 @@ pub(crate) unsafe fn repr_item(
     it: PyObjectRef,
 ) -> Result<rustpython_wtf8::Wtf8Buf, crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(it);
+    let _ = pyre_object::gc_roots::pin_root(it);
     let item_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let current_item = || pyre_object::gc_roots::shadow_stack_get(item_slot);
     if is_ellipsis(current_item()) {
@@ -1588,7 +1588,7 @@ pub(crate) unsafe fn repr_item(
 
 fn is_collections_abc_callable(origin: PyObjectRef) -> Result<bool, crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(origin);
+    let _ = pyre_object::gc_roots::pin_root(origin);
     let origin_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let module = crate::importing::check_sys_modules("collections.abc")
         .or_else(|| crate::importing::check_sys_modules("_collections_abc"));
@@ -1601,7 +1601,7 @@ fn is_collections_abc_callable(origin: PyObjectRef) -> Result<bool, crate::PyErr
 
 fn is_typing_generic_alias(obj: PyObjectRef) -> Result<bool, crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let Some(typing) = crate::importing::check_sys_modules("typing") else {
         return Ok(false);
@@ -1621,7 +1621,7 @@ fn is_typing_generic_alias(obj: PyObjectRef) -> Result<bool, crate::PyError> {
 /// tuple, while `Concatenate` is covered by `is_typing_generic_alias`.
 fn is_param_spec(obj: PyObjectRef) -> Result<bool, crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let Some(typing) = crate::importing::check_sys_modules("_typing") else {
         return Ok(false);

--- a/pyre/pyre-interpreter/src/_structseq.rs
+++ b/pyre/pyre-interpreter/src/_structseq.rs
@@ -531,7 +531,7 @@ pub fn new_instance_with_extra(
     } else {
         pyre_object::w_tuple_new_array_backed(rooted_items)
     };
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // The tuple constructor can collect; the pin at `cls_slot` makes this
     // post-allocation address current.
@@ -543,7 +543,7 @@ pub fn new_instance_with_extra(
     }
     if !extras.is_empty() {
         let w_dict = pyre_object::w_dict_new();
-        pyre_object::gc_roots::pin_root(w_dict);
+        let _ = pyre_object::gc_roots::pin_root(w_dict);
         let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         for (index, (key, _)) in extras.iter().enumerate() {
             unsafe {
@@ -800,7 +800,7 @@ fn make_heap_structseq_type(
     let _roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
     let ns = pyre_object::w_dict_new();
-    pyre_object::gc_roots::pin_root(ns);
+    let ns = pyre_object::gc_roots::pin_root(ns);
     init(ns);
 
     let (module, short_name) = full_name
@@ -818,14 +818,14 @@ fn make_heap_structseq_type(
     }
 
     let bases = pyre_object::w_tuple_new(vec![base]);
-    pyre_object::gc_roots::pin_root(bases);
+    let _ = pyre_object::gc_roots::pin_root(bases);
     let bases_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let cls = pyre_object::w_type_new(
         short_name,
         pyre_object::gc_roots::shadow_stack_get(bases_slot),
         pyre_object::gc_roots::shadow_stack_get(ns_slot) as *mut u8,
     );
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let cls = pyre_object::gc_roots::shadow_stack_get(cls_slot);
     unsafe {

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -239,20 +239,20 @@ pub fn do_combine_starstarargs_wrapped(
     // pairs once the loop is done.
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_starstararg);
-    pyre_object::gc_roots::pin_root(w_function);
+    let _ = pyre_object::gc_roots::pin_root(w_starstararg);
+    let _ = pyre_object::gc_roots::pin_root(w_function);
     let existing_base = pyre_object::gc_roots::shadow_stack_len();
     let existing_len = existingkeywords_w.map_or(0, |existing| existing.len());
     for &w_name in existingkeywords_w.unwrap_or_default() {
-        pyre_object::gc_roots::pin_root(w_name);
+        let _ = pyre_object::gc_roots::pin_root(w_name);
     }
     let keys_base = pyre_object::gc_roots::shadow_stack_len();
     for &key in keys_w {
-        pyre_object::gc_roots::pin_root(key);
+        let _ = pyre_object::gc_roots::pin_root(key);
     }
     let pairs_base = pyre_object::gc_roots::shadow_stack_len();
     for _ in 0..2 * keys_w.len() {
-        pyre_object::gc_roots::pin_root(pyre_object::PY_NULL);
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::PY_NULL);
     }
     let w_starstararg = || pyre_object::gc_roots::shadow_stack_get(root_base);
     let w_function = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
@@ -372,8 +372,8 @@ pub fn combine_starargs_wrapped(
     let _roots = pyre_object::gc_roots::push_roots();
     let args_base = pyre_object::gc_roots::pin_roots(&arguments_w[..]);
     let star_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_stararg);
-    pyre_object::gc_roots::pin_root(w_function);
+    let _ = pyre_object::gc_roots::pin_root(w_stararg);
+    let _ = pyre_object::gc_roots::pin_root(w_function);
     let w_stararg = || pyre_object::gc_roots::shadow_stack_get(star_slot);
     let w_function = || pyre_object::gc_roots::shadow_stack_get(star_slot + 1);
     match crate::baseobjspace::fixedview(w_stararg(), -1) {
@@ -458,8 +458,8 @@ pub fn combine_starstarargs_wrapped(
     // that later read is of the live object, not the address they had on entry.
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_starstararg);
-    pyre_object::gc_roots::pin_root(w_function);
+    let _ = pyre_object::gc_roots::pin_root(w_starstararg);
+    let _ = pyre_object::gc_roots::pin_root(w_function);
     let w_starstararg = || pyre_object::gc_roots::shadow_stack_get(root_base);
     let w_function = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
     // The pairs the caller already accepted are in the same position: native
@@ -779,8 +779,8 @@ impl Arguments {
         // uses them; none of the three sits in storage a root walker updates.
         let _roots = pyre_object::gc_roots::push_roots();
         let root_base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_starstararg.unwrap_or(pyre_object::PY_NULL));
-        pyre_object::gc_roots::pin_root(w_function);
+        let _ = pyre_object::gc_roots::pin_root(w_starstararg.unwrap_or(pyre_object::PY_NULL));
+        let w_function = pyre_object::gc_roots::pin_root(w_function);
         // argument.py — `if w_stararg is not None: self._combine_starargs_wrapped(...)`.
         if let Some(w_star) = w_stararg {
             let w_function = pyre_object::gc_roots::shadow_stack_get(root_base + 1);
@@ -1118,17 +1118,17 @@ impl Arguments {
         // ahead of the first allocation, and read back where it is used.
         let _roots = pyre_object::gc_roots::push_roots();
         let kw_defs_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_kw_defs);
+        let w_kw_defs = pyre_object::gc_roots::pin_root(w_kw_defs);
         let keywords_base = pyre_object::gc_roots::shadow_stack_len();
         if let Some(values) = self.keywords_w.as_ref() {
             for &w_value in values {
-                pyre_object::gc_roots::pin_root(w_value);
+                let _ = pyre_object::gc_roots::pin_root(w_value);
             }
         }
         let names_base = pyre_object::gc_roots::shadow_stack_len();
         if let Some(names) = self.keyword_names_w.as_ref() {
             for &w_name in names {
-                pyre_object::gc_roots::pin_root(w_name);
+                let _ = pyre_object::gc_roots::pin_root(w_name);
             }
         }
         // The defaults arrive as a caller-owned slice — `Function`'s `defs_w`
@@ -1175,7 +1175,7 @@ impl Arguments {
             // PyPy: `space.newdict(kwargs=True)` produces a kwargs-strategy
             // dict; pyre's W_DictObject lacks the strategy variant so a
             // plain dict is used (TODO: add kwargs strategy).
-            pyre_object::gc_roots::pin_root(pyre_object::dictmultiobject::w_dict_new());
+            let _ = pyre_object::gc_roots::pin_root(pyre_object::dictmultiobject::w_dict_new());
             w_kwds = pyre_object::gc_roots::shadow_stack_get(kwds_slot);
             store(scope_w, kwarg_loc, w_kwds);
         }
@@ -1533,9 +1533,9 @@ impl Arguments {
         // it.  A tuple is allocated stable, so `w_args` only needs the one pin
         // that keeps it alive across the same run.
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_args);
+        let w_args = pyre_object::gc_roots::pin_root(w_args);
         let kwds_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(pyre_object::dictmultiobject::w_dict_new());
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::dictmultiobject::w_dict_new());
         if let (Some(names), Some(values)) =
             (self.keyword_names_w.as_ref(), self.keywords_w.as_ref())
         {
@@ -1543,8 +1543,8 @@ impl Arguments {
             let npairs = names.len().min(values.len());
             let pairs_base = pyre_object::gc_roots::shadow_stack_len();
             for (w_key, w_value) in names.iter().zip(values.iter()) {
-                pyre_object::gc_roots::pin_root(*w_key);
-                pyre_object::gc_roots::pin_root(*w_value);
+                let _ = pyre_object::gc_roots::pin_root(*w_key);
+                let _ = pyre_object::gc_roots::pin_root(*w_value);
             }
             for i in 0..npairs {
                 let w_key = pyre_object::gc_roots::shadow_stack_get(pairs_base + 2 * i);
@@ -1713,16 +1713,16 @@ pub fn collect_keyword_args(
     // agree on the index.
     let _roots = pyre_object::gc_roots::push_roots();
     let kwds_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_kwds);
+    let _ = pyre_object::gc_roots::pin_root(w_kwds);
     let pairs_base = pyre_object::gc_roots::shadow_stack_len();
     for i in 0..keyword_names_w.len() {
         if mapping_contains(kwds_mapping, i as isize) {
-            pyre_object::gc_roots::pin_root(pyre_object::PY_NULL);
-            pyre_object::gc_roots::pin_root(pyre_object::PY_NULL);
+            let _ = pyre_object::gc_roots::pin_root(pyre_object::PY_NULL);
+            let _ = pyre_object::gc_roots::pin_root(pyre_object::PY_NULL);
             continue;
         }
-        pyre_object::gc_roots::pin_root(keyword_names_w[i]);
-        pyre_object::gc_roots::pin_root(keywords_w[i]);
+        let _ = pyre_object::gc_roots::pin_root(keyword_names_w[i]);
+        let _ = pyre_object::gc_roots::pin_root(keywords_w[i]);
     }
     for i in 0..keyword_names_w.len() {
         if mapping_contains(kwds_mapping, i as isize) {

--- a/pyre/pyre-interpreter/src/async_operation.rs
+++ b/pyre/pyre-interpreter/src/async_operation.rs
@@ -91,7 +91,7 @@ fn handle(which: usize) -> PyObjectRef {
     let _roots = pyre_object::gc_roots::push_roots();
     let save_point = pyre_object::gc_roots::shadow_stack_len();
     let w_app_globals = pyre_object::dictmultiobject::w_module_dict_new();
-    pyre_object::gc_roots::pin_root(w_app_globals);
+    let _ = pyre_object::gc_roots::pin_root(w_app_globals);
     crate::importing::appleveldef_install(
         pyre_object::gc_roots::shadow_stack_get(save_point),
         ASYNC_OP_SRC,

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -13044,9 +13044,9 @@ pub fn call(
     // publish and reload the corresponding raw pointers explicitly.
     let roots = pyre_object::gc_roots::push_roots();
     let root_base = roots.base();
-    roots.pin_root(callable);
-    roots.pin_root(w_args);
-    roots.pin_root(w_kwds.unwrap_or(PY_NULL));
+    let _ = roots.pin_root(callable);
+    let _ = roots.pin_root(w_args);
+    let _ = roots.pin_root(w_kwds.unwrap_or(PY_NULL));
     let callable = || roots.get(root_base);
     let w_args = || roots.get(root_base + 1);
     let w_kwds = || roots.get(root_base + 2);
@@ -19020,13 +19020,13 @@ pub(crate) fn async_gen_awaitable_finalize(awaitable: PyObjectRef) {
     // them back at every use past this point.
     let _roots = pyre_object::gc_roots::push_roots();
     let async_gen_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(async_gen);
+    let _ = pyre_object::gc_roots::pin_root(async_gen);
 
     let qualname = unsafe {
         w_generator_get_qualname(pyre_object::gc_roots::shadow_stack_get(async_gen_slot))
     };
     let qualname_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(qualname);
+    let _ = pyre_object::gc_roots::pin_root(qualname);
     let method_repr = unsafe { crate::display::py_repr_wtf8(w_str_new(method)) }
         .unwrap_or_else(|_| Wtf8Buf::from_string(format!("'{method}'")));
     let qualname_repr = unsafe {
@@ -19051,7 +19051,7 @@ pub(crate) fn async_gen_awaitable_finalize(awaitable: PyObjectRef) {
             None
         } else {
             let slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(err.exc_object);
+            let _ = pyre_object::gc_roots::pin_root(err.exc_object);
             Some(slot)
         };
         let repr = unsafe {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -910,9 +910,9 @@ pub fn isinstance(obj: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, PyEr
             // pin them on the shadow stack across the walk.
             let _roots = pyre_object::gc_roots::push_roots();
             let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let info_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(classinfo);
+            let _ = pyre_object::gc_roots::pin_root(classinfo);
             let n = w_tuple_len(pyre_object::gc_roots::shadow_stack_get(info_slot));
             for i in 0..n {
                 if let Some(c) =
@@ -929,9 +929,9 @@ pub fn isinstance(obj: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, PyEr
             let union_args = pyre_object::w_union_get_args(classinfo);
             let _roots = pyre_object::gc_roots::push_roots();
             let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let args_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(union_args);
+            let _ = pyre_object::gc_roots::pin_root(union_args);
             let n = w_tuple_len(pyre_object::gc_roots::shadow_stack_get(args_slot));
             for i in 0..n {
                 if let Some(c) =
@@ -996,9 +996,9 @@ pub fn issubclass(derived: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, 
             // so pin them on the shadow stack across the walk.
             let _roots = pyre_object::gc_roots::push_roots();
             let derived_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(derived);
+            let _ = pyre_object::gc_roots::pin_root(derived);
             let info_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(classinfo);
+            let _ = pyre_object::gc_roots::pin_root(classinfo);
             let n = w_tuple_len(pyre_object::gc_roots::shadow_stack_get(info_slot));
             for i in 0..n {
                 if let Some(c) =
@@ -1014,9 +1014,9 @@ pub fn issubclass(derived: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, 
             let union_args = pyre_object::w_union_get_args(classinfo);
             let _roots = pyre_object::gc_roots::push_roots();
             let derived_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(derived);
+            let _ = pyre_object::gc_roots::pin_root(derived);
             let args_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(union_args);
+            let _ = pyre_object::gc_roots::pin_root(union_args);
             let n = w_tuple_len(pyre_object::gc_roots::shadow_stack_get(args_slot));
             for i in 0..n {
                 if let Some(c) =
@@ -1533,15 +1533,15 @@ fn add_internal_exception_note(error: &mut PyError, text: &str) -> Result<(), Py
     // `add_note`; this is interpreter bookkeeping, not a method call.
     let _roots = pyre_object::gc_roots::push_roots();
     let exc = error.to_exc_object();
-    pyre_object::gc_roots::pin_root(exc);
+    let _ = pyre_object::gc_roots::pin_root(exc);
     let exc_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let note = w_str_new(text);
-    pyre_object::gc_roots::pin_root(note);
+    let _ = pyre_object::gc_roots::pin_root(note);
     let note_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     let rooted_exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
     let dict = unsafe { pyre_object::interp_exceptions::w_exception_getdict(rooted_exc) };
-    pyre_object::gc_roots::pin_root(dict);
+    let _ = pyre_object::gc_roots::pin_root(dict);
     let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let notes = match unsafe {
         w_dict_getitem_str(
@@ -1553,7 +1553,7 @@ fn add_internal_exception_note(error: &mut PyError, text: &str) -> Result<(), Py
         Some(_) => {
             let mut note_error = PyError::type_error("Cannot add note: __notes__ is not a list");
             let note_exc = note_error.to_exc_object();
-            pyre_object::gc_roots::pin_root(note_exc);
+            let _ = pyre_object::gc_roots::pin_root(note_exc);
             let note_exc_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             crate::error::chain_context(
                 pyre_object::gc_roots::shadow_stack_get(note_exc_slot),
@@ -1564,7 +1564,7 @@ fn add_internal_exception_note(error: &mut PyError, text: &str) -> Result<(), Py
         }
         None => {
             let notes = w_list_new(Vec::new());
-            pyre_object::gc_roots::pin_root(notes);
+            let _ = pyre_object::gc_roots::pin_root(notes);
             let notes_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             unsafe {
                 pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
@@ -1576,7 +1576,7 @@ fn add_internal_exception_note(error: &mut PyError, text: &str) -> Result<(), Py
             pyre_object::gc_roots::shadow_stack_get(notes_slot)
         }
     };
-    pyre_object::gc_roots::pin_root(notes);
+    let _ = pyre_object::gc_roots::pin_root(notes);
     let notes_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     unsafe {
         w_list_append(
@@ -1888,7 +1888,7 @@ unsafe fn getitem_tuple(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
             // `slice_unpack` runs each component's `__index__`; the tuple is
             // rooted for that window and does not move.
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             crate::sliceobject::slice_unpack(
                 w_slice_get_start(index),
                 w_slice_get_stop(index),
@@ -1920,7 +1920,7 @@ unsafe fn getitem_tuple(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
             // call. A tuple never moves, so the root is for liveness alone
             // and the address in hand stays correct.
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             space_index(index)?
         };
         if is_int(indexed) {
@@ -1972,7 +1972,7 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
             // `slice_unpack` runs each component's `__index__`; the string is
             // rooted for that window and does not move.
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             crate::sliceobject::slice_unpack(
                 w_slice_get_start(index),
                 w_slice_get_stop(index),
@@ -2014,7 +2014,7 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
             // call. A str never moves, so the root is for liveness alone
             // and the address in hand stays correct.
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             space_index(index)?
         };
         if is_int(indexed) {
@@ -2064,7 +2064,7 @@ unsafe fn getitem_bytes_like(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
             // rooted for that window and neither `bytes` nor `bytearray`
             // moves.
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             crate::sliceobject::slice_unpack(
                 w_slice_get_start(index),
                 w_slice_get_stop(index),
@@ -2116,7 +2116,7 @@ unsafe fn getitem_bytes_like(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
             // call. A bytes-like operand never moves, so the root is for liveness alone
             // and the address in hand stays correct.
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             space_index(index)?
         };
         if is_int(indexed) {
@@ -2288,7 +2288,7 @@ unsafe fn getitem_range(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
         // popped off the operand stack before this dispatch, so it needs the
         // root to survive a collection there.
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         space_index(index)?
     };
     let idx = pyre_object::range_obj_to_bigint(w_index);
@@ -2309,7 +2309,7 @@ unsafe fn compute_slice_indices3_big(
 ) -> Result<(BigInt, BigInt, BigInt), PyError> {
     use num_traits::{One, Zero};
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(slice);
+    let slice = pyre_object::gc_roots::pin_root(slice);
     let slice_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // `space.index` below can invoke arbitrary Python. RPython's GC transform
     // keeps both the slice object and incoming rbigint live across every
@@ -2404,7 +2404,7 @@ unsafe fn compute_slice_indices3_big(
 /// a slice of `obj` denotes.
 unsafe fn range_compute_slice(obj: PyObjectRef, slice: PyObjectRef) -> PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(obj);
+    let obj = pyre_object::gc_roots::pin_root(obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let len_b = pyre_object::range_obj_to_bigint(pyre_object::w_range_length(obj));
     let (sl_start, sl_stop, sl_step) = compute_slice_indices3_big(slice, &len_b)?;
@@ -2422,15 +2422,15 @@ unsafe fn range_compute_slice(obj: PyObjectRef, slice: PyObjectRef) -> PyResult 
     let substop = RBigIntGcRoot::new(&*rstart_b + &*sl_stop * &*rstep_b);
     let _roots = pyre_object::gc_roots::push_roots();
     let w_substart = pyre_object::range_bigint_to_obj(substart.translated_alias());
-    pyre_object::gc_roots::pin_root(w_substart);
+    let w_substart = pyre_object::gc_roots::pin_root(w_substart);
     let w_substep = pyre_object::range_bigint_to_obj(substep.translated_alias());
-    pyre_object::gc_roots::pin_root(w_substep);
+    let w_substep = pyre_object::gc_roots::pin_root(w_substep);
     // functional.py:523-526 tests `if w_stop`, i.e. whether the wrapped
     // pointer exists, not whether its integer payload is zero.  The wrapped
     // result of compute_slice_indices3 is always present, so compute the stop
     // lane even when its value is 0 (notably for `r[-1:-3:-1]`).
     let w_substop = pyre_object::range_bigint_to_obj(substop.translated_alias());
-    pyre_object::gc_roots::pin_root(w_substop);
+    let w_substop = pyre_object::gc_roots::pin_root(w_substop);
     Ok(pyre_object::w_range_new(w_substart, w_substop, w_substep))
 }
 
@@ -2503,9 +2503,9 @@ pub(crate) fn sequence_index(w_container: PyObjectRef, w_item: PyObjectRef) -> P
     // stack slots are GC roots; Rust's are not.)
     let _roots = pyre_object::gc_roots::push_roots();
     let iter_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_iter);
+    let _ = pyre_object::gc_roots::pin_root(w_iter);
     let item_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_item);
+    let _ = pyre_object::gc_roots::pin_root(w_item);
     let mut index: i64 = 0;
     loop {
         match next(pyre_object::gc_roots::shadow_stack_get(iter_slot)) {
@@ -2533,9 +2533,9 @@ pub(crate) fn sequence_count(w_container: PyObjectRef, w_item: PyObjectRef) -> P
     // so the iterator and needle live on the shadow stack.
     let _roots = pyre_object::gc_roots::push_roots();
     let iter_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_iter);
+    let _ = pyre_object::gc_roots::pin_root(w_iter);
     let item_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_item);
+    let _ = pyre_object::gc_roots::pin_root(w_item);
     let mut count: i64 = 0;
     loop {
         match next(pyre_object::gc_roots::shadow_stack_get(iter_slot)) {
@@ -2563,9 +2563,9 @@ pub(crate) fn sequence_contains(
     // so the iterator and needle live on the shadow stack.
     let _roots = pyre_object::gc_roots::push_roots();
     let iter_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_iter);
+    let _ = pyre_object::gc_roots::pin_root(w_iter);
     let item_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_item);
+    let _ = pyre_object::gc_roots::pin_root(w_item);
     loop {
         match next(pyre_object::gc_roots::shadow_stack_get(iter_slot)) {
             Ok(w_next) => {
@@ -2676,7 +2676,7 @@ fn iterator_reduce_tuple(
 ) -> PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(callable);
+    let _ = pyre_object::gc_roots::pin_root(callable);
     // A negative cursor is the exhausted sentinel the list iterators store,
     // and `listiter_reduce`/`listreviter_reduce` report the empty producer for
     // it even while the source list is still referenced.
@@ -2689,19 +2689,19 @@ fn iterator_reduce_tuple(
             2 => w_list_new(vec![]),
             _ => w_tuple_new(vec![]),
         };
-        pyre_object::gc_roots::pin_root(empty);
+        let _ = pyre_object::gc_roots::pin_root(empty);
         let state = w_tuple_new(vec![pyre_object::gc_roots::shadow_stack_get(sp + 1)]);
-        pyre_object::gc_roots::pin_root(state);
+        let _ = pyre_object::gc_roots::pin_root(state);
         return Ok(w_tuple_new(vec![
             pyre_object::gc_roots::shadow_stack_get(sp),
             pyre_object::gc_roots::shadow_stack_get(sp + 2),
         ]));
     }
-    pyre_object::gc_roots::pin_root(seq);
+    let _ = pyre_object::gc_roots::pin_root(seq);
     let state = w_tuple_new(vec![pyre_object::gc_roots::shadow_stack_get(sp + 1)]);
-    pyre_object::gc_roots::pin_root(state);
+    let _ = pyre_object::gc_roots::pin_root(state);
     let w_index = w_int_new(index);
-    pyre_object::gc_roots::pin_root(w_index);
+    let _ = pyre_object::gc_roots::pin_root(w_index);
     Ok(w_tuple_new(vec![
         pyre_object::gc_roots::shadow_stack_get(sp),
         pyre_object::gc_roots::shadow_stack_get(sp + 2),
@@ -2719,9 +2719,9 @@ pub(crate) fn seq_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
     // that lookup first, and only then read its live sequence and cursor.
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args[0]);
+    let _ = pyre_object::gc_roots::pin_root(args[0]);
     let callable = builtin_callable("iter");
-    pyre_object::gc_roots::pin_root(callable);
+    let _ = pyre_object::gc_roots::pin_root(callable);
     unsafe {
         let receiver = pyre_object::gc_roots::shadow_stack_get(sp);
         iterator_reduce_tuple(
@@ -2753,26 +2753,26 @@ pub(crate) fn callable_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
     }
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
-    pyre_object::gc_roots::pin_root(builtin_callable("iter"));
+    let _ = pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(builtin_callable("iter"));
     let obj = pyre_object::gc_roots::shadow_stack_get(sp);
     let callable = unsafe { pyre_object::operation::w_callable_iterator_get_callable(obj) };
     let state = if callable.is_null() {
         let empty = w_tuple_new(vec![]);
-        pyre_object::gc_roots::pin_root(empty);
+        let _ = pyre_object::gc_roots::pin_root(empty);
         w_tuple_new(vec![pyre_object::gc_roots::shadow_stack_get(
             pyre_object::gc_roots::shadow_stack_len() - 1,
         )])
     } else {
         let sentinel = unsafe { pyre_object::operation::w_callable_iterator_get_sentinel(obj) };
-        pyre_object::gc_roots::pin_root(callable);
-        pyre_object::gc_roots::pin_root(sentinel);
+        let _ = pyre_object::gc_roots::pin_root(callable);
+        let _ = pyre_object::gc_roots::pin_root(sentinel);
         w_tuple_new(vec![
             pyre_object::gc_roots::shadow_stack_get(sp + 2),
             pyre_object::gc_roots::shadow_stack_get(sp + 3),
         ])
     };
-    pyre_object::gc_roots::pin_root(state);
+    let _ = pyre_object::gc_roots::pin_root(state);
     Ok(w_tuple_new(vec![
         pyre_object::gc_roots::shadow_stack_get(sp + 1),
         pyre_object::gc_roots::shadow_stack_get(pyre_object::gc_roots::shadow_stack_len() - 1),
@@ -2890,9 +2890,9 @@ pub(crate) fn seq_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
 pub(crate) fn list_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args[0]);
+    let _ = pyre_object::gc_roots::pin_root(args[0]);
     let callable = frame_builtin_callable("iter")?;
-    pyre_object::gc_roots::pin_root(callable);
+    let _ = pyre_object::gc_roots::pin_root(callable);
     unsafe {
         let receiver = pyre_object::gc_roots::shadow_stack_get(sp);
         iterator_reduce_tuple(
@@ -2949,9 +2949,9 @@ pub(crate) fn list_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
 pub(crate) fn tuple_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args[0]);
+    let _ = pyre_object::gc_roots::pin_root(args[0]);
     let callable = builtin_callable("iter");
-    pyre_object::gc_roots::pin_root(callable);
+    let _ = pyre_object::gc_roots::pin_root(callable);
     unsafe {
         let receiver = pyre_object::gc_roots::shadow_stack_get(sp);
         iterator_reduce_tuple(
@@ -2997,9 +2997,9 @@ pub(crate) fn tuple_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
 pub(crate) fn list_reverse_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args[0]);
+    let _ = pyre_object::gc_roots::pin_root(args[0]);
     let callable = builtin_callable("reversed");
-    pyre_object::gc_roots::pin_root(callable);
+    let _ = pyre_object::gc_roots::pin_root(callable);
     unsafe {
         let receiver = pyre_object::gc_roots::shadow_stack_get(sp);
         // A spent cursor keeps its list so `__setstate__` can revive it, but
@@ -3075,22 +3075,22 @@ pub(crate) fn range_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
         // those allocating expressions.
         let _roots = pyre_object::gc_roots::push_roots();
         let w_current = w_int_new(current);
-        pyre_object::gc_roots::pin_root(w_current);
+        let _ = pyre_object::gc_roots::pin_root(w_current);
         let current_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_stop = pyre_object::range_bigint_to_obj(stop.translated_alias());
-        pyre_object::gc_roots::pin_root(w_stop);
+        let _ = pyre_object::gc_roots::pin_root(w_stop);
         let stop_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_step = w_int_new(step);
-        pyre_object::gc_roots::pin_root(w_step);
+        let _ = pyre_object::gc_roots::pin_root(w_step);
         let step_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_range = pyre_object::w_range_new(
             pyre_object::gc_roots::shadow_stack_get(current_slot),
             pyre_object::gc_roots::shadow_stack_get(stop_slot),
             pyre_object::gc_roots::shadow_stack_get(step_slot),
         );
-        pyre_object::gc_roots::pin_root(w_range);
+        let w_range = pyre_object::gc_roots::pin_root(w_range);
         let state = w_tuple_new(vec![w_range]);
-        pyre_object::gc_roots::pin_root(state);
+        let state = pyre_object::gc_roots::pin_root(state);
         Ok(w_tuple_new(vec![builtin_callable("iter"), state, w_none()]))
     }
 }
@@ -3114,22 +3114,22 @@ pub(crate) fn long_range_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
         let stop = RBigIntGcRoot::new(&*start_b + &*len_b * &*step_b);
         let _roots = pyre_object::gc_roots::push_roots();
         let w_current = pyre_object::range_bigint_to_obj(current.translated_alias());
-        pyre_object::gc_roots::pin_root(w_current);
+        let _ = pyre_object::gc_roots::pin_root(w_current);
         let current_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_stop = pyre_object::range_bigint_to_obj(stop.translated_alias());
-        pyre_object::gc_roots::pin_root(w_stop);
+        let _ = pyre_object::gc_roots::pin_root(w_stop);
         let stop_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_step = pyre_object::range_bigint_to_obj(step_b.translated_alias());
-        pyre_object::gc_roots::pin_root(w_step);
+        let _ = pyre_object::gc_roots::pin_root(w_step);
         let step_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_range = pyre_object::w_range_new(
             pyre_object::gc_roots::shadow_stack_get(current_slot),
             pyre_object::gc_roots::shadow_stack_get(stop_slot),
             pyre_object::gc_roots::shadow_stack_get(step_slot),
         );
-        pyre_object::gc_roots::pin_root(w_range);
+        let w_range = pyre_object::gc_roots::pin_root(w_range);
         let state = w_tuple_new(vec![w_range]);
-        pyre_object::gc_roots::pin_root(state);
+        let state = pyre_object::gc_roots::pin_root(state);
         Ok(w_tuple_new(vec![builtin_callable("iter"), state, w_none()]))
     }
 }
@@ -3254,11 +3254,11 @@ pub(crate) fn enumerate_reduce_method(args: &[PyObjectRef]) -> PyResult {
         // Keep `self` live and reload it before every later field read, matching
         // the GC-transformed RPython object's rooted `self` local.
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(args[0]);
+        let _ = pyre_object::gc_roots::pin_root(args[0]);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
         let self_type = crate::typedef::r#type(self_).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
-        pyre_object::gc_roots::pin_root(self_type);
+        let _ = pyre_object::gc_roots::pin_root(self_type);
         let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let i64_index = pyre_object::functional::w_enumerate_get_index(self_);
         let raw = pyre_object::functional::w_enumerate_get_iter_or_list(self_);
@@ -3279,7 +3279,7 @@ pub(crate) fn enumerate_reduce_method(args: &[PyObjectRef]) -> PyResult {
         } else {
             raw
         };
-        pyre_object::gc_roots::pin_root(w_iter);
+        let _ = pyre_object::gc_roots::pin_root(w_iter);
         let iter_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
         let w_index_slot = pyre_object::functional::w_enumerate_get_w_index(self_);
@@ -3288,13 +3288,13 @@ pub(crate) fn enumerate_reduce_method(args: &[PyObjectRef]) -> PyResult {
         } else {
             w_index_slot
         };
-        pyre_object::gc_roots::pin_root(index);
+        let _ = pyre_object::gc_roots::pin_root(index);
         let index_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let state = w_tuple_new(vec![
             pyre_object::gc_roots::shadow_stack_get(iter_slot),
             pyre_object::gc_roots::shadow_stack_get(index_slot),
         ]);
-        pyre_object::gc_roots::pin_root(state);
+        let _ = pyre_object::gc_roots::pin_root(state);
         let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         Ok(w_tuple_new(vec![
             pyre_object::gc_roots::shadow_stack_get(self_type_slot),
@@ -3340,11 +3340,11 @@ pub(crate) fn reversed_reduce_method(args: &[PyObjectRef]) -> PyResult {
     let self_ = reversed_receiver(args, "__reduce__")?;
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self_);
+        let _ = pyre_object::gc_roots::pin_root(self_);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
         let self_type = crate::typedef::r#type(self_).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
-        pyre_object::gc_roots::pin_root(self_type);
+        let _ = pyre_object::gc_roots::pin_root(self_type);
         let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let seq = pyre_object::functional::w_reversed_get_sequence(self_);
         let remaining = pyre_object::functional::w_reversed_get_remaining(self_);
@@ -3353,13 +3353,13 @@ pub(crate) fn reversed_reduce_method(args: &[PyObjectRef]) -> PyResult {
         // PyPy selects the empty form on the cleared sequence alone and reports
         // the -1 cursor verbatim for a `__setstate__` that drove it negative.
         if !seq.is_null() && remaining >= 0 {
-            pyre_object::gc_roots::pin_root(seq);
+            let _ = pyre_object::gc_roots::pin_root(seq);
             let seq_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let state = w_tuple_new(vec![pyre_object::gc_roots::shadow_stack_get(seq_slot)]);
-            pyre_object::gc_roots::pin_root(state);
+            let _ = pyre_object::gc_roots::pin_root(state);
             let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_remaining = w_int_new(remaining);
-            pyre_object::gc_roots::pin_root(w_remaining);
+            let _ = pyre_object::gc_roots::pin_root(w_remaining);
             let remaining_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             Ok(w_tuple_new(vec![
                 pyre_object::gc_roots::shadow_stack_get(self_type_slot),
@@ -3368,10 +3368,10 @@ pub(crate) fn reversed_reduce_method(args: &[PyObjectRef]) -> PyResult {
             ]))
         } else {
             let empty = w_tuple_new(vec![]);
-            pyre_object::gc_roots::pin_root(empty);
+            let _ = pyre_object::gc_roots::pin_root(empty);
             let empty_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let state = w_tuple_new(vec![pyre_object::gc_roots::shadow_stack_get(empty_slot)]);
-            pyre_object::gc_roots::pin_root(state);
+            let _ = pyre_object::gc_roots::pin_root(state);
             let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             Ok(w_tuple_new(vec![
                 pyre_object::gc_roots::shadow_stack_get(self_type_slot),
@@ -3394,12 +3394,12 @@ pub(crate) fn reversed_setstate_method(args: &[PyObjectRef]) -> PyResult {
         return Ok(w_none());
     }
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(self_);
+    let self_ = pyre_object::gc_roots::pin_root(self_);
     let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     unsafe {
         let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
         let seq = pyre_object::functional::w_reversed_get_sequence(self_);
-        pyre_object::gc_roots::pin_root(seq);
+        let seq = pyre_object::gc_roots::pin_root(seq);
         let seq_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let n = if !seq.is_null() {
             len_w(pyre_object::gc_roots::shadow_stack_get(seq_slot))?
@@ -3424,7 +3424,7 @@ pub(crate) fn reversed_setstate_method(args: &[PyObjectRef]) -> PyResult {
 pub(crate) fn reversed_length_hint_method(args: &[PyObjectRef]) -> PyResult {
     let self_ = reversed_receiver(args, "__length_hint__")?;
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(self_);
+    let self_ = pyre_object::gc_roots::pin_root(self_);
     let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     unsafe {
         let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
@@ -3432,7 +3432,7 @@ pub(crate) fn reversed_length_hint_method(args: &[PyObjectRef]) -> PyResult {
         let mut res = 0i64;
         if remaining >= 0 {
             let seq = pyre_object::functional::w_reversed_get_sequence(self_);
-            pyre_object::gc_roots::pin_root(seq);
+            let seq = pyre_object::gc_roots::pin_root(seq);
             let seq_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let total = if !seq.is_null() {
                 len_w(pyre_object::gc_roots::shadow_stack_get(seq_slot))?
@@ -3480,11 +3480,11 @@ pub(crate) fn filter_reduce_method(args: &[PyObjectRef]) -> PyResult {
     let self_ = filter_receiver(args, "__reduce__")?;
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self_);
+        let _ = pyre_object::gc_roots::pin_root(self_);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
         let self_type = crate::typedef::r#type(self_).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
-        pyre_object::gc_roots::pin_root(self_type);
+        let _ = pyre_object::gc_roots::pin_root(self_type);
         let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let raw_predicate = pyre_object::functional::w_filter_get_predicate(self_);
         let w_predicate = if raw_predicate.is_null() {
@@ -3492,16 +3492,16 @@ pub(crate) fn filter_reduce_method(args: &[PyObjectRef]) -> PyResult {
         } else {
             raw_predicate
         };
-        pyre_object::gc_roots::pin_root(w_predicate);
+        let _ = pyre_object::gc_roots::pin_root(w_predicate);
         let predicate_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_iterable = pyre_object::functional::w_filter_get_iterable(self_);
-        pyre_object::gc_roots::pin_root(w_iterable);
+        let _ = pyre_object::gc_roots::pin_root(w_iterable);
         let iterable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let state = w_tuple_new(vec![
             pyre_object::gc_roots::shadow_stack_get(predicate_slot),
             pyre_object::gc_roots::shadow_stack_get(iterable_slot),
         ]);
-        pyre_object::gc_roots::pin_root(state);
+        let _ = pyre_object::gc_roots::pin_root(state);
         let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         Ok(w_tuple_new(vec![
             pyre_object::gc_roots::shadow_stack_get(self_type_slot),
@@ -3573,10 +3573,10 @@ unsafe fn pull_iterator_tuple(
     let _roots = pyre_object::gc_roots::push_roots();
     // Pin the iterator list itself: `next(it)` runs Python and can move it, and
     // later iterations dereference it again — a raw local would go stale.
-    pyre_object::gc_roots::pin_root(w_iterators);
+    let _ = pyre_object::gc_roots::pin_root(w_iterators);
     let iters_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let zip_slot = w_zip.map(|zip| {
-        pyre_object::gc_roots::pin_root(zip);
+        let _ = pyre_object::gc_roots::pin_root(zip);
         pyre_object::gc_roots::shadow_stack_len() - 1
     });
     if let Some(slot) = zip_slot {
@@ -3594,7 +3594,7 @@ unsafe fn pull_iterator_tuple(
         .unwrap();
         match next(it) {
             Ok(v) => {
-                pyre_object::gc_roots::pin_root(v);
+                let _ = pyre_object::gc_roots::pin_root(v);
                 if let Some(slot) = zip_slot {
                     pyre_object::functional::w_zip_set_iteration_progress(
                         pyre_object::gc_roots::shadow_stack_get(slot),
@@ -3671,17 +3671,17 @@ pub(crate) fn map_reduce_method(args: &[PyObjectRef]) -> PyResult {
     let self_ = map_receiver(args, "__reduce__")?;
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self_);
+        let _ = pyre_object::gc_roots::pin_root(self_);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
         let self_type = crate::typedef::r#type(self_).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
-        pyre_object::gc_roots::pin_root(self_type);
+        let _ = pyre_object::gc_roots::pin_root(self_type);
         let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_fun = pyre_object::functional::w_map_get_fun(self_);
-        pyre_object::gc_roots::pin_root(w_fun);
+        let _ = pyre_object::gc_roots::pin_root(w_fun);
         let fun_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_iterators = pyre_object::functional::w_map_get_iterators(self_);
-        pyre_object::gc_roots::pin_root(w_iterators);
+        let w_iterators = pyre_object::gc_roots::pin_root(w_iterators);
         let iterators_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let n = pyre_object::w_list_len(w_iterators);
         let mut state_items = Vec::with_capacity(n as usize + 1);
@@ -3692,11 +3692,11 @@ pub(crate) fn map_reduce_method(args: &[PyObjectRef]) -> PyResult {
                 i as i64,
             )
             .unwrap();
-            pyre_object::gc_roots::pin_root(w_iter);
+            let w_iter = pyre_object::gc_roots::pin_root(w_iter);
             state_items.push(w_iter);
         }
         let state = w_tuple_new(state_items);
-        pyre_object::gc_roots::pin_root(state);
+        let _ = pyre_object::gc_roots::pin_root(state);
         let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         if pyre_object::functional::w_map_get_strict(pyre_object::gc_roots::shadow_stack_get(
             self_slot,
@@ -3721,9 +3721,9 @@ pub(crate) fn map_setstate_method(args: &[PyObjectRef]) -> PyResult {
     let self_ = map_receiver(args, "__setstate__")?;
     let state = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(self_);
+    let _ = pyre_object::gc_roots::pin_root(self_);
     let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(state);
+    let _ = pyre_object::gc_roots::pin_root(state);
     let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let strict = is_true(unsafe { pyre_object::gc_roots::shadow_stack_get(state_slot) })?;
     unsafe {
@@ -3760,14 +3760,14 @@ pub(crate) fn zip_reduce_method(args: &[PyObjectRef]) -> PyResult {
     let self_ = zip_receiver(args, "__reduce__")?;
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self_);
+        let _ = pyre_object::gc_roots::pin_root(self_);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
         let self_type = crate::typedef::r#type(self_).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
-        pyre_object::gc_roots::pin_root(self_type);
+        let _ = pyre_object::gc_roots::pin_root(self_type);
         let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_iterators = pyre_object::functional::w_zip_get_iterators(self_);
-        pyre_object::gc_roots::pin_root(w_iterators);
+        let w_iterators = pyre_object::gc_roots::pin_root(w_iterators);
         let iterators_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let n = pyre_object::w_list_len(w_iterators);
         let mut state_items = Vec::with_capacity(n as usize);
@@ -3777,11 +3777,11 @@ pub(crate) fn zip_reduce_method(args: &[PyObjectRef]) -> PyResult {
                 i as i64,
             )
             .unwrap();
-            pyre_object::gc_roots::pin_root(w_iter);
+            let w_iter = pyre_object::gc_roots::pin_root(w_iter);
             state_items.push(w_iter);
         }
         let state = w_tuple_new(state_items);
-        pyre_object::gc_roots::pin_root(state);
+        let _ = pyre_object::gc_roots::pin_root(state);
         let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         if pyre_object::functional::w_zip_get_strict(pyre_object::gc_roots::shadow_stack_get(
             self_slot,
@@ -3806,9 +3806,9 @@ pub(crate) fn zip_setstate_method(args: &[PyObjectRef]) -> PyResult {
     let self_ = zip_receiver(args, "__setstate__")?;
     let state = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(self_);
+    let _ = pyre_object::gc_roots::pin_root(self_);
     let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(state);
+    let _ = pyre_object::gc_roots::pin_root(state);
     let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let strict = is_true(unsafe { pyre_object::gc_roots::shadow_stack_get(state_slot) })?;
     unsafe {
@@ -4031,11 +4031,11 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
     // stack first and read each one back after any step that can collect.
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(value);
+    let _ = pyre_object::gc_roots::pin_root(value);
     let index_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(index);
+    let _ = pyre_object::gc_roots::pin_root(index);
     // CPython 3.14 `list_ass_subscript_lock_held`: unpack the slice first,
     // materialize the replacement next, and only then adjust the bounds
     // against the list's live length. Materializing an arbitrary iterable may
@@ -4062,7 +4062,7 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
         pyre_object::listobject::w_list_new(items)
     };
     let other_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_other);
+    let w_other = pyre_object::gc_roots::pin_root(w_other);
     let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
     let len = w_list_len(obj) as i64;
     let (start, stop, step, slicelength) =
@@ -4124,7 +4124,7 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
         let item =
             pyre_object::w_list_getitem(w_other, k as i64).expect("k < other_len by construction");
         let item_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
         let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         let item = pyre_object::gc_roots::shadow_stack_get(item_slot);
         if !pyre_object::w_list_setitem(obj, idx, item) {
@@ -4261,7 +4261,7 @@ unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjec
             // The value's own `__index__` runs Python too, and the bytearray
             // written below is still unrooted at this point.
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             space_index(value)?
         };
         if is_int(indexed) {
@@ -4964,7 +4964,7 @@ pub fn getdict(obj: PyObjectRef) -> PyResult {
             }
             let _roots = pyre_object::gc_roots::push_roots();
             let root_base = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let w_dict = pyre_object::w_dict_new();
             unsafe {
                 pyre_object::bytesobject::w_bytes_setdict(
@@ -4986,7 +4986,7 @@ pub fn getdict(obj: PyObjectRef) -> PyResult {
             }
             let _roots = pyre_object::gc_roots::push_roots();
             let root_base = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let w_dict = pyre_object::w_dict_new();
             unsafe {
                 pyre_object::bytearrayobject::w_bytearray_setdict(
@@ -5008,7 +5008,7 @@ pub fn getdict(obj: PyObjectRef) -> PyResult {
             }
             let _roots = pyre_object::gc_roots::push_roots();
             let root_base = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let w_dict = pyre_object::w_dict_new();
             unsafe {
                 pyre_object::floatobject::w_float_setdict(
@@ -5030,7 +5030,7 @@ pub fn getdict(obj: PyObjectRef) -> PyResult {
             }
             let _roots = pyre_object::gc_roots::push_roots();
             let root_base = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let w_dict = pyre_object::w_dict_new();
             unsafe {
                 pyre_object::complexobject::w_complex_setdict(
@@ -5052,7 +5052,7 @@ pub fn getdict(obj: PyObjectRef) -> PyResult {
             }
             let _roots = pyre_object::gc_roots::push_roots();
             let root_base = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let w_dict = pyre_object::w_dict_new();
             unsafe {
                 pyre_object::interp_array::w_array_setdict(
@@ -6880,10 +6880,10 @@ fn attr_error_wtf8(obj: PyObjectRef, name: &Wtf8) -> PyError {
 
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let w_name = pyre_object::w_str_from_wtf8(name.to_wtf8_buf());
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_name);
+    let _ = pyre_object::gc_roots::pin_root(w_name);
     let exc = pyre_object::interp_exceptions::w_exception_new_wtf8(
         pyre_object::interp_exceptions::ExcKind::AttributeError,
         &message,
@@ -7074,7 +7074,7 @@ unsafe fn module_getattr_hook_or_err(
     // allocate, then read the display form back from its slot.
     let _scope = pyre_object::gc_roots::push_roots();
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_name);
+    let w_name = pyre_object::gc_roots::pin_root(w_name);
     let nm = pyre_object::w_str_get_wtf8(w_name).to_string();
     // Classify the miss through `__spec__`: a same-named file shadowing a
     // search-path module is flagged first (the stdlib hint takes priority over
@@ -7083,7 +7083,7 @@ unsafe fn module_getattr_hook_or_err(
     let w_spec = finditem_str(w_dict, "__spec__")?.filter(|w| !w.is_null());
     let msg = if let Some(w_spec) = w_spec {
         let spec_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_spec);
+        let w_spec = pyre_object::gc_roots::pin_root(w_spec);
         let w_name = pyre_object::gc_roots::shadow_stack_get(name_slot);
         let (origin, is_shadowing, is_shadowing_stdlib) =
             crate::importing::module_shadow_info(w_spec, w_name)?;
@@ -9168,7 +9168,7 @@ fn buffer_bytes(
     let require_contiguous = request.require_contiguous();
     let flags = request.flags();
     let roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let r_obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
     unsafe {
@@ -9235,7 +9235,7 @@ fn buffer_bytes(
             return Ok(None);
         }
         let w_view = crate::builtins::w_memoryview_new_with_flags(r_obj, flags)?;
-        pyre_object::gc_roots::pin_root(w_view);
+        let _ = pyre_object::gc_roots::pin_root(w_view);
         let view_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let r_view = pyre_object::gc_roots::shadow_stack_get(view_slot);
         if require_contiguous && !crate::builtins::memoryview_contiguity(r_view).0 {
@@ -10646,7 +10646,7 @@ pub(crate) unsafe fn compute_and_set_mro(w_self: PyObjectRef) -> PyResult {
     let default_mro_start = pyre_object::gc_roots::shadow_stack_len();
     let default_mro_len = default_mro.len();
     for w_class in default_mro {
-        pyre_object::gc_roots::pin_root(w_class);
+        let _ = pyre_object::gc_roots::pin_root(w_class);
     }
     let default_mro =
         |index: usize| pyre_object::gc_roots::shadow_stack_get(default_mro_start + index);
@@ -10666,7 +10666,7 @@ pub(crate) unsafe fn compute_and_set_mro(w_self: PyObjectRef) -> PyResult {
             let _mro_roots = pyre_object::gc_roots::push_roots();
             let mro_root_start = pyre_object::gc_roots::shadow_stack_len();
             for &w_class in &mro_w {
-                pyre_object::gc_roots::pin_root(w_class);
+                let _ = pyre_object::gc_roots::pin_root(w_class);
             }
             for index in 0..mro_w.len() {
                 let w_class = pyre_object::gc_roots::shadow_stack_get(mro_root_start + index);
@@ -10708,7 +10708,7 @@ pub(crate) unsafe fn compute_and_set_mro(w_self: PyObjectRef) -> PyResult {
 
 /// Pin `w` into the ambient root scope and hand back its slot.
 fn pin_slot(w: PyObjectRef) -> usize {
-    pyre_object::gc_roots::pin_root(w);
+    let _ = pyre_object::gc_roots::pin_root(w);
     pyre_object::gc_roots::shadow_stack_len() - 1
 }
 
@@ -13229,7 +13229,7 @@ pub fn call_args_and_c_profile_args(
     // `Arguments` vectors before the return hook reads them again.
     let _roots = pyre_object::gc_roots::push_roots();
     let callable_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(callable);
+    let _ = pyre_object::gc_roots::pin_root(callable);
     let flat_base = pyre_object::gc_roots::pin_roots(flat_args);
     let positional_base = pyre_object::gc_roots::pin_roots(&arguments.arguments_w);
     let keyword_base = arguments
@@ -13296,7 +13296,7 @@ pub fn call_args_and_c_profile_args(
     // The return hook runs Python too, so the callee's result is published
     // before it and read back afterwards.
     let result_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_res);
+    let _ = pyre_object::gc_roots::pin_root(w_res);
     if !ec.is_null()
         && let Err(err) = unsafe {
             (*ec).c_return_trace(
@@ -13428,7 +13428,7 @@ pub fn unpackiterable(
     // that call so the hint reads the live object.
     let _roots = pyre_object::gc_roots::push_roots();
     let iterable_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_iterable);
+    let _ = pyre_object::gc_roots::pin_root(w_iterable);
     let w_iterator = iter(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?;
     let w_iterable = || pyre_object::gc_roots::shadow_stack_get(iterable_slot);
     if expected_length == -1 {
@@ -13565,7 +13565,7 @@ fn generator_unpack_into(
     use pyre_object::generator::*;
     let _roots = pyre_object::gc_roots::push_roots();
     let gen_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(gen_obj);
+    let _ = pyre_object::gc_roots::pin_root(gen_obj);
     let gen_obj = || pyre_object::gc_roots::shadow_stack_get(gen_slot);
     unsafe {
         // generator.py:325-327 — `frame is None: return`.
@@ -13629,7 +13629,7 @@ fn generator_unpack_into(
                         break;
                     }
                     // generator.py `results.append(w_result)`.
-                    pyre_object::gc_roots::pin_root(w_result);
+                    let _ = pyre_object::gc_roots::pin_root(w_result);
                     produced += 1;
                 }
             }
@@ -13696,12 +13696,12 @@ fn _unpackiterable_unknown_length(
     // `__len__` / `__length_hint__`, which run Python too.
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_iterator);
+    let _ = pyre_object::gc_roots::pin_root(w_iterator);
     let w_iterator = || pyre_object::gc_roots::shadow_stack_get(root_base);
     // baseobjspace.py — `try: items = newlist_hint(length_hint(...))
     // except MemoryError: items = []`.
     let _ = length_hint(w_iterable, 0)?;
-    pyre_object::gc_roots::pin_root(pyre_object::listobject::w_list_new_empty());
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::listobject::w_list_new_empty());
     // The slot index is computed once here, not at the append below.  Spelled
     // `root_base + 1` inside the drain's `Ok` arm, the addition lands in the
     // arm's own block ahead of the call, and the link out of that block then
@@ -13765,13 +13765,13 @@ fn _unpackiterable_unknown_length(
 pub(crate) fn drain_collect_items(items: PyObjectRef) -> Vec<PyObjectRef> {
     let _roots = pyre_object::gc_roots::push_roots();
     let items_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(items);
+    let _ = pyre_object::gc_roots::pin_root(items);
     let n = unsafe {
         pyre_object::listobject::w_list_len(pyre_object::gc_roots::shadow_stack_get(items_slot))
     };
     let save = pyre_object::gc_roots::shadow_stack_len();
     for i in 0..n as i64 {
-        pyre_object::gc_roots::pin_root(unsafe {
+        let _ = pyre_object::gc_roots::pin_root(unsafe {
             pyre_object::listobject::w_list_getitem(
                 pyre_object::gc_roots::shadow_stack_get(items_slot),
                 i,
@@ -14356,7 +14356,7 @@ fn _unpackiterable_known_length_jitlook(
     // shape here is rebuilt from the published set instead.
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_iterator);
+    let _ = pyre_object::gc_roots::pin_root(w_iterator);
     let iterator = || pyre_object::gc_roots::shadow_stack_get(root_base);
     let mut count = 0usize;
     loop {
@@ -14367,7 +14367,7 @@ fn _unpackiterable_known_length_jitlook(
                         "too many values to unpack (expected {expected_length})",
                     )));
                 }
-                pyre_object::gc_roots::pin_root(w_item);
+                let _ = pyre_object::gc_roots::pin_root(w_item);
                 count += 1;
             }
             Err(e) if e.matches_stop_iteration() => break,
@@ -14994,7 +14994,7 @@ unsafe fn builtin_iter_override(
     // receiver must survive that step to be the one handed to the override.
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let obj = pyre_object::gc_roots::pin_root(obj);
     let Some(method) = (unsafe { builtin_iter_replacement(obj, base) }) else {
         return Ok(None);
     };
@@ -15036,7 +15036,7 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
     // kind is consumed after that lookup.
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let obj = pyre_object::gc_roots::pin_root(obj);
     // `pypy/objspace/std/dictmultiobject.py`
     // `W_BaseDictMultiIterObject` line-by-line port — pyre's
     // `W_BaseDictMultiIterObject`
@@ -15435,12 +15435,12 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
 /// back onto the rooted parent after arbitrary iterator/key-function calls.
 fn groupby_step(obj: PyObjectRef) -> Result<(), PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_self = unsafe { pyre_object::gc_roots::shadow_stack_get(obj_slot) };
     let state = unsafe { &*(w_self as *const pyre_object::interp_itertools::W_GroupBy) };
     let w_newvalue = next(state.w_iterator)?;
-    pyre_object::gc_roots::pin_root(w_newvalue);
+    let _ = pyre_object::gc_roots::pin_root(w_newvalue);
     let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     let w_self = unsafe { pyre_object::gc_roots::shadow_stack_get(obj_slot) };
@@ -15449,14 +15449,14 @@ fn groupby_step(obj: PyObjectRef) -> Result<(), PyError> {
     let w_newkey = if unsafe { pyre_object::is_none(w_keyfunc) } {
         unsafe { pyre_object::gc_roots::shadow_stack_get(value_slot) }
     } else {
-        pyre_object::gc_roots::pin_root(w_keyfunc);
+        let _ = pyre_object::gc_roots::pin_root(w_keyfunc);
         let keyfunc_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         crate::call::call_function_impl_result(
             unsafe { pyre_object::gc_roots::shadow_stack_get(keyfunc_slot) },
             &[unsafe { pyre_object::gc_roots::shadow_stack_get(value_slot) }],
         )?
     };
-    pyre_object::gc_roots::pin_root(w_newkey);
+    let _ = pyre_object::gc_roots::pin_root(w_newkey);
     let key_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     let w_self = unsafe { pyre_object::gc_roots::shadow_stack_get(obj_slot) };
@@ -15591,7 +15591,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 // `obj`, so pin it and read the iterator state back through the
                 // re-read pointer rather than the now-stale `iter` reference.
                 let _roots = pyre_object::gc_roots::push_roots();
-                pyre_object::gc_roots::pin_root(obj);
+                let _ = pyre_object::gc_roots::pin_root(obj);
                 let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 match getitem(seq, w_int_new(idx)) {
                     Ok(v) => {
@@ -15675,14 +15675,14 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         if pyre_object::interp_itertools::is_count(obj) {
             let _guard = pyre_object::interp_itertools::w_count_lock(obj);
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let w_c = pyre_object::interp_itertools::w_count_get_c(w_self);
-            pyre_object::gc_roots::pin_root(w_c);
+            let _ = pyre_object::gc_roots::pin_root(w_c);
             let current_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_step = pyre_object::interp_itertools::w_count_get_step(w_self);
-            pyre_object::gc_roots::pin_root(w_step);
+            let _ = pyre_object::gc_roots::pin_root(w_step);
             let step_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let new_c = add(
                 pyre_object::gc_roots::shadow_stack_get(current_slot),
@@ -15804,7 +15804,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 return crate::call::call_function_impl_result(method, &[obj]);
             }
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
@@ -15881,7 +15881,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             }
 
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let state = &*(w_self as *const pyre_object::interp_itertools::W_Batched);
@@ -15897,7 +15897,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 let it = (*(w_self as *const pyre_object::interp_itertools::W_Batched)).it;
                 match next(it) {
                     Ok(item) => {
-                        pyre_object::gc_roots::pin_root(item);
+                        let _ = pyre_object::gc_roots::pin_root(item);
                         item_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
                     }
                     Err(e) if e.matches_stop_iteration() => {
@@ -15939,7 +15939,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             }
 
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let state = &*(w_self as *const pyre_object::interp_itertools::W_Product);
@@ -15964,7 +15964,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     }
                     let item =
                         pyre_object::w_list_getitem(gear, 0).expect("non-empty product gear");
-                    pyre_object::gc_roots::pin_root(item);
+                    let _ = pyre_object::gc_roots::pin_root(item);
                     item_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
                 }
                 let initial = pyre_object::w_list_new(
@@ -16041,7 +16041,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 let lst = (*(w_self as *const pyre_object::interp_itertools::W_Product)).lst;
                 let item = pyre_object::w_list_getitem(lst, index as i64)
                     .expect("product result in range");
-                pyre_object::gc_roots::pin_root(item);
+                let _ = pyre_object::gc_roots::pin_root(item);
                 result_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
             }
             return Ok(pyre_object::w_tuple_new(
@@ -16062,7 +16062,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             }
 
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let state = &*(w_self as *const pyre_object::interp_itertools::W_Combinations);
@@ -16083,7 +16083,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     let index = pyre_object::w_int_get_value(w_index);
                     let item = pyre_object::w_list_getitem(state.pool_w, index)
                         .expect("combinations pool index in range");
-                    pyre_object::gc_roots::pin_root(item);
+                    let _ = pyre_object::gc_roots::pin_root(item);
                     item_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
                 }
                 pyre_object::w_list_new(
@@ -16099,7 +16099,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 for i in 0..r {
                     let item = pyre_object::w_list_getitem(state.last_result_w, i as i64)
                         .expect("combinations result index in range");
-                    pyre_object::gc_roots::pin_root(item);
+                    let _ = pyre_object::gc_roots::pin_root(item);
                     old_item_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
                 }
                 let result = pyre_object::w_list_new(
@@ -16108,7 +16108,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                         .map(pyre_object::gc_roots::shadow_stack_get)
                         .collect(),
                 );
-                pyre_object::gc_roots::pin_root(result);
+                let result = pyre_object::gc_roots::pin_root(result);
                 let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
                 // Scan right-to-left for an index below i + n - r.
@@ -16178,7 +16178,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 pyre_object::gc_roots::shadow_stack_get(result_slot)
             };
 
-            pyre_object::gc_roots::pin_root(result);
+            let _ = pyre_object::gc_roots::pin_root(result);
             let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             (*(w_self as *mut pyre_object::interp_itertools::W_Combinations)).last_result_w =
@@ -16192,7 +16192,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     i as i64,
                 )
                 .expect("combinations result in range");
-                pyre_object::gc_roots::pin_root(item);
+                let _ = pyre_object::gc_roots::pin_root(item);
                 result_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
             }
             return Ok(pyre_object::w_tuple_new(
@@ -16216,7 +16216,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             }
 
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let state =
@@ -16239,7 +16239,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     let index = pyre_object::w_int_get_value(w_index);
                     let item = pyre_object::w_list_getitem(state.pool_w, index)
                         .expect("combinations_with_replacement pool index in range");
-                    pyre_object::gc_roots::pin_root(item);
+                    let _ = pyre_object::gc_roots::pin_root(item);
                     item_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
                 }
                 pyre_object::w_list_new(
@@ -16253,7 +16253,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 for i in 0..r {
                     let item = pyre_object::w_list_getitem(state.last_result_w, i as i64)
                         .expect("combinations_with_replacement result index in range");
-                    pyre_object::gc_roots::pin_root(item);
+                    let _ = pyre_object::gc_roots::pin_root(item);
                     old_item_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
                 }
                 let result = pyre_object::w_list_new(
@@ -16262,7 +16262,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                         .map(pyre_object::gc_roots::shadow_stack_get)
                         .collect(),
                 );
-                pyre_object::gc_roots::pin_root(result);
+                let result = pyre_object::gc_roots::pin_root(result);
                 let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
                 // W_CombinationsWithReplacement.get_maximum always returns
@@ -16317,7 +16317,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 pyre_object::gc_roots::shadow_stack_get(result_slot)
             };
 
-            pyre_object::gc_roots::pin_root(result);
+            let _ = pyre_object::gc_roots::pin_root(result);
             let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             (*(w_self as *mut pyre_object::interp_itertools::W_CombinationsWithReplacement))
@@ -16331,7 +16331,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     i as i64,
                 )
                 .expect("combinations_with_replacement result in range");
-                pyre_object::gc_roots::pin_root(item);
+                let _ = pyre_object::gc_roots::pin_root(item);
                 result_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
             }
             return Ok(pyre_object::w_tuple_new(
@@ -16352,7 +16352,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             }
 
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let state = &*(w_self as *const pyre_object::interp_itertools::W_Permutations);
@@ -16376,7 +16376,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 );
                 let item = pyre_object::w_list_getitem(state.pool_w, index)
                     .expect("permutations pool index in range");
-                pyre_object::gc_roots::pin_root(item);
+                let _ = pyre_object::gc_roots::pin_root(item);
                 result_item_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
             }
             let result = pyre_object::w_tuple_new(
@@ -16385,7 +16385,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     .map(pyre_object::gc_roots::shadow_stack_get)
                     .collect(),
             );
-            pyre_object::gc_roots::pin_root(result);
+            let _ = pyre_object::gc_roots::pin_root(result);
             let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
             let mut i = r;
@@ -16450,7 +16450,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             }
 
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             (*(w_self as *mut pyre_object::interp_itertools::W_GroupBy)).w_currgrouper = PY_NULL;
@@ -16467,9 +16467,9 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 } else {
                     {
                         let _compare_roots = pyre_object::gc_roots::push_roots();
-                        pyre_object::gc_roots::pin_root(state.w_tgtkey);
+                        let _ = pyre_object::gc_roots::pin_root(state.w_tgtkey);
                         let tgt_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-                        pyre_object::gc_roots::pin_root(state.w_currkey);
+                        let _ = pyre_object::gc_roots::pin_root(state.w_currkey);
                         let curr_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                         eq_w(
                             pyre_object::gc_roots::shadow_stack_get(tgt_slot),
@@ -16485,7 +16485,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
 
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let w_key = (*(w_self as *const pyre_object::interp_itertools::W_GroupBy)).w_currkey;
-            pyre_object::gc_roots::pin_root(w_key);
+            let _ = pyre_object::gc_roots::pin_root(w_key);
             let key_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             (*(w_self as *mut pyre_object::interp_itertools::W_GroupBy)).w_tgtkey =
@@ -16496,7 +16496,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 pyre_object::gc_roots::shadow_stack_get(obj_slot),
                 pyre_object::gc_roots::shadow_stack_get(key_slot),
             );
-            pyre_object::gc_roots::pin_root(grouper);
+            let _ = pyre_object::gc_roots::pin_root(grouper);
             let grouper_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             return Ok(pyre_object::w_tuple_new(vec![
                 pyre_object::gc_roots::shadow_stack_get(key_slot),
@@ -16506,12 +16506,12 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         // itertools._grouper — PyPy W_GroupByIterator.next_w.
         if pyre_object::interp_itertools::is_groupby_iterator(obj) {
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let parent =
                 (*(w_self as *const pyre_object::interp_itertools::W_GroupByIterator)).groupby;
-            pyre_object::gc_roots::pin_root(parent);
+            let _ = pyre_object::gc_roots::pin_root(parent);
             let parent_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
             let parent = pyre_object::gc_roots::shadow_stack_get(parent_slot);
@@ -16531,12 +16531,12 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
                 let w_tgtkey =
                     (*(w_self as *const pyre_object::interp_itertools::W_GroupByIterator)).w_tgtkey;
-                pyre_object::gc_roots::pin_root(w_tgtkey);
+                let _ = pyre_object::gc_roots::pin_root(w_tgtkey);
                 let tgt_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let parent = pyre_object::gc_roots::shadow_stack_get(parent_slot);
                 let w_currkey =
                     (*(parent as *const pyre_object::interp_itertools::W_GroupBy)).w_currkey;
-                pyre_object::gc_roots::pin_root(w_currkey);
+                let _ = pyre_object::gc_roots::pin_root(w_currkey);
                 let curr_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 eq_w(
                     pyre_object::gc_roots::shadow_stack_get(tgt_slot),
@@ -16553,7 +16553,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 return Err(PyError::stop_iteration());
             }
             let w_result = parent_state.w_currvalue;
-            pyre_object::gc_roots::pin_root(w_result);
+            let _ = pyre_object::gc_roots::pin_root(w_result);
             let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let parent = pyre_object::gc_roots::shadow_stack_get(parent_slot);
             let parent_state = &mut *(parent as *mut pyre_object::interp_itertools::W_GroupBy);
@@ -16566,7 +16566,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         // source and then linked to a fresh empty node.
         if pyre_object::interp_itertools::is_tee_iterable(obj) {
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let w_node =
@@ -16574,7 +16574,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             if w_node.is_null() {
                 return Err(PyError::stop_iteration());
             }
-            pyre_object::gc_roots::pin_root(w_node);
+            let _ = pyre_object::gc_roots::pin_root(w_node);
             let node_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
             let node = pyre_object::gc_roots::shadow_stack_get(node_slot);
@@ -16588,7 +16588,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
                 let w_iterator =
                     (*(w_self as *const pyre_object::interp_itertools::W_TeeIterable)).w_iterator;
-                pyre_object::gc_roots::pin_root(w_iterator);
+                let _ = pyre_object::gc_roots::pin_root(w_iterator);
                 let iterator_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let next_result = next(pyre_object::gc_roots::shadow_stack_get(iterator_slot));
                 let w_item = match next_result {
@@ -16606,10 +16606,10 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                         return Err(err);
                     }
                 };
-                pyre_object::gc_roots::pin_root(w_item);
+                let _ = pyre_object::gc_roots::pin_root(w_item);
                 let item_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let w_next = pyre_object::interp_itertools::w_tee_chained_list_node_new();
-                pyre_object::gc_roots::pin_root(w_next);
+                let _ = pyre_object::gc_roots::pin_root(w_next);
                 let next_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
                 let node = pyre_object::gc_roots::shadow_stack_get(node_slot);
@@ -16625,9 +16625,9 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             let node_state = &*(node as *const pyre_object::interp_itertools::W_TeeChainedListNode);
             let w_item = node_state.w_obj;
             let w_next = node_state.w_next;
-            pyre_object::gc_roots::pin_root(w_item);
+            let _ = pyre_object::gc_roots::pin_root(w_item);
             let item_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            pyre_object::gc_roots::pin_root(w_next);
+            let _ = pyre_object::gc_roots::pin_root(w_next);
             let next_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             (*(w_self as *mut pyre_object::interp_itertools::W_TeeIterable)).w_chained_list =
@@ -16641,26 +16641,26 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         // rooted across both arbitrary Python iterator/truth calls.
         if pyre_object::interp_itertools::is_compress(obj) {
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             loop {
                 let _iteration_roots = pyre_object::gc_roots::push_roots();
                 let w_data = (*(pyre_object::gc_roots::shadow_stack_get(obj_slot)
                     as *const pyre_object::interp_itertools::W_Compress))
                     .w_data;
-                pyre_object::gc_roots::pin_root(w_data);
+                let _ = pyre_object::gc_roots::pin_root(w_data);
                 let data_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let w_item = next(pyre_object::gc_roots::shadow_stack_get(data_slot))?;
-                pyre_object::gc_roots::pin_root(w_item);
+                let _ = pyre_object::gc_roots::pin_root(w_item);
                 let item_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
                 let w_selectors = (*(pyre_object::gc_roots::shadow_stack_get(obj_slot)
                     as *const pyre_object::interp_itertools::W_Compress))
                     .w_selectors;
-                pyre_object::gc_roots::pin_root(w_selectors);
+                let _ = pyre_object::gc_roots::pin_root(w_selectors);
                 let selectors_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let w_selector = next(pyre_object::gc_roots::shadow_stack_get(selectors_slot))?;
-                pyre_object::gc_roots::pin_root(w_selector);
+                let _ = pyre_object::gc_roots::pin_root(w_selector);
                 let selector_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 if is_true(pyre_object::gc_roots::shadow_stack_get(selector_slot))? {
                     return Ok(pyre_object::gc_roots::shadow_stack_get(item_slot));
@@ -16672,22 +16672,22 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         // re-read from the rooted owner across calls that may move the heap.
         if pyre_object::interp_itertools::is_starmap(obj) {
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_iterable = (*(pyre_object::gc_roots::shadow_stack_get(obj_slot)
                 as *const pyre_object::interp_itertools::W_StarMap))
                 .w_iterable;
-            pyre_object::gc_roots::pin_root(w_iterable);
+            let _ = pyre_object::gc_roots::pin_root(w_iterable);
             let iterable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_obj = next(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?;
-            pyre_object::gc_roots::pin_root(w_obj);
+            let _ = pyre_object::gc_roots::pin_root(w_obj);
             let obj_args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let call_args = crate::builtins::collect_iterable(
                 pyre_object::gc_roots::shadow_stack_get(obj_args_slot),
             )?;
             let first_arg_slot = pyre_object::gc_roots::shadow_stack_len();
             for &arg in &call_args {
-                pyre_object::gc_roots::pin_root(arg);
+                let _ = pyre_object::gc_roots::pin_root(arg);
             }
             let mut rooted_args = Vec::with_capacity(call_args.len());
             for index in 0..call_args.len() {
@@ -16698,7 +16698,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             let w_fun = (*(pyre_object::gc_roots::shadow_stack_get(obj_slot)
                 as *const pyre_object::interp_itertools::W_StarMap))
                 .w_fun;
-            pyre_object::gc_roots::pin_root(w_fun);
+            let _ = pyre_object::gc_roots::pin_root(w_fun);
             let fun_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             return crate::call::call_function_impl_result(
                 pyre_object::gc_roots::shadow_stack_get(fun_slot),
@@ -16710,7 +16710,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         // operation only when the next result is requested.
         if pyre_object::interp_itertools::is_accumulate(obj) {
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let w_initial =
@@ -16727,7 +16727,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             let w_iterable =
                 (*(w_self as *const pyre_object::interp_itertools::W_Accumulate)).w_iterable;
             let w_value = next(w_iterable)?;
-            pyre_object::gc_roots::pin_root(w_value);
+            let w_value = pyre_object::gc_roots::pin_root(w_value);
             let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let w_total = (*(w_self as *const pyre_object::interp_itertools::W_Accumulate)).w_total;
@@ -16737,7 +16737,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 return Ok(w_value);
             }
 
-            pyre_object::gc_roots::pin_root(w_total);
+            let _ = pyre_object::gc_roots::pin_root(w_total);
             let total_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_func = (*(pyre_object::gc_roots::shadow_stack_get(obj_slot)
                 as *const pyre_object::interp_itertools::W_Accumulate))
@@ -16748,7 +16748,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     pyre_object::gc_roots::shadow_stack_get(value_slot),
                 )?
             } else {
-                pyre_object::gc_roots::pin_root(w_func);
+                let _ = pyre_object::gc_roots::pin_root(w_func);
                 let func_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 crate::call::call_function_impl_result(
                     pyre_object::gc_roots::shadow_stack_get(func_slot),
@@ -16768,7 +16768,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         // shared fill value until the last iterator stops.
         if pyre_object::interp_itertools::is_zip_longest(obj) {
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let w_iterators =
@@ -16806,7 +16806,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                         Err(e) => return Err(e),
                     }
                 };
-                pyre_object::gc_roots::pin_root(w_obj);
+                let w_obj = pyre_object::gc_roots::pin_root(w_obj);
                 objects.push(w_obj);
             }
             // Rebuild from roots because any preceding `next` may have moved
@@ -16838,7 +16838,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             // can move the filter and the yielded item; pin the filter and re-read
             // its fields after each call, and pin the item across the predicate.
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             loop {
                 let w_iterable = (*(pyre_object::gc_roots::shadow_stack_get(obj_slot)
@@ -16846,12 +16846,12 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     .w_iterable;
                 let w_obj = {
                     let _iter_roots = pyre_object::gc_roots::push_roots();
-                    pyre_object::gc_roots::pin_root(w_iterable);
+                    let _ = pyre_object::gc_roots::pin_root(w_iterable);
                     let iterable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                     next(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?
                 };
                 let _r = pyre_object::gc_roots::push_roots();
-                pyre_object::gc_roots::pin_root(w_obj);
+                let _ = pyre_object::gc_roots::pin_root(w_obj);
                 let w_obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let w_predicate = (*(pyre_object::gc_roots::shadow_stack_get(obj_slot)
                     as *const pyre_object::functional::W_Filter))
@@ -16859,13 +16859,13 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 let pred = if w_predicate.is_null() {
                     is_true(pyre_object::gc_roots::shadow_stack_get(w_obj_slot))?
                 } else {
-                    pyre_object::gc_roots::pin_root(w_predicate);
+                    let _ = pyre_object::gc_roots::pin_root(w_predicate);
                     let predicate_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                     let w_pred = crate::call::call_function_impl_result(
                         pyre_object::gc_roots::shadow_stack_get(predicate_slot),
                         &[pyre_object::gc_roots::shadow_stack_get(w_obj_slot)],
                     )?;
-                    pyre_object::gc_roots::pin_root(w_pred);
+                    let _ = pyre_object::gc_roots::pin_root(w_pred);
                     let pred_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                     is_true(pyre_object::gc_roots::shadow_stack_get(pred_slot))?
                 };
@@ -16880,11 +16880,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         if pyre_object::functional::is_map(obj) {
             use pyre_object::functional as mo;
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let w_iterators = mo::w_map_get_iterators(obj);
-            pyre_object::gc_roots::pin_root(w_iterators);
+            let _ = pyre_object::gc_roots::pin_root(w_iterators);
             let iterators_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let strict = mo::w_map_get_strict(obj);
             return match pull_iterator_tuple(
@@ -16896,11 +16896,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 Some(items) => {
                     let items_base = pyre_object::gc_roots::shadow_stack_len();
                     for &item in &items {
-                        pyre_object::gc_roots::pin_root(item);
+                        let _ = pyre_object::gc_roots::pin_root(item);
                     }
                     let w_fun =
                         mo::w_map_get_fun(pyre_object::gc_roots::shadow_stack_get(obj_slot));
-                    pyre_object::gc_roots::pin_root(w_fun);
+                    let _ = pyre_object::gc_roots::pin_root(w_fun);
                     let fun_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                     let mut rooted_items = Vec::with_capacity(items.len());
                     for index in 0..items.len() {
@@ -16921,11 +16921,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         if pyre_object::functional::is_zip(obj) {
             use pyre_object::functional as zo;
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let w_iterators = zo::w_zip_get_iterators(obj);
-            pyre_object::gc_roots::pin_root(w_iterators);
+            let _ = pyre_object::gc_roots::pin_root(w_iterators);
             let iterators_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let length =
                 pyre_object::w_list_len(pyre_object::gc_roots::shadow_stack_get(iterators_slot))
@@ -16955,9 +16955,9 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     1,
                 )
                 .unwrap();
-                pyre_object::gc_roots::pin_root(iterator0);
+                let _ = pyre_object::gc_roots::pin_root(iterator0);
                 let iterator0_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-                pyre_object::gc_roots::pin_root(iterator1);
+                let _ = pyre_object::gc_roots::pin_root(iterator1);
                 let iterator1_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 zo::w_zip_set_iteration_progress(
                     pyre_object::gc_roots::shadow_stack_get(obj_slot),
@@ -16981,7 +16981,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     }
                     Err(other) => return Err(other),
                 };
-                pyre_object::gc_roots::pin_root(item0);
+                let _ = pyre_object::gc_roots::pin_root(item0);
                 let item0_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 zo::w_zip_set_iteration_progress(
                     pyre_object::gc_roots::shadow_stack_get(obj_slot),
@@ -16997,7 +16997,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     }
                     Err(other) => return Err(other),
                 };
-                pyre_object::gc_roots::pin_root(item1);
+                let _ = pyre_object::gc_roots::pin_root(item1);
                 let item1_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 return Ok(pyre_object::w_specialised_tuple_oo_new(
                     pyre_object::gc_roots::shadow_stack_get(item0_slot),
@@ -17014,7 +17014,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             )? {
                 Some(items) => {
                     for &item in &items {
-                        pyre_object::gc_roots::pin_root(item);
+                        let _ = pyre_object::gc_roots::pin_root(item);
                     }
                     // PyPy's `space.newtuple(items)` may select the `_ii` or
                     // `_ff` value-backed arity-2 representation because its
@@ -17064,10 +17064,10 @@ pub fn next(obj: PyObjectRef) -> PyResult {
 
             let roots = pyre_object::gc_roots::push_roots();
             let base = roots.base();
-            roots.pin_root(obj);
-            roots.pin_root(pairwise::w_pairwise_get_iterator(roots.get(base + SELF)));
-            roots.pin_root(pairwise::w_pairwise_get_prev(roots.get(base + SELF)));
-            roots.pin_root(std::ptr::null_mut());
+            let _ = roots.pin_root(obj);
+            let _ = roots.pin_root(pairwise::w_pairwise_get_iterator(roots.get(base + SELF)));
+            let _ = roots.pin_root(pairwise::w_pairwise_get_prev(roots.get(base + SELF)));
+            let _ = roots.pin_root(std::ptr::null_mut());
 
             if roots.get(base + PREV).is_null() {
                 let w_prev = next(roots.get(base + ITERATOR))?;
@@ -17165,7 +17165,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             // Keep the chain rooted and re-read it after calls into Python.
             // Both `next` and `iter` can allocate and relocate GC objects.
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             loop {
                 let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
@@ -17196,7 +17196,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     };
                     let w_it_result = {
                         let _iter_roots = pyre_object::gc_roots::push_roots();
-                        pyre_object::gc_roots::pin_root(w_iterable);
+                        let _ = pyre_object::gc_roots::pin_root(w_iterable);
                         let iterable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                         iter(pyre_object::gc_roots::shadow_stack_get(iterable_slot))
                     };
@@ -17398,7 +17398,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             // RPython's GC transform keeps `self` and the active bigint Box
             // rooted; mirror that explicitly and reload fields after calls.
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let w_index_slot = eo::w_enumerate_get_w_index(obj);
@@ -17430,16 +17430,16 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                         None => {
                             // Promote to bigint slot per `:299-302`.
                             let w_idx = pyre_object::w_long_new(BigInt::from(index));
-                            pyre_object::gc_roots::pin_root(w_idx);
+                            let _ = pyre_object::gc_roots::pin_root(w_idx);
                             let w_idx_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                             let one = pyre_object::w_long_new(BigInt::from(1i64));
-                            pyre_object::gc_roots::pin_root(one);
+                            let _ = pyre_object::gc_roots::pin_root(one);
                             let one_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                             let bumped = add(
                                 pyre_object::gc_roots::shadow_stack_get(w_idx_slot),
                                 pyre_object::gc_roots::shadow_stack_get(one_slot),
                             )?;
-                            pyre_object::gc_roots::pin_root(bumped);
+                            let _ = pyre_object::gc_roots::pin_root(bumped);
                             let bumped_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                             let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
                             eo::w_enumerate_set_w_index(
@@ -17453,16 +17453,16 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 w_index = pyre_object::w_int_new(index);
             } else {
                 // Bigint slot active — bump via `space.add`.
-                pyre_object::gc_roots::pin_root(w_index_slot);
+                let _ = pyre_object::gc_roots::pin_root(w_index_slot);
                 let w_index_slot_root = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let one = pyre_object::w_int_new(1);
-                pyre_object::gc_roots::pin_root(one);
+                let _ = pyre_object::gc_roots::pin_root(one);
                 let one_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let bumped = add(
                     pyre_object::gc_roots::shadow_stack_get(w_index_slot_root),
                     pyre_object::gc_roots::shadow_stack_get(one_slot),
                 )?;
-                pyre_object::gc_roots::pin_root(bumped);
+                let _ = pyre_object::gc_roots::pin_root(bumped);
                 let bumped_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
                 eo::w_enumerate_set_w_index(
@@ -17471,7 +17471,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 );
                 w_index = pyre_object::gc_roots::shadow_stack_get(w_index_slot_root);
             }
-            pyre_object::gc_roots::pin_root(w_index);
+            let _ = pyre_object::gc_roots::pin_root(w_index);
             let result_index_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             if w_item.is_null() {
                 // Re-read slot — list fast-path already set w_item;
@@ -17481,7 +17481,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 if w_iter_or_list.is_null() {
                     return Err(PyError::stop_iteration());
                 }
-                pyre_object::gc_roots::pin_root(w_iter_or_list);
+                let _ = pyre_object::gc_roots::pin_root(w_iter_or_list);
                 let iter_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 w_item = next(pyre_object::gc_roots::shadow_stack_get(iter_slot))?;
             }
@@ -17501,14 +17501,14 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 // `getitem` runs `__getitem__` (Python) and can move the reversed
                 // iterator; pin it and write its state through the re-read pointer.
                 let _roots = pyre_object::gc_roots::push_roots();
-                pyre_object::gc_roots::pin_root(obj);
+                let obj = pyre_object::gc_roots::pin_root(obj);
                 let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let seq =
                     ro::w_reversed_get_sequence(pyre_object::gc_roots::shadow_stack_get(obj_slot));
-                pyre_object::gc_roots::pin_root(seq);
+                let _ = pyre_object::gc_roots::pin_root(seq);
                 let seq_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let index = w_int_new(remaining);
-                pyre_object::gc_roots::pin_root(index);
+                let _ = pyre_object::gc_roots::pin_root(index);
                 let index_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 match getitem(
                     pyre_object::gc_roots::shadow_stack_get(seq_slot),
@@ -18173,7 +18173,7 @@ unsafe fn leak_generator_iteration(mut e: PyError, message: &str) -> PyError {
     // is stamped onto `rt` as `__context__` / `__cause__`.
     let _roots = pyre_object::gc_roots::push_roots();
     if !w_stopiter.is_null() {
-        pyre_object::gc_roots::pin_root(w_stopiter);
+        let _ = pyre_object::gc_roots::pin_root(w_stopiter);
     }
     let rt = w_exception_new(ExcKind::RuntimeError, message);
     if pyre_object::is_exception(rt) && !w_stopiter.is_null() {
@@ -18261,8 +18261,8 @@ fn cycle_setstate_method(args: &[PyObjectRef]) -> PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let w_self = args[0];
     let w_state = if args.len() > 1 { args[1] } else { w_none() };
-    pyre_object::gc_roots::pin_root(w_self);
-    pyre_object::gc_roots::pin_root(w_state);
+    let w_self = pyre_object::gc_roots::pin_root(w_self);
+    let w_state = pyre_object::gc_roots::pin_root(w_state);
     let state_w = unpackiterable(w_state, 2)?;
     let saved_w = unpackiterable(state_w[0], -1)?;
     let w_saved = w_list_new(saved_w);
@@ -18313,8 +18313,8 @@ fn chain_setstate_method(args: &[PyObjectRef]) -> PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let w_self = args[0];
     let w_state = if args.len() > 1 { args[1] } else { w_none() };
-    pyre_object::gc_roots::pin_root(w_self);
-    pyre_object::gc_roots::pin_root(w_state);
+    let w_self = pyre_object::gc_roots::pin_root(w_self);
+    let w_state = pyre_object::gc_roots::pin_root(w_state);
     let state = unpackiterable(w_state, -1)?;
     let n = state.len();
     if n < 1 {
@@ -18479,7 +18479,7 @@ pub(crate) fn generator_close_method(args: &[PyObjectRef]) -> PyResult {
             // GeneratorExit is caught and the generator executes `return x`.
             let w_exc = e.to_exc_object();
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(w_exc);
+            let w_exc = pyre_object::gc_roots::pin_root(w_exc);
             let value = getattr_str(w_exc, "value").or_else(|_| Ok(w_none()));
             // The StopIteration has been consumed at this Rust-level catch;
             // unlike a Python handler, no PUSH_EXC_INFO will clear the
@@ -18504,10 +18504,10 @@ pub(crate) fn generator_close_method(args: &[PyObjectRef]) -> PyResult {
             // locals became unreachable.
             let _roots = pyre_object::gc_roots::push_roots();
             match &mut result {
-                Ok(value) => pyre_object::gc_roots::pin_root(*value),
+                Ok(value) => *value = pyre_object::gc_roots::pin_root(*value),
                 Err(error) => {
                     let w_exc = error.to_exc_object();
-                    pyre_object::gc_roots::pin_root(w_exc);
+                    let _ = pyre_object::gc_roots::pin_root(w_exc);
                 }
             }
             let ec = crate::call::getexecutioncontext()
@@ -18572,8 +18572,8 @@ fn async_generator_init_hooks(async_gen: PyObjectRef) -> PyResult {
         let firstiter = (*ec).w_asyncgen_firstiter_fn;
         if !firstiter.is_null() {
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(async_gen);
-            pyre_object::gc_roots::pin_root(firstiter);
+            let async_gen = pyre_object::gc_roots::pin_root(async_gen);
+            let firstiter = pyre_object::gc_roots::pin_root(firstiter);
             crate::call::call_function_impl_result(firstiter, &[async_gen])?;
         }
     }
@@ -18803,8 +18803,8 @@ fn async_gen_athrow_do_send(awaitable: PyObjectRef, arg: PyObjectRef) -> PyResul
     // the nested execution may park while another thread performs a major GC.
     let _roots = pyre_object::gc_roots::push_roots();
     let awaitable_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(awaitable);
-    pyre_object::gc_roots::pin_root(arg);
+    let _ = pyre_object::gc_roots::pin_root(awaitable);
+    let _ = pyre_object::gc_roots::pin_root(arg);
     let awaitable = pyre_object::gc_roots::shadow_stack_get(awaitable_slot);
     let arg = pyre_object::gc_roots::shadow_stack_get(awaitable_slot + 1);
     let (async_gen, exc_type, exc_value, exc_tb, state) = {
@@ -18823,8 +18823,7 @@ fn async_gen_athrow_do_send(awaitable: PyObjectRef, arg: PyObjectRef) -> PyResul
     // exactly as the translated livevar set does, rather than depending only
     // on the edge from `self`.
     let async_gen_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(async_gen);
-    let async_gen = pyre_object::gc_roots::shadow_stack_get(async_gen_slot);
+    let async_gen = pyre_object::gc_roots::pin_root(async_gen);
     if state == ASYNC_GEN_STATE_CLOSED {
         return Err(PyError::runtime_error(
             "cannot reuse already awaited aclose()/athrow()",
@@ -19142,7 +19141,7 @@ pub fn generator_finalize(gen_obj: PyObjectRef) -> PyResult {
         {
             w_coroutine_set_warned_unawaited(gen_obj);
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(gen_obj);
+            let gen_obj = pyre_object::gc_roots::pin_root(gen_obj);
             warn_unawaited_coroutine(gen_obj);
         }
         if last_instr < 0 {
@@ -19243,7 +19242,7 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
                     // path, so pin it across the probe.
                     let _roots = pyre_object::gc_roots::push_roots();
                     let needle_slot = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(needle);
+                    let _ = pyre_object::gc_roots::pin_root(needle);
                     return match unsafe {
                         pyre_object::dictmultiobject::w_dict_lookup_checked(
                             dict,
@@ -19273,9 +19272,9 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
                     // raw locals read after the probe, so pin them across it.
                     let _roots = pyre_object::gc_roots::push_roots();
                     let k_slot = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(k);
+                    let _ = pyre_object::gc_roots::pin_root(k);
                     let want_slot = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(want);
+                    let _ = pyre_object::gc_roots::pin_root(want);
                     return match unsafe {
                         pyre_object::dictmultiobject::w_dict_lookup_checked(
                             dict,
@@ -19298,10 +19297,10 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
                     let items = pyre_object::w_dict_items(dict);
                     let _roots = pyre_object::gc_roots::push_roots();
                     let needle_slot = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(needle);
+                    let _ = pyre_object::gc_roots::pin_root(needle);
                     let base = pyre_object::gc_roots::shadow_stack_len();
                     for (_, v) in &items {
-                        pyre_object::gc_roots::pin_root(*v);
+                        let _ = pyre_object::gc_roots::pin_root(*v);
                     }
                     for j in 0..items.len() {
                         if eq_w(
@@ -19344,9 +19343,9 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
             // raw locals, so pin them on the shadow stack across the scan.
             let _roots = pyre_object::gc_roots::push_roots();
             let hay_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(haystack);
+            let _ = pyre_object::gc_roots::pin_root(haystack);
             let needle_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(needle);
+            let _ = pyre_object::gc_roots::pin_root(needle);
             let len = w_tuple_len(pyre_object::gc_roots::shadow_stack_get(hay_slot));
             for i in 0..len {
                 if let Some(item) =
@@ -19428,7 +19427,7 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
             // `needle` is a raw local read again on the error path, so pin it.
             let _roots = pyre_object::gc_roots::push_roots();
             let needle_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(needle);
+            let _ = pyre_object::gc_roots::pin_root(needle);
             return match pyre_object::dictmultiobject::w_dict_lookup_checked(
                 haystack,
                 pyre_object::gc_roots::shadow_stack_get(needle_slot),
@@ -19493,9 +19492,9 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
     // are raw locals, so pin them on the shadow stack across the scan.
     let _roots = pyre_object::gc_roots::push_roots();
     let iter_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(iterator);
+    let _ = pyre_object::gc_roots::pin_root(iterator);
     let needle_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(needle);
+    let _ = pyre_object::gc_roots::pin_root(needle);
     loop {
         match next(pyre_object::gc_roots::shadow_stack_get(iter_slot)) {
             Ok(item) => {
@@ -19736,7 +19735,7 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
                     // Rooted for the components' `__index__` calls; a
                     // bytearray does not move, so this is liveness alone.
                     let _roots = pyre_object::gc_roots::push_roots();
-                    pyre_object::gc_roots::pin_root(obj);
+                    let _ = pyre_object::gc_roots::pin_root(obj);
                     crate::sliceobject::slice_unpack(
                         w_slice_get_start(index),
                         w_slice_get_stop(index),
@@ -19780,7 +19779,7 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
             }
             let i = {
                 let _roots = pyre_object::gc_roots::push_roots();
-                pyre_object::gc_roots::pin_root(obj);
+                let _ = pyre_object::gc_roots::pin_root(obj);
                 subscript_index_w("bytearray", index)?
             };
             let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5277,23 +5277,26 @@ fn min_max_sequence(
     want_max: bool,
     fn_name: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let _roots = pyre_object::gc_roots::push_roots();
-    let sequence_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(sequence);
     // `iter` below runs the argument's `__iter__`.  The gateway pins the
-    // argument array, but `key` and `default` are copies taken out of it and a
-    // minor rewrites the array rather than the copies, so both take slots of
-    // their own before anything can collect.  Publishing a stale word as a
-    // root is worse than reading one: the next collection walks it as if it
-    // named an object.
-    let key_fn_slot = key_fn.map(|key| {
-        let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(key);
-        slot
-    });
+    // argument array, but `sequence`, `key` and `default` are copies taken out
+    // of it and a minor rewrites the array rather than the copies, so all
+    // three take slots of their own before anything can collect.  Publishing a
+    // stale word as a root is worse than reading one: the next collection
+    // walks it as if it named an object.
+    //
+    // One `pin_roots` for the three rather than a `pin_root` each: the
+    // forwarding query that ends a publication is itself a safepoint, so a
+    // value still sitting in a native local while an earlier query runs is
+    // published afterwards at the address it had before.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sequence_slot = pyre_object::gc_roots::pin_roots(&[
+        sequence,
+        key_fn.unwrap_or_else(pyre_object::w_none),
+        default.unwrap_or_else(pyre_object::w_none),
+    ]);
+    let key_fn_slot = key_fn.map(|_| sequence_slot + 1);
     let has_default = default.is_some();
-    let default_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(default.unwrap_or_else(pyre_object::w_none));
+    let default_slot = sequence_slot + 2;
     let it = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(sequence_slot))?;
     let iterator_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(it);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -183,7 +183,7 @@ unsafe fn memoryview_wrap_dims(dims: &[i64]) -> PyObjectRef {
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
         for &d in dims {
-            pyre_object::gc_roots::pin_root(w_int_new(d));
+            let _ = pyre_object::gc_roots::pin_root(w_int_new(d));
         }
         let items: Vec<PyObjectRef> = (0..dims.len())
             .map(|i| pyre_object::gc_roots::shadow_stack_get(sp + i))
@@ -208,7 +208,7 @@ unsafe fn w_memoryview_new_derived(
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(mv_src);
+        let _ = pyre_object::gc_roots::pin_root(mv_src);
         // A derived view stays alive independently of the view it came from,
         // so it takes its own `_exports` count on the backing rather than
         // relying on the source's: releasing the source must not leave this
@@ -232,8 +232,8 @@ unsafe fn w_memoryview_cast_1d(mv_src: PyObjectRef, fmt: &str, itemsize: i64) ->
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(mv_src);
-        pyre_object::gc_roots::pin_root(w_str_new(fmt));
+        let _ = pyre_object::gc_roots::pin_root(mv_src);
+        let _ = pyre_object::gc_roots::pin_root(w_str_new(fmt));
         let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
         let r_src = pyre_object::gc_roots::shadow_stack_get(sp);
         let r_fmt = pyre_object::gc_roots::shadow_stack_get(sp + 1);
@@ -265,13 +265,13 @@ unsafe fn w_memoryview_cast_nd(
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(mv_src);
+        let _ = pyre_object::gc_roots::pin_root(mv_src);
         // Build each geometry object and pin it as produced: a later allocation
         // may relocate an earlier one, so the pinned shadow slot (re-read below)
         // is the source of truth, not the stale local.
-        pyre_object::gc_roots::pin_root(w_str_new(fmt));
-        pyre_object::gc_roots::pin_root(memoryview_wrap_dims(shape));
-        pyre_object::gc_roots::pin_root(memoryview_wrap_dims(strides));
+        let _ = pyre_object::gc_roots::pin_root(w_str_new(fmt));
+        let _ = pyre_object::gc_roots::pin_root(memoryview_wrap_dims(shape));
+        let _ = pyre_object::gc_roots::pin_root(memoryview_wrap_dims(strides));
         let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
         let r_src = pyre_object::gc_roots::shadow_stack_get(sp);
         let r_fmt = pyre_object::gc_roots::shadow_stack_get(sp + 1);
@@ -332,10 +332,10 @@ unsafe fn w_memoryview_new_plain(
             || crate::baseobjspace::isinstance_w(w_obj, array_ty);
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_obj);
+        let _ = pyre_object::gc_roots::pin_root(w_obj);
         // A Raw view keeps its explicit format object; a Simple view derives 'B'.
         if is_array {
-            pyre_object::gc_roots::pin_root(w_str_new(fmt));
+            let _ = pyre_object::gc_roots::pin_root(w_str_new(fmt));
         }
         // Root view over an exporter: it owns the backing's buffer export.
         let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
@@ -382,8 +382,8 @@ pub(crate) fn w_memoryview_new_simple_with_owner(
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_backing);
-        pyre_object::gc_roots::pin_root(w_obj);
+        let _ = pyre_object::gc_roots::pin_root(w_backing);
+        let _ = pyre_object::gc_roots::pin_root(w_obj);
         let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
         let r_backing = pyre_object::gc_roots::shadow_stack_get(sp);
         let r_obj = pyre_object::gc_roots::shadow_stack_get(sp + 1);
@@ -415,7 +415,7 @@ unsafe fn w_memoryview_new_mmap(
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_obj);
+        let _ = pyre_object::gc_roots::pin_root(w_obj);
         let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
         let r_obj = pyre_object::gc_roots::shadow_stack_get(sp);
         let view = BufferView::Simple {
@@ -552,9 +552,9 @@ unsafe fn w_memoryview_new_python_buffer(
         use pyre_object::memoryview::*;
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_obj);
-        pyre_object::gc_roots::pin_root(w_descr);
-        pyre_object::gc_roots::pin_root(w_int_new(flags as i64));
+        let _ = pyre_object::gc_roots::pin_root(w_obj);
+        let _ = pyre_object::gc_roots::pin_root(w_descr);
+        let _ = pyre_object::gc_roots::pin_root(w_int_new(flags as i64));
 
         let r_obj = pyre_object::gc_roots::shadow_stack_get(sp);
         let w_type = crate::typedef::r#type(r_obj).map_or(r_obj, |p| p.as_ptr());
@@ -569,7 +569,7 @@ unsafe fn w_memoryview_new_python_buffer(
                 "__buffer__ returned non-memoryview object",
             ));
         }
-        pyre_object::gc_roots::pin_root(w_ret);
+        let _ = pyre_object::gc_roots::pin_root(w_ret);
         let ret_slot = sp + 3;
         let r_ret = pyre_object::gc_roots::shadow_stack_get(ret_slot);
         memoryview_check_released(r_ret)?;
@@ -592,7 +592,7 @@ unsafe fn w_memoryview_new_python_buffer(
             pyre_object::gc_roots::shadow_stack_get(ret_slot),
             pyre_object::gc_roots::shadow_stack_get(sp),
         );
-        pyre_object::gc_roots::pin_root(wrapper);
+        let _ = pyre_object::gc_roots::pin_root(wrapper);
         let wrapper_slot = sp + 4;
         let outer = w_memoryview_alloc_header(false, true);
         let r_ret = pyre_object::gc_roots::shadow_stack_get(ret_slot);
@@ -679,9 +679,9 @@ fn w_memoryview_new_with_flags_impl(
             use pyre_object::bufferview::BufferView;
             let _roots = pyre_object::gc_roots::push_roots();
             let sp = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(w_obj);
-            pyre_object::gc_roots::pin_root(backing_obj);
-            pyre_object::gc_roots::pin_root(w_str_new(&fmt));
+            let _ = pyre_object::gc_roots::pin_root(w_obj);
+            let _ = pyre_object::gc_roots::pin_root(backing_obj);
+            let _ = pyre_object::gc_roots::pin_root(w_str_new(&fmt));
             let shape_i64 = shape.iter().map(|&dim| dim as i64).collect::<Vec<_>>();
             let mut strides = vec![0i64; shape.len()];
             let mut stride = itemsize as i64;
@@ -689,8 +689,8 @@ fn w_memoryview_new_with_flags_impl(
                 strides[i] = stride;
                 stride = stride.saturating_mul(dim);
             }
-            pyre_object::gc_roots::pin_root(memoryview_wrap_dims(&shape_i64));
-            pyre_object::gc_roots::pin_root(memoryview_wrap_dims(&strides));
+            let _ = pyre_object::gc_roots::pin_root(memoryview_wrap_dims(&shape_i64));
+            let _ = pyre_object::gc_roots::pin_root(memoryview_wrap_dims(&strides));
             let mv = w_memoryview_alloc_header(false, true);
             let r_obj = pyre_object::gc_roots::shadow_stack_get(sp);
             let r_backing = pyre_object::gc_roots::shadow_stack_get(sp + 1);
@@ -999,7 +999,7 @@ unsafe fn memoryview_slice_view(
         // path.  `Buffer::sub` never nests, so one parent peel is sufficient.
         backing_exports_incref(snapshot.backing());
         w_memoryview_set_view(sliced, bufferview_alloc(snapshot));
-        pyre_object::gc_roots::pin_root(sliced);
+        let _ = pyre_object::gc_roots::pin_root(sliced);
 
         let r_index = pyre_object::gc_roots::shadow_stack_get(sp + 1);
         let (start, stop, step) = crate::baseobjspace::normalize_slice(r_index, count)?;
@@ -1878,9 +1878,9 @@ unsafe fn memoryview_call_python_release_unraisable(
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(exporter);
-        pyre_object::gc_roots::pin_root(view);
-        pyre_object::gc_roots::pin_root(descr);
+        let _ = pyre_object::gc_roots::pin_root(exporter);
+        let _ = pyre_object::gc_roots::pin_root(view);
+        let _ = pyre_object::gc_roots::pin_root(descr);
         let r_exporter = pyre_object::gc_roots::shadow_stack_get(sp);
         let w_type = crate::typedef::r#type(r_exporter).map_or(r_exporter, |p| p.as_ptr());
         if let Err(mut error) = crate::baseobjspace::get_and_call_function(
@@ -1912,7 +1912,7 @@ unsafe fn w_memoryview_new_restricted_snapshot(source: PyObjectRef) -> PyObjectR
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(source);
+        let _ = pyre_object::gc_roots::pin_root(source);
         let restricted = pyre_object::memoryview::w_memoryview_alloc_header(false, false);
         let r_source = pyre_object::gc_roots::shadow_stack_get(sp);
         let snapshot = pyre_object::memoryview::w_memoryview_view(r_source).clone();
@@ -1935,12 +1935,12 @@ unsafe fn memoryview_release_native_python_slot(exporter: PyObjectRef, source: P
         };
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(exporter);
-        pyre_object::gc_roots::pin_root(source);
-        pyre_object::gc_roots::pin_root(descr);
+        let _ = pyre_object::gc_roots::pin_root(exporter);
+        let _ = pyre_object::gc_roots::pin_root(source);
+        let _ = pyre_object::gc_roots::pin_root(descr);
         let restricted =
             w_memoryview_new_restricted_snapshot(pyre_object::gc_roots::shadow_stack_get(sp + 1));
-        pyre_object::gc_roots::pin_root(restricted);
+        let _ = pyre_object::gc_roots::pin_root(restricted);
         memoryview_call_python_release_unraisable(
             pyre_object::gc_roots::shadow_stack_get(sp),
             pyre_object::gc_roots::shadow_stack_get(sp + 3),
@@ -1971,9 +1971,9 @@ unsafe fn memoryview_release_buffer_wrapper(wrapper: PyObjectRef) {
         }
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(wrapper);
-        pyre_object::gc_roots::pin_root(w_mv);
-        pyre_object::gc_roots::pin_root(w_obj);
+        let _ = pyre_object::gc_roots::pin_root(wrapper);
+        let _ = pyre_object::gc_roots::pin_root(w_mv);
+        let _ = pyre_object::gc_roots::pin_root(w_obj);
 
         let r_mv = pyre_object::gc_roots::shadow_stack_get(sp + 1);
         w_memoryview_exports_decref(r_mv);
@@ -2150,7 +2150,7 @@ fn memoryview_compare_eq(args: &[PyObjectRef], name: &str) -> Result<Option<bool
         } else {
             match w_memoryview_new(other) {
                 Ok(view) => {
-                    pyre_object::gc_roots::pin_root(view);
+                    let _ = pyre_object::gc_roots::pin_root(view);
                     (pyre_object::gc_roots::shadow_stack_get(base + 2), true)
                 }
                 // `PyObject_GetBuffer(..., PyBUF_FULL_RO)` failures are
@@ -2183,13 +2183,13 @@ fn memoryview_compare_eq(args: &[PyObjectRef], name: &str) -> Result<Option<bool
             for index in 0..count {
                 let _values = pyre_object::gc_roots::push_roots();
                 let values = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(memoryview_unpack_element(
+                let _ = pyre_object::gc_roots::pin_root(memoryview_unpack_element(
                     lhs_fmt,
                     &lhs_data,
                     index * lhs_size,
                     lhs_size,
                 ));
-                pyre_object::gc_roots::pin_root(memoryview_unpack_element(
+                let _ = pyre_object::gc_roots::pin_root(memoryview_unpack_element(
                     rhs_fmt,
                     &rhs_data,
                     index * rhs_size,
@@ -2468,11 +2468,11 @@ fn memoryview_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     let base = pyre_object::gc_roots::pin_roots(&[args[0], args[1]]);
     let iterator = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(base))?;
     let iterator_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(iterator);
+    let iterator = pyre_object::gc_roots::pin_root(iterator);
     // One reused slot for the element under test, so the loop does not grow the
     // shadow stack once per view element.
     let item_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_none());
+    let _ = pyre_object::gc_roots::pin_root(w_none());
     let mut count = 0i64;
     loop {
         let iterator = pyre_object::gc_roots::shadow_stack_get(iterator_slot);
@@ -2546,7 +2546,7 @@ fn memoryview_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::pin_roots(&[mv, args[1]]);
     let item_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_none());
+    let _ = pyre_object::gc_roots::pin_root(w_none());
     for index in start..stop {
         let item = memoryview_getitem(&[
             pyre_object::gc_roots::shadow_stack_get(base),
@@ -2578,7 +2578,7 @@ pub(crate) fn init_memoryview_type(ns: PyObjectRef) {
     // allocating insertions below.
     let _roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(ns);
+    let _ = pyre_object::gc_roots::pin_root(ns);
     // `__new__` is a `BuiltinFunction`-typed staticmethod descriptor like
     // every other native type's `tp_new` (typedef::make_new_descr), so it
     // does not bind the class and pickle's `isinstance(new, type(int.__new__))`
@@ -2630,9 +2630,9 @@ pub(crate) fn init_memoryview_type(ns: PyObjectRef) {
         "__class_getitem__",
         crate::_pypy_generic_alias::generic_alias_class_getitem,
     );
-    pyre_object::gc_roots::pin_root(class_getitem);
+    let class_getitem = pyre_object::gc_roots::pin_root(class_getitem);
     let from_flags = make_builtin_function_with_arity("_from_flags", memoryview_from_flags, 3);
-    pyre_object::gc_roots::pin_root(from_flags);
+    let from_flags = pyre_object::gc_roots::pin_root(from_flags);
     unsafe {
         crate::function::fset_func_text_signature(class_getitem, w_str_new("($type, object, /)"));
         crate::function::fset_func_text_signature(
@@ -3741,9 +3741,9 @@ pub fn new_builtin_module_dict() -> pyre_object::PyObjectRef {
     let w_dict = pyre_object::w_module_dict_new();
     let _roots = pyre_object::gc_roots::push_roots();
     let save_point = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_dict);
+    let w_dict = pyre_object::gc_roots::pin_root(w_dict);
     let name_obj = pyre_object::w_str_new("builtins");
-    pyre_object::gc_roots::pin_root(name_obj);
+    let _ = pyre_object::gc_roots::pin_root(name_obj);
     install_default_builtins(w_dict);
     let keys: Vec<String> = unsafe { pyre_object::w_dict_str_entries(w_dict) }
         .into_iter()
@@ -3904,8 +3904,8 @@ fn builtin_input(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
     let _roots = pyre_object::gc_roots::push_roots();
     let root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(sys);
-    pyre_object::gc_roots::pin_root(prompt);
+    let sys = pyre_object::gc_roots::pin_root(sys);
+    let _ = pyre_object::gc_roots::pin_root(prompt);
 
     // `bltinmodule.c builtin_input_impl`: an absent — or `None` — standard
     // stream is a `RuntimeError`, not an attribute error from the stream call.
@@ -3921,13 +3921,13 @@ fn builtin_input(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     };
 
     let stdin = stream("stdin")?;
-    pyre_object::gc_roots::pin_root(stdin);
+    let stdin = pyre_object::gc_roots::pin_root(stdin);
     let stdin_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let stdout = stream("stdout")?;
-    pyre_object::gc_roots::pin_root(stdout);
+    let _ = pyre_object::gc_roots::pin_root(stdout);
     let stdout_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let stderr = stream("stderr")?;
-    pyre_object::gc_roots::pin_root(stderr);
+    let _ = pyre_object::gc_roots::pin_root(stderr);
     let stderr_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     // app_io.py `stderr.flush()`.
@@ -3935,7 +3935,7 @@ fn builtin_input(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         pyre_object::gc_roots::shadow_stack_get(stderr_slot),
         "flush",
     )?;
-    pyre_object::gc_roots::pin_root(stderr_flush);
+    let _ = pyre_object::gc_roots::pin_root(stderr_flush);
     crate::call_and_check(
         pyre_object::gc_roots::shadow_stack_get(pyre_object::gc_roots::shadow_stack_len() - 1),
         &[],
@@ -3944,13 +3944,13 @@ fn builtin_input(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // app_io.py `_write_prompt`: `str(prompt)`, `stdout.write`, then an
     // optional `stdout.flush`.
     let prompt_text = builtin_str(&[pyre_object::gc_roots::shadow_stack_get(root + 1)])?;
-    pyre_object::gc_roots::pin_root(prompt_text);
+    let _ = pyre_object::gc_roots::pin_root(prompt_text);
     let prompt_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let stdout_write = crate::baseobjspace::getattr_str(
         pyre_object::gc_roots::shadow_stack_get(stdout_slot),
         "write",
     )?;
-    pyre_object::gc_roots::pin_root(stdout_write);
+    let _ = pyre_object::gc_roots::pin_root(stdout_write);
     let write_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     crate::call_and_check(
         pyre_object::gc_roots::shadow_stack_get(write_slot),
@@ -3961,7 +3961,7 @@ fn builtin_input(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         "flush",
     ) {
         Ok(flush) => {
-            pyre_object::gc_roots::pin_root(flush);
+            let _ = pyre_object::gc_roots::pin_root(flush);
             crate::call_and_check(
                 pyre_object::gc_roots::shadow_stack_get(
                     pyre_object::gc_roots::shadow_stack_len() - 1,
@@ -3978,7 +3978,7 @@ fn builtin_input(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         pyre_object::gc_roots::shadow_stack_get(stdin_slot),
         "readline",
     )?;
-    pyre_object::gc_roots::pin_root(readline);
+    let _ = pyre_object::gc_roots::pin_root(readline);
     let line = crate::call_and_check(
         pyre_object::gc_roots::shadow_stack_get(pyre_object::gc_roots::shadow_stack_len() - 1),
         &[],
@@ -4057,19 +4057,19 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let arg_roots = pyre_object::gc_roots::push_roots();
     let args_base = arg_roots.base();
     for &arg in positional {
-        arg_roots.pin_root(arg);
+        let _ = arg_roots.pin_root(arg);
     }
     let nargs = positional.len();
     // `base()` is the bracket's fixed save point, so the two slots that follow
     // the arguments are read off the live top instead.
     let sep = sep.map(|s| {
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        arg_roots.pin_root(s);
+        let _ = arg_roots.pin_root(s);
         slot
     });
     let end = end.map(|e| {
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        arg_roots.pin_root(e);
+        let _ = arg_roots.pin_root(e);
         slot
     });
 
@@ -4095,7 +4095,7 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let file_roots = pyre_object::gc_roots::push_roots();
     let file_slot = file.map(|fp| {
         let base = file_roots.base();
-        file_roots.pin_root(fp);
+        let _ = file_roots.pin_root(fp);
         base
     });
 
@@ -4119,7 +4119,7 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // `__getattr__`, re-entering the eval loop where the `PYRE_GC_INTERP`
         // safepoint may sweep an unrooted old-gen object. Pin it across the call.
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(s_obj);
+        let _ = pyre_object::gc_roots::pin_root(s_obj);
         let s_obj =
             pyre_object::gc_roots::shadow_stack_get(pyre_object::gc_roots::shadow_stack_len() - 1);
         // Read the sink only here: `py_str_wtf8` above ran `__str__`, and the
@@ -4146,7 +4146,7 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // lookup may re-enter the eval loop and reach the safepoint. See `emit`.
         let s = pyre_object::w_str_new_managed(lit);
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(s);
+        let _ = pyre_object::gc_roots::pin_root(s);
         let s =
             pyre_object::gc_roots::shadow_stack_get(pyre_object::gc_roots::shadow_stack_len() - 1);
         // Same as `emit`: the preceding write's own lookup may have moved the
@@ -4220,7 +4220,7 @@ fn displayhook_write(part: PyObjectRef) -> Result<bool, crate::PyError> {
     // surviving one — so read it back from the rooted slot at the point of use.
     let roots = pyre_object::gc_roots::push_roots();
     let part_slot = roots.base();
-    roots.pin_root(part);
+    let _ = roots.pin_root(part);
     match resolve_default_print_target()? {
         DefaultPrintTarget::Native => {
             let s = unsafe { print_render(roots.get(part_slot))? };
@@ -4355,22 +4355,22 @@ pub(crate) fn builtin_range(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
         let mut w_start = range_index_bound(args[0])?;
-        pyre_object::gc_roots::pin_root(w_start);
+        let mut w_start = pyre_object::gc_roots::pin_root(w_start);
         let w_stop;
         let w_step;
         if n == 1 {
             // Only `stop` given — `w_start, w_stop = 0, w_start`.
             w_stop = w_start;
             w_start = w_int_new(0);
-            pyre_object::gc_roots::pin_root(w_start);
+            let _ = pyre_object::gc_roots::pin_root(w_start);
             w_step = w_int_new(1);
-            pyre_object::gc_roots::pin_root(w_step);
+            let w_step = pyre_object::gc_roots::pin_root(w_step);
         } else {
             w_stop = range_index_bound(args[1])?;
-            pyre_object::gc_roots::pin_root(w_stop);
+            let _ = pyre_object::gc_roots::pin_root(w_stop);
             if n == 3 {
                 w_step = range_index_bound(args[2])?;
-                pyre_object::gc_roots::pin_root(w_step);
+                let w_step = pyre_object::gc_roots::pin_root(w_step);
                 let step_is_zero = match pyre_object::range_obj_as_i64(w_step) {
                     Some(step) => step == 0,
                     None => pyre_object::range_obj_to_bigint(w_step) == BigInt::from(0),
@@ -4382,7 +4382,7 @@ pub(crate) fn builtin_range(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
                 }
             } else {
                 w_step = w_int_new(1);
-                pyre_object::gc_roots::pin_root(w_step);
+                let _ = pyre_object::gc_roots::pin_root(w_step);
             }
         }
         Ok(pyre_object::w_range_new(w_start, w_stop, w_step))
@@ -5299,7 +5299,7 @@ fn min_max_sequence(
     let default_slot = sequence_slot + 2;
     let it = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(sequence_slot))?;
     let iterator_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(it);
+    let _ = pyre_object::gc_roots::pin_root(it);
     // Dict-view iterators are off-GC carriers, so retain their source dict
     // explicitly while the iterator is rooted by this native loop.
     if unsafe {
@@ -5312,22 +5312,22 @@ fn min_max_sequence(
                 pyre_object::gc_roots::shadow_stack_get(iterator_slot),
             )
         };
-        pyre_object::gc_roots::pin_root(w_dict);
+        let _ = pyre_object::gc_roots::pin_root(w_dict);
     }
     let best_item_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(default_slot));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(default_slot));
     let best_key_slot = if key_fn_slot.is_some() {
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(pyre_object::w_none());
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_none());
         slot
     } else {
         best_item_slot
     };
     let candidate_item_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::w_none());
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_none());
     let candidate_key_slot = if key_fn_slot.is_some() {
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(pyre_object::w_none());
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_none());
         slot
     } else {
         candidate_item_slot
@@ -5402,11 +5402,11 @@ fn min_max_multiple_args(
     let _roots = pyre_object::gc_roots::push_roots();
     let item_base = pyre_object::gc_roots::shadow_stack_len();
     for &item in positional {
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
     }
     let key_fn_slot = key_fn.map(|key| {
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(key);
+        let _ = pyre_object::gc_roots::pin_root(key);
         slot
     });
     let cmp_op = if want_max {
@@ -5415,10 +5415,10 @@ fn min_max_multiple_args(
         crate::baseobjspace::CompareOp::Lt
     };
     let best_item_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(item_base));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(item_base));
     let best_key_slot = if let Some(key_fn_slot) = key_fn_slot {
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(pyre_object::w_none());
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_none());
         let first_key = crate::call::call_function_impl_result(
             pyre_object::gc_roots::shadow_stack_get(key_fn_slot),
             &[pyre_object::gc_roots::shadow_stack_get(best_item_slot)],
@@ -5429,10 +5429,12 @@ fn min_max_multiple_args(
         best_item_slot
     };
     let candidate_item_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(best_item_slot));
+    let _ =
+        pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(best_item_slot));
     let candidate_key_slot = if key_fn_slot.is_some() {
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(best_key_slot));
+        let _ =
+            pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(best_key_slot));
         slot
     } else {
         candidate_item_slot
@@ -5570,15 +5572,14 @@ pub(crate) fn check_surrogate(w_name: PyObjectRef) -> Result<(), crate::PyError>
 pub(crate) fn type_new_wrap_special_methods(ns: PyObjectRef) {
     let _ns_root = pyre_object::gc_roots::push_roots();
     let ns_root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(ns);
-    let ns = pyre_object::gc_roots::shadow_stack_get(ns_root);
+    let ns = pyre_object::gc_roots::pin_root(ns);
     if let Some(f) = unsafe { pyre_object::w_dict_getitem_str(ns, "__new__") }
         && unsafe { crate::function::is_function(f) }
         && !unsafe { pyre_object::function::is_staticmethod(f) }
     {
         let wrapped = pyre_object::function::w_staticmethod_new(f);
         let wrapped_root = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(wrapped);
+        let _ = pyre_object::gc_roots::pin_root(wrapped);
         let ns = pyre_object::gc_roots::shadow_stack_get(ns_root);
         let wrapped = pyre_object::gc_roots::shadow_stack_get(wrapped_root);
         unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, "__new__", wrapped) };
@@ -5591,7 +5592,7 @@ pub(crate) fn type_new_wrap_special_methods(ns: PyObjectRef) {
         {
             let wrapped = pyre_object::function::w_classmethod_new(f);
             let wrapped_root = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(wrapped);
+            let _ = pyre_object::gc_roots::pin_root(wrapped);
             let ns = pyre_object::gc_roots::shadow_stack_get(ns_root);
             let wrapped = pyre_object::gc_roots::shadow_stack_get(wrapped_root);
             unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, name, wrapped) };
@@ -5603,8 +5604,7 @@ pub(crate) fn type_new_wrap_special_methods(ns: PyObjectRef) {
 pub(crate) fn type_new_set_hash_if_eq(ns: PyObjectRef) {
     let _ns_root = pyre_object::gc_roots::push_roots();
     let ns_root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(ns);
-    let ns = pyre_object::gc_roots::shadow_stack_get(ns_root);
+    let ns = pyre_object::gc_roots::pin_root(ns);
     if unsafe { pyre_object::w_dict_getitem_str(ns, "__eq__") }.is_some()
         && unsafe { pyre_object::w_dict_getitem_str(ns, "__hash__") }.is_none()
     {
@@ -5623,7 +5623,7 @@ pub(crate) fn type_new_set_doc(ns: PyObjectRef) -> crate::PyResult {
     // parameter, so the word is pinned here and read back at every use.
     let _roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(ns);
+    let _ = pyre_object::gc_roots::pin_root(ns);
     if unsafe {
         pyre_object::w_dict_getitem_str(pyre_object::gc_roots::shadow_stack_get(ns_slot), "__doc__")
     }
@@ -5659,7 +5659,7 @@ pub(crate) fn type_new_take_qualname(w_type: PyObjectRef, ns: PyObjectRef) -> cr
     // string value do not move, and the dict holds the value until the delete.
     let _roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(ns);
+    let _ = pyre_object::gc_roots::pin_root(ns);
     let Some(value) = (unsafe {
         pyre_object::w_dict_getitem_str(
             pyre_object::gc_roots::shadow_stack_get(ns_slot),
@@ -5807,10 +5807,10 @@ fn type_descr_new_with_metaclass(
         // still walks correctly.
         let _class_ns_root = pyre_object::gc_roots::push_roots();
         let namespace_root = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_namespace_dict);
+        let _ = pyre_object::gc_roots::pin_root(w_namespace_dict);
         let class_ns = pyre_object::w_dict_new();
         let class_ns_root = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(class_ns);
+        let class_ns = pyre_object::gc_roots::pin_root(class_ns);
         // type_new_classcell — capture the `__classcell__` cell and keep
         // both explicit class cells out of the new type's `__dict__`
         // (CPython consumes them here rather than storing them).
@@ -5823,12 +5823,12 @@ fn type_descr_new_with_metaclass(
         let w_namespace_dict = pyre_object::gc_roots::shadow_stack_get(namespace_root);
         if !w_ns_backing.is_null() {
             let backing_root = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(w_ns_backing);
+            let w_ns_backing = pyre_object::gc_roots::pin_root(w_ns_backing);
             let items = unsafe { pyre_object::w_dict_items(w_ns_backing) };
             let item_root = pyre_object::gc_roots::shadow_stack_len();
             for &(key, value) in &items {
-                pyre_object::gc_roots::pin_root(key);
-                pyre_object::gc_roots::pin_root(value);
+                let _ = pyre_object::gc_roots::pin_root(key);
+                let _ = pyre_object::gc_roots::pin_root(value);
             }
             let mut has_non_string_key = false;
             for index in 0..items.len() {
@@ -5856,7 +5856,7 @@ fn type_descr_new_with_metaclass(
                         )));
                     }
                     let root = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(value);
+                    let _ = pyre_object::gc_roots::pin_root(value);
                     classcell_root = Some(root);
                     continue;
                 }
@@ -5866,7 +5866,7 @@ fn type_descr_new_with_metaclass(
                 {
                     if unsafe { pyre_object::is_cell(value) } {
                         let root = pyre_object::gc_roots::shadow_stack_len();
-                        pyre_object::gc_roots::pin_root(value);
+                        let _ = pyre_object::gc_roots::pin_root(value);
                         classdictcell_root = Some(root);
                     }
                     continue;
@@ -5950,7 +5950,7 @@ fn type_descr_new_with_metaclass(
             } else {
                 bases
             };
-        pyre_object::gc_roots::pin_root(w_effective_bases);
+        let w_effective_bases = pyre_object::gc_roots::pin_root(w_effective_bases);
         // calculate_metaclass — delegate to winner if different
         let default_meta = if w_metaclass.is_null() {
             crate::typedef::w_type()
@@ -6017,8 +6017,7 @@ fn type_descr_new_with_metaclass(
         // side-effecting `__hash__` an extra time (and dropping any error it
         // raised, since the store cannot propagate one).
         let dict_obj = unsafe { pyre_object::w_dict_copy(class_ns) };
-        pyre_object::gc_roots::pin_root(dict_obj);
-        let dict_obj = pyre_object::gc_roots::shadow_stack_get(dict_root);
+        let dict_obj = pyre_object::gc_roots::pin_root(dict_obj);
         let w_type = pyre_object::w_type_new(name, w_effective_bases, dict_obj as *mut u8);
         // The type allocation may have moved the namespace, so the qualname
         // pass receives the forwarded address rather than the word above.
@@ -6229,11 +6228,11 @@ macro_rules! exc_constructor {
             let _roots = pyre_object::gc_roots::push_roots();
             let args_base = pyre_object::gc_roots::shadow_stack_len();
             for &arg in args {
-                pyre_object::gc_roots::pin_root(arg);
+                let _ = pyre_object::gc_roots::pin_root(arg);
             }
             let exc = pyre_object::interp_exceptions::w_exception_new_empty($kind);
             let exc_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(exc);
+            let _ = pyre_object::gc_roots::pin_root(exc);
             // The allocation above may collect and move the arguments without
             // updating the raw slice, so rebuild them from their rooted slots.
             let mut rooted_args = Vec::with_capacity(args.len());
@@ -6604,7 +6603,7 @@ fn os_error_build(
     // is pinned over the tuple mint: it holds no heap edge yet, and building
     // a tuple instantiates the type's lazy map.  An instance is old-gen, so
     // the pin is for liveness and the value is used as it is.
-    pyre_object::gc_roots::pin_root(exc);
+    let exc = pyre_object::gc_roots::pin_root(exc);
     let args_list =
         pyre_object::interp_exceptions::w_exception_args_new((0..args.len()).map(arg).collect());
     unsafe { interp_exceptions::w_exception_set_args(exc, args_list) };
@@ -6778,7 +6777,7 @@ fn os_error_fill_slots(exc: PyObjectRef, args: &[PyObjectRef]) {
     // stack rather than out of the caller's slice once either has run.
     let _roots = pyre_object::gc_roots::push_roots();
     let args_base = pyre_object::gc_roots::pin_roots(args);
-    pyre_object::gc_roots::pin_root(exc);
+    let exc = pyre_object::gc_roots::pin_root(exc);
     let arg = |index: usize| pyre_object::gc_roots::shadow_stack_get(args_base + index);
     let arg_opt = |index: usize| (index < args.len()).then(|| arg(index));
     // `_parse_init_args`: only a 2..=5 argument call carries errno/strerror
@@ -7275,7 +7274,7 @@ fn attribute_error_getstate_value(w_self: PyObjectRef) -> PyObjectRef {
     } else {
         unsafe { pyre_object::w_dict_copy(stored) }
     };
-    pyre_object::gc_roots::pin_root(state);
+    let _ = pyre_object::gc_roots::pin_root(state);
     let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_name = unsafe {
         interp_exceptions::w_exception_get_name(pyre_object::gc_roots::shadow_stack_get(base))
@@ -7283,7 +7282,7 @@ fn attribute_error_getstate_value(w_self: PyObjectRef) -> PyObjectRef {
     if !w_name.is_null() {
         // Mirrors the `args` twin below: both operands reach the dictionary
         // from a root slot rather than from a raw read of the typed field.
-        pyre_object::gc_roots::pin_root(w_name);
+        let _ = pyre_object::gc_roots::pin_root(w_name);
         let name_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         unsafe {
             pyre_object::w_dict_setitem_str(
@@ -7296,7 +7295,7 @@ fn attribute_error_getstate_value(w_self: PyObjectRef) -> PyObjectRef {
     let w_args = unsafe {
         interp_exceptions::w_exception_get_args(pyre_object::gc_roots::shadow_stack_get(base))
     };
-    pyre_object::gc_roots::pin_root(w_args);
+    let _ = pyre_object::gc_roots::pin_root(w_args);
     let args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     unsafe {
         pyre_object::w_dict_setitem_str(
@@ -7328,17 +7327,17 @@ fn attribute_error_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         .unwrap_or_else(|| {
             crate::baseobjspace::exception_getclass(pyre_object::gc_roots::shadow_stack_get(base))
         });
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_args = unsafe {
         pyre_object::interp_exceptions::w_exception_get_args(
             pyre_object::gc_roots::shadow_stack_get(base),
         )
     };
-    pyre_object::gc_roots::pin_root(w_args);
+    let _ = pyre_object::gc_roots::pin_root(w_args);
     let args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let state = attribute_error_getstate_value(pyre_object::gc_roots::shadow_stack_get(base));
-    pyre_object::gc_roots::pin_root(state);
+    let _ = pyre_object::gc_roots::pin_root(state);
     let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     Ok(pyre_object::w_tuple_new(vec![
         pyre_object::gc_roots::shadow_stack_get(cls_slot),
@@ -7382,7 +7381,7 @@ fn import_error_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     } else {
         pyre_object::w_dict_new()
     };
-    pyre_object::gc_roots::pin_root(w_dict);
+    let _ = pyre_object::gc_roots::pin_root(w_dict);
     let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     type ExcGetter = unsafe fn(PyObjectRef) -> PyObjectRef;
     for (key, get) in [
@@ -7646,7 +7645,7 @@ fn os_error_family_new(
     let _roots = pyre_object::gc_roots::push_roots();
     let positional_base = pyre_object::gc_roots::pin_roots(positional);
     let exc = ctor(if use_init { &[] } else { positional })?;
-    pyre_object::gc_roots::pin_root(exc);
+    let exc = pyre_object::gc_roots::pin_root(exc);
     let positional: Vec<PyObjectRef> = (0..positional.len())
         .map(|index| pyre_object::gc_roots::shadow_stack_get(positional_base + index))
         .collect();
@@ -8065,7 +8064,7 @@ fn base_exception_str_method(args: &[PyObjectRef]) -> crate::PyResult {
             unsafe { pyre_object::w_tuple_getitem(stored, 0) }
         }
         .unwrap_or(pyre_object::PY_NULL);
-        pyre_object::gc_roots::pin_root(first);
+        let _ = pyre_object::gc_roots::pin_root(first);
         let first_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         return builtin_str(&[pyre_object::gc_roots::shadow_stack_get(first_slot)]);
     }
@@ -8074,7 +8073,7 @@ fn base_exception_str_method(args: &[PyObjectRef]) -> crate::PyResult {
             pyre_object::gc_roots::shadow_stack_get(obj_slot),
         )
     };
-    pyre_object::gc_roots::pin_root(tuple);
+    let _ = pyre_object::gc_roots::pin_root(tuple);
     let tuple_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     builtin_str(&[pyre_object::gc_roots::shadow_stack_get(tuple_slot)])
 }
@@ -8227,7 +8226,7 @@ pub(crate) fn exception_getset_fget_obj() -> PyObjectRef {
 /// store because nothing references it yet.
 fn type_ns_store(ns_slot: usize, key: &str, value: PyObjectRef) {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(value);
+    let value = pyre_object::gc_roots::pin_root(value);
     unsafe {
         pyre_object::w_dict_setitem_str_no_proxy(
             pyre_object::gc_roots::shadow_stack_get(ns_slot),
@@ -8241,7 +8240,7 @@ fn type_ns_store(ns_slot: usize, key: &str, value: PyObjectRef) {
 fn install_exception_getsets(ns: PyObjectRef, class_name: &str) {
     let _roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(ns);
+    let _ = pyre_object::gc_roots::pin_root(ns);
     let (fget, fset, fdel) = exception_getset_ends();
     for attr in exception_typedef_attrs(class_name) {
         type_ns_store(
@@ -8303,7 +8302,7 @@ pub(crate) fn make_exc_type_with_init(
             // the run of allocating insertions below.
             let _roots = pyre_object::gc_roots::push_roots();
             let ns_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(ns);
+            let _ = pyre_object::gc_roots::pin_root(ns);
             if let Some(doc) = doc {
                 type_ns_store(ns_slot, "__doc__", pyre_object::w_str_new(doc));
             }
@@ -8706,9 +8705,9 @@ pub(crate) fn make_exc_type_with_init(
                                     ));
                                 }
                                 None => {
-                                    pyre_object::gc_roots::pin_root(pyre_object::w_list_new(
-                                        Vec::new(),
-                                    ));
+                                    let _ = pyre_object::gc_roots::pin_root(
+                                        pyre_object::w_list_new(Vec::new()),
+                                    );
                                     crate::baseobjspace::setattr_str(
                                         w_self,
                                         "__notes__",
@@ -8872,7 +8871,7 @@ pub(crate) fn make_exc_type_multi(
         move |ns| {
             let _roots = pyre_object::gc_roots::push_roots();
             let ns_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(ns);
+            let _ = pyre_object::gc_roots::pin_root(ns);
             type_ns_store(ns_slot, "__new__", crate::typedef::make_new_descr(new_fn));
         },
         bases,
@@ -8948,7 +8947,7 @@ fn exception_group_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
         let rendered = pyre_object::w_str_from_wtf8(unsafe {
             crate::display::py_repr_wtf8(pyre_object::gc_roots::shadow_stack_get(base + 2))?
         });
-        pyre_object::gc_roots::pin_root(rendered);
+        let _ = pyre_object::gc_roots::pin_root(rendered);
         Some(pyre_object::gc_roots::shadow_stack_len() - 1)
     };
     let exceptions =
@@ -8997,12 +8996,12 @@ fn exception_group_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     };
     // `cls` may have been retargeted to `ExceptionGroup` above; publish
     // whichever class the instance is about to be tagged with.
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // Each allocation below is a safepoint, so the nascent group and the tuple
     // it stores both go on the shadow stack before the next one runs.
     let exc = pyre_object::interp_exceptions::w_exception_new_empty(kind);
-    pyre_object::gc_roots::pin_root(exc);
+    let _ = pyre_object::gc_roots::pin_root(exc);
     let exc_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     crate::typedef::tag_subclass_instance(
         pyre_object::gc_roots::shadow_stack_get(exc_slot),
@@ -9010,7 +9009,7 @@ fn exception_group_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     );
     unsafe {
         let tuple = pyre_object::w_tuple_new(exceptions);
-        pyre_object::gc_roots::pin_root(tuple);
+        let _ = pyre_object::gc_roots::pin_root(tuple);
         let tuple_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         // `interp_group.py:19-20` — the two attrproperty slots, plus the
         // constructor-time sequence repr.  None of these writes allocates, so
@@ -9497,7 +9496,7 @@ fn make_exception_group_type(
         move |ns| {
             let _roots = pyre_object::gc_roots::push_roots();
             let ns_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(ns);
+            let _ = pyre_object::gc_roots::pin_root(ns);
             if let Some(doc) = doc {
                 type_ns_store(ns_slot, "__doc__", pyre_object::w_str_new(doc));
             }
@@ -10689,7 +10688,7 @@ fn builtin_getattr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         // is the one the tracer folds.
         let default_root = pyre_object::gc_roots::push_roots();
         let default_base = default_root.base();
-        default_root.pin_root(args[2]);
+        let _ = default_root.pin_root(args[2]);
         return match crate::baseobjspace::lookup_attr(obj, args[1]) {
             Ok(val) => Ok(val),
             Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
@@ -10790,9 +10789,9 @@ pub(crate) fn builtin_list_ctor(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
     // and result rooted across that allocation and the iterator callbacks.
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args[0]);
+    let _ = pyre_object::gc_roots::pin_root(args[0]);
     let list = w_list_new(vec![]);
-    pyre_object::gc_roots::pin_root(list);
+    let _ = pyre_object::gc_roots::pin_root(list);
     crate::type_methods::list_method_extend(&[
         pyre_object::gc_roots::shadow_stack_get(root_base + 1),
         pyre_object::gc_roots::shadow_stack_get(root_base),
@@ -10836,7 +10835,7 @@ pub fn collect_iterable(obj: PyObjectRef) -> Result<Vec<PyObjectRef>, crate::PyE
     // RPython's shadowstack transform emits around `space.iter`.
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let it = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(obj_slot))?;
     collect_iterator(it)
 }
@@ -10851,7 +10850,7 @@ pub(crate) fn sequence_fast(
 ) -> Result<Vec<PyObjectRef>, crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let it = match crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(obj_slot)) {
         Ok(it) => it,
         Err(e) if e.kind == crate::PyErrorKind::TypeError => {
@@ -10878,7 +10877,7 @@ pub(crate) fn collect_iterator(it: PyObjectRef) -> Result<Vec<PyObjectRef>, crat
     // translator's shadowstack save/restore around a collecting call
     // (framework.py:853-856).
     let base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(it);
+    let _ = pyre_object::gc_roots::pin_root(it);
     // `pin_root` itself queries the collector, so read the iterator back from
     // its slot instead of reusing the caller's copy: a foreign collection that
     // ran inside the pin forwarded the object and rewrote the slot, not the
@@ -10890,7 +10889,7 @@ pub(crate) fn collect_iterator(it: PyObjectRef) -> Result<Vec<PyObjectRef>, crat
     // source dict explicitly for the duration of the native loop.
     if unsafe { pyre_object::dictmultiobject::is_dict_view_iterator(it) } {
         let w_dict = unsafe { pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(it) };
-        pyre_object::gc_roots::pin_root(w_dict);
+        let _ = pyre_object::gc_roots::pin_root(w_dict);
     }
     let item_base = pyre_object::gc_roots::shadow_stack_len();
     let mut count = 0usize;
@@ -10900,7 +10899,7 @@ pub(crate) fn collect_iterator(it: PyObjectRef) -> Result<Vec<PyObjectRef>, crat
         let it_now = pyre_object::gc_roots::shadow_stack_get(base);
         match crate::baseobjspace::next(it_now) {
             Ok(v) => {
-                pyre_object::gc_roots::pin_root(v);
+                let _ = pyre_object::gc_roots::pin_root(v);
                 count += 1;
             }
             Err(e) if e.matches_stop_iteration() => break,
@@ -10963,10 +10962,10 @@ fn builtin_set_add_items_impl(
         // matching `set_update_value`.
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(set);
+        let set = pyre_object::gc_roots::pin_root(set);
         let item_base = sp + 1;
         for &item in items {
-            pyre_object::gc_roots::pin_root(item);
+            let _ = pyre_object::gc_roots::pin_root(item);
         }
         let item_len = pyre_object::gc_roots::shadow_stack_len() - item_base;
         for i in 0..item_len {
@@ -11245,7 +11244,7 @@ fn builtin_next(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // one-argument form free of the slot.
         let default_root = pyre_object::gc_roots::push_roots();
         let default_base = default_root.base();
-        default_root.pin_root(args[1]);
+        let _ = default_root.pin_root(args[1]);
         return match crate::baseobjspace::next(args[0]) {
             Ok(v) => Ok(v),
             Err(e) if e.matches_stop_iteration() => Ok(default_root.get(default_base)),
@@ -13276,7 +13275,7 @@ fn exec_or_eval(
             pyre_object::PY_NULL,
             closure,
         );
-        pyre_object::gc_roots::pin_root(f);
+        let f = pyre_object::gc_roots::pin_root(f);
         Some(f)
     } else {
         None
@@ -13317,7 +13316,7 @@ fn exec_or_eval(
         // yet, so expose it as a temporary GC root while selecting and storing
         // its builtin Module.
         let _frame_roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(frame.as_mut_ptr() as pyre_object::PyObjectRef);
+        let _ = pyre_object::gc_roots::pin_root(frame.as_mut_ptr() as pyre_object::PyObjectRef);
         let current_globals = frame.get_w_globals();
         frame.w_builtin = crate::baseobjspace::pick_builtin_obj_checked(current_globals, exec_ctx)?;
     }
@@ -13615,7 +13614,7 @@ fn dir_names_from_locals_mapping(
 pub extern "C" fn jit_dir_names_from_locals(mapping: i64) -> i64 {
     let _roots = pyre_object::gc_roots::push_roots();
     let mapping_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(mapping as PyObjectRef);
+    let _ = pyre_object::gc_roots::pin_root(mapping as PyObjectRef);
     let mapping = pyre_object::gc_roots::shadow_stack_get(mapping_slot);
     match dir_names_from_locals_mapping(mapping) {
         Ok(names) => names as i64,
@@ -13950,7 +13949,7 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
             // pin it on the shadow stack.
             let _roots = pyre_object::gc_roots::push_roots();
             let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let n = w_tuple_len(pyre_object::gc_roots::shadow_stack_get(obj_slot));
             let mut hashes = Vec::with_capacity(n);
             for i in 0..(n as i64) {
@@ -13981,7 +13980,7 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
             // afterward, so pin it across the first hash.
             let _roots = pyre_object::gc_roots::push_roots();
             let args_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(args);
+            let _ = pyre_object::gc_roots::pin_root(args);
             let origin_hash = try_hash_value(origin)?;
             let args_hash = try_hash_value(pyre_object::gc_roots::shadow_stack_get(args_slot))?;
             return Ok(origin_hash ^ args_hash);
@@ -14042,7 +14041,7 @@ fn slice_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
     for &part in parts.iter() {
-        pyre_object::gc_roots::pin_root(part);
+        let _ = pyre_object::gc_roots::pin_root(part);
     }
     let mut acc = PRIME5;
     for j in 0..parts.len() {
@@ -14596,9 +14595,9 @@ pub(crate) fn builtin_filter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
         )));
     }
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(args[0]);
+    let _ = pyre_object::gc_roots::pin_root(args[0]);
     let predicate_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(args[1]);
+    let _ = pyre_object::gc_roots::pin_root(args[1]);
     let iterable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let func = unsafe { pyre_object::gc_roots::shadow_stack_get(predicate_slot) };
     // `functional.py:921-924` — a None predicate is stored as PY_NULL.
@@ -14611,7 +14610,7 @@ pub(crate) fn builtin_filter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
     let w_iterable = crate::baseobjspace::iter(unsafe {
         pyre_object::gc_roots::shadow_stack_get(iterable_slot)
     })?;
-    pyre_object::gc_roots::pin_root(w_iterable);
+    let _ = pyre_object::gc_roots::pin_root(w_iterable);
     let iterator_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     Ok(pyre_object::functional::w_filter_new(
         if w_predicate.is_null() {
@@ -14640,11 +14639,11 @@ pub(crate) fn builtin_map(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     let _roots = pyre_object::gc_roots::push_roots();
     let args_base = pyre_object::gc_roots::shadow_stack_len();
     for &arg in args {
-        pyre_object::gc_roots::pin_root(arg);
+        let _ = pyre_object::gc_roots::pin_root(arg);
     }
     let w_strict = kwarg_get(kwargs, "strict");
     let strict_slot = w_strict.map(|value| {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
         pyre_object::gc_roots::shadow_stack_len() - 1
     });
     let strict = strict_slot
@@ -14660,7 +14659,7 @@ pub(crate) fn builtin_map(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         let w_iter = crate::baseobjspace::iter(unsafe {
             pyre_object::gc_roots::shadow_stack_get(args_base + index)
         })?;
-        pyre_object::gc_roots::pin_root(w_iter);
+        let _ = pyre_object::gc_roots::pin_root(w_iter);
         iter_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
     }
     let w_iterators = pyre_object::w_list_new(
@@ -14669,7 +14668,7 @@ pub(crate) fn builtin_map(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             .map(|slot| unsafe { pyre_object::gc_roots::shadow_stack_get(slot) })
             .collect(),
     );
-    pyre_object::gc_roots::pin_root(w_iterators);
+    let _ = pyre_object::gc_roots::pin_root(w_iterators);
     let iterators_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     Ok(pyre_object::functional::w_map_new(
         unsafe { pyre_object::gc_roots::shadow_stack_get(args_base) },
@@ -14694,10 +14693,10 @@ pub(crate) fn builtin_zip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     let _roots = pyre_object::gc_roots::push_roots();
     let args_base = pyre_object::gc_roots::shadow_stack_len();
     for &arg in args {
-        pyre_object::gc_roots::pin_root(arg);
+        let _ = pyre_object::gc_roots::pin_root(arg);
     }
     let strict_slot = kwarg_get(kwargs, "strict").map(|value| {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
         pyre_object::gc_roots::shadow_stack_len() - 1
     });
     let strict = strict_slot
@@ -14712,7 +14711,7 @@ pub(crate) fn builtin_zip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         let w_iter = crate::baseobjspace::iter(unsafe {
             pyre_object::gc_roots::shadow_stack_get(args_base + index)
         })?;
-        pyre_object::gc_roots::pin_root(w_iter);
+        let _ = pyre_object::gc_roots::pin_root(w_iter);
         iter_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
     }
     let w_iterators = pyre_object::w_list_new(
@@ -14721,7 +14720,7 @@ pub(crate) fn builtin_zip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             .map(|slot| unsafe { pyre_object::gc_roots::shadow_stack_get(slot) })
             .collect(),
     );
-    pyre_object::gc_roots::pin_root(w_iterators);
+    let _ = pyre_object::gc_roots::pin_root(w_iterators);
     let iterators_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     Ok(pyre_object::functional::w_zip_new(
         unsafe { pyre_object::gc_roots::shadow_stack_get(iterators_slot) },
@@ -14782,10 +14781,10 @@ pub(crate) fn builtin_enumerate(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
     // arguments in the shadow stack exactly as the translated RPython locals
     // remain GC-visible across `space.index` / `space.iter`.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(source);
+    let _ = pyre_object::gc_roots::pin_root(source);
     let source_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let raw_start = start_obj.unwrap_or(pyre_object::PY_NULL);
-    pyre_object::gc_roots::pin_root(raw_start);
+    let raw_start = pyre_object::gc_roots::pin_root(raw_start);
     let raw_start_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     // `functional.py descr___new__` — `space.index(w_start)` then
@@ -14798,7 +14797,7 @@ pub(crate) fn builtin_enumerate(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
         let indexed = crate::baseobjspace::space_index(unsafe {
             pyre_object::gc_roots::shadow_stack_get(raw_start_slot)
         })?;
-        pyre_object::gc_roots::pin_root(indexed);
+        let indexed = pyre_object::gc_roots::pin_root(indexed);
         let indexed_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         match crate::baseobjspace::int_w(indexed) {
             Ok(value) => (value, pyre_object::PY_NULL),
@@ -14808,7 +14807,7 @@ pub(crate) fn builtin_enumerate(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
             Err(e) => return Err(e),
         }
     };
-    pyre_object::gc_roots::pin_root(w_start);
+    let w_start = pyre_object::gc_roots::pin_root(w_start);
     let w_start_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // `functional.py:268-271` — `if start == 0 and type(w_iterable) is
     // W_ListObject: w_iter = w_iterable` (skip space.iter for the
@@ -14846,7 +14845,7 @@ pub(crate) fn builtin_reversed(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     // iterator. The translated RPython argument remains a GC root throughout;
     // keep the Rust carrier in the shadow stack and reload at each call site.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(args[0]);
+    let _ = pyre_object::gc_roots::pin_root(args[0]);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let obj = unsafe { pyre_object::gc_roots::shadow_stack_get(obj_slot) };
     unsafe {
@@ -14912,7 +14911,7 @@ pub(crate) fn builtin_reversed(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
                 crate::baseobjspace::object_functionstr_type_name(obj)
             )));
         }
-        pyre_object::gc_roots::pin_root(method);
+        let _ = pyre_object::gc_roots::pin_root(method);
         let method_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         // Propagate a raised error from `__reversed__` instead of handing
         // back a null result.
@@ -14996,7 +14995,7 @@ pub(crate) fn builtin_sorted(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
     // `list.sort` uses.
     let w_list = builtin_list_ctor(&[pyre_object::gc_roots::shadow_stack_get(base)])?;
     let list_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_list);
+    let _ = pyre_object::gc_roots::pin_root(w_list);
     let key_fn = key_fn.map(|_| pyre_object::gc_roots::shadow_stack_get(base + 1));
     sort_list_in_place(list_slot, key_fn, reverse)?;
     Ok(pyre_object::gc_roots::shadow_stack_get(list_slot))
@@ -15041,7 +15040,7 @@ pub(crate) fn sort_list_in_place(
         let _roots = pyre_object::gc_roots::push_roots();
         let item_base = pyre_object::gc_roots::shadow_stack_len();
         for item in saved {
-            pyre_object::gc_roots::pin_root(item);
+            let _ = pyre_object::gc_roots::pin_root(item);
         }
         let saved_len = pyre_object::gc_roots::shadow_stack_len() - item_base;
         pyre_object::listobject::w_list_clear(list);
@@ -15129,7 +15128,7 @@ pub(crate) fn sort_rooted_items(
     let _key_roots = pyre_object::gc_roots::push_roots();
     let key_base = pyre_object::gc_roots::shadow_stack_len();
     let key_fn_slot = key_fn.map(|key| {
-        pyre_object::gc_roots::pin_root(key);
+        let _ = pyre_object::gc_roots::pin_root(key);
         key_base
     });
     let key_base = key_base + usize::from(key_fn_slot.is_some());
@@ -15141,7 +15140,9 @@ pub(crate) fn sort_rooted_items(
                 pyre_object::gc_roots::shadow_stack_get(key_fn_slot),
                 &[pyre_object::gc_roots::shadow_stack_get(item_base + index)],
             ) {
-                Ok(key) => pyre_object::gc_roots::pin_root(key),
+                Ok(key) => {
+                    let _ = pyre_object::gc_roots::pin_root(key);
+                }
                 Err(err) => return (order, Err(err)),
             }
         }
@@ -15298,16 +15299,16 @@ fn builtin_any(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // relocates it behind a plain Rust local. The shape `collect_iterator` uses.
     let _roots = pyre_object::gc_roots::push_roots();
     let iterable_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(positional[0]);
+    let _ = pyre_object::gc_roots::pin_root(positional[0]);
     let it = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?;
     let iterator_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(it);
+    let _ = pyre_object::gc_roots::pin_root(it);
     // The pin queries the collector, so the slot — not this local — is what
     // holds the forwarded iterator once it returns.
     let it = pyre_object::gc_roots::shadow_stack_get(iterator_slot);
     if unsafe { pyre_object::dictmultiobject::is_dict_view_iterator(it) } {
         let w_dict = unsafe { pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(it) };
-        pyre_object::gc_roots::pin_root(w_dict);
+        let _ = pyre_object::gc_roots::pin_root(w_dict);
     }
     loop {
         let it_now = pyre_object::gc_roots::shadow_stack_get(iterator_slot);
@@ -15349,7 +15350,7 @@ pub(crate) fn init_file_wrapper_type(ns: PyObjectRef) {
     // allocating insertions below.
     let _roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(ns);
+    let _ = pyre_object::gc_roots::pin_root(ns);
     type_ns_store(
         ns_slot,
         "read",
@@ -15621,7 +15622,7 @@ pub(crate) fn init_fileio_type(ns: PyObjectRef) {
     // allocating insertions below.
     let _roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(ns);
+    let _ = pyre_object::gc_roots::pin_root(ns);
     // The table carries the code pointer and arity, not the built function:
     // building all six up front would leave the early ones in a Rust array the
     // collector does not walk while the later ones allocate.
@@ -15945,8 +15946,8 @@ pub(crate) fn fileio_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         opener,
     ])?;
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(self_obj);
-    pyre_object::gc_roots::pin_root(opened);
+    let self_obj = pyre_object::gc_roots::pin_root(self_obj);
+    let opened = pyre_object::gc_roots::pin_root(opened);
     for name in [
         "__file_data__",
         "__file_pos__",
@@ -16082,11 +16083,11 @@ impl WritableBuffer {
         // concrete storage owner so Python called while the buffer is live
         // cannot leave Drop with a pre-GC address.
         let roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let (data, owner) =
             unsafe { fileio_writebuf(pyre_object::gc_roots::shadow_stack_get(obj_slot))? };
-        pyre_object::gc_roots::pin_root(owner);
+        let _ = pyre_object::gc_roots::pin_root(owner);
         let owner_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let owner = pyre_object::gc_roots::shadow_stack_get(owner_slot);
         let held = unsafe { buffer_export_incref(owner) };
@@ -17067,7 +17068,7 @@ fn file_method_close(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     }
     let _roots = pyre_object::gc_roots::push_roots();
     let self_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args[0]);
+    let _ = pyre_object::gc_roots::pin_root(args[0]);
     let current = || pyre_object::gc_roots::shadow_stack_get(self_slot);
     fileio_clear_stat_atopen(current());
 
@@ -17341,7 +17342,7 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     // can call Python and move objects, so the complete live argument set must
     // already be on the shadow stack before the first such callback.
     let argument_roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(file);
+    let file = pyre_object::gc_roots::pin_root(file);
     let mut file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_mode =
         bind_pos_or_kw(positional, kwargs, 1, "mode", "open", 2)?.unwrap_or_else(|| w_str_new("r"));
@@ -17373,7 +17374,7 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         w_closefd,
         w_opener,
     ] {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
     }
     let opener_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let closefd_slot = opener_slot - 1;
@@ -17407,7 +17408,7 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     // user __bool__ a second time after __fspath__.
     let closefd =
         crate::baseobjspace::is_true(pyre_object::gc_roots::shadow_stack_get(closefd_slot))?;
-    pyre_object::gc_roots::pin_root(w_bool_from(closefd));
+    let _ = pyre_object::gc_roots::pin_root(w_bool_from(closefd));
     let converted_closefd_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     // PyPy `_open` resolves a PathLike after unwrap_spec has converted the
@@ -17433,7 +17434,7 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
                 crate::gateway::short_type_name(file_now)
             )));
         };
-        pyre_object::gc_roots::pin_root(fspath_fn);
+        let _ = pyre_object::gc_roots::pin_root(fspath_fn);
         let fspath_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let resolved = crate::call::call_function_impl_result(
             pyre_object::gc_roots::shadow_stack_get(fspath_slot),
@@ -17448,7 +17449,7 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
                 crate::gateway::short_type_name(resolved)
             )));
         }
-        pyre_object::gc_roots::pin_root(resolved);
+        let _ = pyre_object::gc_roots::pin_root(resolved);
         file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     }
 
@@ -17559,7 +17560,7 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         ],
     )?;
     let roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(raw);
+    let _ = pyre_object::gc_roots::pin_root(raw);
     let raw_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     // `_open` closes the outermost constructed layer when a later layer's
@@ -17617,7 +17618,7 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
                 w_int_new(buffering),
             ],
         )?;
-        pyre_object::gc_roots::pin_root(buffer);
+        let _ = pyre_object::gc_roots::pin_root(buffer);
         let buffer_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         close_target_slot = buffer_slot;
         if binary {
@@ -17638,7 +17639,7 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
                 1,
             )?
         };
-        pyre_object::gc_roots::pin_root(resolved_encoding);
+        let _ = pyre_object::gc_roots::pin_root(resolved_encoding);
         let resolved_encoding_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let wrapper = crate::call::call_function_impl_result(
             text_io_wrapper_type(),
@@ -18103,16 +18104,16 @@ fn builtin_all(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // Python, so the iterator is reloaded from its slot before each call.
     let _roots = pyre_object::gc_roots::push_roots();
     let iterable_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(positional[0]);
+    let _ = pyre_object::gc_roots::pin_root(positional[0]);
     let it = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?;
     let iterator_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(it);
+    let _ = pyre_object::gc_roots::pin_root(it);
     // The pin queries the collector, so the slot — not this local — is what
     // holds the forwarded iterator once it returns.
     let it = pyre_object::gc_roots::shadow_stack_get(iterator_slot);
     if unsafe { pyre_object::dictmultiobject::is_dict_view_iterator(it) } {
         let w_dict = unsafe { pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(it) };
-        pyre_object::gc_roots::pin_root(w_dict);
+        let _ = pyre_object::gc_roots::pin_root(w_dict);
     }
     loop {
         let it_now = pyre_object::gc_roots::shadow_stack_get(iterator_slot);
@@ -18227,15 +18228,15 @@ fn builtin_sum(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // them first and read every later use back out of the slot, never from the
     // local a foreign collection has left stale.
     let last_slot = roots.base();
-    roots.pin_root(start);
+    let _ = roots.pin_root(start);
     let iterable_slot = last_slot + 1;
-    roots.pin_root(iterable);
+    let _ = roots.pin_root(iterable);
     let it_slot = iterable_slot + 1;
-    roots.pin_root(crate::baseobjspace::iter(roots.get(iterable_slot))?);
+    let _ = roots.pin_root(crate::baseobjspace::iter(roots.get(iterable_slot))?);
     // Seeded with `start` purely to own a slot; every read is guarded by
     // `pending`, which is only set once a real item has been written here.
     let item_slot = it_slot + 1;
-    roots.pin_root(roots.get(last_slot));
+    let _ = roots.pin_root(roots.get(last_slot));
     // A dict-view iterator is an off-GC carrier whose own walker does not cover
     // this native loop; retain its source dict for the duration, as
     // `collect_iterator` does.
@@ -18243,7 +18244,7 @@ fn builtin_sum(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let w_dict = unsafe {
             pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(roots.get(it_slot))
         };
-        roots.pin_root(w_dict);
+        let _ = roots.pin_root(w_dict);
     }
     let mut pending = false;
     let mut exhausted = false;
@@ -19115,7 +19116,7 @@ fn builtin_dunder_import(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     // collector can relocate a young string while the index protocol runs.
     let _name_roots = pyre_object::gc_roots::push_roots();
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(name_obj);
+    let _ = pyre_object::gc_roots::pin_root(name_obj);
     let globals = scope[1];
     let locals = scope[2];
     let fromlist = scope[3];

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -23,12 +23,12 @@ pub(crate) fn frame_into_generator_for_function(
 ) -> PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let function_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(function);
+    let function = pyre_object::gc_roots::pin_root(function);
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(unsafe { function_get_name_obj(function) });
+    let _ = pyre_object::gc_roots::pin_root(unsafe { function_get_name_obj(function) });
     let function = pyre_object::gc_roots::shadow_stack_get(function_slot);
     let qualname_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(unsafe { function_get_qualname_obj(function) });
+    let _ = pyre_object::gc_roots::pin_root(unsafe { function_get_qualname_obj(function) });
     frame.into_generator_named(
         Some(pyre_object::gc_roots::shadow_stack_get(name_slot)),
         Some(pyre_object::gc_roots::shadow_stack_get(qualname_slot)),
@@ -1068,9 +1068,9 @@ fn call_builtin_code_positional(code: PyObjectRef, args: &[PyObjectRef]) -> PyRe
     // reload immediately before invoking the builtin.
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = _roots.base();
-    _roots.pin_root(code);
+    let _ = _roots.pin_root(code);
     for &arg in args {
-        _roots.pin_root(arg);
+        let _ = _roots.pin_root(arg);
     }
     // RPython's pop-roots reload produces ordinary live variables.  Spell the
     // common fixed-arity cases the same way so source translation sees no Rust
@@ -1259,10 +1259,10 @@ pub fn call_function_ex_in_ctx(
     // them before the first unpack, not after it.
     let _roots = pyre_object::gc_roots::push_roots();
     let callable_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(callable);
-    pyre_object::gc_roots::pin_root(kwargs_or_null);
-    pyre_object::gc_roots::pin_root(self_or_null);
-    pyre_object::gc_roots::pin_root(starargs);
+    let _ = pyre_object::gc_roots::pin_root(callable);
+    let _ = pyre_object::gc_roots::pin_root(kwargs_or_null);
+    let _ = pyre_object::gc_roots::pin_root(self_or_null);
+    let _ = pyre_object::gc_roots::pin_root(starargs);
     let callable = || pyre_object::gc_roots::shadow_stack_get(callable_slot);
     let kwargs_or_null = || pyre_object::gc_roots::shadow_stack_get(callable_slot + 1);
     let self_or_null = || pyre_object::gc_roots::shadow_stack_get(callable_slot + 2);
@@ -1304,7 +1304,7 @@ pub fn call_function_ex_in_ctx(
     // slice for the dispatch.
     let args_base = pyre_object::gc_roots::shadow_stack_len();
     for &arg in &args {
-        pyre_object::gc_roots::pin_root(arg);
+        let _ = pyre_object::gc_roots::pin_root(arg);
     }
     let nargs = args.len();
     let args = || -> Vec<PyObjectRef> {
@@ -1830,9 +1830,9 @@ fn call_non_function_callable_with_mode(
     // the translated shadow-stack roots and reload them after binding.
     let _user_call_roots = pyre_object::gc_roots::push_roots();
     let user_call_root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(callable);
+    let callable = pyre_object::gc_roots::pin_root(callable);
     for &arg in args {
-        pyre_object::gc_roots::pin_root(arg);
+        let _ = pyre_object::gc_roots::pin_root(arg);
     }
     if let Some((call_fn, prepend_receiver)) =
         user_call_slot(pyre_object::gc_roots::shadow_stack_get(user_call_root_base))?
@@ -2314,12 +2314,12 @@ pub(crate) fn resolve_kwargs(
     let roots = pyre_object::gc_roots::push_roots();
     let result_slot = roots.base();
     for &value in &result {
-        roots.pin_root(value);
+        let _ = roots.pin_root(value);
     }
     let extra_slot = result_slot + result.len();
     for &(key, value) in &extra_kwargs {
-        roots.pin_root(key);
-        roots.pin_root(value);
+        let _ = roots.pin_root(key);
+        let _ = roots.pin_root(value);
     }
     let varargs_slot = extra_slot + extra_kwargs.len() * 2;
     if has_varargs {
@@ -2328,7 +2328,7 @@ pub(crate) fn resolve_kwargs(
         } else {
             vec![]
         };
-        roots.pin_root(pyre_object::w_tuple_new(extra_pos));
+        let _ = roots.pin_root(pyre_object::w_tuple_new(extra_pos));
     }
     let varkw_slot = varargs_slot + usize::from(has_varargs);
     if has_varkw {
@@ -2336,7 +2336,7 @@ pub(crate) fn resolve_kwargs(
         // EmptyKwargsDictStrategy so the first unicode setitem promotes
         // directly to KwargsDictStrategy (parallel `(keys_w, values_w)`
         // shape) instead of stepping through UnicodeDictStrategy.
-        roots.pin_root(pyre_object::w_dict_new_kwargs());
+        let _ = roots.pin_root(pyre_object::w_dict_new_kwargs());
         for i in 0..extra_kwargs.len() {
             unsafe {
                 pyre_object::w_dict_store(
@@ -2497,11 +2497,11 @@ pub(crate) fn bind_kwargs_to_signature(
     let roots = pyre_object::gc_roots::push_roots();
     let result_slot = roots.base();
     for &value in &result {
-        roots.pin_root(value);
+        let _ = roots.pin_root(value);
     }
     let extra_slot = result_slot + result.len();
     for &(_, value) in &extra_kwargs {
-        roots.pin_root(value);
+        let _ = roots.pin_root(value);
     }
     let varargs_slot = extra_slot + extra_kwargs.len();
     if has_varargs {
@@ -2510,11 +2510,11 @@ pub(crate) fn bind_kwargs_to_signature(
         } else {
             vec![]
         };
-        roots.pin_root(pyre_object::w_tuple_new(extra_pos));
+        let _ = roots.pin_root(pyre_object::w_tuple_new(extra_pos));
     }
     let varkw_slot = varargs_slot + usize::from(has_varargs);
     if has_varkw {
-        roots.pin_root(pyre_object::w_dict_new_kwargs());
+        let _ = roots.pin_root(pyre_object::w_dict_new_kwargs());
         // The index loop lowers to direct element loads; iterator adapters are residual calls.
         #[allow(clippy::needless_range_loop)]
         for i in 0..extra_kwargs.len() {
@@ -2586,12 +2586,12 @@ fn call_with_kwargs_in_ctx_impl(
     // and keyword-name strings before the callee frame owns these values.
     let _call_roots = pyre_object::gc_roots::push_roots();
     let call_root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(callable);
+    let callable = pyre_object::gc_roots::pin_root(callable);
     for &arg in pos_args {
-        pyre_object::gc_roots::pin_root(arg);
+        let _ = pyre_object::gc_roots::pin_root(arg);
     }
     for (_, value) in kwargs {
-        pyre_object::gc_roots::pin_root(*value);
+        let _ = pyre_object::gc_roots::pin_root(*value);
     }
     let current_callable = || pyre_object::gc_roots::shadow_stack_get(call_root_base);
     let current_pos_arg =
@@ -2796,7 +2796,7 @@ fn call_with_kwargs_in_ctx_impl(
             let kw_roots = pyre_object::gc_roots::push_roots();
             let kw_slot = kw_roots.base();
             if !kwargs.is_empty() {
-                kw_roots.pin_root(pyre_object::w_dict_new());
+                let _ = kw_roots.pin_root(pyre_object::w_dict_new());
                 for (index, (key, _)) in kwargs.iter().enumerate() {
                     unsafe {
                         // The key allocation runs first: as the second argument
@@ -3079,7 +3079,7 @@ fn call_with_kwargs_in_ctx_impl(
             let _bound_roots = pyre_object::gc_roots::push_roots();
             let bound_root_base = pyre_object::gc_roots::shadow_stack_len();
             for &value in &result {
-                pyre_object::gc_roots::pin_root(value);
+                let _ = pyre_object::gc_roots::pin_root(value);
             }
             let mut packed_tail_slots = Vec::new();
             if has_varargs {
@@ -3092,13 +3092,13 @@ fn call_with_kwargs_in_ctx_impl(
                 };
                 let packed = pyre_object::w_tuple_new(extra_pos);
                 let slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(packed);
+                let _ = pyre_object::gc_roots::pin_root(packed);
                 packed_tail_slots.push(slot);
             }
             if has_varkw {
                 let kw_dict = pyre_object::w_dict_new();
                 let kw_dict_slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(kw_dict);
+                let _ = pyre_object::gc_roots::pin_root(kw_dict);
                 for (key, value) in &extra_kwargs {
                     unsafe {
                         // The key allocation runs first: as the second argument
@@ -3169,7 +3169,7 @@ fn call_with_kwargs_in_ctx_impl(
         // otherwise retain the pre-move address of a heap type.
         let _type_root = pyre_object::gc_roots::push_roots();
         let type_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(callable);
+        let _ = pyre_object::gc_roots::pin_root(callable);
         let current_type = || pyre_object::gc_roots::shadow_stack_get(type_slot);
         if let Some(result) = type_call_special_case(current_type(), pos_args, !kwargs.is_empty()) {
             return result;
@@ -3228,7 +3228,7 @@ fn call_with_kwargs_in_ctx_impl(
             current_type()
         };
         let metaclass_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_metaclass);
+        let _ = pyre_object::gc_roots::pin_root(w_metaclass);
         let current_metaclass = || pyre_object::gc_roots::shadow_stack_get(metaclass_slot);
         // Step 1: __new__(cls, *args, **kwargs)
         let instance = if let Some(new_fn) =
@@ -3258,7 +3258,7 @@ fn call_with_kwargs_in_ctx_impl(
         // (framework.py:853-856).
         let _instance_roots = pyre_object::gc_roots::push_roots();
         let instance_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(instance);
+        let _ = pyre_object::gc_roots::pin_root(instance);
         // Step 2: __init__(self, *args, **kwargs) with full kwargs support.
         if let Some(w_insttype) = type_call_init_type(
             pyre_object::gc_roots::shadow_stack_get(instance_slot),
@@ -3419,9 +3419,9 @@ pub fn call_function_impl_result(
     // and dispatch from freshly reloaded values.
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = _roots.base();
-    _roots.pin_root(callable);
+    let _ = _roots.pin_root(callable);
     for &arg in args {
-        _roots.pin_root(arg);
+        let _ = _roots.pin_root(arg);
     }
 
     // A JIT prologue may have published an overflow before entering this
@@ -3680,9 +3680,9 @@ fn type_descr_call_impl(w_type: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRe
     // slices are only copies and otherwise retain pre-move addresses.
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_type);
+    let _ = pyre_object::gc_roots::pin_root(w_type);
     for &arg in args {
-        pyre_object::gc_roots::pin_root(arg);
+        let _ = pyre_object::gc_roots::pin_root(arg);
     }
     let current_type = || pyre_object::gc_roots::shadow_stack_get(root_base);
     // `Arguments.prepend` builds one list per call, so both call sites below
@@ -3720,7 +3720,7 @@ fn type_descr_call_impl(w_type: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRe
         pyre_object::w_instance_new(current_type())
     };
     let instance_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(instance);
+    let _ = pyre_object::gc_roots::pin_root(instance);
 
     // Step 2: __init__ — only if __new__ returned an instance of w_type.
     // PyPy checks the Python-level type(instance), so builtin-layout subtypes
@@ -3958,11 +3958,11 @@ fn call_metaclass_with_kwargs(
     // old-gen is swept even though it does not move.
     let _roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_namespace_dict);
-    pyre_object::gc_roots::pin_root(kwargs);
-    pyre_object::gc_roots::pin_root(w_metaclass);
-    pyre_object::gc_roots::pin_root(name);
-    pyre_object::gc_roots::pin_root(bases);
+    let w_namespace_dict = pyre_object::gc_roots::pin_root(w_namespace_dict);
+    let kwargs = pyre_object::gc_roots::pin_root(kwargs);
+    let w_metaclass = pyre_object::gc_roots::pin_root(w_metaclass);
+    let name = pyre_object::gc_roots::pin_root(name);
+    let bases = pyre_object::gc_roots::pin_root(bases);
     if unsafe { !pyre_object::is_type(w_metaclass) } {
         // compiling.py:215-221 — `space.call_args(w_meta, Arguments(name,
         // bases, ns, **kwds))`; a non-type metaclass receives the
@@ -4056,8 +4056,7 @@ fn call_metaclass_with_kwargs(
     // A fresh type is allocated stable, so it never moves and needs no
     // read-back -- but until `type_call_init_type` stores it, this local is
     // its only reference, and `__init__` below runs Python.
-    pyre_object::gc_roots::pin_root(instance);
-
+    let instance = pyre_object::gc_roots::pin_root(instance);
     if let Some(w_insttype) = type_call_init_type(instance, w_metaclass)
         && let Some(init_fn) =
             unsafe { crate::baseobjspace::lookup_in_type(w_insttype, "__init__") }
@@ -4203,7 +4202,7 @@ fn update_bases(
                         "__mro_entries__ must return a tuple",
                     ));
                 }
-                pyre_object::gc_roots::pin_root(w_new_base);
+                let w_new_base = pyre_object::gc_roots::pin_root(w_new_base);
                 if new_bases.is_none() {
                     new_bases = Some(base_args[..i].to_vec());
                 }
@@ -4287,7 +4286,7 @@ pub(crate) fn real_build_class(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
             // walks the strategy.
             // Born young, and `w_dict_store` allocates on strategy promotion —
             // the bracket in `call_with_kwargs`.
-            extra_roots.pin_root(pyre_object::w_dict_new());
+            let _ = extra_roots.pin_root(pyre_object::w_dict_new());
             unsafe {
                 for (k, v) in pyre_object::w_dict_items(last) {
                     if pyre_object::is_str(k) {
@@ -4322,7 +4321,7 @@ pub(crate) fn real_build_class(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     // `build_class_inner`, the one consumer, returns.
     let bases_roots = pyre_object::gc_roots::push_roots();
     let orig_bases_slot = bases_roots.base();
-    bases_roots.pin_root(pyre_object::w_tuple_new(base_args.to_vec()));
+    let _ = bases_roots.pin_root(pyre_object::w_tuple_new(base_args.to_vec()));
     let (resolved_bases, bases_changed) =
         update_bases(base_args, bases_roots.get(orig_bases_slot))?;
     // Non-type bases are not rejected here: `__build_class__` hands the
@@ -4330,7 +4329,7 @@ pub(crate) fn real_build_class(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     // that is not a type may legitimately accept them.  `best_base` performs
     // the `bases must be types` check on the type-construction path.
     let bases_slot = pyre_object::gc_roots::shadow_stack_len();
-    bases_roots.pin_root(pyre_object::w_tuple_new(resolved_bases));
+    let _ = bases_roots.pin_root(pyre_object::w_tuple_new(resolved_bases));
     let bases_tuple = bases_roots.get(bases_slot);
     let w_orig_bases = if bases_changed {
         Some(bases_roots.get(orig_bases_slot))
@@ -4406,7 +4405,7 @@ fn build_class_inner(
     let kwds_roots = extra_kwargs.map(|kw| {
         let scope = pyre_object::gc_roots::push_roots();
         let slot = scope.base();
-        scope.pin_root(kw);
+        let _ = scope.pin_root(kw);
         (scope, slot)
     });
     let current_kwds = || kwds_roots.as_ref().map(|(scope, slot)| scope.get(*slot));
@@ -4419,10 +4418,10 @@ fn build_class_inner(
     // each site that consumes them.
     let bases_scope = pyre_object::gc_roots::push_roots();
     let bases_slot = bases_scope.base();
-    bases_scope.pin_root(bases);
+    let _ = bases_scope.pin_root(bases);
     let orig_bases_slot = w_orig_bases.map(|w_orig_bases| {
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_orig_bases);
+        let _ = pyre_object::gc_roots::pin_root(w_orig_bases);
         slot
     });
     let bases = || bases_scope.get(bases_slot);
@@ -4513,12 +4512,12 @@ fn build_class_inner(
     let _class_ns_root = pyre_object::gc_roots::push_roots();
     let w_namespace_root = w_namespace.map(|w_namespace| {
         let root = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_namespace);
+        let _ = pyre_object::gc_roots::pin_root(w_namespace);
         root
     });
     let class_ns = pyre_object::w_dict_new();
     let class_ns_root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(class_ns);
+    let class_ns = pyre_object::gc_roots::pin_root(class_ns);
     if let Some(w_namespace_root) = w_namespace_root {
         let w_prepared_dict = pyre_object::gc_roots::shadow_stack_get(w_namespace_root);
         if unsafe { pyre_object::is_dict(w_prepared_dict) } {
@@ -4548,7 +4547,7 @@ fn build_class_inner(
             let backing = crate::type_methods::resolve_dict_backing(w_prepared_dict);
             if !backing.is_null() && unsafe { pyre_object::is_dict(backing) } {
                 let backing_root = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(backing);
+                let backing = pyre_object::gc_roots::pin_root(backing);
                 let keys: Vec<Wtf8Buf> = unsafe {
                     pyre_object::w_dict_str_entries_wtf8(backing)
                         .into_iter()
@@ -4681,7 +4680,7 @@ fn build_class_inner(
         if distinct_namespace && !backing.is_null() && unsafe { pyre_object::is_dict(backing) } {
             // Dict subclass: read final entries off the backing dict.
             let backing_root = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(backing);
+            let backing = pyre_object::gc_roots::pin_root(backing);
             let keys: Vec<Wtf8Buf> = unsafe {
                 pyre_object::w_dict_str_entries_wtf8(backing)
                     .into_iter()
@@ -4804,7 +4803,7 @@ fn build_class_inner(
         let cell = unsafe { pyre_object::w_dict_getitem_str(class_ns, "__classdictcell__") };
         cell.filter(|value| unsafe { pyre_object::is_cell(*value) })
             .map(|cell| {
-                pyre_object::gc_roots::pin_root(cell);
+                let _ = pyre_object::gc_roots::pin_root(cell);
                 pyre_object::gc_roots::shadow_stack_len() - 1
             })
     };
@@ -4829,7 +4828,7 @@ fn build_class_inner(
     // `create_all_slots` unpacks `__slots__`; both execute Python, so the
     // tuple cannot stay in an untraced local across them.
     let bases_root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_effective_bases);
+    let w_effective_bases = pyre_object::gc_roots::pin_root(w_effective_bases);
     // A custom metaclass owns its bases until (and unless) it invokes
     // type.__new__; do not perform type's C3 validation before dispatch.
     if w_metaclass.is_none() {
@@ -4888,7 +4887,7 @@ fn build_class_inner(
         } else {
             let d = pyre_object::w_dict_new();
             let d_root = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(d);
+            let d = pyre_object::gc_roots::pin_root(d);
             w_namespace_dict_root = Some(d_root);
             let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
             let keys: Vec<String> = unsafe {
@@ -4979,7 +4978,7 @@ fn build_class_inner(
         crate::builtins::type_new_wrap_special_methods(class_ns);
         let dict_root = pyre_object::gc_roots::shadow_stack_len();
         let dict_obj = pyre_object::w_dict_new();
-        pyre_object::gc_roots::pin_root(dict_obj);
+        let dict_obj = pyre_object::gc_roots::pin_root(dict_obj);
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
         let keys: Vec<Wtf8Buf> = unsafe {
             pyre_object::w_dict_str_entries_wtf8(class_ns)
@@ -5014,7 +5013,7 @@ fn build_class_inner(
             pyre_object::gc_roots::shadow_stack_get(bases_root),
             dict_obj as *mut u8,
         );
-        pyre_object::gc_roots::pin_root(w);
+        let w = pyre_object::gc_roots::pin_root(w);
         crate::builtins::type_new_take_qualname(w, dict_obj)?;
         // typeobject.py create_all_slots parity.
         unsafe { create_all_slots(w, pyre_object::gc_roots::shadow_stack_get(bases_root))? };
@@ -5069,8 +5068,8 @@ fn build_class_inner(
             let mut pinned = 0;
             for (w_name, value) in entries {
                 if !value.is_null() && unsafe { pyre_object::is_str(w_name) } {
-                    pyre_object::gc_roots::pin_root(w_name);
-                    pyre_object::gc_roots::pin_root(value);
+                    let _ = pyre_object::gc_roots::pin_root(w_name);
+                    let _ = pyre_object::gc_roots::pin_root(value);
                     pinned += 1;
                 }
             }
@@ -5181,11 +5180,11 @@ fn pack_pyre_kwargs(kw_items: &[(PyObjectRef, PyObjectRef)]) -> PyObjectRef {
     let kw_roots = pyre_object::gc_roots::push_roots();
     let item_slot = kw_roots.base();
     for &(k, v) in kw_items {
-        kw_roots.pin_root(k);
-        kw_roots.pin_root(v);
+        let _ = kw_roots.pin_root(k);
+        let _ = kw_roots.pin_root(v);
     }
     let kw_slot = item_slot + kw_items.len() * 2;
-    kw_roots.pin_root(pyre_object::w_dict_new());
+    let _ = kw_roots.pin_root(pyre_object::w_dict_new());
     unsafe {
         for i in 0..kw_items.len() {
             pyre_object::w_dict_store(
@@ -5285,9 +5284,9 @@ fn type_descr_call_with_mode(
     // them back from the shadow stack after `__new__` has run Python code.
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_type);
+    let _ = pyre_object::gc_roots::pin_root(w_type);
     for &arg in args {
-        pyre_object::gc_roots::pin_root(arg);
+        let _ = pyre_object::gc_roots::pin_root(arg);
     }
     let current_type = || pyre_object::gc_roots::shadow_stack_get(root_base);
     let extend_current_args = |dst: &mut Vec<PyObjectRef>| {
@@ -5328,7 +5327,7 @@ fn type_descr_call_with_mode(
     let instance = call_callable_with_mode(execution_context, new_fn, &new_args, mode)?;
     let _instance_roots = pyre_object::gc_roots::push_roots();
     let instance_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(instance);
+    let _ = pyre_object::gc_roots::pin_root(instance);
     let current_instance = || pyre_object::gc_roots::shadow_stack_get(instance_slot);
 
     // Step 2: __init__ — only if __new__ returned an instance of w_type.

--- a/pyre/pyre-interpreter/src/cpyext/buffer.rs
+++ b/pyre/pyre-interpreter/src/cpyext/buffer.rs
@@ -178,8 +178,7 @@ fn acquire(
 
     let roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_obj);
-
+    let _ = roots.pin_root(w_obj);
     let view = Box::into_raw(Box::new(unsafe { std::mem::zeroed::<CPyBuffer>() }));
     let receiver = pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(obj_slot));
     let status = unsafe {
@@ -230,10 +229,10 @@ fn acquire(
     }
 
     let base = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(pyre_object::w_str_new(&format));
+    let _ = roots.pin_root(pyre_object::w_str_new(&format));
     if ndim != 1 {
-        roots.pin_root(wrap_dims(&shape));
-        roots.pin_root(wrap_dims(&strides));
+        let _ = roots.pin_root(wrap_dims(&shape));
+        let _ = roots.pin_root(wrap_dims(&strides));
     }
     let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
@@ -272,7 +271,7 @@ fn wrap_dims(dims: &[i64]) -> PyObjectRef {
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
     for &extent in dims {
-        roots.pin_root(pyre_object::w_int_new(extent));
+        let _ = roots.pin_root(pyre_object::w_int_new(extent));
     }
     let items = (0..dims.len())
         .map(|index| pyre_object::gc_roots::shadow_stack_get(base + index))
@@ -523,8 +522,8 @@ pub unsafe extern "C" fn PyBuffer_SizeFromFormat(format: *const c_char) -> isize
     let sized = super::import_::import_module("_struct").and_then(|module| {
         let roots = pyre_object::gc_roots::push_roots();
         let base = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(module);
-        roots.pin_root(pyre_object::w_str_new(&format));
+        let _ = roots.pin_root(module);
+        let _ = roots.pin_root(pyre_object::w_str_new(&format));
         let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
         let calcsize = crate::baseobjspace::getattr_str(reload(0), "calcsize")?;
         let size = crate::call::call_function_impl_result(calcsize, &[reload(1)])?;
@@ -888,7 +887,7 @@ fn unowned_view(
     use pyre_object::bufferview::BufferView;
     let roots = pyre_object::gc_roots::push_roots();
     let fmt_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(pyre_object::w_str_new(format));
+    let _ = roots.pin_root(pyre_object::w_str_new(format));
     let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, false);
     let w_obj = pyre_object::w_none();
     let built = BufferView::Raw {

--- a/pyre/pyre-interpreter/src/cpyext/bytesobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/bytesobject.rs
@@ -130,7 +130,7 @@ pub(super) fn realize_pending(raw: *mut CPyObject) {
     let data = unsafe { std::slice::from_raw_parts(pointer as *const u8, length) }.to_vec();
     let roots = pyre_object::gc_roots::push_roots();
     let slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(pyre_object::bytesobject::w_bytes_from_bytes(&data));
+    let _ = roots.pin_root(pyre_object::bytesobject::w_bytes_from_bytes(&data));
     let refcnt = unsafe { (*raw).ob_refcnt };
     pyobject::link_allocated(
         pyre_object::gc_roots::shadow_stack_get(slot),
@@ -351,7 +351,7 @@ pub(super) fn bytes_of(object: PyObjectRef) -> Result<PyObjectRef, crate::PyErro
         }
     };
     let iterator_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(iterator);
+    let _ = roots.pin_root(iterator);
     let mut data = Vec::new();
     loop {
         let item =
@@ -464,9 +464,9 @@ fn concatenated(left: PyObjectRef, right: PyObjectRef) -> Result<PyObjectRef, cr
         || crate::PyError::type_error(format!("can't concat {right_name} to {left_name}"));
     let roots = pyre_object::gc_roots::push_roots();
     let left_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(left);
+    let _ = roots.pin_root(left);
     let right_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(right);
+    let _ = roots.pin_root(right);
     let Some(tail) = concat_bytes(pyre_object::gc_roots::shadow_stack_get(right_slot))? else {
         return Err(refusal());
     };

--- a/pyre/pyre-interpreter/src/cpyext/capsule.rs
+++ b/pyre/pyre-interpreter/src/cpyext/capsule.rs
@@ -69,14 +69,14 @@ fn slot_get(carrier: PyObjectRef, key: &str) -> usize {
 fn slot_set(carrier: PyObjectRef, key: &str, value: usize) {
     let roots = pyre_object::gc_roots::push_roots();
     let carrier_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(carrier);
+    let _ = roots.pin_root(carrier);
     let dict =
         crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(carrier_slot));
     if dict.is_null() {
         return;
     }
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(dict);
+    let _ = roots.pin_root(dict);
     let value = pyre_object::w_int_new(value as i64);
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str(
@@ -159,7 +159,7 @@ pub unsafe extern "C" fn PyCapsule_New(
     let roots = pyre_object::gc_roots::push_roots();
     let carrier = pyre_object::w_instance_new(capsule_type());
     let carrier_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(carrier);
+    let _ = roots.pin_root(carrier);
     let reload = || pyre_object::gc_roots::shadow_stack_get(carrier_slot);
     slot_set(reload(), POINTER_KEY, pointer as usize);
     slot_set(reload(), NAME_KEY, name as usize);
@@ -292,7 +292,7 @@ pub unsafe extern "C" fn PyCapsule_Import(name: *const c_char, _no_block: c_int)
         return std::ptr::null_mut();
     };
     let mut slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(reached);
+    let _ = roots.pin_root(reached);
     for component in components {
         let step = super::pyerrors::trap(crate::baseobjspace::getattr_str(
             pyre_object::gc_roots::shadow_stack_get(slot),
@@ -302,7 +302,7 @@ pub unsafe extern "C" fn PyCapsule_Import(name: *const c_char, _no_block: c_int)
             return std::ptr::null_mut();
         };
         slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(step);
+        let _ = roots.pin_root(step);
     }
     let capsule = pyre_object::gc_roots::shadow_stack_get(slot);
     if !is_capsule(capsule) {

--- a/pyre/pyre-interpreter/src/cpyext/dictobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/dictobject.rs
@@ -104,9 +104,9 @@ pub unsafe extern "C" fn PyDict_SetItemString(
     };
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(dict);
+    let _ = roots.pin_root(dict);
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(value);
+    let _ = roots.pin_root(value);
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str(
             pyre_object::gc_roots::shadow_stack_get(dict_slot),
@@ -406,11 +406,11 @@ pub unsafe extern "C" fn PyDict_SetDefaultRef(
     };
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(dict);
+    let _ = roots.pin_root(dict);
     let key_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(key);
+    let _ = roots.pin_root(key);
     let default_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(default_value);
+    let _ = roots.pin_root(default_value);
     // The key is looked for once, so which of the two things happened is read
     // off the size either side of it.  Asking the dict whether it holds the key
     // would run the key's `__hash__` and `__eq__` a second time, and a key that
@@ -472,10 +472,9 @@ unsafe fn pop_from(dict: PyObjectRef, key: PyObjectRef, result: *mut *mut CPyObj
     }
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(dict);
+    let _ = roots.pin_root(dict);
     let key_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(key);
-    let key = pyre_object::gc_roots::shadow_stack_get(key_slot);
+    let key = roots.pin_root(key);
     let found = unsafe {
         pyre_object::dictmultiobject::w_dict_pop_checked(
             pyre_object::gc_roots::shadow_stack_get(dict_slot),
@@ -552,7 +551,7 @@ fn view_list(
         return std::ptr::null_mut();
     };
     let roots = pyre_object::gc_roots::push_roots();
-    roots.pin_root(dict);
+    let dict = roots.pin_root(dict);
     pyobject::make_ref(pyre_object::listobject::w_list_new(part(dict)))
 }
 
@@ -637,8 +636,8 @@ pub unsafe extern "C" fn PyDict_Merge(
     };
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(target);
-    roots.pin_root(source);
+    let _ = roots.pin_root(target);
+    let _ = roots.pin_root(source);
     let target = || pyre_object::gc_roots::shadow_stack_get(base);
     let source_now = pyre_object::gc_roots::shadow_stack_get(base + 1);
 
@@ -677,7 +676,7 @@ pub unsafe extern "C" fn PyDict_Merge(
             None => return -1,
         };
         let keys_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(keys);
+        let _ = roots.pin_root(keys);
         let keys = match trap(unpack_all(pyre_object::gc_roots::shadow_stack_get(
             keys_slot,
         ))) {
@@ -696,8 +695,8 @@ pub unsafe extern "C" fn PyDict_Merge(
                 Some(value) => value,
                 None => return -1,
             };
-            roots.pin_root(pyre_object::gc_roots::shadow_stack_get(unpacked + index));
-            roots.pin_root(value);
+            let _ = roots.pin_root(pyre_object::gc_roots::shadow_stack_get(unpacked + index));
+            let _ = roots.pin_root(value);
         }
         (pairs, keys.len())
     };
@@ -753,8 +752,8 @@ pub unsafe extern "C" fn PyDict_MergeFromSeq2(
     };
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(target);
-    roots.pin_root(sequence);
+    let _ = roots.pin_root(target);
+    let sequence = roots.pin_root(sequence);
     let target = || pyre_object::gc_roots::shadow_stack_get(base);
 
     let Some(pairs) = trap(unpack_all(pyre_object::gc_roots::shadow_stack_get(
@@ -771,7 +770,7 @@ pub unsafe extern "C" fn PyDict_MergeFromSeq2(
     for index in 0..pairs.len() {
         let pair_roots = pyre_object::gc_roots::push_roots();
         let pair_slot = pyre_object::gc_roots::shadow_stack_len();
-        pair_roots.pin_root(pyre_object::gc_roots::shadow_stack_get(unpacked + index));
+        let _ = pair_roots.pin_root(pyre_object::gc_roots::shadow_stack_get(unpacked + index));
         let Some(items) = trap(unpack_all(pyre_object::gc_roots::shadow_stack_get(
             pair_slot,
         ))) else {
@@ -851,7 +850,7 @@ pub unsafe extern "C" fn PyDict_Next(
 
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(dict);
+    let _ = roots.pin_root(dict);
 
     let snapshot = if index == 0 {
         let keys: Vec<PyObjectRef> = unsafe {
@@ -892,7 +891,7 @@ pub unsafe extern "C" fn PyDict_Next(
     // The lookup below can collect, so the key is pinned first and both it and
     // the value are read back from the shadow stack afterwards.
     let key_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_key);
+    let _ = roots.pin_root(w_key);
     let Some(w_value) = trap(crate::baseobjspace::getitem(
         pyre_object::gc_roots::shadow_stack_get(dict_slot),
         pyre_object::gc_roots::shadow_stack_get(key_slot),
@@ -900,7 +899,7 @@ pub unsafe extern "C" fn PyDict_Next(
         return 0;
     };
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_value);
+    let _ = roots.pin_root(w_value);
     unsafe { *pos = index + 1 };
     if !key.is_null() {
         unsafe {

--- a/pyre/pyre-interpreter/src/cpyext/import_.rs
+++ b/pyre/pyre-interpreter/src/cpyext/import_.rs
@@ -18,9 +18,9 @@ pub(super) fn import_module(name: &str) -> Result<PyObjectRef, crate::PyError> {
     // `__import__` is pinned before the name is built: minting the string
     // allocates, and a collection there would leave this a pre-move address.
     let import_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(import);
+    let import = roots.pin_root(import);
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(pyre_object::w_str_new(name));
+    let _ = roots.pin_root(pyre_object::w_str_new(name));
     // `__import__` answers with the top-level package, so the submodule is
     // read back out of `sys.modules` afterwards.
     crate::call::call_function_impl_result(
@@ -204,8 +204,8 @@ fn import_module_level(
     let import = crate::baseobjspace::getattr_str(builtins, "__import__")?;
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(import);
-    roots.pin_root(name);
+    let _ = roots.pin_root(import);
+    let _ = roots.pin_root(name);
     // Each default allocates, so every argument is on the stack before the
     // next one is built and all five are read back afterwards.
     for (raw, default) in [(globals, None), (locals, None), (fromlist, Some(()))] {
@@ -217,9 +217,9 @@ fn import_module_level(
         } else {
             pyre_object::w_none()
         };
-        roots.pin_root(value);
+        let _ = roots.pin_root(value);
     }
-    roots.pin_root(pyre_object::w_int_new(level));
+    let _ = roots.pin_root(pyre_object::w_int_new(level));
     let at = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     crate::call::call_function_impl_result(at(0), &[at(1), at(2), at(3), at(4), at(5)])
 }
@@ -241,7 +241,7 @@ pub unsafe extern "C" fn PyImport_AddModuleRef(name: *const c_char) -> *mut CPyO
     let roots = pyre_object::gc_roots::push_roots();
     let module = pyre_object::module::w_module_new(&name);
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(module);
+    let _ = roots.pin_root(module);
     crate::importing::set_sys_module(&name, pyre_object::gc_roots::shadow_stack_get(module_slot));
     pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(module_slot))
 }

--- a/pyre/pyre-interpreter/src/cpyext/iterator.rs
+++ b/pyre/pyre-interpreter/src/cpyext/iterator.rs
@@ -26,7 +26,7 @@ fn has_method(object: *mut CPyObject, name: &str) -> c_int {
 fn is_stop_iteration(error: &mut crate::PyError) -> bool {
     let roots = pyre_object::gc_roots::push_roots();
     let instance_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(error.to_exc_object());
+    let _ = roots.pin_root(error.to_exc_object());
     let Some(class) = crate::builtins::lookup_exc_class("StopIteration") else {
         return false;
     };
@@ -43,7 +43,7 @@ fn is_stop_iteration(error: &mut crate::PyError) -> bool {
 fn returned_value(error: &mut crate::PyError) -> Result<PyObjectRef, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let instance_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(error.to_exc_object());
+    let _ = roots.pin_root(error.to_exc_object());
     crate::baseobjspace::getattr_str(
         pyre_object::gc_roots::shadow_stack_get(instance_slot),
         "value",
@@ -179,8 +179,8 @@ pub unsafe extern "C" fn PyIter_Send(
     } else {
         let roots = pyre_object::gc_roots::push_roots();
         let base = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(w_iterator);
-        roots.pin_root(sent);
+        let _ = roots.pin_root(w_iterator);
+        let _ = roots.pin_root(sent);
         let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
         crate::baseobjspace::getattr_str(reload(0), "send")
             .and_then(|send| crate::call::call_function_impl_result(send, &[reload(1)]))

--- a/pyre/pyre-interpreter/src/cpyext/longobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/longobject.rs
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn PyLong_FromString(
     let text = raw.to_string_lossy().into_owned();
     let roots = pyre_object::gc_roots::push_roots();
     let source_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(pyre_object::w_str_new(&text));
+    let _ = roots.pin_root(pyre_object::w_str_new(&text));
     let parsed = crate::builtins::parse_int_from_str(
         pyre_object::gc_roots::shadow_stack_get(source_slot),
         &text,

--- a/pyre/pyre-interpreter/src/cpyext/methodobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/methodobject.rs
@@ -443,11 +443,11 @@ pub fn new_pycfunction_in_class(
 ) -> Result<PyObjectRef, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let self_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_self);
+    let _ = roots.pin_root(w_self);
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_module);
+    let _ = roots.pin_root(w_module);
     let class_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_class.unwrap_or_else(pyre_object::w_none));
+    let _ = roots.pin_root(w_class.unwrap_or_else(pyre_object::w_none));
     let carrier_type = if w_class.is_some() {
         pycmethod_type()
     } else {
@@ -455,7 +455,7 @@ pub fn new_pycfunction_in_class(
     };
     let carrier = pyre_object::w_instance_new(carrier_type);
     let carrier_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(carrier);
+    let _ = roots.pin_root(carrier);
 
     let name = text_or_none(unsafe { (*method).ml_name });
     carrier_set(

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -258,11 +258,10 @@ pub fn walk_gc_roots(visitor: &mut dyn FnMut(&mut PyObjectRef)) {
 fn module_from_cached_dict(name: &str, dict: PyObjectRef) -> PyObjectRef {
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(dict);
+    let _ = roots.pin_root(dict);
     let module = pyre_object::w_module_new_managed(name);
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(module);
-    let module = pyre_object::gc_roots::shadow_stack_get(module_slot);
+    let module = roots.pin_root(module);
     let module_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
     crate::type_methods::dict_update1(
         module_dict,
@@ -278,7 +277,7 @@ fn cached_extension(name: &str, path: &Path) -> Option<PyObjectRef> {
         let cache = EXTENSIONS.lock();
         let dict = cache.get(path)?.dict as PyObjectRef;
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(dict);
+        let _ = roots.pin_root(dict);
         slot
     };
     Some(module_from_cached_dict(
@@ -294,7 +293,7 @@ fn cached_extension_handle(path: &Path) -> Option<usize> {
 fn fixup_extension(module: PyObjectRef, name: &str, path: &Path, handle: usize) {
     let roots = pyre_object::gc_roots::push_roots();
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(module);
+    let module = roots.pin_root(module);
     crate::importing::set_sys_module(name, module);
     let module = pyre_object::gc_roots::shadow_stack_get(module_slot);
     let dict = unsafe { pyre_object::w_module_get_w_dict(module) };
@@ -323,9 +322,9 @@ fn init_symbol(name: &str) -> Result<String, crate::PyError> {
 fn extension_import_error(message: String, name: &str, path: &Path) -> crate::PyError {
     let roots = pyre_object::gc_roots::push_roots();
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(pyre_object::w_str_new(name));
+    let _ = roots.pin_root(pyre_object::w_str_new(name));
     let path_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(crate::gateway::fsdecode_os_str(path.as_os_str()));
+    let _ = roots.pin_root(crate::gateway::fsdecode_os_str(path.as_os_str()));
     crate::PyError::import_error_name_path(
         message,
         pyre_object::gc_roots::shadow_stack_get(name_slot),
@@ -374,7 +373,7 @@ pub fn load_extension_module(
         if let Some(module) = cached_extension(name, path) {
             let roots = pyre_object::gc_roots::push_roots();
             let module_slot = pyre_object::gc_roots::shadow_stack_len();
-            roots.pin_root(module);
+            let _ = roots.pin_root(module);
             crate::importing::set_sys_module(
                 name,
                 pyre_object::gc_roots::shadow_stack_get(module_slot),
@@ -430,7 +429,7 @@ pub fn load_extension_module(
     };
     let roots = pyre_object::gc_roots::push_roots();
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(init_result.module());
+    let _ = roots.pin_root(init_result.module());
     match init_result {
         // `create_cpyext_module` returns straight from the multi-phase branch:
         // the definition, not a copied dictionary, is what a later import
@@ -523,19 +522,19 @@ fn finish_init(
 pub fn create_dynamic(spec: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let spec_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(spec);
+    let _ = roots.pin_root(spec);
     let w_name = crate::baseobjspace::getattr_str(
         pyre_object::gc_roots::shadow_stack_get(spec_slot),
         "name",
     )?;
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_name);
+    let _ = roots.pin_root(w_name);
     let w_origin = crate::baseobjspace::getattr_str(
         pyre_object::gc_roots::shadow_stack_get(spec_slot),
         "origin",
     )?;
     let origin_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_origin);
+    let _ = roots.pin_root(w_origin);
     let name =
         crate::baseobjspace::text0_wtf8_w(pyre_object::gc_roots::shadow_stack_get(name_slot))?
             .to_string();
@@ -594,12 +593,12 @@ pub(super) fn call_cfunction_in_class(
     // the argument tuple, the keyword dict and the key strings all collect.
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_self);
+    let _ = roots.pin_root(w_self);
     for &argument in positional {
-        roots.pin_root(argument);
+        let _ = roots.pin_root(argument);
     }
     for (_, value) in keywords {
-        roots.pin_root(*value);
+        let _ = roots.pin_root(*value);
     }
     let value_slot = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + 1 + index);
 
@@ -622,11 +621,11 @@ pub(super) fn call_cfunction_in_class(
         let items: Vec<PyObjectRef> = (0..positional.len()).map(value_slot).collect();
         let tuple = pyre_object::tupleobject::w_tuple_new(items);
         let tuple_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(tuple);
+        let _ = roots.pin_root(tuple);
         if flags & METH_KEYWORDS != 0 && !keywords.is_empty() {
             let dict = pyre_object::dictmultiobject::w_dict_new();
             let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-            roots.pin_root(dict);
+            let _ = roots.pin_root(dict);
             for (index, (name, _)) in keywords.iter().enumerate() {
                 unsafe {
                     pyre_object::dictmultiobject::w_dict_setitem_str(
@@ -745,7 +744,7 @@ pub fn exec_dynamic(module: PyObjectRef) -> Result<PyObjectRef, crate::PyError> 
     let _load_guard = extension_load_lock();
     let roots = pyre_object::gc_roots::push_roots();
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(module);
+    let module = roots.pin_root(module);
     if unsafe { pyre_object::module::is_module(module) }
         && !modsupport::has_module_state(pyre_object::gc_roots::shadow_stack_get(module_slot))
     {

--- a/pyre/pyre-interpreter/src/cpyext/modsupport.rs
+++ b/pyre/pyre-interpreter/src/cpyext/modsupport.rs
@@ -148,9 +148,9 @@ fn convert_method_defs(
     }
     let roots = pyre_object::gc_roots::push_roots();
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(module);
+    let module = roots.pin_root(module);
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_module_name);
+    let _ = roots.pin_root(w_module_name);
     let mut index = 0isize;
     loop {
         let method = unsafe { methods.offset(index) };
@@ -170,7 +170,7 @@ fn convert_method_defs(
             pyre_object::gc_roots::shadow_stack_get(name_slot),
         )?;
         let function_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(function);
+        let _ = roots.pin_root(function);
         store(
             pyre_object::gc_roots::shadow_stack_get(module_slot),
             &name,
@@ -211,7 +211,7 @@ fn populate_module(
 ) -> Result<PyObjectRef, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(module);
+    let _ = roots.pin_root(module);
     let reload = |slot| pyre_object::gc_roots::shadow_stack_get(slot);
 
     set_field(reload(module_slot), |fields| fields.md_def = def as usize);
@@ -219,13 +219,13 @@ fn populate_module(
     if let Some(path) = path {
         let value = crate::gateway::fsdecode_os_str(path.as_os_str());
         let value_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(value);
+        let _ = roots.pin_root(value);
         store(reload(module_slot), "__file__", reload(value_slot));
     }
 
     let w_name = pyre_object::w_str_new(name);
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_name);
+    let _ = roots.pin_root(w_name);
     convert_method_defs(
         reload(module_slot),
         unsafe { (*def).m_methods },
@@ -236,7 +236,7 @@ fn populate_module(
     if !doc.is_empty() {
         let value = pyre_object::w_str_new(&doc);
         let value_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(value);
+        let _ = roots.pin_root(value);
         store(reload(module_slot), "__doc__", reload(value_slot));
     }
 
@@ -299,7 +299,7 @@ pub unsafe extern "C" fn PyModule_Create2(
     let module = pyre_object::w_module_new_managed(name);
     let roots = pyre_object::gc_roots::push_roots();
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(module);
+    let module = roots.pin_root(module);
     let Some(module) = trap(populate_module(
         pyre_object::gc_roots::shadow_stack_get(module_slot),
         def,
@@ -310,7 +310,7 @@ pub unsafe extern "C" fn PyModule_Create2(
     };
     if unsafe { (*def).m_size } > 0 {
         let module_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(module);
+        let _ = roots.pin_root(module);
         if trap(allocate_module_state(
             pyre_object::gc_roots::shadow_stack_get(module_slot),
             unsafe { (*def).m_size },
@@ -396,7 +396,7 @@ pub(super) fn create_module_from_def_and_spec(
 
     let roots = pyre_object::gc_roots::push_roots();
     let spec_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(spec);
+    let _ = roots.pin_root(spec);
     let module = if create.is_null() {
         pyre_object::w_module_new_managed(name)
     } else {
@@ -410,7 +410,7 @@ pub(super) fn create_module_from_def_and_spec(
         super::from_c_result(result)?
     };
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(module);
+    let module = roots.pin_root(module);
     if !unsafe { pyre_object::module::is_module(module) } {
         if unsafe { (*def).m_size } > 0
             || unsafe { !(*def).m_traverse.is_null() }
@@ -462,7 +462,7 @@ pub(super) fn exec_def(module: PyObjectRef) -> Result<(), crate::PyError> {
 fn exec_def_of(module: PyObjectRef, def: *mut CPyModuleDef) -> Result<(), crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(module);
+    let module = roots.pin_root(module);
     // The state block is allocated before the first slot runs, both because
     // `PyModule_GetState` is what an exec slot is there to fill and because its
     // address is the marker that keeps a second exec from running.
@@ -606,7 +606,7 @@ pub unsafe extern "C" fn PyModule_AddIntConstant(
     let key = text_or_empty(name);
     let roots = pyre_object::gc_roots::push_roots();
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(module);
+    let _ = roots.pin_root(module);
     let value = pyre_object::w_int_new(value as i64);
     store(
         pyre_object::gc_roots::shadow_stack_get(module_slot),
@@ -633,7 +633,7 @@ pub unsafe extern "C" fn PyModule_AddStringConstant(
     let text = text_or_empty(value);
     let roots = pyre_object::gc_roots::push_roots();
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(module);
+    let _ = roots.pin_root(module);
     let value = pyre_object::w_str_new(&text);
     store(
         pyre_object::gc_roots::shadow_stack_get(module_slot),
@@ -653,12 +653,12 @@ pub unsafe extern "C" fn PyModule_AddStringConstant(
 fn new_module(w_name: PyObjectRef) -> PyObjectRef {
     let roots = pyre_object::gc_roots::push_roots();
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_name);
+    let _ = roots.pin_root(w_name);
     // The empty name is the anonymous-module sentinel, so the name is attached
     // afterwards rather than through the allocation.
     let module = pyre_object::w_module_new_managed("");
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(module);
+    let _ = roots.pin_root(module);
     let reload = |slot| pyre_object::gc_roots::shadow_stack_get(slot);
     unsafe { pyre_object::w_module_set_name(reload(module_slot), reload(name_slot)) };
     store(reload(module_slot), "__name__", reload(name_slot));
@@ -818,7 +818,7 @@ pub unsafe extern "C" fn PyModule_SetDocString(
     let text = text_or_empty(doc);
     let roots = pyre_object::gc_roots::push_roots();
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(module);
+    let _ = roots.pin_root(module);
     let value = pyre_object::w_str_new(&text);
     store(
         pyre_object::gc_roots::shadow_stack_get(module_slot),
@@ -839,7 +839,7 @@ pub unsafe extern "C" fn PyModule_AddFunctions(
     };
     let roots = pyre_object::gc_roots::push_roots();
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(module);
+    let _ = roots.pin_root(module);
     let Some(name) = module_name_object(
         pyre_object::gc_roots::shadow_stack_get(module_slot),
         "PyModule_AddFunctions",
@@ -847,7 +847,7 @@ pub unsafe extern "C" fn PyModule_AddFunctions(
         return -1;
     };
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(name);
+    let _ = roots.pin_root(name);
     if trap(convert_method_defs(
         pyre_object::gc_roots::shadow_stack_get(module_slot),
         methods,
@@ -896,7 +896,7 @@ pub unsafe extern "C" fn PyModule_FromDefAndSpec2(
     };
     let roots = pyre_object::gc_roots::push_roots();
     let spec_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_spec);
+    let _ = roots.pin_root(w_spec);
     let Some(name) = trap(
         crate::baseobjspace::getattr_str(
             pyre_object::gc_roots::shadow_stack_get(spec_slot),

--- a/pyre/pyre-interpreter/src/cpyext/object.rs
+++ b/pyre/pyre-interpreter/src/cpyext/object.rs
@@ -107,17 +107,17 @@ pub(super) fn call_method(
 ) -> Result<PyObjectRef, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let object_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(object);
+    let _ = roots.pin_root(object);
     let first_argument = pyre_object::gc_roots::shadow_stack_len();
     for &argument in arguments {
-        roots.pin_root(argument);
+        let _ = roots.pin_root(argument);
     }
     let method = crate::baseobjspace::getattr_str(
         pyre_object::gc_roots::shadow_stack_get(object_slot),
         name,
     )?;
     let method_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(method);
+    let _ = roots.pin_root(method);
     let reloaded: Vec<PyObjectRef> = (0..arguments.len())
         .map(|index| pyre_object::gc_roots::shadow_stack_get(first_argument + index))
         .collect();
@@ -616,10 +616,10 @@ pub unsafe extern "C" fn PyObject_DelItemString(
     // shadow stack rather than from the pointer taken before it.
     let roots = pyre_object::gc_roots::push_roots();
     let object_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(object);
+    let _ = roots.pin_root(object);
     let w_key = pyre_object::w_str_new(&key);
     let key_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_key);
+    let _ = roots.pin_root(w_key);
     let outcome = crate::baseobjspace::delitem(
         pyre_object::gc_roots::shadow_stack_get(object_slot),
         pyre_object::gc_roots::shadow_stack_get(key_slot),
@@ -852,11 +852,11 @@ fn call_with_keywords(
 ) -> Result<PyObjectRef, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let callable_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(callable);
+    let _ = roots.pin_root(callable);
     let args_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(args);
+    let _ = roots.pin_root(args);
     let kwargs_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(kwargs);
+    let _ = roots.pin_root(kwargs);
     let arguments = unsafe {
         pyre_object::tupleobject::w_tuple_items_copy_as_vec(
             pyre_object::gc_roots::shadow_stack_get(args_slot),
@@ -958,7 +958,7 @@ fn file_descriptor_of(object: PyObjectRef) -> Result<c_int, crate::PyError> {
                 ));
             };
             let fileno_slot = pyre_object::gc_roots::shadow_stack_len();
-            roots.pin_root(fileno);
+            let _ = roots.pin_root(fileno);
             let answer = crate::call::call_function_impl_result(
                 pyre_object::gc_roots::shadow_stack_get(fileno_slot),
                 &[],
@@ -1397,7 +1397,7 @@ unsafe fn call_vector(
     // first: converting a mirror below can realize it, which allocates.
     let roots = pyre_object::gc_roots::push_roots();
     let callable_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(callable);
+    let _ = roots.pin_root(callable);
     let kwnames = unsafe { pyobject::from_ref(kwnames) };
     if !kwnames.is_null() && !unsafe { pyre_object::is_tuple(kwnames) } {
         return Err(crate::PyError::type_error(
@@ -1405,7 +1405,7 @@ unsafe fn call_vector(
         ));
     }
     let kwnames_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(kwnames);
+    let kwnames = roots.pin_root(kwnames);
     let named = if kwnames.is_null() {
         0
     } else {
@@ -1420,7 +1420,7 @@ unsafe fn call_vector(
                 "vectorcall argument vector holds a NULL",
             ));
         }
-        roots.pin_root(value);
+        let _ = roots.pin_root(value);
     }
     let value_at = |index: usize| pyre_object::gc_roots::shadow_stack_get(value_base + index);
 

--- a/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
@@ -202,9 +202,9 @@ exception_mirrors! {
 fn normalized(w_type: PyObjectRef, w_value: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let type_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_type);
+    let _ = roots.pin_root(w_type);
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_value);
+    let w_value = roots.pin_root(w_value);
     if !w_value.is_null()
         && unsafe { pyre_object::is_exception(w_value) }
         && crate::baseobjspace::isinstance(
@@ -683,7 +683,7 @@ fn set_import_error(
     let import_error = crate::builtins::lookup_exc_class("ImportError")?;
     let roots = pyre_object::gc_roots::push_roots();
     let class_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(class);
+    let class = roots.pin_root(class);
     if !trap(crate::baseobjspace::issubclass(class, import_error))? {
         set_pending_error(crate::PyError::type_error(
             "expected a subclass of ImportError",
@@ -791,12 +791,12 @@ pub unsafe extern "C" fn PyErr_NormalizeException(
     };
     let roots = pyre_object::gc_roots::push_roots();
     let instance_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(instance);
+    let instance = roots.pin_root(instance);
     let Some(w_class) = crate::typedef::r#type(instance) else {
         return;
     };
     let class_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_class.as_ptr());
+    let _ = roots.pin_root(w_class.as_ptr());
     let value_ref = pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(instance_slot));
     let type_ref = pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(class_slot));
     unsafe {
@@ -965,11 +965,11 @@ pub(super) fn ensure_linked() {
         };
         let roots = pyre_object::gc_roots::push_roots();
         let class_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(class);
+        let _ = roots.pin_root(class);
         let filename_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(unsafe { pyobject::from_ref(filename) });
+        let _ = roots.pin_root(unsafe { pyobject::from_ref(filename) });
         let second_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(unsafe { pyobject::from_ref(second_filename) });
+        let _ = roots.pin_root(unsafe { pyobject::from_ref(second_filename) });
 
         let mut arguments = vec![
             pyre_object::w_int_new(code as i64),

--- a/pyre/pyre-interpreter/src/cpyext/sequence.rs
+++ b/pyre/pyre-interpreter/src/cpyext/sequence.rs
@@ -146,9 +146,9 @@ fn index_of(object: PyObjectRef, value: PyObjectRef) -> Result<isize, crate::PyE
     // looks: the elements go on the shadow stack and are read back per turn.
     let roots = pyre_object::gc_roots::push_roots();
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(value);
+    let _ = roots.pin_root(value);
     let object_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(object);
+    let _ = roots.pin_root(object);
     let items = crate::baseobjspace::unpackiterable(
         pyre_object::gc_roots::shadow_stack_get(object_slot),
         -1,
@@ -252,9 +252,9 @@ fn count_of(object: PyObjectRef, value: PyObjectRef) -> Result<isize, crate::PyE
     // The same shadow-stack discipline as [`index_of`], for the same reason.
     let roots = pyre_object::gc_roots::push_roots();
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(value);
+    let _ = roots.pin_root(value);
     let object_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(object);
+    let _ = roots.pin_root(object);
     let items = crate::baseobjspace::unpackiterable(
         pyre_object::gc_roots::shadow_stack_get(object_slot),
         -1,

--- a/pyre/pyre-interpreter/src/cpyext/setobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/setobject.rs
@@ -17,14 +17,14 @@ fn method(
 ) -> Result<PyObjectRef, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(receiver);
+    let _ = roots.pin_root(receiver);
     for &argument in args {
-        roots.pin_root(argument);
+        let _ = roots.pin_root(argument);
     }
     let bound =
         crate::baseobjspace::getattr_str(pyre_object::gc_roots::shadow_stack_get(base), name)?;
     let bound_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(bound);
+    let _ = roots.pin_root(bound);
     let args: Vec<PyObjectRef> = (0..args.len())
         .map(|index| pyre_object::gc_roots::shadow_stack_get(base + 1 + index))
         .collect();
@@ -92,8 +92,8 @@ pub unsafe extern "C" fn PyFrozenSet_New(iterable: *mut CPyObject) -> *mut CPyOb
 fn add_frozen(set: PyObjectRef, key: PyObjectRef) -> Result<(), crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(set);
-    roots.pin_root(key);
+    let _ = roots.pin_root(set);
+    let _ = roots.pin_root(key);
     let hash = crate::builtins::try_hash_value(pyre_object::gc_roots::shadow_stack_get(base + 1))
         .map_err(|error| {
         crate::baseobjspace::wrap_set_element_hash_error(

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -617,10 +617,10 @@ fn new_carrier(
 ) -> PyObjectRef {
     let roots = pyre_object::gc_roots::push_roots();
     let class_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_class);
+    let _ = roots.pin_root(w_class);
     let carrier = pyre_object::w_instance_new(carrier_type);
     let carrier_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(carrier);
+    let _ = roots.pin_root(carrier);
     let reload = |slot| pyre_object::gc_roots::shadow_stack_get(slot);
 
     let w_name = text_or_none(name);
@@ -940,9 +940,9 @@ fn write_member(
     );
     let roots = pyre_object::gc_roots::push_roots();
     let self_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_self);
+    let _ = roots.pin_root(w_self);
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(value);
+    let _ = roots.pin_root(value);
     let number = if integer {
         crate::baseobjspace::gateway_int_w(pyre_object::gc_roots::shadow_stack_get(value_slot))?
     } else {
@@ -1068,9 +1068,9 @@ fn getset_descr_set(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     }
     let roots = pyre_object::gc_roots::push_roots();
     let self_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(args[1]);
+    let _ = roots.pin_root(args[1]);
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(args[2]);
+    let _ = roots.pin_root(args[2]);
     let receiver = pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(self_slot));
     let value = pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(value_slot));
     let result = unsafe {
@@ -1117,21 +1117,21 @@ fn ternary_args(positional: &[PyObjectRef], keywords: &[(String, PyObjectRef)]) 
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
     for &argument in positional {
-        roots.pin_root(argument);
+        let _ = roots.pin_root(argument);
     }
     for (_, value) in keywords {
-        roots.pin_root(*value);
+        let _ = roots.pin_root(*value);
     }
     let value_slot = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     let items: Vec<PyObjectRef> = (0..positional.len()).map(value_slot).collect();
     let tuple = pyre_object::tupleobject::w_tuple_new(items);
     let tuple_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(tuple);
+    let _ = roots.pin_root(tuple);
     let mut keywords_arg = std::ptr::null_mut();
     if !keywords.is_empty() {
         let dict = pyre_object::dictmultiobject::w_dict_new();
         let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(dict);
+        let _ = roots.pin_root(dict);
         for (index, (name, _)) in keywords.iter().enumerate() {
             unsafe {
                 pyre_object::dictmultiobject::w_dict_setitem_str(
@@ -1362,9 +1362,9 @@ fn rich_compare(args: &[PyObjectRef], operation: c_int) -> Result<PyObjectRef, c
     }
     let roots = pyre_object::gc_roots::push_roots();
     let self_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_self);
+    let _ = roots.pin_root(w_self);
     let other_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(args[1]);
+    let _ = roots.pin_root(args[1]);
     let receiver = pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(self_slot));
     let other = pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(other_slot));
     let result = unsafe {
@@ -1463,9 +1463,9 @@ fn call_binary(
 ) -> Result<PyObjectRef, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let first_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(first);
+    let _ = roots.pin_root(first);
     let second_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(second);
+    let _ = roots.pin_root(second);
     let left = pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(first_slot));
     let right = pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(second_slot));
     let result = unsafe {
@@ -1653,9 +1653,9 @@ fn power(args: &[PyObjectRef], reflected: bool) -> Result<PyObjectRef, crate::Py
     let modulus = args.get(2).copied().unwrap_or_else(pyre_object::w_none);
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(first);
-    roots.pin_root(second);
-    roots.pin_root(modulus);
+    let _ = roots.pin_root(first);
+    let _ = roots.pin_root(second);
+    let _ = roots.pin_root(modulus);
     let owned =
         |index: usize| pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(base + index));
     let (left, right, third) = (owned(0), owned(1), owned(2));
@@ -1701,9 +1701,9 @@ fn call_ternary(
 ) -> Result<PyObjectRef, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(first);
-    roots.pin_root(second);
-    roots.pin_root(third.unwrap_or_else(pyre_object::w_none));
+    let _ = roots.pin_root(first);
+    let _ = roots.pin_root(second);
+    let _ = roots.pin_root(third.unwrap_or_else(pyre_object::w_none));
     let owned =
         |index: usize| pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(base + index));
     let (left, right, modulus) = (owned(0), owned(1), owned(2));
@@ -1793,9 +1793,9 @@ fn slot_getitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
     let roots = pyre_object::gc_roots::push_roots();
     let self_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_self);
+    let _ = roots.pin_root(w_self);
     let key_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(args[1]);
+    let _ = roots.pin_root(args[1]);
     let index = sequence_index(
         pyre_object::gc_roots::shadow_stack_get(self_slot),
         pyre_object::gc_roots::shadow_stack_get(key_slot),
@@ -1818,11 +1818,11 @@ fn assign_item(
 ) -> Result<PyObjectRef, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let self_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_self);
+    let _ = roots.pin_root(w_self);
     let key_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(key);
+    let _ = roots.pin_root(key);
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(value.unwrap_or_else(pyre_object::w_none));
+    let _ = roots.pin_root(value.unwrap_or_else(pyre_object::w_none));
     let reload = |slot| pyre_object::gc_roots::shadow_stack_get(slot);
 
     let subscript = slot_of(reload(self_slot), mapping_slot!(mp_ass_subscript));
@@ -1896,9 +1896,9 @@ fn slot_contains(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
     let roots = pyre_object::gc_roots::push_roots();
     let self_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(args[0]);
+    let _ = roots.pin_root(args[0]);
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(args[1]);
+    let _ = roots.pin_root(args[1]);
     let receiver = pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(self_slot));
     let value = pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(value_slot));
     let result = unsafe {
@@ -1940,9 +1940,9 @@ fn repeat(
     }
     let roots = pyre_object::gc_roots::push_roots();
     let self_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_self);
+    let _ = roots.pin_root(w_self);
     let count_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(count);
+    let _ = roots.pin_root(count);
     let times =
         crate::baseobjspace::getindex_w(pyre_object::gc_roots::shadow_stack_get(count_slot))?;
     let receiver = pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(self_slot));
@@ -2132,7 +2132,7 @@ fn inherit_slots(tp: *mut CPyTypeObject, base: *mut CPyTypeObject) {
 fn install_namespace(ns: PyObjectRef, tp: *mut CPyTypeObject) {
     let roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(ns);
+    let _ = roots.pin_root(ns);
     let reload = || pyre_object::gc_roots::shadow_stack_get(ns_slot);
 
     if unsafe { !(*tp).tp_doc.is_null() } {
@@ -2157,7 +2157,7 @@ fn install_namespace(ns: PyObjectRef, tp: *mut CPyTypeObject) {
             pyre_object::PY_NULL,
         );
         let descriptor_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(descriptor);
+        let _ = roots.pin_root(descriptor);
         store(
             reload(),
             &name,
@@ -2182,7 +2182,7 @@ fn install_namespace(ns: PyObjectRef, tp: *mut CPyTypeObject) {
             pyre_object::PY_NULL,
         );
         let descriptor_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(descriptor);
+        let _ = roots.pin_root(descriptor);
         store(
             reload(),
             &name,
@@ -2206,7 +2206,7 @@ fn install_namespace(ns: PyObjectRef, tp: *mut CPyTypeObject) {
             pyre_object::PY_NULL,
         );
         let descriptor_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(descriptor);
+        let _ = roots.pin_root(descriptor);
         store(
             reload(),
             &name,
@@ -2347,9 +2347,9 @@ fn set_attribute(
     }
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_self);
-    roots.pin_root(name);
-    roots.pin_root(value.unwrap_or_else(pyre_object::w_none));
+    let _ = roots.pin_root(w_self);
+    let _ = roots.pin_root(name);
+    let _ = roots.pin_root(value.unwrap_or_else(pyre_object::w_none));
     let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     let receiver = pyobject::make_ref(reload(0));
     let key = pyobject::make_ref(reload(1));
@@ -2391,9 +2391,9 @@ fn slot_descr_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(args[0]);
-    roots.pin_root(args[1]);
-    roots.pin_root(args[2]);
+    let _ = roots.pin_root(args[0]);
+    let _ = roots.pin_root(args[1]);
+    let _ = roots.pin_root(args[2]);
     let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     let none = |value: PyObjectRef| unsafe { pyre_object::is_none(value) };
     let descriptor = pyobject::make_ref(reload(0));
@@ -2436,9 +2436,9 @@ fn descr_assign(
     }
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(descriptor);
-    roots.pin_root(instance);
-    roots.pin_root(value.unwrap_or_else(pyre_object::w_none));
+    let descriptor = roots.pin_root(descriptor);
+    let _ = roots.pin_root(instance);
+    let _ = roots.pin_root(value.unwrap_or_else(pyre_object::w_none));
     let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     let owner = pyobject::make_ref(reload(0));
     let target = pyobject::make_ref(reload(1));
@@ -2479,7 +2479,7 @@ fn slot_descr_delete(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
 fn stamp_objclass(w_type: PyObjectRef, tp: *mut CPyTypeObject) {
     let roots = pyre_object::gc_roots::push_roots();
     let type_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_type);
+    let w_type = roots.pin_root(w_type);
     let mut names: Vec<String> = Vec::new();
     let mut collect = |mut next: Box<dyn FnMut(isize) -> *const c_char>| {
         let mut index = 0isize;
@@ -2597,7 +2597,7 @@ fn ready(tp: *mut CPyTypeObject) -> Result<(), crate::PyError> {
 
     let roots = pyre_object::gc_roots::push_roots();
     let base_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_base);
+    let _ = roots.pin_root(w_base);
     let w_type = crate::typedef::make_builtin_type_with_base(
         &qualified,
         |ns| install_namespace(ns, tp),
@@ -2612,7 +2612,7 @@ fn ready(tp: *mut CPyTypeObject) -> Result<(), crate::PyError> {
         );
     }
     let type_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_type);
+    let _ = roots.pin_root(w_type);
     unsafe {
         pyre_object::typeobject::w_type_set_hasdict(
             pyre_object::gc_roots::shadow_stack_get(type_slot),
@@ -3226,10 +3226,10 @@ pub unsafe extern "C" fn PyType_GenericAlloc(
     }
     let roots = pyre_object::gc_roots::push_roots();
     let type_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_type);
+    let _ = roots.pin_root(w_type);
     let instance = pyre_object::w_instance_new(pyre_object::gc_roots::shadow_stack_get(type_slot));
     let instance_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(instance);
+    let _ = roots.pin_root(instance);
     let size = unsafe { (*tp).tp_basicsize + nitems.max(0) * (*tp).tp_itemsize } as usize;
     // `tp_alloc` returns a new reference, so the count is the link share plus
     // the one this call hands out.  Not immortal: the link is a rawrefcount
@@ -3309,7 +3309,7 @@ pub unsafe extern "C" fn PyObject_Init(
     }
     let roots = pyre_object::gc_roots::push_roots();
     let type_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_type);
+    let _ = roots.pin_root(w_type);
     let instance = pyre_object::w_instance_new(pyre_object::gc_roots::shadow_stack_get(type_slot));
     pyobject::link_allocated(instance, object, REFCNT_FROM_PYRE + 1);
     object
@@ -3701,13 +3701,13 @@ fn new_exception(
 
     let roots = pyre_object::gc_roots::push_roots();
     let base_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(if w_base.is_null() {
+    let _ = roots.pin_root(if w_base.is_null() {
         crate::builtins::lookup_exc_class("Exception").unwrap_or(pyre_object::PY_NULL)
     } else {
         w_base
     });
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(if w_dict.is_null() {
+    let _ = roots.pin_root(if w_dict.is_null() {
         pyre_object::dictmultiobject::w_dict_new()
     } else {
         w_dict
@@ -3722,10 +3722,10 @@ fn new_exception(
     }
     let bases = pyre_object::tupleobject::w_tuple_new(vec![reload(base_slot)]);
     let bases_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(bases);
+    let _ = roots.pin_root(bases);
     let w_name = pyre_object::w_str_new(short);
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(w_name);
+    let _ = roots.pin_root(w_name);
     let w_type = crate::typedef::gettypeobject(&pyre_object::TYPE_TYPE);
     crate::call::call_function_impl_result(
         w_type,

--- a/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
@@ -345,7 +345,7 @@ pub(super) fn realize_pending(raw: *mut CPyObject) {
     // deallocator takes this lock.
     let roots = pyre_object::gc_roots::push_roots();
     let slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(pyre_object::w_str_from_wtf8_managed(text));
+    let _ = roots.pin_root(pyre_object::w_str_from_wtf8_managed(text));
     let refcnt = unsafe { (*raw).ob_refcnt };
     pyobject::link_allocated(
         pyre_object::gc_roots::shadow_stack_get(slot),

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -46,7 +46,7 @@ pub(crate) unsafe fn try_call_dunder_obj(
         // the descriptor rejects that as an instance of the wrong type.
         let _roots = pyre_object::gc_roots::push_roots();
         let root_base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         let obj = || pyre_object::gc_roots::shadow_stack_get(root_base);
         let Some(method) = crate::baseobjspace::lookup(obj(), name) else {
             return Ok(None);
@@ -54,7 +54,7 @@ pub(crate) unsafe fn try_call_dunder_obj(
         if method.is_null() {
             return Ok(None);
         }
-        pyre_object::gc_roots::pin_root(method);
+        let _ = pyre_object::gc_roots::pin_root(method);
         let method = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
         // A raising `__repr__`/`__str__` propagates; a non-string return is a
         // TypeError (`object.c slot_tp_repr` / `slot_tp_str`).
@@ -81,7 +81,7 @@ pub(crate) unsafe fn try_call_dunder_obj_above_object(
         // Published across the allocating MRO walk, as in `try_call_dunder_obj`.
         let _roots = pyre_object::gc_roots::push_roots();
         let root_base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         let obj = || pyre_object::gc_roots::shadow_stack_get(root_base);
         let Some((src, method)) =
             crate::baseobjspace::lookup_where_with_method_cache(w_type.as_ptr(), name)
@@ -91,7 +91,7 @@ pub(crate) unsafe fn try_call_dunder_obj_above_object(
         if method.is_null() || std::ptr::eq(src, crate::typedef::w_object()) {
             return Ok(None);
         }
-        pyre_object::gc_roots::pin_root(method);
+        let _ = pyre_object::gc_roots::pin_root(method);
         let method = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
         let result =
             crate::baseobjspace::get_and_call_function(method(), obj(), w_type.as_ptr(), &[])?;
@@ -333,7 +333,7 @@ pub unsafe fn list_repr(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     // walk; re-read it from the shadow stack before every element fetch.
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
     let n = pyre_object::w_list_len(obj());
     let mut out = Wtf8Buf::new();
@@ -368,7 +368,7 @@ pub unsafe fn tuple_repr(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     // Same as `list_repr`: an item's `__repr__` moves the tuple under the walk.
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
     let n = pyre_object::w_tuple_len(obj());
     let mut out = Wtf8Buf::new();
@@ -501,7 +501,7 @@ pub(crate) unsafe fn builtin_subclass_dunder_obj(
         // Published across the allocating MRO walk, as in `try_call_dunder_obj`.
         let _roots = pyre_object::gc_roots::push_roots();
         let root_base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         let obj = || pyre_object::gc_roots::shadow_stack_get(root_base);
         let Some((src, found)) = crate::baseobjspace::lookup_where_with_method_cache(w_class, name)
         else {
@@ -517,7 +517,7 @@ pub(crate) unsafe fn builtin_subclass_dunder_obj(
         if std::ptr::eq(src, w_object) {
             return Ok(None);
         }
-        pyre_object::gc_roots::pin_root(found);
+        let _ = pyre_object::gc_roots::pin_root(found);
         let found = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
         // A raising override propagates; a non-string return is a TypeError.
         let r = crate::builtins::call_and_check(found(), &[obj()])?;
@@ -551,7 +551,7 @@ pub(crate) unsafe fn type_metaclass_dunder_obj(
         // Published across the allocating MRO walk, as in `try_call_dunder_obj`.
         let _roots = pyre_object::gc_roots::push_roots();
         let root_base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         let obj = || pyre_object::gc_roots::shadow_stack_get(root_base);
         let Some((src, method)) =
             crate::baseobjspace::lookup_where_with_method_cache(metaclass.as_ptr(), name)
@@ -563,7 +563,7 @@ pub(crate) unsafe fn type_metaclass_dunder_obj(
         {
             return Ok(None);
         }
-        pyre_object::gc_roots::pin_root(method);
+        let _ = pyre_object::gc_roots::pin_root(method);
         let method = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
         let result = crate::builtins::call_and_check(method(), &[obj()])?;
         if pyre_object::is_str(result) {
@@ -598,7 +598,7 @@ pub(crate) unsafe fn exc_user_dunder_obj(
         // Published across the allocating MRO walk, as in `try_call_dunder_obj`.
         let _roots = pyre_object::gc_roots::push_roots();
         let root_base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         let obj = || pyre_object::gc_roots::shadow_stack_get(root_base);
         let Some((src, method)) =
             crate::baseobjspace::lookup_where_with_method_cache(w_class, name)
@@ -622,7 +622,7 @@ pub(crate) unsafe fn exc_user_dunder_obj(
         {
             return Ok(None);
         }
-        pyre_object::gc_roots::pin_root(method);
+        let _ = pyre_object::gc_roots::pin_root(method);
         let method = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
         let r = crate::builtins::call_and_check(method(), &[obj()])?;
         if pyre_object::is_str(r) {
@@ -655,7 +655,7 @@ unsafe fn module_user_dunder_obj(
         // Published across the allocating MRO walk, as in `try_call_dunder_obj`.
         let _roots = pyre_object::gc_roots::push_roots();
         let root_base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         let obj = || pyre_object::gc_roots::shadow_stack_get(root_base);
         let Some((src, method)) =
             crate::baseobjspace::lookup_where_with_method_cache(w_class, name)
@@ -668,7 +668,7 @@ unsafe fn module_user_dunder_obj(
         {
             return Ok(None);
         }
-        pyre_object::gc_roots::pin_root(method);
+        let _ = pyre_object::gc_roots::pin_root(method);
         let method = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
         let r = crate::builtins::call_and_check(method(), &[obj()])?;
         if pyre_object::is_str(r) {
@@ -715,7 +715,7 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
         // a static type, so it survives the moves the object itself makes.
         let _roots = pyre_object::gc_roots::push_roots();
         let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         let mut obj = obj;
         let tp = (*obj).ob_type;
         // A builtin leaf subclass keeps `ob_type` at the canonical storage
@@ -956,7 +956,7 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
                 // read back through the pinned tuple.
                 let _args_roots = pyre_object::gc_roots::push_roots();
                 let args_slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(args_obj);
+                let _ = pyre_object::gc_roots::pin_root(args_obj);
                 let args_obj = || pyre_object::gc_roots::shadow_stack_get(args_slot);
                 let n = pyre_object::w_tuple_len(args_obj());
                 if n == 1 {
@@ -1866,7 +1866,7 @@ fn unicode_err_end_minus_one_repr(slot: &Result<i64, Wtf8Buf>) -> Wtf8Buf {
 unsafe fn unicode_translate_error_str(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(obj);
+        let obj = pyre_object::gc_roots::pin_root(obj);
         let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let initial = pyre_object::interp_exceptions::w_exception_get_object(obj);
         if initial.is_null() || pyre_object::is_none(initial) {
@@ -1971,7 +1971,7 @@ unsafe fn unicode_translate_error_str(obj: PyObjectRef) -> Result<Wtf8Buf, crate
 unsafe fn unicode_decode_error_str(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(obj);
+        let obj = pyre_object::gc_roots::pin_root(obj);
         let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let initial = pyre_object::interp_exceptions::w_exception_get_object(obj);
         if initial.is_null() || pyre_object::is_none(initial) {
@@ -2048,7 +2048,7 @@ unsafe fn unicode_decode_error_str(obj: PyObjectRef) -> Result<Wtf8Buf, crate::P
 unsafe fn unicode_encode_error_str(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(obj);
+        let obj = pyre_object::gc_roots::pin_root(obj);
         let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let initial = pyre_object::interp_exceptions::w_exception_get_object(obj);
         if initial.is_null() || pyre_object::is_none(initial) {

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -3008,7 +3008,7 @@ fn write_traceback_chain_from_tb<W: Write>(
     let mut repeats: usize = 0;
     while !tb.is_null() {
         let tb_slot = pyre_object::gc_roots::shadow_stack_len();
-        let mut tb = pyre_object::gc_roots::pin_root(tb);
+        tb = pyre_object::gc_roots::pin_root(tb);
         let current_tb = pyre_object::gc_roots::shadow_stack_get(tb_slot);
         if !unsafe { crate::pytraceback::is_pytraceback(current_tb) } {
             break;

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -679,11 +679,11 @@ impl PyError {
             None
         } else {
             let slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(self.exc_object);
+            let _ = pyre_object::gc_roots::pin_root(self.exc_object);
             Some(slot)
         };
         let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_obj);
+        let _ = pyre_object::gc_roots::pin_root(w_obj);
         let w_name = pyre_object::w_str_new(name);
         if let Some(slot) = exc_slot {
             self.exc_object = pyre_object::gc_roots::shadow_stack_get(slot);
@@ -3624,7 +3624,7 @@ fn expected_fmt_arg(format: char) -> &'static str {
 fn format_obj_as_utf8(obj: PyObjectRef, format: char) -> Wtf8Buf {
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = _roots.base();
-    _roots.pin_root(obj);
+    let _ = _roots.pin_root(obj);
     let obj = || _roots.get(obj_slot);
 
     let (rendered, fallback) = if format == 'R' {

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -742,7 +742,7 @@ impl PyError {
         let _roots = pyre_object::gc_roots::push_roots();
         let exc = w_exception_new_wtf8(ExcKind::SyntaxError, &message);
         let exc_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(exc);
+        let _ = pyre_object::gc_roots::pin_root(exc);
         // Build the `(filename, lineno, offset, text, end_lineno, end_offset)`
         // details tuple element by element. Each is pinned as it is created and
         // reloaded before the tuple is assembled: an int / str allocation for a
@@ -750,24 +750,25 @@ impl PyError {
         // young element (the filename or text string, or an uncached line/col
         // int), leaving its raw local pointing at the old address.
         let filename_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8(filename.to_wtf8_buf()));
+        let _ =
+            pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8(filename.to_wtf8_buf()));
         let lineno_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(pyre_object::w_int_new(lineno));
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(lineno));
         let offset_slot = pyre_object::gc_roots::shadow_stack_len();
         // CPython 3.14 keeps the start offset numeric even for the tokenizer's
         // two sentinel values: 0 for an encoding-cookie range beginning
         // before the first character, and -1 for a location-less codec
         // failure.  Only absent *end* positions use `None` below.
-        pyre_object::gc_roots::pin_root(pyre_object::w_int_new(offset));
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(offset));
         let text_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(match text {
+        let _ = pyre_object::gc_roots::pin_root(match text {
             Some(t) => pyre_object::w_str_new(t),
             None => pyre_object::w_none(),
         });
         let end_lineno_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(wrap_pos(end_lineno));
+        let _ = pyre_object::gc_roots::pin_root(wrap_pos(end_lineno));
         let end_offset_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(wrap_pos(end_offset));
+        let _ = pyre_object::gc_roots::pin_root(wrap_pos(end_offset));
         let rooted_exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
         unsafe {
             pyre_object::interp_exceptions::w_exception_set_syntax_filename(
@@ -806,10 +807,10 @@ impl PyError {
         // Root the details tuple across the message allocation below before it
         // becomes `args[1]`.
         let details_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(details);
+        let _ = pyre_object::gc_roots::pin_root(details);
         let w_msg = pyre_object::w_str_from_wtf8(message.clone());
         let msg_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_msg);
+        let _ = pyre_object::gc_roots::pin_root(w_msg);
         unsafe {
             pyre_object::interp_exceptions::w_exception_set_syntax_msg(
                 pyre_object::gc_roots::shadow_stack_get(exc_slot),
@@ -855,8 +856,8 @@ impl PyError {
         }
         let _roots = pyre_object::gc_roots::push_roots();
         let base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(self.exc_object);
-        pyre_object::gc_roots::pin_root(w_filename);
+        let _ = pyre_object::gc_roots::pin_root(self.exc_object);
+        let _ = pyre_object::gc_roots::pin_root(w_filename);
         let storage = unsafe {
             pyre_object::interp_exceptions::w_exception_get_args_storage(
                 pyre_object::gc_roots::shadow_stack_get(base),
@@ -874,12 +875,12 @@ impl PyError {
         if unsafe { !pyre_object::is_tuple(details) || pyre_object::w_tuple_len(details) < 6 } {
             return;
         }
-        pyre_object::gc_roots::pin_root(w_msg);
+        let _ = pyre_object::gc_roots::pin_root(w_msg);
         for index in 1..6 {
             let Some(item) = (unsafe { pyre_object::w_tuple_getitem(details, index) }) else {
                 return;
             };
-            pyre_object::gc_roots::pin_root(item);
+            let _ = pyre_object::gc_roots::pin_root(item);
         }
         let rebuilt_details = pyre_object::w_tuple_new(vec![
             pyre_object::gc_roots::shadow_stack_get(base + 1),
@@ -889,7 +890,7 @@ impl PyError {
             pyre_object::gc_roots::shadow_stack_get(base + 6),
             pyre_object::gc_roots::shadow_stack_get(base + 7),
         ]);
-        pyre_object::gc_roots::pin_root(rebuilt_details);
+        let _ = pyre_object::gc_roots::pin_root(rebuilt_details);
         let rebuilt_args = pyre_object::interp_exceptions::w_exception_args_new(vec![
             pyre_object::gc_roots::shadow_stack_get(base + 2),
             pyre_object::gc_roots::shadow_stack_get(base + 8),
@@ -987,7 +988,7 @@ impl PyError {
         let _roots = pyre_object::gc_roots::push_roots();
         let key_slot = pyre_object::gc_roots::shadow_stack_len();
         if !key.is_null() {
-            pyre_object::gc_roots::pin_root(key);
+            let _ = pyre_object::gc_roots::pin_root(key);
         }
         let message = if key.is_null() {
             Wtf8Buf::from_string("<null>".to_string())
@@ -996,7 +997,7 @@ impl PyError {
                 .unwrap_or_else(|_| Wtf8Buf::from_string("<unrepresentable>".to_string()))
         };
         let exc = w_exception_new_wtf8(ExcKind::KeyError, &message);
-        pyre_object::gc_roots::pin_root(exc);
+        let exc = pyre_object::gc_roots::pin_root(exc);
         if !key.is_null() {
             // Reload the key after the repr / exception allocations: the pin
             // keeps it alive, but a minor collection may have relocated the
@@ -1142,13 +1143,13 @@ impl PyError {
                 return None;
             }
             let slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             Some(slot)
         };
         let filename_slot = pin(w_filename);
         let filename2_slot = pin(w_filename2);
         let exc = w_exception_new(exc_kind, &message);
-        pyre_object::gc_roots::pin_root(exc);
+        let exc = pyre_object::gc_roots::pin_root(exc);
         // Retag to the errno subclass through `w_class`, like
         // `os_error_family_new`: the subclasses share OSError's layout, so
         // the ExcKind stays OSError and only the class differs.
@@ -1227,7 +1228,7 @@ impl PyError {
         // exception before `w_exception_set_args` writes through it.
         let _roots = pyre_object::gc_roots::push_roots();
         let exc = w_exception_new(exc_kind, &strerror);
-        pyre_object::gc_roots::pin_root(exc);
+        let exc = pyre_object::gc_roots::pin_root(exc);
         let args_list = pyre_object::interp_exceptions::w_exception_args_new(vec![
             pyre_object::w_int_new(errno as i64),
             pyre_object::w_str_new(&strerror),
@@ -1277,7 +1278,7 @@ impl PyError {
         // exception before `w_exception_set_args` writes through it.
         let _roots = pyre_object::gc_roots::push_roots();
         let exc = w_exception_new_wtf8(exc_kind, &message);
-        pyre_object::gc_roots::pin_root(exc);
+        let exc = pyre_object::gc_roots::pin_root(exc);
         if let Some(w_target) = subclass.and_then(crate::builtins::lookup_exc_class) {
             unsafe {
                 (*(exc as *mut pyre_object::PyObject)).w_class = w_target;
@@ -1328,14 +1329,14 @@ impl PyError {
         let _roots = pyre_object::gc_roots::push_roots();
         let name_slot = pyre_object::gc_roots::shadow_stack_len();
         if !w_name.is_null() {
-            pyre_object::gc_roots::pin_root(w_name);
+            let _ = pyre_object::gc_roots::pin_root(w_name);
         }
         let path_slot = pyre_object::gc_roots::shadow_stack_len();
         if !w_path.is_null() {
-            pyre_object::gc_roots::pin_root(w_path);
+            let _ = pyre_object::gc_roots::pin_root(w_path);
         }
         let exc = w_exception_new_wtf8(ExcKind::ImportError, &message);
-        pyre_object::gc_roots::pin_root(exc);
+        let exc = pyre_object::gc_roots::pin_root(exc);
         // `ImportError.__init__` mirrors args[0] into the dedicated `msg`
         // slot; the prebuilt-instance path bypasses it, so stamp it here.
         let w_msg = if message.is_empty() {
@@ -1426,11 +1427,11 @@ impl PyError {
         let _roots = pyre_object::gc_roots::push_roots();
         let name_ctx_slot = pyre_object::gc_roots::shadow_stack_len();
         if !self.w_name_context.is_null() {
-            pyre_object::gc_roots::pin_root(self.w_name_context);
+            let _ = pyre_object::gc_roots::pin_root(self.w_name_context);
         }
         let obj_ctx_slot = pyre_object::gc_roots::shadow_stack_len();
         if !self.w_obj_context.is_null() {
-            pyre_object::gc_roots::pin_root(self.w_obj_context);
+            let _ = pyre_object::gc_roots::pin_root(self.w_obj_context);
         }
         // `w_exception_new_empty`, not `w_exception_new`: the message block
         // below builds `args_w` itself (it must keep the message object in a
@@ -1442,11 +1443,11 @@ impl PyError {
         // below: `exc` lives only in this Rust local while `w_list_new` (and the
         // setters) run, so a collection there could sweep the unrooted
         // (non-moving oldgen) exception before it is written through.
-        pyre_object::gc_roots::pin_root(exc);
+        let exc = pyre_object::gc_roots::pin_root(exc);
         if !self.message.is_empty() {
             let msg_slot = pyre_object::gc_roots::shadow_stack_len();
             let msg = pyre_object::w_str_from_wtf8(self.message.clone());
-            pyre_object::gc_roots::pin_root(msg);
+            let msg = pyre_object::gc_roots::pin_root(msg);
             let args_list = pyre_object::interp_exceptions::w_exception_args_new(vec![msg]);
             unsafe { pyre_object::interp_exceptions::w_exception_set_args(exc, args_list) };
             // `ImportError` / `ModuleNotFoundError` expose the message through a
@@ -1992,7 +1993,7 @@ pub fn write_exception<W: Write>(
         // rather than re-deriving a flat header here.
         let _roots = pyre_object::gc_roots::push_roots();
         let exc_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(err.exc_object);
+        let _ = pyre_object::gc_roots::pin_root(err.exc_object);
         let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
         let mut context = ExceptionPrintContext::new(exc);
         return write_exception_object_recursive(writer, exc, &mut context);
@@ -2019,9 +2020,9 @@ pub fn write_exception_from_parts<W: Write>(
 ) -> std::io::Result<()> {
     let _roots = pyre_object::gc_roots::push_roots();
     let exc_value_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(exc_value);
+    let _ = pyre_object::gc_roots::pin_root(exc_value);
     let exc_tb_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(exc_tb);
+    let _ = pyre_object::gc_roots::pin_root(exc_tb);
     let exc_value = pyre_object::gc_roots::shadow_stack_get(exc_value_slot);
     if exc_value.is_null() || !unsafe { pyre_object::is_exception(exc_value) } {
         if !exc_value.is_null() && unsafe { pyre_object::is_none(exc_value) } {
@@ -2076,7 +2077,7 @@ pub fn write_syntax_error<W: Write>(writer: &mut W, err: &PyError) -> std::io::R
 fn write_syntax_error_object<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io::Result<()> {
     let _roots = pyre_object::gc_roots::push_roots();
     let exc_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(exc);
+    let exc = pyre_object::gc_roots::pin_root(exc);
     let attr = |name: &str| {
         let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
         crate::baseobjspace::syntax_error_attr(exc, name)
@@ -2194,7 +2195,7 @@ fn write_exception_object_recursive<W: Write>(
     // GC pointers: formatting calls arbitrary `__str__` / attribute code.
     let _roots = pyre_object::gc_roots::push_roots();
     let first_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(exc);
+    let _ = pyre_object::gc_roots::pin_root(exc);
     let mut chain: Vec<(usize, Option<&'static str>)> = Vec::new();
     let mut current_slot = first_slot;
     loop {
@@ -2256,8 +2257,7 @@ fn pin_unseen_exception(
         return None;
     }
     let slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(candidate);
-    let candidate = pyre_object::gc_roots::shadow_stack_get(slot);
+    let candidate = pyre_object::gc_roots::pin_root(candidate);
     let identity = pyre_object::gc_hook::gc_identity_hash(candidate as usize);
     context.seen.insert(identity).then_some(slot)
 }
@@ -2296,8 +2296,7 @@ fn exception_group_item_slots(exc_slot: usize) -> Option<Vec<usize>> {
     let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
     let exceptions = crate::baseobjspace::getattr_str(exc, "exceptions").ok()?;
     let tuple_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(exceptions);
-    let exceptions = pyre_object::gc_roots::shadow_stack_get(tuple_slot);
+    let exceptions = pyre_object::gc_roots::pin_root(exceptions);
     if !unsafe { pyre_object::is_tuple(exceptions) } {
         return None;
     }
@@ -2307,7 +2306,7 @@ fn exception_group_item_slots(exc_slot: usize) -> Option<Vec<usize>> {
         let exceptions = pyre_object::gc_roots::shadow_stack_get(tuple_slot);
         let child = unsafe { pyre_object::w_tuple_getitem(exceptions, index as i64) }?;
         let child_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(child);
+        let _ = pyre_object::gc_roots::pin_root(child);
         slots.push(child_slot);
     }
     Some(slots)
@@ -2506,8 +2505,7 @@ fn write_exception_notes<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io:
     }
     let _roots = pyre_object::gc_roots::push_roots();
     let exc_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(exc);
-    let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
+    let exc = pyre_object::gc_roots::pin_root(exc);
     let notes = match crate::baseobjspace::getattr_str(exc, "__notes__") {
         Ok(v) if !v.is_null() => v,
         Ok(_) => return Ok(()),
@@ -2517,7 +2515,7 @@ fn write_exception_notes<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io:
             // failures raised by a custom `__notes__` descriptor as a
             // synthetic note instead of silently discarding the diagnostic.
             let err_obj = err.to_exc_object();
-            pyre_object::gc_roots::pin_root(err_obj);
+            let _ = pyre_object::gc_roots::pin_root(err_obj);
             let err_obj = pyre_object::gc_roots::shadow_stack_get(
                 pyre_object::gc_roots::shadow_stack_len() - 1,
             );
@@ -2529,8 +2527,7 @@ fn write_exception_notes<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io:
         }
     };
     let notes_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(notes);
-    let notes = pyre_object::gc_roots::shadow_stack_get(notes_slot);
+    let notes = pyre_object::gc_roots::pin_root(notes);
     let is_list = unsafe { crate::baseobjspace::isinstance_list_w(notes) };
     let is_tuple = unsafe {
         pyre_object::is_tuple(notes)
@@ -2560,7 +2557,7 @@ fn write_exception_notes<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io:
                 .unwrap_or(pyre_object::PY_NULL);
                 if !item.is_null() {
                     let item_slot = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(item);
+                    let _ = pyre_object::gc_roots::pin_root(item);
                     item_slots.push(item_slot);
                 }
             }
@@ -2569,7 +2566,7 @@ fn write_exception_notes<W: Write>(writer: &mut W, exc: PyObjectRef) -> std::io:
             if let Ok(items) = crate::builtins::collect_iterable(notes) {
                 for item in items {
                     let item_slot = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(item);
+                    let _ = pyre_object::gc_roots::pin_root(item);
                     item_slots.push(item_slot);
                 }
             }
@@ -2611,7 +2608,7 @@ fn notes_is_abc_sequence(notes_slot: usize) -> bool {
         return false;
     };
     let sequence_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(sequence);
+    let _ = pyre_object::gc_roots::pin_root(sequence);
     let notes = pyre_object::gc_roots::shadow_stack_get(notes_slot);
     let sequence = pyre_object::gc_roots::shadow_stack_get(sequence_slot);
     crate::baseobjspace::isinstance(notes, sequence).unwrap_or(false)
@@ -2650,7 +2647,7 @@ fn render_exc_object_wtf8(exc: PyObjectRef) -> Wtf8Buf {
     }
     let _roots = pyre_object::gc_roots::push_roots();
     let exc_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(exc);
+    let _ = pyre_object::gc_roots::pin_root(exc);
     render_rooted_exc_object_wtf8(exc_slot)
 }
 
@@ -2760,7 +2757,7 @@ fn traceback_last_frame(tb: PyObjectRef) -> Option<*mut crate::pyframe::PyFrame>
         return None;
     }
     let tb_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(tb);
+    let _ = pyre_object::gc_roots::pin_root(tb);
     let mut current = pyre_object::gc_roots::shadow_stack_get(tb_slot);
     let mut last = pyre_object::PY_NULL;
     while !current.is_null() && unsafe { crate::pytraceback::is_pytraceback(current) } {
@@ -2779,7 +2776,7 @@ fn traceback_self_is(tb: PyObjectRef, obj: PyObjectRef) -> bool {
         return false;
     }
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let Some(frame) = traceback_last_frame(tb) else {
         return false;
     };
@@ -2788,8 +2785,7 @@ fn traceback_self_is(tb: PyObjectRef, obj: PyObjectRef) -> bool {
         return false;
     };
     let locals_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(locals);
-    let locals = pyre_object::gc_roots::shadow_stack_get(locals_slot);
+    let locals = pyre_object::gc_roots::pin_root(locals);
     let Some(self_obj) = (unsafe { pyre_object::w_dict_getitem_str(locals, "self") }) else {
         return false;
     };
@@ -2802,12 +2798,10 @@ fn object_dir_strings(obj: PyObjectRef) -> Option<Vec<String>> {
         return None;
     }
     let slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
-    let obj = pyre_object::gc_roots::shadow_stack_get(slot);
+    let obj = pyre_object::gc_roots::pin_root(obj);
     let names = crate::builtins::builtin_dir(&[obj]).ok()?;
     let names_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(names);
-    let names = pyre_object::gc_roots::shadow_stack_get(names_slot);
+    let names = pyre_object::gc_roots::pin_root(names);
     let items = crate::builtins::collect_iterable(names).ok()?;
     Some(
         items
@@ -2833,10 +2827,10 @@ fn stdlib_module_name(name: &str) -> bool {
         return false;
     }
     let names_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(names);
+    let _ = pyre_object::gc_roots::pin_root(names);
     let name = pyre_object::w_str_new(name);
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(name);
+    let _ = pyre_object::gc_roots::pin_root(name);
     let names = pyre_object::gc_roots::shadow_stack_get(names_slot);
     let name = pyre_object::gc_roots::shadow_stack_get(name_slot);
     crate::baseobjspace::contains(names, name).unwrap_or(false)
@@ -2871,7 +2865,7 @@ fn exception_suggestion(exc_slot: usize) -> Option<String> {
         None
     } else {
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(tb);
+        let _ = pyre_object::gc_roots::pin_root(tb);
         Some(slot)
     };
     let suggestion = match kind {
@@ -2879,8 +2873,7 @@ fn exception_suggestion(exc_slot: usize) -> Option<String> {
             let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
             let obj = unsafe { pyre_object::interp_exceptions::w_exception_get_attr_obj(exc) };
             let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(obj);
-            let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+            let obj = pyre_object::gc_roots::pin_root(obj);
             object_dir_strings(obj).and_then(|mut names| {
                 let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
                 let tb = tb_slot
@@ -2932,13 +2925,11 @@ fn exception_suggestion(exc_slot: usize) -> Option<String> {
             let mut names = Vec::new();
             if let Ok(locals) = unsafe { &mut *anchor.live() }.getdictscope() {
                 let locals_slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(locals);
-                let locals = pyre_object::gc_roots::shadow_stack_get(locals_slot);
+                let locals = pyre_object::gc_roots::pin_root(locals);
                 dict_string_keys(locals, &mut names);
                 if let Some(self_obj) = unsafe { pyre_object::w_dict_getitem_str(locals, "self") } {
                     let self_slot = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(self_obj);
-                    let self_obj = pyre_object::gc_roots::shadow_stack_get(self_slot);
+                    let self_obj = pyre_object::gc_roots::pin_root(self_obj);
                     if crate::baseobjspace::getattr_str(self_obj, &wrong_name).is_ok() {
                         return Some(format!(". Did you mean: 'self.{wrong_name}'?"));
                     }
@@ -3017,7 +3008,7 @@ fn write_traceback_chain_from_tb<W: Write>(
     let mut repeats: usize = 0;
     while !tb.is_null() {
         let tb_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(tb);
+        let mut tb = pyre_object::gc_roots::pin_root(tb);
         let current_tb = pyre_object::gc_roots::shadow_stack_get(tb_slot);
         if !unsafe { crate::pytraceback::is_pytraceback(current_tb) } {
             break;
@@ -3565,11 +3556,11 @@ fn operation_error_from_class(w_type: PyObjectRef, message: Wtf8Buf) -> Operatio
     // `alloc_dict_object` re-reads `dstorage` across its header malloc.
     let _roots = pyre_object::gc_roots::push_roots();
     let base = _roots.base();
-    _roots.pin_root(w_type);
+    let _ = _roots.pin_root(w_type);
     // `w_str_new`'s buffer-taking sibling: same allocation policy, and it is
     // the one that accepts a lone surrogate.
     let w_message = pyre_object::w_str_from_wtf8(message.clone());
-    _roots.pin_root(w_message);
+    let _ = _roots.pin_root(w_message);
     let (w_type, w_message) = (_roots.get(base), _roots.get(base + 1));
     operation_error_from_instance(
         crate::call::call_function_impl_result(w_type, &[w_message]),
@@ -3829,11 +3820,11 @@ pub fn exception_from_errno(
     // slot rather than this frame's copy of the pointer.
     let _roots = pyre_object::gc_roots::push_roots();
     let base = _roots.base();
-    _roots.pin_root(w_type);
+    let w_type = _roots.pin_root(w_type);
     let w_errno = pyre_object::w_int_new(errno as i64);
-    _roots.pin_root(w_errno);
+    let w_errno = _roots.pin_root(w_errno);
     let w_msg = pyre_object::w_str_new(&msg);
-    _roots.pin_root(w_msg);
+    let w_msg = _roots.pin_root(w_msg);
     let (w_type, w_errno, w_msg) = (_roots.get(base), _roots.get(base + 1), _roots.get(base + 2));
     operation_error_from_instance(
         crate::call::call_function_impl_result(w_type, &[w_errno, w_msg]),
@@ -3900,17 +3891,17 @@ pub fn new_exception_class(
         )]),
         Some(w_bases) if unsafe { !pyre_object::is_tuple(w_bases) } => {
             let slot = pyre_object::gc_roots::shadow_stack_len();
-            _roots.pin_root(w_bases);
+            let _ = _roots.pin_root(w_bases);
             pyre_object::w_tuple_new(vec![_roots.get(slot)])
         }
         Some(w_bases) => w_bases,
     };
     let bases_slot = pyre_object::gc_roots::shadow_stack_len();
-    _roots.pin_root(w_bases);
+    let _ = _roots.pin_root(w_bases);
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    _roots.pin_root(w_dict.unwrap_or_else(pyre_object::w_dict_new));
+    let _ = _roots.pin_root(w_dict.unwrap_or_else(pyre_object::w_dict_new));
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    _roots.pin_root(pyre_object::w_str_new(name));
+    let _ = _roots.pin_root(pyre_object::w_str_new(name));
     let args = [
         _roots.get(name_slot),
         _roots.get(bases_slot),
@@ -3931,11 +3922,11 @@ pub fn new_exception_class(
     // falsy upstream, so the attribute is left alone rather than set to `""`.
     if let Some(module) = module.filter(|module| !module.is_empty()) {
         let exc_slot = pyre_object::gc_roots::shadow_stack_len();
-        _roots.pin_root(w_exc);
+        let _ = _roots.pin_root(w_exc);
         // Pinned like every other operand here: `setattr_str` allocates, and a
         // collection rewrites the root SLOT rather than this frame's copy.
         let module_slot = pyre_object::gc_roots::shadow_stack_len();
-        _roots.pin_root(pyre_object::w_str_new(module));
+        let _ = _roots.pin_root(pyre_object::w_str_new(module));
         // `space.setattr` propagates its failure through the same bare-return
         // channel as the class call above.
         if let Err(err) = crate::baseobjspace::setattr_str(
@@ -4016,11 +4007,11 @@ pub fn wrap_oserror2(
     // pointer.
     let _roots = pyre_object::gc_roots::push_roots();
     let base = _roots.base();
-    _roots.pin_root(w_exc);
-    _roots.pin_root(pyre_object::w_int_new(errno as i64));
-    _roots.pin_root(pyre_object::w_str_new(&msg));
-    _roots.pin_root(w_filename.unwrap_or_else(pyre_object::w_none));
-    _roots.pin_root(w_filename2.unwrap_or_else(pyre_object::w_none));
+    let _ = _roots.pin_root(w_exc);
+    let _ = _roots.pin_root(pyre_object::w_int_new(errno as i64));
+    let _ = _roots.pin_root(pyre_object::w_str_new(&msg));
+    let _ = _roots.pin_root(w_filename.unwrap_or_else(pyre_object::w_none));
+    let _ = _roots.pin_root(w_filename2.unwrap_or_else(pyre_object::w_none));
     // The five the constructor takes, in `_wrap_oserror2_impl`'s order.  A
     // subclass reading `filename2` sees the argument it declares rather than a
     // short call.
@@ -4066,7 +4057,7 @@ pub fn wrap_oserror(
     // from its slot afterwards.
     let _roots = pyre_object::gc_roots::push_roots();
     let base = _roots.base();
-    _roots.pin_root(pyre_object::w_str_new(filename));
+    let _ = _roots.pin_root(pyre_object::w_str_new(filename));
     let w_filename2 = filename2.map(pyre_object::w_str_new);
     wrap_oserror2(
         space,

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2472,7 +2472,7 @@ impl SharedOpcodeHandler for PyFrame {
         // Python — and the failing branch below still has to read its type.
         let roots = pyre_object::gc_roots::push_roots();
         let obj_slot = roots.base();
-        roots.pin_root(obj);
+        let obj = roots.pin_root(obj);
         getattr_str(obj, name).map_err(|error| {
             if finalize_failed_attr_receiver_now(roots.get(obj_slot)) {
                 // Keep this write on the live virtualizable red frame.  The
@@ -2760,7 +2760,7 @@ impl StackOpcodeHandler for PyFrame {
         // thing out here and read `w_top` back.
         let roots = pyre_object::gc_roots::push_roots();
         let top_slot = roots.base();
-        roots.pin_root(w_top);
+        let _ = roots.pin_root(w_top);
         self.settopvalue(w_other, 0);
         self.settopvalue(roots.get(top_slot), depth - 1);
         Ok(())
@@ -3040,7 +3040,7 @@ impl IterOpcodeHandler for PyFrame {
             let iter = if pyre_object::is_dict_proxy(iter) {
                 let roots = pyre_object::gc_roots::push_roots();
                 let mapping_slot = roots.base();
-                roots.pin_root(pyre_object::w_dict_proxy_get_mapping(iter));
+                let _ = roots.pin_root(pyre_object::w_dict_proxy_get_mapping(iter));
                 let tos = self.valuestackdepth - 1;
                 self.set_locals_w(tos, roots.get(mapping_slot));
                 roots.get(mapping_slot)
@@ -3932,7 +3932,7 @@ impl OpcodeStepExecutor for PyFrame {
                         // below can drive a collection.
                         let _roots = pyre_object::gc_roots::push_roots();
                         if let Some(c) = &cause {
-                            pyre_object::gc_roots::pin_root(c.w_cause);
+                            let _ = pyre_object::gc_roots::pin_root(c.w_cause);
                         }
                         // pyopcode.py:711-713 — class raise: call the type.
                         let result = instantiate_raised_class(w_value)?;
@@ -4196,9 +4196,9 @@ impl OpcodeStepExecutor for PyFrame {
                 // function to its target.
                 let roots = pyre_object::gc_roots::push_roots();
                 let func_slot = roots.base();
-                roots.pin_root(func);
+                let _ = roots.pin_root(func);
                 let attr_slot = func_slot + 1;
-                roots.pin_root(attr);
+                let _ = roots.pin_root(attr);
                 let mut qualname =
                     unsafe { crate::function::function_get_qualname(roots.get(func_slot)) };
                 qualname.push_str(".__annotate__");
@@ -4851,7 +4851,7 @@ impl OpcodeStepExecutor for PyFrame {
             );
             let cause_obj = cause.to_exc_object();
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(cause_obj);
+            let _ = pyre_object::gc_roots::pin_root(cause_obj);
             let cause_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let mut error = crate::PyError::type_error(message);
             let error_obj = error.to_exc_object();
@@ -4969,7 +4969,7 @@ impl OpcodeStepExecutor for PyFrame {
         // live frame.
         let roots = pyre_object::gc_roots::push_roots();
         let obj_slot = roots.base();
-        roots.pin_root(obj);
+        let obj = roots.pin_root(obj);
         let anchor = FrameAnchor::new(self);
         let attr = crate::baseobjspace::getattr_str(obj, name)?;
         let obj = roots.get(obj_slot);
@@ -5015,7 +5015,7 @@ impl OpcodeStepExecutor for PyFrame {
         // the cache lookup, which runs arbitrary Python on a cache miss.
         let roots = pyre_object::gc_roots::push_roots();
         let obj_slot = roots.base();
-        roots.pin_root(obj);
+        let obj = roots.pin_root(obj);
         let pycode = self.pycode as PyObjectRef;
         let anchor = FrameAnchor::new(self);
         let w_value = unsafe {

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -2739,6 +2739,12 @@ impl UserDelAction {
         let _ = pyre_object::gc_roots::pin_root(w_del);
         let del_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let del = || pyre_object::gc_roots::shadow_stack_get(del_slot);
+        // The queue this object arrives on is the collector's, so record the
+        // run where `finalize_garbage` sets `_PyGC_SET_FINALIZED` — before the
+        // call, not after it the way the refcount path's
+        // `PyObject_CallFinalizer` does.  `gc.is_finalized` reads it back for
+        // an object that `__del__` resurrected.
+        majit_gc::gc_mark_finalizer_run(current() as usize);
         // pyre's combined helper cannot distinguish get-vs-call errors;
         // report through the call arm (executioncontext.py:680-690).
         if let Err(error) = unsafe {

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -662,7 +662,7 @@ impl ExecutionContext {
             // taken on this arm rather than for every frame that leaves.
             let _roots = pyre_object::gc_roots::push_roots();
             let exit_slot = pyre_object::gc_roots::shadow_stack_len();
-            let mut w_exitvalue = pyre_object::gc_roots::pin_root(w_exitvalue);
+            w_exitvalue = pyre_object::gc_roots::pin_root(w_exitvalue);
             let result = self._trace(
                 frame,
                 "leaveframe",

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -663,7 +663,12 @@ impl ExecutionContext {
             let _roots = pyre_object::gc_roots::push_roots();
             let exit_slot = pyre_object::gc_roots::shadow_stack_len();
             pyre_object::gc_roots::pin_root(w_exitvalue);
-            let result = self._trace(frame, "leaveframe", w_exitvalue, None);
+            let result = self._trace(
+                frame,
+                "leaveframe",
+                pyre_object::gc_roots::shadow_stack_get(exit_slot),
+                None,
+            );
             w_exitvalue = pyre_object::gc_roots::shadow_stack_get(exit_slot);
             result
         } else {
@@ -808,7 +813,15 @@ impl ExecutionContext {
         let _roots = pyre_object::gc_roots::push_roots();
         let retval_slot = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(w_retval);
-        self._trace(frame, "return", w_retval, None)?;
+        // The callback is handed the value off its slot too: publication ends
+        // in a forwarding query, which is a safepoint, and it rewrites the
+        // slot rather than this frame's copy.
+        self._trace(
+            frame,
+            "return",
+            pyre_object::gc_roots::shadow_stack_get(retval_slot),
+            None,
+        )?;
         Ok(pyre_object::gc_roots::shadow_stack_get(retval_slot))
     }
 

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -431,7 +431,7 @@ impl ExecutionContext {
     #[inline]
     pub fn new() -> Self {
         let builtins_module = crate::builtins::new_builtin_module_dict();
-        pyre_object::gc_roots::pin_root(builtins_module);
+        let builtins_module = pyre_object::gc_roots::pin_root(builtins_module);
         Self {
             space: pyre_object::PY_NULL,
             topframeref: std::ptr::null_mut(),
@@ -662,7 +662,7 @@ impl ExecutionContext {
             // taken on this arm rather than for every frame that leaves.
             let _roots = pyre_object::gc_roots::push_roots();
             let exit_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(w_exitvalue);
+            let mut w_exitvalue = pyre_object::gc_roots::pin_root(w_exitvalue);
             let result = self._trace(
                 frame,
                 "leaveframe",
@@ -812,7 +812,7 @@ impl ExecutionContext {
         }
         let _roots = pyre_object::gc_roots::push_roots();
         let retval_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_retval);
+        let _ = pyre_object::gc_roots::pin_root(w_retval);
         // The callback is handed the value off its slot too: publication ends
         // in a forwarding query, which is a safepoint, and it rewrites the
         // slot rather than this frame's copy.
@@ -1535,7 +1535,7 @@ impl ExecutionContext {
         // module-dict cell may trigger a minor collection before the caller
         // has stored the new namespace anywhere else.
         let _root = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(dict);
+        let dict = pyre_object::gc_roots::pin_root(dict);
         unsafe {
             let w_builtin = self.get_builtin();
             if !w_builtin.is_null() {
@@ -2621,7 +2621,7 @@ impl UserDelAction {
                 Some(w) => {
                     // The deque entry was the object's only root; pin it across the __del__ call.
                     let _roots = pyre_object::gc_roots::push_roots();
-                    pyre_object::gc_roots::pin_root(w);
+                    let w = pyre_object::gc_roots::pin_root(w);
                     self._call_finalizer(w);
                 }
             }
@@ -2649,7 +2649,7 @@ impl UserDelAction {
     pub fn _call_finalizer(&mut self, w_obj: PyObjectRef) {
         let _roots = pyre_object::gc_roots::push_roots();
         let root_base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_obj);
+        let _ = pyre_object::gc_roots::pin_root(w_obj);
         let current = || pyre_object::gc_roots::shadow_stack_get(root_base);
         crate::module::_weakref::interp__weakref::finalize_weakrefs(current());
         if let Some(pb) = crate::module::__pypy__::W_PickleBuffer::from_obj(current()) {
@@ -2736,7 +2736,7 @@ impl UserDelAction {
         // `__del__` runs arbitrary Python, so it can collect and move the
         // callable that the error report names; publish it and read it back
         // the way `current()` does for the receiver.
-        pyre_object::gc_roots::pin_root(w_del);
+        let _ = pyre_object::gc_roots::pin_root(w_del);
         let del_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let del = || pyre_object::gc_roots::shadow_stack_get(del_slot);
         // pyre's combined helper cannot distinguish get-vs-call errors;

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -686,14 +686,13 @@ pub(crate) fn function_new_impl(
     // collection point.
     let _roots = pyre_object::gc_roots::push_roots();
     let closure_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(closure);
+    let _ = pyre_object::gc_roots::pin_root(closure);
     let code_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(code as PyObjectRef);
+    let _ = pyre_object::gc_roots::pin_root(code as PyObjectRef);
     // `function.py self.w_func_globals = w_globals` stores the dict
     // object directly as the function's sole globals carrier.
     let globals_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_func_globals_obj);
-
+    let w_func_globals_obj = pyre_object::gc_roots::pin_root(w_func_globals_obj);
     // CPython 3.14 `_PyDict_LoadBuiltinsFromGlobals` at function construction:
     // retain the selected mapping identity even if the globals entry changes
     // later.  Its `_Py_dict_lookup_threadsafe_stackref` reads the native dict
@@ -732,8 +731,7 @@ pub(crate) fn function_new_impl(
         }
     };
     let builtins_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_builtins);
-
+    let _ = pyre_object::gc_roots::pin_root(w_builtins);
     // Resolving the caller vref and later allocations may collect.  Reload every
     // pinned input before embedding it in the new Function; the original raw
     // locals are not rewritten when the shadow-stack slots are forwarded.
@@ -1269,18 +1267,18 @@ pub unsafe fn descr_fixed_code_reduce(obj: PyObjectRef) -> crate::PyResult {
     let owner = unsafe { fget_func_objclass(obj)? };
     let _roots = pyre_object::gc_roots::push_roots();
     let owner_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(owner);
+    let _ = pyre_object::gc_roots::pin_root(owner);
     let name = pyre_object::w_str_new(unsafe { function_get_name(obj) });
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(name);
+    let _ = pyre_object::gc_roots::pin_root(name);
     let getattr = crate::baseobjspace::builtin_callable("getattr");
     let getattr_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(getattr);
+    let _ = pyre_object::gc_roots::pin_root(getattr);
     let args = pyre_object::w_tuple_new(vec![
         pyre_object::gc_roots::shadow_stack_get(owner_slot),
         pyre_object::gc_roots::shadow_stack_get(name_slot),
     ]);
-    pyre_object::gc_roots::pin_root(args);
+    let _ = pyre_object::gc_roots::pin_root(args);
     let args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     Ok(pyre_object::w_tuple_new(vec![
         pyre_object::gc_roots::shadow_stack_get(getattr_slot),
@@ -1483,7 +1481,7 @@ pub unsafe fn fget_func_qualname(obj: PyObjectRef) -> PyObjectRef {
                 function_get_name(obj).to_owned()
             };
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let value = pyre_object::w_str_new(&qualname);
         function_set_qualname(pyre_object::gc_roots::shadow_stack_get(obj_slot), value);
@@ -1530,7 +1528,7 @@ pub unsafe fn function_get_qualname_obj(obj: PyObjectRef) -> PyObjectRef {
         // itself lives in the off-GC `Box<String>` and does not move.
         let _roots = pyre_object::gc_roots::push_roots();
         let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
+        let obj = pyre_object::gc_roots::pin_root(obj);
         let w_qualname = pyre_object::w_str_new(function_get_name(obj));
         let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         function_write_barrier(obj);
@@ -1595,7 +1593,7 @@ pub unsafe fn function_get_name_obj(obj: PyObjectRef) -> PyObjectRef {
         // name itself lives in off-GC storage and does not move.
         let _roots = pyre_object::gc_roots::push_roots();
         let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
+        let obj = pyre_object::gc_roots::pin_root(obj);
         let w_name = pyre_object::w_str_new(function_get_name(obj));
         let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         function_set_name_obj(obj, w_name);
@@ -3613,26 +3611,26 @@ pub fn funccall_valuestack(
         // the same live-variable set on pyre's shadow stack before doing so.
         let _roots = pyre_object::gc_roots::push_roots();
         let root_base = _roots.base();
-        _roots.pin_root(code as PyObjectRef);
+        let _ = _roots.pin_root(code as PyObjectRef);
         match nargs {
             0 => {}
             1 => {
-                _roots.pin_root(frame.peekvalue(0));
+                let _ = _roots.pin_root(frame.peekvalue(0));
             }
             2 => {
-                _roots.pin_root(frame.peekvalue(1));
-                _roots.pin_root(frame.peekvalue(0));
+                let _ = _roots.pin_root(frame.peekvalue(1));
+                let _ = _roots.pin_root(frame.peekvalue(0));
             }
             3 => {
-                _roots.pin_root(frame.peekvalue(2));
-                _roots.pin_root(frame.peekvalue(1));
-                _roots.pin_root(frame.peekvalue(0));
+                let _ = _roots.pin_root(frame.peekvalue(2));
+                let _ = _roots.pin_root(frame.peekvalue(1));
+                let _ = _roots.pin_root(frame.peekvalue(0));
             }
             4 => {
-                _roots.pin_root(frame.peekvalue(3));
-                _roots.pin_root(frame.peekvalue(2));
-                _roots.pin_root(frame.peekvalue(1));
-                _roots.pin_root(frame.peekvalue(0));
+                let _ = _roots.pin_root(frame.peekvalue(3));
+                let _ = _roots.pin_root(frame.peekvalue(2));
+                let _ = _roots.pin_root(frame.peekvalue(1));
+                let _ = _roots.pin_root(frame.peekvalue(0));
             }
             _ => unreachable!(),
         }
@@ -3714,10 +3712,10 @@ pub fn funccall_valuestack(
         // for the call.
         let _roots = pyre_object::gc_roots::push_roots();
         let root_base = _roots.base();
-        _roots.pin_root(code as PyObjectRef);
-        _roots.pin_root(w_obj);
+        let _ = _roots.pin_root(code as PyObjectRef);
+        let _ = _roots.pin_root(w_obj);
         for &w_arg in &rest {
-            _roots.pin_root(w_arg);
+            let _ = _roots.pin_root(w_arg);
         }
         frame.dropvalues(dropvalues);
         let args_w: Vec<PyObjectRef> = (0..nargs).map(|i| _roots.get(root_base + 1 + i)).collect();

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1791,8 +1791,7 @@ fn path_or_fd_w(
     };
     let roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
-
+    let obj = pyre_object::gc_roots::pin_root(obj);
     let (data, w_path_slot, as_fd) = unsafe {
         let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         if nullable && pyre_object::is_none(obj) {
@@ -1858,7 +1857,7 @@ fn path_or_fd_w(
                 return Err(reject(obj));
             };
             let fspath_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(fspath_descr);
+            let _ = pyre_object::gc_roots::pin_root(fspath_descr);
             let path_type =
                 crate::typedef::r#type(pyre_object::gc_roots::shadow_stack_get(obj_slot))
                     .expect("a path argument has a type");
@@ -1884,8 +1883,7 @@ fn path_or_fd_w(
                 &[],
             )?;
             let result_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(result);
-            let result = pyre_object::gc_roots::shadow_stack_get(result_slot);
+            let result = pyre_object::gc_roots::pin_root(result);
             // interp_posix.py:3049-3051 accepts only `str` or `bytes` back from
             // `__fspath__`; a `bytearray` is a readable buffer but not a path.
             if pyre_object::bytesobject::is_bytes(result) {

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -850,7 +850,7 @@ fn init_string_module(ns: PyObjectRef) {
             // but nothing else refers to it while the parts below allocate:
             // one liveness pin covers it to the end of the call.
             let roots = pyre_object::gc_roots::push_roots();
-            roots.pin_root(first);
+            let first = roots.pin_root(first);
             let rest = parts
                 .into_iter()
                 .map(|part| match part {
@@ -904,7 +904,7 @@ fn init_sysconfig_stub(ns: PyObjectRef) {
             // left to right, so the key and value are bound before that read.
             let roots = pyre_object::gc_roots::push_roots();
             let vars_slot = roots.base();
-            roots.pin_root(pyre_object::w_dict_new());
+            let _ = roots.pin_root(pyre_object::w_dict_new());
             let so_ext = extension_abi_suffix();
             unsafe {
                 for (name, value) in [("Py_DEBUG", 0), ("Py_GIL_DISABLED", 1)] {
@@ -1186,7 +1186,7 @@ fn init_sysconfigdata(ns: PyObjectRef) {
 
     let _roots = pyre_object::gc_roots::push_roots();
     let vars_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
     // `_init_non_posix` derives the same `t` from `Py_GIL_DISABLED` below.
     // The lower-case `abiflags` that forms the include and site-packages
     // directory names is a separate variable, read from `sys.abiflags`
@@ -1450,7 +1450,7 @@ fn init_scproxy(ns: PyObjectRef) {
             // The `dict` moves across the allocations each store makes.
             let roots = pyre_object::gc_roots::push_roots();
             let d_slot = roots.base();
-            roots.pin_root(pyre_object::w_dict_new());
+            let _ = roots.pin_root(pyre_object::w_dict_new());
             unsafe {
                 let w_key = pyre_object::w_str_new("exclude_simple");
                 let w_value = pyre_object::w_bool_from(false);
@@ -1484,9 +1484,9 @@ pub(crate) fn load_builtin_module(name: &str) -> Option<PyObjectRef> {
     let w_dict = pyre_object::dictmultiobject::w_module_dict_new();
     let _roots = pyre_object::gc_roots::push_roots();
     let save_point = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_dict);
+    let w_dict = pyre_object::gc_roots::pin_root(w_dict);
     let name_obj = pyre_object::w_str_new(name);
-    pyre_object::gc_roots::pin_root(name_obj);
+    let _ = pyre_object::gc_roots::pin_root(name_obj);
     // Set __name__ (PyPy: Module.__init__ sets __name__)
     crate::module_ns_store(
         w_dict,
@@ -1591,7 +1591,7 @@ pub(crate) fn create_builtin_module(
     let Some(module) = load_builtin_module(name) else {
         return Ok(None);
     };
-    pyre_object::gc_roots::pin_root(module);
+    let _ = pyre_object::gc_roots::pin_root(module);
     set_sys_module(name, pyre_object::gc_roots::shadow_stack_get(module_slot));
     let module = pyre_object::gc_roots::shadow_stack_get(module_slot);
     startup_builtin_module_impl(name, module, execution_context, false)?;
@@ -1622,9 +1622,9 @@ fn set_builtin_module_spec(name: &str, module: PyObjectRef) -> Result<(), crate:
 
     let _roots = push_roots();
     let mod_slot = shadow_stack_len();
-    pin_root(module);
+    let _ = pin_root(module);
     let boot_slot = shadow_stack_len();
-    pin_root(bootstrap);
+    let _ = pin_root(bootstrap);
 
     // Best-effort throughout: a builtin imported while `_bootstrap` is still
     // executing sees a partially-initialised module whose `BuiltinImporter` /
@@ -1636,17 +1636,17 @@ fn set_builtin_module_spec(name: &str, module: PyObjectRef) -> Result<(), crate:
         return Ok(());
     };
     let importer_slot = shadow_stack_len();
-    pin_root(importer);
+    let _ = pin_root(importer);
     let Ok(find_spec) =
         crate::baseobjspace::getattr_str(shadow_stack_get(importer_slot), "find_spec")
     else {
         return Ok(());
     };
     let find_spec_slot = shadow_stack_len();
-    pin_root(find_spec);
+    let _ = pin_root(find_spec);
     let w_name = pyre_object::w_str_new(name);
     let name_slot = shadow_stack_len();
-    pin_root(w_name);
+    let _ = pin_root(w_name);
     let Ok(spec) = crate::call::call_function_impl_result(
         shadow_stack_get(find_spec_slot),
         &[shadow_stack_get(name_slot)],
@@ -1657,7 +1657,7 @@ fn set_builtin_module_spec(name: &str, module: PyObjectRef) -> Result<(), crate:
         return Ok(());
     }
     let spec_slot = shadow_stack_len();
-    pin_root(spec);
+    let _ = pin_root(spec);
 
     // _init_module_attrs(spec, module)
     let Ok(init) =
@@ -1666,7 +1666,7 @@ fn set_builtin_module_spec(name: &str, module: PyObjectRef) -> Result<(), crate:
         return Ok(());
     };
     let init_slot = shadow_stack_len();
-    pin_root(init);
+    let _ = pin_root(init);
     let _ = crate::call::call_function_impl_result(
         shadow_stack_get(init_slot),
         &[shadow_stack_get(spec_slot), shadow_stack_get(mod_slot)],
@@ -1717,20 +1717,20 @@ fn extension_module_spec(name: &str, pathname: &Path) -> PyObjectRef {
     };
     let _roots = push_roots();
     let ext_slot = shadow_stack_len();
-    pin_root(ext);
+    let _ = pin_root(ext);
     let Ok(from_location) =
         crate::baseobjspace::getattr_str(shadow_stack_get(ext_slot), "spec_from_file_location")
     else {
         return pyre_object::PY_NULL;
     };
     let from_location_slot = shadow_stack_len();
-    pin_root(from_location);
+    let _ = pin_root(from_location);
     let w_name = pyre_object::w_str_new(name);
     let name_slot = shadow_stack_len();
-    pin_root(w_name);
+    let _ = pin_root(w_name);
     let w_path = crate::gateway::fsdecode_os_str(pathname.as_os_str());
     let path_slot = shadow_stack_len();
-    pin_root(w_path);
+    let _ = pin_root(w_path);
     // A suffix `_get_supported_file_loaders` does not know yields `None`; that
     // is the same "no spec" answer as a missing bootstrap.
     let Ok(spec) = crate::call::call_function_impl_result(
@@ -1762,11 +1762,11 @@ fn set_extension_module_spec(
 
     let _roots = push_roots();
     let mod_slot = shadow_stack_len();
-    pin_root(module);
+    let _ = pin_root(module);
     let boot_slot = shadow_stack_len();
-    pin_root(bootstrap);
+    let _ = pin_root(bootstrap);
     let ext_slot = shadow_stack_len();
-    pin_root(ext);
+    let _ = pin_root(ext);
 
     let Ok(from_location) =
         crate::baseobjspace::getattr_str(shadow_stack_get(ext_slot), "spec_from_file_location")
@@ -1774,13 +1774,13 @@ fn set_extension_module_spec(
         return Ok(());
     };
     let from_location_slot = shadow_stack_len();
-    pin_root(from_location);
+    let _ = pin_root(from_location);
     let w_name = pyre_object::w_str_new(name);
     let name_slot = shadow_stack_len();
-    pin_root(w_name);
+    let _ = pin_root(w_name);
     let w_path = crate::gateway::fsdecode_os_str(pathname.as_os_str());
     let path_slot = shadow_stack_len();
-    pin_root(w_path);
+    let _ = pin_root(w_path);
 
     // A suffix `_get_supported_file_loaders` does not know yields `None`; that
     // is the same "leave it alone" answer as a missing bootstrap.
@@ -1794,7 +1794,7 @@ fn set_extension_module_spec(
         return Ok(());
     }
     let spec_slot = shadow_stack_len();
-    pin_root(spec);
+    let _ = pin_root(spec);
 
     let Ok(init) =
         crate::baseobjspace::getattr_str(shadow_stack_get(boot_slot), "_init_module_attrs")
@@ -1802,7 +1802,7 @@ fn set_extension_module_spec(
         return Ok(());
     };
     let init_slot = shadow_stack_len();
-    pin_root(init);
+    let _ = pin_root(init);
     let _ = crate::call::call_function_impl_result(
         shadow_stack_get(init_slot),
         &[shadow_stack_get(spec_slot), shadow_stack_get(mod_slot)],
@@ -1833,20 +1833,20 @@ fn fix_up_source_module_spec(
 
     let _roots = push_roots();
     let ns_slot = shadow_stack_len();
-    pin_root(ns);
+    let _ = pin_root(ns);
     let name_slot = shadow_stack_len();
-    pin_root(w_name);
+    let _ = pin_root(w_name);
     let ext_slot = shadow_stack_len();
-    pin_root(ext);
+    let _ = pin_root(ext);
     let w_path = pyre_object::w_str_from_wtf8(pathname.to_wtf8_buf());
     let path_slot = shadow_stack_len();
-    pin_root(w_path);
+    let _ = pin_root(w_path);
     let w_cpath = match cpathname {
         Some(c) => pyre_object::w_str_new(c),
         None => pyre_object::w_none(),
     };
     let cpath_slot = shadow_stack_len();
-    pin_root(w_cpath);
+    let _ = pin_root(w_cpath);
 
     // Best-effort: `_bootstrap_external` itself is a source module, and its
     // spec is fixed up (during partial-init) before its body defines
@@ -1858,7 +1858,7 @@ fn fix_up_source_module_spec(
         return Ok(false);
     };
     let fix_slot = shadow_stack_len();
-    pin_root(fix);
+    let _ = pin_root(fix);
     // An error raised by `_fix_up_module` itself propagates — the appexec
     // at importing.py:293-298 does not shield the call.
     crate::call::call_function_impl_result(
@@ -1901,7 +1901,7 @@ fn startup_builtin_module_impl(
 
     let _roots = push_roots();
     let mod_slot = shadow_stack_len();
-    pin_root(module);
+    let _ = pin_root(module);
 
     let startup = BUILTIN_MODULES
         .lock()
@@ -2664,7 +2664,7 @@ pub fn add_sys_path(dir: &Path) {
     // path is allocation-free until the pinned entry reaches `w_list_append`.
     let _roots = push_roots();
     let slot = shadow_stack_len();
-    pin_root(pyre_object::w_str_from_wtf8(entry.clone()));
+    let _ = pin_root(pyre_object::w_str_from_wtf8(entry.clone()));
     let Some(sys_mod) = get_sys_module("sys") else {
         return;
     };
@@ -2714,7 +2714,7 @@ pub fn add_sys_path_0() {
     // dict lookup allocate) can relocate it — `add_sys_path` parity.
     let _roots = push_roots();
     let slot = shadow_stack_len();
-    pin_root(crate::gateway::fsdecode_os_str(&entry));
+    let _ = pin_root(crate::gateway::fsdecode_os_str(&entry));
     let Some(sys_mod) = get_sys_module("sys") else {
         return;
     };
@@ -2852,7 +2852,7 @@ pub fn set_sys_module(name: &str, module: PyObjectRef) {
     if !dict.is_null() {
         let roots = pyre_object::gc_roots::push_roots();
         let dict_slot = roots.base();
-        roots.pin_root(dict);
+        let _ = roots.pin_root(dict);
         let w_key = pyre_object::w_str_new(name);
         unsafe {
             pyre_object::w_dict_store(roots.get(dict_slot), w_key, module);
@@ -3289,7 +3289,7 @@ pub fn set_sys_modules_dict(dict: PyObjectRef) {
     // and may grow the dict.
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(dict);
+    let _ = roots.pin_root(dict);
     // Populate with all modules already in the cache.
     for (name, &module) in SYS_MODULES.lock().unwrap().iter() {
         let w_key = pyre_object::w_str_new(name);
@@ -3792,7 +3792,7 @@ pub fn appleveldef_install_seeded(
     }
     let w_app_globals = unsafe { (*ctx).fresh_module_globals() };
     let _root = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_app_globals);
+    let w_app_globals = pyre_object::gc_roots::pin_root(w_app_globals);
     for &(name, value) in seed {
         unsafe { pyre_object::w_dict_setitem_str(w_app_globals, name, value) };
     }
@@ -3876,7 +3876,7 @@ fn load_source_module(
     unsafe { crate::pycode::set_compilation_unit_filename_bytes(w_code, filename_bytes) };
     // Root before any allocation (fresh_module_globals, the cache write) can
     // collect the freshly boxed code out from under us.
-    pyre_object::gc_roots::pin_root(w_code);
+    let w_code = pyre_object::gc_roots::pin_root(w_code);
     if let (true, Some(key)) = (store, cache_key) {
         crate::module::imp::interp_imp::frozen_cache_store(key, &source, w_code);
     }
@@ -3886,8 +3886,7 @@ fn load_source_module(
     // then exec_code_module sets __builtins__ and runs code in w_dict.
     let ctx = unsafe { &*execution_context };
     let w_globals = ctx.fresh_module_globals();
-    pyre_object::gc_roots::pin_root(w_globals);
-
+    let w_globals = pyre_object::gc_roots::pin_root(w_globals);
     // PyPy `interpreter/module.py:Module.__init__` seeds `__name__` on
     // the module's w_dict.  `w_module_new_aliasing_dict` below does that
     // via `w_dict_setitem_str("__name__", ...)`, so an explicit store
@@ -4055,19 +4054,19 @@ fn install_importlib_bootstrap(
 
     let _roots = push_roots();
     let module_slot = shadow_stack_len();
-    pin_root(module);
+    let _ = pin_root(module);
 
     let w_sys = absolute_import("sys", pyre_object::PY_NULL, execution_context)?;
     let sys_slot = shadow_stack_len();
-    pin_root(w_sys);
+    let _ = pin_root(w_sys);
 
     let w_imp = absolute_import("_imp", pyre_object::PY_NULL, execution_context)?;
     let imp_slot = shadow_stack_len();
-    pin_root(w_imp);
+    let _ = pin_root(w_imp);
 
     let install = crate::baseobjspace::getattr_str(shadow_stack_get(module_slot), "_install")?;
     let install_slot = shadow_stack_len();
-    pin_root(install);
+    let _ = pin_root(install);
     let args = [shadow_stack_get(sys_slot), shadow_stack_get(imp_slot)];
     crate::call::call_function_impl_result(shadow_stack_get(install_slot), &args)?;
 
@@ -4106,11 +4105,11 @@ fn install_importlib_bootstrap(
     // zipimport` path — rather than failing the whole bootstrap.
     if let Ok(w_zipimport) = absolute_import("zipimport", pyre_object::PY_NULL, execution_context) {
         let zipimport_slot = shadow_stack_len();
-        pin_root(w_zipimport);
+        let _ = pin_root(w_zipimport);
         let w_zipimporter =
             crate::baseobjspace::getattr_str(shadow_stack_get(zipimport_slot), "zipimporter")?;
         let zipimporter_slot = shadow_stack_len();
-        pin_root(w_zipimporter);
+        let _ = pin_root(w_zipimporter);
         let w_path_hooks =
             crate::baseobjspace::getattr_str(shadow_stack_get(sys_slot), "path_hooks")?;
         unsafe {
@@ -4135,26 +4134,26 @@ fn set_frozen_alias_metadata(
 
     let _roots = push_roots();
     let module_slot = shadow_stack_len();
-    pin_root(module);
+    let _ = pin_root(module);
     let bootstrap_slot = shadow_stack_len();
-    pin_root(bootstrap);
+    let _ = pin_root(bootstrap);
 
     let loader =
         crate::baseobjspace::getattr_str(shadow_stack_get(bootstrap_slot), "FrozenImporter")?;
     let loader_slot = shadow_stack_len();
-    pin_root(loader);
+    let _ = pin_root(loader);
     let find_spec = crate::baseobjspace::getattr_str(shadow_stack_get(loader_slot), "find_spec")?;
     let find_spec_slot = shadow_stack_len();
-    pin_root(find_spec);
+    let _ = pin_root(find_spec);
     let w_name = pyre_object::w_str_new(name);
     let name_slot = shadow_stack_len();
-    pin_root(w_name);
+    let _ = pin_root(w_name);
     let spec = crate::call::call_function_impl_result(
         shadow_stack_get(find_spec_slot),
         &[shadow_stack_get(name_slot)],
     )?;
     let spec_slot = shadow_stack_len();
-    pin_root(spec);
+    let _ = pin_root(spec);
 
     crate::baseobjspace::setattr_str(
         shadow_stack_get(module_slot),
@@ -4214,8 +4213,7 @@ fn load_namespace_package(
     let ctx = unsafe { &*execution_context };
     let w_globals = ctx.fresh_module_globals();
     let _root = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_globals);
-
+    let w_globals = pyre_object::gc_roots::pin_root(w_globals);
     unsafe {
         pyre_object::w_dict_setitem_str(
             w_globals,
@@ -4304,14 +4302,14 @@ fn load_part(
         FindInfo::ExtensionFile { pathname } => {
             let roots = pyre_object::gc_roots::push_roots();
             let spec_slot = pyre_object::gc_roots::shadow_stack_len();
-            roots.pin_root(extension_module_spec(modulename, &pathname));
+            let _ = roots.pin_root(extension_module_spec(modulename, &pathname));
             let module = crate::cpyext::load_extension_module(
                 modulename,
                 &pathname,
                 pyre_object::gc_roots::shadow_stack_get(spec_slot),
             )?;
             let module_slot = pyre_object::gc_roots::shadow_stack_len();
-            roots.pin_root(module);
+            let _ = roots.pin_root(module);
             set_extension_module_spec(
                 modulename,
                 &pathname,
@@ -4331,14 +4329,14 @@ fn load_part(
         FindInfo::ExtensionPackage { dirpath, pathname } => {
             let roots = pyre_object::gc_roots::push_roots();
             let spec_slot = pyre_object::gc_roots::shadow_stack_len();
-            roots.pin_root(extension_module_spec(modulename, &pathname));
+            let _ = roots.pin_root(extension_module_spec(modulename, &pathname));
             let module = crate::cpyext::load_extension_module(
                 modulename,
                 &pathname,
                 pyre_object::gc_roots::shadow_stack_get(spec_slot),
             )?;
             let module_slot = pyre_object::gc_roots::shadow_stack_len();
-            roots.pin_root(module);
+            let _ = roots.pin_root(module);
             set_extension_module_spec(
                 modulename,
                 &pathname,
@@ -4346,14 +4344,14 @@ fn load_part(
             )?;
             let path = crate::gateway::fsdecode_os_str(dirpath.as_os_str());
             let path_slot = pyre_object::gc_roots::shadow_stack_len();
-            roots.pin_root(path);
+            let _ = roots.pin_root(path);
             // `__path__` is re-stamped after the spec: the loader derives it
             // from the file name, and the directory found here is the same
             // answer spelled without that dependency.
             // The store below allocates, so the fresh list is pinned rather
             // than held in a local across it.
             let list_slot = pyre_object::gc_roots::shadow_stack_len();
-            roots.pin_root(pyre_object::w_list_new(vec![
+            let _ = roots.pin_root(pyre_object::w_list_new(vec![
                 pyre_object::gc_roots::shadow_stack_get(path_slot),
             ]));
             let module = pyre_object::gc_roots::shadow_stack_get(module_slot);
@@ -4608,14 +4606,14 @@ fn gcd_import_fast(name: &str) -> Result<Option<PyObjectRef>, crate::PyError> {
     };
     let _roots = push_roots();
     let mod_slot = shadow_stack_len();
-    pin_root(w_module);
+    let _ = pin_root(w_module);
     let Some(w_spec) =
         crate::baseobjspace::findattr_result(shadow_stack_get(mod_slot), "__spec__")?
     else {
         return Ok(None);
     };
     let spec_slot = shadow_stack_len();
-    pin_root(w_spec);
+    let _ = pin_root(w_spec);
     if let Some(w_initializing) =
         crate::baseobjspace::findattr_result(shadow_stack_get(spec_slot), "_initializing")?
         && crate::baseobjspace::is_true(w_initializing)?
@@ -4624,7 +4622,7 @@ fn gcd_import_fast(name: &str) -> Result<Option<PyObjectRef>, crate::PyError> {
             return Ok(None);
         };
         let bootstrap_slot = shadow_stack_len();
-        pin_root(w_bootstrap);
+        let _ = pin_root(w_bootstrap);
         let Some(w_lock_unlock) = crate::baseobjspace::findattr_result(
             shadow_stack_get(bootstrap_slot),
             "_lock_unlock_module",
@@ -4633,9 +4631,9 @@ fn gcd_import_fast(name: &str) -> Result<Option<PyObjectRef>, crate::PyError> {
             return Ok(None);
         };
         let lock_unlock_slot = shadow_stack_len();
-        pin_root(w_lock_unlock);
+        let _ = pin_root(w_lock_unlock);
         let name_slot = shadow_stack_len();
-        pin_root(pyre_object::w_str_new(name));
+        let _ = pin_root(pyre_object::w_str_new(name));
         crate::call::call_function_impl_result(
             shadow_stack_get(lock_unlock_slot),
             &[shadow_stack_get(name_slot)],
@@ -4690,11 +4688,11 @@ fn strip_bootstrap_traceback_frames(mut err: crate::PyError) -> crate::PyError {
         // its own walk.
         let _roots = push_roots();
         let exc_slot = shadow_stack_len();
-        pin_root(exc);
+        let exc = pin_root(exc);
         let tb_slot = shadow_stack_len();
-        pin_root(w_exception_get_traceback(exc));
+        let _ = pin_root(w_exception_get_traceback(exc));
         let code_slot = shadow_stack_len();
-        pin_root(pyre_object::PY_NULL);
+        let _ = pin_root(pyre_object::PY_NULL);
         loop {
             let tb = shadow_stack_get(tb_slot);
             if tb.is_null() || is_none(tb) {
@@ -4769,21 +4767,21 @@ fn handle_fromlist_fast(
 
     let _roots = push_roots();
     let mod_slot = shadow_stack_len();
-    pin_root(w_mod);
+    let _ = pin_root(w_mod);
     let fromlist_slot = shadow_stack_len();
-    pin_root(w_fromlist);
+    let _ = pin_root(w_fromlist);
     let Some(w_bootstrap) = get_sys_module("importlib._bootstrap") else {
         return Ok(None);
     };
     let bootstrap_slot = shadow_stack_len();
-    pin_root(w_bootstrap);
+    let _ = pin_root(w_bootstrap);
     let Some(w_handle) =
         crate::baseobjspace::findattr_result(shadow_stack_get(bootstrap_slot), "_handle_fromlist")?
     else {
         return Ok(None);
     };
     let handle_slot = shadow_stack_len();
-    pin_root(w_handle);
+    let _ = pin_root(w_handle);
     // `space.w_default_importlib_import` is the importer `_handle_fromlist`
     // calls for a name the package does not already carry.  It is the space's
     // own captured copy, so rebinding `builtins.__import__` or
@@ -4792,7 +4790,7 @@ fn handle_fromlist_fast(
         return Ok(None);
     };
     let import_slot = shadow_stack_len();
-    pin_root(w_import);
+    let _ = pin_root(w_import);
     crate::call::call_function_impl_result(
         shadow_stack_get(handle_slot),
         &[
@@ -4826,19 +4824,19 @@ pub fn dunder_import(
 
     let _roots = push_roots();
     let globals_slot = shadow_stack_len();
-    pin_root(if w_globals.is_null() {
+    let _ = pin_root(if w_globals.is_null() {
         pyre_object::w_none()
     } else {
         w_globals
     });
     let locals_slot = shadow_stack_len();
-    pin_root(if w_locals.is_null() {
+    let _ = pin_root(if w_locals.is_null() {
         pyre_object::w_none()
     } else {
         w_locals
     });
     let fromlist_slot = shadow_stack_len();
-    pin_root(if w_fromlist.is_null() {
+    let _ = pin_root(if w_fromlist.is_null() {
         pyre_object::w_none()
     } else {
         w_fromlist
@@ -4855,7 +4853,7 @@ pub fn dunder_import(
             !fromlist_missing && crate::baseobjspace::is_true(shadow_stack_get(fromlist_slot))?;
         if let Some(w_mod) = gcd_import_fast(name)? {
             let mod_slot = shadow_stack_len();
-            pin_root(w_mod);
+            let _ = pin_root(w_mod);
             if !have_fromlist {
                 let dotindex = rpython_str_find_char(name, '.', 0);
                 if dotindex < 0 {
@@ -4903,12 +4901,12 @@ pub fn dunder_import(
     // Slow path: the app-level `_bootstrap.__import__`.
     if let Some(w_bootstrap) = get_sys_module("importlib._bootstrap") {
         let bootstrap_slot = shadow_stack_len();
-        pin_root(w_bootstrap);
+        let _ = pin_root(w_bootstrap);
         if let Some(w_import) =
             crate::baseobjspace::findattr_result(shadow_stack_get(bootstrap_slot), "__import__")?
         {
             let import_slot = shadow_stack_len();
-            pin_root(w_import);
+            let _ = pin_root(w_import);
             // `PyImport_ImportModuleLevelObject`: a relative import with an
             // empty fromlist hands back the head package named by the *resolved
             // absolute name*, and the imported module itself when `name` carries
@@ -4975,21 +4973,21 @@ fn call_bootstrap_import(
 
     let _roots = push_roots();
     let import_slot = shadow_stack_len();
-    pin_root(w_import);
+    let _ = pin_root(w_import);
     let name_slot = shadow_stack_len();
-    pin_root(w_name);
+    let _ = pin_root(w_name);
     let globals_slot = shadow_stack_len();
-    pin_root(w_globals);
+    let _ = pin_root(w_globals);
     let locals_slot = shadow_stack_len();
-    pin_root(w_locals);
+    let _ = pin_root(w_locals);
     let fromlist_slot = shadow_stack_len();
-    pin_root(if w_fromlist.is_null() {
+    let _ = pin_root(if w_fromlist.is_null() {
         pyre_object::w_tuple_new(vec![])
     } else {
         w_fromlist
     });
     let level_slot = shadow_stack_len();
-    pin_root(pyre_object::w_int_new(level));
+    let _ = pin_root(pyre_object::w_int_new(level));
     crate::call::call_function_impl_result(
         shadow_stack_get(import_slot),
         &[
@@ -5020,15 +5018,15 @@ pub fn dunder_import_name_obj(
 
     let _roots = push_roots();
     let name_slot = shadow_stack_len();
-    pin_root(w_name);
+    let _ = pin_root(w_name);
     let globals_slot = shadow_stack_len();
-    pin_root(if w_globals.is_null() {
+    let _ = pin_root(if w_globals.is_null() {
         pyre_object::w_none()
     } else {
         w_globals
     });
     let locals_slot = shadow_stack_len();
-    pin_root(if w_locals.is_null() {
+    let _ = pin_root(if w_locals.is_null() {
         pyre_object::w_none()
     } else {
         w_locals
@@ -5039,11 +5037,11 @@ pub fn dunder_import_name_obj(
     } else {
         w_fromlist
     };
-    pin_root(w_fromlist);
+    let _ = pin_root(w_fromlist);
 
     let bootstrap = if let Some(w_bootstrap) = get_sys_module("importlib._bootstrap") {
         let bootstrap_slot = shadow_stack_len();
-        pin_root(w_bootstrap);
+        let _ = pin_root(w_bootstrap);
         crate::baseobjspace::findattr_result(shadow_stack_get(bootstrap_slot), "__import__")?
     } else {
         None
@@ -5088,38 +5086,38 @@ fn relative_import_head(
 
     let _roots = push_roots();
     let bootstrap_slot = shadow_stack_len();
-    pin_root(w_bootstrap);
+    let _ = pin_root(w_bootstrap);
     // `_bootstrap.__import__` — `globals_ = globals if globals is not None else {}`.
     let globals_slot = shadow_stack_len();
-    pin_root(if w_globals.is_null() || unsafe { is_none(w_globals) } {
+    let _ = pin_root(if w_globals.is_null() || unsafe { is_none(w_globals) } {
         pyre_object::w_dict_new()
     } else {
         w_globals
     });
     let name_slot = shadow_stack_len();
-    pin_root(pyre_object::w_str_new(name));
+    let _ = pin_root(pyre_object::w_str_new(name));
     let level_slot = shadow_stack_len();
-    pin_root(pyre_object::w_int_new(level));
+    let _ = pin_root(pyre_object::w_int_new(level));
 
     // `_bootstrap.__import__` — `package = _calc___package__(globals_)`.
     let w_calc =
         crate::baseobjspace::getattr_str(shadow_stack_get(bootstrap_slot), "_calc___package__")?;
     let calc_slot = shadow_stack_len();
-    pin_root(w_calc);
+    let _ = pin_root(w_calc);
     let w_package = crate::call::call_function_impl_result(
         shadow_stack_get(calc_slot),
         &[shadow_stack_get(globals_slot)],
     )
     .map_err(strip_bootstrap_traceback_frames)?;
     let package_slot = shadow_stack_len();
-    pin_root(w_package);
+    let _ = pin_root(w_package);
 
     // `_bootstrap.__import__` — `module = _gcd_import(name, package, level)`.
     // `_sanity_check` / `_resolve_name` validate `package` and `level` in there,
     // so running it before the slice below keeps their diagnostics first.
     let w_gcd = crate::baseobjspace::getattr_str(shadow_stack_get(bootstrap_slot), "_gcd_import")?;
     let gcd_slot = shadow_stack_len();
-    pin_root(w_gcd);
+    let _ = pin_root(w_gcd);
     let w_module = crate::call::call_function_impl_result(
         shadow_stack_get(gcd_slot),
         &[
@@ -5130,7 +5128,7 @@ fn relative_import_head(
     )
     .map_err(strip_bootstrap_traceback_frames)?;
     let module_slot = shadow_stack_len();
-    pin_root(w_module);
+    let _ = pin_root(w_module);
 
     // No dot in `name`: the imported module is already the head.
     let Some(dot) = name.find('.') else {
@@ -5142,7 +5140,7 @@ fn relative_import_head(
     let w_resolve =
         crate::baseobjspace::getattr_str(shadow_stack_get(bootstrap_slot), "_resolve_name")?;
     let resolve_slot = shadow_stack_len();
-    pin_root(w_resolve);
+    let _ = pin_root(w_resolve);
     let w_abs_name = crate::call::call_function_impl_result(
         shadow_stack_get(resolve_slot),
         &[
@@ -5153,7 +5151,7 @@ fn relative_import_head(
     )
     .map_err(strip_bootstrap_traceback_frames)?;
     let abs_slot = shadow_stack_len();
-    pin_root(w_abs_name);
+    let _ = pin_root(w_abs_name);
     // Owned: the slicing below outlives the allocations that follow it.
     let abs_name = crate::baseobjspace::utf8_w(shadow_stack_get(abs_slot))?.to_string();
     let cut_off = name.len() - dot;
@@ -5164,7 +5162,7 @@ fn relative_import_head(
         .unwrap_or(abs_name.as_str());
 
     let head_slot = shadow_stack_len();
-    pin_root(pyre_object::w_str_new(head));
+    let _ = pin_root(pyre_object::w_str_new(head));
     // The raw `sys.modules` entry, `None` sentinel included: only a *missing*
     // key is the KeyError.
     let w_modules = sys_modules_dict();
@@ -5409,7 +5407,7 @@ pub(crate) fn spec_file_origin(w_spec: PyObjectRef) -> Result<Option<PyObjectRef
     // pin the spec and read it back before the `origin` lookup.
     let _scope = pyre_object::gc_roots::push_roots();
     let spec_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_spec);
+    let w_spec = pyre_object::gc_roots::pin_root(w_spec);
     let w_has_location = match crate::baseobjspace::getattr_str(w_spec, "has_location") {
         Ok(v) => v,
         Err(e) if e.kind == crate::PyErrorKind::AttributeError => return Ok(None),
@@ -5488,7 +5486,7 @@ pub(crate) fn module_shadow_info(
     if let Some(sys_mod) = get_sys_module("sys") {
         let _scope = pyre_object::gc_roots::push_roots();
         let name_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_name);
+        let w_name = pyre_object::gc_roots::pin_root(w_name);
         let w_names = match crate::baseobjspace::getattr_str(sys_mod, "stdlib_module_names") {
             Ok(v) => v,
             Err(e) if e.kind == crate::PyErrorKind::AttributeError => pyre_object::w_none(),
@@ -5603,7 +5601,7 @@ pub fn import_from(
     // The `__file__` lookup below can run a descriptor or `__getattr__` and so
     // collect; the name string is young and movable, so pin it and read it
     // back from the slot afterwards.
-    pyre_object::gc_roots::pin_root(w_pkgname);
+    let _ = pyre_object::gc_roots::pin_root(w_pkgname);
     // pypy/module/imp/importing.py get_path — a non-str `__file__`
     // (including None) reports the location as unknown.
     let w_pkgpath = match crate::baseobjspace::getattr_str(module, "__file__") {
@@ -5616,7 +5614,7 @@ pub fn import_from(
     };
     // Pin the path string across the spec lookups below (which allocate) too.
     let pkgpath_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_pkgpath);
+    let _ = pyre_object::gc_roots::pin_root(w_pkgpath);
     let w_pkgname = pyre_object::gc_roots::shadow_stack_get(pkgname_slot);
     // Own the name so the spec lookups below (which allocate) cannot dangle it.
     let pkgname = unsafe { pyre_object::w_str_get_value(w_pkgname) }.to_string();
@@ -5625,7 +5623,7 @@ pub fn import_from(
     // reports the circular-import cause, then an unset submodule slot.
     let w_spec = get_spec(module)?;
     let spec_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_spec);
+    let w_spec = pyre_object::gc_roots::pin_root(w_spec);
     let w_pkgname = pyre_object::gc_roots::shadow_stack_get(pkgname_slot);
     let (origin, is_shadowing, is_shadowing_stdlib) = module_shadow_info(w_spec, w_pkgname)?;
     let w_spec = pyre_object::gc_roots::shadow_stack_get(spec_slot);

--- a/pyre/pyre-interpreter/src/listobject.rs
+++ b/pyre/pyre-interpreter/src/listobject.rs
@@ -54,9 +54,9 @@ pub fn w_list_find_or_count(
     // locals re-read each iteration, so pin them on the shadow stack.
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let item_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_item);
+    let _ = pyre_object::gc_roots::pin_root(w_item);
     while i < stop
         && i < unsafe { pyre_object::w_list_len(pyre_object::gc_roots::shadow_stack_get(obj_slot)) }
             as i64
@@ -95,7 +95,7 @@ pub fn w_list_remove(obj: PyObjectRef, w_value: PyObjectRef) -> Result<(), PyErr
     // address the list at its pre-move header.
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let obj = pyre_object::gc_roots::pin_root(obj);
     let i = match w_list_find_or_count(obj, w_value, 0, i64::MAX, false)? {
         FindOrCountResult::Index(i) => i,
         FindOrCountResult::NotFound => {

--- a/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
@@ -386,8 +386,8 @@ impl W_PickleBuffer {
         }
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(self.w_obj);
-        pyre_object::gc_roots::pin_root(self.w_release_exporter);
+        let _ = pyre_object::gc_roots::pin_root(self.w_obj);
+        let _ = pyre_object::gc_roots::pin_root(self.w_release_exporter);
         let w_obj = pyre_object::gc_roots::shadow_stack_get(sp);
         if self.export_active {
             self.export_active = false;
@@ -494,13 +494,13 @@ fn acquire_pickle_buffer(obj: PyObjectRef) -> Result<(PyObjectRef, bool, PyObjec
 
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
-        pyre_object::gc_roots::pin_root(pyre_object::w_int_new(
+        let _ = pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(
             crate::baseobjspace::BUF_FULL_RO as i64,
         ));
         let r_obj = pyre_object::gc_roots::shadow_stack_get(sp);
         if let Some(w_impl) = crate::baseobjspace::lookup(r_obj, "__buffer__") {
-            pyre_object::gc_roots::pin_root(w_impl);
+            let _ = pyre_object::gc_roots::pin_root(w_impl);
             let w_type = crate::typedef::r#type(r_obj).map_or(r_obj, |p| p.as_ptr());
             let w_result = crate::baseobjspace::get_and_call_function(
                 pyre_object::gc_roots::shadow_stack_get(sp + 2),

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -578,9 +578,9 @@ fn subclass_of(cls: PyObjectRef, subclass: PyObjectRef) -> Result<bool, crate::P
     // `ABCMeta.__subclasscheck__`.
     let roots = pyre_object::gc_roots::push_roots();
     let cls_slot = roots.base();
-    roots.pin_root(cls);
+    let _ = roots.pin_root(cls);
     let subclass_slot = cls_slot + 1;
-    roots.pin_root(subclass);
+    let _ = roots.pin_root(subclass);
 
     // `app_abc.py:130-131` — a positive hit is final: nothing invalidates it,
     // since `register` can only ever add subclasses.
@@ -620,7 +620,7 @@ fn subclass_of(cls: PyObjectRef, subclass: PyObjectRef) -> Result<bool, crate::P
         if !hook.is_null() {
             let hook_roots = pyre_object::gc_roots::push_roots();
             let hook_slot = hook_roots.base();
-            hook_roots.pin_root(hook);
+            let _ = hook_roots.pin_root(hook);
             let ok = crate::call::call_function_impl_result(
                 hook_roots.get(hook_slot),
                 &[roots.get(subclass_slot)],
@@ -649,10 +649,10 @@ fn subclass_of(cls: PyObjectRef, subclass: PyObjectRef) -> Result<bool, crate::P
         {
             let registry_roots = pyre_object::gc_roots::push_roots();
             let registry_slot = registry_roots.base();
-            registry_roots.pin_root(registry);
+            let _ = registry_roots.pin_root(registry);
             let iterator = crate::baseobjspace::iter(registry_roots.get(registry_slot))?;
             let iterator_slot = registry_slot + 1;
-            registry_roots.pin_root(iterator);
+            let _ = registry_roots.pin_root(iterator);
             loop {
                 let rcls = match crate::baseobjspace::next(registry_roots.get(iterator_slot)) {
                     Ok(rcls) => rcls,
@@ -661,7 +661,7 @@ fn subclass_of(cls: PyObjectRef, subclass: PyObjectRef) -> Result<bool, crate::P
                 };
                 let item_roots = pyre_object::gc_roots::push_roots();
                 let rcls_slot = item_roots.base();
-                item_roots.pin_root(rcls);
+                let _ = item_roots.pin_root(rcls);
                 if crate::baseobjspace::issubclass(
                     roots.get(subclass_slot),
                     item_roots.get(rcls_slot),
@@ -678,13 +678,13 @@ fn subclass_of(cls: PyObjectRef, subclass: PyObjectRef) -> Result<bool, crate::P
             crate::baseobjspace::getattr_str(roots.get(cls_slot), "__subclasses__")?;
         let walk_roots = pyre_object::gc_roots::push_roots();
         let method_slot = walk_roots.base();
-        walk_roots.pin_root(subclasses_method);
+        let _ = walk_roots.pin_root(subclasses_method);
         let subclasses = crate::call::call_function_impl_result(walk_roots.get(method_slot), &[])?;
         let subclasses_slot = method_slot + 1;
-        walk_roots.pin_root(subclasses);
+        let _ = walk_roots.pin_root(subclasses);
         let iterator = crate::baseobjspace::iter(walk_roots.get(subclasses_slot))?;
         let iterator_slot = subclasses_slot + 1;
-        walk_roots.pin_root(iterator);
+        let _ = walk_roots.pin_root(iterator);
         loop {
             let scls = match crate::baseobjspace::next(walk_roots.get(iterator_slot)) {
                 Ok(scls) => scls,
@@ -693,7 +693,7 @@ fn subclass_of(cls: PyObjectRef, subclass: PyObjectRef) -> Result<bool, crate::P
             };
             let item_roots = pyre_object::gc_roots::push_roots();
             let scls_slot = item_roots.base();
-            item_roots.pin_root(scls);
+            let _ = item_roots.pin_root(scls);
             if crate::baseobjspace::issubclass(roots.get(subclass_slot), item_roots.get(scls_slot))?
             {
                 break 'decide true;

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -1740,7 +1740,7 @@ fn module_to_object(
 ) -> crate::PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let ast_module = Rooted(pyre_object::gc_roots::shadow_stack_len());
-    pyre_object::gc_roots::pin_root(module_object);
+    let _ = pyre_object::gc_roots::pin_root(module_object);
     let converter = Converter { source, ast_module };
     let root = match module {
         ast::Mod::Expression(module) => converter.node(
@@ -1801,7 +1801,7 @@ impl Converter<'_> {
     /// where it was forwarded to.
     fn pin(&self, value: PyObjectRef) -> Rooted {
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
         Rooted(slot)
     }
 

--- a/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
@@ -157,9 +157,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // of its slot at every use.
         let roots = pyre_object::gc_roots::push_roots();
         let dict_slot = roots.base();
-        roots.pin_root(pyre_object::w_dict_new());
+        let _ = roots.pin_root(pyre_object::w_dict_new());
         let field_types_slot = dict_slot + 1;
-        roots.pin_root(pyre_object::w_dict_new());
+        let _ = roots.pin_root(pyre_object::w_dict_new());
         // The value arrives already built.  Call arguments evaluate left to
         // right, so reading a dict slot inline with an allocating value
         // expression would read the slot first and hand over a pre-move word.
@@ -167,7 +167,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         let put = |target_slot: usize, key: &str, value: PyObjectRef| -> crate::PyResult {
             let value_roots = pyre_object::gc_roots::push_roots();
             let value_slot = value_roots.base();
-            value_roots.pin_root(value);
+            let _ = value_roots.pin_root(value);
             let key = pyre_object::w_str_new(key);
             crate::baseobjspace::setitem(roots.get(target_slot), key, value_roots.get(value_slot))
         };

--- a/pyre/pyre-interpreter/src/module/_bisect/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_bisect/mod.rs
@@ -39,7 +39,7 @@ impl BisectArgs {
 /// this argument, is what holds the forwarded object afterwards.
 fn pin(value: PyObjectRef) -> usize {
     let slot = shadow_stack_len();
-    pin_root(value);
+    let _ = pin_root(value);
     slot
 }
 

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -698,7 +698,7 @@ pub(crate) fn encode_text_codec(
     // Rooted for the same window as `decode_text_codec`: the lookup runs
     // Python while `w_obj` is still whatever the caller handed over.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let w_obj = pyre_object::gc_roots::pin_root(w_obj);
     let w_codec_info = lookup_text_codec("encode", encoding)?;
     if crate::importing::dev_mode_flag() {
         validate_error_handler(errors)?;
@@ -727,7 +727,7 @@ pub(crate) fn decode_text_codec(
     // swept mid-lookup and the decoder is handed a reused box.  Bytes do not
     // move, so the pin is for liveness alone and the value is used as it is.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let w_obj = pyre_object::gc_roots::pin_root(w_obj);
     let w_codec_info = lookup_text_codec("decode", encoding)?;
     if crate::importing::dev_mode_flag() {
         validate_error_handler(errors)?;

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -145,8 +145,7 @@ fn deque_len(self_obj: PyObjectRef) -> i64 {
 fn snapshot(self_obj: PyObjectRef) -> Vec<PyObjectRef> {
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
-    let self_obj = pyre_object::gc_roots::shadow_stack_get(root_base);
+    let self_obj = pyre_object::gc_roots::pin_root(self_obj);
     let _deque_guard = unsafe { w_deque_lock(self_obj) };
     let self_obj = pyre_object::gc_roots::shadow_stack_get(root_base);
     let Some(deque) = W_Deque::from_obj(self_obj) else {
@@ -195,8 +194,7 @@ fn store(self_obj: PyObjectRef, items: Vec<PyObjectRef>) {
 fn clear_blocks(self_obj: PyObjectRef) {
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
-    let self_obj = pyre_object::gc_roots::shadow_stack_get(root_base);
+    let self_obj = pyre_object::gc_roots::pin_root(self_obj);
     let _deque_guard = unsafe { w_deque_lock(self_obj) };
     let self_obj = pyre_object::gc_roots::shadow_stack_get(root_base);
     let new_block = deque_block::new(PY_NULL, PY_NULL);
@@ -383,7 +381,7 @@ pub mod deque_iter {
             }
         }
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(deque);
+        let deque = pyre_object::gc_roots::pin_root(deque);
         W_DequeIter::allocate_stable(W_DequeIter {
             ob: PyObject {
                 ob_type: std::ptr::null(),
@@ -503,7 +501,7 @@ pub mod deque_rev_iter {
             }
         }
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(deque);
+        let deque = pyre_object::gc_roots::pin_root(deque);
         W_DequeRevIter::allocate_stable(W_DequeRevIter {
             ob: PyObject {
                 ob_type: std::ptr::null(),
@@ -540,7 +538,7 @@ fn extend_from_iterable(
     let items = crate::builtins::collect_iterable(iterable)?;
     let _roots = pyre_object::gc_roots::push_roots();
     let deque_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
+    let _ = pyre_object::gc_roots::pin_root(self_obj);
     let item_base = pyre_object::gc_roots::pin_roots(&items);
     for index in 0..items.len() {
         append(
@@ -555,8 +553,8 @@ fn extend_from_iterable(
 fn append_right(self_obj: PyObjectRef, item: PyObjectRef) {
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
-    pyre_object::gc_roots::pin_root(item);
+    let _ = pyre_object::gc_roots::pin_root(self_obj);
+    let _ = pyre_object::gc_roots::pin_root(item);
     let self_obj = pyre_object::gc_roots::shadow_stack_get(root_base);
     let _deque_guard = unsafe { w_deque_lock(self_obj) };
     let self_obj = pyre_object::gc_roots::shadow_stack_get(root_base);
@@ -586,8 +584,8 @@ fn append_right(self_obj: PyObjectRef, item: PyObjectRef) {
 fn append_left(self_obj: PyObjectRef, item: PyObjectRef) {
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
-    pyre_object::gc_roots::pin_root(item);
+    let _ = pyre_object::gc_roots::pin_root(self_obj);
+    let _ = pyre_object::gc_roots::pin_root(item);
     let self_obj = pyre_object::gc_roots::shadow_stack_get(root_base);
     let _deque_guard = unsafe { w_deque_lock(self_obj) };
     let self_obj = pyre_object::gc_roots::shadow_stack_get(root_base);
@@ -617,8 +615,7 @@ fn append_left(self_obj: PyObjectRef, item: PyObjectRef) {
 fn pop_right(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
-    let self_obj = pyre_object::gc_roots::shadow_stack_get(root_base);
+    let self_obj = pyre_object::gc_roots::pin_root(self_obj);
     let _deque_guard = unsafe { w_deque_lock(self_obj) };
     let self_obj = pyre_object::gc_roots::shadow_stack_get(root_base);
     let deque = W_Deque::from_obj(self_obj).expect("deque");
@@ -649,8 +646,7 @@ fn pop_right(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
 fn pop_left(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
-    let self_obj = pyre_object::gc_roots::shadow_stack_get(root_base);
+    let self_obj = pyre_object::gc_roots::pin_root(self_obj);
     let _deque_guard = unsafe { w_deque_lock(self_obj) };
     let self_obj = pyre_object::gc_roots::shadow_stack_get(root_base);
     let deque = W_Deque::from_obj(self_obj).expect("deque");
@@ -1246,7 +1242,7 @@ impl W_Deque {
         }
         let _roots = pyre_object::gc_roots::push_roots();
         let root_base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(copy);
+        let _ = pyre_object::gc_roots::pin_root(copy);
         for item in snapshot(other) {
             append_right(pyre_object::gc_roots::shadow_stack_get(root_base), item);
         }

--- a/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
@@ -409,12 +409,22 @@ fn new_token(
     var: PyObjectRef,
     old_value: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let token = w_instance_new(token_type());
-    crate::baseobjspace::setattr_str(token, "_context", context)?;
-    crate::baseobjspace::setattr_str(token, "_var", var)?;
-    crate::baseobjspace::setattr_str(token, "_old_value", old_value)?;
-    crate::baseobjspace::setattr_str(token, "_used", w_bool_from(false))?;
-    Ok(token)
+    // The three values arrive as native words and outlive the allocation
+    // below and four attribute stores, each of which can collect; `old_value`
+    // is whatever the caller last set, a list or a dict included.  The token
+    // takes a slot of its own for liveness: an instance never moves, but one
+    // nothing refers to yet is still swept.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::pin_roots(&[context, var, old_value]);
+    let token_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_instance_new(token_type()));
+    let token = || pyre_object::gc_roots::shadow_stack_get(token_slot);
+    let value_at = |offset: usize| pyre_object::gc_roots::shadow_stack_get(base + offset);
+    crate::baseobjspace::setattr_str(token(), "_context", value_at(0))?;
+    crate::baseobjspace::setattr_str(token(), "_var", value_at(1))?;
+    crate::baseobjspace::setattr_str(token(), "_old_value", value_at(2))?;
+    crate::baseobjspace::setattr_str(token(), "_used", w_bool_from(false))?;
+    Ok(token())
 }
 
 fn token_var_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
@@ -201,15 +201,17 @@ fn context_var_set(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     let value = || pyre_object::gc_roots::shadow_stack_get(args_base + 1);
 
     let context_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(current_context(true)?.expect("create=true returns a Context"));
+    let _ = pyre_object::gc_roots::pin_root(
+        current_context(true)?.expect("create=true returns a Context"),
+    );
     let context = || pyre_object::gc_roots::shadow_stack_get(context_slot);
 
     let data_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(context(), "_data")?);
+    let _ = pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(context(), "_data")?);
     let data = || pyre_object::gc_roots::shadow_stack_get(data_slot);
 
     let old_value_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(match crate::baseobjspace::getitem(data(), var()) {
+    let _ = pyre_object::gc_roots::pin_root(match crate::baseobjspace::getitem(data(), var()) {
         Ok(value) => value,
         Err(err) if err.kind == crate::PyErrorKind::KeyError => token_missing(),
         Err(err) => return Err(err),
@@ -251,7 +253,7 @@ fn context_var_reset(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         )));
     }
     let token_var_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(token(), "_var")?);
+    let _ = pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(token(), "_var")?);
     let token_var = || pyre_object::gc_roots::shadow_stack_get(token_var_slot);
     if !std::ptr::eq(token_var(), var()) {
         return Err(crate::PyError::value_error(
@@ -259,7 +261,9 @@ fn context_var_reset(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         ));
     }
     let context_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(current_context(true)?.expect("create=true returns a Context"));
+    let _ = pyre_object::gc_roots::pin_root(
+        current_context(true)?.expect("create=true returns a Context"),
+    );
     let context = || pyre_object::gc_roots::shadow_stack_get(context_slot);
     if !std::ptr::eq(
         crate::baseobjspace::getattr_str(token(), "_context")?,
@@ -270,10 +274,11 @@ fn context_var_reset(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         ));
     }
     let data_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(context(), "_data")?);
+    let _ = pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(context(), "_data")?);
     let data = || pyre_object::gc_roots::shadow_stack_get(data_slot);
     let old_value_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(token(), "_old_value")?);
+    let _ =
+        pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(token(), "_old_value")?);
     let old_value = || pyre_object::gc_roots::shadow_stack_get(old_value_slot);
     let updated_data = if std::ptr::eq(old_value(), token_missing()) {
         call_method_result(data(), "delete", &[token_var()])?
@@ -417,7 +422,7 @@ fn new_token(
     let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::pin_roots(&[context, var, old_value]);
     let token_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_instance_new(token_type()));
+    let _ = pyre_object::gc_roots::pin_root(w_instance_new(token_type()));
     let token = || pyre_object::gc_roots::shadow_stack_get(token_slot);
     let value_at = |offset: usize| pyre_object::gc_roots::shadow_stack_get(base + offset);
     crate::baseobjspace::setattr_str(token(), "_context", value_at(0))?;

--- a/pyre/pyre-interpreter/src/module/_csv/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_csv/mod.rs
@@ -353,7 +353,7 @@ fn config_to_dialect(cfg: &DialectConfig) -> Result<PyObjectRef, PyError> {
     let d = pyre_object::w_instance_new(dialect_class::type_object());
     let _roots = gc_roots::push_roots();
     let slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(d);
+    let _ = gc_roots::pin_root(d);
     let set = |name: &str, val: PyObjectRef| -> Result<(), PyError> {
         let d = gc_roots::shadow_stack_get(slot);
         crate::baseobjspace::setattr_str(d, name, val)?;
@@ -645,7 +645,7 @@ fn reader_next_impl(self_obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
     }
     let _roots = gc_roots::push_roots();
     let self_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(self_obj);
+    let _ = gc_roots::pin_root(self_obj);
     crate::baseobjspace::setattr_str(
         gc_roots::shadow_stack_get(self_slot),
         "_reading",
@@ -678,9 +678,9 @@ fn reader_next_inner(self_obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
 
     let _roots = gc_roots::push_roots();
     let iter_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(crate::baseobjspace::getattr_str(self_obj, "_iterator")?);
+    let _ = gc_roots::pin_root(crate::baseobjspace::getattr_str(self_obj, "_iterator")?);
     let self_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(self_obj);
+    let _ = gc_roots::pin_root(self_obj);
 
     let mut fields: Vec<(String, bool, usize)> = Vec::new();
     let mut field = String::new();
@@ -836,7 +836,7 @@ fn reader_next_inner(self_obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
 
     let result = pyre_object::listobject::w_list_new(Vec::new());
     let result_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(result);
+    let _ = gc_roots::pin_root(result);
     for (s, unquoted, len) in fields {
         // `parse_save_field` quoting conversions: an empty unquoted field is
         // `None` under QUOTE_NOTNULL / QUOTE_STRINGS; a non-empty unquoted
@@ -929,10 +929,10 @@ fn writer_writerow_impl(
     // remaining type queries.
     let _roots = pyre_object::gc_roots::push_roots();
     let write_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_filewrite);
+    let _ = pyre_object::gc_roots::pin_root(w_filewrite);
     let row_base = pyre_object::gc_roots::shadow_stack_len();
     for &item in &row {
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
     }
 
     for i in 0..n {
@@ -1058,9 +1058,9 @@ fn writer_writerows_impl(
     let it = crate::baseobjspace::iter(w_seqseq)?;
     let _roots = gc_roots::push_roots();
     let it_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(it);
+    let _ = gc_roots::pin_root(it);
     let self_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(self_obj);
+    let _ = gc_roots::pin_root(self_obj);
     loop {
         let it = gc_roots::shadow_stack_get(it_slot);
         let row = match crate::baseobjspace::next(it) {
@@ -1196,9 +1196,9 @@ crate::py_module! {
             let r = pyre_object::w_instance_new(reader_class::type_object());
             let _roots = gc_roots::push_roots();
             let slot = gc_roots::shadow_stack_len();
-            gc_roots::pin_root(r);
-            gc_roots::pin_root(dialect_obj);
-            gc_roots::pin_root(w_iter);
+            let _ = gc_roots::pin_root(r);
+            let _ = gc_roots::pin_root(dialect_obj);
+            let _ = gc_roots::pin_root(w_iter);
             crate::baseobjspace::setattr_str(gc_roots::shadow_stack_get(slot), "dialect", gc_roots::shadow_stack_get(slot + 1))?;
             crate::baseobjspace::setattr_str(gc_roots::shadow_stack_get(slot), "_iterator", gc_roots::shadow_stack_get(slot + 2))?;
             crate::baseobjspace::setattr_str(gc_roots::shadow_stack_get(slot), "line_num", pyre_object::w_int_new(0))?;
@@ -1236,9 +1236,9 @@ crate::py_module! {
             let w = pyre_object::w_instance_new(writer_class::type_object());
             let _roots = gc_roots::push_roots();
             let slot = gc_roots::shadow_stack_len();
-            gc_roots::pin_root(w);
-            gc_roots::pin_root(dialect_obj);
-            gc_roots::pin_root(w_write);
+            let _ = gc_roots::pin_root(w);
+            let _ = gc_roots::pin_root(dialect_obj);
+            let _ = gc_roots::pin_root(w_write);
             crate::baseobjspace::setattr_str(gc_roots::shadow_stack_get(slot), "dialect", gc_roots::shadow_stack_get(slot + 1))?;
             crate::baseobjspace::setattr_str(gc_roots::shadow_stack_get(slot), "_write", gc_roots::shadow_stack_get(slot + 2))?;
             Ok(gc_roots::shadow_stack_get(slot))

--- a/pyre/pyre-interpreter/src/module/_ctypes/callbacks.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/callbacks.rs
@@ -47,7 +47,7 @@ mod imp {
     pub(super) fn build_thunk(obj: PyObjectRef) -> Result<Option<usize>, crate::PyError> {
         let _roots = pyre_object::gc_roots::push_roots();
         let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         let current_obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
         let argtypes = funcptr::resolve_argtypes(current_obj()).unwrap_or_default();
         // The whole livevar set is published before the first forwarding query:
@@ -220,14 +220,14 @@ mod imp {
         let _callback = crate::module::thread::enter_external_callback_from_foreign_thread();
         let _roots = pyre_object::gc_roots::push_roots();
         let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(unsafe { *userdata.slot } as PyObjectRef);
+        let _ = pyre_object::gc_roots::pin_root(unsafe { *userdata.slot } as PyObjectRef);
         let current_obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
         let use_errno = funcptr::funcptr_flags(current_obj()) & funcptr::FUNCFLAG_USE_ERRNO != 0;
         let call_result = match decode_args(current_obj(), args) {
             Ok(decoded) => host_ctypes::with_callback_errno_preserved(use_errno, || {
                 let callable = funcptr::instance_get(current_obj(), funcptr::CALLABLE_KEY)
                     .ok_or_else(|| crate::PyError::type_error("callback has no callable"))?;
-                pyre_object::gc_roots::pin_root(callable);
+                let _ = pyre_object::gc_roots::pin_root(callable);
                 let callable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 crate::call::call_function_impl_result(
                     pyre_object::gc_roots::shadow_stack_get(callable_slot),
@@ -242,7 +242,7 @@ mod imp {
         // `restype` cannot represent.
         let written = match funcptr::callback_result(current_obj(), call_result) {
             Ok(value) => {
-                pyre_object::gc_roots::pin_root(value);
+                let _ = pyre_object::gc_roots::pin_root(value);
                 let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 write_result(
                     current_obj(),
@@ -284,7 +284,7 @@ mod imp {
             match decode_arg(at, p) {
                 Ok(value) => {
                     decoded_slots.push(pyre_object::gc_roots::shadow_stack_len());
-                    pyre_object::gc_roots::pin_root(value);
+                    let _ = pyre_object::gc_roots::pin_root(value);
                 }
                 Err(error) => return Err(error),
             }
@@ -305,7 +305,7 @@ mod imp {
             let address = unsafe { *(p as *const usize) };
             let inst = crate::call::type_call_instantiate(at, &[])?;
             let inst_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(inst);
+            let _ = pyre_object::gc_roots::pin_root(inst);
             funcptr::store_funcptr_addr(
                 pyre_object::gc_roots::shadow_stack_get(inst_slot),
                 address,
@@ -330,7 +330,7 @@ mod imp {
         if let Some(size) = cdata::ctype_size_of(at) {
             let inst = crate::call::type_call_instantiate(at, &[])?;
             let inst_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(inst);
+            let _ = pyre_object::gc_roots::pin_root(inst);
             let bytes = unsafe { host_ctypes::borrow_memory(p.cast::<u8>(), size) };
             cdata::cdata_write(pyre_object::gc_roots::shadow_stack_get(inst_slot), 0, bytes);
             return Ok(pyre_object::gc_roots::shadow_stack_get(inst_slot));

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -210,7 +210,7 @@ fn cdata_from_buffer(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     let view_obj = crate::builtins::w_memoryview_new(args[1])?;
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(view_obj);
+    let view_obj = pyre_object::gc_roots::pin_root(view_obj);
     let view = unsafe { pyre_object::memoryview::w_memoryview_view(view_obj) };
     if view.readonly() {
         return Err(crate::PyError::type_error(
@@ -374,7 +374,7 @@ pub(super) fn simple_from_param(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
     // lookup and the carrier allocate — the address is into its buffer, so the
     // instance has to outlive them.  It does not move, so one pin is enough.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(converted);
+    let converted = pyre_object::gc_roots::pin_root(converted);
     let addr = cdata_addr(converted)
         .ok_or_else(|| crate::PyError::type_error("ctypes instance has no buffer"))?;
     Ok(super::interp_ctypes::make_carg(addr, converted))
@@ -407,7 +407,7 @@ pub(super) fn new_simplecdata_obj(
     // runs, and that call can run Python.  It does not move, so it is pinned once
     // and never re-read; the bytearray rides along through the instance dict.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(obj);
+    let obj = pyre_object::gc_roots::pin_root(obj);
     let ba = cdata_buffer(obj).expect("new cdata object has a backing buffer");
     // Encode after the instance exists so a `char*` keepalive can attach to it.
     if let Some(v) = value {
@@ -415,7 +415,7 @@ pub(super) fn new_simplecdata_obj(
         // `dict`, both of which move: pin it before the encode and read the slot
         // back where it is stored.
         let v_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(v);
+        let v = pyre_object::gc_roots::pin_root(v);
         let mut bytes = encode_value_into(tc, v, obj, "0")?;
         if unsafe { crate::baseobjspace::lookup_in_type(cls, "_swappedbytes_") }.is_some() {
             bytes.reverse();
@@ -444,9 +444,9 @@ pub(super) fn new_cdata_obj_from_bytes(
     // them live and no word has to be re-read.
     let ba = pyre_object::w_bytearray_new(size);
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(ba);
+    let ba = pyre_object::gc_roots::pin_root(ba);
     let obj = pyre_object::w_instance_new(cls);
-    pyre_object::gc_roots::pin_root(obj);
+    let obj = pyre_object::gc_roots::pin_root(obj);
     let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return Err(crate::PyError::type_error(
@@ -509,7 +509,7 @@ fn value_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // and read the slot back where it is stored.
     let _roots = pyre_object::gc_roots::push_roots();
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(value);
+    let value = pyre_object::gc_roots::pin_root(value);
     let mut bytes = encode_value_into(&tc, value, obj, "0")?;
     if unsafe { crate::baseobjspace::lookup_in_type(cls, "_swappedbytes_") }.is_some() {
         bytes.reverse();
@@ -879,12 +879,12 @@ pub(super) fn make_subview(
     // consume a pre-move dictionary word.
     let _roots = pyre_object::gc_roots::push_roots();
     let inst = pyre_object::w_instance_new(proto);
-    pyre_object::gc_roots::pin_root(inst);
+    let inst = pyre_object::gc_roots::pin_root(inst);
     let d = crate::baseobjspace::getdict_native(inst);
     if d.is_null() {
         return inst;
     }
-    pyre_object::gc_roots::pin_root(d);
+    let _ = pyre_object::gc_roots::pin_root(d);
     let d_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     unsafe {
         if let Some(ba) = cdata_buffer(parent) {
@@ -933,10 +933,10 @@ pub(super) fn make_indexed_subview(
     // `make_subview` dropped its own root bracket on the way out, so the view is
     // reachable only from this frame again across the lookup and the store.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(view);
+    let view = pyre_object::gc_roots::pin_root(view);
     let d = crate::baseobjspace::getdict_native(view);
     if !d.is_null() {
-        pyre_object::gc_roots::pin_root(d);
+        let _ = pyre_object::gc_roots::pin_root(d);
         let d_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_index = pyre_object::w_int_new(index as i64);
         unsafe {
@@ -964,10 +964,10 @@ pub(super) fn make_at_address(
     // the stores below; it does not move, so one pin covers it.
     let _roots = pyre_object::gc_roots::push_roots();
     let inst = pyre_object::w_instance_new(proto);
-    pyre_object::gc_roots::pin_root(inst);
+    let inst = pyre_object::gc_roots::pin_root(inst);
     let d = crate::baseobjspace::getdict_native(inst);
     if !d.is_null() {
-        pyre_object::gc_roots::pin_root(d);
+        let _ = pyre_object::gc_roots::pin_root(d);
         let d_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         unsafe {
             let w_address = pyre_object::w_int_new(address as i64);
@@ -998,11 +998,11 @@ pub(super) fn make_at_address(
 /// storing it under `key` in the ultimate root's `"_objects_"` dict.
 pub(super) fn keep_ref(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // Walk `_b_base_` up to the owning root.
     let mut root = anchor;
-    pyre_object::gc_roots::pin_root(root);
+    let mut root = pyre_object::gc_roots::pin_root(root);
     let mut root_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let mut composite_key = key.to_string();
     loop {
@@ -1020,7 +1020,7 @@ pub(super) fn keep_ref(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
         match unsafe { pyre_object::w_dict_getitem_str(d, BBASE_KEY) } {
             Some(base) if !base.is_null() && !unsafe { pyre_object::is_none(base) } => {
                 root = base;
-                pyre_object::gc_roots::pin_root(root);
+                let _ = pyre_object::gc_roots::pin_root(root);
                 root_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             }
             _ => break,
@@ -1042,9 +1042,11 @@ pub(super) fn keep_ref(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
     };
     let objs_slot = pyre_object::gc_roots::shadow_stack_len();
     match existing {
-        Some(objs) => pyre_object::gc_roots::pin_root(objs),
+        Some(objs) => {
+            let _ = pyre_object::gc_roots::pin_root(objs);
+        }
         None => {
-            pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+            let _ = pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
             root = pyre_object::gc_roots::shadow_stack_get(root_slot);
             d = crate::baseobjspace::getdict_native(root);
             let nd = pyre_object::gc_roots::shadow_stack_get(objs_slot);
@@ -1073,7 +1075,7 @@ pub(super) fn keep_ref(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
 /// CData value with no inner references yet.
 pub(super) fn objects_for_keep(value: PyObjectRef) -> PyObjectRef {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(value);
+    let value = pyre_object::gc_roots::pin_root(value);
     let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let mut d = crate::baseobjspace::getdict_native(value);
     if d.is_null() {
@@ -1083,7 +1085,7 @@ pub(super) fn objects_for_keep(value: PyObjectRef) -> PyObjectRef {
         Some(objects) if !objects.is_null() && !unsafe { pyre_object::is_none(objects) } => objects,
         _ => {
             let objects_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+            let _ = pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
             let value = pyre_object::gc_roots::shadow_stack_get(value_slot);
             d = crate::baseobjspace::getdict_native(value);
             let objects = pyre_object::gc_roots::shadow_stack_get(objects_slot);
@@ -1100,10 +1102,10 @@ pub(super) fn objects_for_keep(value: PyObjectRef) -> PyObjectRef {
 /// root instance dict rather than in the user-visible keepalive dictionary.
 fn keep_alive(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(obj);
+    let obj = pyre_object::gc_roots::pin_root(obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let mut root = anchor;
-    pyre_object::gc_roots::pin_root(root);
+    let mut root = pyre_object::gc_roots::pin_root(root);
     let mut root_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     loop {
         root = pyre_object::gc_roots::shadow_stack_get(root_slot);
@@ -1114,7 +1116,7 @@ fn keep_alive(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
         match unsafe { pyre_object::w_dict_getitem_str(d, BBASE_KEY) } {
             Some(base) if !base.is_null() && !unsafe { pyre_object::is_none(base) } => {
                 root = base;
-                pyre_object::gc_roots::pin_root(root);
+                let _ = pyre_object::gc_roots::pin_root(root);
                 root_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             }
             _ => break,
@@ -1139,12 +1141,12 @@ pub(super) fn share_objects_for_cast(result: PyObjectRef, source: PyObjectRef) {
     // lifetime explicitly across `w_dict_new` and `w_dict_setitem` (the latter
     // allocates the integer identity key and can trigger a nursery collection).
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(result);
+    let result = pyre_object::gc_roots::pin_root(result);
     let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(source);
+    let source = pyre_object::gc_roots::pin_root(source);
     let source_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let mut root = source;
-    pyre_object::gc_roots::pin_root(root);
+    let mut root = pyre_object::gc_roots::pin_root(root);
     let mut root_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     loop {
         root = pyre_object::gc_roots::shadow_stack_get(root_slot);
@@ -1155,7 +1157,7 @@ pub(super) fn share_objects_for_cast(result: PyObjectRef, source: PyObjectRef) {
         match unsafe { pyre_object::w_dict_getitem_str(d, BBASE_KEY) } {
             Some(base) if !base.is_null() && !unsafe { pyre_object::is_none(base) } => {
                 root = base;
-                pyre_object::gc_roots::pin_root(root);
+                let _ = pyre_object::gc_roots::pin_root(root);
                 root_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             }
             _ => break,
@@ -1176,7 +1178,7 @@ pub(super) fn share_objects_for_cast(result: PyObjectRef, source: PyObjectRef) {
         // be a `list` that moves; the lookup that follows can collect, so it is
         // pinned here and read back at the store.
         let holder_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(objects);
+        let objects = pyre_object::gc_roots::pin_root(objects);
         let result = pyre_object::gc_roots::shadow_stack_get(result_slot);
         let result_dict = crate::baseobjspace::getdict_native(result);
         if !result_dict.is_null() {
@@ -1188,10 +1190,10 @@ pub(super) fn share_objects_for_cast(result: PyObjectRef, source: PyObjectRef) {
     let objects_slot = pyre_object::gc_roots::shadow_stack_len();
     match existing {
         Some(objects) if !objects.is_null() && unsafe { pyre_object::is_dict(objects) } => {
-            pyre_object::gc_roots::pin_root(objects)
+            let _ = pyre_object::gc_roots::pin_root(objects);
         }
         _ => {
-            pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+            let _ = pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
             root = pyre_object::gc_roots::shadow_stack_get(root_slot);
             source_dict = crate::baseobjspace::getdict_native(root);
             let objects = pyre_object::gc_roots::shadow_stack_get(objects_slot);
@@ -1200,7 +1202,7 @@ pub(super) fn share_objects_for_cast(result: PyObjectRef, source: PyObjectRef) {
     }
     let source = pyre_object::gc_roots::shadow_stack_get(source_slot);
     let identity_key = pyre_object::w_int_new(source as usize as i64);
-    pyre_object::gc_roots::pin_root(identity_key);
+    let _ = pyre_object::gc_roots::pin_root(identity_key);
     let key_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let source = pyre_object::gc_roots::shadow_stack_get(source_slot);
     let objects = pyre_object::gc_roots::shadow_stack_get(objects_slot);
@@ -1523,7 +1525,7 @@ pub(super) fn encode_value_into(
         // `keep_ref` allocates, so pin it for that window; it does not move, so
         // the word is never re-read.
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(copy);
+        let copy = pyre_object::gc_roots::pin_root(copy);
         keep_ref(dest, key, value);
         keep_alive(dest, key, copy);
         let addr = unsafe { pyre_object::bytesobject::w_bytes_data(copy).as_ptr() } as usize;
@@ -1538,7 +1540,7 @@ pub(super) fn encode_value_into(
         let copy =
             pyre_object::w_bytearray_from_bytes(&host_ctypes::clone_wchar_null_terminated(raw));
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(copy);
+        let copy = pyre_object::gc_roots::pin_root(copy);
         keep_ref(dest, key, value);
         keep_alive(dest, key, copy);
         let addr =

--- a/pyre/pyre-interpreter/src/module/_ctypes/com.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/com.rs
@@ -226,25 +226,25 @@ pub(super) fn error(hresult: i32, iid: usize, this: usize) -> crate::PyError {
     let _roots = pyre_object::gc_roots::push_roots();
     let details_base = pyre_object::gc_roots::shadow_stack_len();
     for bstr in [info.description, info.source, info.help_file] {
-        pyre_object::gc_roots::pin_root(bstr_str(bstr));
+        let _ = pyre_object::gc_roots::pin_root(bstr_str(bstr));
     }
-    pyre_object::gc_roots::pin_root(pyre_object::w_int_new(info.help_context as i64));
-    pyre_object::gc_roots::pin_root(prog_id(&info.guid));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(info.help_context as i64));
+    let _ = pyre_object::gc_roots::pin_root(prog_id(&info.guid));
     let details = pyre_object::w_tuple_new(
         (0..5)
             .map(|i| pyre_object::gc_roots::shadow_stack_get(details_base + i))
             .collect(),
     );
     let details_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(details);
+    let _ = pyre_object::gc_roots::pin_root(details);
     let text = match host_ctypes::format_error_message(Some(hresult as u32)) {
         Some(message) => pyre_object::w_str_new(&message),
         None => pyre_object::w_none(),
     };
     let text_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(text);
+    let _ = pyre_object::gc_roots::pin_root(text);
     let hresult_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::w_int_new(hresult as i64));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(hresult as i64));
     // Without the class there is nothing to raise but the report the id-less
     // form would have given, which is the same status by another name.
     let win32_error = || {
@@ -261,7 +261,7 @@ pub(super) fn error(hresult: i32, iid: usize, this: usize) -> crate::PyError {
     match crate::call::type_call_instantiate(cls, &args) {
         Ok(instance) => {
             let instance_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(instance);
+            let _ = pyre_object::gc_roots::pin_root(instance);
             let mut error = win32_error();
             error.exc_object = pyre_object::gc_roots::shadow_stack_get(instance_slot);
             error

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -174,7 +174,7 @@ fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
     let _roots = pyre_object::gc_roots::push_roots();
     let cls_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args[0]);
+    let _ = pyre_object::gc_roots::pin_root(args[0]);
     let cls = pyre_object::gc_roots::shadow_stack_get(cls_slot);
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
     reject_kwargs(kwargs)?;
@@ -229,17 +229,17 @@ fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         None
     } else {
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(callback);
+        let _ = pyre_object::gc_roots::pin_root(callback);
         Some(slot)
     };
     // Building the instance allocates, so what gets stored on it is read back
     // out of a root slot once it exists.
     let paramflags_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(paramflags);
+    let _ = pyre_object::gc_roots::pin_root(paramflags);
     #[cfg(windows)]
     let iid_slot = {
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(if com_iid.is_null() {
+        let _ = pyre_object::gc_roots::pin_root(if com_iid.is_null() {
             pyre_object::w_none()
         } else {
             com_iid
@@ -252,12 +252,12 @@ fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         &[],
     )?;
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     store_funcptr_addr(pyre_object::gc_roots::shadow_stack_get(obj_slot), addr)?;
     if !callback.is_null() {
         let current_obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         let d = crate::baseobjspace::getdict_native(current_obj);
-        pyre_object::gc_roots::pin_root(d);
+        let _ = pyre_object::gc_roots::pin_root(d);
         let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let callback = pyre_object::gc_roots::shadow_stack_get(callback_slot.unwrap());
         unsafe {
@@ -556,11 +556,11 @@ fn apply_errcheck(
     let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
     for value in [self_obj, result, errcheck] {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
     }
     let arguments = pyre_object::w_tuple_new(inargs.to_vec());
     let arguments_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(arguments);
+    let _ = pyre_object::gc_roots::pin_root(arguments);
     let value = crate::call::call_function_impl_result(
         pyre_object::gc_roots::shadow_stack_get(base + 2),
         &[
@@ -589,7 +589,7 @@ fn wrap_pointer_result(rt: PyObjectRef, p: usize) -> Result<PyObjectRef, crate::
     // rootless.
     let _roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(d);
+    let _ = pyre_object::gc_roots::pin_root(d);
     let psize = host_ctypes::pointer_size();
     let ba = pyre_object::w_bytearray_new(psize);
     let bytes = host_ctypes::simple_storage_value_to_bytes_endian(
@@ -768,10 +768,10 @@ pub(super) fn funcptr_addr(obj: PyObjectRef) -> usize {
 pub(super) fn store_funcptr_addr(obj: PyObjectRef, addr: usize) -> Result<(), crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let w_addr = pyre_object::w_int_new(addr as i64);
     let addr_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_addr);
+    let _ = pyre_object::gc_roots::pin_root(w_addr);
     let current_obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
     let d = crate::baseobjspace::getdict_native(current_obj);
     if d.is_null() {
@@ -779,7 +779,7 @@ pub(super) fn store_funcptr_addr(obj: PyObjectRef, addr: usize) -> Result<(), cr
             "CFuncPtr instance has no instance dict",
         ));
     }
-    pyre_object::gc_roots::pin_root(d);
+    let _ = pyre_object::gc_roots::pin_root(d);
     let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     unsafe {
         pyre_object::w_dict_setitem_str(
@@ -1160,7 +1160,7 @@ fn build_callargs(
                 get_arg(&mut index, name.as_deref(), defval, passed, kwargs)?
             }
         };
-        pyre_object::gc_roots::pin_root(value);
+        let value = pyre_object::gc_roots::pin_root(value);
         out.args.push(value);
     }
     for (i, arg) in out.args.iter_mut().enumerate() {
@@ -1236,7 +1236,7 @@ fn build_result(result: PyObjectRef, callargs: &CallArgs) -> Result<PyObjectRef,
     let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
     for &arg in &callargs.args {
-        pyre_object::gc_roots::pin_root(arg);
+        let _ = pyre_object::gc_roots::pin_root(arg);
     }
     let returned_base = pyre_object::gc_roots::shadow_stack_len();
     let mut returned = 0;
@@ -1249,7 +1249,7 @@ fn build_result(result: PyObjectRef, callargs: &CallArgs) -> Result<PyObjectRef,
         } else {
             continue;
         };
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
         returned += 1;
         if returned == callargs.numretvals as usize {
             break;

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -804,9 +804,9 @@ fn comerror_init(
     // store.  Pin the three before that store and read them back at each use.
     let roots = pyre_object::gc_roots::push_roots();
     let args_slot = roots.base();
-    roots.pin_root(*hresult);
-    roots.pin_root(*text);
-    roots.pin_root(*details);
+    let _ = roots.pin_root(*hresult);
+    let _ = roots.pin_root(*text);
+    let _ = roots.pin_root(*details);
     crate::baseobjspace::setattr_str(w_self, "hresult", roots.get(args_slot))?;
     crate::baseobjspace::setattr_str(w_self, "text", roots.get(args_slot + 1))?;
     crate::baseobjspace::setattr_str(w_self, "details", roots.get(args_slot + 2))?;
@@ -1006,7 +1006,7 @@ pub(super) fn make_carg(addr: usize, obj: pyre_object::PyObjectRef) -> pyre_obje
         // inline slot read would precede that allocation and go stale.
         let roots = pyre_object::gc_roots::push_roots();
         let dict_slot = roots.base();
-        roots.pin_root(d);
+        let _ = roots.pin_root(d);
         let ptr = pyre_object::w_int_new(addr as i64);
         unsafe {
             pyre_object::w_dict_setitem_str(roots.get(dict_slot), "_ptr", ptr);

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -492,7 +492,7 @@ fn simple_init_stginfo(cls: PyObjectRef) -> PyResult {
         // expression would hand the store a pre-move address.
         let roots = pyre_object::gc_roots::push_roots();
         let ns_slot = roots.base();
-        roots.pin_root(pyre_object::w_dict_new());
+        let _ = roots.pin_root(pyre_object::w_dict_new());
         let w_tc = pyre_object::w_str_new(&tc);
         unsafe {
             pyre_object::w_dict_setitem_str(roots.get(ns_slot), "_type_", w_tc);
@@ -513,7 +513,7 @@ fn simple_init_stginfo(cls: PyObjectRef) -> PyResult {
         // The new class does not move, but nothing references it until the
         // first `set_type_attr` below completes and that store allocates its
         // key string, so it takes one pin for liveness.
-        roots.pin_root(swapped);
+        let swapped = roots.pin_root(swapped);
         if cfg!(target_endian = "little") {
             set_type_attr(cls, "__ctype_le__", cls);
             set_type_attr(cls, "__ctype_be__", swapped);
@@ -631,9 +631,9 @@ fn promote_anonymous_fields(
             // root slot on every iteration.  `promoted` does not move but is
             // unreferenced until `set_type_attr` below, so it takes one pin.
             let roots = pyre_object::gc_roots::push_roots();
-            roots.pin_root(promoted);
+            let promoted = roots.pin_root(promoted);
             let d_slot = roots.base() + 1;
-            roots.pin_root(crate::baseobjspace::getdict_native(promoted));
+            let _ = roots.pin_root(crate::baseobjspace::getdict_native(promoted));
             unsafe {
                 for key in ["size", "bit_size", "bit_offset", "is_bitfield"] {
                     if let Some(value) = pyre_object::w_dict_getitem_str(
@@ -802,7 +802,7 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
     // store.
     let fields_roots = pyre_object::gc_roots::push_roots();
     let fields_slot = fields_roots.base();
-    fields_roots.pin_root(fields);
+    let fields = fields_roots.pin_root(fields);
     let entries = field_entries(fields)?;
     let anonymous = anonymous_names(cls)?;
 
@@ -954,9 +954,9 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
         // slot with the value already built.  `cf` does not move but is
         // unreferenced until `set_type_attr` below, so it takes one pin.
         let roots = pyre_object::gc_roots::push_roots();
-        roots.pin_root(cf);
+        let cf = roots.pin_root(cf);
         let d_slot = roots.base() + 1;
-        roots.pin_root(crate::baseobjspace::getdict_native(cf));
+        let _ = roots.pin_root(crate::baseobjspace::getdict_native(cf));
         let put = |key: &str, value: PyObjectRef| {
             // SAFETY: the slot holds the descriptor dict pinned above.
             unsafe { pyre_object::w_dict_setitem_str(roots.get(d_slot), key, value) };
@@ -1119,10 +1119,10 @@ fn cfield_new(
     // each insertion.  `inst` does not move, but nothing else references it
     // while the run allocates, so it takes one pin for liveness.
     let roots = pyre_object::gc_roots::push_roots();
-    roots.pin_root(inst);
+    let inst = roots.pin_root(inst);
     // The dict lands in the slot after `inst`.
     let d_slot = roots.base() + 1;
-    roots.pin_root(crate::baseobjspace::getdict_native(inst));
+    let _ = roots.pin_root(crate::baseobjspace::getdict_native(inst));
     let put = |key: &str, value: PyObjectRef| {
         // SAFETY: the slot holds the instance dict pinned above.
         unsafe { pyre_object::w_dict_setitem_str(roots.get(d_slot), key, value) };
@@ -1525,7 +1525,7 @@ fn cfield_new_internal(args: &[PyObjectRef]) -> PyResult {
     // `field` does not move, but nothing else references it before the return
     // and the argument decoding below allocates, so it takes one pin.
     let field_roots = pyre_object::gc_roots::push_roots();
-    field_roots.pin_root(field);
+    let field = field_roots.pin_root(field);
     let bit_size = get("bit_size", 7)?
         .map(crate::baseobjspace::int_w)
         .transpose()?;
@@ -1548,7 +1548,7 @@ fn cfield_new_internal(args: &[PyObjectRef]) -> PyResult {
         // the value already built.
         let roots = pyre_object::gc_roots::push_roots();
         let d_slot = roots.base();
-        roots.pin_root(crate::baseobjspace::getdict_native(field));
+        let _ = roots.pin_root(crate::baseobjspace::getdict_native(field));
         let put = |key: &str, value: PyObjectRef| {
             // SAFETY: the slot holds the field dict pinned above.
             unsafe { pyre_object::w_dict_setitem_str(roots.get(d_slot), key, value) };
@@ -1585,9 +1585,9 @@ fn structure_new(args: &[PyObjectRef]) -> PyResult {
     // built first and the dict word is read back out of a root slot for the
     // store; `obj` does not move and takes one pin for liveness.
     let roots = pyre_object::gc_roots::push_roots();
-    roots.pin_root(obj);
+    let obj = roots.pin_root(obj);
     let d_slot = roots.base() + 1;
-    roots.pin_root(d);
+    let _ = roots.pin_root(d);
     let buffer = pyre_object::w_bytearray_new(size);
     unsafe { pyre_object::w_dict_setitem_str(roots.get(d_slot), "_b_", buffer) };
     Ok(obj)
@@ -1617,7 +1617,7 @@ fn structure_init(args: &[PyObjectRef]) -> PyResult {
     let roots = pyre_object::gc_roots::push_roots();
     let args_slot = roots.base();
     for &arg in args {
-        roots.pin_root(arg);
+        let _ = roots.pin_root(arg);
     }
     let obj = args[0];
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
@@ -1641,8 +1641,8 @@ fn structure_init(args: &[PyObjectRef]) -> PyResult {
         let items = unsafe { pyre_object::w_dict_items(roots.get(kw_slot)) };
         let items_slot = pyre_object::gc_roots::shadow_stack_len();
         for &(key_obj, val) in &items {
-            roots.pin_root(key_obj);
-            roots.pin_root(val);
+            let _ = roots.pin_root(key_obj);
+            let _ = roots.pin_root(val);
         }
         for (i, &(key_obj, _)) in items.iter().enumerate() {
             if !unsafe { pyre_object::is_str(key_obj) } {
@@ -1803,7 +1803,7 @@ fn array_type_from_ctype(elem: PyObjectRef, n: usize) -> PyResult {
     let roots = pyre_object::gc_roots::push_roots();
     let cache_slot = roots.base();
     let cached = crate::type_dict_lookup(elem, ARRAY_TYPE_CACHE_KEY);
-    roots.pin_root(cached.unwrap_or_else(pyre_object::w_dict_new));
+    let _ = roots.pin_root(cached.unwrap_or_else(pyre_object::w_dict_new));
     if cached.is_none() && crate::type_dict_store(elem, ARRAY_TYPE_CACHE_KEY, roots.get(cache_slot))
     {
         pyre_object::gc_hook::try_gc_write_barrier(elem as *mut u8);
@@ -1814,7 +1814,7 @@ fn array_type_from_ctype(elem: PyObjectRef, n: usize) -> PyResult {
     let name = format!("{}_Array_{}", type_name(elem), n);
     let ns_roots = pyre_object::gc_roots::push_roots();
     let ns_slot = ns_roots.base();
-    ns_roots.pin_root(pyre_object::w_dict_new());
+    let _ = ns_roots.pin_root(pyre_object::w_dict_new());
     let w_length = pyre_object::w_int_new(n as i64);
     unsafe {
         pyre_object::w_dict_setitem_str(ns_roots.get(ns_slot), "_type_", elem);
@@ -1867,9 +1867,9 @@ fn array_new(args: &[PyObjectRef]) -> PyResult {
     // The instance `dict` moves under the buffer allocation; `obj` does not
     // move and takes one pin for liveness.
     let roots = pyre_object::gc_roots::push_roots();
-    roots.pin_root(obj);
+    let obj = roots.pin_root(obj);
     let d_slot = roots.base() + 1;
-    roots.pin_root(d);
+    let _ = roots.pin_root(d);
     let buffer = pyre_object::w_bytearray_new(size);
     unsafe { pyre_object::w_dict_setitem_str(roots.get(d_slot), "_b_", buffer) };
     Ok(obj)
@@ -2300,9 +2300,9 @@ fn pointer_new(args: &[PyObjectRef]) -> PyResult {
     // The instance `dict` moves under the buffer allocation; `obj` does not
     // move and takes one pin for liveness.
     let roots = pyre_object::gc_roots::push_roots();
-    roots.pin_root(obj);
+    let obj = roots.pin_root(obj);
     let d_slot = roots.base() + 1;
-    roots.pin_root(d);
+    let _ = roots.pin_root(d);
     let psize = host_ctypes::pointer_size();
     let buffer = pyre_object::w_bytearray_new(psize);
     unsafe { pyre_object::w_dict_setitem_str(roots.get(d_slot), "_b_", buffer) };

--- a/pyre/pyre-interpreter/src/module/_ctypes/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/mod.rs
@@ -29,7 +29,7 @@ fn finish_cpython_type(
     immutable: bool,
 ) -> pyre_object::PyObjectRef {
     let roots = pyre_object::gc_roots::push_roots();
-    roots.pin_root(tp);
+    let _ = roots.pin_root(tp);
     let slot = roots.base();
     let w_module = pyre_object::w_str_new(module);
     let tp = roots.get(slot);

--- a/pyre/pyre-interpreter/src/module/_functools/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_functools/mod.rs
@@ -66,7 +66,7 @@ fn key_wrapper_compare(
             pyre_object::gc_roots::shadow_stack_get(slot + 2),
         ],
     )?;
-    pyre_object::gc_roots::pin_root(result);
+    let _ = pyre_object::gc_roots::pin_root(result);
     // Build the comparison operand first: a custom numeric result makes
     // `w_int_new` allocate, and reading the result slot before that would leave
     // the argument naming a pre-move address.
@@ -163,7 +163,7 @@ fn reduce(args: &[PyObjectRef]) -> crate::PyResult {
             }
             Err(err) => return Err(err),
         };
-    pyre_object::gc_roots::pin_root(w_iter);
+    let _ = pyre_object::gc_roots::pin_root(w_iter);
     let iter_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     let initial = if effective.len() == 3 {
@@ -179,13 +179,13 @@ fn reduce(args: &[PyObjectRef]) -> crate::PyResult {
             Err(err) => return Err(err),
         }
     };
-    pyre_object::gc_roots::pin_root(initial);
+    let _ = pyre_object::gc_roots::pin_root(initial);
     let initial_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let accumulator =
         pyre_object::listobject::w_list_new(vec![pyre_object::gc_roots::shadow_stack_get(
             initial_slot,
         )]);
-    pyre_object::gc_roots::pin_root(accumulator);
+    let _ = pyre_object::gc_roots::pin_root(accumulator);
     let accumulator_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     loop {
@@ -199,7 +199,7 @@ fn reduce(args: &[PyObjectRef]) -> crate::PyResult {
         // transient values in their own root scope: the reducer is arbitrary
         // Python and `w_list_setitem` may switch list strategy and allocate.
         let _iteration_roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
         let item_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let current = unsafe {
             pyre_object::listobject::w_list_getitem(
@@ -212,7 +212,7 @@ fn reduce(args: &[PyObjectRef]) -> crate::PyResult {
             pyre_object::gc_roots::shadow_stack_get(function_slot),
             &[current, pyre_object::gc_roots::shadow_stack_get(item_slot)],
         )?;
-        pyre_object::gc_roots::pin_root(result);
+        let _ = pyre_object::gc_roots::pin_root(result);
         let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         unsafe {
             pyre_object::listobject::w_list_setitem(

--- a/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
@@ -96,7 +96,7 @@ impl W_HashState {
         assert_eq!(16, pyre_native::hash::HASH_STATE_STORAGE_ALIGN);
         let _roots = gc_roots::push_roots();
         let name_slot = gc_roots::shadow_stack_len();
-        gc_roots::pin_root(w_str_new(name));
+        let _ = gc_roots::pin_root(w_str_new(name));
         let state = W_HashState::allocate_stable(W_HashState {
             ob: PyObject::default(),
             name: gc_roots::shadow_stack_get(name_slot),
@@ -138,7 +138,7 @@ impl W_HashState {
     ) -> Result<PyObjectRef, crate::PyError> {
         let _roots = gc_roots::push_roots();
         let name_slot = gc_roots::shadow_stack_len();
-        gc_roots::pin_root(w_str_new(name));
+        let _ = gc_roots::pin_root(w_str_new(name));
         let state = W_HashState::allocate_stable(W_HashState {
             ob: PyObject::default(),
             name: gc_roots::shadow_stack_get(name_slot),
@@ -279,7 +279,7 @@ mod hash_state_class {
         fn copy(&self) -> Result<PyObjectRef, crate::PyError> {
             let _roots = gc_roots::push_roots();
             let name_slot = gc_roots::shadow_stack_len();
-            gc_roots::pin_root(self.name);
+            let _ = gc_roots::pin_root(self.name);
             let clone = W_HashState::allocate_stable(W_HashState {
                 ob: PyObject::default(),
                 name: gc_roots::shadow_stack_get(name_slot),
@@ -437,7 +437,7 @@ impl W_Hmac {
             .ok_or_else(|| unsupported_digestmod("unsupported hash type"))?;
         let _roots = gc_roots::push_roots();
         let name_slot = gc_roots::shadow_stack_len();
-        gc_roots::pin_root(w_str_new(&format!("hmac-{name}")));
+        let _ = gc_roots::pin_root(w_str_new(&format!("hmac-{name}")));
         let obj = W_Hmac::allocate_stable(W_Hmac {
             ob: PyObject::default(),
             name: gc_roots::shadow_stack_get(name_slot),
@@ -544,7 +544,7 @@ mod hmac_class {
         fn copy(&self) -> Result<PyObjectRef, crate::PyError> {
             let _roots = gc_roots::push_roots();
             let name_slot = gc_roots::shadow_stack_len();
-            gc_roots::pin_root(self.name);
+            let _ = gc_roots::pin_root(self.name);
             let obj = W_Hmac::allocate_stable(W_Hmac {
                 ob: PyObject::default(),
                 name: gc_roots::shadow_stack_get(name_slot),
@@ -845,7 +845,7 @@ fn blake2_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let _roots = gc_roots::push_roots();
     let base = gc_roots::shadow_stack_len();
     for &arg in args {
-        gc_roots::pin_root(arg);
+        let _ = gc_roots::pin_root(arg);
     }
     let arg = |index| gc_roots::shadow_stack_get(base + index);
     let name_obj = arg(0);
@@ -1006,10 +1006,10 @@ fn make_hash(
     // from its slot after each re-entry.
     let _roots = pyre_object::gc_roots::push_roots();
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(name);
+    let _ = pyre_object::gc_roots::pin_root(name);
     let pin = |obj: PyObjectRef| {
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         slot
     };
     let data_slot = data.map(pin);
@@ -1124,7 +1124,7 @@ crate::py_module! {
     extra_init: |ns| {
         let _roots = gc_roots::push_roots();
         let mapping_slot = gc_roots::shadow_stack_len();
-        gc_roots::pin_root(w_dict_new());
+        let _ = gc_roots::pin_root(w_dict_new());
         for (constructor, name) in [
             ("openssl_md5", "md5"),
             ("openssl_sha1", "sha1"),
@@ -1142,9 +1142,9 @@ crate::py_module! {
             let function = crate::module_ns_get(ns, constructor)
                 .expect("_hashlib constructor installed before extra_init");
             let function_slot = gc_roots::shadow_stack_len();
-            gc_roots::pin_root(function);
+            let _ = gc_roots::pin_root(function);
             let name_slot = gc_roots::shadow_stack_len();
-            gc_roots::pin_root(w_str_new(name));
+            let _ = gc_roots::pin_root(w_str_new(name));
             crate::baseobjspace::setitem(
                 gc_roots::shadow_stack_get(mapping_slot),
                 gc_roots::shadow_stack_get(function_slot),

--- a/pyre/pyre-interpreter/src/module/_heapq/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_heapq/mod.rs
@@ -52,7 +52,7 @@ fn less_than(left: PyObjectRef, right: PyObjectRef) -> Result<bool, crate::PyErr
 /// this argument, is what holds the forwarded object afterwards.
 fn pin(value: PyObjectRef) -> usize {
     let slot = shadow_stack_len();
-    pin_root(value);
+    let _ = pin_root(value);
     slot
 }
 

--- a/pyre/pyre-interpreter/src/module/_io/buffered.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered.rs
@@ -47,7 +47,7 @@ pub(super) fn raw_readinto_size(
             // conversion TypeError as the explicit cause.
             let _roots = pyre_object::gc_roots::push_roots();
             let cause_obj = cause.to_exc_object();
-            pyre_object::gc_roots::pin_root(cause_obj);
+            let _ = pyre_object::gc_roots::pin_root(cause_obj);
             let cause_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let mut outer = crate::PyError::os_error("raw readinto() returned invalid length");
             let outer_obj = outer.to_exc_object();
@@ -213,8 +213,8 @@ impl W_BufferedReader {
     fn raw_read(&mut self, start: usize, length: usize) -> Result<usize, crate::PyError> {
         let temp = pyre_object::bytearrayobject::w_bytearray_new(length);
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self.self_obj());
-        pyre_object::gc_roots::pin_root(temp);
+        let _ = pyre_object::gc_roots::pin_root(self.self_obj());
+        let _ = pyre_object::gc_roots::pin_root(temp);
         let sp = pyre_object::gc_roots::shadow_stack_len() - 2;
         let result = super::call_method_result(
             self.w_raw,
@@ -343,8 +343,8 @@ impl W_BufferedReader {
             let block = self.buffer_size as usize * (remaining / self.buffer_size as usize);
             let temp = pyre_object::bytearrayobject::w_bytearray_new(block);
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(self.self_obj());
-            pyre_object::gc_roots::pin_root(temp);
+            let _ = pyre_object::gc_roots::pin_root(self.self_obj());
+            let _ = pyre_object::gc_roots::pin_root(temp);
             let sp = pyre_object::gc_roots::shadow_stack_len() - 2;
             let result = super::call_method_result(
                 self.w_raw,
@@ -439,8 +439,8 @@ impl W_BufferedReader {
                     let requested = size as usize;
                     let temp = pyre_object::bytearrayobject::w_bytearray_new(requested);
                     let _roots = pyre_object::gc_roots::push_roots();
-                    pyre_object::gc_roots::pin_root(this.self_obj());
-                    pyre_object::gc_roots::pin_root(temp);
+                    let _ = pyre_object::gc_roots::pin_root(this.self_obj());
+                    let _ = pyre_object::gc_roots::pin_root(temp);
                     let temp_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                     let result = super::call_method_result(
                         this.w_raw,
@@ -511,8 +511,8 @@ impl W_BufferedReader {
                 if remaining > this.buffer_size as usize {
                     let temp = pyre_object::bytearrayobject::w_bytearray_new(remaining);
                     let _roots = pyre_object::gc_roots::push_roots();
-                    pyre_object::gc_roots::pin_root(this.self_obj());
-                    pyre_object::gc_roots::pin_root(temp);
+                    let _ = pyre_object::gc_roots::pin_root(this.self_obj());
+                    let _ = pyre_object::gc_roots::pin_root(temp);
                     let sp = pyre_object::gc_roots::shadow_stack_len() - 2;
                     let result = super::call_method_result(
                         this.w_raw,
@@ -598,7 +598,7 @@ impl W_BufferedReader {
             ));
         }
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_raw);
+        let _ = pyre_object::gc_roots::pin_root(w_raw);
         let raw_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let buffer = pyre_object::bytearrayobject::w_bytearray_new(buffer_size as usize);
         self.w_raw = pyre_object::gc_roots::shadow_stack_get(raw_slot);
@@ -849,7 +849,7 @@ impl W_BufferedReader {
                 // earlier flush exception as the close exception's context.
                 let _roots = pyre_object::gc_roots::push_roots();
                 let flush_obj = flush_error.to_exc_object();
-                pyre_object::gc_roots::pin_root(flush_obj);
+                let _ = pyre_object::gc_roots::pin_root(flush_obj);
                 let flush_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let close_obj = close_error.to_exc_object();
                 unsafe {

--- a/pyre/pyre-interpreter/src/module/_io/buffered_random.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered_random.rs
@@ -161,8 +161,8 @@ impl W_BufferedRandom {
     fn raw_read(&mut self, start: usize, length: usize) -> Result<usize, crate::PyError> {
         let temp = pyre_object::bytearrayobject::w_bytearray_new(length);
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self.self_obj());
-        pyre_object::gc_roots::pin_root(temp);
+        let _ = pyre_object::gc_roots::pin_root(self.self_obj());
+        let _ = pyre_object::gc_roots::pin_root(temp);
         let sp = pyre_object::gc_roots::shadow_stack_len() - 2;
         let result = super::call_method_result(
             self.w_raw,
@@ -202,8 +202,8 @@ impl W_BufferedRandom {
     fn raw_write(&mut self, data: &[u8]) -> Result<usize, crate::PyError> {
         let bytes = pyre_object::bytesobject::w_bytes_from_bytes(data);
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self.self_obj());
-        pyre_object::gc_roots::pin_root(bytes);
+        let _ = pyre_object::gc_roots::pin_root(self.self_obj());
+        let _ = pyre_object::gc_roots::pin_root(bytes);
         let sp = pyre_object::gc_roots::shadow_stack_len() - 2;
         let result = super::call_method_result(
             self.w_raw,
@@ -440,8 +440,8 @@ impl W_BufferedRandom {
             let block = self.buffer_size as usize * (remaining / self.buffer_size as usize);
             let temp = pyre_object::bytearrayobject::w_bytearray_new(block);
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(self.self_obj());
-            pyre_object::gc_roots::pin_root(temp);
+            let _ = pyre_object::gc_roots::pin_root(self.self_obj());
+            let _ = pyre_object::gc_roots::pin_root(temp);
             let sp = pyre_object::gc_roots::shadow_stack_len() - 2;
             let result = super::call_method_result(
                 self.w_raw,
@@ -534,8 +534,8 @@ impl W_BufferedRandom {
                     let requested = size as usize;
                     let temp = pyre_object::bytearrayobject::w_bytearray_new(requested);
                     let _roots = pyre_object::gc_roots::push_roots();
-                    pyre_object::gc_roots::pin_root(this.self_obj());
-                    pyre_object::gc_roots::pin_root(temp);
+                    let _ = pyre_object::gc_roots::pin_root(this.self_obj());
+                    let _ = pyre_object::gc_roots::pin_root(temp);
                     let temp_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                     let result = super::call_method_result(
                         this.w_raw,
@@ -604,8 +604,8 @@ impl W_BufferedRandom {
                 if remaining > this.buffer_size as usize {
                     let temp = pyre_object::bytearrayobject::w_bytearray_new(remaining);
                     let _roots = pyre_object::gc_roots::push_roots();
-                    pyre_object::gc_roots::pin_root(this.self_obj());
-                    pyre_object::gc_roots::pin_root(temp);
+                    let _ = pyre_object::gc_roots::pin_root(this.self_obj());
+                    let _ = pyre_object::gc_roots::pin_root(temp);
                     let sp = pyre_object::gc_roots::shadow_stack_len() - 2;
                     let result = super::call_method_result(
                         this.w_raw,
@@ -704,7 +704,7 @@ impl W_BufferedRandom {
             ));
         }
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_raw);
+        let _ = pyre_object::gc_roots::pin_root(w_raw);
         let raw_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let buffer = pyre_object::bytearrayobject::w_bytearray_new(buffer_size as usize);
         self.w_raw = pyre_object::gc_roots::shadow_stack_get(raw_slot);
@@ -967,7 +967,7 @@ impl W_BufferedRandom {
             if let Some(mut flush_error) = flush_error {
                 let _roots = pyre_object::gc_roots::push_roots();
                 let flush_obj = flush_error.to_exc_object();
-                pyre_object::gc_roots::pin_root(flush_obj);
+                let _ = pyre_object::gc_roots::pin_root(flush_obj);
                 let flush_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let close_obj = close_error.to_exc_object();
                 unsafe {

--- a/pyre/pyre-interpreter/src/module/_io/buffered_rwpair.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered_rwpair.rs
@@ -78,8 +78,8 @@ impl W_BufferedRWPair {
         self.w_writer = PY_NULL;
 
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_reader);
-        pyre_object::gc_roots::pin_root(w_writer);
+        let _ = pyre_object::gc_roots::pin_root(w_reader);
+        let _ = pyre_object::gc_roots::pin_root(w_writer);
         let input_sp = pyre_object::gc_roots::shadow_stack_len() - 2;
         let reader_size = w_int_new(buffer_size);
         let reader = crate::call::call_function_impl_result(
@@ -89,7 +89,7 @@ impl W_BufferedRWPair {
                 reader_size,
             ],
         )?;
-        pyre_object::gc_roots::pin_root(reader);
+        let _ = pyre_object::gc_roots::pin_root(reader);
         let reader_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let writer_size = w_int_new(buffer_size);
         let writer = crate::call::call_function_impl_result(
@@ -145,7 +145,7 @@ impl W_BufferedRWPair {
             if let Some(mut context) = writer_error {
                 let _roots = pyre_object::gc_roots::push_roots();
                 let context_obj = context.to_exc_object();
-                pyre_object::gc_roots::pin_root(context_obj);
+                let _ = pyre_object::gc_roots::pin_root(context_obj);
                 let context_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let reader_obj = reader_error.to_exc_object();
                 unsafe {

--- a/pyre/pyre-interpreter/src/module/_io/buffered_writer.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered_writer.rs
@@ -174,8 +174,8 @@ impl W_BufferedWriter {
     fn raw_write(&mut self, data: &[u8]) -> Result<usize, crate::PyError> {
         let bytes = pyre_object::bytesobject::w_bytes_from_bytes(data);
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self.self_obj());
-        pyre_object::gc_roots::pin_root(bytes);
+        let _ = pyre_object::gc_roots::pin_root(self.self_obj());
+        let _ = pyre_object::gc_roots::pin_root(bytes);
         let sp = pyre_object::gc_roots::shadow_stack_len() - 2;
         let result = super::call_method_result(
             self.w_raw,
@@ -359,7 +359,7 @@ impl W_BufferedWriter {
             ));
         }
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_raw);
+        let _ = pyre_object::gc_roots::pin_root(w_raw);
         let raw_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let buffer = pyre_object::bytearrayobject::w_bytearray_new(buffer_size as usize);
         self.w_raw = pyre_object::gc_roots::shadow_stack_get(raw_slot);
@@ -500,7 +500,7 @@ impl W_BufferedWriter {
             if let Some(mut flush_error) = flush_error {
                 let _roots = pyre_object::gc_roots::push_roots();
                 let flush_obj = flush_error.to_exc_object();
-                pyre_object::gc_roots::pin_root(flush_obj);
+                let _ = pyre_object::gc_roots::pin_root(flush_obj);
                 let flush_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let close_obj = close_error.to_exc_object();
                 unsafe {

--- a/pyre/pyre-interpreter/src/module/_io/bytesio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/bytesio.rs
@@ -233,7 +233,7 @@ impl W_BytesIO {
     /// Pin the receiver so [`Self::from_slot`] can recover it, and answer the
     /// slot it landed in.
     fn pin_self(&self) -> usize {
-        pyre_object::gc_roots::pin_root(self.self_obj());
+        let _ = pyre_object::gc_roots::pin_root(self.self_obj());
         pyre_object::gc_roots::shadow_stack_len() - 1
     }
 
@@ -255,7 +255,7 @@ impl W_BytesIO {
     fn __new__(cls: PyObjectRef, _args: &[PyObjectRef]) -> PyObjectRef {
         let _roots = pyre_object::gc_roots::push_roots();
         let buffer = pyre_object::bytearrayobject::w_bytearray_new(0);
-        pyre_object::gc_roots::pin_root(buffer);
+        let _ = pyre_object::gc_roots::pin_root(buffer);
         let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let obj = W_BytesIO::allocate_stable(W_BytesIO {
             buffer: pyre_object::gc_roots::shadow_stack_get(slot),
@@ -483,11 +483,11 @@ impl W_BytesIO {
         self.check_closed()?;
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(self.self_obj());
-        pyre_object::gc_roots::pin_root(self.getvalue()?);
-        pyre_object::gc_roots::pin_root(w_int_new(self.tell_pos()));
+        let _ = pyre_object::gc_roots::pin_root(self.self_obj());
+        let _ = pyre_object::gc_roots::pin_root(self.getvalue()?);
+        let _ = pyre_object::gc_roots::pin_root(w_int_new(self.tell_pos()));
         let dict = crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(sp));
-        pyre_object::gc_roots::pin_root(if dict.is_null() { w_none() } else { dict });
+        let _ = pyre_object::gc_roots::pin_root(if dict.is_null() { w_none() } else { dict });
         Ok(w_tuple_new(vec![
             pyre_object::gc_roots::shadow_stack_get(sp + 1),
             pyre_object::gc_roots::shadow_stack_get(sp + 2),

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -149,7 +149,7 @@ pub(crate) fn unsupported(message: &str) -> crate::PyError {
     }
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_str_new(message));
+    let _ = pyre_object::gc_roots::pin_root(w_str_new(message));
     match crate::call::call_function_impl_result(
         w_type,
         &[pyre_object::gc_roots::shadow_stack_get(sp)],
@@ -169,7 +169,7 @@ pub(crate) fn iobase_close(args: &[PyObjectRef]) -> crate::PyResult {
     }
     let _roots = pyre_object::gc_roots::push_roots();
     let self_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
+    let _ = pyre_object::gc_roots::pin_root(self_obj);
     // PyPy `close_w`: `flush()` runs while `closed` is still false, and the
     // internal flag is set in `finally`, even when the virtual flush raises.
     let flushed = call_method_result(
@@ -401,7 +401,7 @@ pub(crate) fn autoflusher_add(w_iobase: PyObjectRef) -> PyObjectRef {
     }
     let _roots = pyre_object::gc_roots::push_roots();
     let target_root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_iobase);
+    let _ = pyre_object::gc_roots::pin_root(w_iobase);
     loop {
         let (index, generation, handle) = {
             let mut flusher = AUTOFLUSHER.lock().unwrap();
@@ -465,7 +465,7 @@ pub fn flush_all_streams() {
         let _handle_roots = pyre_object::gc_roots::push_roots();
         let handles_root = pyre_object::gc_roots::shadow_stack_len();
         for &handle in &handles {
-            pyre_object::gc_roots::pin_root(handle);
+            let _ = pyre_object::gc_roots::pin_root(handle);
         }
         let mut progress = false;
         for index in 0..handles.len() {
@@ -476,7 +476,7 @@ pub fn flush_all_streams() {
             if stream.is_null() {
                 continue;
             }
-            pyre_object::gc_roots::pin_root(stream);
+            let _ = pyre_object::gc_roots::pin_root(stream);
             progress = true;
             // "Silencing all errors is bad, but getting randomly interrupted
             // here is equally as bad, and potentially more frequent (because of
@@ -634,10 +634,10 @@ pub(crate) fn iobase_writelines(args: &[PyObjectRef]) -> crate::PyResult {
 
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
-    pyre_object::gc_roots::pin_root(lines);
+    let _ = pyre_object::gc_roots::pin_root(self_obj);
+    let _ = pyre_object::gc_roots::pin_root(lines);
     let iterator = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(sp + 1))?;
-    pyre_object::gc_roots::pin_root(iterator);
+    let iterator = pyre_object::gc_roots::pin_root(iterator);
     loop {
         let iterator = pyre_object::gc_roots::shadow_stack_get(sp + 2);
         let line = match crate::baseobjspace::next(iterator) {
@@ -646,7 +646,7 @@ pub(crate) fn iobase_writelines(args: &[PyObjectRef]) -> crate::PyResult {
             Err(err) => return Err(err),
         };
         let _line_root = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(line);
+        let _ = pyre_object::gc_roots::pin_root(line);
         let line =
             pyre_object::gc_roots::shadow_stack_get(pyre_object::gc_roots::shadow_stack_len() - 1);
         call_method_result(
@@ -690,8 +690,8 @@ fn iobase_readline(args: &[PyObjectRef]) -> crate::PyResult {
 
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
-    pyre_object::gc_roots::pin_root(peek.unwrap_or(PY_NULL));
+    let _ = pyre_object::gc_roots::pin_root(self_obj);
+    let _ = pyre_object::gc_roots::pin_root(peek.unwrap_or(PY_NULL));
     let mut output = Vec::new();
     while limit < 0 || output.len() < limit as usize {
         let mut nreadahead = 1usize;
@@ -758,7 +758,7 @@ pub(super) fn iobase_readlines(args: &[PyObjectRef]) -> crate::PyResult {
     let iterator = crate::baseobjspace::iter(self_obj)?;
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(iterator);
+    let _ = pyre_object::gc_roots::pin_root(iterator);
     let lines_sp = pyre_object::gc_roots::shadow_stack_len();
     let mut count = 0usize;
     let mut length = 0i64;
@@ -769,7 +769,7 @@ pub(super) fn iobase_readlines(args: &[PyObjectRef]) -> crate::PyResult {
             Err(error) => return Err(error),
         };
         length = length.saturating_add(crate::baseobjspace::len_w(line)?);
-        pyre_object::gc_roots::pin_root(line);
+        let _ = pyre_object::gc_roots::pin_root(line);
         count += 1;
         if hint > 0 && length > hint {
             break;
@@ -989,8 +989,8 @@ fn rawiobase_read(args: &[PyObjectRef]) -> crate::PyResult {
 
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
-    pyre_object::gc_roots::pin_root(pyre_object::bytearrayobject::w_bytearray_new(size));
+    let _ = pyre_object::gc_roots::pin_root(self_obj);
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::bytearrayobject::w_bytearray_new(size));
     let length = call_method_result(
         pyre_object::gc_roots::shadow_stack_get(sp),
         "readinto",
@@ -1029,7 +1029,7 @@ fn rawiobase_readall(args: &[PyObjectRef]) -> crate::PyResult {
 
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
+    let _ = pyre_object::gc_roots::pin_root(self_obj);
     let mut output = Vec::new();
     loop {
         let data = call_method_result(

--- a/pyre/pyre-interpreter/src/module/_io/stringio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/stringio.rs
@@ -47,7 +47,7 @@ impl W_StringIO {
     }
 
     fn pin_self(&self) -> usize {
-        pyre_object::gc_roots::pin_root(self.self_obj());
+        let _ = pyre_object::gc_roots::pin_root(self.self_obj());
         pyre_object::gc_roots::shadow_stack_len() - 1
     }
 
@@ -187,7 +187,7 @@ impl W_StringIO {
         } else {
             super::call_method_result(this.w_decoder, "decode", &[w_obj, w_bool_from(true)])?
         };
-        pyre_object::gc_roots::pin_root(decoded);
+        let mut decoded = pyre_object::gc_roots::pin_root(decoded);
         let decoded_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let this = Self::from_slot(slot);
         if !this.writenl.is_null() {
@@ -239,7 +239,7 @@ impl W_StringIO {
     fn __new__(cls: PyObjectRef, _args: &[PyObjectRef]) -> PyObjectRef {
         let _roots = pyre_object::gc_roots::push_roots();
         let buffer = pyre_object::interp_array::w_array_new(b'w', 4);
-        pyre_object::gc_roots::pin_root(buffer);
+        let _ = pyre_object::gc_roots::pin_root(buffer);
         let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let obj = W_StringIO::allocate_stable(W_StringIO {
             buffer: pyre_object::gc_roots::shadow_stack_get(slot),
@@ -265,7 +265,7 @@ impl W_StringIO {
         } else {
             Self::decode_string(slot, w_initvalue)?
         };
-        pyre_object::gc_roots::pin_root(decoded);
+        let _ = pyre_object::gc_roots::pin_root(decoded);
         let decoded =
             pyre_object::gc_roots::shadow_stack_get(pyre_object::gc_roots::shadow_stack_len() - 1);
         Self::reset_buffer_from(slot, decoded)?;
@@ -279,11 +279,11 @@ impl W_StringIO {
         // interp_stringio.py:264-296.
         let _roots = pyre_object::gc_roots::push_roots();
         let slot = self.pin_self();
-        pyre_object::gc_roots::pin_root(w_obj);
+        let _ = pyre_object::gc_roots::pin_root(w_obj);
         let input_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let decoded =
             Self::decode_string(slot, pyre_object::gc_roots::shadow_stack_get(input_slot))?;
-        pyre_object::gc_roots::pin_root(decoded);
+        let decoded = pyre_object::gc_roots::pin_root(decoded);
         let original_size = unsafe {
             pyre_object::w_str_len(pyre_object::gc_roots::shadow_stack_get(input_slot)) as i64
         };
@@ -507,13 +507,13 @@ impl W_StringIO {
         self.check_closed()?;
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(self.self_obj());
-        pyre_object::gc_roots::pin_root(self.getvalue()?);
+        let _ = pyre_object::gc_roots::pin_root(self.self_obj());
+        let _ = pyre_object::gc_roots::pin_root(self.getvalue()?);
         let own_dict =
             crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(sp));
-        pyre_object::gc_roots::pin_root(own_dict);
+        let own_dict = pyre_object::gc_roots::pin_root(own_dict);
         let copied = super::call_method_result(own_dict, "copy", &[])?;
-        pyre_object::gc_roots::pin_root(copied);
+        let _ = pyre_object::gc_roots::pin_root(copied);
         let this = Self::from_slot(sp);
         let readnl = if unsafe { pyre_object::is_none(this.readnl) } {
             w_none()
@@ -522,9 +522,9 @@ impl W_StringIO {
                 pyre_object::w_str_get_wtf8(this.readnl).to_wtf8_buf()
             })
         };
-        pyre_object::gc_roots::pin_root(readnl);
+        let _ = pyre_object::gc_roots::pin_root(readnl);
         let pos = Self::from_slot(sp).pos;
-        pyre_object::gc_roots::pin_root(w_int_new(pos));
+        let _ = pyre_object::gc_roots::pin_root(w_int_new(pos));
         Ok(w_tuple_new(vec![
             pyre_object::gc_roots::shadow_stack_get(sp + 1),
             pyre_object::gc_roots::shadow_stack_get(sp + 4),
@@ -547,7 +547,7 @@ impl W_StringIO {
             )));
         }
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_state);
+        let _ = pyre_object::gc_roots::pin_root(w_state);
         let slot = self.pin_self();
         let state_slot = slot - 1;
         let state = pyre_object::gc_roots::shadow_stack_get(state_slot);

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -907,8 +907,8 @@ impl W_TextIOWrapper {
             ..Self::default()
         });
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(obj);
-        pyre_object::gc_roots::pin_root(buffer);
+        let obj = pyre_object::gc_roots::pin_root(obj);
+        let buffer = pyre_object::gc_roots::pin_root(buffer);
         // `app_main.py create_stdio:494`
         // `newline = None if sys.platform == 'win32' else '\n'`.  Universal
         // newline mode must never be on for POSIX stdio — '\r\n' in stdin does
@@ -1266,7 +1266,7 @@ impl W_TextIOWrapper {
         // and detach this wrapper.
         let buffer = self.w_buffer;
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(buffer);
+        let _ = pyre_object::gc_roots::pin_root(buffer);
         let buffer_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let closed = crate::baseobjspace::getattr_str(
             pyre_object::gc_roots::shadow_stack_get(buffer_slot),
@@ -1297,7 +1297,7 @@ impl W_TextIOWrapper {
             if let Some(mut flush_error) = flush_error {
                 let _roots = pyre_object::gc_roots::push_roots();
                 let flush_obj = flush_error.to_exc_object();
-                pyre_object::gc_roots::pin_root(flush_obj);
+                let _ = pyre_object::gc_roots::pin_root(flush_obj);
                 let flush_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let close_obj = close_error.to_exc_object();
                 unsafe {
@@ -1368,7 +1368,7 @@ impl W_TextIOWrapper {
         let mut chars_to_skip = self.decoded.upos as u64;
         let saved_state = super::call_method_result(self.w_decoder, "getstate", &[])?;
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(saved_state);
+        let _ = pyre_object::gc_roots::pin_root(saved_state);
         let saved_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
         let result = (|| -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/module/_io/winconsoleio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/winconsoleio.rs
@@ -80,7 +80,7 @@ impl W_WindowsConsoleIO {
     }
 
     fn pin_self(&self) -> usize {
-        pyre_object::gc_roots::pin_root(self.self_obj());
+        let _ = pyre_object::gc_roots::pin_root(self.self_obj());
         pyre_object::gc_roots::shadow_stack_len() - 1
     }
 
@@ -165,11 +165,11 @@ impl W_WindowsConsoleIO {
         self.smallbuf = [0; SMALLBUF];
 
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_name);
+        let w_name = pyre_object::gc_roots::pin_root(w_name);
         let name_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        pyre_object::gc_roots::pin_root(w_mode);
+        let _ = pyre_object::gc_roots::pin_root(w_mode);
         let mode_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        pyre_object::gc_roots::pin_root(w_closefd);
+        let _ = pyre_object::gc_roots::pin_root(w_closefd);
         let closefd_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let self_slot = self.pin_self();
 
@@ -381,7 +381,7 @@ impl W_WindowsConsoleIO {
             (Some(mut flush), Some(mut close)) => {
                 let flush_slot = pyre_object::gc_roots::shadow_stack_len();
                 let flush_obj = flush.to_exc_object();
-                pyre_object::gc_roots::pin_root(flush_obj);
+                let _ = pyre_object::gc_roots::pin_root(flush_obj);
                 // The second `to_exc_object` allocates, so a moving collection
                 // can run between the pin and the read: it forwards the slot,
                 // never the local copy above.

--- a/pyre/pyre-interpreter/src/module/_json/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_json/mod.rs
@@ -989,7 +989,7 @@ fn encode_sequence(
     // back out of the slot; capturing the parameter would name the pre-move
     // address and report the type of whatever now occupies that cell.
     let obj_slot = gc_roots::shadow_stack_len();
-    let _ = gc_roots::pin_root(obj);
+    let obj = gc_roots::pin_root(obj);
     let iter = crate::baseobjspace::iter(obj)?;
     let iter_slot = gc_roots::shadow_stack_len();
     let _ = gc_roots::pin_root(iter);
@@ -1088,7 +1088,7 @@ fn encode_dict(
     // back where it is used.
     let _roots = gc_roots::push_roots();
     let obj_slot = gc_roots::shadow_stack_len();
-    let _ = gc_roots::pin_root(obj);
+    let obj = gc_roots::pin_root(obj);
     let items = crate::call::call_function_impl_result(
         crate::baseobjspace::getattr_str(obj, "items")?,
         &[],

--- a/pyre/pyre-interpreter/src/module/_json/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_json/mod.rs
@@ -26,7 +26,7 @@ fn pin_pyerror_payload(err: &PyError) -> PyErrorRootSlots {
     {
         if !value.is_null() {
             *slot = Some(gc_roots::shadow_stack_len());
-            gc_roots::pin_root(value);
+            let _ = gc_roots::pin_root(value);
         }
     }
     slots
@@ -97,9 +97,9 @@ fn scanstring_impl(doc: PyObjectRef, end: i64, strict_obj: PyObjectRef) -> PyRes
         Ok((decoded, next, _)) => {
             let _roots = gc_roots::push_roots();
             let decoded_slot = gc_roots::shadow_stack_len();
-            gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(decoded));
+            let _ = gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(decoded));
             let next_slot = gc_roots::shadow_stack_len();
-            gc_roots::pin_root(pyre_object::w_int_new(next as i64));
+            let _ = gc_roots::pin_root(pyre_object::w_int_new(next as i64));
             Ok(pyre_object::w_tuple_new(vec![
                 gc_roots::shadow_stack_get(decoded_slot),
                 gc_roots::shadow_stack_get(next_slot),
@@ -149,7 +149,7 @@ fn scanner_scan_once(
     let _roots = gc_roots::push_roots();
     let slot = gc_roots::shadow_stack_len();
     for value in [self_obj, memo, doc] {
-        gc_roots::pin_root(value);
+        let _ = gc_roots::pin_root(value);
     }
     let doc = gc_roots::shadow_stack_get(slot + 2);
     let bytes = unsafe { pyre_object::w_str_get_wtf8(doc) }.as_bytes();
@@ -298,7 +298,7 @@ fn scanner_parse_object(
     let _roots = gc_roots::push_roots();
     let slot = gc_roots::shadow_stack_len();
     for value in [self_obj, memo, doc] {
-        gc_roots::pin_root(value);
+        let _ = gc_roots::pin_root(value);
     }
     let pairs_hook = W_Scanner::from_obj(gc_roots::shadow_stack_get(slot))
         .expect("Scanner payload")
@@ -309,7 +309,7 @@ fn scanner_parse_object(
     } else {
         pyre_object::w_dict_new()
     };
-    gc_roots::pin_root(result);
+    let _ = gc_roots::pin_root(result);
 
     (char_index, byte_index) =
         skip_json_whitespace(gc_roots::shadow_stack_get(slot + 2), char_index, byte_index);
@@ -348,7 +348,7 @@ fn scanner_parse_object(
             let iteration_roots = gc_roots::push_roots();
             let item_slot = gc_roots::shadow_stack_len();
             let candidate = pyre_object::w_str_from_wtf8(decoded);
-            gc_roots::pin_root(candidate);
+            let _ = gc_roots::pin_root(candidate);
             let memo = gc_roots::shadow_stack_get(slot + 1);
             let key =
                 match crate::baseobjspace::finditem(memo, gc_roots::shadow_stack_get(item_slot))? {
@@ -362,7 +362,7 @@ fn scanner_parse_object(
                         gc_roots::shadow_stack_get(item_slot)
                     }
                 };
-            gc_roots::pin_root(key);
+            let _ = gc_roots::pin_root(key);
 
             (char_index, byte_index) =
                 skip_json_whitespace(gc_roots::shadow_stack_get(slot + 2), char_index, byte_index);
@@ -400,7 +400,7 @@ fn scanner_parse_object(
                     err
                 }
             })?;
-            gc_roots::pin_root(value);
+            let _ = gc_roots::pin_root(value);
             char_index = next_char;
             byte_index = next_byte;
 
@@ -409,7 +409,7 @@ fn scanner_parse_object(
                     gc_roots::shadow_stack_get(item_slot + 1),
                     gc_roots::shadow_stack_get(item_slot + 2),
                 ]);
-                gc_roots::pin_root(pair);
+                let _ = gc_roots::pin_root(pair);
                 unsafe {
                     pyre_object::w_list_append(
                         gc_roots::shadow_stack_get(slot + 3),
@@ -493,10 +493,10 @@ fn scanner_parse_array(
     let _roots = gc_roots::push_roots();
     let slot = gc_roots::shadow_stack_len();
     for value in [self_obj, memo, doc] {
-        gc_roots::pin_root(value);
+        let _ = gc_roots::pin_root(value);
     }
     let result = pyre_object::w_list_new_empty();
-    gc_roots::pin_root(result);
+    let _ = gc_roots::pin_root(result);
     (char_index, byte_index) =
         skip_json_whitespace(gc_roots::shadow_stack_get(slot + 2), char_index, byte_index);
     let doc = gc_roots::shadow_stack_get(slot + 2);
@@ -532,7 +532,7 @@ fn scanner_parse_array(
                 err
             }
         })?;
-        gc_roots::pin_root(value);
+        let _ = gc_roots::pin_root(value);
         unsafe {
             pyre_object::w_list_append(
                 gc_roots::shadow_stack_get(slot + 3),
@@ -596,12 +596,12 @@ fn scanner_call_impl(self_obj: PyObjectRef, doc: PyObjectRef, index: i64) -> PyR
     let _roots = gc_roots::push_roots();
     let slot = gc_roots::shadow_stack_len();
     for value in [self_obj, doc] {
-        gc_roots::pin_root(value);
+        let _ = gc_roots::pin_root(value);
     }
     // CPython `scanner_call`: one exact dict per public invocation, shared by
     // the whole recursive descent and discarded with the call.
     let memo = pyre_object::w_dict_new();
-    gc_roots::pin_root(memo);
+    let _ = gc_roots::pin_root(memo);
     let (value, next, _) = scanner_scan_once(
         gc_roots::shadow_stack_get(slot),
         gc_roots::shadow_stack_get(slot + 2),
@@ -609,7 +609,7 @@ fn scanner_call_impl(self_obj: PyObjectRef, doc: PyObjectRef, index: i64) -> PyR
         char_index,
         byte_index,
     )?;
-    gc_roots::pin_root(value);
+    let _ = gc_roots::pin_root(value);
     Ok(pyre_object::w_tuple_new(vec![
         gc_roots::shadow_stack_get(slot + 3),
         pyre_object::w_int_new(next as i64),
@@ -817,7 +817,7 @@ fn add_json_note(mut err: PyError, note: impl Into<rustpython_wtf8::Wtf8Buf>) ->
     // surrogate, so it is carried as the WTF-8 it is.
     let note = pyre_object::w_str_from_wtf8_managed(note.into());
     let note_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(note);
+    let _ = gc_roots::pin_root(note);
     if let Ok(add_note) =
         crate::baseobjspace::getattr_str(gc_roots::shadow_stack_get(exc_slot), "add_note")
     {
@@ -879,14 +879,14 @@ where
     // for deletion; no parallel Rust identity table is introduced.
     let _roots = gc_roots::push_roots();
     let markers_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(markers);
+    let _ = gc_roots::pin_root(markers);
     let self_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(self_obj);
+    let _ = gc_roots::pin_root(self_obj);
     let obj_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(obj);
+    let _ = gc_roots::pin_root(obj);
     let key = marker_key(gc_roots::shadow_stack_get(obj_slot));
     let key_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(key);
+    let _ = gc_roots::pin_root(key);
     if crate::baseobjspace::contains(
         gc_roots::shadow_stack_get(markers_slot),
         gc_roots::shadow_stack_get(key_slot),
@@ -989,10 +989,10 @@ fn encode_sequence(
     // back out of the slot; capturing the parameter would name the pre-move
     // address and report the type of whatever now occupies that cell.
     let obj_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(obj);
+    let _ = gc_roots::pin_root(obj);
     let iter = crate::baseobjspace::iter(obj)?;
     let iter_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(iter);
+    let _ = gc_roots::pin_root(iter);
     let separator_obj = encoder_attr(self_obj, "item_separator")?;
     let separator = require_string(separator_obj)?.to_wtf8_buf();
     let indent = indent_value(self_obj)?.map(Wtf8::to_wtf8_buf);
@@ -1088,13 +1088,13 @@ fn encode_dict(
     // back where it is used.
     let _roots = gc_roots::push_roots();
     let obj_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(obj);
+    let _ = gc_roots::pin_root(obj);
     let items = crate::call::call_function_impl_result(
         crate::baseobjspace::getattr_str(obj, "items")?,
         &[],
     )?;
     let mut items_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(items);
+    let _ = gc_roots::pin_root(items);
     if crate::baseobjspace::is_true(encoder_attr(self_obj, "sort_keys")?)? {
         let builtins = crate::importing::get_sys_module("builtins")
             .ok_or_else(|| PyError::runtime_error("builtins module is unavailable"))?;
@@ -1104,11 +1104,11 @@ fn encode_dict(
             &[gc_roots::shadow_stack_get(items_slot)],
         )?;
         items_slot = gc_roots::shadow_stack_len();
-        gc_roots::pin_root(sorted_items);
+        let _ = gc_roots::pin_root(sorted_items);
     }
     let iter = crate::baseobjspace::iter(gc_roots::shadow_stack_get(items_slot))?;
     let iter_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(iter);
+    let _ = gc_roots::pin_root(iter);
     let item_separator = require_string(encoder_attr(self_obj, "item_separator")?)?.to_wtf8_buf();
     let key_separator = require_string(encoder_attr(self_obj, "key_separator")?)?.to_wtf8_buf();
     let indent = indent_value(self_obj)?.map(Wtf8::to_wtf8_buf);
@@ -1134,12 +1134,12 @@ fn encode_dict(
         // this pair.  Root both halves before the first of those calls.
         let _pair_roots = gc_roots::push_roots();
         let pair_slot = gc_roots::shadow_stack_len();
-        gc_roots::pin_root(pair_items[0]);
-        gc_roots::pin_root(pair_items[1]);
+        let _ = gc_roots::pin_root(pair_items[0]);
+        let _ = gc_roots::pin_root(pair_items[1]);
         let Some(key) = coerce_key(self_obj, gc_roots::shadow_stack_get(pair_slot))? else {
             continue;
         };
-        gc_roots::pin_root(key);
+        let _ = gc_roots::pin_root(key);
         if first {
             first = false;
             if let Some(indent) = &indent {
@@ -1190,7 +1190,7 @@ fn encoder_call_impl(self_obj: PyObjectRef, obj: PyObjectRef, level: i64) -> PyR
     let encoded = encode_value(self_obj, obj, level.max(0))?;
     let _roots = gc_roots::push_roots();
     let encoded_slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(encoded));
+    let _ = gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(encoded));
     Ok(pyre_object::w_list_new(vec![gc_roots::shadow_stack_get(
         encoded_slot,
     )]))
@@ -1248,7 +1248,7 @@ fn make_encoder_impl(
         skipkeys,
         allow_nan,
     ] {
-        gc_roots::pin_root(value);
+        let _ = gc_roots::pin_root(value);
     }
     let _ = encoder_class::type_object();
     Ok(W_Encoder::allocate_stable(W_Encoder {
@@ -1270,7 +1270,7 @@ fn make_encoder_impl(
 fn make_scanner_impl(context: PyObjectRef) -> PyResult {
     let _roots = gc_roots::push_roots();
     let slot = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(context);
+    let _ = gc_roots::pin_root(context);
     for name in [
         "strict",
         "parse_float",
@@ -1280,7 +1280,7 @@ fn make_scanner_impl(context: PyObjectRef) -> PyResult {
         "object_pairs_hook",
     ] {
         let value = crate::baseobjspace::getattr_str(gc_roots::shadow_stack_get(slot), name)?;
-        gc_roots::pin_root(value);
+        let _ = gc_roots::pin_root(value);
     }
     // Match the C accelerator: strict is converted during construction, so
     // an overriding `__bool__` raises before the first token is scanned.

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -172,7 +172,7 @@ fn localeconv_to_dict(c: &LocaleConvData) -> pyre_object::PyObjectRef {
     // for every insertion and for the return.
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(pyre_object::w_dict_new());
+    let _ = roots.pin_root(pyre_object::w_dict_new());
     // The value arrives already built.  Call arguments evaluate left to right,
     // so reading the dict slot inline with an allocating value expression
     // would read the slot first and hand over a pre-move word.
@@ -181,7 +181,7 @@ fn localeconv_to_dict(c: &LocaleConvData) -> pyre_object::PyObjectRef {
         // allocated after this value is handed over.
         let value_root = pyre_object::gc_roots::push_roots();
         let value_slot = value_root.base();
-        value_root.pin_root(value);
+        let _ = value_root.pin_root(value);
         // SAFETY: the slot holds the `W_DictObject` pinned above.
         unsafe {
             pyre_object::w_dict_setitem_str(roots.get(dict_slot), k, value_root.get(value_slot));

--- a/pyre/pyre-interpreter/src/module/_lsprof/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_lsprof/mod.rs
@@ -145,7 +145,7 @@ impl ProfilerSubEntry {
     fn stats(&self, factor: f64) -> PyObjectRef {
         let _roots = pyre_object::gc_roots::push_roots();
         let frame_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(self.frame);
+        let _ = pyre_object::gc_roots::pin_root(self.frame);
         W_StatsSubEntry::allocate_stable(W_StatsSubEntry {
             ob: PyObject::default(),
             frame: pyre_object::gc_roots::shadow_stack_get(frame_slot),
@@ -186,13 +186,13 @@ impl ProfilerEntry {
     fn stats(&self, factor: f64) -> PyObjectRef {
         let _roots = pyre_object::gc_roots::push_roots();
         let frame_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(self.frame);
+        let _ = pyre_object::gc_roots::pin_root(self.frame);
         let w_sublist = if self.calls.is_empty() {
             w_none()
         } else {
             let root_base = pyre_object::gc_roots::shadow_stack_len();
             for subentry in &self.calls {
-                pyre_object::gc_roots::pin_root(subentry.stats(factor));
+                let _ = pyre_object::gc_roots::pin_root(subentry.stats(factor));
             }
             let items = (root_base..pyre_object::gc_roots::shadow_stack_len())
                 .map(pyre_object::gc_roots::shadow_stack_get)
@@ -203,7 +203,7 @@ impl ProfilerEntry {
         // each subentry pinned above sits between them, so `frame_slot + 1` is
         // the first subentry whenever there is one.
         let sublist_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_sublist);
+        let _ = pyre_object::gc_roots::pin_root(w_sublist);
         W_StatsEntry::allocate_stable(W_StatsEntry {
             ob: PyObject::default(),
             frame: pyre_object::gc_roots::shadow_stack_get(frame_slot),
@@ -612,11 +612,11 @@ impl W_Profiler {
     fn enter_builtin_call(&mut self, self_obj: PyObjectRef, w_arg: PyObjectRef) {
         let _roots = pyre_object::gc_roots::push_roots();
         let root_base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(self_obj);
-        pyre_object::gc_roots::pin_root(w_arg);
+        let _ = pyre_object::gc_roots::pin_root(self_obj);
+        let _ = pyre_object::gc_roots::pin_root(w_arg);
         let (w_func, w_type, w_frame) =
             prepare_spec(pyre_object::gc_roots::shadow_stack_get(root_base + 1));
-        pyre_object::gc_roots::pin_root(w_frame);
+        let _ = pyre_object::gc_roots::pin_root(w_frame);
         let this = W_Profiler::from_obj(pyre_object::gc_roots::shadow_stack_get(root_base))
             .expect("profile hook owns a live Profiler");
         if let Some(entry_index) = this.get_or_make_builtin_entry(
@@ -654,7 +654,7 @@ impl W_Profiler {
         let root_base = pyre_object::gc_roots::shadow_stack_len();
         for entry in &self.entries {
             if entry.callcount != 0 {
-                pyre_object::gc_roots::pin_root(entry.stats(factor));
+                let _ = pyre_object::gc_roots::pin_root(entry.stats(factor));
             }
         }
         let items = (root_base..pyre_object::gc_roots::shadow_stack_len())
@@ -705,7 +705,7 @@ mod profiler_methods {
             };
             let _roots = pyre_object::gc_roots::push_roots();
             let callable_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(callable);
+            let _ = pyre_object::gc_roots::pin_root(callable);
             let obj = W_Profiler::allocate_stable(W_Profiler {
                 ob: PyObject::default(),
                 subcalls: subcalls != 0,

--- a/pyre/pyre-interpreter/src/module/_lzma/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_lzma/mod.rs
@@ -132,7 +132,7 @@ const BCJ_KIND: FilterKind = FilterKind {
 fn parse_filter_spec(spec: PyObjectRef) -> Result<backend::FilterSpec, crate::PyError> {
     let _roots = push_roots();
     let spec_slot = shadow_stack_len();
-    pin_root(spec);
+    let spec = pin_root(spec);
     let spec = || shadow_stack_get(spec_slot);
 
     if unsafe { crate::baseobjspace::lookup(spec(), "__getitem__") }.is_none() {
@@ -229,7 +229,7 @@ fn parse_filter_spec(spec: PyObjectRef) -> Result<backend::FilterSpec, crate::Py
 fn parse_filter_chain(filters: PyObjectRef) -> Result<Vec<backend::FilterSpec>, crate::PyError> {
     let _roots = push_roots();
     let filters_slot = shadow_stack_len();
-    pin_root(filters);
+    let filters = pin_root(filters);
     let filters = || shadow_stack_get(filters_slot);
 
     let count = crate::runtime_ops::sequence_len(filters())?;
@@ -308,7 +308,7 @@ mod compressor_methods {
             // here on rather than in this argument.
             let _roots = push_roots();
             let filters_slot = shadow_stack_len();
-            pin_root(filters);
+            let filters = pin_root(filters);
             let filters = || shadow_stack_get(filters_slot);
 
             if format != backend::FORMAT_XZ && check != -1 && check != backend::CHECK_NONE as i32 {
@@ -400,7 +400,7 @@ mod decompressor_methods {
             // caller's own, so the chain moves to a shadow-stack slot first.
             let _roots = push_roots();
             let filters_slot = shadow_stack_len();
-            pin_root(filters);
+            let filters = pin_root(filters);
             let filters = || shadow_stack_get(filters_slot);
 
             let memlimit = if unsafe { is_none(memlimit) } {
@@ -613,7 +613,7 @@ crate::py_module! {
             // is read back out of its slot for every one of them.
             let _roots = push_roots();
             let dict_slot = shadow_stack_len();
-            pin_root(w_dict_new());
+            let _ = pin_root(w_dict_new());
             let dict = || shadow_stack_get(dict_slot);
             let id = w_int_new(decoded.id as i64);
             unsafe { w_dict_setitem_str(dict(), "id", id) };

--- a/pyre/pyre-interpreter/src/module/_multibytecodec/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multibytecodec/mod.rs
@@ -269,7 +269,7 @@ fn encode_impl(
     // from there rather than kept as a Rust local across the call.
     let roots = pyre_object::gc_roots::push_roots();
     let input_slot = roots.base();
-    roots.pin_root(w_input);
+    let _ = roots.pin_root(w_input);
     let input = unsafe { pyre_object::w_str_get_wtf8(roots.get(input_slot)) };
     let (mut units, boundaries) = text_to_wchars(input);
     let codec = codec_ptr(name).ok_or_else(|| {

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -84,14 +84,14 @@ fn semlock_set_i64(obj: PyObjectRef, key: &str, value: i64) {
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
     let boxed_slot = obj_slot + 1;
-    pyre_object::gc_roots::pin_root(w_int_new(value));
+    let _ = pyre_object::gc_roots::pin_root(w_int_new(value));
     let dict =
         crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(obj_slot));
     if dict.is_null() {
         return;
     }
     let dict_slot = boxed_slot + 1;
-    pyre_object::gc_roots::pin_root(dict);
+    let _ = pyre_object::gc_roots::pin_root(dict);
     unsafe {
         w_dict_setitem_str(
             pyre_object::gc_roots::shadow_stack_get(dict_slot),
@@ -575,7 +575,7 @@ fn semlock_instance(
     let obj = w_instance_new(w_subtype);
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     // `getdict_native` materialises the instance dict, so it can collect and
     // move `obj`; read the receiver back from its slot the way every store
     // below does, rather than handing over the pre-pin copy.
@@ -586,7 +586,7 @@ fn semlock_instance(
             "SemLock instance has no storage",
         ));
     }
-    pyre_object::gc_roots::pin_root(dict);
+    let _ = pyre_object::gc_roots::pin_root(dict);
     macro_rules! store {
         ($name:literal, $value:expr) => {{
             let value = $value;

--- a/pyre/pyre-interpreter/src/module/_overlapped/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_overlapped/mod.rs
@@ -231,7 +231,7 @@ fn retain_writable_buffer(
     let r_buffer = pyre_object::gc_roots::shadow_stack_get(base + 1);
     let (slice, owner) = writable_buffer(r_buffer)?;
     let length = slice.len();
-    pyre_object::gc_roots::pin_root(owner);
+    let _ = pyre_object::gc_roots::pin_root(owner);
     let owner_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let held = unsafe {
         crate::builtins::buffer_export_incref(pyre_object::gc_roots::shadow_stack_get(owner_slot))
@@ -391,7 +391,7 @@ fn overlapped_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         buffer_export_held: false,
     })));
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let obj = W_Overlapped::allocate_stable(W_Overlapped {
         ob: PyObject::default(),

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -282,7 +282,7 @@ fn pickle_state() -> Option<*const PickleState> {
     let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
     let compat = import_module("_compat_pickle").ok()?;
-    pyre_object::gc_roots::pin_root(compat);
+    let compat = pyre_object::gc_roots::pin_root(compat);
     for attr in [
         "NAME_MAPPING",
         "IMPORT_MAPPING",
@@ -291,7 +291,7 @@ fn pickle_state() -> Option<*const PickleState> {
     ] {
         let compat = pyre_object::gc_roots::shadow_stack_get(base);
         let table = crate::baseobjspace::getattr_str(compat, attr).ok()?;
-        pyre_object::gc_roots::pin_root(table);
+        let _ = pyre_object::gc_roots::pin_root(table);
     }
     // Slots base+1..=base+4 hold the four tables (updated by any relocation
     // during the reads). No GC-allocating step runs between here and publication.
@@ -372,7 +372,7 @@ pub(crate) fn compat_map(
     // The cached real-dict tables take the native `w_dict_lookup_checked` path
     // and never collect, so this only guards a user-replaced mapping.
     let _key_root = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(key);
+    let key = pyre_object::gc_roots::pin_root(key);
     // (module, name) entry takes precedence over a bare module remap. Probe
     // through the generic `space.finditem` so a replaced or non-dict `*_MAPPING`
     // and a raising key comparison behave like PyPy's `space.finditem`.
@@ -443,19 +443,19 @@ pub(crate) fn getattribute_dotted_obj(
     w_qualname: PyObjectRef,
 ) -> Result<(PyObjectRef, PyObjectRef), PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let mut cur_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(w_qualname);
+    let _ = pyre_object::gc_roots::pin_root(w_qualname);
     let qualname_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_dot = pyre_object::w_str_new(".");
-    pyre_object::gc_roots::pin_root(w_dot);
+    let _ = pyre_object::gc_roots::pin_root(w_dot);
     let dot_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_parts = call_meth(
         pyre_object::gc_roots::shadow_stack_get(qualname_slot),
         "split",
         &[pyre_object::gc_roots::shadow_stack_get(dot_slot)],
     )?;
-    pyre_object::gc_roots::pin_root(w_parts);
+    let _ = pyre_object::gc_roots::pin_root(w_parts);
     let parts_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let n = unsafe {
         pyre_object::listobject::w_list_len(pyre_object::gc_roots::shadow_stack_get(parts_slot))
@@ -484,7 +484,7 @@ pub(crate) fn getattribute_dotted_obj(
             pyre_object::gc_roots::shadow_stack_get(cur_slot),
             w_part,
         )?;
-        pyre_object::gc_roots::pin_root(next);
+        let _ = pyre_object::gc_roots::pin_root(next);
         cur_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     }
     Ok((
@@ -686,15 +686,15 @@ crate::py_module! {
             // (`__index__`) and `is_true` (`__bool__`) run user code and can
             // relocate objects under the moving GC.
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            pyre_object::gc_roots::pin_root(buffer_callback);
+            let _ = pyre_object::gc_roots::pin_root(buffer_callback);
             let bc_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            pyre_object::gc_roots::pin_root(file);
+            let _ = pyre_object::gc_roots::pin_root(file);
             let file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            pyre_object::gc_roots::pin_root(protocol);
+            let _ = pyre_object::gc_roots::pin_root(protocol);
             let proto_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            pyre_object::gc_roots::pin_root(fix_imports);
+            let _ = pyre_object::gc_roots::pin_root(fix_imports);
             let fix_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let proto = pickler::normalize_protocol(pyre_object::gc_roots::shadow_stack_get(
                 proto_slot,
@@ -705,7 +705,7 @@ crate::py_module! {
             // The dump-time `dispatch_table` (no per-pickler one here) — its
             // `copyreg` import can collect; pin it before the memo allocation.
             let dispatch_table = pickler::copyreg_dispatch_table();
-            pyre_object::gc_roots::pin_root(dispatch_table);
+            let _ = pyre_object::gc_roots::pin_root(dispatch_table);
             let dt_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_memo = pyre_object::listobject::w_list_new(Vec::new());
             // Pass `file` so `pickle_core` streams the frames to it directly.
@@ -740,13 +740,13 @@ crate::py_module! {
             // Pin every input before any Python-visible work (`__index__` /
             // `__bool__` / `copyreg` import / memo alloc can relocate objects).
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            pyre_object::gc_roots::pin_root(buffer_callback);
+            let _ = pyre_object::gc_roots::pin_root(buffer_callback);
             let bc_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            pyre_object::gc_roots::pin_root(protocol);
+            let _ = pyre_object::gc_roots::pin_root(protocol);
             let proto_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            pyre_object::gc_roots::pin_root(fix_imports);
+            let _ = pyre_object::gc_roots::pin_root(fix_imports);
             let fix_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let proto = pickler::normalize_protocol(pyre_object::gc_roots::shadow_stack_get(
                 proto_slot,
@@ -755,7 +755,7 @@ crate::py_module! {
             let fix =
                 crate::baseobjspace::is_true(pyre_object::gc_roots::shadow_stack_get(fix_slot))?;
             let dispatch_table = pickler::copyreg_dispatch_table();
-            pyre_object::gc_roots::pin_root(dispatch_table);
+            let _ = pyre_object::gc_roots::pin_root(dispatch_table);
             let dt_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_memo = pyre_object::listobject::w_list_new(Vec::new());
             // No file: `pickle_core` accumulates and returns the pickle bytes.
@@ -812,11 +812,11 @@ crate::py_module! {
             // a minor collection there can relocate them.
             let _roots = pyre_object::gc_roots::push_roots();
             let base = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(data);
-            pyre_object::gc_roots::pin_root(fix_imports);
-            pyre_object::gc_roots::pin_root(encoding);
-            pyre_object::gc_roots::pin_root(errors);
-            pyre_object::gc_roots::pin_root(buffers);
+            let _ = pyre_object::gc_roots::pin_root(data);
+            let fix_imports = pyre_object::gc_roots::pin_root(fix_imports);
+            let encoding = pyre_object::gc_roots::pin_root(encoding);
+            let errors = pyre_object::gc_roots::pin_root(errors);
+            let buffers = pyre_object::gc_roots::pin_root(buffers);
             let io = import_module("io")?;
             let bytesio_cls = crate::baseobjspace::getattr_str(io, "BytesIO")?;
             let file = call_fn(

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -41,7 +41,7 @@ struct PinnedRef {
 impl PinnedRef {
     fn new(value: PyObjectRef, movable: bool) -> Self {
         let slot = if movable {
-            pyre_object::gc_roots::pin_root(value);
+            let _ = pyre_object::gc_roots::pin_root(value);
             Some(pyre_object::gc_roots::shadow_stack_len() - 1)
         } else {
             None
@@ -181,12 +181,12 @@ impl PickleCtx {
 /// `when serializing test.pickletester.REX object`.
 fn pickle_type_name(w_obj: PyObjectRef) -> Result<String, PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_type = crate::typedef::r#type(pyre_object::gc_roots::shadow_stack_get(obj_slot))
         .ok_or_else(|| PyError::type_error("object has no type"))?
         .as_ptr();
-    pyre_object::gc_roots::pin_root(w_type);
+    let _ = pyre_object::gc_roots::pin_root(w_type);
     let type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     let w_module = crate::baseobjspace::getattr_str(
@@ -220,9 +220,9 @@ fn add_pickle_object_note(
 ) -> PyError {
     let _roots = pyre_object::gc_roots::push_roots();
     let w_exc = err.to_exc_object();
-    pyre_object::gc_roots::pin_root(w_exc);
+    let _ = pyre_object::gc_roots::pin_root(w_exc);
     let exc_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     if let Ok(type_name) = pickle_type_name(pyre_object::gc_roots::shadow_stack_get(obj_slot)) {
@@ -230,13 +230,13 @@ fn add_pickle_object_note(
             format!("when serializing {type_name} "),
             role
         ));
-        pyre_object::gc_roots::pin_root(w_note);
+        let _ = pyre_object::gc_roots::pin_root(w_note);
         let note_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         if let Ok(w_add_note) = crate::baseobjspace::getattr_str(
             pyre_object::gc_roots::shadow_stack_get(exc_slot),
             "add_note",
         ) {
-            pyre_object::gc_roots::pin_root(w_add_note);
+            let _ = pyre_object::gc_roots::pin_root(w_add_note);
             let add_note_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             // The original exception remains authoritative. A pathological
             // overridden `add_note` must not turn serializer context handling
@@ -332,7 +332,7 @@ impl Framer {
             // Pin the freshly-built bytes and re-read both it and the
             // cached callable from their roots before arbitrary Python.
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(w_bytes);
+            let _ = pyre_object::gc_roots::pin_root(w_bytes);
             let bytes_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             if let Some(write_slot) = self.write_slot {
                 call_fn(
@@ -400,7 +400,7 @@ impl Framer {
                 // Pin the freshly-built payload and re-read the cached
                 // callable from its outer root before arbitrary Python.
                 let _roots = pyre_object::gc_roots::push_roots();
-                pyre_object::gc_roots::pin_root(w_payload);
+                let _ = pyre_object::gc_roots::pin_root(w_payload);
                 let payload_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 if let Some(write_slot) = self.write_slot {
                     call_fn(
@@ -464,15 +464,15 @@ impl W_Pickler {
         // `_pickle.c:711-721` BEGIN/END_USING_PICKLER.  In particular,
         // `file.write` lookup and protocol coercion may execute Python.
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self as *mut W_Pickler as PyObjectRef);
+        let _ = pyre_object::gc_roots::pin_root(self as *mut W_Pickler as PyObjectRef);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        pyre_object::gc_roots::pin_root(file);
+        let file = pyre_object::gc_roots::pin_root(file);
         let file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        pyre_object::gc_roots::pin_root(protocol);
+        let protocol = pyre_object::gc_roots::pin_root(protocol);
         let protocol_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        pyre_object::gc_roots::pin_root(fix_imports);
+        let _ = pyre_object::gc_roots::pin_root(fix_imports);
         let fix_imports_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        pyre_object::gc_roots::pin_root(buffer_callback);
+        let buffer_callback = pyre_object::gc_roots::pin_root(buffer_callback);
         let buffer_callback_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         if cur_pickler(self_slot).running {
             return Err(PyError::runtime_error("Pickler object is already used"));
@@ -493,7 +493,7 @@ impl W_Pickler {
         else {
             return Err(PyError::type_error("file must have a 'write' attribute"));
         };
-        pyre_object::gc_roots::pin_root(w_write);
+        let _ = pyre_object::gc_roots::pin_root(w_write);
         let write_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         if !unsafe {
             pyre_object::is_none(pyre_object::gc_roots::shadow_stack_get(
@@ -532,7 +532,7 @@ impl W_Pickler {
         // `UnpicklerMemoProxy::clear` already has this shape.
         let self_obj = self as *mut W_Pickler as PyObjectRef;
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self_obj);
+        let _ = pyre_object::gc_roots::pin_root(self_obj);
         let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let empty = pyre_object::listobject::w_list_new(Vec::new());
         let me = cur_pickler(slot);
@@ -546,7 +546,7 @@ impl W_Pickler {
         // pickler's active memo/framer state.
         let self_ptr = self as *mut W_Pickler as PyObjectRef;
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self_ptr);
+        let _ = pyre_object::gc_roots::pin_root(self_ptr);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let (
             proto,
@@ -594,17 +594,17 @@ impl W_Pickler {
         // `reducer_override` / `dispatch_table` lookups below: each runs Python
         // (a property / `__getattr__` / `copyreg` import) and can relocate
         // objects under the moving GC.
-        pyre_object::gc_roots::pin_root(w_obj);
+        let _ = pyre_object::gc_roots::pin_root(w_obj);
         let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        pyre_object::gc_roots::pin_root(w_file);
+        let _ = pyre_object::gc_roots::pin_root(w_file);
         let file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        pyre_object::gc_roots::pin_root(w_write);
+        let _ = pyre_object::gc_roots::pin_root(w_write);
         let write_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        pyre_object::gc_roots::pin_root(w_memo);
+        let _ = pyre_object::gc_roots::pin_root(w_memo);
         let memo_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        pyre_object::gc_roots::pin_root(buffer_callback);
+        let _ = pyre_object::gc_roots::pin_root(buffer_callback);
         let cb_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        pyre_object::gc_roots::pin_root(w_dispatch_table);
+        let _ = pyre_object::gc_roots::pin_root(w_dispatch_table);
         let configured_dt_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
         // `persistent_id` resolves to a subclass method override or the
@@ -621,14 +621,14 @@ impl W_Pickler {
             "persistent_id",
         )?
         .unwrap_or(pyre_object::PY_NULL);
-        pyre_object::gc_roots::pin_root(pers_func);
+        let _ = pyre_object::gc_roots::pin_root(pers_func);
         let pers_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let reducer_override = crate::baseobjspace::findattr_result(
             pyre_object::gc_roots::shadow_stack_get(self_slot),
             "reducer_override",
         )?
         .unwrap_or(pyre_object::PY_NULL);
-        pyre_object::gc_roots::pin_root(reducer_override);
+        let _ = pyre_object::gc_roots::pin_root(reducer_override);
         let reducer_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         // `interp_pickle.py:686-690` — the internal `dispatch_table` field,
         // else a dynamically-resolved `dispatch_table` attribute (a subclass
@@ -647,7 +647,7 @@ impl W_Pickler {
         } else {
             copyreg_dispatch_table()
         };
-        pyre_object::gc_roots::pin_root(dispatch_table);
+        let _ = pyre_object::gc_roots::pin_root(dispatch_table);
         let dt_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
         // Re-read every pinned value: the lookups / `copyreg` import above may
@@ -736,17 +736,17 @@ impl W_Pickler {
             return Ok(self.w_pers_func);
         }
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self as *const W_Pickler as PyObjectRef);
+        let _ = pyre_object::gc_roots::pin_root(self as *const W_Pickler as PyObjectRef);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let cls = type_object();
-        pyre_object::gc_roots::pin_root(cls);
+        let _ = pyre_object::gc_roots::pin_root(cls);
         let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let descr = crate::runtime_ops::type_dict_lookup(
             pyre_object::gc_roots::shadow_stack_get(cls_slot),
             "__persistent_id_default",
         )
         .ok_or_else(|| PyError::runtime_error("lost Pickler.persistent_id descriptor"))?;
-        pyre_object::gc_roots::pin_root(descr);
+        let _ = pyre_object::gc_roots::pin_root(descr);
         let descr_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         Ok(pyre_object::w_method_new(
             pyre_object::gc_roots::shadow_stack_get(descr_slot),
@@ -772,7 +772,7 @@ impl W_Pickler {
     fn memo(&self) -> PyObjectRef {
         let self_obj = self as *const W_Pickler as PyObjectRef;
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self_obj);
+        let _ = pyre_object::gc_roots::pin_root(self_obj);
         let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         memo_proxy::type_object();
         let proxy = PicklerMemoProxy::allocate_stable(PicklerMemoProxy {
@@ -804,7 +804,7 @@ impl W_Pickler {
     fn set_memo(&mut self, w_value: PyObjectRef) -> Result<(), PyError> {
         let self_obj = self as *mut W_Pickler as PyObjectRef;
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self_obj);
+        let _ = pyre_object::gc_roots::pin_root(self_obj);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_dict = if PicklerMemoProxy::from_obj(w_value).is_some() {
             call_meth(w_value, "copy", &[])?
@@ -816,7 +816,7 @@ impl W_Pickler {
                 crate::baseobjspace::object_functionstr_type_name(w_value),
             )));
         };
-        pyre_object::gc_roots::pin_root(w_dict);
+        let _ = pyre_object::gc_roots::pin_root(w_dict);
         let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         // No GC between reading the items and `w_list_new` (which re-pins them).
         let items = unsafe {
@@ -891,10 +891,10 @@ mod memo_proxy {
         fn copy(&self) -> Result<PyObjectRef, PyError> {
             let w_memo = unsafe { &*(self.w_pickler as *const W_Pickler) }.w_memo;
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(w_memo);
+            let _ = pyre_object::gc_roots::pin_root(w_memo);
             let memo_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let result = pyre_object::dictmultiobject::w_dict_new();
-            pyre_object::gc_roots::pin_root(result);
+            let _ = pyre_object::gc_roots::pin_root(result);
             let res_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let n = unsafe {
                 pyre_object::listobject::w_list_len(pyre_object::gc_roots::shadow_stack_get(
@@ -922,7 +922,7 @@ mod memo_proxy {
                     pyre_object::w_int_new(i as i64),
                     obj,
                 ]);
-                pyre_object::gc_roots::pin_root(tup);
+                let _ = pyre_object::gc_roots::pin_root(tup);
                 let tup_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 // id(obj) read from the (relocated) tuple element.
                 let cur_obj = unsafe {
@@ -933,7 +933,7 @@ mod memo_proxy {
                 }
                 .unwrap();
                 let key = pyre_object::w_int_new(cur_obj as i64);
-                pyre_object::gc_roots::pin_root(key);
+                let _ = pyre_object::gc_roots::pin_root(key);
                 let key_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 // The IndexMap insert allocates via `std::alloc` (no collection), so
                 // the freshly read addresses stay valid through it.
@@ -952,7 +952,7 @@ mod memo_proxy {
         fn clear(&self) {
             let w_pickler = self.w_pickler;
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(w_pickler);
+            let _ = pyre_object::gc_roots::pin_root(w_pickler);
             let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let empty = pyre_object::listobject::w_list_new(Vec::new());
             let p =
@@ -1057,7 +1057,7 @@ fn pickle_core_impl(
     reducer_override: PyObjectRef,
 ) -> Result<PyObjectRef, PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let w_obj = pyre_object::gc_roots::pin_root(w_obj);
     let pers_func = PinnedRef::new(pers_func, !pers_func.is_null());
     let buffer_callback = PinnedRef::new(
         buffer_callback,
@@ -1070,7 +1070,7 @@ fn pickle_core_impl(
     let reducer_override = PinnedRef::new(reducer_override, !reducer_override.is_null());
     // Pin the memo list and index its existing entries (a reused `Pickler`
     // carries memo state across `dump` calls until `clear_memo`).
-    pyre_object::gc_roots::pin_root(w_memo);
+    let w_memo = pyre_object::gc_roots::pin_root(w_memo);
     let memo_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let mut index: HashMap<usize, Vec<usize>> = HashMap::new();
     let n = unsafe { pyre_object::listobject::w_list_len(w_memo) };
@@ -1106,13 +1106,13 @@ fn pickle_core_impl(
     let file_slot = if w_file.is_null() {
         None
     } else {
-        pyre_object::gc_roots::pin_root(w_file);
+        let _ = pyre_object::gc_roots::pin_root(w_file);
         Some(pyre_object::gc_roots::shadow_stack_len() - 1)
     };
     let write_slot = if w_write.is_null() {
         None
     } else {
-        pyre_object::gc_roots::pin_root(w_write);
+        let _ = pyre_object::gc_roots::pin_root(w_write);
         Some(pyre_object::gc_roots::shadow_stack_len() - 1)
     };
     let mut fr = Framer::new(file_slot, write_slot);
@@ -1206,7 +1206,7 @@ fn save(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(),
     // Committing streams to the file (arbitrary Python), and the `persistent_id`
     // hook below is too, so pin `w_obj` across both and read it from the pin.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     buf.commit_frame(false)?;
     let pers_func = ctx.pers_func.get();
@@ -1337,7 +1337,7 @@ fn dispatch_save(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> R
     let reducer_override = ctx.reducer_override.get();
     if !reducer_override.is_null() {
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_obj);
+        let _ = pyre_object::gc_roots::pin_root(w_obj);
         let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_rv = call_fn(
             reducer_override,
@@ -1371,7 +1371,7 @@ fn save_global_or_reduce(
     // two consumers that sit after one of those calls.
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let w_obj = pyre_object::gc_roots::pin_root(w_obj);
     // CPython 3.14 pickle.py dispatch[type] = save_type: only a class whose
     // exact metaclass is `type` takes this built-in dispatch entry. A class
     // with a custom metaclass must consult dispatch_table first.
@@ -1406,7 +1406,7 @@ fn save_global_or_reduce(
         Some(reduce_ex) => {
             // A bound method the lookup minted has no other referrer, and
             // boxing the protocol number allocates before the call reaches it.
-            pyre_object::gc_roots::pin_root(reduce_ex);
+            let reduce_ex = pyre_object::gc_roots::pin_root(reduce_ex);
             call_fn(reduce_ex, &[pyre_object::w_int_new(ctx.proto)])?
         }
         None => match crate::baseobjspace::findattr_result(
@@ -1442,13 +1442,13 @@ fn save_type(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Resul
     };
 
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_type = builtin_attr("type")?;
-    pyre_object::gc_roots::pin_root(w_type);
+    let _ = pyre_object::gc_roots::pin_root(w_type);
     let type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_args = pyre_object::tupleobject::w_tuple_new(vec![singleton]);
-    pyre_object::gc_roots::pin_root(w_args);
+    let _ = pyre_object::gc_roots::pin_root(w_args);
     let args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     save_reduce(
         ctx,
@@ -1471,9 +1471,9 @@ fn save_reduce_value(
     w_rv: PyObjectRef,
 ) -> Result<(), PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(w_rv);
+    let _ = pyre_object::gc_roots::pin_root(w_rv);
     let rv_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     let w_rv = pyre_object::gc_roots::shadow_stack_get(rv_slot);
@@ -1553,15 +1553,15 @@ fn dispatch_table_reduce(
     let type_fn = crate::module::_pickle::lookup_builtin("type")
         .ok_or_else(|| pickling_error("type builtin unavailable"))?;
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(dt);
+    let _ = pyre_object::gc_roots::pin_root(dt);
     let dt_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_type = call_fn(
         type_fn,
         &[pyre_object::gc_roots::shadow_stack_get(obj_slot)],
     )?;
-    pyre_object::gc_roots::pin_root(w_type);
+    let _ = pyre_object::gc_roots::pin_root(w_type);
     let type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let dt = pyre_object::gc_roots::shadow_stack_get(dt_slot);
     let w_type = pyre_object::gc_roots::shadow_stack_get(type_slot);
@@ -1692,7 +1692,7 @@ fn save_bytes(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Resu
     // A large payload streams via `file.write` (arbitrary Python); pin `w_obj`
     // so the trailing `memoize` reads it at its post-write address.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     if n <= 0xff {
         buf.push(op::SHORT_BINBYTES);
@@ -1719,7 +1719,7 @@ fn save_str(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result
     // A large payload streams via `file.write` (arbitrary Python); pin `w_obj`
     // so the trailing `memoize` reads it at its post-write address.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let w_obj = pyre_object::gc_roots::pin_root(w_obj);
     let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     if ctx.bin {
         // The binary opcodes carry the string's `surrogatepass` UTF-8, which is
@@ -1793,7 +1793,7 @@ fn save_tuple(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Resu
     // re-read each one (and the tuple itself for the memo) from the
     // GC-walked tuple right before it is used.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let elem = |i: usize| unsafe {
         pyre_object::tupleobject::w_tuple_getitem(
@@ -1862,7 +1862,7 @@ fn save_list(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Resul
     // The list itself is a GC-walked Python `list`; pin it and append by
     // re-reading each element, so a relocation during a recursive save is
     // observed instead of dereferencing a stale snapshot.
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let fast_token = fast_save_enter(ctx, slot)?;
     if ctx.bin {
@@ -1883,7 +1883,7 @@ fn save_dict(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Resul
     // Pin the dict so `memoize` sees its current address. PyPy passes the live
     // `dict.items()` view to `_batch_setitems`; retaining that iterator shape
     // is what detects mutation from a persistent-id callback.
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let fast_token = fast_save_enter(ctx, dict_slot)?;
     if ctx.bin {
@@ -1898,7 +1898,7 @@ fn save_dict(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Resul
         "items",
         &[],
     )?;
-    pyre_object::gc_roots::pin_root(w_items);
+    let _ = pyre_object::gc_roots::pin_root(w_items);
     let items_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let result = batch_setitems(ctx, buf, items_slot, Some(dict_slot));
     fast_save_leave(ctx, fast_token, dict_slot);
@@ -1922,7 +1922,7 @@ fn save_set(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result
     // members into a pinned Python `list` re-read per save (a recursive save
     // can relocate them).
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let set_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let fast_token = fast_save_enter(ctx, set_slot)?;
     memoize(ctx, buf, pyre_object::gc_roots::shadow_stack_get(set_slot));
@@ -2005,7 +2005,7 @@ fn save_frozenset(
     // re-read per save (a recursive save can relocate them); the frozenset
     // itself is re-read for the memo check after the saves.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let fs_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let items = unsafe {
         pyre_object::setobject::w_set_items(pyre_object::gc_roots::shadow_stack_get(fs_slot))
@@ -2057,7 +2057,7 @@ fn save_bytearray(
     // A large payload streams via `file.write` (arbitrary Python); pin `w_obj`
     // so the trailing `memoize` reads it at its post-write address.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     if n >= FRAME_SIZE_TARGET {
         let mut header = vec![op::BYTEARRAY8];
@@ -2116,7 +2116,7 @@ fn save_picklebuffer(
         // `_save_bytearray_data`), so a repeated reference becomes a GET. A
         // large payload streams via `file.write`; pin `w_obj` for the memoize.
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_obj);
+        let _ = pyre_object::gc_roots::pin_root(w_obj);
         let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         if readonly {
             save_raw_bytes(ctx, buf, &data)?;
@@ -2182,7 +2182,7 @@ fn save_raw_bytearray(buf: &mut Framer, data: &[u8]) -> Result<(), PyError> {
 /// element even after the recursive `save` calls below trigger collections.
 fn pin_items(items: Vec<PyObjectRef>) -> usize {
     let w_list = pyre_object::listobject::w_list_new(items);
-    pyre_object::gc_roots::pin_root(w_list);
+    let _ = pyre_object::gc_roots::pin_root(w_list);
     pyre_object::gc_roots::shadow_stack_len() - 1
 }
 
@@ -2206,7 +2206,7 @@ fn pinned_get(slot: usize, i: usize) -> PyObjectRef {
 fn pinned_iter_next(iter_slot: usize) -> Result<Option<usize>, PyError> {
     match crate::baseobjspace::next(pyre_object::gc_roots::shadow_stack_get(iter_slot)) {
         Ok(item) => {
-            pyre_object::gc_roots::pin_root(item);
+            let _ = pyre_object::gc_roots::pin_root(item);
             Ok(Some(pyre_object::gc_roots::shadow_stack_len() - 1))
         }
         Err(e) if e.matches_stop_iteration() => Ok(None),
@@ -2222,7 +2222,7 @@ fn pinned_iter_next(iter_slot: usize) -> Result<Option<usize>, PyError> {
 fn snapshot_pinned_iterable(source_slot: usize) -> Result<usize, PyError> {
     let snapshot_slot = pin_items(Vec::new());
     let w_iter = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(source_slot))?;
-    pyre_object::gc_roots::pin_root(w_iter);
+    let _ = pyre_object::gc_roots::pin_root(w_iter);
     let iter_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     loop {
         let item =
@@ -2233,7 +2233,7 @@ fn snapshot_pinned_iterable(source_slot: usize) -> Result<usize, PyError> {
             };
         {
             let _item_root = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(item);
+            let _ = pyre_object::gc_roots::pin_root(item);
             let item_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             unsafe {
                 pyre_object::listobject::w_list_append(
@@ -2278,7 +2278,7 @@ fn batch_appends(
     }
 
     let w_iter = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(slot))?;
-    pyre_object::gc_roots::pin_root(w_iter);
+    let _ = pyre_object::gc_roots::pin_root(w_iter);
     let iter_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let mut index = 0usize;
 
@@ -2356,7 +2356,7 @@ fn pinned_pair_next(iter_slot: usize) -> Result<Option<usize>, PyError> {
         Err(e) if e.matches_stop_iteration() => return Ok(None),
         Err(e) => return Err(e),
     };
-    pyre_object::gc_roots::pin_root(item);
+    let _ = pyre_object::gc_roots::pin_root(item);
     let item_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let item = pyre_object::gc_roots::shadow_stack_get(item_slot);
     if !unsafe { pyre_object::is_tuple(item) }
@@ -2411,7 +2411,7 @@ fn batch_setitems(
     obj_slot: Option<usize>,
 ) -> Result<(), PyError> {
     let w_iter = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(slot))?;
-    pyre_object::gc_roots::pin_root(w_iter);
+    let _ = pyre_object::gc_roots::pin_root(w_iter);
     let iter_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     if !ctx.bin {
@@ -2519,7 +2519,7 @@ fn pickling_error_with_context(
 ) -> PyError {
     let _roots = pyre_object::gc_roots::push_roots();
     let w_context = context.to_exc_object();
-    pyre_object::gc_roots::pin_root(w_context);
+    let _ = pyre_object::gc_roots::pin_root(w_context);
     let context_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let mut error = pickling_error(message);
     let w_error = error.to_exc_object();
@@ -2549,7 +2549,7 @@ fn whichmodule(w_obj: PyObjectRef, name: &str) -> Result<ModuleName, PyError> {
     // in between runs arbitrary Python; keep the object in a shadow-stack slot
     // so a relocation cannot leave those reads holding a stale address.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     if name.split('.').any(|s| s == "<locals>") {
         let obj_repr = unsafe {
@@ -2583,9 +2583,10 @@ fn whichmodule(w_obj: PyObjectRef, name: &str) -> Result<ModuleName, PyError> {
         Some(ModuleName::Utf8(mn)) => mn,
         Some(ModuleName::Surrogate(w_module_name)) => {
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(obj_slot));
+            let _ =
+                pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(obj_slot));
             let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            pyre_object::gc_roots::pin_root(w_module_name);
+            let _ = pyre_object::gc_roots::pin_root(w_module_name);
             let module_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let modules = crate::importing::sys_modules_dict();
             let module = unsafe {
@@ -2627,7 +2628,9 @@ fn whichmodule(w_obj: PyObjectRef, name: &str) -> Result<ModuleName, PyError> {
                 // name as an owned String — GC-independent), then scan via the
                 // pinned slots. The snapshot loop itself triggers no collection.
                 let _roots = pyre_object::gc_roots::push_roots();
-                pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(obj_slot));
+                let _ = pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(
+                    obj_slot,
+                ));
                 let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let mut candidates: Vec<(String, usize)> = Vec::new();
                 for (w_modname, w_module) in
@@ -2643,7 +2646,7 @@ fn whichmodule(w_obj: PyObjectRef, name: &str) -> Result<ModuleName, PyError> {
                     if modname == "__main__" || modname == "__mp_main__" {
                         continue;
                     }
-                    pyre_object::gc_roots::pin_root(w_module);
+                    let _ = pyre_object::gc_roots::pin_root(w_module);
                     candidates.push((modname, pyre_object::gc_roots::shadow_stack_len() - 1));
                 }
                 for (modname, mod_slot) in candidates {
@@ -2746,9 +2749,9 @@ fn save_global(
     // `whichmodule` imports the home module (to verify the reference), so pin
     // `w_obj` / `w_name` and re-read them afterwards.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(w_name);
+    let _ = pyre_object::gc_roots::pin_root(w_name);
     let name_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     let w_name = pyre_object::gc_roots::shadow_stack_get(name_slot);
@@ -2764,7 +2767,7 @@ fn save_global(
     let module_name = match module_name {
         ModuleName::Utf8(module_name) => module_name,
         ModuleName::Surrogate(w_module_name) => {
-            pyre_object::gc_roots::pin_root(w_module_name);
+            let _ = pyre_object::gc_roots::pin_root(w_module_name);
             let module_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             return save_global_surrogate_module(ctx, buf, obj_slot, name_slot, module_slot);
         }
@@ -2875,7 +2878,7 @@ fn save_global_surrogate_name(
         }
         _ => pyre_object::w_str_new("__main__"),
     };
-    pyre_object::gc_roots::pin_root(w_module_name);
+    let _ = pyre_object::gc_roots::pin_root(w_module_name);
     let module_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let module_name = unsafe {
         pyre_object::unicodeobject::w_str_get_value_opt(pyre_object::gc_roots::shadow_stack_get(
@@ -2953,10 +2956,10 @@ fn identifier_encoding_error(
     proto: i64,
 ) -> PyError {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_identifier);
+    let _ = pyre_object::gc_roots::pin_root(w_identifier);
     let identifier_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let context_obj = context.to_exc_object();
-    pyre_object::gc_roots::pin_root(context_obj);
+    let _ = pyre_object::gc_roots::pin_root(context_obj);
     let context_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let identifier_repr = unsafe {
         crate::display::py_repr_wtf8(pyre_object::gc_roots::shadow_stack_get(identifier_slot))
@@ -2968,7 +2971,7 @@ fn identifier_encoding_error(
         format!(" using pickle protocol {proto}")
     ));
     let exc = error.to_exc_object();
-    pyre_object::gc_roots::pin_root(exc);
+    let _ = pyre_object::gc_roots::pin_root(exc);
     let exc_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     crate::error::chain_context(
         pyre_object::gc_roots::shadow_stack_get(exc_slot),
@@ -2994,10 +2997,10 @@ fn save_toplevel_by_name(
     let encoding = if ctx.proto < 3 { "ascii" } else { "utf-8" };
     let _roots = pyre_object::gc_roots::push_roots();
     let w_module_name = pyre_object::w_str_new(&module_name);
-    pyre_object::gc_roots::pin_root(w_module_name);
+    let _ = pyre_object::gc_roots::pin_root(w_module_name);
     let module_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_name = pyre_object::w_str_new(&name);
-    pyre_object::gc_roots::pin_root(w_name);
+    let _ = pyre_object::gc_roots::pin_root(w_name);
     let name_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let module_bytes = crate::type_methods::encode_object(
         pyre_object::gc_roots::shadow_stack_get(module_slot),
@@ -3091,7 +3094,7 @@ fn save_reduce(
     // stub into the slot and every later read of it would return the stub.
     let w_obj_slot = match w_obj_opt {
         Some(o) => {
-            pyre_object::gc_roots::pin_root(o);
+            let _ = pyre_object::gc_roots::pin_root(o);
             Some(pyre_object::gc_roots::shadow_stack_len() - 1)
         }
         None => None,
@@ -3148,7 +3151,7 @@ fn save_reduce(
     let func_name = func_name_str(rv_get(0))?;
 
     // Pin the args tuple; its elements are re-read per save.
-    pyre_object::gc_roots::pin_root(rv_get(1));
+    let _ = pyre_object::gc_roots::pin_root(rv_get(1));
     let args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let args_get = |i: usize| unsafe {
         pyre_object::tupleobject::w_tuple_getitem(
@@ -3190,7 +3193,7 @@ fn save_reduce(
                 "__class__",
             )?;
             if !crate::baseobjspace::is_w(args_get(0), w_class) {
-                pyre_object::gc_roots::pin_root(w_class);
+                let _ = pyre_object::gc_roots::pin_root(w_class);
                 let class_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let cls_repr = unsafe { crate::display::py_repr_wtf8(args_get(0))? };
                 let obj_class_repr = unsafe {
@@ -3248,7 +3251,7 @@ fn save_reduce(
             // inside the partial is observable in both reconstruction and
             // the nested PEP 678 notes emitted while the partial is saved.
             let w_new = crate::baseobjspace::getattr_str(args_get(0), "__new__")?;
-            pyre_object::gc_roots::pin_root(w_new);
+            let _ = pyre_object::gc_roots::pin_root(w_new);
             let new_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
             let functools = import_module("functools")?;
@@ -3284,7 +3287,7 @@ fn save_reduce(
                 &partial_args,
                 &kwargs,
             )?;
-            pyre_object::gc_roots::pin_root(w_func);
+            let _ = pyre_object::gc_roots::pin_root(w_func);
             let func_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             if let Err(err) = save(ctx, buf, pyre_object::gc_roots::shadow_stack_get(func_slot)) {
                 return Err(add_reduce_note(
@@ -3314,7 +3317,7 @@ fn save_reduce(
                 "__class__",
             )?;
             if !crate::baseobjspace::is_w(args_get(0), w_class) {
-                pyre_object::gc_roots::pin_root(w_class);
+                let _ = pyre_object::gc_roots::pin_root(w_class);
                 let class_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let cls_repr = unsafe { crate::display::py_repr_wtf8(args_get(0))? };
                 let obj_class_repr = unsafe {
@@ -3332,7 +3335,7 @@ fn save_reduce(
         }
         let w_newargs =
             pyre_object::tupleobject::w_tuple_new((1..args_len).map(&args_get).collect());
-        pyre_object::gc_roots::pin_root(w_newargs);
+        let _ = pyre_object::gc_roots::pin_root(w_newargs);
         let newargs_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         if let Err(err) = save(ctx, buf, args_get(0)) {
             return Err(add_reduce_note(
@@ -3382,12 +3385,12 @@ fn save_reduce(
     }
 
     if has_listitems {
-        pyre_object::gc_roots::pin_root(rv_get(3));
+        let _ = pyre_object::gc_roots::pin_root(rv_get(3));
         let items_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         batch_appends(ctx, buf, items_slot, w_obj_slot)?;
     }
     if has_dictitems {
-        pyre_object::gc_roots::pin_root(rv_get(4));
+        let _ = pyre_object::gc_roots::pin_root(rv_get(4));
         let pairs_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         batch_setitems(ctx, buf, pairs_slot, w_obj_slot)?;
     }

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -147,10 +147,10 @@ impl W_Unpickler {
         // `_pickle.c:724-734` BEGIN/END_USING_UNPICKLER.  Attribute lookup
         // on the input stream may execute arbitrary Python.
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self as *mut W_Unpickler as PyObjectRef);
+        let _ = pyre_object::gc_roots::pin_root(self as *mut W_Unpickler as PyObjectRef);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         for value in [file, fix_imports, encoding, errors, buffers] {
-            pyre_object::gc_roots::pin_root(value);
+            let _ = pyre_object::gc_roots::pin_root(value);
         }
         let file_slot = self_slot + 1;
         let fix_imports_slot = self_slot + 2;
@@ -202,14 +202,14 @@ impl W_Unpickler {
             "read",
         )?
         .unwrap_or(pyre_object::PY_NULL);
-        pyre_object::gc_roots::pin_root(w_file_read);
+        let _ = pyre_object::gc_roots::pin_root(w_file_read);
         let read_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_file_readline = crate::baseobjspace::findattr_result(
             pyre_object::gc_roots::shadow_stack_get(file_slot),
             "readline",
         )?
         .unwrap_or(pyre_object::PY_NULL);
-        pyre_object::gc_roots::pin_root(w_file_readline);
+        let _ = pyre_object::gc_roots::pin_root(w_file_readline);
         let readline_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         if pyre_object::gc_roots::shadow_stack_get(read_slot).is_null()
             || pyre_object::gc_roots::shadow_stack_get(readline_slot).is_null()
@@ -221,7 +221,7 @@ impl W_Unpickler {
         // The memo persists across `load` calls (a multi-object stream may
         // back-reference an object memoized by an earlier load).
         let memo = pyre_object::listobject::w_list_new(Vec::new());
-        pyre_object::gc_roots::pin_root(memo);
+        let _ = pyre_object::gc_roots::pin_root(memo);
         let memo_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         // A non-None `buffers` is consumed as an iterator by NEXT_BUFFER.
         let buffers = pyre_object::gc_roots::shadow_stack_get(buffers_slot);
@@ -256,7 +256,7 @@ impl W_Unpickler {
         // must not recursively consume or reset the active opcode stack.
         let self_ptr = self as *mut W_Unpickler as PyObjectRef;
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self_ptr);
+        let _ = pyre_object::gc_roots::pin_root(self_ptr);
         let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         if cur(slot).running {
             return Err(PyError::runtime_error("Unpickler object is already used"));
@@ -274,7 +274,7 @@ impl W_Unpickler {
             else {
                 return Err(unpickling_error("Unpickler.__init__() was not called"));
             };
-            pyre_object::gc_roots::pin_root(w_read);
+            let _ = pyre_object::gc_roots::pin_root(w_read);
             let read_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let Some(w_readline) = crate::baseobjspace::findattr_result(
                 pyre_object::gc_roots::shadow_stack_get(slot),
@@ -283,7 +283,7 @@ impl W_Unpickler {
             else {
                 return Err(unpickling_error("Unpickler.__init__() was not called"));
             };
-            pyre_object::gc_roots::pin_root(w_readline);
+            let _ = pyre_object::gc_roots::pin_root(w_readline);
             let readline_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let current = cur(slot);
             current.w_file_read = pyre_object::gc_roots::shadow_stack_get(read_slot);
@@ -429,17 +429,17 @@ impl W_Unpickler {
             return Ok(self.w_persistent_load);
         }
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self as *const W_Unpickler as PyObjectRef);
+        let _ = pyre_object::gc_roots::pin_root(self as *const W_Unpickler as PyObjectRef);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let cls = type_object();
-        pyre_object::gc_roots::pin_root(cls);
+        let _ = pyre_object::gc_roots::pin_root(cls);
         let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let descr = crate::runtime_ops::type_dict_lookup(
             pyre_object::gc_roots::shadow_stack_get(cls_slot),
             "__persistent_load_default",
         )
         .ok_or_else(|| PyError::runtime_error("lost Unpickler.persistent_load descriptor"))?;
-        pyre_object::gc_roots::pin_root(descr);
+        let _ = pyre_object::gc_roots::pin_root(descr);
         let descr_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         Ok(pyre_object::w_method_new(
             pyre_object::gc_roots::shadow_stack_get(descr_slot),
@@ -465,7 +465,7 @@ impl W_Unpickler {
     fn memo(&self) -> PyObjectRef {
         let self_obj = self as *const W_Unpickler as PyObjectRef;
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self_obj);
+        let _ = pyre_object::gc_roots::pin_root(self_obj);
         let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         memo_proxy::type_object();
         let proxy = UnpicklerMemoProxy::allocate_stable(UnpicklerMemoProxy {
@@ -497,11 +497,11 @@ impl W_Unpickler {
     fn set_memo(&mut self, w_value: PyObjectRef) -> Result<(), PyError> {
         let self_obj = self as *mut W_Unpickler as PyObjectRef;
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(self_obj);
+        let _ = pyre_object::gc_roots::pin_root(self_obj);
         let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         if UnpicklerMemoProxy::from_obj(w_value).is_some() {
             let w_dict = call_meth(w_value, "copy", &[])?;
-            pyre_object::gc_roots::pin_root(w_dict);
+            let _ = pyre_object::gc_roots::pin_root(w_dict);
             let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let (w_list, next) =
                 memo_list_from_dict(pyre_object::gc_roots::shadow_stack_get(dict_slot))?;
@@ -567,7 +567,7 @@ fn resolve_dotted_find_class(
 fn attribute_error_with_context(message: String, mut context: PyError) -> PyError {
     let _roots = pyre_object::gc_roots::push_roots();
     let w_context = context.to_exc_object();
-    pyre_object::gc_roots::pin_root(w_context);
+    let _ = pyre_object::gc_roots::pin_root(w_context);
     let context_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let mut error = PyError::attribute_error(message);
     let w_error = error.to_exc_object();
@@ -608,9 +608,9 @@ mod memo_proxy {
                 return Ok(w_dict);
             }
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(w_memo);
+            let _ = pyre_object::gc_roots::pin_root(w_memo);
             let memo_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            pyre_object::gc_roots::pin_root(w_dict);
+            let w_dict = pyre_object::gc_roots::pin_root(w_dict);
             let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let len = unsafe {
                 pyre_object::listobject::w_list_len(pyre_object::gc_roots::shadow_stack_get(
@@ -630,7 +630,7 @@ mod memo_proxy {
                     // `w_dict_setitem` boxes the int key (`w_int_new`), which
                     // may collect and move `v`; pin it across the store.
                     let _r = pyre_object::gc_roots::push_roots();
-                    pyre_object::gc_roots::pin_root(v);
+                    let _ = pyre_object::gc_roots::pin_root(v);
                     let v_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                     let w_dict = pyre_object::gc_roots::shadow_stack_get(dict_slot);
                     unsafe {
@@ -649,7 +649,7 @@ mod memo_proxy {
         fn clear(&self) {
             let w_unpickler = self.w_unpickler;
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(w_unpickler);
+            let _ = pyre_object::gc_roots::pin_root(w_unpickler);
             let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let empty = pyre_object::listobject::w_list_new(Vec::new());
             let u = unsafe {
@@ -789,7 +789,7 @@ fn memo_put(slot: usize, i: i64, w_val: PyObjectRef) {
     } else {
         // Grow. `w_list_append` may collect; pin the value and re-read self/list.
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_val);
+        let _ = pyre_object::gc_roots::pin_root(w_val);
         let val_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         // NULL-fill through index `i` (inclusive). Appending `PY_NULL` forces the
         // Object strategy, so memoized values keep pointer identity on GET.
@@ -1138,7 +1138,7 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
             // Pin `items` so the `extend`/`append` lookups (which may allocate
             // and collect) do not strand it; re-read the list top per call.
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(items);
+            let _ = pyre_object::gc_roots::pin_root(items);
             let items_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_list = top(slot, "APPENDS")?;
             match crate::baseobjspace::findattr_result(w_list, "extend")? {
@@ -1198,7 +1198,7 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
         x if x == op::ADDITEMS => {
             let items = pop_mark(slot)?;
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(items);
+            let _ = pyre_object::gc_roots::pin_root(items);
             let items_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_set = top(slot, "ADDITEMS")?;
             let w_set_type = crate::typedef::gettypeobject(&pyre_object::setobject::SET_TYPE);
@@ -1298,9 +1298,9 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
             let w_args = pop(slot)?;
             let w_func = top(slot, "REDUCE")?;
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(w_args);
+            let _ = pyre_object::gc_roots::pin_root(w_args);
             let args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            pyre_object::gc_roots::pin_root(w_func);
+            let _ = pyre_object::gc_roots::pin_root(w_func);
             let func_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             // `_pickle.c:load_reduce` rejects a non-tuple argument list before
             // the callable ever runs, so an iterable operand is a stream error
@@ -1329,7 +1329,7 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
                     pyre_object::gc_roots::shadow_stack_get(args_slot),
                     kind,
                 )?;
-                pyre_object::gc_roots::pin_root(w_obj);
+                let _ = pyre_object::gc_roots::pin_root(w_obj);
                 let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 let me = cur(slot);
                 unsafe {
@@ -1352,7 +1352,7 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
             )?;
             let arg_base = pyre_object::gc_roots::shadow_stack_len();
             for arg in args {
-                pyre_object::gc_roots::pin_root(arg);
+                let _ = pyre_object::gc_roots::pin_root(arg);
             }
             let rooted_args: Vec<PyObjectRef> = (arg_base
                 ..pyre_object::gc_roots::shadow_stack_len())
@@ -1362,7 +1362,7 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
                 pyre_object::gc_roots::shadow_stack_get(func_slot),
                 &rooted_args,
             )?;
-            pyre_object::gc_roots::pin_root(w_obj);
+            let _ = pyre_object::gc_roots::pin_root(w_obj);
             let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             // The callable remains in place at stack[-1], matching PyPy's
             // `_stack_top`; replace it with the reduction result.
@@ -1518,14 +1518,14 @@ fn packed_list_from_args(
 ) -> Result<PyObjectRef, PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_args);
+    let _ = pyre_object::gc_roots::pin_root(w_args);
     let w_zero = pyre_object::w_int_new(0);
-    pyre_object::gc_roots::pin_root(w_zero);
+    let _ = pyre_object::gc_roots::pin_root(w_zero);
     let w_packed = crate::baseobjspace::getitem(
         pyre_object::gc_roots::shadow_stack_get(base),
         pyre_object::gc_roots::shadow_stack_get(base + 1),
     )?;
-    pyre_object::gc_roots::pin_root(w_packed);
+    let _ = pyre_object::gc_roots::pin_root(w_packed);
     if unsafe {
         !crate::baseobjspace::isinstance_bytes_w(pyre_object::gc_roots::shadow_stack_get(base + 2))
     } {
@@ -1567,7 +1567,7 @@ fn packed_list_from_args(
                 pyre_object::bytesobject::w_bytes_from_bytes(&data[offset..end])
             }
         };
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
         offset = end;
     }
     let items = (item_base..pyre_object::gc_roots::shadow_stack_len())
@@ -1583,8 +1583,8 @@ fn dict_update_from_pairs(w_dict: PyObjectRef, items: PyObjectRef) -> Result<PyO
     // alive while key hashing/equality can call back into Python and collect.
     let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_dict);
-    pyre_object::gc_roots::pin_root(items);
+    let _ = pyre_object::gc_roots::pin_root(w_dict);
+    let items = pyre_object::gc_roots::pin_root(items);
     let n = unsafe {
         pyre_object::listobject::w_list_len(pyre_object::gc_roots::shadow_stack_get(base + 1))
     };
@@ -1640,7 +1640,7 @@ fn read_line_int(slot: usize) -> Result<i64, PyError> {
 fn call_find_class_names(slot: usize, module: &str, name: &str) -> Result<PyObjectRef, PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let w_module = pyre_object::w_str_new(module);
-    pyre_object::gc_roots::pin_root(w_module);
+    let _ = pyre_object::gc_roots::pin_root(w_module);
     let module_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_name = pyre_object::w_str_new(name);
     call_find_class(
@@ -1658,9 +1658,9 @@ fn call_find_class(
     // Resolving the bound `find_class` allocates, which can move the nursery;
     // pin the arguments (and re-read `self`) across the lookup.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_module);
+    let _ = pyre_object::gc_roots::pin_root(w_module);
     let module_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(w_name);
+    let _ = pyre_object::gc_roots::pin_root(w_name);
     let name_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let method = crate::baseobjspace::getattr_str(
         pyre_object::gc_roots::shadow_stack_get(slot),
@@ -1695,9 +1695,9 @@ fn audit_find_class(module: &str, name: &str) -> Result<(), PyError> {
 
 fn audit_find_class_objects(w_module: PyObjectRef, w_name: PyObjectRef) -> Result<(), PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_module);
+    let _ = pyre_object::gc_roots::pin_root(w_module);
     let module_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(w_name);
+    let _ = pyre_object::gc_roots::pin_root(w_name);
     let name_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     if let Ok(sys) = import_module("sys")
         && let Ok(audit) = crate::baseobjspace::getattr_str(sys, "audit")
@@ -1742,7 +1742,7 @@ fn get_extension(slot: usize, code: i64) -> Result<(), PyError> {
     let obj = call_find_class(slot, w_module, w_name)?;
     // `_extension_cache[code] = obj`; pin `obj` across the dict lookups.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let copyreg = import_module("copyreg")?;
     let cache = crate::baseobjspace::getattr_str(copyreg, "_extension_cache")?;
@@ -1772,10 +1772,10 @@ fn decode_string(slot: usize, data: &[u8]) -> Result<PyObjectRef, PyError> {
     }
     let _roots = pyre_object::gc_roots::push_roots();
     let w_bytes = pyre_object::w_bytes_from_bytes(data);
-    pyre_object::gc_roots::pin_root(w_bytes);
+    let _ = pyre_object::gc_roots::pin_root(w_bytes);
     let b = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_encoding = pyre_object::w_str_new(&encoding);
-    pyre_object::gc_roots::pin_root(w_encoding);
+    let _ = pyre_object::gc_roots::pin_root(w_encoding);
     let e = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_errors = pyre_object::w_str_new(&errors);
     call_meth(
@@ -1865,7 +1865,7 @@ fn persistent_load(slot: usize, w_pid: PyObjectRef) -> Result<PyObjectRef, PyErr
     // is not in a GC-walked container; resolving the bound `persistent_load`
     // allocates and can move the nursery, so pin it across the lookup.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_pid);
+    let _ = pyre_object::gc_roots::pin_root(w_pid);
     let pid_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let self_obj = pyre_object::gc_roots::shadow_stack_get(slot);
     // `findattr_result` propagates a descriptor's own error instead of panicking;
@@ -1948,19 +1948,19 @@ fn new_instance_star(
         )));
     }
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_cls);
+    let _ = pyre_object::gc_roots::pin_root(w_cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(w_args);
+    let _ = pyre_object::gc_roots::pin_root(w_args);
     let star_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let kwargs_slot = w_kwargs.map(|kwargs| {
-        pyre_object::gc_roots::pin_root(kwargs);
+        let _ = pyre_object::gc_roots::pin_root(kwargs);
         pyre_object::gc_roots::shadow_stack_len() - 1
     });
     let w_new = crate::baseobjspace::getattr_str(
         pyre_object::gc_roots::shadow_stack_get(cls_slot),
         "__new__",
     )?;
-    pyre_object::gc_roots::pin_root(w_new);
+    let _ = pyre_object::gc_roots::pin_root(w_new);
     let new_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     // interp_pickle.py `load_newobj`: an empty star-argument
@@ -1983,7 +1983,7 @@ fn new_instance_star(
     )?;
     let positional_base = pyre_object::gc_roots::shadow_stack_len();
     for value in unpacked {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
     }
 
     let mut keyword_names = Vec::new();
@@ -1998,11 +1998,11 @@ fn new_instance_star(
     }
     let keyword_name_base = pyre_object::gc_roots::shadow_stack_len();
     for name in keyword_names {
-        pyre_object::gc_roots::pin_root(name);
+        let _ = pyre_object::gc_roots::pin_root(name);
     }
     let keyword_value_base = pyre_object::gc_roots::shadow_stack_len();
     for value in keyword_values {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
     }
 
     let mut call_args = Vec::with_capacity(1 + keyword_name_base.saturating_sub(positional_base));
@@ -2045,9 +2045,9 @@ fn new_instance_star(
 /// `load_build` — apply pickled state to a freshly created instance.
 fn build_instance(w_inst: PyObjectRef, w_state: PyObjectRef) -> Result<(), PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_inst);
+    let _ = pyre_object::gc_roots::pin_root(w_inst);
     let inst_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(w_state);
+    let _ = pyre_object::gc_roots::pin_root(w_state);
     let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     // __setstate__ takes precedence.
@@ -2059,7 +2059,7 @@ fn build_instance(w_inst: PyObjectRef, w_state: PyObjectRef) -> Result<(), PyErr
         // attribute explicitly set to `None` is still called — and reports the
         // ordinary "'NoneType' object is not callable".  Only a missing hook
         // falls through to state restoration.
-        pyre_object::gc_roots::pin_root(setstate);
+        let _ = pyre_object::gc_roots::pin_root(setstate);
         let setstate_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         call_fn(
             pyre_object::gc_roots::shadow_stack_get(setstate_slot),
@@ -2081,9 +2081,9 @@ fn build_instance(w_inst: PyObjectRef, w_state: PyObjectRef) -> Result<(), PyErr
     } else {
         (current_state, pyre_object::w_none())
     };
-    pyre_object::gc_roots::pin_root(w_dict_state);
+    let _ = pyre_object::gc_roots::pin_root(w_dict_state);
     let dict_state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(w_slot_state);
+    let _ = pyre_object::gc_roots::pin_root(w_slot_state);
     let slot_state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     if !unsafe { pyre_object::is_none(pyre_object::gc_roots::shadow_stack_get(dict_state_slot)) } {
@@ -2098,7 +2098,7 @@ fn build_instance(w_inst: PyObjectRef, w_state: PyObjectRef) -> Result<(), PyErr
             pyre_object::gc_roots::shadow_stack_get(inst_slot),
             "__dict__",
         )?;
-        pyre_object::gc_roots::pin_root(w_inst_dict);
+        let _ = pyre_object::gc_roots::pin_root(w_inst_dict);
         let inst_dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let items = unsafe {
             pyre_object::dictmultiobject::w_dict_items(pyre_object::gc_roots::shadow_stack_get(
@@ -2107,9 +2107,9 @@ fn build_instance(w_inst: PyObjectRef, w_state: PyObjectRef) -> Result<(), PyErr
         };
         for (key, value) in items {
             let _item_roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(key);
+            let _ = pyre_object::gc_roots::pin_root(key);
             let key_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            pyre_object::gc_roots::pin_root(value);
+            let _ = pyre_object::gc_roots::pin_root(value);
             let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             // CPython 3.14 Modules/_pickle.c:6837-6843: exact `str`
             // instance-attribute keys pass through the interpreter intern
@@ -2140,9 +2140,9 @@ fn build_instance(w_inst: PyObjectRef, w_state: PyObjectRef) -> Result<(), PyErr
         };
         for (key, value) in items {
             let _item_roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(key);
+            let _ = pyre_object::gc_roots::pin_root(key);
             let key_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            pyre_object::gc_roots::pin_root(value);
+            let _ = pyre_object::gc_roots::pin_root(value);
             let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             if !unsafe { pyre_object::is_str(pyre_object::gc_roots::shadow_stack_get(key_slot)) } {
                 return Err(PyError::type_error(format!(

--- a/pyre/pyre-interpreter/src/module/_queue/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_queue/mod.rs
@@ -101,7 +101,7 @@ fn simplequeue_put(queue: &W_SimpleQueue, item: PyObjectRef) -> PyObjectRef {
     // from the argument, which a move would have left stale.
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(item);
+    let _ = roots.pin_root(item);
     let mut guard = queue_lock(&queue.queue);
     guard.push_back(pyre_object::gc_roots::shadow_stack_get(base));
     drop(guard);

--- a/pyre/pyre-interpreter/src/module/_random/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_random/mod.rs
@@ -196,17 +196,17 @@ impl W_Random {
         let random_type = type_object();
         crate::typedef::check_user_subclass(random_type, cls)?;
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(cls);
-        pyre_object::gc_roots::pin_root(w_anything);
+        let _ = pyre_object::gc_roots::pin_root(cls);
+        let _ = pyre_object::gc_roots::pin_root(w_anything);
         let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 2;
         let seed_slot = cls_slot + 1;
         // `interp_random.py:21` builds the generator before anything can reach
         // it through the wrapper, so each allocation has to hold the previous
         // one down: the twister across the wrapper's allocation, the wrapper
         // across `seed`'s.
-        pyre_object::gc_roots::pin_root(Random::new_instance());
+        let _ = pyre_object::gc_roots::pin_root(Random::new_instance());
         let rnd_slot = seed_slot + 1;
-        pyre_object::gc_roots::pin_root(W_Random::allocate_stable(W_Random::default()));
+        let _ = pyre_object::gc_roots::pin_root(W_Random::allocate_stable(W_Random::default()));
         let obj_slot = rnd_slot + 1;
         let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         crate::typedef::tag_subclass_instance(obj, unsafe {

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -162,11 +162,11 @@ struct SocketWritableBuffer {
 impl SocketWritableBuffer {
     unsafe fn acquire(obj: pyre_object::PyObjectRef) -> Result<Self, crate::PyError> {
         let roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let (data, owner) =
             socket_writebuf(pyre_object::gc_roots::shadow_stack_get(obj_slot))?;
-        pyre_object::gc_roots::pin_root(owner);
+        let _ = pyre_object::gc_roots::pin_root(owner);
         let owner_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let owner = pyre_object::gc_roots::shadow_stack_get(owner_slot);
         let held = crate::builtins::buffer_export_incref(owner);
@@ -2004,9 +2004,9 @@ fn unpack_hostent(he: *mut rffi::Hostent) -> Result<pyre_object::PyObjectRef, cr
         // that follows it and is re-read from its slot afterwards.
         let _roots = pyre_object::gc_roots::push_roots();
         let aliases_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(pyre_object::w_list_new(aliases));
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_list_new(aliases));
         let addrs_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(pyre_object::w_list_new(addrs));
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_list_new(addrs));
         Ok(pyre_object::w_tuple_new(vec![
             pyre_object::w_str_new(&name),
             pyre_object::gc_roots::shadow_stack_get(aliases_slot),
@@ -2700,7 +2700,7 @@ fn windows_if_nameindex() -> Result<pyre_object::PyObjectRef, crate::PyError> {
     // in a plain vector while the next allocation runs.
     let _roots = pyre_object::gc_roots::push_roots();
     let list_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::w_list_new_empty());
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_list_new_empty());
     let outcome = (|| {
         for index in 0..unsafe { (*table).NumEntries } as usize {
             let row = unsafe { &*(*table).Table.as_ptr().add(index) };
@@ -2794,7 +2794,7 @@ fn ioctl_keepalive_w(obj: pyre_object::PyObjectRef) -> Result<[u32; 3], crate::P
     let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
     for &item in &items {
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
     }
     let mut values = [0u32; 3];
     for (index, value) in values.iter_mut().enumerate() {

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -798,7 +798,7 @@ struct RootedObject(usize);
 impl RootedObject {
     fn pin(obj: PyObjectRef) -> Self {
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         Self(slot)
     }
 
@@ -1425,7 +1425,7 @@ fn subx(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
                         "sub: replacement must be bytes-like or callable",
                     ));
                 };
-                pyre_object::gc_roots::pin_root(w_bytes);
+                let w_bytes = pyre_object::gc_roots::pin_root(w_bytes);
                 (
                     unsafe { pyre_object::bytesobject::bytes_like_data(w_bytes) },
                     true,

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -461,7 +461,7 @@ fn allocate_ssl_socket(
         owner,
         server_hostname,
     ] {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
     }
     let first = pyre_object::gc_roots::shadow_stack_len() - SLOT_COUNT;
     for slot in [SOCKET_SLOT, OWNER_SLOT] {
@@ -507,7 +507,7 @@ fn allocate_ssl_session(backend: *mut pyre_native::ssl::NativeSession) -> PyObje
 fn allocate_certificate(der: Vec<u8>) -> PyObjectRef {
     let _ = certificate_methods::type_object();
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_bytes_from_bytes(&der));
+    let _ = pyre_object::gc_roots::pin_root(w_bytes_from_bytes(&der));
     let der_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     W_Certificate::allocate_stable(W_Certificate {
         ob: PyObject {
@@ -546,7 +546,7 @@ mod context_methods {
         backend: *mut pyre_native::ssl::Context,
     ) -> PyObjectRef {
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(cls);
+        let _ = pyre_object::gc_roots::pin_root(cls);
         let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let obj = W_SSLContext::allocate_stable(W_SSLContext {
             ob: PyObject {
@@ -1343,7 +1343,7 @@ mod memory_bio_methods {
             }
             crate::typedef::check_user_subclass(type_object(), cls)?;
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(cls);
+            let _ = pyre_object::gc_roots::pin_root(cls);
             let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let obj = W_MemoryBIO::allocate_stable(W_MemoryBIO {
                 ob: PyObject {
@@ -2483,7 +2483,7 @@ mod cert_store {
             }
             match convert(&*context) {
                 Ok(item) => {
-                    pyre_object::gc_roots::pin_root(item);
+                    let _ = pyre_object::gc_roots::pin_root(item);
                     count += 1;
                 }
                 Err(error) => {
@@ -2547,9 +2547,10 @@ mod cert_store {
                     // the tuple that consumes them roots them itself.
                     let _roots = pyre_object::gc_roots::push_roots();
                     let trust_slot = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(trust.unwrap_or_else(|| w_bool_from(true)));
+                    let _ =
+                        pyre_object::gc_roots::pin_root(trust.unwrap_or_else(|| w_bool_from(true)));
                     let cert_slot = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(w_bytes_from_bytes(
+                    let _ = pyre_object::gc_roots::pin_root(w_bytes_from_bytes(
                         std::slice::from_raw_parts(cert.pbCertEncoded, cert.cbCertEncoded as usize),
                     ));
                     let encoding = encoding_type(cert.dwCertEncodingType);
@@ -2571,10 +2572,9 @@ mod cert_store {
                 // The CRL bytes are live across the encoding value's allocation.
                 let _roots = pyre_object::gc_roots::push_roots();
                 let crl_slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(w_bytes_from_bytes(std::slice::from_raw_parts(
-                    crl.pbCrlEncoded,
-                    crl.cbCrlEncoded as usize,
-                )));
+                let _ = pyre_object::gc_roots::pin_root(w_bytes_from_bytes(
+                    std::slice::from_raw_parts(crl.pbCrlEncoded, crl.cbCrlEncoded as usize),
+                ));
                 let encoding = encoding_type(crl.dwCertEncodingType);
                 Ok(w_tuple_new(vec![
                     pyre_object::gc_roots::shadow_stack_get(crl_slot),

--- a/pyre/pyre-interpreter/src/module/_symtable/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_symtable/mod.rs
@@ -64,7 +64,7 @@ fn append_public_children(table: &SymbolTable, children_slot: usize) {
         }
         let data = table_data(child);
         let data_roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(data);
+        let _ = pyre_object::gc_roots::pin_root(data);
         let data_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         unsafe {
             pyre_object::listobject::w_list_append(
@@ -82,7 +82,7 @@ fn table_data(table: &SymbolTable) -> PyObjectRef {
     let _roots = pyre_object::gc_roots::push_roots();
 
     let symbols = pyre_object::dictmultiobject::w_dict_new();
-    pyre_object::gc_roots::pin_root(symbols);
+    let _ = pyre_object::gc_roots::pin_root(symbols);
     let symbols_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     for (name, symbol) in &table.symbols {
         // CPython stores the resolved scope in the high bits of the public
@@ -94,7 +94,7 @@ fn table_data(table: &SymbolTable) -> PyObjectRef {
         // `symbols_slot`, so evaluating it inline as the third call argument
         // would leave the first argument holding the pre-collection address.
         let value_roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(pyre_object::w_int_new(flags as i64));
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(flags as i64));
         let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         unsafe {
             pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
@@ -107,11 +107,11 @@ fn table_data(table: &SymbolTable) -> PyObjectRef {
     }
 
     let varnames = pyre_object::listobject::w_list_new(Vec::new());
-    pyre_object::gc_roots::pin_root(varnames);
+    let _ = pyre_object::gc_roots::pin_root(varnames);
     let varnames_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     for name in &table.varnames {
         let value_roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(pyre_object::w_str_new(name));
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(name));
         let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         unsafe {
             pyre_object::listobject::w_list_append(
@@ -123,15 +123,15 @@ fn table_data(table: &SymbolTable) -> PyObjectRef {
     }
 
     let children = pyre_object::listobject::w_list_new(Vec::new());
-    pyre_object::gc_roots::pin_root(children);
+    let _ = pyre_object::gc_roots::pin_root(children);
     let children_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     append_public_children(table, children_slot);
 
-    pyre_object::gc_roots::pin_root(pyre_object::w_str_new(&table.name));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(&table.name));
     let name_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(pyre_object::w_int_new(table_type(table) as i64));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(table_type(table) as i64));
     let type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(pyre_object::w_int_new(table.line_number as i64));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(table.line_number as i64));
     let line_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     pyre_object::tupleobject::w_tuple_new(vec![
@@ -155,7 +155,7 @@ fn symtable_data(args: &[PyObjectRef]) -> crate::PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
     for &arg in args {
-        pyre_object::gc_roots::pin_root(arg);
+        let _ = pyre_object::gc_roots::pin_root(arg);
     }
     let w_filename = unsafe {
         let arg = pyre_object::gc_roots::shadow_stack_get(base + 1);
@@ -173,7 +173,7 @@ fn symtable_data(args: &[PyObjectRef]) -> crate::PyResult {
             )));
         }
     };
-    pyre_object::gc_roots::pin_root(w_filename);
+    let _ = pyre_object::gc_roots::pin_root(w_filename);
     let filename_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // The compiler dependency still requires a Rust `str`; retain this only
     // as its internal source path and restore the surrogate-preserving Python

--- a/pyre/pyre-interpreter/src/module/_tokenize/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_tokenize/mod.rs
@@ -110,8 +110,8 @@ fn read_line(self_obj: PyObjectRef) -> Result<String, crate::PyError> {
         (this.readline, this.encoding.clone())
     };
     let _roots = gc_roots::push_roots();
-    gc_roots::pin_root(self_obj);
-    gc_roots::pin_root(readline);
+    let _ = gc_roots::pin_root(self_obj);
+    let _ = gc_roots::pin_root(readline);
     let raw = match crate::builtins::call_and_check(
         gc_roots::shadow_stack_get(gc_roots::shadow_stack_len() - 1),
         &[],
@@ -168,7 +168,7 @@ fn prepare_tokens(self_obj: PyObjectRef) {
 
 fn tokenizer_next(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     let _roots = gc_roots::push_roots();
-    gc_roots::pin_root(self_obj);
+    let _ = gc_roots::pin_root(self_obj);
     let slot = gc_roots::shadow_stack_len() - 1;
     loop {
         let self_obj = gc_roots::shadow_stack_get(slot);
@@ -736,8 +736,8 @@ fn positioned_syntax_error(
         return crate::PyError::syntax_error(message);
     };
     let _roots = gc_roots::push_roots();
-    gc_roots::pin_root(class);
-    gc_roots::pin_root(w_str_new(message));
+    let _ = gc_roots::pin_root(class);
+    let _ = gc_roots::pin_root(w_str_new(message));
     let base = gc_roots::shadow_stack_len() - 2;
     let exc = match crate::builtins::call_and_check(
         gc_roots::shadow_stack_get(base),
@@ -746,7 +746,7 @@ fn positioned_syntax_error(
         Ok(exc) => exc,
         Err(_) => return crate::PyError::syntax_error(message),
     };
-    gc_roots::pin_root(exc);
+    let _ = gc_roots::pin_root(exc);
     let exc_slot = gc_roots::shadow_stack_len() - 1;
     for (name, value) in [("lineno", line as i64), ("offset", offset as i64)] {
         let value = w_int_new(value);
@@ -866,23 +866,23 @@ fn make_token_tuple(
     let line = line.to_owned();
     let _roots = gc_roots::push_roots();
     let base = gc_roots::shadow_stack_len();
-    gc_roots::pin_root(w_int_new(token_type as i64));
-    gc_roots::pin_root(w_str_new(&text));
-    gc_roots::pin_root(w_int_new(start_line as i64));
-    gc_roots::pin_root(w_int_new(start_col as i64));
-    gc_roots::pin_root(w_int_new(end_line as i64));
-    gc_roots::pin_root(w_int_new(end_col as i64));
-    gc_roots::pin_root(w_str_new(&line));
+    let _ = gc_roots::pin_root(w_int_new(token_type as i64));
+    let _ = gc_roots::pin_root(w_str_new(&text));
+    let _ = gc_roots::pin_root(w_int_new(start_line as i64));
+    let _ = gc_roots::pin_root(w_int_new(start_col as i64));
+    let _ = gc_roots::pin_root(w_int_new(end_line as i64));
+    let _ = gc_roots::pin_root(w_int_new(end_col as i64));
+    let _ = gc_roots::pin_root(w_str_new(&line));
     let start = w_tuple_new(vec![
         gc_roots::shadow_stack_get(base + 2),
         gc_roots::shadow_stack_get(base + 3),
     ]);
-    gc_roots::pin_root(start);
+    let _ = gc_roots::pin_root(start);
     let end = w_tuple_new(vec![
         gc_roots::shadow_stack_get(base + 4),
         gc_roots::shadow_stack_get(base + 5),
     ]);
-    gc_roots::pin_root(end);
+    let _ = gc_roots::pin_root(end);
     w_tuple_new(vec![
         gc_roots::shadow_stack_get(base),
         gc_roots::shadow_stack_get(base + 1),

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -6,7 +6,7 @@ use pyre_object::*;
 const VERSION_ATTR: &str = "_filters_version_state";
 
 fn pin_root_slot(value: PyObjectRef) -> usize {
-    pyre_object::gc_roots::pin_root(value);
+    let _ = pyre_object::gc_roots::pin_root(value);
     pyre_object::gc_roots::shadow_stack_len() - 1
 }
 

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -89,7 +89,7 @@ fn field_slot(obj: PyObjectRef, name: &str) -> Option<u32> {
 fn read_attr(obj: PyObjectRef, name: &str) -> PyObjectRef {
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     if let Some(slot) = field_slot(pyre_object::gc_roots::shadow_stack_get(root_base), name) {
         let value = unsafe {
             crate::objspace::std::mapdict::getslotvalue(
@@ -108,7 +108,7 @@ fn read_attr(obj: PyObjectRef, name: &str) -> PyObjectRef {
     if w_dict.is_null() {
         return PY_NULL;
     }
-    pyre_object::gc_roots::pin_root(w_dict);
+    let _ = pyre_object::gc_roots::pin_root(w_dict);
     let value = unsafe {
         pyre_object::w_dict_getitem_str(
             pyre_object::gc_roots::shadow_stack_get(root_base + 1),
@@ -127,8 +127,8 @@ fn read_attr(obj: PyObjectRef, name: &str) -> PyObjectRef {
 fn write_attr(obj: PyObjectRef, name: &str, value: PyObjectRef) {
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
-    pyre_object::gc_roots::pin_root(value);
+    let _ = pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(value);
     if let Some(slot) = field_slot(pyre_object::gc_roots::shadow_stack_get(root_base), name) {
         unsafe {
             crate::objspace::std::mapdict::setslotvalue(
@@ -142,7 +142,7 @@ fn write_attr(obj: PyObjectRef, name: &str, value: PyObjectRef) {
     let w_dict =
         crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(root_base));
     if !w_dict.is_null() {
-        pyre_object::gc_roots::pin_root(w_dict);
+        let _ = pyre_object::gc_roots::pin_root(w_dict);
         unsafe {
             pyre_object::w_dict_setitem_str(
                 pyre_object::gc_roots::shadow_stack_get(root_base + 2),
@@ -489,12 +489,12 @@ pub fn weakref_lifeline_new() -> PyObjectRef {
 fn append_wref_to(self_lifeline: PyObjectRef, w_ref: PyObjectRef) {
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_lifeline);
-    pyre_object::gc_roots::pin_root(w_ref);
+    let _ = pyre_object::gc_roots::pin_root(self_lifeline);
+    let _ = pyre_object::gc_roots::pin_root(w_ref);
     let weak = pyre_object::weakref::w_gc_weakref_box_new_or_strong(
         pyre_object::gc_roots::shadow_stack_get(root_base + 1),
     );
-    pyre_object::gc_roots::pin_root(weak);
+    let _ = pyre_object::gc_roots::pin_root(weak);
     let lifeline = pyre_object::gc_roots::shadow_stack_get(root_base);
     let mut refs = unsafe { pyre_object::weakref::w_weakref_lifeline_other_refs(lifeline) };
     if refs.is_null() {
@@ -734,12 +734,12 @@ pub fn W_Weakref_new(
     let exact_type = std::ptr::eq(actual_type, weakref_type());
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_obj);
-    pyre_object::gc_roots::pin_root(w_callable);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_callable);
     let w_obj_weak = pyre_object::weakref::w_gc_weakref_box_new_or_strong(
         pyre_object::gc_roots::shadow_stack_get(root_base),
     );
-    pyre_object::gc_roots::pin_root(w_obj_weak);
+    let _ = pyre_object::gc_roots::pin_root(w_obj_weak);
     let callable = pyre_object::gc_roots::shadow_stack_get(root_base + 1);
     let callable = if !callable.is_null() && !unsafe { pyre_object::is_none(callable) } {
         callable
@@ -897,7 +897,7 @@ pub fn descr__init__weakref(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError
 pub fn descr_hash(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args[0]);
+    let _ = pyre_object::gc_roots::pin_root(args[0]);
     let current_self = || pyre_object::gc_roots::shadow_stack_get(root_base);
     let cached = weakref_hash(current_self());
     if !cached.is_null() {
@@ -912,7 +912,7 @@ pub fn descr_hash(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     // `hash_w_strict` can run a user-defined `__hash__`, which allocates, so
     // the referent is rooted across the call and `current_self` re-reads the
     // reference afterwards.
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let h = pyre_object::w_int_new(crate::baseobjspace::hash_w_strict(
         pyre_object::gc_roots::shadow_stack_get(obj_slot),
@@ -1046,11 +1046,11 @@ pub fn remove_dead_weakref(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError>
     // primitive exactly as `delitem_if_value_is(d, key, wr)` does upstream.
     let _roots = pyre_object::gc_roots::push_roots();
     let backing_root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(backing);
+    let _ = pyre_object::gc_roots::pin_root(backing);
     let key_root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(key);
+    let _ = pyre_object::gc_roots::pin_root(key);
     let stored_root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(stored);
+    let stored = pyre_object::gc_roots::pin_root(stored);
     let result = crate::call::call_function_impl_result(stored, &[])?;
     if !unsafe { pyre_object::is_none(result) } {
         return Ok(pyre_object::w_none());
@@ -1127,8 +1127,7 @@ pub fn finalize_weakrefs(w_obj: PyObjectRef) {
     }
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_obj);
-
+    let w_obj = pyre_object::gc_roots::pin_root(w_obj);
     // RPython's local `items` list is GC-transformed together with every
     // element. A Rust Vec only holds copied raw pointers, so retain the same
     // collection in shadow-stack slots while reads below can allocate.
@@ -1136,7 +1135,7 @@ pub fn finalize_weakrefs(w_obj: PyObjectRef) {
     let others = unsafe { pyre_object::weakref::w_weakref_lifeline_other_refs(w_obj) };
     if !others.is_null() {
         let others_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(others);
+        let _ = pyre_object::gc_roots::pin_root(others);
         let length = unsafe {
             pyre_object::w_list_len(pyre_object::gc_roots::shadow_stack_get(others_slot))
         };
@@ -1152,7 +1151,7 @@ pub fn finalize_weakrefs(w_obj: PyObjectRef) {
             let w_ref = unsafe { pyre_object::weakref::w_gc_weakref_box_or_strong_deref(weak) };
             if !w_ref.is_null() {
                 let slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(w_ref);
+                let _ = pyre_object::gc_roots::pin_root(w_ref);
                 ref_slots.push(slot);
             }
         }
@@ -1169,7 +1168,7 @@ pub fn finalize_weakrefs(w_obj: PyObjectRef) {
         }
         let _call_roots = pyre_object::gc_roots::push_roots();
         let call_base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_callable);
+        let _ = pyre_object::gc_roots::pin_root(w_callable);
         let current_ref = || pyre_object::gc_roots::shadow_stack_get(slot);
         let current_callable = || pyre_object::gc_roots::shadow_stack_get(call_base);
         if let Err(error) =

--- a/pyre/pyre-interpreter/src/module/_winapi/host.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/host.rs
@@ -779,7 +779,7 @@ pub fn VirtualQuerySize(address: PyObjectRef) -> Result<PyObjectRef, crate::PyEr
 pub fn _mimetypes_read_windows_registry(on_type_read: PyObjectRef) -> Result<(), crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let callback_slot = roots.base();
-    roots.pin_root(on_type_read);
+    let _ = roots.pin_root(on_type_read);
     host_winapi::read_windows_mimetype_registry_in_batches(
         |entries: &mut Vec<(String, String)>| -> Result<(), crate::PyError> {
             // The host refills the batch it hands over, so it has to be

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -192,9 +192,9 @@ fn array_extend_iterable(
     // allocations, so neither address goes stale; what the scope buys is that
     // an unmarked block is not swept out from under the loop.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(obj);
+    let obj = pyre_object::gc_roots::pin_root(obj);
     let w_iter = crate::baseobjspace::iter(w_iterable)?;
-    pyre_object::gc_roots::pin_root(w_iter);
+    let w_iter = pyre_object::gc_roots::pin_root(w_iter);
     loop {
         match crate::baseobjspace::next(w_iter) {
             Ok(w_item) => array_append(obj, w_item)?,
@@ -302,7 +302,7 @@ fn array_descr_new(args: &[PyObjectRef]) -> PyResult {
     // Nothing refers to the fresh array yet and every initializer below runs
     // Python.  An array is stable, so the local stays a valid address; the pin
     // is what stops a major cycle sweeping it as unreachable.
-    pyre_object::gc_roots::pin_root(obj);
+    let obj = pyre_object::gc_roots::pin_root(obj);
     // Subclass: retag the fresh array with the requested class.
     if !cls.is_null() && unsafe { pyre_object::is_type(cls) } && !std::ptr::eq(cls, canonical) {
         crate::typedef::tag_subclass_instance(obj, cls);

--- a/pyre/pyre-interpreter/src/module/errno/mod.rs
+++ b/pyre/pyre-interpreter/src/module/errno/mod.rs
@@ -32,7 +32,7 @@ crate::py_module! {
         // stays valid across the same run.
         let roots = pyre_object::gc_roots::push_roots();
         let errorcode_slot = roots.base();
-        roots.pin_root(pyre_object::w_dict_new());
+        let _ = roots.pin_root(pyre_object::w_dict_new());
         crate::module_ns_store(ns, "errorcode", roots.get(errorcode_slot));
         let mut store = |name: &str, value: i64| {
             crate::module_ns_store(ns, name, pyre_object::w_int_new(value));

--- a/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
+++ b/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
@@ -302,7 +302,7 @@ fn faulthandler_get_fileno_and_file(
     // them so the caller receives the relocated pointer, not a stale one.
     // `pin_root` normalizes a forwarding stub into the slot, not into the
     // caller's copy, so read the pinned value back before using it.
-    pyre_object::gc_roots::pin_root(resolved);
+    let _ = pyre_object::gc_roots::pin_root(resolved);
     let file_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let resolved = pyre_object::gc_roots::shadow_stack_get(file_slot);
     let method = crate::baseobjspace::getattr_str(resolved, "fileno")?;
@@ -360,7 +360,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     // owner store below, so keep it rooted across the install.
                     let _roots = pyre_object::gc_roots::push_roots();
                     let file_slot = (!w_file.is_null()).then(|| {
-                        pyre_object::gc_roots::pin_root(w_file);
+                        let _ = pyre_object::gc_roots::pin_root(w_file);
                         pyre_object::gc_roots::shadow_stack_len() - 1
                     });
                     // `pypy_faulthandler_enable(fileno, all_threads)` takes the
@@ -545,7 +545,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     // owner store below, so keep it rooted across the install.
                     let _roots = pyre_object::gc_roots::push_roots();
                     let file_slot = (!w_file.is_null()).then(|| {
-                        pyre_object::gc_roots::pin_root(w_file);
+                        let _ = pyre_object::gc_roots::pin_root(w_file);
                         pyre_object::gc_roots::shadow_stack_len() - 1
                     });
                     let _state = lock_faulthandler_state();

--- a/pyre/pyre-interpreter/src/module/gc/hook.rs
+++ b/pyre/pyre-interpreter/src/module/gc/hook.rs
@@ -55,7 +55,7 @@ impl GcMinorHookAction {
         self.reset();
 
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(unsafe { (*hooks).w_on_gc_minor });
+        let _ = pyre_object::gc_roots::pin_root(unsafe { (*hooks).w_on_gc_minor });
         let callable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let stats = new_minor_stats(
             count,
@@ -65,7 +65,7 @@ impl GcMinorHookAction {
             total_memory_used,
             pinned_objects,
         )?;
-        pyre_object::gc_roots::pin_root(stats);
+        let _ = pyre_object::gc_roots::pin_root(stats);
         let stats_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         crate::call::call_function_impl_result(
             pyre_object::gc_roots::shadow_stack_get(callable_slot),
@@ -146,7 +146,7 @@ impl GcCollectStepHookAction {
         self.reset();
 
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(unsafe { (*hooks).w_on_gc_collect_step });
+        let _ = pyre_object::gc_roots::pin_root(unsafe { (*hooks).w_on_gc_collect_step });
         let callable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let stats = new_collect_step_stats_full(
             count,
@@ -157,7 +157,7 @@ impl GcCollectStepHookAction {
             newstate,
             super::is_done_states(oldstate, newstate),
         )?;
-        pyre_object::gc_roots::pin_root(stats);
+        let _ = pyre_object::gc_roots::pin_root(stats);
         let stats_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         crate::call::call_function_impl_result(
             pyre_object::gc_roots::shadow_stack_get(callable_slot),
@@ -237,7 +237,7 @@ impl GcCollectHookAction {
         self.count = 0;
 
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(unsafe { (*hooks).w_on_gc_collect });
+        let _ = pyre_object::gc_roots::pin_root(unsafe { (*hooks).w_on_gc_collect });
         let callable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let stats = new_collect_stats(
             count,
@@ -249,7 +249,7 @@ impl GcCollectHookAction {
             rawmalloc_bytes_after,
             pinned_objects,
         )?;
-        pyre_object::gc_roots::pin_root(stats);
+        let _ = pyre_object::gc_roots::pin_root(stats);
         let stats_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         crate::call::call_function_impl_result(
             pyre_object::gc_roots::shadow_stack_get(callable_slot),
@@ -348,25 +348,25 @@ impl W_AppLevelHooks {
         // hook.py:100-107 — fetch all three first, so a missing later
         // attribute leaves the existing hook set untouched.
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_obj);
+        let _ = pyre_object::gc_roots::pin_root(w_obj);
         let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_a = crate::baseobjspace::getattr_str(
             pyre_object::gc_roots::shadow_stack_get(obj_slot),
             "on_gc_minor",
         )?;
-        pyre_object::gc_roots::pin_root(w_a);
+        let _ = pyre_object::gc_roots::pin_root(w_a);
         let a_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_b = crate::baseobjspace::getattr_str(
             pyre_object::gc_roots::shadow_stack_get(obj_slot),
             "on_gc_collect_step",
         )?;
-        pyre_object::gc_roots::pin_root(w_b);
+        let _ = pyre_object::gc_roots::pin_root(w_b);
         let b_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_c = crate::baseobjspace::getattr_str(
             pyre_object::gc_roots::shadow_stack_get(obj_slot),
             "on_gc_collect",
         )?;
-        pyre_object::gc_roots::pin_root(w_c);
+        let _ = pyre_object::gc_roots::pin_root(w_c);
         let c_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         self.set_on_gc_minor(pyre_object::gc_roots::shadow_stack_get(a_slot));
         self.set_on_gc_collect_step(pyre_object::gc_roots::shadow_stack_get(b_slot));

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -28,11 +28,12 @@ static GC_DEBUG: AtomicI64 = AtomicI64::new(0);
 /// has no generational allocation counters to drive, so the values are only
 /// remembered: `set_threshold` stores what it was given and `get_threshold`
 /// hands the same tuple back, which is the part of the pair's behaviour a
-/// caller can observe.  The third threshold is not among them — an incremental
-/// collector has no third generation to size, so it reads back as 0 whatever
-/// it was set to.  The initial values are the ones a fresh interpreter starts
-/// with.
-static GC_THRESHOLD: [AtomicI64; 2] = [AtomicI64::new(2000), AtomicI64::new(10)];
+/// caller can observe.  All three are kept, including the third, whose round
+/// trip 3.14 preserves even though its own incremental collector sizes no
+/// third generation.  The initial values are the ones a fresh interpreter
+/// starts with.
+static GC_THRESHOLD: [AtomicI64; 3] =
+    [AtomicI64::new(2000), AtomicI64::new(10), AtomicI64::new(10)];
 
 const STATE_SCANNING: u8 = 0;
 const STATE_MARKING: u8 = 1;
@@ -1537,8 +1538,7 @@ crate::py_module! {
             }
             // Read every value before storing any, so a non-integer in the
             // tail leaves the previous thresholds untouched.  An omitted
-            // trailing value keeps the threshold it already had, and a third
-            // value is validated but not kept.
+            // trailing value keeps the threshold it already had.
             let mut given = Vec::with_capacity(positional.len());
             for &w_value in positional {
                 // The index protocol, so an object carrying only `__int__` is
@@ -1554,7 +1554,6 @@ crate::py_module! {
             GC_THRESHOLD
                 .iter()
                 .map(|slot| w_int_new(slot.load(Ordering::Relaxed)))
-                .chain(std::iter::once(w_int_new(0)))
                 .collect(),
         )),
         "get_count"     / 0 = |_| Ok(w_tuple_new(vec![

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -573,10 +573,10 @@ fn initialize_stats(
 ) -> Result<PyObjectRef, crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let stats_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_instance_new(stats_type));
+    let _ = pyre_object::gc_roots::pin_root(w_instance_new(stats_type));
     for (name, value) in fields {
         let value_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(value.materialize());
+        let _ = pyre_object::gc_roots::pin_root(value.materialize());
         let stored = unsafe {
             crate::objspace::std::mapdict::instance_node_setdictvalue(
                 pyre_object::gc_roots::shadow_stack_get(stats_slot),
@@ -661,7 +661,7 @@ fn new_collect_stats(
 }
 
 fn pin_object(object: majit_ir::GcRef) {
-    pyre_object::gc_roots::pin_root(object.0 as PyObjectRef);
+    let _ = pyre_object::gc_roots::pin_root(object.0 as PyObjectRef);
 }
 
 /// `[3.14-spec]` PyPy's `referents.py:115-122` exposes every app-level
@@ -799,7 +799,7 @@ fn wrap_raw_nodes(first: usize, last: usize) -> usize {
         } else {
             gcref::wrap_rooted(slot)
         };
-        pyre_object::gc_roots::pin_root(wrapped);
+        let _ = pyre_object::gc_roots::pin_root(wrapped);
     }
     result_first
 }
@@ -815,7 +815,7 @@ fn wrap_raw_nodes(first: usize, last: usize) -> usize {
 /// address valid.
 fn list_from_root_slots(slots: impl IntoIterator<Item = usize>) -> PyObjectRef {
     let list_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_list_new_empty());
+    let _ = pyre_object::gc_roots::pin_root(w_list_new_empty());
     for slot in slots {
         unsafe {
             w_list_append(
@@ -854,7 +854,7 @@ fn enable_finalizers(action: &mut crate::executioncontext::UserDelAction) {
         // GC-visible list as it progresses, interp_gc.py:80-84).
         let _roots = pyre_object::gc_roots::push_roots();
         for &obj in pending.iter() {
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
         }
         let root_end = pyre_object::gc_roots::shadow_stack_len();
         let root_base = root_end - pending.len();
@@ -930,10 +930,10 @@ fn gc_stats_attr_string(self_slot: usize, name: &'static str) -> Result<String, 
 fn gc_stats_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let self_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args[0]);
+    let _ = pyre_object::gc_roots::pin_root(args[0]);
     let raw =
         crate::baseobjspace::getattr_str(pyre_object::gc_roots::shadow_stack_get(self_slot), "_s")?;
-    pyre_object::gc_roots::pin_root(raw);
+    let _ = pyre_object::gc_roots::pin_root(raw);
     let raw_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let raw = stats::W_GcStats::from_obj(pyre_object::gc_roots::shadow_stack_get(raw_slot))
         .ok_or_else(|| crate::PyError::type_error("GcStats._s is not a native GcStats"))?;
@@ -962,7 +962,7 @@ fn gc_stats_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         pyre_object::gc_roots::shadow_stack_get(self_slot),
         "total_gc_time",
     )?;
-    pyre_object::gc_roots::pin_root(total_gc_time_obj);
+    let _ = pyre_object::gc_roots::pin_root(total_gc_time_obj);
     let total_gc_time_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let total_gc_time =
         crate::baseobjspace::float_w(pyre_object::gc_roots::shadow_stack_get(total_gc_time_slot))?
@@ -1014,9 +1014,9 @@ fn gc_stats_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 fn populate_public_gc_stats(obj: PyObjectRef, raw: PyObjectRef) -> Result<(), crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     let raw_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(raw);
+    let _ = pyre_object::gc_roots::pin_root(raw);
     let raw = stats::W_GcStats::from_obj(pyre_object::gc_roots::shadow_stack_get(raw_slot))
         .ok_or_else(|| crate::PyError::type_error("GcStats() requires a native GcStats"))?;
     let memory_pressure_value = if raw.total_memory_pressure == -1 {
@@ -1054,7 +1054,7 @@ fn populate_public_gc_stats(obj: PyObjectRef, raw: PyObjectRef) -> Result<(), cr
     )?;
     for (name, value) in formatted {
         let text = w_str_new(&format_gc_stat(value));
-        pyre_object::gc_roots::pin_root(text);
+        let _ = pyre_object::gc_roots::pin_root(text);
         let text_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         crate::baseobjspace::setattr_str(
             pyre_object::gc_roots::shadow_stack_get(obj_slot),
@@ -1066,7 +1066,7 @@ fn populate_public_gc_stats(obj: PyObjectRef, raw: PyObjectRef) -> Result<(), cr
     // receiver first, so an inline `w_int_new` here would allocate — and
     // possibly collect — after the argument already held a raw address.
     let time_value = w_int_new(total_gc_time);
-    pyre_object::gc_roots::pin_root(time_value);
+    let _ = pyre_object::gc_roots::pin_root(time_value);
     let time_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     crate::baseobjspace::setattr_str(
         pyre_object::gc_roots::shadow_stack_get(obj_slot),
@@ -1080,11 +1080,11 @@ fn new_public_gc_stats(memory_pressure: bool) -> Result<PyObjectRef, crate::PyEr
     let _roots = pyre_object::gc_roots::push_roots();
     let raw = stats::new(memory_pressure);
     let raw_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(raw);
+    let _ = pyre_object::gc_roots::pin_root(raw);
     let public_type = gc_stats_public_type();
     let obj = w_instance_new(public_type);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let _ = pyre_object::gc_roots::pin_root(obj);
     populate_public_gc_stats(
         pyre_object::gc_roots::shadow_stack_get(obj_slot),
         pyre_object::gc_roots::shadow_stack_get(raw_slot),
@@ -1184,9 +1184,9 @@ fn write_typeids_sidecar(
 ) -> Result<(), crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(crate::gateway::fsdecode_os_str(path.as_os_str()));
+    let _ = pyre_object::gc_roots::pin_root(crate::gateway::fsdecode_os_str(path.as_os_str()));
     let mode_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_str_new(match payload {
+    let _ = pyre_object::gc_roots::pin_root(w_str_new(match payload {
         TypeidsPayload::Binary(_) => "wb",
         TypeidsPayload::Text(_) => "w",
     }));
@@ -1195,11 +1195,11 @@ fn write_typeids_sidecar(
         pyre_object::gc_roots::shadow_stack_get(mode_slot),
     ])?;
     let opened_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(opened);
+    let _ = pyre_object::gc_roots::pin_root(opened);
     // Materialize the payload only now: `builtin_open` allocates, so a value
     // boxed before it would have to be rooted across the open for nothing.
     let data_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(match payload {
+    let _ = pyre_object::gc_roots::pin_root(match payload {
         TypeidsPayload::Binary(bytes) => w_bytes_from_bytes(bytes),
         TypeidsPayload::Text(text) => w_str_new(text),
     });
@@ -1221,7 +1221,7 @@ fn write_typeids_sidecar(
 fn dump_rpy_heap_public(file: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let file_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(file);
+    let _ = pyre_object::gc_roots::pin_root(file);
     // Read the slot at every use instead of caching it in a local: the
     // collector forwards the shadow-stack entry, not the Rust binding, and
     // `w_str_new`, `builtin_open`, `getattr_str`, and `gc_call_method` below
@@ -1233,12 +1233,12 @@ fn dump_rpy_heap_public(file: PyObjectRef) -> Result<PyObjectRef, crate::PyError
         // dump, closes it, then materializes typeids.txt/.lst if absent.
         let path = crate::gateway::fspath_buf(file())?;
         let mode_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_str_new("wb"));
+        let _ = pyre_object::gc_roots::pin_root(w_str_new("wb"));
         let opened = crate::builtins::builtin_open(&[
             file(),
             pyre_object::gc_roots::shadow_stack_get(mode_slot),
         ])?;
-        pyre_object::gc_roots::pin_root(opened);
+        let _ = pyre_object::gc_roots::pin_root(opened);
         let opened_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let fileno = gc_call_method(
             pyre_object::gc_roots::shadow_stack_get(opened_slot),
@@ -1358,7 +1358,7 @@ crate::py_module! {
             // no generations to select between.
             let _generation_root = pyre_object::gc_roots::push_roots();
             let generation_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(generation);
+            let _ = pyre_object::gc_roots::pin_root(generation);
             crate::module::sys::vm::audit("gc.get_objects", &[w_int_new(-1)])?;
             let generation = pyre_object::gc_roots::shadow_stack_get(generation_slot);
             if !unsafe { is_none(generation) } {
@@ -1506,7 +1506,7 @@ crate::py_module! {
         "get_rpy_referents" / 1 = |args| {
             let _roots = pyre_object::gc_roots::push_roots();
             let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(args[0]);
+            let _ = pyre_object::gc_roots::pin_root(args[0]);
             let raw = gcref::unwrap(pyre_object::gc_roots::shadow_stack_get(obj_slot));
             let first = pyre_object::gc_roots::shadow_stack_len();
             if !majit_gc::get_rpy_referents(raw, pin_object) {
@@ -1587,7 +1587,7 @@ crate::py_module! {
             // internal storage.
             let _roots = pyre_object::gc_roots::push_roots();
             let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(args[0]);
+            let _ = pyre_object::gc_roots::pin_root(args[0]);
             let raw = gcref::unwrap(pyre_object::gc_roots::shadow_stack_get(obj_slot));
             let size = majit_gc::get_rpy_memory_usage(raw).ok_or_else(|| {
                     crate::PyError::not_implemented("operation not implemented by this GC")
@@ -1599,7 +1599,7 @@ crate::py_module! {
             // type-info group (index zero is the upstream dummy member).
             let _roots = pyre_object::gc_roots::push_roots();
             let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(args[0]);
+            let _ = pyre_object::gc_roots::pin_root(args[0]);
             let raw = gcref::unwrap(pyre_object::gc_roots::shadow_stack_get(obj_slot));
             let index = majit_gc::get_rpy_type_index(raw).ok_or_else(|| {
                     crate::PyError::not_implemented("operation not implemented by this GC")
@@ -1623,7 +1623,7 @@ crate::py_module! {
             let _roots = pyre_object::gc_roots::push_roots();
             let first = pyre_object::gc_roots::shadow_stack_len();
             for value in list {
-                pyre_object::gc_roots::pin_root(w_int_new(value as i64));
+                let _ = pyre_object::gc_roots::pin_root(w_int_new(value as i64));
             }
             Ok(list_from_roots(first))
         },

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -1626,7 +1626,9 @@ crate::py_module! {
             }
             Ok(list_from_roots(first))
         },
-        "is_finalized"  / 1 = |_| Ok(w_bool_from(false)),
+        "is_finalized"  / 1 = |args| Ok(w_bool_from(
+            majit_gc::gc_finalizer_has_run(args[0] as usize),
+        )),
         // CPython 3.14 `gc.freeze()` moves the surviving objects into a
         // permanent generation that later collections skip; it is a pre-fork
         // hint, not a semantic guarantee. The collector has no permanent

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -674,7 +674,7 @@ fn pin_object(object: majit_ir::GcRef) {
 fn pin_cpython_tracked_object(object: majit_ir::GcRef) {
     let w_obj = object.0 as PyObjectRef;
     if crate::typedef::cpython_object_is_gc(w_obj) {
-        pyre_object::gc_roots::pin_root(w_obj);
+        let _ = pyre_object::gc_roots::pin_root(w_obj);
     }
 }
 
@@ -705,7 +705,7 @@ fn pin_unboxed_container_referents(source_slot: usize) {
             for index in 0..len {
                 let list = pyre_object::gc_roots::shadow_stack_get(source_slot);
                 if let Some(item) = listobject::w_list_getitem(list, index as i64) {
-                    pyre_object::gc_roots::pin_root(item);
+                    let _ = pyre_object::gc_roots::pin_root(item);
                 }
             }
         } else if std::ptr::eq((*w_obj).ob_type, &DICT_TYPE) {
@@ -722,7 +722,7 @@ fn pin_unboxed_container_referents(source_slot: usize) {
                 if let Some((key, _)) = dictmultiobject::w_dict_nth_item(dict, index) {
                     // The typed strategy's GC walker already reported the
                     // boxed value; only its native i64/Vec<u8> key was absent.
-                    pyre_object::gc_roots::pin_root(key);
+                    let _ = pyre_object::gc_roots::pin_root(key);
                 }
             }
         } else if is_specialised_tuple_ii(w_obj) || is_specialised_tuple_ff(w_obj) {
@@ -735,7 +735,7 @@ fn pin_unboxed_container_referents(source_slot: usize) {
             for index in 0..2 {
                 let tuple = pyre_object::gc_roots::shadow_stack_get(source_slot);
                 if let Some(item) = tupleobject::w_tuple_getitem(tuple, index) {
-                    pyre_object::gc_roots::pin_root(item);
+                    let _ = pyre_object::gc_roots::pin_root(item);
                 }
             }
         }
@@ -775,7 +775,7 @@ fn remove_root_slot_preserving_tail(slot: usize) {
 /// safely widen to.
 fn pin_referents(w_obj: PyObjectRef) {
     let source_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let source = pyre_object::gc_roots::shadow_stack_get(source_slot);
     majit_gc::get_referents(majit_ir::GcRef(source as usize), pin_object);
     pin_unboxed_container_referents(source_slot);

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -590,7 +590,7 @@ fn frozen_code(entry: &FrozenModule) -> Result<pyre_object::PyObjectRef, crate::
         // `frozen_cache_store` marshals `w_code`, which can allocate and collect;
         // keep the freshly boxed code reachable across that call.
         let _root = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_code);
+        let w_code = pyre_object::gc_roots::pin_root(w_code);
         frozen_cache_store(key, &source, w_code);
     }
     Ok(w_code)
@@ -728,7 +728,7 @@ fn frozen_data(entry: &FrozenModule) -> Result<pyre_object::PyObjectRef, crate::
     let w_bytes = pyre_object::bytesobject::w_bytes_from_bytes(&bytes);
     let _roots = pyre_object::gc_roots::push_roots();
     let bytes_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_bytes);
+    let _ = pyre_object::gc_roots::pin_root(w_bytes);
     let mv_type = crate::typedef::gettypeobject(&pyre_object::memoryview::MEMORYVIEW_TYPE);
     crate::module::_pickle::call_fn(
         mv_type,
@@ -833,11 +833,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let code = frozen_code(entry)?;
                 let _roots = pyre_object::gc_roots::push_roots();
                 let code_slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(code);
+                let _ = pyre_object::gc_roots::pin_root(code);
                 let ec = crate::call::getexecutioncontext();
                 let w_globals = unsafe { &*ec }.fresh_module_globals();
                 let globals_slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(w_globals);
+                let _ = pyre_object::gc_roots::pin_root(w_globals);
                 // The name string is allocated before the store so the mapping
                 // it writes into is read after that allocation, not before it.
                 let w_name = pyre_object::w_str_new(&name);
@@ -876,7 +876,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     };
                 }
                 let module_slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(pyre_object::w_module_new_aliasing_dict(
+                let _ = pyre_object::gc_roots::pin_root(pyre_object::w_module_new_aliasing_dict(
                     &name,
                     pyre_object::gc_roots::shadow_stack_get(globals_slot),
                 ));
@@ -937,13 +937,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             };
             let _roots = pyre_object::gc_roots::push_roots();
             let data_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(if withdata {
+            let _ = pyre_object::gc_roots::pin_root(if withdata {
                 frozen_data(entry)?
             } else {
                 pyre_object::w_none()
             });
             let origname_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(
+            let _ = pyre_object::gc_roots::pin_root(
                 entry
                     .origname
                     .map(pyre_object::w_str_new)

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -161,7 +161,7 @@ impl WriterRefs {
         let index = self.entries.len() as u32;
         let identity = pyre_object::gc_hook::gc_identity_hash(obj as usize);
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         self.entries.push(WriterRefEntry { slot, incomplete });
         self.by_identity.entry(identity).or_default().push(index);
         Ok(index)
@@ -493,7 +493,7 @@ struct Rooted(usize);
 impl Rooted {
     fn new(obj: PyObjectRef) -> Self {
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         Self(slot)
     }
 
@@ -539,13 +539,13 @@ impl FileReader {
         // Build and root the argument before reloading the file. Integer
         // construction may collect, so neither raw pointer crosses it.
         let count_slot = roots.base();
-        roots.pin_root(w_int_new(n as i64));
+        let _ = roots.pin_root(w_int_new(n as i64));
         let result = match call_method(self.file.get(), "read", &[roots.get(count_slot)]) {
             Ok(result) => result,
             Err(error) => return self.python_error(error),
         };
         let result_slot = count_slot + 1;
-        roots.pin_root(result);
+        let _ = roots.pin_root(result);
         let bytes = match bytes_like(roots.get(result_slot), "load") {
             Ok(bytes) => bytes,
             Err(error) => return self.python_error(error),
@@ -566,7 +566,7 @@ impl FileReader {
     fn read_with_readinto(&mut self, n: usize) -> Result<(), wire::MarshalError> {
         let roots = pyre_object::gc_roots::push_roots();
         let buffer_slot = roots.base();
-        roots.pin_root(bytearrayobject::w_bytearray_new(n));
+        let _ = roots.pin_root(bytearrayobject::w_bytearray_new(n));
         let count = match call_method(self.file.get(), "readinto", &[roots.get(buffer_slot)]) {
             Ok(count) => count,
             // AttributeError from inside `readinto` is an application error,
@@ -1019,7 +1019,7 @@ fn marshal_to_bytes(
         reject_code(value)?;
     }
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(value);
+    let value = pyre_object::gc_roots::pin_root(value);
     let mut out = Vec::new();
     let mut refs = (version >= 3).then(WriterRefs::new);
     write_object(&mut out, value, &mut refs, version, MAX_DEPTH)?;

--- a/pyre/pyre-interpreter/src/module/math/interp_math.rs
+++ b/pyre/pyre-interpreter/src/module/math/interp_math.rs
@@ -695,7 +695,7 @@ pub fn dist(args: &[PyObjectRef]) -> PyResult {
         let _roots = pyre_object::gc_roots::push_roots();
         let items_base = pyre_object::gc_roots::shadow_stack_len();
         for &item in &items {
-            pyre_object::gc_roots::pin_root(item);
+            let _ = pyre_object::gc_roots::pin_root(item);
         }
         (0..items.len())
             .map(|index| {
@@ -1456,10 +1456,10 @@ pub fn fsum(args: &[PyObjectRef]) -> PyResult {
     // consumed.
     let _roots = pyre_object::gc_roots::push_roots();
     let iterable_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args[0]);
+    let _ = pyre_object::gc_roots::pin_root(args[0]);
     let w_iter = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?;
     let iter_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_iter);
+    let _ = pyre_object::gc_roots::pin_root(w_iter);
 
     let mut inf_sum = 0.0;
     let mut special_sum = 0.0;
@@ -1477,7 +1477,7 @@ pub fn fsum(args: &[PyObjectRef]) -> PyResult {
         let original = {
             let _value_root = pyre_object::gc_roots::push_roots();
             let value_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(w_value);
+            let _ = pyre_object::gc_roots::pin_root(w_value);
             try_get_double(pyre_object::gc_roots::shadow_stack_get(value_slot))?
         };
         let mut value = original;
@@ -1602,11 +1602,11 @@ pub fn prod(args: &[PyObjectRef]) -> PyResult {
     }
     let _roots = pyre_object::gc_roots::push_roots();
     let acc_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(start);
+    let _ = pyre_object::gc_roots::pin_root(start);
     let items = crate::builtins::collect_iterable(positional[0])?;
     let items_base = pyre_object::gc_roots::shadow_stack_len();
     for &item in &items {
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
     }
     // Multiplication can call `__mul__`; reload both operands after every
     // collection and keep the running product in its rooted slot.
@@ -1636,7 +1636,7 @@ pub fn sumprod(args: &[PyObjectRef]) -> PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let p_base = pyre_object::gc_roots::shadow_stack_len();
     for &item in &p {
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
     }
     let q = crate::builtins::collect_iterable(args[1])?;
     // `mul` and `add` dispatch to the operands' `__mul__` / `__add__`, so a
@@ -1645,7 +1645,7 @@ pub fn sumprod(args: &[PyObjectRef]) -> PyResult {
     // walker updates, so publish them and read each operand back per turn.
     let q_base = pyre_object::gc_roots::shadow_stack_len();
     for &item in &q {
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
     }
     if p.len() != q.len() {
         return Err(crate::PyError::value_error(
@@ -1656,7 +1656,7 @@ pub fn sumprod(args: &[PyObjectRef]) -> PyResult {
     // Python `total = 0; total += p_i * q_i` recipe: int stays int, and a
     // Decimal/Fraction/float product widens the running total on first add.
     let acc_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_int_new(0));
+    let _ = pyre_object::gc_roots::pin_root(w_int_new(0));
     for index in 0..p.len() {
         let prod = crate::baseobjspace::mul(
             pyre_object::gc_roots::shadow_stack_get(p_base + index),
@@ -1666,7 +1666,7 @@ pub fn sumprod(args: &[PyObjectRef]) -> PyResult {
         // that call, released again each turn so the bracket stays fixed-size.
         let iteration_roots = pyre_object::gc_roots::push_roots();
         let prod_slot = pyre_object::gc_roots::shadow_stack_len();
-        iteration_roots.pin_root(prod);
+        let _ = iteration_roots.pin_root(prod);
         let total = crate::baseobjspace::add(
             pyre_object::gc_roots::shadow_stack_get(acc_slot),
             pyre_object::gc_roots::shadow_stack_get(prod_slot),

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -1615,7 +1615,7 @@ fn mmap_new_object(
 ) -> pyre_object::PyObjectRef {
     let backend = Box::into_raw(Box::new(backend));
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let obj = W_MMap::allocate_stable(W_MMap {
         ob: pyre_object::PyObject {

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -545,17 +545,17 @@ fn sched_param_seq_type() -> PyObjectRef {
     *T.get_or_init(|| {
         let _roots = pyre_object::gc_roots::push_roots();
         let ty = crate::_structseq::make_struct_seq("posix.sched_param", &["sched_priority"]);
-        pyre_object::gc_roots::pin_root(ty);
+        let _ = pyre_object::gc_roots::pin_root(ty);
         let ty_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
         let new_descr = crate::typedef::make_new_descr_with_signature(
             crate::_structseq::structseq_descr_new,
             crate::gateway::Signature::new(vec!["cls", "sched_priority"], None, None, 0, 1),
         );
-        pyre_object::gc_roots::pin_root(new_descr);
+        let _ = pyre_object::gc_roots::pin_root(new_descr);
         let new_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let reduce = crate::make_builtin_function_with_arity("__reduce__", sched_param_reduce, 1);
-        pyre_object::gc_roots::pin_root(reduce);
+        let _ = pyre_object::gc_roots::pin_root(reduce);
         let reduce_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
         unsafe {
@@ -607,10 +607,10 @@ fn sched_param_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     // it is stored.
     let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(cls);
-    pyre_object::gc_roots::pin_root(priority);
+    let _ = pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(priority);
     let inner = pyre_object::w_tuple_new(vec![pyre_object::gc_roots::shadow_stack_get(base + 1)]);
-    pyre_object::gc_roots::pin_root(inner);
+    let _ = pyre_object::gc_roots::pin_root(inner);
     Ok(pyre_object::w_tuple_new(vec![
         pyre_object::gc_roots::shadow_stack_get(base),
         pyre_object::gc_roots::shadow_stack_get(base + 2),
@@ -1067,7 +1067,7 @@ mod win_nt {
 fn create_environ() -> pyre_object::PyObjectRef {
     let _roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
     // Both halves of an entry stay rooted across the store: either allocation
     // may move what the other one already produced.
     #[cfg_attr(
@@ -1081,9 +1081,9 @@ fn create_environ() -> pyre_object::PyObjectRef {
     ) {
         let _entry = pyre_object::gc_roots::push_roots();
         let key_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(key());
+        let _ = pyre_object::gc_roots::pin_root(key());
         let value_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(value());
+        let _ = pyre_object::gc_roots::pin_root(value());
         unsafe {
             pyre_object::w_dict_store(
                 pyre_object::gc_roots::shadow_stack_get(dict_slot),
@@ -1155,15 +1155,14 @@ pub(crate) fn fspath(
     }
     let roots = pyre_object::gc_roots::push_roots();
     let arg_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(arg);
-    let arg = pyre_object::gc_roots::shadow_stack_get(arg_slot);
+    let arg = pyre_object::gc_roots::pin_root(arg);
     let path_type = crate::typedef::r#type(arg);
     if let Some(pt) = path_type
         && let Some(fspath_descr) =
             unsafe { crate::baseobjspace::lookup_in_type(pt.as_ptr(), "__fspath__") }
     {
         let fspath_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(fspath_descr);
+        let _ = pyre_object::gc_roots::pin_root(fspath_descr);
         // PyPy's `interp_posix._fspath` binds `__fspath__` before calling it;
         // a non-descriptor is its own value.
         let fspath_fn = unsafe {
@@ -1191,8 +1190,7 @@ pub(crate) fn fspath(
             &[],
         )?;
         let result_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(result);
-        let result = pyre_object::gc_roots::shadow_stack_get(result_slot);
+        let result = pyre_object::gc_roots::pin_root(result);
         // The protocol is only satisfied by what a path can be, so an answer
         // that is neither names the object that gave it and the type it gave.
         if unsafe { pyre_object::is_str(result) || pyre_object::bytesobject::is_bytes(result) } {
@@ -5330,9 +5328,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     ) {
         let _entry_scope = pyre_object::gc_roots::push_roots();
         let base = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(fs_name_obj(bytes_mode, name));
-        pyre_object::gc_roots::pin_root(fs_name_obj(bytes_mode, full));
-        pyre_object::gc_roots::pin_root(W_DirEntry::allocate_stable(W_DirEntry::default()));
+        let _ = pyre_object::gc_roots::pin_root(fs_name_obj(bytes_mode, name));
+        let _ = pyre_object::gc_roots::pin_root(fs_name_obj(bytes_mode, full));
+        let _ = pyre_object::gc_roots::pin_root(W_DirEntry::allocate_stable(W_DirEntry::default()));
         let obj = pyre_object::gc_roots::shadow_stack_get(base + 2);
         let de = W_DirEntry::from_obj(obj).expect("freshly allocated posix.DirEntry");
         de.w_name = pyre_object::gc_roots::shadow_stack_get(base);
@@ -5363,7 +5361,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // allocation can still drive a moving collection over a large listing,
         // so `list` and each per-entry temporary live on the shadow stack.
         let _list_scope = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(list);
+        let _ = pyre_object::gc_roots::pin_root(list);
         let list_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         // A `scandir(fd)` lists through the descriptor and every entry records
         // it (`-1` for the entries a name produced), so its own stat resolves
@@ -5443,7 +5441,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // Initialise the iterator type before allocating its native owner, then
         // pin that stable owner while connecting it to the entries list.
         let _ = scandir_iter_type();
-        pyre_object::gc_roots::pin_root(W_ScandirIterator::allocate_stable(
+        let _ = pyre_object::gc_roots::pin_root(W_ScandirIterator::allocate_stable(
             W_ScandirIterator::default(),
         ));
         let it_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
@@ -8871,12 +8869,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         let _roots = pyre_object::gc_roots::push_roots();
                         let header_slot = bound[4].map(|value| {
                             let slot = pyre_object::gc_roots::shadow_stack_len();
-                            pyre_object::gc_roots::pin_root(value);
+                            let _ = pyre_object::gc_roots::pin_root(value);
                             slot
                         });
                         let trailer_slot = bound[5].map(|value| {
                             let slot = pyre_object::gc_roots::shadow_stack_len();
-                            pyre_object::gc_roots::pin_root(value);
+                            let _ = pyre_object::gc_roots::pin_root(value);
                             slot
                         });
                         let collect_buffers = |slot: Option<usize>, name: &str| {
@@ -9067,7 +9065,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 ]);
                 let kwargs_slot = kwargs.map(|kwargs| {
                     let slot = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(kwargs);
+                    let _ = pyre_object::gc_roots::pin_root(kwargs);
                     slot
                 });
                 let positional =
@@ -9377,7 +9375,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     // take the policy out of it afterwards.
                     let _roots = pyre_object::gc_roots::push_roots();
                     let tuple_slot = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(value);
+                    let value = pyre_object::gc_roots::pin_root(value);
                     let param_obj = unsafe { pyre_object::w_tuple_getitem(value, 1).unwrap() };
                     let priority = sched_priority_w(param_obj)?;
                     let value = pyre_object::gc_roots::shadow_stack_get(tuple_slot);
@@ -9820,7 +9818,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         fn store_names_dict(ns: PyObjectRef, key: &str, table: &[(&str, i32)]) {
             let _names_roots = pyre_object::gc_roots::push_roots();
             let names_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+            let _ = pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
             for (name, value) in table {
                 // The value is allocated before the store, and the dict is
                 // reloaded from its root slot every iteration because the
@@ -9961,7 +9959,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         );
         let w_sysconf_names = pyre_object::w_dict_new();
         let _sysconf_names_root = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_sysconf_names);
+        let _ = pyre_object::gc_roots::pin_root(w_sysconf_names);
         let names_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         for (name, value) in sysconf_names() {
             // Build the value first: call arguments evaluate left to right, so

--- a/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
+++ b/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
@@ -238,7 +238,7 @@ impl<'a> MiniXmlParser<'a> {
         let mut version = String::new();
         let mut encoding = w_none();
         let mut standalone = w_int_new(-1);
-        roots.pin_root(standalone);
+        let mut standalone = roots.pin_root(standalone);
         loop {
             self.skip_ws();
             if self.consume("?>") {
@@ -256,11 +256,11 @@ impl<'a> MiniXmlParser<'a> {
                 "version" => version = value,
                 "encoding" => {
                     encoding = w_str_new(&value);
-                    roots.pin_root(encoding);
+                    let _ = roots.pin_root(encoding);
                 }
                 "standalone" => {
                     standalone = w_int_new(if value == "yes" { 1 } else { 0 });
-                    roots.pin_root(standalone);
+                    let _ = roots.pin_root(standalone);
                 }
                 _ => {}
             }
@@ -374,15 +374,15 @@ impl<'a> MiniXmlParser<'a> {
             self.expect("PUBLIC")?;
             self.skip_ws();
             pubid = w_str_new(&self.read_quoted()?);
-            roots.pin_root(pubid);
+            let _ = roots.pin_root(pubid);
             self.skip_ws();
             sysid = w_str_new(&self.read_quoted()?);
-            roots.pin_root(sysid);
+            let sysid = roots.pin_root(sysid);
         } else if self.starts_with("SYSTEM") {
             self.expect("SYSTEM")?;
             self.skip_ws();
             sysid = w_str_new(&self.read_quoted()?);
-            roots.pin_root(sysid);
+            let _ = roots.pin_root(sysid);
         }
         self.skip_ws();
         if crate::baseobjspace::getattr_str(self.parser, "_pyre_not_standalone_pending")
@@ -472,12 +472,12 @@ impl<'a> MiniXmlParser<'a> {
             let v = self.read_quoted()?;
             self.internal_entities.insert(name.clone(), v.clone());
             value = w_str_new(&v);
-            roots.pin_root(value);
+            let _ = roots.pin_root(value);
         } else if self.starts_with("PUBLIC") {
             self.expect("PUBLIC")?;
             self.skip_ws();
             pubid = w_str_new(&self.read_quoted()?);
-            roots.pin_root(pubid);
+            let pubid = roots.pin_root(pubid);
             self.skip_ws();
             let system = self.read_quoted()?;
             self.external_entities.insert(
@@ -488,7 +488,7 @@ impl<'a> MiniXmlParser<'a> {
                 ),
             );
             sysid = w_str_new(&system);
-            roots.pin_root(sysid);
+            let sysid = roots.pin_root(sysid);
         } else if self.starts_with("SYSTEM") {
             self.expect("SYSTEM")?;
             self.skip_ws();
@@ -496,14 +496,14 @@ impl<'a> MiniXmlParser<'a> {
             self.external_entities
                 .insert(name.clone(), (system.clone(), None));
             sysid = w_str_new(&system);
-            roots.pin_root(sysid);
+            let _ = roots.pin_root(sysid);
         }
         self.skip_ws();
         if self.starts_with("NDATA") {
             self.expect("NDATA")?;
             self.skip_ws();
             notation = w_str_new(&self.read_name()?);
-            roots.pin_root(notation);
+            let _ = roots.pin_root(notation);
         }
         self.skip_until_gt()?;
         let _ = &mut base;
@@ -569,7 +569,7 @@ impl<'a> MiniXmlParser<'a> {
             w_none(),
             w_tuple_new(vec![]),
         ]);
-        roots.pin_root(model);
+        let model = roots.pin_root(model);
         self.set_event_position(event_pos);
         self.call_handler("ElementDeclHandler", &[w_str_new(&name), model])
     }
@@ -631,17 +631,17 @@ impl<'a> MiniXmlParser<'a> {
             self.expect("PUBLIC")?;
             self.skip_ws();
             pubid = w_str_new(&self.read_quoted()?);
-            roots.pin_root(pubid);
+            let _ = roots.pin_root(pubid);
             self.skip_ws();
             if matches!(self.peek_char(), Some('"' | '\'')) {
                 sysid = w_str_new(&self.read_quoted()?);
-                roots.pin_root(sysid);
+                let _ = roots.pin_root(sysid);
             }
         } else if self.starts_with("SYSTEM") {
             self.expect("SYSTEM")?;
             self.skip_ws();
             sysid = w_str_new(&self.read_quoted()?);
-            roots.pin_root(sysid);
+            let _ = roots.pin_root(sysid);
         }
         self.skip_until_gt()?;
         self.set_event_position(event_pos);
@@ -697,7 +697,7 @@ impl<'a> MiniXmlParser<'a> {
                 // first, since the argument list evaluates left to right.
                 let roots = pyre_object::gc_roots::push_roots();
                 let attrs_slot = roots.base();
-                roots.pin_root(self.convert_attributes(&expanded_attrs));
+                let _ = roots.pin_root(self.convert_attributes(&expanded_attrs));
                 self.set_event_position(event_pos);
                 let w_name = self.intern_string(&name);
                 self.call_handler("StartElementHandler", &[w_name, roots.get(attrs_slot)])?;
@@ -717,7 +717,7 @@ impl<'a> MiniXmlParser<'a> {
                 self.ns_stack.push(ns_declared);
                 let roots = pyre_object::gc_roots::push_roots();
                 let attrs_slot = roots.base();
-                roots.pin_root(self.convert_attributes(&expanded_attrs));
+                let _ = roots.pin_root(self.convert_attributes(&expanded_attrs));
                 self.set_event_position(event_pos);
                 let w_name = self.intern_string(&name);
                 self.call_handler("StartElementHandler", &[w_name, roots.get(attrs_slot)])?;
@@ -806,8 +806,8 @@ impl<'a> MiniXmlParser<'a> {
             let roots = pyre_object::gc_roots::push_roots();
             let base = roots.base();
             for (name, value) in attrs {
-                roots.pin_root(self.intern_string(name));
-                roots.pin_root(w_str_new(value));
+                let _ = roots.pin_root(self.intern_string(name));
+                let _ = roots.pin_root(w_str_new(value));
             }
             // `w_list_new` pins the vector it is handed, so the vector is built
             // out of the slots at the call rather than while the members are
@@ -821,11 +821,11 @@ impl<'a> MiniXmlParser<'a> {
             // allocates.
             let roots = pyre_object::gc_roots::push_roots();
             let attrs_slot = roots.base();
-            roots.pin_root(w_dict_new());
+            let _ = roots.pin_root(w_dict_new());
             for (name, value) in attrs {
                 let name_roots = pyre_object::gc_roots::push_roots();
                 let name_slot = name_roots.base();
-                name_roots.pin_root(self.intern_string(name));
+                let _ = name_roots.pin_root(self.intern_string(name));
                 let w_value = w_str_new(value);
                 unsafe { w_dict_store(roots.get(attrs_slot), name_roots.get(name_slot), w_value) };
             }
@@ -898,7 +898,7 @@ impl<'a> MiniXmlParser<'a> {
         let roots = pyre_object::gc_roots::push_roots();
         let base = roots.base();
         for &arg in args {
-            roots.pin_root(arg);
+            let _ = roots.pin_root(arg);
         }
         if name != "CharacterDataHandler" && self.handler_is_set(name) {
             self.flush_character_buffer()?;
@@ -1147,7 +1147,7 @@ impl<'a> MiniXmlParser<'a> {
         // does not move, so the local is not read back.  `base` needs nothing:
         // it is the parser's own attribute and stays reachable through it.
         let roots = pyre_object::gc_roots::push_roots();
-        roots.pin_root(handler);
+        let handler = roots.pin_root(handler);
         let base = crate::baseobjspace::getattr_str(self.parser, "_pyre_base")
             .unwrap_or_else(|_| w_none());
         let ret = crate::call::call_function_impl_result(
@@ -1192,7 +1192,7 @@ impl<'a> MiniXmlParser<'a> {
         // takes one liveness pin.  `sysid` / `pubid` are the caller's, pinned
         // there for the whole doctype.
         let roots = pyre_object::gc_roots::push_roots();
-        roots.pin_root(handler);
+        let handler = roots.pin_root(handler);
         let base = crate::baseobjspace::getattr_str(self.parser, "_pyre_base")
             .unwrap_or_else(|_| w_none());
         let ret = crate::call::call_function_impl_result(handler, &[w_none(), base, sysid, pubid])?;
@@ -1208,7 +1208,7 @@ impl<'a> MiniXmlParser<'a> {
         // does not move, so the local stays current.
         let value_roots = pyre_object::gc_roots::push_roots();
         let w_value = w_str_new(value);
-        value_roots.pin_root(w_value);
+        let w_value = value_roots.pin_root(w_value);
         let Ok(intern) = crate::baseobjspace::getattr_str(self.parser, "intern") else {
             return w_value;
         };
@@ -1222,7 +1222,7 @@ impl<'a> MiniXmlParser<'a> {
         // address.  The map is read back out of its root slot for both uses.
         let roots = pyre_object::gc_roots::push_roots();
         let intern_slot = roots.base();
-        roots.pin_root(intern);
+        let _ = roots.pin_root(intern);
         unsafe {
             if let Some(existing) = w_dict_getitem_str(roots.get(intern_slot), value) {
                 existing
@@ -1496,7 +1496,7 @@ fn parse_impl(
     // not move, so the parameter stays current.  `parser` is the receiver and
     // stays reachable through the caller.
     let roots = pyre_object::gc_roots::push_roots();
-    roots.pin_root(data);
+    let data = roots.pin_root(data);
     if crate::baseobjspace::getattr_str(parser, "_pyre_finished")
         .map(is_true_obj)
         .unwrap_or(false)
@@ -1583,7 +1583,7 @@ fn call_foreign_dtd_handler(
     // and the base lookup that follows is a full `getattr`, so it takes one
     // liveness pin.
     let roots = pyre_object::gc_roots::push_roots();
-    roots.pin_root(handler);
+    let handler = roots.pin_root(handler);
     let base = crate::baseobjspace::getattr_str(parser, "_pyre_base").unwrap_or_else(|_| w_none());
     let ret = crate::call::call_function_impl_result(handler, &[w_none(), base, sysid, pubid])?;
     if unsafe { is_int(ret) && w_int_get_value(ret) == 0 } {
@@ -1628,7 +1628,7 @@ fn pyexpat_error(msg: String, code: i64, lineno: i64, offset: i64) -> crate::PyE
             // so the local stays current.  `cls` is the registered class and
             // stays reachable through the registry.
             let roots = pyre_object::gc_roots::push_roots();
-            roots.pin_root(exc);
+            let exc = roots.pin_root(exc);
             crate::baseobjspace::setdictvalue_native(exc, "code", w_int_new(code));
             crate::baseobjspace::setdictvalue_native(exc, "lineno", w_int_new(lineno));
             crate::baseobjspace::setdictvalue_native(exc, "offset", w_int_new(offset));
@@ -1691,7 +1691,7 @@ mod xmlparser_class {
                 // does not move, so the local stays current.
                 let roots = pyre_object::gc_roots::push_roots();
                 let read = crate::baseobjspace::getattr_str(file, "read")?;
-                roots.pin_root(read);
+                let read = roots.pin_root(read);
                 let mut result = w_int_new(1);
                 loop {
                     let data = crate::call::call_function_impl_result(read, &[w_int_new(2048)])?;
@@ -1798,7 +1798,7 @@ mod xmlparser_class {
                 // takes one liveness pin, and an instance does not move.
                 let roots = pyre_object::gc_roots::push_roots();
                 let parser = w_instance_new(xmlparser_class::type_object());
-                roots.pin_root(parser);
+                let parser = roots.pin_root(parser);
                 init_parser_slots(parser);
                 copy_parser_config(self_obj, parser);
                 crate::baseobjspace::setdictvalue_native(parser, "_pyre_is_subparser", w_bool_from(true));
@@ -1917,9 +1917,9 @@ fn parser_create3(
     // takes one liveness pin; an instance does not move and is not read back.
     let roots = pyre_object::gc_roots::push_roots();
     let intern_slot = roots.base();
-    roots.pin_root(intern);
+    let _ = roots.pin_root(intern);
     let parser = w_instance_new(xmlparser_class::type_object());
-    roots.pin_root(parser);
+    let parser = roots.pin_root(parser);
     init_parser_slots(parser);
     if unsafe { !is_none(encoding) } {
         if unsafe { !is_str(encoding) } {
@@ -2100,7 +2100,7 @@ fn make_namespace(name: &'static str) -> PyObjectRef {
     // held by the instance afterwards.
     let roots = pyre_object::gc_roots::push_roots();
     let obj = w_instance_new(tp);
-    roots.pin_root(obj);
+    let obj = roots.pin_root(obj);
     crate::baseobjspace::setdictvalue_native(obj, "__name__", w_str_new(name));
     obj
 }
@@ -2148,7 +2148,7 @@ crate::py_module! {
         // mint; an instance does not move, so the locals stay current.
         let ns_roots = pyre_object::gc_roots::push_roots();
         let model = make_namespace("pyexpat.model");
-        ns_roots.pin_root(model);
+        let model = ns_roots.pin_root(model);
         for (name, value) in MODEL_CONSTANTS {
             crate::baseobjspace::setdictvalue_native(model, name, w_int_new(*value));
         }
@@ -2157,7 +2157,7 @@ crate::py_module! {
         // errors — XML_ERROR_* message strings plus the `codes`
         // (message -> code) and `messages` (code -> message) maps.
         let errors = make_namespace("pyexpat.errors");
-        ns_roots.pin_root(errors);
+        let errors = ns_roots.pin_root(errors);
         // Both maps are dicts, whose headers move, and every iteration of the
         // loop allocates: the message string, the code objects, the key strings
         // the stores build, and each dict's own storage as it grows.  They are
@@ -2167,9 +2167,9 @@ crate::py_module! {
         // value allocates.
         let error_map_roots = pyre_object::gc_roots::push_roots();
         let codes_slot = error_map_roots.base();
-        error_map_roots.pin_root(w_dict_new());
+        let _ = error_map_roots.pin_root(w_dict_new());
         let messages_slot = codes_slot + 1;
-        error_map_roots.pin_root(w_dict_new());
+        let _ = error_map_roots.pin_root(w_dict_new());
         for (idx, name) in ERROR_NAMES.iter().enumerate() {
             // ERROR_NAMES[0] is XML_ERROR_NONE (no message); codes start at 1.
             if idx == 0 {

--- a/pyre/pyre-interpreter/src/module/select/interp_select.rs
+++ b/pyre/pyre-interpreter/src/module/select/interp_select.rs
@@ -353,9 +353,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // read each back at its own call.
                 let arg_roots = pyre_object::gc_roots::push_roots();
                 let args_base = arg_roots.base();
-                arg_roots.pin_root(args[0]);
-                arg_roots.pin_root(args[1]);
-                arg_roots.pin_root(args[2]);
+                let _ = arg_roots.pin_root(args[0]);
+                let _ = arg_roots.pin_root(args[1]);
+                let _ = arg_roots.pin_root(args[2]);
                 let rfds = collect_fds(arg_roots.get(args_base))?;
                 let wfds = collect_fds(arg_roots.get(args_base + 1))?;
                 let xfds = collect_fds(arg_roots.get(args_base + 2))?;
@@ -479,9 +479,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // is built.
                 let roots = pyre_object::gc_roots::push_roots();
                 let ready_base = roots.base();
-                roots.pin_root(build_ready(&mut rset, &rfds));
-                roots.pin_root(build_ready(&mut wset, &wfds));
-                roots.pin_root(build_ready(&mut xset, &xfds));
+                let _ = roots.pin_root(build_ready(&mut rset, &rfds));
+                let _ = roots.pin_root(build_ready(&mut wset, &wfds));
+                let _ = roots.pin_root(build_ready(&mut xset, &xfds));
                 Ok(pyre_object::w_tuple_new(vec![
                     roots.get(ready_base),
                     roots.get(ready_base + 1),

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -96,7 +96,7 @@ fn handlers_dict() -> PyObjectRef {
     let mut d = HANDLERS.load(Ordering::Acquire) as PyObjectRef;
     if d.is_null() {
         d = pyre_object::w_dict_new();
-        pyre_object::gc_roots::pin_root(d);
+        let mut d = pyre_object::gc_roots::pin_root(d);
         match HANDLERS.compare_exchange(0, d as usize, Ordering::AcqRel, Ordering::Acquire) {
             Ok(_) => {}
             Err(installed) => d = installed as PyObjectRef,
@@ -333,7 +333,7 @@ pub fn default_int_handler_obj() -> PyObjectRef {
                 Err(unsafe { crate::PyError::from_exc_object(exc) })
             },
         );
-        pyre_object::gc_roots::pin_root(h);
+        let mut h = pyre_object::gc_roots::pin_root(h);
         match DEFAULT_INT_HANDLER.compare_exchange(
             0,
             h as usize,

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -96,7 +96,7 @@ fn handlers_dict() -> PyObjectRef {
     let mut d = HANDLERS.load(Ordering::Acquire) as PyObjectRef;
     if d.is_null() {
         d = pyre_object::w_dict_new();
-        let mut d = pyre_object::gc_roots::pin_root(d);
+        d = pyre_object::gc_roots::pin_root(d);
         match HANDLERS.compare_exchange(0, d as usize, Ordering::AcqRel, Ordering::Acquire) {
             Ok(_) => {}
             Err(installed) => d = installed as PyObjectRef,
@@ -333,7 +333,7 @@ pub fn default_int_handler_obj() -> PyObjectRef {
                 Err(unsafe { crate::PyError::from_exc_object(exc) })
             },
         );
-        let mut h = pyre_object::gc_roots::pin_root(h);
+        h = pyre_object::gc_roots::pin_root(h);
         match DEFAULT_INT_HANDLER.compare_exchange(
             0,
             h as usize,

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -1470,8 +1470,8 @@ pub mod unpack_iter {
         // iterator, never an unrooted caller-local pointer.
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(format);
-        pyre_object::gc_roots::pin_root(buffer);
+        let format = pyre_object::gc_roots::pin_root(format);
+        let buffer = pyre_object::gc_roots::pin_root(buffer);
         let buf = unsafe { readbuf(pyre_object::gc_roots::shadow_stack_get(sp + 1))? };
         if size <= 0 {
             return Err(struct_error(format!(

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -356,7 +356,7 @@ fn simple_namespace_new(args: &[PyObjectRef]) -> crate::PyResult {
     // `__getattribute__` or shadows `__dict__` neither runs during
     // construction nor can make `S()` raise.
     let dict = crate::baseobjspace::getdict(pyre_object::gc_roots::shadow_stack_get(object_slot))?;
-    pyre_object::gc_roots::pin_root(dict);
+    let _ = pyre_object::gc_roots::pin_root(dict);
     let dict = pyre_object::gc_roots::shadow_stack_get(object_slot + 1);
     unsafe {
         use pyre_object::dictmultiobject::DictStrategy;

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -110,7 +110,7 @@ pub fn monitoring_free_tool_id(tool_id: usize) {
 fn get_sizeof(w_obj: PyObjectRef) -> crate::PyResult {
     let roots = pyre_object::gc_roots::push_roots();
     let obj_slot = roots.base();
-    roots.pin_root(w_obj);
+    let _ = roots.pin_root(w_obj);
     let current = || roots.get(obj_slot);
     let method = unsafe { crate::baseobjspace::lookup_special(current(), "__sizeof__")? }
         .ok_or_else(|| {
@@ -256,20 +256,20 @@ fn namespace_update_dict(
 ) -> Result<(), crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
-    pyre_object::gc_roots::pin_root(source);
+    let _ = pyre_object::gc_roots::pin_root(self_obj);
+    let _ = pyre_object::gc_roots::pin_root(source);
     let destination = crate::baseobjspace::getattr_str(
         pyre_object::gc_roots::shadow_stack_get(sp),
         "__dict__",
     )?;
-    pyre_object::gc_roots::pin_root(destination);
+    let _ = pyre_object::gc_roots::pin_root(destination);
     let items = unsafe {
         pyre_object::w_dict_items(pyre_object::gc_roots::shadow_stack_get(sp + 1))
     };
     let items_sp = pyre_object::gc_roots::shadow_stack_len();
     for &(key, value) in &items {
-        pyre_object::gc_roots::pin_root(key);
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(key);
+        let _ = pyre_object::gc_roots::pin_root(value);
     }
     for i in 0..items.len() {
         let key = pyre_object::gc_roots::shadow_stack_get(items_sp + i * 2);
@@ -377,7 +377,7 @@ fn simple_namespace_init(args: &[PyObjectRef]) -> crate::PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
     for &arg in args {
-        pyre_object::gc_roots::pin_root(arg);
+        let _ = pyre_object::gc_roots::pin_root(arg);
     }
     let rooted = (0..args.len())
         .map(|i| pyre_object::gc_roots::shadow_stack_get(sp + i))
@@ -399,16 +399,16 @@ fn simple_namespace_init(args: &[PyObjectRef]) -> crate::PyResult {
     // canonical order before any allocation instead of deriving their slots
     // from the flat input layout.
     let operands_sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
+    let _ = pyre_object::gc_roots::pin_root(self_obj);
     if positional.len() == 2 {
-        pyre_object::gc_roots::pin_root(positional[1]);
+        let _ = pyre_object::gc_roots::pin_root(positional[1]);
     }
     if let Some(kwargs) = kwargs {
-        pyre_object::gc_roots::pin_root(kwargs);
+        let _ = pyre_object::gc_roots::pin_root(kwargs);
     }
     if positional.len() == 2 {
         let temporary = w_dict_new();
-        pyre_object::gc_roots::pin_root(temporary);
+        let _ = pyre_object::gc_roots::pin_root(temporary);
         let temporary_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let temporary = pyre_object::gc_roots::shadow_stack_get(temporary_slot);
         crate::type_methods::dict_update1(
@@ -519,7 +519,7 @@ fn simple_namespace_repr(args: &[PyObjectRef]) -> crate::PyResult {
     };
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
+    let self_obj = pyre_object::gc_roots::pin_root(self_obj);
     let actual_type = crate::typedef::r#type(self_obj)
         .map(|tp| tp.as_ptr())
         .unwrap_or(simple_namespace_type());
@@ -535,7 +535,7 @@ fn simple_namespace_repr(args: &[PyObjectRef]) -> crate::PyResult {
         pyre_object::gc_roots::shadow_stack_get(sp),
         "__dict__",
     )?;
-    pyre_object::gc_roots::pin_root(dict);
+    let _ = pyre_object::gc_roots::pin_root(dict);
     let keys = unsafe {
         pyre_object::w_dict_items(pyre_object::gc_roots::shadow_stack_get(sp + 1))
             .into_iter()
@@ -544,7 +544,7 @@ fn simple_namespace_repr(args: &[PyObjectRef]) -> crate::PyResult {
     };
     let keys_sp = pyre_object::gc_roots::shadow_stack_len();
     for &key in &keys {
-        pyre_object::gc_roots::pin_root(key);
+        let _ = pyre_object::gc_roots::pin_root(key);
     }
     let mut parts = Vec::with_capacity(keys.len());
     for i in 0..keys.len() {
@@ -563,7 +563,7 @@ fn simple_namespace_repr(args: &[PyObjectRef]) -> crate::PyResult {
             Err(err) => return Err(err),
         };
         let value_sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
         // `getitem` above ran a lookup that can collect, so the key has to be
         // reread from its slot rather than reused from before the call.
         let key = pyre_object::gc_roots::shadow_stack_get(keys_sp + i);
@@ -638,13 +638,13 @@ fn simple_namespace_richcompare(
     // the first dict have to survive it.
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
-    pyre_object::gc_roots::pin_root(other);
+    let _ = pyre_object::gc_roots::pin_root(self_obj);
+    let _ = pyre_object::gc_roots::pin_root(other);
     let self_dict = crate::baseobjspace::getattr_str(
         pyre_object::gc_roots::shadow_stack_get(sp),
         "__dict__",
     )?;
-    pyre_object::gc_roots::pin_root(self_dict);
+    let _ = pyre_object::gc_roots::pin_root(self_dict);
     let other_dict = crate::baseobjspace::getattr_str(
         pyre_object::gc_roots::shadow_stack_get(sp + 1),
         "__dict__",
@@ -665,18 +665,18 @@ fn simple_namespace_reduce(args: &[PyObjectRef]) -> crate::PyResult {
     };
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
+    let self_obj = pyre_object::gc_roots::pin_root(self_obj);
     let w_type = crate::typedef::r#type(self_obj)
         .map(|tp| tp.as_ptr())
         .unwrap_or(PY_NULL);
-    pyre_object::gc_roots::pin_root(w_type);
+    let _ = pyre_object::gc_roots::pin_root(w_type);
     let w_args = w_tuple_new(Vec::new());
-    pyre_object::gc_roots::pin_root(w_args);
+    let _ = pyre_object::gc_roots::pin_root(w_args);
     let w_dict = crate::baseobjspace::getattr_str(
         pyre_object::gc_roots::shadow_stack_get(sp),
         "__dict__",
     )?;
-    pyre_object::gc_roots::pin_root(w_dict);
+    let _ = pyre_object::gc_roots::pin_root(w_dict);
     Ok(w_tuple_new(vec![
         pyre_object::gc_roots::shadow_stack_get(sp + 1),
         pyre_object::gc_roots::shadow_stack_get(sp + 2),
@@ -701,9 +701,9 @@ fn simple_namespace_replace(args: &[PyObjectRef]) -> crate::PyResult {
     }
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_obj);
+    let self_obj = pyre_object::gc_roots::pin_root(self_obj);
     if let Some(kwargs) = kwargs {
-        pyre_object::gc_roots::pin_root(kwargs);
+        let _ = pyre_object::gc_roots::pin_root(kwargs);
     }
     let self_type = crate::typedef::r#type(self_obj)
         .map(|tp| tp.as_ptr())
@@ -721,14 +721,14 @@ fn simple_namespace_replace(args: &[PyObjectRef]) -> crate::PyResult {
             "descriptor '__replace__' for 'types.SimpleNamespace' objects doesn't apply to a '{received}' object"
         )));
     }
-    pyre_object::gc_roots::pin_root(self_type);
+    let _ = pyre_object::gc_roots::pin_root(self_type);
     let result = crate::call::call_function_impl_result(
         pyre_object::gc_roots::shadow_stack_get(
             sp + 1 + usize::from(kwargs.is_some()),
         ),
         &[],
     )?;
-    pyre_object::gc_roots::pin_root(result);
+    let _ = pyre_object::gc_roots::pin_root(result);
     // Reread from this slot at every use below: the `__dict__` lookup and each
     // `namespace_update_dict` can run Python and collect, so a local captured
     // here would name the pre-relocation address.
@@ -758,7 +758,7 @@ fn simple_namespace_replace(args: &[PyObjectRef]) -> crate::PyResult {
         pyre_object::gc_roots::shadow_stack_get(sp),
         "__dict__",
     )?;
-    pyre_object::gc_roots::pin_root(source_dict);
+    let _ = pyre_object::gc_roots::pin_root(source_dict);
     namespace_update_dict(
         pyre_object::gc_roots::shadow_stack_get(result_slot),
         pyre_object::gc_roots::shadow_stack_get(
@@ -1254,14 +1254,14 @@ fn sys_baserepl(_args: &[PyObjectRef]) -> crate::PyResult {
     // collection that forwards the slot without touching a local copy.
     let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(code_module, "interact")?);
+    let _ = pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(code_module, "interact")?);
     // `interact(banner, readfunc, local, exitmsg)`.  Both messages are empty:
     // the console this stands in for prints neither a banner nor a farewell.
-    pyre_object::gc_roots::pin_root(pyre_object::w_str_new(""));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(""));
     let main_module = crate::importing::get_sys_module("__main__")
         .ok_or_else(|| crate::PyError::runtime_error("no module named '__main__'"))?;
-    pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(main_module, "__dict__")?);
-    pyre_object::gc_roots::pin_root(pyre_object::w_str_new(""));
+    let _ = pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(main_module, "__dict__")?);
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(""));
     let slot = pyre_object::gc_roots::shadow_stack_get;
     crate::call::call_function_impl_result(
         slot(base),
@@ -2979,9 +2979,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let w_default = scope[1];
                 let roots = pyre_object::gc_roots::push_roots();
                 let obj_slot = roots.base();
-                roots.pin_root(w_obj);
+                let _ = roots.pin_root(w_obj);
                 let default_slot = obj_slot + 1;
-                roots.pin_root(w_default);
+                let w_default = roots.pin_root(w_default);
                 match get_sizeof(roots.get(obj_slot)) {
                     Ok(size) => Ok(size),
                     Err(err)
@@ -3336,7 +3336,7 @@ fn trigger_audit_events(
         .map(|i| pyre_object::gc_roots::shadow_stack_get(args_slot + i))
         .collect();
     let args_tuple_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::tupleobject::w_tuple_new(items));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::tupleobject::w_tuple_new(items));
 
     let ec = crate::call::getexecutioncontext() as *mut crate::executioncontext::ExecutionContext;
     // don't trace audithooks by default
@@ -3505,7 +3505,7 @@ fn sys_addaudithook(args: &[pyre_object::PyObjectRef]) -> crate::PyResult {
     // and not this local.
     let _roots = pyre_object::gc_roots::push_roots();
     let hook_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_hook);
+    let _ = pyre_object::gc_roots::pin_root(w_hook);
     if let Err(err) = audit("sys.addaudithook", &[]) {
         if !error_is_exception(&err) {
             return Err(err);
@@ -3557,8 +3557,8 @@ fn error_is_exception(err: &crate::PyError) -> bool {
     );
     if !err.exc_object.is_null() && !w_exception.is_null() {
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(err.exc_object);
-        pyre_object::gc_roots::pin_root(w_exception);
+        let _ = pyre_object::gc_roots::pin_root(err.exc_object);
+        let w_exception = pyre_object::gc_roots::pin_root(w_exception);
         return crate::baseobjspace::isinstance(err.exc_object, w_exception).unwrap_or(false);
     }
     // `exc_kind_matches(kind, "Exception")` spelled over `PyErrorKind`: every
@@ -3585,10 +3585,10 @@ fn sys_clear_type_descriptors(args: &[PyObjectRef]) -> crate::PyResult {
 
     let _roots = pyre_object::gc_roots::push_roots();
     if let Some(descr) = crate::type_dict_lookup(w_type, "__dict__") {
-        pyre_object::gc_roots::pin_root(descr);
+        let _ = pyre_object::gc_roots::pin_root(descr);
     }
     if let Some(descr) = crate::type_dict_lookup(w_type, "__weakref__") {
-        pyre_object::gc_roots::pin_root(descr);
+        let _ = pyre_object::gc_roots::pin_root(descr);
     }
     crate::type_dict_delete(w_type, "__dict__");
     crate::type_dict_delete(w_type, "__weakref__");
@@ -3669,7 +3669,7 @@ fn stdio_stdin_readline(args: &[PyObjectRef]) -> crate::PyResult {
         ));
     }
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(bytes);
+    let _ = pyre_object::gc_roots::pin_root(bytes);
     let bytes_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let (encoding, errors) = live_stdio_encoding_errors("stdin", "strict");
     crate::typedef::bytes_method_decode(&[
@@ -3724,7 +3724,7 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
     ])
     .unwrap_or_else(|_| w_none());
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(buffer);
+    let buffer = pyre_object::gc_roots::pin_root(buffer);
     let buffer_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // `app_main.py create_stdio` names the raw descriptor object rather
     // than the wrapper, so `repr(sys.stdin.buffer)` reads `name='<stdin>'`
@@ -3810,7 +3810,7 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
         // across it rather than left as a bare temporary.
         let _roots = pyre_object::gc_roots::push_roots();
         let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(out));
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8_managed(out));
         crate::type_methods::encode_object(
             pyre_object::gc_roots::shadow_stack_get(slot),
             encoding,

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -492,13 +492,13 @@ pub(crate) fn current_frames() -> PyObjectRef {
                 // rather than taken from the pre-force local.
                 let anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
                 crate::executioncontext::force_frame(frame);
-                pyre_object::gc_roots::pin_root(anchor.live() as PyObjectRef);
+                let _ = pyre_object::gc_roots::pin_root(anchor.live() as PyObjectRef);
                 entries.push(ident);
             }
         }
     });
     let result = w_dict_new();
-    pyre_object::gc_roots::pin_root(result);
+    let _ = pyre_object::gc_roots::pin_root(result);
     let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     for (index, ident) in entries.into_iter().enumerate() {
         // The key is built first: `w_int_new` allocates, so a dict or a value
@@ -535,7 +535,7 @@ pub(crate) fn current_exceptions() -> PyObjectRef {
             // parked on the generator, and `_get_topmost_exception` is what
             // reads it back.
             let exception = unsafe { (*(ec as *const crate::PyExecutionContext)).sys_exc_info() };
-            pyre_object::gc_roots::pin_root(if exception.is_null() {
+            let _ = pyre_object::gc_roots::pin_root(if exception.is_null() {
                 w_none()
             } else {
                 exception
@@ -544,7 +544,7 @@ pub(crate) fn current_exceptions() -> PyObjectRef {
         }
     });
     let result = w_dict_new();
-    pyre_object::gc_roots::pin_root(result);
+    let _ = pyre_object::gc_roots::pin_root(result);
     let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     for (index, ident) in entries.into_iter().enumerate() {
         // The key is built first: `w_int_new` allocates, so a dict or a value
@@ -1305,7 +1305,7 @@ mod local_class {
             // create a new dict for this thread
             let w_dict = pyre_object::w_dict_new();
             let roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(w_dict);
+            let w_dict = pyre_object::gc_roots::pin_root(w_dict);
             let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             // Published before the initializer runs: the `__init__` about to be
             // entered reaches `getdict` again, and finding this entry is what
@@ -1472,12 +1472,12 @@ mod local_class {
             // initialization.
             let roots = pyre_object::gc_roots::push_roots();
             let cls_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(cls);
+            let _ = pyre_object::gc_roots::pin_root(cls);
             // A plain `_local()` has no keyword mapping, and a null takes no
             // shadow-stack slot.
             let initkwargs_slot = kwargs.map(|w_kwargs| {
                 let slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(w_kwargs);
+                let _ = pyre_object::gc_roots::pin_root(w_kwargs);
                 slot
             });
             // Pinned BEFORE the tuple is built: `w_tuple_new` allocates, and
@@ -1487,13 +1487,13 @@ mod local_class {
             // addresses, so both are read back from their slots below.
             let initargs = w_tuple_new(positional.get(1..).unwrap_or(&[]).to_vec());
             let initargs_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(initargs);
+            let _ = pyre_object::gc_roots::pin_root(initargs);
             let dicts_slot = pyre_object::gc_roots::shadow_stack_len();
             let dicts = pyre_object::w_dict_new();
-            pyre_object::gc_roots::pin_root(dicts);
+            let _ = pyre_object::gc_roots::pin_root(dicts);
             let dict_slot = pyre_object::gc_roots::shadow_stack_len();
             let w_dict = pyre_object::w_dict_new();
-            pyre_object::gc_roots::pin_root(w_dict);
+            let _ = pyre_object::gc_roots::pin_root(w_dict);
             let ident = current_ident();
             unsafe {
                 pyre_object::w_dict_setitem(
@@ -1563,7 +1563,7 @@ fn register_local_in_current_ec(local: PyObjectRef) {
         return;
     }
     let root = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(local);
+    let local = pyre_object::gc_roots::pin_root(local);
     let wref = unsafe { pyre_object::weakref::w_weakref_new(local) as PyObjectRef };
     unsafe { (*ec).thread_local_refs.push(wref) };
     drop(root);
@@ -1697,15 +1697,15 @@ fn spawn_thread(
 
     let roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(callable);
+    let callable = pyre_object::gc_roots::pin_root(callable);
     for &arg in &positional {
-        pyre_object::gc_roots::pin_root(arg);
+        let _ = pyre_object::gc_roots::pin_root(arg);
     }
     if let Some(d) = kwargs {
-        pyre_object::gc_roots::pin_root(d);
+        let _ = pyre_object::gc_roots::pin_root(d);
     }
     if let Some(h) = handle {
-        pyre_object::gc_roots::pin_root(h);
+        let _ = pyre_object::gc_roots::pin_root(h);
     }
     let nargs = positional.len();
     let has_kwargs = kwargs.is_some();
@@ -1793,15 +1793,15 @@ fn spawn_thread(
             // interpreter allocation can trigger a moving collection.
             let worker_roots = pyre_object::gc_roots::push_roots();
             let worker_base = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(callable_addr as PyObjectRef);
+            let _ = pyre_object::gc_roots::pin_root(callable_addr as PyObjectRef);
             for addr in &args_addr {
-                pyre_object::gc_roots::pin_root(*addr as PyObjectRef);
+                let _ = pyre_object::gc_roots::pin_root(*addr as PyObjectRef);
             }
             if has_kwargs {
-                pyre_object::gc_roots::pin_root(kwargs_addr as PyObjectRef);
+                let _ = pyre_object::gc_roots::pin_root(kwargs_addr as PyObjectRef);
             }
             if has_handle {
-                pyre_object::gc_roots::pin_root(handle_addr as PyObjectRef);
+                let _ = pyre_object::gc_roots::pin_root(handle_addr as PyObjectRef);
             }
 
             let mut ec = Box::new(unsafe {
@@ -2145,7 +2145,7 @@ fn except_hook_args_type() -> PyObjectRef {
 
 #[inline]
 fn pin_root_slot(value: PyObjectRef) -> usize {
-    pyre_object::gc_roots::pin_root(value);
+    let _ = pyre_object::gc_roots::pin_root(value);
     pyre_object::gc_roots::shadow_stack_len() - 1
 }
 

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -1749,9 +1749,9 @@ pub fn strptime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // and can move young objects; pin and re-read them for the delegated call.
     let _roots = pyre_object::gc_roots::push_roots();
     let string_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(string);
+    let _ = pyre_object::gc_roots::pin_root(string);
     let format_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(format);
+    let _ = pyre_object::gc_roots::pin_root(format);
     let w_mod = match crate::importing::get_sys_module("_strptime") {
         Some(m) => m,
         None => crate::importing::importhook(
@@ -1792,10 +1792,10 @@ pub fn get_clock_info(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     let name = positional[0];
     let _roots = pyre_object::gc_roots::push_roots();
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(name);
+    let _ = pyre_object::gc_roots::pin_root(name);
     let info = crate::module::sys::vm::new_simple_namespace_instance()?;
     let info_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(info);
+    let _ = pyre_object::gc_roots::pin_root(info);
     // `_get_time_info` overwrites implementation/monotonic/adjustable/resolution
     // on success and raises `ValueError("unknown clock")` otherwise, so the
     // app-level default fields are redundant.

--- a/pyre/pyre-interpreter/src/module/unicodedata/mod.rs
+++ b/pyre/pyre-interpreter/src/module/unicodedata/mod.rs
@@ -436,7 +436,7 @@ crate::py_module! {
         // Installing the module attribute can allocate; keep the freshly
         // allocated instance rooted until the namespace owns it.
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(ucd);
+        let _ = pyre_object::gc_roots::pin_root(ucd);
         let ucd = pyre_object::gc_roots::shadow_stack_get(
             pyre_object::gc_roots::shadow_stack_len() - 1,
         );

--- a/pyre/pyre-interpreter/src/module/winsound/mod.rs
+++ b/pyre/pyre-interpreter/src/module/winsound/mod.rs
@@ -24,8 +24,7 @@ const SND_ASYNC: i32 = 0x0001;
 fn sound_name(sound: PyObjectRef) -> Result<Vec<u16>, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let sound_slot = roots.base();
-    roots.pin_root(sound);
-
+    let sound = roots.pin_root(sound);
     let w_name = if unsafe { pyre_object::is_str(sound) } {
         roots.get(sound_slot)
     } else if unsafe { pyre_object::bytesobject::is_bytes(sound) } {
@@ -44,14 +43,13 @@ fn sound_name(sound: PyObjectRef) -> Result<Vec<u16>, crate::PyError> {
             )));
         };
         let fspath_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(fspath_fn);
+        let _ = roots.pin_root(fspath_fn);
         let resolved = crate::call::call_function_impl_result(
             roots.get(fspath_slot),
             &[roots.get(sound_slot)],
         )?;
         let resolved_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(resolved);
-        let resolved = roots.get(resolved_slot);
+        let resolved = roots.pin_root(resolved);
         if !unsafe { pyre_object::is_str(resolved) } {
             return Err(crate::PyError::type_error(format!(
                 "'sound' must resolve to str, not {}",
@@ -86,12 +84,12 @@ fn win32_runtime_error(code: u32) -> crate::PyError {
     // a Rust array of raw references is not something the collector updates.
     let roots = pyre_object::gc_roots::push_roots();
     let cls_slot = roots.base();
-    roots.pin_root(cls);
-    roots.pin_root(pyre_object::w_int_new(0));
-    roots.pin_root(pyre_object::w_str_new(&message));
-    roots.pin_root(pyre_object::w_none());
-    roots.pin_root(pyre_object::w_int_new(i64::from(code as i32)));
-    roots.pin_root(pyre_object::w_none());
+    let _ = roots.pin_root(cls);
+    let _ = roots.pin_root(pyre_object::w_int_new(0));
+    let _ = roots.pin_root(pyre_object::w_str_new(&message));
+    let _ = roots.pin_root(pyre_object::w_none());
+    let _ = roots.pin_root(pyre_object::w_int_new(i64::from(code as i32)));
+    let _ = roots.pin_root(pyre_object::w_none());
     let args = [
         roots.get(cls_slot + 1),
         roots.get(cls_slot + 2),

--- a/pyre/pyre-interpreter/src/module/zlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/zlib/mod.rs
@@ -201,7 +201,7 @@ static ZDECOMPRESS_RUNTIME_TYPE: std::sync::OnceLock<usize> = std::sync::OnceLoc
 /// those PyPy type names and add only the observable namespace entry.
 fn publish_cpython_module(ns: PyObjectRef) {
     let roots = pyre_object::gc_roots::push_roots();
-    roots.pin_root(ns);
+    let _ = roots.pin_root(ns);
     let slot = roots.base();
     let module = pyre_object::w_str_new("zlib");
     unsafe {

--- a/pyre/pyre-interpreter/src/module/zlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/zlib/mod.rs
@@ -406,7 +406,7 @@ fn allocate_compress(
 ) -> Result<PyObjectRef, crate::PyError> {
     let backend = Box::into_raw(Box::new(Mutex::new(backend)));
     let _roots = gc_roots::push_roots();
-    gc_roots::pin_root(cls);
+    let _ = gc_roots::pin_root(cls);
     let cls_slot = gc_roots::shadow_stack_len() - 1;
     let obj = W_Compress::allocate_stable(W_Compress {
         ob: PyObject::default(),
@@ -664,7 +664,7 @@ fn allocate_decompress(
 ) -> Result<PyObjectRef, crate::PyError> {
     let backend = Box::into_raw(Box::new(Mutex::new(backend)));
     let _roots = gc_roots::push_roots();
-    gc_roots::pin_root(cls);
+    let _ = gc_roots::pin_root(cls);
     let cls_slot = gc_roots::shadow_stack_len() - 1;
     let obj = W_Decompress::allocate_stable(W_Decompress {
         ob: PyObject::default(),
@@ -733,7 +733,7 @@ fn allocate_zdecompress(
 ) -> Result<PyObjectRef, crate::PyError> {
     let backend = Box::into_raw(Box::new(Mutex::new(backend)));
     let _roots = gc_roots::push_roots();
-    gc_roots::pin_root(cls);
+    let _ = gc_roots::pin_root(cls);
     let cls_slot = gc_roots::shadow_stack_len() - 1;
     let obj = W_ZlibDecompressor::allocate_stable(W_ZlibDecompressor {
         ob: PyObject::default(),

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -4108,7 +4108,7 @@ pub(crate) fn try_dispatch_binary_special(
         // The reflected implementation has to survive the forward call too.
         let right_slot = w_right_impl.map(|method| {
             let slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(method);
+            let _ = pyre_object::gc_roots::pin_root(method);
             slot
         });
         let mut result = None;
@@ -4172,7 +4172,7 @@ fn try_dispatch_ternary_pow_special(
         // in an operand's.
         let pin = |method: PyObjectRef| {
             let slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(method);
+            let _ = pyre_object::gc_roots::pin_root(method);
             slot
         };
         let base_impl_slot = w_base_impl.map(pin);
@@ -4839,12 +4839,13 @@ pub fn or_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
             // already brackets its own operands for that reason.
             let _roots = pyre_object::gc_roots::push_roots();
             let root_base = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(a);
-            pyre_object::gc_roots::pin_root(b);
+            let _ = pyre_object::gc_roots::pin_root(a);
+            let _ = pyre_object::gc_roots::pin_root(b);
             let src = || pyre_object::gc_roots::shadow_stack_get(root_base);
             let other = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
             let merged = || pyre_object::gc_roots::shadow_stack_get(root_base + 2);
-            pyre_object::gc_roots::pin_root(crate::type_methods::dict_method_copy(&[src()])?);
+            let _ =
+                pyre_object::gc_roots::pin_root(crate::type_methods::dict_method_copy(&[src()])?);
             crate::type_methods::dict_update1(merged(), other())?;
             return Ok(merged());
         }
@@ -5128,8 +5129,8 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
             // and read each entry back after the comparisons that precede it.
             let _roots = pyre_object::gc_roots::push_roots();
             let root_base = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(a);
-            pyre_object::gc_roots::pin_root(b);
+            let _ = pyre_object::gc_roots::pin_root(a);
+            let _ = pyre_object::gc_roots::pin_root(b);
             let la = pyre_object::w_dict_len(pyre_object::gc_roots::shadow_stack_get(root_base));
             let lb =
                 pyre_object::w_dict_len(pyre_object::gc_roots::shadow_stack_get(root_base + 1));
@@ -5139,8 +5140,8 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
                     pyre_object::w_dict_items(pyre_object::gc_roots::shadow_stack_get(root_base));
                 let items_base = pyre_object::gc_roots::shadow_stack_len();
                 for &(k, v) in &items {
-                    pyre_object::gc_roots::pin_root(k);
-                    pyre_object::gc_roots::pin_root(v);
+                    let _ = pyre_object::gc_roots::pin_root(k);
+                    let _ = pyre_object::gc_roots::pin_root(v);
                 }
                 for index in 0..items.len() {
                     let k = pyre_object::gc_roots::shadow_stack_get(items_base + index * 2);
@@ -5220,9 +5221,9 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
                 // but an unreachable one is still swept.
                 let _roots = pyre_object::gc_roots::push_roots();
                 let a_set = as_set(a)?;
-                pyre_object::gc_roots::pin_root(a_set);
+                let a_set = pyre_object::gc_roots::pin_root(a_set);
                 let b_set = as_set(b)?;
-                pyre_object::gc_roots::pin_root(b_set);
+                let b_set = pyre_object::gc_roots::pin_root(b_set);
                 let la = pyre_object::w_set_len(a_set);
                 let lb = pyre_object::w_set_len(b_set);
                 let a_subset_b = || crate::typedef::set_is_subset_of(a_set, b_set);
@@ -5270,8 +5271,8 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
             // what makes the "read the live lists" contract above hold.
             let _roots = pyre_object::gc_roots::push_roots();
             let root_base = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(a);
-            pyre_object::gc_roots::pin_root(b);
+            let _ = pyre_object::gc_roots::pin_root(a);
+            let _ = pyre_object::gc_roots::pin_root(b);
             let a = || pyre_object::gc_roots::shadow_stack_get(root_base);
             let b = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
             if matches!(op, CompareOp::Eq | CompareOp::Ne)

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -32,9 +32,9 @@ pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> 
     // is rooted by the frame any more.  A str is immobile and read directly
     // once pinned; `args` may be a dict and is read back from its slot.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(fmt);
+    let fmt = pyre_object::gc_roots::pin_root(fmt);
     let args_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args);
+    let args = pyre_object::gc_roots::pin_root(args);
     let fmt_str = w_str_get_wtf8(fmt);
     let format = CFormatWtf8::parse_from_wtf8(fmt_str)
         .map_err(|err| PyError::value_error(err.to_string()))?;
@@ -146,9 +146,9 @@ unsafe fn bytes_format_percent_inner(fmt: PyObjectRef, args: PyObjectRef) -> PyR
     // the borrow below — a bytes-like object never moves, but an unreachable
     // one is still swept, and the slice points into its payload.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(fmt);
+    let fmt = pyre_object::gc_roots::pin_root(fmt);
     let args_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args);
+    let args = pyre_object::gc_roots::pin_root(args);
     let fmt_bytes = pyre_object::bytesobject::bytes_like_data(fmt);
     let format = CFormatBytes::parse_from_bytes(fmt_bytes)
         .map_err(|err| PyError::value_error(err.to_string()))?;

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -2968,7 +2968,7 @@ impl MapdictObject for pyre_object::W_ObjectObject {
             } else {
                 let grown =
                     pyre_object::object_array::grow_instance_items_block(old, needed, old_cap);
-                pyre_object::gc_roots::pin_root(grown as PyObjectRef);
+                let _ = pyre_object::gc_roots::pin_root(grown as PyObjectRef);
                 let block_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 pyre_object::gc_roots::shadow_stack_get(block_slot)
                     as *mut pyre_object::object_array::ItemsBlock
@@ -3008,7 +3008,7 @@ impl MapdictObject for pyre_object::W_ObjectObject {
                 .len()
                 .max(pyre_object::object_array::items_block_capacity(old));
             let fresh = pyre_object::object_array::alloc_instance_items_block(&storage, cap);
-            pyre_object::gc_roots::pin_root(fresh as PyObjectRef);
+            let _ = pyre_object::gc_roots::pin_root(fresh as PyObjectRef);
             let fresh_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let owner = &mut *(pyre_object::gc_roots::shadow_stack_get(self_slot) as *mut Self);
             owner.storage = pyre_object::gc_roots::shadow_stack_get(fresh_slot) as *mut _;
@@ -3177,7 +3177,7 @@ impl MapdictObject for MapdictCarrier {
             } else {
                 let grown =
                     pyre_object::object_array::grow_instance_items_block(old, needed, old_cap);
-                pyre_object::gc_roots::pin_root(grown as PyObjectRef);
+                let _ = pyre_object::gc_roots::pin_root(grown as PyObjectRef);
                 pyre_object::gc_roots::shadow_stack_get(
                     pyre_object::gc_roots::shadow_stack_len() - 1,
                 ) as *mut pyre_object::object_array::ItemsBlock
@@ -3207,7 +3207,7 @@ impl MapdictObject for MapdictCarrier {
                 .len()
                 .max(pyre_object::object_array::items_block_capacity(old));
             let fresh = pyre_object::object_array::alloc_instance_items_block(&storage, cap);
-            pyre_object::gc_roots::pin_root(fresh as PyObjectRef);
+            let _ = pyre_object::gc_roots::pin_root(fresh as PyObjectRef);
             let fresh_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let owner = pyre_object::gc_roots::shadow_stack_get(self_slot);
             carrier = mapdict_carrier(owner);
@@ -4464,7 +4464,7 @@ unsafe fn switch_map_and_write_increase_storage1<O: MapdictObject>(
                 // never read back.  The sibling arm needs none: its
                 // `erase_unboxed` is the argument expression of the store.
                 let _unboxed_root = pyre_object::gc_roots::push_roots();
-                pyre_object::gc_roots::pin_root(unboxed);
+                let unboxed = pyre_object::gc_roots::pin_root(unboxed);
                 if unsafe { (*attr).storage_needed() } > obj._mapdict_storage_length() {
                     obj._set_mapdict_increase_storage1(attr, unboxed);
                     return;
@@ -4527,7 +4527,7 @@ unsafe fn reorder_and_add<O: MapdictObject>(
             for _ in 0..number_to_readd {
                 // current is a PlainAttribute
                 let w_self_value = unsafe { plain_direct_read(current, obj) };
-                pyre_object::gc_roots::pin_root(w_self_value);
+                let _ = pyre_object::gc_roots::pin_root(w_self_value);
                 stack.push((current, pyre_object::gc_roots::shadow_stack_len() - 1));
                 current = unsafe { (*current).as_plain() }.back;
                 obj._mapdict_pop_attribute(current);
@@ -4859,7 +4859,7 @@ pub unsafe fn instance_node_dict_values(obj: PyObjectRef) -> Vec<PyObjectRef> {
     while i < nodes.len() {
         let node = nodes[i];
         let w_value = plain_direct_read(node, &inst);
-        roots.pin_root(w_value);
+        let w_value = roots.pin_root(w_value);
         vals.push(w_value);
         i += 1;
     }
@@ -4897,7 +4897,7 @@ pub unsafe fn instance_node_dict_items(obj: PyObjectRef) -> Vec<(PyObjectRef, Py
         let name = &(*node).as_plain().name;
         let w_key = pyre_object::unicodeobject::box_str_constant(name);
         let w_value = plain_direct_read(node, &inst);
-        roots.pin_root(w_value);
+        let w_value = roots.pin_root(w_value);
         out.push((w_key, w_value));
         i += 1;
     }
@@ -4946,7 +4946,7 @@ pub unsafe fn mapdict_switch_to_object_strategy(w_dict: PyObjectRef) {
     // w_obj = self.unerase(w_dict.dstorage) — the backing instance.
     let w_obj =
         unsafe { mapdict_strategy_unerase(pyre_object::gc_roots::shadow_stack_get(dict_slot)) };
-    pyre_object::gc_roots::pin_root(w_obj);
+    let w_obj = pyre_object::gc_roots::pin_root(w_obj);
     // dict_w = strategy.unerase(strategy.get_empty_storage()); set_strategy(Object);
     // w_dict.dstorage = strategy.erase(dict_w).
     let dstorage = pyre_object::dictmultiobject::OBJECT_DICT_STRATEGY.get_empty_storage();
@@ -4973,7 +4973,7 @@ pub unsafe fn mapdict_switch_to_text_strategy(w_dict: PyObjectRef) {
     let dict_slot = pyre_object::gc_roots::pin_roots(&[w_dict]);
     let w_obj =
         unsafe { mapdict_strategy_unerase(pyre_object::gc_roots::shadow_stack_get(dict_slot)) };
-    pyre_object::gc_roots::pin_root(w_obj);
+    let w_obj = pyre_object::gc_roots::pin_root(w_obj);
     let dstorage = pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY.get_empty_storage();
     let dict = unsafe {
         &mut *(pyre_object::gc_roots::shadow_stack_get(dict_slot) as *mut pyre_object::W_DictObject)
@@ -5322,7 +5322,7 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
         while let Some(node) = curr {
             let w_key = pyre_object::unicodeobject::box_str_constant(&(*node).as_plain().name);
             let w_value = plain_direct_read(node, &inst);
-            roots.pin_root(w_value);
+            let w_value = roots.pin_root(w_value);
             items.push((w_key, w_value));
             curr = node_search((*node).as_plain().back, DICT);
         }
@@ -5422,7 +5422,7 @@ pub fn _obj_getdict(self_ref: PyObjectRef) -> PyObjectRef {
         let _roots = pyre_object::gc_roots::push_roots();
         let self_slot = pyre_object::gc_roots::pin_roots(&[self_ref]);
         let dict_slot = self_slot + 1;
-        pyre_object::gc_roots::pin_root(pyre_object::w_dict_new_with(
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_dict_new_with(
             &MAP_DICT_STRATEGY_REF,
             pyre_object::gc_roots::shadow_stack_get(self_slot) as *mut u8,
         ));

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -274,7 +274,7 @@ pub fn match_keys_value(subject: PyObjectRef, keys: PyObjectRef) -> Result<PyObj
     // so no kind that moves reaches `key_items`.
     let _roots = pyre_object::gc_roots::push_roots();
     let subject_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(subject);
+    let _ = pyre_object::gc_roots::pin_root(subject);
     // pyopcode.py:1797-1818 — a key repeated in the pattern is rejected
     // before it binds anything; track keys already looked up and raise on
     // a duplicate. Each key is looked up with `map.get(key, sentinel)`
@@ -284,11 +284,11 @@ pub fn match_keys_value(subject: PyObjectRef, keys: PyObjectRef) -> Result<PyObj
     // `object()` (match_keys `dummy = object()`), so a value present in the
     // subject can never be mistaken for the absent marker.
     let seen_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::w_set_new());
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_set_new());
     let sentinel_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::w_instance_new(crate::typedef::gettypeobject(
-        &pyre_object::pyobject::INSTANCE_TYPE,
-    )));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_instance_new(
+        crate::typedef::gettypeobject(&pyre_object::pyobject::INSTANCE_TYPE),
+    ));
     let values_base = pyre_object::gc_roots::shadow_stack_len();
     let mut value_count = 0usize;
     let mut all_match = true;
@@ -320,7 +320,7 @@ pub fn match_keys_value(subject: PyObjectRef, keys: PyObjectRef) -> Result<PyObj
             all_match = false;
             break;
         }
-        pyre_object::gc_roots::pin_root(w_value);
+        let _ = pyre_object::gc_roots::pin_root(w_value);
         value_count += 1;
     }
     Ok(if all_match {
@@ -357,9 +357,9 @@ pub fn match_class_value(
     // makes the collector walk it, so its name slots are forwarded too.
     let roots = pyre_object::gc_roots::push_roots();
     let subject_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(subject);
+    let _ = roots.pin_root(subject);
     let kwd_attrs_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(kwd_attrs);
+    let _ = roots.pin_root(kwd_attrs);
     let subject = || roots.get(subject_slot);
     let kwd_attrs = || roots.get(kwd_attrs_slot);
 
@@ -429,7 +429,7 @@ pub fn match_class_value(
                 match crate::baseobjspace::getattr_str(subject(), attr_name) {
                     Ok(v) => {
                         extracted.push(pyre_object::gc_roots::shadow_stack_len());
-                        roots.pin_root(v);
+                        let _ = roots.pin_root(v);
                     }
                     Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
                         return Ok(pyre_object::w_none());
@@ -473,7 +473,7 @@ pub fn match_class_value(
         match crate::baseobjspace::getattr_str(subject(), name) {
             Ok(v) => {
                 extracted.push(pyre_object::gc_roots::shadow_stack_len());
-                roots.pin_root(v);
+                let _ = roots.pin_root(v);
             }
             Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
                 return Ok(pyre_object::w_none());
@@ -582,8 +582,8 @@ pub fn set_add_value(set: PyObjectRef, value: PyObjectRef) -> Result<(), PyError
             // digest keys the store, so the element is hashed once.
             let _roots = pyre_object::gc_roots::push_roots();
             let sp = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(set);
-            pyre_object::gc_roots::pin_root(value);
+            let _ = pyre_object::gc_roots::pin_root(set);
+            let value = pyre_object::gc_roots::pin_root(value);
             let hash = crate::builtins::try_hash_value(value).map_err(|err| {
                 crate::baseobjspace::wrap_set_element_hash_error(
                     pyre_object::gc_roots::shadow_stack_get(sp + 1),
@@ -616,10 +616,10 @@ pub fn set_update_value(set: PyObjectRef, iterable: PyObjectRef) -> Result<(), P
             let items = crate::builtins::collect_iterable(iterable)?;
             let _roots = pyre_object::gc_roots::push_roots();
             let sp = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(set);
+            let set = pyre_object::gc_roots::pin_root(set);
             let item_base = sp + 1;
             for item in items {
-                pyre_object::gc_roots::pin_root(item);
+                let _ = pyre_object::gc_roots::pin_root(item);
             }
             let item_len = pyre_object::gc_roots::shadow_stack_len() - item_base;
             for i in 0..item_len {
@@ -666,9 +666,9 @@ pub fn map_add_value(
         // `set_add_value`.
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(dict);
-        pyre_object::gc_roots::pin_root(key);
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(dict);
+        let key = pyre_object::gc_roots::pin_root(key);
+        let _ = pyre_object::gc_roots::pin_root(value);
         let hash = crate::builtins::try_hash_value(key)
             .map_err(|err| crate::baseobjspace::wrap_dict_key_hash_error(key, err))?;
         let dict = pyre_object::gc_roots::shadow_stack_get(sp);
@@ -694,7 +694,7 @@ pub fn dict_update_value(dict: PyObjectRef, source: PyObjectRef) -> Result<(), P
             // its own loop for the same reason.
             let _roots = pyre_object::gc_roots::push_roots();
             let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(dict);
+            let _ = pyre_object::gc_roots::pin_root(dict);
             let entries = pyre_object::w_dict_items(source);
             let flat: Vec<PyObjectRef> = entries.iter().flat_map(|&(k, v)| [k, v]).collect();
             let pair_base = pyre_object::gc_roots::pin_roots(&flat);
@@ -731,11 +731,11 @@ pub fn dict_update_value(dict: PyObjectRef, source: PyObjectRef) -> Result<(), P
         // move them.
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(dict);
-        pyre_object::gc_roots::pin_root(source);
+        let dict = pyre_object::gc_roots::pin_root(dict);
+        let source = pyre_object::gc_roots::pin_root(source);
         let key_base = sp + 2;
         for key in keys {
-            pyre_object::gc_roots::pin_root(key);
+            let _ = pyre_object::gc_roots::pin_root(key);
         }
         let key_len = pyre_object::gc_roots::shadow_stack_len() - key_base;
         for i in 0..key_len {
@@ -744,7 +744,7 @@ pub fn dict_update_value(dict: PyObjectRef, source: PyObjectRef) -> Result<(), P
             let val = crate::baseobjspace::getitem(source, key)?;
             let _val_root = pyre_object::gc_roots::push_roots();
             let val_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(val);
+            let _ = pyre_object::gc_roots::pin_root(val);
             let key = pyre_object::gc_roots::shadow_stack_get(key_base + i);
             let hash = crate::builtins::try_hash_value(key)
                 .map_err(|err| crate::baseobjspace::wrap_dict_key_hash_error(key, err))?;
@@ -778,9 +778,9 @@ pub fn dict_merge_value(
     // above brackets the same walk.
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(dict);
-    pyre_object::gc_roots::pin_root(source);
-    pyre_object::gc_roots::pin_root(w_callable);
+    let _ = pyre_object::gc_roots::pin_root(dict);
+    let _ = pyre_object::gc_roots::pin_root(source);
+    let _ = pyre_object::gc_roots::pin_root(w_callable);
     let dict = || pyre_object::gc_roots::shadow_stack_get(root_base);
     let source = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
     let w_callable = || pyre_object::gc_roots::shadow_stack_get(root_base + 2);
@@ -820,8 +820,8 @@ pub fn dict_merge_value(
             let items = unsafe { pyre_object::w_dict_items(source()) };
             let items_base = pyre_object::gc_roots::shadow_stack_len();
             for &(k, v) in &items {
-                pyre_object::gc_roots::pin_root(k);
-                pyre_object::gc_roots::pin_root(v);
+                let _ = pyre_object::gc_roots::pin_root(k);
+                let _ = pyre_object::gc_roots::pin_root(v);
             }
             for index in 0..items.len() {
                 unsafe {
@@ -853,18 +853,18 @@ pub fn dict_merge_value(
         Err(e) => return Err(e),
     };
     let keys_method_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(keys_method);
+    let _ = pyre_object::gc_roots::pin_root(keys_method);
     let keys_obj = crate::call::call_function_impl_result(
         pyre_object::gc_roots::shadow_stack_get(keys_method_slot),
         &[],
     )?;
     let keys_obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(keys_obj);
+    let _ = pyre_object::gc_roots::pin_root(keys_obj);
     let keys =
         crate::builtins::collect_iterable(pyre_object::gc_roots::shadow_stack_get(keys_obj_slot))?;
     let keys_base = pyre_object::gc_roots::shadow_stack_len();
     for &key in &keys {
-        pyre_object::gc_roots::pin_root(key);
+        let _ = pyre_object::gc_roots::pin_root(key);
     }
     for index in 0..keys.len() {
         let key = || pyre_object::gc_roots::shadow_stack_get(keys_base + index);
@@ -874,7 +874,7 @@ pub fn dict_merge_value(
         // fixed-size.
         let _iteration_roots = pyre_object::gc_roots::push_roots();
         let val_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(val);
+        let _ = pyre_object::gc_roots::pin_root(val);
         if crate::baseobjspace::contains(dict(), key())? {
             let key_str = unsafe { crate::display::py_str_wtf8(key()) }?;
             return Err(crate::argument::raise_type_error(

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -927,7 +927,7 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
     // publish one object in every co_consts_w slot before returning PyCode.
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(obj);
+    let obj = pyre_object::gc_roots::pin_root(obj);
     // The shadow-stack root forwards the wrapper itself; only the raw walker
     // driven from this registry reaches its `co_consts_w` slots. Enrol an
     // off-GC wrapper before the fill loop, or a collection triggered by a
@@ -1363,7 +1363,7 @@ pub unsafe fn code_get_field(obj: PyObjectRef, name: &str) -> Result<PyObjectRef
         // borrow across the re-entrant boundary.
         let _roots = pyre_object::gc_roots::push_roots();
         let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(obj);
+        let _ = pyre_object::gc_roots::pin_root(obj);
         crate::warn::warn_deprecation("co_lnotab is deprecated, use co_lines instead.")?;
         let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         let code = unsafe { require_code(obj, name)? };

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3202,6 +3202,15 @@ impl PyFrame {
         frame.valuestackdepth = idx + 1;
     }
 
+    /// Reads and writes through the caller's `&mut self`, without the
+    /// [`Self::live_mut`] reload [`Self::push`] takes.
+    ///
+    /// That is sound because the opcode bodies keep `pyopcode.py`'s
+    /// `pop; op; push` order: every pop runs before the operation that can
+    /// collect, and the push that follows the operation reloads for itself.
+    /// A body that allocates between two pops breaks the premise — the second
+    /// pop would read the abandoned copy — and owes the reload at its own call
+    /// site.
     #[inline]
     pub fn pop(&mut self) -> PyObjectRef {
         if self.valuestackdepth <= self.stack_base() {

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -127,9 +127,9 @@ pub mod frame_locals_proxy {
             // one slot rather than growing the stack once per local.
             let roots = pyre_object::gc_roots::push_roots();
             let key_slot = roots.base();
-            roots.pin_root(key);
+            let _ = roots.pin_root(key);
             let candidate_slot = key_slot + 1;
-            roots.pin_root(pyre_object::PY_NULL);
+            let _ = roots.pin_root(pyre_object::PY_NULL);
             // The scan hashes the key first whether it was reached to write or
             // to read, so an unhashable key is a `TypeError` here rather than
             // whatever the extras dict would go on to say about it.
@@ -228,9 +228,9 @@ pub mod frame_locals_proxy {
             // first of them and read back from that root afterwards.
             let roots = pyre_object::gc_roots::push_roots();
             let key_slot = roots.base();
-            roots.pin_root(key);
+            let _ = roots.pin_root(key);
             let candidate_slot = key_slot + 1;
-            roots.pin_root(pyre_object::PY_NULL);
+            let _ = roots.pin_root(pyre_object::PY_NULL);
             // Hashing runs before the scan, so an unhashable key is a
             // `TypeError` even for a frame with no locals to compare against.
             let key_hash = crate::baseobjspace::hash_w_strict(roots.get(key_slot))?;
@@ -307,7 +307,7 @@ pub mod frame_locals_proxy {
                 ));
             }
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(w_frame);
+            let _ = pyre_object::gc_roots::pin_root(w_frame);
             let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let proxy = FrameLocalsProxy::allocate_stable(FrameLocalsProxy {
                 ob: PyObject {
@@ -329,14 +329,14 @@ pub mod frame_locals_proxy {
             // reload the key from its root between them.
             let roots = pyre_object::gc_roots::push_roots();
             let key_slot = roots.base();
-            roots.pin_root(key);
+            let _ = roots.pin_root(key);
             if let Some(value) = self.locals_plus_value(roots.get(key_slot))? {
                 return Ok(value);
             }
             let extra = self.frame().get_extra_locals();
             if !extra.is_null() {
                 let extra_slot = key_slot + 1;
-                roots.pin_root(extra);
+                let _ = roots.pin_root(extra);
                 if let Some(value) =
                     crate::baseobjspace::finditem(roots.get(extra_slot), roots.get(key_slot))?
                 {
@@ -369,7 +369,7 @@ pub mod frame_locals_proxy {
             // The extras lookup allocates, so reload the key from its root.
             let roots = pyre_object::gc_roots::push_roots();
             let key_slot = roots.base();
-            roots.pin_root(key);
+            let _ = roots.pin_root(key);
             if self.key_is_fast_local(roots.get(key_slot))? {
                 return Err(crate::PyError::value_error(
                     "cannot remove local variables from FrameLocalsProxy",
@@ -381,7 +381,7 @@ pub mod frame_locals_proxy {
                 return Err(crate::PyError::key_error_with_key(roots.get(key_slot)));
             }
             let extra_slot = key_slot + 1;
-            roots.pin_root(extra);
+            let _ = roots.pin_root(extra);
             crate::baseobjspace::delitem(roots.get(extra_slot), roots.get(key_slot))
         }
 
@@ -406,7 +406,7 @@ pub mod frame_locals_proxy {
         fn __contains__(&self, key: PyObjectRef) -> Result<bool, crate::PyError> {
             let roots = pyre_object::gc_roots::push_roots();
             let key_slot = roots.base();
-            roots.pin_root(key);
+            let _ = roots.pin_root(key);
             let mapping = self.mapping()?;
             crate::baseobjspace::contains(mapping, roots.get(key_slot))
         }
@@ -438,12 +438,12 @@ pub mod frame_locals_proxy {
             let items = unsafe { pyre_object::dictmultiobject::w_dict_items(mapping) };
             let pairs_base = pyre_object::gc_roots::shadow_stack_len();
             for &(key, value) in &items {
-                roots.pin_root(key);
-                roots.pin_root(value);
+                let _ = roots.pin_root(key);
+                let _ = roots.pin_root(value);
             }
             let out_base = pyre_object::gc_roots::shadow_stack_len();
             for index in 0..items.len() {
-                roots.pin_root(pyre_object::w_tuple_new(vec![
+                let _ = roots.pin_root(pyre_object::w_tuple_new(vec![
                     roots.get(pairs_base + index * 2),
                     roots.get(pairs_base + index * 2 + 1),
                 ]));
@@ -472,9 +472,9 @@ pub mod frame_locals_proxy {
             // mapping's Python, so read both back across each other.
             let roots = pyre_object::gc_roots::push_roots();
             let other_slot = roots.base();
-            roots.pin_root(other);
+            let _ = roots.pin_root(other);
             let incoming_slot = other_slot + 1;
-            roots.pin_root(unsafe { pyre_object::w_dict_new() });
+            let _ = roots.pin_root(unsafe { pyre_object::w_dict_new() });
             let result = crate::baseobjspace::call_method(
                 roots.get(incoming_slot),
                 "update",
@@ -492,8 +492,8 @@ pub mod frame_locals_proxy {
             let items =
                 unsafe { pyre_object::dictmultiobject::w_dict_items(roots.get(incoming_slot)) };
             for &(key, value) in &items {
-                roots.pin_root(key);
-                roots.pin_root(value);
+                let _ = roots.pin_root(key);
+                let _ = roots.pin_root(value);
             }
             for index in 0..items.len() {
                 self.setitem_value(
@@ -559,7 +559,7 @@ pub mod frame_locals_proxy {
                 };
             }
             let extra_slot = args_base + nargs;
-            roots.pin_root(extra);
+            let _ = roots.pin_root(extra);
             let call_args: Vec<PyObjectRef> =
                 (0..nargs).map(|i| roots.get(args_base + i)).collect();
             let result = crate::baseobjspace::call_method(roots.get(extra_slot), "pop", &call_args);
@@ -587,7 +587,7 @@ pub mod frame_locals_proxy {
         fn __eq__(&self, other: PyObjectRef) -> Result<bool, crate::PyError> {
             let roots = pyre_object::gc_roots::push_roots();
             let other_slot = roots.base();
-            roots.pin_root(other);
+            let _ = roots.pin_root(other);
             let mapping = self.mapping()?;
             crate::baseobjspace::eq_w(mapping, roots.get(other_slot))
         }
@@ -608,7 +608,7 @@ pub mod frame_locals_proxy {
 
     pub fn new(w_frame: PyObjectRef) -> PyObjectRef {
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_frame);
+        let _ = pyre_object::gc_roots::pin_root(w_frame);
         let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let w_type = type_object();
         unsafe { pyre_object::typeobject::w_type_set_flag_map_or_seq(w_type, b'M') };
@@ -1028,7 +1028,7 @@ impl FrameBox {
             // GC operation: a contended barrier is an entry safepoint, so an
             // unrooted fresh frame could otherwise be swept by another
             // collector between this allocation and the barrier below.
-            pyre_object::gc_roots::pin_root(raw as pyre_object::PyObjectRef);
+            let _ = pyre_object::gc_roots::pin_root(raw as pyre_object::PyObjectRef);
             // Read back through the bracket's own cell rather than
             // `shadow_stack_get`, which resolves the thread-local per slot.
             frame.ob_header.w_class = frame_root.get(inputs);
@@ -1188,17 +1188,17 @@ impl FrameBox {
         let _origin_roots = pyre_object::gc_roots::push_roots();
         let name_slot = name.map(|name| {
             let slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(name);
+            let _ = pyre_object::gc_roots::pin_root(name);
             slot
         });
         let qualname_slot = qualname.map(|qualname| {
             let slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(qualname);
+            let _ = pyre_object::gc_roots::pin_root(qualname);
             slot
         });
         let coroutine_origin_slot = if is_coroutine {
             let origin = capture_coroutine_origin(self.execution_context);
-            pyre_object::gc_roots::pin_root(origin);
+            let _ = pyre_object::gc_roots::pin_root(origin);
             Some(pyre_object::gc_roots::shadow_stack_len() - 1)
         } else {
             None
@@ -1218,7 +1218,7 @@ impl FrameBox {
         // locals slot (the latter also covers the std::alloc fallback frame)
         // across that allocation.
         let _frame_roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(frame_ptr as pyre_object::PyObjectRef);
+        let _ = pyre_object::gc_roots::pin_root(frame_ptr as pyre_object::PyObjectRef);
         let _root = FrameLocalsRoot::new(frame_ptr);
         // generator.py `self.pycode = frame.pycode`: preserve the exact
         // code object independently of the frame, which is cleared when the
@@ -1241,7 +1241,7 @@ impl FrameBox {
             pyre_object::generator::w_generator_new(frame_ptr as *mut u8, pycode)
         };
         let _generator_roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(generator);
+        let generator = pyre_object::gc_roots::pin_root(generator);
         if let Some(slot) = coroutine_origin_slot {
             unsafe {
                 pyre_object::generator::w_coroutine_set_origin(
@@ -1310,19 +1310,21 @@ fn capture_coroutine_origin(ec: *const PyExecutionContext) -> PyObjectRef {
         crate::executioncontext::force_frame(frame);
         let w_code = unsafe { (*anchor.live()).fget_f_code() };
         let filename_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(unsafe { crate::pycode::w_code_filename_obj(w_code) });
+        let _ =
+            pyre_object::gc_roots::pin_root(unsafe { crate::pycode::w_code_filename_obj(w_code) });
         let lineno_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_int_new(
-            unsafe { (*anchor.live()).fget_f_lineno() } as i64
-        ));
+        let _ =
+            pyre_object::gc_roots::pin_root(w_int_new(
+                unsafe { (*anchor.live()).fget_f_lineno() } as i64
+            ));
         let funcname_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(unsafe { crate::pycode::w_code_name_obj(w_code) });
+        let _ = pyre_object::gc_roots::pin_root(unsafe { crate::pycode::w_code_name_obj(w_code) });
         let summary = w_tuple_new(vec![
             pyre_object::gc_roots::shadow_stack_get(filename_slot),
             pyre_object::gc_roots::shadow_stack_get(lineno_slot),
             pyre_object::gc_roots::shadow_stack_get(funcname_slot),
         ]);
-        pyre_object::gc_roots::pin_root(summary);
+        let _ = pyre_object::gc_roots::pin_root(summary);
         summary_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
         frame = crate::executioncontext::ExecutionContext::getnextframe_nohidden(anchor.live());
     }
@@ -2633,7 +2635,7 @@ impl PyFrame {
         // observable instead of faulting.
         let roots = pyre_object::gc_roots::push_roots();
         let locals_slot = roots.base();
-        roots.pin_root(unsafe { pyre_object::w_dict_new() });
+        let _ = roots.pin_root(unsafe { pyre_object::w_dict_new() });
         let frame = unsafe { &mut *frame_anchor.live() };
         frame.getorcreate_debug_data(-1).w_locals = roots.get(locals_slot);
         roots.get(locals_slot)
@@ -2857,7 +2859,7 @@ impl PyFrame {
         // the payload has been installed and then reload its forwarded value.
         let roots = pyre_object::gc_roots::push_roots();
         let slot = roots.base();
-        roots.pin_root(unsafe { pyre_object::w_dict_new() });
+        let _ = roots.pin_root(unsafe { pyre_object::w_dict_new() });
         let debug = self.getorcreate_debug_data(-1);
         debug.w_extra_locals = roots.get(slot);
         roots.get(slot)
@@ -2918,7 +2920,7 @@ impl PyFrame {
     pub fn frame_locals_proxy_snapshot(&mut self) -> Result<PyObjectRef, crate::PyError> {
         let roots = pyre_object::gc_roots::push_roots();
         let snapshot_slot = pyre_object::gc_roots::shadow_stack_len();
-        roots.pin_root(unsafe { pyre_object::w_dict_new() });
+        let _ = roots.pin_root(unsafe { pyre_object::w_dict_new() });
 
         // `framelocalsproxy_getitem` gives a live fast local priority over an
         // equal key in `f_extra_locals`.  Copy extras first, then overlay the
@@ -2926,7 +2928,7 @@ impl PyFrame {
         let extra = self.get_extra_locals();
         if !extra.is_null() {
             let extra_slot = pyre_object::gc_roots::shadow_stack_len();
-            roots.pin_root(extra);
+            let _ = roots.pin_root(extra);
             crate::opcode_ops::dict_update_value(roots.get(snapshot_slot), roots.get(extra_slot))?;
         }
 
@@ -2950,7 +2952,7 @@ impl PyFrame {
                 // `value`; keep it in a shadow-stack slot and reload it for
                 // the store.
                 let value_slot = pyre_object::gc_roots::shadow_stack_len();
-                roots.pin_root(value);
+                let _ = roots.pin_root(value);
                 setitem_str_object(roots.get(snapshot_slot), name, roots.get(value_slot))
             };
 
@@ -3016,7 +3018,7 @@ impl PyFrame {
         // Root the fresh globals across the `__name__` store; the frame
         // construction below roots them again for its own span.
         let _root = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_globals);
+        let w_globals = pyre_object::gc_roots::pin_root(w_globals);
         unsafe {
             pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                 w_globals,
@@ -3043,7 +3045,7 @@ impl PyFrame {
         // (and `w_code_set_w_globals` into the code), both of which root it
         // once they return.
         let _root = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_globals);
+        let w_globals = pyre_object::gc_roots::pin_root(w_globals);
         let code_ptr = Box::into_raw(Box::new(code));
         let w_code = crate::w_code_new(code_ptr as *const ());
         unsafe {
@@ -3920,7 +3922,7 @@ impl PyFrame {
                 let frame_anchor = crate::eval::FrameAnchor::new(self);
                 let roots = pyre_object::gc_roots::push_roots();
                 let gen_slot = roots.base();
-                roots.pin_root(w_gen);
+                let _ = roots.pin_root(w_gen);
                 crate::baseobjspace::generator_finalize(roots.get(gen_slot))?;
                 // CPython 3.14 `frame_clear_impl` finishes a never-started
                 // generator after `_PyGen_Finalize`, then clears the owned
@@ -4302,7 +4304,7 @@ impl PyFrame {
         }
         let locals_roots = pyre_object::gc_roots::push_roots();
         let locals_slot = locals_roots.base();
-        locals_roots.pin_root(w_locals);
+        let _ = locals_roots.pin_root(w_locals);
         let code_ptr = unsafe { pyframe_get_pycode(&*frame_anchor.live()) };
         let code = unsafe { &*code_ptr };
         let numlocals = code.varnames.len();
@@ -4407,7 +4409,7 @@ impl PyFrame {
         let w_locals = unsafe { (&mut *frame_anchor.live()).get_or_create_w_locals() };
         let locals_roots = pyre_object::gc_roots::push_roots();
         let locals_slot = locals_roots.base();
-        locals_roots.pin_root(w_locals);
+        let _ = locals_roots.pin_root(w_locals);
         let code_ptr = unsafe { pyframe_get_pycode(&*frame_anchor.live()) };
         let code = unsafe { &*code_ptr };
         let varnames = &code.varnames;
@@ -4622,11 +4624,11 @@ impl PyFrame {
         // forwarded, so never carry the original slice across that call.
         let _roots = pyre_object::gc_roots::push_roots();
         let root_base = _roots.base();
-        _roots.pin_root(code as PyObjectRef);
-        _roots.pin_root(w_globals);
-        _roots.pin_root(closure);
+        let _ = _roots.pin_root(code as PyObjectRef);
+        let _ = _roots.pin_root(w_globals);
+        let _ = _roots.pin_root(closure);
         for &arg in args {
-            _roots.pin_root(arg);
+            let _ = _roots.pin_root(arg);
         }
         let w_builtin = crate::baseobjspace::frame_builtin_obj_checked(
             _roots.get(root_base + 1),
@@ -4665,11 +4667,11 @@ impl PyFrame {
     ) -> Self {
         let _roots = pyre_object::gc_roots::push_roots();
         let root_base = _roots.base();
-        _roots.pin_root(code as PyObjectRef);
-        _roots.pin_root(w_globals);
-        _roots.pin_root(closure);
+        let _ = _roots.pin_root(code as PyObjectRef);
+        let _ = _roots.pin_root(w_globals);
+        let _ = _roots.pin_root(closure);
         for &arg in args {
-            _roots.pin_root(arg);
+            let _ = _roots.pin_root(arg);
         }
         let w_builtin =
             crate::baseobjspace::frame_builtin_obj(_roots.get(root_base + 1), execution_context);
@@ -4731,7 +4733,7 @@ impl PyFrame {
         // or any other GC operation can park this free-threaded mutator. It
         // joins the bracket the call inputs already opened: its lifetime is
         // the rest of this function body, so it needs no owner of its own.
-        pyre_object::gc_roots::pin_root(locals_cells_stack_w as PyObjectRef);
+        let _ = pyre_object::gc_roots::pin_root(locals_cells_stack_w as PyObjectRef);
 
         {
             // Populate the freshly-allocated array via its mutable slice.
@@ -5118,7 +5120,7 @@ pub fn createframe_obj(
         // initialization allocations, so expose the frame object alongside
         // the separately registered locals-array field.
         let _frame_roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(frame.as_mut_ptr() as pyre_object::PyObjectRef);
+        let _ = pyre_object::gc_roots::pin_root(frame.as_mut_ptr() as pyre_object::PyObjectRef);
         let _root = FrameLocalsRoot::new(frame.as_mut_ptr());
         frame.initialize_frame_scopes(outer_ref, code)?;
     }
@@ -5143,9 +5145,9 @@ fn finditem_str_object(
     // `delitem` siblings do.
     let roots = pyre_object::gc_roots::push_roots();
     let object_slot = roots.base();
-    roots.pin_root(w_obj);
+    let _ = roots.pin_root(w_obj);
     let key_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(unsafe { pyre_object::w_str_new(name) });
+    let _ = roots.pin_root(unsafe { pyre_object::w_str_new(name) });
     match crate::baseobjspace::getitem(roots.get(object_slot), roots.get(key_slot)) {
         Ok(v) if !v.is_null() => Ok(Some(v)),
         Ok(_) => Ok(None),
@@ -5164,10 +5166,10 @@ fn setitem_str_object(
 ) -> Result<(), crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let object_slot = roots.base();
-    roots.pin_root(w_obj);
-    roots.pin_root(value);
+    let _ = roots.pin_root(w_obj);
+    let _ = roots.pin_root(value);
     let key_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(unsafe { pyre_object::w_str_new(name) });
+    let _ = roots.pin_root(unsafe { pyre_object::w_str_new(name) });
     crate::baseobjspace::setitem(
         roots.get(object_slot),
         roots.get(key_slot),
@@ -5181,9 +5183,9 @@ fn setitem_str_object(
 fn delitem_str_object(w_obj: PyObjectRef, name: &str) -> Result<(), crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let object_slot = roots.base();
-    roots.pin_root(w_obj);
+    let _ = roots.pin_root(w_obj);
     let key_slot = pyre_object::gc_roots::shadow_stack_len();
-    roots.pin_root(unsafe { pyre_object::w_str_new(name) });
+    let _ = roots.pin_root(unsafe { pyre_object::w_str_new(name) });
     match crate::baseobjspace::delitem(roots.get(object_slot), roots.get(key_slot)) {
         Ok(_) => Ok(()),
         Err(e) if e.kind == crate::PyErrorKind::KeyError => Ok(()),
@@ -5233,9 +5235,9 @@ pub extern "C" fn jit_locals_dict_setitem_local(
 ) -> i64 {
     let _roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(dict as PyObjectRef);
+    let _ = pyre_object::gc_roots::pin_root(dict as PyObjectRef);
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(value as PyObjectRef);
+    let _ = pyre_object::gc_roots::pin_root(value as PyObjectRef);
     let code = unsafe { &*(code as usize as *const CodeObject) };
     let name: &str = &code.varnames[index as usize];
     unsafe {
@@ -5269,11 +5271,11 @@ pub extern "C" fn jit_locals_dict_setitem_local(
 pub extern "C" fn jit_locals_dict_delitem_local(dict: i64, code: i64, index: i64) -> i64 {
     let _roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(dict as PyObjectRef);
+    let _ = pyre_object::gc_roots::pin_root(dict as PyObjectRef);
     let code = unsafe { &*(code as usize as *const CodeObject) };
     let name: &str = &code.varnames[index as usize];
     let key_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(unsafe { pyre_object::w_str_new(name) });
+    let _ = pyre_object::gc_roots::pin_root(unsafe { pyre_object::w_str_new(name) });
     let deleted = unsafe {
         pyre_object::dictmultiobject::w_dict_delitem_checked(
             pyre_object::gc_roots::shadow_stack_get(dict_slot),
@@ -5303,9 +5305,9 @@ pub extern "C" fn jit_locals_dict_delitem_local(dict: i64, code: i64, index: i64
 pub extern "C" fn jit_locals_dict_snapshot(w_locals: i64) -> i64 {
     let _roots = pyre_object::gc_roots::push_roots();
     let locals_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_locals as PyObjectRef);
+    let _ = pyre_object::gc_roots::pin_root(w_locals as PyObjectRef);
     let snapshot_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(unsafe { pyre_object::w_dict_new() });
+    let _ = pyre_object::gc_roots::pin_root(unsafe { pyre_object::w_dict_new() });
     // `dict_update_value` walks a mapping's `keys()`, so both sides are
     // reloaded across it as well as across the `w_dict_new` above.
     match crate::opcode_ops::dict_update_value(

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -177,7 +177,7 @@ pub fn w_pytraceback_new(
         // The fresh block is a root before `get_instantiate` below can enter
         // an allocation of its own, matching `FrameBox::new`'s pin of its own
         // result.  The block is non-moving, so `raw` stays the address.
-        pyre_object::gc_roots::pin_root(raw as PyObjectRef);
+        let _ = pyre_object::gc_roots::pin_root(raw as PyObjectRef);
     }
 
     // Every input is read back through the bracket's own cell rather than

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -54,7 +54,7 @@ fn handle(which: usize) -> PyObjectRef {
     let _roots = pyre_object::gc_roots::push_roots();
     let save_point = pyre_object::gc_roots::shadow_stack_len();
     let w_app_globals = pyre_object::dictmultiobject::w_module_dict_new();
-    pyre_object::gc_roots::pin_root(w_app_globals);
+    let _ = pyre_object::gc_roots::pin_root(w_app_globals);
     crate::importing::appleveldef_install(
         pyre_object::gc_roots::shadow_stack_get(save_point),
         include_str!("reduce_protocol_app.py"),
@@ -115,23 +115,23 @@ pub fn object_getstate_default(w_obj: PyObjectRef) -> PyResult {
     // locals across those points.
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let current_obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
     let w_objdict = crate::baseobjspace::findattr(current_obj(), "__dict__");
     let mut state_slot = None;
     if let Some(d) = w_objdict {
         let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(d);
+        let _ = pyre_object::gc_roots::pin_root(d);
         if crate::baseobjspace::len_w(pyre_object::gc_roots::shadow_stack_get(dict_slot))? > 0 {
             let copy_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+            let _ = pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
             let items = unsafe {
                 pyre_object::w_dict_items(pyre_object::gc_roots::shadow_stack_get(dict_slot))
             };
             let items_slot = pyre_object::gc_roots::shadow_stack_len();
             for (k, v) in &items {
-                pyre_object::gc_roots::pin_root(*k);
-                pyre_object::gc_roots::pin_root(*v);
+                let _ = pyre_object::gc_roots::pin_root(*k);
+                let _ = pyre_object::gc_roots::pin_root(*v);
             }
             let mut count = 0usize;
             for index in 0..items.len() {
@@ -170,7 +170,7 @@ pub fn getnewargs(w_obj: PyObjectRef) -> Result<(bool, PyObjectRef, PyObjectRef)
     // this frame.  Read it back from the shadow stack for every later use.
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let current_obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
     let w_type = crate::typedef::r#type(current_obj())
         .ok_or_else(|| PyError::type_error("cannot determine type for __getnewargs__"))?;
@@ -252,12 +252,12 @@ pub fn descr_reduce(w_obj: PyObjectRef) -> PyResult {
 /// base type.
 pub fn set_reduce(w_obj: PyObjectRef) -> PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let w_obj = pyre_object::gc_roots::pin_root(w_obj);
     let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     let w_type = crate::typedef::r#type(w_obj)
         .ok_or_else(|| PyError::type_error("cannot determine type for __reduce__"))?;
-    pyre_object::gc_roots::pin_root(w_type.as_ptr());
+    let _ = pyre_object::gc_roots::pin_root(w_type.as_ptr());
     let type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     // PySequence_List(self): no GC between reading the items and `w_list_new`
@@ -267,7 +267,7 @@ pub fn set_reduce(w_obj: PyObjectRef) -> PyResult {
     };
     let w_list = pyre_object::listobject::w_list_new(items);
     let w_args = pyre_object::w_tuple_new(vec![w_list]);
-    pyre_object::gc_roots::pin_root(w_args);
+    let _ = pyre_object::gc_roots::pin_root(w_args);
     let args_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     let w_state = object_getstate_default(pyre_object::gc_roots::shadow_stack_get(obj_slot))?;
@@ -285,10 +285,10 @@ fn reduce_1(w_obj: PyObjectRef, proto: i64) -> PyResult {
     // argument array before it.
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let w_proto = pyre_object::w_int_new(proto);
     let proto_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_proto);
+    let _ = pyre_object::gc_roots::pin_root(w_proto);
     crate::call::call_function_impl_result(
         handle(REDUCE_1),
         &[
@@ -309,12 +309,12 @@ fn reduce_2(
     // three already-copied references.
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_obj);
-    pyre_object::gc_roots::pin_root(w_args);
-    pyre_object::gc_roots::pin_root(w_kwargs);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_args);
+    let _ = pyre_object::gc_roots::pin_root(w_kwargs);
     let w_proto = pyre_object::w_int_new(proto);
     let proto_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_proto);
+    let _ = pyre_object::gc_roots::pin_root(w_proto);
     crate::call::call_function_impl_result(
         handle(REDUCE_2),
         &[
@@ -334,21 +334,21 @@ pub fn descr_reduce_ex(w_obj: PyObjectRef, proto: i64) -> PyResult {
     // out of a Rust local.
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_obj);
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
     let current_obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
     // Honour a user `__reduce__` override:
     // `type(obj).__reduce__ is not object.__reduce__`.
     let w_reduce = crate::baseobjspace::findattr(current_obj(), "__reduce__");
     if let Some(w_reduce) = w_reduce {
         let reduce_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_reduce);
+        let _ = pyre_object::gc_roots::pin_root(w_reduce);
         let w_type = crate::typedef::r#type(current_obj())
             .ok_or_else(|| PyError::type_error("cannot determine type for __reduce_ex__"))?;
         let w_cls_reduce = crate::baseobjspace::getattr_str(w_type.as_ptr(), "__reduce__")?;
         // Both sides of the identity test have to survive the second lookup,
         // or a collection between them reports a spurious override.
         let cls_reduce_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_cls_reduce);
+        let _ = pyre_object::gc_roots::pin_root(w_cls_reduce);
         let w_obj_reduce =
             crate::baseobjspace::getattr_str(crate::typedef::w_object(), "__reduce__")?;
         let w_cls_reduce = pyre_object::gc_roots::shadow_stack_get(cls_reduce_slot);
@@ -392,8 +392,8 @@ pub fn descr_reduce_ex(w_obj: PyObjectRef, proto: i64) -> PyResult {
         }
         let (hasargs, w_args, w_kwargs) = getnewargs(current_obj())?;
         let args_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_args);
-        pyre_object::gc_roots::pin_root(w_kwargs);
+        let _ = pyre_object::gc_roots::pin_root(w_args);
+        let _ = pyre_object::gc_roots::pin_root(w_kwargs);
         // objectobject.py:276 / `_PyObject_GetState(required)`: a type whose
         // instances carry C-level state that `__dict__`/`__slots__` cannot
         // reconstruct, and that supplies no `__getnewargs__`, cannot be

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -248,9 +248,9 @@ fn call_builtin_with_args(callable: i64, args: &[i64]) -> i64 {
     // frame `call_builtin_code_positional` builds for the interpreter entry.
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = _roots.base();
-    _roots.pin_root(code);
+    let _ = _roots.pin_root(code);
     for &arg in args {
-        _roots.pin_root(arg as PyObjectRef);
+        let _ = _roots.pin_root(arg as PyObjectRef);
     }
     let mut rooted = [PY_NULL; MAX_KNOWN_BUILTIN_ARGS];
     for (index, slot) in rooted[..args.len()].iter_mut().enumerate() {
@@ -597,10 +597,10 @@ pub fn build_map_from_refs(items: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     let _roots = pyre_object::gc_roots::push_roots();
     let items_base = pyre_object::gc_roots::shadow_stack_len();
     for &item in items {
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
     }
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_dict_new());
+    let _ = pyre_object::gc_roots::pin_root(w_dict_new());
     let dict = || pyre_object::gc_roots::shadow_stack_get(dict_slot);
     for index in (0..items.len() - items.len() % 2).step_by(2) {
         let key = pyre_object::gc_roots::shadow_stack_get(items_base + index);
@@ -739,7 +739,7 @@ pub fn store_slice_values(
     roots.publish(&[obj, value]);
     roots.normalize(obj_slot, 2);
     let slice = pyre_object::w_slice_new(start, stop, pyre_object::w_none());
-    roots.pin_root(slice);
+    let slice = roots.pin_root(slice);
     crate::baseobjspace::setitem(roots.get(obj_slot), slice, roots.get(value_slot))?;
     Ok(())
 }
@@ -799,7 +799,7 @@ pub fn binary_slice_values(
             let mut fetched = 0usize;
             for i in s..e {
                 if let Some(v) = pyre_object::w_list_getitem(roots.get(obj_slot), i as i64) {
-                    roots.pin_root(v);
+                    let _ = roots.pin_root(v);
                     fetched += 1;
                 }
             }
@@ -859,7 +859,7 @@ pub fn binary_slice_values(
             let mut fetched = 0usize;
             for i in s..e {
                 if let Some(v) = pyre_object::w_tuple_getitem(obj, i as i64) {
-                    roots.pin_root(v);
+                    let _ = roots.pin_root(v);
                     fetched += 1;
                 }
             }
@@ -871,7 +871,7 @@ pub fn binary_slice_values(
         let slice_obj = pyre_object::sliceobject::w_slice_new(start, stop, pyre_object::w_none());
         // The receiver is live across that allocation, and the fresh slice has
         // no heap edge until `getitem` stores it.
-        roots.pin_root(slice_obj);
+        let slice_obj = roots.pin_root(slice_obj);
         crate::baseobjspace::getitem(roots.get(obj_slot), slice_obj)
     }
 }
@@ -1359,11 +1359,11 @@ pub fn unpack_sequence_exact(seq: PyObjectRef, count: usize) -> Result<Vec<PyObj
         // iterator loop below does.
         let _roots = pyre_object::gc_roots::push_roots();
         let seq_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(seq);
+        let _ = pyre_object::gc_roots::pin_root(seq);
         let seq = || pyre_object::gc_roots::shadow_stack_get(seq_slot);
         let items_base = pyre_object::gc_roots::shadow_stack_len();
         for idx in 0..count {
-            pyre_object::gc_roots::pin_root(sequence_getitem(seq(), idx)?);
+            let _ = pyre_object::gc_roots::pin_root(sequence_getitem(seq(), idx)?);
         }
         return Ok((0..count)
             .map(|index| pyre_object::gc_roots::shadow_stack_get(items_base + index))
@@ -1392,8 +1392,8 @@ pub fn unpack_sequence_exact(seq: PyObjectRef, count: usize) -> Result<Vec<PyObj
     // does for the same loop.
     let _roots = pyre_object::gc_roots::push_roots();
     let seq_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(seq);
-    pyre_object::gc_roots::pin_root(iter);
+    let _ = pyre_object::gc_roots::pin_root(seq);
+    let _ = pyre_object::gc_roots::pin_root(iter);
     let seq = || pyre_object::gc_roots::shadow_stack_get(seq_slot);
     let iter = || pyre_object::gc_roots::shadow_stack_get(seq_slot + 1);
     let root_base = seq_slot + 1;
@@ -1420,7 +1420,7 @@ pub fn unpack_sequence_exact(seq: PyObjectRef, count: usize) -> Result<Vec<PyObj
                         "too many values to unpack (expected {count})"
                     )));
                 }
-                pyre_object::gc_roots::pin_root(val);
+                let _ = pyre_object::gc_roots::pin_root(val);
                 pulled += 1;
             }
             Err(e) if e.matches_stop_iteration() => break,
@@ -1458,7 +1458,7 @@ pub fn unpack_ex_slots(
     // slots, as `unpack_sequence_exact` does for the same split.
     let _roots = pyre_object::gc_roots::push_roots();
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(value);
+    let _ = pyre_object::gc_roots::pin_root(value);
     let value = || pyre_object::gc_roots::shadow_stack_get(value_slot);
     let elements: Vec<PyObjectRef> = unsafe {
         if is_tuple(value()) {
@@ -1492,13 +1492,13 @@ pub fn unpack_ex_slots(
     }
     let elements_base = pyre_object::gc_roots::shadow_stack_len();
     for &item in &elements {
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
     }
     let element = |index: usize| pyre_object::gc_roots::shadow_stack_get(elements_base + index);
     let middle_len = elements.len() - min_expected;
     let middle: Vec<PyObjectRef> = (before..before + middle_len).map(element).collect();
     let middle_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_list_new(middle));
+    let _ = pyre_object::gc_roots::pin_root(w_list_new(middle));
     // Head and tail are read back only after the middle list exists, so the
     // returned slots all carry post-move words.
     let mut slots = Vec::with_capacity(before + 1 + after);

--- a/pyre/pyre-interpreter/src/sliceobject.rs
+++ b/pyre/pyre-interpreter/src/sliceobject.rs
@@ -151,9 +151,9 @@ pub(crate) fn slice_unpack(
 ) -> Result<(i64, i64, i64), crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_start);
-    pyre_object::gc_roots::pin_root(w_stop);
-    pyre_object::gc_roots::pin_root(w_step);
+    let _ = pyre_object::gc_roots::pin_root(w_start);
+    let _ = pyre_object::gc_roots::pin_root(w_stop);
+    let _ = pyre_object::gc_roots::pin_root(w_step);
     let (start_slot, stop_slot, step_slot) = (base, base + 1, base + 2);
     let step = if unsafe { is_none(pyre_object::gc_roots::shadow_stack_get(step_slot)) } {
         1

--- a/pyre/pyre-interpreter/src/syntax_warnings.rs
+++ b/pyre/pyre-interpreter/src/syntax_warnings.rs
@@ -250,11 +250,11 @@ fn warn_invalid_escape_sequence(
     // call rather than held in a Rust local across the next allocation.
     let _roots = pyre_object::gc_roots::push_roots();
     let category_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(category);
+    let _ = pyre_object::gc_roots::pin_root(category);
     let message_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::w_str_new(&warning_message(escape)));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(&warning_message(escape)));
     let filename_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::w_str_new(filename));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(filename));
 
     crate::module::_warnings::do_warn_explicit(
         pyre_object::gc_roots::shadow_stack_get(category_slot),

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -618,7 +618,7 @@ pub fn list_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             // between iterator steps.
             let _roots = pyre_object::gc_roots::push_roots();
             let root_base = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(list);
+            let list = pyre_object::gc_roots::pin_root(list);
             let items = pyre_object::w_set_items(other);
             pyre_object::gc_roots::pin_roots(&items);
             pyre_object::listobject::w_list_resize_for_extend(
@@ -640,13 +640,13 @@ pub fn list_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             // exception from a later `next()` does not roll back the prefix.
             let _roots = pyre_object::gc_roots::push_roots();
             let root_base = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(list);
-            pyre_object::gc_roots::pin_root(other);
+            let _ = pyre_object::gc_roots::pin_root(list);
+            let _ = pyre_object::gc_roots::pin_root(other);
             // CPython 3.14 `list_extend_iter_lock_held` obtains the iterator
             // before asking the original iterable for its length hint.
             let iterator =
                 crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(root_base + 1))?;
-            pyre_object::gc_roots::pin_root(iterator);
+            let _ = pyre_object::gc_roots::pin_root(iterator);
             // listobject.py _extend_from_iterable — consult the length
             // hint before iterating.  A `__length_hint__` returning a negative
             // value raises ValueError, and one exceeding a C ssize_t raises
@@ -688,7 +688,7 @@ pub fn list_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
                 };
                 let _item_roots = pyre_object::gc_roots::push_roots();
                 let item_slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(item);
+                let _ = pyre_object::gc_roots::pin_root(item);
                 pyre_object::listobject::w_list_append_preallocated(
                     pyre_object::gc_roots::shadow_stack_get(root_base),
                     pyre_object::gc_roots::shadow_stack_get(item_slot),
@@ -830,8 +830,8 @@ pub fn list_method_sort(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     // two roots adjacent so one base covers both.
     let _roots = pyre_object::gc_roots::push_roots();
     let list_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args[0]);
-    pyre_object::gc_roots::pin_root(
+    let _ = pyre_object::gc_roots::pin_root(args[0]);
+    let _ = pyre_object::gc_roots::pin_root(
         crate::builtins::kwarg_get(kwargs, "key").unwrap_or_else(w_none),
     );
 
@@ -875,8 +875,8 @@ pub fn list_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     // reload after the coercion.
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(list);
-    pyre_object::gc_roots::pin_root(value);
+    let _ = pyre_object::gc_roots::pin_root(list);
+    let _ = pyre_object::gc_roots::pin_root(value);
     let (raw_start, raw_stop) = crate::sliceobject::index_bounds_not_none(w_start, w_stop)?;
     let list = pyre_object::gc_roots::shadow_stack_get(sp);
     let value = pyre_object::gc_roots::shadow_stack_get(sp + 1);
@@ -1666,9 +1666,9 @@ fn format_render(
     let _roots = pyre_object::gc_roots::push_roots();
     let positional_base = pyre_object::gc_roots::pin_roots(positional);
     let kwargs_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(kwargs_dict.unwrap_or(pyre_object::PY_NULL));
+    let _ = pyre_object::gc_roots::pin_root(kwargs_dict.unwrap_or(pyre_object::PY_NULL));
     let mapping_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(mapping.unwrap_or(pyre_object::PY_NULL));
+    let _ = pyre_object::gc_roots::pin_root(mapping.unwrap_or(pyre_object::PY_NULL));
     let lookup_kwarg = |name: &str| -> Result<Option<PyObjectRef>, crate::PyError> {
         if mapping.is_some() {
             // `newformat.format_method(... w_mapping, True)` resolves
@@ -1813,7 +1813,7 @@ fn format_render(
             // into its own roots) and read `val` back once it returns.
             let inner = pyre_object::gc_roots::push_roots();
             let val_slot = inner.base();
-            inner.pin_root(val);
+            let mut val = inner.pin_root(val);
             let reloaded: Vec<PyObjectRef> = (0..positional.len())
                 .map(|i| pyre_object::gc_roots::shadow_stack_get(positional_base + i))
                 .collect();
@@ -6426,8 +6426,8 @@ unsafe fn set_lookup_checked(
 ) -> Result<bool, crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(item);
-    pyre_object::gc_roots::pin_root(set);
+    let _ = pyre_object::gc_roots::pin_root(item);
+    let set = pyre_object::gc_roots::pin_root(set);
     let hash = crate::builtins::try_hash_value(pyre_object::gc_roots::shadow_stack_get(sp))
         .map_err(|err| {
             crate::baseobjspace::wrap_set_element_hash_error(
@@ -6588,7 +6588,7 @@ pub fn dict_view_snapshot(view: PyObjectRef) -> Vec<PyObjectRef> {
                 let k = pyre_object::gc_roots::shadow_stack_get(pair_base + i * 2);
                 let v = pyre_object::gc_roots::shadow_stack_get(pair_base + i * 2 + 1);
                 let tuple_slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(w_tuple_new(vec![k, v]));
+                let _ = pyre_object::gc_roots::pin_root(w_tuple_new(vec![k, v]));
                 built.push(pyre_object::gc_roots::shadow_stack_get(tuple_slot));
             }
             built
@@ -6631,8 +6631,8 @@ pub(crate) fn dict_update1(w_dict: PyObjectRef, w_data: PyObjectRef) -> Result<(
     // frame still holds its raw pointer.
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(dict);
-    pyre_object::gc_roots::pin_root(w_data);
+    let _ = pyre_object::gc_roots::pin_root(dict);
+    let _ = pyre_object::gc_roots::pin_root(w_data);
     let dict = || pyre_object::gc_roots::shadow_stack_get(root_base);
     let data = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
     unsafe {
@@ -6683,8 +6683,8 @@ pub(crate) fn dict_update1(w_dict: PyObjectRef, w_data: PyObjectRef) -> Result<(
                     };
                     let _iteration_roots = pyre_object::gc_roots::push_roots();
                     let iteration_roots = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(k);
-                    pyre_object::gc_roots::pin_root(v);
+                    let _ = pyre_object::gc_roots::pin_root(k);
+                    let _ = pyre_object::gc_roots::pin_root(v);
                     let k = pyre_object::gc_roots::shadow_stack_get(iteration_roots);
                     let v = pyre_object::gc_roots::shadow_stack_get(iteration_roots + 1);
                     match hashed {
@@ -6718,13 +6718,13 @@ pub(crate) fn dict_update1(w_dict: PyObjectRef, w_data: PyObjectRef) -> Result<(
                 let keys = crate::builtins::collect_iterable(w_keys_view)?;
                 let keys_base = pyre_object::gc_roots::shadow_stack_len();
                 for &key in &keys {
-                    pyre_object::gc_roots::pin_root(key);
+                    let _ = pyre_object::gc_roots::pin_root(key);
                 }
                 for i in 0..keys.len() {
                     let k = pyre_object::gc_roots::shadow_stack_get(keys_base + i);
                     let v = crate::baseobjspace::getitem(data(), k)?;
                     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(v);
+                    let _ = pyre_object::gc_roots::pin_root(v);
                     let k = pyre_object::gc_roots::shadow_stack_get(keys_base + i);
                     let v = pyre_object::gc_roots::shadow_stack_get(value_slot);
                     dict_store_checked(dict(), k, v)?;
@@ -6736,7 +6736,7 @@ pub(crate) fn dict_update1(w_dict: PyObjectRef, w_data: PyObjectRef) -> Result<(
                 let pairs = crate::builtins::collect_iterable(data())?;
                 let pairs_base = pyre_object::gc_roots::shadow_stack_len();
                 for &pair in &pairs {
-                    pyre_object::gc_roots::pin_root(pair);
+                    let _ = pyre_object::gc_roots::pin_root(pair);
                 }
                 for idx in 0..pairs.len() {
                     let pair = pyre_object::gc_roots::shadow_stack_get(pairs_base + idx);
@@ -6748,8 +6748,8 @@ pub(crate) fn dict_update1(w_dict: PyObjectRef, w_data: PyObjectRef) -> Result<(
                         )));
                     }
                     let entry_base = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(entries[0]);
-                    pyre_object::gc_roots::pin_root(entries[1]);
+                    let _ = pyre_object::gc_roots::pin_root(entries[0]);
+                    let _ = pyre_object::gc_roots::pin_root(entries[1]);
                     let k = pyre_object::gc_roots::shadow_stack_get(entry_base);
                     let v = pyre_object::gc_roots::shadow_stack_get(entry_base + 1);
                     dict_store_checked(dict(), k, v)?;
@@ -6771,8 +6771,7 @@ fn dict_update_pair_entries(
 ) -> Result<Vec<PyObjectRef>, crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let pair_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pair);
-    let pair = pyre_object::gc_roots::shadow_stack_get(pair_slot);
+    let pair = pyre_object::gc_roots::pin_root(pair);
     unsafe {
         if is_exact_list(pair) {
             let len = w_list_len(pair);
@@ -6850,7 +6849,7 @@ pub fn dict_init_or_update(
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
     for &arg in args {
-        pyre_object::gc_roots::pin_root(arg);
+        let _ = pyre_object::gc_roots::pin_root(arg);
     }
     let rooted_args = (0..args.len())
         .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + i))
@@ -7166,8 +7165,8 @@ pub fn tuple_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(tup);
-        pyre_object::gc_roots::pin_root(value);
+        let tup = pyre_object::gc_roots::pin_root(tup);
+        let value = pyre_object::gc_roots::pin_root(value);
         let (start, stop) = crate::sliceobject::unwrap_start_stop_not_none(size, w_start, w_stop)?;
         let mut i = start.max(0);
         while i < stop {
@@ -7206,8 +7205,8 @@ pub fn tuple_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(tup);
-        pyre_object::gc_roots::pin_root(value);
+        let tup = pyre_object::gc_roots::pin_root(tup);
+        let value = pyre_object::gc_roots::pin_root(value);
         let mut i = 0i64;
         loop {
             let tup = pyre_object::gc_roots::shadow_stack_get(sp);

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -5552,9 +5552,17 @@ fn init_list_type(ns: PyObjectRef) {
                     // slots rather than that copy.  Returning the pre-move word
                     // stores it into the assignment target, where the next
                     // minor finds a root pointing at a stale header.
+                    // The publication ends in a forwarding query, which is
+                    // itself a safepoint, and it rewrites the slots rather
+                    // than `args`; the helper is handed the words read back
+                    // out of them.
                     let _roots = pyre_object::gc_roots::push_roots();
                     let base = pyre_object::gc_roots::pin_roots(args);
-                    crate::type_methods::list_method_extend(args)?;
+                    let live = [
+                        pyre_object::gc_roots::shadow_stack_get(base),
+                        pyre_object::gc_roots::shadow_stack_get(base + 1),
+                    ];
+                    crate::type_methods::list_method_extend(&live)?;
                     Ok(pyre_object::gc_roots::shadow_stack_get(base))
                 },
                 2,
@@ -7214,9 +7222,17 @@ fn init_dict_type(ns: PyObjectRef) {
                     // copy, as `list.__iadd__` does.
                     let _roots = pyre_object::gc_roots::push_roots();
                     let base = pyre_object::gc_roots::pin_roots(args);
-                    let self_ = crate::type_methods::resolve_dict_backing(args[0]);
+                    // Both operands come off their slots, not out of `args`:
+                    // the publication's own forwarding query is a safepoint,
+                    // and it rewrites the slots alone.
+                    let self_ = crate::type_methods::resolve_dict_backing(
+                        pyre_object::gc_roots::shadow_stack_get(base),
+                    );
                     if !self_.is_null() {
-                        crate::type_methods::dict_update1(self_, args[1])?;
+                        crate::type_methods::dict_update1(
+                            self_,
+                            pyre_object::gc_roots::shadow_stack_get(base + 1),
+                        )?;
                     }
                     Ok(pyre_object::gc_roots::shadow_stack_get(base))
                 },
@@ -26622,10 +26638,15 @@ pub(crate) fn set_method_symmetric_difference(
     // `set_method_union` and `set_method_difference`, which copy it before any
     // Python runs, this one drains the operand first and only then walks the
     // receiver — and `COMPARE_OP` popped it off the value stack.
+    // Both go on the stack as one slice: a `pin_root` per value ends each
+    // publication in a forwarding query, itself a safepoint, so the operand
+    // would be published at its pre-query address.  The operand is also the
+    // movable one — any iterable, a list included — so the conversion reads it
+    // off its slot.
     let _roots = pyre_object::gc_roots::push_roots();
-    let receiver_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args[0]);
-    let w_other_as_set = set_operand_as_set(args[1])?;
+    let receiver_slot = pyre_object::gc_roots::pin_roots(&[args[0], args[1]]);
+    let w_other_as_set =
+        set_operand_as_set(pyre_object::gc_roots::shadow_stack_get(receiver_slot + 1))?;
     pyre_object::gc_roots::pin_root(w_other_as_set);
     let w_new = set_symmetric_difference_storage(
         pyre_object::gc_roots::shadow_stack_get(receiver_slot),

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2181,8 +2181,7 @@ unsafe fn is_any_object(_obj: PyObjectRef) -> bool {
 unsafe fn stamp_method_owners(ns: PyObjectRef, owner: &'static crate::gateway::MethodOwner) {
     let _roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(ns);
-
+    let ns = pyre_object::gc_roots::pin_root(ns);
     let keys: Vec<String> = pyre_object::w_dict_items(ns)
         .into_iter()
         .filter_map(|(key, _)| pyre_object::w_str_get_value_opt(key).map(str::to_owned))
@@ -2204,7 +2203,8 @@ unsafe fn stamp_method_owners(ns: PyObjectRef, owner: &'static crate::gateway::M
         // key can route `w_dict_getitem_str` through a user `__eq__`, which
         // allocates and would relocate a `descr` read before it.
         let qualname_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(pyre_object::w_str_new(&format!("{qualifier}.{key}")));
+        let _ =
+            pyre_object::gc_roots::pin_root(pyre_object::w_str_new(&format!("{qualifier}.{key}")));
         let ns = pyre_object::gc_roots::shadow_stack_get(ns_slot);
         let Some(entry) = pyre_object::w_dict_getitem_str(ns, &key) else {
             continue;
@@ -2329,9 +2329,8 @@ pub(crate) unsafe fn stamp_builtin_owner(func: PyObjectRef, type_name: &str) {
 pub(crate) unsafe fn stamp_new_descr_self(ns: PyObjectRef, type_obj: PyObjectRef) {
     let _roots = pyre_object::gc_roots::push_roots();
     let save_point = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(ns);
-    pyre_object::gc_roots::pin_root(type_obj);
-
+    let ns = pyre_object::gc_roots::pin_root(ns);
+    let type_obj = pyre_object::gc_roots::pin_root(type_obj);
     if let Some(w_new) = pyre_object::w_dict_getitem_str(ns, "__new__") {
         // A user class reaches type creation with `__new__` already wrapped in
         // `staticmethod`; a builtin type's entry is the carrier itself.
@@ -2384,7 +2383,7 @@ pub(crate) unsafe fn stamp_new_descr_self(ns: PyObjectRef, type_obj: PyObjectRef
                 // and re-read both it and the type before stamping them.
                 let _function_roots = pyre_object::gc_roots::push_roots();
                 let function_slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(function);
+                let _ = pyre_object::gc_roots::pin_root(function);
                 let w_qualname = pyre_object::w_str_new(&qualname);
                 let function = pyre_object::gc_roots::shadow_stack_get(function_slot);
                 let type_obj = pyre_object::gc_roots::shadow_stack_get(save_point + 1);
@@ -2436,7 +2435,7 @@ pub(crate) unsafe fn stamp_new_descr_self(ns: PyObjectRef, type_obj: PyObjectRef
         }
         if !descr.is_null() && pyre_object::typedef::is_getset_property(descr) {
             let descr_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(descr);
+            let descr = pyre_object::gc_roots::pin_root(descr);
             let bound = copy_for_type(descr, type_obj);
             if !std::ptr::eq(bound, descr) {
                 let ns = pyre_object::gc_roots::shadow_stack_get(save_point);
@@ -2478,7 +2477,7 @@ fn new_root_typeobject(name: &str, init: fn(PyObjectRef)) -> PyObjectRef {
     let _roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
     let ns = pyre_object::w_dict_new();
-    pyre_object::gc_roots::pin_root(ns);
+    let ns = pyre_object::gc_roots::pin_root(ns);
     init(ns);
     // `object`'s own methods are descriptors of `object` just like every other
     // builtin type's, so they are bound here too: their receiver test accepts
@@ -2540,7 +2539,7 @@ fn new_typeobject_with_base_and_layout(
     let _roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
     let ns = pyre_object::w_dict_new();
-    pyre_object::gc_roots::pin_root(ns);
+    let ns = pyre_object::gc_roots::pin_root(ns);
     init(ns);
     // `type_ready_set_dict` — a static type whose `tp_name` is qualified
     // publishes the leading component as a `__module__` entry, so
@@ -2652,7 +2651,7 @@ pub fn make_builtin_type_with_bases(
     let _roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
     let ns = pyre_object::w_dict_new();
-    pyre_object::gc_roots::pin_root(ns);
+    let ns = pyre_object::gc_roots::pin_root(ns);
     init(ns);
     let bases_tuple = w_tuple_new(bases.to_vec());
     let ns = pyre_object::gc_roots::shadow_stack_get(ns_slot);
@@ -3034,9 +3033,9 @@ fn module_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     // supplied and rides the same run; `w_name` is a `str` and never moves.
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(unsafe { pyre_object::w_module_get_w_dict(self_) });
+    let _ = roots.pin_root(unsafe { pyre_object::w_module_get_w_dict(self_) });
     let doc_slot = dict_slot + 1;
-    roots.pin_root(w_doc);
+    let _ = roots.pin_root(w_doc);
     unsafe {
         pyre_object::w_dict_setitem_str(roots.get(dict_slot), "__name__", w_name);
         pyre_object::w_dict_setitem_str(roots.get(dict_slot), "__doc__", roots.get(doc_slot));
@@ -3081,13 +3080,13 @@ pub(crate) fn module_repr_string(module: PyObjectRef) -> Result<Wtf8Buf, crate::
     // test for.
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(unsafe { pyre_object::w_module_get_w_dict(module) });
+    let _ = roots.pin_root(unsafe { pyre_object::w_module_get_w_dict(module) });
     let loader_slot = dict_slot + 1;
-    roots.pin_root(
+    let _ = roots.pin_root(
         crate::baseobjspace::finditem_str(roots.get(dict_slot), "__loader__")?.unwrap_or(PY_NULL),
     );
     let spec_slot = loader_slot + 1;
-    roots.pin_root(
+    let _ = roots.pin_root(
         crate::baseobjspace::finditem_str(roots.get(dict_slot), "__spec__")?.unwrap_or(PY_NULL),
     );
     let spec = roots.get(spec_slot);
@@ -3100,15 +3099,15 @@ pub(crate) fn module_repr_string(module: PyObjectRef) -> Result<Wtf8Buf, crate::
             name = pyre_object::w_str_new("?");
         }
         let name_slot = spec_slot + 1;
-        roots.pin_root(name);
+        let _ = roots.pin_root(name);
         let origin_slot = name_slot + 1;
-        roots.pin_root(crate::baseobjspace::getattr_str(
+        let _ = roots.pin_root(crate::baseobjspace::getattr_str(
             roots.get(spec_slot),
             "origin",
         )?);
         if unsafe { pyre_object::is_none(roots.get(origin_slot)) } {
             let spec_loader_slot = origin_slot + 1;
-            roots.pin_root(crate::baseobjspace::getattr_str(
+            let _ = roots.pin_root(crate::baseobjspace::getattr_str(
                 roots.get(spec_slot),
                 "loader",
             )?);
@@ -3178,7 +3177,7 @@ fn module_descr_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     // the listing that follows the probe.
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(crate::baseobjspace::getattr_str(module, "__dict__")?);
+    let _ = roots.pin_root(crate::baseobjspace::getattr_str(module, "__dict__")?);
     let w_dict = roots.get(dict_slot);
     if w_dict.is_null()
         || (!unsafe { pyre_object::is_dict(w_dict) }
@@ -3203,7 +3202,7 @@ fn module_annotations_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
     let _roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_dict);
+    let w_dict = pyre_object::gc_roots::pin_root(w_dict);
     if let Some(annotations) = crate::baseobjspace::finditem_str(w_dict, "__annotations__")? {
         return Ok(annotations);
     }
@@ -3213,7 +3212,7 @@ fn module_annotations_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     )? {
         Some(annotate) if !annotate.is_null() && !unsafe { pyre_object::is_none(annotate) } => {
             let annotate_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(annotate);
+            let _ = pyre_object::gc_roots::pin_root(annotate);
             let format = pyre_object::w_int_new(1);
             let result = crate::call::call_function_impl_result(
                 pyre_object::gc_roots::shadow_stack_get(annotate_slot),
@@ -3232,7 +3231,7 @@ fn module_annotations_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         _ => pyre_object::w_dict_new(),
     };
     let annotations_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(annotations);
+    let _ = pyre_object::gc_roots::pin_root(annotations);
     let key = pyre_object::w_str_new("__annotations__");
     crate::baseobjspace::setitem(
         pyre_object::gc_roots::shadow_stack_get(dict_slot),
@@ -3248,9 +3247,9 @@ fn module_annotations_set(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
     let _roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_dict);
+    let _ = pyre_object::gc_roots::pin_root(w_dict);
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(value);
+    let _ = pyre_object::gc_roots::pin_root(value);
     let annotations_key = pyre_object::w_str_new("__annotations__");
     crate::baseobjspace::setitem(
         pyre_object::gc_roots::shadow_stack_get(dict_slot),
@@ -3270,7 +3269,7 @@ fn module_annotations_del(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
     let _roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_dict);
+    let w_dict = pyre_object::gc_roots::pin_root(w_dict);
     if crate::baseobjspace::finditem_str(w_dict, "__annotations__")?.is_none() {
         return Err(crate::PyError::attribute_error("__annotations__"));
     }
@@ -3291,7 +3290,7 @@ fn module_annotate_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     let module = module_require(args.get(1).copied().unwrap_or(PY_NULL), "__annotate__")?;
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(unsafe { pyre_object::w_module_get_w_dict(module) });
+    let _ = roots.pin_root(unsafe { pyre_object::w_module_get_w_dict(module) });
     if let Some(annotate) = crate::baseobjspace::finditem_str(roots.get(dict_slot), "__annotate__")?
     {
         return Ok(annotate);
@@ -3317,9 +3316,9 @@ fn module_annotate_set(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
     let _roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_dict);
+    let _ = pyre_object::gc_roots::pin_root(w_dict);
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(value);
+    let value = pyre_object::gc_roots::pin_root(value);
     let annotate_key = pyre_object::w_str_new("__annotate__");
     crate::baseobjspace::setitem(
         pyre_object::gc_roots::shadow_stack_get(dict_slot),
@@ -3792,9 +3791,9 @@ fn dict_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // read back where the store consumes it.
     let _roots = pyre_object::gc_roots::push_roots();
     let instance = pyre_object::w_instance_new(cls);
-    pyre_object::gc_roots::pin_root(instance);
+    let instance = pyre_object::gc_roots::pin_root(instance);
     let backing_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
     crate::type_methods::set_dict_backing(
         instance,
         pyre_object::gc_roots::shadow_stack_get(backing_slot),
@@ -4083,10 +4082,10 @@ fn enumerate_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 fn map_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let value = crate::builtins::builtin_map(args.get(1..).unwrap_or(&[]))?;
-    pyre_object::gc_roots::pin_root(value);
+    let _ = pyre_object::gc_roots::pin_root(value);
     let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let value = unsafe { pyre_object::gc_roots::shadow_stack_get(value_slot) };
     let cls = unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) };
@@ -4107,17 +4106,17 @@ fn filter_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     // the source gateway. Keep the subtype and both positional arguments live
     // before reproducing that conditional keyword check.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // Pin whatever operands the call supplied — the argument-count check
     // itself comes after the keyword inspection, which may collect.
     let mut arg_slots = [usize::MAX; 2];
     for (slot, &arg) in arg_slots.iter_mut().zip(args_w) {
-        pyre_object::gc_roots::pin_root(arg);
+        let _ = pyre_object::gc_roots::pin_root(arg);
         *slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     }
     let kwargs_slot = kwargs.map(|dict| {
-        pyre_object::gc_roots::pin_root(dict);
+        let _ = pyre_object::gc_roots::pin_root(dict);
         pyre_object::gc_roots::shadow_stack_len() - 1
     });
     let cls = unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) };
@@ -4153,7 +4152,7 @@ fn filter_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         unsafe { pyre_object::gc_roots::shadow_stack_get(arg_slots[0]) },
         unsafe { pyre_object::gc_roots::shadow_stack_get(arg_slots[1]) },
     ])?;
-    pyre_object::gc_roots::pin_root(value);
+    let _ = pyre_object::gc_roots::pin_root(value);
     let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let value = unsafe { pyre_object::gc_roots::shadow_stack_get(value_slot) };
     let cls = unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) };
@@ -4168,10 +4167,10 @@ fn filter_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 fn zip_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let value = crate::builtins::builtin_zip(args.get(1..).unwrap_or(&[]))?;
-    pyre_object::gc_roots::pin_root(value);
+    let _ = pyre_object::gc_roots::pin_root(value);
     let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let value = unsafe { pyre_object::gc_roots::shadow_stack_get(value_slot) };
     let cls = unsafe { pyre_object::gc_roots::shadow_stack_get(cls_slot) };
@@ -4190,10 +4189,10 @@ fn zip_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 fn reversed_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let cls = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let value = crate::builtins::builtin_reversed(args.get(1..).unwrap_or(&[]))?;
-    pyre_object::gc_roots::pin_root(value);
+    let _ = pyre_object::gc_roots::pin_root(value);
     let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let value = unsafe { pyre_object::gc_roots::shadow_stack_get(value_slot) };
     if unsafe { pyre_object::functional::is_reversed(value) } {
@@ -5030,9 +5029,9 @@ fn set_init_from_iterable_impl(
     // only reference.
     let _roots = pyre_object::gc_roots::push_roots();
     let set_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_set);
+    let _ = pyre_object::gc_roots::pin_root(w_set);
     let iterable_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_iterable);
+    let _ = pyre_object::gc_roots::pin_root(w_iterable);
     // Python 3.14 `set_update_dict_lock_held`: an exact dict is walked
     // through its key table and each cached hash is handed directly to the
     // set.  This is observable when a key's `__hash__` has side effects, and
@@ -5124,7 +5123,7 @@ fn set_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             let mut names = Vec::with_capacity(entries.len());
             for (key, _) in entries {
                 let w_name = pyre_object::w_str_from_wtf8(key);
-                pyre_object::gc_roots::pin_root(w_name);
+                let w_name = pyre_object::gc_roots::pin_root(w_name);
                 names.push(w_name);
             }
             (names, base)
@@ -5151,7 +5150,7 @@ fn set_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         pyre_object::PY_NULL,
     )?;
     let iterable_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(scope_w[1]);
+    let _ = pyre_object::gc_roots::pin_root(scope_w[1]);
 
     // setobject.py `_initialize_set` — `w_obj.clear()` drops the
     // storage in one go, then the iterable populates it when it is not None
@@ -6423,7 +6422,7 @@ fn init_str_type(ns: PyObjectRef) {
                     // a receiver read before it ran.
                     let _roots = pyre_object::gc_roots::push_roots();
                     let d_slot = pyre_object::gc_roots::shadow_stack_len();
-                    pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+                    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
                     if args.len() >= 2 {
                         if !unsafe { pyre_object::is_str(args[0]) } {
                             return Err(crate::PyError::type_error(
@@ -6458,7 +6457,7 @@ fn init_str_type(ns: PyObjectRef) {
                             // never moves, so it is not read back.
                             let _pair = pyre_object::gc_roots::push_roots();
                             let key = pyre_object::w_int_new(xc.to_u32() as i64);
-                            pyre_object::gc_roots::pin_root(key);
+                            let key = pyre_object::gc_roots::pin_root(key);
                             let value = pyre_object::w_int_new(yc.to_u32() as i64);
                             unsafe {
                                 pyre_object::w_dict_store(
@@ -6729,7 +6728,7 @@ fn dict_descr_sizeof(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
 fn dict_or_new(base: PyObjectRef, overlay: PyObjectRef) -> PyObjectRef {
     let _roots = pyre_object::gc_roots::push_roots();
     let dst_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
     for source in [base, overlay] {
         if source.is_null() {
             continue;
@@ -7390,9 +7389,9 @@ fn init_dict_type(ns: PyObjectRef) {
             } {
                 let _roots = pyre_object::gc_roots::push_roots();
                 let sp = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(d);
-                pyre_object::gc_roots::pin_root(value);
-                pyre_object::gc_roots::pin_root(iterable);
+                let d = pyre_object::gc_roots::pin_root(d);
+                let value = pyre_object::gc_roots::pin_root(value);
+                let iterable = pyre_object::gc_roots::pin_root(iterable);
                 let mut index = 0usize;
                 loop {
                     let iterable = pyre_object::gc_roots::shadow_stack_get(sp + 2);
@@ -7429,11 +7428,11 @@ fn init_dict_type(ns: PyObjectRef) {
             let d = unsafe {
                 let _roots = pyre_object::gc_roots::push_roots();
                 let sp = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(d);
-                pyre_object::gc_roots::pin_root(value);
+                let d = pyre_object::gc_roots::pin_root(d);
+                let value = pyre_object::gc_roots::pin_root(value);
                 let key_base = sp + 2;
                 for key in items {
-                    pyre_object::gc_roots::pin_root(key);
+                    let _ = pyre_object::gc_roots::pin_root(key);
                 }
                 let key_len = pyre_object::gc_roots::shadow_stack_len() - key_base;
                 for i in 0..key_len {
@@ -7458,16 +7457,16 @@ fn init_dict_type(ns: PyObjectRef) {
             // shadow stack rather than a raw `Vec`.
             let _roots = pyre_object::gc_roots::push_roots();
             let sp = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(iterable);
-            pyre_object::gc_roots::pin_root(value);
+            let _ = pyre_object::gc_roots::pin_root(iterable);
+            let value = pyre_object::gc_roots::pin_root(value);
             let d = crate::call::call_function_impl_result(cls, &[])?;
             let dict_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(d);
+            let d = pyre_object::gc_roots::pin_root(d);
             let items =
                 crate::builtins::collect_iterable(pyre_object::gc_roots::shadow_stack_get(sp))?;
             let key_base = pyre_object::gc_roots::shadow_stack_len();
             for key in items {
-                pyre_object::gc_roots::pin_root(key);
+                let _ = pyre_object::gc_roots::pin_root(key);
             }
             let key_len = pyre_object::gc_roots::shadow_stack_len() - key_base;
             for i in 0..key_len {
@@ -8479,7 +8478,7 @@ fn dict_view_all_contained_in(
     // read each one back at its use.
     let _roots = pyre_object::gc_roots::push_roots();
     let other_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(other);
+    let other = pyre_object::gc_roots::pin_root(other);
     let item_base = pyre_object::gc_roots::pin_roots(&snapshot);
     for i in 0..snapshot.len() {
         let other = pyre_object::gc_roots::shadow_stack_get(other_slot);
@@ -8550,7 +8549,7 @@ fn dict_view_isdisjoint(
     // `__eq__`.  Same shape as `dict_view_all_contained_in` above.
     let _roots = pyre_object::gc_roots::push_roots();
     let view_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_view);
+    let self_view = pyre_object::gc_roots::pin_root(self_view);
     let item_base = pyre_object::gc_roots::pin_roots(&other_items);
     for index in 0..other_items.len() {
         let self_view = pyre_object::gc_roots::shadow_stack_get(view_slot);
@@ -9528,8 +9527,8 @@ fn slice_method_indices(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     }
     let _roots = pyre_object::gc_roots::push_roots();
     let roots = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(self_);
-    pyre_object::gc_roots::pin_root(args[1]);
+    let _ = pyre_object::gc_roots::pin_root(self_);
+    let _ = pyre_object::gc_roots::pin_root(args[1]);
     // sliceobject.py app-level `indices`: unlike the machine-word
     // `indices3()` used by concrete sequence operations, this rarely-used
     // public method deliberately keeps start/stop/step/length unbounded.
@@ -9610,11 +9609,11 @@ fn slice_method_indices(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     };
 
     let w_start = pyre_object::range_bigint_to_obj(start);
-    pyre_object::gc_roots::pin_root(w_start);
+    let _ = pyre_object::gc_roots::pin_root(w_start);
     let w_stop = pyre_object::range_bigint_to_obj(stop);
-    pyre_object::gc_roots::pin_root(w_stop);
+    let _ = pyre_object::gc_roots::pin_root(w_stop);
     let w_step = pyre_object::range_bigint_to_obj(step);
-    pyre_object::gc_roots::pin_root(w_step);
+    let _ = pyre_object::gc_roots::pin_root(w_step);
     Ok(w_tuple_new(vec![
         unsafe { pyre_object::gc_roots::shadow_stack_get(roots + 2) },
         unsafe { pyre_object::gc_roots::shadow_stack_get(roots + 3) },
@@ -9666,9 +9665,9 @@ fn slice_descr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 /// `slice is slice` is always equal even with non-comparable params.
 fn slice_components_eq(a: PyObjectRef, b: PyObjectRef) -> Result<bool, crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(a);
+    let _ = pyre_object::gc_roots::pin_root(a);
     let a_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(b);
+    let _ = pyre_object::gc_roots::pin_root(b);
     let b_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     Ok(
         slice_component_eq(a_slot, b_slot, pyre_object::sliceobject::w_slice_get_start)?
@@ -9689,9 +9688,9 @@ fn slice_component_eq(
         )
     };
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(left);
+    let _ = pyre_object::gc_roots::pin_root(left);
     let left_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(right);
+    let _ = pyre_object::gc_roots::pin_root(right);
     let right_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     crate::baseobjspace::eq_w(
         unsafe { pyre_object::gc_roots::shadow_stack_get(left_slot) },
@@ -9701,22 +9700,22 @@ fn slice_component_eq(
 
 fn slice_components_tuple(s: PyObjectRef) -> PyObjectRef {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(s);
+    let _ = pyre_object::gc_roots::pin_root(s);
     let s_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let start = unsafe {
         pyre_object::sliceobject::w_slice_get_start(pyre_object::gc_roots::shadow_stack_get(s_slot))
     };
-    pyre_object::gc_roots::pin_root(start);
+    let _ = pyre_object::gc_roots::pin_root(start);
     let start_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let stop = unsafe {
         pyre_object::sliceobject::w_slice_get_stop(pyre_object::gc_roots::shadow_stack_get(s_slot))
     };
-    pyre_object::gc_roots::pin_root(stop);
+    let _ = pyre_object::gc_roots::pin_root(stop);
     let stop_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let step = unsafe {
         pyre_object::sliceobject::w_slice_get_step(pyre_object::gc_roots::shadow_stack_get(s_slot))
     };
-    pyre_object::gc_roots::pin_root(step);
+    let _ = pyre_object::gc_roots::pin_root(step);
     let step_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     w_tuple_new(vec![
         unsafe { pyre_object::gc_roots::shadow_stack_get(start_slot) },
@@ -9796,15 +9795,15 @@ fn slice_descr_richcompare(
         )));
     }
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(a);
+    let _ = pyre_object::gc_roots::pin_root(a);
     let a_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(b);
+    let _ = pyre_object::gc_roots::pin_root(b);
     let b_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let left = slice_components_tuple(unsafe { pyre_object::gc_roots::shadow_stack_get(a_slot) });
-    pyre_object::gc_roots::pin_root(left);
+    let _ = pyre_object::gc_roots::pin_root(left);
     let left_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let right = slice_components_tuple(unsafe { pyre_object::gc_roots::shadow_stack_get(b_slot) });
-    pyre_object::gc_roots::pin_root(right);
+    let _ = pyre_object::gc_roots::pin_root(right);
     let right_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     crate::baseobjspace::compare(
         unsafe { pyre_object::gc_roots::shadow_stack_get(left_slot) },
@@ -9824,14 +9823,14 @@ fn slice_descr_hash(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 fn slice_descr_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let s = slice_receiver(args, "__reduce__")?;
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(s);
+    let s = pyre_object::gc_roots::pin_root(s);
     let s_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let ty = r#type(s).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
-    pyre_object::gc_roots::pin_root(ty);
+    let _ = pyre_object::gc_roots::pin_root(ty);
     let ty_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let components =
         slice_components_tuple(unsafe { pyre_object::gc_roots::shadow_stack_get(s_slot) });
-    pyre_object::gc_roots::pin_root(components);
+    let _ = pyre_object::gc_roots::pin_root(components);
     let components_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     Ok(w_tuple_new(vec![
         unsafe { pyre_object::gc_roots::shadow_stack_get(ty_slot) },
@@ -9994,9 +9993,9 @@ fn union_getitem(args: &[PyObjectRef]) -> crate::PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::shadow_stack_len();
     for &arg in &newargs {
-        pyre_object::gc_roots::pin_root(arg);
+        let _ = pyre_object::gc_roots::pin_root(arg);
     }
-    pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(base));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(base));
     let curr_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     for i in 1..newargs.len() {
         let next = pyre_object::gc_roots::shadow_stack_get(base + i);
@@ -11480,16 +11479,16 @@ fn init_type_type(ns: PyObjectRef) {
                     // are materialised for pyre's flat call ABI.
                     let roots = pyre_object::gc_roots::push_roots();
                     let root_base = roots.base();
-                    roots.pin_root(cls);
-                    roots.pin_root(packed_args);
-                    roots.pin_root(packed_kwargs);
+                    let _ = roots.pin_root(cls);
+                    let _ = roots.pin_root(packed_args);
+                    let _ = roots.pin_root(packed_kwargs);
                     let nargs = unsafe { pyre_object::w_tuple_len(roots.get(root_base + 1)) };
                     for index in 0..nargs {
                         let value = unsafe {
                             pyre_object::w_tuple_getitem(roots.get(root_base + 1), index as i64)
                         }
                         .expect("index is in the packed type.__call__ argument range");
-                        roots.pin_root(value);
+                        let _ = roots.pin_root(value);
                     }
                     let positional: Vec<PyObjectRef> = (0..nargs)
                         .map(|index| roots.get(root_base + 3 + index))
@@ -12397,7 +12396,7 @@ unsafe fn mro_subclasses(
     temp: &mut Vec<MroUpdate>,
 ) -> Result<(), crate::PyError> {
     let w_type_root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_type);
+    let w_type = pyre_object::gc_roots::pin_root(w_type);
     let old_mro_ptr = pyre_object::w_type_get_mro(w_type);
     let old_mro_roots = if old_mro_ptr.is_null() {
         None
@@ -12405,7 +12404,7 @@ unsafe fn mro_subclasses(
         let start = pyre_object::gc_roots::shadow_stack_len();
         let old_mro = (*old_mro_ptr).as_slice();
         for &w_class in old_mro {
-            pyre_object::gc_roots::pin_root(w_class);
+            let _ = pyre_object::gc_roots::pin_root(w_class);
         }
         Some((start, old_mro.len()))
     };
@@ -12421,7 +12420,7 @@ unsafe fn mro_subclasses(
     let subclasses = pyre_object::typeobject::w_type_get_subclasses(w_type, false);
     let subclass_roots = pyre_object::gc_roots::shadow_stack_len();
     for &w_sc in &subclasses {
-        pyre_object::gc_roots::pin_root(w_sc);
+        let _ = pyre_object::gc_roots::pin_root(w_sc);
     }
     for index in 0..subclasses.len() {
         let w_sc = pyre_object::gc_roots::shadow_stack_get(subclass_roots + index);
@@ -12587,11 +12586,11 @@ fn type_set_bases(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // rollback value GC-visible while custom mro() methods execute.
         let _mro_roots = pyre_object::gc_roots::push_roots();
         let w_type_root = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_type);
+        let _ = pyre_object::gc_roots::pin_root(w_type);
         let saved_bases_root = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(saved_bases);
+        let _ = pyre_object::gc_roots::pin_root(saved_bases);
         let new_bases_root = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_value);
+        let _ = pyre_object::gc_roots::pin_root(w_value);
         // Invalidate the method cache of w_type and every subclass before the
         // hierarchy changes (typeobject.py `w_type.mutated(None)`).
         let w_type = pyre_object::gc_roots::shadow_stack_get(w_type_root);
@@ -16534,15 +16533,15 @@ fn staticmethod_descr_init(args: &[PyObjectRef]) -> crate::PyResult {
     // the store rather than out of the locals that produced them.
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(unsafe { pyre_object::function::w_staticmethod_getdict(sm) });
+    let _ = roots.pin_root(unsafe { pyre_object::function::w_staticmethod_getdict(sm) });
     let function_slot = dict_slot + 1;
-    roots.pin_root(function);
+    let _ = roots.pin_root(function);
     for name in ["__module__", "__name__", "__qualname__", "__doc__"] {
         match crate::baseobjspace::getattr_str(roots.get(function_slot), name) {
             Ok(value) => {
                 let value_roots = pyre_object::gc_roots::push_roots();
                 let value_slot = value_roots.base();
-                value_roots.pin_root(value);
+                let _ = value_roots.pin_root(value);
                 let key = w_str_new(name);
                 crate::baseobjspace::setitem(
                     roots.get(dict_slot),
@@ -16614,13 +16613,13 @@ fn staticmethod_wrapped_attr_get(obj: PyObjectRef, name: &str) -> crate::PyResul
     // return.
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(unsafe { pyre_object::function::w_staticmethod_getdict(sm) });
+    let _ = roots.pin_root(unsafe { pyre_object::function::w_staticmethod_getdict(sm) });
     if let Some(value) = crate::baseobjspace::finditem_str(roots.get(dict_slot), name)? {
         return Ok(value);
     }
     let function = unsafe { pyre_object::function::w_staticmethod_get_func(sm) };
     let value_slot = dict_slot + 1;
-    roots.pin_root(crate::baseobjspace::getattr_str(function, name)?);
+    let _ = roots.pin_root(crate::baseobjspace::getattr_str(function, name)?);
     let key = w_str_new(name);
     crate::baseobjspace::setitem(roots.get(dict_slot), key, roots.get(value_slot))?;
     Ok(roots.get(value_slot))
@@ -16642,9 +16641,9 @@ fn staticmethod_wrapped_attr_set(args: &[PyObjectRef], name: &str) -> crate::PyR
     // an immortal non-GC string and needs none.
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(unsafe { pyre_object::function::w_staticmethod_getdict(sm) });
+    let _ = roots.pin_root(unsafe { pyre_object::function::w_staticmethod_getdict(sm) });
     let value_slot = dict_slot + 1;
-    roots.pin_root(args.get(2).copied().unwrap_or(PY_NULL));
+    let _ = roots.pin_root(args.get(2).copied().unwrap_or(PY_NULL));
     let key = w_str_new(name);
     crate::baseobjspace::setitem(roots.get(dict_slot), key, roots.get(value_slot))?;
     Ok(w_none())
@@ -16662,7 +16661,7 @@ fn staticmethod_wrapped_attr_del(args: &[PyObjectRef], name: &str) -> crate::PyR
     let sm = staticmethod_require(args.get(1).copied().unwrap_or(PY_NULL), name)?;
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(unsafe { pyre_object::function::w_staticmethod_getdict(sm) });
+    let _ = roots.pin_root(unsafe { pyre_object::function::w_staticmethod_getdict(sm) });
     let key = w_str_new(name);
     if let Err(err) = crate::baseobjspace::delitem(roots.get(dict_slot), key) {
         if err.kind == crate::PyErrorKind::KeyError {
@@ -16879,15 +16878,15 @@ fn classmethod_descr_init(args: &[PyObjectRef]) -> crate::PyResult {
     // The `staticmethod.__init__` bracket, for the same reasons.
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(unsafe { pyre_object::function::w_classmethod_getdict(cm) });
+    let _ = roots.pin_root(unsafe { pyre_object::function::w_classmethod_getdict(cm) });
     let function_slot = dict_slot + 1;
-    roots.pin_root(function);
+    let _ = roots.pin_root(function);
     for name in ["__module__", "__name__", "__qualname__", "__doc__"] {
         match crate::baseobjspace::getattr_str(roots.get(function_slot), name) {
             Ok(value) => {
                 let value_roots = pyre_object::gc_roots::push_roots();
                 let value_slot = value_roots.base();
-                value_roots.pin_root(value);
+                let _ = value_roots.pin_root(value);
                 let key = w_str_new(name);
                 crate::baseobjspace::setitem(
                     roots.get(dict_slot),
@@ -16944,13 +16943,13 @@ fn classmethod_wrapped_attr_get(obj: PyObjectRef, name: &str) -> crate::PyResult
     let cm = classmethod_require(obj, name)?;
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(unsafe { pyre_object::function::w_classmethod_getdict(cm) });
+    let _ = roots.pin_root(unsafe { pyre_object::function::w_classmethod_getdict(cm) });
     if let Some(value) = crate::baseobjspace::finditem_str(roots.get(dict_slot), name)? {
         return Ok(value);
     }
     let function = unsafe { pyre_object::function::w_classmethod_get_func(cm) };
     let value_slot = dict_slot + 1;
-    roots.pin_root(crate::baseobjspace::getattr_str(function, name)?);
+    let _ = roots.pin_root(crate::baseobjspace::getattr_str(function, name)?);
     let key = w_str_new(name);
     crate::baseobjspace::setitem(roots.get(dict_slot), key, roots.get(value_slot))?;
     Ok(roots.get(value_slot))
@@ -16968,9 +16967,9 @@ fn classmethod_wrapped_attr_set(args: &[PyObjectRef], name: &str) -> crate::PyRe
     let cm = classmethod_require(args.get(1).copied().unwrap_or(PY_NULL), name)?;
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(unsafe { pyre_object::function::w_classmethod_getdict(cm) });
+    let _ = roots.pin_root(unsafe { pyre_object::function::w_classmethod_getdict(cm) });
     let value_slot = dict_slot + 1;
-    roots.pin_root(args.get(2).copied().unwrap_or(PY_NULL));
+    let _ = roots.pin_root(args.get(2).copied().unwrap_or(PY_NULL));
     let key = w_str_new(name);
     crate::baseobjspace::setitem(roots.get(dict_slot), key, roots.get(value_slot))?;
     Ok(w_none())
@@ -16988,7 +16987,7 @@ fn classmethod_wrapped_attr_del(args: &[PyObjectRef], name: &str) -> crate::PyRe
     let cm = classmethod_require(args.get(1).copied().unwrap_or(PY_NULL), name)?;
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(unsafe { pyre_object::function::w_classmethod_getdict(cm) });
+    let _ = roots.pin_root(unsafe { pyre_object::function::w_classmethod_getdict(cm) });
     let key = w_str_new(name);
     if let Err(err) = crate::baseobjspace::delitem(roots.get(dict_slot), key) {
         if err.kind == crate::PyErrorKind::KeyError {
@@ -22452,8 +22451,8 @@ fn bytes_method_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     // `idx.__index__`.
     let _roots = pyre_object::gc_roots::push_roots();
     let src_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(require_bytes_like_source(pos[1])?);
-    pyre_object::gc_roots::pin_root(require_bytes_like_source(pos[2])?);
+    let _ = pyre_object::gc_roots::pin_root(require_bytes_like_source(pos[1])?);
+    let _ = pyre_object::gc_roots::pin_root(require_bytes_like_source(pos[2])?);
     let limit = match pos.get(3) {
         Some(&w_count) if !w_count.is_null() => {
             let c = crate::builtins::space_index_w(w_count)?;
@@ -25715,7 +25714,7 @@ fn setlike_descr_isdisjoint(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     // items still waiting in this native Vec both move under the loop.
     let _roots = pyre_object::gc_roots::push_roots();
     let set_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args[0]);
+    let _ = pyre_object::gc_roots::pin_root(args[0]);
     let item_base = pyre_object::gc_roots::pin_roots(&items);
     for index in 0..items.len() {
         let receiver = pyre_object::gc_roots::shadow_stack_get(set_slot);
@@ -26497,7 +26496,7 @@ fn set_intersect_update(
         // across that probe.
         let _roots = pyre_object::gc_roots::push_roots();
         let result = pyre_object::w_set_new();
-        pyre_object::gc_roots::pin_root(result);
+        let result = pyre_object::gc_roots::pin_root(result);
         let mut i = 0;
         while let Some(key) = pyre_object::w_set_key_at(keep, i) {
             if pyre_object::w_set_contains_key_checked(probe, key)
@@ -26576,23 +26575,23 @@ pub(crate) fn set_method_intersection(
     // them, the iterable drain and the `__eq__` a bucket probe runs.
     let _roots = pyre_object::gc_roots::push_roots();
     let mut result = set_newobj_intersection(operand(0))?;
-    pyre_object::gc_roots::pin_root(result);
+    let mut result = pyre_object::gc_roots::pin_root(result);
     for position in 1..args.len() {
         let w_other = operand(position);
         let w_other_as_set = if unsafe { pyre_object::is_set_or_frozenset(w_other) } {
             w_other
         } else {
             let w_fresh = set_newobj_intersection(w_other)?;
-            pyre_object::gc_roots::pin_root(w_fresh);
+            let w_fresh = pyre_object::gc_roots::pin_root(w_fresh);
             w_fresh
         };
         result = set_intersect_update(result, w_other_as_set)?;
-        pyre_object::gc_roots::pin_root(result);
+        let _ = pyre_object::gc_roots::pin_root(result);
     }
     unsafe {
         if pyre_object::is_frozenset(args[0]) {
             let w_frozenset = pyre_object::w_frozenset_new();
-            pyre_object::gc_roots::pin_root(w_frozenset);
+            let w_frozenset = pyre_object::gc_roots::pin_root(w_frozenset);
             pyre_object::w_set_copy_storage_from(w_frozenset, result);
             return Ok(w_frozenset);
         }
@@ -26614,7 +26613,7 @@ pub(crate) fn set_method_difference(
     // the word stays usable as it stands.
     let _roots = pyre_object::gc_roots::push_roots();
     let result = set_copy_real(args[0]);
-    pyre_object::gc_roots::pin_root(result);
+    let result = pyre_object::gc_roots::pin_root(result);
     let mut update_args: Vec<pyre_object::PyObjectRef> = vec![result];
     update_args.extend_from_slice(&args[1..]);
     set_method_difference_update(&update_args)?;
@@ -26647,16 +26646,16 @@ pub(crate) fn set_method_symmetric_difference(
     let receiver_slot = pyre_object::gc_roots::pin_roots(&[args[0], args[1]]);
     let w_other_as_set =
         set_operand_as_set(pyre_object::gc_roots::shadow_stack_get(receiver_slot + 1))?;
-    pyre_object::gc_roots::pin_root(w_other_as_set);
+    let w_other_as_set = pyre_object::gc_roots::pin_root(w_other_as_set);
     let w_new = set_symmetric_difference_storage(
         pyre_object::gc_roots::shadow_stack_get(receiver_slot),
         w_other_as_set,
     )?;
-    pyre_object::gc_roots::pin_root(w_new);
+    let w_new = pyre_object::gc_roots::pin_root(w_new);
     unsafe {
         if pyre_object::is_frozenset(args[0]) {
             let w_frozenset = pyre_object::w_frozenset_new();
-            pyre_object::gc_roots::pin_root(w_frozenset);
+            let w_frozenset = pyre_object::gc_roots::pin_root(w_frozenset);
             pyre_object::w_set_copy_storage_from(w_frozenset, w_new);
             return Ok(w_frozenset);
         }
@@ -26818,8 +26817,8 @@ pub(crate) fn set_is_subset_of(
     // set is old-gen and never moves, so this is liveness only and neither
     // local is reloaded; `key` stays reachable through the pinned `w_set`.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_set);
-    pyre_object::gc_roots::pin_root(w_other);
+    let w_set = pyre_object::gc_roots::pin_root(w_set);
+    let w_other = pyre_object::gc_roots::pin_root(w_other);
     unsafe {
         let mut i = 0;
         while let Some(key) = pyre_object::w_set_key_at(w_set, i) {
@@ -27001,7 +27000,7 @@ fn set_symmetric_difference_storage(
     unsafe {
         let _roots = pyre_object::gc_roots::push_roots();
         let d_new = pyre_object::w_set_new();
-        pyre_object::gc_roots::pin_root(d_new);
+        let d_new = pyre_object::gc_roots::pin_root(d_new);
         for (walk, probe) in [(w_other, w_set), (w_set, w_other)] {
             let mut i = 0;
             while let Some(key) = pyre_object::w_set_key_at(walk, i) {
@@ -27128,8 +27127,8 @@ fn init_set_type(ns: PyObjectRef) {
                     unsafe {
                         let _roots = pyre_object::gc_roots::push_roots();
                         let sp = pyre_object::gc_roots::shadow_stack_len();
-                        pyre_object::gc_roots::pin_root(args[0]);
-                        pyre_object::gc_roots::pin_root(args[1]);
+                        let _ = pyre_object::gc_roots::pin_root(args[0]);
+                        let _ = pyre_object::gc_roots::pin_root(args[1]);
                         let hash = crate::builtins::try_hash_value(args[1]).map_err(|err| {
                             crate::baseobjspace::wrap_set_element_hash_error(
                                 pyre_object::gc_roots::shadow_stack_get(sp + 1),
@@ -28804,7 +28803,7 @@ fn itertools_constructor_scope_kwonly(
             let mut names = Vec::with_capacity(entries.len());
             for (key, _) in entries {
                 let w_name = pyre_object::w_str_from_wtf8(key);
-                pyre_object::gc_roots::pin_root(w_name);
+                let w_name = pyre_object::gc_roots::pin_root(w_name);
                 names.push(w_name);
             }
             (names, base)
@@ -28816,7 +28815,7 @@ fn itertools_constructor_scope_kwonly(
         PY_NULL
     } else {
         let w_kw_defs = pyre_object::w_dict_new();
-        pyre_object::gc_roots::pin_root(w_kw_defs);
+        let _ = pyre_object::gc_roots::pin_root(w_kw_defs);
         let kw_defs_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let kw_names_start = names.len() - kwonlyargcount;
         for index in 0..kwonlyargcount {
@@ -28890,9 +28889,9 @@ fn count_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     // W_Count___new__(space, w_subtype, w_start=0, w_step=1).
     let _roots = pyre_object::gc_roots::push_roots();
     let w_zero = w_int_new(0);
-    pyre_object::gc_roots::pin_root(w_zero);
+    let w_zero = pyre_object::gc_roots::pin_root(w_zero);
     let w_one = w_int_new(1);
-    pyre_object::gc_roots::pin_root(w_one);
+    let w_one = pyre_object::gc_roots::pin_root(w_one);
     let (cls, scope) =
         itertools_constructor_scope(args, "count", vec!["start", "step"], &[w_zero, w_one])?;
     let w_start = scope[0];
@@ -29117,16 +29116,16 @@ fn compress_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     let (cls, scope_w) =
         itertools_constructor_scope(args, "compress", vec!["data", "selectors"], &[])?;
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(scope_w[0]);
+    let _ = pyre_object::gc_roots::pin_root(scope_w[0]);
     let data_arg_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(scope_w[1]);
+    let _ = pyre_object::gc_roots::pin_root(scope_w[1]);
     let selectors_arg_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_data = crate::baseobjspace::iter(unsafe {
         pyre_object::gc_roots::shadow_stack_get(data_arg_slot)
     })?;
-    pyre_object::gc_roots::pin_root(w_data);
+    let _ = pyre_object::gc_roots::pin_root(w_data);
     let data_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_selectors = crate::baseobjspace::iter(unsafe {
         pyre_object::gc_roots::shadow_stack_get(selectors_arg_slot)
@@ -29167,11 +29166,11 @@ fn starmap_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         gettypefor(&pyre_object::interp_itertools::STARMAP_TYPE).map_or(PY_NULL, |p| p.as_ptr());
     let (cls, w_fun, w_iterable) = itertools_twoarg_new(args, exact, "starmap")?;
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(w_fun);
+    let _ = pyre_object::gc_roots::pin_root(w_fun);
     let fun_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(w_iterable);
+    let _ = pyre_object::gc_roots::pin_root(w_iterable);
     let iterable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let iterator = crate::baseobjspace::iter(unsafe {
         pyre_object::gc_roots::shadow_stack_get(iterable_slot)
@@ -29220,13 +29219,13 @@ fn accumulate_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
         1,
     )?;
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(scope_w[0]);
+    let _ = pyre_object::gc_roots::pin_root(scope_w[0]);
     let iterable_arg_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(scope_w[1]);
+    let _ = pyre_object::gc_roots::pin_root(scope_w[1]);
     let func_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(scope_w[2]);
+    let _ = pyre_object::gc_roots::pin_root(scope_w[2]);
     let initial_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_iterable = crate::baseobjspace::iter(unsafe {
         pyre_object::gc_roots::shadow_stack_get(iterable_arg_slot)
@@ -29260,20 +29259,20 @@ fn zip_longest_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
         crate::builtins::kwarg_get(kwargs, "fillvalue").unwrap_or_else(pyre_object::w_none);
 
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(w_fillvalue);
+    let _ = pyre_object::gc_roots::pin_root(w_fillvalue);
     let fill_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let sources_base = pyre_object::gc_roots::shadow_stack_len();
     for &source in sources {
-        pyre_object::gc_roots::pin_root(source);
+        let _ = pyre_object::gc_roots::pin_root(source);
     }
     let iterators_base = pyre_object::gc_roots::shadow_stack_len();
     for index in 0..sources.len() {
         let w_iterable = crate::baseobjspace::iter(unsafe {
             pyre_object::gc_roots::shadow_stack_get(sources_base + index)
         })?;
-        pyre_object::gc_roots::pin_root(w_iterable);
+        let _ = pyre_object::gc_roots::pin_root(w_iterable);
     }
     let iterators = (0..sources.len())
         .map(|index| unsafe { pyre_object::gc_roots::shadow_stack_get(iterators_base + index) })
@@ -29424,11 +29423,11 @@ fn islice_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     // All inputs and the requested subtype must remain live while `__index__`
     // and `iter` call back into Python and can trigger a collection.
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let values_base = pyre_object::gc_roots::shadow_stack_len();
     for &value in args_w {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
     }
     let value =
         |index: usize| unsafe { pyre_object::gc_roots::shadow_stack_get(values_base + index) };
@@ -29521,7 +29520,7 @@ fn batched_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     // Argument Clinic signature:
     //     batched(iterable, n, *, strict=False)
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // The positional column is a borrowed slice, not a slot the collector
     // rewrites either, and the keyword names and defaults below all allocate
@@ -29545,7 +29544,7 @@ fn batched_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             let mut names = Vec::with_capacity(entries.len());
             for (key, _) in entries {
                 let w_name = pyre_object::w_str_from_wtf8(key);
-                pyre_object::gc_roots::pin_root(w_name);
+                let w_name = pyre_object::gc_roots::pin_root(w_name);
                 names.push(w_name);
             }
             (names, base)
@@ -29560,7 +29559,7 @@ fn batched_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     // word and the receiver read back out of the slot.  `w_bool_from` hands
     // back an immortal singleton, so evaluating it after that read allocates
     // nothing.
-    pyre_object::gc_roots::pin_root(w_kw_defaults);
+    let _ = pyre_object::gc_roots::pin_root(w_kw_defaults);
     let kw_defaults_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     unsafe {
         pyre_object::w_dict_setitem_str_no_proxy(
@@ -29586,7 +29585,7 @@ fn batched_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
 
     // Clinic converts n and strict before entering batched_new_impl.
     for &value in &scope_w {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
     }
     let values_base = pyre_object::gc_roots::shadow_stack_len() - scope_w.len();
     let value =
@@ -29654,14 +29653,14 @@ fn product_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     check_user_subclass(exact, cls)?;
 
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let inputs_base = pyre_object::gc_roots::shadow_stack_len();
     for &input in inputs {
-        pyre_object::gc_roots::pin_root(input);
+        let _ = pyre_object::gc_roots::pin_root(input);
     }
     let repeat_slot = crate::builtins::kwarg_get(kwargs, "repeat").map(|value| {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
         pyre_object::gc_roots::shadow_stack_len() - 1
     });
     let repeat = match repeat_slot {
@@ -29699,10 +29698,10 @@ fn product_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             })?;
             stopped |= items.is_empty();
             for &item in &items {
-                pyre_object::gc_roots::pin_root(item);
+                let _ = pyre_object::gc_roots::pin_root(item);
             }
             let pool = pyre_object::w_list_new(items);
-            pyre_object::gc_roots::pin_root(pool);
+            let _ = pyre_object::gc_roots::pin_root(pool);
             pool_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
         }
     }
@@ -29716,7 +29715,7 @@ fn product_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         }
     }
     let gears = pyre_object::w_list_new(gear_items);
-    pyre_object::gc_roots::pin_root(gears);
+    let _ = pyre_object::gc_roots::pin_root(gears);
     let gears_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let mut index_items = crate::builtins::try_vec_with_capacity(npools)?;
     index_items.extend((0..npools).map(|_| pyre_object::w_int_new(0)));
@@ -29767,10 +29766,10 @@ fn combinations_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         itertools_constructor_scope(args, "combinations", vec!["iterable", "r"], &[])?;
 
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     for &value in &scope {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
     }
     let values_base = pyre_object::gc_roots::shadow_stack_len() - scope.len();
     let r = crate::builtins::space_index_w(unsafe {
@@ -29788,10 +29787,10 @@ fn combinations_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     })?;
     let stopped = r as usize > items.len();
     for &item in &items {
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
     }
     let pool_w = pyre_object::w_list_new(items);
-    pyre_object::gc_roots::pin_root(pool_w);
+    let _ = pyre_object::gc_roots::pin_root(pool_w);
     let pool_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // `r` is unbounded above — the odometer is sized before `stopped` gets a
     // chance to short-circuit it.
@@ -29851,10 +29850,10 @@ fn combinations_with_replacement_descr_new(
     )?;
 
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     for &value in &scope {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
     }
     let values_base = pyre_object::gc_roots::shadow_stack_len() - scope.len();
     let r = crate::builtins::space_index_w(unsafe {
@@ -29872,10 +29871,10 @@ fn combinations_with_replacement_descr_new(
     })?;
     let stopped = items.is_empty() && r > 0;
     for &item in &items {
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
     }
     let pool_w = pyre_object::w_list_new(items);
-    pyre_object::gc_roots::pin_root(pool_w);
+    let _ = pyre_object::gc_roots::pin_root(pool_w);
     let pool_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // `r` is bounded only by `ssize_t`, and an empty pool sets `stopped`
     // without shrinking the odometer.
@@ -29932,10 +29931,10 @@ fn permutations_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         itertools_constructor_scope(args, "permutations", vec!["iterable", "r"], &[w_none()])?;
 
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     for &value in &scope {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
     }
     let values_base = pyre_object::gc_roots::shadow_stack_len() - scope.len();
 
@@ -29945,11 +29944,11 @@ fn permutations_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         pyre_object::gc_roots::shadow_stack_get(values_base)
     })?;
     for &item in &items {
-        pyre_object::gc_roots::pin_root(item);
+        let _ = pyre_object::gc_roots::pin_root(item);
     }
     let n = items.len();
     let pool_w = pyre_object::w_list_new(items);
-    pyre_object::gc_roots::pin_root(pool_w);
+    let _ = pyre_object::gc_roots::pin_root(pool_w);
     let pool_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     let w_r = unsafe { pyre_object::gc_roots::shadow_stack_get(values_base + 1) };
@@ -29984,7 +29983,7 @@ fn permutations_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     } else {
         let indices =
             pyre_object::w_list_new((0..n).map(|i| pyre_object::w_int_new(i as i64)).collect());
-        pyre_object::gc_roots::pin_root(indices);
+        let _ = pyre_object::gc_roots::pin_root(indices);
         let indices_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let cycles = pyre_object::w_list_new(
             (0..r as usize)
@@ -30044,10 +30043,10 @@ fn groupby_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         itertools_constructor_scope(args, "groupby", vec!["iterable", "key"], &[w_none()])?;
 
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     for &value in &scope {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
     }
     let values_base = pyre_object::gc_roots::shadow_stack_len() - scope.len();
     let w_iterator =
@@ -30086,11 +30085,11 @@ fn groupby_iterator_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
     }
 
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(values[0]);
+    let _ = pyre_object::gc_roots::pin_root(values[0]);
     let parent_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(values[1]);
+    let _ = pyre_object::gc_roots::pin_root(values[1]);
     let key_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let obj = pyre_object::interp_itertools::w_groupby_iterator_new(
         unsafe { pyre_object::gc_roots::shadow_stack_get(parent_slot) },
@@ -30167,10 +30166,10 @@ fn tee_dataobject_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     }
 
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     for &value in values {
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
     }
     let values_base = pyre_object::gc_roots::shadow_stack_len() - values.len();
     let w_values = unsafe { pyre_object::gc_roots::shadow_stack_get(values_base + 1) };
@@ -30197,7 +30196,7 @@ fn tee_dataobject_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     }
 
     let head = pyre_object::interp_itertools::w_tee_chained_list_node_new();
-    pyre_object::gc_roots::pin_root(head);
+    let _ = pyre_object::gc_roots::pin_root(head);
     let head_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let mut current_slot = head_slot;
     for index in 0..value_count {
@@ -30206,7 +30205,7 @@ fn tee_dataobject_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
             pyre_object::w_list_getitem(w_values, index as i64)
                 .expect("tee dataobject list index in range")
         };
-        pyre_object::gc_roots::pin_root(w_item);
+        let _ = pyre_object::gc_roots::pin_root(w_item);
         let item_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let last_with_link = index + 1 == LINKCELLS && !next_is_none;
         let next = if last_with_link {
@@ -30214,7 +30213,7 @@ fn tee_dataobject_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
         } else {
             pyre_object::interp_itertools::w_tee_chained_list_node_new()
         };
-        pyre_object::gc_roots::pin_root(next);
+        let _ = pyre_object::gc_roots::pin_root(next);
         let next_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
         let current = unsafe { pyre_object::gc_roots::shadow_stack_get(current_slot) };
@@ -30252,9 +30251,9 @@ fn tee_iterable_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     }
 
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(values[0]);
+    let _ = pyre_object::gc_roots::pin_root(values[0]);
     let source_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let (w_iterator, w_chained_list) = if unsafe {
         pyre_object::interp_itertools::is_tee_iterable(values[0])
@@ -30345,10 +30344,10 @@ pub(crate) fn itertools_tee(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
         )));
     }
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(positional[0]);
+    let _ = pyre_object::gc_roots::pin_root(positional[0]);
     let source_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     if positional.len() == 2 {
-        pyre_object::gc_roots::pin_root(positional[1]);
+        let _ = pyre_object::gc_roots::pin_root(positional[1]);
     }
     let n = if positional.len() == 2 {
         crate::builtins::space_index_w(unsafe {
@@ -30366,7 +30365,7 @@ pub(crate) fn itertools_tee(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 
     let w_iterator =
         crate::baseobjspace::iter(unsafe { pyre_object::gc_roots::shadow_stack_get(source_slot) })?;
-    pyre_object::gc_roots::pin_root(w_iterator);
+    let _ = pyre_object::gc_roots::pin_root(w_iterator);
     let iterator_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     // `n` is the caller's requested copy count, so the reservation is fallible.
@@ -30375,7 +30374,7 @@ pub(crate) fn itertools_tee(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
         unsafe { pyre_object::gc_roots::shadow_stack_get(iterator_slot) },
         "__copy__",
     )? {
-        pyre_object::gc_roots::pin_root(w_copy);
+        let _ = pyre_object::gc_roots::pin_root(w_copy);
         let copy_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let first_copy = if unsafe {
             pyre_object::interp_itertools::is_tee_iterable(pyre_object::gc_roots::shadow_stack_get(
@@ -30395,19 +30394,19 @@ pub(crate) fn itertools_tee(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
                 unsafe { pyre_object::gc_roots::shadow_stack_get(copy_slot) },
                 &[],
             )?;
-            pyre_object::gc_roots::pin_root(copied);
+            let _ = pyre_object::gc_roots::pin_root(copied);
             result_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
         }
     } else {
         let node = pyre_object::interp_itertools::w_tee_chained_list_node_new();
-        pyre_object::gc_roots::pin_root(node);
+        let _ = pyre_object::gc_roots::pin_root(node);
         let node_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         for _ in 0..n {
             let tee = pyre_object::interp_itertools::w_tee_iterable_new(
                 unsafe { pyre_object::gc_roots::shadow_stack_get(iterator_slot) },
                 unsafe { pyre_object::gc_roots::shadow_stack_get(node_slot) },
             );
-            pyre_object::gc_roots::pin_root(tee);
+            let _ = pyre_object::gc_roots::pin_root(tee);
             result_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
         }
     }
@@ -30548,9 +30547,9 @@ fn itertools_posonly_iter_new(
     )?;
 
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(values[0]);
+    let _ = pyre_object::gc_roots::pin_root(values[0]);
     let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let iterator =
         crate::baseobjspace::iter(unsafe { pyre_object::gc_roots::shadow_stack_get(value_slot) })?;
@@ -30650,11 +30649,11 @@ fn chain_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     )?;
 
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let sources_base = pyre_object::gc_roots::shadow_stack_len();
     for &source in positional.get(1..).unwrap_or(&[]) {
-        pyre_object::gc_roots::pin_root(source);
+        let _ = pyre_object::gc_roots::pin_root(source);
     }
     let sources = (0..positional.len().saturating_sub(1))
         .map(|index| unsafe { pyre_object::gc_roots::shadow_stack_get(sources_base + index) })
@@ -30687,9 +30686,9 @@ fn chain_from_iterable(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     }
     let cls = positional[0];
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(cls);
+    let _ = pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(positional[1]);
+    let _ = pyre_object::gc_roots::pin_root(positional[1]);
     let iterable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let w_iterables = crate::baseobjspace::iter(unsafe {
         pyre_object::gc_roots::shadow_stack_get(iterable_slot)
@@ -31041,7 +31040,7 @@ fn descr_del_dict(
     // already been evaluated.
     let roots = pyre_object::gc_roots::push_roots();
     let obj_slot = roots.base();
-    roots.pin_root(w_obj);
+    let _ = roots.pin_root(w_obj);
     let w_dict = pyre_object::w_dict_new();
     crate::baseobjspace::setdict(roots.get(obj_slot), w_dict)?;
     Ok(pyre_object::w_none())

--- a/pyre/pyre-interpreter/src/warn.rs
+++ b/pyre/pyre-interpreter/src/warn.rs
@@ -63,7 +63,7 @@ pub fn warn_category_w(
         .filter(|_| crate::module::_warnings::state_is_readable())
     else {
         let _roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_msg);
+        let w_msg = pyre_object::gc_roots::pin_root(w_msg);
         let text = crate::baseobjspace::text_w(w_msg)
             .map(|text| text.to_string())
             .unwrap_or_default();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -4775,7 +4775,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
             let arg_roots = pyre_object::gc_roots::push_roots();
             let arg_root_base = pyre_object::gc_roots::shadow_stack_len();
             for concrete in callee_arg_concretes.iter().take(seeded_locals).copied() {
-                pyre_object::gc_roots::pin_root(concrete.to_pyobj());
+                let _ = pyre_object::gc_roots::pin_root(concrete.to_pyobj());
             }
             let concrete_args: Vec<pyre_object::PyObjectRef> = (0..seeded_locals)
                 .map(|i| pyre_object::gc_roots::shadow_stack_get(arg_root_base + i))
@@ -7287,13 +7287,13 @@ pub(crate) fn try_walker_specialize_instance_next<Sym: WalkSym>(
 
     let _roots = pyre_object::gc_roots::push_roots();
     let iter_root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(iter_obj);
+    let _ = pyre_object::gc_roots::pin_root(iter_obj);
     let type_root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_type);
+    let _ = pyre_object::gc_roots::pin_root(w_type);
     let next_root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_next);
+    let _ = pyre_object::gc_roots::pin_root(w_next);
     let code_root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_code as pyre_object::PyObjectRef);
+    let _ = pyre_object::gc_roots::pin_root(w_code as pyre_object::PyObjectRef);
 
     let iter_obj = pyre_object::gc_roots::shadow_stack_get(iter_root);
     let w_type = pyre_object::gc_roots::shadow_stack_get(type_root);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -65,14 +65,14 @@ fn walker_emit_recorded_builtin_raise<Sym: WalkSym>(
     // these values are baked into the trace as `ConstPtr`s, which outlive the
     // walk.  Same shape as the zip/tuple concrete-shadow build below.
     let exc_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(exc);
+    let exc = pyre_object::gc_roots::pin_root(exc);
     let args_storage = unsafe {
         pyre_object::interp_exceptions::w_exception_get_args_storage(
             pyre_object::gc_roots::shadow_stack_get(exc_slot),
         )
     };
     let args_storage_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args_storage);
+    let _ = pyre_object::gc_roots::pin_root(args_storage);
     let args_len = unsafe {
         pyre_object::w_list_len(pyre_object::gc_roots::shadow_stack_get(args_storage_slot))
     };
@@ -86,7 +86,7 @@ fn walker_emit_recorded_builtin_raise<Sym: WalkSym>(
         }
         .expect("recorded exception args were validated before trace emission");
         let arg_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(arg);
+        let _ = pyre_object::gc_roots::pin_root(arg);
         concrete_args.push(unsafe { pyre_object::gc_roots::shadow_stack_get(arg_slot) });
     }
     let args = concrete_args
@@ -8388,23 +8388,23 @@ pub(crate) fn try_walker_specialize_builtin_zip<Sym: WalkSym>(
     // Recognition is complete; build the authentic shadow before emitting.
     let roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(*tuple0);
-    pyre_object::gc_roots::pin_root(*tuple1);
+    let _ = pyre_object::gc_roots::pin_root(*tuple0);
+    let _ = pyre_object::gc_roots::pin_root(*tuple1);
     let concrete_iter0 = pyre_object::w_tuple_iter_new(unsafe {
         pyre_object::gc_roots::shadow_stack_get(root_base)
     });
-    pyre_object::gc_roots::pin_root(concrete_iter0);
+    let _ = pyre_object::gc_roots::pin_root(concrete_iter0);
     let iter0_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let concrete_iter1 = pyre_object::w_tuple_iter_new(unsafe {
         pyre_object::gc_roots::shadow_stack_get(root_base + 1)
     });
-    pyre_object::gc_roots::pin_root(concrete_iter1);
+    let _ = pyre_object::gc_roots::pin_root(concrete_iter1);
     let iter1_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let concrete_list = pyre_object::w_list_new(vec![
         unsafe { pyre_object::gc_roots::shadow_stack_get(iter0_slot) },
         unsafe { pyre_object::gc_roots::shadow_stack_get(iter1_slot) },
     ]);
-    pyre_object::gc_roots::pin_root(concrete_list);
+    let _ = pyre_object::gc_roots::pin_root(concrete_list);
     let list_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let concrete_zip = pyre_object::functional::w_zip_new(
         unsafe { pyre_object::gc_roots::shadow_stack_get(list_slot) },
@@ -8414,7 +8414,7 @@ pub(crate) fn try_walker_specialize_builtin_zip<Sym: WalkSym>(
         drop(roots);
         return Err(DispatchError::ConcreteShadowAllocationFailed { pc: op.pc });
     }
-    pyre_object::gc_roots::pin_root(concrete_zip);
+    let _ = pyre_object::gc_roots::pin_root(concrete_zip);
     let zip_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     walker_guard_builtin_callable_identity(ctx, op.pc, r_args[0], *callable)?;
@@ -8804,7 +8804,7 @@ pub(crate) fn try_walker_specialize_builtin_locals<Sym: WalkSym>(
         // Re-read rather than reuse the gate's `w_locals`: the slot resolution
         // above sits between the two, so the pin takes the address the frame
         // holds NOW.
-        pyre_object::gc_roots::pin_root(if frame_owned {
+        let _ = pyre_object::gc_roots::pin_root(if frame_owned {
             frame_ref.get_w_locals()
         } else {
             unsafe { pyre_object::w_dict_new() }
@@ -8813,7 +8813,7 @@ pub(crate) fn try_walker_specialize_builtin_locals<Sym: WalkSym>(
             .iter()
             .map(|&value| {
                 let slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(value);
+                let _ = pyre_object::gc_roots::pin_root(value);
                 slot
             })
             .collect();
@@ -13656,7 +13656,7 @@ pub(crate) fn try_walker_trace_immutable_type_attr_raise<Sym: WalkSym>(
     // and rooted by the compiled loop's gcref table thereafter.
     let _roots = pyre_object::gc_roots::push_roots();
     let exc_root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(exc);
+    let _ = pyre_object::gc_roots::pin_root(exc);
     let msg = pyre_object::w_str_from_wtf8(err.message.clone());
     // The root keeps the exception alive across that allocation but does not
     // fix its address: a minor collection moves the object and rewrites the
@@ -13914,7 +13914,7 @@ pub(crate) fn try_walker_trace_readonly_descr_attr_raise<Sym: WalkSym>(
 
     let _roots = pyre_object::gc_roots::push_roots();
     let exc_root = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(exc);
+    let _ = pyre_object::gc_roots::pin_root(exc);
     let msg = pyre_object::w_str_from_wtf8(err.message.clone());
     // The allocation may move the exception and leave the local pointer naming
     // its forwarded corpse; the shadow slot contains the live address.
@@ -15389,7 +15389,7 @@ pub(crate) fn try_walker_specialize_setslice<Sym: WalkSym>(
                 unreachable!("setslice specialization: source index {j} has no element");
             };
             let src_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(src_item);
+            let _ = pyre_object::gc_roots::pin_root(src_item);
             let Some(list_obj) = walker_concrete_ref_object(ctx, list_op) else {
                 unreachable!("setslice specialization: operand concrete vanished from the shadow");
             };
@@ -15401,9 +15401,9 @@ pub(crate) fn try_walker_specialize_setslice<Sym: WalkSym>(
                 );
             };
             let disp_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(displaced);
+            let _ = pyre_object::gc_roots::pin_root(displaced);
             let key_box = pyre_object::w_int_new(tgt_index);
-            pyre_object::gc_roots::pin_root(key_box);
+            let key_box = pyre_object::gc_roots::pin_root(key_box);
             let Some(list_obj) = walker_concrete_ref_object(ctx, list_op) else {
                 unreachable!("setslice specialization: list concrete vanished mid-apply");
             };

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -14924,7 +14924,7 @@ pub(crate) fn setup_reconstructed_callee_frame(
                 }
                 _ => PY_NULL,
             };
-            pyre_object::gc_roots::pin_root(obj);
+            let _ = pyre_object::gc_roots::pin_root(obj);
         }
         let concrete_locals: Vec<pyre_object::PyObjectRef> = (0..locals_boxes.len())
             .map(|k| pyre_object::gc_roots::shadow_stack_get(arg_root_base + k))
@@ -14968,8 +14968,8 @@ pub(crate) fn setup_reconstructed_callee_frame(
     // op becomes its trace root.
     let concrete_roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_code as pyre_object::PyObjectRef);
-    pyre_object::gc_roots::pin_root(w_globals as pyre_object::PyObjectRef);
+    let _ = pyre_object::gc_roots::pin_root(w_code as pyre_object::PyObjectRef);
+    let _ = pyre_object::gc_roots::pin_root(w_globals as pyre_object::PyObjectRef);
     for (slot, &captured) in recipe.concrete_r[..stack_base].iter().enumerate() {
         let value = match captured {
             majit_ir::Value::Ref(gc) if gc != majit_ir::GcRef::NO_CONCRETE => {
@@ -14981,7 +14981,7 @@ pub(crate) fn setup_reconstructed_callee_frame(
             majit_ir::Value::Void => pyre_object::PY_NULL,
             _ => return None,
         };
-        pyre_object::gc_roots::pin_root(value);
+        let _ = pyre_object::gc_roots::pin_root(value);
     }
     let closure = if stack_base == nlocals {
         pyre_object::PY_NULL
@@ -14990,7 +14990,7 @@ pub(crate) fn setup_reconstructed_callee_frame(
             .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + 2 + i))
             .collect();
         let closure = pyre_object::w_tuple_new(cells);
-        pyre_object::gc_roots::pin_root(closure);
+        let closure = pyre_object::gc_roots::pin_root(closure);
         closure
     };
     let closure_root = (stack_base != nlocals).then_some(root_base + 2 + stack_base);

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -536,11 +536,11 @@ fn park_residual_call_exception() -> ParkedResidualException {
     let save = pyre_object::gc_roots::shadow_stack_len();
     let bh_pinned = bh != 0;
     if bh_pinned {
-        pyre_object::gc_roots::pin_root(bh as pyre_object::PyObjectRef);
+        let _ = pyre_object::gc_roots::pin_root(bh as pyre_object::PyObjectRef);
     }
     let backend_pinned = backend != 0;
     if backend_pinned {
-        pyre_object::gc_roots::pin_root(backend as pyre_object::PyObjectRef);
+        let _ = pyre_object::gc_roots::pin_root(backend as pyre_object::PyObjectRef);
     }
     majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
     drain_backend_jit_exc();
@@ -877,7 +877,7 @@ pub(crate) extern "C" fn resolve_exception_context(exc_value: i64) -> i64 {
         return existing as i64;
     }
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_exc);
+    let w_exc = pyre_object::gc_roots::pin_root(w_exc);
     let active = pyre_interpreter::eval::get_sys_exception();
     pyre_interpreter::error::chain_context(w_exc, active);
     unsafe { pyre_object::interp_exceptions::w_exception_get_context(w_exc) as i64 }
@@ -919,9 +919,9 @@ pub(crate) extern "C" fn record_inline_traceback_for_recording(
     let w_code = w_code_value as PyObjectRef;
     let w_globals = w_globals_value as PyObjectRef;
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_exc);
-    pyre_object::gc_roots::pin_root(w_code);
-    pyre_object::gc_roots::pin_root(w_globals);
+    let w_exc = pyre_object::gc_roots::pin_root(w_exc);
+    let w_code = pyre_object::gc_roots::pin_root(w_code);
+    let w_globals = pyre_object::gc_roots::pin_root(w_globals);
     // `record_application_traceback` requires the traceback's own frame
     // identity. The recording walker cannot force the optimizer's virtual
     // locals, so materialize a traceback-only frame from the promoted callee
@@ -941,7 +941,7 @@ pub(crate) extern "C" fn record_inline_traceback_for_recording(
     // traceback.clear_frames() must not mistake it for a live activation.
     frame.set_frame_finished_execution(true);
     let frame_ptr = frame.into_raw();
-    pyre_object::gc_roots::pin_root(frame_ptr as PyObjectRef);
+    let _ = pyre_object::gc_roots::pin_root(frame_ptr as PyObjectRef);
     unsafe {
         pyre_interpreter::pytraceback::record_application_traceback(
             w_exc,
@@ -1000,9 +1000,9 @@ pub(crate) extern "C" fn record_discarded_level_traceback(
     let w_globals = unsafe { pyre_interpreter::w_code_get_w_globals(w_code) };
     let w_exc = exc_value as PyObjectRef;
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_exc);
-    pyre_object::gc_roots::pin_root(w_code);
-    pyre_object::gc_roots::pin_root(w_globals);
+    let w_exc = pyre_object::gc_roots::pin_root(w_exc);
+    let w_code = pyre_object::gc_roots::pin_root(w_code);
+    let w_globals = pyre_object::gc_roots::pin_root(w_globals);
     let Ok(mut frame) = pyre_interpreter::createframe_obj(
         w_code as *const (),
         w_globals,
@@ -1016,7 +1016,7 @@ pub(crate) extern "C" fn record_discarded_level_traceback(
     // unwind, exactly the `pyopcode.py:184` finished-frame transition.
     frame.set_frame_finished_execution(true);
     let frame_ptr = frame.into_raw();
-    pyre_object::gc_roots::pin_root(frame_ptr as PyObjectRef);
+    let _ = pyre_object::gc_roots::pin_root(frame_ptr as PyObjectRef);
     unsafe {
         pyre_interpreter::pytraceback::record_application_traceback(
             w_exc,
@@ -2939,7 +2939,7 @@ pub fn blackhole_resume_via_rd_numb(
             // its whole life; root the value across the equivalent window.
             let _exc_roots = pyre_object::gc_roots::push_roots();
             let exc_slot = pyre_object::gc_roots::shadow_stack_len();
-            pyre_object::gc_roots::pin_root(bh.exception_last_value as PyObjectRef);
+            let _ = pyre_object::gc_roots::pin_root(bh.exception_last_value as PyObjectRef);
             let exc_value = bh.exception_last_value;
             let next = bh.nextblackholeinterp.take();
             let frame_ptr = bh.virtualizable_ptr as *mut PyFrame;
@@ -5221,10 +5221,10 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
     // dispatch only values reloaded from the forwarded slots.
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = _roots.base();
-    _roots.pin_root(callable);
-    _roots.pin_root(null_or_self);
+    let _ = _roots.pin_root(callable);
+    let _ = _roots.pin_root(null_or_self);
     for &arg in args {
-        _roots.pin_root(arg);
+        let _ = _roots.pin_root(arg);
     }
     // `eval.rs`'s `PyFrame::call` — a non-null null_or_self is the method receiver
     // (load_method_fast_path pushes `[w_descr, w_obj]`); the call proceeds
@@ -5331,8 +5331,8 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
             && unsafe { pyre_interpreter::builtin_code_get_fast_natural_arity(code) as usize }
                 == positional_count;
         if exact_fixed_arity {
-            _roots.pin_root(code);
-            _roots.pin_root(receiver);
+            let _ = _roots.pin_root(code);
+            let _ = _roots.pin_root(receiver);
             let code_slot = root_base + 2 + args.len();
             let receiver_slot = code_slot + 1;
             let mut call_args = [pyre_object::PY_NULL; 4];

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6811,8 +6811,8 @@ fn drive_unpack_iterable_trace(
         // scope guard truncates both entries on the way out; `pin_root` without
         // one grows `ln`'s shadow stack by two per jd1 crossing.
         let _enter_roots = pyre_object::gc_roots::push_roots();
-        pyre_object::gc_roots::pin_root(w_iterator);
-        pyre_object::gc_roots::pin_root(items);
+        let _ = pyre_object::gc_roots::pin_root(w_iterator);
+        let items = pyre_object::gc_roots::pin_root(items);
         let before = unsafe { pyre_object::listobject::w_list_len(items) };
         // A drain-time error that is not the loop-exit StopIteration has to
         // travel out of the unpack; `ln` cannot re-derive it, because calling

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -2162,7 +2162,7 @@ fn expand_pyre_methods(
                 // reload it before stamping the result.
                 let __pyre_new_roots = ::pyre_object::gc_roots::push_roots();
                 let __pyre_cls_input = args.first().copied().unwrap_or(::pyre_object::PY_NULL);
-                ::pyre_object::gc_roots::pin_root(__pyre_cls_input);
+                let _ = ::pyre_object::gc_roots::pin_root(__pyre_cls_input);
                 let __pyre_cls_slot = ::pyre_object::gc_roots::shadow_stack_len() - 1;
                 let __pyre_obj: ::pyre_object::PyObjectRef = match { #body } {
                     ::std::result::Result::Ok(o) => o,

--- a/pyre/pyre-object/src/_pypy_generic_alias.rs
+++ b/pyre/pyre-object/src/_pypy_generic_alias.rs
@@ -46,9 +46,9 @@ pub fn w_generic_alias_new(
     // `gct_fv_gc_malloc` bracket pattern (`framework.py`).
     let _roots = crate::gc_roots::push_roots();
     let save_point = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(origin);
-    crate::gc_roots::pin_root(args);
-    crate::gc_roots::pin_root(parameters);
+    let _ = crate::gc_roots::pin_root(origin);
+    let _ = crate::gc_roots::pin_root(args);
+    let _ = crate::gc_roots::pin_root(parameters);
     // Allocate with empty pointer fields, then reload the GC-forwarded roots
     // and install them.  Building the payload before `allocate` retained the
     // pre-minor-collection addresses even though the shadow-stack slots were
@@ -206,19 +206,19 @@ pub fn w_union_from_parts(
     // `gct_fv_gc_malloc` bracket pattern (`framework.py`).
     let _roots = crate::gc_roots::push_roots();
     let save_point = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(hashable_args);
-    crate::gc_roots::pin_root(unhashable_args);
-    crate::gc_roots::pin_root(parameters);
+    let _ = crate::gc_roots::pin_root(hashable_args);
+    let _ = crate::gc_roots::pin_root(unhashable_args);
+    let _ = crate::gc_roots::pin_root(parameters);
     let member_base = crate::gc_roots::shadow_stack_len();
     for member in members {
-        crate::gc_roots::pin_root(member);
+        let _ = crate::gc_roots::pin_root(member);
     }
     let args = crate::w_tuple_new(
         (member_base..crate::gc_roots::shadow_stack_len())
             .map(crate::gc_roots::shadow_stack_get)
             .collect(),
     );
-    crate::gc_roots::pin_root(args);
+    let _ = crate::gc_roots::pin_root(args);
     let args_slot = crate::gc_roots::shadow_stack_len() - 1;
     // CPython's unionobject is GC-owned and traverses all four object fields.
     // The stable managed bridge preserves that ownership while interpreter

--- a/pyre/pyre-object/src/bytearrayobject.rs
+++ b/pyre/pyre-object/src/bytearrayobject.rs
@@ -164,7 +164,7 @@ pub fn w_bytearray_from_bytes(bytes: &[u8]) -> PyObjectRef {
 pub fn w_bytearray_subclass_from_bytes(bytes: &[u8], w_class: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(w_class);
+    let _ = crate::gc_roots::pin_root(w_class);
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(
         <W_BytearrayObject as crate::lltype::GcType>::type_id(),
         <W_BytearrayObject as crate::lltype::GcType>::SIZE,

--- a/pyre/pyre-object/src/bytesobject.rs
+++ b/pyre/pyre-object/src/bytesobject.rs
@@ -140,7 +140,7 @@ pub fn w_bytes_from_bytes(bytes: &[u8]) -> PyObjectRef {
 pub fn w_bytes_subclass_from_bytes(bytes: &[u8], w_class: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(w_class);
+    let _ = crate::gc_roots::pin_root(w_class);
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(
         <W_BytesObject as crate::lltype::GcType>::type_id(),
         <W_BytesObject as crate::lltype::GcType>::SIZE,

--- a/pyre/pyre-object/src/descriptor.rs
+++ b/pyre/pyre-object/src/descriptor.rs
@@ -40,10 +40,9 @@ pub fn w_super_new(
     // survive a later minor collection.
     let _roots = crate::gc_roots::push_roots();
     let save_point = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(super_type);
-    crate::gc_roots::pin_root(obj_type);
-    crate::gc_roots::pin_root(obj);
-
+    let _ = crate::gc_roots::pin_root(super_type);
+    let _ = crate::gc_roots::pin_root(obj_type);
+    let _ = crate::gc_roots::pin_root(obj);
     let header = PyObject {
         ob_type: &SUPER_TYPE as *const PyType,
         w_class: get_instantiate(&SUPER_TYPE),
@@ -211,10 +210,9 @@ pub fn w_property_new(fget: PyObjectRef, fset: PyObjectRef, fdel: PyObjectRef) -
     // barrier (`set_doc`/`set_name`).
     let _roots = crate::gc_roots::push_roots();
     let save_point = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(fget);
-    crate::gc_roots::pin_root(fset);
-    crate::gc_roots::pin_root(fdel);
-
+    let _ = crate::gc_roots::pin_root(fget);
+    let _ = crate::gc_roots::pin_root(fset);
+    let _ = crate::gc_roots::pin_root(fdel);
     let header = PyObject {
         ob_type: &PROPERTY_TYPE as *const PyType,
         w_class: get_instantiate(&PROPERTY_TYPE),

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -154,7 +154,7 @@ pub unsafe fn object_key_for(obj: PyObjectRef) -> ObjectKey {
     // pre-move pointer and every later probe dereferences reclaimed memory.
     let _roots = crate::gc_roots::push_roots();
     let obj_slot = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(obj);
+    let obj = crate::gc_roots::pin_root(obj);
     let hash = crate::dict_eq_hook::try_hash_w(obj)
         .unwrap_or_else(|| crate::dict_eq_hook::missing_hash_hook());
     if crate::dict_eq_hook::take_hash_error() {
@@ -393,7 +393,7 @@ pub unsafe fn dict_entries_insert_object(
     // here and insert the reloaded one.
     let roots = crate::gc_roots::push_roots();
     let value_slot = roots.base();
-    roots.pin_root(value);
+    let _ = roots.pin_root(value);
     let object_key = object_key_for(key);
     entries.insert(object_key, roots.get(value_slot));
 }
@@ -619,7 +619,7 @@ pub unsafe fn object_key_for_checked(obj: PyObjectRef) -> Result<ObjectKey, Dict
     // key caches the pointer, so key on the reloaded address.
     let _roots = crate::gc_roots::push_roots();
     let obj_slot = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(obj);
+    let obj = crate::gc_roots::pin_root(obj);
     let hash = crate::dict_eq_hook::try_hash_w(obj)
         .unwrap_or_else(|| crate::dict_eq_hook::missing_hash_hook());
     if crate::dict_eq_hook::take_hash_error() {
@@ -1492,7 +1492,7 @@ pub fn alloc_dict_object(value: W_DictObject, stable: bool) -> PyObjectRef {
     let mut value = value;
     let _roots = crate::gc_roots::push_roots();
     let save_point = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(value.dstorage as PyObjectRef);
+    let _ = crate::gc_roots::pin_root(value.dstorage as PyObjectRef);
     let raw = if stable {
         crate::gc_hook::try_gc_alloc_stable_raw(W_DICT_GC_TYPE_ID, W_DICT_OBJECT_SIZE)
     } else {
@@ -2124,7 +2124,7 @@ unsafe fn w_module_dict_setitem_str_internal(obj: PyObjectRef, key: &str, w_valu
         // whichever arm writes it.
         let roots = crate::gc_roots::push_roots();
         let value_slot = roots.base();
-        roots.pin_root(w_value);
+        let _ = roots.pin_root(w_value);
         let entries = w_module_dict_object_storage_mut(obj);
         match dict_entries_index_of_str(entries, key, 0) {
             Some(idx) => {
@@ -2598,7 +2598,7 @@ macro_rules! with_dict_rooted {
     ($obj:ident, $body:expr) => {{
         let _scope = crate::gc_roots::push_roots();
         let slot = crate::gc_roots::shadow_stack_len();
-        crate::gc_roots::pin_root($obj);
+        let _ = crate::gc_roots::pin_root($obj);
         let result = $body;
         $obj = crate::gc_roots::shadow_stack_get(slot);
         result
@@ -2673,8 +2673,7 @@ unsafe fn scan_dict_key_reentrant(
         // fresh allocation, so a stale index would compare the wrong key.
         let _attempt = crate::gc_roots::push_roots();
         let obj_slot = crate::gc_roots::shadow_stack_len();
-        crate::gc_roots::pin_root(obj);
-        obj = crate::gc_roots::shadow_stack_get(obj_slot);
+        obj = crate::gc_roots::pin_root(obj);
         let (table_capacity, clear_generation) = (
             dict_entries_capacity(scan_object_entries(obj)),
             scan_clear_generation(obj),
@@ -2693,9 +2692,9 @@ unsafe fn scan_dict_key_reentrant(
             if stored_hash == key.hash {
                 let _roots = crate::gc_roots::push_roots();
                 let stored_slot = crate::gc_roots::shadow_stack_len();
-                crate::gc_roots::pin_root(stored_obj);
+                let stored_obj = crate::gc_roots::pin_root(stored_obj);
                 let key_slot = crate::gc_roots::shadow_stack_len();
-                crate::gc_roots::pin_root(key.obj);
+                let _ = crate::gc_roots::pin_root(key.obj);
 
                 let equal = dict_keys_equal(stored_obj, key.obj);
                 obj = crate::gc_roots::shadow_stack_get(obj_slot);
@@ -3111,7 +3110,7 @@ pub unsafe fn w_dict_setdefault_checked(
         // and reload it alongside the container the scan returns.
         let _value_root = crate::gc_roots::push_roots();
         let value_slot = crate::gc_roots::shadow_stack_len();
-        crate::gc_roots::pin_root(value);
+        let _ = crate::gc_roots::pin_root(value);
         let (found, object_key, obj) = scan_dict_key_reentrant(obj, object_key)?;
         let value = crate::gc_roots::shadow_stack_get(value_slot);
         if let Some(i) = found {
@@ -3357,7 +3356,7 @@ unsafe fn w_dict_store_object_strategy_checked_inner(
     // and reload it alongside the container the scan returns.
     let _value_root = crate::gc_roots::push_roots();
     let value_slot = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(value);
+    let _ = crate::gc_roots::pin_root(value);
     let (found, object_key, obj) = scan_dict_key_reentrant(obj, object_key)?;
     let value = crate::gc_roots::shadow_stack_get(value_slot);
     match found {
@@ -4000,7 +3999,7 @@ pub unsafe fn w_dict_delitem_if_value_is_checked(
         // the identity check), then remove in place on the module storage.
         let _value_root = crate::gc_roots::push_roots();
         let value_slot = crate::gc_roots::shadow_stack_len();
-        crate::gc_roots::pin_root(value);
+        let _ = crate::gc_roots::pin_root(value);
         let (found, _, obj) = scan_dict_key_reentrant(obj, object_key)?;
         let value = crate::gc_roots::shadow_stack_get(value_slot);
         let Some(index) = found else {
@@ -4051,7 +4050,7 @@ pub unsafe fn w_dict_delitem_if_value_is_checked(
     // and reload it alongside the container the scan returns.
     let _value_root = crate::gc_roots::push_roots();
     let value_slot = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(value);
+    let _ = crate::gc_roots::pin_root(value);
     let (found, _, obj) = scan_dict_key_reentrant(obj, object_key)?;
     let value = crate::gc_roots::shadow_stack_get(value_slot);
     let Some(index) = found else {
@@ -4779,7 +4778,7 @@ pub unsafe fn w_dict_nth_item_int_strategy(
     // Wrapping the key collects, and `v` is a bare local by then.
     let roots = crate::gc_roots::push_roots();
     let value_slot = roots.base();
-    roots.pin_root(v);
+    let _ = roots.pin_root(v);
     let w_key = crate::w_int_new(k);
     Some((w_key, roots.get(value_slot)))
 }
@@ -4824,7 +4823,7 @@ pub unsafe fn w_dict_switch_int_to_object_strategy(w_dict: PyObjectRef) {
     // from those slots once every allocation is behind us.
     let roots = crate::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(w_dict);
+    let w_dict = roots.pin_root(w_dict);
     // Borrow the old typed box (its field stays live, so it is traced
     // while the migration allocates keys); after the store the box is
     // unreachable and the sweep reclaims it.
@@ -4970,7 +4969,7 @@ pub unsafe fn w_dict_nth_item_bytes_strategy(
     // Wrapping the key collects, and `value` is a bare local by then.
     let roots = crate::gc_roots::push_roots();
     let value_slot = roots.base();
-    roots.pin_root(*v);
+    let _ = roots.pin_root(*v);
     let w_key = crate::w_bytes_from_bytes(key_bytes.as_slice());
     Some((w_key, roots.get(value_slot)))
 }
@@ -5000,7 +4999,7 @@ pub unsafe fn w_dict_switch_bytes_to_object_strategy(w_dict: PyObjectRef) {
     // same three reasons.
     let roots = crate::gc_roots::push_roots();
     let dict_slot = roots.base();
-    roots.pin_root(w_dict);
+    let w_dict = roots.pin_root(w_dict);
     let old = &*((*(w_dict as *const W_DictObject)).dstorage as *const BytesDictStorage);
     let len = old.len();
     let mut hashes = Vec::with_capacity(len);
@@ -5212,7 +5211,7 @@ pub unsafe fn w_module_dict_items_inner(obj: PyObjectRef) -> Vec<(PyObjectRef, P
         let roots = crate::gc_roots::push_roots();
         let keys_base = roots.base();
         for k in strategy.getiterkeys(storage) {
-            roots.pin_root(crate::w_str_new(k));
+            let _ = roots.pin_root(crate::w_str_new(k));
         }
         strategy
             .getitervalues(storage)
@@ -5256,7 +5255,7 @@ pub unsafe fn w_module_dict_nth_item_inner(
     // back afterwards — the cell storage keeps it traced.
     let roots = crate::gc_roots::push_roots();
     let key_slot = roots.base();
-    roots.pin_root(crate::w_str_new(key));
+    let _ = roots.pin_root(crate::w_str_new(key));
     let value = strategy.nth_unwrapped_value(&*w_module_dict_get_storage(obj), index)?;
     Some((roots.get(key_slot), value))
 }
@@ -5515,7 +5514,7 @@ fn w_dict_view_iterator_new_direction(
     let tp = dict_view_iterator_type_for_kind(kind, reverse);
     let _roots = crate::gc_roots::push_roots();
     let dict_slot = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(w_dict);
+    let _ = crate::gc_roots::pin_root(w_dict);
     let startlen = unsafe { w_dict_len(crate::gc_roots::shadow_stack_get(dict_slot)) };
     let start_keys_version =
         unsafe { w_dict_keys_version(crate::gc_roots::shadow_stack_get(dict_slot)) };
@@ -5686,7 +5685,7 @@ pub fn w_dict_view_new(w_dict: PyObjectRef, kind: DictViewKind) -> PyObjectRef {
     let tp = dict_view_type_for_kind(kind);
     let _roots = crate::gc_roots::push_roots();
     let dict_slot = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(w_dict);
+    let _ = crate::gc_roots::pin_root(w_dict);
     let raw =
         crate::gc_hook::try_gc_alloc_stable_raw(W_DICT_VIEW_GC_TYPE_ID, W_DICT_VIEW_OBJECT_SIZE);
     let value = W_DictViewObject {
@@ -5998,7 +5997,7 @@ pub trait DictStrategy {
         let value_slot = dict_slot + 3;
         let w_item = self.getitem(w_dict, w_key);
         if let Some(val) = w_item {
-            roots.pin_root(val);
+            let _ = roots.pin_root(val);
             if !self.delitem(roots.get(dict_slot), roots.get(dict_slot + 1)) {
                 return Err(DictPopError);
             }
@@ -6025,7 +6024,7 @@ pub trait DictStrategy {
         // the removal and the returned pair is stale after it.
         let roots = crate::gc_roots::push_roots();
         let dict_slot = roots.base();
-        roots.pin_root(w_dict);
+        let w_dict = roots.pin_root(w_dict);
         let mut items = self.items(w_dict);
         let (w_key, w_value) = items.pop()?;
         let pair_base = roots.publish(&[w_key, w_value]);
@@ -6316,7 +6315,7 @@ pub struct EmptyDictStrategy;
 unsafe fn install_empty_strategy(w_dict: PyObjectRef, strategy: &'static DictStrategyRef) {
     let _roots = crate::gc_roots::push_roots();
     let dict_slot = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(w_dict);
+    let _ = crate::gc_roots::pin_root(w_dict);
     let storage = strategy.get_empty_storage();
     let w_dict = crate::gc_roots::shadow_stack_get(dict_slot);
     let dict = &mut *(w_dict as *mut crate::dictmultiobject::W_DictObject);
@@ -7070,7 +7069,7 @@ impl DictStrategy for BytesDictStrategy {
 
         let _roots = crate::gc_roots::push_roots();
         let value_slot = crate::gc_roots::shadow_stack_len();
-        crate::gc_roots::pin_root(value);
+        let _ = crate::gc_roots::pin_root(value);
         let w_key = crate::w_bytes_from_bytes(key.as_slice());
         let value = crate::gc_roots::shadow_stack_get(value_slot);
         Some((w_key, value))
@@ -7521,7 +7520,7 @@ impl DictStrategy for IntDictStrategy {
 
         let _roots = crate::gc_roots::push_roots();
         let value_slot = crate::gc_roots::shadow_stack_len();
-        crate::gc_roots::pin_root(value);
+        let _ = crate::gc_roots::pin_root(value);
         let w_key = crate::w_int_new(key);
         let value = crate::gc_roots::shadow_stack_get(value_slot);
         Some((w_key, value))

--- a/pyre/pyre-object/src/dictproxyobject.rs
+++ b/pyre/pyre-object/src/dictproxyobject.rs
@@ -77,7 +77,7 @@ pub fn w_dict_proxy_new(w_mapping: PyObjectRef) -> PyObjectRef {
     // it so the young mapping is forwarded on the first minor collection.
     let _roots = crate::gc_roots::push_roots();
     let save_point = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(w_mapping);
+    let _ = crate::gc_roots::pin_root(w_mapping);
     let header = PyObject {
         ob_type: &MAPPING_PROXY_TYPE as *const PyType,
         w_class: get_instantiate(&MAPPING_PROXY_TYPE),

--- a/pyre/pyre-object/src/float_array.rs
+++ b/pyre/pyre-object/src/float_array.rs
@@ -68,7 +68,7 @@ impl FloatArray {
     #[must_use]
     pub fn pin_block(&self) -> usize {
         let slot = crate::gc_roots::shadow_stack_len();
-        crate::gc_roots::pin_root(self.block as crate::PyObjectRef);
+        let _ = crate::gc_roots::pin_root(self.block as crate::PyObjectRef);
         slot
     }
 

--- a/pyre/pyre-object/src/function.rs
+++ b/pyre/pyre-object/src/function.rs
@@ -48,9 +48,9 @@ pub fn w_method_new(
     // young members survive a later minor collection.
     let _roots = crate::gc_roots::push_roots();
     let save_point = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(w_function);
-    crate::gc_roots::pin_root(w_self);
-    crate::gc_roots::pin_root(w_class);
+    let _ = crate::gc_roots::pin_root(w_function);
+    let _ = crate::gc_roots::pin_root(w_self);
+    let _ = crate::gc_roots::pin_root(w_class);
     let header = PyObject {
         ob_type: &METHOD_TYPE as *const PyType,
         w_class: get_instantiate(&METHOD_TYPE),
@@ -204,8 +204,7 @@ pub fn w_staticmethod_new(func: PyObjectRef) -> PyObjectRef {
     // wrapped function across the GC malloc and read its relocated address.
     let _roots = crate::gc_roots::push_roots();
     let save_point = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(func);
-
+    let _ = crate::gc_roots::pin_root(func);
     let header = PyObject {
         ob_type: &STATICMETHOD_TYPE as *const PyType,
         w_class: get_instantiate(&STATICMETHOD_TYPE),
@@ -390,8 +389,7 @@ pub fn w_classmethod_new(func: PyObjectRef) -> PyObjectRef {
     // wrapped function across the GC malloc and read its relocated address.
     let _roots = crate::gc_roots::push_roots();
     let save_point = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(func);
-
+    let _ = crate::gc_roots::pin_root(func);
     let header = PyObject {
         ob_type: &CLASSMETHOD_TYPE as *const PyType,
         w_class: get_instantiate(&CLASSMETHOD_TYPE),

--- a/pyre/pyre-object/src/functional.rs
+++ b/pyre/pyre-object/src/functional.rs
@@ -51,8 +51,8 @@ pub fn w_enumerate_new(
     w_index: PyObjectRef,
 ) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_iter_or_list);
-    crate::gc_roots::pin_root(w_index);
+    let w_iter_or_list = crate::gc_roots::pin_root(w_iter_or_list);
+    let w_index = crate::gc_roots::pin_root(w_index);
     W_Enumerate::allocate_stable(W_Enumerate {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -173,7 +173,7 @@ pub struct W_ReversedIterator {
 /// caller.
 pub fn w_reversed_new(w_sequence: PyObjectRef, remaining: i64) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_sequence);
+    let w_sequence = crate::gc_roots::pin_root(w_sequence);
     W_ReversedIterator::allocate_stable(W_ReversedIterator {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -256,8 +256,8 @@ pub struct W_Map {
 /// iterators (`build_iterators_from_args`).
 pub fn w_map_new(w_fun: PyObjectRef, w_iterators: PyObjectRef, strict: bool) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_fun);
-    crate::gc_roots::pin_root(w_iterators);
+    let w_fun = crate::gc_roots::pin_root(w_fun);
+    let w_iterators = crate::gc_roots::pin_root(w_iterators);
     W_Map::allocate_stable(W_Map {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -341,9 +341,9 @@ pub struct W_Filter {
 pub fn w_filter_new(w_predicate: PyObjectRef, w_iterable: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     if !w_predicate.is_null() {
-        crate::gc_roots::pin_root(w_predicate);
+        let _ = crate::gc_roots::pin_root(w_predicate);
     }
-    crate::gc_roots::pin_root(w_iterable);
+    let w_iterable = crate::gc_roots::pin_root(w_iterable);
     W_Filter::allocate_stable(W_Filter {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -409,7 +409,7 @@ pub struct W_Zip {
 /// iterators (`build_iterators_from_args`).
 pub fn w_zip_new(w_iterators: PyObjectRef, strict: bool) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_iterators);
+    let w_iterators = crate::gc_roots::pin_root(w_iterators);
     W_Zip::allocate_stable(W_Zip {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -706,9 +706,9 @@ pub const RANGE_LENGTH_OFFSET: usize = std::mem::offset_of!(W_Range, length);
 )]
 pub fn w_range_new(start: PyObjectRef, stop: PyObjectRef, step: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(start);
-    crate::gc_roots::pin_root(stop);
-    crate::gc_roots::pin_root(step);
+    let start = crate::gc_roots::pin_root(start);
+    let stop = crate::gc_roots::pin_root(stop);
+    let step = crate::gc_roots::pin_root(step);
     let length = unsafe {
         let len_big = range_length_big(
             &range_obj_to_bigint(start),
@@ -717,7 +717,7 @@ pub fn w_range_new(start: PyObjectRef, stop: PyObjectRef, step: PyObjectRef) -> 
         );
         range_bigint_to_obj(len_big)
     };
-    crate::gc_roots::pin_root(length);
+    let length = crate::gc_roots::pin_root(length);
     W_Range::allocate_stable(W_Range {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -916,11 +916,11 @@ pub unsafe fn w_range_reversed(obj: PyObjectRef) -> PyObjectRef {
         let len_b = range_obj_to_bigint(len_obj);
         let lastitem = &start_b + (&len_b - BigInt::one()) * &step_b;
         let _roots = crate::gc_roots::push_roots();
-        crate::gc_roots::pin_root(len_obj);
+        let len_obj = crate::gc_roots::pin_root(len_obj);
         let w_lastitem = range_bigint_to_obj(lastitem);
-        crate::gc_roots::pin_root(w_lastitem);
+        let w_lastitem = crate::gc_roots::pin_root(w_lastitem);
         let w_negstep = range_bigint_to_obj(-step_b);
-        crate::gc_roots::pin_root(w_negstep);
+        let w_negstep = crate::gc_roots::pin_root(w_negstep);
         w_long_range_iter_new(w_lastitem, w_negstep, len_obj)
     }
 }
@@ -1070,11 +1070,11 @@ pub fn w_long_range_iter_new(
     len: PyObjectRef,
 ) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(start);
-    crate::gc_roots::pin_root(step);
-    crate::gc_roots::pin_root(len);
+    let start = crate::gc_roots::pin_root(start);
+    let step = crate::gc_roots::pin_root(step);
+    let len = crate::gc_roots::pin_root(len);
     let index = crate::intobject::w_int_new(0);
-    crate::gc_roots::pin_root(index);
+    let index = crate::gc_roots::pin_root(index);
     W_LongRangeIterator::allocate_stable(W_LongRangeIterator {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -1169,10 +1169,10 @@ pub unsafe fn w_long_range_iter_next(obj: PyObjectRef) -> Option<PyObjectRef> {
         // RPython's GC transform roots this local automatically.
         let value = RBigIntGcRoot::new(start + index.translated_alias() * step);
         let _roots = crate::gc_roots::push_roots();
-        crate::gc_roots::pin_root(obj);
+        let _ = crate::gc_roots::pin_root(obj);
         let iter_slot = crate::gc_roots::shadow_stack_len() - 1;
         let next_index = range_bigint_to_obj(index + BigInt::from(1));
-        crate::gc_roots::pin_root(next_index);
+        let next_index = crate::gc_roots::pin_root(next_index);
         let it = crate::gc_roots::shadow_stack_get(iter_slot) as *mut W_LongRangeIterator;
         (*it).index = next_index;
         crate::gc_hook::try_gc_write_barrier(it as *mut u8);

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -345,7 +345,8 @@ impl RootScope {
 
     /// Scope-local [`pin_root`] using the already-resolved root-stack cell.
     #[majit_macros::dont_look_inside]
-    pub fn pin_root(&self, root: PyObjectRef) {
+    #[must_use = "a pinned root may have been normalized; use the returned live word or bind it to `let _ =` for liveness-only pins"]
+    pub fn pin_root(&self, root: PyObjectRef) -> PyObjectRef {
         #[cfg(debug_assertions)]
         assert_shadow_stack_not_walking();
         // SAFETY: `stack_slot` is this thread's root-stack cell, alive for the
@@ -361,14 +362,16 @@ impl RootScope {
         // this root write.  Pyre's free-threaded seam needs the normalization
         // only after a second mutator has existed; the sticky predicate also
         // covers one which collected and unregistered before this point.
-        if majit_gc::gc_sync::foreign_mutator_seen() {
-            let normalized =
-                crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
-            if normalized != root {
-                // SAFETY: same cell, and `index` is still live.
-                unsafe { *(*self.stack_slot).slot(index) = normalized };
-            }
+        if !majit_gc::gc_sync::foreign_mutator_seen() {
+            return root;
         }
+        let normalized =
+            crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
+        if normalized != root {
+            // SAFETY: same cell, and `index` is still live.
+            unsafe { *(*self.stack_slot).slot(index) = normalized };
+        }
+        normalized
     }
 
     /// Scope-local [`shadow_stack_get`] using the cached cell.
@@ -480,11 +483,16 @@ pub fn push_roots() -> RootScope {
 /// so the matching [`Drop`] truncates the entry. Pinning without a
 /// guard is a leak from the GC's perspective once the backend GC consumes the stack.
 ///
+/// Returns the word now held by the shadow-stack slot. A foreign collection
+/// may have forwarded `root` while this call waited at its normalization
+/// safepoint, so callers that use the word after pinning must use this value.
+///
 /// Pushes onto the thread-local `ROOT_STACK`, a runtime-mutable root the
 /// tracer cannot type; the JIT residualises the call instead of tracing into
 /// it (`@dont_look_inside`, `rlib/jit.py`), the `shadow_stack_len` twin.
+#[must_use = "a pinned root may have been normalized; use the returned live word or bind it to `let _ =` for liveness-only pins"]
 #[majit_macros::dont_look_inside]
-pub fn pin_root(root: PyObjectRef) {
+pub fn pin_root(root: PyObjectRef) -> PyObjectRef {
     #[cfg(debug_assertions)]
     assert_shadow_stack_not_walking();
     // Publish the raw value first.  `try_gc_current_object_address` is itself
@@ -505,7 +513,7 @@ pub fn pin_root(root: PyObjectRef) {
     // an already-forwarded nursery object; normalize the host-side copy at
     // the same boundary so the shadow stack never gains a forwarding stub.
     if !majit_gc::gc_sync::foreign_mutator_seen() {
-        return;
+        return root;
     }
     let normalized = crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
     // The slot already holds `root`, so a query that found no forwarding stub
@@ -520,6 +528,7 @@ pub fn pin_root(root: PyObjectRef) {
             unsafe { *stack.slot(index) = normalized }
         });
     }
+    normalized
 }
 
 /// Publish a complete translated livevar set before performing any
@@ -912,8 +921,8 @@ mod tests {
         {
             let roots = push_roots();
             assert_eq!(roots.base(), before);
-            roots.pin_root(dummy(0x1234));
-            roots.pin_root(dummy(0x5678));
+            let _ = roots.pin_root(dummy(0x1234));
+            let _ = roots.pin_root(dummy(0x5678));
             assert_eq!(roots.get(before) as usize, 0x1234);
             assert_eq!(roots.get(before + 1) as usize, 0x5678);
         }
@@ -929,8 +938,8 @@ mod tests {
         let before = shadow_stack_len();
         {
             let _roots = push_roots();
-            pin_root(dummy(0xDEAD_BEEF));
-            pin_root(dummy(0xCAFE_F00D));
+            let _ = pin_root(dummy(0xDEAD_BEEF));
+            let _ = pin_root(dummy(0xCAFE_F00D));
             assert_eq!(shadow_stack_len(), before + 2);
             assert_eq!(shadow_stack_get(before) as usize, 0xDEAD_BEEF);
             assert_eq!(shadow_stack_get(before + 1) as usize, 0xCAFE_F00D);
@@ -946,13 +955,13 @@ mod tests {
     fn nested_root_scopes_pop_in_lifo_order() {
         let before = shadow_stack_len();
         let outer = push_roots();
-        pin_root(dummy(1));
+        let _ = pin_root(dummy(1));
         let mid_outer_len = shadow_stack_len();
         assert_eq!(mid_outer_len, before + 1);
         {
             let _inner = push_roots();
-            pin_root(dummy(2));
-            pin_root(dummy(3));
+            let _ = pin_root(dummy(2));
+            let _ = pin_root(dummy(3));
             assert_eq!(shadow_stack_len(), mid_outer_len + 2);
         }
         // _inner dropped — back to the outer's view.
@@ -981,7 +990,7 @@ mod tests {
     #[test]
     fn copy_range_accepts_an_empty_range_at_the_top_of_the_stack() {
         let _roots = push_roots();
-        pin_root(dummy(0x1));
+        let _ = pin_root(dummy(0x1));
         shadow_stack_copy_range(shadow_stack_len(), &mut []);
     }
 
@@ -991,7 +1000,7 @@ mod tests {
     #[should_panic(expected = "shadow-stack range out of bounds")]
     fn copy_range_rejects_an_empty_range_past_the_top_of_the_stack() {
         let _roots = push_roots();
-        pin_root(dummy(0x1));
+        let _ = pin_root(dummy(0x1));
         shadow_stack_copy_range(shadow_stack_len() + 1, &mut []);
     }
 
@@ -1002,9 +1011,9 @@ mod tests {
     #[test]
     fn walk_shadow_stack_visits_each_slot_mutably() {
         let _roots = push_roots();
-        pin_root(dummy(0x1));
-        pin_root(dummy(0x2));
-        pin_root(dummy(0x3));
+        let _ = pin_root(dummy(0x1));
+        let _ = pin_root(dummy(0x2));
+        let _ = pin_root(dummy(0x3));
 
         // Read pass: collect the addresses we see.
         let mut seen = Vec::new();
@@ -1030,19 +1039,23 @@ mod tests {
     #[should_panic(expected = "the shadow stack was mutated while a root walk was in progress")]
     fn walk_shadow_stack_area_rejects_reentrant_push_in_debug_builds() {
         let _roots = push_roots();
-        pin_root(dummy(0x1));
+        let _ = pin_root(dummy(0x1));
         let area = capture_shadow_stack_area();
         // SAFETY: `area` is this thread's shadow stack, and this synchronous
         // self-walk keeps it live for the duration of the call.
-        unsafe { walk_shadow_stack_area(area, |_| pin_root(dummy(0x2))) };
+        unsafe {
+            walk_shadow_stack_area(area, |_| {
+                let _ = pin_root(dummy(0x2));
+            })
+        };
     }
 
     #[cfg(not(debug_assertions))]
     #[test]
     fn walk_shadow_stack_survives_push_that_grows_the_buffer() {
         let _roots = push_roots();
-        pin_root(dummy(0x11));
-        pin_root(dummy(0x22));
+        let _ = pin_root(dummy(0x11));
+        let _ = pin_root(dummy(0x22));
 
         let (capacity_before, additional) =
             with_shadow_stack(|stack| (stack.capacity(), stack.capacity() - stack.len() + 1));
@@ -1053,7 +1066,7 @@ mod tests {
             if !pushed {
                 pushed = true;
                 for offset in 0..additional {
-                    pin_root(dummy(0x1000 + offset));
+                    let _ = pin_root(dummy(0x1000 + offset));
                 }
             }
         });
@@ -1081,8 +1094,8 @@ mod tests {
     #[test]
     fn walk_shadow_stack_write_back_follows_a_grow_inside_the_visitor() {
         let _roots = push_roots();
-        pin_root(dummy(0x11));
-        pin_root(dummy(0x22));
+        let _ = pin_root(dummy(0x11));
+        let _ = pin_root(dummy(0x22));
 
         let additional = with_shadow_stack(|stack| stack.capacity() - stack.len() + 1);
         let mut pushed = false;
@@ -1090,7 +1103,7 @@ mod tests {
             if !pushed {
                 pushed = true;
                 for offset in 0..additional {
-                    pin_root(dummy(0x1000 + offset));
+                    let _ = pin_root(dummy(0x1000 + offset));
                 }
             }
             // Forward the root the way a moving collector would, *after* the

--- a/pyre/pyre-object/src/generator.rs
+++ b/pyre/pyre-object/src/generator.rs
@@ -122,7 +122,7 @@ fn w_generator_or_coroutine_new(
     kind: GeneratorKind,
 ) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(pycode);
+    let pycode = crate::gc_roots::pin_root(pycode);
     let value = GeneratorIterator {
         ob: PyObject {
             ob_type: match kind {
@@ -199,9 +199,7 @@ pub fn w_async_generator_new(frame_ptr: *mut u8, pycode: PyObjectRef) -> PyObjec
 
 pub fn w_coroutine_wrapper_new(coroutine: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    let root_base = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(coroutine);
-    let coroutine = crate::gc_roots::shadow_stack_get(root_base);
+    let coroutine = crate::gc_roots::pin_root(coroutine);
     CoroutineWrapper::allocate_stable(CoroutineWrapper {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -245,9 +243,7 @@ pub unsafe fn is_generator_or_coroutine(obj: PyObjectRef) -> bool {
 
 pub fn w_async_gen_value_wrapper_new(w_value: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    let root_base = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(w_value);
-    let w_value = crate::gc_roots::shadow_stack_get(root_base);
+    let w_value = crate::gc_roots::pin_root(w_value);
     AsyncGenValueWrapper::allocate_stable(AsyncGenValueWrapper {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -260,8 +256,8 @@ pub fn w_async_gen_value_wrapper_new(w_value: PyObjectRef) -> PyObjectRef {
 pub fn w_async_gen_asend_new(async_gen: PyObjectRef, w_value_to_send: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(async_gen);
-    crate::gc_roots::pin_root(w_value_to_send);
+    let _ = crate::gc_roots::pin_root(async_gen);
+    let _ = crate::gc_roots::pin_root(w_value_to_send);
     let async_gen = crate::gc_roots::shadow_stack_get(root_base);
     let w_value_to_send = crate::gc_roots::shadow_stack_get(root_base + 1);
     AsyncGenASend::allocate_stable(AsyncGenASend {
@@ -284,7 +280,7 @@ pub fn w_async_gen_athrow_new(
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
     for value in [async_gen, w_exc_type, w_exc_value, w_exc_tb] {
-        crate::gc_roots::pin_root(value);
+        let _ = crate::gc_roots::pin_root(value);
     }
     let async_gen = crate::gc_roots::shadow_stack_get(root_base);
     let w_exc_type = crate::gc_roots::shadow_stack_get(root_base + 1);

--- a/pyre/pyre-object/src/int_array.rs
+++ b/pyre/pyre-object/src/int_array.rs
@@ -104,7 +104,7 @@ impl IntArray {
     #[must_use]
     pub fn pin_block(&self) -> usize {
         let slot = crate::gc_roots::shadow_stack_len();
-        crate::gc_roots::pin_root(self.block as crate::PyObjectRef);
+        let _ = crate::gc_roots::pin_root(self.block as crate::PyObjectRef);
         slot
     }
 

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -631,7 +631,7 @@ pub fn w_exception_new(kind: ExcKind, message: &str) -> PyObjectRef {
         // collection there could sweep the unrooted (non-moving oldgen)
         // exception before `w_exception_set_args` writes through it.
         let _roots = crate::gc_roots::push_roots();
-        crate::gc_roots::pin_root(exc);
+        let exc = crate::gc_roots::pin_root(exc);
         let arg = crate::unicodeobject::w_str_new(message);
         unsafe { w_exception_set_args(exc, w_exception_args_new(vec![arg])) };
     }
@@ -645,7 +645,7 @@ pub fn w_exception_new_wtf8(kind: ExcKind, message: &Wtf8) -> PyObjectRef {
     if !message.is_empty() {
         // See `w_exception_new`: pin `exc` across the allocating arg build.
         let _roots = crate::gc_roots::push_roots();
-        crate::gc_roots::pin_root(exc);
+        let exc = crate::gc_roots::pin_root(exc);
         let arg = crate::unicodeobject::w_str_from_wtf8(message.to_wtf8_buf());
         unsafe { w_exception_set_args(exc, w_exception_args_new(vec![arg])) };
     }

--- a/pyre/pyre-object/src/interp_itertools.rs
+++ b/pyre/pyre-object/src/interp_itertools.rs
@@ -92,8 +92,8 @@ pub struct W_Count {
 pub fn w_count_new(w_firstval: PyObjectRef, w_step: PyObjectRef) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py`).
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_firstval);
-    crate::gc_roots::pin_root(w_step);
+    let w_firstval = crate::gc_roots::pin_root(w_firstval);
+    let w_step = crate::gc_roots::pin_root(w_step);
     W_Count::allocate_stable(W_Count {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -176,7 +176,7 @@ pub fn w_repeat_new(w_obj: PyObjectRef, w_times: Option<i64>) -> PyObjectRef {
     };
     // `gct_fv_gc_malloc` bracket pattern (`framework.py`).
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_obj);
+    let w_obj = crate::gc_roots::pin_root(w_obj);
     W_Repeat::allocate_stable(W_Repeat {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -257,8 +257,8 @@ pub struct W_TakeWhile {
 pub fn w_takewhile_new(w_predicate: PyObjectRef, w_iterable: PyObjectRef) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py`).
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_predicate);
-    crate::gc_roots::pin_root(w_iterable);
+    let w_predicate = crate::gc_roots::pin_root(w_predicate);
+    let w_iterable = crate::gc_roots::pin_root(w_iterable);
     W_TakeWhile::allocate_stable(W_TakeWhile {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -302,8 +302,8 @@ pub struct W_DropWhile {
 pub fn w_dropwhile_new(w_predicate: PyObjectRef, w_iterable: PyObjectRef) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py`).
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_predicate);
-    crate::gc_roots::pin_root(w_iterable);
+    let w_predicate = crate::gc_roots::pin_root(w_predicate);
+    let w_iterable = crate::gc_roots::pin_root(w_iterable);
     W_DropWhile::allocate_stable(W_DropWhile {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -355,9 +355,9 @@ pub fn w_filterfalse_new(w_predicate: PyObjectRef, w_iterable: PyObjectRef) -> P
     // `gct_fv_gc_malloc` bracket pattern (`framework.py`).
     let _roots = crate::gc_roots::push_roots();
     if !w_predicate.is_null() {
-        crate::gc_roots::pin_root(w_predicate);
+        let _ = crate::gc_roots::pin_root(w_predicate);
     }
-    crate::gc_roots::pin_root(w_iterable);
+    let w_iterable = crate::gc_roots::pin_root(w_iterable);
     W_FilterFalse::allocate_stable(W_FilterFalse {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -407,7 +407,7 @@ pub struct W_ISlice {
 /// `space.iter`).  All numeric arguments have already passed `arg_int_w`.
 pub fn w_islice_new(iterable: PyObjectRef, start: i64, stop: i64, step: i64) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(iterable);
+    let iterable = crate::gc_roots::pin_root(iterable);
     W_ISlice::allocate_stable(W_ISlice {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -459,7 +459,7 @@ pub struct W_Batched {
 /// `PyObject_GetIter` before allocating the instance).
 pub fn w_batched_new(it: PyObjectRef, batch_size: isize, strict: bool) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(it);
+    let it = crate::gc_roots::pin_root(it);
     W_Batched::allocate_stable(W_Batched {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -519,8 +519,8 @@ pub struct W_Product {
 
 pub fn w_product_new(gears: PyObjectRef, indices: PyObjectRef, stopped: bool) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(gears);
-    crate::gc_roots::pin_root(indices);
+    let gears = crate::gc_roots::pin_root(gears);
+    let indices = crate::gc_roots::pin_root(indices);
     W_Product::allocate_stable(W_Product {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -563,8 +563,8 @@ pub fn w_combinations_new(
     stopped: bool,
 ) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(pool_w);
-    crate::gc_roots::pin_root(indices);
+    let pool_w = crate::gc_roots::pin_root(pool_w);
+    let indices = crate::gc_roots::pin_root(indices);
     W_Combinations::allocate_stable(W_Combinations {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -611,8 +611,8 @@ pub fn w_combinations_with_replacement_new(
     stopped: bool,
 ) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(pool_w);
-    crate::gc_roots::pin_root(indices);
+    let pool_w = crate::gc_roots::pin_root(pool_w);
+    let indices = crate::gc_roots::pin_root(indices);
     W_CombinationsWithReplacement::allocate_stable(W_CombinationsWithReplacement {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -659,12 +659,12 @@ pub fn w_permutations_new(
     cycles: PyObjectRef,
 ) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(pool_w);
+    let pool_w = crate::gc_roots::pin_root(pool_w);
     if !indices.is_null() {
-        crate::gc_roots::pin_root(indices);
+        let _ = crate::gc_roots::pin_root(indices);
     }
     if !cycles.is_null() {
-        crate::gc_roots::pin_root(cycles);
+        let _ = crate::gc_roots::pin_root(cycles);
     }
     W_Permutations::allocate_stable(W_Permutations {
         ob: PyObject {
@@ -707,8 +707,8 @@ pub struct W_GroupBy {
 
 pub fn w_groupby_new(w_iterator: PyObjectRef, w_keyfunc: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_iterator);
-    crate::gc_roots::pin_root(w_keyfunc);
+    let w_iterator = crate::gc_roots::pin_root(w_iterator);
+    let w_keyfunc = crate::gc_roots::pin_root(w_keyfunc);
     W_GroupBy::allocate_stable(W_GroupBy {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -739,8 +739,8 @@ pub struct W_GroupByIterator {
 
 pub fn w_groupby_iterator_new(groupby: PyObjectRef, w_tgtkey: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(groupby);
-    crate::gc_roots::pin_root(w_tgtkey);
+    let groupby = crate::gc_roots::pin_root(groupby);
+    let w_tgtkey = crate::gc_roots::pin_root(w_tgtkey);
     let grouper = W_GroupByIterator::allocate_stable(W_GroupByIterator {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -803,9 +803,9 @@ pub struct W_TeeIterable {
 
 pub fn w_tee_iterable_new(w_iterator: PyObjectRef, w_chained_list: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_iterator);
+    let w_iterator = crate::gc_roots::pin_root(w_iterator);
     if !w_chained_list.is_null() {
-        crate::gc_roots::pin_root(w_chained_list);
+        let _ = crate::gc_roots::pin_root(w_chained_list);
     }
     W_TeeIterable::allocate_stable(W_TeeIterable {
         ob: PyObject {
@@ -848,8 +848,8 @@ pub struct W_Compress {
 /// `W_Compress.__init__`.
 pub fn w_compress_new(w_data: PyObjectRef, w_selectors: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_data);
-    crate::gc_roots::pin_root(w_selectors);
+    let w_data = crate::gc_roots::pin_root(w_data);
+    let w_selectors = crate::gc_roots::pin_root(w_selectors);
     W_Compress::allocate_stable(W_Compress {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -891,8 +891,8 @@ pub struct W_StarMap {
 /// `w_iterable` must already have had `space.iter` applied.
 pub fn w_starmap_new(w_fun: PyObjectRef, w_iterable: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_fun);
-    crate::gc_roots::pin_root(w_iterable);
+    let w_fun = crate::gc_roots::pin_root(w_fun);
+    let w_iterable = crate::gc_roots::pin_root(w_iterable);
     W_StarMap::allocate_stable(W_StarMap {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -933,11 +933,11 @@ pub fn w_accumulate_new(
     w_initial: PyObjectRef,
 ) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_iterable);
+    let w_iterable = crate::gc_roots::pin_root(w_iterable);
     if !w_func.is_null() {
-        crate::gc_roots::pin_root(w_func);
+        let _ = crate::gc_roots::pin_root(w_func);
     }
-    crate::gc_roots::pin_root(w_initial);
+    let w_initial = crate::gc_roots::pin_root(w_initial);
     W_Accumulate::allocate_stable(W_Accumulate {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -996,8 +996,8 @@ pub fn w_zip_longest_new(
     active: i64,
 ) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_iterators);
-    crate::gc_roots::pin_root(w_fillvalue);
+    let w_iterators = crate::gc_roots::pin_root(w_iterators);
+    let w_fillvalue = crate::gc_roots::pin_root(w_fillvalue);
     W_ZipLongest::allocate_stable(W_ZipLongest {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -1040,7 +1040,7 @@ pub struct W_Pairwise {
 pub fn w_pairwise_new(w_iterator: PyObjectRef) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py`).
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_iterator);
+    let w_iterator = crate::gc_roots::pin_root(w_iterator);
     W_Pairwise::allocate_stable(W_Pairwise {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -1125,9 +1125,9 @@ pub fn w_cycle_new(w_iterable: PyObjectRef) -> PyObjectRef {
     // rather than from the parameter copy that collection left pre-move.
     let roots = crate::gc_roots::push_roots();
     let iterable_slot = roots.base();
-    roots.pin_root(w_iterable);
+    let _ = roots.pin_root(w_iterable);
     let saved = crate::listobject::w_list_new(Vec::new());
-    roots.pin_root(saved);
+    let saved = roots.pin_root(saved);
     W_Cycle::allocate_stable(W_Cycle {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -1192,7 +1192,7 @@ pub struct W_Chain {
 pub fn w_chain_new(w_iterables: PyObjectRef) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py`).
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_iterables);
+    let w_iterables = crate::gc_roots::pin_root(w_iterables);
     W_Chain::allocate_stable(W_Chain {
         ob: PyObject {
             ob_type: std::ptr::null(),

--- a/pyre/pyre-object/src/interp_sre.rs
+++ b/pyre/pyre-object/src/interp_sre.rs
@@ -74,9 +74,9 @@ pub fn w_sre_pattern_new(
 ) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py`).
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_pattern);
-    crate::gc_roots::pin_root(w_groupindex);
-    crate::gc_roots::pin_root(w_indexgroup);
+    let w_pattern = crate::gc_roots::pin_root(w_pattern);
+    let w_groupindex = crate::gc_roots::pin_root(w_groupindex);
+    let w_indexgroup = crate::gc_roots::pin_root(w_indexgroup);
     let obj = W_SRE_Pattern::allocate(W_SRE_Pattern {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -153,9 +153,9 @@ pub fn w_sre_match_new(
 ) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py`).
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_srepat);
-    crate::gc_roots::pin_root(w_string);
-    crate::gc_roots::pin_root(w_buffer);
+    let w_srepat = crate::gc_roots::pin_root(w_srepat);
+    let w_string = crate::gc_roots::pin_root(w_string);
+    let w_buffer = crate::gc_roots::pin_root(w_buffer);
     W_SRE_Match::allocate_stable(W_SRE_Match {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -242,9 +242,9 @@ pub fn w_sre_scanner_new(
     export_active: bool,
 ) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_srepat);
-    crate::gc_roots::pin_root(w_string);
-    crate::gc_roots::pin_root(w_buffer);
+    let w_srepat = crate::gc_roots::pin_root(w_srepat);
+    let w_string = crate::gc_roots::pin_root(w_string);
+    let w_buffer = crate::gc_roots::pin_root(w_buffer);
     W_SRE_Scanner::allocate_stable(W_SRE_Scanner {
         ob: PyObject {
             ob_type: std::ptr::null(),

--- a/pyre/pyre-object/src/iterobject.rs
+++ b/pyre/pyre-object/src/iterobject.rs
@@ -96,9 +96,7 @@ fn seq_iter_type_for(seq: PyObjectRef) -> &'static PyType {
 pub fn w_seq_iter_new(seq: PyObjectRef, length: usize) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py`).
     let _roots = crate::gc_roots::push_roots();
-    let seq_slot = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(seq);
-    let seq = crate::gc_roots::shadow_stack_get(seq_slot);
+    let seq = crate::gc_roots::pin_root(seq);
     let tp = seq_iter_type_for(seq);
     let value = W_SeqIterObject {
         ob: PyObject {
@@ -115,7 +113,7 @@ pub fn w_seq_iter_new(seq: PyObjectRef, length: usize) -> PyObjectRef {
 
 pub fn w_list_iter_new(seq: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(seq);
+    let seq = crate::gc_roots::pin_root(seq);
     W_ListIterObject::allocate_stable(W_ListIterObject {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -128,7 +126,7 @@ pub fn w_list_iter_new(seq: PyObjectRef) -> PyObjectRef {
 
 pub fn w_list_reverse_iter_new(seq: PyObjectRef, index: i64) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(seq);
+    let seq = crate::gc_roots::pin_root(seq);
     W_ListReverseIterObject::allocate_stable(W_ListReverseIterObject {
         ob: PyObject {
             ob_type: std::ptr::null(),
@@ -141,7 +139,7 @@ pub fn w_list_reverse_iter_new(seq: PyObjectRef, index: i64) -> PyObjectRef {
 
 pub fn w_tuple_iter_new(seq: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(seq);
+    let seq = crate::gc_roots::pin_root(seq);
     W_TupleIterObject::allocate_stable(W_TupleIterObject {
         ob: PyObject {
             ob_type: std::ptr::null(),

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -217,8 +217,7 @@ impl W_ListObject {
     unsafe fn object_grow(obj: PyObjectRef, min_cap: usize) -> PyObjectRef {
         let _roots = crate::gc_roots::push_roots();
         let obj_slot = crate::gc_roots::shadow_stack_len();
-        crate::gc_roots::pin_root(obj);
-        let obj = crate::gc_roots::shadow_stack_get(obj_slot);
+        let obj = crate::gc_roots::pin_root(obj);
         let list = &mut *(obj as *mut W_ListObject);
         let current_cap = list.object_items_capacity();
         let target_cap = min_cap.max(current_cap.saturating_mul(2).max(4));
@@ -235,7 +234,7 @@ impl W_ListObject {
         let obj = crate::gc_roots::shadow_stack_get(obj_slot);
         let list = &mut *(obj as *mut W_ListObject);
         let new_items = grow_list_items_block_gc(list.items, target_cap, list.length);
-        crate::gc_roots::pin_root(new_items as PyObjectRef);
+        let _ = crate::gc_roots::pin_root(new_items as PyObjectRef);
         // framework.py's GC transform places the owner write barrier directly
         // before SETFIELD_GC. Keep the old block installed while the barrier
         // runs, then swap without another safepoint: a post-store barrier may
@@ -450,7 +449,7 @@ impl W_ListObject {
         }
         let new_items_slot = crate::gc_roots::shadow_stack_len();
         let new_items = alloc_list_items_block_gc(&rooted_values);
-        crate::gc_roots::pin_root(new_items as PyObjectRef);
+        let _ = crate::gc_roots::pin_root(new_items as PyObjectRef);
         // `_ll_list_resize_really` installs the freshly allocated GcArray
         // through SETFIELD_GC.  Run the owner barrier before publishing the
         // edge: a post-store barrier can itself park behind a foreign
@@ -500,8 +499,8 @@ impl W_ListObject {
 pub unsafe fn w_list_grow_items_block(obj: PyObjectRef, value: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     let save = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(obj);
-    crate::gc_roots::pin_root(value);
+    let _ = crate::gc_roots::pin_root(obj);
+    let _ = crate::gc_roots::pin_root(value);
     let obj = crate::gc_roots::shadow_stack_get(save);
     let list = &mut *(obj as *mut W_ListObject);
     W_ListObject::object_grow(obj, list.length + 1);
@@ -670,7 +669,7 @@ fn boxed_from_int_or_float(values: &[i64]) -> Vec<PyObjectRef> {
         } else {
             w_float_new(f64::from_bits(value as u64))
         };
-        crate::gc_roots::pin_root(item);
+        let _ = crate::gc_roots::pin_root(item);
     }
     (0..values.len())
         .map(|i| crate::gc_roots::shadow_stack_get(root_base + i))
@@ -714,7 +713,7 @@ fn boxed_from_ints(values: &[i64]) -> Vec<PyObjectRef> {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
     for &value in values {
-        crate::gc_roots::pin_root(w_int_new(value));
+        let _ = crate::gc_roots::pin_root(w_int_new(value));
     }
     (0..values.len())
         .map(|i| crate::gc_roots::shadow_stack_get(root_base + i))
@@ -725,7 +724,7 @@ fn boxed_from_floats(values: &[f64]) -> Vec<PyObjectRef> {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
     for &value in values {
-        crate::gc_roots::pin_root(w_float_new(value));
+        let _ = crate::gc_roots::pin_root(w_float_new(value));
     }
     (0..values.len())
         .map(|i| crate::gc_roots::shadow_stack_get(root_base + i))
@@ -753,7 +752,7 @@ pub unsafe fn switch_to_object_strategy(list: &mut W_ListObject) -> PyObjectRef 
     }
     let _roots = crate::gc_roots::push_roots();
     let obj_slot = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(list as *mut W_ListObject as PyObjectRef);
+    let _ = crate::gc_roots::pin_root(list as *mut W_ListObject as PyObjectRef);
     let obj = crate::gc_roots::shadow_stack_get(obj_slot);
     let list = &mut *(obj as *mut W_ListObject);
     let seed: Vec<PyObjectRef> = match list.strategy {
@@ -867,8 +866,7 @@ pub extern "C" fn list_write_barrier(obj: PyObjectRef) {
 fn list_write_barrier_impl(obj: PyObjectRef, managed: bool) {
     let _roots = crate::gc_roots::push_roots();
     let obj_slot = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(obj);
-    let obj = crate::gc_roots::shadow_stack_get(obj_slot);
+    let obj = crate::gc_roots::pin_root(obj);
     if managed {
         crate::gc_hook::try_gc_write_barrier_managed(obj as *mut u8);
     } else {
@@ -938,9 +936,7 @@ pub fn prepare_list_ref_store(obj: *mut PyObject, value: *mut PyObject) -> *mut 
 #[majit_macros::dont_look_inside]
 pub fn current_gc_ref(obj: *mut PyObject) -> *mut PyObject {
     let _roots = crate::gc_roots::push_roots();
-    let obj_slot = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(obj);
-    let obj = crate::gc_roots::shadow_stack_get(obj_slot);
+    let obj = crate::gc_roots::pin_root(obj);
     crate::gc_hook::try_gc_current_object_address(obj as *mut u8) as *mut PyObject
 }
 
@@ -1085,7 +1081,7 @@ pub fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy)
     // function entry covers every strategy uniformly.
     let _roots = crate::gc_roots::push_roots();
     for &item in &items {
-        crate::gc_roots::pin_root(item);
+        let _ = crate::gc_roots::pin_root(item);
     }
 
     // The nursery `items_block` is allocated last and pinned across the
@@ -1100,7 +1096,7 @@ pub fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy)
     // before storing it into the wrapper. Inert for a null or std::alloc block.
     let block_root: Option<usize> = if !items_block.is_null() {
         let s = crate::gc_roots::shadow_stack_len();
-        crate::gc_roots::pin_root(items_block as PyObjectRef);
+        let _ = crate::gc_roots::pin_root(items_block as PyObjectRef);
         Some(s)
     } else {
         None
@@ -1211,8 +1207,8 @@ pub unsafe fn w_list_slot_get(obj: PyObjectRef, index: usize) -> Option<PyObject
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_list_slot_set(obj: PyObjectRef, index: usize, value: PyObjectRef) {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(obj);
-    crate::gc_roots::pin_root(value);
+    let _ = crate::gc_roots::pin_root(obj);
+    let _ = crate::gc_roots::pin_root(value);
     let obj_slot = crate::gc_roots::shadow_stack_len() - 2;
     let value_slot = crate::gc_roots::shadow_stack_len() - 1;
 
@@ -1224,7 +1220,7 @@ pub unsafe fn w_list_slot_set(obj: PyObjectRef, index: usize, value: PyObjectRef
         unsafe { (*(rooted_obj as *mut W_ListObject)).w_slots = slots };
         crate::gc_hook::try_gc_write_barrier(rooted_obj as *mut u8);
     }
-    crate::gc_roots::pin_root(slots);
+    let _ = crate::gc_roots::pin_root(slots);
     let slots_slot = crate::gc_roots::shadow_stack_len() - 1;
     while unsafe { w_list_len(crate::gc_roots::shadow_stack_get(slots_slot)) } <= index {
         unsafe { w_list_append(crate::gc_roots::shadow_stack_get(slots_slot), PY_NULL) };
@@ -1387,8 +1383,7 @@ pub fn ll_list_obj_setitem_fast(l: &mut W_ListObject, index: usize, item: PyObje
 pub unsafe fn w_list_getitem(obj: PyObjectRef, index: i64) -> Option<PyObjectRef> {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(obj);
-    let obj = crate::gc_roots::shadow_stack_get(root_base);
+    let obj = crate::gc_roots::pin_root(obj);
     let _list_guard = w_list_lock(obj);
     let obj = crate::gc_roots::shadow_stack_get(root_base);
     let list = &*(obj as *const W_ListObject);
@@ -1821,8 +1816,7 @@ pub unsafe fn w_list_int_or_float_setitem(
 pub unsafe fn w_list_len(obj: PyObjectRef) -> usize {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(obj);
-    let obj = crate::gc_roots::shadow_stack_get(root_base);
+    let obj = crate::gc_roots::pin_root(obj);
     let _list_guard = w_list_lock(obj);
     let obj = crate::gc_roots::shadow_stack_get(root_base);
     let list = &*(obj as *const W_ListObject);
@@ -1843,8 +1837,7 @@ pub unsafe fn w_list_len(obj: PyObjectRef) -> usize {
 pub unsafe fn w_list_allocated(obj: PyObjectRef) -> isize {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(obj);
-    let obj = crate::gc_roots::shadow_stack_get(root_base);
+    let obj = crate::gc_roots::pin_root(obj);
     let _list_guard = w_list_lock(obj);
     let obj = crate::gc_roots::shadow_stack_get(root_base);
     (*(obj as *const W_ListObject)).allocated
@@ -2081,7 +2074,7 @@ unsafe fn temporarily_as_objects(list: &W_ListObject) -> Vec<PyObjectRef> {
             let _roots = crate::gc_roots::push_roots();
             let root_base = crate::gc_roots::shadow_stack_len();
             for &v in items {
-                crate::gc_roots::pin_root(w_int_new(v));
+                let _ = crate::gc_roots::pin_root(w_int_new(v));
             }
             (0..items.len())
                 .map(|i| crate::gc_roots::shadow_stack_get(root_base + i))
@@ -2093,7 +2086,7 @@ unsafe fn temporarily_as_objects(list: &W_ListObject) -> Vec<PyObjectRef> {
             let _roots = crate::gc_roots::push_roots();
             let root_base = crate::gc_roots::shadow_stack_len();
             for &v in items {
-                crate::gc_roots::pin_root(w_float_new(v));
+                let _ = crate::gc_roots::pin_root(w_float_new(v));
             }
             (0..items.len())
                 .map(|i| crate::gc_roots::shadow_stack_get(root_base + i))
@@ -2218,8 +2211,7 @@ pub unsafe fn w_list_insert(obj: PyObjectRef, index: i64, value: PyObjectRef) {
 pub unsafe fn w_list_pop(obj: PyObjectRef, index: i64) -> Option<PyObjectRef> {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(obj);
-    let obj = crate::gc_roots::shadow_stack_get(root_base);
+    let obj = crate::gc_roots::pin_root(obj);
     let _list_guard = w_list_lock(obj);
     let obj = crate::gc_roots::shadow_stack_get(root_base);
     let list = &mut *(obj as *mut W_ListObject);
@@ -2304,8 +2296,7 @@ pub unsafe fn w_list_pop(obj: PyObjectRef, index: i64) -> Option<PyObjectRef> {
 pub unsafe fn w_list_pop_end(obj: PyObjectRef) -> Option<PyObjectRef> {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(obj);
-    let obj = crate::gc_roots::shadow_stack_get(root_base);
+    let obj = crate::gc_roots::pin_root(obj);
     let _list_guard = w_list_lock(obj);
     let obj = crate::gc_roots::shadow_stack_get(root_base);
     let list = &mut *(obj as *mut W_ListObject);
@@ -2446,7 +2437,7 @@ pub unsafe fn w_list_init_items(obj: PyObjectRef, items: Vec<PyObjectRef>) {
     // roots until the install.
     let _roots = crate::gc_roots::push_roots();
     let obj_slot = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(obj);
+    let _ = crate::gc_roots::pin_root(obj);
     let strategy = list_strategy_for(&items);
     let mut storage = build_list_storage(&items, strategy);
     let obj = crate::gc_roots::shadow_stack_get(obj_slot);
@@ -2468,7 +2459,7 @@ pub unsafe fn w_list_init_items(obj: PyObjectRef, items: Vec<PyObjectRef>) {
         None
     } else {
         let s = crate::gc_roots::shadow_stack_len();
-        crate::gc_roots::pin_root(storage.block as PyObjectRef);
+        let _ = crate::gc_roots::pin_root(storage.block as PyObjectRef);
         Some(s)
     };
     let _list_guard = w_list_lock(obj);
@@ -2503,8 +2494,7 @@ pub unsafe fn w_list_init_items(obj: PyObjectRef, items: Vec<PyObjectRef>) {
 pub unsafe fn w_list_clear(obj: PyObjectRef) {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(obj);
-    let obj = crate::gc_roots::shadow_stack_get(root_base);
+    let obj = crate::gc_roots::pin_root(obj);
     let _list_guard = w_list_lock(obj);
     let obj = crate::gc_roots::shadow_stack_get(root_base);
     let list = &mut *(obj as *mut W_ListObject);
@@ -2801,8 +2791,8 @@ unsafe fn w_list_setslice_inner(
 ) -> Result<(), &'static str> {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(obj);
-    crate::gc_roots::pin_root(w_other);
+    let _ = crate::gc_roots::pin_root(obj);
+    let _ = crate::gc_roots::pin_root(w_other);
     let obj = crate::gc_roots::shadow_stack_get(root_base);
     let w_other = crate::gc_roots::shadow_stack_get(root_base + 1);
     let list = &mut *(obj as *mut W_ListObject);

--- a/pyre/pyre-object/src/memoryview.rs
+++ b/pyre/pyre-object/src/memoryview.rs
@@ -123,8 +123,8 @@ pub fn w_memoryview_alloc_header(released: bool, owns_export: bool) -> PyObjectR
 pub fn w_buffer_wrapper_new(w_mv: PyObjectRef, w_obj: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
     let sp = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(w_mv);
-    crate::gc_roots::pin_root(w_obj);
+    let _ = crate::gc_roots::pin_root(w_mv);
+    let _ = crate::gc_roots::pin_root(w_obj);
     W_BufferWrapper::allocate_stable(W_BufferWrapper {
         ob: PyObject {
             ob_type: std::ptr::null(),

--- a/pyre/pyre-object/src/nestedscope.rs
+++ b/pyre/pyre-object/src/nestedscope.rs
@@ -26,8 +26,7 @@ pub fn w_cell_new(value: PyObjectRef) -> PyObjectRef {
     // the slot; we read the relocated address back after the malloc.
     let _roots = crate::gc_roots::push_roots();
     let save_point = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(value);
-
+    let _ = crate::gc_roots::pin_root(value);
     let header = PyObject {
         ob_type: &CELL_TYPE as *const PyType,
         w_class: get_instantiate(&CELL_TYPE),

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -276,7 +276,7 @@ pub unsafe fn alloc_instance_items_block(values: &[PyObjectRef], cap: usize) -> 
     let values_base = crate::gc_roots::pin_roots(values);
     unsafe {
         let block = alloc_mapdict_storage_block(cap);
-        crate::gc_roots::pin_root(block as PyObjectRef);
+        let _ = crate::gc_roots::pin_root(block as PyObjectRef);
         let block =
             crate::gc_roots::shadow_stack_get(values_base + values.len()) as *mut ItemsBlock;
         let base = items_block_items_base(block);
@@ -385,7 +385,7 @@ pub unsafe fn alloc_list_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBlo
     let _roots = crate::gc_roots::push_roots();
     let save = crate::gc_roots::shadow_stack_len();
     for &v in values {
-        crate::gc_roots::pin_root(v);
+        let _ = crate::gc_roots::pin_root(v);
     }
     let block_slot = crate::gc_roots::shadow_stack_len();
     let block = unsafe { alloc_items_block_gc(cap) };
@@ -394,7 +394,7 @@ pub unsafe fn alloc_list_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBlo
     // collecting operation.  Publish it before the ownership query / write
     // barrier below: either operation can park behind another thread's
     // collection, which may move the otherwise-unrooted fresh array.
-    crate::gc_roots::pin_root(block as PyObjectRef);
+    let _ = crate::gc_roots::pin_root(block as PyObjectRef);
     let block = crate::gc_roots::shadow_stack_get(block_slot) as *mut ItemsBlock;
     let base = unsafe { items_block_items_base(block) };
     if len > 0 {
@@ -465,12 +465,12 @@ pub unsafe fn grow_list_items_block_gc(
         // std::alloc fallback unconditionally is both safe and removes the
         // ownership-query safepoint entirely.
         let slot = crate::gc_roots::shadow_stack_len();
-        crate::gc_roots::pin_root(old as crate::pyobject::PyObjectRef);
+        let _ = crate::gc_roots::pin_root(old as crate::pyobject::PyObjectRef);
         Some(slot)
     };
     let new_block_slot = crate::gc_roots::shadow_stack_len();
     let new_block = unsafe { alloc_items_block_gc(new_cap) };
-    crate::gc_roots::pin_root(new_block as PyObjectRef);
+    let _ = crate::gc_roots::pin_root(new_block as PyObjectRef);
     let new_block = crate::gc_roots::shadow_stack_get(new_block_slot) as *mut ItemsBlock;
     let new_base = unsafe { items_block_items_base(new_block) };
     let old = old_slot
@@ -508,11 +508,11 @@ pub unsafe fn alloc_tuple_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBl
     let _roots = crate::gc_roots::push_roots();
     let save = crate::gc_roots::shadow_stack_len();
     for &v in values {
-        crate::gc_roots::pin_root(v);
+        let _ = crate::gc_roots::pin_root(v);
     }
     let block_slot = crate::gc_roots::shadow_stack_len();
     let block = unsafe { alloc_items_block_gc(cap) };
-    crate::gc_roots::pin_root(block as PyObjectRef);
+    let _ = crate::gc_roots::pin_root(block as PyObjectRef);
     let block = crate::gc_roots::shadow_stack_get(block_slot) as *mut ItemsBlock;
     let base = unsafe { items_block_items_base(block) };
     if cap > 0 {
@@ -781,7 +781,7 @@ pub unsafe fn grow_typed_items_block(
         // brackets a malloc with (`framework.py:853-856`).
         let _roots = crate::gc_roots::push_roots();
         let fresh_root = crate::gc_roots::shadow_stack_len();
-        crate::gc_roots::pin_root(fresh as crate::PyObjectRef);
+        let _ = crate::gc_roots::pin_root(fresh as crate::PyObjectRef);
         if !old.is_null() && live_len > 0 {
             std::ptr::copy_nonoverlapping(
                 typed_items_block_items_base(old),
@@ -951,8 +951,8 @@ impl FixedObjectArray {
         }
         let _roots = crate::gc_roots::push_roots();
         let root_base = _roots.base();
-        _roots.pin_root(self as *mut Self as PyObjectRef);
-        _roots.pin_root(value);
+        let _ = _roots.pin_root(self as *mut Self as PyObjectRef);
+        let _ = _roots.pin_root(value);
         let array = _roots.get(root_base) as *mut Self;
         // Every mutable FixedObjectArray has a real header word: managed frame
         // locals carry the collector's header, while the StdAlloc snapshot

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -395,8 +395,24 @@ pub unsafe fn alloc_list_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBlo
     // barrier below: either operation can park behind another thread's
     // collection, which may move the otherwise-unrooted fresh array.
     let _ = crate::gc_roots::pin_root(block as PyObjectRef);
+    // Ask the ownership question first: it is the operation that can park
+    // behind a collection, and the barrier has to be the last thing before the
+    // items land, the way `writebarrier_before_copy` precedes `ll_arraycopy`'s
+    // memcpy.  Asking it after the fill leaves the young elements in an
+    // unregistered old-gen block across that wait, where a minor collection
+    // does not trace them.  A move during the query keeps the answer, since
+    // both generations are managed; re-read the block for the address.
+    let owns_block = crate::gc_hook::try_gc_owns_object(crate::gc_roots::shadow_stack_get(
+        block_slot,
+    ) as *mut u8);
     let block = crate::gc_roots::shadow_stack_get(block_slot) as *mut ItemsBlock;
     let base = unsafe { items_block_items_base(block) };
+    // Old→young barrier if the block landed in old-gen (see
+    // alloc_tuple_items_block_gc): registers an old-gen block holding young
+    // elements onto the remembered set, no-op for a nursery block.
+    if owns_block {
+        crate::gc_hook::try_gc_write_barrier(block as *mut u8);
+    }
     if len > 0 {
         // RPython's pop_roots reloads the livevars as one generated block.
         // Enter TLS once for the whole contiguous item range instead of once
@@ -407,12 +423,6 @@ pub unsafe fn alloc_list_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBlo
     }
     for i in len..cap {
         unsafe { *base.add(i) = PY_NULL };
-    }
-    // Old→young barrier if the block landed in old-gen (see
-    // alloc_tuple_items_block_gc): registers an old-gen block holding young
-    // elements onto the remembered set, no-op for a nursery block.
-    if crate::gc_hook::try_gc_owns_object(block as *mut u8) {
-        crate::gc_hook::try_gc_write_barrier(block as *mut u8);
     }
     block
 }
@@ -471,22 +481,28 @@ pub unsafe fn grow_list_items_block_gc(
     let new_block_slot = crate::gc_roots::shadow_stack_len();
     let new_block = unsafe { alloc_items_block_gc(new_cap) };
     let _ = crate::gc_roots::pin_root(new_block as PyObjectRef);
+    // The ownership query is the safepoint, so it runs before the barrier and
+    // the copy — see `alloc_list_items_block_gc` for why the barrier cannot
+    // follow the items.
+    let owns_new = crate::gc_hook::try_gc_owns_object(crate::gc_roots::shadow_stack_get(
+        new_block_slot,
+    ) as *mut u8);
     let new_block = crate::gc_roots::shadow_stack_get(new_block_slot) as *mut ItemsBlock;
     let new_base = unsafe { items_block_items_base(new_block) };
     let old = old_slot
         .map(|slot| crate::gc_roots::shadow_stack_get(slot) as *mut ItemsBlock)
         .unwrap_or(old);
+    // Old→young barrier if the grown block landed in old-gen (see
+    // alloc_tuple_items_block_gc).
+    if owns_new {
+        crate::gc_hook::try_gc_write_barrier(new_block as *mut u8);
+    }
     if live_len > 0 {
         let old_base = unsafe { items_block_items_base(old) };
         unsafe { std::ptr::copy_nonoverlapping(old_base, new_base, live_len) };
     }
     for i in live_len..new_cap {
         unsafe { *new_base.add(i) = PY_NULL };
-    }
-    // Old→young barrier if the grown block landed in old-gen (see
-    // alloc_tuple_items_block_gc).
-    if crate::gc_hook::try_gc_owns_object(new_block as *mut u8) {
-        crate::gc_hook::try_gc_write_barrier(new_block as *mut u8);
     }
     new_block
 }
@@ -513,13 +529,13 @@ pub unsafe fn alloc_tuple_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBl
     let block_slot = crate::gc_roots::shadow_stack_len();
     let block = unsafe { alloc_items_block_gc(cap) };
     let _ = crate::gc_roots::pin_root(block as PyObjectRef);
+    // The ownership query is the safepoint, so it runs before the barrier and
+    // the fill — see `alloc_list_items_block_gc`.
+    let owns_block = crate::gc_hook::try_gc_owns_object(crate::gc_roots::shadow_stack_get(
+        block_slot,
+    ) as *mut u8);
     let block = crate::gc_roots::shadow_stack_get(block_slot) as *mut ItemsBlock;
     let base = unsafe { items_block_items_base(block) };
-    if cap > 0 {
-        // Same block-shaped pop_roots reload as the list constructor above.
-        let dst = unsafe { std::slice::from_raw_parts_mut(base, cap) };
-        crate::gc_roots::shadow_stack_copy_range(save, dst);
-    }
     // The block may have landed in old-gen (nursery-full fallback) while its
     // elements are still young. That old→young edge is invisible to a minor
     // collection unless the block is on the remembered set, so write-barrier
@@ -527,8 +543,13 @@ pub unsafe fn alloc_tuple_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBl
     // a no-op; an old-gen block is registered so the next minor collection
     // walks its items (write_barrier_from_array, incminimark.py). Guard
     // on GC ownership exactly like `list_write_barrier`.
-    if crate::gc_hook::try_gc_owns_object(block as *mut u8) {
+    if owns_block {
         crate::gc_hook::try_gc_write_barrier(block as *mut u8);
+    }
+    if cap > 0 {
+        // Same block-shaped pop_roots reload as the list constructor above.
+        let dst = unsafe { std::slice::from_raw_parts_mut(base, cap) };
+        crate::gc_roots::shadow_stack_copy_range(save, dst);
     }
     block
 }
@@ -1065,17 +1086,22 @@ pub unsafe fn alloc_mro_block_gc(values: &[PyObjectRef]) -> *mut FixedObjectArra
         }
         mem as *mut FixedObjectArray
     };
+    // The ownership query can park behind another thread's collection, so it
+    // runs before the elements are written rather than between them and the
+    // barrier — see `alloc_list_items_block_gc`.  The block is stable, so no
+    // re-read is owed for the address.
+    let owns_block = crate::gc_hook::try_gc_owns_object(block as *mut u8);
     unsafe {
         (*block).len = len;
-        let items = (*block).items_mut_ptr();
-        for (i, &v) in values.iter().enumerate() {
-            items.add(i).write(v);
-        }
         // Old→young barrier if the block landed in old-gen and any element is a
         // young object: registers the block on the remembered set so a later
         // minor collection forwards the young MRO entries.
-        if crate::gc_hook::try_gc_owns_object(block as *mut u8) {
+        if owns_block {
             crate::gc_hook::try_gc_write_barrier(block as *mut u8);
+        }
+        let items = (*block).items_mut_ptr();
+        for (i, &v) in values.iter().enumerate() {
+            items.add(i).write(v);
         }
     }
     block

--- a/pyre/pyre-object/src/objectobject.rs
+++ b/pyre/pyre-object/src/objectobject.rs
@@ -87,8 +87,7 @@ pub fn w_instance_new(w_type: PyObjectRef) -> PyObjectRef {
     // `is_in_nursery` filter in the walker (`majit-gc/src/collector.rs`)
     // keeps the built-in static `PyType` case (e.g. `INT_TYPE`) untouched.
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_type);
-
+    let w_type = crate::gc_roots::pin_root(w_type);
     let obj = alloc_instance_object(W_ObjectObject {
         ob_header: PyObject {
             ob_type: &INSTANCE_TYPE as *const PyType,

--- a/pyre/pyre-object/src/operation.rs
+++ b/pyre/pyre-object/src/operation.rs
@@ -44,8 +44,8 @@ pub struct _CallableIterator {
 /// Allocate a `_CallableIterator` for `iter(callable, sentinel)`.
 pub fn w_callable_iterator_new(callable: PyObjectRef, sentinel: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(callable);
-    crate::gc_roots::pin_root(sentinel);
+    let callable = crate::gc_roots::pin_root(callable);
+    let sentinel = crate::gc_roots::pin_root(sentinel);
     _CallableIterator::allocate_stable(_CallableIterator {
         ob: PyObject {
             ob_type: std::ptr::null(),

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -34,7 +34,7 @@ pub struct W_SetIterObject {
 )]
 pub fn w_set_iter_new(w_set: PyObjectRef) -> PyObjectRef {
     let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_set);
+    let w_set = crate::gc_roots::pin_root(w_set);
     let startlen = unsafe { w_set_len(w_set) };
     W_SetIterObject::allocate_stable(W_SetIterObject {
         ob: PyObject {
@@ -455,9 +455,9 @@ unsafe fn scan_set_key_reentrant(
             if stored_hash == key.hash {
                 let _roots = crate::gc_roots::push_roots();
                 let stored_slot = crate::gc_roots::shadow_stack_len();
-                crate::gc_roots::pin_root(stored_obj);
+                let stored_obj = crate::gc_roots::pin_root(stored_obj);
                 let key_slot = crate::gc_roots::shadow_stack_len();
-                crate::gc_roots::pin_root(key.obj);
+                let _ = crate::gc_roots::pin_root(key.obj);
 
                 let equal = crate::dictmultiobject::dict_keys_equal(stored_obj, key.obj);
                 let stored_obj = crate::gc_roots::shadow_stack_get(stored_slot);
@@ -494,7 +494,7 @@ unsafe fn scan_set_key_reentrant(
 #[inline]
 unsafe fn capture_set_items(obj: PyObjectRef) -> *mut SetItemsStorage {
     let items = (*(obj as *const W_SetObject)).items;
-    crate::gc_roots::pin_root(items as PyObjectRef);
+    let _ = crate::gc_roots::pin_root(items as PyObjectRef);
     items
 }
 
@@ -747,7 +747,7 @@ pub unsafe fn w_set_difference_update_from_set(
         // probe runs is a collection point that would otherwise sweep it.
         let _roots = crate::gc_roots::push_roots();
         let result = w_set_new();
-        crate::gc_roots::pin_root(result);
+        let result = crate::gc_roots::pin_root(result);
         let dst_items = (*(dst as *const W_SetObject)).items;
         let dst_len = (*dst_items).len();
         let mut i = 0;
@@ -952,9 +952,9 @@ unsafe fn w_set_contains_key_for_update(
             if stored.hash == key.hash {
                 let _roots = crate::gc_roots::push_roots();
                 let stored_slot = crate::gc_roots::shadow_stack_len();
-                crate::gc_roots::pin_root(stored.obj);
+                let _ = crate::gc_roots::pin_root(stored.obj);
                 let key_slot = crate::gc_roots::shadow_stack_len();
-                crate::gc_roots::pin_root(key.obj);
+                let _ = crate::gc_roots::pin_root(key.obj);
                 let equal = crate::dictmultiobject::dict_keys_equal(stored.obj, key.obj);
                 let stored_obj = crate::gc_roots::shadow_stack_get(stored_slot);
                 key.obj = crate::gc_roots::shadow_stack_get(key_slot);
@@ -1019,9 +1019,9 @@ unsafe fn w_set_remove_key_for_update(
             if stored.hash == key.hash {
                 let _roots = crate::gc_roots::push_roots();
                 let stored_slot = crate::gc_roots::shadow_stack_len();
-                crate::gc_roots::pin_root(stored.obj);
+                let _ = crate::gc_roots::pin_root(stored.obj);
                 let key_slot = crate::gc_roots::shadow_stack_len();
-                crate::gc_roots::pin_root(key.obj);
+                let _ = crate::gc_roots::pin_root(key.obj);
                 let equal = crate::dictmultiobject::dict_keys_equal(stored.obj, key.obj);
                 let stored_obj = crate::gc_roots::shadow_stack_get(stored_slot);
                 key.obj = crate::gc_roots::shadow_stack_get(key_slot);

--- a/pyre/pyre-object/src/sliceobject.rs
+++ b/pyre/pyre-object/src/sliceobject.rs
@@ -31,10 +31,9 @@ pub fn w_slice_new(start: PyObjectRef, stop: PyObjectRef, step: PyObjectRef) -> 
     // survive a later minor collection.
     let _roots = crate::gc_roots::push_roots();
     let save_point = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(start);
-    crate::gc_roots::pin_root(stop);
-    crate::gc_roots::pin_root(step);
-
+    let _ = crate::gc_roots::pin_root(start);
+    let _ = crate::gc_roots::pin_root(stop);
+    let _ = crate::gc_roots::pin_root(step);
     let header = PyObject {
         ob_type: &SLICE_TYPE as *const PyType,
         w_class: get_instantiate(&SLICE_TYPE),

--- a/pyre/pyre-object/src/slots.rs
+++ b/pyre/pyre-object/src/slots.rs
@@ -53,8 +53,8 @@ pub unsafe fn slot_set(
     }
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(obj);
-    crate::gc_roots::pin_root(value);
+    let _ = crate::gc_roots::pin_root(obj);
+    let _ = crate::gc_roots::pin_root(value);
     if slots.is_null() {
         let new_slots = crate::listobject::w_list_new(vec![PY_NULL; index + 1]);
         let obj = crate::gc_roots::shadow_stack_get(root_base);

--- a/pyre/pyre-object/src/specialisedtupleobject.rs
+++ b/pyre/pyre-object/src/specialisedtupleobject.rs
@@ -191,9 +191,8 @@ pub fn w_specialised_tuple_oo_new(value0: PyObjectRef, value1: PyObjectRef) -> P
     // variants take unboxed i64/f64 and need no bracket here.
     let _roots = crate::gc_roots::push_roots();
     let save_point = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(value0);
-    crate::gc_roots::pin_root(value1);
-
+    let _ = crate::gc_roots::pin_root(value0);
+    let _ = crate::gc_roots::pin_root(value1);
     let header = PyObject {
         ob_type: &SPECIALISED_TUPLE_OO_TYPE as *const PyType,
         w_class: get_instantiate(&TUPLE_TYPE),

--- a/pyre/pyre-object/src/tupleobject.rs
+++ b/pyre/pyre-object/src/tupleobject.rs
@@ -158,8 +158,8 @@ pub unsafe fn w_tuple_setitem_initializing(
 ) -> bool {
     let roots = crate::gc_roots::push_roots();
     let base = roots.base();
-    roots.pin_root(obj);
-    roots.pin_root(value);
+    let _ = roots.pin_root(obj);
+    let _ = roots.pin_root(value);
     crate::gc_hook::try_gc_write_barrier_managed(roots.get(base) as *mut u8);
     let obj = roots.get(base);
     let value = roots.get(base + 1);
@@ -294,7 +294,7 @@ fn w_tuple_new_array_backed_impl(
     let save_point = crate::gc_roots::shadow_stack_len();
     let len = items.len();
     for &item in &items {
-        crate::gc_roots::pin_root(item);
+        let _ = crate::gc_roots::pin_root(item);
     }
 
     // The only allocations that may collect: the type's lazy instantiate
@@ -331,7 +331,7 @@ fn w_tuple_new_array_backed_impl(
                 user_layout,
             );
         }
-        crate::gc_roots::pin_root(raw as PyObjectRef);
+        let _ = crate::gc_roots::pin_root(raw as PyObjectRef);
         Some(crate::gc_roots::shadow_stack_len() - 1)
     };
 
@@ -356,7 +356,7 @@ fn w_tuple_new_array_backed_impl(
         None
     } else {
         let s = crate::gc_roots::shadow_stack_len();
-        crate::gc_roots::pin_root(items_block as PyObjectRef);
+        let _ = crate::gc_roots::pin_root(items_block as PyObjectRef);
         Some(s)
     };
     let raw = raw_slot

--- a/pyre/pyre-object/src/typedef.rs
+++ b/pyre/pyre-object/src/typedef.rs
@@ -387,7 +387,7 @@ pub fn w_member_new_with_doc(
     // `gct_fv_gc_malloc` bracket pattern (`framework.py`).
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(w_cls);
+    let _ = crate::gc_roots::pin_root(w_cls);
     let name = crate::lltype::malloc_raw(name);
     let doc = doc.map_or(std::ptr::null(), |doc| {
         crate::lltype::malloc_raw(doc) as *const String

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -390,8 +390,8 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
     // `gct_fv_gc_malloc` bracket pattern (`framework.py`).
     let _roots = crate::gc_roots::push_roots();
     let save_point = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(bases);
-    crate::gc_roots::pin_root(dict_ptr as PyObjectRef);
+    let _ = crate::gc_roots::pin_root(bases);
+    let _ = crate::gc_roots::pin_root(dict_ptr as PyObjectRef);
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_TYPE_GC_TYPE_ID, W_TYPE_OBJECT_SIZE);
     // A mortal (GC-managed) heap type boxes its name in a GC-managed storage box
     // reclaimed by the box tid's drop glue (`NameStorage`), greyed through the
@@ -408,7 +408,7 @@ pub fn w_type_new(name: &str, bases: PyObjectRef, dict_ptr: *mut u8) -> PyObject
     } else {
         let name =
             crate::gc_storage::gc_alloc_storage_box(name_value.clone(), name_storage_gc_type_id());
-        crate::gc_roots::pin_root(name as PyObjectRef);
+        let _ = crate::gc_roots::pin_root(name as PyObjectRef);
         let qualname =
             crate::gc_storage::gc_alloc_storage_box(name_value, name_storage_gc_type_id());
         let name = crate::gc_roots::shadow_stack_get(save_point + 2) as *mut String;
@@ -539,8 +539,8 @@ pub fn w_type_new_builtin(
     // `gct_fv_gc_malloc` bracket pattern (`framework.py`).
     let _roots = crate::gc_roots::push_roots();
     let save_point = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(bases);
-    crate::gc_roots::pin_root(dict_ptr as PyObjectRef);
+    let _ = crate::gc_roots::pin_root(bases);
+    let _ = crate::gc_roots::pin_root(dict_ptr as PyObjectRef);
 
     let bases = crate::gc_roots::shadow_stack_get(save_point);
     let dict_ptr = crate::gc_roots::shadow_stack_get(save_point + 1) as *mut u8;
@@ -1192,7 +1192,7 @@ pub unsafe fn w_type_get_bases(obj: PyObjectRef) -> PyObjectRef {
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_type_set_bases(obj: PyObjectRef, bases: PyObjectRef) {
-    crate::gc_roots::pin_root(bases);
+    let bases = crate::gc_roots::pin_root(bases);
     crate::gc_roots::mark_prebuilt_roots_dirty();
     (*(obj as *mut W_TypeObject)).bases = bases;
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);

--- a/pyre/pyre-object/src/weakref.rs
+++ b/pyre/pyre-object/src/weakref.rs
@@ -455,7 +455,7 @@ pub unsafe fn w_gc_weakref_box_retarget(obj: PyObjectRef, target: PyObjectRef) -
     // livevar explicitly: `w_weakref_new` may collect and relocate the box.
     let _roots = crate::gc_roots::push_roots();
     let box_root = crate::gc_roots::shadow_stack_len();
-    crate::gc_roots::pin_root(obj);
+    let _ = crate::gc_roots::pin_root(obj);
     let rooted_obj = crate::gc_roots::shadow_stack_get(box_root);
     if !unsafe { is_gc_weakref_box(rooted_obj) } {
         return false;

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -823,7 +823,7 @@ fn run_python_impl(source: &str) -> String {
     // registration below allocates and can collect in between. Publish it for
     // that span (pyrex `run_source` does the same).
     let _main_frame_root = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(
+    let _ = pyre_object::gc_roots::pin_root(
         &*frame as *const pyre_interpreter::pyframe::PyFrame as pyre_object::PyObjectRef,
     );
 

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1421,7 +1421,7 @@ fn clear_shutdown_modules(
             builtins_module_slot = Some(index);
         }
         names.push(name);
-        pyre_object::gc_roots::pin_root(module);
+        let _ = pyre_object::gc_roots::pin_root(module);
     }
     // `finalize_runtime` sweeps immediately before detaching the import cache,
     // and every module that detach handed over is pinned just above — so a
@@ -1611,7 +1611,7 @@ fn run_module(module: &str, no_site: bool) {
     // Module.getdict()).
     let w_globals = execution_context.fresh_module_globals();
     let _root = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_globals);
+    let w_globals = pyre_object::gc_roots::pin_root(w_globals);
     unsafe {
         pyre_object::w_dict_setitem_str(w_globals, "__name__", pyre_object::w_str_new("__main__"))
     };
@@ -1755,12 +1755,12 @@ fn path_hook_accepts(
 
     let _roots = push_roots();
     let filename_slot = shadow_stack_len();
-    pin_root(pyre_object::w_str_new(filename));
+    let _ = pin_root(pyre_object::w_str_new(filename));
     // A hook call runs arbitrary Python and can drive a collection, which moves
     // the iterator that has to survive it. A Rust local is not walked, so
     // publish it in a shadow-stack slot and read it back for the next step.
     let iterator_slot = shadow_stack_len();
-    pin_root(iterator);
+    let _ = pin_root(iterator);
     loop {
         let hook = match pyre_interpreter::baseobjspace::next(shadow_stack_get(iterator_slot)) {
             Ok(hook) => hook,
@@ -1818,7 +1818,7 @@ fn prepare_main_module(
 ) -> (pyre_object::PyObjectRef, pyre_object::PyObjectRef) {
     let w_globals = execution_context.fresh_module_globals();
     let _root = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_globals);
+    let w_globals = pyre_object::gc_roots::pin_root(w_globals);
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str(
             w_globals,
@@ -1897,7 +1897,7 @@ fn eval_source_in_main(
     // allocation.  RPython keeps a local holding a GC object alive through the
     // translated shadow stack; publish it explicitly for the same span.
     let _main_frame_root = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(&*frame as *const PyFrame as pyre_object::PyObjectRef);
+    let _ = pyre_object::gc_roots::pin_root(&*frame as *const PyFrame as pyre_object::PyObjectRef);
 
     // Seed the module-identity attributes every `__main__` namespace carries
     // (pythonrun.c seeds these; `runpy` does the `-m` case). Without them a

--- a/pyre/pyrex/src/repl.rs
+++ b/pyre/pyrex/src/repl.rs
@@ -64,7 +64,7 @@ pub fn run_repl(quiet: bool, no_site: bool) {
 
     let w_globals = execution_context.fresh_module_globals();
     let _root = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_globals);
+    let w_globals = pyre_object::gc_roots::pin_root(w_globals);
     unsafe {
         pyre_object::w_dict_setitem_str(w_globals, "__name__", pyre_object::w_str_new("__main__"))
     };
@@ -262,7 +262,7 @@ fn register_interactive_code(
     source: &str,
 ) -> Result<(), PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_code);
+    let _ = pyre_object::gc_roots::pin_root(w_code);
     let code_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let linecache = importing::importhook(
         "linecache",
@@ -271,19 +271,19 @@ fn register_interactive_code(
         0,
         runtime.ctx_ptr,
     )?;
-    pyre_object::gc_roots::pin_root(linecache);
+    let _ = pyre_object::gc_roots::pin_root(linecache);
     let linecache_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let register = pyre_interpreter::baseobjspace::getattr_str(
         pyre_object::gc_roots::shadow_stack_get(linecache_slot),
         "_register_code",
     )?;
-    pyre_object::gc_roots::pin_root(register);
+    let _ = pyre_object::gc_roots::pin_root(register);
     let register_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     // Each `w_str_new` can collect, so the earlier string is rooted before
     // the next one is built rather than left in a temporary.
-    pyre_object::gc_roots::pin_root(pyre_object::w_str_new(source));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(source));
     let source_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(pyre_object::w_str_new("<stdin>"));
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new("<stdin>"));
     let filename_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     pyre_interpreter::call::call_function_impl_result(
         pyre_object::gc_roots::shadow_stack_get(register_slot),
@@ -307,7 +307,7 @@ fn shell_exec(
             let code_ptr = Box::into_raw(Box::new(code));
             let w_code = pyre_interpreter::pycode::w_code_new(code_ptr as *const ());
             let _roots = pyre_object::gc_roots::push_roots();
-            pyre_object::gc_roots::pin_root(w_code);
+            let w_code = pyre_object::gc_roots::pin_root(w_code);
             let code_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             // Source registration is cosmetic — it only feeds later traceback
             // and `inspect` lookups — so a failure must not discard the


### PR DESCRIPTION
`pin_root` publishes a word to the shadow stack and then asks the collector where that object actually lives — a query that is itself a GC operation, so the answer can differ from the argument. Callers were dropping that answer and going on using the word they passed in. This makes the return value the contract (`#[must_use]`), fixes the call sites where dropping it was a live defect, and carries three unrelated GC findings from the same audit.

| commit | change |
|---|---|
| `five pin sites` | `pin_root` callers that read the original local afterwards now read the slot |
| `_contextvars` | `new_token` held its three values across the instance allocation |
| `pin_root` | returns the normalized `PyObjectRef`, `#[must_use]`; ~400 call sites take `let _ =` or the value |
| `four rebind sites` | `let mut x = pin_root(x)` inside a nested block shadowed the outer `x`, so the later `x = …` assigned the inner copy |
| `_json` | `encode_sequence` / `encode_dict` used the pre-pin receiver for `iter()` / `getattr("items")` |
| `gc.set_threshold` | the third threshold was stored and then read back as `0` |
| `gc.is_finalized` | answered a constant `False` |
| `object_array` | four block allocators ran fill → ownership-query → write-barrier |
| `twenty call sites` | the `pin_root` calls `main` added while this branch was out |

## The shadowing arm is the one that had teeth

`let mut x = pyre_object::gc_roots::pin_root(x);` written inside a nested block declares a *new* `x`. Where the enclosing function later assigns `x = …` — a CAS retry arm, a loop-carried traceback — that assignment lands on the inner copy and the outer binding keeps its pre-pin word.

Two of the four were reachable. `write_traceback_chain_from_tb` walks `tb = tb.tb_next`; with the loop variable shadowed the walk never advanced, so **any uncaught exception hung the process forever**. `ExecutionContext::leave` returned the exit value taken before the `leaveframe` callback ran. The other two are `interp_signal`'s `handlers_dict` / `default_int_handler_obj`, whose `Err(installed)` arm returns the loser of a CAS and needs the outer binding to carry it.

## The barrier has to be the last thing before the writes

`finish_alloc_in_oldgen` stamps `TRACK_YOUNG_PTRS` on an old-gen birth and `do_write_barrier` only acts while that flag is set, so **the barrier is the registration**. All four block allocators asked `try_gc_owns_object` — a `gc_op`, which parks this mutator while another thread can drive a cycle to `STATE_SWEEPING` — *after* the young elements were already in an unregistered old-gen block, where a minor collection does not trace them. The order is now query → barrier → fill, which is where `writebarrier_before_copy` sits relative to `ll_arraycopy`'s memcpy: no safepoint between the barrier and the stores it covers.

## Two `gc` answers that were placeholders

`set_threshold(a, b, c)` stored `c` and `get_threshold` appended a literal `0` in its place, so the save/restore idiom (`saved = gc.get_threshold(); …; gc.set_threshold(*saved)`) silently lost the third value. 3.14's collector is incremental and sizes no third generation, but the value still has to round-trip.

`is_finalized` returned a constant `False`. The collector's queue delivers an object once and never asks afterwards, so nothing recorded the answer; a new header flag (bit 14) does, set where `finalize_garbage` sets `_PyGC_SET_FINALIZED` — before `__del__`, not after it the way the refcount path's `PyObject_CallFinalizer` does. An object its own finalizer resurrects now reports `True`, and `__del__` still runs once.

## The last commit is a rebase artefact, not a review find

`main` added twenty `pin_root` call sites while this branch was out, written against the `()` signature. None of them overlap a hunk here, so they merged with no conflict and silently violated the new `#[must_use]`. Nineteen record a slot and read the value back, so they take `let _ =`; `w_code_new`'s prebuilt-code root reuses the local after the pin and takes the returned word.

## Noticed while measuring, and **not** part of these commits

A loop that allocates and drops one list over `LARGE_OBJECT_THRESHOLD` gets essentially no automatic old-gen collection once it runs three Python frames deep. `alloc_in_oldgen` asks `external_malloc`'s threshold question where upstream asks it, but defers the collection to the dispatch-loop safepoint through `EB_GC`; both the arming probe and the safepoint require `at_outermost_activation()` — `EVAL_NESTING <= 2` — and that counter is one per Python frame, not one per callback re-entry the way its doc comment reasons. `x = [0]*1000000; x = None`, 200 iterations, JIT **off**:

| eval nesting | `[gc][major] complete` | peak RSS |
|---|---|---|
| 1 — module-level loop | 208 | 141.9 MB |
| 2 — `module -> loop()` | 208 | 156.3 MB |
| 3 — `module -> f1() -> loop()` | **9** | **7746.8 MB** |
| 4 | 9 | 7746.6 MB |

Backend-independent (`pyre-cranelift` reads 207 / 207 / **8** / 8) and not a JIT effect: with the JIT on over 900 iterations the counts are 907 / 907 / **8** and the peaks 177.1 / 178.2 / **31384.4** MB. It is not retention either — the live set sampled right after an explicit `gc.collect()` reads 4.5 MB at every point, and collecting every 10 iterations holds the whole run flat. What is affected splits into two populations, and only the first is the nesting gate. 200 iterations of allocate-and-drop, 4 MB per block, JIT off, peak RSS at nesting 1 vs 3:

| block | nesting 1 | nesting 3 |
|---|---|---|
| `[0]*500000` | 106.3 MB | **3892.1 MB** |
| `[None]*500000` | 83.2 MB | **819.9 MB** |
| `{i: i for i in range(200000)}` | 113.4 MB | **2725.4 MB** |
| `b"x"*4000000` | **808.1 MB** | 808.1 MB |
| `"x"*4000000` | **804.2 MB** | 804.3 MB |
| `bytearray(4000000)` | **1572.9 MB** | 1573.1 MB |

The `bytes` / `str` / `bytearray` rows are flat across nesting because they never reach the arming site at all: the payload is outside the collector's accounting entirely. `gc.get_stats()` after a single `b"x"*4000000` reads `total_gc_memory`, `total_rawmalloced_memory` and `total_memory_pressure` all unchanged, where `[0]*500000` moves the first two to 24.1 MB and 3.8 MB. So `get_total_memory_used()` never grows, the threshold is never reached, and 200 iterations produce 7 majors — while `gc.collect()` every iteration holds the same loop at 45.6 MB. That is a second, independent defect: a raw payload owes `rgc.add_memory_pressure`, and `total_memory_pressure` is a reporting field with no producer.

At nesting <= 2 this base is flat with the JIT on: 1600 iterations peak at 212.0 MB, 2000 at 257.8 MB. An earlier round of this measurement reported 6.1 GB and 21.5 GB there and named JIT compilation as a second trigger; those runs were taken on a binary built before the rebase onto `b6038b1c616`, and they do not reproduce on a binary built from this base. Only the nesting result above survives re-measurement.

## Gates

Two new snippets, each `# pyre-check: gate=1`, each verified against CPython 3.14.6:

- `gc_set_threshold_keeps_the_third_value.py`
- `gc_is_finalized_reports_a_resurrected_object.py` — prints `False / True / 0 / False` on CPython and post-fix; pre-fix printed `False / **False** / 0 / False`

Local lanes on this base, on binaries rebuilt after the rebase: gated snippets 96/96 across cpython/dynasm/cranelift, parity, `cargo test --all --no-default-features --features dynasm`, `cargo fmt --all -- --check`, LLBC `--check`, the new-line citation gate. Two earlier runs of this battery read green on stale artefacts — the tool timeout had SIGTERM'd the charon extraction and then both backend builds — so this one is the one with build timestamps that postdate the commit and the LLBC. CI is the gate.

`git range-diff` across the rebase onto `b6038b1c616`: seven of the eight replayed commits are byte-identical, the eighth (`pin_root`) differs only where `main` edited the same regions of `error.rs` and `gc/mod.rs`.

— *authored by Claude*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
