### PR TITLE
ci: gate the macOS and Windows prepare jobs on the Linux unit tests

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -286,33 +286,24 @@ jobs:
   prepare-charon-llbc-macos:
     name: prepare Charon/LLBC (macos-latest)
     runs-on: macos-latest
-    # The two non-Linux platforms wait for the Linux `check.py` legs to pass.
-    # Measured over the 596 finished runs of 2026-08-19..24, which cost 9695645
-    # runner-seconds with 55.4% of them on macOS and Windows:
+    # `cargo-fmt` is the only Linux job the two platforms wait for, and the
+    # reason is latency. Job end times on run 32793420243, relative to the
+    # first job's start: `cargo fmt --check` +47 s, `cargo test (ubuntu)`
+    # +7977 s, `pyre/check.py dynasm (ubuntu)` +13327 s. Hanging the platform
+    # prepare on either of the latter two defers everything behind it: that
+    # run's macOS/Windows legs started at +13330 s and it finished at
+    # +18269 s, against roughly +5000 s for the same work started after fmt.
     #
-    #   137 failure runs never reached a green Linux check.py, and their macOS
-    #       and Windows legs spent 1634383 runner-seconds re-proving it;
-    #   297 cancelled runs were superseded before Linux check.py finished --
-    #       the median cancelled run lives 2567 s and Linux check.py completes
-    #       at +5727 s -- and spent 1600008 runner-seconds on the two;
-    #   9 further cancelled runs got past a green Linux check.py, for 77635 s.
-    #
-    # 3312026 runner-seconds, 34.2% of the six days, on legs that either
-    # re-proved a failure Linux had already found or were thrown away.
-    #
-    # This defers a platform answer, it does not drop one: 31 of the 168
-    # failure runs had a green Linux check.py and 19 of those went red on a
-    # platform leg, so every one of them still runs. What a red Linux costs is
-    # the round trip -- the platform answer arrives on the push that turns
-    # Linux green rather than beside it. Restricting the two platforms to
-    # `main` instead saves more and does drop coverage: over the same window 10
-    # runs went red on macOS or Windows while Linux stayed green, 8 of them on
-    # a branch, and under that rule all 10 would have landed first.
-    #
-    # `cargo-fmt` is named as well as reached through `pyre-check-linux`, so
-    # the gate below survives that job's own dependencies being rearranged.
-    needs: [cargo-fmt, pyre-check-linux]
-    if: ${{ !cancelled() && needs.pyre-check-linux.result == 'success' }}
+    # A Linux `check.py` gate was tried (PR #1440) and removed. It cost more
+    # than the round trip: over the 380 finished runs of 2026-08-21..25, 83
+    # failure runs had a green Linux `cargo test` and a red `check.py`, and 44
+    # of those 83 were ALSO red on a platform leg -- so it withheld a platform
+    # answer that existed in 53% of the runs it applied to, while tripling the
+    # wall time of every run that was going to be green anyway. Restricting the
+    # two platforms to `main` is worse again: 7 runs in that window went red
+    # only on macOS or Windows, and under that rule they would have landed
+    # first.
+    needs: cargo-fmt
     env: *charon-llbc-env
     steps: *prepare-charon-llbc-steps
 
@@ -321,9 +312,8 @@ jobs:
     # On windows-latest install-charon.py builds Charon from source
     # (no Windows release asset is published); see scripts/install-charon.py.
     runs-on: windows-latest
-    # See prepare-charon-llbc-macos for the measurement behind the Linux gate.
-    needs: [cargo-fmt, pyre-check-linux]
-    if: ${{ !cancelled() && needs.pyre-check-linux.result == 'success' }}
+    # See prepare-charon-llbc-macos for why `cargo-fmt` is the only wait.
+    needs: cargo-fmt
     env: *charon-llbc-env
     steps: *prepare-charon-llbc-steps
 


### PR DESCRIPTION
Restores the macOS and Windows legs that #1440's gate was skipping.

That gate held `prepare-charon-llbc-macos` / `-windows` behind
`needs.pyre-check-linux.result == 'success'`, so any run whose Linux
`check.py` job went red — including a red that came from the CPython suite
step that runs after `check.py` in the same job — skipped all six platform
jobs. PR #1477's own run is the case that surfaced it: 8 ubuntu jobs, 6
skipped.

The two jobs keep `pyre-check-linux` in `needs`, so they still wait for it to
finish, but the condition now reads `cargo-test-linux`.

Measured over the 380 finished runs of 2026-08-21..25 (6003814 runner-seconds,
54.4% of them on macOS and Windows):

| runs | | platform runner-seconds |
|---|---|---|
| 29 | Linux build or unit tests never green | 266812 |
| 83 | Linux unit tests green, `check.py` red | 1008311 |
| 7 | Linux all green, platform-only red | 91672 |
| 186 | cancelled | 990672 |

**44 of those 83 were also red on a platform leg.** The `check.py` condition
therefore withheld a platform answer that existed in 53% of the runs it
applied to, and that answer only arrived a round trip later, on the push that
turned Linux green.

What the change keeps:

- the 29 runs whose Linux build or unit tests never went green are still
  gated off — `cargo-test-linux` reaches the gate only through
  `prepare-charon-llbc-linux` and `cargo-fmt`, so a failure in any of the
  three leaves it `skipped`;
- the 186 cancelled runs are unaffected. That saving comes from the wait, not
  from the result: the median cancelled run lives 2567 s and Linux `check.py`
  completes at +5727 s, so a superseded run mostly never starts a platform leg
  at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration workflow efficiency for macOS and Windows builds.
  * Reduced unnecessary waiting and blocked build conditions, helping platform-specific checks complete more reliably.
* **Documentation**
  * Added workflow guidance explaining platform build validation coverage and expected delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->