### PR TITLE
llbc: reduce the layout sidecar through a streamed scan and a widening decode window

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -147,14 +147,22 @@ jobs:
       # artefact it will name exists. The narrow digest the stamp records is a
       # freshness verdict, not a key, and is not available here.
       #
-      # Take the `source=` line alone. `--fingerprint` prints three fields, and
-      # `$GITHUB_OUTPUT` parses one `name=value` per line, so passing the whole
-      # block through would file `closure=` and `external=` as outputs of their
-      # own and leave the key holding a stray `source=` prefix.
+      # Take each crate's `source[<crate>]=` line alone. `--fingerprint` prints
+      # three fields per crate, and `$GITHUB_OUTPUT` parses one `name=value`
+      # per line, so passing the whole block through would file `closure=` and
+      # `external=` as outputs of their own and leave the key holding a stray
+      # `source=` prefix. One `--per-crate` process for all four, not one
+      # process per crate: the cargo metadata and include walks are shared, and
+      # four processes cost 42 s on the windows runner.
       run: |
+        # Outside the checkout: the redirect creates the file before the walk
+        # that would otherwise see it as an untracked input.
+        fingerprints="$RUNNER_TEMP/llbc-fingerprints.txt"
+        scripts/extract-llbc.py --fingerprint --per-crate \
+          majit-rlib pyre-object pyre-interpreter pyre-jit > "$fingerprints"
         for crate in majit-rlib pyre-object pyre-interpreter pyre-jit; do
-          value="$(scripts/extract-llbc.py --fingerprint "$crate" | sed -n 's/^source=//p')"
-          test -n "$value" || { echo "no source= for $crate" >&2; exit 1; }
+          value="$(sed -n "s/^source\[$crate\]=//p" "$fingerprints")"
+          test -n "$value" || { echo "no source[$crate]= for $crate" >&2; exit 1; }
           echo "${crate//-/_}=${value}" >> "$GITHUB_OUTPUT"
         done
     # Per-crate caches (per-OS/arch because cfg(target_os)/cfg(target_arch)

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -338,7 +338,7 @@ def include_closure(root: Path, files: set[Path]) -> set[Path]:
         source = root / rel_source
         if not source.is_file():
             continue
-        text = source.read_text(encoding="utf-8", errors="replace")
+        text = read_input_bytes(root, rel_source).decode("utf-8", errors="replace")
         for call in _INCLUDE_CALL.finditer(text):
             line = text.count("\n", 0, call.start()) + 1
             where = f"{rel_source.as_posix()}:{line}"
@@ -755,6 +755,31 @@ def load_readfiles(eng: Engine, crate: str) -> set[Path] | None:
     return result
 
 
+# File contents read while hashing and while scanning for `include*!`
+# arguments, keyed by repo-relative path and validated against the file's
+# size and mtime on every hit, so a caller that rewrites an input between two
+# walks (the selftest does, per case) reads the new bytes without having to
+# know about this memo. `forget_collected_inputs` drops it with the input
+# walks it serves. One `--fingerprint --per-crate` over the four pyre crates
+# hashes the interpreter's closure three times over (the `source=` fallback,
+# `closure=`, and the include scan) and the jit's on top, which on a windows
+# runner is the cost of the step — every read there goes through the
+# real-time scanner, where a stat does not.
+_file_bytes_cache: dict[Path, tuple[int, int, bytes]] = {}
+
+
+def read_input_bytes(root: Path, path: Path) -> bytes:
+    """`(root / path).read_bytes()`, memoised while the file's stat holds."""
+    full_path = root / path
+    stat = full_path.stat()
+    hit = _file_bytes_cache.get(path)
+    if hit is not None and hit[0] == stat.st_size and hit[1] == stat.st_mtime_ns:
+        return hit[2]
+    data = full_path.read_bytes()
+    _file_bytes_cache[path] = (stat.st_size, stat.st_mtime_ns, data)
+    return data
+
+
 def forget_collected_inputs() -> None:
     """Drop the memoised input sets, because the tree they describe has moved.
 
@@ -767,6 +792,7 @@ def forget_collected_inputs() -> None:
     input set.
     """
     _inputs_cache.clear()
+    _file_bytes_cache.clear()
 
 
 def _collect_inputs(
@@ -1202,7 +1228,7 @@ def _repo_fingerprint(
         digest.update(b"\0")
         full_path = eng.root / path
         if full_path.is_file():
-            digest.update(full_path.read_bytes())
+            digest.update(read_input_bytes(eng.root, path))
         elif full_path.exists():
             # A directory in the input list is never a source file. Hashing it
             # below would fold it to one constant token that no edit inside it

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1791,6 +1791,36 @@ def crate_layout_targets(eng: Engine, spec: CrateSpec) -> list[str]:
     return [t for t in extra if t != host]
 
 
+def scan_for_keys(
+    path: Path, keys: list[bytes], chunk_size: int = 1 << 22
+) -> dict[bytes, int]:
+    """Byte offset of the first occurrence of each key, in one streamed pass."""
+    found: dict[bytes, int] = {}
+    keep = max(len(key) for key in keys) - 1
+    buffer = b""
+    base = 0
+    with path.open("rb") as artefact:
+        while len(found) < len(keys):
+            piece = artefact.read(chunk_size)
+            if not piece:
+                break
+            buffer += piece
+            for key in keys:
+                if key not in found:
+                    index = buffer.find(key)
+                    if index >= 0:
+                        found[key] = base + index
+            base += len(buffer) - keep
+            buffer = buffer[-keep:]
+    return found
+
+
+# First decode window of `write_layout_sidecar`, in bytes; it widens fourfold
+# until the value closes. Wide enough for every scalar field in one read and
+# for the smaller crates' `type_decls`, small enough that a miss costs little.
+LAYOUT_DECODE_WINDOW = 1 << 22
+
+
 def write_layout_sidecar(source: Path, dest: Path) -> None:
     """Reduce a full `.ullbc` to its type declarations.
 
@@ -1801,33 +1831,55 @@ def write_layout_sidecar(source: Path, dest: Path) -> None:
     `.ullbc` — the reader needs no special case, and the consumer merges
     it ahead of the host artefacts so its layouts win.
 
-    Only the fields kept are decoded, not the whole file: bodies dominate
-    the input (the interpreter's are ~94% of it), and parsing them costs an
-    order of magnitude more memory than the text itself.
+    Only the fields kept are decoded, and only a window of the file around
+    each is ever in memory: the artefact is three quarters of a GB of
+    one-line JSON, and `read_text` on it peaked at 7 GB of RSS (measured on
+    the interpreter's), the entire memory of a 7 GB macos runner. The keys
+    are located by one streamed byte scan; each value is then decoded from
+    a window that starts at the value and widens until the value closes.
     """
-    text = source.read_text(encoding="utf-8")
     decoder = json.JSONDecoder()
+    keys = {
+        name: f'"{name}":'.encode("ascii")
+        for name in ("charon_version", "has_errors", "crate_name", "type_decls")
+    }
+    offsets = scan_for_keys(source, list(keys.values()))
+    size = source.stat().st_size
 
     def field(name: str, *, want: type):
-        key = f'"{name}":'
-        at = text.find(key)
-        if at < 0:
+        key = keys[name]
+        if key not in offsets:
             raise SystemExit(f"extract-llbc.py: {source.name} has no `{name}` field")
-        # `raw_decode` does not skip leading whitespace of its own.
-        start = at + len(key)
-        while text[start] in " \t\r\n":
-            start += 1
-        try:
-            value, _ = decoder.raw_decode(text, start)
-        except json.JSONDecodeError as exc:
-            # The substring scan is unscoped, so `"{name}":` could match inside
-            # a string literal before the real key; then `start` points at
-            # non-JSON and decoding fails.  Report it the same way the rest of
-            # this file does instead of surfacing a bare traceback.
-            raise SystemExit(
-                f"extract-llbc.py: {source.name} `{name}` did not decode as JSON "
-                f"({exc}); the reducer's key scan matched a non-field occurrence."
-            ) from exc
+        start = offsets[key] + len(key)
+        window = LAYOUT_DECODE_WINDOW
+        with source.open("rb") as artefact:
+            while True:
+                artefact.seek(start)
+                # A window cut inside a multi-byte character only loses bytes
+                # PAST the value being decoded; a value that does not close
+                # inside the window is retried with a wider one.
+                text = artefact.read(window).decode("utf-8", errors="replace")
+                # `raw_decode` does not skip leading whitespace of its own.
+                at = 0
+                while at < len(text) and text[at] in " \t\r\n":
+                    at += 1
+                try:
+                    value, _ = decoder.raw_decode(text, at)
+                except json.JSONDecodeError as exc:
+                    if start + window < size:
+                        window *= 4
+                        continue
+                    # The substring scan is unscoped, so `"{name}":` could
+                    # match inside a string literal before the real key; then
+                    # `start` points at non-JSON and decoding fails.  Report
+                    # it the same way the rest of this file does instead of
+                    # surfacing a bare traceback.
+                    raise SystemExit(
+                        f"extract-llbc.py: {source.name} `{name}` did not decode as"
+                        f" JSON ({exc}); the reducer's key scan matched a non-field"
+                        " occurrence."
+                    ) from exc
+                break
         # Shape guard: a wrong (earlier) match can still decode as valid JSON of
         # the wrong type.  `type_decls` in particular must reach the sidecar
         # intact — it is the sole source of the target field offsets.
@@ -1848,7 +1900,6 @@ def write_layout_sidecar(source: Path, dest: Path) -> None:
             "fun_decls": [],
         },
     }
-    del text
     dest.write_text(json.dumps(slim), encoding="utf-8")
 
 
@@ -2229,6 +2280,11 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
         layout_passes: list[
             tuple[str, Path, Path, subprocess.Popen | None, typing.BinaryIO | None]
         ] = []
+        # Wall-clock marks for the per-phase figures printed below. Under CI
+        # stdout is block-buffered, so every line of a crate's extraction
+        # lands with one timestamp and the figures in the text are the only
+        # record of where the minutes went.
+        phase_started = time.monotonic()
         host_pass = subprocess.Popen(command, cwd=path, env=host_env)
         try:
             # One extra extraction per cross target, reduced to its type
@@ -2303,11 +2359,17 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
                     if host_pass is not None:
                         finish_charon_pass(host_pass, command, dest)
                         host_pass = None
+                        print(f"    host pass: {time.monotonic() - phase_started:.0f} s")
+                        phase_started = time.monotonic()
                     subprocess.run(layout_command, cwd=path, env=layout_env, check=True)
+                    print(f"    {target} pass: {time.monotonic() - phase_started:.0f} s")
+                    phase_started = time.monotonic()
 
             if host_pass is not None:
                 finish_charon_pass(host_pass, command, dest)
                 host_pass = None
+                print(f"    host pass: {time.monotonic() - phase_started:.0f} s")
+                phase_started = time.monotonic()
 
             layout_tables: dict[str, set[Path]] = {}
             for target, sidecar, full, proc, log in layout_passes:
@@ -2318,6 +2380,11 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
                             log.seek(0)
                             sys.stdout.write(log.read().decode("utf-8", errors="replace"))
                             raise subprocess.CalledProcessError(returncode, proc.args)
+                    print(
+                        f"    {target} pass: {time.monotonic() - phase_started:.0f} s"
+                        " (beside the host pass)"
+                    )
+                    phase_started = time.monotonic()
                 if not full.exists() or full.stat().st_size == 0:
                     raise SystemExit(
                         f"extract-llbc.py: Charon emitted no {target} artefact at {full}"
@@ -2333,7 +2400,11 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
                 # sidecar froze are consumed as current.
                 merge_readfiles(layout_tables, artefact_local_readfiles(full))
                 full.unlink()
-                print(f"    wrote {sidecar} ({sidecar.stat().st_size} bytes)")
+                print(
+                    f"    wrote {sidecar} ({sidecar.stat().st_size} bytes),"
+                    f" reduced in {time.monotonic() - phase_started:.0f} s"
+                )
+                phase_started = time.monotonic()
         finally:
             # A raise anywhere above -- a pass that failed, an artefact
             # that is missing, a layout std that will not build -- leaves
@@ -2472,7 +2543,10 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
         stamp_path.write_text(
             current_stamp + "\n", encoding="utf-8", newline="\n"
         )
-        print(f"    wrote {dest} ({dest.stat().st_size} bytes)")
+        print(
+            f"    wrote {dest} ({dest.stat().st_size} bytes),"
+            f" stamped in {time.monotonic() - phase_started:.0f} s"
+        )
 
     print()
     if unstamped:

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -3232,6 +3232,14 @@ def run_cli(
     # everywhere else, and argparse can refuse it here.
     modes = parser.add_mutually_exclusive_group()
     modes.add_argument("--fingerprint", action="store_true")
+    parser.add_argument(
+        "--per-crate",
+        action="store_true",
+        help="with --fingerprint: one `<field>[<crate>]=` line per crate and"
+        " field, instead of one digest over all the crates named. One process"
+        " shares the cargo metadata and include walks every crate needs, where"
+        " one process per crate repeats them",
+    )
     modes.add_argument("--list-inputs", action="store_true")
     modes.add_argument(
         "--check",
@@ -3305,10 +3313,18 @@ def run_cli(
         # BOTH fields. Printing only `source=` here previously cost a session:
         # three legs returned identical hashes that were consistent with every
         # hypothesis, because the field under test was not in the output.
-        print(f"source={source_fingerprint(eng, crates, cargo_features)}")
-        print(f"closure={closure_fingerprint(eng, crates, cargo_features)}")
-        print(f"external={external_fingerprint(eng, crates, cargo_features)}")
+        groups = (
+            [(f"[{crate}]", [crate]) for crate in crates]
+            if args.per_crate
+            else [("", crates)]
+        )
+        for suffix, group in groups:
+            print(f"source{suffix}={source_fingerprint(eng, group, cargo_features)}")
+            print(f"closure{suffix}={closure_fingerprint(eng, group, cargo_features)}")
+            print(f"external{suffix}={external_fingerprint(eng, group, cargo_features)}")
         return
+    if args.per_crate:
+        parser.error("--per-crate only applies with --fingerprint")
     if args.self_test:
         # The parser test runs first because it mutates only a temporary file;
         # the live probe below briefly changes the shared working tree.

--- a/scripts/llbc_extract_selftest.py
+++ b/scripts/llbc_extract_selftest.py
@@ -13,6 +13,7 @@ Runs on a synthetic tree in a temp dir: no cargo, no git, well under a second.
 from __future__ import annotations
 
 import importlib.util
+import json
 import pathlib
 import shutil
 import subprocess
@@ -176,9 +177,57 @@ def run_fingerprint(engine) -> int:
         shutil.rmtree(root, ignore_errors=True)
 
 
+def run_layout_sidecar(engine) -> int:
+    """Reduce a synthetic full artefact whose shape mirrors Charon's.
+
+    `type_decls` is made wider than the reducer's first decode window so the
+    widening retry runs, the bodies around it carry non-ASCII text so a window
+    edge can fall inside a multi-byte character, and `has_errors` sits at the
+    tail of the file, past every body, the way Charon writes it.
+    """
+    root = pathlib.Path(tempfile.mkdtemp()).resolve()
+    try:
+        type_decls = [
+            {"item_meta": {"name": f"ty{i}", "doc": "\u00e9" * 64}, "layout": [i]}
+            for i in range(60_000)
+        ]
+        fun_decls = [{"body": "\u2603" * 512, "index": i} for i in range(2_000)]
+        artefact = {
+            "charon_version": "probe",
+            "translated": {
+                "crate_name": "probe",
+                "files": [{"name": {"Local": "src/lib.rs"}}],
+                "type_decls": type_decls,
+                "fun_decls": fun_decls,
+            },
+            "has_errors": False,
+        }
+        full = root / "probe.full"
+        full.write_text(json.dumps(artefact, ensure_ascii=False), encoding="utf-8")
+        dest = root / "probe.layouts.ullbc"
+        engine.write_layout_sidecar(full, dest)
+        slim = json.loads(dest.read_text(encoding="utf-8"))
+        expected = {
+            "charon_version": "probe",
+            "has_errors": False,
+            "translated": {
+                "crate_name": "probe",
+                "type_decls": type_decls,
+                "fun_decls": [],
+            },
+        }
+        encoded = json.dumps(type_decls, ensure_ascii=False).encode("utf-8")
+        wide = len(encoded) > engine.LAYOUT_DECODE_WINDOW
+        ok = slim == expected and wide
+        print(f"{'ok  ' if ok else 'FAIL'} layout sidecar keeps type_decls and drops bodies")
+        return 0 if ok else 1
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
 def main() -> None:
     engine = load_engine()
-    failures = run(engine) + run_fingerprint(engine)
+    failures = run(engine) + run_fingerprint(engine) + run_layout_sidecar(engine)
     if failures:
         raise SystemExit(f"llbc_extract_selftest: {failures} failed")
     print("llbc_extract_selftest: all passed")


### PR DESCRIPTION
## What

1. **`write_layout_sidecar` reads a window, not the file.** It read the whole cross-target artefact with `read_text` before keeping four fields. On the interpreter's ~750 MB artefact that peaks at **7.26 GB RSS**; the reducer now locates the keys with one chunked byte scan and decodes each value from a widening window — **0.28 GB**, byte-identical sidecar.
2. **One fingerprint process for all four cache keys.** `--fingerprint --per-crate a b c d` prints `source[<crate>]=` (and the other two fields) per crate, the same digests the single-crate call prints. The CI step used one process per crate.
3. **Input bytes memoised across the walks of one tree snapshot.** `source=`, `closure=` and the `include*!` scan each re-read every input; over the four crates with no `.readfiles` (the CI key step) that was 5237 reads of 821 distinct files, now 821. Memo entries are validated by size + mtime_ns on every hit and dropped by `forget_collected_inputs`, so the post-build re-hash still reads the tree.
4. `extract` prints elapsed seconds per host pass / cross-target pass / reduction / stamp, so a CI log records where the minutes went even though stdout is block-buffered there.

## Why (run 32638927522, PR #1441)

- The gap between the layout pass finishing and the next crate's pass starting — reducer, file tables, stamp — was **72 s macos** (a 7 GB runner swapping through the 7 GB peak), **48 s windows**, **37 s ubuntu**. Locally that whole stretch is ~5 s.
- The `Compute LLBC fingerprints` step over the last 40 runs: ubuntu 5–8 s, macos 9–20 s, **windows 21–52 s** (every file read there goes through the real-time scanner). With (2) alone the windows step measured 57 s (run 32651435782, n=1), which is what motivated (3).

## Verification

- `scripts/llbc_extract_selftest.py` gains a synthetic artefact whose `type_decls` is wider than the first window (widening retry runs) with non-ASCII bodies on both sides; its per-case rewrite of `lib.rs` exercises the memo's stat check.
- Old vs new reducer on the same 781 MB artefact: `cmp` identical.
- Forced `pyre-object` and `majit-rlib` extractions end to end; `--check` and `--self-test` pass.
- All four `source[<crate>]=` digests equal the per-process ones before and after the memo, so no cache key moves.
- CI here: the fingerprint step's duration per OS, and — when a crate actually re-extracts — the Extract step's `reduced in N s` / `stamped in N s` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)