### PR TITLE
majit: port the execute_and_record fold funnel and route the tracer's record sites through it

### DIFF
--- a/majit/majit-backend/src/call_stub.rs
+++ b/majit/majit-backend/src/call_stub.rs
@@ -1089,6 +1089,12 @@ macro_rules! dispatch_classes_body {
 /// `extern "C" fn(...) -> i64` whose parameter list is the same ordered
 /// Int/Float sequence and whose float slots are carried in `args` as
 /// `f64::to_bits`.
+///
+/// The `-> i64` is a requirement on the target, not a convenience of the
+/// transmute: this reads the whole return register, and a callee whose result
+/// is narrower leaves the bits above it undefined. `#[jit_interp]` meets it by
+/// registering a widening shim in place of such a target — see
+/// `majit_ir::CallResultWord`.
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -8843,7 +8843,23 @@ pub fn make_field_descr(
     field_type: Type,
     flag: ArrayFlag,
 ) -> DescrRef {
-    Arc::new(SimpleFieldDescr::new(0, offset, field_size, field_type, false).with_flag(flag))
+    make_field_descr_with_immutability(offset, field_size, field_type, flag, false)
+}
+
+/// [`make_field_descr`] for a caller that knows the field's
+/// `_immutable_fields_` declaration.
+///
+/// Discarding it is not free: `is_always_pure` is what licenses the
+/// constant fold of a read off a constant struct, so a descr that arrives
+/// here immutable and leaves mutable silently costs that fold.
+pub fn make_field_descr_with_immutability(
+    offset: usize,
+    field_size: usize,
+    field_type: Type,
+    flag: ArrayFlag,
+    is_immutable: bool,
+) -> DescrRef {
+    Arc::new(SimpleFieldDescr::new(0, offset, field_size, field_type, is_immutable).with_flag(flag))
 }
 
 /// Create a field descriptor whose `parent_descr` back-references an existing

--- a/majit/majit-ir/src/lib.rs
+++ b/majit/majit-ir/src/lib.rs
@@ -50,9 +50,9 @@ pub use resoperation::{
     Op, OpCode, OpRc, OpRef, RdVirtualInfo, VectorizationInfo, VirtualFieldsInfo, format_trace,
 };
 pub use value::{
-    Const, FAILARGS_LIMIT, GREEN_UHASH_MULT, GREEN_UHASH_SEED, GcRef, GreenAsI64, GreenKey,
-    GreenType, InputArg, InputArgRc, JitDriverVar, RefReleaseFn, RefRetainFn, RetainedGreens,
-    SharedConstPool, StrEqFn, StrHashFn, Type, Value, VarKind, green_type_to_ir, green_uhash_step,
-    make_str_slot, pypyjit_greenkey, pypyjit_greenkey_uhash, set_ref_resolver, set_str_resolver,
-    set_unicode_resolver,
+    CallResultWord, Const, FAILARGS_LIMIT, GREEN_UHASH_MULT, GREEN_UHASH_SEED, GcRef, GreenAsI64,
+    GreenKey, GreenType, InputArg, InputArgRc, JitDriverVar, RefReleaseFn, RefRetainFn,
+    RetainedGreens, SharedConstPool, StrEqFn, StrHashFn, Type, Value, VarKind, green_type_to_ir,
+    green_uhash_step, make_str_slot, pypyjit_greenkey, pypyjit_greenkey_uhash, set_ref_resolver,
+    set_str_resolver, set_unicode_resolver,
 };

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -2223,6 +2223,41 @@ impl OpCode {
         (ALWAYS_PURE_FIRST..=ALWAYS_PURE_LAST).contains(&n)
     }
 
+    /// `resoperation.py` `OpHelpers.is_pure_with_descr` — the predicate
+    /// `MIFrame.execute_and_record` consults before folding an operation
+    /// on all-constant arguments. Always-pure opcodes fold on the opcode
+    /// alone; the reads listed below fold only when their descr declares
+    /// the location immutable.
+    ///
+    /// `GETARRAYITEM_GC_*` is deliberately absent from the descr-gated
+    /// list. An immutable GC array read is spelled with the dedicated
+    /// `GETARRAYITEM_GC_PURE_*` opcode, which the always-pure range
+    /// already admits; the plain GC read stays foldable never, whatever
+    /// its descr says.
+    ///
+    /// A `None` descr answers `false` for the gated opcodes, matching the
+    /// explicit `descr is not None` guard `OpHelpers.is_pure_getfield`
+    /// spells for the same question.
+    pub fn is_pure_with_descr(self, descr: Option<&DescrRef>) -> bool {
+        if self.is_always_pure() {
+            return true;
+        }
+        if matches!(
+            self,
+            OpCode::GetfieldRawI
+                | OpCode::GetfieldRawR
+                | OpCode::GetfieldRawF
+                | OpCode::GetfieldGcI
+                | OpCode::GetfieldGcR
+                | OpCode::GetfieldGcF
+                | OpCode::GetarrayitemRawI
+                | OpCode::GetarrayitemRawF
+        ) {
+            return descr.is_some_and(|d| d.is_always_pure());
+        }
+        false
+    }
+
     pub fn has_no_side_effect(self) -> bool {
         let n = self.as_u16();
         (NOSIDEEFFECT_FIRST..=NOSIDEEFFECT_LAST).contains(&n)
@@ -5468,5 +5503,58 @@ mod tests {
         // Sentinel range stays out of the constant namespace.
         assert!(!OpRef::raw_is_constant(u32::MAX));
         assert!(!OpRef::raw_is_constant(u32::MAX - 1));
+    }
+
+    /// Pins `OpHelpers.is_pure_with_descr`, the predicate
+    /// `MIFrame.execute_and_record` consults before folding on all-constant
+    /// arguments.
+    #[test]
+    fn is_pure_with_descr_admits_only_the_upstream_opcode_list() {
+        let field = |is_immutable: bool| -> DescrRef {
+            std::sync::Arc::new(crate::descr::SimpleFieldDescr::new_with_name(
+                0,
+                0,
+                8,
+                Type::Int,
+                is_immutable,
+                crate::descr::ArrayFlag::Signed,
+                "f".to_string(),
+                "f".to_string(),
+            ))
+        };
+        let immutable = field(true);
+        let mutable = field(false);
+
+        // An always-pure opcode answers on the opcode alone, descr or not.
+        assert!(OpCode::IntAdd.is_pure_with_descr(None));
+        assert!(OpCode::IntAdd.is_pure_with_descr(Some(&mutable)));
+
+        // The gated reads follow their descr, and a missing descr is a no.
+        for opcode in [
+            OpCode::GetfieldGcI,
+            OpCode::GetfieldGcR,
+            OpCode::GetfieldGcF,
+            OpCode::GetfieldRawI,
+            OpCode::GetfieldRawR,
+            OpCode::GetfieldRawF,
+            OpCode::GetarrayitemRawI,
+            OpCode::GetarrayitemRawF,
+        ] {
+            assert!(opcode.is_pure_with_descr(Some(&immutable)), "{opcode:?}");
+            assert!(!opcode.is_pure_with_descr(Some(&mutable)), "{opcode:?}");
+            assert!(!opcode.is_pure_with_descr(None), "{opcode:?}");
+        }
+
+        // `GETARRAYITEM_GC_*` is absent from that list at any descr: an
+        // immutable GC array read is spelled `GETARRAYITEM_GC_PURE_*`, which
+        // the always-pure range admits on its own.
+        for opcode in [
+            OpCode::GetarrayitemGcI,
+            OpCode::GetarrayitemGcR,
+            OpCode::GetarrayitemGcF,
+        ] {
+            assert!(!opcode.is_pure_with_descr(Some(&immutable)), "{opcode:?}");
+        }
+        assert!(OpCode::GetarrayitemGcPureI.is_pure_with_descr(None));
     }
 }

--- a/majit/majit-ir/src/value.rs
+++ b/majit/majit-ir/src/value.rs
@@ -1330,6 +1330,64 @@ impl<T: ?Sized> GreenAsI64 for &mut T {
     }
 }
 
+/// Widens a registered call target's result to the machine word a trace
+/// register holds it in.
+///
+/// A target registered through `#[jit_interp]`'s `calls = { ... }` is
+/// dispatched by `majit_backend::call_stub::bh_call_i_dispatch`, which
+/// transmutes the recorded address to `extern "C" fn(..) -> i64` and reads the
+/// whole return register. Neither the System V AMD64 nor the AAPCS procedure
+/// call standard defines the bits above a result narrower than a word, and
+/// compilers use that freedom: an x86-64 callee returning `u8` from an array
+/// read compiles to `mov al, [rax + rcx]`, leaving the element's own address in
+/// the rest of `rax`. Read as an `i64` the result is then an address wearing
+/// the returned byte as its low bits, so the damage surfaces far from the call
+/// as an out-of-range index rather than as a crash at the call itself.
+/// AArch64's `ldrb` zero-extends, which is why the same build is correct
+/// there.
+///
+/// So the macro does not read a callee's return register directly. It routes
+/// every int-result target through a shim returning `i64`, and the register is
+/// defined by construction. A result that is not one of the types below — a
+/// `#[repr(transparent)]` wrapper over a word, say — has to implement this
+/// before it can be registered; the widening it wants is not something the
+/// macro can guess.
+pub trait CallResultWord {
+    fn into_call_word(self) -> i64;
+}
+
+macro_rules! impl_call_result_word_int {
+    ($($ty:ty),*) => {
+        $(
+            impl CallResultWord for $ty {
+                #[inline(always)]
+                fn into_call_word(self) -> i64 {
+                    self as i64
+                }
+            }
+        )*
+    };
+}
+
+// `as i64` per type, so each width extends the way the language says it does:
+// signed types sign-extend, unsigned types zero-extend, and the word-width
+// types are the identity.
+impl_call_result_word_int!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, bool);
+
+impl<T: ?Sized> CallResultWord for *const T {
+    #[inline(always)]
+    fn into_call_word(self) -> i64 {
+        self as *const () as usize as i64
+    }
+}
+
+impl<T: ?Sized> CallResultWord for *mut T {
+    #[inline(always)]
+    fn into_call_word(self) -> i64 {
+        self as *const () as usize as i64
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1568,5 +1626,27 @@ mod tests {
                 "greenkey types mismatch for (pc={pc}, profiled={profiled}, code={code:#x})"
             );
         }
+    }
+
+    /// Each width extends the way the language says it does, so a caller
+    /// reading the whole register recovers the value the callee returned and
+    /// not a sign-flipped or truncated one.
+    #[test]
+    fn call_result_words_extend_by_signedness() {
+        assert_eq!((-1i8).into_call_word(), -1);
+        assert_eq!(0xffu8.into_call_word(), 255);
+        assert_eq!((-1i32).into_call_word(), -1);
+        assert_eq!(u32::MAX.into_call_word(), 4_294_967_295);
+        assert_eq!(i64::MIN.into_call_word(), i64::MIN);
+        assert_eq!(usize::MAX.into_call_word(), -1);
+        assert_eq!(true.into_call_word(), 1);
+        assert_eq!(false.into_call_word(), 0);
+    }
+
+    #[test]
+    fn call_result_words_carry_a_pointer_whole() {
+        let x = 7u32;
+        let p: *const u32 = &x;
+        assert_eq!(p.into_call_word() as usize, p as usize);
     }
 }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -936,7 +936,7 @@ fn lower_extended_arg_inner_while_body(
 }
 
 /// Match `Stmt::Local { pat: Pat::Ident(X), init: Some(program[<idx>]) }`.
-/// If `X` is in `inner_alias`, emit `BC_GETARRAYITEM_GC_I` writing into
+/// If `X` is in `inner_alias`, emit `BC_GETARRAYITEM_GC_I_PURE` writing into
 /// the aliased outer register and re-bind `X → outer_reg`. Otherwise
 /// fall through to the existing `try_lower_opcode_fetch_stmt` (which
 /// allocates a fresh register).
@@ -986,7 +986,9 @@ fn try_lower_inner_byte_fetch(
         ),
         quote! {
             let __descr_idx = #descr_tok;
-            __builder.getarrayitem_gc_i(
+            // Reads the same immutable env array as the outer fetch, so the
+            // same always-pure spelling.
+            __builder.getarrayitem_gc_i_pure(
                 #aliased_reg as u16,
                 #program_reg as u16,
                 #index_reg as u16,
@@ -1428,7 +1430,11 @@ fn try_lower_opcode_fetch_stmt(lowerer: &mut Lowerer, stmt: &Stmt) -> bool {
                 ),
                 quote::quote! {
                     let __descr_idx = #descr_tok;
-                    __builder.getarrayitem_gc_i(
+                    // The bytecode array is fixed once the program is built,
+                    // so the read is spelled with the always-pure opcode and
+                    // the tracer folds it at a green index on the strength of
+                    // that spelling rather than on who the caller is.
+                    __builder.getarrayitem_gc_i_pure(
                         #result_reg as u16,
                         #program_reg as u16,
                         #index_reg as u16,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
@@ -634,3 +634,41 @@ pub(super) fn opcode_for_assign_binop_f(op: &BinOp) -> Option<Ident> {
     };
     Some(Ident::new(name, proc_macro2::Span::call_site()))
 }
+
+/// The address of a shim that returns `func`'s result as a machine word.
+///
+/// Registered addresses are dispatched through
+/// `majit_backend::call_stub::bh_call_i_dispatch`, which transmutes them to
+/// `extern "C" fn(..) -> i64` and reads the whole return register. A callee
+/// whose result is narrower than a word leaves the bits above it undefined —
+/// see [`majit_ir::CallResultWord`] for what that costs — so the register is
+/// not readable as an `i64` unless the callee is known to fill it. Registering
+/// a shim rather than the callee itself makes that true of every target.
+///
+/// The shim's parameter types come from `func` itself: the annotation supplies
+/// the `extern`-free `fn` shape and the call in the body resolves each hole, so
+/// no argument type has to be spelled here. `arity` counts the receiver for a
+/// method path.
+pub(super) fn word_result_addr_tokens(func: &impl ToTokens, arity: usize) -> TokenStream {
+    let params: Vec<Ident> = (0..arity).map(|i| format_ident!("__majit_a{i}")).collect();
+    let holes: Vec<TokenStream> = (0..arity).map(|_| quote! { _ }).collect();
+    quote! {
+        {
+            let __majit_word_shim: fn(#(#holes),*) -> i64 = |#(#params),*| {
+                majit_ir::CallResultWord::into_call_word(#func(#(#params),*))
+            };
+            __majit_word_shim as *const ()
+        }
+    }
+}
+
+/// [`word_result_addr_tokens`] for a target whose result kind is `kind`, and
+/// `None` for a kind that has no narrow result to widen: a ref result is a
+/// pointer, which already fills the register, and a void result is never read.
+pub(super) fn word_result_addr_for_kind(
+    kind: BindingKind,
+    func: &impl ToTokens,
+    arity: usize,
+) -> Option<TokenStream> {
+    matches!(kind, BindingKind::Int).then(|| word_result_addr_tokens(func, arity))
+}

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
@@ -649,6 +649,16 @@ pub(super) fn opcode_for_assign_binop_f(op: &BinOp) -> Option<Ident> {
 /// the `extern`-free `fn` shape and the call in the body resolves each hole, so
 /// no argument type has to be spelled here. `arity` counts the receiver for a
 /// method path.
+///
+/// `extern`-free is also all this can be. A non-capturing closure coerces to
+/// `fn(..)` and not to `extern "C" fn(..)`, and an `extern "C"` fn item has to
+/// spell parameter types that only inference knows here — so the shim carries
+/// the Rust ABI, as the callee it stands in for does. The C ABI that both the
+/// dispatch and the compiled call name is answered where a helper's signature
+/// is in scope instead: `#[elidable]` and its siblings emit an
+/// `extern "C" fn(..) -> i64` call-target wrapper and register that. A
+/// `calls = { .. }` entry naming a function that carries no such attribute has
+/// no wrapper to reach for.
 pub(super) fn word_result_addr_tokens(func: &impl ToTokens, arity: usize) -> TokenStream {
     let params: Vec<Ident> = (0..arity).map(|i| format_ident!("__majit_a{i}")).collect();
     let holes: Vec<TokenStream> = (0..arity).map(|_| quote! { _ }).collect();

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -916,6 +916,7 @@ impl<'c> Lowerer<'c> {
             slot,
             is_inferred,
             inferred_policy_check,
+            None,
         );
         self.emit_op(
             OpMeta::linear(OpKind::Call, arg_regs, vec![]),
@@ -1062,6 +1063,7 @@ impl<'c> Lowerer<'c> {
             slot,
             is_inferred,
             inferred_policy_check,
+            word_result_addr_for_kind(value_kind, func_path, func_args.len()),
         );
         self.emit_op(
             OpMeta::linear(
@@ -1279,6 +1281,7 @@ impl<'c> Lowerer<'c> {
             slot,
             is_inferred,
             inferred_policy_check,
+            word_result_addr_for_kind(result_binding.kind, func_path, args.len() - 2),
         );
         let result_typed = Register::new(result_binding.kind, result_reg);
         let mut reads = Vec::with_capacity(arg_regs.len() + 1);
@@ -1463,6 +1466,7 @@ impl<'c> Lowerer<'c> {
             arg_bindings.push(binding);
         }
         let func = &call.func;
+        let word_result_addr = word_result_addr_tokens(func, arg_bindings.len());
         // jtransform.py:467-471 / 480-482: `-live-` follows the call, it does
         // not precede it.  Decide here whether the explicit arm below needs a
         // trailing marker; the inferred arm emits its own runtime-conditional
@@ -1767,7 +1771,7 @@ impl<'c> Lowerer<'c> {
                                 vec![Register::int(throwaway_reg)],
                             ),
                             quote! {
-                                let __fn_idx = __builder.add_fn_ptr(#func as *const ());
+                                let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
                                 #call_invocation
                             },
                         );
@@ -1796,7 +1800,7 @@ impl<'c> Lowerer<'c> {
                                 vec![Register::int(throwaway_reg)],
                             ),
                             quote! {
-                                let __fn_idx = __builder.add_fn_ptr(#func as *const ());
+                                let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
                                 #call_invocation
                             },
                         );
@@ -1819,7 +1823,7 @@ impl<'c> Lowerer<'c> {
                             vec![Register::int(throwaway_reg)],
                         ),
                         quote! {
-                            let __fn_idx = __builder.add_fn_ptr(#func as *const ());
+                            let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
                             __builder.residual_call_int_canonical_via_target_with_effect_info(
                                 __fn_idx,
                                 #typed_args,
@@ -1866,7 +1870,7 @@ impl<'c> Lowerer<'c> {
                             vec![Register::int(throwaway_reg)],
                         ),
                         quote! {
-                            let __fn_idx = __builder.add_fn_ptr(#func as *const ());
+                            let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
                             #call_stmt
                         },
                     );

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -235,8 +235,8 @@ struct ArrayFieldBase {
 impl<'c> Lowerer<'c> {
     /// Read an immediate operand byte from the green bytecode array:
     /// `program[<index>]`.  Mirrors the dispatch-top opcode fetch
-    /// (`try_lower_opcode_fetch_stmt`) so the same `getarrayitem_gc_i` is
-    /// emitted for operand reads inside opcode arm bodies.  RPython
+    /// (`try_lower_opcode_fetch_stmt`) so the same `getarrayitem_gc_i_pure`
+    /// is emitted for operand reads inside opcode arm bodies.  RPython
     /// `pyopcode.py:171 ord(co_code[next_instr])`: the bytecode array and
     /// `pc` are green, so the optimizer constant-folds the load.
     ///
@@ -247,7 +247,7 @@ impl<'c> Lowerer<'c> {
         // `pyopcode.py:171 ord(co_code[next_instr])`) only holds when `pc` is
         // a declared green — PyPy `tl.py greens=['pc','code']` makes both the
         // bytecode array and the instruction pointer green, so the load folds
-        // away.  With a red `pc` the `getarrayitem_gc_i` does not fold and the
+        // away.  With a red `pc` the read does not fold and the
         // surrounding state-field dispatch loop cannot close on it; leave the
         // operand read unlowered so the arm aborts and the interpreter handles
         // that opcode (the pre-green-pc behaviour).
@@ -285,7 +285,9 @@ impl<'c> Lowerer<'c> {
             ),
             quote! {
                 let __descr_idx = #descr_tok;
-                __builder.getarrayitem_gc_i(
+                // Same array and same immutability as the dispatch-top fetch,
+                // so the same always-pure spelling.
+                __builder.getarrayitem_gc_i_pure(
                     #result_reg as u16,
                     #program_reg as u16,
                     #index_reg as u16,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -1501,7 +1501,7 @@ impl<'c> Lowerer<'c> {
                         quote! {
                             let (__policy, __inline_builder, __trace_target, __concrete_target, _prebuild, __save_err) = #policy_path();
                             let __trace_target = if __trace_target.is_null() {
-                                #func as *const ()
+                                #word_result_addr
                             } else {
                                 __trace_target
                             };
@@ -1599,7 +1599,7 @@ impl<'c> Lowerer<'c> {
                         quote! {
                             let (__policy, __inline_builder, __trace_target, __concrete_target, _prebuild, __save_err) = #policy_path();
                             let __trace_target = if __trace_target.is_null() {
-                                #func as *const ()
+                                #word_result_addr
                             } else {
                                 __trace_target
                             };

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -952,6 +952,7 @@ impl<'c> Lowerer<'c> {
 
         let reg = self.alloc_reg();
         let func = &call.func;
+        let word_result_addr = word_result_addr_tokens(func, arg_bindings.len());
         let mut result_kind = BindingKind::Int;
         // jtransform.py:467-471 / 480-482: `-live-` follows the call, it does
         // not precede it.  Decide here whether the explicit arm below needs a
@@ -1025,7 +1026,7 @@ impl<'c> Lowerer<'c> {
                                 vec![Register::new(result_kind, reg)],
                             ),
                             quote! {
-                                let __fn_idx = __builder.add_fn_ptr(#func as *const ());
+                                let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
                                 #call_invocation
                             },
                         );
@@ -1054,7 +1055,7 @@ impl<'c> Lowerer<'c> {
                                 vec![Register::new(result_kind, reg)],
                             ),
                             quote! {
-                                let __fn_idx = __builder.add_fn_ptr(#func as *const ());
+                                let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
                                 #call_invocation
                             },
                         );
@@ -1072,7 +1073,7 @@ impl<'c> Lowerer<'c> {
                             vec![Register::new(result_kind, reg)],
                         ),
                         quote! {
-                            let __fn_idx = __builder.add_fn_ptr(#func as *const ());
+                            let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
                             __builder.residual_call_int_canonical_via_target_with_effect_info(
                                 __fn_idx,
                                 #typed_args,
@@ -1111,7 +1112,7 @@ impl<'c> Lowerer<'c> {
                             vec![Register::new(result_kind, reg)],
                         ),
                         quote! {
-                            let __fn_idx = __builder.add_fn_ptr(#func as *const ());
+                            let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
                             #call_stmt
                         },
                     );
@@ -1822,6 +1823,7 @@ impl<'c> Lowerer<'c> {
                 let typed_args = typed_call_arg_tokens(&arg_bindings);
                 let __arg_regs: Vec<Register> =
                     arg_bindings.iter().map(Register::from_binding).collect();
+                let word_result_addr = word_result_addr_tokens(&func_path, arg_bindings.len());
                 let call_stmt = match kind {
                     crate::jit_interp::CallPolicyKind::ElidableInt => quote! {
                         __builder.call_pure_int_canonical_via_target(__fn_idx, #typed_args, #reg);
@@ -1841,7 +1843,7 @@ impl<'c> Lowerer<'c> {
                         vec![Register::new(result_kind, reg)],
                     ),
                     quote! {
-                        let __fn_idx = __builder.add_fn_ptr(#func_path as *const ());
+                        let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
                         #call_stmt
                     },
                 );

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -309,10 +309,10 @@ impl<'c> Lowerer<'c> {
                 if let Some(binding) = self.lower_native_tag_small_call(call) {
                     return Some(binding);
                 }
-                // A helper that hands its argument straight back is opened by
-                // the inliner upstream and its residue dropped by
-                // `jtransform.py` `rewrite_op_same_as`; the LLBC tracer sees
-                // the call, so drop it here instead.
+                // A helper that hands its argument straight back is opened
+                // by `inline.auto_inline_graphs` upstream, before the
+                // codewriter ever sees the graph. This front end has no such
+                // stage, so the drop is declared and applied here.
                 if let Some(binding) = self.lower_native_identity_call(call) {
                     return Some(binding);
                 }
@@ -2059,6 +2059,11 @@ impl<'c> Lowerer<'c> {
     ///
     /// The argument is still lowered, so a receiver that mutates state keeps
     /// running; only the wrapper around its result goes away.
+    ///
+    /// This runs ahead of the `calls` policy machinery, so a path in both
+    /// would take this route and leave its policy dead; the config parse
+    /// rejects that pair rather than let it lower
+    /// (`reject_overlapping_call_vocabularies`).
     fn lower_native_identity_call(&mut self, call: &ExprCall) -> Option<Binding> {
         let config = self.config?;
         let func_segments = canonical_expr_segments(&call.func)?;

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
@@ -408,6 +408,7 @@ impl<'c> Lowerer<'c> {
         slot: CondCallEffectSlot,
         is_inferred: bool,
         inferred_policy_check: Option<TokenStream>,
+        word_result_addr: Option<TokenStream>,
     ) -> TokenStream {
         let static_slot_token = slot.token();
         // For `Infer` mode, the helper's `_jit_helper_policy` byte is
@@ -500,8 +501,12 @@ impl<'c> Lowerer<'c> {
                 );
             }
         } else {
+            // An int-result target is registered through its widening shim;
+            // see `word_result_addr_tokens`.  A void- or ref-result target has
+            // no narrow return to widen and registers its own address.
+            let target_addr = word_result_addr.unwrap_or_else(|| quote! { #func as *const () });
             quote! {
-                let __fn_idx = __builder.add_fn_ptr_with_slot(#func as *const (), #slot_expr);
+                let __fn_idx = __builder.add_fn_ptr_with_slot(#target_addr, #slot_expr);
             }
         }
     }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -44,6 +44,7 @@ mod reexports {
         is_supported_float_type, is_supported_int_cast, is_supported_ref_type, is_word_width_int,
         opcode_for_assign_binop, opcode_for_assign_binop_f, opcode_for_binop, opcode_for_binop_f,
         opcode_for_compare_f, stmt_has_loop_control, typed_call_arg_tokens,
+        word_result_addr_for_kind, word_result_addr_tokens,
     };
     pub(super) use super::liveness::{
         annotate_live_markers_with_liveness, compute_per_marker_liveness, get_liveness_info,
@@ -58,7 +59,7 @@ use reexports::*;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::{ToTokens, format_ident, quote};
 
 use super::call_policy_byte::{
     INT_DONT_LOOK_INSIDE, INT_DONT_LOOK_INSIDE_CANNOT_RAISE, INT_ELIDABLE,
@@ -3197,5 +3198,77 @@ mod tests {
             dispatch::InlineArmOutcome::Rejected,
         );
         assert!(lowerer.inline_liveness_prebuild.is_empty());
+    }
+
+    /// A registered int-result target is dispatched by
+    /// `bh_call_i_dispatch`, which reads the whole return register; a callee
+    /// whose result is narrower than a word does not define it.  So the
+    /// address that reaches `add_fn_ptr` must be the widening shim's, never
+    /// the callee's own.
+    #[test]
+    fn int_result_call_registers_the_widening_shim() {
+        let call = parse_call("helper(1)");
+        let mut lowerer =
+            lowerer_with_call_policy("helper", crate::jit_interp::CallPolicyKind::ResidualInt);
+        lowerer
+            .lower_call_value(&call)
+            .expect("residual int call should lower");
+        let statements = &lowerer.statements;
+        let body = quote! { #(#statements)* }.to_string();
+        assert!(body.contains("into_call_word"));
+        assert!(!body.contains("add_fn_ptr (helper as * const ())"));
+    }
+
+    /// A ref result is a pointer and a void result is never read, so neither
+    /// has anything to widen and both register the callee's own address.
+    #[test]
+    fn non_int_result_calls_register_the_callee_address() {
+        let call = parse_call("helper(1)");
+        let mut lowerer =
+            lowerer_with_call_policy("helper", crate::jit_interp::CallPolicyKind::ResidualRef);
+        lowerer
+            .lower_call_value(&call)
+            .expect("residual ref call should lower");
+        let statements = &lowerer.statements;
+        let body = quote! { #(#statements)* }.to_string();
+        assert!(body.contains("add_fn_ptr (helper as * const ())"));
+        assert!(!body.contains("into_call_word"));
+
+        let expr: syn::Expr = syn::parse_quote! { helper(1) };
+        let mut lowerer =
+            lowerer_with_call_policy("helper", crate::jit_interp::CallPolicyKind::ResidualVoid);
+        lowerer
+            .lower_config_call_stmt(&expr)
+            .expect("residual void call should lower");
+        let statements = &lowerer.statements;
+        let body = quote! { #(#statements)* }.to_string();
+        assert!(body.contains("add_fn_ptr (helper as * const ())"));
+        assert!(!body.contains("into_call_word"));
+    }
+
+    /// `record_known_result!` registers through `add_fn_ptr_with_slot`, which
+    /// takes the same shim for an int result.
+    #[test]
+    fn record_known_result_int_registers_the_widening_shim() {
+        let mut lowerer =
+            lowerer_with_call_policy("helper", crate::jit_interp::CallPolicyKind::ElidableInt);
+        lowerer
+            .bindings
+            .insert("known".to_string(), binding(0, BindingKind::Int));
+        lowerer
+            .bindings
+            .insert("arg".to_string(), binding(1, BindingKind::Int));
+        let expr: Expr =
+            syn::parse_str("record_known_result!(known, helper, arg)").expect("parse macro expr");
+        lowerer
+            .lower_record_known_result(&expr)
+            .expect("record_known_result should lower");
+        let body = lowerer
+            .statements
+            .iter()
+            .map(ToString::to_string)
+            .collect::<String>();
+        assert!(body.contains("into_call_word"));
+        assert!(!body.contains("add_fn_ptr_with_slot (helper as * const ()"));
     }
 }

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -197,11 +197,15 @@ pub struct JitInterpConfig {
     pub native_tag_small: Vec<Path>,
     /// Pure function → its own argument.  `native_identity = { unwrap_word }`.
     /// A call whose path matches one of these is replaced by the binding of
-    /// its single argument, so the trace never sees a call at all.  RPython
-    /// needs no such declaration: `backendopt/inline.py` opens a helper this
-    /// small before the codewriter runs, and `jtransform.py`
-    /// `rewrite_op_same_as` drops the identity residue it leaves behind.  The
-    /// LLBC tracer still sees the Rust call, so the drop is declared here.
+    /// its single argument, so the trace never sees a call at all.  What opens
+    /// a helper this small upstream is the inliner, not `same_as` handling:
+    /// `warmspot.WarmRunnerDesc.__init__` runs `prejit_optimizations` →
+    /// `inline.auto_inline_graphs` → `BaseInliner.do_inline`, then
+    /// `BaseInliner.cleanup` → `simplify.cleanup_graph`, all before
+    /// `make_jitcodes()`, and that leaves no residue for the codewriter to
+    /// drop.  This front end lowers a `syn` AST straight to a `JitCode` with
+    /// no flow-graph stage for an inliner to run in, so the declaration is
+    /// that pass relocated to the only stage there is.
     /// Declaring a function whose argument and result do not share a register
     /// class is a miscompile — the argument's binding is handed straight to
     /// the consumer.
@@ -363,6 +367,60 @@ pub enum StateFieldKind {
     /// int bank.
     #[allow(dead_code)]
     Ref(syn::Path),
+}
+
+/// Reject a path declared in two of the mutually exclusive call vocabularies.
+///
+/// `lower_value.rs`'s call arm tries `native_int_binops`, `native_tag_small`
+/// and `native_identity` in that order and only then the `calls` policy
+/// machinery, and each match returns immediately. A path in two of them
+/// therefore takes the earlier route and the later declaration is dead — with
+/// nothing downstream able to say so, because by that point only the winning
+/// route survives. The declaration order below is the lowerer's, so the
+/// vocabulary reported first is the one that actually applies.
+///
+/// Two entries inside a single vocabulary are left alone: `calls` is filled
+/// from both `calls = { ... }` and `helpers = [ ... ]`, where naming a
+/// function in both is how a policy is attached to a discovered helper.
+pub(crate) fn reject_overlapping_call_vocabularies(
+    calls: &[CallEntry],
+    native_int_binops: &[(Path, Ident)],
+    native_tag_small: &[Path],
+    native_identity: &[Path],
+) -> syn::Result<()> {
+    let vocabularies: [(&str, Vec<&Path>); 4] = [
+        (
+            "native_int_binops",
+            native_int_binops.iter().map(|(path, _)| path).collect(),
+        ),
+        ("native_tag_small", native_tag_small.iter().collect()),
+        ("native_identity", native_identity.iter().collect()),
+        ("calls", calls.iter().map(|entry| &entry.path).collect()),
+    ];
+
+    let mut declared: Vec<(Vec<String>, &str)> = Vec::new();
+    for (vocabulary, paths) in &vocabularies {
+        for path in paths {
+            let segments = jitcode_lower::canonical_path_segments(path);
+            if let Some((_, winner)) = declared
+                .iter()
+                .find(|(other, owner)| *other == segments && owner != vocabulary)
+            {
+                return Err(syn::Error::new_spanned(
+                    path,
+                    format!(
+                        "`{name}` is declared in both `{winner}` and `{vocabulary}`; \
+                         the lowering takes the `{winner}` route and the \
+                         `{vocabulary}` declaration never applies. Declare it in \
+                         exactly one.",
+                        name = segments.join("::"),
+                    ),
+                ));
+            }
+            declared.push((segments, vocabulary));
+        }
+    }
+    Ok(())
 }
 
 /// One entry in the `calls = { ... }` / `helpers = [ ... ]` map.
@@ -838,6 +896,13 @@ impl Parse for JitInterpConfig {
                 .into_iter()
                 .map(|spec| (spec.expr, spec.type_tag))
                 .unzip();
+
+        reject_overlapping_call_vocabularies(
+            &calls,
+            &native_int_binops,
+            &native_tag_small,
+            &native_identity,
+        )?;
 
         Ok(JitInterpConfig {
             state_type,
@@ -3193,6 +3258,47 @@ fn rewrite_body(
 mod tests {
     use super::*;
     use syn::parse_quote;
+
+    /// A path in two vocabularies is rejected at parse time, naming the route
+    /// that wins. Without the check the `calls` policy is simply never
+    /// consulted and nothing downstream can tell the author.
+    #[test]
+    fn a_path_in_two_call_vocabularies_is_rejected() {
+        let calls = vec![CallEntry {
+            path: parse_quote!(unwrap_word),
+            policy: Some(CallPolicyKind::ElidableIntCannotRaise),
+        }];
+        let native_identity: Vec<Path> = vec![parse_quote!(unwrap_word)];
+
+        let err = reject_overlapping_call_vocabularies(&calls, &[], &[], &native_identity)
+            .expect_err("a path in both `native_identity` and `calls` must not parse");
+        let message = err.to_string();
+        assert!(
+            message.contains("`unwrap_word`")
+                && message.contains("`native_identity`")
+                && message.contains("`calls`"),
+            "the diagnostic must name the path and both vocabularies: {message}"
+        );
+    }
+
+    /// Two entries under one key stay legal: `calls` is filled from `calls`
+    /// and `helpers` both, and naming a discovered helper there is how it
+    /// gets its policy.
+    #[test]
+    fn a_path_declared_twice_in_one_vocabulary_is_accepted() {
+        let calls = vec![
+            CallEntry {
+                path: parse_quote!(helper),
+                policy: None,
+            },
+            CallEntry {
+                path: parse_quote!(helper),
+                policy: Some(CallPolicyKind::ResidualInt),
+            },
+        ];
+        reject_overlapping_call_vocabularies(&calls, &[], &[], &[])
+            .expect("a repeated `calls` entry is how `helpers` gets its policy");
+    }
 
     #[test]
     fn an_unambiguous_imported_leaf_resolves_its_inlined_base() {

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -142,6 +142,13 @@ impl Parse for JitInlineArgs {
             }
             let _ = input.parse::<Token![,]>();
         }
+        jit_interp::reject_overlapping_call_vocabularies(
+            &calls,
+            &native_int_binops,
+            &native_tag_small,
+            &native_identity,
+        )?;
+
         Ok(Self {
             calls,
             ref_params,

--- a/majit/majit-metainterp/src/execute_and_record.rs
+++ b/majit/majit-metainterp/src/execute_and_record.rs
@@ -1,0 +1,364 @@
+//! `pyjitpl.py MetaInterp.execute_and_record` and its `_record_helper` /
+//! `_all_constants` companions — the single funnel every non-raising
+//! operation passes through on its way into the trace.
+//!
+//! # Why the funnel does not execute
+//!
+//! Upstream runs `resvalue = executor.execute(...)` *inside* the funnel, so
+//! the fold decides only whether to **record**, never whether to **compute**.
+//! Every caller here has already computed: the tracer advances its own
+//! register banks (`read_int_reg` → `eval_binop_i` → `set_int_reg`) before it
+//! can decide anything, and `execute_nonspec_const` cannot perform a live
+//! memory read for the callers that need one. So the result arrives as the
+//! `resvalue` parameter and the funnel keeps only the invariant that matters:
+//! it decides whether to record.
+//!
+//! `resvalue: None` is a state upstream cannot have, because
+//! `executor.execute` always runs on a real CPU. It means "no trace-time
+//! concrete available" — `TraceCtx::opimpl_arraylen_gc` receives it when
+//! `arraylen_sanity_load` finds no lendescr, and the layout-missing
+//! virtualizable fallbacks return it. A `None` never folds, always records,
+//! and never stamps.
+//!
+//! # The fold value and the stamped value come from different evaluators
+//!
+//! Upstream has one `executor.execute` feeding both this funnel and
+//! `Optimizer.constant_fold`. Here the fold runs
+//! `executor::execute_nonspec_const` — the same evaluator `constant_fold`
+//! consults — while the stamp uses the caller's `resvalue`, which came from
+//! the tracer-side evaluators. Those two disagree in a handful of cases:
+//! `eval_binop_i` masks out-of-range shifts and answers 0 for div/mod by
+//! zero, `eval_binop_f` has no zero-divisor guard, and the tracer casts
+//! saturate, where `execute_binary_int_const` and its siblings *decline*. A
+//! decline records instead of folding, so the trace and the optimizer can
+//! never disagree about what a constant is. That is narrower than upstream,
+//! which would fold `float_truediv(1.0, 0.0)` to `inf`; widening it is one
+//! line in `execute_binary_float_const`, not in this funnel.
+//!
+//! # Heapcache invalidation stays outside
+//!
+//! Upstream's `_record_helper` calls `heapcache.invalidate_caches`. Here
+//! invalidation is hand-called per arm, and `TraceCtx::record_call_with_descr`
+//! does its own, so pulling it in would double-invalidate every site that
+//! already calls it. Adopting sites keep their existing call, before the
+//! funnel call. Skipping it on the *fold* path is separately sound: a fold
+//! requires every argument constant, and `HeapCache::_escape_box` opens with
+//! `if opref.is_constant() { return; }`, exactly as upstream's `_escape_box`
+//! acts only on `RefFrontendOp`. That is a licence to skip invalidation when
+//! folding, **not** a licence to widen the foldable opcode set.
+
+use majit_ir::{OpCode, OpRef, Type, Value, descr::DescrRef};
+
+use crate::trace_ctx::TraceCtx;
+
+impl TraceCtx {
+    /// `pyjitpl.py MetaInterp.execute_and_record(opnum, descr, *argboxes)`.
+    ///
+    /// Returns a `Const*` OpRef when the operation folded and nothing was
+    /// recorded, else the recorded op's OpRef, already stamped with
+    /// `resvalue`. Callers distinguish the two with `.is_constant()` — that is
+    /// upstream's `isinstance(resbox, Const)`.
+    ///
+    /// `cpu` and `last_exc_value` are the two pieces of `MetaInterp` state
+    /// the funnel needs and `TraceCtx` does not hold, so both are passed.
+    /// `cpu` is upstream's `self.cpu`, which `executor.execute` takes as an
+    /// explicit argument anyway; production installs a real one through
+    /// `MetaInterp::set_cpu`, so reaching for `cpu::default_cpu()` here would
+    /// fold memory reads against the wrong backend. `last_exc_value` is
+    /// upstream's `self.last_exc_value`, which majit splits across
+    /// `JitCodeMachine::last_exception_value`, `MetaInterp::last_exc_box` and
+    /// the `blackhole::BH_LAST_EXC_VALUE` thread-local — a caller must name
+    /// which one it means rather than have a fourth copy minted here.
+    ///
+    /// The `is_pure_with_descr` test is structurally first, and must stay
+    /// there. `_all_constants` is **vacuously true** for a zero-argument
+    /// operation, so every `New`, `NewWithVtable`, `ForceToken`,
+    /// `LeavePortalFrame` and `Keepalive` would fold — deleting every
+    /// allocation and every portal marker from the trace — if the predicate
+    /// were dropped in favour of an arguments-only test.
+    pub fn execute_and_record(
+        &mut self,
+        cpu: &dyn crate::cpu::Cpu,
+        opnum: OpCode,
+        descr: Option<DescrRef>,
+        args: &[OpRef],
+        resvalue: Option<Value>,
+        last_exc_value: i64,
+    ) -> OpRef {
+        // `assert not (rop._CANRAISE_FIRST <= opnum <= rop._CANRAISE_LAST)` —
+        // a can-raise operation belongs to `execute_and_record_varargs`.
+        // Spelled with the `is_ovf` escape because the two ranges nest the
+        // other way round here: `CANRAISE_LAST` is `IntMulOvf`, so
+        // `is_ovf()` is a subset of `can_raise()`, where `resoperation.py`
+        // closes the can-raise range before `_OVF_FIRST` opens and can spell
+        // the assert bare.
+        debug_assert!(
+            !opnum.can_raise() || opnum.is_ovf(),
+            "execute_and_record: {opnum:?} can raise",
+        );
+        // `profiler.count_ops(opnum)` — counted on both paths.
+        self.profiler().count_ops(opnum, crate::counters::OPS);
+
+        if opnum.is_pure_with_descr(descr.as_ref()) || (opnum.is_ovf() && last_exc_value == 0) {
+            // `canfold = self._all_constants(*argboxes)`. `OpRef::is_constant`
+            // is the variant test, so it answers the `isinstance(box, Const)`
+            // question for every Const subclass at once. The extra
+            // `resvalue.is_some()` conjunct is the `None` rule from the module
+            // doc: a caller that could not compute the value has no register
+            // to receive a constant either.
+            if resvalue.is_some()
+                && args.iter().all(|a| a.is_constant())
+                && let Some(folded) = Self::fold_value(cpu, opnum, args, descr.as_ref())
+            {
+                // `executor.wrap_constant(resvalue)`. Upstream's structural
+                // guarantee that no foldable opcode has result type `/n`.
+                debug_assert_ne!(opnum.result_type(), Type::Void);
+                return OpRef::const_inline_from_value(&folded);
+            }
+        }
+        self.record_helper(opnum, resvalue, descr, args)
+    }
+
+    /// `pyjitpl.py MetaInterp._record_helper(opnum, resvalue, descr, *argboxes)`.
+    ///
+    /// Upstream returns `None` for `op.type == 'v'`; here a void operation
+    /// still gets a real position from `recorder::Trace::record_op`, and
+    /// `set_opref_concrete` asserts every recorded op has one, so the OpRef is
+    /// returned for every result type.
+    fn record_helper(
+        &mut self,
+        opnum: OpCode,
+        resvalue: Option<Value>,
+        descr: Option<DescrRef>,
+        args: &[OpRef],
+    ) -> OpRef {
+        self.profiler()
+            .count_ops(opnum, crate::counters::RECORDED_OPS);
+        // `self.heapcache.invalidate_caches(...)` stays at the call sites —
+        // see the module doc.
+        let op = match descr {
+            Some(d) => self.record_op_with_descr(opnum, args, d),
+            None => self.record_op(opnum, args),
+        };
+        // `self.attach_debug_info(op)` is a documented no-op stub.
+        if let Some(v) = resvalue {
+            self.set_opref_concrete(op, v);
+        }
+        op
+    }
+
+    /// The constant the fold wraps, or `None` when the operation must be
+    /// recorded after all.
+    ///
+    /// Both non-folding outcomes of `execute_nonspec_const` record. `Ok(None)`
+    /// is a registered evaluator declining its operands, and declining is a
+    /// decision. `Err(NoConstExecutor)` is documented as the separate
+    /// "no helper registered" outcome — but the arity-2 integer arm reaches it
+    /// by falling through when `execute_binary_int_const` answers `None`, so
+    /// today it also carries every decline in that family (out-of-range shift,
+    /// div/mod by zero, OVF overflow). Recording on both keeps the decline
+    /// honoured; once the executor separates the two, this arm becomes the
+    /// `panic!` that `Optimizer::constant_fold` already spells for a genuinely
+    /// missing helper.
+    fn fold_value(
+        cpu: &dyn crate::cpu::Cpu,
+        opnum: OpCode,
+        args: &[OpRef],
+        descr: Option<&DescrRef>,
+    ) -> Option<Value> {
+        let vals: Vec<Value> = args
+            .iter()
+            .map(|a| {
+                a.inline_const_to_value()
+                    .expect("_all_constants held for every argument")
+            })
+            .collect();
+        crate::executor::execute_nonspec_const(cpu, opnum, &vals, descr, opnum.result_type())
+            .ok()
+            .flatten()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recorder::Trace;
+
+    fn fresh_ctx() -> TraceCtx {
+        TraceCtx::new(
+            Trace::new(),
+            0,
+            std::sync::Arc::new(crate::MetaInterpStaticData::new()),
+        )
+    }
+
+    /// `_all_constants` is vacuously true for a zero-argument operation, so
+    /// the funnel is kept off `ForceToken`, `New`, `NewWithVtable`,
+    /// `LeavePortalFrame` and `Keepalive` only by `is_pure_with_descr`
+    /// answering false first. Simplifying the gate into an arguments-only
+    /// test deletes every allocation and every portal marker from the trace.
+    #[test]
+    fn a_zero_argument_impure_op_is_recorded_not_folded() {
+        let mut ctx = fresh_ctx();
+        let cpu = crate::cpu::default_cpu();
+        let before = ctx.num_ops();
+        let op = ctx.execute_and_record(
+            cpu.as_ref(),
+            OpCode::ForceToken,
+            None,
+            &[],
+            Some(Value::Int(7)),
+            0,
+        );
+        assert!(!op.is_constant(), "ForceToken must not fold");
+        assert_eq!(ctx.num_ops(), before + 1);
+    }
+
+    #[test]
+    fn an_all_constant_pure_op_folds_and_records_nothing() {
+        let mut ctx = fresh_ctx();
+        let cpu = crate::cpu::default_cpu();
+        let before = ctx.num_ops();
+        let op = ctx.execute_and_record(
+            cpu.as_ref(),
+            OpCode::IntAdd,
+            None,
+            &[OpRef::ConstInt(2), OpRef::ConstInt(3)],
+            Some(Value::Int(5)),
+            0,
+        );
+        assert_eq!(op, OpRef::ConstInt(5));
+        assert_eq!(ctx.num_ops(), before, "a fold records nothing");
+    }
+
+    #[test]
+    fn a_non_constant_argument_blocks_the_fold() {
+        let mut recorder = Trace::new();
+        let arg = recorder.record_input_arg(majit_ir::Type::Int);
+        let mut ctx = TraceCtx::new(
+            recorder,
+            0,
+            std::sync::Arc::new(crate::MetaInterpStaticData::new()),
+        );
+        let cpu = crate::cpu::default_cpu();
+        let op = ctx.execute_and_record(
+            cpu.as_ref(),
+            OpCode::IntAdd,
+            None,
+            &[arg, OpRef::ConstInt(3)],
+            Some(Value::Int(5)),
+            0,
+        );
+        assert!(!op.is_constant());
+        assert_eq!(
+            ctx.box_value(op),
+            Some(Value::Int(5)),
+            "resvalue is stamped"
+        );
+    }
+
+    /// `execute_binary_int_const` declines `IntFloorDiv` by zero rather than
+    /// answering the tracer's 0, so the operation is recorded and the trace
+    /// and the optimizer cannot disagree about what the constant is.
+    #[test]
+    fn a_declining_evaluator_records_instead_of_folding() {
+        let mut ctx = fresh_ctx();
+        let cpu = crate::cpu::default_cpu();
+        let before = ctx.num_ops();
+        let op = ctx.execute_and_record(
+            cpu.as_ref(),
+            OpCode::IntFloorDiv,
+            None,
+            &[OpRef::ConstInt(5), OpRef::ConstInt(0)],
+            Some(Value::Int(0)),
+            0,
+        );
+        assert!(!op.is_constant(), "div by zero must not fold");
+        assert_eq!(ctx.num_ops(), before + 1);
+    }
+
+    /// `_OVF_FIRST <= opnum <= _OVF_LAST and not self.last_exc_value` — the
+    /// ovf arm of the fold gate is closed while an exception is pending.
+    #[test]
+    fn a_pending_exception_closes_the_ovf_fold_gate() {
+        let mut ctx = fresh_ctx();
+        let cpu = crate::cpu::default_cpu();
+        let args = [OpRef::ConstInt(2), OpRef::ConstInt(3)];
+
+        let before = ctx.num_ops();
+        let clear = ctx.execute_and_record(
+            cpu.as_ref(),
+            OpCode::IntAddOvf,
+            None,
+            &args,
+            Some(Value::Int(5)),
+            0,
+        );
+        assert_eq!(clear, OpRef::ConstInt(5));
+        assert_eq!(ctx.num_ops(), before);
+
+        let pending = ctx.execute_and_record(
+            cpu.as_ref(),
+            OpCode::IntAddOvf,
+            None,
+            &args,
+            Some(Value::Int(5)),
+            0xdead,
+        );
+        assert!(
+            !pending.is_constant(),
+            "a pending exception blocks the fold"
+        );
+        assert_eq!(ctx.num_ops(), before + 1);
+    }
+
+    /// `checked_add` in `execute_binary_int_const` means a constant pair that
+    /// really overflows declines the fold, so the op and its guard survive.
+    #[test]
+    fn an_overflowing_constant_ovf_pair_is_recorded() {
+        let mut ctx = fresh_ctx();
+        let cpu = crate::cpu::default_cpu();
+        let before = ctx.num_ops();
+        let op = ctx.execute_and_record(
+            cpu.as_ref(),
+            OpCode::IntAddOvf,
+            None,
+            &[OpRef::ConstInt(i64::MAX), OpRef::ConstInt(1)],
+            Some(Value::Int(i64::MIN)),
+            0,
+        );
+        assert!(!op.is_constant());
+        assert_eq!(ctx.num_ops(), before + 1);
+    }
+
+    /// The C6 trap, pinned: `CANRAISE_LAST` is `IntMulOvf` here, so the OVF
+    /// range sits *inside* the can-raise range, where `resoperation.py` closes
+    /// the can-raise range before `_OVF_FIRST` opens. A literal port of
+    /// `assert not (_CANRAISE_FIRST <= opnum <= _CANRAISE_LAST)` would reject
+    /// every OVF opcode the funnel exists to fold.
+    #[test]
+    fn every_ovf_opcode_also_answers_can_raise() {
+        for opnum in [OpCode::IntAddOvf, OpCode::IntSubOvf, OpCode::IntMulOvf] {
+            assert!(opnum.is_ovf(), "{opnum:?}");
+            assert!(opnum.can_raise(), "{opnum:?}");
+        }
+    }
+
+    /// `resvalue: None` — no trace-time concrete available — never folds,
+    /// always records, never stamps.
+    #[test]
+    fn a_missing_resvalue_records_without_stamping() {
+        let mut ctx = fresh_ctx();
+        let cpu = crate::cpu::default_cpu();
+        let op = ctx.execute_and_record(
+            cpu.as_ref(),
+            OpCode::IntAdd,
+            None,
+            &[OpRef::ConstInt(2), OpRef::ConstInt(3)],
+            None,
+            0,
+        );
+        assert!(!op.is_constant());
+        assert_eq!(ctx.box_value(op), None);
+    }
+}

--- a/majit/majit-metainterp/src/execute_and_record.rs
+++ b/majit/majit-metainterp/src/execute_and_record.rs
@@ -377,4 +377,52 @@ mod tests {
         assert!(!op.is_constant());
         assert_eq!(ctx.box_value(op), None);
     }
+
+    /// `OPS` counts every operation the funnel is asked for and
+    /// `RECORDED_OPS` only those it records, so the two differ by exactly the
+    /// folds. Each is bumped from one place, and this is what says so: a
+    /// second bump on either — or a fold that reached `record_helper` anyway —
+    /// changes a number no committed baseline can hold, because neither count
+    /// has a healthy value and a successful fold lowers `RECORDED_OPS` by
+    /// design.
+    #[test]
+    fn the_funnel_counts_ops_once_and_recorded_ops_only_when_it_records() {
+        let mut ctx = fresh_ctx();
+        let cpu = crate::cpu::default_cpu();
+        let counts = |ctx: &TraceCtx| {
+            (
+                ctx.profiler().get_counter(crate::counters::OPS),
+                ctx.profiler().get_counter(crate::counters::RECORDED_OPS),
+            )
+        };
+        assert_eq!(counts(&ctx), (Some(0), Some(0)));
+
+        ctx.execute_and_record(
+            cpu.as_ref(),
+            OpCode::IntAdd,
+            None,
+            &[OpRef::ConstInt(2), OpRef::ConstInt(3)],
+            Some(Value::Int(5)),
+            0,
+        );
+        assert_eq!(
+            counts(&ctx),
+            (Some(1), Some(0)),
+            "a fold is counted, not recorded"
+        );
+
+        ctx.execute_and_record(
+            cpu.as_ref(),
+            OpCode::ForceToken,
+            None,
+            &[],
+            Some(Value::Int(7)),
+            0,
+        );
+        assert_eq!(
+            counts(&ctx),
+            (Some(2), Some(1)),
+            "a record is counted on both"
+        );
+    }
 }

--- a/majit/majit-metainterp/src/execute_and_record.rs
+++ b/majit/majit-metainterp/src/execute_and_record.rs
@@ -35,6 +35,23 @@
 //! which would fold `float_truediv(1.0, 0.0)` to `inf`; widening it is one
 //! line in `execute_binary_float_const`, not in this funnel.
 //!
+//! # A caller holding only a `Backend` cannot be routed
+//!
+//! `TraceCtx::set_cpu` installs a `majit_backend::Backend`, and that is what
+//! `TraceCtx::field_sanity_load` reads a field through. The fold here needs a
+//! `majit_backend::model::Cpu` — an unrelated trait, no supertrait relation,
+//! its own `bh_getfield_gc_i`. So the `vable_getfield_{int,ref,float}` /
+//! `vable_arraylen_vable` family cannot be routed as it stands: reaching for
+//! `cpu::default_cpu()` would fold the memory read through a stand-in while
+//! the stamp came from the real backend — two readers of one field, which is
+//! the disagreement the D3 rule above exists to rule out.
+//!
+//! What makes it *only* a wiring gap is that `MetaInterp` holds both objects
+//! at the three sites where it calls `ctx.set_cpu(Some(&self.backend))`. Until
+//! it hands over the second one too, those arms stay on `record_op_with_descr`.
+//! Operations that read no memory are exempt and say so at the call site —
+//! `_nonstandard_virtualizable`'s `PTR_EQ` is the one that takes the exemption.
+//!
 //! # Heapcache invalidation stays outside
 //!
 //! Upstream's `_record_helper` calls `heapcache.invalidate_caches`. Here

--- a/majit/majit-metainterp/src/execute_and_record.rs
+++ b/majit/majit-metainterp/src/execute_and_record.rs
@@ -150,16 +150,15 @@ impl TraceCtx {
     /// The constant the fold wraps, or `None` when the operation must be
     /// recorded after all.
     ///
-    /// Both non-folding outcomes of `execute_nonspec_const` record. `Ok(None)`
-    /// is a registered evaluator declining its operands, and declining is a
-    /// decision. `Err(NoConstExecutor)` is documented as the separate
-    /// "no helper registered" outcome — but the arity-2 integer arm reaches it
-    /// by falling through when `execute_binary_int_const` answers `None`, so
-    /// today it also carries every decline in that family (out-of-range shift,
-    /// div/mod by zero, OVF overflow). Recording on both keeps the decline
-    /// honoured; once the executor separates the two, this arm becomes the
-    /// `panic!` that `Optimizer::constant_fold` already spells for a genuinely
-    /// missing helper.
+    /// Both non-folding outcomes of `execute_nonspec_const` record.
+    /// `Ok(None)` is a registered evaluator declining its operands — an
+    /// out-of-range shift, a zero divisor, an OVF opcode that overflowed, a
+    /// non-finite `cast_float_to_int` — and declining is a decision.
+    /// `Err(NoConstExecutor)` is upstream's `NotImplementedError`, which
+    /// `Optimizer::constant_fold` spells as a `panic!`. This funnel records
+    /// instead: it runs inside the tracer, where a panic is caught and
+    /// downgraded to a silent `TraceAction::Abort`, so an evaluator gap would
+    /// cost the whole loop rather than one folded operation.
     fn fold_value(
         cpu: &dyn crate::cpu::Cpu,
         opnum: OpCode,

--- a/majit/majit-metainterp/src/execute_and_record.rs
+++ b/majit/majit-metainterp/src/execute_and_record.rs
@@ -52,6 +52,15 @@
 //! `_nonstandard_virtualizable`'s `PTR_EQ` is the one that takes the
 //! exemption.
 //!
+//! Most callers have no reader to thread, because the fold has two other
+//! preconditions and either one alone closes it. `SETFIELD_GC`,
+//! `SETARRAYITEM_GC`, `GETARRAYITEM_GC_*`, `ASSERT_NOT_NONE` and
+//! `RECORD_EXACT_CLASS` answer `is_pure_with_descr` false, and a caller with
+//! no `resvalue` is the `None` rule below. Those pass `cpu: None`, which
+//! states that no reader is needed rather than standing in for one; a
+//! `debug_assert` refuses `None` from a call that could otherwise have
+//! folded, so the pairing cannot go quietly wrong.
+//!
 //! The fold this opens is narrow: `is_pure_with_descr` admits a getfield only
 //! through `descr.is_always_pure()`, so a mutable virtualizable field records
 //! however constant its box is.
@@ -99,7 +108,7 @@ impl TraceCtx {
     /// were dropped in favour of an arguments-only test.
     pub fn execute_and_record(
         &mut self,
-        cpu: &dyn crate::cpu::Cpu,
+        cpu: Option<&dyn crate::cpu::Cpu>,
         opnum: OpCode,
         descr: Option<DescrRef>,
         args: &[OpRef],
@@ -117,6 +126,13 @@ impl TraceCtx {
             !opnum.can_raise() || opnum.is_ovf(),
             "execute_and_record: {opnum:?} can raise",
         );
+        // `None` is not "any cpu will do" — it is the caller stating that this
+        // opcode cannot reach the fold, so no reader is needed. An opcode that
+        // *can* fold would silently lose the fold instead, so say so loudly.
+        debug_assert!(
+            cpu.is_some() || resvalue.is_none() || !opnum.is_pure_with_descr(descr.as_ref()),
+            "execute_and_record: {opnum:?} can fold but no cpu was supplied",
+        );
         // `profiler.count_ops(opnum)` — counted on both paths.
         self.profiler().count_ops(opnum, crate::counters::OPS);
 
@@ -129,6 +145,7 @@ impl TraceCtx {
             // to receive a constant either.
             if resvalue.is_some()
                 && args.iter().all(|a| a.is_constant())
+                && let Some(cpu) = cpu
                 && let Some(folded) = Self::fold_value(cpu, opnum, args, descr.as_ref())
             {
                 // `executor.wrap_constant(resvalue)`. Upstream's structural
@@ -223,7 +240,7 @@ mod tests {
         let cpu = crate::cpu::default_cpu();
         let before = ctx.num_ops();
         let op = ctx.execute_and_record(
-            cpu.as_ref(),
+            Some(cpu.as_ref()),
             OpCode::ForceToken,
             None,
             &[],
@@ -240,7 +257,7 @@ mod tests {
         let cpu = crate::cpu::default_cpu();
         let before = ctx.num_ops();
         let op = ctx.execute_and_record(
-            cpu.as_ref(),
+            Some(cpu.as_ref()),
             OpCode::IntAdd,
             None,
             &[OpRef::ConstInt(2), OpRef::ConstInt(3)],
@@ -262,7 +279,7 @@ mod tests {
         );
         let cpu = crate::cpu::default_cpu();
         let op = ctx.execute_and_record(
-            cpu.as_ref(),
+            Some(cpu.as_ref()),
             OpCode::IntAdd,
             None,
             &[arg, OpRef::ConstInt(3)],
@@ -286,7 +303,7 @@ mod tests {
         let cpu = crate::cpu::default_cpu();
         let before = ctx.num_ops();
         let op = ctx.execute_and_record(
-            cpu.as_ref(),
+            Some(cpu.as_ref()),
             OpCode::IntFloorDiv,
             None,
             &[OpRef::ConstInt(5), OpRef::ConstInt(0)],
@@ -307,7 +324,7 @@ mod tests {
 
         let before = ctx.num_ops();
         let clear = ctx.execute_and_record(
-            cpu.as_ref(),
+            Some(cpu.as_ref()),
             OpCode::IntAddOvf,
             None,
             &args,
@@ -318,7 +335,7 @@ mod tests {
         assert_eq!(ctx.num_ops(), before);
 
         let pending = ctx.execute_and_record(
-            cpu.as_ref(),
+            Some(cpu.as_ref()),
             OpCode::IntAddOvf,
             None,
             &args,
@@ -340,7 +357,7 @@ mod tests {
         let cpu = crate::cpu::default_cpu();
         let before = ctx.num_ops();
         let op = ctx.execute_and_record(
-            cpu.as_ref(),
+            Some(cpu.as_ref()),
             OpCode::IntAddOvf,
             None,
             &[OpRef::ConstInt(i64::MAX), OpRef::ConstInt(1)],
@@ -371,7 +388,7 @@ mod tests {
         let mut ctx = fresh_ctx();
         let cpu = crate::cpu::default_cpu();
         let op = ctx.execute_and_record(
-            cpu.as_ref(),
+            Some(cpu.as_ref()),
             OpCode::IntAdd,
             None,
             &[OpRef::ConstInt(2), OpRef::ConstInt(3)],
@@ -402,7 +419,7 @@ mod tests {
         assert_eq!(counts(&ctx), (Some(0), Some(0)));
 
         ctx.execute_and_record(
-            cpu.as_ref(),
+            Some(cpu.as_ref()),
             OpCode::IntAdd,
             None,
             &[OpRef::ConstInt(2), OpRef::ConstInt(3)],
@@ -416,7 +433,7 @@ mod tests {
         );
 
         ctx.execute_and_record(
-            cpu.as_ref(),
+            Some(cpu.as_ref()),
             OpCode::ForceToken,
             None,
             &[],

--- a/majit/majit-metainterp/src/execute_and_record.rs
+++ b/majit/majit-metainterp/src/execute_and_record.rs
@@ -35,22 +35,26 @@
 //! which would fold `float_truediv(1.0, 0.0)` to `inf`; widening it is one
 //! line in `execute_binary_float_const`, not in this funnel.
 //!
-//! # A caller holding only a `Backend` cannot be routed
+//! # A `TraceCtx` method needs the cpu threaded in
 //!
 //! `TraceCtx::set_cpu` installs a `majit_backend::Backend`, and that is what
 //! `TraceCtx::field_sanity_load` reads a field through. The fold here needs a
 //! `majit_backend::model::Cpu` — an unrelated trait, no supertrait relation,
-//! its own `bh_getfield_gc_i`. So the `vable_getfield_{int,ref,float}` /
-//! `vable_arraylen_vable` family cannot be routed as it stands: reaching for
-//! `cpu::default_cpu()` would fold the memory read through a stand-in while
-//! the stamp came from the real backend — two readers of one field, which is
-//! the disagreement the D3 rule above exists to rule out.
+//! its own `bh_getfield_gc_i`. A method that both stamps a live load and
+//! folds it therefore touches both, and only one of them is a `TraceCtx`
+//! field.
 //!
-//! What makes it *only* a wiring gap is that `MetaInterp` holds both objects
-//! at the three sites where it calls `ctx.set_cpu(Some(&self.backend))`. Until
-//! it hands over the second one too, those arms stay on `record_op_with_descr`.
-//! Operations that read no memory are exempt and say so at the call site —
-//! `_nonstandard_virtualizable`'s `PTR_EQ` is the one that takes the exemption.
+//! The other arrives as a parameter, threaded from the `MetaInterp` that owns
+//! the `Arc`; `trace_arraylen_gc` and the `vable_getfield_{int,ref,float}`
+//! family take it that way. Reaching for `cpu::default_cpu()` inside the
+//! method instead installs a second reader nobody chose, which is sound only
+//! where the operation reads no memory — and such a call site says so.
+//! `_nonstandard_virtualizable`'s `PTR_EQ` is the one that takes the
+//! exemption.
+//!
+//! The fold this opens is narrow: `is_pure_with_descr` admits a getfield only
+//! through `descr.is_always_pure()`, so a mutable virtualizable field records
+//! however constant its box is.
 //!
 //! # Heapcache invalidation stays outside
 //!

--- a/majit/majit-metainterp/src/executor.rs
+++ b/majit/majit-metainterp/src/executor.rs
@@ -392,6 +392,34 @@ pub fn execute_varargs<M: Clone>(
     result
 }
 
+/// One row of `executor.EXECUTE_BY_NUM_ARGS`, resolved.
+///
+/// `_execute_arglist` raises `NotImplementedError` when the table holds no
+/// helper for the opcode — a different event from a registered helper refusing
+/// its operands, which upstream cannot express at all because every upstream
+/// helper is total. The `Option`-returning wrappers below collapse the two into
+/// `None`, so [`execute_nonspec_const`] consults the `*_row` functions instead
+/// and keeps [`NoConstExecutor`] for the missing helper alone.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ConstFold<T> {
+    /// This row has no entry for the opcode.
+    Unregistered,
+    /// The entry exists and refused these operands.
+    Declined,
+    /// The folded constant.
+    Folded(T),
+}
+
+impl<T> ConstFold<T> {
+    /// The `Option` view: a decline and a missing row are both `None`.
+    pub fn folded(self) -> Option<T> {
+        match self {
+            ConstFold::Folded(value) => Some(value),
+            ConstFold::Unregistered | ConstFold::Declined => None,
+        }
+    }
+}
+
 /// `executor.py::execute_nonspec_const` for binary integer opcodes.
 ///
 /// Returns the folded `i64` result when the operation is recognized and
@@ -415,46 +443,56 @@ pub fn execute_varargs<M: Clone>(
 /// Mirrors the overflow helpers and binary-int rows generated in
 /// `executor.EXECUTE_BY_NUM_ARGS`.
 pub fn execute_binary_int_const(opcode: OpCode, a: i64, b: i64) -> Option<i64> {
-    let result = match opcode {
-        OpCode::IntAdd => a.wrapping_add(b),
-        OpCode::IntSub => a.wrapping_sub(b),
-        OpCode::IntMul => a.wrapping_mul(b),
-        OpCode::IntAddOvf => a.checked_add(b)?,
-        OpCode::IntSubOvf => a.checked_sub(b)?,
-        OpCode::IntMulOvf => a.checked_mul(b)?,
-        OpCode::IntAnd => a & b,
-        OpCode::IntOr => a | b,
-        OpCode::IntXor => a ^ b,
-        OpCode::IntLshift if (0..64).contains(&b) => a << b,
-        OpCode::IntRshift if (0..64).contains(&b) => a >> b,
-        OpCode::UintRshift if (0..64).contains(&b) => (a as u64 >> b as u64) as i64,
-        OpCode::IntLt => (a < b) as i64,
-        OpCode::IntLe => (a <= b) as i64,
-        OpCode::IntGt => (a > b) as i64,
-        OpCode::IntGe => (a >= b) as i64,
-        OpCode::IntEq => (a == b) as i64,
-        OpCode::IntNe => (a != b) as i64,
-        OpCode::UintLt => ((a as u64) < (b as u64)) as i64,
-        OpCode::UintLe => ((a as u64) <= (b as u64)) as i64,
-        OpCode::UintGe => ((a as u64) >= (b as u64)) as i64,
-        OpCode::UintGt => ((a as u64) > (b as u64)) as i64,
+    execute_binary_int_const_row(opcode, a, b).folded()
+}
+
+/// [`execute_binary_int_const`] with its two `None`s separated — see
+/// [`ConstFold`]. Every opcode named below has an entry, so an arm answering
+/// `None` is that entry declining, never a missing one.
+pub fn execute_binary_int_const_row(opcode: OpCode, a: i64, b: i64) -> ConstFold<i64> {
+    let folded = match opcode {
+        OpCode::IntAdd => Some(a.wrapping_add(b)),
+        OpCode::IntSub => Some(a.wrapping_sub(b)),
+        OpCode::IntMul => Some(a.wrapping_mul(b)),
+        OpCode::IntAddOvf => a.checked_add(b),
+        OpCode::IntSubOvf => a.checked_sub(b),
+        OpCode::IntMulOvf => a.checked_mul(b),
+        OpCode::IntAnd => Some(a & b),
+        OpCode::IntOr => Some(a | b),
+        OpCode::IntXor => Some(a ^ b),
+        OpCode::IntLshift => (0..64).contains(&b).then(|| a << b),
+        OpCode::IntRshift => (0..64).contains(&b).then(|| a >> b),
+        OpCode::UintRshift => (0..64).contains(&b).then(|| (a as u64 >> b as u64) as i64),
+        OpCode::IntLt => Some((a < b) as i64),
+        OpCode::IntLe => Some((a <= b) as i64),
+        OpCode::IntGt => Some((a > b) as i64),
+        OpCode::IntGe => Some((a >= b) as i64),
+        OpCode::IntEq => Some((a == b) as i64),
+        OpCode::IntNe => Some((a != b) as i64),
+        OpCode::UintLt => Some(((a as u64) < (b as u64)) as i64),
+        OpCode::UintLe => Some(((a as u64) <= (b as u64)) as i64),
+        OpCode::UintGe => Some(((a as u64) >= (b as u64)) as i64),
+        OpCode::UintGt => Some(((a as u64) > (b as u64)) as i64),
         // Truncating, as `_ll_2_int_floordiv` / `_ll_2_int_mod` are and as the
         // blackhole and every backend execute them. Wrapping keeps
         // `i64::MIN / -1` off the panic path; the trace guards that corner out
         // before it reaches either op.
-        OpCode::IntFloorDiv if b != 0 => a.wrapping_div(b),
-        OpCode::IntMod if b != 0 => a.wrapping_rem(b),
-        OpCode::IntSignext if (1..=8).contains(&b) => {
-            // `blackhole.bhimpl_int_signext` delegates to `support.int_signext`.
-            crate::support::int_signext(a, b)
-        }
+        OpCode::IntFloorDiv => (b != 0).then(|| a.wrapping_div(b)),
+        OpCode::IntMod => (b != 0).then(|| a.wrapping_rem(b)),
+        // `blackhole.bhimpl_int_signext` delegates to `support.int_signext`.
+        OpCode::IntSignext => (1..=8)
+            .contains(&b)
+            .then(|| crate::support::int_signext(a, b)),
         OpCode::UintMulHigh => {
             // blackhole.py bhimpl_uint_mul_high — high 64 of (a as u64) * (b as u64).
-            (((a as u64) as u128 * (b as u64) as u128) >> 64) as i64
+            Some((((a as u64) as u128 * (b as u64) as u128) >> 64) as i64)
         }
-        _ => return None,
+        _ => return ConstFold::Unregistered,
     };
-    Some(result)
+    match folded {
+        Some(value) => ConstFold::Folded(value),
+        None => ConstFold::Declined,
+    }
 }
 
 /// Pointer-comparison row of `executor.EXECUTE_BY_NUM_ARGS`.
@@ -507,14 +545,23 @@ pub fn execute_unary_float_const(opcode: OpCode, a: f64) -> Option<f64> {
 /// performs `a / b` through `blackhole.bhimpl_float_truediv`;
 /// only trace-time folding is suppressed.
 pub fn execute_binary_float_const(opcode: OpCode, a: f64, b: f64) -> Option<f64> {
-    let result = match opcode {
-        OpCode::FloatAdd => a + b,
-        OpCode::FloatSub => a - b,
-        OpCode::FloatMul => a * b,
-        OpCode::FloatTrueDiv if b != 0.0 => a / b,
-        _ => return None,
+    execute_binary_float_const_row(opcode, a, b).folded()
+}
+
+/// [`execute_binary_float_const`] with its two `None`s separated — see
+/// [`ConstFold`].
+pub fn execute_binary_float_const_row(opcode: OpCode, a: f64, b: f64) -> ConstFold<f64> {
+    let folded = match opcode {
+        OpCode::FloatAdd => Some(a + b),
+        OpCode::FloatSub => Some(a - b),
+        OpCode::FloatMul => Some(a * b),
+        OpCode::FloatTrueDiv => (b != 0.0).then(|| a / b),
+        _ => return ConstFold::Unregistered,
     };
-    Some(result)
+    match folded {
+        Some(value) => ConstFold::Folded(value),
+        None => ConstFold::Declined,
+    }
 }
 
 /// Float-comparison row of `executor.EXECUTE_BY_NUM_ARGS`, mirroring the
@@ -577,8 +624,10 @@ pub fn execute_nonspec_const(
         {
             return Ok(Some(Value::Float(folded)));
         }
-        if let Some(folded) = execute_cast_const(opnum, a) {
-            return Ok(Some(folded));
+        match execute_cast_const_row(opnum, a) {
+            ConstFold::Folded(folded) => return Ok(Some(folded)),
+            ConstFold::Declined => return Ok(None),
+            ConstFold::Unregistered => {}
         }
         // GETFIELD_GC_{I,R,F} — withdescr arity-1.
         // The executor helper is registered under the plain opnum
@@ -652,14 +701,18 @@ pub fn execute_nonspec_const(
 
     // ── arity == 2 row of EXECUTE_BY_NUM_ARGS ──
     if arity == 2 {
-        if let (Value::Int(a), Value::Int(b)) = (argboxes[0], argboxes[1])
-            && let Some(folded) = execute_binary_int_const(opnum, a, b)
-        {
-            return Ok(Some(Value::Int(folded)));
+        if let (Value::Int(a), Value::Int(b)) = (argboxes[0], argboxes[1]) {
+            match execute_binary_int_const_row(opnum, a, b) {
+                ConstFold::Folded(folded) => return Ok(Some(Value::Int(folded))),
+                ConstFold::Declined => return Ok(None),
+                ConstFold::Unregistered => {}
+            }
         }
         if let (Value::Float(a), Value::Float(b)) = (argboxes[0], argboxes[1]) {
-            if let Some(folded) = execute_binary_float_const(opnum, a, b) {
-                return Ok(Some(Value::Float(folded)));
+            match execute_binary_float_const_row(opnum, a, b) {
+                ConstFold::Folded(folded) => return Ok(Some(Value::Float(folded))),
+                ConstFold::Declined => return Ok(None),
+                ConstFold::Unregistered => {}
             }
             if let Some(folded) = execute_float_compare_const(opnum, a, b) {
                 return Ok(Some(Value::Int(folded)));
@@ -745,6 +798,11 @@ pub fn execute_nonspec_const(
 ///   CAST_PTR_TO_INT / CAST_INT_TO_PTR — pointer reinterpret
 /// Mirrors blackhole.py bhimpl_cast_*.
 pub fn execute_cast_const(opcode: OpCode, arg: majit_ir::Value) -> Option<majit_ir::Value> {
+    execute_cast_const_row(opcode, arg).folded()
+}
+
+/// [`execute_cast_const`] with its two `None`s separated — see [`ConstFold`].
+pub fn execute_cast_const_row(opcode: OpCode, arg: majit_ir::Value) -> ConstFold<majit_ir::Value> {
     use majit_ir::{GcRef, Value};
     match (opcode, arg) {
         (OpCode::CastFloatToInt, Value::Float(f)) => {
@@ -759,26 +817,23 @@ pub fn execute_cast_const(opcode: OpCode, arg: majit_ir::Value) -> Option<majit_
             // `i64::MIN ..= i64::MAX`; `i64::MAX + 1` rounds to the
             // same f64 as `i64::MAX` (precision loss), so use the
             // strictly-less-than upper bound `9.223372036854776e18`.
-            if !f.is_finite() {
-                return None;
+            if !f.is_finite() || f < (i64::MIN as f64) || f >= 9.223372036854776e18_f64 {
+                return ConstFold::Declined;
             }
-            if f < (i64::MIN as f64) || f >= 9.223372036854776e18_f64 {
-                return None;
-            }
-            Some(Value::Int(f as i64))
+            ConstFold::Folded(Value::Int(f as i64))
         }
-        (OpCode::CastIntToFloat, Value::Int(i)) => Some(Value::Float(i as f64)),
+        (OpCode::CastIntToFloat, Value::Int(i)) => ConstFold::Folded(Value::Float(i as f64)),
         (OpCode::CastFloatToSinglefloat, Value::Float(f)) => {
-            Some(Value::Int((f as f32).to_bits() as i64))
+            ConstFold::Folded(Value::Int((f as f32).to_bits() as i64))
         }
         (OpCode::CastSinglefloatToFloat, Value::Int(i)) => {
-            Some(Value::Float(f32::from_bits(i as u32) as f64))
+            ConstFold::Folded(Value::Float(f32::from_bits(i as u32) as f64))
         }
         (OpCode::ConvertFloatBytesToLonglong, Value::Float(f)) => {
-            Some(Value::Int(f.to_bits() as i64))
+            ConstFold::Folded(Value::Int(f.to_bits() as i64))
         }
         (OpCode::ConvertLonglongBytesToFloat, Value::Int(i)) => {
-            Some(Value::Float(f64::from_bits(i as u64)))
+            ConstFold::Folded(Value::Float(f64::from_bits(i as u64)))
         }
         // `assembler.py:1528-1529 genop_cast_ptr_to_int =
         // _genop_same_as` / `genop_cast_int_to_ptr = _genop_same_as`.
@@ -786,9 +841,9 @@ pub fn execute_cast_const(opcode: OpCode, arg: majit_ir::Value) -> Option<majit_
         // backend, executor, and test_lltype.py:693-701 /
         // runner_test.py:1957-1966 expect
         // `cast_int_to_ptr(21) → cast_ptr_to_int == 21`.
-        (OpCode::CastPtrToInt, Value::Ref(r)) => Some(Value::Int(r.0 as i64)),
-        (OpCode::CastIntToPtr, Value::Int(i)) => Some(Value::Ref(GcRef(i as usize))),
-        _ => None,
+        (OpCode::CastPtrToInt, Value::Ref(r)) => ConstFold::Folded(Value::Int(r.0 as i64)),
+        (OpCode::CastIntToPtr, Value::Int(i)) => ConstFold::Folded(Value::Ref(GcRef(i as usize))),
+        _ => ConstFold::Unregistered,
     }
 }
 
@@ -1202,5 +1257,94 @@ mod execute_nonspec_const_tests {
             Ok(Some(Value::Int(42))) => {}
             other => panic!("{opnum:?} must fold to Ok(Some(Int(42))), got {other:?}"),
         }
+    }
+
+    /// Every registered helper that refuses its operands must answer
+    /// `Ok(None)`. `Err(NoConstExecutor)` is upstream's
+    /// `NotImplementedError`, and `Optimizer::constant_fold` spells it as a
+    /// `panic!` — so conflating the two turns a decline into a crash.
+    #[test]
+    fn a_registered_helper_that_refuses_its_operands_answers_ok_none() {
+        let cpu = crate::cpu::default_cpu();
+        let declines: &[(OpCode, Vec<Value>, Type)] = &[
+            // Shift count outside `blackhole.check_shift_count`'s range.
+            (
+                OpCode::IntLshift,
+                vec![Value::Int(1), Value::Int(64)],
+                Type::Int,
+            ),
+            (
+                OpCode::IntRshift,
+                vec![Value::Int(1), Value::Int(-1)],
+                Type::Int,
+            ),
+            // Zero divisor.
+            (
+                OpCode::IntFloorDiv,
+                vec![Value::Int(5), Value::Int(0)],
+                Type::Int,
+            ),
+            (
+                OpCode::IntMod,
+                vec![Value::Int(5), Value::Int(0)],
+                Type::Int,
+            ),
+            // OVF opcodes are spelled with `checked_*`.
+            (
+                OpCode::IntAddOvf,
+                vec![Value::Int(i64::MAX), Value::Int(1)],
+                Type::Int,
+            ),
+            (
+                OpCode::IntSubOvf,
+                vec![Value::Int(i64::MIN), Value::Int(1)],
+                Type::Int,
+            ),
+            (
+                OpCode::IntMulOvf,
+                vec![Value::Int(i64::MAX), Value::Int(2)],
+                Type::Int,
+            ),
+            // `test_optimizebasic.test_float_division_by_multiplication`
+            // keeps `float_truediv(f, 0.0)` in the optimized loop.
+            (
+                OpCode::FloatTrueDiv,
+                vec![Value::Float(1.0), Value::Float(0.0)],
+                Type::Float,
+            ),
+            // Non-finite and out-of-range `cast_float_to_int`.
+            (
+                OpCode::CastFloatToInt,
+                vec![Value::Float(f64::INFINITY)],
+                Type::Int,
+            ),
+            (
+                OpCode::CastFloatToInt,
+                vec![Value::Float(f64::NAN)],
+                Type::Int,
+            ),
+            (OpCode::CastFloatToInt, vec![Value::Float(1e30)], Type::Int),
+        ];
+        for (opnum, args, ty) in declines {
+            match execute_nonspec_const(cpu.as_ref(), *opnum, args, None, *ty) {
+                Ok(None) => {}
+                other => panic!("{opnum:?}{args:?} must decline with Ok(None), got {other:?}"),
+            }
+        }
+    }
+
+    /// The counterpart: an opcode with no row at all still reaches
+    /// `Err(NoConstExecutor)`, so the distinction is real in both directions.
+    #[test]
+    fn an_opcode_with_no_row_still_answers_err() {
+        let cpu = crate::cpu::default_cpu();
+        let folded = execute_nonspec_const(
+            cpu.as_ref(),
+            OpCode::SetfieldGc,
+            &[Value::Int(1), Value::Int(2)],
+            None,
+            Type::Void,
+        );
+        assert_eq!(folded, Err(NoConstExecutor));
     }
 }

--- a/majit/majit-metainterp/src/executor.rs
+++ b/majit/majit-metainterp/src/executor.rs
@@ -796,8 +796,8 @@ pub fn execute_cast_const(opcode: OpCode, arg: majit_ir::Value) -> Option<majit_
 ///
 /// RPython `executor.execute_varargs(cpu, ..., exc=False)`
 /// (`executor.py:75-78`) skips the `metainterp.execute_raised` coordination
-/// when the helper provably cannot raise — `pyjitpl.py:_record_helper_pure`
-/// (`pyjitpl.py:1346-1400`) reaches this path for every `EF_ELIDABLE_CANNOT_RAISE`
+/// when the helper provably cannot raise — `MIFrame.execute_varargs` with
+/// `pure=True` reaches this path for every `EF_ELIDABLE_CANNOT_RAISE`
 /// callee. Pyre's walker (`pyre-jit-trace::jitcode_dispatch::
 /// dispatch_residual_call_*`) cannot thread `&mut MetaInterp` through the
 /// trace recorder seam, so this helper exposes the `exc=False` shape via

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -3335,11 +3335,36 @@ impl TraceCtx {
         &self.metainterp_sd.profiler
     }
 
-    /// Root portal merge-point green key for this trace.
+    /// `pyjitpl.py MIFrame.implement_guard_value`, promoting `opref` into the
+    /// already-minted `promoted_box`.
     ///
-    /// Mirrors RPython's `current_merge_points[0]`: this stays anchored to the
-    /// original loop/portal merge point even if `green_key` is later retargeted
-    /// Record a promote: emit GuardValue to specialize on a runtime value.
+    /// Upstream mints the constant itself with `executor.constant_from_op(box)`,
+    /// which dispatches on the box's type; `TraceCtx` spells that through three
+    /// type-specific entry points, so the typed wrappers below mint and this
+    /// body takes the result.
+    ///
+    /// Upstream's `self.metainterp.replace_box(box, promoted_box)` is not here:
+    /// it walks the `MIFrame` register banks, which live a layer above the
+    /// recorder. Callers that need the rebind do it themselves.
+    fn implement_guard_value(
+        &mut self,
+        opref: OpRef,
+        promoted_box: OpRef,
+        num_live: usize,
+    ) -> OpRef {
+        // `if isinstance(box, Const): return box  # no promotion needed`.
+        // Structurally first: a `GuardValue` over an already-constant box can
+        // only ever succeed, and it would still hang a full resume snapshot
+        // off itself.
+        if opref.is_constant() {
+            return opref;
+        }
+        self.record_guard_with_snapshot(OpCode::GuardValue, &[opref, promoted_box], num_live);
+        promoted_box
+    }
+
+    /// Record an int-typed promote: emit GuardValue to specialize on a runtime
+    /// value.
     ///
     /// In RPython this is `jit.promote(x)` — it records a `GUARD_VALUE`
     /// that asserts the runtime value equals the constant captured during
@@ -3349,15 +3374,13 @@ impl TraceCtx {
     /// value seen at trace time.
     pub fn promote_int(&mut self, opref: OpRef, runtime_value: i64, num_live: usize) -> OpRef {
         let const_ref = self.const_int(runtime_value);
-        self.record_guard_with_snapshot(OpCode::GuardValue, &[opref, const_ref], num_live);
-        const_ref
+        self.implement_guard_value(opref, const_ref, num_live)
     }
 
     /// Record a ref-typed promote (GUARD_VALUE for GC references).
     pub fn promote_ref(&mut self, opref: OpRef, runtime_value: i64, num_live: usize) -> OpRef {
         let const_ref = self.const_ref(runtime_value);
-        self.record_guard_with_snapshot(OpCode::GuardValue, &[opref, const_ref], num_live);
-        const_ref
+        self.implement_guard_value(opref, const_ref, num_live)
     }
 
     /// Record a float-typed promote (GUARD_VALUE for floats).
@@ -3365,8 +3388,7 @@ impl TraceCtx {
     /// pyjitpl.py opimpl_float_guard_value = _opimpl_guard_value
     pub fn promote_float(&mut self, opref: OpRef, runtime_value: i64, num_live: usize) -> OpRef {
         let const_ref = self.const_float(runtime_value);
-        self.record_guard_with_snapshot(OpCode::GuardValue, &[opref, const_ref], num_live);
-        const_ref
+        self.implement_guard_value(opref, const_ref, num_live)
     }
 
     /// `pyjitpl.py generate_guard` + `:2610 capture_resumedata`:
@@ -3426,8 +3448,8 @@ impl TraceCtx {
     /// That hoist narrows this path, it does not close it, and the
     /// difference is worth stating because the doc above was already once
     /// wrong in exactly this direction. `get_arrayitem_vable_index` still
-    /// carries its `promote_int` call; it is guarded by `index.is_constant()`
-    /// and so fires only for an index that did not arrive constant. What the
+    /// carries its `promote_int` call; `implement_guard_value`'s Const arm
+    /// makes it fire only for an index that did not arrive constant. What the
     /// hoist bought is that the `pyjitpl/dispatch.rs` family is const *by
     /// construction* at all of its index reads. The
     /// `jitcode_dispatch/vable_ops.rs` family is gated only on the index
@@ -5525,6 +5547,34 @@ mod history_record_tests {
         recorder.close_loop(jump_args);
         let mut trace = recorder.get_trace();
         (*trace.ops.remove(0)).clone()
+    }
+
+    /// `MIFrame.implement_guard_value`'s `isinstance(box, Const)` arm, for all
+    /// three typed entry points: an already-constant box is handed straight
+    /// back, with no `GUARD_VALUE` and so no resume snapshot behind one.
+    #[test]
+    fn promoting_an_already_constant_box_records_no_guard() {
+        let (mut ctx, _) = make_ctx_with_mixed_inputs();
+        let before = ctx.num_guards();
+
+        let i = OpRef::const_int(7);
+        assert_eq!(ctx.promote_int(i, 7, 0), i);
+        let f = OpRef::const_float(1.5);
+        assert_eq!(ctx.promote_float(f, 1.5f64.to_bits() as i64, 0), f);
+        let r = OpRef::const_ptr(majit_ir::GcRef(0));
+        assert_eq!(ctx.promote_ref(r, 0, 0), r);
+
+        assert_eq!(ctx.num_guards(), before, "a Const needs no promotion");
+    }
+
+    /// The other arm, unchanged: a real box still gets its `GUARD_VALUE` and
+    /// the promoted constant back.
+    #[test]
+    fn promoting_a_non_constant_box_records_the_guard() {
+        let (mut ctx, args) = make_ctx_with_mixed_inputs();
+        let before = ctx.num_guards();
+        assert_eq!(ctx.promote_int(args[2], 7, 0), OpRef::const_int(7));
+        assert_eq!(ctx.num_guards(), before + 1);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -1690,6 +1690,36 @@ impl JitCodeBuilder {
         self.push_reg_u8(dst, "getarrayitem_gc_i dst");
     }
 
+    /// The always-pure spelling of [`Self::getarrayitem_gc_i`], for an array
+    /// whose elements never change after it is built.
+    ///
+    /// `blackhole.py` aliases `bhimpl_getarrayitem_gc_i_pure` onto the plain
+    /// impl, so the two run the same handler; what differs is the opcode the
+    /// tracer records. `GetarrayitemGcPureI` is inside the always-pure range
+    /// that `OpHelpers.is_pure_with_descr` admits, which is what licenses the
+    /// record-time constant fold of a read at a green index — the same fold
+    /// `rlist.py ll_getitem_foldable_nonneg` earns by spelling the read this
+    /// way. Emitting the plain opcode and folding it anyway would fold on the
+    /// accident of who the caller happens to be.
+    ///
+    /// Encoding is [`Self::getarrayitem_gc_i`]'s.
+    pub fn getarrayitem_gc_i_pure(
+        &mut self,
+        dst: u16,
+        array_reg: u16,
+        index_reg: u16,
+        descr_idx: u16,
+    ) {
+        self.touch_ref_reg(array_reg);
+        self.touch_reg(index_reg);
+        self.touch_reg(dst);
+        self.write_insn("getarrayitem_gc_i_pure/rid>i");
+        self.push_reg_u8(array_reg, "getarrayitem_gc_i_pure array");
+        self.push_reg_u8(index_reg, "getarrayitem_gc_i_pure index");
+        self.push_u16(descr_idx);
+        self.push_reg_u8(dst, "getarrayitem_gc_i_pure dst");
+    }
+
     /// Ref-result array read: `dst = array[index]` where the element is a
     /// GC pointer (8 bytes). Mirrors [`Self::getarrayitem_gc_i`] but routes
     /// `dst` through the ref register bank and uses the `/rid>r` mnemonic.

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -2469,15 +2469,19 @@ impl JitCodeBuilder {
         *slot = Some(self.code.len());
     }
 
-    /// RPython `flatten.py:247` emits the bool exitswitch as opname
-    /// `goto_if_not` (not `goto_if_not_int_is_true`).  The `_int_is_true`
-    /// suffix in upstream is a Python class-attribute alias on
-    /// `BlackholeInterpreter` (`blackhole.py`
-    /// `bhimpl_goto_if_not_int_is_true = bhimpl_goto_if_not`) that
-    /// shares the handler function under two attribute names — it is
-    /// NOT a second opname registered in `Assembler.insns`.  The Rust
-    /// method name preserves the longer attribute spelling for
-    /// readability; the bytecode key matches upstream's single opname.
+    /// RPython `flatten.py` emits a plain `Bool` exitswitch as opname
+    /// `goto_if_not`, which is what this writes.
+    ///
+    /// `goto_if_not_int_is_true` is a real second opname upstream —
+    /// `jtransform.py optimize_goto_if_not` admits `int_is_true` into the set
+    /// of operations it folds into the exitswitch tuple, and `flatten.py` then
+    /// spells the opname `'goto_if_not_' + exitswitch[0]`. It reaches
+    /// `MIFrame.opimpl_goto_if_not_int_is_true`, which re-executes the folded
+    /// `INT_IS_TRUE` before branching. Nothing here performs that fold: every
+    /// caller's condition is a Rust `bool`, already the `0|1` the canonical
+    /// opname wants, so there is no `int_is_true` to fold away and no
+    /// operation to re-materialise. The Rust method keeps the longer name for
+    /// readability at the call site.
     pub fn goto_if_not_int_is_true(&mut self, reg: u16, label: u16) {
         self.touch_reg(reg);
         self.write_insn("goto_if_not/iL");

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -846,6 +846,18 @@ impl JitCodeBuilder {
     /// resolves the `d` argcode to a FieldDescr carrying the byte
     /// offset; the flag/sign follow the field kind.
     fn add_scalar_field_descr(&mut self, offset: usize, field_type: majit_ir::value::Type) -> u16 {
+        self.add_scalar_field_descr_with_immutability(offset, field_type, false)
+    }
+
+    /// [`Self::add_scalar_field_descr`] for a field the codewriter declared in
+    /// `_immutable_fields_`, so `SimpleFieldDescr::is_always_pure` answers
+    /// true and the read is foldable.
+    fn add_scalar_field_descr_with_immutability(
+        &mut self,
+        offset: usize,
+        field_type: majit_ir::value::Type,
+        is_immutable: bool,
+    ) -> u16 {
         let (field_flag, is_field_signed) = match field_type {
             majit_ir::value::Type::Ref => (majit_ir::descr::ArrayFlag::Pointer, false),
             majit_ir::value::Type::Float => (majit_ir::descr::ArrayFlag::Float, false),
@@ -857,7 +869,7 @@ impl JitCodeBuilder {
             field_type,
             field_flag,
             is_field_signed,
-            is_immutable: false,
+            is_immutable,
             is_quasi_immutable: false,
             // Same as the vable synthesizers: no parent, so no slot claim.
             index_in_parent: None,
@@ -1055,6 +1067,22 @@ impl JitCodeBuilder {
         self.push_reg_u8(struct_reg, "getfield_gc_i struct");
         self.push_u16(descr);
         self.push_reg_u8(dest, "getfield_gc_i result");
+    }
+
+    /// Emit `getfield_gc_i_pure/rd>i` (`blackhole.py
+    /// bhimpl_getfield_gc_i_pure`): the same load as
+    /// [`Self::getfield_gc_i`], off a field declared immutable. The bytecode
+    /// pair carries no separate op-kind — the recorded `GetfieldGcI` carries
+    /// the immutable descr, and that descr is what licenses the fold.
+    pub fn getfield_gc_i_pure(&mut self, dest: u16, struct_reg: u16, offset: usize) {
+        self.touch_ref_reg(struct_reg);
+        self.touch_reg(dest);
+        let descr =
+            self.add_scalar_field_descr_with_immutability(offset, majit_ir::value::Type::Int, true);
+        self.write_insn("getfield_gc_i_pure/rd>i");
+        self.push_reg_u8(struct_reg, "getfield_gc_i_pure struct");
+        self.push_u16(descr);
+        self.push_reg_u8(dest, "getfield_gc_i_pure result");
     }
 
     /// Emit `getfield_gc_r/rd>r` (`blackhole.py bhimpl_getfield_gc_r`):

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -106,6 +106,7 @@ pub mod counter;
 pub use majit_backend::model as cpu;
 pub use majit_ir::Value;
 pub use majit_ir::debug;
+pub mod execute_and_record;
 pub mod executor;
 pub mod gc;
 pub mod graphpage;

--- a/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
+++ b/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
@@ -32,7 +32,7 @@ pub fn tag_box(
     memo: &mut crate::resume::ResumeDataLoopMemo,
     env: &dyn majit_ir::BoxEnv,
     new_liveboxes: &crate::resume::LiveboxMap,
-) -> i16 {
+) -> Result<i16, crate::resume::TagOverflow> {
     memo._gettagged(opref, env, liveboxes_from_env, new_liveboxes)
 }
 
@@ -68,7 +68,7 @@ pub fn serialize_optimizer_knowledge(
     new_liveboxes: &crate::resume::LiveboxMap,
     env: &dyn majit_ir::BoxEnv,
     optimizer_knowledge: Option<&crate::resume::OptimizerKnowledgeForResume>,
-) {
+) -> Result<(), crate::resume::TagOverflow> {
     // bridgeopt.py `available_boxes = {}` followed by
     // `available_boxes[box] = None` — RPython uses a dict as a
     // membership set (values are always None). Pyre uses a Vec scanned
@@ -151,7 +151,7 @@ pub fn serialize_optimizer_knowledge(
         numb_state.append_int(0); // struct fields count
         numb_state.append_int(0); // array items count
         numb_state.append_int(0); // loopinvariant count
-        return;
+        return Ok(());
     };
     // bridgeopt.py:93: triples_struct = optimizer.optheap.serialize_optheap(available_boxes)
     let filtered_fields: Vec<(OpRef, i32, OpRef)> = knowledge
@@ -166,10 +166,10 @@ pub fn serialize_optimizer_knowledge(
         .collect();
     numb_state.append_int(filtered_fields.len() as i64);
     for (obj, descr_idx, val) in &filtered_fields {
-        let obj_tag = tag_box(*obj, &numb_state.liveboxes, memo, env, new_liveboxes);
+        let obj_tag = tag_box(*obj, &numb_state.liveboxes, memo, env, new_liveboxes)?;
         numb_state.writer.append_short(obj_tag as i32);
         numb_state.append_int(*descr_idx as i64);
-        let val_tag = tag_box(*val, &numb_state.liveboxes, memo, env, new_liveboxes);
+        let val_tag = tag_box(*val, &numb_state.liveboxes, memo, env, new_liveboxes)?;
         numb_state.writer.append_short(val_tag as i32);
     }
     // bridgeopt.py:102-108: array items
@@ -185,7 +185,7 @@ pub fn serialize_optimizer_knowledge(
         .collect();
     numb_state.append_int(filtered_arrayitems.len() as i64);
     for (obj, index, descr_idx, val) in &filtered_arrayitems {
-        let obj_tag = tag_box(*obj, &numb_state.liveboxes, memo, env, new_liveboxes);
+        let obj_tag = tag_box(*obj, &numb_state.liveboxes, memo, env, new_liveboxes)?;
         numb_state.writer.append_short(obj_tag as i32);
         // bridgeopt.py:106 numb_state.append_int(index) — pass the original
         // index unchanged; resumecode.py:90-93 enforces SHORT range on the
@@ -193,7 +193,7 @@ pub fn serialize_optimizer_knowledge(
         // index into an i32.
         numb_state.append_int(*index);
         numb_state.append_int(*descr_idx as i64);
-        let val_tag = tag_box(*val, &numb_state.liveboxes, memo, env, new_liveboxes);
+        let val_tag = tag_box(*val, &numb_state.liveboxes, memo, env, new_liveboxes)?;
         numb_state.writer.append_short(val_tag as i32);
     }
 
@@ -206,11 +206,12 @@ pub fn serialize_optimizer_knowledge(
         .collect();
     numb_state.append_int(filtered_loopinvariant.len() as i64);
     for (const_ptr, result) in &filtered_loopinvariant {
-        let const_tag = memo.getconst_int(*const_ptr);
+        let const_tag = memo.getconst_int(*const_ptr)?;
         numb_state.writer.append_short(const_tag as i32);
-        let result_tag = tag_box(*result, &numb_state.liveboxes, memo, env, new_liveboxes);
+        let result_tag = tag_box(*result, &numb_state.liveboxes, memo, env, new_liveboxes)?;
         numb_state.writer.append_short(result_tag as i32);
     }
+    Ok(())
 }
 
 /// `frontend_boxes`: runtime values from guard failure (RPython Box objects

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -6651,8 +6651,12 @@ impl OptContext {
 
         // resume.py, 520-558: pending_setfields are passed to finish()
         // which handles register_box, visitor_walk_recursive, and tagging.
-        let (rd_numb, rd_consts, rd_virtuals, liveboxes, livebox_types) =
-            memo.finish(numb_state, &env, &mut pending_setfields, knowledge.as_ref());
+        let Ok((rd_numb, rd_consts, rd_virtuals, liveboxes, livebox_types)) =
+            memo.finish(numb_state, &env, &mut pending_setfields, knowledge.as_ref())
+        else {
+            self.signal_invalid_loop("resume numbering: TagOverflow");
+            return;
+        };
 
         if crate::callee_rca_enabled() {
             let vable_items = if rd_numb.len() >= 3 {

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -2294,13 +2294,15 @@ mod tests {
             true,
         );
 
-        let ovf_count = result
+        let opcodes: Vec<OpCode> = result.iter().map(|o| o.opcode).collect();
+        let ovf_at = opcodes
             .iter()
-            .filter(|o| o.opcode == OpCode::IntAddOvf)
-            .count();
+            .position(|opcode| *opcode == OpCode::IntAddOvf)
+            .unwrap_or_else(|| panic!("the OVF op must survive the fold, got {opcodes:?}"));
         assert_eq!(
-            ovf_count, 1,
-            "an overflowing OVF pair must survive the fold"
+            opcodes.get(ovf_at + 1),
+            Some(&OpCode::GuardNoOverflow),
+            "the guard that catches the overflow must still follow it, got {opcodes:?}"
         );
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -2272,6 +2272,38 @@ mod tests {
         assert_eq!(ovf_count, 0, "OVF(3,4) should be constant-folded");
     }
 
+    /// The all-constant pair that actually overflows. `constant_fold` panics
+    /// on `Err(NoConstExecutor)` — upstream's `NotImplementedError` — and the
+    /// `all_args_const` pre-check above the call does not filter this case, so
+    /// the executor must answer `Ok(None)` here and not fall through to
+    /// `Err`. The op and its guard then stay, and the runtime guard fires.
+    #[test]
+    fn test_ovf_constant_fold_declines_on_real_overflow() {
+        let result = run_pure(
+            0,
+            &[
+                op_spec(
+                    OpCode::IntAddOvf,
+                    &[Arg::Const(Value::Int(i64::MAX)), Arg::Const(Value::Int(1))],
+                ),
+                op_spec(OpCode::GuardNoOverflow, &[]),
+                op_spec(OpCode::Finish, &[]),
+            ],
+            &mut majit_ir::ConstMap::new(),
+            &[],
+            true,
+        );
+
+        let ovf_count = result
+            .iter()
+            .filter(|o| o.opcode == OpCode::IntAddOvf)
+            .count();
+        assert_eq!(
+            ovf_count, 1,
+            "an overflowing OVF pair must survive the fold"
+        );
+    }
+
     fn run_immutable_getfield_cse(opcode: OpCode, index: u32, field_type: Type) -> Vec<Op> {
         let flag = match field_type {
             Type::Int => majit_ir::ArrayFlag::Signed,

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -649,29 +649,6 @@ impl OptRewrite {
         OptimizationResult::PassOn
     }
 
-    /// Constant fold int_between(a, b, c) => a <= b < c.
-    fn optimize_int_between(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = op.arg(0);
-        let arg1 = op.arg(1);
-        let arg2 = op.arg(2);
-
-        if let (Some(a), Some(b), Some(c)) = (
-            ctx.resolve_operand_operand_opt(&arg0)
-                .and_then(|b| ctx.get_constant_int_box(&b)),
-            ctx.resolve_operand_operand_opt(&arg1)
-                .and_then(|b| ctx.get_constant_int_box(&b)),
-            ctx.resolve_operand_operand_opt(&arg2)
-                .and_then(|b| ctx.get_constant_int_box(&b)),
-        ) {
-            let result = (a <= b && b < c) as i64;
-            let b = ctx.materialize_operand_at(op.pos.get());
-            ctx.make_constant_box(&b, Value::Int(result));
-            return OptimizationResult::Remove;
-        }
-
-        OptimizationResult::PassOn
-    }
-
     // ── Comparisons ──
 
     /// Comparison folds (constant folds, knownbits eq/ne, eq_zero /
@@ -1917,7 +1894,6 @@ impl Optimization for OptRewrite {
             OpCode::IntIsZero => self.optimize_int_is_zero(op, ctx),
             OpCode::IntIsTrue => self.optimize_int_is_true(op, op_rc, ctx),
             OpCode::IntForceGeZero => self.optimize_int_force_ge_zero(op, op_rc, ctx),
-            OpCode::IntBetween => self.optimize_int_between(op, ctx),
             OpCode::IntMul => self.optimize_int_mul_range_test(op, ctx),
 
             // ── Comparisons ──

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -99,13 +99,18 @@ pub struct OptRewrite {
     /// present at `pure.rs`) keyed off the pure-op table — coupled to the
     /// pure-optimizer subsystem.
     ///
-    /// `comparison_producing` reads the map the other way round. That
-    /// direction has no index because the reverse question is asked only for
-    /// the operands of an `IntMul`, whereas the forward one is asked up to
-    /// three times per comparison; a second map would buy the rare lookup a
-    /// constant factor at the price of a parallel record of box identity to
-    /// keep in step.
+    /// A repeated comparison overwrites its key, which is why the reverse
+    /// question gets its own map below rather than a backwards scan of this
+    /// one.
     comparison_results: indexmap::IndexMap<(OpCode, OpRef, OpRef), OpRef>,
+    /// The same records keyed by the result, for `comparison_producing`.
+    ///
+    /// Results are unique per operation, so every comparison that passes
+    /// through keeps an entry here even when a later duplicate takes over its
+    /// forward key. A consumer asks under the result CSE left live, which is
+    /// the *earlier* of a duplicate pair — the one the forward map no longer
+    /// names.
+    comparison_by_result: indexmap::IndexMap<OpRef, (OpCode, OpRef, OpRef)>,
     /// rewrite.py:39: loop_invariant_results — cache for CALL_LOOPINVARIANT results.
     /// Key: function pointer (arg0 as i64).
     /// Value: Direct(OpRef) or Preamble(PreambleOp) — RPython isinstance check.
@@ -119,6 +124,7 @@ impl OptRewrite {
     pub fn new() -> Self {
         OptRewrite {
             comparison_results: indexmap::IndexMap::new(),
+            comparison_by_result: indexmap::IndexMap::new(),
             loop_invariant_results: indexmap::IndexMap::new(),
             loop_invariant_producer: indexmap::IndexMap::new(),
         }
@@ -658,12 +664,13 @@ impl OptRewrite {
         let arg1 = ctx.resolve_operand_operand(&op.arg(1)).to_opref();
         self.comparison_results
             .insert((op.opcode, arg0, arg1), op.pos.get());
+        self.comparison_by_result
+            .insert(op.pos.get(), (op.opcode, arg0, arg1));
 
         OptimizationResult::PassOn
     }
 
-    /// The comparison whose result is `result`, read out of
-    /// `comparison_results` backwards.
+    /// The comparison whose result is `result`.
     ///
     /// A fold that reaches back from a consumer to its comparison operands
     /// cannot use `get_producing_op`: that reports a producer only once it is
@@ -674,15 +681,8 @@ impl OptRewrite {
     /// written as the comparison passes through this pass, so nothing
     /// downstream can hide it.
     ///
-    /// The last matching entry wins: keys are inserted in trace order and a
-    /// repeated key overwrites, so scanning backwards reports the record that
-    /// is still live.
     fn comparison_producing(&self, result: OpRef) -> Option<(OpCode, OpRef, OpRef)> {
-        self.comparison_results
-            .iter()
-            .rev()
-            .find(|(_, produced)| **produced == result)
-            .map(|(&(opcode, arg0, arg1), _)| (opcode, arg0, arg1))
+        self.comparison_by_result.get(&result).copied()
     }
 
     /// One side of a range test: the value compared, its bound, and whether
@@ -2451,6 +2451,7 @@ impl Optimization for OptRewrite {
         // maintained cross-pass by propagate_from_pass_range +
         // emit_operation — no per-pass setup needed.
         self.comparison_results.clear();
+        self.comparison_by_result.clear();
         self.loop_invariant_results.clear();
         self.loop_invariant_producer.clear();
     }
@@ -2935,6 +2936,44 @@ mod tests {
             2,
             "both bound comparisons must survive the fold"
         );
+    }
+
+    /// A guest that spells the same bound twice leaves two comparisons with
+    /// one forward key, and CSE forwards the multiply's operand to the first
+    /// result. The reverse lookup has to answer for that first result, which
+    /// is the one the forward key no longer names.
+    #[test]
+    fn a_repeated_bound_comparison_still_fuses_its_range_test() {
+        let specs = vec![
+            same_i(),                    // 0: v
+            same_i(),                    // 1: LO
+            same_i(),                    // 2: HI
+            bin_i(OpCode::IntGe, 0, 1),  // 3: v >= LO
+            bin_i(OpCode::IntGe, 2, 0),  // 4: HI >= v
+            bin_i(OpCode::IntGe, 0, 1),  // 5: v >= LO, again
+            bin_i(OpCode::IntMul, 5, 4), // 6: both, reading the repeat
+        ];
+        let constants = vec![
+            (OpRef::int_op(1), Value::Int(2025)),
+            (OpRef::int_op(2), Value::Int(5625)),
+        ];
+        let (ops, queued) = run_rewrite_after_inputs(&specs, 3, &constants);
+        let opcodes = opcodes_of(&ops);
+
+        assert!(
+            !opcodes.contains(&OpCode::IntMul),
+            "the repeat must not hide the range test, got {opcodes:?}"
+        );
+        let sub = queued
+            .iter()
+            .find(|op| op.opcode == OpCode::IntSub)
+            .unwrap_or_else(|| panic!("the offset subtraction must be queued, got {queued:?}"));
+        assert_eq!(sub.arg(1).const_int(), Some(2025), "offset is `v - LO`");
+        let cmp = ops
+            .iter()
+            .find(|op| op.opcode == OpCode::UintLt)
+            .expect("the fused compare must be emitted");
+        assert_eq!(cmp.arg(1).const_int(), Some(3601));
     }
 
     /// opimpl_int_between collapses `a <= b < a+1` to `b == a`; a range whose

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -85,28 +85,27 @@ enum RangeBound {
 /// - Guard-no-exception removal after removed calls
 /// - Range-test fusion (two constant-bounded comparisons multiplied together)
 pub struct OptRewrite {
-    /// pyre-only side-cache: (opcode, arg0, arg1) → result OpRef, populated by
-    /// optimize_comparison. Upstream has no bool_result_cache; find_rewritable_bool
-    /// / try_boolinvers (rewrite.py) build a synthetic ResOperation and look
-    /// it up via get_pure_result against the shared _pure_operations table.
-    /// Convergence: retire this cache and route the bool lookups through the pure
-    /// optimizer's get_pure_result / pure_from_args2 (both already present at
-    /// `pure.rs`) keyed off the pure-op table — coupled to the pure-optimizer
-    /// subsystem. NOT a box-identity rekey target: rekeying the OpRef pair to operand
-    /// would entrench a structure upstream does not have.
-    bool_result_cache: indexmap::IndexMap<(OpCode, OpRef, OpRef), OpRef>,
-    /// Result OpRef → the comparison that produced it, the reverse of
-    /// `bool_result_cache` and populated from the same arm.
+    /// pyre-only side-cache: (opcode, arg0, arg1) → result OpRef, the sole
+    /// record of the comparisons this pass has seen. Operands are normalized
+    /// through forwarding before they are keyed on, as `OptPure.pure_from_args2`
+    /// (`pure.py`) does, so a probe and a store describe the same value the
+    /// same way.
     ///
-    /// A fold that reaches back from a consumer to its comparison operands
-    /// cannot use `get_producing_op`: that reports a producer only once it is
-    /// in `emitted_operations`, and `OptHeap` — last in the pipeline — holds
-    /// the most recent comparison in `postponed_op` instead of emitting it.
-    /// The comparison immediately preceding a consumer is therefore invisible
-    /// there, which is the common case rather than a corner one. This map is
-    /// written as the comparison passes through this pass, so nothing
-    /// downstream can hide it.
-    comparison_by_result: indexmap::IndexMap<OpRef, (OpCode, Operand, Operand)>,
+    /// Upstream has no such map: `find_rewritable_bool` / `try_boolinvers`
+    /// (`rewrite.py`) build a synthetic `ResOperation` and look the result up
+    /// with `get_pure_result` against the shared `_pure_operations` table.
+    /// Convergence: retire this cache and route the bool lookups through the
+    /// pure optimizer's `get_pure_result` / `pure_from_args2` (both already
+    /// present at `pure.rs`) keyed off the pure-op table — coupled to the
+    /// pure-optimizer subsystem.
+    ///
+    /// `comparison_producing` reads the map the other way round. That
+    /// direction has no index because the reverse question is asked only for
+    /// the operands of an `IntMul`, whereas the forward one is asked up to
+    /// three times per comparison; a second map would buy the rare lookup a
+    /// constant factor at the price of a parallel record of box identity to
+    /// keep in step.
+    comparison_results: indexmap::IndexMap<(OpCode, OpRef, OpRef), OpRef>,
     /// rewrite.py:39: loop_invariant_results — cache for CALL_LOOPINVARIANT results.
     /// Key: function pointer (arg0 as i64).
     /// Value: Direct(OpRef) or Preamble(PreambleOp) — RPython isinstance check.
@@ -119,8 +118,7 @@ pub struct OptRewrite {
 impl OptRewrite {
     pub fn new() -> Self {
         OptRewrite {
-            bool_result_cache: indexmap::IndexMap::new(),
-            comparison_by_result: indexmap::IndexMap::new(),
+            comparison_results: indexmap::IndexMap::new(),
             loop_invariant_results: indexmap::IndexMap::new(),
             loop_invariant_producer: indexmap::IndexMap::new(),
         }
@@ -655,15 +653,36 @@ impl OptRewrite {
     /// eq_one / eq_sub_eq) live in OptIntBounds, as upstream. This arm
     /// only records the comparison result for `find_rewritable_bool`
     /// (inverse/reflex lookup).
-    fn optimize_comparison(&mut self, op: &Op) -> OptimizationResult {
-        let arg0 = op.arg(0);
-        let arg1 = op.arg(1);
-        self.bool_result_cache
-            .insert((op.opcode, arg0.to_opref(), arg1.to_opref()), op.pos.get());
-        self.comparison_by_result
-            .insert(op.pos.get(), (op.opcode, arg0, arg1));
+    fn optimize_comparison(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+        let arg0 = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
+        let arg1 = ctx.resolve_operand_operand(&op.arg(1)).to_opref();
+        self.comparison_results
+            .insert((op.opcode, arg0, arg1), op.pos.get());
 
         OptimizationResult::PassOn
+    }
+
+    /// The comparison whose result is `result`, read out of
+    /// `comparison_results` backwards.
+    ///
+    /// A fold that reaches back from a consumer to its comparison operands
+    /// cannot use `get_producing_op`: that reports a producer only once it is
+    /// in `emitted_operations`, and `OptHeap` — last in the pipeline — holds
+    /// the most recent comparison in `postponed_op` instead of emitting it.
+    /// The comparison immediately preceding a consumer is therefore invisible
+    /// there, which is the common case rather than a corner one. This map is
+    /// written as the comparison passes through this pass, so nothing
+    /// downstream can hide it.
+    ///
+    /// The last matching entry wins: keys are inserted in trace order and a
+    /// repeated key overwrites, so scanning backwards reports the record that
+    /// is still live.
+    fn comparison_producing(&self, result: OpRef) -> Option<(OpCode, OpRef, OpRef)> {
+        self.comparison_results
+            .iter()
+            .rev()
+            .find(|(_, produced)| **produced == result)
+            .map(|(&(opcode, arg0, arg1), _)| (opcode, arg0, arg1))
     }
 
     /// One side of a range test: the value compared, its bound, and whether
@@ -674,20 +693,20 @@ impl OptRewrite {
     /// not a range test side — constant folding owns it.
     fn range_bound_of(
         &self,
-        entry: &(OpCode, Operand, Operand),
+        entry: (OpCode, OpRef, OpRef),
         ctx: &mut OptContext,
-    ) -> Option<(RangeBound, Operand, i64)> {
-        let (opcode, ref arg0, ref arg1) = *entry;
+    ) -> Option<(RangeBound, OpRef, i64)> {
+        let (opcode, arg0, arg1) = entry;
         if opcode != OpCode::IntGe {
             return None;
         }
-        let const_of = |ctx: &mut OptContext, o: &Operand| {
-            ctx.resolve_operand_operand_opt(o)
+        let const_of = |ctx: &mut OptContext, o: OpRef| {
+            ctx.get_box_replacement_operand_opt(o)
                 .and_then(|b| ctx.get_constant_int_box(&b))
         };
         match (const_of(ctx, arg0), const_of(ctx, arg1)) {
-            (None, Some(lo)) => Some((RangeBound::Lower, arg0.clone(), lo)),
-            (Some(hi), None) => Some((RangeBound::Upper, arg1.clone(), hi)),
+            (None, Some(lo)) => Some((RangeBound::Lower, arg0, lo)),
+            (Some(hi), None) => Some((RangeBound::Upper, arg1, hi)),
             _ => None,
         }
     }
@@ -711,14 +730,14 @@ impl OptRewrite {
         let lhs = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
         let rhs = ctx.resolve_operand_operand(&op.arg(1)).to_opref();
         let (Some(lhs_entry), Some(rhs_entry)) = (
-            self.comparison_by_result.get(&lhs).cloned(),
-            self.comparison_by_result.get(&rhs).cloned(),
+            self.comparison_producing(lhs),
+            self.comparison_producing(rhs),
         ) else {
             return OptimizationResult::PassOn;
         };
         let (Some(left), Some(right)) = (
-            self.range_bound_of(&lhs_entry, ctx),
-            self.range_bound_of(&rhs_entry, ctx),
+            self.range_bound_of(lhs_entry, ctx),
+            self.range_bound_of(rhs_entry, ctx),
         ) else {
             return OptimizationResult::PassOn;
         };
@@ -729,7 +748,7 @@ impl OptRewrite {
             | ((RangeBound::Upper, o, hi), (RangeBound::Lower, v, lo)) => ((v, lo), (o, hi)),
             _ => return OptimizationResult::PassOn,
         };
-        if var.to_opref() != other.to_opref() {
+        if var != other {
             return OptimizationResult::PassOn;
         }
         // An empty range is a constant-false predicate this fold does not
@@ -745,6 +764,7 @@ impl OptRewrite {
         // The value rides on the inline-Const OpRef tag, so a bound needs no
         // producing operation of its own.
         let lo_operand = ctx.materialize_operand_at(majit_ir::OpRef::const_int(lo));
+        let var = ctx.materialize_operand_at(var);
         // opimpl_int_between: `a <= b < a+1` is `b == a`.
         let mut fused = if span == 1 {
             Op::new(OpCode::IntEq, &[var, lo_operand])
@@ -1634,7 +1654,7 @@ impl OptRewrite {
         ctx: &mut OptContext,
     ) -> Option<OptimizationResult> {
         let key = (inverse_opcode, arg0, arg1);
-        let cached_ref = self.bool_result_cache.get(&key).copied()?;
+        let cached_ref = self.comparison_results.get(&key).copied()?;
         // rewrite.py:60-65: b = self.getintbound(oldop)
         // First try direct constant (fast path)
         if let Some(val) = ctx
@@ -1679,21 +1699,23 @@ impl OptRewrite {
         if op.num_args() < 2 {
             return None;
         }
-        let arg0 = op.arg(0);
-        let arg1 = op.arg(1);
+        // Probe with the same normalization the recording arm stores under, so
+        // a value renamed by `make_equal_to` between the comparison and its
+        // consumer still finds its entry.
+        let arg0 = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
+        let arg1 = ctx.resolve_operand_operand(&op.arg(1)).to_opref();
 
         // rewrite.py:72-75: boolinverse(arg0, arg1)
         if let Some(inverse_opcode) = op.opcode.bool_inverse()
-            && let Some(result) =
-                self.try_boolinvers(op, inverse_opcode, arg0.to_opref(), arg1.to_opref(), ctx)
+            && let Some(result) = self.try_boolinvers(op, inverse_opcode, arg0, arg1, ctx)
         {
             return Some(result);
         }
 
         // rewrite.py:77-83: boolreflex(arg1, arg0)
         if let Some(reflex_opcode) = op.opcode.bool_reflex() {
-            let key = (reflex_opcode, arg1.to_opref(), arg0.to_opref());
-            if let Some(&cached_ref) = self.bool_result_cache.get(&key) {
+            let key = (reflex_opcode, arg1, arg0);
+            if let Some(&cached_ref) = self.comparison_results.get(&key) {
                 let b_old = Operand::from_bound_op(op_rc);
                 let b_cached = ctx.get_box_replacement_operand(cached_ref);
                 ctx.make_equal_to(&b_old, &b_cached);
@@ -1702,8 +1724,7 @@ impl OptRewrite {
 
             // rewrite.py:87-91: boolreflex.boolinverse(arg1, arg0)
             if let Some(reflex_inverse) = reflex_opcode.bool_inverse()
-                && let Some(result) =
-                    self.try_boolinvers(op, reflex_inverse, arg1.to_opref(), arg0.to_opref(), ctx)
+                && let Some(result) = self.try_boolinvers(op, reflex_inverse, arg1, arg0, ctx)
             {
                 return Some(result);
             }
@@ -1906,7 +1927,7 @@ impl Optimization for OptRewrite {
             | OpCode::UintLt
             | OpCode::UintLe
             | OpCode::UintGt
-            | OpCode::UintGe => self.optimize_comparison(op),
+            | OpCode::UintGe => self.optimize_comparison(op, ctx),
 
             // ── Guards ──
             OpCode::GuardTrue => self.optimize_guard_true(op, ctx),
@@ -2429,8 +2450,7 @@ impl Optimization for OptRewrite {
         // ctx.last_op_removed is initialised by OptContext::new() and
         // maintained cross-pass by propagate_from_pass_range +
         // emit_operation — no per-pass setup needed.
-        self.bool_result_cache.clear();
-        self.comparison_by_result.clear();
+        self.comparison_results.clear();
         self.loop_invariant_results.clear();
         self.loop_invariant_producer.clear();
     }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -2448,6 +2448,13 @@ impl<M: Clone> MetaInterp<M> {
                 visitor(gcref);
             }
         }
+        // The per-guard snapshot side table copies inline gcrefs out of the
+        // `ref_regs` slots walked above into words of its own; see
+        // `recorder::Snapshot::walk_const_ptr_refs` for why nothing else
+        // forwards them.
+        for snapshot in trace_ctx.snapshots.iter_mut() {
+            snapshot.walk_const_ptr_refs(&mut visitor);
+        }
         // pyjitpl.py:3290-3306 `self.virtualizable_boxes` stores ordinary
         // BoxPtr objects whose concrete refs are traced by RPython's object
         // graph.  Pyre keeps their concrete half in `virtualizable_values`;
@@ -22910,6 +22917,61 @@ mod tests {
             inputargs[0].get_value(),
             Some(Value::Ref(GcRef(0x8000)))
         ));
+    }
+
+    #[test]
+    fn walk_active_trace_refs_forwards_snapshot_const_ptr() {
+        // `get_list_of_active_snapshot_boxes` copies a constant ref register's
+        // gcref into a raw `SnapshotTagged::Const` word, and the vable / vref
+        // lists can hold an inline `ConstPtr` operand. Both accumulate across
+        // the whole trace, so a collection during tracing must forward them.
+        let mut meta = MetaInterp::<()>::new(0);
+        let mut trace_ctx = crate::trace_ctx::TraceCtx::for_test(1);
+        trace_ctx.snapshots.push(crate::recorder::Snapshot {
+            frames: vec![crate::recorder::SnapshotFrame {
+                jitcode_index: 0,
+                pc: 4,
+                py_pc: 4,
+                boxes: vec![
+                    crate::recorder::SnapshotTagged::Const(0xA000, Type::Ref),
+                    // Same bits, non-Ref type: an integer, not an address.
+                    crate::recorder::SnapshotTagged::Const(0xA000, Type::Int),
+                ],
+            }],
+            vable_boxes: vec![crate::recorder::SnapshotTagged::Box(
+                OpRef::const_ptr(GcRef(0xA000)),
+                Type::Ref,
+            )],
+            vref_boxes: vec![crate::recorder::SnapshotTagged::Box(
+                OpRef::input_arg_ref(0),
+                Type::Ref,
+            )],
+        });
+        meta.tracing = Some(trace_ctx);
+
+        meta.walk_active_trace_refs(|slot| {
+            if slot.0 == 0xA000 {
+                slot.0 = 0xB000;
+            }
+        });
+
+        let snapshot = &meta.tracing.as_ref().unwrap().snapshots[0];
+        assert_eq!(
+            snapshot.frames[0].boxes[0],
+            crate::recorder::SnapshotTagged::Const(0xB000, Type::Ref)
+        );
+        assert_eq!(
+            snapshot.frames[0].boxes[1],
+            crate::recorder::SnapshotTagged::Const(0xA000, Type::Int)
+        );
+        assert_eq!(
+            snapshot.vable_boxes[0],
+            crate::recorder::SnapshotTagged::Box(OpRef::const_ptr(GcRef(0xB000)), Type::Ref)
+        );
+        assert_eq!(
+            snapshot.vref_boxes[0],
+            crate::recorder::SnapshotTagged::Box(OpRef::input_arg_ref(0), Type::Ref)
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -17108,10 +17108,23 @@ impl<M: Clone> MetaInterp<M> {
         } else {
             0
         };
+        // Two distinct `ConstPtr`s cannot be equal at runtime either, so the
+        // funnel's fold is sound here and collapses the pair to `ConstInt(0)`;
+        // `promote_int` then short-circuits on it and no GUARD_VALUE is
+        // recorded. `PTR_EQ` reads no memory, so the fold does not depend on
+        // which backend `self.cpu` is.
+        let cpu = self.cpu.clone();
+        let last_exc_value = self.last_exc_value;
         let eqbox_opref = {
             let ctx = self.tracing.as_mut()?;
-            ctx.recorder
-                .record_op(OpCode::PtrEq, &[vref_box, standard_box])
+            ctx.execute_and_record(
+                cpu.as_ref(),
+                OpCode::PtrEq,
+                None,
+                &[vref_box, standard_box],
+                Some(majit_ir::Value::Int(isstandard_int)),
+                last_exc_value,
+            )
         };
         // pyjitpl.py: eqbox = self.implement_guard_value(eqbox, pc)
         // — pyre's `promote_int` records GUARD_VALUE on the result and

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5499,10 +5499,11 @@ impl<M: Clone> MetaInterp<M> {
         vable_struct_ptr: i64,
         fielddescr: DescrRef,
     ) -> (OpRef, Option<Value>) {
+        let cpu = self.cpu.clone();
         self.tracing
             .as_mut()
             .expect("opimpl_getfield_vable_int requires active tracing")
-            .vable_getfield_int(pc, vable_opref, vable_struct_ptr, fielddescr)
+            .vable_getfield_int(cpu.as_ref(), pc, vable_opref, vable_struct_ptr, fielddescr)
     }
 
     /// pyjitpl.py `opimpl_getfield_vable_r(box, fielddescr, pc)`.
@@ -5513,10 +5514,11 @@ impl<M: Clone> MetaInterp<M> {
         vable_struct_ptr: i64,
         fielddescr: DescrRef,
     ) -> (OpRef, Option<Value>) {
+        let cpu = self.cpu.clone();
         self.tracing
             .as_mut()
             .expect("opimpl_getfield_vable_ref requires active tracing")
-            .vable_getfield_ref(pc, vable_opref, vable_struct_ptr, fielddescr)
+            .vable_getfield_ref(cpu.as_ref(), pc, vable_opref, vable_struct_ptr, fielddescr)
     }
 
     /// pyjitpl.py `opimpl_getfield_vable_f(box, fielddescr, pc)`.
@@ -5527,10 +5529,11 @@ impl<M: Clone> MetaInterp<M> {
         vable_struct_ptr: i64,
         fielddescr: DescrRef,
     ) -> (OpRef, Option<Value>) {
+        let cpu = self.cpu.clone();
         self.tracing
             .as_mut()
             .expect("opimpl_getfield_vable_float requires active tracing")
-            .vable_getfield_float(pc, vable_opref, vable_struct_ptr, fielddescr)
+            .vable_getfield_float(cpu.as_ref(), pc, vable_opref, vable_struct_ptr, fielddescr)
     }
 
     /// pyjitpl.py `_opimpl_setfield_vable(box, valuebox, fielddescr, pc)`.

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -15010,12 +15010,15 @@ impl<M: Clone> MetaInterp<M> {
         self.count_ops(opnum, counters::OPS);
         // pyjitpl.py: resvalue = executor.execute_varargs(self.cpu, self, ...)
         let resvalue = crate::executor::execute_varargs(self, opnum, argboxes, descr_view);
-        // pyjitpl.py:2649-2650: assert not rop._ALWAYS_PURE_FIRST <= opnum <= rop._ALWAYS_PURE_LAST
+        // `MetaInterp.execute_and_record_varargs` asserts
+        // `not rop._ALWAYS_PURE_FIRST <= opnum <= rop._ALWAYS_PURE_LAST`;
+        // the predicate below is the narrower call-only slice of that range.
         debug_assert!(
             !opnum.is_call_pure(),
-            "execute_and_record_varargs: pure calls go through _record_helper_pure_varargs",
+            "execute_and_record_varargs: pure calls go through \
+             MIFrame.execute_varargs(pure=True) → record_result_of_call_pure",
         );
-        // pyjitpl.py: return self._record_helper_varargs(...)
+        // `MetaInterp._record_helper_varargs`
         let opref_args: Vec<OpRef> = argboxes.iter().map(|(_, opref, _)| *opref).collect();
         self._record_helper_varargs(opnum, resvalue, descr, &opref_args)
     }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5762,7 +5762,14 @@ impl<M: Clone> MetaInterp<M> {
         self.tracing
             .as_mut()
             .expect("opimpl_arraylen_vable requires active tracing")
-            .vable_arraylen_vable(cpu.as_ref(), pc, vable_opref, vable_struct_ptr, fdescr, adescr)
+            .vable_arraylen_vable(
+                cpu.as_ref(),
+                pc,
+                vable_opref,
+                vable_struct_ptr,
+                fdescr,
+                adescr,
+            )
     }
 
     /// pyjitpl.py `opimpl_hint_force_virtualizable(box)`.

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5758,10 +5758,11 @@ impl<M: Clone> MetaInterp<M> {
         fdescr: DescrRef,
         adescr: DescrRef,
     ) -> OpRef {
+        let cpu = self.cpu.clone();
         self.tracing
             .as_mut()
             .expect("opimpl_arraylen_vable requires active tracing")
-            .vable_arraylen_vable(pc, vable_opref, vable_struct_ptr, fdescr, adescr)
+            .vable_arraylen_vable(cpu.as_ref(), pc, vable_opref, vable_struct_ptr, fdescr, adescr)
     }
 
     /// pyjitpl.py `opimpl_hint_force_virtualizable(box)`.
@@ -17121,7 +17122,7 @@ impl<M: Clone> MetaInterp<M> {
         let eqbox_opref = {
             let ctx = self.tracing.as_mut()?;
             ctx.execute_and_record(
-                cpu.as_ref(),
+                Some(cpu.as_ref()),
                 OpCode::PtrEq,
                 None,
                 &[vref_box, standard_box],

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -5091,8 +5091,14 @@ where
                 };
                 let (src, src_value) = self.read_int_reg(src_idx);
                 let cond_value = if src_value == 0 { 1 } else { 0 };
-                let cond = ctx.record_op(OpCode::IntIsZero, &[src]);
-                ctx.set_opref_concrete(cond, majit_ir::Value::Int(cond_value));
+                let cond = ctx.execute_and_record(
+                    self.cpu.as_ref(),
+                    OpCode::IntIsZero,
+                    None,
+                    &[src],
+                    Some(majit_ir::Value::Int(cond_value)),
+                    self.last_exception_value,
+                );
                 let guard = if cond_value == 0 {
                     OpCode::GuardFalse
                 } else {
@@ -5244,8 +5250,26 @@ where
                 } else {
                     for &key in descr.switch_const_keys_in_order() {
                         let key_ref = ctx.const_int(key);
-                        let cond = ctx.record_op(OpCode::IntEq, &[value_box, key_ref]);
-                        ctx.set_opref_concrete(cond, majit_ir::Value::Int(0));
+                        // `SwitchDictDescr.attach` builds `const_keys_in_order`
+                        // as `sorted(dict.keys())`, so a `switch_lookup` miss
+                        // means no key equals the switched value. Evaluate the
+                        // comparison rather than assume that: the funnel folds
+                        // this value into the trace when `value_box` is
+                        // constant, and a constant that disagrees with the
+                        // guard beside it is a miscompile with no diagnostic.
+                        let cond_value = (concrete_value == key) as i64;
+                        debug_assert_eq!(
+                            cond_value, 0,
+                            "BC_SWITCH miss chain: key {key} equals the switched value",
+                        );
+                        let cond = ctx.execute_and_record(
+                            self.cpu.as_ref(),
+                            OpCode::IntEq,
+                            None,
+                            &[value_box, key_ref],
+                            Some(majit_ir::Value::Int(cond_value)),
+                            self.last_exception_value,
+                        );
                         self.record_state_guard(
                             ctx,
                             sym,
@@ -13189,6 +13213,72 @@ mod tests {
         );
         assert!(recorded.contains(&OpCode::ConvertFloatBytesToLonglong));
         assert!(recorded.contains(&OpCode::ConvertLonglongBytesToFloat));
+    }
+
+    #[test]
+    fn goto_if_not_int_is_zero_folds_a_constant_source() {
+        // The fused compare folds and `record_state_guard`'s Const gate then
+        // drops the guard too, so both ops disappear.
+        let mut builder = JitCodeBuilder::new();
+        let target = builder.new_label();
+        builder.load_const_i_value(0, 5);
+        builder.goto_if_not_int_is_zero(0, target);
+        builder.mark_label(target);
+        let folded = traced_opcodes(&[], &builder.finish(), &[]);
+        assert!(!folded.contains(&OpCode::IntIsZero));
+        assert!(!folded.contains(&OpCode::GuardFalse));
+
+        let mut builder = JitCodeBuilder::new();
+        let target = builder.new_label();
+        builder.goto_if_not_int_is_zero(0, target);
+        builder.mark_label(target);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Int],
+            &builder.finish(),
+            &[(JitArgKind::Int, OpRef::input_arg_int(0), 5)],
+        );
+        assert!(recorded.contains(&OpCode::IntIsZero));
+        assert!(recorded.contains(&OpCode::GuardFalse));
+    }
+
+    #[test]
+    fn switch_miss_chain_folds_a_constant_switched_value() {
+        // One IntEq + one GuardFalse per key on the miss path; a constant
+        // switched value collapses the whole chain to nothing.
+        let mut builder = JitCodeBuilder::new();
+        let case_a = builder.new_label();
+        let case_b = builder.new_label();
+        builder.load_const_i_value(0, 99);
+        builder.switch(0, &[(-3, case_a), (7, case_b)]);
+        builder.mark_label(case_a);
+        builder.mark_label(case_b);
+        let folded = traced_opcodes(&[], &builder.finish(), &[]);
+        assert!(!folded.contains(&OpCode::IntEq));
+        assert!(!folded.contains(&OpCode::GuardFalse));
+
+        let mut builder = JitCodeBuilder::new();
+        let case_a = builder.new_label();
+        let case_b = builder.new_label();
+        builder.switch(0, &[(-3, case_a), (7, case_b)]);
+        builder.mark_label(case_a);
+        builder.mark_label(case_b);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Int],
+            &builder.finish(),
+            &[(JitArgKind::Int, OpRef::input_arg_int(0), 99)],
+        );
+        assert_eq!(
+            recorded.iter().filter(|&&o| o == OpCode::IntEq).count(),
+            2,
+            "one comparison per switch key",
+        );
+        assert_eq!(
+            recorded
+                .iter()
+                .filter(|&&o| o == OpCode::GuardFalse)
+                .count(),
+            2,
+        );
     }
 
     fn switch_return_jitcode() -> JitCode {

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -9093,9 +9093,9 @@ where
             return (ctx.const_int(fast), fast);
         }
         let value = eval_binop_i(opcode, lhs_value, rhs_value);
-        // pyjitpl.py `_record_helper_pure`: a pure op whose args are all
-        // constants folds to its constant result at trace time and records
-        // nothing.  Every opcode routed here is a pure int/uint arithmetic or
+        // `MetaInterp.execute_and_record`: a pure op whose args are all
+        // constants (`_all_constants`) folds to its constant result at trace
+        // time and records nothing.  Every opcode routed here is a pure int/uint arithmetic or
         // comparison, so an all-constant pair yields a constant destination.
         if lhs.is_constant() && rhs.is_constant() {
             return (ctx.const_int(value), value);
@@ -9164,8 +9164,8 @@ where
             OpCode::IntMulOvf => lhs_value.overflowing_mul(rhs_value),
             _ => unreachable!("trace_int_binop_jump_if_ovf: {opcode:?}"),
         };
-        // All-constant operands fold at trace time (pyjitpl `_record_helper_pure`):
-        // no resop, no guard.  A constant pair that overflows unconditionally
+        // All-constant operands fold at trace time
+        // (`MetaInterp.execute_and_record`): no resop, no guard.  A constant pair that overflows unconditionally
         // takes the overflow branch.
         if lhs.is_constant() && rhs.is_constant() {
             if overflowed {
@@ -9207,7 +9207,8 @@ where
         };
         let (src, src_value) = self.read_int_reg(src_idx);
         let value = eval_unary_i(opcode, src_value);
-        // `_record_helper_pure`: a constant source folds to a constant result.
+        // `MetaInterp.execute_and_record`: a constant source folds to a
+        // constant result.
         if src.is_constant() {
             self.set_int_reg(dst, Some(ctx.const_int(value)), Some(value));
             return;

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1869,11 +1869,13 @@ where
     /// survives optimization then deopts into a frame with no live registers
     /// and a zero-length vable section.
     ///
-    /// `replace_box` has no whole-metainterp equivalent here; writing the
-    /// promoted constant back into the source register is the same stand-in
-    /// the `BC_SWITCH` arm in this file already uses for it, and it is what
-    /// keeps a second read of the same register from emitting a redundant
-    /// `GUARD_VALUE`.
+    /// The promoted constant is written back into the source register rather
+    /// than fanned out through [`Self::replace_box`] — the same stand-in the
+    /// `BC_SWITCH` arm uses. A second read of that register then folds instead
+    /// of emitting a redundant `GUARD_VALUE`, but a slot in another frame that
+    /// `MIFrame::setup_call` copied the same box into keeps naming it.
+    /// Widening this to the full walk changes what every promote records, so
+    /// it wants a recorded-operation measurement of its own.
     fn implement_guard_value(
         &mut self,
         ctx: &mut TraceCtx,
@@ -2006,8 +2008,9 @@ where
     /// rebind lands in: `Some(reg)` is `replace=True`, `None` is the
     /// `goto_if_not_int_is_true` caller's `replace=False`, whose condbox "does
     /// not appear anywhere in any register" because the arm just made it.
-    /// `replace_box` has no whole-metainterp equivalent at this layer — see
-    /// [`Self::implement_guard_value`] for the same stand-in.
+    /// The rebind is that register write-back and not [`Self::replace_box`];
+    /// see [`Self::implement_guard_value`] for what the stand-in leaves
+    /// behind.
     fn goto_if_not(
         &mut self,
         ctx: &mut TraceCtx,

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -9271,8 +9271,14 @@ where
             OpCode::PtrNe | OpCode::InstancePtrNe => (lhs_value != rhs_value) as i64,
             other => panic!("trace_binop_r_to_i: unsupported opcode {other:?}"),
         };
-        let opref = ctx.record_op(opcode, &[lhs, rhs]);
-        ctx.set_opref_concrete(opref, majit_ir::Value::Int(value));
+        let opref = ctx.execute_and_record(
+            self.cpu.as_ref(),
+            opcode,
+            None,
+            &[lhs, rhs],
+            Some(majit_ir::Value::Int(value)),
+            self.last_exception_value,
+        );
         self.set_int_reg(dst, Some(opref), Some(value));
     }
 
@@ -9298,8 +9304,14 @@ where
         } else {
             (src_value == 0) as i64
         };
-        let opref = ctx.record_op(opcode, &[src, null]);
-        ctx.set_opref_concrete(opref, majit_ir::Value::Int(value));
+        let opref = ctx.execute_and_record(
+            self.cpu.as_ref(),
+            opcode,
+            None,
+            &[src, null],
+            Some(majit_ir::Value::Int(value)),
+            self.last_exception_value,
+        );
         self.set_int_reg(dst, Some(opref), Some(value));
     }
 
@@ -9317,8 +9329,14 @@ where
         let (lhs, lhs_value) = self.read_float_reg(lhs_idx);
         let (rhs, rhs_value) = self.read_float_reg(rhs_idx);
         let value = eval_binop_f(opcode, lhs_value, rhs_value);
-        let opref = ctx.record_op(opcode, &[lhs, rhs]);
-        ctx.set_opref_concrete(opref, majit_ir::Value::Float(f64::from_bits(value as u64)));
+        let opref = ctx.execute_and_record(
+            self.cpu.as_ref(),
+            opcode,
+            None,
+            &[lhs, rhs],
+            Some(majit_ir::Value::Float(f64::from_bits(value as u64))),
+            self.last_exception_value,
+        );
         self.set_float_reg(dst, Some(opref), Some(value));
     }
 
@@ -9336,8 +9354,14 @@ where
         let (lhs, lhs_value) = self.read_float_reg(lhs_idx);
         let (rhs, rhs_value) = self.read_float_reg(rhs_idx);
         let value = eval_float_cmp(opcode, lhs_value, rhs_value);
-        let opref = ctx.record_op(opcode, &[lhs, rhs]);
-        ctx.set_opref_concrete(opref, majit_ir::Value::Int(value));
+        let opref = ctx.execute_and_record(
+            self.cpu.as_ref(),
+            opcode,
+            None,
+            &[lhs, rhs],
+            Some(majit_ir::Value::Int(value)),
+            self.last_exception_value,
+        );
         self.set_int_reg(dst, Some(opref), Some(value));
     }
 
@@ -9352,8 +9376,14 @@ where
         };
         let (src, src_value) = self.read_float_reg(src_idx);
         let value = eval_unary_f(opcode, src_value);
-        let opref = ctx.record_op(opcode, &[src]);
-        ctx.set_opref_concrete(opref, majit_ir::Value::Float(f64::from_bits(value as u64)));
+        let opref = ctx.execute_and_record(
+            self.cpu.as_ref(),
+            opcode,
+            None,
+            &[src],
+            Some(majit_ir::Value::Float(f64::from_bits(value as u64))),
+            self.last_exception_value,
+        );
         self.set_float_reg(dst, Some(opref), Some(value));
     }
 
@@ -9369,8 +9399,14 @@ where
         };
         let (src, src_value) = self.read_int_reg(src_idx);
         let fvalue = src_value as f64;
-        let opref = ctx.record_op(OpCode::CastIntToFloat, &[src]);
-        ctx.set_opref_concrete(opref, majit_ir::Value::Float(fvalue));
+        let opref = ctx.execute_and_record(
+            self.cpu.as_ref(),
+            OpCode::CastIntToFloat,
+            None,
+            &[src],
+            Some(majit_ir::Value::Float(fvalue)),
+            self.last_exception_value,
+        );
         self.set_float_reg(dst, Some(opref), Some(fvalue.to_bits() as i64));
     }
 
@@ -9391,8 +9427,14 @@ where
         };
         let (src, bits) = self.read_float_reg(src_idx);
         let ivalue = f64::from_bits(bits as u64) as i64;
-        let opref = ctx.record_op(OpCode::CastFloatToInt, &[src]);
-        ctx.set_opref_concrete(opref, majit_ir::Value::Int(ivalue));
+        let opref = ctx.execute_and_record(
+            self.cpu.as_ref(),
+            OpCode::CastFloatToInt,
+            None,
+            &[src],
+            Some(majit_ir::Value::Int(ivalue)),
+            self.last_exception_value,
+        );
         self.set_int_reg(dst, Some(opref), Some(ivalue));
     }
 
@@ -9407,8 +9449,14 @@ where
             (src_idx, dst)
         };
         let (src, bits) = self.read_float_reg(src_idx);
-        let opref = ctx.record_op(OpCode::ConvertFloatBytesToLonglong, &[src]);
-        ctx.set_opref_concrete(opref, majit_ir::Value::Int(bits));
+        let opref = ctx.execute_and_record(
+            self.cpu.as_ref(),
+            OpCode::ConvertFloatBytesToLonglong,
+            None,
+            &[src],
+            Some(majit_ir::Value::Int(bits)),
+            self.last_exception_value,
+        );
         self.set_int_reg(dst, Some(opref), Some(bits));
     }
 
@@ -9422,8 +9470,14 @@ where
             (src_idx, dst)
         };
         let (src, bits) = self.read_int_reg(src_idx);
-        let opref = ctx.record_op(OpCode::ConvertLonglongBytesToFloat, &[src]);
-        ctx.set_opref_concrete(opref, majit_ir::Value::Float(f64::from_bits(bits as u64)));
+        let opref = ctx.execute_and_record(
+            self.cpu.as_ref(),
+            OpCode::ConvertLonglongBytesToFloat,
+            None,
+            &[src],
+            Some(majit_ir::Value::Float(f64::from_bits(bits as u64))),
+            self.last_exception_value,
+        );
         self.set_float_reg(dst, Some(opref), Some(bits));
     }
 }
@@ -12900,6 +12954,241 @@ mod tests {
                 .any(|op| op.opcode == OpCode::GuardFalse),
             "non-constant false branch must guard on the comparison",
         );
+    }
+
+    /// Opcodes the tracer recorded for `jitcode`, run from pc 0 with
+    /// `argboxes` bound as the frame's arguments.
+    ///
+    /// The always-pure arms below each need the same two runs — every operand
+    /// a `load_const_*` (the funnel's `_all_constants` holds, so the op folds
+    /// and nothing is recorded) and every operand an input arg (it does not,
+    /// so the op is recorded) — and differ only in the jitcode.
+    fn traced_opcodes(
+        types: &[majit_ir::Type],
+        jitcode: &JitCode,
+        argboxes: &[(JitArgKind, OpRef, i64)],
+    ) -> Vec<OpCode> {
+        let mut ctx = TraceCtx::for_test_types(types);
+        let mut sym = DummySym;
+        let action = trace_jitcode_with_args(&mut ctx, &mut sym, jitcode, 0, |_pc| 0, argboxes);
+        assert!(matches!(action, TraceAction::Continue));
+        ctx.into_recorder()
+            .ops()
+            .iter()
+            .map(|op| op.opcode)
+            .collect()
+    }
+
+    #[test]
+    fn ptr_compare_folds_two_constant_refs() {
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_r_value(0, 0x30);
+        builder.load_const_r_value(1, 0x40);
+        builder.record_binop_r(2, OpCode::PtrEq, 0, 1);
+        let folded = traced_opcodes(&[], &builder.finish(), &[]);
+        assert!(!folded.contains(&OpCode::PtrEq));
+
+        let mut builder = JitCodeBuilder::new();
+        builder.record_binop_r(2, OpCode::PtrEq, 0, 1);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Ref, majit_ir::Type::Ref],
+            &builder.finish(),
+            &[
+                (JitArgKind::Ref, OpRef::input_arg_ref(0), 0x30),
+                (JitArgKind::Ref, OpRef::input_arg_ref(1), 0x40),
+            ],
+        );
+        assert!(recorded.contains(&OpCode::PtrEq));
+    }
+
+    #[test]
+    fn ptr_nullity_folds_a_constant_ref() {
+        // The `CONST_NULL` operand is constant by construction, so the fold
+        // turns on the source alone.
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_r_value(0, 0x30);
+        builder.ptr_nonzero(1, 0);
+        let folded = traced_opcodes(&[], &builder.finish(), &[]);
+        assert!(!folded.contains(&OpCode::PtrNe));
+
+        let mut builder = JitCodeBuilder::new();
+        builder.ptr_nonzero(1, 0);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Ref],
+            &builder.finish(),
+            &[(JitArgKind::Ref, OpRef::input_arg_ref(0), 0x30)],
+        );
+        assert!(recorded.contains(&OpCode::PtrNe));
+    }
+
+    #[test]
+    fn float_binop_folds_two_constant_floats() {
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_f_value(0, 1.5f64.to_bits() as i64);
+        builder.load_const_f_value(1, 2.5f64.to_bits() as i64);
+        builder.record_binop_f(2, OpCode::FloatAdd, 0, 1);
+        let folded = traced_opcodes(&[], &builder.finish(), &[]);
+        assert!(!folded.contains(&OpCode::FloatAdd));
+
+        let mut builder = JitCodeBuilder::new();
+        builder.record_binop_f(2, OpCode::FloatAdd, 0, 1);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Float, majit_ir::Type::Float],
+            &builder.finish(),
+            &[
+                (
+                    JitArgKind::Float,
+                    OpRef::input_arg_float(0),
+                    1.5f64.to_bits() as i64,
+                ),
+                (
+                    JitArgKind::Float,
+                    OpRef::input_arg_float(1),
+                    2.5f64.to_bits() as i64,
+                ),
+            ],
+        );
+        assert!(recorded.contains(&OpCode::FloatAdd));
+    }
+
+    #[test]
+    fn float_truediv_by_zero_records_instead_of_folding() {
+        // `execute_binary_float_const_row` declines this operand pair, and a
+        // decline records — the tracer and the optimizer then agree about
+        // what is constant.
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_f_value(0, 1.0f64.to_bits() as i64);
+        builder.load_const_f_value(1, 0.0f64.to_bits() as i64);
+        builder.record_binop_f(2, OpCode::FloatTrueDiv, 0, 1);
+        let ops = traced_opcodes(&[], &builder.finish(), &[]);
+        assert!(ops.contains(&OpCode::FloatTrueDiv));
+    }
+
+    #[test]
+    fn float_compare_folds_two_constant_floats() {
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_f_value(0, 1.5f64.to_bits() as i64);
+        builder.load_const_f_value(1, 2.5f64.to_bits() as i64);
+        builder.record_compare_f(2, OpCode::FloatLt, 0, 1);
+        let folded = traced_opcodes(&[], &builder.finish(), &[]);
+        assert!(!folded.contains(&OpCode::FloatLt));
+
+        let mut builder = JitCodeBuilder::new();
+        builder.record_compare_f(2, OpCode::FloatLt, 0, 1);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Float, majit_ir::Type::Float],
+            &builder.finish(),
+            &[
+                (
+                    JitArgKind::Float,
+                    OpRef::input_arg_float(0),
+                    1.5f64.to_bits() as i64,
+                ),
+                (
+                    JitArgKind::Float,
+                    OpRef::input_arg_float(1),
+                    2.5f64.to_bits() as i64,
+                ),
+            ],
+        );
+        assert!(recorded.contains(&OpCode::FloatLt));
+    }
+
+    #[test]
+    fn float_unary_folds_a_constant_float() {
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_f_value(0, (-1.5f64).to_bits() as i64);
+        builder.record_unary_f(1, OpCode::FloatAbs, 0);
+        let folded = traced_opcodes(&[], &builder.finish(), &[]);
+        assert!(!folded.contains(&OpCode::FloatAbs));
+
+        let mut builder = JitCodeBuilder::new();
+        builder.record_unary_f(1, OpCode::FloatAbs, 0);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Float],
+            &builder.finish(),
+            &[(
+                JitArgKind::Float,
+                OpRef::input_arg_float(0),
+                (-1.5f64).to_bits() as i64,
+            )],
+        );
+        assert!(recorded.contains(&OpCode::FloatAbs));
+    }
+
+    #[test]
+    fn cast_int_to_float_folds_a_constant_int() {
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_i_value(0, 7);
+        builder.record_cast_int_to_float(1, 0);
+        let folded = traced_opcodes(&[], &builder.finish(), &[]);
+        assert!(!folded.contains(&OpCode::CastIntToFloat));
+
+        let mut builder = JitCodeBuilder::new();
+        builder.record_cast_int_to_float(1, 0);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Int],
+            &builder.finish(),
+            &[(JitArgKind::Int, OpRef::input_arg_int(0), 7)],
+        );
+        assert!(recorded.contains(&OpCode::CastIntToFloat));
+    }
+
+    #[test]
+    fn cast_float_to_int_folds_in_range_and_records_out_of_range() {
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_f_value(0, 7.5f64.to_bits() as i64);
+        builder.record_cast_float_to_int(1, 0);
+        let folded = traced_opcodes(&[], &builder.finish(), &[]);
+        assert!(!folded.contains(&OpCode::CastFloatToInt));
+
+        // `execute_cast_const_row` declines a non-finite source rather than
+        // freeze the runtime's saturation as a constant.
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_f_value(0, f64::INFINITY.to_bits() as i64);
+        builder.record_cast_float_to_int(1, 0);
+        let declined = traced_opcodes(&[], &builder.finish(), &[]);
+        assert!(declined.contains(&OpCode::CastFloatToInt));
+
+        let mut builder = JitCodeBuilder::new();
+        builder.record_cast_float_to_int(1, 0);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Float],
+            &builder.finish(),
+            &[(
+                JitArgKind::Float,
+                OpRef::input_arg_float(0),
+                7.5f64.to_bits() as i64,
+            )],
+        );
+        assert!(recorded.contains(&OpCode::CastFloatToInt));
+    }
+
+    #[test]
+    fn float_bits_conversions_fold_a_constant_operand() {
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_f_value(0, 1.5f64.to_bits() as i64);
+        builder.record_convert_float_bytes_to_longlong(1, 0);
+        builder.load_const_i_value(2, 1.5f64.to_bits() as i64);
+        builder.record_convert_longlong_bytes_to_float(3, 2);
+        let folded = traced_opcodes(&[], &builder.finish(), &[]);
+        assert!(!folded.contains(&OpCode::ConvertFloatBytesToLonglong));
+        assert!(!folded.contains(&OpCode::ConvertLonglongBytesToFloat));
+
+        let mut builder = JitCodeBuilder::new();
+        builder.record_convert_float_bytes_to_longlong(1, 0);
+        builder.record_convert_longlong_bytes_to_float(2, 1);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Float],
+            &builder.finish(),
+            &[(
+                JitArgKind::Float,
+                OpRef::input_arg_float(0),
+                1.5f64.to_bits() as i64,
+            )],
+        );
+        assert!(recorded.contains(&OpCode::ConvertFloatBytesToLonglong));
+        assert!(recorded.contains(&OpCode::ConvertLonglongBytesToFloat));
     }
 
     fn switch_return_jitcode() -> JitCode {

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1904,6 +1904,68 @@ where
         promoted_box
     }
 
+    /// `pyjitpl.py MIFrame._establish_nullity(box, orgpc)` — returns
+    /// `box.nonnull()`, guarding it into the trace on the way.
+    ///
+    /// ```python
+    /// value = box.nonnull()
+    /// if heapcache.is_nullity_known(box):
+    ///     profiler.count_ops(rop.GUARD_NONNULL, Counters.HEAPCACHED_OPS)
+    ///     return value
+    /// if value:
+    ///     if not self.metainterp.heapcache.is_class_known(box):
+    ///         self.metainterp.generate_guard(rop.GUARD_NONNULL, box, resumepc=orgpc)
+    /// else:
+    ///     if not isinstance(box, Const):
+    ///         self.metainterp.generate_guard(rop.GUARD_ISNULL, box, resumepc=orgpc)
+    ///         promoted_box = executor.constant_from_op(box)
+    ///         self.metainterp.replace_box(box, promoted_box)
+    /// heapcache.nullity_now_known(box)
+    /// return value
+    /// ```
+    ///
+    /// The nullity question is asked of the box directly — there is no
+    /// comparison operation, and none of `GUARD_NONNULL` / `GUARD_ISNULL` /
+    /// the two heapcache updates has an analogue in a `PTR_EQ` against null
+    /// under a `GUARD_TRUE`.
+    fn establish_nullity(
+        &mut self,
+        ctx: &mut TraceCtx,
+        sym: &mut S,
+        src_reg: usize,
+        src: OpRef,
+        src_value: i64,
+        opcode_pc: usize,
+    ) -> bool {
+        let value = src_value != 0;
+        if ctx.heapcache_nullity_known(src) == Some(true) {
+            ctx.profiler().count_ops(
+                OpCode::GuardNonnull,
+                crate::pyjitpl::counters::HEAPCACHED_OPS,
+            );
+            return value;
+        }
+        if value {
+            // A known class already implies non-null, so the guard would be
+            // redundant.
+            if !ctx.heap_cache().is_class_known(src) {
+                self.record_state_guard(ctx, sym, OpCode::GuardNonnull, &[src], opcode_pc, false);
+            }
+        } else if !src.is_constant() {
+            self.record_state_guard(ctx, sym, OpCode::GuardIsnull, &[src], opcode_pc, false);
+            // `replace_box(box, constant_from_op(box))` — the register
+            // write-back stand-in, as in [`Self::implement_guard_value`].
+            let null = ctx.const_null();
+            self.set_ref_reg(src_reg, Some(null), Some(0));
+        }
+        // majit's `nullity_now_known` also records WHICH nullity, where
+        // upstream only sets the flag; `is_nullity_known` then answers
+        // `Some(false)` for a known-null box rather than conflating it with
+        // unknown.
+        ctx.heap_cache_mut().nullity_now_known(src, value);
+        value
+    }
+
     /// `pyjitpl.py MIFrame.opimpl_goto_if_not(box, target, orgpc, replace)`.
     ///
     /// ```python
@@ -5438,25 +5500,16 @@ where
                     )
                 };
                 let (src, src_value) = self.read_ref_reg(src_idx);
-                let null = ctx.const_null();
-                let (opcode, cond_value) = match bytecode {
-                    jitcode::insns::BC_GOTO_IF_NOT_PTR_ISZERO => {
-                        (OpCode::PtrEq, (src_value == 0) as i64)
-                    }
-                    jitcode::insns::BC_GOTO_IF_NOT_PTR_NONZERO => {
-                        (OpCode::PtrNe, (src_value != 0) as i64)
-                    }
+                let nonnull = self.establish_nullity(ctx, sym, src_idx, src, src_value, opcode_pc);
+                // pyjitpl.py:
+                //   opimpl_goto_if_not_ptr_nonzero: if not nonnull: self.pc = target
+                //   opimpl_goto_if_not_ptr_iszero:  if     nonnull: self.pc = target
+                let branch_taken = match bytecode {
+                    jitcode::insns::BC_GOTO_IF_NOT_PTR_ISZERO => nonnull,
+                    jitcode::insns::BC_GOTO_IF_NOT_PTR_NONZERO => !nonnull,
                     _ => unreachable!(),
                 };
-                let cond = ctx.record_op(opcode, &[src, null]);
-                ctx.set_opref_concrete(cond, majit_ir::Value::Int(cond_value));
-                let guard = if cond_value == 0 {
-                    OpCode::GuardFalse
-                } else {
-                    OpCode::GuardTrue
-                };
-                self.record_state_guard(ctx, sym, guard, &[cond], opcode_pc, false);
-                if cond_value == 0 {
+                if branch_taken {
                     self.frames.current_mut().code_cursor = target;
                 }
             }
@@ -13145,6 +13198,91 @@ mod tests {
             .iter()
             .map(|op| op.opcode)
             .collect()
+    }
+
+    /// `_establish_nullity` asks the nullity question of the box itself:
+    /// `GUARD_NONNULL` / `GUARD_ISNULL`, never a comparison against null under
+    /// a `GUARD_TRUE`. Both bytecodes share it and differ only in which answer
+    /// takes the branch.
+    #[test]
+    fn a_ptr_nullity_branch_guards_the_box_itself() {
+        // (bytecode-emitting closure, traced pointer, expected guard)
+        let cases: [(fn(&mut JitCodeBuilder, u16), i64, OpCode); 4] = [
+            (
+                |b, t| b.goto_if_not_ptr_nonzero(0, t),
+                0x40,
+                OpCode::GuardNonnull,
+            ),
+            (
+                |b, t| b.goto_if_not_ptr_nonzero(0, t),
+                0,
+                OpCode::GuardIsnull,
+            ),
+            (
+                |b, t| b.goto_if_not_ptr_iszero(0, t),
+                0x40,
+                OpCode::GuardNonnull,
+            ),
+            (
+                |b, t| b.goto_if_not_ptr_iszero(0, t),
+                0,
+                OpCode::GuardIsnull,
+            ),
+        ];
+        for (emit, ptr, want) in cases {
+            let mut builder = JitCodeBuilder::new();
+            let target = builder.new_label();
+            emit(&mut builder, target);
+            builder.mark_label(target);
+            let recorded = traced_opcodes(
+                &[majit_ir::Type::Ref],
+                &builder.finish(),
+                &[(JitArgKind::Ref, OpRef::input_arg_ref(0), ptr)],
+            );
+            assert_eq!(recorded, vec![want], "ptr={ptr:#x}");
+        }
+    }
+
+    /// `heapcache.nullity_now_known(box)` closes the question, so a second
+    /// nullity branch on the same box takes the `is_nullity_known`
+    /// short-circuit and guards nothing.
+    #[test]
+    fn a_second_nullity_branch_on_one_box_is_answered_by_the_heapcache() {
+        let mut builder = JitCodeBuilder::new();
+        let first = builder.new_label();
+        builder.goto_if_not_ptr_nonzero(0, first);
+        builder.mark_label(first);
+        let second = builder.new_label();
+        builder.goto_if_not_ptr_nonzero(0, second);
+        builder.mark_label(second);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Ref],
+            &builder.finish(),
+            &[(JitArgKind::Ref, OpRef::input_arg_ref(0), 0x40)],
+        );
+        assert_eq!(recorded, vec![OpCode::GuardNonnull], "{recorded:?}");
+    }
+
+    /// The null arm's `replace_box(box, constant_from_op(box))`: the source
+    /// register comes out of the branch holding `CONST_NULL`, so a following
+    /// nullity read of it folds instead of recording a `PTR_NE`.
+    ///
+    /// The probe is `ptr_nonzero` rather than a `PTR_EQ` against the register
+    /// itself, because `trace_binop_r_to_i` short-circuits identical operands
+    /// through `FASTPATHS_SAME_BOXES` and would answer the same either way.
+    #[test]
+    fn a_null_ptr_nullity_branch_rebinds_its_source_register() {
+        let mut builder = JitCodeBuilder::new();
+        let target = builder.new_label();
+        builder.goto_if_not_ptr_iszero(0, target);
+        builder.ptr_nonzero(1, 0);
+        builder.mark_label(target);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Ref],
+            &builder.finish(),
+            &[(JitArgKind::Ref, OpRef::input_arg_ref(0), 0)],
+        );
+        assert_eq!(recorded, vec![OpCode::GuardIsnull], "{recorded:?}");
     }
 
     /// `opimpl_goto_if_not`'s tail — `if replace: replace_box(box,

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1869,18 +1869,14 @@ where
     /// survives optimization then deopts into a frame with no live registers
     /// and a zero-length vable section.
     ///
-    /// The promoted constant is written back into the source register rather
-    /// than fanned out through [`Self::replace_box`] — the same stand-in the
-    /// `BC_SWITCH` arm uses. A second read of that register then folds instead
-    /// of emitting a redundant `GUARD_VALUE`, but a slot in another frame that
-    /// `MIFrame::setup_call` copied the same box into keeps naming it.
-    /// Widening this to the full walk changes what every promote records, so
-    /// it wants a recorded-operation measurement of its own.
+    /// The promoted constant goes out through [`Self::replace_box`], so a
+    /// later read of any slot naming the box folds rather than re-guarding —
+    /// including one in a caller frame that `MIFrame::setup_call` copied the
+    /// same box into.
     fn implement_guard_value(
         &mut self,
         ctx: &mut TraceCtx,
         sym: &mut S,
-        reg: usize,
         box_: OpRef,
         runtime_value: i64,
         resume_pc: usize,
@@ -1901,7 +1897,7 @@ where
             false,
         );
         // pyjitpl.py `replace_box`.
-        self.set_int_reg(reg, Some(promoted_box), Some(runtime_value));
+        self.replace_box(ctx, box_, promoted_box, Type::Int);
         // pyjitpl.py:1927
         promoted_box
     }
@@ -2004,13 +2000,9 @@ where
     ///     self.metainterp.replace_box(box, promoted_box)
     /// ```
     ///
-    /// `replace_reg` carries upstream's `replace` flag *and* the register the
-    /// rebind lands in: `Some(reg)` is `replace=True`, `None` is the
-    /// `goto_if_not_int_is_true` caller's `replace=False`, whose condbox "does
-    /// not appear anywhere in any register" because the arm just made it.
-    /// The rebind is that register write-back and not [`Self::replace_box`];
-    /// see [`Self::implement_guard_value`] for what the stand-in leaves
-    /// behind.
+    /// `replace=false` is the `goto_if_not_int_is_true` caller's, whose
+    /// condbox "does not appear anywhere in any register" because the arm
+    /// just made it.
     fn goto_if_not(
         &mut self,
         ctx: &mut TraceCtx,
@@ -2019,7 +2011,7 @@ where
         cond: OpRef,
         cond_value: i64,
         target: usize,
-        replace_reg: Option<usize>,
+        replace: bool,
     ) {
         let (guard, promoted_value) = if cond_value != 0 {
             // `assert switchcase == 1`. Every producer of this bytecode passes
@@ -2037,9 +2029,9 @@ where
         if cond.is_constant() {
             return;
         }
-        if let Some(reg) = replace_reg {
+        if replace {
             let promoted_box = ctx.const_int(promoted_value);
-            self.set_int_reg(reg, Some(promoted_box), Some(promoted_value));
+            self.replace_box(ctx, cond, promoted_box, Type::Int);
         }
     }
 
@@ -4864,7 +4856,7 @@ where
                 let index = if nonstandard {
                     index
                 } else {
-                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc)
+                    self.implement_guard_value(ctx, sym, index, index_value, opcode_pc)
                 };
                 let guards_before = ctx.num_guards();
                 let (opref, value) = ctx.vable_getarrayitem_int_checked(
@@ -4916,7 +4908,7 @@ where
                 let index = if nonstandard {
                     index
                 } else {
-                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc)
+                    self.implement_guard_value(ctx, sym, index, index_value, opcode_pc)
                 };
                 let guards_before = ctx.num_guards();
                 let (opref, value) = ctx.vable_getarrayitem_ref_checked(
@@ -4968,7 +4960,7 @@ where
                 let index = if nonstandard {
                     index
                 } else {
-                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc)
+                    self.implement_guard_value(ctx, sym, index, index_value, opcode_pc)
                 };
                 let guards_before = ctx.num_guards();
                 let (opref, value) = ctx.vable_getarrayitem_float_checked(
@@ -5020,7 +5012,7 @@ where
                 let index = if nonstandard {
                     index
                 } else {
-                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc)
+                    self.implement_guard_value(ctx, sym, index, index_value, opcode_pc)
                 };
                 let (value, concrete) = self.read_int_reg(src);
                 let guards_before = ctx.num_guards();
@@ -5081,7 +5073,7 @@ where
                 let index = if nonstandard {
                     index
                 } else {
-                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc)
+                    self.implement_guard_value(ctx, sym, index, index_value, opcode_pc)
                 };
                 let (value, concrete) = self.read_ref_reg(src);
                 let guards_before = ctx.num_guards();
@@ -5139,7 +5131,7 @@ where
                 let index = if nonstandard {
                     index
                 } else {
-                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc)
+                    self.implement_guard_value(ctx, sym, index, index_value, opcode_pc)
                 };
                 let (value, concrete) = self.read_float_reg(src);
                 let guards_before = ctx.num_guards();
@@ -5275,15 +5267,7 @@ where
                     )
                 };
                 let (cond, cond_value) = self.read_int_reg(cond_idx);
-                self.goto_if_not(
-                    ctx,
-                    sym,
-                    opcode_pc,
-                    cond,
-                    cond_value,
-                    target,
-                    Some(cond_idx),
-                );
+                self.goto_if_not(ctx, sym, opcode_pc, cond, cond_value, target, true);
             }
             // pyjitpl.py opimpl_goto_if_not_int_is_true(box, target):
             //   condbox = self.execute(rop.INT_IS_TRUE, box)
@@ -5315,7 +5299,7 @@ where
                     Some(majit_ir::Value::Int(cond_value)),
                     self.last_exception_value,
                 );
-                self.goto_if_not(ctx, sym, opcode_pc, cond, cond_value, target, None);
+                self.goto_if_not(ctx, sym, opcode_pc, cond, cond_value, target, false);
             }
             // pyjitpl.py opimpl_goto_if_not_int_is_zero(box, target):
             //   condbox = execute(rop.INT_IS_ZERO, box)
@@ -8729,7 +8713,10 @@ where
                     opcode_pc,
                     false,
                 );
-                self.set_int_reg(src, Some(const_ref), Some(concrete));
+                // `implement_guard_value`'s `if isinstance(box, Const): return box`.
+                if !opref.is_constant() {
+                    self.replace_box(ctx, opref, const_ref, Type::Int);
+                }
             }
             // pyjitpl.py opimpl_assert_not_none.  Blackhole:
             // asserts the concrete ref is non-null and advances past
@@ -8774,7 +8761,10 @@ where
                     opcode_pc,
                     false,
                 );
-                self.set_ref_reg(src, Some(const_ref), Some(concrete));
+                // `implement_guard_value`'s `if isinstance(box, Const): return box`.
+                if !opref.is_constant() {
+                    self.replace_box(ctx, opref, const_ref, Type::Ref);
+                }
             }
             // pyjitpl.py opimpl_float_guard_value = _opimpl_guard_value
             jitcode::insns::BC_FLOAT_GUARD_VALUE => {
@@ -8793,7 +8783,10 @@ where
                     opcode_pc,
                     false,
                 );
-                self.set_float_reg(src, Some(const_ref), Some(concrete));
+                // `implement_guard_value`'s `if isinstance(box, Const): return box`.
+                if !opref.is_constant() {
+                    self.replace_box(ctx, opref, const_ref, Type::Float);
+                }
             }
             jitcode::insns::BC_RAISE => {
                 // pyjitpl.py opimpl_raise:
@@ -13405,6 +13398,25 @@ mod tests {
             &[(JitArgKind::Ref, aliased, 0), (JitArgKind::Ref, aliased, 0)],
         );
         assert_eq!(recorded, vec![OpCode::GuardIsnull], "{recorded:?}");
+    }
+
+    /// `implement_guard_value` ends in `replace_box`, so the constant the
+    /// guard proved reaches every register naming the box — a promote inside
+    /// an inlined helper leaves the caller's copy folded too, rather than
+    /// recording arithmetic against a box already pinned to a value.
+    #[test]
+    fn a_guard_value_promote_replaces_the_box_in_an_aliasing_register() {
+        let mut builder = JitCodeBuilder::new();
+        builder.int_guard_value(0);
+        // Read the ALIAS, not the register the guard named.
+        builder.record_binop_i(2, OpCode::IntAdd, 1, 1);
+        let aliased = OpRef::input_arg_int(0);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Int, majit_ir::Type::Int],
+            &builder.finish(),
+            &[(JitArgKind::Int, aliased, 3), (JitArgKind::Int, aliased, 3)],
+        );
+        assert_eq!(recorded, vec![OpCode::GuardValue], "{recorded:?}");
     }
 
     /// `opimpl_goto_if_not`'s tail — `if replace: replace_box(box,

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1904,6 +1904,25 @@ where
         promoted_box
     }
 
+    /// `pyjitpl.py MetaInterp.replace_box(oldbox, newbox)`.
+    ///
+    /// The box has just been proven constant, so every record of it made
+    /// during tracing has to name the constant instead: each frame's active
+    /// boxes, and the virtualref, virtualizable and heapcache records
+    /// `TraceCtx::replace_box` owns. Writing back the one register the
+    /// opcode read leaves an alias in another register still naming the
+    /// non-constant box.
+    ///
+    /// The concrete-value banks are not touched: the constant stands for the
+    /// value the box already had, so every slot that named it already carries
+    /// that value.
+    fn replace_box(&mut self, ctx: &mut TraceCtx, oldbox: OpRef, newbox: OpRef, oldbox_type: Type) {
+        for frame in self.frames.frames.iter_mut() {
+            frame.replace_active_box_in_frame(oldbox, newbox, oldbox_type);
+        }
+        ctx.replace_box(oldbox, newbox);
+    }
+
     /// `pyjitpl.py MIFrame._establish_nullity(box, orgpc)` — returns
     /// `box.nonnull()`, guarding it into the trace on the way.
     ///
@@ -1932,7 +1951,6 @@ where
         &mut self,
         ctx: &mut TraceCtx,
         sym: &mut S,
-        src_reg: usize,
         src: OpRef,
         src_value: i64,
         opcode_pc: usize,
@@ -1953,10 +1971,8 @@ where
             }
         } else if !src.is_constant() {
             self.record_state_guard(ctx, sym, OpCode::GuardIsnull, &[src], opcode_pc, false);
-            // `replace_box(box, constant_from_op(box))` — the register
-            // write-back stand-in, as in [`Self::implement_guard_value`].
             let null = ctx.const_null();
-            self.set_ref_reg(src_reg, Some(null), Some(0));
+            self.replace_box(ctx, src, null, Type::Ref);
         }
         // majit's `nullity_now_known` also records WHICH nullity, where
         // upstream only sets the flag; `is_nullity_known` then answers
@@ -5519,7 +5535,7 @@ where
                     )
                 };
                 let (src, src_value) = self.read_ref_reg(src_idx);
-                let nonnull = self.establish_nullity(ctx, sym, src_idx, src, src_value, opcode_pc);
+                let nonnull = self.establish_nullity(ctx, sym, src, src_value, opcode_pc);
                 // pyjitpl.py:
                 //   opimpl_goto_if_not_ptr_nonzero: if not nonnull: self.pc = target
                 //   opimpl_goto_if_not_ptr_iszero:  if     nonnull: self.pc = target
@@ -13329,6 +13345,27 @@ mod tests {
             &[majit_ir::Type::Ref],
             &builder.finish(),
             &[(JitArgKind::Ref, OpRef::input_arg_ref(0), 0)],
+        );
+        assert_eq!(recorded, vec![OpCode::GuardIsnull], "{recorded:?}");
+    }
+
+    /// `replace_box` rewrites every frame's active boxes, not just the
+    /// register the branch was handed. An alias of the same box in another
+    /// register comes out of the null arm naming `CONST_NULL` too, so a read
+    /// through the alias folds.
+    #[test]
+    fn a_null_ptr_nullity_branch_replaces_the_box_in_an_aliasing_register() {
+        let mut builder = JitCodeBuilder::new();
+        let target = builder.new_label();
+        builder.goto_if_not_ptr_iszero(0, target);
+        // Read the ALIAS, not the register the branch resolved.
+        builder.ptr_nonzero(0, 1);
+        builder.mark_label(target);
+        let aliased = OpRef::input_arg_ref(0);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Ref, majit_ir::Type::Ref],
+            &builder.finish(),
+            &[(JitArgKind::Ref, aliased, 0), (JitArgKind::Ref, aliased, 0)],
         );
         assert_eq!(recorded, vec![OpCode::GuardIsnull], "{recorded:?}");
     }

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -3803,8 +3803,13 @@ where
                 // wires the check itself).
                 let vable_struct_ptr = self.read_ref_reg(vable_reg).1;
                 let guards_before = ctx.num_guards();
-                let (opref, value) =
-                    ctx.vable_getfield_int(opcode_pc, vable_opref, vable_struct_ptr, fielddescr);
+                let (opref, value) = ctx.vable_getfield_int(
+                    self.cpu.as_ref(),
+                    opcode_pc,
+                    vable_opref,
+                    vable_struct_ptr,
+                    fielddescr,
+                );
                 self.capture_vable_promote_guard(ctx, sym, opcode_pc, guards_before, None);
                 self.set_int_reg(dest, Some(opref), value.map(value_as_int_bits));
             }
@@ -3822,8 +3827,13 @@ where
                 };
                 let vable_struct_ptr = self.read_ref_reg(vable_reg).1;
                 let guards_before = ctx.num_guards();
-                let (opref, value) =
-                    ctx.vable_getfield_ref(opcode_pc, vable_opref, vable_struct_ptr, fielddescr);
+                let (opref, value) = ctx.vable_getfield_ref(
+                    self.cpu.as_ref(),
+                    opcode_pc,
+                    vable_opref,
+                    vable_struct_ptr,
+                    fielddescr,
+                );
                 self.capture_vable_promote_guard(ctx, sym, opcode_pc, guards_before, None);
                 self.set_ref_reg(dest, Some(opref), value.map(value_as_ref_bits));
             }
@@ -3841,8 +3851,13 @@ where
                 };
                 let vable_struct_ptr = self.read_ref_reg(vable_reg).1;
                 let guards_before = ctx.num_guards();
-                let (opref, value) =
-                    ctx.vable_getfield_float(opcode_pc, vable_opref, vable_struct_ptr, fielddescr);
+                let (opref, value) = ctx.vable_getfield_float(
+                    self.cpu.as_ref(),
+                    opcode_pc,
+                    vable_opref,
+                    vable_struct_ptr,
+                    fielddescr,
+                );
                 self.capture_vable_promote_guard(ctx, sym, opcode_pc, guards_before, None);
                 self.set_float_reg(dest, Some(opref), value.map(value_as_float_bits));
             }

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1938,7 +1938,7 @@ where
         opcode_pc: usize,
     ) -> bool {
         let value = src_value != 0;
-        if ctx.heapcache_nullity_known(src) == Some(true) {
+        if ctx.heapcache_nullity_answered(src) {
             ctx.profiler().count_ops(
                 OpCode::GuardNonnull,
                 crate::pyjitpl::counters::HEAPCACHED_OPS,
@@ -4561,6 +4561,18 @@ where
                     && array_opref.is_constant()
                     && index_opref.is_constant();
                 let (opref, reg_concrete) = if foldable {
+                    // `execute_and_record` counts the operation *before* it
+                    // decides to fold, so a hand-built constant that skips the
+                    // funnel under-reports OPS on green pure-array reads.
+                    //
+                    // The fold itself stays here rather than routing: the
+                    // funnel would re-read the item through
+                    // `Cpu::bh_getarrayitem_gc_i`, a second reader of an array
+                    // this site has already read directly with the descr's own
+                    // geometry — and of a raw data pointer carrying no GC type
+                    // header, which is why the record-time fold is licensed at
+                    // all (see above).
+                    ctx.profiler().count_ops(opcode, crate::counters::OPS);
                     (ctx.const_int(concrete), concrete)
                 } else if let Some(cached) = cached {
                     // pyjitpl.py:646 `count_ops(rop.GETARRAYITEM_GC_I,
@@ -13268,6 +13280,35 @@ mod tests {
             &[(JitArgKind::Ref, OpRef::input_arg_ref(0), 0x40)],
         );
         assert_eq!(recorded, vec![OpCode::GuardNonnull], "{recorded:?}");
+    }
+
+    /// `nullity_now_known` records a known-**null** box too, and upstream's
+    /// `is_nullity_known` answers true for it, so a second nullity branch on
+    /// that box short-circuits instead of re-guarding. Reading only
+    /// `Some(true)` out of pyre's three-valued answer emits a second
+    /// `GUARD_ISNULL`.
+    ///
+    /// The two branches must read the box through **different registers**.
+    /// The null arm rebinds only the register it was handed, so branching on
+    /// the same one twice reaches the heapcache holding `CONST_NULL` — a
+    /// constant, which upstream answers false for — and the test would pass
+    /// without ever exercising the known-null answer.
+    #[test]
+    fn a_second_nullity_branch_on_a_known_null_box_is_answered_by_the_heapcache() {
+        let mut builder = JitCodeBuilder::new();
+        let first = builder.new_label();
+        builder.goto_if_not_ptr_nonzero(0, first);
+        builder.mark_label(first);
+        let second = builder.new_label();
+        builder.goto_if_not_ptr_nonzero(1, second);
+        builder.mark_label(second);
+        let aliased = OpRef::input_arg_ref(0);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Ref, majit_ir::Type::Ref],
+            &builder.finish(),
+            &[(JitArgKind::Ref, aliased, 0), (JitArgKind::Ref, aliased, 0)],
+        );
+        assert_eq!(recorded, vec![OpCode::GuardIsnull], "{recorded:?}");
     }
 
     /// The null arm's `replace_box(box, constant_from_op(box))`: the source

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2748,14 +2748,23 @@ where
                 | OpCode::FloatGe
         );
         let same_box = !is_float && lhs.same_box(rhs);
-        if !(same_box || lhs.is_constant() && rhs.is_constant()) {
-            let cond = ctx.record_op(opcode, &[lhs, rhs]);
-            ctx.set_opref_concrete(cond, majit_ir::Value::Int(taken as i64));
+        if !same_box {
+            let cond = ctx.execute_and_record(
+                self.cpu.as_ref(),
+                opcode,
+                None,
+                &[lhs, rhs],
+                Some(majit_ir::Value::Int(taken as i64)),
+                self.last_exception_value,
+            );
             let guard = if taken {
                 OpCode::GuardTrue
             } else {
                 OpCode::GuardFalse
             };
+            // `generate_guard`'s `if isinstance(box, Const): return` is
+            // `record_state_guard`'s own first gate, so a folded `cond`
+            // suppresses the guard without a second test here.
             self.record_state_guard(ctx, sym, guard, &[cond], opcode_pc, false);
         }
         if !taken {
@@ -9110,18 +9119,18 @@ where
             return (ctx.const_int(fast), fast);
         }
         let value = eval_binop_i(opcode, lhs_value, rhs_value);
-        // `MetaInterp.execute_and_record`: a pure op whose args are all
-        // constants (`_all_constants`) folds to its constant result at trace
-        // time and records nothing.  Every opcode routed here is a pure int/uint arithmetic or
-        // comparison, so an all-constant pair yields a constant destination.
-        if lhs.is_constant() && rhs.is_constant() {
-            return (ctx.const_int(value), value);
-        }
-        let opref = ctx.record_op(opcode, &[lhs, rhs]);
-        // `Box(value)` parity: stamp the result OpRef with its
-        // runtime concrete so downstream `box_value(opref)` consumers
-        // see the value (matches PyPy `BoxInt(value)` carrier).
-        ctx.set_opref_concrete(opref, majit_ir::Value::Int(value));
+        // The returned `value` stays `eval_binop_i`'s, not the funnel's: on
+        // the fold path the two agree, and where the constant evaluator
+        // declines — an out-of-range shift, a zero divisor — the funnel
+        // records instead of folding and stamps the op with exactly this value.
+        let opref = ctx.execute_and_record(
+            self.cpu.as_ref(),
+            opcode,
+            None,
+            &[lhs, rhs],
+            Some(majit_ir::Value::Int(value)),
+            self.last_exception_value,
+        );
         (opref, value)
     }
 
@@ -9181,27 +9190,30 @@ where
             OpCode::IntMulOvf => lhs_value.overflowing_mul(rhs_value),
             _ => unreachable!("trace_int_binop_jump_if_ovf: {opcode:?}"),
         };
-        // All-constant operands fold at trace time
-        // (`MetaInterp.execute_and_record`): no resop, no guard.  A constant pair that overflows unconditionally
-        // takes the overflow branch.
-        if lhs.is_constant() && rhs.is_constant() {
-            if overflowed {
-                self.frames.current_mut().code_cursor = target;
-            } else {
-                self.set_int_reg(dst, Some(ctx.const_int(wrapped)), Some(wrapped));
-            }
-            return;
-        }
         // `int_*_ovf` produces the wrapping result and sets the overflow flag;
-        // the following box-less guard checks that flag.
-        let opref = ctx.record_op(opcode, &[lhs, rhs]);
-        ctx.set_opref_concrete(opref, majit_ir::Value::Int(wrapped));
-        let guard = if overflowed {
-            OpCode::GuardOverflow
-        } else {
-            OpCode::GuardNoOverflow
-        };
-        self.record_state_guard(ctx, sym, guard, &[], opcode_pc, false);
+        // the box-less guard below checks that flag.  An all-constant pair
+        // folds and needs neither, but only while the arithmetic stays in
+        // range: `execute_binary_int_const` spells the OVF opcodes with
+        // `checked_*`, so a constant pair that really overflows declines the
+        // fold and is recorded with its guard instead.
+        let opref = ctx.execute_and_record(
+            self.cpu.as_ref(),
+            opcode,
+            None,
+            &[lhs, rhs],
+            Some(majit_ir::Value::Int(wrapped)),
+            self.last_exception_value,
+        );
+        if !opref.is_constant() {
+            let guard = if overflowed {
+                OpCode::GuardOverflow
+            } else {
+                OpCode::GuardNoOverflow
+            };
+            // The guard is box-less, so `record_state_guard`'s Const gate —
+            // which reads `args[0]` — cannot see that the operation folded.
+            self.record_state_guard(ctx, sym, guard, &[], opcode_pc, false);
+        }
         if overflowed {
             // Overflow branch taken: the result register is not written; follow
             // the label (matches `bhimpl_int_*_jump_if_ovf` returning `None`).
@@ -9224,14 +9236,14 @@ where
         };
         let (src, src_value) = self.read_int_reg(src_idx);
         let value = eval_unary_i(opcode, src_value);
-        // `MetaInterp.execute_and_record`: a constant source folds to a
-        // constant result.
-        if src.is_constant() {
-            self.set_int_reg(dst, Some(ctx.const_int(value)), Some(value));
-            return;
-        }
-        let opref = ctx.record_op(opcode, &[src]);
-        ctx.set_opref_concrete(opref, majit_ir::Value::Int(value));
+        let opref = ctx.execute_and_record(
+            self.cpu.as_ref(),
+            opcode,
+            None,
+            &[src],
+            Some(majit_ir::Value::Int(value)),
+            self.last_exception_value,
+        );
         self.set_int_reg(dst, Some(opref), Some(value));
     }
 

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -4274,7 +4274,13 @@ where
                     Some(majit_ir::Value::Int(n)) => Some(*n),
                     _ => None,
                 };
-                let opref = ctx.opimpl_arraylen_gc(array_opref, descr, concrete);
+                let opref = ctx.opimpl_arraylen_gc(
+                    self.cpu.as_ref(),
+                    array_opref,
+                    descr,
+                    concrete,
+                    self.last_exception_value,
+                );
                 self.set_int_reg(dst, Some(opref), reg_concrete);
             }
             // ── BC_GETARRAYITEM_GC_I ──

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2876,7 +2876,7 @@ where
         let same_box = !is_float && lhs.same_box(rhs);
         if !same_box {
             let cond = ctx.execute_and_record(
-                self.cpu.as_ref(),
+                Some(self.cpu.as_ref()),
                 opcode,
                 None,
                 &[lhs, rhs],
@@ -4137,7 +4137,7 @@ where
                 // the op counters and the concrete stamp every sibling read
                 // already carries.
                 let opref = ctx.execute_and_record(
-                    self.cpu.as_ref(),
+                    Some(self.cpu.as_ref()),
                     OpCode::RawLoadI,
                     Some(descr),
                     &[base_opref, ea_opref],
@@ -4184,7 +4184,7 @@ where
                 };
                 // Never folds, for the reason given in the `BC_RAW_LOAD_I` arm.
                 let opref = ctx.execute_and_record(
-                    self.cpu.as_ref(),
+                    Some(self.cpu.as_ref()),
                     OpCode::RawLoadF,
                     Some(descr),
                     &[base_opref, ea_opref],
@@ -4283,7 +4283,7 @@ where
                 // a null gcptr before any fold — the executor row would
                 // dereference it.
                 let op = ctx.execute_and_record(
-                    self.cpu.as_ref(),
+                    Some(self.cpu.as_ref()),
                     kind,
                     Some(fielddescr),
                     &[struct_opref],
@@ -4320,7 +4320,7 @@ where
                 // See the `BC_GETFIELD_GC_I` arm on the descr gate and the
                 // null case.
                 let op = ctx.execute_and_record(
-                    self.cpu.as_ref(),
+                    Some(self.cpu.as_ref()),
                     OpCode::GetfieldGcF,
                     Some(fielddescr),
                     &[struct_opref],
@@ -5153,6 +5153,7 @@ where
                 let vable_struct_ptr = self.read_ref_reg(vable_reg).1;
                 let guards_before = ctx.num_guards();
                 let result = ctx.vable_arraylen_vable(
+                    self.cpu.as_ref(),
                     opcode_pc,
                     vable_opref,
                     vable_struct_ptr,
@@ -5285,7 +5286,7 @@ where
                 let (src, src_value) = self.read_int_reg(src_idx);
                 let cond_value = (src_value != 0) as i64;
                 let cond = ctx.execute_and_record(
-                    self.cpu.as_ref(),
+                    Some(self.cpu.as_ref()),
                     OpCode::IntIsTrue,
                     None,
                     &[src],
@@ -5313,7 +5314,7 @@ where
                 let (src, src_value) = self.read_int_reg(src_idx);
                 let cond_value = if src_value == 0 { 1 } else { 0 };
                 let cond = ctx.execute_and_record(
-                    self.cpu.as_ref(),
+                    Some(self.cpu.as_ref()),
                     OpCode::IntIsZero,
                     None,
                     &[src],
@@ -5484,7 +5485,7 @@ where
                             "BC_SWITCH miss chain: key {key} equals the switched value",
                         );
                         let cond = ctx.execute_and_record(
-                            self.cpu.as_ref(),
+                            Some(self.cpu.as_ref()),
                             OpCode::IntEq,
                             None,
                             &[value_box, key_ref],
@@ -9360,7 +9361,7 @@ where
         // declines — an out-of-range shift, a zero divisor — the funnel
         // records instead of folding and stamps the op with exactly this value.
         let opref = ctx.execute_and_record(
-            self.cpu.as_ref(),
+            Some(self.cpu.as_ref()),
             opcode,
             None,
             &[lhs, rhs],
@@ -9433,7 +9434,7 @@ where
         // `checked_*`, so a constant pair that really overflows declines the
         // fold and is recorded with its guard instead.
         let opref = ctx.execute_and_record(
-            self.cpu.as_ref(),
+            Some(self.cpu.as_ref()),
             opcode,
             None,
             &[lhs, rhs],
@@ -9473,7 +9474,7 @@ where
         let (src, src_value) = self.read_int_reg(src_idx);
         let value = eval_unary_i(opcode, src_value);
         let opref = ctx.execute_and_record(
-            self.cpu.as_ref(),
+            Some(self.cpu.as_ref()),
             opcode,
             None,
             &[src],
@@ -9508,7 +9509,7 @@ where
             other => panic!("trace_binop_r_to_i: unsupported opcode {other:?}"),
         };
         let opref = ctx.execute_and_record(
-            self.cpu.as_ref(),
+            Some(self.cpu.as_ref()),
             opcode,
             None,
             &[lhs, rhs],
@@ -9541,7 +9542,7 @@ where
             (src_value == 0) as i64
         };
         let opref = ctx.execute_and_record(
-            self.cpu.as_ref(),
+            Some(self.cpu.as_ref()),
             opcode,
             None,
             &[src, null],
@@ -9566,7 +9567,7 @@ where
         let (rhs, rhs_value) = self.read_float_reg(rhs_idx);
         let value = eval_binop_f(opcode, lhs_value, rhs_value);
         let opref = ctx.execute_and_record(
-            self.cpu.as_ref(),
+            Some(self.cpu.as_ref()),
             opcode,
             None,
             &[lhs, rhs],
@@ -9591,7 +9592,7 @@ where
         let (rhs, rhs_value) = self.read_float_reg(rhs_idx);
         let value = eval_float_cmp(opcode, lhs_value, rhs_value);
         let opref = ctx.execute_and_record(
-            self.cpu.as_ref(),
+            Some(self.cpu.as_ref()),
             opcode,
             None,
             &[lhs, rhs],
@@ -9613,7 +9614,7 @@ where
         let (src, src_value) = self.read_float_reg(src_idx);
         let value = eval_unary_f(opcode, src_value);
         let opref = ctx.execute_and_record(
-            self.cpu.as_ref(),
+            Some(self.cpu.as_ref()),
             opcode,
             None,
             &[src],
@@ -9636,7 +9637,7 @@ where
         let (src, src_value) = self.read_int_reg(src_idx);
         let fvalue = src_value as f64;
         let opref = ctx.execute_and_record(
-            self.cpu.as_ref(),
+            Some(self.cpu.as_ref()),
             OpCode::CastIntToFloat,
             None,
             &[src],
@@ -9664,7 +9665,7 @@ where
         let (src, bits) = self.read_float_reg(src_idx);
         let ivalue = f64::from_bits(bits as u64) as i64;
         let opref = ctx.execute_and_record(
-            self.cpu.as_ref(),
+            Some(self.cpu.as_ref()),
             OpCode::CastFloatToInt,
             None,
             &[src],
@@ -9686,7 +9687,7 @@ where
         };
         let (src, bits) = self.read_float_reg(src_idx);
         let opref = ctx.execute_and_record(
-            self.cpu.as_ref(),
+            Some(self.cpu.as_ref()),
             OpCode::ConvertFloatBytesToLonglong,
             None,
             &[src],
@@ -9707,7 +9708,7 @@ where
         };
         let (src, bits) = self.read_int_reg(src_idx);
         let opref = ctx.execute_and_record(
-            self.cpu.as_ref(),
+            Some(self.cpu.as_ref()),
             OpCode::ConvertLonglongBytesToFloat,
             None,
             &[src],

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -4345,24 +4345,24 @@ where
                         ),
                     }
                 };
-                let (opref, reg_concrete) =
-                    if array_opref.is_constant() && index_opref.is_constant() {
-                        // pyjitpl.py `execute_varargs(pure=True)` →
-                        // `record_result_of_call_pure`: a read of the immutable
-                        // bytecode array at a green index has all-constant args, so
-                        // it folds to a ConstInt and is not recorded — the same
-                        // record-time fold PyPy applies to `strgetitem(green_str,
-                        // green_pc)` (strings/immutable arrays lower to the pure
-                        // read variant). BC_GETARRAYITEM_GC_I is emitted only for
-                        // the green-pc dispatch's `program` fetch (the sole caller,
-                        // `add_gc_byte_array_descr`; comment above), whose array is
-                        // a green ref and index a green int, so folding here
-                        // collapses the per-pc opcode-dispatch guard ladder instead
-                        // of leaving a residual load. Done at record time, the read
-                        // hits the live array directly, so the optimizer's
-                        // `protect_speculative_array` typeid check (which a raw
-                        // `&[u8]` data pointer, having no GC type header, would fail)
-                        // never applies.
+                // `execute_varargs(pure=True)` → `record_result_of_call_pure`:
+                // an all-constant read of an array the opcode itself declares
+                // immutable folds to a ConstInt and is not recorded — the same
+                // record-time fold `strgetitem(green_str, green_pc)` gets, and
+                // for the same reason, that the pure spelling is what licenses
+                // it. `is_pure_with_descr` admits `GetarrayitemGcPureI` and no
+                // descr admits the plain read, so the plain read is recorded
+                // even with two constant arguments; whether an array qualifies
+                // is the emitter's call (`OpKind::ArrayRead { pure }`,
+                // `jitcode/assembler.rs`'s `getarrayitem_gc_i_pure`), not this
+                // site's. Done at record time the read hits the live array
+                // directly, so the optimizer's `protect_speculative_array`
+                // typeid check — which a raw `&[u8]` data pointer, having no GC
+                // type header, would fail — never applies.
+                let foldable = opcode == OpCode::GetarrayitemGcPureI
+                    && array_opref.is_constant()
+                    && index_opref.is_constant();
+                let (opref, reg_concrete) = if foldable {
                         (ctx.const_int(concrete), concrete)
                     } else if let Some(cached) = cached {
                         // pyjitpl.py:646 `count_ops(rop.GETARRAYITEM_GC_I,

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -9446,12 +9446,25 @@ where
             OpCode::IntMulOvf => lhs_value.overflowing_mul(rhs_value),
             _ => unreachable!("trace_int_binop_jump_if_ovf: {opcode:?}"),
         };
+        // `elif self.metainterp.ovf_flag: self.pc = lbl; return None # but
+        // don't emit GUARD_OVERFLOW`. Upstream folds the constant pair either
+        // way — `do_int_add_ovf` answers 0 and raises the flag when the
+        // arithmetic leaves range — and takes the branch with neither the
+        // operation nor its guard recorded. `execute_binary_int_const` spells
+        // these with `checked_*` and declines instead, because the optimizer
+        // shares it and there the operation and its guard are what carry the
+        // overflow, so the overflowing-constant case is decided here. The
+        // funnel's own fold gate is the condition mirrored.
+        if overflowed && lhs.is_constant() && rhs.is_constant() && self.last_exception_value == 0 {
+            // `execute_and_record` counts the operation before it decides to
+            // fold, and this returns in its place.
+            ctx.profiler().count_ops(opcode, crate::counters::OPS);
+            self.frames.current_mut().code_cursor = target;
+            return;
+        }
         // `int_*_ovf` produces the wrapping result and sets the overflow flag;
-        // the box-less guard below checks that flag.  An all-constant pair
-        // folds and needs neither, but only while the arithmetic stays in
-        // range: `execute_binary_int_const` spells the OVF opcodes with
-        // `checked_*`, so a constant pair that really overflows declines the
-        // fold and is recorded with its guard instead.
+        // the box-less guard below checks that flag.  An all-constant pair in
+        // range folds and needs neither.
         let opref = ctx.execute_and_record(
             Some(self.cpu.as_ref()),
             opcode,
@@ -13347,6 +13360,27 @@ mod tests {
             &[(JitArgKind::Ref, OpRef::input_arg_ref(0), 0)],
         );
         assert_eq!(recorded, vec![OpCode::GuardIsnull], "{recorded:?}");
+    }
+
+    /// `opimpl_int_*_jump_if_ovf`'s `elif self.metainterp.ovf_flag` arm: a
+    /// constant pair whose arithmetic leaves range takes the branch with
+    /// nothing recorded — neither the operation nor the guard that would
+    /// stand for an overflow both operands already decide.
+    #[test]
+    fn a_constant_pair_that_overflows_takes_the_branch_without_recording() {
+        let mut builder = JitCodeBuilder::new();
+        let overflow = builder.new_label();
+        builder.int_add_jump_if_ovf(2, 0, 1, overflow);
+        builder.mark_label(overflow);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Int, majit_ir::Type::Int],
+            &builder.finish(),
+            &[
+                (JitArgKind::Int, OpRef::const_int(i64::MAX), i64::MAX),
+                (JitArgKind::Int, OpRef::const_int(1), 1),
+            ],
+        );
+        assert!(recorded.is_empty(), "{recorded:?}");
     }
 
     /// `replace_box` rewrites every frame's active boxes, not just the

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -3969,9 +3969,9 @@ where
                 };
                 let (base_opref, base_addr) = self.read_int_reg(base_reg);
                 let (ea_opref, ea_value) = self.read_int_reg(ea_reg);
-                let opref =
-                    ctx.record_op_with_descr(OpCode::RawLoadI, &[base_opref, ea_opref], descr);
-                // Concrete eval: descriptor-sized read at `base + ea`.
+                // Concrete eval: descriptor-sized read at `base + ea`. It runs
+                // before the record because `execute_and_record` takes the
+                // value rather than computing it.
                 //
                 // SAFETY: the kernel clamps `ea` to an in-bounds byte offset
                 // (0 when the access would trap), so `base_addr + ea_value`
@@ -3994,6 +3994,21 @@ where
                         }
                     }
                 };
+                // `RawLoadI` is outside `is_pure_with_descr` at every descr —
+                // `test_raw_load_i_stays_non_pure_for_eval_breaker_poll` pins
+                // it there, because a pure raw load lets `optimize_guard_false`
+                // delete the back-edge eval-breaker poll — so the funnel always
+                // records. What it adds over a bare `record_op_with_descr` is
+                // the op counters and the concrete stamp every sibling read
+                // already carries.
+                let opref = ctx.execute_and_record(
+                    self.cpu.as_ref(),
+                    OpCode::RawLoadI,
+                    Some(descr),
+                    &[base_opref, ea_opref],
+                    Some(Value::Int(concrete)),
+                    self.last_exception_value,
+                );
                 self.set_int_reg(dst, Some(opref), Some(concrete));
             }
             jitcode::insns::BC_RAW_LOAD_F => {
@@ -4022,8 +4037,6 @@ where
                 };
                 let (base_opref, base_addr) = self.read_int_reg(base_reg);
                 let (ea_opref, ea_value) = self.read_int_reg(ea_reg);
-                let opref =
-                    ctx.record_op_with_descr(OpCode::RawLoadF, &[base_opref, ea_opref], descr);
                 // Concrete eval: an 8-byte f64 read at `base + ea`, carried as
                 // raw bits in the float bank (set_float_reg takes i64 bits).
                 //
@@ -4034,6 +4047,15 @@ where
                     8 => unsafe { core::ptr::read_unaligned(item_addr as *const i64) },
                     other => panic!("BC_RAW_LOAD_F: unsupported itemsize = {other}"),
                 };
+                // Never folds, for the reason given in the `BC_RAW_LOAD_I` arm.
+                let opref = ctx.execute_and_record(
+                    self.cpu.as_ref(),
+                    OpCode::RawLoadF,
+                    Some(descr),
+                    &[base_opref, ea_opref],
+                    Some(Value::Float(f64::from_bits(concrete_bits as u64))),
+                    self.last_exception_value,
+                );
                 self.set_float_reg(dst, Some(opref), Some(concrete_bits));
             }
             jitcode::insns::BC_GETFIELD_GC_I
@@ -13034,6 +13056,64 @@ mod tests {
             .iter()
             .map(|op| op.opcode)
             .collect()
+    }
+
+    /// `BC_RAW_LOAD_I` / `_F` advanced their register bank with the traced
+    /// concrete but left the recorded op unstamped — the one read family that
+    /// did. `RawLoad*` is outside `is_pure_with_descr` at every descr, so the
+    /// op is still recorded; only the stamp and the counters are new.
+    #[test]
+    fn a_raw_load_records_and_stamps_its_concrete() {
+        let ipayload: i64 = 0x0123_4567_89ab_cdef;
+        let fpayload: f64 = 1.5;
+
+        for (want_op, want_value, base, jitcode) in [
+            (
+                OpCode::RawLoadI,
+                Value::Int(ipayload),
+                &ipayload as *const i64 as i64,
+                {
+                    let mut b = JitCodeBuilder::new();
+                    let descr = b.add_raw_int_array_descr(8);
+                    b.raw_load_i(2, 0, 1, descr);
+                    b.finish()
+                },
+            ),
+            (
+                OpCode::RawLoadF,
+                Value::Float(fpayload),
+                &fpayload as *const f64 as i64,
+                {
+                    let mut b = JitCodeBuilder::new();
+                    let descr = b.add_raw_float_array_descr();
+                    b.raw_load_f(0, 0, 1, descr);
+                    b.finish()
+                },
+            ),
+        ] {
+            let mut ctx = TraceCtx::for_test_types(&[majit_ir::Type::Int, majit_ir::Type::Int]);
+            let mut sym = DummySym;
+            let action = trace_jitcode_with_args(
+                &mut ctx,
+                &mut sym,
+                &jitcode,
+                0,
+                |_pc| 0,
+                &[
+                    (JitArgKind::Int, OpRef::input_arg_int(0), base),
+                    (JitArgKind::Int, OpRef::input_arg_int(1), 0),
+                ],
+            );
+            assert!(matches!(action, TraceAction::Continue));
+
+            let recorder = ctx.into_recorder();
+            let op = recorder
+                .ops()
+                .iter()
+                .find(|op| op.opcode == want_op)
+                .unwrap_or_else(|| panic!("{want_op:?} must be recorded, never folded"));
+            assert_eq!(op.get_value(), Some(want_value), "{want_op:?}");
+        }
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -4262,7 +4262,8 @@ where
             // `add_gc_byte_array_descr`).  Concrete eval reads byte at
             // `array_addr + index` and zero-extends to i64 (matching
             // CPython `ord()` 0..=255 semantics).
-            jitcode::insns::BC_GETARRAYITEM_GC_I => {
+            jitcode::insns::BC_GETARRAYITEM_GC_I
+            | jitcode::insns::BC_GETARRAYITEM_GC_I_PURE => {
                 let (array_reg, index_reg, descr_idx, dst) = {
                     let frame = self.frames.current_mut();
                     let array_reg = frame.next_reg() as usize;
@@ -4281,6 +4282,22 @@ where
                 };
                 let (array_opref, array_addr) = self.read_ref_reg(array_reg);
                 let (index_opref, index_value) = self.read_int_reg(index_reg);
+                // `getarrayitem_gc_i_pure` shares this body: the load, the
+                // heapcache handling and the register write are identical, and
+                // only the recorded opcode differs — the same reason
+                // `blackhole.py` aliases `bhimpl_getarrayitem_gc_i_pure` onto
+                // the plain impl.  The distinction that does matter is which
+                // opcode reaches the optimizer: `GetarrayitemGcPureI` is inside
+                // the always-pure range, so `OpHelpers.is_pure_with_descr`
+                // admits it, while the plain read is admitted by no descr.
+                // The codewriter has already made that choice —
+                // `OpKind::ArrayRead { pure }` picks the spelling from whether
+                // the list is ever mutated (`ll_getitem_foldable_nonneg`).
+                let opcode = if bytecode == jitcode::insns::BC_GETARRAYITEM_GC_I_PURE {
+                    OpCode::GetarrayitemGcPureI
+                } else {
+                    OpCode::GetarrayitemGcI
+                };
                 let descr_index = descr.index();
                 // pyjitpl.py `_do_getarrayitem_gc_any`: check
                 // `heapcache.getarrayitem(arraybox, indexbox, arraydescr)`
@@ -4323,7 +4340,7 @@ where
                         (4, false) => *(item_addr as *const u32) as i64,
                         (8, _) => *(item_addr as *const i64),
                         other => panic!(
-                            "BC_GETARRAYITEM_GC_I: unsupported (itemsize, signed) = {:?}",
+                            "getarrayitem_gc_i: unsupported (itemsize, signed) = {:?}",
                             other,
                         ),
                     }
@@ -4351,7 +4368,7 @@ where
                         // pyjitpl.py:646 `count_ops(rop.GETARRAYITEM_GC_I,
                         // Counters.HEAPCACHED_OPS)` — folded-away op accounting.
                         ctx.profiler().count_ops(
-                            OpCode::GetarrayitemGcI,
+                            opcode,
                             crate::pyjitpl::counters::HEAPCACHED_OPS,
                         );
                         // pyjitpl.py:644-668 sanity check: compare the
@@ -4394,20 +4411,20 @@ where
                             // is `mark_escaped` escaping `array_opref` and
                             // `index_opref` — match that structure here.
                             ctx.heapcache_invalidate_caches_varargs(
-                                OpCode::GetarrayitemGcI,
+                                opcode,
                                 None,
                                 &[array_opref, index_opref],
                             );
                             let _ = ctx.record_op_with_descr(
-                                OpCode::GetarrayitemGcI,
+                                opcode,
                                 &[array_opref, index_opref],
                                 descr,
                             );
                             debug_assert!(
                                 false,
-                                "BC_GETARRAYITEM_GC_I sanity check failed: \
+                                "{:?} sanity check failed: \
                              cached={:?} concrete={}",
-                                expected, concrete,
+                                opcode, expected, concrete,
                             );
                         }
                         let reg_concrete = if stale {
@@ -4418,7 +4435,7 @@ where
                         (cached, reg_concrete)
                     } else {
                         let opref = ctx.record_op_with_descr(
-                            OpCode::GetarrayitemGcI,
+                            opcode,
                             &[array_opref, index_opref],
                             descr,
                         );

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1904,6 +1904,64 @@ where
         promoted_box
     }
 
+    /// `pyjitpl.py MIFrame.opimpl_goto_if_not(box, target, orgpc, replace)`.
+    ///
+    /// ```python
+    /// switchcase = box.getint()
+    /// if switchcase:
+    ///     assert switchcase == 1
+    ///     opnum = rop.GUARD_TRUE
+    ///     promoted_box = CONST_1
+    /// else:
+    ///     opnum = rop.GUARD_FALSE
+    ///     promoted_box = CONST_0
+    /// self.metainterp.generate_guard(opnum, box, resumepc=orgpc)
+    /// if not switchcase:
+    ///     self.pc = target
+    /// if isinstance(box, Const):
+    ///     return
+    /// if replace:
+    ///     self.metainterp.replace_box(box, promoted_box)
+    /// ```
+    ///
+    /// `replace_reg` carries upstream's `replace` flag *and* the register the
+    /// rebind lands in: `Some(reg)` is `replace=True`, `None` is the
+    /// `goto_if_not_int_is_true` caller's `replace=False`, whose condbox "does
+    /// not appear anywhere in any register" because the arm just made it.
+    /// `replace_box` has no whole-metainterp equivalent at this layer — see
+    /// [`Self::implement_guard_value`] for the same stand-in.
+    fn goto_if_not(
+        &mut self,
+        ctx: &mut TraceCtx,
+        sym: &mut S,
+        opcode_pc: usize,
+        cond: OpRef,
+        cond_value: i64,
+        target: usize,
+        replace_reg: Option<usize>,
+    ) {
+        let (guard, promoted_value) = if cond_value != 0 {
+            // `assert switchcase == 1`. Every producer of this bytecode passes
+            // a Rust `bool`, so the operand is 0 or 1 by construction — and
+            // the `CONST_1` rebind below is only sound while that holds.
+            debug_assert_eq!(cond_value, 1, "goto_if_not: operand is not a bool");
+            (OpCode::GuardTrue, 1)
+        } else {
+            (OpCode::GuardFalse, 0)
+        };
+        self.record_state_guard(ctx, sym, guard, &[cond], opcode_pc, false);
+        if cond_value == 0 {
+            self.frames.current_mut().code_cursor = target;
+        }
+        if cond.is_constant() {
+            return;
+        }
+        if let Some(reg) = replace_reg {
+            let promoted_box = ctx.const_int(promoted_value);
+            self.set_int_reg(reg, Some(promoted_box), Some(promoted_value));
+        }
+    }
+
     /// pyjitpl.py `MIFrame._create_segmented_trace_and_blackhole`,
     /// recording half.
     ///
@@ -5096,7 +5154,7 @@ where
             }
             jitcode::insns::BC_PTR_ISZERO => self.trace_ptr_nullity(ctx, false),
             jitcode::insns::BC_PTR_NONZERO => self.trace_ptr_nullity(ctx, true),
-            jitcode::insns::BC_GOTO_IF_NOT | jitcode::insns::BC_GOTO_IF_NOT_INT_IS_TRUE => {
+            jitcode::insns::BC_GOTO_IF_NOT => {
                 // Canonical `iL` encoding (`assembler.py:165-174`):
                 // [cond:u8][target:u16].
                 let (opcode_pc, cond_idx, target) = {
@@ -5117,16 +5175,47 @@ where
                     )
                 };
                 let (cond, cond_value) = self.read_int_reg(cond_idx);
-                let branch_taken = cond_value == 0;
-                let opcode = if branch_taken {
-                    OpCode::GuardFalse
-                } else {
-                    OpCode::GuardTrue
+                self.goto_if_not(
+                    ctx,
+                    sym,
+                    opcode_pc,
+                    cond,
+                    cond_value,
+                    target,
+                    Some(cond_idx),
+                );
+            }
+            // pyjitpl.py opimpl_goto_if_not_int_is_true(box, target):
+            //   condbox = self.execute(rop.INT_IS_TRUE, box)
+            //   self.opimpl_goto_if_not(condbox, target, ..., replace=False)
+            //
+            // `jtransform.py optimize_goto_if_not` admits `int_is_true` into
+            // the folded-exitswitch set and `flatten.py` then emits
+            // `goto_if_not_int_is_true`, so this is a distinct opname with its
+            // own byte — only `blackhole.py:913` aliases the two, and only on
+            // the blackhole side, where there is no operation to re-record.
+            jitcode::insns::BC_GOTO_IF_NOT_INT_IS_TRUE => {
+                // Canonical `iL` encoding: [src:u8][target:u16].
+                let (opcode_pc, src_idx, target) = {
+                    let frame = self.frames.current_mut();
+                    let opcode_pc = frame.code_cursor - 1;
+                    (
+                        opcode_pc,
+                        frame.next_reg() as usize,
+                        frame.next_u16() as usize,
+                    )
                 };
-                self.record_state_guard(ctx, sym, opcode, &[cond], opcode_pc, false);
-                if branch_taken {
-                    self.frames.current_mut().code_cursor = target;
-                }
+                let (src, src_value) = self.read_int_reg(src_idx);
+                let cond_value = (src_value != 0) as i64;
+                let cond = ctx.execute_and_record(
+                    self.cpu.as_ref(),
+                    OpCode::IntIsTrue,
+                    None,
+                    &[src],
+                    Some(majit_ir::Value::Int(cond_value)),
+                    self.last_exception_value,
+                );
+                self.goto_if_not(ctx, sym, opcode_pc, cond, cond_value, target, None);
             }
             // pyjitpl.py opimpl_goto_if_not_int_is_zero(box, target):
             //   condbox = execute(rop.INT_IS_ZERO, box)
@@ -13056,6 +13145,65 @@ mod tests {
             .iter()
             .map(|op| op.opcode)
             .collect()
+    }
+
+    /// `opimpl_goto_if_not`'s tail — `if replace: replace_box(box,
+    /// promoted_box)` — rebinds the condition register to the constant the
+    /// guard just proved, so a second read of it folds instead of re-guarding.
+    #[test]
+    fn goto_if_not_rebinds_its_condition_register_to_the_proved_constant() {
+        // `cond` is an input arg, so the guard cannot be elided; reading it
+        // again after the branch is what shows the rebind.
+        let mut builder = JitCodeBuilder::new();
+        let target = builder.new_label();
+        builder.goto_if_not_int_is_true(0, target);
+        builder.record_binop_i(1, OpCode::IntAdd, 0, 0);
+        builder.mark_label(target);
+        let jitcode = builder.finish();
+
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Int],
+            &jitcode,
+            &[(JitArgKind::Int, OpRef::input_arg_int(0), 1)],
+        );
+        assert!(recorded.contains(&OpCode::GuardTrue), "{recorded:?}");
+        assert!(
+            !recorded.contains(&OpCode::IntAdd),
+            "the rebound CONST_1 must let the following IntAdd fold: {recorded:?}",
+        );
+    }
+
+    /// `MIFrame.opimpl_goto_if_not_int_is_true` re-executes the `INT_IS_TRUE`
+    /// that `jtransform.py optimize_goto_if_not` folded into the exitswitch,
+    /// then branches with `replace=False`. No majit front end emits this byte
+    /// today — every condition it lowers is already a Rust `bool` — so the
+    /// jitcode is patched to it directly.
+    #[test]
+    fn goto_if_not_int_is_true_records_the_folded_int_is_true() {
+        let mut builder = JitCodeBuilder::new();
+        let target = builder.new_label();
+        builder.goto_if_not_int_is_true(0, target);
+        builder.record_binop_i(1, OpCode::IntAdd, 0, 0);
+        builder.mark_label(target);
+        let mut jitcode = builder.finish();
+        let code = &mut jitcode.core_mut().body_mut().code;
+        let at = code
+            .iter()
+            .position(|&b| b == jitcode::insns::BC_GOTO_IF_NOT)
+            .expect("the builder writes the canonical goto_if_not byte");
+        code[at] = jitcode::insns::BC_GOTO_IF_NOT_INT_IS_TRUE;
+
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Int],
+            &jitcode,
+            &[(JitArgKind::Int, OpRef::input_arg_int(0), 7)],
+        );
+        assert!(recorded.contains(&OpCode::IntIsTrue), "{recorded:?}");
+        assert!(recorded.contains(&OpCode::GuardTrue), "{recorded:?}");
+        assert!(
+            recorded.contains(&OpCode::IntAdd),
+            "replace=False leaves the source register alone: {recorded:?}",
+        );
     }
 
     /// `BC_RAW_LOAD_I` / `_F` advanced their register bank with the traced

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -478,7 +478,13 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
             }
             (
                 *offset,
-                majit_ir::descr::make_field_descr(*offset, *field_size, *field_type, *field_flag),
+                majit_ir::descr::make_field_descr_with_immutability(
+                    *offset,
+                    *field_size,
+                    *field_type,
+                    *field_flag,
+                    *is_immutable,
+                ),
             )
         }
         other => panic!("getfield_gc/setfield_gc: descr is not a Field: {other:?}"),
@@ -4107,13 +4113,26 @@ where
                 } else {
                     OpCode::GetfieldGcI
                 };
-                let op = ctx.record_op_with_descr(kind, &[struct_opref], fielddescr);
                 let value = if is_ref {
                     Value::Ref(majit_ir::GcRef(loaded as usize))
                 } else {
                     Value::Int(loaded)
                 };
-                ctx.set_opref_concrete(op, value);
+                // `is_pure_with_descr` admits GETFIELD_GC_{I,R} only for a
+                // descr that answers `is_always_pure`, so only an immutable
+                // field off a constant struct folds. The null case hands the
+                // funnel no concrete: `loaded` is a fabricated 0 rather than a
+                // real load, and `llmodel.py protect_speculative_field` rejects
+                // a null gcptr before any fold — the executor row would
+                // dereference it.
+                let op = ctx.execute_and_record(
+                    self.cpu.as_ref(),
+                    kind,
+                    Some(fielddescr),
+                    &[struct_opref],
+                    (struct_ptr != 0).then_some(value),
+                    self.last_exception_value,
+                );
                 if is_ref {
                     self.set_ref_reg(dest, Some(op), Some(loaded));
                 } else {
@@ -4141,8 +4160,16 @@ where
                 } else {
                     0
                 };
-                let op = ctx.record_op_with_descr(OpCode::GetfieldGcF, &[struct_opref], fielddescr);
-                ctx.set_opref_concrete(op, Value::Float(f64::from_bits(loaded as u64)));
+                // See the `BC_GETFIELD_GC_I` arm on the descr gate and the
+                // null case.
+                let op = ctx.execute_and_record(
+                    self.cpu.as_ref(),
+                    OpCode::GetfieldGcF,
+                    Some(fielddescr),
+                    &[struct_opref],
+                    (struct_ptr != 0).then_some(Value::Float(f64::from_bits(loaded as u64))),
+                    self.last_exception_value,
+                );
                 self.set_float_reg(dest, Some(op), Some(loaded));
             }
             jitcode::insns::BC_SETFIELD_VABLE_I => {
@@ -13279,6 +13306,54 @@ mod tests {
                 .count(),
             2,
         );
+    }
+
+    #[test]
+    fn pure_getfield_folds_off_a_constant_struct() {
+        // One-word header + an i64 payload at offset 8, the layout
+        // `getfield_gc_fold_accepts_plain_spelling` (`executor.rs`) uses.
+        let storage: Box<[i64; 2]> = Box::new([0, 42]);
+        let base = storage.as_ref().as_ptr() as i64;
+
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_r_value(0, base);
+        builder.getfield_gc_i_pure(1, 0, 8);
+        let folded = traced_opcodes(&[], &builder.finish(), &[]);
+        assert!(!folded.contains(&OpCode::GetfieldGcI));
+
+        let mut builder = JitCodeBuilder::new();
+        builder.getfield_gc_i_pure(1, 0, 8);
+        let recorded = traced_opcodes(
+            &[majit_ir::Type::Ref],
+            &builder.finish(),
+            &[(JitArgKind::Ref, OpRef::input_arg_ref(0), base)],
+        );
+        assert!(recorded.contains(&OpCode::GetfieldGcI));
+    }
+
+    #[test]
+    fn a_pure_getfield_off_a_null_struct_records() {
+        // `loaded` is a fabricated 0 on this leg, and the executor row would
+        // dereference the null; the arm hands the funnel no concrete so it
+        // records.
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_r_value(0, 0);
+        builder.getfield_gc_i_pure(1, 0, 8);
+        let ops = traced_opcodes(&[], &builder.finish(), &[]);
+        assert!(ops.contains(&OpCode::GetfieldGcI));
+    }
+
+    #[test]
+    fn a_mutable_getfield_records_off_a_constant_struct() {
+        // `getfield_gc_i` builds a mutable descr, so `is_pure_with_descr`
+        // answers false and the read records however constant the struct is.
+        let storage: Box<[i64; 2]> = Box::new([0, 42]);
+        let base = storage.as_ref().as_ptr() as i64;
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_r_value(0, base);
+        builder.getfield_gc_i(1, 0, 8, 0, "payload");
+        let ops = traced_opcodes(&[], &builder.finish(), &[]);
+        assert!(ops.contains(&OpCode::GetfieldGcI));
     }
 
     fn switch_return_jitcode() -> JitCode {

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -13307,35 +13307,6 @@ mod tests {
         assert_eq!(recorded, vec![OpCode::GuardNonnull], "{recorded:?}");
     }
 
-    /// `nullity_now_known` records a known-**null** box too, and upstream's
-    /// `is_nullity_known` answers true for it, so a second nullity branch on
-    /// that box short-circuits instead of re-guarding. Reading only
-    /// `Some(true)` out of pyre's three-valued answer emits a second
-    /// `GUARD_ISNULL`.
-    ///
-    /// The two branches must read the box through **different registers**.
-    /// The null arm rebinds only the register it was handed, so branching on
-    /// the same one twice reaches the heapcache holding `CONST_NULL` — a
-    /// constant, which upstream answers false for — and the test would pass
-    /// without ever exercising the known-null answer.
-    #[test]
-    fn a_second_nullity_branch_on_a_known_null_box_is_answered_by_the_heapcache() {
-        let mut builder = JitCodeBuilder::new();
-        let first = builder.new_label();
-        builder.goto_if_not_ptr_nonzero(0, first);
-        builder.mark_label(first);
-        let second = builder.new_label();
-        builder.goto_if_not_ptr_nonzero(1, second);
-        builder.mark_label(second);
-        let aliased = OpRef::input_arg_ref(0);
-        let recorded = traced_opcodes(
-            &[majit_ir::Type::Ref, majit_ir::Type::Ref],
-            &builder.finish(),
-            &[(JitArgKind::Ref, aliased, 0), (JitArgKind::Ref, aliased, 0)],
-        );
-        assert_eq!(recorded, vec![OpCode::GuardIsnull], "{recorded:?}");
-    }
-
     /// The null arm's `replace_box(box, constant_from_op(box))`: the source
     /// register comes out of the branch holding `CONST_NULL`, so a following
     /// nullity read of it folds instead of recording a `PTR_NE`.

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -4461,8 +4461,7 @@ where
             // `add_gc_byte_array_descr`).  Concrete eval reads byte at
             // `array_addr + index` and zero-extends to i64 (matching
             // CPython `ord()` 0..=255 semantics).
-            jitcode::insns::BC_GETARRAYITEM_GC_I
-            | jitcode::insns::BC_GETARRAYITEM_GC_I_PURE => {
+            jitcode::insns::BC_GETARRAYITEM_GC_I | jitcode::insns::BC_GETARRAYITEM_GC_I_PURE => {
                 let (array_reg, index_reg, descr_idx, dst) = {
                     let frame = self.frames.current_mut();
                     let array_reg = frame.next_reg() as usize;
@@ -4562,100 +4561,92 @@ where
                     && array_opref.is_constant()
                     && index_opref.is_constant();
                 let (opref, reg_concrete) = if foldable {
-                        (ctx.const_int(concrete), concrete)
-                    } else if let Some(cached) = cached {
-                        // pyjitpl.py:646 `count_ops(rop.GETARRAYITEM_GC_I,
-                        // Counters.HEAPCACHED_OPS)` — folded-away op accounting.
-                        ctx.profiler().count_ops(
-                            opcode,
-                            crate::pyjitpl::counters::HEAPCACHED_OPS,
-                        );
-                        // pyjitpl.py:644-668 sanity check: compare the
-                        // freshly executed load (`resvalue`) against the
-                        // cached box's `tobox.getint()`.  On mismatch
-                        // `_record_helper` records a fallback op whose
-                        // return value is discarded; `assert 0` fires in
-                        // debug mode; the function still returns the
-                        // (stale) cached box.  `_record_helper` routes
-                        // through `heapcache.invalidate_caches`, but that
-                        // call short-circuits on GETARRAYITEM_GC_I
-                        // (`mark_escaped` does not escape the read,
-                        // `clear_caches_not_necessary` returns True), so
-                        // the heapcache state is intentionally left
-                        // untouched.  The cached Box's intrinsic value is
-                        // the upstream `tobox.getint()` payload — fetched
-                        // through `box_value(cached)` which composes the
-                        // const pool, standard-virtualizable shadow, and
-                        // the frontend object's `value` field (RPython
-                        // `currfieldbox.getint()` dispatch parity).
-                        // `None` payload (entry seeded without a live
-                        // concrete) skips the check.
-                        let expected = match ctx.box_value(cached) {
-                            Some(majit_ir::Value::Int(n)) => Some(n),
-                            _ => None,
-                        };
-                        // Cache hit propagates the stale `tobox.getint()`
-                        // into the destination on mismatch — pyjitpl.py:669
-                        // returns `tobox` so the caller sees the cached
-                        // box's int, not `resvalue`.  Match that by
-                        // selecting `expected` (stale) when the assertion
-                        // fires, else the freshly executed int (which
-                        // equals expected in the no-mismatch arm).
-                        let stale = matches!(expected, Some(exp) if exp != concrete);
-                        if stale {
-                            // pyjitpl.py `_record_helper` invalidates
-                            // before recording.  `clear_caches_not_necessary`
-                            // short-circuits for GETARRAYITEM_GC_I (no-side-
-                            // effect read), so the only remaining side effect
-                            // is `mark_escaped` escaping `array_opref` and
-                            // `index_opref` — match that structure here.
-                            ctx.heapcache_invalidate_caches_varargs(
-                                opcode,
-                                None,
-                                &[array_opref, index_opref],
-                            );
-                            let _ = ctx.record_op_with_descr(
-                                opcode,
-                                &[array_opref, index_opref],
-                                descr,
-                            );
-                            debug_assert!(
-                                false,
-                                "{:?} sanity check failed: \
-                             cached={:?} concrete={}",
-                                opcode, expected, concrete,
-                            );
-                        }
-                        let reg_concrete = if stale {
-                            expected.expect("stale only set when expected is Some")
-                        } else {
-                            concrete
-                        };
-                        (cached, reg_concrete)
-                    } else {
-                        let opref = ctx.record_op_with_descr(
-                            opcode,
-                            &[array_opref, index_opref],
-                            descr,
-                        );
-                        // pyjitpl.py:671-672 `heapcache.getarrayitem_now_known`.
-                        // Pair the recorded opref with the live `concrete`
-                        // payload — mirrors RPython's `resbox` Box carrying
-                        // both identity and value from `executor.execute`.
-                        // `Box.value` parity: stamp the result OpRef's
-                        // frontend value slot so `lookup_opref_concrete(opref)`
-                        // returns the runtime concrete (RPython
-                        // `IntFrontendOp(pos, intval)` construction-time
-                        // field assignment).
-                        ctx.set_opref_concrete(opref, majit_ir::Value::Int(concrete));
-                        ctx.heapcache_getarrayitem_now_known(
-                            array_opref,
-                            index_opref,
-                            descr_index,
-                            opref,
-                        );
-                        (opref, concrete)
+                    (ctx.const_int(concrete), concrete)
+                } else if let Some(cached) = cached {
+                    // pyjitpl.py:646 `count_ops(rop.GETARRAYITEM_GC_I,
+                    // Counters.HEAPCACHED_OPS)` — folded-away op accounting.
+                    ctx.profiler()
+                        .count_ops(opcode, crate::pyjitpl::counters::HEAPCACHED_OPS);
+                    // pyjitpl.py:644-668 sanity check: compare the
+                    // freshly executed load (`resvalue`) against the
+                    // cached box's `tobox.getint()`.  On mismatch
+                    // `_record_helper` records a fallback op whose
+                    // return value is discarded; `assert 0` fires in
+                    // debug mode; the function still returns the
+                    // (stale) cached box.  `_record_helper` routes
+                    // through `heapcache.invalidate_caches`, but that
+                    // call short-circuits on GETARRAYITEM_GC_I
+                    // (`mark_escaped` does not escape the read,
+                    // `clear_caches_not_necessary` returns True), so
+                    // the heapcache state is intentionally left
+                    // untouched.  The cached Box's intrinsic value is
+                    // the upstream `tobox.getint()` payload — fetched
+                    // through `box_value(cached)` which composes the
+                    // const pool, standard-virtualizable shadow, and
+                    // the frontend object's `value` field (RPython
+                    // `currfieldbox.getint()` dispatch parity).
+                    // `None` payload (entry seeded without a live
+                    // concrete) skips the check.
+                    let expected = match ctx.box_value(cached) {
+                        Some(majit_ir::Value::Int(n)) => Some(n),
+                        _ => None,
                     };
+                    // Cache hit propagates the stale `tobox.getint()`
+                    // into the destination on mismatch — pyjitpl.py:669
+                    // returns `tobox` so the caller sees the cached
+                    // box's int, not `resvalue`.  Match that by
+                    // selecting `expected` (stale) when the assertion
+                    // fires, else the freshly executed int (which
+                    // equals expected in the no-mismatch arm).
+                    let stale = matches!(expected, Some(exp) if exp != concrete);
+                    if stale {
+                        // pyjitpl.py `_record_helper` invalidates
+                        // before recording.  `clear_caches_not_necessary`
+                        // short-circuits for GETARRAYITEM_GC_I (no-side-
+                        // effect read), so the only remaining side effect
+                        // is `mark_escaped` escaping `array_opref` and
+                        // `index_opref` — match that structure here.
+                        ctx.heapcache_invalidate_caches_varargs(
+                            opcode,
+                            None,
+                            &[array_opref, index_opref],
+                        );
+                        let _ =
+                            ctx.record_op_with_descr(opcode, &[array_opref, index_opref], descr);
+                        debug_assert!(
+                            false,
+                            "{:?} sanity check failed: \
+                             cached={:?} concrete={}",
+                            opcode, expected, concrete,
+                        );
+                    }
+                    let reg_concrete = if stale {
+                        expected.expect("stale only set when expected is Some")
+                    } else {
+                        concrete
+                    };
+                    (cached, reg_concrete)
+                } else {
+                    let opref =
+                        ctx.record_op_with_descr(opcode, &[array_opref, index_opref], descr);
+                    // pyjitpl.py:671-672 `heapcache.getarrayitem_now_known`.
+                    // Pair the recorded opref with the live `concrete`
+                    // payload — mirrors RPython's `resbox` Box carrying
+                    // both identity and value from `executor.execute`.
+                    // `Box.value` parity: stamp the result OpRef's
+                    // frontend value slot so `lookup_opref_concrete(opref)`
+                    // returns the runtime concrete (RPython
+                    // `IntFrontendOp(pos, intval)` construction-time
+                    // field assignment).
+                    ctx.set_opref_concrete(opref, majit_ir::Value::Int(concrete));
+                    ctx.heapcache_getarrayitem_now_known(
+                        array_opref,
+                        index_opref,
+                        descr_index,
+                        opref,
+                    );
+                    (opref, concrete)
+                };
                 self.set_int_reg(dst, Some(opref), Some(reg_concrete));
             }
             // ── BC_GETARRAYITEM_GC_R ──

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -67,6 +67,42 @@ pub struct Snapshot {
     pub vref_boxes: Vec<SnapshotTagged>,
 }
 
+impl Snapshot {
+    /// Forward every inline gcref this snapshot carries.
+    ///
+    /// `MIFrame.get_list_of_active_snapshot_boxes` copies a constant ref
+    /// register's already-forwarded gcref out of its `OpRef::ConstPtr` into a
+    /// raw [`SnapshotTagged::Const`] word, and `jitcode.constants_r` entries
+    /// reach the same arm. The side table these land in accumulates for the
+    /// whole trace and is only handed to the compiler at the end of it, so
+    /// without this walk a collection between capture and compile leaves the
+    /// resume data naming a pre-move address. RPython has no such copy: its
+    /// snapshot holds the `ConstPtr` box itself, whose `value` the GC traces
+    /// through the object graph.
+    pub fn walk_const_ptr_refs(&mut self, visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+        let tagged = self
+            .frames
+            .iter_mut()
+            .flat_map(|f| f.boxes.iter_mut())
+            .chain(self.vable_boxes.iter_mut())
+            .chain(self.vref_boxes.iter_mut());
+        for t in tagged {
+            match t {
+                SnapshotTagged::Const(bits, Type::Ref) => {
+                    let mut gcref = majit_ir::GcRef(*bits as usize);
+                    visitor(&mut gcref);
+                    *bits = gcref.0 as i64;
+                }
+                // `build_vable_snapshot_boxes` / `build_vref_snapshot_boxes`
+                // tag their entries by `OpRef::ty()` without asking whether the
+                // operand is constant, so this arm can hold an inline gcref too.
+                SnapshotTagged::Box(OpRef::ConstPtr(gcref), _) => visitor(gcref),
+                SnapshotTagged::Const(..) | SnapshotTagged::Box(..) => {}
+            }
+        }
+    }
+}
+
 /// `jitcode_index` for a frame the recorder minted with no real coordinate.
 ///
 /// `crate::history::TraceCtx::record_guard_with_snapshot` attaches a

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -3274,7 +3274,12 @@ impl ResumeDataLoopMemo {
     /// resume.py getconst(const) — tag a constant value.
     /// Unified entry point matching RPython's getconst(const) which
     /// dispatches on const.type (INT, REF, FLOAT).
-    pub fn getconst(&mut self, val: i64, tp: majit_ir::Type) -> i16 {
+    ///
+    /// `Err(TagOverflow)` when the constant pool has outgrown the tag's 14-bit
+    /// signed field; RPython lets `tag`'s exception out of `getconst` the same
+    /// way, up to `optimizer.py`'s `except resume.TagOverflow: raise
+    /// compile.giveup()`.
+    pub fn getconst(&mut self, val: i64, tp: majit_ir::Type) -> Result<i16, TagOverflow> {
         match tp {
             majit_ir::Type::Int => self.getconst_int(val),
             majit_ir::Type::Ref => self.getconst_ref(val),
@@ -3284,46 +3289,61 @@ impl ResumeDataLoopMemo {
     }
 
     /// resume.py getconst for INT type.
-    pub fn getconst_int(&mut self, val: i64) -> i16 {
+    pub fn getconst_int(&mut self, val: i64) -> Result<i16, TagOverflow> {
         // Try inline TAGINT (-8191..8190 in RPython's i16 range).
         let shifted = val >> 13;
         if shifted == 0 || shifted == -1 {
-            return ((val << 2) | TAGINT as i64) as i16;
+            return Ok(((val << 2) | TAGINT as i64) as i16);
         }
         // Large int: check cache.
         if let Some(&tagged) = self.large_ints.get(&val) {
-            return tagged;
+            return Ok(tagged);
         }
-        let tagged = self.newconst(val, majit_ir::Type::Int);
+        let tagged = self.newconst(val, majit_ir::Type::Int)?;
         self.large_ints.insert(val, tagged);
-        tagged
+        Ok(tagged)
     }
 
     /// resume.py getconst for REF type.
-    pub fn getconst_ref(&mut self, val: i64) -> i16 {
+    pub fn getconst_ref(&mut self, val: i64) -> Result<i16, TagOverflow> {
         if val == 0 {
-            return NULLREF;
+            return Ok(NULLREF);
         }
         if let Some(&tagged) = self.refs.get(&val) {
-            return tagged;
+            return Ok(tagged);
         }
-        let tagged = self.newconst(val, majit_ir::Type::Ref);
+        let tagged = self.newconst(val, majit_ir::Type::Ref)?;
         self.refs.insert(val, tagged);
-        tagged
+        Ok(tagged)
     }
 
     /// resume.py getconst fallback for FLOAT type.
-    pub fn getconst_float(&mut self, val: i64) -> i16 {
+    pub fn getconst_float(&mut self, val: i64) -> Result<i16, TagOverflow> {
         // FLOAT constants always go to the pool (no inline encoding).
         // RPython: return self._newconst(const)
         self.newconst(val, majit_ir::Type::Float)
     }
 
-    /// resume.py _newconst — add to consts pool, return TAGCONST-tagged.
-    fn newconst(&mut self, val: i64, tp: majit_ir::Type) -> i16 {
-        let index = self.consts.len() as i32 + TAG_CONST_OFFSET;
+    /// resume.py `_newconst` — add to consts pool, return TAGCONST-tagged.
+    ///
+    /// ```python
+    /// result = tag(len(self.consts) + TAG_CONST_OFFSET, TAGCONST)
+    /// self.consts.append(const)
+    /// return result
+    /// ```
+    ///
+    /// The tag is minted through [`tag`] rather than by an inline shift-and-
+    /// cast, so a pool larger than the 14-bit signed field answers
+    /// `Err(TagOverflow)` instead of wrapping. A wrapped tag names a different
+    /// pool slot, and the deopt then restores a different constant than the
+    /// one the guard captured — with no diagnostic anywhere.
+    ///
+    /// The pool entry is pushed only after the tag is minted, so a rejected
+    /// tag leaves the pool exactly as it was.
+    fn newconst(&mut self, val: i64, tp: majit_ir::Type) -> Result<i16, TagOverflow> {
+        let tagged = tag(self.consts.len() as i32 + TAG_CONST_OFFSET, TAGCONST)?;
         self.consts.push(majit_ir::Const::from_raw_i64(val, tp));
-        ((index << 2) | TAGCONST as i32) as i16
+        Ok(tagged)
     }
 
     /// resume.py getconst — i64-sized variant used by the rd_numb
@@ -3344,10 +3364,16 @@ impl ResumeDataLoopMemo {
                 self.consts.push(majit_ir::Const::Int(*value));
                 // Also publish through the i16 cache so that a later
                 // `getconst_int(value)` returns the same pool slot
-                // (resume.py:171 self.large_ints[val] = tagged).
-                let tagged_i16 =
-                    ((((index as i32) + TAG_CONST_OFFSET) << 2) | TAGCONST as i32) as i16;
-                self.large_ints.insert(*value, tagged_i16);
+                // (resume.py:171 self.large_ints[val] = tagged). The cache
+                // records only slots an i16 tag can name: this encoder's own
+                // result is i64 and never truncates, so a slot past the tag's
+                // range is still encodable here, and skipping the entry leaves
+                // a later `getconst_int` to mint a fresh one and answer
+                // `Err(TagOverflow)` itself rather than be handed a wrapped
+                // tag naming somebody else's constant.
+                if let Ok(tagged_i16) = tag((index as i32) + TAG_CONST_OFFSET, TAGCONST) {
+                    self.large_ints.insert(*value, tagged_i16);
+                }
                 tag_i64(encode_len(index), TAGCONST)
             }
             majit_ir::Const::Ref(gcref) => {
@@ -3366,9 +3392,10 @@ impl ResumeDataLoopMemo {
                 }
                 let index = self.consts.len();
                 self.consts.push(majit_ir::Const::Ref(*gcref));
-                let tagged_i16 =
-                    ((((index as i32) + TAG_CONST_OFFSET) << 2) | TAGCONST as i32) as i16;
-                self.refs.insert(raw, tagged_i16);
+                // See the Int arm on why an unrepresentable tag skips the cache.
+                if let Ok(tagged_i16) = tag((index as i32) + TAG_CONST_OFFSET, TAGCONST) {
+                    self.refs.insert(raw, tagged_i16);
+                }
                 tag_i64(encode_len(index), TAGCONST)
             }
             majit_ir::Const::Float(v) => {
@@ -3558,7 +3585,7 @@ impl ResumeDataLoopMemo {
         num_env_virtuals: usize,
         numb_state: &NumberingState,
         env: &dyn majit_ir::BoxEnv,
-    ) -> (Vec<std::rc::Rc<majit_ir::RdVirtualInfo>>, usize) {
+    ) -> Result<(Vec<std::rc::Rc<majit_ir::RdVirtualInfo>>, usize), TagOverflow> {
         // resume.py: new_liveboxes = [None] * memo.num_cached_boxes()
         let mut new_boxes_list: Vec<Option<majit_ir::OpRef>> = vec![None; self.num_cached_boxes()];
         let mut count = 0;
@@ -3640,41 +3667,15 @@ impl ResumeDataLoopMemo {
                 };
                 if num_idx < rd_virtuals.len() {
                     // resume.py: fieldnums = [self._gettagged(box) for box in fieldboxes]
-                    let fieldnums: Vec<i16> = vf
-                        .field_oprefs
-                        .iter()
-                        .map(|&opref| {
-                            // resume.py _gettagged with pyre-specific fallback
-                            // to cached_boxes/cached_virtuals when the local
-                            // liveboxes entries are still UNASSIGNED/UNASSIGNEDVIRTUAL.
-                            if opref.is_none() {
-                                return UNINITIALIZED_TAG;
-                            }
-                            if env.is_const(opref) {
-                                let (val, tp) = env.get_const(opref);
-                                return self.getconst(val, tp);
-                            }
-                            // #160/S11: livebox / cached maps are box-keyed.
-                            let b = env.get_box_replacement_operand(opref);
-                            if let Some(t) = numb_state.liveboxes.get(&b) {
-                                return t;
-                            }
-                            if let Some(t) = new_liveboxes.get(&b) {
-                                if tagged_eq(t, UNASSIGNED)
-                                    && let Some(&num) = self.cached_boxes.get(&b)
-                                {
-                                    return tag(num, TAGBOX).unwrap_or(UNASSIGNED);
-                                }
-                                if tagged_eq(t, UNASSIGNEDVIRTUAL)
-                                    && let Some(&num) = self.cached_virtuals.get(&b)
-                                {
-                                    return tag(num, TAGVIRTUAL).unwrap_or(UNASSIGNEDVIRTUAL);
-                                }
-                                return t;
-                            }
-                            UNASSIGNED
-                        })
-                        .collect();
+                    let mut fieldnums: Vec<i16> = Vec::with_capacity(vf.field_oprefs.len());
+                    for &opref in &vf.field_oprefs {
+                        fieldnums.push(self._gettagged(
+                            opref,
+                            env,
+                            &numb_state.liveboxes,
+                            new_liveboxes,
+                        )?);
+                    }
                     let reused = env.virtual_info_would_be_reused(opref_id, &fieldnums);
                     // resume.py: vinfo = self.make_virtual_info(info, fieldnums)
                     if let Some(rd_virt) = env.make_virtual_info(opref_id, fieldnums) {
@@ -3687,7 +3688,7 @@ impl ResumeDataLoopMemo {
                 }
             }
         }
-        (rd_virtuals, nholes)
+        Ok((rd_virtuals, nholes))
     }
 
     /// resume.py `_add_pending_fields(pending_setfields)`.
@@ -3704,14 +3705,15 @@ impl ResumeDataLoopMemo {
         env: &dyn majit_ir::BoxEnv,
         liveboxes_from_env: &LiveboxMap,
         new_liveboxes: &LiveboxMap,
-    ) {
+    ) -> Result<(), TagOverflow> {
         for pf in pending_setfields.iter_mut() {
             let target = env.get_box_replacement(pf.target);
             let value = env.get_box_replacement(pf.value);
             // resume.py num = self._gettagged(box); fieldnum = self._gettagged(fieldbox)
-            pf.target_tagged = self._gettagged(target, env, liveboxes_from_env, new_liveboxes);
-            pf.value_tagged = self._gettagged(value, env, liveboxes_from_env, new_liveboxes);
+            pf.target_tagged = self._gettagged(target, env, liveboxes_from_env, new_liveboxes)?;
+            pf.value_tagged = self._gettagged(value, env, liveboxes_from_env, new_liveboxes)?;
         }
+        Ok(())
     }
 
     /// resume.py `_add_optimizer_sections(numb_state, liveboxes, liveboxes_from_env)`.
@@ -3738,7 +3740,7 @@ impl ResumeDataLoopMemo {
         new_liveboxes: &LiveboxMap,
         env: &dyn majit_ir::BoxEnv,
         optimizer_knowledge: Option<&OptimizerKnowledgeForResume>,
-    ) {
+    ) -> Result<(), TagOverflow> {
         // resume.py:572-574: serialize_optimizer_knowledge(
         //     self.optimizer, numb_state, liveboxes, liveboxes_from_env, self.memo)
         crate::optimizeopt::bridgeopt::serialize_optimizer_knowledge(
@@ -3748,7 +3750,7 @@ impl ResumeDataLoopMemo {
             new_liveboxes,
             env,
             optimizer_knowledge,
-        );
+        )
     }
 
     /// resume.py `_invalidation_needed(nliveboxes, nholes)`.
@@ -3779,15 +3781,17 @@ impl ResumeDataLoopMemo {
 
     /// resume.py _gettagged — resolve an OpRef to its tagged number.
     /// Looks up in liveboxes_from_env first, then new_liveboxes, then constant.
+    ///
+    /// Only the constant arm can fail, and it fails the way `getconst` does.
     pub(crate) fn _gettagged(
         &mut self,
         opref: majit_ir::OpRef,
         env: &dyn majit_ir::BoxEnv,
         liveboxes_from_env: &LiveboxMap,
         new_liveboxes: &LiveboxMap,
-    ) -> i16 {
+    ) -> Result<i16, TagOverflow> {
         if opref.is_none() {
-            return UNINITIALIZED_TAG;
+            return Ok(UNINITIALIZED_TAG);
         }
         // resume.py: isinstance(box, Const) → getconst
         if env.is_const(opref) {
@@ -3799,23 +3803,23 @@ impl ResumeDataLoopMemo {
         let b = env.get_box_replacement_operand(opref);
         // resume.py: liveboxes_from_env → existing tag
         if let Some(tagged) = liveboxes_from_env.get(&b) {
-            return tagged;
+            return Ok(tagged);
         }
         if let Some(tagged) = new_liveboxes.get(&b) {
             // Resolve UNASSIGNED to real cached number
             if tagged_eq(tagged, UNASSIGNED)
                 && let Some(&num) = self.cached_boxes.get(&b)
             {
-                return tag(num, TAGBOX).unwrap_or(UNASSIGNED);
+                return Ok(tag(num, TAGBOX).unwrap_or(UNASSIGNED));
             }
             if tagged_eq(tagged, UNASSIGNEDVIRTUAL)
                 && let Some(&num) = self.cached_virtuals.get(&b)
             {
-                return tag(num, TAGVIRTUAL).unwrap_or(UNASSIGNEDVIRTUAL);
+                return Ok(tag(num, TAGVIRTUAL).unwrap_or(UNASSIGNEDVIRTUAL));
             }
-            return tagged;
+            return Ok(tagged);
         }
-        UNASSIGNED
+        Ok(UNASSIGNED)
     }
 
     /// `ResumeDataLoopMemo._number_boxes` tags each box in a snapshot section.
@@ -3843,7 +3847,7 @@ impl ResumeDataLoopMemo {
             // resume.py: isinstance(box, Const) → getconst
             if env.is_const(opref) {
                 let (val, tp) = env.get_const(opref);
-                let tagged = self.getconst(val, tp);
+                let tagged = self.getconst(val, tp)?;
                 numb_state.append_short(tagged);
                 continue;
             }
@@ -4037,13 +4041,16 @@ impl ResumeDataLoopMemo {
         env: &dyn majit_ir::BoxEnv,
         pending_setfields: &mut [majit_ir::GuardPendingFieldEntry],
         optimizer_knowledge: Option<&OptimizerKnowledgeForResume>,
-    ) -> (
-        Vec<u8>,
-        Vec<majit_ir::Const>,
-        Vec<std::rc::Rc<majit_ir::RdVirtualInfo>>,
-        Vec<majit_ir::OpRef>,
-        LiveboxTypeMap,
-    ) {
+    ) -> Result<
+        (
+            Vec<u8>,
+            Vec<majit_ir::Const>,
+            Vec<std::rc::Rc<majit_ir::RdVirtualInfo>>,
+            Vec<majit_ir::OpRef>,
+            LiveboxTypeMap,
+        ),
+        TagOverflow,
+    > {
         let num_env_virtuals = numb_state.num_virtuals;
 
         // resume.py: split liveboxes_from_env into TAGBOX/TAGVIRTUAL
@@ -4218,7 +4225,7 @@ impl ResumeDataLoopMemo {
             num_env_virtuals as usize,
             &numb_state,
             env,
-        );
+        )?;
 
         // resume.py: if self._invalidation_needed(...): memo.clear_box_virtual_numbers()
         if self._invalidation_needed(liveboxes.len(), nholes) {
@@ -4231,7 +4238,7 @@ impl ResumeDataLoopMemo {
             env,
             &numb_state.liveboxes,
             &new_liveboxes,
-        );
+        )?;
 
         // resume.py:447: numb_state.patch(1, len(liveboxes))
         numb_state.writer.patch(1, liveboxes.len() as i32);
@@ -4243,7 +4250,7 @@ impl ResumeDataLoopMemo {
             &new_liveboxes,
             env,
             optimizer_knowledge,
-        );
+        )?;
 
         // resume.py:450-451: storage.rd_numb, storage.rd_consts
         let rd_numb = numb_state.create_numbering();
@@ -4305,13 +4312,13 @@ impl ResumeDataLoopMemo {
                 all_livebox_types.insert(opref, env.get_type(opref));
             }
         }
-        (
+        Ok((
             rd_numb,
             rd_consts,
             rd_virtuals,
             ordered_liveboxes,
             all_livebox_types,
-        )
+        ))
     }
 
     /// resume.py finish (on ResumeDataVirtualAdder) — encode with shared pool.
@@ -5106,7 +5113,7 @@ mod tests {
         );
         let numb_state = memo.number(&snapshot, &env, -1).unwrap();
         let (rd_numb, rd_consts, _rd_virtuals, liveboxes, _livebox_types) =
-            memo.finish(numb_state, &env, &mut [], None);
+            memo.finish(numb_state, &env, &mut [], None).unwrap();
 
         // liveboxes should contain only TAGBOX entries: OpRef::int_op(1) and OpRef::int_op(3)
         assert_eq!(liveboxes.len(), 2);
@@ -5596,6 +5603,41 @@ mod tests {
             rd_virtual_field_source(UNASSIGNEDVIRTUAL),
             ResumeValueSource::Unavailable
         );
+    }
+
+    /// The TAGCONST field is 14 signed bits, so pool index 8192 is the first
+    /// one it cannot name. Minting through `tag` makes that index an error;
+    /// the shift-and-cast it replaced produced `-8192`, a tag that reads back
+    /// as a *different* pool slot with no diagnostic anywhere.
+    #[test]
+    fn a_const_pool_past_the_tag_field_gives_up_instead_of_wrapping() {
+        let mut memo = ResumeDataLoopMemo::new();
+        // Floats never take the inline encoding, so each one is a pool entry.
+        for i in 0..8192 {
+            let tagged = memo
+                .getconst_float(i as i64)
+                .expect("index 0..8191 fits the 14-bit field");
+            assert_eq!(untag(tagged), (i, TAGCONST));
+        }
+        assert_eq!(memo.consts().len(), 8192);
+
+        // The whole getconst family gives up once the pool is full, and none
+        // of them leaves a half-written entry behind: `newconst` mints the
+        // tag before it pushes.
+        assert!(memo.getconst_float(0).is_err());
+        assert!(memo.getconst_ref(0x1234).is_err());
+        assert!(memo.getconst_int(1 << 40).is_err());
+        assert!(
+            memo.getconst(2.5f64.to_bits() as i64, majit_ir::Type::Float)
+                .is_err()
+        );
+        assert_eq!(memo.consts().len(), 8192);
+
+        // A wrapped tag would have been silently accepted: it stays in i16
+        // range and untags to a live pool slot that holds someone else's
+        // constant.
+        let wrapped = ((8192i32 << 2) | TAGCONST as i32) as i16;
+        assert_eq!(untag(wrapped), (-8192, TAGCONST));
     }
 }
 

--- a/majit/majit-metainterp/src/resume_box_reader.rs
+++ b/majit/majit-metainterp/src/resume_box_reader.rs
@@ -134,6 +134,23 @@ fn emit_stroruni_oopspec_call(
 /// resume.py decode_box parity for fieldnums (i16 tagged): decode one
 /// tagged array/field value into its bridge `OpRef` (typed InputArg for TAGBOX,
 /// const for TAGINT/TAGCONST, recursively materialized virtual for TAGVIRTUAL).
+/// The concrete `executor.execute(INT_ADD, a, b)` would have produced for the
+/// two `INT_ADD`s a resume decode synthesizes.
+///
+/// Neither has a live execution behind it, so the sum exists exactly when both
+/// operands decoded to constants — which is also the only case
+/// `TraceCtx::execute_and_record` folds in. It is evaluated through the same
+/// executor row the funnel folds with, so the two cannot disagree.
+fn int_add_concrete(a: OpRef, b: OpRef) -> Option<majit_ir::Value> {
+    let (majit_ir::Value::Int(x), majit_ir::Value::Int(y)) =
+        (a.inline_const_to_value()?, b.inline_const_to_value()?)
+    else {
+        return None;
+    };
+    crate::executor::execute_binary_int_const(majit_ir::OpCode::IntAdd, x, y)
+        .map(majit_ir::Value::Int)
+}
+
 pub fn decode_fieldnum(
     ctx: &mut crate::TraceCtx,
     tagged: i16,
@@ -650,19 +667,23 @@ pub fn materialize_bridge_virtual(
             let base_buffer = decode_fieldnum(ctx, fieldnums[0], rd_virtuals, resume_data, cache);
             // resume.py: buffer = decoder.int_add_const(base_buffer, self.offset)
             let offset_ref = ctx.const_int(*offset);
-            ctx.profiler()
-                .count_ops(OpCode::IntAdd, crate::counters::OPS);
-            ctx.profiler()
-                .count_ops(OpCode::IntAdd, crate::counters::RECORDED_OPS);
-            let buffer = ctx.record_op(OpCode::IntAdd, &[base_buffer, offset_ref]);
+            // `INT_ADD` is always-pure, so the funnel neither reads
+            // `last_exc_value` nor consults the cpu — the integer row folds
+            // from the operands alone.
+            let cpu = crate::cpu::default_cpu();
+            let buffer = ctx.execute_and_record(
+                cpu.as_ref(),
+                OpCode::IntAdd,
+                None,
+                &[base_buffer, offset_ref],
+                int_add_concrete(base_buffer, offset_ref),
+                0,
+            );
             // resume.py: decoder.virtuals_cache.set_int(index, buffer)
             cache.set_int(vidx, buffer);
             if crate::majit_log_enabled() {
                 eprintln!(
-                    "[jit][bridge-virtual] vidx={} VRawSliceInfo(offset={}) → OpRef::from_raw({})",
-                    vidx,
-                    offset,
-                    buffer.raw(),
+                    "[jit][bridge-virtual] vidx={vidx} VRawSliceInfo(offset={offset}) → {buffer:?}",
                 );
             }
             buffer
@@ -806,11 +827,17 @@ pub fn materialize_bridge_virtual(
             let start = decode_fieldnum(ctx, fieldnums[1], rd_virtuals, resume_data, cache);
             let length = decode_fieldnum(ctx, fieldnums[2], rd_virtuals, resume_data, cache);
             // resume.py:1157-1158 / :1185-1186: stopbox = INT_ADD(startbox, lengthbox)
-            ctx.profiler()
-                .count_ops(OpCode::IntAdd, crate::counters::OPS);
-            ctx.profiler()
-                .count_ops(OpCode::IntAdd, crate::counters::RECORDED_OPS);
-            let stop = ctx.record_op(OpCode::IntAdd, &[start, length]);
+            // See the `VRawSliceInfo` arm on the cpu and `last_exc_value`
+            // arguments an always-pure opcode does not reach.
+            let cpu = crate::cpu::default_cpu();
+            let stop = ctx.execute_and_record(
+                cpu.as_ref(),
+                OpCode::IntAdd,
+                None,
+                &[start, length],
+                int_add_concrete(start, length),
+                0,
+            );
             let oopspec = if is_unicode {
                 majit_ir::effectinfo::OopSpecIndex::UniSlice
             } else {
@@ -1122,4 +1149,81 @@ pub fn seed_bridge_virtualizable_boxes(
     values.push(identity_value);
     ctx.set_virtualizable_boxes_with_info(boxes, values, info, &array_lengths);
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use majit_ir::{OpCode, Type};
+
+    fn empty_resume_data(fail_arg_types: Vec<Type>) -> crate::jit_state::ResumeDataResult {
+        let num_failargs = fail_arg_types.len() as i32;
+        crate::jit_state::ResumeDataResult {
+            frames: Vec::new(),
+            virtualizable_values: Vec::new(),
+            virtualref_values: Vec::new(),
+            storage: None,
+            num_failargs,
+            fail_arg_types,
+        }
+    }
+
+    fn tag_int(value: i32) -> i16 {
+        ((value << 2) | majit_ir::resumedata::TAGINT as i32) as i16
+    }
+
+    fn tag_box(index: i32) -> i16 {
+        ((index << 2) | majit_ir::resumedata::TAGBOX as i32) as i16
+    }
+
+    /// `VRawSliceInfo` is `base_buffer + offset`; the base decodes to a
+    /// constant whenever the guard captured a TAGINT, which is the common case
+    /// for a resume decode.
+    fn materialize_raw_slice(base: i16, fail_arg_types: Vec<Type>) -> (OpRef, Vec<OpCode>) {
+        let mut ctx = crate::TraceCtx::for_test_types(&fail_arg_types);
+        let resume_data = empty_resume_data(fail_arg_types);
+        let mut cache = BridgeVirtualCache::new(1, default_bridge_array_descr);
+        let virtuals = vec![std::rc::Rc::new(majit_ir::RdVirtualInfo::VRawSliceInfo {
+            offset: 7,
+            fieldnums: vec![base],
+        })];
+        let buffer =
+            materialize_bridge_virtual(&mut ctx, 0, Some(&virtuals), &resume_data, &mut cache);
+        let ops = ctx
+            .into_recorder()
+            .ops()
+            .iter()
+            .map(|op| op.opcode)
+            .collect();
+        (buffer, ops)
+    }
+
+    #[test]
+    fn a_raw_slice_off_a_constant_base_folds_its_int_add() {
+        let (buffer, ops) = materialize_raw_slice(tag_int(5), Vec::new());
+        assert_eq!(buffer, OpRef::const_int(12));
+        assert!(!ops.contains(&OpCode::IntAdd));
+
+        let (buffer, ops) = materialize_raw_slice(tag_box(0), vec![Type::Int]);
+        assert!(!buffer.is_constant());
+        assert!(ops.contains(&OpCode::IntAdd));
+    }
+
+    /// The funnel folds through the executor row, so the concrete this helper
+    /// supplies has to come from the same one.
+    #[test]
+    fn int_add_concrete_answers_only_for_two_constant_operands() {
+        assert_eq!(
+            int_add_concrete(OpRef::const_int(5), OpRef::const_int(7)),
+            Some(majit_ir::Value::Int(12))
+        );
+        assert_eq!(
+            int_add_concrete(OpRef::input_arg_int(0), OpRef::const_int(7)),
+            None
+        );
+        assert_eq!(
+            int_add_concrete(OpRef::const_int(5), OpRef::const_ptr(majit_ir::GcRef(8))),
+            None
+        );
+    }
 }

--- a/majit/majit-metainterp/src/resume_box_reader.rs
+++ b/majit/majit-metainterp/src/resume_box_reader.rs
@@ -672,7 +672,7 @@ pub fn materialize_bridge_virtual(
             // from the operands alone.
             let cpu = crate::cpu::default_cpu();
             let buffer = ctx.execute_and_record(
-                cpu.as_ref(),
+                Some(cpu.as_ref()),
                 OpCode::IntAdd,
                 None,
                 &[base_buffer, offset_ref],
@@ -831,7 +831,7 @@ pub fn materialize_bridge_virtual(
             // arguments an always-pure opcode does not reach.
             let cpu = crate::cpu::default_cpu();
             let stop = ctx.execute_and_record(
-                cpu.as_ref(),
+                Some(cpu.as_ref()),
                 OpCode::IntAdd,
                 None,
                 &[start, length],

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -4795,12 +4795,7 @@ impl TraceCtx {
             eprintln!("[vable-idx-probe] {constness} pc={pc} value={index_runtime_value}");
         }
         // indexbox = self.implement_guard_value(indexbox, pc)
-        let promoted_index = if index.is_constant() {
-            index
-        } else {
-            self.promote_int(index, index_runtime_value, pc)
-        };
-        let _ = promoted_index;
+        self.promote_int(index, index_runtime_value, pc);
         let item_index = usize::try_from(index_runtime_value).ok()?;
         // arrayindex = vinfo.array_field_by_descrs[arrayfielddescr]
         // assert 0 <= index < vinfo.get_array_length(virtualizable, arrayindex)

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -3986,18 +3986,29 @@ impl TraceCtx {
             // guard descr via `num_live` (live-var count), not pc, so the
             // parameter is documented here but not consumed at this layer.
             let _ = pc;
-            // pyjitpl.py `_nonstandard_virtualizable` execute leg.
-            self.profiler()
-                .count_ops(OpCode::PtrEq, crate::counters::OPS);
-            self.profiler()
-                .count_ops(OpCode::PtrEq, crate::counters::RECORDED_OPS);
-            let eqbox = self.record_op(OpCode::PtrEq, &[vable_opref, standard_box]);
             let isstandard: i64 = if concrete_ptrs_eq(concrete.as_ref(), standard_concrete.as_ref())
             {
                 1
             } else {
                 0
             };
+            // pyjitpl.py `_nonstandard_virtualizable` execute leg. Step 3
+            // already returned for `standard_box is box`, so two constants
+            // arriving here are *different* constants and cannot be equal at
+            // runtime either — the fold to `ConstInt(0)` is sound, and
+            // `promote_int` then short-circuits it into no GUARD_VALUE.
+            // `PTR_EQ` reads no memory, so the fold does not depend on which
+            // backend answers; `TraceCtx` holds no `Cpu`, so the default one
+            // stands in.
+            let cpu = crate::cpu::default_cpu();
+            let eqbox = self.execute_and_record(
+                cpu.as_ref(),
+                OpCode::PtrEq,
+                None,
+                &[vable_opref, standard_box],
+                Some(Value::Int(isstandard)),
+                0,
+            );
             self.promote_int(eqbox, isstandard, 0);
             if isstandard != 0 {
                 // pyjitpl.py:1140-1142 `if box.type == 'r':

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -5837,6 +5837,33 @@ mod tests {
         assert_eq!(ctx.opref_to_box(add), OcBox::ResOp(add.raw()));
     }
 
+    /// `heapcache.py is_nullity_known` answers truthy for a non-`Const` box
+    /// whatever its nullity — `nullity_now_known` sets one flag for both — and
+    /// falsy for a null `Const`, whose answer is `bool(box.getref_base())`.
+    ///
+    /// Pinned here rather than through a second nullity branch: the walker's
+    /// `replace_box` puts `CONST_NULL` in every register naming the box, so
+    /// after the null arm no branch can reach it as a non-constant again.
+    #[test]
+    fn a_known_null_box_answers_the_nullity_question_unless_it_is_constant() {
+        let mut ctx = TraceCtx::for_test(1);
+        let box_ = OpRef::input_arg_ref(0);
+        assert!(
+            !ctx.heapcache_nullity_answered(box_),
+            "an unknown box answers nothing",
+        );
+        ctx.heap_cache_mut().nullity_now_known(box_, false);
+        assert!(
+            ctx.heapcache_nullity_answered(box_),
+            "a non-constant box known to be null short-circuits",
+        );
+        let null = ctx.const_null();
+        assert!(
+            !ctx.heapcache_nullity_answered(null),
+            "a null constant falls through to the guard arm",
+        );
+    }
+
     /// M1: constant OpRefs resolve via `OpRef::inline_const_to_value` for
     /// type-preserving Box::Const* construction.
     #[test]

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -4294,6 +4294,21 @@ impl TraceCtx {
         self.record_op_with_descr(OpCode::GetfieldGcI, &[vable_opref], descr)
     }
 
+    /// `heapcache.py is_nullity_known(box)`, supplying the `getref_base()`
+    /// reader its `Const` arm needs. `Some(true)` / `Some(false)` / `None` are
+    /// known-nonnull / known-null / unknown; only `Some(true)` is upstream's
+    /// truthy answer, for the reason spelled out at
+    /// [`Self::trace_assert_not_none`].
+    pub fn heapcache_nullity_known(&self, opref: OpRef) -> Option<bool> {
+        self.heap_cache.is_nullity_known(opref, |op| {
+            op.inline_const_to_value().and_then(|v| match v {
+                Value::Int(n) => Some(n),
+                Value::Ref(gc) => Some(gc.0 as i64),
+                _ => None,
+            })
+        })
+    }
+
     /// pyjitpl.py `opimpl_assert_not_none`:
     ///
     /// ```text
@@ -4326,14 +4341,7 @@ impl TraceCtx {
         // `Some(true)` for known non-null, `Some(false)` for known
         // null, `None` for unknown — match PyPy's semantics by
         // short-circuiting only on `Some(true)`.
-        let known = self.heap_cache.is_nullity_known(opref, |op| {
-            op.inline_const_to_value().and_then(|v| match v {
-                Value::Int(n) => Some(n),
-                Value::Ref(gc) => Some(gc.0 as i64),
-                _ => None,
-            })
-        });
-        if known == Some(true) {
+        if self.heapcache_nullity_known(opref) == Some(true) {
             self.profiler().count_ops(
                 OpCode::AssertNotNone,
                 crate::pyjitpl::counters::HEAPCACHED_OPS,

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -5326,12 +5326,19 @@ impl TraceCtx {
     ///
     /// `concrete` is the runtime length the `execute_with_descr` box carries
     /// (`arraylen_sanity_load`); `None` leaves the recorded OpRef unstamped
-    /// (the cpu is unwired or the descr lacks a lendescr).
+    /// (the cpu is unwired or the descr lacks a lendescr) and, by
+    /// `execute_and_record`'s rule for a missing concrete, blocks the fold.
+    ///
+    /// `ARRAYLEN_GC` is always-pure, so a constant array base with a concrete
+    /// length folds and records nothing. `last_exc_value` is not consulted for
+    /// an always-pure opcode; only the overflow arm reads it.
     pub fn opimpl_arraylen_gc(
         &mut self,
+        cpu: &dyn crate::cpu::Cpu,
         array_opref: OpRef,
         arraydescr: DescrRef,
         concrete: Option<Value>,
+        last_exc_value: i64,
     ) -> OpRef {
         if let Some(cached_len) = self.heap_cache().arraylen(array_opref) {
             // pyjitpl.py:763 profiler.count_ops(rop.ARRAYLEN_GC, HEAPCACHED_OPS).
@@ -5339,16 +5346,30 @@ impl TraceCtx {
                 .count_ops(OpCode::ArraylenGc, crate::pyjitpl::counters::HEAPCACHED_OPS);
             return cached_len;
         }
-        // pyjitpl.py `opimpl_arraylen_gc` miss.
-        self.profiler()
-            .count_ops(OpCode::ArraylenGc, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::ArraylenGc, crate::counters::RECORDED_OPS);
-        let len = self.record_op_with_descr(OpCode::ArraylenGc, &[array_opref], arraydescr);
-        if let Some(v) = concrete {
-            self.set_opref_concrete(len, v);
-        }
+        // `execute_nonspec_const`'s ARRAYLEN_GC row reads the length through
+        // `ArrayDescr::len_descr` and fails loud without one, while
+        // `arraylen_sanity_load` reaches the backend directly and answers even
+        // for a descr that has none. Withhold the concrete in that case so the
+        // funnel records rather than entering a fold it cannot complete.
+        let concrete = concrete.filter(|_| {
+            arraydescr
+                .as_array_descr()
+                .is_some_and(|a| a.len_descr().is_some())
+        });
+        // pyjitpl.py `opimpl_arraylen_gc` miss. The funnel owns the OPS /
+        // RECORDED_OPS pairing this leg used to count by hand.
+        let len = self.execute_and_record(
+            cpu,
+            OpCode::ArraylenGc,
+            Some(arraydescr),
+            &[array_opref],
+            concrete,
+            last_exc_value,
+        );
         // pyjitpl.py:761 heapcache.arraylen_now_known(arraybox, lengthbox).
+        // `HeapCache::arraylen_now_known` returns early for a constant array,
+        // so the fold path self-cancels rather than depositing under a key the
+        // cache does not track.
         self.heap_cache_mut().arraylen_now_known(array_opref, len);
         len
     }
@@ -5436,7 +5457,11 @@ impl TraceCtx {
             // nonstandard-virtualizable fallback reads the length through the GC
             // array; no runtime concrete to stamp here (the vable read supplies
             // the length on the standard path below).
-            return self.opimpl_arraylen_gc(array_opref, adescr, None);
+            // No runtime concrete on this leg, so `execute_and_record` records
+            // without consulting an evaluator; the default cpu stands in for
+            // an argument it cannot reach.
+            let cpu = crate::cpu::default_cpu();
+            return self.opimpl_arraylen_gc(cpu.as_ref(), array_opref, adescr, None, 0);
         }
         // arrayindex = vinfo.array_field_by_descrs[fdescr]
         // result = vinfo.get_array_length(virtualizable, arrayindex)
@@ -6705,5 +6730,95 @@ mod tests {
         // The identity slot itself left unseeded.
         ctx.virtualizable_boxes = Some(vec![OpRef::int_op(3), OpRef::NONE]);
         assert!(!ctx.vable_snapshot_buildable());
+    }
+
+    /// `[len][item0][item1][item2]`: the length word at offset 0, items from
+    /// offset 8 — the shape `get_field_arraylen_descr` describes.
+    fn boxed_int_array(items: &[i64]) -> (Box<Vec<i64>>, i64) {
+        let mut words = vec![items.len() as i64];
+        words.extend_from_slice(items);
+        let storage = Box::new(words);
+        let base = storage.as_ptr() as i64;
+        (storage, base)
+    }
+
+    fn int_array_descr(with_lendescr: bool) -> DescrRef {
+        let lendescr: Option<DescrRef> = with_lendescr.then(|| {
+            std::sync::Arc::new(majit_ir::descr::SimpleFieldDescr::new(
+                0,
+                0,
+                std::mem::size_of::<i64>(),
+                Type::Int,
+                true,
+            )) as DescrRef
+        });
+        majit_ir::descr::make_array_descr_from_lltype_shape(
+            1,
+            std::mem::size_of::<i64>(),
+            std::mem::size_of::<i64>(),
+            None,
+            Type::Int,
+            false,
+            false,
+            true,
+            true,
+            lendescr,
+            false,
+            u32::MAX,
+            Vec::new(),
+        ) as DescrRef
+    }
+
+    /// `ARRAYLEN_GC` is always-pure, so a constant array with a trace-time
+    /// length folds; every other combination records.
+    #[test]
+    fn arraylen_gc_folds_only_a_constant_array_with_a_concrete_length() {
+        let cpu = crate::cpu::default_cpu();
+        let (_storage, base) = boxed_int_array(&[10, 20, 30]);
+
+        let mut ctx = TraceCtx::for_test(0);
+        let len = ctx.opimpl_arraylen_gc(
+            cpu.as_ref(),
+            OpRef::const_ptr(majit_ir::GcRef(base as usize)),
+            int_array_descr(true),
+            Some(Value::Int(3)),
+            0,
+        );
+        assert_eq!(len, OpRef::const_int(3));
+        assert!(ctx.into_recorder().ops().is_empty());
+
+        // No trace-time concrete: record, and leave the op unstamped.
+        let mut ctx = TraceCtx::for_test(0);
+        let len = ctx.opimpl_arraylen_gc(
+            cpu.as_ref(),
+            OpRef::const_ptr(majit_ir::GcRef(base as usize)),
+            int_array_descr(true),
+            None,
+            0,
+        );
+        assert!(!len.is_constant());
+
+        // A descr with no `lendescr` is one the executor row cannot read; the
+        // concrete is withheld so the funnel records instead of failing loud.
+        let mut ctx = TraceCtx::for_test(0);
+        let len = ctx.opimpl_arraylen_gc(
+            cpu.as_ref(),
+            OpRef::const_ptr(majit_ir::GcRef(base as usize)),
+            int_array_descr(false),
+            Some(Value::Int(3)),
+            0,
+        );
+        assert!(!len.is_constant());
+
+        // Non-constant array base.
+        let mut ctx = TraceCtx::for_test_types(&[Type::Ref]);
+        let len = ctx.opimpl_arraylen_gc(
+            cpu.as_ref(),
+            OpRef::input_arg_ref(0),
+            int_array_descr(true),
+            Some(Value::Int(3)),
+            0,
+        );
+        assert!(!len.is_constant());
     }
 }

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -3662,12 +3662,16 @@ impl TraceCtx {
         for field_index in 0..info.static_fields.len() {
             if let Some(&value) = boxes.get(field_index) {
                 let descr = info.static_field_descr(field_index);
-                // pyjitpl.py `gen_store_back_in_vable`.
-                self.profiler()
-                    .count_ops(OpCode::SetfieldGc, crate::counters::OPS);
-                self.profiler()
-                    .count_ops(OpCode::SetfieldGc, crate::counters::RECORDED_OPS);
-                self.vable_setfield_descr(vable_opref, value, descr);
+                // pyjitpl.py `gen_store_back_in_vable`. A store has no
+                // `resvalue` and `SETFIELD_GC` is never pure, so no cpu.
+                self.execute_and_record(
+                    None,
+                    OpCode::SetfieldGc,
+                    Some(descr),
+                    &[vable_opref, value],
+                    None,
+                    0,
+                );
             }
         }
 
@@ -3680,11 +3684,14 @@ impl TraceCtx {
             for item_index in 0..len {
                 if let Some(&value) = boxes.get(flat_box_index) {
                     let index = self.const_int(item_index as i64);
-                    self.profiler()
-                        .count_ops(OpCode::SetarrayitemGc, crate::counters::OPS);
-                    self.profiler()
-                        .count_ops(OpCode::SetarrayitemGc, crate::counters::RECORDED_OPS);
-                    self.vable_setarrayitem_descr(array_ref, index, value, array_descr.clone());
+                    self.execute_and_record(
+                        None,
+                        OpCode::SetarrayitemGc,
+                        Some(array_descr.clone()),
+                        &[array_ref, index, value],
+                        None,
+                        0,
+                    );
                 }
                 flat_box_index += 1;
             }
@@ -3828,22 +3835,26 @@ impl TraceCtx {
             (token_descr, clear_ptr, clear_descr)
         };
         //     tokenbox = mi.execute_and_record(rop.GETFIELD_GC_R, token_descr, box)
-        // pyjitpl.py `emit_force_virtualizable`.
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-        let tokenbox = self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], token_descr);
+        // pyjitpl.py `emit_force_virtualizable`. Neither read carries a
+        // trace-time concrete, so both pass `resvalue: None` — which closes
+        // the fold and leaves no reader for a cpu to be.
+        let tokenbox = self.execute_and_record(
+            None,
+            OpCode::GetfieldGcR,
+            Some(token_descr),
+            &[vable_opref],
+            None,
+            0,
+        );
         //     condbox = mi.execute_and_record(rop.PTR_NE, None, tokenbox, CONST_NULL)
         let null_ref = self.const_null();
-        self.profiler()
-            .count_ops(OpCode::PtrNe, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::PtrNe, crate::counters::RECORDED_OPS);
-        let condbox = self.record_op(OpCode::PtrNe, &[tokenbox, null_ref]);
+        let condbox =
+            self.execute_and_record(None, OpCode::PtrNe, None, &[tokenbox, null_ref], None, 0);
         let funcbox = self.const_int(clear_ptr as i64);
         //     self.execute_varargs(rop.COND_CALL, [condbox, funcbox, box],
         //                          calldescr, False, False)
+        // `execute_varargs`, not `execute_and_record`: `COND_CALL_N` is inside
+        // the can-raise range, which the funnel refuses.
         self.profiler()
             .count_ops(OpCode::CondCallN, crate::counters::OPS);
         self.profiler()
@@ -4002,7 +4013,7 @@ impl TraceCtx {
             // stands in.
             let cpu = crate::cpu::default_cpu();
             let eqbox = self.execute_and_record(
-                cpu.as_ref(),
+                Some(cpu.as_ref()),
                 OpCode::PtrEq,
                 None,
                 &[vable_opref, standard_box],
@@ -4172,12 +4183,17 @@ impl TraceCtx {
             );
             return cached;
         }
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-        let op =
-            self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr.clone());
+        // The array base is stamped after the fact by
+        // `stamp_vable_array_base`, not handed in, so there is no `resvalue`
+        // for the funnel to fold against and no reader for a cpu to be.
+        let op = self.execute_and_record(
+            None,
+            OpCode::GetfieldGcR,
+            Some(record_descr.clone()),
+            &[vable_opref],
+            None,
+            0,
+        );
         let vable_concrete = self.concrete_of_opref(vable_opref);
         self.stamp_vable_array_base(op, vable_concrete, &record_descr);
         self.heapcache_getfield_now_known(vable_opref, field_index, op);
@@ -4262,7 +4278,7 @@ impl TraceCtx {
             // opcode, so the funnel never reads `last_exc_value` and 0 names
             // no copy of it.
             let op = self.execute_and_record(
-                cpu,
+                Some(cpu),
                 OpCode::GetfieldGcI,
                 Some(record_descr),
                 &[vable_opref],
@@ -4289,7 +4305,7 @@ impl TraceCtx {
         // Fallback for tests/missing layout.  No live load reached this leg,
         // so the funnel's `resvalue` is `None` and it records unconditionally.
         let op = self.execute_and_record(
-            cpu,
+            Some(cpu),
             OpCode::GetfieldGcI,
             Some(fielddescr),
             &[vable_opref],
@@ -4366,12 +4382,9 @@ impl TraceCtx {
             concrete != 0,
             "do_assert_not_none: ref operand {opref:?} is null at trace time"
         );
-        // pyjitpl.py `execute(ASSERT_NOT_NONE, ...)`.
-        self.profiler()
-            .count_ops(OpCode::AssertNotNone, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::AssertNotNone, crate::counters::RECORDED_OPS);
-        self.record_op(OpCode::AssertNotNone, &[opref]);
+        // pyjitpl.py `execute(ASSERT_NOT_NONE, ...)`. Void result, never
+        // pure — the funnel records it and no cpu is consulted.
+        self.execute_and_record(None, OpCode::AssertNotNone, None, &[opref], None, 0);
         // pyjitpl.py:391 `self.metainterp.heapcache.nullity_now_known(box)`.
         self.heap_cache.nullity_now_known(opref, true);
     }
@@ -4412,12 +4425,16 @@ impl TraceCtx {
             // class argument silently skips the record in RPython.
             return;
         }
-        // pyjitpl.py `execute(RECORD_EXACT_CLASS, ...)`.
-        self.profiler()
-            .count_ops(OpCode::RecordExactClass, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::RecordExactClass, crate::counters::RECORDED_OPS);
-        self.record_op(OpCode::RecordExactClass, &[opref, cls_const]);
+        // pyjitpl.py `execute(RECORD_EXACT_CLASS, ...)`. Void result, never
+        // pure, so the funnel records it without consulting a cpu.
+        self.execute_and_record(
+            None,
+            OpCode::RecordExactClass,
+            None,
+            &[opref, cls_const],
+            None,
+            0,
+        );
         let cls_value = match self.constants_get_value(cls_const) {
             Some(Value::Int(vtable)) => vtable,
             other => panic!(
@@ -4487,11 +4504,14 @@ impl TraceCtx {
             }
             // pyjitpl.py:1173-1199 nonstandard vable miss delegates to
             // the standard heap operation.
-            self.profiler()
-                .count_ops(OpCode::SetfieldGc, crate::counters::OPS);
-            self.profiler()
-                .count_ops(OpCode::SetfieldGc, crate::counters::RECORDED_OPS);
-            self.record_op_with_descr(OpCode::SetfieldGc, &[vable_opref, value], record_descr);
+            self.execute_and_record(
+                None,
+                OpCode::SetfieldGc,
+                Some(record_descr),
+                &[vable_opref, value],
+                None,
+                0,
+            );
             // pyjitpl.py:980 upd.setfield(valuebox).  Cache stores the
             // Box identity (`value` OpRef); the intrinsic concrete
             // travels with the frontend value slot — `value`'s slot was
@@ -4604,7 +4624,7 @@ impl TraceCtx {
                 None
             };
             let op = self.execute_and_record(
-                cpu,
+                Some(cpu),
                 OpCode::GetfieldGcR,
                 Some(record_descr),
                 &[vable_opref],
@@ -4627,7 +4647,7 @@ impl TraceCtx {
             return (op, concrete_shadow_value(value));
         }
         let op = self.execute_and_record(
-            cpu,
+            Some(cpu),
             OpCode::GetfieldGcR,
             Some(fielddescr),
             &[vable_opref],
@@ -4639,12 +4659,17 @@ impl TraceCtx {
 
     /// Record a virtualizable ref field read with an explicit field descriptor.
     pub fn vable_getfield_ref_descr(&mut self, vable_opref: OpRef, descr: DescrRef) -> OpRef {
-        // pyjitpl.py `gen_store_back_in_vable`.
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-        self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], descr)
+        // pyjitpl.py `gen_store_back_in_vable`. No live load reaches this
+        // helper, so the funnel's `resvalue` is `None`; that closes the fold
+        // on its own and no cpu is needed to read a field nobody folds.
+        self.execute_and_record(
+            None,
+            OpCode::GetfieldGcR,
+            Some(descr),
+            &[vable_opref],
+            None,
+            0,
+        )
     }
 
     /// pyjitpl.py `opimpl_getfield_vable_f(box, fielddescr, pc)`.
@@ -4716,7 +4741,7 @@ impl TraceCtx {
                 None
             };
             let op = self.execute_and_record(
-                cpu,
+                Some(cpu),
                 OpCode::GetfieldGcF,
                 Some(record_descr),
                 &[vable_opref],
@@ -4739,7 +4764,7 @@ impl TraceCtx {
             return (op, concrete_shadow_value(value));
         }
         let op = self.execute_and_record(
-            cpu,
+            Some(cpu),
             OpCode::GetfieldGcF,
             Some(fielddescr),
             &[vable_opref],
@@ -4766,14 +4791,16 @@ impl TraceCtx {
         }
         let index = self.const_int(item_index as i64);
         // pyjitpl.py:1218-1230 vable fallback uses standard array access.
-        self.profiler()
-            .count_ops(OpCode::GetarrayitemGcI, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetarrayitemGcI, crate::counters::RECORDED_OPS);
-        let op = self.record_op_with_descr(
+        // The element is stamped afterwards by `stamp_vable_array_item`, so
+        // there is no `resvalue` here; `GETARRAYITEM_GC_*` is not descr-pure
+        // either, so nothing would consult a cpu.
+        let op = self.execute_and_record(
+            None,
             OpCode::GetarrayitemGcI,
+            Some(adescr.clone()),
             &[array_opref, index],
-            adescr.clone(),
+            None,
+            0,
         );
         let value =
             self.stamp_vable_array_item(op, array_opref, item_index as i64, &adescr, Type::Int);
@@ -4915,12 +4942,16 @@ impl TraceCtx {
             return (op, concrete_shadow_value(value));
         }
         // Fallback: vable layout missing — go through getfield + arrayitem.
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-        let array_opref =
-            self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], fdescr.clone());
+        // `stamp_vable_array_base` supplies the concrete after the record, so
+        // the funnel sees no `resvalue` and cannot fold.
+        let array_opref = self.execute_and_record(
+            None,
+            OpCode::GetfieldGcR,
+            Some(fdescr.clone()),
+            &[vable_opref],
+            None,
+            0,
+        );
         self.stamp_vable_array_base(array_opref, concrete, &fdescr);
         if let Ok(item_index) = usize::try_from(index_runtime_value) {
             self.vable_getarrayitem_int_vable(array_opref, &fdescr, item_index, adescr)
@@ -4987,14 +5018,16 @@ impl TraceCtx {
             return (op, concrete_shadow_value(value));
         }
         let index = self.const_int(item_index as i64);
-        self.profiler()
-            .count_ops(OpCode::GetarrayitemGcR, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetarrayitemGcR, crate::counters::RECORDED_OPS);
-        let op = self.record_op_with_descr(
+        // The element is stamped afterwards by `stamp_vable_array_item`, so
+        // there is no `resvalue` here; `GETARRAYITEM_GC_*` is not descr-pure
+        // either, so nothing would consult a cpu.
+        let op = self.execute_and_record(
+            None,
             OpCode::GetarrayitemGcR,
+            Some(adescr.clone()),
             &[array_opref, index],
-            adescr.clone(),
+            None,
+            0,
         );
         let value =
             self.stamp_vable_array_item(op, array_opref, item_index as i64, &adescr, Type::Ref);
@@ -5062,12 +5095,16 @@ impl TraceCtx {
         {
             return (op, concrete_shadow_value(value));
         }
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-        let array_opref =
-            self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], fdescr.clone());
+        // `stamp_vable_array_base` supplies the concrete after the record, so
+        // the funnel sees no `resvalue` and cannot fold.
+        let array_opref = self.execute_and_record(
+            None,
+            OpCode::GetfieldGcR,
+            Some(fdescr.clone()),
+            &[vable_opref],
+            None,
+            0,
+        );
         self.stamp_vable_array_base(array_opref, concrete, &fdescr);
         if let Ok(item_index) = usize::try_from(index_runtime_value) {
             self.vable_getarrayitem_ref_vable(array_opref, &fdescr, item_index, adescr)
@@ -5093,14 +5130,16 @@ impl TraceCtx {
             return (op, concrete_shadow_value(value));
         }
         let index = self.const_int(item_index as i64);
-        self.profiler()
-            .count_ops(OpCode::GetarrayitemGcF, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetarrayitemGcF, crate::counters::RECORDED_OPS);
-        let op = self.record_op_with_descr(
+        // The element is stamped afterwards by `stamp_vable_array_item`, so
+        // there is no `resvalue` here; `GETARRAYITEM_GC_*` is not descr-pure
+        // either, so nothing would consult a cpu.
+        let op = self.execute_and_record(
+            None,
             OpCode::GetarrayitemGcF,
+            Some(adescr.clone()),
             &[array_opref, index],
-            adescr.clone(),
+            None,
+            0,
         );
         let value =
             self.stamp_vable_array_item(op, array_opref, item_index as i64, &adescr, Type::Float);
@@ -5160,12 +5199,16 @@ impl TraceCtx {
         {
             return (op, concrete_shadow_value(value));
         }
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-        let array_opref =
-            self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], fdescr.clone());
+        // `stamp_vable_array_base` supplies the concrete after the record, so
+        // the funnel sees no `resvalue` and cannot fold.
+        let array_opref = self.execute_and_record(
+            None,
+            OpCode::GetfieldGcR,
+            Some(fdescr.clone()),
+            &[vable_opref],
+            None,
+            0,
+        );
         self.stamp_vable_array_base(array_opref, concrete, &fdescr);
         if let Ok(item_index) = usize::try_from(index_runtime_value) {
             self.vable_getarrayitem_float_vable(array_opref, &fdescr, item_index, adescr)
@@ -5285,11 +5328,14 @@ impl TraceCtx {
         self.heapcache_getfield_now_known(vable_opref, field_descr.index(), array_opref);
         for &(item_index, value) in items {
             let index = self.const_int(item_index);
-            self.profiler()
-                .count_ops(OpCode::SetarrayitemGc, crate::counters::OPS);
-            self.profiler()
-                .count_ops(OpCode::SetarrayitemGc, crate::counters::RECORDED_OPS);
-            self.vable_setarrayitem_descr(array_opref, index, value, array_descr.clone());
+            self.execute_and_record(
+                None,
+                OpCode::SetarrayitemGc,
+                Some(array_descr.clone()),
+                &[array_opref, index, value],
+                None,
+                0,
+            );
         }
         true
     }
@@ -5316,10 +5362,6 @@ impl TraceCtx {
     ) -> VableArrayStore {
         if nonstandard {
             let array_opref = self.nonstandard_vable_array_base(vable_opref, &fdescr);
-            self.profiler()
-                .count_ops(OpCode::SetarrayitemGc, crate::counters::OPS);
-            self.profiler()
-                .count_ops(OpCode::SetarrayitemGc, crate::counters::RECORDED_OPS);
             self.execute_setarrayitem_gc(array_opref, index, value, adescr);
             return VableArrayStore::Stored(None);
         }
@@ -5393,7 +5435,7 @@ impl TraceCtx {
         // pyjitpl.py `opimpl_arraylen_gc` miss. The funnel owns the OPS /
         // RECORDED_OPS pairing this leg used to count by hand.
         let len = self.execute_and_record(
-            cpu,
+            Some(cpu),
             OpCode::ArraylenGc,
             Some(arraydescr),
             &[array_opref],
@@ -5424,6 +5466,7 @@ impl TraceCtx {
     /// ```
     pub fn vable_arraylen_vable(
         &mut self,
+        cpu: &dyn crate::cpu::Cpu,
         pc: usize,
         vable_opref: OpRef,
         vable_struct_ptr: i64,
@@ -5434,59 +5477,60 @@ impl TraceCtx {
         if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, concrete) {
             // arraybox = self.opimpl_getfield_gc_r(box, fdescr)
             let f_index = fdescr.index();
-            let array_opref = if let Some(cached) =
-                self.heapcache_getfield_cached(vable_opref, f_index)
-            {
-                // pyjitpl.py:934-945 + :938-939 sanity check (ref arm):
-                //     resvalue = executor.execute(cpu, mi, opnum, fielddescr, box)
-                //     assert resvalue == upd.currfieldbox.getref_base()
-                // `box_value(cached)` resolves the upstream
-                // `currfieldbox.getref_base()` payload through the
-                // full chain (const pool, standard-virtualizable
-                // shadow, the frontend object's `value` field).
-                let expected_ref = match self.box_value(cached) {
-                    Some(Value::Ref(r)) => Some(r),
-                    _ => None,
-                };
-                if let Some(cached_ref) = expected_ref
-                    && vable_struct_ptr != 0
-                    && let Some(Value::Ref(loaded)) =
-                        self.field_sanity_load(vable_struct_ptr, &fdescr, Type::Ref)
-                {
-                    assert_eq!(
-                        loaded, cached_ref,
-                        "_opimpl_getfield_gc_any_pureornot sanity \
+            let array_opref =
+                if let Some(cached) = self.heapcache_getfield_cached(vable_opref, f_index) {
+                    // pyjitpl.py:934-945 + :938-939 sanity check (ref arm):
+                    //     resvalue = executor.execute(cpu, mi, opnum, fielddescr, box)
+                    //     assert resvalue == upd.currfieldbox.getref_base()
+                    // `box_value(cached)` resolves the upstream
+                    // `currfieldbox.getref_base()` payload through the
+                    // full chain (const pool, standard-virtualizable
+                    // shadow, the frontend object's `value` field).
+                    let expected_ref = match self.box_value(cached) {
+                        Some(Value::Ref(r)) => Some(r),
+                        _ => None,
+                    };
+                    if let Some(cached_ref) = expected_ref
+                        && vable_struct_ptr != 0
+                        && let Some(Value::Ref(loaded)) =
+                            self.field_sanity_load(vable_struct_ptr, &fdescr, Type::Ref)
+                    {
+                        assert_eq!(
+                            loaded, cached_ref,
+                            "_opimpl_getfield_gc_any_pureornot sanity \
                                      check (ref): loaded {:#x} != cached {:#x} \
                                      (field_index={f_index}, vable_struct_ptr=\
                                      {vable_struct_ptr:#x})",
-                        loaded.0, cached_ref.0,
+                            loaded.0, cached_ref.0,
+                        );
+                    }
+                    self.profiler().count_ops(
+                        OpCode::GetfieldGcR,
+                        crate::pyjitpl::counters::HEAPCACHED_OPS,
                     );
-                }
-                self.profiler().count_ops(
-                    OpCode::GetfieldGcR,
-                    crate::pyjitpl::counters::HEAPCACHED_OPS,
-                );
-                cached
-            } else {
-                let record_descr = self.vable_array_record_descr(&fdescr);
-                // pyjitpl.py:1253-1263 nonstandard vable getfield miss.
-                self.profiler()
-                    .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-                self.profiler()
-                    .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-                let op =
-                    self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
-                let live = if vable_struct_ptr != 0 {
-                    self.field_sanity_load(vable_struct_ptr, &fdescr, Type::Ref)
+                    cached
                 } else {
-                    None
+                    let record_descr = self.vable_array_record_descr(&fdescr);
+                    // pyjitpl.py:1253-1263 nonstandard vable getfield miss. The
+                    // live load is the funnel's `resvalue`, so it runs first; this
+                    // is the one leg of the family that can reach a fold, which is
+                    // why the cpu is threaded in.
+                    let live = if vable_struct_ptr != 0 {
+                        self.field_sanity_load(vable_struct_ptr, &fdescr, Type::Ref)
+                    } else {
+                        None
+                    };
+                    let op = self.execute_and_record(
+                        Some(cpu),
+                        OpCode::GetfieldGcR,
+                        Some(record_descr),
+                        &[vable_opref],
+                        live,
+                        0,
+                    );
+                    self.heapcache_getfield_now_known(vable_opref, f_index, op);
+                    op
                 };
-                if let Some(live_value) = live {
-                    self.set_opref_concrete(op, live_value);
-                }
-                self.heapcache_getfield_now_known(vable_opref, f_index, op);
-                op
-            };
             // return self.opimpl_arraylen_gc(arraybox, adescr) — the
             // nonstandard-virtualizable fallback reads the length through the GC
             // array; no runtime concrete to stamp here (the vable read supplies
@@ -5507,17 +5551,24 @@ impl TraceCtx {
         {
             return self.const_int(length as i64);
         }
-        // Fallback when the layout is unavailable.
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-        let array_opref = self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], fdescr);
-        self.profiler()
-            .count_ops(OpCode::ArraylenGc, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::ArraylenGc, crate::counters::RECORDED_OPS);
-        self.record_op_with_descr(OpCode::ArraylenGc, &[array_opref], adescr)
+        // Fallback when the layout is unavailable. Neither leg has a
+        // trace-time concrete, so both close the fold on `resvalue`.
+        let array_opref = self.execute_and_record(
+            None,
+            OpCode::GetfieldGcR,
+            Some(fdescr),
+            &[vable_opref],
+            None,
+            0,
+        );
+        self.execute_and_record(
+            None,
+            OpCode::ArraylenGc,
+            Some(adescr),
+            &[array_opref],
+            None,
+            0,
+        )
     }
 
     /// Compute the flat index into virtualizable_boxes for an array element.
@@ -5536,14 +5587,17 @@ impl TraceCtx {
         index: OpRef,
         descr: DescrRef,
     ) -> OpRef {
-        self.profiler()
-            .count_ops(OpCode::GetarrayitemGcI, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetarrayitemGcI, crate::counters::RECORDED_OPS);
-        let op = self.record_op_with_descr(
+        // `GETARRAYITEM_GC_*` answers `is_pure_with_descr` false whatever its
+        // descr says — an immutable GC array read is spelled with the
+        // dedicated `_PURE` opcode — so the fold gate is shut and no cpu is
+        // consulted.
+        let op = self.execute_and_record(
+            None,
             OpCode::GetarrayitemGcI,
+            Some(descr.clone()),
             &[array_opref, index],
-            descr.clone(),
+            None,
+            0,
         );
         if let Some(Value::Int(item_index)) = self.concrete_of_opref(index) {
             self.stamp_vable_array_item(op, array_opref, item_index, &descr, Type::Int);
@@ -5558,14 +5612,17 @@ impl TraceCtx {
         index: OpRef,
         descr: DescrRef,
     ) -> OpRef {
-        self.profiler()
-            .count_ops(OpCode::GetarrayitemGcR, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetarrayitemGcR, crate::counters::RECORDED_OPS);
-        let op = self.record_op_with_descr(
+        // `GETARRAYITEM_GC_*` answers `is_pure_with_descr` false whatever its
+        // descr says — an immutable GC array read is spelled with the
+        // dedicated `_PURE` opcode — so the fold gate is shut and no cpu is
+        // consulted.
+        let op = self.execute_and_record(
+            None,
             OpCode::GetarrayitemGcR,
+            Some(descr.clone()),
             &[array_opref, index],
-            descr.clone(),
+            None,
+            0,
         );
         if let Some(Value::Int(item_index)) = self.concrete_of_opref(index) {
             self.stamp_vable_array_item(op, array_opref, item_index, &descr, Type::Ref);
@@ -5580,14 +5637,17 @@ impl TraceCtx {
         index: OpRef,
         descr: DescrRef,
     ) -> OpRef {
-        self.profiler()
-            .count_ops(OpCode::GetarrayitemGcF, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetarrayitemGcF, crate::counters::RECORDED_OPS);
-        let op = self.record_op_with_descr(
+        // `GETARRAYITEM_GC_*` answers `is_pure_with_descr` false whatever its
+        // descr says — an immutable GC array read is spelled with the
+        // dedicated `_PURE` opcode — so the fold gate is shut and no cpu is
+        // consulted.
+        let op = self.execute_and_record(
+            None,
             OpCode::GetarrayitemGcF,
+            Some(descr.clone()),
             &[array_opref, index],
-            descr.clone(),
+            None,
+            0,
         );
         if let Some(Value::Int(item_index)) = self.concrete_of_opref(index) {
             self.stamp_vable_array_item(op, array_opref, item_index, &descr, Type::Float);
@@ -5625,7 +5685,16 @@ impl TraceCtx {
         descr: DescrRef,
     ) {
         let descr_index = descr.index();
-        self.vable_setarrayitem_descr(array_opref, index, value, descr);
+        // A store has no `resvalue` and `SETARRAYITEM_GC` is never pure, so
+        // the funnel records it without consulting a cpu.
+        self.execute_and_record(
+            None,
+            OpCode::SetarrayitemGc,
+            Some(descr),
+            &[array_opref, index, value],
+            None,
+            0,
+        );
         self.heapcache_setarrayitem(array_opref, index, descr_index, value);
     }
 }

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -4196,6 +4196,7 @@ impl TraceCtx {
     /// ```
     pub fn vable_getfield_int(
         &mut self,
+        cpu: &dyn crate::cpu::Cpu,
         pc: usize,
         vable_opref: OpRef,
         vable_struct_ptr: i64,
@@ -4242,27 +4243,32 @@ impl TraceCtx {
                 return (cached, cached_value);
             }
             let record_descr = self.vable_static_record_descr(&fielddescr);
-            // pyjitpl.py:1173-1199 nonstandard vable miss delegates to
-            // the standard heap operation.
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcI, crate::counters::OPS);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcI, crate::counters::RECORDED_OPS);
-            let op = self.record_op_with_descr(OpCode::GetfieldGcI, &[vable_opref], record_descr);
             // pyjitpl.py:949 upd.getfield_now_known(resbox).  `resbox`
             // in RPython carries the loaded value via `BoxInt.value`;
             // pyre stamps the frontend value slot for `op` with the live
             // load so subsequent `box_value(op)` sees the
             // executor-returned payload (RPython `IntFrontendOp(pos,
-            // intval)` construction-time field assignment).
+            // intval)` construction-time field assignment).  It is the
+            // funnel's `resvalue`, so the load runs before the record;
+            // `None` — no struct pointer, or an unwired backend — records
+            // without folding.
             let live = if vable_struct_ptr != 0 {
                 self.field_sanity_load(vable_struct_ptr, &fielddescr, Type::Int)
             } else {
                 None
             };
-            if let Some(live_value) = live {
-                self.set_opref_concrete(op, live_value);
-            }
+            // pyjitpl.py:1173-1199 nonstandard vable miss delegates to
+            // the standard heap operation.  GETFIELD_GC_I is not an OVF
+            // opcode, so the funnel never reads `last_exc_value` and 0 names
+            // no copy of it.
+            let op = self.execute_and_record(
+                cpu,
+                OpCode::GetfieldGcI,
+                Some(record_descr),
+                &[vable_opref],
+                live,
+                0,
+            );
             self.heapcache_getfield_now_known(vable_opref, field_index, op);
             return (op, live);
         }
@@ -4280,12 +4286,16 @@ impl TraceCtx {
         {
             return (op, concrete_shadow_value(value));
         }
-        // Fallback for tests/missing layout
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcI, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcI, crate::counters::RECORDED_OPS);
-        let op = self.record_op_with_descr(OpCode::GetfieldGcI, &[vable_opref], fielddescr);
+        // Fallback for tests/missing layout.  No live load reached this leg,
+        // so the funnel's `resvalue` is `None` and it records unconditionally.
+        let op = self.execute_and_record(
+            cpu,
+            OpCode::GetfieldGcI,
+            Some(fielddescr),
+            &[vable_opref],
+            None,
+            0,
+        );
         (op, None)
     }
 
@@ -4538,6 +4548,7 @@ impl TraceCtx {
     /// ```
     pub fn vable_getfield_ref(
         &mut self,
+        cpu: &dyn crate::cpu::Cpu,
         pc: usize,
         vable_opref: OpRef,
         vable_struct_ptr: i64,
@@ -4582,23 +4593,24 @@ impl TraceCtx {
                 return (cached, cached_value);
             }
             let record_descr = self.vable_static_record_descr(&fielddescr);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-            let op = self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], record_descr);
             // pyjitpl.py:949 upd.getfield_now_known(resbox) — `resbox`
             // carries `.getref_base()` payload; pair it with the
             // recorded opref so subsequent `box_value(op)` matches
-            // RPython's executor-returned Box.
+            // RPython's executor-returned Box.  It is the funnel's
+            // `resvalue`, so the load runs before the record.
             let live = if vable_struct_ptr != 0 {
                 self.field_sanity_load(vable_struct_ptr, &fielddescr, Type::Ref)
             } else {
                 None
             };
-            if let Some(live_value) = live {
-                self.set_opref_concrete(op, live_value);
-            }
+            let op = self.execute_and_record(
+                cpu,
+                OpCode::GetfieldGcR,
+                Some(record_descr),
+                &[vable_opref],
+                live,
+                0,
+            );
             self.heapcache_getfield_now_known(vable_opref, field_index, op);
             return (op, live);
         }
@@ -4614,11 +4626,14 @@ impl TraceCtx {
         {
             return (op, concrete_shadow_value(value));
         }
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcR, crate::counters::RECORDED_OPS);
-        let op = self.record_op_with_descr(OpCode::GetfieldGcR, &[vable_opref], fielddescr);
+        let op = self.execute_and_record(
+            cpu,
+            OpCode::GetfieldGcR,
+            Some(fielddescr),
+            &[vable_opref],
+            None,
+            0,
+        );
         (op, None)
     }
 
@@ -4644,6 +4659,7 @@ impl TraceCtx {
     /// ```
     pub fn vable_getfield_float(
         &mut self,
+        cpu: &dyn crate::cpu::Cpu,
         pc: usize,
         vable_opref: OpRef,
         vable_struct_ptr: i64,
@@ -4690,22 +4706,23 @@ impl TraceCtx {
                 return (cached, cached_value);
             }
             let record_descr = self.vable_static_record_descr(&fielddescr);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcF, crate::counters::OPS);
-            self.profiler()
-                .count_ops(OpCode::GetfieldGcF, crate::counters::RECORDED_OPS);
-            let op = self.record_op_with_descr(OpCode::GetfieldGcF, &[vable_opref], record_descr);
             // pyjitpl.py:949 upd.getfield_now_known(resbox) — pair the
             // float payload with the recorded opref so subsequent
-            // `box_value(op)` matches RPython's executor-returned Box.
+            // `box_value(op)` matches RPython's executor-returned Box.  It is
+            // the funnel's `resvalue`, so the load runs before the record.
             let live = if vable_struct_ptr != 0 {
                 self.field_sanity_load(vable_struct_ptr, &fielddescr, Type::Float)
             } else {
                 None
             };
-            if let Some(live_value) = live {
-                self.set_opref_concrete(op, live_value);
-            }
+            let op = self.execute_and_record(
+                cpu,
+                OpCode::GetfieldGcF,
+                Some(record_descr),
+                &[vable_opref],
+                live,
+                0,
+            );
             self.heapcache_getfield_now_known(vable_opref, field_index, op);
             return (op, live);
         }
@@ -4721,11 +4738,14 @@ impl TraceCtx {
         {
             return (op, concrete_shadow_value(value));
         }
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcF, crate::counters::OPS);
-        self.profiler()
-            .count_ops(OpCode::GetfieldGcF, crate::counters::RECORDED_OPS);
-        let op = self.record_op_with_descr(OpCode::GetfieldGcF, &[vable_opref], fielddescr);
+        let op = self.execute_and_record(
+            cpu,
+            OpCode::GetfieldGcF,
+            Some(fielddescr),
+            &[vable_opref],
+            None,
+            0,
+        );
         (op, None)
     }
 
@@ -5840,7 +5860,13 @@ mod tests {
         let cached = ctx.const_int(42);
         let field_index = fd.index();
         ctx.heapcache_getfield_now_known(vable, field_index, cached);
-        ctx.vable_getfield_int(0, vable, 0xCAFE_BABE, fd);
+        ctx.vable_getfield_int(
+            crate::cpu::default_cpu().as_ref(),
+            0,
+            vable,
+            0xCAFE_BABE,
+            fd,
+        );
     }
 
     /// `test_pyjitpl.py test_remove_consts_and_duplicates` — the upstream
@@ -5996,7 +6022,13 @@ mod tests {
         let cached = ctx.const_ref(0xAAAA_BBBB);
         let field_index = fd.index();
         ctx.heapcache_getfield_now_known(vable, field_index, cached);
-        ctx.vable_getfield_ref(0, vable, 0xCAFE_BABE, fd);
+        ctx.vable_getfield_ref(
+            crate::cpu::default_cpu().as_ref(),
+            0,
+            vable,
+            0xCAFE_BABE,
+            fd,
+        );
     }
 
     /// vable_getfield_float cache-hit (pyjitpl.py:944
@@ -6021,7 +6053,13 @@ mod tests {
         let cached = ctx.const_float((1.5_f64).to_bits() as i64);
         let field_index = fd.index();
         ctx.heapcache_getfield_now_known(vable, field_index, cached);
-        ctx.vable_getfield_float(0, vable, 0xCAFE_BABE, fd);
+        ctx.vable_getfield_float(
+            crate::cpu::default_cpu().as_ref(),
+            0,
+            vable,
+            0xCAFE_BABE,
+            fd,
+        );
     }
 
     /// Matched (loaded == cached) ref + float cache-hits — no panic;
@@ -6051,9 +6089,21 @@ mod tests {
         let field_index_f = fd_f.index();
         ctx.heapcache_getfield_now_known(vable, field_index_f, cached_f);
 
-        let (r_result, _) = ctx.vable_getfield_ref(0, vable, 0xCAFE_BABE, fd_r);
+        let (r_result, _) = ctx.vable_getfield_ref(
+            crate::cpu::default_cpu().as_ref(),
+            0,
+            vable,
+            0xCAFE_BABE,
+            fd_r,
+        );
         assert_eq!(r_result, cached_r);
-        let (f_result, _) = ctx.vable_getfield_float(0, vable, 0xCAFE_BABE, fd_f);
+        let (f_result, _) = ctx.vable_getfield_float(
+            crate::cpu::default_cpu().as_ref(),
+            0,
+            vable,
+            0xCAFE_BABE,
+            fd_f,
+        );
         assert_eq!(f_result, cached_f);
     }
 
@@ -6077,7 +6127,13 @@ mod tests {
         let cached = ctx.const_int(7);
         let field_index = fd.index();
         ctx.heapcache_getfield_now_known(vable, field_index, cached);
-        let (result, _) = ctx.vable_getfield_int(0, vable, 0xCAFE_BABE, fd);
+        let (result, _) = ctx.vable_getfield_int(
+            crate::cpu::default_cpu().as_ref(),
+            0,
+            vable,
+            0xCAFE_BABE,
+            fd,
+        );
         assert_eq!(result, cached);
     }
 
@@ -6174,10 +6230,12 @@ mod tests {
         );
 
         // getfield with offset=8 → static field 0 → box0
-        let (result, _) = ctx.vable_getfield_int(0, vable, 0, fd8);
+        let (result, _) =
+            ctx.vable_getfield_int(crate::cpu::default_cpu().as_ref(), 0, vable, 0, fd8);
         assert_eq!(result, box0);
         // getfield with offset=16 → static field 1 → box1
-        let (result, _) = ctx.vable_getfield_int(0, vable, 0, fd16);
+        let (result, _) =
+            ctx.vable_getfield_int(crate::cpu::default_cpu().as_ref(), 0, vable, 0, fd16);
         assert_eq!(result, box1);
 
         // No heap ops should have been emitted
@@ -6217,10 +6275,12 @@ mod tests {
         ctx.vable_setfield(0, vable, fd8.clone(), new_val, Some(ph(Type::Int)));
 
         // Box 0 should now be new_val
-        let (result, _) = ctx.vable_getfield_int(0, vable, 0, fd8);
+        let (result, _) =
+            ctx.vable_getfield_int(crate::cpu::default_cpu().as_ref(), 0, vable, 0, fd8);
         assert_eq!(result, new_val);
         // Box 1 unchanged
-        let (result, _) = ctx.vable_getfield_int(0, vable, 0, fd16);
+        let (result, _) =
+            ctx.vable_getfield_int(crate::cpu::default_cpu().as_ref(), 0, vable, 0, fd16);
         assert_eq!(result, box1);
 
         // No heap ops should have been emitted
@@ -6243,7 +6303,7 @@ mod tests {
         );
 
         let fd8 = majit_ir::make_field_descr(8, 8, Type::Int, majit_ir::ArrayFlag::Signed);
-        let _result = ctx.vable_getfield_int(0, vable, 0, fd8);
+        let _result = ctx.vable_getfield_int(crate::cpu::default_cpu().as_ref(), 0, vable, 0, fd8);
 
         let ops = take_all_ops(ctx);
         assert_eq!(ops.len(), 1);
@@ -6343,7 +6403,8 @@ mod tests {
 
         // Unknown offset (999) → fallback to heap op
         let fd999 = majit_ir::make_field_descr(999, 8, Type::Int, majit_ir::ArrayFlag::Signed);
-        let _result = ctx.vable_getfield_int(0, vable, 0, fd999);
+        let _result =
+            ctx.vable_getfield_int(crate::cpu::default_cpu().as_ref(), 0, vable, 0, fd999);
 
         let ops = take_all_ops(ctx);
         assert_eq!(ops.len(), 1);
@@ -6369,7 +6430,8 @@ mod tests {
 
         ctx.init_virtualizable_boxes(&info, vable, ph(Type::Ref), &[box0], &[ph(Type::Ref)], &[]);
 
-        let (result, _) = ctx.vable_getfield_ref(0, vable, 0, fd8);
+        let (result, _) =
+            ctx.vable_getfield_ref(crate::cpu::default_cpu().as_ref(), 0, vable, 0, fd8);
         assert_eq!(result, box0);
 
         let ops = take_all_ops(ctx);
@@ -6402,7 +6464,8 @@ mod tests {
             &[],
         );
 
-        let (result, _) = ctx.vable_getfield_float(0, vable, 0, fd8);
+        let (result, _) =
+            ctx.vable_getfield_float(crate::cpu::default_cpu().as_ref(), 0, vable, 0, fd8);
         assert_eq!(result, box0);
 
         let ops = take_all_ops(ctx);

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -4325,6 +4325,25 @@ impl TraceCtx {
     /// known-nonnull / known-null / unknown; only `Some(true)` is upstream's
     /// truthy answer, for the reason spelled out at
     /// [`Self::trace_assert_not_none`].
+    /// `if self.metainterp.heapcache.is_nullity_known(box):` — upstream's
+    /// *truthiness* test, which is not the same question as
+    /// [`Self::heapcache_nullity_known`] answering `Some`.
+    ///
+    /// `heapcache.py` returns `bool(box.getref_base())` for a `Const` and
+    /// `_check_flag(box, HF_KNOWN_NULLITY)` otherwise, and
+    /// `nullity_now_known` sets that flag for *either* nullity. So a
+    /// non-`Const` box already known to be **null** answers true here and
+    /// short-circuits, while a **null `Const`** answers false and falls
+    /// through. Reading `Some(true)` alone gets the second of those right and
+    /// the first wrong, and re-guards a box whose nullity is already settled.
+    pub fn heapcache_nullity_answered(&self, opref: OpRef) -> bool {
+        match self.heapcache_nullity_known(opref) {
+            Some(true) => true,
+            Some(false) => !opref.is_constant(),
+            None => false,
+        }
+    }
+
     pub fn heapcache_nullity_known(&self, opref: OpRef) -> Option<bool> {
         self.heap_cache.is_nullity_known(opref, |op| {
             op.inline_const_to_value().and_then(|v| match v {

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -2106,43 +2106,6 @@ impl TraceCtx {
         opref.inline_const_to_value()
     }
 
-    /// Constant-fold a pure field read on a constant object pointer.
-    /// If `obj` is a constant and `descr` is immutable, reads the field
-    /// at runtime and returns the value as a constant OpRef.
-    ///
-    /// The constant is minted through `OpRef::const_inline_from_value`
-    /// (`executor.wrap_constant`), so the result carries the field's own
-    /// type rather than always being an int. A ref field folded as a
-    /// `ConstInt` would be a live heap pointer that the trace walkers
-    /// cannot see — `OpRef::walk_const_ptr_refs` forwards `ConstPtr`
-    /// alone — and a moving collection would leave it stale.
-    pub fn try_const_fold_pure_field(
-        &mut self,
-        obj: OpRef,
-        descr: &dyn majit_ir::Descr,
-    ) -> Option<OpRef> {
-        if !descr.is_always_pure() {
-            return None;
-        }
-        let obj_ptr = self.const_value(obj)? as usize;
-        if obj_ptr == 0 {
-            return None;
-        }
-        let fd = descr.as_field_descr()?;
-        let value = unsafe {
-            let base = (obj_ptr as *const u8).add(fd.offset());
-            match (fd.field_type(), fd.field_size()) {
-                (Type::Ref, 8) => Value::Ref(majit_ir::value::GcRef(*(base as *const usize))),
-                (Type::Float, 8) => Value::Float(*(base as *const f64)),
-                (Type::Int, 8) => Value::Int(*(base as *const i64)),
-                (Type::Int, 4) if fd.is_field_signed() => Value::Int(*(base as *const i32) as i64),
-                (Type::Int, 4) => Value::Int(*(base as *const u32) as i64),
-                _ => return None,
-            }
-        };
-        Some(OpRef::const_inline_from_value(&value))
-    }
-
     /// M1 bridge: translate a pyre `OpRef` into the `opencoder::Box` that
     /// `TraceRecordBuffer::record_op(&[Box], descr)` expects.
     ///

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -2109,6 +2109,13 @@ impl TraceCtx {
     /// Constant-fold a pure field read on a constant object pointer.
     /// If `obj` is a constant and `descr` is immutable, reads the field
     /// at runtime and returns the value as a constant OpRef.
+    ///
+    /// The constant is minted through `OpRef::const_inline_from_value`
+    /// (`executor.wrap_constant`), so the result carries the field's own
+    /// type rather than always being an int. A ref field folded as a
+    /// `ConstInt` would be a live heap pointer that the trace walkers
+    /// cannot see — `OpRef::walk_const_ptr_refs` forwards `ConstPtr`
+    /// alone — and a moving collection would leave it stale.
     pub fn try_const_fold_pure_field(
         &mut self,
         obj: OpRef,
@@ -2122,18 +2129,18 @@ impl TraceCtx {
             return None;
         }
         let fd = descr.as_field_descr()?;
-        let offset = fd.offset();
-        let field_size = fd.field_size();
         let value = unsafe {
-            let base = obj_ptr as *const u8;
-            match field_size {
-                8 => *(base.add(offset) as *const i64),
-                4 if fd.is_field_signed() => *(base.add(offset) as *const i32) as i64,
-                4 => *(base.add(offset) as *const u32) as i64,
+            let base = (obj_ptr as *const u8).add(fd.offset());
+            match (fd.field_type(), fd.field_size()) {
+                (Type::Ref, 8) => Value::Ref(majit_ir::value::GcRef(*(base as *const usize))),
+                (Type::Float, 8) => Value::Float(*(base as *const f64)),
+                (Type::Int, 8) => Value::Int(*(base as *const i64)),
+                (Type::Int, 4) if fd.is_field_signed() => Value::Int(*(base as *const i32) as i64),
+                (Type::Int, 4) => Value::Int(*(base as *const u32) as i64),
                 _ => return None,
             }
         };
-        Some(self.const_int(value))
+        Some(OpRef::const_inline_from_value(&value))
     }
 
     /// M1 bridge: translate a pyre `OpRef` into the `opencoder::Box` that

--- a/majit/majit-metainterp/tests/elidable_ref_canary_test.rs
+++ b/majit/majit-metainterp/tests/elidable_ref_canary_test.rs
@@ -21,7 +21,7 @@
 //! (`REF_ELIDABLE = 21`, `call.py elif cr:`).  The fold machinery
 //! exercised by checks 2-3 (`call_typed_with_effect_pure` →
 //! `record_result_of_call_pure` → `execute_pure_call`) is the
-//! `_record_helper_pure` path, which `pyjitpl.py:1351-1352` reaches ONLY
+//! `MIFrame.execute_varargs(pure=True)` path, which is reached ONLY
 //! for `EF_ELIDABLE_CANNOT_RAISE`.  Both `call_typed_with_effect_pure`
 //! (`history.rs` debug_assert) and `execute_pure_call`
 //! (`executor.rs`'s `elidable_can_raise_panics_debug_assertion`
@@ -88,8 +88,8 @@ fn elidable_ref_canary_traces_to_call_pure_r_when_args_not_all_const() {
     let action = meta.force_start_tracing(0, (0, 0), None, &[Value::Ref(GcRef(live_p))]);
     assert!(matches!(action, BackEdgeAction::StartedTracing));
 
-    // Fold path requires EF_ELIDABLE_CANNOT_RAISE: `_record_helper_pure`
-    // is reached only for that policy (pyjitpl.py:1351-1352).
+    // Fold path requires EF_ELIDABLE_CANNOT_RAISE:
+    // `MIFrame.execute_varargs(pure=True)` is reached only for that policy.
     let effect = EffectInfo::new(ExtraEffect::ElidableCannotRaise, OopSpecIndex::None);
 
     // inputarg slot 0 = first live value, Ref-typed (resoperation.py:739

--- a/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
+++ b/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
@@ -7,7 +7,7 @@
 //! loop close.
 
 use majit_metainterp::jitcode::insns::{
-    BC_ABORT, BC_GETARRAYITEM_GC_I, BC_GOTO_IF_NOT_INT_EQ, BC_INLINE_CALL, BC_INT_ADD,
+    BC_ABORT, BC_GETARRAYITEM_GC_I_PURE, BC_GOTO_IF_NOT_INT_EQ, BC_INLINE_CALL, BC_INT_ADD,
     BC_INT_RETURN, BC_JIT_MERGE_POINT, BC_JIT_MERGE_POINT_C, BC_LIVE, BC_STORE_STATE_FIELD,
 };
 use majit_metainterp::{Assembler, BC_GOTO, JitCode, JitDriver};
@@ -444,7 +444,7 @@ fn dispatch_jitcode_contains_loop_back_goto() {
 
 /// The dispatch JitCode body must contain the opcode-fetch IR ops
 /// lowered from `let opcode = program[pc]; pc += 1;`:
-///   1. BC_GETARRAYITEM_GC_I — loads program[pc] into an int register
+///   1. BC_GETARRAYITEM_GC_I_PURE — loads program[pc] into an int register
 ///   2. BC_INT_ADD           — increments pc_reg by 1 (via load_const + int_add)
 ///
 /// pyopcode.py:171 `opcode = ord(co_code[next_instr])` + `next_instr += 1`.
@@ -458,8 +458,8 @@ fn dispatch_jitcode_lowers_opcode_fetch() {
         .expect("missing JIT_MERGE_POINT");
     let post_mp = &code[mp_idx..];
     assert!(
-        post_mp.contains(&BC_GETARRAYITEM_GC_I),
-        "dispatch JitCode body must emit BC_GETARRAYITEM_GC_I for program[pc]; \
+        post_mp.contains(&BC_GETARRAYITEM_GC_I_PURE),
+        "dispatch JitCode body must emit BC_GETARRAYITEM_GC_I_PURE for program[pc]; \
          got bytes {:?}",
         post_mp
     );
@@ -846,17 +846,17 @@ mod oparg_minimal {
     /// A.2.2: the dispatch JitCode body must lower BOTH byte fetches in
     /// `let opcode = program[pc]; let oparg = program[pc + 1]; pc += 2;`
     /// per RPython `pyopcode.py:179-181`:
-    ///     - opcode fetch → `BC_GETARRAYITEM_GC_I result, program, pc`
+    ///     - opcode fetch → `BC_GETARRAYITEM_GC_I_PURE result, program, pc`
     ///     - oparg  fetch → `BC_INT_ADD offset, pc, +1` then
-    ///       `BC_GETARRAYITEM_GC_I result, program, offset`
+    ///       `BC_GETARRAYITEM_GC_I_PURE result, program, offset`
     ///     - pc advance   → `BC_INT_ADD pc, pc, +2`
     ///
-    /// Net post-merge-point op shape: BC_GETARRAYITEM_GC_I × 2 and at
+    /// Net post-merge-point op shape: BC_GETARRAYITEM_GC_I_PURE × 2 and at
     /// least two BC_INT_ADDs (one for `pc + 1` offset, one for `pc += 2`).
     #[test]
     fn dispatch_oparg_minimal_lowers_oparg_fetch_and_pc_advance() {
         use majit_metainterp::jitcode::insns::{
-            BC_GETARRAYITEM_GC_I, BC_INT_ADD, BC_JIT_MERGE_POINT, BC_JIT_MERGE_POINT_C,
+            BC_GETARRAYITEM_GC_I_PURE, BC_INT_ADD, BC_JIT_MERGE_POINT, BC_JIT_MERGE_POINT_C,
         };
 
         let dispatch_jc = build_oparg_minimal();
@@ -869,11 +869,11 @@ mod oparg_minimal {
 
         let getarrayitem_count = post_mp
             .iter()
-            .filter(|&&b| b == BC_GETARRAYITEM_GC_I)
+            .filter(|&&b| b == BC_GETARRAYITEM_GC_I_PURE)
             .count();
         assert_eq!(
             getarrayitem_count, 2,
-            "A.2.2: dispatch JitCode body must emit exactly two BC_GETARRAYITEM_GC_I \
+            "A.2.2: dispatch JitCode body must emit exactly two BC_GETARRAYITEM_GC_I_PURE \
              ops (opcode + oparg per pyopcode.py:179-180); got {}",
             getarrayitem_count
         );
@@ -886,15 +886,15 @@ mod oparg_minimal {
             int_add_count
         );
 
-        // Order check: the FIRST BC_GETARRAYITEM_GC_I (opcode fetch) must
+        // Order check: the FIRST BC_GETARRAYITEM_GC_I_PURE (opcode fetch) must
         // precede the first BC_INT_ADD (which is the pc+1 offset compute
-        // for the oparg fetch). The SECOND BC_GETARRAYITEM_GC_I (oparg
+        // for the oparg fetch). The SECOND BC_GETARRAYITEM_GC_I_PURE (oparg
         // fetch) must come after the offset compute. RPython
         // `pyopcode.py:179-180` orders opcode → oparg.
         let first_getarr = post_mp
             .iter()
-            .position(|&b| b == BC_GETARRAYITEM_GC_I)
-            .expect("first BC_GETARRAYITEM_GC_I missing");
+            .position(|&b| b == BC_GETARRAYITEM_GC_I_PURE)
+            .expect("first BC_GETARRAYITEM_GC_I_PURE missing");
         let first_int_add = post_mp
             .iter()
             .position(|&b| b == BC_INT_ADD)
@@ -902,10 +902,10 @@ mod oparg_minimal {
         let second_getarr = post_mp
             .iter()
             .enumerate()
-            .filter(|&(_, &b)| b == BC_GETARRAYITEM_GC_I)
+            .filter(|&(_, &b)| b == BC_GETARRAYITEM_GC_I_PURE)
             .nth(1)
             .map(|(i, _)| i)
-            .expect("second BC_GETARRAYITEM_GC_I missing");
+            .expect("second BC_GETARRAYITEM_GC_I_PURE missing");
         assert!(
             first_getarr < first_int_add,
             "A.2.2: opcode fetch must precede pc+1 offset compute; \
@@ -936,7 +936,8 @@ mod oparg_minimal {
     #[test]
     fn dispatch_oparg_minimal_pins_last_instr_store_position() {
         use majit_metainterp::jitcode::insns::{
-            BC_GETARRAYITEM_GC_I, BC_JIT_MERGE_POINT, BC_JIT_MERGE_POINT_C, BC_STORE_STATE_FIELD,
+            BC_GETARRAYITEM_GC_I_PURE, BC_JIT_MERGE_POINT, BC_JIT_MERGE_POINT_C,
+            BC_STORE_STATE_FIELD,
         };
 
         let dispatch_jc = build_oparg_minimal();
@@ -965,8 +966,8 @@ mod oparg_minimal {
             .expect("BC_STORE_STATE_FIELD missing");
         let first_getarr = post_mp
             .iter()
-            .position(|&b| b == BC_GETARRAYITEM_GC_I)
-            .expect("BC_GETARRAYITEM_GC_I missing");
+            .position(|&b| b == BC_GETARRAYITEM_GC_I_PURE)
+            .expect("BC_GETARRAYITEM_GC_I_PURE missing");
         assert!(
             store_pos < first_getarr,
             "A.2.4: last_instr store must precede opcode fetch \
@@ -982,7 +983,7 @@ mod oparg_minimal {
     /// `emit_canonical_call_void`
     /// auto-selection (no float / no int args → R variant with
     /// `ref_count = 0`). Position: between the `BC_STORE_STATE_FIELD`
-    /// for `state.last_instr` (L172) and the first `BC_GETARRAYITEM_GC_I`
+    /// for `state.last_instr` (L172) and the first `BC_GETARRAYITEM_GC_I_PURE`
     /// for the opcode fetch (L179) — RPython source order is
     /// L172 store → L174 trace → L179 fetch.
     ///
@@ -1001,8 +1002,8 @@ mod oparg_minimal {
     #[test]
     fn dispatch_oparg_minimal_pins_bytecode_only_trace_residual_call() {
         use majit_metainterp::jitcode::insns::{
-            BC_GETARRAYITEM_GC_I, BC_JIT_MERGE_POINT, BC_JIT_MERGE_POINT_C, BC_RESIDUAL_CALL_R_V,
-            BC_STORE_STATE_FIELD,
+            BC_GETARRAYITEM_GC_I_PURE, BC_JIT_MERGE_POINT, BC_JIT_MERGE_POINT_C,
+            BC_RESIDUAL_CALL_R_V, BC_STORE_STATE_FIELD,
         };
 
         let dispatch_jc = build_oparg_minimal();
@@ -1046,11 +1047,11 @@ mod oparg_minimal {
             .iter()
             .enumerate()
             .skip(residual_pos + 1)
-            .find(|&(_, &b)| b == BC_GETARRAYITEM_GC_I)
+            .find(|&(_, &b)| b == BC_GETARRAYITEM_GC_I_PURE)
             .map(|(i, _)| i)
-            .expect("BC_GETARRAYITEM_GC_I after BC_RESIDUAL_CALL_R_V missing");
+            .expect("BC_GETARRAYITEM_GC_I_PURE after BC_RESIDUAL_CALL_R_V missing");
         // Successful chained `find_after` proves the ordering:
-        // BC_STORE_STATE_FIELD → BC_RESIDUAL_CALL_R_V → BC_GETARRAYITEM_GC_I,
+        // BC_STORE_STATE_FIELD → BC_RESIDUAL_CALL_R_V → BC_GETARRAYITEM_GC_I_PURE,
         // matching pyopcode.py:172 → L174 → L179 source order.
         let _ = (store_pos, residual_pos, first_getarr);
     }
@@ -1325,7 +1326,7 @@ mod oparg_minimal {
 mod oparg_extended {
 
     use majit_metainterp::jitcode::insns::{
-        BC_ABORT, BC_GETARRAYITEM_GC_I, BC_INT_MUL, BC_INT_OR, BC_JIT_MERGE_POINT,
+        BC_ABORT, BC_GETARRAYITEM_GC_I_PURE, BC_INT_MUL, BC_INT_OR, BC_JIT_MERGE_POINT,
         BC_JIT_MERGE_POINT_C,
     };
     use majit_metainterp::{Assembler, JitDriver};
@@ -1421,7 +1422,7 @@ mod oparg_extended {
     /// A.2.3b shape pin: lowered EXTENDED_ARG inner while emits the
     /// RPython L188-193 IR sequence:
     ///
-    /// - 4 × BC_GETARRAYITEM_GC_I — outer opcode + outer oparg
+    /// - 4 × BC_GETARRAYITEM_GC_I_PURE — outer opcode + outer oparg
     ///   (pyopcode.py:179-180) plus inner opcode2 + inner arg2
     ///   (pyopcode.py:188-189)
     /// - 1 × BC_INT_MUL — `oparg * 256` (Pre-A.2.3 codex BLOCKER (c):
@@ -1460,15 +1461,15 @@ mod oparg_extended {
         // a naive byte filter (.filter(|&&b| b == BC_X).count()) can
         // collide with operand values that happen to equal BC_X. The
         // existing `dispatch_oparg_minimal_lowers_oparg_fetch_and_pc_advance`
-        // test gets away with `== 2` for BC_GETARRAYITEM_GC_I (0xa9)
+        // test gets away with `== 2` for the fetch opcode
         // because the fixture uses a small register window; this richer
         // EXTENDED_ARG fixture has more registers and high-byte descr
         // indices, so we assert minimums + ordering instead.
         let count = |target: u8| post_mp.iter().filter(|&&b| b == target).count();
-        let getarr_count = count(BC_GETARRAYITEM_GC_I);
+        let getarr_count = count(BC_GETARRAYITEM_GC_I_PURE);
         assert!(
             getarr_count >= 4,
-            "A.2.3b: dispatch JitCode body must emit ≥ 4 BC_GETARRAYITEM_GC_I \
+            "A.2.3b: dispatch JitCode body must emit ≥ 4 BC_GETARRAYITEM_GC_I_PURE \
              ops (outer opcode + outer oparg + inner opcode2 + inner arg2 \
              per pyopcode.py:179-180/188-189); got {}",
             getarr_count
@@ -1511,10 +1512,10 @@ mod oparg_extended {
                 .map(|(i, _)| i)
                 .unwrap_or_else(|| panic!("BC_{:02x} after offset {} missing", target, after))
         };
-        let outer_opcode_pos = first_pos(BC_GETARRAYITEM_GC_I, 0);
-        let outer_oparg_pos = first_pos(BC_GETARRAYITEM_GC_I, outer_opcode_pos + 1);
-        let inner_opcode_pos = first_pos(BC_GETARRAYITEM_GC_I, outer_oparg_pos + 1);
-        let inner_arg_pos = first_pos(BC_GETARRAYITEM_GC_I, inner_opcode_pos + 1);
+        let outer_opcode_pos = first_pos(BC_GETARRAYITEM_GC_I_PURE, 0);
+        let outer_oparg_pos = first_pos(BC_GETARRAYITEM_GC_I_PURE, outer_opcode_pos + 1);
+        let inner_opcode_pos = first_pos(BC_GETARRAYITEM_GC_I_PURE, outer_oparg_pos + 1);
+        let inner_arg_pos = first_pos(BC_GETARRAYITEM_GC_I_PURE, inner_opcode_pos + 1);
         let abort_pos = first_pos(BC_ABORT, inner_arg_pos + 1);
         let int_mul_pos = first_pos(BC_INT_MUL, abort_pos + 1);
         let int_or_pos = first_pos(BC_INT_OR, int_mul_pos + 1);

--- a/majit/majit-metainterp/tests/vable_array_promote_order.rs
+++ b/majit/majit-metainterp/tests/vable_array_promote_order.rs
@@ -144,10 +144,19 @@ fn build_jitcode(arm: Arm) -> (Arc<JitCode>, usize) {
     (jitcode, pc)
 }
 
+/// Whether the vable register holds a recorded box or a prebuilt constant.
+/// Step 4's `PTR_EQ` runs through `execute_and_record`, so the two shapes
+/// differ in whether the comparison survives into the trace.
+#[derive(Clone, Copy)]
+enum VableBox {
+    Recorded,
+    Constant,
+}
+
 /// Run one dispatch step of `arm` against a NON-standard virtualizable whose
 /// index box is non-constant, and report `(guards minted, whether any guard
-/// names the index box)`.
-fn run_arm(arm: Arm) -> (usize, bool) {
+/// names the index box, whether Step 4's PTR_EQ was recorded)`.
+fn run_arm(arm: Arm, vable: VableBox) -> (usize, bool, bool) {
     let info = one_int_array_vinfo();
     let mut ctx = TraceCtx::for_test_types(&[Type::Ref]);
 
@@ -171,7 +180,21 @@ fn run_arm(arm: Arm) -> (usize, bool) {
     // reaches its Step 4 `PTR_EQ`, reads unequal, and takes the non-standard
     // branch. This is the whole point of the fixture — the standard branch
     // promotes on purpose.
-    let other_vable = ctx.const_ref(2);
+    //
+    // `VableBox::Recorded` must NOT be a `ConstPtr`. Step 4 runs its `PTR_EQ`
+    // through `execute_and_record`, so a constant on both sides folds the
+    // comparison and no guard is minted — which would leave the `guards > 0`
+    // line measuring nothing. A virtualizable in a register is a recorded box
+    // in production anyway; the concrete pointer arrives from the frame's
+    // `ref_values`, not from the box being constant.
+    let other_vable = match vable {
+        VableBox::Recorded => {
+            let b = OpRef::input_arg_ref(0);
+            ctx.set_opref_concrete(b, Value::Ref(majit_ir::GcRef(2)));
+            b
+        }
+        VableBox::Constant => ctx.const_ref(2),
+    };
 
     // A non-constant index carrying a recording-time concrete. Any other shape
     // makes the promote a no-op, so the test would pass without measuring it.
@@ -211,7 +234,15 @@ fn run_arm(arm: Arm) -> (usize, bool) {
                 .first()
                 .is_some_and(|arg| arg.to_opref() == index)
     });
-    (ctx.num_guards() - guards_before, promoted_index)
+    let recorded_ptr_eq = ctx
+        .ops()
+        .iter()
+        .any(|recorded| recorded.opcode == majit_ir::OpCode::PtrEq);
+    (
+        ctx.num_guards() - guards_before,
+        promoted_index,
+        recorded_ptr_eq,
+    )
 }
 
 /// ## The negative control, and how it was taken
@@ -245,7 +276,8 @@ fn run_arm(arm: Arm) -> (usize, bool) {
 #[test]
 fn a_nonstandard_vable_array_access_does_not_promote_the_index() {
     for arm in [Arm::Get, Arm::Set] {
-        let (guards, promoted_index) = run_arm(arm);
+        let (guards, promoted_index, recorded_ptr_eq) = run_arm(arm, VableBox::Recorded);
+        assert!(recorded_ptr_eq, "{}: Step 4's PTR_EQ", arm.name());
         assert!(
             guards > 0,
             "{}: the arm must still mint the Step 4 PTR_EQ promote of \
@@ -263,5 +295,32 @@ fn a_nonstandard_vable_array_access_does_not_promote_the_index() {
              only the standard leg enters.",
             arm.name()
         );
+    }
+}
+
+/// The same walk with a prebuilt `ConstPtr` in the vable register. Step 3
+/// already returned for `standard_box is box`, so two constants reaching Step 4
+/// are *different* constants and cannot be equal at runtime either — the
+/// `PTR_EQ` folds to `ConstInt(0)` and `implement_guard_value`'s Const arm then
+/// declines the promote, leaving neither the comparison nor a `GUARD_VALUE` in
+/// the trace. `capture_vable_promote_guard` derives its stamp count from
+/// `ctx.num_guards()` rather than assuming one, so minting none is a case it
+/// already handles.
+#[test]
+fn a_constant_vable_folds_the_step_four_ptr_eq_away() {
+    for arm in [Arm::Get, Arm::Set] {
+        let (guards, promoted_index, recorded_ptr_eq) = run_arm(arm, VableBox::Constant);
+        assert!(
+            !recorded_ptr_eq,
+            "{}: two different ConstPtrs must fold, not record",
+            arm.name()
+        );
+        assert_eq!(
+            guards,
+            0,
+            "{}: a folded PTR_EQ has nothing to promote",
+            arm.name()
+        );
+        assert!(!promoted_index, "{}", arm.name());
     }
 }

--- a/majit/majit-trace/src/heapcache.rs
+++ b/majit/majit-trace/src/heapcache.rs
@@ -586,8 +586,26 @@ impl HeapCache {
         }
     }
 
-    /// RPython-compatible alias.
-    pub fn _get_deps(&mut self, opref: OpRef) -> &mut Vec<Option<OpRef>> {
+    /// `heapcache.py HeapCache._get_deps`.
+    ///
+    /// ```text
+    ///  def _get_deps(self, box):
+    ///      if not isinstance(box, RefFrontendOp):
+    ///          return None
+    ///      self.update_version(box)
+    ///      if box._heapc_deps is None:
+    ///          box._heapc_deps = [None]
+    ///      return box._heapc_deps
+    /// ```
+    ///
+    /// The `isinstance` arm is why this returns an `Option`: a `Const` has no
+    /// `_heapc_deps` slot upstream and no `raw()` index here, so there is no
+    /// list to hand back. Dropping it would make `OpRef::raw()` panic, which
+    /// the tracer catches and downgrades to a silent `TraceAction::Abort`.
+    pub fn _get_deps(&mut self, opref: OpRef) -> Option<&mut Vec<Option<OpRef>>> {
+        if opref.is_constant() {
+            return None;
+        }
         self.update_version(opref);
         let i = opref.raw() as usize;
         if i >= self.heapc_deps.len() {
@@ -597,7 +615,7 @@ impl HeapCache {
         if deps.is_empty() {
             deps.push(None);
         }
-        deps
+        Some(deps)
     }
 
     /// heapcache.py:224-229
@@ -612,7 +630,9 @@ impl HeapCache {
     /// ```
     pub fn _escape_from_write(&mut self, r#box: OpRef, fieldbox: OpRef) {
         if self.is_unescaped(r#box) && self.is_unescaped(fieldbox) {
-            let deps = self._get_deps(r#box);
+            let deps = self
+                ._get_deps(r#box)
+                .expect("is_unescaped answers false for a Const");
             deps.push(Some(fieldbox));
         } else {
             // RPython's `elif fieldbox is not None` — pyre's OpRef is always
@@ -1932,7 +1952,9 @@ impl HeapCache {
         if array.is_constant() {
             return;
         }
-        let deps = self._get_deps(array);
+        let deps = self
+            ._get_deps(array)
+            .expect("assert deps is not None — the Const arm above returned");
         deps[0] = Some(length);
     }
 
@@ -2151,8 +2173,16 @@ impl HeapCache {
         self.heap_array_cache.clear();
     }
 
-    /// RPython-compatible alias kept for existing codepaths.
+    /// `update_version`'s `ref_frontend_op._heapc_deps = None`, split out.
+    ///
+    /// A `Const` has no slot to clear, exactly as `flags_for_ref` and
+    /// `set_flags_for_ref` already answer 0 and no-op for one. Without this
+    /// arm `update_version` is a no-op for a constant right up to its last
+    /// line, where `raw()` panics.
     pub fn _remove_deps_for_box(&mut self, opref: OpRef) {
+        if opref.is_constant() {
+            return;
+        }
         let i = opref.raw() as usize;
         if i < self.heapc_deps.len() {
             self.heapc_deps[i] = None;
@@ -2236,6 +2266,27 @@ mod tests {
         let ci = OpRef::const_int(42);
         assert_eq!(entry._unique_const_heuristic(ci, &oracle), ci);
         assert!(entry.last_const_box.is_none());
+    }
+
+    /// `_get_deps`'s `if not isinstance(box, RefFrontendOp): return None`.
+    /// A `Const` has no `raw()` index, so without the arm the accessor
+    /// panics instead of declining.
+    #[test]
+    fn get_deps_declines_a_constant_instead_of_indexing_it() {
+        let mut cache = HeapCache::new();
+        assert!(cache._get_deps(OpRef::const_ptr(GcRef(0x1000))).is_none());
+        assert!(cache._get_deps(OpRef::const_int(42)).is_none());
+        assert!(cache._get_deps(OpRef::ref_op(0)).is_some());
+    }
+
+    /// `update_version` is already a no-op for a `Const` through
+    /// `flags_for_ref` / `set_flags_for_ref`; its last line must not then
+    /// index one.
+    #[test]
+    fn update_version_is_a_no_op_for_a_constant() {
+        let mut cache = HeapCache::new();
+        cache.update_version(OpRef::const_ptr(GcRef(0x1000)));
+        cache._remove_deps_for_box(OpRef::const_int(42));
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -8807,9 +8807,17 @@ const FLOAT_CMP_TARGETS: &[CallTargetPattern] = &[
     CallTargetPattern::FunctionPath(&["float_ne"]),
 ];
 
-// effectinfo.py: EF_ELIDABLE_CAN_RAISE — may raise (e.g. ZeroDivisionError)
-// int_floordiv and int_mod have distinct oopspec indices (IntPyDiv vs IntPyMod)
-// because intbounds.rs optimizes them differently.
+// effectinfo.py: EF_ELIDABLE_CAN_RAISE — these name the source-level helpers,
+// which check for a zero divisor and raise.
+//
+// They carry no oopspec index. `OS_INT_PY_DIV` / `OS_INT_PY_MOD` identify
+// `rint.py ll_int_py_div` and `ll_int_py_mod`, the machine-word primitives
+// whose zero check `ll_int_py_div_zer` has already inlined away — that is why
+// `jtransform.py _handle_int_special` gives them `EF_ELIDABLE_CANNOT_RAISE` —
+// and `rewrite.py optimize_call_int_py_div` rewrites a call carrying either
+// index into `int_rshift` / `int_neg` on the strength of it. The `int.py_div`
+// / `int.py_mod` oopspec names are the only spelling that identifies those
+// primitives, and `_handle_int_special` is where the indices are minted.
 const INT_FLOORDIV_TARGETS: &[CallTargetPattern] =
     &[CallTargetPattern::FunctionPath(&["int_floordiv"])];
 
@@ -8906,12 +8914,12 @@ const CALL_DESCRIPTOR_TABLE: &[CallDescriptorEntry] = &[
     CallDescriptorEntry {
         targets: INT_FLOORDIV_TARGETS,
         extraeffect: ExtraEffect::ElidableCanRaise,
-        oopspecindex: OopSpecIndex::IntPyDiv,
+        oopspecindex: OopSpecIndex::None,
     },
     CallDescriptorEntry {
         targets: INT_MOD_TARGETS,
         extraeffect: ExtraEffect::ElidableCanRaise,
-        oopspecindex: OopSpecIndex::IntPyMod,
+        oopspecindex: OopSpecIndex::None,
     },
     // RPython `jtransform.py` `_do_builtin_call` casts —
     // unsigned-domain conversion helpers.  Cannot raise; elidable.

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -4091,6 +4091,15 @@ impl<'a> Transformer<'a> {
             {
                 return prepend_const_prefix(&mut const_prefix_ops, result);
             }
+            // jtransform.py:489-490 — int.* oopspecs → _handle_int_special.
+            // Unhandled spellings return `None` and fall through to the
+            // residual-call path.
+            if base.starts_with("int.")
+                && let Some(result) =
+                    self._handle_int_special(base, op, target, args, result_ty, graph_name, graph)
+            {
+                return prepend_const_prefix(&mut const_prefix_ops, result);
+            }
             // jtransform.py — stroruni.* oopspecs → _handle_stroruni_call.
             // Unhandled spellings return `None` and fall through to the
             // residual-call path (RPython raises `NotSupported`).
@@ -4394,6 +4403,70 @@ impl<'a> Transformer<'a> {
             }
             _ => None,
         }
+    }
+
+    /// Port of `jtransform.py _handle_int_special`'s general arm:
+    ///
+    /// ```python
+    /// # int.py_div, int.udiv, int.py_mod, int.umod
+    /// opname = oopspec_name.replace('.', '_')
+    /// os = getattr(EffectInfo, 'OS_' + opname.upper())
+    /// return self._handle_oopspec_call(op, args, os,
+    ///                                  EffectInfo.EF_ELIDABLE_CANNOT_RAISE)
+    /// ```
+    ///
+    /// The index is derived from the DECLARED oopspec string, never from the
+    /// callee's name or path, so a function carrying
+    /// `#[oopspec("int.py_div(x, y)")]` lowers to a residual call whose descr
+    /// says `IntPyDiv` whatever the function is called. That is what lets a
+    /// front end attach one of these to a division helper of its own naming;
+    /// a table of callee paths can only recognise the names it was written
+    /// against.
+    ///
+    /// `getattr` over the `OS_*` namespace has no Rust counterpart, so the
+    /// four spellings upstream's own comment enumerates are matched directly.
+    /// An unlisted one returns `None` and falls through to the ordinary
+    /// residual call, the convention the `rgc.*` and `list.*` siblings use for
+    /// an oopspec this codewriter has not lowered.
+    ///
+    /// The two spellings upstream rewrites into operations here rather than
+    /// into a call — `int.neg_ovf` and `int.uint_mul_high` — are deliberately
+    /// absent. Both are recognised at the MIR front end
+    /// (`front::checked_arith`, `front::checked_arith_uint`), which emits
+    /// `sub_ovf` / `uint_mul_high` directly, so neither can reach a decoded
+    /// oopspec and an arm for them would be unreachable.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The parameter order mirrors the corresponding RPython translation routine; grouping arguments into a Rust-only context object would obscure line-by-line parity and ownership"
+    )]
+    fn _handle_int_special(
+        &mut self,
+        oopspec_name: &str,
+        op: &SpaceOperation,
+        target: &CallTarget,
+        args: &[crate::flowspace::model::Variable],
+        result_ty: &ValueType,
+        graph_name: &str,
+        graph: &mut FunctionGraph,
+    ) -> Option<RewriteResult> {
+        let oopspecindex = match oopspec_name {
+            "int.py_div" => OopSpecIndex::IntPyDiv,
+            "int.udiv" => OopSpecIndex::IntUdiv,
+            "int.py_mod" => OopSpecIndex::IntPyMod,
+            "int.umod" => OopSpecIndex::IntUmod,
+            _ => return None,
+        };
+        Some(self._handle_oopspec_call(
+            graph,
+            op,
+            target,
+            args,
+            result_ty,
+            graph_name,
+            oopspecindex,
+            Some(majit_ir::descr::ExtraEffect::ElidableCannotRaise),
+            None,
+        ))
     }
 
     /// Port of `jtransform.py _handle_list_call` for pyre's
@@ -13628,6 +13701,67 @@ mod tests {
             })
             .expect("marked newlist_clear must lower to new_array_clear");
         assert_eq!(new_array_clear, count);
+    }
+
+    /// The `int.*` index comes from the declared oopspec string, so a helper
+    /// whose name is nothing like `int_floordiv` still lowers to a residual
+    /// call carrying `IntPyDiv`. A front end that names its division helper
+    /// after its own domain is the case a callee-path table cannot serve.
+    #[test]
+    fn declared_int_py_div_oopspec_indexes_a_differently_named_helper() {
+        let path = crate::parse::CallPath::from_segments(["band_div"]);
+        let target = CallTarget::function_path(["band_div"]);
+
+        let mut cc = crate::call::CallControl::new();
+        cc.mark_oopspec(path, "int.py_div(x, y)".to_string());
+
+        let mut graph = FunctionGraph::new("caller");
+        let lhs = graph.alloc_value_var();
+        let rhs = graph.alloc_value_var();
+        let result = graph.alloc_value_var();
+        FunctionGraph::set_concretetype_of_inline(&lhs, ConcreteType::Signed);
+        FunctionGraph::set_concretetype_of_inline(&rhs, ConcreteType::Signed);
+        FunctionGraph::set_concretetype_of_inline(&result, ConcreteType::Signed);
+        let startblock = graph.startblock;
+        graph.push_op_var(
+            startblock,
+            OpKind::Call {
+                target,
+                args: vec![lhs.clone(), rhs.clone()],
+                result_ty: ValueType::Int,
+            },
+            false,
+        );
+        graph
+            .block_mut(startblock)
+            .operations
+            .last_mut()
+            .unwrap()
+            .result = Some(result.clone());
+
+        let config = GraphTransformConfig::default();
+        let transformed = Transformer::new(&config)
+            .with_callcontrol(&mut cc)
+            .transform(&graph);
+
+        let descriptor = transformed
+            .graph
+            .block(startblock)
+            .operations
+            .iter()
+            .find_map(|op| match &op.kind {
+                OpKind::CallResidual { descriptor, .. } => Some(descriptor),
+                _ => None,
+            })
+            .expect("a declared int.py_div oopspec must lower to a residual call");
+        assert_eq!(
+            descriptor.get_extra_info().oopspecindex,
+            OopSpecIndex::IntPyDiv
+        );
+        assert_eq!(
+            descriptor.get_extra_info().extraeffect,
+            majit_ir::descr::ExtraEffect::ElidableCannotRaise
+        );
     }
 
     /// T3 end-to-end: the rtyper mints the `_ll_alloc_and_set` family (whose

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -2036,7 +2036,7 @@ pub(crate) fn select_residual_call_opcode(
     }
 }
 
-/// `pyjitpl.py _record_helper_pure` parity for the
+/// `MIFrame.execute_varargs(pure=True)` parity for the
 /// walker layer: when a residual_call routes to `CallPure*` (elidable +
 /// cannot-raise EI per [`select_residual_call_opcode`]) AND every
 /// argument in `allboxes` has a known concrete value
@@ -2054,7 +2054,7 @@ pub(crate) fn select_residual_call_opcode(
 /// with raised exceptions surfaced through `BH_LAST_EXC_VALUE` so
 /// `eval_loop_jit` can route them into the bytecode exception handler.
 ///
-/// RPython upstream `_record_helper_pure` invokes
+/// RPython upstream `MIFrame.execute_varargs` invokes
 /// `executor.execute_varargs(opnum, argboxes, descr, exc=False, pure=True)`
 /// which dispatches to `cpu.bh_call_*` and stores the result on
 /// `result_box.value` (`pyjitpl.py`).  Pyre's walker observes the
@@ -2091,7 +2091,7 @@ pub(crate) fn try_fold_pure_call_via_executor<Sym: WalkSym>(
     ) {
         return;
     }
-    // pyjitpl.py — `_record_helper_pure` only fires for
+    // `MIFrame.execute_varargs(pure=True)` only fires for
     // `EF_ELIDABLE_CANNOT_RAISE`. `select_residual_call_opcode` returns
     // `CallPure*` whenever `check_is_elidable()` is true (including
     // `EF_ELIDABLE_CAN_RAISE`), so re-check the can-raise predicate here
@@ -2110,7 +2110,7 @@ pub(crate) fn try_fold_pure_call_via_executor<Sym: WalkSym>(
     // 1.. are user args in `descr.arg_types()` ABI order.  Walker's
     // [`build_allboxes`] preserves the same layout.
     //
-    // pyjitpl.py invariant: `_record_helper_pure` requires
+    // `MIFrame.execute_varargs(pure=True)` invariant: it requires
     // `funcbox` to be a Const so its `getint()` is the actual fn
     // pointer.  Non-constant funcboxes carry a stale-stamped Int
     // (from `cast_ptr_to_int` of a Ref-bank receiver, etc.) and
@@ -2189,7 +2189,7 @@ pub(crate) fn try_fold_pure_call_via_executor<Sym: WalkSym>(
         majit_ir::Type::Float => majit_ir::Value::Float(f64::from_bits(result_i64 as u64)),
         // void callees discard the result upstream too (`bh_call_v` has
         // no return value); `CallPureN` is included in the matched set
-        // only to mirror PyPy's `_record_helper_pure` handling of all
+        // only to mirror `MIFrame.execute_varargs(pure=True)`'s handling of all
         // pure shapes — skip the stamp for void.
         majit_ir::Type::Void => return,
     };
@@ -6458,7 +6458,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
             .trace_ctx
             .record_op_with_descr(call_opcode, &allboxes, descr.clone());
 
-        // pyjitpl.py `_record_helper_pure` parity: for
+        // `MIFrame.execute_varargs(pure=True)` parity: for
         // `CallPure*` whose every argbox carries a known `box_value`,
         // execute the helper now and stamp `recorded` with the result so
         // downstream walker chain (sub-jitcode bodies that consume the
@@ -7651,7 +7651,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
             .trace_ctx
             .record_op_with_descr(call_opcode, &allboxes, descr.clone());
 
-        // pyjitpl.py `_record_helper_pure` parity — see
+        // `MIFrame.execute_varargs(pure=True)` parity — see
         // `dispatch_residual_call_iRd_kind` for the upstream walk.
         try_fold_pure_call_via_executor(ctx, call_opcode, &allboxes, call_descr, recorded);
 
@@ -7890,7 +7890,7 @@ pub(crate) fn dispatch_residual_call_iIRFd_kind<Sym: WalkSym>(
             .trace_ctx
             .record_op_with_descr(call_opcode, &allboxes, descr.clone());
 
-        // pyjitpl.py `_record_helper_pure` parity — see
+        // `MIFrame.execute_varargs(pure=True)` parity — see
         // `dispatch_residual_call_iRd_kind` for the upstream walk.
         try_fold_pure_call_via_executor(ctx, call_opcode, &allboxes, call_descr, recorded);
         // `boxes3`-shaped may-force residual (`CallMayForce{R,I,F,N}`):

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -1036,7 +1036,16 @@ fn a_nonstandard_vable_array_access_does_not_promote_the_index() {
         );
         // A different frame: `_nonstandard_virtualizable` reaches its Step 4
         // PTR_EQ, reads unequal, and takes the non-standard branch.
-        let vable = tc.const_ref(2);
+        //
+        // It must NOT be a `ConstPtr`. Step 4 runs its PTR_EQ through
+        // `execute_and_record`, so a constant on both sides folds the
+        // comparison away and mints no guard — which would leave the
+        // `num_guards() > guards_before` line below measuring nothing. A
+        // virtualizable in a register is a recorded box in production anyway;
+        // the concrete pointer arrives from the frame's ref values, not from
+        // the box being constant.
+        let vable = OpRef::input_arg_ref(0);
+        tc.set_opref_concrete(vable, Value::Ref(majit_ir::GcRef(2)));
         // A non-constant index carrying a recording-time concrete — the only
         // shape for which the promote is not already a no-op.
         let zero = tc.const_int(0);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -172,16 +172,20 @@ pub(crate) fn getfield_vable_via_metainterp<Sym: WalkSym>(
         ConcreteValue::Int(_) | ConcreteValue::Float(_) | ConcreteValue::Bool(_) => 0,
     };
     let guards_before = ctx.trace_ctx.num_guards();
+    // The cpu the read folds through has to be the one the MetaInterp stamps
+    // with, or the trace and the optimizer could disagree about the constant;
+    // `trace.rs` installs this same `shared()` handle via `set_cpu`.
+    let cpu = crate::pyre_cpu::shared();
     let (result, shadow_value) = match dst_bank {
         'i' => ctx
             .trace_ctx
-            .vable_getfield_int(pc, obj, vable_struct_ptr, descr),
+            .vable_getfield_int(cpu.as_ref(), pc, obj, vable_struct_ptr, descr),
         'r' => ctx
             .trace_ctx
-            .vable_getfield_ref(pc, obj, vable_struct_ptr, descr),
+            .vable_getfield_ref(cpu.as_ref(), pc, obj, vable_struct_ptr, descr),
         'f' => ctx
             .trace_ctx
-            .vable_getfield_float(pc, obj, vable_struct_ptr, descr),
+            .vable_getfield_float(cpu.as_ref(), pc, obj, vable_struct_ptr, descr),
         _ => unreachable!("dst_bank must be 'i', 'r' or 'f'"),
     };
     walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before, None)?;
@@ -1001,9 +1005,15 @@ pub(crate) fn arraylen_vable_via_metainterp<Sym: WalkSym>(
     };
     let (fdescr, adescr) = vable_array_descrs_from_jitcode(code, op, 1, 3, ctx)?;
     let guards_before = ctx.trace_ctx.num_guards();
-    let result = ctx
-        .trace_ctx
-        .vable_arraylen_vable(op.pc, vable, vable_struct_ptr, fdescr, adescr);
+    let cpu = crate::pyre_cpu::shared();
+    let result = ctx.trace_ctx.vable_arraylen_vable(
+        cpu.as_ref(),
+        op.pc,
+        vable,
+        vable_struct_ptr,
+        fdescr,
+        adescr,
+    );
     walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before, None)?;
     let dst = code[op.pc + 6] as usize;
     let concrete_for_shadow = concrete_from_recorded_opref(ctx, result);


### PR DESCRIPTION
Ports `MetaInterp.execute_and_record` — RPython's fold-or-record funnel — and routes the tracer's hand-open-coded record sites through it.

## The funnel

`TraceCtx::execute_and_record(cpu, opnum, descr, args, resvalue, last_exc_value)` folds when the operation is pure for its descr (or is an OVF opcode with no pending exception), every argument is constant, and a `resvalue` is available; otherwise it records. Three rules the port fixes in place:

- **D2** — `resvalue: None` never folds, always records, never stamps. A caller that could not compute the value has no register to receive a constant either.
- **D3** — the folded value comes from `executor::execute_*_const`, the stamp from the caller's `resvalue`. A declining evaluator (divide by zero, out-of-range shift, non-finite cast) records rather than letting the trace and the optimizer disagree about what a constant is.
- `is_pure_with_descr` is structurally first. `_all_constants` is vacuously true for a zero-argument operation, so dropping that test in favour of an arguments-only one would delete every `New`, `ForceToken` and `LeavePortalFrame` from the trace.

`cpu` is `Option<&dyn Cpu>`. `None` states that the call cannot reach a fold rather than standing in for a reader — `SETFIELD_GC`, `SETARRAYITEM_GC`, `GETARRAYITEM_GC_*`, `ASSERT_NOT_NONE` and `RECORD_EXACT_CLASS` all answer `is_pure_with_descr` false, and a caller with no `resvalue` is closed by D2. A `debug_assert` refuses `None` from a call that could otherwise have folded.

## Routed sites

The always-pure dispatch arms, the `getfield_gc` arms, `opimpl_arraylen_gc`, the resume-decode `INT_ADD`s, `BC_RAW_LOAD_I/_F`, the two virtualizable `PTR_EQ` sites, and — in the last two commits — every remaining virtualizable read and write leg: `gen_store_back_in_vable`, `emit_force_virtualizable`, `vable_setfield`, `nonstandard_vable_array_base`, `trace_assert_not_none`, `trace_record_exact_class`, the `vable_getfield_{int,ref,float}` family, the six `vable_getarrayitem_*` legs and their three `_descr` helpers, `execute_setarrayitem_gc`, and `vable_arraylen_vable`.

`emit_force_virtualizable`'s `COND_CALL_N` deliberately stays off the funnel and says why: it is inside the can-raise range, which belongs to `execute_and_record_varargs`.

Where a leg both stamps a live load and can fold it, the `majit_backend::model::Cpu` is threaded in as a parameter — the shape `trace_arraylen_gc` already used. It is a separate trait from the `majit_backend::Backend` that `field_sanity_load` reads through, with no supertrait relation, so a `TraceCtx` method that does both needs both handles.

## Also in this branch

- `MIFrame._establish_nullity`: the ptr-nullity branches guard the box itself with `GUARD_NONNULL` / `GUARD_ISNULL` instead of comparing it against a null constant under a `GUARD_TRUE`, honour `is_class_known`, and do the null-arm `replace_box`.
- `BC_GOTO_IF_NOT_INT_IS_TRUE` split out, with `opimpl_goto_if_not`'s tail (`if replace: replace_box`) finished.
- `implement_guard_value`'s `Const` short-circuit and `HeapCache::_get_deps`'s missing `isinstance` guard.
- `OpCode::is_pure_with_descr`, and corrections to the `_record_helper_pure` citations that pointed at the wrong upstream symbol.

## Verification

- `cargo test -p majit-metainterp --no-default-features --features dynasm` — 1864 passed, 0 failed. `cargo test -p majit-trace --lib` — 67 passed.
- aheui logo: exit 42, 996310 bytes, md5 `7fcdbfff0af449c4283c008e3ca317ce`, `--jit` output byte-identical to `--no-jit`.
- aheui metacircular (`aheui.aheui` running 99bottles): exit 99, 11782 bytes, byte-identical to the reference output.

⚠️ `pyre/check.py` could not be run locally — the tree's `cargo check --workspace` fails with `LLBC STALE` for `majit-rlib` / `pyre-object` / `pyre-interpreter` / `pyre-jit` in `pyre-jit-trace`'s build script. The op census and `.jitstats` comparison are therefore CI-only for this branch.

⚠️ aheui never emits `BC_GOTO_IF_NOT_PTR_*` — no ptr-nullity lowering exists in `majit-macros`; only `pyre/pyre-jit/src/jit/assembler.rs` emits them. The byte-identity gates above do **not** exercise the `_establish_nullity` port; its three unit tests and CI carry it.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved trace recording and constant folding across arithmetic, comparisons, casts, field loads, arrays, and array lengths.
  - Preserved immutable-field and pure array-read metadata.
  - Improved reference handling during trace snapshots and resumption.
  - Added enhanced lowering for integer division and modulo operations.

- **Bug Fixes**
  - Prevented incorrect results from narrow integer and pointer-returning calls.
  - Added safe handling for resume-data capacity limits and overflow conditions.
  - Fixed optimizer behavior for constants, nullity checks, and overflowing operations.

- **Validation**
  - Added checks for conflicting call declarations and expanded tracing, folding, dispatch, and guard coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->