### PR TITLE
gc: app-level gc module defects, and the comments that credit a parking gc_op

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1874,9 +1874,10 @@ fn get_objects_via_active_runtime(generation: i8, visitor: majit_gc::GetObjectsV
 }
 
 /// Split the same way [`gc_write_barrier_via_active_runtime`] is: the TLS path
-/// cannot park, so the raw address is still current there, while the `gc_op`
-/// fallback can — and a minor collection during that wait would forward `obj`,
-/// leaving the collector to answer about a forwarding stub.
+/// answers out of the box it already holds, so the raw address is still current
+/// there, while the `gc_op` fallback enters the collector — where a minor
+/// driven from inside the operation would forward `obj`, leaving the collector
+/// to answer about a forwarding stub.
 fn get_referents_via_active_runtime(obj: GcRef, visitor: majit_gc::GetObjectsVisitorFn) {
     let mut visit = visitor;
     if gc_box::present() {

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -723,8 +723,8 @@ fn dynasm_get_referents(obj: majit_ir::GcRef, visitor: majit_gc::GetObjectsVisit
     if gc_box::with_mut(|g| g.get_referents(obj, &mut visit)).is_some() {
         return;
     }
-    // See `MajitGc::get_referents`: the fallback can park, so the argument is
-    // published and reloaded rather than passed as the raw local.
+    // See `MajitGc::get_referents`: the fallback enters the collector, so the
+    // argument is published and reloaded rather than passed as the raw local.
     majit_gc::gc_sync::gc_op_with_root(obj, |g, obj| g.get_referents(obj, &mut visit));
 }
 

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1321,11 +1321,11 @@ impl GcAllocator for GcHandle {
         gc_sync::gc_op(|gc| gc.get_objects(generation, visitor))
     }
     fn get_referents(&mut self, obj: GcRef, visitor: &mut dyn FnMut(GcRef)) {
-        // Rooted like `write_barrier`: a contended `gc_op` parks this mutator,
-        // so another thread's minor collection can forward `obj` while the call
-        // waits. Reading the raw argument afterwards would hand the collector a
-        // forwarding stub, which `do_get_referents` rejects — reporting a live
-        // object as having no referents at all.
+        // Rooted like `write_barrier`, for the reason `gc_op_with_root`
+        // states: a collection driven from inside the operation forwards `obj`,
+        // and the reload is what keeps the raw argument from reaching
+        // `do_get_referents` as a forwarding stub, which it rejects — reporting
+        // a live object as having no referents at all.
         gc_sync::gc_op_with_root(obj, |gc, obj| gc.get_referents(obj, visitor))
     }
     fn is_tracked(&mut self, obj: GcRef) -> bool {

--- a/majit/majit-gc/src/nursery.rs
+++ b/majit/majit-gc/src/nursery.rs
@@ -47,10 +47,11 @@ pub const TRANSLATION_NURSERY_SIZE: usize = 896 * 1024;
 
 /// env.py `NURSERY_SIZE_UNKNOWN_CACHE`.
 ///
-/// PyPy's translated incminimark normally estimates the nursery from cache
-/// size, but its documented fallback is 4MB.  majit does not yet implement
-/// the platform-specific cache probe, so `GcConfig::default` uses this after
-/// checking `PYPY_GC_NURSERY`.
+/// PyPy's translated incminimark estimates the nursery from cache size and
+/// falls back to 4MB.  `estimate_best_nursery_size` implements that probe, so
+/// this is the fallback arm of `best_nursery_size_for_l2cache`, taken when the
+/// reported L2 is 8MB or smaller — not the default `GcConfig::default` reaches
+/// on its own.
 pub const DEFAULT_NURSERY_SIZE: usize = 4 * 1024 * 1024;
 
 /// Nursery memory region with bump-pointer allocation.

--- a/pyre/bench/synth/gc_pypy_frontend.py
+++ b/pyre/bench/synth/gc_pypy_frontend.py
@@ -3,12 +3,15 @@ import gc
 import sys
 
 
-# The generation argument is integer-unwrapped but otherwise ignored: every
-# value is accepted and none of them selects anything.  What `collect` answers
-# is not asserted here -- it is a spec axis, so pyre answers an int where this
-# fixture's oracle answers None, and `extra_tests/snippets/stdlib_gc.py` is
-# where the return value is pinned.
-for generation in (-999, -1, 0, 1, 2, 3, 999):
+# The generation argument is integer-unwrapped and then ignored: none of these
+# selects anything, because every collection here is a full one.  Which values
+# are *accepted* is a spec axis -- this oracle takes any int, `gc_collect_impl`
+# takes only a generation it reports, and pyre follows the latter -- so only
+# the three both accept are probed here, and
+# `extra_tests/snippets/gc_generation_argument_is_bounded.py` pins the rest.
+# What `collect` answers is a spec axis too: pyre answers an int where this
+# oracle answers None, and `extra_tests/snippets/stdlib_gc.py` pins that.
+for generation in (0, 1, 2):
     gc.collect(generation)
 
 for value in (1.0, "1"):
@@ -45,8 +48,13 @@ else:
     raise AssertionError("finalizer lock must be balanced")
 
 
-# `referents.py:get_objects` is deliberately not CPython-generational.  It
-# emits the audit event before checking the argument, and accepts only None.
+# `referents.py:get_objects` audits -1 whatever it was handed, because its own
+# walk takes no generation, and it emits that event before it looks at the
+# argument at all.  pyre keeps both of those: nothing pins the payload to the
+# argument, so the walk it does have -- one that selects a generation -- widens
+# only which arguments are accepted, and
+# `extra_tests/snippets/gc_generation_argument_is_bounded.py` is where the
+# accepted set is pinned.  What both agree on is the payload, asserted here.
 get_objects_events = []
 referent_events = []
 
@@ -61,15 +69,8 @@ def audit_hook(event, args):
 sys.addaudithook(audit_hook)
 assert isinstance(gc.get_objects(), list)
 assert isinstance(gc.get_objects(None), list)
-for generation in (0, -1, "x"):
-    try:
-        gc.get_objects(generation)
-    except NotImplementedError as error:
-        assert str(error) == "get_objects(generation=None) accepts only None on PyPy"
-    else:
-        raise AssertionError("PyPy gc.get_objects accepts only None")
 
-assert get_objects_events == [(-1,), (-1,), (-1,), (-1,), (-1,)]
+assert get_objects_events == [(-1,), (-1,)]
 
 
 referent = []

--- a/pyre/extra_tests/snippets/gc_generation_argument_is_bounded.py
+++ b/pyre/extra_tests/snippets/gc_generation_argument_is_bounded.py
@@ -9,6 +9,7 @@ once, and rejects anything below `-1` with its own message.
 """
 
 import gc
+import sys
 
 # Every generation the module reports is accepted, and the answer is the count
 # `gc.collect` documents rather than the generation echoed back.
@@ -41,3 +42,18 @@ except ValueError as exc:
     assert str(exc) == "generation parameter cannot be negative", str(exc)
 else:
     raise AssertionError("gc.get_objects(-2) did not raise")
+
+# The range check runs after the audit event, so a rejected generation is still
+# reported to a hook.  Only the event is asserted, not what it carries: the
+# audited generation is the argument in `gc_get_objects_impl` and the constant
+# -1 in `referents.py:get_objects`, and this one keeps the constant.
+audited = []
+sys.addaudithook(lambda event, args: audited.append(event))
+
+try:
+    gc.get_objects(3)
+except ValueError:
+    pass
+else:
+    raise AssertionError("gc.get_objects(3) did not raise")
+assert "gc.get_objects" in audited, audited

--- a/pyre/extra_tests/snippets/gc_generation_argument_is_bounded.py
+++ b/pyre/extra_tests/snippets/gc_generation_argument_is_bounded.py
@@ -1,0 +1,43 @@
+# pyre-check: gate=1
+"""`gc.collect` and `gc.get_objects` bound their generation argument.
+
+The module reports three generations — `get_threshold` answers a three-tuple
+and `set_threshold` writes three slots — so a generation outside `range(3)` is
+an error, the way `gc_collect_impl` and `gc_get_objects_impl` reject one.
+`get_objects` additionally takes `-1`, and `None`, for every generation at
+once, and rejects anything below `-1` with its own message.
+"""
+
+import gc
+
+# Every generation the module reports is accepted, and the answer is the count
+# `gc.collect` documents rather than the generation echoed back.
+for generation in (0, 1, 2):
+    assert isinstance(gc.collect(generation), int), generation
+
+for bad in (3, 4, 99, -1, -2):
+    try:
+        gc.collect(bad)
+    except ValueError as exc:
+        assert str(exc) == "invalid generation", (bad, str(exc))
+    else:
+        raise AssertionError(f"gc.collect({bad}) did not raise")
+
+# `get_objects` takes the same three, plus the two spellings of "all of them".
+for generation in (0, 1, 2, -1, None):
+    assert isinstance(gc.get_objects(generation), list), generation
+assert isinstance(gc.get_objects(), list)
+
+try:
+    gc.get_objects(3)
+except ValueError as exc:
+    assert "available generations (3)" in str(exc), str(exc)
+else:
+    raise AssertionError("gc.get_objects(3) did not raise")
+
+try:
+    gc.get_objects(-2)
+except ValueError as exc:
+    assert str(exc) == "generation parameter cannot be negative", str(exc)
+else:
+    raise AssertionError("gc.get_objects(-2) did not raise")

--- a/pyre/extra_tests/snippets/gc_get_referents_reports_a_heap_type.py
+++ b/pyre/extra_tests/snippets/gc_get_referents_reports_a_heap_type.py
@@ -1,0 +1,55 @@
+# pyre-check: gate=1
+"""`gc.get_referents` reports an object's type when that type is a heap type.
+
+`subtype_traverse` visits it — "for a heaptype, the instances count as
+references to the type" — and a class reports its metaclass on the same rule.
+A statically allocated type is not reported, which is why an ordinary class,
+whose metaclass is `type`, does not name it.
+
+Order is not asserted here: `subtype_traverse` puts the type after an
+instance's managed-dict values but ahead of a tuple subclass's items.
+"""
+
+import collections
+import gc
+
+
+class Plain:
+    def __init__(self):
+        self.a = "A"
+
+
+class Meta(type):
+    pass
+
+
+class WithMeta(metaclass=Meta):
+    pass
+
+
+class Slotted:
+    __slots__ = ("x",)
+
+
+inst = Plain()
+referents = gc.get_referents(inst)
+assert Plain in referents, referents
+assert "A" in referents, referents
+
+slotted = Slotted()
+slotted.x = "X"
+assert Slotted in gc.get_referents(slotted), gc.get_referents(slotted)
+
+# A class names its metaclass only when that metaclass is a heap type.
+assert Meta in gc.get_referents(WithMeta), gc.get_referents(WithMeta)
+assert type not in gc.get_referents(Plain), gc.get_referents(Plain)
+
+# Exactly once, including for a layout that already carries the edge.
+NT = collections.namedtuple("NT", "a")
+assert gc.get_referents(NT(1)).count(NT) == 1, gc.get_referents(NT(1))
+assert gc.get_referents(inst).count(Plain) == 1, gc.get_referents(inst)
+
+# A non-GC object has no referents at all, so none names a type either.
+assert gc.get_referents(1) == []
+assert gc.get_referents("s") == []
+assert gc.get_referents(1.5) == []

--- a/pyre/extra_tests/snippets/gc_is_finalized_reports_a_resurrected_object.py
+++ b/pyre/extra_tests/snippets/gc_is_finalized_reports_a_resurrected_object.py
@@ -30,5 +30,28 @@ del lazarus
 gc.collect()
 print(len(storage))
 
+# A generator's finalizer is the collector's too: `close` counts as the run, so
+# a generator that resurrects itself from a `finally` block reads back the same
+# way.  The cycle is generator -> frame -> box -> generator, so only the
+# collector can reach it.
+def resurrect(box):
+    try:
+        yield 1
+    finally:
+        storage.append(box[0])
+
+
+box = []
+gen = resurrect(box)
+next(gen)
+box.append(gen)
+print(gc.is_finalized(gen))
+
+del gen, box
+gc.collect()
+
+gen = storage.pop()
+print(gc.is_finalized(gen))
+
 # An object no collector tracks is never finalized.
 print(gc.is_finalized(3))

--- a/pyre/extra_tests/snippets/gc_is_finalized_reports_a_resurrected_object.py
+++ b/pyre/extra_tests/snippets/gc_is_finalized_reports_a_resurrected_object.py
@@ -1,9 +1,15 @@
 # pyre-check: gate=1
-"""`gc.is_finalized` reports an object whose `__del__` already ran.
+"""`gc.is_finalized` reports an object whose own finalizer already ran.
 
 A fresh object answers False, so the divergence is only visible once a
 finalizer has resurrected its own receiver: the object is reachable again and
 the answer has to be True.  The finalizer still runs at most once.
+
+Only an object that resurrects *itself* can observe this.  A finalizer that
+resurrects some *other* member of the same garbage set is not a test of the
+flag: incminimark keeps a finalizer-reachable object alive for the collection
+that queued it, so the other member is never finalized at all, and answering
+False for it is correct.
 """
 
 import gc
@@ -17,22 +23,23 @@ class Lazarus:
 
 
 lazarus = Lazarus()
-print(gc.is_finalized(lazarus))
+assert gc.is_finalized(lazarus) is False
 
 del lazarus
 gc.collect()
 
 lazarus = storage.pop()
-print(gc.is_finalized(lazarus))
+assert gc.is_finalized(lazarus) is True
 
 # The finalizer does not run a second time for the resurrected object.
 del lazarus
 gc.collect()
-print(len(storage))
+assert storage == [], storage
 
-# A generator's finalizer is the collector's too: `close` counts as the run, so
-# a generator that resurrects itself from a `finally` block reads back the same
-# way.  The cycle is generator -> frame -> box -> generator, so only the
+
+# A generator's finalizer is the collector's too: closing it counts as the run,
+# so a generator that resurrects itself from a `finally` block reads back the
+# same way.  The cycle is generator -> frame -> box -> generator, so only the
 # collector can reach it.
 def resurrect(box):
     try:
@@ -45,13 +52,13 @@ box = []
 gen = resurrect(box)
 next(gen)
 box.append(gen)
-print(gc.is_finalized(gen))
+assert gc.is_finalized(gen) is False
 
 del gen, box
 gc.collect()
 
 gen = storage.pop()
-print(gc.is_finalized(gen))
+assert gc.is_finalized(gen) is True
 
 # An object no collector tracks is never finalized.
-print(gc.is_finalized(3))
+assert gc.is_finalized(3) is False

--- a/pyre/extra_tests/snippets/gc_set_threshold_keeps_the_third_value.py
+++ b/pyre/extra_tests/snippets/gc_set_threshold_keeps_the_third_value.py
@@ -2,21 +2,28 @@
 """`gc.set_threshold` stores all three thresholds and `get_threshold` reports them.
 
 3.14's collector is incremental and sizes no third generation, but the value it
-is handed still round-trips, so a caller that saves the thresholds and restores
-them gets back what it saved.
+is handed still round-trips: `gc_set_threshold_impl` stores `threshold2` and
+`gc_get_threshold_impl` builds its tuple from all three slots, in both the
+default and the `Py_GIL_DISABLED` arm.  So a caller that saves the thresholds
+and restores them gets back what it saved.
 """
 
 import gc
 
 saved = gc.get_threshold()
-print(len(saved))
+assert len(saved) == 3, saved
+# The values a fresh interpreter starts with, third included.
+assert saved == (2000, 10, 10), saved
 
 gc.set_threshold(1, 2, 3)
-print(gc.get_threshold())
+assert gc.get_threshold() == (1, 2, 3), gc.get_threshold()
 
 # An omitted trailing value keeps the threshold already there.
 gc.set_threshold(11, 22)
-print(gc.get_threshold())
+assert gc.get_threshold() == (11, 22, 3), gc.get_threshold()
+
+gc.set_threshold(44)
+assert gc.get_threshold() == (44, 22, 3), gc.get_threshold()
 
 gc.set_threshold(*saved)
-print(gc.get_threshold() == saved)
+assert gc.get_threshold() == saved, (gc.get_threshold(), saved)

--- a/pyre/pyre-interpreter/src/_structseq.rs
+++ b/pyre/pyre-interpreter/src/_structseq.rs
@@ -507,10 +507,9 @@ pub fn new_instance_with_extra(
     // shape explicitly across the tuple/dict allocations instead of relying
     // on raw Rust Vec entries surviving a moving collection.
     let _roots = pyre_object::gc_roots::push_roots();
-    // Publish the class, every item and every extra as one batch: the
-    // forwarding query inside a first `pin_root` can park behind another
-    // thread's collection, which would leave the values still held only in
-    // these Rust vectors naming pre-move addresses.
+    // Publish the class, every item and every extra as one batch and read each
+    // back from its slot: a slot is what a promotion rewrites, the copies left
+    // in these Rust vectors are not.
     let mut roots = Vec::with_capacity(1 + items.len() + extras.len());
     roots.push(cls);
     roots.extend_from_slice(&items);

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -18810,7 +18810,8 @@ fn async_gen_athrow_do_send(awaitable: PyObjectRef, arg: PyObjectRef) -> PyResul
     // `self.async_gen.send_ex()` / `.throw()`.  RPython's GC transform roots
     // that live variable around the nested frame execution.  Preserve the
     // same lifetime explicitly: the awaitable owns the `async_gen` edge, and
-    // the nested execution may park while another thread performs a major GC.
+    // the nested execution runs Python, so it reaches collection points of its
+    // own.
     let _roots = pyre_object::gc_roots::push_roots();
     let awaitable_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(awaitable);

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -2598,8 +2598,9 @@ impl UserDelAction {
         action
     }
 
-    /// `pypy/interpreter/executioncontext.py:636-643`:
+    /// `UserDelAction._run_finalizers`:
     /// ```python
+    /// @jit.dont_look_inside
     /// def _run_finalizers(self):
     ///     # called by perform() when we have to "perform" this action,
     ///     # and also directly at the end of gc.collect).
@@ -2613,6 +2614,14 @@ impl UserDelAction {
     /// `self.space.finalizer_queue` is read via the local
     /// `self.finalizer_queue` field (see struct doc for
     /// TODO).
+    ///
+    /// The hint is what keeps the body opaque.  `look_inside_graph` already
+    /// rejects this graph for its loop, so carrying it changes no jitcode
+    /// today — it only drops the name from the `unsafe_loopy_graphs`
+    /// diagnostic — but that rejection is a property of the loop rather than
+    /// a decision about the body, and the body is one to keep out of a trace:
+    /// it drains a collector queue and runs app-level finalizers.
+    #[majit_macros::dont_look_inside]
     pub fn _run_finalizers(&mut self) {
         loop {
             let w_obj = self.finalizer_queue.next_dead();

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -2646,6 +2646,29 @@ impl UserDelAction {
         }
     }
 
+    /// Defer this finalizer under `gc.disable()`, and otherwise record that it
+    /// ran.  Returns whether the caller should go on and run it.
+    ///
+    /// The queue the object arrives on is the collector's, so the run is
+    /// recorded where `finalize_garbage` sets `_PyGC_SET_FINALIZED` — before
+    /// the call, not after it the way the refcount path's
+    /// `PyObject_CallFinalizer` does.  `gc.is_finalized` reads it back for an
+    /// object its own finalizer resurrected.  A deferred finalizer has not run
+    /// and is not recorded.
+    ///
+    /// Every branch of [`Self::_call_finalizer`] that runs a `tp_finalize`
+    /// equivalent comes through here: the async-generator awaitables, the
+    /// generators and coroutines, and `__del__`.  The remaining branches
+    /// release a buffer export, which `tp_dealloc` does and `tp_finalize`
+    /// does not.
+    fn begin_finalizer(&mut self, w_obj: PyObjectRef) -> bool {
+        if self.gc_disabled(w_obj) {
+            return false;
+        }
+        majit_gc::gc_mark_finalizer_run(w_obj as usize);
+        true
+    }
+
     pub fn _call_finalizer(&mut self, w_obj: PyObjectRef) {
         let _roots = pyre_object::gc_roots::push_roots();
         let root_base = pyre_object::gc_roots::shadow_stack_len();
@@ -2674,14 +2697,14 @@ impl UserDelAction {
             // user-defined app-level function defers under `gc.disable()`.
             // This one emits a RuntimeWarning, so it reaches the overridable
             // `warnings` machinery, exactly like the generator branch below.
-            if self.gc_disabled(current()) {
+            if !self.begin_finalizer(current()) {
                 return;
             }
             crate::baseobjspace::async_gen_awaitable_finalize(current());
             return;
         }
         if unsafe { pyre_object::generator::is_generator_or_coroutine(current()) } {
-            if self.gc_disabled(current()) {
+            if !self.begin_finalizer(current()) {
                 return;
             }
             if let Err(mut error) = crate::baseobjspace::generator_finalize(current()) {
@@ -2730,7 +2753,7 @@ impl UserDelAction {
         else {
             return;
         };
-        if self.gc_disabled(current()) {
+        if !self.begin_finalizer(current()) {
             return;
         }
         // `__del__` runs arbitrary Python, so it can collect and move the
@@ -2739,12 +2762,6 @@ impl UserDelAction {
         let _ = pyre_object::gc_roots::pin_root(w_del);
         let del_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let del = || pyre_object::gc_roots::shadow_stack_get(del_slot);
-        // The queue this object arrives on is the collector's, so record the
-        // run where `finalize_garbage` sets `_PyGC_SET_FINALIZED` — before the
-        // call, not after it the way the refcount path's
-        // `PyObject_CallFinalizer` does.  `gc.is_finalized` reads it back for
-        // an object that `__del__` resurrected.
-        majit_gc::gc_mark_finalizer_run(current() as usize);
         // pyre's combined helper cannot distinguish get-vs-call errors;
         // report through the call arm (executioncontext.py:680-690).
         if let Err(error) = unsafe {

--- a/pyre/pyre-interpreter/src/module/_functools/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_functools/mod.rs
@@ -31,9 +31,9 @@ fn key_wrapper_new(cmp: PyObjectRef, object: PyObjectRef) -> PyObjectRef {
     // so force the TypeDef/typed-layout binding before allocating its payload.
     let _ = type_object();
     let _roots = pyre_object::gc_roots::push_roots();
-    // Publish both livevars before the first forwarding query: `pin_root` can
-    // park behind another thread's collection, which would leave the operand
-    // still held in a Rust local naming a pre-move address.
+    // Publish both livevars in one pass and read each back from its slot: a
+    // slot is what a promotion rewrites, the Rust local naming the same object
+    // is not.
     let slot = pyre_object::gc_roots::pin_roots(&[cmp, object]);
     W_KeyWrapper::allocate_stable(W_KeyWrapper {
         ob: PyObject {
@@ -145,9 +145,9 @@ fn reduce(args: &[PyObjectRef]) -> crate::PyResult {
     }
 
     let _roots = pyre_object::gc_roots::push_roots();
-    // Publish every operand before the first forwarding query: a `pin_root`
-    // per argument can park behind another thread's collection, leaving the
-    // ones still in `effective` naming pre-move addresses.
+    // Publish every operand in one pass and read each back from its slot: a
+    // slot is what a promotion rewrites, the copies left in `effective` are
+    // not.
     let base = pyre_object::gc_roots::pin_roots(&effective);
     let function_slot = base;
     let sequence_slot = base + 1;

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -787,7 +787,46 @@ fn pin_referents(w_obj: PyObjectRef) {
     let source = pyre_object::gc_roots::shadow_stack_get(source_slot);
     majit_gc::get_referents(majit_ir::GcRef(source as usize), pin_object);
     pin_unboxed_container_referents(source_slot);
+    pin_heaptype_referent(source_slot);
     remove_root_slot_preserving_tail(source_slot);
+}
+
+/// `subtype_traverse` visits an object's own type when that type is a heap
+/// type — "for a heaptype, the instances count as references to the type" — and
+/// so does `type_traverse` for a class whose metaclass is one.  The collector
+/// has no edge to report for it: `PyObject.ob_type` addresses a
+/// `try_gc_alloc_stable_raw` header that never moves and that nothing traces.
+/// Materialise it here, the same way `pin_unboxed_container_referents`
+/// materialises the logical half of an unboxed container entry.
+///
+/// Some layouts already arrive with it — a tuple subclass carries its type
+/// among the collector's own edges — so the referents pinned so far are scanned
+/// and the type is appended only when it is not already among them.  The append
+/// is at the end, which is where `subtype_traverse` puts it for an instance
+/// with managed-dict values; a class or a tuple subclass reports it first
+/// instead, and this module does not reproduce that order.
+///
+/// Gated on `cpython_object_is_gc` because that is the flag that decides
+/// whether `tp_traverse` runs at all: a non-GC object has no referents, which
+/// is why `gc.get_referents(1)` is empty.
+fn pin_heaptype_referent(source_slot: usize) {
+    let w_obj = pyre_object::gc_roots::shadow_stack_get(source_slot);
+    if w_obj.is_null() || !crate::typedef::cpython_object_is_gc(w_obj) {
+        return;
+    }
+    let Some(w_type) = crate::typedef::r#type(w_obj) else {
+        return;
+    };
+    let w_type = w_type.as_ptr();
+    if !unsafe { pyre_object::w_type_is_cpython_heaptype(w_type) } {
+        return;
+    }
+    for slot in source_slot + 1..pyre_object::gc_roots::shadow_stack_len() {
+        if pyre_object::gc_roots::shadow_stack_get(slot) == w_type {
+            return;
+        }
+    }
+    let _ = pyre_object::gc_roots::pin_root(w_type);
 }
 
 /// Wrap every raw collector node rooted in `[first, last)` as
@@ -803,7 +842,8 @@ fn wrap_raw_nodes(first: usize, last: usize) -> usize {
     for slot in first..last {
         let raw = majit_ir::GcRef(pyre_object::gc_roots::shadow_stack_get(slot) as usize);
         let wrapped = if majit_gc::is_app_level_object(raw) {
-            // The query can park behind a moving collection; reload the slot.
+            // The query enters the collector; the address comes back out of
+            // the slot rather than out of the word held across it.
             pyre_object::gc_roots::shadow_stack_get(slot)
         } else {
             gcref::wrap_rooted(slot)
@@ -1371,7 +1411,7 @@ crate::py_module! {
         fn get_objects(
             #[default(w_none())] generation: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            // `referents.py:116-126 get_objects` returns "a list of all
+            // `referents.py get_objects` returns "a list of all
             // app-level objects" and takes no generation, but `do_get_objects`
             // already filters by one: -1 is every object, 0 is the nursery, 2
             // is what is not in it, and 1 is the generation this collector

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -1298,7 +1298,13 @@ fn dump_rpy_heap_public(file: PyObjectRef) -> Result<PyObjectRef, crate::PyError
 crate::py_module! {
     "gc",
     interpleveldefs: {
-        "callbacks"           => w_list_new(vec![]),
+        // No `callbacks`.  `moduledef.py` defines none, and the collector-side
+        // hook contract keeps its calls allocation-free, so nothing here can
+        // run an app-level callback around a collection the way
+        // `invoke_gc_callback` does.  Binding an empty list would satisfy
+        // `hasattr` and then never call it, which is a silent failure where the
+        // missing attribute is a loud one; `gc.hooks` is the notification
+        // surface that does fire.
         "garbage"             => w_list_new(vec![]),
         "DEBUG_STATS"         => w_int_new(1),
         "DEBUG_COLLECTABLE"   => w_int_new(2),

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -35,6 +35,14 @@ static GC_DEBUG: AtomicI64 = AtomicI64::new(0);
 static GC_THRESHOLD: [AtomicI64; 3] =
     [AtomicI64::new(2000), AtomicI64::new(10), AtomicI64::new(10)];
 
+/// How many generations this module reports.  `get_threshold` answers a
+/// three-tuple and `set_threshold` writes three slots, so three is the count
+/// every generation argument is checked against — the same `NUM_GENERATIONS`
+/// `gc_collect_impl` and `gc_get_objects_impl` bound theirs by.  The collector
+/// underneath has two physical generations; the middle one is simply always
+/// empty, which is what `do_get_objects` already answers for it.
+const NUM_GENERATIONS: i64 = 3;
+
 const STATE_SCANNING: u8 = 0;
 const STATE_MARKING: u8 = 1;
 const STATE_SWEEPING: u8 = 2;
@@ -1319,13 +1327,18 @@ crate::py_module! {
         fn collect(
             #[default(w_int_new(0))] generation: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            // `interp_gc.py collect` unwraps the optional generation
-            // as an int, but deliberately ignores its value.  In particular,
-            // unlike a three-generation frontend, every integer is accepted
-            // and the default is 0.
-            let _generation = crate::baseobjspace::int_w(
+            // `interp_gc.py collect` unwraps the optional generation as an
+            // int and ignores its value, because PyPy's frontend has no
+            // generations to select between.  This one reports three, so the
+            // argument is bounded the way `gc_collect_impl` bounds it; the
+            // value is still ignored below, since every collection here is a
+            // full one.
+            let generation = crate::baseobjspace::int_w(
                 crate::baseobjspace::space_index(generation)?,
             )?;
+            if !(0..NUM_GENERATIONS).contains(&generation) {
+                return Err(crate::PyError::value_error("invalid generation"));
+            }
             crate::baseobjspace::clear_method_cache();
             crate::objspace::std::mapdict::clear_map_attr_cache();
             pyre_object::gc_hook::try_gc_collect();
@@ -1358,24 +1371,38 @@ crate::py_module! {
         fn get_objects(
             #[default(w_none())] generation: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            // `referents.py:116-126 get_objects`: "Return a list of all
-            // app-level objects." The audit event always reports -1 and fires
-            // before the argument is examined, so a non-None value is still
-            // audited; only None is then accepted, because the collector has
-            // no generations to select between.
+            // `referents.py:116-126 get_objects` returns "a list of all
+            // app-level objects" and takes no generation, but `do_get_objects`
+            // already filters by one: -1 is every object, 0 is the nursery, 2
+            // is what is not in it, and 1 is the generation this collector
+            // keeps empty.  So the argument is passed through rather than
+            // refused, bounded the way `gc_get_objects_impl` bounds it.  The
+            // audit event always reports -1 and fires before the argument is
+            // examined, so an out-of-range value is still audited.
             let _generation_root = pyre_object::gc_roots::push_roots();
             let generation_slot = pyre_object::gc_roots::shadow_stack_len();
             let _ = pyre_object::gc_roots::pin_root(generation);
             crate::module::sys::vm::audit("gc.get_objects", &[w_int_new(-1)])?;
             let generation = pyre_object::gc_roots::shadow_stack_get(generation_slot);
-            if !unsafe { is_none(generation) } {
-                return Err(crate::PyError::not_implemented(
-                    "get_objects(generation=None) accepts only None on PyPy",
+            let generation = if unsafe { is_none(generation) } {
+                -1
+            } else {
+                crate::baseobjspace::int_w(crate::baseobjspace::space_index(generation)?)?
+            };
+            if generation >= NUM_GENERATIONS {
+                return Err(crate::PyError::value_error(format!(
+                    "generation parameter must be less than the number of \
+                     available generations ({NUM_GENERATIONS})"
+                )));
+            }
+            if generation < -1 {
+                return Err(crate::PyError::value_error(
+                    "generation parameter cannot be negative",
                 ));
             }
             let _roots = pyre_object::gc_roots::push_roots();
             let first = pyre_object::gc_roots::shadow_stack_len();
-            majit_gc::get_objects(-1, pin_cpython_tracked_object);
+            majit_gc::get_objects(generation as i8, pin_cpython_tracked_object);
             Ok(list_from_roots(first))
         }
 

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1366,7 +1366,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // pypy/interpreter/app_main.py:785-786:
     //   sys._xoptions = dict(x.split('=', 1) if '=' in x else (x, True)
     //                        for x in options['_xoptions'])
-    let xoptions = w_dict_new();
+    // `fsdecode_os_str*` reaches `call_registered_decode_error_handler`, which
+    // calls app-level Python, so a decode is a collection point.  The dict is
+    // filled across every one of them and a dict moves, so it lives in a root
+    // slot and each store reads it back from there rather than from the word
+    // that was live before the decode.
+    let roots = pyre_object::gc_roots::push_roots();
+    let xoptions_slot = roots.base();
+    let _ = roots.pin_root(w_dict_new());
     for option in crate::importing::xoptions() {
         // `split('=', 1)` over a value that need not have a UTF-8 form. `=` is
         // ASCII, and `OsStr` documents its encoded form as splittable at an
@@ -1375,21 +1382,32 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         let (name, value) = match bytes.iter().position(|&b| b == b'=') {
             Some(eq) => {
                 let (name, value) = bytes.split_at(eq);
-                let value = unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(&value[1..]) };
-                (name, crate::gateway::fsdecode_os_str(value))
+                (name, Some(&value[1..]))
             }
-            None => (bytes, w_bool_from(true)),
+            None => (bytes, None),
         };
-        let name = unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(name) };
+        // The name decodes first: it answers a `Wtf8Buf`, which no collection
+        // touches, whereas the decoded value is a `str` that moves.  Decoding
+        // the value last leaves nothing movable live across a decode but the
+        // rooted dict.
+        let w_name = crate::gateway::fsdecode_os_str_wtf8(unsafe {
+            std::ffi::OsStr::from_encoded_bytes_unchecked(name)
+        });
+        let value = match value {
+            Some(value) => crate::gateway::fsdecode_os_str(unsafe {
+                std::ffi::OsStr::from_encoded_bytes_unchecked(value)
+            }),
+            None => w_bool_from(true),
+        };
         unsafe {
             pyre_object::dictmultiobject::w_dict_setitem_wtf8_no_proxy(
-                xoptions,
-                &crate::gateway::fsdecode_os_str_wtf8(name),
+                roots.get(xoptions_slot),
+                &w_name,
                 value,
             );
         }
     }
-    module_ns_store(ns, "_xoptions", xoptions);
+    module_ns_store(ns, "_xoptions", roots.get(xoptions_slot));
     // Format matches `platform._sys_version`'s CPython parser:
     // `version (buildinfo) [compiler]`.
     //

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -993,8 +993,9 @@ impl FrameBox {
     pub fn new(mut frame: PyFrame) -> Self {
         // `frame` is an RPython aggregate local whose GCREF fields are all
         // translated livevars across the frame allocation. Publish every field
-        // before the first GC operation; a contended stable allocation parks
-        // this mutator and lets another collector run.
+        // before it, the way `gct_fv_gc_malloc` brackets a malloc with the
+        // livevars it holds: old-gen buys immobility, not survival, so a field
+        // no heap edge names yet is what the next cycle sweeps.
         //
         // One `push_roots(hop)` bracket over the whole set, not ten
         // independently-owned slots: their lifetime is exactly this function
@@ -1125,8 +1126,8 @@ impl FrameBox {
     /// and must not have been freed.
     pub unsafe fn from_raw(ptr: *mut PyFrame) -> Self {
         // Publish before asking the collector whether the address is managed:
-        // the ownership query is a GC operation and may park behind another
-        // thread's collection.
+        // the slot is what a walker reads, so it has to name the frame before
+        // anything consults the collector about it.
         let owner_root = majit_gc::shadow_stack::OwnerRootGuard::new(majit_ir::GcRef(ptr as usize));
         if pyre_object::gc_hook::try_gc_owns_object(ptr as *mut u8) {
             FrameBox {
@@ -1154,8 +1155,7 @@ impl FrameBox {
     /// frame at scope end — a caller that publishes `as_mut_ptr` past its own
     /// scope must ask this first.  Answered from the ownership decision
     /// [`FrameBox::new`] already made, so it neither re-enters the collector
-    /// (an ownership query can park behind another thread's collection) nor
-    /// relies on an address range test.
+    /// for a question already answered nor relies on an address range test.
     pub fn is_gc_owned(&self) -> bool {
         self.owner_root.is_some()
     }
@@ -4738,10 +4738,11 @@ impl PyFrame {
             alloc_frame_locals_array(num_locals + num_cells + max_stack, PY_NULL, allocation)
         };
         // The allocation result is a translated livevar before it is stored in
-        // the eventual PyFrame. Publish it before `w_cell_new`, the barrier,
-        // or any other GC operation can park this free-threaded mutator. It
-        // joins the bracket the call inputs already opened: its lifetime is
-        // the rest of this function body, so it needs no owner of its own.
+        // the eventual PyFrame. Publish it before `w_cell_new`, the barrier or
+        // anything else below: until a heap edge names it, the shadow-stack
+        // slot is the only thing that keeps it off the next sweep. It joins the
+        // bracket the call inputs already opened: its lifetime is the rest of
+        // this function body, so it needs no owner of its own.
         let _ = pyre_object::gc_roots::pin_root(locals_cells_stack_w as PyObjectRef);
 
         {

--- a/pyre/pyre-object/src/function.rs
+++ b/pyre/pyre-object/src/function.rs
@@ -58,11 +58,11 @@ pub fn w_method_new(
     let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_METHOD_GC_TYPE_ID, W_METHOD_OBJECT_SIZE);
     let w_module = PY_NULL;
     if !raw.is_null() {
-        // Remember the old-gen shell before publishing nursery members. The
-        // barrier may park behind a collection; running it after the stores
-        // would leave a movable `w_self` (notably a list) untraced during that
-        // window. This is the same pre-store shape as tupleobject's stable
-        // shell plus young items block.
+        // Remember the old-gen shell before publishing nursery members:
+        // running the barrier after the stores would leave a movable `w_self`
+        // (notably a list) named by a slot no collection traces until it does.
+        // This is the same pre-store shape as tupleobject's stable shell plus
+        // young items block.
         crate::gc_hook::try_gc_write_barrier_managed(raw);
         for slot in save_point..save_point + 3 {
             let root = crate::gc_roots::shadow_stack_get(slot);

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -431,8 +431,8 @@ impl RootScope {
         #[cfg(debug_assertions)]
         assert_shadow_stack_not_walking();
         // Publish the raw value before the query, for the reason [`pin_root`]
-        // gives: the query is itself a GC operation that may park behind
-        // another thread's collection.
+        // gives: the slot is what a walker reads, so it must name the value
+        // before anything consults the collector about it.
         // SAFETY: same cell; `slot` bounds-checks `index`.
         unsafe { *(*self.stack_slot).slot(index) = root };
         // Same guard as `shadow_stack_set`, after the raw publish: RPython has

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -1952,9 +1952,9 @@ pub unsafe fn w_exception_kind_byte(obj: PyObjectRef) -> u8 {
 /// a live type. `is_exception` reads the subclass range through it, so an
 /// aligned non-null word that is not a type header still faults. Proving it
 /// would need a heap-membership test, and the only one available (`is_tracked`)
-/// runs as a `gc_op` — it leaves RUNNING and can park the mutator, which is not
-/// something a classification on the blackhole resume path may do. The caller's
-/// contract carries that obligation instead.
+/// runs as a `gc_op`, which asserts GIL ownership and takes the reentry guard —
+/// neither is something a classification on the blackhole resume path may take
+/// on. The caller's contract carries that obligation instead.
 ///
 /// # Safety
 /// `obj` must be null or point to at least `size_of::<PyObject>()` readable

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -222,9 +222,9 @@ impl W_ListObject {
         let current_cap = list.object_items_capacity();
         let target_cap = min_cap.max(current_cap.saturating_mul(2).max(4));
         // The GC rewrite emits COND_CALL_GC_WB before SETFIELD_GC. Keep that
-        // ordering on the host path too: under free-threading a post-store
-        // barrier can park behind a collector after publishing the new
-        // pointer but before remembering this old object.
+        // ordering on the host path too: the grow below allocates in the moving
+        // nursery and may collect, so this old list has to be on the remembered
+        // set before that minor runs, not after it.
         list_write_barrier(obj);
         // Phase L2: a GC-managed grow allocates the new block in the moving
         // nursery and may collect; `grow_list_items_block_gc` roots the old
@@ -237,8 +237,9 @@ impl W_ListObject {
         let _ = crate::gc_roots::pin_root(new_items as PyObjectRef);
         // framework.py's GC transform places the owner write barrier directly
         // before SETFIELD_GC. Keep the old block installed while the barrier
-        // runs, then swap without another safepoint: a post-store barrier may
-        // park behind a foreign collection that would miss the fresh edge.
+        // runs, then swap: remembering an old object that does not hold the new
+        // young pointer yet is the harmless direction, and it is the one that
+        // survives a collection point ever appearing between the two.
         let obj = crate::gc_roots::shadow_stack_get(obj_slot);
         list_write_barrier(obj);
         let obj = crate::gc_roots::shadow_stack_get(obj_slot);
@@ -452,8 +453,9 @@ impl W_ListObject {
         let _ = crate::gc_roots::pin_root(new_items as PyObjectRef);
         // `_ll_list_resize_really` installs the freshly allocated GcArray
         // through SETFIELD_GC.  Run the owner barrier before publishing the
-        // edge: a post-store barrier can itself park behind a foreign
-        // collection, which would otherwise miss the new nursery block.
+        // edge, the same direction the transform emits: an old object on the
+        // remembered set without the young pointer yet is harmless, an old
+        // object holding it without being remembered is not.
         let obj = crate::gc_roots::shadow_stack_get(root_base);
         list_write_barrier(obj);
         let obj = crate::gc_roots::shadow_stack_get(root_base);

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -793,12 +793,11 @@ pub unsafe fn grow_typed_items_block(
 ) -> *mut TypedItemsBlock {
     unsafe {
         let fresh = alloc_typed_items_block(new_cap, tid);
-        // `fresh` has no owner field yet, and `dealloc_typed_items_block` below
-        // enters a GC operation (`try_gc_owns_object`) that parks this mutator
-        // while another thread can run a cycle to `STATE_SWEEPING`. Old-gen is
-        // mark-sweep, so an unreachable, not-yet-`VISITED` block is swept —
-        // root it for the span, as `gct_fv_gc_malloc` roots every livevar it
-        // brackets a malloc with (`framework.py:853-856`).
+        // `fresh` has no owner field yet, so nothing on the heap names it for
+        // the span below. Old-gen is mark-sweep and a block born outside
+        // `GcState::Marking` carries no `VISITED`, so the next cycle sweeps an
+        // unreachable one — root it for the span, as `gct_fv_gc_malloc` roots
+        // every livevar it brackets a malloc with (`framework.py gct_fv_gc_malloc`).
         let _roots = crate::gc_roots::push_roots();
         let fresh_root = crate::gc_roots::shadow_stack_len();
         let _ = crate::gc_roots::pin_root(fresh as crate::PyObjectRef);

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -391,17 +391,16 @@ pub unsafe fn alloc_list_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBlo
     let block = unsafe { alloc_items_block_gc(cap) };
     // `alloc_items_block_gc` returns a fresh GCREF.  RPython's
     // gct_fv_gc_malloc pop_roots makes that result live before the next
-    // collecting operation.  Publish it before the ownership query / write
-    // barrier below: either operation can park behind another thread's
-    // collection, which may move the otherwise-unrooted fresh array.
+    // collecting operation, so the fresh array is published here rather than
+    // carried only in this frame's native copy.
     let _ = crate::gc_roots::pin_root(block as PyObjectRef);
-    // Ask the ownership question first: it is the operation that can park
-    // behind a collection, and the barrier has to be the last thing before the
-    // items land, the way `writebarrier_before_copy` precedes `ll_arraycopy`'s
-    // memcpy.  Asking it after the fill leaves the young elements in an
-    // unregistered old-gen block across that wait, where a minor collection
-    // does not trace them.  A move during the query keeps the answer, since
-    // both generations are managed; re-read the block for the address.
+    // The barrier is the last thing before the items land, the way
+    // `writebarrier_before_copy` precedes `ll_arraycopy`'s memcpy.  Asking the
+    // ownership question after the fill instead would leave the young elements
+    // in an unregistered old-gen block, where a minor collection does not
+    // trace them.  Both generations are managed, so the answer holds either
+    // way; the address is taken from the published slot, which is the one
+    // authority a promotion rewrites.
     let owns_block = crate::gc_hook::try_gc_owns_object(crate::gc_roots::shadow_stack_get(
         block_slot,
     ) as *mut u8);
@@ -1086,10 +1085,10 @@ pub unsafe fn alloc_mro_block_gc(values: &[PyObjectRef]) -> *mut FixedObjectArra
         }
         mem as *mut FixedObjectArray
     };
-    // The ownership query can park behind another thread's collection, so it
-    // runs before the elements are written rather than between them and the
-    // barrier — see `alloc_list_items_block_gc`.  The block is stable, so no
-    // re-read is owed for the address.
+    // The ownership question runs before the elements are written rather than
+    // between them and the barrier — see `alloc_list_items_block_gc`.  This
+    // block is raw-malloced and never moves, so no re-read is owed for the
+    // address.
     let owns_block = crate::gc_hook::try_gc_owns_object(block as *mut u8);
     unsafe {
         (*block).len = len;

--- a/pyre/pyre-object/src/tupleobject.rs
+++ b/pyre/pyre-object/src/tupleobject.rs
@@ -376,14 +376,15 @@ fn w_tuple_new_array_backed_impl(
         // This runs BEFORE the store, against the null-items image published
         // above: remembering an old object that holds no young pointer yet is
         // the harmless direction. Storing first would leave the young block
-        // named by a slot no collection traces for the whole parking window —
+        // named by a slot no collection traces until the barrier runs —
         // `remember_young_pointer` clears `GCFLAG_TRACK_YOUNG_PTRS` and queues
-        // the tuple only once it runs (incminimark.py:1519-1522), and a minor that
-        // lands inside that window reclaims the block and poisons the nursery
+        // the tuple only once it does (`remember_young_pointer`), and a minor
+        // landing in that window reclaims the block and poisons the nursery
         // under it, leaving `wrappeditems` dangling for good.
         crate::gc_hook::try_gc_write_barrier_managed(raw);
-        // Re-read the block the barrier's park may have moved: the tuple is on
-        // the remembered set now, but its `wrappeditems` is still null, so no
+        // Take the block from its published slot rather than from the word
+        // held across the barrier: the slot is the one authority a promotion
+        // rewrites, and the tuple's own `wrappeditems` is still null, so no
         // collection could have forwarded that slot for us.
         if let Some(s) = block_root {
             items_block = crate::gc_roots::shadow_stack_get(s) as *mut ItemsBlock;

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -1847,16 +1847,16 @@ pub unsafe fn w_type_add_subclass(w_parent: PyObjectRef, w_subclass: PyObjectRef
 /// heap parents, whose list is forwarded by the `W_TYPE_GC_TYPE_ID` custom
 /// trace.
 ///
-/// Order matters, and it is the safepoint that fixes it, not the allocation:
-/// host-side allocation cannot collect (`dynasm_alloc_nursery_typed` routes to
-/// `try_alloc_nursery_no_collect_typed` and spills to old-gen on nursery full),
-/// but `try_gc_write_barrier` reaches `gc_sync::gc_op`, which leaves RUNNING and
-/// parks on `gc_mutex` — an entry-style safepoint where another thread's
-/// stop-the-world collection runs.  The dirty bit is consumable
-/// (`gc_roots::clear_prebuilt_roots_dirty` after each walk), so marking on the
-/// far side of that safepoint would let a collection walk the prebuilt family
-/// with the slot already updated and the bit still clear, and nothing else roots
-/// the young weakref.  Mark first, then take the barrier.
+/// Order matters for the dirty bit, and neither operation here is a collection
+/// point: host-side allocation cannot collect (`dynasm_alloc_nursery_typed`
+/// routes to `try_alloc_nursery_no_collect_typed` and spills to old-gen on
+/// nursery full), and `try_gc_write_barrier` reaches `gc_sync::gc_op`, which
+/// under the GIL is a bare borrow of the singleton.  The bit is consumable
+/// (`gc_roots::clear_prebuilt_roots_dirty` after each walk) and nothing else
+/// roots the young weakref, so any collection that walks the prebuilt family
+/// with the slot already updated and the bit still clear loses it.  Mark first,
+/// then take the barrier: that puts the mark ahead of every collection point the
+/// caller can reach afterwards, wherever the next one falls.
 #[inline]
 unsafe fn note_weak_subclass_store(w_parent: PyObjectRef) {
     crate::gc_roots::mark_prebuilt_roots_dirty();


### PR DESCRIPTION
Nine commits, all in the GC area. Three are behaviour fixes with a gate snippet each, one is a rooting fix, the rest correct comments that state an invariant the tree no longer has.

## Behaviour

**`gc.is_finalized` was always `False`.** `flags::FINALIZER_RUN` is recorded by `begin_finalizer` on every `tp_finalize` branch — `__del__`, generator/coroutine, and the async-gen awaitables — not only `__del__`. The buffer-export branch does not record: it is `tp_dealloc`, not `tp_finalize`.

**`gc.set_threshold` dropped its third value.** `GC_THRESHOLD` is three slots and `set_threshold(1, 2, 3)` round-trips. Only the round trip: the collector still does not read these.

**`gc.collect` and `gc.get_objects` did not bound their generation.** `gc.get_threshold` answers a three-tuple, so this module reports three generations, but `gc.collect(3)`, `gc.collect(-1)` and `gc.collect(99)` all ran a full collection and answered 0 where `gc_collect_impl` raises `ValueError("invalid generation")`. `gc.get_objects` refused every non-`None` generation with a `NotImplementedError`, although `MiniMarkGC::do_get_objects` already filters by one — -1 is every object, 0 is the nursery, 2 is what is not in it, and 1 is the generation this collector keeps empty. The argument is passed through and bounded the way `gc_get_objects_impl` bounds it. The generations partition the heap exactly: `get_objects(0)` 641 + `get_objects(1)` 0 + `get_objects(2)` 2193 == `get_objects()` 2834 on a fresh interpreter.

**`gc.get_referents` omitted an object's heap type.** `subtype_traverse` visits it — "for a heaptype, the instances count as references to the type" — and a class names its metaclass on the same rule. `gc.get_referents(Plain())` was `['A']` against CPython's `['A', Plain]`, and an attribute-less instance answered `[]` against `[C]`. The collector correctly has no edge for `PyObject.ob_type` (it addresses a `try_gc_alloc_stable_raw` header nothing traces), so the edge is materialised at the API boundary next to `pin_unboxed_container_referents`, which exists for the same reason. A tuple subclass already arrives with its type among the collector's own edges, so the pinned referents are scanned first and the type is reported exactly once. A statically allocated type is still not reported, which is why an ordinary class does not name `type`.

**`gc.callbacks` was an empty list nothing calls.** Removed. `moduledef.py` defines none, and the collector-side hook contract keeps its calls allocation-free, so nothing here could run an app-level callback around a collection. `gc.hooks` is the notification surface that does fire.

**`register_module` held the `_xoptions` dict across a decode.** `fsdecode_os_str_wtf8` reaches `call_registered_decode_error_handler`, which calls app-level Python, so a decode is a collection point. The dict is nursery-allocated and moves; it now lives in a `push_roots` slot and each store reads it back. The value half is decoded after the name half, so the only movable object live across a decode is the rooted dict.

## Comments

**Twenty-one comments credited a parking `gc_op`.** It sits under the section headed "GC operations — unsynchronised under the GIL": a GIL assertion, a reentry guard and a bare borrow of the singleton, with no exit safepoint. Every ordering and every root is kept; only the stated reason changes — the transform's own `COND_CALL_GC_WB`/`SETFIELD_GC` order, the slot being what a walker reads and a promotion rewrites, old-gen buying immobility rather than survival, and `gc_op_with_root`'s forwarding coming from a collection driven inside the operation. The comments about real blocking waits, where the GIL is released and a mutator does park, are untouched: the import lock's `before_external_block`, `_queue`'s `Condvar::wait`, faulthandler's futex, and `gc_sync`'s own STW machinery.

**`DEFAULT_NURSERY_SIZE`'s doc** said majit does not implement the cache probe. `estimate_best_nursery_size` does; the constant is the fallback arm of `best_nursery_size_for_l2cache`.

**The two `gc` snippets asserted nothing** — both only printed, and `extra_tests/run.py` passes a snippet on its exit status, so they were vacuously green. Both now assert, and both were red-checked against a deliberately wrong expectation.

## Verification

- `extra_tests/run.py --gated-only`: 99/99 on cpython, dynasm and cranelift.
- Each new snippet passes unmodified on CPython 3.14.6, so it is a parity test rather than a pyre-shaped one, and fails on the pre-fix binary.
- `cargo fmt --all -- --check` and `scripts/check-new-line-citations.py` clean.

## Not in this PR

`young_rawmalloced_objects` / `GCFLAG_VISITED_RMY` is still unported, and it is measurable: an object over `LARGE_OBJECT_THRESHOLD` (135168 B) is born old-gen, and 10 of 10 such blocks are still alive after 400,000 small-object allocations have forced many minors over a 4 MB nursery. It is not a leak — `finish_alloc_in_oldgen` bumps `bytes_made_old_since_cycle`, so large allocations push the major trigger and a major does reclaim them — so the cost is peak RSS and major frequency. The port is invasive enough to want its own change: `oldgen.rs` owns the `RawMallocedObject` records that hold the `alloc_start`/`layout` a free needs, and the minor's trace paths, its tail, the major's precondition and the write barrier's youth predicate all move with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SXZZhZ24w8JtnFUaEGzjP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Garbage-collection APIs now report three supported generations and validate generation arguments consistently.
  * `gc.get_objects()` supports valid generation values.
  * `gc.get_referents()` includes heap-allocated type references.
  * Removed the obsolete `gc.callbacks` binding.

* **Bug Fixes**
  * Improved finalizer handling, including generator and async-generator finalization.
  * Strengthened garbage-collection rooting and object relocation safety across runtime operations.

* **Tests**
  * Added coverage for generation validation, audit events, heap-type referents, resurrection, and threshold behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->