### PR TITLE
Windows: winreg clinic surface, stat_result members, the spawn pair and win32_wchdir

### DIFF
--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -17444,9 +17444,14 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
             && !pyre_object::bytesobject::is_bytes(file_now)
             && !pyre_object::is_int(file_now)
     } {
-        let Some(fspath_fn) = crate::typedef::r#type(file_now).and_then(|pt| unsafe {
+        let fspath_fn = crate::typedef::r#type(file_now).and_then(|pt| unsafe {
             crate::baseobjspace::lookup_in_type(pt.as_ptr(), "__fspath__")
-        }) else {
+        });
+        // A `None` left on the type switches the protocol off the way
+        // `__hash__ = None` does, so the object is turned away as not
+        // path-like rather than reported as an uncallable `None`.
+        let Some(fspath_fn) = fspath_fn.filter(|&fn_obj| unsafe { !pyre_object::is_none(fn_obj) })
+        else {
             return Err(crate::PyError::type_error(format!(
                 "expected str, bytes or os.PathLike object, not {}",
                 crate::gateway::short_type_name(file_now)

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1209,6 +1209,18 @@ pub fn make_builtin_function_with_doc(
     crate::function_new_with_fixed_code(code as *const (), name.to_string(), pyre_object::PY_NULL)
 }
 
+/// `make_builtin_function_with_doc` for a caller that only sometimes has a
+/// docstring to attach -- `None` leaves the code object without one, the way
+/// `interp2app` does for a function whose `__doc__` is empty.
+pub fn make_builtin_function_with_opt_doc(
+    name: &'static str,
+    func: BuiltinCodeFn,
+    docstring: Option<&'static str>,
+) -> PyObjectRef {
+    let code = builtin_code_new_with_doc(name, func, docstring);
+    crate::function_new_with_fixed_code(code as *const (), name.to_string(), pyre_object::PY_NULL)
+}
+
 /// GatewayCache.build parity for an interp2app carrying the text signature
 /// produced by `interp2app._generate_text_signature`.
 pub fn make_builtin_function_with_text_signature(

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1645,16 +1645,53 @@ pub fn fs_arg_bytes(data: Vec<u8>) -> Result<Vec<u8>, crate::PyError> {
 /// Win32 error ends the encode, and there is no caller here to report one to,
 /// so the interpreter's own spelling stands in for it.
 pub fn fs_result_bytes(data: &[u8]) -> Vec<u8> {
+    fsencode_wtf8_total(&crate::typedef::fsdecode_wtf8_total(data))
+}
+
+/// [`fs_result_bytes`] for a caller holding the name as text rather than as
+/// the bytes it decoded from — a path the interpreter folded or split before
+/// handing it back, where re-deriving the bytes would mean encoding the text
+/// itself.
+///
+/// Total for the same reason: every caller reached this text through the
+/// filesystem decode, so each escape in it folds back to the byte it stood
+/// for and no code point is left that the codec cannot spell.
+pub fn fsencode_wtf8_total(text: &rustpython_wtf8::Wtf8) -> Vec<u8> {
     #[cfg(windows)]
     if crate::typedef::legacy_windows_fs_encoding()
         && let Ok(bytes) = crate::unicodehelper_win32::encode_code_page_replace(
             windows_sys::Win32::Globalization::CP_ACP,
-            &crate::typedef::fsdecode_wtf8_total(data),
+            text,
         )
     {
         return bytes;
     }
-    data.to_vec()
+    if crate::typedef::FS_ERRORS == "surrogatepass" {
+        // The text's own WTF-8 spelling is the encoding: a surrogate keeps its
+        // three bytes rather than folding to the one byte an escape names.
+        return text.as_bytes().to_vec();
+    }
+    let mut out = Vec::with_capacity(text.len());
+    for cp in text.code_points() {
+        if let Some(ch) = cp.to_char() {
+            let mut buf = [0; 4];
+            out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+            continue;
+        }
+        let code = cp.to_u32();
+        if (0xDC80..=0xDCFF).contains(&code) {
+            out.push((code - 0xDC00) as u8);
+        } else {
+            // A surrogate outside the escape range has no byte under
+            // `surrogateescape`, and no caller can reach one: the text came
+            // from the decode, which produces no others. Carry its own
+            // spelling rather than inventing a failure with nobody to report
+            // it to.
+            let mut buf = [0; 4];
+            out.extend_from_slice(cp.encode_wtf8(&mut buf).as_bytes());
+        }
+    }
+    out
 }
 
 /// [`fsencode_os_str`]'s other direction: the host name filesystem bytes
@@ -1710,7 +1747,7 @@ impl FsEncodedPath {
 /// a boundary spelling its path some other way than `path_converter` — Windows'
 /// `os.system`, whose argument is text rather than a path — falls back to.
 pub fn fsencode_path_w(obj: pyre_object::PyObjectRef) -> Result<FsEncodedPath, crate::PyError> {
-    path_or_fd_w(obj, None, false, false)
+    path_or_fd_w(obj, None, false, false, false)
 }
 
 /// [`fsencode_path_w`] for a path-only boundary that names itself. The argument
@@ -1722,7 +1759,20 @@ pub fn fsencode_path_named_w(
     funcname: &str,
     argname: &str,
 ) -> Result<FsEncodedPath, crate::PyError> {
-    path_or_fd_w(obj, Some((funcname, argname)), false, false)
+    path_or_fd_w(obj, Some((funcname, argname)), false, false, false)
+}
+
+/// [`fsencode_path_named_w`] for a boundary declaring `path_t(nonstrict=True)`
+/// — `_path_normpath` and `_path_splitroot_ex`, which fold and split the name
+/// as text and hand it to nobody. A null is a character like any other there,
+/// so the rejection every other boundary takes is lifted and the name comes
+/// back carrying it.
+pub fn fsencode_path_nonstrict_w(
+    obj: pyre_object::PyObjectRef,
+    funcname: &str,
+    argname: &str,
+) -> Result<FsEncodedPath, crate::PyError> {
+    path_or_fd_w(obj, Some((funcname, argname)), false, false, true)
 }
 
 /// [`fsencode_path_w`] for a boundary that also takes an open file descriptor —
@@ -1735,7 +1785,7 @@ pub fn fsencode_path_or_fd_w(
     funcname: &str,
     allow_fd: bool,
 ) -> Result<FsEncodedPath, crate::PyError> {
-    path_or_fd_w(obj, Some((funcname, "path")), allow_fd, false)
+    path_or_fd_w(obj, Some((funcname, "path")), allow_fd, false, false)
 }
 
 /// [`fsencode_path_or_fd_w`] for a boundary whose path argument also takes
@@ -1748,7 +1798,7 @@ pub fn fsencode_path_or_fd_nullable_w(
     funcname: &str,
     allow_fd: bool,
 ) -> Result<FsEncodedPath, crate::PyError> {
-    path_or_fd_w(obj, Some((funcname, "path")), allow_fd, true)
+    path_or_fd_w(obj, Some((funcname, "path")), allow_fd, true, false)
 }
 
 /// `_PyType_Name` — the type's own name, with any module that qualifies it
@@ -1768,6 +1818,7 @@ fn path_or_fd_w(
     caller: Option<(&str, &str)>,
     allow_fd: bool,
     nullable: bool,
+    nonstrict: bool,
 ) -> Result<FsEncodedPath, crate::PyError> {
     // interp_posix.py:170-180 builds this list from the same two flags. The
     // caller pair is `path_converter`'s `function_name` and `argument_name`;
@@ -1908,8 +1959,18 @@ fn path_or_fd_w(
     };
     // baseobjspace.py `bytesbuf0_w` rejects embedded nulls. A
     // descriptor carries no bytes to check.
-    if as_fd == -1 && data.contains(&0) {
-        return Err(crate::PyError::value_error("embedded null byte"));
+    //
+    // `path_converter` names itself and the argument it was reading, so
+    // `link` reports a null in its first argument as `src` and in its second
+    // as `dst`. A boundary converting on nobody's behalf has neither to give
+    // and reports the character alone, the way `PyUnicode_FSConverter` does
+    // for the builtin `open`.
+    if as_fd == -1 && !nonstrict && data.contains(&0) {
+        let text = match caller {
+            Some((name, arg)) => format!("{name}: embedded null character in {arg}"),
+            None => "embedded null character".to_string(),
+        };
+        return Err(crate::PyError::value_error(text));
     }
     // Where the filesystem encoding is `surrogatepass`, the byte spelling of a
     // path is UTF-8 and a byte that begins no sequence names nothing at all.

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -909,10 +909,10 @@ pub use gateway::{
     make_builtin_function, make_builtin_function_as_builtin_with_signature,
     make_builtin_function_maybe_sig, make_builtin_function_passthrough_args1,
     make_builtin_function_with_arity, make_builtin_function_with_arity_and_maybe_sig,
-    make_builtin_function_with_signature, make_method_descriptor_with_arity,
-    make_module_builtin_function, make_module_builtin_function_with_arity,
-    make_module_builtin_function_with_arity_and_maybe_sig, make_module_builtin_function_with_doc,
-    make_slot_wrapper, make_slot_wrapper_with_arity,
+    make_builtin_function_with_doc, make_builtin_function_with_signature,
+    make_method_descriptor_with_arity, make_module_builtin_function,
+    make_module_builtin_function_with_arity, make_module_builtin_function_with_arity_and_maybe_sig,
+    make_module_builtin_function_with_doc, make_slot_wrapper, make_slot_wrapper_with_arity,
 };
 pub use jit_fnaddr::*;
 pub use majit_rlib::rbigint::RBigInt as PyBigInt;

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -464,6 +464,7 @@ macro_rules! py_class {
         $name:literal
         $(, methods: {
             $(
+                $(#[doc = $mdoc:literal])?
                 fn $mname:ident ( $($margs:tt)* ) $(-> $mret:ty)? $mbody:block
             )*
         })?
@@ -492,7 +493,12 @@ macro_rules! py_class {
                             unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                                 ns,
                                 stringify!($mname),
-                                $crate::make_builtin_function(stringify!($mname), $mname),
+                                $crate::make_builtin_function_with_opt_doc(
+                                    stringify!($mname),
+                                    $mname,
+                                    ::core::option::Option::<&'static str>::None
+                                        $(.or(::core::option::Option::Some($mdoc)))?,
+                                ),
                             ) };
                         }
                     )*)?
@@ -909,10 +915,11 @@ pub use gateway::{
     make_builtin_function, make_builtin_function_as_builtin_with_signature,
     make_builtin_function_maybe_sig, make_builtin_function_passthrough_args1,
     make_builtin_function_with_arity, make_builtin_function_with_arity_and_maybe_sig,
-    make_builtin_function_with_doc, make_builtin_function_with_signature,
-    make_method_descriptor_with_arity, make_module_builtin_function,
-    make_module_builtin_function_with_arity, make_module_builtin_function_with_arity_and_maybe_sig,
-    make_module_builtin_function_with_doc, make_slot_wrapper, make_slot_wrapper_with_arity,
+    make_builtin_function_with_doc, make_builtin_function_with_opt_doc,
+    make_builtin_function_with_signature, make_method_descriptor_with_arity,
+    make_module_builtin_function, make_module_builtin_function_with_arity,
+    make_module_builtin_function_with_arity_and_maybe_sig, make_module_builtin_function_with_doc,
+    make_slot_wrapper, make_slot_wrapper_with_arity,
 };
 pub use jit_fnaddr::*;
 pub use majit_rlib::rbigint::RBigInt as PyBigInt;

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -813,6 +813,285 @@ fn split_root(path: &rustpython_wtf8::Wtf8) -> (&rustpython_wtf8::Wtf8, &rustpyt
     }
 }
 
+/// The separator a path is spelled with, and the second one Windows also
+/// accepts. Which pair applies is the host's, and it travels as a value rather
+/// than a `cfg` so both spellings stay under test wherever the tests run.
+#[derive(Clone, Copy)]
+struct PathSeps {
+    /// `SEP`.
+    sep: u16,
+    /// `ALTSEP`, absent where the host defines none.
+    altsep: Option<u16>,
+    /// Whether the drive, UNC share and device prefixes exist at all, which is
+    /// the `#ifdef MS_WINDOWS` in `_Py_skiproot` and `_Py_normpath_and_size`.
+    drives: bool,
+}
+
+const NT_SEPS: PathSeps = PathSeps {
+    sep: b'\\' as u16,
+    altsep: Some(b'/' as u16),
+    drives: true,
+};
+
+const POSIX_SEPS: PathSeps = PathSeps {
+    sep: b'/' as u16,
+    altsep: None,
+    drives: false,
+};
+
+/// The host's own pair — `ntpath` on Windows, `posixpath` everywhere else.
+const HOST_SEPS: PathSeps = if cfg!(windows) { NT_SEPS } else { POSIX_SEPS };
+
+impl PathSeps {
+    fn is_sep(self, path: &[u16], index: usize) -> bool {
+        match path.get(index) {
+            Some(&c) => c == self.sep || self.altsep == Some(c),
+            None => false,
+        }
+    }
+}
+
+/// `_Py_skiproot` — how much of `path` is the drive prefix, and how much of
+/// what follows is the root separator. Everything past the two is the tail.
+///
+/// The counts are UTF-16 units, the width the wide spelling of a path is
+/// measured in, so the drive test reads the second unit of a surrogate pair
+/// rather than the second character: `"\u{1f600}:\\x"` names no drive.
+fn skiproot(path: &[u16], seps: PathSeps) -> (usize, usize) {
+    let is_sep = |index: usize| seps.is_sep(path, index);
+    let is_end = |index: usize| index >= path.len();
+    let sep_or_end = |index: usize| is_sep(index) || is_end(index);
+    let is_letter = |index: usize, upper: u8| {
+        matches!(path.get(index), Some(&c)
+            if c == u16::from(upper) || c == u16::from(upper.to_ascii_lowercase()))
+    };
+
+    if !seps.drives {
+        if !is_sep(0) {
+            // Relative path, e.g.: 'foo'
+            return (0, 0);
+        }
+        if !is_sep(1) || is_sep(2) {
+            // Absolute path, e.g.: '/foo', '///foo', '////foo', etc.
+            return (0, 1);
+        }
+        // Precisely two leading slashes, e.g.: '//foo'. Implementation defined
+        // per POSIX.
+        return (0, 2);
+    }
+    if is_sep(0) {
+        if !is_sep(1) {
+            // Relative path with root, e.g. \Windows
+            return (0, 1);
+        }
+        // Device drives, e.g. \\.\device or \\?\device
+        // UNC drives, e.g. \\server\share or \\?\UNC\server\share
+        let unc = path.get(2) == Some(&u16::from(b'?'))
+            && is_sep(3)
+            && is_letter(4, b'U')
+            && is_letter(5, b'N')
+            && is_letter(6, b'C')
+            && is_sep(7);
+        let mut idx = if unc { 8 } else { 2 };
+        while !sep_or_end(idx) {
+            idx += 1;
+        }
+        if is_end(idx) {
+            return (idx, 0);
+        }
+        idx += 1;
+        while !sep_or_end(idx) {
+            idx += 1;
+        }
+        return (idx, usize::from(!is_end(idx)));
+    }
+    if !is_end(0) && path.get(1) == Some(&u16::from(b':')) {
+        // Absolute drive-letter path, e.g. X:\Windows, or one relative to the
+        // drive's own cursor, e.g. X:Windows.
+        return (2, usize::from(is_sep(2)));
+    }
+    // Relative path, e.g. Windows
+    (0, 0)
+}
+
+/// `_Py_normpath_and_size` — fold `.`, `..` and repeated separators out of
+/// `buf` in place, and answer how many units the result occupies.
+///
+/// `buf` carries the trailing null the wide spelling of a path does, and is
+/// one unit longer than the path itself: the scan reads one unit past the
+/// segment it is measuring, and the last write is the terminator behind the
+/// folded name. The fold never lengthens a path, so it needs no other room.
+fn normpath_and_size(buf: &mut [u16], seps: PathSeps) -> usize {
+    const DOT: u16 = b'.' as u16;
+    let sep = seps.sep;
+    let size = buf.len() - 1;
+    if size == 0 {
+        return 0;
+    }
+    let is_sep = |buf: &[u16], index: usize| seps.is_sep(buf, index);
+    let is_end = |index: usize| index >= size;
+    let sep_or_end = |buf: &[u16], index: usize| is_sep(buf, index) || is_end(index);
+
+    let mut p1 = 0; // sequentially scanned index in the path
+    let mut p2 = 0; // destination of a scanned unit to be ljusted
+    let mut min_p2 = 0; // the beginning of the destination range
+    let mut last_c = 0; // the last ljusted unit, buf[p2 - 1] in most cases
+
+    let (drvsize, rootsize) = skiproot(&buf[..size], seps);
+    if drvsize != 0 || rootsize != 0 {
+        // Skip past root and update min_p2
+        p1 = drvsize + rootsize;
+        match seps.altsep {
+            Some(altsep) => {
+                while p2 < p1 {
+                    if buf[p2] == altsep {
+                        buf[p2] = sep;
+                    }
+                    p2 += 1;
+                }
+            }
+            None => p2 = p1,
+        }
+        min_p2 = p2 - 1;
+        last_c = buf[min_p2];
+        if seps.drives && last_c != sep {
+            min_p2 += 1;
+        }
+    }
+    if buf[p1] == DOT && sep_or_end(buf, p1 + 1) {
+        // Skip leading '.\'
+        p1 += 1;
+        last_c = buf[p1];
+        if seps.altsep == Some(last_c) {
+            last_c = sep;
+        }
+        while is_sep(buf, p1) {
+            p1 += 1;
+        }
+    }
+
+    while !is_end(p1) {
+        let mut c = buf[p1];
+        if seps.altsep == Some(c) {
+            c = sep;
+        }
+        if last_c == sep {
+            if c == DOT {
+                let sep_at_1 = sep_or_end(buf, p1 + 1);
+                let sep_at_2 = !sep_at_1 && sep_or_end(buf, p1 + 2);
+                if sep_at_2 && buf[p1 + 1] == DOT {
+                    let mut p3 = p2;
+                    while p3 != min_p2 {
+                        p3 -= 1;
+                        if buf[p3] != sep {
+                            break;
+                        }
+                    }
+                    while p3 != min_p2 && buf[p3 - 1] != sep {
+                        p3 -= 1;
+                    }
+                    if p2 == min_p2
+                        || (buf[p3] == DOT && buf[p3 + 1] == DOT && is_sep(buf, p3 + 2))
+                    {
+                        // Previous segment is also ../, so append instead.
+                        // Relative path does not absorb ../ at min_p2 as well.
+                        buf[p2] = DOT;
+                        buf[p2 + 1] = DOT;
+                        p2 += 2;
+                        last_c = DOT;
+                    } else if buf[p3] == sep {
+                        // Absolute path, so absorb segment
+                        p2 = p3 + 1;
+                    } else {
+                        p2 = p3;
+                    }
+                    p1 += 1;
+                } else if !sep_at_1 {
+                    buf[p2] = c;
+                    p2 += 1;
+                    last_c = c;
+                }
+            } else if c != sep {
+                buf[p2] = c;
+                p2 += 1;
+                last_c = c;
+            }
+        } else {
+            buf[p2] = c;
+            p2 += 1;
+            last_c = c;
+        }
+        p1 += 1;
+    }
+
+    buf[p2] = 0;
+    if p2 == min_p2 {
+        // The destination never advanced, so the fold left nothing behind the
+        // root: one unit before the range is where it ends.
+        return p2;
+    }
+    loop {
+        p2 -= 1;
+        if p2 == min_p2 || buf[p2] != sep {
+            return p2 + 1;
+        }
+        buf[p2] = 0;
+    }
+}
+
+/// The wide spelling `_Py_skiproot` and `_Py_normpath_and_size` read, with the
+/// trailing null they scan up to.
+fn wide_with_nul(text: &rustpython_wtf8::Wtf8) -> Vec<u16> {
+    let mut wide: Vec<u16> = text.encode_wide().collect();
+    wide.push(0);
+    wide
+}
+
+/// A `path_t(make_wide=True, nonstrict=True)` argument, read as the wide units
+/// a path is measured in. The flag reports whether it arrived as `bytes`, so
+/// the answer can be spelled back the way the caller spelled the question.
+///
+/// `nonstrict` is what lifts the embedded-null rejection: the two callers fold
+/// and split the name as text and hand it to nobody, so a null is a character
+/// like any other there.
+fn nonstrict_wide_path(
+    obj: PyObjectRef,
+    func: &str,
+) -> Result<(Vec<u16>, bool), crate::PyError> {
+    let resolved = crate::gateway::fsencode_path_nonstrict_w(obj, func, "path")?;
+    let as_bytes = unsafe { resolved.is_bytes() };
+    let text = crate::gateway::fsdecode_filename_wtf8(&resolved.as_bytes);
+    Ok((wide_with_nul(&text), as_bytes))
+}
+
+/// One of the `_path_*` helpers as a function object, carrying both the
+/// docstring `__doc__` reports and the clinic signature line ahead of it that
+/// `__text_signature__` does.
+fn path_helper_fn(
+    name: &'static str,
+    func: crate::gateway::BuiltinCodeFn,
+    text_signature: &'static str,
+    docstring: &'static str,
+) -> PyObjectRef {
+    let function = crate::make_builtin_function_with_doc(name, func, docstring);
+    unsafe {
+        crate::function::fset_func_text_signature(function, pyre_object::w_str_new(text_signature));
+    }
+    function
+}
+
+/// A name answered back in the units the question was asked in:
+/// `PyUnicode_FromWideChar`, and `PyUnicode_EncodeFSDefault` over that where
+/// the argument was `bytes`.
+fn wide_result(units: &[u16], as_bytes: bool) -> PyObjectRef {
+    let text = rustpython_wtf8::Wtf8Buf::from_wide(units);
+    if as_bytes {
+        pyre_object::w_bytes_from_bytes(&crate::gateway::fsencode_wtf8_total(&text))
+    } else {
+        pyre_object::w_str_from_wtf8(text)
+    }
+}
+
 /// Windows-only `nt` calls — PyPy: pypy/module/posix/interp_nt.py and the
 /// `if _WIN32` blocks of interp_posix.py. Registered under the `nt` module
 /// name on Windows (moduledef.py `applevel_name = os.name`); `ntpath` reaches
@@ -849,10 +1128,9 @@ mod win_nt {
     /// Read argument 0 as a filesystem path; the flag reports whether the
     /// input was bytes so the result can be encoded back to match.
     ///
-    /// The conversion is the caller-less one. Every entry point reached through
-    /// here is Windows-only, so what it should name itself and its argument is
-    /// not something this host can measure, and a guessed wording would be
-    /// worse than the one uniform gap. See the follow-up task.
+    /// `path_converter` fills `function_name` and `argument_name` from the
+    /// argument clinic, so a rejected argument and an embedded null both name
+    /// the call that read them.
     fn arg_path(
         args: &[PyObjectRef],
         func: &str,
@@ -862,7 +1140,7 @@ mod win_nt {
                 "{func}() missing required argument 'path'"
             )));
         };
-        let resolved = crate::gateway::fsencode_path_w(arg)?;
+        let resolved = crate::gateway::fsencode_path_named_w(arg, func, "path")?;
         let as_bytes = unsafe { resolved.is_bytes() };
         // Windows names files in UTF-16, so the path reaches the host API as
         // code units rather than bytes. Going through a Rust `String` on the
@@ -936,6 +1214,115 @@ mod win_nt {
             Ok(name) => Ok(pyre_object::w_str_from_wtf8(
                 crate::gateway::fsdecode_os_str_wtf8(&name),
             )),
+            Err(error) => Err(io_err_with_filename(&error, resolved.w_path())),
+        }
+    }
+
+    /// `path_t(suppress_value_error=True)` — the name or the descriptor a file
+    /// test reads, or nothing where the conversion reported a `ValueError` and
+    /// the test's own answer is `False`. Every other failure is still one:
+    /// `path_converter` clears the error only for that one class.
+    fn path_or_fd_suppressing(
+        obj: PyObjectRef,
+        func: &str,
+    ) -> Result<Option<crate::gateway::FsEncodedPath>, crate::PyError> {
+        match crate::gateway::fsencode_path_or_fd_w(obj, func, true) {
+            Ok(path) => Ok(Some(path)),
+            Err(mut error) => match crate::builtins::lookup_exc_class("ValueError") {
+                Some(value_error)
+                    if crate::eval::check_exc_match_against(
+                        error.to_exc_object(),
+                        value_error,
+                    ) =>
+                {
+                    Ok(None)
+                }
+                _ => Err(error),
+            },
+        }
+    }
+
+    /// The wide name a converted path spells. A null would have ended the
+    /// conversion already, so the only argument that gets here without one is
+    /// a name the host can take.
+    fn tested_wide(path: &crate::gateway::FsEncodedPath) -> Option<widestring::WideCString> {
+        let wide: Vec<u16> = crate::gateway::fsdecode_filename_wtf8(&path.as_bytes)
+            .encode_wide()
+            .collect();
+        widestring::WideCString::from_vec(wide).ok()
+    }
+
+    /// `_testFileType` — the descriptor's handle where the argument named one,
+    /// and `_testFileTypeByName` over the name otherwise. A descriptor is
+    /// tested `diskOnly`, so a pipe or a console is no kind of file.
+    pub fn test_file_type(
+        obj: PyObjectRef,
+        func: &str,
+        tested: host_nt::TestType,
+    ) -> Result<PyObjectRef, crate::PyError> {
+        let Some(path) = path_or_fd_suppressing(obj, func)? else {
+            return Ok(pyre_object::w_bool_from(false));
+        };
+        // Both arms open handles and query the volume, which blocks while a
+        // network name answers.
+        let _blocked = crate::module::thread::before_external_block();
+        let result = if path.as_fd != -1 {
+            host_nt::test_file_type_by_handle(host_nt::handle_from_fd(path.as_fd), tested, true)
+        } else {
+            tested_wide(&path).is_some_and(|wide| host_nt::test_file_type_by_name(&wide, tested))
+        };
+        Ok(pyre_object::w_bool_from(result))
+    }
+
+    /// `_testFileExists` — a descriptor exists where its handle has a type,
+    /// and a name where `_testFileExistsByName` reaches it. `follow_links`
+    /// separates `_path_exists`, which a broken link is not, from
+    /// `_path_lexists`, which it is.
+    pub fn test_file_exists(
+        obj: PyObjectRef,
+        func: &str,
+        follow_links: bool,
+    ) -> Result<PyObjectRef, crate::PyError> {
+        let Some(path) = path_or_fd_suppressing(obj, func)? else {
+            return Ok(pyre_object::w_bool_from(false));
+        };
+        let _blocked = crate::module::thread::before_external_block();
+        let result = if path.as_fd != -1 {
+            unsafe { rustpython_host_env::crt_fd::Borrowed::try_borrow_raw(path.as_fd) }
+                .is_ok_and(host_nt::fd_exists)
+        } else {
+            tested_wide(&path)
+                .is_some_and(|wide| host_nt::test_file_exists_by_name(&wide, follow_links))
+        };
+        Ok(pyre_object::w_bool_from(result))
+    }
+
+    /// ntpath.isdevdrive helper — whether the volume the name sits on carries
+    /// `PERSISTENT_VOLUME_STATE_DEV_VOLUME`. A volume that cannot be reached
+    /// is an error rather than a `False`, which is why `ntpath.isdevdrive`
+    /// wraps the call in its own `except OSError`.
+    pub fn _path_isdevdrive(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let (path, _as_bytes, _resolved) = arg_path(args, "_path_isdevdrive")?;
+        let state = {
+            let _blocked = crate::module::thread::before_external_block();
+            host_nt::path_isdevdrive(&path)
+        };
+        // `PyErr_SetFromWindowsErr` — the volume, not the name, is what
+        // failed, so no filename is attached.
+        state
+            .map(pyre_object::w_bool_from)
+            .map_err(|error| io_err(&error, ""))
+    }
+
+    /// ntpath.ismount helper — the mount point the name sits under.
+    pub fn _getvolumepathname(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let (path, as_bytes, resolved) = arg_path(args, "_getvolumepathname")?;
+        let volume = {
+            let _blocked = crate::module::thread::before_external_block();
+            host_nt::getvolumepathname(&path)
+        };
+        match volume {
+            Ok(name) => Ok(wrap_path(&name, as_bytes)),
             Err(error) => Err(io_err_with_filename(&error, resolved.w_path())),
         }
     }
@@ -2515,9 +2902,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 pos.len()
             )));
         }
-        let mut allowed: Vec<&str> = params.to_vec();
-        allowed.extend_from_slice(kwonly);
-        crate::builtins::kwarg_reject_unknown(kwargs, &allowed, name)?;
+        // The names are checked after the count is satisfied:
+        // `_PyArg_UnpackKeywords` fills the slots first and reports a required
+        // one still empty, so `os.stat(other=1)` names `path` as missing
+        // rather than `other` as unexpected.
         let mut bound = Vec::with_capacity(params.len());
         for (index, key) in params.iter().enumerate() {
             let value = crate::builtins::bind_pos_or_kw(pos, kwargs, index, key, name, index + 1)?;
@@ -2529,6 +2917,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             }
             bound.push(value);
         }
+        let mut allowed: Vec<&str> = params.to_vec();
+        allowed.extend_from_slice(kwonly);
+        crate::builtins::kwarg_reject_unknown(kwargs, &allowed, name)?;
         Ok((bound, kwargs))
     }
 
@@ -3574,18 +3965,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "_path_splitroot",
-        crate::make_builtin_function_with_arity(
+        path_helper_fn(
             "_path_splitroot",
             |args| {
-                let Some(&arg) = args.first() else {
-                    return Err(crate::PyError::type_error(
-                        "_path_splitroot() missing required argument 'path'",
-                    ));
-                };
-                // Windows-only, so what it should name itself with is not
-                // measurable from a POSIX host; it keeps the caller-less
-                // conversion meanwhile. See the follow-up task.
-                let path = extract_path(arg)?;
+                let (bound, _) = bind_path_args(args, "_path_splitroot", &["path"], 1, &[])?;
+                let path = crate::gateway::fsencode_path_named_w(
+                    bound[0].expect("path is required"),
+                    "_path_splitroot",
+                    "path",
+                )?
+                .as_bytes;
                 // Splitting a drive or UNC prefix is a text operation on a
                 // Windows path, and both halves are handed back as `str`, so
                 // this one stays in the text domain rather than the byte one.
@@ -3596,9 +3985,203 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     pyre_object::w_str_from_wtf8(tail.to_wtf8_buf()),
                 ]))
             },
-            1,
+            "($module, /, path)",
+            "Removes everything after the root on Win32.",
         ),
     );
+
+    // ── posix._path_splitroot_ex(p) → (drive, root, tail) ──
+    // `_Py_skiproot` measures the two prefixes and the three pieces are slices
+    // of the one name. This is `ntpath.splitroot` and `posixpath.splitroot`
+    // themselves: both import it and fall back to their own Python split only
+    // where a build does not carry it.
+    crate::module_ns_store(
+        ns,
+        "_path_splitroot_ex",
+        path_helper_fn(
+            "_path_splitroot_ex",
+            |args| {
+                let (bound, _) = bind_path_args(args, "_path_splitroot_ex", &["p"], 1, &[])?;
+                let (wide, as_bytes) =
+                    nonstrict_wide_path(bound[0].expect("p is required"), "_path_splitroot_ex")?;
+                let units = &wide[..wide.len() - 1];
+                let (drvsize, rootsize) = skiproot(units, HOST_SEPS);
+                Ok(pyre_object::w_tuple_new(vec![
+                    wide_result(&units[..drvsize], as_bytes),
+                    wide_result(&units[drvsize..drvsize + rootsize], as_bytes),
+                    wide_result(&units[drvsize + rootsize..], as_bytes),
+                ]))
+            },
+            "($module, /, p)",
+            "Split a pathname into drive, root and tail.\n\nThe tail contains \
+             anything after the root.",
+        ),
+    );
+
+    // ── posix._path_normpath(path) → path ──
+    // `ntpath.normpath` and `posixpath.normpath` themselves, on the same
+    // import-or-fall-back terms as `_path_splitroot_ex` above.
+    crate::module_ns_store(
+        ns,
+        "_path_normpath",
+        path_helper_fn(
+            "_path_normpath",
+            |args| {
+                let (bound, _) = bind_path_args(args, "_path_normpath", &["path"], 1, &[])?;
+                let (mut wide, as_bytes) =
+                    nonstrict_wide_path(bound[0].expect("path is required"), "_path_normpath")?;
+                let norm_len = normpath_and_size(&mut wide, HOST_SEPS);
+                // A name that folds away to nothing names the current
+                // directory, which `PyUnicode_FromOrdinal('.')` spells.
+                if norm_len == 0 {
+                    return Ok(wide_result(&[u16::from(b'.')], as_bytes));
+                }
+                Ok(wide_result(&wide[..norm_len], as_bytes))
+            },
+            "($module, /, path)",
+            "Normalize path, eliminating double slashes, etc.",
+        ),
+    );
+
+    // ── nt._path_isdir / _path_isfile / _path_islink / _path_isjunction /
+    //    _path_exists / _path_lexists ──
+    // `path_t(allow_fd=True, suppress_value_error=True)`: a descriptor is
+    // tested through its handle, and a name the conversion cannot spell is not
+    // an error but a `False` — `_testFileType` and `_testFileExists` both open
+    // with `if (path->value_error) return FALSE`. `ntpath` imports the six in
+    // one `try`, in place of the `genericpath` predicates that would stat.
+    #[cfg(all(windows, feature = "host_env"))]
+    {
+        crate::module_ns_store(
+            ns,
+            "_path_isdir",
+            path_helper_fn(
+                "_path_isdir",
+                |args| {
+                    let (bound, _) = bind_path_args(args, "_path_isdir", &["s"], 1, &[])?;
+                    win_nt::test_file_type(
+                        bound[0].expect("s is required"),
+                        "_path_isdir",
+                        rustpython_host_env::nt::TestType::Directory,
+                    )
+                },
+                "($module, /, s)",
+                "Return true if the pathname refers to an existing directory.",
+            ),
+        );
+        crate::module_ns_store(
+            ns,
+            "_path_isfile",
+            path_helper_fn(
+                "_path_isfile",
+                |args| {
+                    let (bound, _) = bind_path_args(args, "_path_isfile", &["path"], 1, &[])?;
+                    win_nt::test_file_type(
+                        bound[0].expect("path is required"),
+                        "_path_isfile",
+                        rustpython_host_env::nt::TestType::RegularFile,
+                    )
+                },
+                "($module, /, path)",
+                "Test whether a path is a regular file",
+            ),
+        );
+        crate::module_ns_store(
+            ns,
+            "_path_islink",
+            path_helper_fn(
+                "_path_islink",
+                |args| {
+                    let (bound, _) = bind_path_args(args, "_path_islink", &["path"], 1, &[])?;
+                    win_nt::test_file_type(
+                        bound[0].expect("path is required"),
+                        "_path_islink",
+                        rustpython_host_env::nt::TestType::Symlink,
+                    )
+                },
+                "($module, /, path)",
+                "Test whether a path is a symbolic link",
+            ),
+        );
+        crate::module_ns_store(
+            ns,
+            "_path_isjunction",
+            path_helper_fn(
+                "_path_isjunction",
+                |args| {
+                    let (bound, _) = bind_path_args(args, "_path_isjunction", &["path"], 1, &[])?;
+                    win_nt::test_file_type(
+                        bound[0].expect("path is required"),
+                        "_path_isjunction",
+                        rustpython_host_env::nt::TestType::Junction,
+                    )
+                },
+                "($module, /, path)",
+                "Test whether a path is a junction",
+            ),
+        );
+        crate::module_ns_store(
+            ns,
+            "_path_exists",
+            path_helper_fn(
+                "_path_exists",
+                |args| {
+                    let (bound, _) = bind_path_args(args, "_path_exists", &["path"], 1, &[])?;
+                    win_nt::test_file_exists(
+                        bound[0].expect("path is required"),
+                        "_path_exists",
+                        true,
+                    )
+                },
+                "($module, /, path)",
+                "Test whether a path exists.  Returns False for broken symbolic links.",
+            ),
+        );
+        crate::module_ns_store(
+            ns,
+            "_getvolumepathname",
+            path_helper_fn(
+                "_getvolumepathname",
+                |args| {
+                    let (bound, _) =
+                        bind_path_args(args, "_getvolumepathname", &["path"], 1, &[])?;
+                    win_nt::_getvolumepathname(&[bound[0].expect("path is required")])
+                },
+                "($module, /, path)",
+                "A helper function for ismount on Win32.",
+            ),
+        );
+        crate::module_ns_store(
+            ns,
+            "_path_isdevdrive",
+            path_helper_fn(
+                "_path_isdevdrive",
+                |args| {
+                    let (bound, _) = bind_path_args(args, "_path_isdevdrive", &["path"], 1, &[])?;
+                    win_nt::_path_isdevdrive(&[bound[0].expect("path is required")])
+                },
+                "($module, /, path)",
+                "Determines whether the specified path is on a Windows Dev Drive.",
+            ),
+        );
+        crate::module_ns_store(
+            ns,
+            "_path_lexists",
+            path_helper_fn(
+                "_path_lexists",
+                |args| {
+                    let (bound, _) = bind_path_args(args, "_path_lexists", &["path"], 1, &[])?;
+                    win_nt::test_file_exists(
+                        bound[0].expect("path is required"),
+                        "_path_lexists",
+                        false,
+                    )
+                },
+                "($module, /, path)",
+                "Test whether a path exists.  Returns True for broken symbolic links.",
+            ),
+        );
+    }
 
     // ── Windows-only nt calls — moduledef.py `if os.name == 'nt'` block ──
     // ntpath imports these from `nt` behind try/except ImportError, so a build
@@ -11594,5 +12177,518 @@ mod split_root_tests {
         assert_eq!(root.as_str(), Ok("C:\\"));
         assert_eq!(tail.code_points().next().map(|c| c.to_u32()), Some(0xdcff));
         assert_eq!(tail.len(), path.len() - root.len());
+    }
+}
+
+#[cfg(test)]
+mod normpath_tests {
+    use super::{NT_SEPS, POSIX_SEPS, PathSeps, normpath_and_size, skiproot, wide_with_nul};
+    use rustpython_wtf8::{CodePoint, Wtf8, Wtf8Buf};
+
+    /// The tables spell the lone surrogate `fsdecode` produces for an
+    /// undecodable name as U+0001, which a Rust string literal can hold and no
+    /// path carries.
+    fn w(text: &str) -> Wtf8Buf {
+        let mut out = Wtf8Buf::new();
+        for ch in text.chars() {
+            match ch {
+                '\u{1}' => out.push(CodePoint::from_u32(0xdfff).unwrap()),
+                _ => out.push_char(ch),
+            }
+        }
+        out
+    }
+
+    fn split_ex(path: &Wtf8, seps: PathSeps) -> (Wtf8Buf, Wtf8Buf, Wtf8Buf) {
+        let wide: Vec<u16> = path.encode_wide().collect();
+        let (drvsize, rootsize) = skiproot(&wide, seps);
+        (
+            Wtf8Buf::from_wide(&wide[..drvsize]),
+            Wtf8Buf::from_wide(&wide[drvsize..drvsize + rootsize]),
+            Wtf8Buf::from_wide(&wide[drvsize + rootsize..]),
+        )
+    }
+
+    fn normpath(path: &Wtf8, seps: PathSeps) -> Wtf8Buf {
+        let mut buf = wide_with_nul(path);
+        let norm_len = normpath_and_size(&mut buf, seps);
+        if norm_len == 0 {
+            return Wtf8Buf::from_string(".".to_string());
+        }
+        Wtf8Buf::from_wide(&buf[..norm_len])
+    }
+
+    fn check_split(cases: &[(&str, &str, &str, &str)], seps: PathSeps) {
+        for &(path, drive, root, tail) in cases {
+            assert_eq!(
+                split_ex(&w(path), seps),
+                (w(drive), w(root), w(tail)),
+                "splitroot({path:?})"
+            );
+        }
+    }
+
+    fn check_normpath(cases: &[(&str, &str)], seps: PathSeps) {
+        for &(path, expected) in cases {
+            assert_eq!(normpath(&w(path), seps), w(expected), "normpath({path:?})");
+        }
+    }
+
+    /// Expectations taken from `ntpath.splitroot`, which is `_path_splitroot_ex`
+    /// itself on a Windows host.
+    #[test]
+    fn skiproot_matches_ntpath_splitroot() {
+        let cases: &[(&str, &str, &str, &str)] = &[
+            ("", "", "", ""),
+            (".", "", "", "."),
+            ("..", "", "", ".."),
+            ("...", "", "", "..."),
+            ("/", "", "/", ""),
+            ("//", "//", "", ""),
+            ("///", "///", "", ""),
+            ("////", "///", "/", ""),
+            ("\\", "", "\\", ""),
+            ("\\\\", "\\\\", "", ""),
+            ("\\\\\\", "\\\\\\", "", ""),
+            ("foo", "", "", "foo"),
+            ("foo/bar", "", "", "foo/bar"),
+            ("foo\\bar", "", "", "foo\\bar"),
+            ("foo//bar", "", "", "foo//bar"),
+            ("foo\\\\bar", "", "", "foo\\\\bar"),
+            ("./foo", "", "", "./foo"),
+            (".\\foo", "", "", ".\\foo"),
+            ("././foo", "", "", "././foo"),
+            ("./", "", "", "./"),
+            (".\\", "", "", ".\\"),
+            ("./.", "", "", "./."),
+            ("foo/.", "", "", "foo/."),
+            ("foo\\.", "", "", "foo\\."),
+            ("foo/..", "", "", "foo/.."),
+            ("foo\\..", "", "", "foo\\.."),
+            ("foo/../bar", "", "", "foo/../bar"),
+            ("foo\\..\\bar", "", "", "foo\\..\\bar"),
+            ("../foo", "", "", "../foo"),
+            ("..\\foo", "", "", "..\\foo"),
+            ("../../foo", "", "", "../../foo"),
+            ("..\\..\\foo", "", "", "..\\..\\foo"),
+            ("/..", "", "/", ".."),
+            ("/../foo", "", "/", "../foo"),
+            ("//../foo", "//../foo", "", ""),
+            ("///../foo", "///..", "/", "foo"),
+            ("\\..\\foo", "", "\\", "..\\foo"),
+            ("/foo/../..", "", "/", "foo/../.."),
+            ("/foo/../../bar", "", "/", "foo/../../bar"),
+            ("foo/../..", "", "", "foo/../.."),
+            ("foo/../../bar", "", "", "foo/../../bar"),
+            ("foo/bar/../..", "", "", "foo/bar/../.."),
+            ("foo/bar/../../..", "", "", "foo/bar/../../.."),
+            ("C:", "C:", "", ""),
+            ("C:.", "C:", "", "."),
+            ("C:..", "C:", "", ".."),
+            ("C:foo", "C:", "", "foo"),
+            ("C:\\", "C:", "\\", ""),
+            ("C:\\.", "C:", "\\", "."),
+            ("C:\\..", "C:", "\\", ".."),
+            ("C:\\foo", "C:", "\\", "foo"),
+            ("C:/foo/../bar", "C:", "/", "foo/../bar"),
+            ("C:\\foo\\..\\..\\bar", "C:", "\\", "foo\\..\\..\\bar"),
+            ("C:foo\\..\\..\\bar", "C:", "", "foo\\..\\..\\bar"),
+            ("c:\\a\\b\\..\\..\\..\\c", "c:", "\\", "a\\b\\..\\..\\..\\c"),
+            ("\\\\server\\share", "\\\\server\\share", "", ""),
+            ("\\\\server\\share\\", "\\\\server\\share", "\\", ""),
+            ("\\\\server\\share\\dir", "\\\\server\\share", "\\", "dir"),
+            ("\\\\server\\share\\..\\dir", "\\\\server\\share", "\\", "..\\dir"),
+            ("\\\\server\\share\\dir\\..\\..", "\\\\server\\share", "\\", "dir\\..\\.."),
+            ("//server/share/dir/../..", "//server/share", "/", "dir/../.."),
+            ("//server/share/../..", "//server/share", "/", "../.."),
+            ("\\\\?\\C:\\foo\\..\\bar", "\\\\?\\C:", "\\", "foo\\..\\bar"),
+            ("\\\\?\\UNC\\server\\share\\dir\\..", "\\\\?\\UNC\\server\\share", "\\", "dir\\.."),
+            ("//?/unc/server/share/dir/..", "//?/unc/server/share", "/", "dir/.."),
+            ("\\\\.\\device\\x\\..", "\\\\.\\device", "\\", "x\\.."),
+            ("\\\\.\\device", "\\\\.\\device", "", ""),
+            ("\\\\", "\\\\", "", ""),
+            ("\\\\a", "\\\\a", "", ""),
+            ("\\\\a\\", "\\\\a\\", "", ""),
+            ("\\\\a\\b", "\\\\a\\b", "", ""),
+            ("\\\\a\\b\\", "\\\\a\\b", "\\", ""),
+            ("\\\\a\\b\\c", "\\\\a\\b", "\\", "c"),
+            (":a", "", "", ":a"),
+            ("a:b:c", "a:", "", "b:c"),
+            ("\u{e4}:\\x", "\u{e4}:", "\\", "x"),
+            ("\u{e4}:\\x\\..", "\u{e4}:", "\\", "x\\.."),
+            ("fo\u{0}o", "", "", "fo\u{0}o"),
+            ("fo\u{0}o\\..\\bar", "", "", "fo\u{0}o\\..\\bar"),
+            ("fo\u{0}o/../bar", "", "", "fo\u{0}o/../bar"),
+            ("\u{1}", "", "", "\u{1}"),
+            ("\u{1}\\..\\foo", "", "", "\u{1}\\..\\foo"),
+            ("\u{1}/../foo", "", "", "\u{1}/../foo"),
+            ("\u{1f600}:\\x", "", "", "\u{1f600}:\\x"),
+            ("\u{1f600}/../foo", "", "", "\u{1f600}/../foo"),
+            ("foo/./bar", "", "", "foo/./bar"),
+            ("foo/././bar", "", "", "foo/././bar"),
+            ("foo/.bar", "", "", "foo/.bar"),
+            ("foo/..bar", "", "", "foo/..bar"),
+            ("foo/...", "", "", "foo/..."),
+            ("foo/.../bar", "", "", "foo/.../bar"),
+            ("/./", "", "/", "./"),
+            ("/.", "", "/", "."),
+            ("//.", "//.", "", ""),
+            ("/././.", "", "/", "././."),
+            ("a/b/c/../../../../d", "", "", "a/b/c/../../../../d"),
+            ("\\a\\b\\..\\..\\..\\c", "", "\\", "a\\b\\..\\..\\..\\c"),
+            ("C:\\\\\\foo", "C:", "\\", "\\\\foo"),
+            ("C:////foo", "C:", "/", "///foo"),
+            ("//foo", "//foo", "", ""),
+            ("///foo", "///foo", "", ""),
+            ("//foo/bar", "//foo/bar", "", ""),
+            ("foo/bar/", "", "", "foo/bar/"),
+            ("foo/bar//", "", "", "foo/bar//"),
+            ("foo\\bar\\\\", "", "", "foo\\bar\\\\"),
+            ("C:\\foo\\", "C:", "\\", "foo\\"),
+        ];
+        check_split(cases, NT_SEPS);
+    }
+
+    /// Expectations taken from `posixpath.splitroot`.
+    #[test]
+    fn skiproot_matches_posixpath_splitroot() {
+        let cases: &[(&str, &str, &str, &str)] = &[
+            ("", "", "", ""),
+            (".", "", "", "."),
+            ("..", "", "", ".."),
+            ("...", "", "", "..."),
+            ("/", "", "/", ""),
+            ("//", "", "//", ""),
+            ("///", "", "/", "//"),
+            ("////", "", "/", "///"),
+            ("\\", "", "", "\\"),
+            ("\\\\", "", "", "\\\\"),
+            ("\\\\\\", "", "", "\\\\\\"),
+            ("foo", "", "", "foo"),
+            ("foo/bar", "", "", "foo/bar"),
+            ("foo\\bar", "", "", "foo\\bar"),
+            ("foo//bar", "", "", "foo//bar"),
+            ("foo\\\\bar", "", "", "foo\\\\bar"),
+            ("./foo", "", "", "./foo"),
+            (".\\foo", "", "", ".\\foo"),
+            ("././foo", "", "", "././foo"),
+            ("./", "", "", "./"),
+            (".\\", "", "", ".\\"),
+            ("./.", "", "", "./."),
+            ("foo/.", "", "", "foo/."),
+            ("foo\\.", "", "", "foo\\."),
+            ("foo/..", "", "", "foo/.."),
+            ("foo\\..", "", "", "foo\\.."),
+            ("foo/../bar", "", "", "foo/../bar"),
+            ("foo\\..\\bar", "", "", "foo\\..\\bar"),
+            ("../foo", "", "", "../foo"),
+            ("..\\foo", "", "", "..\\foo"),
+            ("../../foo", "", "", "../../foo"),
+            ("..\\..\\foo", "", "", "..\\..\\foo"),
+            ("/..", "", "/", ".."),
+            ("/../foo", "", "/", "../foo"),
+            ("//../foo", "", "//", "../foo"),
+            ("///../foo", "", "/", "//../foo"),
+            ("\\..\\foo", "", "", "\\..\\foo"),
+            ("/foo/../..", "", "/", "foo/../.."),
+            ("/foo/../../bar", "", "/", "foo/../../bar"),
+            ("foo/../..", "", "", "foo/../.."),
+            ("foo/../../bar", "", "", "foo/../../bar"),
+            ("foo/bar/../..", "", "", "foo/bar/../.."),
+            ("foo/bar/../../..", "", "", "foo/bar/../../.."),
+            ("C:", "", "", "C:"),
+            ("C:.", "", "", "C:."),
+            ("C:..", "", "", "C:.."),
+            ("C:foo", "", "", "C:foo"),
+            ("C:\\", "", "", "C:\\"),
+            ("C:\\.", "", "", "C:\\."),
+            ("C:\\..", "", "", "C:\\.."),
+            ("C:\\foo", "", "", "C:\\foo"),
+            ("C:/foo/../bar", "", "", "C:/foo/../bar"),
+            ("C:\\foo\\..\\..\\bar", "", "", "C:\\foo\\..\\..\\bar"),
+            ("C:foo\\..\\..\\bar", "", "", "C:foo\\..\\..\\bar"),
+            ("c:\\a\\b\\..\\..\\..\\c", "", "", "c:\\a\\b\\..\\..\\..\\c"),
+            ("\\\\server\\share", "", "", "\\\\server\\share"),
+            ("\\\\server\\share\\", "", "", "\\\\server\\share\\"),
+            ("\\\\server\\share\\dir", "", "", "\\\\server\\share\\dir"),
+            ("\\\\server\\share\\..\\dir", "", "", "\\\\server\\share\\..\\dir"),
+            ("\\\\server\\share\\dir\\..\\..", "", "", "\\\\server\\share\\dir\\..\\.."),
+            ("//server/share/dir/../..", "", "//", "server/share/dir/../.."),
+            ("//server/share/../..", "", "//", "server/share/../.."),
+            ("\\\\?\\C:\\foo\\..\\bar", "", "", "\\\\?\\C:\\foo\\..\\bar"),
+            ("\\\\?\\UNC\\server\\share\\dir\\..", "", "", "\\\\?\\UNC\\server\\share\\dir\\.."),
+            ("//?/unc/server/share/dir/..", "", "//", "?/unc/server/share/dir/.."),
+            ("\\\\.\\device\\x\\..", "", "", "\\\\.\\device\\x\\.."),
+            ("\\\\.\\device", "", "", "\\\\.\\device"),
+            ("\\\\", "", "", "\\\\"),
+            ("\\\\a", "", "", "\\\\a"),
+            ("\\\\a\\", "", "", "\\\\a\\"),
+            ("\\\\a\\b", "", "", "\\\\a\\b"),
+            ("\\\\a\\b\\", "", "", "\\\\a\\b\\"),
+            ("\\\\a\\b\\c", "", "", "\\\\a\\b\\c"),
+            (":a", "", "", ":a"),
+            ("a:b:c", "", "", "a:b:c"),
+            ("\u{e4}:\\x", "", "", "\u{e4}:\\x"),
+            ("\u{e4}:\\x\\..", "", "", "\u{e4}:\\x\\.."),
+            ("fo\u{0}o", "", "", "fo\u{0}o"),
+            ("fo\u{0}o\\..\\bar", "", "", "fo\u{0}o\\..\\bar"),
+            ("fo\u{0}o/../bar", "", "", "fo\u{0}o/../bar"),
+            ("\u{1}", "", "", "\u{1}"),
+            ("\u{1}\\..\\foo", "", "", "\u{1}\\..\\foo"),
+            ("\u{1}/../foo", "", "", "\u{1}/../foo"),
+            ("\u{1f600}:\\x", "", "", "\u{1f600}:\\x"),
+            ("\u{1f600}/../foo", "", "", "\u{1f600}/../foo"),
+            ("foo/./bar", "", "", "foo/./bar"),
+            ("foo/././bar", "", "", "foo/././bar"),
+            ("foo/.bar", "", "", "foo/.bar"),
+            ("foo/..bar", "", "", "foo/..bar"),
+            ("foo/...", "", "", "foo/..."),
+            ("foo/.../bar", "", "", "foo/.../bar"),
+            ("/./", "", "/", "./"),
+            ("/.", "", "/", "."),
+            ("//.", "", "//", "."),
+            ("/././.", "", "/", "././."),
+            ("a/b/c/../../../../d", "", "", "a/b/c/../../../../d"),
+            ("\\a\\b\\..\\..\\..\\c", "", "", "\\a\\b\\..\\..\\..\\c"),
+            ("C:\\\\\\foo", "", "", "C:\\\\\\foo"),
+            ("C:////foo", "", "", "C:////foo"),
+            ("//foo", "", "//", "foo"),
+            ("///foo", "", "/", "//foo"),
+            ("//foo/bar", "", "//", "foo/bar"),
+            ("foo/bar/", "", "", "foo/bar/"),
+            ("foo/bar//", "", "", "foo/bar//"),
+            ("foo\\bar\\\\", "", "", "foo\\bar\\\\"),
+            ("C:\\foo\\", "", "", "C:\\foo\\"),
+        ];
+        check_split(cases, POSIX_SEPS);
+    }
+
+    /// Expectations taken from `ntpath.normpath`, which is `_path_normpath`
+    /// itself on a Windows host.
+    #[test]
+    fn normpath_matches_ntpath() {
+        let cases: &[(&str, &str)] = &[
+            ("", "."),
+            (".", "."),
+            ("..", ".."),
+            ("...", "..."),
+            ("/", "\\"),
+            ("//", "\\\\"),
+            ("///", "\\\\\\"),
+            ("////", "\\\\\\\\"),
+            ("\\", "\\"),
+            ("\\\\", "\\\\"),
+            ("\\\\\\", "\\\\\\"),
+            ("foo", "foo"),
+            ("foo/bar", "foo\\bar"),
+            ("foo\\bar", "foo\\bar"),
+            ("foo//bar", "foo\\bar"),
+            ("foo\\\\bar", "foo\\bar"),
+            ("./foo", "foo"),
+            (".\\foo", "foo"),
+            ("././foo", "foo"),
+            ("./", "."),
+            (".\\", "."),
+            ("./.", "."),
+            ("foo/.", "foo"),
+            ("foo\\.", "foo"),
+            ("foo/..", "."),
+            ("foo\\..", "."),
+            ("foo/../bar", "bar"),
+            ("foo\\..\\bar", "bar"),
+            ("../foo", "..\\foo"),
+            ("..\\foo", "..\\foo"),
+            ("../../foo", "..\\..\\foo"),
+            ("..\\..\\foo", "..\\..\\foo"),
+            ("/..", "\\"),
+            ("/../foo", "\\foo"),
+            ("//../foo", "\\\\..\\foo"),
+            ("///../foo", "\\\\\\..\\foo"),
+            ("\\..\\foo", "\\foo"),
+            ("/foo/../..", "\\"),
+            ("/foo/../../bar", "\\bar"),
+            ("foo/../..", ".."),
+            ("foo/../../bar", "..\\bar"),
+            ("foo/bar/../..", "."),
+            ("foo/bar/../../..", ".."),
+            ("C:", "C:"),
+            ("C:.", "C:"),
+            ("C:..", "C:.."),
+            ("C:foo", "C:foo"),
+            ("C:\\", "C:\\"),
+            ("C:\\.", "C:\\"),
+            ("C:\\..", "C:\\"),
+            ("C:\\foo", "C:\\foo"),
+            ("C:/foo/../bar", "C:\\bar"),
+            ("C:\\foo\\..\\..\\bar", "C:\\bar"),
+            ("C:foo\\..\\..\\bar", "C:..\\bar"),
+            ("c:\\a\\b\\..\\..\\..\\c", "c:\\c"),
+            ("\\\\server\\share", "\\\\server\\share"),
+            ("\\\\server\\share\\", "\\\\server\\share\\"),
+            ("\\\\server\\share\\dir", "\\\\server\\share\\dir"),
+            ("\\\\server\\share\\..\\dir", "\\\\server\\share\\dir"),
+            ("\\\\server\\share\\dir\\..\\..", "\\\\server\\share\\"),
+            ("//server/share/dir/../..", "\\\\server\\share\\"),
+            ("//server/share/../..", "\\\\server\\share\\"),
+            ("\\\\?\\C:\\foo\\..\\bar", "\\\\?\\C:\\bar"),
+            ("\\\\?\\UNC\\server\\share\\dir\\..", "\\\\?\\UNC\\server\\share\\"),
+            ("//?/unc/server/share/dir/..", "\\\\?\\unc\\server\\share\\"),
+            ("\\\\.\\device\\x\\..", "\\\\.\\device\\"),
+            ("\\\\.\\device", "\\\\.\\device"),
+            ("\\\\", "\\\\"),
+            ("\\\\a", "\\\\a"),
+            ("\\\\a\\", "\\\\a\\"),
+            ("\\\\a\\b", "\\\\a\\b"),
+            ("\\\\a\\b\\", "\\\\a\\b\\"),
+            ("\\\\a\\b\\c", "\\\\a\\b\\c"),
+            (":a", ":a"),
+            ("a:b:c", "a:b:c"),
+            ("\u{e4}:\\x", "\u{e4}:\\x"),
+            ("\u{e4}:\\x\\..", "\u{e4}:\\"),
+            ("fo\u{0}o", "fo\u{0}o"),
+            ("fo\u{0}o\\..\\bar", "bar"),
+            ("fo\u{0}o/../bar", "bar"),
+            ("\u{1}", "\u{1}"),
+            ("\u{1}\\..\\foo", "foo"),
+            ("\u{1}/../foo", "foo"),
+            ("\u{1f600}:\\x", "\u{1f600}:\\x"),
+            ("\u{1f600}/../foo", "foo"),
+            ("foo/./bar", "foo\\bar"),
+            ("foo/././bar", "foo\\bar"),
+            ("foo/.bar", "foo\\.bar"),
+            ("foo/..bar", "foo\\..bar"),
+            ("foo/...", "foo\\..."),
+            ("foo/.../bar", "foo\\...\\bar"),
+            ("/./", "\\"),
+            ("/.", "\\"),
+            ("//.", "\\\\."),
+            ("/././.", "\\"),
+            ("a/b/c/../../../../d", "..\\d"),
+            ("\\a\\b\\..\\..\\..\\c", "\\c"),
+            ("C:\\\\\\foo", "C:\\foo"),
+            ("C:////foo", "C:\\foo"),
+            ("//foo", "\\\\foo"),
+            ("///foo", "\\\\\\foo"),
+            ("//foo/bar", "\\\\foo\\bar"),
+            ("foo/bar/", "foo\\bar"),
+            ("foo/bar//", "foo\\bar"),
+            ("foo\\bar\\\\", "foo\\bar"),
+            ("C:\\foo\\", "C:\\foo"),
+        ];
+        check_normpath(cases, NT_SEPS);
+    }
+
+    /// Expectations taken from `posixpath.normpath`.
+    #[test]
+    fn normpath_matches_posixpath() {
+        let cases: &[(&str, &str)] = &[
+            ("", "."),
+            (".", "."),
+            ("..", ".."),
+            ("...", "..."),
+            ("/", "/"),
+            ("//", "//"),
+            ("///", "/"),
+            ("////", "/"),
+            ("\\", "\\"),
+            ("\\\\", "\\\\"),
+            ("\\\\\\", "\\\\\\"),
+            ("foo", "foo"),
+            ("foo/bar", "foo/bar"),
+            ("foo\\bar", "foo\\bar"),
+            ("foo//bar", "foo/bar"),
+            ("foo\\\\bar", "foo\\\\bar"),
+            ("./foo", "foo"),
+            (".\\foo", ".\\foo"),
+            ("././foo", "foo"),
+            ("./", "."),
+            (".\\", ".\\"),
+            ("./.", "."),
+            ("foo/.", "foo"),
+            ("foo\\.", "foo\\."),
+            ("foo/..", "."),
+            ("foo\\..", "foo\\.."),
+            ("foo/../bar", "bar"),
+            ("foo\\..\\bar", "foo\\..\\bar"),
+            ("../foo", "../foo"),
+            ("..\\foo", "..\\foo"),
+            ("../../foo", "../../foo"),
+            ("..\\..\\foo", "..\\..\\foo"),
+            ("/..", "/"),
+            ("/../foo", "/foo"),
+            ("//../foo", "//foo"),
+            ("///../foo", "/foo"),
+            ("\\..\\foo", "\\..\\foo"),
+            ("/foo/../..", "/"),
+            ("/foo/../../bar", "/bar"),
+            ("foo/../..", ".."),
+            ("foo/../../bar", "../bar"),
+            ("foo/bar/../..", "."),
+            ("foo/bar/../../..", ".."),
+            ("C:", "C:"),
+            ("C:.", "C:."),
+            ("C:..", "C:.."),
+            ("C:foo", "C:foo"),
+            ("C:\\", "C:\\"),
+            ("C:\\.", "C:\\."),
+            ("C:\\..", "C:\\.."),
+            ("C:\\foo", "C:\\foo"),
+            ("C:/foo/../bar", "C:/bar"),
+            ("C:\\foo\\..\\..\\bar", "C:\\foo\\..\\..\\bar"),
+            ("C:foo\\..\\..\\bar", "C:foo\\..\\..\\bar"),
+            ("c:\\a\\b\\..\\..\\..\\c", "c:\\a\\b\\..\\..\\..\\c"),
+            ("\\\\server\\share", "\\\\server\\share"),
+            ("\\\\server\\share\\", "\\\\server\\share\\"),
+            ("\\\\server\\share\\dir", "\\\\server\\share\\dir"),
+            ("\\\\server\\share\\..\\dir", "\\\\server\\share\\..\\dir"),
+            ("\\\\server\\share\\dir\\..\\..", "\\\\server\\share\\dir\\..\\.."),
+            ("//server/share/dir/../..", "//server"),
+            ("//server/share/../..", "//"),
+            ("\\\\?\\C:\\foo\\..\\bar", "\\\\?\\C:\\foo\\..\\bar"),
+            ("\\\\?\\UNC\\server\\share\\dir\\..", "\\\\?\\UNC\\server\\share\\dir\\.."),
+            ("//?/unc/server/share/dir/..", "//?/unc/server/share"),
+            ("\\\\.\\device\\x\\..", "\\\\.\\device\\x\\.."),
+            ("\\\\.\\device", "\\\\.\\device"),
+            ("\\\\", "\\\\"),
+            ("\\\\a", "\\\\a"),
+            ("\\\\a\\", "\\\\a\\"),
+            ("\\\\a\\b", "\\\\a\\b"),
+            ("\\\\a\\b\\", "\\\\a\\b\\"),
+            ("\\\\a\\b\\c", "\\\\a\\b\\c"),
+            (":a", ":a"),
+            ("a:b:c", "a:b:c"),
+            ("\u{e4}:\\x", "\u{e4}:\\x"),
+            ("\u{e4}:\\x\\..", "\u{e4}:\\x\\.."),
+            ("fo\u{0}o", "fo\u{0}o"),
+            ("fo\u{0}o\\..\\bar", "fo\u{0}o\\..\\bar"),
+            ("fo\u{0}o/../bar", "bar"),
+            ("\u{1}", "\u{1}"),
+            ("\u{1}\\..\\foo", "\u{1}\\..\\foo"),
+            ("\u{1}/../foo", "foo"),
+            ("\u{1f600}:\\x", "\u{1f600}:\\x"),
+            ("\u{1f600}/../foo", "foo"),
+            ("foo/./bar", "foo/bar"),
+            ("foo/././bar", "foo/bar"),
+            ("foo/.bar", "foo/.bar"),
+            ("foo/..bar", "foo/..bar"),
+            ("foo/...", "foo/..."),
+            ("foo/.../bar", "foo/.../bar"),
+            ("/./", "/"),
+            ("/.", "/"),
+            ("//.", "//"),
+            ("/././.", "/"),
+            ("a/b/c/../../../../d", "../d"),
+            ("\\a\\b\\..\\..\\..\\c", "\\a\\b\\..\\..\\..\\c"),
+            ("C:\\\\\\foo", "C:\\\\\\foo"),
+            ("C:////foo", "C:/foo"),
+            ("//foo", "//foo"),
+            ("///foo", "/foo"),
+            ("//foo/bar", "//foo/bar"),
+            ("foo/bar/", "foo/bar"),
+            ("foo/bar//", "foo/bar"),
+            ("foo\\bar\\\\", "foo\\bar\\\\"),
+            ("C:\\foo\\", "C:\\foo\\"),
+        ];
+        check_normpath(cases, POSIX_SEPS);
     }
 }

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -461,6 +461,16 @@ fn stat_result_seq_type() -> PyObjectRef {
                 "st_atime_ns",
                 "st_mtime_ns",
                 "st_ctime_ns",
+                // The Windows members of `stat_result_fields`, which sit
+                // after every time and platform extra there too.
+                #[cfg(windows)]
+                "st_birthtime",
+                #[cfg(windows)]
+                "st_birthtime_ns",
+                #[cfg(windows)]
+                "st_file_attributes",
+                #[cfg(windows)]
+                "st_reparse_tag",
             ],
         ) as usize
     }) as PyObjectRef
@@ -1635,6 +1645,21 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         fn illegal_name(name: &[u8]) -> bool {
             name.is_empty() || name.contains(&b'=')
         }
+        /// `win32_putenv` measures the whole `NAME=VALUE` entry it is about to
+        /// hand the block and turns away one longer than `_MAX_ENV`, which is
+        /// as much as the block can hold. The count is in UTF-16 units, the
+        /// width the entry is written at.
+        #[cfg(windows)]
+        fn entry_fits(name: &[u8], value: &[u8]) -> Result<(), crate::PyError> {
+            const MAX_ENV: usize = 32767;
+            let units = |bytes: &[u8]| String::from_utf8_lossy(bytes).encode_utf16().count();
+            if units(name) + 1 + units(value) > MAX_ENV {
+                return Err(crate::PyError::value_error(format!(
+                    "the environment variable is longer than {MAX_ENV} characters"
+                )));
+            }
+            Ok(())
+        }
         crate::module_ns_store(
             ns,
             "putenv",
@@ -1649,6 +1674,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         ));
                     }
                     let value = env_bytes(args[1])?;
+                    #[cfg(windows)]
+                    entry_fits(&name, &value)?;
                     unsafe {
                         host_os::set_var(os_str_from_bytes(&name), os_str_from_bytes(&value))
                     };
@@ -1672,6 +1699,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             pyre_object::PY_NULL,
                         ));
                     }
+                    // `os_unsetenv_impl` reaches the same `win32_putenv`, so
+                    // the entry it would write is measured too.
+                    #[cfg(windows)]
+                    entry_fits(&name, b"")?;
                     unsafe { host_os::remove_var(os_str_from_bytes(&name)) };
                     Ok(pyre_object::w_none())
                 },
@@ -2113,11 +2144,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         ],
     );
 
-    // The spawn entry points `nt` has of its own. There is no fork on Windows
-    // for os.py:881 to write them over, so unbinding them here would not hand
-    // the definition back to os.py — it would delete the name.
-    #[cfg(windows)]
-    install_noop_stubs(ns, &["spawnv", "spawnve"]);
+    // `spawnv` / `spawnve` are the entry points `nt` has of its own, and are
+    // registered further down; os.py builds `spawnl` and `spawnle` out of them
+    // rather than out of fork+exec, because its fork branch is behind
+    // `_exists("fork")`.
 
     // The calls `nt` has not got. Each is probed for presence rather than
     // called blind — `os.py` gates `supports_fd` on `_exists`, `shutil` picks
@@ -3369,6 +3399,30 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 "path",
             )?;
             let bytes_mode = unsafe { path.is_bytes() };
+            // `FSCTL_GET_REPARSE_POINT` and the substitute name out of the
+            // buffer it fills, which is what spells a junction's target
+            // `\\?\C:\...`; `std::fs::read_link` hands back a name with
+            // that prefix already taken off.
+            #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+            {
+                use rustpython_host_env::nt::ReadlinkError;
+                return match rustpython_host_env::nt::readlink(&wide_path(&path.as_bytes)?) {
+                    Ok(target) => Ok(fs_name_obj(
+                        bytes_mode,
+                        target.as_os_str().as_encoded_bytes(),
+                    )),
+                    Err(ReadlinkError::Io(error)) => {
+                        Err(fs_err_with_filename(error, path.w_path()))
+                    }
+                    // A reparse point of any other kind names nothing this
+                    // call can answer with.
+                    Err(ReadlinkError::NotSymbolicLink)
+                    | Err(ReadlinkError::InvalidReparseData) => {
+                        Err(crate::PyError::value_error("not a symbolic link"))
+                    }
+                };
+            }
+            #[cfg(not(all(windows, feature = "host_env", not(feature = "sandbox"))))]
             match std::fs::read_link(path_from_bytes(&path.as_bytes).as_ref()) {
                 Ok(target) => {
                     let target = target.as_os_str().as_encoded_bytes();
@@ -4630,10 +4684,25 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             )
         };
 
+        // The Windows-only members `std::fs::Metadata` can answer: the
+        // attribute word it already carries, and the creation time it reports
+        // as a FILETIME. It knows no reparse tag, so that stays zero.
+        #[cfg(windows)]
+        let (win_file_attributes, win_birthtime, win_birthtime_ns) = {
+            use std::os::windows::fs::MetadataExt;
+            const EPOCH_DIFF: i64 = 11_644_473_600;
+            let created = meta.creation_time() as i64;
+            let secs = (created / 10_000_000) - EPOCH_DIFF;
+            (
+                meta.file_attributes(),
+                secs,
+                whole_ns(secs, (created % 10_000_000) * 100),
+            )
+        };
         stat_result_from_fields(
             &StatFields {
                 mode: st_mode,
-                ino: st_ino,
+                ino: st_ino as u128,
                 dev: st_dev,
                 nlink: st_nlink,
                 uid: st_uid,
@@ -4651,6 +4720,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 blocks: st_blocks,
                 #[cfg(unix)]
                 rdev: st_rdev,
+                #[cfg(windows)]
+                file_attributes: win_file_attributes,
+                #[cfg(windows)]
+                reparse_tag: 0,
+                #[cfg(windows)]
+                birthtime: win_birthtime,
+                #[cfg(windows)]
+                birthtime_ns: win_birthtime_ns,
             },
             st_flags,
         )
@@ -4678,9 +4755,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         }
     }
 
+    /// `_pystat_l128_from_l64_l64` -- Windows reports a 128-bit file id, whose
+    /// upper half is the only part some volumes fill in, so `st_ino` is an int
+    /// of whatever width the id needs rather than the low word alone.
+    fn w_ino(ino: u128) -> pyre_object::PyObjectRef {
+        match i64::try_from(ino) {
+            Ok(n) => pyre_object::w_int_new(n),
+            Err(_) => pyre_object::longobject::w_long_new(majit_rlib::rbigint::RBigInt::from(ino)),
+        }
+    }
+
     struct StatFields {
         mode: i64,
-        ino: i64,
+        ino: u128,
         dev: i64,
         nlink: i64,
         uid: i64,
@@ -4698,6 +4785,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         blocks: i64,
         #[cfg(unix)]
         rdev: i64,
+        /// `st_file_attributes` / `st_reparse_tag` -- the raw Win32 attribute
+        /// word and, where it says the name is a reparse point, that point's
+        /// tag.
+        #[cfg(windows)]
+        file_attributes: u32,
+        #[cfg(windows)]
+        reparse_tag: u32,
+        /// `st_birthtime` -- the creation time, which `st_ctime` reports here
+        /// as well.
+        #[cfg(windows)]
+        birthtime: i64,
+        #[cfg(windows)]
+        birthtime_ns: i128,
     }
 
     fn stat_result_from_fields(f: &StatFields, st_flags: u32) -> pyre_object::PyObjectRef {
@@ -4726,7 +4826,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // and the platform block/device extras are named-only fields.
         let seq = vec![
             pyre_object::w_int_new(st_mode),
-            pyre_object::w_int_new(st_ino),
+            w_ino(st_ino),
             pyre_object::w_int_new(st_dev),
             pyre_object::w_int_new(st_nlink),
             pyre_object::w_int_new(st_uid),
@@ -4776,6 +4876,21 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         extras.push(("st_flags", pyre_object::w_int_new(st_flags as i64)));
         #[cfg(not(target_os = "macos"))]
         let _ = st_flags;
+        #[cfg(windows)]
+        {
+            let birthtime_f =
+                f.birthtime as f64 + 1e-9 * (f.birthtime_ns - whole_ns(f.birthtime, 0)) as f64;
+            extras.push((
+                "st_file_attributes",
+                pyre_object::w_int_new(f.file_attributes as i64),
+            ));
+            extras.push((
+                "st_reparse_tag",
+                pyre_object::w_int_new(f.reparse_tag as i64),
+            ));
+            extras.push(("st_birthtime", pyre_object::w_float_new(birthtime_f)));
+            extras.push(("st_birthtime_ns", w_time_ns(f.birthtime_ns)));
+        }
         crate::_structseq::new_instance_with_extra(stat_result_seq_type(), seq, extras)
     }
     /// Build a `stat_result` from the sandbox wire `StatBuf` (sandbox build
@@ -4937,7 +5052,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     fn stat_fields_from_libc(st: &libc::stat) -> StatFields {
         StatFields {
             mode: st.st_mode as i64,
-            ino: st.st_ino as i64,
+            ino: st.st_ino as u128,
             dev: st.st_dev as i64,
             nlink: st.st_nlink as i64,
             uid: st.st_uid as i64,
@@ -4968,7 +5083,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     fn stat_fields_from_statstruct(st: &rustpython_host_env::fileutils::StatStruct) -> StatFields {
         StatFields {
             mode: st.st_mode as i64,
-            ino: st.st_ino as i64,
+            // `_pystat_l128_from_l64_l64` -- a volume that numbers its files
+            // above 2**64 leaves the low word at zero, which is how every
+            // directory on such a volume used to answer with the same id.
+            ino: (st.st_ino_high as u128) << 64 | st.st_ino as u128,
             dev: st.st_dev as i64,
             nlink: st.st_nlink as i64,
             uid: st.st_uid as i64,
@@ -4980,6 +5098,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             atime_ns: whole_ns(st.st_atime as i64, st.st_atime_nsec as i64),
             mtime_ns: whole_ns(st.st_mtime as i64, st.st_mtime_nsec as i64),
             ctime_ns: whole_ns(st.st_birthtime as i64, st.st_birthtime_nsec as i64),
+            file_attributes: st.st_file_attributes as u32,
+            reparse_tag: st.st_reparse_tag,
+            birthtime: st.st_birthtime as i64,
+            birthtime_ns: whole_ns(st.st_birthtime as i64, st.st_birthtime_nsec as i64),
         }
     }
 
@@ -5417,7 +5539,20 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         Ok(pyre_object::w_bool_from(ans))
     }
     fn dir_entry_is_junction(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        // `DirEntry_is_junction` -- the lstat's reparse tag naming a mount
+        // point. A name that is no reparse point at all carries tag 0.
+        #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+        {
+            const IO_REPARSE_TAG_MOUNT_POINT: u32 = 0xA000_0003;
+            let (w_path, path) = dir_entry_path(_args[0])?;
+            let fields =
+                win_stat_fields(&path, false).map_err(|e| fs_err_with_filename(e, w_path))?;
+            return Ok(pyre_object::w_bool_from(
+                fields.reparse_tag == IO_REPARSE_TAG_MOUNT_POINT,
+            ));
+        }
         // POSIX has no junction points.
+        #[allow(unreachable_code)]
         Ok(pyre_object::w_bool_from(false))
     }
     fn dir_entry_inode(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -5447,7 +5582,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         {
             let fields =
                 win_stat_fields(&path, false).map_err(|e| fs_err_with_filename(e, w_path))?;
-            return Ok(pyre_object::w_int_new(fields.ino));
+            return Ok(w_ino(fields.ino));
         }
         #[cfg(not(all(windows, feature = "host_env", not(feature = "sandbox"))))]
         {
@@ -10836,10 +10971,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         /// The descriptor an fd argument names, for the runtime calls that
         /// take one. `-1` is the sentinel for "no descriptor", never a real
         /// one, so it is refused before the call sees it.
-        fn borrowed_fd(w_fd: PyObjectRef) -> Result<crt_fd::Borrowed<'static>, crate::PyError> {
-            let fd = crate::baseobjspace::c_int_w(w_fd)?;
+        fn borrow_raw_fd(fd: i32) -> Result<crt_fd::Borrowed<'static>, crate::PyError> {
             unsafe { crt_fd::Borrowed::try_borrow_raw(fd) }
                 .map_err(|e| errno_err(crt_errno_of(&e), ""))
+        }
+
+        /// The `fd: int` spelling of that argument, which is `_PyLong_AsInt`
+        /// and nothing more.
+        fn borrowed_fd(w_fd: PyObjectRef) -> Result<crt_fd::Borrowed<'static>, crate::PyError> {
+            borrow_raw_fd(crate::baseobjspace::c_int_w(w_fd)?)
         }
 
         fn crt_result(result: std::io::Result<()>) -> Result<PyObjectRef, crate::PyError> {
@@ -10943,7 +11083,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.is_empty() {
                         return Err(crate::PyError::type_error("fsync() requires 1 argument"));
                     }
-                    crt_result(crt_fd::fsync(borrowed_fd(args[0])?))
+                    // `fd: fildes`, which is `PyObject_AsFileDescriptor`:
+                    // it takes an object with a `fileno()` and warns that a
+                    // bool is being used as a descriptor. It is the only
+                    // argument spelled that way in this half of the module.
+                    let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
+                    crt_result(crt_fd::fsync(borrow_raw_fd(fd)?))
                 },
                 1,
             ),
@@ -11004,8 +11149,88 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             ),
         );
 
-        // os.chdir(path) — `SetCurrentDirectoryW`, which is what
-        // `std::env::set_current_dir` is here.
+        /// The working directory published under `=X:`, the name a drive's
+        /// current directory is kept in. A name beginning `\\` or `//` is on
+        /// no drive and publishes nothing.
+        fn publish_drive_current_directory() -> std::io::Result<()> {
+            use std::os::windows::ffi::OsStrExt;
+            use windows_sys::Win32::System::Environment::SetEnvironmentVariableW;
+
+            let new_path: Vec<u16> = std::env::current_dir()?
+                .as_os_str()
+                .encode_wide()
+                .chain(std::iter::once(0))
+                .collect();
+            let unc_like = new_path.starts_with(&[b'\\' as u16, b'\\' as u16])
+                || new_path.starts_with(&[b'/' as u16, b'/' as u16]);
+            if unc_like || new_path.len() < 2 {
+                return Ok(());
+            }
+            let name = [b'=' as u16, new_path[0], b':' as u16, 0];
+            if unsafe { SetEnvironmentVariableW(name.as_ptr(), new_path.as_ptr()) } == 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        }
+
+        /// `win32_wchdir` -- `SetCurrentDirectoryW`, then the directory read
+        /// back and published for the drive it is on.
+        fn win32_wchdir(path: &std::path::Path) -> std::io::Result<()> {
+            std::env::set_current_dir(path)?;
+            publish_drive_current_directory()
+        }
+
+        /// The same entry, written before an environment is handed to the
+        /// runtime rather than because the directory changed.
+        ///
+        /// `construct_environment_block`, which `_wspawnve` and `_wexecve`
+        /// both reach, finds the first `=X:` entry by walking the environment
+        /// for one that begins with `=`:
+        ///
+        /// ```text
+        /// while (*it != '=') it += tcslen(it) + 1;
+        /// ```
+        ///
+        /// There is no bound on that walk, so an environment carrying none of
+        /// those entries sends it past the block's terminator and through
+        /// whatever follows until it reaches a page that is not mapped. Only
+        /// the command shell writes them, and a process it did not start --
+        /// one under a build runner, or under a shell of another family --
+        /// holds none. Publishing the working directory gives the walk its
+        /// first entry; `win32_wchdir` is what keeps it current afterwards.
+        fn ensure_drive_current_directory() {
+            use windows_sys::Win32::System::Environment::{
+                FreeEnvironmentStringsW, GetEnvironmentStringsW,
+            };
+
+            let block = unsafe { GetEnvironmentStringsW() };
+            if block.is_null() {
+                return;
+            }
+            let mut present = false;
+            let mut entry = block;
+            unsafe {
+                while *entry != 0 {
+                    if *entry == b'=' as u16 {
+                        present = true;
+                        break;
+                    }
+                    while *entry != 0 {
+                        entry = entry.add(1);
+                    }
+                    entry = entry.add(1);
+                }
+                FreeEnvironmentStringsW(block);
+            }
+            if !present {
+                // A working directory that cannot be read or published leaves
+                // the environment as it was; the call this precedes is the one
+                // that reports, and it has its own errno to report with.
+                let _ = publish_drive_current_directory();
+            }
+        }
+
+        // os.chdir(path)
         crate::module_ns_store(
             ns,
             "chdir",
@@ -11019,7 +11244,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     // because it can `fchdir`; there is none here, so the list
                     // this one shows is the path-only one.
                     let path = crate::gateway::fsencode_path_named_w(args[0], "chdir", "path")?;
-                    std::env::set_current_dir(path_from_bytes(&path.as_bytes).as_ref())
+                    win32_wchdir(path_from_bytes(&path.as_bytes).as_ref())
                         .map_err(|e| fs_err_with_filename(e, path.w_path()))?;
                     Ok(pyre_object::w_none())
                 },
@@ -11190,6 +11415,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         })
                         .collect::<Result<Vec<_>, _>>()?;
                     let env_ptrs = exec_pointer_array_wide(&env);
+                    ensure_drive_current_directory();
                     crate::builtins::crt_call!(libc::wexecve(
                         command_w.as_ptr(),
                         argv_ptrs.as_ptr(),
@@ -11201,6 +11427,150 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     ))
                 },
                 3,
+            ),
+        );
+
+        // os.spawnv(mode, path, argv) / os.spawnve(mode, path, argv, env)
+        //
+        // `_wspawnv` / `_wspawnve`. `P_WAIT` answers with the child's exit
+        // status and the other modes with the handle the child was started
+        // under, which is what `os.waitpid` takes.
+        //
+        // `os_spawnv_impl` takes a list or a tuple and nothing else -- an
+        // iterable of its own is not one -- and reads the shape of `argv`
+        // before anything in it, which is why the two halves are separate.
+        fn spawn_argv_shape(
+            w_argv: PyObjectRef,
+            function: &str,
+        ) -> Result<Vec<PyObjectRef>, crate::PyError> {
+            if unsafe { !pyre_object::is_list(w_argv) && !pyre_object::is_tuple(w_argv) } {
+                return Err(crate::PyError::type_error(format!(
+                    "{function}() arg 2 must be a tuple or list"
+                )));
+            }
+            let items = crate::baseobjspace::unpackiterable(w_argv, -1)?;
+            if items.is_empty() {
+                return Err(crate::PyError::value_error(format!(
+                    "{function}() arg 2 cannot be empty"
+                )));
+            }
+            Ok(items)
+        }
+
+        /// The same elements as wide strings. `fsconvert_strdup` reports for
+        /// itself, and only `spawnv` replaces what it says with a message of
+        /// its own -- the rejected type and the embedded null alike, since
+        /// `os_spawnv_impl` sets its own error over whichever one came back.
+        fn spawn_argv_wide(
+            items: Vec<PyObjectRef>,
+            function: &str,
+            name_element_errors: bool,
+        ) -> Result<Vec<widestring::WideCString>, crate::PyError> {
+            let mut argv = Vec::with_capacity(items.len());
+            for (index, item) in items.into_iter().enumerate() {
+                let converted = extract_path(item).and_then(|value| {
+                    widestring::WideCString::from_os_str(&*os_str_from_bytes(&value))
+                        .map_err(|_| crate::PyError::value_error("embedded null character"))
+                });
+                let wide = converted.map_err(|error| {
+                    if name_element_errors {
+                        crate::PyError::type_error(format!(
+                            "{function}() arg 2 must contain only strings"
+                        ))
+                    } else {
+                        error
+                    }
+                })?;
+                // The first element is judged as soon as it is converted, so a
+                // later element that cannot be converted at all does not
+                // report ahead of it. `os_spawnve_impl` names `spawnv` here
+                // whichever of the two is running.
+                if index == 0 && wide.is_empty() {
+                    return Err(crate::PyError::value_error(
+                        "spawnv() arg 2 first element cannot be empty",
+                    ));
+                }
+                argv.push(wide);
+            }
+            Ok(argv)
+        }
+
+        fn spawn_wide_refs(
+            values: &[widestring::WideCString],
+        ) -> Vec<&widestring::WideCStr> {
+            values.iter().map(|value| value.as_ucstr()).collect()
+        }
+
+        crate::module_ns_store(
+            ns,
+            "spawnv",
+            crate::make_builtin_function_with_arity(
+                "spawnv",
+                |args| {
+                    let mode = crate::baseobjspace::c_int_w(args[0])?;
+                    let path = crate::gateway::fsencode_path_named_w(args[1], "spawnv", "path")?;
+                    let command_w = wide_path(&path.as_bytes)?;
+                    let items = spawn_argv_shape(args[2], "spawnv")?;
+                    let argv = spawn_argv_wide(items, "spawnv", true)?;
+                    let spawned = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_nt::spawnv(mode, &command_w, &spawn_wide_refs(&argv))
+                    };
+                    match spawned {
+                        Ok(value) => Ok(pyre_object::w_int_new(value as i64)),
+                        // `posix_error` -- the runtime's own errno, which is
+                        // where `_wspawnv` reports a name it cannot start.
+                        Err(error) => Err(errno_err(crt_errno_of(&error), "")),
+                    }
+                },
+                3,
+            ),
+        );
+
+        crate::module_ns_store(
+            ns,
+            "spawnve",
+            crate::make_builtin_function_with_arity(
+                "spawnve",
+                |args| {
+                    let mode = crate::baseobjspace::c_int_w(args[0])?;
+                    let path = crate::gateway::fsencode_path_named_w(args[1], "spawnve", "path")?;
+                    let command_w = wide_path(&path.as_bytes)?;
+                    let items = spawn_argv_shape(args[2], "spawnve")?;
+                    // The mapping is judged between the shape of `argv` and
+                    // its contents, and by its own wording rather than the
+                    // `execve` one `collect_env_entries` would give it.
+                    if !crate::baseobjspace::py_mapping_check(args[3]) {
+                        return Err(crate::PyError::type_error(
+                            "spawnve() arg 3 must be a mapping object",
+                        ));
+                    }
+                    let argv = spawn_argv_wide(items, "spawnve", false)?;
+                    let env = collect_env_entries(args[3], "spawnve", false)?
+                        .into_iter()
+                        .map(|entry| {
+                            widestring::WideCString::from_os_str(&*os_str_from_bytes(&entry))
+                                .map_err(|_| {
+                                    crate::PyError::value_error("embedded null character")
+                                })
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    ensure_drive_current_directory();
+                    let spawned = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_nt::spawnve(
+                            mode,
+                            &command_w,
+                            &spawn_wide_refs(&argv),
+                            &spawn_wide_refs(&env),
+                        )
+                    };
+                    match spawned {
+                        Ok(value) => Ok(pyre_object::w_int_new(value as i64)),
+                        Err(error) => Err(errno_err(crt_errno_of(&error), "")),
+                    }
+                },
+                4,
             ),
         );
 
@@ -11288,7 +11658,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 }
                 let follow_symlinks = match crate::builtins::kwarg_get(kwargs, "follow_symlinks") {
                     Some(w) => crate::baseobjspace::is_true(w)?,
-                    None => true,
+                    // `CHMOD_DEFAULT_FOLLOW_SYMLINKS` is 0 here, which the
+                    // clinic spells `follow_symlinks=(os.name != 'nt')`: an
+                    // unqualified `chmod` writes the attribute on the name it
+                    // was given, link or not.
+                    None => false,
                 };
                 let wide = wide_path(&path.as_bytes)?;
                 // `os_chmod_impl` holds one `Py_BEGIN_ALLOW_THREADS` region
@@ -11711,14 +12085,68 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         host_nt::cwait(pid, options)
                     };
                     match waited {
+                        // `unsigned long long ustatus = (unsigned int)status`
+                        // -- an exit code above `INT_MAX`, which
+                        // `ExitProcess` takes, is a positive number here and
+                        // not a negative `int`.
                         Ok((pid, status)) => Ok(pyre_object::w_tuple_new(vec![
                             pyre_object::w_int_new(pid as i64),
-                            pyre_object::w_int_new((status as i64) << 8),
+                            pyre_object::w_int_new((status as u32 as i64) << 8),
                         ])),
                         Err(e) => Err(errno_err(crt_errno_of(&e), "")),
                     }
                 },
                 2,
+            ),
+        );
+
+        // os.waitstatus_to_exitcode(status) -> int
+        //
+        // `os_waitstatus_to_exitcode_impl` under `MS_WINDOWS`: `os.waitpid`
+        // shifted the child's exit code up by a byte to spell it the way a
+        // POSIX wait status does, and this shifts it back down.
+
+        /// `PyLong_AsUnsignedLongLong` -- an `int` and nothing else, so an
+        /// object carrying `__index__` is turned away rather than converted.
+        fn unsigned_long_long_w(value: PyObjectRef) -> Result<u64, crate::PyError> {
+            if unsafe { pyre_object::pyobject::is_int(value) } {
+                let signed = unsafe { pyre_object::intobject::w_int_get_value(value) };
+                return u64::try_from(signed).map_err(|_| {
+                    crate::PyError::overflow_error("can't convert negative int to unsigned")
+                });
+            }
+            if unsafe { pyre_object::pyobject::is_long(value) } {
+                let big = unsafe { pyre_object::w_long_get_value(value) };
+                if big.get_sign() < 0 {
+                    return Err(crate::PyError::overflow_error(
+                        "can't convert negative int to unsigned",
+                    ));
+                }
+                if pyre_object::longobject::jit_bigint_to_u64_fits(big) == 0 {
+                    return Err(crate::PyError::overflow_error("int too big to convert"));
+                }
+                return Ok(pyre_object::longobject::jit_bigint_to_u64_value(big));
+            }
+            Err(crate::PyError::type_error("an integer is required"))
+        }
+
+        crate::module_ns_store(
+            ns,
+            "waitstatus_to_exitcode",
+            crate::make_builtin_function_with_arity(
+                "waitstatus_to_exitcode",
+                |args| {
+                    let exitcode = unsigned_long_long_w(args[0])? >> 8;
+                    // `ExitProcess` takes a `UINT`, so a wider value names no
+                    // exit code a child could have left.
+                    if exitcode > u64::from(u32::MAX) {
+                        return Err(crate::PyError::value_error(format!(
+                            "invalid exit code: {exitcode}"
+                        )));
+                    }
+                    Ok(pyre_object::w_int_new(exitcode as i64))
+                },
+                1,
             ),
         );
 

--- a/pyre/pyre-interpreter/src/module/winreg/mod.rs
+++ b/pyre/pyre-interpreter/src/module/winreg/mod.rs
@@ -91,7 +91,12 @@ mod imp {
     /// predefined roots sign-extend past `i64::MAX` on 64-bit, so route those
     /// through a long.
     fn int_from_ptr(raw: HKEY) -> PyObjectRef {
-        let value = raw as usize as u64;
+        int_from_u64(raw as usize as u64)
+    }
+
+    /// `PyLong_FromUnsignedLongLong` — a 64-bit value one past `i64::MAX`
+    /// reads back as the large positive it is rather than as a negative.
+    fn int_from_u64(value: u64) -> PyObjectRef {
         if value <= i64::MAX as u64 {
             w_int_new(value as i64)
         } else {
@@ -108,6 +113,7 @@ mod imp {
     crate::py_class! {
         "winreg.PyHKEY",
         methods: {
+            #[doc = "Closes the underlying Windows handle.\n\nIf the handle is already closed, no error is raised."]
             fn Close(self_obj: PyObjectRef) -> Result<(), crate::PyError> {
                 let raw = take_handle(self_obj);
                 if !raw.is_null() {
@@ -115,6 +121,7 @@ mod imp {
                 }
                 Ok(())
             }
+            #[doc = "Detaches the Windows handle from the handle object.\n\nThe result is the value of the handle before it is detached.  If the\nhandle is already detached, this will return zero.\n\nAfter calling this function, the handle is effectively invalidated,\nbut the handle is not closed.  You would call this function when you\nneed the underlying win32 handle to exist beyond the lifetime of the\nhandle object."]
             fn Detach(self_obj: PyObjectRef) -> PyObjectRef {
                 int_from_ptr(take_handle(self_obj))
             }
@@ -138,6 +145,30 @@ mod imp {
                     host_reg::close_key(raw);
                 }
                 Ok(false)
+            }
+            fn __str__(self_obj: PyObjectRef) -> PyObjectRef {
+                // `PyHKEY_strFunc` — `PyUnicode_FromFormat("<PyHKEY:%p>", …)`.
+                // `%p` is the host's own pointer spelling, which on Windows is
+                // the full width in upper-case digits with no prefix of its
+                // own; `PyUnicode_FromFormat` is what puts the `0x` in front.
+                // The type keeps `object.__repr__`, so `repr` and `str` of a
+                // handle read differently.
+                let raw = get_handle(self_obj) as usize;
+                w_str_new(&format!(
+                    "<PyHKEY:0x{raw:0width$X}>",
+                    width = core::mem::size_of::<usize>() * 2
+                ))
+            }
+        },
+        properties: {
+            fn handle(_descr: PyObjectRef, self_obj: PyObjectRef) -> PyObjectRef {
+                // `W_HKEY.descr_handle_get` — the handle as the integer it
+                // points at. `PyHKEY_memberlist` reads the same field through
+                // a `Py_T_INT` member, which on a 64-bit host truncates it to
+                // the low word; the property answers the whole pointer, so it
+                // agrees with `int(key)` for every handle rather than only for
+                // one below 2**31.
+                int_from_ptr(get_handle(self_obj))
             }
         }
     }
@@ -179,12 +210,27 @@ mod imp {
             .map(|u| u as usize as HKEY)
     }
 
-    /// Resolve a key argument — a `PyHKEY` or an integer handle (the predefined
-    /// `HKEY_*` roots) — to a raw `HKEY`.
-    fn key_arg(args: &[PyObjectRef], idx: usize) -> Result<HKEY, crate::PyError> {
-        let obj = arg(args, idx)?;
-        if let Some(raw) = stored_handle(obj) {
-            return Ok(raw);
+    /// `PyHKEY_Check` — the handle object this module hands out, and nothing
+    /// that merely happens to carry a `_handle` entry.
+    fn is_pyhkey(obj: PyObjectRef) -> bool {
+        crate::typedef::r#type(obj).map(|w_type| w_type.as_ptr()) == Some(type_object())
+    }
+
+    /// `PyHKEY_AsHKEY` — a key argument is a `PyHKEY`, an integer handle (the
+    /// predefined `HKEY_*` roots are published as their pointer value), or
+    /// `None` at `CloseKey`, the one boundary that reads it as the null
+    /// handle rather than as a mistake.
+    fn as_hkey(obj: PyObjectRef, none_ok: bool) -> Result<HKEY, crate::PyError> {
+        if unsafe { is_none(obj) } {
+            if none_ok {
+                return Ok(core::ptr::null_mut());
+            }
+            return Err(crate::PyError::type_error(
+                "None is not a valid HKEY in this context",
+            ));
+        }
+        if is_pyhkey(obj) {
+            return Ok(get_handle(obj));
         }
         if unsafe { is_int_or_long(obj) } {
             return Ok(crate::baseobjspace::uint_w(obj)? as usize as HKEY);
@@ -194,67 +240,219 @@ mod imp {
         ))
     }
 
-    fn arg(args: &[PyObjectRef], idx: usize) -> Result<PyObjectRef, crate::PyError> {
-        args.get(idx)
-            .copied()
-            .ok_or_else(|| crate::PyError::type_error("required argument missing"))
-    }
-
-    /// A `str` or `None` argument → owned `String` / `None`.
-    fn opt_str(args: &[PyObjectRef], idx: usize) -> Result<Option<String>, crate::PyError> {
-        match args.get(idx).copied() {
-            None => Ok(None),
-            Some(obj) if unsafe { is_none(obj) } => Ok(None),
-            Some(obj) if unsafe { is_str(obj) } => {
-                Ok(Some(unsafe { w_str_get_value(obj) }.to_string()))
-            }
-            Some(_) => Err(crate::PyError::type_error(
-                "argument must be a string or None",
-            )),
-        }
-    }
-
-    fn req_str(args: &[PyObjectRef], idx: usize) -> Result<String, crate::PyError> {
-        let obj = arg(args, idx)?;
-        if unsafe { is_str(obj) } {
-            Ok(unsafe { w_str_get_value(obj) }.to_string())
-        } else {
-            Err(crate::PyError::type_error("argument must be a string"))
-        }
-    }
-
-    fn req_int(args: &[PyObjectRef], idx: usize) -> Result<i64, crate::PyError> {
-        crate::baseobjspace::int_w(arg(args, idx)?)
-    }
-
-    /// An access mask or `reserved` word, which `OpenKeyEx`, `CreateKeyEx` and
-    /// `DeleteKeyEx` each take positionally or by name, defaulting where the
-    /// caller passed neither.
-    fn uint_arg(
-        pos: &[PyObjectRef],
-        kwargs: Option<PyObjectRef>,
-        idx: usize,
-        name: &str,
-        default: u32,
-    ) -> Result<u32, crate::PyError> {
-        let value = match crate::builtins::kwarg_get(kwargs, name) {
-            Some(value) => value,
-            None => match pos.get(idx) {
-                Some(&value) => value,
-                None => return Ok(default),
-            },
+    /// Whether the call carried a keyword at all. The gateway appends its own
+    /// marker entry to the kwargs dict, which is not one of them.
+    fn has_keywords(kwargs: Option<PyObjectRef>) -> bool {
+        let Some(dict) = kwargs else {
+            return false;
         };
-        Ok(crate::baseobjspace::int_w(value)? as u32)
+        unsafe { pyre_object::w_dict_str_entries_wtf8(dict) }
+            .iter()
+            .any(|(key, _)| key.as_str() != Ok("__pyre_kw__"))
     }
 
-    /// The sub-key argument as a wide string; absent and `None` both mean the
-    /// key itself, which the Win32 calls spell as the empty name.
-    fn sub_key_wide(args: &[PyObjectRef], idx: usize) -> Result<WideCString, crate::PyError> {
-        Ok(WideCString::from_str_truncate(
-            opt_str(args, idx)?.as_deref().unwrap_or(""),
+    /// The wording a boundary with no keyword table gives one anyway. It
+    /// qualifies itself with the module, which the clinic's keyword binder
+    /// does not.
+    fn no_keywords(name: &str) -> crate::PyError {
+        crate::PyError::type_error(format!("winreg.{name}() takes no keyword arguments"))
+    }
+
+    /// A positional-only call of fixed arity — `_PyArg_CheckPositional`
+    /// reports the count it wanted against the count it got.
+    fn exact_args<'a>(
+        args: &'a [PyObjectRef],
+        name: &str,
+        count: usize,
+    ) -> Result<&'a [PyObjectRef], crate::PyError> {
+        let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+        if has_keywords(kwargs) {
+            return Err(no_keywords(name));
+        }
+        if pos.len() != count {
+            return Err(crate::PyError::type_error(format!(
+                "{name} expected {count} arguments, got {}",
+                pos.len()
+            )));
+        }
+        Ok(pos)
+    }
+
+    /// `METH_O` — the single key the seven one-argument calls take, whose
+    /// count is checked by the call machinery rather than by a converter.
+    fn single_arg(args: &[PyObjectRef], name: &str) -> Result<PyObjectRef, crate::PyError> {
+        let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+        if has_keywords(kwargs) {
+            return Err(no_keywords(name));
+        }
+        if pos.len() != 1 {
+            return Err(crate::PyError::type_error(format!(
+                "winreg.{name}() takes exactly one argument ({} given)",
+                pos.len()
+            )));
+        }
+        Ok(pos[0])
+    }
+
+    /// The four `key, sub_key, …` boundaries the clinic exposes by keyword.
+    /// The first two are required; the last two default differently per
+    /// boundary, so an unset slot comes back for the caller to fill.
+    ///
+    /// The order the three refusals come in is `_PyArg_UnpackKeywords`':
+    /// too many positionals first, then a required slot still empty — which
+    /// is why `OpenKey(bogus=1)` names `key` as missing rather than `bogus`
+    /// as unexpected — and the unknown keyword last.
+    fn bind_key_args(
+        args: &[PyObjectRef],
+        name: &str,
+        params: [&str; 4],
+    ) -> Result<[Option<PyObjectRef>; 4], crate::PyError> {
+        let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+        if pos.len() > params.len() {
+            return Err(crate::PyError::type_error(format!(
+                "{name}() takes at most {} arguments ({} given)",
+                params.len(),
+                pos.len()
+            )));
+        }
+        let mut bound = [None; 4];
+        for (index, key) in params.iter().enumerate() {
+            let value = crate::builtins::bind_pos_or_kw(pos, kwargs, index, key, name, index + 1)?;
+            if value.is_none() && index < 2 {
+                return Err(crate::PyError::type_error(format!(
+                    "{name}() missing required argument '{key}' (pos {})",
+                    index + 1
+                )));
+            }
+            bound[index] = value;
+        }
+        crate::builtins::kwarg_reject_unknown(kwargs, &params, name)?;
+        Ok(bound)
+    }
+
+    /// A rejected string argument. The clinic names the parameter where the
+    /// boundary takes keywords and its 1-based position where it does not, and
+    /// names neither at `ExpandEnvironmentStrings`, so `label` arrives already
+    /// spelled the way the message wants it — `'sub_key'`, `2`, or nothing.
+    fn text_arg_error(
+        func: &str,
+        label: &str,
+        accept_none: bool,
+        obj: PyObjectRef,
+    ) -> crate::PyError {
+        let none = if accept_none { " or None" } else { "" };
+        let label = if label.is_empty() {
+            String::new()
+        } else {
+            format!("{label} ")
+        };
+        // `_PyArg_BadArgument` names `None` by the value rather than by
+        // `NoneType`, which is the only object it spells that way.
+        let got = if unsafe { is_none(obj) } {
+            "None".to_string()
+        } else {
+            crate::error::type_name_of(obj)
+        };
+        crate::PyError::type_error(format!(
+            "{func}() argument {label}must be str{none}, not {got}"
         ))
     }
 
+    /// `Py_UNICODE(accept={str, NoneType})`.
+    fn opt_text(
+        obj: PyObjectRef,
+        func: &str,
+        label: &str,
+    ) -> Result<Option<String>, crate::PyError> {
+        if unsafe { is_none(obj) } {
+            return Ok(None);
+        }
+        if unsafe { is_str(obj) } {
+            return Ok(Some(unsafe { w_str_get_value(obj) }.to_string()));
+        }
+        Err(text_arg_error(func, label, true, obj))
+    }
+
+    /// `Py_UNICODE` — the same argument where `None` is not one of the
+    /// answers.
+    fn req_text(obj: PyObjectRef, func: &str, label: &str) -> Result<String, crate::PyError> {
+        if unsafe { is_str(obj) } {
+            return Ok(unsafe { w_str_get_value(obj) }.to_string());
+        }
+        Err(text_arg_error(func, label, false, obj))
+    }
+
+    /// The name a sub-key argument spells; absent and `None` both mean the key
+    /// itself, which the Win32 calls take as the empty name.
+    fn wide_or_empty(text: Option<String>) -> WideCString {
+        WideCString::from_str_truncate(text.as_deref().unwrap_or(""))
+    }
+
+    // The four wordings `longobject.c` gives a value outside an unsigned
+    // width. The `unsigned long` pair names `int` for the negative and `long`
+    // for the overflow; both are its own, and neither follows from the other.
+    const NEGATIVE_UNSIGNED_INT: &str = "can't convert negative value to unsigned int";
+    const TOO_BIG_UNSIGNED_LONG: &str = "Python int too large to convert to C unsigned long";
+    const NEGATIVE_UNSIGNED: &str = "can't convert negative int to unsigned";
+    const TOO_BIG_UNSIGNED: &str = "int too big to convert";
+
+    /// `PyLong_AsUnsignedLong` and `PyLong_AsUnsignedLongLong` differ only in
+    /// the width they fit into and in what they call a value outside it. The
+    /// argument is already known to be an `int`.
+    fn unsigned_w(
+        value: PyObjectRef,
+        max: u64,
+        negative: &str,
+        too_big: &str,
+    ) -> Result<u64, crate::PyError> {
+        let raw = if unsafe { is_bool(value) } {
+            (unsafe { pyre_object::boolobject::w_bool_get_value(value) }) as i64 as u64
+        } else if unsafe { is_int(value) } {
+            let signed = unsafe { pyre_object::intobject::w_int_get_value(value) };
+            if signed < 0 {
+                return Err(crate::PyError::overflow_error(negative));
+            }
+            signed as u64
+        } else {
+            let big = unsafe { pyre_object::w_long_get_value(value) };
+            if big.get_sign() < 0 {
+                return Err(crate::PyError::overflow_error(negative));
+            }
+            if pyre_object::longobject::jit_bigint_to_u64_fits(big) == 0 {
+                return Err(crate::PyError::overflow_error(too_big));
+            }
+            pyre_object::longobject::jit_bigint_to_u64_value(big)
+        };
+        if raw > max {
+            return Err(crate::PyError::overflow_error(too_big));
+        }
+        Ok(raw)
+    }
+
+    /// `_PyLong_UnsignedLong_Converter` — a `DWORD` argument: an access mask,
+    /// a reserved word, or a value type.
+    fn dword_arg(obj: PyObjectRef) -> Result<u32, crate::PyError> {
+        let value = crate::baseobjspace::space_index(obj)?;
+        unsigned_w(
+            value,
+            u64::from(u32::MAX),
+            NEGATIVE_UNSIGNED_INT,
+            TOO_BIG_UNSIGNED_LONG,
+        )
+        .map(|raw| raw as u32)
+    }
+
+    /// `_PyLong_AsInt` — the `index` the two Enum calls count with.
+    fn int_arg(obj: PyObjectRef) -> Result<i32, crate::PyError> {
+        let value = crate::baseobjspace::space_index(obj)?;
+        // `space_index` answers an int, so the only reading left to fail is
+        // the width.
+        let raw = crate::baseobjspace::int_w(value).map_err(|_| {
+            crate::PyError::overflow_error("Python int too large to convert to C int")
+        })?;
+        i32::try_from(raw)
+            .map_err(|_| crate::PyError::overflow_error("Python int too large to convert to C int"))
+    }
     /// The `OSError` a failed `Reg*` call raises.  These report `LSTATUS`
     /// codes, which are Win32 error codes, so the code is kept in `.winerror`
     /// and `str(e)` opens `[WinError 2]` rather than `[Errno 2]`
@@ -299,23 +497,33 @@ mod imp {
                 } else {
                     0
                 };
-                // Registry QWORDs above i64::MAX are vanishingly rare; the raw
-                // 64-bit pattern is preserved.
-                w_int_new(value as i64)
+                int_from_u64(value)
             }
-            host_reg::REG_SZ | host_reg::REG_EXPAND_SZ | host_reg::REG_LINK => {
+            host_reg::REG_SZ | host_reg::REG_EXPAND_SZ => {
                 let units = utf16_units(data);
                 let end = units.iter().position(|&c| c == 0).unwrap_or(units.len());
                 w_str_new(&String::from_utf16_lossy(&units[..end]))
             }
             host_reg::REG_MULTI_SZ => {
+                // `countStrings`/`fixupMultiSZ` — one trailing terminator ends
+                // the block and every run before it is a string, the empty
+                // ones included; a block that is nothing but terminators reads
+                // back as that many empty strings.
                 let units = utf16_units(data);
+                let end = match units.last() {
+                    None => 0,
+                    Some(&0) => units.len() - 1,
+                    Some(_) => units.len(),
+                };
                 let mut items = Vec::new();
-                for chunk in units.split(|&c| c == 0) {
-                    if chunk.is_empty() {
-                        break;
+                let mut start = 0;
+                while start < end {
+                    let mut stop = start;
+                    while stop < end && units[stop] != 0 {
+                        stop += 1;
                     }
-                    items.push(w_str_new(&String::from_utf16_lossy(chunk)));
+                    items.push(w_str_new(&String::from_utf16_lossy(&units[start..stop])));
+                    start = stop + 1;
                 }
                 w_list_new(items)
             }
@@ -335,31 +543,73 @@ mod imp {
         units.iter().flat_map(|u| u.to_le_bytes()).collect()
     }
 
+    /// What `Py2Reg` reports when it answers `FALSE`: either an exception of
+    /// its own — a value outside the width it is being written at, or one no
+    /// buffer can be taken from — or no exception at all, which the caller
+    /// turns into a `ValueError` naming neither.
+    enum Py2RegError {
+        Raised(crate::PyError),
+        Unconvertible,
+    }
+
+    impl From<crate::PyError> for Py2RegError {
+        fn from(error: crate::PyError) -> Self {
+            Py2RegError::Raised(error)
+        }
+    }
+
     /// `Py2Reg` — a Python value + type → registry bytes.
-    fn py2reg(value: PyObjectRef, typ: u32) -> Result<Vec<u8>, crate::PyError> {
+    fn py2reg(value: PyObjectRef, typ: u32) -> Result<Vec<u8>, Py2RegError> {
         match typ {
-            host_reg::REG_DWORD => Ok((crate::baseobjspace::int_w(value)? as u32)
-                .to_le_bytes()
-                .to_vec()),
-            host_reg::REG_QWORD => Ok((crate::baseobjspace::int_w(value)? as u64)
-                .to_le_bytes()
-                .to_vec()),
+            host_reg::REG_DWORD => {
+                if unsafe { is_none(value) } {
+                    return Ok(0u32.to_le_bytes().to_vec());
+                }
+                if unsafe { !is_int_or_long(value) } {
+                    return Err(Py2RegError::Unconvertible);
+                }
+                let d = unsigned_w(
+                    value,
+                    u64::from(u32::MAX),
+                    NEGATIVE_UNSIGNED_INT,
+                    TOO_BIG_UNSIGNED_LONG,
+                )? as u32;
+                Ok(d.to_le_bytes().to_vec())
+            }
+            host_reg::REG_QWORD => {
+                if unsafe { is_none(value) } {
+                    return Ok(0u64.to_le_bytes().to_vec());
+                }
+                if unsafe { !is_int_or_long(value) } {
+                    return Err(Py2RegError::Unconvertible);
+                }
+                let d = unsigned_w(value, u64::MAX, NEGATIVE_UNSIGNED, TOO_BIG_UNSIGNED)?;
+                Ok(d.to_le_bytes().to_vec())
+            }
             host_reg::REG_SZ | host_reg::REG_EXPAND_SZ => {
+                if unsafe { is_none(value) } {
+                    // No string is still a terminated one.
+                    return Ok(vec![0, 0]);
+                }
                 if unsafe { !is_str(value) } {
-                    return Err(crate::PyError::type_error("value must be a string"));
+                    return Err(Py2RegError::Unconvertible);
                 }
                 Ok(encode_utf16z(unsafe { w_str_get_value(value) }))
             }
             host_reg::REG_MULTI_SZ => {
-                let len = unsafe { w_list_len(value) };
+                let len = if unsafe { is_none(value) } {
+                    0
+                } else if unsafe { is_list(value) } {
+                    unsafe { w_list_len(value) }
+                } else {
+                    return Err(Py2RegError::Unconvertible);
+                };
                 let mut out = Vec::new();
                 for i in 0..len {
                     let item = unsafe { w_list_getitem(value, i as i64) };
                     let Some(item) = item else { continue };
                     if unsafe { !is_str(item) } {
-                        return Err(crate::PyError::type_error(
-                            "REG_MULTI_SZ value must be a list of strings",
-                        ));
+                        return Err(Py2RegError::Unconvertible);
                     }
                     let units: Vec<u16> = unsafe { w_str_get_value(item) }.encode_utf16().collect();
                     out.extend(units.iter().flat_map(|u| u.to_le_bytes()));
@@ -377,20 +627,31 @@ mod imp {
                 if unsafe { pyre_object::bytesobject::is_bytes_like(value) } {
                     Ok(unsafe { pyre_object::bytesobject::bytes_like_data(value) }.to_vec())
                 } else {
-                    Err(crate::PyError::type_error("value must be bytes"))
+                    Err(Py2RegError::Raised(crate::PyError::type_error(format!(
+                        "Objects of type '{}' can not be used as binary registry values",
+                        crate::error::type_name_of(value)
+                    ))))
                 }
             }
         }
     }
 
     // ── module functions ──
-    fn open_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        // (key, sub_key, reserved=0, access=KEY_READ)
-        let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-        let key = key_arg(pos, 0)?;
-        let wide = sub_key_wide(pos, 1)?;
-        let reserved = uint_arg(pos, kwargs, 2, "reserved", 0)?;
-        let access = uint_arg(pos, kwargs, 3, "access", host_reg::KEY_READ)?;
+    /// `OpenKey` and `OpenKeyEx` are one implementation under two names, and
+    /// each names itself in what it refuses.
+    fn open_key_named(args: &[PyObjectRef], name: &str) -> Result<PyObjectRef, crate::PyError> {
+        let bound = bind_key_args(args, name, ["key", "sub_key", "reserved", "access"])?;
+        let key = as_hkey(bound[0].expect("key is required"), false)?;
+        let wide = wide_or_empty(opt_text(
+            bound[1].expect("sub_key is required"),
+            name,
+            "'sub_key'",
+        )?);
+        let reserved = bound[2].map(int_arg).transpose()?.unwrap_or(0) as u32;
+        let access = bound[3]
+            .map(dword_arg)
+            .transpose()?
+            .unwrap_or(host_reg::KEY_READ);
         let mut out: HKEY = core::ptr::null_mut();
         let rc = unsafe { host_reg::open_key_ex(key, &wide, reserved, access, &mut out) };
         if rc != 0 {
@@ -399,15 +660,33 @@ mod imp {
         Ok(make_pyhkey(out))
     }
 
+    fn open_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        open_key_named(args, "OpenKey")
+    }
+
+    fn open_key_ex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        open_key_named(args, "OpenKeyEx")
+    }
+
     fn create_key_ex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        // (key, sub_key, reserved=0, access=KEY_WRITE) — `CreateKey`'s form
-        // with the mask to open it under, which is the only way to reach a
-        // 32-bit view (`KEY_WOW64_32KEY`) of a key.
-        let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-        let key = key_arg(pos, 0)?;
-        let wide = sub_key_wide(pos, 1)?;
-        let reserved = uint_arg(pos, kwargs, 2, "reserved", 0)?;
-        let access = uint_arg(pos, kwargs, 3, "access", host_reg::KEY_WRITE)?;
+        // `CreateKey`'s form with the mask to open it under, which is the only
+        // way to reach a 32-bit view (`KEY_WOW64_32KEY`) of a key.
+        let bound = bind_key_args(
+            args,
+            "CreateKeyEx",
+            ["key", "sub_key", "reserved", "access"],
+        )?;
+        let key = as_hkey(bound[0].expect("key is required"), false)?;
+        let wide = wide_or_empty(opt_text(
+            bound[1].expect("sub_key is required"),
+            "CreateKeyEx",
+            "'sub_key'",
+        )?);
+        let reserved = bound[2].map(int_arg).transpose()?.unwrap_or(0) as u32;
+        let access = bound[3]
+            .map(dword_arg)
+            .transpose()?
+            .unwrap_or(host_reg::KEY_WRITE);
         let mut out: HKEY = core::ptr::null_mut();
         let rc = unsafe {
             host_reg::create_key_ex(
@@ -429,43 +708,57 @@ mod imp {
     }
 
     fn delete_key_ex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        // (key, sub_key, access=KEY_WOW64_64KEY, reserved=0) — the access mask
-        // comes before `reserved` here, the other way round from CreateKeyEx.
-        let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-        let key = key_arg(pos, 0)?;
-        let sub_key = req_str(pos, 1)?;
-        let access = uint_arg(pos, kwargs, 2, "access", host_reg::KEY_WOW64_64KEY)?;
-        let reserved = uint_arg(pos, kwargs, 3, "reserved", 0)?;
+        // The access mask comes before `reserved` here, the other way round
+        // from CreateKeyEx.
+        let bound = bind_key_args(
+            args,
+            "DeleteKeyEx",
+            ["key", "sub_key", "access", "reserved"],
+        )?;
+        let key = as_hkey(bound[0].expect("key is required"), false)?;
+        let sub_key = req_text(
+            bound[1].expect("sub_key is required"),
+            "DeleteKeyEx",
+            "'sub_key'",
+        )?;
+        let access = bound[2]
+            .map(dword_arg)
+            .transpose()?
+            .unwrap_or(host_reg::KEY_WOW64_64KEY);
+        let reserved = bound[3].map(int_arg).transpose()?.unwrap_or(0) as u32;
         let wide = WideCString::from_str_truncate(&sub_key);
         check(unsafe { host_reg::delete_key_ex(key, &wide, access, reserved) })
     }
 
     fn load_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        // (key, sub_key, file_name) — restores a hive a `SaveKey` wrote.  Both
-        // it and SaveKey need SE_RESTORE_NAME/SE_BACKUP_NAME, so an ordinary
-        // account gets ERROR_PRIVILEGE_NOT_HELD rather than a result.
-        let key = key_arg(args, 0)?;
-        let sub_key = req_str(args, 1)?;
-        let file_name = req_str(args, 2)?;
+        // Restores a hive a `SaveKey` wrote.  Both it and SaveKey need
+        // SE_RESTORE_NAME/SE_BACKUP_NAME, so an ordinary account gets
+        // ERROR_PRIVILEGE_NOT_HELD rather than a result.
+        let pos = exact_args(args, "LoadKey", 3)?;
+        let key = as_hkey(pos[0], false)?;
+        let sub_key = req_text(pos[1], "LoadKey", "2")?;
+        let file_name = req_text(pos[2], "LoadKey", "3")?;
         let wide_sub = WideCString::from_str_truncate(&sub_key);
         let wide_file = WideCString::from_str_truncate(&file_name);
         check(unsafe { host_reg::load_key(key, &wide_sub, &wide_file) })
     }
 
     fn save_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        // (key, file_name)
-        let key = key_arg(args, 0)?;
-        let file_name = req_str(args, 1)?;
+        let pos = exact_args(args, "SaveKey", 2)?;
+        let key = as_hkey(pos[0], false)?;
+        let file_name = req_text(pos[1], "SaveKey", "2")?;
         let wide = WideCString::from_str_truncate(&file_name);
         check(unsafe { host_reg::save_key(key, &wide) })
     }
 
     fn close_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let obj = arg(args, 0)?;
-        let raw = if unsafe { is_int(obj) } {
-            (unsafe { w_int_get_value(obj) } as usize) as HKEY
-        } else {
+        // `PyHKEY_Close` takes `None` as the null handle, so closing what was
+        // never opened is not an error.
+        let obj = single_arg(args, "CloseKey")?;
+        let raw = if is_pyhkey(obj) {
             take_handle(obj)
+        } else {
+            as_hkey(obj, true)?
         };
         if !raw.is_null() {
             host_reg::close_key(raw);
@@ -475,8 +768,9 @@ mod imp {
 
     fn query_value(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         use rustpython_host_env::winreg::QueryStringError;
-        let key = key_arg(args, 0)?;
-        let sub_key = opt_str(args, 1)?;
+        let pos = exact_args(args, "QueryValue", 2)?;
+        let key = as_hkey(pos[0], false)?;
+        let sub_key = opt_text(pos[1], "QueryValue", "2")?;
         let wide_sub = sub_key.as_deref().map(WideCString::from_str_truncate);
         match host_reg::query_default_value(key, wide_sub.as_deref()) {
             Ok(value) => Ok(w_str_new(&value)),
@@ -488,8 +782,9 @@ mod imp {
     }
 
     fn query_value_ex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let key = key_arg(args, 0)?;
-        let name = opt_str(args, 1)?.unwrap_or_default();
+        let pos = exact_args(args, "QueryValueEx", 2)?;
+        let key = as_hkey(pos[0], false)?;
+        let name = opt_text(pos[1], "QueryValueEx", "2")?.unwrap_or_default();
         match host_reg::query_value_bytes(key, &WideCString::from_str_truncate(&name)) {
             Ok((data, typ)) => Ok(w_tuple_new(vec![reg2py(&data, typ), w_int_new(typ as i64)])),
             Err(code) => Err(win_err(code)),
@@ -497,8 +792,9 @@ mod imp {
     }
 
     fn enum_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let key = key_arg(args, 0)?;
-        let index = req_int(args, 1)? as u32;
+        let pos = exact_args(args, "EnumKey", 2)?;
+        let key = as_hkey(pos[0], false)?;
+        let index = int_arg(pos[1])? as u32;
         // Registry key names are capped at 255 chars (winnt.h MAX_KEY_LENGTH).
         let mut buffer = [0u16; 257];
         let mut len = buffer.len() as u32;
@@ -512,8 +808,9 @@ mod imp {
     }
 
     fn enum_value(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let key = key_arg(args, 0)?;
-        let index = req_int(args, 1)? as u32;
+        let pos = exact_args(args, "EnumValue", 2)?;
+        let key = as_hkey(pos[0], false)?;
+        let index = int_arg(pos[1])? as u32;
         let mut max_name = 0u32;
         let mut max_data = 0u32;
         let rc = unsafe {
@@ -528,40 +825,59 @@ mod imp {
         if rc != 0 {
             return Err(win_err(rc));
         }
-        let mut name = vec![0u16; (max_name + 1) as usize];
-        let mut data = vec![0u8; max_data as usize];
-        let mut name_len = name.len() as u32;
-        let mut data_len = data.len() as u32;
-        let mut typ = 0u32;
-        let data_ptr = if data.is_empty() {
-            core::ptr::null_mut()
-        } else {
-            data.as_mut_ptr()
-        };
-        let rc = unsafe {
-            host_reg::enum_value(
-                key,
-                index,
-                name.as_mut_ptr(),
-                &mut name_len,
-                &mut typ,
-                data_ptr,
-                &mut data_len,
-            )
-        };
-        if rc != 0 {
-            return Err(win_err(rc));
+        // The two lengths the key reports leave no room for the terminators,
+        // and a key whose values change size under the enumeration — the
+        // performance hive is one, reporting nothing and answering megabytes —
+        // reports neither. `ERROR_MORE_DATA` is the answer to a buffer too
+        // small, and the data one doubles until the value fits.
+        let mut buf_name_size = max_name + 1;
+        let mut buf_data_size = max_data + 1;
+        let mut name = vec![0u16; buf_name_size as usize];
+        let mut data = vec![0u8; buf_data_size as usize];
+        loop {
+            let mut name_len = buf_name_size;
+            let mut data_len = buf_data_size;
+            let mut typ = 0u32;
+            let rc = unsafe {
+                host_reg::enum_value(
+                    key,
+                    index,
+                    name.as_mut_ptr(),
+                    &mut name_len,
+                    &mut typ,
+                    data.as_mut_ptr(),
+                    &mut data_len,
+                )
+            };
+            if rc == windows_sys::Win32::Foundation::ERROR_MORE_DATA {
+                buf_data_size = buf_data_size
+                    .checked_mul(2)
+                    .ok_or_else(|| win_err(windows_sys::Win32::Foundation::ERROR_MORE_DATA))?;
+                data.resize(buf_data_size as usize, 0);
+                continue;
+            }
+            if rc != 0 {
+                return Err(win_err(rc));
+            }
+            // `Py_BuildValue("uOi", retValueBuf, …)` reads the name up to
+            // its terminator rather than to the length the call reports back,
+            // which a key that enumerates without a reliable count -- the
+            // performance hive is one -- spells one character short.
+            let end = name
+                .iter()
+                .position(|&unit| unit == 0)
+                .unwrap_or(name.len());
+            let name_s = String::from_utf16_lossy(&name[..end]);
+            return Ok(w_tuple_new(vec![
+                w_str_new(&name_s),
+                reg2py(&data[..data_len as usize], typ),
+                w_int_new(typ as i64),
+            ]));
         }
-        let name_s = String::from_utf16_lossy(&name[..name_len as usize]);
-        Ok(w_tuple_new(vec![
-            w_str_new(&name_s),
-            reg2py(&data[..data_len as usize], typ),
-            w_int_new(typ as i64),
-        ]))
     }
 
     fn query_info_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let key = key_arg(args, 0)?;
+        let key = as_hkey(single_arg(args, "QueryInfoKey")?, false)?;
         match host_reg::query_info_key_full(key) {
             Ok(info) => Ok(w_tuple_new(vec![
                 w_int_new(info.sub_keys as i64),
@@ -573,12 +889,16 @@ mod imp {
     }
 
     fn flush_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        check(host_reg::flush_key(key_arg(args, 0)?))
+        check(host_reg::flush_key(as_hkey(
+            single_arg(args, "FlushKey")?,
+            false,
+        )?))
     }
 
     fn create_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let key = key_arg(args, 0)?;
-        let wide = sub_key_wide(args, 1)?;
+        let pos = exact_args(args, "CreateKey", 2)?;
+        let key = as_hkey(pos[0], false)?;
+        let wide = wide_or_empty(opt_text(pos[1], "CreateKey", "2")?);
         let mut out: HKEY = core::ptr::null_mut();
         let rc = unsafe { host_reg::create_key(key, &wide, &mut out) };
         if rc != 0 {
@@ -588,14 +908,17 @@ mod imp {
     }
 
     fn set_value(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        // (key, sub_key, type, value) — SetValue only writes REG_SZ.
-        let key = key_arg(args, 0)?;
-        let sub_key = opt_str(args, 1)?.unwrap_or_default();
-        let typ = req_int(args, 2)? as u32;
+        // SetValue only writes REG_SZ, and the type is read before it is
+        // judged, so a non-integer is an integer's complaint rather than the
+        // wrong-type one.
+        let pos = exact_args(args, "SetValue", 4)?;
+        let key = as_hkey(pos[0], false)?;
+        let sub_key = opt_text(pos[1], "SetValue", "2")?.unwrap_or_default();
+        let typ = dword_arg(pos[2])?;
         if typ != host_reg::REG_SZ {
-            return Err(crate::PyError::type_error("Type must be winreg.REG_SZ"));
+            return Err(crate::PyError::type_error("type must be winreg.REG_SZ"));
         }
-        let value = req_str(args, 3)?;
+        let value = req_text(pos[3], "SetValue", "4")?;
         check(host_reg::set_default_value(
             key,
             &WideCString::from_str_truncate(&sub_key),
@@ -605,11 +928,18 @@ mod imp {
     }
 
     fn set_value_ex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        // (key, value_name, reserved, type, value)
-        let key = key_arg(args, 0)?;
-        let name = opt_str(args, 1)?;
-        let typ = req_int(args, 3)? as u32;
-        let data = py2reg(arg(args, 4)?, typ)?;
+        let pos = exact_args(args, "SetValueEx", 5)?;
+        let key = as_hkey(pos[0], false)?;
+        let name = opt_text(pos[1], "SetValueEx", "2")?;
+        // `reserved` is documented as "can be anything" and zero is what
+        // reaches the API, so it is read but not converted.
+        let typ = dword_arg(pos[3])?;
+        let data = py2reg(pos[4], typ).map_err(|error| match error {
+            Py2RegError::Raised(error) => error,
+            Py2RegError::Unconvertible => {
+                crate::PyError::value_error("Could not convert the data to the specified type.")
+            }
+        })?;
         let wide_name = name.as_deref().map(WideCString::from_str_truncate);
         let rc = unsafe {
             host_reg::set_value_ex(
@@ -627,23 +957,25 @@ mod imp {
     }
 
     fn delete_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let key = key_arg(args, 0)?;
-        let sub_key = req_str(args, 1)?;
+        let pos = exact_args(args, "DeleteKey", 2)?;
+        let key = as_hkey(pos[0], false)?;
+        let sub_key = req_text(pos[1], "DeleteKey", "2")?;
         let wide = WideCString::from_str_truncate(&sub_key);
         check(unsafe { host_reg::delete_key(key, &wide) })
     }
 
     fn delete_value(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let key = key_arg(args, 0)?;
-        let name = opt_str(args, 1)?;
+        let pos = exact_args(args, "DeleteValue", 2)?;
+        let key = as_hkey(pos[0], false)?;
+        let name = opt_text(pos[1], "DeleteValue", "2")?;
         let wide_name = name.as_deref().map(WideCString::from_str_truncate);
         check(unsafe { host_reg::delete_value(key, wide_name.as_deref()) })
     }
 
     fn connect_registry(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        // (computer_name, key)
-        let computer = opt_str(args, 0)?;
-        let key = key_arg(args, 1)?;
+        let pos = exact_args(args, "ConnectRegistry", 2)?;
+        let computer = opt_text(pos[0], "ConnectRegistry", "1")?;
+        let key = as_hkey(pos[1], false)?;
         let wide = computer.as_deref().map(WideCString::from_str_truncate);
         let mut out: HKEY = core::ptr::null_mut();
         let rc = unsafe { host_reg::connect_registry(wide.as_deref(), key, &mut out) };
@@ -655,7 +987,13 @@ mod imp {
 
     fn expand_environment_strings(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         use rustpython_host_env::winreg::ExpandEnvironmentStringsError;
-        let input = req_str(args, 0)?;
+        // The only boundary whose refusal names neither a parameter nor a
+        // position, because it has just the one argument.
+        let input = req_text(
+            single_arg(args, "ExpandEnvironmentStrings")?,
+            "ExpandEnvironmentStrings",
+            "",
+        )?;
         match host_reg::expand_environment_strings(&WideCString::from_str_truncate(&input)) {
             Ok(value) => Ok(w_str_new(&value)),
             Err(ExpandEnvironmentStringsError::Os) => Err(win_err(
@@ -668,15 +1006,21 @@ mod imp {
     }
 
     fn disable_reflection_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        check(host_reg::disable_reflection_key(key_arg(args, 0)?))
+        check(host_reg::disable_reflection_key(as_hkey(
+            single_arg(args, "DisableReflectionKey")?,
+            false,
+        )?))
     }
 
     fn enable_reflection_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        check(host_reg::enable_reflection_key(key_arg(args, 0)?))
+        check(host_reg::enable_reflection_key(as_hkey(
+            single_arg(args, "EnableReflectionKey")?,
+            false,
+        )?))
     }
 
     fn query_reflection_key(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let key = key_arg(args, 0)?;
+        let key = as_hkey(single_arg(args, "QueryReflectionKey")?, false)?;
         let mut disabled: i32 = 0;
         let rc = unsafe { host_reg::query_reflection_key(key, &mut disabled) };
         if rc != 0 {
@@ -689,6 +1033,32 @@ mod imp {
         // The handle type is bound under one name only: the class calls itself
         // `PyHKEY`, and `winreg` publishes it as `HKEYType`.
         crate::module_ns_store(ns, "HKEYType", type_object());
+        // `Py_tp_doc`, and the signature line clinic writes ahead of each
+        // `PyHKEY_methods` docstring. The type has just been built by the line
+        // above and nothing has read it yet, so the class dict takes them
+        // directly.
+        unsafe {
+            let ty = type_object();
+            let class_ns = pyre_object::w_type_get_dict_ptr(ty) as PyObjectRef;
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                class_ns,
+                "__doc__",
+                w_str_new(
+                    "PyHKEY Object - A Python object, representing a win32 registry key.\n\nThis object wraps a Windows HKEY object, automatically closing it when\nthe object is destroyed.  To guarantee cleanup, you can call either\nthe Close() method on the PyHKEY, or the CloseKey() method.\n\nAll functions which accept a handle object also accept an integer --\nhowever, use of the handle object is encouraged.\n\nFunctions:\nClose() - Closes the underlying handle.\nDetach() - Returns the integer Win32 handle, detaching it from the object\n\nProperties:\nhandle - The integer Win32 handle.\n\nOperations:\n__bool__ - Handles with an open object return true, otherwise false.\n__int__ - Converting a handle to an integer returns the Win32 handle.\n__enter__, __exit__ - Context manager support for 'with' statement,\nautomatically closes handle.",
+                ),
+            );
+            for (method, signature) in [
+                ("Close", "($self, /)"),
+                ("Detach", "($self, /)"),
+                ("__enter__", "($self, /)"),
+                ("__exit__", "($self, exc_type, exc_value, traceback, /)"),
+            ] {
+                let Some(function) = pyre_object::w_dict_getitem_str(class_ns, method) else {
+                    continue;
+                };
+                crate::function::fset_func_text_signature(function, w_str_new(signature));
+            }
+        }
         // `winreg.error` is `OSError` itself rather than a module-specific
         // class, so `except winreg.error` catches what the Reg* calls raise.
         if let Some(os_error) = crate::builtins::lookup_exc_class("OSError") {
@@ -708,35 +1078,157 @@ mod imp {
         ] {
             crate::module_ns_store(ns, name, int_from_ptr(root));
         }
-        for (name, func) in [
+        // Each call carries the clinic's own signature line and
+        // docstring, which is what `help(winreg.X)` and
+        // `inspect.signature` read back.
+        for (name, func, signature, doc) in [
             (
                 "OpenKey",
                 open_key as fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>,
+                "($module, /, key, sub_key, reserved=0, access=winreg.KEY_READ)",
+                "Opens the specified key.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n  sub_key\n    A string that identifies the sub_key to open.\n  reserved\n    A reserved integer that must be zero.  Default is zero.\n  access\n    An integer that specifies an access mask that describes the desired\n    security access for the key.  Default is KEY_READ.\n\nThe result is a new handle to the specified key.\nIf the function fails, an OSError exception is raised.",
             ),
-            ("OpenKeyEx", open_key),
-            ("CreateKeyEx", create_key_ex),
-            ("DeleteKeyEx", delete_key_ex),
-            ("LoadKey", load_key),
-            ("SaveKey", save_key),
-            ("CloseKey", close_key),
-            ("QueryValue", query_value),
-            ("QueryValueEx", query_value_ex),
-            ("EnumKey", enum_key),
-            ("EnumValue", enum_value),
-            ("QueryInfoKey", query_info_key),
-            ("FlushKey", flush_key),
-            ("CreateKey", create_key),
-            ("SetValue", set_value),
-            ("SetValueEx", set_value_ex),
-            ("DeleteKey", delete_key),
-            ("DeleteValue", delete_value),
-            ("ConnectRegistry", connect_registry),
-            ("ExpandEnvironmentStrings", expand_environment_strings),
-            ("DisableReflectionKey", disable_reflection_key),
-            ("EnableReflectionKey", enable_reflection_key),
-            ("QueryReflectionKey", query_reflection_key),
+            (
+                "OpenKeyEx",
+                open_key_ex,
+                "($module, /, key, sub_key, reserved=0, access=winreg.KEY_READ)",
+                "Opens the specified key.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n  sub_key\n    A string that identifies the sub_key to open.\n  reserved\n    A reserved integer that must be zero.  Default is zero.\n  access\n    An integer that specifies an access mask that describes the desired\n    security access for the key.  Default is KEY_READ.\n\nThe result is a new handle to the specified key.\nIf the function fails, an OSError exception is raised.",
+            ),
+            (
+                "CreateKeyEx",
+                create_key_ex,
+                "($module, /, key, sub_key, reserved=0,\n            access=winreg.KEY_WRITE)",
+                "Creates or opens the specified key.\n\n  key\n    An already open key, or one of the predefined HKEY_* constants.\n  sub_key\n    The name of the key this method opens or creates.\n  reserved\n    A reserved integer, and must be zero.  Default is zero.\n  access\n    An integer that specifies an access mask that describes the\n    desired security access for the key. Default is KEY_WRITE.\n\nIf key is one of the predefined keys, sub_key may be None. In that case,\nthe handle returned is the same key handle passed in to the function.\n\nIf the key already exists, this function opens the existing key\n\nThe return value is the handle of the opened key.\nIf the function fails, an OSError exception is raised.",
+            ),
+            (
+                "DeleteKeyEx",
+                delete_key_ex,
+                "($module, /, key, sub_key, access=winreg.KEY_WOW64_64KEY,\n            reserved=0)",
+                "Deletes the specified key (intended for 64-bit OS).\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n  sub_key\n    A string that must be the name of a subkey of the key identified by\n    the key parameter. This value must not be None, and the key may not\n    have subkeys.\n  access\n    An integer that specifies an access mask that describes the\n    desired security access for the key. Default is KEY_WOW64_64KEY.\n  reserved\n    A reserved integer, and must be zero.  Default is zero.\n\nWhile this function is intended to be used for 64-bit OS, it is also\n available on 32-bit systems.\n\nThis method can not delete keys with subkeys.\n\nIf the function succeeds, the entire key, including all of its values,\nis removed.  If the function fails, an OSError exception is raised.\nOn unsupported Windows versions, NotImplementedError is raised.",
+            ),
+            (
+                "LoadKey",
+                load_key,
+                "($module, key, sub_key, file_name, /)",
+                "Insert data into the registry from a file.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n  sub_key\n    A string that identifies the sub-key to load.\n  file_name\n    The name of the file to load registry data from.  This file must\n    have been created with the SaveKey() function.  Under the file\n    allocation table (FAT) file system, the filename may not have an\n    extension.\n\nCreates a subkey under the specified key and stores registration\ninformation from a specified file into that subkey.\n\nA call to LoadKey() fails if the calling process does not have the\nSE_RESTORE_PRIVILEGE privilege.\n\nIf key is a handle returned by ConnectRegistry(), then the path\nspecified in fileName is relative to the remote computer.\n\nThe MSDN docs imply key must be in the HKEY_USER or HKEY_LOCAL_MACHINE\ntree.",
+            ),
+            (
+                "SaveKey",
+                save_key,
+                "($module, key, file_name, /)",
+                "Saves the specified key, and all its subkeys to the specified file.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n  file_name\n    The name of the file to save registry data to.  This file cannot\n    already exist. If this filename includes an extension, it cannot be\n    used on file allocation table (FAT) file systems by the LoadKey(),\n    ReplaceKey() or RestoreKey() methods.\n\nIf key represents a key on a remote computer, the path described by\nfile_name is relative to the remote computer.\n\nThe caller of this method must possess the SeBackupPrivilege\nsecurity privilege.  This function passes NULL for security_attributes\nto the API.",
+            ),
+            (
+                "CloseKey",
+                close_key,
+                "($module, hkey, /)",
+                "Closes a previously opened registry key.\n\n  hkey\n    A previously opened key.\n\nNote that if the key is not closed using this method, it will be\nclosed when the hkey object is destroyed by Python.",
+            ),
+            (
+                "QueryValue",
+                query_value,
+                "($module, key, sub_key, /)",
+                "Retrieves the unnamed value for a key.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n  sub_key\n    A string that holds the name of the subkey with which the value\n    is associated.  If this parameter is None or empty, the function\n    retrieves the value set by the SetValue() method for the key\n    identified by key.\n\nValues in the registry have name, type, and data components. This method\nretrieves the data for a key's first value that has a NULL name.\nBut since the underlying API call doesn't return the type, you'll\nprobably be happier using QueryValueEx; this function is just here for\ncompleteness.",
+            ),
+            (
+                "QueryValueEx",
+                query_value_ex,
+                "($module, key, name, /)",
+                "Retrieves the type and value of a specified sub-key.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n  name\n    A string indicating the value to query.\n\nBehaves mostly like QueryValue(), but also returns the type of the\nspecified value name associated with the given open registry key.\n\nThe return value is a tuple of the value and the type_id.",
+            ),
+            (
+                "EnumKey",
+                enum_key,
+                "($module, key, index, /)",
+                "Enumerates subkeys of an open registry key.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n  index\n    An integer that identifies the index of the key to retrieve.\n\nThe function retrieves the name of one subkey each time it is called.\nIt is typically called repeatedly until an OSError exception is\nraised, indicating no more values are available.",
+            ),
+            (
+                "EnumValue",
+                enum_value,
+                "($module, key, index, /)",
+                "Enumerates values of an open registry key.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n  index\n    An integer that identifies the index of the value to retrieve.\n\nThe function retrieves the name of one subkey each time it is called.\nIt is typically called repeatedly, until an OSError exception\nis raised, indicating no more values.\n\nThe result is a tuple of 3 items:\n  value_name\n    A string that identifies the value.\n  value_data\n    An object that holds the value data, and whose type depends\n    on the underlying registry type.\n  data_type\n    An integer that identifies the type of the value data.",
+            ),
+            (
+                "QueryInfoKey",
+                query_info_key,
+                "($module, key, /)",
+                "Returns information about a key.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n\nThe result is a tuple of 3 items:\nAn integer that identifies the number of sub keys this key has.\nAn integer that identifies the number of values this key has.\nAn integer that identifies when the key was last modified (if available)\nas 100's of nanoseconds since Jan 1, 1600.",
+            ),
+            (
+                "FlushKey",
+                flush_key,
+                "($module, key, /)",
+                "Writes all the attributes of a key to the registry.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n\nIt is not necessary to call FlushKey to change a key.  Registry changes\nare flushed to disk by the registry using its lazy flusher.  Registry\nchanges are also flushed to disk at system shutdown.  Unlike\nCloseKey(), the FlushKey() method returns only when all the data has\nbeen written to the registry.\n\nAn application should only call FlushKey() if it requires absolute\ncertainty that registry changes are on disk.  If you don't know whether\na FlushKey() call is required, it probably isn't.",
+            ),
+            (
+                "CreateKey",
+                create_key,
+                "($module, key, sub_key, /)",
+                "Creates or opens the specified key.\n\n  key\n    An already open key, or one of the predefined HKEY_* constants.\n  sub_key\n    The name of the key this method opens or creates.\n\nIf key is one of the predefined keys, sub_key may be None. In that case,\nthe handle returned is the same key handle passed in to the function.\n\nIf the key already exists, this function opens the existing key.\n\nThe return value is the handle of the opened key.\nIf the function fails, an OSError exception is raised.",
+            ),
+            (
+                "SetValue",
+                set_value,
+                "($module, key, sub_key, type, value, /)",
+                "Associates a value with a specified key.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n  sub_key\n    A string that names the subkey with which the value is associated.\n  type\n    An integer that specifies the type of the data.  Currently this must\n    be REG_SZ, meaning only strings are supported.\n  value\n    A string that specifies the new value.\n\nIf the key specified by the sub_key parameter does not exist, the\nSetValue function creates it.\n\nValue lengths are limited by available memory. Long values (more than\n2048 bytes) should be stored as files with the filenames stored in\nthe configuration registry to help the registry perform efficiently.\n\nThe key identified by the key parameter must have been opened with\nKEY_SET_VALUE access.",
+            ),
+            (
+                "SetValueEx",
+                set_value_ex,
+                "($module, key, value_name, reserved, type, value, /)",
+                "Stores data in the value field of an open registry key.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n  value_name\n    A string containing the name of the value to set, or None.\n  reserved\n    Can be anything - zero is always passed to the API.\n  type\n    An integer that specifies the type of the data, one of:\n    REG_BINARY -- Binary data in any form.\n    REG_DWORD -- A 32-bit number.\n    REG_DWORD_LITTLE_ENDIAN -- A 32-bit number in little-endian format. Equivalent to REG_DWORD\n    REG_DWORD_BIG_ENDIAN -- A 32-bit number in big-endian format.\n    REG_EXPAND_SZ -- A null-terminated string that contains unexpanded\n                     references to environment variables (for example,\n                     %PATH%).\n    REG_LINK -- A Unicode symbolic link.\n    REG_MULTI_SZ -- A sequence of null-terminated strings, terminated\n                    by two null characters.  Note that Python handles\n                    this termination automatically.\n    REG_NONE -- No defined value type.\n    REG_QWORD -- A 64-bit number.\n    REG_QWORD_LITTLE_ENDIAN -- A 64-bit number in little-endian format. Equivalent to REG_QWORD.\n    REG_RESOURCE_LIST -- A device-driver resource list.\n    REG_SZ -- A null-terminated string.\n  value\n    A string that specifies the new value.\n\nThis method can also set additional value and type information for the\nspecified key.  The key identified by the key parameter must have been\nopened with KEY_SET_VALUE access.\n\nTo open the key, use the CreateKeyEx() or OpenKeyEx() methods.\n\nValue lengths are limited by available memory. Long values (more than\n2048 bytes) should be stored as files with the filenames stored in\nthe configuration registry to help the registry perform efficiently.",
+            ),
+            (
+                "DeleteKey",
+                delete_key,
+                "($module, key, sub_key, /)",
+                "Deletes the specified key.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n  sub_key\n    A string that must be the name of a subkey of the key identified by\n    the key parameter. This value must not be None, and the key may not\n    have subkeys.\n\nThis method can not delete keys with subkeys.\n\nIf the function succeeds, the entire key, including all of its values,\nis removed.  If the function fails, an OSError exception is raised.",
+            ),
+            (
+                "DeleteValue",
+                delete_value,
+                "($module, key, value, /)",
+                "Removes a named value from a registry key.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n  value\n    A string that identifies the value to remove.",
+            ),
+            (
+                "ConnectRegistry",
+                connect_registry,
+                "($module, computer_name, key, /)",
+                "Establishes a connection to the registry on another computer.\n\n  computer_name\n    The name of the remote computer, of the form r\"\\\\computername\".  If\n    None, the local computer is used.\n  key\n    The predefined key to connect to.\n\nThe return value is the handle of the opened key.\nIf the function fails, an OSError exception is raised.",
+            ),
+            (
+                "ExpandEnvironmentStrings",
+                expand_environment_strings,
+                "($module, string, /)",
+                "Expand environment vars.",
+            ),
+            (
+                "DisableReflectionKey",
+                disable_reflection_key,
+                "($module, key, /)",
+                "Disables registry reflection for 32bit processes running on a 64bit OS.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n\nWill generally raise NotImplementedError if executed on a 32bit OS.\n\nIf the key is not on the reflection list, the function succeeds but has\nno effect.  Disabling reflection for a key does not affect reflection\nof any subkeys.",
+            ),
+            (
+                "EnableReflectionKey",
+                enable_reflection_key,
+                "($module, key, /)",
+                "Restores registry reflection for the specified disabled key.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n\nWill generally raise NotImplementedError if executed on a 32bit OS.\nRestoring reflection for a key does not affect reflection of any\nsubkeys.",
+            ),
+            (
+                "QueryReflectionKey",
+                query_reflection_key,
+                "($module, key, /)",
+                "Returns the reflection state for the specified key as a bool.\n\n  key\n    An already open key, or any one of the predefined HKEY_* constants.\n\nWill generally raise NotImplementedError if executed on a 32bit OS.",
+            ),
         ] {
-            crate::module_ns_store(ns, name, crate::make_builtin_function(name, func));
+            let function = crate::make_builtin_function_with_doc(name, func, doc);
+            unsafe {
+                crate::function::fset_func_text_signature(
+                    function,
+                    pyre_object::w_str_new(signature),
+                );
+            }
+            crate::module_ns_store(ns, name, function);
         }
     }
 }


### PR DESCRIPTION
Five commits, all Windows: the ten `_path_*` helpers `ntpath` imports, the
`winreg` argument layer and clinic surface, the Windows members of
`stat_result`, the `spawnv`/`spawnve` pair with the `waitpid` status they feed,
`win32_wchdir`, and two smaller answers.

### `posix: port _Py_skiproot and _Py_normpath_and_size, and register the ten _path_* helpers`

`ntpath` imports eleven names from `nt` and pyre carried one, so every other
import fell back to the Python path beside it. `_path_splitroot_ex` and
`_path_normpath` are line-by-line ports operating on UTF-16 units, registered on
every platform; Windows also gains the six `_path_is*` predicates,
`_path_exists`, `_path_lexists` and `_getvolumepathname`, all with `__doc__` and
`__text_signature__`. Four unit tests cover the two ports over 106 cases each.

### `interpreter: let a py_class! method carry its docstring`

`py_class!`'s `methods:` arm takes a `#[doc = "..."]` attribute and passes it to
a new `make_builtin_function_with_opt_doc`, so a method's `__doc__` is attached
where the method is written. Stamping it afterwards cannot work: `__doc__` on a
builtin function goes through `_check_code_mutable`, which refuses.

### `winreg: rework the argument layer and publish the clinic surface`

The 23 module functions bind their arguments through one shared layer.
`OpenKey`, `OpenKeyEx`, `CreateKeyEx` and `DeleteKeyEx` take `key`, `sub_key`,
`reserved` and `access` by keyword, and the refusals come in
`_PyArg_UnpackKeywords`' order. Every function is registered with the signature
line and docstring the clinic generates. `PyHKEY` gains `__str__`, a `handle`
property, and the type docstring. `EnumValue` retries on `ERROR_MORE_DATA` and
reads a value name up to its terminator rather than to the length the call
reports back. `Reg2Py` keeps the empty strings inside a `REG_MULTI_SZ` block;
`Py2Reg` range-checks `REG_DWORD` and `REG_QWORD`.

`handle` stays the `GetSetProperty` `interp_winreg.py` declares, so it answers
the whole handle and its descriptor is a `getset_descriptor`; `winreg.c` spells
it a read-only `Py_T_INT` member, which truncates and names a `member_descriptor`.

`test_winreg`: 1F/11E → OK (skipped=6), and the surface is otherwise identical
to CPython 3.14.2's for a scripted probe of all 23 functions.

### `builtins: turn away a None __fspath__ in open()`

A `__fspath__` left as `None` switches the protocol off the way `__hash__ =
None` does.

### `posix: fill in the Windows stat_result members, the spawn pair and eight adjacent answers`

- `stat_result` gains `st_file_attributes`, `st_reparse_tag`, `st_birthtime`
  and `st_birthtime_ns`, as instance values *and* as structseq names —
  `shutil` picks `_rmtree_islink` off `hasattr(os.stat_result,
  'st_file_attributes')`.
- `st_ino` is the whole 128-bit file id. A volume that numbers its files above
  2\*\*64 leaves the low word at zero for every directory, so `samestat` used to
  call any two of them the same file.
- `DirEntry.is_junction` answers from the lstat's reparse tag.
- `readlink` reads the substitute name out of the `FSCTL_GET_REPARSE_POINT`
  buffer, so a junction's target keeps its `\\?\` prefix.
- `chmod` defaults `follow_symlinks` to false, which is
  `CHMOD_DEFAULT_FOLLOW_SYMLINKS`.
- `putenv`/`unsetenv` reject an entry longer than `_MAX_ENV`.
- `chdir` is `win32_wchdir`: it publishes the directory it read back under
  `=X:`, and `spawnve`/`execve` publish the same entry before handing an
  environment over where the process holds none. That entry is load-bearing
  beyond the drive it names — `construct_environment_block`
  (ucrt `exec/cenvarg.cpp`), which `_wspawnve` and `_wexecve` both reach, finds
  the first `=`-prefixed entry with `while (*it != '=') it += tcslen(it) + 1;`
  and there is no bound on that walk, so an environment carrying none of them
  sends it past the block's terminator and through the heap until it reaches an
  unmapped page. Only the command shell writes those entries, so `os.spawnve`
  faulted about one run in three before this. CPython 3.14.2 has the identical
  exposure on the same host (15/15 with an empty `envp`); the entry is what
  keeps its own suite alive, because an earlier test chdirs.
- `spawnv`/`spawnve` were no-op stubs and now call `_wspawnv`/`_wspawnve`, with
  `os_spawnv_impl`'s refusal order and wordings.
- `waitpid` reports `(unsigned int)status`, so an exit code above `INT_MAX`
  comes back positive, and `waitstatus_to_exitcode` is implemented here rather
  than answering `None`.
- `fsync` takes its argument as `fildes`.

`test_os`: 13F/5E → 2F.

## Suites on this host

| suite | before | after |
|---|---|---|
| test_winreg | 1F / 11E | **OK** (skipped=6) |
| test_os | 13F / 5E | 2F |
| test_shutil | 14F | **OK** (skipped=55) |
| test_posixpath | — | **OK** (skipped=24) |
| test_ntpath | — | **OK** (skipped=3) |
| test_msvcrt | — | **OK** (skipped=3) |
| test_nturl2path | — | **OK** |
| test_winapi | — | **OK** |
| test_zipfile | — | 1-2F (flaky, see below) |
| test_mmap | 40E | 40E (untouched) |
| test_tempfile | 1F / 2E | 1F / 1E |

## Not fixed, and why

- **`test_os.TestScandir.test_removed_dir` / `test_removed_file`** — on Windows
  a `DirEntry` caches the `WIN32_FIND_DATA` the enumeration already reported
  (`win32_lstat` on the entry), so `is_dir()`, `is_file()` and `stat()` keep
  answering after the name is removed. pyre's `DirEntry` carries only the
  enumeration's `d_type`, which the Windows arm leaves `DT_UNKNOWN`, and stats
  the name on every query. Filling the cache means routing the Windows arm
  through the find data instead of `read_dir`, which is its own change.
- **`test_tempfile.TestMktemp.test_basic` /
  `TestTemporaryDirectory.test_warnings_on_cleanup`** — both wait on a file
  object being finalised at the moment its last reference goes, which a tracing
  collector does not promise.
- **`test_winconsoleio`** — imports `_testconsole`, an extension module built
  only by CPython's own build.
- **`st_dev` is truncated to 32 bits** — `host_env`'s `StatStruct.st_dev` is a
  `libc::c_ulong`, so the volume serial number loses its upper half. Widening it
  is a change to an external dependency.
- **`execv() arg 2 must be an iterable of strings`** — upstream says `must be a
  tuple or list` and takes neither anything else nor an iterator. Pre-existing,
  and `os.execv` is not what this branch is about.
- **`os.spawnv` and `os.spawnve` carry no `__doc__` or `__text_signature__`,
  and take no keyword** — neither does any other function in this module; the
  arity layer they register through is positional-only.
- **`test_mmap`, 40 errors** — every one is a `PermissionError` on a test file
  the previous test left open, which is the finaliser-timing cascade a tracing
  collector produces. Nothing in this branch touches it.
- **`test_zipfile.DeflateTestsWithRandomBinaryFiles.test_open` and
  `DeflateTestsWithSourceFile.test_readline_read`** — a
  `while True: fp.read(256)` loop over a `ZipExtFile` loses a run of bytes out
  of the middle of the member: 101155 bytes of 101376 in the binary case, and
  the text case steps straight from line 534 to line 537. It needs the whole
  module's warm-up. The two classes on their own pass 3/3; the full module
  failed 5 of 6 runs; `PYRE_JIT=0` passes 3/3. So it is the compiled loop
  rather than `zipfile`, and nothing in this branch touches `zipfile`, `zlib`
  or `io`. `cpython_tests/baseline.json` already records `test.test_zipfile`
  as `FAIL`. Attributing it to a commit needs a build at the base, which this
  run did not make.

## Gates

All green on this host:

- `cargo fmt --all -- --check`
- `scripts/check-new-line-citations.py --base 9cd072d663` -- 2344 added Rust
  lines, no line-number citations
- `cargo test --all --no-default-features --features dynasm,cpyext` -- 168
  blocks, 8123 passed, 0 failed
- cold `check.py --backend dynasm --no-build` (`lib-python/3` `__pycache__`
  cleared first) -- `ALL PASSED: dynasm 456/456`; no baseline was re-recorded

The branch is based on `9cd072d663`; `main` moved ten commits ahead while this
was in flight, so it wants a rebase before it lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filesystem path handling, including surrogate characters, embedded null bytes, and disabled path protocols.
  * Corrected Windows and POSIX path normalization, metadata, directory scanning, and process behavior.
  * Improved registry handle validation, integer preservation, string decoding, and buffer handling.

* **Enhancements**
  * Expanded Windows filesystem, process, junction, and registry compatibility.
  * Improved function signatures, documentation, argument validation, and Python-compatible error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->