### PR TITLE
jit: root and forward the jitcode constant pool, and exclude RESUME from tracer line events

### DIFF
--- a/lib-python/3/test/test_generators.py
+++ b/lib-python/3/test/test_generators.py
@@ -317,17 +317,20 @@ class GeneratorTest(unittest.TestCase):
         # Test a freshly created generator (not suspended)
         g = generator(DetectDelete())
         g.close()
+        support.gc_collect()  # For PyPy or other GCs.
         self.assertTrue(DetectDelete.deleted)
 
         # Test a suspended generator
         g = generator(DetectDelete())
         next(g)
         g.close()
+        support.gc_collect()  # For PyPy or other GCs.
         self.assertTrue(DetectDelete.deleted)
 
         # Clear via gi_frame.clear()
         g = generator(DetectDelete())
         g.gi_frame.clear()
+        support.gc_collect()  # For PyPy or other GCs.
         self.assertTrue(DetectDelete.deleted)
 
 class ModifyUnderlyingIterableTest(unittest.TestCase):

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -4459,7 +4459,7 @@ impl MiniMarkGC {
         }
 
         let mut visit_extra_area = |gcref: &mut GcRef| {
-            result.push((*gcref, "extra_area"));
+            result.push((*gcref, crate::shadow_stack::current_extra_area()));
         };
         if walk_all_mutators {
             crate::shadow_stack::walk_all_extra_areas(&mut visit_extra_area);

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -284,6 +284,32 @@ pub type MutatorExtraWalkFn = unsafe fn(*const (), &mut dyn FnMut(&mut GcRef));
 struct MutatorExtraArea {
     walk: MutatorExtraWalkFn,
     data: *const (),
+    /// Label the collector stamps on the refs this area yields.  Without it a
+    /// root that fails validation reports the bare `extra_area`, which names
+    /// the mechanism and not the registrar — and there are fifteen of them.
+    name: &'static str,
+}
+
+std::thread_local! {
+    /// The area [`walk_all_extra_areas`] / [`walk_my_extra_areas`] is currently
+    /// inside, on the collecting thread.  `extra_area` outside a walk.
+    static CURRENT_EXTRA_AREA: std::cell::Cell<&'static str> =
+        const { std::cell::Cell::new("extra_area") };
+}
+
+/// The registered area whose walk is running on this thread, for a collector
+/// diagnostic that wants to name where a ref came from.
+pub fn current_extra_area() -> &'static str {
+    CURRENT_EXTRA_AREA.with(|cell| cell.get())
+}
+
+/// Run one area's walk with [`current_extra_area`] naming it.
+fn walk_one_extra_area(area: &MutatorExtraArea, visitor: &mut dyn FnMut(&mut GcRef)) {
+    let previous = CURRENT_EXTRA_AREA.with(|cell| cell.replace(area.name));
+    // SAFETY: the callers below establish the quiescence / ownership
+    // precondition; this helper only brackets the call.
+    unsafe { (area.walk)(area.data, visitor) };
+    CURRENT_EXTRA_AREA.with(|cell| cell.set(previous));
 }
 
 /// Pruner for one owner-keyed side table owned by a registered mutator.
@@ -340,14 +366,18 @@ pub fn register_mutator() {
 /// thread. `walk` must derive every address it dereferences from `data`, never
 /// from caller TLS, because a foreign collecting thread invokes `walk` during
 /// STW.
-pub unsafe fn register_mutator_extra_area(walk: MutatorExtraWalkFn, data: *const ()) {
+pub unsafe fn register_mutator_extra_area(
+    walk: MutatorExtraWalkFn,
+    data: *const (),
+    name: &'static str,
+) {
     let thread_id = std::thread::current().id();
     let mut registry = MUTATOR_REGISTRY.lock().unwrap();
     let entry = registry
         .iter_mut()
         .find(|entry| entry.thread_id == thread_id)
         .expect("register_mutator_extra_area called before register_mutator");
-    entry.extra_areas.push(MutatorExtraArea { walk, data });
+    entry.extra_areas.push(MutatorExtraArea { walk, data, name });
 }
 
 /// Append an owner-keyed-table pruner to the current registered mutator.
@@ -427,7 +457,7 @@ pub fn walk_all_extra_areas(mut visitor: impl FnMut(&mut GcRef)) {
         for area in mutator.extra_areas.iter() {
             // SAFETY: gc_sync has quiesced every registered owner, and each
             // area remains valid until its MutatorEntry is removed.
-            unsafe { (area.walk)(area.data, &mut visitor) };
+            walk_one_extra_area(area, &mut visitor);
         }
     }
 }
@@ -444,7 +474,7 @@ pub fn walk_my_extra_areas(mut visitor: impl FnMut(&mut GcRef)) {
     };
     for area in mutator.extra_areas.iter() {
         // SAFETY: this is the owning thread's synchronous collection path.
-        unsafe { (area.walk)(area.data, &mut visitor) };
+        walk_one_extra_area(area, &mut visitor);
     }
 }
 
@@ -1642,7 +1672,7 @@ mod tests {
         // SAFETY: `root` remains valid until unregistration, and `walk_cell`
         // derives its sole dereference from the supplied `data` pointer.
         unsafe {
-            register_mutator_extra_area(walk_cell, &mut root as *mut GcRef as *const ());
+            register_mutator_extra_area(walk_cell, &mut root as *mut GcRef as *const (), "test_cell");
         }
         walk_my_extra_areas(|gcref| gcref.0 += 0x100);
         unregister_mutator();

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -377,7 +377,9 @@ pub unsafe fn register_mutator_extra_area(
         .iter_mut()
         .find(|entry| entry.thread_id == thread_id)
         .expect("register_mutator_extra_area called before register_mutator");
-    entry.extra_areas.push(MutatorExtraArea { walk, data, name });
+    entry
+        .extra_areas
+        .push(MutatorExtraArea { walk, data, name });
 }
 
 /// Append an owner-keyed-table pruner to the current registered mutator.
@@ -1672,7 +1674,11 @@ mod tests {
         // SAFETY: `root` remains valid until unregistration, and `walk_cell`
         // derives its sole dereference from the supplied `data` pointer.
         unsafe {
-            register_mutator_extra_area(walk_cell, &mut root as *mut GcRef as *const (), "test_cell");
+            register_mutator_extra_area(
+                walk_cell,
+                &mut root as *mut GcRef as *const (),
+                "test_cell",
+            );
         }
         walk_my_extra_areas(|gcref| gcref.0 += 0x100);
         unregister_mutator();

--- a/majit/majit-ir/src/value.rs
+++ b/majit/majit-ir/src/value.rs
@@ -1231,10 +1231,27 @@ pub fn pypyjit_greenkey_uhash(pc: usize, is_being_profiled: bool, code_ptr: u64)
 /// slot order and the `Ref` tag on the pycode from drifting apart — a
 /// swapped slot still hashes to something, just not to the same cell.
 ///
-/// `is_being_profiled` is a real green in the spec even though pyre's
-/// JIT path always passes `false`; it is a parameter and not a folded
-/// constant so a future profiled portal does not silently share cells
-/// with the unprofiled one.
+/// `is_being_profiled` is a real green, and pyre's callers pass a live value:
+/// both green-key construction sites read
+/// `executioncontext::current_is_being_profiled()`, so a profiled portal does
+/// not share cells with the unprofiled one.
+///
+/// What that separation buys a `setprofile` armed on an ALREADY-COMPILED loop
+/// is a re-warmup, and only that: the green flips, the cell the back edge
+/// looks up holds no compiled loop, and execution is interpreted and reporting
+/// until the new cell reaches `threshold` and compiles a loop of its own.
+/// Measured, a profiler armed mid-loop over a 100 000-iteration tail reports
+/// 1041 `call` events for a callee the walker INLINES and all 99 999 for one
+/// it leaves residual — the same reading with and without the `debugdata`
+/// guard, so the ceiling is the inlined callee's unrecorded `call_trace` /
+/// `return_trace` (see `walker_ec_enter`, `jitcode_dispatch/inline_call.rs`)
+/// and not the green.  It is also not what protects a profiler installed
+/// BEFORE the frame is entered — measured, such a frame never reaches a trace
+/// at all (`loops_compiled = 0`, `loops_aborted = 0`), because
+/// `eval_with_jit_inner` routes it to `execute_frame_plain`.  Tracing has no
+/// green of its own and so gets neither: the mid-loop case is answered instead
+/// by the `debugdata` guard `pyopcode.py dispatch_bytecode`'s
+/// `jit.we_are_jitted()` arm records.
 pub fn pypyjit_greenkey(pc: usize, is_being_profiled: bool, code_ptr: u64) -> GreenKey {
     GreenKey::with_types(
         vec![pc as i64, is_being_profiled as i64, code_ptr as i64],

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -279,7 +279,7 @@ pub struct BlackholeInterpreter {
     /// The vable bytecodes do NOT read this. `handler_getfield_vable_*` and
     /// `handler_setfield_vable_*` take the struct as their own `r` operand at
     /// their own pc, the shape `bhimpl_getfield_vable_r` has; correspondingly
-    /// `BlackholeInterpreter` carries no virtualizable field at all. This one
+    /// the vable handlers never consult this field. This pointer
     /// serves only readers that have no operand to read — `record_frame_traceback`
     /// and the `on_enter_level` / `on_leave_level` rooting callbacks — so a
     /// wrong value here corrupts a traceback or a root, never a vable access.

--- a/majit/majit-translate/tests/test_unroll_safe_inventory.rs
+++ b/majit/majit-translate/tests/test_unroll_safe_inventory.rs
@@ -71,9 +71,13 @@ const REVIEWED_UNROLL_SAFE: &[(&str, &str)] = &[
     // Its slot loop scans the same fixed-size locals-plus array `fast2locals`
     // does and takes the hint for the same reason — without it the function is
     // one residual call, and the `f_locals` read behind it forces the
-    // virtualizable for that call's whole length.  Same evidence as the two
-    // above: the body is unreachable from the portal BFS, so the abort
-    // population and every baseline are unchanged.
+    // virtualizable for that call's whole length.
+    //
+    // NOT the same evidence as the two above, and this line used to claim it
+    // was: the body is REACHED.  `frame_locals_proxy_snapshot` holds a jitcode
+    // in the metadata artefact, where `gettopframe_nohidden` and
+    // `getnextframe_nohidden` do not.  The abort population and the baselines
+    // were measured unchanged; unreachability is not why.
     (
         "frame_locals_proxy_snapshot",
         "fast2locals' scan of the same locals-plus array",

--- a/majit/majit-translate/tests/test_vable_array_len.rs
+++ b/majit/majit-translate/tests/test_vable_array_len.rs
@@ -325,9 +325,9 @@ fn report_vable_array_shape_of_frame_locals_proxy_snapshot() {
     let mut graphs: Vec<FunctionGraph> = Vec::new();
     for fd in llbc.iter_local_fns() {
         let path = fd.item_meta.name_path();
-        if path.contains("frame_locals_proxy_snapshot")
-            && let Ok(g) = lower_fun_decl(&llbc, fd)
-        {
+        if path.contains("frame_locals_proxy_snapshot") {
+            let g = lower_fun_decl(&llbc, fd)
+                .unwrap_or_else(|e| panic!("lower {path}: {e:?}"));
             eprintln!("[vable-probe] lowered {path}");
             graphs.push(g);
         }

--- a/majit/majit-translate/tests/test_vable_array_len.rs
+++ b/majit/majit-translate/tests/test_vable_array_len.rs
@@ -423,6 +423,15 @@ fn report_vable_array_shape_of_frame_locals_proxy_snapshot() {
         "no `locals_cells_stack_w` read found in any \
          `frame_locals_proxy_snapshot` graph — probe is inert"
     );
+    // The escape list was collected and printed but never asserted on, so a
+    // read that rode a link out of its defining block would print and pass —
+    // and that is precisely what `_check_no_vable_array`'s `link argument`
+    // route refuses.
+    assert!(
+        escapes.is_empty(),
+        "`frame_locals_proxy_snapshot`'s virtualizable-array read escapes its \
+         defining block: {escapes:?}"
+    );
 
     // Pin the measured shape rather than only reporting it.  Both reads now
     // pair: the body is a plain loop, so each `locals_w!(self)` copies the

--- a/majit/majit-translate/tests/test_vable_array_len.rs
+++ b/majit/majit-translate/tests/test_vable_array_len.rs
@@ -326,8 +326,7 @@ fn report_vable_array_shape_of_frame_locals_proxy_snapshot() {
     for fd in llbc.iter_local_fns() {
         let path = fd.item_meta.name_path();
         if path.contains("frame_locals_proxy_snapshot") {
-            let g = lower_fun_decl(&llbc, fd)
-                .unwrap_or_else(|e| panic!("lower {path}: {e:?}"));
+            let g = lower_fun_decl(&llbc, fd).unwrap_or_else(|e| panic!("lower {path}: {e:?}"));
             eprintln!("[vable-probe] lowered {path}");
             graphs.push(g);
         }

--- a/pyre/bench/synth/_pending/exec_foreign_globals_gc_root.py
+++ b/pyre/bench/synth/_pending/exec_foreign_globals_gc_root.py
@@ -1,0 +1,56 @@
+# Reproducer for a GC root that holds a stale reference after a polymorphic
+# slice loop runs in a frame whose globals are not a module's own `__dict__`.
+#
+# Run it by exec'ing this file's source into a plain dict:
+#
+#     code = compile(open(__file__).read(), __file__, "exec")
+#     exec(code, {"__name__": "__main__"})
+#
+# Running it directly, or exec'ing it into any module's `__dict__` (including a
+# freshly built `types.ModuleType("p").__dict__`), is clean.  So is `PYRE_JIT=0`.
+#
+# The program completes and prints both lines; the abort happens afterwards,
+# when a later collection seeds its roots:
+#
+#     GC BUG: invalid type_id=... at obj_addr=... site=extra_area
+#       obj_in_nursery=true minor_collections=2 major_collections=1
+#     ... MiniMarkGC::seed_major_root
+#     ... MiniMarkGC::start_incremental_cycle
+#     ... MiniMarkGC::do_collect_oldgen_nonmoving
+#
+# Both ingredients are load-bearing, established by ablation: dropping `lst` and
+# `tup` from the loop makes it clean, and replacing the lambda with a
+# module-level `def` passed the same way makes it clean.  Neither the slice in
+# the callee, the `try`/`except`, nor a raising callee is required --
+# `call(lambda: 1)` aborts just as reliably.
+N = 50000
+
+
+class Idx:
+    def __init__(self, v):
+        self.v = v
+
+    def __index__(self):
+        return self.v
+
+
+def call(fn):
+    return fn()
+
+
+def main():
+    seq = "abcdefghij"
+    lst = list(range(10))
+    tup = tuple(range(10))
+    acc = 0
+    i = 0
+    while i < N:
+        a = Idx(i % 5)
+        b = Idx(i % 5 + 3)
+        acc = acc + len(seq[a:b]) + len(lst[a:b]) + len(tup[a:b])
+        i = i + 1
+    print("acc", acc)
+    print(call(lambda: 1))
+
+
+main()

--- a/pyre/bench/synth/_pending/loop_callee_for_header_resume.py
+++ b/pyre/bench/synth/_pending/loop_callee_for_header_resume.py
@@ -1,0 +1,70 @@
+# OPEN DEFECT reproducer, kept out of the runner glob until it passes.
+#
+# A loop-bearing callee resumed at its own `for` header with the operand-stack
+# height left over from the walk instead of the height that header executes
+# against.  `rec` has three locals (n, acc, ch) and its loop header is the
+# FOR_ITER at py_pc 18, whose static operand-stack depth is 1 (the iterator).
+# The frame reaches the header advertising `valuestackdepth == stack_base`, so
+# its TOS is the last LOCAL and the resumed FOR_ITER calls `next()` on it:
+#
+#     TypeError: 'int' object is not an iterator
+#
+#     python3 pyre/bench/synth/_pending/loop_callee_for_header_resume.py   # PASS
+#     target/release/pyre-dynasm pyre/bench/synth/_pending/loop_callee_for_header_resume.py
+#
+# Deterministic on dynasm; `PYRE_NO_JIT=1` passes, and the failure survives
+# `PYRE_TRACE_EAGERNESS=1000000` (bridging off), `PYRE_WALKABORT_OFF=1` and
+# `PYRE_FORITER_CALL_BODY=1`.  The two loops in `main` are both needed at these
+# trip counts; a single loop needs ~1200 trials to reach it.
+#
+# Traced writer (`PYRE_FBW_DEBUG_ABORT` census against an instrumented build):
+# `maybe_publish_inline_callee_last_instr_concrete`
+# (pyre-jit-trace/src/jitcode_dispatch/residual_call.rs) publishes the EXECUTING
+# `last_instr = callee_py_pc` onto the inline callee's concrete frame and writes
+# no `valuestackdepth` beside it; `LiveLastInstrGuard` then captures that pair
+# as its saved state and restores it verbatim, so the pc reads back as a resume
+# coordinate with the walk's mid-flight depth.
+
+DATA = tuple(range(40))
+STEP = sum(DATA)
+
+
+def rec(n):
+    if n <= 0:
+        return 0
+    acc = 0
+    for ch in DATA:
+        acc = acc + ch
+    return acc + rec(n - 1)
+
+
+def expected(n):
+    return STEP * n if n > 0 else 0
+
+
+def main():
+    total = 0
+    bad = 0
+    for trial in range(50):
+        n = trial % 50
+        for value in [rec(i) for i in range(n)]:
+            total += value
+    for trial in range(60):
+        n = trial % 20
+        for i in range(n):
+            value = rec(i)
+            if value != expected(i):
+                bad += 1
+                if bad < 4:
+                    print("MISMATCH i=%d got=%r want=%r" % (i, value, expected(i)))
+            total += value
+    if bad:
+        print("FAIL %d wrong rec() results" % bad)
+        raise SystemExit(1)
+    if total != 17955600:
+        print("FAIL total=%d want=17955600" % total)
+        raise SystemExit(1)
+    print("PASS loop-callee for-header resume total=%d" % total)
+
+
+main()

--- a/pyre/bench/synth/_pending/loop_callee_for_header_resume.py
+++ b/pyre/bench/synth/_pending/loop_callee_for_header_resume.py
@@ -1,3 +1,51 @@
+# FILING (2026-08-23). Read this before attempting a fix -- four attempts have
+# already been made and refuted by measurement, and the diagnosis they produced
+# is not the one the first three assumed.
+#
+# THE INVARIANT IS A TRIPLE, not a pair:
+#     (last_instr, valuestackdepth, the stack cells [base .. base+depth))
+# Attempt 4 is the proof rather than merely a failure: pairing the depth at the
+# publishing writer makes `ForIter` read slot base+0, but nothing ever wrote the
+# iterator INTO that cell, so it still reads an int -- which is exactly the
+# TypeError below. Supplying two words without the cells cannot work.
+#
+# The four refuted attempts, with what discriminated each:
+#   1. `adopt_blackhole_crn` restores `last_instr` alone where its sibling
+#      `apply_blackhole_crn_handoff` restores both via `correct_resume_vsd`.
+#      Real and main-owned -- but an audit placed inside it NEVER FIRES here.
+#   2. `LiveLastInstrGuard` saves only `last_instr`. Saving/restoring the whole
+#      `FrameScalars` pair did not fix it: the guard is FAITHFUL, and the pair is
+#      already inconsistent when `enter_frame` captures it.
+#   3. The CALL_ASSEMBLER pin in `emit_walker_loop_callee_call_assembler`. Real
+#      and live on main (11 emits on `str_search_index_bounds`) -- ZERO events
+#      on this reproducer.
+#   4. Pairing both words at the publish site: RED, build provenance verified.
+#      `maybe_publish_inline_callee_last_instr_concrete` records this in its own
+#      doc.
+#
+# The plurality of coordinates is NOT the defect. A virtualizable's stored fields
+# are stale by design while the JIT executes -- upstream elides per-opcode
+# `last_instr` stores and reconstructs at exits -- so the walk-local coordinate
+# governs during a walk, the resume/blackhole image at exits, and the concrete
+# frame only outside the JIT domain.
+#
+# THE NEXT EXPERIMENT IS CONSUMER-SIDE, not another writer audit: instrument
+# every interpreter (re)entry on this frame, logging `last_instr`, `vsd`, AND THE
+# TYPES OF THE CELLS [base .. base+analysis_depth), to catch a re-entry that
+# never passed a reconstruction writing all three.
+#
+# Do NOT resurrect the "resumed inside a Cache slot" reading: `pc` in
+# `report_stack_underflow` is `next_instr()`, so `last_instr=66 pc=67` means
+# resume pc 66, an ordinary opcode boundary. That was an inference, never an
+# observation.
+#
+# Census: 128-case sweep = 32 fail / 96 pass, all 32 in the `rec_for` family.
+# Red on four dynasm binaries incl. one built at origin/main, and on cranelift --
+# so it is backend-independent and main-owned. Clean under PYRE_NO_JIT=1.
+# One-shot audit line:
+#   inline_callee_last_instr: next_instr=18 op=ForIter
+#     analysis_depth=Some(1) frame_depth=Some(0) (vsd=3 base=3)
+#
 # OPEN DEFECT reproducer, kept out of the runner glob until it passes.
 #
 # A loop-bearing callee resumed at its own `for` header with the operand-stack

--- a/pyre/bench/synth/current_frames_hot_loop.py
+++ b/pyre/bench/synth/current_frames_hot_loop.py
@@ -11,9 +11,17 @@
 # The discriminator is the SINGLE source line carrying both `f_lineno` reads.
 # Both name this frame, so the answers must agree; a values-only check would
 # accept a stale line number from either route, because each looks plausible
-# on its own.  Identity is asserted first -- the two routes must return the
-# same frame object, and a route answering with a copy would still report a
+# on its own.  Identity is asserted too -- the two routes must return the same
+# frame object, and a route answering with a copy would still report a
 # believable line.
+#
+# The roster's own read comes FIRST, and `sys._getframe()` -- the reference
+# route, which forces -- is only reached after it, on the same source line.
+# The two routes hand back ONE object, so a `_getframe()` evaluated ahead of
+# the roster read would force that object and repair a stale roster image
+# before it was ever inspected: `_current_frames` could stop forcing entirely
+# and this loop would still see agreeing line numbers.  The identity check
+# runs after both reads for the same reason.
 #
 # The roster is unpacked rather than indexed by thread id: the wasm guest ships
 # no `threading` module, so `get_ident` is unavailable there, and the roster's
@@ -38,12 +46,13 @@ def hot(n):
     bad_line = 0
     roster_sizes = set()
     for _ in range(n):
-        roster, frame_direct = sys._current_frames(), sys._getframe()
+        roster = sys._current_frames()
         roster_sizes.add(len(roster))
         (frame_roster,) = roster.values()
-        if frame_roster is not frame_direct:
+        line_roster, line_direct = frame_roster.f_lineno, sys._getframe().f_lineno
+        if frame_roster is not sys._getframe():
             bad_ident += 1
-        elif frame_roster.f_lineno != frame_direct.f_lineno:
+        elif line_roster != line_direct:
             bad_line += 1
     return bad_ident, bad_line, sorted(roster_sizes)
 

--- a/pyre/bench/synth/force_all_frames_hot_stack.py
+++ b/pyre/bench/synth/force_all_frames_hot_stack.py
@@ -1,4 +1,5 @@
 # pyre-check: selfcheck
+# pyre-check: spec-folds=for_iter_next,compare_op_int
 # Self-checking regression guard for `force_all_frames`
 # (`executioncontext.rs`), the only frame-materializing consumer in the tree
 # that no fixture reached.
@@ -11,15 +12,30 @@
 # stamps `is_being_profiled` on every frame it walks.
 #
 # The discriminator is a caller local read back through the forced frame.
-# `middle` is called from inside the compiled inner loop, so its frame is the
-# one an inline sub-walk keeps virtual; `witness` is computed in it and never
-# read by `middle` itself, so nothing but the force can put the current value
-# where `f_locals` finds it.  A stale materialization returns an earlier
-# round's number, and every round uses a different one.
+# `witness` is computed in `middle` and never read by `middle` itself, so a
+# stale materialization returns an earlier round's number, and every round uses
+# a different one.
 #
-# `entered` fails the fixture if the inner loop stops being entered, and
-# `hook_calls` fails it if the hook was never installed -- either would make
-# the check pass without the forced read ever happening.
+# What this fixture does NOT establish, stated plainly because the wording it
+# replaces claimed otherwise: `middle`'s frame is not an inlined virtual frame
+# here.  Measured on this shape -- `loops_compiled=1`, `loops_aborted=3`, and
+# `sys_getframe` / `builtin_locals` both `consulted=3 fired=0` -- the tracer
+# does walk into `leaf` three times, but every one of those walks aborts, and
+# the loop that does compile is the inner `for j` loop, which reaches `middle`
+# only through a guard failure into the interpreter.  Calling `middle` on every
+# iteration instead does not help: the `install` on the hot path drops the
+# workload to `loops_compiled=0`.  That is inherent to the subject rather than
+# a gap in the fixture -- installing a hook is precisely what stops a frame
+# being compiled -- so the value check below is a correctness guard on
+# `force_all_frames`, not evidence that a virtual frame was materialized.
+#
+# Three checks keep it from passing while nothing happened.  `entered` fails
+# the fixture if the inner loop stops being entered and `hook_calls` fails it
+# if the hook was never installed -- either would make the value check pass
+# without the forced read ever happening.  Neither looks at the JIT at all, so
+# the `spec-folds` header above adds the one signal that does: check.py censuses
+# the trace-time folds and fails the fixture unless both named folds fire, which
+# they cannot if the workload stops being traced.
 import sys
 
 OUTER = 400

--- a/pyre/bench/synth/frame_lasti_fold_callee_and_bridge.py
+++ b/pyre/bench/synth/frame_lasti_fold_callee_and_bridge.py
@@ -1,0 +1,75 @@
+# pyre-check: selfcheck
+# pyre-check: spec-folds=frame_lasti
+# Self-checking guard for the `f_lasti` coordinate on the two frames a walk
+# owns that are NOT the loop's own portal: the frame of an inlined callee, and
+# the caller's frame read from inside one.
+#
+# The virtualizable boxes describe the PORTAL frame only, so a read inside an
+# inlined callee cannot answer from them -- `pyjitpl.py` keeps one MIFrame per
+# inlined call and each carries its own coordinate.  pyre's walker mirrors that
+# with a per-level source: an inline sub-walk resolves the callee's own jitcode
+# pc through its own metadata, and the caller keeps the CALL boundary it is
+# suspended at.  Two sources behind one witness, so both need a site here.
+#
+# The cold arm compiles as a guard-failure bridge off the hot loop, which
+# records its `f_lasti` read at a pc the loop trace never held.
+#
+# Every site collects a SET: the loop compiles part-way through, so an
+# interpreted answer and a compiled one that disagree appear as a second
+# element rather than as one shifted value.  `co_positions()` indexed by
+# `f_lasti // 2` is the oracle for the coordinate, the way a `dis` consumer
+# reads it.
+import sys
+
+N = 20000
+
+FIRST = sys._getframe().f_lineno
+
+
+def leaf(x):
+    f = sys._getframe()
+    return (f.f_code, f.f_lasti)                             # +5
+
+
+def caller_view():
+    f = sys._getframe(1)
+    return (f.f_code, f.f_lasti)
+
+
+def main():
+    inlined = set()
+    caller = set()
+    cold = set()
+    total = 0
+    for i in range(N):
+        inlined.add(leaf(i))
+        caller.add(caller_view())                            # +20
+        if i % 997 == 0:
+            f = sys._getframe()
+            cold.add((f.f_code, f.f_lasti))                  # +23
+        total += i
+
+    for label, seen, want_line in (
+        ("inlined-callee", inlined, 5),
+        ("caller-from-callee", caller, 20),
+        ("bridge", cold, 23),
+    ):
+        if len(seen) != 1:
+            print(f"FAIL {label} diverged: {sorted(v for _, v in seen)}")
+            return 1
+        code, lasti = next(iter(seen))
+        if lasti < 0 or lasti % 2 != 0:
+            print(f"FAIL {label} f_lasti not an even byte offset: {lasti}")
+            return 1
+        row = list(code.co_positions())[lasti // 2][0]
+        if row is None or row - FIRST != want_line:
+            print(f"FAIL {label} f_lasti={lasti} names line {row} not +{want_line}")
+            return 1
+    if total != sum(range(N)):
+        print(f"FAIL dropped iteration: total={total}")
+        return 1
+    print("PASS f_lasti callee and bridge coordinates")
+    return 0
+
+
+sys.exit(main())

--- a/pyre/bench/synth/frame_lasti_fold_coordinates.py
+++ b/pyre/bench/synth/frame_lasti_fold_coordinates.py
@@ -1,0 +1,85 @@
+# pyre-check: selfcheck
+# pyre-check: spec-folds=frame_lasti
+# Self-checking guard for the coordinate an app-level `f_lasti` read reports
+# for the frame that is running it.
+#
+# `pyframe.py fget_f_lasti` is loop-free and carries no hint, so
+# `policy.py look_inside_graph` traces through it, `jtransform.py
+# rewrite_op_jit_force_virtualizable` deletes the injected force, and
+# `pyjitpl.py opimpl_getfield_vable_i` answers the field out of
+# `virtualizable_boxes` -- a constant, because the bytecode dispatch stored one
+# there.  The read neither forces the virtualizable nor needs a residual, and
+# pyre folds it to the constant its own LOAD_ATTR coordinate names.
+#
+# A wrong constant is invisible in one iteration, so every site collects a SET
+# across the run: the loop compiles part-way through, so an interpreted answer
+# and a compiled one that disagree appear as a SECOND element rather than as
+# one shifted value.
+#
+# `co_positions()` is the oracle for the coordinate itself.  Indexing it with
+# `f_lasti // 2` is what a `dis` consumer does, so it pins BOTH halves of the
+# adaptation the getset performs (`typedef.rs` returns `fget_f_lasti() * 2`
+# over an instruction-unit field): a missing factor lands on the wrong row, and
+# a pc short by one lands on the previous instruction.  Site C is where that
+# second failure becomes a line difference -- its `.f_lasti` is the FIRST
+# instruction of its own line, so the row before it belongs to the line above.
+import sys
+
+N = 20000
+
+FIRST = sys._getframe().f_lineno
+
+
+def main():
+    code = sys._getframe().f_code
+    site_a = set()
+    site_b = set()
+    site_c = set()
+    total = 0
+    for i in range(N):
+        f = sys._getframe()
+        site_a.add((f.f_lasti, f.f_lineno - FIRST))          # +11
+        total += i
+        g = sys._getframe()
+        site_b.add((g.f_lasti, g.f_lineno - FIRST))          # +14
+        h = sys._getframe()
+        site_c.add(
+            h
+            .f_lasti                                         # +18
+        )
+
+    positions = list(code.co_positions())
+    for label, seen, want_line in (
+        ("A", site_a, 11),
+        ("B", site_b, 14),
+        ("C", site_c, 18),
+    ):
+        if len(seen) != 1:
+            print(f"FAIL site {label} diverged across iterations: {sorted(seen)}")
+            return 1
+        entry = next(iter(seen))
+        lasti = entry[0] if isinstance(entry, tuple) else entry
+        if lasti < 0 or lasti % 2 != 0:
+            print(f"FAIL site {label} f_lasti not an even byte offset: {lasti}")
+            return 1
+        row = positions[lasti // 2][0]
+        if row is None or row - FIRST != want_line:
+            print(f"FAIL site {label} f_lasti={lasti} names line {row} not +{want_line}")
+            return 1
+        if isinstance(entry, tuple) and entry[1] != want_line:
+            print(f"FAIL site {label} f_lineno +{entry[1]} != +{want_line}")
+            return 1
+    a = next(iter(site_a))[0]
+    b = next(iter(site_b))[0]
+    c = next(iter(site_c))
+    if not (a < b < c):
+        print(f"FAIL f_lasti not increasing across sites: {a} {b} {c}")
+        return 1
+    if total != sum(range(N)):
+        print(f"FAIL dropped iteration: total={total}")
+        return 1
+    print("PASS f_lasti fold coordinates")
+    return 0
+
+
+sys.exit(main())

--- a/pyre/bench/synth/frame_lasti_fold_foreign_frames.py
+++ b/pyre/bench/synth/frame_lasti_fold_foreign_frames.py
@@ -1,0 +1,76 @@
+# pyre-check: selfcheck
+# Self-checking guard that a foreign frame's `f_lasti` keeps its residual.
+#
+# The fold's whole licence is that the walk KNOWS the coordinate of the frame
+# being read: the portal frame's own pc, or an inlined callee's.  A frame the
+# walk does not own carries a coordinate only its own writer knows -- a
+# suspended generator's, a traceback node's -- so the read has to stay the
+# residual getter that goes to the heap.  This fixture is the negative half of
+# the fold's identity gate: nothing here may be answered from the walk's pc.
+#
+# The suspended generator is the sharper of the two, because its answer is
+# STABLE across the loop the way a folded constant would be, and wrong by a
+# fold that keyed on the reading frame instead of the read one.  The traceback
+# node has its own oracle beside it: `tb_lasti` is resolved by the recorder at
+# raise time, so `tb_frame.f_lasti == tb_lasti` for a frame the exception has
+# already left.
+import sys
+
+N = 20000
+
+FIRST = sys._getframe().f_lineno
+
+
+def gen():
+    i = 0
+    while True:
+        yield i                                              # +6
+        i += 1
+
+
+def raises(i):
+    raise ValueError(i)
+
+
+def main():
+    g = gen()
+    next(g)
+    gframe = g.gi_frame
+    suspended = set()
+    unwound = set()
+    total = 0
+    for i in range(N):
+        suspended.add((gframe.f_code, gframe.f_lasti))
+        try:
+            raises(i)
+        except ValueError as e:
+            tb = e.__traceback__.tb_next
+            unwound.add((tb.tb_frame.f_lasti, tb.tb_lasti))
+        total += i
+
+    if len(suspended) != 1:
+        print(f"FAIL suspended generator f_lasti diverged: {sorted(v for _, v in suspended)}")
+        return 1
+    code, lasti = next(iter(suspended))
+    if lasti < 0 or lasti % 2 != 0:
+        print(f"FAIL suspended generator f_lasti not an even byte offset: {lasti}")
+        return 1
+    row = list(code.co_positions())[lasti // 2][0]
+    if row is None or row - FIRST != 6:
+        print(f"FAIL suspended generator f_lasti={lasti} names line {row} not +6")
+        return 1
+    if len(unwound) != 1:
+        print(f"FAIL unwound frame f_lasti diverged: {sorted(unwound)}")
+        return 1
+    frame_lasti, tb_lasti = next(iter(unwound))
+    if frame_lasti != tb_lasti:
+        print(f"FAIL unwound frame f_lasti={frame_lasti} != tb_lasti={tb_lasti}")
+        return 1
+    if total != sum(range(N)):
+        print(f"FAIL dropped iteration: total={total}")
+        return 1
+    print("PASS foreign frame f_lasti stays residual")
+    return 0
+
+
+sys.exit(main())

--- a/pyre/bench/synth/generator_frame_handout_image.py
+++ b/pyre/bench/synth/generator_frame_handout_image.py
@@ -16,6 +16,17 @@
 # a stale `last_instr` -- a values-only check cannot see it, because each answer
 # on its own looks like a plausible line number.
 #
+# The ORDER of the two reads is what makes that discriminator reachable, and it
+# is why the hand-out is read into a name of its own first.  Both routes return
+# ONE frame object -- the identity check below asserts exactly that -- and
+# forcing is a property of the object, not of the reference it arrived through.
+# So any `sys._getframe()` evaluated ahead of the hand-out read refreshes the
+# image the hand-out route is supposed to be inspecting, and the comparison
+# becomes a frame against its own forced self.  `_getframe()` stays on the same
+# source line as the hand-out read (tuple right-hand sides evaluate left to
+# right, so the hand-out read still runs first) and the identity check follows
+# both, where its own force can no longer hide anything.
+#
 # The generator body carries an inner loop with no `yield` in it.  That is
 # load-bearing: a loop that yields re-enters through the driver every iteration
 # and never becomes a compiled loop, so the frame is never a traced
@@ -36,11 +47,11 @@ def gen(holder):
             if j == INNER - 1:
                 g = holder[0]
                 rounds += 1
-                f_handout, f_getframe = g.gi_frame, sys._getframe()
-                if f_handout is not f_getframe:
+                f_handout = g.gi_frame
+                a, b = f_handout.f_lineno, sys._getframe().f_lineno
+                if f_handout is not sys._getframe():
                     identity_breaks += 1
                     continue
-                a, b = f_handout.f_lineno, f_getframe.f_lineno
                 if a != b:
                     disagreements.append((rounds, a, b))
         yield None
@@ -65,11 +76,11 @@ async def coro_body(holder):
             if j == INNER - 1:
                 c = holder[0]
                 rounds += 1
-                f_handout, f_getframe = c.cr_frame, sys._getframe()
-                if f_handout is not f_getframe:
+                f_handout = c.cr_frame
+                a, b = f_handout.f_lineno, sys._getframe().f_lineno
+                if f_handout is not sys._getframe():
                     identity_breaks += 1
                     continue
-                a, b = f_handout.f_lineno, f_getframe.f_lineno
                 if a != b:
                     disagreements.append((rounds, a, b))
     return (rounds, identity_breaks, disagreements)

--- a/pyre/bench/synth/getframemodulename_hot_loop.py
+++ b/pyre/bench/synth/getframemodulename_hot_loop.py
@@ -17,15 +17,44 @@
 # oscillated and happened to be right on the last iteration.
 #
 # Depth 1 is read from a callee the tracer can inline, so the answer has to
-# name the CALLER's module rather than the frame the walk is standing in.
+# name the CALLER's module rather than the frame the walk is standing in.  The
+# callee therefore runs under a module of its OWN: with caller and callee both
+# in `__main__` the two answers coincide, and an implementation that ignored
+# the requested depth entirely -- always reporting the frame it is standing in
+# -- produced the expected `{"__main__"}` and passed.  Measured on the shipped
+# shape: depth 1 and depth 0 both answered `__main__`.  With the callee moved
+# out, depth 0 answers `OTHER_MODULE` and depth 1 still answers `__main__`, so
+# the two are finally distinguishable -- and BOTH are asserted, because pinning
+# only depth 1 leaves a route that has stopped distinguishing them unremarked.
+#
+# The callee is built by rebinding a code object against the other module's
+# namespace rather than by `exec`-ing source into it: `exec` into a namespace
+# that is not a module's own dict is a separate open defect here, and this
+# fixture has no reason to depend on it.
 import sys
 
 N = 200000
 EXPECTED = "__main__"
+OTHER_MODULE = "pyre_getframemodulename_callee"
+
+_other = type(sys)(OTHER_MODULE)
+_other.sys = sys
 
 
-def inner_depth1(seen):
-    seen.add(sys._getframemodulename(1))
+def _callee_template(seen_depth1):
+    seen_depth1.add(sys._getframemodulename(1))
+
+
+def _callee_depth0_template():
+    return sys._getframemodulename(0)
+
+
+inner_depth1 = type(_callee_template)(
+    _callee_template.__code__, _other.__dict__, "inner_depth1"
+)
+callee_depth0 = type(_callee_depth0_template)(
+    _callee_depth0_template.__code__, _other.__dict__, "callee_depth0"
+)
 
 
 def hot(n):
@@ -39,12 +68,27 @@ def hot(n):
 
 def main():
     at0, at1 = hot(N)
+    # Read once, OUTSIDE the hot loop.  Every `_getframemodulename` forces the
+    # frame -- it reads `w_globals`, a redirected field -- so a third call in
+    # the loop body costs a third escape per iteration and the loop stops
+    # compiling altogether (measured: `loops_compiled` 1 -> 0, `abrt_escape`
+    # 5 -> 10).  The depth-0 answer is invariant, so one read establishes it
+    # and the hot loop keeps guarding what it exists to guard: the depth-1
+    # answer from a callee the tracer inlines, in COMPILED code.
+    callee_at0 = {callee_depth0()}
     if at0 != {EXPECTED}:
         print("FAIL _getframemodulename(0) not invariant:", sorted(at0, key=str))
         return 1
     if at1 != {EXPECTED}:
         print("FAIL _getframemodulename(1) from an inlinable callee:",
               sorted(at1, key=str))
+        return 1
+    # The callee's own depth 0.  Distinct from `at1` by construction, so a
+    # route that collapsed the two -- ignoring the requested depth -- fails
+    # here even while `at1` still reads `__main__`.
+    if callee_at0 != {OTHER_MODULE}:
+        print("FAIL _getframemodulename(0) inside the foreign-module callee:",
+              sorted(callee_at0, key=str))
         return 1
     print("PASS _getframemodulename hot loop")
     return 0

--- a/pyre/bench/synth/locals_proxy_extra_key_hot.py
+++ b/pyre/bench/synth/locals_proxy_extra_key_hot.py
@@ -1,0 +1,99 @@
+# pyre-check: selfcheck
+# pyre-check: spec-folds=builtin_locals
+# A key written through `frame.f_locals` that names no writable fast local must
+# survive into the mapping `locals()` / `vars()` / `dir()` hand back, including
+# when the trace folds those builtins.
+#
+# `framelocalsproxy_setitem` sends such a key to `FrameDebugData.w_extra_locals`
+# and touches neither a fast slot nor `w_locals`, and
+# `frame_locals_proxy_snapshot` copies that dict in ahead of the fastlocals.
+# Both `locals()` folds rebuild the mapping WITHOUT it -- the callee arm from
+# `CalleeLocalsShadow`, the portal arm from the virtualizable's slot array --
+# so each needs its own gate on `w_extra_locals` rather than reading a null
+# `w_locals` as "this frame carries no mapping".  Neither gate existed:
+# compiled runs answered `['f', 'x', 'y']` where `PYRE_JIT=0` answered
+# `['extra_key', 'f', 'x', 'y']`.
+#
+# The two folds are separate code paths reached by separate gates, so both are
+# driven here: `probe_callee_extra` calls the builtin one frame in, where the
+# tracer answers from the inlined callee's shadow, and `probe_portal_extra`
+# calls it in the compiled loop's own frame, where it answers from the standard
+# virtualizable.  `dir()` rides the same gate through its sorted-names tail.
+#
+# `probe_plain` carries no proxy write at all, so the fold still FIRES there.
+# It is what keeps the fixture honest: the two gates above are declines, and a
+# fixture built only from declines passes just as well with the whole fold
+# deleted.  The `spec-folds` header censuses `builtin_locals` and fails the run
+# unless it fired at least once, which only `probe_plain` can supply.
+import sys
+
+N = 200000
+KEY = "extra_key"
+
+
+def helper_plain(x):
+    y = x + 1
+    return sorted(locals())
+
+
+def helper_extra(x):
+    y = x + 1
+    # Not a fast local of this frame, so it lands in `f_extra_locals`.
+    sys._getframe().f_locals[KEY] = x
+    return sorted(locals()), sorted(vars()), sorted(dir())
+
+
+def probe_plain():
+    last = None
+    for _ in range(N):
+        last = helper_plain(1)
+    return last
+
+
+def probe_callee_extra():
+    last = None
+    for i in range(N):
+        last = helper_extra(i)
+    return last
+
+
+def probe_portal_extra():
+    y = 0
+    sys._getframe().f_locals[KEY] = 1
+    last = None
+    for i in range(N):
+        y = i
+        last = sorted(locals())
+    return last
+
+
+def report(label, seen, expected):
+    if seen != expected:
+        print(f"FAIL {label}: {seen}")
+        print(f"  expected: {expected}")
+        return 1
+    return 0
+
+
+def main():
+    rc = report("plain callee", probe_plain(), ["x", "y"])
+
+    locals_names, vars_names, dir_names = probe_callee_extra()
+    expected_callee = [KEY, "x", "y"]
+    rc |= report("locals() in callee", locals_names, expected_callee)
+    rc |= report("vars() in callee", vars_names, expected_callee)
+    rc |= report("dir() in callee", dir_names, expected_callee)
+
+    rc |= report(
+        "locals() in the compiled loop's own frame",
+        probe_portal_extra(),
+        [KEY, "i", "last", "y"],
+    )
+
+    if rc:
+        return rc
+    print("PASS proxy-written extra locals survive the locals folds")
+    return 0
+
+
+sys.exit(main())

--- a/pyre/bench/synth/settrace_f_trace_armed_mid_loop.py
+++ b/pyre/bench/synth/settrace_f_trace_armed_mid_loop.py
@@ -1,0 +1,114 @@
+# pyre-check: selfcheck
+# Self-checking guard for local tracing armed on a frame that is ALREADY
+# running compiled code.
+#
+# `dispatch_bytecode` (pyopcode.py) opens its loop with a `jit.we_are_jitted()`
+# arm that reads the frame's own `debugdata` and fires `ec.bytecode_only_trace`
+# when `_d.w_f_trace is not None`.  `debugdata` is one of the `_virtualizable_`
+# fields (`interp_jit.py PyFrame._virtualizable_`), so that read is recorded
+# into the trace and every compiled loop carries a guard on it; arming
+# `frame.f_trace` mid-run fails that guard and the events keep arriving from
+# the interpreter.  Reading a per-ExecutionContext flag instead produces no
+# such guard, and the compiled loop then runs to completion with the tracer
+# installed and silent.
+#
+# THE TAIL IS THE TEST.  The loss the guard prevents is total and permanent,
+# not partial: `settrace` forces every frame, so the compiled loop deopts once
+# at the moment of arming and reports that single iteration -- and then, with
+# nothing testing the frame again, runs the whole remaining tail in compiled
+# code and reports nothing, at any length.  Measured before the guard: a
+# 100 000-iteration tail reported the same handful of events a 9-iteration tail
+# did.  So the tail here is long enough that the one-shot deopt cannot come
+# close to satisfying it, and a fix that merely moves or repeats that deopt
+# fails just as loudly as no fix at all.
+#
+# The expectation is stated per source line, not as a total, so an
+# implementation that keeps firing but at the wrong instruction fails too.  The
+# two loop-body lines are exact -- one event per remaining iteration, no more
+# and no fewer, which cpython 3.14.6 and pypy3 7.3.22 both hold.  The loop
+# HEADER is a lower bound, because the rule `run_trace_func` fires on is
+# `frame.last_instr < d.instr_prev_plus_one` and an implementation whose back
+# edge lands lower fires the header a second time: at this tail cpython reads
+# exactly TAIL and pypy3 reads 3599, and neither is wrong.
+#
+# Both `sys` entry points that install a trace function are exercised, because
+# the defect is in the compiled loop rather than in either setter and a fix
+# pinned on one spelling is pinned on nothing.  `threading.settrace_all_threads`
+# is the same path -- it stores the hook and delegates to
+# `sys._settraceallthreads` -- so it is left out rather than paying the
+# `threading` import in a synthetic fixture.
+#
+# `f_trace` is armed from a callee via `sys._getframe(1)`, so the traced frame
+# is mid-execution and no `call` event ever fires for it.
+import sys
+
+N = 20000  # past `threshold` (1039) many times over before ARM
+TAIL = 2000  # iterations left after arming
+
+events = []
+
+
+def tracer(frame, event, arg):
+    events.append((event, frame.f_lineno - frame.f_code.co_firstlineno))
+    return tracer
+
+
+def arm(setter):
+    frame = sys._getframe(1)
+    frame.f_trace = tracer
+    frame.f_trace_lines = True
+    setter(tracer)
+
+
+def hot(n, arm_at, setter, unsetter):   # +0
+    acc = 0                             # +1
+    for i in range(n):                  # +2
+        acc += i                        # +3
+        if i == arm_at:                 # +4
+            arm(setter)                 # +5
+    unsetter(None)                      # +6
+    return acc                          # +7
+
+
+def run(setter, unsetter):
+    del events[:]
+    hot(N, N - TAIL, setter, unsetter)
+    return list(events)
+
+
+# One `line` event per body line for each of the `TAIL - 1` iterations that
+# follow the arming one, then the line after the loop.  The `+2` header entry
+# is checked separately as a lower bound.
+EXACT = {("line", 3): TAIL - 1, ("line", 4): TAIL - 1, ("line", 6): 1}
+HEADER = ("line", 2)
+
+SETTERS = [("sys.settrace", sys.settrace, sys.settrace)]
+_all_threads = getattr(sys, "_settraceallthreads", None)
+if _all_threads is not None:
+    SETTERS.append(("sys._settraceallthreads", _all_threads, _all_threads))
+
+
+def main():
+    failures = []
+    for name, setter, unsetter in SETTERS:
+        counts = {}
+        for event in run(setter, unsetter):
+            counts[event] = counts.get(event, 0) + 1
+        header = counts.pop(HEADER, 0)
+        if counts != EXACT:
+            failures.append(
+                f"{name}: got {sorted(counts.items())!r}, want {sorted(EXACT.items())!r}"
+            )
+        if header < TAIL:
+            failures.append(
+                f"{name}: loop header fired {header!r} times, want at least {TAIL!r}"
+            )
+    if failures:
+        for line in failures:
+            print("FAIL", line)
+        return 1
+    print("PASS f_trace armed mid-loop")
+    return 0
+
+
+sys.exit(main())

--- a/pyre/bench/synth/settrace_f_trace_opcodes_armed_mid_loop.py
+++ b/pyre/bench/synth/settrace_f_trace_opcodes_armed_mid_loop.py
@@ -1,0 +1,191 @@
+# pyre-check: selfcheck
+# Self-checking guard for `f_trace_opcodes` armed on a frame that is ALREADY
+# running compiled code.  Sibling of `settrace_f_trace_armed_mid_loop`; see
+# that fixture for why the `debugdata` read in `dispatch_bytecode`'s
+# `jit.we_are_jitted()` arm is what keeps the events coming, and for why the
+# tail has to be long.
+#
+# The opcode probe is the denser half of the pair: `run_trace_func`
+# (executioncontext.py) fires an `opcode` event for EVERY bytecode rather than
+# once per source line, so it reads the same defect through a different rule
+# and at roughly ten times the event rate.
+#
+# Absolute counts are not portable -- they are a property of the bytecode a
+# given implementation compiles this loop to, and cpython 3.14.6 and pypy3
+# 7.3.22 disagree on it for the same source -- so the invariant is stated
+# against THIS BINARY'S OWN interpreted answer.  Three runs:
+#
+#   * two short runs, both below `threshold` and therefore never compiled,
+#     whose tails differ by exactly one iteration.  One traced iteration `B`
+#     and the loop-exit block `E` are recovered from the pair by algebra, and
+#     so is `P`, the remainder of the iteration the setter interrupted.
+#   * one long run, long past `threshold`, whose stream after the first loop
+#     header must be `B * (HOT_TAIL - 1) + E` -- EXACTLY, event for event and
+#     `f_lasti` for `f_lasti`, not merely as dense.
+#
+# Two separate assertions, because the fix establishes two different things.
+# They share all three runs, which is why they are one file.
+#
+# 1. THE TAIL, exact.  From the first loop header after arming onward the
+#    compiled stream is identical to the interpreted one.  This is the gate
+#    worth having: the pre-fix behaviour is that `settrace` forces every frame,
+#    the loop deopts once, reports that single iteration, and then runs
+#    compiled and silent for the rest of the tail however long it is.
+#
+#    One normalisation, and only one: consecutive duplicate loop-header events
+#    are collapsed.  The rule `run_trace_func` fires on is
+#    `frame.last_instr < d.instr_prev_plus_one`, so an implementation whose
+#    compiled back edge lands below that fires the header twice in a row --
+#    pypy3 does (3793 header events over a 2000-iteration tail against
+#    cpython's and pyre's 2000), cpython does not, and neither is wrong.
+#    Nothing else is normalised and nothing is given any tolerance.
+#
+# 2. THE ARMING ITERATION, pinned.  The setter interrupts an iteration, and an
+#    implementation that leaves compiled code at the forcing call resumes the
+#    rest of that iteration through its guard-failure path rather than through
+#    the eval loop, so the opcodes between the setter and the next merge point
+#    report nothing.  Measured on pyre when this was written: five events,
+#    `f_lasti` 78, 80, 82, 84, 86 -- against zero on `PYRE_JIT=0`, on cpython
+#    and on pypy3.  That is a real and separate gap, so it is asserted rather
+#    than absorbed: whatever the hot run does report in that window must be a
+#    suffix of what the interpreted run reports (nothing spurious, nothing
+#    reordered), and at most `ARMING_GAP_MAX` events may be missing.  The bound
+#    cannot grow silently; a fix that closes the gap to zero still passes.
+#    It is bounded by a single iteration at any tail length, where the defect
+#    assertion 1 guards against loses the entire tail.
+import sys
+
+COLD = 40  # below `threshold` (1039) -- these two runs are never compiled
+HOT = 20000  # past it many times over before ARM
+COLD_TAIL = 6
+HOT_TAIL = 2000
+ARMING_GAP_MAX = 5  # measured on pyre; 0 on PYRE_JIT=0, cpython and pypy3
+
+events = []
+
+
+def tracer(frame, event, arg):
+    events.append((event, frame.f_lasti))
+    return tracer
+
+
+def arm():
+    frame = sys._getframe(1)
+    frame.f_trace = tracer
+    frame.f_trace_lines = False
+    frame.f_trace_opcodes = True
+    sys.settrace(tracer)
+
+
+def hot(n, arm_at):              # +0
+    acc = 0                      # +1
+    for i in range(n):           # +2
+        acc += i                 # +3
+        if i == arm_at:          # +4
+            arm()                # +5
+    sys.settrace(None)           # +6
+    return acc                   # +7
+
+
+def run(n, tail):
+    del events[:]
+    hot(n, n - tail)
+    return list(events)
+
+
+def collapse(stream, header):
+    """Fold runs of consecutive loop-header events down to one."""
+    out = []
+    for event in stream:
+        if event[1] == header and out and out[-1][1] == header:
+            continue
+        out.append(event)
+    return out
+
+
+def main():
+    failures = []
+    # Both control runs first, while the loop is still cold.
+    cold_a = run(COLD, COLD_TAIL)
+    cold_b = run(COLD + 1, COLD_TAIL + 1)
+    hot_events = run(HOT, HOT_TAIL)
+
+    block_len = len(cold_b) - len(cold_a)
+    if block_len < 3:
+        print(f"FAIL cold: one iteration is {block_len!r} opcode events, want at least 3")
+        return 1
+
+    # `cold_a` is `P + B * (COLD_TAIL - 1) + E` and `cold_b` is the same with one
+    # more `B`, so the arming remainder `P` is the shortest prefix for which
+    # dropping one block from `cold_b` leaves exactly `cold_a`.
+    arming = None
+    for i in range(len(cold_a) + 1):
+        if cold_b[i + block_len:] == cold_a[i:]:
+            arming = i
+            break
+    if arming is None:
+        print("FAIL cold: the two control runs do not differ by exactly one iteration")
+        return 1
+
+    cold_prefix = cold_a[:arming]
+    block = cold_b[arming:arming + block_len]
+    exit_block = cold_a[arming + block_len * (COLD_TAIL - 1):]
+    header = block[0][1]
+    if cold_a != cold_prefix + block * (COLD_TAIL - 1) + exit_block:
+        print("FAIL cold: the interpreted tail is not a repetition of one iteration")
+        return 1
+
+    split = next(
+        (i for i, event in enumerate(hot_events) if event[1] == header), len(hot_events)
+    )
+    hot_prefix, hot_suffix = hot_events[:split], hot_events[split:]
+
+    # 1. The tail, exact.
+    want = block * (HOT_TAIL - 1) + exit_block
+    got_n, want_n = collapse(hot_suffix, header), collapse(want, header)
+    if got_n != want_n:
+        where = next(
+            (i for i, (g, w) in enumerate(zip(got_n, want_n)) if g != w),
+            min(len(got_n), len(want_n)),
+        )
+        failures.append(
+            f"hot: the stream after the first loop header is not the interpreted "
+            f"one repeated: got {len(got_n)} events, want {len(want_n)} "
+            f"({len(block)}/iteration over {HOT_TAIL - 1} iterations + "
+            f"{len(exit_block)} at the exit); first difference at index {where}: "
+            f"{got_n[where:where + 3]!r} vs {want_n[where:where + 3]!r}"
+        )
+
+    # 2. The arming iteration, pinned.
+    gap = len(cold_prefix) - len(hot_prefix)
+    if gap < 0 or hot_prefix != cold_prefix[gap:]:
+        failures.append(
+            f"hot: the arming-iteration window is not a suffix of the interpreted "
+            f"one: got {[l for _, l in hot_prefix]!r}, interpreted "
+            f"{[l for _, l in cold_prefix]!r}"
+        )
+    elif gap > ARMING_GAP_MAX:
+        failures.append(
+            f"hot: {gap} events lost in the arming iteration "
+            f"(f_lasti {[l for _, l in cold_prefix[:gap]]!r}), want at most "
+            f"{ARMING_GAP_MAX}"
+        )
+
+    if not all(event == "opcode" for event, _ in hot_events + cold_a):
+        failures.append(
+            f"non-opcode events present: "
+            f"{sorted({e for e, _ in hot_events + cold_a})!r}"
+        )
+
+    if failures:
+        for line in failures:
+            print("FAIL", line)
+        return 1
+    print(
+        f"PASS f_trace_opcodes armed mid-loop "
+        f"(tail exact: {len(got_n)} events; arming gap {gap}/{ARMING_GAP_MAX})"
+    )
+    return 0
+
+
+sys.exit(main())

--- a/pyre/bench/synth/settrace_local_tracer_armed_before_entry.py
+++ b/pyre/bench/synth/settrace_local_tracer_armed_before_entry.py
@@ -1,0 +1,94 @@
+# pyre-check: selfcheck
+# Self-checking guard for the other half of the local-tracing contract: a
+# global tracer that RETURNS ITSELF, so `_trace` (executioncontext.py) installs
+# it as `w_f_trace` on every frame it sees a `call` event for, and the loop
+# inside that frame then runs with local tracing already armed.  A global hook
+# that returns `None` declines local tracing and only ever fires frame-level
+# events, so it cannot observe any of this -- which is why the events below
+# were not covered by anything before.
+#
+# SCOPE -- read this before citing the fixture as a guard for anything.  The
+# hook is armed BEFORE the frame is entered, which is what the name says and
+# what makes this the plain evaluator's fixture and not the JIT's:
+# `eval_with_jit_inner` (`pyre-jit/src/eval.rs`) routes any frame for which
+# `frame_tracing_active` holds to `execute_frame_plain`, so the loop here never
+# compiles and never reaches the portal.  Measured: it passes identically with
+# and without the `debugdata` guard its sibling fixtures were added for, so it
+# discriminates nothing about that fix and must not be read as covering it.
+# It is written to keep holding when that gate is narrowed -- which is the
+# point of having it now rather than then, since a fixture added alongside the
+# change that needs it proves nothing about the state before.
+#
+# In particular it does NOT cover the open GC abort (`GC BUG: invalid type_id
+# ... site=marking_regray_root`).  That one needs local tracing armed on a
+# frame that is ALREADY compiled: `f_trace` set on the frames up the stack from
+# inside an already-hot loop, via a SIGALRM handler, with the tracer returning
+# itself.  A tracer returning `None` is clean and so is a global-only one --
+# that is the discriminating rung, and none of it is what this file does.
+#
+# Only the loop is measured.  The frame-entry and frame-exit events are
+# deliberately outside the window: pyre instruments the `RESUME` at pc 0 and so
+# reports one extra `line` event at the `def` line, with and without the JIT,
+# and that belongs to a separate open defect rather than to this one.  What is
+# stated here is exact where it counts -- one `line` event on the body
+# statement per iteration, no more and no fewer.
+import sys
+
+N = 4000
+
+events = []
+
+
+def tracer(frame, event, arg):
+    if frame.f_code.co_name == "hot":
+        events.append((event, frame.f_lineno - frame.f_code.co_firstlineno))
+    return tracer
+
+
+def hot(n):                      # +0
+    acc = 0                      # +1
+    for i in range(n):           # +2
+        acc += i                 # +3
+    return acc                   # +4
+
+
+def main():
+    sys.settrace(tracer)
+    try:
+        acc = hot(N)
+    finally:
+        sys.settrace(None)
+
+    failures = []
+    if acc != N * (N - 1) // 2:
+        failures.append(f"acc: got {acc!r}, want {N * (N - 1) // 2!r}")
+
+    counts = {}
+    for event in events:
+        counts[event] = counts.get(event, 0) + 1
+    body = counts.get(("line", 3), 0)
+    if body != N:
+        failures.append(f"loop body: got {body!r} line events, want exactly {N!r}")
+    # The loop header runs once per iteration plus once for the exhausted
+    # iterator.  How many `line` events that is depends on where the back edge
+    # lands: the header fires again for a backwards jump onto a lower
+    # instruction (`run_trace_func`'s `frame.last_instr <
+    # d.instr_prev_plus_one`), and whether the jump and the FOR_ITER share the
+    # line is a property of the compiled bytecode -- cpython 3.14.6 reads
+    # N + 1 where pypy3 7.3.22 reads more.  Only the lower bound is portable.
+    header = counts.get(("line", 2), 0)
+    if header < N + 1:
+        failures.append(f"loop header: got {header!r} line events, want at least {N + 1!r}")
+    for want in (("call", 0), ("return", 4)):
+        if counts.get(want, 0) != 1:
+            failures.append(f"{want!r}: got {counts.get(want, 0)!r}, want 1")
+
+    if failures:
+        for line in failures:
+            print("FAIL", line)
+        return 1
+    print("PASS local tracer returning itself, armed before entry")
+    return 0
+
+
+sys.exit(main())

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -4005,7 +4005,7 @@ class Check:
     # ── self-checking regression guard ──
 
     def run_selfcheck(self, name, script, timeout, expect="PASS", skip_backends=(),
-                      require_jit=True):
+                      require_jit=True, spec_folds=()):
         """Run a self-checking regression script on each enabled backend.
 
         The script asserts its own invariant (exit 0 AND prints *expect*);
@@ -4024,8 +4024,18 @@ class Check:
         guards stopped reaching the JIT, which is the change most likely to
         make the guard vacuous. `synth_selfcheck_interpreted` turns it off for
         a fixture whose invariant is not about compiled code.
+
+        *spec_folds* is the `# pyre-check: spec-folds=` list, read the same way
+        `run_synthetic_bench` reads it. A fixture written to guard a trace-time
+        fold asserts the ANSWER, and the residual answers identically -- so
+        without the census the fixture passes just as well with the fold gone,
+        which is the one failure it exists to catch.
         """
         print(f"  {name}")
+        if spec_folds and not self._check_spec_folds(
+            name, script, spec_folds, timeout, "-", "-",
+        ):
+            return
         for backend in ALL_BACKENDS:
             if not self.enabled(backend):
                 continue
@@ -4332,6 +4342,7 @@ class Check:
             try:
                 selfcheck = synth_selfcheck(path)
                 skip_backends = synth_skip_backends(path) if selfcheck else ()
+                selfcheck_folds = synth_spec_folds(path) if selfcheck else ()
             except ValueError as e:
                 print(f"{red('ERROR')}: {e}")
                 sys.exit(1)
@@ -4342,6 +4353,7 @@ class Check:
                     self.args.synthetic_timeout,
                     skip_backends=skip_backends,
                     require_jit=not synth_selfcheck_interpreted(path),
+                    spec_folds=selfcheck_folds,
                 )
             else:
                 self.run_synthetic_bench(

--- a/pyre/extra_tests/parity_tests/foriter_stopiteration_exception_event.py
+++ b/pyre/extra_tests/parity_tests/foriter_stopiteration_exception_event.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins that a StopIteration caught by FOR_ITER's exhaustion arm reports no `exception` event; pypy3 reports ('consume_generator', 'StopIteration')
 # CPython-suite gap: `test_sys_settrace` traces loops and it traces raising
 # code, but never a loop whose iterator ends by raising StopIteration from a
 # Python-level `__next__` while a tracer is installed.  A runtime that

--- a/pyre/extra_tests/parity_tests/frame_lasti_negative_is_the_sentinel.py
+++ b/pyre/extra_tests/parity_tests/frame_lasti_negative_is_the_sentinel.py
@@ -1,0 +1,62 @@
+# CPython-suite gap: the suite reads `f_lasti` only off frames that have run an
+# instruction -- `test.test_sys_settrace`, which is the module that would see a
+# frame at its `call` event, is SKIP in `pyre/cpython_tests/baseline.json`
+# ("implementation detail").  A wrong value on a not-yet-started frame is also
+# the kind of defect that survives every consumer that does `f_lasti // 2`,
+# because the quotient of a negative sentinel still looks negative.
+#
+# parity-tests reason: pyre stores `last_instr` in instruction units and
+# CPython's `f_lasti` is a byte offset, so the getset scales by two.  A negative
+# `last_instr` is the not-yet-started sentinel rather than a coordinate, and
+# scaling it produced `-2`, a value NEITHER reference can report.  Both spell
+# the sentinel exactly `-1`: `PyFrame_GetLasti` (`Objects/frameobject.c`) is
+# `lasti < 0 ? -1 : lasti * sizeof(_Py_CODEUNIT)`, `frame_lasti_get_impl`
+# returns `-1` for the same case, and `pyframe.py fget_f_lasti` hands
+# `last_instr` back unscaled.
+#
+# What is asserted is therefore the invariant both references satisfy -- a
+# negative `f_lasti` is exactly `-1` -- rather than a literal value.  The two
+# disagree on WHETHER a given frame is negative, because a CPython frame starts
+# past the `RESUME` it counts as already executed while a pypy/pyre frame starts
+# at `-1`; that difference is the frame model and is not what this pins.
+import sys
+
+
+def unstarted_generator_frame_lasti():
+    def counting():
+        yield 1
+
+    generator = counting()
+    try:
+        return generator.gi_frame.f_lasti
+    finally:
+        generator.close()
+
+
+def call_event_frame_lasti():
+    seen = []
+
+    def tracer(frame, event, arg):
+        if event == "call" and frame.f_code.co_name == "probe":
+            seen.append(frame.f_lasti)
+        return tracer
+
+    def probe():
+        return 1
+
+    sys.settrace(tracer)
+    try:
+        probe()
+    finally:
+        sys.settrace(None)
+    assert len(seen) == 1, seen
+    return seen[0]
+
+
+for label, lasti in (
+    ("unstarted generator", unstarted_generator_frame_lasti()),
+    ("call event", call_event_frame_lasti()),
+):
+    assert lasti >= 0 or lasti == -1, (label, lasti)
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/settrace_line_events_skip_resume.py
+++ b/pyre/extra_tests/parity_tests/settrace_line_events_skip_resume.py
@@ -1,0 +1,133 @@
+# CPython-suite gap: `test.test_sys_settrace` is SKIP in
+# `pyre/cpython_tests/baseline.json` ("implementation detail"), so the one suite
+# module that walks a tracer's whole line-event stream never runs here.  Nothing
+# else in the tree counts line events, and a spurious one is invisible to every
+# test that only asks whether a callback fired at all -- the tracer still gets
+# its `call`, still gets every real line, and still gets its `return`.
+#
+# parity-tests reason: pyre's bytecode carries 3.14's `RESUME`, which opens
+# every function body stamped with the `def` line.  pypy's 3.11 bytecode has no
+# such instruction -- its pc 0 IS the first body statement -- so pypy cannot
+# have this bug and offers no reading on it.  CPython 3.14 does have `RESUME`
+# and refuses to instrument it: `initialize_lines` (`Python/instrumentation.c`)
+# excludes `END_ASYNC_FOR`, `END_FOR`, `END_SEND`, `RESUME` and `POP_ITER` from
+# `INSTRUMENTED_LINE`.  Without that exclusion pyre reported one extra `line`
+# event at the `def` line on every call: 104 events where CPython 3.14 and
+# pypy3 both report 103.
+#
+# The generator half is the other side of the same instruction.  A resumed
+# generator re-enters at a `RESUME` carrying the `yield` line, so instrumenting
+# it would report a line event for a line the frame is only passing back
+# through.  Both references agree on the whole resumed stream, so it is pinned
+# verbatim.
+#
+# The `f_lineno` assertion at the end is the guard rail on the fix.  A
+# not-yet-started frame answers `f_lineno` with its `def` line through
+# `offset2lineno(code, -1)`, and that is the correct answer for the getset
+# (`pyframe.py fget_f_lineno`) even though it is the wrong one for a line
+# event.  Suppressing the event by changing that shared helper instead would
+# break this, and `bench/synth/frame_inlined_callee_own_image_regression.py`
+# with it.
+import sys
+
+
+def record(thunk):
+    """Every event a tracer sees while `thunk` runs, as (event, name, lineno)."""
+    events = []
+
+    def tracer(frame, event, arg):
+        events.append((event, frame.f_code.co_name, frame.f_lineno))
+        return tracer
+
+    sys.settrace(tracer)
+    try:
+        thunk()
+    finally:
+        sys.settrace(None)
+    return events
+
+
+def offsets(events, func):
+    """`events` for `func`'s frames, with linenos relative to its `def`.
+
+    Relative so the expectations survive an edit above them.
+    """
+    first = func.__code__.co_firstlineno
+    name = func.__code__.co_name
+    return [
+        (event, lineno - first) for event, seen, lineno in events if seen == name
+    ]
+
+
+def work(n):                                              # +0
+    total = 0                                             # +1
+    for i in range(n):                                    # +2
+        total += i                                        # +3
+    return total                                          # +4
+
+
+def counting(n):                                          # +0
+    total = 0                                             # +1
+    for i in range(n):                                    # +2
+        total += i                                        # +3
+        yield total                                       # +4
+    return total                                          # +5
+
+
+def entering_a_function_emits_no_line_event_for_the_def_line():
+    got = offsets(record(lambda: work(2)), work)
+    assert got == [
+        ("call", 0),
+        ("line", 1),
+        ("line", 2),
+        ("line", 3),
+        ("line", 2),
+        ("line", 3),
+        ("line", 2),
+        ("line", 4),
+        ("return", 4),
+    ], got
+
+
+def resuming_a_generator_emits_no_line_event_for_the_yield_line():
+    def drain():
+        for _ in counting(3):
+            pass
+
+    got = offsets(record(drain), counting)
+    assert got == [
+        ("call", 0),
+        ("line", 1),
+        ("line", 2),
+        ("line", 3),
+        ("line", 4),
+        ("return", 4),
+        ("call", 4),
+        ("line", 2),
+        ("line", 3),
+        ("line", 4),
+        ("return", 4),
+        ("call", 4),
+        ("line", 2),
+        ("line", 3),
+        ("line", 4),
+        ("return", 4),
+        ("call", 4),
+        ("line", 2),
+        ("line", 5),
+        ("return", 5),
+    ], got
+
+
+def an_unstarted_generator_still_reports_its_def_line():
+    unstarted = counting(1)
+    assert unstarted.gi_frame.f_lineno == counting.__code__.co_firstlineno, (
+        unstarted.gi_frame.f_lineno
+    )
+    unstarted.close()
+
+
+entering_a_function_emits_no_line_event_for_the_def_line()
+resuming_a_generator_emits_no_line_event_for_the_yield_line()
+an_unstarted_generator_still_reports_its_def_line()
+print("OK")

--- a/pyre/extra_tests/parity_tests/settrace_line_events_skip_resume.py
+++ b/pyre/extra_tests/parity_tests/settrace_line_events_skip_resume.py
@@ -15,11 +15,39 @@
 # event at the `def` line on every call: 104 events where CPython 3.14 and
 # pypy3 both report 103.
 #
-# The generator half is the other side of the same instruction.  A resumed
+# The same function also excludes everything ahead of the first `RESUME`
+# (`i < code->_co_firsttraceable`), which is the rest of the frame prologue:
+# `COPY_FREE_VARS`, `MAKE_CELL`, and a generator's `RETURN_GENERATOR` /
+# `POP_TOP` pair.  That pair carries the `def` line too, so a traced generator
+# needs the prologue rule as well as the opcode one -- excluding `RESUME` alone
+# only moved the spurious event one instruction earlier, which is what the
+# generator case below caught.
+#
+# The generator half is also the other side of the `RESUME` rule.  A resumed
 # generator re-enters at a `RESUME` carrying the `yield` line, so instrumenting
 # it would report a line event for a line the frame is only passing back
 # through.  Both references agree on the whole resumed stream, so it is pinned
 # verbatim.
+#
+# IF YOU ARE COMPARING TOTAL EVENT COUNTS AGAINST CPYTHON, READ THIS FIRST.
+# A total taken over a long traced loop wanders, and not because of event
+# emission.  pyre's collection is deferred where CPython's is refcounted, so the
+# `_ModuleLock` weakref callback `cb` (`_get_module_lock`, `lib-python/3/
+# importlib/_bootstrap.py`) runs inside the traced region here while CPython had
+# already collected those locks at import time, long before the tracer existed.
+# Each such callback is a Python frame the tracer sees, so it contributes its
+# own `call` + lines + `return`, and HOW MANY fire depends on the collection
+# schedule -- two runs of one binary disagree.  Measured on
+# `work(n): total = 0; for i in range(n): total += i; return total` traced
+# whole: CPython 400005 at n=200000, which is exactly 2n+5, and pyre 400061 in
+# the same shape, the difference being 8 `cb` frames at 7 events each.
+#
+# The instrument that does work: run the same probe at a scale where no `cb`
+# fires -- n=50 and n=5000 both do -- and the total is exactly 2n+5, equal to
+# CPython, with no excess and no deficit.  That is what shows a change to event
+# emission removed exactly the events it meant to and no others; a large-n total
+# cannot show it.  (pypy3 reads 598732 on the same probe, so a bare
+# three-way total comparison says far less than it looks like it does.)
 #
 # The `f_lineno` assertion at the end is the guard rail on the fix.  A
 # not-yet-started frame answers `f_lineno` with its `def` line through
@@ -119,6 +147,29 @@ def resuming_a_generator_emits_no_line_event_for_the_yield_line():
     ], got
 
 
+def entering_a_closure_emits_no_line_event_for_the_def_line():
+    """The prologue ahead of `RESUME` is `COPY_FREE_VARS` / `MAKE_CELL` here.
+
+    Both are stamped with no line at all rather than the `def` line, so this
+    would pass even without the prologue rule -- it is here because the rule is
+    what makes that a fact about the prologue rather than a fact about how one
+    compiler happened to stamp two opcodes.
+    """
+    cell = 7
+
+    def reads_the_cell(n):                                # +0
+        total = cell                                      # +1
+        return total + n                                  # +2
+
+    got = offsets(record(lambda: reads_the_cell(1)), reads_the_cell)
+    assert got == [
+        ("call", 0),
+        ("line", 1),
+        ("line", 2),
+        ("return", 2),
+    ], got
+
+
 def an_unstarted_generator_still_reports_its_def_line():
     unstarted = counting(1)
     assert unstarted.gi_frame.f_lineno == counting.__code__.co_firstlineno, (
@@ -128,6 +179,7 @@ def an_unstarted_generator_still_reports_its_def_line():
 
 
 entering_a_function_emits_no_line_event_for_the_def_line()
+entering_a_closure_emits_no_line_event_for_the_def_line()
 resuming_a_generator_emits_no_line_event_for_the_yield_line()
 an_unstarted_generator_still_reports_its_def_line()
 print("OK")

--- a/pyre/extra_tests/parity_tests/traceback_lineno_sentinel.py
+++ b/pyre/extra_tests/parity_tests/traceback_lineno_sentinel.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins tb_lineno=-1 meaning "resolve from tb_lasti"; pypy3 answers -1 instead of the line
 # CPython-suite gap: `test_traceback` builds `TracebackType` objects, but every
 # one it builds passes a real line number.  A runtime that stored the fourth
 # argument and handed it straight back would pass the whole module.

--- a/pyre/extra_tests/parity_tests/utf8_check_untrusted_bytes.py
+++ b/pyre/extra_tests/parity_tests/utf8_check_untrusted_bytes.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins _json.scanstring indexed past the subject's length; pypy3 has no _json module
 # CPython-suite gap: no test feeds marshal/pickle a three-byte sequence that
 # holds no code point, and none indexes _json past the subject's length.
 # parity-tests reason: these reach pyre's own WTF-8 representation, where the

--- a/pyre/extra_tests/parity_tests/utf8_surrogatepass_error_span.py
+++ b/pyre/extra_tests/parity_tests/utf8_surrogatepass_error_span.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins the one-byte span of a surrogate the surrogatepass decoders cannot complete; pypy3 reports (0, 2)
 # CPython-suite gap: test_codeccallbacks exercises surrogatepass round-trips
 # but never the span of a truncated surrogate, and neither entry point is
 # compared against the other anywhere.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -17886,6 +17886,14 @@ pub(crate) fn property_descr_delete_impl(args: &[PyObjectRef]) -> PyResult {
 /// generator.py `frame_is_finished` plus Python 3.14's eager frame
 /// clearing on `close()`.  Dropping the generator's frame edge releases all
 /// suspended locals; an escaped `gi_frame` remains a valid, cleared frame.
+///
+/// Releasing them is where this ends.  A local left unreachable by the release
+/// is finalized on the collector's own schedule: the `rgc` FinalizerQueue hands
+/// it to `UserDelAction`, which runs `__del__` at a following dispatch
+/// boundary, which is where `generator.py descr_close` leaves it too.  Forcing
+/// a major collection here so that `__del__` lands before `close()` returns
+/// buys a refcount's promptness at the price of a whole-heap mark and sweep on
+/// every close of a live generator.
 pub(crate) unsafe fn generator_frame_is_finished(
     gen_obj: PyObjectRef,
     frame: &mut crate::pyframe::PyFrame,
@@ -18543,16 +18551,11 @@ pub(crate) fn generator_close_method(args: &[PyObjectRef]) -> PyResult {
             } else {
                 generator_frame_is_finished(gen_obj, &mut *frame_ptr);
             }
-            let ec = crate::call::getexecutioncontext()
-                as *mut crate::executioncontext::ExecutionContext;
-            if !ec.is_null() {
-                (*ec).finalize_explicitly_cleared_frame_references();
-            }
             return Ok(w_none());
         }
     }
     let err = PyError::new(PyErrorKind::GeneratorExit, String::new());
-    let mut result = match generator_send_ex(gen_obj, w_none(), Some(err), None, true) {
+    match generator_send_ex(gen_obj, w_none(), Some(err), None, true) {
         Ok(_) => {
             // Generator yielded after GeneratorExit — RuntimeError.
             // generator.py:267-268 `"%s ignored GeneratorExit" % self.KIND`.
@@ -18582,29 +18585,7 @@ pub(crate) fn generator_close_method(args: &[PyObjectRef]) -> PyResult {
             Ok(w_none())
         }
         Err(e) => Err(e),
-    };
-    unsafe {
-        if w_generator_get_frame(gen_obj).is_null() {
-            // The result has left the cleared generator frame but has not yet
-            // reached the caller's value stack. Publish it while the
-            // compatibility collection below determines which former frame
-            // locals became unreachable.
-            let _roots = pyre_object::gc_roots::push_roots();
-            match &mut result {
-                Ok(value) => *value = pyre_object::gc_roots::pin_root(*value),
-                Err(error) => {
-                    let w_exc = error.to_exc_object();
-                    let _ = pyre_object::gc_roots::pin_root(w_exc);
-                }
-            }
-            let ec = crate::call::getexecutioncontext()
-                as *mut crate::executioncontext::ExecutionContext;
-            if !ec.is_null() {
-                (*ec).finalize_explicitly_cleared_frame_references();
-            }
-        }
     }
-    result
 }
 
 /// PyPy `Coroutine.descr__await__`: return a distinct iterator wrapper rather

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -970,14 +970,17 @@ impl ExecutionContext {
     /// pypy/interpreter/executioncontext.py `run_trace_func`.
     ///
     /// ```python
+    /// @jit.unroll_safe
     /// def run_trace_func(self, frame):
-    ///     code = frame.pycode
-    ///     if frame.last_instr == -1:
-    ///         return     # don't trace the SETUP_ANNOTATIONS at the very start
+    ///     code = frame.getcode() # promote the frame!
     ///     d = frame.getorcreatedebug()
-    ///     if d.is_in_line_tracing or d.f_trace_lines:
-    ///         lastline = d.f_lineno
-    ///         lineno = code._get_lineno_for_pc_tracing(frame.last_instr)
+    ///     lastline = d.f_lineno
+    ///     lineno = frame.pycode._get_lineno_for_pc_tracing(frame.last_instr)
+    ///     if lineno != -1:
+    ///         d.f_lineno = lineno
+    ///     if d.f_trace_lines and lineno != -1:
+    ///         # when we are at a start of a line, or executing a backwards jump,
+    ///         # produce a line event
     ///         if lastline != lineno or frame.last_instr < d.instr_prev_plus_one:
     ///             self._trace(frame, 'line', self.space.w_None)
     ///     if d.f_trace_opcodes:
@@ -988,33 +991,32 @@ impl ExecutionContext {
         if frame.is_null() {
             return Ok(());
         }
-        // executioncontext.py:189-192:
-        //   d = frame.getorcreatedebug()
-        //   lastline = d.f_lineno
-        //   lineno = frame.pycode._get_lineno_for_pc_tracing(frame.last_instr)
-        //   d.f_lineno = lineno
         let last_instr = unsafe { (*frame).last_instr };
-        let lineno = unsafe { (*frame).get_last_lineno() };
-        let (lastline, want_line, want_opcode) = unsafe {
-            let d = (*frame).getorcreatedebug(lineno);
+        // `frame.pycode._get_lineno_for_pc_tracing(frame.last_instr)`, not
+        // `get_last_lineno`: the two differ on exactly the instructions that
+        // carry a line but may not start one, and `-1` is what both guards
+        // below are written against.
+        let lineno = unsafe { (*frame).get_lineno_for_pc_tracing() };
+        let (want_line, want_opcode) = unsafe {
+            // `getorcreatedebug()` with no argument: reached only through
+            // `bytecode_only_trace`, which returns early unless
+            // `get_w_f_trace()` is non-null, so the debug block already exists
+            // and the seed is dead.  Passing `lineno` here would seed
+            // `f_lineno` with the line whose novelty decides the event.
+            let d = (*frame).getorcreatedebug(-1);
             let lastline = d.f_lineno;
-            // executioncontext.py:192 d.f_lineno = lineno — PERSISTENT
-            // write so subsequent run_trace_func invocations see the
-            // current line (not the previous).
-            d.f_lineno = lineno;
-            // executioncontext.py:193-197:
-            //   if d.f_trace_lines and lineno != -1:
-            //       if lastline != lineno or frame.last_instr < d.instr_prev_plus_one:
-            //           self._trace(frame, 'line', self.space.w_None)
-            //   if d.f_trace_opcodes:
-            //       self._trace(frame, 'opcode', self.space.w_None)
+            // Persistent, so the next invocation compares against this line —
+            // but only for an instruction that names one, or a `RESUME` would
+            // overwrite the resumed line with the `def` line it carries.
+            if lineno != -1 {
+                d.f_lineno = lineno;
+            }
             let want_line = d.f_trace_lines
                 && lineno != -1
                 && (lastline != lineno || last_instr < d.instr_prev_plus_one);
             let want_opcode = d.f_trace_opcodes;
-            (lastline, want_line, want_opcode)
+            (want_line, want_opcode)
         };
-        let _ = lastline;
         // Reached only with a tracer installed, so the anchor is already on the
         // slow path; both events run Python and the sentinel write below is a
         // store into the frame's debug block.
@@ -1026,11 +1028,11 @@ impl ExecutionContext {
             self._trace(anchor.live(), "opcode", pyre_object::w_none(), None)?;
         }
         let frame = anchor.live();
-        // executioncontext.py:200 — record the next-PC sentinel so
-        // backward jumps re-fire the line event even when staying on
-        // the same source line.
+        // `d.instr_prev_plus_one = frame.last_instr + 1` — the next-PC sentinel
+        // that makes a backward jump re-fire the line event even when it stays
+        // on the same source line.
         unsafe {
-            (*frame).getorcreatedebug(lineno).instr_prev_plus_one = last_instr + 1;
+            (*frame).getorcreatedebug(-1).instr_prev_plus_one = last_instr + 1;
         }
         Ok(())
     }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -946,18 +946,6 @@ impl ExecutionContext {
         }
     }
 
-    /// gh-142766 compatibility for `generator.close()`: once the close path
-    /// clears a generator frame, an otherwise-dead local with `__del__` must
-    /// finalize before `close()` returns. Pyre's user instances are non-moving
-    /// old-generation objects, so a non-moving major pass stands in for those
-    /// synchronous releases. Keep this on the `generator.py:243` close path;
-    /// normal generator exhaustion follows deferred finalizer scheduling and
-    /// must not collect on every return.
-    pub fn finalize_explicitly_cleared_frame_references(&mut self) {
-        pyre_object::gc_hook::try_gc_collect_oldgen();
-        self._run_finalizers_now();
-    }
-
     /// Request the CPython refcount boundary associated with exposing a
     /// coroutine's frame.  The action runs before the next opcode, after the
     /// attribute receiver has left the value stack.

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -2935,29 +2935,57 @@ pub fn w_code_addr2line(code: &crate::CodeObject, addrq: i64) -> Option<usize> {
 /// Whether the instruction at `pc` may be reported to a trace function as the
 /// start of a source line.
 ///
-/// `initialize_lines` (`Python/instrumentation.c`) refuses `INSTRUMENTED_LINE`
-/// on five opcodes — `END_ASYNC_FOR`, `END_FOR`, `END_SEND`, `RESUME` and
-/// `POP_ITER`.  `END_FOR` and `END_SEND` are skipped by the `FOR_ITER` / `SEND`
-/// ahead of them; the other three carry no line event of their own even though
-/// the line table gives them a line.
+/// Both rules come from `initialize_lines` (`Python/instrumentation.c`), which
+/// decides once per code object which instructions carry `INSTRUMENTED_LINE`:
 ///
-/// [`crate::PyFrame::get_lineno_for_pc_tracing`] needs this because `RESUME`
-/// opens every function body carrying the `def` line (`emit_resume_for_scope`
-/// in the compiler's `codegen`), so reporting it as a line start puts a line
-/// event on the `def` line at every call.  `pycode.py` cannot answer this: its
-/// 3.11 bytecode has none of these five opcodes, and where its own
-/// `_get_lineno_for_pc_tracing` has no line for a pc it answers `-1`, which is
-/// the sentinel `run_trace_func` already guards on.
+/// * `if (i < code->_co_firsttraceable)` — the frame prologue starts no line.
+///   `_co_firsttraceable` is the index of the first `RESUME` (`init_code`,
+///   `Objects/codeobject.c`), so this covers everything the compiler inserts
+///   ahead of it: `COPY_FREE_VARS`, `MAKE_CELL`, and a generator's
+///   `RETURN_GENERATOR` / `POP_TOP` pair, which carries the `def` line.
+/// * a switch excluding `END_ASYNC_FOR`, `END_FOR`, `END_SEND`, `RESUME` and
+///   `POP_ITER`.  `END_FOR` and `END_SEND` are skipped by the `FOR_ITER` /
+///   `SEND` ahead of them; the other three carry no line event of their own
+///   even though the line table gives them a line.
+///
+/// [`crate::PyFrame::get_lineno_for_pc_tracing`] needs both because the
+/// prologue and the `RESUME` that ends it are all stamped with the `def` line,
+/// so tracing any of them as a line start puts a line event on the `def` line
+/// at every call.  `pycode.py` cannot answer this: its 3.11 bytecode has none
+/// of these opcodes, and where its own `_get_lineno_for_pc_tracing` has no line
+/// for a pc it answers `-1`, which is the sentinel `run_trace_func` already
+/// guards on.
 pub fn instruction_can_start_a_line(code: &crate::CodeObject, pc: usize) -> bool {
     use crate::bytecode::Instruction;
 
-    let Some(unit) = code.instructions.get(pc) else {
-        return true;
-    };
     // Specialization rewrites the opcode byte in place (`RESUME` becomes
-    // `RESUME_CHECK`), so ask about the family, not the specialized form.
-    let op = unit.op;
-    let op = op.to_base().unwrap_or(op);
+    // `RESUME_CHECK`), so every read below asks about the family.
+    fn base_op(code: &crate::CodeObject, index: usize) -> Option<Instruction> {
+        let op = code.instructions.get(index)?.op;
+        Some(op.to_base().unwrap_or(op))
+    }
+
+    // `i < code->_co_firsttraceable`, resolved by walking to the first
+    // `RESUME`.  This costs the prologue's length rather than `pc`, because it
+    // stops at that `RESUME` — which sits within a handful of units of the
+    // start for every code object the compiler produces.  A code object with no
+    // `RESUME` at all leaves `_co_firsttraceable` past the end and so traces no
+    // lines, which is what `init_code`'s scan does with one too.
+    let mut index = 0;
+    while index <= pc {
+        match base_op(code, index) {
+            Some(Instruction::Resume { .. }) => break,
+            Some(_) => index += 1,
+            None => return false,
+        }
+    }
+    if index > pc {
+        return false;
+    }
+
+    let Some(op) = base_op(code, pc) else {
+        return false;
+    };
     !matches!(
         op,
         Instruction::EndAsyncFor

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -2932,6 +2932,42 @@ pub fn w_code_addr2line(code: &crate::CodeObject, addrq: i64) -> Option<usize> {
         .map(|(start, _)| start.line.get())
 }
 
+/// Whether the instruction at `pc` may be reported to a trace function as the
+/// start of a source line.
+///
+/// `initialize_lines` (`Python/instrumentation.c`) refuses `INSTRUMENTED_LINE`
+/// on five opcodes — `END_ASYNC_FOR`, `END_FOR`, `END_SEND`, `RESUME` and
+/// `POP_ITER`.  `END_FOR` and `END_SEND` are skipped by the `FOR_ITER` / `SEND`
+/// ahead of them; the other three carry no line event of their own even though
+/// the line table gives them a line.
+///
+/// [`crate::PyFrame::get_lineno_for_pc_tracing`] needs this because `RESUME`
+/// opens every function body carrying the `def` line (`emit_resume_for_scope`
+/// in the compiler's `codegen`), so reporting it as a line start puts a line
+/// event on the `def` line at every call.  `pycode.py` cannot answer this: its
+/// 3.11 bytecode has none of these five opcodes, and where its own
+/// `_get_lineno_for_pc_tracing` has no line for a pc it answers `-1`, which is
+/// the sentinel `run_trace_func` already guards on.
+pub fn instruction_can_start_a_line(code: &crate::CodeObject, pc: usize) -> bool {
+    use crate::bytecode::Instruction;
+
+    let Some(unit) = code.instructions.get(pc) else {
+        return true;
+    };
+    // Specialization rewrites the opcode byte in place (`RESUME` becomes
+    // `RESUME_CHECK`), so ask about the family, not the specialized form.
+    let op = unit.op;
+    let op = op.to_base().unwrap_or(op);
+    !matches!(
+        op,
+        Instruction::EndAsyncFor
+            | Instruction::EndFor
+            | Instruction::EndSend
+            | Instruction::PopIter
+            | Instruction::Resume { .. }
+    )
+}
+
 /// Registry mapping a raw CodeObject pointer (`PyCode.code_ptr`) to the
 /// live, globals-stamped `PyCode` wrapper. Populated where a frame stamps
 /// the wrapper's `w_globals` — the only point both the raw pointer and the

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3978,11 +3978,6 @@ impl PyFrame {
                         &mut *frame_anchor.live(),
                     )
                 };
-                let ec = crate::call::getexecutioncontext()
-                    as *mut crate::executioncontext::ExecutionContext;
-                if !ec.is_null() {
-                    unsafe { (*ec).finalize_explicitly_cleared_frame_references() };
-                }
                 return Ok(());
             }
             // pyframe.py:815-820: a dead `f_generator_wref` simply skips the

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1774,6 +1774,10 @@ impl Default for FrameDebugData {
 /// Byte offset of `w_locals` in `FrameDebugData`.
 pub const FRAME_DEBUG_DATA_W_LOCALS_OFFSET: usize = std::mem::offset_of!(FrameDebugData, w_locals);
 
+/// Byte offset of `w_extra_locals` in `FrameDebugData`.
+pub const FRAME_DEBUG_DATA_W_EXTRA_LOCALS_OFFSET: usize =
+    std::mem::offset_of!(FrameDebugData, w_extra_locals);
+
 /// Allocated size of a `FrameDebugData`.
 pub const FRAME_DEBUG_DATA_SIZE: usize = std::mem::size_of::<FrameDebugData>();
 
@@ -2863,7 +2867,7 @@ impl PyFrame {
     }
 
     #[inline]
-    fn get_extra_locals(&self) -> PyObjectRef {
+    pub fn get_extra_locals(&self) -> PyObjectRef {
         self.getdebug_data()
             .map_or(pyre_object::PY_NULL, |data| data.w_extra_locals)
     }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -4148,6 +4148,32 @@ impl PyFrame {
         }
     }
 
+    /// pycode.py `_get_lineno_for_pc_tracing(frame.last_instr)` — the line a
+    /// trace function attributes to the instruction the frame is executing, or
+    /// `-1` when that instruction cannot start a line.
+    ///
+    /// Upstream decodes the line table into one entry per code unit and leaves
+    /// `-1` in every entry the decode never reached, so `-1` is the "no line
+    /// here" answer `run_trace_func` guards on twice.  pyre's table covers
+    /// every instruction, so the sentinel comes from the opcode instead:
+    /// [`crate::pycode::instruction_can_start_a_line`].
+    ///
+    /// Separate from [`Self::get_last_lineno`], which answers the *frame's*
+    /// line for `f_lineno` and reports `co_firstlineno` for a frame that has
+    /// not started.  That is the right answer for the getset — a not-yet-run
+    /// generator's `f_lineno` is its `def` line — and the wrong one for a line
+    /// event, which is why this is a second entry point rather than an edit to
+    /// that one.
+    #[inline]
+    pub fn get_lineno_for_pc_tracing(&self) -> isize {
+        if self.last_instr < 0
+            || !crate::pycode::instruction_can_start_a_line(self.code(), self.last_instr as usize)
+        {
+            return -1;
+        }
+        self.get_last_lineno()
+    }
+
     /// pyframe.py fget_f_lineno — the line currently executing.
     ///
     /// `None` when an untraced frame's line table yields no entry; the

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8129,6 +8129,12 @@ fn init_frame_type(ns: PyObjectRef) {
     // `dis` / `code.co_positions()` consumers that do `f_lasti // 2`
     // recover the right instruction — the same adaptation `tb_lasti`
     // uses (`typedef.rs` tb_lasti getter).
+    //
+    // A negative `last_instr` is the not-yet-started sentinel, not a
+    // coordinate, so it is handed out as-is: `PyFrame_GetLasti` scales only
+    // the non-negative case (`lasti < 0 ? -1 : lasti * sizeof(_Py_CODEUNIT)`)
+    // and `pyframe.py fget_f_lasti` returns `last_instr` unscaled. Scaling it
+    // reported `-2`, a value neither reference produces.
     let lasti_getter = make_builtin_function_with_arity(
         "f_lasti",
         |args| {
@@ -8136,9 +8142,12 @@ fn init_frame_type(ns: PyObjectRef) {
             if f.is_null() {
                 return Ok(pyre_object::w_none());
             }
-            Ok(pyre_object::w_int_new(
-                unsafe { &*f }.fget_f_lasti() as i64 * 2,
-            ))
+            let lasti = unsafe { &*f }.fget_f_lasti() as i64;
+            Ok(pyre_object::w_int_new(if lasti < 0 {
+                -1
+            } else {
+                lasti * 2
+            }))
         },
         2,
     );

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2447,15 +2447,26 @@ static FRAME_DEBUG_DATA_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::
         pyre_interpreter::pyframe::FRAME_DEBUG_DATA_SIZE,
         0,
         0,
-        &[(
-            "w_locals",
-            pyre_interpreter::pyframe::FRAME_DEBUG_DATA_W_LOCALS_OFFSET,
-            std::mem::size_of::<usize>(),
-            Type::Ref,
-            false,
-            false,
-            false,
-        )],
+        &[
+            (
+                "w_locals",
+                pyre_interpreter::pyframe::FRAME_DEBUG_DATA_W_LOCALS_OFFSET,
+                std::mem::size_of::<usize>(),
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "w_extra_locals",
+                pyre_interpreter::pyframe::FRAME_DEBUG_DATA_W_EXTRA_LOCALS_OFFSET,
+                std::mem::size_of::<usize>(),
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+        ],
         "FrameDebugData",
         "pyframe::FrameDebugData",
     )
@@ -4149,6 +4160,15 @@ pub fn rbigint_pair_item1_descr() -> DescrRef {
 /// reads at the head of `fast2locals` (pyframe.py).
 pub fn frame_debug_data_w_locals_descr() -> DescrRef {
     field_descr_from_group(&FRAME_DEBUG_DATA_DESCR_GROUP, 0)
+}
+
+/// `FrameDebugData.w_extra_locals` — the dict `framelocalsproxy_setitem`
+/// allocates for a key that names no writable fast local.  `fast2locals` never
+/// touches it, but `frame_locals_proxy_snapshot` copies it into every mapping
+/// `locals()` / `vars()` / `dir()` hand back, so a fold that rebuilds that
+/// mapping from fastlocals alone has to see it.
+pub fn frame_debug_data_w_extra_locals_descr() -> DescrRef {
+    field_descr_from_group(&FRAME_DEBUG_DATA_DESCR_GROUP, 1)
 }
 
 /// `len(bytes)` returns the byte count.  `bytesobject.py` reads it as

--- a/pyre/pyre-jit-trace/src/frame_layout.rs
+++ b/pyre/pyre-jit-trace/src/frame_layout.rs
@@ -98,25 +98,44 @@ const _: () = {
     assert!(PYFRAME_W_GLOBALS_OFFSET == pyre_interpreter::pyframe::PYFRAME_W_GLOBALS_OFFSET);
 };
 
-/// virtualizable.py `clear_vable_ptr` — C-ABI helper that writes TOKEN_NONE
-/// (0) to a PyFrame's `vable_token`.
+/// virtualizable.py `clear_vable_ptr` — C-ABI helper behind the `COND_CALL`
+/// `emit_force_virtualizable` records, built out of `clear_vable_token`:
+/// force the virtualizable when the token is set, then leave TOKEN_NONE.
 ///
-/// Upstream builds that helper out of `clear_vable_token`, which FORCES the
-/// virtualizable when the token is set and only then asserts TOKEN_NONE.  This
-/// one only zeroes, so the citation covers the write and not the force.  The
-/// gap is unreachable rather than latent: `execute_assembler` clears the token
-/// before `func_execute_token`, and the `COND_CALL` `emit_force_virtualizable`
-/// records is gated on the token being non-null — measured over `pyre/bench`
-/// plus `pyre/bench/synth` (462 fixtures) the call was recorded 183 times and
-/// invoked 0 times.  Porting the force is deliberately left undone on that
-/// evidence.
+/// `force_now` has two arms and only one of them is a bare write.  On
+/// TOKEN_TRACING_RESCALL it clears the marker, which is what the post-residual
+/// probe reads as "the callee escaped".  On a machine-frame token it runs
+/// `ResumeGuardForcedDescr.force_now`, writing the compiled activation's
+/// registers back into the frame — a step this helper used to skip, on the
+/// evidence that the call was recorded 183 times and invoked 0 times over 462
+/// fixtures.  That measurement no longer holds: the call fires on the corpus
+/// today, so the arm is reachable and the frame it hands back has to carry the
+/// compiled values.  `force_frame` selects whichever arm the token names.
+///
+/// The trailing write is a backstop, not the port: `force_pyframe` declines a
+/// token the metainterp does not recognise as armed, and zeroing it anyway is
+/// what this helper did unconditionally before.  Upstream asserts there
+/// instead; a panic reached from compiled code is the worse failure.
 unsafe extern "C" fn pyre_clear_vable_token(obj_ptr: i64) {
     unsafe {
         let ptr = obj_ptr as *mut u8;
-        if !ptr.is_null() {
-            // `vable_token` is `usize` (pointer-width: 4 on wasm32). Writing
-            // 8 bytes would clobber the following field.
-            let token_ptr = ptr.add(PYFRAME_VABLE_TOKEN_OFFSET) as *mut usize;
+        if ptr.is_null() {
+            return;
+        }
+        // `vable_token` is `usize` (pointer-width: 4 on wasm32). Writing
+        // 8 bytes would clobber the following field.
+        let token_ptr = ptr.add(PYFRAME_VABLE_TOKEN_OFFSET) as *mut usize;
+        if *token_ptr == 0 {
+            return;
+        }
+        pyre_interpreter::executioncontext::force_frame(
+            ptr as *mut pyre_interpreter::PyFrame,
+        );
+        if *token_ptr != 0 {
+            if majit_metainterp::majit_log_enabled() {
+                let token = *token_ptr;
+                eprintln!("[jit][clear-vable] force left token=0x{token:x} frame={ptr:p}");
+            }
             *token_ptr = 0;
         }
     }

--- a/pyre/pyre-jit-trace/src/frame_layout.rs
+++ b/pyre/pyre-jit-trace/src/frame_layout.rs
@@ -128,9 +128,7 @@ unsafe extern "C" fn pyre_clear_vable_token(obj_ptr: i64) {
         if *token_ptr == 0 {
             return;
         }
-        pyre_interpreter::executioncontext::force_frame(
-            ptr as *mut pyre_interpreter::PyFrame,
-        );
+        pyre_interpreter::executioncontext::force_frame(ptr as *mut pyre_interpreter::PyFrame);
         if *token_ptr != 0 {
             if majit_metainterp::majit_log_enabled() {
                 let token = *token_ptr;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -286,7 +286,7 @@ pub fn skip_python_trivia_forward(code: &pyre_interpreter::CodeObject, mut py_pc
 /// `parent` marks the second row as a split of the first so the reader does not
 /// sum them.
 #[rustfmt::skip]
-pub const SPEC_FOLD_ROWS: [(&str, &str, &str); 69] = [
+pub const SPEC_FOLD_ROWS: [(&str, &str, &str); 70] = [
     // (label, site, parent)
     ("truth_int",                 "residual_call", "-"),
     ("truth_bool",                "residual_call", "-"),
@@ -357,6 +357,7 @@ pub const SPEC_FOLD_ROWS: [(&str, &str, &str); 69] = [
     ("builtin_divmod_long_int",   "specialize",    "builtin_divmod"),
     ("zip_two_tuple_iters",       "specialize",    "for_iter_next"),
     ("instance_next",             "residual_call", "-"),
+    ("frame_lasti",               "specialize",    "load_attr"),
 ];
 
 const SPEC_FOLD_COUNT: usize = SPEC_FOLD_ROWS.len();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1461,6 +1461,23 @@ pub(crate) fn emit_walker_loop_callee_call_assembler<Sym: WalkSym>(
     // when the CALL_ASSEMBLER forces the virtual. Uses `SetfieldGc` + a real
     // `FieldDescr` (the same field-set the builder uses), so
     // `optimize_setfield_gc` records it into the virtual's `vinfo.fields`.
+    //
+    // MEASURED INCONSISTENCY, no failing case known.  That seeded depth is the
+    // right one only for a header whose static operand-stack depth is zero,
+    // which is what "empty stack at the while-header" above assumes.  A `for`
+    // header is entered with the iterator on the stack.  Census over the 447
+    // `pyre/bench/synth` fixtures (a `stack_depth_at(target_pc)` probe on this
+    // arm, dynasm, 84131dc4da8): 36 emits reach here, 25 at depth 0 and 11 at
+    // depth 1 — all 11 in `str_search_index_bounds.py`, all with `ForIter` at
+    // `target_pc`, pinning `last_instr` beside an operand height one slot short
+    // of what that header executes against.  That fixture still passes its own
+    // asserts and its output comparison, and pinning the analysis depth here
+    // instead changed nothing on it, so no wrong answer is attributable to this
+    // and no gate is warranted yet.  Written down because a measured inconsistency nobody
+    // recorded is one somebody re-derives: see
+    // `pyre/bench/synth/_pending/loop_callee_for_header_resume.py` for the same
+    // "resume pc pinned without its operand height" shape that DOES produce a
+    // wrong answer, through a different writer.
     let last_instr = ctx.trace_ctx.const_int(target_pc as i64 - 1);
     let last_instr_descr = crate::descr::pyframe_next_instr_descr();
     let last_instr_idx = last_instr_descr.index();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2365,11 +2365,35 @@ fn walker_ec_enter(
 /// The profile-hook half (`if self.profilefunc: self._trace(frame,
 /// 'leaveframe', w_exitvalue)`) stays with the interpreter's own
 /// [`pyre_interpreter::PyExecutionContext::leave`].  Omitting it here does not
-/// lose a leave event, because `is_being_profiled` is a portal-driver GREEN
-/// (`interp_jit.py greens = ['next_instr', 'is_being_profiled', 'pycode']`):
-/// a trace is keyed on it, so one recorded with profiling off is only ever
-/// entered with profiling off, and turning profiling on selects a different
-/// green key rather than reusing this trace.
+/// lose a PROFILE leave event, because `is_being_profiled` is a portal-driver
+/// GREEN (`interp_jit.py greens = ['next_instr', 'is_being_profiled',
+/// 'pycode']`): a trace is keyed on it, so one recorded with profiling off is
+/// only ever entered with profiling off, and turning profiling on selects a
+/// different green key rather than reusing this trace.
+///
+/// ⛔ That argument is sound for profiling and for nothing else, and it is not
+/// licence to omit another hook here.  TRACING has no green, so no key change
+/// separates a traced re-entry from an untraced one; and the events an inlined
+/// callee owes a tracer are `call_trace` / `return_trace`, which upstream runs
+/// from `pyframe.py execute_frame` rather than from `enter` / `leave`.
+/// Whatever inlines the callee inlines those `ec.gettrace()` reads with it, so
+/// upstream's trace carries a guard on them and a tracer installed later cannot
+/// be missed.  This walker inlines neither, so an inlined callee reports
+/// nothing for as long as the loop stays compiled.
+///
+/// Two things currently keep that from being observable, and neither is the
+/// green: `eval_with_jit_inner` (`pyre-jit/src/eval.rs`) routes any frame for
+/// which `frame_tracing_active` holds to `execute_frame_plain`, so a hooked
+/// frame never reaches the portal at all — measured, a profiled loop reads
+/// `loops_compiled = 0`, `loops_aborted = 0`; and a tracer armed mid-run on an
+/// already-compiled frame fails the portal frame's own `debugdata` guard
+/// (`record_portal_debugdata_guard`), which stops that frame running compiled
+/// at all.  Neither is a correctness argument for this omission.  The first is
+/// a compilation gate: the moment it is narrowed so a hooked frame can compile,
+/// this becomes a reporting bug for the profile half.  The second is about the
+/// CALLER's frame: it says nothing about a callee whose own `call_trace` /
+/// `return_trace` this walker declines to inline, and it does not fire at all
+/// for a global tracer that leaves the caller's `f_trace` unset.
 ///
 /// The escape branch runs in both worlds.  Concretely it marks the caller and
 /// forces the leaving vref; in the trace it records the force as

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2532,6 +2532,13 @@ pub enum DispatchError {
     /// `pyjitpl.py get_procedure_token(greenboxes)` always receives
     /// concrete greens at a reached merge point.
     JitMergePointGreenKeyUnresolved { pc: usize },
+    /// The portal frame reached its merge point with a tracer already armed
+    /// (`debugdata.w_f_trace` non-NULL). `dispatch_bytecode`'s jitted arm
+    /// (pyopcode.py) answers that state with `ec.bytecode_only_trace(self)`
+    /// on every opcode; the walker has no route to record that call, so a
+    /// trace taken here would compile a loop that owes `line` events and
+    /// cannot fire them. Decline and leave the frame to the interpreter.
+    PortalFrameTracerArmed { pc: usize },
     /// `loop_header/i` or `jit_merge_point/iIRFIRF` could not resolve its
     /// jdindex operand to a concrete Int. The assembler encodes the jdindex as a
     /// populated int-constant-pool slot (`assembler.rs loop_header`:
@@ -2711,6 +2718,7 @@ impl DispatchError {
                 "LastExceptionWithoutActiveException"
             }
             Self::JitMergePointGreenKeyUnresolved { .. } => "JitMergePointGreenKeyUnresolved",
+            Self::PortalFrameTracerArmed { .. } => "PortalFrameTracerArmed",
             Self::LoopHeaderJdIndexUnresolved { .. } => "LoopHeaderJdIndexUnresolved",
             Self::SubWalkClosedLoop { .. } => "SubWalkClosedLoop",
             Self::BranchGuardKeptStackUnsupported { .. } => "BranchGuardKeptStackUnsupported",
@@ -2790,6 +2798,7 @@ impl DispatchError {
             | Self::GuardResumeCoordinateUnavailable { pc, .. }
             | Self::LastExceptionWithoutActiveException { pc, .. }
             | Self::JitMergePointGreenKeyUnresolved { pc, .. }
+            | Self::PortalFrameTracerArmed { pc, .. }
             | Self::LoopHeaderJdIndexUnresolved { pc, .. }
             | Self::SubWalkClosedLoop { pc, .. }
             | Self::BranchGuardKeptStackUnsupported { pc, .. }
@@ -10149,6 +10158,132 @@ fn fused_goto_if_not_int<Sym: WalkSym>(
     goto_if_not_branch_on(code, op, ctx, condbox, switchcase, target)
 }
 
+/// The portal frame's `debugdata` read from `PyFrame.dispatch_bytecode`'s
+/// `we_are_jitted()` arm (pyopcode.py):
+///
+/// ```text
+/// while True:
+///     assert next_instr & 1 == 0
+///     self.last_instr = intmask(next_instr)
+///     if jit.we_are_jitted():
+///         _d = self.debugdata
+///         if ec.space.reverse_debugging or (
+///                 _d is not None and _d.w_f_trace is not None):
+///             ec.bytecode_only_trace(self)
+///             next_instr = r_uint(self.last_instr)
+/// ```
+///
+/// `debugdata` is one of `PyFrame._virtualizable_` (interp_jit.py), so the
+/// read resolves against `virtualizable_boxes` and folds to the value the
+/// frame carried when the trace started.  A trace that folds a virtualizable
+/// field without validating it compiles a loop that cannot observe that field
+/// changing.  Upstream validates it, and its own optimized trace says how:
+/// `patch_new_loop_to_load_virtualizable_fields` (compile.py) loads every
+/// virtualizable field off the frame at loop entry, and virtual-state matching
+/// then pins the one the body was specialized on —
+///
+/// ```text
+/// +280: p5 = getfield_gc_r(p0, descr=<FieldP ...PyFrame.inst_debugdata 16>)
+/// +316: label(p0, p1, i2, p3, i4, p5, ...)
+/// +352: guard_isnull(p5, ...)
+/// ```
+///
+/// so arming `f_trace` on a running frame fails that guard and the interpreter
+/// resumes firing `line` events.  pyre loads the field at entry the same way
+/// but pins nothing, so the compiled loop ran the whole tail blind.
+///
+/// Recorded at the portal merge point — the trace's counterpart of the top of
+/// `dispatch_bytecode`'s loop.  The read is registered with the heapcache, so
+/// a run of merge points with no intervening call collapses to one read and
+/// one guard.  A call does not collapse, so a loop body carrying residual
+/// calls records one pair per call-free window — measured, three for a loop
+/// whose body makes one residual Python call.  Upstream carries exactly one
+/// because its guard comes from virtual-state matching at the label rather
+/// than from the recorded read; matching that would mean pinning the vable
+/// field in the virtual state, which pyre does not do for `debugdata` today.
+fn record_portal_debugdata_guard<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+) -> Result<(), DispatchError> {
+    // An inlined callee's own header is not the portal loop the compiled code
+    // re-enters, and the sub-walk's boxes describe the callee frame.
+    if ctx.fbw_mode.inline_subwalk {
+        return Ok(());
+    }
+    let Some(info) = ctx.trace_ctx.virtualizable_info().cloned() else {
+        return Ok(());
+    };
+    let Some(field_index) = info.static_field_index_by_name("debugdata") else {
+        return Ok(());
+    };
+    let Some(frame_box) = ctx.trace_ctx.standard_virtualizable_box() else {
+        return Ok(());
+    };
+    // The value the trace is folding, read from `virtualizable_boxes` rather
+    // than from the live frame: the guard exists to validate exactly that fold,
+    // so a live frame that has since diverged from it must still be guarded
+    // against, not silently agreed with.
+    let Some((_, Value::Ref(debugdata))) = ctx.trace_ctx.virtualizable_entry_at(field_index) else {
+        return Ok(());
+    };
+    if debugdata.as_usize() != 0 {
+        let debugdata = debugdata.as_usize() as *const pyre_interpreter::pyframe::FrameDebugData;
+        // `_d is not None and _d.w_f_trace is not None`.  Upstream answers
+        // that state with `ec.bytecode_only_trace(self)` on every opcode and
+        // records the call, so its bridge out of the failed `guard_isnull`
+        // keeps firing events from compiled code.  pyre's walker has no route
+        // to record that call, so anything it compiles here runs the tail with
+        // no way to fire the events the frame is owed.  Decline and leave the
+        // frame to the interpreter, which fires them.
+        //
+        // Every walk that reaches a merge point in this state is declined, not
+        // only one that has recorded nothing yet.  The walk that would
+        // otherwise lose the tail is the BRIDGE out of the failed guard, and
+        // that one resumes inside the loop body: it reaches its merge point
+        // with the body already recorded, so a decline conditioned on an empty
+        // recording never fires for it — measured, 401 of 1999 `line` events
+        // on `settrace_f_trace_armed_mid_loop`, the rest swallowed by a bridge
+        // that compiled at the 400th guard failure.
+        //
+        // A frame whose `debugdata` already exists records no guard below, so
+        // it looks like a residual half of this gap.  Measured, it is not.
+        // Reading `f_lineno`, `f_locals`, `locals()`, `f_lasti` or `f_back`
+        // does not create `debugdata` at all — among the paths tried only a
+        // write to one of the `f_trace*` attributes did — and a frame that HAS
+        // it still reports its whole tail: 99999 of 99999 `call` events at a
+        // 100000 tail, against 1042 with this decline disabled.  The exit is
+        // `GuardNotForced` (`settrace` forces every frame) where the guard
+        // below would otherwise be it, and this decline then refuses to
+        // recompile, so the frame stays interpreted either way.  The decline
+        // is what covers that state, and it is reached: `PYRE_FBW_DEBUG_ABORT`
+        // names four `PortalFrameTracerArmed` aborts in that arm, the same
+        // count as when `debugdata` starts null.
+        if !unsafe { (*debugdata).w_f_trace }.is_null() {
+            return Err(DispatchError::PortalFrameTracerArmed { pc: op_pc });
+        }
+        return Ok(());
+    }
+    let descr = info.static_field_struct_descr(field_index);
+    let descr_index = descr.index();
+    if ctx
+        .trace_ctx
+        .heapcache_getfield_cached(frame_box, descr_index)
+        .is_some()
+    {
+        return Ok(());
+    }
+    let read = ctx
+        .trace_ctx
+        .record_op_with_descr(OpCode::GetfieldGcR, &[frame_box], descr);
+    ctx.trace_ctx
+        .heapcache_getfield_now_known(frame_box, descr_index, read);
+    ctx.trace_ctx
+        .set_opref_concrete(read, Value::Ref(majit_ir::GcRef(0)));
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardIsnull, &[read])?;
+    ctx.trace_ctx.heap_cache_mut().nullity_now_known(read, false);
+    Ok(())
+}
+
 /// RPython `pyjitpl.py _establish_nullity(box, orgpc)` — the shared body
 /// behind `opimpl_goto_if_not_ptr_nonzero` / `opimpl_goto_if_not_ptr_iszero`:
 ///
@@ -11713,6 +11848,10 @@ fn handle<Sym: WalkSym>(
             // Copy the walk green before any mutable session borrow in this
             // handler; key construction and greenboxes must use one value.
             let is_being_profiled = ctx.session.borrow().is_being_profiled;
+            // `dispatch_bytecode`'s `we_are_jitted()` arm reads the portal
+            // frame's `debugdata` at the top of every opcode (pyopcode.py).
+            // The merge point is the trace's counterpart of that loop top.
+            record_portal_debugdata_guard(ctx, op.pc)?;
             // RPython parity: `opimpl_jit_merge_point` →
             // `reached_loop_header`. pyre's retired
             // trait mirror was `close_loop_args`.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -10280,7 +10280,9 @@ fn record_portal_debugdata_guard<Sym: WalkSym>(
     ctx.trace_ctx
         .set_opref_concrete(read, Value::Ref(majit_ir::GcRef(0)));
     walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardIsnull, &[read])?;
-    ctx.trace_ctx.heap_cache_mut().nullity_now_known(read, false);
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .nullity_now_known(read, false);
     Ok(())
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -4288,7 +4288,10 @@ pub(crate) fn walker_vable_and_vrefs_before_residual_call(ctx: &mut TraceCtx) {
 /// when this walk is not inside an inline callee.  A callee `jit_pc` has no
 /// meaning in the outer jitcode's py_pc tables, so every consumer that writes
 /// a pc onto the callee's frame has to go through the callee's own metadata.
-fn inline_callee_py_pc<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>, jit_pc: usize) -> Option<u32> {
+pub(super) fn inline_callee_py_pc<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    jit_pc: usize,
+) -> Option<u32> {
     let consts = ctx.inline_callee_consts?;
     let pjc = crate::state::pyjitcode_for_jitcode_index(consts.jitcode_index)?;
     Some(crate::py_coord::containing_py_pc_for_jitcode_pc(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -4368,9 +4368,20 @@ pub(super) fn maybe_publish_inline_callee_last_instr_concrete<Sym: WalkSym>(
     // `fbw_publish_exit_last_instr` does for the portal frame; otherwise a
     // residual observer during this walk records the constructor's `-1`
     // sentinel and bakes that answer into the compiled trace.  Inline frames
-    // are owned by this walk (and may already have escaped), so this is the
-    // authentic per-opcode PyFrame transition, not a speculative write to the
-    // portal frame that must be rolled back for replay.
+    // are owned by this walk (and may already have escaped), so this write is
+    // not speculative — unlike the portal frame's, it is never rolled back for
+    // replay.
+    //
+    // It is still only half a coordinate.  A reader takes its next opcode from
+    // `last_instr + 1` and its operand stack from `valuestackdepth`; the walk
+    // keeps the operand stack symbolic, so `valuestackdepth` stays at whatever
+    // the frame was built with while `last_instr` advances per opcode.
+    // `capture_frame_scalars` and `correct_resume_vsd` move the two words
+    // together; this site moves one, and nothing downstream re-pairs them.
+    // Pairing it here with the forward analysis's depth at `callee_py_pc + 1`
+    // was measured and does not fix
+    // `bench/synth/_pending/loop_callee_for_header_resume.py`, so the split is
+    // a recorded gap rather than that fixture's cause.
     if let Some(ConcreteValue::Ref(frame_ptr)) = ctx.concrete_registers_r.get(frame_reg).copied() {
         if !frame_ptr.is_null() {
             unsafe {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2627,6 +2627,136 @@ fn walker_write_back_standard_frame_locals<Sym: WalkSym>(
         .vable_array_region_write_back(frame_op, 0, &slots)
 }
 
+/// The frame box and EXECUTING Python pc of a frame receiver the walk owns,
+/// or `None` for one it does not.
+///
+/// `pyjitpl.py` keeps one MIFrame per inlined call and each carries its own
+/// coordinate, so this resolves per level exactly as
+/// [`LiveLastInstrGuard::enter`] retargets its publication: inside an inline
+/// sub-walk the callee's own jitcode pc resolved through the callee's
+/// metadata, at the portal the walk's `vstack_cur_pypc`.
+///
+/// The virtualizable boxes are NOT a source here, which a probe against the
+/// residual's own answers settled rather than an argument: at three portal
+/// sites the boxes' `last_instr` entry read 110/165/185 against executing
+/// pcs of 115/170/197, and at an inlined-callee site it read 232 -- the
+/// caller's CALL boundary -- against the callee's own 22.  They describe the
+/// PORTAL frame and carry whichever of the field's two conventions their last
+/// writer left.
+///
+/// A receiver that is not this level's own frame declines, which is what keeps
+/// a suspended generator's frame, a traceback node's frame and a caller's
+/// frame read from inside a callee on the residual getter that reads the heap.
+fn walker_frame_executing_py_pc<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    concrete_obj: pyre_object::PyObjectRef,
+    op_pc: usize,
+) -> Option<(OpRef, u32)> {
+    let inline_frame = current_inline_concrete_frame();
+    if inline_frame != 0 {
+        let shadow = ctx.callee_shadow.as_ref()?;
+        if shadow.concrete_frame != inline_frame
+            || shadow.frame_box == OpRef::NONE
+            || concrete_obj as usize != inline_frame
+        {
+            return None;
+        }
+        return Some((
+            shadow.frame_box,
+            residual_call::inline_callee_py_pc(ctx, op_pc)?,
+        ));
+    }
+    // An inline sub-walk with no concrete callee frame has no level-local
+    // coordinate to answer with: `vstack_cur_pypc` is the outer walk's mirror
+    // and a sub-walk never advances it.
+    if ctx.fbw_mode.inline_subwalk || !ctx.vstack_valid {
+        return None;
+    }
+    let vable_box = ctx.trace_ctx.standard_virtualizable_box()?;
+    if ctx.trace_ctx.standard_virtualizable_ptr() != Some(concrete_obj as usize) {
+        return None;
+    }
+    Some((vable_box, ctx.vstack_cur_pypc))
+}
+
+/// `pyframe.py fget_f_lasti` — `return self.last_instr`, loop-free and
+/// carrying no hint, so `policy.py look_inside_graph` admits it, `jtransform.py
+/// rewrite_op_jit_force_virtualizable` deletes the force
+/// `rvirtualizable.py hook_access_field` injects, and `pyjitpl.py
+/// opimpl_getfield_vable_i` answers the field out of `virtualizable_boxes`.
+/// The box there is a `ConstInt`, because the only writer is the bytecode
+/// dispatch's `_opimpl_setfield_vable` of the pc it is about to run — which is
+/// why upstream answers the read for less than a loop that does not perform
+/// it.  Nothing forces, so the generic reader's residual boundary buys nothing
+/// and this emits the same constant.
+///
+/// The constant owes two coordinates the residual boundary hides.
+/// `last_instr` is an instruction-unit index here while the getset reports the
+/// byte offset (`typedef.rs` returns `fget_f_lasti() * 2`), so the emission
+/// carries the factor; without it a `dis` consumer's `f_lasti // 2` lands on
+/// half the instruction index.  And the field has two writers on two
+/// conventions — `flush_walk_end_state_to_frame` stores the resume coordinate
+/// `pc - 1`, `LiveLastInstrGuard::enter_frame` stores the executing pc
+/// unshifted — and a getter owes the executing one, which is what
+/// [`walker_frame_executing_py_pc`] resolves.
+///
+/// `last_instr` travels as half of a pair — `capture_frame_scalars` records it
+/// beside `valuestackdepth` because the interpreter derives its next opcode
+/// from `last_instr + 1` and reads the operand stack at `valuestackdepth`, so
+/// a consumer restoring one of them owes the other.  This emission assumes
+/// nothing about `valuestackdepth` and is entitled to: it is a pure read that
+/// never reaches the frame at all.  The pc it answers with comes from the
+/// walk's own trace-time coordinate, not from the frame's field, so no state
+/// is captured, none is restored, and the pair is never split.  Writing
+/// `last_instr` from here would incur that obligation, which is the second
+/// reason this path never does.
+///
+/// The receiver is pinned two ways.  Its class, its `w_class` and the frame
+/// type's `version_tag` are guarded, so rebinding `f_lasti` on the type
+/// revokes the loop instead of the constant outliving the getset that produced
+/// it.  And when the receiver arrives in a box other than the frame's own —
+/// a local the loop hoisted the frame into — a `ptr_eq` against that box is
+/// guarded, so a later entry holding a different frame side-exits to the
+/// residual rather than reading this trace's coordinate.
+fn try_walker_specialize_frame_lasti<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    obj: OpRef,
+    concrete_obj: pyre_object::PyObjectRef,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    let Some((frame_box, py_pc)) = walker_frame_executing_py_pc(ctx, concrete_obj, op_pc) else {
+        return Ok(None);
+    };
+    let w_type = pyre_interpreter::typedef::gettypeobject(&pyre_interpreter::pyframe::FRAME_TYPE);
+    let version_tag = unsafe { pyre_object::typeobject::w_type_get_version_tag(w_type) };
+    if version_tag == 0 || unsafe { (*concrete_obj).w_class } != w_type {
+        return Ok(None);
+    }
+    walker_guard_exception_attr_slot(ctx, op_pc, obj, concrete_obj, w_type, version_tag)?;
+    if obj != frame_box {
+        let is_own_frame = ctx.trace_ctx.record_op(OpCode::PtrEq, &[obj, frame_box]);
+        ctx.trace_ctx
+            .set_opref_concrete(is_own_frame, majit_ir::Value::Int(1));
+        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[is_own_frame])?;
+    }
+    let value = py_pc as i64 * 2;
+    let raw = ctx.trace_ctx.const_int(value);
+    let boxed = walker_box_int(ctx, op_pc, raw, value)?;
+    // `walker_box_int` emits a heap `NewWithVtable`, so the recording-time
+    // shadow has to be a heap `W_IntObject` too — the same pairing
+    // [`box_int_concrete`] makes for a residual whose result arrived tagged.
+    ctx.trace_ctx.set_opref_concrete(
+        boxed,
+        majit_ir::Value::Ref(majit_ir::GcRef(
+            pyre_object::intobject::w_int_new_unique(value) as usize,
+        )),
+    );
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
+    Ok(Some(()))
+}
+
 /// `mapdict.py LOAD_ATTR_caching` full-body-walker fast path for a
 /// plain (non-method) instance attribute.  When the concrete receiver is a
 /// monomorphic instance whose attribute resolves to a boxed plain storage slot
@@ -2741,6 +2871,15 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
             majit_ir::Value::Ref(majit_ir::GcRef(concrete_proxy as usize)),
         );
         write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, proxy)?;
+        return Ok(Some(()));
+    }
+    if name == "f_lasti"
+        && unsafe { (*concrete_obj).ob_type } == &pyre_interpreter::pyframe::FRAME_TYPE
+        && spec_gate("frame_lasti", || {
+            try_walker_specialize_frame_lasti(ctx, op_pc, obj, concrete_obj, dst, dst_bank)
+        })?
+        .is_some()
+    {
         return Ok(Some(()));
     }
     // `mapdict.py` resolution, returning the fold ingredients (the
@@ -9377,7 +9516,7 @@ fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
 /// frame is always the portal, so the residual always escapes.  Removing it
 /// removes the force with it, and nothing has to replace it: `last_instr` is
 /// published onto the portal frame at every may-force boundary
-/// (`LiveLastInstrGuard`).  Generic `f_lasti` / `f_lineno` readers retain that
+/// (`LiveLastInstrGuard`).  A generic `f_lineno` reader still retains that
 /// residual boundary.  Upstream does not: `pyframe.py fget_f_lasti` and
 /// `fget_f_lineno` are loop-free and carry no hint, so `policy.py
 /// look_inside_graph` admits them, `jtransform.py
@@ -9385,17 +9524,18 @@ fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
 /// `pyjitpl.py opimpl_getfield_vable_i` answers `last_instr` out of
 /// `virtualizable_boxes`.  Measured over a 200k-iteration read against a
 /// same-shape loop that does not read the frame: pypy3 answers `f_lasti`
-/// faster than that control loop -- the trace constant -- and pyre is 53x it,
+/// faster than that control loop -- the trace constant -- and pyre was 53x it,
 /// while `f_lineno` keeps one non-forcing residual on both and pyre is 2.1x.
-/// Closing the gap is an optimization over a correct path, not a fix, and it
-/// owes two coordinates the boundary currently hides.  `last_instr` is an
-/// instruction-unit index here and the app-level getter reports it doubled
-/// (`typedef.rs`, matching `location.py offset2lineno`'s `stopat // 2` on the
-/// byte offset upstream stores), so an emission at the app level owes the
-/// factor.  And the field has two writers on two conventions:
-/// `flush_walk_end_state_to_frame` writes `resume_py_pc - 1` while
-/// `LiveLastInstrGuard::enter_frame` writes the executing pc unshifted, and a
-/// getter owes the executing one.
+/// [`try_walker_specialize_frame_lasti`] closes the `f_lasti` half by emitting
+/// the constant, leaving `f_lineno` the open one.  Closing either is an
+/// optimization over a correct path, not a fix, and it owes two coordinates
+/// the boundary hides.  `last_instr` is an instruction-unit index here and the
+/// app-level getter reports it doubled (`typedef.rs`, matching `location.py
+/// offset2lineno`'s `stopat // 2` on the byte offset upstream stores), so an
+/// emission at the app level owes the factor.  And the field has two writers
+/// on two conventions: `flush_walk_end_state_to_frame` writes
+/// `resume_py_pc - 1` while `LiveLastInstrGuard::enter_frame` writes the
+/// executing pc unshifted, and a getter owes the executing one.
 /// An exact optimized-frame `f_locals` read is specialized
 /// below instead: `pyframe.py fast2locals` is `@jit.unroll_safe`, so upstream
 /// traces through it and reads the virtualizable boxes rather than forcing.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -8847,6 +8847,22 @@ pub(crate) fn try_walker_specialize_builtin_locals<Sym: WalkSym>(
     if !std::ptr::eq(w_locals, frame_ref.get_w_locals()) {
         return Ok(None);
     }
+    // `f_extra_locals` is the OTHER half of what the residual reports.  A
+    // proxy write whose key names no writable fast local lands there
+    // (`framelocalsproxy_setitem`) and sets NEITHER `w_locals` nor a slot, and
+    // `frame_locals_proxy_snapshot` copies it in ahead of the fastlocals — so
+    // the mapping this fold rebuilds from slots alone would silently drop the
+    // key.  Decline while the frame carries any, read through the same shadow
+    // payload for the same reason `w_locals` is, and pin the null direction
+    // with a guard below so a write mid-loop side-exits instead.
+    let w_extra_locals = if shadow_debugdata.is_null() {
+        pyre_object::PY_NULL
+    } else {
+        unsafe { (*shadow_debugdata).w_extra_locals }
+    };
+    if !w_extra_locals.is_null() || !frame_ref.get_extra_locals().is_null() {
+        return Ok(None);
+    }
     // Two shapes, each pinned by a guard so the compiled loop side-exits when
     // the frame moves to the other one:
     //
@@ -9048,6 +9064,17 @@ pub(crate) fn try_walker_specialize_builtin_locals<Sym: WalkSym>(
             walker_emit_fold_guard_with_snapshot(ctx, op.pc, opcode, &[op_ref])?;
         }
         field_op = Some(op_ref);
+        // `d.w_extra_locals` — the gate above required it absent, so the loop
+        // side-exits the moment an `f_locals` write puts a non-fast key there
+        // rather than going on publishing a mapping without it.
+        let extra_op = crate::state::opimpl_getfield_gc_r(
+            ctx.trace_ctx,
+            debugdata_op,
+            crate::descr::frame_debug_data_w_extra_locals_descr(),
+        );
+        if !extra_op.is_constant() {
+            walker_emit_fold_guard_with_snapshot(ctx, op.pc, OpCode::GuardIsnull, &[extra_op])?;
+        }
     }
     let mut dict_op = match field_op.filter(|_| frame_owned) {
         Some(op_ref) => op_ref,
@@ -9230,8 +9257,9 @@ pub(crate) fn try_walker_specialize_builtin_locals<Sym: WalkSym>(
 /// inactive strict fold or unseeded frame register, a top frame that is not
 /// this level's own, a shadow describing another code object, a non-OPTIMIZED
 /// frame, cellvars / freevars / `CO_FAST_HIDDEN` slots, a frame wider than
-/// [`MAX_MODELLED_FASTLOCALS`], a frame that already carries a locals mapping,
-/// and a written slot the shadow cannot resolve back to a Ref.
+/// [`MAX_MODELLED_FASTLOCALS`], a frame that already carries a locals mapping
+/// or an `f_extra_locals` dict, and a written slot the shadow cannot resolve
+/// back to a Ref.
 fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op: &DecodedOp,
@@ -9295,6 +9323,17 @@ fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
     // this level's frame is rebuilt from scratch by the compiled trace when it
     // is built at all, so that shape has no counterpart here and declines.
     if !frame_ref.get_w_locals().is_null() {
+        return Ok(None);
+    }
+    // A null `w_locals` is NOT on its own a fresh mapping.  A proxy write
+    // whose key names no writable fast local goes to `f_extra_locals`
+    // (`framelocalsproxy_setitem`) and leaves `w_locals` null, and
+    // `frame_locals_proxy_snapshot` copies that dict into every mapping it
+    // hands back — so rebuilding from the shadow's slots alone would drop the
+    // key.  Read the LIVE callee frame, which is the only holder: this level's
+    // frame is built by the compiled trace, so its payload starts empty every
+    // iteration and only a residual on the recorded path can have filled it.
+    if !frame_ref.get_extra_locals().is_null() {
         return Ok(None);
     }
     // Collect each slot's shadow entry first, so a slot the shadow cannot

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -983,8 +983,7 @@ fn probe14_note_nursery(kind: &str, addr: usize, name: &str, jitcode_index: usiz
         let header = unsafe { (addr as *const usize).offset(-1).read_unaligned() };
         eprintln!(
             "[probe14] NURSERY ROOT #{n}: {kind} 0x{addr:x} header={header:#x} in jitcode \
-             {jitcode_index} {name:?} -- this area skips minor collections, so nothing \
-             keeps it alive"
+             {jitcode_index} {name:?}"
         );
     }
 }
@@ -1475,8 +1474,31 @@ fn walk_jitcode_constants_refs_in(
     }
     for (jitcode_index, jc) in sd.jitcodes.iter().enumerate() {
         let pool_len = jc.payload.jitcode.constants_r.len();
-        for (pool_slot, &slot) in jc.payload.jitcode.constants_r.iter().enumerate() {
-            let mut gcref = majit_ir::GcRef(slot as usize);
+        // The pool cell, not a copy of it.  Upstream reaches a run-time write
+        // into a prebuilt structure through the write barrier —
+        // `_remember_young_pointer_inlined` puts the written-to object on
+        // `old_objects_pointing_to_young`, and the remembered set is scanned at
+        // every minor, so the entry is kept and forwarded.  `constants_r` is a
+        // bare Rust `Vec<i64>` with no GC header to carry
+        // GCFLAG_TRACK_YOUNG_PTRS, so this walker IS pyre's remembered set for
+        // it, and owes both halves: drag the object out, and store back where
+        // it went.
+        //
+        // Sound for the same reason the `RefCell::as_ptr` read above is: the
+        // walk runs on the collecting thread with the owning mutator quiesced.
+        // `METAINTERP_SD` is thread-local while `Arc<RuntimeJitCode>` is not,
+        // so two threads' areas can present the same slot; the second visit
+        // reads an address that is no longer a nursery start and is a no-op.
+        //
+        // The pool also carries words that are not gcrefs at all — patched
+        // host-static addresses and pre-patch STR sentinels.  `drag_out_root`
+        // and `seed_major_root` reject them before any deref, which is what
+        // makes handing them the whole pool safe; a fast path that pre-filtered
+        // the slots would have to reproduce those gates.
+        let pool = jc.payload.jitcode.constants_r.as_ptr() as *mut i64;
+        for pool_slot in 0..pool_len {
+            let cell = unsafe { pool.add(pool_slot) };
+            let mut gcref = majit_ir::GcRef(unsafe { *cell } as usize);
             let before = gcref.0;
             if probe {
                 probe14_note_nursery(
@@ -1487,6 +1509,9 @@ fn walk_jitcode_constants_refs_in(
                 );
             }
             visitor(&mut gcref);
+            if gcref.0 != before {
+                unsafe { *cell = gcref.0 as i64 };
+            }
             if probe {
                 PROBE14_SLOTS.fetch_add(1, Relaxed);
                 if gcref.0 != before {
@@ -1503,7 +1528,7 @@ fn walk_jitcode_constants_refs_in(
                         // nothing here distinguishes a pool built by
                         // `add_const_r` from one built by `emit_const_r_bits`.
                         eprintln!(
-                            "[probe14] RELOCATION DISCARDED #{n}: constants_r slot \
+                            "[probe14] RELOCATION APPLIED #{n}: constants_r slot \
                              0x{before:x} -> 0x{:x} (walk {}, cum_slot {}, \
                              jitcode {}/{}, pool_slot {}/{})",
                             gcref.0,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1455,8 +1455,7 @@ pub static PROBE14_RELOCATED: std::sync::atomic::AtomicUsize =
 /// both halves' documented invariants actually assert.
 pub static PROBE14_CODE_SLOTS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
-pub static PROBE14_NURSERY: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+pub static PROBE14_NURSERY: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
 fn probe14_enabled() -> bool {
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
@@ -1501,12 +1500,7 @@ fn walk_jitcode_constants_refs_in(
             let mut gcref = majit_ir::GcRef(unsafe { *cell } as usize);
             let before = gcref.0;
             if probe {
-                probe14_note_nursery(
-                    "CONSTANT",
-                    before,
-                    jc.payload.jitcode.name(),
-                    jitcode_index,
-                );
+                probe14_note_nursery("CONSTANT", before, jc.payload.jitcode.name(), jitcode_index);
             }
             visitor(&mut gcref);
             if gcref.0 != before {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2119,7 +2119,8 @@ pub fn pcdep_trivia_at(jitcode_index: i32, jit_pc: i32) -> Option<Vec<(u8, u16, 
 /// physical frame's vsd must be corrected to that section's depth, else
 /// the interpreter resumes at the inner pc carrying the outer depth (an
 /// over-count that materializes a stray operand slot).  Returns `None`
-/// when the code or the liveness entry for `py_pc` is missing.
+/// when the code or the liveness entry for `py_pc` is missing, or when the
+/// forward analysis never reached `py_pc`.
 pub fn depth_based_vsd_for_wcode(w_code: usize, py_pc: usize) -> Option<usize> {
     if w_code == 0 {
         return None;
@@ -2133,11 +2134,17 @@ pub fn depth_based_vsd_for_wcode(w_code: usize, py_pc: usize) -> Option<usize> {
     }
     let code = unsafe { &*raw_code };
     let stack_base = code.varnames.len() + pyre_interpreter::pyframe::ncells(code);
-    let depth = crate::liveness::liveness_for(raw_code)
-        .depth_at_py_pc()
-        .get(py_pc)
-        .copied()?;
-    Some(stack_base + depth as usize)
+    // `depth_at_py_pc` collapses the forward pass's `usize::MAX` unreachable
+    // sentinel to `0`, which answers `stack_base` — a confidently empty operand
+    // stack — for a pc the analysis never reached.  `stack_depth_at` keeps the
+    // sentinel distinguishable; decline there instead, which every caller reads
+    // as "leave the frame's own `valuestackdepth` alone".  That table is one
+    // longer than the per-PC one, so keep the instruction-count bound.
+    if py_pc >= code.instructions.len() {
+        return None;
+    }
+    let depth = crate::liveness::liveness_for(raw_code).stack_depth_at(py_pc)?;
+    Some(stack_base + depth)
 }
 
 /// Inputs `setup_bridge_sym` needs to rebuild the slot-indexed semantic

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -927,13 +927,65 @@ fn walk_jitcode_code_roots_in(
     sd: &MetaInterpStaticData,
     visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
 ) {
-    for jc in sd.jitcodes.iter() {
+    use std::sync::atomic::Ordering::Relaxed;
+    let probe = probe14_enabled();
+    for (jitcode_index, jc) in sd.jitcodes.iter().enumerate() {
         let wrapper =
             pyre_interpreter::live_code_wrapper(jc.payload.code_ptr as *const ()) as usize;
-        if wrapper != 0 {
-            let mut root = majit_ir::GcRef(wrapper);
-            visitor(&mut root);
+        if wrapper == 0 {
+            continue;
         }
+        if probe {
+            PROBE14_CODE_SLOTS.fetch_add(1, Relaxed);
+            probe14_note_nursery(
+                "CODE WRAPPER",
+                wrapper,
+                jc.payload.jitcode.name(),
+                jitcode_index,
+            );
+        }
+        let mut root = majit_ir::GcRef(wrapper);
+        visitor(&mut root);
+        if probe && root.0 != wrapper {
+            let n = PROBE14_RELOCATED.fetch_add(1, Relaxed) + 1;
+            if n <= 20 {
+                eprintln!(
+                    "[probe14] RELOCATION DISCARDED #{n}: code wrapper 0x{wrapper:x} -> 0x{:x} \
+                     (jitcode {jitcode_index}/{}) -- the `code_ptr -> wrapper` registry still \
+                     holds the old address",
+                    root.0,
+                    sd.jitcodes.len(),
+                );
+            }
+        }
+    }
+}
+
+/// Report a root that sits in the nursery at walk time.
+///
+/// Both halves of this area document an invariant that forbids it — the code
+/// wrappers because `malloc_typed_stable` places them outside the nursery, the
+/// constants because with tagged ints disabled they are old-gen or immortal —
+/// and the minor-collection skip is justified by exactly that.  One counter-
+/// example refutes the skip.
+fn probe14_note_nursery(kind: &str, addr: usize, name: &str, jitcode_index: usize) {
+    use std::sync::atomic::Ordering::Relaxed;
+    if !majit_gc::gc_is_nursery_object(addr) {
+        return;
+    }
+    let n = PROBE14_NURSERY.fetch_add(1, Relaxed) + 1;
+    if n <= 20 {
+        // Address and header word only.  Reading the object's TYPE here is not
+        // sound: measured, on the run that aborts the slot is already invalid
+        // at walk time, and `type_name_of` returned a multi-kilobyte garbage
+        // string from unmapped bytes.  The header word says the same thing
+        // safely — a plausible type id means the corpse is still ahead.
+        let header = unsafe { (addr as *const usize).offset(-1).read_unaligned() };
+        eprintln!(
+            "[probe14] NURSERY ROOT #{n}: {kind} 0x{addr:x} header={header:#x} in jitcode \
+             {jitcode_index} {name:?} -- this area skips minor collections, so nothing \
+             keeps it alive"
+        );
     }
 }
 
@@ -1394,6 +1446,18 @@ pub static PROBE14_WALKS: std::sync::atomic::AtomicUsize = std::sync::atomic::At
 pub static PROBE14_SLOTS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 pub static PROBE14_RELOCATED: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
+/// Companion witnesses for the OTHER half of this area, the `code_ptr ->
+/// wrapper` roots, and for the invariant a relocation count cannot test.
+///
+/// The constants half skips minor collections outright, so a movable object in
+/// the pool is never offered for relocation there — it simply dies.  A
+/// relocation counter therefore cannot refute "no movable object is in this
+/// pool"; membership of the nursery at walk time can, and it is the property
+/// both halves' documented invariants actually assert.
+pub static PROBE14_CODE_SLOTS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+pub static PROBE14_NURSERY: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
 
 fn probe14_enabled() -> bool {
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
@@ -1414,6 +1478,14 @@ fn walk_jitcode_constants_refs_in(
         for (pool_slot, &slot) in jc.payload.jitcode.constants_r.iter().enumerate() {
             let mut gcref = majit_ir::GcRef(slot as usize);
             let before = gcref.0;
+            if probe {
+                probe14_note_nursery(
+                    "CONSTANT",
+                    before,
+                    jc.payload.jitcode.name(),
+                    jitcode_index,
+                );
+            }
             visitor(&mut gcref);
             if probe {
                 PROBE14_SLOTS.fetch_add(1, Relaxed);
@@ -1467,11 +1539,13 @@ fn walk_jitcode_constants_refs_in(
         // out.  Cover every early walk, then thin out.
         if walks <= 50 || walks % 50 == 0 {
             eprintln!(
-                "[probe14] ARMED walk={} slots_cumulative={} relocated_cumulative={} \
-                 jitcodes={}",
+                "[probe14] ARMED walk={} slots_cumulative={} code_slots_cumulative={} \
+                 relocated_cumulative={} nursery_cumulative={} jitcodes={}",
                 walks,
                 PROBE14_SLOTS.load(Relaxed),
+                PROBE14_CODE_SLOTS.load(Relaxed),
                 PROBE14_RELOCATED.load(Relaxed),
+                PROBE14_NURSERY.load(Relaxed),
                 sd.jitcodes.len(),
             );
         }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5595,28 +5595,23 @@ unsafe fn jitcode_constants_root_walker_area(
     data: *const (),
     visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
 ) {
-    // incminimark.py:355 `prebuilt_root_objects` parity.  The two populations
-    // owned by this area cannot point into the nursery:
+    // Every collection, minor included.  `jitcode.py JitCode` is an ordinary
+    // GC object upstream and `constants_r` an ordinary traced field of it, so
+    // the collector keeps and forwards its entries whatever generation they
+    // are in.  pyre owns the array in `Arc` memory, out of the object graph,
+    // so this walker IS that tracing and owes the same guarantee.
     //
-    // * PyCode wrappers are allocated through `try_gc_alloc_stable_raw`;
-    // * with tagged ints disabled, JitCode `constants_r` entries are either
-    //   stable old-generation int/float objects or immortal build-time
-    //   constants.
-    //
-    // A minor collection cannot reclaim either population, and there is no
-    // old-to-young edge here for its remembered-set pass to discover.  Walking
-    // every JitCode on every recursive CALL_ASSEMBLER nursery refill therefore
-    // only repeated `drag_out_root`'s non-nursery fast return.  Major marking
-    // still has to keep both populations alive, exactly like RPython's
-    // unconditional `prebuilt_root_objects` major scan.
-    // If tagged ints are enabled, codewriter normalization can materialize a
-    // moving `W_IntObject`; retain the conservative minor scan in that mode.
-    if !pyre_object::tagged_int::CAN_BE_TAGGED
-        && majit_gc::shadow_stack::extra_root_walk_kind()
-            == majit_gc::shadow_stack::ExtraRootWalkKind::Minor
-    {
-        return;
-    }
+    // This used to skip minor collections when tagged ints were disabled, on
+    // the claim that the entries were then "stable old-generation int/float
+    // objects or immortal build-time constants".  That claim is false, and its
+    // consequence was the fault it was meant to make impossible: upstream
+    // builds every jitcode at translation time, while pyre builds one per
+    // CodeObject at RUN time, so a trace's `Operand::ConstRef` reaches the pool
+    // straight off the heap.  Measured with `PYRE_PROBE14=1` on
+    // `_pending/exec_foreign_globals_gc_root.py`, one slot holds a NURSERY
+    // object on every walk; skipped by the minor pass, it was neither kept
+    // alive nor forwarded, and the next major seeded a corpse
+    // (`GC BUG: invalid type_id ... site=jitcode_constants`).
     unsafe { pyre_jit_trace::state::walk_jitcode_constants_refs_area(data, visitor) };
 }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4771,49 +4771,69 @@ fn register_thread_root_areas() {
         register(
             pyframe_root_walker_area,
             pyre_interpreter::eval::capture_pyframe_root_area(),
+            "pyframe",
         );
         register(
             pyre_object_root_walker_area,
             pyre_object::gc_roots::capture_shadow_stack_area(),
+            "pyre_object_shadow_stack",
+        );
+        // Two registrations over one `data`, not one walker over two
+        // populations: the areas are what the collector names when a root
+        // fails validation, and `code wrappers` and `constants_r` have
+        // separate invariants, separate producers and separate fixes.  Fused,
+        // the report named neither.
+        register(
+            jitcode_code_root_walker_area,
+            pyre_jit_trace::state::capture_jitcode_constants_root_area(),
+            "jitcode_code_wrappers",
         );
         register(
             jitcode_constants_root_walker_area,
             pyre_jit_trace::state::capture_jitcode_constants_root_area(),
+            "jitcode_constants",
         );
         register(
             fbw_store_journal_root_walker_area,
             pyre_jit_trace::jitcode_dispatch::capture_fbw_store_journal_root_area(),
+            "fbw_store_journal",
         );
         register(
             fbw_finish_concrete_root_walker_area,
             pyre_jit_trace::jitcode_dispatch::capture_fbw_finish_concrete_root_area(),
+            "fbw_finish_concrete",
         );
         register(
             walk_end_root_walker_area,
             pyre_jit_trace::trace::capture_walk_end_root_area(),
+            "walk_end",
         );
         register(
             mapdict_root_walker_area,
             pyre_interpreter::objspace::std::mapdict::capture_mapdict_root_area(),
+            "mapdict",
         );
         register(
             repr_active_root_walker_area,
             pyre_interpreter::display::capture_repr_active_area(),
+            "repr_active",
         );
         #[cfg(not(target_arch = "wasm32"))]
         register(
             signal_handler_root_walker_area,
             pyre_interpreter::module::signal::interp_signal::capture_signal_handler_root_area(),
+            "signal_handler",
         );
         register(
             jit_callee_frame_root_walker_area,
             crate::call_jit::capture_jit_callee_frame_root_area(),
+            "jit_callee_frame",
         );
-        register(rd_consts_root_walker_area, jit_driver);
-        register(partial_trace_root_walker_area, jit_driver);
-        register(active_trace_root_walker_area, jit_driver);
-        register(compile_snapshot_root_walker_area, jit_driver);
-        register(forced_virtuals_root_walker_area, jit_driver);
+        register(rd_consts_root_walker_area, jit_driver, "rd_consts");
+        register(partial_trace_root_walker_area, jit_driver, "partial_trace");
+        register(active_trace_root_walker_area, jit_driver, "active_trace");
+        register(compile_snapshot_root_walker_area, jit_driver, "compile_snapshot");
+        register(forced_virtuals_root_walker_area, jit_driver, "forced_virtuals");
         // The ephemeron half of the walker above, on the same `data` so the
         // prune reaches exactly the drivers the root walk reaches.
         majit_gc::shadow_stack::register_mutator_pruner(forced_virtuals_pruner_area, jit_driver);
@@ -5597,10 +5617,27 @@ unsafe fn jitcode_constants_root_walker_area(
     {
         return;
     }
-    unsafe {
-        pyre_jit_trace::state::walk_jitcode_code_roots_area(data, visitor);
-        pyre_jit_trace::state::walk_jitcode_constants_refs_area(data, visitor);
+    unsafe { pyre_jit_trace::state::walk_jitcode_constants_refs_area(data, visitor) };
+}
+
+/// The `code_ptr -> wrapper` half of the population the comment above
+/// describes, registered separately so a failing root names it.
+///
+/// Same minor-collection skip and the same justification for it: a wrapper is
+/// placed by `malloc_typed_stable`, so it is not a nursery object and a minor
+/// collection has nothing to do here.  `PYRE_PROBE14=1` tests that claim
+/// directly rather than by its relocation consequence.
+unsafe fn jitcode_code_root_walker_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    if !pyre_object::tagged_int::CAN_BE_TAGGED
+        && majit_gc::shadow_stack::extra_root_walk_kind()
+            == majit_gc::shadow_stack::ExtraRootWalkKind::Minor
+    {
+        return;
     }
+    unsafe { pyre_jit_trace::state::walk_jitcode_code_roots_area(data, visitor) };
 }
 
 unsafe fn fbw_store_journal_root_walker_area(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6512,10 +6512,13 @@ pub(crate) fn call_depth() -> u32 {
 #[majit_macros::dont_look_inside]
 pub fn make_green_key(code_ptr: *const (), pc: usize, is_being_profiled: bool) -> u64 {
     // Full `JitCell.get_uhash` over the pypyjit green tuple
-    // `[next_instr, is_being_profiled, pycode]` (warmstate.py:584-593),
-    // computed allocation-free. The caller supplies the same frame green used
-    // by the portal markers, so this and the typed marker-path key resolve to
-    // the same cell.
+    // `[next_instr, is_being_profiled, pycode]` (warmstate.py `JitCell`),
+    // computed allocation-free. The caller supplies the same live frame green
+    // the portal markers use -- `PyFrame.dispatch` (extended in `interp_jit.py`)
+    // hoists `self.get_is_being_profiled()` into a local and hands that one
+    // value to `jit_merge_point` -- so this and the typed marker-path key
+    // (`green_key_typed_from_pycode`) resolve to the same cell, and a profiled
+    // portal gets its own.
     majit_ir::pypyjit_greenkey_uhash(pc, is_being_profiled, code_ptr as u64)
 }
 
@@ -8892,6 +8895,20 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         // PyPy's `actionflag.decrement_ticker(decr_by)` invariant);
         // the `action_dispatcher` slow path itself is still a stub
         // pending the actionflag port.
+        //
+        // This is `dispatch_bytecode`'s NON-jitted arm only.  Its jitted arm
+        // (`if jit.we_are_jitted(): _d = self.debugdata; ...`) has no
+        // counterpart here because this body is never traced: pyre records
+        // from a per-CodeObject JitCode built by `jit/codewriter.rs` and walked
+        // by `pyre-jit-trace`'s `run_perfn_walk`, not from this Rust loop.  The
+        // port of that arm is `record_portal_debugdata_guard`
+        // (`pyre-jit-trace/src/jitcode_dispatch/mod.rs`), which runs at the
+        // portal merge point — the walker's counterpart of this loop's top.
+        // `we_are_jitted()` here would be a runtime thread-local set only while
+        // cranelift-compiled code is on the stack, not the folded compile-time
+        // constant upstream's translator sees, so splitting on it would strip
+        // the ticker from nested interpreted frames rather than from traced
+        // ones.
         let ec_ptr = unsafe { &*f }.execution_context as *mut PyExecutionContext;
         if !ec_ptr.is_null() {
             // Keep the JIT portal's concrete dispatch in lockstep with

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4832,8 +4832,16 @@ fn register_thread_root_areas() {
         register(rd_consts_root_walker_area, jit_driver, "rd_consts");
         register(partial_trace_root_walker_area, jit_driver, "partial_trace");
         register(active_trace_root_walker_area, jit_driver, "active_trace");
-        register(compile_snapshot_root_walker_area, jit_driver, "compile_snapshot");
-        register(forced_virtuals_root_walker_area, jit_driver, "forced_virtuals");
+        register(
+            compile_snapshot_root_walker_area,
+            jit_driver,
+            "compile_snapshot",
+        );
+        register(
+            forced_virtuals_root_walker_area,
+            jit_driver,
+            "forced_virtuals",
+        );
         // The ephemeron half of the walker above, on the same `data` so the
         // prune reaches exactly the drivers the root walk reaches.
         majit_gc::shadow_stack::register_mutator_pruner(forced_virtuals_pruner_area, jit_driver);

--- a/pyre/pyre-jit/src/jit/assembler.rs
+++ b/pyre/pyre-jit/src/jit/assembler.rs
@@ -2057,8 +2057,8 @@ fn expect_int_reg_or_pool(state: &mut AssemblyState, op: &Operand) -> u16 {
 /// pool.  A tagged small-int immediate would be baked verbatim as a
 /// `ConstPtr(GcRef(tagged))` that an in-trace `GuardClass` derefs as a heap
 /// `W_IntObject` (fannkuch `sign=-1`), and the pool is GC-root-walked
-/// (`walk_jitcode_constants_refs`) so a tagged slot is also forwarded as a
-/// moving-GC pointer.  Re-realize it as a distinct heap box so the pool holds
+/// (`walk_jitcode_constants_refs`, at every collection) so a tagged slot is
+/// also forwarded as a moving-GC pointer.  Re-realize it as a distinct heap box so the pool holds
 /// only real gcrefs — byte-identical to the flag-false bake (`w_int_new` of a
 /// fresh heap `W_IntObject`).  `w_int_new_unique` allocates regardless of
 /// `CAN_BE_TAGGED` (never re-tags).  Gated so flag-false emission is


### PR DESCRIPTION
Follow-ups on the virtualizable work, on top of #1451.

## The load-bearing change: the jitcode constant pool was an unrooted, unforwarded GC root area

`walk_jitcode_constants_refs_in` offered each `constants_r` slot to the visitor
and then **discarded the write-back**, and its area **skipped minor
collections**. Upstream has no equivalent hole because a run-time write into a
prebuilt structure goes through `_remember_young_pointer_inlined`, which appends
the written-to object to `old_objects_pointing_to_young` (scanned every minor).
`constants_r` is a bare `Vec<i64>` with no GC header, so it cannot carry
`GCFLAG_*` — **this walker is the remembered set**, and it owes both duties.

The fix roots the pool at every collection for the constants half only, and
writes the forwarded address back into the pool cell.

Measured, on the `_pending/exec_foreign_globals_gc_root.py` reproducer:

| arm | result |
|---|---|
| fixed | **0 aborts / 130 runs** |
| unfixed control | 3 aborts / 53 runs, across three binaries built the same day (p≈0.057) |

P(0 aborts in 130 runs \| unfixed) ≈ 0.05%. The probe signature after the fix is
the predicted one: `NURSERY ROOT` once at walk 1, `RELOCATION APPLIED` once,
`nursery_cumulative` frozen at 1 thereafter.

Two commits precede it as separable steps: naming each mutator extra root area
(so a `seed_major_root` failure names its area instead of the constant
`"extra_area"`), and splitting the single jitcode area into a code-wrapper half
and a constants half — only the latter needs the per-minor walk.

## Tracer line events

`RESUME` opens every function body carrying the `def` line, so reporting it as a
line start put a line event on the `def` line at every call.
`initialize_lines` (`Python/instrumentation.c`) refuses `INSTRUMENTED_LINE` on
five opcodes — `END_ASYNC_FOR`, `END_FOR`, `END_SEND`, `RESUME`, `POP_ITER`;
`instruction_can_start_a_line` now answers the same, and the whole prologue is
excluded rather than `RESUME` alone. The negative `f_lasti` sentinel is no
longer scaled.

## Virtualizable / frame coordinates

- The portal frame's `debugdata` is guarded at the merge point — the trace's
  counterpart of the `we_are_jitted()` read at the top of every opcode.
- The clear-vable helper forces the virtualizable before zeroing the token.
- `depth_based_vsd_for_wcode` declines on the unreachable-pc sentinel instead of
  collapsing it to "confidently empty stack".
- An owned frame's `f_lasti` folds to its executing pc.
- The locals folds are gated on the frame's extra locals.

## Test corrections

`test_vable_array_len.rs` now asserts the proxy-snapshot escape list rather than
only reporting it, and `test_unroll_safe_inventory.rs`'s claim that
`frame_locals_proxy_snapshot`'s body is unreached is corrected — it holds a
jitcode in the metadata artefact, and the abort population and baselines were
measured unchanged, so unreachability was never why.

Two `_pending/` reproducers are filed for defects that remain open and
main-owned (a for-header resume with the wrong stack depth; the exec-into-a-
plain-dict GC root, now fixed by this PR's constant-pool change).

## A fixture that had gone vacuous

Rebasing onto #1451 put this branch's `getframemodulename_hot_loop` change next
to main's new `require_jit` check, and the pair went red: *"the guard ran
interpreted (loops_compiled=0)"*.

The cause is this PR's own subject matter. `sys._getframemodulename` reads
`w_globals`, a redirected field, so every call forces the frame. This branch had
added a second depth-0 read **inside** the hot loop, making three calls per
iteration where main had two, and the third escape per iteration stopped the
loop compiling:

| fixture | `loops_compiled` | `abrt_escape` |
|---|---|---|
| main's | 1 | 5 |
| this branch's, before the fix | **0** | **10** |
| after the fix | 1 | 5 |

The depth-0 answer is invariant, so it is now read once outside the loop. The
anti-vacuity property is unchanged -- it lives in the depth-1 read from the
foreign-module callee, which is still in the loop, and a depth-ignoring
`_getframemodulename` answers `OTHER_MODULE` there and fails.

Worth recording that `require_jit` earned its place here: the guard had quietly
become an assertion about an interpreted run, and nothing else would have said so.

## Gate

`cargo test --all --features dynasm`: **8232 passed / 0 failed** across 168
suites. `pyre/check.py --backend dynasm`: 469 passed with the one failure above,
which is fixed in this branch and re-verified green through check.py's own
`require_jit` path.

One disclosure: the local gate ran before a final comment-only edit to
`pyre/pyre-jit/src/eval.rs` (correcting a citation to `PyFrame.dispatch` --
upstream's class is `__extend__(PyFrame)`, so `PyPyFrame` named nothing). The
source-fingerprint gate then correctly refused `--no-build`, and rather than
spend another full extract+build locally to re-verify a comment, CI gates the
final sha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wapwfqfqNe7kFcxQRx85P


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage-collection handling for generator cleanup and moving references.
  * Corrected frame inspection values, including `f_lasti`, line numbers, and local-variable mappings.
  * Improved tracing behavior across generators, loops, resumed frames, and active trace hooks.
  * Preserved virtualizable frame state during JIT transitions.

* **Tests**
  * Added regression coverage for frame inspection, tracing events, GC roots, and JIT behavior.
  * Expanded self-checking benchmarks and parity tests for interpreter compatibility.

* **Documentation**
  * Clarified profiling, frame metadata, virtualizable pointers, and platform behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->