### PR TITLE
jit, interp: skip the w_class pin where the payload determines the class; two audits and a documented copy

### DIFF
--- a/pyre/bench/synth/gc_bug_bridge_flavor_traceback_names.cranelift.jitstats
+++ b/pyre/bench/synth/gc_bug_bridge_flavor_traceback_names.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=7
+bridges_compiled=6
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1459
+guard_failures=1054
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=3

--- a/pyre/bench/synth/gc_bug_bridge_flavor_traceback_names.dynasm.jitstats
+++ b/pyre/bench/synth/gc_bug_bridge_flavor_traceback_names.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=7
+bridges_compiled=6
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1459
+guard_failures=1054
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=3

--- a/pyre/bench/synth/gc_bug_bridge_flavor_traceback_names.wasm.jitstats
+++ b/pyre/bench/synth/gc_bug_bridge_flavor_traceback_names.wasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=7
+bridges_compiled=6
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1459
+guard_failures=1054
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=3

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -210,12 +210,13 @@ the folds it selects, not before them.
 `PYRE_FBW_SPEC_CENSUS` in §6c is its read-only half: the per-fold
 consulted/fired tallies.
 
-### §6c — Default-OFF diagnostics, censuses and probes (70): keep, cost nothing
+### §6c — Default-OFF diagnostics, censuses and probes (71): keep, cost nothing
 
 Each is inert unless set, so none is a removal target by this file's
 already-ON criterion. They are listed so they cannot be missed again.
 
-`PYRE_ALLOCSITES`, `PYRE_BH_NULL_ARG`, `PYRE_CALLEE_RCA`, `PYRE_CATCH_LIVE_CENSUS`,
+`PYRE_ALLOCSITES`, `PYRE_BH_NULL_ARG`, `PYRE_BRIDGE_LATCH_AUDIT`,
+`PYRE_CALLEE_RCA`, `PYRE_CATCH_LIVE_CENSUS`,
 `PYRE_CELL_CENSUS`, `PYRE_CHECK_INHERIT_ENV`,
 `PYRE_DESCR_SPELLING_GATE`,
 `PYRE_DEOPT_PROBE`, `PYRE_DIAG_51C`, `PYRE_DIAG_GIN`, `PYRE_DIAG_INLINE_RECOG`,

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3414,6 +3414,15 @@ impl ConstantOpcodeHandler for PyFrame {
         // (e.g. a tuple element), which has no top-level `co_consts_w` slot;
         // realize a wrapper directly.  Top-level `LOAD_CONST` of a code constant
         // goes through `constant_at` below.
+        //
+        // Defensive: the compiler does not emit that shape, and both routes into
+        // here are narrow.  `load_const_value` is entered either from the trait
+        // default `constant_at` — which `PyFrame`, the only implementor,
+        // overrides — or from `opcode_load_const` by way of
+        // `OpcodeStepExecutor::load_const`, which no caller in the tree invokes
+        // today, though `opcode_load_const` is registered as a JIT call target.
+        // So the copy this makes is not on a measured path; see
+        // `box_code_constant` for why removing it is not worth its price.
         Ok(crate::pycode::box_code_constant(code))
     }
 

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -998,6 +998,25 @@ pub fn box_code_object(code: crate::CodeObject) -> PyObjectRef {
 /// [`box_code_object`] for a caller that only has a borrow, which has to copy.
 /// A caller that owns its `CodeObject` should hand it over instead — the copy
 /// is a whole recursive duplicate of the constants graph.
+///
+/// The marshal decode path used to be such a caller twice over
+/// (`make_runtime_code`, `make_code`), copying and then dropping the original;
+/// both now pass ownership to [`box_code_object`]. What is left are two
+/// defensive sites — [`crate::eval`]'s `code_constant` and the blackhole's
+/// constant realization — that see a code object only as an element of a
+/// *container* constant. The compiler does not emit that shape: the pinned
+/// compiler crate's `constant_data_to_ast_constant_value` treats
+/// `ConstantData::Code` as `unreachable!`, since a code object is not an
+/// `ast.Constant` value. A top-level code constant reaches
+/// [`box_code_constant_in_place`] instead, so the copy here is not on any
+/// measured path.
+///
+/// Two ways to remove the copy were considered and both cost more than it:
+/// widening [`box_code_constant_in_place`] would put its "never freed, never
+/// moved" contract on a `pub fn` that other crates and tests call with
+/// stack-owned values, and holding constants as `Rc<CodeObject>` would fork
+/// `CodeObject` out of the shared compiler crate — the crate that keeps the
+/// translation and interpreter halves separate.
 #[majit_macros::dont_look_inside]
 pub fn box_code_constant(code: &crate::CodeObject) -> PyObjectRef {
     box_code_object(code.clone())

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -4959,7 +4959,12 @@ pub fn pyobject_from_constant(constant: &crate::bytecode::ConstantData) -> PyObj
         ConstantData::Bytes { value } => pyre_object::bytesobject::w_bytes_from_bytes(value),
         // Reached only for a code constant nested inside a container constant;
         // top-level `LOAD_CONST` routes through `co_consts_w` in `bh_load_const_fn`
-        // so the blackhole shares the interpreter's wrapper.
+        // so the blackhole shares the interpreter's wrapper.  The exceptions are
+        // this function's own fallbacks and `load_const_from_code`, which never
+        // consults `co_consts_w`, so a top-level code constant can arrive here
+        // too.  Either way the compiler does not emit a code object inside a
+        // container, so the copy is defensive; `box_code_constant` records why
+        // it is kept rather than removed.
         ConstantData::Code { code } => crate::pycode::box_code_constant(code),
         // `eval.rs` `none_constant`.
         ConstantData::None => pyre_object::w_none(),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -1458,8 +1458,27 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
         // would replay them.  Capture the frames while this `WalkContext` still
         // owns their banks — `drive_bridge_carrier_walk`'s abort tail adopts
         // the image, and a decline there leaves the pre-existing rollback.
+        let audit = bridge_latch_audit_enabled();
         if let Err(ref error) = outcome {
-            let _ = latch_abort_blackhole(&sub_wc, error.stop_pc(), "bridge1361");
+            // Sampled before the latch: afterwards `abort_blackhole_latched` is
+            // always true.  `already_latched` is the one that matters — it means
+            // this call replaced an inner frame's image with one rooted here.
+            let already_latched = audit.then(abort_blackhole_latched);
+            let accepted = latch_abort_blackhole(&sub_wc, error.stop_pc(), "bridge1361");
+            if let Some(already_latched) = already_latched {
+                eprintln!(
+                    "[bridge-latch] outcome=err already_latched={already_latched} complete_image={} accepted={accepted} stop_pc={} error={error:?}",
+                    error.leaves_complete_image(),
+                    error.stop_pc(),
+                );
+            }
+        } else if audit {
+            // Reported on the Ok leg too, so the absence of an `outcome=err`
+            // line means "this sub-walk never aborted" rather than "the site was
+            // never reached".  A silent counter cannot tell those apart, and
+            // reading one as the other is how a diagnostic ends up proving
+            // nothing.
+            eprintln!("[bridge-latch] outcome=ok");
         }
         outcome
     };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -79,6 +79,26 @@ pub(crate) fn p2_diag_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_P2_DIAG").is_some())
 }
 
+/// `PYRE_BRIDGE_LATCH_AUDIT`: report what the bridge sub-walk's abort latch
+/// would have been refused for at the walk-level latch site.
+///
+/// `drive_bridge_frame_subwalk` latches on any `Err`, where the walk-level site
+/// first requires the abort coordinate, `leaves_complete_image`, a carrier
+/// exclusion and `!abort_blackhole_latched`. Two of those are observable from
+/// the bridge site without inventing state: whether an image is *already*
+/// latched — the innermost abort owns the handoff, so a second latch replaces
+/// it with one rooted at the caller — and whether the error class leaves a
+/// complete image.
+///
+/// Both must be sampled **before** latching. Reading `abort_blackhole_latched`
+/// afterwards always reports `true` and witnesses nothing; the multi-frame arm
+/// this site always takes also prints nothing on accept, which is why the
+/// question has had no answer.
+pub(crate) fn bridge_latch_audit_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_BRIDGE_LATCH_AUDIT").is_some())
+}
+
 pub(crate) fn pcmap_recipe_resultcolor_audit_probe(site: &'static str, verdict: &'static str) {
     if let Some(path) = std::env::var_os("PYRE_PCMAP_RECIPE_RESULTCOLOR_AUDIT_PROBE") {
         use std::io::Write;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -8786,6 +8786,38 @@ fn walker_guard_mapdict_instance_shape<Sym: WalkSym>(
     Ok(())
 }
 
+/// True when the payload `ob_type` already determines the Python-visible
+/// class, so pinning `w_class` against `w_type` is a tautology.
+///
+/// pyre carries the Python-visible class in `w_class` beside the payload
+/// `ob_type` that `GuardClass` reads, which is the whole reason a second pin
+/// exists: a builtin subclass shares the layout and retags `w_class`.  Three
+/// properties together remove that freedom.  `w_type` is the canonical class
+/// of the payload; it refuses to be a base class, so no subclass can share the
+/// layout; and it is not a heap type, so `__class__` assignment cannot retag an
+/// instance onto or off it — `objectobject.py descr_set___class__` requires
+/// both ends to be mutable heap types.  `frame`, `code` and `traceback` are all
+/// three, which is what makes the pin removable on a traceback walk.
+///
+/// This is the argument [`walker_numeric_builtin_class`] already makes for
+/// `bool`, stated for a receiver whose class is not known at codegen time.
+///
+/// # Safety
+/// `ob_type` must be null or a live `PyType`, and `w_type` a live type object.
+unsafe fn walker_payload_determines_w_class(
+    ob_type: *const pyre_object::PyType,
+    w_type: pyre_object::PyObjectRef,
+) -> bool {
+    if ob_type.is_null() {
+        return false;
+    }
+    unsafe {
+        !pyre_object::typeobject::w_type_get_acceptable_as_base_class(w_type)
+            && !pyre_object::typeobject::w_type_is_cpython_heaptype(w_type)
+            && std::ptr::eq(pyre_object::pyobject::get_instantiate(&*ob_type), w_type)
+    }
+}
+
 /// Pin every branch input preceding a raw typed exception-slot arm.
 /// `GuardClass` fixes the kind-specific `W_BaseException` layout and kind tag;
 /// `GuardValue(getfield(w_class))` distinguishes heap subclasses sharing that
@@ -8801,7 +8833,8 @@ fn walker_guard_exception_attr_slot<Sym: WalkSym>(
     w_type: pyre_object::PyObjectRef,
     version_tag: u64,
 ) -> Result<(), DispatchError> {
-    let physical_type = unsafe { (*concrete_obj).ob_type } as i64;
+    let ob_type = unsafe { (*concrete_obj).ob_type };
+    let physical_type = ob_type as i64;
     if !ctx.trace_ctx.heap_cache().is_class_known(obj) {
         let type_const = ctx.trace_ctx.const_int(physical_type);
         walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardClass, &[obj, type_const])?;
@@ -8809,18 +8842,25 @@ fn walker_guard_exception_attr_slot<Sym: WalkSym>(
             .heap_cache_mut()
             .class_now_known(obj, physical_type);
     }
-    let live_w_class =
-        crate::state::opimpl_getfield_gc_r(ctx.trace_ctx, obj, crate::descr::w_class_descr());
-    let w_class_const = ctx.trace_ctx.const_ref(w_type as i64);
-    walker_emit_fold_guard_with_snapshot(
-        ctx,
-        op_pc,
-        OpCode::GuardValue,
-        &[live_w_class, w_class_const],
-    )?;
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .replace_box(live_w_class, w_class_const);
+    // The `GuardClass` above pins the payload, and for a receiver whose payload
+    // determines its class there is nothing left for the `w_class` pin to
+    // exclude.  It is not free: the pin does not dedupe the way `GuardClass`
+    // does through `is_class_known`, so a traceback walk pays a load and a
+    // guard on every hop of every node.
+    if !unsafe { walker_payload_determines_w_class(ob_type, w_type) } {
+        let live_w_class =
+            crate::state::opimpl_getfield_gc_r(ctx.trace_ctx, obj, crate::descr::w_class_descr());
+        let w_class_const = ctx.trace_ctx.const_ref(w_type as i64);
+        walker_emit_fold_guard_with_snapshot(
+            ctx,
+            op_pc,
+            OpCode::GuardValue,
+            &[live_w_class, w_class_const],
+        )?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(live_w_class, w_class_const);
+    }
 
     let type_const = ctx.trace_ctx.const_ref(w_type as i64);
     walker_pin_type_version_tag(ctx, op_pc, type_const)?;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -13251,3 +13251,38 @@ fn the_decline_census_counts_a_record_from_another_thread() {
         "a decline recorded off-thread never reached the census"
     );
 }
+
+/// The three receivers a traceback walk hops through — `traceback`, `frame`,
+/// `code` — refuse to be base classes and are not heap types, so `GuardClass`
+/// on the payload already establishes the Python-visible class and
+/// `walker_guard_exception_attr_slot` owes no second pin.  A subclassable
+/// builtin is the control: `list` keeps the pin because a `list` subclass
+/// shares the payload and retags `w_class`.
+#[test]
+fn the_traceback_walk_receivers_pin_their_class_through_the_payload() {
+    pyre_interpreter::typedef::init_typeobjects();
+
+    for pytype in [
+        &pyre_interpreter::pytraceback::PYTRACEBACK_TYPE as *const pyre_object::PyType,
+        &pyre_interpreter::pyframe::FRAME_TYPE as *const pyre_object::PyType,
+        &pyre_interpreter::pycode::CODE_TYPE as *const pyre_object::PyType,
+    ] {
+        let w_type = pyre_interpreter::typedef::gettypeobject(unsafe { &*pytype });
+        assert!(
+            unsafe { walker_payload_determines_w_class(pytype, w_type) },
+            "{} carries no subclass and no heap retagging, so the payload determines its class",
+            unsafe { pyre_object::w_type_get_name(w_type) },
+        );
+    }
+
+    let list_type = &pyre_object::LIST_TYPE as *const pyre_object::PyType;
+    assert!(
+        !unsafe {
+            walker_payload_determines_w_class(
+                list_type,
+                pyre_object::pyobject::get_instantiate(&*list_type),
+            )
+        },
+        "list is acceptable as a base class, so its payload does not determine w_class",
+    );
+}

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -830,8 +830,22 @@ pub(crate) extern "C" fn record_caught_blackhole_traceback(
     unsafe {
         let walk_owns_resume =
             pyre_jit_trace::trace::active_walk_live_frame() == frame_ptr as usize;
-        if (*frame_ptr).last_instr < 0 && !walk_owns_resume {
+        let live = (*frame_ptr).last_instr;
+        if live < 0 && !walk_owns_resume {
             (*frame_ptr).last_instr = last_instruction as isize;
+        } else if m73_lastinstr_audit_enabled() && live != last_instruction as isize {
+            // The frame keeps a coordinate the node about to be minted does not
+            // carry, which is precisely the shape a later `tb.tb_frame.f_lasti`
+            // disagrees with `tb.tb_lasti` in.  Both values are doubled the way
+            // the two getters report them, and `walk` names which of the two
+            // conditions above declined the stamp.  This is the only record site
+            // that can diverge: every other one passes the frame's own
+            // `last_instr` or builds the frame it records.
+            eprintln!(
+                "[M73-LASTINSTR] mint-diverge frame={frame_ptr:p} f_lasti={} tb_lasti={} walk={walk_owns_resume}",
+                live * 2,
+                (last_instruction as isize) * 2,
+            );
         }
     }
     unsafe {


### PR DESCRIPTION
Two commits on top of `9cd072d663d`.

## 1. Skip the `w_class` pin when the payload type already determines the class

`walker_guard_exception_attr_slot` emitted `getfield_gc_r(w_class)` plus a `guard_value` on **every** call with no elision, unlike the `guard_class` above it which `heap_cache().is_class_known` already suppresses on a repeat. The pin exists because pyre keeps the Python-visible class in `w_class` beside the payload `ob_type` that `guard_class` reads, so a builtin subclass shares the layout and retags `w_class`.

`walker_payload_determines_w_class` reports the receivers with no such freedom: the type is the canonical class of the payload, refuses to be a base class, and is not a heap type — so `__class__` assignment, which requires both ends to be mutable heap types, cannot retag an instance either. `frame`, `code` and `traceback` are all three, which is what makes the pin removable on a traceback walk. The five exception-attribute callers keep it: a user exception class is a heap type.

`walker_numeric_builtin_class` already makes this argument for `bool`.

**Measured**, `MAJIT_LOG_OPT` across all four trace labels on `exception_bridge_traceback_head` against a variant that hoists the attribute chain out of the loop:

| | before | after |
|---|---|---|
| `GetfieldGcR w_class` on the delta | 12 | 3 |
| `GuardValue` on the delta | 12 | 3 |

−9 each (75%), net −15 ops on the delta, outputs identical. Two things worth stating plainly rather than leaving to be discovered:

- **It does not collapse to zero, and should not.** The residual 3 are receivers the predicate correctly declines.
- **The elision is not free.** `GuardClass` +3 and `GuardNonnull` +3 — removing the pin exposes guards the pin had been standing in front of.

Independently confirmed to fire on `gc_bug_bridge_flavor_traceback_names`, whose whole purpose is reading `tb_frame.f_code.co_name` off every traceback node: in the optimized loop body all three receivers (`PyTraceback`, `PyFrame`, `pycode`) now carry `GuardClass` with no `w_class` load or `GuardValue` behind it. Across a whole fixture run the `w_class` pin count drops 36 → 22.

## 2. Report a caught-blackhole frame whose `last_instr` the traceback does not carry

An `eprintln!` behind `PYRE_M73_LASTINSTR_AUDIT=1`, in the one record site that can diverge — every other site either passes the frame's own `last_instr` or builds the frame it records. Default-off, so it cannot move a counter.

This is diagnostic scaffolding, and it has already earned its keep: it settled the question of whether the caught-blackhole mint site is the *producer* of `tb.tb_frame.f_lasti != tb.tb_lasti` divergences. Over 5,814 reports, **5,810 are `walk=false` with a constant `f_lasti − tb_lasti = +6`**, and because those all have `live >= 0` none of them takes the stamp branch — so the mint site is a **witness, not the producer**. The 4 `walk=true` reports confirm the earlier `active_walk_live_frame` fix is load-bearing. Keeping the probe because the same class of question will be asked again.

## 3. Record why the two remaining `box_code_constant` callers keep the copy

Comments only. `box_code_constant` copies a whole recursive duplicate of the constants graph, and its doc already told an owning caller to hand the `CodeObject` over instead — but not what was left after the two marshal-decode callers were moved to `box_code_object`. The two survivors (`eval.rs`'s `code_constant`, and the blackhole's constant realization) exist for one shape: a code object as an **element of a container constant**. The pinned compiler crate's `constant_data_to_ast_constant_value` treats `ConstantData::Code` as `unreachable!`, and a top-level code constant takes `box_code_constant_in_place`, so the copy is defensive rather than paid.

Both ways to remove it cost more than it does, and that is now written down too: widening `box_code_constant_in_place` puts its never-freed/never-moved contract onto a `pub fn` that other crates and tests call with stack-owned values, and holding constants as `Rc<CodeObject>` forks `CodeObject` out of the shared compiler crate — the crate that keeps the translation and interpreter halves separate.

The commit also **narrows** what the two existing site comments claimed, rather than just endorsing them: `load_const_value` is entered either from the trait default `constant_at` (which `PyFrame`, its only implementor, overrides) or from `opcode_load_const` via `OpcodeStepExecutor::load_const`, which no caller in the tree invokes today — though `opcode_load_const` *is* a registered JIT call target, so this is written as "narrow", not "unreachable". And the blackhole site can in fact see a *top-level* code constant, through its own fallbacks and through `load_const_from_code`, which never consults `co_consts_w`.

## 4. Audit the bridge sub-walk's abort latch against the gates the walk-level site applies

`drive_bridge_frame_subwalk` latches the abort blackhole on **any** `Err` from its sub-walk:

```rust
if let Err(ref error) = outcome {
    let _ = latch_abort_blackhole(&sub_wc, error.stop_pc(), "bridge1361");
}
```

The walk-level site requires four things first — abort-coordinate ownership, `error.leaves_complete_image()`, a `carrier_owned` exclusion, and `!abort_blackhole_latched()`. The bridge site applies none of them, and the only test it inherits (`latch_abort_blackhole`'s `is_authoritative_executor` early-out) cannot decline there, because `sub_wc` sets that flag. `inline_subwalk` is set too, so the latch always takes the multi-frame arm — which overwrites its slot unconditionally, with no first-writer-wins, and which (unlike the single-frame arm's `[latch-accept]`) prints **nothing** on accept. That silence is why the question had no answer.

The gate that matters is the fourth, and its own doc states the failure in prose: the innermost abort owns the handoff, and an enclosing re-latch *"would otherwise re-latch and overwrite that image with one rooted at the caller — resuming the blackhole above the frame whose opcode was left half-executed."*

`PYRE_BRIDGE_LATCH_AUDIT` reports the two gates observable from that site, sampling `abort_blackhole_latched` **before** the call because it reads `true` afterwards.

**The `Ok` leg reports too, and that is the point.** The first version printed only on `Err`, returned nothing on six bridge-heavy fixtures, and could not distinguish "this sub-walk never aborted" from "the site was never reached" — the same shape as a counter fed downstream of what it is supposed to witness.

**Result over all 446 synthetic fixtures** (`-P`, 45 s cap, 0 timeouts, 0 nonzero exits):

| | |
|---|---|
| fixtures reaching the site | 35 |
| total `outcome=ok` | **496** |
| total `outcome=err` | **0** |

Top reachers: `foriter_call_resume_drops_iteration` 113, `recursion_memo_branch` 82, `ca_bridge_multiframe_resume_double_call` 76, `generator_tree_recursion` 64. `nested_callee_chain_mutation_abort` — named for aborting — reaches it 5 times and never aborts either.

So the site is hot and the ungated arm is never taken. **No latch behaviour is changed here**: no committed fixture can be shown to fail before a fix, and gate 4 decides which frame owns a blackhole handoff, so this ships as a probe and the fix waits for a witness.

## Verification

- `cargo fmt --all --check` — clean.
- `cargo test --all --features dynasm` — **8157 passed, 0 failed** across 168 suites.
- `pyre/check.py --no-build`: **dynasm 1 failed / 455 passed**, **cranelift 13 failed / 443 passed**. Every one is a jit-stats SNAPDIFF; there are no correctness failures and no ratio failures.
- Commits 3 and 4 touch `pyre-interpreter`, which stales the LLBC, so the artefacts were **re-extracted and both native backends rebuilt** before re-running. `pyre-interpreter.ullbc` came back at 781,563,565 bytes against a 781,556,526-byte floor (guarding the silent short-extract), all four fingerprints match the tree, and the binary's checksum changed — so this is not the old binary being re-measured. `check.py` then reported the **same single dynasm red with the same numbers**, i.e. the re-extract moved nothing.

**All of those reds are inherited, and that is measured, not asserted.** A sibling worktree holds a release binary built without either of these commits. Its `w_class` pin count on the traceback fixture is 36 against this branch's 22, which proves the two binaries genuinely differ *on the change under suspicion* — and with that established, both produce byte-identical counters:

| fixture | backend | this branch | binary without these commits |
|---|---|---|---|
| `gc_bug_bridge_flavor_traceback_names` | dynasm | 3 / 6 / 1054 | 3 / 6 / 1054 |
| `gc_bug_bridge_flavor_traceback_names` | cranelift | 4 / 8 / 1670 | 4 / 8 / 1670 |
| `abc_instancecheck_weak_cache` | cranelift | 1 / 1 / 202 | 1 / 1 / 202 |
| `arith_int_bool` | cranelift | 7 / 11 / 2307 | 7 / 11 / 2307 |
| `inheritance_dispatch` | cranelift | 1 / 4 / 801 | 1 / 4 / 801 |
| `str_fstring` | cranelift | 646 → 657 | 646 → 657 |

(loops / bridges / guard_failures.)

These fixtures are the documented local-host divergence: this developer box disagrees with all three CI runners on a set of bridge/guard-shaped fixtures, deterministically, while the runners agree with the committed baselines. `str_fstring` at 657 is one of the eight originally measured. **Nothing here is re-recorded** — a previous attempt to `--snapshot` this class to green turned 1 failure into 31 across macOS, Ubuntu and Windows and had to be reverted. Banding is not available either: the band instrument is only valid when the compile counters hold still, and here `bridges_compiled` and `loops_compiled` both move.

Also of note: the same suite reported **20 such reds at the previous base and 1 now** — the base moved 19 of them back onto their baselines on its own. CI is the authority on these; local reds on this box are not evidence against the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBNBmnBveAQFbqRtrvQVyQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced redundant runtime checks in traceback and exception handling paths, improving execution efficiency without changing behavior.

* **Reliability**
  * Improved preservation and auditing of traceback instruction positions during exceptional execution.
  * Added optional diagnostics for bridge recovery decisions and blackhole-latch state.

* **Documentation**
  * Clarified defensive handling of code constants and fallback execution paths for maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->