### PR TITLE
jit-trace: elidable builtin and math folds, an ordering-guard min/max arm, and the portal green threaded through the green-key builders

### DIFF
--- a/majit/majit-metainterp/src/call_descr.rs
+++ b/majit/majit-metainterp/src/call_descr.rs
@@ -314,6 +314,48 @@ pub const CANNOT_RAISE_NO_HEAP_EFFECT_INFO: EffectInfo = EffectInfo {
     call_release_gil_target: EffectInfo::_NO_CALL_RELEASE_GIL_TARGET,
 };
 
+/// `EF_ELIDABLE_CANNOT_RAISE` for a callee that cannot trigger GC.
+///
+/// This is a representable analyzer output, not a special case:
+/// `EffectInfo.__new__` takes `can_collect` as its own parameter, defaulting
+/// to true, and `effectinfo_from_writeanalyze` forces it true only for
+/// `extraeffect >= EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE`;
+/// `EF_ELIDABLE_CANNOT_RAISE` is 0.  Elidable with `can_collect=false` is
+/// therefore the analyzer output for an `@jit.elidable` leaf whose collect
+/// analyzer clears it, which is the shape of every helper in
+/// `jit_builtin_folds`.
+///
+/// `EffectInfo.__new__` additionally empties `_write_descrs_*` for every
+/// `EF_ELIDABLE_*`.  Those sets are already empty here, so no other field
+/// differs from [`CANNOT_RAISE_NO_HEAP_EFFECT_INFO`].
+///
+/// This differs from [`ELIDABLE_CANNOT_RAISE_EFFECT_INFO`], which goes
+/// through `const_new` and leaves `can_collect=true`, costing every backend
+/// the gcmap bracket and reference-register spill these callees do not need.
+pub const ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO: EffectInfo = EffectInfo {
+    extraeffect: ExtraEffect::ElidableCannotRaise,
+    oopspecindex: OopSpecIndex::None,
+    pyre_helper: PyreHelperKind::None,
+    _readonly_descrs_fields: Some(Vec::new()),
+    _write_descrs_fields: Some(Vec::new()),
+    _readonly_descrs_arrays: Some(Vec::new()),
+    _write_descrs_arrays: Some(Vec::new()),
+    _readonly_descrs_interiorfields: Some(Vec::new()),
+    _write_descrs_interiorfields: Some(Vec::new()),
+    descr_set_keys: Some(majit_ir::effectinfo::DescrSetKeysImage::Empty),
+    readonly_descrs_fields: Some(Vec::new()),
+    write_descrs_fields: Some(Vec::new()),
+    readonly_descrs_arrays: Some(Vec::new()),
+    write_descrs_arrays: Some(Vec::new()),
+    readonly_descrs_interiorfields: Some(Vec::new()),
+    write_descrs_interiorfields: Some(Vec::new()),
+    can_invalidate: false,
+    can_collect: false,
+    single_write_descr_array: None,
+    extradescrs: None,
+    call_release_gil_target: EffectInfo::_NO_CALL_RELEASE_GIL_TARGET,
+};
+
 /// `EF_ELIDABLE_CANNOT_RAISE` with `OS_INT_PY_DIV` oopspec — Python `//`
 /// (floor division). RPython parity: jtransform.py:2046-2047
 /// `_handle_int_special` classifies `int.py_div` as

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -152,7 +152,8 @@ pub mod warmspot;
 pub mod warmstate;
 
 pub use call_descr::{
-    CANNOT_RAISE_NO_HEAP_EFFECT_INFO, ELIDABLE_CANNOT_RAISE_EFFECT_INFO, ELIDABLE_EFFECT_INFO,
+    CANNOT_RAISE_NO_HEAP_EFFECT_INFO, ELIDABLE_CANNOT_RAISE_EFFECT_INFO,
+    ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO, ELIDABLE_EFFECT_INFO,
     ELIDABLE_OR_MEMERROR_EFFECT_INFO, EffectInfoSlot, INT_PY_DIV_EFFECT_INFO,
     INT_PY_MOD_EFFECT_INFO, LOOPINVARIANT_EFFECT_INFO, cannot_raise_effect_info,
     default_effect_info, effect_info_for_slot, forces_virtual_or_virtualizable_effect_info,

--- a/pyre/bench/synth/builtin_folds_hot.py
+++ b/pyre/bench/synth/builtin_folds_hot.py
@@ -13,6 +13,16 @@
 # arm on that host.  The gate clears the highest folded reading by 20% and still
 # sits an order of magnitude under the residual arm scaled to it.
 #
+# Those three-runner readings predate recording the `Int1` and `Float1`
+# channels as elidable calls.  A fold whose operand does not change is hoisted
+# out of the loop now instead of called once per iteration, and darwin-arm64
+# reads 3.1x / 2.9x where it read 4.6x / 4.7x.  The ceiling is unchanged: it
+# was fitted to a reading from all three runners, and only a reading from all
+# three can replace it.  `min` / `max` is the channel that did not move -- it
+# answers with a reference, and the loop re-proves that reference's `w_class`
+# before it can unbox it, so the call stays in the body.  That channel is what
+# the remaining ratio is mostly made of.
+#
 # pyre-check: spec-folds=builtin_fold1,builtin_fold2
 # This fixture carried a wasm allowance of 13 while every folded builtin still
 # left the trace module: a fold removes the frame force, the argument rooting,

--- a/pyre/bench/synth/builtin_folds_hot.py
+++ b/pyre/bench/synth/builtin_folds_hot.py
@@ -13,15 +13,15 @@
 # arm on that host.  The gate clears the highest folded reading by 20% and still
 # sits an order of magnitude under the residual arm scaled to it.
 #
-# Those three-runner readings predate recording the `Int1` and `Float1`
-# channels as elidable calls.  A fold whose operand does not change is hoisted
-# out of the loop now instead of called once per iteration, and darwin-arm64
-# reads 3.1x / 2.9x where it read 4.6x / 4.7x.  The ceiling is unchanged: it
-# was fitted to a reading from all three runners, and only a reading from all
-# three can replace it.  `min` / `max` is the channel that did not move -- it
-# answers with a reference, and the loop re-proves that reference's `w_class`
-# before it can unbox it, so the call stays in the body.  That channel is what
-# the remaining ratio is mostly made of.
+# Those three-runner readings predate two changes to how these folds are
+# recorded.  The `Int1` and `Float1` channels became elidable calls, so a fold
+# whose operand does not change is hoisted out of the loop instead of called
+# once per iteration.  And `min` / `max` over a pair of exact machine ints
+# stopped emitting a call at all: what is guarded is the ordering of the two
+# unboxed values, and under that ordering the answer is the winning operand's
+# own reference.  darwin-arm64 reads 2.0x / 2.2x where it read 4.6x / 4.7x.
+# The ceiling is unchanged: it was fitted to a reading from all three runners,
+# and only a reading from all three can replace it.
 #
 # pyre-check: spec-folds=builtin_fold1,builtin_fold2
 # This fixture carried a wasm allowance of 13 while every folded builtin still
@@ -62,7 +62,10 @@
 #                      length, not a type.
 #   abs_int/abs_float  one builtin holding two rows, one per result channel.
 #   min_max            the `Ref2` channel — the helper returns one of its own
-#                      arguments, so nothing is allocated at all.
+#                      arguments, so nothing is allocated at all.  A pair of
+#                      exact machine ints does not reach the helper: the
+#                      ordering guard picks the winner and the answer is that
+#                      operand's own reference.
 HASH_N = 32000000
 ORD_N = 32000000
 ABS_N = 32000000

--- a/pyre/bench/synth/inline_freevar_after_mayforce.py
+++ b/pyre/bench/synth/inline_freevar_after_mayforce.py
@@ -32,8 +32,10 @@
 # failed decode leaves two guards failing on nearly every iteration, while
 # guarding the callee namespace through the portal/root frame compiles an
 # endless chain of equally failing bridges.  With both frame properties
-# preserved, guard failures stay at 471 and local native ratios are 10.3x
-# dynasm / 15.9x cranelift versus PyPy.
+# preserved the guard-failure count reaches a fixed point instead of growing
+# with the iteration count; the 471 it once settled at belongs to a smaller N
+# and an older baseline, and what it settles at now is what the committed
+# baselines carry.
 from fractions import Fraction
 
 
@@ -45,25 +47,27 @@ from fractions import Fraction
 # and moved between two runs of one binary -- 923/6 loops against 925/7 here,
 # 923/6 against 938/8 on ubuntu and 922 against 923 on windows. Convergence
 # completes by 48000 on both native backends, and past it every gated counter is
-# independent of N: dynasm holds 1003 guard failures and cranelift 1008, with
-# six loops and five bridges, unchanged from 48000 through 96000. This sits far
-# enough above that point to keep the fixed point on a host that needs a few
-# more iterations to reach it.
+# independent of N: the loop, bridge and guard-failure values the committed
+# baselines carry hold from 48000 through 96000. This sits far enough above that
+# point to keep the fixed point on a host that needs a few more iterations to
+# reach it.
 #
-# The fixed point was seven loops and 1007/1012 guard failures for as long as
-# the blackhole recognized `catch_exception/L`: once jd0's staticdata carries
-# the assembler's real opcode ids instead of the 255 `op_live` sentinel, an
-# exception it used to let escape is caught, and the extra loop plus three
-# guard failures are that arm being compiled. `driver_finish_setup` still
-# installs those ids, but the arm is no longer reached, so the counters sit
-# below that pair on both native backends. Whatever stopped reaching it is
-# unattributed; the wasm backend never reached the arm at all, which is why its
-# baseline never moved off six.
+# Seven loops and the third guard failure are the `catch_exception/L` arm being
+# compiled: once jd0's staticdata carries the assembler's real opcode ids
+# instead of the 255 `op_live` sentinel, an exception the blackhole used to let
+# escape is caught. That arm stopped being reached for a while and the counters
+# fell back to six loops; it is reached again as of `d6408935b3c`, and all three
+# legs agreed on the way back up, which is what the current baselines record.
+# Two things about that return are unattributed. The guard failures did not come
+# back to the 1007/1012 pair the arm earned historically but to 1005/1009. And
+# wasm gained the loop as well -- its baseline moved off six at the same commit
+# -- while its guard failures stayed at 1004, so on that backend the arm costs a
+# loop and no guard failure.
 #
-# At six loops the guard counts have alternated between 1004/1009 and 1003/1008
-# across runs while the loop and bridge counts held. Only the loop count answers
-# whether the arm compiles, so treat a one-count move here as the unattributed
-# remainder rather than as this fixture's subject.
+# The committed baselines are seven loops, five bridges, and 1005 dynasm / 1009
+# cranelift / 1004 wasm. Only the loop count answers whether the arm compiles,
+# so treat a one-count guard-failure move as the unattributed remainder rather
+# than as this fixture's subject.
 N = 64000
 
 

--- a/pyre/bench/synth/math_folds_hot.py
+++ b/pyre/bench/synth/math_folds_hot.py
@@ -45,6 +45,20 @@
 #
 # A rebound callable, a numeric subclass, or an operand outside the folded
 # domain keeps the residual in every case.
+#
+# Every loop below derives its operand from the counter, so what the ratio
+# reads is the per-iteration cost of a fold and not what the optimizer can do
+# with one.  Recording these calls as elidable lets the pure pass serve a
+# second identical call from the first, which pays only where the operand does
+# not change.  Measured on darwin-arm64 against the previous binary,
+# interleaved over seven rounds, an invariant operand reads 6.2x on
+# `pow`/`atan2`, 3.5x on `tan`/`exp`, 3.3x on `log`/`cos`/`sin`, 2.1x on
+# `frexp`, 1.9x on `ldexp`, 1.4x on `floor`/`ceil`, 1.2x on `isqrt` and 1.05x
+# on `sqrt` -- each ahead in 7 of 7 rounds -- while the shapes below stay
+# within noise of where they were, their peeled bodies unchanged op for op.
+# `isclose` is the one fold that does not move even on an invariant operand:
+# its answer is consumed entirely by the branch's own guard and never reaches
+# the `Jump`, so nothing pulls the cached value across the loop boundary.
 import math
 
 # Sized so pypy's own execution clears the measurement floor: below it the

--- a/pyre/extra_tests/snippets/builtin_jit_folds.py
+++ b/pyre/extra_tests/snippets/builtin_jit_folds.py
@@ -172,6 +172,22 @@ class _Cmp:
 assert _stable(min, (_Cmp(1), _Cmp(2))).v == 1
 assert _stable(max, (_Cmp(1), _Cmp(2))).v == 2
 
+# Every pair above is a loop invariant, so the trace only ever sees the shape
+# it recorded.  A loop whose operands change has to leave through the guards
+# and answer from the builtin again.  Each stretch is long enough to compile
+# before the next one flips it, and the tie is driven after the `a > b`
+# stretch rather than after `a < b`: a trace recorded on `a > b` guards the
+# ordering it saw, and a later tie still satisfies that guard.
+_varying = ([(9, 3)] * ROUNDS + [(3, 3)] * ROUNDS + [(3, 9)] * ROUNDS
+            + [(1.5, 2.5)] * ROUNDS + [(9, 3)] * ROUNDS)
+_wrong = 0
+for _a, _b in _varying:
+    if min(_a, _b) != (_a if _a <= _b else _b):
+        _wrong += 1
+    if max(_a, _b) != (_a if _a >= _b else _b):
+        _wrong += 1
+assert _wrong == 0
+
 # --- rebound names ----------------------------------------------------------
 # The fold keys on the wrapped builtin code, not the name it is reachable
 # under, so a shadowing definition must win.

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -2920,31 +2920,3 @@ pub fn make_finalizer_queue<WRoot>(w_root: WRoot, _space: PyObjectRef) -> WRootF
     let _ = w_root;
     WRootFinalizerQueue
 }
-
-/// A stand-in for `interp_jit.py`'s `is_being_profiled` portal green at the
-/// green-key sites that hold no frame.
-///
-/// The markers do not use this: `jit_merge_point` and `can_enter_jit` both
-/// take `frame.get_is_being_profiled()`, as their declarations do. What has no
-/// frame to read is the `u64` key form — a function entry keys on
-/// `(pycode, 0)` and `fbw_decline` keys on `(pycode, start_pc)` from inside a
-/// walk — so `make_green_key` names the green here instead of taking it.
-///
-/// That makes this an approximation of the green at those sites, and the two
-/// forms can disagree while a profile function is installed. Threading the
-/// caller's own green through `make_green_key` is what removes the
-/// approximation; until then the disagreement is confined to the profiled
-/// regime, where the portal is already effectively out of service.
-///
-/// It reads `profilefunc` rather than a frame's flag because the flag is a
-/// cache of this slot: `setllprofile` calls
-/// `force_all_frames(is_being_profiled=True)` only when installing, so
-/// clearing the profile function leaves every live frame's flag set until
-/// `_c_call_return_trace` or `c_exception_trace` next observes `profilefunc`
-/// gone and repairs it. Every hook fire is gated on `profilefunc` — `leave`,
-/// `call_trace` and `_c_call_return_trace` all test it — so between the clear
-/// and the repair the flag names a regime that is no longer in force.
-pub fn current_is_being_profiled() -> bool {
-    let ec = crate::call::getexecutioncontext();
-    !ec.is_null() && unsafe { (*ec).profilefunc.is_some() }
-}

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -2921,16 +2921,29 @@ pub fn make_finalizer_queue<WRoot>(w_root: WRoot, _space: PyObjectRef) -> WRootF
     WRootFinalizerQueue
 }
 
-/// `interp_jit.py`'s `is_being_profiled` portal green, read from the running
-/// execution context rather than from a frame.
+/// A stand-in for `interp_jit.py`'s `is_being_profiled` portal green at the
+/// green-key sites that hold no frame.
 ///
-/// `setllprofile` sets the per-frame flag on every live frame
-/// (`force_all_frames(is_being_profiled=True)`) and `call_trace` sets it on
-/// each frame it enters, so "this frame is being profiled" and "a profile
-/// function is installed" name the same state for every frame the portal can
-/// reach. The portal has green-key sites with no frame in hand — a function
-/// entry keys on `(pycode, 0)` — and the hash form and the typed form must
-/// agree or they resolve to different cells, so both derive the green here.
+/// The markers do not use this: `jit_merge_point` and `can_enter_jit` both
+/// take `frame.get_is_being_profiled()`, as their declarations do. What has no
+/// frame to read is the `u64` key form — a function entry keys on
+/// `(pycode, 0)` and `fbw_decline` keys on `(pycode, start_pc)` from inside a
+/// walk — so `make_green_key` names the green here instead of taking it.
+///
+/// That makes this an approximation of the green at those sites, and the two
+/// forms can disagree while a profile function is installed. Threading the
+/// caller's own green through `make_green_key` is what removes the
+/// approximation; until then the disagreement is confined to the profiled
+/// regime, where the portal is already effectively out of service.
+///
+/// It reads `profilefunc` rather than a frame's flag because the flag is a
+/// cache of this slot: `setllprofile` calls
+/// `force_all_frames(is_being_profiled=True)` only when installing, so
+/// clearing the profile function leaves every live frame's flag set until
+/// `_c_call_return_trace` or `c_exception_trace` next observes `profilefunc`
+/// gone and repairs it. Every hook fire is gated on `profilefunc` — `leave`,
+/// `call_trace` and `_c_call_return_trace` all test it — so between the clear
+/// and the repair the flag names a regime that is no longer in force.
 pub fn current_is_being_profiled() -> bool {
     let ec = crate::call::getexecutioncontext();
     !ec.is_null() && unsafe { (*ec).profilefunc.is_some() }

--- a/pyre/pyre-interpreter/src/jit_builtin_folds.rs
+++ b/pyre/pyre-interpreter/src/jit_builtin_folds.rs
@@ -33,7 +33,9 @@
 //! channels are recorded that way; the reference channel satisfies the same
 //! requirement but is still emitted as a plain call, for a reason that belongs
 //! with the emission and is recorded at
-//! `try_walker_specialize_builtin_fold2`.
+//! `try_walker_specialize_builtin_fold2`.  That site also answers a pair of
+//! exact machine ints without reaching this module at all, by guarding the
+//! ordering of the two operands instead of calling anything.
 
 use pyre_object::{PY_NULL, PyObjectRef};
 

--- a/pyre/pyre-interpreter/src/jit_builtin_folds.rs
+++ b/pyre/pyre-interpreter/src/jit_builtin_folds.rs
@@ -25,7 +25,15 @@
 //! answer where the builtin would have raised, returned something else, or run
 //! app-level code.  Nothing here allocates: the result box is emitted as
 //! `wrapint` / `wrapfloat` / `newbool` in the trace instead, where the
-//! optimizer can keep it virtual.
+//! optimizer can keep it virtual.  Every helper must also be a pure function
+//! of its arguments: the same operands must always produce the same answer.
+//! That is what lets the trace record a call as elidable, so the optimizer may
+//! serve a loop's copy from an earlier identical one; a helper whose answer
+//! drifted would be answered once and reused forever.  The int and float
+//! channels are recorded that way; the reference channel satisfies the same
+//! requirement but is still emitted as a plain call, for a reason that belongs
+//! with the emission and is recorded at
+//! `try_walker_specialize_builtin_fold2`.
 
 use pyre_object::{PY_NULL, PyObjectRef};
 
@@ -107,6 +115,14 @@ pub struct BuiltinFold {
 /// fresh `int`.  The trace emits this call as one that cannot collect, so it
 /// carries no gcmap and spills no reference registers; allocating under it
 /// would leave the collector blind.  Decline and let the interpreter allocate.
+///
+/// `hash_value` memoizes a string's digest through `w_str_set_hash`; that write
+/// is compatible with elidability because it stores the digest the next call
+/// would recompute, and `EffectInfo.__new__` drops `_write_descrs_*` for every
+/// `EF_ELIDABLE_*` for exactly this shape.  Every other admitted arm reads a
+/// content- or value-determined digest, and the one arm that is neither -- a
+/// NaN `float`, which reaches `default_identity_hash_value` -- already
+/// declines.
 extern "C" fn jit_builtin_hash(obj: i64) -> i64 {
     let obj = obj as PyObjectRef;
     if obj.is_null() {
@@ -247,6 +263,11 @@ fn compare_pair(a: PyObjectRef, b: PyObjectRef, want_second_wins: bool) -> Optio
 
 /// `min(a, b)` — `builtin_min`'s two-positional form: keep the first argument
 /// unless the second compares strictly smaller.
+///
+/// The helper returns one of its own arguments after comparing two exact
+/// machine ints or two non-NaN floats, so the answer is fixed by the pair, as
+/// the table requires.  A NaN operand, whose winner would depend on the scan
+/// order, already declines.
 extern "C" fn jit_builtin_min2(a: i64, b: i64) -> i64 {
     let (a, b) = (a as PyObjectRef, b as PyObjectRef);
     if a.is_null() || b.is_null() {
@@ -260,6 +281,11 @@ extern "C" fn jit_builtin_min2(a: i64, b: i64) -> i64 {
 }
 
 /// `max(a, b)` — the `builtin_max` twin of [`jit_builtin_min2`].
+///
+/// Like [`jit_builtin_min2`], this helper returns one of its own arguments
+/// after an exact machine-int or non-NaN float comparison, so the answer is
+/// fixed by the pair.  A NaN operand already declines instead of preserving a
+/// scan-order-dependent winner.
 extern "C" fn jit_builtin_max2(a: i64, b: i64) -> i64 {
     let (a, b) = (a as PyObjectRef, b as PyObjectRef);
     if a.is_null() || b.is_null() {

--- a/pyre/pyre-jit-trace/src/driver.rs
+++ b/pyre/pyre-jit-trace/src/driver.rs
@@ -7,20 +7,13 @@ use crate::callbacks;
 use crate::state::PyreJitState;
 
 /// RPython green_key = pypyjit greens `[next_instr, is_being_profiled,
-/// pycode]` (interp_jit.py). `is_being_profiled` is read from the running
-/// execution context (`current_is_being_profiled`) rather than folded to 0,
-/// so installing a profiler selects a different cell instead of sharing the
-/// unprofiled one. The returned u64 is the full
+/// pycode]` (interp_jit.py). The returned u64 is the full
 /// `JitCell.get_uhash` over the typed green tuple (warmstate.py),
 /// so this legacy hash flow and the typed marker-path lookup
 /// (`lookup_chain_with_key`) agree on the same cell.
 #[inline(always)]
-pub fn make_green_key(code_ptr: *const (), pc: usize) -> u64 {
-    majit_ir::pypyjit_greenkey_uhash(
-        pc,
-        pyre_interpreter::executioncontext::current_is_being_profiled(),
-        code_ptr as u64,
-    )
+pub fn make_green_key(code_ptr: *const (), pc: usize, is_being_profiled: bool) -> u64 {
+    majit_ir::pypyjit_greenkey_uhash(pc, is_being_profiled, code_ptr as u64)
 }
 
 /// The typed form of [`make_green_key`]: the greens themselves, not a fold of
@@ -31,12 +24,19 @@ pub fn make_green_key(code_ptr: *const (), pc: usize) -> u64 {
 /// cell out of a bucket, and a cell created from the fold alone is filed
 /// without a comparekey, where no later typed lookup can find it. The u64 form
 /// stays correct for calls that only move a counter.
-pub fn make_green_key_typed(code_ptr: *const (), pc: usize) -> majit_ir::GreenKey {
-    majit_ir::pypyjit_greenkey(
-        pc,
-        pyre_interpreter::executioncontext::current_is_being_profiled(),
-        code_ptr as u64,
-    )
+pub fn make_green_key_typed(
+    code_ptr: *const (),
+    pc: usize,
+    is_being_profiled: bool,
+) -> majit_ir::GreenKey {
+    majit_ir::pypyjit_greenkey(pc, is_being_profiled, code_ptr as u64)
+}
+
+/// Read the pypyjit profiling green from the concrete frame for a walk.
+#[inline]
+pub fn frame_is_being_profiled(frame_addr: usize) -> bool {
+    let frame = frame_addr as *const pyre_interpreter::pyframe::PyFrame;
+    !frame.is_null() && unsafe { (*frame).get_is_being_profiled() }
 }
 
 /// Type alias for the JIT driver pair. Must match pyre-jit/eval.rs JitDriverPair.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -909,6 +909,7 @@ pub(crate) fn call_dst_reg_for_residual_return(code: &[u8], entry: usize) -> Opt
 
 pub(crate) fn recipe_parent_frame_from_recipe(
     ctx: &mut TraceCtx,
+    is_being_profiled: bool,
     recipe: &majit_metainterp::ReconstructRecipe,
     root_ec: *const pyre_interpreter::PyExecutionContext,
     root_ec_box: majit_ir::OpRef,
@@ -940,6 +941,7 @@ pub(crate) fn recipe_parent_frame_from_recipe(
     // snapshot.
     let (pending, _argboxes_r) = crate::state::setup_reconstructed_callee_frame(
         ctx,
+        is_being_profiled,
         recipe,
         root_ec,
         root_ec_box,
@@ -1092,6 +1094,8 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
     paused_parent_recipes: &[majit_metainterp::ReconstructRecipe],
 ) -> Option<Result<(DispatchOutcome, usize), DispatchError>> {
     use majit_metainterp::jitcode::RuntimeBhDescr;
+
+    let is_being_profiled = session.borrow().is_being_profiled;
 
     // Terminal descrs must be wired on MetaInterpStaticData before the walk can
     // produce a compilable FINISH (mirror `dispatch_perfn_frame`).  The walk
@@ -1286,6 +1290,7 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
         ));
         parent_for_current = recipe_parent_frame_from_recipe(
             ctx,
+            is_being_profiled,
             parent_recipe,
             root_sym.concrete_execution_context(),
             root_sym.execution_context(),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -1953,6 +1953,7 @@ pub(crate) fn fbw_abort_nested_unjournaled_residual<Sym: WalkSym>(
         // letting the enclosing loop retrace (`pyjitpl.py:2818-2828`).
         if let Some((callee_code_key, _)) = hazardous_callee {
             fbw_deny_hazardous_inline(callee_code_key);
+            let is_being_profiled = ctx.session.borrow().is_being_profiled;
             // `fbw_deny_hazardous_inline` writes a thread-local set that only
             // this walker reads, so the deny stayed invisible to the warm
             // state: `dont_trace_here` counted zero on every fixture that
@@ -1969,6 +1970,7 @@ pub(crate) fn fbw_abort_nested_unjournaled_residual<Sym: WalkSym>(
                     .disable_noninlinable_function(crate::driver::make_green_key(
                         callee_code_key as *const (),
                         0,
+                        is_being_profiled,
                     ));
             }
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -952,6 +952,7 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
     if !ctx.is_authoritative_executor {
         return Ok(None);
     }
+    let is_being_profiled = ctx.session.borrow().is_being_profiled;
     // Only a genuine `call_fn` residual is a candidate — every
     // container/builtin helper carries a distinct tag.
     if pyre_helper != majit_ir::PyreHelperKind::CallFn {
@@ -1142,18 +1143,18 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
         return Ok(None);
     }
     // Resolve the callee's own loop or trace-in-progress marker with
-    // `make_green_key(w_callee_code, 0)` (`pc = 0` = function entry). A
+    // `make_green_key` at `(w_callee_code, 0)` (`pc = 0` = function entry). A
     // pending token only proves the callee is
     // being traced; emission below resolves compiled-or-tmp so the descr never
     // carries a bodyless token.
     let (driver, _) = crate::driver::driver_pair();
-    let callee_key = crate::driver::make_green_key(w_code, 0);
+    let callee_key = crate::driver::make_green_key(w_code, 0, is_being_profiled);
     // warmstate.py / compile.py: resolve an installed
     // procedure token, or synthesize a tmp callback token while the real loop
     // is still tracing.
     let greenboxes = [
         majit_ir::Value::Int(0),
-        majit_ir::Value::Int(0),
+        majit_ir::Value::Int(is_being_profiled as i64),
         majit_ir::Value::Ref(majit_ir::GcRef(w_code as usize)),
     ];
     let red_types = [Type::Ref, Type::Ref];
@@ -3374,6 +3375,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     require_exact_int_result: bool,
     instance_next_foriter_green_key: Option<u64>,
 ) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
+    let is_being_profiled = ctx.session.borrow().is_being_profiled;
     // `_compute_flatcall` (`pycode.py`) leaves `fast_natural_arity`
     // HOPELESS for a `*args` / `**kwargs` / keyword-only callee.  The general
     // `funcrun` path still traces through `_match_signature`, which writes a
@@ -3579,7 +3581,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     // later sibling calls in the same trace go straight to CALL_ASSEMBLER
     // instead of starting a fresh unroll from their now-shallower framestack.
     let callee_code_key = w_code as pyre_object::PyObjectRef as usize;
-    let callee_green_key = crate::driver::make_green_key(w_code, 0);
+    let callee_green_key = crate::driver::make_green_key(w_code, 0, is_being_profiled);
     if let Some((driver, _)) = crate::driver::try_driver_pair()
         && !driver
             .meta_interp_mut()
@@ -5335,13 +5337,14 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         // `disable_noninlinable_function` is applied to.
         let subwalk_jd_no = crate::state::note_inline_subwalk_start(
             (
-                crate::driver::make_green_key(raw_callee_code as *const (), 0),
+                crate::driver::make_green_key(raw_callee_code as *const (), 0, is_being_profiled),
                 // The callee's greens are in scope here, so the log carries
                 // them: `disable_noninlinable_function` applies to this key,
                 // and it reaches a cell.
                 Some(crate::driver::make_green_key_typed(
                     raw_callee_code as *const (),
                     0,
+                    is_being_profiled,
                 )),
             ),
             sub_wc.trace_ctx.get_trace_position(),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -519,6 +519,8 @@ pub struct InlineFrame {
 /// through [`WalkContext`] — `MetaInterp.framestack` (`pyjitpl.py`,
 /// `:2487`; depth scan `:1390`). Innermost level last.
 pub struct WalkSession {
+    /// The root frame's `is_being_profiled` portal green for this walk.
+    pub is_being_profiled: bool,
     /// Inlined callee levels. Parent snapshots are outermost-first, matching
     /// `Snapshot.frames`; a caller is pushed at its inline CALL and popped
     /// when the callee sub-walk returns.
@@ -558,6 +560,7 @@ pub struct WalkSession {
 impl Default for WalkSession {
     fn default() -> Self {
         Self {
+            is_being_profiled: false,
             framestack: Vec::new(),
             abort_in_subwalk: false,
             tmpreg_r: OpRef::NONE,
@@ -2520,8 +2523,9 @@ pub enum DispatchError {
     /// `jit_merge_point/cIRFIRF` could not derive its green key from the
     /// op's green operands. pyre's portal jitdriver greens =
     /// `[next_instr, is_being_profiled, pycode]` (`eval.rs`), so the
-    /// green key is `make_green_key(concrete(gr[0]=pycode),
-    /// concrete(gi[0]=next_instr))`. This fires when the int/ref green
+    /// green key is `make_green_key` at `(concrete(gr[0]=pycode),
+    /// concrete(gi[0]=next_instr))`, with the walk's own
+    /// `is_being_profiled`. This fires when the int/ref green
     /// list is empty or its leading element has no concrete Int/Ref —
     /// either a codewriter shape mismatch or (pre-Phase-5) the greens
     /// weren't seeded with concretes. RPython parity:
@@ -9256,7 +9260,11 @@ fn walker_foriter_green_key<Sym: WalkSym>(
     }
     let foriter_start_pc =
         crate::py_coord::containing_py_pc_for_jitcode_pc(&jitcode.payload.metadata, op_pc) as usize;
-    Some(crate::driver::make_green_key(w_code, foriter_start_pc))
+    Some(crate::driver::make_green_key(
+        w_code,
+        foriter_start_pc,
+        ctx.session.borrow().is_being_profiled,
+    ))
 }
 
 fn mark_trace_reads_module_global(
@@ -11673,6 +11681,9 @@ fn handle<Sym: WalkSym>(
         // slot containing the jdindex; the `c` spelling stores the jdindex
         // directly in that byte.
         "jit_merge_point/cIRFIRF" | "jit_merge_point/iIRFIRF" => {
+            // Copy the walk green before any mutable session borrow in this
+            // handler; key construction and greenboxes must use one value.
+            let is_being_profiled = ctx.session.borrow().is_being_profiled;
             // RPython parity: `opimpl_jit_merge_point` →
             // `reached_loop_header`. pyre's retired
             // trait mirror was `close_loop_args`.
@@ -11810,12 +11821,15 @@ fn handle<Sym: WalkSym>(
                     fbw_root_code.is_none_or(|root| root as *const () != cc as *const ())
                 });
             if let Some(callee_code) = callee_code {
-                let callee_key =
-                    crate::driver::make_green_key(callee_code as *const (), next_instr);
+                let callee_key = crate::driver::make_green_key(
+                    callee_code as *const (),
+                    next_instr,
+                    is_being_profiled,
+                );
                 let (driver, _) = crate::driver::driver_pair();
                 let greenboxes = [
                     Value::Int(next_instr as i64),
-                    Value::Int(0),
+                    Value::Int(is_being_profiled as i64),
                     Value::Ref(majit_ir::GcRef(callee_code)),
                 ];
                 let red_types = [Type::Ref, Type::Ref];
@@ -11852,12 +11866,15 @@ fn handle<Sym: WalkSym>(
                         .last()
                         .map(|frame| frame.w_code);
                     if let Some(callee_code) = callee_code {
-                        let callee_key =
-                            crate::driver::make_green_key(callee_code as *const (), next_instr);
+                        let callee_key = crate::driver::make_green_key(
+                            callee_code as *const (),
+                            next_instr,
+                            is_being_profiled,
+                        );
                         let (driver, _) = crate::driver::driver_pair();
                         let greenboxes = [
                             Value::Int(next_instr as i64),
-                            Value::Int(0),
+                            Value::Int(is_being_profiled as i64),
                             Value::Ref(majit_ir::GcRef(callee_code)),
                         ];
                         let red_types = [Type::Ref, Type::Ref];
@@ -11879,7 +11896,7 @@ fn handle<Sym: WalkSym>(
                         .ok_or(DispatchError::JitMergePointGreenKeyUnresolved { pc: op.pc })?
                 }
             };
-            let key = crate::driver::make_green_key(code_ptr, next_instr);
+            let key = crate::driver::make_green_key(code_ptr, next_instr, is_being_profiled);
 
             // pyjitpl.py: a jit_merge_point is a loop CROSSING
             // only when a `loop_header` op (the lowered `can_enter_jit`
@@ -12340,7 +12357,11 @@ fn handle<Sym: WalkSym>(
                     .collect();
                 ctx.trace_ctx.add_merge_point_with_key(
                     key,
-                    Some(crate::driver::make_green_key_typed(code_ptr, next_instr)),
+                    Some(crate::driver::make_green_key_typed(
+                        code_ptr,
+                        next_instr,
+                        is_being_profiled,
+                    )),
                     green_boxes,
                     next_instr,
                 );

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -10111,13 +10111,20 @@ pub(crate) fn try_walker_specialize_math_sqrt<Sym: WalkSym>(
     walker_float_cmp_guard(ctx, op.pc, OpCode::FloatEq, &[diff, zero], true)?;
     // The pure elidable libm sqrt: EF_ELIDABLE_CANNOT_RAISE → CALL_F, no
     // trailing guard, foldable/hoistable.
-    let raw = ctx.trace_ctx.call_float_typed_with_effect(
+    let result_val = unsafe { pyre_object::w_float_get_value(boxed_result) };
+    let raw = ctx.trace_ctx.call_typed_with_effect_pure(
+        OpCode::CallF,
         crate::trace_opcode::sqrt_nonneg_jit as *const (),
         &[x],
         &[majit_ir::Type::Float],
-        majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        majit_ir::Type::Float,
+        majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        &[
+            majit_ir::Value::Int(crate::trace_opcode::sqrt_nonneg_jit as *const () as i64),
+            majit_ir::Value::Float(val),
+        ],
+        majit_ir::Value::Float(result_val),
     );
-    let result_val = unsafe { pyre_object::w_float_get_value(boxed_result) };
     ctx.trace_ctx
         .set_opref_concrete(raw, majit_ir::Value::Float(result_val));
     let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw);
@@ -10229,13 +10236,20 @@ pub(crate) fn try_walker_specialize_math_log_trig<Sym: WalkSym>(
     ctx.trace_ctx
         .set_opref_concrete(diff, majit_ir::Value::Float(0.0));
     walker_float_cmp_guard(ctx, op.pc, OpCode::FloatEq, &[diff, zero], true)?;
-    let raw = ctx.trace_ctx.call_float_typed_with_effect(
+    let result_val = unsafe { pyre_object::w_float_get_value(boxed_result) };
+    let raw = ctx.trace_ctx.call_typed_with_effect_pure(
+        OpCode::CallF,
         raw_fn,
         &[x],
         &[majit_ir::Type::Float],
-        majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        majit_ir::Type::Float,
+        majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        &[
+            majit_ir::Value::Int(raw_fn as i64),
+            majit_ir::Value::Float(val),
+        ],
+        majit_ir::Value::Float(result_val),
     );
-    let result_val = unsafe { pyre_object::w_float_get_value(boxed_result) };
     ctx.trace_ctx
         .set_opref_concrete(raw, majit_ir::Value::Float(result_val));
     let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw);
@@ -10330,19 +10344,39 @@ pub(crate) fn try_walker_specialize_math_frexp<Sym: WalkSym>(
         // and ignores an override there too.
         walker_guard_exact_w_class(ctx, op.pc, r_args[2], walker_numeric_builtin_class(arg_obj))?;
     }
-    let mantissa = ctx.trace_ctx.call_float_typed_with_effect(
+    let mantissa = ctx.trace_ctx.call_typed_with_effect_pure(
+        OpCode::CallF,
         pyre_interpreter::module::math::interp_math::jit_math_frexp_mantissa as *const (),
         &[x],
         &[majit_ir::Type::Float],
-        majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        majit_ir::Type::Float,
+        majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        &[
+            majit_ir::Value::Int(
+                pyre_interpreter::module::math::interp_math::jit_math_frexp_mantissa as *const ()
+                    as i64,
+            ),
+            majit_ir::Value::Float(x_value),
+        ],
+        majit_ir::Value::Float(mantissa_value),
     );
     ctx.trace_ctx
         .set_opref_concrete(mantissa, majit_ir::Value::Float(mantissa_value));
-    let exponent = ctx.trace_ctx.call_int_typed_with_effect(
+    let exponent = ctx.trace_ctx.call_typed_with_effect_pure(
+        OpCode::CallI,
         pyre_interpreter::module::math::interp_math::jit_math_frexp_exponent as *const (),
         &[x],
         &[majit_ir::Type::Float],
-        majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        majit_ir::Type::Int,
+        majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        &[
+            majit_ir::Value::Int(
+                pyre_interpreter::module::math::interp_math::jit_math_frexp_exponent as *const ()
+                    as i64,
+            ),
+            majit_ir::Value::Float(x_value),
+        ],
+        majit_ir::Value::Int(exponent_value),
     );
     ctx.trace_ctx
         .set_opref_concrete(exponent, majit_ir::Value::Int(exponent_value));
@@ -10466,11 +10500,21 @@ pub(crate) fn try_walker_specialize_math_ldexp<Sym: WalkSym>(
     let exp = walker_unbox_int_typed(ctx, op.pc, r_args[3], exp_type_addr, exp_descr)?;
     ctx.trace_ctx
         .set_opref_concrete(exp, majit_ir::Value::Int(exp_value));
-    let raw = ctx.trace_ctx.call_float_typed_with_effect(
+    let raw = ctx.trace_ctx.call_typed_with_effect_pure(
+        OpCode::CallF,
         pyre_interpreter::module::math::interp_math::jit_math_ldexp_raw as *const (),
         &[x, exp],
         &[majit_ir::Type::Float, majit_ir::Type::Int],
-        majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        majit_ir::Type::Float,
+        majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        &[
+            majit_ir::Value::Int(
+                pyre_interpreter::module::math::interp_math::jit_math_ldexp_raw as *const () as i64,
+            ),
+            majit_ir::Value::Float(x_value),
+            majit_ir::Value::Int(exp_value),
+        ],
+        majit_ir::Value::Float(result_value),
     );
     ctx.trace_ctx
         .set_opref_concrete(raw, majit_ir::Value::Float(result_value));
@@ -10582,11 +10626,20 @@ pub(crate) fn try_walker_specialize_math_isqrt<Sym: WalkSym>(
         .set_opref_concrete(nonnegative, majit_ir::Value::Int(1));
     walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardTrue, &[nonnegative])?;
 
-    let raw_result = ctx.trace_ctx.call_int_typed_with_effect(
+    let raw_result = ctx.trace_ctx.call_typed_with_effect_pure(
+        OpCode::CallI,
         pyre_interpreter::module::math::interp_math::jit_math_isqrt_i64 as *const (),
         &[raw_int],
         &[majit_ir::Type::Int],
-        majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        majit_ir::Type::Int,
+        majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        &[
+            majit_ir::Value::Int(
+                pyre_interpreter::module::math::interp_math::jit_math_isqrt_i64 as *const () as i64,
+            ),
+            majit_ir::Value::Int(value),
+        ],
+        majit_ir::Value::Int(result_value),
     );
     ctx.trace_ctx
         .set_opref_concrete(raw_result, majit_ir::Value::Int(result_value));
@@ -10916,11 +10969,18 @@ pub(crate) fn try_walker_specialize_math_round_to_int<Sym: WalkSym>(
                     value.ceil(),
                 ),
             };
-            let rounded = ctx.trace_ctx.call_float_typed_with_effect(
+            let rounded = ctx.trace_ctx.call_typed_with_effect_pure(
+                OpCode::CallF,
                 helper,
                 &[raw_float],
                 &[majit_ir::Type::Float],
-                majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+                majit_ir::Type::Float,
+                majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+                &[
+                    majit_ir::Value::Int(helper as i64),
+                    majit_ir::Value::Float(value),
+                ],
+                majit_ir::Value::Float(rounded_value),
             );
             ctx.trace_ctx
                 .set_opref_concrete(rounded, majit_ir::Value::Float(rounded_value));
@@ -11090,11 +11150,18 @@ pub(crate) fn try_walker_specialize_math_float1<Sym: WalkSym>(
     walker_guard_fold_callable(ctx, op.pc, r_args[0], concrete_callable)?;
     let x =
         walker_coerce_operand_to_float(ctx, op.pc, r_args[2], operands[0], is_int, value, false)?;
-    let raw = ctx.trace_ctx.call_float_typed_with_effect(
+    let raw = ctx.trace_ctx.call_typed_with_effect_pure(
+        OpCode::CallF,
         raw_fn as *const (),
         &[x],
         &[majit_ir::Type::Float],
-        majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        majit_ir::Type::Float,
+        majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        &[
+            majit_ir::Value::Int(raw_fn as *const () as i64),
+            majit_ir::Value::Float(value),
+        ],
+        majit_ir::Value::Float(result_value),
     );
     ctx.trace_ctx
         .set_opref_concrete(raw, majit_ir::Value::Float(result_value));
@@ -11172,11 +11239,19 @@ pub(crate) fn try_walker_specialize_math_float2<Sym: WalkSym>(
         y_value,
         false,
     )?;
-    let raw = ctx.trace_ctx.call_float_typed_with_effect(
+    let raw = ctx.trace_ctx.call_typed_with_effect_pure(
+        OpCode::CallF,
         raw_fn as *const (),
         &[x, y],
         &[majit_ir::Type::Float, majit_ir::Type::Float],
-        majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        majit_ir::Type::Float,
+        majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        &[
+            majit_ir::Value::Int(raw_fn as *const () as i64),
+            majit_ir::Value::Float(x_value),
+            majit_ir::Value::Float(y_value),
+        ],
+        majit_ir::Value::Float(result_value),
     );
     ctx.trace_ctx
         .set_opref_concrete(raw, majit_ir::Value::Float(result_value));
@@ -11270,11 +11345,19 @@ pub(crate) fn try_walker_specialize_math_isclose<Sym: WalkSym>(
         b_value,
         false,
     )?;
-    let truth = ctx.trace_ctx.call_int_typed_with_effect(
+    let truth = ctx.trace_ctx.call_typed_with_effect_pure(
+        OpCode::CallI,
         helper as *const (),
         &[a, b],
         &[majit_ir::Type::Float, majit_ir::Type::Float],
-        majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        majit_ir::Type::Int,
+        majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        &[
+            majit_ir::Value::Int(helper as *const () as i64),
+            majit_ir::Value::Float(a_value),
+            majit_ir::Value::Float(b_value),
+        ],
+        majit_ir::Value::Int(i64::from(observed)),
     );
     ctx.trace_ctx
         .set_opref_concrete(truth, majit_ir::Value::Int(i64::from(observed)));

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -11618,11 +11618,10 @@ pub(crate) fn try_walker_specialize_builtin_fold2<Sym: WalkSym>(
             && (pyre_object::tagged_int::is_tagged_int(operands[0])
                 || pyre_object::tagged_int::is_tagged_int(operands[1]));
         let int_typeobj = pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::INT_TYPE);
-        let is_exact_int = |o: pyre_object::PyObjectRef| unsafe {
-            std::ptr::eq((*o).ob_type, &pyre_object::pyobject::INT_TYPE)
-                && std::ptr::eq((*o).w_class, int_typeobj)
-        };
-        if !has_tagged_int && is_exact_int(operands[0]) && is_exact_int(operands[1]) {
+        if !has_tagged_int
+            && walker_is_exact_machine_int_concrete(operands[0])
+            && walker_is_exact_machine_int_concrete(operands[1])
+        {
             let (a_value, b_value) = unsafe {
                 (
                     pyre_object::w_int_get_value(operands[0]),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -11514,6 +11514,81 @@ pub(crate) fn try_walker_specialize_builtin_fold2<Sym: WalkSym>(
         if value.is_null() || value != boxed_result {
             continue;
         }
+        // Two distinct exact machine ints need no builtin-specific branch:
+        // the ordering guard determines which object `min_max_multiple_args`
+        // would keep for either comparison direction.  The answer written to
+        // the destination is the winning operand's own `OpRef`, so nothing is
+        // allocated and no new box is made.  If a later iteration reverses
+        // the ordering the guard fails and resumes in the builtin, the same
+        // side exit the decline sentinel below uses.
+        //
+        // Recording starts only from a pair that already differs, because on
+        // a tie the winner is scan order rather than an ordering this arm
+        // could guard.  The guard is then recorded in whichever direction
+        // held, so the `a < b` trace excludes a later tie while the `a >= b`
+        // one admits it.  On such a tie `min_max_multiple_args` keeps its
+        // first argument and this arm may hand back the second, but the two
+        // are exact ints of equal value and `is_w` compares those by value
+        // rather than by pointer, so which one the loop gets back is not
+        // observable.
+        let has_tagged_int = pyre_object::tagged_int::CAN_BE_TAGGED
+            && (pyre_object::tagged_int::is_tagged_int(operands[0])
+                || pyre_object::tagged_int::is_tagged_int(operands[1]));
+        let int_typeobj = pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::INT_TYPE);
+        let is_exact_int = |o: pyre_object::PyObjectRef| unsafe {
+            std::ptr::eq((*o).ob_type, &pyre_object::pyobject::INT_TYPE)
+                && std::ptr::eq((*o).w_class, int_typeobj)
+        };
+        if !has_tagged_int && is_exact_int(operands[0]) && is_exact_int(operands[1]) {
+            let (a_value, b_value) = unsafe {
+                (
+                    pyre_object::w_int_get_value(operands[0]),
+                    pyre_object::w_int_get_value(operands[1]),
+                )
+            };
+            if a_value != b_value {
+                let winner = if value == operands[0] {
+                    r_args[2]
+                } else if value == operands[1] {
+                    r_args[3]
+                } else {
+                    continue;
+                };
+
+                walker_guard_fold_callable(ctx, op.pc, r_args[0], concrete_callable)?;
+                let (a_op, b_op) = (r_args[2], r_args[3]);
+                let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+                walker_guard_class(ctx, op.pc, a_op, int_type_addr)?;
+                walker_guard_class(ctx, op.pc, b_op, int_type_addr)?;
+                walker_guard_exact_w_class(ctx, op.pc, a_op, int_typeobj)?;
+                walker_guard_exact_w_class(ctx, op.pc, b_op, int_typeobj)?;
+                let a_raw = walker_unbox_int_typed(
+                    ctx,
+                    op.pc,
+                    a_op,
+                    int_type_addr,
+                    crate::descr::int_intval_descr(),
+                )?;
+                let b_raw = walker_unbox_int_typed(
+                    ctx,
+                    op.pc,
+                    b_op,
+                    int_type_addr,
+                    crate::descr::int_intval_descr(),
+                )?;
+                let lt = ctx.trace_ctx.record_op(OpCode::IntLt, &[a_raw, b_raw]);
+                ctx.trace_ctx
+                    .set_opref_concrete(lt, Value::Int(i64::from(a_value < b_value)));
+                let guard_opcode = if a_value < b_value {
+                    OpCode::GuardTrue
+                } else {
+                    OpCode::GuardFalse
+                };
+                walker_emit_fold_guard_with_snapshot(ctx, op.pc, guard_opcode, &[lt])?;
+                write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', winner)?;
+                return Ok(Some(()));
+            }
+        }
         walker_guard_fold_callable(ctx, op.pc, r_args[0], concrete_callable)?;
         let raw = ctx.trace_ctx.call_ref_typed_with_effect(
             raw_fn as *const (),
@@ -11538,6 +11613,9 @@ pub(crate) fn try_walker_specialize_builtin_fold2<Sym: WalkSym>(
             // plain call ahead in 8 of 9 rounds.  A `w_class` that can be
             // proved away, or an int channel that answers with the winning
             // value instead of the winning object, is what would change that.
+            // It is also the arm for every shape the inline comparison
+            // declines: floats, equal values, tagged immediates, and any
+            // operand that is not an exact machine int.
             majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
         );
         // Concrete before the guard: the guard captures a resume snapshot, and

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -11403,11 +11403,18 @@ pub(crate) fn try_walker_specialize_builtin_fold1<Sym: WalkSym>(
                     continue;
                 }
                 walker_guard_fold_callable(ctx, op.pc, r_args[0], concrete_callable)?;
-                let raw = ctx.trace_ctx.call_int_typed_with_effect(
+                let raw = ctx.trace_ctx.call_typed_with_effect_pure(
+                    OpCode::CallI,
                     raw_fn as *const (),
                     &[r_args[2]],
                     &[majit_ir::Type::Ref],
-                    majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+                    majit_ir::Type::Int,
+                    majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+                    &[
+                        majit_ir::Value::Int(raw_fn as *const () as i64),
+                        majit_ir::Value::Ref(majit_ir::GcRef(operands[0] as usize)),
+                    ],
+                    majit_ir::Value::Int(value),
                 );
                 ctx.trace_ctx
                     .set_opref_concrete(raw, majit_ir::Value::Int(value));
@@ -11429,11 +11436,18 @@ pub(crate) fn try_walker_specialize_builtin_fold1<Sym: WalkSym>(
                     continue;
                 }
                 walker_guard_fold_callable(ctx, op.pc, r_args[0], concrete_callable)?;
-                let raw = ctx.trace_ctx.call_float_typed_with_effect(
+                let raw = ctx.trace_ctx.call_typed_with_effect_pure(
+                    OpCode::CallF,
                     raw_fn as *const (),
                     &[r_args[2]],
                     &[majit_ir::Type::Ref],
-                    majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+                    majit_ir::Type::Float,
+                    majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+                    &[
+                        majit_ir::Value::Int(raw_fn as *const () as i64),
+                        majit_ir::Value::Ref(majit_ir::GcRef(operands[0] as usize)),
+                    ],
+                    majit_ir::Value::Float(value),
                 );
                 ctx.trace_ctx
                     .set_opref_concrete(raw, majit_ir::Value::Float(value));
@@ -11509,6 +11523,21 @@ pub(crate) fn try_walker_specialize_builtin_fold2<Sym: WalkSym>(
             // their own arguments, so unlike the allocating ref helpers this
             // one really cannot collect -- which drops the gcmap bracket the
             // plain `CannotRaise` constructor would ask every backend for.
+            //
+            // The helper is a pure function of its pair, so this call could be
+            // recorded elidable the way the int and float channels are.  It is
+            // not, because it does not pay: what a caller does with the answer
+            // is unbox it, and the returned reference's `w_class` is not an
+            // immutable field, so the loop re-proves it every iteration before
+            // it can read `intval`.  The derived value therefore cannot cross
+            // the jump, and the optimizer re-materializes both calls at the
+            // end of the body to feed it -- leaving the loop paying the calls
+            // it already paid plus the re-check.  Measured on a
+            // `min(a, b) + max(a, b)` loop over 8M iterations, interleaved:
+            // 0.0515s as a plain call against 0.0541s as an elidable one, the
+            // plain call ahead in 8 of 9 rounds.  A `w_class` that can be
+            // proved away, or an int channel that answers with the winning
+            // value instead of the winning object, is what would change that.
             majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
         );
         // Concrete before the guard: the guard captures a resume snapshot, and

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -11894,11 +11894,11 @@ fn jit_merge_point_first_visit_continues_then_closes_loop() {
     ];
     // Model the trace as having STARTED at this loop header, so the second
     // arrival closes on the merge point the first arrival registered.  The
-    // arriving key is `make_green_key(pycode, next_instr)` from the green
+    // arriving key is `make_green_key` at `(pycode, next_instr)` from the green
     // concretes below.
     let mut tc = TraceCtx::for_test_types_with_green_key(
         &[Type::Ref],
-        crate::driver::make_green_key(0x1_0000 as *const (), 42),
+        crate::driver::make_green_key(0x1_0000 as *const (), 42, false),
     );
     let next_instr = tc.const_int(42); // gi[0] = Python pc
     let pycode = tc.const_ref(0x1_0000); // gr[0] = PyCode ptr
@@ -12057,7 +12057,7 @@ fn jit_merge_point_int_form_resolves_jdindex_from_the_int_bank() {
     let pycode_ptr = 0x1_0000usize;
     let mut tc = TraceCtx::for_test_types_with_green_key(
         &[Type::Ref],
-        crate::driver::make_green_key(pycode_ptr as *const (), 42),
+        crate::driver::make_green_key(pycode_ptr as *const (), 42, false),
     );
     let next_instr = tc.const_int(42);
     let unused = tc.const_int(99);

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -11433,8 +11433,12 @@ impl JitState for PyreJitState {
         if frame_ptr.is_null() {
             return None;
         }
-        let code = unsafe { (*frame_ptr).pycode };
-        Some(crate::driver::make_green_key(code, pc))
+        let frame = unsafe { &*frame_ptr };
+        Some(crate::driver::make_green_key(
+            frame.pycode,
+            pc,
+            frame.get_is_being_profiled(),
+        ))
     }
 
     fn code_ptr(&self) -> usize {
@@ -14677,6 +14681,7 @@ pub(crate) fn recover_inline_callee_globals(code_ptr: *const ()) -> pyre_object:
 /// stamps `parent_frames.first().pending_result_*`, which stays `None`.
 pub(crate) fn assemble_bridge_inline_pending(
     ctx: &mut TraceCtx,
+    is_being_profiled: bool,
     recipe: &ReconstructRecipe,
     execution_context: *const pyre_interpreter::PyExecutionContext,
     parent_frames: Vec<ResumeFrameState>,
@@ -14758,7 +14763,7 @@ pub(crate) fn assemble_bridge_inline_pending(
         // The reconstructed frame represents the same inlined call the
         // forward trace pushed at function entry; match its (code, 0)
         // greenkey identity for recursion-depth + inline-position tracking.
-        green_key: crate::driver::make_green_key(w_code, 0),
+        green_key: crate::driver::make_green_key(w_code, 0, is_being_profiled),
         green_key_raw: (w_code as usize, 0),
         parent_frames,
         nargs: recipe.nargs,
@@ -14792,6 +14797,7 @@ pub(crate) fn assemble_bridge_inline_pending(
 /// caller must invoke this at the point the callee frame is reconstructed.
 pub(crate) fn setup_reconstructed_callee_frame(
     ctx: &mut TraceCtx,
+    is_being_profiled: bool,
     recipe: &ReconstructRecipe,
     execution_context: *const pyre_interpreter::PyExecutionContext,
     ec_box: OpRef,
@@ -15030,7 +15036,13 @@ pub(crate) fn setup_reconstructed_callee_frame(
     drop(concrete_frame);
     drop(concrete_roots);
 
-    let mut pending = assemble_bridge_inline_pending(ctx, recipe, execution_context, parent_frames);
+    let mut pending = assemble_bridge_inline_pending(
+        ctx,
+        is_being_profiled,
+        recipe,
+        execution_context,
+        parent_frames,
+    );
     pending.sym.frame = frame_vable;
     pending.sym.concrete_vable_ptr = concrete_frame_ptr as *mut u8;
     // The portal reds are [frame, ec], force-alive at every pc; a guard snapshot

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -504,7 +504,7 @@ pub(crate) fn range_foriter_demoted(key: u64) -> bool {
 /// unrelated body guard at the same loop can never demote the site.
 ///
 /// `site_key` is the key the marker carries — the FOR_ITER's own
-/// `make_green_key(w_code, foriter_start_pc)`, which is what
+/// `make_green_key` at `(w_code, foriter_start_pc)`, which is what
 /// [`range_foriter_demoted`] is later asked about before the site specializes
 /// again.  It is not the key the failing trace was entered at.
 pub fn range_foriter_demote_once(site_key: u64) -> bool {
@@ -1241,7 +1241,13 @@ pub fn trace_bytecode<Sym: WalkSym>(
     // so the decline is permanent for this process: retraces bypass the
     // walker and the key re-interprets without JIT instead of being
     // permanently blacklisted (`DONT_TRACE_HERE`).
-    if carrier.is_none() && !fbw_declined(crate::driver::make_green_key(w_code, start_pc)) {
+    if carrier.is_none()
+        && !fbw_declined(crate::driver::make_green_key(
+            w_code,
+            start_pc,
+            concrete_frame.get_is_being_profiled(),
+        ))
+    {
         let action = full_body_walk_trace(ctx, sym, w_code, start_pc, cf_addr, WalkJournals::Reset);
         finish_trace_namespace_dependency(meta);
         return (action, concrete_frame);
@@ -1762,7 +1768,11 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
     let entry_depth = ctx.virtualref_boxes_len();
     let pre_virtualref_boxes = ctx.snapshot_virtualref_boxes();
     let pre_pos = ctx.get_trace_position();
-    let session = std::cell::RefCell::new(crate::jitcode_dispatch::WalkSession::default());
+    let is_being_profiled = crate::driver::frame_is_being_profiled(cf_addr);
+    let session = std::cell::RefCell::new(crate::jitcode_dispatch::WalkSession {
+        is_being_profiled,
+        ..Default::default()
+    });
     crate::jitcode_dispatch::fbw_finish_payload_reset();
     crate::jitcode_dispatch::fbw_store_journal_reset();
     // A prior walk's blackhole image must not be adopted as this drain's
@@ -1808,6 +1818,7 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
     // frame vable, not a callee MIFrame).
     let Some((pending, argboxes_r)) = crate::state::setup_reconstructed_callee_frame(
         ctx,
+        is_being_profiled,
         recipe,
         root_ec,
         root_ec_box,
@@ -2213,6 +2224,7 @@ fn drive_middle_frame_and_thread<Sym: WalkSym>(
     paused_parents: &[majit_metainterp::ReconstructRecipe],
     child_result: majit_ir::OpRef,
 ) -> Option<majit_ir::OpRef> {
+    let is_being_profiled = session.borrow().is_being_profiled;
     // `descr_call`'s tail: no frame to reconstruct and no bytecode to walk.
     // Discarding the child's result and answering with the instance IS its
     // whole body, so perform it here instead of driving a frame.
@@ -2244,6 +2256,7 @@ fn drive_middle_frame_and_thread<Sym: WalkSym>(
     }
     let Some((pending, middle_argboxes_r)) = crate::state::setup_reconstructed_callee_frame(
         ctx,
+        is_being_profiled,
         middle,
         root_ec,
         root_ec_box,
@@ -3514,7 +3527,11 @@ fn run_perfn_walk<Sym: WalkSym>(
     cf_addr: usize,
     authoritative: bool,
 ) -> Option<(usize, usize, PerfnWalkResult)> {
-    let session = std::cell::RefCell::new(crate::jitcode_dispatch::WalkSession::default());
+    let is_being_profiled = crate::driver::frame_is_being_profiled(cf_addr);
+    let session = std::cell::RefCell::new(crate::jitcode_dispatch::WalkSession {
+        is_being_profiled,
+        ..Default::default()
+    });
     let Some(pjc) = crate::state::pyjitcode_for_code(w_code) else {
         eprintln!("[walk-perfn] no per-CodeObject PyJitCode for code={w_code:?}");
         return None;
@@ -3570,7 +3587,11 @@ fn run_perfn_walk<Sym: WalkSym>(
             );
         }
         fbw_bridge_decline(ctx);
-        fbw_decline(crate::driver::make_green_key(w_code, start_pc));
+        fbw_decline(crate::driver::make_green_key(
+            w_code,
+            start_pc,
+            is_being_profiled,
+        ));
         return None;
     };
     // A kept-stack branch-guard bridge resumes at the guard's OWN mid-opcode
@@ -3603,7 +3624,11 @@ fn run_perfn_walk<Sym: WalkSym>(
                 );
             }
             fbw_bridge_decline(ctx);
-            fbw_decline(crate::driver::make_green_key(w_code, start_pc));
+            fbw_decline(crate::driver::make_green_key(
+                w_code,
+                start_pc,
+                is_being_profiled,
+            ));
             return None;
         }
     }
@@ -3622,7 +3647,11 @@ fn run_perfn_walk<Sym: WalkSym>(
             );
         }
         fbw_bridge_decline(ctx);
-        fbw_decline(crate::driver::make_green_key(w_code, start_pc));
+        fbw_decline(crate::driver::make_green_key(
+            w_code,
+            start_pc,
+            is_being_profiled,
+        ));
         return None;
     }
 
@@ -5870,6 +5899,7 @@ fn full_body_walk_trace<Sym: WalkSym>(
     cf_addr: usize,
     journals: WalkJournals,
 ) -> TraceAction {
+    let is_being_profiled = crate::driver::frame_is_being_profiled(cf_addr);
     // #125: decline up front when a loop body carries an `abort_permanent`
     // marker.  The authoritative walk would otherwise mis-seed the loop
     // guard, exit early, and concretely double-execute the post-loop tail;
@@ -5885,7 +5915,11 @@ fn full_body_walk_trace<Sym: WalkSym>(
             let owner = describe_abort_permanent_owner(w_code, abort_pc);
             eprintln!("[fbw-abort] start_pc={start_pc} abort_permanent_pc={abort_pc} {owner}");
         }
-        fbw_decline(crate::driver::make_green_key(w_code, start_pc));
+        fbw_decline(crate::driver::make_green_key(
+            w_code,
+            start_pc,
+            is_being_profiled,
+        ));
         return TraceAction::Decline;
     }
     if loop_iterates_send_generator(cf_addr, start_pc) {
@@ -5895,7 +5929,11 @@ fn full_body_walk_trace<Sym: WalkSym>(
                 "[fbw-abort] start_pc={start_pc} SEND generator iterator; declining before delegation"
             );
         }
-        fbw_decline(crate::driver::make_green_key(w_code, start_pc));
+        fbw_decline(crate::driver::make_green_key(
+            w_code,
+            start_pc,
+            is_being_profiled,
+        ));
         return TraceAction::Decline;
     }
     // Sibling defense to the above, transitively through inlined callees: a
@@ -5913,7 +5951,11 @@ fn full_body_walk_trace<Sym: WalkSym>(
                 hit.callee_name, hit.marker_jit_pc
             );
         }
-        fbw_decline(crate::driver::make_green_key(w_code, start_pc));
+        fbw_decline(crate::driver::make_green_key(
+            w_code,
+            start_pc,
+            is_being_profiled,
+        ));
         return TraceAction::Decline;
     }
     // Register the initial merge point with typed input-arg boxes so the trace head
@@ -5946,7 +5988,7 @@ fn full_body_walk_trace<Sym: WalkSym>(
     // treat the resume pc as a fresh loop header (the portal entry signature),
     // which only a MAIN trace should do.  So skip it for bridges.
     if !ctx.is_bridge_trace {
-        let start_key = crate::driver::make_green_key(w_code, start_pc);
+        let start_key = crate::driver::make_green_key(w_code, start_pc, is_being_profiled);
         let input_types = ctx.inputarg_types();
         let input_args: Vec<majit_metainterp::GreenBox> = input_types
             .iter()
@@ -5957,7 +5999,11 @@ fn full_body_walk_trace<Sym: WalkSym>(
             .collect();
         ctx.add_merge_point_with_key(
             start_key,
-            Some(crate::driver::make_green_key_typed(w_code, start_pc)),
+            Some(crate::driver::make_green_key_typed(
+                w_code,
+                start_pc,
+                is_being_profiled,
+            )),
             input_args,
             start_pc,
         );
@@ -5993,12 +6039,13 @@ fn full_body_walk_trace<Sym: WalkSym>(
                 // green key to the true merge point (cut-to-inner-loop);
                 // start_pc closes at the trace head.
                 if loop_header_pc != start_pc {
-                    let target_key = crate::driver::make_green_key(w_code, loop_header_pc);
+                    let target_key =
+                        crate::driver::make_green_key(w_code, loop_header_pc, is_being_profiled);
                     ctx.set_green_key(target_key, (w_code as usize, loop_header_pc));
                     ctx.header_pc = loop_header_pc;
                     ctx.cut_inner_green_key = Some(target_key);
                 } else {
-                    let key = crate::driver::make_green_key(w_code, start_pc);
+                    let key = crate::driver::make_green_key(w_code, start_pc, is_being_profiled);
                     ctx.set_green_key(key, (w_code as usize, start_pc));
                     ctx.header_pc = start_pc;
                 }
@@ -6172,7 +6219,11 @@ fn full_body_walk_trace<Sym: WalkSym>(
                 // concretely. Record the bridge-guard decline too, the way
                 // `ExcEdgeNoInFrameCatch` below does.
                 DE::GotoIfNotValueNotConcrete { .. } => {
-                    fbw_decline(crate::driver::make_green_key(w_code, start_pc));
+                    fbw_decline(crate::driver::make_green_key(
+                        w_code,
+                        start_pc,
+                        is_being_profiled,
+                    ));
                     fbw_bridge_decline(ctx);
                     TraceAction::Abort
                 }
@@ -6198,8 +6249,11 @@ fn full_body_walk_trace<Sym: WalkSym>(
             if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
                 eprintln!("[fbw-abort] start_pc={start_pc} run_perfn_walk returned None");
             }
-            if fbw_declined(crate::driver::make_green_key(w_code, start_pc))
-                || (ctx.is_bridge_trace && FBW_BRIDGE_DECLINED.with(|c| c.get()))
+            if fbw_declined(crate::driver::make_green_key(
+                w_code,
+                start_pc,
+                is_being_profiled,
+            )) || (ctx.is_bridge_trace && FBW_BRIDGE_DECLINED.with(|c| c.get()))
             {
                 TraceAction::Decline
             } else {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1639,7 +1639,7 @@ pub extern "C" fn jit_force_self_recursive_call_raw_1(caller_frame: i64, raw_int
     }
     let caller = unsafe { &*(caller_frame as *const PyFrame) };
     let w_code = caller.pycode;
-    let green_key = crate::eval::make_green_key(w_code, 0);
+    let green_key = crate::eval::make_green_key(w_code, 0, caller.get_is_being_profiled());
     let _token_num = self_recursive_dispatch(green_key);
 
     let boxed = pyre_object::intobject::w_int_new(raw_int_arg);
@@ -2078,8 +2078,8 @@ fn jit_blackhole_resume_from_guard(
         None if num_fail_values >= 1 => {
             let frame_ptr = fail_values[0] as *const pyre_interpreter::pyframe::PyFrame;
             if !frame_ptr.is_null() {
-                let code = unsafe { (*frame_ptr).pycode };
-                crate::eval::make_green_key(code, 0)
+                let frame = unsafe { &*frame_ptr };
+                crate::eval::make_green_key(frame.pycode, 0, frame.get_is_being_profiled())
             } else {
                 0
             }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6020,11 +6020,7 @@ fn green_key_from_pycode(
     if code_ptr.is_null() {
         return None;
     }
-    Some(majit_ir::pypyjit_greenkey_uhash(
-        next_instr,
-        is_being_profiled,
-        code_ptr as u64,
-    ))
+    Some(make_green_key(code_ptr, next_instr, is_being_profiled))
 }
 
 /// The typed `GreenKey` behind [`green_key_from_pycode`]'s `u64`.
@@ -6514,17 +6510,13 @@ pub(crate) fn call_depth() -> u32 {
 /// Each (code, pc) pair has independent warmup counter and compiled loop.
 // dont_look_inside: green-key construction (pypyjit_greenkey_uhash); JIT-driver machinery.
 #[majit_macros::dont_look_inside]
-pub fn make_green_key(code_ptr: *const (), pc: usize) -> u64 {
+pub fn make_green_key(code_ptr: *const (), pc: usize, is_being_profiled: bool) -> u64 {
     // Full `JitCell.get_uhash` over the pypyjit green tuple
     // `[next_instr, is_being_profiled, pycode]` (warmstate.py:584-593),
-    // computed allocation-free. `is_being_profiled` folds to 0 (the JIT
-    // path is never profiled), so this matches the typed marker-path key
-    // and both lookups resolve to the same cell.
-    majit_ir::pypyjit_greenkey_uhash(
-        pc,
-        pyre_interpreter::executioncontext::current_is_being_profiled(),
-        code_ptr as u64,
-    )
+    // computed allocation-free. The caller supplies the same frame green used
+    // by the portal markers, so this and the typed marker-path key resolve to
+    // the same cell.
+    majit_ir::pypyjit_greenkey_uhash(pc, is_being_profiled, code_ptr as u64)
 }
 
 // JIT_CALL_DEPTH removed — pyre-interpreter::call::PY_RECURSION_DEPTH is the
@@ -6731,8 +6723,9 @@ fn unpack_merge_point_jit(
     }
     // baseobjspace.py iterator_greenkey → space.type(w_iterable): a per-type
     // singleton, so its address hashes to one stable green key per iterator type
-    // (`pc = 0`, novable — no bytecode offset).
-    let green_key = make_green_key(greenkey as *const (), 0);
+    // (`pc = 0`, novable — no bytecode offset). The jd1 driver has no
+    // `is_being_profiled` green, so its pypyjit-shaped key uses false.
+    let green_key = make_green_key(greenkey as *const (), 0, false);
     if !jd1_counter_tick(green_key) {
         return;
     }
@@ -6875,7 +6868,7 @@ fn drive_unpack_iterable_trace(
     // (`JitCell.comparekey` is what selects a cell within its bucket,
     // warmstate.py `def comparekey(self, *greenargs2)`), so the same
     // green key can go on to own a second cell in the same bucket, with its own
-    // token and flags. `green_key` is `make_green_key(greenkey_raw, 0)` (above),
+    // token and flags. `green_key` is `make_green_key` at `(greenkey_raw, 0)` (above),
     // so the pair reconstructs the identical hash.
     let action = meta.force_start_tracing(
         green_key,
@@ -9098,7 +9091,11 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 // can_enter_jit is a lowered no-op / merge point; re-seed
                 // conservatively before the next frame reads.
                 let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
-                let green_key = make_green_key(unsafe { &*f }.pycode, loop_header_pc);
+                let green_key = make_green_key(
+                    unsafe { &*f }.pycode,
+                    loop_header_pc,
+                    unsafe { &*f }.get_is_being_profiled(),
+                );
                 if let Some(loop_result) = maybe_compile_and_run(
                     unsafe { &mut *f },
                     green_key,
@@ -9631,7 +9628,7 @@ fn handle_fail(
     //
     // The demotion registry is keyed on the FOR_ITER SITE, which is what the
     // marker carries and what `walker_foriter_green_key` reads back before
-    // specializing again — `make_green_key(w_code, foriter_start_pc)` for the
+    // specializing again — `make_green_key` at `(w_code, foriter_start_pc)` for the
     // FOR_ITER the guard protects, not for the loop this trace was entered at.
     // Those differ whenever the specialized FOR_ITER is not the entry header
     // itself (an inner loop inside a trace entered at an outer one), and
@@ -10769,7 +10766,11 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
             }
         }
     }
-    let green_key = make_green_key(frame_root.frame().pycode, frame_root.frame().next_instr());
+    let green_key = make_green_key(
+        frame_root.frame().pycode,
+        frame_root.frame().next_instr(),
+        frame_root.frame().get_is_being_profiled(),
+    );
     let (driver, info) = driver_pair();
 
     // RPython warmstate.py maybe_compile_and_run fast path:

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6009,14 +6009,22 @@ pub fn _call_not_in_trace(
 }
 
 #[inline]
-fn green_key_from_pycode(next_instr: usize, w_pycode: pyre_object::PyObjectRef) -> Option<u64> {
+fn green_key_from_pycode(
+    next_instr: usize,
+    is_being_profiled: bool,
+    w_pycode: pyre_object::PyObjectRef,
+) -> Option<u64> {
     // Safety: this follows existing wrappers that treat `PyCode`
     // as an owned pointer to a `CodeObject`.
     let code_ptr = unsafe { pyre_interpreter::pycode::w_code_get_ptr(w_pycode) };
     if code_ptr.is_null() {
         return None;
     }
-    Some(make_green_key(code_ptr, next_instr))
+    Some(majit_ir::pypyjit_greenkey_uhash(
+        next_instr,
+        is_being_profiled,
+        code_ptr as u64,
+    ))
 }
 
 /// The typed `GreenKey` behind [`green_key_from_pycode`]'s `u64`.
@@ -6028,11 +6036,14 @@ fn green_key_from_pycode(next_instr: usize, w_pycode: pyre_object::PyObjectRef) 
 /// warmstate.py:575-582). Callers that read a cell take this; callers that
 /// only tick a counter can keep the hash.
 ///
-/// `is_being_profiled` comes from `current_is_being_profiled` here **because
-/// [`make_green_key`] reads it from the same place** — the two must agree or
-/// the typed and hash paths would resolve to different cells.
+/// `is_being_profiled` is the caller's own green, not a re-derivation of it.
+/// `interp_jit.py` hands each of these entry points' `is_being_profiled`
+/// straight to `jit_hooks`, so a caller naming one half of the key reaches
+/// that half; deriving the green here instead would answer about whichever
+/// cell the running profile state selects and silently ignore the argument.
 fn green_key_typed_from_pycode(
     next_instr: usize,
+    is_being_profiled: bool,
     w_pycode: pyre_object::PyObjectRef,
 ) -> Option<majit_ir::GreenKey> {
     // Safety: as `green_key_from_pycode` — `PyCode` is an owned pointer to a
@@ -6043,7 +6054,7 @@ fn green_key_typed_from_pycode(
     }
     Some(majit_ir::pypyjit_greenkey(
         next_instr,
-        pyre_interpreter::executioncontext::current_is_being_profiled(),
+        is_being_profiled,
         code_ptr as u64,
     ))
 }
@@ -6152,13 +6163,13 @@ pub fn should_unroll_one_iteration(
 pub fn get_jitcell_at_key(
     _space: pyre_object::PyObjectRef,
     next_instr: usize,
-    _is_being_profiled: bool,
+    is_being_profiled: bool,
     w_pycode: pyre_object::PyObjectRef,
 ) -> pyre_object::PyObjectRef {
     // warmstate.py `get_jit_cell_at_key(greenkey)` unwraps the
     // greenkey and hands the green *args* to `get_jitcell`. The green args
     // are this function's own parameters, so the typed key costs no plumbing.
-    let key = green_key_typed_from_pycode(next_instr, w_pycode);
+    let key = green_key_typed_from_pycode(next_instr, is_being_profiled, w_pycode);
     let (driver, _) = driver_pair();
     w_bool_from(key.is_some_and(|green_key| {
         driver
@@ -6174,13 +6185,14 @@ pub fn get_jitcell_at_key(
 pub fn dont_trace_here(
     _space: pyre_object::PyObjectRef,
     next_instr: usize,
-    _is_being_profiled: bool,
+    is_being_profiled: bool,
     w_pycode: pyre_object::PyObjectRef,
 ) {
     // warmstate.py `dont_trace_here(*greenargs)` reaches its cell
     // through `_ensure_jit_cell_at_key(*greenargs)`, by comparekey. The green
     // args are this function's parameters.
-    let Some(green_key) = green_key_typed_from_pycode(next_instr, w_pycode) else {
+    let Some(green_key) = green_key_typed_from_pycode(next_instr, is_being_profiled, w_pycode)
+    else {
         return;
     };
     let (driver, _) = driver_pair();
@@ -6195,13 +6207,14 @@ pub fn dont_trace_here(
 pub fn mark_as_being_traced(
     _space: pyre_object::PyObjectRef,
     next_instr: usize,
-    _is_being_profiled: bool,
+    is_being_profiled: bool,
     w_pycode: pyre_object::PyObjectRef,
 ) {
     // warmstate.py `mark_as_being_traced(*greenargs)` reaches its cell
     // through `_ensure_jit_cell_at_key(*greenargs)`, by comparekey. The green
     // args are this function's parameters.
-    let Some(green_key) = green_key_typed_from_pycode(next_instr, w_pycode) else {
+    let Some(green_key) = green_key_typed_from_pycode(next_instr, is_being_profiled, w_pycode)
+    else {
         return;
     };
     let (driver, _) = driver_pair();
@@ -6225,10 +6238,10 @@ pub fn mark_as_being_traced(
 pub fn trace_next_iteration(
     _space: pyre_object::PyObjectRef,
     next_instr: usize,
-    _is_being_profiled: bool,
+    is_being_profiled: bool,
     w_pycode: pyre_object::PyObjectRef,
 ) {
-    let Some(green_key) = green_key_from_pycode(next_instr, w_pycode) else {
+    let Some(green_key) = green_key_from_pycode(next_instr, is_being_profiled, w_pycode) else {
         return;
     };
     let (driver, _) = driver_pair();


### PR DESCRIPTION
Rebased onto `origin/main` (`786365fe7ce`). Seven commits, in three groups.

## The portal green stops being read from ambient state

`744faf2034b`, `64c30fff3ae`. The four green-key entry points were handed a
green and then read a second one out of ambient state anyway; they now use the
one they were given, and `drive_bridge_carrier_walk` seeds its `WalkSession`
with the root frame's `is_being_profiled` instead of leaving it default.

## Three folds stop calling

`0f3b5c56d0b` — the `Int1` and `Float1` builtin fold channels.
`8a2c163cd45` + `bd1f3c94737` — `min` / `max` over an exact-int pair.
`c9fcbce4fe3` — the ten math fold sites.

The first and third go through `call_typed_with_effect_pure` with a new
`ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO`, so `record_result_of_call_pure`
patches them to `CallPure*` and `optimize_CALL_PURE` serves the peeled body's
copy from the preamble's. The constant is new because every existing
`ELIDABLE_*` goes through `EffectInfo::const_new`, which sets
`can_collect = true`; `EffectInfo.__new__` takes `can_collect` as its own
parameter and `effectinfo_from_writeanalyze` forces it true only for
`extraeffect >= EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE`, while
`EF_ELIDABLE_CANNOT_RAISE` is 0.

`min` / `max` is the channel where elidable **loses** — measured 0.0515s plain
against 0.0541s elidable, plain ahead in 8 of 9 rounds, because the answer is a
reference whose `w_class` is not immutable, so the loop re-proves it every
iteration and the derived value cannot cross the jump. What works there is
emitting no call at all: for two exact machine ints of distinct value, guard
the ordering of the two unboxed values and write the winning operand's own
`OpRef`. Under a fixed ordering the winner is determined for either comparison
direction, so the arm needs no min-versus-max branch and allocates nothing.

The `a >= b` arm records `GuardFalse(IntLt(a, b))`, which admits a later tie.
On a tie `min_max_multiple_args` keeps its first argument while this arm may
hand back the second — sound only because `is_w` compares exact ints by value,
which is stated in the code rather than left implicit. Recording only ever
starts from a pair that already differs.

For the math sites, `ll_math` marks only `copysign`, `floor`, `sin`, `cos` and
the domain-guarded `sqrt_nonneg` elidable; the rest are held back by `save_err`
or an out-pointer. Neither reason transfers: these helpers read no errno and
return by value, and `frexp`'s components come back from two separate helpers.
`Value`'s float equality is bitwise, so `-0.0` is never served from a `0.0`
entry.

### Structural discriminator (load-independent), peeled body

| channel | body calls before | after |
|---|---|---|
| `hash_int` / `ord` / `abs_int` | 1 | **0** (13 ops) |
| `hash_str` | 1 | **0** (17 ops) |
| `abs_float` | 1 | **0** (14 ops) |
| `min_max` | 2 `CallR` | **0** (27 -> 19 ops, 22 -> 21 guards) |
| math `sqrt`/`log`/`floor`/`tan`/`pow`/`isqrt`/`ldexp`/`frexp`, invariant operand | 1-3 | **0** |
| the same math channels, operand from the counter | 1-3 | unchanged |

`min_max`'s whole `min + max` sum hoists into one `Label` constant; the body's
entire residue is the two operands' `w_class` `PtrEq`/`GuardTrue` pairs plus
one `IntLt`/`GuardTrue`. `isclose` is the one math fold that does not move even
on an invariant operand: its answer is consumed by the branch's own guard and
never reaches the `Jump`.

### Timings, darwin-arm64, interleaved in-tree control

`min_max` over 8M iterations, 11 rounds: median 0.0537s -> **0.0116s (4.6x),
11/11**. ns/iter 6.71 -> 1.45 against pypy 7.3.20's 0.88, so 7.6x -> **1.6x**.

Math folds, 4M iterations, 7 rounds, invariant operand, each ahead 7/7:
`pow`/`atan2` 6.2x, `tan`/`exp` 3.5x, `log`/`cos`/`sin` 3.3x, `frexp` 2.1x,
`ldexp` 1.9x, `floor`/`ceil` 1.4x, `isqrt` 1.2x, `sqrt` 1.05x. With an operand
that varies, all eighteen loops read 0.99-1.01x.

## Fixture headers corrected to what is recorded

`1e28c04e1da` rewrites `inline_freevar_after_mayforce`'s header to the counters
it actually gates, and the two `_folds_hot` headers record what moved.

## Gates

Run from the workspace root at `bd1f3c94737`, LLBC re-extracted for the new
base (`--check` rc=0), HEAD stamped identical before and after.

| gate | result |
|---|---|
| dynasm | **ALL PASSED 462/462** |
| cranelift | 461/462 — one ratio red, discriminated below |
| dynasm,wasm (one invocation) | **dynasm 462/462 + wasm 454/454** |

`synth/generator_tree_recursion` read 9.1x against its 7.6x ceiling on the
cranelift leg. **It is not this branch's**: the fixture and its jitstats are
untouched here (empty diff against `origin/main`), and it reads 3.9x on the
dynasm leg of the very same suite. Scoped and repeated four times it passes
4/4 (5.4x, 6.4x, 6.5x, 8.3x). Its pypy denominator is 0.04-0.05s, at the
measurement floor, and this box was carrying three sibling worktrees building
concurrently at load average 20-35.

Two `BANDED` rows are pre-existing and inside their declared bands:
`inline_freevar_after_mayforce` guard_failures 1005 -> 1004 on dynasm and
1009 -> 1010 on cranelift, band 8, with `loops_compiled=7` and
`bridges_compiled=5` unchanged on both.

Coverage for the shapes the min/max arm introduces went into
`extra_tests/snippets/builtin_jit_folds.py` as a loop whose operand pair
changes — every pair already there is a loop invariant, so none of them
exercise the guards' side exits.

## Rebase notes

Three conflict regions, each judged on its own:

- `trace.rs` — took this branch's `is_being_profiled` seeding and **dropped**
  the `bool_box_truth_reset()` call, because `2cc8a5604bb` removed that side
  table on main and the symbol no longer exists.
- `builtin_folds_hot.py`, first region — kept the elidable paragraph, dropped
  the `max-wasm-ratio=13` directive: `e3d296ebe8a` retired every
  `max-wasm-ratio` in `pyre/bench` by vouching the mixed-ABI helper for
  in-module lowering.
- `builtin_folds_hot.py`, second region — took main's paragraph. This branch's
  version described a world where the `env.jit_call` trampoline is still the
  crossing and the allowance still stands; main removed both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFbvNce7TD6xB2Xe2Zh3Vs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved JIT optimization for `min` and `max` with exact integer values, reducing unnecessary calls and allocations.
  * Improved optimization of pure, repeatable math and builtin operations in compiled code.
  * Profiling-aware compilation now keeps profiled and unprofiled execution paths distinct.

* **Bug Fixes**
  * Added coverage for varying operands, ties, ordering changes, and floating-point values in compiled `min`/`max` operations.

* **Documentation**
  * Updated benchmark and optimization notes to reflect current behavior and performance measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->