### PR TITLE
error, pytraceback: OperationError.async, FOR_ITER's StopIteration report, and tb_lineno's -1 sentinel

### DIFF
--- a/pyre/extra_tests/parity_tests/foriter_stopiteration_exception_event.py
+++ b/pyre/extra_tests/parity_tests/foriter_stopiteration_exception_event.py
@@ -61,6 +61,25 @@ def a_python_level_next_reports_to_the_consuming_frame():
     assert seen == [('__next__', 'StopIteration'), ('consume', 'StopIteration')], seen
 
 
+def the_rule_is_the_traceback_and_not_the_iterator():
+    """`map`'s `__next__` is native, but the StopIteration is not."""
+
+    def stop(_):
+        raise StopIteration
+
+    def consume():
+        for _ in map(stop, [1, 2]):
+            raise AssertionError('the map was not empty')
+
+    # The exhaustion came out of a native `__next__`, so a rule that keyed off
+    # the iterator's kind would report nothing here.  It travelled through
+    # `stop`'s frame on the way, which is what the consuming frame reports on.
+    assert exception_events_in(consume) == [
+        ('stop', 'StopIteration'),
+        ('consume', 'StopIteration'),
+    ], 'unexpected events'
+
+
 def a_natively_signalled_end_reports_nothing():
     def consume_generator():
         def empty():
@@ -82,7 +101,25 @@ def a_natively_signalled_end_reports_nothing():
         for _ in {'a': 1}:
             pass
 
-    for consumer in (consume_generator, consume_list, consume_range, consume_dict):
+    def consume_callable_iter():
+        box = [0]
+
+        def step():
+            box[0] += 1
+            return box[0]
+
+        # `iter(callable, sentinel)` ends by comparing, not by raising through
+        # `step`, so this is a native end even though `step` is Python.
+        for _ in iter(step, 3):
+            pass
+
+    for consumer in (
+        consume_generator,
+        consume_list,
+        consume_range,
+        consume_dict,
+        consume_callable_iter,
+    ):
         assert exception_events_in(consumer) == [], consumer.__name__
 
 
@@ -116,6 +153,7 @@ def the_loop_still_ends_normally():
 
 
 a_python_level_next_reports_to_the_consuming_frame()
+the_rule_is_the_traceback_and_not_the_iterator()
 a_natively_signalled_end_reports_nothing()
 the_loop_still_ends_normally()
 print('OK')

--- a/pyre/extra_tests/parity_tests/foriter_stopiteration_exception_event.py
+++ b/pyre/extra_tests/parity_tests/foriter_stopiteration_exception_event.py
@@ -1,0 +1,121 @@
+# CPython-suite gap: `test_sys_settrace` traces loops and it traces raising
+# code, but never a loop whose iterator ends by raising StopIteration from a
+# Python-level `__next__` while a tracer is installed.  A runtime that
+# swallowed that StopIteration without reporting it would pass the whole
+# module.
+#
+# parity-tests reason: FOR_ITER's exhaustion arm catches the StopIteration and
+# jumps, so the consuming frame never dispatches it and never reaches the
+# code that reports an exception to the tracer.  Whether an `exception` event
+# is delivered there is therefore a decision the exhaustion arm has to make on
+# its own, and it is one a debugger sees: `pdb` stops on `exception` events.
+#
+# The rule is not "always" and not "never".  3.14 reports the event exactly
+# when the StopIteration carries a traceback -- which is to say, when it was
+# raised by Python code rather than signalled by an iterator implemented
+# natively.  A generator ending, a list ending and a range ending all deliver
+# nothing; a class whose `__next__` raises delivers one.  That asymmetry is
+# what this pins: reporting always would fire on every `for` over a list, and
+# reporting never would lose the one case a debugger cares about.
+#
+# PyPy 7.3.20 fails `a_natively_signalled_end_reports_nothing` on the generator
+# case: it reports every generator-iterator unconditionally, which its own
+# comment calls "an approximative rule" for a case it says it cannot emulate.
+# The rule pinned here is 3.14's, so this file is a place the two references
+# disagree and CPython wins.
+import sys
+
+
+def exception_events_in(consumer):
+    """The 'exception' events a tracer sees while `consumer` runs."""
+    seen = []
+
+    def record(frame, event, arg):
+        if event == 'exception':
+            seen.append((frame.f_code.co_name, arg[0].__name__))
+        return record
+
+    sys.settrace(record)
+    try:
+        consumer()
+    finally:
+        sys.settrace(None)
+    return seen
+
+
+def a_python_level_next_reports_to_the_consuming_frame():
+    class Ending:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise StopIteration
+
+    def consume():
+        for _ in Ending():
+            raise AssertionError('the iterator was not empty')
+
+    seen = exception_events_in(consume)
+    # Two events: the raise inside `__next__`, and the report FOR_ITER makes
+    # in the frame running the loop.  The second is the one under test.
+    assert seen == [('__next__', 'StopIteration'), ('consume', 'StopIteration')], seen
+
+
+def a_natively_signalled_end_reports_nothing():
+    def consume_generator():
+        def empty():
+            return
+            yield
+
+        for _ in empty():
+            raise AssertionError('the generator was not empty')
+
+    def consume_list():
+        for _ in [1, 2]:
+            pass
+
+    def consume_range():
+        for _ in range(2):
+            pass
+
+    def consume_dict():
+        for _ in {'a': 1}:
+            pass
+
+    for consumer in (consume_generator, consume_list, consume_range, consume_dict):
+        assert exception_events_in(consumer) == [], consumer.__name__
+
+
+def the_loop_still_ends_normally():
+    class Ending:
+        def __init__(self, n):
+            self.n = n
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.n == 0:
+                raise StopIteration
+            self.n -= 1
+            return self.n
+
+    collected = []
+
+    def consume():
+        for item in Ending(3):
+            collected.append(item)
+
+    # The report must not disturb what the loop collects, and must not leave
+    # the StopIteration visible to the loop body.
+    assert exception_events_in(consume) == [
+        ('__next__', 'StopIteration'),
+        ('consume', 'StopIteration'),
+    ], 'unexpected events'
+    assert collected == [2, 1, 0], collected
+
+
+a_python_level_next_reports_to_the_consuming_frame()
+a_natively_signalled_end_reports_nothing()
+the_loop_still_ends_normally()
+print('OK')

--- a/pyre/extra_tests/parity_tests/traceback_lineno_sentinel.py
+++ b/pyre/extra_tests/parity_tests/traceback_lineno_sentinel.py
@@ -1,0 +1,101 @@
+# CPython-suite gap: `test_traceback` builds `TracebackType` objects, but every
+# one it builds passes a real line number.  A runtime that stored the fourth
+# argument and handed it straight back would pass the whole module.
+#
+# parity-tests reason: `tb_lineno` is not a stored field.  `-1` means "I have
+# not resolved this yet, take the line from tb_lasti", and that sentinel is
+# app-level reachable through the constructor, so what a runtime does with it
+# is observable.  A runtime carrying a different sentinel -- PyPy uses
+# `-sys.maxsize-1` -- answers `-1` here instead of the line, and a runtime that
+# resolves eagerly at raise time has nothing to resolve when the constructor
+# hands it one.
+#
+# The rule is not "negative means resolve": `-2` and `0` are stored and read
+# back as they are.  Only `-1` resolves, and only against `tb_lasti`: an offset
+# that names no instruction answers `None`, and a negative offset answers the
+# code object's first line, which is where a frame that has not run an
+# instruction sits.
+#
+# PyPy 7.3.20 fails every `rebuilt` case: its sentinel is `-sys.maxsize-1`, so
+# a `-1` handed to the constructor reads back as `-1`.
+
+
+def raiser():
+    raise ValueError('x')
+
+
+def caller():
+    raiser()
+
+
+def natural():
+    """The traceback of a two-frame raise, innermost node first."""
+    try:
+        caller()
+    except ValueError as exc:
+        tb = exc.__traceback__
+    nodes = []
+    while tb is not None:
+        nodes.append(tb)
+        tb = tb.tb_next
+    # `natural`'s own frame is the outermost node; drop it so the fixture does
+    # not pin the line the `caller()` call above happens to sit on.
+    return nodes[1:]
+
+
+NODES = natural()
+TracebackType = type(NODES[0])
+
+
+def rebuilt(node, lasti, lineno):
+    """`node` reconstructed with a different offset and line number."""
+    return TracebackType(None, node.tb_frame, lasti, lineno)
+
+
+def a_recorded_node_reports_the_line_it_froze_at():
+    lines = [node.tb_lineno for node in NODES]
+    print('recorded:', lines)
+    # The body line of each function, derived rather than written out so the
+    # fixture survives an edit to the header above it.
+    expected = [caller.__code__.co_firstlineno + 1, raiser.__code__.co_firstlineno + 1]
+    assert lines == expected, (lines, expected)
+
+
+def the_sentinel_resolves_against_tb_lasti():
+    # Every node rebuilt with `-1` has to come back with the line it already
+    # reported: the offset is unchanged and the sentinel means "use it".
+    for node in NODES:
+        again = rebuilt(node, node.tb_lasti, -1)
+        print('rebuilt:', again.tb_lineno)
+        assert again.tb_lineno == node.tb_lineno, (again.tb_lineno, node.tb_lineno)
+
+
+def an_offset_naming_no_instruction_resolves_to_none():
+    node = rebuilt(NODES[0], 1 << 30, -1)
+    print('out of range:', node.tb_lineno)
+    assert node.tb_lineno is None, node.tb_lineno
+
+
+def a_negative_offset_resolves_to_the_first_line():
+    firstlineno = NODES[0].tb_frame.f_code.co_firstlineno
+    for lasti in (-1, -2):
+        node = rebuilt(NODES[0], lasti, -1)
+        print('negative offset:', node.tb_lineno)
+        assert node.tb_lineno == firstlineno, (node.tb_lineno, firstlineno)
+
+
+def only_minus_one_is_the_sentinel():
+    # `-2` and `0` are stored line numbers, however implausible; the
+    # constructor is documented to take them and nothing resolves them.
+    for lineno in (-2, 0, 7):
+        node = rebuilt(NODES[0], NODES[0].tb_lasti, lineno)
+        print('stored:', node.tb_lineno)
+        assert node.tb_lineno == lineno, (node.tb_lineno, lineno)
+
+
+a_recorded_node_reports_the_line_it_froze_at()
+the_sentinel_resolves_against_tb_lasti()
+an_offset_naming_no_instruction_resolves_to_none()
+a_negative_offset_resolves_to_the_first_line()
+only_minus_one_is_the_sentinel()
+print('OK')

--- a/pyre/extra_tests/parity_tests/traceback_lineno_sentinel.py
+++ b/pyre/extra_tests/parity_tests/traceback_lineno_sentinel.py
@@ -17,7 +17,10 @@
 # instruction sits.
 #
 # PyPy 7.3.20 fails every `rebuilt` case: its sentinel is `-sys.maxsize-1`, so
-# a `-1` handed to the constructor reads back as `-1`.
+# a `-1` handed to the constructor reads back as `-1`.  It also accepts writes
+# to `tb_lineno` and `tb_lasti`, which is the other half of the same choice --
+# it took the most negative value as its sentinel precisely because a written
+# line number could otherwise collide with it.
 
 
 def raiser():
@@ -84,6 +87,22 @@ def a_negative_offset_resolves_to_the_first_line():
         assert node.tb_lineno == firstlineno, (node.tb_lineno, firstlineno)
 
 
+def only_tb_next_is_writable():
+    # With `tb_lineno` resolving rather than storing, a writable slot would let
+    # a `-1` written back read as a computed line -- an answer neither
+    # reference gives.  Only `tb_next` takes an assignment.
+    node = NODES[0]
+    for name, value in (('tb_lineno', 5), ('tb_lasti', 5), ('tb_frame', None)):
+        try:
+            setattr(node, name, value)
+        except AttributeError as exc:
+            print(name, type(exc).__name__)
+        else:
+            print(name, 'writable')
+    node.tb_next = None
+    print('tb_next:', node.tb_next)
+
+
 def only_minus_one_is_the_sentinel():
     # `-2` and `0` are stored line numbers, however implausible; the
     # constructor is documented to take them and nothing resolves them.
@@ -98,4 +117,5 @@ the_sentinel_resolves_against_tb_lasti()
 an_offset_naming_no_instruction_resolves_to_none()
 a_negative_offset_resolves_to_the_first_line()
 only_minus_one_is_the_sentinel()
+only_tb_next_is_writable()
 print('OK')

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -523,25 +523,22 @@ pub fn combine_starstarargs_wrapped(
         if !isinst {
             false
         } else {
-            // argument.py:127-128 — `space.findattr(space.type(...),
-            // w_st_iter)`: PyPy issues `getattr` on the type object
+            // `argument.py` — `space.findattr(space.type(...),
+            // w_st_iter)`: the `getattr` is issued on the type object
             // itself, going through the metaclass / descriptor lookup
-            // chain.  `space.findattr` returns `None` for ordinary
-            // OperationError and re-raises async (baseobjspace.py:878).
-            // Pyre's `findattr` matches the same shape (Option<W>),
-            // modulo async-propagation (still a known gap covered by
-            // the `findattr` TODO).
+            // chain, so a raising `__getattribute__` on the metaclass
+            // surfaces here instead of reading as "no `__iter__`".
             let w_obj_type = crate::typedef::r#type(w_starstararg())
                 .map_or(pyre_object::PY_NULL, |p| p.as_ptr());
             let lhs = if w_obj_type.is_null() {
                 None
             } else {
-                crate::baseobjspace::findattr(w_obj_type, "__iter__")
+                crate::baseobjspace::findattr(w_obj_type, "__iter__")?
             };
             let rhs = if w_dict_type.is_null() {
                 None
             } else {
-                crate::baseobjspace::findattr(w_dict_type, "__iter__")
+                crate::baseobjspace::findattr(w_dict_type, "__iter__")?
             };
             // `space.is_w` is pointer identity.
             match (lhs, rhs) {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4698,31 +4698,33 @@ pub fn not_(obj: PyObjectRef) -> Result<PyObjectRef, PyError> {
     Ok(w_bool_from(!is_true(obj)?))
 }
 
-/// PyPy-compatible attribute lookup returning `None` when not found.  Runs
-/// suppressed (`_PyObject_LookupAttr`) since the AttributeError is swallowed.
-pub fn findattr(obj: PyObjectRef, name: &str) -> Option<PyObjectRef> {
-    if unsafe { is_none(obj) } {
-        return None;
-    }
-    match getattr_str_impl(obj, name, true, true) {
-        Ok(value) if value.is_null() => None,
-        Ok(value) => Some(value),
-        Err(err) => {
-            if err.kind == crate::PyErrorKind::AttributeError
-                || err.kind == crate::PyErrorKind::NameError
-            {
-                None
-            } else {
-                panic!("space.findattr: unexpected {err:?}");
-            }
-        }
-    }
-}
-
-/// Like [`findattr`] but propagates a non-`AttributeError`/`NameError` error
-/// (e.g. a descriptor or `__getattr__` raising) instead of panicking. `Ok(None)`
-/// means the attribute is absent.
-pub fn findattr_result(obj: PyObjectRef, name: &str) -> Result<Option<PyObjectRef>, PyError> {
+/// `baseobjspace.py findattr`.
+///
+/// ```python
+/// def findattr(self, w_object, w_name):
+///     try:
+///         return self.getattr(w_object, w_name)
+///     except OperationError as e:
+///         # a PyPy extension: let SystemExit and KeyboardInterrupt go through
+///         if e.async(self):
+///             raise
+///         return None
+/// ```
+///
+/// The `return None` arm is narrower here than upstream's, and deliberately:
+/// upstream swallows every error but the two `PyError::async` names,
+/// while `PyObject_GetOptionalAttr` reports only a missing attribute as
+/// "absent" and propagates anything else. `object.__reduce_ex__` — one of
+/// this function's callers — takes exactly that route
+/// (`object___reduce_ex___impl` returns on `< 0`), and a raising
+/// `__qualname__` descriptor likewise stops `_PyObject_FunctionStr` rather
+/// than reading as "no qualname". The 3.14 rule subsumes the async arm: an
+/// exit request or a Ctrl-C is never one of the two kinds swallowed here.
+///
+/// The lookup runs suppressed (`_PyObject_LookupAttr`), which is what makes
+/// the common absent case reach the `Ok(null)` arm without building an
+/// AttributeError to throw away.
+pub fn findattr(obj: PyObjectRef, name: &str) -> Result<Option<PyObjectRef>, PyError> {
     if unsafe { is_none(obj) } {
         return Ok(None);
     }
@@ -4739,6 +4741,12 @@ pub fn findattr_result(obj: PyObjectRef, name: &str) -> Result<Option<PyObjectRe
             }
         }
     }
+}
+
+/// [`findattr`] under the name most of its callers reach it by; the note on
+/// how the swallow set was chosen is on that one.
+pub fn findattr_result(obj: PyObjectRef, name: &str) -> Result<Option<PyObjectRef>, PyError> {
+    findattr(obj, name)
 }
 
 /// Check whether `exc_type` matches `check_class`, including tuple/list class inputs.
@@ -14687,14 +14695,18 @@ fn object_functionstr_str(w_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyEr
 ///         return None
 /// ```
 ///
-/// `Err(_)` carries the propagated async exception
-/// (`PyErrorKind::SystemExit`, mirroring `OperationError.async`'s
-/// SystemExit/KeyboardInterrupt arm — `error.py:62-65`).  Pyre's
-/// `PyError` does not yet carry a `KeyboardInterrupt` kind; SystemExit
-/// alone covers the propagation contract for the cases pyre raises
-/// today.  Ordinary `OperationError`s (AttributeError, NameError,
-/// TypeError from descriptors) collapse to `Ok(None)`, matching
-/// PyPy's `return None` arm.
+/// `Err(_)` carries the propagated async exception, asked through
+/// `PyError::async`.  Ordinary `OperationError`s
+/// (AttributeError, NameError, TypeError from descriptors) collapse to
+/// `Ok(None)`, matching the `return None` arm.
+///
+/// This one keeps upstream's swallow set rather than the narrower 3.14 rule
+/// [`findattr`] takes, because the surrounding `object_functionstr` is a
+/// port of upstream's try/except layout and the two have to agree on which
+/// faults reach the `str(w_function)` fallback.  The residual divergence is
+/// upstream's own: `_PyObject_FunctionStr` propagates any non-AttributeError
+/// from either lookup, so a raising `__qualname__` descriptor stops it where
+/// this falls through.
 fn object_functionstr_findattr(
     obj: PyObjectRef,
     name: &str,
@@ -14705,8 +14717,13 @@ fn object_functionstr_findattr(
     match getattr_str(obj, name) {
         Ok(value) if value.is_null() => Ok(None),
         Ok(value) => Ok(Some(value)),
-        Err(e) if e.kind == crate::PyErrorKind::SystemExit => Err(e),
-        Err(_) => Ok(None),
+        Err(mut e) => {
+            if e.r#async(w_none()) {
+                Err(e)
+            } else {
+                Ok(None)
+            }
+        }
     }
 }
 

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1783,6 +1783,42 @@ impl PyError {
         !w_value.is_null() && crate::eval::check_exc_match_against(w_value, w_check_class)
     }
 
+    /// pypy/interpreter/error.py `OperationError.async`.
+    ///
+    /// ```python
+    /// def async(self, space):
+    ///     "Check if this is an exception that should better not be caught."
+    ///     return (self.match(space, space.w_SystemExit) or
+    ///             self.match(space, space.w_KeyboardInterrupt))
+    ///     # note: an extra case is added in OpErrFmtNoArgs
+    /// ```
+    ///
+    /// Named `r#async` because `async` is a Rust keyword, the same escape
+    /// `typedef::r#type` uses for `space.type`.
+    ///
+    /// The guard sites all read the same way: an error is about to be
+    /// swallowed and turned into a fallback answer, and this says which
+    /// errors must not be. The two named classes are the ones a program has
+    /// no business converting into `None` or `NotImplemented` — an exit
+    /// request and a Ctrl-C.
+    ///
+    /// `KeyboardInterrupt` has no `ExcKind`, so it reaches a `PyError`
+    /// only as an already-built instance and the class is named through the
+    /// registry rather than through a static. That is also why an error
+    /// that has not materialised can answer from its `kind` alone: nothing
+    /// unmaterialised is ever a `KeyboardInterrupt`, and building an
+    /// instance merely to ask would put an allocation on the swallow path
+    /// of every attribute lookup that misses.
+    pub fn r#async(&mut self, space: PyObjectRef) -> bool {
+        if self.exc_object.is_null() {
+            return self.kind == PyErrorKind::SystemExit;
+        }
+        ["SystemExit", "KeyboardInterrupt"].iter().any(|name| {
+            crate::builtins::lookup_exc_class(name)
+                .is_some_and(|w_class| self.match_(space, w_class))
+        })
+    }
+
     /// pypy/interpreter/error.py `chain_exceptions`.
     ///
     /// ```python
@@ -4554,5 +4590,26 @@ mod tests {
         assert!(!err.has_any_traceback());
         assert!(!err.got_any_traceback());
         assert!(err.exc_object.is_null(), "the reads must not materialise");
+    }
+
+    #[test]
+    fn an_unmaterialised_error_answers_async_from_its_kind() {
+        // The guard sites ask this on the swallow path of every miss, so it
+        // must not build an instance to answer.  `kind` settles both
+        // disjuncts before materialisation: nothing unmaterialised is a
+        // `KeyboardInterrupt`, which has no `ExcKind` at all.
+        let mut ordinary = super::PyError::type_error("bad operand");
+        assert!(!ordinary.r#async(pyre_object::PY_NULL));
+        assert!(
+            ordinary.exc_object.is_null(),
+            "the read must not materialise"
+        );
+
+        let mut exiting = super::PyError::new(super::PyErrorKind::SystemExit, "0");
+        assert!(exiting.r#async(pyre_object::PY_NULL));
+        assert!(
+            exiting.exc_object.is_null(),
+            "the read must not materialise"
+        );
     }
 }

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1597,6 +1597,11 @@ impl PyError {
     /// An unmaterialised error therefore has no chain to report, which is the
     /// same answer upstream's `None` gives: nothing has recorded a frame yet.
     ///
+    /// 3.14 does not defer the instance either — `_PyErr_SetObject` comments
+    /// "We must normalize the value right now" and calls
+    /// `_PyErr_CreateException` before storing anything — so building it at
+    /// the first unwind, rather than never, is the closer of the two.
+    ///
     /// Reading marks the head frame escaped, upstream's documented side
     /// effect — see [`crate::pytraceback::mark_traceback_escaped`] for which
     /// single-frame case that covers.

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -3983,6 +3983,46 @@ pub(crate) fn type_name_of(w_obj: PyObjectRef) -> String {
     }
 }
 
+/// `error.py oefmt` — build an exception whose message is `valuefmt` with each
+/// format code filled from its own argument.
+///
+/// ```python
+/// @specialize.arg(1)
+/// def oefmt(w_type, valuefmt, *args):
+///     """Equivalent to OperationError(w_type, space.newtext(valuefmt % args)).
+///     More efficient in the (common) case where the value is not actually
+///     needed."""
+/// ```
+///
+/// The conversions run here rather than behind the message accessor, and that
+/// is a decision rather than an omission.  Upstream returns an `OpErrFmt`
+/// storing the operands and formats only when `get_w_value` asks
+/// `_compute_value`, which is the RPython saving its docstring advertises: an
+/// error caught by an interpreter-level guard and discarded never pays for its
+/// `%R`.  3.14 does not defer.  `_PyErr_FormatV` renders the whole string
+/// before it ever names the exception —
+///
+/// ```c
+/// /* Issue #23571: PyUnicode_FromFormatV() must not be called with an
+///    exception set, it calls arbitrary Python code like PyObject_Repr() */
+/// _PyErr_Clear(tstate);
+/// string = PyUnicode_FromFormatV(format, vargs);
+/// ```
+///
+/// — so `%R`'s `PyObject_Repr` runs at the raise, not at the read.  Measured on
+/// 3.14.2 with a `__repr__` that logs, against `types.GenericAlias(obj, ...)[int]`
+/// (`genericaliasobject.c` `"%R is not a generic class"`): one call at
+/// construction, none at `str(e)`.  Deferring would move that side effect and
+/// its unraisable to a different moment than 3.14 picks.
+///
+/// The upstream saving is also narrower than it looks on 3.x: `except` pushes
+/// the instance whether or not the handler binds it, so the first
+/// application-level handler forces `_compute_value` anyway.  What is left is
+/// the interpreter-internal swallow — `findattr`, the `async` guards — and
+/// taking it would need the operands rooted for a `PyError` in flight, which
+/// nothing can do: Rust memcpies the carrier at every `?`, the same
+/// constraint that keeps the traceback chain on the instance
+/// ([`PyError::get_traceback`]).
 pub fn oefmt(w_type: PyObjectRef, valuefmt: &str, args: &[FmtArg<'_>]) -> OperationError {
     // `OpErrFmtNoArgs(w_type, valuefmt)` — no argument, so the format string is
     // the message verbatim, `%` sequences and all.  Nothing on the way to the

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -3311,7 +3311,10 @@ fn write_traceback_chain_from_tb<W: Write>(
             break;
         }
         let w_code = unsafe { crate::pytraceback::w_pytraceback_get_w_code(current_tb) };
-        let lineno = unsafe { crate::pytraceback::w_pytraceback_get_lineno(current_tb) };
+        // `Py_DisplayTraceback` prints whatever `tb_get_lineno` gave it,
+        // negative included, rather than skipping a node it cannot place.
+        let lineno =
+            unsafe { crate::pytraceback::w_pytraceback_get_lineno(current_tb) }.unwrap_or(-1);
         let lasti = unsafe { crate::pytraceback::w_pytraceback_get_lasti(current_tb) };
         let (filename, funcname, location) = if w_code.is_null() {
             (b"<unknown>".to_vec(), String::from("<unknown>"), None)

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3034,18 +3034,25 @@ impl PyFrame {
     /// consuming frame under `sys.settrace` on 3.14.2:
     ///
     /// ```text
-    /// for _ in CustomIter():  # Python-level __next__ raising StopIteration
-    ///     -> [('__next__', 'StopIteration'), ('run', 'StopIteration')]
-    /// for _ in gen():   -> []
-    /// for _ in [1]:     -> []
-    /// for _ in range(1):-> []
+    /// for _ in CustomIter():   # Python-level __next__ raising StopIteration
+    ///     -> [('__next__', 'StopIteration'), ('consume', 'StopIteration')]
+    /// for _ in map(stop, [1]): # native __next__, Python-raised StopIteration
+    ///     -> [('stop', 'StopIteration'), ('consume', 'StopIteration')]
+    /// for _ in gen():          -> []
+    /// for _ in [1]:            -> []
+    /// for _ in range(1):       -> []
+    /// for _ in iter(step, 3):  -> []
     /// ```
     ///
     /// So the report fires when the StopIteration carries a traceback and
     /// not otherwise; porting the generator arms would fire an event 3.14
-    /// does not.  A StopIteration raised inside a Python `__next__` picks up
-    /// its traceback on the way out of that frame, which is what makes the
-    /// two rules coincide.
+    /// does not.  The `map` row is what settles that the rule is about the
+    /// traceback rather than about the iterator's kind: its `__next__` is
+    /// native, and the event still fires, because the StopIteration passed
+    /// through a Python frame on the way out.
+    ///
+    /// `pyre/extra_tests/parity_tests/foriter_stopiteration_exception_event.py`
+    /// pins all of it.
     ///
     /// The exhaustion an iterator signals from Rust never materialises an
     /// exception, so the common loop exit answers `has_any_traceback` false

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3015,6 +3015,60 @@ unsafe fn load_global_via_cache(
     }
 }
 
+impl PyFrame {
+    /// `pyopcode.py _report_stopiteration_sometimes`.
+    ///
+    /// ```python
+    /// def _report_stopiteration_sometimes(self, w_iterator, operr):
+    ///     ...
+    ///     if (isinstance(w_iterator, GeneratorOrCoroutine) or
+    ///             isinstance(w_iterator, AsyncGenASend) or
+    ///             operr.has_any_traceback()):
+    ///         self.space.getexecutioncontext().exception_trace(self, operr)
+    /// ```
+    ///
+    /// Only the traceback arm is ported, and `w_iterator` is unused as a
+    /// result.  Upstream calls its two generator arms "an approximative
+    /// rule" for a case it says it cannot emulate; 3.14 turns out to be
+    /// exactly the third disjunct.  Counting `exception` events in the
+    /// consuming frame under `sys.settrace` on 3.14.2:
+    ///
+    /// ```text
+    /// for _ in CustomIter():  # Python-level __next__ raising StopIteration
+    ///     -> [('__next__', 'StopIteration'), ('run', 'StopIteration')]
+    /// for _ in gen():   -> []
+    /// for _ in [1]:     -> []
+    /// for _ in range(1):-> []
+    /// ```
+    ///
+    /// So the report fires when the StopIteration carries a traceback and
+    /// not otherwise; porting the generator arms would fire an event 3.14
+    /// does not.  A StopIteration raised inside a Python `__next__` picks up
+    /// its traceback on the way out of that frame, which is what makes the
+    /// two rules coincide.
+    ///
+    /// The exhaustion an iterator signals from Rust never materialises an
+    /// exception, so the common loop exit answers `has_any_traceback` false
+    /// off a null carrier and never reaches the tracer test.
+    fn _report_stopiteration_sometimes(
+        &mut self,
+        _w_iterator: PyObjectRef,
+        operr: &mut PyError,
+    ) -> Result<(), PyError> {
+        if !operr.has_any_traceback() {
+            return Ok(());
+        }
+        let ec = self.execution_context as *mut crate::PyExecutionContext;
+        if ec.is_null() {
+            return Ok(());
+        }
+        // The tracer runs Python, so the frame it is handed is read off the
+        // anchor rather than out of `self`.
+        let anchor = FrameAnchor::new(self);
+        unsafe { (*ec).exception_trace(anchor.live(), operr) }
+    }
+}
+
 /// PyPy: pyopcode.py GET_ITER → space.iter(w_iterable)
 ///       pyopcode.py FOR_ITER → space.next(w_iterator)
 impl IterOpcodeHandler for PyFrame {
@@ -3251,7 +3305,11 @@ impl IterOpcodeHandler for PyFrame {
         // iter_next), not by branching the interpreter opcode implementation.
         match crate::baseobjspace::next(iter) {
             Ok(result) => Ok(Some(result)),
-            Err(e) if e.matches_stop_iteration() => Ok(None),
+            Err(mut e) if e.matches_stop_iteration() => {
+                // iterator exhausted
+                self._report_stopiteration_sometimes(iter, &mut e)?;
+                Ok(None)
+            }
             Err(e) => Err(e),
         }
     }

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -2888,6 +2888,36 @@ pub fn code_locations(code: &crate::CodeObject) -> &[(SourceLocation, SourceLoca
     rows
 }
 
+/// `PyCode_Addr2Line` — the source line the byte offset `addrq` sits on, or
+/// `None` when the offset names no line.
+///
+/// ```c
+/// if (addrq < 0) {
+///     return co->co_firstlineno;
+/// }
+/// ...
+/// return _PyCode_CheckLineNumber(addrq, &bounds);
+/// ```
+///
+/// `addrq` counts bytes, two per instruction, so the row index is `addrq / 2`
+/// — the same conversion `traceback._get_code_position` makes app-level.  A
+/// negative offset names the code object's first line, which is the answer for
+/// a frame that has not run an instruction yet.
+///
+/// An offset past the last row answers `None`, and `tb_lineno` hands that back
+/// as `None`.  `_PyCode_CheckLineNumber` also answers `-1` for an in-range
+/// instruction that carries no line at all; pyre's rows cannot spell that,
+/// because `SourceLocation::line` is a `OneIndexed`.
+pub fn w_code_addr2line(code: &crate::CodeObject, addrq: i64) -> Option<usize> {
+    if addrq < 0 {
+        return Some(code.first_line_number.map_or(1, |line| line.get()));
+    }
+    let index = usize::try_from(addrq / 2).ok()?;
+    code_locations(code)
+        .get(index)
+        .map(|(start, _)| start.line.get())
+}
+
 /// Registry mapping a raw CodeObject pointer (`PyCode.code_ptr`) to the
 /// live, globals-stamped `PyCode` wrapper. Populated where a frame stamps
 /// the wrapper's `w_globals` — the only point both the raw pointer and the
@@ -3527,6 +3557,34 @@ mod tests {
         let w_code = w_code_new(std::ptr::null());
         let result = unsafe { w_code_const(w_code, 0) };
         assert_eq!(result, pyre_object::pyobject::PY_NULL);
+    }
+
+    /// `PyCode_Addr2Line` on a real code object: the byte offset halves into a
+    /// row index, a negative offset names the first line, and an offset past
+    /// the last row reports no line at all.
+    #[test]
+    fn w_code_addr2line_halves_the_offset_and_reports_a_miss() {
+        let code = compile_exec("a = 1\nb = 2\nc = 3\n").expect("compile failed");
+        let firstlineno = code.first_line_number.map_or(1, |line| line.get());
+        assert_eq!(w_code_addr2line(&code, -1), Some(firstlineno));
+        assert_eq!(w_code_addr2line(&code, -2), Some(firstlineno));
+
+        let rows: Vec<usize> = code_locations(&code)
+            .iter()
+            .map(|(start, _)| start.line.get())
+            .collect();
+        assert!(!rows.is_empty());
+        for (index, line) in rows.iter().copied().enumerate() {
+            let addrq = index as i64 * 2;
+            assert_eq!(w_code_addr2line(&code, addrq), Some(line));
+            // The odd byte inside an instruction reads that instruction's row.
+            assert_eq!(w_code_addr2line(&code, addrq + 1), Some(line));
+        }
+        // Each of the three statements contributes at least one instruction.
+        assert!(rows.contains(&(firstlineno + 2)), "{rows:?}");
+
+        assert_eq!(w_code_addr2line(&code, rows.len() as i64 * 2), None);
+        assert_eq!(w_code_addr2line(&code, 1 << 30), None);
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -2899,6 +2899,12 @@ pub fn code_locations(code: &crate::CodeObject) -> &[(SourceLocation, SourceLoca
 /// return _PyCode_CheckLineNumber(addrq, &bounds);
 /// ```
 ///
+/// `location.py offset2lineno(c, stopat)` is the same resolver upstream, down
+/// to the byte-offset convention: it answers `c.co_firstlineno` for `-1` and
+/// halves `stopat` before walking the line table.  `pyframe::offset2lineno`
+/// carries the name but takes an instruction index, so this is the one a
+/// `tb_lasti` reaches.
+///
 /// `addrq` counts bytes, two per instruction, so the row index is `addrq / 2`
 /// — the same conversion `traceback._get_code_position` makes app-level.  A
 /// negative offset names the code object's first line, which is the answer for

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1902,16 +1902,16 @@ pub const PYFRAME_LOCALS_OFFSET: usize = PYFRAME_LOCALS_CELLS_STACK_OFFSET;
 /// pytraceback.py offset2lineno(c, stopat) — convert instruction index to line number.
 /// Matches RPython: negative `stopat` means "frame not yet started", returns
 /// first-line.
+///
+/// The same row lookup as [`crate::pycode::w_code_addr2line`], which takes the
+/// byte offset `tb_lasti` carries rather than an instruction index and reports
+/// a miss instead of clamping.  This one clamps to the first line, so it can
+/// never express the `None` a `tb_lineno` read answers.
 #[inline]
 pub fn offset2lineno(code: &CodeObject, stopat: isize) -> usize {
-    let lineno = code.first_line_number.map(|n| n.get()).unwrap_or(1);
-    if stopat < 0 {
-        return lineno;
-    }
-    crate::pycode::code_locations(code)
-        .get(stopat as usize)
-        .map(|(start, _)| start.line.get())
-        .unwrap_or(lineno)
+    let addrq = (stopat as i64).saturating_mul(2);
+    crate::pycode::w_code_addr2line(code, addrq)
+        .unwrap_or_else(|| code.first_line_number.map_or(1, |n| n.get()))
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -51,9 +51,19 @@ use pyre_object::pyobject::*;
 
 /// `pytraceback.py` `LINENO_NOT_COMPUTED = -sys.maxint-1` —
 /// sentinel meaning "please take the lineno from the frame and
-/// `lasti`".  Pyre uses `i64::MIN` to match RPython's `-sys.maxint-1`
-/// idiom (`pytraceback.py:9-12`).
-pub const LINENO_NOT_COMPUTED: i64 = i64::MIN;
+/// `lasti`".
+///
+/// The value is `-1`, not upstream's `-sys.maxint-1`, because the sentinel is
+/// app-level visible through the fourth constructor argument and `-1` is the
+/// one 3.14 measures it against: `tb_lineno_get` resolves on
+/// `if (lineno == -1)`, and `_PyTraceBack_FromFrame` records a node with
+/// `tb_create_raw(..., -1)`.  Upstream's comment explains its own choice —
+/// negative line numbers are settable there, so it took the most negative
+/// value to keep a written line number from colliding with the sentinel — and
+/// 3.14 answered the same worry by making `tb_lineno` read-only instead.  Pyre
+/// keeps the setter, so a written `-1` re-resolves here where 3.14 would raise
+/// `AttributeError`; every value 3.14 can actually produce reads the same.
+pub const LINENO_NOT_COMPUTED: i64 = -1;
 
 pub static PYTRACEBACK_TYPE: PyType = new_pytype("traceback");
 
@@ -91,8 +101,7 @@ pub struct PyTraceback {
     pub w_next: PyObjectRef,
     /// `pytraceback.py self.lineno = lineno` — either a real
     /// source line number or `LINENO_NOT_COMPUTED`, in which case
-    /// `get_lineno` calls `offset2lineno` to resolve it lazily
-    /// (`pytraceback.py:34-37`).
+    /// `w_pytraceback_get_lineno` resolves it from `w_code` and `lasti`.
     pub lineno: i64,
     /// Snapshot of the raising frame's `pycode`, with no upstream
     /// counterpart — `pytraceback.py` reads `self.frame.pycode`
@@ -308,35 +317,45 @@ pub unsafe fn w_pytraceback_get_w_code(obj: PyObjectRef) -> PyObjectRef {
 ///     return space.newint(self.get_lineno())
 /// ```
 ///
-/// Pyre stamps the real line number at `record_application_traceback`
-/// time instead of resolving it here.  The upstream walk goes through
-/// `self.frame.pycode`, which this reader cannot do: `frame` is only
-/// forwarded for a frame the GC owns, so it may already have been
-/// freed by the time `tb_lineno` is read.  The `w_code` snapshot is
-/// forwarded unconditionally and IS that `pycode`, so `offset2lineno`
-/// off `w_code` and `lasti` would be safe to run lazily.  What still
-/// depends on the eager stamp is the JIT fold
-/// `walker_specialize_traceback_walk_field` (pyre-jit-trace): it reads
-/// this slot directly and declines on the sentinel, so under a lazy
-/// `get_lineno` every fresh node would decline on its first read.
+/// The resolution walks the `w_code` snapshot rather than upstream's
+/// `self.frame.pycode`: `frame` is only forwarded for a frame the GC owns, so
+/// it may already have been freed by the time `tb_lineno` is read, while
+/// `w_code` is forwarded unconditionally and IS that `pycode`.
 ///
-/// Two `tb_lineno` answers diverge from `get_lineno` because of it.
-/// Upstream re-resolves from the CURRENT `lasti` whenever the slot
-/// still holds the sentinel, so `tb.tb_lasti = N; tb.tb_lineno` reads
-/// the new offset there and the originally-stamped line here; and a
-/// sentinel written back through `TracebackType(..., -sys.maxsize-1)`
-/// or the `tb_lineno` setter is re-resolved there and answered `-1`
-/// here.  Porting back to lazy needs the fold to call a resolver
-/// rather than decline.  The sentinel also still surfaces as `-1` for
-/// a traceback constructed without a frame (e.g. unit tests).
+/// `None` is the `Py_RETURN_NONE` arm of `tb_lineno_get`, taken when
+/// `PyCode_Addr2Line` reports no line for `tb_lasti` — here also when the node
+/// carries no code object at all, which upstream cannot reach because its
+/// frame edge is unconditional.
+///
+/// The resolved line is NOT written back to the slot.  Upstream memoizes
+/// (`self.lineno = offset2lineno(...)`); `tb_lineno_get` re-reads instead, and
+/// re-reading is what keeps the slot single-writer for the JIT fold
+/// `walker_specialize_traceback_walk_field`, which folds the raw slot against
+/// a guard that it is not the sentinel.
+///
+/// `record_application_traceback` still stamps the line eagerly, so a recorded
+/// node reaches the first branch and never resolves here.  That timing is not
+/// observable against 3.14: `tb_lasti` and `tb_lineno` are both read-only
+/// there, so the only way to hand a live node a sentinel is the constructor,
+/// which lands in the second branch either way.
 ///
 /// # Safety
 /// `tb` must point to a valid `PyTraceback`.
-#[inline]
-pub unsafe fn w_pytraceback_get_lineno(tb: PyObjectRef) -> i64 {
+pub unsafe fn w_pytraceback_get_lineno(tb: PyObjectRef) -> Option<i64> {
     unsafe {
         let raw = w_pytraceback_get_lineno_raw(tb);
-        if raw == LINENO_NOT_COMPUTED { -1 } else { raw }
+        if raw != LINENO_NOT_COMPUTED {
+            return Some(raw);
+        }
+        let w_code = w_pytraceback_get_w_code(tb);
+        if w_code.is_null() {
+            return None;
+        }
+        let code = crate::w_code_get_ptr(w_code) as *const crate::CodeObject;
+        if code.is_null() {
+            return None;
+        }
+        crate::pycode::w_code_addr2line(&*code, w_pytraceback_get_lasti(tb)).map(|line| line as i64)
     }
 }
 
@@ -425,24 +444,23 @@ pub unsafe fn record_application_traceback(
         // safepoint's non-moving major would otherwise sweep its old-gen
         // traceback chain (`tstate->current_exception` parity).
         crate::eval::set_in_flight_exception(w_exc_object);
-        // `pytraceback.py:36 self.lineno = offset2lineno(self.frame
-        // .pycode, self.lasti)` — pyre resolves the line number
-        // eagerly here rather than lazily in `get_lineno`, so the slot
-        // never holds `LINENO_NOT_COMPUTED` for a node built here.
+        // `pytraceback.py self.lineno = offset2lineno(self.frame
+        // .pycode, self.lasti)` — pyre resolves the line number eagerly
+        // here rather than leaving the sentinel for the getter, so the
+        // slot never holds `LINENO_NOT_COMPUTED` for a node built here.
+        // `_PyTraceBack_FromFrame` records the sentinel instead and
+        // `tb_lineno_get` resolves it, but a node's `tb_lasti` and
+        // `tb_lineno` are both read-only there, so which of the two
+        // moments does the walk is not app-level observable.
         //
-        // Frame lifetime is NOT what blocks the lazy form: the `w_code`
+        // What the eager stamp buys is the JIT fold
+        // `walker_specialize_traceback_walk_field` (pyre-jit-trace): it
+        // reads this slot directly and declines on the sentinel, so a
+        // node that carried the sentinel would decline on every read of
+        // its line.  Frame lifetime is not part of it — the `w_code`
         // slot below is forwarded unconditionally and is the same
-        // `pycode` upstream reads, so resolving off `w_code` + `lasti`
-        // would be safe at any later point.  What blocks it is the JIT
-        // fold `walker_specialize_traceback_walk_field`
-        // (pyre-jit-trace), which reads this slot directly and declines
-        // on the sentinel; under a lazy `get_lineno` every freshly
-        // recorded node carries the sentinel on its first read, so the
-        // fold would have to emit a resolver call plus the memoizing
-        // write-back in place of today's plain `getfield`.  That trades
-        // a folded field read for a call on the `tb_lineno` walk.
-        // See `w_pytraceback_get_lineno` for the two `tb_lineno`
-        // answers the eager stamp diverges on.
+        // `pycode` upstream reads, which is what makes the getter's
+        // resolution safe at any later point.
         //
         // `frame.pycode` is the `PyCode` wrapper; the inner
         // `CodeObject` is extracted via `pyframe_get_pycode`.
@@ -504,6 +522,40 @@ mod tests {
             assert_eq!(w_pytraceback_get_lineno_raw(tb), LINENO_NOT_COMPUTED);
             assert!(w_pytraceback_get_frame(tb).is_null());
             assert!(w_pytraceback_get_w_code(tb).is_null());
+        }
+    }
+
+    /// The sentinel is the value the fourth constructor argument is measured
+    /// against, so it has to be the one `tb_lineno_get` tests for.
+    #[test]
+    fn the_sentinel_is_the_one_the_constructor_can_hand_in() {
+        assert_eq!(LINENO_NOT_COMPUTED, -1);
+    }
+
+    /// A node carrying no code object cannot resolve, which is the
+    /// `Py_RETURN_NONE` arm; a stamped line is handed back as it is, including
+    /// the negative values `descr_set_tb_lineno` accepts.
+    #[test]
+    fn an_unresolvable_node_answers_none_and_a_stamped_line_answers_itself() {
+        unsafe {
+            let unresolvable = w_pytraceback_new(
+                std::ptr::null_mut(),
+                42,
+                PY_NULL,
+                LINENO_NOT_COMPUTED,
+                PY_NULL,
+            );
+            assert_eq!(w_pytraceback_get_lineno(unresolvable), None);
+
+            let stamped = w_pytraceback_new(std::ptr::null_mut(), 42, PY_NULL, 7, PY_NULL);
+            assert_eq!(w_pytraceback_get_lineno(stamped), Some(7));
+
+            // `-2` is not the sentinel, so it reads back rather than resolving.
+            let negative = w_pytraceback_new(std::ptr::null_mut(), 42, PY_NULL, -2, PY_NULL);
+            assert_eq!(w_pytraceback_get_lineno(negative), Some(-2));
+
+            let zero = w_pytraceback_new(std::ptr::null_mut(), 42, PY_NULL, 0, PY_NULL);
+            assert_eq!(w_pytraceback_get_lineno(zero), Some(0));
         }
     }
 

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -57,12 +57,14 @@ use pyre_object::pyobject::*;
 /// app-level visible through the fourth constructor argument and `-1` is the
 /// one 3.14 measures it against: `tb_lineno_get` resolves on
 /// `if (lineno == -1)`, and `_PyTraceBack_FromFrame` records a node with
-/// `tb_create_raw(..., -1)`.  Upstream's comment explains its own choice —
-/// negative line numbers are settable there, so it took the most negative
-/// value to keep a written line number from colliding with the sentinel — and
-/// 3.14 answered the same worry by making `tb_lineno` read-only instead.  Pyre
-/// keeps the setter, so a written `-1` re-resolves here where 3.14 would raise
-/// `AttributeError`; every value 3.14 can actually produce reads the same.
+/// `tb_create_raw(..., -1)`.
+///
+/// Upstream's comment explains its own choice — negative line numbers are
+/// settable there, so it took the most negative value to keep a written line
+/// number from colliding with the sentinel.  3.14 answered the same worry by
+/// making `tb_lineno` read-only, and `init_pytraceback_type` follows it, so a
+/// line number can only arrive through the constructor and the collision
+/// upstream guarded against has no path here either.
 pub const LINENO_NOT_COMPUTED: i64 = -1;
 
 pub static PYTRACEBACK_TYPE: PyType = new_pytype("traceback");
@@ -244,13 +246,6 @@ pub unsafe fn w_pytraceback_get_lasti(obj: PyObjectRef) -> i64 {
 /// # Safety
 /// `obj` must point to a valid `PyTraceback`.
 #[inline]
-pub unsafe fn w_pytraceback_set_lasti(obj: PyObjectRef, value: i64) {
-    unsafe { (*(obj as *mut PyTraceback)).lasti = value }
-}
-
-/// # Safety
-/// `obj` must point to a valid `PyTraceback`.
-#[inline]
 pub unsafe fn w_pytraceback_get_w_next(obj: PyObjectRef) -> PyObjectRef {
     unsafe { (*(obj as *const PyTraceback)).w_next }
 }
@@ -293,13 +288,6 @@ pub unsafe fn w_pytraceback_get_lineno_raw(obj: PyObjectRef) -> i64 {
 /// # Safety
 /// `obj` must point to a valid `PyTraceback`.
 #[inline]
-pub unsafe fn w_pytraceback_set_lineno(obj: PyObjectRef, value: i64) {
-    unsafe { (*(obj as *mut PyTraceback)).lineno = value }
-}
-
-/// # Safety
-/// `obj` must point to a valid `PyTraceback`.
-#[inline]
 pub unsafe fn w_pytraceback_get_w_code(obj: PyObjectRef) -> PyObjectRef {
     unsafe { (*(obj as *const PyTraceback)).w_code }
 }
@@ -335,9 +323,9 @@ pub unsafe fn w_pytraceback_get_w_code(obj: PyObjectRef) -> PyObjectRef {
 ///
 /// `record_application_traceback` still stamps the line eagerly, so a recorded
 /// node reaches the first branch and never resolves here.  That timing is not
-/// observable against 3.14: `tb_lasti` and `tb_lineno` are both read-only
-/// there, so the only way to hand a live node a sentinel is the constructor,
-/// which lands in the second branch either way.
+/// observable: `tb_lasti` and `tb_lineno` are read-only, so the only way to
+/// hand a live node a sentinel is the constructor, which lands in the second
+/// branch either way.
 ///
 /// # Safety
 /// `tb` must point to a valid `PyTraceback`.
@@ -534,7 +522,7 @@ mod tests {
 
     /// A node carrying no code object cannot resolve, which is the
     /// `Py_RETURN_NONE` arm; a stamped line is handed back as it is, including
-    /// the negative values `descr_set_tb_lineno` accepts.
+    /// the negative values the constructor accepts.
     #[test]
     fn an_unresolvable_node_answers_none_and_a_stamped_line_answers_itself() {
         unsafe {

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -117,7 +117,7 @@ pub fn object_getstate_default(w_obj: PyObjectRef) -> PyResult {
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(w_obj);
     let current_obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
-    let w_objdict = crate::baseobjspace::findattr(current_obj(), "__dict__");
+    let w_objdict = crate::baseobjspace::findattr(current_obj(), "__dict__")?;
     let mut state_slot = None;
     if let Some(d) = w_objdict {
         let dict_slot = pyre_object::gc_roots::shadow_stack_len();
@@ -338,7 +338,7 @@ pub fn descr_reduce_ex(w_obj: PyObjectRef, proto: i64) -> PyResult {
     let current_obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
     // Honour a user `__reduce__` override:
     // `type(obj).__reduce__ is not object.__reduce__`.
-    let w_reduce = crate::baseobjspace::findattr(current_obj(), "__reduce__");
+    let w_reduce = crate::baseobjspace::findattr(current_obj(), "__reduce__")?;
     if let Some(w_reduce) = w_reduce {
         let reduce_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = pyre_object::gc_roots::pin_root(w_reduce);

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -7831,8 +7831,11 @@ fn init_pytraceback_type(ns: PyObjectRef) {
             if tb.is_null() {
                 return Ok(pyre_object::w_none());
             }
-            let n = unsafe { crate::pytraceback::w_pytraceback_get_lineno(tb) };
-            Ok(pyre_object::w_int_new(n))
+            // `tb_lineno_get` answers `None` when the offset names no line.
+            match unsafe { crate::pytraceback::w_pytraceback_get_lineno(tb) } {
+                Some(n) => Ok(pyre_object::w_int_new(n)),
+                None => Ok(pyre_object::w_none()),
+            }
         },
         2,
     );

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -7779,11 +7779,20 @@ fn init_pytraceback_type(ns: PyObjectRef) {
             make_new_descr(traceback_descr_new),
         )
     };
-    // pytraceback.py descr_get_tb_lasti / descr_set_tb_lasti — the slot
-    // is handed out and taken back as it is.  It already holds the byte offset
-    // `tb_lasti` means, so `traceback._get_code_position` recovers the
-    // instruction with its `// 2`, and a value written here reads back
-    // unchanged.
+    // pytraceback.py descr_get_tb_lasti — the slot is handed out as it is.
+    // It already holds the byte offset `tb_lasti` means, so
+    // `traceback._get_code_position` recovers the instruction with its `// 2`.
+    //
+    // `descr_set_tb_lasti` and `descr_set_tb_lineno` are deliberately NOT
+    // wired, for the reason `__reduce__` / `__setstate__` are not: 3.14 is the
+    // behaviour authority and it makes both fields read-only -- `tb_lasti` is
+    // `Py_READONLY` in `tb_memberlist` and `tb_lineno` is a getset with a NULL
+    // setter, leaving `tb_next` as the type's only writable field.  Keeping
+    // upstream's setters would matter more now than it used to: `tb_lineno`
+    // resolves `LINENO_NOT_COMPUTED` rather than storing it, so a written `-1`
+    // would read back as a resolved line, which is an answer neither reference
+    // gives.  The constructor still takes both values, which is how a
+    // traceback with a chosen offset is built here as it is there.
     let lasti_getter = make_builtin_function_with_arity(
         "tb_lasti",
         |args| {
@@ -7796,34 +7805,20 @@ fn init_pytraceback_type(ns: PyObjectRef) {
         },
         2,
     );
-    let lasti_setter = make_builtin_function_with_arity(
-        "tb_lasti",
-        |args| {
-            let tb = args[1];
-            let w_value = args[2];
-            if tb.is_null() {
-                return Ok(pyre_object::w_none());
-            }
-            let v = crate::baseobjspace::int_w(w_value)?;
-            unsafe { crate::pytraceback::w_pytraceback_set_lasti(tb, v) };
-            Ok(pyre_object::w_none())
-        },
-        3,
-    );
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "tb_lasti",
             make_getset_property_named(
                 lasti_getter,
-                lasti_setter,
+                pyre_object::PY_NULL,
                 pyre_object::PY_NULL,
                 "tb_lasti",
             ),
         )
     };
 
-    // pytraceback.py descr_get_tb_lineno / descr_set_tb_lineno.
+    // pytraceback.py descr_get_tb_lineno.
     let lineno_getter = make_builtin_function_with_arity(
         "tb_lineno",
         |args| {
@@ -7839,27 +7834,13 @@ fn init_pytraceback_type(ns: PyObjectRef) {
         },
         2,
     );
-    let lineno_setter = make_builtin_function_with_arity(
-        "tb_lineno",
-        |args| {
-            let tb = args[1];
-            let w_value = args[2];
-            if tb.is_null() {
-                return Ok(pyre_object::w_none());
-            }
-            let v = crate::baseobjspace::int_w(w_value)?;
-            unsafe { crate::pytraceback::w_pytraceback_set_lineno(tb, v) };
-            Ok(pyre_object::w_none())
-        },
-        3,
-    );
     unsafe {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "tb_lineno",
             make_getset_property_named(
                 lineno_getter,
-                lineno_setter,
+                pyre_object::PY_NULL,
                 pyre_object::PY_NULL,
                 "tb_lineno",
             ),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2277,13 +2277,14 @@ enum TracebackWalkField {
     TbFrame,
     /// `frame.f_code` — `fget_f_code` is `self.pycode as PyObjectRef`.
     FCode,
-    /// `tb.tb_lineno` — the line the node froze at.  `get_lineno` resolves it
-    /// lazily upstream; pyre stamps it at `record_application_traceback` time,
-    /// so the getter is the slot read plus the `LINENO_NOT_COMPUTED` mapping.
+    /// `tb.tb_lineno` — the line the node froze at.  The getter resolves the
+    /// sentinel out of `w_code` and `lasti`; `record_application_traceback`
+    /// stamps the real line instead, so a recorded node reads as the slot and
+    /// only a hand-constructed one has to resolve.  The fold covers the stamped
+    /// case and declines the other.
     ///
-    /// `tb_lasti` is deliberately absent: its getter reports `lasti * 2`, so
-    /// the fold would have to carry the doubling rather than hand back the
-    /// slot.
+    /// `tb_lasti` is deliberately absent: it is the one traceback slot the
+    /// walker has no reason to reach, since nothing on the walk consumes it.
     TbLineno,
     /// `code.co_name` — `code_get_field` answers it with `w_code_name_obj`,
     /// which realizes the string once and retains it on the code object, so
@@ -2435,12 +2436,13 @@ fn walker_specialize_traceback_walk_field<Sym: WalkSym>(
     if field == TracebackWalkField::TbLineno {
         let live =
             unsafe { pyre_interpreter::pytraceback::w_pytraceback_get_lineno_raw(concrete_obj) };
-        // `get_lineno` answers the sentinel with `-1`, so the slot value is the
-        // getter's value only once it is pinned against the sentinel.  A node
-        // that already carries it — built from a frame with no `pycode`, or
-        // handed the sentinel through `TracebackType(..., -sys.maxsize-1)` or
-        // the `tb_lineno` setter — has nothing to pin, so decline before
-        // recording anything.
+        // A slot holding the sentinel is not the getter's value — the getter
+        // resolves it out of `w_code` and `lasti`, which are two more slots
+        // this fold would have to pin — so the slot value is the getter's value
+        // only once it is pinned against the sentinel.  A node that already
+        // carries the sentinel — built from a frame with no `pycode`, or handed
+        // it through `TracebackType(..., -1)` or the `tb_lineno` setter — has
+        // nothing to pin, so decline before recording anything.
         if live == pyre_interpreter::pytraceback::LINENO_NOT_COMPUTED {
             return Ok(None);
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2441,8 +2441,8 @@ fn walker_specialize_traceback_walk_field<Sym: WalkSym>(
         // this fold would have to pin — so the slot value is the getter's value
         // only once it is pinned against the sentinel.  A node that already
         // carries the sentinel — built from a frame with no `pycode`, or handed
-        // it through `TracebackType(..., -1)` or the `tb_lineno` setter — has
-        // nothing to pin, so decline before recording anything.
+        // it through `TracebackType(..., -1)` — has nothing to pin, so decline
+        // before recording anything.
         if live == pyre_interpreter::pytraceback::LINENO_NOT_COMPUTED {
             return Ok(None);
         }


### PR DESCRIPTION
## What

The three follow-ups #1439 filed, plus the reasons two of its other follow-ups
turned out not to be gaps. Every candidate here was measured against CPython
3.14.2 before it was ported — three of them came back "upstream does this,
3.14 does not", and those were not ported.

### 1. `error: add OperationError.async, and stop findattr panicking on a raising descriptor`

`OperationError.async(space)` — "is this the kind of error a swallow must not
swallow" — had no counterpart. Ported as `PyError::r#async`, answering from
`kind` for an unmaterialised error so it allocates nothing, and by
`match_` against `SystemExit` / `KeyboardInterrupt` otherwise
(`KeyboardInterrupt` has no `ExcKind`; it is a heap class reached through
`lookup_exc_class`).

**Its 11 upstream guard sites are deliberately NOT ported.** Each was checked
against 3.14.5 and every one is a PyPy extension pyre already diverges from in
3.14's direction — `_csv`'s `QUOTE_NONNUMERIC` arm raises nothing there,
faulthandler's flush arm is a bare `PyErr_Clear()`, `_warnings get_category`
replaces the error with its own `TypeError`, islice clears and raises
`ValueError`, `_PyEval_GetANext` wraps every failure with
`_PyErr_FormatFromCause`. Porting the sites would have regressed the oracle.

The one site that stays is `object_functionstr_findattr`, whose upstream form
is the `async` guard. Getting there meant fixing `findattr`, which returned
`Option` and **panicked** on a raising descriptor. It now returns
`Result<Option<_>, PyError>` and follows the CPython rule: `AttributeError` and
`NameError` mean "absent", everything else propagates. Four call sites in
`reduce_protocol.rs` and `argument.rs` gained the `?`.

### 2. `eval: report FOR_ITER's StopIteration to the tracer when it carries a traceback`

FOR_ITER's exhaustion arm caught the `StopIteration` and jumped, so the
consuming frame never dispatched it and never reported an `exception` event —
which `pdb` stops on.

Upstream fires the event for `GeneratorOrCoroutine or AsyncGenASend or
operr.has_any_traceback()`, and its own comment calls the generator arms an
approximation. Measured under `sys.settrace` on 3.14.2: the consuming frame
gets the event for a Python-level `__next__` **only** — generator, list, range,
dict and `iter(callable, sentinel)` all deliver nothing. So the
`has_any_traceback()` arm is ported and the generator arms are not.

### 3. `pytraceback: resolve tb_lineno from tb_lasti when the slot holds the sentinel`

`LINENO_NOT_COMPUTED` was `i64::MIN` (upstream's `-sys.maxint-1`) and the
getter mapped it to `-1` instead of resolving it. The sentinel is app-level
reachable — it is `TracebackType`'s fourth argument — and 3.14 measures it
against `-1` (`tb_lineno_get`'s `if (lineno == -1)`,
`_PyTraceBack_FromFrame`'s `tb_create_raw(..., -1)`), so
`TracebackType(None, f, lasti, -1).tb_lineno` read back as `-1` rather than the
line `lasti` names.

Measured on 3.14.2, three cells a store-and-return runtime misses:

| | 3.14.2 | PyPy 7.3.20 | pyre before |
|---|---|---|---|
| `TracebackType(..., lasti, -1).tb_lineno` | the line | `-1` | `-1` |
| `... lasti = 1 << 30` | `None` | `-1` | `-1` |
| `... lineno = -2` / `0` | `-2` / `0` | same | same |

So the constant moves to `-1` and the getter resolves, returning
`Option<i64>` whose `None` is `tb_lineno_get`'s `Py_RETURN_NONE`. It walks the
`w_code` snapshot rather than upstream's `self.frame.pycode`, because `frame`
is only forwarded for a frame the GC owns.

New `pycode::w_code_addr2line` is the `PyCode_Addr2Line` port —
`location.py offset2lineno` is the same resolver upstream, down to halving the
byte offset and answering `co_firstlineno` for a negative one.
`pyframe::offset2lineno` carries that name but takes an instruction index, so
it now runs through the new one and keeps clamping.

`record_application_traceback` still stamps the line eagerly. That timing is
**not observable against 3.14**, because `tb_lasti` and `tb_lineno` are both
read-only there, so the only way to hand a live node a sentinel is the
constructor. Keeping the stamp is also what lets the JIT fold
`walker_specialize_traceback_walk_field` stay exactly as it was — only the
constant its guard compares against changes, so it emits no new op.

### 4. `pytraceback: stop wiring the tb_lasti and tb_lineno setters`

Raised by the Codex parity review of the commit above, and it was right: with
`-1` resolving rather than storing, a writable slot let `tb.tb_lineno = -1`
read back as a **computed line** — an answer neither reference gives (upstream
returns the `-1`, 3.14 refuses the assignment). Moving a sentinel obliges you
to close the write path.

3.14 leaves `tb_next` as the type's only writable field (`tb_lasti` and
`tb_frame` are `Py_READONLY` in `tb_memberlist`, `tb_lineno` is a getset with a
NULL setter). `tb_frame` was already wired read-only here; the other two now
match, for the reason `__reduce__` / `__setstate__` are not wired at all. The
constructor still takes both values. `w_pytraceback_set_lasti` and
`w_pytraceback_set_lineno` lose their only callers and go with them.

### 5. Two commits that record why a filed follow-up was not a gap

`error: record why oefmt converts its operands at the raise` — `OpErrFmt`
storing operands for `_compute_value` to convert lazily was flagged as "the
largest remaining parity gap in error.rs" by two consecutive reviews. It is
not one: `_PyErr_FormatV` clears the error state and renders **before** it
names the exception, with the comment *"PyUnicode_FromFormatV() must not be
called with an exception set, it calls arbitrary Python code like
PyObject_Repr()"*. Probe — a logging `__repr__` at a `%R` site:
`types.GenericAlias(NoisyRepr(), (int,))[int]` logs `['repr']` at construction
and nothing more at `str(e)`. Pyre's eager conversion is the 3.14 behaviour.

`error: note that 3.14 normalizes at the raise too` — same shape for
`_w_value`: `_PyErr_SetObject` comments *"We must normalize the value right
now"* and calls `_PyErr_CreateException`.

### Fixtures

Three parity fixtures, each pinning a rule the CPython suite does not reach:
`foriter_stopiteration_exception_event.py` (the traceback-vs-iterator rule, and
that a generator/list/range end delivers nothing),
`for_iter_raising_next_traceback.py`, and `traceback_lineno_sentinel.py` (the
sentinel, the offsets it resolves against, and which fields take an
assignment). PyPy 7.3.20 fails the generator case of the first and every
rebuilt case of the last; both headers say so.

## Verification

Rebased onto `e15c1f9aae9` (this branch's own #1439, merged) and re-verified
there, after a full `scripts/extract-llbc.py` (RC=0):

- **`cargo test --all --features dynasm` — 169 targets, 8216 passed, 0 failed.**
- The 13 traceback / lineno fixtures and synth benches that exercise the
  changed paths are **byte-identical to CPython 3.14.2** on a debug `pyre`
  built from this tree, including `traceback_lineno_sentinel.py`, which failed
  identically to PyPy before the change.
- Full parity sweep, 137 fixtures: 131 match; the 6 that do not are debug-build
  artefacts unchanged before and after (5 × a `majit-ir` `debug_assert` on
  `W_BytesObject.data`, 1 × a recursion-depth fixture on a debug stack).
- `cargo fmt --all --check` clean; `scripts/check-new-line-citations.py` clean
  against a pinned merge-base.
- **`pyre/check.py` was NOT run locally** — it needs release binaries and three
  release builds have been OOM-killed on this box. CI is the authority for it
  and for the `.jitstats` gates.

## Follow-ups not done here

- Defer materialisation to a real `_application_traceback` on `PyError`
  (blocked on rooting the propagating error — a Rust `PyError` is memcpy'd at
  every `?`, so its address cannot be registered).
- `OpErrFmtNoArgs.async`'s stack-almost-full `RecursionError` arm.
- `findattr` suppresses `AttributeError` / `NameError` where upstream suppresses
  every non-async `OperationError`; pre-existing, and the narrower set is the
  CPython rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved traceback line-number reporting, including unavailable, negative, and zero line values.
  * Corrected `StopIteration` exception tracing during Python-level iteration while preserving normal loop behavior.
  * Improved propagation of asynchronous exceptions during attribute lookups.
  * Updated traceback properties to accurately reflect resolved source locations and read-only behavior.

* **Tests**
  * Added coverage for iteration tracing, traceback reconstruction, source-line mapping, and exceptional lookup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->