### PR TITLE
pycode, pyframe: every line and position off the line table's ranges, three lazy code-object iterators, and the faults object_functionstr swallowed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,18 @@ insta = "1"
 # stdout and stderr.  The fork moves the table to `.CRT$XCU`, which `_initterm`
 # walks as `_PVFV` and whose result is discarded; the change is
 # simnalamburt/xz-rs#20 and this pin drops when it is released.
+#
+# A second defect lives at this rev and is worth fixing before the pin drops:
+# `alone_decoder.rs` validates a picky LZMA-alone dictionary size by smearing
+# `dict_size - 1` down and then adding 1 back.  When the smear saturates to
+# `0xFFFF_FFFF` — `dict_size == 0` is the reachable case — that `+ 1` is an
+# overflow.  The C it ports from wraps, and so does a release build, but a
+# DEBUG build panics "attempt to add with overflow", which takes the whole
+# process down: `test.test_tarfile` dies before its first Lzma test on a debug
+# `pyre`, identically with the JIT on and off, and so do any tarfile classes
+# whose module setup builds an lzma archive.  Release CI never sees it.  The
+# fix is to spell the add as wrapping, matching the surrounding ported
+# arithmetic.
 [patch.crates-io]
 xz-core = { git = "https://github.com/youknowone/xz-rs-simnalamburt", rev = "9c5cc27154e90b48348f713e28ab02bb2c5b52b4" }
 

--- a/pyre/extra_tests/parity_tests/ast_types_carry_match_args.py
+++ b/pyre/extra_tests/parity_tests/ast_types_carry_match_args.py
@@ -13,9 +13,13 @@
 # `TypeError: Expr() accepts 0 positional sub-patterns` and every traceback
 # rendered through `traceback.py` loses its `~`/`^` anchor row.
 #
-# PyPy 7.3.20 binds `__match_args__` on the concrete node types the same
-# way, `Pass` and its empty tuple included, but leaves the base `ast.AST`
-# without one, so the last line of the surface check cannot hold there.
+# PyPy binds `__match_args__` the same way, `Pass` and its empty tuple
+# included, but only in `State.make_new_type`, which runs over `AST_TYPES`.
+# The base is `space.gettypeobject(W_AST.typedef)` and never goes through it,
+# and that typedef lists `_fields` and `_attributes` alone -- so `ast.AST`
+# carries no `__match_args__` and the last line of the surface check cannot
+# hold there.  Structural, not a version gap: unchanged from 7.3.20 through
+# the 7.3.24 checkout under this repository.
 
 import ast
 import sys

--- a/pyre/extra_tests/parity_tests/ast_types_carry_match_args.py
+++ b/pyre/extra_tests/parity_tests/ast_types_carry_match_args.py
@@ -1,0 +1,50 @@
+# CPython-suite gap: `test_ast` reads `_fields` on every node type but never
+# reads `__match_args__`, and its pattern-matching tests build their own
+# classes.  A runtime that binds only `_fields` passes the whole module while
+# every `case ast.Expr(value)` in the standard library silently stops matching.
+#
+# parity-tests reason: `make_type` builds ONE tuple of field names and binds it
+# to both names, so the two are the same object on every `_ast` type, field-less
+# ones included.  The observable consequence is not the attribute itself:
+# `traceback._extract_caret_anchors_from_line_segment` is written as class
+# patterns over `ast.BinOp` / `ast.Subscript` / `ast.Call`, so without
+# `__match_args__` a class pattern with positional sub-patterns raises
+# `TypeError: Expr() accepts 0 positional sub-patterns` and every traceback
+# rendered through `traceback.py` loses its `~`/`^` anchor row.
+#
+# PyPy 7.3.20 builds `_ast` the same way and passes.
+
+import ast
+import sys
+import traceback
+
+print("_fields is __match_args__:", ast.Expr._fields is ast.Expr.__match_args__)
+print("Expr.__match_args__:", ast.Expr.__match_args__)
+# A node type with no fields still carries the (empty) tuple, as does the base.
+print("Pass/AST:", ast.Pass.__match_args__, ast.AST.__match_args__)
+
+TREE = ast.parse("a + b")
+match TREE.body[0]:
+    case ast.Expr(ast.BinOp(left, op, right)):
+        print("matched:", type(left).__name__, type(op).__name__, type(right).__name__)
+    case _:
+        print("class pattern did not match")
+
+
+def boom(mapping):
+    return mapping["a"] + mapping["b"]
+
+
+try:
+    boom({"a": 1})
+except KeyError:
+    report = "".join(traceback.format_exception(*sys.exc_info()))
+    for line in report.splitlines():
+        # Only the anchor rows and the frame bodies are compared; the file
+        # path and line numbers move with this file.
+        stripped = line.strip()
+        if stripped.startswith("File "):
+            continue
+        print(repr(stripped))
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/ast_types_carry_match_args.py
+++ b/pyre/extra_tests/parity_tests/ast_types_carry_match_args.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins `__match_args__` on every `_ast` type, the base included; pypy3 binds it on the concrete nodes but `ast.AST` carries none
 # CPython-suite gap: `test_ast` reads `_fields` on every node type but never
 # reads `__match_args__`, and its pattern-matching tests build their own
 # classes.  A runtime that binds only `_fields` passes the whole module while
@@ -12,7 +13,9 @@
 # `TypeError: Expr() accepts 0 positional sub-patterns` and every traceback
 # rendered through `traceback.py` loses its `~`/`^` anchor row.
 #
-# PyPy 7.3.20 builds `_ast` the same way and passes.
+# PyPy 7.3.20 binds `__match_args__` on the concrete node types the same
+# way, `Pass` and its empty tuple included, but leaves the base `ast.AST`
+# without one, so the last line of the surface check cannot hold there.
 
 import ast
 import sys

--- a/pyre/extra_tests/parity_tests/co_branches_iterator_identity.py
+++ b/pyre/extra_tests/parity_tests/co_branches_iterator_identity.py
@@ -1,0 +1,73 @@
+# CPython-suite gap: `test_monitoring` and `test_code` read the *values*
+# `co_branches()` yields and never look at the object producing them, so a
+# runtime that materializes the whole list up front and hands back a generic
+# sequence iterator passes both modules.
+#
+# parity-tests reason: `co_branches()` returns a `branchesiterator`, whose
+# `tp_name` is `line_iterator` — the same string `_PyLineIterator` carries, so
+# the two distinct types are told apart only by identity.  The walk is lazy:
+# `next()` resumes the bytecode scan at `bi_offset` and returns at the first
+# branch it reaches, so reading one row does not cost a pass over the whole
+# code object.  Both iterators are `Py_TPFLAGS_BASETYPE` with no `tp_new`.
+
+def branchy(x):
+    for i in range(3):
+        if i:
+            x += i
+        elif x:
+            x -= 1
+    while x > 0:
+        x -= 1
+    return x
+
+
+CODE = branchy.__code__
+it = CODE.co_branches()
+
+print("type name:", type(it).__name__)
+print("distinct from co_lines:", type(it) is not type(CODE.co_lines()))
+print("iter is self:", iter(it) is it)
+print("rows:", list(it))
+print("exhausted:", list(it))
+
+# Laziness is observable: an iterator only stepped once has not walked past the
+# branch it reported, so a second iterator over the same code starts over and
+# agrees row for row.
+first = CODE.co_branches()
+print("first row:", next(first))
+print("full walk agrees:", list(CODE.co_branches())[0] == next(iter(CODE.co_branches())))
+
+# No `tp_new`, but `Py_TPFLAGS_BASETYPE` is set.
+try:
+    type(it)()
+except TypeError as exc:
+    print("ctor:", exc)
+
+
+class Sub(type(it)):
+    pass
+
+
+print("subclassable:", Sub.__mro__[1] is type(it))
+
+# The unbound `__next__` of the *other* type named `line_iterator` rejects this
+# receiver, and reports both types by that shared name.
+try:
+    type(CODE.co_lines()).__next__(CODE.co_branches())
+except TypeError as exc:
+    print("cross receiver:", exc)
+
+# An `async for` contributes its END_ASYNC_FOR row.
+SRC = """
+async def drain(aiterable):
+    async for item in aiterable:
+        pass
+"""
+ns = {}
+exec(compile(SRC, "<branches>", "exec"), ns)
+print("async rows:", list(ns["drain"].__code__.co_branches()))
+
+# A code object with no branch at all yields nothing.
+print("no branches:", list((lambda: 1).__code__.co_branches()))
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/co_branches_iterator_identity.py
+++ b/pyre/extra_tests/parity_tests/co_branches_iterator_identity.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins the object `co_branches()` returns; pypy3 has no `co_branches` at all
 # CPython-suite gap: `test_monitoring` and `test_code` read the *values*
 # `co_branches()` yields and never look at the object producing them, so a
 # runtime that materializes the whole list up front and hands back a generic

--- a/pyre/extra_tests/parity_tests/f_lineno_jump_lands_on_a_line_table_range_start.py
+++ b/pyre/extra_tests/parity_tests/f_lineno_jump_lands_on_a_line_table_range_start.py
@@ -1,0 +1,110 @@
+# CPython-suite gap: `test_sys_settrace`'s jump tests all move between lines a
+# statement actually starts on, inside a function whose first instruction
+# already carries `co_firstlineno`.  None of them jumps to the first line of a
+# *module* body, whose `RESUME` sits in a range carrying line 0, and none of
+# them jumps out of the body of a `with`, so a runtime can pass every module
+# while resolving jump targets off an expanded per-instruction table and while
+# assuming every stack slot it unwinds is bound.
+#
+# parity-tests reason: `marklines` marks the **start** unit of each line-table
+# range, and skips a range whose line is `-1`.  A table expanded into one entry
+# per instruction can express neither -- its line is a one-indexed integer, so
+# the module `RESUME`'s line 0 reads back as 1 and the `RESUME` itself becomes
+# a legal target for `f_lineno = 1`.  The unwind is the other half: upstream
+# closes each dropped slot with `PyStackRef_XCLOSE`, and a jump out of a `with`
+# body drops exactly one slot that is still unbound, so a pop that requires a
+# value aborts the interpreter rather than raising.
+#
+# PyPy 7.3.20 reports the module `RESUME` differently -- it is a 3.11 line
+# table and has no line-0 range there -- so it fails the first case for the
+# same reason `traceback_lineno_sentinel.py` gives.
+
+import sys
+
+MODULE_SOURCE = "x = 1\ny = 2\n"
+MODULE_JUMP = []
+
+
+def module_tracer(frame, event, arg):
+    if frame.f_code.co_filename != "<jump>":
+        return None
+    if event == "call":
+        frame.f_trace = module_tracer
+        frame.f_trace_lines = True
+        return module_tracer
+    if event == "line" and not MODULE_JUMP:
+        try:
+            frame.f_lineno = 1
+        except BaseException as exc:
+            MODULE_JUMP.append((type(exc).__name__, str(exc)))
+        else:
+            MODULE_JUMP.append((frame.f_lasti, frame.f_lineno))
+    return module_tracer
+
+
+sys.settrace(module_tracer)
+try:
+    exec(compile(MODULE_SOURCE, "<jump>", "exec"), {})
+finally:
+    sys.settrace(None)
+
+# The `RESUME` is a range start carrying line 0, so it is not where line 1
+# begins; line 1 begins at the next instruction unit, byte offset 2.
+print("module jump to line 1:", MODULE_JUMP)
+
+
+WITH_SOURCE = """
+def run(cm, log):
+    with cm:
+        log.append('body')
+    log.append('after')
+    return 'done'
+"""
+
+NAMESPACE = {}
+exec(compile(WITH_SOURCE, "<with>", "exec"), NAMESPACE)
+
+
+class Manager:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        LOG.append("exit")
+        return False
+
+
+LOG = []
+WITH_JUMP = []
+
+
+def with_tracer(frame, event, arg):
+    if frame.f_code.co_filename != "<with>":
+        return None
+    if event == "call":
+        frame.f_trace = with_tracer
+        frame.f_trace_lines = True
+        return with_tracer
+    if event == "line" and frame.f_lineno == 4 and not WITH_JUMP:
+        WITH_JUMP.append("attempted")
+        try:
+            frame.f_lineno = 5
+        except BaseException as exc:
+            WITH_JUMP.append((type(exc).__name__, str(exc)))
+        else:
+            WITH_JUMP.append(("landed", frame.f_lineno))
+    return with_tracer
+
+
+sys.settrace(with_tracer)
+try:
+    RESULT = NAMESPACE["run"](Manager(), LOG)
+finally:
+    sys.settrace(None)
+
+# Leaving the block this way abandons it: the bound `__exit__` is dropped off
+# the stack unbound rather than called, so nothing appends 'exit'.
+print("with jump to line 5:", WITH_JUMP)
+print("with jump log:", LOG, "result:", RESULT)
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/functionstr_propagates.py
+++ b/pyre/extra_tests/parity_tests/functionstr_propagates.py
@@ -1,0 +1,173 @@
+# CPython-suite gap: `test_extcall` and `test_call` check the `f() argument
+# after * must be an iterable` message, but only ever for callables whose
+# `__qualname__` and `__module__` are ordinary strings.  A runtime that
+# swallowed every fault while building that prefix would pass both modules.
+#
+# parity-tests reason: the prefix comes from `_PyObject_FunctionStr`, which is
+# reached only while another error is already being reported.  That makes it
+# tempting to treat it as best-effort and fall back to `str(x)` on any
+# problem -- and PyPy does exactly that, with two
+# `try/except OperationError: pass` blocks.  3.14 propagates instead: a
+# `__qualname__` descriptor that raises replaces the whole message with its
+# own error.  Nothing else in the suite forces that choice.
+#
+# The prefix rule is a rich comparison, not a type check: `__module__` is
+# rendered with `%S` whenever it is neither `None` nor equal to `'builtins'`,
+# so a non-string one is formatted rather than dropped, and `''` yields a bare
+# leading dot.
+#
+# PyPy 7.3.20 fails every case here.  Its `except OperationError: pass` sends
+# the class cells to the `getname() + ' object'` answer and leaves the plain
+# functions with a bare `f()`, so every raising descriptor is swallowed and
+# every module that is not a plain non-empty `str` is dropped.
+import re
+import sys
+
+
+def message(callable_object):
+    """The report from calling `callable_object` with a non-iterable `*arg`."""
+    try:
+        callable_object(*1)
+    except BaseException as exc:
+        # The `str(x)` fallback embeds an address; nothing here should reach it.
+        return type(exc).__name__ + ': ' + re.sub(r'0x[0-9a-fA-F]+', '0xADDR', str(exc))
+    return 'no error'
+
+
+def named(qualname):
+    """A callable answering `qualname` for `__qualname__` and nothing else."""
+
+    class C:
+        def __call__(self, *args):
+            pass
+
+        def __getattr__(self, name):
+            if name == '__qualname__':
+                return qualname
+            raise AttributeError(name)
+
+    return C
+
+
+def a_raising_qualname_replaces_the_message():
+    class C:
+        def __call__(self, *args):
+            pass
+
+        def __getattr__(self, name):
+            raise TypeError(name + ' boom')
+
+    print('qualname raises:', message(C()))
+
+
+def a_non_string_qualname_is_formatted_not_dropped():
+    print('qualname is 42:', message(named(42)()))
+
+
+def the_module_test_is_a_comparison_not_a_type_check():
+    for module in (42, None, 'builtins', '', 'mymod'):
+        cls = named('Q')
+        cls.__module__ = module
+        print('module %-10r ->' % (module,), message(cls()))
+
+
+def a_raising_str_on_either_name_replaces_the_message():
+    class StrRaises:
+        def __str__(self):
+            raise TypeError('str boom')
+
+    class ModuleStrRaises:
+        def __str__(self):
+            raise TypeError('module str boom')
+
+    cls = named('Q')
+    cls.__module__ = StrRaises()
+    print('module __str__ raises:', message(cls()))
+    print('qualname __str__ raises:', message(named(StrRaises())()))
+    # `%S.%S()` converts the module first, so its error is the one that wins.
+    cls = named(StrRaises())
+    cls.__module__ = ModuleStrRaises()
+    print('both __str__ raise:', message(cls()))
+
+
+def the_absent_qualname_fallback_is_str_and_str_can_fail():
+    class StrRaises:
+        def __call__(self, *args):
+            pass
+
+        def __str__(self):
+            raise TypeError('str boom')
+
+    class StrNonString:
+        def __call__(self, *args):
+            pass
+
+        def __str__(self):
+            return 42
+
+    print('no qualname, __str__ raises:', message(StrRaises()))
+    print('no qualname, __str__ is int:', message(StrNonString()))
+
+
+def the_module_comparison_is_ne_and_reaches_a_str_subclass():
+    """`PyObject_RichCompareBool(module, 'builtins', Py_NE)` — `__ne__`, and no
+    exact-type shortcut around it.
+
+    A runtime that answers the module test by reading the string's bytes
+    whenever it is *a* str takes that shortcut for a str SUBCLASS too, and
+    then a subclass overriding `__ne__` never runs.  Both cells below stop the
+    message with the subclass's own error, including the one whose text is
+    exactly `'builtins'`.
+
+    The `__eq__`-vs-`__ne__` half is only visible when the two disagree, which
+    is why each class here raises a differently-worded error from each.
+    """
+
+    class NeRaises:
+        def __ne__(self, other):
+            raise TypeError('__ne__ boom')
+
+        def __eq__(self, other):
+            raise TypeError('__eq__ boom')
+
+        __hash__ = None
+
+        def __str__(self):
+            return 'nemod'
+
+    class SubNeRaises(str):
+        def __ne__(self, other):
+            raise TypeError('sub __ne__ boom')
+
+        def __eq__(self, other):
+            raise TypeError('sub __eq__ boom')
+
+        __hash__ = str.__hash__
+
+    def f(*args):
+        pass
+
+    f.__module__ = NeRaises()
+    print('module __ne__ raises:', message(f))
+    for text in ('mymod', 'builtins'):
+        f.__module__ = SubNeRaises(text)
+        print('str-subclass module %-10r ->' % (text,), message(f))
+
+
+def a_function_takes_the_same_module_rule():
+    def f(*args):
+        pass
+
+    for module in ('', 42, None, 'builtins'):
+        f.__module__ = module
+        print('function module %-10r ->' % (module,), message(f))
+
+
+a_raising_qualname_replaces_the_message()
+a_non_string_qualname_is_formatted_not_dropped()
+the_module_test_is_a_comparison_not_a_type_check()
+a_raising_str_on_either_name_replaces_the_message()
+the_absent_qualname_fallback_is_str_and_str_can_fail()
+a_function_takes_the_same_module_rule()
+the_module_comparison_is_ne_and_reaches_a_str_subclass()
+print('OK')

--- a/pyre/extra_tests/parity_tests/line_table_entry_ends_at_the_next_marker.py
+++ b/pyre/extra_tests/parity_tests/line_table_entry_ends_at_the_next_marker.py
@@ -1,0 +1,48 @@
+# CPython-suite gap: every `co_linetable` the suite reads was written by the
+# compiler, so each entry's payload ends exactly where the next entry's header
+# begins and the two ways of finding that boundary agree.  `code.replace(
+# co_linetable=...)` stores arbitrary bytes, and nothing in the suite does.
+#
+# parity-tests reason: the two walks over the table are different functions
+# upstream and stop at different places on purpose.  `advance`, which
+# `co_lines()` and every line resolution use, reads the line delta *without*
+# moving the cursor and then skips forward to the next byte with bit 7 set --
+# so an entry ends at the next marker, not after however many payload bytes its
+# code declares.  `advance_with_locations`, which `co_positions()` uses, really
+# does consume the payload.  A single byte can be a payload by length and a
+# header by its marker, and only the marker decides for the first walk.
+#
+# PyPy 7.3.20 is a 3.11 line table and rejects a `co_linetable` this short.
+
+TABLES = [
+    b"",
+    b"\x00",
+    b"\x80",
+    # `\x00` declares a one-byte `Short0` payload and `\x80` is that byte by
+    # length -- but it carries the marker, so it opens a second range instead.
+    b"\x00\x80",
+    # Code 15 without the marker is a location kind, not a no-location range:
+    # `co_lines()` reports the computed line and `co_positions()` reports None.
+    b"\x78",
+    b"\xf8",
+    b"\xf8\xf8",
+    # A `NoColumns` entry whose signed varint carries the line far negative.
+    b"\xe8\x7f",
+    # A header claiming eight code units, followed by the same two bytes.
+    b"\x0f\x00\x80",
+]
+
+
+# Compiled from a string so `co_firstlineno` is 1 and the lines printed below
+# do not move when this file is edited.
+NAMESPACE = {}
+exec(compile("def probe():\n    return 1\n", "<table>", "exec"), NAMESPACE)
+BASE = NAMESPACE["probe"].__code__
+
+for table in TABLES:
+    code = BASE.replace(co_linetable=table)
+    print(repr(table))
+    print("   co_lines:", list(code.co_lines()))
+    print("   co_positions:", list(code.co_positions()))
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/lineno_of_a_no_location_instruction.py
+++ b/pyre/extra_tests/parity_tests/lineno_of_a_no_location_instruction.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: pins the line a NO_LOCATION range reports; pypy3's 3.11 codegen gives a `with` cleanup real positions and emits no such range
 # CPython-suite gap: `test_traceback`, `test_frame` and `test_sys_settrace` all
 # read line numbers, but only off instructions the compiler gave a position to.
 # Nothing in the suite stops on one of the `NO_LOCATION` ranges a `with` or a

--- a/pyre/extra_tests/parity_tests/lineno_of_a_no_location_instruction.py
+++ b/pyre/extra_tests/parity_tests/lineno_of_a_no_location_instruction.py
@@ -1,0 +1,164 @@
+# CPython-suite gap: `test_traceback`, `test_frame` and `test_sys_settrace` all
+# read line numbers, but only off instructions the compiler gave a position to.
+# Nothing in the suite stops on one of the `NO_LOCATION` ranges a `with` or a
+# `try`/`finally` cleanup sits in, so a runtime that answered those with the
+# line that happened to precede them would pass every module.
+#
+# parity-tests reason: `co_positions` already reports those instructions with a
+# `None` line, so the information is present; what is observable is whether the
+# two readers of a *resolved* line agree with it.  `PyCode_Addr2Line` answers
+# `-1` there, and both `tb_lineno_get` and `frame_getlineno` turn a line below
+# zero into `None`.  A runtime that expands the line table into one entry per
+# instruction cannot represent the gap and answers the previous line instead --
+# the same expansion also loses a zero `co_firstlineno`, which the constructor
+# accepts, so both are pinned here.
+#
+# PyPy 7.3.20 is a 3.11 line table and has no `TracebackType` sentinel, so it
+# fails the rebuilt cases for the reason `traceback_lineno_sentinel.py` gives
+# rather than for anything about a missing line.
+
+import sys
+import types
+
+SOURCE = '''
+def guarded(cm):
+    with cm:
+        raise ValueError('body')
+'''
+
+NAMESPACE = {}
+exec(compile(SOURCE, '<no-location>', 'exec'), NAMESPACE)
+GUARDED = NAMESPACE['guarded']
+POSITIONS = list(GUARDED.__code__.co_positions())
+NO_LOCATION = [index for index, row in enumerate(POSITIONS) if row[0] is None]
+
+
+FRAMES = []
+
+
+class Manager:
+    def __enter__(self):
+        FRAMES.append(sys._getframe(1))
+        return self
+
+    def __exit__(self, *unused):
+        return False
+
+
+try:
+    GUARDED(Manager())
+except ValueError:
+    pass
+
+
+def the_cleanup_of_a_with_carries_no_line():
+    # Derived rather than written out: the count is what matters, not which
+    # offsets the compiler put them at.
+    print('no-location instructions:', len(NO_LOCATION) > 0)
+    assert NO_LOCATION, POSITIONS
+
+
+def a_traceback_rebuilt_on_one_reports_no_line():
+    # A live frame for that code object, so the rebuilt node resolves against
+    # the same line table.  Reached through `__enter__` rather than a trace
+    # function on purpose: `PyCode_Addr2Line` consults the monitoring line
+    # table ahead of `co_linetable` once a code object is instrumented, and
+    # that one answers only at instruction starts, so tracing this frame would
+    # report `None` for every inline cache as well.
+    frame = FRAMES[0]
+    TracebackType = types.TracebackType
+    lines = [TracebackType(None, frame, index * 2, -1).tb_lineno for index in NO_LOCATION]
+    print('tb_lineno on no-location:', lines)
+    assert lines == [None] * len(NO_LOCATION), lines
+    # The control: every instruction that does carry a line still answers one,
+    # so the `None`s above are the gap and not a resolver that stopped early.
+    carried = [index for index, row in enumerate(POSITIONS) if row[0] is not None]
+    answered = [TracebackType(None, frame, index * 2, -1).tb_lineno for index in carried]
+    print('every carrying instruction answers a line:',
+          all(line is not None for line in answered))
+    assert all(line is not None for line in answered), answered
+
+
+def a_frame_stopped_on_one_reports_no_line():
+    seen = {}
+    reprs = {}
+
+    def tracer(frame, event, arg):
+        if frame.f_code is GUARDED.__code__:
+            frame.f_trace_opcodes = True
+            if event == 'opcode':
+                index = frame.f_lasti // 2
+                if index in NO_LOCATION:
+                    seen[index] = frame.f_lineno
+                    reprs[index] = repr(frame).split(', line ')[1].split(',')[0]
+        return tracer
+
+    sys.settrace(tracer)
+    try:
+        GUARDED(Manager())
+    except ValueError:
+        pass
+    finally:
+        sys.settrace(None)
+    executed = sorted(seen)
+    print('f_lineno on no-location:', [seen[index] for index in executed])
+    print('frame repr line there:', sorted(set(reprs.values())))
+    assert executed, (seen, NO_LOCATION)
+    assert all(seen[index] is None for index in executed), seen
+
+
+def holder():
+    HOLDER.append(sys._getframe())
+    return 1
+
+
+HOLDER = []
+holder()
+RESTING = HOLDER[0]
+
+
+def a_frame_for(linetable):
+    """A frame of `holder` recompiled with a replacement line table."""
+    replaced = holder.__code__.replace(co_linetable=linetable)
+    types.FunctionType(replaced, globals())()
+    return HOLDER[-1]
+
+
+def a_line_table_covering_nothing_resolves_to_none():
+    frame = a_frame_for(b'')
+    TracebackType = types.TracebackType
+    lines = [TracebackType(None, frame, lasti, -1).tb_lineno for lasti in (0, 2, 4, 100)]
+    print('empty line table:', lines, frame.f_lineno)
+    assert lines == [None, None, None, None], lines
+    assert frame.f_lineno is None, frame.f_lineno
+
+
+def a_line_table_covering_one_instruction_stops_there():
+    # One header byte with a zero payload code: a single two-byte range on the
+    # first line, and nothing after it.
+    frame = a_frame_for(b'\x00')
+    firstlineno = holder.__code__.co_firstlineno
+    TracebackType = types.TracebackType
+    lines = [TracebackType(None, frame, lasti, -1).tb_lineno for lasti in (0, 2, 4, 100)]
+    print('one-range line table:', [lines[0] == firstlineno] + lines[1:])
+    assert lines[0] == firstlineno, (lines[0], firstlineno)
+    assert lines[1:] == [None, None, None], lines
+
+
+def a_zero_first_line_is_the_answer_for_a_negative_offset():
+    replaced = holder.__code__.replace(co_firstlineno=0)
+    types.FunctionType(replaced, globals())()
+    frame = HOLDER[-1]
+    TracebackType = types.TracebackType
+    lines = [TracebackType(None, frame, lasti, -1).tb_lineno for lasti in (-1, -2, 0)]
+    print('zero co_firstlineno:', lines)
+    assert lines == [0, 0, 0], lines
+
+
+the_cleanup_of_a_with_carries_no_line()
+a_traceback_rebuilt_on_one_reports_no_line()
+a_frame_stopped_on_one_reports_no_line()
+a_line_table_covering_nothing_resolves_to_none()
+a_line_table_covering_one_instruction_stops_there()
+a_zero_first_line_is_the_answer_for_a_negative_offset()
+print('OK')

--- a/pyre/extra_tests/parity_tests/lineno_when_the_first_line_is_zero_or_negative.py
+++ b/pyre/extra_tests/parity_tests/lineno_when_the_first_line_is_zero_or_negative.py
@@ -1,3 +1,4 @@
+# pyre-check: pypy-diverges: rebuilds a code object through `types.CodeType` to reach `co_firstlineno <= 0`; pypy3 has no `co_exceptiontable` to hand it
 # CPython-suite gap: `test_code`, `test_frame` and `test_traceback` only ever
 # build code objects whose `co_firstlineno` is a real source line, and
 # `code.replace(co_firstlineno=...)` rejects anything below 1.  The

--- a/pyre/extra_tests/parity_tests/lineno_when_the_first_line_is_zero_or_negative.py
+++ b/pyre/extra_tests/parity_tests/lineno_when_the_first_line_is_zero_or_negative.py
@@ -1,0 +1,73 @@
+# CPython-suite gap: `test_code`, `test_frame` and `test_traceback` only ever
+# build code objects whose `co_firstlineno` is a real source line, and
+# `code.replace(co_firstlineno=...)` rejects anything below 1.  The
+# `types.CodeType` constructor does not, and `marshal` round-trips whatever it
+# was given, so a runtime that stores the first line as a one-indexed value can
+# pass every module while decoding the whole line table against a different
+# origin than the one the code object reports.
+#
+# parity-tests reason: `_PyCode_InitAddressRange` seeds the walk with
+# `co->co_firstlineno` whatever its sign, and every line the table computes is
+# that origin plus a delta.  Both readers of a *resolved* line -- `tb_lineno`
+# and `f_lineno` -- answer `None` below zero, while `repr(frame)` prints the
+# number itself, so the three disagree on purpose and only a signed resolver
+# gets all three right.  `co_lines()` and `co_positions()` add a third rule:
+# `-1` exactly is the missing-value marker and reports as `None` there, so a
+# line that *computes* to `-1` is indistinguishable from a `NO_LOCATION` range.
+#
+# PyPy 7.3.20 is a 3.11 line table with no `co_exceptiontable`, so the
+# `types.CodeType` call below raises there before any of this is reached.
+
+import re
+import sys
+import types
+
+SOURCE = "def probe(box):\n    box.append(sys._getframe())\n    return 1\n"
+NAMESPACE = {"sys": sys}
+exec(compile(SOURCE, "<origin>", "exec"), NAMESPACE)
+BASE = NAMESPACE["probe"].__code__
+
+
+def with_first_line(firstlineno):
+    return types.CodeType(
+        BASE.co_argcount,
+        BASE.co_posonlyargcount,
+        BASE.co_kwonlyargcount,
+        BASE.co_nlocals,
+        BASE.co_stacksize,
+        BASE.co_flags,
+        BASE.co_code,
+        BASE.co_consts,
+        BASE.co_names,
+        BASE.co_varnames,
+        BASE.co_filename,
+        BASE.co_name,
+        BASE.co_qualname,
+        firstlineno,
+        BASE.co_linetable,
+        BASE.co_exceptiontable,
+        BASE.co_freevars,
+        BASE.co_cellvars,
+    )
+
+
+for first in (-8, -1, 0, 1):
+    code = with_first_line(first)
+    box = []
+    types.FunctionType(code, NAMESPACE)(box)
+    frame = box[0]
+    print("co_firstlineno:", code.co_firstlineno)
+    # The first range covers the `RESUME`, which carries the origin itself.
+    print("   co_lines:", list(code.co_lines())[:2])
+    print("   co_positions:", list(code.co_positions())[:2])
+    # `frame_getlineno` hides a negative line; `frame_repr` prints it.
+    print("   f_lineno:", frame.f_lineno)
+    print("   repr:", re.sub(r"0x[0-9a-f]+", "0xADDR", repr(frame)))
+    # `tb_lineno` resolves the stored `-1` sentinel against the same origin.
+    resolved = [
+        types.TracebackType(None, frame, lasti, -1).tb_lineno
+        for lasti in (-2, -1, 0, 2, 4, 10000)
+    ]
+    print("   tb_lineno:", resolved)
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/no_line_event_on_the_prologue_resume.py
+++ b/pyre/extra_tests/parity_tests/no_line_event_on_the_prologue_resume.py
@@ -1,0 +1,71 @@
+# CPython-suite gap: `test_sys_settrace` compares full event lists, but every
+# expectation it carries was written from a function body, and `test_pdb`'s
+# doctests that would catch this live in `test_zipimport_support` -- gated, and
+# only reached by running a zipped copy of the doctest module.
+#
+# parity-tests reason: `initialize_lines` refuses to instrument five opcodes as
+# line-event sites -- `RESUME`, `POP_ITER`, `END_FOR`, `END_SEND` and
+# `END_ASYNC_FOR` -- so `INSTRUMENTED_LINE` is never written over them and no
+# `line` event can fire there.  The prologue `RESUME` is the one every frame
+# has, and a module body's carries line 0, below `co_firstlineno`: a runtime
+# without the filter reports an extra `line` event at line 0 before the first
+# statement, and `pdb` stops on `<string>(0)` where 3.14 stops on `(1)`.
+#
+# The `call` event's `f_lasti` is deliberately not compared: `_PyInterpreterFrame
+# _LASTI` is 0 while the frame sits on its `RESUME`, where this runtime reports
+# "not started", and that convention gap is a separate open item.
+#
+# PyPy 7.3.20 is a 3.11 line table whose module body has no line-0 range, so
+# its event list differs for that reason.
+
+import sys
+
+MODULE_EVENTS = []
+FUNCTION_EVENTS = []
+
+
+def module_tracer(frame, event, arg):
+    if frame.f_code.co_filename != "<events>":
+        return None
+    MODULE_EVENTS.append((event, frame.f_lineno))
+    return module_tracer
+
+
+CODE = compile("x = 12\ny = x\n", "<events>", "exec")
+print("co_lines:", list(CODE.co_lines()))
+sys.settrace(module_tracer)
+try:
+    exec(CODE, {})
+finally:
+    sys.settrace(None)
+print("module events:", MODULE_EVENTS)
+
+
+SOURCE = """
+def target(a):
+    b = a + 1
+    for i in range(2):
+        b += i
+    return b
+"""
+NAMESPACE = {}
+exec(compile(SOURCE, "<events>", "exec"), NAMESPACE)
+
+
+def function_tracer(frame, event, arg):
+    if frame.f_code.co_name != "target":
+        return None
+    FUNCTION_EVENTS.append((event, frame.f_lineno))
+    return function_tracer
+
+
+sys.settrace(function_tracer)
+try:
+    NAMESPACE["target"](1)
+finally:
+    sys.settrace(None)
+# The loop's `END_FOR` / `POP_ITER` are excluded for the same reason, so the
+# exit carries no event of its own.
+print("function events:", FUNCTION_EVENTS)
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/traceback_report_of_a_frame_with_no_line.py
+++ b/pyre/extra_tests/parity_tests/traceback_report_of_a_frame_with_no_line.py
@@ -1,0 +1,73 @@
+# CPython-suite gap: `test_traceback` renders plenty of tracebacks, but every
+# frame in them sits on an instruction the compiler gave a position to, so the
+# line slot always holds a number.  Nothing in the suite prints a frame whose
+# line is missing, even though `co_positions()` reports those instructions and
+# `tb_lineno` already answers `None` for them.
+#
+# parity-tests reason: the default report is written by the interpreter, not by
+# the `traceback` module, so what it does with a `None` line is a separate
+# implementation.  `FrameSummary.lineno` is whatever `tb_lineno` answered and
+# is formatted straight into the `File "...", line ...` header, so the header
+# reads `line None`; `_set_lines` returns early for a summary with no line, so
+# no source line is echoed under it.  A report that substitutes a number there
+# -- the resolver's `-1`, or the line that happened to precede the range --
+# claims a position the code object does not have.
+#
+# PyPy 7.3.20 has no `TracebackType` constructor, so the child below fails
+# there for the reason `traceback_lineno_sentinel.py` gives.
+
+import subprocess
+import sys
+import tempfile
+import os
+
+PROBE = '''\
+import sys
+import types
+
+SOURCE = """
+def guarded(cm, box):
+    box.append(sys._getframe())
+    with cm:
+        pass
+"""
+NAMESPACE = {"sys": sys}
+exec(compile(SOURCE, "<no-line>", "exec"), NAMESPACE)
+POSITIONS = list(NAMESPACE["guarded"].__code__.co_positions())
+NO_LOCATION = [index for index, row in enumerate(POSITIONS) if row[0] is None]
+
+
+class Manager:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+box = []
+NAMESPACE["guarded"](Manager(), box)
+error = ValueError("no line here")
+error.__traceback__ = types.TracebackType(None, box[0], NO_LOCATION[0] * 2, -1)
+raise error
+'''
+
+with tempfile.TemporaryDirectory() as folder:
+    script = os.path.join(folder, "probe.py")
+    with open(script, "w") as handle:
+        handle.write(PROBE)
+    child = subprocess.run(
+        [sys.executable, script],
+        capture_output=True,
+        text=True,
+    )
+
+print("exit:", child.returncode)
+for line in child.stderr.splitlines():
+    # The child's own path is a temporary directory; only the rebuilt frame
+    # and the exception line are being compared.
+    if script in line or line.strip() == "raise error":
+        continue
+    print(repr(line))
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/traceback_type_int_arguments.py
+++ b/pyre/extra_tests/parity_tests/traceback_type_int_arguments.py
@@ -1,0 +1,64 @@
+# CPython-suite gap: `test_traceback`'s `TestTracebackType` builds nodes with
+# plain in-range integers, so nothing in the suite reaches either edge of the
+# `int` converter its signature declares -- neither an object that is only
+# index-able, nor a value the C `int` cannot hold.
+#
+# parity-tests reason: `tb_lasti` and `tb_lineno` are declared `int`, so the
+# converter Argument Clinic emits is `PyLong_AsInt`.  That reduces through
+# `__index__`, which is why the rejection reads `'str' object cannot be
+# interpreted as an integer` rather than a signature-shaped message, and it
+# raises `OverflowError` rather than storing a value the slot cannot hold.  A
+# runtime that tests `int` directly and stores a machine word gets all three
+# answers wrong, and the stored value then reaches the traceback's line
+# resolution as a byte offset no code object can have.
+#
+# PyPy 7.3.20 has no `TracebackType` constructor at all, so it fails here for
+# the reason `traceback_lineno_sentinel.py` gives.
+
+import types
+
+
+def frame_of_a_raise():
+    try:
+        raise ValueError("probe")
+    except ValueError as exc:
+        return exc.__traceback__.tb_frame
+
+
+FRAME = frame_of_a_raise()
+
+
+class Indexable:
+    def __index__(self):
+        return 7
+
+
+node = types.TracebackType(None, FRAME, Indexable(), Indexable())
+print("index argument:", node.tb_lasti, node.tb_lineno)
+# `True` is an `int` subclass and converts to 1 / 0.
+node = types.TracebackType(None, FRAME, True, False)
+print("bool argument:", node.tb_lasti, node.tb_lineno)
+# The largest and smallest values the slot does hold.
+node = types.TracebackType(None, FRAME, 2**31 - 1, -(2**31))
+print("at the edge:", node.tb_lasti, node.tb_lineno)
+
+for argument in (2**31, -(2**31) - 1):
+    for position in (0, 1):
+        arguments = [1, 1]
+        arguments[position] = argument
+        try:
+            types.TracebackType(None, FRAME, *arguments)
+        except BaseException as exc:
+            print("out of range:", type(exc).__name__, exc)
+        else:
+            print("out of range: accepted")
+
+for argument in ("x", 1.0, None):
+    try:
+        types.TracebackType(None, FRAME, argument, 1)
+    except BaseException as exc:
+        print("not an integer:", type(exc).__name__, exc)
+    else:
+        print("not an integer: accepted")
+
+print("OK")

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -14592,25 +14592,21 @@ pub fn view_as_kwargs(w_dict: PyObjectRef) -> (Option<Vec<PyObjectRef>>, Option<
 ///         return self.type(w_function).getname(self) + ' object'
 /// ```
 ///
-/// `object_functionstr` uses small private helpers instead of the
-/// public `findattr` / `display::py_str` shortcuts because PyPy's
-/// control flow is intentionally narrow here:
+/// The two `try/except OperationError: pass` blocks above are NOT ported, and
+/// neither is the `getname(self) + ' object'` answer the last one falls back
+/// to.  `_PyObject_FunctionStr` propagates every fault instead — a raising
+/// `__qualname__` descriptor, a raising `__module__` one, a raising or
+/// non-string `__str__` on either name, and a raising `__eq__` on the module.
+/// Its fallback for an ABSENT `__qualname__` is `PyObject_Str`, and that one
+/// is kept.  Upstream also requires `__module__` to be a non-empty `str`,
+/// where the C code rich-compares the object and renders it with `%S`, so
+/// `__module__ = 42` prefixes `42.` there and is dropped here.
+/// `functionstr_propagates.py` pins the seven cells.
 ///
-/// - `findattr` suppresses ordinary `OperationError` and returns
-///   `None`, but **re-raises** SystemExit / KeyboardInterrupt
-///   (`baseobjspace.py:881-884 if e.async(self): raise`).
-/// - the final fallback calls `space.str(w_function)` once, then
-///   `space.text_w(...)`; it does not try `repr()` after a failing or
-///   non-string `__str__`.
-///
-/// The async-propagation contract is preserved: the `__qualname__`
-/// findattr lives outside the inner try, so any async error there
-/// surfaces as `Err(PyError)` to `raise_type_error`, which then
-/// returns the async error in place of the TypeError prefix.  The
-/// `__module__` findattr and the `text_w(...)` calls live inside the
-/// PyPy try/except OperationError block — async OR ordinary errors
-/// there fall through to the `str(w_function)` fallback, matching
-/// PyPy's `except OperationError: pass`.
+/// `text_w` gave way to `display::py_str_wtf8`, which IS `PyObject_Str`: it
+/// tries `__str__` and falls back to `__repr__`, and reports a non-string
+/// return as `__str__ returned non-string (type X)` rather than reading it as
+/// "no name".
 ///
 /// `function.py` initialises `self.qualname = qualname or self.name`,
 /// so `w_function.qualname` returns the dotted form (e.g.
@@ -14623,6 +14619,12 @@ pub fn object_functionstr(w_function: PyObjectRef) -> Result<Wtf8Buf, crate::PyE
     // `FunctionWithFixedCode` and `BuiltinFunction`, both subclasses
     // of `Function` per function.py).  Pyre's `is_function`
     // unifies all three over `FUNCTION_TYPE` + `BUILTIN_FUNCTION_TYPE`.
+    //
+    // `_PyObject_FunctionStr` has no fast path — it reads both names off the
+    // object — and the two agree for a function, whose `__qualname__` is a
+    // `str` the slot already holds.  Only the module part has to run the
+    // general rule, which is why it goes through the same helper the generic
+    // path below uses.
     if !w_function.is_null() && unsafe { crate::function::is_function(w_function) } {
         // function.py:2108 `qualname = w_function.qualname` — match
         // PyPy's stored `qualname` field via the helper that walks
@@ -14630,16 +14632,12 @@ pub fn object_functionstr(w_function: PyObjectRef) -> Result<Wtf8Buf, crate::PyE
         // The qualname is WTF-8 and this text becomes a TypeError's
         // `args[0]` prefix, so `format!` (which would render it through
         // `Display` and substitute U+FFFD) is not usable here.
+        // `function_get_qualname` hands back owned bytes and runs no Python, so
+        // reading it first is unobservable — and it keeps the function off the
+        // live set across `object_functionstr_prefix`, which can collect.
         let qualname = unsafe { crate::function::function_get_qualname(w_function) };
-        let mut out = Wtf8Buf::new();
         let w_module = unsafe { crate::function::fget___module__(w_function) };
-        if !is_w(w_module, w_none()) && unsafe { pyre_object::is_str(w_module) } {
-            let module = unsafe { pyre_object::w_str_get_wtf8(w_module) };
-            if !module.is_empty() && module.as_str() != Ok("builtins") {
-                out.push_wtf8(module);
-                out.push_str(".");
-            }
-        }
+        let mut out = object_functionstr_prefix(w_module)?;
         out.push_wtf8(&qualname);
         out.push_str("()");
         return Ok(out);
@@ -14650,171 +14648,98 @@ pub fn object_functionstr(w_function: PyObjectRef) -> Result<Wtf8Buf, crate::PyE
         let inner = unsafe { pyre_object::function::w_method_get_func(w_function) };
         return object_functionstr(inner);
     }
-    // baseobjspace.py — `w_qualname = self.findattr(...)`.  This
-    // findattr lives **outside** the inner try/except, so an async
-    // exception (SystemExit/KeyboardInterrupt) here is propagated to
-    // the caller via `Err(...)` matching `findattr`'s `e.async(self):
-    // raise` re-raise (`baseobjspace.py:881-884`).
-    let w_qualname_opt = object_functionstr_findattr(w_function, "__qualname__")?;
-    // baseobjspace.py:2125-2135 — `try/except OperationError: pass`.
-    // Every fault inside this block (text_w(qualname), findattr(module),
-    // text_w(module)) must fall through to the `str(w_function)`
-    // fallback rather than propagate.  In particular the second
-    // `findattr(__module__)` is **inside** the try, so async errors
-    // there are also suppressed — matches PyPy literally.
-    'qualname: {
-        let Some(w_qualname) = w_qualname_opt else {
-            break 'qualname;
-        };
-        let Ok(qualname) = object_functionstr_text_w(w_qualname) else {
-            break 'qualname;
-        };
-        let w_module = match object_functionstr_findattr(w_function, "__module__") {
-            Ok(opt) => opt,
-            // try/except OperationError: pass — async findattr suppressed too.
-            Err(_) => break 'qualname,
-        };
-        // The dotted prefix is optional; the qualname and the trailing `()`
-        // are not, so build the one and prepend the other.
-        let bare = |qualname: &Wtf8Buf| {
-            let mut out = qualname.clone();
-            out.push_str("()");
-            out
-        };
-        match w_module {
-            // No `__module__` or `__module__ is None`: bare `qualname()`.
-            None => return Ok(bare(&qualname)),
-            Some(w_module) if is_w(w_module, w_none()) => return Ok(bare(&qualname)),
-            Some(w_module) => {
-                // text_w(w_module) — non-string raises in PyPy → except →
-                // fall through (do NOT return `qualname()` here, which
-                // would mask the OperationError).
-                let Ok(module) = object_functionstr_text_w(w_module) else {
-                    break 'qualname;
-                };
-                if !module.is_empty() && module.as_str() != Ok("builtins") {
-                    let mut out = module;
-                    out.push_str(".");
-                    out.push_wtf8(&qualname);
-                    out.push_str("()");
-                    return Ok(out);
-                }
-                // module empty or 'builtins': bare qualname().
-                return Ok(bare(&qualname));
-            }
-        }
-    }
-    // baseobjspace.py — `text_w(str(w_function))` fallback,
-    // else `type(w_function).getname() + ' object'`.  Both calls live
-    // in `try/except OperationError: pass`, so any error (including
-    // async) here is swallowed in PyPy — keep the same shape.  PyPy
-    // calls `space.str(w_function)`, which dispatches to `__str__`
-    // ALONE via `descroperation.str` (it does NOT fall back to
-    // `__repr__` — that would require `space.repr(...)`).  Routing
-    // through `display::py_str` would mask a failing/non-string
-    // `__str__` by calling `__repr__`, producing a different message
-    // than upstream.
-    if let Ok(w_s) = object_functionstr_str(w_function)
-        && unsafe { pyre_object::is_str(w_s) }
-    {
-        // `str(w_function)`'s own text: another `w_str_get_value` that would
-        // panic on a lone surrogate rather than answer.
-        return Ok(unsafe { pyre_object::w_str_get_wtf8(w_s).to_wtf8_buf() });
-    }
-    Ok(Wtf8Buf::from_string(format!(
-        "{} object",
-        object_functionstr_type_name(w_function)
-    )))
+    // The generic path is `_PyObject_FunctionStr`:
+    //
+    // ```c
+    // int ret = PyObject_GetOptionalAttr(x, &_Py_ID(__qualname__), &qualname);
+    // if (qualname == NULL) {
+    //     if (ret < 0) { return NULL; }
+    //     return PyObject_Str(x);
+    // }
+    // ret = PyObject_GetOptionalAttr(x, &_Py_ID(__module__), &module);
+    // if (module != NULL && module != Py_None) { ... }
+    // else if (ret < 0) { goto done; }
+    // result = PyUnicode_FromFormat("%S()", qualname);
+    // ```
+    //
+    // Upstream wraps the second lookup and both text conversions in a
+    // `try/except OperationError: pass` that falls through to the
+    // `str(w_function)` answer; there is no such block here, because 3.14
+    // propagates every one of those faults.  Measured, a callable whose
+    // `__qualname__` descriptor raises `TypeError('boom')` and is then called
+    // as `f(*1)` reports `TypeError: boom` on 3.14.2 and the
+    // "argument after * must be an iterable" message on PyPy 7.3.20 —
+    // `functionstr_propagates.py` pins that and the six other faults.
+    //
+    // The lookups are `findattr`, which is `PyObject_GetOptionalAttr`: only a
+    // missing name reads as absent.
+    let Some(w_qualname) = findattr(w_function, "__qualname__")? else {
+        return unsafe { crate::display::py_str_wtf8(w_function) };
+    };
+    // `PyUnicode_FromFormat("%S.%S()", module, qualname)` converts the module
+    // first, so a raising `__str__` on it wins over one on the qualname —
+    // measured, a callable whose module and qualname both raise from `__str__`
+    // reports the module's.  That leaves the qualname object live across the
+    // second lookup and the whole prefix, both of which run Python and can
+    // collect, so it waits on the shadow stack rather than in a local.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let qualname_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_qualname);
+    let w_module = findattr(w_function, "__module__")?.unwrap_or(pyre_object::PY_NULL);
+    let mut out = object_functionstr_prefix(w_module)?;
+    let w_qualname = pyre_object::gc_roots::shadow_stack_get(qualname_slot);
+    out.push_wtf8(&unsafe { crate::display::py_str_wtf8(w_qualname) }?);
+    out.push_str("()");
+    Ok(out)
 }
 
-/// `space.str(w_obj)` — `__str__`-only fast path for
-/// `object_functionstr`'s final fallback.
+/// The `module.` prefix `_PyObject_FunctionStr` puts in front of a qualname,
+/// or the empty string when there is none to put there.
 ///
-/// `pypy/objspace/descroperation.py str(self, space, w_obj)` does
-/// `lookup(w_obj, '__str__')` then `space.get_and_call_function(...)`.
-/// `__repr__` is never tried here — that would be `space.repr(...)`.
-/// Returning `Err` for any of: missing `__str__` slot, descriptor
-/// invocation failure, non-string return — caller suppresses to the
-/// `<Type> object` fallback per PyPy's `except OperationError`.
-fn object_functionstr_str(w_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-    if w_obj.is_null() {
-        return Err(crate::PyError::type_error("NULL object"));
-    }
-    unsafe {
-        if pyre_object::is_str(w_obj) {
-            return Ok(w_obj);
-        }
-        let Some(w_descr) = lookup(w_obj, "__str__") else {
-            return Err(crate::PyError::type_error(format!(
-                "'{}' object has no __str__",
-                object_functionstr_type_name(w_obj),
-            )));
-        };
-        crate::call::call_function_impl_result(w_descr, &[w_obj])
-    }
-}
-
-/// `object_functionstr`-local version of
-/// `baseobjspace.py findattr`.
-///
-/// ```python
-/// def findattr(self, w_object, w_name):
-///     try:
-///         return self.getattr(w_object, w_name)
-///     except OperationError as e:
-///         # a PyPy extension: let SystemExit and KeyboardInterrupt go through
-///         if e.async(self):
-///             raise
-///         return None
+/// ```c
+/// if (module != NULL && module != Py_None) {
+///     ret = PyObject_RichCompareBool(module, &_Py_ID(builtins), Py_NE);
+///     if (ret < 0) { goto done; }
+///     if (ret > 0) { result = PyUnicode_FromFormat("%S.%S()", module, qualname); }
+/// }
 /// ```
 ///
-/// `Err(_)` carries the propagated async exception, asked through
-/// `PyError::async`.  Ordinary `OperationError`s
-/// (AttributeError, NameError, TypeError from descriptors) collapse to
-/// `Ok(None)`, matching the `return None` arm.
+/// The test is a rich comparison against the object, not a check that it is a
+/// string, so `__module__ = 42` prefixes `42.` and `__module__ = ''` prefixes
+/// a bare `.`; upstream instead requires a non-empty `str` and drops the
+/// prefix for both.
 ///
-/// This one keeps upstream's swallow set rather than the narrower 3.14 rule
-/// [`findattr`] takes, because the surrounding `object_functionstr` is a
-/// port of upstream's try/except layout and the two have to agree on which
-/// faults reach the `str(w_function)` fallback.  The residual divergence is
-/// upstream's own: `_PyObject_FunctionStr` propagates any non-AttributeError
-/// from either lookup, so a raising `__qualname__` descriptor stops it where
-/// this falls through.
-fn object_functionstr_findattr(
-    obj: PyObjectRef,
-    name: &str,
-) -> Result<Option<PyObjectRef>, crate::PyError> {
-    if unsafe { is_none(obj) } {
-        return Ok(None);
+/// The comparison is `Py_NE`, so it reaches `__ne__` and not `__eq__` — a
+/// module whose type defines only a raising `__ne__` stops the message with
+/// that error.  Two *exact* `str`s compare by value without running Python,
+/// which covers every module a real import produces; a `str` SUBCLASS may
+/// override `__ne__` and so has to take the general route, which allocates,
+/// so the module is rooted across it.
+fn object_functionstr_prefix(w_module: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
+    if w_module.is_null() || unsafe { is_none(w_module) } {
+        return Ok(Wtf8Buf::new());
     }
-    match getattr_str(obj, name) {
-        Ok(value) if value.is_null() => Ok(None),
-        Ok(value) => Ok(Some(value)),
-        Err(mut e) => {
-            if e.r#async(w_none()) {
-                Err(e)
-            } else {
-                Ok(None)
-            }
-        }
+    let _roots = pyre_object::gc_roots::push_roots();
+    let slot = pyre_object::gc_roots::shadow_stack_len();
+    let w_module = pyre_object::gc_roots::pin_root(w_module);
+    let exact_str = unsafe {
+        pyre_object::is_exact_type(w_module, &pyre_object::STR_TYPE)
+            && pyre_object::is_str(w_module)
+    };
+    let differs = if exact_str {
+        unsafe { pyre_object::w_str_get_wtf8(w_module) }.as_str() != Ok("builtins")
+    } else {
+        let w_builtins = unsafe { pyre_object::w_str_new("builtins") };
+        let w_module = pyre_object::gc_roots::shadow_stack_get(slot);
+        is_true(compare(w_module, w_builtins, CompareOp::Ne)?)?
+    };
+    if !differs {
+        return Ok(Wtf8Buf::new());
     }
-}
-
-/// `space.text_w(w_obj)` for the `object_functionstr` try blocks.
-fn object_functionstr_text_w(w_obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
-    unsafe {
-        if pyre_object::is_str(w_obj) {
-            // `text_w` is the surrogate-preserving spelling upstream, and
-            // `w_str_get_value` would panic outright on a `__qualname__`
-            // carrying a lone surrogate rather than return its text.
-            Ok(pyre_object::w_str_get_wtf8(w_obj).to_wtf8_buf())
-        } else {
-            Err(crate::PyError::type_error(format!(
-                "expected str, got {} object",
-                object_functionstr_type_name(w_obj),
-            )))
-        }
-    }
+    let w_module = pyre_object::gc_roots::shadow_stack_get(slot);
+    let mut out = unsafe { crate::display::py_str_wtf8(w_module) }?;
+    out.push_str(".");
+    Ok(out)
 }
 
 pub(crate) fn object_functionstr_type_name(w_obj: PyObjectRef) -> String {

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -21,6 +21,27 @@ use crate::{
 /// glibc does neither. So `<function f at 0x000001B7AF7FFCC0>` and
 /// `<function f at 0x1b7af7ffcc0>` are the same repr, each on its own platform,
 /// and Rust's `{:p}` is only ever the second one.
+///
+/// The *value* is a raw address, where `getaddrstring` renders `space.id(self)`
+/// — the same number `builtin_id` answers, which since #1316 goes through
+/// `gc_identity_hash` so a nursery move preserves it.  The two spellings can
+/// therefore disagree for a young object, whose id is the shadow address it is
+/// about to be moved to rather than the one it currently occupies.
+///
+/// They do not disagree in practice, and that was measured rather than assumed:
+/// for `object()`, an instance, a function and a generator — the classes whose
+/// repr carries an address at all — the repr address equals `hex(id(x))` at
+/// birth and again after a collection, at the default nursery, at 1MB and at
+/// 512KB, and under `MAJIT_GC_STRESS=1`.  The classes that do move, list and
+/// dict, print no address.  So the sets do not overlap and there is nothing to
+/// observe.
+///
+/// Closing the gap anyway would mean routing the callers through the hook, and
+/// they are not uniform: several pass a `*const` to a Rust struct
+/// (`PyFrame`, the thread lock types) rather than a GC handle, and one already
+/// holds a `usize` computed elsewhere.  It would also put a shadow-allocating
+/// call — i.e. a collection point — inside every address-printing repr.  Take
+/// that on with a witness in hand, not on the strength of the spelling.
 pub(crate) fn repr_addr(addr: usize) -> String {
     if cfg!(windows) {
         format!("0x{addr:0width$X}", width = size_of::<usize>() * 2)

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -3417,7 +3417,7 @@ fn write_traceback_chain_from_tb<W: Write>(
     let _roots = pyre_object::gc_roots::push_roots();
     // `StackSummary.format` dedup state: the previous frame's identity and how
     // many consecutive frames have carried it.
-    let mut last: Option<(Vec<u8>, i64, String)> = None;
+    let mut last: Option<(Vec<u8>, Option<i64>, String)> = None;
     let mut repeats: usize = 0;
     while !tb.is_null() {
         let tb_slot = pyre_object::gc_roots::shadow_stack_len();
@@ -3427,10 +3427,11 @@ fn write_traceback_chain_from_tb<W: Write>(
             break;
         }
         let w_code = unsafe { crate::pytraceback::w_pytraceback_get_w_code(current_tb) };
-        // `Py_DisplayTraceback` prints whatever `tb_get_lineno` gave it,
-        // negative included, rather than skipping a node it cannot place.
-        let lineno =
-            unsafe { crate::pytraceback::w_pytraceback_get_lineno(current_tb) }.unwrap_or(-1);
+        // `FrameSummary.lineno` is whatever `tb_lineno` answered, `None`
+        // included: the node is still printed, with `None` where the line
+        // would go and with no source line under it, because `_set_lines`
+        // returns early for a summary that has no line to read.
+        let lineno = unsafe { crate::pytraceback::w_pytraceback_get_lineno(current_tb) };
         let lasti = unsafe { crate::pytraceback::w_pytraceback_get_lasti(current_tb) };
         let (filename, funcname, location) = if w_code.is_null() {
             (b"<unknown>".to_vec(), String::from("<unknown>"), None)
@@ -3476,6 +3477,7 @@ fn write_traceback_chain_from_tb<W: Write>(
             continue;
         }
         let (filename, lineno, funcname) = key;
+        let shown_lineno = lineno.map_or_else(|| String::from("None"), |line| line.to_string());
         // The name is *reported* as the text it decodes to, with the same error
         // handler that read it off the filesystem, so a byte with no UTF-8
         // spelling reaches the stream as its escape.  Writing the raw bytes
@@ -3485,13 +3487,13 @@ fn write_traceback_chain_from_tb<W: Write>(
         let shown_filename = crate::gateway::fsdecode_filename_wtf8(&filename);
         writer.write_all(b"  File \"")?;
         writer.write_all(shown_filename.as_bytes())?;
-        writeln!(writer, "\", line {lineno}, in {funcname}")?;
+        writeln!(writer, "\", line {shown_lineno}, in {funcname}")?;
         // `FrameSummary._set_lines` collects every line the failing
         // instruction spans, so a statement written across several lines (a
         // class body, a multi-line call) shows all of them, dedented by the
         // indentation they share.
         if let Some((start_line, end_line, _, _)) = location
-            && usize::try_from(lineno).ok() == Some(start_line)
+            && lineno.and_then(|line| usize::try_from(line).ok()) == Some(start_line)
             && end_line > start_line
         {
             let span: Vec<String> = (start_line..=end_line)
@@ -3505,13 +3507,15 @@ fn write_traceback_chain_from_tb<W: Write>(
                     writeln!(writer, "    {line}")?;
                 }
             }
-        } else if let Some(line) = frame_source_line(tb_slot, &filename, lineno) {
+        } else if let Some(line) =
+            lineno.and_then(|line| frame_source_line(tb_slot, &filename, line))
+        {
             let raw_line = line.trim_end_matches(['\n', '\r']);
             let shown_line = raw_line.trim_start();
             writeln!(writer, "    {shown_line}")?;
 
             if let Some((start_line, end_line, start_col, end_col)) = location
-                && usize::try_from(lineno).ok() == Some(start_line)
+                && lineno.and_then(|line| usize::try_from(line).ok()) == Some(start_line)
                 && end_line == start_line
                 && end_col > start_col
                 && start_col <= raw_line.len()

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -1213,48 +1213,54 @@ pub fn all_subclass_range_aliases() -> Vec<pyre_object::pyobject::SubclassRangeA
         // `_queue.SimpleQueue` is unconditional and carries a native FIFO, so
         // it closes the ungated aliases ahead of the target-gated ones.
         subclass_range_alias(179, typed::<crate::module::_queue::W_SimpleQueue>()),
-        // Native-only posix aliases 180 and 181 preserve `build_gc`'s rclass
+        // `_PyLineIterator` / `_PyPositionsIterator` — each retains the code
+        // object whose `co_linetable` its suspended walk reads.  Both are
+        // unconditional, so they close the ungated block ahead of the
+        // target-gated native aliases.
+        subclass_range_alias(180, typed::<crate::pycode::W_LineIterObject>()),
+        subclass_range_alias(181, typed::<crate::pycode::W_PositionsIterObject>()),
+        // Native-only posix aliases 182 and 183 preserve `build_gc`'s rclass
         // registration order after the unconditional aliases.
         #[cfg(not(target_arch = "wasm32"))]
-        subclass_range_alias(180, typed::<crate::module::posix::W_DirEntry>()),
+        subclass_range_alias(182, typed::<crate::module::posix::W_DirEntry>()),
         #[cfg(not(target_arch = "wasm32"))]
-        subclass_range_alias(181, typed::<crate::module::posix::W_ScandirIterator>()),
+        subclass_range_alias(183, typed::<crate::module::posix::W_ScandirIterator>()),
         // The rustls-backed `_ssl` aliases preserve `build_gc`'s registration
         // order for `W_SSLContext`, `W_MemoryBIO`, and `W_SSLSession`.
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(182, typed::<crate::module::_ssl::W_SSLContext>()),
+        subclass_range_alias(184, typed::<crate::module::_ssl::W_SSLContext>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(183, typed::<crate::module::_ssl::W_MemoryBIO>()),
+        subclass_range_alias(185, typed::<crate::module::_ssl::W_MemoryBIO>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(184, typed::<crate::module::_ssl::W_SSLSession>()),
+        subclass_range_alias(186, typed::<crate::module::_ssl::W_SSLSession>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(185, typed::<crate::module::_ssl::W_SSLSocket>()),
+        subclass_range_alias(187, typed::<crate::module::_ssl::W_SSLSocket>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(186, typed::<crate::module::_ssl::W_Certificate>()),
+        subclass_range_alias(188, typed::<crate::module::_ssl::W_Certificate>()),
         // `mmap.mmap` follows the optional SSL tail on ordinary Unix builds.
         // A sandbox build has no `mmap` module at all (`module/mod.rs`), so it
         // contributes no alias rather than sliding into the vacated SSL slot.
         #[cfg(all(any(unix, windows), not(feature = "sandbox")))]
-        subclass_range_alias(187, typed::<crate::module::mmap::W_MMap>()),
+        subclass_range_alias(189, typed::<crate::module::mmap::W_MMap>()),
         // Windows asyncio's Overlapped owner follows mmap at the native tail.
         // It is a non-subclassable builtin in Python, but still participates
         // in the rclass hierarchy because its managed header and retained
         // buffer/result fields are traced by the ordinary object marker.
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
-        subclass_range_alias(188, typed::<crate::module::_overlapped::W_Overlapped>()),
+        subclass_range_alias(190, typed::<crate::module::_overlapped::W_Overlapped>()),
         // `_winapi.Overlapped` follows it: a second record of the same kind,
         // owning its own event and transfer buffer rather than retained
         // Python objects, so nothing of it is traced beyond the header.
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
         subclass_range_alias(
-            189,
+            191,
             typed::<crate::module::_winapi::overlapped::W_Overlapped>(),
         ),
         // PEP 528's raw console stream follows the two overlapped owners at
         // the append-only Windows tail.  It is subclassable and therefore
         // participates in the same rclass hierarchy as every typed IO base.
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
-        subclass_range_alias(190, typed::<crate::module::_io::W_WindowsConsoleIO>()),
+        subclass_range_alias(192, typed::<crate::module::_io::W_WindowsConsoleIO>()),
     ]
 }
 

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -1213,54 +1213,55 @@ pub fn all_subclass_range_aliases() -> Vec<pyre_object::pyobject::SubclassRangeA
         // `_queue.SimpleQueue` is unconditional and carries a native FIFO, so
         // it closes the ungated aliases ahead of the target-gated ones.
         subclass_range_alias(179, typed::<crate::module::_queue::W_SimpleQueue>()),
-        // `_PyLineIterator` / `_PyPositionsIterator` — each retains the code
-        // object whose `co_linetable` its suspended walk reads.  Both are
-        // unconditional, so they close the ungated block ahead of the
+        // `_PyLineIterator` / `_PyPositionsIterator` / `_PyBranchesIterator` —
+        // each retains the code object its suspended walk reads.  All three
+        // are unconditional, so they close the ungated block ahead of the
         // target-gated native aliases.
         subclass_range_alias(180, typed::<crate::pycode::W_LineIterObject>()),
         subclass_range_alias(181, typed::<crate::pycode::W_PositionsIterObject>()),
-        // Native-only posix aliases 182 and 183 preserve `build_gc`'s rclass
+        subclass_range_alias(182, typed::<crate::pycode::W_BranchesIterObject>()),
+        // Native-only posix aliases 183 and 184 preserve `build_gc`'s rclass
         // registration order after the unconditional aliases.
         #[cfg(not(target_arch = "wasm32"))]
-        subclass_range_alias(182, typed::<crate::module::posix::W_DirEntry>()),
+        subclass_range_alias(183, typed::<crate::module::posix::W_DirEntry>()),
         #[cfg(not(target_arch = "wasm32"))]
-        subclass_range_alias(183, typed::<crate::module::posix::W_ScandirIterator>()),
+        subclass_range_alias(184, typed::<crate::module::posix::W_ScandirIterator>()),
         // The rustls-backed `_ssl` aliases preserve `build_gc`'s registration
         // order for `W_SSLContext`, `W_MemoryBIO`, and `W_SSLSession`.
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(184, typed::<crate::module::_ssl::W_SSLContext>()),
+        subclass_range_alias(185, typed::<crate::module::_ssl::W_SSLContext>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(185, typed::<crate::module::_ssl::W_MemoryBIO>()),
+        subclass_range_alias(186, typed::<crate::module::_ssl::W_MemoryBIO>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(186, typed::<crate::module::_ssl::W_SSLSession>()),
+        subclass_range_alias(187, typed::<crate::module::_ssl::W_SSLSession>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(187, typed::<crate::module::_ssl::W_SSLSocket>()),
+        subclass_range_alias(188, typed::<crate::module::_ssl::W_SSLSocket>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(188, typed::<crate::module::_ssl::W_Certificate>()),
+        subclass_range_alias(189, typed::<crate::module::_ssl::W_Certificate>()),
         // `mmap.mmap` follows the optional SSL tail on ordinary Unix builds.
         // A sandbox build has no `mmap` module at all (`module/mod.rs`), so it
         // contributes no alias rather than sliding into the vacated SSL slot.
         #[cfg(all(any(unix, windows), not(feature = "sandbox")))]
-        subclass_range_alias(189, typed::<crate::module::mmap::W_MMap>()),
+        subclass_range_alias(190, typed::<crate::module::mmap::W_MMap>()),
         // Windows asyncio's Overlapped owner follows mmap at the native tail.
         // It is a non-subclassable builtin in Python, but still participates
         // in the rclass hierarchy because its managed header and retained
         // buffer/result fields are traced by the ordinary object marker.
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
-        subclass_range_alias(190, typed::<crate::module::_overlapped::W_Overlapped>()),
+        subclass_range_alias(191, typed::<crate::module::_overlapped::W_Overlapped>()),
         // `_winapi.Overlapped` follows it: a second record of the same kind,
         // owning its own event and transfer buffer rather than retained
         // Python objects, so nothing of it is traced beyond the header.
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
         subclass_range_alias(
-            191,
+            192,
             typed::<crate::module::_winapi::overlapped::W_Overlapped>(),
         ),
         // PEP 528's raw console stream follows the two overlapped owners at
         // the append-only Windows tail.  It is subclassable and therefore
         // participates in the same rclass hierarchy as every typed IO base.
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
-        subclass_range_alias(192, typed::<crate::module::_io::W_WindowsConsoleIO>()),
+        subclass_range_alias(193, typed::<crate::module::_io::W_WindowsConsoleIO>()),
     ]
 }
 

--- a/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
@@ -160,6 +160,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         let _ = roots.pin_root(pyre_object::w_dict_new());
         let field_types_slot = dict_slot + 1;
         let _ = roots.pin_root(pyre_object::w_dict_new());
+        // `make_type` builds ONE tuple of field names and binds it to both
+        // `_fields` and `__match_args__`, so `Expr._fields is
+        // Expr.__match_args__`.  It is pinned here, beside the two namespace
+        // dicts, because the first store of it allocates a key string and can
+        // grow the dict it lands in.
+        let fields_slot = field_types_slot + 1;
+        let _ = roots.pin_root(tuple_of_names(node_fields(name)));
         // The value arrives already built.  Call arguments evaluate left to
         // right, so reading a dict slot inline with an allocating value
         // expression would read the slot first and hand over a pre-move word.
@@ -182,6 +189,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         let _ = roots.pin_root(tuple_of_names(node_fields(name)));
         put(dict_slot, "_fields", roots.get(fields_slot))
             .expect("set _fields on _ast type namespace");
+        // Without this name a class pattern carrying positional sub-patterns
+        // raises `TypeError: Expr() accepts 0 positional sub-patterns`.
+        // `traceback._extract_caret_anchors_from_line_segment` is written as
+        // `case ast.Expr(expr)` over `ast.BinOp` / `ast.Subscript` /
+        // `ast.Call`, so every traceback printed through `traceback.py` loses
+        // its `~`/`^` anchors without it.
         put(dict_slot, "__match_args__", roots.get(fields_slot))
             .expect("set __match_args__ on _ast type namespace");
         put(

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -2046,6 +2046,20 @@ pub struct W_PositionsIterObject {
     pub end_column: i64,
 }
 
+/// `branchesiterator` — the object `co_branches()` returns.
+///
+/// `_PyBranchesIterator` reports `line_iterator` as its `tp_name`, the same
+/// string `_PyLineIterator` carries, so the two distinct types are
+/// indistinguishable by name; only `type(a) is type(b)` tells them apart.
+#[crate::pyre_class("line_iterator", static_name = "BRANCHES_ITER")]
+pub struct W_BranchesIterObject {
+    /// `bi_code` — the code object whose bytecode the walk reads, held so it
+    /// outlives the iterator.
+    pub w_code: PyObjectRef,
+    /// `bi_offset`, in code units.
+    pub offset: i64,
+}
+
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
@@ -2064,6 +2078,29 @@ pub unsafe fn is_positions_iter(obj: PyObjectRef) -> bool {
         return false;
     }
     !obj.is_null() && std::ptr::eq(unsafe { (*obj).ob_type }, &POSITIONS_ITER_TYPE)
+}
+
+/// # Safety
+/// The caller must uphold every validity, runtime-type, aliasing, and lifetime
+/// invariant required by the object and pointer arguments for the entire call.
+pub unsafe fn is_branches_iter(obj: PyObjectRef) -> bool {
+    if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
+        return false;
+    }
+    !obj.is_null() && std::ptr::eq(unsafe { (*obj).ob_type }, &BRANCHES_ITER_TYPE)
+}
+
+/// Whether `obj` is an instance of *a* type named `line_iterator`.
+///
+/// The owner a builtin method reports its receiver against is keyed by type
+/// name, and two types answer to `line_iterator`, so the name-keyed test
+/// admits either; each method body still checks the one layout it reads.
+///
+/// # Safety
+/// The caller must uphold every validity, runtime-type, aliasing, and lifetime
+/// invariant required by the object and pointer arguments for the entire call.
+pub unsafe fn is_named_line_iterator(obj: PyObjectRef) -> bool {
+    unsafe { is_line_iter(obj) || is_branches_iter(obj) }
 }
 
 /// The `co_linetable` an iterator walks, or `None` once its code object is
@@ -2258,70 +2295,114 @@ pub unsafe fn code_lines(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError
     }))
 }
 
+/// `int_triple` — the `(a, b, c)` tuple every branch row is reported as.
+fn int_triple(a: i64, b: i64, c: i64) -> PyObjectRef {
+    w_tuple_new(vec![w_int_new(a), w_int_new(b), w_int_new(c)])
+}
+
+/// `branchesiter_next` — the next branch instruction's
+/// `(instruction, not-taken target, taken target)` triple, in byte offsets.
+///
+/// The scan resumes at `bi_offset` and stops at the branch it reports, so a
+/// caller that reads one row does not pay for the rest of the bytecode.
+///
+/// # Safety
+/// `obj` must be a live [`W_BranchesIterObject`].
+pub unsafe fn branches_iter_next(obj: PyObjectRef) -> Option<PyObjectRef> {
+    unsafe {
+        let it = &mut *(obj as *mut W_BranchesIterObject);
+        if it.w_code.is_null() {
+            return None;
+        }
+        let code = w_code_get_ptr(it.w_code) as *const crate::CodeObject;
+        if code.is_null() {
+            return None;
+        }
+        let code = &*code;
+        let mut offset = usize::try_from(it.offset).ok()?;
+        let mut op_arg = 0usize;
+        while offset < code.instructions.len() {
+            let op = code.instructions.read_op(offset).deoptimize();
+            let next_offset = offset + 1 + op.cache_entries();
+            let arg = u8::from(code.instructions.read_arg(offset)) as usize;
+            match op {
+                crate::bytecode::Instruction::ExtendedArg => {
+                    op_arg = (op_arg << 8) | arg;
+                }
+                crate::bytecode::Instruction::ForIter { .. } => {
+                    op_arg = (op_arg << 8) | arg;
+                    it.offset = next_offset as i64;
+                    // Skips END_FOR and POP_ITER.
+                    let target = next_offset + op_arg + 2;
+                    return Some(int_triple(
+                        (offset * 2) as i64,
+                        (next_offset * 2) as i64,
+                        (target * 2) as i64,
+                    ));
+                }
+                crate::bytecode::Instruction::PopJumpIfFalse { .. }
+                | crate::bytecode::Instruction::PopJumpIfTrue { .. }
+                | crate::bytecode::Instruction::PopJumpIfNone { .. }
+                | crate::bytecode::Instruction::PopJumpIfNotNone { .. } => {
+                    op_arg = (op_arg << 8) | arg;
+                    // Skip NOT_TAKEN, which Python 3.14 emits at the
+                    // fallthrough edge so branch instrumentation can tell the
+                    // untaken path apart.
+                    let not_taken = next_offset + 1;
+                    it.offset = not_taken as i64;
+                    return Some(int_triple(
+                        (offset * 2) as i64,
+                        (not_taken * 2) as i64,
+                        ((next_offset + op_arg) * 2) as i64,
+                    ));
+                }
+                crate::bytecode::Instruction::EndAsyncFor => {
+                    op_arg = (op_arg << 8) | arg;
+                    let src_offset = next_offset - op_arg;
+                    it.offset = next_offset as i64;
+                    debug_assert!(matches!(
+                        code.instructions.read_op(src_offset).deoptimize(),
+                        crate::bytecode::Instruction::EndSend
+                    ));
+                    debug_assert!(matches!(
+                        code.instructions.read_op(src_offset + 1).deoptimize(),
+                        crate::bytecode::Instruction::NotTaken
+                    ));
+                    let not_taken = src_offset + 2;
+                    return Some(int_triple(
+                        (src_offset * 2) as i64,
+                        (not_taken * 2) as i64,
+                        (next_offset * 2) as i64,
+                    ));
+                }
+                _ => op_arg = 0,
+            }
+            offset = next_offset;
+        }
+        it.offset = offset as i64;
+        None
+    }
+}
+
+/// `_PyInstrumentation_BranchesIterator` — `co_branches()`.
+///
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn code_branches(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-    let code = unsafe { require_code(obj, "co_branches")? };
-    let mut rows = Vec::new();
-    let mut index = 0usize;
-    let mut op_arg = 0usize;
-    while index < code.instructions.len() {
-        let op = code.instructions.read_op(index).deoptimize();
-        let next = index + 1 + op.cache_entries();
-        let arg = u8::from(code.instructions.read_arg(index)) as usize;
-        match op {
-            crate::bytecode::Instruction::ExtendedArg => {
-                op_arg = (op_arg << 8) | arg;
-            }
-            crate::bytecode::Instruction::ForIter { .. } => {
-                op_arg = (op_arg << 8) | arg;
-                rows.push(w_tuple_new(vec![
-                    w_int_new((index * 2) as i64),
-                    w_int_new((next * 2) as i64),
-                    w_int_new(((next + op_arg + 2) * 2) as i64),
-                ]));
-                op_arg = 0;
-            }
-            crate::bytecode::Instruction::PopJumpIfFalse { .. }
-            | crate::bytecode::Instruction::PopJumpIfTrue { .. }
-            | crate::bytecode::Instruction::PopJumpIfNone { .. }
-            | crate::bytecode::Instruction::PopJumpIfNotNone { .. } => {
-                op_arg = (op_arg << 8) | arg;
-                // Python 3.14 inserts NOT_TAKEN at the fallthrough edge so
-                // branch instrumentation can distinguish the untaken path.
-                let not_taken = next + 1;
-                rows.push(w_tuple_new(vec![
-                    w_int_new((index * 2) as i64),
-                    w_int_new((not_taken * 2) as i64),
-                    w_int_new(((next + op_arg) * 2) as i64),
-                ]));
-                op_arg = 0;
-            }
-            crate::bytecode::Instruction::EndAsyncFor => {
-                op_arg = (op_arg << 8) | arg;
-                let source = next - op_arg;
-                debug_assert!(matches!(
-                    code.instructions.read_op(source).deoptimize(),
-                    crate::bytecode::Instruction::EndSend
-                ));
-                debug_assert!(matches!(
-                    code.instructions.read_op(source + 1).deoptimize(),
-                    crate::bytecode::Instruction::NotTaken
-                ));
-                rows.push(w_tuple_new(vec![
-                    w_int_new((source * 2) as i64),
-                    w_int_new(((source + 2) * 2) as i64),
-                    w_int_new((next * 2) as i64),
-                ]));
-                op_arg = 0;
-            }
-            _ => op_arg = 0,
-        }
-        index = next.max(index + 1);
-    }
-    let n = rows.len();
-    Ok(w_seq_iter_new(w_list_new(rows), n))
+    unsafe { require_code(obj, "co_branches")? };
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj = pyre_object::gc_roots::pin_root(obj);
+    Ok(W_BranchesIterObject::allocate_stable(
+        W_BranchesIterObject {
+            ob: pyre_object::PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
+            },
+            w_code: obj,
+            offset: 0,
+        },
+    ))
 }
 
 /// `code.replace(**kwds)` — `pypy/interpreter/pycode.py` applevel

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -2968,15 +2968,26 @@ pub fn code_locations(code: &crate::CodeObject) -> &[(SourceLocation, SourceLoca
 /// ```
 ///
 /// `location.py offset2lineno(c, stopat)` is the same resolver upstream, down
-/// to the byte-offset convention: it answers `c.co_firstlineno` for `-1` and
-/// halves `stopat` before walking the line table.  `pyframe::offset2lineno`
-/// carries the name but takes an instruction index, so this is the one a
-/// `tb_lasti` reaches.
+/// to the byte-offset convention: it halves `stopat` before walking the line
+/// table.  `pyframe::offset2lineno` carries the name but takes an instruction
+/// index, so this is the one a `tb_lasti` reaches.
 ///
 /// `addrq` counts bytes, two per instruction, so the row index is `addrq / 2`
-/// — the same conversion `traceback._get_code_position` makes app-level.  A
-/// negative offset names the code object's first line, which is the answer for
-/// a frame that has not run an instruction yet.
+/// — the same conversion `traceback._get_code_position` makes app-level.
+///
+/// EVERY negative offset names the code object's first line, which is the
+/// answer for a frame that has not run an instruction yet.  Upstream tests
+/// `stopat == -1` alone, so `-2` reaches `_offset2lineno(..., -1)`, walks a
+/// zero-length range and answers `-1`.  Measured with a traceback rebuilt at
+/// each offset:
+///
+/// | `tb_lasti` | 3.14.2 | PyPy 7.3.20 |
+/// |---|---|---|
+/// | `-1` | `co_firstlineno` | `co_firstlineno` |
+/// | `-2`, `-3` | `co_firstlineno` | `-1` |
+///
+/// The `addrq < 0` arm above is 3.14's, and `traceback_lineno_sentinel.py`
+/// pins it.
 ///
 /// An offset past the last row answers `None`, and `tb_lineno` hands that back
 /// as `None`.  `_PyCode_CheckLineNumber` also answers `-1` for an in-range

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -77,6 +77,39 @@ impl<'a> PyCodeAddressRange<'a> {
         true
     }
 
+    /// `_PyCode_CheckLineNumber` — the line the byte offset `lasti` sits on,
+    /// or `-1` when the walk runs out of ranges before reaching it.
+    ///
+    /// ```c
+    /// while (bounds->ar_end <= lasti) {
+    ///     if (!advance(bounds)) {
+    ///         return -1;
+    ///     }
+    /// }
+    /// while (bounds->ar_start > lasti) {
+    ///     if (!retreat(bounds)) {
+    ///         return -1;
+    ///     }
+    /// }
+    /// return bounds->ar_line;
+    /// ```
+    ///
+    /// The retreat loop has no counterpart here: a range built by
+    /// [`PyCodeAddressRange::new`] starts before the first offset and this is
+    /// the only walker, so `ar_start` never runs past `lasti`.
+    ///
+    /// `-1` covers two answers upstream also conflates: an offset past the
+    /// last range, and an offset inside a `NO_LOCATION` range, which
+    /// [`PyCodeAddressRange::advance`] reports by leaving `ar_line` at `-1`.
+    fn check_line_number(&mut self, lasti: i32) -> i32 {
+        while self.ar_end <= lasti {
+            if !self.advance() {
+                return -1;
+            }
+        }
+        self.ar_line
+    }
+
     fn get_line_delta(&mut self, code: u8) -> i32 {
         let Some(kind) = PyCodeLocationInfoKind::from_code(code) else {
             return 0;
@@ -2972,8 +3005,8 @@ pub fn code_locations(code: &crate::CodeObject) -> &[(SourceLocation, SourceLoca
 /// table.  `pyframe::offset2lineno` carries the name but takes an instruction
 /// index, so this is the one a `tb_lasti` reaches.
 ///
-/// `addrq` counts bytes, two per instruction, so the row index is `addrq / 2`
-/// — the same conversion `traceback._get_code_position` makes app-level.
+/// `addrq` counts bytes, two per instruction — the same unit
+/// `traceback._get_code_position` works in app-level.
 ///
 /// EVERY negative offset names the code object's first line, which is the
 /// answer for a frame that has not run an instruction yet.  Upstream tests
@@ -2989,18 +3022,38 @@ pub fn code_locations(code: &crate::CodeObject) -> &[(SourceLocation, SourceLoca
 /// The `addrq < 0` arm above is 3.14's, and `traceback_lineno_sentinel.py`
 /// pins it.
 ///
-/// An offset past the last row answers `None`, and `tb_lineno` hands that back
-/// as `None`.  `_PyCode_CheckLineNumber` also answers `-1` for an in-range
-/// instruction that carries no line at all; pyre's rows cannot spell that,
-/// because `SourceLocation::line` is a `OneIndexed`.
+/// `None` is `_PyCode_CheckLineNumber`'s `-1`, which both readers of this
+/// answer render as `None`: `tb_lineno_get` and `frame_getlineno` each return
+/// `Py_None` for a line below zero.  It covers an offset past the last range
+/// AND an offset inside a `NO_LOCATION` range — the compiler-generated
+/// cleanup a `with` or a `try`/`finally` leaves at the end of a code object,
+/// which `co_positions` reports with a `None` line.
+///
+/// The walk goes through [`PyCodeAddressRange`], not [`code_locations`]: the
+/// expanded array holds a `SourceLocation` per instruction and its `line` is a
+/// `OneIndexed`, so a `NO_LOCATION` range comes back carrying whatever line
+/// preceded it.  Reading `linetable` directly is also what lets a zero
+/// `co_firstlineno` — which `CodeType(...)` and `code.replace` both accept and
+/// `OneIndexed` cannot hold — reach the answer, and it takes no lock, where
+/// the array is behind a process-global mutex once `w_code_new` releases it.
 pub fn w_code_addr2line(code: &crate::CodeObject, addrq: i64) -> Option<usize> {
     if addrq < 0 {
-        return Some(code.first_line_number.map_or(1, |line| line.get()));
+        return usize::try_from(code_firstlineno_raw(code)).ok();
     }
-    let index = usize::try_from(addrq / 2).ok()?;
-    code_locations(code)
-        .get(index)
-        .map(|(start, _)| start.line.get())
+    let lasti = i32::try_from(addrq).unwrap_or(i32::MAX);
+    let mut bounds = PyCodeAddressRange::new(&code.linetable, code_firstlineno_raw(code));
+    usize::try_from(bounds.check_line_number(lasti)).ok()
+}
+
+/// The first line number `linetable` is decoded against, as the Python
+/// integer `co_firstlineno` answers rather than as a `OneIndexed`.
+///
+/// `CodeObject.first_line_number` is `None` for exactly the values
+/// `OneIndexed` cannot spell: both writers — the `CodeType(...)` constructor
+/// and `code.replace(co_firstlineno=...)` — take that branch on `<= 0`, and
+/// `replace` rejects a negative one, so `None` means zero.
+fn code_firstlineno_raw(code: &crate::CodeObject) -> i32 {
+    code.first_line_number.map_or(0, |line| line.get() as i32)
 }
 
 /// Whether the instruction at `pc` may be reported to a trace function as the
@@ -3756,9 +3809,9 @@ mod tests {
         assert_eq!(result, pyre_object::pyobject::PY_NULL);
     }
 
-    /// `PyCode_Addr2Line` on a real code object: the byte offset halves into a
-    /// row index, a negative offset names the first line, and an offset past
-    /// the last row reports no line at all.
+    /// `PyCode_Addr2Line` on a real code object: a negative offset names the
+    /// first line, an in-range offset names the line its range carries, and an
+    /// offset past the last range reports no line at all.
     #[test]
     fn w_code_addr2line_halves_the_offset_and_reports_a_miss() {
         let code = compile_exec("a = 1\nb = 2\nc = 3\n").expect("compile failed");
@@ -3766,22 +3819,32 @@ mod tests {
         assert_eq!(w_code_addr2line(&code, -1), Some(firstlineno));
         assert_eq!(w_code_addr2line(&code, -2), Some(firstlineno));
 
-        let rows: Vec<usize> = code_locations(&code)
-            .iter()
-            .map(|(start, _)| start.line.get())
+        let count = code.instructions.len();
+        assert!(count > 0);
+        let lines: Vec<Option<usize>> = (0..count)
+            .map(|index| w_code_addr2line(&code, index as i64 * 2))
             .collect();
-        assert!(!rows.is_empty());
-        for (index, line) in rows.iter().copied().enumerate() {
-            let addrq = index as i64 * 2;
-            assert_eq!(w_code_addr2line(&code, addrq), Some(line));
+        for (index, line) in lines.iter().copied().enumerate() {
             // The odd byte inside an instruction reads that instruction's row.
-            assert_eq!(w_code_addr2line(&code, addrq + 1), Some(line));
+            assert_eq!(w_code_addr2line(&code, index as i64 * 2 + 1), line);
         }
         // Each of the three statements contributes at least one instruction.
-        assert!(rows.contains(&(firstlineno + 2)), "{rows:?}");
+        for statement in 0..3 {
+            assert!(lines.contains(&Some(firstlineno + statement)), "{lines:?}");
+        }
 
-        assert_eq!(w_code_addr2line(&code, rows.len() as i64 * 2), None);
         assert_eq!(w_code_addr2line(&code, 1 << 30), None);
+        // An empty line table describes no range, so nothing resolves against
+        // it — `linetable_to_locations` instead expands one first-line row per
+        // instruction, which is why this reads `linetable` directly.
+        let mut blank = compile_exec("a = 1\n").expect("compile failed");
+        blank.linetable = Vec::new().into_boxed_slice();
+        assert_eq!(w_code_addr2line(&blank, 0), None);
+        assert_eq!(w_code_addr2line(&blank, 2), None);
+        assert_eq!(
+            w_code_addr2line(&blank, -1),
+            Some(blank.first_line_number.map_or(0, |line| line.get()))
+        );
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -116,6 +116,37 @@ impl<'a> PyCodeAddressRange<'a> {
         self.ar_line
     }
 
+    /// The whole walk state except the table it reads.
+    ///
+    /// Upstream keeps `PyCodeAddressRange` inline in the two iterator objects,
+    /// which own a reference to the code object.  A Rust borrow of
+    /// `co_linetable` cannot outlive the call that took it, so the cursor
+    /// travels between calls instead of the range, and the range is rebuilt on
+    /// the same table each time.
+    pub(crate) fn cursor(&self) -> LineTableCursor {
+        LineTableCursor {
+            pos: self.reader.pos,
+            ar_start: self.ar_start,
+            ar_end: self.ar_end,
+            ar_line: self.ar_line,
+            computed_line: self.computed_line,
+        }
+    }
+
+    pub(crate) fn restore(&mut self, cursor: LineTableCursor) {
+        self.reader.pos = cursor.pos;
+        self.ar_start = cursor.ar_start;
+        self.ar_end = cursor.ar_end;
+        self.ar_line = cursor.ar_line;
+        self.computed_line = cursor.computed_line;
+    }
+
+    pub(crate) fn resume(linetable: &'a [u8], cursor: LineTableCursor) -> Self {
+        let mut range = Self::new(linetable, 0);
+        range.restore(cursor);
+        range
+    }
+
     /// `advance_with_locations(bounds, endline, column, endcolumn)` — the
     /// walk `positionsiter_next` steps, which decodes the full location and
     /// not just the line.
@@ -256,6 +287,17 @@ fn get_line_delta(reader: &LineTableReader<'_>, code: u8) -> i32 {
 
 /// RustPython `LineTableReader`, matching CPython's 6-bit little-endian
 /// location-table varints.
+/// A suspended [`PyCodeAddressRange`] — every field of it but the borrowed
+/// `co_linetable`.  See [`PyCodeAddressRange::cursor`].
+#[derive(Clone, Copy)]
+pub(crate) struct LineTableCursor {
+    pos: usize,
+    ar_start: i32,
+    ar_end: i32,
+    ar_line: i32,
+    computed_line: i32,
+}
+
 #[derive(Clone, Copy)]
 struct LineTableReader<'a> {
     data: &'a [u8],
@@ -1965,92 +2007,255 @@ pub unsafe fn code_varname_from_oparg(
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
-pub unsafe fn code_positions(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-    let code = unsafe { require_code(obj, "co_positions")? };
-    let first_line = unsafe { (*(obj as *const PyCode)).co_firstlineno_raw };
-    let mut bounds = PyCodeAddressRange::new(&code.linetable, first_line);
-    let mut rows = Vec::new();
+/// `lineiterator` — the object `co_lines()` returns.
+///
+/// The walk is lazy, as upstream's is: `next()` decodes one range (plus the
+/// lookahead the merge needs) and no more.  Materializing the whole table up
+/// front made a single `co_lines()` call on a large code object cost time
+/// proportional to the table, and `traceback._get_code_position` calls
+/// `co_positions()` for every frame it renders.
+#[crate::pyre_class("line_iterator", static_name = "LINE_ITER")]
+pub struct W_LineIterObject {
+    /// `li_code` — the code object whose `co_linetable` the walk reads, held
+    /// so the table outlives the iterator.
+    pub w_code: PyObjectRef,
+    /// `li_line`, suspended.  See [`PyCodeAddressRange::cursor`].
+    pub pos: i64,
+    pub ar_start: i64,
+    pub ar_end: i64,
+    pub ar_line: i64,
+    pub computed_line: i64,
+}
 
-    // `positionsiter_next` keeps its own byte offset and re-decodes only when
-    // that offset reaches the end of the current range, so every code unit of
-    // a multi-instruction range repeats the same location in a fresh tuple.
-    //
-    // ```c
-    // if (po->pi_offset >= po->pi_range.ar_end) {
-    //     if (at_end(&po->pi_range)) { return NULL; }
-    //     advance_with_locations(&po->pi_range, &po->pi_endline, ...);
-    // }
-    // ...
-    // po->pi_offset += 2;
-    // ```
-    let mut location = (-1, -1, -1, -1);
-    let mut offset = 0i32;
-    loop {
-        if offset >= bounds.ar_end {
-            let Some(next) = bounds.advance_with_locations() else {
-                break;
-            };
-            location = next;
-        }
-        let (line, end_line, column, end_column) = location;
-        rows.push(w_tuple_new(vec![
-            source_offset_converter(line),
-            source_offset_converter(end_line),
-            source_offset_converter(column),
-            source_offset_converter(end_column),
-        ]));
-        offset = offset.wrapping_add(2);
-    }
-    let n = rows.len();
-    Ok(w_seq_iter_new(w_list_new(rows), n))
+/// `positionsiterator` — the object `co_positions()` returns.
+#[crate::pyre_class("positions_iterator", static_name = "POSITIONS_ITER")]
+pub struct W_PositionsIterObject {
+    /// `pi_code`.
+    pub w_code: PyObjectRef,
+    /// `pi_range`, suspended.
+    pub pos: i64,
+    pub ar_start: i64,
+    pub ar_end: i64,
+    pub ar_line: i64,
+    pub computed_line: i64,
+    /// `pi_offset`, and the three locations `advance_with_locations` writes
+    /// through its out-params.
+    pub offset: i64,
+    pub end_line: i64,
+    pub column: i64,
+    pub end_column: i64,
 }
 
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
-pub unsafe fn code_lines(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-    let code = unsafe { require_code(obj, "co_lines")? };
-    let mut rows = Vec::new();
-    let first_line = unsafe { (*(obj as *const PyCode)).co_firstlineno_raw };
-    let mut range = PyCodeAddressRange::new(&code.linetable, first_line);
-    let mut pending: Option<(i32, i32, i32)> = None;
-
-    while range.advance() {
-        let start = range.ar_start;
-        let end = range.ar_end;
-        let line = range.ar_line;
-        if let Some((previous_start, _, previous_line)) = pending {
-            if previous_line == line {
-                pending = Some((previous_start, end, previous_line));
-            } else {
-                rows.push(w_tuple_new(vec![
-                    w_int_new(previous_start as i64),
-                    w_int_new(start as i64),
-                    if previous_line == -1 {
-                        pyre_object::w_none()
-                    } else {
-                        w_int_new(previous_line as i64)
-                    },
-                ]));
-                pending = Some((start, end, line));
-            }
-        } else {
-            pending = Some((start, end, line));
-        }
+pub unsafe fn is_line_iter(obj: PyObjectRef) -> bool {
+    if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
+        return false;
     }
-    if let Some((start, end, line)) = pending {
-        rows.push(w_tuple_new(vec![
+    !obj.is_null() && std::ptr::eq(unsafe { (*obj).ob_type }, &LINE_ITER_TYPE)
+}
+
+/// # Safety
+/// The caller must uphold every validity, runtime-type, aliasing, and lifetime
+/// invariant required by the object and pointer arguments for the entire call.
+pub unsafe fn is_positions_iter(obj: PyObjectRef) -> bool {
+    if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
+        return false;
+    }
+    !obj.is_null() && std::ptr::eq(unsafe { (*obj).ob_type }, &POSITIONS_ITER_TYPE)
+}
+
+/// The `co_linetable` an iterator walks, or `None` once its code object is
+/// gone.
+///
+/// # Safety
+/// `w_code` must be null or a live `PyCode`.
+unsafe fn iter_linetable<'a>(w_code: PyObjectRef) -> Option<&'a [u8]> {
+    if w_code.is_null() {
+        return None;
+    }
+    let code = unsafe { w_code_get_ptr(w_code) } as *const crate::CodeObject;
+    if code.is_null() {
+        return None;
+    }
+    Some(unsafe { &(*code).linetable })
+}
+
+/// `lineiter_next` — one merged `(start, end, line)` range.
+///
+/// ```c
+/// if (!_PyLineTable_NextAddressRange(bounds)) { return NULL; }
+/// int start = bounds->ar_start;
+/// int line = bounds->ar_line;
+/// while (_PyLineTable_NextAddressRange(bounds)) {
+///     if (bounds->ar_line != line) {
+///         _PyLineTable_PreviousAddressRange(bounds);
+///         break;
+///     }
+/// }
+/// return Py_BuildValue("iiO&", start, bounds->ar_end,
+///                      _source_offset_converter, &line);
+/// ```
+///
+/// The lookahead is undone by restoring the saved cursor rather than by
+/// `retreat`: restoring is the exact inverse of the `advance` it undoes, where
+/// `retreat` re-derives the previous entry's line and extent by scanning
+/// backwards and is a second decoder to keep in step.
+///
+/// # Safety
+/// `obj` must be a live [`W_LineIterObject`].
+pub unsafe fn line_iter_next(obj: PyObjectRef) -> Option<PyObjectRef> {
+    unsafe {
+        let it = &mut *(obj as *mut W_LineIterObject);
+        let linetable = iter_linetable(it.w_code)?;
+        let mut bounds = PyCodeAddressRange::resume(linetable, line_iter_cursor(it));
+        if !bounds.advance() {
+            return None;
+        }
+        let start = bounds.ar_start;
+        let line = bounds.ar_line;
+        loop {
+            let saved = bounds.cursor();
+            if !bounds.advance() {
+                break;
+            }
+            if bounds.ar_line != line {
+                bounds.restore(saved);
+                break;
+            }
+        }
+        let end = bounds.ar_end;
+        line_iter_store(it, bounds.cursor());
+        Some(w_tuple_new(vec![
             w_int_new(start as i64),
             w_int_new(end as i64),
-            if line == -1 {
-                pyre_object::w_none()
-            } else {
-                w_int_new(line as i64)
-            },
-        ]));
+            source_offset_converter(line),
+        ]))
     }
-    let n = rows.len();
-    Ok(w_seq_iter_new(w_list_new(rows), n))
+}
+
+fn line_iter_cursor(it: &W_LineIterObject) -> LineTableCursor {
+    LineTableCursor {
+        pos: it.pos as usize,
+        ar_start: it.ar_start as i32,
+        ar_end: it.ar_end as i32,
+        ar_line: it.ar_line as i32,
+        computed_line: it.computed_line as i32,
+    }
+}
+
+fn line_iter_store(it: &mut W_LineIterObject, cursor: LineTableCursor) {
+    it.pos = cursor.pos as i64;
+    it.ar_start = cursor.ar_start as i64;
+    it.ar_end = cursor.ar_end as i64;
+    it.ar_line = cursor.ar_line as i64;
+    it.computed_line = cursor.computed_line as i64;
+}
+
+/// `positionsiter_next` — one `(line, end_line, column, end_column)` tuple per
+/// code unit, re-decoding only when the offset reaches the end of the range.
+///
+/// ```c
+/// if (pi->pi_offset >= pi->pi_range.ar_end) {
+///     if (at_end(&pi->pi_range)) { return NULL; }
+///     advance_with_locations(&pi->pi_range, &pi->pi_endline, &pi->pi_column,
+///                            &pi->pi_endcolumn);
+/// }
+/// pi->pi_offset += 2;
+/// ```
+///
+/// # Safety
+/// `obj` must be a live [`W_PositionsIterObject`].
+pub unsafe fn positions_iter_next(obj: PyObjectRef) -> Option<PyObjectRef> {
+    unsafe {
+        let it = &mut *(obj as *mut W_PositionsIterObject);
+        let linetable = iter_linetable(it.w_code)?;
+        let cursor = LineTableCursor {
+            pos: it.pos as usize,
+            ar_start: it.ar_start as i32,
+            ar_end: it.ar_end as i32,
+            ar_line: it.ar_line as i32,
+            computed_line: it.computed_line as i32,
+        };
+        let mut bounds = PyCodeAddressRange::resume(linetable, cursor);
+        if it.offset as i32 >= bounds.ar_end {
+            let Some((line, end_line, column, end_column)) = bounds.advance_with_locations() else {
+                return None;
+            };
+            it.ar_line = line as i64;
+            it.end_line = end_line as i64;
+            it.column = column as i64;
+            it.end_column = end_column as i64;
+        }
+        let saved = bounds.cursor();
+        it.pos = saved.pos as i64;
+        it.ar_start = saved.ar_start as i64;
+        it.ar_end = saved.ar_end as i64;
+        it.ar_line = saved.ar_line as i64;
+        it.computed_line = saved.computed_line as i64;
+        it.offset = it.offset.wrapping_add(2);
+        Some(w_tuple_new(vec![
+            source_offset_converter(it.ar_line as i32),
+            source_offset_converter(it.end_line as i32),
+            source_offset_converter(it.column as i32),
+            source_offset_converter(it.end_column as i32),
+        ]))
+    }
+}
+
+/// `code_positionsiterator` — `co_positions()`.
+///
+/// # Safety
+/// The caller must uphold every validity, runtime-type, aliasing, and lifetime
+/// invariant required by the object and pointer arguments for the entire call.
+pub unsafe fn code_positions(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    unsafe { require_code(obj, "co_positions")? };
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj = pyre_object::gc_roots::pin_root(obj);
+    let first_line = unsafe { (*(obj as *const PyCode)).co_firstlineno_raw };
+    Ok(W_PositionsIterObject::allocate_stable(
+        W_PositionsIterObject {
+            ob: pyre_object::PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
+            },
+            w_code: obj,
+            pos: 0,
+            ar_start: -1,
+            ar_end: 0,
+            ar_line: -1,
+            computed_line: first_line as i64,
+            offset: 0,
+            end_line: -1,
+            column: -1,
+            end_column: -1,
+        },
+    ))
+}
+
+/// `code_linesiterator` — `co_lines()`.
+///
+/// # Safety
+/// The caller must uphold every validity, runtime-type, aliasing, and lifetime
+/// invariant required by the object and pointer arguments for the entire call.
+pub unsafe fn code_lines(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    unsafe { require_code(obj, "co_lines")? };
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj = pyre_object::gc_roots::pin_root(obj);
+    let first_line = unsafe { (*(obj as *const PyCode)).co_firstlineno_raw };
+    Ok(W_LineIterObject::allocate_stable(W_LineIterObject {
+        ob: pyre_object::PyObject {
+            ob_type: std::ptr::null(),
+            w_class: std::ptr::null_mut(),
+        },
+        w_code: obj,
+        pos: 0,
+        ar_start: -1,
+        ar_end: 0,
+        ar_line: -1,
+        computed_line: first_line as i64,
+    }))
 }
 
 /// # Safety

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -3440,6 +3440,37 @@ fn code_addr2line(code: &crate::CodeObject, firstlineno: i32, addrq: i64) -> i32
     bounds.check_line_number(lasti)
 }
 
+/// Specialization rewrites the opcode byte in place (`RESUME` becomes
+/// `RESUME_CHECK`), so every read asks about the family.
+fn base_op(code: &crate::CodeObject, index: usize) -> Option<crate::bytecode::Instruction> {
+    let op = code.instructions.get(index)?.op;
+    Some(op.to_base().unwrap_or(op))
+}
+
+/// `code->_co_firsttraceable` — the index of the first `RESUME`, which is where
+/// a frame that has not run an instruction is reported to be.
+///
+/// `init_code` (`Objects/codeobject.c`) scans for it once and stores it; this
+/// walks instead, which costs the prologue's length because it stops at that
+/// `RESUME` — within a handful of units of the start for every code object the
+/// compiler produces.  Everything ahead of it is what the compiler inserts:
+/// `COPY_FREE_VARS`, `MAKE_CELL`, and a generator's `RETURN_GENERATOR` /
+/// `POP_TOP` pair.  A code object with no `RESUME` at all leaves the index past
+/// the end, so it starts no line anywhere — what `init_code`'s scan does with
+/// one too.
+pub fn first_traceable_index(code: &crate::CodeObject) -> usize {
+    use crate::bytecode::Instruction;
+
+    let mut index = 0;
+    while let Some(op) = base_op(code, index) {
+        if matches!(op, Instruction::Resume { .. }) {
+            break;
+        }
+        index += 1;
+    }
+    index
+}
+
 /// Whether the instruction at `pc` may be reported to a trace function as the
 /// start of a source line.
 ///
@@ -3466,28 +3497,8 @@ fn code_addr2line(code: &crate::CodeObject, firstlineno: i32, addrq: i64) -> i32
 pub fn instruction_can_start_a_line(code: &crate::CodeObject, pc: usize) -> bool {
     use crate::bytecode::Instruction;
 
-    // Specialization rewrites the opcode byte in place (`RESUME` becomes
-    // `RESUME_CHECK`), so every read below asks about the family.
-    fn base_op(code: &crate::CodeObject, index: usize) -> Option<Instruction> {
-        let op = code.instructions.get(index)?.op;
-        Some(op.to_base().unwrap_or(op))
-    }
-
-    // `i < code->_co_firsttraceable`, resolved by walking to the first
-    // `RESUME`.  This costs the prologue's length rather than `pc`, because it
-    // stops at that `RESUME` — which sits within a handful of units of the
-    // start for every code object the compiler produces.  A code object with no
-    // `RESUME` at all leaves `_co_firsttraceable` past the end and so traces no
-    // lines, which is what `init_code`'s scan does with one too.
-    let mut index = 0;
-    while index <= pc {
-        match base_op(code, index) {
-            Some(Instruction::Resume { .. }) => break,
-            Some(_) => index += 1,
-            None => return false,
-        }
-    }
-    if index > pc {
+    // `i < code->_co_firsttraceable`.
+    if pc < first_traceable_index(code) {
         return false;
     }
 

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -31,16 +31,16 @@ impl From<BytecodeCorruption> for crate::PyError {
 /// object implementation.  This reads the authoritative `co_linetable`;
 /// `CodeObject.locations` is an execution-oriented expansion which cannot
 /// represent a missing line or column.
-struct PyCodeAddressRange<'a> {
-    ar_start: i32,
-    ar_end: i32,
-    ar_line: i32,
+pub(crate) struct PyCodeAddressRange<'a> {
+    pub(crate) ar_start: i32,
+    pub(crate) ar_end: i32,
+    pub(crate) ar_line: i32,
     computed_line: i32,
     reader: LineTableReader<'a>,
 }
 
 impl<'a> PyCodeAddressRange<'a> {
-    fn new(linetable: &'a [u8], first_line: i32) -> Self {
+    pub(crate) fn new(linetable: &'a [u8], first_line: i32) -> Self {
         Self {
             ar_start: 0,
             ar_end: 0,
@@ -50,7 +50,7 @@ impl<'a> PyCodeAddressRange<'a> {
         }
     }
 
-    fn advance(&mut self) -> bool {
+    pub(crate) fn advance(&mut self) -> bool {
         let Some(first_byte) = self.reader.read_byte() else {
             return false;
         };
@@ -61,14 +61,20 @@ impl<'a> PyCodeAddressRange<'a> {
         // `co_linetable=b"\0"` report no ranges where one entry is decoded.
         let code = (first_byte >> 3) & 0x0f;
         let length = ((first_byte & 0x07) + 1) as i32;
-        self.computed_line += self.get_line_delta(code);
+        let line_delta = get_line_delta(&self.reader, code);
+        // Both accumulators wrap. `co_linetable` and `co_firstlineno` are
+        // both writable from app-level, so a line delta chain can carry
+        // `computed_line` past `i32` and a length chain can carry `ar_end`
+        // there; upstream is built with `-fwrapv` and keeps walking, where a
+        // plain `+` panics in a debug build.
+        self.computed_line = self.computed_line.wrapping_add(line_delta);
         self.ar_line = if first_byte >> 3 == 0x1f {
             -1
         } else {
             self.computed_line
         };
         self.ar_start = self.ar_end;
-        self.ar_end += length * 2;
+        self.ar_end = self.ar_end.wrapping_add(length * 2);
 
         // Every payload byte has bit 7 clear; the next header has it set.
         while self.reader.peek_byte().is_some_and(|byte| byte & 0x80 == 0) {
@@ -110,38 +116,147 @@ impl<'a> PyCodeAddressRange<'a> {
         self.ar_line
     }
 
-    fn get_line_delta(&mut self, code: u8) -> i32 {
-        let Some(kind) = PyCodeLocationInfoKind::from_code(code) else {
-            return 0;
+    /// `advance_with_locations(bounds, endline, column, endcolumn)` — the
+    /// walk `positionsiter_next` steps, which decodes the full location and
+    /// not just the line.
+    ///
+    /// ```c
+    /// int first_byte = *bounds->opaque.lo_next++;
+    /// int code = (first_byte >> 3) & 15;
+    /// bounds->ar_start = bounds->ar_end;
+    /// bounds->ar_end = bounds->ar_start + ((first_byte & 7) + 1) * sizeof(_Py_CODEUNIT);
+    /// switch(code) { ... }
+    /// ```
+    ///
+    /// This one really does read the payload through the cursor and stops
+    /// where the payload ends: there is no bit-7 scan, because upstream has
+    /// none here.  `co_lines()` and `co_positions()` are therefore two
+    /// separate walks that a hand-written `co_linetable` can make disagree,
+    /// and both are reproduced rather than folded into one.
+    ///
+    /// The four values are returned instead of written through out-params.
+    /// `-1` in any of them is the missing-offset marker
+    /// [`source_offset_converter`] renders as `None`.
+    fn advance_with_locations(&mut self) -> Option<(i32, i32, i32, i32)> {
+        let first_byte = self.reader.read_byte()?;
+        let code = (first_byte >> 3) & 0x0f;
+        self.ar_start = self.ar_end;
+        self.ar_end = self
+            .ar_start
+            .wrapping_add(((first_byte & 0x07) as i32 + 1) * 2);
+        let (end_line, column, end_column) = match PyCodeLocationInfoKind::from_code(code) {
+            Some(PyCodeLocationInfoKind::None) => {
+                self.ar_line = -1;
+                (-1, -1, -1)
+            }
+            Some(PyCodeLocationInfoKind::Long) => {
+                self.computed_line = self
+                    .computed_line
+                    .wrapping_add(self.reader.read_signed_varint());
+                self.ar_line = self.computed_line;
+                let end_line = self.ar_line.wrapping_add(self.reader.read_varint() as i32);
+                let column = (self.reader.read_varint() as i32).wrapping_sub(1);
+                let end_column = (self.reader.read_varint() as i32).wrapping_sub(1);
+                (end_line, column, end_column)
+            }
+            Some(PyCodeLocationInfoKind::NoColumns) => {
+                self.computed_line = self
+                    .computed_line
+                    .wrapping_add(self.reader.read_signed_varint());
+                self.ar_line = self.computed_line;
+                (self.ar_line, -1, -1)
+            }
+            Some(
+                kind @ (PyCodeLocationInfoKind::OneLine0
+                | PyCodeLocationInfoKind::OneLine1
+                | PyCodeLocationInfoKind::OneLine2),
+            ) => {
+                self.computed_line = self
+                    .computed_line
+                    .wrapping_add(kind.one_line_delta().unwrap_or(0));
+                self.ar_line = self.computed_line;
+                let column = self.reader.read_byte().unwrap_or(0) as i32;
+                let end_column = self.reader.read_byte().unwrap_or(0) as i32;
+                (self.ar_line, column, end_column)
+            }
+            // Short forms. `from_code` covers every value `(byte >> 3) & 15`
+            // can take, so the `None` arm is unreachable and shares this one.
+            _ => {
+                let second_byte = self.reader.read_byte().unwrap_or(0);
+                self.ar_line = self.computed_line;
+                let column = ((code as i32) << 3) | ((second_byte >> 4) as i32);
+                (self.ar_line, column, column + (second_byte & 0x0f) as i32)
+            }
         };
-        match kind {
-            PyCodeLocationInfoKind::None => 0,
-            PyCodeLocationInfoKind::Long => {
-                let delta = self.reader.read_signed_varint();
-                self.reader.read_varint();
-                self.reader.read_varint();
-                self.reader.read_varint();
-                delta
-            }
-            PyCodeLocationInfoKind::NoColumns => self.reader.read_signed_varint(),
-            PyCodeLocationInfoKind::OneLine0
-            | PyCodeLocationInfoKind::OneLine1
-            | PyCodeLocationInfoKind::OneLine2 => {
-                self.reader.read_byte();
-                self.reader.read_byte();
-                kind.one_line_delta().unwrap_or(0)
-            }
-            _ if kind.is_short() => {
-                self.reader.read_byte();
-                0
-            }
-            _ => 0,
-        }
+        Some((self.ar_line, end_line, column, end_column))
+    }
+}
+
+/// `get_line_delta(ptr)` — the entry's line delta, read **without moving**
+/// the cursor.
+///
+/// ```c
+/// static int
+/// get_line_delta(const uint8_t *ptr)
+/// {
+///     int code = ((*ptr) >> 3) & 15;
+///     switch (code) {
+///         ...
+///         case PY_CODE_LOCATION_INFO_LONG: return scan_signed_varint(ptr+1);
+/// ```
+///
+/// `advance` moves solely by the byte scan that follows this call, stopping
+/// at the next byte with bit 7 set. Consuming the payload here instead makes
+/// the two disagree the moment a payload's declared varints run past that
+/// byte — which `code.replace(co_linetable=...)` can store. `b"\x00\x80"`
+/// is the shortest witness: the second byte is a `Short0` payload by length
+/// and an entry header by its marker, and only the marker decides.
+/// `co_lines()` reports one `(0, 4, ...)` range there, not `(0, 2, ...)`.
+///
+/// `reader` sits one byte past the header, where `ptr + 1` does, and `code`
+/// is the caller's already-decoded `(*ptr >> 3) & 15`.
+/// `_source_offset_converter(int *value)` — the marker `-1`, and only that
+/// value, is the missing offset `co_positions()` reports as `None`.
+///
+/// ```c
+/// static PyObject *
+/// _source_offset_converter(int *value) {
+///     if (*value == -1) {
+///         Py_RETURN_NONE;
+///     }
+///     return PyLong_FromLong(*value);
+/// }
+/// ```
+///
+/// It runs on all four members of the tuple, so a line that *computes* to
+/// `-1` is reported as `None` exactly like a `NO_LOCATION` range's is.
+fn source_offset_converter(value: i32) -> PyObjectRef {
+    if value == -1 {
+        pyre_object::w_none()
+    } else {
+        w_int_new(value as i64)
+    }
+}
+
+fn get_line_delta(reader: &LineTableReader<'_>, code: u8) -> i32 {
+    let Some(kind) = PyCodeLocationInfoKind::from_code(code) else {
+        return 0;
+    };
+    let mut reader = *reader;
+    match kind {
+        PyCodeLocationInfoKind::None => 0,
+        PyCodeLocationInfoKind::Long => reader.read_signed_varint(),
+        PyCodeLocationInfoKind::NoColumns => reader.read_signed_varint(),
+        PyCodeLocationInfoKind::OneLine0 => 0,
+        PyCodeLocationInfoKind::OneLine1 => 1,
+        PyCodeLocationInfoKind::OneLine2 => 2,
+        _ => 0,
     }
 }
 
 /// RustPython `LineTableReader`, matching CPython's 6-bit little-endian
 /// location-table varints.
+#[derive(Clone, Copy)]
 struct LineTableReader<'a> {
     data: &'a [u8],
     pos: usize,
@@ -203,10 +318,6 @@ impl<'a> LineTableReader<'a> {
         } else {
             (value >> 1) as i32
         }
-    }
-
-    fn at_end(&self) -> bool {
-        self.pos >= self.data.len()
     }
 }
 
@@ -1448,8 +1559,16 @@ fn legacy_lnotab(code: &crate::CodeObject, firstlineno: i64) -> Vec<u8> {
         // `ar_line`, so a NO_LOCATION range does not manufacture a -1 delta.
         let next_line = range.computed_line as i64;
         if next_line != line {
+            // `int bdelta = bounds.ar_start - code_offset;` is signed and
+            // wraps upstream. A hand-written `co_linetable` can carry
+            // `ar_end` past `i32` and hand back a start below the previous
+            // one; saturating keeps the byte-delta loop below finite.
             let offset = range.ar_start as usize;
-            encode_pair(offset - start_offset, next_line - line, &mut out);
+            encode_pair(
+                offset.saturating_sub(start_offset),
+                next_line - line,
+                &mut out,
+            );
             line = next_line;
             start_offset = offset;
         }
@@ -1848,76 +1967,39 @@ pub unsafe fn code_varname_from_oparg(
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn code_positions(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     let code = unsafe { require_code(obj, "co_positions")? };
+    let first_line = unsafe { (*(obj as *const PyCode)).co_firstlineno_raw };
+    let mut bounds = PyCodeAddressRange::new(&code.linetable, first_line);
     let mut rows = Vec::new();
-    let mut reader = LineTableReader::new(&code.linetable);
-    let mut line = unsafe { (*(obj as *const PyCode)).co_firstlineno_raw };
 
-    while !reader.at_end() {
-        let Some(first_byte) = reader.read_byte() else {
-            break;
-        };
-        // Decoded as a header regardless of bit 7, for the reason given on
-        // `PyCodeAddressRange::advance`.
-        let code = (first_byte >> 3) & 0x0f;
-        let length = ((first_byte & 0x07) + 1) as usize;
-        let Some(kind) = PyCodeLocationInfoKind::from_code(code) else {
-            break;
-        };
-        let (line_delta, end_line_delta, column, end_column) = match kind {
-            PyCodeLocationInfoKind::None => (0, 0, None, None),
-            PyCodeLocationInfoKind::Long => {
-                let delta = reader.read_signed_varint();
-                let end_line_delta = reader.read_varint() as i32;
-                let column = match reader.read_varint() {
-                    0 => None,
-                    value => Some((value - 1) as i32),
-                };
-                let end_column = match reader.read_varint() {
-                    0 => None,
-                    value => Some((value - 1) as i32),
-                };
-                (delta, end_line_delta, column, end_column)
-            }
-            PyCodeLocationInfoKind::NoColumns => (reader.read_signed_varint(), 0, None, None),
-            PyCodeLocationInfoKind::OneLine0
-            | PyCodeLocationInfoKind::OneLine1
-            | PyCodeLocationInfoKind::OneLine2 => {
-                let column = reader.read_byte().unwrap_or(0) as i32;
-                let end_column = reader.read_byte().unwrap_or(0) as i32;
-                (
-                    kind.one_line_delta().unwrap_or(0),
-                    0,
-                    Some(column),
-                    Some(end_column),
-                )
-            }
-            _ if kind.is_short() => {
-                let column_data = reader.read_byte().unwrap_or(0);
-                let column_group = kind.short_column_group().unwrap_or(0);
-                let column = ((column_group as i32) << 3) | ((column_data >> 4) as i32);
-                let end_column = column + (column_data & 0x0f) as i32;
-                (0, 0, Some(column), Some(end_column))
-            }
-            _ => (0, 0, None, None),
-        };
-        line += line_delta;
-
-        for _ in 0..length {
-            let (line_obj, end_line_obj) = if kind == PyCodeLocationInfoKind::None {
-                (pyre_object::w_none(), pyre_object::w_none())
-            } else {
-                (
-                    w_int_new(line as i64),
-                    w_int_new((line + end_line_delta) as i64),
-                )
+    // `positionsiter_next` keeps its own byte offset and re-decodes only when
+    // that offset reaches the end of the current range, so every code unit of
+    // a multi-instruction range repeats the same location in a fresh tuple.
+    //
+    // ```c
+    // if (po->pi_offset >= po->pi_range.ar_end) {
+    //     if (at_end(&po->pi_range)) { return NULL; }
+    //     advance_with_locations(&po->pi_range, &po->pi_endline, ...);
+    // }
+    // ...
+    // po->pi_offset += 2;
+    // ```
+    let mut location = (-1, -1, -1, -1);
+    let mut offset = 0i32;
+    loop {
+        if offset >= bounds.ar_end {
+            let Some(next) = bounds.advance_with_locations() else {
+                break;
             };
-            rows.push(w_tuple_new(vec![
-                line_obj,
-                end_line_obj,
-                column.map_or_else(pyre_object::w_none, |value| w_int_new(value as i64)),
-                end_column.map_or_else(pyre_object::w_none, |value| w_int_new(value as i64)),
-            ]));
+            location = next;
         }
+        let (line, end_line, column, end_column) = location;
+        rows.push(w_tuple_new(vec![
+            source_offset_converter(line),
+            source_offset_converter(end_line),
+            source_offset_converter(column),
+            source_offset_converter(end_column),
+        ]));
+        offset = offset.wrapping_add(2);
     }
     let n = rows.len();
     Ok(w_seq_iter_new(w_list_new(rows), n))
@@ -2990,7 +3072,7 @@ pub fn code_locations(code: &crate::CodeObject) -> &[(SourceLocation, SourceLoca
 }
 
 /// `PyCode_Addr2Line` — the source line the byte offset `addrq` sits on, or
-/// `None` when the offset names no line.
+/// `-1` when the offset names no line.
 ///
 /// ```c
 /// if (addrq < 0) {
@@ -3022,38 +3104,54 @@ pub fn code_locations(code: &crate::CodeObject) -> &[(SourceLocation, SourceLoca
 /// The `addrq < 0` arm above is 3.14's, and `traceback_lineno_sentinel.py`
 /// pins it.
 ///
-/// `None` is `_PyCode_CheckLineNumber`'s `-1`, which both readers of this
-/// answer render as `None`: `tb_lineno_get` and `frame_getlineno` each return
-/// `Py_None` for a line below zero.  It covers an offset past the last range
-/// AND an offset inside a `NO_LOCATION` range — the compiler-generated
-/// cleanup a `with` or a `try`/`finally` leaves at the end of a code object,
-/// which `co_positions` reports with a `None` line.
+/// The answer is signed and is **not** narrowed to "a line or nothing":
+/// `_PyCode_CheckLineNumber`'s `-1` and a genuinely negative line are one
+/// value upstream too, and the two readers that render it as `None` —
+/// `tb_lineno_get` and `frame_getlineno` — test `< 0` themselves.  `repr` of
+/// a frame does not, and prints whatever came back, so a code object whose
+/// table spells line `-8` has to reach `frame_repr` as `-8`.  `-1` therefore
+/// also covers an offset past the last range AND an offset inside a
+/// `NO_LOCATION` range — the compiler-generated cleanup a `with` or a
+/// `try`/`finally` leaves at the end of a code object, which `co_positions`
+/// reports with a `None` line.
 ///
 /// The walk goes through [`PyCodeAddressRange`], not [`code_locations`]: the
 /// expanded array holds a `SourceLocation` per instruction and its `line` is a
 /// `OneIndexed`, so a `NO_LOCATION` range comes back carrying whatever line
-/// preceded it.  Reading `linetable` directly is also what lets a zero
-/// `co_firstlineno` — which `CodeType(...)` and `code.replace` both accept and
-/// `OneIndexed` cannot hold — reach the answer, and it takes no lock, where
-/// the array is behind a process-global mutex once `w_code_new` releases it.
-pub fn w_code_addr2line(code: &crate::CodeObject, addrq: i64) -> Option<usize> {
-    if addrq < 0 {
-        return usize::try_from(code_firstlineno_raw(code)).ok();
+/// preceded it.  Reading `linetable` directly also takes no lock, where the
+/// array is behind a process-global mutex once `w_code_new` releases it.
+///
+/// # Safety
+/// `w_code` must be a live `PyCode`.
+pub unsafe fn w_code_addr2line(w_code: PyObjectRef, addrq: i64) -> i32 {
+    unsafe {
+        let code = w_code_get_ptr(w_code) as *const crate::CodeObject;
+        if code.is_null() {
+            return -1;
+        }
+        code_addr2line(&*code, w_code_firstlineno_raw(w_code), addrq)
     }
-    let lasti = i32::try_from(addrq).unwrap_or(i32::MAX);
-    let mut bounds = PyCodeAddressRange::new(&code.linetable, code_firstlineno_raw(code));
-    usize::try_from(bounds.check_line_number(lasti)).ok()
 }
 
-/// The first line number `linetable` is decoded against, as the Python
-/// integer `co_firstlineno` answers rather than as a `OneIndexed`.
+/// `PyCode_Addr2Line`'s body, split from the object it reads its two inputs
+/// from so a bare `CodeObject` and a first line number can be walked directly.
 ///
-/// `CodeObject.first_line_number` is `None` for exactly the values
-/// `OneIndexed` cannot spell: both writers — the `CodeType(...)` constructor
-/// and `code.replace(co_firstlineno=...)` — take that branch on `<= 0`, and
-/// `replace` rejects a negative one, so `None` means zero.
-fn code_firstlineno_raw(code: &crate::CodeObject) -> i32 {
-    code.first_line_number.map_or(0, |line| line.get() as i32)
+/// `firstlineno` is `co->co_firstlineno`, which `_PyCode_InitAddressRange`
+/// seeds `computed_line` with whatever its sign.  It has to come from the
+/// `PyCode` wrapper's `co_firstlineno_raw` stamp: `CodeObject
+/// .first_line_number` is an `Option<OneIndexed>`, `None` for every value
+/// `OneIndexed` cannot spell, and `CodeType(...)` accepts the negative ones —
+/// only `code.replace(co_firstlineno=...)` rejects them.  Reconstructing the
+/// integer from the option therefore reads `0` for a code object whose
+/// `co_firstlineno` is `-1`, and decodes the table against a different first
+/// line than `co_lines()` and `co_positions()` do.
+fn code_addr2line(code: &crate::CodeObject, firstlineno: i32, addrq: i64) -> i32 {
+    if addrq < 0 {
+        return firstlineno;
+    }
+    let lasti = i32::try_from(addrq).unwrap_or(i32::MAX);
+    let mut bounds = PyCodeAddressRange::new(&code.linetable, firstlineno);
+    bounds.check_line_number(lasti)
 }
 
 /// Whether the instruction at `pc` may be reported to a trace function as the
@@ -3815,36 +3913,53 @@ mod tests {
     #[test]
     fn w_code_addr2line_halves_the_offset_and_reports_a_miss() {
         let code = compile_exec("a = 1\nb = 2\nc = 3\n").expect("compile failed");
-        let firstlineno = code.first_line_number.map_or(1, |line| line.get());
-        assert_eq!(w_code_addr2line(&code, -1), Some(firstlineno));
-        assert_eq!(w_code_addr2line(&code, -2), Some(firstlineno));
+        let firstlineno = code.first_line_number.map_or(1, |line| line.get()) as i32;
+        assert_eq!(code_addr2line(&code, firstlineno, -1), firstlineno);
+        assert_eq!(code_addr2line(&code, firstlineno, -2), firstlineno);
 
         let count = code.instructions.len();
         assert!(count > 0);
-        let lines: Vec<Option<usize>> = (0..count)
-            .map(|index| w_code_addr2line(&code, index as i64 * 2))
+        let lines: Vec<i32> = (0..count)
+            .map(|index| code_addr2line(&code, firstlineno, index as i64 * 2))
             .collect();
         for (index, line) in lines.iter().copied().enumerate() {
             // The odd byte inside an instruction reads that instruction's row.
-            assert_eq!(w_code_addr2line(&code, index as i64 * 2 + 1), line);
+            assert_eq!(
+                code_addr2line(&code, firstlineno, index as i64 * 2 + 1),
+                line
+            );
         }
         // Each of the three statements contributes at least one instruction.
         for statement in 0..3 {
-            assert!(lines.contains(&Some(firstlineno + statement)), "{lines:?}");
+            assert!(lines.contains(&(firstlineno + statement)), "{lines:?}");
         }
 
-        assert_eq!(w_code_addr2line(&code, 1 << 30), None);
+        assert_eq!(code_addr2line(&code, firstlineno, 1 << 30), -1);
         // An empty line table describes no range, so nothing resolves against
         // it — `linetable_to_locations` instead expands one first-line row per
         // instruction, which is why this reads `linetable` directly.
         let mut blank = compile_exec("a = 1\n").expect("compile failed");
         blank.linetable = Vec::new().into_boxed_slice();
-        assert_eq!(w_code_addr2line(&blank, 0), None);
-        assert_eq!(w_code_addr2line(&blank, 2), None);
-        assert_eq!(
-            w_code_addr2line(&blank, -1),
-            Some(blank.first_line_number.map_or(0, |line| line.get()))
-        );
+        assert_eq!(code_addr2line(&blank, 1, 0), -1);
+        assert_eq!(code_addr2line(&blank, 1, 2), -1);
+        // A negative `co_firstlineno` is answered as-is, not clamped: only
+        // `code.replace` rejects one, `CodeType(...)` stores it.
+        assert_eq!(code_addr2line(&blank, -8, -1), -8);
+        assert_eq!(code_addr2line(&blank, 0, -1), 0);
+    }
+
+    /// The entry payload is peeked, not consumed: `advance` moves by the
+    /// bit-7 scan alone, so a byte that is a payload by length and a header by
+    /// its marker starts the next range.
+    #[test]
+    fn advance_stops_at_the_marker_a_short_payload_would_swallow() {
+        let table = [0x00u8, 0x80u8];
+        let mut bounds = PyCodeAddressRange::new(&table, 3);
+        assert!(bounds.advance());
+        assert_eq!((bounds.ar_start, bounds.ar_end, bounds.ar_line), (0, 2, 3));
+        assert!(bounds.advance());
+        assert_eq!((bounds.ar_start, bounds.ar_end, bounds.ar_line), (2, 4, 3));
+        assert!(!bounds.advance());
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1978,33 +1978,19 @@ pub const PYFRAME_W_GLOBALS_OFFSET: usize = std::mem::offset_of!(PyFrame, w_glob
 pub const PYFRAME_STACK_DEPTH_OFFSET: usize = PYFRAME_VALUESTACKDEPTH_OFFSET;
 pub const PYFRAME_LOCALS_OFFSET: usize = PYFRAME_LOCALS_CELLS_STACK_OFFSET;
 
-/// Whether a line table records no position for any instruction.
-///
-/// A `None`-kind entry is the spelling for "this instruction has no line",
-/// which `co_positions()` reports as `None`; every other kind carries one,
-/// `NoColumns` included, which drops the columns and keeps the line.  A
-/// `None` entry has no payload, so a table made only of them can be walked a
-/// byte at a time and any other kind ends the walk at its first byte.
-fn linetable_records_no_position(linetable: &[u8]) -> bool {
-    linetable.iter().all(|&byte| {
-        byte & 0x80 != 0
-            && (byte >> 3) & 0x0f == crate::bytecode::PyCodeLocationInfoKind::None as u8
-    })
-}
-
 /// pytraceback.py offset2lineno(c, stopat) — convert instruction index to line number.
 /// Matches RPython: negative `stopat` means "frame not yet started", returns
 /// first-line.
 ///
-/// The same row lookup as [`crate::pycode::w_code_addr2line`], which takes the
-/// byte offset `tb_lasti` carries rather than an instruction index and reports
-/// a miss instead of clamping.  This one clamps to the first line, so it can
-/// never express the `None` a `tb_lineno` read answers.
+/// [`crate::pycode::w_code_addr2line`] with the instruction index converted to
+/// the byte offset `tb_lasti` carries.  `-1` is its miss, the value upstream
+/// returns from the same zero-length walk and the value both readers of a line
+/// number render as `None`; it is also `LINENO_NOT_COMPUTED`, so a traceback
+/// node stamped with it resolves lazily and answers `None` there too.
 #[inline]
-pub fn offset2lineno(code: &CodeObject, stopat: isize) -> usize {
+pub fn offset2lineno(code: &CodeObject, stopat: isize) -> isize {
     let addrq = (stopat as i64).saturating_mul(2);
-    crate::pycode::w_code_addr2line(code, addrq)
-        .unwrap_or_else(|| code.first_line_number.map_or(1, |n| n.get()))
+    crate::pycode::w_code_addr2line(code, addrq).map_or(-1, |line| line as isize)
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -4230,6 +4216,12 @@ impl PyFrame {
     }
 
     /// pyframe.py get_last_lineno → pytraceback.offset2lineno(pycode, last_instr)
+    ///
+    /// `-1` is `PyFrame_GetLineNumber`'s no-line answer, which
+    /// [`PyFrame::fget_f_lineno`] renders as `None`.  It reaches here for a
+    /// replacement `co_linetable` that describes no range covering
+    /// `last_instr` — including an empty one — and for the `NO_LOCATION`
+    /// ranges a compiler-generated cleanup sits in.
     #[inline]
     pub fn get_last_lineno(&self) -> isize {
         self.get_lineno_at(self.last_instr)
@@ -4244,23 +4236,7 @@ impl PyFrame {
     /// coordinate answers this read without one.
     #[inline]
     pub fn get_lineno_at(&self, last_instr: isize) -> isize {
-        // A line table that records no position at all reports ``f_lineno is
-        // None`` rather than the code object's first line number.  The decoded
-        // `locations` cannot answer this: a `SourceLocation` always carries a
-        // line, so an entry that records none is padded out to the same value
-        // an entry that records a line without columns produces.  The raw
-        // table separates them.
-        if linetable_records_no_position(&self.code().linetable) {
-            return -1;
-        }
-        // CPython exposes ``None`` when a code object's line table has no
-        // usable entry for the current instruction.  Ruff's decoded
-        // zero-line entries reach us as line 0; preserve the frame getter's
-        // existing -1 sentinel instead of leaking that implementation value.
-        match offset2lineno(self.code(), last_instr) {
-            0 => -1,
-            lineno => lineno as isize,
-        }
+        offset2lineno(self.code(), last_instr)
     }
 
     /// pycode.py `_get_lineno_for_pc_tracing(frame.last_instr)` — the line a
@@ -4291,8 +4267,19 @@ impl PyFrame {
 
     /// pyframe.py fget_f_lineno — the line currently executing.
     ///
-    /// `None` when an untraced frame's line table yields no entry; the
-    /// `f_trace` test only selects the -1 fallback.
+    /// ```c
+    /// int lineno = PyFrame_GetLineNumber(f);
+    /// if (lineno < 0) {
+    ///     Py_RETURN_NONE;
+    /// }
+    /// return PyLong_FromLong(lineno);
+    /// ```
+    ///
+    /// `frame_getlineno` reads the same number whether or not the frame is
+    /// traced, so the `f_trace` test that used to substitute the code
+    /// object's first line for a missing one is gone: it stood in for a
+    /// resolver that answered `-1` only for a line table it could not decode,
+    /// and the resolver now answers `-1` wherever `PyCode_Addr2Line` does.
     #[inline]
     pub fn fget_f_lineno(&self) -> PyObjectRef {
         self.f_lineno_at(self.last_instr)
@@ -4302,25 +4289,15 @@ impl PyFrame {
     /// terms as [`Self::get_lineno_at`].
     ///
     /// The whole getter body stays here rather than being split across the
-    /// caller: the `f_trace` test, the `-1` sentinel and the `first_line_number`
-    /// fallback are one decision, and a caller reproducing part of it would
-    /// answer a differently-shaped read.
+    /// caller: the `-1` sentinel and the `None` it renders as are one
+    /// decision, and a caller reproducing part of it would answer a
+    /// differently-shaped read.
     #[inline]
     pub fn f_lineno_at(&self, last_instr: isize) -> PyObjectRef {
         let lineno = self.get_lineno_at(last_instr);
-        if self.get_w_f_trace().is_null() {
-            if lineno == -1 {
-                return pyre_object::w_none();
-            }
-            return pyre_object::w_int_new(lineno as i64);
+        if lineno < 0 {
+            return pyre_object::w_none();
         }
-        let lineno = if lineno == -1 {
-            self.code()
-                .first_line_number
-                .map_or(-1, |n| n.get() as isize)
-        } else {
-            lineno
-        };
         pyre_object::w_int_new(lineno as i64)
     }
 

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -2178,23 +2178,43 @@ fn mark_explain_incompatible_stack(target_stack: i64) -> &'static str {
 
 /// `frameobject.c marklines` — the source line that starts at each
 /// instruction-unit index (`-1` where no line change begins).
-fn mark_lines(code: &CodeObject, len: usize) -> Vec<i32> {
-    let mut lines = vec![-1i32; len];
-    let first = code.first_line_number.map(|n| n.get() as i32).unwrap_or(1);
-    let locations = crate::pycode::code_locations(code);
+///
+/// ```c
+/// while (_PyLineTable_NextAddressRange(&bounds)) {
+///     assert(bounds.ar_start / (int)sizeof(_Py_CODEUNIT) < len);
+///     if (bounds.ar_line != last_line && bounds.ar_line != -1) {
+///         linestarts[bounds.ar_start / (int)sizeof(_Py_CODEUNIT)] = bounds.ar_line;
+///         last_line = bounds.ar_line;
+///     }
+/// }
+/// ```
+///
+/// Only the **start** unit of a range is a jump target, and a `NO_LOCATION`
+/// range contributes none: `ar_line` is `-1` there and the second test drops
+/// it.  `code_locations` cannot express either — it holds one `SourceLocation`
+/// per unit whose `line` is a `OneIndexed`, so a range carrying line `0` or no
+/// line at all reads back as `1` and turns the module `RESUME` into a legal
+/// target for `f_lineno = 1`.
+///
+/// `firstlineno` is `co->co_firstlineno` as app-level set it; the assert is a
+/// bounds check here because a replaced `co_linetable` can describe ranges past
+/// `len`, which upstream would write out of bounds in a release build.
+fn mark_lines(code: &CodeObject, firstlineno: i32, len: usize) -> Vec<i32> {
+    let mut linestarts = vec![-1i32; len];
+    let mut bounds = crate::pycode::PyCodeAddressRange::new(&code.linetable, firstlineno);
     let mut last_line = -1i32;
-    for i in 0..len {
-        // `locations[i].0` is the start SourceLocation of unit `i`.
-        let line = locations
-            .get(i)
-            .map(|(start, _)| start.line.get() as i32)
-            .unwrap_or(first);
-        if line != last_line && line != -1 {
-            lines[i] = line;
-            last_line = line;
+    while bounds.advance() {
+        if bounds.ar_line != last_line && bounds.ar_line != -1 {
+            if let Some(slot) = usize::try_from(bounds.ar_start / 2)
+                .ok()
+                .and_then(|index| linestarts.get_mut(index))
+            {
+                *slot = bounds.ar_line;
+            }
+            last_line = bounds.ar_line;
         }
     }
-    lines
+    linestarts
 }
 
 /// `frameobject.c first_line_not_before` — the smallest line `>= line`
@@ -4391,7 +4411,11 @@ impl PyFrame {
 
         let code = self.code();
         let len = code.instructions.len();
-        let first_line = code.first_line_number.map(|n| n.get() as i32).unwrap_or(1);
+        // `if (new_lineno < f->f_frame->f_code->co_firstlineno)` — the bound
+        // is the code object's own first line, which app-level can set to
+        // zero or below, not a `OneIndexed` floor of 1.
+        let first_line =
+            unsafe { crate::pycode::w_code_firstlineno_raw(self.pycode as PyObjectRef) };
 
         let mut new_lineno = new_f_lineno as i32;
         if new_lineno < first_line {
@@ -4400,7 +4424,7 @@ impl PyFrame {
             )));
         }
 
-        let lines = mark_lines(code, len);
+        let lines = mark_lines(code, first_line, len);
         new_lineno = mark_first_line_not_before(&lines, new_lineno);
         if new_lineno < 0 {
             return Err(crate::PyError::value_error(format!(
@@ -4453,11 +4477,17 @@ impl PyFrame {
             cur_stack = mark_pop_value(cur_stack);
         }
         while cur_stack > best_stack {
-            let popped = self.popvalue();
             if mark_top_of_stack(cur_stack) == StackKind::Except as i64 {
                 // The popped value is the saved previous exception; make
                 // it current again.
-                crate::eval::set_current_exception(popped);
+                crate::eval::set_current_exception(self.popvalue());
+            } else {
+                // `PyStackRef_XCLOSE(_PyFrame_StackPop(f->f_frame))` — the
+                // `X` is load-bearing.  A slot below the jump target can be
+                // unbound, which is what a jump out of the body of a `with`
+                // pops: the block's `__exit__` slot is NULL until the
+                // cleanup runs.
+                self.popvalue_maybe_none();
             }
             cur_stack = mark_pop_value(cur_stack);
         }
@@ -5694,10 +5724,13 @@ mod tests {
     fn mark_lines_and_first_line_not_before() {
         let code = crate::compile_exec("a = 1\nb = 2\nc = 3\n").expect("compile");
         let len = code.instructions.len();
-        let lines = mark_lines(&code, len);
         let first = code.first_line_number.map(|n| n.get() as i32).unwrap_or(1);
-        // The earliest recorded line is the first source line.
-        let min_line = lines.iter().copied().filter(|&l| l >= 0).min().unwrap();
+        let lines = mark_lines(&code, first, len);
+        // A module body opens with a `RESUME` whose range carries line 0,
+        // below `co_firstlineno`; it is a range start, so it is marked.
+        assert_eq!(lines[0], 0);
+        // The earliest recorded statement line is the first source line.
+        let min_line = lines.iter().copied().filter(|&l| l > 0).min().unwrap();
         assert_eq!(min_line, first);
         // A request before the code resolves to the first line.
         assert_eq!(mark_first_line_not_before(&lines, first), first);

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1987,10 +1987,19 @@ pub const PYFRAME_LOCALS_OFFSET: usize = PYFRAME_LOCALS_CELLS_STACK_OFFSET;
 /// returns from the same zero-length walk and the value both readers of a line
 /// number render as `None`; it is also `LINENO_NOT_COMPUTED`, so a traceback
 /// node stamped with it resolves lazily and answers `None` there too.
+///
+/// The `PyCode` wrapper is the argument, not the bare `CodeObject`, because
+/// the walk is seeded with `co_firstlineno` and only the wrapper carries it
+/// as the signed integer app-level set: `CodeObject.first_line_number` is an
+/// `Option<OneIndexed>` and cannot hold the zero and negative values
+/// `CodeType(...)` accepts.
+///
+/// # Safety
+/// `w_code` must be a live `PyCode`.
 #[inline]
-pub fn offset2lineno(code: &CodeObject, stopat: isize) -> isize {
+pub unsafe fn offset2lineno(w_code: PyObjectRef, stopat: isize) -> isize {
     let addrq = (stopat as i64).saturating_mul(2);
-    crate::pycode::w_code_addr2line(code, addrq).map_or(-1, |line| line as isize)
+    unsafe { crate::pycode::w_code_addr2line(w_code, addrq) as isize }
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -4222,6 +4231,16 @@ impl PyFrame {
     /// replacement `co_linetable` that describes no range covering
     /// `last_instr` — including an empty one — and for the `NO_LOCATION`
     /// ranges a compiler-generated cleanup sits in.
+    ///
+    /// A frame that has not run an instruction resolves against instruction
+    /// **0**, not against `PyCode_Addr2Line`'s `addrq < 0` arm.  Upstream has
+    /// no "not started" offset to resolve: `_PyInterpreterFrame_LASTI` is 0
+    /// while the frame sits on its `RESUME`, so `frame_getlineno` answers that
+    /// instruction's own line.  The two differ for a module body, whose
+    /// `RESUME` carries line **0** while `co_firstlineno` is 1 — and the gap
+    /// is observable, because `_trace` seeds the last-traced line from here on
+    /// the `call` event, so answering `co_firstlineno` made the `RESUME`'s own
+    /// line look like a change and fired a `line` event upstream does not have.
     #[inline]
     pub fn get_last_lineno(&self) -> isize {
         self.get_lineno_at(self.last_instr)
@@ -4236,7 +4255,7 @@ impl PyFrame {
     /// coordinate answers this read without one.
     #[inline]
     pub fn get_lineno_at(&self, last_instr: isize) -> isize {
-        offset2lineno(self.code(), last_instr)
+        unsafe { offset2lineno(self.pycode as PyObjectRef, last_instr.max(0)) }
     }
 
     /// pycode.py `_get_lineno_for_pc_tracing(frame.last_instr)` — the line a

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -4252,15 +4252,21 @@ impl PyFrame {
     /// `last_instr` — including an empty one — and for the `NO_LOCATION`
     /// ranges a compiler-generated cleanup sits in.
     ///
-    /// A frame that has not run an instruction resolves against instruction
-    /// **0**, not against `PyCode_Addr2Line`'s `addrq < 0` arm.  Upstream has
-    /// no "not started" offset to resolve: `_PyInterpreterFrame_LASTI` is 0
-    /// while the frame sits on its `RESUME`, so `frame_getlineno` answers that
-    /// instruction's own line.  The two differ for a module body, whose
-    /// `RESUME` carries line **0** while `co_firstlineno` is 1 — and the gap
-    /// is observable, because `_trace` seeds the last-traced line from here on
-    /// the `call` event, so answering `co_firstlineno` made the `RESUME`'s own
-    /// line look like a change and fired a `line` event upstream does not have.
+    /// A frame that has not run an instruction resolves against its first
+    /// `RESUME`, not against `PyCode_Addr2Line`'s `addrq < 0` arm.  Upstream
+    /// has no "not started" offset to resolve: `_PyInterpreterFrame_LASTI` is
+    /// `_co_firsttraceable` while the frame sits on that `RESUME`, so
+    /// `frame_getlineno` answers the instruction's own line.  That differs from
+    /// `co_firstlineno` for a module body, whose `RESUME` carries line **0**
+    /// while `co_firstlineno` is 1 — and the gap is observable, because
+    /// `_trace` seeds the last-traced line from here on the `call` event, so
+    /// answering `co_firstlineno` made the `RESUME`'s own line look like a
+    /// change and fired a `line` event upstream does not have.
+    ///
+    /// It differs from instruction **0** too, and only for a code object with a
+    /// prologue: `COPY_FREE_VARS` and `MAKE_CELL` are stamped with no line at
+    /// all, so a closure resolved at 0 answers `-1` and reports `f_lineno` as
+    /// `None` where the `RESUME` two units later carries the `def` line.
     #[inline]
     pub fn get_last_lineno(&self) -> isize {
         self.get_lineno_at(self.last_instr)
@@ -4275,7 +4281,12 @@ impl PyFrame {
     /// coordinate answers this read without one.
     #[inline]
     pub fn get_lineno_at(&self, last_instr: isize) -> isize {
-        unsafe { offset2lineno(self.pycode as PyObjectRef, last_instr.max(0)) }
+        let stopat = if last_instr < 0 {
+            crate::pycode::first_traceable_index(self.code()) as isize
+        } else {
+            last_instr
+        };
+        unsafe { offset2lineno(self.pycode as PyObjectRef, stopat) }
     }
 
     /// pycode.py `_get_lineno_for_pc_tracing(frame.last_instr)` — the line a

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -340,11 +340,14 @@ pub unsafe fn w_pytraceback_get_lineno(tb: PyObjectRef) -> Option<i64> {
         if w_code.is_null() {
             return None;
         }
-        let code = crate::w_code_get_ptr(w_code) as *const crate::CodeObject;
-        if code.is_null() {
+        // `if (lineno < 0) { Py_RETURN_NONE; }` — the test `tb_lineno_get`
+        // applies to what it just resolved, and only to that: a line stored
+        // on the node is returned above whatever its sign.
+        let lineno = crate::pycode::w_code_addr2line(w_code, w_pytraceback_get_lasti(tb));
+        if lineno < 0 {
             return None;
         }
-        crate::pycode::w_code_addr2line(&*code, w_pytraceback_get_lasti(tb)).map(|line| line as i64)
+        Some(lineno as i64)
     }
 }
 
@@ -461,13 +464,10 @@ pub unsafe fn record_application_traceback(
         // `write_traceback_chain` in `error.rs`) MUST go through
         // `w_code` rather than dereferencing the `frame` pointer.
         let w_code = (*frame).pycode as PyObjectRef;
-        let lineno = {
-            let code_obj = crate::pyframe::pyframe_get_pycode(&*frame);
-            if code_obj.is_null() {
-                LINENO_NOT_COMPUTED
-            } else {
-                crate::pyframe::offset2lineno(&*code_obj, last_instruction as isize) as i64
-            }
+        let lineno = if w_code.is_null() {
+            LINENO_NOT_COMPUTED
+        } else {
+            crate::pyframe::offset2lineno(w_code, last_instruction as isize) as i64
         };
         // `tb = operror.get_traceback()` — the read that grows the chain
         // marks the previous head's frame, matching `get_traceback`.

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -321,11 +321,12 @@ pub unsafe fn w_pytraceback_get_w_code(obj: PyObjectRef) -> PyObjectRef {
 /// `walker_specialize_traceback_walk_field`, which folds the raw slot against
 /// a guard that it is not the sentinel.
 ///
-/// `record_application_traceback` still stamps the line eagerly, so a recorded
-/// node reaches the first branch and never resolves here.  That timing is not
-/// observable: `tb_lasti` and `tb_lineno` are read-only, so the only way to
-/// hand a live node a sentinel is the constructor, which lands in the second
-/// branch either way.
+/// `record_application_traceback` stamps the line eagerly, so a recorded node
+/// reaches the first branch — unless its `tb_lasti` names no line, where the
+/// eager walk answers `-1` and stamps the sentinel, and the resolution below
+/// runs and answers `None`.  That timing is not observable: `tb_lasti` and
+/// `tb_lineno` are read-only, so the only other way to hand a live node a
+/// sentinel is the constructor, which lands in the second branch either way.
 ///
 /// # Safety
 /// `tb` must point to a valid `PyTraceback`.
@@ -434,12 +435,13 @@ pub unsafe fn record_application_traceback(
         crate::eval::set_in_flight_exception(w_exc_object);
         // `pytraceback.py self.lineno = offset2lineno(self.frame
         // .pycode, self.lasti)` — pyre resolves the line number eagerly
-        // here rather than leaving the sentinel for the getter, so the
-        // slot never holds `LINENO_NOT_COMPUTED` for a node built here.
+        // here rather than leaving the sentinel for the getter.
         // `_PyTraceBack_FromFrame` records the sentinel instead and
         // `tb_lineno_get` resolves it, but a node's `tb_lasti` and
         // `tb_lineno` are both read-only there, so which of the two
-        // moments does the walk is not app-level observable.
+        // moments does the walk is not app-level observable.  An offset
+        // that names no line resolves to `-1`, which IS the sentinel, so
+        // such a node is stamped unresolved and reaches the getter.
         //
         // What the eager stamp buys is the JIT fold
         // `walker_specialize_traceback_walk_field` (pyre-jit-trace): it

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -776,6 +776,26 @@ pub fn init_typeobjects() {
         unsafe { pyre_object::w_type_set_acceptable_as_base_class(none_type, false) };
         reg.insert(&NONE_TYPE as *const PyType as usize, none_type as usize);
 
+        // `_PyLineIterator` / `_PyPositionsIterator` — the two walks over a
+        // code object's line table.  Both carry `Py_TPFLAGS_BASETYPE` and have
+        // no `tp_new`: only `co_lines()` and `co_positions()` produce one.
+        for (name, init, tp) in [
+            (
+                "line_iterator",
+                init_line_iterator_type as fn(PyObjectRef),
+                &crate::pycode::LINE_ITER_TYPE as *const PyType as usize,
+            ),
+            (
+                "positions_iterator",
+                init_positions_iterator_type as fn(PyObjectRef),
+                &crate::pycode::POSITIONS_ITER_TYPE as *const PyType as usize,
+            ),
+        ] {
+            let w_type = new_typeobject_with_base(name, init, object_type);
+            unsafe { pyre_object::w_type_set_disallow_instantiation(w_type) };
+            reg.insert(tp, w_type as usize);
+        }
+
         // setobject.py W_SetIterObject.typedef. Python 3.14 exposes the
         // concrete name as `set_iterator` (PyPy 3.11 used `setiterator`).
         let set_iterator_type =
@@ -2075,6 +2095,8 @@ fn method_owner(type_name: &str) -> Option<&'static crate::gateway::MethodOwner>
         "set" => pyre_object::is_set,
         "frozenset" => pyre_object::is_frozenset,
         "set_iterator" => pyre_object::is_set_iterator,
+        "line_iterator" => crate::pycode::is_line_iter,
+        "positions_iterator" => crate::pycode::is_positions_iter,
         "range" => pyre_object::functional::is_w_range,
         "slice" => pyre_object::is_slice,
         "memoryview" => pyre_object::memoryview::is_w_memoryview,
@@ -27607,6 +27629,100 @@ fn set_iter_reduce(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             state,
         ]))
     }
+}
+
+/// `_PyLineIterator` — `tp_iter` is `PyObject_SelfIter`, `tp_iternext` is
+/// `lineiter_next`, and `tp_methods` is empty.
+fn init_line_iterator_type(ns: PyObjectRef) {
+    init_line_table_iterator_type(ns, line_iter_self, line_iter_next);
+}
+
+/// `_PyPositionsIterator`, the same shape over `positionsiter_next`.
+fn init_positions_iterator_type(ns: PyObjectRef) {
+    init_line_table_iterator_type(ns, positions_iter_self, positions_iter_next);
+}
+
+fn init_line_table_iterator_type(
+    ns: PyObjectRef,
+    self_fn: fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>,
+    next_fn: fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>,
+) {
+    unsafe { pyre_object::w_dict_setitem_str(ns, "__doc__", pyre_object::w_none()) };
+    let entries = [
+        (
+            "__iter__",
+            make_builtin_function_with_arity("__iter__", self_fn, 1),
+        ),
+        (
+            "__next__",
+            make_builtin_function_with_arity("__next__", next_fn, 1),
+        ),
+    ];
+    for (name, value) in entries {
+        unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, name, value) };
+    }
+}
+
+fn line_iter_self(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    require_line_table_iterator(
+        args,
+        "__iter__",
+        "line_iterator",
+        crate::pycode::is_line_iter,
+    )
+}
+
+fn line_iter_next(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let receiver = require_line_table_iterator(
+        args,
+        "__next__",
+        "line_iterator",
+        crate::pycode::is_line_iter,
+    )?;
+    unsafe { crate::pycode::line_iter_next(receiver) }.ok_or_else(crate::PyError::stop_iteration)
+}
+
+fn positions_iter_self(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    require_line_table_iterator(
+        args,
+        "__iter__",
+        "positions_iterator",
+        crate::pycode::is_positions_iter,
+    )
+}
+
+fn positions_iter_next(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let receiver = require_line_table_iterator(
+        args,
+        "__next__",
+        "positions_iterator",
+        crate::pycode::is_positions_iter,
+    )?;
+    unsafe { crate::pycode::positions_iter_next(receiver) }
+        .ok_or_else(crate::PyError::stop_iteration)
+}
+
+/// The receiver check every unbound `line_iterator` / `positions_iterator`
+/// method needs: each reads its payload at its own layout, so an unchecked
+/// receiver reaches those accessors as type confusion.
+fn require_line_table_iterator(
+    args: &[PyObjectRef],
+    name: &str,
+    type_name: &str,
+    is_receiver: unsafe fn(PyObjectRef) -> bool,
+) -> Result<PyObjectRef, crate::PyError> {
+    let Some(&receiver) = args.first() else {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' of '{type_name}' object needs an argument"
+        )));
+    };
+    if !unsafe { is_receiver(receiver) } {
+        let received = crate::baseobjspace::object_functionstr_type_name(receiver);
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' requires a '{type_name}' object but received a '{received}'"
+        )));
+    }
+    Ok(receiver)
 }
 
 fn init_set_iterator_type(ns: PyObjectRef) {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -7793,6 +7793,25 @@ fn init_dict_view_items_type(ns: PyObjectRef) {
 /// traceback constructor.  `args[0]` is the class; the four positional
 /// arguments follow.  `tb_next` is a traceback or `None`; `tb_frame`
 /// must be a `frame`; `tb_lasti` / `tb_lineno` are ints, stored as given.
+/// `PyLong_AsInt` — the argument converter behind a clinic `int` parameter.
+///
+/// It goes through `__index__`, so the TypeError for anything else is
+/// `'X' object cannot be interpreted as an integer` rather than a
+/// signature-shaped one, and a value outside the C `int` range raises
+/// instead of being truncated into the slot.
+///
+/// A value past `i64` reaches this as `space_index_w`'s own OverflowError,
+/// whose message names `int` rather than `C int`.
+fn traceback_c_int_arg(obj: PyObjectRef) -> Result<i64, crate::PyError> {
+    let value = crate::builtins::space_index_w(obj)?;
+    if i32::try_from(value).is_err() {
+        return Err(crate::PyError::overflow_error(
+            "Python int too large to convert to C int",
+        ));
+    }
+    Ok(value)
+}
+
 fn traceback_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.len() != 5 {
         return Err(crate::PyError::type_error(format!(
@@ -7828,22 +7847,11 @@ fn traceback_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     }
     let frame = w_frame as *mut crate::pyframe::PyFrame;
 
-    // tb_lasti / tb_lineno: integers, stored as given
-    // (`pytraceback.py descr_new`).
-    if !unsafe { pyre_object::is_int(w_lasti) } {
-        return Err(crate::PyError::type_error(format!(
-            "an integer is required (got type {})",
-            type_name_of(w_lasti)
-        )));
-    }
-    if !unsafe { pyre_object::is_int(w_lineno) } {
-        return Err(crate::PyError::type_error(format!(
-            "an integer is required (got type {})",
-            type_name_of(w_lineno)
-        )));
-    }
-    let lasti = unsafe { pyre_object::w_int_get_value(w_lasti) };
-    let lineno = unsafe { pyre_object::w_int_get_value(w_lineno) };
+    // tb_lasti / tb_lineno: both are declared `int` in the signature, so the
+    // converter Argument Clinic emits is `PyLong_AsInt` — it reduces through
+    // `__index__` and refuses a value the C `int` cannot hold.
+    let lasti = traceback_c_int_arg(w_lasti)?;
+    let lineno = traceback_c_int_arg(w_lineno)?;
     let w_code = unsafe { (*frame).fget_f_code() };
 
     Ok(crate::pytraceback::w_pytraceback_new(

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -776,9 +776,12 @@ pub fn init_typeobjects() {
         unsafe { pyre_object::w_type_set_acceptable_as_base_class(none_type, false) };
         reg.insert(&NONE_TYPE as *const PyType as usize, none_type as usize);
 
-        // `_PyLineIterator` / `_PyPositionsIterator` — the two walks over a
-        // code object's line table.  Both carry `Py_TPFLAGS_BASETYPE` and have
-        // no `tp_new`: only `co_lines()` and `co_positions()` produce one.
+        // `_PyLineIterator` / `_PyPositionsIterator` /
+        // `_PyBranchesIterator` — the three walks over a code object.  All
+        // three carry `Py_TPFLAGS_BASETYPE` and have no `tp_new`: only
+        // `co_lines()`, `co_positions()` and `co_branches()` produce one.
+        // The branches iterator answers to `line_iterator` as well, so the
+        // two are distinguishable only by identity.
         for (name, init, tp) in [
             (
                 "line_iterator",
@@ -789,6 +792,11 @@ pub fn init_typeobjects() {
                 "positions_iterator",
                 init_positions_iterator_type as fn(PyObjectRef),
                 &crate::pycode::POSITIONS_ITER_TYPE as *const PyType as usize,
+            ),
+            (
+                "line_iterator",
+                init_branches_iterator_type as fn(PyObjectRef),
+                &crate::pycode::BRANCHES_ITER_TYPE as *const PyType as usize,
             ),
         ] {
             let w_type = new_typeobject_with_base(name, init, object_type);
@@ -2095,7 +2103,9 @@ fn method_owner(type_name: &str) -> Option<&'static crate::gateway::MethodOwner>
         "set" => pyre_object::is_set,
         "frozenset" => pyre_object::is_frozenset,
         "set_iterator" => pyre_object::is_set_iterator,
-        "line_iterator" => crate::pycode::is_line_iter,
+        // Two types report `line_iterator`; the name-keyed owner admits
+        // either and each method body checks the layout it reads.
+        "line_iterator" => crate::pycode::is_named_line_iterator,
         "positions_iterator" => crate::pycode::is_positions_iter,
         "range" => pyre_object::functional::is_w_range,
         "slice" => pyre_object::is_slice,
@@ -27642,6 +27652,11 @@ fn init_positions_iterator_type(ns: PyObjectRef) {
     init_line_table_iterator_type(ns, positions_iter_self, positions_iter_next);
 }
 
+/// `_PyBranchesIterator`, the same shape over `branchesiter_next`.
+fn init_branches_iterator_type(ns: PyObjectRef) {
+    init_line_table_iterator_type(ns, branches_iter_self, branches_iter_next);
+}
+
 fn init_line_table_iterator_type(
     ns: PyObjectRef,
     self_fn: fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>,
@@ -27699,6 +27714,26 @@ fn positions_iter_next(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
         crate::pycode::is_positions_iter,
     )?;
     unsafe { crate::pycode::positions_iter_next(receiver) }
+        .ok_or_else(crate::PyError::stop_iteration)
+}
+
+fn branches_iter_self(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    require_line_table_iterator(
+        args,
+        "__iter__",
+        "line_iterator",
+        crate::pycode::is_branches_iter,
+    )
+}
+
+fn branches_iter_next(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let receiver = require_line_table_iterator(
+        args,
+        "__next__",
+        "line_iterator",
+        crate::pycode::is_branches_iter,
+    )?;
+    unsafe { crate::pycode::branches_iter_next(receiver) }
         .ok_or_else(crate::PyError::stop_iteration)
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1183,10 +1183,12 @@ fn traceback_node_site<Sym: WalkSym>(
         jitcode_index,
         opcode_position as i32,
     )?;
-    let raw_code = crate::state::raw_code_for_jitcode_index(jitcode_index)?;
-    let lineno =
-        unsafe { pyre_interpreter::pyframe::offset2lineno(&*raw_code, last_instruction as isize) }
-            as i64;
+    let lineno = unsafe {
+        pyre_interpreter::pyframe::offset2lineno(
+            w_code as pyre_object::PyObjectRef,
+            last_instruction as isize,
+        )
+    } as i64;
     let frame = ctx
         .registers_r
         .get(jitcode.metadata.portal_frame_reg as usize)

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7559,6 +7559,31 @@ fn for_iter_body_op_is_jit_safe(instr: pyre_interpreter::Instruction) -> bool {
             // records the shape's answer while the frame stays interpreted;
             // `bench/synth/exception_with_exit_self_null_slot` is the `while`
             // form, which never depended on this gate.
+            //
+            // 2026-08-24: the witness above no longer fires.  Admitting both
+            // opcodes on this tree and rebuilding, `test.test_pow` is OK 3/3
+            // with no `GeneratorExit` anywhere in the output, and 14 further
+            // `with`/generator-heavy modules — `test_long`, `test_contextlib`,
+            // `test_contextlib_async`, `test_with`, `test_unittest`,
+            // `test_exceptions`, `test_exception_variations`, `test_except_star`,
+            // `test_raise`, `test_decimal`, `test_generator_stop`,
+            // `test_coroutines`, `test_yield_from` — are clean too.  The
+            // admission is not inert: it takes `foriter_load_special_with` from
+            // `loops_compiled=2` to `3` and the fixture still prints its
+            // recorded answer.  Two `with` root causes landed in between, either
+            // of which could account for it: the `bh_with_except_start_fn`
+            // null-receiver tag that was aborting every bridge out of a `with`
+            // handler at op 1, and the blackhole `guard_class` no-op stub that
+            // lost a second suppressing `__exit__`.
+            //
+            // The gate stays shut anyway, because admitting it is not a
+            // one-file change: `loops_aborted` goes 0 -> 9 on that fixture, so
+            // all three backends' jitstats need re-recording, and the method
+            // note on the original defect is that two green synthetic gate runs
+            // on three backends missed it while the cpython suite caught it —
+            // so the full 209-module suite is the evidence to produce, not a
+            // subset.  Neither is measurable on a host that cannot build
+            // release.
             // oparg prefix + inline-cache padding (no-ops in the body scan)
             | I::ExtendedArg
             | I::Cache

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3979,6 +3979,19 @@ fn build_gc() -> Box<MiniMarkGC> {
         simplequeue_descr.ptr_offsets,
     );
 
+    // `_PyLineIterator` / `_PyPositionsIterator` — each holds the code object
+    // whose `co_linetable` its suspended walk reads.  Both are unconditional,
+    // so they close the ungated block here rather than joining the
+    // target-gated tail, whose ids would otherwise move per target.
+    for descriptor in [
+        <pyre_interpreter::pycode::W_LineIterObject
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        <pyre_interpreter::pycode::W_PositionsIterObject
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    ] {
+        register_pyre_class(&mut gc, &mut pytype_to_tid, descriptor);
+    }
+
     // Register `posix.DirEntry`'s four inline GC edges and
     // `posix.ScandirIterator`'s entries-list edge. The entries in
     // `SUBCLASS_RANGE_HIERARCHY` and `all_subclass_range_aliases` are

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3979,14 +3979,16 @@ fn build_gc() -> Box<MiniMarkGC> {
         simplequeue_descr.ptr_offsets,
     );
 
-    // `_PyLineIterator` / `_PyPositionsIterator` — each holds the code object
-    // whose `co_linetable` its suspended walk reads.  Both are unconditional,
-    // so they close the ungated block here rather than joining the
-    // target-gated tail, whose ids would otherwise move per target.
+    // `_PyLineIterator` / `_PyPositionsIterator` / `_PyBranchesIterator` —
+    // each holds the code object its suspended walk reads.  All three are
+    // unconditional, so they close the ungated block here rather than joining
+    // the target-gated tail, whose ids would otherwise move per target.
     for descriptor in [
         <pyre_interpreter::pycode::W_LineIterObject
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
         <pyre_interpreter::pycode::W_PositionsIterObject
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+        <pyre_interpreter::pycode::W_BranchesIterObject
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     ] {
         register_pyre_class(&mut gc, &mut pytype_to_tid, descriptor);

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -680,26 +680,31 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     // `_queue.SimpleQueue` owns a native FIFO and is unconditional, so it
     // closes the ungated block rather than joining the target-gated tail.
     (179, Some(0)),
-    // Native-only type IDs 180 and 181 represent `posix.DirEntry` and
-    // `posix.ScandirIterator`, matching `build_gc`'s registration order.
-    #[cfg(not(target_arch = "wasm32"))]
+    // The two walks over a code object's line table are unconditional, so
+    // they close the ungated block behind `_queue.SimpleQueue` rather than
+    // joining the target-gated tail.
     (180, Some(0)),
-    #[cfg(not(target_arch = "wasm32"))]
     (181, Some(0)),
-    // rustls `_ssl` context, MemoryBIO, and session native payloads.  These
-    // extend the append-only native rclass tail; wasm omits the host TLS
-    // module and therefore the hierarchy entries as well. Sandbox filtering
-    // belongs to pyre-interpreter, which owns that module configuration.
+    // Native-only type IDs 182 and 183 represent `posix.DirEntry` and
+    // `posix.ScandirIterator`, matching `build_gc`'s registration order.
     #[cfg(not(target_arch = "wasm32"))]
     (182, Some(0)),
     #[cfg(not(target_arch = "wasm32"))]
     (183, Some(0)),
+    // rustls `_ssl` context, MemoryBIO, and session native payloads.  These
+    // extend the append-only native rclass tail; wasm omits the host TLS
+    // module and therefore the hierarchy entries as well. Sandbox filtering
+    // belongs to pyre-interpreter, which owns that module configuration.
     #[cfg(not(target_arch = "wasm32"))]
     (184, Some(0)),
     #[cfg(not(target_arch = "wasm32"))]
     (185, Some(0)),
     #[cfg(not(target_arch = "wasm32"))]
     (186, Some(0)),
+    #[cfg(not(target_arch = "wasm32"))]
+    (187, Some(0)),
+    #[cfg(not(target_arch = "wasm32"))]
+    (188, Some(0)),
     // `mmap.mmap` owns its native mapping payload — the duplicated fd on POSIX
     // and the file handle on Windows — and follows the optional SSL tail
     // wherever the module is compiled.  The gate must match the alias gate in
@@ -708,20 +713,20 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     // A sandbox build has no `mmap` module either, so
     // `active_subclass_range_hierarchy` drops this entry along with SSL's.
     #[cfg(any(unix, windows))]
-    (187, Some(0)),
+    (189, Some(0)),
     // `_overlapped.Overlapped` owns the Windows OVERLAPPED record and its
     // retained Python buffers.  pyre-interpreter supplies the vtable alias;
     // the object layer owns only the append-only hierarchy slot.
     #[cfg(windows)]
-    (188, Some(0)),
+    (190, Some(0)),
     // `_winapi.Overlapped` owns a second Windows OVERLAPPED record, the one
     // waited on through an event of its own rather than a completion port.
     #[cfg(windows)]
-    (189, Some(0)),
+    (191, Some(0)),
     // PEP 528 `_io._WindowsConsoleIO` is a subclassable `_RawIOBase` payload.
     // Its append-only vtable id follows both Windows overlapped owners.
     #[cfg(windows)]
-    (190, Some(0)),
+    (192, Some(0)),
 ];
 
 /// Compute subclass IDs from [`SUBCLASS_RANGE_HIERARCHY`] and write every

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -680,23 +680,22 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     // `_queue.SimpleQueue` owns a native FIFO and is unconditional, so it
     // closes the ungated block rather than joining the target-gated tail.
     (179, Some(0)),
-    // The two walks over a code object's line table are unconditional, so
-    // they close the ungated block behind `_queue.SimpleQueue` rather than
-    // joining the target-gated tail.
+    // The three walks over a code object are unconditional, so they close the
+    // ungated block behind `_queue.SimpleQueue` rather than joining the
+    // target-gated tail.
     (180, Some(0)),
     (181, Some(0)),
-    // Native-only type IDs 182 and 183 represent `posix.DirEntry` and
+    (182, Some(0)),
+    // Native-only type IDs 183 and 184 represent `posix.DirEntry` and
     // `posix.ScandirIterator`, matching `build_gc`'s registration order.
     #[cfg(not(target_arch = "wasm32"))]
-    (182, Some(0)),
-    #[cfg(not(target_arch = "wasm32"))]
     (183, Some(0)),
+    #[cfg(not(target_arch = "wasm32"))]
+    (184, Some(0)),
     // rustls `_ssl` context, MemoryBIO, and session native payloads.  These
     // extend the append-only native rclass tail; wasm omits the host TLS
     // module and therefore the hierarchy entries as well. Sandbox filtering
     // belongs to pyre-interpreter, which owns that module configuration.
-    #[cfg(not(target_arch = "wasm32"))]
-    (184, Some(0)),
     #[cfg(not(target_arch = "wasm32"))]
     (185, Some(0)),
     #[cfg(not(target_arch = "wasm32"))]
@@ -705,6 +704,8 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     (187, Some(0)),
     #[cfg(not(target_arch = "wasm32"))]
     (188, Some(0)),
+    #[cfg(not(target_arch = "wasm32"))]
+    (189, Some(0)),
     // `mmap.mmap` owns its native mapping payload — the duplicated fd on POSIX
     // and the file handle on Windows — and follows the optional SSL tail
     // wherever the module is compiled.  The gate must match the alias gate in
@@ -713,20 +714,20 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     // A sandbox build has no `mmap` module either, so
     // `active_subclass_range_hierarchy` drops this entry along with SSL's.
     #[cfg(any(unix, windows))]
-    (189, Some(0)),
+    (190, Some(0)),
     // `_overlapped.Overlapped` owns the Windows OVERLAPPED record and its
     // retained Python buffers.  pyre-interpreter supplies the vtable alias;
     // the object layer owns only the append-only hierarchy slot.
     #[cfg(windows)]
-    (190, Some(0)),
+    (191, Some(0)),
     // `_winapi.Overlapped` owns a second Windows OVERLAPPED record, the one
     // waited on through an event of its own rather than a completion port.
     #[cfg(windows)]
-    (191, Some(0)),
+    (192, Some(0)),
     // PEP 528 `_io._WindowsConsoleIO` is a subclassable `_RawIOBase` payload.
     // Its append-only vtable id follows both Windows overlapped owners.
     #[cfg(windows)]
-    (192, Some(0)),
+    (193, Some(0)),
 ];
 
 /// Compute subclass IDs from [`SUBCLASS_RANGE_HIERARCHY`] and write every


### PR DESCRIPTION
## What

Line numbers and positions are resolved from `co_linetable`'s ranges instead of
from a decoded per-instruction table; `co_lines`, `co_positions` and
`co_branches` get their own lazy iterator types; and `object_functionstr` stops
swallowing the faults it raises.

Every observable decision below was measured against CPython 3.14 before it was
ported, and the places where 3.14 and PyPy 3.11 disagree are called out
explicitly — those are the ones a reviewer should look at hardest.

### 1. Resolve every line and position off the line table's ranges

`offset2lineno` walks `co_linetable` directly, seeded with `co_firstlineno`,
the way `pypy/interpreter/location.py:120-135` does. The previous resolver
decoded the table into one `SourceLocation` per code unit, which cannot
represent "this instruction has no position at all": a decoded entry always
carries a line, so an instruction stamped `NO_LOCATION` was indistinguishable
from one stamped with a line and no columns.

That cost a pre-scan (`linetable_records_no_position`) over the whole table and
a `0 => -1` remap on the way out, both of which are gone. `co_positions` and
`tb_lineno` read the same ranges, so a no-position instruction now reports the
same thing through all three.

`f_lineno`'s jump validation marks jump targets off the range starts rather
than off decoded entries, and a negative `tb_lasti` names the first line
instead of falling through to the miss.

### 2. `f_lineno` reports a missing line as `None`

3.14's `frame_lineno_get_impl` (`Objects/frameobject.c`) is
`PyFrame_GetLineNumber() < 0 -> None`, with no `f_trace` test and no
`co_firstlineno` substitution. PyPy's `pyframe.py:654-664` still has both —
this is a deliberate 3.11 -> 3.14 divergence, not a porting slip.

A frame that has not run an instruction resolves against `_co_firsttraceable`,
the index of its first `RESUME`. Two things make that the right coordinate and
neither is instruction 0:

- a module body's `RESUME` carries line **0** while `co_firstlineno` is 1, and
  the gap is observable — `_trace` seeds the last-traced line from here on the
  `call` event, so answering `co_firstlineno` makes the `RESUME`'s own line
  look like a change and fires a `line` event 3.14 does not have;
- a closure's prologue (`COPY_FREE_VARS` / `MAKE_CELL`) is stamped with no line
  at all, so resolving at instruction 0 answers `-1` and reports `f_lineno` as
  `None` where the `RESUME` two units later carries the `def` line.

`_co_firsttraceable` was already modelled inside `instruction_can_start_a_line`;
it is now a named accessor both callers share rather than a second copy of the
walk.

### 3. `co_lines`, `co_positions` and `co_branches` get their own iterator types

All three returned eagerly built lists. They are now `_PyLineIterator`,
`_PyPositionsIterator` and `_PyBranchesIterator`, lazy and `Py_TPFLAGS_BASETYPE`
with no `tp_new`, matching 3.14.

`_PyBranchesIterator` reports `line_iterator` as its `tp_name` — the same string
`_PyLineIterator` carries, so two distinct types share one name and only
`type(a) is type(b)` separates them. pyre's method-owner table is keyed by name,
so its predicate admits either payload and each method body checks the layout it
reads.

### 4. `object_functionstr` propagates the faults it used to swallow

`_PyObject_FunctionStr`'s module test is `Py_NE` rather than `__eq__` and has no
exact-type shortcut, so a `str` subclass overriding `__ne__` must run it. The
faults that raises now reach the caller instead of being dropped.

### 5. `TracebackType`'s two int arguments go through `PyLong_AsInt`

`tb_lasti` and `tb_lineno` were taken with a wider conversion than the
constructor uses.

## Divergences declared

Four fixtures carry a `pyre-check: pypy-diverges` header, each for a stated
structural reason read out of the vendored PyPy source rather than from a
version table:

- `ast_types_carry_match_args.py` — `astcompiler/ast.py State.make_new_type`
  binds `_fields` but not `__match_args__`;
- `co_branches_iterator_identity.py` — 3.11 has no `co_branches`;
- `lineno_of_a_no_location_instruction.py`,
  `lineno_when_the_first_line_is_zero_or_negative.py` — 3.11 line tables have
  neither shape.

## Verification

`cargo test --all --features dynasm` green; the parity suite's CPython lane is
clean on both backends. The three remaining PyPy-lane failures
(`builtin_subclass_attr_mapdict`, `pickle_pypy_reduce_build_gc`,
`foriter_stopiteration_exception_event`) are pre-existing and untouched by this
branch.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.
