### PR TITLE
jit: follow-ups to the #1458 review

### DIFF
--- a/lib-python/3/test/test_generators.py
+++ b/lib-python/3/test/test_generators.py
@@ -317,20 +317,17 @@ class GeneratorTest(unittest.TestCase):
         # Test a freshly created generator (not suspended)
         g = generator(DetectDelete())
         g.close()
-        support.gc_collect()  # For PyPy or other GCs.
         self.assertTrue(DetectDelete.deleted)
 
         # Test a suspended generator
         g = generator(DetectDelete())
         next(g)
         g.close()
-        support.gc_collect()  # For PyPy or other GCs.
         self.assertTrue(DetectDelete.deleted)
 
         # Clear via gi_frame.clear()
         g = generator(DetectDelete())
         g.gi_frame.clear()
-        support.gc_collect()  # For PyPy or other GCs.
         self.assertTrue(DetectDelete.deleted)
 
 class ModifyUnderlyingIterableTest(unittest.TestCase):

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -303,13 +303,25 @@ pub fn current_extra_area() -> &'static str {
     CURRENT_EXTRA_AREA.with(|cell| cell.get())
 }
 
+/// Restores [`CURRENT_EXTRA_AREA`] on every exit path out of
+/// [`walk_one_extra_area`], an unwind included.  A plain store after the call
+/// is skipped when the area's walk panics, which leaves the finished area's
+/// label installed and makes the next validation failure name the wrong
+/// registrar -- the opposite of what the label exists for.
+struct ExtraAreaLabel(&'static str);
+
+impl Drop for ExtraAreaLabel {
+    fn drop(&mut self) {
+        CURRENT_EXTRA_AREA.with(|cell| cell.set(self.0));
+    }
+}
+
 /// Run one area's walk with [`current_extra_area`] naming it.
 fn walk_one_extra_area(area: &MutatorExtraArea, visitor: &mut dyn FnMut(&mut GcRef)) {
-    let previous = CURRENT_EXTRA_AREA.with(|cell| cell.replace(area.name));
+    let _label = ExtraAreaLabel(CURRENT_EXTRA_AREA.with(|cell| cell.replace(area.name)));
     // SAFETY: the callers below establish the quiescence / ownership
     // precondition; this helper only brackets the call.
     unsafe { (area.walk)(area.data, visitor) };
-    CURRENT_EXTRA_AREA.with(|cell| cell.set(previous));
 }
 
 /// Pruner for one owner-keyed side table owned by a registered mutator.

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -479,7 +479,7 @@ impl BlackholeInterpreter {
             &mut self.registers_r,
             jitcode.num_regs_and_consts_r(),
             jitcode.num_regs_r(),
-            jitcode.constants_r.iter().copied(),
+            jitcode.constants_r.iter().map(|slot| slot.get()),
         );
         Self::init_register_file_from_i64s(
             &mut self.registers_f,
@@ -514,7 +514,7 @@ impl BlackholeInterpreter {
             &mut self.registers_r,
             jitcode.num_regs_and_consts_r(),
             jitcode.num_regs_r(),
-            body.constants_r.iter().copied(),
+            body.constants_r.iter().map(|slot| slot.get()),
         );
         Self::init_register_file_from_i64s(
             &mut self.registers_f,

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -5455,7 +5455,7 @@ impl JitCodeBuilder {
             calldescr: self.calldescr,
             code: self.code,
             constants_i: self.constants_i,
-            constants_r: self.constants_r,
+            constants_r: self.constants_r.into_iter().map(Into::into).collect(),
             constants_f: self.constants_f,
             // This builder constructs bytecode directly and never emits
             // prebuilt-string ref constants, so the descriptor bank is empty.

--- a/majit/majit-metainterp/src/jitcode/mod.rs
+++ b/majit/majit-metainterp/src/jitcode/mod.rs
@@ -884,8 +884,8 @@ mod tests {
             c_num_regs_f: 1,
             constants_i: vec![100, 200, 300],
             constants_r: vec![
-                0xAABB_CCDD_EEFF_0011_u64 as i64,
-                0x2233_4455_6677_8899_u64 as i64,
+                (0xAABB_CCDD_EEFF_0011_u64 as i64).into(),
+                (0x2233_4455_6677_8899_u64 as i64).into(),
             ],
             constants_f: vec![f64::to_bits(1.25_f64) as i64],
             ..Default::default()

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -485,7 +485,8 @@ impl MIFrame {
             self.int_values[slot] = Some(value);
         }
         let num_regs_r = self.jitcode.c_num_regs_r as usize;
-        for (i, &value) in self.jitcode.constants_r.iter().enumerate() {
+        for (i, slot) in self.jitcode.constants_r.iter().enumerate() {
+            let value = slot.get();
             let slot = num_regs_r + i;
             self.ref_regs[slot] = Some(ctx.const_ref(value));
             self.ref_values[slot] = Some(value);
@@ -796,7 +797,7 @@ impl MIFrame {
                     // pyjitpl.py `copy_constants(..., constants_r, ...,
                     // ConstPtrJitCode)` — constants_r store raw GC
                     // addresses; we cast through u64 for `Box::ConstPtr`.
-                    OpBox::ConstPtr(self.jitcode.constants_r[idx - num_regs_r] as u64)
+                    OpBox::ConstPtr(self.jitcode.constants_r[idx - num_regs_r].get() as u64)
                 };
                 trace._add_box_to_storage_box(b);
             }
@@ -1000,7 +1001,10 @@ impl MIFrame {
                         SnapshotTagged::Box(opref, Type::Ref)
                     }
                 } else {
-                    SnapshotTagged::Const(self.jitcode.constants_r[idx - num_regs_r], Type::Ref)
+                    SnapshotTagged::Const(
+                        self.jitcode.constants_r[idx - num_regs_r].get(),
+                        Type::Ref,
+                    )
                 };
                 boxes.push(tagged);
             }
@@ -1701,7 +1705,7 @@ mod tests {
         {
             let jc = Arc::get_mut(&mut jitcode).expect("fresh Arc");
             jc.body_mut().constants_i = vec![123];
-            jc.body_mut().constants_r = vec![0x1234];
+            jc.body_mut().constants_r = vec![0x1234.into()];
             jc.body_mut().constants_f = vec![1.5f64.to_bits() as i64];
         }
         let sd = Arc::new(crate::MetaInterpStaticData::new());

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -574,7 +574,14 @@ impl Assembler {
             calldescr: BhCallDescr::default(),
             code: state.code,
             constants_i: state.constants_i,
-            constants_r: state.constants_r,
+            // The builder keeps plain `i64` — nothing walks a pool that is
+            // still being assembled. Interior mutability is owed only from
+            // publication onward, so the conversion happens here.
+            constants_r: state
+                .constants_r
+                .into_iter()
+                .map(super::jitcode::ConstSlotR::new)
+                .collect(),
             constants_f: state.constants_f,
             str_consts: state.str_consts,
             c_num_regs_i: num_regs_i as u16,

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -74,6 +74,87 @@ pub struct StrConstDescriptor {
 /// JitCode object in place; pyre groups the late-set fields into a body
 /// struct that is committed via `OnceLock::set` so `Arc<JitCode>` shells
 /// handed out by `CallControl::get_jitcode` can be filled while shared.
+/// One `constants_r` slot.
+///
+/// Interior-mutable because the GC's constant-pool walker forwards these slots
+/// at every collection, and by then the body is published behind an `Arc` with
+/// no `&mut` route left — [`JitCode::body_mut`] takes `&mut self` and its own
+/// doc records that `runtime_fnaddr_patch` can only call it *before*
+/// publication.  Writing through a `*mut` derived from `Vec::as_ptr()` on a
+/// shared body is undefined by the aliasing model even where it happens to
+/// work today, and a compiler free to keep the pre-write value in a register
+/// is precisely the stale-GC-reference failure the walker exists to prevent.
+///
+/// `AtomicI64` rather than `Cell<i64>`: the pool is reachable from more than
+/// one thread (`METAINTERP_SD` is thread-local, the `Arc` is not), so the
+/// element type has to stay `Sync`, and relaxed accesses lower to ordinary
+/// aligned loads and stores.
+///
+/// `repr(transparent)` keeps the pool bit-identical to the `Vec<i64>` it
+/// replaced.  Nothing reads it at a raw address today -- a jitcode operand is
+/// a register-slot byte (`const_pool_slot`) into a register file seeded from
+/// the pool, and the walker indexes the slice -- so this is about keeping the
+/// serialized form and any future word-level consumer honest, not about a
+/// current address-level reader.
+#[repr(transparent)]
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ConstSlotR(std::sync::atomic::AtomicI64);
+
+impl ConstSlotR {
+    pub const fn new(bits: i64) -> Self {
+        Self(std::sync::atomic::AtomicI64::new(bits))
+    }
+
+    #[inline]
+    pub fn get(&self) -> i64 {
+        self.0.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Store a forwarded address back into the slot. Shared-reference receiver
+    /// on purpose: the GC walker reaches the pool through an `Arc`.
+    #[inline]
+    pub fn set(&self, bits: i64) {
+        self.0.store(bits, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Unsynchronised access for a caller that still holds `&mut`, i.e. before
+    /// the jitcode is published behind an `Arc`. `runtime_fnaddr_patch` bakes
+    /// host addresses in during that window.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut i64 {
+        self.0.get_mut()
+    }
+}
+
+impl Clone for ConstSlotR {
+    fn clone(&self) -> Self {
+        Self::new(self.get())
+    }
+}
+
+impl PartialEq for ConstSlotR {
+    fn eq(&self, other: &Self) -> bool {
+        self.get() == other.get()
+    }
+}
+
+impl Eq for ConstSlotR {}
+
+/// Compare a slot against a plain word, so an assertion can spell the expected
+/// pool as `vec![0x1234]` rather than wrapping every element.
+impl PartialEq<i64> for ConstSlotR {
+    fn eq(&self, other: &i64) -> bool {
+        self.get() == *other
+    }
+}
+
+impl From<i64> for ConstSlotR {
+    fn from(bits: i64) -> Self {
+        Self::new(bits)
+    }
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct JitCodeBody {
     /// RPython `jitcode.py` `self.calldescr = calldescr`. RPython sets
@@ -91,7 +172,7 @@ pub struct JitCodeBody {
     /// RPython uses `lltype.cast_opaque_ptr(GCREF, ...)`; pyre stores the
     /// raw 64-bit address as `i64` to match the runtime jitcode/blackhole
     /// register file (where `r` registers also flow through `i64`).
-    pub constants_r: Vec<i64>,
+    pub constants_r: Vec<ConstSlotR>,
     /// RPython `jitcode.py:34` `self.constants_f`.
     /// RPython packs the float as `longlong.FLOATSTORAGE` (a 64-bit int
     /// reinterpretation); pyre stores the same bitwise representation as

--- a/pyre/bench/synth/settrace_local_tracer_armed_before_entry.py
+++ b/pyre/bench/synth/settrace_local_tracer_armed_before_entry.py
@@ -1,4 +1,5 @@
 # pyre-check: selfcheck
+# pyre-check: selfcheck-interpreted
 # Self-checking guard for the other half of the local-tracing contract: a
 # global tracer that RETURNS ITSELF, so `_trace` (executioncontext.py) installs
 # it as `w_f_trace` on every frame it sees a `call` event for, and the loop
@@ -63,9 +64,17 @@ def main():
     if acc != N * (N - 1) // 2:
         failures.append(f"acc: got {acc!r}, want {N * (N - 1) // 2!r}")
 
-    counts = {}
-    for event in events:
-        counts[event] = counts.get(event, 0) + 1
+    # Counted with `list.count` rather than a `for` loop on purpose.  A
+    # bookkeeping loop here is long enough to become hot and compile, and
+    # `run_selfcheck`'s JIT floor is corpus-level (`loops_compiled >= 1`), not
+    # "the loop under test compiled" -- so it would be satisfied by this loop
+    # while the loop the fixture is about never compiles, which is exactly the
+    # vacuous pass the floor exists to catch.  Measured: with the loop here the
+    # run reports `loops_compiled=1`, without it `0`.
+    counts = {
+        key: events.count(key)
+        for key in (("line", 3), ("line", 2), ("call", 0), ("return", 4))
+    }
     body = counts.get(("line", 3), 0)
     if body != N:
         failures.append(f"loop body: got {body!r} line events, want exactly {N!r}")

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1933,9 +1933,16 @@ def synth_selfcheck_interpreted(path):
     which for a guard against a *compiled* mis-admission is a pass that
     establishes nothing. `run_selfcheck` therefore requires the run to have
     compiled a loop, and this is how a fixture says its invariant is not about
-    compiled code: the two that carry it (`oserror_errno_fields_regression`,
-    `posix_replace_regression`) guard interpreter-level behaviour and measure
-    `loops_compiled=0` on every backend.
+    compiled code: the three that carry it (`oserror_errno_fields_regression`,
+    `posix_replace_regression`, `settrace_local_tracer_armed_before_entry`)
+    guard interpreter-level behaviour and measure `loops_compiled=0` on every
+    backend.
+
+    Note the floor it turns off is corpus-level — `loops_compiled >= 1` for the
+    run, not "the loop under test compiled" — so any hot loop in the file
+    satisfies it, a bookkeeping loop over recorded events included. A fixture
+    whose subject never compiles can therefore clear the floor by accident;
+    measure which loop was counted before concluding the floor covered it.
 
     An opt-out rather than an opt-in, so a fixture that quietly stops being
     compiled is reported rather than passing on in silence.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -137,7 +137,7 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
     // Top-level jitcode's per-bank constant pool — seeded into
     // register slots `[num_regs_*, num_regs_* + constants_*.len())`
     // per `pyjitpl.py copy_constants`.
-    top_constants_r: &[i64],
+    top_constants_r: &[majit_translate::codewriter::jitcode::ConstSlotR],
     top_constants_i: &[i64],
     top_constants_f: &[i64],
     // PyPy `pyjitpl.py setup_call(argboxes)` analog.
@@ -219,7 +219,8 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
         top_regs_i[top_num_regs_i + i] = trace_ctx.const_int(v);
         top_concrete_i[top_num_regs_i + i] = ConcreteValue::Int(v);
     }
-    for (i, &v) in top_constants_r.iter().enumerate() {
+    for (i, v) in top_constants_r.iter().enumerate() {
+        let v = v.get();
         top_regs_r[top_num_regs_r + i] = trace_ctx.const_ref(v);
         if v != 0 {
             top_concrete_r[top_num_regs_r + i] = ConcreteValue::Ref(v as pyre_object::PyObjectRef);
@@ -1163,7 +1164,8 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
         regs_i[num_regs_i + i] = ctx.const_int(v);
         concrete_i[num_regs_i + i] = ConcreteValue::Int(v);
     }
-    for (i, &v) in jc.constants_r.iter().enumerate() {
+    for (i, v) in jc.constants_r.iter().enumerate() {
+        let v = v.get();
         regs_r[num_regs_r + i] = ctx.const_ref(v);
         if v != 0 {
             concrete_r[num_regs_r + i] = ConcreteValue::Ref(v as pyre_object::PyObjectRef);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -2690,7 +2690,7 @@ pub(crate) fn fbw_callee_body_replay_safety(
     num_regs_i: usize,
     constants_i: &[i64],
     num_regs_r: usize,
-    constants_r: &[i64],
+    constants_r: &[majit_translate::codewriter::jitcode::ConstSlotR],
     callee_descr_refs: &[DescrRef],
     method_form_deferred_helpers: bool,
 ) -> CalleeReplaySafety {
@@ -2738,14 +2738,14 @@ pub(crate) fn fbw_callee_body_replay_safety(
     // holds the caller's argument.
     let mut seed_numeric_ref_regs = [false; u8::MAX as usize + 1];
     let mut seed_plain_int_ref_regs = [false; u8::MAX as usize + 1];
-    for (index, &raw) in constants_r.iter().enumerate() {
+    for (index, raw) in constants_r.iter().enumerate() {
         let Some(reg) = num_regs_r
             .checked_add(index)
             .filter(|r| *r < seed_numeric_ref_regs.len())
         else {
             break;
         };
-        let obj = raw as usize as pyre_object::PyObjectRef;
+        let obj = raw.get() as usize as pyre_object::PyObjectRef;
         if !obj.is_null() {
             let exact_int = unsafe { pyre_object::is_plain_int1(obj) };
             seed_plain_int_ref_regs[reg] = exact_int;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -7906,7 +7906,8 @@ pub(crate) fn allocate_callee_register_banks(
         regs_i[body.num_regs_i + i] = trace_ctx.const_int(v);
         concrete_i[body.num_regs_i + i] = ConcreteValue::Int(v);
     }
-    for (i, &v) in body.constants_r.iter().enumerate() {
+    for (i, v) in body.constants_r.iter().enumerate() {
+        let v = v.get();
         regs_r[body.num_regs_r + i] = trace_ctx.const_ref(v);
         concrete_r[body.num_regs_r + i] =
             ConcreteValue::Ref(v as usize as pyre_object::PyObjectRef);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -279,7 +279,7 @@ pub struct SubJitCodeBody {
     /// Callee's Ref-bank constant pool (`JitCode.constants_r`). Each
     /// `i64` is the erased `PyObjectRef` of a const object resolved
     /// at codewriter time.
-    pub constants_r: &'static [i64],
+    pub constants_r: &'static [majit_translate::codewriter::jitcode::ConstSlotR],
     /// Callee's Float-bank constant pool (`JitCode.constants_f`).
     pub constants_f: &'static [i64],
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -10246,12 +10246,21 @@ fn record_portal_debugdata_guard<Sym: WalkSym>(
         // that compiled at the 400th guard failure.
         //
         // A frame whose `debugdata` already exists records no guard below, so
-        // it looks like a residual half of this gap.  Measured, it is not.
-        // Reading `f_lineno`, `f_locals`, `locals()`, `f_lasti` or `f_back`
-        // does not create `debugdata` at all — among the paths tried only a
-        // write to one of the `f_trace*` attributes did — and a frame that HAS
-        // it still reports its whole tail: 99999 of 99999 `call` events at a
-        // 100000 tail, against 1042 with this decline disabled.  The exit is
+        // it looks like a residual half of this gap.  For tracing it is not:
+        // reading `f_lineno`, `f_locals`, `locals()`, `f_lasti` or `f_back`
+        // does not create `debugdata` at all, and a frame that HAS it still
+        // reports its whole tail — 99999 of 99999 `call` events at a 100000
+        // tail, against 1042 with this decline disabled.
+        //
+        // The creator is not only an `f_trace*` write, though.  `getorcreatedebug`
+        // is the single creation point, and `setprofile` / `setllprofile` reach
+        // it as `getorcreatedebug(-1).is_being_profiled = ...`, which mints a
+        // `debugdata` whose `w_f_trace` stays null.  So this arm is reachable
+        // with no tracer ever installed, and the guard-free return below is
+        // then load-bearing for the PROFILING path rather than incidental.
+        // That path is a separate open defect — its event ceiling measures the
+        // same with this decline and without it, so the decline is not what
+        // bounds it — and closing it is not what this change is for.  The exit is
         // `GuardNotForced` (`settrace` forces every frame) where the guard
         // below would otherwise be it, and this decline then refuses to
         // recompile, so the frame stays interpreted either way.  The decline

--- a/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
+++ b/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
@@ -205,7 +205,7 @@ pub fn patch_static_addr_constants(jitcodes: &mut [Arc<JitCode>]) {
             for c in body
                 .constants_i
                 .iter_mut()
-                .chain(body.constants_r.iter_mut())
+                .chain(body.constants_r.iter_mut().map(|slot| slot.get_mut()))
             {
                 if let Some(&runtime) = correspondence.get(c) {
                     *c = runtime;
@@ -336,11 +336,11 @@ pub fn materialize_str_consts(jitcodes: &mut [Arc<JitCode>]) {
             // The slot must still hold its non-canonical sentinel — never a
             // real address (which has the high bits clear).
             assert_eq!(
-                (body.constants_r[idx] as u64) & SENTINEL_HIGH_MASK,
+                (body.constants_r[idx].get() as u64) & SENTINEL_HIGH_MASK,
                 (majit_translate::assembler::STR_CONST_SENTINEL_BASE as u64) & SENTINEL_HIGH_MASK,
                 "constants_r[{idx}] did not hold a prebuilt-string sentinel",
             );
-            body.constants_r[idx] = addr;
+            body.constants_r[idx] = addr.into();
         }
     }
 }
@@ -371,7 +371,7 @@ mod tests {
         let jc = JitCode::new("test");
         jc.set_body(JitCodeBody {
             str_consts: descs,
-            constants_r,
+            constants_r: constants_r.into_iter().map(Into::into).collect(),
             ..Default::default()
         });
         Arc::new(jc)
@@ -390,7 +390,7 @@ mod tests {
         let mut jcs = vec![jitcode_with_str_consts(descs)];
         materialize_str_consts(&mut jcs);
 
-        let addr = jcs[0].body().constants_r[0];
+        let addr = jcs[0].body().constants_r[0].get();
         assert_ne!(addr, sentinel(0), "sentinel must be overwritten");
         assert_eq!(
             (addr as u64) & SENTINEL_HIGH_MASK,
@@ -422,8 +422,8 @@ mod tests {
             jitcode_with_str_consts(vec![desc()]),
         ];
         materialize_str_consts(&mut jcs);
-        let a0 = jcs[0].body().constants_r[0];
-        let a1 = jcs[1].body().constants_r[0];
+        let a0 = jcs[0].body().constants_r[0].get();
+        let a1 = jcs[1].body().constants_r[0].get();
         assert_eq!(
             a0, a1,
             "identical literals must share one immortal W_UnicodeObject",
@@ -470,7 +470,7 @@ mod tests {
         }];
         let mut jcs = vec![jitcode_with_str_consts(descs)];
         materialize_str_consts(&mut jcs);
-        let addr = jcs[0].body().constants_r[0];
+        let addr = jcs[0].body().constants_r[0].get();
         let cpu = crate::pyre_cpu::PyreCpu::new();
         assert_eq!(cpu.bh_strlen(GcRef(addr as usize)), Some(0));
     }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1478,33 +1478,41 @@ fn walk_jitcode_constants_refs_in(
         // `_remember_young_pointer_inlined` puts the written-to object on
         // `old_objects_pointing_to_young`, and the remembered set is scanned at
         // every minor, so the entry is kept and forwarded.  `constants_r` is a
-        // bare Rust `Vec<i64>` with no GC header to carry
+        // bare Rust `Vec` with no GC header to carry
         // GCFLAG_TRACK_YOUNG_PTRS, so this walker IS pyre's remembered set for
         // it, and owes both halves: drag the object out, and store back where
         // it went.
         //
-        // Sound for the same reason the `RefCell::as_ptr` read above is: the
-        // walk runs on the collecting thread with the owning mutator quiesced.
+        // The store goes through `ConstSlotR::set`, whose receiver is `&self`.
+        // By the time the walk runs the body is published behind an `Arc` and
+        // there is no `&mut` route to it, so a `*mut` cast out of
+        // `Vec::as_ptr()` would be a write through shared-reference provenance
+        // — undefined, and free to be compiled as if the slot still held the
+        // pre-write value, which is the stale GC reference this walker exists
+        // to prevent. Interior mutability makes the store well-defined instead
+        // of relying on it happening to survive optimisation.
+        //
         // `METAINTERP_SD` is thread-local while `Arc<RuntimeJitCode>` is not,
         // so two threads' areas can present the same slot; the second visit
         // reads an address that is no longer a nursery start and is a no-op.
+        // That is also why the slot is an `AtomicI64` and not a `Cell`.
         //
         // The pool also carries words that are not gcrefs at all — patched
         // host-static addresses and pre-patch STR sentinels.  `drag_out_root`
         // and `seed_major_root` reject them before any deref, which is what
         // makes handing them the whole pool safe; a fast path that pre-filtered
         // the slots would have to reproduce those gates.
-        let pool = jc.payload.jitcode.constants_r.as_ptr() as *mut i64;
+        let pool = jc.payload.jitcode.constants_r.as_slice();
         for pool_slot in 0..pool_len {
-            let cell = unsafe { pool.add(pool_slot) };
-            let mut gcref = majit_ir::GcRef(unsafe { *cell } as usize);
+            let cell = &pool[pool_slot];
+            let mut gcref = majit_ir::GcRef(cell.get() as usize);
             let before = gcref.0;
             if probe {
                 probe14_note_nursery("CONSTANT", before, jc.payload.jitcode.name(), jitcode_index);
             }
             visitor(&mut gcref);
             if gcref.0 != before {
-                unsafe { *cell = gcref.0 as i64 };
+                cell.set(gcref.0 as i64);
             }
             if probe {
                 PROBE14_SLOTS.fetch_add(1, Relaxed);
@@ -1616,7 +1624,8 @@ pub(crate) fn sub_jitcode_body_for_code(
             num_regs_i: jc.num_regs_i() as usize,
             num_regs_f: jc.num_regs_f() as usize,
             constants_i: &*(jc.constants_i.as_slice() as *const [i64]),
-            constants_r: &*(jc.constants_r.as_slice() as *const [i64]),
+            constants_r: &*(jc.constants_r.as_slice()
+                as *const [majit_translate::codewriter::jitcode::ConstSlotR]),
             constants_f: &*(jc.constants_f.as_slice() as *const [i64]),
         }
     })
@@ -6755,7 +6764,14 @@ impl PyreSym {
                 runtime_jc.num_regs_r() as usize,
                 runtime_jc.num_regs_f() as usize,
                 runtime_jc.constants_i.clone(),
-                runtime_jc.constants_r.clone(),
+                // Snapshot the pool's current values: `copy_constants`
+                // seeds a register file and never writes back, so it wants
+                // plain words, not the live interior-mutable slots.
+                runtime_jc
+                    .constants_r
+                    .iter()
+                    .map(|slot| slot.get())
+                    .collect::<Vec<i64>>(),
                 runtime_jc.constants_f.clone(),
             )
         };
@@ -14000,7 +14016,7 @@ mod tests {
         runtime_jc.body_mut().c_num_regs_r = 4;
         runtime_jc.body_mut().c_num_regs_f = 2;
         runtime_jc.body_mut().constants_i = vec![100, 200];
-        runtime_jc.body_mut().constants_r = vec![0xAABB_CCDD_u64 as i64];
+        runtime_jc.body_mut().constants_r = vec![(0xAABB_CCDD_u64 as i64).into()];
         runtime_jc.body_mut().constants_f = vec![3.25_f64.to_bits() as i64];
 
         let mut pyjit = crate::PyJitCode::skeleton(std::ptr::null());


### PR DESCRIPTION
Follow-ups to the review on #1458, which merged before these were addressed.

### `constants_r` interior mutability (Codex P1)

The GC's constant-pool walker forwarded slots through `constants_r.as_ptr() as *mut i64`.
By the time it runs the body is published behind an `Arc` and there is no `&mut` route to
it, so that is a write through shared-reference provenance — undefined by the aliasing
model, and free to be compiled as if the slot still held its pre-write value, which is the
stale GC reference the walker exists to remove. The pool is also handed out as long-lived
shared slices (`SubJitCodeBody::constants_r`), with the same problem.

Slots are now `ConstSlotR`, a `repr(transparent)` newtype over `AtomicI64`.
`AtomicI64` and not `Cell<i64>` because the pool is reachable from more than one thread —
`METAINTERP_SD` is thread-local, the `Arc` is not — so the element type has to stay `Sync`.
The assemblers keep building plain `i64` and convert at publication.

### `test_close_clears_frame` revert (Codex P1)

CPython 3.14.7 asserts `DetectDelete.deleted` immediately after `close()` and after
`gi_frame.clear()`, with no collection between. The three `support.gc_collect()` calls
weakened all three checks, and fixed nothing — `test.test_generators` is recorded
IMPORTERROR in `baseline.json`, so the module never runs. `cpython_tests/README.md` states
the rule: vendored tests carry PyPy's edits and nothing else, and a pyre-specific
expected-status decision belongs in the external baseline. The body is byte-identical to
upstream again.

### Extra-area label on an unwind (CodeRabbit)

`walk_one_extra_area` restored `CURRENT_EXTRA_AREA` only on normal return, so a panic left
the finished area's name installed and a later validation failure named the wrong
registrar. Restored from a `Drop` guard.

### The settrace fixture's JIT floor (CodeRabbit — accepted in substance, not in mechanism)

The review asked for `# pyre-check: selfcheck-interpreted`. That marker is for fixtures
measuring `loops_compiled=0`, and the file measured 1, so declaring it would have been
false. Measured where the 1 came from:

| variant | `loops_compiled` |
|---|---|
| counting loop replaced by C-level `list.count`, tracer still armed | **0** |
| tracer removed, both loops present | 1 |
| original | 1 |

`hot()`'s loop genuinely never compiles, as the file's header says. The floor was being
satisfied by `main()`'s `for event in events` bookkeeping loop — the JIT floor is
corpus-level (`loops_compiled >= 1` for the run), not "the loop under test compiled".
Removed the incidental loop so the marker is now true, and recorded the general gap in
`synth_selfcheck_interpreted`'s docstring.

### Portal tracing state (CodeRabbit — declined, but it found a real comment error)

The measured evidence for the guard-free return is already at the site. What was wrong is
the comment's account of what creates `debugdata`: it said only an `f_trace*` write did,
among paths tried. `getorcreatedebug` is the single creation point and
`setprofile` / `setllprofile` reach it as `getorcreatedebug(-1).is_being_profiled = ...`,
minting a `debugdata` whose `w_f_trace` stays null. So that arm is reachable with no tracer
installed, and the guard-free return is load-bearing for the profiling path. That path's
event ceiling measures the same with this decline and without it, so it is a separate
defect and not what this arm bounds. Comment corrected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved cleanup of generator frames and referenced objects when generators are closed or cleared.
  * Strengthened runtime handling of managed references during JIT execution and garbage-collection activities.
  * Improved recovery of runtime state when stack-walking operations exit unexpectedly.

* **Validation**
  * Expanded interpreter checks and test coverage for generator cleanup, tracing behavior, and reference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->