### PR TITLE
error: carry oefmt's message as WTF-8, and publish its class and operands as one root set

### DIFF
--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -3754,12 +3754,21 @@ pub fn oefmt(w_type: PyObjectRef, valuefmt: &str, args: &[FmtArg<'_>]) -> Operat
             ('d', FmtArg::Int(value)) => message.push_str(&value.to_string()),
             ('s', FmtArg::Text(value)) => message.push_str(value),
             // `_compute_value`'s final `else` — `%s` over a byte string,
-            // which upstream checks is already UTF-8 rather than decoding.
-            // The check has no failure branch there beyond a length
-            // correction, and an invalid byte cannot be carried into this
-            // buffer, so it is replaced the way `%8` replaces one.
+            // which it keeps verbatim after only checking the length — and
+            // `%8`, which it decodes with `'replace'`.  Both run with
+            // `allow_surrogates`, so a byte string that is already WTF-8
+            // reaches the message unchanged, encoded surrogates included;
+            // decoding it as UTF-8 would turn each into `U+FFFD`.
+            //
+            // Bytes that are not WTF-8 at all are where the two part company
+            // upstream: `%8` replaces them, which this matches, while `%s`
+            // keeps them and subtracts the bad run from the reported length
+            // instead.  No `Wtf8Buf` can hold them, so `%s` replaces them too.
             ('s', FmtArg::Bytes(value)) | ('8', FmtArg::Bytes(value)) => {
-                message.push_str(&String::from_utf8_lossy(value))
+                match rustpython_wtf8::Wtf8::from_bytes(value) {
+                    Some(value) => message.push_wtf8(value),
+                    None => message.push_str(&String::from_utf8_lossy(value)),
+                }
             }
             ('T', FmtArg::Obj(_)) => {
                 let obj = _roots.get(next_obj_slot);
@@ -4181,6 +4190,25 @@ mod tests {
             from_bytes.render_exception(),
             format!("RuntimeError: {text}")
         );
+    }
+
+    #[test]
+    fn oefmt_keeps_a_surrogate_encoded_in_a_byte_string() {
+        // WTF-8 for a lone `U+D800`.  `_compute_value` decodes `%8` with
+        // `allow_surrogates` and hands `%s` its bytes untouched, so neither
+        // conversion replaces this.
+        let bytes = [0xEDu8, 0xA0, 0x80];
+        let expected = rustpython_wtf8::Wtf8::from_bytes(&bytes)
+            .expect("the encoding of a lone surrogate is WTF-8")
+            .to_owned();
+        for valuefmt in ["%s", "%8"] {
+            let err = super::oefmt(
+                std::ptr::null_mut(),
+                valuefmt,
+                &[super::FmtArg::Bytes(&bytes)],
+            );
+            assert_eq!(err.message_wtf8(), expected, "for {valuefmt}");
+        }
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -3493,6 +3493,12 @@ pub fn decompose_valuefmt(valuefmt: &str) -> (Vec<String>, Vec<String>) {
                     strings.push(std::mem::take(&mut current));
                     formats.push(spec.to_string());
                 }
+                // Upstream raises `ValueError` here, but `oefmt` is
+                // `@specialize.arg(1)`: `valuefmt` is a constant per call site
+                // and the class this feeds is built during translation, so the
+                // raise aborts the build rather than a running program.  A
+                // panic is that same "this call site is malformed" report at
+                // the earliest point this port can make it.
                 Some(_) | None => {
                     panic!("invalid format string (only %8, %N, %R, %S, %T, %d or %s supported)")
                 }
@@ -3549,7 +3555,7 @@ fn operation_error_from_instance(
 ///
 /// A null class falls back to the message alone — a value cannot be reported
 /// through a class that is not there.
-fn operation_error_from_class(w_type: PyObjectRef, message: &str) -> OperationError {
+fn operation_error_from_class(w_type: PyObjectRef, message: Wtf8Buf) -> OperationError {
     if w_type.is_null() {
         return PyError::runtime_error(message);
     }
@@ -3560,7 +3566,9 @@ fn operation_error_from_class(w_type: PyObjectRef, message: &str) -> OperationEr
     let _roots = pyre_object::gc_roots::push_roots();
     let base = _roots.base();
     _roots.pin_root(w_type);
-    let w_message = pyre_object::w_str_new(message);
+    // `w_str_new`'s buffer-taking sibling: same allocation policy, and it is
+    // the one that accepts a lone surrogate.
+    let w_message = pyre_object::w_str_from_wtf8(message.clone());
     _roots.pin_root(w_message);
     let (w_type, w_message) = (_roots.get(base), _roots.get(base + 1));
     operation_error_from_instance(
@@ -3612,7 +3620,7 @@ impl FmtArg<'_> {
 
 fn expected_fmt_arg(format: char) -> &'static str {
     match format {
-        's' => "Text",
+        's' => "Text or Bytes",
         'd' => "Int",
         '8' => "Bytes",
         'R' | 'S' | 'T' | 'N' => "Obj",
@@ -3622,7 +3630,7 @@ fn expected_fmt_arg(format: char) -> &'static str {
 
 /// The shared `%R` / `%S` conversion and rescue from
 /// `get_operrcls2.OpErrFmt._compute_value`.
-fn format_obj_as_utf8(obj: PyObjectRef, format: char) -> String {
+fn format_obj_as_utf8(obj: PyObjectRef, format: char) -> Wtf8Buf {
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = _roots.base();
     _roots.pin_root(obj);
@@ -3645,16 +3653,16 @@ fn format_obj_as_utf8(obj: PyObjectRef, format: char) -> String {
         // takes the rescue below.  Reading it back through a `&str` view
         // instead would divert a lone surrogate — legal in that buffer — into
         // the rescue as well, reporting `<repr raised>` for a repr that
-        // succeeded.  The surrogate itself does not survive the last step: the
-        // message this builds is a Rust `String`.
-        Ok(rendered) => rendered.to_string_lossy().into_owned(),
+        // succeeded.  The buffer is carried on rather than converted, so the
+        // surrogate reaches the message intact.
+        Ok(rendered) => rendered,
         Err(mut error) => {
             error.write_unraisable(
                 pyre_object::w_none(),
                 rustpython_wtf8::Wtf8::new("exception formatting: "),
                 obj(),
             );
-            fallback.to_owned()
+            Wtf8Buf::from_string(fallback.to_string())
         }
     }
 }
@@ -3665,12 +3673,12 @@ fn format_obj_as_utf8(obj: PyObjectRef, format: char) -> String {
 /// The name is read off the string's own buffer for the reason
 /// [`format_obj_as_utf8`] gives: a `&str` view would turn a lone surrogate in
 /// `__name__` into a raise, and this function reports a raise as `?`.
-fn format_obj_name(obj: PyObjectRef) -> String {
+fn format_obj_name(obj: PyObjectRef) -> Wtf8Buf {
     match crate::baseobjspace::getattr_str(obj, "__name__")
         .and_then(crate::baseobjspace::text_wtf8_w)
     {
-        Ok(name) => name.to_string_lossy().into_owned(),
-        Err(_) => "?".to_owned(),
+        Ok(name) => name.to_owned(),
+        Err(_) => Wtf8Buf::from_string("?".to_string()),
     }
 }
 
@@ -3696,7 +3704,7 @@ pub fn oefmt(w_type: PyObjectRef, valuefmt: &str, args: &[FmtArg<'_>]) -> Operat
     // `OpErrFmtNoArgs(w_type, valuefmt)` — no argument, so the format string is
     // the message verbatim, `%` sequences and all.
     let message = if args.is_empty() {
-        valuefmt.to_string()
+        Wtf8Buf::from_string(valuefmt.to_string())
     } else {
         // `OpErrFmt, strings = get_operr_class(valuefmt)`, then the walk
         // `_compute_value` makes over them: a literal part, the argument
@@ -3724,43 +3732,52 @@ pub fn oefmt(w_type: PyObjectRef, valuefmt: &str, args: &[FmtArg<'_>]) -> Operat
         }
         let first_obj_slot = _roots.base();
         let mut next_obj_slot = first_obj_slot;
-        let mut message = String::new();
+        // The message is a `Wtf8Buf` for the same reason `_compute_value`
+        // joins `space.utf8_w` results: `%R`, `%S` and `%N` can each produce a
+        // lone surrogate, which no `&str` can hold.
+        let mut message = Wtf8Buf::new();
         for (i, part) in strings[..formats.len()].iter().enumerate() {
             message.push_str(part);
             let format = formats[i].chars().next().unwrap();
             let arg = &args[i];
-            let rendered = match (format, arg) {
-                ('d', FmtArg::Int(value)) => value.to_string(),
-                ('s', FmtArg::Text(value)) => (*value).to_owned(),
-                ('8', FmtArg::Bytes(value)) => String::from_utf8_lossy(value).into_owned(),
+            match (format, arg) {
+                ('d', FmtArg::Int(value)) => message.push_str(&value.to_string()),
+                ('s', FmtArg::Text(value)) => message.push_str(value),
+                // `_compute_value`'s final `else` — `%s` over a byte string,
+                // which upstream checks is already UTF-8 rather than decoding.
+                // The check has no failure branch there beyond a length
+                // correction, and an invalid byte cannot be carried into this
+                // buffer, so it is replaced the way `%8` replaces one.
+                ('s', FmtArg::Bytes(value)) | ('8', FmtArg::Bytes(value)) => {
+                    message.push_str(&String::from_utf8_lossy(value))
+                }
                 ('T', FmtArg::Obj(_)) => {
                     let obj = _roots.get(next_obj_slot);
                     next_obj_slot += 1;
-                    type_name_of(obj)
+                    message.push_str(&type_name_of(obj));
                 }
                 ('N', FmtArg::Obj(_)) => {
                     let obj = _roots.get(next_obj_slot);
                     next_obj_slot += 1;
-                    format_obj_name(obj)
+                    message.push_wtf8(&format_obj_name(obj));
                 }
                 ('R' | 'S', FmtArg::Obj(_)) => {
                     let obj = _roots.get(next_obj_slot);
                     next_obj_slot += 1;
-                    format_obj_as_utf8(obj, format)
+                    message.push_wtf8(&format_obj_as_utf8(obj, format));
                 }
                 _ => panic!(
                     "oefmt format %{format} requires {} argument, got {}",
                     expected_fmt_arg(format),
                     arg.kind_name()
                 ),
-            };
-            message.push_str(&rendered);
+            }
         }
         debug_assert_eq!(next_obj_slot - first_obj_slot, rooted_obj_count);
         message.push_str(&strings[formats.len()]);
         message
     };
-    operation_error_from_class(w_type, &message)
+    operation_error_from_class(w_type, message)
 }
 
 pub fn debug_print(text: &str, file: Option<&mut dyn Write>, _newline: bool) {
@@ -3893,15 +3910,22 @@ pub fn new_exception_class(
             return std::ptr::null_mut();
         }
     };
-    if let Some(module) = module {
+    // `if module:` — a name like `".Name"` splits to an empty prefix, which is
+    // falsy upstream, so the attribute is left alone rather than set to `""`.
+    if let Some(module) = module.filter(|module| !module.is_empty()) {
         let exc_slot = pyre_object::gc_roots::shadow_stack_len();
         _roots.pin_root(w_exc);
-        let w_module = pyre_object::w_str_new(module);
+        // Pinned like every other operand here: `setattr_str` allocates, and a
+        // collection rewrites the root SLOT rather than this frame's copy.
+        let module_slot = pyre_object::gc_roots::shadow_stack_len();
+        _roots.pin_root(pyre_object::w_str_new(module));
         // `space.setattr` propagates its failure through the same bare-return
         // channel as the class call above.
-        if let Err(err) =
-            crate::baseobjspace::setattr_str(_roots.get(exc_slot), "__module__", w_module)
-        {
+        if let Err(err) = crate::baseobjspace::setattr_str(
+            _roots.get(exc_slot),
+            "__module__",
+            _roots.get(module_slot),
+        ) {
             crate::call::set_call_error(err);
             return std::ptr::null_mut();
         }
@@ -4129,6 +4153,26 @@ mod tests {
             &[super::FmtArg::Int(-42), super::FmtArg::Text("items")],
         );
         assert_eq!(err.render_exception(), "RuntimeError: -42 items");
+    }
+
+    #[test]
+    fn oefmt_takes_a_byte_string_for_percent_s() {
+        // `error.py _compute_value`'s final `else`, which
+        // `interpreter/test/test_error.py test_oefmt_utf8` exercises: a UTF-8
+        // byte string reaches `%s` and reads back as the same text a `str`
+        // operand would have produced.
+        let text = "abc \u{e0}\u{e8}\u{ec}\u{f2}\u{f9}";
+        let from_bytes = super::oefmt(
+            std::ptr::null_mut(),
+            "%s",
+            &[super::FmtArg::Bytes(text.as_bytes())],
+        );
+        let from_text = super::oefmt(std::ptr::null_mut(), "%s", &[super::FmtArg::Text(text)]);
+        assert_eq!(from_bytes.message_wtf8(), from_text.message_wtf8());
+        assert_eq!(
+            from_bytes.render_exception(),
+            format!("RuntimeError: {text}")
+        );
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -3702,82 +3702,90 @@ pub(crate) fn type_name_of(w_obj: PyObjectRef) -> String {
 
 pub fn oefmt(w_type: PyObjectRef, valuefmt: &str, args: &[FmtArg<'_>]) -> OperationError {
     // `OpErrFmtNoArgs(w_type, valuefmt)` — no argument, so the format string is
-    // the message verbatim, `%` sequences and all.
-    let message = if args.is_empty() {
-        Wtf8Buf::from_string(valuefmt.to_string())
-    } else {
-        // `OpErrFmt, strings = get_operr_class(valuefmt)`, then the walk
-        // `_compute_value` makes over them: a literal part, the argument
-        // belonging to the format code that followed it, and so on to the
-        // trailing part `decompose_valuefmt` guarantees.
-        let (strings, formats) = decompose_valuefmt(valuefmt);
-        assert_eq!(
-            args.len(),
-            formats.len(),
-            "oefmt argument count mismatch: {} format codes but {} arguments",
-            formats.len(),
-            args.len()
-        );
+    // the message verbatim, `%` sequences and all.  Nothing on the way to the
+    // error runs application-level code, so the class needs no root here.
+    if args.is_empty() {
+        return operation_error_from_class(w_type, Wtf8Buf::from_string(valuefmt.to_string()));
+    }
+    // `OpErrFmt, strings = get_operr_class(valuefmt)`, then the walk
+    // `_compute_value` makes over them: a literal part, the argument
+    // belonging to the format code that followed it, and so on to the
+    // trailing part `decompose_valuefmt` guarantees.
+    let (strings, formats) = decompose_valuefmt(valuefmt);
+    assert_eq!(
+        args.len(),
+        formats.len(),
+        "oefmt argument count mismatch: {} format codes but {} arguments",
+        formats.len(),
+        args.len()
+    );
 
-        // Pin every object before the first object-space conversion can move
-        // any later operand. The argument slice itself contains raw pointers
-        // and is not a GC root.
-        let _roots = pyre_object::gc_roots::push_roots();
-        let mut rooted_obj_count = 0;
-        for arg in args {
-            if let FmtArg::Obj(obj) = arg {
-                _roots.pin_root(*obj);
-                rooted_obj_count += 1;
-            }
+    // The class and every object operand form one livevar set, published in
+    // one pass and normalized once.  `pin_root` per operand would instead
+    // query the GC between publications, and that query is a safepoint: it
+    // can wait through a foreign collection which moves the operands still
+    // held only in `args`, which is not a root.  `publish_roots` states the
+    // rule, and `DictOperationGuard::new` follows it for the same reason:
+    // its `refs` is a caller-owned native slice no collection rewrites.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let type_slot = _roots.publish(std::slice::from_ref(&w_type));
+    let mut rooted_obj_count = 0;
+    for arg in args {
+        if let FmtArg::Obj(obj) = arg {
+            _roots.publish(std::slice::from_ref(obj));
+            rooted_obj_count += 1;
         }
-        let first_obj_slot = _roots.base();
-        let mut next_obj_slot = first_obj_slot;
-        // The message is a `Wtf8Buf` for the same reason `_compute_value`
-        // joins `space.utf8_w` results: `%R`, `%S` and `%N` can each produce a
-        // lone surrogate, which no `&str` can hold.
-        let mut message = Wtf8Buf::new();
-        for (i, part) in strings[..formats.len()].iter().enumerate() {
-            message.push_str(part);
-            let format = formats[i].chars().next().unwrap();
-            let arg = &args[i];
-            match (format, arg) {
-                ('d', FmtArg::Int(value)) => message.push_str(&value.to_string()),
-                ('s', FmtArg::Text(value)) => message.push_str(value),
-                // `_compute_value`'s final `else` — `%s` over a byte string,
-                // which upstream checks is already UTF-8 rather than decoding.
-                // The check has no failure branch there beyond a length
-                // correction, and an invalid byte cannot be carried into this
-                // buffer, so it is replaced the way `%8` replaces one.
-                ('s', FmtArg::Bytes(value)) | ('8', FmtArg::Bytes(value)) => {
-                    message.push_str(&String::from_utf8_lossy(value))
-                }
-                ('T', FmtArg::Obj(_)) => {
-                    let obj = _roots.get(next_obj_slot);
-                    next_obj_slot += 1;
-                    message.push_str(&type_name_of(obj));
-                }
-                ('N', FmtArg::Obj(_)) => {
-                    let obj = _roots.get(next_obj_slot);
-                    next_obj_slot += 1;
-                    message.push_wtf8(&format_obj_name(obj));
-                }
-                ('R' | 'S', FmtArg::Obj(_)) => {
-                    let obj = _roots.get(next_obj_slot);
-                    next_obj_slot += 1;
-                    message.push_wtf8(&format_obj_as_utf8(obj, format));
-                }
-                _ => panic!(
-                    "oefmt format %{format} requires {} argument, got {}",
-                    expected_fmt_arg(format),
-                    arg.kind_name()
-                ),
+    }
+    _roots.normalize(type_slot, 1 + rooted_obj_count);
+    // The class is read back out of its slot after the conversions, which is
+    // why it is in the set at all: `%R`, `%S` and `%N` each run
+    // application-level code between this point and the error below.
+    let first_obj_slot = type_slot + 1;
+    let mut next_obj_slot = first_obj_slot;
+    // The message is a `Wtf8Buf` for the same reason `_compute_value`
+    // joins `space.utf8_w` results: `%R`, `%S` and `%N` can each produce a
+    // lone surrogate, which no `&str` can hold.
+    let mut message = Wtf8Buf::new();
+    for (i, part) in strings[..formats.len()].iter().enumerate() {
+        message.push_str(part);
+        let format = formats[i].chars().next().unwrap();
+        let arg = &args[i];
+        match (format, arg) {
+            ('d', FmtArg::Int(value)) => message.push_str(&value.to_string()),
+            ('s', FmtArg::Text(value)) => message.push_str(value),
+            // `_compute_value`'s final `else` — `%s` over a byte string,
+            // which upstream checks is already UTF-8 rather than decoding.
+            // The check has no failure branch there beyond a length
+            // correction, and an invalid byte cannot be carried into this
+            // buffer, so it is replaced the way `%8` replaces one.
+            ('s', FmtArg::Bytes(value)) | ('8', FmtArg::Bytes(value)) => {
+                message.push_str(&String::from_utf8_lossy(value))
             }
+            ('T', FmtArg::Obj(_)) => {
+                let obj = _roots.get(next_obj_slot);
+                next_obj_slot += 1;
+                message.push_str(&type_name_of(obj));
+            }
+            ('N', FmtArg::Obj(_)) => {
+                let obj = _roots.get(next_obj_slot);
+                next_obj_slot += 1;
+                message.push_wtf8(&format_obj_name(obj));
+            }
+            ('R' | 'S', FmtArg::Obj(_)) => {
+                let obj = _roots.get(next_obj_slot);
+                next_obj_slot += 1;
+                message.push_wtf8(&format_obj_as_utf8(obj, format));
+            }
+            _ => panic!(
+                "oefmt format %{format} requires {} argument, got {}",
+                expected_fmt_arg(format),
+                arg.kind_name()
+            ),
         }
-        debug_assert_eq!(next_obj_slot - first_obj_slot, rooted_obj_count);
-        message.push_str(&strings[formats.len()]);
-        message
-    };
-    operation_error_from_class(w_type, message)
+    }
+    debug_assert_eq!(next_obj_slot - first_obj_slot, rooted_obj_count);
+    message.push_str(&strings[formats.len()]);
+    operation_error_from_class(_roots.get(type_slot), message)
 }
 
 pub fn debug_print(text: &str, file: Option<&mut dyn Write>, _newline: bool) {


### PR DESCRIPTION
Three commits on `oefmt`, closing the findings the review of #1418 raised against that function and one the local parity review found in the fix itself.

## `%R` / `%S` / `%N` lost a lone surrogate the conversion had just preserved

The conversions were careful to read `repr` / `str` / `__name__` off the string's own buffer rather than through a `&str` view — precisely so a lone surrogate would not be diverted into the `<repr raised>` rescue. Then the message was assembled as a Rust `String`, which cannot hold one, and `to_string_lossy` replaced it with U+FFFD at the last step.

Nothing forced that: `PyError`'s message is already a `Wtf8Buf`. **The note in #1418 saying the carrier forced the loss is wrong, and this corrects it.** The buffer is now carried end to end and reaches the exception through `w_str_from_wtf8` — `w_str_new`'s buffer-taking sibling, with the same allocation policy, so nothing else about the allocation changes.

`%s` also takes a byte string now. That is `_compute_value`'s final `else`, and `interpreter/test/test_error.py test_oefmt_utf8` asserts a UTF-8 byte string there reads back as the text a `str` operand would have produced — which is the new unit test.

Two smaller things in the same commit:

- `new_exception_class` held the freshly allocated `w_module` in a raw local across `setattr_str`, which allocates and can therefore collect. It is pinned and read back out of its slot now, like every other operand in that function.
- A name whose module prefix is empty, as `".Name"` splits, no longer sets `__module__` to `""`. Upstream's `if module:` leaves the attribute alone.

## `%s` and `%8` over a byte string kept their surrogates

The arm above accepts a byte string for `%s`, and it decoded through `String::from_utf8_lossy` — which rejects an encoded surrogate and writes `U+FFFD` where it stood. That is the same loss this branch exists to stop, reintroduced by the new path: `_compute_value` decodes `%8` with `allow_surrogates` and hands `%s` its bytes untouched, so neither replaces one. The bytes are checked for WTF-8 first now and pushed as they are when they pass.

Bytes that are not WTF-8 at all still take the lossy decode. That is what `%8` does upstream. `%s` there keeps them and subtracts the bad run from the reported length instead, which no `Wtf8Buf` can represent — so this is a real divergence, and it is stated at the site rather than papered over.

## `oefmt`'s class and operands are one root set

`RootScope::pin_root` is publish-then-normalize, and the normalize half *queries* the GC — which its own comment describes as an operation that "may wait behind another thread's collection". So a `pin_root` per operand, as the loop did, lets the first operand's query wait through a foreign collection that moves operands 2..N — which at that moment live only in `args`, a caller-owned slice that is not a root. They are then published stale.

`publish_roots` documents exactly this window, and `DictOperationGuard::new` avoids it the way this now does: publish the whole set, normalize once.

The same commit puts the exception class in that set. It arrived by value and was held in a raw local across the conversion loop, which runs application-level code — `%R` and `%S` call `repr` and `str`, `%N` reads `__name__` — so it is read back out of its slot for the error it builds. The no-argument arm returns early instead, so the bracket covers only the walk that needs it.

## Left in place, deliberately

- **The malformed-format `panic!`.** Upstream raises `ValueError`, but `oefmt` is `@specialize.arg(1)`: `valuefmt` is a constant per call site and the class it feeds is built during translation, so that raise aborts the *build*, not a running program. A panic is the same report at the earliest point this port can make it. The reason is now recorded at the site.

## Left for a follow-up

- **Eager formatting.** Upstream's `OpErrFmt` stores the operands and runs `repr` / `str` / `getname` only when `_compute_value` is asked for the message; pyre has no such carrier, so the conversions — and any side effect or unraisable exception they raise — happen when the error is constructed. Closing that needs the carrier type, which is a larger change than this diff.

## Verification

`cargo test --all --features dynasm` — **169 targets, 8158 passed, 0 failed, 96 ignored**, on a full LLBC re-extract (`rc=0`, no staleness warnings). `cargo fmt --check` and the citation checker are clean.

That run was on the same three commits over the previous base; the branch has since been rebased onto #1421, which touches no file these commits touch. `pyre/check.py` was not run locally — it needs a release build, and release builds have been OOM-killed on this box at every `-j` value while sibling worktrees extract. CI measures the pushed tree.
