### PR TITLE
_abc's weak cache, hidden_applevel and __name__ for an installed app source, and a type's owner on either heaptype axis

### DIFF
--- a/pyre/extra_tests/parity_tests/abc_check_frames_are_observable.py
+++ b/pyre/extra_tests/parity_tests/abc_check_frames_are_observable.py
@@ -76,6 +76,64 @@ def a_failure_behind_the_check_names_the_frames():
     assert names[-1] == '__subclasshook__', names
 
 
+def the_cache_membership_body_is_not_a_frame():
+    class Shape(metaclass=abc.ABCMeta):
+        pass
+
+    class Circle(Shape):
+        pass
+
+    circle = Circle()
+    # A populated positive cache, so the membership test really runs.
+    assert isinstance(circle, Shape) is True
+
+    seen = []
+
+    def record(frame, event, arg):
+        if event == 'call':
+            seen.append(frame.f_code.co_name)
+        return None
+
+    sys.settrace(record)
+    try:
+        isinstance(circle, Shape)
+    finally:
+        sys.settrace(None)
+
+    # The opposite pin to the two above, and the reason they are not a blanket
+    # rule about everything an ABC check touches.  The cache is a weak-set
+    # whose membership test is written in Python on one of these runtimes, yet
+    # no runtime reports a frame for it: where it is a built-in it has none,
+    # and where it is the module's own helper source the frame is hidden --
+    # `ApplevelClass.hidden_applevel` marks that code, `frame.hide()` drops it
+    # from the trace hook and `record_application_traceback` refuses to record
+    # it.  So answering membership without a frame is what every runtime
+    # already does, and only the `abc.py` frames above are observable.
+    assert seen.count('__contains__') == 0, seen
+
+    class Raising(type):
+        def __hash__(cls):
+            raise ValueError('refused')
+
+    class Opaque(metaclass=Raising):
+        pass
+
+    try:
+        isinstance(Opaque(), Shape)
+    except ValueError:
+        traceback = sys.exc_info()[2]
+    else:
+        raise AssertionError('the hash did not raise')
+
+    names = []
+    while traceback is not None:
+        names.append(traceback.tb_frame.f_code.co_name)
+        traceback = traceback.tb_next
+    assert names.count('__contains__') == 0, names
+    assert names[-1] == '__hash__', names
+
+
 instancecheck_is_a_traced_call()
 a_failure_behind_the_check_names_the_frames()
+the_cache_membership_body_is_not_a_frame()
 print('OK')

--- a/pyre/extra_tests/parity_tests/abc_check_frames_are_observable.py
+++ b/pyre/extra_tests/parity_tests/abc_check_frames_are_observable.py
@@ -133,7 +133,51 @@ def the_cache_membership_body_is_not_a_frame():
     assert names[-1] == '__hash__', names
 
 
+def the_declined_membership_body_is_not_a_frame():
+    class Shape(metaclass=abc.ABCMeta):
+        pass
+
+    class Circle(Shape):
+        pass
+
+    circle = Circle()
+    assert isinstance(circle, Shape) is True
+
+    collection = type(Shape._abc_cache)
+    namespace = collection.__contains__.__globals__
+
+    class Missing(Exception):
+        pass
+
+    seen = []
+
+    def record(frame, event, arg):
+        if event == 'call':
+            seen.append(frame.f_code.co_name)
+        return None
+
+    # A shadowing module entry is one of the things that makes the native
+    # answer decline, so this is the run where the app-level body really
+    # executes.  It is still not a frame: the body being reached is a fact
+    # about which implementation answers, and the frame's absence is a fact
+    # about whose code it is.
+    namespace['TypeError'] = Missing
+    sys.settrace(record)
+    try:
+        isinstance(circle, Shape)
+    finally:
+        sys.settrace(None)
+        del namespace['TypeError']
+
+    assert seen.count('__contains__') == 0, seen
+
+
 instancecheck_is_a_traced_call()
 a_failure_behind_the_check_names_the_frames()
 the_cache_membership_body_is_not_a_frame()
+# The last arm names a collection this implementation spells as a class
+# attribute; where it is not spellable there is nothing to shadow and the arm
+# does not apply.
+if hasattr(abc.ABCMeta('_Probe', (), {}), '_abc_cache'):
+    the_declined_membership_body_is_not_a_frame()
 print('OK')

--- a/pyre/extra_tests/parity_tests/abc_weak_cache_membership.py
+++ b/pyre/extra_tests/parity_tests/abc_weak_cache_membership.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins 3.14's "cannot use ... as a set element"; pypy3 reports only "unhashable type"
 # CPython-suite gap: `test_abc` asks membership only through classes whose
 # caches it never inspects, so it covers neither the empty-collection answer,
 # nor an item that cannot carry a weakref, nor a class whose hash raises, and

--- a/pyre/extra_tests/parity_tests/abc_weak_cache_membership.py
+++ b/pyre/extra_tests/parity_tests/abc_weak_cache_membership.py
@@ -322,6 +322,42 @@ def a_shadowed_typeerror_global_is_consulted():
     assert 'weak reference' in message, message
 
 
+def a_rebound_builtin_typeerror_is_consulted():
+    import builtins
+
+    class Caught(metaclass=ABCMeta):
+        pass
+
+    class Impl(Caught):
+        pass
+
+    class Claims:
+        __class__ = 3
+
+    assert isinstance(Impl(), Caught) is True
+
+    class Missing(Exception):
+        pass
+
+    # The other half of the shadowed-global arm.  With no module entry to find,
+    # `except TypeError` reaches the builtins binding, so rebinding it there
+    # leaves the handler naming something the weakref failure is not, and the
+    # failure escapes instead of becoming a `False`.  `except original` rather
+    # than `except TypeError`, because the name in this frame resolves through
+    # the same rebound builtins.
+    original = builtins.TypeError
+    builtins.TypeError = Missing
+    try:
+        isinstance(Claims(), Caught)
+    except original as exc:
+        message = str(exc)
+    else:
+        raise AssertionError('an unweakreferenceable class was accepted')
+    finally:
+        builtins.TypeError = original
+    assert 'weak reference' in message, message
+
+
 empty_collection_answers_then_fills()
 unweakreferenceable_class_reaches_the_subclass_check()
 a_raising_hash_runs_once()
@@ -335,4 +371,5 @@ if hasattr(ABCMeta('_Probe', (), {}), '_abc_cache'):
     a_non_function_contains_declines()
     a_mutated_ref_global_is_consulted()
     a_shadowed_typeerror_global_is_consulted()
+    a_rebound_builtin_typeerror_is_consulted()
 print('OK')

--- a/pyre/extra_tests/parity_tests/applevel_module_frames_are_hidden.py
+++ b/pyre/extra_tests/parity_tests/applevel_module_frames_are_hidden.py
@@ -1,28 +1,34 @@
 # CPython-suite gap: nothing in the suite installs a tracer around a builtin
 # whose implementation happens to be written in Python on some runtime, or
 # walks the traceback of a failure raised inside one, so nothing there notices
-# when such a helper starts reporting a frame.  On CPython every name below is
-# native and has no frame to report, which is exactly why the suite cannot
-# express the question.
+# when such a helper starts reporting a frame.  On CPython every name below
+# lives in an extension module and has no frame to report, which is exactly why
+# the suite cannot express the question.
 #
 # parity-tests reason: a frame is not an implementation detail once a program
-# can see it.  `sys.settrace` receives a `call` event for it and a traceback
-# records it, so a helper that is native on one runtime and app-level on
-# another must still answer both the same way -- and every arm here is a silent
-# difference in what a debugger shows rather than a wrong answer or a crash.
+# can see it.  `sys.settrace` receives a `call` event for it, a traceback
+# records it, and `sys._getframe` counts along a walk that includes it -- so a
+# helper that is native on CPython and app-level here must still answer all
+# three the same way.  Every arm is a silent difference in what a debugger
+# shows rather than a wrong answer or a crash.
 #
-# PyPy writes several of these in Python and keeps them invisible by
-# construction: a mixed module's app-level half loads through
-# `gateway.ApplevelClass`, whose `hidden_applevel` marks the code, and
-# `PyFrame.hide` then keeps those frames out of the trace hook
-# (`executioncontext.py _trace`), out of `record_application_traceback`, and
-# out of the `getnextframe_nohidden` walk.  The last arm is the other half of
-# that rule: a module PyPy ships as an ordinary import is the program's own,
-# its frames stay visible, and one of them counts them with `sys._getframe`.
+# PyPy has the same problem and the same mechanism: a mixed module's app-level
+# half loads through `gateway.ApplevelClass`, whose `hidden_applevel` marks the
+# code, and `PyFrame.hide` then keeps those frames out of the trace hook
+# (`executioncontext.py _trace`), out of `record_application_traceback` and out
+# of `getnextframe_nohidden`.
+#
+# Where PyPy does NOT apply it, the visible frames are an artefact of PyPy
+# implementing in Python (in `lib_pypy`) what CPython implements in C, not a
+# decision that those frames belong to the program: `_contextvars.Context.run`
+# only became hidden in PyPy 7.3.14, reactively, after it broke Django.  So the
+# arms below follow CPython, and `contextvars` and `blake2b` in particular
+# report FEWER frames here than a PyPy 3.11 build does.
 import sys
 import atexit
 import collections
 import contextvars
+import hashlib
 import operator
 import typing
 
@@ -78,14 +84,30 @@ def the_atexit_registry_is_not_a_frame():
     assert traced(register_and_drop) == ['register_and_drop'], traced(register_and_drop)
 
 
-def the_context_run_body_is_not_a_frame():
+def the_context_machinery_is_not_frames():
+    var = contextvars.ContextVar('probe', default=0)
     ctx = contextvars.copy_context()
-    names = traced(lambda: ctx.run(lambda: None))
-    # `run` is the frame between a callable and whoever asked the context to
-    # run it, and it is marked one at a time rather than by its module: the
-    # rest of the context object is the program's own.
-    assert names.count('run') == 0, names
-    assert names.count('<lambda>') == 2, names
+
+    def run_in_context():
+        return ctx.run(lambda: var.get())
+
+    # `run`, the variable lookup and the persistent map that stores the
+    # bindings are one extension module on CPython, so the only frame this
+    # reports is the callable the context was asked to run.
+    assert traced(run_in_context) == ['run_in_context', '<lambda>'], traced(run_in_context)
+
+    def set_and_reset():
+        token = var.set(1)
+        var.reset(token)
+
+    assert traced(set_and_reset) == ['set_and_reset'], traced(set_and_reset)
+
+
+def the_hash_wrappers_are_not_frames():
+    assert traced(lambda: hashlib.blake2b(b'abc').hexdigest()) == ['<lambda>'], traced(
+        lambda: hashlib.blake2b(b'abc').hexdigest()
+    )
+    assert traced(lambda: hashlib.sha256(b'abc').hexdigest()) == ['<lambda>']
 
 
 def a_failure_inside_aiter_records_no_frame():
@@ -107,21 +129,27 @@ def a_failure_inside_aiter_records_no_frame():
     assert names == ['a_failure_inside_aiter_records_no_frame'], names
 
 
-def a_module_the_program_imports_keeps_its_frames():
-    # The opposite pin.  A type-parameter object takes its `__module__` from
-    # the caller by counting frames back to it, so the helper's own frames and
-    # the constructor's have to be there to be counted.  Hiding the module that
-    # defines them would move the count onto this file's caller instead.
+def the_caller_a_type_parameter_records_is_this_frame():
+    # The arm that fails in the other direction.  A type-parameter object takes
+    # its `__module__` from the frame that is running when it is built, and
+    # every frame between this one and that read is one of the hidden ones --
+    # so the answer has to be this module, not whoever called it.
     assert typing.TypeVar('T').__module__ == '__main__', typing.TypeVar('T').__module__
     assert typing.ParamSpec('P').__module__ == '__main__'
     assert typing.TypeVarTuple('Ts').__module__ == '__main__'
+
+    def built_one_frame_deeper():
+        return typing.TypeVar('U').__module__
+
+    assert built_one_frame_deeper() == '__main__', built_one_frame_deeper()
 
 
 the_object_reduce_helpers_are_not_frames()
 the_defaultdict_factory_is_not_a_frame()
 the_operator_getters_are_not_frames()
 the_atexit_registry_is_not_a_frame()
-the_context_run_body_is_not_a_frame()
+the_context_machinery_is_not_frames()
+the_hash_wrappers_are_not_frames()
 a_failure_inside_aiter_records_no_frame()
-a_module_the_program_imports_keeps_its_frames()
+the_caller_a_type_parameter_records_is_this_frame()
 print('OK')

--- a/pyre/extra_tests/parity_tests/applevel_module_frames_are_hidden.py
+++ b/pyre/extra_tests/parity_tests/applevel_module_frames_are_hidden.py
@@ -1,0 +1,127 @@
+# CPython-suite gap: nothing in the suite installs a tracer around a builtin
+# whose implementation happens to be written in Python on some runtime, or
+# walks the traceback of a failure raised inside one, so nothing there notices
+# when such a helper starts reporting a frame.  On CPython every name below is
+# native and has no frame to report, which is exactly why the suite cannot
+# express the question.
+#
+# parity-tests reason: a frame is not an implementation detail once a program
+# can see it.  `sys.settrace` receives a `call` event for it and a traceback
+# records it, so a helper that is native on one runtime and app-level on
+# another must still answer both the same way -- and every arm here is a silent
+# difference in what a debugger shows rather than a wrong answer or a crash.
+#
+# PyPy writes several of these in Python and keeps them invisible by
+# construction: a mixed module's app-level half loads through
+# `gateway.ApplevelClass`, whose `hidden_applevel` marks the code, and
+# `PyFrame.hide` then keeps those frames out of the trace hook
+# (`executioncontext.py _trace`), out of `record_application_traceback`, and
+# out of the `getnextframe_nohidden` walk.  The last arm is the other half of
+# that rule: a module PyPy ships as an ordinary import is the program's own,
+# its frames stay visible, and one of them counts them with `sys._getframe`.
+import sys
+import atexit
+import collections
+import contextvars
+import operator
+import typing
+
+
+def traced(call):
+    seen = []
+
+    def record(frame, event, arg):
+        if event == 'call':
+            seen.append(frame.f_code.co_name)
+        return None
+
+    call()  # warm every lazy import and cache outside the trace
+    sys.settrace(record)
+    try:
+        call()
+    finally:
+        sys.settrace(None)
+    return seen
+
+
+def the_object_reduce_helpers_are_not_frames():
+    class Simple:
+        pass
+
+    obj = Simple()
+    # The protocol-2 reduction walks the instance dict and the slot names, and
+    # where that walk is written in Python it is still not the program's.
+    assert traced(lambda: obj.__reduce_ex__(2)) == ['<lambda>'], traced(
+        lambda: obj.__reduce_ex__(2)
+    )
+
+
+def the_defaultdict_factory_is_not_a_frame():
+    d = collections.defaultdict(int)
+    assert traced(lambda: d['missing']) == ['<lambda>'], traced(lambda: d['missing'])
+
+
+def the_operator_getters_are_not_frames():
+    get = operator.attrgetter('real')
+    assert traced(lambda: get(1)) == ['<lambda>'], traced(lambda: get(1))
+    assert traced(lambda: operator.itemgetter(0)([7])) == ['<lambda>']
+
+
+def the_atexit_registry_is_not_a_frame():
+    def callback():
+        pass
+
+    def register_and_drop():
+        atexit.register(callback)
+        atexit.unregister(callback)
+
+    assert traced(register_and_drop) == ['register_and_drop'], traced(register_and_drop)
+
+
+def the_context_run_body_is_not_a_frame():
+    ctx = contextvars.copy_context()
+    names = traced(lambda: ctx.run(lambda: None))
+    # `run` is the frame between a callable and whoever asked the context to
+    # run it, and it is marked one at a time rather than by its module: the
+    # rest of the context object is the program's own.
+    assert names.count('run') == 0, names
+    assert names.count('<lambda>') == 2, names
+
+
+def a_failure_inside_aiter_records_no_frame():
+    class NotAnAsyncIterator:
+        def __aiter__(self):
+            return self
+
+    try:
+        aiter(NotAnAsyncIterator())
+    except TypeError:
+        traceback = sys.exc_info()[2]
+    else:
+        raise AssertionError('aiter accepted a non-async-iterator')
+
+    names = []
+    while traceback is not None:
+        names.append(traceback.tb_frame.f_code.co_name)
+        traceback = traceback.tb_next
+    assert names == ['a_failure_inside_aiter_records_no_frame'], names
+
+
+def a_module_the_program_imports_keeps_its_frames():
+    # The opposite pin.  A type-parameter object takes its `__module__` from
+    # the caller by counting frames back to it, so the helper's own frames and
+    # the constructor's have to be there to be counted.  Hiding the module that
+    # defines them would move the count onto this file's caller instead.
+    assert typing.TypeVar('T').__module__ == '__main__', typing.TypeVar('T').__module__
+    assert typing.ParamSpec('P').__module__ == '__main__'
+    assert typing.TypeVarTuple('Ts').__module__ == '__main__'
+
+
+the_object_reduce_helpers_are_not_frames()
+the_defaultdict_factory_is_not_a_frame()
+the_operator_getters_are_not_frames()
+the_atexit_registry_is_not_a_frame()
+the_context_run_body_is_not_a_frame()
+a_failure_inside_aiter_records_no_frame()
+a_module_the_program_imports_keeps_its_frames()
+print('OK')

--- a/pyre/extra_tests/parity_tests/applevel_module_frames_are_hidden.py
+++ b/pyre/extra_tests/parity_tests/applevel_module_frames_are_hidden.py
@@ -18,17 +18,12 @@
 # (`executioncontext.py _trace`), out of `record_application_traceback` and out
 # of `getnextframe_nohidden`.
 #
-# Where PyPy does NOT apply it, the visible frames are an artefact of PyPy
-# implementing in Python (in `lib_pypy`) what CPython implements in C, not a
-# decision that those frames belong to the program: `_contextvars.Context.run`
-# only became hidden in PyPy 7.3.14, reactively, after it broke Django.  So the
-# arms below follow CPython, and `contextvars` and `blake2b` in particular
-# report FEWER frames here than a PyPy 3.11 build does.
+# Every name below is one PyPy hides too, so this file is checked against PyPy
+# as well.  The two subjects where PyPy answers differently are split into
+# `contextvars_and_hash_bodies_are_not_frames.py`, which says so in its header.
 import sys
 import atexit
 import collections
-import contextvars
-import hashlib
 import operator
 import typing
 
@@ -84,32 +79,6 @@ def the_atexit_registry_is_not_a_frame():
     assert traced(register_and_drop) == ['register_and_drop'], traced(register_and_drop)
 
 
-def the_context_machinery_is_not_frames():
-    var = contextvars.ContextVar('probe', default=0)
-    ctx = contextvars.copy_context()
-
-    def run_in_context():
-        return ctx.run(lambda: var.get())
-
-    # `run`, the variable lookup and the persistent map that stores the
-    # bindings are one extension module on CPython, so the only frame this
-    # reports is the callable the context was asked to run.
-    assert traced(run_in_context) == ['run_in_context', '<lambda>'], traced(run_in_context)
-
-    def set_and_reset():
-        token = var.set(1)
-        var.reset(token)
-
-    assert traced(set_and_reset) == ['set_and_reset'], traced(set_and_reset)
-
-
-def the_hash_wrappers_are_not_frames():
-    assert traced(lambda: hashlib.blake2b(b'abc').hexdigest()) == ['<lambda>'], traced(
-        lambda: hashlib.blake2b(b'abc').hexdigest()
-    )
-    assert traced(lambda: hashlib.sha256(b'abc').hexdigest()) == ['<lambda>']
-
-
 def a_failure_inside_aiter_records_no_frame():
     class NotAnAsyncIterator:
         def __aiter__(self):
@@ -148,8 +117,6 @@ the_object_reduce_helpers_are_not_frames()
 the_defaultdict_factory_is_not_a_frame()
 the_operator_getters_are_not_frames()
 the_atexit_registry_is_not_a_frame()
-the_context_machinery_is_not_frames()
-the_hash_wrappers_are_not_frames()
 a_failure_inside_aiter_records_no_frame()
 the_caller_a_type_parameter_records_is_this_frame()
 print('OK')

--- a/pyre/extra_tests/parity_tests/applevel_module_source_names_its_definitions.py
+++ b/pyre/extra_tests/parity_tests/applevel_module_source_names_its_definitions.py
@@ -1,0 +1,93 @@
+# CPython-suite gap: no suite test asks a module's own helpers what
+# `__module__` they report.  `test_atexit`, `test_ordered_dict`,
+# `test_hashlib` and `test_contextvars` all exercise what those objects *do*,
+# and each name here is reached through its module, so a wrong owner never
+# changes an answer any of them checks.  The name only surfaces when something
+# asks the object where it came from -- a traceback header, a `repr`, `help`,
+# or `pickle` resolving a reference.
+#
+# The subject is where the answer comes from.  A class reads `__module__` off
+# the globals it is defined in, through a name lookup that reaches the
+# builtins module when its own namespace has none -- so a namespace with no
+# `__name__` makes every class in it claim `builtins`.  A function reads the
+# same entry with a plain dict lookup instead, so the same namespace leaves
+# it with `None`.  Both are silent: the object is built, and only its account
+# of itself is wrong.
+#
+# parity-tests reason: several of these are written in Python here and in C on
+# CPython, and the namespace such a source runs in is the runtime's own
+# construction rather than a real module's dict.  That construction is what
+# has to bind the name, and nothing else in this suite would notice if it
+# stopped: pickling by reference is the one arm that fails loudly, and it
+# fails only for a subset.  CPython and PyPy agree on every arm below.
+import pickle
+import sys
+
+import atexit
+import collections
+import contextvars
+import hashlib
+import typing
+import _io
+
+
+def a_nameless_namespace_answers_two_different_ways():
+    namespace = {}
+    exec('class Cls: pass\ndef fn(): pass\n', namespace)
+
+    # The two halves of what an unnamed namespace costs.  Neither raises, and
+    # a runtime that builds its own module sources this way inherits both.
+    assert namespace['Cls'].__module__ == 'builtins', namespace['Cls'].__module__
+    assert namespace['fn'].__module__ is None, namespace['fn'].__module__
+
+
+def a_native_modules_own_helpers_name_it():
+    # `atexit` is a C module whose callbacks are pure Python here.  Whichever
+    # half a name is written in, it belongs to `atexit`.
+    for helper in (atexit.register, atexit.unregister, atexit._ncallbacks):
+        assert helper.__module__ == 'atexit', (helper, helper.__module__)
+
+
+def an_accelerated_class_names_the_module_it_is_reached_through():
+    # Each of these is a class an accelerator module defines and a public
+    # module re-exports, so the owner it reports is the one a reader can
+    # import it from -- not always the one whose source defines it.
+    expected = [
+        (collections.OrderedDict, 'collections'),
+        (collections.defaultdict, 'collections'),
+        (hashlib.blake2b, '_blake2'),
+        (contextvars.ContextVar, '_contextvars'),
+        (typing.TypeVar, 'typing'),
+        (_io.IncrementalNewlineDecoder, '_io'),
+    ]
+    for cls, owner in expected:
+        assert cls.__module__ == owner, (cls, cls.__module__, owner)
+
+
+def the_reported_owner_is_the_one_pickle_resolves():
+    # The arm that makes a wrong owner an error rather than a cosmetic slip.
+    # A class and a function both pickle as a reference -- module name plus
+    # qualified name -- so the owner has to be a module the loader can import
+    # and find the object in.  `None` and `builtins` are each unusable, and
+    # the failure lands on the caller pickling an ordinary object.
+    for obj in (
+        atexit.register,
+        atexit.unregister,
+        collections.OrderedDict,
+        collections.defaultdict,
+        hashlib.blake2b,
+        contextvars.ContextVar,
+        typing.TypeVar,
+        _io.IncrementalNewlineDecoder,
+    ):
+        restored = pickle.loads(pickle.dumps(obj))
+        assert restored is obj, (obj, restored)
+        module = sys.modules[obj.__module__]
+        assert getattr(module, obj.__name__) is obj, (obj, module)
+
+
+a_nameless_namespace_answers_two_different_ways()
+a_native_modules_own_helpers_name_it()
+an_accelerated_class_names_the_module_it_is_reached_through()
+the_reported_owner_is_the_one_pickle_resolves()
+print('OK')

--- a/pyre/extra_tests/parity_tests/binop_notimplemented_gc_roots.py
+++ b/pyre/extra_tests/parity_tests/binop_notimplemented_gc_roots.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins 3.14's "can't multiply sequence by non-int"; pypy3 reports "unsupported operand type(s) for *"
 # CPython-suite gap: no test returns NotImplemented from a dunder that collects.
 # parity-tests reason: this is a pyre/PyPy moving-GC root-liveness regression.
 

--- a/pyre/extra_tests/parity_tests/contextvars_and_hash_bodies_are_not_frames.py
+++ b/pyre/extra_tests/parity_tests/contextvars_and_hash_bodies_are_not_frames.py
@@ -1,0 +1,68 @@
+# pyre-check: pypy-diverges: pins the frameless contextvars and blake2b of a C implementation; pypy3 writes both in Python and shows their frames
+# CPython-suite gap: the suite never installs a tracer around a context switch
+# or a hash update, because on CPython there is nothing there to trace -- both
+# are extension modules in 3.11 and in 3.14 alike.
+#
+# parity-tests reason: pyre writes these two module bodies in Python, so
+# without a marker on that code their frames reach `sys.settrace`, a recorded
+# traceback and the walk `sys._getframe` counts along.  None of that shows up
+# as a wrong answer, so only a frame-shaped test can hold the line.
+#
+# Split out of `applevel_module_frames_are_hidden.py` because these two arms
+# are the ones PyPy answers differently, and the rest of that file is checked
+# against PyPy as well.  PyPy also writes them in Python -- in `lib_pypy` --
+# and leaves the frames visible, which is a consequence of the implementation
+# rather than a decision about them: `Context.run` alone became hidden in PyPy
+# 7.3.14, reactively, after it broke Django (release note: "Discovered in
+# django PR 17500").  So the reference here is CPython.
+import sys
+import contextvars
+import hashlib
+
+
+def traced(call):
+    seen = []
+
+    def record(frame, event, arg):
+        if event == 'call':
+            seen.append(frame.f_code.co_name)
+        return None
+
+    call()  # warm every lazy import and cache outside the trace
+    sys.settrace(record)
+    try:
+        call()
+    finally:
+        sys.settrace(None)
+    return seen
+
+
+def the_context_machinery_is_not_frames():
+    var = contextvars.ContextVar('probe', default=0)
+    ctx = contextvars.copy_context()
+
+    def run_in_context():
+        return ctx.run(lambda: var.get())
+
+    # `run`, the variable lookup and the persistent map holding the bindings
+    # are one extension module on CPython, so the only frame this reports is
+    # the callable the context was asked to run.
+    assert traced(run_in_context) == ['run_in_context', '<lambda>'], traced(run_in_context)
+
+    def set_and_reset():
+        token = var.set(1)
+        var.reset(token)
+
+    assert traced(set_and_reset) == ['set_and_reset'], traced(set_and_reset)
+
+
+def the_hash_wrappers_are_not_frames():
+    assert traced(lambda: hashlib.blake2b(b'abc').hexdigest()) == ['<lambda>'], traced(
+        lambda: hashlib.blake2b(b'abc').hexdigest()
+    )
+    assert traced(lambda: hashlib.sha256(b'abc').hexdigest()) == ['<lambda>']
+
+
+the_context_machinery_is_not_frames()
+the_hash_wrappers_are_not_frames()
+print('OK')

--- a/pyre/extra_tests/parity_tests/dict_set_sizeof_python314.py
+++ b/pyre/extra_tests/parity_tests/dict_set_sizeof_python314.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins __sizeof__ in the type dict of dict and set, which pypy3 does not put there
 # CPython-suite gap: exact dict and set __sizeof__ values are not asserted.
 # parity-tests reason: guard pyre's CPython 3.14 container size surface.
 

--- a/pyre/extra_tests/parity_tests/framelocalsproxy_gc_roots.py
+++ b/pyre/extra_tests/parity_tests/framelocalsproxy_gc_roots.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins PEP 667 write-through f_locals (3.13); a write through pypy3's proxy does not reach the fast local
 # CPython-suite gap: no suite test collects inside the key comparison a
 # FrameLocalsProxy operation performs.
 # parity-tests reason: this is a pyre/PyPy moving-GC root-liveness regression.

--- a/pyre/extra_tests/parity_tests/int_div_mod_raising_specialization.py
+++ b/pyre/extra_tests/parity_tests/int_div_mod_raising_specialization.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins 3.14's "division by zero"; pypy3 reports "integer division or modulo by zero"
 # CPython-suite gap: int div/mod tests do not compare cold/hot raising traces.
 # parity-tests reason: this guards pyre's JIT exact-int raising specialization.
 

--- a/pyre/extra_tests/parity_tests/itertools_subclass_lifetime.py
+++ b/pyre/extra_tests/parity_tests/itertools_subclass_lifetime.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins itertools.batched (3.12), absent from the CPython 3.11 pypy3 implements
 # CPython-suite gap: itertools subclass tests omit user-finalizer lifetime.
 # parity-tests reason: this guards PyPy-style allocation and moving-GC ownership.
 

--- a/pyre/extra_tests/parity_tests/jit_recursive_closure_live_set.py
+++ b/pyre/extra_tests/parity_tests/jit_recursive_closure_live_set.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins _pylong (3.12), absent from the CPython 3.11 pypy3 implements
 # CPython-suite gap: closure tests cannot cover pyre JIT residual-call liveness.
 # parity-tests reason: guard a closure-owned set across an inlined recursive call.
 

--- a/pyre/extra_tests/parity_tests/lsprof_enable_frees_tool_id_on_failure.py
+++ b/pyre/extra_tests/parity_tests/lsprof_enable_frees_tool_id_on_failure.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins sys.monitoring tool ids (3.12), absent from the CPython 3.11 pypy3 implements
 # CPython-suite gap: test_cprofile and test_profile only ever pass real bools
 # to `enable`, so neither exercises the failing-conversion path, and the leak
 # they would expose is process-wide rather than per-test.

--- a/pyre/extra_tests/parity_tests/math_prod_moving_gc_roots.py
+++ b/pyre/extra_tests/parity_tests/math_prod_moving_gc_roots.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins math.sumprod (3.12), absent from the CPython 3.11 pypy3 implements
 # CPython-suite gap: math tests do not collect while retaining numeric operands.
 # parity-tests reason: this is a pyre/PyPy moving-GC root-liveness regression.
 # parity-env: PYPY_GC_NURSERY=4096

--- a/pyre/extra_tests/parity_tests/memoryview_tobytes_order_python314.py
+++ b/pyre/extra_tests/parity_tests/memoryview_tobytes_order_python314.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins 3.14 taking memoryview.tobytes' order positionally; pypy3 accepts it only by keyword
 # CPython-suite gap: memoryview.tobytes order conversions are not all asserted.
 # parity-tests reason: guard pyre's CPython 3.14 memoryview conversion surface.
 

--- a/pyre/extra_tests/parity_tests/nan_unboxed_storage_identity.py
+++ b/pyre/extra_tests/parity_tests/nan_unboxed_storage_identity.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins two float("nan") calls being two objects, which every CPython gives; pypy3 gives one
 # CPython-suite gap: the suite checks NaN value semantics, not identity through containers.
 # parity-tests reason: pyre's raw-f64 storage reboxes on read, which only `is` / `id()` sees.
 

--- a/pyre/extra_tests/parity_tests/numeric_binary_subclass_specialization.py
+++ b/pyre/extra_tests/parity_tests/numeric_binary_subclass_specialization.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins PyFloat_AsDouble short-circuiting a float subclass; pypy3 runs its __float__ override instead
 # CPython-suite gap: numeric tests do not alternate subclasses at a hot binary site.
 # parity-tests reason: this guards pyre's JIT exact-class specialization guards.
 

--- a/pyre/extra_tests/parity_tests/ordered_dict_python314.py
+++ b/pyre/extra_tests/parity_tests/ordered_dict_python314.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins the OrderedDict({...}) repr (3.12); pypy3 spells it OrderedDict([(...)])
 # CPython-suite gap: these OrderedDict 3.14 contracts are not jointly asserted.
 # parity-tests reason: guard pyre's app-level OrderedDict compatibility surface.
 

--- a/pyre/extra_tests/parity_tests/projected_static_class_reports_its_module.py
+++ b/pyre/extra_tests/parity_tests/projected_static_class_reports_its_module.py
@@ -1,0 +1,70 @@
+# CPython-suite gap: `test_context` builds contexts, runs them and copies
+# them; it never asks the class what it is.  `test_pickle` pickles values, not
+# the runtime's own types.  So nothing there reads `Context.__module__`, and a
+# wrong answer costs nothing until someone prints the class, prints an
+# instance, or pickles either.
+#
+# The subject is a class two runtimes build two different ways.  It is a C
+# static type on CPython (`PyContext_Type`, `tp_name` `"_contextvars.Context"`)
+# and an ordinary Python class on PyPy (`lib_pypy/_contextvars.py`), and pyre
+# writes it in Python while projecting CPython's public type flags onto it --
+# `Context.__flags__` reports no heap bit and the class refuses attribute
+# assignment, both of which this suite's callers can see.  A runtime with two
+# separate notions of "this is a class" can answer the flag question one way
+# and the where-is-`__module__`-stored question the other, and then the class
+# reports a module it was never defined in.
+#
+# parity-tests reason: `__module__` is not read on its own -- three things
+# derive from it, and all three are what a user sees rather than what a test
+# asserts.  `repr` of the class, `repr` of an instance, and the reference
+# `pickle` writes and resolves.  The pickle arm is the one that raises; the
+# other two silently print a name that does not identify anything.
+#
+# The flags themselves are deliberately not pinned here: CPython reports no
+# heap bit and PyPy reports one, because PyPy really does define the class in
+# Python.  What both agree on is everything below.
+import pickle
+import sys
+
+import _contextvars
+import contextvars
+
+
+def the_class_reports_the_module_that_defines_it():
+    assert _contextvars.Context.__module__ == '_contextvars', (
+        _contextvars.Context.__module__)
+    # The other half: the name stays unqualified.  A runtime that repaired the
+    # module by qualifying the type's name instead would move this too.
+    assert _contextvars.Context.__name__ == 'Context', _contextvars.Context.__name__
+    assert _contextvars.Context.__qualname__ == 'Context', (
+        _contextvars.Context.__qualname__)
+
+
+def both_reprs_name_the_module():
+    assert repr(_contextvars.Context) == "<class '_contextvars.Context'>", (
+        repr(_contextvars.Context))
+    instance = repr(contextvars.copy_context())
+    assert instance.startswith('<_contextvars.Context object at 0x'), instance
+
+
+def the_class_pickles_by_reference():
+    # `pickle` writes the class as its module plus its qualified name and
+    # resolves it back through `sys.modules`, so a module the class was not
+    # defined in is a `PicklingError` rather than a cosmetic slip.
+    restored = pickle.loads(pickle.dumps(_contextvars.Context))
+    assert restored is _contextvars.Context, restored
+    module = sys.modules[_contextvars.Context.__module__]
+    assert getattr(module, 'Context') is _contextvars.Context
+
+
+def the_module_it_reports_is_the_one_it_is_reached_through():
+    # `contextvars` re-exports the accelerator's class rather than defining
+    # its own, so the owner the class claims has to be the accelerator.
+    assert contextvars.Context is _contextvars.Context
+
+
+the_class_reports_the_module_that_defines_it()
+both_reprs_name_the_module()
+the_class_pickles_by_reference()
+the_module_it_reports_is_the_one_it_is_reached_through()
+print('OK')

--- a/pyre/extra_tests/parity_tests/raise_from_invalid_cause.py
+++ b/pyre/extra_tests/parity_tests/raise_from_invalid_cause.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins 3.14's "exception causes must derive from BaseException"; pypy3 appends ", not int"
 # CPython-suite gap: test_raise.TestCause.test_invalid_cause raises
 # `IndexError from 5`, whose class has no observable constructor, so no test
 # sees whether the raised class is instantiated before the cause is rejected,

--- a/pyre/extra_tests/parity_tests/recursion_limit_survives_jit_warmup.py
+++ b/pyre/extra_tests/parity_tests/recursion_limit_survives_jit_warmup.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins a recursion depth decided by sys.setrecursionlimit alone; pypy3's moves between repeats
 # CPython-suite gap: recursion tests do not compare cold and JIT-hot call depth.
 # parity-tests reason: this guards pyre's native budget across JIT guard resume.
 

--- a/pyre/extra_tests/parity_tests/run.py
+++ b/pyre/extra_tests/parity_tests/run.py
@@ -18,6 +18,18 @@ A script whose subject is platform-specific names the platforms it
 applies to in its header (`# pyre-check: platforms=linux,darwin`) and is
 skipped elsewhere.
 
+PyPy runs too when one is on PATH, as a cross-check rather than a
+reference: it is a second implementation of the same language, so it
+catches a script that pins something pyre and CPython agree on only by
+accident. PyPy 7.3.x implements CPython 3.11, so a script pinning
+behaviour introduced later — or pinning something PyPy does its own way —
+cannot hold there and says so in its header:
+
+    # pyre-check: pypy-diverges: <what this pins, and what pypy3 reports>
+
+A script carrying that must fail under PyPy and a script without it must
+pass, so the directive cannot quietly outlive the divergence it names.
+
 A script whose defect is only reachable under a particular runtime
 configuration declares it with one or more
 
@@ -30,6 +42,9 @@ stops being reachable, i.e. cover nothing while still looking green.
 Usage:
     python3 pyre/extra_tests/parity_tests/run.py
         [--dynasm-only|--cranelift-only] [--gc-poison]
+
+`PYRE_CHECK_PYPY3` names the PyPy binary; setting it empty turns the
+cross-check off.
 
 `--gc-poison` fills reclaimed nursery bytes with a poison pattern for the
 pyre backends. A dangling reference into reclaimed nursery memory usually
@@ -68,6 +83,14 @@ PARITY_REASON_PREFIX = "# parity-tests reason:"
 # measures nothing, so a run that cannot find the right one stops rather than
 # reporting what it found.
 CPYTHON_TARGET = (3, 14)
+
+PYPY_DIVERGES_PREFIX = "# pyre-check: pypy-diverges:"
+
+# The CPython version PyPy implements, which is what makes it a cross-check and
+# not a second reference: it is three releases behind the one these scripts
+# pin. A PyPy on some other target has not been classified against this corpus,
+# so the lane skips rather than reporting what it found.
+PYPY_TARGET = (3, 11)
 
 
 def _runs_here(path: Path) -> bool:
@@ -110,8 +133,24 @@ def _scripts() -> tuple[list[Path], list[Path]]:
         if missing:
             names = ", ".join(missing)
             raise RuntimeError(f"{p.name}: missing parity header field(s): {names}")
+        for line in header:
+            if line.startswith(PYPY_DIVERGES_PREFIX):
+                if not line[len(PYPY_DIVERGES_PREFIX):].strip():
+                    raise RuntimeError(
+                        f"{p.name}: `{PYPY_DIVERGES_PREFIX}` with no reason — the "
+                        f"directive exists to say which divergence is expected"
+                    )
         (out if _runs_here(p) else skipped).append(p)
     return out, skipped
+
+
+def _pypy_divergence(script: Path) -> str | None:
+    """The divergence from PyPy this script declares, if it declares one."""
+    header = script.read_text(encoding="utf-8").splitlines()[:20]
+    for line in header:
+        if line.startswith(PYPY_DIVERGES_PREFIX):
+            return line[len(PYPY_DIVERGES_PREFIX):].strip()
+    return None
 
 
 _ENV_DIRECTIVE = re.compile(r"^#\s*parity-env:\s*(\w+)=(\S*)\s*$", re.MULTILINE)
@@ -246,6 +285,50 @@ def _cpython() -> str:
     )
 
 
+PYPY_PROBE = (
+    "import sys; print(sys.implementation.name); "
+    "print(sys.version_info[0], sys.version_info[1]); print(sys.executable)"
+)
+
+
+def _pypy() -> tuple[str | None, str]:
+    """The PyPy to cross-check against, and why there is none when there isn't.
+
+    Unlike [`_cpython`] this never stops the run: PyPy is a cross-check, and a
+    host without one still measures everything the references can decide.
+    Which is also why its absence is announced — a lane that silently does not
+    run reads exactly like a lane that ran and agreed.
+    """
+    named = os.environ.get("PYRE_CHECK_PYPY3")
+    if named is not None and not named.strip():
+        return None, "PYRE_CHECK_PYPY3 is set empty"
+    candidate = named or "pypy3"
+    if named is None and shutil.which(candidate) is None:
+        return None, "no pypy3 on PATH"
+    try:
+        proc = subprocess.run(
+            [candidate, "-c", PYPY_PROBE], capture_output=True, text=True, timeout=30
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None, f"{candidate} did not run"
+    lines = (proc.stdout or "").splitlines()
+    if proc.returncode != 0 or len(lines) < 3:
+        return None, f"{candidate} did not report its version"
+    if lines[0].strip() != "pypy":
+        return None, f"{candidate} is {lines[0].strip()}, not pypy"
+    try:
+        version = tuple(int(part) for part in lines[1].split())
+    except ValueError:
+        return None, f"{candidate} did not report its version"
+    if version != PYPY_TARGET:
+        wanted = "%d.%d" % PYPY_TARGET
+        return None, (
+            "%s implements CPython %d.%d, and the `pypy-diverges:` directives "
+            "were classified against %s" % (candidate, *version, wanted)
+        )
+    return lines[2].strip() or candidate, ""
+
+
 def _report(failures: list[Failure]) -> None:
     """The evidence for every failure, printed last and on stdout.
 
@@ -317,12 +400,17 @@ def main() -> int:
     sys.stdout.reconfigure(encoding="utf-8", errors="replace", line_buffering=True)
 
     runners = _runners(args.dynasm_only, args.cranelift_only, args.gc_poison)
+    pypy, pypy_off = _pypy()
     scripts, skipped = _scripts()
     if not scripts:
         print("no parity test scripts found", file=sys.stderr)
         return 1
 
     print(f"runners: {[name for name, _, _ in runners]}")
+    if pypy is None:
+        print(f"pypy cross-check: off — {pypy_off}")
+    else:
+        print(f"pypy cross-check: {pypy}")
     print(f"scripts: {len(scripts)}")
     for script in skipped:
         print(f"skipped ({sys.platform} not in its platforms): {script.name}")
@@ -341,6 +429,27 @@ def main() -> int:
             if not ok:
                 failures.append(Failure(name, backend, reason, err))
                 reasons.append(f"      {backend}: {reason}")
+        if pypy is not None:
+            declared = _pypy_divergence(script)
+            ok, reason, err = _run([pypy], script, pinned or None)
+            if declared is None:
+                row.append(f"pypy={'OK' if ok else 'FAIL'}")
+                if not ok:
+                    failures.append(Failure(name, "pypy", reason, err))
+                    reasons.append(f"      pypy: {reason}")
+            elif ok:
+                # The directive named a divergence that is no longer there, so
+                # what it now does is exempt this script from the lane for a
+                # reason that has stopped being true.
+                row.append("pypy=XPASS")
+                stale = (
+                    f"passed, but its header declares a divergence: {declared!r} "
+                    f"— drop the `{PYPY_DIVERGES_PREFIX}` line"
+                )
+                failures.append(Failure(name, "pypy", stale, ""))
+                reasons.append(f"      pypy: {stale}")
+            else:
+                row.append("pypy=xfail")
         print(" ".join(row))
         for line in reasons:
             print(line)

--- a/pyre/extra_tests/parity_tests/syntax_error_python314_offsets.py
+++ b/pyre/extra_tests/parity_tests/syntax_error_python314_offsets.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins 3.14's SyntaxError column offsets, which pypy3 reports differently
 # CPython-suite gap: multibyte SyntaxError offsets are not exhaustively asserted.
 # parity-tests reason: guard pyre's CPython 3.14 character-column semantics.
 

--- a/pyre/extra_tests/parity_tests/text_signatures_python314.py
+++ b/pyre/extra_tests/parity_tests/text_signatures_python314.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins staticmethod.__text_signature__ (3.14); pypy3's staticmethod has no such attribute
 # CPython-suite gap: exact builtin and descriptor text signatures are not asserted.
 # parity-tests reason: guard pyre's CPython 3.14 signature metadata surface.
 

--- a/pyre/extra_tests/parity_tests/type_name_attr_identity.py
+++ b/pyre/extra_tests/parity_tests/type_name_attr_identity.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins type.__name__ handing back the assigned str object; pypy3 hands back a copy
 # CPython-suite gap: mutable-type-name tests omit str-subclass identity under hot reads.
 # parity-tests reason: this guards pyre's JIT fold of the metatype name slot.
 

--- a/pyre/pyre-interpreter/src/async_operation.rs
+++ b/pyre/pyre-interpreter/src/async_operation.rs
@@ -96,6 +96,9 @@ fn handle(which: usize) -> PyObjectRef {
         pyre_object::gc_roots::shadow_stack_get(save_point),
         ASYNC_OP_SRC,
         "app_operation.py",
+        // `pypy/module/__builtin__/moduledef.py Module.applevel_name`, which
+        // `get_applevel_name` hands to every appleveldef of that module.
+        "builtins",
         &["aiter", "anext"],
     );
     let w_app_globals = pyre_object::gc_roots::shadow_stack_get(save_point);

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9976,12 +9976,32 @@ pub unsafe fn getfulltypename(w_obj: PyObjectRef) -> String {
     }
 }
 
+/// `typeobject.py W_TypeObject.is_heaptype` as the four readers of a type's
+/// owner need it: true when `__module__` lives in the type's own dict rather
+/// than in the prefix of its name.
+///
+/// pyre carries two heaptype bits, because either kind of type can be
+/// published with the other's public flags — a `TypeDef` marked through
+/// `mark_cpython_heap_type`, and an app-level class marked with CPython's
+/// static-type flags (`_contextvars.Context`, a static `PyContext_Type`
+/// there).  A projection moves the flags a program reads; it does not move
+/// where the type stores its owner, so either bit means the dict is the
+/// place to look and the name prefix is for a type that has no dict entry.
+///
+/// # Safety
+/// `w_type` must be a valid `W_TypeObject`.
+pub unsafe fn type_owner_is_in_dict(w_type: PyObjectRef) -> bool {
+    unsafe {
+        pyre_object::w_type_is_cpython_heaptype(w_type) || pyre_object::w_type_is_heaptype(w_type)
+    }
+}
+
 /// [`getfulltypename`] for an already-resolved type.
 ///
 /// # Safety
 /// `w_type` must be a valid `W_TypeObject`.
 pub unsafe fn getfulltypename_of_type(w_type: PyObjectRef) -> String {
-    if !pyre_object::w_type_is_cpython_heaptype(w_type) {
+    if !unsafe { type_owner_is_in_dict(w_type) } {
         return w_type_get_name(w_type).to_string();
     }
     let qualname = pyre_object::w_type_get_qualname(w_type).to_string();
@@ -10002,7 +10022,7 @@ pub unsafe fn getfulltypename_of_type(w_type: PyObjectRef) -> String {
 /// `w_type` must be a valid `W_TypeObject`.
 pub unsafe fn type_repr_qualified_name(w_type: PyObjectRef) -> String {
     let name = w_type_get_name(w_type).to_string();
-    if !pyre_object::w_type_is_cpython_heaptype(w_type) {
+    if !unsafe { type_owner_is_in_dict(w_type) } {
         return name;
     }
     let module = lookup_in_type_where(w_type, "__module__")
@@ -10073,7 +10093,7 @@ pub fn load_special_resolve(obj: PyObjectRef, name: &str) -> Result<PyObjectRef,
 /// # Safety
 /// `w_type` must be a valid `W_TypeObject`.
 pub unsafe fn type_fully_qualified_name(w_type: PyObjectRef) -> String {
-    if !pyre_object::w_type_is_cpython_heaptype(w_type) {
+    if !unsafe { type_owner_is_in_dict(w_type) } {
         return w_type_get_name(w_type).to_string();
     }
     let qualname = pyre_object::w_type_get_qualname(w_type).to_string();

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -3772,29 +3772,6 @@ pub fn appleveldef_install(
     appleveldef_install_seeded(ns, source, filename, names, &[]);
 }
 
-/// Whether app level can see the frames of an installed source.
-///
-/// `gateway.py ApplevelClass.hidden_applevel = True`.  The app-level half of a
-/// mixed module is not part of the program being run, so `pyframe.py hide`
-/// answers for its frames: the trace hook returns before reporting the call
-/// (`executioncontext.py _trace`), a failure raised behind one records no
-/// entry (`pytraceback.py record_application_traceback`), and
-/// `getnextframe_nohidden` steps over it, which is the walk `sys._getframe`
-/// counts along.  Every `appleveldefs` entry loads through that class —
-/// `mixedmodule.py getappfileloader` builds a `gateway.applevel` for the
-/// sibling app file — so `Hidden` is what an app file gets upstream.
-///
-/// `Visible` is `gateway.py applevel_temp.hidden_applevel = False`.  pyre also
-/// installs through this path a handful of sources upstream ships as ordinary
-/// `lib_pypy` modules reached by import; those frames are part of the program
-/// upstream, and one of them counts its own with `sys._getframe`, so hiding
-/// them would remove frames pypy shows.
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum AppleveldefFrames {
-    Hidden,
-    Visible,
-}
-
 /// [`appleveldef_install`] with `seed` bound into the app namespace before the
 /// source runs.
 ///
@@ -3805,24 +3782,11 @@ pub enum AppleveldefFrames {
 /// module initializer, before the module object exists, so a name the source
 /// needs from its own module is bound up front instead.
 pub fn appleveldef_install_seeded(
-    ns: impl AppleveldefNamespace,
-    source: &str,
-    filename: &str,
-    names: &[&str],
-    seed: &[(&str, PyObjectRef)],
-) {
-    appleveldef_install_with_frames(ns, source, filename, names, seed, AppleveldefFrames::Hidden);
-}
-
-/// [`appleveldef_install_seeded`] for a source whose frames are not the ones
-/// `gateway.applevel` hands out — see [`AppleveldefFrames`].
-pub fn appleveldef_install_with_frames(
     mut ns: impl AppleveldefNamespace,
     source: &str,
     filename: &str,
     names: &[&str],
     seed: &[(&str, PyObjectRef)],
-    frames: AppleveldefFrames,
 ) {
     let code = compile_source_with_filename(source, Mode::Exec, filename)
         .unwrap_or_else(|e| panic!("appleveldef `{filename}`: compile failed — {e}"));
@@ -3837,14 +3801,16 @@ pub fn appleveldef_install_with_frames(
         unsafe { pyre_object::w_dict_setitem_str(w_app_globals, name, value) };
     }
     let code_ptr = Box::into_raw(Box::new(code));
-    // `build_applevel_dict` passes `hidden_applevel=self.hidden_applevel` to
-    // `space.exec_`, which reaches the compiler as `CompileInfo`; every code
-    // object of the unit is then built with it (`assemble.py make_code`), so
-    // the flag set here reaches the nested functions this source defines.
-    let w_code = crate::pycode::w_code_new_with_hidden_applevel(
-        code_ptr as *const (),
-        frames == AppleveldefFrames::Hidden,
-    );
+    // `gateway.py ApplevelClass.hidden_applevel = True`, which
+    // `build_applevel_dict` passes to `space.exec_` and the compiler carries as
+    // `CompileInfo`; every code object of the unit is then built with it
+    // (`assemble.py make_code`), so the flag set here reaches the nested
+    // functions this source defines.
+    //
+    // Every source installed here is a native module's body — the module is
+    // built in, and what it holds is an extension module on CPython — so none
+    // of these frames are the running program's.
+    let w_code = crate::pycode::w_code_new_with_hidden_applevel(code_ptr as *const (), true);
     let mut frame = crate::pyframe::createframe_obj(w_code as *const (), w_app_globals, ctx, None)
         .unwrap_or_else(|e| panic!("appleveldef `{filename}`: createframe — {e:?}"));
     if let Err(e) = frame.run_with_jit() {

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -3749,7 +3749,9 @@ fn exec_code_module(
 /// each binding in `names` into the caller's module dict `ns`.
 ///
 /// `filename` is used as the source path for tracebacks / co_filename
-/// only.  Every function defined in `source` retains the intermediate
+/// only; `modname` is the name the namespace answers `__name__` with, and so
+/// the `__module__` of everything `source` defines.  Every function defined
+/// in `source` retains the intermediate
 /// namespace as its `__globals__`; once copied into the caller's module,
 /// those functions keep the namespace transitively reachable.
 #[doc(hidden)]
@@ -3767,9 +3769,10 @@ pub fn appleveldef_install(
     ns: impl AppleveldefNamespace,
     source: &str,
     filename: &str,
+    modname: &str,
     names: &[&str],
 ) {
-    appleveldef_install_seeded(ns, source, filename, names, &[]);
+    appleveldef_install_seeded(ns, source, filename, modname, names, &[]);
 }
 
 /// [`appleveldef_install`] with `seed` bound into the app namespace before the
@@ -3785,6 +3788,7 @@ pub fn appleveldef_install_seeded(
     mut ns: impl AppleveldefNamespace,
     source: &str,
     filename: &str,
+    modname: &str,
     names: &[&str],
     seed: &[(&str, PyObjectRef)],
 ) {
@@ -3797,6 +3801,17 @@ pub fn appleveldef_install_seeded(
     let w_app_globals = unsafe { (*ctx).fresh_module_globals() };
     let _root = pyre_object::gc_roots::push_roots();
     let w_app_globals = pyre_object::gc_roots::pin_root(w_app_globals);
+    // `gateway.py build_applevel_dict` binds the owning module's name into the
+    // namespace before the source runs, so a `def` or a `class` in it answers
+    // `__module__` with the module it belongs to rather than `None` for a
+    // function or `builtins` for a class.  `modname` is what
+    // `mixedmodule.py MixedModule.get_applevel_name` names: the module's own
+    // name, or `"<parent>.<child>"` for a submodule.  A source that must be
+    // seen under a different name -- the public spelling of an accelerator it
+    // backs -- rebinds `__name__` itself, and that assignment runs later.
+    unsafe {
+        pyre_object::w_dict_setitem_str(w_app_globals, "__name__", pyre_object::w_str_new(modname))
+    };
     for &(name, value) in seed {
         unsafe { pyre_object::w_dict_setitem_str(w_app_globals, name, value) };
     }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -3772,6 +3772,29 @@ pub fn appleveldef_install(
     appleveldef_install_seeded(ns, source, filename, names, &[]);
 }
 
+/// Whether app level can see the frames of an installed source.
+///
+/// `gateway.py ApplevelClass.hidden_applevel = True`.  The app-level half of a
+/// mixed module is not part of the program being run, so `pyframe.py hide`
+/// answers for its frames: the trace hook returns before reporting the call
+/// (`executioncontext.py _trace`), a failure raised behind one records no
+/// entry (`pytraceback.py record_application_traceback`), and
+/// `getnextframe_nohidden` steps over it, which is the walk `sys._getframe`
+/// counts along.  Every `appleveldefs` entry loads through that class —
+/// `mixedmodule.py getappfileloader` builds a `gateway.applevel` for the
+/// sibling app file — so `Hidden` is what an app file gets upstream.
+///
+/// `Visible` is `gateway.py applevel_temp.hidden_applevel = False`.  pyre also
+/// installs through this path a handful of sources upstream ships as ordinary
+/// `lib_pypy` modules reached by import; those frames are part of the program
+/// upstream, and one of them counts its own with `sys._getframe`, so hiding
+/// them would remove frames pypy shows.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum AppleveldefFrames {
+    Hidden,
+    Visible,
+}
+
 /// [`appleveldef_install`] with `seed` bound into the app namespace before the
 /// source runs.
 ///
@@ -3782,11 +3805,24 @@ pub fn appleveldef_install(
 /// module initializer, before the module object exists, so a name the source
 /// needs from its own module is bound up front instead.
 pub fn appleveldef_install_seeded(
+    ns: impl AppleveldefNamespace,
+    source: &str,
+    filename: &str,
+    names: &[&str],
+    seed: &[(&str, PyObjectRef)],
+) {
+    appleveldef_install_with_frames(ns, source, filename, names, seed, AppleveldefFrames::Hidden);
+}
+
+/// [`appleveldef_install_seeded`] for a source whose frames are not the ones
+/// `gateway.applevel` hands out — see [`AppleveldefFrames`].
+pub fn appleveldef_install_with_frames(
     mut ns: impl AppleveldefNamespace,
     source: &str,
     filename: &str,
     names: &[&str],
     seed: &[(&str, PyObjectRef)],
+    frames: AppleveldefFrames,
 ) {
     let code = compile_source_with_filename(source, Mode::Exec, filename)
         .unwrap_or_else(|e| panic!("appleveldef `{filename}`: compile failed — {e}"));
@@ -3801,7 +3837,14 @@ pub fn appleveldef_install_seeded(
         unsafe { pyre_object::w_dict_setitem_str(w_app_globals, name, value) };
     }
     let code_ptr = Box::into_raw(Box::new(code));
-    let w_code = crate::w_code_new(code_ptr as *const ());
+    // `build_applevel_dict` passes `hidden_applevel=self.hidden_applevel` to
+    // `space.exec_`, which reaches the compiler as `CompileInfo`; every code
+    // object of the unit is then built with it (`assemble.py make_code`), so
+    // the flag set here reaches the nested functions this source defines.
+    let w_code = crate::pycode::w_code_new_with_hidden_applevel(
+        code_ptr as *const (),
+        frames == AppleveldefFrames::Hidden,
+    );
     let mut frame = crate::pyframe::createframe_obj(w_code as *const (), w_app_globals, ctx, None)
         .unwrap_or_else(|e| panic!("appleveldef `{filename}`: createframe — {e:?}"));
     if let Err(e) = frame.run_with_jit() {

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -291,7 +291,6 @@ macro_rules! py_module {
         $(, int_constants: { $($int_key:literal => $int_value:expr),* $(,)? })?
         $(, exceptions: { $($exc_key:literal => $exc_base:expr),* $(,)? })?
         $(, appleveldefs: { $($appfile:literal => [ $($appname:literal),* $(,)? ]),* $(,)? })?
-        $(, lib_appleveldefs: { $($libfile:literal => [ $($libname:literal),* $(,)? ]),* $(,)? })?
         $(, inline_app: { $($inline_src:literal => [ $($inline_name:literal),* $(,)? ]),* $(,)? })?
         $(, inline_functions: {
             $(
@@ -349,21 +348,6 @@ macro_rules! py_module {
                     include_str!($appfile),
                     $appfile,
                     &[ $( $appname ),* ],
-                );
-            )*)?
-            // lib_appleveldefs: installed the same way, for a source PyPy
-            // ships as a `lib_pypy` module reached by import rather than as a
-            // mixed module's app-level half.  Those frames are part of the
-            // program upstream, so they stay visible — see
-            // `importing::AppleveldefFrames`.
-            $($(
-                $crate::importing::appleveldef_install_with_frames(
-                    ns,
-                    include_str!($libfile),
-                    $libfile,
-                    &[ $( $libname ),* ],
-                    &[],
-                    $crate::importing::AppleveldefFrames::Visible,
                 );
             )*)?
             // inline_app: PyPy `applevel(r'''…''')` (gateway.py) —

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -347,6 +347,7 @@ macro_rules! py_module {
                     ns,
                     include_str!($appfile),
                     $appfile,
+                    $name,
                     &[ $( $appname ),* ],
                 );
             )*)?
@@ -361,6 +362,7 @@ macro_rules! py_module {
                     ns,
                     $inline_src,
                     "<inline>",
+                    $name,
                     &[ $( $inline_name ),* ],
                 );
             )*)?

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -291,6 +291,7 @@ macro_rules! py_module {
         $(, int_constants: { $($int_key:literal => $int_value:expr),* $(,)? })?
         $(, exceptions: { $($exc_key:literal => $exc_base:expr),* $(,)? })?
         $(, appleveldefs: { $($appfile:literal => [ $($appname:literal),* $(,)? ]),* $(,)? })?
+        $(, lib_appleveldefs: { $($libfile:literal => [ $($libname:literal),* $(,)? ]),* $(,)? })?
         $(, inline_app: { $($inline_src:literal => [ $($inline_name:literal),* $(,)? ]),* $(,)? })?
         $(, inline_functions: {
             $(
@@ -348,6 +349,21 @@ macro_rules! py_module {
                     include_str!($appfile),
                     $appfile,
                     &[ $( $appname ),* ],
+                );
+            )*)?
+            // lib_appleveldefs: installed the same way, for a source PyPy
+            // ships as a `lib_pypy` module reached by import rather than as a
+            // mixed module's app-level half.  Those frames are part of the
+            // program upstream, so they stay visible — see
+            // `importing::AppleveldefFrames`.
+            $($(
+                $crate::importing::appleveldef_install_with_frames(
+                    ns,
+                    include_str!($libfile),
+                    $libfile,
+                    &[ $( $libname ),* ],
+                    &[],
+                    $crate::importing::AppleveldefFrames::Visible,
                 );
             )*)?
             // inline_app: PyPy `applevel(r'''…''')` (gateway.py) —

--- a/pyre/pyre-interpreter/src/module/__pypy__/mod.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/mod.rs
@@ -67,6 +67,29 @@ fn add_memory_pressure(args: &[pyre_object::PyObjectRef]) -> crate::PyResult {
     Ok(pyre_object::w_none())
 }
 
+/// `interp_magic.py hidden_applevel` — `func.getcode().hidden_applevel = True`,
+/// returning the function so it can be spelled as a decorator.
+///
+/// One function at a time, rather than a whole compilation unit: a module that
+/// is otherwise the program's own reaches for this on the single frame that is
+/// not, the way `lib_pypy/_contextvars.py` marks `Context.run`, which stands
+/// between a callable and whoever asked the context to run it.
+fn hidden_applevel(args: &[pyre_object::PyObjectRef]) -> crate::PyResult {
+    let w_func = args[0];
+    // `space.interp_w(Function, w_func)`, whose mismatch raises the same
+    // `'%s' object expected, got '%T' instead` as `descr_call_mismatch`.
+    if w_func.is_null() || !unsafe { crate::is_function(w_func) } {
+        return Err(crate::baseobjspace::descr_call_mismatch(
+            w_func,
+            "hidden_applevel",
+            crate::typedef::gettypeobject(&crate::FUNCTION_TYPE),
+        ));
+    }
+    let w_code = unsafe { crate::function_get_code(w_func) } as pyre_object::PyObjectRef;
+    unsafe { crate::pycode::w_code_set_hidden_applevel(w_code, true) };
+    Ok(w_func)
+}
+
 /// `interp_dict.py:43-45 / 79-81` `isinstance(w_obj, W_DictMultiObject)`:
 /// resolve the backing of an exact dict, module dict, or dict subclass,
 /// rejecting a read-only `mappingproxy` (a `W_Root`, not a `W_DictMultiObject`)
@@ -209,6 +232,7 @@ crate::py_module! {
         "move_to_end" / * = move_to_end,
         "objects_in_repr" / 0 = objects_in_repr,
         "write_unraisable" / 3 = write_unraisable,
+        "hidden_applevel" / 1 = hidden_applevel,
         "newmemoryview" / * = interp_buffer::newmemoryview,
     },
     extra_init: |ns| {

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -26,20 +26,23 @@ static ROOTED_SLOTS: std::sync::Mutex<Vec<Box<usize>>> = std::sync::Mutex::new(V
 
 /// Keep an object this module will go on naming by address.
 ///
-/// Everything stashed below is an ordinary mortal GC object reached through a
-/// module attribute, and old-gen is mark-sweep: not moving is not staying
-/// alive.  Rebinding the attribute, or dropping the module, lets the sweep
-/// reclaim the object while the stash still hands its address out — and the
-/// collector traces neither the stash nor anything that would keep the object
-/// on its account.  [`simple_weak_set_type`] would then name freed memory, and
-/// the identity comparison could match an address the allocator has since
-/// handed to something else.  Registering the address in a stable slot is what
-/// buys survival, the `_structseq.rs` `root_structseq_type` idiom.
+/// [`simple_weak_set_type`] hands out an address the caller dereferences, and
+/// old-gen is mark-sweep: not moving is not staying alive.  Rebinding the
+/// module attribute, or dropping the module, lets the sweep reclaim the type
+/// while the stash still names it — the collector traces neither the stash nor
+/// anything that would keep the object on its account.  Registering the address
+/// in a stable slot is what buys survival, the `_structseq.rs`
+/// `root_structseq_type` idiom.
 ///
-/// The stashes stay plain addresses rather than reads of these slots.  Types,
-/// functions and code objects are all born outside the nursery, so no walker
-/// rewrites a slot naming one and a read back through the root would return
-/// the same bits; only list and dict headers move.
+/// Used only where the object must genuinely outlive its last Python
+/// reference: the class itself, and the weak references in
+/// [`SIMPLE_WEAK_SET_CONTAINS`], which retain nothing of what they name.  The
+/// bodies those references identify are deliberately not rooted.
+///
+/// The stashes stay plain addresses rather than reads of these slots.  Types
+/// and weak references are born outside the nursery, so no walker rewrites a
+/// slot naming one and a read back through the root would return the same bits;
+/// only list and dict headers move.
 fn root_forever(obj: PyObjectRef) {
     let mut slot = Box::new(obj as usize);
     let root_slot = (&raw mut *slot) as *mut *mut u8;
@@ -82,8 +85,61 @@ fn simple_weak_set_type() -> PyObjectRef {
 /// `__globals__["TypeError"]` moves it off `0` and the comparison declines,
 /// which is the mutation this guards.  Rebinding `builtins.TypeError` itself is
 /// a process-wide change this does not pretend to cover.
-static SIMPLE_WEAK_SET_CONTAINS: std::sync::OnceLock<(usize, usize, usize, usize)> =
-    std::sync::OnceLock::new();
+///
+/// What is stored is not those four addresses but a weak reference to each,
+/// [`weak_lifeline`], read back through [`installed_contains_identity`].  A
+/// strong stash would answer the address question by making the object
+/// immortal: rebinding `__contains__` and dropping the last reference to the
+/// old function would still leave it, its code and the module dict its
+/// `__globals__` names alive for the life of the process.  Weakly, a dead
+/// referent reads as "the body is gone", which is the same answer the
+/// comparison wanted, and a live one cannot have had its address reused.
+///
+/// This buys hygiene rather than a behaviour, and the difference is worth
+/// stating: a `__contains__` that is replaced and dropped stays reachable here
+/// and on the reference build alike — measured, still alive after seven full
+/// collections — because a method-cache slot goes on naming it.  What the weak
+/// stash avoids is the one retention no eviction can undo, a root that is
+/// permanent by construction.
+static SIMPLE_WEAK_SET_CONTAINS: std::sync::OnceLock<[usize; 4]> = std::sync::OnceLock::new();
+
+/// A weak reference to `obj`, kept by a root of its own.
+///
+/// Rooting the reference does not root its referent — that is the whole point —
+/// so the address stays readable while the object lives without the stash being
+/// the reason it lives.
+fn weak_lifeline(obj: PyObjectRef) -> Option<usize> {
+    let lifeline = crate::module::_weakref::interp__weakref::descr__new__weakref(
+        crate::module::_weakref::interp__weakref::weakref_type(),
+        &[obj],
+    )
+    .ok()?;
+    root_forever(lifeline);
+    Some(lifeline as usize)
+}
+
+/// The identity [`SIMPLE_WEAK_SET_CONTAINS`] recorded, as addresses again.
+///
+/// `None` once any referent has died, because an object the class no longer
+/// holds cannot be the body a membership test would reach.  A `0` entry is a
+/// word that was absent at install time — the `TypeError` shadow — and stays
+/// absent here rather than becoming a dead reference.
+fn installed_contains_identity() -> Option<(usize, usize, usize, usize)> {
+    let lifelines = SIMPLE_WEAK_SET_CONTAINS.get()?;
+    let mut words = [0usize; 4];
+    for (word, &lifeline) in words.iter_mut().zip(lifelines.iter()) {
+        if lifeline == 0 {
+            continue;
+        }
+        let referent =
+            crate::module::_weakref::interp__weakref::dereference(lifeline as PyObjectRef);
+        if referent.is_null() {
+            return None;
+        }
+        *word = referent as usize;
+    }
+    Some((words[0], words[1], words[2], words[3]))
+}
 
 /// The installed `__contains__`, the code object it currently holds and its two
 /// globals, as the tuple [`SIMPLE_WEAK_SET_CONTAINS`] stores.  Anything that is
@@ -170,7 +226,7 @@ fn simple_weak_set_contains(
     // rebinding either global its body resolves — the `ref` it calls, the
     // `TypeError` it catches — each leaves every instance an exact
     // `SimpleWeakSet` while changing what a membership test answers.
-    let Some(&installed) = SIMPLE_WEAK_SET_CONTAINS.get() else {
+    let Some(installed) = installed_contains_identity() else {
         return Ok(None);
     };
     if simple_weak_set_contains_identity() != installed {
@@ -889,17 +945,34 @@ crate::py_module! {
         let _ = SIMPLE_WEAK_SET_TYPE.set(simple_weak_set as usize);
         let installed = simple_weak_set_contains_identity();
         if installed != (0, 0, 0, 0) {
-            // Each word is an address the comparison keeps naming, so each has
-            // to outlive the stash for a match to mean the body is unchanged
-            // rather than that the allocator reused the address.  The
+            // Each word is an address the comparison keeps naming, so a match
+            // has to mean the object is still the one installed rather than
+            // that the allocator reused its address.  A weak reference settles
+            // that without also deciding how long the object lives.  The
             // `TypeError` word is `0` unless a module entry shadows the
-            // builtin, and zero names nothing.
-            for word in [installed.0, installed.1, installed.2, installed.3] {
-                if word != 0 {
-                    root_forever(word as PyObjectRef);
-                }
+            // builtin, and zero names nothing to reference.
+            let mut lifelines = [0usize; 4];
+            let installed_words = [installed.0, installed.1, installed.2, installed.3];
+            let recorded = lifelines
+                .iter_mut()
+                .zip(installed_words)
+                .all(|(lifeline, word)| {
+                    if word == 0 {
+                        return true;
+                    }
+                    match weak_lifeline(word as PyObjectRef) {
+                        Some(recorded) => {
+                            *lifeline = recorded;
+                            true
+                        }
+                        None => false,
+                    }
+                });
+            // A referent that refuses a weak reference leaves nothing to
+            // compare against later, so the fast path simply never installs.
+            if recorded {
+                let _ = SIMPLE_WEAK_SET_CONTAINS.set(lifelines);
             }
-            let _ = SIMPLE_WEAK_SET_CONTAINS.set(installed);
         }
     },
 }

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -995,6 +995,7 @@ crate::py_module! {
             ns,
             include_str!("app_abc.py"),
             "app_abc.py",
+            "_abc",
             &["SimpleWeakSet"],
             &[],
         );

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -83,8 +83,9 @@ fn simple_weak_set_type() -> PyObjectRef {
 /// key, so what is stashed for it is the module entry that would *shadow*
 /// builtins — `0` while there is none.  A caller who assigns
 /// `__globals__["TypeError"]` moves it off `0` and the comparison declines,
-/// which is the mutation this guards.  Rebinding `builtins.TypeError` itself is
-/// a process-wide change this does not pretend to cover.
+/// which is the mutation this guards.  The builtins binding the name falls
+/// through to is checked where it is consulted, on the handler's own arm in
+/// [`simple_weak_set_contains`].
 ///
 /// What is stored is not those four addresses but a weak reference to each,
 /// [`weak_lifeline`], read back through [`installed_contains_identity`].  A
@@ -139,6 +140,52 @@ fn installed_contains_identity() -> Option<(usize, usize, usize, usize)> {
         *word = referent as usize;
     }
     Some((words[0], words[1], words[2], words[3]))
+}
+
+/// The weak reference naming the class `TypeError` resolved to at module init,
+/// as [`weak_lifeline`] records it.
+static BUILTIN_TYPE_ERROR: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+/// What `TypeError` names in the builtins the body falls through to.
+///
+/// `None` while there is no reachable builtins module or it holds no such key.
+/// The lookup is the fallback leg of `LOAD_GLOBAL` itself — `space.builtin`
+/// under the default `honor__builtins__=False`, not the `__builtins__` entry of
+/// the module dict.
+fn builtin_type_error() -> Option<PyObjectRef> {
+    let ec = crate::call::getexecutioncontext();
+    if ec.is_null() {
+        return None;
+    }
+    let w_builtin = unsafe { (*ec).get_builtin() };
+    if w_builtin.is_null() || !unsafe { pyre_object::is_module(w_builtin) } {
+        return None;
+    }
+    let w_dict = unsafe { pyre_object::w_module_get_w_dict(w_builtin) };
+    if w_dict.is_null() {
+        return None;
+    }
+    unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(w_dict, "TypeError") }
+}
+
+fn record_builtin_type_error() {
+    if let Some(installed) = builtin_type_error()
+        && let Some(lifeline) = weak_lifeline(installed)
+    {
+        let _ = BUILTIN_TYPE_ERROR.set(lifeline);
+    }
+}
+
+/// Whether `TypeError` still names the class it named when this module loaded.
+///
+/// `false` also when nothing was recorded, which costs a decline rather than an
+/// answer taken on a binding never established.
+fn type_error_names_the_installed_class() -> bool {
+    let Some(&lifeline) = BUILTIN_TYPE_ERROR.get() else {
+        return false;
+    };
+    let installed = crate::module::_weakref::interp__weakref::dereference(lifeline as PyObjectRef);
+    !installed.is_null() && builtin_type_error().is_some_and(|now| std::ptr::eq(now, installed))
 }
 
 /// The installed `__contains__`, the code object it currently holds and its two
@@ -258,6 +305,18 @@ fn simple_weak_set_contains(
     ) {
         Ok(probe) => probe,
         Err(err) if matches!(err.kind, crate::error::PyErrorKind::TypeError) => {
+            // `except TypeError` resolves the name where the handler runs, so
+            // the binding matters on this arm and nowhere else.  A shadowing
+            // module entry already moved an identity word and declined above,
+            // which leaves the builtins entry the name falls through to:
+            // rebound, the handler `app_abc.py` spells need not match what the
+            // constructor raised, and answering `False` here would catch what
+            // the body would have let out.  Hand the test back instead of
+            // deciding it.  `ref` on an item that refuses one raises without
+            // running anything observable, so re-running it costs the raise.
+            if !type_error_names_the_installed_class() {
+                return Ok(None);
+            }
             return Ok(Some(false));
         }
         Err(err) => return Err(err),
@@ -973,6 +1032,7 @@ crate::py_module! {
             if recorded {
                 let _ = SIMPLE_WEAK_SET_CONTAINS.set(lifelines);
             }
+            record_builtin_type_error();
         }
     },
 }

--- a/pyre/pyre-interpreter/src/module/_blake2/_blake2_app.py
+++ b/pyre/pyre-interpreter/src/module/_blake2/_blake2_app.py
@@ -189,9 +189,12 @@ def _make_blake_type(class_name, _salt_size, _person_size, _key_size,
                 type(self).__module__, type(self).__name__, id(self)
             )
 
+    # The class statement above names both types `_Blake`; the factory's two
+    # results have to answer with the name each was asked for.  `__module__`
+    # needs no such repair -- the class body already read it off this file's
+    # own `__name__`.
     type.__setattr__(_Blake, "__name__", class_name)
     type.__setattr__(_Blake, "__qualname__", class_name)
-    type.__setattr__(_Blake, "__module__", "_blake2")
     return _Blake
 
 

--- a/pyre/pyre-interpreter/src/module/_blake2/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_blake2/mod.rs
@@ -16,7 +16,7 @@ crate::py_module! {
         "BLAKE2S_MAX_KEY_SIZE" => 32,
         "BLAKE2S_MAX_DIGEST_SIZE" => 32,
     },
-    appleveldefs: {
+    lib_appleveldefs: {
         "_blake2_app.py" => ["blake2b", "blake2s"],
     },
 }

--- a/pyre/pyre-interpreter/src/module/_blake2/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_blake2/mod.rs
@@ -16,7 +16,7 @@ crate::py_module! {
         "BLAKE2S_MAX_KEY_SIZE" => 32,
         "BLAKE2S_MAX_DIGEST_SIZE" => 32,
     },
-    lib_appleveldefs: {
+    appleveldefs: {
         "_blake2_app.py" => ["blake2b", "blake2s"],
     },
 }

--- a/pyre/pyre-interpreter/src/module/_contextvars/_contextvars_app.py
+++ b/pyre/pyre-interpreter/src/module/_contextvars/_contextvars_app.py
@@ -92,6 +92,3 @@ class Context(metaclass=Unsubclassable):
         if not isinstance(other, Context):
             return NotImplemented
         return dict(self.items()) == dict(other.items())
-
-
-Context.__module__ = '_contextvars'

--- a/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
@@ -489,16 +489,12 @@ crate::py_module! {
     extra_init: |ns| {
         let context_var = crate::module_ns_get(ns, "ContextVar")
             .expect("_contextvars.ContextVar must be installed first");
-        // `lib_pypy/_contextvars.py` is an ordinary module upstream, so its
-        // frames are the program's.  Only `Context.run` is hidden there, by
-        // its own `@hidden_applevel` decorator, which the source below keeps.
-        crate::importing::appleveldef_install_with_frames(
+        crate::importing::appleveldef_install_seeded(
             ns,
             include_str!("_contextvars_app.py"),
             "_contextvars_app.py",
             &["Context"],
             &[("ContextVar", context_var)],
-            crate::importing::AppleveldefFrames::Visible,
         );
         let context = crate::module_ns_get(ns, "Context")
             .expect("_contextvars.Context must be installed by appleveldefs");

--- a/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
@@ -493,6 +493,7 @@ crate::py_module! {
             ns,
             include_str!("_contextvars_app.py"),
             "_contextvars_app.py",
+            "_contextvars",
             &["Context"],
             &[("ContextVar", context_var)],
         );

--- a/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
@@ -489,12 +489,16 @@ crate::py_module! {
     extra_init: |ns| {
         let context_var = crate::module_ns_get(ns, "ContextVar")
             .expect("_contextvars.ContextVar must be installed first");
-        crate::importing::appleveldef_install_seeded(
+        // `lib_pypy/_contextvars.py` is an ordinary module upstream, so its
+        // frames are the program's.  Only `Context.run` is hidden there, by
+        // its own `@hidden_applevel` decorator, which the source below keeps.
+        crate::importing::appleveldef_install_with_frames(
             ns,
             include_str!("_contextvars_app.py"),
             "_contextvars_app.py",
             &["Context"],
             &[("ContextVar", context_var)],
+            crate::importing::AppleveldefFrames::Visible,
         );
         let context = crate::module_ns_get(ns, "Context")
             .expect("_contextvars.Context must be installed by appleveldefs");

--- a/pyre/pyre-interpreter/src/module/_immutables_map/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_immutables_map/mod.rs
@@ -6,7 +6,7 @@
 
 crate::py_module! {
     "_immutables_map",
-    lib_appleveldefs: {
+    appleveldefs: {
         "../../../../../lib_pypy/_immutables_map.py" => ["Map"],
     },
 }

--- a/pyre/pyre-interpreter/src/module/_immutables_map/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_immutables_map/mod.rs
@@ -6,7 +6,7 @@
 
 crate::py_module! {
     "_immutables_map",
-    appleveldefs: {
+    lib_appleveldefs: {
         "../../../../../lib_pypy/_immutables_map.py" => ["Map"],
     },
 }

--- a/pyre/pyre-interpreter/src/module/_io/_io_app.py
+++ b/pyre/pyre-interpreter/src/module/_io/_io_app.py
@@ -117,6 +117,3 @@ class IncrementalNewlineDecoder:
             ("\r", "\r\n"),
             ("\r", "\n", "\r\n"),
         )[self.seennl]
-
-
-IncrementalNewlineDecoder.__module__ = "_io"

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -1498,6 +1498,7 @@ crate::py_module! {
             ns,
             include_str!("_io_app.py"),
             "_io_app.py",
+            "_io",
             &["IncrementalNewlineDecoder"],
             &[("_TextIOBase", text_base)],
         );

--- a/pyre/pyre-interpreter/src/module/_multibytecodec/app_multibytecodec.py
+++ b/pyre/pyre-interpreter/src/module/_multibytecodec/app_multibytecodec.py
@@ -1,10 +1,5 @@
 """PyPy-compatible app-level surface over the cjkcodecs engine."""
 
-# These are the module's own classes, so `__module__` should say so; without
-# it the exec namespace leaves them looking like builtins.  Same reason
-# `app_operator.py` sets it.
-__name__ = "_multibytecodec"
-
 
 # `PyArg_ParseTupleAndKeywords` leaves an argument the caller omitted at the C
 # NULL its variable was initialized to, and `internal_error_callback(NULL)`

--- a/pyre/pyre-interpreter/src/module/_multibytecodec/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multibytecodec/mod.rs
@@ -478,6 +478,7 @@ crate::py_module! {
             ns,
             include_str!("app_multibytecodec.py"),
             "app_multibytecodec.py",
+            "_multibytecodec",
             &[
                 "MultibyteCodec",
                 "MultibyteIncrementalDecoder",

--- a/pyre/pyre-interpreter/src/module/_typing/_typing_app.py
+++ b/pyre/pyre-interpreter/src/module/_typing/_typing_app.py
@@ -19,10 +19,13 @@ from types import GenericAlias, UnionType as Union
 
 
 def _caller_module():
-    # Equivalent to sys._getframe(2).f_globals['__name__']: frame 0 is this
-    # helper, frame 1 the constructor, frame 2 the user that called it.
+    # `typevarobject.c caller()` reads `__name__` out of the globals of the
+    # frame that is running, and the constructor calling it is native, so the
+    # frame it finds is the user's.  The frames of this module are not the
+    # program's either -- `sys._getframe` counts along a walk that steps over
+    # them -- so depth 0 names that same frame however deep the helper sits.
     try:
-        return sys._getframe(2).f_globals.get('__name__')
+        return sys._getframe(0).f_globals.get('__name__')
     except (AttributeError, ValueError):
         return None
 

--- a/pyre/pyre-interpreter/src/module/_typing/_typing_app.py
+++ b/pyre/pyre-interpreter/src/module/_typing/_typing_app.py
@@ -8,10 +8,10 @@ module-level helpers (_typevar_subst, _paramspec_subst, _generic_class_getitem,
 ...), exactly as the C objects call back into the typing module.
 """
 
-# CPython exposes these runtime classes as members of `typing`, and their
-# repr/pickle/substitution semantics depend on that public owner. Mixed-module
-# applevel code executes in a private globals dict, so declare it explicitly
-# instead of inheriting that dict's default `builtins` module name.
+# `_typing.c` names each of these types `typing.X`, because `typing` is the
+# public owner their repr, their pickle and their substitution semantics all
+# report.  This file backs `_typing`, so the name the install binds is that
+# one; rebind it to the owner the classes below must claim.
 __name__ = "typing"
 
 import sys

--- a/pyre/pyre-interpreter/src/module/_typing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_typing/mod.rs
@@ -7,7 +7,7 @@
 
 crate::py_module! {
     "_typing",
-    lib_appleveldefs: {
+    appleveldefs: {
         "_typing_app.py" => [
             "TypeVar", "ParamSpec", "TypeVarTuple",
             "ParamSpecArgs", "ParamSpecKwargs", "TypeAliasType",

--- a/pyre/pyre-interpreter/src/module/_typing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_typing/mod.rs
@@ -7,7 +7,7 @@
 
 crate::py_module! {
     "_typing",
-    appleveldefs: {
+    lib_appleveldefs: {
         "_typing_app.py" => [
             "TypeVar", "ParamSpec", "TypeVarTuple",
             "ParamSpecArgs", "ParamSpecKwargs", "TypeAliasType",

--- a/pyre/pyre-interpreter/src/module/operator/app_operator.py
+++ b/pyre/pyre-interpreter/src/module/operator/app_operator.py
@@ -5,6 +5,9 @@
 # instead exposes countOf as a non-binding interp-level builtin
 # (space.sequence_count), matching _operator.c's C countOf.
 
+# `_operator.c` names the three factory types `operator.X`: they are reached
+# through the pure-Python `operator`, which re-exports this module wholesale.
+# The install binds `_operator` here, so rebind it to that public owner.
 __name__ = 'operator'
 
 

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -391,11 +391,13 @@ pub struct PyCode {
     /// with the rest of this code object's managed children.
     pub w_weakreflifeline: PyObjectRef,
     /// PyPy: `PyCode.hidden_applevel` (`pycode.py, 147`). Set by
-    /// `pycompiler.compile(hidden_applevel=True)` for PyPy gateway/
-    /// app_main bridge code.  Pyre has no such call site yet, so this
-    /// is always `false` on currently constructed instances; the
-    /// field exists so that `frame.hide()` can read the canonical
-    /// `pyframe.py return self.pycode.hidden_applevel`.
+    /// `pycompiler.compile(hidden_applevel=True)` for the app-level half of a
+    /// mixed module (`gateway.py ApplevelClass`), and by
+    /// `interp_magic.py hidden_applevel(func)` for one function at a time.
+    /// `pyframe.py hide` reads it, which is what keeps such a frame out of the
+    /// trace hook (`executioncontext.py _trace`), out of a recorded traceback
+    /// (`pytraceback.py record_application_traceback`) and out of the
+    /// `getnextframe_nohidden` walk `sys._getframe` counts along.
     pub hidden_applevel: bool,
     /// pycode.py `_compute_flatcall`. Cached arity descriptor:
     /// - 0-4: impossible (builtins only)
@@ -1033,22 +1035,28 @@ pub fn box_code_constant(code: &crate::CodeObject) -> PyObjectRef {
 ///
 /// # Safety
 /// `code` must point to a `CodeObject` that is never freed and never moved.
-unsafe fn box_code_constant_in_place(code: *const crate::CodeObject) -> PyObjectRef {
-    w_code_new(code as *const ())
+unsafe fn box_code_constant_in_place(
+    code: *const crate::CodeObject,
+    hidden_applevel: bool,
+) -> PyObjectRef {
+    w_code_new_with_hidden_applevel(code as *const (), hidden_applevel)
 }
 
-/// Wrap a nested compiler constant and inherit the enclosing `PyCode`'s raw
-/// filename when it belongs to the set selected by
-/// `importing.py update_code_filenames`' `oldname` guard.
+/// Wrap a nested compiler constant and inherit the two things the enclosing
+/// `PyCode` holds for a whole compilation unit rather than for one object: the
+/// raw filename, when it belongs to the set selected by
+/// `importing.py update_code_filenames`' `oldname` guard, and
+/// `hidden_applevel`, which `assemble.py make_code` reads off `compile_info`
+/// for every code object one compilation produces.
 ///
 /// # Safety
 /// `code` must satisfy [`box_code_constant_in_place`], and `parent` must be
 /// the `PyCode` whose constants table holds it.
-unsafe fn box_code_constant_inheriting_filename(
+unsafe fn box_code_constant_inheriting_unit(
     code: *const crate::CodeObject,
     parent: &PyCode,
 ) -> PyObjectRef {
-    let obj = unsafe { box_code_constant_in_place(code) };
+    let obj = unsafe { box_code_constant_in_place(code, parent.hidden_applevel) };
     if parent.filename_inherits_to_nested
         && unsafe { &*code }.source_path
             == unsafe { &*(parent.code_ptr as *const crate::CodeObject) }.source_path
@@ -2470,7 +2478,7 @@ pub unsafe fn w_code_const(w_code_obj: PyObjectRef, idx: usize) -> PyObjectRef {
 
     let mut realized = match &constants[idx] {
         crate::bytecode::ConstantData::Code { code } => unsafe {
-            box_code_constant_inheriting_filename(&**code as *const crate::CodeObject, w_code)
+            box_code_constant_inheriting_unit(&**code as *const crate::CodeObject, w_code)
         },
         constant => crate::pyframe::pyobject_from_constant(constant),
     };

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -59,6 +59,11 @@ fn handle(which: usize) -> PyObjectRef {
         pyre_object::gc_roots::shadow_stack_get(save_point),
         include_str!("reduce_protocol_app.py"),
         "reduce_protocol_app.py",
+        // `objectobject.py` builds these with a bare `applevel(...)`, so they
+        // take the `ApplevelClass.__init__` default rather than a module's
+        // name.  Nothing binds them into a module, so this reaches app level
+        // only as their `__globals__['__name__']`.
+        "__builtin__",
         &["reduce_1", "reduce_2", "get_slotvalues"],
     );
     let w_app_globals = pyre_object::gc_roots::shadow_stack_get(save_point);

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -12100,11 +12100,13 @@ fn init_type_type(ns: PyObjectRef) {
             // `typeobject.py get_module`:
             //     if self.is_heaptype():
             //         return self.getdictvalue(space, '__module__')
-            // Only a heaptype reads `__module__` from its dict; a builtin
-            // type derives it from the qualified name.  `lookup_in_type`
-            // filters out null entries but preserves `w_none()`, matching
-            // PyPy's "value present even if it's None" semantic.
-            if unsafe { pyre_object::w_type_is_cpython_heaptype(cls) }
+            // A class reads `__module__` from its dict; a builtin type derives
+            // it from the qualified name.  `type_owner_is_in_dict` is that
+            // question, asked the same way by the three readers that render a
+            // name out of the answer.  `lookup_in_type` filters out null
+            // entries but preserves `w_none()`, matching PyPy's "value present
+            // even if it's None" semantic.
+            if unsafe { crate::baseobjspace::type_owner_is_in_dict(cls) }
                 && let Some(v) = crate::type_dict_lookup(cls, "__module__")
                 && !v.is_null()
             {


### PR DESCRIPTION
Three groups, in commit order.

### `_abc`'s cache membership (3 commits)

`SimpleWeakSet.__contains__`'s identity shortcut rooted the installed method; it now
holds it weakly, so replacing the collection, its `data`, the method's `__code__`, or
the method itself is observed rather than read past. The `except TypeError` arm resolves
the name the way the app-level body does — module dict first, then builtins — so
shadowing either binding stops the handler catching the weakref failure, as it does on
the reference build.

Parity: `abc_weak_cache_membership.py` gains the two shadowing arms;
`abc_check_frames_are_observable.py` pins that the declined path's app-level
`__contains__` is still not a frame.

### An installed app source hides its frames and reports its own name (6 commits)

`appleveldef_install` compiled through the `hidden_applevel=False` shorthand, so every
function a mixed module's app-level half defines reported a frame — a `call` event for a
tracer, a traceback entry behind a failure, a name for `getnextframe_nohidden`. Upstream
loads those files through `gateway.applevel`, whose `ApplevelClass.hidden_applevel` is
`True`. `box_code_constant_in_place` dropped the flag on the way down to a nested code
constant, so that is inherited too.

The same installer never bound `__name__`, so a `def` in such a source reported
`__module__` as `None` and a `class` reported `builtins` — the class body's `LOAD_NAME`
falls back to the builtins module, a function's `__globals__.get` does not.
`build_applevel_dict` binds the owning module's name before the source runs; both
installers now take a `modname` and do the same. This moves `atexit`'s five entry points,
`_functools.cmp_to_key`, `_symtable.symtable`, `_template._build_*`, `_abc.SimpleWeakSet`,
`_immutables_map.Map` and `__pypy__.identity_dict` onto their own module's name, and drops
the four assignments that stood in for it. `app_operator.py` and `_typing_app.py` keep
theirs, which name a different module than the one installing them.

`_typing_app.py`'s `_caller_module` counted its own frames with `sys._getframe(2)`; with
them hidden it reads depth 0, which `typevarobject.c caller()` also reads.

The parity corpus now runs `pypy3` as a third opinion when one is on PATH. 118 of 137
scripts pass there unchanged; the other 19 name their divergence in a
`# pyre-check: pypy-diverges:` header, and the runner enforces it both ways — an unmarked
script must pass, a marked one must fail, and a marked one that passes is reported as
`XPASS`. A host without pypy3 still runs everything and says on its own line that the lane
is off.

### A type's owner on either heaptype axis (1 commit)

pyre carries two heaptype bits and the four readers that render a type's owner each gated
on the CPython one alone. `_contextvars.Context` is an app-level class published with
`PyContext_Type`'s static-type flags, so all four took the name-prefix branch on the bare
name `Context`: `__module__` was `builtins`, `repr(Context)` was `<class 'Context'>`, and
`pickle.dumps(Context)` raised. `type_owner_is_in_dict` asks the question once. `Context`
is the only type in the tree on both axes' seam — a walk of 906 reachable types reports one
changed `__module__`.

### Gates

`check.py` dynasm 457/457, cranelift 457/457, wasm 449/449, 3/3 backend runs; parity corpus
across cpython 3.14, both backends and the pypy lane; `extra_tests --gated-only` 97/97 ×3;
`cargo test -p pyre-interpreter --features dynasm` 411 passed; `cargo fmt --all --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for ABC cache checks, weak-reference errors, and exception handling.
  - Corrected module ownership reported by built-in and accelerated types, including representations and pickle behavior.
  - Prevented internal helper frames from appearing in tracing, traceback, and frame inspection.
  - Improved module metadata for typing, context variables, hashing, I/O, and other built-in helpers.

- **Tests**
  - Expanded CPython compatibility coverage for tracing, module metadata, recursion, numeric operations, and Python 3.14 behavior.
  - Added optional PyPy cross-checking with clearer reporting of expected differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->