### PR TITLE
gc: the ignore_finalizer hint, the copy/move write barriers, collect(gen), a --heapsize that reaches the collector, and a refused allocation told apart from a missing hook

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -1059,6 +1059,9 @@ pub struct MiniMarkGC {
     /// minor left at least one pinned object in the nursery.
     any_pinned_object_kept: bool,
     old_objects_pointing_to_pinned: Vec<usize>,
+    /// incminimark.py `updated_old_objects_pointing_to_pinned`: set whenever
+    /// the list above changes, and read by `writebarrier_before_copy` alone.
+    updated_old_objects_pointing_to_pinned: bool,
     /// incminimark.py:311,430 `max_number_of_pinned_objects` and
     /// `pinned_objects_in_nursery`.
     max_number_of_pinned_objects: usize,
@@ -1203,6 +1206,7 @@ impl MiniMarkGC {
             surviving_pinned_objects: Vec::new(),
             any_pinned_object_kept: false,
             old_objects_pointing_to_pinned: Vec::new(),
+            updated_old_objects_pointing_to_pinned: false,
             max_number_of_pinned_objects,
             pinned_objects_in_nursery: 0,
             nursery_objects_shadows: AddressMap::default(),
@@ -1268,6 +1272,14 @@ impl MiniMarkGC {
     ///
     /// `has_gc_ptrs_in_var` should be true for arrays containing GC pointers
     /// (i.e. `has_gcptr_in_varsize(typeid)` in RPython).
+    ///
+    /// Every caller today is a test, so no card array exists in a running
+    /// heap.  A production one arrives owing two things that the per-item
+    /// barrier does not supply, because a card records a *position*: a bulk
+    /// copy into it owes [`Self::writebarrier_before_copy`], and any move of
+    /// items within it — a list insert, remove, splice or reverse — owes
+    /// [`Self::writebarrier_before_move`], which is what generalizes the cards
+    /// back to "any item may be young" before the positions change.
     pub fn alloc_in_oldgen_with_cards(
         &mut self,
         type_id: u32,
@@ -3669,6 +3681,36 @@ impl MiniMarkGC {
         self.allocate_shadow(obj_addr)
     }
 
+    /// incminimark.py `move_out_of_nursery`: "called twice, it should return
+    /// the same shadow object, and not creating another shadow object.  As a
+    /// safety feature, when called on a non-nursery object, do nothing."
+    ///
+    /// `rgc.move_out_of_nursery`'s contract is what makes the eager copy sound:
+    /// "Only use for immutable objects!"  The shadow is filled once and the
+    /// nursery original may still be written to afterwards, so a mutable object
+    /// would have the two copies disagree until the next minor.
+    pub fn move_out_of_nursery(&mut self, obj_addr: usize) -> usize {
+        if !self.is_in_nursery(obj_addr) {
+            return obj_addr;
+        }
+        let shadow = self.find_shadow(obj_addr);
+        let hdr = unsafe { header_of(obj_addr) };
+        if unsafe { (*hdr).has_flag(flags::SHADOW_INITIALIZED) } {
+            return shadow;
+        }
+        unsafe { (*hdr).set_flag(flags::SHADOW_INITIALIZED) };
+        let type_id = unsafe { (*hdr).type_id() };
+        let payload_size = self.size_for_typeid(obj_addr, type_id, "move_out_of_nursery");
+        // Payload only: `allocate_shadow` already wrote the shadow's own header
+        // and the flags the old generation needs, and the copy must not undo
+        // them.  The next minor reads SHADOW_INITIALIZED and skips its own copy
+        // for the same reason.
+        unsafe {
+            std::ptr::copy_nonoverlapping(obj_addr as *const u8, shadow as *mut u8, payload_size)
+        };
+        shadow
+    }
+
     /// minimark.py `id_or_identityhash(gcobj)`.
     /// Return a stable address usable as identity hash.  For nursery
     /// objects, returns the shadow's address (which is where the object
@@ -3841,6 +3883,7 @@ impl MiniMarkGC {
                 let holder_hdr = unsafe { header_of(holder_addr) };
                 if unsafe { !(*holder_hdr).has_flag(flags::PINNED) } {
                     self.old_objects_pointing_to_pinned.push(holder_addr);
+                    self.updated_old_objects_pointing_to_pinned = true;
                     unsafe { (*holder_hdr).set_flag(flags::PINNED) };
                 }
             }
@@ -3946,11 +3989,21 @@ impl MiniMarkGC {
             // Remember VISITED and re-apply it after the copy.
             let shadow_was_visited =
                 unsafe { (*(shadow_hdr as *const GcHeader)).has_flag(flags::VISITED) };
+            // incminimark.py `_trace_drag_out`: `if (tid &
+            // GCFLAG_SHADOW_INITIALIZED) != 0: copy = False`.
+            // `move_out_of_nursery` has already filled this shadow, and its
+            // caller has been reading it ever since.  Copying again is not
+            // merely redundant: HAS_SHADOW and SHADOW_INITIALIZED "have no
+            // meaning in non-nursery objects", so the second copy is what would
+            // carry the nursery flag word onto an object that has the right one.
+            let shadow_initialized = unsafe { (*hdr_ptr).has_flag(flags::SHADOW_INITIALIZED) };
             // minimark.py:1518-1520: clear HAS_SHADOW before copy so the
             // flag does not propagate to the shadow object itself.
             unsafe { (*hdr_ptr).clear_flag(flags::HAS_SHADOW) };
-            unsafe {
-                std::ptr::copy_nonoverlapping(header_ptr as *const u8, shadow_hdr, total_size);
+            if !shadow_initialized {
+                unsafe {
+                    std::ptr::copy_nonoverlapping(header_ptr as *const u8, shadow_hdr, total_size);
+                }
             }
             if shadow_was_visited {
                 unsafe { (*(shadow_hdr as *mut GcHeader)).set_flag(flags::VISITED) };
@@ -5816,6 +5869,7 @@ impl MiniMarkGC {
         // VISITED set at this point; the oldgen sweep clears it later.
         self.old_objects_pointing_to_pinned
             .retain(|&obj_addr| unsafe { (*header_of(obj_addr)).has_flag(flags::VISITED) });
+        self.updated_old_objects_pointing_to_pinned = true;
         // incminimark.py:2528-2529 — VISITED still distinguishes survivors, so
         // this is where each mirror learns whether its object made it.
         if self.rrc.enabled {
@@ -6234,6 +6288,79 @@ impl MiniMarkGC {
         self.rrc_invoke_callback();
     }
 
+    /// incminimark.py `minor_collection_with_major_progress`: "Do a minor
+    /// collection.  Then, if the GC is enabled and there is already a major GC
+    /// in progress, run at least one major collection step.  If there is no
+    /// major GC but the threshold is reached, start a major GC."
+    ///
+    /// `do_collect_nursery` is that function with `force_enabled=False` baked
+    /// in, because its tail `run_major_progress_after_minor` reads
+    /// `self.enabled`.  The forced form lends the flag for the call, which is
+    /// what `force_enabled` means: an explicit collection makes major progress
+    /// even while automatic progress is switched off.
+    fn minor_collection_with_major_progress(&mut self, force_enabled: bool) {
+        if !force_enabled {
+            self.do_collect_nursery();
+            return;
+        }
+        let was_enabled = std::mem::replace(&mut self.enabled, true);
+        self.do_collect_nursery();
+        self.enabled = was_enabled;
+    }
+
+    /// incminimark.py `collect(gen=2)`: "Do a minor (gen=0), start a major
+    /// (gen=1), or do a full major (gen>=2) collection."
+    ///
+    /// The app-level `gc.collect(n)` does not reach this — `interp_gc.py
+    /// collect` unwraps its generation and then asks for a full collection
+    /// whatever it was.  This is the internal `rgc.collect(gen)` entry, whose
+    /// callers want a named amount of work rather than all of it.
+    pub fn do_collect(&mut self, generation: i64) {
+        if generation >= 2 {
+            // `minor_and_major_collection`, which ends with the same callback.
+            self.do_collect_full();
+            return;
+        }
+        let _stw = if crate::gc_sync::stw_required() {
+            Some(crate::gc_sync::quiesce_mutators())
+        } else {
+            None
+        };
+        if generation < 0 {
+            // "Dangerous! this makes no progress on the major GC cycle.  If
+            // called too often, the memory usage will keep increasing, because
+            // we'll never completely fill the nursery (and so never run
+            // anything about the major collection)."
+            let was_enabled = std::mem::replace(&mut self.enabled, false);
+            self.do_collect_nursery();
+            self.enabled = was_enabled;
+        } else {
+            self.minor_collection_with_major_progress(true);
+            // gen == 1 is gen == 0 plus "if no major collection is running,
+            // then it forces one to start now".
+            if generation == 1 && self.gc_state == GcState::Scanning {
+                self.major_collection_step();
+            }
+        }
+        self.rrc_invoke_callback();
+    }
+
+    /// incminimark.py `set_max_heap_size`.  `PYPY_GC_MAX` is read once at
+    /// startup; this is the same limit set from inside a running process, and
+    /// it pulls the pending major-collection thresholds down with it so a limit
+    /// lowered below them takes effect before the next major rather than after.
+    pub fn set_max_heap_size(&mut self, size: usize) {
+        self.max_heap_size = size as f64;
+        if self.max_heap_size > 0.0 {
+            if self.max_heap_size < self.next_major_collection_initial {
+                self.next_major_collection_initial = self.max_heap_size;
+            }
+            if self.max_heap_size < self.next_major_collection_threshold {
+                self.next_major_collection_threshold = self.max_heap_size;
+            }
+        }
+    }
+
     /// incminimark.py `collect_step`.
     pub fn collect_step(&mut self) -> crate::GcStepTransition {
         let _stw = if crate::gc_sync::stw_required() {
@@ -6510,6 +6637,140 @@ impl MiniMarkGC {
             // No cards: the JIT already passed the inline flag test, so use
             // the corresponding remember_young_pointer path.
             self.jit_remember_young_pointer(obj);
+        }
+    }
+
+    /// incminimark.py `writebarrier_before_copy`: "This has the same effect as
+    /// calling writebarrier over each element in dest copied from source,
+    /// except it might reset one of the following flags a bit too eagerly,
+    /// which means we'll have a bit more objects to track, but being on the
+    /// safe side."
+    ///
+    /// `false` is the answer "do it manually in ll_arraycopy" — the bulk form
+    /// cannot express this copy and the caller owes a per-item barrier.
+    /// Addresses are payload addresses, and `length` counts items.
+    pub fn writebarrier_before_copy(
+        &mut self,
+        source_addr: usize,
+        dest_addr: usize,
+        source_start: usize,
+        dest_start: usize,
+        length: usize,
+    ) -> bool {
+        // "obscuuuure" upstream, and for the same reason here: entering a
+        // parent on `old_objects_pointing_to_pinned` does not itself put that
+        // parent through the barrier, so the flags this function reads below
+        // are only trustworthy once every such entry has been.  Upstream notes
+        // there should only be a small number of them.
+        if self.updated_old_objects_pointing_to_pinned {
+            let mut parents = std::mem::take(&mut self.old_objects_pointing_to_pinned);
+            for &obj_addr in &parents {
+                self.do_write_barrier(GcRef(obj_addr));
+            }
+            parents.append(&mut self.old_objects_pointing_to_pinned);
+            self.old_objects_pointing_to_pinned = parents;
+            self.updated_old_objects_pointing_to_pinned = false;
+        }
+
+        let source_hdr = unsafe { header_of(source_addr) };
+        let dest_hdr = unsafe { header_of(dest_addr) };
+        // The fast path of the write barrier: a destination already on the
+        // remembered set needs nothing more.
+        if unsafe { !(*dest_hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
+            return true;
+        }
+
+        if self.config.card_page_indices > 0 && unsafe { (*source_hdr).has_flag(flags::HAS_CARDS) }
+        {
+            if unsafe { !(*source_hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
+                // "The source object may have random young pointers."
+                return false;
+            }
+            if unsafe { !(*dest_hdr).has_flag(flags::HAS_CARDS) } {
+                // "The dest object doesn't have cards.  Do it manually."
+                return false;
+            }
+            debug_assert!(
+                unsafe { !(*dest_hdr).has_flag(flags::NO_HEAP_PTRS) },
+                "prebuilt object with cards is not supported"
+            );
+            if unsafe { !(*source_hdr).has_flag(flags::CARDS_SET) } {
+                // The source has no young pointers at all, so no card needs
+                // marking.  A black destination still has to go gray and be
+                // rescanned, which is what `collect_cardrefs_to_nursery` reads
+                // CARDS_SET for at the end of a marking step.
+                if self.gc_state == GcState::Marking
+                    && unsafe { !(*dest_hdr).has_flag(flags::CARDS_SET) }
+                {
+                    self.old_objects_with_cards_set.push(dest_addr);
+                    unsafe { (*dest_hdr).set_flag(flags::CARDS_SET) };
+                }
+                return true;
+            }
+            if source_start != 0 || dest_start != 0 {
+                // Misaligned: the card index of an item differs between the
+                // two objects, so the bits cannot be copied across.
+                return false;
+            }
+            self.manually_copy_card_bits(source_addr, dest_addr, length);
+            return true;
+        }
+
+        // While marking, the source's TRACK_YOUNG_PTRS says nothing: the
+        // barrier is also what turns a black object gray again, so a source
+        // that already lost the flag can still hold pointers this copy must
+        // report.
+        if unsafe { !(*source_hdr).has_flag(flags::TRACK_YOUNG_PTRS) }
+            || self.gc_state == GcState::Marking
+        {
+            self.remember_young_pointer(GcRef(dest_addr));
+        }
+
+        if unsafe { (*dest_hdr).has_flag(flags::NO_HEAP_PTRS) }
+            && unsafe { !(*source_hdr).has_flag(flags::NO_HEAP_PTRS) }
+        {
+            unsafe { (*dest_hdr).clear_flag(flags::NO_HEAP_PTRS) };
+            self.prebuilt_root_objects.push(dest_addr);
+        }
+        true
+    }
+
+    /// incminimark.py `writebarrier_before_move`: "If 'array_addr' uses cards,
+    /// then this has the same effect as a call to the generic writebarrier,
+    /// effectively generalizing the cards to 'any item may be young'."
+    ///
+    /// A move within one object carries its items across card boundaries while
+    /// the card bits stay where they are, so the per-card record is no longer
+    /// true of the object and only the whole-object record is.
+    pub fn writebarrier_before_move(&mut self, array_addr: usize) {
+        if self.config.card_page_indices == 0 {
+            return;
+        }
+        let hdr = unsafe { header_of(array_addr) };
+        if unsafe { (*hdr).has_flag(flags::CARDS_SET) } {
+            self.do_write_barrier(GcRef(array_addr));
+        }
+    }
+
+    /// incminimark.py `manually_copy_card_bits`.
+    fn manually_copy_card_bits(&mut self, source_addr: usize, dest_addr: usize, length: usize) {
+        debug_assert!(
+            self.config.card_page_indices > 0,
+            "non-positive card_page_indices"
+        );
+        let bytes = self.card_marking_bytes_for_length(length);
+        let mut anybyte = 0u8;
+        for i in 0..bytes {
+            let byte = unsafe { *Self::get_card_ptr(source_addr, i) };
+            anybyte |= byte;
+            unsafe { *Self::get_card_ptr(dest_addr, i) |= byte };
+        }
+        if anybyte != 0 {
+            let dest_hdr = unsafe { header_of(dest_addr) };
+            if unsafe { !(*dest_hdr).has_flag(flags::CARDS_SET) } {
+                self.old_objects_with_cards_set.push(dest_addr);
+                unsafe { (*dest_hdr).set_flag(flags::CARDS_SET) };
+            }
         }
     }
 
@@ -7354,6 +7615,19 @@ impl GcAllocator for MiniMarkGC {
             self.probably_young_objects_with_finalizers
                 .push_back((obj.0, fq_index));
         }
+    }
+
+    fn ignore_finalizer(&mut self, obj: GcRef) {
+        // The same admission the finalizer queues apply
+        // (`deal_with_young_objects_with_finalizers` drops an entry whose
+        // object is outside both generations): an address the collector does
+        // not own has no header to stamp, and dropping the hint only costs the
+        // finalizer that would have run anyway.
+        if obj.is_null() || !self.is_managed_heap_object(obj.0) {
+            return;
+        }
+        let hdr = unsafe { header_of(obj.0) };
+        unsafe { (*hdr).set_flag(flags::IGNORE_FINALIZER) };
     }
 
     fn finalizer_next_dead(&mut self, fq_index: usize) -> Option<GcRef> {
@@ -12469,6 +12743,292 @@ cache size\t: 8192 kB\n";
         gc.do_collect_oldgen_nonmoving();
         assert_eq!(TRIGGERS.load(Ordering::Relaxed), 1);
         assert_eq!(GcAllocator::finalizer_next_dead(&mut gc, 0), None);
+    }
+
+    /// incminimark.py `ignore_finalizer`: the object stays on the queue, and
+    /// `deal_with_objects_with_finalizers` is what passes over it.
+    #[test]
+    fn ignore_finalizer_withholds_a_registered_object_from_its_queue() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        static TRIGGERS: AtomicUsize = AtomicUsize::new(0);
+        fn trigger() {
+            TRIGGERS.fetch_add(1, Ordering::Relaxed);
+        }
+
+        TRIGGERS.store(0, Ordering::Relaxed);
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(16));
+        let obj = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + 16);
+        let mut root = obj;
+        unsafe { gc.roots.add(&mut root) };
+        GcAllocator::register_finalizer(&mut gc, 0, obj, trigger);
+        assert_eq!(gc.old_objects_with_finalizers.len(), 1);
+
+        GcAllocator::ignore_finalizer(&mut gc, obj);
+        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::IGNORE_FINALIZER) });
+
+        gc.roots.remove(&mut root);
+        gc.do_collect_oldgen_nonmoving();
+        assert_eq!(TRIGGERS.load(Ordering::Relaxed), 0);
+        assert_eq!(GcAllocator::finalizer_next_dead(&mut gc, 0), None);
+    }
+
+    /// An address the collector does not own has no header to stamp, so the
+    /// hint is dropped rather than written into whatever precedes it.
+    #[test]
+    fn ignore_finalizer_drops_an_unmanaged_address() {
+        let mut gc = test_gc(4096);
+        let outside = Box::into_raw(Box::new([0usize; 4])) as usize;
+        GcAllocator::ignore_finalizer(&mut gc, GcRef(outside));
+        GcAllocator::ignore_finalizer(&mut gc, GcRef::NULL);
+        unsafe { drop(Box::from_raw(outside as *mut [usize; 4])) };
+    }
+
+    /// incminimark.py `writebarrier_before_copy`: with no cards involved, a
+    /// source that has already lost TRACK_YOUNG_PTRS may hold young pointers,
+    /// so the destination joins the remembered set.
+    #[test]
+    fn writebarrier_before_copy_remembers_dest_when_source_is_untracked() {
+        let ptr_size = std::mem::size_of::<GcRef>();
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::with_gc_ptrs(ptr_size, vec![0]));
+        let source = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
+        let dest = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
+        unsafe { (*header_of(source.0)).clear_flag(flags::TRACK_YOUNG_PTRS) };
+        let before = gc.remembered_set.len();
+
+        assert!(gc.writebarrier_before_copy(source.0, dest.0, 0, 0, 1));
+
+        assert_eq!(gc.remembered_set.len(), before + 1);
+        assert!(gc.remembered_set.contains(&dest.0));
+        assert!(unsafe { !(*header_of(dest.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
+    }
+
+    /// A source that still carries TRACK_YOUNG_PTRS has no young pointers to
+    /// hand over, so outside the marking phase the copy needs nothing.
+    #[test]
+    fn writebarrier_before_copy_is_a_noop_for_a_tracked_source() {
+        let ptr_size = std::mem::size_of::<GcRef>();
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::with_gc_ptrs(ptr_size, vec![0]));
+        let source = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
+        let dest = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
+        assert_eq!(gc.gc_state, GcState::Scanning);
+        let before = gc.remembered_set.len();
+
+        assert!(gc.writebarrier_before_copy(source.0, dest.0, 0, 0, 1));
+
+        assert_eq!(gc.remembered_set.len(), before);
+        assert!(unsafe { (*header_of(dest.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
+    }
+
+    /// A destination already on the remembered set is the fast path: nothing
+    /// below it runs, and the answer is still "handled".
+    #[test]
+    fn writebarrier_before_copy_fast_paths_an_untracked_dest() {
+        let ptr_size = std::mem::size_of::<GcRef>();
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::with_gc_ptrs(ptr_size, vec![0]));
+        let source = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
+        let dest = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
+        unsafe { (*header_of(source.0)).clear_flag(flags::TRACK_YOUNG_PTRS) };
+        unsafe { (*header_of(dest.0)).clear_flag(flags::TRACK_YOUNG_PTRS) };
+        let before = gc.remembered_set.len();
+
+        assert!(gc.writebarrier_before_copy(source.0, dest.0, 0, 0, 1));
+
+        assert_eq!(gc.remembered_set.len(), before);
+    }
+
+    /// The card arms: a source with cards and a destination without cannot be
+    /// served in bulk, and the caller is told to do it per item.
+    #[test]
+    fn writebarrier_before_copy_declines_a_card_source_with_a_plain_dest() {
+        let ptr_size = std::mem::size_of::<GcRef>();
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::with_gc_ptrs(ptr_size, vec![0]));
+        let source = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
+        let dest = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
+        unsafe { (*header_of(source.0)).set_flag(flags::HAS_CARDS) };
+        assert!(gc.config.card_page_indices > 0);
+
+        assert!(!gc.writebarrier_before_copy(source.0, dest.0, 0, 0, 1));
+    }
+
+    /// Two card arrays whose copy is misaligned: the card index of an item
+    /// differs between them, so the bits cannot be carried across.
+    #[test]
+    fn writebarrier_before_copy_declines_a_misaligned_card_copy() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::varsize(8, 8, 0, true, vec![]));
+        let source = gc.alloc_in_oldgen_with_cards(tid, GcHeader::SIZE + 8 + 8 * 64, 64, true);
+        let dest = gc.alloc_in_oldgen_with_cards(tid, GcHeader::SIZE + 8 + 8 * 64, 64, true);
+        unsafe { (*header_of(source.0)).set_flag(flags::CARDS_SET) };
+
+        assert!(!gc.writebarrier_before_copy(source.0, dest.0, 1, 0, 64));
+    }
+
+    /// `manually_copy_card_bits`: an aligned copy between two card arrays
+    /// carries the source's marks onto the destination and enters it on
+    /// `old_objects_with_cards_set`.
+    #[test]
+    fn writebarrier_before_copy_copies_card_bits_across() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::varsize(8, 8, 0, true, vec![]));
+        let source = gc.alloc_in_oldgen_with_cards(tid, GcHeader::SIZE + 8 + 8 * 64, 64, true);
+        let dest = gc.alloc_in_oldgen_with_cards(tid, GcHeader::SIZE + 8 + 8 * 64, 64, true);
+        assert!(unsafe { (*header_of(source.0)).has_flag(flags::HAS_CARDS) });
+        assert!(unsafe { (*header_of(dest.0)).has_flag(flags::HAS_CARDS) });
+        unsafe { *MiniMarkGC::get_card_ptr(source.0, 0) = 0b0000_0101 };
+        unsafe { (*header_of(source.0)).set_flag(flags::CARDS_SET) };
+        gc.old_objects_with_cards_set.clear();
+
+        assert!(gc.writebarrier_before_copy(source.0, dest.0, 0, 0, 64));
+
+        assert_eq!(unsafe { *MiniMarkGC::get_card_ptr(dest.0, 0) }, 0b0000_0101);
+        assert!(unsafe { (*header_of(dest.0)).has_flag(flags::CARDS_SET) });
+        assert_eq!(gc.old_objects_with_cards_set, vec![dest.0]);
+    }
+
+    /// incminimark.py `writebarrier_before_move`: the card bits stay put while
+    /// the items move past them, so the per-card record is replaced by the
+    /// whole-object one.
+    #[test]
+    fn writebarrier_before_move_generalizes_a_marked_card_array() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::varsize(8, 8, 0, true, vec![]));
+        let array = gc.alloc_in_oldgen_with_cards(tid, GcHeader::SIZE + 8 + 8 * 64, 64, true);
+        unsafe { (*header_of(array.0)).set_flag(flags::CARDS_SET) };
+        let before = gc.remembered_set.len();
+
+        gc.writebarrier_before_move(array.0);
+
+        assert_eq!(gc.remembered_set.len(), before + 1);
+        assert!(gc.remembered_set.contains(&array.0));
+    }
+
+    /// An array with no card marked has nothing the move could invalidate.
+    #[test]
+    fn writebarrier_before_move_is_a_noop_without_cards_set() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::varsize(8, 8, 0, true, vec![]));
+        let array = gc.alloc_in_oldgen_with_cards(tid, GcHeader::SIZE + 8 + 8 * 64, 64, true);
+        let before = gc.remembered_set.len();
+
+        gc.writebarrier_before_move(array.0);
+
+        assert_eq!(gc.remembered_set.len(), before);
+    }
+
+    /// incminimark.py `move_out_of_nursery`: "called twice, it should return
+    /// the same shadow object, and not creating another shadow object.  As a
+    /// safety feature, when called on a non-nursery object, do nothing."
+    #[test]
+    fn move_out_of_nursery_fills_one_shadow_and_the_minor_keeps_it() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(16));
+        let obj = gc.alloc_with_type(tid, 16);
+        assert!(gc.is_in_nursery(obj.0));
+        unsafe { *(obj.0 as *mut u64) = 0xfeed_face };
+
+        let shadow = gc.move_out_of_nursery(obj.0);
+        assert_ne!(shadow, obj.0);
+        assert!(!gc.is_in_nursery(shadow));
+        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::SHADOW_INITIALIZED) });
+        assert_eq!(unsafe { *(shadow as *const u64) }, 0xfeed_face);
+        assert_eq!(gc.move_out_of_nursery(obj.0), shadow);
+
+        // The nursery original may be written after the shadow was filled;
+        // upstream's contract ("Only use for immutable objects!") is what makes
+        // the promotion's skipped copy sound, so the shadow keeps what it had.
+        unsafe { *(obj.0 as *mut u64) = 0xdead_beef };
+        let mut root = obj;
+        unsafe { gc.roots.add(&mut root) };
+        gc.do_collect_nursery();
+        assert_eq!(root.0, shadow);
+        assert_eq!(unsafe { *(shadow as *const u64) }, 0xfeed_face);
+        gc.roots.clear();
+    }
+
+    /// An old-gen object is already where a shadow would put it.
+    #[test]
+    fn move_out_of_nursery_answers_a_non_nursery_object_unchanged() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(16));
+        let obj = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + 16);
+        assert_eq!(gc.move_out_of_nursery(obj.0), obj.0);
+        assert!(unsafe { !(*header_of(obj.0)).has_flag(flags::SHADOW_INITIALIZED) });
+    }
+
+    /// incminimark.py `collect(gen)`: a negative generation is the minor that
+    /// deliberately makes no major progress.
+    #[test]
+    fn do_collect_with_a_negative_generation_runs_a_minor_only() {
+        let mut gc = test_gc(4096);
+        let minors = gc.minor_collections;
+        let majors = gc.major_collections;
+
+        gc.do_collect(-1);
+
+        assert_eq!(gc.minor_collections, minors + 1);
+        assert_eq!(gc.major_collections, majors);
+        assert_eq!(gc.gc_state, GcState::Scanning);
+    }
+
+    /// `gen == 1` "is like gen == 0, but if no major collection is running,
+    /// then it forces one to start now".
+    #[test]
+    fn do_collect_with_generation_one_starts_a_major_cycle() {
+        let mut gc = test_gc(4096);
+        assert_eq!(gc.gc_state, GcState::Scanning);
+        let minors = gc.minor_collections;
+
+        gc.do_collect(1);
+
+        assert_eq!(gc.minor_collections, minors + 1);
+        assert_ne!(
+            gc.gc_state,
+            GcState::Scanning,
+            "gen == 1 forces a cycle to start"
+        );
+    }
+
+    /// `gen >= 2` is the complete collection, and it leaves no cycle running.
+    #[test]
+    fn do_collect_with_generation_two_completes_a_cycle() {
+        let mut gc = test_gc(4096);
+        let majors = gc.major_collections;
+
+        gc.do_collect(2);
+
+        assert!(gc.major_collections > majors);
+        assert_eq!(gc.gc_state, GcState::Scanning);
+    }
+
+    /// incminimark.py `set_max_heap_size`: a limit below the pending
+    /// thresholds pulls them down with it.
+    #[test]
+    fn set_max_heap_size_pulls_the_pending_thresholds_down() {
+        let mut gc = test_gc(4096);
+        gc.next_major_collection_initial = 8192.0;
+        gc.next_major_collection_threshold = 8192.0;
+
+        gc.set_max_heap_size(1024);
+
+        assert_eq!(gc.max_heap_size, 1024.0);
+        assert_eq!(gc.next_major_collection_initial, 1024.0);
+        assert_eq!(gc.next_major_collection_threshold, 1024.0);
+
+        // A larger limit does not raise a threshold that is already lower.
+        gc.set_max_heap_size(65536);
+        assert_eq!(gc.max_heap_size, 65536.0);
+        assert_eq!(gc.next_major_collection_threshold, 1024.0);
+
+        // Unbounded leaves them alone entirely.
+        gc.set_max_heap_size(0);
+        assert_eq!(gc.max_heap_size, 0.0);
+        assert_eq!(gc.next_major_collection_threshold, 1024.0);
     }
 
     // ── rawrefcount (incminimark.py:3157-3409) ──────────────────────

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -792,6 +792,12 @@ pub trait GcAllocator: Send {
     /// finalizer handler.  Backends without finalizer queues ignore it.
     fn register_finalizer(&mut self, _fq_index: usize, _obj: GcRef, _trigger: FinalizerTriggerFn) {}
 
+    /// incminimark.py `ignore_finalizer` / framework.py
+    /// `gct_gc_ignore_finalizer`: mark `obj` so the finalizer queues skip it.
+    /// An optimization hint — a backend with no such flag ignores it, and the
+    /// finalizer simply runs.
+    fn ignore_finalizer(&mut self, _obj: GcRef) {}
+
     /// rgc.py `FinalizerQueue.next_dead` / framework.py `gc_fq_next_dead`.
     fn finalizer_next_dead(&mut self, _fq_index: usize) -> Option<GcRef> {
         None
@@ -1381,6 +1387,9 @@ impl GcAllocator for GcHandle {
     }
     fn register_finalizer(&mut self, fq_index: usize, obj: GcRef, trigger: FinalizerTriggerFn) {
         gc_sync::gc_op(|gc| gc.register_finalizer(fq_index, obj, trigger))
+    }
+    fn ignore_finalizer(&mut self, obj: GcRef) {
+        gc_sync::gc_op(|gc| gc.ignore_finalizer(obj))
     }
     fn finalizer_next_dead(&mut self, fq_index: usize) -> Option<GcRef> {
         gc_sync::gc_op(|gc| gc.finalizer_next_dead(fq_index))
@@ -3047,6 +3056,45 @@ pub fn gc_register_finalizer(fq_index: usize, obj: GcRef, trigger: FinalizerTrig
         Some(f) => f(fq_index, obj, trigger),
         None => gc_sync::gc_op(|gc| gc.register_finalizer(fq_index, obj, trigger)),
     }
+}
+
+/// rgc.py `collect(gen)` — the internal entry that names how much work to do,
+/// as opposed to `gc.collect()`, which asks for all of it.  `gen < 0` is a
+/// minor with no major progress at all, `0` a minor plus whatever major step
+/// the accounting calls for, `1` that plus starting a cycle if none is running,
+/// and `>= 2` a full collection.
+pub fn gc_collect_gen(generation: i64) {
+    gc_sync::gc_op(|gc| gc.do_collect(generation));
+}
+
+/// incminimark.py `set_max_heap_size` — the `PYPY_GC_MAX` limit, set from
+/// inside a running process instead of read once at startup.  `0` is
+/// unbounded.
+pub fn gc_set_max_heap_size(size: usize) {
+    gc_sync::gc_op(|gc| gc.set_max_heap_size(size));
+}
+
+/// rgc.py `move_out_of_nursery` — "Returns another object which is a copy of
+/// obj; but at any point (either now or in the future) the returned object
+/// might suddenly become identical to the one returned.  NOTE: Only use for
+/// immutable objects!"
+///
+/// The argument must stay reachable across the call: filling the shadow can
+/// allocate one first, and that is a collection point.
+pub fn gc_move_out_of_nursery(obj: GcRef) -> GcRef {
+    gc_sync::gc_op_with_root(obj, |gc, obj| GcRef(gc.move_out_of_nursery(obj.0)))
+}
+
+/// rgc.py `may_ignore_finalizer` — "says that it is valid for any finalizer
+/// for 'obj' to be ignored, depending on the GC".  A hint and nothing else: the
+/// object stays on its queue, and what changes is that the queue skips it when
+/// it comes to deliver.
+///
+/// Unlike [`gc_register_finalizer`] there is no backend trampoline to consult.
+/// The hint is a header bit, and a backend that keeps no such bit is a backend
+/// whose queues never read one.
+pub fn gc_ignore_finalizer(obj: GcRef) {
+    gc_sync::gc_op(|gc| gc.ignore_finalizer(obj));
 }
 
 /// Pop one object from the active GC's RPython-style finalizer death queue.

--- a/pyre/extra_tests/snippets/coroutine_never_awaited_survives_a_send_typeerror.py
+++ b/pyre/extra_tests/snippets/coroutine_never_awaited_survives_a_send_typeerror.py
@@ -1,0 +1,56 @@
+# pyre-check: gate=1
+"""A rejected `send` does not start a coroutine, so it still reports as unawaited.
+
+`send(non_None)` on a coroutine that has not run raises before any of its body
+executes, so the coroutine is exactly as unawaited afterwards as it was before.
+Collecting it therefore still warns.
+
+The reason this needs pinning: `generator.py _invoke_execute_frame` hands the
+GC `may_ignore_finalizer` for a started coroutine without `CO_YIELD_INSIDE_TRY`,
+and it does so *ahead* of this raise — so the object whose `send` was rejected
+carries the hint too, and pypy3 emits no warning here.  3.14 does, so the hint
+belongs behind the raise.
+"""
+
+import gc
+import warnings
+
+
+async def never_awaited():
+    pass
+
+
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    coro = never_awaited()
+    try:
+        coro.send(1)
+    except TypeError as exc:
+        assert "just-started coroutine" in str(exc), exc
+    else:
+        raise AssertionError("send(1) on a fresh coroutine did not raise")
+    del coro
+    gc.collect()
+    messages = [str(entry.message) for entry in caught]
+
+assert any("was never awaited" in message for message in messages), messages
+
+
+# The control: a coroutine that really was started reports nothing, because
+# starting it is what settles the question the warning asks.
+async def started_then_dropped():
+    pass
+
+
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    coro = started_then_dropped()
+    try:
+        coro.send(None)
+    except StopIteration:
+        pass
+    del coro
+    gc.collect()
+    messages = [str(entry.message) for entry in caught]
+
+assert not any("was never awaited" in message for message in messages), messages

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -17910,6 +17910,10 @@ pub(crate) unsafe fn generator_frame_is_finished(
     frame.f_backref = std::ptr::null_mut();
     frame.f_generator_nowref = PY_NULL;
     unsafe { w_generator_set_frame(gen_obj, std::ptr::null_mut()) };
+    // generator.py `frame_is_finished`: the frame edge is what `_finalize_`
+    // reads, and it is gone, so nothing is left for the queue to deliver this
+    // object for.
+    crate::executioncontext::may_ignore_finalizer(gen_obj);
 }
 
 /// generator.py `_invoke_execute_frame`: install the generator's
@@ -18033,6 +18037,25 @@ fn generator_send_ex(
                 "can't send non-None value to a just-started {}",
                 generator_kind(gen_obj)
             )));
+        }
+        if !already_started
+            && is_coroutine(gen_obj)
+            && !crate::pycode::w_code_yields_inside_try(w_generator_get_pycode(gen_obj))
+        {
+            // generator.py `_invoke_execute_frame`: "after we've started a
+            // Coroutine without CO_YIELD_INSIDE_TRY, then
+            // Coroutine._finalize_() will be a no-op".  Such a coroutine is on
+            // the queue for the never-awaited warning alone
+            // (`into_generator_named` registers it for being a Coroutine, not
+            // for its flags), and starting it is what settles that question.
+            //
+            // Behind the just-started check, where upstream puts it ahead: the
+            // hint says the coroutine has been started, and one that reports
+            // that error has not been.  Upstream's order suppresses the
+            // never-awaited warning for it — 3.14 emits it, and
+            // `extra_tests/snippets/coroutine_never_awaited_survives_a_send_typeerror.py`
+            // pins that.
+            crate::executioncontext::may_ignore_finalizer(gen_obj);
         }
         w_generator_set_started(gen_obj);
         // generator.py `_invoke_execute_frame` delegates the complete

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -13879,6 +13879,10 @@ fn builtin_id(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // emit and read the answer back out of its slot.
         let _roots = pyre_object::gc_roots::push_roots();
         let res_slot = pyre_object::gc_roots::pin_roots(&[w_res]);
+        // The pin normalizes, and its query is itself a safepoint, so `w_res`
+        // is dead from here on: what the hooks are handed has to come out of
+        // the slot, not out of the copy that named the object beforehand.
+        let w_res = pyre_object::gc_roots::shadow_stack_get(res_slot);
         crate::module::sys::vm::audit("builtins.id", &[w_res])?;
         return Ok(pyre_object::gc_roots::shadow_stack_get(res_slot));
     }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -306,6 +306,24 @@ pub fn maybe_register_user_finalizer(obj: PyObjectRef) {
     }
 }
 
+/// `rgc.may_ignore_finalizer` — "Optimization hint: says that it is valid for
+/// any finalizer for 'obj' to be ignored, depending on the GC."  The object
+/// stays on the queue it was registered with; what changes is that the queue
+/// passes over it when the collector comes to deliver.
+///
+/// Only ever a hint, so a build with no collector behind it drops the call and
+/// the finalizer runs — the same answer a collector without the flag gives.
+///
+/// `W_Root.may_unregister_rpython_finalizer` — the same hint behind a
+/// `hasuserdel` guard — has no pyre caller: every module that reaches it
+/// upstream (`_socket`, `zlib`, `select.epoll`/`kqueue`, `_cffi_backend`)
+/// registers no finalizer here, so there is nothing for it to withhold.  `_io`
+/// wants the other guard and carries its own
+/// (`_io::maybe_unregister_rpython_finalizer_io`).
+pub fn may_ignore_finalizer(obj: PyObjectRef) {
+    pyre_object::gc_hook::try_gc_ignore_finalizer(obj);
+}
+
 /// Shared execution context for all frames in one interpreter run.
 ///
 /// Holds the builtin module dict used by module-level frames.

--- a/pyre/pyre-interpreter/src/module/_io/buffered.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered.rs
@@ -862,13 +862,19 @@ impl W_BufferedReader {
             }
             return Err(close_error);
         }
-        self.buffer = PY_NULL;
-        pyre_object::gc_hook::try_gc_write_barrier(self as *mut Self as *mut u8);
+        // interp_bufferedio.py `close_w`: the `raise` in the flush handler
+        // carries that error out of the `try`/`finally`, so a failed flush
+        // reaches neither of the two lines below it — the raw close in the
+        // `finally` is all that still runs. Releasing the buffer here would
+        // report the object as having nothing left to write while its
+        // finalizer, correctly, still thinks otherwise.
         if let Some(error) = flush_error {
             return Err(error);
         }
-        // interp_bufferedio.py `close_w`, after `self.buffer = None`: the
-        // object is closed, so `iobase_del` has nothing left to do for it.
+        self.buffer = PY_NULL;
+        pyre_object::gc_hook::try_gc_write_barrier(self as *mut Self as *mut u8);
+        // `close_w`, on the line after `self.buffer = None`: the object is
+        // closed, so `iobase_del` has nothing left to do for it.
         super::maybe_unregister_rpython_finalizer_io(self.self_obj());
         Ok(())
     }

--- a/pyre/pyre-interpreter/src/module/_io/buffered.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered.rs
@@ -867,6 +867,9 @@ impl W_BufferedReader {
         if let Some(error) = flush_error {
             return Err(error);
         }
+        // interp_bufferedio.py `close_w`, after `self.buffer = None`: the
+        // object is closed, so `iobase_del` has nothing left to do for it.
+        super::maybe_unregister_rpython_finalizer_io(self.self_obj());
         Ok(())
     }
 

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -178,7 +178,31 @@ pub(crate) fn iobase_close(args: &[PyObjectRef]) -> crate::PyResult {
         &[],
     );
     iobase_set_internal_closed(pyre_object::gc_roots::shadow_stack_get(self_slot), true)?;
-    flushed.map(|_| w_none())
+    flushed?;
+    // `close_w` reaches its `maybe_unregister_rpython_finalizer_io` only past
+    // the `try`, so a flush that raised does not get the hint even though the
+    // `finally` above has already marked the object closed.
+    maybe_unregister_rpython_finalizer_io(pyre_object::gc_roots::shadow_stack_get(self_slot));
+    Ok(w_none())
+}
+
+/// `interp_iobase.py W_IOBase.maybe_unregister_rpython_finalizer_io`: once
+/// `closed` is set, `iobase_del`'s own work is a no-op, so the object may be
+/// collected without being delivered.
+///
+/// Withheld from an app-level subclass — upstream's `user_overridden_class`
+/// guard.  Its `close` may do anything, and `iobase_del` reaches it through
+/// the ordinary lookup.  `is_heaptype` is that predicate here: every
+/// interp-level `_io` type is a builtin one, so a heap type in this position
+/// is a class written in Python.
+pub(crate) fn maybe_unregister_rpython_finalizer_io(self_obj: PyObjectRef) {
+    let Some(w_type) = crate::typedef::r#type(self_obj) else {
+        return;
+    };
+    if unsafe { pyre_object::w_type_is_heaptype(w_type.as_ptr()) } {
+        return;
+    }
+    crate::executioncontext::may_ignore_finalizer(self_obj);
 }
 
 fn iobase_flush(args: &[PyObjectRef]) -> crate::PyResult {

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -1313,6 +1313,11 @@ impl W_TextIOWrapper {
         if let Some(error) = flush_error {
             return Err(error);
         }
+        // interp_textio.py `close_w`: the wrapper is closed, so `iobase_del`'s
+        // own work is done.  On the success path only — a close that raised
+        // leaves the object in a state its finalizer still has something to
+        // say about.
+        super::maybe_unregister_rpython_finalizer_io(self.self_obj());
         Ok(())
     }
 

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -920,6 +920,30 @@ fn disable_finalizers(action: &mut crate::executioncontext::UserDelAction) {
     }
 }
 
+/// Release the mirrors the collection queued, the way `interp_gc.py collect`
+/// ends with `_rawrefcount_perform` — "perform dealloc callbacks now, instead
+/// of waiting for the next AsyncAction to fire".  A `tp_dealloc` is then part
+/// of the `gc.collect()` that freed its object rather than of whatever runs
+/// next; `PyObjDeallocAction` stays registered and still drains what an
+/// automatic collection queues.
+#[cfg(all(
+    feature = "cpyext",
+    not(feature = "sandbox"),
+    any(target_os = "macos", target_os = "linux")
+))]
+fn run_cpyext_deallocs_now() {
+    crate::cpyext::pyobject::drain_dead();
+}
+
+/// The builds with no mirrors to release — upstream reaches its
+/// `_rawrefcount_perform` only under `usemodules.cpyext`.
+#[cfg(not(all(
+    feature = "cpyext",
+    not(feature = "sandbox"),
+    any(target_os = "macos", target_os = "linux")
+)))]
+fn run_cpyext_deallocs_now() {}
+
 fn run_finalizers_now() {
     if let Some(action) = user_del_action() {
         let temp_reenable = !action.enabled_at_app_level;
@@ -1383,6 +1407,7 @@ crate::py_module! {
             crate::objspace::std::mapdict::clear_map_attr_cache();
             pyre_object::gc_hook::try_gc_collect();
             run_finalizers_now();
+            run_cpyext_deallocs_now();
             // The return value is the caller-observable axis and is an int.
             // A collector that never counts unreachable objects has no count
             // to report, so the constant `interp_gc.py:48` carries is what it

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -9413,12 +9413,12 @@ fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
             .iter()
             .map(|&(_, _, value)| {
                 let slot = pyre_object::gc_roots::shadow_stack_len();
-                pyre_object::gc_roots::pin_root(value);
+                let _ = pyre_object::gc_roots::pin_root(value);
                 slot
             })
             .collect();
         let locals_root = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(unsafe { pyre_object::w_dict_new() });
+        let _ = pyre_object::gc_roots::pin_root(unsafe { pyre_object::w_dict_new() });
         let mut result = pyre_object::PY_NULL;
         let mut slot_failed = false;
         for (&(index, _, _), &value_root) in slots.iter().zip(&value_roots) {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -170,6 +170,10 @@ fn pyre_object_gc_register_finalizer_trampoline(
     majit_gc::gc_register_finalizer(fq_index, majit_ir::GcRef(obj as usize), trigger);
 }
 
+fn pyre_object_gc_ignore_finalizer_trampoline(obj: pyre_object::PyObjectRef) {
+    majit_gc::gc_ignore_finalizer(majit_ir::GcRef(obj as usize));
+}
+
 fn pyre_object_gc_finalizer_next_dead_trampoline(fq_index: usize) -> pyre_object::PyObjectRef {
     majit_gc::gc_fq_next_dead(fq_index)
         .map(|obj| obj.0 as pyre_object::PyObjectRef)
@@ -4875,6 +4879,7 @@ fn install_pyre_object_hooks() {
     pyre_object::gc_hook::register_gc_finalizer_hooks(
         pyre_object_gc_register_finalizer_trampoline,
         pyre_object_gc_finalizer_next_dead_trampoline,
+        pyre_object_gc_ignore_finalizer_trampoline,
     );
     pyre_object::register_gc_root_hooks(
         pyre_object_gc_add_root_trampoline,

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1496,9 +1496,16 @@ pub fn alloc_dict_object(value: W_DictObject, stable: bool) -> PyObjectRef {
     let raw = if stable {
         crate::gc_hook::try_gc_alloc_stable_raw(W_DICT_GC_TYPE_ID, W_DICT_OBJECT_SIZE)
     } else {
-        crate::gc_hook::try_gc_alloc(W_DICT_GC_TYPE_ID, W_DICT_OBJECT_SIZE)
-            .filter(|p| !p.is_null())
-            .unwrap_or(std::ptr::null_mut())
+        // The `malloc_typed` box below answers a missing hook. It cannot
+        // answer a GC that owns the heap and refused: the dict's strategy and
+        // storage edges would sit outside the object graph, behind a header
+        // the collector never walks.
+        crate::gc_hook::GcAllocOutcome::from_hook(crate::gc_hook::try_gc_alloc(
+            W_DICT_GC_TYPE_ID,
+            W_DICT_OBJECT_SIZE,
+        ))
+        .allocated_or_abort(W_DICT_OBJECT_SIZE)
+        .unwrap_or(std::ptr::null_mut())
     };
     value.dstorage = crate::gc_roots::shadow_stack_get(save_point) as *mut u8;
     if !raw.is_null() {

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -169,18 +169,26 @@ pub fn try_gc_alloc_stable(type_id: u32, payload_size: usize) -> Option<*mut u8>
     GC_ALLOC_STABLE_HOOK.get().map(|f| f(type_id, payload_size))
 }
 
-/// Null-collapsing view of [`try_gc_alloc_stable`] for JIT-traced callers.
+/// [`try_gc_alloc_stable`] narrowed to the one answer its callers can act on.
 ///
-/// Returns `null` both when no hook is installed and when the hook itself
-/// returned `null`; every traced caller already treats those two cases
-/// identically (fall back to `malloc_typed`), so the `Option` discriminant
-/// carries no information the caller reads.  Residualising this primitive
-/// (`@dont_look_inside`, `rlib/jit.py`) keeps the process-global hook
-/// dispatch out of the trace — a `*mut u8` return has no discriminant to
-/// erase, unlike the `Option<*mut u8>` accessor.
+/// `null` means [`GcAllocOutcome::NoRoute`] alone: no hook is installed, so
+/// the caller's own `malloc_raw` path is the whole heap and taking it keeps
+/// the object graph consistent.  A [`Failed`](GcAllocOutcome::Failed) does not
+/// come back — a GC owns the heap and could not satisfy the request, and every
+/// caller here answers a null by allocating outside that heap, which is the
+/// one thing it must not do: the object would hold managed references the
+/// collector never traces or forwards, and its missing header lets a type-id
+/// witness misread the words before it.  So the two are told apart here rather
+/// than at each call site, and the failure aborts (see [`gc_alloc_failed`]).
+///
+/// Residualising this primitive (`@dont_look_inside`, `rlib/jit.py`) keeps the
+/// process-global hook dispatch out of the trace — a `*mut u8` return has no
+/// discriminant to erase, unlike the `Option<*mut u8>` accessor.
 #[majit_macros::dont_look_inside]
 pub fn try_gc_alloc_stable_raw(type_id: u32, payload_size: usize) -> *mut u8 {
-    try_gc_alloc_stable(type_id, payload_size).unwrap_or(core::ptr::null_mut())
+    GcAllocOutcome::from_hook(try_gc_alloc_stable(type_id, payload_size))
+        .allocated_or_abort(payload_size)
+        .unwrap_or(core::ptr::null_mut())
 }
 
 majit_gc::global_hook!(static GC_ALLOC_COLLECTING_HOOK: GcAllocHookFn);
@@ -908,6 +916,19 @@ mod tests {
         let outcome = GcAllocOutcome::from_hook(try_gc_alloc(1, 8));
         clear_gc_alloc_hook();
         assert_eq!(outcome, GcAllocOutcome::Failed);
+    }
+
+    #[test]
+    fn a_stable_allocation_with_no_hook_installed_still_answers_null() {
+        // `NoRoute` is the one answer `try_gc_alloc_stable_raw` still hands
+        // back: nothing owns the heap, so each caller's own `malloc_raw` path
+        // is the whole heap and taking it is correct. The `Failed` it now
+        // separates out cannot be asserted from here — that one does not
+        // return.
+        let _hook_lock = hook_test_guard();
+        clear_gc_alloc_stable_hook();
+        assert!(try_gc_alloc_stable(1, 8).is_none());
+        assert!(try_gc_alloc_stable_raw(1, 8).is_null());
     }
 
     // Per-thread for the same reason the allocation record is: while these

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -394,21 +394,38 @@ pub fn try_gc_isenabled() -> bool {
 pub type GcFinalizerTriggerFn = fn();
 pub type GcRegisterFinalizerHookFn = fn(usize, PyObjectRef, GcFinalizerTriggerFn);
 pub type GcFinalizerNextDeadHookFn = fn(usize) -> PyObjectRef;
+/// `gc_ignore_finalizer` — the third of the finalizer operations
+/// `gctransform/framework.py` binds, and the only one that carries no queue
+/// index: the hint is a property of the object, not of the queue holding it.
+pub type GcIgnoreFinalizerHookFn = fn(PyObjectRef);
 
 majit_gc::global_hook!(static GC_REGISTER_FINALIZER_HOOK: GcRegisterFinalizerHookFn);
 majit_gc::global_hook!(static GC_FINALIZER_NEXT_DEAD_HOOK: GcFinalizerNextDeadHookFn);
+majit_gc::global_hook!(static GC_IGNORE_FINALIZER_HOOK: GcIgnoreFinalizerHookFn);
 
 pub fn register_gc_finalizer_hooks(
     register: GcRegisterFinalizerHookFn,
     next_dead: GcFinalizerNextDeadHookFn,
+    ignore: GcIgnoreFinalizerHookFn,
 ) {
     GC_REGISTER_FINALIZER_HOOK.set(Some(register));
     GC_FINALIZER_NEXT_DEAD_HOOK.set(Some(next_dead));
+    GC_IGNORE_FINALIZER_HOOK.set(Some(ignore));
 }
 
 pub fn try_gc_register_finalizer(fq_index: usize, obj: PyObjectRef, trigger: GcFinalizerTriggerFn) {
     if let Some(register) = GC_REGISTER_FINALIZER_HOOK.get() {
         register(fq_index, obj, trigger);
+    }
+}
+
+/// `rgc.may_ignore_finalizer(obj)` — "says that it is valid for any finalizer
+/// for 'obj' to be ignored, depending on the GC".  Nothing at all when no
+/// collector is installed, which is the same answer a collector that keeps no
+/// such flag gives: the finalizer runs.
+pub fn try_gc_ignore_finalizer(obj: PyObjectRef) {
+    if let Some(ignore) = GC_IGNORE_FINALIZER_HOOK.get() {
+        ignore(obj);
     }
 }
 

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1134,9 +1134,13 @@ pub fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy)
             &mut allocation_root,
             &mut needs_write_barrier,
         )
-    }
-    .filter(|p| !p.is_null())
-    .unwrap_or(std::ptr::null_mut());
+    };
+    // The `std::alloc` header below is the answer for a missing hook, not for
+    // a GC that owns the heap and refused: that one would leave the list's
+    // managed edges untraced behind a header the collector never walks.
+    let raw = crate::gc_hook::GcAllocOutcome::from_hook(raw)
+        .allocated_or_abort(W_LIST_OBJECT_SIZE)
+        .unwrap_or(std::ptr::null_mut());
     // `pop_roots` for the two typed blocks: this was the last allocation they
     // had to survive, and both take their heap edge from the struct built below.
     storage.reload_typed_blocks();

--- a/pyre/pyre-object/src/lltype.rs
+++ b/pyre/pyre-object/src/lltype.rs
@@ -348,8 +348,12 @@ pub fn malloc_typed_managed<T: GcType>(value: T) -> *mut T {
         TypeIdCell::UNASSIGNED => 0,
         id => id,
     };
-    if let Some(raw) = crate::gc_hook::try_gc_alloc(type_id, T::SIZE)
-        && !raw.is_null()
+    // `Some(null)` is a GC that owns the heap and could not satisfy the
+    // request, which the fallback below must not answer; only a missing hook
+    // leaves this path free to take it.
+    if let Some(raw) =
+        crate::gc_hook::GcAllocOutcome::from_hook(crate::gc_hook::try_gc_alloc(type_id, T::SIZE))
+            .allocated_or_abort(T::SIZE)
     {
         unsafe {
             std::ptr::write(raw as *mut T, value);

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -180,8 +180,9 @@ fn finalize_flags(flags: LaunchFlags) -> LaunchFlags {
 
 fn parse_args(
     binary_name: &str,
+    argv: Vec<std::ffi::OsString>,
 ) -> Result<(RunMode, LaunchFlags, Vec<std::ffi::OsString>), lexopt::Error> {
-    let mut parser = lexopt::Parser::from_env();
+    let mut parser = lexopt::Parser::from_iter(argv);
     let mut flags = LaunchFlags::default();
 
     while let Some(arg) = parser.next()? {
@@ -288,10 +289,10 @@ fn parse_args(
     ))
 }
 
-/// Parse a `--heapsize` value (`pypy_interact.py:88-102`): a byte count with an
-/// optional `k`/`m`/`g` suffix. pyre's GC has no runtime heap-limit knob, so the
-/// value is validated and accepted for CLI-surface parity but not enforced
-/// (accept-and-ignore); a non-positive or malformed value is a usage error.
+/// Parse a `--heapsize` value (`pypy_interact.py main`): a byte count with an
+/// optional `k`/`m`/`g` suffix. The suffixes are the controller's spelling and
+/// stop here — what it hands the sandboxed program is the byte count written
+/// out, so [`take_heapsize_option`] on the other side parses a plain integer.
 fn parse_heapsize(value: &str) -> Result<u64, lexopt::Error> {
     let value = value.trim().to_ascii_lowercase();
     let (digits, mult) = match value.strip_suffix('k') {
@@ -315,7 +316,39 @@ fn parse_heapsize(value: &str) -> Result<u64, lexopt::Error> {
             "interact: --heapsize must be positive".into(),
         ));
     }
+    // `bytes > sys.maxint` is the upstream OverflowError. `sys.maxsize` is
+    // `i64::MAX` here on every target, and the child parses the count back out
+    // of its own command line, so a value it could not name is refused now.
+    if bytes > i64::MAX as u64 {
+        return Err(lexopt::Error::Custom(
+            format!("interact: --heapsize maximum is {}", i64::MAX).into(),
+        ));
+    }
     Ok(bytes)
+}
+
+/// `targetpypystandalone.py entry_point`: `--heapsize N`, in that position and
+/// no other, is an undocumented interp-level option that exists to support
+/// sandboxing — `pypy_interact.py` is what puts it there. Taking it out here
+/// leaves the argv `parse_args` reads, and the one `sys.orig_argv` records,
+/// equal to what `app_main.py` would have received: `entry_point` rewrites
+/// `argv` before app-level parsing ever sees it.
+fn take_heapsize_option(
+    binary_name: &str,
+    mut argv: Vec<std::ffi::OsString>,
+) -> (Vec<std::ffi::OsString>, Option<u64>) {
+    if argv.len() <= 2 || argv[1] != "--heapsize" {
+        return (argv, None);
+    }
+    // `int(argv[2])` — the controller has already resolved any suffix, so a
+    // value that is not a plain byte count came from somewhere that does not
+    // speak this protocol.
+    let Some(Ok(size)) = argv[2].to_str().map(str::parse::<u64>) else {
+        eprintln!("{binary_name}: --heapsize: not a byte count");
+        std::process::exit(2);
+    };
+    argv.drain(1..3);
+    (argv, Some(size))
 }
 
 /// Parse the `interact` subcommand: `pyre interact [--tmp DIR] [--lib DIR]
@@ -329,6 +362,7 @@ fn parse_interact(parser: &mut lexopt::Parser) -> Result<RunMode, lexopt::Error>
     let mut allow_net = false;
     let mut log_file = None;
     let mut verbose = false;
+    let mut heapsize = None;
     while let Some(arg) = parser.next()? {
         match arg {
             Long("tmp") => tmpdir = Some(parser.value()?.string()?),
@@ -347,10 +381,12 @@ fn parse_interact(parser: &mut lexopt::Parser) -> Result<RunMode, lexopt::Error>
                 }
                 timeout = Some(secs);
             }
-            // pypy_interact.py:88: validated and accepted for CLI parity, but
-            // pyre has no runtime heap-limit knob, so the value is discarded.
+            // `pypy_interact.py main`: the controller does not limit its own
+            // heap. It resolves the suffix and carries the byte count into the
+            // sandboxed program's arguments, where `take_heapsize_option` acts
+            // on it.
             Long("heapsize") => {
-                parse_heapsize(&parser.value()?.string()?)?;
+                heapsize = Some(parse_heapsize(&parser.value()?.string()?)?);
             }
             // setlogfile (sandlib.py): append the guest's stdin to FILE.
             Long("log") => log_file = Some(parser.value()?.string()?),
@@ -365,10 +401,18 @@ fn parse_interact(parser: &mut lexopt::Parser) -> Result<RunMode, lexopt::Error>
                 // program's: they are rendered into the child's command line
                 // as text, so one with no UTF-8 form is reported here rather
                 // than carried the way `sys.argv` carries it.
-                let args = drain_args(parser)?
+                let program_args = drain_args(parser)?
                     .into_iter()
                     .map(|arg| arg.into_string().map_err(lexopt::Error::NonUnicodeValue))
                     .collect::<Result<Vec<String>, _>>()?;
+                // `extraoptions + arguments[1:]`: the controller's own options
+                // lead the child's command line, ahead of the arguments meant
+                // for the program itself.
+                let mut args = match heapsize {
+                    Some(bytes) => vec!["--heapsize".to_string(), bytes.to_string()],
+                    None => Vec::new(),
+                };
+                args.extend(program_args);
                 return Ok(RunMode::Interact {
                     exe,
                     args,
@@ -647,10 +691,13 @@ fn real_main(binary_name: &str) {
         }
     }));
     // pypy/interpreter/app_main.py `entry_point`: preserve the executable and
-    // every original launcher argument before command-line parsing rewrites
-    // them into the run mode and `sys.argv`.
-    importing::set_sys_orig_argv(std::env::args_os().collect());
-    let (mode, flags, args) = match parse_args(binary_name) {
+    // every launcher argument reaching app level before command-line parsing
+    // rewrites them into the run mode and `sys.argv`. Only the interp-level
+    // option below is missing from that list, exactly as `sys.orig_argv[:] =
+    // [executable] + argv` records the list `entry_point` handed on.
+    let (argv, heapsize) = take_heapsize_option(binary_name, std::env::args_os().collect());
+    importing::set_sys_orig_argv(argv.clone());
+    let (mode, flags, args) = match parse_args(binary_name, argv) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("{binary_name}: {e}");
@@ -686,6 +733,16 @@ fn real_main(binary_name: &str) {
         // sys.settrace / set_jit_param routing is live from the very first
         // user statement, not only after the first JIT-traced bytecode.
         pyre_jit::eval::init_jit_hooks();
+        // `entry_point` sets the limit ahead of `space.startup()`; the earliest
+        // equivalent here is the line above, which is what builds the
+        // collector. Nothing has allocated yet either way, so the thresholds
+        // `set_max_heap_size` pulls down are still their startup values.
+        // Reaching the GC from the launcher is an entry from outside pyre and
+        // takes the GIL as one.
+        if let Some(size) = heapsize {
+            let _entry = majit_gc::gc_sync::enter_external_callback();
+            majit_gc::gc_set_max_heap_size(usize::try_from(size).unwrap_or(usize::MAX));
+        }
     }
 
     // Record `-S` before the first `import sys` so `sys.flags.no_site`
@@ -2072,7 +2129,10 @@ fn run_source(source: &str, mode: Mode, filename: &str, no_site: bool) {
 
 #[cfg(test)]
 mod tests {
-    use super::{dedent_command, parse_heapsize, set_last_exec_ctx, setup_exec_context};
+    use super::{
+        RunMode, dedent_command, parse_heapsize, parse_interact, set_last_exec_ctx,
+        setup_exec_context, take_heapsize_option,
+    };
 
     #[test]
     fn command_dedent_removes_shared_space_prefix() {
@@ -2182,6 +2242,72 @@ mod tests {
         assert!(parse_heapsize("0").is_err());
         assert!(parse_heapsize("abc").is_err());
         assert!(parse_heapsize("").is_err());
+        // `bytes > sys.maxint` is refused rather than handed on.
+        assert_eq!(
+            parse_heapsize("9223372036854775807").unwrap(),
+            i64::MAX as u64
+        );
+        assert!(parse_heapsize("9223372036854775808").is_err());
+        // 2**33 gibibytes is 2**63 — one past the maximum, and reached through
+        // a multiplier rather than by naming the count.
+        assert!(parse_heapsize("8589934592g").is_err());
+    }
+
+    #[test]
+    fn interact_carries_heapsize_into_the_child_argv() {
+        // `extraoptions[:0] = ['--heapsize', str(bytes)]` then
+        // `extraoptions + arguments[1:]`: the suffix is resolved by the
+        // controller, and the child is handed the byte count in front of its
+        // own arguments.
+        let mode = parse_interact(&mut lexopt::Parser::from_args([
+            "--heapsize",
+            "64k",
+            "./pyre-sandbox",
+            "prog.py",
+            "--flag",
+        ]))
+        .unwrap();
+        let RunMode::Interact { exe, args, .. } = mode else {
+            panic!("expected an interact mode");
+        };
+        assert_eq!(exe, "./pyre-sandbox");
+        assert_eq!(args, ["--heapsize", "65536", "prog.py", "--flag"]);
+
+        // Without the option the child's arguments are its own alone.
+        let mode = parse_interact(&mut lexopt::Parser::from_args([
+            "./pyre-sandbox",
+            "prog.py",
+        ]))
+        .unwrap();
+        let RunMode::Interact { args, .. } = mode else {
+            panic!("expected an interact mode");
+        };
+        assert_eq!(args, ["prog.py"]);
+    }
+
+    #[test]
+    fn the_leading_heapsize_option_is_taken_out_of_argv() {
+        // `if len(argv) > 2 and argv[1] == '--heapsize': ... argv = argv[:1] +
+        // argv[3:]`.
+        let argv = |args: &[&str]| -> Vec<std::ffi::OsString> {
+            args.iter().map(std::ffi::OsString::from).collect()
+        };
+        let (rest, size) =
+            take_heapsize_option("pyre", argv(&["pyre", "--heapsize", "65536", "prog.py"]));
+        assert_eq!(size, Some(65536));
+        assert_eq!(rest, argv(&["pyre", "prog.py"]));
+
+        // The position is the whole test: anywhere else it is an ordinary
+        // argument, and `parse_args` reports it as one.
+        let (rest, size) =
+            take_heapsize_option("pyre", argv(&["pyre", "prog.py", "--heapsize", "65536"]));
+        assert_eq!(size, None);
+        assert_eq!(rest, argv(&["pyre", "prog.py", "--heapsize", "65536"]));
+
+        // `len(argv) > 2` — a trailing `--heapsize` has no value to read.
+        let (rest, size) = take_heapsize_option("pyre", argv(&["pyre", "--heapsize"]));
+        assert_eq!(size, None);
+        assert_eq!(rest, argv(&["pyre", "--heapsize"]));
     }
 
     #[test]

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -342,10 +342,16 @@ fn take_heapsize_option(
     }
     // `int(argv[2])` — the controller has already resolved any suffix, so a
     // value that is not a plain byte count came from somewhere that does not
-    // speak this protocol.
-    let Some(Ok(size)) = argv[2].to_str().map(str::parse::<u64>) else {
-        eprintln!("{binary_name}: --heapsize: not a byte count");
-        std::process::exit(2);
+    // speak this protocol.  `sys.maxsize` bounds it on this side too: the
+    // controller refuses a larger count rather than write one here, and a
+    // value the limit cannot hold would otherwise be taken and then silently
+    // clamped.
+    let size = match argv[2].to_str().map(str::parse::<u64>) {
+        Some(Ok(size)) if size <= i64::MAX as u64 => size,
+        _ => {
+            eprintln!("{binary_name}: --heapsize: not a byte count");
+            std::process::exit(2);
+        }
     };
     argv.drain(1..3);
     (argv, Some(size))

--- a/pyre/pyrex/tests/cpyext_types.rs
+++ b/pyre/pyrex/tests/cpyext_types.rs
@@ -568,12 +568,22 @@ assert ref() is None, 'releasing the C reference did not let the object go'
 
 # ── and gc.collect() runs the deallocators before it returns ───────────
 # Read from C, so no bytecode runs between the collection and the count: a
-# drain left to the async action would not have happened yet.
-before = m.owner_deallocs()
-for _ in range(16):
-    m.Owner()
-during = m.collect_then_owner_deallocs()
-assert during > before, f'gc.collect() returned before tp_dealloc ran: {before} -> {during}'
+# drain left to the async action would not have happened yet.  Automatic
+# collection is off across the setup and the count is read again once it is
+# built, so a collection nobody asked for cannot be what moves the number.
+was_enabled = gc.isenabled()
+gc.disable()
+try:
+    before = m.owner_deallocs()
+    for _ in range(16):
+        m.Owner()
+    settled = m.owner_deallocs()
+    assert settled == before, f'an Owner was deallocated before the explicit collect: {before} -> {settled}'
+    during = m.collect_then_owner_deallocs()
+finally:
+    if was_enabled:
+        gc.enable()
+assert during > settled, f'gc.collect() returned before tp_dealloc ran: {settled} -> {during}'
 
 print('cpyext-lifetime-ok')
 "#;

--- a/pyre/pyrex/tests/cpyext_types.rs
+++ b/pyre/pyrex/tests/cpyext_types.rs
@@ -566,6 +566,15 @@ assert after > before, f'the last Owner was not deallocated: {before} -> {after}
 gc.collect()
 assert ref() is None, 'releasing the C reference did not let the object go'
 
+# ── and gc.collect() runs the deallocators before it returns ───────────
+# Read from C, so no bytecode runs between the collection and the count: a
+# drain left to the async action would not have happened yet.
+before = m.owner_deallocs()
+for _ in range(16):
+    m.Owner()
+during = m.collect_then_owner_deallocs()
+assert during > before, f'gc.collect() returned before tp_dealloc ran: {before} -> {during}'
+
 print('cpyext-lifetime-ok')
 "#;
 

--- a/pyre/pyrex/tests/fixtures/cpyext_types.c
+++ b/pyre/pyrex/tests/fixtures/cpyext_types.c
@@ -1146,6 +1146,29 @@ static PyObject *m_owner_deallocs(PyObject *self, PyObject *unused)
     return PyLong_FromLong(owner_deallocs);
 }
 
+/* Call gc.collect() and answer the deallocation count as it stands when that
+   call returns.  No bytecode runs in between, so a drain left to the next
+   async action has not happened yet and this reads the count from before it. */
+static PyObject *m_collect_then_owner_deallocs(PyObject *self, PyObject *unused)
+{
+    PyObject *module = PyImport_ImportModule("gc");
+    if (module == NULL) {
+        return NULL;
+    }
+    PyObject *collect = PyObject_GetAttrString(module, "collect");
+    Py_DECREF(module);
+    if (collect == NULL) {
+        return NULL;
+    }
+    PyObject *collected = PyObject_CallNoArgs(collect);
+    Py_DECREF(collect);
+    if (collected == NULL) {
+        return NULL;
+    }
+    Py_DECREF(collected);
+    return PyLong_FromLong(owner_deallocs);
+}
+
 static PyTypeObject OwnerType = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "cpyext_types.Owner",                       /* tp_name */
@@ -1807,6 +1830,8 @@ static PyMethodDef methods[] = {
     {"subclass_flags", m_subclass_flags, METH_NOARGS, "fast-subclass flags"},
     {"is_subtype", m_is_subtype, METH_NOARGS, "PyType_IsSubtype both ways"},
     {"owner_deallocs", m_owner_deallocs, METH_NOARGS, "how often Owner.tp_dealloc ran"},
+    {"collect_then_owner_deallocs", m_collect_then_owner_deallocs, METH_NOARGS,
+     "gc.collect(), then the count as it stands on return"},
     {NULL, NULL, 0, NULL},
 };
 


### PR DESCRIPTION
Four commits on top of `62d2029eb21`.

## `gc: release the queued cpyext mirrors before collect returns`

`gc.collect()` drains the cpyext dead queue before returning, so a mirror
released by the collection is gone by the time the call answers.

## `gc: ignore_finalizer, the copy/move write barriers, move_out_of_nursery, collect(gen) and set_max_heap_size`

Ports the `incminimark` surface that had readers but no writers:

- `ignore_finalizer` (`GCFLAG_IGNORE_FINALIZER`) — the flag had three readers
  and no setter. Wired to `rgc.may_ignore_finalizer`'s upstream call sites:
  `generator.frame_is_finished`, the coroutine arm of `_invoke_execute_frame`,
  and `W_IOBase.maybe_unregister_rpython_finalizer_io` for
  `_IOBase`/`BufferedReader`/`TextIOWrapper.close`.
- `writebarrier_before_copy` / `writebarrier_before_move` /
  `manually_copy_card_bits`, together with the
  `updated_old_objects_pointing_to_pinned` flag they read, set at the two sites
  that change the list.
- `move_out_of_nursery` and the `GCFLAG_SHADOW_INITIALIZED` arm of
  `_trace_drag_out` (`copy = False`), which had zero uses.
- `collect(gen)` via `minor_collection_with_major_progress(force_enabled)`,
  and `set_max_heap_size`.
- `builtin_id` hands the audit hook the value read back out of the pinned slot
  rather than the pre-normalization one.

16 new collector tests.

### A CPython-3.14 divergence in the hint's position

Upstream emits `rgc.may_ignore_finalizer(self)` *ahead* of the
`"can't send non-None value to a just-started %s"` raise. Ported verbatim that
loses a warning CPython emits:

| runtime | `c.send(1)` then `del c` |
|---|---|
| CPython 3.14.6 | TypeError **and** `coroutine 'f' was never awaited` |
| pypy3 7.3.22 | TypeError, **no warning** |

A rejected `send` does not start the coroutine, so this is not a 3.11↔3.14
axis — the hint's position is the cause. Under spec=CPython the hint goes
*behind* the raise, pinned by
`extra_tests/snippets/coroutine_never_awaited_survives_a_send_typeerror.py`.

Because the hint has no other app-level effect, a passing snippet alone would
not show the plumbing is live, so the tree was built once with upstream's
ordering as a red arm:

| arm | result |
|---|---|
| hint ahead of the raise (upstream) | `AssertionError: []` |
| hint behind the raise (this PR) | pass |

### Deliberately not done

`ll_arraycopy` is not switched to `writebarrier_before_copy`: the copy sites
already emit the unconditional `try_gc_write_barrier`, which is strictly more
conservative, and no production allocator sets `HAS_CARDS`, so the swap would
buy nothing and add a dependency on the nursery `TRACK_YOUNG_PTRS` discipline.
The list-shift sites cannot take `writebarrier_before_move` without a
`try_gc_owns_object` probe — the `std::alloc` fallback `ItemsBlock` carries no
`GcHeader` — and that probe is the hot query the codebase removed. The
obligation is documented at `alloc_in_oldgen_with_cards` instead.

`young_rawmalloced_objects` + `GCFLAG_VISITED_RMY` (and `malloc_big_fixedsize`
as a young rawmalloc, which depends on it) is not attempted: the youth
predicate is spread across eight `is_nursery_object_start` copy-decision sites,
and a partial port frees live objects.

## `launcher: consume a leading --heapsize and forward the interact option to the child`

`set_max_heap_size` has exactly one upstream production caller, and pyre's
half of it was parsing the value and throwing it away, with a comment saying
why: *"pyre's GC has no runtime heap-limit knob."* It does now.

- `pypy_interact.py main` — the controller resolves the `k`/`m`/`g` suffix and
  prepends `--heapsize <bytes>` to the sandboxed program's arguments
  (`extraoptions + arguments[1:]`), instead of discarding it.
- `targetpypystandalone.py entry_point` — `--heapsize N` in `argv[1]`, and no
  other position, is consumed and cut out (`argv[:1] + argv[3:]`), so it
  reaches neither `sys.argv` nor `sys.orig_argv`; `app_main.py` fills both from
  the list `entry_point` hands on.
- `parse_heapsize` refuses a count above `i64::MAX` (`bytes > sys.maxint`).

Verified by equivalence with the channel that already worked, same program and
same limit:

| arm | result |
|---|---|
| no limit (control) | `allocated 4000000` |
| `PYPY_GC_MAX=41943040` | `using too much memory, aborting` |
| `--heapsize 41943040` | identical |

### An open defect this surfaced

The first heap-limit event should raise `MemoryError` and does not.
`pyre_object::lltype::malloc_typed_managed` reads the collector's OOM `NULL` as
*no GC hook installed* and falls back to `std::alloc`, so the object is
allocated outside the GC heap, the program keeps running, and the next major
collection takes the `max_heap_size_already_raised` arm and aborts. The
collector comments that promise "the interpreter allocation chokepoint raises
`MemoryError`" are measured false. `PYPY_GC_MAX` has behaved this way all
along — the row above is the proof, since it runs untouched code. Aborting on
the *second* event is upstream-faithful; only the first event's `MemoryError`
is missing.

**The remaining `MemoryError` gap is still open**, but the fourth commit
addresses the classification half of it — see below.

## `gc_hook: separate a refused allocation from a missing hook at the four sites that merged them`

`majit_gc::GcAllocOutcome` splits `NoRoute` (no hook installed, so the caller's
own `malloc_raw` path *is* the whole heap) from `Failed` (a GC owns the heap and
could not satisfy the request), and its doc records that `malloc_raw` is the
wrong answer for the second: the object holds managed references the collector
never traces, behind a header it never walks.

`try_gc_alloc_stable_raw` collapsed the two into one null and documented the
collapse as information-free — *"every traced caller already treats those two
cases identically"* — which contradicts `GcAllocOutcome`'s doc in the same
crate. Its **48 callers** all answer that null with `malloc_typed` /
`malloc_raw` / `Box`. It now classifies, so null means `NoRoute` alone and a
`Failed` reaches `gc_alloc_failed`. `malloc_typed_managed`, `w_list_new`'s
rooted collecting allocation, and `w_dict_new`'s non-stable arm made the same
merge on their own `Option<*mut u8>` results and now classify too. Four edits
cover roughly fifty-one sites; `pyframe.rs` `alloc_frame_block` already did
this correctly and is the model.

**This is a latent-correctness fix, not a demonstrated one.** Behaviour is
unchanged in every configuration measured, and I could not construct a repro
that routes an OOM null through any of the four sites: list-heavy, dict-heavy
and `PYRE_JIT=0` programs at four different `--heapsize` limits all still abort
at the second event. On the stable path a `Failed` is reachable only through the
size-overflow guard, since `alloc_in_oldgen_clear` memclears its result
unconditionally — a null there would already segfault. What is fixed is the
contract, and the contradiction between the two doc comments.

Left alone deliberately: the items-block sites in `object_array.rs` fall back to
a `std::alloc` block, which is a gated supported configuration rather than an
off-heap accident; `weakref.rs` and `unicodeobject.rs` answer a `Failed` with an
*immortal* object, which stays in the root set and is traced.

## Gates

| lane | result |
|---|---|
| `check.py --synthetic-only` | 453/453 × dynasm, cranelift — ALL PASSED 2/2 |
| `extra_tests/run.py --gated-only` | 100/100 × cpython, dynasm, cranelift |
| `cargo test -p majit-gc` | 289 passed |
| `cargo test -p pyrex --lib` | 19 passed |
| `cargo test -p pyre-object --lib` | 292 passed |
| `cpyext_types` (dynasm,cpyext) | 2 passed |
| `cargo fmt --all -- --check` | clean |
| citation gate, rpython module parity | clean |

— *authored by Claude*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SXZZhZ24w8JtnFUaEGzjP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added generation-aware garbage collection controls and runtime heap-size configuration.
  * Added support for moving objects out of the nursery and selectively ignoring unnecessary finalizers.
  * Added launcher support for the `--heapsize` option.
  * `gc.collect()` now completes eligible native deallocations before returning.

* **Bug Fixes**
  * Improved coroutine and generator finalization behavior, including more accurate “never awaited” warnings.
  * Improved cleanup and finalizer handling when closing buffered and text I/O objects.
  * Fixed object pinning, allocation failure handling, and garbage-collection tracking in runtime operations.
  * Improved memory updates during object copying and movement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
