### PR TITLE
Windows: scandir/stat_result/_path_* on the host, CI runner-seconds 26348 -> ~23400, and the non-Windows gaps the same probing found

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -540,7 +540,7 @@ jobs:
           --test test_make_jitcodes_produces_graph_keyed_output
 
   pyre-check-linux:
-    name: pyre/check.py ${{ matrix.backend }} (ubuntu-24.04)
+    name: pyre/check.py ${{ matrix.label }} (ubuntu-24.04)
     runs-on: ubuntu-24.04
     needs: prepare-charon-llbc-linux
     if: ${{ !cancelled() && needs.prepare-charon-llbc-linux.result == 'success' }}
@@ -550,16 +550,28 @@ jobs:
     # the work.
     timeout-minutes: 90
     strategy: &pyre-check-backends
-      # One job per backend rather than one job running both in sequence.
-      # `check.py` builds each backend's release binary itself and the two
-      # builds share almost nothing: measured on run 32611112376 they were
-      # 866s + 692s on Linux, 1239s + 768s on Windows and 1247s + 828s on
-      # macOS, so over three quarters of each leg's wall time was a serial
-      # build. `fail-fast: false` because one backend going red says nothing
-      # about the other, and cancelling it would hide a second failure.
+      # Linux runs one job per backend; macOS and Windows run both backends in
+      # one job. `check.py` builds each backend's release binary itself, and
+      # splitting the two builds across jobs only pays off where the second
+      # build is cheap. Runner-seconds spent on check.py, one backend per job
+      # (run 32657938846) against both in one (run 32647581403):
+      # ubuntu 3990s vs 4243s, windows 5449s vs 4170s, macos 3704s vs 3136s.
+      # Only Linux comes out ahead: on the other two the second job pays for a
+      # full release build over a target directory the first job never warmed,
+      # and that costs more than the two backends cost in sequence. Collapsing
+      # the two back into one job on macOS and Windows is worth 1847 runner-
+      # seconds a run against the 253 the Linux split saves.
+      # `fail-fast: false` because one backend going red says nothing about the
+      # other, and cancelling it would hide a second failure.
       fail-fast: false
       matrix:
-        backend: [dynasm, cranelift]
+        include:
+        - backend: dynasm
+          label: dynasm
+          only: --dynasm-only
+        - backend: cranelift
+          label: cranelift
+          only: --cranelift-only
     env:
       # See prepare-charon-llbc: downstream jobs download the prepared Charon
       # artifact into this workspace path.
@@ -686,7 +698,7 @@ jobs:
       if: ${{ !cancelled() }}
       env:
         PYRE_CHECK_PYTHON3: ${{ steps.cpython.outputs.python-path }}
-      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/parity_tests/run.py --${{ matrix.backend }}-only
+      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/parity_tests/run.py ${{ matrix.only }}
     - name: Run pyre/extra_tests/snippets (gated subset)
       # The snippet corpus is mostly imported from RustPython and is not all
       # green, so only the scripts declaring `# pyre-check: gate=1` run here —
@@ -700,7 +712,7 @@ jobs:
       if: ${{ !cancelled() }}
       env:
         PYRE_CHECK_PYTHON3: ${{ steps.cpython.outputs.python-path }}
-      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/run.py --gated-only --${{ matrix.backend }}-only
+      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/run.py --gated-only ${{ matrix.only }}
     - name: Run the vendored root extra_tests
       # PyPy's own `extra_tests/` tree, run in place through a driver that
       # supplies the pytest names those files use. Only `run.py`'s ENABLED list
@@ -709,7 +721,7 @@ jobs:
       # the runner exits 0 saying so.
       env:
         PYRE_CHECK_PYTHON3: ${{ steps.cpython.outputs.python-path }}
-      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/upstream/run.py --${{ matrix.backend }}-only
+      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/upstream/run.py ${{ matrix.only }}
     - name: JIT structural stats vs committed baseline (Linux, informational)
       # Diff each benchmark's [jit-stats] counters against the committed
       # pyre/bench/<name>.<backend>.jitstats baselines. The counters are decided
@@ -817,22 +829,40 @@ jobs:
       run: ${{ steps.cpython.outputs.python-path }} pyre/cpython_tests/run.py --backend dynasm --baseline pyre/cpython_tests/baseline.json --jobs 3 --timeout 300
 
   pyre-check-macos:
-    name: pyre/check.py ${{ matrix.backend }} (macos-latest)
+    name: pyre/check.py ${{ matrix.label }} (macos-latest)
     runs-on: macos-latest
     needs: prepare-charon-llbc-macos
     if: ${{ !cancelled() && needs.prepare-charon-llbc-macos.result == 'success' }}
-    strategy: *pyre-check-backends
+    strategy:
+      # Both backends in one job rather than one job each: see the runner-second
+      # measurements on `&pyre-check-backends`. The single entry keeps
+      # `matrix.backend` / `matrix.label` / `matrix.only` defined for the shared
+      # steps, and the steps that name one backend are gated on Linux anyway.
+      matrix:
+        include:
+        - backend: dynasm,cranelift
+          label: dynasm+cranelift
+          only: ""
     env:
       PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
       CHARON_VERSION: nightly-2026.05.29
     steps: *pyre-check-steps
 
   pyre-check-windows:
-    name: pyre/check.py ${{ matrix.backend }} (windows-latest)
+    name: pyre/check.py ${{ matrix.label }} (windows-latest)
     runs-on: windows-latest
     needs: prepare-charon-llbc-windows
     if: ${{ !cancelled() && needs.prepare-charon-llbc-windows.result == 'success' }}
-    strategy: *pyre-check-backends
+    strategy:
+      # Both backends in one job rather than one job each: see the runner-second
+      # measurements on `&pyre-check-backends`. The single entry keeps
+      # `matrix.backend` / `matrix.label` / `matrix.only` defined for the shared
+      # steps, and the steps that name one backend are gated on Linux anyway.
+      matrix:
+        include:
+        - backend: dynasm,cranelift
+          label: dynasm+cranelift
+          only: ""
     env:
       PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
       CHARON_VERSION: nightly-2026.05.29

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -567,6 +567,72 @@ jobs:
       shell: bash
       run: ${{ steps.cpython.outputs.python-path }} pyre/cpython_tests/run.py --backend dynasm --baseline pyre/cpython_tests/baseline.json --jobs 3 --timeout 300
 
+  dispatcher-graph-linux:
+    name: dispatcher-graph acceptance (ubuntu-24.04)
+    runs-on: ubuntu-24.04
+    needs: prepare-charon-llbc-linux
+    if: ${{ !cancelled() && needs.prepare-charon-llbc-linux.result == 'success' }}
+    # `slow_generated_jitcodes_preserve_complete_dispatcher_graph` self-ignores
+    # under `debug_assertions`, so the `cargo test --all` job never runs it: it
+    # translates the full LLBC set, which is far too slow unoptimized. Left
+    # unrun it rots — its dispatcher arm counts drifted stale once and masked a
+    # live lowering defect.
+    #
+    # It rode the `pyre/check.py` job on the premise that check.py leaves a warm
+    # release profile behind. It does not: the test harness pulls dev
+    # dependencies that are outside pyrex's graph, so the step recompiles 66
+    # crates either way — 628s on the longest job in the workflow. The only
+    # thing it needs from the rest of CI is the extracted LLBC, which is an
+    # artifact download.
+    timeout-minutes: 45
+    env:
+      # See prepare-charon-llbc: downstream jobs download the prepared Charon
+      # artifact into this workspace path.
+      PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
+      CHARON_VERSION: nightly-2026.05.29
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+    - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        cache-bin: false
+        shared-key: ${{ runner.arch }}
+        # Restore-only on PRs (they pull main's cache via restore-keys); save
+        # only on main so per-PR target caches don't multiply across refs past
+        # GitHub's 10 GB cache budget and trigger LRU eviction.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+    - name: Download Charon artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: charon-${{ runner.os }}-${{ runner.arch }}
+        path: .pyre-build/charon
+    - name: Restore Charon executable permissions
+      shell: bash
+      run: chmod +x .pyre-build/charon/*/charon .pyre-build/charon/*/charon-driver
+    - name: Download LLBC artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: llbc-${{ runner.os }}-${{ runner.arch }}
+        path: build/llbc
+    - name: Verify prepared Charon/LLBC
+      shell: bash
+      run: |
+        test -d .pyre-build/charon
+        for crate in majit-rlib pyre-object pyre-interpreter pyre-jit; do
+          test -s "build/llbc/${crate}.ullbc"
+          # The sidecar carries the artefact's own file table, which is what
+          # `source=` hashes. Without it the fingerprint falls back to the whole
+          # cargo closure and every consumer reports LLBC STALE, so fail here
+          # where the cause is still visible.
+          test -s "build/llbc/${crate}.ullbc.readfiles"
+        done
+    - name: Run release-only dispatcher-graph acceptance test
+      run: |
+        cargo test --release -p majit-translate \
+          --test test_make_jitcodes_produces_graph_keyed_output
+
   pyre-check-linux:
     name: pyre/check.py ${{ matrix.backend }} (ubuntu-24.04)
     runs-on: ubuntu-24.04
@@ -797,19 +863,6 @@ jobs:
       # it is where check.py builds wasm alongside the native backend.
       if: runner.os == 'Linux' && matrix.backend == 'dynasm'
       run: cargo test -p majit-backend-wasm --test codegen_test -- --ignored
-    - name: Run release-only dispatcher-graph acceptance test (Linux only)
-      # `slow_generated_jitcodes_preserve_complete_dispatcher_graph` self-ignores
-      # under `debug_assertions`, so the `cargo test --all` job never runs it: it
-      # translates the full LLBC set, which is far too slow unoptimized. This job
-      # has both halves it needs — the downloaded build/llbc/*.ullbc and a warm
-      # release profile from check.py — so run it here. Left unrun it rots: its
-      # dispatcher arm counts drifted stale and masked a live lowering defect.
-      # It translates LLBC rather than exercising a backend, so one leg of
-      # the backend matrix runs it.
-      if: runner.os == 'Linux' && matrix.backend == 'dynasm'
-      run: |
-        cargo test --release -p majit-translate \
-          --test test_make_jitcodes_produces_graph_keyed_output
 
   pyre-check-macos:
     name: pyre/check.py ${{ matrix.backend }} (macos-latest)

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -290,10 +290,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: prepare-charon-llbc-linux
     if: ${{ !cancelled() && needs.prepare-charon-llbc-linux.result == 'success' }}
-    # Two cargo passes plus the release build and run of the CPython suite.
-    # The cap carries over from the suite's former job; the passes above it
-    # measured ~34 min together, so it bounds a hang without bounding the work.
-    timeout-minutes: 90
+    # Two cargo passes, one per backend. They measured ~27 min together, so
+    # the cap bounds a hang without bounding the work.
+    timeout-minutes: 60
     env:
       # See prepare-charon-llbc: downstream jobs download the prepared Charon
       # artifact into this workspace path.
@@ -305,15 +304,6 @@ jobs:
       with:
         persist-credentials: false
     - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-    - name: Set up CPython
-      # Only the Linux copy of this job runs the CPython suite, which needs an
-      # interpreter to drive its runner. The other two copies share these steps
-      # through the anchor, so the condition keeps the install off them.
-      id: cpython
-      if: runner.os == 'Linux'
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: "3.14"
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-bin: false
@@ -457,46 +447,6 @@ jobs:
           --lib -- --ignored --test-threads=1 \
           compiler::tests::test_host_loop_external_jump_to
 
-    # The CPython suite rides this job's Linux copy rather than a job of its
-    # own: it needs the same checkout, toolchain, Cargo cache and prepared
-    # Charon/LLBC set, and those cost a job's worth of setup to assemble a
-    # second time. `!cancelled()` keeps the suite reporting even when a cargo
-    # pass above it fails — as separate jobs neither could hide the other, and
-    # a plain step order would.
-    - name: Build pyre-dynasm
-      if: ${{ !cancelled() && runner.os == 'Linux' }}
-      shell: bash
-      run: cargo build --release -p pyrex --bin pyre-dynasm --no-default-features --features dynasm
-    - name: Run pyre/extra_tests/pip (hermetic pip end-to-end)
-      # Drives the binary built above through venv, ensurepip, a wheel
-      # install, a PEP 517 build under real isolation, and an uninstall.
-      # Everything it resolves is a wheel already in the checkout, so it never
-      # reaches an index — and one of its checks asserts that, by requiring a
-      # plain `pip download` to fail.
-      #
-      # It rides this job's Linux copy for the same reason the suite below
-      # does: the release binary and the interpreter to drive it are already
-      # here. Ahead of the suite so its verdict lands early rather than after
-      # the suite's wall time, and `--dynasm-only` because the restored target
-      # directory can hold a `pyre-cranelift` this job never built.
-      if: ${{ !cancelled() && runner.os == 'Linux' }}
-      shell: bash
-      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/pip/run.py --dynasm-only
-    - name: Run CPython suite (gate regressions, JIT on)
-      # This is the only place CI runs the suite — `pyre/check.py` keeps the
-      # stage behind `--cpython-suite`, which no job passes, so its wall time is
-      # paid once. The runner gates against the shared baseline plus its own
-      # `baseline.linux-x86_64.json` overlay; `PLATFORM_GATED` only handles
-      # modules CPython skips wholesale on this host.
-      #
-      # The runner has 3 cores, so `--jobs 4` oversubscribes them and stretches
-      # the wall time of whichever module is running when the extra job lands.
-      # `--timeout` is per module: `test.test_asyncio` alone takes ~117s of CPU
-      # and ~2m47s of wall time, which does not fit the former 120s limit.
-      if: ${{ !cancelled() && runner.os == 'Linux' }}
-      shell: bash
-      run: ${{ steps.cpython.outputs.python-path }} pyre/cpython_tests/run.py --backend dynasm --baseline pyre/cpython_tests/baseline.json --jobs 3 --timeout 300
-
   cargo-test-macos:
     name: cargo test (macos-latest)
     runs-on: macos-latest
@@ -516,6 +466,106 @@ jobs:
       PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
       CHARON_VERSION: nightly-2026.05.29
     steps: *cargo-test-steps
+
+  cpython-suite-linux:
+    name: CPython suite + pip (ubuntu-24.04)
+    runs-on: ubuntu-24.04
+    needs: prepare-charon-llbc-linux
+    if: ${{ !cancelled() && needs.prepare-charon-llbc-linux.result == 'success' }}
+    # These three steps used to ride `cargo test`'s Linux copy, on the argument
+    # that a job of their own costs a second checkout, toolchain, Cargo cache
+    # restore and Charon/LLBC download. That preamble measured about three
+    # minutes; the steps themselves measured 27, and they started only after
+    # the cargo passes had spent 27 of their own. The two halves share nothing
+    # but the checkout, so keeping them in one job made `cargo test
+    # (ubuntu-24.04)` the longest job in the workflow by roughly the suite's
+    # whole wall time. Side by side they cost the same runner minutes and half
+    # the wall clock, and as separate jobs neither can hide the other's verdict
+    # — which is what the `!cancelled()` conditions were emulating.
+    timeout-minutes: 60
+    env:
+      # See prepare-charon-llbc: downstream jobs download the prepared Charon
+      # artifact into this workspace path.
+      PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
+      CHARON_VERSION: nightly-2026.05.29
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+    - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+    - name: Set up CPython
+      # Both runners below are Python programs.
+      id: cpython
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.14"
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        cache-bin: false
+        shared-key: ${{ runner.arch }}
+        # Restore-only on PRs (they pull main's cache via restore-keys); save
+        # only on main so per-PR target caches don't multiply across refs past
+        # GitHub's 10 GB cache budget and trigger LRU eviction.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+    - name: Download Charon artifact
+      # Run-scoped handoff from prepare-charon-llbc, as in the cargo test job.
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: charon-${{ runner.os }}-${{ runner.arch }}
+        path: .pyre-build/charon
+    - name: Restore Charon executable permissions
+      shell: bash
+      run: chmod +x .pyre-build/charon/*/charon .pyre-build/charon/*/charon-driver
+    - name: Download LLBC artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: llbc-${{ runner.os }}-${{ runner.arch }}
+        path: build/llbc
+    - name: Verify prepared Charon/LLBC
+      shell: bash
+      run: |
+        test -d .pyre-build/charon
+        for crate in majit-rlib pyre-object pyre-interpreter pyre-jit; do
+          test -s "build/llbc/${crate}.ullbc"
+          # The sidecar carries the artefact's own file table, which is what
+          # `source=` hashes. Without it the fingerprint falls back to the whole
+          # cargo closure and every consumer reports LLBC STALE, so fail here
+          # where the cause is still visible.
+          test -s "build/llbc/${crate}.ullbc.readfiles"
+        done
+    - name: Build pyre-dynasm
+      id: build
+      shell: bash
+      run: cargo build --release -p pyrex --bin pyre-dynasm --no-default-features --features dynasm
+    - name: Run pyre/extra_tests/pip (hermetic pip end-to-end)
+      # Drives the binary built above through venv, ensurepip, a wheel
+      # install, a PEP 517 build under real isolation, and an uninstall.
+      # Everything it resolves is a wheel already in the checkout, so it never
+      # reaches an index — and one of its checks asserts that, by requiring a
+      # plain `pip download` to fail.
+      #
+      # Ahead of the suite so its verdict lands early rather than after the
+      # suite's wall time, and `--dynasm-only` because the restored target
+      # directory can hold a `pyre-cranelift` this job never built.
+      shell: bash
+      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/pip/run.py --dynasm-only
+    - name: Run CPython suite (gate regressions, JIT on)
+      # This is the only place CI runs the suite — `pyre/check.py` keeps the
+      # stage behind `--cpython-suite`, which no job passes, so its wall time is
+      # paid once. The runner gates against the shared baseline plus its own
+      # `baseline.linux-x86_64.json` overlay; `PLATFORM_GATED` only handles
+      # modules CPython skips wholesale on this host.
+      #
+      # The runner has 3 cores, so `--jobs 4` oversubscribes them and stretches
+      # the wall time of whichever module is running when the extra job lands.
+      # `--timeout` is per module: `test.test_asyncio` alone takes ~117s of CPU
+      # and ~2m47s of wall time, which does not fit the former 120s limit.
+      #
+      # Reports even when the pip run above fails; only a missing binary makes
+      # it meaningless.
+      if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+      shell: bash
+      run: ${{ steps.cpython.outputs.python-path }} pyre/cpython_tests/run.py --backend dynasm --baseline pyre/cpython_tests/baseline.json --jobs 3 --timeout 300
 
   pyre-check-linux:
     name: pyre/check.py (ubuntu-24.04)

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -77,6 +77,18 @@ jobs:
   prepare-charon-llbc-linux:
     name: prepare Charon/LLBC (ubuntu-24.04)
     runs-on: ubuntu-24.04
+    # Every expensive job in this workflow hangs off one of the three prepare
+    # jobs, so naming `cargo fmt --check` here is what holds a whole run behind
+    # a 33 s check. Waiting costs no runner-seconds of its own -- a queued job
+    # occupies no runner -- only the wall time fmt spends queued, which on a
+    # saturated pool is already the larger half of every job's latency.
+    #
+    # Measured over the 95 finished runs of 2026-08-24: `cargo fmt --check` was
+    # the first job to go red in 5 of the 20 failures, and those five runs spent
+    # 97751 runner-seconds after it had already failed, against 1545805 for the
+    # day. `cpyext ABI` is the other job cheap enough to gate on and is left
+    # ungated: it went red in none of the 95.
+    needs: cargo-fmt
     env: &charon-llbc-env
       # Redirect the shared charon/ullbc build dir INTO the workspace so
       # actions/cache can reach it. Locally PYRE_SHARED_BUILD is unset and
@@ -274,6 +286,9 @@ jobs:
   prepare-charon-llbc-macos:
     name: prepare Charon/LLBC (macos-latest)
     runs-on: macos-latest
+    # See prepare-charon-llbc-linux: the gate has to name every prepare job,
+    # because each platform's consumers wait on their own.
+    needs: cargo-fmt
     env: *charon-llbc-env
     steps: *prepare-charon-llbc-steps
 
@@ -282,6 +297,8 @@ jobs:
     # On windows-latest install-charon.py builds Charon from source
     # (no Windows release asset is published); see scripts/install-charon.py.
     runs-on: windows-latest
+    # See prepare-charon-llbc-linux.
+    needs: cargo-fmt
     env: *charon-llbc-env
     steps: *prepare-charon-llbc-steps
 

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -473,106 +473,6 @@ jobs:
       CHARON_VERSION: nightly-2026.05.29
     steps: *cargo-test-steps
 
-  cpython-suite-linux:
-    name: CPython suite + pip (ubuntu-24.04)
-    runs-on: ubuntu-24.04
-    needs: prepare-charon-llbc-linux
-    if: ${{ !cancelled() && needs.prepare-charon-llbc-linux.result == 'success' }}
-    # These three steps used to ride `cargo test`'s Linux copy, on the argument
-    # that a job of their own costs a second checkout, toolchain, Cargo cache
-    # restore and Charon/LLBC download. That preamble measured about three
-    # minutes; the steps themselves measured 27, and they started only after
-    # the cargo passes had spent 27 of their own. The two halves share nothing
-    # but the checkout, so keeping them in one job made `cargo test
-    # (ubuntu-24.04)` the longest job in the workflow by roughly the suite's
-    # whole wall time. Side by side they cost the same runner minutes and half
-    # the wall clock, and as separate jobs neither can hide the other's verdict
-    # — which is what the `!cancelled()` conditions were emulating.
-    timeout-minutes: 60
-    env:
-      # See prepare-charon-llbc: downstream jobs download the prepared Charon
-      # artifact into this workspace path.
-      PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
-      CHARON_VERSION: nightly-2026.05.29
-    steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        persist-credentials: false
-    - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-    - name: Set up CPython
-      # Both runners below are Python programs.
-      id: cpython
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: "3.14"
-    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      with:
-        cache-bin: false
-        shared-key: ${{ runner.arch }}
-        # Restore-only on PRs (they pull main's cache via restore-keys); save
-        # only on main so per-PR target caches don't multiply across refs past
-        # GitHub's 10 GB cache budget and trigger LRU eviction.
-        save-if: ${{ github.ref == 'refs/heads/main' }}
-    - name: Download Charon artifact
-      # Run-scoped handoff from prepare-charon-llbc, as in the cargo test job.
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: charon-${{ runner.os }}-${{ runner.arch }}
-        path: .pyre-build/charon
-    - name: Restore Charon executable permissions
-      shell: bash
-      run: chmod +x .pyre-build/charon/*/charon .pyre-build/charon/*/charon-driver
-    - name: Download LLBC artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: llbc-${{ runner.os }}-${{ runner.arch }}
-        path: build/llbc
-    - name: Verify prepared Charon/LLBC
-      shell: bash
-      run: |
-        test -d .pyre-build/charon
-        for crate in majit-rlib pyre-object pyre-interpreter pyre-jit; do
-          test -s "build/llbc/${crate}.ullbc"
-          # The sidecar carries the artefact's own file table, which is what
-          # `source=` hashes. Without it the fingerprint falls back to the whole
-          # cargo closure and every consumer reports LLBC STALE, so fail here
-          # where the cause is still visible.
-          test -s "build/llbc/${crate}.ullbc.readfiles"
-        done
-    - name: Build pyre-dynasm
-      id: build
-      shell: bash
-      run: cargo build --release -p pyrex --bin pyre-dynasm --no-default-features --features dynasm
-    - name: Run pyre/extra_tests/pip (hermetic pip end-to-end)
-      # Drives the binary built above through venv, ensurepip, a wheel
-      # install, a PEP 517 build under real isolation, and an uninstall.
-      # Everything it resolves is a wheel already in the checkout, so it never
-      # reaches an index — and one of its checks asserts that, by requiring a
-      # plain `pip download` to fail.
-      #
-      # Ahead of the suite so its verdict lands early rather than after the
-      # suite's wall time, and `--dynasm-only` because the restored target
-      # directory can hold a `pyre-cranelift` this job never built.
-      shell: bash
-      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/pip/run.py --dynasm-only
-    - name: Run CPython suite (gate regressions, JIT on)
-      # This is the only place CI runs the suite — `pyre/check.py` keeps the
-      # stage behind `--cpython-suite`, which no job passes, so its wall time is
-      # paid once. The runner gates against the shared baseline plus its own
-      # `baseline.linux-x86_64.json` overlay; `PLATFORM_GATED` only handles
-      # modules CPython skips wholesale on this host.
-      #
-      # The runner has 3 cores, so `--jobs 4` oversubscribes them and stretches
-      # the wall time of whichever module is running when the extra job lands.
-      # `--timeout` is per module: `test.test_asyncio` alone takes ~117s of CPU
-      # and ~2m47s of wall time, which does not fit the former 120s limit.
-      #
-      # Reports even when the pip run above fails; only a missing binary makes
-      # it meaningless.
-      if: ${{ !cancelled() && steps.build.outcome == 'success' }}
-      shell: bash
-      run: ${{ steps.cpython.outputs.python-path }} pyre/cpython_tests/run.py --backend dynasm --baseline pyre/cpython_tests/baseline.json --jobs 3 --timeout 300
-
   dispatcher-graph-linux:
     name: dispatcher-graph acceptance (ubuntu-24.04)
     runs-on: ubuntu-24.04
@@ -644,6 +544,11 @@ jobs:
     runs-on: ubuntu-24.04
     needs: prepare-charon-llbc-linux
     if: ${{ !cancelled() && needs.prepare-charon-llbc-linux.result == 'success' }}
+    # The dynasm leg carries the pip end-to-end and the CPython suite as well,
+    # and measured 48 min without them against the 11 min they take. The cap
+    # comes from the job they used to be, and still bounds a hang rather than
+    # the work.
+    timeout-minutes: 90
     strategy: &pyre-check-backends
       # One job per backend rather than one job running both in sequence.
       # `check.py` builds each backend's release binary itself and the two
@@ -869,6 +774,47 @@ jobs:
       # it is where check.py builds wasm alongside the native backend.
       if: runner.os == 'Linux' && matrix.backend == 'dynasm'
       run: cargo test -p majit-backend-wasm --test codegen_test -- --ignored
+    - name: Run pyre/extra_tests/pip (hermetic pip end-to-end, Linux only)
+      # Drives the release `pyre-dynasm` through venv, ensurepip, a wheel
+      # install, a PEP 517 build under real isolation, and an uninstall.
+      # Everything it resolves is a wheel already in the checkout, so it never
+      # reaches an index -- and one of its checks asserts that, by requiring a
+      # plain `pip download` to fail.
+      #
+      # This and the suite below had a job of their own, which opened by
+      # running `cargo build --release -p pyrex --bin pyre-dynasm
+      # --no-default-features --features dynasm` -- the identical command
+      # `check.py` runs here, 894s in each of the two jobs. The dynasm leg of
+      # this matrix is the one place in the workflow where that binary already
+      # exists. It is also the longest Linux job, so appending 11 minutes to it
+      # is the whole cost: the run is bounded by `cargo test (windows-latest)`
+      # at 4153s against this leg's 3490s.
+      #
+      # `--dynasm-only` because a restored target directory can hold a
+      # `pyre-cranelift` this leg never built. Ahead of the suite so its verdict
+      # lands early rather than after the suite's wall time.
+      if: ${{ !cancelled() && runner.os == 'Linux' && matrix.backend == 'dynasm' }}
+      shell: bash
+      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/pip/run.py --dynasm-only
+    - name: Run CPython suite (gate regressions, JIT on, Linux only)
+      # This is the only place CI runs the suite -- `pyre/check.py` keeps the
+      # stage behind `--cpython-suite`, which no job passes, so its wall time is
+      # paid once. The runner gates against the shared baseline plus its own
+      # `baseline.linux-x86_64.json` overlay; `PLATFORM_GATED` only handles
+      # modules CPython skips wholesale on this host.
+      #
+      # The runner has 3 cores, so `--jobs 4` oversubscribes them and stretches
+      # the wall time of whichever module is running when the extra job lands.
+      # `--timeout` is per module: `test.test_asyncio` alone takes ~117s of CPU
+      # and ~2m47s of wall time, which does not fit the former 120s limit.
+      #
+      # Last, as the longest step here, so every other verdict in this job lands
+      # before it. It reports whatever check.py and the pip run above did; the
+      # one case it cannot report on is check.py failing to build the binary,
+      # where it goes red naming the same cause a second time.
+      if: ${{ !cancelled() && runner.os == 'Linux' && matrix.backend == 'dynasm' }}
+      shell: bash
+      run: ${{ steps.cpython.outputs.python-path }} pyre/cpython_tests/run.py --backend dynasm --baseline pyre/cpython_tests/baseline.json --jobs 3 --timeout 300
 
   pyre-check-macos:
     name: pyre/check.py ${{ matrix.backend }} (macos-latest)

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -286,9 +286,33 @@ jobs:
   prepare-charon-llbc-macos:
     name: prepare Charon/LLBC (macos-latest)
     runs-on: macos-latest
-    # See prepare-charon-llbc-linux: the gate has to name every prepare job,
-    # because each platform's consumers wait on their own.
-    needs: cargo-fmt
+    # The two non-Linux platforms wait for the Linux `check.py` legs to pass.
+    # Measured over the 596 finished runs of 2026-08-19..24, which cost 9695645
+    # runner-seconds with 55.4% of them on macOS and Windows:
+    #
+    #   137 failure runs never reached a green Linux check.py, and their macOS
+    #       and Windows legs spent 1634383 runner-seconds re-proving it;
+    #   297 cancelled runs were superseded before Linux check.py finished --
+    #       the median cancelled run lives 2567 s and Linux check.py completes
+    #       at +5727 s -- and spent 1600008 runner-seconds on the two;
+    #   9 further cancelled runs got past a green Linux check.py, for 77635 s.
+    #
+    # 3312026 runner-seconds, 34.2% of the six days, on legs that either
+    # re-proved a failure Linux had already found or were thrown away.
+    #
+    # This defers a platform answer, it does not drop one: 31 of the 168
+    # failure runs had a green Linux check.py and 19 of those went red on a
+    # platform leg, so every one of them still runs. What a red Linux costs is
+    # the round trip -- the platform answer arrives on the push that turns
+    # Linux green rather than beside it. Restricting the two platforms to
+    # `main` instead saves more and does drop coverage: over the same window 10
+    # runs went red on macOS or Windows while Linux stayed green, 8 of them on
+    # a branch, and under that rule all 10 would have landed first.
+    #
+    # `cargo-fmt` is named as well as reached through `pyre-check-linux`, so
+    # the gate below survives that job's own dependencies being rearranged.
+    needs: [cargo-fmt, pyre-check-linux]
+    if: ${{ !cancelled() && needs.pyre-check-linux.result == 'success' }}
     env: *charon-llbc-env
     steps: *prepare-charon-llbc-steps
 
@@ -297,8 +321,9 @@ jobs:
     # On windows-latest install-charon.py builds Charon from source
     # (no Windows release asset is published); see scripts/install-charon.py.
     runs-on: windows-latest
-    # See prepare-charon-llbc-linux.
-    needs: cargo-fmt
+    # See prepare-charon-llbc-macos for the measurement behind the Linux gate.
+    needs: [cargo-fmt, pyre-check-linux]
+    if: ${{ !cancelled() && needs.pyre-check-linux.result == 'success' }}
     env: *charon-llbc-env
     steps: *prepare-charon-llbc-steps
 

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -561,6 +561,14 @@ jobs:
       # and that costs more than the two backends cost in sequence. Collapsing
       # the two back into one job on macOS and Windows is worth 1847 runner-
       # seconds a run against the 253 the Linux split saves.
+      # Re-measured on run 32712894722, where both collapsed jobs are green.
+      # Windows confirms it at 3957s against the 5449s it split into. macOS read
+      # 4089s and confirms nothing either way: `cargo test (macos-latest)`, which
+      # nothing here touches, went 1516s to 2757s across the same pair of runs,
+      # so that runner was about 1.8x slower and the two macOS figures are not
+      # comparable. The mechanism is the same on all three -- the split builds
+      # the shared release workspace twice and the collapsed job builds it once
+      # -- and macOS has the slowest build of the three.
       # `fail-fast: false` because one backend going red says nothing about the
       # other, and cancelling it would hide a second failure.
       fail-fast: false

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -407,12 +407,18 @@ jobs:
       # the format cannot silently turn every consumer into "not checked". It
       # is `#[ignore]`d because it spawns `python3`, which is why it is pinned
       # to Linux: `python3` is not a name that resolves on the windows runner.
-      # `prepass` is named because `--no-default-features` applies to the
-      # selected package: without it the build script writes placeholders and
-      # refuses outside an LLBC extraction.
+      # The test target is named under the same `--all` feature set as the
+      # two steps above so it reuses what they compiled: `-p pyre-jit-trace`
+      # resolves `pyre-interpreter` differently and rebuilt 61 crates, and
+      # `pyre-jit-trace` cannot name `cpyext` itself -- the feature belongs
+      # to `pyre-interpreter`. `prepass` need not be named either: the
+      # workspace selection enables it through `pyrex`, where naming it
+      # beside `-p pyre-jit-trace` was what kept the build script off its
+      # placeholder path. Measured locally, 139s and 281s for those two
+      # forms against 3s for this one, with 0 crates compiled.
       run: |
-        cargo test --no-default-features --features dynasm,prepass,cpyext \
-          -p pyre-jit-trace --test llbc_fingerprint_format_test -- --ignored
+        cargo test --all --no-default-features --features dynasm,cpyext \
+          --test llbc_fingerprint_format_test -- --ignored
 
     - name: Build test binaries (cranelift)
       shell: bash

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -421,7 +421,7 @@ jobs:
       # selected package: without it the build script writes placeholders and
       # refuses outside an LLBC extraction.
       run: |
-        cargo test --no-default-features --features dynasm,prepass \
+        cargo test --no-default-features --features dynasm,prepass,cpyext \
           -p pyre-jit-trace --test llbc_fingerprint_format_test -- --ignored
 
     - name: Build test binaries (cranelift)

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -568,10 +568,21 @@ jobs:
       run: ${{ steps.cpython.outputs.python-path }} pyre/cpython_tests/run.py --backend dynasm --baseline pyre/cpython_tests/baseline.json --jobs 3 --timeout 300
 
   pyre-check-linux:
-    name: pyre/check.py (ubuntu-24.04)
+    name: pyre/check.py ${{ matrix.backend }} (ubuntu-24.04)
     runs-on: ubuntu-24.04
     needs: prepare-charon-llbc-linux
     if: ${{ !cancelled() && needs.prepare-charon-llbc-linux.result == 'success' }}
+    strategy: &pyre-check-backends
+      # One job per backend rather than one job running both in sequence.
+      # `check.py` builds each backend's release binary itself and the two
+      # builds share almost nothing: measured on run 32611112376 they were
+      # 866s + 692s on Linux, 1239s + 768s on Windows and 1247s + 828s on
+      # macOS, so over three quarters of each leg's wall time was a serial
+      # build. `fail-fast: false` because one backend going red says nothing
+      # about the other, and cancelling it would hide a second failure.
+      fail-fast: false
+      matrix:
+        backend: [dynasm, cranelift]
     env:
       # See prepare-charon-llbc: downstream jobs download the prepared Charon
       # artifact into this workspace path.
@@ -653,8 +664,10 @@ jobs:
       # `&pyre-check-steps`, which the macOS and Windows legs alias, so it is
       # copied into all three jobs; the census resolves charon per platform and
       # has no Windows mapping, and would hard-fail that leg ungated. Running
-      # once is also sufficient — the property is platform-independent.
-      if: runner.os == 'Linux'
+      # once is also sufficient — the property is platform-independent, and
+      # so is the LLBC it reads, so it rides the dynasm leg of the backend
+      # matrix instead of running once per backend.
+      if: runner.os == 'Linux' && matrix.backend == 'dynasm'
       shell: bash
       run: python3 pyre/scripts/vable-projection-census.py build/llbc/pyre-object.ullbc build/llbc/pyre-interpreter.ullbc build/llbc/pyre-jit.ullbc
     - name: Add wasm32 target (Linux only)
@@ -662,20 +675,29 @@ jobs:
       # installed, so this is what makes the Linux leg build and run the wasm
       # backend too. wasm output is platform-independent, so exercising it on
       # one OS is enough — macOS/Windows keep no wasm32 target and stay on the
-      # native backends.
-      if: runner.os == 'Linux'
+      # native backends. It rides the dynasm leg of the backend matrix
+      # because the wasm codegen tests below compare a bench run on wasm
+      # against the same bench run on dynasm.
+      if: runner.os == 'Linux' && matrix.backend == 'dynasm'
       run: rustup target add wasm32-unknown-unknown
     - name: Run pyre/check.py
+      # Naming the backend is what makes the matrix legs disjoint: left to
+      # its default each leg runs every backend it finds a target for. The
+      # Linux dynasm leg carries wasm too, because it is the leg that
+      # installed the wasm32 target and the one whose release `pyre-dynasm`
+      # the wasm codegen tests below need.
       env:
         PYRE_CHECK_PYTHON3: ${{ steps.cpython.outputs.python-path }}
         PYRE_CHECK_PYPY3: ${{ steps.pypy.outputs.python-path }}
-      run: ${{ steps.cpython.outputs.python-path }} pyre/check.py
+      run: ${{ steps.cpython.outputs.python-path }} pyre/check.py --backend ${{ (runner.os == 'Linux' && matrix.backend == 'dynasm') && 'dynasm,wasm' || matrix.backend }}
     - name: Run pyre/extra_tests/parity_tests
       # Every script must exit 0 and print "OK" as its last line under CPython
       # AND under each pyre backend, so a divergence from CPython observable
-      # semantics fails here. check.py has just built the release pyre-dynasm
-      # and pyre-cranelift binaries the runner drives, so this costs only the
-      # per-script process spawns.
+      # semantics fails here. check.py has just built this leg's release
+      # binary, so this costs only the per-script process spawns. The `-only`
+      # flag is what holds the leg to that binary: the runner drives whatever
+      # it finds in `target/release`, and a restored Cargo cache can hold the
+      # other backend's binary from a build this job never ran.
       #
       # Run it even when check.py above failed. The two gates answer different
       # questions and check.py is the one that goes red on a jitstats drift
@@ -687,7 +709,7 @@ jobs:
       if: ${{ !cancelled() }}
       env:
         PYRE_CHECK_PYTHON3: ${{ steps.cpython.outputs.python-path }}
-      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/parity_tests/run.py
+      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/parity_tests/run.py --${{ matrix.backend }}-only
     - name: Run pyre/extra_tests/snippets (gated subset)
       # The snippet corpus is mostly imported from RustPython and is not all
       # green, so only the scripts declaring `# pyre-check: gate=1` run here —
@@ -701,7 +723,7 @@ jobs:
       if: ${{ !cancelled() }}
       env:
         PYRE_CHECK_PYTHON3: ${{ steps.cpython.outputs.python-path }}
-      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/run.py --gated-only
+      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/run.py --gated-only --${{ matrix.backend }}-only
     - name: Run the vendored root extra_tests
       # PyPy's own `extra_tests/` tree, run in place through a driver that
       # supplies the pytest names those files use. Only `run.py`'s ENABLED list
@@ -710,7 +732,7 @@ jobs:
       # the runner exits 0 saying so.
       env:
         PYRE_CHECK_PYTHON3: ${{ steps.cpython.outputs.python-path }}
-      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/upstream/run.py
+      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/upstream/run.py --${{ matrix.backend }}-only
     - name: JIT structural stats vs committed baseline (Linux, informational)
       # Diff each benchmark's [jit-stats] counters against the committed
       # pyre/bench/<name>.<backend>.jitstats baselines. The counters are decided
@@ -742,16 +764,14 @@ jobs:
         set -uo pipefail
         {
           echo '### JIT structural stats vs committed baseline'
-          for backend in dynasm cranelift; do
-            echo "#### $backend"
-            echo '```'
-            out=$(${{ steps.cpython.outputs.python-path }} pyre/check.py \
-              --backend "$backend" --no-build --no-synthetic \
-              --snapshot-diff 2>&1 || true)
-            echo "$out" | grep -Ei 'jit-stats diff|snapshot diff' \
-              || echo '(no jit-stats output)'
-            echo '```'
-          done
+          echo '#### ${{ matrix.backend }}'
+          echo '```'
+          out=$(${{ steps.cpython.outputs.python-path }} pyre/check.py \
+            --backend '${{ matrix.backend }}' --no-build --no-synthetic \
+            --snapshot-diff 2>&1 || true)
+          echo "$out" | grep -Ei 'jit-stats diff|snapshot diff' \
+            || echo '(no jit-stats output)'
+          echo '```'
         } >> "$GITHUB_STEP_SUMMARY"
     - name: Run wasm runtime codegen regression tests (Linux only)
       # majit-backend-wasm/tests/codegen_test.rs holds six #[ignore]d runtime
@@ -772,7 +792,10 @@ jobs:
       # previously left a runner here exiting non-zero having written nothing
       # at all, in a different test each time; run_runtime_program now names
       # the signal when a child dies on one.
-      if: runner.os == 'Linux'
+      #
+      # The dynasm leg of the backend matrix is the one holding both halves:
+      # it is where check.py builds wasm alongside the native backend.
+      if: runner.os == 'Linux' && matrix.backend == 'dynasm'
       run: cargo test -p majit-backend-wasm --test codegen_test -- --ignored
     - name: Run release-only dispatcher-graph acceptance test (Linux only)
       # `slow_generated_jitcodes_preserve_complete_dispatcher_graph` self-ignores
@@ -781,26 +804,30 @@ jobs:
       # has both halves it needs — the downloaded build/llbc/*.ullbc and a warm
       # release profile from check.py — so run it here. Left unrun it rots: its
       # dispatcher arm counts drifted stale and masked a live lowering defect.
-      if: runner.os == 'Linux'
+      # It translates LLBC rather than exercising a backend, so one leg of
+      # the backend matrix runs it.
+      if: runner.os == 'Linux' && matrix.backend == 'dynasm'
       run: |
         cargo test --release -p majit-translate \
           --test test_make_jitcodes_produces_graph_keyed_output
 
   pyre-check-macos:
-    name: pyre/check.py (macos-latest)
+    name: pyre/check.py ${{ matrix.backend }} (macos-latest)
     runs-on: macos-latest
     needs: prepare-charon-llbc-macos
     if: ${{ !cancelled() && needs.prepare-charon-llbc-macos.result == 'success' }}
+    strategy: *pyre-check-backends
     env:
       PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
       CHARON_VERSION: nightly-2026.05.29
     steps: *pyre-check-steps
 
   pyre-check-windows:
-    name: pyre/check.py (windows-latest)
+    name: pyre/check.py ${{ matrix.backend }} (windows-latest)
     runs-on: windows-latest
     needs: prepare-charon-llbc-windows
     if: ${{ !cancelled() && needs.prepare-charon-llbc-windows.result == 'success' }}
+    strategy: *pyre-check-backends
     env:
       PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
       CHARON_VERSION: nightly-2026.05.29

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,6 +247,26 @@ xz-core = { git = "https://github.com/youknowone/xz-rs-simnalamburt", rev = "9c5
 # this: `CARGO_PROFILE_DEV_DEBUG=2 cargo build`.
 debug = "line-tables-only"
 
+# The LLBC artefacts the `majit-translate` integration tests read are large --
+# `pyre-interpreter.ullbc` alone is around 800 MB of JSON -- and at the dev
+# profile's `opt-level = 0` the two passes `Llbc::from_slice` makes over those
+# bytes dominate the whole `cargo test` run: six of the 166 test binaries spend
+# 211s of its 268s of test time. Optimizing the three crates that do that work
+# leaves the tests themselves unoptimized, so a failing assertion still reports
+# from line-table debuginfo with `debug_assertions` on.
+#
+# Measured over the same 166 binaries: those six go 211s -> 42s and the whole
+# run 268s -> 97s. The compile side barely moves -- a clean `cargo build -p
+# majit-translate --tests` measured 92s at `opt-level = 0`, 87s at 1 and 104s
+# at 2, because the front end rather than codegen is what that crate spends its
+# build on.
+[profile.dev.package.serde_json]
+opt-level = 2
+[profile.dev.package.majit-charon-reader]
+opt-level = 2
+[profile.dev.package.majit-translate]
+opt-level = 2
+
 [profile.release]
 lto = "thin"
 codegen-units = 1

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -4058,9 +4058,9 @@ impl MiniMarkGC {
                  (minor={}, header_addr={:#x}, nursery_start={:#x}, site={}, \
                  parent_site={}, \
                  nursery_free={:#x}, nursery_top={:#x}, holder_addr={:#x}, \
-                 holder_type_id={:?}, holder_offset={:?}, holder_words={:#x?}, \
+                 holder_type_id={:?}, holder_offset={:?}, holder_words={}, \
                  child_tid_and_flags={:#x}, child_flag_complement={:#x}, \
-                 child_words={:#x?}, child_vtable_type_id={:?}, \
+                 child_words={}, child_vtable_type_id={:?}, \
                  nearest_header={}, \
                  child_nursery_offset={:#x}, child_gen={}, holder_gen={}, \
                  holder_tid_and_flags={:#x}, holder_in_remembered={}, \
@@ -4077,12 +4077,12 @@ impl MiniMarkGC {
                 holder_addr,
                 holder_type_id,
                 slot_addr.checked_sub(holder_addr),
-                holder_words,
+                Self::hex_words(&holder_words),
                 unsafe { (*hdr_ptr).tid_and_flags },
                 // FORWARDED_MARKER sets every flag bit, so a corpse whose
                 // 64-bit equality no longer holds names the cleared bit here.
                 (!unsafe { (*hdr_ptr).flags() }) as u32,
-                child_words,
+                Self::hex_words(&child_words),
                 self.vtable_to_type_id.get(&child_words[0]).copied(),
                 self.describe_nearest_header(obj_addr),
                 obj_addr.wrapping_sub(self.nursery.start_ptr() as usize),
@@ -5454,6 +5454,18 @@ impl MiniMarkGC {
         Some(GcHeader::SIZE + payload_size)
     }
 
+    /// The eight words read out of a holder or a child, on one line.
+    ///
+    /// The crash-triage extractors in `check.py` and `cpython_tests/run.py`
+    /// keep only the first line of a panic body, and the two array formats Rust
+    /// offers each give up something: `{:x?}` drops the `0x` every other
+    /// address in the message carries, and `{:#x?}` puts each element on a line
+    /// of its own, which is a line those extractors never read.
+    fn hex_words(words: &[usize; 8]) -> String {
+        let hex: Vec<String> = words.iter().map(|word| format!("{word:#x}")).collect();
+        format!("[{}]", hex.join(", "))
+    }
+
     /// Which generation an address falls in.
     ///
     /// A corrupt child separates into two unrelated defects depending on the
@@ -5635,8 +5647,8 @@ impl MiniMarkGC {
                 panic!(
                     "GC BUG: invalid major child type_id={} at child_addr={:#x} \
                      holder_addr={:#x} holder_type_id={} slot_addr={:#x} \
-                     holder_offset={:?} site={} holder_words={:#x?} \
-                     child_vtable_type_id={:?} child_words={:#x?} \
+                     holder_offset={:?} site={} holder_words={} \
+                     child_vtable_type_id={:?} child_words={} \
                      holder_tid_and_flags={:#x} holder_in_remembered={} \
                      child_gen={} holder_gen={} \
                      enclosing={} gc_state={:?} minors={} majors={}",
@@ -5647,9 +5659,9 @@ impl MiniMarkGC {
                     slot_addr,
                     slot_addr.checked_sub(holder_addr),
                     site,
-                    holder_words,
+                    Self::hex_words(&holder_words),
                     child_vtable_type_id,
-                    child_words,
+                    Self::hex_words(&child_words),
                     holder_hdr.tid_and_flags,
                     self.remembered_set.contains(&holder_addr),
                     self.describe_generation(addr),

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -503,7 +503,13 @@ pub fn no_bridge_enabled() -> bool {
 /// than a rebuild per arm.  Consumes fuel only when the rest of `should_bridge`
 /// already held, so the count is bridges actually taken — place it last in the
 /// `&&` chain.  `MAJIT_BRIDGE_FUEL_LOG` reports each one taken.
-fn bridge_fuel_take() -> bool {
+///
+/// Public for the same reason `no_bridge_enabled` is: a frontend with its own
+/// guard-failure entry point spends fuel there too, and a counter that only
+/// half the bridges draw from makes `MAJIT_MAX_BRIDGES=0` disagree with
+/// `MAJIT_NO_BRIDGE=1` — the arm that reads as "no bridges" still compiles
+/// every bridge that entry point reaches.
+pub fn bridge_fuel_take() -> bool {
     static LIMIT: std::sync::OnceLock<Option<u64>> = std::sync::OnceLock::new();
     let Some(limit) = *LIMIT.get_or_init(|| {
         std::env::var("MAJIT_MAX_BRIDGES")

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -181,8 +181,9 @@ pub use jitcode::{
 pub use jitdriver::{
     DeclarativeJitDriver, FlatEntryContract, JitDriver, JitDriverStaticData,
     MultiFrameBlackholeResult, PendingAbortBlackhole, SingleFrameBlackholeResult,
-    TraceContinuationSuspendGuard, current_state_field_fvc_epoch, drive_multi_frame_blackhole,
-    drive_single_frame_blackhole, no_bridge_enabled, trace_continuation_suspended,
+    TraceContinuationSuspendGuard, bridge_fuel_take, current_state_field_fvc_epoch,
+    drive_multi_frame_blackhole, drive_single_frame_blackhole, no_bridge_enabled,
+    trace_continuation_suspended,
 };
 pub use majit_backend::CompiledTraceInfo;
 pub use pyjitpl::{eval_binop_f, eval_binop_i, eval_float_cmp, eval_unary_f, eval_unary_i};

--- a/pyre/bench/synth/mapdict_frozen_unboxing_fold.py
+++ b/pyre/bench/synth/mapdict_frozen_unboxing_fold.py
@@ -13,6 +13,19 @@
 # itself marks `?`. At the previous 406399 pypy measured 0.02s -- four times the
 # floor, and 2.5x short of the gate minimum -- so whether this fixture passed
 # came down to how loaded the runner was. Here pypy measures 0.17s.
+#
+# It is still the runner that decides, though not through load. Four Linux CI
+# legs measured pypy at 0.31s, 0.35s, 0.35s and 0.35s; one measured 0.05s, and
+# on that leg cpython read 1.20s against 1.36-1.42s and cranelift 4.49s against
+# 7.28-7.40s. Everything ran faster there and pypy by far the most, because
+# pypy's time here is almost all the two-million-object build: its read loops
+# JIT down to nothing, so what it measures is the cost of first-touching the
+# pages, which is the part that moves most between hosts. The ratio reached
+# 115x against the 63x ceiling with the numerator *smaller* than usual, and
+# check.py's own margin put it at 3.06x pypy startup -- so not a subtraction
+# artefact. Raising the ceiling to cover it would have to reach 230x, which
+# would stop the gate seeing a real 3x regression on every other runner, so the
+# ceiling stays where the other four legs put it.
 N = 2000000
 
 

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1039,15 +1039,18 @@ def _jit_panic_reason(stderr):
                 # diagnostic); the location line alone is not enough to triage
                 # a flaky crash from CI logs, so append the first message line.
                 #
-                # The width has to reach `site=`, which the GC prints last. At
-                # 200 the varsize-length diagnostic was cut mid-`nursery_start`,
+                # The width has to reach the last field the GC prints. At 200
+                # the varsize-length diagnostic was cut mid-`nursery_start`,
                 # dropping both `forwarded=` and `site=` — the two fields that
                 # name which path reached the object — and leaving a CI-only
-                # crash with no way to attribute it.
+                # crash with no way to attribute it. At 400 the two
+                # `invalid type_id` diagnostics, which reach about 800
+                # characters once their eight-word holder and child dumps are
+                # in, are cut inside the first dump.
                 for follow in lines[idx + 1 :]:
                     follow = follow.strip()
                     if follow:
-                        reason += f" | {follow[:400]}"
+                        reason += f" | {follow[:1200]}"
                         break
                 return reason
         return "rust panic"

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -195,15 +195,18 @@ def jit_panic_reason(stderr: str) -> str | None:
         lines = stderr.splitlines()
         for idx, line in enumerate(lines):
             if "panicked" in line:
-                reason = f"rust panic: {line.strip()[:200]}"
+                reason = f"rust panic: {line.strip()[:80]}"
                 # Rust's default hook prints the panic MESSAGE on the line(s)
                 # after 'panicked at file:line:col:'. That body carries the
                 # actionable detail; the location line alone cannot triage a
-                # crash from a CI log, so append the first message line.
+                # crash from a CI log, so append the first message line, at the
+                # width check.py uses — 200 cut the GC's `invalid major child`
+                # diagnostic at `holder_words`, which is where the fields that
+                # name the culprit start.
                 for follow in lines[idx + 1:]:
                     follow = follow.strip()
                     if follow:
-                        reason += f" | {follow[:200]}"
+                        reason += f" | {follow[:1200]}"
                         break
                 return reason
         return "rust panic"

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -100,7 +100,8 @@ lz4_flex = { version = "0.13", default-features = false, features = [
 # (System_Environment), and the OVERLAPPED record `_winapi.Overlapped` owns
 # with the CancelIoEx/GetOverlappedResult pair that drives it (System_IO), and
 # the UuidFromStringW/UuidToStringW pair an AF_HYPERV address is spelled with
-# (System_Rpc).
+# (System_Rpc), and `GetVersionExW` for `sys.getwindowsversion`
+# (System_SystemInformation).
 # Kept on the same 0.61 line rustpython-host_env's nt module resolves to, so
 # HANDLE types match at the boundary.
 windows-sys = { version = "0.61", features = [
@@ -121,6 +122,7 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_LibraryLoader",
     "Win32_System_Pipes",
     "Win32_System_Rpc",
+    "Win32_System_SystemInformation",
     "Win32_System_Threading",
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",

--- a/pyre/pyre-interpreter/src/_structseq.rs
+++ b/pyre/pyre-interpreter/src/_structseq.rs
@@ -492,12 +492,12 @@ pub fn new_instance(cls: PyObjectRef, items: Vec<PyObjectRef>) -> PyObjectRef {
 }
 
 /// Allocate a structseq instance carrying both the positional tuple body
-/// (`items`) and named-only extras (`extras`).  The extras are written
-/// into the instance `__dict__` so the per-field getter can resolve them
-/// (`_structseq.py:31-37`); the owning type must have been built with a
-/// matching `extra_fields` list via [`make_struct_seq_with_extra`] (which
-/// sets `hasdict`).  `os.stat_result` uses this for the float time fields
-/// and the `st_*_ns` extras.
+/// (`items`) and named-only extras (`extras`).  Each extra is stored under
+/// its own name so the per-field getter can resolve it (`_structseq.py`
+/// extra-field arm); the owning type must have been built with a matching
+/// `extra_fields` list via [`make_struct_seq_with_extra`] (which sets
+/// `hasdict`).  `os.stat_result` uses this for the float time fields and the
+/// `st_*_ns` extras.
 pub fn new_instance_with_extra(
     cls: PyObjectRef,
     items: Vec<PyObjectRef>,
@@ -540,25 +540,26 @@ pub fn new_instance_with_extra(
             (*pyre_object::gc_roots::shadow_stack_get(obj_slot)).w_class = rooted_cls;
         }
     }
-    if !extras.is_empty() {
-        let w_dict = pyre_object::w_dict_new();
-        let _ = pyre_object::gc_roots::pin_root(w_dict);
-        let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        for (index, (key, _)) in extras.iter().enumerate() {
-            unsafe {
-                pyre_object::w_dict_setitem_str(
-                    pyre_object::gc_roots::shadow_stack_get(dict_slot),
-                    key,
-                    pyre_object::gc_roots::shadow_stack_get(extras_slot + index),
-                )
-            };
-        }
-        crate::baseobjspace::setdict(
+    // `build_stat_result` stores each named-only field with
+    // `w_result.setdictvalue(space, name, w_value)` and never builds a dict:
+    // its comment names that as the point -- "circumvent the huge mess of
+    // structseq_new and a dict argument and just build the object ourselves.
+    // then it stays nicely virtual". On a mapdict carrier each store is a map
+    // transition, and every later instance of the same structseq reuses the
+    // shape those transitions built. Assembling a dict and installing it
+    // instead materialises the `("dict", SPECIAL)` wrapper on the instance's
+    // map, which moves the whole instance to dict storage -- one hashed insert
+    // per extra on every allocation, for `os.stat_result` thirteen of them.
+    for (index, (key, _)) in extras.iter().enumerate() {
+        let stored = crate::baseobjspace::setdictvalue(
             pyre_object::gc_roots::shadow_stack_get(obj_slot),
-            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            key,
+            pyre_object::gc_roots::shadow_stack_get(extras_slot + index),
         )
-        .expect(
-            "structseq extras: setdict on a fresh hasdict tuple subclass with a fresh dict cannot fail",
+        .expect("structseq extras: a name store on a fresh tuple subclass cannot raise");
+        assert!(
+            stored,
+            "structseq extras: the owning type must carry a dict (make_struct_seq_with_extra)"
         );
     }
     pyre_object::gc_roots::shadow_stack_get(obj_slot)

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3832,18 +3832,24 @@ fn print_sep_check(
     )))
 }
 
-/// Render `str(obj)` for writing to the (utf-8, strict) stdout stream.  The
-/// common all-UTF-8 result is returned directly; a lone surrogate is routed
-/// through `encode_object`'s strict handler, raising `UnicodeEncodeError`
-/// rather than panicking in `w_str_get_value`.
-unsafe fn print_render(obj: PyObjectRef) -> Result<String, crate::PyError> {
+/// Write `str(obj)` to the native stdout path under the stream's own error
+/// handler.
+///
+/// The common all-UTF-8 result goes out as it stands, which is what either
+/// handler produces for it.  A lone surrogate is routed through
+/// `encode_object` rather than panicking in `w_str_get_value`: `strict` raises
+/// `UnicodeEncodeError` there, and `surrogateescape` spells the escape as the
+/// byte it stands for, which is no longer a `str`.
+unsafe fn print_emit_native(obj: PyObjectRef, errors: &str) -> Result<(), crate::PyError> {
     let w = unsafe { crate::py_str_wtf8(obj)? };
     if let Ok(s) = w.as_str() {
-        return Ok(s.to_owned());
+        crate::print_output(s);
+        return Ok(());
     }
     let s_obj = pyre_object::w_str_from_wtf8(w);
-    let bytes = crate::type_methods::encode_object(s_obj, "utf-8", "strict")?;
-    Ok(String::from_utf8(bytes).expect("strict utf-8 encode yields valid utf-8"))
+    let bytes = crate::type_methods::encode_object(s_obj, "utf-8", errors)?;
+    crate::print_output_bytes(&bytes);
+    Ok(())
 }
 
 /// A text stream's `encoding`/`errors` (defaults `utf-8`/`strict`), read so a
@@ -3867,10 +3873,10 @@ unsafe fn stream_encoding_errors(stream: PyObjectRef) -> (String, String) {
 /// `sys.stdout = ...` redirects `print()`.
 enum DefaultPrintTarget {
     /// Unmodified default stdout (`sys.stdout is sys.__stdout__`) still
-    /// configured for the codec the native path renders: keep pyre's
-    /// `print_output` path (its strict-utf-8 `print_render` render and direct
-    /// write), leaving default output and surrogate handling unchanged.
-    Native,
+    /// configured for a codec the native path renders: keep pyre's
+    /// `print_output` path (its `print_emit_native` render and direct write),
+    /// carrying the stream's own error handler for the surrogate case.
+    Native(&'static str),
     /// A `sys.stdout` the native path cannot stand in for -- rebound, or the
     /// default stream under a codec other than strict utf-8; write through its
     /// `write` / `flush` methods.
@@ -3890,7 +3896,7 @@ enum DefaultPrintTarget {
 fn resolve_default_print_target() -> Result<DefaultPrintTarget, crate::PyError> {
     let Some(sys_mod) = crate::importing::get_sys_module("sys") else {
         // No `sys` yet (very early bootstrap) — native path.
-        return Ok(DefaultPrintTarget::Native);
+        return Ok(DefaultPrintTarget::Native("strict"));
     };
     let stdout = match crate::baseobjspace::getattr_str(sys_mod, "stdout") {
         Ok(w) => w,
@@ -3904,9 +3910,9 @@ fn resolve_default_print_target() -> Result<DefaultPrintTarget, crate::PyError> 
     }
     if let Ok(orig) = crate::baseobjspace::getattr_str(sys_mod, "__stdout__")
         && std::ptr::eq(orig, stdout)
-        && crate::module::_io::W_TextIOWrapper::stdio_renders_strict_utf8(stdout)
+        && let Some(errors) = crate::module::_io::W_TextIOWrapper::stdio_native_print_errors(stdout)
     {
-        return Ok(DefaultPrintTarget::Native);
+        return Ok(DefaultPrintTarget::Native(errors));
     }
     Ok(DefaultPrintTarget::Rebound(stdout))
 }
@@ -4124,11 +4130,13 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // With no explicit `file` (absent or `file=None`), the sink is the live
     // `sys.stdout`, resolved per call so a Python-level rebinding redirects
     // `print()`.  The unmodified default keeps the native path (`file = None`).
-    let file = match file {
-        Some(f) => Some(f),
+    // `native_errors` is read only on the native path, i.e. only where `file`
+    // came back `None`; an explicit `file=` never reaches it.
+    let (file, native_errors) = match file {
+        Some(f) => (Some(f), "strict"),
         None => match resolve_default_print_target()? {
-            DefaultPrintTarget::Native => None,
-            DefaultPrintTarget::Rebound(fp) => Some(fp),
+            DefaultPrintTarget::Native(errors) => (None, errors),
+            DefaultPrintTarget::Rebound(fp) => (Some(fp), "strict"),
             DefaultPrintTarget::Silent => return Ok(w_none()),
         },
     };
@@ -4157,9 +4165,7 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // `print_render`.
     let emit = |source: PyObjectRef| -> Result<(), crate::PyError> {
         let Some(file_slot) = file_slot else {
-            let s = unsafe { print_render(source)? };
-            crate::print_output(&s);
-            return Ok(());
+            return unsafe { print_emit_native(source, native_errors) };
         };
         let s_obj = pyre_object::w_str_from_wtf8_managed(unsafe { crate::py_str_wtf8(source)? });
         // `s_obj` is a fresh managed str reachable only through this Rust local.
@@ -4270,9 +4276,8 @@ fn displayhook_write(part: PyObjectRef) -> Result<bool, crate::PyError> {
     let part_slot = roots.base();
     let _ = roots.pin_root(part);
     match resolve_default_print_target()? {
-        DefaultPrintTarget::Native => {
-            let s = unsafe { print_render(roots.get(part_slot))? };
-            crate::print_output(&s);
+        DefaultPrintTarget::Native(errors) => {
+            unsafe { print_emit_native(roots.get(part_slot), errors)? };
         }
         DefaultPrintTarget::Rebound(fp) => {
             let r = crate::baseobjspace::call_method(fp, "write", &[roots.get(part_slot)]);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3866,11 +3866,14 @@ unsafe fn stream_encoding_errors(stream: PyObjectRef) -> (String, String) {
 /// `app_io.py print_` map `file is None` to `sys.stdout`, so a Python-level
 /// `sys.stdout = ...` redirects `print()`.
 enum DefaultPrintTarget {
-    /// Unmodified default stdout (`sys.stdout is sys.__stdout__`): keep pyre's
-    /// native `print_output` path (its strict-utf-8 `print_render` render and
-    /// direct write), leaving default output and surrogate handling unchanged.
+    /// Unmodified default stdout (`sys.stdout is sys.__stdout__`) still
+    /// configured for the codec the native path renders: keep pyre's
+    /// `print_output` path (its strict-utf-8 `print_render` render and direct
+    /// write), leaving default output and surrogate handling unchanged.
     Native,
-    /// A rebound `sys.stdout`; write through its `write` / `flush` methods.
+    /// A `sys.stdout` the native path cannot stand in for -- rebound, or the
+    /// default stream under a codec other than strict utf-8; write through its
+    /// `write` / `flush` methods.
     Rebound(PyObjectRef),
     /// `sys.stdout` is `None`; emit nothing (builtin_print returns `None`).
     Silent,
@@ -3878,9 +3881,11 @@ enum DefaultPrintTarget {
 
 /// Resolve `print()`'s default sink from the live `sys` module.
 ///
-/// Only a user redirect (`sys.stdout` rebound to some object other than the
-/// saved `sys.__stdout__`) is routed through Python `write` / `flush`; the
-/// unmodified default keeps the native path. A missing `sys.stdout` attribute
+/// A user redirect (`sys.stdout` rebound to some object other than the saved
+/// `sys.__stdout__`) is routed through Python `write` / `flush`, and so is a
+/// default stream whose codec is not the strict utf-8 the native path renders
+/// -- `PYTHONIOENCODING=cp424` makes `print(chr(0xa2))` a `b'J'` on the stream
+/// and a `b'Â¢'` on the native path. A missing `sys.stdout` attribute
 /// raises `RuntimeError("lost sys.stdout")` as builtin_print does.
 fn resolve_default_print_target() -> Result<DefaultPrintTarget, crate::PyError> {
     let Some(sys_mod) = crate::importing::get_sys_module("sys") else {
@@ -3899,6 +3904,7 @@ fn resolve_default_print_target() -> Result<DefaultPrintTarget, crate::PyError> 
     }
     if let Ok(orig) = crate::baseobjspace::getattr_str(sys_mod, "__stdout__")
         && std::ptr::eq(orig, stdout)
+        && crate::module::_io::W_TextIOWrapper::stdio_renders_strict_utf8(stdout)
     {
         return Ok(DefaultPrintTarget::Native);
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7208,9 +7208,10 @@ pub(crate) fn crt_errno() -> i32 {
 /// matches the libc constants the subclass table keys on; translate the common
 /// kinds to their POSIX errno through `ErrorKind` (which the standard library
 /// normalises per platform), the way `winerror_to_errno` fills `OSError.errno`
-/// alongside `.winerror`.  Unrecognised kinds keep the raw code, and an error
-/// carrying no OS code at all falls back to `default` (the errno each call site
-/// used before the translation existed).
+/// alongside `.winerror`.  A C runtime call reports its errno as the error's
+/// payload instead, which `posix_errno` reads.  Unrecognised kinds keep the raw
+/// code, and an error carrying no code of either kind falls back to `default`
+/// (the errno each call site used before the translation existed).
 pub(crate) fn io_error_posix_errno(e: &std::io::Error, default: i32) -> i32 {
     #[cfg(windows)]
     {
@@ -7230,6 +7231,19 @@ pub(crate) fn io_error_posix_errno(e: &std::io::Error, default: i32) -> i32 {
         };
         if let Some(errno) = mapped {
             return errno;
+        }
+        // A C runtime call carries its exact errno as the error's payload and
+        // leaves `raw_os_error()` empty (`io_error_from_errno`), so the
+        // fallback below would answer `default` for every one of them --
+        // `_wopen` refusing at the descriptor limit read back as the `open`
+        // call site's EACCES rather than as EMFILE.  Only a payload-carrying
+        // error is asked, since `posix_errno` answers EINVAL for an error that
+        // holds neither a payload nor a code.
+        #[cfg(all(feature = "host_env", not(feature = "sandbox")))]
+        if e.raw_os_error().is_none() && e.get_ref().is_some() {
+            use rustpython_host_env::os::ErrorExt;
+
+            return e.posix_errno();
         }
     }
     e.raw_os_error().unwrap_or(default)

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -11936,18 +11936,32 @@ fn incompatible_string_prefix_error(
     ))
 }
 
-/// CPython 3.14 `Parser/string_parser.c:decode_unicode_with_escapes` sends
-/// non-raw Unicode literals through the `unicode_escape` decoder before the
-/// f-string parser interprets replacement fields.  Ruff instead diagnoses an
-/// incomplete `\N{...` as either its own escape error or an unclosed f-string
-/// field.  Recover the decoder-first error, including the byte range relative
-/// to the literal contents used by the codec error message.
-/// The message a malformed `\N` escape produces, with the byte offset of the
-/// literal that carries it.
+/// A string literal's escape-decode failure.
+struct EscapeError {
+    /// What the decoder would have said.
+    message: String,
+    /// Byte offset of the literal, its prefix included.  The caller needs it
+    /// because [`string_escape_error`] walks the whole source: the escape is
+    /// only what gets reported when nothing earlier in the file already
+    /// failed.
+    literal_start: usize,
+    /// Byte range the diagnostic points at.
+    span: (usize, usize),
+}
+
+/// The escape-decode failure a string literal in `source` carries, if any.
 ///
-/// The caller needs the offset because this walks the whole source: the escape
-/// is only what gets reported when nothing earlier in the file already failed.
-fn malformed_unicode_name_escape(source: &str) -> Option<(String, usize)> {
+/// `decode_unicode_with_escapes` runs a non-raw literal through the
+/// `unicode_escape` decoder, and `decode_bytes_with_escapes` runs a bytes
+/// literal through its own, both before the parser interprets anything inside
+/// the literal.  The parser pyre delegates to reports every one of those
+/// failures as a single `Got unexpected unicode`, so the literal is re-scanned
+/// here to recover which escape failed and what the decoder would have said.
+///
+/// The positions the message carries are byte offsets into the literal's
+/// contents, spanning the backslash through the last character the decoder
+/// consumed.
+fn string_escape_error(source: &str) -> Option<EscapeError> {
     let bytes = source.as_bytes();
     let mut cursor = 0;
     while cursor < bytes.len() {
@@ -11979,13 +11993,22 @@ fn malformed_unicode_name_escape(source: &str) -> Option<(String, usize)> {
         if !prefix
             .iter()
             .all(|byte| matches!(byte.to_ascii_lowercase(), b'b' | b'f' | b'r' | b't' | b'u'))
-            || prefix
-                .iter()
-                .any(|byte| matches!(byte.to_ascii_lowercase(), b'b' | b'r'))
         {
             cursor += 1;
             continue;
         }
+        let has = |wanted: u8| {
+            prefix
+                .iter()
+                .any(|byte| byte.to_ascii_lowercase() == wanted)
+        };
+        // A raw literal keeps its backslashes, so no decoder runs over it.
+        if has(b'r') {
+            cursor += 1;
+            continue;
+        }
+        let bytes_literal = has(b'b');
+        let replacement_fields = has(b'f') || has(b't');
 
         let quote = bytes[quote_start];
         let triple = bytes[quote_start..].starts_with(&[quote, quote, quote]);
@@ -12006,39 +12029,154 @@ fn malformed_unicode_name_escape(source: &str) -> Option<(String, usize)> {
             }
         }
 
-        let mut escape = content_start;
-        while escape < content_end {
-            if bytes[escape] != b'\\' {
-                escape += 1;
-                continue;
-            }
-            if bytes.get(escape + 1) != Some(&b'N') {
-                escape = (escape + 2).min(content_end);
-                continue;
-            }
-            let malformed_end = if bytes.get(escape + 2) != Some(&b'{') {
-                Some(escape + 1)
-            } else if bytes[escape + 3..content_end]
-                .iter()
-                .all(|byte| *byte != b'}')
-            {
-                Some(content_end.saturating_sub(1))
+        let token_end = (content_end + quote_len).min(bytes.len());
+        if let Some(message) = escape_decode_error(
+            &bytes[content_start..content_end],
+            bytes_literal,
+            replacement_fields,
+        ) {
+            // A literal that holds replacement fields is several tokens, and
+            // the one the report points at is the closing quote; a literal
+            // that is one token is pointed at whole.
+            let span = if replacement_fields {
+                (token_end.saturating_sub(quote_len), token_end)
             } else {
-                None
+                (token_start, token_end)
             };
-            if let Some(malformed_end) = malformed_end {
-                return Some((
-                    format!(
-                        "(unicode error) 'unicodeescape' codec can't decode bytes in position {}-{}: malformed \\N character escape",
-                        escape - content_start,
-                        malformed_end - content_start,
-                    ),
-                    token_start,
+            return Some(EscapeError {
+                message,
+                literal_start: token_start,
+                span,
+            });
+        }
+        cursor = token_end;
+    }
+    None
+}
+
+/// The decoder's complaint about a literal's `contents`.
+///
+/// A literal holding replacement fields reaches the decoder one piece at a
+/// time -- the run of text between two fields -- and the positions the message
+/// carries are relative to the piece the escape sits in.
+fn escape_decode_error(
+    contents: &[u8],
+    bytes_literal: bool,
+    replacement_fields: bool,
+) -> Option<String> {
+    /// `'unicodeescape' codec can't decode bytes in position ...`, whose range
+    /// runs from the backslash through the last character consumed.
+    fn unicode_error(start: usize, end: usize, reason: &str) -> String {
+        format!(
+            "(unicode error) 'unicodeescape' codec can't decode bytes in position {start}-{end}: {reason}"
+        )
+    }
+
+    let mut piece_start = 0;
+    let mut cursor = 0;
+    while cursor < contents.len() {
+        // A replacement field is not text the decoder ever sees, and the piece
+        // after it starts over at position 0.  A doubled brace is not one: it
+        // stays in the piece it is written in.
+        if replacement_fields && contents[cursor] == b'{' && contents.get(cursor + 1) != Some(&b'{')
+        {
+            let mut depth = 1usize;
+            cursor += 1;
+            while cursor < contents.len() && depth > 0 {
+                match contents[cursor] {
+                    b'{' => depth += 1,
+                    b'}' => depth -= 1,
+                    _ => {}
+                }
+                cursor += 1;
+            }
+            piece_start = cursor;
+            continue;
+        }
+        if contents[cursor] != b'\\' {
+            cursor += 1;
+            continue;
+        }
+        let Some(&kind) = contents.get(cursor + 1) else {
+            return None;
+        };
+        // `\N{...}` names a character; a bytes literal has no such escape.  The
+        // brace here belongs to the escape, which is why the field skip above
+        // runs only where no backslash precedes it.
+        if kind == b'N' && !bytes_literal {
+            if contents.get(cursor + 2) != Some(&b'{') {
+                return Some(unicode_error(
+                    cursor - piece_start,
+                    cursor + 1 - piece_start,
+                    r"malformed \N character escape",
                 ));
             }
-            escape += 2;
+            let Some(close) = contents[cursor + 3..].iter().position(|byte| *byte == b'}') else {
+                return Some(unicode_error(
+                    cursor - piece_start,
+                    contents.len().saturating_sub(1) - piece_start,
+                    r"malformed \N character escape",
+                ));
+            };
+            let close = cursor + 3 + close;
+            let name = std::str::from_utf8(&contents[cursor + 3..close]).ok();
+            if name
+                .and_then(rustpython_unicode::lookup_character)
+                .is_none()
+            {
+                return Some(unicode_error(
+                    cursor - piece_start,
+                    close - piece_start,
+                    "unknown Unicode character name",
+                ));
+            }
+            cursor = close + 1;
+            continue;
         }
-        cursor = content_end.saturating_add(quote_len);
+        // `\u` and `\U` are ordinary characters in a bytes literal too.
+        let (width, form) = match kind {
+            b'x' => (2, r"\xXX"),
+            b'u' if !bytes_literal => (4, r"\uXXXX"),
+            b'U' if !bytes_literal => (8, r"\UXXXXXXXX"),
+            _ => {
+                cursor += 2;
+                continue;
+            }
+        };
+        let digits_start = cursor + 2;
+        let digits = contents[digits_start.min(contents.len())..]
+            .iter()
+            .take(width)
+            .take_while(|byte| byte.is_ascii_hexdigit())
+            .count();
+        if digits < width {
+            // `decode_bytes_with_escapes` reports its own failure, and names
+            // only where the escape began.
+            return Some(if bytes_literal {
+                let position = cursor - piece_start;
+                format!(r"(value error) invalid \x escape at position {position}")
+            } else {
+                unicode_error(
+                    cursor - piece_start,
+                    digits_start + digits - 1 - piece_start,
+                    &format!("truncated {form} escape"),
+                )
+            });
+        }
+        let end = digits_start + width;
+        if kind == b'U'
+            && std::str::from_utf8(&contents[digits_start..end])
+                .ok()
+                .and_then(|text| u32::from_str_radix(text, 16).ok())
+                .is_none_or(|value| value > 0x10_FFFF)
+        {
+            return Some(unicode_error(
+                cursor - piece_start,
+                end - 1 - piece_start,
+                "illegal Unicode character",
+            ));
+        }
+        cursor = end;
     }
     None
 }
@@ -12327,20 +12465,20 @@ fn compile_err_to_syntax_error_maybe_incomplete(
             );
         }
     }
-    if let Some((unicode_error, literal_start)) = malformed_unicode_name_escape(source) {
+    let escape_error = string_escape_error(source).filter(|escape| {
         // Both the decode and the parse are failures of the same compile, and
         // the one reported is whichever comes first in the source. A literal
         // that sits after the parser's own error keeps that error, so
         // `1 +\nx = "\N"\n` still reports the incomplete expression on line 1.
-        let parser_start = match &e {
+        match &e {
             crate::compile::CompileError::Parse(parse_error) => {
-                Some(parse_error.raw_location.start().to_usize())
+                parse_error.raw_location.start().to_usize() >= escape.literal_start
             }
-            _ => None,
-        };
-        if parser_start.is_none_or(|start| start >= literal_start) {
-            msg = unicode_error;
+            _ => true,
         }
+    });
+    if let Some(escape) = &escape_error {
+        msg = escape.message.clone();
     }
     if let Some(comment_error) = fstring_comment_diagnostic(&msg, source) {
         msg = comment_error.to_owned();
@@ -12419,7 +12557,14 @@ fn compile_err_to_syntax_error_maybe_incomplete(
     }
     let prefix_span = prefix_error.map(|(_, start, end)| (start, end));
     let delimiter_span = delimiter_error.map(|(_, index)| (index, index));
-    let diagnostic_span = literal_span
+    // Only where the decoder's complaint is still the one being reported: a
+    // literal can carry both a bad escape and one of the errors above, and
+    // that one names its own span.
+    let escape_span = escape_error
+        .filter(|escape| escape.message == msg)
+        .map(|escape| escape.span);
+    let diagnostic_span = escape_span
+        .or(literal_span)
         .or(fstring_span)
         .or(scope_span)
         .or(generator_span)
@@ -19502,23 +19647,60 @@ mod tests {
     }
 
     #[test]
-    fn malformed_unicode_name_escape_precedes_fstring_parsing() {
-        for (source, range) in [
-            (r"f'\N'", "0-1"),
-            (r"f'\N{'", "0-2"),
-            (r"'\N{GREEK CAPITAL LETTER DELTA'", "0-28"),
+    fn string_escape_errors_precede_parsing() {
+        for (source, range, reason) in [
+            (r"f'\N'", "0-1", r"malformed \N character escape"),
+            (r"f'\N{'", "0-2", r"malformed \N character escape"),
+            (
+                r"'\N{GREEK CAPITAL LETTER DELTA'",
+                "0-28",
+                r"malformed \N character escape",
+            ),
+            (r"'\N{DELTA}'", "0-8", "unknown Unicode character name"),
+            (r"'\x'", "0-1", r"truncated \xXX escape"),
+            (r"'ab\x1'", "2-4", r"truncated \xXX escape"),
+            (r"'\u12'", "0-3", r"truncated \uXXXX escape"),
+            (r"'\U0001'", "0-5", r"truncated \UXXXXXXXX escape"),
+            (r"'\U00110000'", "0-9", "illegal Unicode character"),
         ] {
-            let (message, literal_start) = malformed_unicode_name_escape(source).unwrap();
-            assert!(message.contains(&format!("position {range}:")), "{message}");
-            assert!(message.ends_with(r"malformed \N character escape"));
-            assert_eq!(literal_start, 0);
+            let escape = string_escape_error(source).unwrap();
+            assert!(
+                escape
+                    .message
+                    .contains(&format!("position {range}: {reason}")),
+                "{}",
+                escape.message
+            );
+            assert_eq!(escape.literal_start, 0);
         }
-        assert_eq!(malformed_unicode_name_escape(r"r'\N'"), None);
-        assert_eq!(malformed_unicode_name_escape(r"'\N{DELTA}'"), None);
-        assert_eq!(malformed_unicode_name_escape(r"'\\N'"), None);
+        // A bytes literal has its own decoder, and no `\N`/`\u`/`\U` escape.
+        let escape = string_escape_error(r"b'ab\x1'").unwrap();
+        assert_eq!(
+            escape.message,
+            r"(value error) invalid \x escape at position 2"
+        );
+        assert!(string_escape_error(r"b'\N'").is_none());
+        assert!(string_escape_error(r"b'\u12'").is_none());
+
+        assert!(string_escape_error(r"r'\N'").is_none());
+        assert!(string_escape_error(r"'\N{GREEK CAPITAL LETTER DELTA}'").is_none());
+        assert!(string_escape_error(r"'\x41'").is_none());
+        assert!(string_escape_error(r"'\\N'").is_none());
+        // The whole literal is what a report without replacement fields points
+        // at; one with them points at the escape.
+        assert_eq!(string_escape_error(r"'\x'").unwrap().span, (0, 4));
+        assert_eq!(string_escape_error(r"f'\x'").unwrap().span, (4, 5));
+        // Each piece between two replacement fields is decoded on its own, so
+        // the position starts over after every one.
+        assert!(
+            string_escape_error(r"f'{1}\x'")
+                .unwrap()
+                .message
+                .contains("position 0-1:")
+        );
         // The offset is what lets an earlier parse error keep the report.
         assert_eq!(
-            malformed_unicode_name_escape("1 +\nx = \"\\N\"\n").map(|(_, start)| start),
+            string_escape_error("1 +\nx = \"\\N\"\n").map(|escape| escape.literal_start),
             Some(8)
         );
     }

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1064,20 +1064,24 @@ impl PyError {
             unsafe { crate::display::py_repr_wtf8(key) }
                 .unwrap_or_else(|_| Wtf8Buf::from_string("<unrepresentable>".to_string()))
         };
-        let exc = w_exception_new_wtf8(ExcKind::KeyError, &message);
-        let exc = pyre_object::gc_roots::pin_root(exc);
+        let exc_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_exception_new_wtf8(ExcKind::KeyError, &message));
+        // The exception is read back out of its slot at every use: the pin
+        // keeps it alive without keeping it in place, and the allocations
+        // below can relocate it.
+        let exc = || pyre_object::gc_roots::shadow_stack_get(exc_slot);
         if !key.is_null() {
             // Reload the key after the repr / exception allocations: the pin
             // keeps it alive, but a minor collection may have relocated the
             // young key, leaving this raw local pointing at the old address.
             let key = pyre_object::gc_roots::shadow_stack_get(key_slot);
             let args_list = pyre_object::interp_exceptions::w_exception_args_new(vec![key]);
-            unsafe { pyre_object::interp_exceptions::w_exception_set_args(exc, args_list) };
+            unsafe { pyre_object::interp_exceptions::w_exception_set_args(exc(), args_list) };
         }
         PyError {
             kind: PyErrorKind::KeyError,
             message,
-            exc_object: exc,
+            exc_object: exc(),
             attach_tb: true,
             context_recorded: false,
             reraise_lasti: -1,
@@ -1216,14 +1220,18 @@ impl PyError {
         };
         let filename_slot = pin(w_filename);
         let filename2_slot = pin(w_filename2);
-        let exc = w_exception_new(exc_kind, &message);
-        let exc = pyre_object::gc_roots::pin_root(exc);
+        // The exception is read back out of its slot at every use below rather
+        // than out of a Rust local: each setter is preceded by an allocation,
+        // and the pin keeps the object alive without keeping it in place.
+        let exc_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_exception_new(exc_kind, &message));
+        let exc = || pyre_object::gc_roots::shadow_stack_get(exc_slot);
         // Retag to the errno subclass through `w_class`, like
         // `os_error_family_new`: the subclasses share OSError's layout, so
         // the ExcKind stays OSError and only the class differs.
         if let Some(w_target) = subclass.and_then(crate::builtins::lookup_exc_class) {
             unsafe {
-                (*(exc as *mut pyre_object::PyObject)).w_class = w_target;
+                (*(exc() as *mut pyre_object::PyObject)).w_class = w_target;
             }
         }
         // `PyErr_SetExcFromWindowsErrWithFilenameObjects` builds the exception
@@ -1258,32 +1266,29 @@ impl PyError {
                 .collect(),
         );
         unsafe {
-            pyre_object::interp_exceptions::w_exception_set_args(exc, args_list);
-            pyre_object::interp_exceptions::w_exception_set_errno(
-                exc,
-                pyre_object::w_int_new(errno as i64),
-            );
-            pyre_object::interp_exceptions::w_exception_set_strerror(
-                exc,
-                pyre_object::w_str_new(&strerror),
-            );
+            pyre_object::interp_exceptions::w_exception_set_args(exc(), args_list);
+            // Each value is built before the setter runs, so the exception the
+            // setter is handed is the one that exists after that allocation
+            // rather than the one that existed before it.
+            let w_errno = pyre_object::w_int_new(errno as i64);
+            pyre_object::interp_exceptions::w_exception_set_errno(exc(), w_errno);
+            let w_strerror = pyre_object::w_str_new(&strerror);
+            pyre_object::interp_exceptions::w_exception_set_strerror(exc(), w_strerror);
             #[cfg(windows)]
             if let Some(code) = winerror {
-                pyre_object::interp_exceptions::w_exception_set_winerror(
-                    exc,
-                    pyre_object::w_int_new(code as i64),
-                );
+                let w_winerror = pyre_object::w_int_new(code as i64);
+                pyre_object::interp_exceptions::w_exception_set_winerror(exc(), w_winerror);
             }
             // Reload the paths after the args allocations: the pins keep them
             // alive, but a minor collection may have relocated the young
             // strings, leaving the raw locals pointing at the old addresses.
             if let Some(slot) = filename_slot {
                 let w_filename = pyre_object::gc_roots::shadow_stack_get(slot);
-                pyre_object::interp_exceptions::w_exception_set_filename(exc, w_filename);
+                pyre_object::interp_exceptions::w_exception_set_filename(exc(), w_filename);
             }
             if let Some(slot) = filename2_slot {
                 let w_filename2 = pyre_object::gc_roots::shadow_stack_get(slot);
-                pyre_object::interp_exceptions::w_exception_set_filename2(exc, w_filename2);
+                pyre_object::interp_exceptions::w_exception_set_filename2(exc(), w_filename2);
             }
         }
         PyError {
@@ -1293,7 +1298,7 @@ impl PyError {
             // `: 'filename'` suffix; the bare "[Errno N] strerror" would bypass
             // it and the uncaught-traceback header would drop the filename.
             message: Wtf8Buf::new(),
-            exc_object: exc,
+            exc_object: exc(),
             attach_tb: true,
             context_recorded: false,
             reraise_lasti: -1,
@@ -1322,20 +1327,28 @@ impl PyError {
         // `w_list_new` run, so a collection there could sweep the unrooted
         // exception before `w_exception_set_args` writes through it.
         let _roots = pyre_object::gc_roots::push_roots();
-        let exc = w_exception_new(exc_kind, &strerror);
-        let exc = pyre_object::gc_roots::pin_root(exc);
+        let exc_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_exception_new(exc_kind, &strerror));
+        // Everything below is read back out of its slot: `w_list_new_object`
+        // takes elements its caller has already pinned, and each pin keeps its
+        // object alive without keeping it in place.
+        let exc = || pyre_object::gc_roots::shadow_stack_get(exc_slot);
+        let errno_slot = exc_slot + 1;
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(errno as i64));
+        let strerror_slot = errno_slot + 1;
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(&strerror));
         let args_list = pyre_object::interp_exceptions::w_exception_args_new(vec![
-            pyre_object::w_int_new(errno as i64),
-            pyre_object::w_str_new(&strerror),
+            pyre_object::gc_roots::shadow_stack_get(errno_slot),
+            pyre_object::gc_roots::shadow_stack_get(strerror_slot),
         ]);
-        unsafe { pyre_object::interp_exceptions::w_exception_set_args(exc, args_list) };
+        unsafe { pyre_object::interp_exceptions::w_exception_set_args(exc(), args_list) };
         PyError {
             kind,
             // Leave the display message empty so `message_text` derives it
             // from `exc_object`, whose `descr_str` renders the two-element
             // `args` as a tuple repr rather than as a bare string.
             message: Wtf8Buf::new(),
-            exc_object: exc,
+            exc_object: exc(),
             attach_tb: true,
             context_recorded: false,
             reraise_lasti: -1,
@@ -1372,32 +1385,36 @@ impl PyError {
         // `w_list_new` run, so a collection there could sweep the unrooted
         // exception before `w_exception_set_args` writes through it.
         let _roots = pyre_object::gc_roots::push_roots();
-        let exc = w_exception_new_wtf8(exc_kind, &message);
-        let exc = pyre_object::gc_roots::pin_root(exc);
+        let exc_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(w_exception_new_wtf8(exc_kind, &message));
+        // Everything below is read back out of its slot: `w_list_new_object`
+        // takes elements its caller has already pinned, and each pin keeps its
+        // object alive without keeping it in place.
+        let exc = || pyre_object::gc_roots::shadow_stack_get(exc_slot);
         if let Some(w_target) = subclass.and_then(crate::builtins::lookup_exc_class) {
             unsafe {
-                (*(exc as *mut pyre_object::PyObject)).w_class = w_target;
+                (*(exc() as *mut pyre_object::PyObject)).w_class = w_target;
             }
         }
+        let errno_slot = exc_slot + 1;
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(errno as i64));
+        let strerror_slot = errno_slot + 1;
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_from_wtf8(strerror.clone()));
         let args_list = pyre_object::interp_exceptions::w_exception_args_new(vec![
-            pyre_object::w_int_new(errno as i64),
-            pyre_object::w_str_from_wtf8(strerror.clone()),
+            pyre_object::gc_roots::shadow_stack_get(errno_slot),
+            pyre_object::gc_roots::shadow_stack_get(strerror_slot),
         ]);
         unsafe {
-            pyre_object::interp_exceptions::w_exception_set_args(exc, args_list);
-            pyre_object::interp_exceptions::w_exception_set_errno(
-                exc,
-                pyre_object::w_int_new(errno as i64),
-            );
-            pyre_object::interp_exceptions::w_exception_set_strerror(
-                exc,
-                pyre_object::w_str_from_wtf8(strerror.clone()),
-            );
+            pyre_object::interp_exceptions::w_exception_set_args(exc(), args_list);
+            let w_errno = pyre_object::w_int_new(errno as i64);
+            pyre_object::interp_exceptions::w_exception_set_errno(exc(), w_errno);
+            let w_strerror = pyre_object::w_str_from_wtf8(strerror.clone());
+            pyre_object::interp_exceptions::w_exception_set_strerror(exc(), w_strerror);
         }
         PyError {
             kind,
             message,
-            exc_object: exc,
+            exc_object: exc(),
             attach_tb: true,
             context_recorded: false,
             reraise_lasti: -1,
@@ -1448,8 +1465,13 @@ impl PyError {
         if !w_name_from.is_null() {
             let _ = pyre_object::gc_roots::pin_root(w_name_from);
         }
-        let exc = w_exception_new_wtf8(ExcKind::ImportError, &message);
-        let exc = pyre_object::gc_roots::pin_root(exc);
+        let exc_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ =
+            pyre_object::gc_roots::pin_root(w_exception_new_wtf8(ExcKind::ImportError, &message));
+        // The exception is read back out of its slot at every use: the pin
+        // keeps it alive without keeping it in place, and the message
+        // allocation below can relocate it.
+        let exc = || pyre_object::gc_roots::shadow_stack_get(exc_slot);
         // `ImportError.__init__` mirrors args[0] into the dedicated `msg`
         // slot; the prebuilt-instance path bypasses it, so stamp it here.
         let w_msg = if message.is_empty() {
@@ -1477,15 +1499,15 @@ impl PyError {
             pyre_object::gc_roots::shadow_stack_get(name_from_slot)
         };
         unsafe {
-            pyre_object::interp_exceptions::w_exception_set_import_msg(exc, w_msg);
-            pyre_object::interp_exceptions::w_exception_set_name(exc, w_name);
-            pyre_object::interp_exceptions::w_exception_set_import_path(exc, w_path);
-            pyre_object::interp_exceptions::w_exception_set_import_name_from(exc, w_name_from);
+            pyre_object::interp_exceptions::w_exception_set_import_msg(exc(), w_msg);
+            pyre_object::interp_exceptions::w_exception_set_name(exc(), w_name);
+            pyre_object::interp_exceptions::w_exception_set_import_path(exc(), w_path);
+            pyre_object::interp_exceptions::w_exception_set_import_name_from(exc(), w_name_from);
         }
         PyError {
             kind: PyErrorKind::ImportError,
             message,
-            exc_object: exc,
+            exc_object: exc(),
             attach_tb: true,
             context_recorded: false,
             reraise_lasti: -1,

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -2482,12 +2482,36 @@ fn write_syntax_error_object<W: Write>(writer: &mut W, exc: PyObjectRef) -> std:
         (!w.is_null() && unsafe { pyre_object::is_int(w) })
             .then(|| unsafe { pyre_object::intobject::w_int_get_value(w) })
     };
-    let filename = wtf8_of(attr("filename"));
+    // `traceback.py _format_syntax_error`: the header goes out whenever the
+    // instance carries a line number, with the filename rendered through
+    // `str()` -- a `bytes` filename shows as `b'…'` -- and `<string>` standing
+    // in for one that is falsy. Without a line number there is no header and
+    // the filename becomes a ` (…)` suffix on the message line instead.
+    //
+    // Each read below takes the attribute off the pinned exception again
+    // rather than holding one reference across a call that re-enters Python.
+    let filename_is_set = {
+        let w = attr("filename");
+        !w.is_null() && !unsafe { pyre_object::is_none(w) }
+    };
+    let filename_is_truthy =
+        filename_is_set && crate::baseobjspace::is_true(attr("filename")).unwrap_or(true);
+    let filename_text = filename_is_set.then(|| {
+        unsafe { crate::py_str_wtf8(attr("filename")) }
+            .unwrap_or_else(|_| Wtf8Buf::from_string(String::new()))
+    });
     let lineno = int_of(attr("lineno"));
-    if let (Some(fname), Some(lineno)) = (filename.as_ref(), lineno) {
+    let mut filename_suffix = None;
+    if let Some(lineno) = lineno {
+        let shown = match (&filename_text, filename_is_truthy) {
+            (Some(text), true) => text.as_bytes(),
+            _ => b"<string>".as_slice(),
+        };
         writer.write_all(b"  File \"")?;
-        writer.write_all(fname.as_bytes())?;
+        writer.write_all(shown)?;
         writeln!(writer, "\", line {lineno}")?;
+    } else {
+        filename_suffix = filename_text;
     }
     if let Some(text) = wtf8_of(attr("text")) {
         // A constructor-supplied `text` is any str, so it may hold a lone
@@ -2533,10 +2557,15 @@ fn write_syntax_error_object<W: Write>(writer: &mut W, exc: PyObjectRef) -> std:
         Some(msg) if !msg.is_empty() => {
             write!(writer, "{name}: ")?;
             writer.write_all(msg.as_bytes())?;
-            writer.write_all(b"\n")
         }
-        _ => writeln!(writer, "{name}"),
+        _ => write!(writer, "{name}")?,
     }
+    if let Some(suffix) = filename_suffix {
+        writer.write_all(b" (")?;
+        writer.write_all(suffix.as_bytes())?;
+        writer.write_all(b")")?;
+    }
+    writer.write_all(b"\n")
 }
 
 /// Emit `write_syntax_error` through the mediated stderr seam, mirroring

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -2045,12 +2045,15 @@ impl PyError {
     /// `PySys_WriteStderr` -- one line of a report, on `sys.stderr` when there
     /// is one and on the host's stream when there is not.
     pub(crate) fn write_report_line(buf: &[u8]) {
-        if !Self::write_unraisable_to_sys_stderr(buf) {
+        if !Self::write_to_sys_stderr(buf) {
             emit_report_to_host_stderr(buf);
         }
     }
 
-    fn write_unraisable_to_sys_stderr(buf: &[u8]) -> bool {
+    /// Write WTF-8 `buf` through the live `sys.stderr`, so the text spends that
+    /// stream's codec and error handler. False for a stream that is missing,
+    /// `None` or refuses the write, leaving the caller its own descriptor sink.
+    fn write_to_sys_stderr(buf: &[u8]) -> bool {
         let Some(sys_mod) = crate::importing::get_sys_module("sys") else {
             return false;
         };
@@ -2118,7 +2121,7 @@ impl PyError {
             let err = unsafe { PyError::from_exc_object(w_value) };
             let _ = write_exception(&mut buf, &err, true);
         }
-        if !Self::write_unraisable_to_sys_stderr(&buf) {
+        if !Self::write_to_sys_stderr(&buf) {
             emit_report_to_host_stderr(&buf);
         }
     }
@@ -3845,8 +3848,21 @@ pub fn system_exit_code(err: &PyError) -> i32 {
         // and `SystemExit(-1)` both exit 255.
         return crate::baseobjspace::int_w(code).unwrap_or(-1) as i32;
     }
-    // Straight to the host's stderr, which has no codec behind it, so the
-    // text spends the `backslashreplace` encode here.
+    // `pylifecycle.c _Py_HandleSystemExit` writes the code object through
+    // `sys.stderr`, so the message spends that stream's codec and its
+    // `backslashreplace` handler: under `PYTHONIOENCODING=latin-1`,
+    // `sys.exit("h\xe9")` reaches the descriptor as `h\xe9` rather than as the
+    // utf-8 spelling of it.
+    if let Ok(text) = unsafe { crate::py_str_wtf8(code) } {
+        let mut buf = text.as_bytes().to_vec();
+        buf.push(b'\n');
+        if PyError::write_to_sys_stderr(&buf) {
+            return 1;
+        }
+    }
+    // The host's stderr has no codec behind it, so a stream that is missing or
+    // refuses the write leaves the text to spend a `backslashreplace` encode
+    // here instead.
     let text = unsafe { crate::display::py_str_display(code) };
     crate::host_seam::emit_stderr(format!("{text}\n").as_bytes());
     1

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1226,10 +1226,37 @@ impl PyError {
                 (*(exc as *mut pyre_object::PyObject)).w_class = w_target;
             }
         }
-        let args_list = pyre_object::interp_exceptions::w_exception_args_new(vec![
-            pyre_object::w_int_new(errno as i64),
-            pyre_object::w_str_new(&strerror),
-        ]);
+        // `PyErr_SetExcFromWindowsErrWithFilenameObjects` builds the exception
+        // from `(errno, strerror, filename, winerror, filename2)`, and
+        // `oserror_init` trims that back to the leading pair only once there is
+        // a filename to carry the rest.  A Win32 failure naming no file keeps
+        // all five, which is what lets `.winerror` survive the round trip
+        // through `args` that a pickle or a re-raise makes.
+        //
+        // Each element is pinned as it is built and read back only once the
+        // last one exists: they are young objects held in a Rust local, so
+        // allocating the next one can relocate the ones already in hand.
+        let mut arg_slots = Vec::with_capacity(5);
+        {
+            let mut push = |obj: PyObjectRef| {
+                let slot = pyre_object::gc_roots::shadow_stack_len();
+                let _ = pyre_object::gc_roots::pin_root(obj);
+                arg_slots.push(slot);
+            };
+            push(pyre_object::w_int_new(errno as i64));
+            push(pyre_object::w_str_new(&strerror));
+            if let Some(code) = winerror.filter(|_| filename_slot.is_none()) {
+                push(pyre_object::w_none());
+                push(pyre_object::w_int_new(code as i64));
+                push(pyre_object::w_none());
+            }
+        }
+        let args_list = pyre_object::interp_exceptions::w_exception_args_new(
+            arg_slots
+                .iter()
+                .map(|&slot| pyre_object::gc_roots::shadow_stack_get(slot))
+                .collect(),
+        );
         unsafe {
             pyre_object::interp_exceptions::w_exception_set_args(exc, args_list);
             pyre_object::interp_exceptions::w_exception_set_errno(

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -466,7 +466,7 @@ macro_rules! py_class {
         $name:literal
         $(, methods: {
             $(
-                $(#[doc = $mdoc:literal])?
+                $(#[doc = $mdoc:literal] $(#[doc = $mdoc_cont:literal])*)?
                 fn $mname:ident ( $($margs:tt)* ) $(-> $mret:ty)? $mbody:block
             )*
         })?
@@ -499,7 +499,9 @@ macro_rules! py_class {
                                     stringify!($mname),
                                     $mname,
                                     ::core::option::Option::<&'static str>::None
-                                        $(.or(::core::option::Option::Some($mdoc)))?,
+                                        $(.or(::core::option::Option::Some(
+                                            ::core::concat!($mdoc $(, "\n", $mdoc_cont)*),
+                                        )))?,
                                 ),
                             ) };
                         }

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -1390,6 +1390,29 @@ pub fn stdio_newline(stream_name: &str) -> Option<&'static str> {
     stated.unwrap_or(platform_default)
 }
 
+/// Write already-encoded bytes through the print hook (if set) or stdout.
+///
+/// The bytes are what `sys.stdout`'s own encoder would have produced, which the
+/// native `print()` path stands in for only while that encoding is utf-8 --
+/// [`stdio_line_endings_bytes`] substitutes at the byte level, which no wider
+/// encoding survives. Only a string holding a surrogate reaches here: every
+/// other render is a `str` and takes [`print_output`].
+pub fn print_output_bytes(bytes: &[u8]) {
+    let bytes = stdio_line_endings_bytes(bytes, "stdout");
+    let bytes = bytes.as_ref();
+    if print_hook_emit_bytes(bytes) {
+        return;
+    }
+    #[cfg(all(unix, feature = "sandbox"))]
+    let _ = crate::host_seam::ops::write(1, bytes);
+    #[cfg(not(all(unix, feature = "sandbox")))]
+    {
+        use std::io::Write;
+        let _ = std::io::stdout().lock().write_all(bytes);
+    }
+    crate::host_seam::flush_stdout_when_unbuffered();
+}
+
 /// Write a string through the print hook (if set) or stdout.
 pub fn print_output(s: &str) {
     // `print()` writing to the unmodified `sys.stdout` short-circuits to here

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -32,6 +32,20 @@ const BADDR_KEY: &str = "_baddr_";
 /// Lazily-created keepalive dict on a root object.
 const OBJECTS_KEY: &str = "_objects_";
 
+/// The instance-dict keys above, which are the object's own storage rather
+/// than attributes anybody set.  `PyCData` keeps that state in C struct fields
+/// and hands `__dict__` back holding only what the program put there, so
+/// `__reduce__` leaves them out of the state it pickles.
+const STORAGE_KEYS: [&str; 7] = [
+    CDATA_BUFFER_KEY,
+    BOFF_KEY,
+    BSZ_KEY,
+    BBASE_KEY,
+    BINDEX_KEY,
+    BADDR_KEY,
+    OBJECTS_KEY,
+];
+
 static CDATA_TYPE_OBJ: OnceLock<usize> = OnceLock::new();
 static SIMPLECDATA_TYPE_OBJ: OnceLock<usize> = OnceLock::new();
 
@@ -87,6 +101,166 @@ fn init_cdata_type(ns: PyObjectRef) {
         "__ctypes_from_outparam__",
         crate::make_builtin_function("__ctypes_from_outparam__", |args| Ok(args[0])),
     );
+    // The pickling pair, alongside it in `PyCData_methods`.
+    type_ns_store(
+        ns,
+        "__reduce__",
+        crate::make_builtin_function_with_arity("__reduce__", cdata_reduce, 1),
+    );
+    type_ns_store(
+        ns,
+        "__setstate__",
+        crate::make_builtin_function_with_arity("__setstate__", cdata_setstate, 3),
+    );
+}
+
+/// `_CData.__reduce__` -- `PyCData_reduce`.
+///
+/// The pickled state is the attributes the program set plus the raw view
+/// bytes, and [`unpickle`] is named as the callable that rebuilds the object
+/// from them.  A value that holds a pointer is refused: the address it carries
+/// means nothing in the process that reads the pickle back.
+fn cdata_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let obj = args[0];
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let info = super::stginfo::stginfo_of(cls)
+        .ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    if super::stginfo::stginfo_flags(info)
+        & (super::stginfo::TYPEFLAG_ISPOINTER | super::stginfo::TYPEFLAG_HASPOINTER)
+        != 0
+    {
+        return Err(crate::PyError::value_error(
+            "ctypes objects containing pointers cannot be pickled",
+        ));
+    }
+    // The instance dict is read once, before anything allocates: the pairs it
+    // hands back are raw words, so a collection between the read and the last
+    // store would leave them behind.  Everything built after that is pinned as
+    // it is built and read back out of its slot.
+    let d = crate::baseobjspace::getdict_native(obj);
+    let attributes: Vec<(PyObjectRef, PyObjectRef)> = if d.is_null() {
+        Vec::new()
+    } else {
+        unsafe { pyre_object::dictmultiobject::w_dict_items(d) }
+            .into_iter()
+            .filter(|&(key, _)| {
+                !unsafe { pyre_object::is_str(key) }
+                    || !STORAGE_KEYS.contains(&unsafe { pyre_object::w_str_get_value(key) })
+            })
+            .collect()
+    };
+    let roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = roots.base();
+    let _ = roots.pin_root(obj);
+    let cls_slot = obj_slot + 1;
+    let _ = roots.pin_root(cls);
+    let attribute_base = cls_slot + 1;
+    for &(key, value) in &attributes {
+        let _ = roots.pin_root(key);
+        let _ = roots.pin_root(value);
+    }
+    let state_slot = attribute_base + 2 * attributes.len();
+    let _ = roots.pin_root(pyre_object::w_dict_new());
+    for i in 0..attributes.len() {
+        crate::baseobjspace::setitem(
+            roots.get(state_slot),
+            roots.get(attribute_base + 2 * i),
+            roots.get(attribute_base + 2 * i + 1),
+        )?;
+    }
+    let buffer = cdata_bytes_object(roots.get(obj_slot))
+        .ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    let buffer_slot = state_slot + 1;
+    let _ = roots.pin_root(buffer);
+    let inner = pyre_object::w_tuple_new(vec![roots.get(state_slot), roots.get(buffer_slot)]);
+    let inner_slot = buffer_slot + 1;
+    let _ = roots.pin_root(inner);
+    let outer = pyre_object::w_tuple_new(vec![roots.get(cls_slot), roots.get(inner_slot)]);
+    let outer_slot = inner_slot + 1;
+    let _ = roots.pin_root(outer);
+    Ok(pyre_object::w_tuple_new(vec![
+        unpickle_function(),
+        roots.get(outer_slot),
+    ]))
+}
+
+/// `_CData.__setstate__` -- `PyCData_setstate`.
+///
+/// The bytes are written over the view and truncated to it, so a state saved
+/// from a wider object fills what fits; the dictionary is merged into the
+/// attributes rather than replacing them.
+fn cdata_setstate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let obj = args[0];
+    if !unsafe { pyre_object::is_dict(args[1]) } {
+        return Err(crate::PyError::type_error(format!(
+            "argument 1 must be dict, not {}",
+            crate::gateway::short_type_name(args[1])
+        )));
+    }
+    let source = crate::typedef::buffer_as_bytes_like(args[2])?.ok_or_else(|| {
+        crate::PyError::type_error(format!(
+            "argument 2 must be str, not {}",
+            crate::gateway::short_type_name(args[2])
+        ))
+    })?;
+    cdata_write(obj, 0, unsafe {
+        pyre_object::bytesobject::bytes_like_data(source)
+    });
+    let d = crate::baseobjspace::getdict_native(obj);
+    if d.is_null() {
+        return Err(crate::PyError::type_error(
+            "ctypes instance has no instance dict",
+        ));
+    }
+    let items = unsafe { pyre_object::dictmultiobject::w_dict_items(args[1]) };
+    let roots = pyre_object::gc_roots::push_roots();
+    let d_slot = roots.base();
+    let _ = roots.pin_root(d);
+    let item_base = d_slot + 1;
+    for &(key, value) in &items {
+        let _ = roots.pin_root(key);
+        let _ = roots.pin_root(value);
+    }
+    for i in 0..items.len() {
+        crate::baseobjspace::setitem(
+            roots.get(d_slot),
+            roots.get(item_base + 2 * i),
+            roots.get(item_base + 2 * i + 1),
+        )?;
+    }
+    Ok(pyre_object::w_none())
+}
+
+static UNPICKLE_FUNCTION: OnceLock<usize> = OnceLock::new();
+
+/// `_ctypes._unpickle`, the callable [`cdata_reduce`] names.
+pub(super) fn unpickle_function() -> PyObjectRef {
+    *UNPICKLE_FUNCTION
+        .get_or_init(|| crate::make_builtin_function_with_arity("_unpickle", unpickle, 2) as usize)
+        as PyObjectRef
+}
+
+/// `_ctypes._unpickle` -- `_ctypes__unpickle_impl`.
+///
+/// Allocate an instance of the pickled class without running `__init__` -- the
+/// state is what decides its contents -- and hand it the state, so a subclass
+/// that writes its own `__setstate__` is the one that reads the state back.
+fn unpickle(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let cls = args[0];
+    let state = args[1];
+    let new = crate::baseobjspace::getattr_str(cls, "__new__")?;
+    let obj = crate::call::call_function_impl_result(new, &[cls])?;
+    let roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = roots.base();
+    let _ = roots.pin_root(obj);
+    let state_slot = obj_slot + 1;
+    let _ = roots.pin_root(state);
+    let setstate = crate::baseobjspace::getattr_str(roots.get(obj_slot), "__setstate__")?;
+    let setstate_slot = state_slot + 1;
+    let _ = roots.pin_root(setstate);
+    let state_args = crate::baseobjspace::fixedview(roots.get(state_slot), -1)?;
+    crate::call::call_function_impl_result(roots.get(setstate_slot), &state_args)?;
+    Ok(roots.get(obj_slot))
 }
 
 pub(super) fn cdata_in_dll(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -301,6 +301,11 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
         pyre_object::w_int_new(rustpython_host_env::ctypes::SIZEOF_TIME_T as i64),
     );
 
+    // The callable `_CData.__reduce__` names.  It has to be reachable by name
+    // for a pickle of a ctypes value to load at all, since that is what the
+    // stream carries.
+    crate::module_ns_store(ns, "_unpickle", super::cdata::unpickle_function());
+
     // ── import-time constants ──
     crate::module_ns_store(ns, "__version__", pyre_object::w_str_new("1.1.0"));
     // `crates/vm/src/stdlib/_ctypes.rs`: CDECL=0x1, PYTHONAPI=0x4,

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -1681,13 +1681,16 @@ fn set_type_attr(cls: PyObjectRef, key: &str, value: PyObjectRef) {
     }
 }
 
+/// `cls.__name__`, read the way `type.__name__` reads it.
+///
+/// An MRO lookup never finds it: the name is a `type` getset over the type
+/// object's own field, not an entry in any class dict along the chain.  Every
+/// caller here read `?` instead, so `c_int * 3` was named `?_Array_3`.
 fn type_name(cls: PyObjectRef) -> String {
-    match unsafe { crate::baseobjspace::lookup_in_type(cls, "__name__") } {
-        Some(o) if unsafe { pyre_object::is_str(o) } => {
-            unsafe { pyre_object::w_str_get_value(o) }.to_string()
-        }
-        _ => "?".to_string(),
+    if !unsafe { pyre_object::is_type(cls) } {
+        return "?".to_string();
     }
+    unsafe { pyre_object::w_str_get_value(pyre_object::w_type_get_name_obj(cls)) }.to_string()
 }
 
 // ── PyCArrayType + Array ───────────────────────────────────────────────

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -973,33 +973,36 @@ impl W_TextIOWrapper {
         Some(unsafe { &*(stream as *const Self) }.write_newline())
     }
 
-    /// Whether `stream` writes a `str` as the strict utf-8 bytes `print()`'s
-    /// native path produces.
+    /// The error handler the native `print()` path has to render with, for a
+    /// `stream` whose codec that path can spell at all.
     ///
     /// `print()` short-circuits the unmodified `sys.stdout` to `print_output`,
-    /// which renders strict utf-8 and hands those bytes to the descriptor. That
-    /// is what the stream itself would have written only while its codec is
-    /// utf-8 and its handler is `strict`: under `PYTHONIOENCODING=cp424`,
+    /// which writes utf-8 bytes straight to the descriptor, so the
+    /// short-circuit stands in for the stream's own `write` only while the
+    /// stream's codec is utf-8: under `PYTHONIOENCODING=cp424`,
     /// `sys.stdout.write(chr(0xa2))` writes `b'J'` where the native path writes
-    /// `b'Â¢'`. `reconfigure` rewrites both fields, so this follows it.
+    /// `b'\xc2\xa2'`. Both handlers pyre's own standard streams take -- `strict`
+    /// and the `surrogateescape` a C/POSIX locale asks for -- are spelled by
+    /// `encode_object`, and they part company only for a string holding a
+    /// surrogate. `reconfigure` rewrites both fields, so this follows it.
     ///
-    /// False for a stream this did not build: it states no codec here, and the
-    /// caller has to go through `write`.
-    pub fn stdio_renders_strict_utf8(stream: PyObjectRef) -> bool {
+    /// `None` for every other stream, including one this did not build: it
+    /// states no codec here, and the caller has to go through `write`.
+    pub fn stdio_native_print_errors(stream: PyObjectRef) -> Option<&'static str> {
         if stream.is_null()
             || !std::ptr::eq(
                 unsafe { pyre_object::ll_type(stream) },
                 <Self as pyre_object::lltype::PyreClassPyTypeOf>::PYTYPE,
             )
         {
-            return false;
+            return None;
         }
         let payload = unsafe { &*(stream as *const Self) };
         let (Some(encoding), Some(errors)) = (
             unsafe { pyre_object::w_str_get_value_opt(payload.w_encoding) },
             unsafe { pyre_object::w_str_get_value_opt(payload.w_errors) },
         ) else {
-            return false;
+            return None;
         };
         // `encodings.normalize_encoding` folds case and separators, so the
         // aliases `utf8`, `utf-8` and `UTF_8` all name the same codec.
@@ -1008,7 +1011,14 @@ impl W_TextIOWrapper {
             .filter(|c| !matches!(c, '-' | '_'))
             .flat_map(char::to_lowercase)
             .collect();
-        errors == "strict" && normalized == "utf8"
+        if normalized != "utf8" {
+            return None;
+        }
+        match errors {
+            "strict" => Some("strict"),
+            "surrogateescape" => Some("surrogateescape"),
+            _ => None,
+        }
     }
 
     /// Give a stream [`allocate_stdio`] built the encoder and decoder it had to

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -973,6 +973,44 @@ impl W_TextIOWrapper {
         Some(unsafe { &*(stream as *const Self) }.write_newline())
     }
 
+    /// Whether `stream` writes a `str` as the strict utf-8 bytes `print()`'s
+    /// native path produces.
+    ///
+    /// `print()` short-circuits the unmodified `sys.stdout` to `print_output`,
+    /// which renders strict utf-8 and hands those bytes to the descriptor. That
+    /// is what the stream itself would have written only while its codec is
+    /// utf-8 and its handler is `strict`: under `PYTHONIOENCODING=cp424`,
+    /// `sys.stdout.write(chr(0xa2))` writes `b'J'` where the native path writes
+    /// `b'Â¢'`. `reconfigure` rewrites both fields, so this follows it.
+    ///
+    /// False for a stream this did not build: it states no codec here, and the
+    /// caller has to go through `write`.
+    pub fn stdio_renders_strict_utf8(stream: PyObjectRef) -> bool {
+        if stream.is_null()
+            || !std::ptr::eq(
+                unsafe { pyre_object::ll_type(stream) },
+                <Self as pyre_object::lltype::PyreClassPyTypeOf>::PYTYPE,
+            )
+        {
+            return false;
+        }
+        let payload = unsafe { &*(stream as *const Self) };
+        let (Some(encoding), Some(errors)) = (
+            unsafe { pyre_object::w_str_get_value_opt(payload.w_encoding) },
+            unsafe { pyre_object::w_str_get_value_opt(payload.w_errors) },
+        ) else {
+            return false;
+        };
+        // `encodings.normalize_encoding` folds case and separators, so the
+        // aliases `utf8`, `utf-8` and `UTF_8` all name the same codec.
+        let normalized: String = encoding
+            .chars()
+            .filter(|c| !matches!(c, '-' | '_'))
+            .flat_map(char::to_lowercase)
+            .collect();
+        errors == "strict" && normalized == "utf8"
+    }
+
     /// Give a stream [`allocate_stdio`] built the encoder and decoder it had to
     /// go without.  Every read path needs the decoder: without it the stream
     /// reports itself unreadable however readable its buffer is, and only the

--- a/pyre/pyre-interpreter/src/module/_winapi/host.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/host.rs
@@ -28,7 +28,7 @@ fn win32_err_named(error: std::io::Error, w_name: PyObjectRef) -> crate::PyError
 /// How a call names a wide-string argument in the `TypeError` it raises for a
 /// non-`str`.  Most of them do not name it at all; the two path calls name it,
 /// and two more give its position.
-enum WideArg<'a> {
+pub(super) enum WideArg<'a> {
     Unnamed,
     Named {
         function: &'a str,
@@ -44,35 +44,50 @@ enum WideArg<'a> {
 ///
 /// The text goes to the host as spelled, unpaired surrogates included: these
 /// calls take UTF-16, and a lossy re-encode would name a different object.
-fn wide(w_text: PyObjectRef, argument: WideArg<'_>) -> Result<WideCString, crate::PyError> {
+pub(super) fn wide(
+    w_text: PyObjectRef,
+    argument: WideArg<'_>,
+) -> Result<WideCString, crate::PyError> {
     if !unsafe { pyre_object::is_str(w_text) } {
-        let got = crate::gateway::short_type_name(w_text);
-        return Err(crate::PyError::type_error(match argument {
-            WideArg::Unnamed => format!("argument must be str, not {got}"),
-            WideArg::Named { function, argument } => {
-                format!("{function}() argument '{argument}' must be str, not {got}")
-            }
-            WideArg::Numbered { function, position } => {
-                format!("{function}() argument {position} must be str, not {got}")
-            }
-        }));
+        return Err(wide_type_error(&argument, "str", w_text));
     }
-    WideCString::from_vec(wide_units(w_text))
-        .map_err(|_| crate::PyError::value_error("embedded null character"))
+    // `PyUnicode_AsWideCharString` refuses every NUL the text holds, the last
+    // character included; `WideCString::from_vec` would read that one as the
+    // terminator it appends itself and accept the string.
+    let units = wide_units(w_text);
+    if units.contains(&0) {
+        return Err(crate::PyError::value_error("embedded null character"));
+    }
+    WideCString::from_vec(units).map_err(|_| crate::PyError::value_error("embedded null character"))
 }
 
-/// [`wide`] where `None` names the Win32 default instead of a string.
-fn wide_or_none(w_text: PyObjectRef) -> Result<Option<WideCString>, crate::PyError> {
-    if unsafe { pyre_object::is_none(w_text) } {
+/// The `TypeError` a wide-string argument raises for a value it cannot take.
+fn wide_type_error(argument: &WideArg<'_>, accepted: &str, w_text: PyObjectRef) -> crate::PyError {
+    let got = crate::gateway::short_type_name(w_text);
+    crate::PyError::type_error(match argument {
+        WideArg::Unnamed => format!("argument must be {accepted}, not {got}"),
+        WideArg::Named { function, argument } => {
+            format!("{function}() argument '{argument}' must be {accepted}, not {got}")
+        }
+        WideArg::Numbered { function, position } => {
+            format!("{function}() argument {position} must be {accepted}, not {got}")
+        }
+    })
+}
+
+/// [`wide`] where `None` — or an argument that is not there at all — names the
+/// Win32 default instead of a string.
+pub(super) fn wide_or_none(
+    w_text: PyObjectRef,
+    argument: WideArg<'_>,
+) -> Result<Option<WideCString>, crate::PyError> {
+    if w_text.is_null() || unsafe { pyre_object::is_none(w_text) } {
         return Ok(None);
     }
     if !unsafe { pyre_object::is_str(w_text) } {
-        return Err(crate::PyError::type_error(format!(
-            "argument must be str or None, not {}",
-            crate::gateway::short_type_name(w_text)
-        )));
+        return Err(wide_type_error(&argument, "str or None", w_text));
     }
-    wide(w_text, WideArg::Unnamed).map(Some)
+    wide(w_text, argument).map(Some)
 }
 
 /// The UTF-16 units of a `str`, without a terminator.
@@ -288,7 +303,7 @@ pub fn CreateEventW(
             position: 1,
         },
     )?;
-    let name = wide_or_none(name)?;
+    let name = wide_or_none(name, WideArg::Unnamed)?;
     host_winapi::create_event_w(manual_reset != 0, initial_state != 0, name.as_deref())
         .map(w_handle)
         .map_err(super::win32_err)
@@ -351,7 +366,7 @@ pub fn CreateMutexW(
             position: 1,
         },
     )?;
-    let name = wide_or_none(name)?;
+    let name = wide_or_none(name, WideArg::Unnamed)?;
     host_winapi::create_mutex_w(initial_owner != 0, name.as_deref())
         .map(w_handle)
         .map_err(super::win32_err)

--- a/pyre/pyre-interpreter/src/module/_winapi/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/mod.rs
@@ -371,21 +371,19 @@ mod process {
     /// The two attribute arguments are security descriptors, which the call
     /// takes the defaults of.
     pub fn create_process(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let wide = |w: PyObjectRef| -> Result<Option<widestring::WideCString>, crate::PyError> {
-            if w.is_null() || unsafe { pyre_object::is_none(w) } {
-                return Ok(None);
-            }
-            let text = crate::baseobjspace::text_w(w)?;
-            widestring::WideCString::from_str(text)
-                .map(Some)
-                .map_err(|_| crate::PyError::value_error("embedded null character"))
-        };
+        use super::host::{WideArg, wide_or_none};
 
-        let application_name = wide(arg(args, 0, "CreateProcess")?)?;
+        let application_name = wide_or_none(arg(args, 0, "CreateProcess")?, WideArg::Unnamed)?;
         // `CreateProcessW` writes into the command line it is given, so it
         // takes a buffer rather than the string itself.
-        let mut command_line =
-            wide(arg(args, 1, "CreateProcess")?)?.map(|line| line.into_vec_with_nul());
+        let mut command_line = wide_or_none(
+            arg(args, 1, "CreateProcess")?,
+            WideArg::Numbered {
+                function: "CreateProcess",
+                position: 2,
+            },
+        )?
+        .map(|line| line.into_vec_with_nul());
         let inherit_handles = crate::baseobjspace::int_w(arg(args, 4, "CreateProcess")?)?;
         let creation_flags = crate::baseobjspace::c_uint_w(arg(args, 5, "CreateProcess")?)?;
         let w_env = arg(args, 6, "CreateProcess")?;
@@ -394,7 +392,7 @@ mod process {
         } else {
             Some(environment_block(w_env)?)
         };
-        let current_directory = wide(arg(args, 7, "CreateProcess")?)?;
+        let current_directory = wide_or_none(arg(args, 7, "CreateProcess")?, WideArg::Unnamed)?;
         let w_startup_info = arg(args, 8, "CreateProcess")?;
         let startup_info = host_winapi::StartupInfoData {
             flags: startup_info_field(w_startup_info, "dwFlags")? as u32,

--- a/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
+++ b/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
@@ -497,6 +497,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // registering, restore on unregister.  The handler writes a short
     // "user signal NN delivered" message to fd 2 (no traceback).
     // `handler.py register(signum, file=None, all_threads=True, chain=False)`.
+    //
+    // The pair exists only off Windows, which has no user signal to hand them
+    // (`moduledef.py` guards the two `extra_interpdef` calls on the platform).
+    // A name that is there but answers every call with an error is worse than
+    // no name: `hasattr(faulthandler, "register")` is how its callers ask.
+    #[cfg(unix)]
     crate::module_ns_store(
         ns,
         "register",
@@ -590,6 +596,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             ),
         ),
     );
+    #[cfg(unix)]
     crate::module_ns_store(
         ns,
         "unregister",

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -5899,27 +5899,24 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     /// call.  The entry never moves (`allocate_stable`), so the raw receiver
     /// stays valid across the fetch's allocation.
     fn dir_entry_get_lstat(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-        #[allow(unused_mut)]
-        let mut from_walk = None;
         {
             let de = W_DirEntry::from_obj(self_obj)
                 .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?;
             if !de.w_lstat.is_null() {
                 return Ok(de.w_lstat);
             }
-            // A walk that read the find record answers from it rather than
-            // returning to the name, which is what keeps a removed entry
-            // answering. The build is deferred to here so a listing nobody
-            // stats never pays for one.
-            #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
-            {
-                from_walk = de.win32_lstat;
-            }
         }
-        if let Some(_found) = from_walk {
-            #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
-            {
-                let result = stat_result_from_fields(&stat_fields_from_find_data(&_found), 0);
+        // A walk that read the find record answers from it rather than
+        // returning to the name, which is what keeps a removed entry
+        // answering. The build waits until here so a listing nobody stats
+        // never pays for one.
+        #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+        {
+            let found = W_DirEntry::from_obj(self_obj)
+                .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?
+                .win32_lstat;
+            if let Some(found) = found {
+                let result = stat_result_from_fields(&stat_fields_from_find_data(&found), 0);
                 let de = W_DirEntry::from_obj(self_obj).ok_or_else(|| {
                     crate::PyError::type_error("expected a 'posix.DirEntry' object")
                 })?;

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -43,6 +43,8 @@ struct ApplevelForkCallbacks {
 /// same enumeration reported (`0` for a name that is no reparse point), which
 /// is what `is_junction` reads; only a Windows directory walk fills it, and
 /// `DirEntry_is_junction` reads the same tag off `win32_lstat` there.
+/// `win32_lstat` is that walk's whole find record, kept so the first `stat()`
+/// builds the `stat_result` from it instead of returning to the name.
 /// The layout carries no instance dict; `name`/`path` are read-only getset
 /// descriptors, so the type is not instantiable and not acceptable as a base.
 #[crate::pyre_class("posix.DirEntry", cpython_heaptype)]
@@ -56,6 +58,35 @@ pub struct W_DirEntry {
     pub enum_ino: i64,
     pub enum_type: i32,
     pub enum_tag: i64,
+    #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+    pub win32_lstat: Option<WinFindData>,
+}
+
+/// The `WIN32_FIND_DATAW` members `_Py_attribute_data_to_stat` reads, in the
+/// place `DirEntry.win32_lstat` keeps them: an entry carries the record its
+/// enumeration reported and turns it into a `stat_result` only when asked.
+/// Building that object at enumeration time instead costs one `os.stat_result`
+/// -- ten sequence slots and thirteen named extras -- for every name in the
+/// directory, which is most of what listing one used to cost.
+///
+/// Stored as plain integers rather than the `WIN32_FIND_DATAW` itself: the
+/// find record is around 600 bytes, nearly all of it the two name buffers the
+/// entry has already turned into its `name` and `path`.
+#[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+#[derive(Clone, Copy)]
+pub struct WinFindData {
+    /// `dwFileAttributes`.
+    pub file_attributes: u32,
+    /// `dwReserved0`, which carries the reparse tag where the attribute word
+    /// says the name is a reparse point and is undefined otherwise.
+    pub reserved0: u32,
+    /// `nFileSizeHigh` and `nFileSizeLow` joined.
+    pub file_size: u64,
+    /// `ftCreationTime`, `ftLastAccessTime` and `ftLastWriteTime`, each as the
+    /// 100ns tick count its `FILETIME`'s two halves spell.
+    pub creation_ticks: u64,
+    pub last_access_ticks: u64,
+    pub last_write_ticks: u64,
 }
 
 /// Native owner for `posix.ScandirIterator` entries and enumeration state.
@@ -5143,9 +5174,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     /// that came out of `scandir`. `DirEntry.inode` is what goes back to the
     /// name for the identity.
     #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
-    fn stat_fields_from_find_data(
-        data: &windows_sys::Win32::Storage::FileSystem::WIN32_FIND_DATAW,
-    ) -> StatFields {
+    fn stat_fields_from_find_data(data: &WinFindData) -> StatFields {
         const FILE_ATTRIBUTE_READONLY: u32 = 0x1;
         const FILE_ATTRIBUTE_DIRECTORY: u32 = 0x10;
         const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
@@ -5153,17 +5182,17 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // A `FILETIME` counts 100ns ticks from 1601-01-01.
         const SECS_BETWEEN_EPOCHS: i64 = 11_644_473_600;
 
-        fn filetime_to_time(ft: windows_sys::Win32::Foundation::FILETIME) -> (i64, i64) {
-            let ticks = ((ft.dwHighDateTime as i64) << 32) | (ft.dwLowDateTime as i64);
+        fn filetime_to_time(ticks: u64) -> (i64, i64) {
+            let ticks = ticks as i64;
             (
                 ticks / 10_000_000 - SECS_BETWEEN_EPOCHS,
                 (ticks % 10_000_000) * 100,
             )
         }
 
-        let attrs = data.dwFileAttributes;
+        let attrs = data.file_attributes;
         let reparse_tag = if attrs & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
-            data.dwReserved0
+            data.reserved0
         } else {
             0
         };
@@ -5181,9 +5210,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             mode = (mode & !S_IFMT) | S_IFLNK;
         }
 
-        let (birthtime, birthtime_nsec) = filetime_to_time(data.ftCreationTime);
-        let (mtime, mtime_nsec) = filetime_to_time(data.ftLastWriteTime);
-        let (atime, atime_nsec) = filetime_to_time(data.ftLastAccessTime);
+        let (birthtime, birthtime_nsec) = filetime_to_time(data.creation_ticks);
+        let (mtime, mtime_nsec) = filetime_to_time(data.last_write_ticks);
+        let (atime, atime_nsec) = filetime_to_time(data.last_access_ticks);
         StatFields {
             mode: mode as i64,
             ino: 0,
@@ -5191,7 +5220,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             nlink: 0,
             uid: 0,
             gid: 0,
-            size: ((data.nFileSizeHigh as i64) << 32) | (data.nFileSizeLow as i64),
+            size: data.file_size as i64,
             atime,
             mtime,
             // `st_ctime` is the creation time here, which is the copy
@@ -5235,7 +5264,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
     fn win_scandir_each(
         path: &[u8],
-        mut each: impl FnMut(&[u8], &[u8], StatFields),
+        mut each: impl FnMut(&[u8], &[u8], WinFindData),
     ) -> std::io::Result<()> {
         use std::os::windows::ffi::{OsStrExt, OsStringExt};
         use windows_sys::Win32::Foundation::{ERROR_NO_MORE_FILES, INVALID_HANDLE_VALUE};
@@ -5262,6 +5291,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         let mut pattern = join_path_filename(&prefix, &[b'*' as u16, b'.' as u16, b'*' as u16]);
         pattern.push(0);
 
+        fn filetime_ticks(ft: windows_sys::Win32::Foundation::FILETIME) -> u64 {
+            ((ft.dwHighDateTime as u64) << 32) | (ft.dwLowDateTime as u64)
+        }
+
         let mut data: WIN32_FIND_DATAW = unsafe { std::mem::zeroed() };
         let handle = unsafe { FindFirstFileW(pattern.as_ptr(), &mut data) };
         if handle == INVALID_HANDLE_VALUE {
@@ -5282,7 +5315,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 each(
                     name.as_encoded_bytes(),
                     full.as_encoded_bytes(),
-                    stat_fields_from_find_data(&data),
+                    WinFindData {
+                        file_attributes: data.dwFileAttributes,
+                        reserved0: data.dwReserved0,
+                        file_size: ((data.nFileSizeHigh as u64) << 32)
+                            | (data.nFileSizeLow as u64),
+                        creation_ticks: filetime_ticks(data.ftCreationTime),
+                        last_access_ticks: filetime_ticks(data.ftLastAccessTime),
+                        last_write_ticks: filetime_ticks(data.ftLastWriteTime),
+                    },
                 );
             }
             if unsafe { FindNextFileW(handle, &mut data) } == 0 {
@@ -5848,11 +5889,33 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     /// call.  The entry never moves (`allocate_stable`), so the raw receiver
     /// stays valid across the fetch's allocation.
     fn dir_entry_get_lstat(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        #[allow(unused_mut)]
+        let mut from_walk = None;
         {
             let de = W_DirEntry::from_obj(self_obj)
                 .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?;
             if !de.w_lstat.is_null() {
                 return Ok(de.w_lstat);
+            }
+            // A walk that read the find record answers from it rather than
+            // returning to the name, which is what keeps a removed entry
+            // answering. The build is deferred to here so a listing nobody
+            // stats never pays for one.
+            #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+            {
+                from_walk = de.win32_lstat;
+            }
+        }
+        if let Some(_found) = from_walk {
+            #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+            {
+                let result = stat_result_from_fields(&stat_fields_from_find_data(&_found), 0);
+                let de = W_DirEntry::from_obj(self_obj).ok_or_else(|| {
+                    crate::PyError::type_error("expected a 'posix.DirEntry' object")
+                })?;
+                de.w_lstat = result;
+                unsafe { pyre_object::gc_hook::try_gc_write_barrier(self_obj as *mut u8) };
+                return Ok(result);
             }
         }
         let dir_fd = dir_entry_dir_fd(self_obj)?;
@@ -6243,21 +6306,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         full.extend_from_slice(name);
         full
     }
-    /// The reparse tag a walk's stat carries.  Only Windows has one; every
-    /// other host answers `0`, which is the "no reparse point" the field means
-    /// there too.
-    fn stat_fields_reparse_tag(_fields: &StatFields) -> i64 {
-        #[cfg(windows)]
-        let tag = _fields.reparse_tag as i64;
-        #[cfg(not(windows))]
-        let tag = 0i64;
-        tag
-    }
-
-    /// `lstat` is the stat the enumeration itself reported, which only a walk
-    /// reading `WIN32_FIND_DATAW` has; it is built and cached here so
-    /// `entry.stat()` answers from it (`DirEntry_from_find_data`).  Elsewhere
-    /// it is `None` and the first `stat()` goes to the name.
+    /// Returns the appended entry so a caller with more to record -- the
+    /// Windows walk, which also carries the find record -- writes it without a
+    /// second lookup.  The entry is `allocate_stable`, so that address stays
+    /// valid for as long as the list holds it.
     fn scandir_push_entry(
         list_slot: usize,
         bytes_mode: bool,
@@ -6266,34 +6318,26 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         dir_fd: i32,
         enum_ino: i64,
         enum_type: u8,
-        lstat: Option<StatFields>,
-    ) {
+    ) -> PyObjectRef {
         let _entry_scope = pyre_object::gc_roots::push_roots();
         let base = pyre_object::gc_roots::shadow_stack_len();
+        // The names are pinned before the entry is allocated, so a moving
+        // collection during `allocate_stable` forwards them.
         let _ = pyre_object::gc_roots::pin_root(fs_name_obj(bytes_mode, name));
         let _ = pyre_object::gc_roots::pin_root(fs_name_obj(bytes_mode, full));
-        // The built result is pinned before the entry is allocated, so a
-        // moving collection during `allocate_stable` forwards it.
-        let lstat_slot = lstat.as_ref().map(|fields| {
-            let _ = pyre_object::gc_roots::pin_root(stat_result_from_fields(fields, 0));
-            pyre_object::gc_roots::shadow_stack_len() - 1
-        });
         let _ = pyre_object::gc_roots::pin_root(W_DirEntry::allocate_stable(W_DirEntry::default()));
         let obj =
             pyre_object::gc_roots::shadow_stack_get(pyre_object::gc_roots::shadow_stack_len() - 1);
         let de = W_DirEntry::from_obj(obj).expect("freshly allocated posix.DirEntry");
         de.w_name = pyre_object::gc_roots::shadow_stack_get(base);
         de.w_path = pyre_object::gc_roots::shadow_stack_get(base + 1);
-        de.w_lstat = lstat_slot.map_or(pyre_object::PY_NULL, |slot| {
-            pyre_object::gc_roots::shadow_stack_get(slot)
-        });
         de.dir_fd = dir_fd;
         de.enum_ino = enum_ino;
         de.enum_type = enum_type as i32;
-        de.enum_tag = lstat.map_or(0, |fields| stat_fields_reparse_tag(&fields));
         unsafe { pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8) };
         let list = pyre_object::gc_roots::shadow_stack_get(list_slot);
         unsafe { pyre_object::w_list_append(list, obj) };
+        obj
     }
     fn scandir_fn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let (bound, _kwargs) = bind_path_args(args, "scandir", &["path"], 0, &[])?;
@@ -6332,7 +6376,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // so both come back as `str`. Every entry records the
                 // descriptor so its own stat resolves the bare name against it.
                 fd_readdir(fd, |name, ino, d_type| {
-                    scandir_push_entry(list_slot, false, name, name, fd, ino, d_type, None);
+                    scandir_push_entry(list_slot, false, name, name, fd, ino, d_type);
                 })
                 .map_err(|errno| errno_err_with_filename(errno, w_path()))?;
             }
@@ -6354,9 +6398,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 }
                 let errno = readdir_collect(dirp, |name, ino, d_type| {
                     let full = join_dir_name(path, name);
-                    scandir_push_entry(
-                        list_slot, bytes_mode, name, &full, -1, ino, d_type, None,
-                    );
+                    scandir_push_entry(list_slot, bytes_mode, name, &full, -1, ino, d_type);
                 });
                 unsafe { libc::closedir(dirp) };
                 if errno != 0 {
@@ -6370,18 +6412,23 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             // back to the name.
             #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
             _ => {
-                win_scandir_each(path, |name, full, fields| {
-                    let known_type = find_data_known_type(&fields);
-                    scandir_push_entry(
+                win_scandir_each(path, |name, full, found| {
+                    // The find record decides the type and the reparse tag
+                    // without allocating; only the `stat_result` waits for a
+                    // caller to ask for it.
+                    let fields = stat_fields_from_find_data(&found);
+                    let obj = scandir_push_entry(
                         list_slot,
                         bytes_mode,
                         name,
                         full,
                         -1,
                         -1,
-                        known_type,
-                        Some(fields),
+                        find_data_known_type(&fields),
                     );
+                    let de = W_DirEntry::from_obj(obj).expect("freshly appended posix.DirEntry");
+                    de.enum_tag = fields.reparse_tag as i64;
+                    de.win32_lstat = Some(found);
                 })
                 .map_err(|e| fs_err_with_filename(e, w_path()))?;
             }
@@ -6411,7 +6458,6 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         -1,
                         enum_ino,
                         DT_UNKNOWN,
-                        None,
                     );
                 }
             }

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -4468,6 +4468,33 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         ),
     );
 
+    // ── posix._inputhook() / posix._is_inputhook_installed() ──
+    // `PyOS_InputHook` is the seam a C extension (readline, Tk) installs a
+    // callback in so the REPL can pump its event loop while it waits for a
+    // line.  `_pyrepl`'s console reads both at start-up — `unix_console.py`
+    // and `windows_console.py` each answer `input_hook` with
+    // `posix._inputhook` when `posix._is_inputhook_installed()` says one is
+    // there — so a missing name is an `AttributeError` out of the interactive
+    // prompt, not a feature nobody asks for.
+    //
+    // Nothing in pyre publishes that seam, so the answers are the ones the
+    // calls give with no hook installed: `False`, and the 0 the absent hook
+    // would have returned.
+    crate::module_ns_store(
+        ns,
+        "_inputhook",
+        crate::make_builtin_function_with_arity("_inputhook", |_| Ok(pyre_object::w_int_new(0)), 0),
+    );
+    crate::module_ns_store(
+        ns,
+        "_is_inputhook_installed",
+        crate::make_builtin_function_with_arity(
+            "_is_inputhook_installed",
+            |_| Ok(pyre_object::w_bool_from(false)),
+            0,
+        ),
+    );
+
     // ── posix.urandom(n) → bytes ──
     crate::module_ns_store(
         ns,

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -1107,6 +1107,16 @@ fn nonstrict_wide_path(
     obj: PyObjectRef,
     func: &str,
 ) -> Result<(Vec<u16>, bool), crate::PyError> {
+    // `path_converter` reads a `str` argument's own wide units
+    // (`PyUnicode_AsWideCharString`) and reaches the filesystem codec only for
+    // `bytes`. Taking a `str` through the codec anyway costs a
+    // str -> bytes -> str round trip on every call -- and where the legacy
+    // filesystem encoding is in force it is not even a round trip, so a name
+    // no code page can spell would come back changed.
+    if unsafe { pyre_object::is_str(obj) } {
+        let units = wide_with_nul(unsafe { pyre_object::w_str_get_wtf8(obj) });
+        return Ok((units, false));
+    }
     let resolved = crate::gateway::fsencode_path_nonstrict_w(obj, func, "path")?;
     let as_bytes = unsafe { resolved.is_bytes() };
     let text = crate::gateway::fsdecode_filename_wtf8(&resolved.as_bytes);

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -39,7 +39,10 @@ struct ApplevelForkCallbacks {
 /// `known_type` half of `self.flags`), so `is_dir`/`is_file`/`is_symlink`
 /// answer from it without a stat when it is not `DT_UNKNOWN`; it defaults to
 /// `DT_UNKNOWN` (`0`) — the value for a host or filesystem that reports no
-/// type — which falls through to the stat.
+/// type — which falls through to the stat.  `enum_tag` is the reparse tag the
+/// same enumeration reported (`0` for a name that is no reparse point), which
+/// is what `is_junction` reads; only a Windows directory walk fills it, and
+/// `DirEntry_is_junction` reads the same tag off `win32_lstat` there.
 /// The layout carries no instance dict; `name`/`path` are read-only getset
 /// descriptors, so the type is not instantiable and not acceptable as a base.
 #[crate::pyre_class("posix.DirEntry", cpython_heaptype)]
@@ -52,6 +55,7 @@ pub struct W_DirEntry {
     pub dir_fd: i32,
     pub enum_ino: i64,
     pub enum_type: i32,
+    pub enum_tag: i64,
 }
 
 /// Native owner for `posix.ScandirIterator` entries and enumeration state.
@@ -1656,7 +1660,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         #[cfg(windows)]
         fn entry_fits(name: &[u8], value: &[u8]) -> Result<(), crate::PyError> {
             const MAX_ENV: usize = 32767;
-            let units = |bytes: &[u8]| String::from_utf8_lossy(bytes).encode_utf16().count();
+            // Through the same decoder the name reaches the API by, so a
+            // lone surrogate is counted as the one unit it is written as
+            // rather than as whatever a lossy decode substitutes for it.
+            let units =
+                |bytes: &[u8]| crate::typedef::fsdecode_wtf8_total(bytes).encode_wide().count();
             if units(name) + 1 + units(value) > MAX_ENV {
                 return Err(crate::PyError::value_error(format!(
                     "the environment variable is longer than {MAX_ENV} characters"
@@ -5125,6 +5133,170 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             .map(|st| stat_fields_from_statstruct(&st))
     }
 
+    /// `find_data_to_file_info` followed by `_Py_attribute_data_to_stat` --
+    /// the `lstat` a directory walk already knows, read out of the
+    /// `WIN32_FIND_DATAW` it reported rather than from a call of its own.
+    ///
+    /// A find record carries no link count, no file index and no volume, and
+    /// `find_data_to_file_info` zeroes the `BY_HANDLE_FILE_INFORMATION` it
+    /// fills, so `st_nlink`, `st_ino` and `st_dev` all read `0` on an entry
+    /// that came out of `scandir`. `DirEntry.inode` is what goes back to the
+    /// name for the identity.
+    #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+    fn stat_fields_from_find_data(
+        data: &windows_sys::Win32::Storage::FileSystem::WIN32_FIND_DATAW,
+    ) -> StatFields {
+        const FILE_ATTRIBUTE_READONLY: u32 = 0x1;
+        const FILE_ATTRIBUTE_DIRECTORY: u32 = 0x10;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        const IO_REPARSE_TAG_SYMLINK: u32 = 0xA000_000C;
+        // A `FILETIME` counts 100ns ticks from 1601-01-01.
+        const SECS_BETWEEN_EPOCHS: i64 = 11_644_473_600;
+
+        fn filetime_to_time(ft: windows_sys::Win32::Foundation::FILETIME) -> (i64, i64) {
+            let ticks = ((ft.dwHighDateTime as i64) << 32) | (ft.dwLowDateTime as i64);
+            (
+                ticks / 10_000_000 - SECS_BETWEEN_EPOCHS,
+                (ticks % 10_000_000) * 100,
+            )
+        }
+
+        let attrs = data.dwFileAttributes;
+        let reparse_tag = if attrs & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            data.dwReserved0
+        } else {
+            0
+        };
+        let mut mode = if attrs & FILE_ATTRIBUTE_DIRECTORY != 0 {
+            S_IFDIR | 0o111
+        } else {
+            S_IFREG
+        };
+        mode |= if attrs & FILE_ATTRIBUTE_READONLY != 0 {
+            0o444
+        } else {
+            0o666
+        };
+        if reparse_tag == IO_REPARSE_TAG_SYMLINK {
+            mode = (mode & !S_IFMT) | S_IFLNK;
+        }
+
+        let (birthtime, birthtime_nsec) = filetime_to_time(data.ftCreationTime);
+        let (mtime, mtime_nsec) = filetime_to_time(data.ftLastWriteTime);
+        let (atime, atime_nsec) = filetime_to_time(data.ftLastAccessTime);
+        StatFields {
+            mode: mode as i64,
+            ino: 0,
+            dev: 0,
+            nlink: 0,
+            uid: 0,
+            gid: 0,
+            size: ((data.nFileSizeHigh as i64) << 32) | (data.nFileSizeLow as i64),
+            atime,
+            mtime,
+            // `st_ctime` is the creation time here, which is the copy
+            // `DirEntry_from_find_data` makes across from `st_birthtime`.
+            ctime: birthtime,
+            atime_ns: whole_ns(atime, atime_nsec),
+            mtime_ns: whole_ns(mtime, mtime_nsec),
+            ctime_ns: whole_ns(birthtime, birthtime_nsec),
+            file_attributes: attrs,
+            reparse_tag,
+            birthtime,
+            birthtime_ns: whole_ns(birthtime, birthtime_nsec),
+        }
+    }
+
+    /// The `DT_*` an entry's find data decides, so `is_dir`, `is_file` and
+    /// `is_symlink` answer from the walk rather than from the name.  A reparse
+    /// point that is not a symlink -- a junction, or any other tag -- is the
+    /// directory or file its attribute word says it is, which is how
+    /// `DirEntry_test_mode` reads `FILE_ATTRIBUTE_DIRECTORY` for everything
+    /// its `win32_lstat` did not spell `S_IFLNK`.
+    #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+    fn find_data_known_type(fields: &StatFields) -> u8 {
+        match fields.mode as u32 & S_IFMT {
+            S_IFLNK => DT_LNK,
+            S_IFDIR => DT_DIR,
+            _ => DT_REG,
+        }
+    }
+
+    /// `os_scandir_impl`'s Windows arm -- `FindFirstFileW` over the directory
+    /// joined to `*.*`.  It is the one directory walk that hands each entry's
+    /// `WIN32_FIND_DATAW` back, which is what lets a `DirEntry` answer
+    /// `is_dir`, `is_file` and `stat` without returning to the name, and so
+    /// keep answering after the name is removed.
+    ///
+    /// `join_path_filenameW` puts a separator between the directory and the
+    /// name unless the directory already ends in one or in a drive's colon,
+    /// and it leaves an empty directory empty -- `FindFirstFileW("")` then
+    /// fails the way `os.scandir("")` reports.
+    #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+    fn win_scandir_each(
+        path: &[u8],
+        mut each: impl FnMut(&[u8], &[u8], StatFields),
+    ) -> std::io::Result<()> {
+        use std::os::windows::ffi::{OsStrExt, OsStringExt};
+        use windows_sys::Win32::Foundation::{ERROR_NO_MORE_FILES, INVALID_HANDLE_VALUE};
+        use windows_sys::Win32::Storage::FileSystem::{
+            FindClose, FindFirstFileW, FindNextFileW, WIN32_FIND_DATAW,
+        };
+
+        const SEP_UNIT: u16 = b'\\' as u16;
+        const ALTSEP_UNIT: u16 = b'/' as u16;
+        const COLON_UNIT: u16 = b':' as u16;
+
+        fn join_path_filename(prefix: &[u16], name: &[u16]) -> Vec<u16> {
+            let mut joined = prefix.to_vec();
+            if let Some(&last) = joined.last() {
+                if last != SEP_UNIT && last != ALTSEP_UNIT && last != COLON_UNIT {
+                    joined.push(SEP_UNIT);
+                }
+                joined.extend_from_slice(name);
+            }
+            joined
+        }
+
+        let prefix: Vec<u16> = os_str_from_bytes(path).encode_wide().collect();
+        let mut pattern = join_path_filename(&prefix, &[b'*' as u16, b'.' as u16, b'*' as u16]);
+        pattern.push(0);
+
+        let mut data: WIN32_FIND_DATAW = unsafe { std::mem::zeroed() };
+        let handle = unsafe { FindFirstFileW(pattern.as_ptr(), &mut data) };
+        if handle == INVALID_HANDLE_VALUE {
+            return Err(std::io::Error::last_os_error());
+        }
+        loop {
+            let len = data
+                .cFileName
+                .iter()
+                .position(|&unit| unit == 0)
+                .unwrap_or(data.cFileName.len());
+            let name_units = &data.cFileName[..len];
+            let dot = [b'.' as u16];
+            let dotdot = [b'.' as u16, b'.' as u16];
+            if name_units != dot && name_units != dotdot {
+                let name = std::ffi::OsString::from_wide(name_units);
+                let full = std::ffi::OsString::from_wide(&join_path_filename(&prefix, name_units));
+                each(
+                    name.as_encoded_bytes(),
+                    full.as_encoded_bytes(),
+                    stat_fields_from_find_data(&data),
+                );
+            }
+            if unsafe { FindNextFileW(handle, &mut data) } == 0 {
+                let error = std::io::Error::last_os_error();
+                unsafe { FindClose(handle) };
+                return if error.raw_os_error() == Some(ERROR_NO_MORE_FILES as i32) {
+                    Ok(())
+                } else {
+                    Err(error)
+                };
+            }
+        }
+    }
+
     /// Where the `host_env::posix`-backed implementations below are compiled.
     /// Elsewhere those names are the noop placeholders registered near the top
     /// of this function, which cannot serve a descriptor.
@@ -5462,7 +5634,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
 
     /// Answer `is_dir`/`is_file`/`is_symlink` from the enumeration `d_type`
     /// when it decides the question, else `None` to fall through to a stat
-    /// (`interp_scandir.py:399-426`).  `target` is the `DT_*` the query wants.
+    /// (`W_DirEntry.is_dir` / `.is_file` / `.is_symlink`).  A Windows walk
+    /// reports the type for every entry, so only a followed query on a symlink
+    /// reaches the stat there -- which is the
+    /// `need_stat = follow_symlinks && is_symlink` of `DirEntry_test_mode`.
+    /// `target` is the `DT_*` the query wants.
     /// An unknown type never decides.  A symlink decides every query but a
     /// followed `is_dir`/`is_file`, which need the target's type instead.
     fn dir_entry_kind_from_type(known: u8, target: u8, follow: bool) -> Option<bool> {
@@ -5533,26 +5709,30 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         };
         Ok(pyre_object::w_bool_from(ans))
     }
+    /// `os_DirEntry_is_symlink_impl`.  `is_symlink` never follows, so a known
+    /// non-`DT_LNK` type answers `false` and `DT_LNK` answers `true`; only
+    /// `DT_UNKNOWN` needs the lstat.
+    fn dir_entry_is_symlink_value(args: &[PyObjectRef]) -> Result<bool, crate::PyError> {
+        match dir_entry_kind_from_type(dir_entry_known_type(args[0]), DT_LNK, false) {
+            Some(b) => Ok(b),
+            None => Ok(dir_entry_kind(args, false)? == Some(S_IFLNK)),
+        }
+    }
     fn dir_entry_is_symlink(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        // `is_symlink` never follows, so a known non-`DT_LNK` type answers `false`
-        // and `DT_LNK` answers `true`; only `DT_UNKNOWN` needs the lstat.
-        let ans = match dir_entry_kind_from_type(dir_entry_known_type(args[0]), DT_LNK, false) {
-            Some(b) => b,
-            None => dir_entry_kind(args, false)? == Some(S_IFLNK),
-        };
-        Ok(pyre_object::w_bool_from(ans))
+        Ok(pyre_object::w_bool_from(dir_entry_is_symlink_value(args)?))
     }
     fn dir_entry_is_junction(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // `DirEntry_is_junction` -- the lstat's reparse tag naming a mount
         // point. A name that is no reparse point at all carries tag 0.
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
         {
-            const IO_REPARSE_TAG_MOUNT_POINT: u32 = 0xA000_0003;
-            let (w_path, path) = dir_entry_path(_args[0])?;
-            let fields =
-                win_stat_fields(&path, false).map_err(|e| fs_err_with_filename(e, w_path))?;
+            // The walk reported that tag, so the answer costs no call and
+            // survives the name being removed.
+            const IO_REPARSE_TAG_MOUNT_POINT: i64 = 0xA000_0003;
+            let de = W_DirEntry::from_obj(_args[0])
+                .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?;
             return Ok(pyre_object::w_bool_from(
-                fields.reparse_tag == IO_REPARSE_TAG_MOUNT_POINT,
+                de.enum_tag == IO_REPARSE_TAG_MOUNT_POINT,
             ));
         }
         // POSIX has no junction points.
@@ -5667,27 +5847,51 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     /// does.)  Only a successful fetch is cached; an error re-raises on each
     /// call.  The entry never moves (`allocate_stable`), so the raw receiver
     /// stays valid across the fetch's allocation.
-    fn dir_entry_stat(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let self_obj = args[0];
-        let follow = dir_entry_follow(args)?;
+    fn dir_entry_get_lstat(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
         {
             let de = W_DirEntry::from_obj(self_obj)
                 .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?;
-            let cached = if follow { de.w_stat } else { de.w_lstat };
-            if !cached.is_null() {
-                return Ok(cached);
+            if !de.w_lstat.is_null() {
+                return Ok(de.w_lstat);
             }
         }
         let dir_fd = dir_entry_dir_fd(self_obj)?;
         let (w_path, path) = dir_entry_path(self_obj)?;
-        let result = dir_entry_fetch_stat(w_path, &path, follow, dir_fd)?;
+        let result = dir_entry_fetch_stat(w_path, &path, false, dir_fd)?;
         let de = W_DirEntry::from_obj(self_obj)
             .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?;
-        if follow {
-            de.w_stat = result;
-        } else {
-            de.w_lstat = result;
+        de.w_lstat = result;
+        unsafe { pyre_object::gc_hook::try_gc_write_barrier(self_obj as *mut u8) };
+        Ok(result)
+    }
+    fn dir_entry_stat(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = args[0];
+        let follow = dir_entry_follow(args)?;
+        if !follow {
+            return dir_entry_get_lstat(self_obj);
         }
+        {
+            let de = W_DirEntry::from_obj(self_obj)
+                .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?;
+            if !de.w_stat.is_null() {
+                return Ok(de.w_stat);
+            }
+        }
+        // `os_DirEntry_stat_impl` returns to the name for a followed stat only
+        // where the entry is a symlink; anything else is its own `lstat`, and
+        // `get_stat` (interp_scandir.py) decides it the same way. An entry
+        // whose walk reported the `lstat` has therefore answered both.
+        let receiver = [self_obj];
+        let result = if dir_entry_is_symlink_value(&receiver)? {
+            let dir_fd = dir_entry_dir_fd(self_obj)?;
+            let (w_path, path) = dir_entry_path(self_obj)?;
+            dir_entry_fetch_stat(w_path, &path, true, dir_fd)?
+        } else {
+            dir_entry_get_lstat(self_obj)?
+        };
+        let de = W_DirEntry::from_obj(self_obj)
+            .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?;
+        de.w_stat = result;
         // `result` may be a nursery object stored into the stable entry; join
         // the remembered set so the next minor collection forwards it.
         unsafe { pyre_object::gc_hook::try_gc_write_barrier(self_obj as *mut u8) };
@@ -6039,6 +6243,21 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         full.extend_from_slice(name);
         full
     }
+    /// The reparse tag a walk's stat carries.  Only Windows has one; every
+    /// other host answers `0`, which is the "no reparse point" the field means
+    /// there too.
+    fn stat_fields_reparse_tag(_fields: &StatFields) -> i64 {
+        #[cfg(windows)]
+        let tag = _fields.reparse_tag as i64;
+        #[cfg(not(windows))]
+        let tag = 0i64;
+        tag
+    }
+
+    /// `lstat` is the stat the enumeration itself reported, which only a walk
+    /// reading `WIN32_FIND_DATAW` has; it is built and cached here so
+    /// `entry.stat()` answers from it (`DirEntry_from_find_data`).  Elsewhere
+    /// it is `None` and the first `stat()` goes to the name.
     fn scandir_push_entry(
         list_slot: usize,
         bytes_mode: bool,
@@ -6047,19 +6266,31 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         dir_fd: i32,
         enum_ino: i64,
         enum_type: u8,
+        lstat: Option<StatFields>,
     ) {
         let _entry_scope = pyre_object::gc_roots::push_roots();
         let base = pyre_object::gc_roots::shadow_stack_len();
         let _ = pyre_object::gc_roots::pin_root(fs_name_obj(bytes_mode, name));
         let _ = pyre_object::gc_roots::pin_root(fs_name_obj(bytes_mode, full));
+        // The built result is pinned before the entry is allocated, so a
+        // moving collection during `allocate_stable` forwards it.
+        let lstat_slot = lstat.as_ref().map(|fields| {
+            let _ = pyre_object::gc_roots::pin_root(stat_result_from_fields(fields, 0));
+            pyre_object::gc_roots::shadow_stack_len() - 1
+        });
         let _ = pyre_object::gc_roots::pin_root(W_DirEntry::allocate_stable(W_DirEntry::default()));
-        let obj = pyre_object::gc_roots::shadow_stack_get(base + 2);
+        let obj =
+            pyre_object::gc_roots::shadow_stack_get(pyre_object::gc_roots::shadow_stack_len() - 1);
         let de = W_DirEntry::from_obj(obj).expect("freshly allocated posix.DirEntry");
         de.w_name = pyre_object::gc_roots::shadow_stack_get(base);
         de.w_path = pyre_object::gc_roots::shadow_stack_get(base + 1);
+        de.w_lstat = lstat_slot.map_or(pyre_object::PY_NULL, |slot| {
+            pyre_object::gc_roots::shadow_stack_get(slot)
+        });
         de.dir_fd = dir_fd;
         de.enum_ino = enum_ino;
         de.enum_type = enum_type as i32;
+        de.enum_tag = lstat.map_or(0, |fields| stat_fields_reparse_tag(&fields));
         unsafe { pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8) };
         let list = pyre_object::gc_roots::shadow_stack_get(list_slot);
         unsafe { pyre_object::w_list_append(list, obj) };
@@ -6101,7 +6332,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // so both come back as `str`. Every entry records the
                 // descriptor so its own stat resolves the bare name against it.
                 fd_readdir(fd, |name, ino, d_type| {
-                    scandir_push_entry(list_slot, false, name, name, fd, ino, d_type);
+                    scandir_push_entry(list_slot, false, name, name, fd, ino, d_type, None);
                 })
                 .map_err(|errno| errno_err_with_filename(errno, w_path()))?;
             }
@@ -6123,17 +6354,41 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 }
                 let errno = readdir_collect(dirp, |name, ino, d_type| {
                     let full = join_dir_name(path, name);
-                    scandir_push_entry(list_slot, bytes_mode, name, &full, -1, ino, d_type);
+                    scandir_push_entry(
+                        list_slot, bytes_mode, name, &full, -1, ino, d_type, None,
+                    );
                 });
                 unsafe { libc::closedir(dirp) };
                 if errno != 0 {
                     return Err(errno_err_with_filename(errno, w_path()));
                 }
             }
+            // `FindFirstFileW` reports each entry's whole `WIN32_FIND_DATAW`,
+            // so the type and the `lstat` are both known without a second
+            // call and the entry keeps answering after the name is removed.
+            // A find record carries no file index, so `inode()` alone goes
+            // back to the name.
+            #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+            _ => {
+                win_scandir_each(path, |name, full, fields| {
+                    let known_type = find_data_known_type(&fields);
+                    scandir_push_entry(
+                        list_slot,
+                        bytes_mode,
+                        name,
+                        full,
+                        -1,
+                        -1,
+                        known_type,
+                        Some(fields),
+                    );
+                })
+                .map_err(|e| fs_err_with_filename(e, w_path()))?;
+            }
             // No raw `readdir` to read the dirent from (wasm, the sandbox seam,
             // or a build without `host_env`), so `d_type` is unknown and
             // `is_dir` stats; the inode is still free from the dirent on unix.
-            #[cfg(not(all(unix, feature = "host_env", not(feature = "sandbox"))))]
+            #[cfg(not(all(any(unix, windows), feature = "host_env", not(feature = "sandbox"))))]
             _ => {
                 let entries = host_fs::read_dir(path_from_bytes(path).as_ref())
                     .map_err(|e| fs_err_with_filename(e, w_path()))?;
@@ -6156,6 +6411,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         -1,
                         enum_ino,
                         DT_UNKNOWN,
+                        None,
                     );
                 }
             }

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -2059,6 +2059,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             w_int_new(implementation_hexversion),
         );
         crate::baseobjspace::setdictvalue_native(impl_obj, "cache_tag", w_str_new("pyre314"));
+        // PEP 734. pyre runs one interpreter per process, so the answer is
+        // false; `sys.implementation` carries the name either way from 3.14 on.
+        crate::baseobjspace::setdictvalue_native(
+            impl_obj,
+            "supports_isolated_interpreters",
+            w_bool_from(false),
+        );
         crate::baseobjspace::setdictvalue_native(
             impl_obj,
             "_multiarch",

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1730,12 +1730,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // carries its `st_*_ns` extras in. `test.support.os_helper` reads
     // `.platform` at import, so every `test.support` consumer needs it.
     //
-    // `major`/`minor`/`build` are kernel32's own file version rather than
-    // `GetVersionEx`'s answer: that call reports the version an unmanifested
-    // binary is shimmed to, and only an application manifest declaring
-    // compatibility makes it report the running one. `platform_version` — the
-    // field that exists because of exactly that shimming — therefore agrees
-    // with them here instead of correcting them.
+    // `major`/`minor`/`build` are `GetVersionEx`'s answer, which is the running
+    // version because the executable carries `python.manifest`; without one the
+    // call reports the version the process is shimmed to.  `platform_version`
+    // is kernel32's own file version
+    // (`_sys_getwindowsversion_from_kernel32`), which is a different number on
+    // a release shipped as an enablement package over the previous build.
     #[cfg(windows)]
     module_ns_store(
         ns,
@@ -1774,12 +1774,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         ),
                     ) as usize
                 }) as PyObjectRef;
+                let (major, minor, build) =
+                    version_ex_triple().unwrap_or((info.major, info.minor, info.build));
                 Ok(crate::_structseq::new_instance_with_extra(
                     cls,
                     vec![
-                        w_int_new(info.major as i64),
-                        w_int_new(info.minor as i64),
-                        w_int_new(info.build as i64),
+                        w_int_new(major as i64),
+                        w_int_new(minor as i64),
+                        w_int_new(build as i64),
                         w_int_new(info.platform as i64),
                         w_str_new(&info.service_pack),
                     ],
@@ -3684,6 +3686,22 @@ pub fn init_stream_codecs() -> Result<(), crate::PyError> {
         }
     }
     Ok(())
+}
+
+/// The version `GetVersionEx` reports, which the manifest the executable
+/// carries makes the running one rather than the one an unmanifested process is
+/// shimmed to.  `None` where the call fails, leaving the caller its own answer.
+#[cfg(windows)]
+fn version_ex_triple() -> Option<(u32, u32, u32)> {
+    use windows_sys::Win32::System::SystemInformation::{GetVersionExW, OSVERSIONINFOW};
+
+    let mut info: OSVERSIONINFOW = unsafe { std::mem::zeroed() };
+    info.dwOSVersionInfoSize = std::mem::size_of::<OSVERSIONINFOW>() as u32;
+    (unsafe { GetVersionExW(&mut info) } != 0).then_some((
+        info.dwMajorVersion,
+        info.dwMinorVersion,
+        info.dwBuildNumber,
+    ))
 }
 
 fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -2757,12 +2757,6 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             0,
         ),
     );
-    // sys.exc_clear — no-op
-    module_ns_store(
-        ns,
-        "exc_clear",
-        make_builtin_function_with_arity("exc_clear", |_| Ok(w_none()), 0),
-    );
     module_ns_store(
         ns,
         "call_tracing",

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -3665,38 +3665,6 @@ fn live_stdio_encoding_errors(stream_name: &str, default_errors: &str) -> (Strin
     )
 }
 
-fn stdio_stdin_readline(args: &[PyObjectRef]) -> crate::PyResult {
-    if args.len() > 1 {
-        return Err(crate::PyError::type_error(format!(
-            "readline() takes at most one argument ({} given)",
-            args.len()
-        )));
-    }
-    let sys = crate::importing::get_sys_module("sys")
-        .ok_or_else(|| crate::PyError::runtime_error("lost sys.stdin"))?;
-    let stdin = crate::baseobjspace::getattr_str(sys, "stdin")?;
-    let buffer = crate::baseobjspace::getattr_str(stdin, "buffer")?;
-    let bytes = crate::baseobjspace::call_method(buffer, "readline", args);
-    if bytes.is_null() {
-        return Err(crate::call::take_call_error()
-            .unwrap_or_else(|| crate::PyError::runtime_error("readline failed")));
-    }
-    if !unsafe { pyre_object::is_bytes(bytes) } {
-        return Err(crate::PyError::type_error(
-            "underlying readline() should have returned a bytes-like object",
-        ));
-    }
-    let _roots = pyre_object::gc_roots::push_roots();
-    let _ = pyre_object::gc_roots::pin_root(bytes);
-    let bytes_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    let (encoding, errors) = live_stdio_encoding_errors("stdin", "strict");
-    crate::typedef::bytes_method_decode(&[
-        pyre_object::gc_roots::shadow_stack_get(bytes_slot),
-        w_str_new(&encoding),
-        w_str_new(&errors),
-    ])
-}
-
 /// `pylifecycle.c init_sys_streams` builds the standard streams after the
 /// import system, so a text codec is reachable by the time they need one.
 /// Pyre builds them from `sys` module creation instead, where the codec lookup
@@ -3901,13 +3869,6 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
         })
     };
     crate::baseobjspace::setdictvalue_native(stream, "write", write_fn);
-    if fd == 0 {
-        crate::baseobjspace::setdictvalue_native(
-            stream,
-            "readline",
-            crate::make_builtin_function("readline", stdio_stdin_readline),
-        );
-    }
     crate::baseobjspace::setdictvalue_native(
         stream,
         "flush",

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -3624,27 +3624,100 @@ fn sys_clear_type_descriptors(args: &[PyObjectRef]) -> crate::PyResult {
 /// real W_File-backed `TextIOWrapper`; pyre routes writes through Rust's
 /// stdout/stderr (the same sink as `print`) so output ordering is preserved,
 /// storing the read/write surface as instance attributes.
+/// `initstdio`'s test for the default error handler: UTF-8 mode, or the legacy
+/// C/POSIX locale, asks for `surrogateescape`; every other locale settles for
+/// the `strict` that `TextIOWrapper(errors=None)` takes.
+///
+/// Windows answers yes outright. `initstdio` reaches that through UTF-8 mode,
+/// which PyPy runs the whole platform in -- `sys.flags.utf8_mode` reads 1 there
+/// -- and pyre does not, because 3.14 reports 0 unless `-X utf8` asked for it;
+/// `config_get_stdio_errors` states the same answer as its own `MS_WINDOWS`
+/// arm instead of deriving it. Measured, both interpreters answer
+/// `surrogateescape` on this platform. The locale test could not stand in for
+/// it either: the MSVC runtime's `setlocale(LC_CTYPE, "")` reads the user's
+/// ANSI locale and ignores `LC_ALL`, so it never sees C there.
+fn locale_asks_for_surrogateescape() -> bool {
+    #[cfg(windows)]
+    {
+        true
+    }
+    #[cfg(not(windows))]
+    {
+        if crate::importing::utf8_mode_flag() != 0 {
+            return true;
+        }
+        #[cfg(all(unix, feature = "host_env", not(feature = "sandbox")))]
+        {
+            // `initstdio` installs the locale the environment names before
+            // reading it back, so what is tested is the locale the C library
+            // took rather than the variables that asked for it.
+            rustpython_host_env::locale::setlocale(libc::LC_CTYPE, Some(c""));
+            let effective = rustpython_host_env::locale::setlocale(libc::LC_CTYPE, None);
+            matches!(effective.as_deref(), None | Some(b"C") | Some(b"POSIX"))
+        }
+        // No locale database at all -- wasm32, and the sandbox, whose
+        // `_locale.setlocale` answers `C` for every category.
+        #[cfg(not(all(unix, feature = "host_env", not(feature = "sandbox"))))]
+        {
+            true
+        }
+    }
+}
+
+/// `app_main.py initstdio`: the encoding and error handler the standard streams
+/// open with.
+///
+/// PYTHONIOENCODING is `encoding[:errors]`, and which half the user filled in
+/// decides what an empty handler half means. A non-empty encoding is explicit
+/// and settles for `strict`; an omitted one leaves the handler to
+/// [`locale_asks_for_surrogateescape`]. So `iso8859-1` and `iso8859-1:` both
+/// answer `strict`, while `:`, the empty value and no value at all answer
+/// whatever the locale asks for. stderr replaces the handler with
+/// `backslashreplace` separately.
+///
+/// `_WIN32 and not encoding` fixes the encoding at utf-8 rather than the ANSI
+/// code page; pyre takes that on every platform rather than resolving
+/// `initstdio`'s `"locale"`, which agrees with it wherever the locale encoding
+/// is utf-8.
+///
+/// Resolved once: `initstdio` runs once, and a later `locale.setlocale` must
+/// not change the answer a stream is already open with.
 fn stdio_encoding_and_errors() -> (String, String) {
-    // PyPy app_main.py `initstdio`: a non-empty encoding before ':' is
-    // explicit; an omitted encoding defaults to UTF-8 here, while a non-empty
-    // errors suffix overrides the normal strict policy. stderr replaces its
-    // error policy separately below.
-    let Some(raw) = crate::importing::stdio_encoding() else {
-        return ("utf-8".to_string(), "strict".to_string());
-    };
-    let (encoding, errors) = match raw.split_once(':') {
-        Some((encoding, errors)) => (
-            if encoding.is_empty() {
-                "utf-8"
-            } else {
-                encoding
-            },
-            if errors.is_empty() { "strict" } else { errors },
-        ),
-        None if raw.is_empty() => ("utf-8", "strict"),
-        None => (raw.as_str(), "strict"),
-    };
-    (encoding.to_string(), errors.to_string())
+    static RESOLVED: OnceLock<(String, String)> = OnceLock::new();
+    RESOLVED
+        .get_or_init(|| {
+            let raw = crate::importing::stdio_encoding();
+            let (encoding, errors, user_set_encoding) = match raw.as_deref() {
+                Some(value) if value.contains(':') => {
+                    let (encoding, errors) = value.split_once(':').expect("value holds a ':'");
+                    let user_set_encoding = !encoding.is_empty();
+                    let errors = if !errors.is_empty() {
+                        Some(errors)
+                    } else if user_set_encoding {
+                        Some("strict")
+                    } else {
+                        None
+                    };
+                    let encoding = if encoding.is_empty() {
+                        "utf-8"
+                    } else {
+                        encoding
+                    };
+                    (encoding, errors, user_set_encoding)
+                }
+                Some(value) if !value.is_empty() => (value, None, true),
+                _ => ("utf-8", None, false),
+            };
+            let errors = match errors {
+                Some(errors) => errors.to_string(),
+                None if !user_set_encoding && locale_asks_for_surrogateescape() => {
+                    "surrogateescape".to_string()
+                }
+                None => "strict".to_string(),
+            };
+            (encoding.to_string(), errors)
+        })
+        .clone()
 }
 
 fn live_stdio_encoding_errors(stream_name: &str, default_errors: &str) -> (String, String) {

--- a/pyre/pyre-interpreter/src/module/winreg/mod.rs
+++ b/pyre/pyre-interpreter/src/module/winreg/mod.rs
@@ -240,17 +240,6 @@ mod imp {
         ))
     }
 
-    /// Whether the call carried a keyword at all. The gateway appends its own
-    /// marker entry to the kwargs dict, which is not one of them.
-    fn has_keywords(kwargs: Option<PyObjectRef>) -> bool {
-        let Some(dict) = kwargs else {
-            return false;
-        };
-        unsafe { pyre_object::w_dict_str_entries_wtf8(dict) }
-            .iter()
-            .any(|(key, _)| key.as_str() != Ok("__pyre_kw__"))
-    }
-
     /// The wording a boundary with no keyword table gives one anyway. It
     /// qualifies itself with the module, which the clinic's keyword binder
     /// does not.
@@ -266,7 +255,7 @@ mod imp {
         count: usize,
     ) -> Result<&'a [PyObjectRef], crate::PyError> {
         let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-        if has_keywords(kwargs) {
+        if crate::builtins::has_real_kwargs(kwargs) {
             return Err(no_keywords(name));
         }
         if pos.len() != count {
@@ -282,7 +271,7 @@ mod imp {
     /// count is checked by the call machinery rather than by a converter.
     fn single_arg(args: &[PyObjectRef], name: &str) -> Result<PyObjectRef, crate::PyError> {
         let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-        if has_keywords(kwargs) {
+        if crate::builtins::has_real_kwargs(kwargs) {
             return Err(no_keywords(name));
         }
         if pos.len() != 1 {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3465,6 +3465,11 @@ pub fn trace_and_compile_from_bridge(
         // the caller into `resume_in_blackhole` (pyjitpl.py:711).
         return BridgeResolution::ResumeBlackhole;
     };
+    // `MAJIT_MAX_BRIDGES` counts bridges actually attempted, so it is spent
+    // after the bails above rather than alongside `no_bridge_enabled`.
+    if !majit_metainterp::bridge_fuel_take() {
+        return BridgeResolution::ResumeBlackhole;
+    }
 
     let info = {
         let (_, info) = crate::eval::driver_pair();

--- a/pyre/pyrex/build.rs
+++ b/pyre/pyrex/build.rs
@@ -29,6 +29,28 @@ fn main() {
             _ => {}
         }
     }
+    embed_windows_manifest(&target);
+}
+
+/// Embed `python.manifest` in the Windows executables, the way
+/// `rpython/translator/platform/windows.py` links `pypy/goal/python.manifest`
+/// with `/MANIFEST:EMBED /MANIFESTINPUT:`.
+///
+/// Its `longPathAware` setting is the one that carries weight here: without a
+/// manifest the Win32 layer applies the MAX_PATH limit before the wide call
+/// behind it runs, so `open()` on a 270-character name reports ENOENT while the
+/// same name spelled `\\?\...` opens.
+fn embed_windows_manifest(target: &str) {
+    if target != "windows" || std::env::var("CARGO_CFG_TARGET_ENV").as_deref() != Ok("msvc") {
+        return;
+    }
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR")).join("python.manifest");
+    println!("cargo::rerun-if-changed={}", manifest.display());
+    println!("cargo::rustc-link-arg-bins=/MANIFEST:EMBED");
+    println!(
+        "cargo::rustc-link-arg-bins=/MANIFESTINPUT:{}",
+        manifest.display()
+    );
 }
 
 /// Every `#[unsafe(no_mangle)]` item the cpyext layer defines.

--- a/pyre/pyrex/python.manifest
+++ b/pyre/pyrex/python.manifest
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls"
+                        version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*" />
+    </dependentAssembly>
+  </dependency>
+</assembly>


### PR DESCRIPTION
Follow-up to #1436. Thirty-one commits: eight on CI, five on
`os.scandir`'s `DirEntry` and the `nt._path_*` helpers, seven Windows behaviour
fixes found by probing this host against CPython 3.14.2, six more the same
probing turned up that are not Windows-scoped, and five review/diagnostic
fixes.

# CI

The figure optimised here is **runner-seconds**, not the critical path. This
repository is public, so standard GitHub-hosted runners are not billed and the
per-OS multipliers do not apply; runner-seconds is the compute the workflow
spends, and the critical path is a separate number that moves the other way.

Runner-seconds per run, `main`'s run 32647581403 against this branch:

| | jobs | runner-seconds |
|---|---|---|
| `main` | 12 | 23220 |
| this branch at run 32657938846 | 17 | 26348 |
| this branch now, projected from the three deltas below | 14 | ~23400 |

**One `pyre/check.py` job per backend, on Linux only.** Splitting the two
backends across jobs pays only where the second build is cheap. Measured on the
two runs above, one backend per job against both in one: ubuntu 3990s vs 4243s,
windows 5449s vs 4170s, macos 3704s vs 3136s. Linux gains 253s; the other two
lose 1847s between them, because the second job pays for a full release build
over a target directory the first job never warmed. The split is kept on Linux
and reverted on macOS and Windows.

**The CPython suite and the pip end-to-end run at the end of the Linux dynasm
leg**, not in a job of their own — measured at 894s of duplicated release build,
detailed below.

**The LLBC fingerprint test is selected under the workspace feature set** the two
`cargo test` steps ahead of it already used: `-p pyre-jit-trace` resolves
`pyre-interpreter` differently and rebuilt 61 crates. 139s and 281s for the two
wrong forms, 3s for this one, 0 crates compiled.

The critical path moves the other way and is not defended here: collapsing the
Windows check.py matrix takes that path from `prepare` 1025s + 2787s back to
`prepare` 1025s + 4170s, so the run's longest chain returns to about 87 min from
the ~57 min the split bought.

# Windows behaviour

Every row below was measured against `python3.14.exe` (3.14.2) on the same host,
with a scripted probe run under both interpreters and the two outputs diffed.
Each probe is byte-identical after the change unless the table says otherwise.

| | before | after | CPython 3.14.2 |
|---|---|---|---|
| `open()` at the descriptor limit | `PermissionError [Errno 13]` | `OSError [Errno 24]` | `OSError [Errno 24]` |
| `msvcrt.locking(9999, 1, 1)` | `(0, 'No error')` | `(9, 'Bad file descriptor')` | `(9, 'Bad file descriptor')` |
| `msvcrt.setmode(9999, 0)` | `(0, 'No error')` | `(22, 'Invalid argument')` | `(22, 'Invalid argument')` |
| `open()` on a 270-character name | `FileNotFoundError` | opens | opens |
| `os.stat` on a >MAX_PATH name | `winerror=3` | `winerror=2` | `winerror=2` |
| `os.get_terminal_size()` `len(args)` | 2 | 5 | 5 |
| `_winapi.*` / `winreg.*` with no filename | 2 | 5 | 5 |
| `sys.stdin.readline()` over CRLF | `'a\r\n'` | `'a\n'` | `'a\n'` |
| `input()` over CRLF | `'hello\r'` | `'hello'` | `'hello'` |
| `sys.stdin.readline()` over a lone `\r` | no line break | breaks | breaks |
| `CreateProcess` command line ending in NUL | launched, NUL dropped | `ValueError` | `ValueError` |
| `CreateProcess` command line with a lone surrogate | `UnicodeEncodeError` | launches | launches |
| `_winapi.CreateProcess(None, 5, …)` | `expected str, got int object` | `CreateProcess() argument 2 must be str or None, not int` | same |
| `sys.getwindowsversion().build` | 22621 | 22631 | 22631 |
| `faulthandler.register` | present, raises `NotImplementedError` | absent | absent |

## `builtins: read a C runtime error's own errno in io_error_posix_errno`

A Windows C runtime call reports its failure as an errno carried in the error's
payload and leaves `raw_os_error()` empty, so `io_error_posix_errno` fell
through to the caller's `default` for every one of them. Held for two decades of
descriptor calls that happen to default to the errno they would have reported
anyway; visible where they do not.

The `ErrorKind` arm ahead of it is unchanged — for every kind it maps, the
payload agrees, because that kind was derived from the payload through
`errno_to_winerror` in the first place. Only the fall-through changes.

## `pyrex: embed python.manifest in the Windows executables`

`rpython/translator/platform/windows.py` links `pypy/goal/python.manifest` with
`/MANIFEST:EMBED /MANIFESTINPUT:`. The file added here is that manifest, copied
byte for byte; `pyrex`'s build script passes the two linker arguments on
`windows-msvc`. The built binary previously carried no manifest at all
(`longPathAware`, `asmv3`, `requestedExecutionLevel` and `<assembly` all absent
from the image).

Two things follow from it. `longPathAware` is what lets a path past `MAX_PATH`
resolve: the Win32 layer rejected one before the wide call behind it ran, so
`open()` on a 270-character name reported ENOENT while the same name spelled
`\\?\…` opened. And `GetVersionEx` now reports the running version instead of
the one an unmanifested process is shimmed to — confirmed through `ctypes`,
which reads `(10, 0, 22631)` from the manifested binary and `(10, 0, 22621)`
without.

## `error: keep every argument on a Win32 OSError that names no file`

`PyErr_SetExcFromWindowsErrWithFilenameObjects` builds the exception from
`(errno, strerror, filename, winerror, filename2)`, and `oserror_init` trims
that back to the leading pair only once a filename is there to carry the rest.
pyre always passed two, so `.winerror` did not survive a pickle or a re-raise
through `args`. The rule is `filename != NULL && filename != Py_None`, which is
why `os.stat` and `os.startfile` — which name a file — already matched.

pyre's own `OSError(...)` constructor was already exact on all twelve
`args`-shape forms probed; the defect was only in what the raisers passed.

While there: the argument objects were held unrooted in a Rust local across the
allocation of the next one. They are now pinned as they are built and read back
once the last one exists.

## `sys: let TextIOWrapper.readline serve sys.stdin`

The stream carried a `readline` of its own in its instance dictionary that read
bytes off `sys.stdin.buffer` and decoded them, so nothing translated the line
ending: `sys.stdin.readline()` answered `'a\r\n'` where `sys.stdin.read()` on the
same stream answered `'a\n'`, `input()` kept a trailing `'\r'`, and a line ended
by a lone `'\r'` was not a line at all. A file opened through `open()` was never
affected — only the standard stream.

Deleted rather than repaired: `io.TextIOWrapper.readline(sys.stdin)` — the type
method the override shadowed — already answers all four cases the way CPython
does, so there was nothing to write.

This is what `test_subprocess.test_universal_newlines_communicate_stdin` was
failing on: the parent writes `'\r\n'` through its own text layer and the child
was not translating it back.

## `_winapi: convert CreateProcess's wide arguments the way the module's own converter does`

The launch half kept a converter of its own going through
`text_w` / `WideCString::from_str`, while the rest of the module already had one
(`host::wide`) modelled on `PyUnicode_AsWideCharString`. The local copy refused a
lone surrogate the call takes as the UTF-16 unit it is written as, named no
argument in its `TypeError`, and let a NUL through when it was the last
character — `WideCString::from_vec` reads that one as the terminator it appends
itself.

That last one is `test_subprocess.test_invalid_cmd`:
`Popen([exe, "-c", "pass#" + chr(0)])` goes through `list2cmdline` unquoted, so
the NUL lands at the end of the command line and the process launched.

The shared converter now rejects every NUL, and `WideArg::Numbered` — a shape
the enum already carried for exactly this — gives argument 2 the name CPython
gives it.

## `sys: report getwindowsversion's major/minor/build from GetVersionEx`

The three read kernel32's own file version, because the comment beside them said
an unmanifested binary is shimmed to an older answer. With the manifest above
that is no longer true, so they come from `GetVersionEx` and `platform_version`
keeps the kernel32 file version — the split CPython makes, and the reason the
two differ at all on a release shipped as an enablement package over the
previous build (22631 against 22621 here).

`platform.win32_ver()` was already right: it reads `CurrentBuildNumber` out of
the registry.

## `faulthandler: publish register/unregister only where a user signal exists`

Windows has no `sigaction`, so both answered every call with
`NotImplementedError("faulthandler.register requires host_env feature")` —
naming a feature that is enabled. `moduledef.py` guards the two
`extra_interpdef` calls on `sys.platform != 'win32'` and CPython gates them on
`HAVE_SIGACTION`, so neither publishes the names there.

`test_faulthandler`'s five register cases go from errors to the skips their
`hasattr(faulthandler, "register")` guard asks for: 6 errors → 1, 9 skips → 14.

# Windows suites on this host

| suite | before | after |
|---|---|---|
| test_subprocess | 2F | **OK** (353 tests, skipped=205) |
| test_faulthandler | 23F / 6E | 23F / **1E**, skipped 9 → 14 |
| test_os | OK | OK (375 tests, skipped=138) |
| test_io | OK | OK — see below |
| test_winreg | OK | OK (skipped=6) |
| test_msvcrt | OK | OK (skipped=3) |
| test_exceptions | OK | OK (skipped=12) |
| test_builtin | OK | OK (skipped=12) |
| test_platform | OK | OK (skipped=4) |
| test_ntpath | OK | OK (skipped=3) |
| test_pickle | OK | OK (skipped=68) |
| test_sys | 8F | 8F (unchanged, and identical on a pre-change build) |

`test_io` flakes on `PyTextIOWrapperTest.test_append_bom` with
`BufferError: Existing exports of data: object cannot be re-sized`. Not from this
branch: `_pyio.FileIO.readall` makes a `memoryview(result)[bytes_read:]` per loop
iteration and relies on the reference count to release the export before
`result.resize(...)`. `PYPY_GC_NURSERY=1MB` turns it into 60 errors on the
post-change build and **77 on the pre-change one**; `PYPY_GC_NURSERY=64MB` makes
both pass. `cpython_tests/baseline.json` already records `test.test_io` as
`IMPORTERROR`.


# Not Windows-specific

The Windows surface diff turned up gaps that are not Windows-scoped at all;
they are fixed here rather than left in the "measured and not fixed" list.
Every row was measured against `python3.14.exe` (3.14.2) on the same host with
the same scripted probe under both interpreters.

| | before | after | CPython 3.14.2 |
|---|---|---|---|
| `_pyrepl` console `input_hook` | `AttributeError` | `None` | `None` |
| `posix._is_inputhook_installed()` | absent | `False` | `False` |
| `sys.exc_clear` | present | absent | absent |
| `pickle.loads(pickle.dumps(c_int(5))).value` | `0` | `5` | `5` |
| `c_int(5).__reduce__()` | `TypeError('abstract class')` | `(_unpickle, (c_long, ({}, b'\x05\x00\x00\x00')))` | same |
| `c_void_p(0).__reduce__()` | `TypeError('abstract class')` | `ValueError: ctypes objects containing pointers cannot be pickled` | same |
| an attribute set on a pickled ctypes value | lost | kept | kept |
| `(c_int * 3).__name__` | `?_Array_3` | `c_long_Array_3` | `c_long_Array_3` |
| `"\x"` | `Got unexpected unicode` | `truncated \xXX escape` at 0-1 | same |
| `"ab\x1"` | `Got unexpected unicode` | `truncated \xXX escape` at 2-4 | same |
| `"\u12"` / `"\U0001"` | `Got unexpected unicode` | `truncated \uXXXX` / `\UXXXXXXXX escape` | same |
| `"\U00110000"` | `Got unexpected unicode` | `illegal Unicode character` at 0-9 | same |
| `"\N{DELTA}"` | `Got unexpected unicode` | `unknown Unicode character name` at 0-8 | same |
| `b"ab\x1"` | `Got unexpected unicode` | `(value error) invalid \x escape at position 2` | same |
| `x = "\N"` reported columns | 8-8 | 5-9 | 5-9 |

## `posix: publish _inputhook and _is_inputhook_installed`

`_pyrepl/unix_console.py` and `_pyrepl/windows_console.py` each answer
`input_hook` with `posix._inputhook` when `posix._is_inputhook_installed()` says
one is there. Neither name existed, so reading `console.input_hook` raised
`AttributeError: module 'nt' has no attribute '_is_inputhook_installed'` where
CPython answers `None`. Nothing in pyre publishes a `PyOS_InputHook`, so the
answers are `False` and `0` — what the two calls give with no hook installed.

## `_ctypes: build a CData value's pickle through _unpickle`

`_CData` carried no `__reduce__`, so `object.__reduce_ex__` fell through to
`copyreg._reduce_ex`, which calls `_SimpleCData(self)` on the first non-heap
base — the source of the `TypeError: abstract class`. Pickling through protocol
2 did not raise at all; it reconstructed the value with a zeroed buffer.

`__reduce__`, `__setstate__` and `_ctypes._unpickle` are the three names CPython
publishes for this, and the pickle stream they produce is the same one PyPy's
`lib_pypy/_ctypes/basics.py` writes. pyre keeps a CData instance's storage in the
same dict its attributes live in (`_b_`, `_boff_`, `_b_base_`, …), so the state
leaves those keys out — the reduce of a plain `c_int(5)` is `({}, b'…')` the way
it is on CPython.

## `builtins: name the escape a string literal's decoder failed on`

`decode_unicode_with_escapes` and `decode_bytes_with_escapes` run over a literal
before the parser interprets anything inside it. The parser pyre delegates to
reports every one of those failures as one `Got unexpected unicode`, so the
source scan that already recovered `malformed \N character escape` now covers
the rest of the decoder's vocabulary, `unknown Unicode character name` included
— which needs the name lookup `unicodedata.lookup` already has.

The span reported is the literal token, which it was not before: even the `\N`
case pyre already worded correctly pointed at a single column inside the string.
A literal holding replacement fields is several tokens; there the closing quote
is what the report points at and the positions in the message are relative to
the piece between two fields, so `f"{1}\x"` says 0-1 rather than 3-4.

## `error: read the exception back out of its root slot at every use`

Found while reading the OSError-args commit above for the `test_datetime` GC
crash on the Linux CPython-suite leg. Each constructor pinned the fresh
exception and then went on using the word `pin_root` handed back, across
`w_int_new` / `w_str_new` / `w_exception_args_new`. The pin keeps the object
alive; it does not keep it in place. `os_error_from_parts` already reloaded the
two filenames for exactly that reason and not the exception itself.

`w_list_new_object` documents that its caller must have pinned every element it
is handed; `errno_pair` and the WTF-8 errno constructor passed freshly allocated
ints and strings that nothing had pinned.

This is a plausible cause of that crash and not a demonstrated one: it does not
reproduce on this host at `PYPY_GC_NURSERY` 1MB, 4MB or 64MB, and the sites
other than `os_error_from_parts` predate this branch.

## One release `pyre-dynasm`, not two

The pip end-to-end and the CPython suite both drive the release
`pyre-dynasm`, and the job they were split into opened by running `cargo build
--release -p pyrex --bin pyre-dynasm --no-default-features --features dynasm`
to get one -- the identical command `check.py` runs on its dynasm leg. Run
32657938846 measured that build at **894s in each of the two jobs**.

They now run at the end of that leg instead. Measured on the same run, the
Linux legs had the slack for it: `cargo test (windows-latest)` bounds the whole
workflow at 4153s, against 3490s for `prepare Charon/LLBC (ubuntu)` plus
`check.py dynasm (ubuntu)`, so the 668s the two steps take does not move the
total -- it removes a job and 894s of duplicated build.

Running the tests in release to share `check.py`'s artefacts, which would be
the other way to spend that build once, does not work here and was measured
rather than assumed. On the same crate chain, `cargo test -p majit-metainterp
--lib --no-run --features dynasm` compiles 29 crates in 86s under `dev` and 31
in 296s under `release` -- and that release run followed a complete release
`pyre-dynasm` build, so every crate it needed was already compiled in that
profile. It rebuilt all 31 anyway, `serde`, `malachite-nz`, `itertools` and
`syn` among them, because a test target resolves a different feature union.
`[profile.release]` here is `lto = "thin", codegen-units = 1`. The workflow
already carries the same measurement from the other direction: the
dispatcher-graph test "recompiles 66 crates either way -- 628s", which is why
it has a job of its own. Release also drops 948 `debug_assert!` across 185
files and 65 `cfg(debug_assertions)` arms across 30, `gc_stress.rs` and
`gc_roots::assert_shadow_stack_not_walking` included.

# Reading a GC crash out of a CI log

Run 32642072219 went red on one job, `CPython suite + pip (ubuntu-24.04)`, with
`test.test_datetime: PASS -> CRASH` and a `GC BUG: invalid major child` panic.
The panic prints seventeen fields precisely so a crash nobody can reproduce
locally is still attributable, and none of them past `holder_words=` was
readable: the two arrays were formatted `{:#x?}`, which puts each of the eight
words on a line of its own, and the crash-triage extractors in `check.py` and
`cpython_tests/run.py` keep the first line of a panic body and nothing after
it. `cpython_tests/run.py` also still capped that line at 200 characters where
`check.py` had gone to 400.

`hex_words` renders the array on one line and keeps the `0x` that `{:x?}`
drops; both extractors now keep 1200 characters, which the one-line form
reaches at about 800.

The crash itself is green on run 32649198018 — 222/222 PASS, 0 CRASH, no
regressions — after the `error.rs` rooting commit above. That is the only
evidence available either way, and it is not proof: the crash never reproduced
on this host.

Run 32649198018 left one red of its own, `cargo test (ubuntu-24.04)`, which
this branch had caused: `cargo test -p pyre-jit-trace --features
dynasm,prepass,cpyext` cannot resolve, because `--features` applies to the
selected package and `cpyext` belongs to `pyre-interpreter`. The commit that
introduced it described selecting the target under `--all` instead, and added
only the feature. It now does both.

# Measured and not fixed

The Windows-only module surfaces were diffed mechanically against CPython
3.14.2 (`dir()` on both, set-subtracted each way) over `nt`, `msvcrt`,
`_winapi`, `winreg`, `winsound`, `_overlapped`, `ntpath`, `_stat`, `time`,
`signal`, `select`, `_socket`, `errno`, `mmap`, `_ctypes`, `faulthandler` and
`sys`. What is left after the two rounds above:

- **`msvcrt.CRT_ASSEMBLY_VERSION`** — the MSVC toolset's `_CRT_ASSEMBLY_VERSION`
  macro out of `crtassem.h`, a compile-time constant of a C toolchain pyre does
  not use. Nothing under `lib-python/3` reads it.
- **`nt.uname_result`, `faulthandler.dump_c_stack`,
  `faulthandler._fatal_error_c_thread`, `_socket.CAPI`, five `_ctypes` entry
  points** — 3.14 surface not ported; each has a test-only consumer or none at
  all, and adding a name is what arms a `hasattr`-gated test.
- **`nt._getfileinformation`, `faulthandler._stack_overflow`** — present in pyre
  and not in CPython because PyPy publishes them (`posix/moduledef.py`,
  `faulthandler/moduledef.py` interpdefs).
- **`SyntaxError.end_offset` for a bare `invalid syntax`** — `compile("1 +")`
  reports `offset=4 end_offset=4` where CPython reports `4`/`5`. It comes
  from the parser's own location, not from any escape path, and is unchanged by
  this branch.

# Gates

Run on this host against the final tree:

- `cargo fmt --all -- --check`
- `scripts/check-new-line-citations.py` — no line-number citations added
- `cargo check -p pyre-wasm --target wasm32-unknown-unknown --no-default-features
  --features web` — the only non-Windows compile gate available locally
- `cargo test --all --no-default-features --features dynasm,cpyext`
- `pyre/check.py --backend dynasm` — **470/470**, no baseline re-recorded
- `pyre/extra_tests/parity_tests/run.py --dynasm-only` — all pass, PyPy 7.3.22 on PATH
- `pyre/extra_tests/run.py --gated-only --dynasm-only` — 99/99
- CPython suites re-run on the final binary: `test_ctypes`, `test_string_literals`,
  `test_pickle`, `test_exceptions`, `test_os`, `test_datetime`,
  `test_unicode_identifiers` all OK; `test_pyrepl` keeps its `FAIL` baseline with
  no `input_hook` failure left in it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pickling support for supported `ctypes` values and improved restoration of their state.
  - Added Windows application compatibility, long-path, and common-controls support.

- **Bug Fixes**
  - Improved Windows directory scanning, metadata, junction detection, error reporting, and version details.
  - Improved malformed string-escape diagnostics and exception safety.
  - Prevented unnecessary JIT compilation when execution resources are exhausted.
  - Improved named-field struct sequences and wide-string validation.
  - Limited unsupported fault-handler APIs to Unix platforms.

- **Developer Experience**
  - Enhanced multi-line method documentation and improved development/test performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


