### PR TITLE
Finish the default-features audit #1441 half-did, and fix what it found

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,8 +168,8 @@ md-5 = "0.10"
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
-blake2b_simd = { version = "1.0.4", default-features = false }
-blake2s_simd = { version = "1.0.4", default-features = false }
+blake2b_simd = { version = "1.0.4" }
+blake2s_simd = { version = "1.0.4" }
 scrypt = { version = "0.11", default-features = false }
 # zlib backend (pyre-native only): zlib-rs is a pure-Rust zlib port whose
 # DEFLATE output is byte-identical to the reference C zlib.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,9 @@ sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/Rust
 
 # majit JIT framework
 majit = { version = "0.0.2", path = "majit/majit" }
+# Defaults off although that manifest declares none: backend selection there is
+# mandatory, so a `default` added to it later would otherwise arrive through
+# every inheriting edge at once instead of being named per consumer.
 majit-metainterp = { version = "0.0.2", path = "majit/majit-metainterp", default-features = false }
 majit-ir = { version = "0.0.2", path = "majit/majit-ir" }
 majit-trace = { version = "0.0.2", path = "majit/majit-trace" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,13 @@ crc32fast = "1.4"
 
 # TLS backend (pyre-native only).  The interpreter sees opaque, non-inlined
 # entry points so rustls and its crypto provider stay outside Charon/LLBC.
-rustls = { version = "0.23.39", default-features = false, features = ["std", "tls12", "aws_lc_rs"] }
+# `prefer-post-quantum` is named because defaults are off, and it is the only
+# thing that puts X25519MLKEM768 first in `DEFAULT_KX_GROUPS` instead of last;
+# `_ssl` installs that provider process-wide and hands the list to every
+# handshake that does not call `set_ecdh_curve`, so last means a server
+# supporting both picks the classical group every time. `logging` stays off:
+# it only feeds the `log` crate, which nothing here consumes.
+rustls = { version = "0.23.39", default-features = false, features = ["std", "tls12", "aws_lc_rs", "prefer-post-quantum"] }
 rustls-webpki = { version = "0.103.5", default-features = false, features = ["alloc"] }
 rustls-pemfile = "2.2"
 x509-parser = "0.18"

--- a/majit/majit-backend-wasm/src/glue.rs
+++ b/majit/majit-backend-wasm/src/glue.rs
@@ -136,7 +136,13 @@ pub fn execute(func_id: u32, frame_ptr: u32) -> u32 {
     {
         imports::jit_execute_wasm(func_id, frame_ptr)
     }
-    #[cfg(not(feature = "web"))]
+    // `host-import`, not `not(feature = "web")`: `imports` has a third arm —
+    // neither binding — and the direct call below belongs to this one. The
+    // other functions here delegate to `imports::` on both of their arms, so
+    // that arm's stubs trap for them without being named; this one bypasses
+    // `imports` entirely, and under `not(web)` it would answer "no host
+    // binding" with a jump to an arbitrary address instead of the trap.
+    #[cfg(feature = "host-import")]
     unsafe {
         JIT_EXECUTE_COUNT.fetch_add(1, Ordering::Relaxed);
         // `func_id` is the shared-table (`__indirect_function_table`, exported as
@@ -152,6 +158,10 @@ pub fn execute(func_id: u32, frame_ptr: u32) -> u32 {
         }
         let trace: extern "C" fn(u32) -> u32 = core::mem::transmute(func_id as usize);
         trace(frame_ptr)
+    }
+    #[cfg(not(any(feature = "web", feature = "host-import")))]
+    unsafe {
+        imports::jit_execute_wasm(func_id, frame_ptr)
     }
 }
 


### PR DESCRIPTION
Completes the `default-features = false` audit that #1441 only did one axis of, and fixes what it found.

#1441 broke the wasm32 build because a workspace entry's `default-features = false` drops **every** default, and only `prepass` had been checked — `dynasm` came off with it. This branch runs that audit properly: all 47 manifests, all 21 `default-features = false` sites, both in-workspace and crates.io, each dropped default matched against what the consumer names back.

## Result

**No hole on any shipping path.** Both wasm build paths name a JIT host binding (`wasm-host` → `host-import`, `web` → `web`), `majit-backend-dynasm` is absent from the wasm32 *target* graph in both, and the tree's only two `cpu` setters (`blackhole.rs`, `pyre-jit-trace/src/trace.rs`) already carry `pyre_production_cpu`'s own predicate.

Four things did turn up.

### 1. `glue::execute` had one arm fewer than the module it calls

`majit-backend-wasm`'s `imports` module has three arms — `web`, `host-import`, and neither, the last a set of stubs that panic with *"no JIT host binding"*. `compile_module`, `replace_module` and `free` each split two ways on `web` but delegate to `imports::` on **both**, so the stubs are what a no-binding build reaches. `execute` did not: its `not(feature = "web")` arm bypassed `imports` entirely and transmuted `func_id` into a function pointer, so that configuration jumped to an arbitrary address where the arm's own comment promises a trap.

That configuration is compiled today — `extract-llbc.py`'s wasm32 layout pass reaches `majit-backend-wasm` through `majit-metainterp` with zero features. It is latent rather than live: the pass runs nothing, and every producer of a nonzero `func_handle` goes through `glue::compile_module*`, which panics correctly there.

The arm is now `host-import`, with `not(any(web, host-import))` delegating to `imports::jit_execute_wasm`. `web` + `host-import` is already a `compile_error!`, so neither configuration that names a binding moves — `git diff -w` shows only the cfg line, the comment and the new arm.

### 2. `blake2b_simd` / `blake2s_simd` were running the portable implementation on x86_64

Both entries carried `default-features = false` and named nothing back. The sole default of each is `std`, and in the crates' `guts.rs` that feature is what gates `is_x86_feature_detected!` for SSE4.1 and AVX2. The compile-time `#[cfg(target_feature = ...)]` arms beside it are off on the x86_64 baseline and nothing in this repo sets `-C target-cpu`, so `sse41_if_supported` and `avx2_if_supported` both returned `None` and `hashlib.blake2b` / `blake2s` selected `Platform::Portable`. Correct output, silently no SIMD. aarch64 was never affected — the crate has no NEON path.

Not load-bearing for wasm32, where the whole dispatch block sits behind `cfg(any(target_arch = "x86", target_arch = "x86_64"))`: `cargo check -p pyre-wasm --target wasm32-unknown-unknown --no-default-features --features wasm-host` is rc=0 with the feature on.

### 3. rustls was offering the post-quantum group last

`prefer-post-quantum` reorders `aws_lc_rs::DEFAULT_KX_GROUPS` and does nothing else: on, `X25519MLKEM768` is first; off, it sits after X25519, SECP256R1 and SECP384R1. `_ssl` installs that provider process-wide and only replaces `kx_groups` when Python calls `set_ecdh_curve`, so with the feature off every other handshake offered the hybrid group last — and a server supporting both picks the classical one. Offered, never negotiated, nothing logged.

`logging` stays off: it only enables the `log` crate, which nothing in this workspace consumes. The entry now records that rather than leaving the next reader to re-derive it.

### 4. `majit-metainterp`'s workspace entry now says why it turns defaults off

It drops nothing today — that manifest declares no `default`. Its effect is prospective: a `default` added later arrives through all 19 inheriting edges at once. The sibling `pyre-jit-trace` entry already carried its rationale; this one did not.

## Everything else, and why it is fine

| dep | dropped | verdict |
|---|---|---|
| `pyre-jit-trace` (workspace) | `dynasm`, `prepass` | `pyre-jit` forwards both |
| `pyre-wasm` → `pyre-jit` | `dynasm` | intended, no wasm32 dynasm build |
| `majit-backend-wasm` ×4 | `web` | binding chosen by `pyre-jit/wasm-web` \| `wasm-host` |
| `aheui-wasm` ×3 | `malachite-bigint` | 3-state model complete throughout |
| `flate2` | `rust_backend` | consumers name `features = ["zlib-rs"]` |
| `zlib-rs` | `std`, `c-allocator` | deliberate, documented |
| `lz4_flex` | `std`, `frame`, `checked-decode` | `safe-decode` subsumes `checked-decode`; the full-featured second entry is `[build-dependencies]`, a separate resolver universe |
| `wasm-encoder` | `std`, `component-model` | no_std, core modules only |
| `rustls-webpki` | `std` | `alloc` named |
| `scrypt` 0.11 | `simple`, `std` | both feed the `password-hash` façade; `_hashlib` uses only the raw KDF |

One thing worth knowing rather than changing: `cargo test --all --no-default-features --features dynasm,cpyext` keeps `pyre-jit-trace/prepass` only because `pyrex` depends on `pyre-jit` *without* `default-features = false`, so that edge still requests `pyre-jit/default`. Nothing the step names supplies it. Losing it would fail loudly — `pyre-jit-trace`'s build script emits `cargo::error` and exits 1 — so this is fragility, not risk.

### 5. Four parity fixtures were missing their `pypy-diverges` declaration

Not from this audit, but it is why the `pyre/check.py` job is red — and it is red the same way on main, so it had to be settled before anything here could be read.

`parity_tests/run.py`'s `# pyre-check: pypy-diverges:` gate is two-sided: a script carrying it must fail under PyPy, and a script without it must pass. Four fixtures landed on 2026-08-24 carrying no directive and failing under PyPy, which errors the lane. Same four names on main `62d2029eb21`, on this branch before these commits, and here — every one reading `cpython=OK dynasm=OK cranelift=OK pypy=FAIL`, so pyre passes all four and only the reference does not.

Reproduced against the PyPy the workflow provisions (7.3.23 / 3.11.15), which is also what is on this machine:

| fixture | pypy3 |
|---|---|
| `foriter_stopiteration_exception_event` | delivers `[('consume_generator', 'StopIteration')]` to the tracer; CPython delivers `[]` |
| `traceback_lineno_sentinel` | carries `-sys.maxsize-1` as the sentinel, so `tb_lineno` hands the `-1` back instead of resolving from `tb_lasti` — the file's own header already said so in prose |
| `utf8_check_untrusted_bytes` | has no `_json` (its accelerator is `_pypyjson`), so the import fails outright |
| `utf8_surrogatepass_error_span` | spans `(0, 2)` for an incomplete `ED A0` pair against the `(0, 1)` the fixture pins |

Collection parses all 145 scripts and rejects a reasonless directive; the corpus goes 19 → 23 declaring fixtures. All four still pass under CPython after the added first line shifted each file.

## Verification

- `cargo check -p majit-backend-wasm --target wasm32-unknown-unknown` rc=0 on **all three** glue arms
- `check.py --backend wasm`: 445 synthetic + 10, all pass
- `cargo test -p pyre-native --lib hash` 9/9 (incl. `blake2_parameter_block_matches_cpython_vectors`), `--lib ssl` 2/2
- `cargo check -p pyre-native` and `-p pyre-wasm --target wasm32-unknown-unknown` both rc=0

The wasm build used `PYRE_LLBC_SKIP_FINGERPRINT_CHECK=1` on a shared tree, so field offsets are unverified in that run.

Two instrument errors were made and caught while doing this, both of the "read a neighbouring object" kind. `cargo tree -e features | rg '<crate> feature'` reported **zero** features for `majit-backend-wasm` on the shipping wasm path — the subtree carrying them had been elided as `(*)`, and `-e features,no-build,no-dev -i <crate>` shows `host-import` was on the whole time. Separately, resolving a crates.io manifest by name alone read `scrypt` **0.12.0** when ours is 0.11 — the lock holds both — which inverted that row from a two-feature drop to "drops nothing". Every number above was re-taken with the corrected instruments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLkGH6Ee8dMtvQqFYU8k5Q
