### PR TITLE
jit: fold an owned frame's f_lineno and zero-argument super()

### DIFF
--- a/pyre/bench/synth/bare_super_frame_escape.py
+++ b/pyre/bench/synth/bare_super_frame_escape.py
@@ -1,4 +1,5 @@
 # pyre-check: selfcheck
+# pyre-check: spec-folds=bare_super_call
 # Self-checking guard for zero-argument `super()` bound to a name, which is the
 # spelling that reaches the frame-escape path.
 #
@@ -32,6 +33,10 @@
 #      returns the caller's override.
 #   C  a three-deep chain, so a proxy built one level off is still wrong but
 #      would not be caught by a two-level shape alone.
+#   D  a `super()` that raises, which the fold carries rather than declines.
+#      Declining here would hand the same call to the generic residual a second
+#      time, and `super_check`'s `__class__` lookup is free to run Python, so
+#      the message and the raise count both have to survive the re-route.
 N = 20000
 
 
@@ -69,17 +74,28 @@ def main():
     site_a = set()
     site_b = set()
     site_c = set()
+    site_d = set()
     total = 0
     for _ in range(N):
         site_a.add(middle.val())
         site_b.add(leaf.val())
         site_c.add(leaf.tag())
+        try:
+            Leaf.val(42)
+        except TypeError as exc:
+            site_d.add(str(exc))
         total += 1
 
     for label, seen, want in (
         ("A", site_a, 11),
         ("B", site_b, 111),
         ("C", site_c, "leaf-middle-base"),
+        (
+            "D",
+            site_d,
+            "super(type, obj): obj (instance of int) is not an instance "
+            "or subtype of type (Leaf).",
+        ),
     ):
         if len(seen) != 1:
             print(f"FAIL site {label} diverged across iterations: {sorted(seen)}")

--- a/pyre/bench/synth/bare_super_frame_escape.py
+++ b/pyre/bench/synth/bare_super_frame_escape.py
@@ -33,10 +33,17 @@
 #      returns the caller's override.
 #   C  a three-deep chain, so a proxy built one level off is still wrong but
 #      would not be caught by a two-level shape alone.
-#   D  a `super()` that raises, which the fold carries rather than declines.
-#      Declining here would hand the same call to the generic residual a second
-#      time, and `super_check`'s `__class__` lookup is free to run Python, so
-#      the message and the raise count both have to survive the re-route.
+#   D  a receiver `super_check` rejects by walking MROs, so the fold declines
+#      before running anything and the generic residual owns the TypeError.
+#   E  a receiver `super_check` can only classify by asking Python, which the
+#      fold also declines.  E carries per-iteration data in its exception on
+#      purpose: D's message is identical every iteration, so D alone cannot
+#      tell a correctly-declined call from a folded one that answers with the
+#      RECORDING-time exception object.  E can — that answer collapses the
+#      distinct-message count, and it is what an earlier version of this fold
+#      did (20000 iterations, 1662 distinct).  E also pins that the `__class__`
+#      property runs exactly once per iteration, which a fold that executed the
+#      call and then declined would double.
 N = 20000
 
 
@@ -68,6 +75,30 @@ class Leaf(Middle):
         return "leaf-" + s.tag()
 
 
+class Tricky:
+    """A receiver `super_check` can only classify by asking Python."""
+
+    hits = 0
+
+    @property
+    def __class__(self):
+        Tricky.hits += 1
+        raise ValueError(str(Tricky.hits))
+
+
+class ETrap(Base):
+    """Site E's own method, reached only with a `Tricky` receiver.
+
+    Sharing `Leaf.val` does not work: the sites above compile it against a real
+    instance first, so the raising call side-exits on those guards and runs
+    interpreted, where the defect cannot appear.
+    """
+
+    def val(self):
+        s = super()
+        return s.val()
+
+
 def main():
     leaf = Leaf()
     middle = Middle()
@@ -75,6 +106,8 @@ def main():
     site_b = set()
     site_c = set()
     site_d = set()
+    site_e = set()
+    tricky = Tricky()
     total = 0
     for _ in range(N):
         site_a.add(middle.val())
@@ -85,6 +118,15 @@ def main():
         except TypeError as exc:
             site_d.add(str(exc))
         total += 1
+
+    # Site E gets its own loop on purpose.  Sharing the loop above leaves this
+    # call on a path the backend never compiles, and an uncompiled site cannot
+    # witness a compiled-iteration defect.
+    for _ in range(N):
+        try:
+            ETrap.val(tricky)
+        except ValueError as exc:
+            site_e.add(str(exc))
 
     for label, seen, want in (
         ("A", site_a, 11),
@@ -106,6 +148,16 @@ def main():
             return 1
     if total != N:
         print(f"FAIL dropped iteration: total={total}")
+        return 1
+    # Site E's message is the raise count, so one distinct message per
+    # iteration is the only answer that has the property running every
+    # iteration AND each raise reporting its own value.  A compiled iteration
+    # answering with the recording-time exception object collapses this.
+    if Tricky.hits != N:
+        print(f"FAIL site E ran the property {Tricky.hits} times, want {N}")
+        return 1
+    if len(site_e) != N:
+        print(f"FAIL site E saw {len(site_e)} distinct messages, want {N}")
         return 1
     print("PASS bare super frame escape")
     return 0

--- a/pyre/bench/synth/bare_super_frame_escape.py
+++ b/pyre/bench/synth/bare_super_frame_escape.py
@@ -1,0 +1,100 @@
+# pyre-check: selfcheck
+# Self-checking guard for zero-argument `super()` bound to a name, which is the
+# spelling that reaches the frame-escape path.
+#
+# The two spellings do not share a route.  `super().m()` compiles to
+# LOAD_SUPER_ATTR, which the JIT lowers to a frame-explicit residual: the red
+# frame travels as an operand and `builtin_super_from_frame` reads it, so the
+# force happens through the may-force channel the walker already models.
+# `s = super()` compiles to LOAD_GLOBAL super + CALL, which reaches
+# `builtin_super`'s zero-argument tail, and that calls
+# `ExecutionContext::gettopframe()` -- whose `force_frame` runs INSIDE an opaque
+# residual and clears TOKEN_TRACING_RESCALL, which the walker reads back as
+# `VableEscapedDuringResidualCall`.
+#
+# Measured on this shape, 200k iterations, dynasm: `super().val()` reports
+# loops_aborted=0 abrt_escape=0 fbw_force_by_portal=0, while `s = super()`
+# reports 5/5/5 -- same answer, different route.
+#
+# So this fixture is coverage of a route, not of a wrong answer: the escape
+# aborts a recording walk and the interpreter finishes the iteration, which is
+# why the answer stays correct while the loop stops compiling.  A regression
+# that made the escape return a WRONG proxy -- the outer portal frame's `self`
+# and `__class__` instead of the executing frame's -- would be invisible to a
+# counter and is exactly what the sites below pin.
+#
+# Sites:
+#   A  a method that binds `super()` to a name and calls through it, so the
+#      proxy must resolve against A's own class, not its caller's.
+#   B  the same in a callee the loop can inline, where the frame the proxy is
+#      built from is the callee's own and not the portal's.  A proxy built
+#      from the wrong frame answers with the caller's `__class__` cell and so
+#      returns the caller's override.
+#   C  a three-deep chain, so a proxy built one level off is still wrong but
+#      would not be caught by a two-level shape alone.
+N = 20000
+
+
+class Base:
+    def val(self):
+        return 1
+
+    def tag(self):
+        return "base"
+
+
+class Middle(Base):
+    def val(self):
+        s = super()
+        return s.val() + 10
+
+    def tag(self):
+        s = super()
+        return "middle-" + s.tag()
+
+
+class Leaf(Middle):
+    def val(self):
+        s = super()
+        return s.val() + 100
+
+    def tag(self):
+        s = super()
+        return "leaf-" + s.tag()
+
+
+def main():
+    leaf = Leaf()
+    middle = Middle()
+    site_a = set()
+    site_b = set()
+    site_c = set()
+    total = 0
+    for _ in range(N):
+        site_a.add(middle.val())
+        site_b.add(leaf.val())
+        site_c.add(leaf.tag())
+        total += 1
+
+    for label, seen, want in (
+        ("A", site_a, 11),
+        ("B", site_b, 111),
+        ("C", site_c, "leaf-middle-base"),
+    ):
+        if len(seen) != 1:
+            print(f"FAIL site {label} diverged across iterations: {sorted(seen)}")
+            return 1
+        got = next(iter(seen))
+        if got != want:
+            print(f"FAIL site {label} {got!r} != {want!r}")
+            return 1
+    if total != N:
+        print(f"FAIL dropped iteration: total={total}")
+        return 1
+    print("PASS bare super frame escape")
+    return 0
+
+
+import sys
+
+sys.exit(main())

--- a/pyre/bench/synth/frame_lineno_fold_coordinates.py
+++ b/pyre/bench/synth/frame_lineno_fold_coordinates.py
@@ -1,0 +1,85 @@
+# pyre-check: selfcheck
+# pyre-check: spec-folds=frame_lineno
+# Self-checking guard for the line an app-level `f_lineno` read reports for the
+# frame that is running it.
+#
+# `pyframe.py fget_f_lineno` decodes `last_instr` against the line table, and
+# `last_instr` is a virtualizable field.  A generic reader residualizes
+# `space.getattr` as one CALL_MAY_FORCE, and that force is the only reason the
+# frame's own copy of the field is current enough to decode.  The fold hands
+# the same getter body the coordinate the walk already holds instead, so the
+# decode runs with no force -- which means a wrong coordinate surfaces here as
+# a wrong LINE rather than as a crash.
+#
+# One iteration cannot see that.  The loop compiles part-way through, so an
+# interpreted answer and a compiled one that disagree appear as a SECOND
+# element of a set rather than as one shifted value; every site collects across
+# the whole run for that reason.
+#
+# Sites, and what each one pins:
+#   A  the receiver is a fresh local from this statement -- the common shape.
+#   B  the receiver was hoisted into a local BEFORE the loop, so the read is
+#      not on the frame's own box and the fold owes a `ptr_eq` guard.  Its
+#      answer is still the line being EXECUTED, not the line it was hoisted on,
+#      which is what separates the frame's current coordinate from the box the
+#      receiver arrived in.
+#   C  a read spread across physical lines, so the attribute lands on a
+#      different line from the statement that starts it.
+#   D  a callee reading its OWN frame.  The coordinate source differs by
+#      construction there: the portal's virtualizable describes the portal, so
+#      a callee read that took it would report the caller's CALL boundary.
+#
+# Not covered here: `f_lineno` with a trace function installed.  That branch of
+# the getter is the same leaf body, but arming local tracing on a compiled
+# frame is a separate open defect, so a fixture that armed it would be pinning
+# that defect rather than this fold.
+import sys
+
+N = 20000
+
+FIRST = sys._getframe().f_lineno
+
+
+def read_own_line():
+    return sys._getframe().f_lineno - FIRST                  # +4
+
+
+def main():
+    hoisted = sys._getframe()
+    site_a = set()
+    site_b = set()
+    site_c = set()
+    site_d = set()
+    total = 0
+    for i in range(N):
+        site_a.add(sys._getframe().f_lineno - FIRST)         # +15
+        total += i
+        site_b.add(hoisted.f_lineno - FIRST)                 # +17
+        site_c.add(
+            hoisted
+            .f_lineno                                        # +20
+            - FIRST
+        )
+        site_d.add(read_own_line())
+
+    for label, seen, want in (
+        ("A", site_a, 15),
+        ("B", site_b, 17),
+        ("C", site_c, 20),
+        ("D", site_d, 4),
+    ):
+        if len(seen) != 1:
+            print(f"FAIL site {label} diverged across iterations: {sorted(seen)}")
+            return 1
+        got = next(iter(seen))
+        if got != want:
+            print(f"FAIL site {label} f_lineno +{got} != +{want}")
+            return 1
+    if total != sum(range(N)):
+        print(f"FAIL dropped iteration: total={total}")
+        return 1
+    print("PASS f_lineno fold coordinates")
+    return 0
+
+
+sys.exit(main())

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -11278,6 +11278,38 @@ pub(crate) fn builtin_super(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 pub fn builtin_super_from_frame(
     frame_ptr: *mut crate::pyframe::PyFrame,
 ) -> Result<PyObjectRef, crate::PyError> {
+    let (w_class, w_self) = super_operands_from_frame(frame_ptr)?;
+    let obj_type = super_check(w_class, w_self)?;
+    Ok(pyre_object::descriptor::w_super_new(
+        w_class, obj_type, w_self,
+    ))
+}
+
+/// [`builtin_super_from_frame`] for a caller that must not run Python.
+///
+/// `None` where the full entry point would either raise or reach
+/// [`super_check`]'s `__class__` lookup, which a property answers with
+/// arbitrary code.  The meta-tracer executes this concretely while recording,
+/// where running Python could force the virtualizable it is recording against
+/// and where a raise it then declined would run those side effects twice, so
+/// it takes only the settled half and leaves the rest to the generic residual.
+pub fn builtin_super_from_frame_python_free(
+    frame_ptr: *mut crate::pyframe::PyFrame,
+) -> Option<PyObjectRef> {
+    let (w_class, w_self) = super_operands_from_frame(frame_ptr).ok()?;
+    let obj_type = super_check_python_free(w_class, w_self)?;
+    Some(pyre_object::descriptor::w_super_new(
+        w_class, obj_type, w_self,
+    ))
+}
+
+/// The `(__class__ cell, arg[0])` pair zero-argument `super()` is built from.
+///
+/// Every raising arm here reads frame state and runs no Python, so a caller
+/// may take the `Err` and walk away without having changed anything.
+fn super_operands_from_frame(
+    frame_ptr: *mut crate::pyframe::PyFrame,
+) -> Result<(PyObjectRef, PyObjectRef), crate::PyError> {
     if frame_ptr.is_null() {
         return Err(crate::PyError::runtime_error("super(): no current frame"));
     }
@@ -11329,10 +11361,7 @@ pub fn builtin_super_from_frame(
         ));
     }
 
-    let obj_type = super_check(w_class, w_self)?;
-    Ok(pyre_object::descriptor::w_super_new(
-        w_class, obj_type, w_self,
-    ))
+    Ok((w_class, w_self))
 }
 
 /// Exact builtins-namespace `super` type identity used by the meta-tracer's
@@ -11346,21 +11375,40 @@ pub fn is_builtin_super_type(obj: PyObjectRef) -> bool {
 
 /// `descriptor.py _super_check` — validate the explicit `(type, obj)` pair
 /// and return the class whose MRO a bound super proxy walks.
-pub(crate) fn super_check(
+/// The arms of [`super_check`] that settle by walking installed MROs, before
+/// it consults `__class__`.
+///
+/// Split out because the third arm runs `getattr_str`, and a `__class__`
+/// property answers it with arbitrary Python.  A caller that must not run
+/// Python asks for this half alone; `super_check` itself keeps the full
+/// sequence by starting here.
+pub(crate) fn super_check_python_free(
     start_type: PyObjectRef,
     obj_or_type: PyObjectRef,
-) -> Result<PyObjectRef, crate::PyError> {
+) -> Option<PyObjectRef> {
     unsafe {
         if pyre_object::is_type(obj_or_type)
             && crate::baseobjspace::issubtype_w(obj_or_type, start_type)
         {
-            return Ok(obj_or_type);
+            return Some(obj_or_type);
         }
         if let Some(obj_type) = crate::typedef::r#type(obj_or_type)
             && crate::baseobjspace::issubtype_w(obj_type.as_ptr(), start_type)
         {
-            return Ok(obj_type.as_ptr());
+            return Some(obj_type.as_ptr());
         }
+    }
+    None
+}
+
+pub(crate) fn super_check(
+    start_type: PyObjectRef,
+    obj_or_type: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    if let Some(obj_type) = super_check_python_free(start_type, obj_or_type) {
+        return Ok(obj_type);
+    }
+    unsafe {
         match crate::baseobjspace::getattr_str(obj_or_type, "__class__") {
             Ok(apparent_type) => {
                 if pyre_object::is_type(apparent_type)

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -4218,6 +4218,18 @@ impl PyFrame {
     /// pyframe.py get_last_lineno → pytraceback.offset2lineno(pycode, last_instr)
     #[inline]
     pub fn get_last_lineno(&self) -> isize {
+        self.get_lineno_at(self.last_instr)
+    }
+
+    /// [`Self::get_last_lineno`] for an instruction the caller names instead of
+    /// the one the frame's own field records.
+    ///
+    /// `last_instr` is a virtualizable field, so a compiled loop keeps the
+    /// executing coordinate in its own trace-time state and the frame's copy is
+    /// only made current by a force.  A caller that already holds that
+    /// coordinate answers this read without one.
+    #[inline]
+    pub fn get_lineno_at(&self, last_instr: isize) -> isize {
         // A line table that records no position at all reports ``f_lineno is
         // None`` rather than the code object's first line number.  The decoded
         // `locations` cannot answer this: a `SourceLocation` always carries a
@@ -4231,7 +4243,7 @@ impl PyFrame {
         // usable entry for the current instruction.  Ruff's decoded
         // zero-line entries reach us as line 0; preserve the frame getter's
         // existing -1 sentinel instead of leaking that implementation value.
-        match offset2lineno(self.code(), self.last_instr) {
+        match offset2lineno(self.code(), last_instr) {
             0 => -1,
             lineno => lineno as isize,
         }
@@ -4269,7 +4281,19 @@ impl PyFrame {
     /// `f_trace` test only selects the -1 fallback.
     #[inline]
     pub fn fget_f_lineno(&self) -> PyObjectRef {
-        let lineno = self.get_last_lineno();
+        self.f_lineno_at(self.last_instr)
+    }
+
+    /// [`Self::fget_f_lineno`] for an instruction the caller names, on the same
+    /// terms as [`Self::get_lineno_at`].
+    ///
+    /// The whole getter body stays here rather than being split across the
+    /// caller: the `f_trace` test, the `-1` sentinel and the `first_line_number`
+    /// fallback are one decision, and a caller reproducing part of it would
+    /// answer a differently-shaped read.
+    #[inline]
+    pub fn f_lineno_at(&self, last_instr: isize) -> PyObjectRef {
+        let lineno = self.get_lineno_at(last_instr);
         if self.get_w_f_trace().is_null() {
             if lineno == -1 {
                 return pyre_object::w_none();

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -371,24 +371,44 @@ pub extern "C" fn jit_mapdict_unboxed_read_raw(
     }
 }
 
+/// Enter a residual leaf's exception into both channels the trailing
+/// `GuardNoException` and the blackhole read, and answer the null a leaf
+/// returns on the raising arm.
+fn publish_leaf_exception(err: &mut pyre_interpreter::PyError) -> i64 {
+    let exc = err.to_exc_object() as i64;
+    majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc));
+    #[cfg(all(feature = "cranelift", not(target_arch = "wasm32")))]
+    majit_backend_cranelift::jit_exc_raise(exc);
+    #[cfg(all(feature = "dynasm", not(target_arch = "wasm32")))]
+    majit_backend_dynasm::jit_exc_raise(exc);
+    #[cfg(target_arch = "wasm32")]
+    majit_backend_wasm::jit_exc_raise(exc);
+    let _ = exc;
+    0
+}
+
 /// `normalize_hash_digest` as a JIT residual: normalize a boxed `__hash__`
 /// digest to the machine hash, raising for a non-integer.  On error the
 /// exception enters both channels for the trailing `GuardNoException`.
 pub extern "C" fn jit_hash_normalize_digest(digest: i64) -> i64 {
     match pyre_interpreter::builtins::normalize_hash_digest(digest as PyObjectRef) {
         Ok(h) => h,
-        Err(mut err) => {
-            let exc = err.to_exc_object() as i64;
-            majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc));
-            #[cfg(all(feature = "cranelift", not(target_arch = "wasm32")))]
-            majit_backend_cranelift::jit_exc_raise(exc);
-            #[cfg(all(feature = "dynasm", not(target_arch = "wasm32")))]
-            majit_backend_dynasm::jit_exc_raise(exc);
-            #[cfg(target_arch = "wasm32")]
-            majit_backend_wasm::jit_exc_raise(exc);
-            let _ = exc;
-            0
-        }
+        Err(mut err) => publish_leaf_exception(&mut err),
+    }
+}
+
+/// `descriptor.py _super_from_frame` as a JIT residual: build the zero-argument
+/// `super()` proxy from the frame the caller names, rather than from the frame
+/// `ExecutionContext::gettopframe()` rediscovers.
+///
+/// This is the entry point `LOAD_SUPER_ATTR` already reaches through
+/// `bh_load_super_attr_fn`; naming it directly is what lets the name-bound
+/// spelling take the same route.
+pub extern "C" fn jit_bare_super_from_frame(frame: i64) -> i64 {
+    let frame = frame as usize as *mut pyre_interpreter::PyFrame;
+    match pyre_interpreter::builtins::builtin_super_from_frame(frame) {
+        Ok(proxy) => proxy as i64,
+        Err(mut err) => publish_leaf_exception(&mut err),
     }
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -380,6 +380,7 @@ pub const SPEC_FOLD_ROWS: [(&str, &str, &str); 74] = [
     ("instance_next",             "residual_call", "-"),
     ("frame_lasti",               "specialize",    "load_attr"),
     ("load_deref",                "residual_call", "-"),
+    ("frame_lineno",              "specialize",    "load_attr"),
 ];
 
 const SPEC_FOLD_COUNT: usize = SPEC_FOLD_ROWS.len();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -381,6 +381,7 @@ pub const SPEC_FOLD_ROWS: [(&str, &str, &str); 74] = [
     ("frame_lasti",               "specialize",    "load_attr"),
     ("load_deref",                "residual_call", "-"),
     ("frame_lineno",              "specialize",    "load_attr"),
+    ("bare_super_call",           "residual_call", "-"),
 ];
 
 const SPEC_FOLD_COUNT: usize = SPEC_FOLD_ROWS.len();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -304,7 +304,7 @@ pub fn skip_python_trivia_forward(code: &pyre_interpreter::CodeObject, mut py_pc
 /// `parent` marks the second row as a split of the first so the reader does not
 /// sum them.
 #[rustfmt::skip]
-pub const SPEC_FOLD_ROWS: [(&str, &str, &str); 74] = [
+pub const SPEC_FOLD_ROWS: [(&str, &str, &str); 75] = [
     // (label, site, parent)
     ("truth_int",                 "residual_call", "-"),
     ("truth_bool",                "residual_call", "-"),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -276,9 +276,12 @@ pub struct SubJitCodeBody {
     /// `setposition` (RPython `pyjitpl.py copy_constants`)
     /// pre-populates those slots with `ConstClass(constants_i[i])`.
     pub constants_i: &'static [i64],
-    /// Callee's Ref-bank constant pool (`JitCode.constants_r`). Each
-    /// `i64` is the erased `PyObjectRef` of a const object resolved
-    /// at codewriter time.
+    /// Callee's Ref-bank constant pool (`JitCode.constants_r`). Each slot
+    /// holds, behind `ConstSlotR::get`, the erased `PyObjectRef` of a const
+    /// object resolved at codewriter time. The slot is interior-mutable
+    /// because the GC walker forwards it in place once a collection moves the
+    /// object it names, and by then the pool is reachable only through an
+    /// `Arc`.
     pub constants_r: &'static [majit_translate::codewriter::jitcode::ConstSlotR],
     /// Callee's Float-bank constant pool (`JitCode.constants_f`).
     pub constants_f: &'static [i64],

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -6551,6 +6551,18 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && let Some(outcome) = spec_gate("bare_super_call", || {
+            try_walker_specialize_bare_super_call(ctx, code, op, &r_args, dst)
+        })?
+    {
+        // The fold carries `super()`'s raising arms itself rather than handing
+        // this call to the generic residual a second time, so its outcome —
+        // not a fixed `Continue` — is what the step reports.
+        return Ok((outcome, op.next_pc));
+    }
+    if ctx.is_authoritative_executor
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
         && spec_gate("float_call", || {
             try_walker_specialize_float_call(ctx, code, op, &r_args, dst)
         })?

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -6551,14 +6551,12 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && let Some(outcome) = spec_gate("bare_super_call", || {
+        && spec_gate("bare_super_call", || {
             try_walker_specialize_bare_super_call(ctx, code, op, &r_args, dst)
         })?
+        .is_some()
     {
-        // The fold carries `super()`'s raising arms itself rather than handing
-        // this call to the generic residual a second time, so its outcome —
-        // not a fixed `Continue` — is what the step reports.
-        return Ok((outcome, op.next_pc));
+        return Ok((DispatchOutcome::Continue, op.next_pc));
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2647,36 +2647,49 @@ fn walker_write_back_standard_frame_locals<Sym: WalkSym>(
 /// A receiver that is not this level's own frame declines, which is what keeps
 /// a suspended generator's frame, a traceback node's frame and a caller's
 /// frame read from inside a callee on the residual getter that reads the heap.
+/// The box and concrete address of the frame the walk is executing.
+///
+/// Two sources, chosen by whether a sub-walk is active, because they describe
+/// different frames: the portal's virtualizable describes the PORTAL, so an
+/// inlined callee has to answer from its own shadow or it reports its caller's.
+fn walker_executing_frame_box<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+) -> Option<(OpRef, usize)> {
+    let inline_frame = current_inline_concrete_frame();
+    if inline_frame != 0 {
+        let shadow = ctx.callee_shadow.as_ref()?;
+        if shadow.concrete_frame != inline_frame || shadow.frame_box == OpRef::NONE {
+            return None;
+        }
+        return Some((shadow.frame_box, inline_frame));
+    }
+    if ctx.fbw_mode.inline_subwalk {
+        return None;
+    }
+    let vable_box = ctx.trace_ctx.standard_virtualizable_box()?;
+    let vable_ptr = ctx.trace_ctx.standard_virtualizable_ptr()?;
+    Some((vable_box, vable_ptr))
+}
+
 fn walker_frame_executing_py_pc<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
     concrete_obj: pyre_object::PyObjectRef,
     op_pc: usize,
 ) -> Option<(OpRef, u32)> {
-    let inline_frame = current_inline_concrete_frame();
-    if inline_frame != 0 {
-        let shadow = ctx.callee_shadow.as_ref()?;
-        if shadow.concrete_frame != inline_frame
-            || shadow.frame_box == OpRef::NONE
-            || concrete_obj as usize != inline_frame
-        {
-            return None;
-        }
-        return Some((
-            shadow.frame_box,
-            residual_call::inline_callee_py_pc(ctx, op_pc)?,
-        ));
+    let (frame_box, frame_ptr) = walker_executing_frame_box(ctx)?;
+    if frame_ptr != concrete_obj as usize {
+        return None;
+    }
+    if current_inline_concrete_frame() != 0 {
+        return Some((frame_box, residual_call::inline_callee_py_pc(ctx, op_pc)?));
     }
     // An inline sub-walk with no concrete callee frame has no level-local
     // coordinate to answer with: `vstack_cur_pypc` is the outer walk's mirror
     // and a sub-walk never advances it.
-    if ctx.fbw_mode.inline_subwalk || !ctx.vstack_valid {
+    if !ctx.vstack_valid {
         return None;
     }
-    let vable_box = ctx.trace_ctx.standard_virtualizable_box()?;
-    if ctx.trace_ctx.standard_virtualizable_ptr() != Some(concrete_obj as usize) {
-        return None;
-    }
-    Some((vable_box, ctx.vstack_cur_pypc))
+    Some((frame_box, ctx.vstack_cur_pypc))
 }
 
 /// Prove the receiver IS the frame the walk is executing, and answer that
@@ -2851,6 +2864,138 @@ fn try_walker_specialize_frame_lineno<Sym: WalkSym>(
     );
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, value)?;
     Ok(Some(()))
+}
+
+/// Zero-argument `super()` reached as a call, i.e. the `LOAD_GLOBAL super` +
+/// `CALL` spelling a name binding produces rather than `LOAD_SUPER_ATTR`.
+///
+/// Both spellings force the virtualizable — `codewriter.rs` binds
+/// `load_super_attr_fn` with `CallFlavor::MayForce`, because a descriptor
+/// `__get__` may run Python — so this is not about removing a force.  What
+/// differs is where the force happens.  `LOAD_SUPER_ATTR` forces inside a
+/// may-force residual that carries the red frame as an operand, which the
+/// walker models.  The call spelling reaches `builtin_super`'s zero-argument
+/// tail, whose `ExecutionContext::gettopframe()` runs `force_frame` INSIDE an
+/// opaque `bh_call_fn`; that clears `TOKEN_TRACING_RESCALL` and
+/// `tracing_after_residual_call` reads it back as
+/// `VableEscapedDuringResidualCall`.  The frame `gettopframe` answers with is
+/// the one being traced, so that residual always escapes and the loop always
+/// aborts.
+///
+/// So the emission is a re-route: name
+/// [`crate::helpers::jit_bare_super_from_frame`] — the same `descriptor.py
+/// _super_from_frame` half `bh_load_super_attr_fn` calls — as a may-force
+/// residual taking the walk's own frame box.  The force still happens; it moves
+/// to the channel the walker can see, which is the difference between an
+/// escape and an ordinary forced residual.
+///
+/// A raise is carried, not declined.  Declining after the concrete call would
+/// hand the same work to the generic residual a second time, and this call is
+/// not repeatable: `super_check` reaches `getattr_str(obj, "__class__")`
+/// whenever neither `obj` nor `type(obj)` is already a subtype of the
+/// `__class__` cell, so a `__class__` property would run twice.  The raising
+/// arms take the generic residual's own `Err` route instead — seed
+/// `last_exc_value`, emit `GuardException`, surface `SubRaise`.
+pub(crate) fn try_walker_specialize_bare_super_call<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    code: &[u8],
+    op: &DecodedOp,
+    r_args: &[OpRef],
+    dst: usize,
+) -> Result<Option<DispatchOutcome>, DispatchError> {
+    // `super()` with no user arguments arrives as `[callable, null_or_self]`.
+    if r_args.len() != 2 {
+        return Ok(None);
+    }
+    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
+    let (ConcreteValue::Ref(concrete_callable), ConcreteValue::Ref(null_or_self)) =
+        (arg_concretes[0], arg_concretes[1])
+    else {
+        return Ok(None);
+    };
+    if concrete_callable.is_null()
+        || !null_or_self.is_null()
+        || !pyre_interpreter::builtins::is_builtin_super_type(concrete_callable)
+    {
+        return Ok(None);
+    }
+    let Some((frame_box, frame_ptr)) = walker_executing_frame_box(ctx) else {
+        return Ok(None);
+    };
+    // Pin the callable the way the constructor folds do, so rebinding the
+    // global `super` side-exits instead of keeping this route.
+    let callable_op = r_args[0];
+    if !callable_op.is_constant() {
+        let expected = ctx.trace_ctx.const_ref(concrete_callable as i64);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardValue, &[callable_op, expected], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(callable_op, expected);
+    }
+    residual_call::maybe_walker_vable_and_vrefs_before_residual_call(ctx, op.pc);
+    // Steps 2-3 of `MetaInterp._do_jit_call` bracket the CONCRETE execution,
+    // and this execution can run Python on the `super_check` arm above.  A
+    // `__class__` property is free to touch a frame the loop handed out, and a
+    // vref forced that way keeps its pre-call token unless the bracket reads it
+    // back: `vrefs_after_residual_call` would never record `VIRTUAL_REF_FINISH`
+    // and the resume snapshot would go on claiming the frame is still virtual.
+    // Both halves run before the CALL op is recorded, which is the order
+    // `stop_tracking_virtualref` documents.
+    ctx.trace_ctx.vrefs_before_residual_call();
+    let concrete = pyre_interpreter::builtins::builtin_super_from_frame(
+        frame_ptr as *mut pyre_interpreter::PyFrame,
+    );
+    ctx.trace_ctx.vrefs_after_residual_call();
+    let result = ctx.trace_ctx.call_typed_with_effect(
+        OpCode::CallMayForceR,
+        crate::helpers::jit_bare_super_from_frame as *const (),
+        &[frame_box],
+        &[majit_ir::Type::Ref],
+        majit_ir::Type::Ref,
+        majit_ir::EffectInfo::new(
+            majit_ir::ExtraEffect::ForcesVirtualOrVirtualizable,
+            majit_ir::OopSpecIndex::None,
+        ),
+    );
+    // The leaf answers null on its raising arm, so the recorded result carries
+    // the same shadow the raising execution produced.
+    let raised = match concrete {
+        Ok(proxy) => {
+            ctx.trace_ctx.set_opref_concrete(
+                result,
+                majit_ir::Value::Ref(majit_ir::GcRef(proxy as usize)),
+            );
+            None
+        }
+        Err(mut err) => {
+            let exc = err.to_exc_object();
+            ctx.trace_ctx
+                .set_opref_concrete(result, majit_ir::Value::Ref(majit_ir::GcRef(0)));
+            // `execute_raised(exception, constant=False)`: the walk's standing
+            // exception lives in `last_exc_value`, and the class has not been
+            // proven by a guard yet.
+            let exc_op = ctx.trace_ctx.const_ref(exc as i64);
+            let exc_concrete = ConcreteValue::Ref(exc);
+            ctx.last_exc_value = Some(exc_op);
+            ctx.last_exc_value_concrete = exc_concrete;
+            ctx.fbw_mode.class_of_last_exc_is_const = false;
+            Some((exc_op, exc_concrete))
+        }
+    };
+    // The dst is written before both guards, the ordering
+    // `_opimpl_residual_call*` keeps so the dst slot's OpRef rides their
+    // snapshots.
+    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', result)?;
+    ctx.trace_ctx.record_guard(OpCode::GuardNotForced, &[], 0);
+    walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    if let Some((exc, exc_concrete)) = raised {
+        walker_record_guard_exception(ctx, op.pc);
+        return Ok(Some(DispatchOutcome::SubRaise { exc, exc_concrete }));
+    }
+    walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardNoException, &[])?;
+    Ok(Some(DispatchOutcome::Continue))
 }
 
 /// `mapdict.py LOAD_ATTR_caching` full-body-walker fast path for a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2889,20 +2889,26 @@ fn try_walker_specialize_frame_lineno<Sym: WalkSym>(
 /// to the channel the walker can see, which is the difference between an
 /// escape and an ordinary forced residual.
 ///
-/// A raise is carried, not declined.  Declining after the concrete call would
-/// hand the same work to the generic residual a second time, and this call is
-/// not repeatable: `super_check` reaches `getattr_str(obj, "__class__")`
-/// whenever neither `obj` nor `type(obj)` is already a subtype of the
-/// `__class__` cell, so a `__class__` property would run twice.  The raising
-/// arms take the generic residual's own `Err` route instead — seed
-/// `last_exc_value`, emit `GuardException`, surface `SubRaise`.
+/// Only the receivers `super_check` settles without running Python are folded.
+/// [`pyre_interpreter::builtins::builtin_super_from_frame_python_free`] answers
+/// `None` for the rest, and they keep the generic residual.
+///
+/// The walk executes its residuals concretely, and this one would otherwise run
+/// `super_check`'s `__class__` lookup — arbitrary code, which is free to force
+/// the very virtualizable being recorded against and whose side effects a
+/// decline would then repeat under the generic residual.  Restricting the fold
+/// to the settled half makes the recording-time call a read: it cannot force,
+/// so it owes no `vrefs_before/after_residual_call` bracket around itself, and
+/// it cannot raise, so there is no exception to carry.  The runtime leaf still
+/// runs the whole entry point, which is what the trailing `GuardNotForced` and
+/// `GuardNoException` are for.
 pub(crate) fn try_walker_specialize_bare_super_call<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],
     op: &DecodedOp,
     r_args: &[OpRef],
     dst: usize,
-) -> Result<Option<DispatchOutcome>, DispatchError> {
+) -> Result<Option<()>, DispatchError> {
     // `super()` with no user arguments arrives as `[callable, null_or_self]`.
     if r_args.len() != 2 {
         return Ok(None);
@@ -2922,6 +2928,12 @@ pub(crate) fn try_walker_specialize_bare_super_call<Sym: WalkSym>(
     let Some((frame_box, frame_ptr)) = walker_executing_frame_box(ctx) else {
         return Ok(None);
     };
+    // Ahead of every emission, so a decline leaves the trace untouched.
+    let Some(proxy) = pyre_interpreter::builtins::builtin_super_from_frame_python_free(
+        frame_ptr as *mut pyre_interpreter::PyFrame,
+    ) else {
+        return Ok(None);
+    };
     // Pin the callable the way the constructor folds do, so rebinding the
     // global `super` side-exits instead of keeping this route.
     let callable_op = r_args[0];
@@ -2935,67 +2947,33 @@ pub(crate) fn try_walker_specialize_bare_super_call<Sym: WalkSym>(
             .replace_box(callable_op, expected);
     }
     residual_call::maybe_walker_vable_and_vrefs_before_residual_call(ctx, op.pc);
-    // Steps 2-3 of `MetaInterp._do_jit_call` bracket the CONCRETE execution,
-    // and this execution can run Python on the `super_check` arm above.  A
-    // `__class__` property is free to touch a frame the loop handed out, and a
-    // vref forced that way keeps its pre-call token unless the bracket reads it
-    // back: `vrefs_after_residual_call` would never record `VIRTUAL_REF_FINISH`
-    // and the resume snapshot would go on claiming the frame is still virtual.
-    // Both halves run before the CALL op is recorded, which is the order
-    // `stop_tracking_virtualref` documents.
-    ctx.trace_ctx.vrefs_before_residual_call();
-    let concrete = pyre_interpreter::builtins::builtin_super_from_frame(
-        frame_ptr as *mut pyre_interpreter::PyFrame,
-    );
-    ctx.trace_ctx.vrefs_after_residual_call();
+    // `MOST_GENERAL`, not a fresh `EffectInfo`: the leaf is the whole entry
+    // point, whose `super_check` arm can run a `__class__` property, so no
+    // read/write descr set describes it.  A constructed `EffectInfo` inherits
+    // EMPTY sets, which claims the opposite and lets the optimizer keep cached
+    // fields across the call.  `RandomEffects` outranks
+    // `ForcesVirtualOrVirtualizable`, so this keeps the may-force reading the
+    // `GuardNotForced` below depends on.
     let result = ctx.trace_ctx.call_typed_with_effect(
         OpCode::CallMayForceR,
         crate::helpers::jit_bare_super_from_frame as *const (),
         &[frame_box],
         &[majit_ir::Type::Ref],
         majit_ir::Type::Ref,
-        majit_ir::EffectInfo::new(
-            majit_ir::ExtraEffect::ForcesVirtualOrVirtualizable,
-            majit_ir::OopSpecIndex::None,
-        ),
+        majit_ir::EffectInfo::MOST_GENERAL,
     );
-    // The leaf answers null on its raising arm, so the recorded result carries
-    // the same shadow the raising execution produced.
-    let raised = match concrete {
-        Ok(proxy) => {
-            ctx.trace_ctx.set_opref_concrete(
-                result,
-                majit_ir::Value::Ref(majit_ir::GcRef(proxy as usize)),
-            );
-            None
-        }
-        Err(mut err) => {
-            let exc = err.to_exc_object();
-            ctx.trace_ctx
-                .set_opref_concrete(result, majit_ir::Value::Ref(majit_ir::GcRef(0)));
-            // `execute_raised(exception, constant=False)`: the walk's standing
-            // exception lives in `last_exc_value`, and the class has not been
-            // proven by a guard yet.
-            let exc_op = ctx.trace_ctx.const_ref(exc as i64);
-            let exc_concrete = ConcreteValue::Ref(exc);
-            ctx.last_exc_value = Some(exc_op);
-            ctx.last_exc_value_concrete = exc_concrete;
-            ctx.fbw_mode.class_of_last_exc_is_const = false;
-            Some((exc_op, exc_concrete))
-        }
-    };
+    ctx.trace_ctx.set_opref_concrete(
+        result,
+        majit_ir::Value::Ref(majit_ir::GcRef(proxy as usize)),
+    );
     // The dst is written before both guards, the ordering
     // `_opimpl_residual_call*` keeps so the dst slot's OpRef rides their
     // snapshots.
     write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', result)?;
     ctx.trace_ctx.record_guard(OpCode::GuardNotForced, &[], 0);
     walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-    if let Some((exc, exc_concrete)) = raised {
-        walker_record_guard_exception(ctx, op.pc);
-        return Ok(Some(DispatchOutcome::SubRaise { exc, exc_concrete }));
-    }
     walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardNoException, &[])?;
-    Ok(Some(DispatchOutcome::Continue))
+    Ok(Some(()))
 }
 
 /// `mapdict.py LOAD_ATTR_caching` full-body-walker fast path for a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2679,6 +2679,44 @@ fn walker_frame_executing_py_pc<Sym: WalkSym>(
     Some((vable_box, ctx.vstack_cur_pypc))
 }
 
+/// Prove the receiver IS the frame the walk is executing, and answer that
+/// frame's executing pc.
+///
+/// Shared by the two owned-frame getter folds, which answer a coordinate the
+/// walk holds rather than the one the frame's own field records and therefore
+/// owe the same proof about the object in hand.
+///
+/// The receiver is pinned two ways.  Its class, its `w_class` and the frame
+/// type's `version_tag` are guarded, so rebinding the getset on the type
+/// revokes the loop instead of the fold outliving the descriptor that produced
+/// it.  And when the receiver arrives in a box other than the frame's own —
+/// a local the loop hoisted the frame into — a `ptr_eq` against that box is
+/// guarded, so a later entry holding a different frame side-exits to the
+/// residual rather than reading this trace's coordinate.
+fn walker_prove_owned_frame_pc<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    obj: OpRef,
+    concrete_obj: pyre_object::PyObjectRef,
+) -> Result<Option<u32>, DispatchError> {
+    let Some((frame_box, py_pc)) = walker_frame_executing_py_pc(ctx, concrete_obj, op_pc) else {
+        return Ok(None);
+    };
+    let w_type = pyre_interpreter::typedef::gettypeobject(&pyre_interpreter::pyframe::FRAME_TYPE);
+    let version_tag = unsafe { pyre_object::typeobject::w_type_get_version_tag(w_type) };
+    if version_tag == 0 || unsafe { (*concrete_obj).w_class } != w_type {
+        return Ok(None);
+    }
+    walker_guard_exception_attr_slot(ctx, op_pc, obj, concrete_obj, w_type, version_tag)?;
+    if obj != frame_box {
+        let is_own_frame = ctx.trace_ctx.record_op(OpCode::PtrEq, &[obj, frame_box]);
+        ctx.trace_ctx
+            .set_opref_concrete(is_own_frame, majit_ir::Value::Int(1));
+        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[is_own_frame])?;
+    }
+    Ok(Some(py_pc))
+}
+
 /// `pyframe.py fget_f_lasti` — `return self.last_instr`, loop-free and
 /// carrying no hint, so `policy.py look_inside_graph` admits it, `jtransform.py
 /// rewrite_op_jit_force_virtualizable` deletes the force
@@ -2711,13 +2749,7 @@ fn walker_frame_executing_py_pc<Sym: WalkSym>(
 /// `last_instr` from here would incur that obligation, which is the second
 /// reason this path never does.
 ///
-/// The receiver is pinned two ways.  Its class, its `w_class` and the frame
-/// type's `version_tag` are guarded, so rebinding `f_lasti` on the type
-/// revokes the loop instead of the constant outliving the getset that produced
-/// it.  And when the receiver arrives in a box other than the frame's own —
-/// a local the loop hoisted the frame into — a `ptr_eq` against that box is
-/// guarded, so a later entry holding a different frame side-exits to the
-/// residual rather than reading this trace's coordinate.
+/// The receiver is pinned by [`walker_prove_owned_frame_pc`].
 fn try_walker_specialize_frame_lasti<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,
@@ -2726,21 +2758,9 @@ fn try_walker_specialize_frame_lasti<Sym: WalkSym>(
     dst: usize,
     dst_bank: char,
 ) -> Result<Option<()>, DispatchError> {
-    let Some((frame_box, py_pc)) = walker_frame_executing_py_pc(ctx, concrete_obj, op_pc) else {
+    let Some(py_pc) = walker_prove_owned_frame_pc(ctx, op_pc, obj, concrete_obj)? else {
         return Ok(None);
     };
-    let w_type = pyre_interpreter::typedef::gettypeobject(&pyre_interpreter::pyframe::FRAME_TYPE);
-    let version_tag = unsafe { pyre_object::typeobject::w_type_get_version_tag(w_type) };
-    if version_tag == 0 || unsafe { (*concrete_obj).w_class } != w_type {
-        return Ok(None);
-    }
-    walker_guard_exception_attr_slot(ctx, op_pc, obj, concrete_obj, w_type, version_tag)?;
-    if obj != frame_box {
-        let is_own_frame = ctx.trace_ctx.record_op(OpCode::PtrEq, &[obj, frame_box]);
-        ctx.trace_ctx
-            .set_opref_concrete(is_own_frame, majit_ir::Value::Int(1));
-        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[is_own_frame])?;
-    }
     let value = py_pc as i64 * 2;
     let raw = ctx.trace_ctx.const_int(value);
     let boxed = walker_box_int(ctx, op_pc, raw, value)?;
@@ -2754,6 +2774,82 @@ fn try_walker_specialize_frame_lasti<Sym: WalkSym>(
         )),
     );
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
+    Ok(Some(()))
+}
+
+/// Runtime half of the owned-frame `f_lineno` getter: `pyframe.py
+/// fget_f_lineno` with the executing `last_instr` supplied by its caller
+/// instead of read back off the frame.
+extern "C" fn jit_frame_f_lineno_at(frame: i64, last_instr: i64) -> i64 {
+    let frame = frame as usize as *const pyre_interpreter::PyFrame;
+    unsafe { &*frame }.f_lineno_at(last_instr as isize) as i64
+}
+
+/// `pyframe.py fget_f_lineno` — the line the frame is currently executing.
+///
+/// Unlike its `f_lasti` sibling this is **not** a constant, and upstream's
+/// compiled shape is not one either.  `policy.py look_inside_graph` admits
+/// `fget_f_lineno` and `pyjitpl.py opimpl_getfield_vable_r` answers the
+/// `debugdata` test out of `virtualizable_boxes`, but the decode underneath —
+/// `pytraceback.py offset2lineno` walking the line table — stays a residual
+/// call.  One non-forcing call is the shape to emit.
+///
+/// What this removes is the FORCE, not the call.  The generic reader
+/// residualizes `space.getattr` as a single `CALL_MAY_FORCE`, and a may-force
+/// boundary materializes the virtualizable — which is the only reason the
+/// getter could read `last_instr` off the frame at all, since that field is
+/// virtualizable and a compiled loop keeps the live coordinate in its own
+/// state.  Handing the leaf the coordinate the walk already holds
+/// ([`walker_prove_owned_frame_pc`]) removes that reason, leaving a leaf call
+/// that names the frame without forcing it.
+///
+/// The leaf is [`PyFrame::f_lineno_at`], i.e. the getter body whole.  Its
+/// `f_trace` test, `-1` sentinel and `first_line_number` fallback are one
+/// decision, and `w_f_trace` can be armed while the loop is already compiled,
+/// so that decision belongs at run time rather than baked into the trace.
+///
+/// Measured on a 200k-iteration read against a same-shape loop that does not
+/// read the frame, best of 5: the read costs 0.0274s through the residual and
+/// 0.0069s through this emission, against 0.0084s on CPython 3.14.6 and
+/// 0.0227s on pypy3.  What removing the boundary is worth is counted rather
+/// than inferred — the optimized trace loses half its `CALL_MAY_FORCE` (16 ->
+/// 8) and half its `GuardNotForced` (16 -> 8) — and the two arms report the
+/// same `loops_compiled`, `loops_aborted` and `guard_failures`, so the
+/// difference is the emission and not one arm compiling less.
+///
+/// The receiver is pinned by [`walker_prove_owned_frame_pc`].
+fn try_walker_specialize_frame_lineno<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    obj: OpRef,
+    concrete_obj: pyre_object::PyObjectRef,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    let Some(py_pc) = walker_prove_owned_frame_pc(ctx, op_pc, obj, concrete_obj)? else {
+        return Ok(None);
+    };
+    let pc = ctx.trace_ctx.const_int(py_pc as i64);
+    let value = ctx.trace_ctx.call_ref_typed_with_effect(
+        jit_frame_f_lineno_at as *const (),
+        &[obj, pc],
+        &[majit_ir::Type::Ref, majit_ir::Type::Int],
+        majit_ir::EffectInfo::new(
+            majit_ir::ExtraEffect::CannotRaise,
+            majit_ir::OopSpecIndex::None,
+        ),
+    );
+    // The recording-time shadow comes from the same entry point the leaf calls,
+    // so it carries the getter's own small-int caching rather than a second
+    // rendering of it.
+    let concrete = unsafe {
+        (*(concrete_obj as *const pyre_interpreter::PyFrame)).f_lineno_at(py_pc as isize)
+    };
+    ctx.trace_ctx.set_opref_concrete(
+        value,
+        majit_ir::Value::Ref(majit_ir::GcRef(concrete as usize)),
+    );
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, value)?;
     Ok(Some(()))
 }
 
@@ -2877,6 +2973,15 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
         && unsafe { (*concrete_obj).ob_type } == &pyre_interpreter::pyframe::FRAME_TYPE
         && spec_gate("frame_lasti", || {
             try_walker_specialize_frame_lasti(ctx, op_pc, obj, concrete_obj, dst, dst_bank)
+        })?
+        .is_some()
+    {
+        return Ok(Some(()));
+    }
+    if name == "f_lineno"
+        && unsafe { (*concrete_obj).ob_type } == &pyre_interpreter::pyframe::FRAME_TYPE
+        && spec_gate("frame_lineno", || {
+            try_walker_specialize_frame_lineno(ctx, op_pc, obj, concrete_obj, dst, dst_bank)
         })?
         .is_some()
     {
@@ -9730,8 +9835,8 @@ fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
 /// frame is always the portal, so the residual always escapes.  Removing it
 /// removes the force with it, and nothing has to replace it: `last_instr` is
 /// published onto the portal frame at every may-force boundary
-/// (`LiveLastInstrGuard`).  A generic `f_lineno` reader still retains that
-/// residual boundary.  Upstream does not: `pyframe.py fget_f_lasti` and
+/// (`LiveLastInstrGuard`).  A generic reader of either getter still retains
+/// that residual boundary.  Upstream does not: `pyframe.py fget_f_lasti` and
 /// `fget_f_lineno` are loop-free and carry no hint, so `policy.py
 /// look_inside_graph` admits them, `jtransform.py
 /// rewrite_op_jit_force_virtualizable` deletes the injected force, and
@@ -9740,10 +9845,13 @@ fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
 /// same-shape loop that does not read the frame: pypy3 answers `f_lasti`
 /// faster than that control loop -- the trace constant -- and pyre was 53x it,
 /// while `f_lineno` keeps one non-forcing residual on both and pyre is 2.1x.
-/// [`try_walker_specialize_frame_lasti`] closes the `f_lasti` half by emitting
-/// the constant, leaving `f_lineno` the open one.  Closing either is an
-/// optimization over a correct path, not a fix, and it owes two coordinates
-/// the boundary hides.  `last_instr` is an instruction-unit index here and the
+/// The two halves are closed by two different emissions, because the shapes
+/// they are closing to differ: [`try_walker_specialize_frame_lasti`] emits the
+/// constant, while [`try_walker_specialize_frame_lineno`] emits the one
+/// non-forcing residual upstream also keeps for the line-table decode.  Either
+/// is an optimization over a correct path, not a fix, and both owe two
+/// coordinates the boundary hides.  `last_instr` is an instruction-unit index
+/// here and the
 /// app-level getter reports it doubled (`typedef.rs`, matching `location.py
 /// offset2lineno`'s `stopat // 2` on the byte offset upstream stores), so an
 /// emission at the app level owes the factor.  And the field has two writers

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2830,6 +2830,30 @@ extern "C" fn jit_frame_f_lineno_at(frame: i64, last_instr: i64) -> i64 {
 /// same `loops_compiled`, `loops_aborted` and `guard_failures`, so the
 /// difference is the emission and not one arm compiling less.
 ///
+/// The call states an empty `EffectInfo` descr set, which is not a claim that
+/// the leaf reads nothing: `make_call_descr_sized` panics on a non-empty raw
+/// descr set minted after `compute_bitstrings`, and `finish_setup_descrs` runs
+/// before any trace does, so every trace-time residual states the empty set and
+/// `extraeffect` carries what is claimed.
+///
+/// The empty set is inert because no trace op names a field the leaf reads, and
+/// `force_from_effectinfo` forces only descrs already in `cached_fields`.  The
+/// reads are `PyFrame.pycode` and `PyFrame.debugdata`, then
+/// `FrameDebugData.w_f_trace` and the code object's `linetable` and
+/// `first_line_number`; `pyframe_debugdata_descr` has no emitter, `w_f_trace`
+/// has no descr at all, and neither vable slot has a writer.  A later fold that
+/// gives one of them a descr and caches it owes this call an explicit op, the
+/// way `ResolveExceptionContext` records its own `SetfieldGc` rather than
+/// naming `w_context` in a write set it cannot carry.
+///
+/// `pycode` and `debugdata` are read off the frame in memory rather than
+/// through `virtualizable_entry_at`, where the neighbouring `locals()` fold
+/// reads `debugdata`.  Neither slot has a `setfield_vable` writer
+/// (`virtualizable_spec.rs` names the ones that do), so memory holds the live
+/// value while compiled code runs, while the recording-time shadow's
+/// `debugdata` is a `clone_debugdata_ptr` copy of it.  Memory answers the same
+/// at both times; the shadow does not.
+///
 /// The receiver is pinned by [`walker_prove_owned_frame_pc`].
 fn try_walker_specialize_frame_lineno<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,


### PR DESCRIPTION
### `f_lineno` without a may-force boundary

Closes the second half of the `f_lasti` / `f_lineno` pair; the `f_lasti` half landed in
#1437.

`space.getattr` on `f_lineno` residualizes as one `CALL_MAY_FORCE`, and that boundary is
what makes the frame's own `last_instr` — a virtualizable field — current enough for the
getter to decode against the line table. This hands the getter the executing coordinate
the walk already holds, so the same body runs with no boundary.

Not a constant fold, unlike its sibling: `policy.py look_inside_graph` admits
`fget_f_lineno` and `opimpl_getfield_vable_r` answers the `debugdata` test out of
`virtualizable_boxes`, but the decode underneath — `pytraceback.py offset2lineno` walking
the line table — stays a residual call upstream too, so one non-forcing call is the shape
to emit. The leaf is the getter *whole* (`PyFrame::f_lineno_at`): its `f_trace` test, `-1`
sentinel and `first_line_number` fallback are one decision, and `w_f_trace` can be armed
while the loop is already compiled, so it belongs at run time.

`get_lineno_at` / `f_lineno_at` take the instruction index as a parameter; the existing
no-argument getters delegate to them unchanged. The receiver proof
`try_walker_specialize_frame_lasti` performed is extracted as `walker_prove_owned_frame_pc`
and shared by both arms.

**Measured** — 200k-iteration read against a same-shape loop that does not read the frame,
best of 5:

| | control | `f_lineno` |
|---|---|---|
| this branch | 0.0001s | **0.0069s** |
| fold suppressed (`PYRE_FBW_NO_SPECIALIZE=frame_lineno`) | 0.0001s | 0.0274s |
| CPython 3.14.6 | 0.0025s | 0.0084s |
| pypy3 | 0.0001s | 0.0227s |

Counted rather than inferred, in the `--- trace (after opt) ---` section: `CALL_MAY_FORCE`
16 → 8 and `GuardNotForced` 16 → 8, total ops 390 → 312. The control that makes the clock
attributable: `loops_compiled=2`, `loops_aborted=0`, `guard_failures=11` and the computed
result are identical in both arms, so no arm is compiling less than the other.

`frame_lineno_fold_coordinates.py` collects each site's answer across the whole run, so an
interpreted answer and a compiled one that disagree appear as a second set element rather
than as one shifted value. It covers the frame's own box, a receiver hoisted into a local
before the loop, a read split across physical lines, and a callee reading its own frame.
`# pyre-check: spec-folds=frame_lineno` makes it the ceiling gate — check.py fails the
fixture if the fold fires zero times.

Deliberately not covered: `f_lineno` with a trace function installed. That branch is the
same leaf body, but arming local tracing on a compiled frame is a separate open defect, so
a fixture arming it would pin that defect rather than this fold.

### `constants_r` doc

The `SubJitCodeBody` field doc still called each slot an `i64` after #1465 changed the
element type to `ConstSlotR`.


### Zero-argument `super()` bound to a name

A second frame-escape route on the same virtualizable, unrelated to the getter above except
that both end at the executing frame.

The two `super()` spellings do not share a route. `super().m()` compiles to
`LOAD_SUPER_ATTR`, which lowers to a frame-explicit residual: the red frame travels as an
operand and `builtin_super_from_frame` reads it, so the force happens through the may-force
channel the walker already models. `s = super()` compiles to `LOAD_GLOBAL super` + `CALL`
and reaches `builtin_super`'s zero-argument tail, whose
`ExecutionContext::gettopframe()` runs `force_frame` **inside** an opaque residual. That
clears `TOKEN_TRACING_RESCALL`, and `tracing_after_residual_call` reads it back as
`VableEscapedDuringResidualCall` — so the loop aborts every time.

This is a re-route, not a removal: `codewriter.rs` binds `load_super_attr_fn` with
`CallFlavor::MayForce`, so both spellings force. The emission names
`jit_bare_super_from_frame` — the same `_super_from_frame` half `bh_load_super_attr_fn`
calls — as a may-force residual taking the walk's own frame box.
`walker_executing_frame_box` supplies that box from the callee shadow during an inline
sub-walk and from the standard virtualizable otherwise, because the portal's virtualizable
describes the *portal*: an inlined callee answering from it would report its caller's frame
and build the proxy against the wrong `__class__` cell.

#### Only the receivers that run no Python are folded

The walker executes its residuals concretely while recording, and this one would otherwise
reach `super_check`'s `getattr_str(obj, "__class__")` — arbitrary code, which is free to
force the very virtualizable being recorded against, and whose side effects a decline would
then repeat under the generic residual.

So the entry point is split at that boundary rather than the fold trying to survive it.
`super_check_python_free` is the two MRO-walking arms, `super_operands_from_frame` is the
frame reads, and `builtin_super_from_frame_python_free` composes them and answers `None`
wherever the full entry point would raise or consult `__class__`. The fold takes that and
declines otherwise, ahead of any emission. Its recording-time call is then a read: it
cannot force, so it owes no `vrefs_before/after_residual_call` bracket, and it cannot
raise, so there is no exception to carry. The runtime leaf still runs the whole entry
point, which is what the trailing `GuardNotForced` and `GuardNoException` are for, and why
the call carries `EffectInfo::MOST_GENERAL` rather than a constructed one — a constructed
`EffectInfo` inherits EMPTY read/write sets, claiming the leaf touches no modeled field.
`RandomEffects` outranks `ForcesVirtualOrVirtualizable`, so the may-force reading is
unchanged.

**Measured** — dynasm, against `PYRE_FBW_NO_SPECIALIZE=bare_super_call`, on the three sites
the fold claims:

| | fold | suppressed |
|---|---|---|
| `loops_aborted` / `abrt_escape` | **0** | 25 |
| `fbw_force_by_portal` | **0** | 20 |
| `fbw_force_by_callee_only` | **0** | 5 |

On the whole fixture the reading is 10 against 30: sites D and E are receivers the fold
declines, so they keep the generic residual and keep escaping. That is the honest number
for the fixture; the table above is the number for the shapes the fold takes.

The answer is identical in both arms — that is what the fixture checks. It collects each
site's result across the whole run, so an interpreted answer and a compiled one that
disagree appear as a second set element rather than as one shifted value. Sites: a method
binding `super()` to a name; the same in an inlinable callee, where a proxy built from the
portal's frame would return the caller's override; a three-deep chain, which a two-level
shape would not catch; a receiver `super_check` rejects by walking MROs; and a receiver it
can only classify by asking Python.

That last site earns its place. It carries per-iteration data in its exception, and an
earlier version of this fold — which executed the call and carried the raise — answered
every compiled iteration with the exception object *recording* had built: 20000 iterations,
1662 distinct messages against CPython's 20000. Sites whose message is constant cannot see
that. It also needs its own class and its own loop, because sharing `Leaf.val` compiles
that method against a real instance first and the raising call then side-exits on those
guards and runs interpreted, where the defect cannot appear.

`# pyre-check: spec-folds=bare_super_call` makes the fixture the ceiling gate.

### What the residual's effect set can and cannot say

Both folds mint their call descr at trace time, and a trace-time mint may not name a descr
at all: `make_call_descr_sized` panics on any `EffectInfo` carrying a non-empty raw descr
set once `compute_bitstrings` has run, and both arms of `finish_setup_descrs` set that flag
before any trace records anything. Measured with a throwaway `#[should_panic]` probe — the
panic fires. Naming a read set would shift `compute_bitstrings`' `(eisetr, eisetw)`
partition and invalidate every bitstring already computed, which is exactly what the gate
exists to prevent.

So the empty descr sets on the `f_lineno` call are not a claim that its leaf reads nothing;
`extraeffect` carries what is claimed. The last commit writes the leaf's actual reads down
next to it — `PyFrame.pycode` and `PyFrame.debugdata`, then `FrameDebugData.w_f_trace` and
the code object's `linetable` and `first_line_number` — together with why the empty set is
inert: `force_from_effectinfo` forces only descrs already in `cached_fields`,
`pyframe_debugdata_descr` has no emitter, `w_f_trace` has no descr, and neither vable slot
has a `setfield_vable` writer. A later fold that gives one of them a descr and caches it
owes this call an explicit op, the way `ResolveExceptionContext` records its own
`SetfieldGc` rather than naming `w_context` in a write set it cannot carry.

The `super()` call is unaffected: `MOST_GENERAL` is the `None` wildcard, not an empty set.

Full synthetic suite 465/465 on dynasm.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved correctness for zero-argument `super()` calls in optimized execution, including nested inheritance and invalid receivers.
  - Fixed optimized frame line-number reporting so `f_lineno` consistently identifies the currently executing source line.
  - Preserved expected exception behavior when resolving `super()` or frame information triggers errors.

- **Performance**
  - Added optimized execution paths for supported `super()` and `f_lineno` operations while retaining safe fallback behavior for unsupported cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->