### PR TITLE
Fix BlockingIOError 3rd argument handling via PyNumber_Check

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4211,6 +4211,41 @@ pub(crate) unsafe fn getindex_w_index(index: PyObjectRef) -> Result<i64, PyError
     }
 }
 
+/// `abstract.c PyNumber_Check` — `nb_index` / `nb_int` / `nb_float`, or a
+/// complex.  Looked up on the type, so an instance attribute does not answer.
+/// Deliberately wider than what [`getindex_w_written`] accepts: an
+/// `__int__`-only operand has to enter the numeric branch and fail there.
+pub(crate) unsafe fn number_check(w_obj: PyObjectRef) -> bool {
+    if w_obj.is_null() {
+        return false;
+    }
+    unsafe {
+        pyre_object::pyobject::is_int_or_long(w_obj)
+            || pyre_object::is_float(w_obj)
+            || pyre_object::pyobject::is_complex(w_obj)
+            || lookup(w_obj, "__index__").is_some()
+            || lookup(w_obj, "__int__").is_some()
+            || lookup(w_obj, "__float__").is_some()
+    }
+}
+
+/// `PyNumber_AsSsize_t(w_obj, PyExc_ValueError)` — [`getindex_w_index`] with
+/// the exception `exceptions.c oserror_init` passes.  The overflow names the
+/// ORIGINAL operand's type, not the `__index__` result's.
+pub(crate) unsafe fn getindex_w_written(w_obj: PyObjectRef) -> Result<i64, PyError> {
+    match int_w(space_index(w_obj)?) {
+        Ok(i) => Ok(i),
+        Err(e) if e.kind == PyErrorKind::OverflowError => Err(PyError::new(
+            PyErrorKind::ValueError,
+            format!(
+                "cannot fit '{}' into an index-sized integer",
+                object_functionstr_type_name(w_obj)
+            ),
+        )),
+        Err(e) => Err(e),
+    }
+}
+
 #[inline(never)]
 unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef) -> PyResult {
     let mut value = value;

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6794,11 +6794,14 @@ fn os_error_parsed_errno(args: &[PyObjectRef]) -> Option<PyObjectRef> {
 /// filename from `args_w` per `_init_error` (line 652).  Must run after the
 /// `w_class` retag so the `BlockingIOError` numeric-filename special-case can
 /// see the resolved class.
-fn os_error_fill_slots(exc: PyObjectRef, args: &[PyObjectRef]) {
+/// `Err` when the `characters_written` conversion fails — `oserror_init`
+/// propagates it out of the constructor (`return -1`).
+fn os_error_fill_slots(exc: PyObjectRef, args: &[PyObjectRef]) -> Result<(), crate::PyError> {
     use pyre_object::interp_exceptions;
-    // Both the errno parse and the `BlockingIOError` test below run `int_w`,
-    // which is a user `__index__`, so the arguments are read off the root
-    // stack rather than out of the caller's slice once either has run.
+    // The errno parse runs `int_w` and the `BlockingIOError` conversion below
+    // runs `getindex_w_written`, both a user `__index__`, so the arguments are
+    // read off the root stack rather than out of the caller's slice once
+    // either has run.
     let _roots = pyre_object::gc_roots::push_roots();
     let args_base = pyre_object::gc_roots::pin_roots(args);
     let exc = pyre_object::gc_roots::pin_root(exc);
@@ -6826,12 +6829,17 @@ fn os_error_fill_slots(exc: PyObjectRef, args: &[PyObjectRef]) {
             // `_init_error` line 636-643: for an exact `BlockingIOError`, a
             // numeric third argument is `characters_written`, not a filename —
             // it stays in `args_w` and the tuple is not trimmed.
-            let written = |f| {
-                exc_is_blocking_io_error(exc)
-                    .then(|| crate::baseobjspace::int_w(f).ok())
-                    .flatten()
-            };
-            if let Some(value) = w_filename.and_then(written) {
+            // `exceptions.c oserror_init` picks that branch on
+            // `PyNumber_Check` and only then converts, so a failed conversion
+            // propagates instead of falling back here.  PyPy catches
+            // (`_init_error` 637-643), consistent there because it never trims
+            // `args_w`; pyre does, so the fallback lands on neither.  gh#1150.
+            let is_written_arg = exc_is_blocking_io_error(exc)
+                && w_filename.is_some_and(|f| crate::baseobjspace::number_check(f));
+            if is_written_arg {
+                let value = crate::baseobjspace::getindex_w_written(
+                    w_filename.expect("is_written_arg implies a third argument"),
+                )?;
                 interp_exceptions::w_exception_set_written(exc, value);
                 interp_exceptions::w_exception_set_blocking_written_arg(exc);
             } else if let Some(fname) = w_filename {
@@ -6844,7 +6852,7 @@ fn os_error_fill_slots(exc: PyObjectRef, args: &[PyObjectRef]) {
             }
         }
     }
-    // Assembled from the root stack, after the last `int_w`: the caller's
+    // Assembled from the root stack, after the last `__index__`: the caller's
     // slice is a pre-move view of the operands by then.
     let args_w: Vec<PyObjectRef> = match (parsed, trimmed) {
         (Some(w_errno), true) => vec![w_errno, arg(1)],
@@ -6855,6 +6863,7 @@ fn os_error_fill_slots(exc: PyObjectRef, args: &[PyObjectRef]) {
     };
     let args_list = interp_exceptions::w_exception_args_new(args_w);
     unsafe { interp_exceptions::w_exception_set_args(exc, args_list) };
+    Ok(())
 }
 
 /// `ESHUTDOWN` is a POSIX errno absent from the MSVC runtime's own `errno.h`,
@@ -7212,7 +7221,7 @@ fn exc_os_error_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             crate::typedef::r#type(w_self).map(|p| p.as_ptr()),
         ));
     }
-    os_error_fill_slots(w_self, positional);
+    os_error_fill_slots(w_self, positional)?;
     Ok(pyre_object::w_none())
 }
 
@@ -7690,7 +7699,7 @@ fn os_error_family_new(
     // Fill the slots after the retag so `os_error_fill_slots` can see the
     // resolved class (the `BlockingIOError` numeric-filename special-case).
     if !use_init {
-        os_error_fill_slots(exc, &positional);
+        os_error_fill_slots(exc, &positional)?;
     }
     Ok(exc)
 }

--- a/pyre/pyre-interpreter/src/cpyext/number.rs
+++ b/pyre/pyre-interpreter/src/cpyext/number.rs
@@ -456,20 +456,12 @@ pub unsafe extern "C" fn PyNumber_ToBase(object: *mut CPyObject, base: c_int) ->
 }
 
 /// `nb_index`, `nb_int` or `nb_float` — the test `PyNumber_Check` performs.
+/// The predicate lives in `baseobjspace::number_check`, shared with the
+/// interpreter-level caller.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyNumber_Check(object: *mut CPyObject) -> c_int {
     let object = unsafe { super::pyobject::from_ref(object) };
-    if object.is_null() {
-        return 0;
-    }
-    let numeric = unsafe {
-        pyre_object::pyobject::is_int_or_long(object)
-            || pyre_object::is_float(object)
-            || crate::baseobjspace::lookup(object, "__index__").is_some()
-            || crate::baseobjspace::lookup(object, "__int__").is_some()
-            || crate::baseobjspace::lookup(object, "__float__").is_some()
-    };
-    numeric as c_int
+    unsafe { crate::baseobjspace::number_check(object) as c_int }
 }
 
 /// `nb_index` alone — whether [`PyNumber_Index`] would have a slot to call.


### PR DESCRIPTION
## Summary

In the `OSError` family the third constructor argument is the filename. For `BlockingIOError` it is `characters_written` instead — the byte count a partial write got through before it blocked. One slot, two meanings, so the constructor has to decide which one a given value is.

CPython decides in two steps (`Objects/exceptions.c oserror_init`):

1. `PyNumber_Check` picks the branch.
2. Only then is the value converted, and a conversion that fails is an error. It propagates; there is no falling back to the filename branch.

pyre collapsed the two steps into one — it ran the conversion and used its success or failure as the branch test. So a failing conversion quietly turned into "then it must be a filename".

PyPy does fall back that way (`interp_exceptions.py:637-643`), which is fine for PyPy: it keeps the full `args` tuple on both branches. pyre trims `args` on the filename branch, like CPython. Falling back after the trim has already happened produces a state **neither** upstream produces — the value stored as `filename`, but `args` already cut short.

The issue reports the two overflow rows; measuring the whole third-argument space turned up four more.

### Measured

CPython 3.14.6 (`lib-python/stdlib-version.txt` pins `v3.14.6`) vs `pyre-dynasm`. Only the divergent rows are listed; `3` / `True` / `__index__`→5 / `'f'` / `b'f'` / `None` already matched and still do.

| third argument | CPython 3.14.6 | pyre before |
|---|---|---|
| `2**70` | `ValueError: cannot fit 'int' into an index-sized integer` | `filename=2**70`, `args=(1,'x')` |
| `__index__`→`2**70` | same, naming `'Idx'` | `filename=<Idx>` |
| `1.5` | `TypeError: 'float' object cannot be interpreted as an integer` | `filename=1.5` |
| `1j` | `TypeError: 'complex' object …` | `filename=1j` |
| `__int__`-only | `TypeError: 'N' object …` | `written=7` — accepted where CPython rejects |
| `__float__`-only | `TypeError: 'OnlyFloat' object …` | filename |

All six match after the patch. The overflow message names the **original** operand's type, not the `__index__` result's.

## What changed

- **`builtins.rs` `os_error_fill_slots`** — the branch is chosen by `number_check`; the conversion runs through `getindex_w_written`, whose error propagates. The filename arm is untouched.
- **`baseobjspace.rs`** — two helpers beside the precedent they follow: `number_check` (`abstract.c PyNumber_Check`) and `getindex_w_written` (`PyNumber_AsSsize_t` with `ValueError`, same shape as the adjacent `getindex_w_index`). `number_check` is deliberately wider than what the conversion accepts — that width is what sends an `__int__`-only operand into the numeric branch to fail there.
- **`os_error_fill_slots` returns `Result`** so the failure can leave the constructor (`oserror_init`'s `return -1`). Both callers already returned `Result`, so each needed one `?`.
- **`cpyext/number.rs`** — it carried its own copy of the predicate, already drifted: the complex clause was missing, so `PyNumber_Check(1j)` answered 0 where CPython answers 1. It now calls the shared `number_check`.

## Testing

- The 14 third-argument shapes above, plus OSError-family controls (`OSError(2,'No such file','/tmp/x')`, the zero- and one-argument forms, `FileNotFoundError`), diffed against CPython 3.14.6 — no differences.
- `cpython_tests/run.py --filter test_exceptions` — PASS, no regressions.
- `cargo test -p pyre-interpreter --features dynasm` — 376 passed, 0 failed.

No JIT change, so the benchmark suite was not re-measured.

Closes #1150

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.
  

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of numeric objects, including objects supporting standard numeric conversion methods.
  - Improved handling of oversized index values by reporting a clear `ValueError` that identifies the original operand type.
  - Correctly propagates errors when recording the number of characters written during operating system error handling.
  - Ensured consistent numeric checks across supported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->