### PR TITLE
cpyext: load an extension as its header describes it; and the stdlib gaps cffi's and trio's own suites found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3241,7 +3241,7 @@ dependencies = [
 [[package]]
 name = "rustpython-codegen"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=dd2cc4d77a625661e5ca189f1cf9be199ecaa434#dd2cc4d77a625661e5ca189f1cf9be199ecaa434"
+source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
 dependencies = [
  "bitflags 2.13.0",
  "indexmap",
@@ -3264,7 +3264,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=dd2cc4d77a625661e5ca189f1cf9be199ecaa434#dd2cc4d77a625661e5ca189f1cf9be199ecaa434"
+source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
 dependencies = [
  "ascii",
  "bitflags 2.13.0",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=dd2cc4d77a625661e5ca189f1cf9be199ecaa434#dd2cc4d77a625661e5ca189f1cf9be199ecaa434"
+source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
@@ -3301,7 +3301,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=dd2cc4d77a625661e5ca189f1cf9be199ecaa434#dd2cc4d77a625661e5ca189f1cf9be199ecaa434"
+source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
 dependencies = [
  "bitflags 2.13.0",
  "bitflagset",
@@ -3317,7 +3317,7 @@ dependencies = [
 [[package]]
 name = "rustpython-host_env"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=dd2cc4d77a625661e5ca189f1cf9be199ecaa434#dd2cc4d77a625661e5ca189f1cf9be199ecaa434"
+source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
 dependencies = [
  "bitflags 2.13.0",
  "cc",
@@ -3351,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=dd2cc4d77a625661e5ca189f1cf9be199ecaa434#dd2cc4d77a625661e5ca189f1cf9be199ecaa434"
+source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
 dependencies = [
  "hexf-parse",
  "is-macro",
@@ -3430,7 +3430,7 @@ dependencies = [
 [[package]]
 name = "rustpython-sre_engine"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=dd2cc4d77a625661e5ca189f1cf9be199ecaa434#dd2cc4d77a625661e5ca189f1cf9be199ecaa434"
+source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
 dependencies = [
  "bitflags 2.13.0",
  "num_enum",
@@ -3442,7 +3442,7 @@ dependencies = [
 [[package]]
 name = "rustpython-unicode"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=dd2cc4d77a625661e5ca189f1cf9be199ecaa434#dd2cc4d77a625661e5ca189f1cf9be199ecaa434"
+source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
 dependencies = [
  "icu_casemap",
  "icu_locale",
@@ -3456,7 +3456,7 @@ dependencies = [
 [[package]]
 name = "rustpython-wtf8"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=dd2cc4d77a625661e5ca189f1cf9be199ecaa434#dd2cc4d77a625661e5ca189f1cf9be199ecaa434"
+source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
 dependencies = [
  "ascii",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,16 +72,16 @@ pyrex = { version = "0.0.2", path = "pyre/pyrex" }
 # parity fixes from #8550 were merged.  `fix_code_filenames` needs `IndexMut`
 # to edit nested code constants in place, and `loads` relies on the #8552 hook
 # to preserve invalid code bytes, so this pin must not move below either.
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "dd2cc4d77a625661e5ca189f1cf9be199ecaa434" }
-rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "dd2cc4d77a625661e5ca189f1cf9be199ecaa434" }
-rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "dd2cc4d77a625661e5ca189f1cf9be199ecaa434" }
-rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "dd2cc4d77a625661e5ca189f1cf9be199ecaa434" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
+rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
+rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
+rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
 ruff-text-size = { package = "rustpython-ruff_text_size", git = "https://github.com/RustPython/ruff.git", tag = "0.15.19-rustpython" }
 num-complex = "0.4"
-rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "dd2cc4d77a625661e5ca189f1cf9be199ecaa434" }
-rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "dd2cc4d77a625661e5ca189f1cf9be199ecaa434" }
-rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "dd2cc4d77a625661e5ca189f1cf9be199ecaa434" }
-sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "dd2cc4d77a625661e5ca189f1cf9be199ecaa434" }
+rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
+rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
+rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
+sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
 
 # majit JIT framework
 majit = { version = "0.0.2", path = "majit/majit" }

--- a/include/pyre3.14t/listobject.h
+++ b/include/pyre3.14t/listobject.h
@@ -12,8 +12,15 @@ extern "C" {
 #endif
 /* list. */
 
+/* Each is exported as well as spelled here, for the reason `Py_TYPE` is: a
+   caller that declares the prototype itself rather than including this header
+   still has to find a symbol.  The declaration comes before the macro that
+   replaces it. */
+PyAPI_FUNC(Py_ssize_t) PyList_GET_SIZE(PyObject *);
 #define PyList_GET_SIZE(ob) PyList_Size((PyObject *)(ob))
+PyAPI_FUNC(PyObject *) PyList_GET_ITEM(PyObject *, Py_ssize_t);
 #define PyList_GET_ITEM(ob, i) PyList_GetItem((PyObject *)(ob), (i))
+PyAPI_FUNC(void) PyList_SET_ITEM(PyObject *, Py_ssize_t, PyObject *);
 #define PyList_SET_ITEM(ob, i, v) ((void)PyList_SetItem((PyObject *)(ob), (i), (v)))
 
 #ifdef __cplusplus

--- a/include/pyre3.14t/lock.h
+++ b/include/pyre3.14t/lock.h
@@ -53,6 +53,15 @@ _PyMutex_IsLocked(PyMutex *m)
 }
 #define PyMutex_IsLocked _PyMutex_IsLocked
 
+/* The two words a critical section occupies, which the caller embeds.  Nothing
+   the macros below expand to names one -- they open a plain block -- but an
+   extension that calls `PyCriticalSection_Begin` directly allocates the struct
+   itself, so its size has to be the reference one. */
+typedef struct PyCriticalSection {
+    uintptr_t _cs_prev;   /* (private) */
+    PyMutex *_cs_mutex;   /* (private) */
+} PyCriticalSection;
+
 /* A critical section serializes the operations that name the same object.
    Here every Python thread runs under one global lock, which already gives
    that ordering, so entering one costs nothing and the macros are the braces

--- a/include/pyre3.14t/moduleobject.h
+++ b/include/pyre3.14t/moduleobject.h
@@ -49,7 +49,7 @@ struct PyModuleDef {
 };
 
 #define PyModuleDef_HEAD_INIT \
-    { { 1, 0, 0, NULL }, NULL, 0, NULL }
+    { { 1, 0, NULL }, NULL, 0, NULL }
 
 #define PyModule_Create(module) PyModule_Create2((module), PYTHON_API_VERSION)
 

--- a/include/pyre3.14t/moduleobject.h
+++ b/include/pyre3.14t/moduleobject.h
@@ -49,7 +49,7 @@ struct PyModuleDef {
 };
 
 #define PyModuleDef_HEAD_INIT \
-    { { 1, 0, NULL }, NULL, 0, NULL }
+    { { 1, 0, 0, NULL }, NULL, 0, NULL }
 
 #define PyModule_Create(module) PyModule_Create2((module), PYTHON_API_VERSION)
 

--- a/include/pyre3.14t/object.h
+++ b/include/pyre3.14t/object.h
@@ -29,6 +29,9 @@ struct _object {
    way `lock.h` declares `PyMutex_Lock` ahead of its own inline fast path. */
 PyAPI_FUNC(PyTypeObject *) Py_TYPE(PyObject *);
 #define Py_TYPE(ob) (((PyObject *)(ob))->ob_type)
+
+/* Exported as well as spelled here, for the reason `Py_TYPE` is. */
+PyAPI_FUNC(int) Py_IS_TYPE(PyObject *, PyTypeObject *);
 #define Py_IS_TYPE(ob, type) (Py_TYPE(ob) == (type))
 /* bpo-39573: writing `ob_type` and `ob_size` goes through these. */
 #define Py_SET_TYPE(ob, type) ((void)(Py_TYPE(ob) = (type)))
@@ -318,6 +321,27 @@ struct PyType_Spec {
     unsigned int flags;
     PyType_Slot *slots;
 };
+
+/* `PySlot` — one entry of the identifier-keyed array `PyType_FromSlots` reads,
+   which carries what a `PyType_Spec`'s fixed fields carry and points at a
+   `PyType_Slot` array for the rest.  A zero `sl_id` ends the array. */
+struct PySlot {
+    uint16_t sl_id;
+    uint16_t sl_flags;
+    uint32_t sl_reserved;
+    union {
+        void *sl_ptr;
+        void (*sl_func)(void);
+        Py_ssize_t sl_size;
+        int64_t sl_int64;
+        uint64_t sl_uint64;
+    };
+};
+
+/* `PySlot.sl_flags`. */
+#define PySlot_OPTIONAL 0x01
+#define PySlot_STATIC 0x02
+#define PySlot_INTPTR 0x04
 
 /* `PyType_GetModuleByDef` needs `PyModuleDef`, so it is declared with it. */
 

--- a/include/pyre3.14t/object.h
+++ b/include/pyre3.14t/object.h
@@ -22,6 +22,12 @@ struct _object {
 #define PyObject_HEAD PyObject ob_base;
 #define PyObject_HEAD_INIT(type) { 0, 0, type },
 #define Py_REFCNT(ob) (((PyObject *)(ob))->ob_refcnt)
+
+/* `Py_TYPE` is exported as well as spelled here, because an extension that
+   declares the prototype itself rather than including this header still has to
+   find a symbol.  The declaration comes before the macro that replaces it, the
+   way `lock.h` declares `PyMutex_Lock` ahead of its own inline fast path. */
+PyAPI_FUNC(PyTypeObject *) Py_TYPE(PyObject *);
 #define Py_TYPE(ob) (((PyObject *)(ob))->ob_type)
 #define Py_IS_TYPE(ob, type) (Py_TYPE(ob) == (type))
 /* bpo-39573: writing `ob_type` and `ob_size` goes through these. */

--- a/include/pyre3.14t/pyre_decl.h
+++ b/include/pyre3.14t/pyre_decl.h
@@ -179,6 +179,7 @@ PyAPI_FUNC(void) PyException_SetArgs(PyObject *, PyObject *);
 PyAPI_FUNC(void) PyException_SetCause(PyObject *, PyObject *);
 PyAPI_FUNC(void) PyException_SetContext(PyObject *, PyObject *);
 PyAPI_FUNC(int) PyException_SetTraceback(PyObject *, PyObject *);
+PyAPI_FUNC(PyObject *) PyUnicodeDecodeError_Create(const char *, const char *, Py_ssize_t, Py_ssize_t, Py_ssize_t, const char *);
 
 /* cpyext/floatobject.rs */
 PyAPI_FUNC(double) PyFloat_AS_DOUBLE(PyObject *);
@@ -254,6 +255,8 @@ PyAPI_FUNC(Py_ssize_t) PyList_Size(PyObject *);
 PyAPI_FUNC(int) PyList_Sort(PyObject *);
 
 /* cpyext/lock.rs */
+PyAPI_FUNC(void) PyCriticalSection_Begin(PyCriticalSection *, PyObject *);
+PyAPI_FUNC(void) PyCriticalSection_End(PyCriticalSection *);
 PyAPI_FUNC(int) PyThread_acquire_lock(PyThread_type_lock, int);
 PyAPI_FUNC(PyLockStatus) PyThread_acquire_lock_timed(PyThread_type_lock, PY_TIMEOUT_T, int);
 PyAPI_FUNC(PyThread_type_lock) PyThread_allocate_lock(void);
@@ -496,6 +499,7 @@ PyAPI_FUNC(void) PyErr_SetObject(PyObject *, PyObject *);
 PyAPI_FUNC(void) PyErr_SetRaisedException(PyObject *);
 PyAPI_FUNC(void) PyErr_SetString(PyObject *, const char *);
 PyAPI_FUNC(void) PyErr_WriteUnraisable(PyObject *);
+PyAPI_FUNC(int) PyTraceBack_Print(PyObject *, PyObject *);
 PyAPI_FUNC(void) _PyErr_BadInternalCall(const char *, int);
 PyAPI_FUNC(void) _PyErr_ChainExceptions1(PyObject *);
 PyAPI_FUNC(void) _PyPyre_WriteUnraisable(PyObject *, PyObject *);
@@ -515,6 +519,8 @@ PyAPI_FUNC(void *) PyMem_Realloc(void *, size_t);
 PyAPI_FUNC(void) Py_DecRef(PyObject *);
 PyAPI_FUNC(void) Py_IncRef(PyObject *);
 PyAPI_FUNC(Py_ssize_t) _PyPyre_RefCount(PyObject *);
+PyAPI_FUNC(void) _Py_DecRef(PyObject *);
+PyAPI_FUNC(void) _Py_IncRef(PyObject *);
 PyAPI_FUNC(void) _Py_SetRefcnt(PyObject *, Py_ssize_t);
 
 /* cpyext/pystate.rs */
@@ -543,6 +549,10 @@ PyAPI_FUNC(PyThreadState *) _PyThreadState_UncheckedGet(void);
 
 /* cpyext/pystrtod.rs */
 PyAPI_FUNC(double) PyOS_string_to_double(const char *, char **, PyObject *);
+
+/* cpyext/pythonrun.rs */
+PyAPI_FUNC(int) Py_IsFinalizing(void);
+PyAPI_FUNC(int) Py_IsInitialized(void);
 
 /* cpyext/sequence.rs */
 PyAPI_FUNC(int) PySequence_Check(PyObject *);

--- a/include/pyre3.14t/pyre_decl.h
+++ b/include/pyre3.14t/pyre_decl.h
@@ -610,6 +610,7 @@ PyAPI_FUNC(PyObject *) PySys_GetObject(const char *);
 /* cpyext/tupleobject.rs */
 PyAPI_FUNC(int) PyTuple_Check(PyObject *);
 PyAPI_FUNC(int) PyTuple_CheckExact(PyObject *);
+PyAPI_FUNC(PyObject *) PyTuple_FromArray(PyObject *const *, Py_ssize_t);
 PyAPI_FUNC(PyObject *) PyTuple_GetItem(PyObject *, Py_ssize_t);
 PyAPI_FUNC(PyObject *) PyTuple_GetSlice(PyObject *, Py_ssize_t, Py_ssize_t);
 PyAPI_FUNC(PyObject *) PyTuple_New(Py_ssize_t);
@@ -632,6 +633,7 @@ PyAPI_FUNC(unsigned int) PyType_ClearCache(void);
 PyAPI_FUNC(int) PyType_Freeze(PyTypeObject *);
 PyAPI_FUNC(PyObject *) PyType_FromMetaclass(PyTypeObject *, PyObject *, PyType_Spec *, PyObject *);
 PyAPI_FUNC(PyObject *) PyType_FromModuleAndSpec(PyObject *, PyType_Spec *, PyObject *);
+PyAPI_FUNC(PyObject *) PyType_FromSlots(PySlot *);
 PyAPI_FUNC(PyObject *) PyType_FromSpec(PyType_Spec *);
 PyAPI_FUNC(PyObject *) PyType_FromSpecWithBases(PyType_Spec *, PyObject *);
 PyAPI_FUNC(PyObject *) PyType_GenericAlloc(PyTypeObject *, Py_ssize_t);

--- a/include/pyre3.14t/pytypedefs.h
+++ b/include/pyre3.14t/pytypedefs.h
@@ -35,6 +35,7 @@ typedef struct PyMemberDef PyMemberDef;
 typedef struct PyGetSetDef PyGetSetDef;
 typedef struct PyType_Slot PyType_Slot;
 typedef struct PyType_Spec PyType_Spec;
+typedef struct PySlot PySlot;
 typedef struct Py_buffer Py_buffer;
 /* Neither an `int` nor a `str` is a distinct object here, so the reference
    header's `PyLongObject` and `PyUnicodeObject` are the ordinary mirror under

--- a/pyre/cpython_tests/README.md
+++ b/pyre/cpython_tests/README.md
@@ -133,11 +133,12 @@ first:
    fails when `support` isn't already an attribute; IMPORT_FROM must fall back
    to importing the submodule. Also `from unittest import mock`
    (`unittest.mock` submodule).
-2. **Compiler gap (external `rustpython-codegen`): `class_decorator` symbol
-   missing from the symbol table** — `compile error: the symbol
-   'class_decorator' must be present in the symbol table` (hit by
-   `test_grammar`). Lives in the git-pinned compiler dependency, not pyre's
-   tree.
+2. **Compile-time `SyntaxWarning` is never raised.** `test_grammar` fails 16
+   assertions across `test_assert_syntax_warnings`,
+   `test_assert_warning_promotes_to_syntax_error`,
+   `test_comparison_is_literal`, `test_end_of_numerical_literals`,
+   `test_former_statements_refer_to_builtins` and `test_warn_missed_comma` —
+   every one of them waits for a warning the compiler does not emit.
 3. **Assorted stdlib-compat gaps** surfaced per module (e.g. `datetime.date`,
    `genericpath._splitext`, `typing`'s `_idfunc`, complex `re` patterns). Run
    `--full --report` to enumerate the current set.

--- a/pyre/extra_tests/parity_tests/ast_type_comments.py
+++ b/pyre/extra_tests/parity_tests/ast_type_comments.py
@@ -1,0 +1,139 @@
+# CPython-suite gap: test_type_comments is not in the gated set, and nothing
+# else in the suite passes `type_comments=True`, so a parse that accepts the
+# flag and collects nothing looks exactly like one that works.
+# parity-tests reason: pyre took the flag, parsed, and returned a tree whose
+# `type_comment` was None everywhere and whose `type_ignores` was empty. The
+# comments never reached the tree because the parser's token list was dropped.
+
+# pyre-check: pypy-diverges: pypy3 collects `type_comment` but rejects a
+# `# type: ignore` line outright with `SyntaxError: invalid syntax`.
+
+import ast
+
+
+def parse(src):
+    return ast.parse(src, type_comments=True)
+
+
+def comments(src):
+    """Every node that carries a type comment, as (class, lineno, text)."""
+    found = [
+        (type(n).__name__, getattr(n, "lineno", None), n.type_comment)
+        for n in ast.walk(parse(src))
+        if getattr(n, "type_comment", None) is not None
+    ]
+    return sorted(found, key=lambda row: (row[1] or 0, row[0], row[2]))
+
+
+def ignores(src):
+    return [(i.lineno, i.tag) for i in parse(src).type_ignores]
+
+
+# `lexer.c` matches the comment against `"# type: "`, where each space in the
+# pattern stands for any run of spaces and tabs.
+assert comments("x = 1  # type: int\n") == [("Assign", 1, "int")]
+assert comments("x = 1  #type:int\n") == [("Assign", 1, "int")]
+assert comments("x = 1  #\ttype:\tint\n") == [("Assign", 1, "int")]
+# The trailing space matches an empty run, so a bare `# type:` still counts.
+assert comments("x = 1  # type:\n") == [("Assign", 1, "")]
+# What follows the prefix is taken verbatim, trailing spaces and all, and a
+# second `# type:` inside it is just more text.
+assert comments("x = 1  # type: int   \n") == [("Assign", 1, "int   ")]
+assert comments("x = 1  # type: int  # type: str\n") == [
+    ("Assign", 1, "int  # type: str")
+]
+# An ordinary comment stays ordinary, and one inside a string is not a comment.
+assert comments("x = 1  # ordinary\n") == []
+assert comments("x = '# type: int'\n") == []
+
+# The grammar takes a type comment after an assignment's value — through a
+# parenthesised value that ends on a later line, and at any nesting.
+assert comments("x = y = 1  # type: int\n") == [("Assign", 1, "int")]
+assert comments("x = (\n    1\n)  # type: int\n") == [("Assign", 1, "int")]
+assert comments("if 1:\n    x = 1  # type: int\n") == [("Assign", 2, "int")]
+assert comments("class C:\n    x = 1  # type: int\n") == [("Assign", 2, "int")]
+assert comments("while 1:\n    x = 1  # type: int\n") == [("Assign", 2, "int")]
+assert comments("try:\n    x = 1  # type: int\nexcept E:\n    y = 2  # type: str\n") == [
+    ("Assign", 2, "int"),
+    ("Assign", 4, "str"),
+]
+
+# ...after the colon of a `for`, a `with` or a `def`, including the async
+# spellings, which are separate classes in the tree.
+assert comments("for i in []:  # type: int\n    pass\n") == [("For", 1, "int")]
+assert comments("with open('f') as g:  # type: IO\n    pass\n") == [("With", 1, "IO")]
+assert comments("with a as b, c as d:  # type: IO\n    pass\n") == [("With", 1, "IO")]
+assert comments("def f(a, b):  # type: (int, str) -> None\n    pass\n") == [
+    ("FunctionDef", 1, "(int, str) -> None")
+]
+assert comments("def f(a) -> int:  # type: (int) -> int\n    pass\n") == [
+    ("FunctionDef", 1, "(int) -> int")
+]
+# A function's comment may also stand on its own line before the body.
+assert comments("def f(a):\n    # type: (int) -> int\n    pass\n") == [
+    ("FunctionDef", 1, "(int) -> int")
+]
+assert comments("async def g(a):  # type: (int) -> None\n    pass\n") == [
+    ("AsyncFunctionDef", 1, "(int) -> None")
+]
+assert comments("async def g():\n    async for i in []:  # type: int\n        pass\n") == [
+    ("AsyncFor", 2, "int")
+]
+assert comments("async def g():\n    async with a as b:  # type: IO\n        pass\n") == [
+    ("AsyncWith", 2, "IO")
+]
+
+# ...and after a parameter's comma, which is a different span from the
+# function's own: one is inside the parentheses and one is past them.
+assert comments("def f(\n    a,  # type: int\n    b,  # type: str\n):\n    pass\n") == [
+    ("arg", 2, "int"),
+    ("arg", 3, "str"),
+]
+assert comments("def f(\n    a=1,  # type: int\n):\n    pass\n") == [("arg", 2, "int")]
+assert comments("def f(\n    *args,  # type: int\n    **kw,  # type: str\n):\n    pass\n") == [
+    ("arg", 2, "int"),
+    ("arg", 3, "str"),
+]
+assert comments(
+    "def f(\n    a,  # type: int\n):\n    # type: (int) -> None\n    pass\n"
+) == [("FunctionDef", 1, "(int) -> None"), ("arg", 2, "int")]
+
+# `# type: ignore` is the word `ignore` followed by the end of the comment or
+# by an ASCII byte that is not alphanumeric.  `_` and `-` qualify; a letter
+# does not, and neither does a non-ASCII byte.
+assert ignores("x = 1  # type: ignore[foo]\n") == [(1, "[foo]")]
+assert ignores("x = 1  # type: ignore_foo\n") == [(1, "_foo")]
+assert ignores("x = 1  # type: ignore-foo\n") == [(1, "-foo")]
+assert ignores("x = 1  # type:  ignore  extra\n") == [(1, "  extra")]
+assert ignores("x = 1  # type: ignorexyz\n") == []
+assert comments("x = 1  # type: ignorexyz\n") == [("Assign", 1, "ignorexyz")]
+assert ignores("x = 1  # type: ignore\u00e4\n") == []
+# An ignore that stands alone on its line takes the line break with it.
+assert ignores("# type: ignore\nx = 1\n") == [(1, "\n")]
+assert ignores("# type: ignore  extra\nx = 1\n") == [(1, "  extra\n")]
+assert ignores("# type: ignore\n# type: ignore[a]\nx = 1\n") == [(1, "\n"), (2, "[a]\n")]
+assert ignores("def f():\n    # type: ignore\n    pass\n") == [(2, "\n")]
+# One sharing its line with code does not.
+assert ignores("def f(a):  # type: ignore\n    pass\n") == [(1, "")]
+
+# The two kinds are collected from one pass over the same comments.
+mixed = "# type: ignore\nx = 1  # type: int\nfor i in []:  # type: str\n    pass\n"
+assert ignores(mixed) == [(1, "\n")]
+assert comments(mixed) == [("Assign", 2, "int"), ("For", 3, "str")]
+
+# Without the flag nothing is collected, and the flag does not change the tree
+# it is collected from.
+plain = ast.parse(mixed)
+assert plain.type_ignores == []
+assert [n.type_comment for n in ast.walk(plain) if hasattr(n, "type_comment")] == [
+    None,
+    None,
+]
+assert ast.dump(plain) != ast.dump(parse(mixed))
+
+# Not covered here: CPython rejects a type comment the grammar has no place
+# for — `x += 1  # type: int` and `f()  # type: int` are both
+# `SyntaxError` there — and pyre accepts them and attaches nothing.  That is a
+# narrower gap than dropping every comment, and it is left open.
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/compile_flag_and_symtable_constants.py
+++ b/pyre/extra_tests/parity_tests/compile_flag_and_symtable_constants.py
@@ -1,0 +1,71 @@
+# CPython-suite gap: test_ast and test_symtable use these constants through the
+# module that publishes them, so both sides of a comparison move together and
+# a wrong number is invisible.
+# parity-tests reason: `ast.PyCF_TYPE_COMMENTS` carried `0x40000000` and
+# `_symtable.DEF_BOUND` carried an extra `DEF_TYPE_PARAM` bit; both are
+# documented numbers a caller can spell for itself.
+
+# pyre-check: pypy-diverges: pypy3 has no `_symtable` at all, and `consts.py`
+# keeps `PyCF_ASYNC_HACKS` on `0x1000` so it moves `PyCF_TYPE_COMMENTS` out to
+# `0x40000000`; 3.14 has no `PyCF_ASYNC_HACKS`.
+
+import ast
+import symtable
+import _symtable
+
+# `Include/cpython/compile.h`.  The whole `PyCF_*` set is bits 0x0100..0x10000.
+assert ast.PyCF_ONLY_AST == 0x0400, hex(ast.PyCF_ONLY_AST)
+assert ast.PyCF_TYPE_COMMENTS == 0x1000, hex(ast.PyCF_TYPE_COMMENTS)
+assert ast.PyCF_ALLOW_TOP_LEVEL_AWAIT == 0x2000, hex(ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
+assert ast.PyCF_OPTIMIZED_AST == 0x8000 | ast.PyCF_ONLY_AST, hex(ast.PyCF_OPTIMIZED_AST)
+
+# The number has to keep working as the flag it names: `compile()` takes it,
+# and rejects the one it used to be.  What the flag then *collects* is a
+# separate and still-open gap — pyre's parser does not surface type comments,
+# so `ast.parse(type_comments=True)` leaves `type_ignores` empty and every
+# `type_comment` None where 3.14 fills both — and nothing here asserts it.
+tree = compile(
+    "x = 1  # type: int\n",
+    "<s>",
+    "exec",
+    flags=ast.PyCF_ONLY_AST | ast.PyCF_TYPE_COMMENTS,
+)
+assert isinstance(tree, ast.Module), tree
+
+try:
+    compile("x = 1\n", "<s>", "exec", flags=ast.PyCF_ONLY_AST | 0x4000_0000)
+except ValueError as e:
+    assert str(e) == "compile(): unrecognised flags", e
+else:
+    raise AssertionError("0x40000000 is not a compile flag")
+
+# `pycore_symtable.h`: DEF_BOUND is DEF_LOCAL | DEF_PARAM | DEF_IMPORT.
+assert _symtable.DEF_LOCAL == 2 << 0
+assert _symtable.DEF_PARAM == 2 << 1
+assert _symtable.DEF_IMPORT == 2 << 6
+assert _symtable.DEF_TYPE_PARAM == 2 << 9
+assert _symtable.DEF_BOUND == 134, _symtable.DEF_BOUND
+assert _symtable.DEF_BOUND == (
+    _symtable.DEF_LOCAL | _symtable.DEF_PARAM | _symtable.DEF_IMPORT
+)
+
+# `symtable.py` reads DEF_BOUND in `is_global` and `is_local`, and in both only
+# for a symbol in the module block.  DEF_TYPE_PARAM is set only on names inside
+# a `type parameters` block, so the bit that was dropped had no reader.
+top = symtable.symtable(
+    "type Alias[T] = list[T]\ndef f[U](x: U) -> U:\n    return x\n", "<s>", "exec"
+)
+assert top.get_type() == "module", top.get_type()
+assert [s.get_name() for s in top.get_symbols() if s.is_type_parameter()] == []
+blocks = {c.get_name(): c for c in top.get_children()}
+for owner, param in (("Alias", "T"), ("f", "U")):
+    block = blocks[owner]
+    assert block.get_type() == "type parameters", (owner, block.get_type())
+    sym = block.lookup(param)
+    assert sym.is_type_parameter(), owner
+    # It carries DEF_LOCAL as well, and its block is not the module block, so
+    # both readers answer from the scope rather than from the mask.
+    assert sym.is_assigned(), owner
+    assert sym.is_local() and not sym.is_global(), owner
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/compile_flag_and_symtable_constants.py
+++ b/pyre/extra_tests/parity_tests/compile_flag_and_symtable_constants.py
@@ -21,9 +21,7 @@ assert ast.PyCF_OPTIMIZED_AST == 0x8000 | ast.PyCF_ONLY_AST, hex(ast.PyCF_OPTIMI
 
 # The number has to keep working as the flag it names: `compile()` takes it,
 # and rejects the one it used to be.  What the flag then *collects* is a
-# separate and still-open gap — pyre's parser does not surface type comments,
-# so `ast.parse(type_comments=True)` leaves `type_ignores` empty and every
-# `type_comment` None where 3.14 fills both — and nothing here asserts it.
+# separate question, and `ast_type_comments.py` is where it is asserted.
 tree = compile(
     "x = 1  # type: int\n",
     "<s>",

--- a/pyre/extra_tests/parity_tests/darwin_module_constant_surface.py
+++ b/pyre/extra_tests/parity_tests/darwin_module_constant_surface.py
@@ -1,0 +1,163 @@
+# pyre-check: platforms=darwin
+# CPython-suite gap: the suite reads these constants only through the calls
+# that take them, and every such test skips when the name is absent, so a
+# missing name is silently green.
+# parity-tests reason: `socketmodule.c`, `mmapmodule.c`, `fcntlmodule.c`,
+# `posixmodule.c`, `signalmodule.c`, `syslogmodule.c`, `termios.c` and
+# `timemodule.c` publish every name the header defines, and 110 of darwin's
+# were absent here while `socket.IP_MAX_MEMBERSHIPS` carried linux's 20.
+
+# pyre-check: pypy-diverges: `platform.DefinedConstantInteger` reaches only the
+# names each `*_rffi.py` lists, and the darwin-only half of these is not in
+# those lists.
+
+# Every value below was read back from the SDK headers, not from an
+# interpreter: `<sys/fcntl.h>`, `<sys/mman.h>`, `<sys/resource.h>`,
+# `<copyfile.h>`, `<signal.h>`, `<sys/socket.h>`, `<netinet/in.h>`,
+# `<netinet/tcp.h>`, `<net/ethernet.h>`, `<sys/sys_domain.h>`, `<syslog.h>`,
+# `<sys/termios.h>` and `<time.h>`.
+
+import importlib
+
+EXPECTED = {
+    "fcntl": {
+        "FASYNC": 64,
+        "F_FULLFSYNC": 51,
+        "F_GETLEASE": 107,
+        "F_GETNOSIGPIPE": 74,
+        "F_GETPATH": 50,
+        "F_NOCACHE": 48,
+        "F_OFD_GETLK": 92,
+        "F_OFD_SETLK": 90,
+        "F_OFD_SETLKW": 91,
+        "F_RDAHEAD": 45,
+        "F_SETLEASE": 106,
+        "F_SETNOSIGPIPE": 73,
+    },
+    "mmap": {
+        "MADV_FREE": 5,
+        "MADV_FREE_REUSABLE": 7,
+        "MADV_FREE_REUSE": 8,
+        "MAP_32BIT": 32768,
+        "MAP_HASSEMAPHORE": 512,
+        "MAP_JIT": 2048,
+        "MAP_NOCACHE": 1024,
+        "MAP_NOEXTEND": 256,
+        "MAP_NORESERVE": 64,
+        "MAP_RESILIENT_CODESIGN": 8192,
+        "MAP_RESILIENT_MEDIA": 16384,
+        "MAP_TPRO": 524288,
+        "MAP_TRANSLATED_ALLOW_EXECUTE": 131072,
+        "MAP_UNIX03": 262144,
+    },
+    "posix": {
+        "NGROUPS_MAX": 16,
+        "PRIO_DARWIN_BG": 4096,
+        "PRIO_DARWIN_NONUI": 4097,
+        "PRIO_DARWIN_PROCESS": 4,
+        "PRIO_DARWIN_THREAD": 3,
+        "TMP_MAX": 308915776,
+        "_COPYFILE_ACL": 1,
+        "_COPYFILE_DATA": 8,
+        "_COPYFILE_STAT": 2,
+        "_COPYFILE_XATTR": 4,
+    },
+    "signal": {
+        "SIGEMT": 7,
+        "SIGINFO": 29,
+        "SIGIOT": 6,
+    },
+    "socket": {
+        "AF_APPLETALK": 16,
+        "AF_DECnet": 12,
+        "AF_IPX": 23,
+        "AF_LINK": 18,
+        "AF_SNA": 11,
+        "AF_SYSTEM": 32,
+        "ETHERTYPE_ARP": 2054,
+        "ETHERTYPE_IP": 2048,
+        "ETHERTYPE_IPV6": 34525,
+        "ETHERTYPE_VLAN": 33024,
+        "IPPROTO_EON": 80,
+        "IPPROTO_GGP": 3,
+        "IPPROTO_HELLO": 63,
+        "IPPROTO_IPCOMP": 108,
+        "IPPROTO_IPV4": 4,
+        "IPPROTO_ND": 77,
+        "IPPROTO_XTP": 36,
+        "IPV6_DONTFRAG": 62,
+        "IPV6_DSTOPTS": 50,
+        "IPV6_HOPOPTS": 49,
+        "IPV6_NEXTHOP": 48,
+        "IPV6_PATHMTU": 44,
+        "IPV6_RECVDSTOPTS": 40,
+        "IPV6_RECVHOPOPTS": 39,
+        "IPV6_RECVPATHMTU": 43,
+        "IPV6_RECVRTHDR": 38,
+        "IPV6_RTHDR": 51,
+        "IPV6_RTHDRDSTOPTS": 57,
+        "IPV6_RTHDR_TYPE_0": 0,
+        "IPV6_USE_MIN_MTU": 42,
+        "IP_ADD_SOURCE_MEMBERSHIP": 70,
+        "IP_BLOCK_SOURCE": 72,
+        "IP_DROP_SOURCE_MEMBERSHIP": 71,
+        "IP_MAX_MEMBERSHIPS": 4095,
+        "IP_OPTIONS": 1,
+        "IP_PKTINFO": 26,
+        "IP_RECVDSTADDR": 7,
+        "IP_RECVOPTS": 5,
+        "IP_RECVRETOPTS": 6,
+        "IP_RECVTOS": 27,
+        "IP_RECVTTL": 24,
+        "IP_RETOPTS": 8,
+        "IP_UNBLOCK_SOURCE": 73,
+        "LOCAL_PEERCRED": 1,
+        "MSG_EOF": 256,
+        "MSG_NOSIGNAL": 524288,
+        "PF_SYSTEM": 32,
+        "SCM_CREDS": 3,
+        "SO_BINDTODEVICE": 4404,
+        "SO_USELOOPBACK": 64,
+        "SYSPROTO_CONTROL": 2,
+        "TCP_CONNECTION_INFO": 262,
+        "TCP_FASTOPEN": 261,
+        "TCP_KEEPCNT": 258,
+        "TCP_KEEPINTVL": 257,
+        "TCP_NOTSENT_LOWAT": 513,
+    },
+    "syslog": {
+        "LOG_AUTHPRIV": 80,
+        "LOG_FTP": 88,
+        "LOG_INSTALL": 112,
+        "LOG_LAUNCHD": 192,
+        "LOG_NETINFO": 96,
+        "LOG_ODELAY": 4,
+        "LOG_RAS": 120,
+        "LOG_REMOTEAUTH": 104,
+    },
+    "termios": {
+        "_POSIX_VDISABLE": 255,
+    },
+    "time": {
+        "CLOCK_MONOTONIC_RAW": 4,
+        "CLOCK_MONOTONIC_RAW_APPROX": 5,
+        "CLOCK_UPTIME_RAW": 8,
+        "CLOCK_UPTIME_RAW_APPROX": 9,
+    },
+}
+
+for module_name, constants in EXPECTED.items():
+    module = importlib.import_module(module_name)
+    for name, value in constants.items():
+        assert hasattr(module, name), f"{module_name}.{name} is missing"
+        assert getattr(module, name) == value, (
+            f"{module_name}.{name} is {getattr(module, name)}, expected {value}"
+        )
+
+# `mmapmodule.c` publishes `PROT_READ`/`PROT_WRITE`/`PROT_EXEC` and no
+# `PROT_NONE`, so a module that answers to it is one name wide.
+import mmap
+
+assert not hasattr(mmap, "PROT_NONE")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/exception_repr_names_the_bare_class.py
+++ b/pyre/extra_tests/parity_tests/exception_repr_names_the_bare_class.py
@@ -1,0 +1,42 @@
+# CPython-suite gap: the suite's exception-repr coverage is in test_exceptions,
+# which only builds classes whose name has no module component, so nothing in
+# it distinguishes the registered name from the one `__name__` answers.
+# parity-tests reason: a module exception is registered under a dotted name and
+# pyre's `W_BaseException.descr_repr` read that name whole, so `repr` spelled
+# the module twice as often as `str(type(e))` does.
+
+# `pytest` prints `repr(excinfo.value)` in the one-line failure summary, and a
+# doctest that expects `error(...)` sees `struct.error(...)` instead.
+
+import binascii
+import struct
+import zlib
+
+for module, attribute in (
+    (struct, "error"),
+    (zlib, "error"),
+    (binascii, "Error"),
+    (binascii, "Incomplete"),
+):
+    cls = getattr(module, attribute)
+    # `__name__` never carried the module component; `repr` is the channel that
+    # disagreed with it.
+    assert cls.__name__ == attribute, (cls.__name__, attribute)
+    assert cls.__module__ == module.__name__, (cls.__module__, module.__name__)
+    assert str(cls) == "<class '%s.%s'>" % (module.__name__, attribute), str(cls)
+
+    instance = cls(19, "boom")
+    assert repr(instance) == "%s(19, 'boom')" % attribute, repr(instance)
+
+    # One argument takes no trailing comma, and none at all takes empty parens.
+    assert repr(cls("boom")) == "%s('boom')" % attribute, repr(cls("boom"))
+    assert repr(cls()) == "%s()" % attribute, repr(cls())
+
+# A class defined in Python keeps the name it was written with.
+class Plain(Exception):
+    pass
+
+
+assert repr(Plain(1)) == "Plain(1)", repr(Plain(1))
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/locale_langinfo_item_constants.py
+++ b/pyre/extra_tests/parity_tests/locale_langinfo_item_constants.py
@@ -1,0 +1,47 @@
+# CPython-suite gap: test__locale guards every `nl_langinfo` assertion behind
+# `hasattr(locale, name)`, so a module that publishes none of the item keys
+# skips the whole file.
+# parity-tests reason: `_locale.nl_langinfo` accepted any key, but 54 of the
+# 55 names `_localemodule.c langinfo_constants` publishes were absent, so the
+# only key that could be spelled was `CODESET`.
+
+# `<langinfo.h>` numbers the items per platform — the BSD headers count from
+# zero while glibc packs the category into the high bits — so the test reads
+# the numbers back from the module rather than pinning them, and checks the
+# key each name stands for by what `nl_langinfo` answers with.
+
+import locale
+
+NAMES = ["CODESET", "D_T_FMT", "D_FMT", "T_FMT", "T_FMT_AMPM", "AM_STR", "PM_STR"]
+NAMES += [f"DAY_{i}" for i in range(1, 8)]
+NAMES += [f"ABDAY_{i}" for i in range(1, 8)]
+NAMES += [f"MON_{i}" for i in range(1, 13)]
+NAMES += [f"ABMON_{i}" for i in range(1, 13)]
+NAMES += ["ERA", "ERA_D_FMT", "ERA_D_T_FMT", "ERA_T_FMT", "ALT_DIGITS"]
+NAMES += ["RADIXCHAR", "THOUSEP", "YESEXPR", "NOEXPR", "CRNCYSTR"]
+
+missing = [name for name in NAMES if not hasattr(locale, name)]
+assert not missing, missing
+
+keys = {name: getattr(locale, name) for name in NAMES}
+assert len(set(keys.values())) == len(NAMES), keys
+for name, key in keys.items():
+    assert isinstance(key, int), (name, key)
+    assert isinstance(locale.nl_langinfo(key), str), name
+
+# `YESSTR` and `NOSTR` are the two `<langinfo.h>` items the module leaves out.
+assert not hasattr(locale, "YESSTR")
+assert not hasattr(locale, "NOSTR")
+
+# The C locale is what the interpreter starts in, so these are its answers.
+assert locale.setlocale(locale.LC_TIME) == "C"
+assert locale.nl_langinfo(locale.DAY_1) == "Sunday"
+assert locale.nl_langinfo(locale.ABDAY_1) == "Sun"
+assert locale.nl_langinfo(locale.MON_1) == "January"
+assert locale.nl_langinfo(locale.ABMON_12) == "Dec"
+assert locale.nl_langinfo(locale.RADIXCHAR) == "."
+assert locale.nl_langinfo(locale.YESEXPR) == "^[yY]"
+assert locale.nl_langinfo(locale.NOEXPR) == "^[nN]"
+assert locale.nl_langinfo(locale.ERA) == ""
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/locale_langinfo_item_constants.py
+++ b/pyre/extra_tests/parity_tests/locale_langinfo_item_constants.py
@@ -1,9 +1,14 @@
+# pyre-check: platforms=darwin,linux
 # CPython-suite gap: test__locale guards every `nl_langinfo` assertion behind
 # `hasattr(locale, name)`, so a module that publishes none of the item keys
 # skips the whole file.
 # parity-tests reason: `_locale.nl_langinfo` accepted any key, but 54 of the
 # 55 names `_localemodule.c langinfo_constants` publishes were absent, so the
 # only key that could be spelled was `CODESET`.
+
+# Windows has no `<langinfo.h>` and no `nl_langinfo`, so the whole family is
+# absent there on every interpreter; the test is scoped to the hosts that
+# carry it.
 
 # `<langinfo.h>` numbers the items per platform — the BSD headers count from
 # zero while glibc packs the category into the high bits — so the test reads

--- a/pyre/extra_tests/parity_tests/select_kevent_repr.py
+++ b/pyre/extra_tests/parity_tests/select_kevent_repr.py
@@ -1,0 +1,35 @@
+# pyre-check: platforms=darwin
+# pyre-check: pypy-diverges: `interp_kqueue.py W_Kevent` registers no
+# `__repr__`, so pypy3 prints the default `<select.kevent object at 0x...>`.
+# CPython-suite gap: test_kqueue does not import, so nothing in the suite reprs
+# a kevent.
+# parity-tests reason: pyre's `select.kevent` had no `__repr__` at all, so the
+# six fields a caller sets were invisible in any log line or test failure that
+# printed the object.
+
+import select
+
+default = select.kevent(0)
+assert repr(default) == (
+    "<select.kevent ident=0 filter=-1 flags=0x1 fflags=0x0 data=0x0 udata=0x0>"
+), repr(default)
+
+full = select.kevent(
+    ident=7,
+    filter=select.KQ_FILTER_WRITE,
+    flags=select.KQ_EV_ADD | select.KQ_EV_ENABLE,
+    fflags=5,
+    data=12345,
+    udata=0xDEADBEEF,
+)
+assert repr(full) == (
+    "<select.kevent ident=7 filter=-2 flags=0x5 fflags=0x5 data=0x3039"
+    " udata=0xdeadbeef>"
+), repr(full)
+
+# `data` is spelled as a `long long`, so a negative one reads as its two's
+# complement rather than with a sign.
+negative = select.kevent(0, data=-1)
+assert "data=0xffffffffffffffff" in repr(negative), repr(negative)
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/signal_range_is_the_platform_nsig.py
+++ b/pyre/extra_tests/parity_tests/signal_range_is_the_platform_nsig.py
@@ -1,3 +1,4 @@
+# pyre-check: platforms=darwin,linux
 # CPython-suite gap: test_signal never asks for a signal number above the
 # platform's range, so nothing in the suite reads the bound back.
 # parity-tests reason: `NSIG` was a single 64 on every unix, so `getsignal`
@@ -11,7 +12,9 @@
 
 # `NSIG` is what `Py_NSIG` names: one past the highest signal the platform
 # has.  It is 32 on darwin and 65 under glibc, so every assertion below is
-# written against the value rather than a literal.
+# written against the value rather than a literal.  Windows counts its own
+# 23 but has neither `SIGUSR1` nor the POSIX delivery model, so it is out of
+# scope here.
 
 import signal
 
@@ -31,12 +34,14 @@ for out_of_range in (0, NSIG, NSIG + 1, NSIG + 8):
         else:
             raise AssertionError(f"{name}({out_of_range}) did not raise")
 
-# `valid_signals()` is bounded by the same number, so every member it reports
-# is a named signal rather than a bare int.
+# `valid_signals()` sweeps `sigismember` over the same half-open range, so
+# nothing it reports can sit at or past the bound.  Membership is not
+# enum-membership: glibc's realtime signals have no `Signals` name and come
+# back as plain ints on every interpreter.
 valid = signal.valid_signals()
 assert valid, valid
 for sig in valid:
-    assert isinstance(sig, signal.Signals), (sig, type(sig))
+    assert isinstance(sig, int), (sig, type(sig))
     assert 1 <= sig < NSIG, sig
 
 # The pending-signal bits are still delivered after the bound moved.

--- a/pyre/extra_tests/parity_tests/signal_range_is_the_platform_nsig.py
+++ b/pyre/extra_tests/parity_tests/signal_range_is_the_platform_nsig.py
@@ -1,0 +1,51 @@
+# CPython-suite gap: test_signal never asks for a signal number above the
+# platform's range, so nothing in the suite reads the bound back.
+# parity-tests reason: `NSIG` was a single 64 on every unix, so `getsignal`
+# and `strsignal` accepted numbers the platform has no signal for, and
+# `valid_signals()` answered with a bare int for a signal with no name.
+
+# pyre-check: pypy-diverges: `interp_signal.py strsignal` spells its own bound
+# as `signalnum > NSIG`, which admits `NSIG` itself and answers
+# `'Unknown signal: 32'`; 3.14 reports the range as `[1; NSIG - 1]` and
+# raises.
+
+# `NSIG` is what `Py_NSIG` names: one past the highest signal the platform
+# has.  It is 32 on darwin and 65 under glibc, so every assertion below is
+# written against the value rather than a literal.
+
+import signal
+
+NSIG = signal.NSIG
+assert NSIG > 1, NSIG
+
+# The half-open bound: `1` is a signal, `NSIG` is one past the last.
+assert signal.getsignal(1) is not None
+signal.strsignal(1)
+
+for out_of_range in (0, NSIG, NSIG + 1, NSIG + 8):
+    for name in ("getsignal", "strsignal"):
+        try:
+            getattr(signal, name)(out_of_range)
+        except ValueError as e:
+            assert str(e) == "signal number out of range", (name, out_of_range, e)
+        else:
+            raise AssertionError(f"{name}({out_of_range}) did not raise")
+
+# `valid_signals()` is bounded by the same number, so every member it reports
+# is a named signal rather than a bare int.
+valid = signal.valid_signals()
+assert valid, valid
+for sig in valid:
+    assert isinstance(sig, signal.Signals), (sig, type(sig))
+    assert 1 <= sig < NSIG, sig
+
+# The pending-signal bits are still delivered after the bound moved.
+received = []
+previous = signal.signal(signal.SIGUSR1, lambda n, f: received.append(n))
+try:
+    signal.raise_signal(signal.SIGUSR1)
+finally:
+    signal.signal(signal.SIGUSR1, previous)
+assert received == [signal.SIGUSR1], received
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/socket_address_argument_conversions.py
+++ b/pyre/extra_tests/parity_tests/socket_address_argument_conversions.py
@@ -1,0 +1,85 @@
+# CPython-suite gap: test_socket does not import, so nothing in the suite calls
+# these conversions with an argument outside the range the C type holds.
+# parity-tests reason: `htons` / `ntohs` / `htonl` / `ntohl` narrowed with a
+# cast, so `htons(70000)` answered for port 4464 instead of refusing, and the
+# name `<broadcast>` — which `inet_addr` cannot express, because failure and
+# all-ones are the same bit pattern — went to the resolver and failed there.
+
+# pyre-check: pypy-diverges: the `uint16_t` / `uint32_t` converter messages and
+# `getservbyport`'s refusal are CPython 3.14's; pypy3 raises OverflowError with
+# its own `c_uint` wording, and `socket.htons(70000)` answers 28689 there.
+
+import socket
+
+# The wildcard and the broadcast name never reach the resolver.
+assert socket.gethostbyname("") == "0.0.0.0"
+assert socket.gethostbyname("<broadcast>") == "255.255.255.255"
+assert socket.gethostbyname("255.255.255.255") == "255.255.255.255"
+
+# A socket address takes the same two names.
+udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+try:
+    udp.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    udp.connect(("<broadcast>", 9))
+    assert udp.getpeername() == ("255.255.255.255", 9), udp.getpeername()
+finally:
+    udp.close()
+
+# The four byte-order conversions refuse what they cannot hold.
+for convert, ctype in (
+    (socket.htons, "uint16_t"),
+    (socket.ntohs, "uint16_t"),
+    (socket.htonl, "uint32_t"),
+    (socket.ntohl, "uint32_t"),
+):
+    limit = 0xFFFF if ctype == "uint16_t" else 0xFFFFFFFF
+    try:
+        convert(limit + 1)
+    except OverflowError as e:
+        assert str(e) == "Python int too large for C " + ctype, str(e)
+    else:
+        raise SystemExit("%s accepted %d" % (convert.__name__, limit + 1))
+    try:
+        convert(-1)
+    except ValueError as e:
+        assert str(e) == "Cannot convert negative int", str(e)
+    else:
+        raise SystemExit("%s accepted -1" % convert.__name__)
+    # The whole range still round-trips.
+    assert convert(convert(limit)) == limit
+    assert convert(0) == 0
+
+# A port outside the range is refused rather than narrowed, and the message
+# names the method that was called.
+try:
+    socket.socket().bind(("127.0.0.1", 70000))
+except OverflowError as e:
+    assert str(e) == "bind(): port must be 0-65535.", str(e)
+else:
+    raise SystemExit("bind accepted port 70000")
+
+try:
+    socket.getservbyport(70000)
+except OverflowError as e:
+    assert str(e) == "getservbyport: port must be 0-65535.", str(e)
+else:
+    raise SystemExit("getservbyport accepted port 70000")
+
+# A family with no parser is a different failure from an address string the
+# parser rejected: the first carries the errno the call left behind.
+try:
+    socket.inet_pton(1234, "1.2.3.4")
+except OSError as e:
+    assert e.errno is not None, e.args
+else:
+    raise SystemExit("inet_pton accepted family 1234")
+
+try:
+    socket.inet_pton(socket.AF_INET, "nope")
+except OSError as e:
+    assert e.errno is None, e.args
+    assert str(e) == "illegal IP address string passed to inet_pton", str(e)
+else:
+    raise SystemExit("inet_pton accepted 'nope'")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/sre_constant_surface.py
+++ b/pyre/extra_tests/parity_tests/sre_constant_surface.py
@@ -1,0 +1,42 @@
+# CPython-suite gap: test_re reads `MAXGROUPS` out of the module under test, so
+# both sides of every comparison move together and a wrong value is invisible;
+# `MAGIC`, `CODESIZE` and `MAXREPEAT` are never checked against a number at all.
+# parity-tests reason: `_sre.MAXGROUPS` carried `INT32_MAX`, because the engine
+# crate halves its own unsigned `MAXREPEAT` where `sre.h` halves `INT32_MAX`.
+
+# pyre-check: pypy-diverges: `rsre_char.py` sets `MAXGROUPS = 2**31 - 1` on a
+# 64-bit host, which is the wide number pyre used to publish, and pypy3 is 3.11
+# so it carries the older `MAGIC` and has no `re.PatternError`.
+
+import re
+import re._constants
+import _sre
+
+# `Modules/_sre/sre.h`, 64-bit: `SRE_MAXREPEAT` is the whole `Py_UCS4`, while
+# `SRE_MAXGROUPS` halves `INT32_MAX` — half the *signed* maximum, which is one
+# bit narrower than half of `MAXREPEAT`.
+assert _sre.MAGIC == 20230612, _sre.MAGIC
+assert _sre.CODESIZE == 4, _sre.CODESIZE
+assert _sre.MAXREPEAT == 2**32 - 1, _sre.MAXREPEAT
+assert _sre.MAXGROUPS == 2**30 - 1, _sre.MAXGROUPS
+assert _sre.MAXGROUPS == 0x7FFFFFFF // 2, _sre.MAXGROUPS
+
+# `re/_constants.py` re-exports the module's numbers rather than restating them.
+assert re._constants.MAXGROUPS == _sre.MAXGROUPS
+assert re._constants.MAXREPEAT == _sre.MAXREPEAT
+# `_compiler.py` asserts this pairing at import time, so a MAGIC that drifts
+# from the bundled stdlib breaks `import re` rather than one call.
+assert re._constants.MAGIC == _sre.MAGIC
+
+# The number bounds the group references `_parser.py` accepts, but it does not
+# bracket them: a reference below the bound reaches a later check that raises
+# the same message at the same position.  Only the constant shows the value.
+for n in (2**30 - 2, 2**30 - 1, 2**31 - 1):
+    try:
+        re.compile(r"(?P<a>)(?(%d))" % n)
+    except re.PatternError as e:
+        assert str(e) == "invalid group reference %d at position 10" % n, (n, e)
+    else:
+        raise AssertionError("(?(%d)) compiled" % n)
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/std_stream_write_rejects_non_str.py
+++ b/pyre/extra_tests/parity_tests/std_stream_write_rejects_non_str.py
@@ -1,0 +1,29 @@
+# CPython-suite gap: test_sys does not import, so nothing in the suite calls
+# `sys.stdout.write` with an argument that is not a `str`.
+# parity-tests reason: pyre's std streams are native objects that encode
+# straight to the descriptor rather than `TextIOWrapper` instances, so the
+# argument check `W_TextIOWrapper.write_w` performs had no counterpart and a
+# non-`str` write silently reported a zero-length count.
+
+# `click._compat._is_binary_writer` decides whether a stream is the binary
+# layer by calling `stream.write(b"")` and seeing whether that raises. A stream
+# that accepts it is taken for the binary layer and wrapped in click's own text
+# layer, after which every `click.echo` goes to a wrapper over the wrong end
+# and nothing reaches the terminal.
+
+import sys
+
+for stream in (sys.stdout, sys.stderr):
+    for argument in (b"", b"x", 1, None, [], object()):
+        try:
+            stream.write(argument)
+        except TypeError:
+            pass
+        else:
+            raise SystemExit("write accepted %r" % (type(argument).__name__,))
+
+# A `str` still writes, and still reports the number of characters written.
+assert sys.stdout.write("") == 0
+assert sys.stderr.write("") == 0
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/termios_error_carries_errno_and_strerror.py
+++ b/pyre/extra_tests/parity_tests/termios_error_carries_errno_and_strerror.py
@@ -1,0 +1,58 @@
+# pyre-check: platforms=darwin,linux
+# CPython-suite gap: test_termios does not import, so nothing in the suite
+# inspects what a failed termios call raises.
+# parity-tests reason: every pyre call site built the message with
+# `format!("<syscall>: {e}")` over a `std::io::Error`, which names the syscall
+# and appends Rust's `(os error N)`, while `wrap_oserror` and
+# `PyErr_SetFromErrno` both spell it with the platform's `strerror` alone.
+
+# pyre-check: pypy-diverges: `termios.error` is not an OSError subclass, so
+# `wrap_oserror` hands it all five positional arguments and pypy3 reports
+# `(19, 'Operation not supported by device', None, None, None)`;
+# `PyErr_SetFromErrno` builds the two-item form.
+
+# `pexpect` and `ptyprocess` match on `e.args[1]` when deciding whether a
+# terminal is simply not a terminal, and a message with two extra parts around
+# the text never matches.
+
+import os
+import termios
+
+fd = os.open(os.devnull, os.O_RDONLY)
+try:
+    calls = (
+        ("tcgetattr", lambda: termios.tcgetattr(fd)),
+        ("tcdrain", lambda: termios.tcdrain(fd)),
+        ("tcflush", lambda: termios.tcflush(fd, termios.TCIFLUSH)),
+        ("tcflow", lambda: termios.tcflow(fd, termios.TCOOFF)),
+        ("tcsendbreak", lambda: termios.tcsendbreak(fd, 0)),
+    )
+    for name, call in calls:
+        try:
+            call()
+        except termios.error as e:
+            assert len(e.args) == 2, (name, e.args)
+            errno, strerror = e.args
+            assert isinstance(errno, int), (name, e.args)
+            # The message is the platform's own, with nothing added at either
+            # end — no syscall name in front, no error code behind.
+            assert strerror == os.strerror(errno), (name, e.args)
+            # `termios.error` is registered under a dotted name; `repr` spells
+            # the class the way `__name__` does.
+            assert repr(e) == "error(%d, %r)" % (errno, strerror), repr(e)
+        else:
+            raise SystemExit("%s on %s did not fail" % (name, os.devnull))
+finally:
+    os.close(fd)
+
+# A closed descriptor is the kernel's EBADF, reported the same way.
+fd = os.open(os.devnull, os.O_RDONLY)
+os.close(fd)
+try:
+    termios.tcgetattr(fd)
+except termios.error as e:
+    assert e.args[1] == os.strerror(e.args[0]), e.args
+else:
+    raise SystemExit("tcgetattr on a closed descriptor did not fail")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/unbound_hash_is_base_implementation.py
+++ b/pyre/extra_tests/parity_tests/unbound_hash_is_base_implementation.py
@@ -1,0 +1,51 @@
+# CPython-suite gap: test_tuple and test_set never call `tuple.__hash__` or
+# `frozenset.__hash__` on an instance of a subclass that overrides `__hash__`.
+# parity-tests reason: both descriptors dispatched through `hash()`, which looks
+# the dunder up on the instance's type, so the override ran in place of the base
+# implementation the unbound call names.
+
+# The memoising idiom below is what makes this reachable in the wild: a
+# subclass keeps the base hash under a default argument and calls it, so an
+# implementation that re-dispatches recurses until the stack runs out instead of
+# returning the structural hash.
+
+
+class LoudTuple(tuple):
+    def __hash__(self):
+        raise AssertionError("tuple.__hash__ must not consult the subclass")
+
+
+class LoudFrozenset(frozenset):
+    def __hash__(self):
+        raise AssertionError("frozenset.__hash__ must not consult the subclass")
+
+
+assert tuple.__hash__(LoudTuple((1, 2))) == hash((1, 2))
+assert frozenset.__hash__(LoudFrozenset([1, 2])) == hash(frozenset([1, 2]))
+
+
+class MemoisingKey(tuple):
+    def __hash__(self, base=tuple.__hash__):
+        try:
+            return self._hash
+        except AttributeError:
+            pass
+        object.__setattr__(self, "_hash", base(self))
+        return self._hash
+
+
+key = MemoisingKey((1, 2, 3))
+assert hash(key) == hash((1, 2, 3))
+assert hash(key) == hash(key)
+
+# The bound form still honours the override, which is the difference the two
+# spellings exist to express.
+assert type(key).__hash__(key) == hash((1, 2, 3))
+try:
+    hash(LoudTuple((1, 2)))
+except AssertionError:
+    pass
+else:
+    raise SystemExit("hash() must reach the subclass override")
+
+print("OK")

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -13031,6 +13031,7 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
                 mode,
                 opts,
                 syntax_check_only,
+                flags & PYCF_TYPE_COMMENTS != 0,
             )
         };
         return result.map_err(|error| {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -16354,9 +16354,45 @@ impl Drop for WritableBuffer {
     }
 }
 
+/// `space.readbuf_w` — a read-only byte slice from a bytes-like object.
+///
+/// Every readable exporter pyre has: bytes / bytearray, a live mmap, an
+/// `array.array`'s element bytes, and a contiguous memoryview's window.
+pub(crate) unsafe fn acquire_readbuf<'a>(obj: PyObjectRef) -> Result<&'a [u8], crate::PyError> {
+    unsafe {
+        if pyre_object::bytesobject::is_bytes_like(obj) {
+            return Ok(pyre_object::bytesobject::bytes_like_data(obj));
+        }
+        // `W_MMap.readbuf_w` — the live mapping.
+        #[cfg(all(any(unix, windows), not(feature = "sandbox")))]
+        if let Some(view) = crate::module::mmap::interp_mmap::mmap_buffer_view(obj) {
+            let (address, length, _readonly) = view?;
+            return Ok(std::slice::from_raw_parts(address as *const u8, length));
+        }
+        if pyre_object::interp_array::is_array(obj) {
+            return Ok(pyre_object::interp_array::w_array_bytes(obj));
+        }
+        if pyre_object::memoryview::is_w_memoryview(obj) {
+            memoryview_check_released(obj)?;
+            if memoryview_contiguity(obj).0 {
+                let view = pyre_object::memoryview::w_memoryview_view(obj);
+                let full = view.backing().as_bytes();
+                let off = view.offset() as usize;
+                let len = pyre_object::memoryview::w_memoryview_length(obj) as usize;
+                if off <= full.len() && len <= full.len() - off {
+                    return Ok(&full[off..off + len]);
+                }
+            }
+        }
+        Err(crate::PyError::type_error(
+            "a bytes-like object is required",
+        ))
+    }
+}
+
 /// `space.acquire_writebuf` for FileIO.readinto.  These are pyre's native
 /// writable exporters; a memoryview contributes its exact contiguous window.
-unsafe fn fileio_writebuf(
+pub(crate) unsafe fn fileio_writebuf(
     obj: PyObjectRef,
 ) -> Result<(&'static mut [u8], PyObjectRef, bool), crate::PyError> {
     fn type_error(obj: PyObjectRef) -> crate::PyError {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -11473,10 +11473,10 @@ pub fn compile_err_to_syntax_error(
 ///
 /// CPython's tokenizer keeps byte offsets internally too, but
 /// ``_PyPegen_byte_offset_to_character_offset`` converts them before the
-/// exception is materialised.  RustPython's `SourceLocation` is deliberately
-/// built with `PositionEncoding::Utf8`, so its `character_offset` is still a
-/// byte column despite the field name.  Preserve the parser's selected line
-/// and span and port only that final conversion here.
+/// exception is materialised.  This is that conversion, for the spans this
+/// module locates itself by scanning `source`; a location the compiler reports
+/// for a parser diagnostic already counts characters and must not be passed
+/// through here.  The line and the span are the caller's to choose.
 fn syntax_error_character_offset(source: &str, lineno: usize, byte_offset: usize) -> usize {
     if lineno == 0 || byte_offset == 0 {
         return byte_offset;
@@ -11507,6 +11507,24 @@ fn source_byte_location(source: &str, byte_index: usize) -> (usize, usize) {
         .count()
         + 1;
     (lineno, byte_index - line_start + 1)
+}
+
+/// Byte index of the one-based character column a parser diagnostic reports,
+/// which is what indexes back into the source it was parsed from.  A column
+/// past the end of its line lands on the line's end.
+fn source_character_index(source: &str, lineno: usize, char_offset: usize) -> Option<usize> {
+    let line_start = source
+        .split_inclusive('\n')
+        .take(lineno.checked_sub(1)?)
+        .map(str::len)
+        .sum::<usize>();
+    let line = source.get(line_start..)?.split('\n').next()?;
+    let column = char_offset.checked_sub(1)?;
+    let index = line
+        .char_indices()
+        .nth(column)
+        .map_or(line.len(), |(index, _)| index);
+    Some(line_start + index)
 }
 
 fn source_byte_index(source: &str, lineno: usize, byte_offset: usize) -> Option<usize> {
@@ -11570,8 +11588,8 @@ fn fstring_missing_comma_span(source: &str, raw_index: usize) -> Option<(usize, 
     }
     let (start_line, start_offset) = inner_error.python_location();
     let (end_line, end_offset) = inner_error.python_end_location()?;
-    let start = source_byte_index(&wrapped, start_line, start_offset)?.checked_sub(1)?;
-    let end = source_byte_index(&wrapped, end_line, end_offset)?.checked_sub(1)?;
+    let start = source_character_index(&wrapped, start_line, start_offset)?.checked_sub(1)?;
+    let end = source_character_index(&wrapped, end_line, end_offset)?.checked_sub(1)?;
     Some((open + 1 + start, open + 1 + end))
 }
 
@@ -12420,11 +12438,13 @@ fn compile_err_to_syntax_error_maybe_incomplete(
     } else {
         (e.python_location(), None)
     };
-    // Parser diagnostics are converted by pegen before exposure, while
-    // compiler/symtable diagnostics retain the UTF-8 byte columns used by AST
-    // locations (for example `return "ä"` ends at offset 12, not 11).
+    // A parser diagnostic arrives already counted in characters, and a
+    // compiler/symtable one retains the UTF-8 byte columns used by AST
+    // locations (for example `return "ä"` ends at offset 12, not 11).  Neither
+    // is converted here.  A span located above is a byte index into `source`
+    // whichever kind produced it, so only that one is.
     let parser_error = matches!(&e, crate::compile::CompileError::Parse(_));
-    let offset = if parser_error {
+    let offset = if parser_error && diagnostic_span.is_some() {
         syntax_error_character_offset(source, lineno, byte_offset)
     } else {
         byte_offset
@@ -12436,7 +12456,7 @@ fn compile_err_to_syntax_error_maybe_incomplete(
         let (end_lineno, end_byte_offset) = parser_end
             .or_else(|| codegen_statement_end(&e, source, lineno, byte_offset))
             .unwrap_or((lineno, byte_offset));
-        let end_offset = if parser_error && parser_end.is_some() {
+        let end_offset = if parser_error && diagnostic_end.is_some() {
             syntax_error_character_offset(source, end_lineno, end_byte_offset)
         } else {
             end_byte_offset

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -14013,6 +14013,61 @@ pub(crate) fn builtin_hash(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
     Ok(w_int_new(try_hash_value(args[0])?))
 }
 
+/// `tupleobject.py W_AbstractTupleObject.descr_hash` — the hash a tuple has by
+/// virtue of its contents, with no `__hash__` lookup on the receiver.
+///
+/// Separate from [`try_hash_value`] because the two answer different
+/// questions.  `hash(x)` must honour whatever `type(x)` says, override
+/// included; `tuple.__hash__(x)` names the base implementation, and running
+/// the override there would return the subclass's answer for a call that
+/// asked for the base's — and loop outright when the override calls back, as
+/// the memoising `def __hash__(self, hash=tuple.__hash__)` idiom does.
+pub(crate) fn tuple_structural_hash(obj: PyObjectRef) -> Result<i64, crate::PyError> {
+    unsafe {
+        // CPython 3.14 `tuple_hash`: a successful aggregate hash is
+        // retained on the tuple.  Check before the recursive stack guard
+        // so repeated dict probes do not touch the elements at all.
+        if let Some(hash) = pyre_object::w_tuple_cached_hash(obj) {
+            return Ok(hash);
+        }
+        // The element walk is the one recursive step here, and the scalar
+        // fast path in `try_hash_value` no longer reaches the call protocol's
+        // own guard, so a nest deep enough to exhaust the C stack has to be
+        // caught on the way down.
+        crate::stack_check::stack_check()?;
+        if let Some(hash) = pyre_object::w_tuple_cached_hash(obj) {
+            return Ok(hash);
+        }
+        // `try_hash_value` runs each element's `__hash__`, which may
+        // collect; `obj` is a raw local re-read in the loop and after it, so
+        // pin it on the shadow stack.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(obj);
+        let n = w_tuple_len(pyre_object::gc_roots::shadow_stack_get(obj_slot));
+        let mut hashes = Vec::with_capacity(n);
+        for i in 0..(n as i64) {
+            if let Some(item) =
+                w_tuple_getitem(pyre_object::gc_roots::shadow_stack_get(obj_slot), i)
+            {
+                hashes.push(try_hash_value(item)?);
+            }
+        }
+        let hash = _hash_tuple_xx(&hashes);
+        pyre_object::w_tuple_set_cached_hash(
+            pyre_object::gc_roots::shadow_stack_get(obj_slot),
+            hash,
+        );
+        Ok(hash)
+    }
+}
+
+/// `setobject.py W_FrozensetObject.descr_hash` — the frozenset counterpart of
+/// [`tuple_structural_hash`], and separate for the same reason.
+pub(crate) fn frozenset_structural_hash(obj: PyObjectRef) -> i64 {
+    frozenset_hash_from_storage(obj)
+}
+
 pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
     if obj.is_null() {
         return Err(crate::PyError::type_error("hash() argument is null"));
@@ -14103,41 +14158,7 @@ pub fn try_hash_value(obj: PyObjectRef) -> Result<i64, crate::PyError> {
             }
         }
         if is_tuple(obj) {
-            // CPython 3.14 `tuple_hash`: a successful aggregate hash is
-            // retained on the tuple.  Check before the recursive stack guard
-            // so repeated dict probes do not touch the elements at all.
-            if let Some(hash) = pyre_object::w_tuple_cached_hash(obj) {
-                return Ok(hash);
-            }
-            // The element walk is the one recursive step here, and the scalar
-            // fast path above no longer reaches the call protocol's own
-            // guard, so a nest deep enough to exhaust the C stack has to be
-            // caught on the way down.
-            crate::stack_check::stack_check()?;
-            if let Some(hash) = pyre_object::w_tuple_cached_hash(obj) {
-                return Ok(hash);
-            }
-            // `try_hash_value` runs each element's `__hash__`, which may
-            // collect; `obj` is a raw local re-read in the loop and after it, so
-            // pin it on the shadow stack.
-            let _roots = pyre_object::gc_roots::push_roots();
-            let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-            let _ = pyre_object::gc_roots::pin_root(obj);
-            let n = w_tuple_len(pyre_object::gc_roots::shadow_stack_get(obj_slot));
-            let mut hashes = Vec::with_capacity(n);
-            for i in 0..(n as i64) {
-                if let Some(item) =
-                    w_tuple_getitem(pyre_object::gc_roots::shadow_stack_get(obj_slot), i)
-                {
-                    hashes.push(try_hash_value(item)?);
-                }
-            }
-            let hash = _hash_tuple_xx(&hashes);
-            pyre_object::w_tuple_set_cached_hash(
-                pyre_object::gc_roots::shadow_stack_get(obj_slot),
-                hash,
-            );
-            return Ok(hash);
+            return tuple_structural_hash(obj);
         }
         if pyre_object::is_frozenset(obj) {
             return Ok(frozenset_hash_from_storage(obj));

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -19642,9 +19642,14 @@ mod tests {
     #[test]
     fn fstring_missing_comma_uses_recursive_expression_range() {
         assert_eq!(fstring_missing_comma_span("f'{6 0}'", 5), Some((3, 6)));
-        // Ruff's normalized range can end in the middle of a UTF-8 scalar;
-        // never project such a range into the outer SyntaxError.
-        assert_eq!(fstring_missing_comma_span("f'{α β}'", 7), None);
+        // A range whose end falls inside a multi-byte character is reported
+        // one character short, because `character_offset` counts the
+        // characters up to the byte the range ends at and a byte inside a
+        // scalar counts as the character before it.  The span is still worth
+        // projecting: `4, 6` under the message the recursive parse found
+        // beats `6, 7` under `f-string: expecting '}'`, which is what
+        // refusing it leaves behind.  3.14 answers `4, 7`.
+        assert_eq!(fstring_missing_comma_span("f'{α β}'", 7), Some((3, 6)));
         assert_eq!(
             fstring_missing_comma_span(
                 "f\"\"\"\n\n\n            {\n            6\n            0=\"\"\"",

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -12781,7 +12781,11 @@ const PYCF_ONLY_AST: i64 = 0x0400;
 const PYCF_DONT_IMPLY_DEDENT: i64 = 0x0200;
 const PYCF_SOURCE_IS_UTF8: i64 = 0x0100;
 const PYCF_IGNORE_COOKIE: i64 = 0x0800;
-const PYCF_TYPE_COMMENTS: i64 = 0x4000_0000;
+/// `Include/cpython/compile.h` numbers this one `0x1000`, and `_ast`
+/// publishes it, so the value is observable.  `consts.py` moved it out to
+/// `0x40000000` because it kept `PyCF_ASYNC_HACKS` on `0x1000`; that flag is
+/// gone from 3.14 and the bit is free.
+const PYCF_TYPE_COMMENTS: i64 = 0x1000;
 const PYCF_ALLOW_TOP_LEVEL_AWAIT: i64 = 0x2000;
 const PYCF_ALLOW_INCOMPLETE_INPUT: i64 = 0x4000;
 const PYCF_OPTIMIZED_AST: i64 = 0x8000 | PYCF_ONLY_AST;

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3184,6 +3184,12 @@ fn call_with_kwargs_in_ctx_impl(
         // `format=`/`preset=`/`filters=`, and `select.kevent` takes the six
         // `ident=`/`filter=`/`flags=`/`fflags=`/`data=`/`udata=` names.
         // Route them through `__new__`.
+        // `select` is not built under the sandbox feature, so the kevent arm
+        // is answered before the chain rather than inside it.
+        #[cfg(not(feature = "sandbox"))]
+        let is_kevent = std::ptr::eq(current_type(), crate::module::select::kevent_type());
+        #[cfg(feature = "sandbox")]
+        let is_kevent = false;
         let accepts_keywords_despite_nonbase =
             std::ptr::eq(
                 current_type(),
@@ -3202,7 +3208,7 @@ fn call_with_kwargs_in_ctx_impl(
                 crate::module::_contextvars::context_var_type(),
             ) || std::ptr::eq(current_type(), crate::module::_lzma::compressor_type())
                 || std::ptr::eq(current_type(), crate::module::_lzma::decompressor_type())
-                || std::ptr::eq(current_type(), crate::module::select::kevent_type())
+                || is_kevent
                 || crate::_structseq::is_structseq_type(current_type());
         if !kwargs.is_empty()
             && !accepts_keywords_despite_nonbase

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3180,8 +3180,10 @@ fn call_with_kwargs_in_ctx_impl(
         // types are non-acceptable-as-base too, but their `tp_new` functions
         // accept keywords: FunctionType has `kwdefaults=...`, CPython 3.14
         // exposes `memoryview(object=...)`, the deque iterator constructors
-        // accept (and ignore) `index=...`, and both `_lzma` constructors take
-        // `format=`/`preset=`/`filters=`.  Route them through `__new__`.
+        // accept (and ignore) `index=...`, both `_lzma` constructors take
+        // `format=`/`preset=`/`filters=`, and `select.kevent` takes the six
+        // `ident=`/`filter=`/`flags=`/`fflags=`/`data=`/`udata=` names.
+        // Route them through `__new__`.
         let accepts_keywords_despite_nonbase =
             std::ptr::eq(
                 current_type(),
@@ -3200,6 +3202,7 @@ fn call_with_kwargs_in_ctx_impl(
                 crate::module::_contextvars::context_var_type(),
             ) || std::ptr::eq(current_type(), crate::module::_lzma::compressor_type())
                 || std::ptr::eq(current_type(), crate::module::_lzma::decompressor_type())
+                || std::ptr::eq(current_type(), crate::module::select::kevent_type())
                 || crate::_structseq::is_structseq_type(current_type());
         if !kwargs.is_empty()
             && !accepts_keywords_despite_nonbase

--- a/pyre/pyre-interpreter/src/cpyext/bytesobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/bytesobject.rs
@@ -2,6 +2,7 @@
 
 use super::object::argument;
 use super::pyobject::{self, CPyObject};
+use super::typeobject::CPyVarObject;
 use pyre_object::PyObjectRef;
 use std::collections::HashSet;
 use std::ffi::{CStr, c_char, c_int};
@@ -89,7 +90,11 @@ pub unsafe extern "C" fn PyBytes_FromStringAndSize(
     }
     data.resize(size as usize, 0);
     let ob_type = pyobject::borrow_mirror(w_bytes_type) as *mut super::typeobject::CPyTypeObject;
-    let raw = pyobject::allocate_raw(size_of::<CPyObject>(), true) as *mut CPyObject;
+    // Wide enough for `ob_size`: this block becomes the `bytes`'s own mirror
+    // when `realize_pending` links it, and from then on every `make_ref` of
+    // that `bytes` republishes the length into this field.  A block that
+    // stopped at the header would take that write past its own end.
+    let raw = pyobject::allocate_raw(size_of::<CPyVarObject>(), true) as *mut CPyObject;
     if raw.is_null() {
         return unsafe { super::pyerrors::PyErr_NoMemory() };
     }
@@ -99,6 +104,9 @@ pub unsafe extern "C" fn PyBytes_FromStringAndSize(
         (*raw).ob_refcnt = 1;
         (*raw).ob_pyre_link = pyre_object::PY_NULL;
         (*raw).ob_type = ob_type;
+        // `pyobject.py:108` sets `c_ob_size` as it allocates, so `Py_SIZE`
+        // answers the requested length while C is still writing the buffer.
+        (*(raw as *mut CPyVarObject)).ob_size = size;
     }
     PENDING.lock().insert(raw as usize);
     // The terminator `cached_bytes` appends is the NUL upstream's `ob_sval`
@@ -207,6 +215,7 @@ pub unsafe extern "C" fn _PyBytes_Resize(pv: *mut *mut CPyObject, newsize: isize
             }
             return -1;
         }
+        unsafe { (*(raw as *mut CPyVarObject)).ob_size = newsize as isize };
         return 0;
     }
     let Some(value) = argument(raw) else {

--- a/pyre/pyre-interpreter/src/cpyext/exception.rs
+++ b/pyre/pyre-interpreter/src/cpyext/exception.rs
@@ -9,7 +9,7 @@
 
 use super::pyobject::{self, CPyObject};
 use pyre_object::PyObjectRef;
-use std::ffi::{c_char, c_int};
+use std::ffi::{CStr, c_char, c_int};
 
 /// The exception instance an accessor was handed, or `None` after recording
 /// the `AttributeError` a foreign object deserves.
@@ -200,6 +200,76 @@ pub unsafe extern "C" fn PyExceptionClass_Name(object: *mut CPyObject) -> *const
     unsafe { (*(object as *mut super::typeobject::CPyTypeObject)).tp_name }
 }
 
+/// `PyUnicodeDecodeError_Create(encoding, object, length, start, end, reason)`
+/// — the exception a decoder raises, built from what it was decoding.
+///
+/// `object` is the bytes being decoded and `length` how many of them there
+/// are, so it is read as a slice rather than as a C string: a decoder reaches
+/// here precisely because those bytes are not text, and an embedded NUL is one
+/// of the things that makes them not text.
+///
+/// # Safety
+/// `encoding` and `reason` must be NUL-terminated; `object` must address
+/// `length` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeDecodeError_Create(
+    encoding: *const c_char,
+    object: *const c_char,
+    length: isize,
+    start: isize,
+    end: isize,
+    reason: *const c_char,
+) -> *mut CPyObject {
+    if encoding.is_null() || object.is_null() || reason.is_null() || length < 0 {
+        unsafe { super::pyerrors::PyErr_BadInternalCall() };
+        return std::ptr::null_mut();
+    }
+    let Some(class) = crate::builtins::lookup_exc_class("UnicodeDecodeError") else {
+        super::pyerrors::set_pending_error(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            "UnicodeDecodeError is not registered",
+        ));
+        return std::ptr::null_mut();
+    };
+    let encoding = unsafe { CStr::from_ptr(encoding) }
+        .to_string_lossy()
+        .into_owned();
+    let reason = unsafe { CStr::from_ptr(reason) }
+        .to_string_lossy()
+        .into_owned();
+    let bytes = unsafe { std::slice::from_raw_parts(object as *const u8, length as usize) };
+    let roots = pyre_object::gc_roots::push_roots();
+    let class_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(class);
+    // Each argument is pinned as it is made: the next one allocates, and a
+    // collection there moves whatever is only held in a local.
+    let encoding_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(pyre_object::w_str_new(&encoding));
+    let object_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(pyre_object::bytesobject::w_bytes_from_bytes(bytes));
+    let start_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(pyre_object::w_int_new(start as i64));
+    let end_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(pyre_object::w_int_new(end as i64));
+    let reason_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(pyre_object::w_str_new(&reason));
+    let reload = pyre_object::gc_roots::shadow_stack_get;
+    let made = crate::call::call_function_impl_result(
+        reload(class_slot),
+        &[
+            reload(encoding_slot),
+            reload(object_slot),
+            reload(start_slot),
+            reload(end_slot),
+            reload(reason_slot),
+        ],
+    );
+    match super::pyerrors::trap(made) {
+        Some(instance) => pyobject::make_ref(instance),
+        None => std::ptr::null_mut(),
+    }
+}
+
 pub(super) fn ensure_linked() {
     std::hint::black_box(PyException_GetTraceback as *const ());
     std::hint::black_box(PyException_SetTraceback as *const ());
@@ -212,4 +282,5 @@ pub(super) fn ensure_linked() {
     std::hint::black_box(PyExceptionClass_Check as *const ());
     std::hint::black_box(PyExceptionInstance_Check as *const ());
     std::hint::black_box(PyExceptionClass_Name as *const ());
+    std::hint::black_box(PyUnicodeDecodeError_Create as *const ());
 }

--- a/pyre/pyre-interpreter/src/cpyext/listobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/listobject.rs
@@ -79,6 +79,38 @@ pub unsafe extern "C" fn PyList_SetItem(
     0
 }
 
+/// `PyList_GET_SIZE(list)` — the unchecked spelling of [`PyList_Size`].
+///
+/// Exported as well as spelled as a macro, for the reason [`Py_TYPE`] is: a
+/// caller that declares the prototype itself rather than including the header
+/// still has to find a symbol.  It reads the list rather than a field of the
+/// mirror, which is the only place the length is.
+///
+/// [`Py_TYPE`]: super::object::Py_TYPE
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyList_GET_SIZE(object: *mut CPyObject) -> isize {
+    unsafe { PyList_Size(object) }
+}
+
+/// `PyList_GET_ITEM(list, index)` — the unchecked spelling of
+/// [`PyList_GetItem`], exported for the reason [`PyList_GET_SIZE`] is.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyList_GET_ITEM(object: *mut CPyObject, index: isize) -> *mut CPyObject {
+    unsafe { PyList_GetItem(object, index) }
+}
+
+/// `PyList_SET_ITEM(list, index, item)` — the unchecked spelling of
+/// [`PyList_SetItem`], exported for the reason [`PyList_GET_SIZE`] is.  It
+/// steals the reference its checked twin steals.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyList_SET_ITEM(
+    object: *mut CPyObject,
+    index: isize,
+    item: *mut CPyObject,
+) {
+    unsafe { PyList_SetItem(object, index, item) };
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyList_Append(object: *mut CPyObject, item: *mut CPyObject) -> c_int {
     super::object::realize_all([object, item]);
@@ -262,6 +294,9 @@ pub(super) fn ensure_linked() {
     std::hint::black_box(PyList_Size as *const ());
     std::hint::black_box(PyList_GetItem as *const ());
     std::hint::black_box(PyList_SetItem as *const ());
+    std::hint::black_box(PyList_GET_SIZE as *const ());
+    std::hint::black_box(PyList_GET_ITEM as *const ());
+    std::hint::black_box(PyList_SET_ITEM as *const ());
     std::hint::black_box(PyList_Append as *const ());
     std::hint::black_box(PyList_GetItemRef as *const ());
     std::hint::black_box(PyList_Insert as *const ());

--- a/pyre/pyre-interpreter/src/cpyext/lock.rs
+++ b/pyre/pyre-interpreter/src/cpyext/lock.rs
@@ -208,8 +208,56 @@ pub unsafe extern "C" fn PyThread_get_thread_ident() -> c_ulong {
     crate::module::thread::current_ident() as c_ulong
 }
 
+/// The two words a caller embeds for a critical section, which it allocates
+/// and pyre fills in.
+///
+/// `Py_BEGIN_CRITICAL_SECTION` in the header opens a plain block, so nothing
+/// pyre compiles ever names one; an extension that declares the struct itself
+/// still passes the address of two words, and both fields are written so that
+/// the block is defined storage rather than whatever the stack held.
+#[repr(C)]
+pub struct CPyCriticalSection {
+    pub _cs_prev: usize,
+    pub _cs_mutex: *mut CPyMutex,
+}
+
+/// `PyCriticalSection_Begin(section, op)` — serialize against whoever else
+/// operates on `op`.
+///
+/// Every thread that runs Python here does so under one global lock, which
+/// already orders these against each other, so there is nothing to take: the
+/// section records that it holds no mutex and `PyCriticalSection_End` has
+/// nothing to release. That is the same answer the header gives an extension
+/// that spells the block with the macros instead.
+///
+/// # Safety
+/// `section` must address two writable words that outlive the section.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyCriticalSection_Begin(
+    section: *mut CPyCriticalSection,
+    _op: *mut super::pyobject::CPyObject,
+) {
+    if section.is_null() {
+        return;
+    }
+    unsafe {
+        (*section)._cs_prev = 0;
+        (*section)._cs_mutex = std::ptr::null_mut();
+    }
+}
+
+/// `PyCriticalSection_End(section)` — the release half of
+/// [`PyCriticalSection_Begin`], which took nothing.
+///
+/// # Safety
+/// `section` must be one [`PyCriticalSection_Begin`] was handed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyCriticalSection_End(_section: *mut CPyCriticalSection) {}
+
 pub(super) fn ensure_linked() {
     std::hint::black_box(PyMutex_Lock as *const ());
+    std::hint::black_box(PyCriticalSection_Begin as *const ());
+    std::hint::black_box(PyCriticalSection_End as *const ());
     std::hint::black_box(PyMutex_Unlock as *const ());
     std::hint::black_box(PyMutex_IsLocked as *const ());
     std::hint::black_box(PyThread_allocate_lock as *const ());

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -47,6 +47,7 @@ pub mod pymem;
 pub mod pyobject;
 pub mod pystate;
 pub mod pystrtod;
+pub mod pythonrun;
 pub mod sequence;
 pub mod setobject;
 pub mod sliceobject;
@@ -796,6 +797,7 @@ pub fn ensure_linked() {
     pyobject::ensure_linked();
     pystate::ensure_linked();
     pystrtod::ensure_linked();
+    pythonrun::ensure_linked();
     bytearrayobject::ensure_linked();
     complexobject::ensure_linked();
     cdatetime::ensure_linked();

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -322,7 +322,25 @@ fn fixup_extension(module: PyObjectRef, name: &str, path: &Path, handle: usize) 
     EXTENSIONS_ACTIVE.store(true, Ordering::Release);
 }
 
-fn init_symbol(name: &str) -> Result<String, crate::PyError> {
+/// Which entry point an extension published, and under which protocol.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum InitProtocol {
+    /// `PyModExport_*`, answering with a slot array.
+    Export,
+    /// `PyInit_*`, answering with a module or a module definition.
+    Init,
+}
+
+impl InitProtocol {
+    fn symbol(self, basename: &str) -> String {
+        match self {
+            InitProtocol::Export => format!("PyModExport_{basename}"),
+            InitProtocol::Init => format!("PyInit_{basename}"),
+        }
+    }
+}
+
+fn init_basename(name: &str) -> Result<&str, crate::PyError> {
     let basename = name.rsplit('.').next().unwrap_or(name);
     if !basename.is_ascii() {
         return Err(crate::PyError::new(
@@ -330,7 +348,36 @@ fn init_symbol(name: &str) -> Result<String, crate::PyError> {
             format!("non-ASCII cpyext init names are not implemented yet: {basename}"),
         ));
     }
-    Ok(format!("PyInit_{basename}"))
+    Ok(basename)
+}
+
+/// The entry point an open library publishes.
+///
+/// `PyModExport_*` is looked for first, so an extension that publishes both
+/// is read under the protocol that describes itself rather than the one that
+/// hands back a struct this interpreter would have to agree on the layout of.
+fn lookup_init(handle: usize, name: &str) -> Result<Option<(InitProtocol, usize)>, crate::PyError> {
+    let basename = init_basename(name)?;
+    for protocol in [InitProtocol::Export, InitProtocol::Init] {
+        if let Some(address) = lookup_init_address(handle, &protocol.symbol(basename)) {
+            return Ok(Some((protocol, address)));
+        }
+    }
+    Ok(None)
+}
+
+/// What the lookup reports when neither entry point is there.
+fn missing_init_error(name: &str, path: &Path) -> crate::PyError {
+    let basename = name.rsplit('.').next().unwrap_or(name);
+    extension_import_error(
+        format!(
+            "function {} not found in library '{}'",
+            InitProtocol::Init.symbol(basename),
+            path.display()
+        ),
+        name,
+        path,
+    )
 }
 
 fn extension_import_error(message: String, name: &str, path: &Path) -> crate::PyError {
@@ -373,16 +420,8 @@ pub fn load_extension_module(
     // the one library owned by `EXTENSIONS`, so resolve PyPy's cache before
     // opening on this host abstraction.
     if let Some(handle) = cached_extension_handle(path) {
-        let symbol = init_symbol(name)?;
-        if lookup_init_address(handle, &symbol).is_none() {
-            return Err(extension_import_error(
-                format!(
-                    "function {symbol} not found in library '{}'",
-                    path.display()
-                ),
-                name,
-                path,
-            ));
+        if lookup_init(handle, name)?.is_none() {
+            return Err(missing_init_error(name, path));
         }
         if let Some(module) = cached_extension(name, path) {
             let roots = pyre_object::gc_roots::push_roots();
@@ -412,33 +451,42 @@ pub fn load_extension_module(
             )
         })?;
 
-    let symbol = match init_symbol(name) {
-        Ok(symbol) => symbol,
+    let found = match lookup_init(handle, name) {
+        Ok(found) => found,
         Err(error) => {
             rustpython_host_env::ctypes::drop_library(handle);
             return Err(error);
         }
     };
-    let Some(address) = lookup_init_address(handle, &symbol) else {
+    let Some((protocol, address)) = found else {
         rustpython_host_env::ctypes::drop_library(handle);
-        return Err(extension_import_error(
-            format!(
-                "function {symbol} not found in library '{}'",
-                path.display()
-            ),
-            name,
-            path,
-        ));
+        return Err(missing_init_error(name, path));
     };
 
     let old_context = PACKAGE_CONTEXT
         .lock()
         .replace((name.to_string(), path.to_path_buf()));
-    let init: unsafe extern "C" fn() -> *mut CPyObject = unsafe { std::mem::transmute(address) };
-    let result = unsafe { init() };
-    *PACKAGE_CONTEXT.lock() = old_context;
+    let answer = match protocol {
+        InitProtocol::Export => {
+            let export: unsafe extern "C" fn() -> *mut typeobject::CPySlot =
+                unsafe { std::mem::transmute(address) };
+            let slots = unsafe { export() };
+            // The export protocol names the module itself, so the context the
+            // single-phase path reads is not this path's to leave set.
+            *PACKAGE_CONTEXT.lock() = old_context;
+            modsupport::create_module_from_export_slots(slots, spec, name, Some(path))
+                .map(InitResult::MultiPhase)
+        }
+        InitProtocol::Init => {
+            let init: unsafe extern "C" fn() -> *mut CPyObject =
+                unsafe { std::mem::transmute(address) };
+            let result = unsafe { init() };
+            *PACKAGE_CONTEXT.lock() = old_context;
+            finish_init(name, path, spec, result)
+        }
+    };
 
-    let init_result = match finish_init(name, path, spec, result) {
+    let init_result = match answer {
         Ok(module) => module,
         Err(error) => {
             rustpython_host_env::ctypes::drop_library(handle);

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -402,7 +402,11 @@ pub fn load_extension_module(
     let handle =
         rustpython_host_env::ctypes::open_library_with_mode(path, mode).map_err(|error| {
             extension_import_error(
-                format!("cannot load extension '{}': {error}", path.display()),
+                format!(
+                    "cannot load extension '{}': {}",
+                    path.display(),
+                    crate::with_causes(&error)
+                ),
                 name,
                 path,
             )

--- a/pyre/pyre-interpreter/src/cpyext/modsupport.rs
+++ b/pyre/pyre-interpreter/src/cpyext/modsupport.rs
@@ -331,6 +331,28 @@ pub(super) fn create_module_from_def_and_spec(
     name: &str,
     path: Option<&std::path::Path>,
 ) -> Result<PyObjectRef, crate::PyError> {
+    // Every module definition names itself, so a NULL here is not a definition
+    // read at the offsets it was written at.  It is the one field that says so
+    // before anything else goes wrong: a definition laid out against a larger
+    // `PyObject` header -- CPython 3.14's free-threaded one is 32 bytes where
+    // this is 24 -- puts its `m_copy` where `m_name` is read, its `m_name`
+    // where `m_doc` is, and its `m_methods` where `m_slots` is.  Reading it
+    // that way is not an error anywhere: the module is created, `__doc__`
+    // holds the name, no execution slot is found, and the module an extension
+    // spent its whole init filling comes back empty.
+    if unsafe { (*def).m_name.is_null() } {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            format!(
+                "module {name}: its PyModuleDef has no m_name, so it was not \
+                 laid out against this interpreter's headers -- an extension \
+                 that declares CPython's structs itself reads every field of \
+                 this one at the wrong offset, since a PyObject here is {} \
+                 bytes",
+                std::mem::size_of::<CPyObject>()
+            ),
+        ));
+    }
     if unsafe { (*def).m_size } < 0 {
         return Err(crate::PyError::new(
             crate::PyErrorKind::SystemError,

--- a/pyre/pyre-interpreter/src/cpyext/modsupport.rs
+++ b/pyre/pyre-interpreter/src/cpyext/modsupport.rs
@@ -324,6 +324,130 @@ pub unsafe extern "C" fn PyModule_Create2(
     pyobject::make_ref(module)
 }
 
+/// The `PySlot` identifiers a module export array carries.  They are a
+/// separate range from the `PyModuleDef_Slot` numbers the create phase reads,
+/// and the four they overlap in meaning are renumbered on the way in.
+mod export_id {
+    pub const MOD_CREATE: u16 = 84;
+    pub const MOD_EXEC: u16 = 85;
+    pub const MOD_MULTIPLE_INTERPRETERS: u16 = 86;
+    pub const MOD_GIL: u16 = 87;
+    pub const MOD_NAME: u16 = 100;
+    pub const MOD_DOC: u16 = 101;
+    pub const MOD_STATE_SIZE: u16 = 102;
+    pub const MOD_METHODS: u16 = 103;
+    pub const MOD_STATE_TRAVERSE: u16 = 104;
+    pub const MOD_STATE_CLEAR: u16 = 105;
+    pub const MOD_STATE_FREE: u16 = 106;
+    pub const MOD_ABI: u16 = 109;
+    pub const MOD_TOKEN: u16 = 110;
+}
+
+/// `PyModExport_*`'s answer, read into the definition the create phase takes.
+///
+/// The export protocol says the same things a `PyModuleDef` says, as an array
+/// rather than as a struct: an extension that never names the struct cannot be
+/// laid out against the wrong one.  The definition built here is this layer's
+/// own, and lives as long as the module does.
+pub(super) fn create_module_from_export_slots(
+    slots: *mut super::typeobject::CPySlot,
+    spec: PyObjectRef,
+    name: &str,
+    path: Option<&std::path::Path>,
+) -> Result<PyObjectRef, crate::PyError> {
+    let refuse = |message: String| {
+        Err(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            message,
+        ))
+    };
+    if slots.is_null() {
+        return refuse(format!("module {name}: PyModExport_* returned NULL"));
+    }
+    let mut def = Box::new(CPyModuleDef {
+        m_base: CPyModuleDefBase {
+            ob_base: CPyObject {
+                ob_refcnt: 0,
+                ob_pyre_link: PY_NULL,
+                ob_type: std::ptr::null_mut(),
+            },
+            m_init: None,
+            m_index: 0,
+            m_copy: std::ptr::null_mut(),
+        },
+        m_name: std::ptr::null(),
+        m_doc: std::ptr::null(),
+        m_size: 0,
+        m_methods: std::ptr::null_mut(),
+        m_slots: std::ptr::null_mut(),
+        m_traverse: std::ptr::null(),
+        m_clear: std::ptr::null(),
+        m_free: std::ptr::null(),
+    });
+    let mut def_slots: Vec<CPyModuleDefSlot> = Vec::new();
+    let mut entry = slots;
+    loop {
+        let slot = unsafe { &*entry };
+        if slot.sl_id == 0 {
+            break;
+        }
+        let value = slot.sl_value as *mut c_void;
+        match slot.sl_id {
+            export_id::MOD_NAME => def.m_name = value as *const c_char,
+            export_id::MOD_DOC => def.m_doc = value as *const c_char,
+            export_id::MOD_STATE_SIZE => def.m_size = slot.sl_value as isize,
+            export_id::MOD_METHODS => def.m_methods = value as *mut CPyMethodDef,
+            export_id::MOD_STATE_TRAVERSE => def.m_traverse = value as *const c_void,
+            export_id::MOD_STATE_CLEAR => def.m_clear = value as *const c_void,
+            export_id::MOD_STATE_FREE => def.m_free = value as *const c_void,
+            // Reported for the host to check the extension against itself.
+            // Every ABI this interpreter offers is the one it just handed the
+            // extension, so there is nothing here to reject.
+            export_id::MOD_ABI | export_id::MOD_TOKEN => {}
+            export_id::MOD_CREATE => def_slots.push(CPyModuleDefSlot {
+                slot: PY_MOD_CREATE,
+                value,
+            }),
+            export_id::MOD_EXEC => def_slots.push(CPyModuleDefSlot {
+                slot: PY_MOD_EXEC,
+                value,
+            }),
+            export_id::MOD_MULTIPLE_INTERPRETERS => def_slots.push(CPyModuleDefSlot {
+                slot: PY_MOD_MULTIPLE_INTERPRETERS,
+                value,
+            }),
+            export_id::MOD_GIL => def_slots.push(CPyModuleDefSlot {
+                slot: PY_MOD_GIL,
+                value,
+            }),
+            unknown => {
+                if slot.sl_flags & super::typeobject::SLOT_OPTIONAL == 0 {
+                    return refuse(format!(
+                        "module {name}: PyModExport_* returned an unrecognised slot {unknown}"
+                    ));
+                }
+            }
+        }
+        entry = unsafe { entry.add(1) };
+    }
+    if def.m_name.is_null() {
+        return refuse(format!(
+            "module {name}: PyModExport_* returned no Py_mod_name"
+        ));
+    }
+    // The create phase reads the array until a zero, and takes both arrays by
+    // pointer rather than copying them, so both outlive this call.
+    def_slots.push(CPyModuleDefSlot {
+        slot: 0,
+        value: std::ptr::null_mut(),
+    });
+    def.m_slots = Box::leak(def_slots.into_boxed_slice()).as_mut_ptr();
+    let def = Box::leak(def);
+    // Stamps the header the create phase reads the definition back through.
+    unsafe { PyModuleDef_Init(def) };
+    create_module_from_def_and_spec(def, spec, name, path)
+}
+
 /// `modsupport.py:create_module_from_def_and_spec` — the PEP 489 create phase.
 pub(super) fn create_module_from_def_and_spec(
     def: *mut CPyModuleDef,

--- a/pyre/pyre-interpreter/src/cpyext/object.rs
+++ b/pyre/pyre-interpreter/src/cpyext/object.rs
@@ -1228,6 +1228,20 @@ pub unsafe extern "C" fn PyObject_Realloc(block: *mut c_void, size: usize) -> *m
     unsafe { pyobject::reallocate_raw(block, size) }
 }
 
+/// `Py_TYPE(object)` as a call, which is what an extension reaches when it
+/// declares the prototype itself instead of expanding the header's macro.
+///
+/// The answer is the field, not [`crate::typedef::r#type`]: the macro reads
+/// `ob_type` and hands the block back borrowed, so a mirror whose type is not
+/// linked yet must answer NULL here exactly as it does there.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Py_TYPE(object: *mut CPyObject) -> *mut CPyTypeObject {
+    if object.is_null() {
+        return std::ptr::null_mut();
+    }
+    unsafe { (*object).ob_type }
+}
+
 /// `Py_TYPE(object)`, borrowed — the mirror a type mirror is.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyObject_Type(object: *mut CPyObject) -> *mut CPyObject {
@@ -1389,6 +1403,7 @@ pub(super) fn ensure_linked() {
     std::hint::black_box(PyCallable_Check as *const ());
     std::hint::black_box(PyObject_IsInstance as *const ());
     std::hint::black_box(PyObject_Type as *const ());
+    std::hint::black_box(Py_TYPE as *const ());
     std::hint::black_box(PyObject_GenericGetAttr as *const ());
     std::hint::black_box(PyObject_GenericSetAttr as *const ());
     std::hint::black_box(PyObject_GenericGetDict as *const ());

--- a/pyre/pyre-interpreter/src/cpyext/object.rs
+++ b/pyre/pyre-interpreter/src/cpyext/object.rs
@@ -1153,7 +1153,7 @@ pub unsafe extern "C" fn PyObject_VectorcallDict(
         return unsafe { PyObject_Vectorcall(callable, args, nargsf, std::ptr::null_mut()) };
     }
     let nargs = vectorcall_nargs(nargsf);
-    let positional = unsafe { PyTuple_from_vector(args, nargs) };
+    let positional = unsafe { tuple_from_vector(args, nargs) };
     if positional.is_null() {
         return std::ptr::null_mut();
     }
@@ -1163,8 +1163,10 @@ pub unsafe extern "C" fn PyObject_VectorcallDict(
 }
 
 /// The `tuple` a vector's first `count` entries make, as a new reference.
-#[allow(non_snake_case)]
-unsafe fn PyTuple_from_vector(args: *const *mut CPyObject, count: usize) -> *mut CPyObject {
+pub(super) unsafe fn tuple_from_vector(
+    args: *const *mut CPyObject,
+    count: usize,
+) -> *mut CPyObject {
     let tuple = unsafe { super::tupleobject::PyTuple_New(count as isize) };
     if tuple.is_null() {
         return std::ptr::null_mut();
@@ -1240,6 +1242,15 @@ pub unsafe extern "C" fn Py_TYPE(object: *mut CPyObject) -> *mut CPyTypeObject {
         return std::ptr::null_mut();
     }
     unsafe { (*object).ob_type }
+}
+
+/// `Py_IS_TYPE(object, tp)` as a call, for the reason [`Py_TYPE`] is one.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Py_IS_TYPE(object: *mut CPyObject, tp: *mut CPyTypeObject) -> c_int {
+    if object.is_null() {
+        return 0;
+    }
+    (unsafe { (*object).ob_type } == tp) as c_int
 }
 
 /// `Py_TYPE(object)`, borrowed — the mirror a type mirror is.

--- a/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
@@ -549,15 +549,28 @@ pub unsafe extern "C" fn PyErr_Fetch(
 
 /// An exception instance's `__traceback__` as a new reference, or NULL.
 fn traceback_reference(instance: PyObjectRef) -> *mut CPyObject {
-    if instance.is_null() || !unsafe { pyre_object::is_exception(instance) } {
-        return std::ptr::null_mut();
-    }
-    let stored = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(instance) };
+    let stored = escaping_traceback(instance);
     if stored.is_null() {
         return std::ptr::null_mut();
     }
-    unsafe { crate::pytraceback::mark_traceback_escaped(stored) };
     pyobject::make_ref(stored)
+}
+
+/// The traceback `instance` carries, marked as having left the frame it names.
+///
+/// A traceback holds the frame it was taken from, and a frame outlives its own
+/// execution only once something says so; handing one to a caller is that
+/// something, so the mark goes here rather than at each use.
+fn escaping_traceback(instance: PyObjectRef) -> PyObjectRef {
+    if instance.is_null() || !unsafe { pyre_object::is_exception(instance) } {
+        return PY_NULL;
+    }
+    let stored = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(instance) };
+    if stored.is_null() {
+        return PY_NULL;
+    }
+    unsafe { crate::pytraceback::mark_traceback_escaped(stored) };
+    stored
 }
 
 /// Detach the indicator and hand it to the caller, which is fetch-and-clear
@@ -945,6 +958,68 @@ pub unsafe extern "C" fn _PyErr_ChainExceptions1(exception: *mut CPyObject) {
     unsafe { PyErr_SetRaisedException(pending) };
 }
 
+/// `pyerrors.py PyTraceBack_Print(tb, file)` — write `tb` to `file` the way a
+/// report does, header line included.
+///
+/// The entries themselves are `traceback.print_tb`'s work rather than this
+/// one's, so what is written matches what the module writes everywhere else.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyTraceBack_Print(tb: *mut CPyObject, file: *mut CPyObject) -> c_int {
+    if tb.is_null() {
+        return 0;
+    }
+    let Some([traceback, file]) = super::object::arguments([tb, file]) else {
+        return -1;
+    };
+    if !unsafe { crate::pytraceback::is_pytraceback(traceback) } {
+        unsafe { PyErr_BadInternalCall() };
+        return -1;
+    }
+    let roots = pyre_object::gc_roots::push_roots();
+    let traceback_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(traceback);
+    let file_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(file);
+    let reload = pyre_object::gc_roots::shadow_stack_get;
+    let header = crate::baseobjspace::call_method(
+        reload(file_slot),
+        "write",
+        &[pyre_object::w_str_new(
+            "Traceback (most recent call last):\n",
+        )],
+    );
+    if header.is_null() {
+        return report_call_failure();
+    }
+    let Some(module) = trap(super::import_::import_module("traceback")) else {
+        return -1;
+    };
+    let module_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(module);
+    let printed = crate::baseobjspace::call_method(
+        reload(module_slot),
+        "print_tb",
+        &[
+            reload(traceback_slot),
+            pyre_object::w_none(),
+            reload(file_slot),
+        ],
+    );
+    if printed.is_null() {
+        return report_call_failure();
+    }
+    0
+}
+
+/// Move the error a NULL-answering call left behind onto the indicator, and
+/// answer -1 for the entry point that is giving up on it.
+fn report_call_failure() -> c_int {
+    if let Some(error) = crate::call::take_call_error() {
+        set_pending_error(error);
+    }
+    -1
+}
+
 /// `write_unraisable` over whatever the indicator holds, which the two
 /// entry points below share.
 ///
@@ -1290,4 +1365,6 @@ pub(super) fn ensure_linked() {
 
     std::hint::black_box(PyErr_Restore as *const ());
     std::hint::black_box(PyErr_NormalizeException as *const ());
+    std::hint::black_box(PyErr_PrintEx as *const ());
+    std::hint::black_box(PyTraceBack_Print as *const ());
 }

--- a/pyre/pyre-interpreter/src/cpyext/pyobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyobject.rs
@@ -28,7 +28,7 @@
 //! cycle is told apart from one from outside it.
 
 use super::ForkMutex;
-use super::typeobject::CPyTypeObject;
+use super::typeobject::{CPyTypeObject, CPyVarObject};
 use majit_gc::rawrefcount;
 use pyre_object::{PY_NULL, PyObjectRef};
 use std::alloc::Layout;

--- a/pyre/pyre-interpreter/src/cpyext/pyobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyobject.rs
@@ -1066,6 +1066,24 @@ pub unsafe extern "C" fn _Py_SetRefcnt(object: *mut CPyObject, refcnt: isize) {
     unsafe { (*object).ob_refcnt = refcnt };
 }
 
+/// The entry point `Py_INCREF` is a call to on a stable ABI from 3.12 on.
+///
+/// An extension compiled against the stable ABI expands the macro to this
+/// rather than touching `ob_refcnt`, so the two names have to be two symbols
+/// even though they do the same thing; `refcount.h` here spells the macro over
+/// [`Py_IncRef`], and an extension that declares the prototype itself -- as
+/// PyO3 does, which never reads these headers -- reaches this one.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn _Py_IncRef(object: *mut CPyObject) {
+    unsafe { incref(object) };
+}
+
+/// The `Py_DECREF` half of [`_Py_IncRef`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn _Py_DecRef(object: *mut CPyObject) {
+    unsafe { decref(object) };
+}
+
 /// The C-visible reference count, with the interpreter's own share removed —
 /// `Py_REFCNT` as a test can read it without depending on the link share.
 #[unsafe(no_mangle)]
@@ -1079,6 +1097,8 @@ pub unsafe extern "C" fn _PyPyre_RefCount(object: *mut CPyObject) -> isize {
 pub(super) fn ensure_linked() {
     std::hint::black_box(Py_IncRef as *const ());
     std::hint::black_box(Py_DecRef as *const ());
+    std::hint::black_box(_Py_IncRef as *const ());
+    std::hint::black_box(_Py_DecRef as *const ());
     std::hint::black_box(_PyPyre_RefCount as *const ());
     std::hint::black_box(_Py_SetRefcnt as *const ());
 }

--- a/pyre/pyre-interpreter/src/cpyext/pythonrun.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pythonrun.rs
@@ -1,0 +1,31 @@
+//! Starting and stopping the interpreter -- PyPy `cpyext/pythonrun.py`.
+//!
+//! An extension does not start pyre; it is loaded by an interpreter that is
+//! already running. What is left of this file upstream is therefore the pair
+//! of questions an extension asks about that interpreter's state, and both
+//! answer from what the running process already knows.
+
+use std::ffi::c_int;
+
+/// `pythonrun.py Py_IsInitialized` — an extension can only be here because
+/// the interpreter that loaded it is running, so the answer is constant.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Py_IsInitialized() -> c_int {
+    1
+}
+
+/// `Py_IsFinalizing` — whether interpreter teardown has begun.
+///
+/// The flag is the one `sys.is_finalizing` reports, set once atexit callbacks
+/// are done and module teardown is about to start. An extension asks so that a
+/// finalizer of its own can decline to call back in, which is exactly the
+/// window this covers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Py_IsFinalizing() -> c_int {
+    crate::module::thread::is_finalizing() as c_int
+}
+
+pub(super) fn ensure_linked() {
+    std::hint::black_box(Py_IsInitialized as *const ());
+    std::hint::black_box(Py_IsFinalizing as *const ());
+}

--- a/pyre/pyre-interpreter/src/cpyext/tupleobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/tupleobject.rs
@@ -51,6 +51,20 @@ fn is_array_backed(value: PyObjectRef) -> bool {
     }
 }
 
+/// `PyTuple_FromArray(array, size)` — the tuple a C array of references
+/// makes, as a new reference.  The array's own references are left alone.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyTuple_FromArray(
+    array: *const *mut CPyObject,
+    size: isize,
+) -> *mut CPyObject {
+    if size < 0 || (array.is_null() && size != 0) {
+        unsafe { super::pyerrors::PyErr_BadInternalCall() };
+        return std::ptr::null_mut();
+    }
+    unsafe { super::object::tuple_from_vector(array, size as usize) }
+}
+
 fn tuple_argument(object: *mut CPyObject, function: &str) -> Option<PyObjectRef> {
     let value = argument(object)?;
     if !unsafe { pyre_object::is_tuple(value) } {

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -2409,16 +2409,6 @@ pub(super) fn is_heap_type(tp: *mut CPyTypeObject) -> bool {
     !tp.is_null() && unsafe { (*tp).tp_flags } & PY_TPFLAGS_HEAPTYPE != 0
 }
 
-/// `true` when a mirror is itself a `PyTypeObject`, whose block therefore
-/// begins with a `PyVarObject` rather than a bare header.
-pub(super) fn is_type_mirror(raw: *mut CPyObject) -> bool {
-    if raw.is_null() {
-        return false;
-    }
-    let ob_type = unsafe { (*raw).ob_type };
-    !ob_type.is_null() && unsafe { (*ob_type).tp_flags } & PY_TPFLAGS_TYPE_SUBCLASS != 0
-}
-
 /// `true` when a mirror is a `PyModuleDef` rather than a linked object.
 pub(super) fn is_module_def(raw: *mut CPyObject) -> bool {
     !raw.is_null() && unsafe { std::ptr::eq((*raw).ob_type, &raw mut CPY_MODULE_DEF_TYPE) }
@@ -4599,13 +4589,47 @@ fn install_namespace(ns: PyObjectRef, tp: *mut CPyTypeObject) {
         let name = unsafe { std::ffi::CStr::from_ptr((*method).ml_name) }
             .to_string_lossy()
             .into_owned();
+        // `typeobject.c:type_add_method` — the flags decide the descriptor,
+        // each naming a different receiver.  A row carrying both is refused
+        // before the type is built.
+        let flags = unsafe { (*method).ml_flags };
+        let carrier_type = match flags & super::methodobject::METH_CLASS {
+            0 => method_descriptor_type(),
+            _ => classmethod_descriptor_type(),
+        };
         let descriptor = new_carrier(
-            method_descriptor_type(),
+            carrier_type,
             method as usize,
             unsafe { (*method).ml_name },
             unsafe { (*method).ml_doc },
             pyre_object::PY_NULL,
         );
+        let descriptor_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = roots.pin_root(descriptor);
+        // A static row is a function bound to the type, wrapped so that
+        // reading it through the class or an instance yields the function
+        // itself rather than binding a receiver a second time.
+        let descriptor = match flags & super::methodobject::METH_STATIC {
+            0 => pyre_object::gc_roots::shadow_stack_get(descriptor_slot),
+            _ => {
+                let owner = reload();
+                match super::methodobject::new_pycfunction(method, owner, owner) {
+                    Ok(function) => {
+                        let function_slot = pyre_object::gc_roots::shadow_stack_len();
+                        let _ = roots.pin_root(function);
+                        pyre_object::function::w_staticmethod_new(
+                            pyre_object::gc_roots::shadow_stack_get(function_slot),
+                        )
+                    }
+                    // The name is left unbound rather than bound to something
+                    // that would take its first argument as a receiver.
+                    Err(error) => {
+                        super::pyerrors::set_pending_error(error);
+                        continue;
+                    }
+                }
+            }
+        };
         let descriptor_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = roots.pin_root(descriptor);
         store(
@@ -5060,6 +5084,29 @@ fn ready(tp: *mut CPyTypeObject, w_metaclass: PyObjectRef) -> Result<(), crate::
     // where `tp_name`'s prefix is meant to end up.
 
     let w_metatype = resolve_metatype(tp, w_metaclass, w_base)?;
+
+    // `typeobject.c:type_add_method` refuses a row declaring both, because
+    // each of the two names a different receiver.
+    let mut index = 0isize;
+    while unsafe {
+        !(*tp).tp_methods.is_null() && !(*(*tp).tp_methods.offset(index)).ml_name.is_null()
+    } {
+        let method = unsafe { (*tp).tp_methods.offset(index) };
+        index += 1;
+        let flags = unsafe { (*method).ml_flags };
+        if flags & super::methodobject::METH_CLASS == 0
+            || flags & super::methodobject::METH_STATIC == 0
+        {
+            continue;
+        }
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            format!(
+                "method cannot be both class and static: {}",
+                unsafe { std::ffi::CStr::from_ptr((*method).ml_name) }.to_string_lossy()
+            ),
+        ));
+    }
 
     let roots = pyre_object::gc_roots::push_roots();
     let base_slot = pyre_object::gc_roots::shadow_stack_len();

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -2409,6 +2409,16 @@ pub(super) fn is_heap_type(tp: *mut CPyTypeObject) -> bool {
     !tp.is_null() && unsafe { (*tp).tp_flags } & PY_TPFLAGS_HEAPTYPE != 0
 }
 
+/// `true` when a mirror is itself a `PyTypeObject`, whose block therefore
+/// begins with a `PyVarObject` rather than a bare header.
+pub(super) fn is_type_mirror(raw: *mut CPyObject) -> bool {
+    if raw.is_null() {
+        return false;
+    }
+    let ob_type = unsafe { (*raw).ob_type };
+    !ob_type.is_null() && unsafe { (*ob_type).tp_flags } & PY_TPFLAGS_TYPE_SUBCLASS != 0
+}
+
 /// `true` when a mirror is a `PyModuleDef` rather than a linked object.
 pub(super) fn is_module_def(raw: *mut CPyObject) -> bool {
     !raw.is_null() && unsafe { std::ptr::eq((*raw).ob_type, &raw mut CPY_MODULE_DEF_TYPE) }
@@ -5843,6 +5853,97 @@ fn from_spec(
 pub unsafe extern "C" fn PyType_FromSpec(spec: *mut CPyTypeSpec) -> *mut CPyObject {
     super::object::result(from_spec(
         spec,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+    ))
+}
+
+/// `PySlot` — one entry of the identifier-keyed array `PyType_FromSlots`
+/// reads, which supersedes `PyType_Spec`'s fixed fields.  The value is a
+/// union of a pointer, a function, and the integer widths; every arm is
+/// eight bytes wide, so one of them stands for all.
+#[repr(C)]
+pub struct CPySlot {
+    pub sl_id: u16,
+    pub sl_flags: u16,
+    pub sl_reserved: u32,
+    pub sl_value: u64,
+}
+
+/// `PySlot.sl_flags`: an entry the reader may skip rather than refuse.
+pub(super) const SLOT_OPTIONAL: u16 = 0x01;
+
+/// The identifiers `PyType_FromSlots` reads for itself; every other one is
+/// left to the `Py_tp_slots` array, which is the `PyType_Spec` vocabulary.
+mod from_slots_id {
+    pub const TP_SLOTS: u16 = 93;
+    pub const TP_NAME: u16 = 95;
+    pub const TP_BASICSIZE: u16 = 96;
+    pub const TP_EXTRA_BASICSIZE: u16 = 97;
+    pub const TP_ITEMSIZE: u16 = 98;
+    pub const TP_FLAGS: u16 = 99;
+}
+
+/// `PyType_FromSlots(slots)` — a heap type described by one array rather than
+/// by a `PyType_Spec` beside one.
+///
+/// The array is read into the spec the rest of this layer already builds a
+/// type from: the identifiers below carry what the spec's own fields carry,
+/// and `Py_tp_slots` carries the array the spec would have pointed at.  A
+/// zero identifier ends the array.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyType_FromSlots(slots: *mut CPySlot) -> *mut CPyObject {
+    if slots.is_null() {
+        unsafe { super::pyerrors::PyErr_BadInternalCall() };
+        return std::ptr::null_mut();
+    }
+    let mut spec = CPyTypeSpec {
+        name: std::ptr::null(),
+        basicsize: 0,
+        itemsize: 0,
+        flags: 0,
+        slots: std::ptr::null_mut(),
+    };
+    let mut entry = slots;
+    loop {
+        let slot = unsafe { &*entry };
+        if slot.sl_id == 0 {
+            break;
+        }
+        let value = slot.sl_value;
+        match slot.sl_id {
+            from_slots_id::TP_NAME => spec.name = value as *const c_char,
+            from_slots_id::TP_FLAGS => spec.flags = value as c_uint,
+            from_slots_id::TP_BASICSIZE => spec.basicsize = value as isize as c_int,
+            // A size relative to the base's, which the spec spells as the
+            // negative of the same number.
+            from_slots_id::TP_EXTRA_BASICSIZE => {
+                spec.basicsize = -(value as isize as c_int);
+            }
+            from_slots_id::TP_ITEMSIZE => spec.itemsize = value as isize as c_int,
+            from_slots_id::TP_SLOTS => spec.slots = value as *mut CPyTypeSlot,
+            unknown => {
+                if slot.sl_flags & SLOT_OPTIONAL == 0 {
+                    super::pyerrors::set_pending_error(crate::PyError::new(
+                        crate::PyErrorKind::SystemError,
+                        format!("PyType_FromSlots(): unrecognised slot {unknown}"),
+                    ));
+                    return std::ptr::null_mut();
+                }
+            }
+        }
+        entry = unsafe { entry.add(1) };
+    }
+    if spec.name.is_null() {
+        super::pyerrors::set_pending_error(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            "PyType_FromSlots(): the slot array has no Py_tp_name",
+        ));
+        return std::ptr::null_mut();
+    }
+    super::object::result(from_spec(
+        &raw mut spec,
         std::ptr::null_mut(),
         std::ptr::null_mut(),
         std::ptr::null_mut(),

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -943,13 +943,27 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
             // produced outside the constructor path (`gateway.rs` raise
             // sites that bypass `exc_constructor!`).
             let class_name = if let Some(cls) = crate::typedef::r#type(obj) {
-                pyre_object::w_type_get_name(cls.as_ptr()).to_string()
+                // `w_type_get_name_obj` is the accessor the `__name__` getter
+                // reads, so the two answers cannot drift.  A class registered
+                // as `"termios.error"` is named `error` in the module
+                // `termios` — `new_exception_class` splits the dotted name
+                // before it calls `type` — while `w_type_get_name` keeps the
+                // undivided registration name, which spells the module twice
+                // here.
+                let w_name = unsafe { pyre_object::w_type_get_name_obj(cls.as_ptr()) };
+                pyre_object::w_str_get_wtf8(w_name).to_wtf8_buf()
             } else {
-                pyre_object::interp_exceptions::exc_kind_name(pyre_object::w_exception_get_kind(
-                    obj,
-                ))
-                .to_string()
+                Wtf8Buf::from_string(
+                    pyre_object::interp_exceptions::exc_kind_name(
+                        pyre_object::w_exception_get_kind(obj),
+                    )
+                    .to_string(),
+                )
             };
+            // The name object above is minted on its first read of a class, so
+            // that read is a collection point and the receiver comes back off
+            // the shadow stack.
+            obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let args_obj = unsafe { pyre_object::interp_exceptions::w_exception_get_args(obj) };
             let mut inner = Wtf8Buf::new();
             if !args_obj.is_null() && pyre_object::is_tuple(args_obj) {
@@ -983,7 +997,7 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
                 }
             }
             let mut out = Wtf8Buf::new();
-            out.push_str(&class_name);
+            out.push_wtf8(&class_name);
             out.push_str("(");
             out.push_wtf8(&inner);
             out.push_str(")");

--- a/pyre/pyre-interpreter/src/host_seam.rs
+++ b/pyre/pyre-interpreter/src/host_seam.rs
@@ -81,6 +81,23 @@ pub mod sys {
         S_IFREG, SEEK_CUR, SEEK_END, SEEK_SET, ST_NOSUID, ST_RDONLY, TIOCGWINSZ, W_OK, WCONTINUED,
         WEXITED, WNOHANG, WNOWAIT, WSTOPPED, WUNTRACED, X_OK,
     };
+    // `posix`'s darwin-only names: the `setpriority` scopes, the `copyfile`
+    // flags `_fcopyfile` takes, and `<stdio.h>`'s own `TMP_MAX`.
+    #[cfg(target_vendor = "apple")]
+    pub use ::libc::{
+        COPYFILE_ACL, COPYFILE_DATA, COPYFILE_STAT, COPYFILE_XATTR, PRIO_DARWIN_BG,
+        PRIO_DARWIN_NONUI, PRIO_DARWIN_PROCESS, PRIO_DARWIN_THREAD, TMP_MAX,
+    };
+    // The `<langinfo.h>` items beside `CODESET`, which `_locale` publishes as
+    // the keys `nl_langinfo` takes.
+    pub use ::libc::{
+        ABDAY_1, ABDAY_2, ABDAY_3, ABDAY_4, ABDAY_5, ABDAY_6, ABDAY_7, ABMON_1, ABMON_2, ABMON_3,
+        ABMON_4, ABMON_5, ABMON_6, ABMON_7, ABMON_8, ABMON_9, ABMON_10, ABMON_11, ABMON_12,
+        ALT_DIGITS, AM_STR, CRNCYSTR, D_FMT, D_T_FMT, DAY_1, DAY_2, DAY_3, DAY_4, DAY_5, DAY_6,
+        DAY_7, ERA, ERA_D_FMT, ERA_D_T_FMT, ERA_T_FMT, MON_1, MON_2, MON_3, MON_4, MON_5, MON_6,
+        MON_7, MON_8, MON_9, MON_10, MON_11, MON_12, NOEXPR, PM_STR, RADIXCHAR, T_FMT, T_FMT_AMPM,
+        THOUSEP, YESEXPR,
+    };
     // The `<fcntl.h>` flags only one platform declares, carrying the same gates
     // as the table that publishes them.
     #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -937,6 +937,30 @@ pub use shared_opcode::*;
 /// constants as `malachite_bigint::BigInt`.  Convert at that fixed API seam;
 /// interpreter objects and every arithmetic operation use RPython's rbigint.
 #[majit_macros::dont_look_inside]
+/// An error's own message followed by whatever it names as the cause.
+///
+/// A host library loader reports the reason a load failed -- the `dlerror()`
+/// text, and it is the whole diagnostic -- as the error's *source* rather than
+/// in its own `Display`, which alone reads only "dlopen failed". A message
+/// built from `{error}` therefore says that something went wrong and nothing
+/// about what, so every load failure reads alike and none can be triaged.
+///
+/// A cause already quoted by the message it would be appended to is left out,
+/// since a chain that repeats itself reads as two failures.
+pub(crate) fn with_causes(error: &dyn std::error::Error) -> String {
+    let mut rendered = error.to_string();
+    let mut cause = error.source();
+    while let Some(source) = cause {
+        let text = source.to_string();
+        if !text.is_empty() && !rendered.contains(&text) {
+            rendered.push_str(": ");
+            rendered.push_str(&text);
+        }
+        cause = source.source();
+    }
+    rendered
+}
+
 pub(crate) fn compiler_bigint_to_rbigint(value: &malachite_bigint::BigInt) -> PyBigInt {
     let (sign, bytes) = value.to_bytes_le();
     let sign = match sign {

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -105,7 +105,11 @@ pub fn preprocess_object_to_object(
     let mut module = converter.module(object)?;
     crate::astcompiler::validate::validate_ast(&module)?;
     preprocess_module(&mut module, mode, opts, syntax_check_only);
-    let source = if source.is_empty() { &synthetic } else { source };
+    let source = if source.is_empty() {
+        &synthetic
+    } else {
+        source
+    };
     module_to_object(module, source, mode, ast_module)
 }
 
@@ -161,7 +165,8 @@ impl ObjectConverter {
         if !self.is_node(object, "AST")? {
             return Ok(());
         }
-        for (line_field, column_field) in [("lineno", "col_offset"), ("end_lineno", "end_col_offset")]
+        for (line_field, column_field) in
+            [("lineno", "col_offset"), ("end_lineno", "end_col_offset")]
         {
             if let Some(value) = self.optional_field(object, line_field)?
                 && let Ok(line) = self.obj_to_int(value)

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -28,11 +28,17 @@ pub fn compile_object(
     let mut converter = ObjectConverter {
         ast_module,
         depth: 0,
+        line_len: 0,
     };
+    // The compiler reads a node's position out of the source text the range
+    // indexes, so a tree that came from objects needs a text to index.  Stand
+    // one up whose lines are wide enough for every column the tree names; the
+    // characters are never read, only counted.
+    let text = converter.synthetic_source(object)?;
     let module = converter.module(object)?;
     // compiling.py:73 — the tree is walked before it reaches the compiler.
     crate::astcompiler::validate::validate_ast(&module)?;
-    let source_file = rustpython_compiler::core::SourceFileBuilder::new(filename, "").finish();
+    let source_file = rustpython_compiler::core::SourceFileBuilder::new(filename, text).finish();
     rustpython_compiler::codegen::compile::compile_top(module, source_file, mode, opts)
         .map_err(|error| crate::PyError::syntax_error(error.to_string()))
 }
@@ -89,19 +95,115 @@ pub fn preprocess_object_to_object(
     let mut converter = ObjectConverter {
         ast_module,
         depth: 0,
+        line_len: 0,
     };
+    // Both directions have to read positions out of the same text, and a tree
+    // handed in as objects arrives without one.  The synthetic source stands
+    // in for it so the round trip gives every node back the line and column it
+    // came with.
+    let synthetic = converter.synthetic_source(object)?;
     let mut module = converter.module(object)?;
     crate::astcompiler::validate::validate_ast(&module)?;
     preprocess_module(&mut module, mode, opts, syntax_check_only);
+    let source = if source.is_empty() { &synthetic } else { source };
     module_to_object(module, source, mode, ast_module)
 }
 
 struct ObjectConverter {
     ast_module: PyObjectRef,
     depth: usize,
+    /// Characters on each line of the synthetic source, excluding the newline.
+    /// Zero until `synthetic_source` has measured the tree.
+    line_len: usize,
 }
 
 impl ObjectConverter {
+    /// Blank text with a line for every line the tree names and columns for
+    /// the widest of them, so that `location` can turn a node's `lineno` and
+    /// `col_offset` into an offset the compiler can map back.
+    fn synthetic_source(&mut self, object: PyObjectRef) -> AstResult<String> {
+        let mut extent = (0usize, 0usize);
+        self.scan_extent(object, &mut extent)?;
+        let (max_line, max_col) = extent;
+        if max_line == 0 {
+            return Ok(String::new());
+        }
+        self.line_len = max_col.saturating_add(1);
+        let mut source = String::new();
+        let width = self.line_len.saturating_add(1);
+        source
+            .try_reserve(width.saturating_mul(max_line))
+            .map_err(|_| crate::PyError::memory_error("source location is too large"))?;
+        for _ in 0..max_line {
+            source.extend(core::iter::repeat_n(' ', self.line_len));
+            source.push('\n');
+        }
+        Ok(source)
+    }
+
+    /// Widen `extent` to the last line and rightmost column any node in the
+    /// tree claims.  The walk is over `_fields` rather than the typed
+    /// conversion below, because it runs before anything has been validated
+    /// and must not reject a tree the converter would go on to accept.
+    fn scan_extent(&mut self, object: PyObjectRef, extent: &mut (usize, usize)) -> AstResult<()> {
+        if unsafe { pyre_object::is_list(object) } {
+            for item in unsafe { pyre_object::w_list_items_copy_as_vec(object) } {
+                self.recurse(|this| this.scan_extent(item, extent))?;
+            }
+            return Ok(());
+        }
+        if unsafe { pyre_object::is_tuple(object) } {
+            for item in unsafe { pyre_object::w_tuple_items_copy_as_vec(object) } {
+                self.recurse(|this| this.scan_extent(item, extent))?;
+            }
+            return Ok(());
+        }
+        if !self.is_node(object, "AST")? {
+            return Ok(());
+        }
+        for (line_field, column_field) in [("lineno", "col_offset"), ("end_lineno", "end_col_offset")]
+        {
+            if let Some(value) = self.optional_field(object, line_field)?
+                && let Ok(line) = self.obj_to_int(value)
+                && line > 0
+            {
+                extent.0 = extent.0.max(line as usize);
+            }
+            if let Some(value) = self.optional_field(object, column_field)?
+                && let Ok(column) = self.obj_to_int(value)
+                && column > 0
+            {
+                extent.1 = extent.1.max(column as usize);
+            }
+        }
+        let Some(fields) = self.optional_field(object, "_fields")? else {
+            return Ok(());
+        };
+        if !unsafe { pyre_object::is_tuple(fields) } {
+            return Ok(());
+        }
+        for name in unsafe { pyre_object::w_tuple_items_copy_as_vec(fields) } {
+            if !unsafe { pyre_object::is_str(name) } {
+                continue;
+            }
+            let name = unsafe { pyre_object::w_str_get_value(name) }.to_string();
+            if let Some(value) = self.optional_field(object, &name)? {
+                self.recurse(|this| this.scan_extent(value, extent))?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Offset of a one-based line and a zero-based column in the synthetic
+    /// source, clamped to the line it names.
+    fn offset_of(&self, line: i64, column: i64) -> u32 {
+        let line = usize::try_from(line).unwrap_or(1).max(1);
+        let column = usize::try_from(column).unwrap_or(0).min(self.line_len);
+        let width = self.line_len.saturating_add(1);
+        let offset = (line - 1).saturating_mul(width).saturating_add(column);
+        u32::try_from(offset).unwrap_or(u32::MAX)
+    }
+
     fn recurse<T>(&mut self, f: impl FnOnce(&mut Self) -> AstResult<T>) -> AstResult<T> {
         // PyPy's generated ast_from_object calls space.getexecutioncontext()
         // recursion guards around nested ASDL nodes.  Keep the state on this
@@ -175,19 +277,26 @@ impl ObjectConverter {
         crate::builtins::space_index_w(value)
     }
 
-    /// The source range an object carries as attributes.  A tree compiled
-    /// from objects has no source to map a range back onto, so these are read
-    /// only for what the boundary owes them: `lineno` and `col_offset` are
-    /// required, and the two end fields are optional.
-    fn location(&self, object: PyObjectRef, node: &str) -> AstResult<()> {
-        self.int_field(object, "lineno", node)?;
-        self.int_field(object, "col_offset", node)?;
-        for field in ["end_lineno", "end_col_offset"] {
-            if let Some(value) = self.optional_field(object, field)? {
-                self.obj_to_int(value)?;
-            }
-        }
-        Ok(())
+    /// The source range an object carries as attributes, placed in the
+    /// synthetic source.  `lineno` and `col_offset` are required; the two end
+    /// fields are optional and fall back to the start, which is what a node
+    /// built by hand without them describes.
+    fn location(&self, object: PyObjectRef, node: &str) -> AstResult<ruff_text_size::TextRange> {
+        let line = self.int_field(object, "lineno", node)?;
+        let column = self.int_field(object, "col_offset", node)?;
+        let end_line = match self.optional_field(object, "end_lineno")? {
+            Some(value) => self.obj_to_int(value)?,
+            None => line,
+        };
+        let end_column = match self.optional_field(object, "end_col_offset")? {
+            Some(value) => self.obj_to_int(value)?,
+            None => column,
+        };
+        let start = self.offset_of(line, column);
+        // A tree can name an end before its start; the compiler indexes the
+        // range and a reversed one would panic, so it collapses to the start.
+        let end = self.offset_of(end_line, end_column).max(start);
+        Ok(ruff_text_size::TextRange::new(start.into(), end.into()))
     }
 
     /// `Module.type_ignores` (ast.py) holds the `# type: ignore` comments
@@ -248,7 +357,7 @@ impl ObjectConverter {
     }
 
     fn stmt(&mut self, object: PyObjectRef) -> AstResult<ast::Stmt> {
-        self.location(object, "stmt")?;
+        let range = self.location(object, "stmt")?;
         if self.is_node(object, "FunctionDef")? || self.is_node(object, "AsyncFunctionDef")? {
             let is_async = self.is_node(object, "AsyncFunctionDef")?;
             let node = if is_async {
@@ -265,7 +374,7 @@ impl ObjectConverter {
             let type_params = self.type_params(object, node)?;
             Ok(ast::Stmt::FunctionDef(ast::StmtFunctionDef {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 is_async,
                 decorator_list,
                 name,
@@ -281,20 +390,20 @@ impl ObjectConverter {
         } else if self.is_node(object, "Pass")? {
             Ok(ast::Stmt::Pass(ast::StmtPass {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
             }))
         } else if self.is_node(object, "Expr")? {
             let value = self.field(object, "value", "Expr")?;
             Ok(ast::Stmt::Expr(ast::StmtExpr {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 value: Box::new(self.recurse(|this| this.expr(value))?),
             }))
         } else if self.is_node(object, "Return")? {
             let value = self.optional_field(object, "value")?;
             Ok(ast::Stmt::Return(ast::StmtReturn {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 value: value
                     .map(|value| self.recurse(|this| this.expr(value)).map(Box::new))
                     .transpose()?,
@@ -311,7 +420,7 @@ impl ObjectConverter {
             let value = self.field(object, "value", "Assign")?;
             Ok(ast::Stmt::Assign(ast::StmtAssign {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 targets,
                 value: Box::new(self.recurse(|this| this.expr(value))?),
                 runtime_targets: None,
@@ -336,7 +445,7 @@ impl ObjectConverter {
             } else {
                 Some(Box::new(ast::Arguments {
                     node_index: Default::default(),
-                    range: Default::default(),
+                    range,
                     args: bases.into_boxed_slice(),
                     keywords: keywords.into_boxed_slice(),
                     runtime_args: None,
@@ -345,7 +454,7 @@ impl ObjectConverter {
             };
             Ok(ast::Stmt::ClassDef(ast::StmtClassDef {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 decorator_list,
                 name,
                 type_params,
@@ -357,7 +466,7 @@ impl ObjectConverter {
         } else if self.is_node(object, "Delete")? {
             Ok(ast::Stmt::Delete(ast::StmtDelete {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 targets: self.exprs(object, "targets", "Delete")?,
                 runtime_targets: None,
             }))
@@ -367,7 +476,7 @@ impl ObjectConverter {
             let value = self.req_expr(object, "value", "TypeAlias")?;
             Ok(ast::Stmt::TypeAlias(ast::StmtTypeAlias {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 name,
                 type_params,
                 value,
@@ -378,7 +487,7 @@ impl ObjectConverter {
             let value = self.req_expr(object, "value", "AugAssign")?;
             Ok(ast::Stmt::AugAssign(ast::StmtAugAssign {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 target,
                 op: self.operator(op)?,
                 value,
@@ -390,7 +499,7 @@ impl ObjectConverter {
             let simple = self.int_field(object, "simple", "AnnAssign")?;
             Ok(ast::Stmt::AnnAssign(ast::StmtAnnAssign {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 target,
                 annotation,
                 value,
@@ -406,7 +515,7 @@ impl ObjectConverter {
             let orelse = self.body(object, "orelse", node)?;
             Ok(ast::Stmt::For(ast::StmtFor {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 is_async,
                 target,
                 iter,
@@ -423,7 +532,7 @@ impl ObjectConverter {
             let orelse = self.body(object, "orelse", "While")?;
             Ok(ast::Stmt::While(ast::StmtWhile {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 test,
                 body,
                 orelse,
@@ -445,7 +554,7 @@ impl ObjectConverter {
                     let clause_test = self.req_expr(nested, "test", "If")?;
                     let clause_body = self.body(nested, "body", "If")?;
                     elif_else_clauses.push(ast::ElifElseClause {
-                        range: Default::default(),
+                        range,
                         node_index: Default::default(),
                         test: Some(*clause_test),
                         body: clause_body,
@@ -463,7 +572,7 @@ impl ObjectConverter {
                         })
                         .collect::<Result<Vec<_>, _>>()?;
                     elif_else_clauses.push(ast::ElifElseClause {
-                        range: Default::default(),
+                        range,
                         node_index: Default::default(),
                         test: None,
                         body: clause_body,
@@ -474,7 +583,7 @@ impl ObjectConverter {
             }
             Ok(ast::Stmt::If(ast::StmtIf {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 test,
                 body,
                 elif_else_clauses,
@@ -491,7 +600,7 @@ impl ObjectConverter {
             let body = self.body(object, "body", node)?;
             Ok(ast::Stmt::With(ast::StmtWith {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 is_async,
                 items,
                 body,
@@ -502,7 +611,7 @@ impl ObjectConverter {
         } else if self.is_node(object, "Raise")? {
             Ok(ast::Stmt::Raise(ast::StmtRaise {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 exc: self.opt_expr(object, "exc")?,
                 cause: self.opt_expr(object, "cause")?,
             }))
@@ -519,7 +628,7 @@ impl ObjectConverter {
             let finalbody = self.body(object, "finalbody", node)?;
             Ok(ast::Stmt::Try(ast::StmtTry {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 body,
                 handlers,
                 orelse,
@@ -535,14 +644,14 @@ impl ObjectConverter {
             let msg = self.opt_expr(object, "msg")?;
             Ok(ast::Stmt::Assert(ast::StmtAssert {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 test,
                 msg,
             }))
         } else if self.is_node(object, "Import")? {
             Ok(ast::Stmt::Import(ast::StmtImport {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 names: self.aliases(object, "Import")?,
                 is_lazy: false,
             }))
@@ -565,7 +674,7 @@ impl ObjectConverter {
             })?;
             Ok(ast::Stmt::ImportFrom(ast::StmtImportFrom {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 module,
                 names,
                 level,
@@ -575,24 +684,24 @@ impl ObjectConverter {
         } else if self.is_node(object, "Global")? {
             Ok(ast::Stmt::Global(ast::StmtGlobal {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 names: self.identifiers(object, "names", "Global")?,
             }))
         } else if self.is_node(object, "Nonlocal")? {
             Ok(ast::Stmt::Nonlocal(ast::StmtNonlocal {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 names: self.identifiers(object, "names", "Nonlocal")?,
             }))
         } else if self.is_node(object, "Break")? {
             Ok(ast::Stmt::Break(ast::StmtBreak {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
             }))
         } else if self.is_node(object, "Continue")? {
             Ok(ast::Stmt::Continue(ast::StmtContinue {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
             }))
         } else if self.is_node(object, "Match")? {
             let subject = self.req_expr(object, "subject", "Match")?;
@@ -603,7 +712,7 @@ impl ObjectConverter {
                 .collect::<Result<Vec<_>, _>>()?;
             Ok(ast::Stmt::Match(ast::StmtMatch {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 subject,
                 cases,
             }))
@@ -704,9 +813,9 @@ impl ObjectConverter {
     }
 
     fn parameter(&mut self, object: PyObjectRef) -> AstResult<ast::Parameter> {
-        self.location(object, "arg")?;
+        let range = self.location(object, "arg")?;
         Ok(ast::Parameter {
-            range: Default::default(),
+            range,
             node_index: Default::default(),
             name: self.identifier(object, "arg", "arg")?,
             annotation: self.opt_expr(object, "annotation")?,
@@ -726,7 +835,7 @@ impl ObjectConverter {
     }
 
     fn handler(&mut self, object: PyObjectRef) -> AstResult<ast::ExceptHandler> {
-        self.location(object, "excepthandler")?;
+        let range = self.location(object, "excepthandler")?;
         if !self.is_node(object, "ExceptHandler")? {
             return Err(crate::PyError::type_error(crate::display::wtf8_format!(
                 "expected some sort of excepthandler, but got ",
@@ -735,7 +844,7 @@ impl ObjectConverter {
         }
         Ok(ast::ExceptHandler::ExceptHandler(
             ast::ExceptHandlerExceptHandler {
-                range: Default::default(),
+                range,
                 node_index: Default::default(),
                 type_: self.opt_expr(object, "type")?,
                 name: self.opt_identifier(object, "name")?,
@@ -777,9 +886,9 @@ impl ObjectConverter {
         self.list(object, "names", node)?
             .into_iter()
             .map(|value| {
-                self.location(value, "alias")?;
+                let range = self.location(value, "alias")?;
                 Ok(ast::Alias {
-                    range: Default::default(),
+                    range,
                     node_index: Default::default(),
                     name: self.identifier(value, "name", "alias")?,
                     asname: self.opt_identifier(value, "asname")?,
@@ -835,12 +944,12 @@ impl ObjectConverter {
     }
 
     fn type_param(&mut self, object: PyObjectRef) -> AstResult<ast::TypeParam> {
-        self.location(object, "type_param")?;
+        let range = self.location(object, "type_param")?;
         if self.is_node(object, "TypeVar")? {
             let name = self.identifier(object, "name", "TypeVar")?;
             Ok(ast::TypeParam::TypeVar(ast::TypeParamTypeVar {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 name,
                 bound: self.opt_expr(object, "bound")?,
                 default: self.opt_expr(object, "default_value")?,
@@ -849,7 +958,7 @@ impl ObjectConverter {
             let name = self.identifier(object, "name", "TypeVarTuple")?;
             Ok(ast::TypeParam::TypeVarTuple(ast::TypeParamTypeVarTuple {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 name,
                 default: self.opt_expr(object, "default_value")?,
             }))
@@ -857,7 +966,7 @@ impl ObjectConverter {
             let name = self.identifier(object, "name", "ParamSpec")?;
             Ok(ast::TypeParam::ParamSpec(ast::TypeParamParamSpec {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 name,
                 default: self.opt_expr(object, "default_value")?,
             }))
@@ -895,11 +1004,11 @@ impl ObjectConverter {
     }
 
     fn pattern(&mut self, object: PyObjectRef) -> AstResult<ast::Pattern> {
-        self.location(object, "pattern")?;
+        let range = self.location(object, "pattern")?;
         if self.is_node(object, "MatchValue")? {
             Ok(ast::Pattern::MatchValue(ast::PatternMatchValue {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 value: self.req_expr(object, "value", "MatchValue")?,
             }))
         } else if self.is_node(object, "MatchSingleton")? {
@@ -921,13 +1030,13 @@ impl ObjectConverter {
             };
             Ok(ast::Pattern::MatchSingleton(ast::PatternMatchSingleton {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 value,
             }))
         } else if self.is_node(object, "MatchSequence")? {
             Ok(ast::Pattern::MatchSequence(ast::PatternMatchSequence {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 patterns: self.patterns(object, "patterns", "MatchSequence")?,
                 runtime_patterns: None,
             }))
@@ -936,7 +1045,7 @@ impl ObjectConverter {
             let patterns = self.patterns(object, "patterns", "MatchMapping")?;
             Ok(ast::Pattern::MatchMapping(ast::PatternMatchMapping {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 keys,
                 patterns,
                 rest: self.opt_identifier(object, "rest")?,
@@ -957,7 +1066,7 @@ impl ObjectConverter {
                 .into_iter()
                 .zip(kwd_patterns)
                 .map(|(attr, pattern)| ast::PatternKeyword {
-                    range: Default::default(),
+                    range,
                     node_index: Default::default(),
                     attr,
                     pattern,
@@ -965,10 +1074,10 @@ impl ObjectConverter {
                 .collect();
             Ok(ast::Pattern::MatchClass(ast::PatternMatchClass {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 cls,
                 arguments: ast::PatternArguments {
-                    range: Default::default(),
+                    range,
                     node_index: Default::default(),
                     patterns,
                     keywords,
@@ -980,7 +1089,7 @@ impl ObjectConverter {
         } else if self.is_node(object, "MatchStar")? {
             Ok(ast::Pattern::MatchStar(ast::PatternMatchStar {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 name: self.opt_identifier(object, "name")?,
             }))
         } else if self.is_node(object, "MatchAs")? {
@@ -990,14 +1099,14 @@ impl ObjectConverter {
                 .transpose()?;
             Ok(ast::Pattern::MatchAs(ast::PatternMatchAs {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 pattern,
                 name: self.opt_identifier(object, "name")?,
             }))
         } else if self.is_node(object, "MatchOr")? {
             Ok(ast::Pattern::MatchOr(ast::PatternMatchOr {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 patterns: self.patterns(object, "patterns", "MatchOr")?,
                 runtime_patterns: None,
             }))
@@ -1118,13 +1227,13 @@ impl ObjectConverter {
     }
 
     fn expr(&mut self, object: PyObjectRef) -> AstResult<ast::Expr> {
-        self.location(object, "expr")?;
+        let range = self.location(object, "expr")?;
         if self.is_node(object, "UnaryOp")? {
             let operand = self.field(object, "operand", "UnaryOp")?;
             let op = self.field(object, "op", "UnaryOp")?;
             Ok(ast::Expr::UnaryOp(ast::ExprUnaryOp {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 op: self.unaryop(op)?,
                 operand: Box::new(self.recurse(|this| this.expr(operand))?),
             }))
@@ -1134,7 +1243,7 @@ impl ObjectConverter {
             let op = self.field(object, "op", "BinOp")?;
             Ok(ast::Expr::BinOp(ast::ExprBinOp {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 left: Box::new(self.recurse(|this| this.expr(left))?),
                 op: self.operator(op)?,
                 right: Box::new(self.recurse(|this| this.expr(right))?),
@@ -1156,11 +1265,11 @@ impl ObjectConverter {
                 .collect::<Result<Vec<_>, _>>()?;
             Ok(ast::Expr::Call(ast::ExprCall {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 func: Box::new(self.recurse(|this| this.expr(func))?),
                 arguments: ast::Arguments {
                     node_index: Default::default(),
-                    range: Default::default(),
+                    range,
                     args: args.into_boxed_slice(),
                     keywords: keywords.into_boxed_slice(),
                     runtime_args: None,
@@ -1172,7 +1281,7 @@ impl ObjectConverter {
             let ctx = self.field(object, "ctx", "Attribute")?;
             Ok(ast::Expr::Attribute(ast::ExprAttribute {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 value: Box::new(self.recurse(|this| this.expr(value))?),
                 attr: ast::Identifier::new(
                     self.string(object, "attr", "Attribute")?,
@@ -1194,7 +1303,7 @@ impl ObjectConverter {
             if is_tuple {
                 Ok(ast::Expr::Tuple(ast::ExprTuple {
                     node_index: Default::default(),
-                    range: Default::default(),
+                    range,
                     elts: elements,
                     ctx,
                     parenthesized: true,
@@ -1203,7 +1312,7 @@ impl ObjectConverter {
             } else {
                 Ok(ast::Expr::List(ast::ExprList {
                     node_index: Default::default(),
-                    range: Default::default(),
+                    range,
                     elts: elements,
                     ctx,
                     runtime_elts: None,
@@ -1213,7 +1322,7 @@ impl ObjectConverter {
             let ctx = self.context(self.field(object, "ctx", "Name")?)?;
             Ok(ast::Expr::Name(ast::ExprName {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 id: ast::name::Name::new(self.string(object, "id", "Name")?),
                 ctx,
             }))
@@ -1221,7 +1330,7 @@ impl ObjectConverter {
             let value = self.field(object, "value", "Constant")?;
             Ok(ast::Expr::Constant(ast::ExprConstant {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 value: self.constant_value(value)?,
                 kind: self.constant_kind(object)?,
                 invalid_type: None,
@@ -1230,7 +1339,7 @@ impl ObjectConverter {
             let op = self.field(object, "op", "BoolOp")?;
             Ok(ast::Expr::BoolOp(ast::ExprBoolOp {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 op: self.boolop(op)?,
                 values: self.exprs(object, "values", "BoolOp")?,
                 runtime_values: None,
@@ -1240,7 +1349,7 @@ impl ObjectConverter {
             let value = self.req_expr(object, "value", "NamedExpr")?;
             Ok(ast::Expr::Named(ast::ExprNamed {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 target,
                 value,
             }))
@@ -1250,7 +1359,7 @@ impl ObjectConverter {
             let body = self.req_expr(object, "body", "Lambda")?;
             Ok(ast::Expr::Lambda(ast::ExprLambda {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 parameters: Some(Box::new(parameters)),
                 body,
             }))
@@ -1260,7 +1369,7 @@ impl ObjectConverter {
             let orelse = self.req_expr(object, "orelse", "IfExp")?;
             Ok(ast::Expr::If(ast::ExprIf {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 test,
                 body,
                 orelse,
@@ -1292,14 +1401,14 @@ impl ObjectConverter {
                 .collect::<Result<Vec<_>, crate::PyError>>()?;
             Ok(ast::Expr::Dict(ast::ExprDict {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 items,
                 runtime_values: None,
             }))
         } else if self.is_node(object, "Set")? {
             Ok(ast::Expr::Set(ast::ExprSet {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 elts: self.exprs(object, "elts", "Set")?,
                 runtime_elts: None,
             }))
@@ -1308,7 +1417,7 @@ impl ObjectConverter {
             let generators = self.comprehensions(object, "ListComp")?;
             Ok(ast::Expr::ListComp(ast::ExprListComp {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 elt,
                 generators,
             }))
@@ -1317,7 +1426,7 @@ impl ObjectConverter {
             let generators = self.comprehensions(object, "SetComp")?;
             Ok(ast::Expr::SetComp(ast::ExprSetComp {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 elt,
                 generators,
             }))
@@ -1327,7 +1436,7 @@ impl ObjectConverter {
             let generators = self.comprehensions(object, "DictComp")?;
             Ok(ast::Expr::DictComp(ast::ExprDictComp {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 key,
                 value,
                 generators,
@@ -1337,7 +1446,7 @@ impl ObjectConverter {
             let generators = self.comprehensions(object, "GeneratorExp")?;
             Ok(ast::Expr::Generator(ast::ExprGenerator {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 elt,
                 generators,
                 parenthesized: true,
@@ -1345,19 +1454,19 @@ impl ObjectConverter {
         } else if self.is_node(object, "Await")? {
             Ok(ast::Expr::Await(ast::ExprAwait {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 value: self.req_expr(object, "value", "Await")?,
             }))
         } else if self.is_node(object, "Yield")? {
             Ok(ast::Expr::Yield(ast::ExprYield {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 value: self.opt_expr(object, "value")?,
             }))
         } else if self.is_node(object, "YieldFrom")? {
             Ok(ast::Expr::YieldFrom(ast::ExprYieldFrom {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 value: self.req_expr(object, "value", "YieldFrom")?,
             }))
         } else if self.is_node(object, "Compare")? {
@@ -1370,7 +1479,7 @@ impl ObjectConverter {
             let comparators = self.exprs(object, "comparators", "Compare")?;
             Ok(ast::Expr::Compare(ast::ExprCompare {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 left,
                 ops: ops.into_boxed_slice(),
                 comparators: comparators.into_boxed_slice(),
@@ -1382,7 +1491,7 @@ impl ObjectConverter {
             let ctx = self.context(self.field(object, "ctx", "Subscript")?)?;
             Ok(ast::Expr::Subscript(ast::ExprSubscript {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 value,
                 slice,
                 ctx,
@@ -1392,14 +1501,14 @@ impl ObjectConverter {
             let ctx = self.context(self.field(object, "ctx", "Starred")?)?;
             Ok(ast::Expr::Starred(ast::ExprStarred {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 value,
                 ctx,
             }))
         } else if self.is_node(object, "Slice")? {
             Ok(ast::Expr::Slice(ast::ExprSlice {
                 node_index: Default::default(),
-                range: Default::default(),
+                range,
                 lower: self.opt_expr(object, "lower")?,
                 upper: self.opt_expr(object, "upper")?,
                 step: self.opt_expr(object, "step")?,
@@ -1493,7 +1602,7 @@ impl ObjectConverter {
     }
 
     fn keyword(&mut self, object: PyObjectRef) -> AstResult<ast::Keyword> {
-        self.location(object, "keyword")?;
+        let range = self.location(object, "keyword")?;
         let arg = self
             .optional_field(object, "arg")?
             .map(|value| {
@@ -1511,7 +1620,7 @@ impl ObjectConverter {
         let value = self.field(object, "value", "keyword")?;
         Ok(ast::Keyword {
             node_index: Default::default(),
-            range: Default::default(),
+            range,
             arg,
             value: self.recurse(|this| this.expr(value))?,
         })

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -28,6 +28,7 @@ pub fn compile_object(
     let mut converter = ObjectConverter {
         ast_module,
         depth: 0,
+        carried_ignores: Vec::new(),
         line_len: 0,
     };
     // The compiler reads a node's position out of the source text the range
@@ -95,6 +96,7 @@ pub fn preprocess_object_to_object(
     let mut converter = ObjectConverter {
         ast_module,
         depth: 0,
+        carried_ignores: Vec::new(),
         line_len: 0,
     };
     // Both directions have to read positions out of the same text, and a tree
@@ -110,12 +112,15 @@ pub fn preprocess_object_to_object(
     } else {
         source
     };
-    module_to_object(module, source, mode, ast_module)
+    module_to_object(module, source, mode, ast_module, &converter.carried_ignores)
 }
 
 struct ObjectConverter {
     ast_module: PyObjectRef,
     depth: usize,
+    /// The `TypeIgnore`s the incoming `Module` carried. The compiler AST has
+    /// no field for them, so they ride here and are republished unchanged.
+    carried_ignores: Vec<super::type_comments::TypeComment>,
     /// Characters on each line of the synthetic source, excluding the newline.
     /// Zero until `synthetic_source` has measured the tree.
     line_len: usize,
@@ -304,16 +309,21 @@ impl ObjectConverter {
         Ok(ruff_text_size::TextRange::new(start.into(), end.into()))
     }
 
-    /// `Module.type_ignores` (ast.py) holds the `# type: ignore` comments
-    /// a `type_comments=True` parse collected.  The compiler AST has nowhere
-    /// to keep them and never reads them back, but the field is still walked
-    /// so that a list holding something else is reported here.
-    fn type_ignores(&self, object: PyObjectRef) -> AstResult<()> {
+    /// `Module.type_ignores` (ast.py) holds the `# type: ignore` comments a
+    /// `type_comments=True` parse collected.  The compiler AST has nowhere to
+    /// keep them, so they are carried beside it and handed back unchanged; a
+    /// list holding anything but a `TypeIgnore` is reported here.
+    fn type_ignores(
+        &self,
+        object: PyObjectRef,
+    ) -> AstResult<Vec<super::type_comments::TypeComment>> {
         let value = match crate::baseobjspace::getattr_str(object, "type_ignores") {
             Ok(value) => value,
             // An unset field stands for the empty list a parse without type
             // comments produces.
-            Err(error) if error.kind == crate::PyErrorKind::AttributeError => return Ok(()),
+            Err(error) if error.kind == crate::PyErrorKind::AttributeError => {
+                return Ok(Vec::new());
+            }
             Err(error) => return Err(error),
         };
         if !unsafe { pyre_object::is_list(value) } {
@@ -322,8 +332,16 @@ impl ObjectConverter {
                 class_name(value)
             )));
         }
+        let mut out = Vec::new();
         for item in unsafe { pyre_object::w_list_items_copy_as_vec(value) } {
-            if unsafe { pyre_object::is_none(item) } || self.is_node(item, "TypeIgnore")? {
+            if unsafe { pyre_object::is_none(item) } {
+                continue;
+            }
+            if self.is_node(item, "TypeIgnore")? {
+                out.push(super::type_comments::TypeComment::new(
+                    self.int_field(item, "lineno", "TypeIgnore")? as u32,
+                    self.string(item, "tag", "TypeIgnore")?,
+                ));
                 continue;
             }
             return Err(crate::PyError::type_error(crate::display::wtf8_format!(
@@ -331,12 +349,12 @@ impl ObjectConverter {
                 self.repr(item)?
             )));
         }
-        Ok(())
+        Ok(out)
     }
 
     fn module(&mut self, object: PyObjectRef) -> AstResult<ast::Mod> {
         let node = if self.is_node(object, "Module")? {
-            self.type_ignores(object)?;
+            self.carried_ignores = self.type_ignores(object)?;
             "Module"
         } else if self.is_node(object, "Interactive")? {
             "Interactive"
@@ -388,7 +406,7 @@ impl ObjectConverter {
                 returns,
                 body,
                 runtime_decorator_list: None,
-                runtime_type_comment: None,
+                runtime_type_comment: self.opt_type_comment(object)?,
                 runtime_type_comment_bytes: None,
                 runtime_body: None,
             }))
@@ -429,7 +447,7 @@ impl ObjectConverter {
                 targets,
                 value: Box::new(self.recurse(|this| this.expr(value))?),
                 runtime_targets: None,
-                runtime_type_comment: None,
+                runtime_type_comment: self.opt_type_comment(object)?,
                 runtime_type_comment_bytes: None,
             }))
         } else if self.is_node(object, "ClassDef")? {
@@ -526,7 +544,7 @@ impl ObjectConverter {
                 iter,
                 body,
                 orelse,
-                runtime_type_comment: None,
+                runtime_type_comment: self.opt_type_comment(object)?,
                 runtime_type_comment_bytes: None,
                 runtime_body: None,
                 runtime_orelse: None,
@@ -609,7 +627,7 @@ impl ObjectConverter {
                 is_async,
                 items,
                 body,
-                runtime_type_comment: None,
+                runtime_type_comment: self.opt_type_comment(object)?,
                 runtime_type_comment_bytes: None,
                 runtime_body: None,
             }))
@@ -824,7 +842,7 @@ impl ObjectConverter {
             node_index: Default::default(),
             name: self.identifier(object, "arg", "arg")?,
             annotation: self.opt_expr(object, "annotation")?,
-            runtime_type_comment: None,
+            runtime_type_comment: self.opt_type_comment(object)?,
             runtime_type_comment_bytes: None,
         })
     }
@@ -1202,6 +1220,22 @@ impl ObjectConverter {
             unsafe { pyre_object::w_str_get_value(value).to_string() },
             Default::default(),
         )))
+    }
+
+    /// A node's `type_comment`, which every ASDL kind that has one spells the
+    /// same way: an optional plain string.
+    fn opt_type_comment(&self, object: PyObjectRef) -> AstResult<Option<Box<str>>> {
+        let Some(value) = self.optional_field(object, "type_comment")? else {
+            return Ok(None);
+        };
+        if !unsafe { pyre_object::is_str(value) } {
+            return Err(crate::PyError::type_error(
+                "AST type_comment must be of type str",
+            ));
+        }
+        Ok(Some(
+            unsafe { pyre_object::w_str_get_value(value).to_string() }.into(),
+        ))
     }
 
     fn identifiers(
@@ -1809,7 +1843,13 @@ fn fstring(
 }
 
 pub fn parse_to_object(source: &str, mode: crate::compile::Mode) -> crate::PyResult {
-    parse_to_object_with_opts(source, mode, crate::compile::CompileOpts::default(), true)
+    parse_to_object_with_opts(
+        source,
+        mode,
+        crate::compile::CompileOpts::default(),
+        true,
+        false,
+    )
 }
 
 /// CPython 3.14 `Py_CompileStringObject` AST-returning branch: parse, run
@@ -1819,21 +1859,31 @@ pub fn parse_to_object_with_opts(
     mode: crate::compile::Mode,
     opts: crate::compile::CompileOpts,
     syntax_check_only: bool,
+    type_comments: bool,
 ) -> crate::PyResult {
     // The tokenizer sees a source whose line terminators are all `\n`
     // (`pytokenizer.py:654-662`), so the same rewrite runs here; the nodes and
     // the text `module_to_object` slices segments out of then agree.
     let source = &*crate::compile::universal_newline(source);
+    // A comment leaves no node behind, so a `type_comments=True` parse reads
+    // the token list the parser hands back beside the tree.
+    let mut collected = super::type_comments::TypeComments::default();
     let mut module = match mode {
         crate::compile::Mode::Eval => parser::parse_expression(source)
             .map(|parsed| ast::Mod::Expression(parsed.into_syntax())),
         crate::compile::Mode::Exec
         | crate::compile::Mode::Single
-        | crate::compile::Mode::BlockExpr => {
-            parser::parse_module(source).map(|parsed| ast::Mod::Module(parsed.into_syntax()))
-        }
+        | crate::compile::Mode::BlockExpr => parser::parse_module(source).map(|parsed| {
+            if type_comments {
+                collected = super::type_comments::collect(parsed.tokens(), source);
+            }
+            ast::Mod::Module(parsed.into_syntax())
+        }),
     }
     .map_err(|error| crate::PyError::syntax_error(error.to_string()))?;
+    if type_comments {
+        collected.attach(&mut module);
+    }
     preprocess_module(&mut module, mode, opts, syntax_check_only);
 
     let ast_module = crate::importing::importhook(
@@ -1843,7 +1893,7 @@ pub fn parse_to_object_with_opts(
         0,
         crate::call::take_last_exec_ctx(),
     )?;
-    module_to_object(module, source, mode, ast_module)
+    module_to_object(module, source, mode, ast_module, &collected.ignores)
 }
 
 fn module_to_object(
@@ -1851,6 +1901,7 @@ fn module_to_object(
     source: &str,
     mode: crate::compile::Mode,
     module_object: PyObjectRef,
+    ignores: &[super::type_comments::TypeComment],
 ) -> crate::PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let ast_module = Rooted(pyre_object::gc_roots::shadow_stack_len());
@@ -1870,7 +1921,23 @@ fn module_to_object(
             };
             let body = converter.stmt_list(&module.body)?;
             if root_name == "Module" {
-                let type_ignores = converter.list(Vec::new());
+                let type_ignores = ignores
+                    .iter()
+                    .map(|ignore| {
+                        converter.node(
+                            "TypeIgnore",
+                            None,
+                            &[
+                                (
+                                    "lineno",
+                                    converter.pin(pyre_object::w_int_new(ignore.lineno as i64)),
+                                ),
+                                ("tag", converter.string(&ignore.text)),
+                            ],
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let type_ignores = converter.list(type_ignores);
                 converter.node(
                     root_name,
                     None,
@@ -3033,7 +3100,10 @@ impl Converter<'_> {
                     "annotation",
                     self.optional(p.annotation.as_deref().map(|v| self.expr(v)).transpose()?),
                 ),
-                ("type_comment", self.none()),
+                (
+                    "type_comment",
+                    self.optional(p.runtime_type_comment.as_deref().map(|v| self.string(v))),
+                ),
             ],
         )
     }

--- a/pyre/pyre-interpreter/src/module/_ast/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/mod.rs
@@ -6,3 +6,4 @@
 crate::pyre_module_init!(moduledef);
 
 pub mod convert;
+pub mod type_comments;

--- a/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
@@ -285,12 +285,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     }
 
     // `compile()` / `ast.parse()` flag bitmasks, used by `lib-python/3/ast.py`
-    // (`flags = PyCF_ONLY_AST; flags |= PyCF_TYPE_COMMENTS`). Values mirror
-    // `pypy/interpreter/astcompiler/consts.py:33-42`.
+    // (`flags = PyCF_ONLY_AST; flags |= PyCF_TYPE_COMMENTS`). Values are
+    // `Include/cpython/compile.h`'s, which `consts.py` matches everywhere but
+    // `PyCF_TYPE_COMMENTS`: it kept `PyCF_ASYNC_HACKS` on `0x1000` and moved
+    // this one out to `0x40000000`.  3.14 has no `PyCF_ASYNC_HACKS`.
     for (name, value) in &[
         ("PyCF_ONLY_AST", 0x0400i64),
         ("PyCF_ALLOW_TOP_LEVEL_AWAIT", 0x2000),
-        ("PyCF_TYPE_COMMENTS", 0x4000_0000),
+        ("PyCF_TYPE_COMMENTS", 0x1000),
         // CPython 3.14 Include/cpython/compile.h: requesting an optimized
         // tree necessarily requests an AST result as well.
         ("PyCF_OPTIMIZED_AST", 0x8000 | 0x0400),

--- a/pyre/pyre-interpreter/src/module/_ast/type_comments.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/type_comments.rs
@@ -1,0 +1,295 @@
+//! `# type:` comments for a `type_comments=True` parse.
+//!
+//! The tree has no node for a comment, so the only place a type comment
+//! survives a parse is the token list handed back beside it. `lexer.c` decides
+//! what a comment is by matching `"# type: "` against its text, with each space
+//! in that pattern standing for any run of spaces and tabs, and splits what
+//! matches into `TYPE_IGNORE` — the word `ignore` followed by the end of the
+//! comment or by an ASCII non-alphanumeric byte — and `TYPE_COMMENT`, which is
+//! everything else.
+//!
+//! Where one attaches is the grammar's business, and the grammar takes a
+//! `TYPE_COMMENT` in five places: after an assignment's value, after the colon
+//! of a `for`, a `with` or a `def`, and after a parameter's comma. Each of
+//! those is the span between two nodes whose ranges the tree already carries,
+//! so attaching here is a scan of the comment list against those spans rather
+//! than a second parse.
+
+use ruff_text_size::Ranged;
+use rustpython_compiler::ast::{
+    self,
+    token::{Token, TokenKind},
+};
+
+/// The literal `lexer.c` matches a comment against. A space stands for a run
+/// of spaces and tabs, so `#type:int` matches as well as `# type: int`.
+const PREFIX: &[u8] = b"# type: ";
+
+/// One classified comment: where it starts, the line it is on, and the text
+/// the tree publishes — the type for a `TYPE_COMMENT`, the tag for a
+/// `TYPE_IGNORE`.
+pub struct TypeComment {
+    start: u32,
+    pub lineno: u32,
+    pub text: String,
+}
+
+impl TypeComment {
+    /// One read back off an `_ast` object rather than out of a source, which
+    /// has no offset to carry.
+    pub fn new(lineno: u32, text: String) -> Self {
+        Self {
+            start: 0,
+            lineno,
+            text,
+        }
+    }
+}
+
+/// Every `# type:` comment a parse found, split by what the lexer would call
+/// it. The comments are consumed as they are attached; the grammar gives each
+/// one at most one home, and one it never reaches is simply dropped, which is
+/// what the lexer's own `TYPE_COMMENT` token does when no rule accepts it.
+#[derive(Default)]
+pub struct TypeComments {
+    comments: Vec<TypeComment>,
+    attached: Vec<bool>,
+    pub ignores: Vec<TypeComment>,
+    line_starts: Vec<u32>,
+}
+
+/// The offset just past `PREFIX` within `text`, or `None` when the comment is
+/// an ordinary one.
+///
+/// The trailing space of the pattern matches an empty run, so a comment that
+/// stops at the colon still matches and publishes an empty type.
+fn after_prefix(text: &str) -> Option<usize> {
+    let bytes = text.as_bytes();
+    let mut at = 0usize;
+    for want in PREFIX.iter().copied() {
+        if want == b' ' {
+            while matches!(bytes.get(at), Some(b' ' | b'\t')) {
+                at += 1;
+            }
+        } else if bytes.get(at) == Some(&want) {
+            at += 1;
+        } else {
+            return None;
+        }
+    }
+    Some(at)
+}
+
+/// Whether what follows the prefix is the word `ignore` standing on its own:
+/// the comment ends there, or the next byte is ASCII and not alphanumeric.
+///
+/// `_` is not alphanumeric, so `# type: ignore_x` is an ignore whose tag is
+/// `_x`, while `# type: ignorex` is an ordinary type comment.
+fn is_ignore(rest: &[u8]) -> bool {
+    rest.starts_with(b"ignore")
+        && !matches!(rest.get(6), Some(&byte) if byte >= 128 || byte.is_ascii_alphanumeric())
+}
+
+/// Split a parse's comment tokens into the two kinds.
+pub fn collect(tokens: &[Token], source: &str) -> TypeComments {
+    let mut out = TypeComments {
+        line_starts: std::iter::once(0)
+            .chain(
+                source
+                    .bytes()
+                    .enumerate()
+                    .filter(|(_, byte)| *byte == b'\n')
+                    .map(|(offset, _)| offset as u32 + 1),
+            )
+            .collect(),
+        ..TypeComments::default()
+    };
+    for token in tokens {
+        if token.kind() != TokenKind::Comment {
+            continue;
+        }
+        let start = u32::from(token.range().start()) as usize;
+        let end = u32::from(token.range().end()) as usize;
+        let text = &source[start..end];
+        let Some(at) = after_prefix(text) else {
+            continue;
+        };
+        let lineno = out
+            .line_starts
+            .partition_point(|first| *first as usize <= start) as u32;
+        if is_ignore(&text.as_bytes()[at..]) {
+            // The tag runs to the end of the comment, and takes the line break
+            // with it when nothing but whitespace precedes the comment on its
+            // line: `lexer.c` consumes the newline for an ignore that stands
+            // alone, so `# type: ignore` on its own line reports `"\n"`.
+            let mut tag = text[at + "ignore".len()..].to_owned();
+            let line_start = out.line_starts[lineno as usize - 1] as usize;
+            let alone = source[line_start..start]
+                .bytes()
+                .all(|byte| matches!(byte, b' ' | b'\t' | 0x0c));
+            // The tokenizer supplies the line break a source without one is
+            // missing, so an ignore that ends the file reports it too.
+            if alone {
+                tag.push('\n');
+            }
+            out.ignores.push(TypeComment {
+                start: start as u32,
+                lineno,
+                text: tag,
+            });
+        } else {
+            out.comments.push(TypeComment {
+                start: start as u32,
+                lineno,
+                text: text[at..].to_owned(),
+            });
+            out.attached.push(false);
+        }
+    }
+    out
+}
+
+impl TypeComments {
+    /// The first unattached comment starting inside `[from, to)`, consumed.
+    fn take(&mut self, from: u32, to: u32) -> Option<Box<str>> {
+        let index = self
+            .comments
+            .iter()
+            .enumerate()
+            .find(|(index, comment)| {
+                !self.attached[*index] && comment.start >= from && comment.start < to
+            })
+            .map(|(index, _)| index)?;
+        self.attached[index] = true;
+        Some(self.comments[index].text.as_str().into())
+    }
+
+    /// The first unattached comment on the same line as `offset`, consumed.
+    ///
+    /// An assignment takes its comment before the line break that ends the
+    /// statement, so the span runs from the value's end to the next line.
+    fn take_to_line_end(&mut self, offset: u32) -> Option<Box<str>> {
+        let next = self.line_starts.partition_point(|first| *first <= offset);
+        let to = self.line_starts.get(next).copied().unwrap_or(u32::MAX);
+        self.take(offset, to)
+    }
+
+    /// Attach every comment the grammar has a place for, and answer the
+    /// module's `TypeIgnore` list.
+    pub fn attach(&mut self, module: &mut ast::Mod) {
+        if let ast::Mod::Module(module) = module {
+            self.stmts(&mut module.body);
+        }
+    }
+
+    fn stmts(&mut self, body: &mut [ast::Stmt]) {
+        for stmt in body {
+            self.stmt(stmt);
+        }
+    }
+
+    fn stmt(&mut self, stmt: &mut ast::Stmt) {
+        match stmt {
+            ast::Stmt::Assign(node) => {
+                node.runtime_type_comment = self.take_to_line_end(node.range.end().into());
+            }
+            ast::Stmt::For(node) => {
+                let from = node.iter.range().end().into();
+                if let Some(to) = node.body.first().map(|s| s.range().start().into()) {
+                    node.runtime_type_comment = self.take(from, to);
+                }
+                self.stmts(&mut node.body);
+                self.stmts(&mut node.orelse);
+            }
+            ast::Stmt::With(node) => {
+                let from = node
+                    .items
+                    .last()
+                    .map(|item| item.range().end().into())
+                    .unwrap_or_else(|| node.range.start().into());
+                if let Some(to) = node.body.first().map(|s| s.range().start().into()) {
+                    node.runtime_type_comment = self.take(from, to);
+                }
+                self.stmts(&mut node.body);
+            }
+            ast::Stmt::FunctionDef(node) => {
+                // A parameter's comment sits inside the parentheses and the
+                // function's sits past them, so the two spans cannot collide.
+                self.parameters(&mut node.parameters);
+                let from = node
+                    .returns
+                    .as_ref()
+                    .map(|returns| returns.range().end().into())
+                    .unwrap_or_else(|| node.parameters.range().end().into());
+                if let Some(to) = node.body.first().map(|s| s.range().start().into()) {
+                    node.runtime_type_comment = self.take(from, to);
+                }
+                self.stmts(&mut node.body);
+            }
+            ast::Stmt::ClassDef(node) => self.stmts(&mut node.body),
+            ast::Stmt::While(node) => {
+                self.stmts(&mut node.body);
+                self.stmts(&mut node.orelse);
+            }
+            ast::Stmt::If(node) => {
+                self.stmts(&mut node.body);
+                for clause in &mut node.elif_else_clauses {
+                    self.stmts(&mut clause.body);
+                }
+            }
+            ast::Stmt::Try(node) => {
+                self.stmts(&mut node.body);
+                for handler in &mut node.handlers {
+                    let ast::ExceptHandler::ExceptHandler(handler) = handler;
+                    self.stmts(&mut handler.body);
+                }
+                self.stmts(&mut node.orelse);
+                self.stmts(&mut node.finalbody);
+            }
+            ast::Stmt::Match(node) => {
+                for case in &mut node.cases {
+                    self.stmts(&mut case.body);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// A parameter's comment follows its comma, so its span runs to the start
+    /// of the next parameter, or to the closing parenthesis for the last one.
+    fn parameters(&mut self, parameters: &mut ast::Parameters) {
+        let close = parameters.range().end().into();
+        let mut spans: Vec<(u32, &mut Option<Box<str>>)> = Vec::new();
+        for with_default in parameters
+            .posonlyargs
+            .iter_mut()
+            .chain(parameters.args.iter_mut())
+        {
+            spans.push((
+                with_default.range().end().into(),
+                &mut with_default.parameter.runtime_type_comment,
+            ));
+        }
+        if let Some(vararg) = parameters.vararg.as_mut() {
+            spans.push((
+                vararg.range().end().into(),
+                &mut vararg.runtime_type_comment,
+            ));
+        }
+        for with_default in parameters.kwonlyargs.iter_mut() {
+            spans.push((
+                with_default.range().end().into(),
+                &mut with_default.parameter.runtime_type_comment,
+            ));
+        }
+        if let Some(kwarg) = parameters.kwarg.as_mut() {
+            spans.push((kwarg.range().end().into(), &mut kwarg.runtime_type_comment));
+        }
+        spans.sort_by_key(|(end, _)| *end);
+        let ends: Vec<u32> = spans.iter().map(|(end, _)| *end).collect();
+        for (index, (end, slot)) in spans.into_iter().enumerate() {
+            let to = ends.get(index + 1).copied().unwrap_or(close);
+            *slot = self.take(end, to);
+        }
+    }
+}

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -132,7 +132,7 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
             let h = rustpython_host_env::ctypes::open_library_with_mode(&name, mode).map_err(|e| {
                 let mut msg = rustpython_wtf8::Wtf8Buf::from_string("dlopen(".to_string());
                 msg.push_wtf8(&crate::gateway::fsdecode_os_str_wtf8(&name));
-                msg.push_str(&format!("): {e}"));
+                msg.push_str(&format!("): {}", crate::with_causes(&e)));
                 crate::PyError::os_error(msg)
             })?;
             Ok(pyre_object::w_int_new(h as i64))

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -1432,7 +1432,7 @@ crate::py_module! {
             };
         let unsupported = crate::builtins::make_exc_type_multi(
             "io.UnsupportedOperation",
-            crate::builtins::exc_exception_new,
+            crate::builtins::exc_os_error_new,
             bases,
         );
         let _ = UNSUPPORTED_OPERATION_TYPE.set(unsupported as usize);

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -309,6 +309,69 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     ))]
     {
         crate::module_ns_store(ns, "CODESET", pyre_object::w_int_new(libc::CODESET as i64));
+        // The rest of `_localemodule.c langinfo_constants` — the `nl_item`
+        // keys `nl_langinfo` takes.  Each host numbers them for itself: the
+        // BSD headers count from 0 while glibc packs a category into the high
+        // bits, so the values come from `libc` rather than a shared table.
+        // `YESSTR`/`NOSTR` are left out, as they are upstream.
+        for (name, val) in [
+            ("D_T_FMT", libc::D_T_FMT as i64),
+            ("D_FMT", libc::D_FMT as i64),
+            ("T_FMT", libc::T_FMT as i64),
+            ("T_FMT_AMPM", libc::T_FMT_AMPM as i64),
+            ("AM_STR", libc::AM_STR as i64),
+            ("PM_STR", libc::PM_STR as i64),
+            ("DAY_1", libc::DAY_1 as i64),
+            ("DAY_2", libc::DAY_2 as i64),
+            ("DAY_3", libc::DAY_3 as i64),
+            ("DAY_4", libc::DAY_4 as i64),
+            ("DAY_5", libc::DAY_5 as i64),
+            ("DAY_6", libc::DAY_6 as i64),
+            ("DAY_7", libc::DAY_7 as i64),
+            ("ABDAY_1", libc::ABDAY_1 as i64),
+            ("ABDAY_2", libc::ABDAY_2 as i64),
+            ("ABDAY_3", libc::ABDAY_3 as i64),
+            ("ABDAY_4", libc::ABDAY_4 as i64),
+            ("ABDAY_5", libc::ABDAY_5 as i64),
+            ("ABDAY_6", libc::ABDAY_6 as i64),
+            ("ABDAY_7", libc::ABDAY_7 as i64),
+            ("MON_1", libc::MON_1 as i64),
+            ("MON_2", libc::MON_2 as i64),
+            ("MON_3", libc::MON_3 as i64),
+            ("MON_4", libc::MON_4 as i64),
+            ("MON_5", libc::MON_5 as i64),
+            ("MON_6", libc::MON_6 as i64),
+            ("MON_7", libc::MON_7 as i64),
+            ("MON_8", libc::MON_8 as i64),
+            ("MON_9", libc::MON_9 as i64),
+            ("MON_10", libc::MON_10 as i64),
+            ("MON_11", libc::MON_11 as i64),
+            ("MON_12", libc::MON_12 as i64),
+            ("ABMON_1", libc::ABMON_1 as i64),
+            ("ABMON_2", libc::ABMON_2 as i64),
+            ("ABMON_3", libc::ABMON_3 as i64),
+            ("ABMON_4", libc::ABMON_4 as i64),
+            ("ABMON_5", libc::ABMON_5 as i64),
+            ("ABMON_6", libc::ABMON_6 as i64),
+            ("ABMON_7", libc::ABMON_7 as i64),
+            ("ABMON_8", libc::ABMON_8 as i64),
+            ("ABMON_9", libc::ABMON_9 as i64),
+            ("ABMON_10", libc::ABMON_10 as i64),
+            ("ABMON_11", libc::ABMON_11 as i64),
+            ("ABMON_12", libc::ABMON_12 as i64),
+            ("ERA", libc::ERA as i64),
+            ("ERA_D_FMT", libc::ERA_D_FMT as i64),
+            ("ERA_D_T_FMT", libc::ERA_D_T_FMT as i64),
+            ("ERA_T_FMT", libc::ERA_T_FMT as i64),
+            ("ALT_DIGITS", libc::ALT_DIGITS as i64),
+            ("RADIXCHAR", libc::RADIXCHAR as i64),
+            ("THOUSEP", libc::THOUSEP as i64),
+            ("YESEXPR", libc::YESEXPR as i64),
+            ("NOEXPR", libc::NOEXPR as i64),
+            ("CRNCYSTR", libc::CRNCYSTR as i64),
+        ] {
+            crate::module_ns_store(ns, name, pyre_object::w_int_new(val));
+        }
     }
     // `interp_locale.py W_Error = _new_exception('Error', W_Exception, 'locale error')`
     let exception_base = crate::builtins::lookup_exc_class("Exception")

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -107,7 +107,7 @@ fn windows_encoding_too_long(locale: &str) -> bool {
 
 #[cfg(all(any(unix, windows), feature = "host_env"))]
 fn locale_error(message: &str) -> crate::PyError {
-    let cls = crate::builtins::lookup_exc_class("_locale.Error")
+    let cls = crate::builtins::lookup_exc_class("locale.Error")
         .or_else(|| crate::builtins::lookup_exc_class("Exception"))
         .expect("Exception must be installed");
     let args = vec![cls, pyre_object::w_str_new(message)];
@@ -314,7 +314,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     let exception_base = crate::builtins::lookup_exc_class("Exception")
         .expect("Exception must be installed before _locale init");
     let w_error = crate::builtins::make_exc_type(
-        "_locale.Error",
+        "locale.Error",
         crate::builtins::exc_exception_new,
         exception_base,
     );

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -3082,6 +3082,68 @@ fn unpack_hyperv_addr(storage: &rffi::sockaddr_storage) -> pyre_object::PyObject
     ])
 }
 
+/// Resolve `host` for `family` and hand back the first answer's `sockaddr`.
+///
+/// `rsocket.py makeipaddr` ends in
+/// `getaddrinfo(name, None, family=family, address_to_fill=result)` for every
+/// family it serves, and `rsocket.py getaddrinfo` answers a non-zero return
+/// with `raise GAIError(error)` — so a name that does not resolve reports
+/// `gaierror(rc, gai_strerror(rc))`, which is what callers classify on.
+/// gethostbyname is not used here: its process-global result buffer is not
+/// re-entrant and was corrupted by socketserver worker threads.
+#[cfg(any(unix, windows))]
+fn resolve_ip_host(
+    c_host: &std::ffi::CStr,
+    family: libc::c_int,
+) -> Result<rffi::sockaddr_storage, crate::PyError> {
+    let mut hints: rffi::addrinfo = unsafe { std::mem::zeroed() };
+    hints.ai_family = family;
+    let mut result: *mut rffi::addrinfo = std::ptr::null_mut();
+    // A name lookup goes to the resolver and can take seconds.
+    let rc = {
+        let _blocked = crate::module::thread::before_external_block();
+        unsafe { rffi::getaddrinfo(c_host.as_ptr(), std::ptr::null(), &hints, &mut result) }
+    };
+    if rc != 0 {
+        return Err(socket_converted_error(
+            "gaierror",
+            Some(rc),
+            &rffi::gai_strerror(rc),
+        ));
+    }
+    let want = if family == rffi::AF_INET {
+        core::mem::size_of::<rffi::sockaddr_in>()
+    } else {
+        core::mem::size_of::<rffi::sockaddr_in6>()
+    };
+    let mut current = result;
+    let mut resolved = None;
+    while !current.is_null() {
+        let info = unsafe { &*current };
+        if info.ai_family == family && !info.ai_addr.is_null() && info.ai_addrlen as usize >= want {
+            let mut storage: rffi::sockaddr_storage = unsafe { std::mem::zeroed() };
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    info.ai_addr as *const u8,
+                    &mut storage as *mut _ as *mut u8,
+                    want,
+                );
+            }
+            resolved = Some(storage);
+            break;
+        }
+        current = info.ai_next;
+    }
+    unsafe { rffi::freeaddrinfo(result) };
+    // The hints pin `ai_family`, so a success with no answer of that family
+    // is a resolver that ignored them.  `getaddrinfo` returned no code to
+    // carry, so this is the plain module error, the way "sockaddr resolved to
+    // multiple addresses" is.
+    resolved.ok_or_else(|| {
+        socket_converted_error("error", None, "getaddrinfo returned no address of the requested family")
+    })
+}
+
 #[cfg(any(unix, windows))]
 fn pack_inet_addr(
     caller: &str,
@@ -3214,41 +3276,9 @@ fn pack_inet_addr(
             }
         };
         if r != 1 {
-            // `rsocket.makeipaddr` resolves names through getaddrinfo and
-            // copies the resulting address into its INETAddress.  Do the
-            // same here: gethostbyname's process-global result buffer is not
-            // re-entrant and was corrupted by socketserver worker threads.
-            let mut hints: rffi::addrinfo = unsafe { std::mem::zeroed() };
-            hints.ai_family = rffi::AF_INET;
-            let mut result: *mut rffi::addrinfo = std::ptr::null_mut();
-            let rc = {
-                let _blocked = crate::module::thread::before_external_block();
-                unsafe { rffi::getaddrinfo(c_host.as_ptr(), std::ptr::null(), &hints, &mut result) }
-            };
-            if rc != 0 || result.is_null() {
-                return Err(crate::PyError::os_error(format!(
-                    "name or service not known: {host}"
-                )));
-            }
-            let mut current = result;
-            let mut resolved = None;
-            while !current.is_null() {
-                let info = unsafe { &*current };
-                if info.ai_family == rffi::AF_INET
-                    && !info.ai_addr.is_null()
-                    && info.ai_addrlen as usize >= core::mem::size_of::<rffi::sockaddr_in>()
-                {
-                    let resolved_addr = unsafe { &*(info.ai_addr as *const rffi::sockaddr_in) };
-                    resolved = Some(rffi::sockaddr_in_get_addr(resolved_addr));
-                    break;
-                }
-                current = info.ai_next;
-            }
-            unsafe { rffi::freeaddrinfo(result) };
-            let resolved = resolved.ok_or_else(|| {
-                crate::PyError::os_error(format!("name or service not known: {host}"))
-            })?;
-            rffi::sockaddr_in_set_addr(sin, resolved);
+            let found = resolve_ip_host(&c_host, rffi::AF_INET)?;
+            let found = unsafe { &*(&found as *const _ as *const rffi::sockaddr_in) };
+            rffi::sockaddr_in_set_addr(sin, rffi::sockaddr_in_get_addr(found));
         }
         Ok((
             storage,
@@ -3271,9 +3301,13 @@ fn pack_inet_addr(
             }
         };
         if r != 1 {
-            return Err(crate::PyError::os_error(format!(
-                "invalid IPv6 address: {host}"
-            )));
+            let found = resolve_ip_host(&c_host, rffi::AF_INET6)?;
+            let found = unsafe { &*(&found as *const _ as *const rffi::sockaddr_in6) };
+            buf = rffi::sockaddr_in6_get_addr(found);
+            // `makeipaddr` fills the whole INET6Address from the answer, so
+            // the scope id the resolver picked stands unless items 2 and 3 of
+            // the tuple below name their own.
+            rffi::sockaddr_in6_set_scope_id(sin6, rffi::sockaddr_in6_get_scope_id(found));
         }
         rffi::sockaddr_in6_set_addr(sin6, buf);
         if len >= 3

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -2561,7 +2561,15 @@ fn socket_apply_timeout(fd: rffi::Socket, timeout: f64) -> Result<(), crate::PyE
 fn socket_fd(obj: pyre_object::PyObjectRef) -> Result<rffi::Socket, crate::PyError> {
     let fd = rffi::socket_from_i64(socket_get_attr_i64(obj, "_fd"));
     if rffi::is_invalid(fd) {
-        return Err(crate::PyError::os_error("Bad file descriptor"));
+        // `close` leaves `self.fd = INVALID_SOCKET` (`rsocket.py RSocket.close`)
+        // and the operations run the syscall on it anyway, so what a closed
+        // socket reports is the kernel's `EBADF` in its `(errno, strerror)`
+        // form.  This check stands in for that call and owes the same error —
+        // callers read `.errno` to tell a closed socket from a failed one.
+        return Err(crate::PyError::os_error_syscall(
+            libc::EBADF,
+            pyre_object::PY_NULL,
+        ));
     }
     Ok(fd)
 }

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -111,8 +111,13 @@ fn socket_converted_error(
     }
     args.push(pyre_object::w_str_new(message));
 
-    let exc = crate::builtins::exc_exception_new(&args)
-        .expect("exc_exception_new is infallible for str/int args");
+    // Every class this resolves to is an OSError subclass, and
+    // `converted_error` reaches them through `space.call_function`, so the
+    // instance is built by the family `__new__` that parses `(errno,
+    // strerror)` into the slots — not by the bare `BaseException.__new__`
+    // that only stores `args`.
+    let exc = crate::builtins::exc_os_error_new(&args)
+        .expect("exc_os_error_new is infallible for str/int args");
 
     let mut err = crate::PyError::os_error(message);
     err.exc_object = exc;
@@ -1375,6 +1380,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // `socketmodule.c` names them `socket.herror` / `socket.gaierror`
     // instead, and `type.__module__` reads the qualified prefix back, so
     // `socket.gaierror.__module__` is `"socket"` rather than `"_socket"`.
+    // `new_exception_class` leaves the base's `__new__` in place, so both
+    // inherit the OSError family constructor and its errno/strerror parse.
     let w_os_error = crate::builtins::lookup_exc_class("OSError")
         .expect("OSError must be installed before _socket init");
     crate::module_ns_store(ns, "error", w_os_error);
@@ -1383,7 +1390,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "herror",
         crate::builtins::make_exc_type(
             "socket.herror",
-            crate::builtins::exc_exception_new,
+            crate::builtins::exc_os_error_new,
             w_os_error,
         ),
     );
@@ -1392,7 +1399,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "gaierror",
         crate::builtins::make_exc_type(
             "socket.gaierror",
-            crate::builtins::exc_exception_new,
+            crate::builtins::exc_os_error_new,
             w_os_error,
         ),
     );

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -428,12 +428,18 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("IP_DROP_MEMBERSHIP", libc::IP_DROP_MEMBERSHIP);
         cst!("IP_HDRINCL", libc::IP_HDRINCL);
         // IP_OPTIONS / IP_RECVOPTS / IP_RECVRETOPTS / IP_RETOPTS are
-        // POSIX but not exposed by the libc crate on linux/macos;
-        // `_rsocket_rffi.py:170-172` lists them, but
-        // `platform.DefinedConstantInteger` drops them when the header
-        // does not define them.  Same behaviour here — not exposed.
+        // POSIX but the libc crate does not expose them; `_rsocket_rffi.py`
+        // lists them in `constant_names`, and
+        // `platform.DefinedConstantInteger` drops them when the header does
+        // not define them.  The darwin values are spelled out below; on the
+        // other unices they stay unexposed.
         cst!("IP_DEFAULT_MULTICAST_LOOP", 1);
         cst!("IP_DEFAULT_MULTICAST_TTL", 1);
+        // `<netinet/in.h>` sizes the membership table per platform: 4095 on
+        // darwin, 20 on linux.
+        #[cfg(target_vendor = "apple")]
+        cst!("IP_MAX_MEMBERSHIPS", 4095);
+        #[cfg(not(target_vendor = "apple"))]
         cst!("IP_MAX_MEMBERSHIPS", 20);
         // ── IPv6 ──
         cst!("IPV6_V6ONLY", libc::IPV6_V6ONLY);
@@ -544,6 +550,78 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("SCM_CREDENTIALS", libc::SCM_CREDENTIALS);
         // ── socket-level cap ──
         cst!("SOMAXCONN", libc::SOMAXCONN);
+
+        // Names `<sys/socket.h>`, `<netinet/in.h>`, `<netinet/tcp.h>`,
+        // `<net/ethernet.h>` and `<sys/sys_domain.h>` define only on darwin,
+        // or define there with a different value than on linux.  Every value
+        // was read back from the headers themselves.  `socketmodule.c` guards
+        // the RFC 3542 half with `#define __APPLE_USE_RFC_3542 1`, which is
+        // why those names exist on this platform at all.
+        #[cfg(target_vendor = "apple")]
+        {
+            // ── Address / protocol families ──
+            cst!("AF_APPLETALK", libc::AF_APPLETALK);
+            cst!("AF_DECnet", libc::AF_DECnet);
+            cst!("AF_IPX", libc::AF_IPX);
+            cst!("AF_LINK", libc::AF_LINK);
+            cst!("AF_SNA", libc::AF_SNA);
+            cst!("AF_SYSTEM", libc::AF_SYSTEM);
+            cst!("PF_SYSTEM", libc::PF_SYSTEM);
+            cst!("SYSPROTO_CONTROL", libc::SYSPROTO_CONTROL);
+            // ── IPPROTO_* ──
+            cst!("IPPROTO_EON", libc::IPPROTO_EON);
+            cst!("IPPROTO_GGP", libc::IPPROTO_GGP);
+            cst!("IPPROTO_HELLO", libc::IPPROTO_HELLO);
+            cst!("IPPROTO_IPCOMP", libc::IPPROTO_IPCOMP);
+            cst!("IPPROTO_IPV4", 4);
+            cst!("IPPROTO_ND", libc::IPPROTO_ND);
+            cst!("IPPROTO_XTP", libc::IPPROTO_XTP);
+            // ── IPv4 socket options ──
+            cst!("IP_ADD_SOURCE_MEMBERSHIP", libc::IP_ADD_SOURCE_MEMBERSHIP);
+            cst!("IP_BLOCK_SOURCE", libc::IP_BLOCK_SOURCE);
+            cst!("IP_DROP_SOURCE_MEMBERSHIP", libc::IP_DROP_SOURCE_MEMBERSHIP);
+            cst!("IP_UNBLOCK_SOURCE", libc::IP_UNBLOCK_SOURCE);
+            cst!("IP_OPTIONS", 1);
+            cst!("IP_RECVOPTS", 5);
+            cst!("IP_RECVRETOPTS", 6);
+            cst!("IP_RETOPTS", 8);
+            cst!("IP_PKTINFO", libc::IP_PKTINFO);
+            cst!("IP_RECVDSTADDR", libc::IP_RECVDSTADDR);
+            cst!("IP_RECVTOS", libc::IP_RECVTOS);
+            cst!("IP_RECVTTL", libc::IP_RECVTTL);
+            // ── IPv6 socket options ──
+            cst!("IPV6_DONTFRAG", libc::IPV6_DONTFRAG);
+            cst!("IPV6_DSTOPTS", 50);
+            cst!("IPV6_HOPOPTS", 49);
+            cst!("IPV6_NEXTHOP", 48);
+            cst!("IPV6_PATHMTU", 44);
+            cst!("IPV6_RECVDSTOPTS", 40);
+            cst!("IPV6_RECVHOPOPTS", 39);
+            cst!("IPV6_RECVPATHMTU", 43);
+            cst!("IPV6_RECVRTHDR", 38);
+            cst!("IPV6_RTHDR", 51);
+            cst!("IPV6_RTHDRDSTOPTS", 57);
+            cst!("IPV6_RTHDR_TYPE_0", 0);
+            cst!("IPV6_USE_MIN_MTU", 42);
+            // ── TCP ──
+            cst!("TCP_CONNECTION_INFO", libc::TCP_CONNECTION_INFO);
+            cst!("TCP_FASTOPEN", libc::TCP_FASTOPEN);
+            cst!("TCP_KEEPCNT", libc::TCP_KEEPCNT);
+            cst!("TCP_KEEPINTVL", libc::TCP_KEEPINTVL);
+            cst!("TCP_NOTSENT_LOWAT", 513);
+            // ── SO_* / MSG_* / SCM_* ──
+            cst!("SO_BINDTODEVICE", 4404);
+            cst!("SO_USELOOPBACK", libc::SO_USELOOPBACK);
+            cst!("LOCAL_PEERCRED", libc::LOCAL_PEERCRED);
+            cst!("MSG_EOF", libc::MSG_EOF);
+            cst!("MSG_NOSIGNAL", libc::MSG_NOSIGNAL);
+            cst!("SCM_CREDS", libc::SCM_CREDS);
+            // ── `<net/ethernet.h>` ──
+            cst!("ETHERTYPE_ARP", 2054);
+            cst!("ETHERTYPE_IP", 2048);
+            cst!("ETHERTYPE_IPV6", 34525);
+            cst!("ETHERTYPE_VLAN", 33024);
+        }
     }
 
     // `_rsocket_rffi.py` keeps a separate `_MSVC` constant list because the

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -156,7 +156,6 @@ fn interface_io_error(error: std::io::Error) -> crate::PyError {
 /// between.
 #[cfg(any(unix, windows))]
 struct SocketWritableBuffer {
-    _roots: pyre_object::gc_roots::RootScope,
     owner_slot: usize,
     held: bool,
     address: *mut u8,
@@ -165,8 +164,12 @@ struct SocketWritableBuffer {
 
 #[cfg(any(unix, windows))]
 impl SocketWritableBuffer {
+    /// The root scope the pins land in belongs to the caller.  A scope per
+    /// buffer would be released in the order the buffers are dropped, and a
+    /// `Vec` of them drops front to back, so the first release would truncate
+    /// the stack that the slots the later ones still name live in —
+    /// `recvmsg_into` with two buffers is the case that reaches it.
     unsafe fn acquire(obj: pyre_object::PyObjectRef) -> Result<Self, crate::PyError> {
-        let roots = pyre_object::gc_roots::push_roots();
         let _ = pyre_object::gc_roots::pin_root(obj);
         let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let (data, owner) =
@@ -176,7 +179,6 @@ impl SocketWritableBuffer {
         let owner = pyre_object::gc_roots::shadow_stack_get(owner_slot);
         let held = crate::builtins::buffer_export_incref(owner);
         Ok(Self {
-            _roots: roots,
             owner_slot,
             held,
             address: data.as_mut_ptr(),
@@ -4232,6 +4234,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             }
             let obj = args[0];
             let buf_obj = args[1];
+            let _roots = pyre_object::gc_roots::push_roots();
             let mut buffer = unsafe { SocketWritableBuffer::acquire(buf_obj) }?;
             let slot = unsafe { buffer.as_mut_slice() };
             let buf_len = slot.len();
@@ -4301,6 +4304,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             }
             let obj = args[0];
             let buf_obj = args[1];
+            let _roots = pyre_object::gc_roots::push_roots();
             let mut buffer = unsafe { SocketWritableBuffer::acquire(buf_obj) }?;
             let slot = unsafe { buffer.as_mut_slice() };
             let buf_len = slot.len();
@@ -4535,6 +4539,10 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     pyre_object::w_tuple_len(seq)
                 }
             };
+            // One scope for the whole set: `SocketWritableBuffer` records slot
+            // indices into it, and the vector's elements are dropped front to
+            // back.
+            let _roots = pyre_object::gc_roots::push_roots();
             let mut buffers: Vec<SocketWritableBuffer> = Vec::with_capacity(nbufs);
             for i in 0..nbufs {
                 let item = unsafe {

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -799,7 +799,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if args.is_empty() {
                     return Err(crate::PyError::type_error("htons() missing argument"));
                 }
-                let x = (unsafe { pyre_object::w_int_get_value(args[0]) }) as u16;
+                let x = c_uint_converter(args[0], 0xffff, "uint16_t")? as u16;
                 Ok(pyre_object::w_int_new(x.to_be() as i64))
             },
             1,
@@ -814,7 +814,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if args.is_empty() {
                     return Err(crate::PyError::type_error("ntohs() missing argument"));
                 }
-                let x = (unsafe { pyre_object::w_int_get_value(args[0]) }) as u16;
+                let x = c_uint_converter(args[0], 0xffff, "uint16_t")? as u16;
                 Ok(pyre_object::w_int_new(u16::from_be(x) as i64))
             },
             1,
@@ -829,7 +829,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if args.is_empty() {
                     return Err(crate::PyError::type_error("htonl() missing argument"));
                 }
-                let x = (unsafe { pyre_object::w_int_get_value(args[0]) }) as u32;
+                let x = c_uint_converter(args[0], 0xffff_ffff, "uint32_t")? as u32;
                 Ok(pyre_object::w_int_new(x.to_be() as i64))
             },
             1,
@@ -844,7 +844,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if args.is_empty() {
                     return Err(crate::PyError::type_error("ntohl() missing argument"));
                 }
-                let x = (unsafe { pyre_object::w_int_get_value(args[0]) }) as u32;
+                let x = c_uint_converter(args[0], 0xffff_ffff, "uint32_t")? as u32;
                 Ok(pyre_object::w_int_new(u32::from_be(x) as i64))
             },
             1,
@@ -941,6 +941,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     let r = unsafe {
                         rffi::inet_pton(af, c_ip.as_ptr(), buf.as_mut_ptr() as *mut libc::c_void)
                     };
+                    // `inet_pton` separates the two failures: a negative
+                    // return is a family it has no parser for and leaves
+                    // `EAFNOSUPPORT` behind, a zero is an address string it
+                    // parsed and rejected.
+                    if r < 0 {
+                        return Err(crate::PyError::os_error_syscall(
+                            rffi::last_error_code(),
+                            pyre_object::PY_NULL,
+                        ));
+                    }
                     if r != 1 {
                         return Err(crate::PyError::os_error(
                             "illegal IP address string passed to inet_pton",
@@ -1105,37 +1115,24 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         ));
                     }
                     let host_bytes = socket_idna_converter(args[0])?;
-                    let c = std::ffi::CString::new(host_bytes.clone())
+                    let c = std::ffi::CString::new(host_bytes)
                         .map_err(|_| crate::PyError::value_error("embedded null"))?;
-                    let _netdb = rffi::netdb_lock();
-                    let he = unsafe { rffi::host_by_name(c.as_ptr()) };
-                    if he.is_null() {
-                        let host_repr = String::from_utf8_lossy(&host_bytes).into_owned();
+                    // `rsocket.gethostbyname` is `makeipaddr(name, INETAddress())`
+                    // and `socket_gethostbyname` is `setipaddr(name, AF_INET)`:
+                    // both resolve, neither calls the `gethostbyname` of the
+                    // same name, so a name that does not resolve reports
+                    // `gaierror` rather than a message of this module's own.
+                    let storage = resolve_ip_host(&c, rffi::AF_INET)?;
+                    let sin = unsafe { &*(&storage as *const _ as *const rffi::sockaddr_in) };
+                    let packed = rffi::sockaddr_in_get_addr(sin);
+                    let Some(text) = rffi::inet_ntoa(packed.to_ne_bytes()) else {
                         return Err(socket_converted_error(
-                            "gaierror",
+                            "error",
                             None,
-                            &format!("gethostbyname failed for {host_repr}"),
+                            "gethostbyname: address is not representable",
                         ));
-                    }
-                    unsafe {
-                        let first_addr = rffi::pointer_at(rffi::hostent_addr_list(he), 0);
-                        if rffi::hostent_length(he) != 4 || first_addr.is_null() {
-                            return Err(socket_converted_error(
-                                "gaierror",
-                                None,
-                                "gethostbyname: no IPv4 address",
-                            ));
-                        }
-                        let packed = std::ptr::read_unaligned(first_addr as *const u32);
-                        let Some(text) = rffi::inet_ntoa(packed.to_ne_bytes()) else {
-                            return Err(socket_converted_error(
-                                "gaierror",
-                                None,
-                                "gethostbyname: address is not representable",
-                            ));
-                        };
-                        Ok(pyre_object::w_str_new(&text))
-                    }
+                    };
+                    Ok(pyre_object::w_str_new(&text))
                 },
                 1,
             ),
@@ -1156,17 +1153,17 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         ));
                     }
                     let host_bytes = socket_idna_converter(args[0])?;
-                    let c = std::ffi::CString::new(host_bytes.clone())
+                    let c = std::ffi::CString::new(host_bytes)
                         .map_err(|_| crate::PyError::value_error("embedded null"))?;
+                    // `rsocket.gethostbyname_ex` resolves the name first and
+                    // only then reads the `hostent`, so an unresolvable name
+                    // reports `gaierror` and a name the resolver knows but the
+                    // host database does not reports `herror`.
+                    resolve_ip_host(&c, rffi::AF_INET)?;
                     let _netdb = rffi::netdb_lock();
                     let he = unsafe { rffi::host_by_name(c.as_ptr()) };
                     if he.is_null() {
-                        let host_repr = String::from_utf8_lossy(&host_bytes).into_owned();
-                        return Err(socket_converted_error(
-                            "gaierror",
-                            None,
-                            &format!("gethostbyname_ex failed for {host_repr}"),
-                        ));
+                        return Err(host_lookup_error());
                     }
                     unpack_hostent(he)
                 },
@@ -1190,92 +1187,35 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         ));
                     }
                     let host_bytes = socket_idna_converter(args[0])?;
-                    let c = std::ffi::CString::new(host_bytes.clone())
+                    let c = std::ffi::CString::new(host_bytes)
                         .map_err(|_| crate::PyError::value_error("embedded null"))?;
-                    let _netdb = rffi::netdb_lock();
-                    // Try IPv4 first, then IPv6, then fall back to
-                    // gethostbyname → hostent.h_addr to obtain a raw
-                    // bytestring for gethostbyaddr.
-                    let mut buf4 = [0u8; 4];
-                    let r4 = unsafe {
-                        rffi::inet_pton(
-                            rffi::AF_INET,
-                            c.as_ptr(),
-                            buf4.as_mut_ptr() as *mut libc::c_void,
-                        )
-                    };
-                    let (family, addr_ptr, addr_len) = if r4 == 1 {
-                        (
-                            rffi::AF_INET,
-                            buf4.as_ptr() as *const libc::c_void,
-                            4 as rffi::SockLen,
-                        )
+                    // `rsocket.gethostbyaddr` is `makeipaddr(ip)` — the
+                    // argument is resolved for whichever family answers, not
+                    // required to be numeric — and only the reverse lookup that
+                    // follows reports through `h_errno`.
+                    let storage = resolve_ip_host(&c, rffi::AF_UNSPEC)?;
+                    let family = storage.ss_family as libc::c_int;
+                    // `gethostbyaddr` takes the bare address bytes, not the
+                    // whole `sockaddr`, and the accessors are what read them on
+                    // both platforms — WinSock wraps them in anonymous unions.
+                    let mut raw = [0u8; 16];
+                    let addr_len = if family == rffi::AF_INET6 {
+                        let sin6 =
+                            unsafe { &*(&storage as *const _ as *const rffi::sockaddr_in6) };
+                        raw = rffi::sockaddr_in6_get_addr(sin6);
+                        16 as rffi::SockLen
                     } else {
-                        let mut buf6 = [0u8; 16];
-                        let r6 = unsafe {
-                            rffi::inet_pton(
-                                rffi::AF_INET6,
-                                c.as_ptr(),
-                                buf6.as_mut_ptr() as *mut libc::c_void,
-                            )
-                        };
-                        if r6 == 1 {
-                            // Borrowed pointer: we copy into a stable
-                            // buffer below so the lifetime crosses the
-                            // FFI call safely.
-                            let mut owned: [u8; 16] = buf6;
-                            let he = unsafe {
-                                rffi::host_by_addr(
-                                    owned.as_mut_ptr() as *const libc::c_void,
-                                    16 as rffi::SockLen,
-                                    rffi::AF_INET6,
-                                )
-                            };
-                            if he.is_null() {
-                                let host_repr = String::from_utf8_lossy(&host_bytes).into_owned();
-                                return Err(socket_converted_error(
-                                    "herror",
-                                    None,
-                                    &format!("gethostbyaddr failed for {host_repr}"),
-                                ));
-                            }
-                            return unpack_hostent(he);
-                        }
-                        // Fall back: name → hostent → first IPv4 addr
-                        let he = unsafe { rffi::host_by_name(c.as_ptr()) };
-                        if he.is_null() {
-                            let host_repr = String::from_utf8_lossy(&host_bytes).into_owned();
-                            return Err(socket_converted_error(
-                                "herror",
-                                None,
-                                &format!("gethostbyaddr failed for {host_repr}"),
-                            ));
-                        }
-                        unsafe {
-                            let first_addr =
-                                rffi::pointer_at(rffi::hostent_addr_list(he), 0);
-                            if first_addr.is_null() {
-                                return Err(socket_converted_error(
-                                    "herror",
-                                    None,
-                                    "gethostbyaddr: empty address list",
-                                ));
-                            }
-                            (
-                                rffi::hostent_addr_type(he),
-                                first_addr as *const libc::c_void,
-                                rffi::hostent_length(he) as rffi::SockLen,
-                            )
-                        }
+                        let sin = unsafe { &*(&storage as *const _ as *const rffi::sockaddr_in) };
+                        raw[..4]
+                            .copy_from_slice(&rffi::sockaddr_in_get_addr(sin).to_ne_bytes());
+                        4 as rffi::SockLen
                     };
-                    let he = unsafe { rffi::host_by_addr(addr_ptr, addr_len, family) };
+                    let _netdb = rffi::netdb_lock();
+                    let he = unsafe {
+                        rffi::host_by_addr(raw.as_ptr() as *const libc::c_void, addr_len, family)
+                    };
                     if he.is_null() {
-                        let host_repr = String::from_utf8_lossy(&host_bytes).into_owned();
-                        return Err(socket_converted_error(
-                            "herror",
-                            None,
-                            &format!("gethostbyaddr failed for {host_repr}"),
-                        ));
+                        return Err(host_lookup_error());
                     }
                     unpack_hostent(he)
                 },
@@ -1323,10 +1263,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     )
                 };
                 if p.is_null() {
+                    // `rsocket.getservbyname` raises
+                    // `RSocketError("service/proto not found")`; neither it nor
+                    // `socket_getservbyname` names the service it looked for.
                     return Err(socket_converted_error(
                         "error",
                         None,
-                        &format!("service/proto not found: {name}"),
+                        "service/proto not found",
                     ));
                 }
                 let port = unsafe { u16::from_be(rffi::servent_port(p)) };
@@ -1344,7 +1287,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "getservbyport() missing argument",
                     ));
                 }
-                let port = (unsafe { pyre_object::w_int_get_value(args[0]) }) as u16;
+                // `getservbyport` rejects a port outside the range before it
+                // narrows: taking the low sixteen bits of 70000 would look up
+                // 4464 and answer for it.
+                let port = unsafe { pyre_object::w_int_get_value(args[0]) };
+                if !(0..=0xffff).contains(&port) {
+                    return Err(crate::PyError::overflow_error(
+                        "getservbyport: port must be 0-65535.",
+                    ));
+                }
+                let port = port as u16;
                 let proto_c: Option<std::ffi::CString> =
                     if args.len() >= 2 && unsafe { pyre_object::is_str(args[1]) } {
                         let p = crate::baseobjspace::str_utf8_w(args[1])?.to_string();
@@ -1365,10 +1317,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     )
                 };
                 if p.is_null() {
+                    // `rsocket.getservbyport` raises
+                    // `RSocketError("port/proto not found")`, without the port.
                     return Err(socket_converted_error(
                         "error",
                         None,
-                        &format!("port/proto not found: {port}"),
+                        "port/proto not found",
                     ));
                 }
                 let name = unsafe {
@@ -2228,7 +2182,7 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                 }
                 if !unsafe { pyre_object::is_tuple(args[0]) } {
                     return Err(crate::PyError::type_error(
-                        "getnameinfo: sockaddr must be a tuple",
+                        "getnameinfo() argument 1 must be a tuple",
                     ));
                 }
                 if !unsafe { pyre_object::is_int(args[1]) } {
@@ -2240,19 +2194,37 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                 // Resolve sockaddr via getaddrinfo(AF_UNSPEC, SOCK_DGRAM,
                 // AI_NUMERICHOST) so we get a real sockaddr_storage,
                 // matching `interp_func.py:142-152`.
-                let host_obj = unsafe { pyre_object::w_tuple_getitem(args[0], 0) }
-                    .ok_or_else(|| crate::PyError::value_error("sockaddr: missing host"))?;
-                let port_obj = unsafe { pyre_object::w_tuple_getitem(args[0], 1) }
-                    .ok_or_else(|| crate::PyError::value_error("sockaddr: missing port"))?;
-                if !unsafe { pyre_object::is_str(host_obj) } {
-                    return Err(crate::PyError::type_error(
-                        "getnameinfo: sockaddr[0] must be a string",
-                    ));
+                //
+                // The tuple is parsed with `"si|II"` and a `;`-suffixed custom
+                // message, so every shape it rejects — a length outside two to
+                // four, a non-string host, a non-integer port — is the one
+                // TypeError below rather than a per-item message.
+                let sockaddr_len = unsafe { pyre_object::w_tuple_len(args[0]) };
+                let item = |i: i64| unsafe { pyre_object::w_tuple_getitem(args[0], i) };
+                let illegal_sockaddr =
+                    || crate::PyError::type_error("getnameinfo(): illegal sockaddr argument");
+                if !(2..=4).contains(&sockaddr_len) {
+                    return Err(illegal_sockaddr());
                 }
-                if !unsafe { pyre_object::is_int(port_obj) } {
-                    return Err(crate::PyError::type_error(
-                        "getnameinfo: sockaddr[1] must be an integer",
-                    ));
+                let host_obj = item(0).ok_or_else(illegal_sockaddr)?;
+                let port_obj = item(1).ok_or_else(illegal_sockaddr)?;
+                if !unsafe { pyre_object::is_str(host_obj) } || !unsafe { pyre_object::is_int(port_obj) }
+                {
+                    return Err(illegal_sockaddr());
+                }
+                // `flowinfo` is the third item, and its twenty bits are the
+                // only thing checked about it here — the address itself comes
+                // from the lookup below.
+                if let Some(flowinfo_obj) = item(2) {
+                    if !unsafe { pyre_object::is_int(flowinfo_obj) } {
+                        return Err(illegal_sockaddr());
+                    }
+                    let flowinfo = unsafe { pyre_object::w_int_get_value(flowinfo_obj) };
+                    if !(0..=0xfffff).contains(&flowinfo) {
+                        return Err(crate::PyError::overflow_error(
+                            "getnameinfo(): flowinfo must be 0-1048575.",
+                        ));
+                    }
                 }
                 let host = crate::baseobjspace::str_utf8_w(host_obj)?.to_string();
                 let port_v = unsafe { pyre_object::w_int_get_value(port_obj) };
@@ -2282,6 +2254,17 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                         "error",
                         None,
                         "sockaddr resolved to multiple addresses",
+                    ));
+                }
+                // The extra items only exist for IPv6, so an IPv4 answer with
+                // any of them is refused — after the lookup, because until it
+                // returns the family is not known.
+                if ai.ai_family == rffi::AF_INET && sockaddr_len != 2 {
+                    unsafe { rffi::freeaddrinfo(head) };
+                    return Err(socket_converted_error(
+                        "error",
+                        None,
+                        "IPv4 sockaddr must be 2 tuple",
                     ));
                 }
                 let mut host_buf = [0 as libc::c_char; rffi::NI_MAXHOST as usize];
@@ -3082,12 +3065,76 @@ fn unpack_hyperv_addr(storage: &rffi::sockaddr_storage) -> pyre_object::PyObject
     ])
 }
 
-/// Resolve `host` for `family` and hand back the first answer's `sockaddr`.
+/// `_PyLong_UInt16_Converter` / `_PyLong_UInt32_Converter`, the argument
+/// clinic converters `htons` / `ntohs` / `htonl` / `ntohl` declare.
 ///
-/// `rsocket.py makeipaddr` ends in
-/// `getaddrinfo(name, None, family=family, address_to_fill=result)` for every
-/// family it serves, and `rsocket.py getaddrinfo` answers a non-zero return
-/// with `raise GAIError(error)` — so a name that does not resolve reports
+/// `Py_ASNATIVEBYTES_ALLOW_INDEX` takes anything with `__index__`,
+/// `Py_ASNATIVEBYTES_REJECT_NEGATIVE` answers a negative value with
+/// `ValueError("Cannot convert negative int")`, and a value wider than the C
+/// type is an `OverflowError` naming that type.  Narrowing instead would make
+/// `htons(70000)` answer for port 4464.
+fn c_uint_converter(
+    obj: pyre_object::PyObjectRef,
+    max: u64,
+    ctype: &str,
+) -> Result<u64, crate::PyError> {
+    let obj = crate::baseobjspace::space_index(obj)?;
+    let negative = unsafe {
+        if pyre_object::is_long(obj) {
+            pyre_object::w_long_get_value(obj).get_sign() < 0
+        } else {
+            pyre_object::w_int_get_value(obj) < 0
+        }
+    };
+    if negative {
+        return Err(crate::PyError::value_error("Cannot convert negative int"));
+    }
+    match crate::baseobjspace::uint_w(obj) {
+        Ok(value) if value <= max => Ok(value),
+        _ => Err(crate::PyError::overflow_error(format!(
+            "Python int too large for C {ctype}"
+        ))),
+    }
+}
+
+/// The failure `gethostbyname` / `gethostbyaddr` report, which they leave in
+/// `h_errno` rather than `errno`.
+///
+/// `set_herror` raises `herror(h_errno, hstrerror(h_errno))`.  `HSocketError`
+/// carries only the host name, because rsocket says `h_errno` is not reachable
+/// from RPython — a caller that classifies on `.errno` sees nothing there, so
+/// the code the resolver set is read here.
+#[cfg(any(unix, windows))]
+fn host_lookup_error() -> crate::PyError {
+    let (code, message) = rffi::host_error();
+    socket_converted_error("herror", Some(code), &message)
+}
+
+/// The length of the `sockaddr` a family stores, or `None` for a family this
+/// module has no address form for.
+#[cfg(any(unix, windows))]
+fn sockaddr_len_of(family: libc::c_int) -> Option<usize> {
+    if family == rffi::AF_INET {
+        Some(core::mem::size_of::<rffi::sockaddr_in>())
+    } else if family == rffi::AF_INET6 {
+        Some(core::mem::size_of::<rffi::sockaddr_in6>())
+    } else {
+        None
+    }
+}
+
+/// Resolve `host` for `family` and hand back the first answer's `sockaddr`.
+/// `AF_UNSPEC` takes whichever of the two families the resolver answers with.
+///
+/// `rsocket.py makeipaddr` / `setipaddr`: two names never reach the resolver.
+/// The empty one is the wildcard — `getaddrinfo(NULL, "0", AI_PASSIVE)` with a
+/// dummy socktype, and more than one answer means it did not name a single
+/// address.  `<broadcast>` and `255.255.255.255` are IPv4's all-ones address,
+/// which `inet_addr` cannot express because it reports failure with the same
+/// bit pattern.  Everything else ends in
+/// `getaddrinfo(name, None, family=family, address_to_fill=result)`, and
+/// `rsocket.py getaddrinfo` answers a non-zero return with
+/// `raise GAIError(error)` — so a name that does not resolve reports
 /// `gaierror(rc, gai_strerror(rc))`, which is what callers classify on.
 /// gethostbyname is not used here: its process-global result buffer is not
 /// re-entrant and was corrupted by socketserver worker threads.
@@ -3096,13 +3143,39 @@ fn resolve_ip_host(
     c_host: &std::ffi::CStr,
     family: libc::c_int,
 ) -> Result<rffi::sockaddr_storage, crate::PyError> {
+    let host = c_host.to_bytes();
+    if host == b"<broadcast>" || host == b"255.255.255.255" {
+        if family != rffi::AF_INET && family != rffi::AF_UNSPEC {
+            return Err(socket_converted_error(
+                "error",
+                None,
+                "address family mismatched",
+            ));
+        }
+        let mut storage: rffi::sockaddr_storage = unsafe { std::mem::zeroed() };
+        let sin = unsafe { &mut *(&mut storage as *mut _ as *mut rffi::sockaddr_in) };
+        sin.sin_family = rffi::AF_INET as rffi::SaFamily;
+        rffi::sockaddr_in_set_addr(sin, rffi::INADDR_BROADCAST);
+        return Ok(storage);
+    }
+    let wildcard = host.is_empty();
     let mut hints: rffi::addrinfo = unsafe { std::mem::zeroed() };
     hints.ai_family = family;
+    if wildcard {
+        hints.ai_socktype = rffi::SOCK_DGRAM;
+        hints.ai_flags = rffi::AI_PASSIVE;
+    }
+    let service = c"0";
+    let (name_ptr, service_ptr) = if wildcard {
+        (std::ptr::null(), service.as_ptr())
+    } else {
+        (c_host.as_ptr(), std::ptr::null())
+    };
     let mut result: *mut rffi::addrinfo = std::ptr::null_mut();
     // A name lookup goes to the resolver and can take seconds.
     let rc = {
         let _blocked = crate::module::thread::before_external_block();
-        unsafe { rffi::getaddrinfo(c_host.as_ptr(), std::ptr::null(), &hints, &mut result) }
+        unsafe { rffi::getaddrinfo(name_ptr, service_ptr, &hints, &mut result) }
     };
     if rc != 0 {
         return Err(socket_converted_error(
@@ -3111,16 +3184,18 @@ fn resolve_ip_host(
             &rffi::gai_strerror(rc),
         ));
     }
-    let want = if family == rffi::AF_INET {
-        core::mem::size_of::<rffi::sockaddr_in>()
-    } else {
-        core::mem::size_of::<rffi::sockaddr_in6>()
-    };
+    let ambiguous_wildcard =
+        wildcard && !result.is_null() && !unsafe { &*result }.ai_next.is_null();
     let mut current = result;
     let mut resolved = None;
     while !current.is_null() {
         let info = unsafe { &*current };
-        if info.ai_family == family && !info.ai_addr.is_null() && info.ai_addrlen as usize >= want {
+        let wanted = family == rffi::AF_UNSPEC || info.ai_family == family;
+        if wanted
+            && !info.ai_addr.is_null()
+            && let Some(want) = sockaddr_len_of(info.ai_family)
+            && info.ai_addrlen as usize >= want
+        {
             let mut storage: rffi::sockaddr_storage = unsafe { std::mem::zeroed() };
             unsafe {
                 std::ptr::copy_nonoverlapping(
@@ -3135,6 +3210,13 @@ fn resolve_ip_host(
         current = info.ai_next;
     }
     unsafe { rffi::freeaddrinfo(result) };
+    if ambiguous_wildcard {
+        return Err(socket_converted_error(
+            "error",
+            None,
+            "wildcard resolved to multiple address",
+        ));
+    }
     // The hints pin `ai_family`, so a success with no answer of that family
     // is a resolver that ignored them.  `getaddrinfo` returned no code to
     // carry, so this is the plain module error, the way "sockaddr resolved to
@@ -3155,7 +3237,7 @@ fn pack_inet_addr(
     // calling method in its messages and rejects any protocol but
     // `HV_PROTOCOL_RAW`.
     #[cfg(not(windows))]
-    let _ = (caller, proto);
+    let _ = proto;
     let mut storage: rffi::sockaddr_storage = unsafe { std::mem::zeroed() };
     // AF_UNIX is special: rsocket.py:RSocket.bind/connect accept a bare
     // bytes/str path (or a 1-tuple wrapping the path).  Pull the path
@@ -3250,7 +3332,11 @@ fn pack_inet_addr(
     }
     let port_raw = unsafe { pyre_object::w_int_get_value(port_obj) };
     if !(0..=0xFFFF).contains(&port_raw) {
-        return Err(crate::PyError::overflow_error("port must be 0-65535"));
+        // `getsockaddrarg` spells the message with the method it was called
+        // for: `bind(): port must be 0-65535.`
+        return Err(crate::PyError::overflow_error(format!(
+            "{caller}(): port must be 0-65535."
+        )));
     }
     let port = (port_raw as u16).to_be();
 

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -526,11 +526,18 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("EAI_SERVICE", libc::EAI_SERVICE);
         cst!("EAI_SOCKTYPE", libc::EAI_SOCKTYPE);
         cst!("EAI_SYSTEM", libc::EAI_SYSTEM);
-        // EAI_ADDRFAMILY / EAI_BADHINTS / EAI_PROTOCOL / EAI_MAX exist
-        // on macOS at the system-header level but the libc crate does
-        // not export them; PyPy filters them out via
-        // `platform.DefinedConstantInteger` on platforms where they are
-        // absent, so we mirror that and skip.
+        // `_rsocket_rffi.py` names these four alongside the rest and
+        // `platform.DefinedConstantInteger` keeps whichever the platform's
+        // `<netdb.h>` defines.  Darwin defines all four; the libc crate does
+        // not re-export them, so they are spelled out here the way
+        // `NI_MAXSERV` above is.
+        #[cfg(target_vendor = "apple")]
+        {
+            cst!("EAI_ADDRFAMILY", 1);
+            cst!("EAI_BADHINTS", 12);
+            cst!("EAI_PROTOCOL", 13);
+            cst!("EAI_MAX", 15);
+        }
         // ── SCM_* (ancillary data types) ──
         cst!("SCM_RIGHTS", libc::SCM_RIGHTS);
         #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
@@ -542,6 +542,15 @@ pub fn sockaddr_in_set_addr(sin: &mut sockaddr_in, addr: u32) {
 }
 
 #[cfg(unix)]
+pub fn sockaddr_in6_get_addr(sin6: &sockaddr_in6) -> [u8; 16] {
+    sin6.sin6_addr.s6_addr
+}
+#[cfg(windows)]
+pub fn sockaddr_in6_get_addr(sin6: &sockaddr_in6) -> [u8; 16] {
+    unsafe { sin6.sin6_addr.u.Byte }
+}
+
+#[cfg(unix)]
 pub fn sockaddr_in6_set_addr(sin6: &mut sockaddr_in6, addr: [u8; 16]) {
     sin6.sin6_addr.s6_addr = addr;
 }

--- a/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
@@ -80,6 +80,10 @@ pub const NI_MAXHOST: usize = libc::NI_MAXHOST as usize;
 pub const INADDR_ANY: u32 = libc::INADDR_ANY;
 #[cfg(unix)]
 pub const AI_NUMERICHOST: libc::c_int = libc::AI_NUMERICHOST;
+#[cfg(unix)]
+pub const AI_PASSIVE: libc::c_int = libc::AI_PASSIVE;
+#[cfg(unix)]
+pub const INADDR_BROADCAST: u32 = libc::INADDR_BROADCAST;
 
 #[cfg(windows)]
 pub const AF_UNSPEC: libc::c_int = ws::AF_UNSPEC as libc::c_int;
@@ -114,6 +118,12 @@ pub const NI_MAXHOST: usize = ws::NI_MAXHOST as usize;
 pub const INADDR_ANY: u32 = ws::INADDR_ANY;
 #[cfg(windows)]
 pub const AI_NUMERICHOST: libc::c_int = ws::AI_NUMERICHOST as libc::c_int;
+#[cfg(windows)]
+pub const AI_PASSIVE: libc::c_int = ws::AI_PASSIVE as libc::c_int;
+/// WinSock declares it as a preprocessor macro, which the generated bindings
+/// do not carry.  It is all ones, so it reads the same in either byte order.
+#[cfg(windows)]
+pub const INADDR_BROADCAST: u32 = 0xffff_ffff;
 
 // ── WinSock initialisation ──
 
@@ -1079,6 +1089,50 @@ pub unsafe fn host_by_addr(
         init();
         unsafe { ws::gethostbyaddr(addr as *const u8, len, family) }
     }
+}
+
+/// The code the resolver reports a failed name or address lookup with, and the
+/// platform's message for it.
+///
+/// `gethostbyname` / `gethostbyaddr` leave it in `h_errno` rather than `errno`,
+/// and `set_herror` raises `herror(code, hstrerror(code))` from the pair.  The
+/// variable is spelled three ways: glibc and musl make it a thread-local behind
+/// `__h_errno_location`, the BSDs export the plain global `<netdb.h>` declares,
+/// and winsock defines it as `WSAGetLastError()`.
+pub fn host_error() -> (libc::c_int, String) {
+    #[cfg(all(unix, any(target_os = "linux", target_os = "android")))]
+    let code = {
+        unsafe extern "C" {
+            fn __h_errno_location() -> *mut libc::c_int;
+        }
+        unsafe { *__h_errno_location() }
+    };
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+    let code = {
+        unsafe extern "C" {
+            static h_errno: libc::c_int;
+        }
+        unsafe { h_errno }
+    };
+    #[cfg(windows)]
+    let code = last_error_code();
+
+    #[cfg(unix)]
+    let message = {
+        let p = unsafe { libc::hstrerror(code) };
+        if p.is_null() {
+            "host not found".to_string()
+        } else {
+            unsafe { std::ffi::CStr::from_ptr(p) }
+                .to_string_lossy()
+                .into_owned()
+        }
+    };
+    // No `hstrerror` on Windows, where `set_herror` falls back to the literal.
+    #[cfg(windows)]
+    let message = "host not found".to_string();
+
+    (code, message)
 }
 
 /// # Safety

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -24,7 +24,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(ns, "MAGIC", w_int_new(20230612)); // SRE magic number
     module_ns_store(ns, "CODESIZE", w_int_new(sre_engine::CODESIZE as i64));
     module_ns_store(ns, "MAXREPEAT", w_int_new(sre_engine::MAXREPEAT as i64));
-    module_ns_store(ns, "MAXGROUPS", w_int_new(sre_engine::MAXGROUPS as i64));
+    // `sre.h SRE_MAXGROUPS` halves `INT32_MAX`; the engine crate halves its own
+    // `MAXREPEAT`, which is unsigned, and lands one bit wide. `re/_parser.py`
+    // bounds a pattern's group count and two group references on this number,
+    // so it is the one a caller can reach.
+    module_ns_store(ns, "MAXGROUPS", w_int_new(i32::MAX as i64 / 2));
     // _sre module-level functions: PyPy mixedmodule.py:111-116 wraps these
     // as BuiltinFunction so storing them on a user class does not bind self.
     module_ns_store(

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -121,7 +121,7 @@ fn set_library_reason(exception: PyObjectRef, message: &str) {
 fn ssl_error(message: impl Into<String>) -> crate::PyError {
     let message = message.into();
     let mut err = crate::PyError::os_error(message.clone());
-    if let Some(cls) = crate::builtins::lookup_exc_class("_ssl.SSLError")
+    if let Some(cls) = crate::builtins::lookup_exc_class("ssl.SSLError")
         && let Ok(exc) =
             crate::builtins::exc_exception_new(&[cls, w_int_new(0), w_str_new(&message)])
     {
@@ -165,12 +165,12 @@ fn tls_error(code: i32, message: String) -> crate::PyError {
     let verify_code = (code >= pyre_native::ssl::TLS_ERROR_CERT_VERIFY_BASE)
         .then_some(code - pyre_native::ssl::TLS_ERROR_CERT_VERIFY_BASE);
     let class_name = match code {
-        pyre_native::ssl::TLS_ERROR_WANT_READ => "_ssl.SSLWantReadError",
-        pyre_native::ssl::TLS_ERROR_WANT_WRITE => "_ssl.SSLWantWriteError",
-        pyre_native::ssl::TLS_ERROR_ZERO_RETURN => "_ssl.SSLZeroReturnError",
-        pyre_native::ssl::TLS_ERROR_EOF => "_ssl.SSLEOFError",
-        _ if verify_code.is_some() => "_ssl.SSLCertVerificationError",
-        _ => "_ssl.SSLError",
+        pyre_native::ssl::TLS_ERROR_WANT_READ => "ssl.SSLWantReadError",
+        pyre_native::ssl::TLS_ERROR_WANT_WRITE => "ssl.SSLWantWriteError",
+        pyre_native::ssl::TLS_ERROR_ZERO_RETURN => "ssl.SSLZeroReturnError",
+        pyre_native::ssl::TLS_ERROR_EOF => "ssl.SSLEOFError",
+        _ if verify_code.is_some() => "ssl.SSLCertVerificationError",
+        _ => "ssl.SSLError",
     };
     // `ssl_error` would build a complete `_ssl.SSLError` only for the
     // class-specific instance below to replace it, and WANT_READ/WANT_WRITE
@@ -2608,34 +2608,34 @@ crate::py_module! {
         "_SSLSocket" => ssl_socket_methods::type_object(),
         "Certificate" => certificate_methods::type_object(),
         "SSLError" => crate::builtins::make_exc_type(
-            "_ssl.SSLError",
+            "ssl.SSLError",
             crate::builtins::exc_os_error_new,
             crate::builtins::lookup_exc_class("OSError").expect("OSError installed"),
         ),
         "SSLZeroReturnError" => crate::builtins::make_exc_type(
-            "_ssl.SSLZeroReturnError",
+            "ssl.SSLZeroReturnError",
             crate::builtins::exc_os_error_new,
-            crate::builtins::lookup_exc_class("_ssl.SSLError").expect("SSLError installed"),
+            crate::builtins::lookup_exc_class("ssl.SSLError").expect("SSLError installed"),
         ),
         "SSLWantReadError" => crate::builtins::make_exc_type(
-            "_ssl.SSLWantReadError",
+            "ssl.SSLWantReadError",
             crate::builtins::exc_os_error_new,
-            crate::builtins::lookup_exc_class("_ssl.SSLError").expect("SSLError installed"),
+            crate::builtins::lookup_exc_class("ssl.SSLError").expect("SSLError installed"),
         ),
         "SSLWantWriteError" => crate::builtins::make_exc_type(
-            "_ssl.SSLWantWriteError",
+            "ssl.SSLWantWriteError",
             crate::builtins::exc_os_error_new,
-            crate::builtins::lookup_exc_class("_ssl.SSLError").expect("SSLError installed"),
+            crate::builtins::lookup_exc_class("ssl.SSLError").expect("SSLError installed"),
         ),
         "SSLSyscallError" => crate::builtins::make_exc_type(
-            "_ssl.SSLSyscallError",
+            "ssl.SSLSyscallError",
             crate::builtins::exc_os_error_new,
-            crate::builtins::lookup_exc_class("_ssl.SSLError").expect("SSLError installed"),
+            crate::builtins::lookup_exc_class("ssl.SSLError").expect("SSLError installed"),
         ),
         "SSLEOFError" => crate::builtins::make_exc_type(
-            "_ssl.SSLEOFError",
+            "ssl.SSLEOFError",
             crate::builtins::exc_os_error_new,
-            crate::builtins::lookup_exc_class("_ssl.SSLError").expect("SSLError installed"),
+            crate::builtins::lookup_exc_class("ssl.SSLError").expect("SSLError installed"),
         ),
         // OpenSSL-shaped compatibility fields are required by `ssl.py` and
         // consumers such as urllib3, while the suffix names the real backend.
@@ -2740,7 +2740,7 @@ crate::py_module! {
         ] {
             crate::module_ns_store(ns, name, crate::gateway::with_module("_ssl", func));
         }
-        let ssl_error = crate::builtins::lookup_exc_class("_ssl.SSLError")
+        let ssl_error = crate::builtins::lookup_exc_class("ssl.SSLError")
             .expect("SSLError installed");
         let ssl_error_dict =
             unsafe { pyre_object::w_type_get_dict_ptr(ssl_error) as PyObjectRef };
@@ -2754,7 +2754,7 @@ crate::py_module! {
         let value_error = crate::builtins::lookup_exc_class("ValueError")
             .expect("ValueError installed");
         let cert_error = crate::builtins::make_exc_type_multi(
-            "_ssl.SSLCertVerificationError",
+            "ssl.SSLCertVerificationError",
             crate::builtins::exc_os_error_new,
             &[ssl_error, value_error],
         );

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -2755,7 +2755,7 @@ crate::py_module! {
             .expect("ValueError installed");
         let cert_error = crate::builtins::make_exc_type_multi(
             "_ssl.SSLCertVerificationError",
-            crate::builtins::exc_exception_new,
+            crate::builtins::exc_os_error_new,
             &[ssl_error, value_error],
         );
         crate::module_ns_store(ns, "SSLCertVerificationError", cert_error);

--- a/pyre/pyre-interpreter/src/module/_symtable/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_symtable/mod.rs
@@ -32,11 +32,12 @@ const PUBLIC_SYMBOL_FLAGS: SymbolFlags = SymbolFlags::from_bits_retain(
         | SymbolFlags::DEF_TYPE_PARAM.bits()
         | SymbolFlags::DEF_COMP_CELL.bits(),
 );
+/// `pycore_symtable.h DEF_BOUND` — the three bits and no more.  `symtable.py`
+/// reads it in `is_global` and `is_local` alone, and in both only for a symbol
+/// in the module block; `DEF_TYPE_PARAM` is set only on names inside a `type
+/// parameters` block, so the wider mask never reached a reader.
 const DEF_BOUND: SymbolFlags = SymbolFlags::from_bits_retain(
-    SymbolFlags::DEF_LOCAL.bits()
-        | SymbolFlags::DEF_PARAM.bits()
-        | SymbolFlags::DEF_IMPORT.bits()
-        | SymbolFlags::DEF_TYPE_PARAM.bits(),
+    SymbolFlags::DEF_LOCAL.bits() | SymbolFlags::DEF_PARAM.bits() | SymbolFlags::DEF_IMPORT.bits(),
 );
 
 fn table_type(table: &SymbolTable) -> i32 {

--- a/pyre/pyre-interpreter/src/module/fcntl/interp_fcntl.rs
+++ b/pyre/pyre-interpreter/src/module/fcntl/interp_fcntl.rs
@@ -32,13 +32,17 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // number it wraps.
                 let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
                 let cmd = (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32;
-                if args.len() >= 3 && unsafe { pyre_object::bytesobject::is_bytes_like(args[2]) } {
-                    let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[2]) };
-                    let mut buf = data.to_vec();
-                    buf.push(0);
-                    // `interp_fcntl.py fcntl` tries the string-buffer
-                    // path before falling back to the integer path, and
-                    // returns exactly the original buffer length.
+                // `interp_fcntl.py fcntl` tries the string-buffer path before
+                // falling back to the integer one and returns exactly the
+                // original buffer's length; `fcntl_fcntl_impl` takes its
+                // integer arm first, on `PyIndex_Check`.
+                if args.len() >= 3 && !unsafe { pyre_object::is_int(args[2]) } {
+                    let data = arg_readbuf(args[2], "fcntl")?;
+                    let Some(mut buf) = stage_arg(data) else {
+                        return Err(crate::PyError::value_error(
+                            "fcntl argument 3 is too long",
+                        ));
+                    };
                     loop {
                         let outcome = {
                             let _blocked = crate::module::thread::before_external_block();
@@ -46,6 +50,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         };
                         match outcome {
                             Ok(_) => {
+                                guard_intact(&buf, data.len())?;
                                 return Ok(pyre_object::bytesobject::w_bytes_from_bytes(
                                     &buf[..data.len()],
                                 ));
@@ -60,11 +65,6 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     }
                 }
                 let arg = if args.len() >= 3 {
-                    if !unsafe { pyre_object::is_int(args[2]) } {
-                        return Err(crate::PyError::type_error(
-                            "fcntl() arguments must be integers",
-                        ));
-                    }
                     unsafe { pyre_object::w_int_get_value(args[2]) as i32 }
                 } else {
                     0
@@ -103,14 +103,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function("ioctl", |args| {
             #[cfg(all(unix, feature = "host_env"))]
             {
-                if !(2..=3).contains(&args.len()) {
-                    return Err(crate::PyError::type_error(
-                        "ioctl() takes 2 or 3 arguments",
-                    ));
+                // `interp_fcntl.py ioctl(space, w_fd, w_request, w_arg,
+                // mutate_flag=-1)` / `fcntl_ioctl_impl(module, fd, code, arg,
+                // mutate_arg)`.
+                if !(2..=4).contains(&args.len()) {
+                    return Err(crate::PyError::type_error(format!(
+                        "ioctl expected at most 4 arguments, got {}",
+                        args.len()
+                    )));
                 }
-                if !unsafe { pyre_object::is_int(args[1]) }
-                    || (args.len() >= 3 && !unsafe { pyre_object::is_int(args[2]) })
-                {
+                if !unsafe { pyre_object::is_int(args[1]) } {
                     return Err(crate::PyError::type_error(
                         "ioctl() arguments must be integers",
                     ));
@@ -121,6 +123,29 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
                 let raw_req = (unsafe { pyre_object::w_int_get_value(args[1]) }) as i64;
                 let request = rustpython_host_env::fcntl::normalize_ioctl_request(raw_req);
+                // The integer arm comes first, before the argument is ever
+                // looked at as a buffer.
+                if args.len() >= 3 && !unsafe { pyre_object::is_int(args[2]) } {
+                    let arg = args[2];
+                    // `mutate_arg` defaults true, and is consulted only for an
+                    // exporter that is neither `bytes` nor `str` — those two
+                    // always take the read-only form however it is set.
+                    let mutate = if args.len() >= 4 {
+                        crate::baseobjspace::is_true(args[3])?
+                    } else {
+                        true
+                    };
+                    let immutable =
+                        unsafe { pyre_object::bytesobject::is_bytes(arg) || pyre_object::is_str(arg) };
+                    if mutate
+                        && !immutable
+                        && let Ok((slice, _owner, _made_view)) =
+                            unsafe { crate::builtins::fileio_writebuf(arg) }
+                    {
+                        return ioctl_mutable(fd, request, slice);
+                    }
+                    return ioctl_readonly(fd, request, arg_readbuf(arg, "ioctl")?);
+                }
                 let arg = if args.len() >= 3 {
                     unsafe { pyre_object::w_int_get_value(args[2]) as i32 }
                 } else {
@@ -345,4 +370,115 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             cst!("F_GETPIPE_SZ", libc::F_GETPIPE_SZ);
         }
     }
+}
+
+/// `fcntl_ioctl_impl`'s `IOCTL_BUFSZ` / `fcntl_fcntl_impl`'s `FCNTL_BUFSZ` —
+/// the staging buffer a copied argument is handed to the kernel in.  Both are
+/// 1024.
+#[cfg(all(unix, feature = "host_env"))]
+const ARG_BUFSZ: usize = 1024;
+
+/// The `guard` both impls write after the staged argument.  A request
+/// whose payload is longer than the argument the caller supplied overwrites
+/// it, and that is the only way the overrun can be seen at all — so the bytes
+/// are the module's, verbatim, starting with the NUL the staged copy is
+/// terminated by.
+#[cfg(all(unix, feature = "host_env"))]
+const ARG_GUARD: [u8; 8] = [0x00, 0xfa, 0x69, 0xc4, 0x67, 0xa3, 0x6c, 0x58];
+
+/// The third argument as `PyArg_Parse(arg, "s*")` reads it: any readable
+/// buffer, or a `str`'s UTF-8, which `readbuf_w` alone does not accept.
+#[cfg(all(unix, feature = "host_env"))]
+fn arg_readbuf(
+    arg: pyre_object::PyObjectRef,
+    callable: &str,
+) -> Result<&'static [u8], crate::PyError> {
+    if unsafe { pyre_object::is_str(arg) } {
+        return Ok(crate::baseobjspace::str_utf8_w(arg)?.as_bytes());
+    }
+    unsafe { crate::builtins::acquire_readbuf(arg) }.map_err(|_| {
+        let type_name = unsafe { pyre_object::type_name_of(arg) };
+        crate::PyError::type_error(format!(
+            "{callable}() argument 3 must be an integer, a bytes-like object, \
+             or a string, not {type_name}"
+        ))
+    })
+}
+
+/// Run `ioctl` with `arg` as its third argument, reporting the errno on
+/// failure.
+#[cfg(all(unix, feature = "host_env"))]
+fn ioctl_ptr(fd: i32, request: libc::c_ulong, ptr: *mut u8) -> Result<i32, crate::PyError> {
+    let ret = {
+        let _blocked = crate::module::thread::before_external_block();
+        unsafe { libc::ioctl(fd, request, ptr as *mut libc::c_void) }
+    };
+    if ret < 0 {
+        let e = std::io::Error::last_os_error();
+        return Err(crate::PyError::os_error_with_errno(
+            e.raw_os_error().unwrap_or(0),
+            format!("ioctl: {e}"),
+        ));
+    }
+    Ok(ret)
+}
+
+/// A staging buffer holding `arg` followed by the guard, or `None` when `arg`
+/// is longer than the staging buffer and has to be handed over as it is.
+#[cfg(all(unix, feature = "host_env"))]
+fn stage_arg(arg: &[u8]) -> Option<Vec<u8>> {
+    if arg.len() > ARG_BUFSZ {
+        return None;
+    }
+    let mut buf = vec![0u8; ARG_BUFSZ + ARG_GUARD.len()];
+    buf[..arg.len()].copy_from_slice(arg);
+    buf[arg.len()..arg.len() + ARG_GUARD.len()].copy_from_slice(&ARG_GUARD);
+    Some(buf)
+}
+
+#[cfg(all(unix, feature = "host_env"))]
+fn guard_intact(buf: &[u8], len: usize) -> Result<(), crate::PyError> {
+    if buf[len..len + ARG_GUARD.len()] == ARG_GUARD {
+        return Ok(());
+    }
+    Err(crate::PyError::system_error("buffer overflow"))
+}
+
+/// The writable-exporter arm: the kernel's answer lands back in the caller's
+/// own storage and the call returns the syscall's value.  An argument longer
+/// than the staging buffer is handed over directly, so there is no guard to
+/// check and no length to refuse.
+#[cfg(all(unix, feature = "host_env"))]
+fn ioctl_mutable(
+    fd: i32,
+    request: libc::c_ulong,
+    arg: &mut [u8],
+) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    let Some(mut buf) = stage_arg(arg) else {
+        let ret = ioctl_ptr(fd, request, arg.as_mut_ptr())?;
+        return Ok(pyre_object::w_int_new(ret as i64));
+    };
+    let ret = ioctl_ptr(fd, request, buf.as_mut_ptr())?;
+    arg.copy_from_slice(&buf[..arg.len()]);
+    guard_intact(&buf, arg.len())?;
+    Ok(pyre_object::w_int_new(ret as i64))
+}
+
+/// The read-only arm: the answer is the staged copy, returned as bytes of the
+/// argument's own length.  This one does refuse an over-long argument, because
+/// the kernel can only be given the staging buffer.
+#[cfg(all(unix, feature = "host_env"))]
+fn ioctl_readonly(
+    fd: i32,
+    request: libc::c_ulong,
+    arg: &[u8],
+) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    let Some(mut buf) = stage_arg(arg) else {
+        return Err(crate::PyError::value_error("ioctl argument 3 is too long"));
+    };
+    ioctl_ptr(fd, request, buf.as_mut_ptr())?;
+    guard_intact(&buf, arg.len())?;
+    Ok(pyre_object::bytesobject::w_bytes_from_bytes(
+        &buf[..arg.len()],
+    ))
 }

--- a/pyre/pyre-interpreter/src/module/fcntl/interp_fcntl.rs
+++ b/pyre/pyre-interpreter/src/module/fcntl/interp_fcntl.rs
@@ -369,6 +369,24 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             cst!("F_SETPIPE_SZ", libc::F_SETPIPE_SZ);
             cst!("F_GETPIPE_SZ", libc::F_GETPIPE_SZ);
         }
+        // The darwin half of the same list.  `F_SETLEASE`/`F_GETLEASE` carry
+        // different numbers here than under linux, so they are spelled per
+        // platform rather than shared.
+        #[cfg(target_vendor = "apple")]
+        {
+            cst!("FASYNC", 64);
+            cst!("F_FULLFSYNC", libc::F_FULLFSYNC);
+            cst!("F_GETLEASE", 107);
+            cst!("F_SETLEASE", 106);
+            cst!("F_GETNOSIGPIPE", 74);
+            cst!("F_SETNOSIGPIPE", 73);
+            cst!("F_GETPATH", libc::F_GETPATH);
+            cst!("F_NOCACHE", libc::F_NOCACHE);
+            cst!("F_RDAHEAD", libc::F_RDAHEAD);
+            cst!("F_OFD_GETLK", libc::F_OFD_GETLK);
+            cst!("F_OFD_SETLK", libc::F_OFD_SETLK);
+            cst!("F_OFD_SETLKW", libc::F_OFD_SETLKW);
+        }
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -2131,11 +2131,6 @@ fn register_posix_constants(ns: pyre_object::PyObjectRef) {
         );
         crate::module_ns_store(
             ns,
-            "PROT_NONE",
-            pyre_object::w_int_new(libc::PROT_NONE as i64),
-        );
-        crate::module_ns_store(
-            ns,
             "MADV_NORMAL",
             pyre_object::w_int_new(host_mmap::MADV_NORMAL as i64),
         );
@@ -2159,5 +2154,31 @@ fn register_posix_constants(ns: pyre_object::PyObjectRef) {
             "MADV_DONTNEED",
             pyre_object::w_int_new(host_mmap::MADV_DONTNEED as i64),
         );
+        // The `MAP_*` / `MADV_*` names `<sys/mman.h>` defines only on darwin.
+        // `rmmap.py` reaches them through `DefinedConstantInteger`, which
+        // yields None wherever the header is silent; the cfg does the same
+        // job.
+        #[cfg(target_vendor = "apple")]
+        {
+            macro_rules! cst {
+                ($name:literal, $val:expr) => {
+                    crate::module_ns_store(ns, $name, pyre_object::w_int_new($val as i64));
+                };
+            }
+            cst!("MADV_FREE", libc::MADV_FREE);
+            cst!("MADV_FREE_REUSABLE", libc::MADV_FREE_REUSABLE);
+            cst!("MADV_FREE_REUSE", libc::MADV_FREE_REUSE);
+            cst!("MAP_32BIT", 32768);
+            cst!("MAP_HASSEMAPHORE", libc::MAP_HASSEMAPHORE);
+            cst!("MAP_JIT", libc::MAP_JIT);
+            cst!("MAP_NOCACHE", libc::MAP_NOCACHE);
+            cst!("MAP_NOEXTEND", libc::MAP_NOEXTEND);
+            cst!("MAP_NORESERVE", libc::MAP_NORESERVE);
+            cst!("MAP_RESILIENT_CODESIGN", 8192);
+            cst!("MAP_RESILIENT_MEDIA", 16384);
+            cst!("MAP_TPRO", 524288);
+            cst!("MAP_TRANSLATED_ALLOW_EXECUTE", 131072);
+            cst!("MAP_UNIX03", 262144);
+        }
     }
 }

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -2093,6 +2093,27 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         ] {
             crate::module_ns_store(ns, name, pyre_object::w_int_new(val));
         }
+        // Darwin-only names. `NGROUPS_MAX` (`<sys/syslimits.h>`) and `TMP_MAX`
+        // (`<stdio.h>`) exist on linux too but with the glibc numbering, so
+        // they are answered per platform rather than shared. The `PRIO_DARWIN_*`
+        // family is what `setpriority` takes there instead of a nice value, and
+        // the `_COPYFILE_*` bits are the `flags` word `shutil` hands
+        // `copyfile()` through `posix._fcopyfile`.
+        #[cfg(target_vendor = "apple")]
+        for (name, val) in [
+            ("NGROUPS_MAX", 16i64),
+            ("TMP_MAX", libc::TMP_MAX as i64),
+            ("PRIO_DARWIN_BG", libc::PRIO_DARWIN_BG as i64),
+            ("PRIO_DARWIN_NONUI", libc::PRIO_DARWIN_NONUI as i64),
+            ("PRIO_DARWIN_PROCESS", libc::PRIO_DARWIN_PROCESS as i64),
+            ("PRIO_DARWIN_THREAD", libc::PRIO_DARWIN_THREAD as i64),
+            ("_COPYFILE_ACL", libc::COPYFILE_ACL as i64),
+            ("_COPYFILE_DATA", libc::COPYFILE_DATA as i64),
+            ("_COPYFILE_STAT", libc::COPYFILE_STAT as i64),
+            ("_COPYFILE_XATTR", libc::COPYFILE_XATTR as i64),
+        ] {
+            crate::module_ns_store(ns, name, pyre_object::w_int_new(val));
+        }
     }
     // Remaining noop stubs — functions os.py references at module level.
     // Functions with real implementations are registered individually below.

--- a/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
+++ b/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
@@ -1617,9 +1617,14 @@ fn maybe_reject_amplification(parser: PyObjectRef, input: &str) -> Result<(), cr
     Ok(())
 }
 
+/// The name `pyexpat.c` registers the module's exception class under.  It is
+/// reached as `pyexpat.error`, `pyexpat.ExpatError` and
+/// `xml.parsers.expat.ExpatError`, and the last is the one it is named for.
+const EXPAT_ERROR_NAME: &str = "xml.parsers.expat.ExpatError";
+
 fn pyexpat_error(msg: String, code: i64, lineno: i64, offset: i64) -> crate::PyError {
     let mut err = crate::PyError::value_error(msg.clone());
-    if let Some(cls) = crate::builtins::lookup_exc_class("pyexpat.error") {
+    if let Some(cls) = crate::builtins::lookup_exc_class(EXPAT_ERROR_NAME) {
         let args = [cls, w_str_new(&msg)];
         if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
             // The fresh exception is named only by this local while the three
@@ -2116,10 +2121,6 @@ crate::py_module! {
         "XML_PARAM_ENTITY_PARSING_UNLESS_STANDALONE" => w_int_new(1),
         "XML_PARAM_ENTITY_PARSING_ALWAYS" => w_int_new(2),
     },
-    exceptions: {
-        "error" => crate::builtins::lookup_exc_class("Exception")
-            .expect("Exception must be installed before pyexpat init"),
-    },
     inline_functions: {
         fn ParserCreate(
             #[default(w_none())] encoding: PyObjectRef,
@@ -2136,10 +2137,20 @@ crate::py_module! {
         "ErrorString"  / 1 = error_string,
     },
     extra_init: |ns| {
-        // `ExpatError` is an alias of `error` (pyexpat exposes both).
-        if let Some(err) = crate::module_ns_get(ns, "error") {
-            crate::module_ns_store(ns, "ExpatError", err);
-        }
+        // The class is registered under the name `xml.parsers.expat` publishes
+        // it as, not under this module's own — `pyexpat.c` builds it with
+        // `PyErr_NewException("xml.parsers.expat.ExpatError", NULL, NULL)` — so
+        // it cannot come from the `exceptions:` arm, which qualifies the key
+        // with the module it is declared in.  Both `error` and `ExpatError`
+        // name the one class.
+        let err = crate::builtins::make_exc_type(
+            EXPAT_ERROR_NAME,
+            crate::builtins::exc_exception_new,
+            crate::builtins::lookup_exc_class("Exception")
+                .expect("Exception must be installed before pyexpat init"),
+        );
+        crate::module_ns_store(ns, "error", err);
+        crate::module_ns_store(ns, "ExpatError", err);
 
         // model — content-model integer constants.
         // Each submodule object is a fresh instance named only by its local

--- a/pyre/pyre-interpreter/src/module/select/interp_kevent.rs
+++ b/pyre/pyre-interpreter/src/module/select/interp_kevent.rs
@@ -112,6 +112,20 @@ impl W_Kevent {
         newint_from_u64(self.udata)
     }
 
+    /// `kqueue_event_repr` — all six fields, `ident` unsigned decimal,
+    /// `filter` signed decimal, `flags` / `fflags` / `data` hex, and `udata`
+    /// through `%p`, whose leading `0x` `PyUnicode_FromFormat` guarantees.
+    /// `data` is formatted as `long long`, so a negative one reads as its
+    /// two's complement.  `interp_kqueue.py W_Kevent` registers no `__repr__`
+    /// at all.
+    fn __repr__(&self) -> String {
+        format!(
+            "<select.kevent ident={} filter={} flags=0x{:x} fflags=0x{:x} \
+             data=0x{:x} udata=0x{:x}>",
+            self.ident, self.filter, self.flags, self.fflags, self.data, self.udata,
+        )
+    }
+
     /// `interp_kqueue.py descr__eq__` and friends — two kevents
     /// compare by all six fields lexicographically.  A non-kevent other
     /// yields `NotImplemented`.

--- a/pyre/pyre-interpreter/src/module/select/interp_select.rs
+++ b/pyre/pyre-interpreter/src/module/select/interp_select.rs
@@ -579,6 +579,33 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         kq!("KQ_EV_CLEAR", libc::EV_CLEAR);
         kq!("KQ_EV_EOF", libc::EV_EOF);
         kq!("KQ_EV_ERROR", libc::EV_ERROR);
+        // `symbol_map` stops here — it comments out the two internal
+        // `EV_` flags as "not defined on FreeBSD" and never names the
+        // `NOTE_*` family at all.  `selectmodule.c` publishes both under
+        // `#ifdef`, and darwin defines every one of them.
+        kq!("KQ_EV_SYSFLAGS", libc::EV_SYSFLAGS);
+        kq!("KQ_EV_FLAG1", libc::EV_FLAG1);
+        // READ / WRITE filter flag.
+        kq!("KQ_NOTE_LOWAT", libc::NOTE_LOWAT);
+        // VNODE filter flags.
+        kq!("KQ_NOTE_DELETE", libc::NOTE_DELETE);
+        kq!("KQ_NOTE_WRITE", libc::NOTE_WRITE);
+        kq!("KQ_NOTE_EXTEND", libc::NOTE_EXTEND);
+        kq!("KQ_NOTE_ATTRIB", libc::NOTE_ATTRIB);
+        kq!("KQ_NOTE_LINK", libc::NOTE_LINK);
+        kq!("KQ_NOTE_RENAME", libc::NOTE_RENAME);
+        kq!("KQ_NOTE_REVOKE", libc::NOTE_REVOKE);
+        // PROC filter flags.  `NOTE_PCTRLMASK` is `~NOTE_PDATAMASK` over a
+        // signed `int` in `<sys/event.h>`, so it publishes negative; the rest
+        // are unsigned literals and publish as written.
+        kq!("KQ_NOTE_EXIT", libc::NOTE_EXIT);
+        kq!("KQ_NOTE_FORK", libc::NOTE_FORK);
+        kq!("KQ_NOTE_EXEC", libc::NOTE_EXEC);
+        kq!("KQ_NOTE_PCTRLMASK", libc::NOTE_PCTRLMASK as i32);
+        kq!("KQ_NOTE_PDATAMASK", libc::NOTE_PDATAMASK);
+        kq!("KQ_NOTE_TRACK", libc::NOTE_TRACK);
+        kq!("KQ_NOTE_CHILD", libc::NOTE_CHILD);
+        kq!("KQ_NOTE_TRACKERR", libc::NOTE_TRACKERR);
     }
 
     // `interp_select.py:35 W_Error = OSError` — expose the real type so

--- a/pyre/pyre-interpreter/src/module/select/mod.rs
+++ b/pyre/pyre-interpreter/src/module/select/mod.rs
@@ -12,3 +12,20 @@ pub mod interp_kevent;
 pub mod interp_kqueue;
 
 crate::pyre_module_init!(interp_select);
+
+/// The `select.kevent` type object, or null on a platform without kqueue.
+///
+/// The type is not acceptable as a base class and its constructor still binds
+/// keywords — `kqueue_event_init` parses the six-name kwlist, and
+/// `interp_kqueue.py W_Kevent.descr__init__` names the same six — so the call
+/// path has to name it among the non-base types that take keywords.
+pub fn kevent_type() -> pyre_object::PyObjectRef {
+    #[cfg(all(target_os = "macos", feature = "host_env"))]
+    {
+        interp_kevent::type_object()
+    }
+    #[cfg(not(all(target_os = "macos", feature = "host_env")))]
+    {
+        pyre_object::PY_NULL
+    }
+}

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -867,9 +867,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 #[cfg(feature = "host_env")]
                 {
                     // `interp_signal.py valid_signals` returns
-                    // `set(...)` via `_sigset_to_signals` (line 513),
-                    // not a frozenset.  PyPy passes NSIG (64) here.
-                    let sigs = rustpython_host_env::signal::valid_signals(64).unwrap_or_default();
+                    // `set(...)` via `_sigset_to_signals`, not a frozenset.
+                    // The bound is `NSIG`, exclusive: `sigfillset` sets the
+                    // bit for `NSIG - 1` and one past it too on darwin, so a
+                    // wider bound answers with a signal that has no name.
+                    let sigs = rustpython_host_env::signal::valid_signals(
+                        signalstate::NSIG as usize,
+                    )
+                    .unwrap_or_default();
                     let items: Vec<pyre_object::PyObjectRef> = sigs
                         .into_iter()
                         .map(|n| pyre_object::w_int_new(n as i64))
@@ -1460,6 +1465,17 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         );
         crate::module_ns_store(ns, "SIGIO", pyre_object::w_int_new(libc::SIGIO as i64));
         crate::module_ns_store(ns, "SIGSYS", pyre_object::w_int_new(libc::SIGSYS as i64));
+        // `SIGIOT` is the BSD spelling of `SIGABRT` and `SIGEMT`/`SIGINFO` are
+        // BSD signals linux has no number for, so the three are answered where
+        // `<signal.h>` names them.
+        #[cfg(target_vendor = "apple")]
+        for (name, val) in [
+            ("SIGEMT", libc::SIGEMT as i64),
+            ("SIGINFO", libc::SIGINFO as i64),
+            ("SIGIOT", libc::SIGIOT as i64),
+        ] {
+            crate::module_ns_store(ns, name, pyre_object::w_int_new(val));
+        }
     }
     // The seven the MSVC runtime defines, and the two console events
     // `os.kill` sends in place of a signal.  `Lib/signal.py` builds its

--- a/pyre/pyre-interpreter/src/module/signal/signalstate.rs
+++ b/pyre/pyre-interpreter/src/module/signal/signalstate.rs
@@ -11,13 +11,29 @@ use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicPtr, Ordering};
 
 /// `signals.c:34` — one past the highest signal number the platform has,
 /// which is what `Py_NSIG` names and what every range check answers from.
-/// The libc crate does not surface it portably; the POSIX cap is the
-/// reasonable default and fits a single `i64` bitmask, and the MSVC runtime
-/// defines its own, smaller, count.
+/// The libc crate does not surface it, so `<signal.h>`'s own number is
+/// spelled per platform: 32 on darwin, `_NSIG` = 65 under glibc, 23 from the
+/// MSVC runtime.  A host outside that set falls back to the 64 `signals.c`
+/// uses when the header is silent.
 #[cfg(windows)]
 pub const NSIG: i32 = 23;
-#[cfg(not(windows))]
+#[cfg(target_vendor = "apple")]
+pub const NSIG: i32 = 32;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub const NSIG: i32 = 65;
+#[cfg(not(any(
+    windows,
+    target_vendor = "apple",
+    target_os = "linux",
+    target_os = "android"
+)))]
 pub const NSIG: i32 = 64;
+
+/// `signals.c:38-39 N_LONGBITS / N_LONGSIG` — the pending bits live in an
+/// array of words rather than one word, because `NSIG` exceeds a word's
+/// width wherever `_NSIG` is 65.
+const N_LONGBITS: i32 = i64::BITS as i32;
+const N_LONGSIG: usize = ((NSIG - 1) / N_LONGBITS + 1) as usize;
 
 /// Identity of the signal-driving `ActionFlag` ticker cell (`signals.c:45-49
 /// pypysig_counter`).  The pointer is compared by the interpreter but never
@@ -28,7 +44,7 @@ pub const NSIG: i32 = 64;
 static TICKER_PTR: AtomicPtr<isize> = AtomicPtr::new(std::ptr::null_mut());
 
 /// `signals.c:51 pypysig_flags_bits` — one bit per pending signal.
-static SIG_PENDING: AtomicI64 = AtomicI64::new(0);
+static SIG_PENDING: [AtomicI64; N_LONGSIG] = [const { AtomicI64::new(0) }; N_LONGSIG];
 
 /// `signals.c:52 wakeup_fd` — fd to write a byte to on each signal, or
 /// -1 when disabled (`signal.set_wakeup_fd`).
@@ -93,8 +109,9 @@ pub(crate) fn rearm_ticker() {
 /// handler call it.  `set_interrupt` reaches signal delivery through here too.
 pub fn signal_pushback(signum: i32) {
     if (0..NSIG).contains(&signum) {
-        let bitmask = 1i64 << signum;
-        SIG_PENDING.fetch_or(bitmask, Ordering::SeqCst);
+        let index = (signum / N_LONGBITS) as usize;
+        let bitmask = 1i64 << (signum % N_LONGBITS);
+        SIG_PENDING[index].fetch_or(bitmask, Ordering::SeqCst);
         rearm_ticker();
     }
 }
@@ -102,14 +119,15 @@ pub fn signal_pushback(signum: i32) {
 /// `signals.c:205-223 pypysig_poll` — return the lowest-numbered pending
 /// signal, clearing its bit, or -1 when none are pending.
 pub fn signal_poll() -> i32 {
-    let mut value = SIG_PENDING.load(Ordering::SeqCst);
-    while value != 0 {
-        let j = value.trailing_zeros() as i32;
-        let bit = 1i64 << j;
-        match SIG_PENDING.compare_exchange(value, value & !bit, Ordering::SeqCst, Ordering::SeqCst)
-        {
-            Ok(_) => return j,
-            Err(current) => value = current,
+    for (index, word) in SIG_PENDING.iter().enumerate() {
+        let mut value = word.load(Ordering::SeqCst);
+        while value != 0 {
+            let j = value.trailing_zeros() as i32;
+            let bit = 1i64 << j;
+            match word.compare_exchange(value, value & !bit, Ordering::SeqCst, Ordering::SeqCst) {
+                Ok(_) => return index as i32 * N_LONGBITS + j,
+                Err(current) => value = current,
+            }
         }
     }
     -1
@@ -120,7 +138,9 @@ pub fn signal_poll() -> i32 {
 /// eval-breaker bit, closing the race where a signal arrives immediately
 /// before that clear.
 pub(crate) fn has_pending_signals() -> bool {
-    SIG_PENDING.load(Ordering::SeqCst) != 0
+    SIG_PENDING
+        .iter()
+        .any(|word| word.load(Ordering::SeqCst) != 0)
 }
 
 // ── wakeup fd (signals.c:246-272 pypysig_set_wakeup_fd) ──

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -1539,35 +1539,7 @@ pub fn is_unpack_iter(obj: PyObjectRef) -> bool {
 
 /// `space.readbuf_w` — a read-only byte slice from a bytes-like object.
 unsafe fn readbuf<'a>(obj: PyObjectRef) -> Result<&'a [u8], crate::PyError> {
-    unsafe {
-        if bytesobject::is_bytes_like(obj) {
-            return Ok(bytesobject::bytes_like_data(obj));
-        }
-        // `W_MMap.readbuf_w` — the live mapping.
-        #[cfg(all(any(unix, windows), not(feature = "sandbox")))]
-        if let Some(view) = crate::module::mmap::interp_mmap::mmap_buffer_view(obj) {
-            let (address, length, _readonly) = view?;
-            return Ok(std::slice::from_raw_parts(address as *const u8, length));
-        }
-        if interp_array::is_array(obj) {
-            return Ok(interp_array::w_array_bytes(obj));
-        }
-        if memoryview::is_w_memoryview(obj) {
-            crate::builtins::memoryview_check_released(obj)?;
-            if crate::builtins::memoryview_contiguity(obj).0 {
-                let view = memoryview::w_memoryview_view(obj);
-                let full = view.backing().as_bytes();
-                let off = view.offset() as usize;
-                let len = memoryview::w_memoryview_length(obj) as usize;
-                if off <= full.len() && len <= full.len() - off {
-                    return Ok(&full[off..off + len]);
-                }
-            }
-        }
-        Err(crate::PyError::type_error(
-            "a bytes-like object is required",
-        ))
-    }
+    unsafe { crate::builtins::acquire_readbuf(obj) }
 }
 
 crate::py_module! {

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -3787,6 +3787,31 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
     fn pick_str(args: &[PyObjectRef]) -> Option<PyObjectRef> {
         args.iter().find(|&&a| !a.is_null() && unsafe { is_str(a) }).copied()
     }
+    /// The error a `write` call that handed over no `str` owes.
+    ///
+    /// `W_TextIOWrapper.write_w` rejects a non-`str` argument, and code in the
+    /// wild depends on it: `click._compat._is_binary_writer` decides whether a
+    /// stream is the binary layer by calling `stream.write(b"")` and seeing
+    /// whether it raises, then wraps `sys.stdout` in its own text layer when it
+    /// does not — and everything written after that is lost.  Returning a
+    /// zero-length count is indistinguishable from a successful empty write.
+    ///
+    /// The value can only be named positionally, for the same reason
+    /// `pick_str` above scans: the receiver may or may not be prepended, and
+    /// the text is the last element either way.  A call that passed nothing
+    /// leaves only the receiver there, which is why an empty argument list and
+    /// a bare receiver both fall to the arity message.
+    fn reject_non_str(args: &[PyObjectRef]) -> crate::PyError {
+        match args.last() {
+            Some(&arg) if !arg.is_null() && unsafe { !is_str(arg) } => {
+                crate::PyError::type_error(format!(
+                    "unicode argument expected, got '{}'",
+                    crate::type_methods::arg_type_name(arg)
+                ))
+            }
+            _ => crate::PyError::type_error("write() takes exactly one argument (0 given)"),
+        }
+    }
     // `write` here is an instance builtin that encodes straight to the
     // descriptor instead of going through `TextIOWrapper.write`, so it
     // substitutes the line separator itself — on the text, before encoding,
@@ -3869,7 +3894,7 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
                 }
                 return Ok(w_int_new(unsafe { w_str_len(s_obj) } as i64));
             }
-            Ok(w_int_new(0))
+            Err(reject_non_str(args))
         })
     } else {
         crate::make_builtin_function("write", |args| {
@@ -3897,7 +3922,7 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
                 }
                 return Ok(w_int_new(unsafe { w_str_len(s_obj) } as i64));
             }
-            Ok(w_int_new(0))
+            Err(reject_non_str(args))
         })
     };
     crate::baseobjspace::setdictvalue_native(stream, "write", write_fn);

--- a/pyre/pyre-interpreter/src/module/syslog/syslog.rs
+++ b/pyre/pyre-interpreter/src/module/syslog/syslog.rs
@@ -305,6 +305,23 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             "LOG_LOCAL7",
             pyre_object::w_int_new(libc::LOG_LOCAL7 as i64),
         );
+        // `LOG_ODELAY` and `LOG_AUTHPRIV`/`LOG_FTP` are `<syslog.h>` names
+        // every BSD-derived host carries; the four `LOG_NETINFO`-onwards
+        // facilities are darwin's own. Only the darwin numbering has been
+        // read back from a header, so the whole set is answered there.
+        #[cfg(target_vendor = "apple")]
+        for (name, val) in [
+            ("LOG_ODELAY", libc::LOG_ODELAY as i64),
+            ("LOG_AUTHPRIV", libc::LOG_AUTHPRIV as i64),
+            ("LOG_FTP", libc::LOG_FTP as i64),
+            ("LOG_NETINFO", libc::LOG_NETINFO as i64),
+            ("LOG_REMOTEAUTH", libc::LOG_REMOTEAUTH as i64),
+            ("LOG_INSTALL", libc::LOG_INSTALL as i64),
+            ("LOG_RAS", libc::LOG_RAS as i64),
+            ("LOG_LAUNCHD", libc::LOG_LAUNCHD as i64),
+        ] {
+            crate::module_ns_store(ns, name, pyre_object::w_int_new(val));
+        }
     }
     // `Modules/syslogmodule.c syslog_log_mask / syslog_log_upto` —
     // helpers for building setlogmask() arguments.

--- a/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
+++ b/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
@@ -13,8 +13,12 @@
 /// registered `termios.error` class (falling back to `OSError` before
 /// the module finishes installing) and stamp it onto the `PyError`.
 #[cfg(all(unix, feature = "host_env"))]
-fn termios_converted_error(errno: i32, message: impl Into<String>) -> crate::PyError {
-    let message = message.into();
+fn termios_converted_error(errno: i32) -> crate::PyError {
+    // `wrap_oserror` spells the message with the platform's `strerror` alone;
+    // `PyErr_SetFromErrno` does the same.  Neither names the syscall that
+    // failed, and neither carries Rust's `(os error N)` tail, which would
+    // repeat the code the first argument already holds.
+    let message = crate::PyError::clean_strerror(errno);
     let cls = crate::builtins::lookup_exc_class("termios.error")
         .or_else(|| crate::builtins::lookup_exc_class("OSError"))
         .expect("OSError must be installed");
@@ -64,10 +68,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 }
                 let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
                 let t = host_termios::tcgetattr(fd).map_err(|e| {
-                    termios_converted_error(
-                        e.raw_os_error().unwrap_or(0),
-                        format!("tcgetattr: {e}"),
-                    )
+                    termios_converted_error(e.raw_os_error().unwrap_or(0))
                 })?;
                 let ispeed = host_termios::cfgetispeed(&t);
                 let ospeed = host_termios::cfgetospeed(&t);
@@ -137,26 +138,17 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
 
             // Start from the current settings so we preserve any platform-private fields.
             let mut t = host_termios::tcgetattr(fd).map_err(|e| {
-                termios_converted_error(
-                    e.raw_os_error().unwrap_or(0),
-                    format!("tcsetattr: {e}"),
-                )
+                termios_converted_error(e.raw_os_error().unwrap_or(0))
             })?;
             t.c_iflag = iflag;
             t.c_oflag = oflag;
             t.c_cflag = cflag;
             t.c_lflag = lflag;
             host_termios::cfsetispeed(&mut t, ispeed).map_err(|e| {
-                termios_converted_error(
-                    e.raw_os_error().unwrap_or(0),
-                    format!("cfsetispeed: {e}"),
-                )
+                termios_converted_error(e.raw_os_error().unwrap_or(0))
             })?;
             host_termios::cfsetospeed(&mut t, ospeed).map_err(|e| {
-                termios_converted_error(
-                    e.raw_os_error().unwrap_or(0),
-                    format!("cfsetospeed: {e}"),
-                )
+                termios_converted_error(e.raw_os_error().unwrap_or(0))
             })?;
 
             // interp_termios.py:30-33 — c_cc is any iterable; an int element
@@ -193,10 +185,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 t.c_cc[i] = byte;
             }
             host_termios::tcsetattr(fd, when, &t).map_err(|e| {
-                termios_converted_error(
-                    e.raw_os_error().unwrap_or(0),
-                    format!("tcsetattr: {e}"),
-                )
+                termios_converted_error(e.raw_os_error().unwrap_or(0))
             })?;
             Ok(pyre_object::w_none())
         }),
@@ -217,10 +206,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // `@unwrap_spec(duration=int)`.
                 let dur = crate::baseobjspace::int_w(args[1])? as i32;
                 host_termios::tcsendbreak(fd, dur).map_err(|e| {
-                    termios_converted_error(
-                        e.raw_os_error().unwrap_or(0),
-                        format!("tcsendbreak: {e}"),
-                    )
+                    termios_converted_error(e.raw_os_error().unwrap_or(0))
                 })?;
                 Ok(pyre_object::w_none())
             },
@@ -239,10 +225,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 }
                 let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
                 host_termios::tcdrain(fd).map_err(|e| {
-                    termios_converted_error(
-                        e.raw_os_error().unwrap_or(0),
-                        format!("tcdrain: {e}"),
-                    )
+                    termios_converted_error(e.raw_os_error().unwrap_or(0))
                 })?;
                 Ok(pyre_object::w_none())
             },
@@ -263,10 +246,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // `@unwrap_spec(queue=int)`.
                 let q = crate::baseobjspace::int_w(args[1])? as i32;
                 host_termios::tcflush(fd, q).map_err(|e| {
-                    termios_converted_error(
-                        e.raw_os_error().unwrap_or(0),
-                        format!("tcflush: {e}"),
-                    )
+                    termios_converted_error(e.raw_os_error().unwrap_or(0))
                 })?;
                 Ok(pyre_object::w_none())
             },
@@ -287,10 +267,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // `@unwrap_spec(action=int)`.
                 let action = crate::baseobjspace::int_w(args[1])? as i32;
                 host_termios::tcflow(fd, action).map_err(|e| {
-                    termios_converted_error(
-                        e.raw_os_error().unwrap_or(0),
-                        format!("tcflow: {e}"),
-                    )
+                    termios_converted_error(e.raw_os_error().unwrap_or(0))
                 })?;
                 Ok(pyre_object::w_none())
             },
@@ -314,10 +291,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let ret = unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, &mut ws) };
                 if ret != 0 {
                     let e = std::io::Error::last_os_error();
-                    return Err(termios_converted_error(
-                        e.raw_os_error().unwrap_or(0),
-                        format!("tcgetwinsize: {e}"),
-                    ));
+                    return Err(termios_converted_error(e.raw_os_error().unwrap_or(0)));
                 }
                 // `interp_termios.py:99-101` returns `(ws_row, ws_col)`.
                 Ok(pyre_object::w_tuple_new(vec![
@@ -361,10 +335,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let ret = unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, &mut ws) };
                 if ret != 0 {
                     let e = std::io::Error::last_os_error();
-                    return Err(termios_converted_error(
-                        e.raw_os_error().unwrap_or(0),
-                        format!("tcsetwinsize: {e}"),
-                    ));
+                    return Err(termios_converted_error(e.raw_os_error().unwrap_or(0)));
                 }
                 ws.ws_row = rows as libc::c_ushort;
                 ws.ws_col = cols as libc::c_ushort;
@@ -377,10 +348,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let ret = unsafe { libc::ioctl(fd, libc::TIOCSWINSZ, &mut ws) };
                 if ret != 0 {
                     let e = std::io::Error::last_os_error();
-                    return Err(termios_converted_error(
-                        e.raw_os_error().unwrap_or(0),
-                        format!("tcsetwinsize: {e}"),
-                    ));
+                    return Err(termios_converted_error(e.raw_os_error().unwrap_or(0)));
                 }
                 Ok(pyre_object::w_none())
             },

--- a/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
+++ b/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
@@ -880,6 +880,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         tc!("FIOASYNC", libc::FIOASYNC);
         tc!("FIOCLEX", libc::FIOCLEX);
         tc!("FIONCLEX", libc::FIONCLEX);
+
+        // The `c_cc` value that switches a control character off.  It is
+        // `0xff` on the BSDs and `'\0'` on linux, so it is answered here
+        // rather than beside the `V*` indices above.
+        tc!("_POSIX_VDISABLE", libc::_POSIX_VDISABLE);
     }
 
     // `interp_termios.py Cache.__init__`:

--- a/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
+++ b/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
@@ -750,14 +750,17 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         pyre_object::w_int_new(host_termios::VTIME as i64),
     );
 
-    // `interp_termios.py:18 class W_TermiosError(OperationError)` —
-    // wraps OSError so `except termios.error` catches tcsetattr failures.
-    let w_os_error = crate::builtins::lookup_exc_class("OSError")
-        .expect("OSError must be installed before termios init");
+    // `interp_termios.py Cache.__init__`:
+    //   self.w_error = space.new_exception_class("termios.error")
+    // `new_exception_class` with no bases derives from `Exception`, so
+    // `termios.error` is not an OSError subclass; `convert_error` still names
+    // it as the class to raise, which is what `except termios.error` catches.
+    let w_exception = crate::builtins::lookup_exc_class("Exception")
+        .expect("Exception must be installed before termios init");
     let w_error = crate::builtins::make_exc_type(
         "termios.error",
         crate::builtins::exc_exception_new,
-        w_os_error,
+        w_exception,
     );
     crate::module_ns_store(ns, "error", w_error);
 }

--- a/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
+++ b/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
@@ -750,6 +750,170 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         pyre_object::w_int_new(host_termios::VTIME as i64),
     );
 
+    // `rtermios.CONSTANT_NAMES` names most of these and `rffi_platform`
+    // keeps whichever the platform defines, but `host_env::termios`
+    // re-exports only a subset of them.  `Modules/termios.c` publishes
+    // every one darwin defines, so they are read straight from `libc`
+    // here; the twenty-five `libc` has no constant for are spelled out
+    // with the value `<sys/termios.h>` / `<sys/ttydefaults.h>` /
+    // `<sys/ttycom.h>` gives.
+    #[cfg(target_vendor = "apple")]
+    {
+        macro_rules! tc {
+            ($name:literal, $val:expr) => {
+                crate::module_ns_store(ns, $name, pyre_object::w_int_new($val as i64));
+            };
+        }
+        // `c_iflag` bits.
+        tc!("IMAXBEL", libc::IMAXBEL);
+        tc!("IUTF8", libc::IUTF8);
+
+        // `c_oflag` bits and the delay masks they select with.
+        tc!("OFILL", libc::OFILL);
+        tc!("OFDEL", libc::OFDEL);
+        tc!("ONOEOT", libc::ONOEOT);
+        tc!("OXTABS", libc::OXTABS);
+        tc!("NLDLY", libc::NLDLY);
+        tc!("CRDLY", libc::CRDLY);
+        tc!("TABDLY", libc::TABDLY);
+        tc!("BSDLY", libc::BSDLY);
+        tc!("VTDLY", libc::VTDLY);
+        tc!("FFDLY", libc::FFDLY);
+
+        // Delay values.  `<sys/termios.h>` defines `NL2` / `NL3` without a
+        // matching `libc` constant.
+        tc!("NL0", libc::NL0);
+        tc!("NL1", libc::NL1);
+        tc!("NL2", 0x200);
+        tc!("NL3", 0x300);
+        tc!("CR0", libc::CR0);
+        tc!("CR1", libc::CR1);
+        tc!("CR2", libc::CR2);
+        tc!("CR3", libc::CR3);
+        tc!("TAB0", libc::TAB0);
+        tc!("TAB1", libc::TAB1);
+        tc!("TAB2", libc::TAB2);
+        tc!("TAB3", libc::TAB3);
+        tc!("BS0", libc::BS0);
+        tc!("BS1", libc::BS1);
+        tc!("VT0", libc::VT0);
+        tc!("VT1", libc::VT1);
+        tc!("FF0", libc::FF0);
+        tc!("FF1", libc::FF1);
+
+        // `c_cflag` bits.  The `_OFLOW` / `_IFLOW` spellings name the same bits
+        // as `CRTSCTS` and its two halves.
+        tc!("CRTSCTS", libc::CRTSCTS);
+        tc!("CCTS_OFLOW", 0x10000);
+        tc!("CRTS_IFLOW", 0x20000);
+        tc!("CDTR_IFLOW", 0x40000);
+        tc!("CDSR_OFLOW", 0x80000);
+        tc!("CCAR_OFLOW", 0x100000);
+        tc!("MDMBUF", libc::MDMBUF);
+        tc!("CIGNORE", libc::CIGNORE);
+
+        // `c_lflag` bits.
+        tc!("ECHOCTL", libc::ECHOCTL);
+        tc!("ECHOPRT", libc::ECHOPRT);
+        tc!("ECHOKE", libc::ECHOKE);
+        tc!("FLUSHO", libc::FLUSHO);
+        tc!("PENDIN", libc::PENDIN);
+        tc!("ALTWERASE", libc::ALTWERASE);
+        tc!("EXTPROC", libc::EXTPROC);
+        tc!("NOKERNINFO", libc::NOKERNINFO);
+
+        // `c_cc` length and the indices `rtermios` does not name.
+        tc!("NCCS", libc::NCCS);
+        tc!("VEOL2", libc::VEOL2);
+        tc!("VWERASE", libc::VWERASE);
+        tc!("VREPRINT", libc::VREPRINT);
+        tc!("VDISCARD", libc::VDISCARD);
+        tc!("VLNEXT", libc::VLNEXT);
+        tc!("VSTATUS", libc::VSTATUS);
+        tc!("VDSUSP", libc::VDSUSP);
+
+        // `<sys/ttydefaults.h>` — the default `c_cc` values, each a `CTRL()`
+        // of its letter, so `libc` carries none of them.
+        tc!("CEOF", 4);
+        tc!("CEOL", 255);
+        tc!("CEOT", 4);
+        tc!("CERASE", 127);
+        tc!("CINTR", 3);
+        tc!("CKILL", 21);
+        tc!("CQUIT", 28);
+        tc!("CSUSP", 26);
+        tc!("CDSUSP", 25);
+        tc!("CSTART", 17);
+        tc!("CSTOP", 19);
+        tc!("CWERASE", 23);
+        tc!("CLNEXT", 22);
+        tc!("CRPRNT", 18);
+        tc!("CFLUSH", 15);
+
+        // Baud rates.
+        tc!("B7200", libc::B7200);
+        tc!("B14400", libc::B14400);
+        tc!("B28800", libc::B28800);
+        tc!("B76800", libc::B76800);
+        tc!("EXTA", libc::EXTA);
+        tc!("EXTB", libc::EXTB);
+
+        // `tcsetattr` action flag.
+        tc!("TCSASOFT", 16);
+
+        // Terminal ioctls.  `TIOCGSIZE` / `TIOCSSIZE` are the `<sys/ttycom.h>`
+        // aliases for the winsize pair.
+        tc!("TIOCSTI", libc::TIOCSTI);
+        tc!("TIOCGWINSZ", libc::TIOCGWINSZ);
+        tc!("TIOCSWINSZ", libc::TIOCSWINSZ);
+        tc!("TIOCGSIZE", 0x40087468);
+        tc!("TIOCSSIZE", 0x80087467);
+        tc!("TIOCGPGRP", libc::TIOCGPGRP);
+        tc!("TIOCSPGRP", libc::TIOCSPGRP);
+        tc!("TIOCGETD", libc::TIOCGETD);
+        tc!("TIOCSETD", libc::TIOCSETD);
+        tc!("TIOCNOTTY", libc::TIOCNOTTY);
+        tc!("TIOCSCTTY", libc::TIOCSCTTY);
+        tc!("TIOCEXCL", libc::TIOCEXCL);
+        tc!("TIOCNXCL", libc::TIOCNXCL);
+        tc!("TIOCCONS", libc::TIOCCONS);
+        tc!("TIOCOUTQ", libc::TIOCOUTQ);
+        tc!("TIOCPKT", libc::TIOCPKT);
+
+        // Modem-line bits for `TIOCMGET` / `TIOCMSET`.
+        tc!("TIOCMGET", libc::TIOCMGET);
+        tc!("TIOCMSET", libc::TIOCMSET);
+        tc!("TIOCMBIS", libc::TIOCMBIS);
+        tc!("TIOCMBIC", libc::TIOCMBIC);
+        tc!("TIOCM_LE", libc::TIOCM_LE);
+        tc!("TIOCM_DTR", libc::TIOCM_DTR);
+        tc!("TIOCM_RTS", libc::TIOCM_RTS);
+        tc!("TIOCM_ST", libc::TIOCM_ST);
+        tc!("TIOCM_SR", libc::TIOCM_SR);
+        tc!("TIOCM_CTS", libc::TIOCM_CTS);
+        tc!("TIOCM_CAR", libc::TIOCM_CAR);
+        tc!("TIOCM_CD", libc::TIOCM_CD);
+        tc!("TIOCM_RNG", libc::TIOCM_RNG);
+        tc!("TIOCM_RI", libc::TIOCM_RI);
+        tc!("TIOCM_DSR", libc::TIOCM_DSR);
+
+        // `TIOCPKT` mode bits.
+        tc!("TIOCPKT_DATA", libc::TIOCPKT_DATA);
+        tc!("TIOCPKT_FLUSHREAD", libc::TIOCPKT_FLUSHREAD);
+        tc!("TIOCPKT_FLUSHWRITE", libc::TIOCPKT_FLUSHWRITE);
+        tc!("TIOCPKT_STOP", libc::TIOCPKT_STOP);
+        tc!("TIOCPKT_START", libc::TIOCPKT_START);
+        tc!("TIOCPKT_NOSTOP", libc::TIOCPKT_NOSTOP);
+        tc!("TIOCPKT_DOSTOP", libc::TIOCPKT_DOSTOP);
+
+        // File ioctls `Modules/termios.c` publishes beside the terminal ones.
+        tc!("FIONREAD", libc::FIONREAD);
+        tc!("FIONBIO", libc::FIONBIO);
+        tc!("FIOASYNC", libc::FIOASYNC);
+        tc!("FIOCLEX", libc::FIOCLEX);
+        tc!("FIONCLEX", libc::FIONCLEX);
+    }
+
     // `interp_termios.py Cache.__init__`:
     //   self.w_error = space.new_exception_class("termios.error")
     // `new_exception_class` with no bases derives from `Exception`, so

--- a/pyre/pyre-interpreter/src/module/time/mod.rs
+++ b/pyre/pyre-interpreter/src/module/time/mod.rs
@@ -72,6 +72,18 @@ crate::py_module! {
                 pyre_object::w_int_new(libc::CLOCK_REALTIME as i64));
             crate::module_ns_store(ns, "CLOCK_MONOTONIC",
                 pyre_object::w_int_new(libc::CLOCK_MONOTONIC as i64));
+            // The two darwin clocks that keep counting across sleep, and the
+            // `_APPROX` pair that read a cached value instead of taking the
+            // timebase lock.
+            #[cfg(target_vendor = "apple")]
+            for (name, val) in [
+                ("CLOCK_MONOTONIC_RAW", libc::CLOCK_MONOTONIC_RAW as i64),
+                ("CLOCK_MONOTONIC_RAW_APPROX", libc::CLOCK_MONOTONIC_RAW_APPROX as i64),
+                ("CLOCK_UPTIME_RAW", libc::CLOCK_UPTIME_RAW as i64),
+                ("CLOCK_UPTIME_RAW_APPROX", libc::CLOCK_UPTIME_RAW_APPROX as i64),
+            ] {
+                crate::module_ns_store(ns, name, pyre_object::w_int_new(val));
+            }
             #[cfg(not(any(
                 target_os = "illumos",
                 target_os = "netbsd",

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2866,6 +2866,9 @@ fn format_spec_err(
         E::StringAlignmentFlag => {
             crate::PyError::value_error("'=' alignment not allowed in string format specifier")
         }
+        E::StringSpecNotAllowed(s) => {
+            crate::PyError::value_error(format!("{s} not allowed in string format specifier"))
+        }
         E::NotImplemented(c, s) => crate::PyError::value_error(format!(
             "Format code '{c}' for object of type '{s}' not implemented yet"
         )),

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9290,7 +9290,9 @@ fn init_tuple_type(ns: PyObjectRef) {
                 |args| {
                     let tuple =
                         crate::type_methods::require_tuple_receiver(args, "__hash__", false)?;
-                    Ok(w_int_new(crate::builtins::try_hash_value(tuple)?))
+                    // The structural hash, not `hash()`: this *is* the base
+                    // implementation, so a subclass override must not run here.
+                    Ok(w_int_new(crate::builtins::tuple_structural_hash(tuple)?))
                 },
                 1,
             ),
@@ -27512,9 +27514,10 @@ fn init_frozenset_type(ns: PyObjectRef) {
                 "__hash__",
                 |args| {
                     crate::type_methods::require_frozenset_receiver(args, "__hash__", false)?;
-                    Ok(pyre_object::w_int_new(crate::builtins::try_hash_value(
-                        args[0],
-                    )?))
+                    // As for `tuple.__hash__`: the base implementation itself.
+                    Ok(pyre_object::w_int_new(
+                        crate::builtins::frozenset_structural_hash(args[0]),
+                    ))
                 },
                 1,
                 "($self, /)",

--- a/pyre/pyrex/tests/cpyext_stable_abi.rs
+++ b/pyre/pyrex/tests/cpyext_stable_abi.rs
@@ -1,0 +1,92 @@
+//! The exports an extension needs when it never reads pyre's headers.
+//!
+//! PyO3 and Cython declare the C ABI themselves, so what their objects import
+//! is a set of *symbols* where pyre had only ever published macros. Ten such
+//! names -- spelled here as a macro, or absent altogether -- were therefore
+//! unresolvable at `dlopen`: a wheel pip had just built under pyre failed to
+//! load, and the failure named no symbol.
+//!
+//! Every expectation here was taken from CPython 3.14.6 running the same
+//! script against the same fixture.
+
+#![cfg(all(
+    feature = "cpyext",
+    not(feature = "sandbox"),
+    any(target_os = "macos", target_os = "linux")
+))]
+
+mod cpyext_fixture;
+
+use cpyext_fixture::Fixtures;
+
+const SCRIPT: &str = r#"
+import io, sys, traceback
+import cpyext_stable_abi as m
+
+def eq(name, got, want):
+    assert got == want, '%s: got %r, want %r' % (name, got, want)
+
+# `Py_INCREF` and the stable ABI's `_Py_IncRef` move the count alike.
+value = ['held']
+start, public, stable = m.refcount_through_both(value)
+eq('refcount_public', public, 1)
+eq('refcount_stable', stable, 1)
+
+# `Py_TYPE` called answers the same block the field read does.
+eq('type_through_call', m.type_through_call(value), ('list', True))
+
+# The interpreter that loaded the extension is running and not tearing down.
+eq('runtime_state', m.runtime_state(), (1, 0))
+
+# A critical section is entered and left around a call that runs Python.
+eq('inside_critical_section', m.inside_critical_section(lambda: 'ran'), 'ran')
+
+# `PyErr_PrintEx` reports through `sys.excepthook` and clears the indicator.
+seen = []
+sys.excepthook = lambda kind, value, tb: seen.append((kind.__name__, str(value)))
+try:
+    eq('print_pending_cleared', m.print_pending(ValueError('reported'), 0), True)
+    eq('print_pending_hook', seen, [('ValueError', 'reported')])
+    for name in ('last_exc', 'last_type', 'last_value', 'last_traceback'):
+        assert not hasattr(sys, name), 'sys.%s set without the flag' % name
+    eq('print_pending_flagged', m.print_pending(KeyError('recorded'), 1), True)
+    eq('last_exc', repr(sys.last_exc), "KeyError('recorded')")
+    eq('last_type', sys.last_type, KeyError)
+    eq('last_value', repr(sys.last_value), "KeyError('recorded')")
+finally:
+    sys.excepthook = sys.__excepthook__
+
+# `PyTraceBack_Print` writes the header line, then the entries `print_tb` does.
+try:
+    raise RuntimeError('walked')
+except RuntimeError as error:
+    tb = error.__traceback__
+sink = io.StringIO()
+eq('print_traceback', m.print_traceback(tb, sink), 0)
+written = sink.getvalue()
+assert written.startswith('Traceback (most recent call last):\n'), repr(written)
+expected = io.StringIO()
+traceback.print_tb(tb, None, expected)
+eq('print_traceback_body',
+   written[len('Traceback (most recent call last):\n'):], expected.getvalue())
+
+# Anything that is not a traceback is refused rather than printed.
+eq('print_traceback_refused', m.print_traceback(None, sink), -1)
+
+# The decoder's exception carries the bytes it was decoding, NUL included.
+error = m.decode_error('utf-8', b'a\x00\xff', 2, 3, 'invalid start byte')
+eq('decode_error_type', type(error), UnicodeDecodeError)
+eq('decode_error_encoding', error.encoding, 'utf-8')
+eq('decode_error_object', error.object, b'a\x00\xff')
+eq('decode_error_span', (error.start, error.end), (2, 3))
+eq('decode_error_reason', error.reason, 'invalid start byte')
+
+print('cpyext-stable-abi-ok')
+"#;
+
+#[test]
+fn an_extension_that_declares_its_own_prototypes_finds_every_symbol() {
+    let fixtures = Fixtures::new("cpyext-stable-abi");
+    fixtures.compile("cpyext_stable_abi");
+    fixtures.expect_ok(SCRIPT, &[], "cpyext-stable-abi-ok");
+}

--- a/pyre/pyrex/tests/cpyext_types.rs
+++ b/pyre/pyrex/tests/cpyext_types.rs
@@ -116,7 +116,9 @@ assert (origin.x, origin.y) == (0, 0), (origin.x, origin.y)
 assert (m.Point(1, 2).origin().x, m.Point(1, 2).origin().y) == (0, 0)
 assert m.Point.units(21) == 42
 assert m.Point(1, 2).units(3) == 6
-assert repr(m.Point.__dict__['origin']).startswith("<classmethod 'origin' of ")
+# `PyClassMethodDescr_Type` names `method_repr`, so a classmethod descriptor
+# reports itself the way a method descriptor does.
+assert repr(m.Point.__dict__['origin']).startswith("<method 'origin' of ")
 assert m.Point.__dict__['norm'].__doc__ == 'squared length'
 assert m.Point.__dict__['norm'].__objclass__ is m.Point
 # An unbound descriptor takes the receiver as its first argument.

--- a/pyre/pyrex/tests/cpyext_types.rs
+++ b/pyre/pyrex/tests/cpyext_types.rs
@@ -418,8 +418,9 @@ else:
 # ── a spec declaring storage relative to its base's ────────────────────
 assert issubclass(m.Extra, m.Spec)
 assert m.type_data_size(m.Extra) >= 16, m.type_data_size(m.Extra)
-# Spec declares a whole block, so it extends its base by nothing.
-assert m.type_data_size(m.Spec) == 0, m.type_data_size(m.Spec)
+# Spec declares a whole block: one header plus its own `long`, so the data
+# it adds beyond `object`'s is that field alone.
+assert m.type_data_size(m.Spec) == 8, m.type_data_size(m.Spec)
 
 e = m.Extra(9)
 assert e.code == 9

--- a/pyre/pyrex/tests/cpyext_types.rs
+++ b/pyre/pyrex/tests/cpyext_types.rs
@@ -106,6 +106,17 @@ else:
     raise AssertionError('METH_NOARGS took an argument')
 
 assert type(m.Point.__dict__['norm']).__name__ == 'method_descriptor'
+
+# METH_CLASS binds the class, METH_STATIC binds nothing, and each is a
+# different kind of attribute on the type.
+assert type(m.Point.__dict__['origin']).__name__ == 'classmethod_descriptor'
+assert type(m.Point.__dict__['units']).__name__ == 'staticmethod'
+origin = m.Point.origin()
+assert (origin.x, origin.y) == (0, 0), (origin.x, origin.y)
+assert (m.Point(1, 2).origin().x, m.Point(1, 2).origin().y) == (0, 0)
+assert m.Point.units(21) == 42
+assert m.Point(1, 2).units(3) == 6
+assert repr(m.Point.__dict__['origin']).startswith("<classmethod 'origin' of ")
 assert m.Point.__dict__['norm'].__doc__ == 'squared length'
 assert m.Point.__dict__['norm'].__objclass__ is m.Point
 # An unbound descriptor takes the receiver as its first argument.

--- a/pyre/pyrex/tests/cpyext_types.rs
+++ b/pyre/pyrex/tests/cpyext_types.rs
@@ -418,9 +418,9 @@ else:
 # ── a spec declaring storage relative to its base's ────────────────────
 assert issubclass(m.Extra, m.Spec)
 assert m.type_data_size(m.Extra) >= 16, m.type_data_size(m.Extra)
-# Spec declares a whole block: one header plus its own `long`, so the data
-# it adds beyond `object`'s is that field alone.
-assert m.type_data_size(m.Spec) == 8, m.type_data_size(m.Spec)
+# Spec declares a whole block, and its own `long` falls inside the padding
+# the header is already aligned up to, so it extends its base by nothing.
+assert m.type_data_size(m.Spec) == 0, m.type_data_size(m.Spec)
 
 e = m.Extra(9)
 assert e.code == 9

--- a/pyre/pyrex/tests/fixtures/cpyext_stable_abi.c
+++ b/pyre/pyrex/tests/fixtures/cpyext_stable_abi.c
@@ -1,0 +1,124 @@
+/* The entry points an extension reaches when it declares the prototypes
+   itself instead of expanding this header's macros.
+
+   PyO3 and Cython both generate their own declarations of CPython's ABI and
+   never read these headers, so a name pyre only ever spells as a macro is a
+   name their objects import and `dlopen` cannot resolve.  Everything here is
+   called as a function for that reason, `Py_TYPE` with the macro undefined so
+   that the call is the export rather than the field read. */
+
+#include <Python.h>
+
+#undef Py_TYPE
+
+/* Whether the reference count moves the same way through both spellings of
+   the pair -- the macro's, and the stable ABI's own entry points. */
+static PyObject *refcount_through_both(PyObject *self, PyObject *value)
+{
+    (void)self;
+    Py_ssize_t start = Py_REFCNT(value);
+    Py_IncRef(value);
+    Py_ssize_t after_public = Py_REFCNT(value);
+    Py_DecRef(value);
+    _Py_IncRef(value);
+    Py_ssize_t after_stable = Py_REFCNT(value);
+    _Py_DecRef(value);
+    return Py_BuildValue("(nnn)", start, after_public - start,
+                         after_stable - start);
+}
+
+/* `Py_TYPE` as a call answers the same block the macro reads. */
+static PyObject *type_through_call(PyObject *self, PyObject *value)
+{
+    (void)self;
+    PyTypeObject *called = Py_TYPE(value);
+    PyTypeObject *field = ((PyObject *)value)->ob_type;
+    return Py_BuildValue("(sO)", called->tp_name,
+                         called == field ? Py_True : Py_False);
+}
+
+/* The two questions an extension asks about the interpreter that loaded it. */
+static PyObject *runtime_state(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    (void)self;
+    return Py_BuildValue("(ii)", Py_IsInitialized(), Py_IsFinalizing());
+}
+
+/* A critical section around a call, entered and left by name. */
+static PyObject *inside_critical_section(PyObject *self, PyObject *callable)
+{
+    (void)self;
+    PyCriticalSection section;
+    PyCriticalSection_Begin(&section, callable);
+    PyObject *answer = PyObject_CallNoArgs(callable);
+    PyCriticalSection_End(&section);
+    return answer;
+}
+
+/* `PyErr_PrintEx` reports through `sys.excepthook` and clears the indicator;
+   with the flag set it records the exception on `sys` first. */
+static PyObject *print_pending(PyObject *self, PyObject *args)
+{
+    (void)self;
+    PyObject *value;
+    int set_sys_last_vars;
+    if (!PyArg_ParseTuple(args, "Oi", &value, &set_sys_last_vars)) {
+        return NULL;
+    }
+    PyErr_SetObject((PyObject *)Py_TYPE(value), value);
+    PyErr_PrintEx(set_sys_last_vars);
+    return Py_BuildValue("O", PyErr_Occurred() == NULL ? Py_True : Py_False);
+}
+
+/* `PyTraceBack_Print` writes the header line and then the entries. */
+static PyObject *print_traceback(PyObject *self, PyObject *args)
+{
+    (void)self;
+    PyObject *traceback;
+    PyObject *file;
+    if (!PyArg_ParseTuple(args, "OO", &traceback, &file)) {
+        return NULL;
+    }
+    int printed = PyTraceBack_Print(traceback, file);
+    /* The refusal path leaves an indicator, and this returns a value rather
+       than NULL, so it is taken here instead of following the answer out. */
+    PyErr_Clear();
+    return Py_BuildValue("i", printed);
+}
+
+/* The exception a decoder raises, built from the bytes it was decoding --
+   embedded NULs included, which is why the length is passed separately. */
+static PyObject *decode_error(PyObject *self, PyObject *args)
+{
+    (void)self;
+    const char *encoding;
+    const char *object;
+    Py_ssize_t length;
+    Py_ssize_t start;
+    Py_ssize_t end;
+    const char *reason;
+    if (!PyArg_ParseTuple(args, "sy#nns", &encoding, &object, &length, &start,
+                          &end, &reason)) {
+        return NULL;
+    }
+    return PyUnicodeDecodeError_Create(encoding, object, length, start, end,
+                                       reason);
+}
+
+static PyMethodDef methods[] = {
+    {"refcount_through_both", refcount_through_both, METH_O, NULL},
+    {"type_through_call", type_through_call, METH_O, NULL},
+    {"runtime_state", runtime_state, METH_NOARGS, NULL},
+    {"inside_critical_section", inside_critical_section, METH_O, NULL},
+    {"print_pending", print_pending, METH_VARARGS, NULL},
+    {"print_traceback", print_traceback, METH_VARARGS, NULL},
+    {"decode_error", decode_error, METH_VARARGS, NULL},
+    {NULL, NULL, 0, NULL}};
+
+static struct PyModuleDef def = {PyModuleDef_HEAD_INIT, "cpyext_stable_abi",
+                                 NULL, -1, methods};
+
+PyMODINIT_FUNC PyInit_cpyext_stable_abi(void)
+{
+    return PyModule_Create(&def);
+}

--- a/pyre/pyrex/tests/fixtures/cpyext_types.c
+++ b/pyre/pyrex/tests/fixtures/cpyext_types.c
@@ -169,9 +169,27 @@ static PyObject *point_receiver(PyObject *self, PyObject *unused)
                          PyType_Check(self) ? ((PyTypeObject *)self)->tp_name : "-");
 }
 
+/* METH_CLASS: the receiver is the class the attribute was read through. */
+static PyObject *point_origin(PyObject *cls, PyObject *unused)
+{
+    return PyObject_CallFunction(cls, "ll", 0L, 0L);
+}
+
+/* METH_STATIC: the receiver slot carries no argument of the call. */
+static PyObject *point_units(PyObject *self, PyObject *args)
+{
+    long count = 0;
+    if (!PyArg_ParseTuple(args, "l", &count)) {
+        return NULL;
+    }
+    return PyLong_FromLong(count * 2);
+}
+
 static PyMethodDef point_methods[] = {
     {"receiver", point_receiver, METH_NOARGS, "what this row was reached through"},
     {"translate", (PyCFunction)point_translate, METH_VARARGS, "shift in place"},
+    {"origin", (PyCFunction)point_origin, METH_NOARGS | METH_CLASS, "the zero point"},
+    {"units", (PyCFunction)point_units, METH_VARARGS | METH_STATIC, "twice a count"},
     {"norm", (PyCFunction)point_norm, METH_NOARGS, "squared length"},
     {"named", (PyCFunction)(void (*)(void))point_named, METH_VARARGS | METH_KEYWORDS,
      "prefixed name"},

--- a/pyre/scripts/cpyext-abi.py
+++ b/pyre/scripts/cpyext-abi.py
@@ -162,6 +162,7 @@ STRUCTS = {
     "CPyCriticalSection": "PyCriticalSection",
     "CPyUnicodeWriter": "PyUnicodeWriter",
     "CPyDateTimeCAPI": "PyDateTime_CAPI",
+    "CPySlot": "PySlot",
 }
 
 

--- a/pyre/scripts/cpyext-abi.py
+++ b/pyre/scripts/cpyext-abi.py
@@ -159,6 +159,7 @@ STRUCTS = {
     "CPyFrameObject": "PyFrameObject",
     "CPyInterpreterState": "PyInterpreterState",
     "CPyMutex": "PyMutex",
+    "CPyCriticalSection": "PyCriticalSection",
     "CPyUnicodeWriter": "PyUnicodeWriter",
     "CPyDateTimeCAPI": "PyDateTime_CAPI",
 }


### PR DESCRIPTION
Thirty-eight commits. The pip work this branch started with has landed; what is
left is the layer under it — loading real C extensions, and the stdlib gaps two
third-party test suites found when they were run against pyre as-is.

The two suites are the measure here, because a hand-written driver only probes
what its author already suspects:

| suite | before | after |
|---|---|---|
| cffi 2.1.1, its own pytest suite (21 files, ~1190 cases) | `test_new_ffi_1` all-error, `test_recompiler` SIGABRT + 14 failed, `test_function` 13 failed | **2 failed**, both `test_char16_t`, neither a cffi defect |
| trio, its own suite (34 files) | 6 files with pyre-owned failures | **0 pyre-owned failures** |

Every behaviour row below was measured against a CPython 3.14.6 control on the
same host with a scripted probe run under both interpreters and the two outputs
diffed; each is byte-identical after the change unless the row says otherwise.

# cpyext — loading an extension the way the header describes it

- **PEP 793 export slots.** A module whose init returns a `PyModuleDef_Slot`
  array was not built at all; `Py_mod_exec` / `Py_mod_create` are now walked.
- **Entry points.** An extension declares its own `PyInit_*` / `_cffi_pypyinit_*`
  names; pyre now exports what the extension declares instead of guessing one
  spelling. api-mode cffi modules export `_cffi_pypyinit_` because pyre defines
  `PYPY_VERSION` — that is the reason the whole `test_new_ffi_1` file errored.
- **Module definitions read at the wrong offsets are now refused** instead of
  producing a module built from garbage.
- **The names an extension imports when it never reads pyre's headers.**
  PyO3 and Cython declare the C ABI themselves, so their objects import
  `Py_TYPE`, `Py_IS_TYPE`, `_Py_IncRef` / `_Py_DecRef`, the `PyList_GET_*`
  accessors and the rest as *symbols* where pyre had published only macros.
  A wheel pip had just built failed to `dlopen`, naming no symbol.
- **`METH_CLASS` rows get the class, `METH_STATIC` rows get no receiver.**
- A failed `dlopen` reports **what** it failed with, not that it failed.

# compiler / `_ast`

- rustpython pin moved to `48a3a1f`; its columns are read as characters.
- A tree compiled from `ast` objects carries a source, so positions index into
  something.

# Exception construction

`make_exc_type` always installs the `__new__` it is passed, so a module-defined
`OSError` subclass built through the base `Exception.__new__` never parses
`(errno, strerror)`. `_socket`, `_ssl` and `_io` now build theirs through the
family constructor, and `termios.error` derives from `Exception` as
`Modules/termios.c` has it.

# `_socket`

| | before | after | CPython 3.14.6 |
|---|---|---|---|
| any op on a closed socket | `OSError('Bad file descriptor')`, `errno=None` | `OSError(9, 'Bad file descriptor')` | same |
| `("localhost", 80)` on `AF_INET6` | `OSError('invalid IPv6 address: localhost')` | resolves | resolves |
| a bogus name, either family | `OSError('name or service not known: …')`, `errno=None` | `gaierror(8, 'nodename nor servname provided, …')` | same |
| `EAI_*` module constants | absent | the set `netdb.h` names | same |
| `gethostbyname("")` / `("<broadcast>")` | `gaierror` | `0.0.0.0` / `255.255.255.255` | same |
| `connect(("<broadcast>", 9))` | `gaierror` | connects | connects |
| `gethostbyaddr` of an unresolvable name | `herror`, no errno | `gaierror(8, …)` | same |
| `gethostbyaddr` of an IP with no PTR | `herror`, no errno | `herror(1, 'Unknown host')` | same |
| `htons(70000)` | `28689` | `OverflowError` | `OverflowError` |
| `ntohs(-1)` | `65535` | `ValueError` | `ValueError` |
| `getservbyport(70000)` | looked up port 4464 | `OverflowError` | `OverflowError` |
| `inet_pton(1234, …)` | message-only `OSError` | `OSError(47, …)` | same |
| `bind(("127.0.0.1", 70000))` | `port must be 0-65535` | `bind(): port must be 0-65535.` | same |
| `getnameinfo(("127.0.0.1",), 0)` | `ValueError` | `TypeError` | same |

`errno=None` is invisible to every caller that classifies by `e.errno` — trio
does `if exc.errno in _closed_stream_errnos` in two places, and three
`test_highlevel_socket.py` tests failed on the wrong exception type because of
it.

Also: `recvmsg_into` with two buffers panicked. A `Vec` of scope-owning root
guards drops front-to-back, so element 0's truncate killed element 1's roots;
the vector now holds one scope.

# `signal`, `select`, `termios`, `fcntl`

These four are one chain — `test_ki_in_repl` alone exposed all of it, each fix
uncovering the next.

- **`signal`** hands the app-level handler the frame it is called for. It was
  passing `None`.
- **`select`** publishes the 18 `KQ_NOTE_*` / internal `EV_` names it omitted,
  and `kevent()` binds its six keywords. The surface is now byte-identical to
  the control's 33 names.
- **`termios`** published **77 of the 196** integer names darwin defines. Now
  196/196, 0 extra, 0 mismatched — 94 read from `libc`, 25 spelled out with the
  value `<sys/termios.h>` / `<sys/ttydefaults.h>` / `<sys/ttycom.h>` gives.
  Graded by a three-way diff: names against CPython, values against a compiled
  `#ifdef` probe over the headers.
- **`termios`** built every message with `format!("<syscall>: {e}")` over a
  `std::io::Error`, so a failure read `(19, 'tcgetattr: Operation not supported
  by device (os error 19)')`. `wrap_oserror` and `PyErr_SetFromErrno` both spell
  it with `strerror` alone.
- **`select.kevent`** had no `__repr__` at all, so the six fields a caller set
  were invisible in any log line that printed one.
- **`fcntl`** took only an integer third argument — `fcntl.ioctl(fd, req, buf)`
  raised `TypeError: ioctl() arguments must be integers`. Both functions now
  take the buffer argument they are documented to take, including the
  `mutate_flag` dispatch and the 8-byte guard canary `fcntlmodule.c` writes
  after the staged argument, so a 1-byte overrun raises
  `SystemError("buffer overflow")` rather than corrupting the stack. Five
  probes, ~40 cases, all identical to the control.

# Module exceptions

`repr` read the whole registered name, so seventeen classes spelled their
module twice — `termios.error(19, 'boom')` where `_PyType_Name` gives
`error(19, 'boom')`. It now reads the accessor the `__name__` getter reads, so
the two channels cannot disagree. Three were also registered under the wrong
name: `_ssl`'s seven are `ssl.SSLError` and friends, `_locale.Error` is
`locale.Error`, and pyexpat's is `xml.parsers.expat.ExpatError`.

`__name__`, `__qualname__`, `__module__`, `str(cls)` and `repr(instance)` are
identical to the control for all nineteen classes probed.

# Assorted

- A std stream write that got a non-`str` raises `TypeError` instead of
  silently dropping the bytes.
- `tuple` / `frozenset` unbound `__hash__` runs the base implementation from the
  unbound descriptor, not the subclass override.

# Constant surfaces

A three-way diff of the integer surface of 17 modules — names against CPython
3.14.6, values against the SDK headers — found **110 names absent and one wrong
value**. Added to `_socket` (55), `mmap` (14), `fcntl` (12), `posix` (10),
`syslog` (8), `time` (4) and `termios` (1); `socket.IP_MAX_MEMBERSHIPS` carried
linux's 20 where `<netinet/in.h>` says 4095 on darwin. `mmap.PROT_NONE` is
published by neither `mmapmodule.c` nor pypy's `mmap`, so it is dropped rather
than added.

`_locale` published `CODESET` alone, so 54 of the 55 keys
`_localemodule.c langinfo_constants` names could not be spelled even though
`nl_langinfo` accepted them. Those come from `libc`, which carries each
platform's own numbering.

**`signal.NSIG` was 64 on every unix.** `<signal.h>` says 32 on darwin and
glibc's `_NSIG` is 65, so it is now read per platform, keeping 64 where the
header is silent as `signals.c` does. 65 exceeds a word, so `pypysig_flags_bits`
is ported as the `N_LONGSIG`-element array it is upstream. `valid_signals`
passed a literal 64 to its `sigismember` sweep and reported a signal with no
name. `SIGEMT`, `SIGINFO` and `SIGIOT` are added.

**`_sre.MAXGROUPS` published `2**31 - 1` where 3.14 answers `2**30 - 1`.**
`sre.h` halves `INT32_MAX`; the vendored engine crate halved its own unsigned
`MAXREPEAT` and landed one bit wide. `re/_parser.py` bounds a pattern's group
count and two group references on the number.

**`ast.PyCF_TYPE_COMMENTS` was `0x40000000`** — the number `consts.py` uses
because it keeps `PyCF_ASYNC_HACKS` on `0x1000`. `Include/cpython/compile.h`
numbers it `0x1000`, and 3.14 has no `PyCF_ASYNC_HACKS`. **`_symtable.DEF_BOUND`**
carried `DEF_TYPE_PARAM` beside the three bits `pycore_symtable.h` names.

# `_ast` — type comments are collected, and refused where the grammar has no rule

`ast.parse(src, type_comments=True)` was accepted and returned a tree with every
`type_comment` `None` and `type_ignores` `[]`. No parser change was needed: the
parse result already carries its token list and `convert.rs` was discarding it
with `.into_syntax()`, while all five node types already had an unfilled
`runtime_type_comment` field.

`lexer.c`'s three rules are ported — the `"# type: "` prefix where each space
matches a run of spaces **and tabs**, the TYPE_IGNORE split on `ignore` followed
by end-of-comment or an ASCII non-alphanumeric byte, and the newline an ignore
alone on its line takes into its tag — and attachment walks the five spans the
grammar accepts a `TYPE_COMMENT` in.

Collecting is only half the flag. A `TYPE_COMMENT` is a **token**, so a rule
that does not accept one leaves the parser looking at a token it cannot shift:
`x += 1  # type: int`, `x: int = 1  # type: int` and `f()  # type: int` are all
`SyntaxError` in CPython, and pyre parsed all three. What attachment leaves over
is now that refusal — `invalid syntax`, spanning the type text rather than the
`#`, at the first such comment in source order, with the offset counting
characters as `_PyPegen_byte_offset_to_character_offset` does.

Writing the refusal exposed a **live attachment defect**: an assignment took its
comment from anywhere on the value's line, but the rule reads it as the very
next token. With a `;` between them the comment belongs to the assignment it
follows.

| source | CPython | pyre, before |
|---|---|---|
| `y = 1; z = 2  # type: int` | `Assign` at col 7 | `Assign` at col **0** |
| `y = 1; z = 2; w = 3  # type: int` | `Assign` at col 14 | `Assign` at col **0** |
| `y = 1; z += 1  # type: int` | `SyntaxError` | silently attached to col 0 |

Each comment now records where the code before it ends, and an assignment takes
one only when nothing but spaces and tabs stands between. Without the refusal
that misattachment had no symptom — it just built a wrong tree.

Graded by a **76-case differential corpus against CPython 3.14.6: 0
mismatches.** It found four defects a hand-check missed — the two above, plus
`fn parameter` hard-coding `("type_comment", self.none())` so every `arg` case
failed regardless of collection, and the EOF-ignore newline being guarded on a
trailing `\n` already existing.

# cpyext — a heap corruption glibc saw and darwin did not

`PyBytes_FromStringAndSize(NULL, n)` allocated a header-sized block, and
`realize_pending` links that same block to the `bytes` it builds -- so the block
C is still filling becomes that object's mirror. Every later `make_ref` of it
then reached `stamp_ob_size`, which writes `ob_size` **at offset 24 of a 24-byte
allocation**. Under glibc those eight bytes overlap the next chunk's size field,
so the neighbour's `free()` reported `free(): invalid pointer` and
`cpyext_locks` died there with no other output. The darwin allocator leaves that
slack unused, which is why `cargo test` was green on macOS and windows.

The block is now allocated at `CPyVarObject` width, and its `ob_size` is set as
it is allocated -- `pyobject.py:108` does the same with
`pyvarobj.c_ob_size = itemcount`, so `Py_SIZE` answers the requested length for
the whole window in which C owns the buffer.

# Gates

Re-run in full on the rebased tree (base `bf260229c01`):

- `pyre/cpython_tests/run.py --backend dynasm` — **223 PASS / 0 FAIL / 0 CRASH /
  0 TIMEOUT**, no regressions. Graded against the binary CI builds for it,
  `--no-default-features --features dynasm`: adding `cpyext` fills
  `EXTENSION_SUFFIXES`, which un-skips `test_importlib.extension.*` and then
  fails it on a `_testsinglephase` no pyre tree carries.
- `cargo test --all --no-default-features --features dynasm,cpyext` — **181
  result lines, all ok, 8387 passed, 0 failed.**
- `pyre/extra_tests/parity_tests/run.py` — **all parity tests pass.**

The branch adds twelve fixtures: `ast_type_comments`,
`compile_flag_and_symtable_constants`, `darwin_module_constant_surface`,
`exception_repr_names_the_bare_class`, `locale_langinfo_item_constants`,
`select_kevent_repr`, `signal_range_is_the_platform_nsig`,
`socket_address_argument_conversions`, `sre_constant_surface`,
`std_stream_write_rejects_non_str`,
`termios_error_carries_errno_and_strerror`, `unbound_hash_is_base_implementation`.
Each is `cpython=OK dynasm=OK`, with the pypy divergence declared where the
fixture pins one. The langinfo and signal fixtures are scoped to darwin and
linux: windows has no `<langinfo.h>` and neither `SIGUSR1` nor the POSIX
delivery model.

# Known and not fixed here

`pyexpat`'s parser reports an error one column further right than expat does
(`<a><` is column 4, expat says 3). `bump_char` advances the column **after**
consuming, so every diagnostic names the position past the offending character
rather than at it; closing it means capturing the failing token's start at each
of the module's 42 error sites and grading them against real expat, which is a
change of its own rather than an adjustment.

**A parser diagnostic that is not a type comment still carries no location.**
`ast.parse("x = = 1")` raises `SyntaxError` whose `lineno`, `offset` and `text`
are all `None`, and whose message is the underlying parser's
(`Expected an expression at byte range 4..5`) rather than `invalid syntax`. The
type-comment refusal above locates itself because this layer computes that
position; the general path hands the parser's error straight through.

The constant-surface gaps an earlier
draft listed here are closed above; what is left is not addressable by adding a
number — honest capability booleans (`ssl.HAS_*`), build and environment
identity, opaque handles rendered as ints, and modules that are genuinely
absent or partial (`_datetime`, `curses`, `readline`, `sqlite3`).

**A `gc:` commit was withdrawn from this branch.** It made a closed `_io` stream
withdraw its finalizer registration, whose whole diff was setting an existing
`GCFLAG_IGNORE_FINALIZER` bit — but that flag's three readers in `collector.rs`
had never executed, because nothing had ever set it. Setting it armed them, and
`test.test_datetime` went from 6/6 ok to 5/6 SIGSEGV; a fresh `origin/main`
worktree and an ablation of the single call both confirmed it. #1464 has since
landed the collector work properly. Post-rebase, `test_datetime` is 4/4 ok plus
a fifth clean run inside the suite.

`raise_signal` from a non-main thread was listed here in an earlier draft; it
was re-measured and pyre already matches — the handler runs on the main thread,
and does not run before `raise_signal` returns in the worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded CPython extension compatibility, including stable ABI support, type slots, reference counting, exceptions, and runtime-state APIs.
  * Added broader macOS platform constants across networking, signals, terminal control, time, logging, and system modules.
  * Improved socket, `fcntl`, `ioctl`, and buffer support for bytes-like and memory-mapped data.
  * AST conversions now preserve source locations, including multibyte text ranges.

* **Bug Fixes**
  * Corrected exception representations, error details, hashing behavior, stream finalization, signal handling, and standard-stream type validation.

* **Tests**
  * Added extensive cross-platform parity and CPython ABI coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


