### PR TITLE
error: port OperationError's traceback accessors onto PyError

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1526,8 +1526,13 @@ pub fn get_awaitable_iter(w_obj: PyObjectRef, context: u32) -> PyResult {
 /// user `__getattribute__`/`__getattr__` does not run), then bound and called.
 /// A missing `__set_name__` is a no-op.  When the call raises, the original
 /// exception is re-raised with an `"Error calling __set_name__ ..."` note
-/// attached (PEP 678), mirroring `_PyErr_FormatNote`.
-fn add_internal_exception_note(error: &mut PyError, text: &str) -> Result<(), PyError> {
+/// attached (PEP 678) by [`add_internal_exception_note`].
+///
+/// `_PyErr_FormatNote` — attach `text` to `error` as a PEP 678 note and leave
+/// the error itself otherwise untouched, so the caller re-raises the original
+/// with one more line of context under it.  Callers pass the message CPython
+/// formats at the corresponding site.
+pub(crate) fn add_internal_exception_note(error: &mut PyError, text: &str) -> Result<(), PyError> {
     // CPython 3.14 `_PyException_AddNote` writes the exception's `__notes__`
     // list directly.  It does not dispatch through a Python override of
     // `add_note`; this is interpreter bookkeeping, not a method call.

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -425,6 +425,24 @@ pub struct PyError {
 /// traceback, or context state.
 pub type OperationError = PyError;
 
+/// Whether `co_filename` names one of the modules
+/// [`PyError::remove_traceback_module_frames`] was asked to drop.
+///
+/// A name matches outright, as upstream's `co_filename not in module_names`
+/// does, and also matches as a trailing path component: upstream's callers
+/// name frozen modules, whose `co_filename` is the fixed `<frozen ...>`
+/// pseudo-name, while the same module read from disk carries an
+/// installation-dependent absolute path that no fixed string can spell.
+fn traceback_frame_names_module(co_filename: &str, module_names: &[&str]) -> bool {
+    let normalized = co_filename.replace('\\', "/");
+    module_names.iter().any(|name| {
+        normalized == *name
+            || (normalized.len() > name.len()
+                && normalized.ends_with(name)
+                && normalized.as_bytes()[normalized.len() - name.len() - 1] == b'/')
+    })
+}
+
 /// [`PyError::to_exc_object`] behind the residual-call ABI:
 /// one pointer in, one pointer out, and a body the codewriter does not
 /// look inside.
@@ -1557,6 +1575,194 @@ impl PyError {
         }
         self.exc_object = w_value;
         Ok(w_value)
+    }
+
+    /// `error.py` — `OperationError.get_traceback`:
+    ///
+    /// ```python
+    /// def get_traceback(self):
+    ///     tb = self._application_traceback
+    ///     if tb is not None and isinstance(tb, PyTraceback):
+    ///         tb.frame.mark_as_escaped()
+    ///     return tb
+    /// ```
+    ///
+    /// Upstream keeps the chain head in an `_application_traceback` field
+    /// beside `_w_value`, so it can answer while `_w_value` is still `None`.
+    /// This carrier keeps it on the materialised instance's `w_traceback`
+    /// slot instead, for the reason [`to_exc_object`] exists at all: a
+    /// propagating Rust `PyError` is memcpy'd at every `?` and so cannot be
+    /// registered as a GC root, while the instance can — `set_in_flight_exception`
+    /// publishes it and the collector then reaches the whole chain through it.
+    /// An unmaterialised error therefore has no chain to report, which is the
+    /// same answer upstream's `None` gives: nothing has recorded a frame yet.
+    ///
+    /// Reading marks the head frame escaped, upstream's documented side
+    /// effect — see [`crate::pytraceback::mark_traceback_escaped`] for which
+    /// single-frame case that covers.
+    pub fn get_traceback(&self) -> PyObjectRef {
+        let tb = self.application_traceback();
+        unsafe { crate::pytraceback::mark_traceback_escaped(tb) };
+        tb
+    }
+
+    /// The `_application_traceback` field read itself, without
+    /// [`get_traceback`](Self::get_traceback)'s escape mark.  Upstream reads
+    /// the field directly wherever the chain must not escape, and goes through
+    /// `get_traceback` everywhere else.
+    fn application_traceback(&self) -> PyObjectRef {
+        if self.exc_object.is_null() {
+            return pyre_object::PY_NULL;
+        }
+        unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(self.exc_object) }
+    }
+
+    /// `error.py` — `OperationError.has_any_traceback`:
+    ///
+    /// ```python
+    /// def has_any_traceback(self):
+    ///     return self._application_traceback is not None
+    /// ```
+    ///
+    /// The plain field test, so it neither materialises nor marks anything
+    /// escaped; [`get_traceback`](Self::get_traceback) is the reading form.
+    pub fn has_any_traceback(&self) -> bool {
+        !self.application_traceback().is_null()
+    }
+
+    /// `error.py` — `OperationError.got_any_traceback`, upstream's second
+    /// spelling of the same test, kept so both call sites port across.
+    pub fn got_any_traceback(&self) -> bool {
+        self.has_any_traceback()
+    }
+
+    /// `error.py` — `OperationError.get_w_traceback`:
+    ///
+    /// ```python
+    /// def get_w_traceback(self, space):
+    ///     """Return a traceback or w_None. """
+    ///     tb = self.get_traceback()
+    ///     if tb is None:
+    ///         return space.w_None
+    ///     return tb
+    /// ```
+    pub fn get_w_traceback(&self, _space: PyObjectRef) -> PyObjectRef {
+        let tb = self.get_traceback();
+        if tb.is_null() {
+            return pyre_object::w_none();
+        }
+        tb
+    }
+
+    /// `error.py` — `OperationError.set_traceback`:
+    ///
+    /// ```python
+    /// def set_traceback(self, traceback):
+    ///     """Set the current traceback."""
+    ///     self._application_traceback = traceback
+    /// ```
+    ///
+    /// The store is the one operation that cannot be answered without the
+    /// instance, since that is where [`get_traceback`](Self::get_traceback)
+    /// reads it back from, so this is where an error still carrying only a
+    /// message materialises.  Callers that go on to allocate must sequence
+    /// their own allocation after this one: the instance is what roots the
+    /// chain, so a node built before it exists is unreachable.
+    pub fn set_traceback(&mut self, w_traceback: PyObjectRef) {
+        let exc = self.to_exc_object();
+        if exc.is_null() {
+            return;
+        }
+        unsafe { pyre_object::interp_exceptions::w_exception_set_traceback(exc, w_traceback) };
+    }
+
+    /// `error.py` — `OperationError.remove_traceback_module_frames`:
+    ///
+    /// ```python
+    /// def remove_traceback_module_frames(self, *module_names):
+    ///     tb = self._application_traceback
+    ///     while tb is not None and isinstance(tb, PyTraceback):
+    ///         if tb.frame.pycode.co_filename not in module_names:
+    ///             break
+    ///         tb = tb.next
+    ///     self._application_traceback = tb
+    /// ```
+    ///
+    /// Drops the leading, outermost run of traceback entries raised from one
+    /// of `module_names`, so machinery a module implements in Python does not
+    /// surface in an error it re-raises; the first entry from anywhere else
+    /// stops the walk and the rest of the chain is kept intact.
+    ///
+    /// [`traceback_frame_names_module`] is the membership test, which widens
+    /// upstream's `not in module_names` by one case pyre needs.
+    pub fn remove_traceback_module_frames(&mut self, module_names: &[&str]) {
+        let exc = self.to_exc_object();
+        if exc.is_null() {
+            return;
+        }
+        unsafe {
+            use pyre_object::gc_roots::{
+                pin_root, push_roots, shadow_stack_get, shadow_stack_len, shadow_stack_set,
+            };
+
+            // `co_filename` is realised by `code_get_field`, which allocates
+            // and can therefore collect.  A traceback node emitted by compiled
+            // code is nursery-resident, so a collection moves it and a raw
+            // cursor carried across the call would name reclaimed memory —
+            // both when the walk steps to `w_next` and when the survivor is
+            // republished below.  Keep the cursor in a root slot and re-read it
+            // after every call that can allocate, the discipline
+            // `write_traceback_chain` already follows for its own walk.
+            let _roots = push_roots();
+            let exc_slot = shadow_stack_len();
+            let exc = pin_root(exc);
+            // Read the chain off the pinned address, not off
+            // `self.exc_object`: `pin_root` normalizes, so a collection during
+            // the publish leaves the field naming where the exception used to
+            // be.  Store the pinned address back for the same reason
+            // `to_exc_object` does with the deferred context refs.
+            self.exc_object = exc;
+            let tb_slot = shadow_stack_len();
+            let _ = pin_root(pyre_object::interp_exceptions::w_exception_get_traceback(
+                exc,
+            ));
+            let code_slot = shadow_stack_len();
+            let _ = pin_root(pyre_object::PY_NULL);
+            loop {
+                // `while tb is not None and isinstance(tb, PyTraceback)`.
+                let tb = shadow_stack_get(tb_slot);
+                if tb.is_null()
+                    || pyre_object::is_none(tb)
+                    || !crate::pytraceback::is_pytraceback(tb)
+                {
+                    break;
+                }
+                let w_code = crate::pytraceback::w_pytraceback_get_w_code(tb);
+                if w_code.is_null() {
+                    break;
+                }
+                shadow_stack_set(code_slot, w_code);
+                let names_a_module =
+                    crate::pycode::code_get_field(shadow_stack_get(code_slot), "co_filename")
+                        .ok()
+                        .filter(|f| pyre_object::is_str(*f))
+                        // A module imported from a path with no UTF-8 spelling
+                        // carries a surrogate escape in `co_filename`; it is
+                        // not one of the named modules either way.
+                        .and_then(|f| pyre_object::w_str_get_value_opt(f))
+                        .is_some_and(|f| traceback_frame_names_module(f, module_names));
+                if !names_a_module {
+                    break;
+                }
+                let tb = shadow_stack_get(tb_slot);
+                shadow_stack_set(tb_slot, crate::pytraceback::w_pytraceback_get_w_next(tb));
+            }
+            // `self._application_traceback = tb`.  `exc_object` still names the
+            // pinned exception, so the store lands on the same instance the
+            // walk read from.
+            debug_assert_eq!(self.exc_object, shadow_stack_get(exc_slot));
+            self.set_traceback(shadow_stack_get(tb_slot));
+        }
     }
 
     /// pypy/interpreter/error.py `OperationError.match`.
@@ -4283,5 +4489,70 @@ mod tests {
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("Traceback (most recent call last):"));
         assert!(text.contains("TypeError: bad operand"));
+    }
+
+    #[test]
+    fn traceback_frame_names_module_matches_a_frozen_pseudo_name_exactly() {
+        let names = ["<frozen importlib._bootstrap>", "importlib/_bootstrap.py"];
+        assert!(super::traceback_frame_names_module(
+            "<frozen importlib._bootstrap>",
+            &names
+        ));
+        // Upstream's membership test is exact, so a longer pseudo-name that
+        // merely starts the same is a different module.
+        assert!(!super::traceback_frame_names_module(
+            "<frozen importlib._bootstrap_external>",
+            &names
+        ));
+    }
+
+    #[test]
+    fn traceback_frame_names_module_matches_an_installed_path_by_its_tail() {
+        let names = ["importlib/_bootstrap.py"];
+        assert!(super::traceback_frame_names_module(
+            "/usr/lib/python3.14/importlib/_bootstrap.py",
+            &names
+        ));
+        // A Windows spelling of the same file reaches the same verdict.
+        assert!(super::traceback_frame_names_module(
+            r"C:\Python314\Lib\importlib\_bootstrap.py",
+            &names
+        ));
+    }
+
+    #[test]
+    fn traceback_frame_names_module_needs_a_separator_before_the_tail() {
+        // `my_importlib/_bootstrap.py` ends with the name but is a different
+        // package, so the tail match only counts on a path boundary.
+        assert!(!super::traceback_frame_names_module(
+            "/app/my_importlib/_bootstrap.py",
+            &["importlib/_bootstrap.py"]
+        ));
+        assert!(!super::traceback_frame_names_module(
+            "/app/notimportlib/_bootstrap.py",
+            &["importlib/_bootstrap.py"]
+        ));
+    }
+
+    #[test]
+    fn traceback_frame_names_module_answers_no_for_an_application_frame() {
+        assert!(!super::traceback_frame_names_module(
+            "/app/main.py",
+            &["<frozen importlib._bootstrap>", "importlib/_bootstrap.py"]
+        ));
+        assert!(!super::traceback_frame_names_module("/app/main.py", &[]));
+    }
+
+    #[test]
+    fn an_unmaterialised_error_reports_no_traceback() {
+        // `_application_traceback` starts as `None` upstream, and pyre reads
+        // the chain off the exception instance, which a message-only error has
+        // not built.  Neither read may allocate one to find that out.
+        let err = super::PyError::type_error("bad operand");
+        assert!(err.exc_object.is_null());
+        assert!(err.get_traceback().is_null());
+        assert!(!err.has_any_traceback());
+        assert!(!err.got_any_traceback());
+        assert!(err.exc_object.is_null(), "the reads must not materialise");
     }
 }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -1338,13 +1338,11 @@ impl ExecutionContext {
                 let w_value = operr.normalize_exception(space)?;
                 let w_type = crate::typedef::r#type(w_value)
                     .map_or_else(pyre_object::w_none, |p| p.as_ptr());
-                let mut w_traceback =
-                    unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(w_value) };
-                if w_traceback.is_null() {
-                    w_traceback = pyre_object::w_none();
-                } else {
-                    unsafe { crate::pytraceback::mark_traceback_escaped(w_traceback) };
-                }
+                // `operr.get_w_traceback(space)` — the slot read, its escape
+                // mark, and the `w_None` for an empty chain.  The normalization
+                // above put the same instance on the carrier, so the carrier
+                // reads it back.
+                let w_traceback = operr.get_w_traceback(space);
                 pyre_object::tupleobject::w_tuple_new(vec![w_type, w_value, w_traceback])
             } else {
                 w_arg

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -4653,77 +4653,29 @@ fn gcd_import_fast(name: &str) -> Result<Option<PyObjectRef>, crate::PyError> {
     Ok(Some(shadow_stack_get(mod_slot)))
 }
 
-/// `interp_import.py:98` — `e.remove_traceback_module_frames('<frozen
-/// importlib._bootstrap>', '<frozen importlib._bootstrap_external>', ...)`:
-/// drop the leading traceback entries that belong to the importlib bootstrap
+/// `interp_import.py interp___import__` — the `except OperationError` arm:
+///
+/// ```python
+/// e.remove_traceback_module_frames(
+///       '<frozen importlib._bootstrap>',
+///       '<frozen importlib._bootstrap_external>',
+///       '<builtin>/frozen importlib._bootstrap_external')
+/// raise
+/// ```
+///
+/// Drops the leading traceback entries that belong to the importlib bootstrap
 /// so an import error does not expose its internal `__import__` /
-/// `_find_and_load` machinery. pyre runs the bootstrap from the on-disk
-/// `importlib/_bootstrap{,_external}.py` sources, so match those filenames as
-/// well as the frozen pseudo-names. Only leading (outermost, contiguous)
-/// bootstrap frames are removed; a user frame stops the walk, keeping real
-/// application frames intact.
+/// `_find_and_load` machinery.  pyre runs the bootstrap from the on-disk
+/// `importlib/_bootstrap{,_external}.py` sources rather than frozen modules,
+/// so those two path spellings are named alongside upstream's three.
 fn strip_bootstrap_traceback_frames(mut err: crate::PyError) -> crate::PyError {
-    use pyre_object::interp_exceptions::{w_exception_get_traceback, w_exception_set_traceback};
-
-    fn is_bootstrap_filename(path: &str) -> bool {
-        let norm = path.replace('\\', "/");
-        norm.ends_with("importlib/_bootstrap.py")
-            || norm.ends_with("importlib/_bootstrap_external.py")
-            || norm == "<frozen importlib._bootstrap>"
-            || norm == "<frozen importlib._bootstrap_external>"
-    }
-
-    let exc = err.to_exc_object();
-    if exc.is_null() {
-        return err;
-    }
-    unsafe {
-        use pyre_object::gc_roots::{
-            pin_root, push_roots, shadow_stack_get, shadow_stack_len, shadow_stack_set,
-        };
-
-        // `code_get_field` realises `co_filename`, which allocates and can
-        // therefore collect.  A traceback node emitted by compiled code is
-        // nursery-resident, so a collection moves it and a raw cursor carried
-        // across the call would name reclaimed memory — both when the walk
-        // steps to `w_next` and when the survivor is republished below.  Keep
-        // the cursor in a root slot and re-read it after every call that can
-        // allocate, the discipline `write_traceback_chain` already follows for
-        // its own walk.
-        let _roots = push_roots();
-        let exc_slot = shadow_stack_len();
-        let exc = pin_root(exc);
-        let tb_slot = shadow_stack_len();
-        let _ = pin_root(w_exception_get_traceback(exc));
-        let code_slot = shadow_stack_len();
-        let _ = pin_root(pyre_object::PY_NULL);
-        loop {
-            let tb = shadow_stack_get(tb_slot);
-            if tb.is_null() || is_none(tb) {
-                break;
-            }
-            let w_code = crate::pytraceback::w_pytraceback_get_w_code(tb);
-            if w_code.is_null() {
-                break;
-            }
-            shadow_stack_set(code_slot, w_code);
-            let is_bootstrap =
-                crate::pycode::code_get_field(shadow_stack_get(code_slot), "co_filename")
-                    .ok()
-                    .filter(|f| pyre_object::is_str(*f))
-                    // A module imported from a path with no UTF-8 spelling carries a
-                    // surrogate escape in `co_filename`; it is not one of the
-                    // bootstrap names either way.
-                    .and_then(|f| pyre_object::w_str_get_value_opt(f))
-                    .is_some_and(is_bootstrap_filename);
-            if !is_bootstrap {
-                break;
-            }
-            let tb = shadow_stack_get(tb_slot);
-            shadow_stack_set(tb_slot, crate::pytraceback::w_pytraceback_get_w_next(tb));
-        }
-        w_exception_set_traceback(shadow_stack_get(exc_slot), shadow_stack_get(tb_slot));
-    }
+    err.remove_traceback_module_frames(&[
+        "<frozen importlib._bootstrap>",
+        "<frozen importlib._bootstrap_external>",
+        "<builtin>/frozen importlib._bootstrap_external",
+        "importlib/_bootstrap.py",
+        "importlib/_bootstrap_external.py",
+    ]);
     err
 }
 

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -669,13 +669,33 @@ fn call_codec(
     w_coder: PyObjectRef,
     w_obj: PyObjectRef,
     action: &str,
+    encoding: &str,
     errors: Option<&str>,
 ) -> Result<PyObjectRef, crate::PyError> {
     // PyPy `interp_codecs.py _call_codec`.
-    let w_res = if let Some(errors) = errors {
-        crate::call::call_function_impl_result(w_coder, &[w_obj, w_str_new(errors)])?
+    let call = if let Some(errors) = errors {
+        crate::call::call_function_impl_result(w_coder, &[w_obj, w_str_new(errors)])
     } else {
-        crate::call::call_function_impl_result(w_coder, &[w_obj])?
+        crate::call::call_function_impl_result(w_coder, &[w_obj])
+    };
+    // A codec that raises gets one line of context naming the operation and
+    // the encoding, and is re-raised otherwise unchanged:
+    //
+    //     _PyErr_FormatNote("%s with '%s' codec failed", "encoding", encoding);
+    //
+    // `interp_codecs.py _wrap_codec_error` instead rebuilds the error with the
+    // original as `__cause__`, which is the pre-3.12 spelling of the same
+    // context — `gh-102406` replaced the chaining with a PEP 678 note, and
+    // pyre targets 3.14.  The message text is the one both produce.
+    let w_res = match call {
+        Ok(w_res) => w_res,
+        Err(mut operr) => {
+            crate::baseobjspace::add_internal_exception_note(
+                &mut operr,
+                &format!("{action} with '{encoding}' codec failed"),
+            )?;
+            return Err(operr);
+        }
     };
     if !unsafe { pyre_object::is_tuple(w_res) } || unsafe { pyre_object::w_tuple_len(w_res) } != 2 {
         let msg = if action.starts_with("en") {
@@ -704,7 +724,7 @@ pub(crate) fn encode_text_codec(
         validate_error_handler(errors)?;
     }
     let w_encfunc = unsafe { pyre_object::w_tuple_getitem(w_codec_info, 0).unwrap_or_else(w_none) };
-    let w_retval = call_codec(w_encfunc, w_obj, "encoding", Some(errors))?;
+    let w_retval = call_codec(w_encfunc, w_obj, "encoding", encoding, Some(errors))?;
     if !unsafe { pyre_object::bytesobject::is_bytes_like(w_retval) } {
         let tname = unsafe { pyre_object::type_name_of(w_retval) };
         return Err(crate::PyError::type_error(format!(
@@ -733,7 +753,7 @@ pub(crate) fn decode_text_codec(
         validate_error_handler(errors)?;
     }
     let w_decfunc = unsafe { pyre_object::w_tuple_getitem(w_codec_info, 1).unwrap_or_else(w_none) };
-    let w_retval = call_codec(w_decfunc, w_obj, "decoding", Some(errors))?;
+    let w_retval = call_codec(w_decfunc, w_obj, "decoding", encoding, Some(errors))?;
     if !unsafe { pyre_object::is_str(w_retval) } {
         let tname = unsafe { pyre_object::type_name_of(w_retval) };
         return Err(crate::PyError::type_error(format!(

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -379,12 +379,17 @@ pub unsafe fn mark_traceback_escaped(w_traceback: PyObjectRef) {
 ///     operror.set_traceback(tb)
 /// ```
 ///
-/// Pyre stores the chain head on the materialised `W_BaseException`'s
-/// `w_traceback` slot (the same slot
-/// `interp_exceptions.rs`'s `w_exception_set_traceback` writes to).  The
-/// operror-side `_application_traceback: Option<PyObjectRef>` cache
-/// mirrors the slot for `to_exc_object` callers that haven't allocated
-/// the exception yet.
+/// Upstream keys the two reads off the operror, whose
+/// `_application_traceback` field holds the chain beside `_w_value`.  Pyre
+/// keys them off the materialised `W_BaseException`'s `w_traceback` slot
+/// instead, and takes that object rather than the `PyError`: a propagating
+/// Rust `PyError` is memcpy'd at every `?` and so cannot be registered as a
+/// GC root, while the instance can, which is what `set_in_flight_exception`
+/// below relies on.  [`PyError::get_traceback`](crate::PyError::get_traceback)
+/// and [`PyError::set_traceback`](crate::PyError::set_traceback) are the
+/// carrier-level spelling of the same two slot accesses, for callers that do
+/// hold the error; this entry point is also the one the JIT seam reaches
+/// across an ABI boundary carrying only the exception value.
 ///
 /// `last_instruction` is the byte-offset of the in-flight opcode
 /// (`pyframe.py:72 self.last_instr`).  In RPython this is the


### PR DESCRIPTION
## What

`PyError` is `OperationError`, but it carried none of the traceback API that
class exposes — every reader in the tree reached the exception instance's
`w_traceback` slot directly. This adds the accessors and moves two open-coded
readers onto them.

### 1. `error: add the traceback accessors OperationError carries`

`get_traceback`, `has_any_traceback`, `got_any_traceback`, `get_w_traceback`,
`set_traceback`, `remove_traceback_module_frames`, over a private
`application_traceback` field read. `get_traceback` carries upstream's
documented `mark_as_escaped` side effect; the raw read does not, which is the
distinction upstream draws between the two.

`executioncontext::_trace`'s open-coded `(w_type, w_value, tb)` triple becomes
`operr.get_w_traceback(space)`.

**The chain stays on the materialised instance, not on a new
`_application_traceback` field.** Upstream can hold it beside `_w_value`
because its `OperationError` is a GC object. A propagating Rust `PyError` is
memcpy'd at every `?`, so its address cannot be registered as a root — the
instance is what `set_in_flight_exception` publishes and what the collector
reaches the chain through. `get_traceback` therefore answers `PY_NULL` for an
unmaterialised error, the same answer upstream's `None` gives, and allocates
nothing to find that out.

Moving the chain onto the carrier means deferring materialisation, which needs
a root for the propagating error first. That is filed, not attempted here.

`pytraceback::record_application_traceback`'s doc claimed an operror-side
`_application_traceback: Option<PyObjectRef>` cache that does not exist;
corrected. Its signature is deliberately unchanged — it sits on a JIT-traced
graph and on five raw-object JIT-seam call sites, and an ABI change there
cannot be verified without an LLBC extract.

### 2. `importing: strip the bootstrap traceback frames through PyError`

`strip_bootstrap_traceback_frames` open-coded the walk with a hardcoded
four-way filename predicate; it now calls `remove_traceback_module_frames`
with the three names `interp___import__` passes plus the two on-disk spellings
pyre's bootstrap runs from. Two behaviour changes fall out, both toward
upstream: the walk tests `isinstance(tb, PyTraceback)`, and a name matches a
path tail only on a `/` boundary, so `/app/myimportlib/_bootstrap.py` no
longer matches `importlib/_bootstrap.py`.

### 3. `_codecs: note the operation and encoding when a codec raises`

`call_codec` propagated a failing codec's error unchanged. It now attaches
`"<action> with '<encoding>' codec failed"` as a PEP 678 note and re-raises.

**This one deliberately does not follow PyPy.** `interp_codecs.py
_wrap_codec_error` rebuilds the error through `try_set_from_cause` with the
original as `__cause__`; **gh-102406** replaced that chaining with
`_PyErr_FormatNote` in `Python/codecs.c`, and the message text is identical in
both. pyre targets 3.14, so it gets the note. Verified against 3.14.2:

```
>>> codecs.encode("x", "mycodec")   # a codec whose encoder raises TypeError
TypeError: boom
encoding with 'mycodec' codec failed        # <- __notes__
```

`try_set_from_cause` itself was written and then removed — under 3.14 it has
no caller and never will.

## Verification

- `cargo test -p pyre-interpreter --features dynasm` — **rc=0, 412 passed, 0
  failed**, including five new tests. Every changed file is in this one crate.
- `cargo check --workspace --all-targets --features dynasm` — compile coverage
  for the rest of the tree.
- `cargo fmt --all --check` clean; `scripts/check-new-line-citations.py` clean
  against a pinned merge-base.
- **`cargo test --all` and `pyre/check.py` were NOT run locally.** The
  workspace test build stops at `pyre-jit-trace`'s LLBC freshness gate, and
  re-extracting needs 35-90 min on a box whose swap is pinned at 21.3G of
  22.5G — an extract there gets OOM-killed. The workspace check above used
  `PYRE_LLBC_SKIP_FINGERPRINT_CHECK=1`, which is compile-only and proves
  nothing about runtime. **CI is the authority for the full gate and for
  `check.py`.**

## Follow-ups filed, not done here

- Defer materialisation to a real `_application_traceback` on `PyError`
  (blocked on rooting the propagating error).
- `OperationError.async` is absent from pyre entirely — 13 upstream call
  sites, each a "swallow this, unless it must not be swallowed" guard.
- FOR_ITER's StopIteration trace gate. Measured on 3.14.2 under `settrace`:
  the consuming frame gets an `exception` event for a custom `__next__` only,
  not for a generator or a list — so PyPy's `has_any_traceback()` arm is the
  3.14-correct one and its generator arms are not.

Deliberately not ported: PyPy's `"metaclass found to be '%N', but calling %R
with args (%R, %R, ...) raised %R"` rewrite in `__build_class__`. CPython has
no counterpart, so adding it would diverge from the parity oracle.
