### PR TITLE
majit: separate engine names from pyre

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -54,6 +54,8 @@ jobs:
         components: rustfmt
     - name: Run cargo fmt --check
       run: cargo fmt --all -- --check
+    - name: Check majit ownership boundary
+      run: python3 scripts/check-majit-boundary.py
 
   cpyext-abi:
     name: cpyext ABI

--- a/majit/charon-corpus/src/lib.rs
+++ b/majit/charon-corpus/src/lib.rs
@@ -152,7 +152,7 @@ pub fn option_question_mark(keep: bool, value: i64, addend: i64) -> Option<i64> 
 // 8. Header-first object model
 //
 //   1. `(*w).ob_type` off a `*mut ObjectHeader` — a `FieldRead` preceded by
-//      a `__pyre_cast_instance/<Root>` narrow, not a classdef-less read.
+//      a `__cast_instance_intrinsic/<Root>` narrow, not a classdef-less read.
 //   2. `lltype::malloc_typed(Leaf { ob_header: .., payload })` — one
 //      by-value argument, header written before the call, so
 //      `fuse_boxing_alloc` mints `NewWithVtable` with a real vtable.
@@ -226,10 +226,10 @@ pub mod lltype {
 /// Minimal stand-in for the class-instantiation lookup whose result the
 /// class word is stored from.
 ///
-/// `model.rs`'s `get_instantiate_arg_addr` matches the three-segment path
-/// suffix `["pyre_object", "pyobject", "get_instantiate"]` literally, so any
+/// `model.rs`'s `get_instantiate_arg_addr` matches the two-segment path
+/// suffix `["pyobject", "get_instantiate"]` literally, so any
 /// other spelling would not exercise that recognizer.
-pub mod pyre_object {
+pub mod runtime_object {
     pub mod pyobject {
         use crate::ClassObject;
 
@@ -253,7 +253,7 @@ pub fn w_new_int(x: i64) -> *mut W_IntObject {
     lltype::malloc_typed(W_IntObject {
         ob_header: ObjectHeader {
             ob_type: &INT_CLASS,
-            w_class: pyre_object::pyobject::get_instantiate(&INT_CLASS),
+            w_class: runtime_object::pyobject::get_instantiate(&INT_CLASS),
         },
         intval: x,
     })

--- a/majit/examples/tl/src/jit_interp.rs
+++ b/majit/examples/tl/src/jit_interp.rs
@@ -190,7 +190,7 @@ pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
         // after the shared `pc += 1` below and before the arm's own operand
         // advance at `pc += 1` inside `ROLL`, so the resume position names
         // `ROLL`'s operand byte rather than an opcode boundary:
-        // `PYRE_PORTAL_RCA=1` reports `resume_pc=10 compiled_key=None` where
+        // `MAJIT_PORTAL_RCA=1` reports `resume_pc=10 compiled_key=None` where
         // `ROLL, 2` occupies pc 9–10, against `resume_pc=3` with a real
         // `compiled_key` on the `ROLL`-free control.
         //

--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -6,6 +6,47 @@ Each entry records its reader, purpose, and retirement condition. `UNRECORDED` m
 
 ## Live gates
 
+### Translation, backend, and runtime diagnostics
+
+These controls moved with the engine facilities they govern. Unless stated
+otherwise they are disabled when unset and can be removed when ordinary tests
+cover the condition they diagnose.
+
+| gate | default | purpose and retirement condition |
+|---|---|---|
+| `MAJIT_CALLEE_CENSUS` | OFF | Reports resolved and unresolved translation callees; remove when every supported callee is classified. |
+| `MAJIT_CALLEE_CENSUS_ROWS` | value | Limits rows printed by `MAJIT_CALLEE_CENSUS`; remove with that census. |
+| `MAJIT_CALLEE_RCA` | OFF | Reports metainterpreter callee-resolution decisions; remove when those decisions are covered by focused tests. |
+| `MAJIT_CL_NO_CLOSING_JUMP` | OFF | Disables Cranelift's in-code closing jump to exercise external jump dispatch; remove when that fallback no longer needs comparison coverage. |
+| `MAJIT_DESCR_POOL_CENSUS` | OFF | Reports descriptor interning and duplication; remove when descriptor identity is covered by ordinary tests. |
+| `MAJIT_DETERMINISM_TRACE` | OFF | Prints inputs used to diagnose nondeterministic translation output; remove when deterministic output is enforced structurally. |
+| `MAJIT_DTRACE_CONST_BT` | OFF | Adds a backtrace to constant-propagation diagnostics; remove with those diagnostics. |
+| `MAJIT_DTRACE_CONST_FROM` | value | Filters constant-propagation diagnostics by source value; remove with those diagnostics. |
+| `MAJIT_DTRACE_CONST_TO` | value | Filters constant-propagation diagnostics by destination value; remove with those diagnostics. |
+| `MAJIT_DYNASM_EXEC_DIAG` | OFF | Reports dynasm trace execution; remove when trace entry is covered by ordinary telemetry. |
+| `MAJIT_FNPTR_INDIRECT` | OFF | Enables indirect function-pointer lowering; retain while that lowering remains a build configuration. |
+| `MAJIT_GC_FREELIST_DIAG` | OFF | Reports GC freelist allocation and reuse; remove when freelist accounting has sufficient invariant tests. |
+| `MAJIT_GC_ITEMSBLOCK` | ON | Selects GC-managed list item blocks; `0`, `off`, or `false` restores the fallback, which can be removed after deleting the alternate representation. |
+| `MAJIT_JTRANSFORM_SHADOW` | OFF | Compares shadow and primary jtransform results; remove after deleting the shadow implementation. |
+| `MAJIT_MIR_FRAMESTATE` | ON | Selects framestate-threaded MIR lowering; `0` or `false` restores the older lowering, and the escape hatch retires with that path. |
+| `MAJIT_MIR_FRAMESTATE_DEBUG` | OFF | Prints framestate merge diagnostics; remove when merge failures are covered by focused tests. |
+| `MAJIT_MIR_FRAMESTATE_STRICT` | OFF | Turns framestate fallback into a hard failure; remove after deleting the fallback. |
+| `MAJIT_MIR_FRONTEND_DEBUG` | OFF | Prints MIR frontend lowering diagnostics; remove when unsupported shapes are fully classified. |
+| `MAJIT_MIR_FRONTEND_LLBC` | path list | Supplies the complete LLBC input set to the translator; retain as consumer configuration. |
+| `MAJIT_MIR_STRESS_LLBC` | path | Supplies the LLBC snapshot for ignored stress tests; retain while those tests are external-fixture tests. |
+| `MAJIT_NBODY_DEBUG` | OFF | Reports nested-body tracing decisions; remove when those decisions have focused coverage. |
+| `MAJIT_NO_UNROLL` | OFF | Skips the unroll optimizer for diagnosis; remove when the optimizer no longer needs a runtime comparison path. |
+| `MAJIT_PORTAL_RCA` | OFF | Reports portal-selection decisions; remove when portal selection is covered by focused tests. |
+| `MAJIT_PROBE_SUBSCR` | OFF | Reports subscription tracing and dispatch decisions; remove when the relevant opcode paths have focused coverage. |
+| `MAJIT_PROFILE_DRAIN` | OFF | Profiles codewriter queue draining; remove when pipeline performance no longer needs phase attribution. |
+| `MAJIT_PROFILE_PIPELINE` | OFF | Reports translation phase time and memory; retain while translation performance needs phase attribution. |
+| `MAJIT_RTYPER_VERBOSE` | OFF | Emits per-graph rtyper failure census rows; remove when all supported graphs translate or fail through stable classifications. |
+| `MAJIT_S9_PROBE` | OFF | Records optimizer stage-nine diagnostics; remove when that stage has focused invariant coverage. |
+| `MAJIT_SIZE_SHELL_OWNERS` | OFF | Reports owners of size-descriptor shells; remove when shell identity is enforced structurally. |
+| `MAJIT_TRACE_CALL_DIAG` | OFF | Reports calls emitted by the native backend; remove when call lowering has sufficient trace-level coverage. |
+| `MAJIT_TRACE_OPS_DIAG` | OFF | Reports operations executed by the native backend; remove when operation lowering has sufficient trace-level coverage. |
+| `MAJIT_VABLE_IDX_PROBE` | OFF | Reports whether virtualizable array indices are constant; remove when supported index shapes are covered by ordinary tests. |
+
 ### `MAJIT_BH_DEBUG`
 
 - Read sites: 1 — `majit/majit-metainterp/src/lib.rs`

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -2302,7 +2302,7 @@ fn rebuild_state_after_failure_dispatch(
     bridge_num_inputs: usize,
 ) {
     let cb = RESUMEDATA_DEOPT_FN.get().copied().expect(
-        "RESUMEDATA_DEOPT_FN not registered — pyre-jit's init_callbacks (eval.rs) must call \
+        "RESUMEDATA_DEOPT_FN not registered — the runtime must call \
          register_resumedata_deopt before any guard can fail.",
     );
     // `cranelift_resumedata_deopt` recovers the descr via
@@ -6534,7 +6534,7 @@ fn emit_stack_check_result(
             &[],
             Some(cl_types::I64),
         )
-        .expect("pyre_stack_check_for_jit_prologue must return an i64");
+        .expect("the registered prologue stack-check callback must return an i64");
     }
 
     builder.ins().iconst(cl_types::I64, 0)
@@ -7361,13 +7361,13 @@ fn emit_guard_exit(
     //
     // aarch64 re-verified post-fix (cranelift 0.132): tail_sp_leak.rs has
     // zero drift, nbody_50k matches the reference exactly, and the full
-    // bench suite is correct.  `PYRE_CL_NO_CLOSING_JUMP` is an opt-out
+    // bench suite is correct.  `MAJIT_CL_NO_CLOSING_JUMP` is an opt-out
     // hatch for A/B and rollback.
     if let Some((ll_loop_code_addr, label_block_id_addr, target_frame_depth_addr)) =
         info.external_jump_ll_loop_code_addr
     {
         let enabled = cfg!(any(target_arch = "x86_64", target_arch = "aarch64"))
-            && std::env::var_os("PYRE_CL_NO_CLOSING_JUMP").is_none();
+            && std::env::var_os("MAJIT_CL_NO_CLOSING_JUMP").is_none();
         if enabled {
             emit_attached_loop_dispatch(
                 builder,
@@ -17222,7 +17222,7 @@ impl majit_backend::Backend for CraneliftBackend {
         // External JUMP fallback: the in-code `closing_jump` dispatch
         // (`emit_attached_loop_dispatch`) is on by default for x86_64 and
         // aarch64, but stays off on other arches and whenever
-        // `PYRE_CL_NO_CLOSING_JUMP` is set.  In those cases a guard exit may
+        // `MAJIT_CL_NO_CLOSING_JUMP` is set.  In those cases a guard exit may
         // legitimately surface an `is_external_jump` descr here, and the
         // host loop re-enters the target trace exactly as
         // `execute_with_inputs` (compiler.rs) does.  This block
@@ -17341,7 +17341,7 @@ impl majit_backend::Backend for CraneliftBackend {
             // fail descriptor and continue dispatch, mirroring
             // `execute_with_inputs`.  Reached when in-code `closing_jump` is
             // disabled (non-x86_64/non-aarch64 arch, or
-            // `PYRE_CL_NO_CLOSING_JUMP`); otherwise the JUMP transfers
+            // `MAJIT_CL_NO_CLOSING_JUMP`); otherwise the JUMP transfers
             // entirely inside generated code.
             if fail_descr_fd.is_external_jump() {
                 slice_x2_probe::record_execute_with_inputs_hit();
@@ -24384,9 +24384,9 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "sets the process-global PYRE_CL_NO_CLOSING_JUMP env var to force the \
+    #[ignore = "sets the process-global MAJIT_CL_NO_CLOSING_JUMP env var to force the \
         host-loop external-JUMP path (in-code closing_jump disabled); run serially: \
-        `PYRE_CL_NO_CLOSING_JUMP=1 cargo test -p majit-backend-cranelift \
+        `MAJIT_CL_NO_CLOSING_JUMP=1 cargo test -p majit-backend-cranelift \
         test_host_loop_external_jump_to_middle_label -- --ignored --test-threads=1`"]
     fn test_host_loop_external_jump_to_middle_label_uses_label_selector() {
         // Same scenario as the in-code variant above, but with closing_jump
@@ -24397,7 +24397,7 @@ mod tests {
         // selects the loader (reading the carried value run_compiled_code
         // loaded into slot 0) instead of the preamble — which would re-run
         // the start LABEL and finish 35 instead of 25.
-        unsafe { std::env::set_var("PYRE_CL_NO_CLOSING_JUMP", "1") };
+        unsafe { std::env::set_var("MAJIT_CL_NO_CLOSING_JUMP", "1") };
 
         let mut backend = CraneliftBackend::new();
         let start_descr = make_label_descr(1_500_280);
@@ -24492,16 +24492,16 @@ mod tests {
         let is_finish = backend.get_latest_descr(&frame).is_finish();
         let value = backend.get_int_value(&frame, 0);
 
-        unsafe { std::env::remove_var("PYRE_CL_NO_CLOSING_JUMP") };
+        unsafe { std::env::remove_var("MAJIT_CL_NO_CLOSING_JUMP") };
 
         assert!(is_finish);
         assert_eq!(value, 25);
     }
 
     #[test]
-    #[ignore = "sets the process-global PYRE_CL_NO_CLOSING_JUMP env var to force the \
+    #[ignore = "sets the process-global MAJIT_CL_NO_CLOSING_JUMP env var to force the \
         host-loop external-JUMP path (in-code closing_jump disabled); run serially: \
-        `PYRE_CL_NO_CLOSING_JUMP=1 cargo test -p majit-backend-cranelift \
+        `MAJIT_CL_NO_CLOSING_JUMP=1 cargo test -p majit-backend-cranelift \
         test_host_loop_external_jump_to_first_label -- --ignored --test-threads=1`"]
     fn test_host_loop_external_jump_to_first_label_uses_label_selector() {
         // The first LABEL (`label_block_id` 0) is not special: `closing_jump`
@@ -24514,7 +24514,7 @@ mod tests {
         // LABEL's loader) so the carried value (5) reaches the body verbatim
         // and it finishes 15.  Routing the first LABEL to the preamble (key 0)
         // would re-run the `+1000` and finish 1015 instead.
-        unsafe { std::env::set_var("PYRE_CL_NO_CLOSING_JUMP", "1") };
+        unsafe { std::env::set_var("MAJIT_CL_NO_CLOSING_JUMP", "1") };
 
         let mut backend = CraneliftBackend::new();
         let start_descr = make_label_descr(1_500_290);
@@ -24594,7 +24594,7 @@ mod tests {
         let is_finish = backend.get_latest_descr(&frame).is_finish();
         let value = backend.get_int_value(&frame, 0);
 
-        unsafe { std::env::remove_var("PYRE_CL_NO_CLOSING_JUMP") };
+        unsafe { std::env::remove_var("MAJIT_CL_NO_CLOSING_JUMP") };
 
         assert!(is_finish);
         assert_eq!(value, 15);

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -3130,8 +3130,8 @@ impl<'a> AssemblerARM64<'a> {
                 self.genop_call_with_arglocs(op, arglocs);
             }
             OpCode::CallR => {
-                let is_nursery_alloc = op.with_call_descr(|cd| cd.get_extra_info().pyre_helper)
-                    == Some(majit_ir::PyreHelperKind::NurseryAlloc);
+                let is_nursery_alloc = op.with_call_descr(|cd| cd.get_extra_info().runtime_helper)
+                    == Some(majit_ir::RuntimeHelperKind::NurseryAlloc);
                 if is_nursery_alloc {
                     self.genop_nursery_alloc_inline(op, arglocs);
                 } else {
@@ -4292,7 +4292,7 @@ impl<'a> AssemblerARM64<'a> {
         dynasm!(self.mc ; .arch aarch64 ; =>fail_label);
 
         dynasm!(self.mc ; .arch aarch64 ; bl =>save_regs_label);
-        if std::env::var("PYRE_TRACE_CALL_DIAG")
+        if std::env::var("MAJIT_TRACE_CALL_DIAG")
             .ok()
             .and_then(|value| value.parse::<u64>().ok())
             == Some(self.trace_id)
@@ -5493,7 +5493,7 @@ impl<'a> AssemblerARM64<'a> {
                 self.store_rax_to_result(op.pos.get());
             }
         }
-        if std::env::var("PYRE_TRACE_CALL_DIAG")
+        if std::env::var("MAJIT_TRACE_CALL_DIAG")
             .ok()
             .and_then(|value| value.parse::<u64>().ok())
             == Some(self.trace_id)
@@ -5511,7 +5511,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// Inline nursery bump for a call tagged
-    /// [`majit_ir::PyreHelperKind::NurseryAlloc`].
+    /// [`majit_ir::RuntimeHelperKind::NurseryAlloc`].
     ///
     /// The tag declares a two-word headerless node taken from the
     /// interpreter's own nursery, whose payload is the call's two arguments:

--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -72,20 +72,20 @@ pub fn majit_j2plan_log_enabled() -> bool {
     *ENABLED
 }
 
-/// Whether `PYRE_GC_FREELIST_DIAG` is set, cached at first access.
+/// Whether `MAJIT_GC_FREELIST_DIAG` is set, cached at first access.
 ///
 /// Read once per residual call and twice per compiled-trace entry, so the
 /// uncached form put `getenv` on the hottest paths the backend has.
 pub fn gc_freelist_diag_enabled() -> bool {
     static ENABLED: std::sync::LazyLock<bool> =
-        std::sync::LazyLock::new(|| std::env::var_os("PYRE_GC_FREELIST_DIAG").is_some());
+        std::sync::LazyLock::new(|| std::env::var_os("MAJIT_GC_FREELIST_DIAG").is_some());
     *ENABLED
 }
 
-/// Whether `PYRE_DYNASM_EXEC_DIAG` is set, cached at first access.
+/// Whether `MAJIT_DYNASM_EXEC_DIAG` is set, cached at first access.
 pub fn dynasm_exec_diag_enabled() -> bool {
     static ENABLED: std::sync::LazyLock<bool> =
-        std::sync::LazyLock::new(|| std::env::var_os("PYRE_DYNASM_EXEC_DIAG").is_some());
+        std::sync::LazyLock::new(|| std::env::var_os("MAJIT_DYNASM_EXEC_DIAG").is_some());
     *ENABLED
 }
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -695,9 +695,9 @@ fn debug_validate_oldgen_freeblocks(site: std::fmt::Arguments<'_>) {
 }
 
 pub extern "C" fn dynasm_debug_validate_oldgen_freeblocks(site: u64, frame: usize) {
-    // The call itself is only emitted under `PYRE_TRACE_CALL_DIAG`, which is
+    // The call itself is only emitted under `MAJIT_TRACE_CALL_DIAG`, which is
     // what selects the failure-frame report below. The freelist walk is the
-    // only half `PYRE_GC_FREELIST_DIAG` owns, and it gates itself — so no
+    // only half `MAJIT_GC_FREELIST_DIAG` owns, and it gates itself — so no
     // early return here, or enabling one diagnostic would need the other.
     if site >= 1_000_000 {
         let top = majit_gc::shadow_stack::jf_top_ptr().0;
@@ -2405,7 +2405,7 @@ impl Backend for DynasmBackend {
         // The assembler stores the typed `Const` pool directly; each box
         // variant carries its own type (`Const::get_type`).
         let const_pool = std::mem::take(&mut self.constants);
-        if std::env::var("PYRE_TRACE_OPS_DIAG")
+        if std::env::var("MAJIT_TRACE_OPS_DIAG")
             .ok()
             .and_then(|value| value.parse::<u64>().ok())
             == Some(trace_id)
@@ -2656,7 +2656,7 @@ impl Backend for DynasmBackend {
         // format_trace reads raw `i64` values; the assembler stores the
         // typed `Const` pool directly (type rides on `Const::get_type`).
         let const_pool = std::mem::take(&mut self.constants);
-        let trace_ops_diag = std::env::var("PYRE_TRACE_OPS_DIAG")
+        let trace_ops_diag = std::env::var("MAJIT_TRACE_OPS_DIAG")
             .ok()
             .and_then(|value| value.parse::<u64>().ok())
             == Some(trace_id);

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -4270,8 +4270,8 @@ impl<'a> Assembler386<'a> {
                 self.genop_call_with_arglocs(op, arglocs);
             }
             OpCode::CallR => {
-                let is_nursery_alloc = op.with_call_descr(|cd| cd.get_extra_info().pyre_helper)
-                    == Some(majit_ir::PyreHelperKind::NurseryAlloc);
+                let is_nursery_alloc = op.with_call_descr(|cd| cd.get_extra_info().runtime_helper)
+                    == Some(majit_ir::RuntimeHelperKind::NurseryAlloc);
                 if is_nursery_alloc {
                     self.genop_nursery_alloc_inline_x86(op, arglocs);
                 } else {
@@ -6887,7 +6887,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// Inline nursery bump for a call tagged
-    /// [`majit_ir::PyreHelperKind::NurseryAlloc`].
+    /// [`majit_ir::RuntimeHelperKind::NurseryAlloc`].
     ///
     /// The tag declares a two-word headerless node taken from the
     /// interpreter's own nursery, whose payload is the call's two arguments:

--- a/majit/majit-backend-wasm/src/glue.rs
+++ b/majit/majit-backend-wasm/src/glue.rs
@@ -45,10 +45,10 @@ mod imports {
 
 #[cfg(all(feature = "host-import", not(feature = "web")))]
 mod imports {
-    // Plain wasm imports from the `pyre_jit` module namespace. A native
+    // Plain wasm imports from the `majit_host` module namespace. A native
     // embedder backs these with its own runtime, e.g. `wasmi::Module::new`
     // + `Instance::new` sharing this module's exported linear memory.
-    #[link(wasm_import_module = "pyre_jit")]
+    #[link(wasm_import_module = "majit_host")]
     unsafe extern "C" {
         pub(super) fn jit_compile_wasm(bytes_ptr: u32, bytes_len: u32) -> u32;
         pub(super) fn jit_replace_wasm(func_id: u32, bytes_ptr: u32, bytes_len: u32) -> u32;

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 
 use majit_backend_wasm::codegen;
 use majit_ir::operand::Operand;
-use majit_ir::{EffectInfo, InputArg, Op, OpCode, OpRef, PyreHelperKind, Type};
+use majit_ir::{EffectInfo, InputArg, Op, OpCode, OpRef, RuntimeHelperKind, Type};
 use smallvec::smallvec;
 use wasmi::{Engine, Linker, Memory, MemoryType, Module, Store, Table, TableType, Val, ValType};
 
@@ -2072,20 +2072,20 @@ fn test_call_generates_import() {
 }
 
 fn void_call(arg_types: Vec<Type>, args: &[OpRef], result_size: usize) -> Op {
-    void_call_with_helper(arg_types, args, result_size, PyreHelperKind::None)
+    void_call_with_helper(arg_types, args, result_size, RuntimeHelperKind::None)
 }
 
 fn void_call_with_helper(
     arg_types: Vec<Type>,
     args: &[OpRef],
     result_size: usize,
-    helper: PyreHelperKind,
+    helper: RuntimeHelperKind,
 ) -> Op {
     let mut operands = vec![rb(OpRef::const_int(42))];
     operands.extend(args.iter().copied().map(rb));
     let op = Op::new(OpCode::CallN, &operands);
     let effect = EffectInfo {
-        pyre_helper: helper,
+        runtime_helper: helper,
         ..EffectInfo::default()
     };
     op.setdescr(majit_ir::descr::make_call_descr_full(
@@ -2331,7 +2331,7 @@ fn test_list_append_word_abi_and_new_type_indices_match_declared_i64_types() {
             vec![Type::Ref, Type::Ref],
             &[OpRef::input_arg_ref(0), OpRef::input_arg_ref(1)],
             8,
-            PyreHelperKind::ListAppendValue,
+            RuntimeHelperKind::ListAppendValue,
         ),
         new_op,
         Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(2))]),

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -3090,7 +3090,7 @@ impl MiniMarkGC {
     /// [`Self::mark_c_edges`], rather than assumed here.
     fn rrc_roots_link(&self, pyobject: usize) -> bool {
         let rc = unsafe { (*rawrefcount::pyobj(pyobject)).ob_refcnt };
-        let held = rc - rawrefcount::REFCNT_FROM_PYRE;
+        let held = rc - rawrefcount::REFCNT_FROM_PYPY;
         held > self.rrc.c_discount.get(&pyobject).copied().unwrap_or(0)
     }
 
@@ -3333,10 +3333,10 @@ impl MiniMarkGC {
     /// the nursery; there is no young raw-malloc region here, so the two
     /// questions collapse into one and the third combination cannot arise.
     ///
-    /// The caller must already have added [`rawrefcount::REFCNT_FROM_PYRE`] to
+    /// The caller must already have added [`rawrefcount::REFCNT_FROM_PYPY`] to
     /// the mirror's count: that share is what this link is worth, and what
     /// [`Self::_rrc_free`] gives back when the object dies.
-    pub fn rawrefcount_create_link_pyre(&mut self, obj: usize, pyobject: usize) {
+    pub fn rawrefcount_create_link_pypy(&mut self, obj: usize, pyobject: usize) {
         debug_assert!(self.rrc.enabled, "rawrefcount.init not called");
         unsafe { (*rawrefcount::pyobj(pyobject)).ob_link = obj };
         if self.is_in_nursery(obj) {
@@ -3543,10 +3543,10 @@ impl MiniMarkGC {
             "an immortal mirror reached the rawrefcount free pass"
         );
         debug_assert!(
-            rc >= rawrefcount::REFCNT_FROM_PYRE,
+            rc >= rawrefcount::REFCNT_FROM_PYPY,
             "rawrefcount refcount underflow"
         );
-        rc -= rawrefcount::REFCNT_FROM_PYRE;
+        rc -= rawrefcount::REFCNT_FROM_PYPY;
         unsafe { (*header).ob_link = 0 };
         if rc == 0 {
             // incminimark.py:3339-3349 — a mirror at count 0 cannot sit and
@@ -8113,8 +8113,8 @@ mod tests {
     /// concurrently built collector cannot see this table.
     #[test]
     fn supplied_env_fills_in_only_what_the_process_lacks() {
-        let absent = "PYRE_TEST_SUPPLIED_ENV_ABSENT";
-        let present = "PYRE_TEST_SUPPLIED_ENV_PRESENT";
+        let absent = "MAJIT_TEST_SUPPLIED_ENV_ABSENT";
+        let present = "MAJIT_TEST_SUPPLIED_ENV_PRESENT";
         // SAFETY: single-threaded within this test; the names are unique to it.
         unsafe { std::env::set_var(present, "2m") };
 
@@ -13230,8 +13230,8 @@ cache size\t: 8192 kB\n";
         let object = gc.alloc_with_type(tid, 64);
         assert!(gc.is_in_nursery(object.0), "premise: the object is young");
 
-        let mirror = test_mirror(rawrefcount::REFCNT_FROM_PYRE + 1);
-        gc.rawrefcount_create_link_pyre(object.0, mirror);
+        let mirror = test_mirror(rawrefcount::REFCNT_FROM_PYPY + 1);
+        gc.rawrefcount_create_link_pypy(object.0, mirror);
         assert_eq!(gc.rawrefcount_from_obj(object.0), mirror);
 
         gc.do_collect_nursery();
@@ -13254,8 +13254,8 @@ cache size\t: 8192 kB\n";
         let mut gc = rrc_test_gc();
         let tid = gc.register_type(TypeInfo::object(64));
         let object = gc.alloc_with_type(tid, 64);
-        let mirror = test_mirror(rawrefcount::REFCNT_FROM_PYRE);
-        gc.rawrefcount_create_link_pyre(object.0, mirror);
+        let mirror = test_mirror(rawrefcount::REFCNT_FROM_PYPY);
+        gc.rawrefcount_create_link_pypy(object.0, mirror);
 
         RRC_TRIGGER_FIRED.with(|fired| fired.set(0));
         gc.do_collect_nursery();
@@ -13286,10 +13286,10 @@ cache size\t: 8192 kB\n";
         let dying = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + 64);
         assert!(!gc.is_in_nursery(kept.0) && !gc.is_in_nursery(dying.0));
 
-        let kept_mirror = test_mirror(rawrefcount::REFCNT_FROM_PYRE + 1);
-        let dying_mirror = test_mirror(rawrefcount::REFCNT_FROM_PYRE);
-        gc.rawrefcount_create_link_pyre(kept.0, kept_mirror);
-        gc.rawrefcount_create_link_pyre(dying.0, dying_mirror);
+        let kept_mirror = test_mirror(rawrefcount::REFCNT_FROM_PYPY + 1);
+        let dying_mirror = test_mirror(rawrefcount::REFCNT_FROM_PYPY);
+        gc.rawrefcount_create_link_pypy(kept.0, kept_mirror);
+        gc.rawrefcount_create_link_pypy(dying.0, dying_mirror);
         unsafe { gc.roots.add(&mut kept) };
 
         gc.do_collect_full();
@@ -13319,8 +13319,8 @@ cache size\t: 8192 kB\n";
         // Pinning does not root: something must still reach it this collection.
         unsafe { gc.roots.add(&mut object) };
 
-        let mirror = test_mirror(rawrefcount::REFCNT_FROM_PYRE + 1);
-        gc.rawrefcount_create_link_pyre(object.0, mirror);
+        let mirror = test_mirror(rawrefcount::REFCNT_FROM_PYPY + 1);
+        gc.rawrefcount_create_link_pypy(object.0, mirror);
 
         gc.do_collect_nursery();
 
@@ -13349,8 +13349,8 @@ cache size\t: 8192 kB\n";
         let mut gc = rrc_test_gc();
         let tid = gc.register_type(TypeInfo::object(64));
         let object = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + 64);
-        let mirror = test_mirror(rawrefcount::REFCNT_FROM_PYRE + 1);
-        gc.rawrefcount_create_link_pyre(object.0, mirror);
+        let mirror = test_mirror(rawrefcount::REFCNT_FROM_PYPY + 1);
+        gc.rawrefcount_create_link_pypy(object.0, mirror);
 
         let marker = 0x0DEA_DFFF_usize;
         gc.rawrefcount_mark_deallocating(marker, mirror);
@@ -13380,15 +13380,15 @@ cache size\t: 8192 kB\n";
             // nowhere else; the nursery object is reachable from the mirror
             // and from nowhere else.
             unsafe { *(young.0 as *mut GcRef) = old };
-            gc.rawrefcount_create_link_pyre(young.0, test_mirror(mirror_refcnt));
+            gc.rawrefcount_create_link_pypy(young.0, test_mirror(mirror_refcnt));
 
             gc.do_collect_oldgen_nonmoving();
             assert_eq!(gc.rawrefcount_next_dead(), 0, "the nursery is not swept");
             gc.get_total_memory_used()
         }
 
-        let referenced = survivors_with(rawrefcount::REFCNT_FROM_PYRE + 1);
-        let unreferenced = survivors_with(rawrefcount::REFCNT_FROM_PYRE);
+        let referenced = survivors_with(rawrefcount::REFCNT_FROM_PYPY + 1);
+        let unreferenced = survivors_with(rawrefcount::REFCNT_FROM_PYPY);
         assert!(
             referenced > unreferenced,
             "the old object was swept out from under a live C reference \

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -346,7 +346,7 @@ pub struct BlockingGuard {
 /// instruction (`entrypoint.c:78 _RPyGilAcquire`). Takes the GIL back and
 /// rejoins the RUNNING census for as long as the guard lives, then gives both
 /// back so the outward call's `BlockingGuard` finds the state it left.
-#[must_use = "pyre may only run for as long as the guard is alive"]
+#[must_use = "managed runtime code may only run while the guard is alive"]
 pub struct CallbackGuard {
     rejoined: bool,
     took_gil: bool,

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -3135,10 +3135,10 @@ pub fn gc_rawrefcount_set_finalizer_claim(claim: rawrefcount::FinalizerClaimFn) 
 /// `obj` owns it: the mirror lives as long as the interpreter object does, plus
 /// as long afterwards as the C side still holds a reference.
 ///
-/// The caller must already have added [`rawrefcount::REFCNT_FROM_PYRE`] to the
+/// The caller must already have added [`rawrefcount::REFCNT_FROM_PYPY`] to the
 /// mirror's count; that share is what this link is worth.
-pub fn gc_rawrefcount_create_link_pyre(obj: GcRef, pyobject: usize) {
-    gc_sync::gc_op(|gc| gc.rawrefcount_create_link_pyre(obj.0, pyobject));
+pub fn gc_rawrefcount_create_link_pypy(obj: GcRef, pyobject: usize) {
+    gc_sync::gc_op(|gc| gc.rawrefcount_create_link_pypy(obj.0, pyobject));
 }
 
 /// `rawrefcount.py:create_link_pyobj` — the other direction: `pyobject` owns

--- a/majit/majit-gc/src/minimarkpage.rs
+++ b/majit/majit-gc/src/minimarkpage.rs
@@ -519,7 +519,7 @@ impl ArenaCollection {
     unsafe fn free_arena(&mut self, arena: *mut ArenaReference) {
         unsafe {
             let base = (*arena).base as usize;
-            if std::env::var_os("PYRE_GC_FREELIST_DIAG").is_some() {
+            if std::env::var_os("MAJIT_GC_FREELIST_DIAG").is_some() {
                 let end = base + (*arena).layout.size();
                 for size_class in 1..self.page_for_size.len() {
                     for (kind, mut page) in [

--- a/majit/majit-gc/src/rawrefcount.rs
+++ b/majit/majit-gc/src/rawrefcount.rs
@@ -26,11 +26,11 @@ use crate::address_dict::AddressMap;
 /// A mirror whose count is exactly this is referenced by nothing except the
 /// link, so the collector is free to let the linked object die.  Every count
 /// above it is a reference the C side holds.
-pub const REFCNT_FROM_PYRE: isize = (isize::MAX >> 2) + 1;
+pub const REFCNT_FROM_PYPY: isize = (isize::MAX >> 2) + 1;
 
 /// The count a mirror that must never be freed starts at.
 ///
-/// `rawrefcount.py:16-20` has two constants above [`REFCNT_FROM_PYRE`]:
+/// `rawrefcount.py:16-20` has two constants above [`REFCNT_FROM_PYPY`]:
 /// `REFCNT_FROM_PYPY_LIGHT`, for a mirror whose deallocation is a plain free
 /// with no deallocator to run, and `_Py_IMMORTAL_REFCNT`, for one that is never
 /// deallocated at all.  Only the second has a port — nothing here creates a
@@ -40,10 +40,10 @@ pub const REFCNT_FROM_PYRE: isize = (isize::MAX >> 2) + 1;
 /// constant: the asserts below hold it at least `1 << 60` clear of the
 /// threshold at which a mirror is freed, and the same clear of overflow, so no
 /// incref/decref imbalance a running process can produce reaches either end.
-pub const REFCNT_IMMORTAL: isize = REFCNT_FROM_PYRE + (1 << (isize::BITS - 4));
+pub const REFCNT_IMMORTAL: isize = REFCNT_FROM_PYPY + (1 << (isize::BITS - 4));
 
 const IMMORTAL_HEADROOM: isize = 1 << (isize::BITS - 4);
-const _: () = assert!(REFCNT_IMMORTAL - REFCNT_FROM_PYRE >= IMMORTAL_HEADROOM);
+const _: () = assert!(REFCNT_IMMORTAL - REFCNT_FROM_PYPY >= IMMORTAL_HEADROOM);
 const _: () = assert!(isize::MAX - REFCNT_IMMORTAL >= IMMORTAL_HEADROOM);
 
 /// Scheduled when the dead queue becomes non-empty.
@@ -148,7 +148,7 @@ pub type FinalizerClaimFn = fn(usize) -> bool;
 /// Answers with every block whose references the embedder can enumerate, and
 /// what each one references.
 ///
-/// A mirror's count above [`REFCNT_FROM_PYRE`] otherwise means "C still holds
+/// A mirror's count above [`REFCNT_FROM_PYPY`] otherwise means "C still holds
 /// the linked object", which a reference cycle through C defeats: the two ends
 /// of the cycle hold each other, so each reads as externally held and neither
 /// side's collector can see it.  The edges are what makes the difference
@@ -173,10 +173,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn refcnt_from_pyre_is_maxint_over_four_plus_one() {
+    fn refcnt_from_pypy_is_maxint_over_four_plus_one() {
         // rawrefcount.py:15, on a 64-bit host.
-        assert_eq!(REFCNT_FROM_PYRE, (isize::MAX / 4) + 1);
-        assert_eq!(REFCNT_FROM_PYRE, 1 << (isize::BITS - 3));
+        assert_eq!(REFCNT_FROM_PYPY, (isize::MAX / 4) + 1);
+        assert_eq!(REFCNT_FROM_PYPY, 1 << (isize::BITS - 3));
     }
 
     #[test]

--- a/majit/majit-gc/src/trace.rs
+++ b/majit/majit-gc/src/trace.rs
@@ -1121,13 +1121,13 @@ impl TypeRegistry {
             if info.item_size == 0 {
                 let _ = writeln!(
                     text,
-                    "member{member:<4} GcStruct pyre_type_{type_id} {{ size={}, gcptr_offsets={:?} }}",
+                    "member{member:<4} GcStruct gc_type_{type_id} {{ size={}, gcptr_offsets={:?} }}",
                     info.size, info.gc_ptr_offsets,
                 );
             } else {
                 let _ = writeln!(
                     text,
-                    "member{member:<4} GcArray pyre_type_{type_id} {{ base_size={}, item_size={}, gcptr_offsets={:?} }}",
+                    "member{member:<4} GcArray gc_type_{type_id} {{ base_size={}, item_size={}, gcptr_offsets={:?} }}",
                     info.size, info.item_size, info.gc_ptr_offsets,
                 );
             }

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -615,13 +615,13 @@ pub fn strip_instantiation_suffix(name: &str) -> &str {
 
 /// Whether `spelling` is a list-shaped container type (`Vec<T>`,
 /// `VecDeque<T>`, `&[T]`, `[T; N]`) that the annotator's
-/// `project_pyre_field_type` maps to a `SomeList` element model rather
+/// `project_struct_field_type` maps to a `SomeList` element model rather
 /// than a class instance.  The named-ADT root resolver
 /// (`adt_node_class_root`) answers `None` for the core/std/alloc
 /// container family, so a list-typed parameter would otherwise seed the
 /// classdef-less `SomeInstance(None)` shell; this recognizer lets the
 /// parameter seam route it through the list model instead.  Mirrors the
-/// `Vec<` / `[` arms of `project_pyre_field_type`.
+/// `Vec<` / `[` arms of `project_struct_field_type`.
 pub fn is_list_container_spelling(spelling: &str) -> bool {
     let stripped = spelling
         .trim()
@@ -893,7 +893,7 @@ static FIELD_UNRESOLVED_NAMES: std::sync::Mutex<
 ///
 /// The COUNT (`field_pos_unresolved`) is ungated and always accurate; only the
 /// names cost anything, so they sit behind a knob like
-/// `PYRE_SIZE_SHELL_OWNERS`. Read through this one function so the variable has
+/// `MAJIT_SIZE_SHELL_OWNERS`. Read through this one function so the variable has
 /// exactly one spelling in-tree — the collector lives here and the printer
 /// lives in `pyre-jit-trace`, and two independently-checked names would let the
 /// printer report "nothing unresolved" from a run that never recorded.

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -355,7 +355,7 @@ impl Clone for EffectInfoCell {
 /// would have to duplicate all six raw descriptor sets to find the cell it
 /// replaces.
 ///
-/// The key is `EffectInfo` equality, which carries `pyre_helper`.  Upstream has
+/// The key is `EffectInfo` equality, which carries `runtime_helper`.  Upstream has
 /// no such field, and it must stay in: the walker matches a helper by that tag
 /// on the descr's EffectInfo because it cannot match by fnaddr (`pyre-jit`'s
 /// `flatten.rs`), so two helpers with identical effect sets but different tags
@@ -541,7 +541,7 @@ pub struct EffectInfo {
     /// would break the `_OS_CANRAISE` invariant for the CanRaise members.
     /// `None` for every ordinary call, so `has_oopspec()` and the OS_* universe
     /// stay identical to upstream.
-    pub pyre_helper: PyreHelperKind,
+    pub runtime_helper: RuntimeHelperKind,
     // ── effectinfo.py:128-145 raw descr sets ──
     //
     // PyPy stores `_readonly_descrs_fields: frozenset[Descr]` (and the
@@ -638,7 +638,7 @@ impl PartialEq for EffectInfo {
     fn eq(&self, other: &Self) -> bool {
         self.extraeffect == other.extraeffect
             && self.oopspecindex == other.oopspecindex
-            && self.pyre_helper == other.pyre_helper
+            && self.runtime_helper == other.runtime_helper
             && descr_set_eq(
                 &self._readonly_descrs_fields,
                 &other._readonly_descrs_fields,
@@ -674,7 +674,7 @@ impl std::hash::Hash for EffectInfo {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.extraeffect.hash(state);
         self.oopspecindex.hash(state);
-        self.pyre_helper.hash(state);
+        self.runtime_helper.hash(state);
         descr_set_hash(&self._readonly_descrs_fields, state);
         descr_set_hash(&self._write_descrs_fields, state);
         descr_set_hash(&self._readonly_descrs_arrays, state);
@@ -692,7 +692,7 @@ impl Default for EffectInfo {
         EffectInfo {
             extraeffect: ExtraEffect::CanRaise,
             oopspecindex: OopSpecIndex::None,
-            pyre_helper: PyreHelperKind::None,
+            runtime_helper: RuntimeHelperKind::None,
             // effectinfo.py frozenset_or_none: empty frozenset for
             // a non-random-effects EI with no field/array touches yet.
             _readonly_descrs_fields: Some(Vec::new()),
@@ -850,7 +850,7 @@ pub enum OopSpecIndex {
 /// its siblings rather than appending it.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
 #[repr(u8)]
-pub enum PyreHelperKind {
+pub enum RuntimeHelperKind {
     #[default]
     None,
     BinaryOp,
@@ -864,7 +864,7 @@ pub enum PyreHelperKind {
     /// The full-body walker recognises this tag to fold a module-scope name
     /// read (frame's `w_locals_object` is null, so `w_locals` aliases
     /// `w_globals`) through the same module-dict cell fast path as
-    /// [`PyreHelperKind::LoadGlobal`], eliding the per-iteration residual.
+    /// [`RuntimeHelperKind::LoadGlobal`], eliding the per-iteration residual.
     LoadName,
     /// `bh_store_name_fn(frame, w_name, value)` — the STORE_NAME frame-receiver
     /// helper (`pyopcode.py:855-859`, delegates to `store_name_value` →
@@ -873,12 +873,12 @@ pub enum PyreHelperKind {
     /// module-scope int store whose slot holds an `IntMutableCell` (the
     /// stabilised in-place shape) to a `setfield_gc_i(cell, intvalue)`,
     /// eliding the boxing + residual dict setitem — the store dual of
-    /// [`PyreHelperKind::LoadName`].
+    /// [`RuntimeHelperKind::LoadName`].
     StoreName,
     /// `bh_store_global_fn(frame, w_name, value)` — the STORE_GLOBAL
     /// frame-receiver helper (`pyopcode.py:567`, delegates to
     /// `store_global_value`).  Recognised for the same `IntMutableCell`
-    /// in-place store fold as [`PyreHelperKind::StoreName`].
+    /// in-place store fold as [`RuntimeHelperKind::StoreName`].
     StoreGlobal,
     /// `bh_delete_name_fn(frame, w_name)` — the DELETE_NAME frame-receiver
     /// helper (`pyopcode.py:869-880`, delegates to `delitem_str`).  Recognised
@@ -890,7 +890,7 @@ pub enum PyreHelperKind {
     /// meets the rtyper operation and has to ask before executing.
     DeleteName,
     /// `bh_delete_global_fn(frame, w_name)` — the DELETE_GLOBAL twin of
-    /// [`PyreHelperKind::DeleteName`], recognised for the same reason.
+    /// [`RuntimeHelperKind::DeleteName`], recognised for the same reason.
     DeleteGlobal,
     /// `bh_load_locals_fn(frame)` — the LOAD_LOCALS frame-receiver helper
     /// (`pyopcode.py:793-794`). Carries no fold; the tag exists so the class
@@ -899,15 +899,15 @@ pub enum PyreHelperKind {
     LoadLocals,
     /// `bh_load_build_class_fn(frame)` — the LOAD_BUILD_CLASS frame-receiver
     /// helper (`pyopcode.py:866-870`). Same standing as
-    /// [`PyreHelperKind::LoadLocals`].
+    /// [`RuntimeHelperKind::LoadLocals`].
     LoadBuildClass,
     /// `bh_load_import_fn(frame)` — the builtin lookup half of IMPORT_NAME.
-    /// The following invocation is emitted through [`PyreHelperKind::CallFn`]
+    /// The following invocation is emitted through [`RuntimeHelperKind::CallFn`]
     /// so gateway builtins retain their ordinary meta-traceable call shape.
     LoadImport,
     /// `bh_load_import_locals_fn(frame)` — IMPORT_NAME's locals argument
     /// (`pyopcode.py`'s `IMPORT_NAME`).  Infallible, same standing as
-    /// [`PyreHelperKind::LoadLocals`].
+    /// [`RuntimeHelperKind::LoadLocals`].
     LoadImportLocals,
     /// `bh_call_fn_N(callable, null_or_self, args...)` — the CALL-family
     /// Python-call helper.  `null_or_self` (arg index 1) is a sentinel
@@ -951,7 +951,7 @@ pub enum PyreHelperKind {
     /// length and returns the normalized tuple.  The full-body walker
     /// recognises this tag to fold an arity-2 specialised int tuple to a
     /// `guard_class` + pass-through, eliding the opaque residual so the
-    /// partner [`PyreHelperKind::UnpackItem`] reads fold against it.
+    /// partner [`RuntimeHelperKind::UnpackItem`] reads fold against it.
     UnpackSequence,
     /// `bh_unpack_item_fn(index, tuple)` — the per-index UNPACK_SEQUENCE item
     /// reader.  The full-body walker recognises this tag to read `value0` /
@@ -965,7 +965,7 @@ pub enum PyreHelperKind {
     /// virtualize an arity-2 plain-int tuple as a `spec_ii`
     /// `new_with_vtable` + `value0` / `value1` (mirroring the retired
     /// trace-side tuple builder), so the backing array build and the
-    /// partner [`PyreHelperKind::UnpackItem`] reads DCE to a pure-int loop.
+    /// partner [`RuntimeHelperKind::UnpackItem`] reads DCE to a pure-int loop.
     NewtupleFromArray,
     /// `newlist_from_array(array)` — the BUILD_LIST array consumer that
     /// `lower_tuple_build_hlop_to_insn` emits after `new_array_clear` +
@@ -976,7 +976,7 @@ pub enum PyreHelperKind {
     /// from the concrete element shadows the way `w_list_new` /
     /// `list_strategy_for` does at runtime, so the array build and the
     /// residual DCE when the list never escapes.  Unlike
-    /// [`PyreHelperKind::NewtupleFromArray`], the element boxes are
+    /// [`RuntimeHelperKind::NewtupleFromArray`], the element boxes are
     /// recovered from the backing array (const length + per-index element
     /// shadows) rather than from residual args.
     NewlistFromArray,
@@ -1047,7 +1047,7 @@ pub enum PyreHelperKind {
     /// operands are the peeked target list and the popped value; the result
     /// is void.  The full-body walker recognises this tag to fold the append
     /// through the same orthodox `w_list_append` descent as the method-call
-    /// form ([`PyreHelperKind::CallFn`] `lst.append(x)`), recording the
+    /// form ([`RuntimeHelperKind::CallFn`] `lst.append(x)`), recording the
     /// native array store instead of the opaque `jit_list_append` residual.
     /// The recognition has no bound-method callable to pin: the list and
     /// value arrive directly as the residual's Ref operands.
@@ -1117,7 +1117,7 @@ pub enum PyreHelperKind {
     LoadMethodSelf,
     /// `bh_delete_attr_fn(obj, code, name_idx)` — the plain DELETE_ATTR
     /// residual (`lower_delete_attr_hlop_to_insn` → `space.delattr`), the
-    /// deletion counterpart of [`StoreAttr`](PyreHelperKind::StoreAttr).
+    /// deletion counterpart of [`StoreAttr`](RuntimeHelperKind::StoreAttr).
     /// The full-body walker recognises this tag to fold the deterministic
     /// immutable-type raise (`del int.x` → TypeError before any dict
     /// access) to a traced inline exception construction the optimizer
@@ -1146,7 +1146,7 @@ pub enum PyreHelperKind {
     /// a traced `s.add(x)` on a `set` (`try_walker_specialize_set_add_method`).
     /// It inserts into the live set and RETURNS `None` (`Ref`), so it is a
     /// value-returning heap write the `Void`-result write proxy cannot see —
-    /// the same standing as [`PyreHelperKind::StoreDeref`], and the reason the
+    /// the same standing as [`RuntimeHelperKind::StoreDeref`], and the reason the
     /// tag exists: without it the substitution would replace a `CallFn` the
     /// `writes_live_heap` discriminator counts with a descr it does not, and a
     /// nested abort would rewind past a completed insert.  The element's
@@ -1229,7 +1229,7 @@ impl EffectInfo {
         EffectInfo {
             extraeffect,
             oopspecindex,
-            pyre_helper: PyreHelperKind::None,
+            runtime_helper: RuntimeHelperKind::None,
             _readonly_descrs_fields: Some(Vec::new()),
             _write_descrs_fields: Some(Vec::new()),
             _readonly_descrs_arrays: Some(Vec::new()),
@@ -1292,7 +1292,7 @@ impl EffectInfo {
     pub const MOST_GENERAL: EffectInfo = EffectInfo {
         extraeffect: ExtraEffect::RandomEffects,
         oopspecindex: OopSpecIndex::None,
-        pyre_helper: PyreHelperKind::None,
+        runtime_helper: RuntimeHelperKind::None,
         _readonly_descrs_fields: None,
         _write_descrs_fields: None,
         _readonly_descrs_arrays: None,
@@ -1684,7 +1684,7 @@ struct EiCanonKey {
 struct FrozenEiCanonKey {
     extraeffect: ExtraEffect,
     oopspecindex: u16,
-    pyre_helper: u8,
+    runtime_helper: u8,
     descr_set_keys: Option<DescrSetKeys>,
     can_invalidate: bool,
     can_collect: bool,
@@ -1696,7 +1696,7 @@ impl FrozenEiCanonKey {
         Self {
             extraeffect: ei.extraeffect,
             oopspecindex: ei.oopspecindex as u16,
-            pyre_helper: ei.pyre_helper as u8,
+            runtime_helper: ei.runtime_helper as u8,
             descr_set_keys: ei.descr_set_keys.as_deref().cloned(),
             can_invalidate: ei.can_invalidate,
             can_collect: ei.can_collect,

--- a/majit/majit-ir/src/lib.rs
+++ b/majit/majit-ir/src/lib.rs
@@ -40,8 +40,8 @@ pub use descr::{
     make_vtable_field_descr, memcpy_fn_addr, recover_fail_descr_cell, unpack_fielddescr,
 };
 pub use effectinfo::{
-    CallInfoCollection, EffectInfo, ExtraEffect, OopSpecIndex, PyreHelperKind, UnsupportedFieldExc,
-    consider_array, consider_struct, frozenset_or_none,
+    CallInfoCollection, EffectInfo, ExtraEffect, OopSpecIndex, RuntimeHelperKind,
+    UnsupportedFieldExc, consider_array, consider_struct, frozenset_or_none,
 };
 pub use indexmap_ext::{ConstMap, IndexMapExt};
 pub use op_type_index::OpTypeIndex;

--- a/majit/majit-ir/tests/green_key_str_content_equality.rs
+++ b/majit/majit-ir/tests/green_key_str_content_equality.rs
@@ -32,7 +32,7 @@ use std::sync::Once;
 /// `default_unicode_hash`.  `OnceLock`-backed setters are
 /// init-once, so the first registration wins regardless of test
 /// ordering.
-fn ensure_pyre_resolvers() {
+fn ensure_resolvers() {
     static INIT: Once = Once::new();
     INIT.call_once(|| {
         set_str_resolver(default_str_eq, default_str_hash);
@@ -42,7 +42,7 @@ fn ensure_pyre_resolvers() {
 
 #[test]
 fn str_greens_compare_by_content() {
-    ensure_pyre_resolvers();
+    ensure_resolvers();
     let s1: &str = "hello";
     // Distinct backing &str slot (different stack allocation), same content.
     let owned = String::from("hello");
@@ -94,7 +94,7 @@ fn rpython_ll_strhash_reference(s: &str) -> u64 {
 
 #[test]
 fn str_greens_hash_by_content() {
-    ensure_pyre_resolvers();
+    ensure_resolvers();
     let s1: &str = "match-me";
     let owned = String::from("match-me");
     let s2: &str = owned.as_str();
@@ -127,7 +127,7 @@ fn str_greens_hash_by_content() {
 /// `default_str_hash` must surface the same sentinel rather than `0`.
 #[test]
 fn str_green_empty_hashes_to_minus_one_per_rpython() {
-    ensure_pyre_resolvers();
+    ensure_resolvers();
     let s: &str = "";
     let p = (&s) as *const _ as usize as i64;
     let h = hash_whatever(GreenType::Str, p);
@@ -141,7 +141,7 @@ fn str_green_empty_hashes_to_minus_one_per_rpython() {
 
 #[test]
 fn distinct_content_str_greens_are_unequal() {
-    ensure_pyre_resolvers();
+    ensure_resolvers();
     let s1: &str = "foo";
     let s2: &str = "bar";
     let p1 = (&s1) as *const _ as usize as i64;
@@ -167,7 +167,7 @@ fn distinct_content_str_greens_are_unequal() {
 #[test]
 fn make_str_slot_decodes_via_default_str_eq() {
     use majit_ir::make_str_slot;
-    ensure_pyre_resolvers();
+    ensure_resolvers();
     let p_macro_emitted = make_str_slot("decoded-content");
     let owned = String::from("decoded-content");
     let s_local: &str = owned.as_str();

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -66,7 +66,7 @@ pub(super) fn struct_type_id_tokens(path: &syn::Path, is_gc_managed: bool) -> To
                 .collect::<Vec<_>>()
                 .join("::");
             return quote! {
-                majit_metainterp::__pyre_struct_type_id_path(
+                majit_metainterp::__majit_struct_type_id_path(
                     module_path!(),
                     #type_path,
                     #is_gc_managed,
@@ -93,7 +93,7 @@ pub(super) fn struct_type_id_tokens(path: &syn::Path, is_gc_managed: bool) -> To
         let type_id = hasher.finish();
         quote! { #type_id }
     } else {
-        quote! { majit_metainterp::__pyre_struct_type_id::<#path>(#is_gc_managed) }
+        quote! { majit_metainterp::__majit_struct_type_id::<#path>(#is_gc_managed) }
     }
 }
 

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -630,7 +630,7 @@ pub(crate) enum CallPolicyKind {
     ElidableIntOrMemerrorWrapped,
     ResidualRef,
     /// Like `ResidualRef` but stamps the descr EffectInfo with
-    /// `PyreHelperKind::NurseryAlloc`, which the backend lowers to an inline
+    /// `RuntimeHelperKind::NurseryAlloc`, which the backend lowers to an inline
     /// nursery bump. Result is a
     /// real escaping Ref — no virtualization.
     NurseryAllocRef,

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -562,7 +562,7 @@ impl BlackholeInterpreter {
 
     /// Spawn a fresh interpreter that shares `parent`'s builder-context
     /// fields (cpu, descrs, op_*, dispatch_table).  Used by
-    /// `handler_inline_call_pyre_nested` for the callee frame of an
+    /// `handler_inline_call_nested_ext` for the callee frame of an
     /// inline-call: a recursive `BlackholeInterpreter` rather than
     /// `BlackholeInterpBuilder::acquire_interp` to avoid re-entering the
     /// thread-local builder pool already lent to the caller.
@@ -584,7 +584,7 @@ impl BlackholeInterpreter {
     /// Copy the builder-shared context fields from `parent` onto `self`.
     /// Mirrors `BlackholeInterpBuilder::acquire_interp` in this file
     /// — the same 6 fields that builder→interp normally propagates.
-    /// Used by `handler_inline_call_pyre_nested` to give the callee
+    /// Used by `handler_inline_call_nested_ext` to give the callee
     /// `BlackholeInterpreter` the same `dispatch_table` (so a nested
     /// `BC_INLINE_CALL` byte routes through the same handler) plus the
     /// CPU/descrs/op_* slots the wired handlers would consult.  pyre-only:
@@ -1373,7 +1373,7 @@ impl BlackholeInterpreter {
         // Take the exception into this frame's walked slot before anything
         // below can allocate.  `record` builds a traceback node, and on the
         // inline-callee path this slot is the exception's ONLY root at that
-        // moment: `handler_inline_call_pyre_nested` reads
+        // moment: `handler_inline_call_nested_ext` reads
         // `callee.exception_last_value` after `callee.run()` returned, which
         // popped the callee's `push_bh_regs` entry, and a callee-local `raise`
         // never went through `BH_LAST_EXC_VALUE`.  Exception objects do not
@@ -2314,7 +2314,7 @@ impl BlackholeInterpBuilder {
             // `blackhole.py` `assert self._insns[value] is None`:
             // every byte slot is filled exactly once across the
             // forward map.  Pyre's `wellknown_bh_insns` +
-            // `pyre_extension_insns` + `pipeline.insns` union must
+            // `extension_insns` + `pipeline.insns` union must
             // not insert two distinct keys at the same byte.  Empty
             // gaps between sparse `BC_*` constants stay
             // `String::new()` and surface as the unwired-handler
@@ -3737,7 +3737,7 @@ mod tests {
         /// `int/ref/float_guard_value`, etc.) now push 1-byte register
         /// operands matching the canonical `bhhandler_*` decoders, so
         /// every key here is the upstream-canonical opname/argcodes
-        /// pair (no `_pyre_u16` suffix).
+        /// pair (no `_u16_ext` suffix).
         fn build_test_bh_builder() -> BlackholeInterpBuilder {
             use majit_translate::insns;
             let mut builder = BlackholeInterpBuilder::new();
@@ -4286,7 +4286,7 @@ mod tests {
             b.inline_call_ir_i(sub_idx, &[(0, 0)], &[], Some(1));
             let jitcode = b.finish();
 
-            // route through `handler_inline_call_pyre_nested`
+            // route through `handler_inline_call_nested_ext`
             // (the production builder shape) so this test exercises the
             // same path as the production blackhole resume.
             let mut builder = super::build_inline_call_only_bh_builder();
@@ -4640,7 +4640,7 @@ mod tests {
         }
 
         /// Tier 2.1: ref-typed return propagation through
-        /// `handler_inline_call_pyre_nested`.  Sub-jitcode is the ref
+        /// `handler_inline_call_nested_ext`.  Sub-jitcode is the ref
         /// identity (passes its ref arg through and `ref_return`s it);
         /// caller passes a non-trivial constant ref and verifies the
         /// caller-side ref dst slot received the same word.
@@ -4850,7 +4850,7 @@ mod tests {
         ///
         /// The recorder allocates, and on this path — a `raise` inside an
         /// inlined callee, caught by the caller — that slot is the exception's
-        /// only root: `handler_inline_call_pyre_nested` reads
+        /// only root: `handler_inline_call_nested_ext` reads
         /// `callee.exception_last_value` after `callee.run()` popped the
         /// callee's `push_bh_regs` entry, and a callee-local raise never went
         /// through `BH_LAST_EXC_VALUE`.  Exceptions do not move but old gen is
@@ -5011,10 +5011,10 @@ mod tests {
         /// Tier 2.3: callee `abort/` propagates aborted=true.
         /// callee shares the parent's dispatch_table, so
         /// byte `BC_ABORT` fires the wired handler
-        /// (`handler_abort_marker_pyre`), which sets `aborted = true` +
+        /// (`handler_abort_marker`), which sets `aborted = true` +
         /// LeaveFrame.  The
         /// `if callee.aborted { bh.aborted = true; LeaveFrame }` arm
-        /// inside `handler_inline_call_pyre_nested` then propagates to
+        /// inside `handler_inline_call_nested_ext` then propagates to
         /// the caller.
         #[test]
         fn test_bh_interp_inline_call_abort_in_sub_propagates() {
@@ -5045,7 +5045,7 @@ mod tests {
         /// criterion for 's callee runtime context clone:
         /// the inner-most callee inherits the parent's dispatch_table
         /// via `clone_context_from`, so byte 17 routes to
-        /// `handler_inline_call_pyre_nested` recursively.  The
+        /// `handler_inline_call_nested_ext` recursively.  The
         /// caller-side ground truth is that the int value threaded
         /// through three frames lands in the outermost caller's
         /// destination register.
@@ -5130,21 +5130,21 @@ mod tests {
             assert_eq!(callee.jitdrivers_sd.len(), parent.jitdrivers_sd.len());
         }
 
-        /// `handler_abort_marker_pyre` defines the pyre
+        /// `handler_abort_marker` defines the pyre
         /// `BC_ABORT` marker semantics.  Reaching `OpKind::Abort` at
         /// runtime sets `aborted = true` and exits the frame —
         /// continuing dispatch past it would misread the next bytes
         /// as opcodes.
         #[test]
-        fn test_handler_abort_marker_pyre_sets_aborted_and_leaves_frame() {
+        fn test_handler_abort_marker_sets_aborted_and_leaves_frame() {
             let mut builder = BlackholeInterpBuilder::new();
             let mut bh = builder.acquire_interp();
             assert!(!bh.aborted);
-            let result = super::handler_abort_marker_pyre(&mut bh, &[], 0);
+            let result = super::handler_abort_marker(&mut bh, &[], 0);
             match result {
                 Err(super::DispatchError::LeaveFrame) => {}
                 other => {
-                    panic!("handler_abort_marker_pyre must return Err(LeaveFrame), got {other:?}")
+                    panic!("handler_abort_marker must return Err(LeaveFrame), got {other:?}")
                 }
             }
             assert!(bh.aborted);
@@ -5822,14 +5822,14 @@ bhhandler_ii_i!(handler_int_sub, bhimpl_int_sub);
 // one write, so the bytecode shape is identical to `int_add/ii>i` — same
 // primitive. Has no RPython analog; canonical RPython lowers `+=` to plain
 // BINARY_ADD before reaching jtransform.
-bhhandler_ii_i!(handler_int_add_assign_pyre, bhimpl_int_add);
-bhhandler_ii_i!(handler_int_sub_assign_pyre, bhimpl_int_sub);
+bhhandler_ii_i!(handler_int_add_assign, bhimpl_int_add);
+bhhandler_ii_i!(handler_int_sub_assign, bhimpl_int_sub);
 
 // pyre-only: dereference `*x` lowered to the UnaryOp name `"deref"`.
 // After rtyper lowering the &i64 input has already been resolved to a
 // plain i64 value, so the operation degenerates to a copy at dispatch
 // time. Same primitive as `int_same_as`.
-bhhandler_i_i!(handler_int_deref_pyre, bhimpl_int_same_as);
+bhhandler_i_i!(handler_int_deref, bhimpl_int_same_as);
 
 // pyre-only: `OpKind::Abort` placeholder emitted by the front-end when a
 // syntax node has no dedicated OpKind variant (assembler.rs
@@ -5841,7 +5841,7 @@ bhhandler_i_i!(handler_int_deref_pyre, bhimpl_int_same_as);
 // `aborted = true` + `LeaveFrame`. RPython has no
 // direct analog: its codewriter raises before lowering, so a jitcode
 // never carries an unrecognized op.
-fn handler_abort_marker_pyre(
+fn handler_abort_marker(
     bh: &mut BlackholeInterpreter,
     _code: &[u8],
     _position: usize,
@@ -8260,7 +8260,7 @@ fn handler_residual_call_r_v(
 
 // A1-A8: every BC_* emitted by pyre now follows the canonical
 // RPython argcode contract (1-byte register operands per
-// `blackhole.py:107`).  All `*_pyre_u16` width adapters have been
+// `blackhole.py:107`).  All `*_u16_ext` width adapters have been
 // retired; canonical `handler_*` decoders own every dispatch slot.
 
 /// Per-thread Backend instance backing every `bh.cpu` call.
@@ -8304,7 +8304,7 @@ fn handler_residual_call_r_v(
 // `WasmBackend`. A narrower gate here leaves `bh.cpu` unset on wasm and
 // every vable handler trips `expect("cpu not set")`.
 #[cfg(any(target_arch = "wasm32", feature = "dynasm", feature = "cranelift"))]
-pub fn pyre_production_cpu() -> &'static dyn majit_backend::Backend {
+pub fn production_cpu() -> &'static dyn majit_backend::Backend {
     // Per-thread leak: `BackendImpl` is not `Sync`, so we keep one
     // instance per thread.  Mirrors `BH_BUILDER3` (`call_jit.rs`)
     // which is itself a `thread_local!` — production blackhole resume
@@ -8333,19 +8333,19 @@ pub fn pyre_production_cpu() -> &'static dyn majit_backend::Backend {
 /// DSL lowerer, `pyre-jit/src/jit/assembler.rs`) can emit: byte-
 /// identical canonical keys, single-byte register operands,
 /// audited residual_call / vable / state-field families, the pyre
-/// nested inline-call handler, and the `_pyre/P` adapters for
+/// nested inline-call handler, and the `_ext/P` adapters for
 /// `BC_CALL_ASSEMBLER_*`, `BC_COND_CALL_*`, and
 /// `BC_RECORD_KNOWN_RESULT_*` (P10).  The dispatch loop has no legacy
 /// fallback; any emitted byte missing from this table reaches
 /// `dispatch_step`'s unwired-opcode panic.
 ///
 /// Initially registered:
-///   - `inline_call_pyre_nested/P` at `BC_INLINE_CALL` ()
+///   - `inline_call_nested_ext/P` at `BC_INLINE_CALL` ()
 ///   - byte-identical canonical: `live/`, `loop_header/i`,
 ///     `goto/L`, `catch_exception/L`, `jit_merge_point/cIRFIRF`
 ///   - canonical-encoded: every `JitCodeBuilder`-emitted BC_*
 ///     now pushes 1-byte register operands matching the canonical
-///     RPython argcode contract; no `_pyre_u16` width adapters remain.
+///     RPython argcode contract; no `_u16_ext` width adapters remain.
 ///     The pyre-jit production thread-locals (`BH_BUILDER3`,
 ///     `BH_BUILDER_RD`) and inline-call unit fixtures share this builder
 ///     shape.
@@ -8364,15 +8364,15 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     // the residual_call (`bh_call_*`) prereq audit is pending.
     #[cfg(any(target_arch = "wasm32", feature = "dynasm", feature = "cranelift"))]
     {
-        builder.cpu = Some(pyre_production_cpu());
+        builder.cpu = Some(production_cpu());
     }
     let mut insns: indexmap::IndexMap<String, u8> = indexmap::IndexMap::new();
     insns.insert(
-        "inline_call_pyre_nested/P".to_string(),
+        "inline_call_nested_ext/P".to_string(),
         majit_translate::insns::BC_INLINE_CALL,
     );
     // P10 — pyre call_assembler / cond_call / record_known_result
-    // adapters.  The `_pyre/P` suffix matches the inline_call adapter
+    // adapters.  The `_ext/P` suffix matches the inline_call adapter
     // pattern so wire_bhimpl_handlers binds the right handler and
     // strict dispatch resolves the byte without panic.  Producers:
     // `pyjitpl/dispatch.rs` (call_assembler), `majit-macros/
@@ -8380,39 +8380,39 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     // jit/assembler.rs` (cond_call / record_known_result).
     for (key, byte) in [
         (
-            "call_assembler_int_pyre/P",
+            "call_assembler_int_ext/P",
             majit_translate::insns::BC_CALL_ASSEMBLER_INT,
         ),
         (
-            "call_assembler_ref_pyre/P",
+            "call_assembler_ref_ext/P",
             majit_translate::insns::BC_CALL_ASSEMBLER_REF,
         ),
         (
-            "call_assembler_float_pyre/P",
+            "call_assembler_float_ext/P",
             majit_translate::insns::BC_CALL_ASSEMBLER_FLOAT,
         ),
         (
-            "call_assembler_void_pyre/P",
+            "call_assembler_void_ext/P",
             majit_translate::insns::BC_CALL_ASSEMBLER_VOID,
         ),
         (
-            "cond_call_void_pyre/P",
+            "cond_call_void_ext/P",
             majit_translate::insns::BC_COND_CALL_VOID,
         ),
         (
-            "cond_call_value_int_pyre/P",
+            "cond_call_value_int_ext/P",
             majit_translate::insns::BC_COND_CALL_VALUE_INT,
         ),
         (
-            "cond_call_value_ref_pyre/P",
+            "cond_call_value_ref_ext/P",
             majit_translate::insns::BC_COND_CALL_VALUE_REF,
         ),
         (
-            "record_known_result_int_pyre/P",
+            "record_known_result_int_ext/P",
             majit_translate::insns::BC_RECORD_KNOWN_RESULT_INT,
         ),
         (
-            "record_known_result_ref_pyre/P",
+            "record_known_result_ref_ext/P",
             majit_translate::insns::BC_RECORD_KNOWN_RESULT_REF,
         ),
     ] {
@@ -8882,7 +8882,7 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     // without these entries the bytes reach `dispatch_step`'s unwired panic
     // instead of their handler. Build-time (LLBC-extracted) jitcodes are the
     // only producer — the runtime `JitCodeBuilder` emits the pyre-only
-    // `inline_call_pyre_nested/P` byte instead — and any of them a
+    // `inline_call_nested_ext/P` byte instead — and any of them a
     // guard-failure resume forward-executes can reach one.
     //
     // A target whose path the host never published has no runtime address;
@@ -9260,10 +9260,10 @@ pub fn wire_bhimpl_handlers(builder: &mut BlackholeInterpBuilder) {
     builder.wire_handler("int_add/ii>i", handler_int_add);
     builder.wire_handler("int_sub/ii>i", handler_int_sub);
     // pyre-only primitives — see handler comments for rationale.
-    builder.wire_handler("int_add_assign/ii>i", handler_int_add_assign_pyre);
-    builder.wire_handler("int_sub_assign/ii>i", handler_int_sub_assign_pyre);
-    builder.wire_handler("int_deref/i>i", handler_int_deref_pyre);
-    builder.wire_handler("abort/", handler_abort_marker_pyre);
+    builder.wire_handler("int_add_assign/ii>i", handler_int_add_assign);
+    builder.wire_handler("int_sub_assign/ii>i", handler_int_sub_assign);
+    builder.wire_handler("int_deref/i>i", handler_int_deref);
+    builder.wire_handler("abort/", handler_abort_marker);
 
     // pyre-only state_field family (no RPython counterpart). The handlers do
     // real work: they map a logical field/array index to its flat register
@@ -9737,44 +9737,35 @@ pub fn wire_bhimpl_handlers(builder: &mut BlackholeInterpBuilder) {
     builder.wire_handler("inline_call_r_v/dR", handler_inline_call_r_v);
 
     // TODO: pyre nested-bytecode `inline_call`.  See
-    // the comment on `handler_inline_call_pyre_nested` for rationale.
+    // the comment on `handler_inline_call_nested_ext` for rationale.
     // The canonical `inline_call_{r,ir,irf}_*` keys above are now pinned
     // in `wellknown_bh_insns()` (`BC_INLINE_CALL_*`,
     // `insns.rs`'s `wellknown_bh_insns`) so their handlers dispatch through
     // `setup_insns`-built `_insns` like every other canonical opcode.
     // Byte 17 (`BC_INLINE_CALL`) sits below the canonical range and is
-    // exposed via the separate pyre-only `inline_call_pyre_nested/P`
-    // key in `pyre_extension_insns()` — the adapter shape that carries
+    // exposed via the separate pyre-only `inline_call_nested_ext/P`
+    // key in `extension_insns()` — the adapter shape that carries
     // pyre's nested-bytecode payload, distinct from the canonical
     // `dR`/`dIR`/`dIRF` arglists.
-    builder.wire_handler("inline_call_pyre_nested/P", handler_inline_call_pyre_nested);
+    builder.wire_handler("inline_call_nested_ext/P", handler_inline_call_nested_ext);
     // P10 — pyre call_assembler / cond_call / record_known_result adapter wiring.
-    builder.wire_handler("call_assembler_int_pyre/P", handler_call_assembler_int_pyre);
-    builder.wire_handler("call_assembler_ref_pyre/P", handler_call_assembler_ref_pyre);
+    builder.wire_handler("call_assembler_int_ext/P", handler_call_assembler_int_ext);
+    builder.wire_handler("call_assembler_ref_ext/P", handler_call_assembler_ref_ext);
     builder.wire_handler(
-        "call_assembler_float_pyre/P",
-        handler_call_assembler_float_pyre,
+        "call_assembler_float_ext/P",
+        handler_call_assembler_float_ext,
+    );
+    builder.wire_handler("call_assembler_void_ext/P", handler_call_assembler_void_ext);
+    builder.wire_handler("cond_call_void_ext/P", handler_cond_call_void_ext);
+    builder.wire_handler("cond_call_value_int_ext/P", handler_cond_call_value_int_ext);
+    builder.wire_handler("cond_call_value_ref_ext/P", handler_cond_call_value_ref_ext);
+    builder.wire_handler(
+        "record_known_result_int_ext/P",
+        handler_record_known_result_int_ext,
     );
     builder.wire_handler(
-        "call_assembler_void_pyre/P",
-        handler_call_assembler_void_pyre,
-    );
-    builder.wire_handler("cond_call_void_pyre/P", handler_cond_call_void_pyre);
-    builder.wire_handler(
-        "cond_call_value_int_pyre/P",
-        handler_cond_call_value_int_pyre,
-    );
-    builder.wire_handler(
-        "cond_call_value_ref_pyre/P",
-        handler_cond_call_value_ref_pyre,
-    );
-    builder.wire_handler(
-        "record_known_result_int_pyre/P",
-        handler_record_known_result_int_pyre,
-    );
-    builder.wire_handler(
-        "record_known_result_ref_pyre/P",
-        handler_record_known_result_ref_pyre,
+        "record_known_result_ref_ext/P",
+        handler_record_known_result_ref_ext,
     );
 
     // Recursive call (stub — needs portal runner)
@@ -11430,7 +11421,7 @@ fn handler_inline_call_r_v(
 /// The 4 handlers below are the line-by-line port of the legacy
 /// `dispatch_one::BC_CALL_ASSEMBLER_*` arms (pre-P8) into the
 /// strict-dispatch `(bh, code, position) -> Result<usize, _>` shape.
-fn handler_call_assembler_int_pyre(
+fn handler_call_assembler_int_ext(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
     p: usize,
@@ -11453,7 +11444,7 @@ fn handler_call_assembler_int_pyre(
     Ok(p)
 }
 
-fn handler_call_assembler_ref_pyre(
+fn handler_call_assembler_ref_ext(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
     p: usize,
@@ -11490,7 +11481,7 @@ fn handler_call_assembler_ref_pyre(
 /// tracing path; using `call_float_function` here would transmute the
 /// i64-returning concrete wrapper through an `extern "C" fn(...) -> f64`
 /// signature and break the ABI.
-fn handler_call_assembler_float_pyre(
+fn handler_call_assembler_float_ext(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
     p: usize,
@@ -11513,7 +11504,7 @@ fn handler_call_assembler_float_pyre(
     Ok(p)
 }
 
-fn handler_call_assembler_void_pyre(
+fn handler_call_assembler_void_ext(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
     p: usize,
@@ -11570,7 +11561,7 @@ fn read_cond_call_args(
     (args, regs_start + arg_count)
 }
 
-fn handler_cond_call_void_pyre(
+fn handler_cond_call_void_ext(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
     p: usize,
@@ -11590,7 +11581,7 @@ fn handler_cond_call_void_pyre(
     Ok(p_end)
 }
 
-fn handler_cond_call_value_int_pyre(
+fn handler_cond_call_value_int_ext(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
     p: usize,
@@ -11615,7 +11606,7 @@ fn handler_cond_call_value_int_pyre(
     Ok(p_end + 1)
 }
 
-fn handler_cond_call_value_ref_pyre(
+fn handler_cond_call_value_ref_ext(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
     p: usize,
@@ -11632,7 +11623,7 @@ fn handler_cond_call_value_ref_pyre(
         BH_LAST_EXC_VALUE.with(|c| c.set(0));
         // RPython `blackhole.py bhimpl_conditional_call_value_ir_r`
         // → `cpu.bh_call_r(...)` (ref ABI).  See note on
-        // `handler_call_assembler_ref_pyre`.
+        // `handler_call_assembler_ref_ext`.
         let r = call_ref_function(target.concrete_ptr, &args);
         check_residual_call_exception_after(bh, p_end + 1)?;
         r
@@ -11646,7 +11637,7 @@ fn handler_cond_call_value_ref_pyre(
 /// `bhimpl_record_known_result_*` body is `pass` — pure marker for
 /// the trace optimizer's known-result table.  Resume only advances
 /// past the operand bytes.
-fn handler_record_known_result_int_pyre(
+fn handler_record_known_result_int_ext(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
     p: usize,
@@ -11663,12 +11654,12 @@ fn handler_record_known_result_int_pyre(
     Ok(p)
 }
 
-fn handler_record_known_result_ref_pyre(
+fn handler_record_known_result_ref_ext(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
     p: usize,
 ) -> Result<usize, DispatchError> {
-    handler_record_known_result_int_pyre(bh, code, p)
+    handler_record_known_result_int_ext(bh, code, p)
 }
 
 /// TODO: pyre nested-bytecode `inline_call`.
@@ -11689,14 +11680,14 @@ fn handler_record_known_result_ref_pyre(
 ///   `return_i: u8`, `return_r: u8`, `return_f: u8`
 /// `NO_RETURN_REG` in any return slot encodes "no caller destination".
 ///
-/// Registered via the pyre-only opname `inline_call_pyre_nested/P`
-/// in `pyre_extension_insns()`.  Canonical `inline_call_{r,ir,irf}_*`
+/// Registered via the pyre-only opname `inline_call_nested_ext/P`
+/// in `extension_insns()`.  Canonical `inline_call_{r,ir,irf}_*`
 /// keys are pinned in `wellknown_bh_insns()` (`BC_INLINE_CALL_*`,
-/// `insns.rs`'s `wellknown_bh_insns`) — this `_pyre_nested/P` shape is a separate
+/// `insns.rs`'s `wellknown_bh_insns`) — this `_nested_ext/P` shape is a separate
 /// pyre-only adapter that carries the nested-bytecode payload layout
 /// described above, distinct from the canonical `dR`/`dIR`/`dIRF`
 /// arglist shapes the upstream walker dispatches.
-fn handler_inline_call_pyre_nested(
+fn handler_inline_call_nested_ext(
     bh: &mut BlackholeInterpreter,
     code: &[u8],
     p: usize,

--- a/majit/majit-metainterp/src/call_descr.rs
+++ b/majit/majit-metainterp/src/call_descr.rs
@@ -12,7 +12,9 @@ use std::sync::Arc;
 
 use majit_backend::JitCellToken;
 use majit_ir::effectinfo::EffectInfoCell;
-use majit_ir::{CallDescr, DescrRef, EffectInfo, ExtraEffect, OopSpecIndex, PyreHelperKind, Type};
+use majit_ir::{
+    CallDescr, DescrRef, EffectInfo, ExtraEffect, OopSpecIndex, RuntimeHelperKind, Type,
+};
 
 /// Generic CallDescr for function call operations.
 ///
@@ -215,12 +217,12 @@ pub fn can_raise_effect_info() -> EffectInfo {
 /// an allocation publishes a fresh object and writes no field of any
 /// object the trace already cached, so `graphanalyze.py:60
 /// analyze_external_call`'s `bottom_result()` is the honest answer.
-/// Stamped with [`PyreHelperKind::NurseryAlloc`] so the dynasm CallR
+/// Stamped with [`RuntimeHelperKind::NurseryAlloc`] so the dynasm CallR
 /// genop emits an inline nursery bump; the tag does not change effect
 /// analysis.
 pub fn nursery_alloc_effect_info() -> EffectInfo {
     let mut ei = EffectInfo::const_new(ExtraEffect::CanRaise, OopSpecIndex::None);
-    ei.pyre_helper = PyreHelperKind::NurseryAlloc;
+    ei.runtime_helper = RuntimeHelperKind::NurseryAlloc;
     ei
 }
 
@@ -293,7 +295,7 @@ pub fn forces_virtual_or_virtualizable_effect_info() -> EffectInfo {
 pub const CANNOT_RAISE_NO_HEAP_EFFECT_INFO: EffectInfo = EffectInfo {
     extraeffect: ExtraEffect::CannotRaise,
     oopspecindex: OopSpecIndex::None,
-    pyre_helper: PyreHelperKind::None,
+    runtime_helper: RuntimeHelperKind::None,
     _readonly_descrs_fields: Some(Vec::new()),
     _write_descrs_fields: Some(Vec::new()),
     _readonly_descrs_arrays: Some(Vec::new()),
@@ -335,7 +337,7 @@ pub const CANNOT_RAISE_NO_HEAP_EFFECT_INFO: EffectInfo = EffectInfo {
 pub const ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO: EffectInfo = EffectInfo {
     extraeffect: ExtraEffect::ElidableCannotRaise,
     oopspecindex: OopSpecIndex::None,
-    pyre_helper: PyreHelperKind::None,
+    runtime_helper: RuntimeHelperKind::None,
     _readonly_descrs_fields: Some(Vec::new()),
     _write_descrs_fields: Some(Vec::new()),
     _readonly_descrs_arrays: Some(Vec::new()),
@@ -371,7 +373,7 @@ pub const ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO: EffectInfo = EffectInfo {
 pub const INT_PY_DIV_EFFECT_INFO: EffectInfo = EffectInfo {
     extraeffect: ExtraEffect::ElidableCannotRaise,
     oopspecindex: OopSpecIndex::IntPyDiv,
-    pyre_helper: PyreHelperKind::None,
+    runtime_helper: RuntimeHelperKind::None,
     _readonly_descrs_fields: Some(Vec::new()),
     _write_descrs_fields: Some(Vec::new()),
     _readonly_descrs_arrays: Some(Vec::new()),
@@ -400,7 +402,7 @@ pub const INT_PY_DIV_EFFECT_INFO: EffectInfo = EffectInfo {
 pub const INT_PY_MOD_EFFECT_INFO: EffectInfo = EffectInfo {
     extraeffect: ExtraEffect::ElidableCannotRaise,
     oopspecindex: OopSpecIndex::IntPyMod,
-    pyre_helper: PyreHelperKind::None,
+    runtime_helper: RuntimeHelperKind::None,
     _readonly_descrs_fields: Some(Vec::new()),
     _write_descrs_fields: Some(Vec::new()),
     _readonly_descrs_arrays: Some(Vec::new()),
@@ -437,7 +439,7 @@ pub const INT_PY_MOD_EFFECT_INFO: EffectInfo = EffectInfo {
 pub const UINT_PY_DIV_EFFECT_INFO: EffectInfo = EffectInfo {
     extraeffect: ExtraEffect::ElidableCannotRaise,
     oopspecindex: OopSpecIndex::IntUdiv,
-    pyre_helper: PyreHelperKind::None,
+    runtime_helper: RuntimeHelperKind::None,
     _readonly_descrs_fields: Some(Vec::new()),
     _write_descrs_fields: Some(Vec::new()),
     _readonly_descrs_arrays: Some(Vec::new()),
@@ -464,7 +466,7 @@ pub const UINT_PY_DIV_EFFECT_INFO: EffectInfo = EffectInfo {
 pub const UINT_PY_MOD_EFFECT_INFO: EffectInfo = EffectInfo {
     extraeffect: ExtraEffect::ElidableCannotRaise,
     oopspecindex: OopSpecIndex::IntUmod,
-    pyre_helper: PyreHelperKind::None,
+    runtime_helper: RuntimeHelperKind::None,
     _readonly_descrs_fields: Some(Vec::new()),
     _write_descrs_fields: Some(Vec::new()),
     _readonly_descrs_arrays: Some(Vec::new()),

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -3454,7 +3454,7 @@ impl TraceCtx {
     /// construction* at all of its index reads. The
     /// `jitcode_dispatch/vable_ops.rs` family is gated only on the index
     /// having a recorded concrete value (`concrete_of_opref`), which a
-    /// non-constant `OpRef` can satisfy — and `PYRE_VABLE_IDX_PROBE`'s own
+    /// non-constant `OpRef` can satisfy — and `MAJIT_VABLE_IDX_PROBE`'s own
     /// caveat, beside that call, says a `NONCONST == 0` reading cannot
     /// separate "that family is constant" from "that family was never
     /// reached", because the const-by-construction callers dilute it.

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -3628,7 +3628,7 @@ impl JitCodeBuilder {
     /// `result_size = 0`, so it has no counterpart for a semantically void
     /// helper that physically returns a word. `pyre-jit/src/jit/codewriter.rs`
     /// (`CodeWriter::intern_call_descr_stub`) sets it for
-    /// `PyreHelperKind::ListAppendValue`.
+    /// `RuntimeHelperKind::ListAppendValue`.
     pub fn residual_call_void_canonical_via_target_with_effect_info_and_word_abi(
         &mut self,
         fn_ptr_idx: u16,

--- a/majit/majit-metainterp/src/jitcode/mod.rs
+++ b/majit/majit-metainterp/src/jitcode/mod.rs
@@ -27,7 +27,7 @@ pub const BC_GOTO: u8 = insns::BC_JUMP;
 // — the import-path sweep is slice #86e.
 pub(crate) use majit_translate::insns::insn_byte;
 
-pub use majit_translate::insns::{pyre_extension_insns, wellknown_bh_insns};
+pub use majit_translate::insns::{extension_insns, wellknown_bh_insns};
 
 /// Re-export of the canonical `enumerate_vars` function so existing
 /// metainterp callers can keep using `crate::jitcode::enumerate_vars`.
@@ -680,9 +680,9 @@ mod tests {
         // keys (`blackhole.py:1258-1296` + `:621-630`) are pinned at the
         // distinct bytes [`BC_CONDITIONAL_CALL_*`] / [`BC_RECORD_KNOWN_RESULT_*`].
         // The pyre-only helper-side proc-macro adapter keys
-        // `cond_call_*_pyre/P` / `record_known_result_*_pyre/P` reuse the
+        // `cond_call_*_ext/P` / `record_known_result_*_ext/P` reuse the
         // legacy [`BC_COND_CALL_*`] / [`BC_RECORD_KNOWN_RESULT_*`] bytes
-        // (`pyre_extension_insns()`).  The two byte ranges must stay
+        // (`extension_insns()`).  The two byte ranges must stay
         // disjoint so the canonical and adapter forms cannot collide on
         // dispatch.
         assert_eq!(
@@ -720,8 +720,8 @@ mod tests {
         // Canonical `inline_call_*/d{R,IR,IRF}>{i,r,v,f}` keys live in
         // `wellknown_bh_insns()` with their own distinct `BC_*` bytes
         // (187-194); the pyre-only nested-bytecode adapter
-        // `inline_call_pyre_nested/P` reuses `BC_INLINE_CALL = 17` and is
-        // quarantined in `pyre_extension_insns()`.  The two byte ranges
+        // `inline_call_nested_ext/P` reuses `BC_INLINE_CALL = 17` and is
+        // quarantined in `extension_insns()`.  The two byte ranges
         // are disjoint, so they cannot collide on dispatch.
         assert!(insns.contains_key("inline_call_ir_r/dIR>r"));
         assert!(insns.contains_key("inline_call_irf_f/dIRF>f"));
@@ -803,21 +803,21 @@ mod tests {
         );
     }
 
-    /// The `pyre_extension_insns()` quarantine holds 8 keys arising from
+    /// The `extension_insns()` quarantine holds 8 keys arising from
     /// the borrow-checker abort signals (2) and the proc-macro JIT-machine
     /// state addressing (6), plus 3 more pyre-only
-    /// keys — `inline_call_pyre_nested/P` (nested-bytecode `inline_call`
+    /// keys — `inline_call_nested_ext/P` (nested-bytecode `inline_call`
     /// adapter, `BC_INLINE_CALL = 17`), `abort/>r` (Ref-result variant of
     /// `abort/`), `vtable_method_ptr/rd>i` (dyn-trait method-pointer
-    /// reification) — so the `pyre_extension_insns()` table now holds 11
+    /// reification) — so the `extension_insns()` table now holds 11
     /// entries total.  `wellknown_bh_insns()` is a strict
     /// subset of RPython's canonical opname universe; `insn_byte` merges both
     /// tables so build-time `write_insn(...)` callers continue to resolve
     /// unchanged.
     #[test]
-    fn pyre_extension_insns_quarantines_pyre_only_keys_out_of_wellknown() {
+    fn extension_insns_quarantines_runtime_keys_out_of_wellknown() {
         let wellknown = wellknown_bh_insns();
-        let extension = pyre_extension_insns();
+        let extension = extension_insns();
 
         let pairs = [
             // Borrow-checker abort signals.
@@ -831,7 +831,7 @@ mod tests {
             ("load_state_array/dii", insns::BC_LOAD_STATE_ARRAY),
             ("store_state_array/dii", insns::BC_STORE_STATE_ARRAY),
             // pyre nested-bytecode inline_call (pyre-only `P` argcode).
-            ("inline_call_pyre_nested/P", insns::BC_INLINE_CALL),
+            ("inline_call_nested_ext/P", insns::BC_INLINE_CALL),
             // Ref-result variant of the borrow-checker abort signal.
             ("abort/>r", majit_translate::insns::BC_ABORT_RESULT_R),
             // dyn-trait method pointer reification (backend epic).
@@ -844,13 +844,13 @@ mod tests {
         for (key, expected_byte) in pairs {
             assert!(
                 !wellknown.contains_key(key),
-                "{key} must be quarantined in pyre_extension_insns(), not \
+                "{key} must be quarantined in extension_insns(), not \
                  wellknown_bh_insns()",
             );
             assert_eq!(
                 extension.get(key),
                 Some(&expected_byte),
-                "{key} must be present in pyre_extension_insns() with the \
+                "{key} must be present in extension_insns() with the \
                  fixed BC_* byte",
             );
             assert_eq!(

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -538,7 +538,7 @@ fn failvals_enabled() -> bool {
 }
 fn portal_rca_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *FLAG.get_or_init(|| std::env::var_os("PYRE_PORTAL_RCA").is_some())
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_PORTAL_RCA").is_some())
 }
 
 fn format_rca_live_values(labels: Option<&[String]>, values: &[Value]) -> String {
@@ -5482,7 +5482,7 @@ impl<S: JitState> JitDriver<S> {
                     .unwrap_or(&fallback_alloc);
 
                 // Inline-call-only builder so byte 17 (BC_INLINE_CALL) is
-                // wired to handler_inline_call_pyre_nested when the
+                // wired to handler_inline_call_nested_ext when the
                 // multi-frame state-field-JIT chain reconstructs sub-frames
                 // via parent.descrs[idx].as_jitcode() above.  3
                 // retired the dispatch_one BC_INLINE_CALL legacy arm so an

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -51,7 +51,7 @@ use majit_ir::{OpRef, Type};
 /// relative module path. Keep GC-managed and raw layouts distinct, matching
 /// RPython's distinct `GcStruct(T)` / `Struct(T)` lltypes.
 #[doc(hidden)]
-pub fn __pyre_struct_type_id<T: 'static>(is_gc_managed: bool) -> u64 {
+pub fn __majit_struct_type_id<T: 'static>(is_gc_managed: bool) -> u64 {
     use std::any::TypeId;
     use std::hash::{Hash, Hasher};
 
@@ -66,7 +66,7 @@ pub fn __pyre_struct_type_id<T: 'static>(is_gc_managed: bool) -> u64 {
 /// Resolve a `crate`/`self`/`super` type path at its macro expansion module
 /// and hash the crate-stripped definition path used by the graph codewriter.
 #[doc(hidden)]
-pub fn __pyre_struct_type_id_path(module_path: &str, type_path: &str, is_gc_managed: bool) -> u64 {
+pub fn __majit_struct_type_id_path(module_path: &str, type_path: &str, is_gc_managed: bool) -> u64 {
     use std::hash::{Hash, Hasher};
 
     let mut resolved: Vec<&str> = module_path.split("::").collect();
@@ -281,12 +281,12 @@ pub fn bh_debug_enabled() -> bool {
 
 pub fn callee_rca_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *FLAG.get_or_init(|| std::env::var_os("PYRE_CALLEE_RCA").is_some())
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_CALLEE_RCA").is_some())
 }
 
 pub fn nbody_debug_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *FLAG.get_or_init(|| std::env::var_os("PYRE_NBODY_DEBUG").is_some())
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_NBODY_DEBUG").is_some())
 }
 
 /// Constness of every index arriving at `TraceCtx::get_arrayitem_vable_index`.
@@ -295,7 +295,7 @@ pub fn nbody_debug_enabled() -> bool {
 /// caller family without pairing it with a call-site probe.
 pub fn vable_idx_probe_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *FLAG.get_or_init(|| std::env::var_os("PYRE_VABLE_IDX_PROBE").is_some())
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_VABLE_IDX_PROBE").is_some())
 }
 
 pub fn mptrace_enabled() -> bool {
@@ -369,7 +369,7 @@ pub fn bridge_debug_enabled() -> bool {
 
 pub fn no_unroll_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *FLAG.get_or_init(|| std::env::var_os("PYRE_NO_UNROLL").is_some())
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_NO_UNROLL").is_some())
 }
 
 /// Why the unroll optimizer will be skipped, or `None` when it runs.
@@ -382,11 +382,11 @@ pub fn no_unroll_enabled() -> bool {
 ///
 /// Reporting the env override's name for both is worse than reporting nothing.
 /// A frontend that left `unroll` out of its `enable_opts` produces a log naming
-/// `PYRE_NO_UNROLL`; the reader checks their environment, finds it unset, and
+/// `MAJIT_NO_UNROLL`; the reader checks their environment, finds it unset, and
 /// has been sent to look for a cause that does not exist.
 pub fn unroll_skip_reason(env_override: bool, enable_opts: &[String]) -> Option<&'static str> {
     if env_override {
-        Some("PYRE_NO_UNROLL env override")
+        Some("MAJIT_NO_UNROLL env override")
     } else if !enable_opts.iter().any(|opt| opt == "unroll") {
         Some("`unroll` is absent from this jitdriver's enable_opts")
     } else {

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1461,7 +1461,7 @@ impl crate::walkvirtual::VirtualVisitor for RdVirtualInfoBuilder {
         // `FieldDescrInfo.index` must carry the stable descriptor index
         // (tagged offset) so resume-data readers can identify the field by
         // byte offset. Previously stored `fi as u32` (iteration counter),
-        // which made `extract_pyre_field_offset` always fail for virtuals
+        // which made `extract_runtime_field_offset` always fail for virtuals
         // being materialized on bridge entry.
         let built_fielddescrs: Vec<majit_ir::FieldDescrInfo> = fielddescrs
             .iter()
@@ -4980,15 +4980,15 @@ impl OptContext {
         "a-producerless"
     }
 
-    /// S9 probe sink (env-gated). No-op unless `PYRE_S9_PROBE` is set; appends
+    /// S9 probe sink (env-gated). No-op unless `MAJIT_S9_PROBE` is set; appends
     /// one classified line per `from_opref` fallback fire to
-    /// `/tmp/pyre_s9_probe.log`. Process-global file sink because the caller is
+    /// `/tmp/majit_s9_probe.log`. Process-global file sink because the caller is
     /// `&self` (no context-local counter). When the flag is unset, only a
     /// cached bool is read and the sink is never opened.
     fn s9_probe_fire(&self, opref: OpRef) {
         use std::sync::{LazyLock, Mutex};
         static ENABLED: LazyLock<bool> =
-            LazyLock::new(|| std::env::var_os("PYRE_S9_PROBE").is_some());
+            LazyLock::new(|| std::env::var_os("MAJIT_S9_PROBE").is_some());
         if !*ENABLED {
             return;
         }
@@ -4997,16 +4997,16 @@ impl OptContext {
                 std::fs::OpenOptions::new()
                     .create(true)
                     .append(true)
-                    .open("/tmp/pyre_s9_probe.log")
-                    .expect("open /tmp/pyre_s9_probe.log"),
+                    .open("/tmp/majit_s9_probe.log")
+                    .expect("open /tmp/majit_s9_probe.log"),
             )
         });
         let cat = self.classify_s9_fallback(opref);
-        // `PYRE_S9_PROBE=bt` additionally captures the caller backtrace per
+        // `MAJIT_S9_PROBE=bt` additionally captures the caller backtrace per
         // fire, to attribute fallback fires to their `get_box_replacement`
         // call sites.
         static BT: LazyLock<bool> = LazyLock::new(|| {
-            std::env::var("PYRE_S9_PROBE")
+            std::env::var("MAJIT_S9_PROBE")
                 .map(|v| v == "bt")
                 .unwrap_or(false)
         });

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6738,7 +6738,7 @@ impl<M: Clone> MetaInterp<M> {
         let constants_snapshot = constants.clone();
 
         // PyPy: pyjitpl.py:3016-3017 gates unrolling on `unroll` in
-        // warmstate.enable_opts. PYRE_NO_UNROLL remains a diagnostic override.
+        // warmstate.enable_opts. MAJIT_NO_UNROLL remains a diagnostic override.
         let no_unroll_reason = crate::unroll_skip_reason(
             crate::no_unroll_enabled(),
             self.warm_state.get_enable_opts(),
@@ -22660,7 +22660,7 @@ mod metainterp_static_data_tests {
         assert_eq!(
             meta.staticdata.op_live,
             crate::jitcode::insns::BC_LIVE as i32,
-            "install_canonical_liveness must seed op_live to pyre-static BC_LIVE",
+            "install_canonical_liveness must seed op_live to the static BC_LIVE table",
         );
         assert_eq!(
             meta.staticdata.op_catch_exception,

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -8677,7 +8677,7 @@ where
                 // float-result branch): pyre's `call_assembler` wrapper at
                 // `concrete_ptr` is an `extern "C" fn(...) -> i64` whose
                 // result carries the f64 pre-packed via `f64::to_bits()`.
-                // See `handler_call_assembler_float_pyre` in `blackhole.rs`
+                // See `handler_call_assembler_float_ext` in `blackhole.rs`
                 // for the wrapper-ABI
                 // analysis — calling through `call_float_function`
                 // (`extern "C" fn(...) -> f64`) here would transmute the

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1280,7 +1280,7 @@ impl TraceCtx {
         effectinfo: Option<&majit_ir::EffectInfo>,
         argboxes: &[OpRef],
     ) {
-        if std::env::var_os("PYRE_PROBE_SUBSCR").is_some() {
+        if std::env::var_os("MAJIT_PROBE_SUBSCR").is_some() {
             let ei_summary = effectinfo.map(|ei| {
                 format!(
                     "extraeffect={:?} forces_vorv={} can_raise={} plain_call={} oopspec={:?}",
@@ -1292,7 +1292,7 @@ impl TraceCtx {
                 )
             });
             eprintln!(
-                "[PYRE_PROBE_SUBSCR] invalidate_caches_varargs opnum={:?} argboxes.len={} ei={:?}",
+                "[MAJIT_PROBE_SUBSCR] invalidate_caches_varargs opnum={:?} argboxes.len={} ei={:?}",
                 opnum,
                 argboxes.len(),
                 ei_summary
@@ -4846,7 +4846,7 @@ impl TraceCtx {
         index_runtime_value: i64,
         fdescr: &DescrRef,
     ) -> Option<usize> {
-        // `PYRE_VABLE_IDX_PROBE`: does a non-constant index ever arrive here?
+        // `MAJIT_VABLE_IDX_PROBE`: does a non-constant index ever arrive here?
         //
         // Prints on BOTH branches deliberately. A probe that prints only on
         // the branch it is hunting cannot distinguish "never taken" from

--- a/majit/majit-metainterp/tests/jit_interp_array_field_write_kind.rs
+++ b/majit/majit-metainterp/tests/jit_interp_array_field_write_kind.rs
@@ -131,7 +131,7 @@ fn build() -> majit_metainterp::JitCode {
 /// if nothing registered it.
 fn cached_data_field() -> Option<(majit_ir::Type, usize, bool)> {
     use majit_ir::descr::FieldDescr as _;
-    let type_id = majit_metainterp::__pyre_struct_type_id::<PointerFieldStack>(false);
+    let type_id = majit_metainterp::__majit_struct_type_id::<PointerFieldStack>(false);
     let cache = majit_ir::descr::gc_cache().lock().unwrap();
     let descr = cache
         ._cache_field
@@ -188,7 +188,7 @@ fn a_write_set_declaration_over_an_array_field_describes_a_pointer() {
 fn a_scalar_field_of_the_same_struct_is_still_a_scalar() {
     use majit_ir::descr::FieldDescr as _;
     let _jc = build();
-    let type_id = majit_metainterp::__pyre_struct_type_id::<PointerFieldStack>(false);
+    let type_id = majit_metainterp::__majit_struct_type_id::<PointerFieldStack>(false);
     let cache = majit_ir::descr::gc_cache().lock().unwrap();
     let size_field = cache
         ._cache_field

--- a/majit/majit-metainterp/tests/jit_interp_inline_helper_typed_return.rs
+++ b/majit/majit-metainterp/tests/jit_interp_inline_helper_typed_return.rs
@@ -305,7 +305,7 @@ fn jit_inline_ref_param_field_access_lowers_to_native_field_ops() {
             .map(|(key, value)| ((*key).to_string(), *value))
             .collect();
     bh_insns.extend(
-        majit_metainterp::jitcode::pyre_extension_insns()
+        majit_metainterp::jitcode::extension_insns()
             .iter()
             .map(|(key, value)| ((*key).to_string(), *value)),
     );
@@ -428,7 +428,7 @@ fn jit_inline_void_ref_param_field_swap_lowers_to_native_field_ops() {
             .map(|(key, value)| ((*key).to_string(), *value))
             .collect();
     bh_insns.extend(
-        majit_metainterp::jitcode::pyre_extension_insns()
+        majit_metainterp::jitcode::extension_insns()
             .iter()
             .map(|(key, value)| ((*key).to_string(), *value)),
     );
@@ -682,7 +682,7 @@ fn jit_inline_mixed_identity_uses_dense_kind_banks_at_runtime() {
     jc_builder.inline_call_irf_i(sub_idx, &[(0, 0)], &[(0, 0)], &[(0, 0)], Some(1));
     let jitcode = jc_builder.finish();
 
-    // Route through `handler_inline_call_pyre_nested`
+    // Route through `handler_inline_call_nested_ext`
     // (the production builder shape) instead of the legacy
     // `dispatch_one::BC_INLINE_CALL` fallback.
     let mut bh_builder = build_inline_call_only_bh_builder();

--- a/majit/majit-metainterp/tests/unroll_skip_reason.rs
+++ b/majit/majit-metainterp/tests/unroll_skip_reason.rs
@@ -1,9 +1,9 @@
 //! A suppressed unroll has two possible causes, and the log has to say which.
 //!
-//! `compile_loop` skips the unroll optimizer when either the `PYRE_NO_UNROLL`
+//! `compile_loop` skips the unroll optimizer when either the `MAJIT_NO_UNROLL`
 //! env override is set OR the jitdriver's `enable_opts` does not list `unroll`.
-//! Both paths used to emit the same line — `[jit] PYRE_NO_UNROLL: skipping
-//! unroll optimizer` — and raise the same `InvalidLoop("PYRE_NO_UNROLL")`.
+//! Both paths used to emit the same line — `[jit] MAJIT_NO_UNROLL: skipping
+//! unroll optimizer` — and raise the same `InvalidLoop("MAJIT_NO_UNROLL")`.
 //!
 //! That is not a cosmetic difference. A frontend that deliberately leaves
 //! `unroll` out of its `enable_opts` (measuring that peeling the preamble costs
@@ -36,7 +36,7 @@ fn each_cause_is_named_as_itself() {
     let reason = unroll_skip_reason(true, &with_unroll)
         .expect("the env override suppresses unrolling whatever the opts say");
     assert!(
-        reason.contains("PYRE_NO_UNROLL"),
+        reason.contains("MAJIT_NO_UNROLL"),
         "the env override must name the variable a reader can check; got {reason:?}",
     );
 
@@ -50,7 +50,7 @@ fn each_cause_is_named_as_itself() {
          variable a reader would then look for in vain; got {reason:?}",
     );
     assert!(
-        !reason.contains("PYRE_NO_UNROLL"),
+        !reason.contains("MAJIT_NO_UNROLL"),
         "…and must not name the env override at all: it is unset in exactly \
          this case, which is what made the old message misleading; got {reason:?}",
     );

--- a/majit/majit-rlib/src/lltypesystem/rlist.rs
+++ b/majit/majit-rlib/src/lltypesystem/rlist.rs
@@ -134,7 +134,7 @@ pub fn gc_float_array_gc_type_id() -> u32 {
 /// `std::alloc`. Read once; default ON — the nursery path mirrors the
 /// `GcArray` body upstream allocates (rlist.py:84) and is validated identical
 /// to the `std::alloc` fallback (check.py 158 both backends, both gate states;
-/// fannkuch/nbody/spectral_norm timings unchanged). `PYRE_GC_ITEMSBLOCK=0`
+/// fannkuch/nbody/spectral_norm timings unchanged). `MAJIT_GC_ITEMSBLOCK=0`
 /// (or `off`/`false`) restores the `std::alloc` fallback to bisect a
 /// suspected block-GC regression.
 ///
@@ -151,7 +151,7 @@ pub fn itemsblock_gc_enabled() -> bool {
     use std::sync::OnceLock;
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        std::env::var("PYRE_GC_ITEMSBLOCK")
+        std::env::var("MAJIT_GC_ITEMSBLOCK")
             .map(|v| !matches!(v.trim(), "0" | "off" | "false" | ""))
             .unwrap_or(true)
     })

--- a/majit/majit-translate/Cargo.toml
+++ b/majit/majit-translate/Cargo.toml
@@ -63,9 +63,9 @@ majit-charon-reader = { workspace = true }
 [features]
 default = ["mir-frontend"]
 # When this feature is on, `build_semantic_program_via_active_frontend`
-# resolves LLBC artefacts via `PYRE_MIR_FRONTEND_LLBC` env-var or
-# auto-discovers `<workspace>/build/llbc/{pyre-object,
-# pyre-interpreter}.ullbc`; panics when neither source resolves.
+# resolves LLBC artefacts supplied by the caller or via the
+# `MAJIT_MIR_FRONTEND_LLBC` environment variable; it panics when neither
+# source resolves.
 #
 # `tyref_to_value_type` recognises Charon's literal-type schema —
 # `Literal::Int` (signed) / `Literal::UInt` (unsigned) for integers,

--- a/majit/majit-translate/docs/design-346-dstrategy-trait-object-field.md
+++ b/majit/majit-translate/docs/design-346-dstrategy-trait-object-field.md
@@ -50,7 +50,7 @@ Registration is driven two ways:
   codewriter.rs:158. **Empty in production** (test_support.rs:51). NOT gated.
 - **auto** every `>=2`-impl trait, behind `dyn_indirect_enabled()` — **on by default** since
   the `__dyn_call` flip; `PYRE_DYN_INDIRECT=0` is the kill switch. The gate comment warns:
-  minting base/impl subclass classdefs perturbs `pyre_struct_root_names` → `ensure_session`
+  minting base/impl subclass classdefs perturbs `struct_root_names` → `ensure_session`
   inheritance-id numbering even off-path, which is why the kill switch has to restore this
   registration and the `__dyn_call` emit together.
 
@@ -93,9 +93,9 @@ stored spelling from the census/registry before matching.
 ### Hook 2 (constant side): `&'static dyn Trait` static read → `SomeInstance(impl subclass)`
 
 `PlaceKind::Global` (mir.rs:4351). Today only the hard-wired `PyType` bucket narrows a static
-to a classed instance (`pytype_static_addr` → `__pyre_cast_instance["PyType"]`, mir.rs:4379).
+to a classed instance (`pytype_static_addr` → `__cast_instance_intrinsic["PyType"]`, mir.rs:4379).
 Generalize: when the static's declared type is a concrete `impl <RegisteredTrait>` struct,
-wrap the `ConstRefAddr` in `__pyre_cast_instance[<impl_root>]` so its annotation lands as
+wrap the `ConstRefAddr` in `__cast_instance_intrinsic[<impl_root>]` so its annotation lands as
 `SomeInstance(impl_subclass_classdef)`, which unions cleanly (commonbase) with the
 base-classed field cell from Hook 1.
 
@@ -169,7 +169,7 @@ ONLY from `getuniqueclassdef_for_struct_root` (pass-2 bookkeeper.rs:1858, drain 
 `getuniqueclassdef_for_enum_variant` (:1921). None run here.
 
 **Why the eager `ensure_session` struct-root prologue does not cover it** (the true keystone). The
-prologue (pyre_call_registry.rs:562-566) DOES loop `pyre_struct_root_names()` → each is a `reg.fields`
+prologue (call_registry.rs:562-566) DOES loop `struct_root_names()` → each is a `reg.fields`
 key, which is the **`::`-spelled / bare-leaf** spelling (mir.rs:1041-1042). So it calls
 `getuniqueclassdef_for_struct_root("pyre_object::dictmultiobject::W_DictObject")` — the **colon**
 root. But `intern_class_by_qualname` keys its class cache on `canonical_struct_name(&cur)`
@@ -209,10 +209,10 @@ carry a classdef at all. This reframes the fix (see below).
 - **(B) Hook 2 only (constant-side), NO field-side change.** Because the failing union is
   `Ptr ∪ Instance(None)` and `Instance(classed) ∪ Instance(None)` WIDENS (model.rs:3230), lowering the
   `&'static dyn Trait` static reads (mir.rs:4351 `PlaceKind::Global`) to a classed `SomeInstance` via
-  `__pyre_cast_instance[<impl_root>]` may resolve the union with zero field-side / pass-2 work. The
+  `__cast_instance_intrinsic[<impl_root>]` may resolve the union with zero field-side / pass-2 work. The
   field cell stays classdef-less; the widen arm absorbs it. **This is now the most promising minimal
   slice** and sidesteps the entire dotted/colon keystone. Needs: confirm the static read currently
-  produces `_ptr` (Ptr) not an Instance, and that `__pyre_cast_instance` on a static addr is wired.
+  produces `_ptr` (Ptr) not an Instance, and that `__cast_instance_intrinsic` on a static addr is wired.
 
 **Next slice = probe (B):** instrument whether lowering just the static-constant reads flips
 `_ptr ∪ <other>` to `Instance(impl) ∪ Instance(None)` → widen. If yes, (B) is the fix and the
@@ -222,7 +222,7 @@ dotted/colon split never needs touching.
 
 Implemented in `front/mir.rs` `PlaceKind::Global` arm + helper `refs_static_zerofield_struct_root`.
 A `refs`-bucket static whose declared type (`place.ty`, the bare pointee ADT for a Global place)
-resolves to a **zero-field unit struct** is narrowed `ConstRefAddr → __pyre_cast_instance[<impl_root>]`
+resolves to a **zero-field unit struct** is narrowed `ConstRefAddr → __cast_instance_intrinsic[<impl_root>]`
 → classed `SomeInstance(impl)`. Gated to zero-field structs so the 5 field-bearing object singletons
 (`W_NoneObject`/`W_BoolObject`×2/`NotImplemented`/`Ellipsis`) in the same 13-entry `refs` bucket
 (jit_fnaddr.rs:2062-2131) keep their raw-pointer lowering; catches the 8 dstrategy singletons.

--- a/majit/majit-translate/docs/design-346-foreign-lib-cluster-epic.md
+++ b/majit/majit-translate/docs/design-346-foreign-lib-cluster-epic.md
@@ -7,12 +7,12 @@ three readings of one unchanged input set:
 
 - **268 total phaseA failures:** commit `eca75827fe43618b24328653c150751f9b5399e8`,
   release profile, default features, the then-current frozen `build/llbc`
-  snapshot (not re-extracted), and `PYRE_RTYPER_VERBOSE=1`. The exact command
+  snapshot (not re-extracted), and `MAJIT_RTYPER_VERBOSE=1`. The exact command
   was:
 
   ```text
   touch pyre/pyre-jit-trace/build.rs
-  PYRE_RTYPER_VERBOSE=1 cargo build --release -p pyre-jit-trace
+  MAJIT_RTYPER_VERBOSE=1 cargo build --release -p pyre-jit-trace
   stderr=$(ls -t target/release/build/pyre-jit-trace-*/stderr | head -1)
   rg --no-config 'PREPASS phaseA fail' "$stderr" | sort -u | wc -l
   ```
@@ -20,18 +20,18 @@ three readings of one unchanged input set:
 - **16 `try_from`-headed phaseA failures:** commit
   `ccdc1a52be2237365154976149e7b573db811d82`, release profile, default
   features, that worktree's frozen `build/llbc` snapshot, and
-  `PYRE_RTYPER_VERBOSE=1`. This is a filtered diagnostic count, not a total:
+  `MAJIT_RTYPER_VERBOSE=1`. This is a filtered diagnostic count, not a total:
 
   ```text
   touch pyre/pyre-jit-trace/build.rs
-  PYRE_RTYPER_VERBOSE=1 cargo build --release -p pyre-jit-trace
+  MAJIT_RTYPER_VERBOSE=1 cargo build --release -p pyre-jit-trace
   stderr=$(ls -t target/release/build/pyre-jit-trace-*/stderr | head -1)
   rg --no-config 'PREPASS phaseA fail' "$stderr" | rg --no-config 'try_from' | sort -u | wc -l
   ```
 
 - **276 total post-Slice-A phaseA failures** (the *post-Slice-A baseline
   commit*, named that way everywhere below): release profile, default
-  features, and `PYRE_RTYPER_VERBOSE=1`.
+  features, and `MAJIT_RTYPER_VERBOSE=1`.
 
   That commit existed only on a feature branch and was later replaced by the
   squash merge in PR #606 (`7944966b4dd`, "jit: retire foreign-lib cluster
@@ -45,7 +45,7 @@ three readings of one unchanged input set:
   ```text
   python3 scripts/extract-llbc.py
   touch pyre/pyre-jit-trace/build.rs
-  PYRE_RTYPER_VERBOSE=1 cargo build --release -p pyre-jit-trace
+  MAJIT_RTYPER_VERBOSE=1 cargo build --release -p pyre-jit-trace
   stderr=$(ls -t target/release/build/pyre-jit-trace-*/stderr | head -1)
   rg --no-config 'PREPASS phaseA fail' "$stderr" | sort -u | wc -l
   ```

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -346,7 +346,7 @@ pub struct Bookkeeper {
     /// registered `ClassDef.attrs`.  `None` for unit-test fixtures that
     /// build the bookkeeper directly, in which case
     /// `getuniqueclassdef_for_struct_root` leaves `attrs` empty.
-    pub pyre_struct_fields: RefCell<Option<Rc<crate::front::StructFieldRegistry>>>,
+    pub struct_fields: RefCell<Option<Rc<crate::front::StructFieldRegistry>>>,
     /// TODO: no upstream equivalent (RPython has no Rust enums).  Enum
     /// type-root name (dual-keyed: qualified path and bare leaf) →
     /// `discriminant value → variant name` table.  Consulted by
@@ -354,8 +354,7 @@ pub struct Bookkeeper {
     /// discriminant→variant narrowing `knowntypedata` the `__discriminant`
     /// getattr attaches.  `None` for unit-test fixtures that build the
     /// bookkeeper directly.
-    pub pyre_enum_variant_by_discriminant:
-        RefCell<Option<Rc<HashMap<String, HashMap<i64, String>>>>>,
+    pub enum_variant_by_discriminant: RefCell<Option<Rc<HashMap<String, HashMap<i64, String>>>>>,
     /// TODO: no upstream equivalent.  Interning table mapping a struct
     /// type-root name to its canonical host class `HostObject`.  Because
     /// `HostObject` equality is `Arc` pointer identity (`impl PartialEq for
@@ -367,7 +366,7 @@ pub struct Bookkeeper {
     /// `annotationoftype(t) -> getuniqueclassdef(t)` (signature.py)
     /// where `t` is the already-resolved class object.  Used by
     /// [`Self::getuniqueclassdef_for_struct_root`].
-    pub pyre_struct_root_classes: RefCell<HashMap<String, HostObject>>,
+    pub struct_root_classes: RefCell<HashMap<String, HostObject>>,
     /// TODO: no upstream equivalent.  Qualified trait path → owner
     /// root of its only concrete impl in the analyzed LLBC world
     /// (computed in `lib.rs` from `concrete_trait_methods`; multi-impl
@@ -380,7 +379,7 @@ pub struct Bookkeeper {
     /// [`Self::getuniqueclassdef_for_struct_root`].
     /// RPython's annotator never needs this: it sees the concrete
     /// receiver class at every call site (`classdesc.py lookup`).
-    pub pyre_trait_unique_impls: RefCell<HashMap<String, String>>,
+    pub trait_unique_impls: RefCell<HashMap<String, String>>,
     /// Trait qualified-path (`name_path()`) → base `HostObject` for a
     /// receiver-driven method-dispatch family registered through
     /// [`Self::register_trait_family`] (receiver-dispatch configuration).
@@ -390,9 +389,9 @@ pub struct Bookkeeper {
     /// `MethodDesc` family (attrfamily merge) rather than blocking on
     /// the classdef-less shell.  Empty unless a consumer opts a trait
     /// in; pyre production registers none.
-    pub pyre_trait_family_bases: RefCell<HashMap<String, HostObject>>,
+    pub trait_family_bases: RefCell<HashMap<String, HostObject>>,
     /// TODO: no upstream equivalent.  Struct names first interned by
-    /// [`Self::project_pyre_field_type`]'s bare-name arm whose
+    /// [`Self::project_struct_field_type`]'s bare-name arm whose
     /// registry rows have not been projected yet — drained at the end
     /// of [`Self::getuniqueclassdef_for_struct_root`] so a class
     /// never exposes its untyped FORCE shells to subject flow (a
@@ -579,11 +578,11 @@ impl Bookkeeper {
             all_specializations: RefCell::new(HashMap::new()),
             position_entered: std::cell::Cell::new(false),
             needs_generic_instantiate: RefCell::new(std::collections::BTreeMap::new()),
-            pyre_struct_fields: RefCell::new(None),
-            pyre_enum_variant_by_discriminant: RefCell::new(None),
-            pyre_struct_root_classes: RefCell::new(HashMap::new()),
-            pyre_trait_unique_impls: RefCell::new(HashMap::new()),
-            pyre_trait_family_bases: RefCell::new(HashMap::new()),
+            struct_fields: RefCell::new(None),
+            enum_variant_by_discriminant: RefCell::new(None),
+            struct_root_classes: RefCell::new(HashMap::new()),
+            trait_unique_impls: RefCell::new(HashMap::new()),
+            trait_family_bases: RefCell::new(HashMap::new()),
             pending_struct_row_projection: RefCell::new(Vec::new()),
             projected_struct_rows: RefCell::new(std::collections::HashSet::new()),
         }
@@ -600,33 +599,30 @@ impl Bookkeeper {
     /// arrived has its attrs back-filled on the next lookup (RPython grows
     /// class attrs as annotation proceeds).  Idempotent: a second call
     /// overwrites the previous registry.
-    pub fn set_pyre_struct_fields(&self, registry: Rc<crate::front::StructFieldRegistry>) {
-        *self.pyre_struct_fields.borrow_mut() = Some(registry);
+    pub fn set_struct_fields(&self, registry: Rc<crate::front::StructFieldRegistry>) {
+        *self.struct_fields.borrow_mut() = Some(registry);
     }
 
     /// TODO: no upstream equivalent.  Wire the enum
     /// `discriminant → variant` tables consumed by
     /// [`Self::enum_variant_narrowing_knowntypedata`].  Idempotent: a
     /// second call overwrites the previous map.
-    pub fn set_pyre_enum_variant_by_discriminant(
-        &self,
-        map: Rc<HashMap<String, HashMap<i64, String>>>,
-    ) {
-        *self.pyre_enum_variant_by_discriminant.borrow_mut() = Some(map);
+    pub fn set_enum_variant_by_discriminant(&self, map: Rc<HashMap<String, HashMap<i64, String>>>) {
+        *self.enum_variant_by_discriminant.borrow_mut() = Some(map);
     }
 
     /// TODO: no upstream equivalent.  Wire the trait →
     /// unique-concrete-impl-owner map (see
-    /// [`Self::pyre_trait_unique_impls`]).  Idempotent: a second call
+    /// [`Self::trait_unique_impls`]).  Idempotent: a second call
     /// overwrites the previous map.
-    pub fn set_pyre_trait_unique_impls(&self, map: HashMap<String, String>) {
-        *self.pyre_trait_unique_impls.borrow_mut() = map;
+    pub fn set_trait_unique_impls(&self, map: HashMap<String, String>) {
+        *self.trait_unique_impls.borrow_mut() = map;
     }
 
     /// TODO: no upstream equivalent.  The full set of struct type-root
     /// keys in the snapshot registry (`StructFieldRegistry.fields`).
     /// The session-prologue inheritance-id pass
-    /// (`PyreCallRegistry::ensure_session`) iterates these to eagerly
+    /// (`CallRegistry::ensure_session`) iterates these to eagerly
     /// pre-register the build-time-closed `W_*` struct hierarchy before
     /// running [`crate::translator::rtyper::normalizecalls::assign_inheritance_ids`].
     /// Returns owned `String`s (not an iterator) so the registry borrow
@@ -634,9 +630,9 @@ impl Bookkeeper {
     /// [`Self::getuniqueclassdef_for_struct_root`].  Empty when no
     /// registry is set (unit-test fixtures), degrading the pass to a
     /// no-op over whatever classdefs already exist.
-    pub fn pyre_struct_root_names(&self) -> Vec<String> {
+    pub fn struct_root_names(&self) -> Vec<String> {
         let mut roots: Vec<String> = self
-            .pyre_struct_fields
+            .struct_fields
             .borrow()
             .as_ref()
             .map(|reg| reg.fields.keys().cloned().collect())
@@ -654,31 +650,31 @@ impl Bookkeeper {
     }
 
     /// True when `leaf` is the trait-leaf of a registered dispatch family
-    /// ([`Self::pyre_trait_family_bases`], keyed by the trait's full
+    /// ([`Self::trait_family_bases`], keyed by the trait's full
     /// `name_path()`).  A method call lowered as `FunctionPath [<leaf>,
     /// method]` (`front::mir`'s `CallKind::Trait` arm spells the trait by
     /// leaf) routes through the receiver's getattr when this matches and
     /// the direct-path registry has no entry (the required-method,
     /// `>=2`-impl case).  Empty unless a consumer opts a trait in.
     pub fn is_registered_trait_family_leaf(&self, leaf: &str) -> bool {
-        self.pyre_trait_family_bases
+        self.trait_family_bases
             .borrow()
             .keys()
             .any(|path| path.rsplit("::").next().unwrap_or(path) == leaf)
     }
 
     /// Resolve a bare trait `leaf` to the unique registered dispatch-family
-    /// base spelling ([`Self::pyre_trait_family_bases`] key = the trait's
+    /// base spelling ([`Self::trait_family_bases`] key = the trait's
     /// full `name_path()`).  The inline-Field `CallTarget::Indirect` carries
     /// the trait by leaf (`dyn_indirect_target` strips the vtable path to its
     /// leaf, matching `register_trait_method`), but the receiver-narrowing
-    /// cast (`__pyre_cast_instance`) and the family base mint both key on the
+    /// cast (`__cast_instance_intrinsic`) and the family base mint both key on the
     /// qualified spelling — so the leaf must map back to it.  Returns `None`
     /// when the leaf matches no family or matches more than one qualified
     /// path (ambiguous — the caller then keeps the classdef-less receiver
     /// rather than casting to an arbitrary base).
     pub fn registered_trait_family_base_root(&self, leaf: &str) -> Option<String> {
-        let bases = self.pyre_trait_family_bases.borrow();
+        let bases = self.trait_family_bases.borrow();
         let mut matches = bases
             .keys()
             .filter(|path| path.rsplit("::").next().unwrap_or(path) == leaf);
@@ -707,7 +703,7 @@ impl Bookkeeper {
     /// subclasses of every registered enum so the session-prologue
     /// [`crate::translator::rtyper::normalizecalls::assign_inheritance_ids`]
     /// pass numbers each `enum-base + variant-children` subtree as one
-    /// contiguous bracket.  Called from `PyreCallRegistry::ensure_session`
+    /// contiguous bracket.  Called from `CallRegistry::ensure_session`
     /// AFTER the struct-root loop (so the enum-base classdefs already
     /// exist, UNNUMBERED) and BEFORE the single `assign_inheritance_ids`.
     ///
@@ -742,12 +738,12 @@ impl Bookkeeper {
     pub fn pre_register_enum_variant_classes(self: &Rc<Self>) {
         // Collect (qualified_root, [variant names]) for every enum base,
         // releasing both registry borrows before minting (the intern /
-        // getuniqueclassdef calls re-borrow `pyre_struct_fields` and
-        // `pyre_struct_root_classes`).  Sorted for a deterministic mint
+        // getuniqueclassdef calls re-borrow `struct_fields` and
+        // `struct_root_classes`).  Sorted for a deterministic mint
         // order so the numbering bracket is reproducible.
         let mut pairs: Vec<(String, Vec<String>)> = {
-            let variant_guard = self.pyre_enum_variant_by_discriminant.borrow();
-            let fields_guard = self.pyre_struct_fields.borrow();
+            let variant_guard = self.enum_variant_by_discriminant.borrow();
+            let fields_guard = self.struct_fields.borrow();
             let (Some(variants), Some(reg)) = (variant_guard.as_ref(), fields_guard.as_ref())
             else {
                 return;
@@ -1747,7 +1743,7 @@ impl Bookkeeper {
         if root.contains("::") || root.contains('<') {
             return None;
         }
-        let guard = self.pyre_struct_fields.borrow();
+        let guard = self.struct_fields.borrow();
         let reg = guard.as_ref()?;
         if reg.fields.contains_key(root) {
             return None;
@@ -1795,13 +1791,13 @@ impl Bookkeeper {
     /// The struct fields are instance attributes: RPython discovers them
     /// by annotating `setattr`/`__init__`, but pyre has no such pass for
     /// host structs, so the registry projection (via
-    /// [`Self::project_pyre_field_type`]) stands in.  The whole reachable
+    /// [`Self::project_struct_field_type`]) stands in.  The whole reachable
     /// struct-field graph is registered and projected — an explicit
     /// work-list bounds recursion at the reachable-struct count — so a
     /// field typed as another struct resolves to a fully populated inner
     /// `SomeInstance(classdef)`, not an attrs-empty inner stub.
     ///
-    /// Order-independent w.r.t. [`Self::set_pyre_struct_fields`]: the call
+    /// Order-independent w.r.t. [`Self::set_struct_fields`]: the call
     /// re-traverses and re-projects every time, so a root registered
     /// before the field registry arrived has its (and its transitive
     /// structs') attrs back-filled on a later call — RPython grows class
@@ -1822,7 +1818,7 @@ impl Bookkeeper {
         // Pass 1 — traverse the registry's struct-field graph from `root`,
         // registering an identity-keyed `ClassDef` in `descs` for every
         // reachable struct (via `intern_class_by_qualname` ->
-        // `getuniqueclassdef`).  `project_pyre_field_type`'s bare-name arm
+        // `getuniqueclassdef`).  `project_struct_field_type`'s bare-name arm
         // resolves inner struct references through the same identity path,
         // so it sees the registered classdef.  Registration is idempotent
         // (the identity cache is the memo), so a root reached before the
@@ -1866,7 +1862,7 @@ impl Bookkeeper {
                 self.getuniqueclassdef(h)?;
             }
             let referenced: Vec<String> = {
-                let guard = self.pyre_struct_fields.borrow();
+                let guard = self.struct_fields.borrow();
                 if let Some(reg) = guard.as_ref() {
                     if let Some(fields) = reg.fields.get(&n) {
                         let mut out: Vec<String> = Vec::new();
@@ -1911,7 +1907,7 @@ impl Bookkeeper {
         for n in &graph {
             self.project_struct_rows(n)?;
         }
-        // Drain structs first interned by `project_pyre_field_type`'s
+        // Drain structs first interned by `project_struct_field_type`'s
         // bare-name arm during the loop above.  Pass-1's
         // `collect_referenced_struct_names` string parser and the
         // projector resolve type strings independently; a name only
@@ -2014,7 +2010,7 @@ impl Bookkeeper {
     /// getattr binds each method to its correct owner.
     ///
     /// OPT-IN: only a trait registered through this entry point gets a
-    /// member-carrying host in `pyre_struct_root_classes`.  Every other
+    /// member-carrying host in `struct_root_classes`.  Every other
     /// (unregistered) multi-impl trait keeps its current classdef-less /
     /// fail-loud disposition, so this cannot perturb the annotation of pyre
     /// production dispatch that was never registered.
@@ -2028,7 +2024,7 @@ impl Bookkeeper {
         impls: Vec<(String, IndexMap<String, ConstValue>)>,
     ) -> Result<Rc<RefCell<ClassDef>>, AnnotatorError> {
         // Base first — its identity-keyed HostObject must be published in
-        // `pyre_struct_root_classes` before the subclasses intern, so each
+        // `struct_root_classes` before the subclasses intern, so each
         // subclass's `__bases__` resolves to this exact base host (the same
         // discipline `getuniqueclassdef_for_enum_variant` relies on).
         let base_key = majit_ir::descr::canonical_struct_name(base_root);
@@ -2037,14 +2033,14 @@ impl Bookkeeper {
             Vec::new(),
             base_members,
         );
-        self.pyre_struct_root_classes
+        self.struct_root_classes
             .borrow_mut()
             .insert(base_key, base_host.clone());
         // Index the base by the raw `base_root` spelling too, so the
         // receiver seed (`derive_subject_inputcells`) can match a
         // `dyn Trait` receiver's `class_root` (the trait's `name_path()`)
         // directly without re-canonicalising.
-        self.pyre_trait_family_bases
+        self.trait_family_bases
             .borrow_mut()
             .insert(base_root.to_string(), base_host.clone());
         let base_cd = self.getuniqueclassdef(&base_host)?;
@@ -2057,7 +2053,7 @@ impl Bookkeeper {
                 vec![base_host.clone()],
                 members,
             );
-            self.pyre_struct_root_classes
+            self.struct_root_classes
                 .borrow_mut()
                 .insert(impl_key, impl_host.clone());
             self.getuniqueclassdef(&impl_host)?;
@@ -2122,7 +2118,7 @@ impl Bookkeeper {
             // its `<…>` suffix to resolve.  Bare names pass through
             // unchanged.
             let lookup_root = majit_ir::descr::strip_instantiation_suffix(enum_root);
-            let guard = self.pyre_enum_variant_by_discriminant.borrow();
+            let guard = self.enum_variant_by_discriminant.borrow();
             let map = guard.as_ref()?;
             map.get(lookup_root)
                 .or_else(|| {
@@ -2195,7 +2191,7 @@ impl Bookkeeper {
             {
                 Vec::new()
             } else {
-                let guard = self.pyre_struct_fields.borrow();
+                let guard = self.struct_fields.borrow();
                 guard
                     .as_ref()
                     .and_then(|r| r.fields.get(n))
@@ -2207,7 +2203,7 @@ impl Bookkeeper {
             }
         };
         let mut fields: Vec<(String, String)> = {
-            let guard = self.pyre_struct_fields.borrow();
+            let guard = self.struct_fields.borrow();
             match guard.as_ref().and_then(|r| {
                 if majit_ir::descr::is_shaped_tuple_name(n)
                     || majit_ir::descr::is_shaped_array_name(n)
@@ -2229,7 +2225,7 @@ impl Bookkeeper {
             // `setattr` per element), so a projected row has to agree with the
             // value that sequence produces. A sum-typed element does not: the
             // constructor materializes a variant INSTANCE, while
-            // `project_pyre_field_type` models the spelling as the nullable
+            // `project_struct_field_type` models the spelling as the nullable
             // payload — `Option<Vec<*mut PyObject>>` projects to list-or-none
             // and then fails `generalize_attr` against
             // `Instance(Option<Vec<*mut PyObject>>::None)`.  Leave those rows
@@ -2256,7 +2252,7 @@ impl Bookkeeper {
         // of the per-instantiation raw-pointer payload row, so project the two
         // as one slice.
         {
-            let guard = self.pyre_struct_fields.borrow();
+            let guard = self.struct_fields.borrow();
             if let Some(exact) = guard.as_ref().and_then(|r| r.fields.get(n)) {
                 for (fname, fty) in &mut fields {
                     if let Some((_, exact_ty)) = exact.iter().find(|(en, _)| en == fname) {
@@ -2306,7 +2302,7 @@ impl Bookkeeper {
             if field_name == "__class__" {
                 continue;
             }
-            let s_value = self.project_pyre_field_type(field_ty);
+            let s_value = self.project_struct_field_type(field_ty);
             let mut classdef_mut = classdef.borrow_mut();
             let attr = classdef_mut
                 .attrs
@@ -2344,7 +2340,7 @@ impl Bookkeeper {
 
     /// Resolve a struct type-root name to its canonical host class
     /// `HostObject`, minting it on first sight and caching by name in
-    /// [`Self::pyre_struct_root_classes`].  Because `HostObject`
+    /// [`Self::struct_root_classes`].  Because `HostObject`
     /// equality is `Arc` pointer identity, this interning is what makes
     /// `getuniqueclassdef` return the SAME `ClassDef` for repeated
     /// lookups of one type-root — the pyre analog of resolving a type
@@ -2398,7 +2394,7 @@ impl Bookkeeper {
         let mut cur = name.to_string();
         loop {
             let key = majit_ir::descr::canonical_struct_name(&cur);
-            if let Some(existing) = self.pyre_struct_root_classes.borrow().get(&key) {
+            if let Some(existing) = self.struct_root_classes.borrow().get(&key) {
                 if chain.is_empty() {
                     return existing.clone();
                 }
@@ -2407,7 +2403,7 @@ impl Bookkeeper {
             }
             seen.insert(cur.rsplit("::").next().unwrap_or(&cur).to_string());
             chain.push(cur.clone());
-            let next = self.pyre_struct_fields.borrow().as_ref().and_then(|reg| {
+            let next = self.struct_fields.borrow().as_ref().and_then(|reg| {
                 // A constructor mints its class under the dot-joined,
                 // crate-included qualname (`pyre_object.intobject.
                 // W_IntObject`, flowspace_adapter `SyntheticTransparentCtor`
@@ -2424,7 +2420,7 @@ impl Bookkeeper {
                 // (`rclass.py:82-88`).  Checked before the header convention
                 // because a variant's first field is its payload, not a
                 // header: without this the session prologue
-                // (`PyreCallRegistry::ensure_session`), which pre-mints every
+                // (`CallRegistry::ensure_session`), which pre-mints every
                 // `struct_fields` key including the variant keys, would mint
                 // the variant base-less, and first-mint-wins would freeze
                 // that, dropping the subclass link the narrowing relies on.
@@ -2475,7 +2471,7 @@ impl Bookkeeper {
             let key = majit_ir::descr::canonical_struct_name(node);
             let bases = base_host.iter().cloned().collect();
             let host = crate::flowspace::model::HostObject::new_class(key.clone(), bases);
-            self.pyre_struct_root_classes
+            self.struct_root_classes
                 .borrow_mut()
                 .insert(key, host.clone());
             base_host = Some(host);
@@ -2495,25 +2491,25 @@ impl Bookkeeper {
         bases: Vec<HostObject>,
     ) -> HostObject {
         let key = majit_ir::descr::canonical_struct_name(name);
-        if let Some(existing) = self.pyre_struct_root_classes.borrow().get(&key) {
+        if let Some(existing) = self.struct_root_classes.borrow().get(&key) {
             return existing.clone();
         }
         let host = crate::flowspace::model::HostObject::new_class(key.clone(), bases);
-        self.pyre_struct_root_classes
+        self.struct_root_classes
             .borrow_mut()
             .insert(key, host.clone());
         host
     }
 
     /// True when `name` is a type-root key in the snapshot
-    /// struct-field registry ([`Self::pyre_struct_fields`]).  Enums and
+    /// struct-field registry ([`Self::struct_fields`]).  Enums and
     /// structs both register under their qualified path AND bare leaf
     /// (`front/mir.rs` `TypeDeclKind::Enum` / `Struct` arms), so a
     /// ctor's `owner_path` last segment answers true exactly when the
     /// owner is itself an ADT (an enum-variant ctor) rather than a
     /// module (a struct ctor).
-    pub fn is_pyre_struct_root(&self, name: &str) -> bool {
-        self.pyre_struct_fields
+    pub fn is_known_struct_root(&self, name: &str) -> bool {
+        self.struct_fields
             .borrow()
             .as_ref()
             .is_some_and(|reg| reg.fields.contains_key(name))
@@ -2524,15 +2520,12 @@ impl Bookkeeper {
     /// so a method member never shadows a same-named instance field — a
     /// function source for a field attribute would union-conflict in
     /// `generalize_attr`.
-    pub fn pyre_struct_root_has_field(&self, root: &str, name: &str) -> bool {
-        self.pyre_struct_fields
-            .borrow()
-            .as_ref()
-            .is_some_and(|reg| {
-                reg.fields
-                    .get(root)
-                    .is_some_and(|rows| rows.iter().any(|(field, _)| field == name))
-            })
+    pub fn struct_root_has_field(&self, root: &str, name: &str) -> bool {
+        self.struct_fields.borrow().as_ref().is_some_and(|reg| {
+            reg.fields
+                .get(root)
+                .is_some_and(|rows| rows.iter().any(|(field, _)| field == name))
+        })
     }
 
     /// TODO: no upstream equivalent.  Project a Rust type
@@ -2545,7 +2538,7 @@ impl Bookkeeper {
     /// (`PyFrame`, `W_DictObject`) resolve to
     /// `SomeInstance(stub)` only when the registry contains a matching
     /// entry; unknown bare names fall to `Impossible`.
-    pub fn project_pyre_field_type(self: &Rc<Self>, field_ty: &str) -> SomeValue {
+    pub fn project_struct_field_type(self: &Rc<Self>, field_ty: &str) -> SomeValue {
         let t = field_ty.trim();
         // A raw-pointer field (`*const T` / `*mut T`) holds a one-word
         // pointer, not a `T`.  Projecting the pointee is right for an
@@ -2565,7 +2558,7 @@ impl Bookkeeper {
             .strip_prefix("*const ")
             .or_else(|| t.strip_prefix("*mut "))
         {
-            let s_pointee = self.project_pyre_field_type(pointee.trim());
+            let s_pointee = self.project_struct_field_type(pointee.trim());
             if matches!(
                 s_pointee,
                 SomeValue::Integer(_)
@@ -2638,7 +2631,7 @@ impl Bookkeeper {
         }
         for list_wrapper in ["Vec<", "VecDeque<"] {
             if let Some(inner) = strip_generic_one(stripped, list_wrapper) {
-                let s_inner = self.project_pyre_field_type(inner);
+                let s_inner = self.project_struct_field_type(inner);
                 let listdef =
                     super::listdef::ListDef::new(Some(self.clone()), s_inner, false, false);
                 return SomeValue::List(super::model::SomeList::new(listdef));
@@ -2649,20 +2642,20 @@ impl Bookkeeper {
                 Some(semi) => rest[..semi].trim(),
                 None => rest.trim(),
             };
-            let s_inner = self.project_pyre_field_type(inner);
+            let s_inner = self.project_struct_field_type(inner);
             let listdef = super::listdef::ListDef::new(Some(self.clone()), s_inner, false, false);
             return SomeValue::List(super::model::SomeList::new(listdef));
         }
         if let Some(inner) = strip_generic_one(stripped, "Option<") {
-            let s_inner = self.project_pyre_field_type(inner);
+            let s_inner = self.project_struct_field_type(inner);
             let s_none = super::model::s_none();
             return super::model::unionof([&s_inner, &s_none]).unwrap_or(SomeValue::Impossible);
         }
         if let Some(inner) = strip_generic_one(stripped, "Result<") {
             let parts = split_generic_args(inner);
             if parts.len() == 2 {
-                let s_ok = self.project_pyre_field_type(parts[0]);
-                let s_err = self.project_pyre_field_type(parts[1]);
+                let s_ok = self.project_struct_field_type(parts[0]);
+                let s_err = self.project_struct_field_type(parts[1]);
                 return super::model::unionof([&s_ok, &s_err]).unwrap_or(SomeValue::Impossible);
             }
         }
@@ -2670,8 +2663,8 @@ impl Bookkeeper {
             if let Some(inner) = strip_generic_one(stripped, dict_wrapper) {
                 let parts = split_generic_args(inner);
                 if parts.len() == 2 {
-                    let s_key = self.project_pyre_field_type(parts[0]);
-                    let s_val = self.project_pyre_field_type(parts[1]);
+                    let s_key = self.project_struct_field_type(parts[0]);
+                    let s_val = self.project_struct_field_type(parts[1]);
                     let dictdef = super::dictdef::DictDef::new(
                         Some(self.clone()),
                         s_key,
@@ -2686,7 +2679,7 @@ impl Bookkeeper {
         }
         for set_wrapper in ["HashSet<", "BTreeSet<", "IndexSet<"] {
             if let Some(inner) = strip_generic_one(stripped, set_wrapper) {
-                let s_key = self.project_pyre_field_type(inner);
+                let s_key = self.project_struct_field_type(inner);
                 let s_val = super::model::s_none();
                 let dictdef = super::dictdef::DictDef::new(
                     Some(self.clone()),
@@ -2704,7 +2697,7 @@ impl Bookkeeper {
             if !parts.is_empty() {
                 let items: Vec<SomeValue> = parts
                     .iter()
-                    .map(|p| self.project_pyre_field_type(p))
+                    .map(|p| self.project_struct_field_type(p))
                     .collect();
                 return SomeValue::Tuple(super::model::SomeTuple::new(items));
             }
@@ -2725,13 +2718,13 @@ impl Bookkeeper {
             "Reverse<",
         ] {
             if let Some(inner) = strip_generic_one(stripped, wrapper) {
-                return self.project_pyre_field_type(inner);
+                return self.project_struct_field_type(inner);
             }
         }
         if let Some(inner) = strip_generic_one(stripped, "Cow<") {
             let parts = split_generic_args(inner);
             if parts.len() == 2 {
-                return self.project_pyre_field_type(parts[1]);
+                return self.project_struct_field_type(parts[1]);
             }
         }
         // `FixedObjectArray { len: usize, _items: [PyObjectRef; 0] }` is a
@@ -2746,12 +2739,12 @@ impl Bookkeeper {
         // classdef-less stub.
         if majit_ir::descr::canonical_struct_name(stripped) == "object_array::FixedObjectArray" {
             let items_ty = self
-                .pyre_struct_fields
+                .struct_fields
                 .borrow()
                 .as_ref()
                 .and_then(|reg| reg.field_type(stripped, "_items").map(str::to_string));
             if let Some(items_ty) = items_ty {
-                return self.project_pyre_field_type(&items_ty);
+                return self.project_struct_field_type(&items_ty);
             }
         }
         // Named generic structs in Charon's registry are stored under their
@@ -2763,7 +2756,7 @@ impl Bookkeeper {
         // classes whose dedicated paths never reach this arm.
         let named_root = if strip_generic_one(stripped, "Complex<").is_some()
             && self
-                .pyre_struct_fields
+                .struct_fields
                 .borrow()
                 .as_ref()
                 .is_some_and(|r| r.fields.contains_key("num_complex::Complex"))
@@ -2779,7 +2772,7 @@ impl Bookkeeper {
             majit_ir::descr::strip_generic_args(stripped)
         };
         let registered = {
-            let guard = self.pyre_struct_fields.borrow();
+            let guard = self.struct_fields.borrow();
             guard
                 .as_ref()
                 .map(|r| r.fields.contains_key(named_root.as_ref()))
@@ -3814,7 +3807,7 @@ fn collect_referenced_struct_names(
 }
 
 /// Whether a field-type spelling names a sum type that
-/// [`Bookkeeper::project_pyre_field_type`] models as its *payload* plus
+/// [`Bookkeeper::project_struct_field_type`] models as its *payload* plus
 /// `None` — the nullable-pointer shape (`Option<Vec<T>>` → list-or-none).
 /// That model describes a field lowered to one nullable word; it does NOT
 /// describe a slot the frontend fills with a materialized variant instance
@@ -4322,7 +4315,7 @@ mod tests {
             "PyCode".to_string(),
             vec![("argcount".to_string(), "i64".to_string())],
         );
-        bk.set_pyre_struct_fields(Rc::new(reg));
+        bk.set_struct_fields(Rc::new(reg));
 
         let cd1 = bk
             .getuniqueclassdef_for_struct_root("PyFrame")
@@ -4411,18 +4404,21 @@ mod tests {
             "Complex".to_string(),
             reg.fields["num_complex::Complex"].clone(),
         );
-        bk.set_pyre_struct_fields(Rc::new(reg));
+        bk.set_struct_fields(Rc::new(reg));
 
         assert!(
-            matches!(bk.project_pyre_field_type("BigInt"), SomeValue::Instance(ref s) if s.classdef.is_none()),
+            matches!(bk.project_struct_field_type("BigInt"), SomeValue::Instance(ref s) if s.classdef.is_none()),
             "dependency-opaque compiler BigInt remains one GC reference"
         );
         assert!(
-            matches!(bk.project_pyre_field_type("Wtf8Buf"), SomeValue::String(_)),
+            matches!(
+                bk.project_struct_field_type("Wtf8Buf"),
+                SomeValue::String(_)
+            ),
             "Wtf8Buf shares the immutable string annotation"
         );
 
-        let SomeValue::Instance(complex) = bk.project_pyre_field_type("Complex<f64>") else {
+        let SomeValue::Instance(complex) = bk.project_struct_field_type("Complex<f64>") else {
             panic!("Complex<f64> must project to its registered struct class")
         };
         let complex_cd = complex.classdef.expect("Complex classdef");
@@ -4440,7 +4436,8 @@ mod tests {
             Some(SomeValue::Float(_))
         ));
 
-        let SomeValue::Instance(code) = bk.project_pyre_field_type("Box<CodeObject<ConstantData>>")
+        let SomeValue::Instance(code) =
+            bk.project_struct_field_type("Box<CodeObject<ConstantData>>")
         else {
             panic!("concrete CodeObject instantiation must use the template class")
         };
@@ -4473,7 +4470,7 @@ mod tests {
             "Color::Rgb".to_string(),
             vec![("rgb".to_string(), "i64".to_string())],
         );
-        bk.set_pyre_struct_fields(Rc::new(reg));
+        bk.set_struct_fields(Rc::new(reg));
 
         let base = bk
             .getuniqueclassdef_for_struct_root("Color")
@@ -4544,7 +4541,7 @@ mod tests {
 
     #[test]
     fn enum_variant_subclasses_base_even_when_struct_root_preregistered_first() {
-        // The session prologue (`PyreCallRegistry::ensure_session`) pre-mints
+        // The session prologue (`CallRegistry::ensure_session`) pre-mints
         // EVERY `struct_fields` key through `getuniqueclassdef_for_struct_root`
         // — including the variant keys — BEFORE any narrowing's
         // `getuniqueclassdef_for_enum_variant` runs.  Since
@@ -4561,10 +4558,10 @@ mod tests {
             "Color::Rgb".to_string(),
             vec![("rgb".to_string(), "i64".to_string())],
         );
-        bk.set_pyre_struct_fields(Rc::new(reg));
+        bk.set_struct_fields(Rc::new(reg));
 
         // Prologue order: pre-register every struct root, variant keys first.
-        for root in bk.pyre_struct_root_names() {
+        for root in bk.struct_root_names() {
             let _ = bk.getuniqueclassdef_for_struct_root(&root);
         }
         let base = bk
@@ -4603,7 +4600,7 @@ mod tests {
             "shapes::Color::Rgb".to_string(),
             vec![("rgb".to_string(), "i64".to_string())],
         );
-        bk.set_pyre_struct_fields(Rc::new(reg));
+        bk.set_struct_fields(Rc::new(reg));
 
         // Constructor side: the adapter interns through this helper.
         let ctor_host = bk.intern_enum_variant_host("shapes::Color", "Rgb");
@@ -4673,7 +4670,7 @@ mod tests {
             "probemod::Newt::Eft".to_string(),
             vec![("eft".to_string(), "i64".to_string())],
         );
-        bk.set_pyre_struct_fields(Rc::new(reg));
+        bk.set_struct_fields(Rc::new(reg));
         // The origin `front::mir` now registers for an enum leaf.
         majit_ir::descr::register_struct_origins(
             [("Newt".to_string(), "probemod".to_string())].into(),
@@ -4716,7 +4713,7 @@ mod tests {
                 ("rgb".to_string(), "i64".to_string()),
             ],
         );
-        bk.set_pyre_struct_fields(Rc::new(reg));
+        bk.set_struct_fields(Rc::new(reg));
 
         // discriminant 0 -> Rgb, 1 -> Named.
         let mut by_discr: HashMap<i64, String> = HashMap::new();
@@ -4724,7 +4721,7 @@ mod tests {
         by_discr.insert(1, "Named".to_string());
         let mut map: HashMap<String, HashMap<i64, String>> = HashMap::new();
         map.insert("Color".to_string(), by_discr);
-        bk.set_pyre_enum_variant_by_discriminant(Rc::new(map));
+        bk.set_enum_variant_by_discriminant(Rc::new(map));
 
         let base = bk
             .getuniqueclassdef_for_struct_root("Color")
@@ -4797,7 +4794,7 @@ mod tests {
             "Opt<i64>".to_string(),
             vec![("__discriminant".to_string(), "i64".to_string())],
         );
-        bk.set_pyre_struct_fields(Rc::new(reg));
+        bk.set_struct_fields(Rc::new(reg));
 
         // Table keyed by the bare template root (`strip_instantiation_suffix`
         // reduces both `Opt<i64>` and `Opt<i64>::A` to `Opt`).
@@ -4806,7 +4803,7 @@ mod tests {
         by_discr.insert(1, "B".to_string());
         let mut map: HashMap<String, HashMap<i64, String>> = HashMap::new();
         map.insert("Opt".to_string(), by_discr);
-        bk.set_pyre_enum_variant_by_discriminant(Rc::new(map));
+        bk.set_enum_variant_by_discriminant(Rc::new(map));
 
         let receiver = Rc::new(Variable::new());
         let from_base = bk
@@ -4870,7 +4867,7 @@ mod tests {
                 ("mro".to_string(), "Vec<W_TypeObject>".to_string()),
             ],
         );
-        bk.set_pyre_struct_fields(Rc::new(reg));
+        bk.set_struct_fields(Rc::new(reg));
 
         let cd = bk
             .getuniqueclassdef_for_struct_root("FixedObjectArray")
@@ -4926,7 +4923,7 @@ mod tests {
                 ("back".to_string(), "S0".to_string()),
             ],
         );
-        bk.set_pyre_struct_fields(Rc::new(reg));
+        bk.set_struct_fields(Rc::new(reg));
 
         // Registering from the head walks the full depth + the back-edge
         // cycle without overflowing.
@@ -5011,7 +5008,7 @@ mod tests {
             "PyCode".to_string(),
             vec![("argcount".to_string(), "i64".to_string())],
         );
-        bk.set_pyre_struct_fields(Rc::new(reg));
+        bk.set_struct_fields(Rc::new(reg));
 
         // Re-lookup re-projects onto the SAME ClassDef Rc.
         let late = bk
@@ -6441,7 +6438,7 @@ mod tests {
             "CodeObject".to_string(),
             vec![("varnames".to_string(), "Box<[String]>".to_string())],
         );
-        bk.set_pyre_struct_fields(Rc::new(reg));
+        bk.set_struct_fields(Rc::new(reg));
         let _root = bk
             .getuniqueclassdef_for_struct_root("PyFrame")
             .expect("PyFrame registers");
@@ -6502,7 +6499,7 @@ mod tests {
             "Result<Vec<*mut PyObject>,PyErr>::Ok".to_string(),
             vec![("__pos_0".to_string(), "Vec<*mut PyObject>".to_string())],
         );
-        bk.set_pyre_struct_fields(Rc::new(reg));
+        bk.set_struct_fields(Rc::new(reg));
 
         let tuple_host = bk.intern_class_by_qualname(tuple);
         let tuple_cd = bk.getuniqueclassdef(&tuple_host).expect("tuple classdef");

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -336,18 +336,22 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
     // `usize` lattice as `size_of`; called by `object_array.rs` /
     // `pyframe.rs`.
     analyzer_for(&mut reg, "std.mem.align_of", std_mem_align_of);
-    // `__pyre_cast_instance` — front-end pointer-downcast narrow (#298).
+    // `__cast_instance_intrinsic` — front-end pointer-downcast narrow (#298).
     // `obj as *const RegisteredStruct` lowers to a simple_call against
     // this stub so the classdef-less pointer narrows to
     // `SomeInstance(root)` and a field read on the pointee resolves.
     // Keyed by the qualname `flowspace/model.rs`'s HOST_ENV bootstrap
     // assigns (which also keys the `BUILTIN_TYPER` entry on the same Arc).
-    analyzer_for(&mut reg, "__pyre_cast_instance", pyre_cast_instance);
-    // `__pyre_cast_address` — the erasing twin.  `p as *mut u8` lowers to
+    analyzer_for(
+        &mut reg,
+        "__cast_instance_intrinsic",
+        cast_instance_intrinsic,
+    );
+    // `__cast_address_intrinsic` — the erasing twin.  `p as *mut u8` lowers to
     // a simple_call against this stub so the pointee class is dropped
     // instead of riding along on a value whose declared type is a bare
     // byte pointer.
-    analyzer_for(&mut reg, "__pyre_cast_address", pyre_cast_address);
+    analyzer_for(&mut reg, "__cast_address_intrinsic", cast_address_intrinsic);
     // Rust `String::new()` / `String::with_capacity(n)` construct an empty
     // owned UTF-8 buffer; both annotate as a mutable `SomeString` so the
     // `String.new` / `String.with_capacity` HOST_ENV stubs do not reach the
@@ -1375,7 +1379,7 @@ fn std_mem_align_of(
     std_mem_size_of(bk, args_s, kwds)
 }
 
-/// Analyzer for `__pyre_cast_address` — the front-end pointer-type
+/// Analyzer for `__cast_address_intrinsic` — the front-end pointer-type
 /// erasure (`p as *mut u8`).  Upstream a heterogeneous heap block that
 /// reaches a GC ownership predicate or a write barrier travels as
 /// `llmemory.Address` (`llmemory.cast_ptr_to_adr`), never as
@@ -1401,17 +1405,17 @@ fn std_mem_align_of(
 /// twin does reject a non-pointer operand: a downcast to a named root
 /// off a non-pointer is a producer bug, whereas dropping type
 /// information off one never is.)
-fn pyre_cast_address(
+fn cast_address_intrinsic(
     _bk: &Rc<Bookkeeper>,
     args_s: &[Option<SomeValue>],
     kwds: &HashMap<String, Option<SomeValue>>,
 ) -> Result<SomeValue, AnnotatorError> {
     if !kwds.is_empty() || args_s.len() != 1 {
         return Err(AnnotatorError::new(
-            "__pyre_cast_address expects exactly one positional pointer argument",
+            "__cast_address_intrinsic expects exactly one positional pointer argument",
         ));
     }
-    let can_be_none = arg_at(args_s, 0, "__pyre_cast_address").can_be_none();
+    let can_be_none = arg_at(args_s, 0, "__cast_address_intrinsic").can_be_none();
     Ok(SomeValue::Instance(super::model::SomeInstance::new(
         None,
         can_be_none,
@@ -1419,12 +1423,12 @@ fn pyre_cast_address(
     )))
 }
 
-/// Analyzer for `__pyre_cast_instance` — the front-end pointer-downcast
+/// Analyzer for `__cast_instance_intrinsic` — the front-end pointer-downcast
 /// narrow (#298).  `front::mir` aliases the classdef-less pointer for a
 /// same-bank `obj as *const RegisteredStruct` cast, so a field read on
 /// the pointee blocks on a classdef-less `SomeInstance` (unaryop.rs
 /// getattr arm).  The frontend instead lowers such a cast to
-/// `simple_call(__pyre_cast_instance, operand)`, stashing the target
+/// `simple_call(__cast_instance_intrinsic, operand)`, stashing the target
 /// struct root in the `FunctionPath`; `flowspace_adapter` reconstructs
 /// the root as a trailing `ByteStr` constant arg (the `Vec<Variable>`
 /// arg carrier cannot hold a `Constant`).  The result is
@@ -1437,25 +1441,25 @@ fn pyre_cast_address(
 ///
 /// A root the bookkeeper deliberately models as a non-instance value —
 /// a `FixedObjectArray` projected to its `_items` element list, a
-/// `Wtf8Buf` to a byte string (`project_pyre_field_type`,
+/// `Wtf8Buf` to a byte string (`project_struct_field_type`,
 /// in `bookkeeper.rs`) — arrives with a `SomeList`/`SomeString`
 /// operand rather than a pointer.  Its access lowers through
 /// `getitem`/byte reads, not a named-field getattr, so the narrow is a
 /// no-op: the operand passes through unchanged, exactly as the erasure
-/// twin `pyre_cast_address` handles a `SomeList` for a `Vec` whose
+/// twin `cast_address_intrinsic` handles a `SomeList` for a `Vec` whose
 /// address was erased.
-fn pyre_cast_instance(
+fn cast_instance_intrinsic(
     bk: &Rc<Bookkeeper>,
     args_s: &[Option<SomeValue>],
     kwds: &HashMap<String, Option<SomeValue>>,
 ) -> Result<SomeValue, AnnotatorError> {
-    // The marker is `Call(["__pyre_cast_instance", <root>], [operand])`:
+    // The marker is `Call(["__cast_instance_intrinsic", <root>], [operand])`:
     // exactly the pointer operand plus the constant-root string, no
     // keywords.  A different shape is a producer bug, surfaced here
     // rather than silently swallowed.
     if !kwds.is_empty() || args_s.len() != 2 {
         return Err(AnnotatorError::new(
-            "__pyre_cast_instance expects (operand, constant_root) positional arguments",
+            "__cast_instance_intrinsic expects (operand, constant_root) positional arguments",
         ));
     }
     let root = match args_s
@@ -1467,14 +1471,14 @@ fn pyre_cast_instance(
         Some(s) => s.to_string(),
         None => {
             return Err(AnnotatorError::new(
-                "__pyre_cast_instance: target struct root must be a constant string",
+                "__cast_instance_intrinsic: target struct root must be a constant string",
             ));
         }
     };
     // Carry the operand's nullability onto the downcast result instead
     // of unconditionally narrowing to non-None: a downcast of a nullable
     // pointer is itself nullable.
-    let operand = arg_at(args_s, 0, "__pyre_cast_instance");
+    let operand = arg_at(args_s, 0, "__cast_instance_intrinsic");
     let can_be_none = match operand {
         SomeValue::Instance(inst) => inst.can_be_none,
         SomeValue::None_(_) => true,
@@ -1483,20 +1487,20 @@ fn pyre_cast_instance(
             // A root the bookkeeper models as a list or string (a
             // `FixedObjectArray` projected to its `_items` element list,
             // a `Wtf8Buf` projected to a byte string —
-            // `project_pyre_field_type` in `bookkeeper.rs`) reads
+            // `project_struct_field_type` in `bookkeeper.rs`) reads
             // through `getitem`/byte access, never a named field, so the
             // pointer→instance narrow is a no-op for it: return the
             // operand unchanged when its variant matches the model, the
             // same operand-agnostic pass-through the erasure twin
-            // `pyre_cast_address` already performs.  `convert_from_to`
+            // `cast_address_intrinsic` already performs.  `convert_from_to`
             // (rclass.py:1035) constrains only the destination repr, not
             // the operand shape.  A genuine variant mismatch is still a
             // producer bug, surfaced with the root that was expected.
-            if bk.project_pyre_field_type(&root).tag() == other.tag() {
+            if bk.project_struct_field_type(&root).tag() == other.tag() {
                 return Ok(operand.clone());
             }
             return Err(AnnotatorError::new(format!(
-                "__pyre_cast_instance: non-pointer operand for root {root:?}: {other:?}"
+                "__cast_instance_intrinsic: non-pointer operand for root {root:?}: {other:?}"
             )));
         }
     };
@@ -1570,7 +1574,7 @@ fn bigint_from(
 /// residualizes a body that builds one of these containers.  A
 /// subsequent method/accessor call on the opaque handle (`Vec::index`,
 /// `IndexMap::get`, `Box::into_raw`, …) is a separate leaf resolved on
-/// its own path (`translate_op` / `PyreCallRegistry`, not the analyser
+/// its own path (`translate_op` / `CallRegistry`, not the analyser
 /// table); this analyser only types the constructor's result.
 fn foreign_container_ctor(
     _bk: &Rc<Bookkeeper>,
@@ -1665,7 +1669,7 @@ fn lltype_cast_int_to_ptr(
     _kwds: &HashMap<String, Option<SomeValue>>,
 ) -> Result<SomeValue, AnnotatorError> {
     use crate::translator::rtyper::lltypesystem::lltype::{OpaqueType, Ptr, SomePtr};
-    let opaque = OpaqueType::gc("PYRE_REF_OPAQUE");
+    let opaque = OpaqueType::gc("MAJIT_REF_OPAQUE");
     let placeholder_ptr = Ptr::from_container_type(
         crate::translator::rtyper::lltypesystem::lltype::LowLevelType::Opaque(Box::new(opaque)),
     )

--- a/majit/majit-translate/src/annotator/description.rs
+++ b/majit/majit-translate/src/annotator/description.rs
@@ -985,7 +985,7 @@ pub struct FunctionDesc {
     /// If that eager lift fails, cache misses must surface the recorded
     /// producer-side error here instead of falling through to
     /// `buildflowgraph`'s generic synthetic-function failure.
-    pub(crate) pyre_lift_error: RefCell<Option<String>>,
+    pub(crate) lift_error: RefCell<Option<String>>,
     /// Upstream `self.pyobj._signature_` (description.py:294, :315).
     /// Carried on FunctionDesc rather than HostObject because
     /// `_signature_` is a function-level attribute.
@@ -1054,7 +1054,7 @@ impl FunctionDesc {
             defaults: defaults.unwrap_or_default(),
             specializer,
             cache: RefCell::new(HashMap::new()),
-            pyre_lift_error: RefCell::new(None),
+            lift_error: RefCell::new(None),
             annsignature: None,
             annenforceargs: None,
         }
@@ -1068,12 +1068,12 @@ impl FunctionDesc {
     /// Record a pyre eager-lift failure to be observed at the same
     /// lazy `cachedgraph` use-site where upstream would run
     /// `buildgraph` and propagate the original construction error.
-    pub(crate) fn record_pyre_lift_error(&self, message: String) {
-        *self.pyre_lift_error.borrow_mut() = Some(message);
+    pub(crate) fn record_lift_error(&self, message: String) {
+        *self.lift_error.borrow_mut() = Some(message);
     }
 
-    pub(crate) fn pyre_lift_error_message(&self) -> Option<String> {
-        self.pyre_lift_error.borrow().clone()
+    pub(crate) fn lift_error_message(&self) -> Option<String> {
+        self.lift_error.borrow().clone()
     }
 
     /// RPython `FunctionDesc.rowkey()` (description.py).
@@ -1265,9 +1265,9 @@ impl FunctionDesc {
             }
             return Ok(existing.clone());
         }
-        if let Some(lift_err) = self.pyre_lift_error_message() {
+        if let Some(lift_err) = self.lift_error_message() {
             return Err(AnnotatorError::new(format!(
-                "{}.cachedgraph: pyre-side lift failed during \
+                "{}.cachedgraph: source lift failed during \
                  populate_call_registry_from_call_graphs (recorded \
                  lazy-failure error): {lift_err}",
                 self.name,
@@ -3515,9 +3515,9 @@ mod tests {
     }
 
     #[test]
-    fn function_desc_cachedgraph_surfaces_recorded_pyre_lift_error() {
+    fn function_desc_cachedgraph_surfaces_recorded_lift_error() {
         let fd = FunctionDesc::new(bk(), None, "bad_leaf", int_sig(&[]), None, None);
-        fd.record_pyre_lift_error("producer failed before pygraph lift".to_string());
+        fd.record_lift_error("producer failed before pygraph lift".to_string());
 
         let err = fd
             .cachedgraph(
@@ -3530,7 +3530,7 @@ mod tests {
             .expect_err("recorded pyre lift error must surface at cachedgraph");
 
         let msg = err.msg.expect("AnnotatorError should carry message");
-        assert!(msg.contains("bad_leaf.cachedgraph: pyre-side lift failed"));
+        assert!(msg.contains("bad_leaf.cachedgraph: source lift failed"));
         assert!(msg.contains("producer failed before pygraph lift"));
     }
 

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -228,7 +228,7 @@ pub fn commonbase(cls1: KnownType, cls2: KnownType) -> KnownType {
 /// field-read side) and compare.
 ///
 /// Deliberately a COMPARE-time identity, NOT an interning cache key: keying
-/// `pyre_struct_root_classes` on this collapse starves the header/base-chain
+/// `struct_root_classes` on this collapse starves the header/base-chain
 /// walk for `ob_header`-bearing `W_*` structs (they mint base-less under
 /// first-mint-wins and lose their `W_Root` base — a measured +184 phaseA
 /// cascade across `_io`/`_pickle`).  This check fires only where

--- a/majit/majit-translate/src/annotator/unaryop.rs
+++ b/majit/majit-translate/src/annotator/unaryop.rs
@@ -3611,7 +3611,7 @@ pub(crate) fn call_builtin_method(
             let [] = scope.as_slice() else {
                 unreachable!();
             };
-            ann.bookkeeper.project_pyre_field_type("PyObjectRef")
+            ann.bookkeeper.project_struct_field_type("PyObjectRef")
         }
         // unaryop.py — `next(self)` / `method_next = next`.  The
         // bound iterator is the receiver; next takes no positional args and
@@ -4263,7 +4263,7 @@ fn init_someinstance_overrides(
                         // A classdef-less `SomeInstance` has no RPython analogue
                         // (`SomeInstance` upstream always carries a classdef).
                         // It arises only from pyre's pointer erasure:
-                        // `project_pyre_field_type` strips `*mut`/`*const`/`&`
+                        // `project_struct_field_type` strips `*mut`/`*const`/`&`
                         // and resolves the pointee — when the pointee is an
                         // unregistered host struct the field becomes
                         // `SomeInstance(classdef=None)`.  Any attr other than

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -2597,7 +2597,7 @@ impl Assembler {
     /// Pyre serialises `insns.bin` at build time and the runtime
     /// decoder reads those bytes verbatim, so canonical/extension keys
     /// pin a reserved `BC_*` (`crate::insns::wellknown_bh_insns` /
-    /// `pyre_extension_insns`, merged through
+    /// `extension_insns`, merged through
     /// [`crate::insns::insn_byte_opt`]) — this preserves byte stability
     /// across builds for keys that the runtime walker dispatches.
     /// Translator-only keys (transient codewriter helpers, test

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -888,7 +888,7 @@ impl UnknownCalleeCensus {
         rows
     }
 
-    /// Rows per table, from `PYRE_CALLEE_CENSUS_ROWS` (`all` for no cap).
+    /// Rows per table, from `MAJIT_CALLEE_CENSUS_ROWS` (`all` for no cap).
     ///
     /// A knob rather than a constant because the question this census is
     /// usually asked — *what spelling does a call site actually carry?* —
@@ -900,7 +900,7 @@ impl UnknownCalleeCensus {
     /// would make the header's own `limit=` a lie.
     fn row_limit() -> (usize, Option<String>) {
         const DEFAULT: usize = 25;
-        match std::env::var("PYRE_CALLEE_CENSUS_ROWS") {
+        match std::env::var("MAJIT_CALLEE_CENSUS_ROWS") {
             Err(_) => (DEFAULT, None),
             Ok(raw) if raw == "all" => (usize::MAX, None),
             Ok(raw) => match raw.parse::<usize>() {
@@ -1330,7 +1330,7 @@ pub struct CallControl {
     /// analyzed LLBC world (traits with two or more impl owners are
     /// absent).  Computed in `lib.rs` from `concrete_trait_methods` and
     /// forwarded to the dual-gate bookkeeper
-    /// (`Bookkeeper::pyre_trait_unique_impls`) so
+    /// (`Bookkeeper::trait_unique_impls`) so
     /// `derive_subject_inputcells` can resolve a generic receiver's
     /// bound-trait `class_root` to the impl type's `ClassDef`.
     /// RPython has no analogue: its annotator sees the concrete
@@ -1388,7 +1388,7 @@ pub struct CallControl {
     /// callees cannot lower their bodies (`build_flow.rs:215` rejects
     /// `sig.unsafety.is_some()` because raw-pointer ops are not
     /// modelled), but `OpKind::Call::FunctionPath` sites still need
-    /// the path registered in `PyreCallRegistry`.  Populated by `lib.rs`
+    /// the path registered in `CallRegistry`.  Populated by `lib.rs`
     /// from `program.unsafe_fn_stubs` via
     /// `front::mir::collect_unsafe_fn_stubs_from_llbc`; consumed by
     /// `translator::rtyper::cutover::register_unsafe_fn_stubs` from
@@ -1897,7 +1897,7 @@ impl CallControl {
 
     /// Program-wide struct field shapes accumulated at pipeline init.
     /// Threaded into the dual-gate bookkeeper so
-    /// `getuniqueclassdef_for_struct_root` / `project_pyre_field_type` can
+    /// `getuniqueclassdef_for_struct_root` / `project_struct_field_type` can
     /// project a struct's fields onto its classdef.
     pub fn struct_fields(&self) -> &crate::front::StructFieldRegistry {
         &self.struct_fields
@@ -3932,7 +3932,7 @@ impl CallControl {
                             // non-numeric `lltype::malloc_typed[_stable]`, which
                             // has no ported general `malloc->new` lowering.  The
                             // caller resolves them to the
-                            // `collect_pyre_class_ctor_stubs_from_llbc` residual
+                            // `collect_marked_class_ctor_stubs_from_llbc` residual
                             // stub, so — like a builtin — the BFS must not follow
                             // the constructor body: otherwise the two-phase census
                             // annotates its unliftable body (and its transitive
@@ -4004,7 +4004,7 @@ impl CallControl {
     /// function list — so a ratio taken against one is not comparable to a
     /// ratio taken against the other.  Whenever this count is published as a
     /// proportion, name the denominator alongside it; the pipeline profile
-    /// line (`lib.rs`, `PYRE_PROFILE_PIPELINE`) prints both absolutes rather
+    /// line (`lib.rs`, `MAJIT_PROFILE_PIPELINE`) prints both absolutes rather
     /// than a quotient for exactly that reason.
     pub fn candidate_graph_count(&self) -> usize {
         self.candidate_graphs.len()
@@ -4813,7 +4813,7 @@ impl CallControl {
     /// `CallPath`; otherwise it falls back to the stable symbolic address
     /// shim for source-only analysis.
     pub fn fnaddr_for_target(&self, target: &CallTarget) -> i64 {
-        // A `__pyre_wrap_*` wrapper takes `&[PyObjectRef]` (two words) and
+        // A `__majit_wrap_*` wrapper takes `&[PyObjectRef]` (two words) and
         // returns `Result<PyObjectRef, PyError>` (sret), neither of which the
         // one-register-per-slot residual-call ABI can carry. The codewriter
         // gives every wrapper its own jitcode and inlines it, so refusing the
@@ -4832,7 +4832,7 @@ impl CallControl {
         if let Some(path) = &wrapper_path
             && path
                 .last_segment()
-                .is_some_and(|leaf| leaf.starts_with("__pyre_wrap_"))
+                .is_some_and(|leaf| leaf.starts_with("__majit_wrap_"))
         {
             return symbolic_fnaddr_for_path(path);
         }
@@ -5217,7 +5217,7 @@ impl CallControl {
             let Some(leaf) = path.last_segment() else {
                 continue;
             };
-            if !leaf.starts_with("__pyre_wrap_") || !self.function_graphs.contains_key(path) {
+            if !leaf.starts_with("__majit_wrap_") || !self.function_graphs.contains_key(path) {
                 continue;
             }
             by_address.entry(fnaddr).or_default().push(path.clone());
@@ -7122,7 +7122,7 @@ pub fn effectinfo_from_writeanalyze(
         return EffectInfo {
             extraeffect: ExtraEffect::RandomEffects,
             oopspecindex,
-            pyre_helper: majit_ir::PyreHelperKind::None,
+            runtime_helper: majit_ir::RuntimeHelperKind::None,
             _readonly_descrs_fields: None,
             _write_descrs_fields: None,
             _readonly_descrs_arrays: None,
@@ -7315,7 +7315,7 @@ pub fn effectinfo_from_writeanalyze(
         return EffectInfo {
             extraeffect: ExtraEffect::RandomEffects,
             oopspecindex,
-            pyre_helper: majit_ir::PyreHelperKind::None,
+            runtime_helper: majit_ir::RuntimeHelperKind::None,
             _readonly_descrs_fields: None,
             _write_descrs_fields: None,
             _readonly_descrs_arrays: None,
@@ -7339,7 +7339,7 @@ pub fn effectinfo_from_writeanalyze(
     EffectInfo {
         extraeffect,
         oopspecindex,
-        pyre_helper: majit_ir::PyreHelperKind::None,
+        runtime_helper: majit_ir::RuntimeHelperKind::None,
         _readonly_descrs_fields: Some(read_descrs_fields_arcs),
         _write_descrs_fields: Some(write_descrs_fields_arcs),
         _readonly_descrs_arrays: Some(read_descrs_arrays_arcs),
@@ -10404,8 +10404,8 @@ mod tests {
         use crate::annotator::bookkeeper::Bookkeeper;
         use crate::translator::backendopt::canraise::RaiseAnalyzer;
         use crate::translator::backendopt::graphanalyze::GraphAnalyzer;
+        use crate::translator::rtyper::call_registry::CallRegistry;
         use crate::translator::rtyper::flowspace_adapter::function_graph_to_flowspace;
-        use crate::translator::rtyper::pyre_call_registry::PyreCallRegistry;
         use crate::translator::translator::TranslationContext;
         use std::rc::Rc;
 
@@ -10429,7 +10429,7 @@ mod tests {
         // Real front-end graphs ARE well-formed and DO convert — production
         // runs function_graph_to_flowspace on every graph and check.py is
         // green.
-        let registry = || PyreCallRegistry::new(Rc::new(Bookkeeper::new()));
+        let registry = || CallRegistry::new(Rc::new(Bookkeeper::new()));
 
         // -- non-raising: converts, and both paths agree it cannot raise --
         {
@@ -10551,8 +10551,8 @@ mod tests {
         use crate::annotator::bookkeeper::Bookkeeper;
         use crate::translator::backendopt::canraise::RaiseAnalyzer;
         use crate::translator::backendopt::graphanalyze::GraphAnalyzer;
+        use crate::translator::rtyper::call_registry::CallRegistry;
         use crate::translator::rtyper::flowspace_adapter::function_graph_to_flowspace;
-        use crate::translator::rtyper::pyre_call_registry::PyreCallRegistry;
         use crate::translator::translator::TranslationContext;
         use std::rc::Rc;
 
@@ -10674,7 +10674,7 @@ mod tests {
             //    the flat tri-state from the (default, ignore-MemoryError)
             //    boolean pair (default ↔ ignore=false; do_ignore_memory_error
             //    ↔ ignore=true) --
-            let reg = PyreCallRegistry::new(Rc::new(Bookkeeper::new()));
+            let reg = CallRegistry::new(Rc::new(Bookkeeper::new()));
             let out = function_graph_to_flowspace(&build("wf_raise", opname, raises), &reg)
                 .expect("well-formed graph converts to flowspace");
             let translator = TranslationContext::new();

--- a/majit/majit-translate/src/codewriter/codewriter.rs
+++ b/majit/majit-translate/src/codewriter/codewriter.rs
@@ -66,14 +66,14 @@ pub struct CodeWriter {
     pub assembler: Assembler,
     /// RPython: `self.debug = True` (codewriter.py:18).
     pub debug: bool,
-    /// Lazy program-wide `PyreCallRegistry` for the
-    /// PYRE_RTYPER dual-gate (cf. `transform_graph_to_jitcode`).
+    /// Lazy program-wide `CallRegistry` for the
+    /// MAJIT_RTYPER dual-gate (cf. `transform_graph_to_jitcode`).
     /// Built on first use from `callcontrol.function_graphs()` and
     /// reused across every dual-gated graph in the same CodeWriter
     /// run, mirroring upstream `Bookkeeper.descs` lifecycle (one
     /// descs map per `Translator` driving an `RPythonAnnotator`).
     real_rtyper_registry: std::cell::RefCell<
-        Option<std::rc::Rc<crate::translator::rtyper::pyre_call_registry::PyreCallRegistry>>,
+        Option<std::rc::Rc<crate::translator::rtyper::call_registry::CallRegistry>>,
     >,
 }
 
@@ -116,8 +116,8 @@ impl CodeWriter {
         callcontrol.setup_vrefinfo(vrefinfo);
     }
 
-    /// Get-or-build the program-wide `PyreCallRegistry` for the
-    /// PYRE_RTYPER dual-gate.  Builds once per CodeWriter run and
+    /// Get-or-build the program-wide `CallRegistry` for the
+    /// MAJIT_RTYPER dual-gate.  Builds once per CodeWriter run and
     /// caches; subsequent calls reuse the same `Rc`.  The registry
     /// is populated from `callcontrol.function_graphs()` — pyre's
     /// program-wide graph map, the production analog of
@@ -125,30 +125,29 @@ impl CodeWriter {
     fn dual_gate_registry(
         &self,
         callcontrol: &CallControl,
-    ) -> std::rc::Rc<crate::translator::rtyper::pyre_call_registry::PyreCallRegistry> {
+    ) -> std::rc::Rc<crate::translator::rtyper::call_registry::CallRegistry> {
         if let Some(existing) = self.real_rtyper_registry.borrow().as_ref() {
             return existing.clone();
         }
-        let registry = std::rc::Rc::new(
-            crate::translator::rtyper::pyre_call_registry::PyreCallRegistry::new(std::rc::Rc::new(
-                crate::annotator::bookkeeper::Bookkeeper::new(),
-            )),
-        );
+        let registry =
+            std::rc::Rc::new(crate::translator::rtyper::call_registry::CallRegistry::new(
+                std::rc::Rc::new(crate::annotator::bookkeeper::Bookkeeper::new()),
+            ));
         // Thread the program-wide struct field shapes into the shared
         // bookkeeper so
-        // `getuniqueclassdef_for_struct_root` / `project_pyre_field_type`
+        // `getuniqueclassdef_for_struct_root` / `project_struct_field_type`
         // can project a struct's fields onto its classdef when the
         // real-rtyper seed path resolves a `Ref(type_root)` to a class.
-        registry.set_pyre_struct_fields(std::rc::Rc::new(callcontrol.struct_fields().clone()));
+        registry.set_struct_fields(std::rc::Rc::new(callcontrol.struct_fields().clone()));
         // Enum `discriminant → variant` tables for the `__discriminant`
         // getattr's narrowing knowntypedata producer.
-        registry.set_pyre_enum_variant_by_discriminant(std::rc::Rc::new(
+        registry.set_enum_variant_by_discriminant(std::rc::Rc::new(
             callcontrol.enum_variant_by_discriminant().clone(),
         ));
         // Trait → unique-impl owner map for the generic-receiver seed
         // path (`derive_subject_inputcells` resolves a bound-trait
         // `class_root` through it before the struct-root lookup).
-        registry.set_pyre_trait_unique_impls(callcontrol.trait_unique_impls().clone());
+        registry.set_trait_unique_impls(callcontrol.trait_unique_impls().clone());
         // Opt-in receiver-driven dispatch families (issue #346): mint
         // each registered trait's base ClassDef + impl subclasses BEFORE
         // `seed_struct_root_method_members` below, so the method seeding
@@ -162,7 +161,7 @@ impl CodeWriter {
         // through `is_known_unported`.  Known-unported categories
         // leave a partial registry (the per-graph dual-gate will
         // Skip-classify the affected callsites via the cascade
-        // `"not registered in PyreCallRegistry"`).  Unknown errors
+        // `"not registered in CallRegistry"`).  Unknown errors
         // panic immediately so parity bugs surface here rather than
         // silently shifting downstream behind a Skip mask.
         // Metadata-only stubs for `unsafe fn` callees that
@@ -202,8 +201,8 @@ impl CodeWriter {
         // `Translator.buildrtyper()` (`translator.py`) construct
         // exactly one annotator and one rtyper per Translator and assert
         // on re-entry.  Pyre mirrors that contract through
-        // [`PyreCallRegistry::ensure_session`]
-        // (in `pyre_call_registry.rs`), which lazily builds a single
+        // [`CallRegistry::ensure_session`]
+        // (in `call_registry.rs`), which lazily builds a single
         // `(RPythonAnnotator, RPythonTyper)` pair on first use and
         // returns the cached pair on every subsequent
         // `specialize_legacy_graph_with_registry_returning_value_to_var`
@@ -288,7 +287,7 @@ impl CodeWriter {
     /// let the codewriter consume the rtyper's `Variable` graph directly.
     ///
     /// Run the dual-gate type resolver against the program-wide
-    /// `PyreCallRegistry` and commit every resolved kind to the graph's backing
+    /// `CallRegistry` and commit every resolved kind to the graph's backing
     /// `Variable.concretetype` cells. A Match returns the `LegacyToTyped` map so
     /// post-jtransform operands can be rebound to typed variables. A Skip runs
     /// the legacy annotator and resolver, commits their kinds, and returns
@@ -369,9 +368,9 @@ impl CodeWriter {
                 Some(real_value_to_var)
             }
             Ok(crate::translator::rtyper::cutover::DualGateOutcome::Skip(reason)) => {
-                if std::env::var_os("PYRE_RTYPER_VERBOSE").is_some_and(|v| v == "1") {
+                if std::env::var_os("MAJIT_RTYPER_VERBOSE").is_some_and(|v| v == "1") {
                     eprintln!(
-                        "[PYRE_RTYPER skip] graph {diag_label:?} ({:?}): {reason}",
+                        "[MAJIT_RTYPER skip] graph {diag_label:?} ({:?}): {reason}",
                         graph.name,
                     );
                 }
@@ -426,7 +425,7 @@ impl CodeWriter {
                 None
             }
             Err(diff) => panic!(
-                "PYRE_RTYPER real-path failure on graph {diag_label:?} ({:?}): {diff}",
+                "MAJIT_RTYPER real-path failure on graph {diag_label:?} ({:?}): {diff}",
                 graph.name,
             ),
         }
@@ -933,7 +932,7 @@ impl CodeWriter {
         // RPython's enum_pending_graphs() pops from unfinished_graphs (LIFO).
         // During transform, new graphs may be discovered and added via
         // get_jitcode(). We pop one at a time to match RPython's yield semantics.
-        let profile = std::env::var_os("PYRE_PROFILE_DRAIN").is_some();
+        let profile = std::env::var_os("MAJIT_PROFILE_DRAIN").is_some();
         let mut drain_count = 0usize;
         let drain_start = std::time::Instant::now();
         loop {
@@ -966,7 +965,7 @@ impl CodeWriter {
                     let elapsed = iter_start.elapsed().as_secs_f64();
                     if elapsed >= 0.5 {
                         eprintln!(
-                            "[PYRE_PROFILE_DRAIN] graph #{:>3} {:>7.3}s name={}",
+                            "[MAJIT_PROFILE_DRAIN] graph #{:>3} {:>7.3}s name={}",
                             drain_count, elapsed, jitcode.name,
                         );
                     }
@@ -1024,7 +1023,7 @@ impl CodeWriter {
                 let elapsed = iter_start.elapsed().as_secs_f64();
                 if elapsed >= 0.5 {
                     eprintln!(
-                        "[PYRE_PROFILE_DRAIN] graph #{:>3} {:>7.3}s name={}",
+                        "[MAJIT_PROFILE_DRAIN] graph #{:>3} {:>7.3}s name={}",
                         drain_count, elapsed, jitcode.name,
                     );
                 }
@@ -1032,7 +1031,7 @@ impl CodeWriter {
         }
         if profile {
             eprintln!(
-                "[PYRE_PROFILE_DRAIN] DRAIN TOTAL {:>7.3}s  {} graphs",
+                "[MAJIT_PROFILE_DRAIN] DRAIN TOTAL {:>7.3}s  {} graphs",
                 drain_start.elapsed().as_secs_f64(),
                 drain_count,
             );

--- a/majit/majit-translate/src/codewriter/insns.rs
+++ b/majit/majit-translate/src/codewriter/insns.rs
@@ -73,7 +73,7 @@ pub const BC_NEW_WITH_VTABLE: u8 = 219;
 // C-form byte 222) so existing serialised byte assignments are undisturbed.
 // These consts only DECLARE the intended byte
 // numbers; a byte is not actually reserved (`is_reserved_opcode_byte`) until its
-// key joins `pyre_extension_insns()`, and the blackhole handler is bound there.
+// key joins `extension_insns()`, and the blackhole handler is bound there.
 // That registration + the macro lowering + the `run_one_step` dispatch arm are
 // wired together (the registration may shift dynamic byte assignments, so it is
 // verified against the serialised JitCode artifacts at that point, not here).  The
@@ -521,7 +521,7 @@ pub const BC_RAW_STORE_I: u8 = 228;
 // pyre-only `abort/>r` — Ref-result variant of `abort/` (BC_ABORT = 13)
 // emitted by `Assembler::encode_op`'s default branch when an `OpKind::
 // Abort { result_kind: Ref }` reaches the assembler.  Lives in
-// `pyre_extension_insns()` alongside `abort/` / `abort_permanent/`.
+// `extension_insns()` alongside `abort/` / `abort_permanent/`.
 pub const BC_ABORT_RESULT_R: u8 = 195;
 
 // pyre-only `vtable_method_ptr/rd>i` — emitted by `OpKind::
@@ -579,7 +579,7 @@ pub fn insn_byte(key: &str) -> u8 {
 }
 
 /// Non-panicking lookup against the merged
-/// `wellknown_bh_insns()` + `pyre_extension_insns()` table.  Returns
+/// `wellknown_bh_insns()` + `extension_insns()` table.  Returns
 /// `Some(byte)` for canonical/extension keys (build/runtime-stable
 /// `BC_*`) and `None` for translator-only keys.  `Assembler::get_opnum`
 /// uses the `None` return to fall through to the
@@ -604,9 +604,9 @@ pub fn insn_byte_opt(key: &str) -> Option<u8> {
         // tables keeps every legal key resolvable from a single entry
         // point while the source of truth remains split — canonical
         // opnames live in `wellknown_bh_insns()`, pyre-only quarantine
-        // lives in `pyre_extension_insns()`.
+        // lives in `extension_insns()`.
         let mut merged = wellknown_bh_insns();
-        for (k, v) in pyre_extension_insns() {
+        for (k, v) in extension_insns() {
             assert!(
                 !merged.contains_key(k),
                 "insn_byte: pyre extension key {k:?} collides with \
@@ -620,7 +620,7 @@ pub fn insn_byte_opt(key: &str) -> Option<u8> {
 }
 
 /// Highest byte value reserved across `wellknown_bh_insns()` ∪
-/// `pyre_extension_insns()`.  This is a diagnostic for pyre's fixed
+/// `extension_insns()`.  This is a diagnostic for pyre's fixed
 /// `BC_*` range; translator-only opcode allocation must not use this
 /// as a start offset because gaps below the high-water remain legal
 /// dynamic bytes.
@@ -634,7 +634,7 @@ pub fn canonical_byte_high_water() -> u8 {
                 max = v;
             }
         }
-        for (_, v) in pyre_extension_insns() {
+        for (_, v) in extension_insns() {
             if v > max {
                 max = v;
             }
@@ -645,7 +645,7 @@ pub fn canonical_byte_high_water() -> u8 {
 
 /// True when `byte` is pinned by either canonical RPython-mirror keys
 /// (`wellknown_bh_insns`) or pyre-only extension keys
-/// (`pyre_extension_insns`).  Multiple keys may intentionally share a
+/// (`extension_insns`).  Multiple keys may intentionally share a
 /// byte because some RPython blackhole handlers are aliases; this helper
 /// only answers whether the byte is reserved, not whether the table is
 /// one-to-one.
@@ -657,7 +657,7 @@ pub fn is_reserved_opcode_byte(byte: u8) -> bool {
         for (_, value) in wellknown_bh_insns() {
             reserved[value as usize] = true;
         }
-        for (_, value) in pyre_extension_insns() {
+        for (_, value) in extension_insns() {
             reserved[value as usize] = true;
         }
         reserved
@@ -700,11 +700,11 @@ pub fn wellknown_bh_insns() -> IndexMap<&'static str, u8> {
     m.insert("void_return/", BC_VOID_RETURN);
 
     // `abort/` and `abort_permanent/` are pyre-only Rust adaptations and
-    // live in `pyre_extension_insns()` — their byte values
+    // live in `extension_insns()` — their byte values
     // are still `BC_ABORT` / `BC_ABORT_PERMANENT`, but they are kept out
     // of the canonical-mirror table to keep `wellknown_bh_insns()` a
     // strict subset of RPython's `Assembler.insns`. See the comment on
-    // `pyre_extension_insns` for the borrow-checker rationale.
+    // `extension_insns` for the borrow-checker rationale.
 
     // RPython blackhole.py `bhimpl_unreachable()` raises
     // `AssertionError("unreachable")`. Distinct opcode from
@@ -712,10 +712,10 @@ pub fn wellknown_bh_insns() -> IndexMap<&'static str, u8> {
     m.insert("unreachable/", BC_UNREACHABLE);
 
     // The 6 `*_state_*` keys were quarantined into
-    // `pyre_extension_insns()`. They model the
+    // `extension_insns()`. They model the
     // proc-macro-generated JIT-machine-state addressing scheme and have
     // no RPython counterpart — see the doc-comment on
-    // `pyre_extension_insns` for the proc-macro/runtime-bridge
+    // `extension_insns` for the proc-macro/runtime-bridge
     // rationale.
 
     // Virtualizable operations — RPython canonical argcode shapes from
@@ -800,8 +800,8 @@ pub fn wellknown_bh_insns() -> IndexMap<&'static str, u8> {
     // when they are actually emitted; pre-registering them here would make
     // `wellknown_bh_insns()` claim a bytecode contract this runtime does
     // not truthfully expose.  The pyre-only nested-bytecode shape is
-    // registered separately as `inline_call_pyre_nested/P` in
-    // `pyre_extension_insns()`.
+    // registered separately as `inline_call_nested_ext/P` in
+    // `extension_insns()`.
 
     // jtransform.py:196 / flatten.py:247 — fused `goto_if_not_<op>_<type>`.
     // Argcodes follow assembler.py: two registers + label.
@@ -1188,7 +1188,7 @@ pub fn wellknown_bh_insns() -> IndexMap<&'static str, u8> {
 /// `wellknown_bh_insns()` at OnceLock init time, so build-time
 /// `write_insn(...)` callers resolve transparently. Runtime dispatch
 /// reads `BC_*` constants directly and is unaffected.
-pub fn pyre_extension_insns() -> IndexMap<&'static str, u8> {
+pub fn extension_insns() -> IndexMap<&'static str, u8> {
     let mut m = IndexMap::new();
     // Borrow-checker abort signals.
     m.insert("abort/", BC_ABORT);
@@ -1213,13 +1213,13 @@ pub fn pyre_extension_insns() -> IndexMap<&'static str, u8> {
     // Pyre does not compile inlined helpers into separate native
     // functions — guard-failure resume must re-interpret the helper as
     // nested bytecode.  Byte 17 (`BC_INLINE_CALL`) is reused for this
-    // pyre-only handler (`handler_inline_call_pyre_nested`).  The `P`
+    // pyre-only handler (`handler_inline_call_nested_ext`).  The `P`
     // pseudo-argcode is opaque from the canonical RPython argcodes
     // alphabet: payload is `sub_idx u16 + num_args u16 + num_args ×
     // (kind u8, src u16, dst u16) + 3 × (return slot u16; u16::MAX = None)`.
     // Generic walkers must consult `decode_op_at` (which knows `P`) for
     // length, not the canonical argcodes table.
-    m.insert("inline_call_pyre_nested/P", BC_INLINE_CALL);
+    m.insert("inline_call_nested_ext/P", BC_INLINE_CALL);
     // TODO: pyre `call_assembler_*` adapters.
     //
     // `JitCodeBuilder::call_assembler_{int,ref,float,void}_like`
@@ -1229,38 +1229,38 @@ pub fn pyre_extension_insns() -> IndexMap<&'static str, u8> {
     // no `bhimpl_call_assembler_*`; pyre re-interprets the recorded
     // operation by direct-calling `target.concrete_ptr` via the
     // shared `call_int_function` / `call_void_function` helpers.
-    // `P` pseudo-argcode mirrors `inline_call_pyre_nested`'s opaque
+    // `P` pseudo-argcode mirrors `inline_call_nested_ext`'s opaque
     // pyre-payload classification.
-    m.insert("call_assembler_int_pyre/P", BC_CALL_ASSEMBLER_INT);
-    m.insert("call_assembler_ref_pyre/P", BC_CALL_ASSEMBLER_REF);
-    m.insert("call_assembler_float_pyre/P", BC_CALL_ASSEMBLER_FLOAT);
-    m.insert("call_assembler_void_pyre/P", BC_CALL_ASSEMBLER_VOID);
+    m.insert("call_assembler_int_ext/P", BC_CALL_ASSEMBLER_INT);
+    m.insert("call_assembler_ref_ext/P", BC_CALL_ASSEMBLER_REF);
+    m.insert("call_assembler_float_ext/P", BC_CALL_ASSEMBLER_FLOAT);
+    m.insert("call_assembler_void_ext/P", BC_CALL_ASSEMBLER_VOID);
     // TODO: pyre `cond_call` / `record_known_result`
     // adapters.
     //
     // `JitCodeBuilder::call_cond_like` / `call_cond_value_like`
     // (`majit-metainterp/src/jitcode/assembler.rs`) emit a pyre-only flat payload that
     // does not match canonical `iiIRd` / `riIRd>r` argcodes.  The
-    // `_pyre/P` handlers split semantically:
+    // `_ext/P` handlers split semantically:
     //
-    //   * `cond_call_*_pyre` (`blackhole.rs`'s `handler_cond_call_*_pyre`) execute the
+    //   * `cond_call_*_ext` (`blackhole.rs`'s `handler_cond_call_*_ext`) execute the
     //     conditional call directly, mirroring upstream
     //     `bhimpl_conditional_call_ir_v` /
     //     `bhimpl_conditional_call_value_ir_{i,r}`
     //     (`blackhole.py:1257-1276`).
-    //   * `record_known_result_*_pyre` (`blackhole.rs`'s
-    //     `handler_record_known_result_*_pyre`)
+    //   * `record_known_result_*_ext` (`blackhole.rs`'s
+    //     `handler_record_known_result_*_ext`)
     //     are no-ops that skip the operand bytes, mirroring the
     //     `pass`-bodied `bhimpl_record_known_result_{i,r}_ir_v`
     //     (`blackhole.py:621-628`).
     //
     // Producers: `majit-macros/src/jit_interp/jitcode_lower/`,
     // `pyre/pyre-jit/src/jit/assembler.rs`.
-    m.insert("cond_call_void_pyre/P", BC_COND_CALL_VOID);
-    m.insert("cond_call_value_int_pyre/P", BC_COND_CALL_VALUE_INT);
-    m.insert("cond_call_value_ref_pyre/P", BC_COND_CALL_VALUE_REF);
-    m.insert("record_known_result_int_pyre/P", BC_RECORD_KNOWN_RESULT_INT);
-    m.insert("record_known_result_ref_pyre/P", BC_RECORD_KNOWN_RESULT_REF);
+    m.insert("cond_call_void_ext/P", BC_COND_CALL_VOID);
+    m.insert("cond_call_value_int_ext/P", BC_COND_CALL_VALUE_INT);
+    m.insert("cond_call_value_ref_ext/P", BC_COND_CALL_VALUE_REF);
+    m.insert("record_known_result_int_ext/P", BC_RECORD_KNOWN_RESULT_INT);
+    m.insert("record_known_result_ref_ext/P", BC_RECORD_KNOWN_RESULT_REF);
     // pyre-only `abort/>r` — Ref-result variant of `abort/`.  Emitted by
     // `Assembler::encode_op`'s default branch when an `OpKind::Abort` with
     // `result_kind: Ref` reaches the assembler.  The blackhole-side
@@ -1298,7 +1298,7 @@ mod tests {
     #[test]
     fn opcode_bytes_are_one_to_one() {
         let mut byte_to_key: HashMap<u8, String> = HashMap::new();
-        for table in [wellknown_bh_insns(), pyre_extension_insns()] {
+        for table in [wellknown_bh_insns(), extension_insns()] {
             for (key, byte) in table.iter() {
                 let key = (*key).to_string();
                 let byte = *byte;
@@ -1323,7 +1323,7 @@ mod recursive_call_byte_tests {
     /// The reserved `BC_RECURSIVE_CALL_*` bytes (223-226) must be mutually
     /// distinct, sit above the prior high-water (`BC_NEW_WITH_VTABLE` = 219),
     /// and not collide with any byte already registered in `wellknown_bh_insns`
-    /// or `pyre_extension_insns`.  Guards against the #199-class byte-collision
+    /// or `extension_insns`.  Guards against the #199-class byte-collision
     /// (BC_INT_BETWEEN vs BC_NEW) at the point the bytes are reserved, before
     /// the recursive-call lowering/handlers are wired.
     #[test]
@@ -1354,7 +1354,7 @@ mod recursive_call_byte_tests {
 
         let registered: Vec<u8> = wellknown_bh_insns()
             .values()
-            .chain(pyre_extension_insns().values())
+            .chain(extension_insns().values())
             .copied()
             .collect();
         for b in reserved {

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -257,8 +257,8 @@ pub struct CallEffectOverride {
     /// against the artifact and still matches nothing, because non-`Method`
     /// patterns are compared by full structural equality.
     ///
-    /// The spelling a call site actually carries is what `PYRE_CALLEE_CENSUS=1`
-    /// prints in its `with_graph` table (set `PYRE_CALLEE_CENSUS_ROWS=all`;
+    /// The spelling a call site actually carries is what `MAJIT_CALLEE_CENSUS=1`
+    /// prints in its `with_graph` table (set `MAJIT_CALLEE_CENSUS_ROWS=all`;
     /// the default cap is 25 rows). Confirm a new row against the per-entry
     /// match counter in the same output — a row that reads `0x INERT` is not
     /// installed, whatever it looks like here.
@@ -3845,22 +3845,22 @@ impl<'a> Transformer<'a> {
         {
             return RewriteResult::Identity(args[0].clone());
         }
-        // `__pyre_cast_instance/<Root>` — front::mir's pointer-downcast
-        // narrow (#298, `mir.rs` emits `Call(["__pyre_cast_instance",
+        // `__cast_instance_intrinsic/<Root>` — front::mir's pointer-downcast
+        // narrow (#298, `mir.rs` emits `Call(["__cast_instance_intrinsic",
         // root], [v])` for a `Ref → *Struct` reinterpret).  The rtyper
-        // lowers it to `cast_pointer` (`rbuiltin.rs rtype_pyre_cast_instance`,
+        // lowers it to `cast_pointer` (`rbuiltin.rs rtype_cast_instance_intrinsic`,
         // `exception_cannot_occur`), which jtransform folds to `same_as`;
         // the charon front-end skips the rtyper, so fold the marker to the
         // operand alias here too.  The JIT does not distinguish a downcast
         // pointer from its source, so this emits no jitcode op.
-        // `__pyre_cast_address` — the erasing twin (`p as *mut u8`), which
+        // `__cast_address_intrinsic` — the erasing twin (`p as *mut u8`), which
         // carries no root and so is single-segment.  It reinterprets the
         // same pointer too, and the JIT distinguishes a pointer no more
         // from its erasure than from its downcast, so it folds the same
         // way: the operand alias, no jitcode op.
         if let CallTarget::FunctionPath { segments } = target
-            && ((segments.len() == 2 && segments[0] == "__pyre_cast_instance")
-                || (segments.len() == 1 && segments[0] == "__pyre_cast_address"))
+            && ((segments.len() == 2 && segments[0] == "__cast_instance_intrinsic")
+                || (segments.len() == 1 && segments[0] == "__cast_address_intrinsic"))
             && args.len() == 1
         {
             return RewriteResult::Identity(args[0].clone());
@@ -7763,7 +7763,7 @@ static CLASSIFY_SEEN_TOTAL: std::sync::atomic::AtomicUsize = std::sync::atomic::
 
 fn record_classify_seen(target: &CallTarget) {
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    if !*ON.get_or_init(|| std::env::var_os("PYRE_CALLEE_CENSUS").is_some_and(|v| v == "1")) {
+    if !*ON.get_or_init(|| std::env::var_os("MAJIT_CALLEE_CENSUS").is_some_and(|v| v == "1")) {
         return;
     }
     CLASSIFY_SEEN_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -10915,7 +10915,7 @@ mod tests {
 
         let mut cc = CallControl::new();
         cc.setup_jitdriver(
-            CallPath::from_segments(["pyre_jit", "other_portal"]),
+            CallPath::from_segments(["jit_artifact", "other_portal"]),
             Vec::new(),
             Vec::new(),
             Vec::new(),
@@ -10924,7 +10924,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
         );
-        let portal_graph = CallPath::from_segments(["pyre_jit", "eval_loop_jit"]);
+        let portal_graph = CallPath::from_segments(["jit_artifact", "eval_loop_jit"]);
         cc.setup_jitdriver(
             portal_graph.clone(),
             vec![

--- a/majit/majit-translate/src/codewriter/jtransform_shadow.rs
+++ b/majit/majit-translate/src/codewriter/jtransform_shadow.rs
@@ -17,7 +17,7 @@
 //! `SpaceOperation.opname` and reports, per graph, the opname histogram and
 //! the subset of opnames that fall outside the admissible input set jtransform
 //! accepts.  It never mutates the graph and never feeds the production jitcode
-//! path; it is a no-op unless `PYRE_JTRANSFORM_SHADOW` is set in the
+//! path; it is a no-op unless `MAJIT_JTRANSFORM_SHADOW` is set in the
 //! environment, so the default build is byte-for-byte unchanged.  The
 //! histogram of unhandled opnames collected across the corpus is the
 //! per-handler migration backlog for the opname-dispatch rewrite.
@@ -518,16 +518,16 @@ fn admissible_opnames() -> HashSet<String> {
         .collect()
 }
 
-/// Whether the env-gated shadow gauge is active (`PYRE_JTRANSFORM_SHADOW`
+/// Whether the env-gated shadow gauge is active (`MAJIT_JTRANSFORM_SHADOW`
 /// set).  Centralizes the switch so a call site can skip even the graph
 /// borrow when the gauge is off, keeping the default build's behaviour
 /// unchanged.
 pub fn is_enabled() -> bool {
-    std::env::var_os("PYRE_JTRANSFORM_SHADOW").is_some()
+    std::env::var_os("MAJIT_JTRANSFORM_SHADOW").is_some()
 }
 
 /// Walk the post-rtype flowspace graph by `SpaceOperation.opname` and emit a
-/// per-graph diagnostic.  No-op unless `PYRE_JTRANSFORM_SHADOW` is set; never
+/// per-graph diagnostic.  No-op unless `MAJIT_JTRANSFORM_SHADOW` is set; never
 /// mutates the graph.
 pub fn report_if_enabled(graph: &FunctionGraph) {
     if !is_enabled() {

--- a/majit/majit-translate/src/codewriter/mod.rs
+++ b/majit/majit-translate/src/codewriter/mod.rs
@@ -50,7 +50,7 @@ pub mod policy;
 pub mod regalloc;
 pub mod support;
 // Local env-gated profiler for the drain pipeline, with no upstream
-// sibling and no effect unless `PYRE_PROFILE_DRAIN` is set.
+// sibling and no effect unless `MAJIT_PROFILE_DRAIN` is set.
 pub(crate) mod transform_profile;
 // Local Rust boundary for concretetype projection and temporary import
 // compatibility while concretetype data migrates onto Variables.

--- a/majit/majit-translate/src/codewriter/policy.rs
+++ b/majit/majit-translate/src/codewriter/policy.rs
@@ -19,7 +19,7 @@
 //! boundary.
 //!
 //! Pyre converges on the same observable behaviour through a different
-//! mechanism: the `PYRE_JIT_GRAPH_MODULES` whitelist in
+//! mechanism: the `JIT_GRAPH_MODULES` whitelist in
 //! `generated.rs` plus `CallControl::register_function_graph` plays the
 //! role of the allowed-module set. A callee whose `CallPath` is not
 //! present in `CallControl::function_graphs` is treated as residual at

--- a/majit/majit-translate/src/codewriter/transform_profile.rs
+++ b/majit/majit-translate/src/codewriter/transform_profile.rs
@@ -1,6 +1,6 @@
 //! Env-gated per-phase accumulator for `transform_graph_to_jitcode`.
 //!
-//! Enabled when `PYRE_PROFILE_DRAIN` is set; aggregates wall-clock time
+//! Enabled when `MAJIT_PROFILE_DRAIN` is set; aggregates wall-clock time
 //! across every drained graph so the per-phase hotspot is identifiable
 //! without `O(graphs)` log noise.
 
@@ -12,7 +12,7 @@ thread_local! {
 }
 
 pub fn enabled() -> bool {
-    std::env::var_os("PYRE_PROFILE_DRAIN").is_some()
+    std::env::var_os("MAJIT_PROFILE_DRAIN").is_some()
 }
 
 pub fn record(phase: &'static str, dur: Duration) {
@@ -45,14 +45,14 @@ pub fn dump_transform_phase_totals() {
             grand += *d;
         }
         eprintln!(
-            "[PYRE_PROFILE_DRAIN] PHASE TOTALS ({:.3}s wall across all phases):",
+            "[MAJIT_PROFILE_DRAIN] PHASE TOTALS ({:.3}s wall across all phases):",
             grand.as_secs_f64(),
         );
         let mut rows: Vec<_> = t.iter().cloned().collect();
         rows.sort_by_key(|b| std::cmp::Reverse(b.1));
         for (name, dur, n) in rows {
             eprintln!(
-                "[PYRE_PROFILE_DRAIN]   {:>8.3}s  {:>5} calls  {}",
+                "[MAJIT_PROFILE_DRAIN]   {:>8.3}s  {:>5} calls  {}",
                 dur.as_secs_f64(),
                 n,
                 name,

--- a/majit/majit-translate/src/flowspace/bytecode.rs
+++ b/majit/majit-translate/src/flowspace/bytecode.rs
@@ -408,7 +408,7 @@ mod test {
     use rustpython_compiler::{Mode, compile as rp_compile};
 
     fn compile_source(src: &str) -> CodeObject {
-        rp_compile(src, Mode::Exec, "<pyre>", Default::default()).expect("compile should succeed")
+        rp_compile(src, Mode::Exec, "<flow>", Default::default()).expect("compile should succeed")
     }
 
     // RPython basis: test_objspace.py shapes these round-trips by calling

--- a/majit/majit-translate/src/flowspace/flowcontext.rs
+++ b/majit/majit-translate/src/flowspace/flowcontext.rs
@@ -3542,7 +3542,7 @@ mod test {
     }
 
     fn compile_function_body(src: &str) -> CodeObject {
-        let module = rp_compile(src, Mode::Exec, "<pyre>", Default::default())
+        let module = rp_compile(src, Mode::Exec, "<flow>", Default::default())
             .expect("compile should succeed");
         module
             .constants

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -1718,8 +1718,8 @@ impl HostEnv {
         // qualname and its typer (rtyper/rbuiltin.rs) keys on this same
         // singleton Arc, so the binding must live in HOST_ENV.
         self.insert_builtin(
-            "__pyre_cast_instance",
-            HostObject::new_builtin_callable("__pyre_cast_instance"),
+            "__cast_instance_intrinsic",
+            HostObject::new_builtin_callable("__cast_instance_intrinsic"),
         );
         // Pyre-internal front-end pointer-type ERASURE, the twin of the
         // narrow above: the frontend lowers `obj as *mut u8` to a
@@ -1731,8 +1731,8 @@ impl HostEnv {
         // for a pointee-less raw pointer.  Same three-way binding as the
         // narrow (analyzer keys the qualname, typer keys this Arc).
         self.insert_builtin(
-            "__pyre_cast_address",
-            HostObject::new_builtin_callable("__pyre_cast_address"),
+            "__cast_address_intrinsic",
+            HostObject::new_builtin_callable("__cast_address_intrinsic"),
         );
     }
 
@@ -2315,8 +2315,8 @@ impl HostEnv {
         // (`rbuiltin.rs lookup_typer`), so a fresh
         // `new_builtin_callable` with the same qualname would miss the
         // registered typer.
-        let pyre_object_pyobject = HostObject::new_module("pyre_object.pyobject");
-        pyre_object_pyobject.module_set(
+        let object_module = HostObject::new_module("pyre_object.pyobject");
+        object_module.module_set(
             "PY_NULL",
             core_ptr
                 .module_get("null_mut")
@@ -2330,12 +2330,12 @@ impl HostEnv {
         // crate-qualified FunctionPath `["pyre_object","lltype","malloc_typed"]`,
         // which `translate_op`'s Layer-3b resolves via this module
         // (prefix `pyre_object.lltype`, leaf `malloc_typed`).
-        let pyre_object_lltype = HostObject::new_module("pyre_object.lltype");
-        pyre_object_lltype.module_set(
+        let lltype_module = HostObject::new_module("pyre_object.lltype");
+        lltype_module.module_set(
             "malloc_typed",
             HostObject::new_builtin_callable("pyre_object.lltype.malloc_typed"),
         );
-        pyre_object_lltype.module_set(
+        lltype_module.module_set(
             "malloc_typed_managed",
             HostObject::new_builtin_callable("pyre_object.lltype.malloc_typed_managed"),
         );
@@ -2345,7 +2345,7 @@ impl HostEnv {
         // `malloc_raw_alloc` analyzer types the result as the `*mut T`
         // pointer shell.  Resolved by `translate_op`'s Layer-3b via this
         // module (prefix `pyre_object.lltype`, leaf `malloc_raw`).
-        pyre_object_lltype.module_set(
+        lltype_module.module_set(
             "malloc_raw",
             HostObject::new_builtin_callable("pyre_object.lltype.malloc_raw"),
         );
@@ -2389,8 +2389,8 @@ impl HostEnv {
         mods.insert("FrameDebugData".into(), frame_debug_data);
         mods.insert("RootScope".into(), root_scope);
         mods.insert("IntArray".into(), int_array);
-        mods.insert("pyre_object.pyobject".into(), pyre_object_pyobject);
-        mods.insert("pyre_object.lltype".into(), pyre_object_lltype);
+        mods.insert("pyre_object.pyobject".into(), object_module);
+        mods.insert("pyre_object.lltype".into(), lltype_module);
     }
 
     /// upstream `getattr(__builtin__, name)` — `flowcontext.py:851`.
@@ -3240,7 +3240,7 @@ fn alloc_constant_id(value: &ConstValue) -> u64 {
 fn constant_trace_backtrace_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        std::env::var("PYRE_DTRACE_CONST_BT")
+        std::env::var("MAJIT_DTRACE_CONST_BT")
             .as_deref()
             .is_ok_and(|value| value == "1")
     })
@@ -3254,11 +3254,11 @@ fn constant_trace_window() -> Option<&'static (u64, u64)> {
             if !crate::determinism_trace_enabled() {
                 return None;
             }
-            let from = std::env::var("PYRE_DTRACE_CONST_FROM")
+            let from = std::env::var("MAJIT_DTRACE_CONST_FROM")
                 .ok()
                 .and_then(|value| value.parse().ok())
                 .unwrap_or(0);
-            let to = std::env::var("PYRE_DTRACE_CONST_TO")
+            let to = std::env::var("MAJIT_DTRACE_CONST_TO")
                 .ok()
                 .and_then(|value| value.parse().ok())
                 .unwrap_or(0);

--- a/majit/majit-translate/src/front/bool_then.rs
+++ b/majit/majit-translate/src/front/bool_then.rs
@@ -126,7 +126,7 @@ fn rewire_one_bool_then_site(graph: &mut FunctionGraph, site: &BoolThenSite) -> 
     // assuming the last slot: on a simplified graph (a result_exc / next /
     // checked-arith callee runs `simplify_lowered_graph` before this pass) the
     // opaque `Ref` result is immediately narrowed to the concrete `Option<T>`
-    // by a `__pyre_cast_instance` recast tail that `eliminate_empty_blocks`
+    // by a `__cast_instance_intrinsic` recast tail that `eliminate_empty_blocks`
     // folds into A, leaving the call no longer last.
     let call_idx = graph.blocks[a]
         .operations
@@ -256,7 +256,7 @@ fn rewire_one_bool_then_site(graph: &mut FunctionGraph, site: &BoolThenSite) -> 
     )?;
     close_goto_mixed(graph, else_bb, b_target, else_link_args);
 
-    // A: drop the residual `then` call and any peeled `__pyre_cast_instance`
+    // A: drop the residual `then` call and any peeled `__cast_instance_intrinsic`
     // recast tail, branch on `cond`.  `set_branch` appends the `bool(cond)` hop
     // and installs the Bool(false)/Bool(true) arm links; the closure-env
     // construction ops before the call stay as A's tail.

--- a/majit/majit-translate/src/front/checked_arith.rs
+++ b/majit/majit-translate/src/front/checked_arith.rs
@@ -160,7 +160,7 @@ pub(crate) fn rewire_checked_arith_call_sites(
         match rewire_one_checked_arith_site(graph, opt) {
             Ok(()) => rewritten += 1,
             Err(_decline) => {
-                if std::env::var_os("PYRE_MIR_FRONTEND_DEBUG").is_some() {
+                if std::env::var_os("MAJIT_MIR_FRONTEND_DEBUG").is_some() {
                     eprintln!(
                         "[checked_arith] {} decline at {opt:?}: {_decline}",
                         graph.name

--- a/majit/majit-translate/src/front/checked_arith_uint.rs
+++ b/majit/majit-translate/src/front/checked_arith_uint.rs
@@ -76,7 +76,7 @@ pub(crate) fn rewire_checked_arith_uint_sites(
         match rewire_one_checked_arith_uint_site(graph, site) {
             Ok(()) => rewritten += 1,
             Err(_decline) => {
-                if std::env::var_os("PYRE_MIR_FRONTEND_DEBUG").is_some() {
+                if std::env::var_os("MAJIT_MIR_FRONTEND_DEBUG").is_some() {
                     eprintln!(
                         "[checked_arith_uint] {} decline at {:?}: {_decline}",
                         graph.name, site.opt

--- a/majit/majit-translate/src/front/from_size_align.rs
+++ b/majit/majit-translate/src/front/from_size_align.rs
@@ -100,7 +100,7 @@ pub(crate) fn rewire_from_size_align_sites(
         match rewire_one_from_size_align_site(graph, site) {
             Ok(()) => rewritten += 1,
             Err(_decline) => {
-                if std::env::var_os("PYRE_MIR_FRONTEND_DEBUG").is_some() {
+                if std::env::var_os("MAJIT_MIR_FRONTEND_DEBUG").is_some() {
                     eprintln!(
                         "[from_size_align] {} decline at {:?}: {_decline}",
                         graph.name, site.ok_result
@@ -295,7 +295,7 @@ pub(crate) fn rewire_from_size_align_expect_sites(
         match rewire_one_from_size_align_expect_site(graph, site) {
             Ok(()) => rewritten += 1,
             Err(_decline) => {
-                if std::env::var_os("PYRE_MIR_FRONTEND_DEBUG").is_some() {
+                if std::env::var_os("MAJIT_MIR_FRONTEND_DEBUG").is_some() {
                     eprintln!(
                         "[from_size_align expect] {} decline at {:?}: {_decline}",
                         graph.name, site.result_var

--- a/majit/majit-translate/src/front/iter_next.rs
+++ b/majit/majit-translate/src/front/iter_next.rs
@@ -242,7 +242,7 @@ fn iter_next_item_type(
 }
 
 /// Whether `var` traces back to `front::range_iter`'s reserved
-/// `["__pyre_range"]` call — the `range(a, b)` builtin standing in for an
+/// `["__majit_range"]` call — the `range(a, b)` builtin standing in for an
 /// exclusive int `Range`.
 ///
 /// The same backward walk the iterator itself gets.  `range_iter` emits the
@@ -256,7 +256,7 @@ fn produced_by_range_builtin(graph: &FunctionGraph, var: &Variable) -> bool {
         OpKind::Call {
             target: CallTarget::FunctionPath { segments },
             ..
-        } if segments.len() == 1 && segments[0] == "__pyre_range" => Some(()),
+        } if segments.len() == 1 && segments[0] == "__majit_range" => Some(()),
         _ => None,
     })
     .is_some()
@@ -358,7 +358,7 @@ pub(crate) fn rewire_next_call_sites(
     rewritten
 }
 
-/// `true` iff `segments` is a `__pyre_cast_instance` narrow — the front-end
+/// `true` iff `segments` is a `__cast_instance_intrinsic` narrow — the front-end
 /// pointer-downcast marker (`front::mir` `Rvalue::Cast` #298 arm) the MIR
 /// emits when an opaque `Ref` result is reinterpreted as a registered struct
 /// root.  It lowers to `cast_pointer` (a pure alias), so it carries no
@@ -370,13 +370,13 @@ fn is_recast_narrow(kind: &OpKind) -> bool {
             target: CallTarget::FunctionPath { segments },
             args,
             ..
-        } if args.len() == 1 && segments.first().is_some_and(|s| s == "__pyre_cast_instance")
+        } if args.len() == 1 && segments.first().is_some_and(|s| s == "__cast_instance_intrinsic")
     )
 }
 
 /// An unregistered `next()` returns an opaque `Ref`; the MIR immediately
 /// narrows it to the concrete `Option<T>` with one or more pure
-/// `__pyre_cast_instance` recasts (the front-end analogue of
+/// `__cast_instance_intrinsic` recasts (the front-end analogue of
 /// `ListIteratorRepr::rtype_next`'s `recast`, `rpython/rtyper/rlist.py`).
 /// Peel that trailing chain: starting from the raw `next` result at
 /// `next_idx`, follow each contiguous recast whose sole operand is the prior
@@ -391,7 +391,7 @@ fn is_recast_narrow(kind: &OpKind) -> bool {
 ///
 /// Shared with `front::bool_then`: a residual `then`/`then_some` produces the
 /// same opaque `Ref` narrowed to the concrete `Option<T>` by a
-/// `__pyre_cast_instance` recast tail, so it peels the identical chain (the
+/// `__cast_instance_intrinsic` recast tail, so it peels the identical chain (the
 /// caller passes its own `op_label` for the decline messages).
 pub(crate) fn peel_recast_chain(
     graph: &FunctionGraph,
@@ -494,7 +494,7 @@ fn rewire_one_next_site(
     // `lower_call` closes the block right after the raising call, so the
     // `next()` call is normally A's last op.  An UNREGISTERED `next()`
     // returns an opaque `Ref` that the MIR immediately recasts to the
-    // concrete `Option<T>` via one or more pure `__pyre_cast_instance`
+    // concrete `Option<T>` via one or more pure `__cast_instance_intrinsic`
     // narrows (the front-end analogue of `ListIteratorRepr::rtype_next`'s
     // `recast`, `rpython/rtyper/rlist.py` `self.r_list.recast`).  Such a
     // narrow is a `cast_pointer` alias, so the native `next` op subsumes it:
@@ -768,7 +768,7 @@ mod tests {
         let mut g = FunctionGraph::new("test_iter_next_item_type");
         let n = g.startblock;
         let container_segments = if over_a_range {
-            vec!["__pyre_range".to_string()]
+            vec!["__majit_range".to_string()]
         } else {
             vec![
                 "some".to_string(),

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -362,7 +362,7 @@ fn normalize_function_filter(function_names: &[&str]) -> Option<std::collections
 /// every graph and leaves an un-rewritable one to the residual-call ABI
 /// rather than aborting the build.  The coverage gate at the end of this
 /// function reports the shape-coverage gap (split by category under
-/// `PYRE_MIR_FRONTEND_DEBUG=1`) and proceeds; the check.py suite is the
+/// `MAJIT_MIR_FRONTEND_DEBUG=1`) and proceeds; the check.py suite is the
 /// regression net for a silent fallback.
 fn is_known_lowering_gap(msg: &str) -> bool {
     // The forward-reference shape: a body reads a MIR local on a path the
@@ -582,7 +582,7 @@ fn is_inline_aggregate_type(s: &str) -> bool {
 ///
 /// The unsuffixed template rows (`Result::Ok`, [`derive_program_metadata`])
 /// carry the bare type variable, which `tyref_to_ast_string` renders as
-/// `??TypeVar` → `project_pyre_field_type` → `Impossible`.  So a
+/// `??TypeVar` → `project_struct_field_type` → `Impossible`.  So a
 /// narrowing-only receiver (`Result<Tuple>` matched + read, never
 /// constructed in-graph) finds no concrete payload: its suffixed variant
 /// classdef `__pos_0` stays `Impossible` (annotator bottom) and the graph
@@ -968,7 +968,7 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
         // A single function whose body the driver does not yet handle
         // should not abort the whole-program build.  Capture
         // per-function errors into a side bucket and continue; they are
-        // surfaced via `PYRE_MIR_FRONTEND_DEBUG=1` for triage, but
+        // surfaced via `MAJIT_MIR_FRONTEND_DEBUG=1` for triage, but
         // production keeps going with a degraded SemanticProgram —
         // failing-loud on the single broken function rather than
         // erroring out at program-build time.
@@ -1099,7 +1099,7 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
         let (tracked, regressions): (Vec<_>, Vec<_>) = skipped
             .iter()
             .partition(|(_, msg)| is_known_lowering_gap(msg));
-        if std::env::var("PYRE_MIR_FRONTEND_DEBUG").is_ok() && !tracked.is_empty() {
+        if std::env::var("MAJIT_MIR_FRONTEND_DEBUG").is_ok() && !tracked.is_empty() {
             eprintln!(
                 "[mir-frontend] {} function(s) skipped via a shape \
                  `is_known_lowering_gap` recognises; the per-function \
@@ -2072,7 +2072,7 @@ fn harden_duplicate_leaf_metadata(
         // (`derive_program_metadata`'s enum arm), so the struct-shape
         // check above can never tell two distinct enums sharing a leaf
         // apart — their bare base alias survives and
-        // `pyre_struct_root_names` pre-mints ONE merged base class for
+        // `struct_root_names` pre-mints ONE merged base class for
         // both.  Withdraw it here off the same discriminant-divergence
         // signal, gated on the sentinel so a same-named real struct
         // (whose bare alias the shape check already adjudicated) is left
@@ -2093,11 +2093,11 @@ pub fn lower_fun_decl(llbc: &Llbc, fd: &FunDecl) -> Result<FunctionGraph, LowerE
 }
 
 /// Whether the framestate-threaded lowering runs for acyclic bodies.
-/// Default-on; `PYRE_MIR_FRAMESTATE=0` / `=false` is the rollback escape
+/// Default-on; `MAJIT_MIR_FRAMESTATE=0` / `=false` is the rollback escape
 /// hatch to the monotonic lowering.
 fn framestate_enabled() -> bool {
     !matches!(
-        std::env::var("PYRE_MIR_FRAMESTATE").as_deref(),
+        std::env::var("MAJIT_MIR_FRAMESTATE").as_deref(),
         Ok("0") | Ok("false")
     )
 }
@@ -2636,14 +2636,14 @@ fn lower_unstructured_with_static_addrs_and_attrs(
     };
     // Framestate-threaded lowering (the GAP-B path that threads locals
     // as block inputargs / phis — the orthodox flowspace shape).
-    // Default-on; `PYRE_MIR_FRAMESTATE=0` rolls back to the monotonic
+    // Default-on; `MAJIT_MIR_FRAMESTATE=0` rolls back to the monotonic
     // lowering.  Acyclic bodies thread via the two-pass RPO walk; cyclic
     // bodies additionally pre-seed each loop header's entry framestate
     // with the live-in phis `new` pre-bound, so the back-edge threads
     // into them in pass 2 instead of skipping the body to the monotonic
     // single-slot scheme.  On any framestate failure the body falls back
     // to the monotonic path — so the threaded path is never worse than
-    // the monotonic one — unless `PYRE_MIR_FRAMESTATE_STRICT` is set,
+    // the monotonic one — unless `MAJIT_MIR_FRAMESTATE_STRICT` is set,
     // which propagates the error for debugging.
     if framestate_enabled() {
         let mut lo = Lowering::new(
@@ -2679,10 +2679,10 @@ fn lower_unstructured_with_static_addrs_and_attrs(
         match attempt {
             Ok(()) => return Ok(lo.graph),
             Err(e) => {
-                if std::env::var_os("PYRE_MIR_FRAMESTATE_DEBUG").is_some() {
+                if std::env::var_os("MAJIT_MIR_FRAMESTATE_DEBUG").is_some() {
                     eprintln!("[FRAMESTATE fallback] {:?}: {e:?}", name);
                 }
-                if std::env::var_os("PYRE_MIR_FRAMESTATE_STRICT").is_some() {
+                if std::env::var_os("MAJIT_MIR_FRAMESTATE_STRICT").is_some() {
                     return Err(e);
                 }
             }
@@ -2889,7 +2889,7 @@ fn simplify_lowered_graph(
     // of the `NewWithVtable`-chain blocks' inputargs.  Runs last so no later
     // pass can remove the threaded inputarg, restoring the adapter's per-block
     // operand invariant for cross-block boxing clusters (e.g. `w_int_new`,
-    // whose `intval` payload and `__pyre_cast_instance` return chain span the
+    // whose `intval` payload and `__cast_instance_intrinsic` return chain span the
     // blocks split by the `get_instantiate` / `gc_interp::enabled` calls).
     crate::model::thread_undefined_op_operands(graph);
 }
@@ -3035,7 +3035,7 @@ struct Lowering<'a> {
     /// Whether this function contains a builder-form accumulator. The canonical
     /// lowering sets it directly from [`graph_has_builder_accumulator`]; ctor /
     /// append / terminal-`move` sites then emit the
-    /// `__pyre_stringbuilder_{new,append,build}` markers (`flowspace_adapter` →
+    /// `__majit_stringbuilder_{new,append,build}` markers (`flowspace_adapter` →
     /// `newstringbuilder` / `append` / `build`) instead of a parallel
     /// `ll_strconcat` graph. Whether a given local *is* such an
     /// accumulator is resolved on demand from `body`
@@ -3248,7 +3248,7 @@ impl<'a> Lowering<'a> {
             // bodies' `&Self`) has no ADT leaf — carry the bound
             // trait's qualified path instead, which the adapter
             // resolves through the unique-impl map
-            // (`pyre_trait_unique_impls`, keyed by qualified path).
+            // (`trait_unique_impls`, keyed by qualified path).
             let class_root = match &ty {
                 ValueType::Ref(_) => tyref_input_class_root(&local.ty, llbc)
                     // A `&str` / `str` param strips to the `str` builtin
@@ -3267,7 +3267,7 @@ impl<'a> Lowering<'a> {
                     // core/std/alloc container family from classdef
                     // minting.  Carry its full monomorphic spelling so
                     // `derive_subject_inputcells` projects it through the
-                    // annotator's list model (`project_pyre_field_type`)
+                    // annotator's list model (`project_struct_field_type`)
                     // instead of the classdef-less `SomeInstance(None)`
                     // shell, on which a `len()` / iteration would wall at
                     // `getattr` over a classdef-less instance.
@@ -4036,7 +4036,7 @@ impl<'a> Lowering<'a> {
                     if let LinkArg::Value(var) = arg
                         && !self.graph.variable_defined_in_block(bb_id, var)
                     {
-                        if std::env::var_os("PYRE_MIR_FRAMESTATE_DEBUG").is_some() {
+                        if std::env::var_os("MAJIT_MIR_FRAMESTATE_DEBUG").is_some() {
                             self.debug_dump_undefined_link_arg(
                                 bb, bb_id, tgt, tmir, var, &ex, &tgt_state,
                             );
@@ -4102,7 +4102,7 @@ impl<'a> Lowering<'a> {
 
     /// Diagnostic dump for a framestate threading that would emit a
     /// `Link.arg` undefined at its source block.  Gated behind
-    /// `PYRE_MIR_FRAMESTATE_DEBUG`.  Prints the source / target block
+    /// `MAJIT_MIR_FRAMESTATE_DEBUG`.  Prints the source / target block
     /// shapes and both framestates so the alignment bug can be located.
     #[allow(clippy::too_many_arguments)]
     fn debug_dump_undefined_link_arg(
@@ -5383,7 +5383,7 @@ impl<'a> Lowering<'a> {
             Operand::Move(place) => {
                 // A `move c` of a builder-mode accumulator is its single
                 // `ll_build` materialisation point (`accumulator_move_site_count
-                // == 1`).  Emit the `__pyre_stringbuilder_build` marker
+                // == 1`).  Emit the `__majit_stringbuilder_build` marker
                 // (`flowspace_adapter` → getattr("build") + simple_call →
                 // `SomeString`) instead of moving the concat accumulator out.
                 // Only a bare `Local(c)` move qualifies; a projection falls
@@ -5401,7 +5401,7 @@ impl<'a> Lowering<'a> {
         }
     }
 
-    /// Emit the `__pyre_stringbuilder_build(c)` marker for the terminal
+    /// Emit the `__majit_stringbuilder_build(c)` marker for the terminal
     /// `move c` of a builder-mode accumulator, returning the built
     /// `SomeString` Variable.  The builder Ref was minted at the ctor and
     /// mutated in place by the appends, so it is read (not rebound) here.
@@ -5419,7 +5419,7 @@ impl<'a> Lowering<'a> {
             result: Some(result.clone()),
             kind: OpKind::Call {
                 target: CallTarget::FunctionPath {
-                    segments: vec!["__pyre_stringbuilder_build".to_string()],
+                    segments: vec!["__majit_stringbuilder_build".to_string()],
                 },
                 args: vec![builder],
                 result_ty: ValueType::Ref(None),
@@ -5468,13 +5468,13 @@ impl<'a> Lowering<'a> {
     ///   0 and blocks with "cannot unify instances with no common base
     ///   class".  `llmemory.cast_ptr_to_adr` is the upstream erasure: a
     ///   GC ownership / write-barrier hook operates on a type-erased
-    ///   `Address`, never on `Ptr(instance)`.  `__pyre_cast_address` is
+    ///   `Address`, never on `Ptr(instance)`.  `__cast_address_intrinsic` is
     ///   that erasure — its annotator drops the classdef, which is the
     ///   annotation a pointee-less raw pointer already carries here, so
     ///   the erased callers and the callers that pass an untyped `*mut u8`
     ///   straight through agree on one annotation.
     /// * **narrow** — `obj as *const RegisteredStruct`; see
-    ///   `__pyre_cast_instance` below.
+    ///   `__cast_instance_intrinsic` below.
     ///
     /// Both are pointer-to-pointer only: a `Ref` source is required, since
     /// an `addr_usize as *const Struct` reinterpret is `cast_int_to_ptr`
@@ -5494,13 +5494,13 @@ impl<'a> Lowering<'a> {
         let (segments, result_ty) =
             if src_root.is_some() && tyref_is_raw_byte_ptr(dest_ty, self.llbc) {
                 (
-                    vec!["__pyre_cast_address".to_string()],
+                    vec!["__cast_address_intrinsic".to_string()],
                     ValueType::Ref(None),
                 )
             } else {
                 let root = tyref_class_root(dest_ty, self.llbc)?;
                 (
-                    vec!["__pyre_cast_instance".to_string(), root.clone()],
+                    vec!["__cast_instance_intrinsic".to_string(), root.clone()],
                     ValueType::Ref(Some(root)),
                 )
             };
@@ -5741,7 +5741,7 @@ impl<'a> Lowering<'a> {
                     // blocks the annotator on a classdef-less instance. The
                     // field's declaring struct is authoritative, so this is a
                     // sound downcast — identity when the base already carries
-                    // the class — the same `__pyre_cast_instance` narrow the
+                    // the class — the same `__cast_instance_intrinsic` narrow the
                     // ptr-identity-cast arm applies before its own field reads.
                     let narrow_root: Option<String> = match &inner.kind {
                         PlaceKind::Projection(pre, ProjectionElem::Atom(s)) if s == "Deref" => {
@@ -5771,7 +5771,7 @@ impl<'a> Lowering<'a> {
                             kind: OpKind::Call {
                                 target: CallTarget::FunctionPath {
                                     segments: vec![
-                                        "__pyre_cast_instance".to_string(),
+                                        "__cast_instance_intrinsic".to_string(),
                                         root.clone(),
                                     ],
                                 },
@@ -5940,7 +5940,7 @@ impl<'a> Lowering<'a> {
                         // `getattr`) on a classdef-less instance.  Narrow the
                         // base to this tuple's `Tuple{suffix}` classdef first
                         // — identity when it already carries it — the same
-                        // `__pyre_cast_instance` downcast the raw-ptr-deref
+                        // `__cast_instance_intrinsic` downcast the raw-ptr-deref
                         // Adt field arm applies (see `narrow_root` above).  A
                         // by-value tuple base is not deref-shaped and keeps
                         // its concrete classdef, so it is left untouched.
@@ -5959,7 +5959,7 @@ impl<'a> Lowering<'a> {
                                 kind: OpKind::Call {
                                     target: CallTarget::FunctionPath {
                                         segments: vec![
-                                            "__pyre_cast_instance".to_string(),
+                                            "__cast_instance_intrinsic".to_string(),
                                             owner.clone(),
                                         ],
                                     },
@@ -6019,7 +6019,7 @@ impl<'a> Lowering<'a> {
                 let segments = self.global_segments(mir_bb, id)?;
                 // A class-singleton static (`&SLICE_TYPE`, `&CEL_INT_CLASS`):
                 // narrow the raw address through
-                // `__pyre_cast_instance[<root>]` so the read types
+                // `__cast_instance_intrinsic[<root>]` so the read types
                 // `SomeInstance(<root>)`, matching the `(*obj).ob_type`
                 // field-read.  The bare `ConstInt` address would pair
                 // `IntegerRepr` against that field's `InstanceRepr` and
@@ -6047,7 +6047,7 @@ impl<'a> Lowering<'a> {
                 // initialiser fold / residual call), which is what any other
                 // static of that shape gets.  Measured empty for pyre: all
                 // 7362 `pyre-object` local functions lower with an identical
-                // `__pyre_cast_instance` root histogram either way.
+                // `__cast_instance_intrinsic` root histogram either way.
                 if let Some(addr) = self.pytype_static_addr(&segments)
                     && let Some(root) = tyref_class_root(&place_ty, self.llbc)
                 {
@@ -6066,7 +6066,10 @@ impl<'a> Lowering<'a> {
                         result: Some(res.clone()),
                         kind: OpKind::Call {
                             target: CallTarget::FunctionPath {
-                                segments: vec!["__pyre_cast_instance".to_string(), root.clone()],
+                                segments: vec![
+                                    "__cast_instance_intrinsic".to_string(),
+                                    root.clone(),
+                                ],
                             },
                             args: vec![raw],
                             result_ty: ValueType::Ref(Some(root)),
@@ -6077,7 +6080,7 @@ impl<'a> Lowering<'a> {
                 // A prebuilt object-space singleton whose declared type is
                 // a zero-field unit struct (the dict-strategy singletons
                 // `EMPTY_DICT_STRATEGY`, `OBJECT_DICT_STRATEGY`, …).  Narrow
-                // the raw GCREF address through `__pyre_cast_instance[<impl>]`
+                // the raw GCREF address through `__cast_instance_intrinsic[<impl>]`
                 // so the read types `SomeInstance(<impl>)` — the prebuilt
                 // instance the annotator would give it (`immutablevalue`).
                 // The bare `ConstRefAddr` types `SomePtr`, which cannot union
@@ -6105,7 +6108,10 @@ impl<'a> Lowering<'a> {
                         result: Some(res.clone()),
                         kind: OpKind::Call {
                             target: CallTarget::FunctionPath {
-                                segments: vec!["__pyre_cast_instance".to_string(), root.clone()],
+                                segments: vec![
+                                    "__cast_instance_intrinsic".to_string(),
+                                    root.clone(),
+                                ],
                             },
                             args: vec![raw],
                             result_ty: ValueType::Ref(Some(root)),
@@ -6127,7 +6133,7 @@ impl<'a> Lowering<'a> {
                 // 0-arg accessor call would have, but without the residual call
                 // whose funcptr constant degrades to a `symbolic_fnaddr_for_path`
                 // hash that SIGBUSes at trace time.  Deliberately NOT the
-                // `__pyre_cast_instance` narrowing the addressed siblings use:
+                // `__cast_instance_intrinsic` narrowing the addressed siblings use:
                 // its extra cast Variable shifts the loop's ref-register
                 // allocation so a merge-point red lands past `num_regs_r`
                 // (seed-time out-of-bounds in `trace_jitcode_from_merge_point`).
@@ -6810,7 +6816,7 @@ impl<'a> Lowering<'a> {
 
     /// Address of a `pytypes`-bucket host static — a class singleton
     /// (`&SLICE_TYPE`, `&INT_TYPE`, …).  The `Global` reader lowers these
-    /// to a `__pyre_cast_instance[<root>]` narrow of the raw address
+    /// to a `__cast_instance_intrinsic[<root>]` narrow of the raw address
     /// (a typed instance pointer) rather than the bare `ConstInt` the
     /// `refs` siblings avoid: a class static is the same kind of value
     /// as the `(*obj).ob_type` field-read it is compared against, so it
@@ -7165,7 +7171,7 @@ impl<'a> Lowering<'a> {
         // to a classdef-less `Ref(None)` — `tyref_to_value_type` erases the
         // pointee class root.  Capture the pointee root now so the result can be
         // narrowed to `SomeInstance(root)` after the call op: the call-result
-        // twin of the FieldRead-base and ptr-identity-cast `__pyre_cast_instance`
+        // twin of the FieldRead-base and ptr-identity-cast `__cast_instance_intrinsic`
         // narrows, letting a downstream getattr / method dispatch on the result
         // resolve instead of blocking the annotator on a classdef-less instance.
         // Gated on the raw-pointer pointee (not a bare ADT) so foreign value
@@ -7828,7 +7834,7 @@ impl<'a> Lowering<'a> {
                 // single `Wtf8Buf`/`String` `new`/`with_capacity` def of a
                 // builder-mode accumulator (its dest local, proven single-def
                 // by that ctor in [`is_fresh_str_builder`]) mints the
-                // `StringBuilder` once via the `__pyre_stringbuilder_new`
+                // `StringBuilder` once via the `__majit_stringbuilder_new`
                 // marker instead of the concat empty string; later appends
                 // mutate it in place.  Placed before the method-specific arms
                 // so it preempts any generic ctor lowering. Inert unless
@@ -7852,7 +7858,7 @@ impl<'a> Lowering<'a> {
                         result: Some(res.clone()),
                         kind: OpKind::Call {
                             target: CallTarget::FunctionPath {
-                                segments: vec!["__pyre_stringbuilder_new".to_string()],
+                                segments: vec!["__majit_stringbuilder_new".to_string()],
                             },
                             args,
                             result_ty: ValueType::Ref(None),
@@ -7907,7 +7913,7 @@ impl<'a> Lowering<'a> {
                         // Builder form: `b.append(piece)` mutates the buffer in
                         // place and returns `()`, so — unlike the concat rebind
                         // below — the accumulator binding is unchanged.  Emit the
-                        // void `__pyre_stringbuilder_append` marker
+                        // void `__majit_stringbuilder_append` marker
                         // (`flowspace_adapter` → getattr("append") + simple_call).
                         let void = self
                             .graph
@@ -7916,7 +7922,7 @@ impl<'a> Lowering<'a> {
                             result: Some(void),
                             kind: OpKind::Call {
                                 target: CallTarget::FunctionPath {
-                                    segments: vec!["__pyre_stringbuilder_append".to_string()],
+                                    segments: vec!["__majit_stringbuilder_append".to_string()],
                                 },
                                 args: vec![acc_val, args[piece_i].clone()],
                                 result_ty: ValueType::Void,
@@ -7962,7 +7968,7 @@ impl<'a> Lowering<'a> {
                             kind: OpKind::Call {
                                 target: CallTarget::FunctionPath {
                                     segments: vec![
-                                        "__pyre_cast_instance".to_string(),
+                                        "__cast_instance_intrinsic".to_string(),
                                         root.clone(),
                                     ],
                                 },
@@ -9242,7 +9248,10 @@ impl<'a> Lowering<'a> {
                 result: Some(narrowed_receiver.clone()),
                 kind: OpKind::Call {
                     target: CallTarget::FunctionPath {
-                        segments: vec!["__pyre_cast_instance".to_string(), "RBigInt".to_string()],
+                        segments: vec![
+                            "__cast_instance_intrinsic".to_string(),
+                            "RBigInt".to_string(),
+                        ],
                     },
                     args: vec![args[0].clone()],
                     result_ty: ValueType::Ref(Some("RBigInt".to_string())),
@@ -9933,7 +9942,7 @@ impl<'a> Lowering<'a> {
         });
         // Narrow a classdef-less registered-ADT call result to
         // `SomeInstance(root)` (see `result_narrow_root` above).  Identity at
-        // jitcode (`__pyre_cast_instance` → cast_pointer → `same_as`), so
+        // jitcode (`__cast_instance_intrinsic` → cast_pointer → `same_as`), so
         // already-resolved results and production codegen are unaffected; only
         // a `Ref(None)` raw-`PyObjectRef` result gains its pointee class.
         if let Some(root) = result_narrow_root {
@@ -9944,7 +9953,7 @@ impl<'a> Lowering<'a> {
                 result: Some(narrowed.clone()),
                 kind: OpKind::Call {
                     target: CallTarget::FunctionPath {
-                        segments: vec!["__pyre_cast_instance".to_string(), root.clone()],
+                        segments: vec!["__cast_instance_intrinsic".to_string(), root.clone()],
                     },
                     args: vec![result_var.clone()],
                     result_ty: ValueType::Ref(Some(root)),
@@ -10238,7 +10247,7 @@ impl<'a> Lowering<'a> {
                 // Decline the Method hint for an explicitly-named non-`self`
                 // first input so the call routes as `FunctionPath` and the
                 // call registry resolves the constructor (its residual stub via
-                // `collect_pyre_class_ctor_stubs_from_llbc`).
+                // `collect_marked_class_ctor_stubs_from_llbc`).
                 if fd.first_arg_local_name().is_some_and(|n| n != "self") {
                     return None;
                 }
@@ -10299,7 +10308,10 @@ impl<'a> Lowering<'a> {
             result: Some(narrowed.clone()),
             kind: OpKind::Call {
                 target: CallTarget::FunctionPath {
-                    segments: vec!["__pyre_cast_instance".to_string(), "Constants".to_string()],
+                    segments: vec![
+                        "__cast_instance_intrinsic".to_string(),
+                        "Constants".to_string(),
+                    ],
                 },
                 args: vec![base],
                 result_ty: ValueType::Ref(Some("Constants".to_string())),
@@ -10996,7 +11008,7 @@ impl<'a> Lowering<'a> {
                     // `alloc/src/boxed/iter.rs` — the `Box<[T]>` forms, by
                     // value and by reference; the latter delegates to slice
                     // iter. A boxed slice is the same element sequence as the
-                    // slice it owns (`project_pyre_field_type` strips the
+                    // slice it owns (`project_struct_field_type` strips the
                     // `Box`), so both walk the receiver's list.
                     | "alloc::boxed::iter::<Impl>::into_iter"
             )
@@ -12095,7 +12107,7 @@ impl<'a> Lowering<'a> {
     /// `Some` variant owners the length-checked diamond post-pass spells its
     /// arms with.  Gated on [`Self::option_residual_narrow_root`] returning
     /// `Some`: that is exactly the shape `lower_call` appends a trailing
-    /// `__pyre_cast_instance` narrowing to (the cast the post-pass absorbs and
+    /// `__cast_instance_intrinsic` narrowing to (the cast the post-pass absorbs and
     /// re-applies per arm), and it declines a value-slice `Option<u8>` /
     /// `Option<i64>` (no registered pointee root) cleanly, leaving the residual
     /// call for the census Skip.  `None` when the destination is not a
@@ -13595,7 +13607,7 @@ impl<'a> Lowering<'a> {
     /// message parameters (the `PyError` constructor family) reach
     /// `msg.into()` inside the generic body; the annotation model maps
     /// `String`, `str`, `Wtf8` and `Wtf8Buf` to the same string value
-    /// (`project_pyre_field_type` — `s_unicode0`), matching upstream's
+    /// (`project_struct_field_type` — `s_unicode0`), matching upstream's
     /// single string type (`rstr.py`), so the conversion is an identity
     /// at the annotation level.  Other destination types keep the
     /// generic `Call` form.
@@ -13621,7 +13633,7 @@ impl<'a> Lowering<'a> {
     /// `Wtf8Buf::from_string(String) -> Wtf8Buf`, and the reverse reinterpret
     /// `wtf8_key_as_str_unchecked(&Wtf8) -> &str`, to their sole string
     /// argument.  Rust's `&str` / `String` / `Wtf8` / `Wtf8Buf` all map
-    /// to the single immutable rpy_string value (`project_pyre_field_type`
+    /// to the single immutable rpy_string value (`project_struct_field_type`
     /// — `s_unicode0`, matching upstream's one string type in `rstr.py`),
     /// so the wrap is an identity at the annotation level; the boxing the
     /// callers want (`box_str_constant`) happens downstream on the bound
@@ -13685,7 +13697,7 @@ impl<'a> Lowering<'a> {
     /// zero-field unit struct — the shape of the prebuilt dict-strategy
     /// singletons (`EmptyDictStrategy`, `ObjectDictStrategy`, …).  The
     /// `PlaceKind::Global` reader narrows a `refs`-bucket static of such a
-    /// type through `__pyre_cast_instance[<root>]` to a classed
+    /// type through `__cast_instance_intrinsic[<root>]` to a classed
     /// `SomeInstance`.  Returns `None` for a field-bearing struct (the
     /// object singletons `W_NoneObject` / `W_BoolObject` / … in the same
     /// bucket keep their raw-pointer lowering) or any non-struct shape.
@@ -14283,7 +14295,7 @@ fn operand_fn_ptr_family(operand: &Operand, llbc: &Llbc) -> Option<FnPtrFamily> 
 ///
 /// `is_builtin_shape` is [`fn_ptr_signature_is_builtin_code_fn`], which
 /// matches on signature SHAPE. An `unsafe fn` of that shape would otherwise
-/// be handed the `__pyre_wrap_*` family: a positive claim about a callee set
+/// be handed the `__majit_wrap_*` family: a positive claim about a callee set
 /// it is not a member of. Only a safe pointer may name that family.
 ///
 /// An `unsafe fn` pointer is otherwise the same value with the same ABI as a
@@ -14302,7 +14314,7 @@ fn fn_ptr_family_for(
 
 /// Whether an fn-pointer signature is the exact source signature of
 /// `gateway::BuiltinCodeFn`: `fn(&[PyObjectRef]) -> Result<PyObjectRef,
-/// PyError>`.  That family's members are the `__pyre_wrap_*` graphs
+/// PyError>`.  That family's members are the `__majit_wrap_*` graphs
 /// `CallControl::builtin_wrapper_indirect_graphs` enumerates, so a call
 /// through it carries the deferred-family marker instead of `None`.
 fn fn_ptr_signature_is_builtin_code_fn(
@@ -15697,7 +15709,7 @@ fn impl_method_owner_for_fundecl(llbc: &Llbc, fd: &FunDecl) -> Option<(String, S
 /// identifier of the implementing `Self` ADT (`Box`, `Rc`, `Arc`,
 /// `FrameBox`, …) directly from the impl's `Self` type, bypassing the
 /// registry-keyed `impl_method_owner_for_fundecl` (which resolves only
-/// self-receiver methods it can key into `PyreCallRegistry`).  Used to
+/// self-receiver methods it can key into `CallRegistry`).  Used to
 /// subtract the `cast_pointer` thin-pointer rewrite for the
 /// header-offset handles whose word is not the pointee address.
 /// Returns `None` when the owner cannot be resolved, in which case the
@@ -15728,7 +15740,7 @@ fn deref_impl_owner_leaf(llbc: &Llbc, fd: &FunDecl) -> Option<String> {
 /// flowspace adapter does not model), but downstream
 /// `OpKind::Call::FunctionPath` sites still need their signature
 /// registered so the dual gate does not Skip with "not registered in
-/// PyreCallRegistry".
+/// CallRegistry".
 ///
 /// An `unsafe fn` is never lowered, so it never enters
 /// `CallControl::function_graphs` and its call sites already residualize
@@ -15862,7 +15874,7 @@ pub(crate) fn collect_unsafe_fn_stubs_from_llbc(
 /// Reuses the [`CallControl::unsafe_fn_stubs`] carrier + `register_unsafe_fn_stubs`
 /// registration path (both feed `(segments, Signature, return-token)` specs
 /// through the same annotator-only `residual_return_shell`).
-pub(crate) fn collect_pyre_class_ctor_stubs_from_llbc(
+pub(crate) fn collect_marked_class_ctor_stubs_from_llbc(
     llbc: &Llbc,
 ) -> Vec<(
     Vec<String>,
@@ -15925,7 +15937,7 @@ pub(crate) fn collect_pyre_class_ctor_stubs_from_llbc(
 /// declines the `CallTarget::Method` hint for an opaque owner (routing the
 /// call through `CallTarget::FunctionPath`); this collection feeds the
 /// matching registry entries so the `FunctionPath` lookup resolves instead
-/// of raising "not registered in PyreCallRegistry".
+/// of raising "not registered in CallRegistry".
 ///
 /// The registration key is derived through the SAME
 /// [`impl_method_owner_for_fundecl`] the declined-Method
@@ -17835,7 +17847,7 @@ fn typevar_bounded_by_into_string(
 /// `getattr`.  The bound trait names the receiver's only possible shape
 /// when the analyzed world has exactly one concrete impl;
 /// `derive_subject_inputcells` resolves the returned trait path through
-/// `Bookkeeper::pyre_trait_unique_impls` and only seeds a classdef on a
+/// `Bookkeeper::trait_unique_impls` and only seeds a classdef on a
 /// unique hit, so carrying a multi-impl (or foreign) trait path here is
 /// inert.  The qualified path (not the leaf) is the map key so two
 /// distinct traits sharing a final segment cannot seed each other's
@@ -18629,11 +18641,11 @@ fn render_adt_type_args(
 /// Clearing that needs pyre's elidable helpers to stop reaching an
 /// unanalyzable callee — or those hooks to carry a real family — which is
 /// its own change; until then this stays opt-in with
-/// `PYRE_FNPTR_INDIRECT=1`.  The `BuiltinCodeFn` family is unaffected by
+/// `MAJIT_FNPTR_INDIRECT=1`.  The `BuiltinCodeFn` family is unaffected by
 /// the switch: it reached `IndirectCall` before this arm and still does.
 pub(crate) fn fnptr_indirect_enabled() -> bool {
     matches!(
-        std::env::var("PYRE_FNPTR_INDIRECT").as_deref(),
+        std::env::var("MAJIT_FNPTR_INDIRECT").as_deref(),
         Ok("1") | Ok("true")
     )
 }
@@ -19187,7 +19199,7 @@ fn trait_call_label(v: &serde_json::Value) -> String {
 /// relative to their module root instead (`frame::eval_loop_jit` for a
 /// non-empty `module_path`, or the bare leaf for `module_path == ""`)
 /// so `register_function_graph_alias` (lib.rs) can walk
-/// `{bare, crate::*, pyre_interpreter::*, pyre_object::*, pyre_jit::*}`
+/// `{bare, crate::*, pyre_interpreter::*, pyre_object::*, jit_artifact::*}`
 /// aliases off the same `func.name`.
 fn strip_crate_prefix(path: &str) -> String {
     match path.split_once("::") {
@@ -19213,7 +19225,7 @@ fn strip_crate_prefix(path: &str) -> String {
 ///
 /// Matched on the module-qualified path so a leaf collision in another module
 /// cannot widen the gate, and crate-prefix-independent so the same accessor
-/// matches whether reached from `pyre_object`, `pyre_interpreter`, `pyre_jit`'s
+/// matches whether reached from `pyre_object`, `pyre_interpreter`, `jit_artifact`'s
 /// monomorphized copy — or a non-pyre host crate that lays its block out this
 /// way. The prefix carries no information the suffix does not: what makes the
 /// collapse sound is the accessor's CONTRACT (return the interior pointer for
@@ -22527,8 +22539,8 @@ mod tests {
         let llbc = Llbc::load(path).expect("load real LLBC");
         let fd = llbc
             .iter_local_fns()
-            .find(|fd| fd.item_meta.name_path().ends_with("::__pyre_wrap_random"))
-            .expect("_random::__pyre_wrap_random");
+            .find(|fd| fd.item_meta.name_path().ends_with("::__majit_wrap_random"))
+            .expect("_random::__majit_wrap_random");
         let graph = super::lower_fun_decl(&llbc, fd).expect("lower wrapper");
         let receiver = graph
             .blocks
@@ -22562,7 +22574,7 @@ mod tests {
                 target: CallTarget::FunctionPath { segments },
                 result_ty: ValueType::Ref(Some(root)),
                 ..
-            } if segments == &["__pyre_cast_instance".to_string(), "W_Random".to_string()]
+            } if segments == &["__cast_instance_intrinsic".to_string(), "W_Random".to_string()]
                 && root == "W_Random"
         ));
     }
@@ -22874,7 +22886,7 @@ mod tests {
             "pyre_object::object_array::items_block_items_ptr"
         ));
         assert!(graph_is_items_block_base_accessor(
-            "pyre_jit::object_array::items_block_items_base"
+            "jit_artifact::object_array::items_block_items_base"
         ));
         assert!(graph_is_items_block_base_accessor(
             "majit_rlib::lltypesystem::rlist::typed_items_block_items_base"
@@ -22909,7 +22921,7 @@ mod tests {
         for name in [
             "pyre_object::object_array::items_block_items_base",
             "pyre_object::object_array::items_block_items_ptr",
-            "pyre_jit::object_array::items_block_items_base",
+            "jit_artifact::object_array::items_block_items_base",
         ] {
             assert!(
                 is_object_items_block_base_accessor(name),
@@ -24825,7 +24837,7 @@ mod tests {
     /// `for &arg in args { pin_root(arg) }` that 16 census heads funnel
     /// through.  The unregistered `next()` returns an opaque `Ref` the MIR
     /// recasts to `Option<*mut PyObject>` via a trailing
-    /// `__pyre_cast_instance` narrow, so the raw call is not the block's
+    /// `__cast_instance_intrinsic` narrow, so the raw call is not the block's
     /// last op; `peel_recast_chain` must strip the recast and fold anyway.
     /// After the fold no residual `slice::iter::Iter::next` call survives
     /// and the native `[__iter_next]` op is present.  Ignored by default
@@ -25796,7 +25808,7 @@ mod tests {
         reg.fields
             .insert("pyre_object::eval::Point".to_string(), shape.clone());
         reg.fields
-            .insert("pyre_jit::eval::Point".to_string(), shape.clone());
+            .insert("jit_artifact::eval::Point".to_string(), shape.clone());
         reg.fields.insert("Point".to_string(), shape.clone());
         let mut origins = std::collections::HashMap::new();
         origins.insert("Point".to_string(), "eval".to_string());
@@ -25818,11 +25830,11 @@ mod tests {
         let same_as_a = map_a.clone();
         let mut enums = std::collections::HashMap::new();
         enums.insert("pyre_interpreter::eval::StepResult".to_string(), map_a);
-        enums.insert("pyre_jit::eval::StepResult".to_string(), map_b);
+        enums.insert("jit_artifact::eval::StepResult".to_string(), map_b);
         // silent-winner bare alias as the dual-publish would leave it
         enums.insert("StepResult".to_string(), same_as_a.clone());
         enums.insert("pyre_object::flow::Verdict".to_string(), same_as_a.clone());
-        enums.insert("pyre_jit::flow::Verdict".to_string(), same_as_a.clone());
+        enums.insert("jit_artifact::flow::Verdict".to_string(), same_as_a.clone());
         enums.insert("Verdict".to_string(), same_as_a.clone());
         // The `__discriminant`-only base rows as the enum arm registers
         // them — shape-identical across enums, so only the discriminant
@@ -25838,7 +25850,7 @@ mod tests {
             "discriminant-divergent duplicate leaf must lose its bare alias"
         );
         assert!(enums.contains_key("pyre_interpreter::eval::StepResult"));
-        assert!(enums.contains_key("pyre_jit::eval::StepResult"));
+        assert!(enums.contains_key("jit_artifact::eval::StepResult"));
         assert_eq!(
             enums.get("Verdict"),
             Some(&same_as_a),
@@ -26169,7 +26181,7 @@ mod tests {
     /// Anchor the `?`-operator fold to the real lowered IR of
     /// `baseobjspace::lookup` (`let w_type = type(obj)?; lookup_in_type(..)`).
     /// The break arm (`None => return None`) narrows the `from_residual`
-    /// result through a `__pyre_cast_instance` recast; before the break-arm
+    /// result through a `__cast_instance_intrinsic` recast; before the break-arm
     /// purity gate peeled that recast, `option_try` declined and the residual
     /// `Try::branch` Method-call stayed, walling ~50 heads reaching `lookup`.
     /// After: zero residual `branch` Method-call.  Ignored by default (loads
@@ -26964,9 +26976,9 @@ mod tests {
             "/../../build/llbc/pyre-interpreter.ullbc"
         );
         let llbc = Llbc::load(path).expect("load real LLBC");
-        // Any &mut-self __pyre_wrap setter; set__CHUNK_SIZE takes `&mut self`.
+        // Any &mut-self __majit_wrap setter; set__CHUNK_SIZE takes `&mut self`.
         let graph =
-            super::lower_function(&llbc, "__pyre_wrap_set__CHUNK_SIZE").expect("lower setter");
+            super::lower_function(&llbc, "__majit_wrap_set__CHUNK_SIZE").expect("lower setter");
         let pos0_reads = graph
             .blocks
             .iter()

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -31,7 +31,7 @@
 //! `program.functions` carry the per-method graphs the rest of the
 //! pipeline consumes.  `auto_discover_workspace_llbc_paths` in `lib.rs`
 //! resolves `<workspace>/build/llbc/{pyre-object,pyre-interpreter,pyre-jit}.ullbc`
-//! when `PYRE_MIR_FRONTEND_LLBC` is unset; that canonical set is REQUIRED.
+//! when `MAJIT_MIR_FRONTEND_LLBC` is unset; that canonical set is REQUIRED.
 //! `build_semantic_program_via_active_frontend` panics when no LLBC source
 //! resolves, so every build asserts that graphs come from MIR.
 //!

--- a/majit/majit-translate/src/front/option_closure_select.rs
+++ b/majit/majit-translate/src/front/option_closure_select.rs
@@ -150,7 +150,7 @@ fn rewire_one_closure_select_site(
         .ok_or_else(|| format!("{name}: closure-select call op not found in block {a}"))?;
     let ops_len = graph.blocks[a].operations.len();
 
-    // Absorb the optional trailing `__pyre_cast_instance` narrowing cast a
+    // Absorb the optional trailing `__cast_instance_intrinsic` narrowing cast a
     // `*mut <registered ADT>` result gains (see `option_map_or`).
     let (flow_result, narrow_root, remove_upto) = if ci + 1 == ops_len {
         (site.result_var.clone(), None, ci)
@@ -165,7 +165,7 @@ fn rewire_one_closure_select_site(
                 },
                 Some(narrowed),
             ) if segments.len() == 2
-                && segments[0] == "__pyre_cast_instance"
+                && segments[0] == "__cast_instance_intrinsic"
                 && args.len() == 1
                 && args[0] == site.result_var =>
             {

--- a/majit/majit-translate/src/front/option_map_or.rs
+++ b/majit/majit-translate/src/front/option_map_or.rs
@@ -140,7 +140,7 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
     let ops_len = graph.blocks[a].operations.len();
 
     // `lower_call` closes the call as the block tail, but a `*mut <registered
-    // ADT>` result gains a trailing `__pyre_cast_instance` narrowing op
+    // ADT>` result gains a trailing `__cast_instance_intrinsic` narrowing op
     // (`result_narrow_root`) whose output is what the block forwards on.
     // Absorb that optional cast: `flow_result` is the value B consumes,
     // `narrow_root` re-applies the narrowing per arm, and `remove_upto` bounds
@@ -158,7 +158,7 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
                 },
                 Some(narrowed),
             ) if segments.len() == 2
-                && segments[0] == "__pyre_cast_instance"
+                && segments[0] == "__cast_instance_intrinsic"
                 && args.len() == 1
                 && args[0] == site.result_var =>
             {
@@ -383,7 +383,7 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
     Ok(())
 }
 
-/// Re-emit the `__pyre_cast_instance` pointee-class narrowing in `block` on
+/// Re-emit the `__cast_instance_intrinsic` pointee-class narrowing in `block` on
 /// `value`, returning the narrowed value — the same cast `result_narrow_root`
 /// appends after a `*mut <registered ADT>` call result.  `value` unchanged when
 /// no narrowing was absorbed.
@@ -401,7 +401,7 @@ pub(crate) fn emit_narrow(
         result: Some(narrowed.clone()),
         kind: OpKind::Call {
             target: CallTarget::FunctionPath {
-                segments: vec!["__pyre_cast_instance".to_string(), root.clone()],
+                segments: vec!["__cast_instance_intrinsic".to_string(), root.clone()],
             },
             args: vec![value],
             result_ty: ValueType::Ref(Some(root.clone())),
@@ -505,7 +505,7 @@ mod tests {
     }
 
     /// The production shape: a `*mut <registered ADT>` result appends a
-    /// trailing `__pyre_cast_instance` narrowing op, so the call is NOT the
+    /// trailing `__cast_instance_intrinsic` narrowing op, so the call is NOT the
     /// block tail.  The rewrite absorbs the cast, fires, and re-applies the
     /// narrowing in both arms (so B still consumes a narrowed value).
     #[test]
@@ -532,7 +532,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: CallTarget::FunctionPath {
-                        segments: vec!["__pyre_cast_instance".into(), "PyObject".into()],
+                        segments: vec!["__cast_instance_intrinsic".into(), "PyObject".into()],
                     },
                     args: vec![result.clone()],
                     result_ty: ValueType::Ref(Some("PyObject".into())),
@@ -558,7 +558,7 @@ mod tests {
             )),
             "residual map_or call removed from A"
         );
-        // Two arms each re-emit a `__pyre_cast_instance` narrowing.
+        // Two arms each re-emit a `__cast_instance_intrinsic` narrowing.
         let narrow_casts = g
             .blocks
             .iter()
@@ -567,7 +567,7 @@ mod tests {
                 matches!(
                     &op.kind,
                     OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
-                        if segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                        if segments.first().map(String::as_str) == Some("__cast_instance_intrinsic")
                 )
             })
             .count();

--- a/majit/majit-translate/src/front/option_try.rs
+++ b/majit/majit-translate/src/front/option_try.rs
@@ -85,7 +85,7 @@ pub(crate) fn rewire_option_try_call_sites(
             Ok(()) => stats.rewritten += 1,
             Err(decline) => {
                 stats.declined += 1;
-                if std::env::var_os("PYRE_MIR_FRONTEND_DEBUG").is_some() {
+                if std::env::var_os("MAJIT_MIR_FRONTEND_DEBUG").is_some() {
                     eprintln!(
                         "[option_try] {} decline at {:?}: {decline}",
                         graph.name, site.branch_result_var
@@ -431,7 +431,7 @@ fn verify_break_arm_is_return_none(
         ));
     };
     // An unregistered `from_residual` returns an opaque `Ref` the MIR narrows
-    // to the concrete `Option<T>` via pure `__pyre_cast_instance` recasts (the
+    // to the concrete `Option<T>` via pure `__cast_instance_intrinsic` recasts (the
     // same trailing-recast shape `front::iter_next` peels behind an
     // unregistered `next`).  Peel them so the recognized set covers the recast
     // ops and the None-return forwarding traces the narrowed result.

--- a/majit/majit-translate/src/front/option_unwrap_or.rs
+++ b/majit/majit-translate/src/front/option_unwrap_or.rs
@@ -128,7 +128,7 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
         .expect("result var producer resolved to block A above");
     let last_idx = graph.blocks[a].operations.len() - 1;
     // The call sits at the block tail, optionally followed by a single
-    // `__pyre_cast_instance(result)` narrowing op.  `lower_call` appends that
+    // `__cast_instance_intrinsic(result)` narrowing op.  `lower_call` appends that
     // cast when the payload is a `*mut <registered ADT>` (a raw-pointer
     // `Option` payload) and reassigns the destination local to the narrowed
     // var, so the continuation consumes `narrowed`, not the raw call result.
@@ -147,7 +147,7 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
                     result_ty,
                 },
                 Some(narrowed),
-            ) if segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+            ) if segments.first().map(String::as_str) == Some("__cast_instance_intrinsic")
                 && args.as_slice() == std::slice::from_ref(&site.result_var) =>
             {
                 (Some((segments.clone(), result_ty.clone())), narrowed)
@@ -329,7 +329,7 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
     Ok(())
 }
 
-/// Re-emit the `__pyre_cast_instance` narrowing the residual call carried into
+/// Re-emit the `__cast_instance_intrinsic` narrowing the residual call carried into
 /// an arm's `raw` payload value.  `None` (no cast on the original result) is a
 /// pass-through: the raw value flows on unchanged.  The cast is jitcode-identity
 /// (`cast_pointer` → `same_as`), so duplicating it per arm is sound.
@@ -477,7 +477,7 @@ mod tests {
     }
 
     /// A raw-pointer payload (`Option<*mut PyObject>`) makes `lower_call`
-    /// append a `__pyre_cast_instance(result)` narrowing op after the
+    /// append a `__cast_instance_intrinsic(result)` narrowing op after the
     /// `unwrap_or` call, so the call is the block's second-to-last op and the
     /// continuation consumes the *narrowed* var.  The rewrite must tolerate
     /// that trailing identity cast: lift to the discriminant select and apply
@@ -507,7 +507,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: CallTarget::FunctionPath {
-                        segments: vec!["__pyre_cast_instance".into(), "PyObject".into()],
+                        segments: vec!["__cast_instance_intrinsic".into(), "PyObject".into()],
                     },
                     args: vec![result.clone()],
                     result_ty: ValueType::Ref(Some("PyObject".into())),
@@ -546,7 +546,7 @@ mod tests {
             .flat_map(|blk| &blk.operations)
             .filter(|op| {
                 matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
-                    if segments.first().map(String::as_str) == Some("__pyre_cast_instance"))
+                    if segments.first().map(String::as_str) == Some("__cast_instance_intrinsic"))
             })
             .count();
         assert_eq!(arm_casts, 2, "each diamond arm narrows its payload");

--- a/majit/majit-translate/src/front/range_iter.rs
+++ b/majit/majit-translate/src/front/range_iter.rs
@@ -29,7 +29,7 @@
 //!     ... next(r) folded by front::iter_next into the native `next` op
 //! ```
 //!
-//! `range` is emitted under the reserved `["__pyre_range"]` spelling (see
+//! `range` is emitted under the reserved `["__majit_range"]` spelling (see
 //! [`range_builtin_call`]) and resolves through
 //! `HOST_ENV.lookup_builtin("range")` →
 //! `SomeBuiltin("range")` → `builtin_range` (`SomeList` with `range_step`);
@@ -371,9 +371,9 @@ fn graph_defines(graph: &FunctionGraph, var: &Variable) -> bool {
 /// through `HOST_ENV.lookup_builtin("range")` → `SomeBuiltin("range")` →
 /// `builtin_range` (a `SomeList` carrying `range_step`).
 ///
-/// Spelled with the reserved `__pyre_range` segment rather than a bare
+/// Spelled with the reserved `__majit_range` segment rather than a bare
 /// `["range"]`: the adapter resolves a single-segment path against the
-/// `PyreCallRegistry` before `HOST_ENV`, and pyre's registry is one flat
+/// `CallRegistry` before `HOST_ENV`, and pyre's registry is one flat
 /// namespace keyed by leaf-only `CallPath`s, so a pyre free function named
 /// `range` (`pyre_interpreter::module::_ast::convert::range`) registers as
 /// `["range"]` and would capture this call. The reserved spelling has a
@@ -384,7 +384,7 @@ fn range_builtin_call(result: Variable, start: Variable, end: Variable) -> Space
         result: Some(result),
         kind: OpKind::Call {
             target: CallTarget::FunctionPath {
-                segments: vec!["__pyre_range".to_string()],
+                segments: vec!["__majit_range".to_string()],
             },
             args: vec![start, end],
             result_ty: ValueType::Ref(None),
@@ -525,7 +525,7 @@ mod tests {
         assert_eq!(rewritten, 1, "the range for-loop must be diverted");
         assert_eq!(count_range_ctors(&g), 0, "range ctor removed");
         assert_eq!(
-            count_calls_ending(&g, &["__pyre_range"]),
+            count_calls_ending(&g, &["__majit_range"]),
             1,
             "one range() builtin emitted"
         );
@@ -600,7 +600,7 @@ mod tests {
         assert_eq!(rewritten, 1, "two-hop range for-loop must be diverted");
         assert_eq!(count_range_ctors(&g), 0, "range ctor removed");
         assert_eq!(
-            count_calls_ending(&g, &["__pyre_range"]),
+            count_calls_ending(&g, &["__majit_range"]),
             1,
             "one range() builtin emitted"
         );
@@ -679,7 +679,7 @@ mod tests {
         assert_eq!(rewritten, 0, "a second range consumer declines the divert");
         assert_eq!(count_range_ctors(&g), 1, "range ctor survives");
         assert_eq!(
-            count_calls_ending(&g, &["__pyre_range"]),
+            count_calls_ending(&g, &["__majit_range"]),
             0,
             "no range() builtin emitted"
         );

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -2539,7 +2539,7 @@ pub(crate) fn assert_block_pure_besides(
     Ok(())
 }
 
-/// `true` iff `kind` is a `__pyre_cast_instance` narrow — the front-end
+/// `true` iff `kind` is a `__cast_instance_intrinsic` narrow — the front-end
 /// pointer-downcast marker (`front::mir` `Rvalue::Cast` arm) the MIR emits
 /// when an opaque `Ref` result is reinterpreted as a registered struct root.
 /// It lowers to `cast_pointer` (a pure alias), so it carries no side effect
@@ -2551,14 +2551,14 @@ pub(crate) fn is_recast_narrow(kind: &OpKind) -> bool {
             target: CallTarget::FunctionPath { segments },
             args,
             ..
-        } if args.len() == 1 && segments.first().is_some_and(|s| s == "__pyre_cast_instance")
+        } if args.len() == 1 && segments.first().is_some_and(|s| s == "__cast_instance_intrinsic")
     )
 }
 
-/// Peel the trailing chain of pure `__pyre_cast_instance` recasts starting
+/// Peel the trailing chain of pure `__cast_instance_intrinsic` recasts starting
 /// from `start` within `block`: an unregistered call (`from_residual`,
 /// `next`, …) returns an opaque `Ref` the MIR immediately narrows to the
-/// concrete type with one or more `__pyre_cast_instance` recasts.  Follow
+/// concrete type with one or more `__cast_instance_intrinsic` recasts.  Follow
 /// each contiguous recast whose sole operand is the prior result, requiring
 /// that no non-final intermediate is read by anything but the next recast or
 /// escapes on an exit link (else collapsing the chain would strand a live

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -94,7 +94,7 @@ pub struct SemanticFunction {
     /// Fully-qualified `name_path()` of the trait when this function
     /// is an `impl Trait for Type {…}` method, otherwise `None`.
     /// Distinguishes traits whose leaf names collide — the unique-impl
-    /// map (`pyre_trait_unique_impls`) keys on this, not `trait_root`.
+    /// map (`trait_unique_impls`) keys on this, not `trait_root`.
     /// Trait default bodies leave it `None`: Charon names them with
     /// only the trait leaf segment, and they never feed the
     /// unique-impl map.
@@ -301,7 +301,7 @@ pub struct SemanticProgram {
     /// `CallControl.unsafe_fn_stubs` →
     /// `cutover::register_unsafe_fn_stubs` so the dual gate registers a
     /// stub PyGraph for each, covering the "not registered in
-    /// PyreCallRegistry" Skip cluster dominated by `pyre_object::is_*`.
+    /// CallRegistry" Skip cluster dominated by `pyre_object::is_*`.
     /// These callees' bodies access raw pointers the flowspace adapter
     /// does not model, so only a typed signature stub is registered.
     pub unsafe_fn_stubs: Vec<(

--- a/majit/majit-translate/src/front/slice_first.rs
+++ b/majit/majit-translate/src/front/slice_first.rs
@@ -42,7 +42,7 @@
 //!
 //! Block A holds the residual `first` call producing `opt`.  Because
 //! `Option<&PyObjectRef>` triggers `option_residual_narrow_root`, `lower_call`
-//! appends a trailing `__pyre_cast_instance` after the call, so the call is NOT
+//! appends a trailing `__cast_instance_intrinsic` after the call, so the call is NOT
 //! A's last op — the block-A skeleton absorbs that optional cast, exactly as
 //! [`crate::front::option_map_or`] does.  The rewrite:
 //! 1. drops the `first` call (+ absorbed cast) and closes A with a
@@ -124,7 +124,7 @@ fn rewire_one_slice_first_site(
         .ok_or_else(|| format!("{name}: slice::first result var has no producer block"))?;
 
     // Locate the `first` call op by its result (not assuming it is the block
-    // tail — the trailing `__pyre_cast_instance` may follow, see below).
+    // tail — the trailing `__cast_instance_intrinsic` may follow, see below).
     let ci = graph.blocks[a]
         .operations
         .iter()
@@ -132,7 +132,7 @@ fn rewire_one_slice_first_site(
         .ok_or_else(|| format!("{name}: slice::first call op not found in block {a}"))?;
     let ops_len = graph.blocks[a].operations.len();
 
-    // `Option<&PyObjectRef>` gains a trailing `__pyre_cast_instance` narrowing
+    // `Option<&PyObjectRef>` gains a trailing `__cast_instance_intrinsic` narrowing
     // op (`result_narrow_root`) whose output is what the block forwards on.
     // Absorb that optional cast: `flow_result` is the value B consumes,
     // `narrow_root` re-applies the narrowing per arm, `remove_upto` bounds the
@@ -150,7 +150,7 @@ fn rewire_one_slice_first_site(
                 },
                 Some(narrowed),
             ) if segments.len() == 2
-                && segments[0] == "__pyre_cast_instance"
+                && segments[0] == "__cast_instance_intrinsic"
                 && args.len() == 1
                 && args[0] == site.result_var =>
             {
@@ -413,7 +413,7 @@ mod tests {
     }
 
     /// The production shape: an `Option<&RegisteredStruct>` result appends a
-    /// trailing `__pyre_cast_instance` narrowing op, so the call is NOT the
+    /// trailing `__cast_instance_intrinsic` narrowing op, so the call is NOT the
     /// block tail.  The rewrite absorbs the cast, fires, and re-applies the
     /// narrowing in both arms.
     #[test]
@@ -444,7 +444,7 @@ mod tests {
                 a,
                 OpKind::Call {
                     target: CallTarget::FunctionPath {
-                        segments: vec!["__pyre_cast_instance".into(), "PyObject".into()],
+                        segments: vec!["__cast_instance_intrinsic".into(), "PyObject".into()],
                     },
                     args: vec![opt.clone()],
                     result_ty: ValueType::Ref(Some("PyObject".into())),
@@ -471,7 +471,7 @@ mod tests {
             )),
             "residual first call removed from A"
         );
-        // Two arms each re-emit a `__pyre_cast_instance` narrowing.
+        // Two arms each re-emit a `__cast_instance_intrinsic` narrowing.
         let narrow_casts = g
             .blocks
             .iter()
@@ -480,7 +480,7 @@ mod tests {
                 matches!(
                     &op.kind,
                     OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
-                        if segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                        if segments.first().map(String::as_str) == Some("__cast_instance_intrinsic")
                 )
             })
             .count();

--- a/majit/majit-translate/src/generated.rs
+++ b/majit/majit-translate/src/generated.rs
@@ -149,7 +149,7 @@ pub use crate::codewriter::AllJitCodes;
 /// the runtime + production analyser pipeline produce.  Empty module
 /// path (test fixtures that bypass module wiring) is reserved for
 /// `parse_source`; here every entry carries its real module path.
-const PYRE_JIT_GRAPH_MODULES: &[&str] = &["pyopcode", "eval", "pyframe", "shared_opcode", "eval"];
+const JIT_GRAPH_MODULES: &[&str] = &["pyopcode", "eval", "pyframe", "shared_opcode", "eval"];
 
 thread_local! {
     /// Per-thread cache for the pyre-interpreter JitCode registry.
@@ -184,7 +184,7 @@ fn build() -> AllJitCodes {
     // Full canonical pipeline — the same entry point the
     // `test_analyze_pipeline_runs_canonical_graph_path` integration test
     // exercises. Builds a `SemanticProgram` from the LLBC modules
-    // listed in `PYRE_JIT_GRAPH_MODULES`, runs `analyze_program`,
+    // listed in `JIT_GRAPH_MODULES`, runs `analyze_program`,
     // collects trait impls + inherent impl methods with full
     // struct-field / return-type / known-struct context, wires up
     // jitdriver / portal / oopspec metadata, then calls
@@ -201,7 +201,7 @@ fn build() -> AllJitCodes {
     //
     // The blocker is wider than "need a binding table":
     //
-    // - Many graphs in `PYRE_JIT_GRAPH_MODULES` are generic source-level
+    // - Many graphs in `JIT_GRAPH_MODULES` are generic source-level
     //   functions, e.g. `pyopcode.rs` / `shared_opcode.rs`
     //   `opcode_*<H: ...>` helpers and trait default methods on
     //   `OpcodeStepExecutor`. A source graph like
@@ -221,7 +221,7 @@ fn build() -> AllJitCodes {
     // fallback is therefore part of the current API contract and is locked
     // down by the unit tests below.
     let result = crate::analyze_multiple_pipeline_with_modules(
-        PYRE_JIT_GRAPH_MODULES,
+        JIT_GRAPH_MODULES,
         &crate::AnalyzeConfig {
             pipeline: crate::PipelineConfig {
                 transform: crate::GraphTransformConfig::default(),

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -137,7 +137,7 @@ use serde::{Deserialize, Serialize};
 pub(crate) fn determinism_trace_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| {
-        std::env::var_os("PYRE_DETERMINISM_TRACE").is_some_and(|value| value == "1")
+        std::env::var_os("MAJIT_DETERMINISM_TRACE").is_some_and(|value| value == "1")
     })
 }
 
@@ -182,17 +182,12 @@ pub struct MethodInfo {
 ///
 /// 1. Paths supplied by an explicit-LLBC analyzer entry point. These are the
 ///    complete input set and disable every fallback below.
-/// 2. `PYRE_MIR_FRONTEND_LLBC` env-var (OS path-list: `;`-separated on
+/// 2. `MAJIT_MIR_FRONTEND_LLBC` env-var (OS path-list: `;`-separated on
 ///    Windows, `:`-separated elsewhere). Explicit override for CI /
 ///    test fixtures targeting a specific LLBC set.
-/// 3. Auto-discovery at `<workspace>/build/llbc/<expected>.ullbc`,
-///    where `scripts/extract-llbc.py` writes. If every expected file
-///    exists, the MIR front-end engages automatically.
 ///
-/// Panics when neither source resolves: the MIR front-end is the only
-/// graph builder, so a missing LLBC set (Charon not installed, or
-/// `scripts/extract-llbc.py` not run) is a fatal misconfiguration
-/// rather than a fallback to another path.
+/// Panics when neither source resolves. Artifact selection belongs to the
+/// consumer because only the consumer knows which crates form its program.
 fn build_semantic_program_via_active_frontend(
     module_paths: &[&str],
     static_addrs: HostStaticAddrs<'_>,
@@ -201,33 +196,29 @@ fn build_semantic_program_via_active_frontend(
 ) -> front::SemanticProgram {
     #[cfg(feature = "mir-frontend")]
     {
-        // Accept an OS path-list so production can pass the canonical
-        // pyre LLBC set in one env-var.
+        // Accept an OS path-list so a consumer can pass its LLBC set in one
+        // environment variable.
         // `std::env::split_paths` uses the platform separator (`;` on
         // Windows, `:` elsewhere) so a Windows drive letter like `Z:`
         // is not mistaken for a separator.  The single-path form also
         // works.
         //
-        // If the env-var is unset, auto-discover the canonical
-        // workspace LLBC artefacts before failing loud.
         let resolved_paths: Option<Vec<String>> = explicit_llbc_paths
             .filter(|paths| !paths.is_empty())
             .map(|paths| paths.iter().map(|path| (*path).to_string()).collect())
             .or_else(|| {
-                std::env::var_os("PYRE_MIR_FRONTEND_LLBC")
+                std::env::var_os("MAJIT_MIR_FRONTEND_LLBC")
                     .map(|v| {
                         std::env::split_paths(&v)
                             .filter(|p| !p.as_os_str().is_empty())
                             .map(|p| p.to_string_lossy().into_owned())
                             .collect()
                     })
-                    // A present-but-blank override (`PYRE_MIR_FRONTEND_LLBC=`)
-                    // collects to an empty vec; treat it as unset so workspace
-                    // auto-discovery still runs instead of feeding an empty LLBC
-                    // set into the frontend.
+                    // A present-but-blank override (`MAJIT_MIR_FRONTEND_LLBC=`)
+                    // collects to an empty vec; treat it as unset instead of
+                    // feeding an empty LLBC set into the frontend.
                     .filter(|paths: &Vec<String>| !paths.is_empty())
-            })
-            .or_else(|| auto_discover_workspace_llbc_paths(module_paths));
+            });
         if let Some(paths) = resolved_paths {
             let llbcs: Vec<majit_charon_reader::Llbc> = paths
                 .iter()
@@ -241,8 +232,8 @@ fn build_semantic_program_via_active_frontend(
             // Seed the local-crate alias roots from the loaded set so
             // `free_function_alias_paths` and the registry's canonical
             // dedup treat every extracted crate name as an alias root
-            // (`local_crates.rs`); a non-pyre consumer resolves its
-            // crate-qualified cross-crate callsites through this.
+            // (`local_crates.rs`); consumers resolve crate-qualified
+            // cross-crate callsites through this set.
             crate::local_crates::register_local_crate_roots(
                 llbcs.iter().map(|l| l.crate_name().to_string()),
             );
@@ -289,7 +280,7 @@ fn build_semantic_program_via_active_frontend(
                 .chain(
                     llbcs
                         .iter()
-                        .flat_map(front::mir::collect_pyre_class_ctor_stubs_from_llbc),
+                        .flat_map(front::mir::collect_marked_class_ctor_stubs_from_llbc),
                 )
                 .collect();
             // Foreign opaque-ADT methods (`<BigInt as Add>::add`, …) that
@@ -313,143 +304,15 @@ fn build_semantic_program_via_active_frontend(
     }
     let _ = module_paths; // silence unused warning when the feature is off
     // The MIR front-end is the only graph builder.  Reaching this
-    // point means neither `PYRE_MIR_FRONTEND_LLBC` nor the workspace
-    // auto-discover located an LLBC source — surface the
+    // point means neither an explicit path set nor
+    // `MAJIT_MIR_FRONTEND_LLBC` supplied an LLBC source. Surface the
     // misconfiguration immediately.
     panic!(
         "no LLBC source resolved.\n\
-         Run `scripts/extract-llbc.py` to produce \
-         `build/llbc/{{pyre-object,pyre-interpreter,pyre-jit}}.ullbc`, \
-         or set `PYRE_MIR_FRONTEND_LLBC` to an OS path-list \
+         Pass explicit LLBC paths to the analyzer, or set \
+         `MAJIT_MIR_FRONTEND_LLBC` to an OS path-list \
          (`;`-separated on Windows, `:` elsewhere) explicitly."
     );
-}
-
-/// Locate the workspace's `build/llbc/` directory and return paths to
-/// the canonical pyre LLBC artefacts when every expected file is
-/// present *and* the caller looks like a production build (not a test
-/// fixture).
-///
-/// Returns `None` when:
-///   - no source carries a `module_path` (test fixtures pass empty
-///     module paths; production passes per-file crate-stripped paths),
-///   - the caller passed fewer than `PROD_SOURCE_FILES_FLOOR`
-///     module paths (single-source diagnostic),
-///   - a mandatory artefact (`pyre-object.ullbc` /
-///     `pyre-interpreter.ullbc`) is missing (contributor without
-///     Charon installed), or
-///   - the workspace anchoring fails.
-///
-/// `pyre-jit.ullbc` is included when present. Pyre's production
-/// `eval::eval_loop_jit` driver requires it; the extraction bootstrap no
-/// longer relies on a different temporary portal and instead bypasses this
-/// analysis explicitly with `MAJIT_LLBC_EXTRACTION=1`. Returning the mandatory
-/// pair when it is absent remains useful only to consumers whose configured
-/// portal is contained in those artifacts; exact driver resolution rejects an
-/// unavailable portal later in the pipeline.
-///
-/// The two gates together match the production fingerprint:
-/// `pyre-jit-trace/build.rs` calls
-/// `analyze_multiple_pipeline_with_modules` with ≈100 per-file
-/// `module_path`s.  Non-production callers (test fixtures and the
-/// 5-module `generated::PYRE_JIT_GRAPH_MODULES` manifest) stay below
-/// the floor, so auto-discovery does not silently swap their
-/// front-end.
-///
-/// The workspace root is anchored at compile time via
-/// `env!("CARGO_MANIFEST_DIR")` — `<workspace>/majit/majit-translate`
-/// resolves up to `<workspace>` via two `..` segments.  The
-/// `scripts/extract-llbc.py` script writes to the same
-/// `<workspace>/build/llbc/` directory by convention, so the two
-/// halves stay in sync.
-#[cfg(feature = "mir-frontend")]
-fn auto_discover_workspace_llbc_paths(module_paths: &[&str]) -> Option<Vec<String>> {
-    const PROD_SOURCE_FILES_FLOOR: usize = 50;
-    if module_paths.len() < PROD_SOURCE_FILES_FLOOR {
-        return None;
-    }
-    if !module_paths.iter().any(|mp| !mp.is_empty()) {
-        return None;
-    }
-    let workspace_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("..")
-        .join("..");
-    let llbc_dir = workspace_root.join("build").join("llbc");
-    // Canonical production set.  `pyre-module.ullbc` is intentionally
-    // omitted — it is empty in current builds and adds nothing.
-    // `corpus.ullbc` is the Charon fixture, not production.
-    //
-    // The set is fixed at exactly these crates so the generated
-    // `all_jitcodes` table is environment-invariant: every real build
-    // (`cargo test`, `pyre/check.py`) consumes the same `.ullbc`
-    // inputs, so a local tree and CI produce byte-identical codegen.
-    // `majit-rlib.ullbc`, `pyre-object.ullbc` and `pyre-interpreter.ullbc` are
-    // mandatory. `majit-rlib` comes first because it owns `rbigint`: the other
-    // artefacts carry whatever cross-crate references pulled in, and the
-    // first-writer-wins per-type tables below should take the owning crate's
-    // complete declarations rather than those partial ones.
-    //
-    // `pyre-jit.ullbc` hosts Pyre's exact `eval::eval_loop_jit` portal. The
-    // extraction driver sets `MAJIT_LLBC_EXTRACTION=1` while producing that
-    // artifact, so `pyre-jit-trace/build.rs` emits compile-only placeholders
-    // and never enters this analysis during the dependency bootstrap. A normal
-    // Pyre build requires all three artifacts; generic consumers whose portal
-    // lives in the mandatory pair may still use the two-artifact result.
-    const MANDATORY: &[&str] = &[
-        "majit-rlib.ullbc",
-        "pyre-object.ullbc",
-        "pyre-interpreter.ullbc",
-    ];
-    let mut paths = Vec::with_capacity(MANDATORY.len() + 1);
-    for name in MANDATORY {
-        let p = llbc_dir.join(name);
-        if !p.exists() {
-            return None;
-        }
-        paths.push(p.to_string_lossy().into_owned());
-    }
-    let pyre_jit = llbc_dir.join("pyre-jit.ullbc");
-    if pyre_jit.exists() {
-        paths.push(pyre_jit.to_string_lossy().into_owned());
-    } else {
-        eprintln!(
-            "[majit-translate] pyre-jit.ullbc absent — using the 2-crate \
-             front-end. A configured eval::eval_loop_jit driver will fail \
-             exact portal resolution; run scripts/extract-llbc.py first."
-        );
-    }
-    // Cross-target layout sidecars LAST.  Charon resolves struct layouts per
-    // target, and the artefacts above carry the extraction host's; building
-    // for a target with a different pointer width would otherwise read every
-    // field past the first pointer at the wrong offset.  A sidecar is the same
-    // crate re-extracted for that target, reduced to `type_decls`.  It must
-    // contribute *only* its `exact_layouts` (the target field offsets): its
-    // `type_decls` were extracted without the function bodies, so any field
-    // type first hash-consed in a dropped body resolves to nothing, and the
-    // host artefacts — where those types are target-independent and fully
-    // resolvable — are the authority for everything but offsets.  So the
-    // sidecar goes last, and `build_semantic_program_from_llbcs` seeds every
-    // per-type-string table from the host (first-writer) while overwriting
-    // `exact_layouts` from the sidecar (last-writer).
-    let target = std::env::var("TARGET").unwrap_or_default();
-    let host = std::env::var("HOST").unwrap_or_default();
-    if layout::is_cross_target(&target, &host) {
-        for name in MANDATORY {
-            let stem = name.trim_end_matches(".ullbc");
-            let sidecar = llbc_dir.join(layout::layout_sidecar_filename(stem, &target));
-            if sidecar.exists() {
-                paths.push(sidecar.to_string_lossy().into_owned());
-            } else {
-                eprintln!(
-                    "[majit-translate] {stem}.{target}.layouts.ullbc absent — \
-                     cross-target build will read {stem}'s host-extracted field \
-                     offsets, which may be wrong for {target}; run \
-                     scripts/extract-llbc.py to produce it."
-                );
-            }
-        }
-    }
-    Some(paths)
 }
 
 /// Merge JIT-hint markers harvested from the ullbc surrogate consts
@@ -561,8 +424,7 @@ pub struct HostStaticAddrs<'a> {
 /// analyzed source file (e.g. `"intobject"` for
 /// `pyre_object/src/intobject.rs`).  The graph surface itself comes
 /// from the Charon-extracted LLBC set; the `module_paths` slice drives
-/// the workspace LLBC auto-discovery production fingerprint and stays
-/// available for per-file lexical resolution.  Source text is not
+/// per-file lexical resolution. Source text is not
 /// consumed — callers pass paths only.
 ///
 /// An empty `module_paths[i]` keeps simple-name registration only —
@@ -591,9 +453,9 @@ pub fn analyze_multiple_pipeline_with_modules(
 /// Multi-file analysis with an explicit, ordered LLBC input set.
 ///
 /// Consumer build scripts should prefer this entry point over the legacy
-/// `PYRE_MIR_FRONTEND_LLBC` compatibility environment variable. The supplied
-/// paths are the complete translation input and never fall back to Pyre's
-/// workspace auto-discovery.
+/// `MAJIT_MIR_FRONTEND_LLBC` compatibility environment variable. The supplied
+/// paths are the complete translation input and never fall back to the
+/// environment variable.
 pub fn analyze_multiple_pipeline_from_llbc_with_modules(
     llbc_paths: &[&str],
     module_paths: &[&str],
@@ -721,7 +583,7 @@ fn free_function_alias_paths(name: &str, source_module: &str) -> Vec<crate::pars
     paths
 }
 
-/// `PYRE_PROFILE_PIPELINE=1` phase profiler: elapsed wall time plus the
+/// `MAJIT_PROFILE_PIPELINE=1` phase profiler: elapsed wall time plus the
 /// process high-water RSS at each mark, so a phase's contribution to the
 /// translation prepass's peak footprint is visible next to its cost in time.
 pub struct PhaseProfiler {
@@ -734,7 +596,7 @@ impl PhaseProfiler {
     pub fn new() -> Self {
         let now = std::time::Instant::now();
         Self {
-            enabled: std::env::var_os("PYRE_PROFILE_PIPELINE").is_some(),
+            enabled: std::env::var_os("MAJIT_PROFILE_PIPELINE").is_some(),
             start: now,
             last: now,
         }
@@ -747,7 +609,7 @@ impl PhaseProfiler {
         let now = std::time::Instant::now();
         const GB: f64 = (1u64 << 30) as f64;
         eprintln!(
-            "[PYRE_PROFILE_PIPELINE] {:>9.3}s  {:>9.3}s  live {:>6.2}GB  peak {:>6.2}GB  {name}",
+            "[MAJIT_PROFILE_PIPELINE] {:>9.3}s  {:>9.3}s  live {:>6.2}GB  peak {:>6.2}GB  {name}",
             (now - self.start).as_secs_f64(),
             (now - self.last).as_secs_f64(),
             live_rss_bytes() as f64 / GB,
@@ -761,7 +623,7 @@ impl PhaseProfiler {
     /// counting the sizes costs nothing when the profiler is off.
     pub fn note(&self, message: impl FnOnce() -> String) {
         if self.enabled {
-            eprintln!("[PYRE_PROFILE_PIPELINE] {}", message());
+            eprintln!("[MAJIT_PROFILE_PIPELINE] {}", message());
         }
     }
 }
@@ -907,8 +769,8 @@ fn analyze_pipeline_from_module_paths(
     // SemanticProgram build through the MIR-driven
     // `front::mir::build_semantic_program_from_llbcs` path.  The LLBC
     // source is a Charon-extracted .ullbc snapshot (produced by
-    // `scripts/extract-llbc.py`), located via `PYRE_MIR_FRONTEND_LLBC`
-    // or workspace auto-discovery.
+    // `scripts/extract-llbc.py`), supplied explicitly by the consumer or
+    // located via `MAJIT_MIR_FRONTEND_LLBC`.
     mark_phase!("known_statics + struct_field_attrs populated");
     let mut program = build_semantic_program_via_active_frontend(
         module_paths,
@@ -1024,10 +886,9 @@ fn analyze_pipeline_from_module_paths(
     // `bookkeeper.py getdesc` / `newfuncdesc` keys on the host
     // function-object identity, so two unrelated `crate_a::helper` and
     // `crate_b::helper` resolve to distinct `FunctionDesc` instances.
-    // Pyre's call registry is keyed on `CallPath` segment strings, and
-    // the alias expansion below intentionally registers each free
-    // function under every well-known pyre-crate prefix
-    // (`pyre_interpreter` / `pyre_object` / `pyre_jit`).  Without a
+    // The call registry is keyed on `CallPath` segment strings, and the
+    // alias expansion below intentionally registers each free function under
+    // every crate root in the loaded LLBC set. Without a
     // collision check the second registration silently overwrites the
     // first when two source crates happen to define a function with
     // the same tail segments, so the call resolver may then route to
@@ -1242,8 +1103,8 @@ fn analyze_pipeline_from_module_paths(
     call_control.recompute_immutable_array_types();
     // The `unsafe_fn_stubs` carrier lets the codewriter's
     // `dual_gate_registry` register every `unsafe fn` / unsafe
-    // impl-method as a stub-pygraph entry in PyreCallRegistry, covering
-    // the bulk of the "not registered in PyreCallRegistry" Skip cluster
+    // impl-method as a stub-pygraph entry in CallRegistry, covering
+    // the bulk of the "not registered in CallRegistry" Skip cluster
     // dominated by `pyre_object::is_*` predicates whose body lowering is
     // intentionally rejected (raw-pointer access the flowspace adapter
     // does not model — only a typed signature stub is registered).
@@ -1385,10 +1246,10 @@ fn analyze_pipeline_from_module_paths(
     //
     // RPython parity: hints live on `graph.func` and survive alias
     // routing because the call path resolves to a single function
-    // object identity (`policy.py:48` / `call.py:126`).  Pyre keys
-    // hints on `CallPath` segments, so every spelling the graph alias
-    // loop registered above (`free_function_alias_paths`: bare +
-    // `crate::` + `pyre_interpreter|pyre_object|pyre_jit::` + the
+    // object identity (`policy.py:48` / `call.py:126`). This port keys hints
+    // on `CallPath` segments, so every spelling the graph alias loop
+    // registered above (`free_function_alias_paths`: bare + `crate::` +
+    // each loaded LLBC crate root + the
     // `source_module`-prefixed variants thereof) must carry the same
     // hint set.  Missing the source-module-qualified aliases silently
     // disables `_jit_look_inside_` etc. for module-qualified callers,
@@ -1611,7 +1472,7 @@ fn analyze_pipeline_from_module_paths(
     // Default bodies registered that direct path in the loop above; a
     // required method (declaration only, no default body) left it
     // unregistered, so the registry lift failed with "not registered
-    // in PyreCallRegistry" and poisoned every caller.  RPython
+    // in CallRegistry" and poisoned every caller.  RPython
     // resolves the call on the receiver's class
     // (`classdesc.py lookup` MRO walk); when exactly one class
     // implements the method in the closed LLBC world, that walk has a
@@ -2098,7 +1959,7 @@ fn analyze_pipeline_from_module_paths(
     // upstream's declared-external arm without a declaration behind them.
     // Off by default — it is a whole extra walk of the registered universe,
     // and it reports a population, not a defect.
-    if std::env::var_os("PYRE_CALLEE_CENSUS").is_some_and(|v| v == "1") {
+    if std::env::var_os("MAJIT_CALLEE_CENSUS").is_some_and(|v| v == "1") {
         eprint!("{}", call_control.unknown_callee_census());
         // the unused-override check's falsifier. `call_target_matches_loose` reports a
         // non-match by returning `false`, so an override entry that names a
@@ -2316,7 +2177,7 @@ fn make_jitcodes(
     // `insns`, mirroring RPython's single-store model.
     let descrs: Vec<jitcode::BhDescr> = codewriter.assembler.snapshot_descrs();
 
-    if std::env::var_os("PYRE_DESCR_POOL_CENSUS").is_some_and(|v| v == "1") {
+    if std::env::var_os("MAJIT_DESCR_POOL_CENSUS").is_some_and(|v| v == "1") {
         let dup = codewriter.assembler.descr_pool_duplication();
         // C1: the mint universe, beside the pool, in the same generation.
         // `all_descrs` stable while the pool moves is a SELECTION defect;

--- a/majit/majit-translate/src/local_crates.rs
+++ b/majit/majit-translate/src/local_crates.rs
@@ -12,13 +12,10 @@
 //! (`populate_call_registry_from_call_graphs`).
 //!
 //! Seeded from the loaded LLBC set's `crate_name()`s by
-//! `build_semantic_program_via_active_frontend`; the pyre trio is always
-//! included so fixtures that build programs without the active frontend
-//! (and the pyre production set itself) keep their spellings unchanged.
+//! `build_semantic_program_via_active_frontend`. Consumers that construct
+//! programs without the active frontend must register their own crate roots.
 
 use std::cell::RefCell;
-
-const DEFAULT_ROOTS: [&str; 3] = ["pyre_interpreter", "pyre_object", "pyre_jit"];
 
 thread_local! {
     /// Per-pipeline-invocation local-crate alias roots, seeded once at the
@@ -47,19 +44,11 @@ pub(crate) fn register_local_crate_roots(names: impl IntoIterator<Item = String>
     REGISTERED.with(|registered| *registered.borrow_mut() = names.into_iter().collect());
 }
 
-/// Registered local crate names plus the always-included pyre trio,
-/// registered names first.
+/// Registered local crate names for the current pipeline invocation.
 pub(crate) fn local_crate_roots() -> Vec<String> {
-    let mut roots: Vec<String> = REGISTERED.with(|registered| registered.borrow().clone());
-    for default in DEFAULT_ROOTS {
-        if !roots.iter().any(|r| r == default) {
-            roots.push(default.to_string());
-        }
-    }
-    roots
+    REGISTERED.with(|registered| registered.borrow().clone())
 }
 
 pub(crate) fn is_local_crate_root(seg: &str) -> bool {
-    DEFAULT_ROOTS.contains(&seg)
-        || REGISTERED.with(|registered| registered.borrow().iter().any(|r| r == seg))
+    REGISTERED.with(|registered| registered.borrow().iter().any(|r| r == seg))
 }

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -755,7 +755,7 @@ pub enum OpKind {
         owner: String,
     },
     /// RPython `malloc(STRUCT, flavor='gc')` for a fixed-size GcStruct: the
-    /// heap allocation of a boxed object (`pyre_object::lltype::malloc_typed`).
+    /// heap allocation of a boxed object (`runtime_object::lltype::malloc_typed`).
     /// Lowered to the `new_with_vtable` jitcode op (executor
     /// `OpCode::NewWithVtable`). `owner` is the struct leaf (e.g.
     /// `"W_FloatObject"`); the assembler resolves the size descriptor from it
@@ -1322,7 +1322,7 @@ pub enum OpKind {
     /// to a canonical opname.
     /// Reaching the op at runtime means tracing or blackhole resume
     /// crossed an untranslatable graph slice; downstream handlers
-    /// advance past it (see `blackhole.rs::handler_abort_marker_pyre`).
+    /// advance past it (see `blackhole.rs::handler_abort_marker`).
     /// Distinct from RPython's `SwitchToBlackhole` exception path —
     /// RPython aborts before lowering so no equivalent opname exists.
     /// Kept under `kind: UnknownKind` because the same diagnostic enum
@@ -3019,7 +3019,7 @@ pub fn remove_dead_aggregates(graph: &mut FunctionGraph) -> usize {
 /// in Rust as `malloc_typed(W_FloatObject { ob_header: …, floatval: v })` —
 /// construct the whole struct on the stack, then heap-copy.  `front::mir`
 /// lowers that to a `SyntheticTransparentCtor` aggregate (`%agg`) + per-field
-/// `FieldWrite`s + a residual `Call(pyre_object::lltype::malloc_typed, [%agg])`.
+/// `FieldWrite`s + a residual `Call(runtime_object::lltype::malloc_typed, [%agg])`.
 /// RPython's orthodox form is alloc-then-init (`p = malloc(S); p.f = v`); the
 /// rtyper lowers `malloc` to the GC allocation op.  pyre's rtyper is an
 /// ephemeral type oracle that never rewrites the surviving model graph, so the
@@ -3069,7 +3069,7 @@ pub fn fuse_boxing_alloc(
     // here (the runtime stamps `ob_type`/`w_class` from the descriptor).  Two
     // spellings reach this pass: the hand-written boxing structs
     // (`W_FloatObject` etc.) name it `ob_header`, while `#[pyre_class]` injects
-    // it as `ob` (pyre-macros `expand_pyre_class`).  Both name the same base,
+    // it as `ob` (pyre-macros `expand_pyre_class`). Both name the same base,
     // so both are recognised as the header and neither is re-emitted as a
     // payload setfield.
     fn is_header_field(name: &str) -> bool {
@@ -3124,7 +3124,7 @@ pub fn fuse_boxing_alloc(
     };
 
     // Resolve the type-pointer the dropped `ob_header.ob_type` store carries:
-    // `%agg.ob_header = %h; %h.ob_type = __pyre_cast_instance(ConstRefAddr(t))`.
+    // `%agg.ob_header = %h; %h.ob_type = __cast_instance_intrinsic(ConstRefAddr(t))`.
     // The runtime stamps the new object's `ob_type`/`w_class` from this address
     // (read out of the `NewWithVtable` size descriptor), so it must travel with
     // the op rather than being dropped.  Returns `0` when the cluster carries no
@@ -3223,7 +3223,7 @@ pub fn fuse_boxing_alloc(
     /// Resolve `var` to the constant address `terminal` reads off its producer.
     ///
     /// The walk itself is shared by every header spelling: it steps through
-    /// `__pyre_cast_instance[<root>]` pointer reinterprets, and through the
+    /// `__cast_instance_intrinsic[<root>]` pointer reinterprets, and through the
     /// links when `var` is a `Block.inputargs` phi rather than an op result.
     /// A boxing cluster whose header stores sit before a call is exactly that
     /// shape — each call ends a block, so the header value crosses the
@@ -3283,7 +3283,7 @@ pub fn fuse_boxing_alloc(
             args,
             ..
         } = &producer.kind
-            && segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+            && segments.first().map(String::as_str) == Some("__cast_instance_intrinsic")
             && args.len() == 1
         {
             return resolve_addr(graph, &args[0], depth - 1, terminal);
@@ -3296,13 +3296,13 @@ pub fn fuse_boxing_alloc(
             _ => None,
         })
     }
-    /// The `&T` a `pyre_object::pyobject::get_instantiate(&T)` call was handed.
+    /// The `&T` a runtime `pyobject::get_instantiate(&T)` call was handed.
     ///
     /// The owner path is matched in full rather than by the bare leaf, so a
     /// function elsewhere that happens to share the name can never be read as
     /// the `instantiate`-slot load.
     fn get_instantiate_arg_addr(graph: &FunctionGraph, var: &Variable, depth: u32) -> Option<i64> {
-        const GET_INSTANTIATE: [&str; 3] = ["pyre_object", "pyobject", "get_instantiate"];
+        const GET_INSTANTIATE: [&str; 2] = ["pyobject", "get_instantiate"];
         resolve_addr(graph, var, depth, &|graph, kind, depth| match kind {
             OpKind::Call {
                 target: CallTarget::FunctionPath { segments },
@@ -3743,7 +3743,7 @@ fn sink_fused_boxing_aggregates_at_raw_writes(
 /// (`prune_dead_boxing_remnants` / `prune_dead_phis`) then strip the inputargs
 /// that carried the boxing cluster's cross-block values — the scalar payload
 /// (a parameter defined before the `get_instantiate` call that ends the entry
-/// block) and the `__pyre_cast_instance` chain that turns the `NewWithVtable`
+/// block) and the `__cast_instance_intrinsic` chain that turns the `NewWithVtable`
 /// result into the returned `PyObjectRef`.  This pass runs *after* those
 /// sweeps and re-threads every such operand through the predecessor chain,
 /// restoring the per-block operand invariant the adapter
@@ -3860,7 +3860,7 @@ pub fn thread_undefined_op_operands(graph: &mut FunctionGraph) {
 /// carries the type pointer / `w_class` through its vtable descriptor) the
 /// original aggregate ctor, the inner `PyObject` header ctor, their
 /// `ob_header` / `ob_type` / `w_class` field stores, and the
-/// `__pyre_cast_instance` casts feeding `ob_type` / `w_class` are all dead.
+/// `__cast_instance_intrinsic` casts feeding `ob_type` / `w_class` are all dead.
 /// The exception is a `w_class` the vtable cannot stand for: `fuse_boxing_alloc`
 /// re-emits that store on the new object, so its value stays live and the
 /// liveness gate below keeps the producer.
@@ -3886,9 +3886,9 @@ pub fn thread_undefined_op_operands(graph: &mut FunctionGraph) {
 /// ctor bases — a store *through* an aliasing or loaded base (a cast or a
 /// load) is a real heap side effect and roots its base like any other op.
 /// The header producers eligible for removal are all side-effect-free:
-/// a `SyntheticTransparentCtor` stack construct, a `__pyre_cast_instance`
+/// a `SyntheticTransparentCtor` stack construct, a `__cast_instance_intrinsic`
 /// pointer reinterpret (`exception_cannot_occur` → `cast_pointer`), and the
-/// `pyre_object::pyobject::get_instantiate` read of a type's `instantiate`
+/// `runtime_object::pyobject::get_instantiate` read of a type's `instantiate`
 /// slot feeding the dropped `w_class`.  `get_instantiate` is an `Acquire`
 /// atomic load of an init-once slot (the `set_instantiate` `Release` mutator
 /// writes it during `init_typeobjects`); it is removable not because the slot
@@ -3920,18 +3920,18 @@ pub(crate) fn prune_dead_boxing_remnants(graph: &mut FunctionGraph) -> usize {
             args,
             ..
         } => {
-            // `__pyre_cast_instance[<root>]` — the front-end pointer-downcast
+            // `__cast_instance_intrinsic[<root>]` — the front-end pointer-downcast
             // narrow (`front::mir`), always a single-operand reinterpret.
             // Pin the arity so an unrelated multi-arg path that happens to
             // share the synthetic marker leaf is never swept as a cast.
-            let is_cast = segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+            let is_cast = segments.first().map(String::as_str) == Some("__cast_instance_intrinsic")
                 && args.len() == 1;
-            // `pyre_object::pyobject::get_instantiate` — the pure
+            // `pyobject::get_instantiate` — the pure
             // `instantiate`-slot read feeding the dropped `w_class`.  Match
             // the full owner path rather than the bare leaf so a future
             // side-effecting function sharing the `get_instantiate` name in
             // some other module can never be classified removable.
-            let get_instantiate = ["pyre_object", "pyobject", "get_instantiate"];
+            let get_instantiate = ["pyobject", "get_instantiate"];
             let is_get_instantiate = segments.len() >= get_instantiate.len()
                 && segments[segments.len() - get_instantiate.len()..]
                     .iter()
@@ -3969,7 +3969,7 @@ pub(crate) fn prune_dead_boxing_remnants(graph: &mut FunctionGraph) -> usize {
     // `SyntheticTransparentCtor` stack construct and a no-arg
     // `boxed::Box::new_uninit()` heap box (the `vec![…]` lowering's fresh
     // allocation, which nothing aliases legitimately).  A store *through* an
-    // aliasing or loaded base (`__pyre_cast_instance` / `get_instantiate` / a
+    // aliasing or loaded base (`__cast_instance_intrinsic` / `get_instantiate` / a
     // parameter / …) is a real heap side effect, so the exemption is scoped to
     // these fresh-allocation results — every other store roots its base.
     let fresh_alloc_results: HashSet<Variable> = graph
@@ -7372,7 +7372,7 @@ mod tests {
                 OpKind::Call {
                     target: CallTarget::FunctionPath {
                         segments: vec![
-                            "pyre_object".into(),
+                            "runtime_object".into(),
                             "pyobject".into(),
                             "get_instantiate".into(),
                         ],
@@ -7406,7 +7406,7 @@ mod tests {
         //        %agg     = SyntheticTransparentCtor("W_FloatObject");
         //        FieldWrite(%agg.ob_header = %header);   // header store
         //        FieldWrite(%agg.floatval = %v);         // payload store
-        //        %ret     = pyre_object.lltype.malloc_typed(%agg);
+        //        %ret     = runtime_object.lltype.malloc_typed(%agg);
         //        return %ret.
         // fuse_boxing_alloc replaces the malloc with
         //        %ret     = NewWithVtable("W_FloatObject");
@@ -7473,7 +7473,7 @@ mod tests {
                 OpKind::Call {
                     target: CallTarget::FunctionPath {
                         segments: vec![
-                            "pyre_object".into(),
+                            "runtime_object".into(),
                             "lltype".into(),
                             "malloc_typed".into(),
                         ],
@@ -7623,7 +7623,7 @@ mod tests {
                 OpKind::Call {
                     target: CallTarget::FunctionPath {
                         segments: vec![
-                            "pyre_object".into(),
+                            "runtime_object".into(),
                             "lltype".into(),
                             "malloc_typed".into(),
                         ],
@@ -7690,7 +7690,7 @@ mod tests {
                 OpKind::Call {
                     target: CallTarget::FunctionPath {
                         segments: vec![
-                            "pyre_object".into(),
+                            "runtime_object".into(),
                             "lltype".into(),
                             "malloc_typed".into(),
                         ],
@@ -7754,7 +7754,7 @@ mod tests {
             call(
                 graph,
                 blk,
-                &["pyre_object", "pyobject", "get_instantiate"],
+                &["runtime_object", "pyobject", "get_instantiate"],
                 vec![arg],
             )
         }
@@ -7827,7 +7827,7 @@ mod tests {
             let ret = call(
                 &mut graph,
                 entry,
-                &["pyre_object", "lltype", "malloc_typed"],
+                &["runtime_object", "lltype", "malloc_typed"],
                 vec![agg],
             );
             graph.set_return(entry, Some(ret));
@@ -7844,7 +7844,7 @@ mod tests {
             call(
                 graph,
                 blk,
-                &["pyre_object", "gc_roots", "shadow_stack_get"],
+                &["runtime_object", "gc_roots", "shadow_stack_get"],
                 vec![base],
             )
         };
@@ -7988,14 +7988,19 @@ mod tests {
             let ty = graph
                 .push_op_var(entry, OpKind::ConstRefAddr(FLOAT_TYPE_ADDR), true)
                 .unwrap();
-            call(graph, entry, &["__pyre_cast_instance", "PyType"], vec![ty])
+            call(
+                graph,
+                entry,
+                &["__cast_instance_intrinsic", "PyType"],
+                vec![ty],
+            )
         };
         let ob_type = cast(&mut graph);
         let w_class_cast = cast(&mut graph);
         let w_class = call(
             &mut graph,
             entry,
-            &["pyre_object", "pyobject", "get_instantiate"],
+            &["runtime_object", "pyobject", "get_instantiate"],
             vec![w_class_cast],
         );
         let header = ctor(&mut graph, entry, "PyObject");
@@ -8032,7 +8037,7 @@ mod tests {
         let raw = call(
             &mut graph,
             probe,
-            &["pyre_object", "gc_hook", "try_gc_alloc_stable_raw"],
+            &["runtime_object", "gc_hook", "try_gc_alloc_stable_raw"],
             vec![],
         );
         let (gc_arm, gc_args) = graph.create_block_with_arg_vars(2);
@@ -8077,7 +8082,7 @@ mod tests {
         let ret = call(
             &mut graph,
             plain_arm,
-            &["pyre_object", "lltype", "malloc_typed"],
+            &["runtime_object", "lltype", "malloc_typed"],
             vec![plain_args[0].clone()],
         );
         graph.set_return(plain_arm, Some(ret));
@@ -8247,14 +8252,19 @@ mod tests {
                 let ty = graph
                     .push_op_var(entry, OpKind::ConstRefAddr(addr), true)
                     .unwrap();
-                call(graph, entry, &["__pyre_cast_instance", "PyType"], vec![ty])
+                call(
+                    graph,
+                    entry,
+                    &["__cast_instance_intrinsic", "PyType"],
+                    vec![ty],
+                )
             };
             let ob_type = cast(&mut graph, FLOAT_TYPE_ADDR);
             let w_class_cast = cast(&mut graph, FLOAT_TYPE_ADDR);
             let w_class = call(
                 &mut graph,
                 entry,
-                &["pyre_object", "pyobject", "get_instantiate"],
+                &["runtime_object", "pyobject", "get_instantiate"],
                 vec![w_class_cast],
             );
             let header = ctor(&mut graph, entry, "PyObject");
@@ -8287,7 +8297,7 @@ mod tests {
             let cond = call(
                 &mut graph,
                 entry,
-                &["pyre_object", "gc_interp", "enabled"],
+                &["runtime_object", "gc_interp", "enabled"],
                 vec![],
             );
             let (arm, arm_args) = graph.create_block_with_arg_vars(1);
@@ -8318,7 +8328,7 @@ mod tests {
             let ret = call(
                 &mut graph,
                 join,
-                &["pyre_object", "lltype", "malloc_typed"],
+                &["runtime_object", "lltype", "malloc_typed"],
                 vec![join_args[0].clone()],
             );
             graph.set_return(join, Some(ret));
@@ -8361,7 +8371,12 @@ mod tests {
             let other = graph
                 .push_op_var(blk, OpKind::ConstRefAddr(OTHER_TYPE_ADDR), true)
                 .unwrap();
-            let cast = call(graph, blk, &["__pyre_cast_instance", "PyType"], vec![other]);
+            let cast = call(
+                graph,
+                blk,
+                &["__cast_instance_intrinsic", "PyType"],
+                vec![other],
+            );
             graph.push_op_var(blk, field(header, "ob_type", "PyObject", &cast), false);
         };
 
@@ -8455,14 +8470,19 @@ mod tests {
                 let ty = graph
                     .push_op_var(blk, OpKind::ConstRefAddr(addr), true)
                     .unwrap();
-                call(graph, blk, &["__pyre_cast_instance", "PyType"], vec![ty])
+                call(
+                    graph,
+                    blk,
+                    &["__cast_instance_intrinsic", "PyType"],
+                    vec![ty],
+                )
             };
             let ob_type = cast(graph);
             let w_class_cast = cast(graph);
             let w_class = call(
                 graph,
                 blk,
-                &["pyre_object", "pyobject", "get_instantiate"],
+                &["runtime_object", "pyobject", "get_instantiate"],
                 vec![w_class_cast],
             );
             let header = ctor(graph, blk, "PyObject");
@@ -8490,7 +8510,7 @@ mod tests {
             let ret = call(
                 graph,
                 blk,
-                &["pyre_object", "lltype", "malloc_typed"],
+                &["runtime_object", "lltype", "malloc_typed"],
                 vec![agg],
             );
             graph.set_return(blk, Some(ret));
@@ -8591,12 +8611,12 @@ mod tests {
     #[test]
     fn fuse_boxing_alloc_sweeps_nested_header_chain() {
         // Faithful `w_float_new` shape: the boxing struct's header is a nested
-        // `PyObject` ctor whose `ob_type` is a `__pyre_cast_instance` pointer
+        // `PyObject` ctor whose `ob_type` is a `__cast_instance_intrinsic` pointer
         // reinterpret of the `&FLOAT_TYPE` constant and whose `w_class` is a
         // `get_instantiate` read of that same constant.  After fusion drops
         // the `ob_header` (it rides the `NewWithVtable` descriptor), the
         // entire header sub-tree — the inner `PyObject` ctor, the outer
-        // `W_FloatObject` ctor, the two `__pyre_cast_instance` casts and the
+        // `W_FloatObject` ctor, the two `__cast_instance_intrinsic` casts and the
         // `get_instantiate` — is dead and must be swept, leaving only the
         // `NewWithVtable`, its `floatval` payload store, and the return cast.
         // (The two `ConstRefAddr` constants legitimately survive as dead
@@ -8605,7 +8625,7 @@ mod tests {
         type Var = crate::flowspace::model::Variable;
         let cast_instance = |to: &str, arg: &Var| OpKind::Call {
             target: CallTarget::FunctionPath {
-                segments: vec!["__pyre_cast_instance".into(), to.into()],
+                segments: vec!["__cast_instance_intrinsic".into(), to.into()],
             },
             args: vec![arg.clone()],
             result_ty: ValueType::Ref(Some(to.into())),
@@ -8648,7 +8668,7 @@ mod tests {
                 OpKind::Call {
                     target: CallTarget::FunctionPath {
                         segments: vec![
-                            "pyre_object".into(),
+                            "runtime_object".into(),
                             "pyobject".into(),
                             "get_instantiate".into(),
                         ],
@@ -8709,7 +8729,7 @@ mod tests {
                 OpKind::Call {
                     target: CallTarget::FunctionPath {
                         segments: vec![
-                            "pyre_object".into(),
+                            "runtime_object".into(),
                             "lltype".into(),
                             "malloc_typed".into(),
                         ],
@@ -8734,7 +8754,7 @@ mod tests {
 
         let ops = &graph.block(entry).operations;
         // The dead header sub-tree is gone: no SyntheticTransparentCtor and no
-        // `__pyre_cast_instance["PyType"]` cast survives.
+        // `__cast_instance_intrinsic["PyType"]` cast survives.
         assert!(
             !ops.iter().any(|op| matches!(
                 &op.kind,
@@ -8750,7 +8770,7 @@ mod tests {
             !ops.iter().any(|op| matches!(
                 &op.kind,
                 OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
-                    if segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                    if segments.first().map(String::as_str) == Some("__cast_instance_intrinsic")
                         && segments.get(1).map(String::as_str) == Some("PyType")
             )),
             "the dead ob_type/w_class header casts must be swept"
@@ -8779,7 +8799,7 @@ mod tests {
             ops.iter().any(|op| matches!(
                 &op.kind,
                 OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
-                    if segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                    if segments.first().map(String::as_str) == Some("__cast_instance_intrinsic")
                         && segments.get(1).map(String::as_str) == Some("PyObject")
             )),
             "the live return cast must survive"
@@ -8860,7 +8880,7 @@ mod tests {
                 OpKind::Call {
                     target: CallTarget::FunctionPath {
                         segments: vec![
-                            "pyre_object".into(),
+                            "runtime_object".into(),
                             "lltype".into(),
                             "malloc_typed".into(),
                         ],
@@ -9018,7 +9038,7 @@ mod tests {
                     Some(call(
                         &mut graph,
                         entry,
-                        &["pyre_object", "pyobject", "get_instantiate"],
+                        &["runtime_object", "pyobject", "get_instantiate"],
                         vec![arg],
                     ))
                 }
@@ -9027,7 +9047,7 @@ mod tests {
                     Some(call(
                         &mut graph,
                         entry,
-                        &["pyre_object", "gc_roots", "shadow_stack_get"],
+                        &["runtime_object", "gc_roots", "shadow_stack_get"],
                         vec![base],
                     ))
                 }
@@ -9059,7 +9079,7 @@ mod tests {
             let ret = call(
                 &mut graph,
                 entry,
-                &["pyre_object", "lltype", "malloc_typed"],
+                &["runtime_object", "lltype", "malloc_typed"],
                 vec![agg],
             );
             graph.set_return(entry, Some(ret));
@@ -9169,7 +9189,7 @@ mod tests {
     fn prune_dead_boxing_remnants_keeps_cast_used_as_live_store_base() {
         // The malloc-removal exemption (a store's base is not rooted) must be
         // scoped to fresh `SyntheticTransparentCtor` aggregates.  A store
-        // *through* a `__pyre_cast_instance` alias is a real heap side effect:
+        // *through* a `__cast_instance_intrinsic` alias is a real heap side effect:
         // even when the cast's result is read nowhere but the store base, the
         // cast and the store must survive.  The same graph carries a genuinely
         // dead `SyntheticTransparentCtor` whose store IS swept, so the pass is
@@ -9201,7 +9221,7 @@ mod tests {
                 entry,
                 OpKind::Call {
                     target: CallTarget::FunctionPath {
-                        segments: vec!["__pyre_cast_instance".into(), "W_FloatObject".into()],
+                        segments: vec!["__cast_instance_intrinsic".into(), "W_FloatObject".into()],
                     },
                     args: vec![obj.clone()],
                     result_ty: ValueType::Ref(Some("W_FloatObject".into())),
@@ -9260,7 +9280,7 @@ mod tests {
         type Var = crate::flowspace::model::Variable;
         let cast_pytype = |arg: &Var| OpKind::Call {
             target: CallTarget::FunctionPath {
-                segments: vec!["__pyre_cast_instance".into(), "PyType".into()],
+                segments: vec!["__cast_instance_intrinsic".into(), "PyType".into()],
             },
             args: vec![arg.clone()],
             result_ty: ValueType::Ref(Some("PyType".into())),
@@ -9294,7 +9314,7 @@ mod tests {
         let get_instantiate = |arg: &Var| OpKind::Call {
             target: CallTarget::FunctionPath {
                 segments: vec![
-                    "pyre_object".into(),
+                    "runtime_object".into(),
                     "pyobject".into(),
                     "get_instantiate".into(),
                 ],
@@ -9371,7 +9391,7 @@ mod tests {
                 blk,
                 OpKind::Call {
                     target: CallTarget::FunctionPath {
-                        segments: vec!["__pyre_cast_instance".into(), "PyObject".into()],
+                        segments: vec!["__cast_instance_intrinsic".into(), "PyObject".into()],
                     },
                     args: vec![boxed.clone()],
                     result_ty: ValueType::Ref(Some("PyObject".into())),
@@ -9404,7 +9424,7 @@ mod tests {
             !kinds.iter().any(|k| matches!(
                 k,
                 OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
-                    if segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                    if segments.first().map(String::as_str) == Some("__cast_instance_intrinsic")
                         && segments.get(1).map(String::as_str) == Some("PyType")
             )),
             "the dead PyType cast threaded across the block boundary must be swept"

--- a/majit/majit-translate/src/translator/rtyper/call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/call_registry.rs
@@ -110,7 +110,7 @@ impl FunctionPathKey {
 ///   `Signature`.  Pre-registered in `bookkeeper.descs` keyed by
 ///   `host_object`'s Arc identity so `Bookkeeper::getdesc(host_object)`
 ///   short-circuits at the cache.
-pub struct PyreFunctionEntry {
+pub struct FunctionEntry {
     pub host_object: HostObject,
     pub function_desc: Rc<RefCell<FunctionDesc>>,
     /// Declared LLBC fn-ptr signature, projected once at registry
@@ -129,7 +129,7 @@ pub struct PyreFunctionEntry {
         RefCell<Option<crate::translator::rtyper::lltypesystem::lltype::FuncType>>,
 }
 
-impl PyreFunctionEntry {
+impl FunctionEntry {
     /// Pre-fill the entry's `FunctionDesc.cache` for the default
     /// specializer with no `*args` (the lookup key
     /// `Specializer::Default + flatten_star_args(no vararg) ->
@@ -160,7 +160,7 @@ impl PyreFunctionEntry {
     /// from `cutover::populate_call_registry_from_call_graphs`'s Pass
     /// 2 when `lift_callee_to_pygraph` returns Err.
     pub fn record_lift_error(&self, message: String) {
-        self.function_desc.borrow().record_pyre_lift_error(message);
+        self.function_desc.borrow().record_lift_error(message);
     }
 
     /// Read-side twin of [`record_lift_error`]: the recorded pyre-side
@@ -169,12 +169,12 @@ impl PyreFunctionEntry {
     /// whose graph could not be built (unbuildable callee → caller Skips
     /// to the legacy walker), instead of binding a `host_object` that
     /// would partial-codewrite with a pre-real residual kind.
-    pub fn pyre_lift_error(&self) -> Option<String> {
-        self.function_desc.borrow().pyre_lift_error_message()
+    pub fn lift_error(&self) -> Option<String> {
+        self.function_desc.borrow().lift_error_message()
     }
 
     /// Store the callee's declared LLBC fn-ptr signature (see
-    /// [`PyreFunctionEntry::declared_funcptr_type`]).
+    /// [`FunctionEntry::declared_funcptr_type`]).
     pub fn set_declared_funcptr_type(
         &self,
         ft: crate::translator::rtyper::lltypesystem::lltype::FuncType,
@@ -236,7 +236,7 @@ pub struct TwoPhaseTypeCache {
 /// its `Bookkeeper` with the `RPythonAnnotator` so pre-registered
 /// entries are visible to the rtyper's `getdesc` lookup.
 ///
-/// `entries` is the canonical `FunctionPathKey → Rc<PyreFunctionEntry>`
+/// `entries` is the canonical `FunctionPathKey → Rc<FunctionEntry>`
 /// table — one row per distinct callable identity.  Mirrors RPython
 /// `Bookkeeper.descs[Constant(pyobj)] = Desc` (`bookkeeper.py`),
 /// where the dict is keyed by Python function-object identity and
@@ -252,9 +252,9 @@ pub struct TwoPhaseTypeCache {
 /// because Python callable identity gives `Bookkeeper.getdesc` direct
 /// dedup; pyre's segment-key storage stands in for that until host
 /// callable identity is available.
-pub struct PyreCallRegistry {
+pub struct CallRegistry {
     bookkeeper: Rc<Bookkeeper>,
-    entries: RefCell<HashMap<FunctionPathKey, Rc<PyreFunctionEntry>>>,
+    entries: RefCell<HashMap<FunctionPathKey, Rc<FunctionEntry>>>,
     aliases: RefCell<HashMap<FunctionPathKey, FunctionPathKey>>,
     /// Whole-program two-phase type cache. Empty and
     /// `prepass_done = false` unless the two-phase prepass populated it.
@@ -278,10 +278,10 @@ pub struct PyreCallRegistry {
     >,
 }
 
-impl PyreCallRegistry {
+impl CallRegistry {
     /// Construct an empty registry sharing `bookkeeper`.
     pub fn new(bookkeeper: Rc<Bookkeeper>) -> Self {
-        PyreCallRegistry {
+        CallRegistry {
             bookkeeper,
             entries: RefCell::new(HashMap::new()),
             aliases: RefCell::new(HashMap::new()),
@@ -303,11 +303,11 @@ impl PyreCallRegistry {
 
     /// Thread the program-wide `StructFieldRegistry` into the shared
     /// bookkeeper so `getuniqueclassdef_for_struct_root` /
-    /// `project_pyre_field_type` can project struct fields onto a classdef.  Called once from
-    /// `dual_gate_registry` after `PyreCallRegistry::new` with
+    /// `project_struct_field_type` can project struct fields onto a classdef.  Called once from
+    /// `dual_gate_registry` after `CallRegistry::new` with
     /// `CallControl::struct_fields().clone()`.
-    pub fn set_pyre_struct_fields(&self, registry: Rc<crate::front::StructFieldRegistry>) {
-        self.bookkeeper.set_pyre_struct_fields(registry);
+    pub fn set_struct_fields(&self, registry: Rc<crate::front::StructFieldRegistry>) {
+        self.bookkeeper.set_struct_fields(registry);
     }
 
     /// Thread the trait → unique-concrete-impl-owner map into the
@@ -315,8 +315,8 @@ impl PyreCallRegistry {
     /// generic receiver's bound-trait `class_root` to the impl type's
     /// `ClassDef`.  Called once from `dual_gate_registry` with
     /// `CallControl::trait_unique_impls().clone()`.
-    pub fn set_pyre_trait_unique_impls(&self, map: HashMap<String, String>) {
-        self.bookkeeper.set_pyre_trait_unique_impls(map);
+    pub fn set_trait_unique_impls(&self, map: HashMap<String, String>) {
+        self.bookkeeper.set_trait_unique_impls(map);
     }
 
     /// Mint each opt-in receiver-driven dispatch family's base
@@ -359,11 +359,8 @@ impl PyreCallRegistry {
     /// discriminant→variant narrowing `knowntypedata`.  Called once from
     /// `dual_gate_registry` with
     /// `CallControl::enum_variant_by_discriminant().clone()`.
-    pub fn set_pyre_enum_variant_by_discriminant(
-        &self,
-        map: Rc<HashMap<String, HashMap<i64, String>>>,
-    ) {
-        self.bookkeeper.set_pyre_enum_variant_by_discriminant(map);
+    pub fn set_enum_variant_by_discriminant(&self, map: Rc<HashMap<String, HashMap<i64, String>>>) {
+        self.bookkeeper.set_enum_variant_by_discriminant(map);
     }
 
     /// Seed each struct-root class `HostObject`'s dict with its
@@ -389,7 +386,7 @@ impl PyreCallRegistry {
     /// Called once from `dual_gate_registry` after
     /// `populate_call_registry_from_call_graphs`.
     pub fn seed_struct_root_method_members(&self) {
-        let guard = self.bookkeeper.pyre_struct_fields.borrow();
+        let guard = self.bookkeeper.struct_fields.borrow();
         let Some(reg) = guard.as_ref() else {
             return;
         };
@@ -506,7 +503,7 @@ impl PyreCallRegistry {
                 let key = majit_ir::descr::canonical_struct_name(impl_root);
                 let host = self
                     .bookkeeper
-                    .pyre_struct_root_classes
+                    .struct_root_classes
                     .borrow()
                     .get(&key)
                     .cloned();
@@ -615,7 +612,7 @@ impl PyreCallRegistry {
         // already-baked class is NOT append-safe (its bracket would need to
         // nest inside the parent's baked range); it stays unnumbered and
         // the per-graph path Skip-classifies it, exactly as before.
-        for root in self.bookkeeper.pyre_struct_root_names() {
+        for root in self.bookkeeper.struct_root_names() {
             // A malformed root must not abort the whole session — the
             // per-graph path Skip-classifies it later, mirroring the
             // populate path's `is_known_unported` tolerance.
@@ -649,7 +646,7 @@ impl PyreCallRegistry {
     /// resolves through `aliases` to the canonical key and re-reads.
     /// Mirrors RPython `Bookkeeper.getdesc(pyobj)`'s "obj_key direct
     /// lookup" plus alias indirection (`bookkeeper.py:362-364`).
-    pub fn lookup(&self, key: &FunctionPathKey) -> Option<Rc<PyreFunctionEntry>> {
+    pub fn lookup(&self, key: &FunctionPathKey) -> Option<Rc<FunctionEntry>> {
         if let Some(entry) = self.entries.borrow().get(key) {
             return Some(entry.clone());
         }
@@ -675,7 +672,7 @@ impl PyreCallRegistry {
     pub fn find_entry_with_cached_graph(
         &self,
         graph: &crate::flowspace::model::GraphRef,
-    ) -> Option<(FunctionPathKey, Rc<PyreFunctionEntry>)> {
+    ) -> Option<(FunctionPathKey, Rc<FunctionEntry>)> {
         let entries = self.entries.borrow();
         let mut sorted_entries: Vec<_> = entries.iter().collect();
         // Pin HashMap order so the first matching cached graph is stable.
@@ -737,7 +734,7 @@ impl PyreCallRegistry {
     ///   distinct from a same-leaf free function.
     /// - Multi-match aliases of the same source (identical
     ///   `host_object` Arc identity) converge on a single resolution.
-    pub fn lookup_with_leaf_match(&self, key: &FunctionPathKey) -> Option<Rc<PyreFunctionEntry>> {
+    pub fn lookup_with_leaf_match(&self, key: &FunctionPathKey) -> Option<Rc<FunctionEntry>> {
         if let Some(entry) = self.lookup(key) {
             return Some(entry);
         }
@@ -767,7 +764,7 @@ impl PyreCallRegistry {
             .skip(1)
             .all(|s| !starts_with_uppercase(s));
         let entries_borrow = self.entries.borrow();
-        let mut matches: Vec<(&FunctionPathKey, &Rc<PyreFunctionEntry>)> = entries_borrow
+        let mut matches: Vec<(&FunctionPathKey, &Rc<FunctionEntry>)> = entries_borrow
             .iter()
             .filter(|(k, e)| {
                 if !e.host_object.is_user_function() {
@@ -847,7 +844,7 @@ impl PyreCallRegistry {
     ///    cache lookup at upstream `bookkeeper.py:362-364`
     ///    (`try: return self.descs[obj_key]; except KeyError`).
     ///
-    /// Subsequent callers receive the same `Rc<PyreFunctionEntry>`
+    /// Subsequent callers receive the same `Rc<FunctionEntry>`
     /// (identity-cached, matching upstream `Bookkeeper.getdesc`'s
     /// "create once, share thereafter" contract at
     /// `bookkeeper.py:362-364`).
@@ -860,16 +857,12 @@ impl PyreCallRegistry {
     /// adapter must surface the conflict at the producer site rather
     /// than silently route the second caller through the first
     /// caller's signature.
-    pub fn get_or_register(
-        &self,
-        key: FunctionPathKey,
-        signature: Signature,
-    ) -> Rc<PyreFunctionEntry> {
+    pub fn get_or_register(&self, key: FunctionPathKey, signature: Signature) -> Rc<FunctionEntry> {
         if let Some(existing) = self.entries.borrow().get(&key) {
             assert_eq!(
                 existing.function_desc.borrow().signature,
                 signature,
-                "PyreCallRegistry.get_or_register: conflicting signatures for \
+                "CallRegistry.get_or_register: conflicting signatures for \
                  FunctionPath {:?} — upstream description.py:205 \
                  FunctionDesc.__init__ binds the signature to the underlying \
                  Python function object once at creation time, so a single \
@@ -906,7 +899,7 @@ impl PyreCallRegistry {
             host_object.clone(),
             DescEntry::function(function_desc.clone()),
         );
-        let entry = Rc::new(PyreFunctionEntry {
+        let entry = Rc::new(FunctionEntry {
             host_object,
             function_desc,
             declared_funcptr_type: RefCell::new(None),
@@ -942,7 +935,7 @@ impl PyreCallRegistry {
         key: FunctionPathKey,
         signature: Signature,
         pygraph: Rc<PyGraph>,
-    ) -> Rc<PyreFunctionEntry> {
+    ) -> Rc<FunctionEntry> {
         let entry = self.get_or_register(key, signature);
         entry.prefill_default_cache(pygraph);
         entry
@@ -970,19 +963,19 @@ impl PyreCallRegistry {
     pub fn alias(&self, alias_key: FunctionPathKey, canonical_key: &FunctionPathKey) {
         assert!(
             self.entries.borrow().contains_key(canonical_key),
-            "PyreCallRegistry.alias: canonical key {:?} is not registered",
+            "CallRegistry.alias: canonical key {:?} is not registered",
             canonical_key.segments(),
         );
         assert!(
             !self.entries.borrow().contains_key(&alias_key),
-            "PyreCallRegistry.alias: alias key {:?} is already a canonical entry",
+            "CallRegistry.alias: alias key {:?} is already a canonical entry",
             alias_key.segments(),
         );
         if let Some(existing) = self.aliases.borrow().get(&alias_key) {
             assert_eq!(
                 existing,
                 canonical_key,
-                "PyreCallRegistry.alias: alias key {:?} already maps to a different canonical key",
+                "CallRegistry.alias: alias key {:?} already maps to a different canonical key",
                 alias_key.segments(),
             );
             return;
@@ -1026,14 +1019,14 @@ impl PyreCallRegistry {
     // `model.py`); a parallel `FunctionPathKey -> Variable` side
     // map was a pyre-only divergence with no upstream peer.  Real
     // readers must consult `Variable.concretetype` directly through
-    // the `PyGraph.graph` already cached on the `PyreFunctionEntry.
+    // the `PyGraph.graph` already cached on the `FunctionEntry.
     // function_desc.cache`.
 }
 
 /// Rust naming convention shape check: PascalCase / leading-uppercase
 /// idents are type / struct / enum names (impl method receivers); all-
 /// snake_case idents are modules / functions / primitives.  Used by
-/// [`PyreCallRegistry::lookup_with_leaf_match`] to distinguish
+/// [`CallRegistry::lookup_with_leaf_match`] to distinguish
 /// `Type::method` candidates from `module::fn` candidates when the
 /// query path's shape disagrees.
 fn starts_with_uppercase(s: &str) -> bool {
@@ -1055,7 +1048,7 @@ mod tests {
     #[test]
     fn lookup_returns_none_for_unregistered_path() {
         let bk = Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk);
+        let registry = CallRegistry::new(bk);
         assert!(
             registry
                 .lookup(&FunctionPathKey::from_segments(["foo"]))
@@ -1068,7 +1061,7 @@ mod tests {
     #[test]
     fn get_or_register_constructs_entry_with_function_desc_and_host_object() {
         let bk = Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk);
+        let registry = CallRegistry::new(bk);
         let key = FunctionPathKey::from_segments(["foo"]);
         let entry = registry.get_or_register(key.clone(), signature(&["x"]));
         assert_eq!(
@@ -1092,7 +1085,7 @@ mod tests {
     #[test]
     fn get_or_register_preregisters_function_desc_in_bookkeeper_descs() {
         let bk = Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk.clone());
+        let registry = CallRegistry::new(bk.clone());
         let entry =
             registry.get_or_register(FunctionPathKey::from_segments(["foo"]), signature(&["x"]));
         // Direct cache lookup — Bookkeeper.descs[host_object] must
@@ -1116,7 +1109,7 @@ mod tests {
     #[test]
     fn bookkeeper_getdesc_short_circuits_on_pre_registered_host_object() {
         let bk = Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk.clone());
+        let registry = CallRegistry::new(bk.clone());
         let entry =
             registry.get_or_register(FunctionPathKey::from_segments(["foo"]), signature(&["x"]));
         // The headline parity claim: bookkeeper.getdesc(host_object)
@@ -1144,7 +1137,7 @@ mod tests {
     #[should_panic(expected = "conflicting signatures")]
     fn get_or_register_panics_on_signature_conflict() {
         let bk = Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk);
+        let registry = CallRegistry::new(bk);
         let key = FunctionPathKey::from_segments(["foo"]);
         registry.get_or_register(key.clone(), signature(&["x"]));
         // Second registration with a different signature must surface
@@ -1158,7 +1151,7 @@ mod tests {
     #[test]
     fn get_or_register_returns_cached_entry_on_repeat_lookup() {
         let bk = Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk);
+        let registry = CallRegistry::new(bk);
         let key = FunctionPathKey::from_segments(["foo"]);
         let first = registry.get_or_register(key.clone(), signature(&["x"]));
         let second = registry.get_or_register(key.clone(), signature(&["x"]));
@@ -1177,7 +1170,7 @@ mod tests {
     #[test]
     fn lookup_after_register_returns_same_entry() {
         let bk = Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk);
+        let registry = CallRegistry::new(bk);
         let key = FunctionPathKey::from_segments(["foo"]);
         let registered = registry.get_or_register(key.clone(), signature(&["x"]));
         let looked_up = registry
@@ -1192,7 +1185,7 @@ mod tests {
     #[test]
     fn distinct_paths_register_distinct_entries() {
         let bk = Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk.clone());
+        let registry = CallRegistry::new(bk.clone());
         let foo =
             registry.get_or_register(FunctionPathKey::from_segments(["foo"]), signature(&["x"]));
         let bar =
@@ -1216,7 +1209,7 @@ mod tests {
     #[test]
     fn multi_segment_path_distinct_from_single_segment() {
         let bk = Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk);
+        let registry = CallRegistry::new(bk);
         let bare =
             registry.get_or_register(FunctionPathKey::from_segments(["foo"]), signature(&["x"]));
         let qualified = registry.get_or_register(
@@ -1248,7 +1241,7 @@ mod tests {
         // free-fn Python callable identity, never colliding with the
         // bound-method object.
         let bk = Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk);
+        let registry = CallRegistry::new(bk);
         let free_fn = registry.get_or_register(
             FunctionPathKey::from_segments(["pyobject", "is_none"]),
             signature(&["obj"]),
@@ -1275,7 +1268,7 @@ mod tests {
         // upstream would surface the same "no such free fn" gap as a
         // bookkeeper lookup miss.
         let bk = Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk);
+        let registry = CallRegistry::new(bk);
         let _impl_method = registry.get_or_register(
             FunctionPathKey::from_segments(["resoperation", "OpRef", "is_none"]),
             signature(&["self"]),
@@ -1305,7 +1298,7 @@ mod tests {
     #[test]
     fn find_entry_with_cached_graph_resolves_by_graph_identity() {
         let bk = Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk);
+        let registry = CallRegistry::new(bk);
         let key = FunctionPathKey::from_segments(["m", "f"]);
         let pygraph = make_pygraph("f", signature(&["x"]));
         registry.register_callee(key.clone(), signature(&["x"]), pygraph.clone());
@@ -1339,7 +1332,7 @@ mod tests {
     #[test]
     fn keys_for_entry_includes_canonical_and_aliases() {
         let bk = Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk);
+        let registry = CallRegistry::new(bk);
         let canonical = FunctionPathKey::from_segments(["m", "f"]);
         registry.get_or_register(canonical.clone(), signature(&["x"]));
         let alias = FunctionPathKey::from_segments(["crate", "m", "f"]);

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -61,14 +61,12 @@ use crate::flowspace::model::{
 };
 use crate::flowspace::pygraph::PyGraph;
 use crate::model::FunctionGraph as LegacyGraph;
+use crate::translator::rtyper::call_registry::{CallRegistry, FunctionEntry, FunctionPathKey};
 use crate::translator::rtyper::error::TyperError;
 use crate::translator::rtyper::flowspace_adapter::{
     FlowspaceAdapterOutput, LegacyToTyped, LegacyToTypedCandidates,
 };
 use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
-use crate::translator::rtyper::pyre_call_registry::{
-    FunctionPathKey, PyreCallRegistry, PyreFunctionEntry,
-};
 
 /// The `graph.return_type` marker the front-end stamps on a
 /// `dont_look_inside` callee that returns `*mut PyObject` (a
@@ -271,7 +269,7 @@ pub(crate) enum DualGateOutcome {
 /// Production dual-gate — registry-aware entry.
 ///
 /// Drives the real path via [`specialize_legacy_graph_with_registry_returning_value_to_var`]
-/// against a pre-populated `PyreCallRegistry` so graphs with
+/// against a pre-populated `CallRegistry` so graphs with
 /// `OpKind::Call::FunctionPath` callsites resolve through the upstream
 /// `Constant(<function>) -> getdesc -> FunctionDesc` chain
 /// (`bookkeeper.py:353-409`).  Production callers
@@ -301,7 +299,7 @@ pub(crate) enum DualGateOutcome {
 /// directly for hand-built fixtures.
 pub(crate) fn dual_gate_check_with_registry(
     legacy_graph: &LegacyGraph,
-    call_registry: &PyreCallRegistry,
+    call_registry: &CallRegistry,
     lift_sources: &crate::codewriter::call::GraphStore,
 ) -> Result<DualGateOutcome, String> {
     // Same panic-catch contract as `dual_gate_check` — the rtyper's
@@ -407,11 +405,11 @@ struct SubjectSessionSnapshot {
 }
 
 impl SubjectSessionSnapshot {
-    fn capture(call_registry: &PyreCallRegistry) -> Self {
+    fn capture(call_registry: &CallRegistry) -> Self {
         Self::capture_fixed_only(call_registry)
     }
 
-    fn capture_fixed_only(call_registry: &PyreCallRegistry) -> Self {
+    fn capture_fixed_only(call_registry: &CallRegistry) -> Self {
         let Some((annotator, _)) = call_registry.session_if_started() else {
             return Self::default();
         };
@@ -421,7 +419,7 @@ impl SubjectSessionSnapshot {
 }
 
 fn unpoison_failed_subject_callees(
-    call_registry: &PyreCallRegistry,
+    call_registry: &CallRegistry,
     session_at_entry: &SubjectSessionSnapshot,
     lift_sources: &crate::codewriter::call::GraphStore,
 ) {
@@ -1367,7 +1365,7 @@ fn compare_real_against_legacy(
 ///
 /// | Substring                                  | Unimplemented feature                                                        |
 /// |--------------------------------------------|------------------------------------------------------------------------------|
-/// | `not registered in PyreCallRegistry`       | Extern Rust helper registry walker.                                          |
+/// | `not registered in CallRegistry`       | Extern Rust helper registry walker.                                          |
 /// | `translate_op: undefined operand`          | Adapter producer correctness.                                                |
 /// | `unimplemented operation`                  | Per-opname rtyper handlers.                                                  |
 /// | `variable used before definition`          | Cross-block locals threading.                                                |
@@ -1419,7 +1417,7 @@ fn compare_real_against_legacy(
 /// from maintaining a second, drifting copy of the substring table. Lowering
 /// only tests whether the result is `Some`.
 pub(crate) fn unported_category(msg: &str) -> Option<&'static str> {
-    if msg.contains("not registered in PyreCallRegistry") {
+    if msg.contains("not registered in CallRegistry") {
         return Some("call-registry-miss");
     }
     if msg.contains("translate_op: undefined operand") {
@@ -1518,7 +1516,7 @@ pub(crate) fn unported_category(msg: &str) -> Option<&'static str> {
     // `<default methods of IterOpcodeHandler>::record_for_iter_guard`,
     // `pyjitpl_step::Cannot find attribute`); production cannot
     // compile until each underlying real-path gap is closed
-    // (classdef-less SomeInstance dispatch + `PyreCallRegistry::
+    // (classdef-less SomeInstance dispatch + `CallRegistry::
     // ensure_session` coverage — every analyser body routes through
     // per-touch `arg_at` rather than an eager-prefix concrete
     // walk).  Until each gap-hitter is
@@ -1771,7 +1769,7 @@ pub(crate) fn unported_category(msg: &str) -> Option<&'static str> {
 pub(crate) fn is_known_unported(msg: &str) -> bool {
     unported_category(msg).is_some()
 }
-/// Populate a `PyreCallRegistry` from a
+/// Populate a `CallRegistry` from a
 /// `HashMap<CallPath, FunctionGraph>` (the shape pyre's
 /// `CallControl::function_graphs()` returns).
 ///
@@ -1795,12 +1793,12 @@ pub(crate) fn populate_call_registry_from_call_graphs(
     function_graphs: &crate::codewriter::call::GraphStore,
     unsafe_fn_stubs: &[(Vec<String>, Signature, Option<String>)],
     foreign_opaque_method_externals: &[(Vec<String>, Signature, crate::model::ValueType)],
-    registry: &PyreCallRegistry,
+    registry: &CallRegistry,
 ) -> Result<(), TyperError> {
     // Dedupe by canonical path — RPython `Bookkeeper.getdesc(pyobj)`
     // (`bookkeeper.py:353-409`) returns the *same* FunctionDesc for
     // any reference to the same callable, keyed by `Constant(pyobj)`
-    // identity.  Pyre's `function_graphs: HashMap<CallPath, FunctionGraph>`
+    // identity. This port's `function_graphs: HashMap<CallPath, FunctionGraph>`
     // can carry the same callable under multiple keys (`lib.rs`
     // registers free functions under both their canonical path AND a
     // `crate::`-prefixed alias for callsite matching); without dedupe,
@@ -1808,20 +1806,18 @@ pub(crate) fn populate_call_registry_from_call_graphs(
     // pair, violating upstream's "create once, share thereafter"
     // contract.
     //
-    // The dedupe key strips a leading crate-prefix segment so the
-    // five alias-explosion shapes registered by `lib.rs` for
-    // each free function (`[mod, foo]`, `[crate, mod, foo]`,
-    // `[pyre_interpreter, mod, foo]`, `[pyre_object, mod, foo]`,
-    // `[pyre_jit, mod, foo]`) collapse to a single canonical entry
-    // `[mod, foo]`.  Stripping only `crate` (the previous heuristic)
-    // left the three external crate-name aliases as distinct canonical
-    // entries with distinct `Rc<PyreFunctionEntry>` HostObjects, and
+    // The dedupe key strips a leading crate-prefix segment so the alias
+    // spellings registered by `lib.rs` for each free function (`[mod, foo]`,
+    // `[crate, mod, foo]`, and `[loaded_crate, mod, foo]`) collapse to a
+    // single canonical entry `[mod, foo]`. Stripping only `crate` (the
+    // previous heuristic) left the external crate-name aliases as distinct canonical
+    // entries with distinct `Rc<FunctionEntry>` HostObjects, and
     // `lookup_with_leaf_match`'s multi-match convergence check
     // (`all_same` on `host_object` Arc identity) then failed —
     // callsites like `["crate", "w_str_new"]` (a `use crate::w_str_new`
     // bare callsite from another module) found four matches with four
-    // distinct hosts and rejected the cluster.  Stripping all four
-    // well-known prefixes preserves the rule that genuinely distinct
+    // distinct hosts and rejected the cluster. Stripping all registered
+    // prefixes preserves the rule that genuinely distinct
     // functions in different modules (`a::foo` vs `b::foo`) stay
     // separate (`a` / `b` aren't in the stripped set), and the
     // bare-name dedupe trap (using `FunctionGraph::name`) is still
@@ -1838,12 +1834,8 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         }
         segs
     }
-    let mut pending: Vec<(
-        FunctionPathKey,
-        &LegacyGraph,
-        Rc<PyreFunctionEntry>,
-        &Signature,
-    )> = Vec::with_capacity(function_graphs.len());
+    let mut pending: Vec<(FunctionPathKey, &LegacyGraph, Rc<FunctionEntry>, &Signature)> =
+        Vec::with_capacity(function_graphs.len());
     // `by_canonical_path` tracks the canonical `FunctionPathKey` of
     // the first-encountered alias for each canonical-stripped key.
     // Subsequent aliases of the same callable register an alias row
@@ -1899,7 +1891,7 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         // that surfaces on the first constructing caller (`w_range_new`,
         // the iterator/`GenericAlias` `*_new` heads).  Skip registering the
         // constructor as a user function so its key is instead served by the
-        // residual stub from `collect_pyre_class_ctor_stubs_from_llbc` (seeded
+        // residual stub from `collect_marked_class_ctor_stubs_from_llbc` (seeded
         // through the `unsafe_fn_stubs` carrier), whose `*mut PyObject` return
         // shell lets the caller annotate.  The numeric boxes never reach here —
         // they call `malloc_typed` inline (`w_float_new`/`w_int_new`), not the
@@ -2001,13 +1993,13 @@ pub(crate) fn populate_call_registry_from_call_graphs(
     // and unsafe-fn stubs above.
     register_foreign_opaque_method_externals(registry, foreign_opaque_method_externals);
     // Pass 2 — prefill the default-cache once per *unique* registry
-    // entry.  Aliases already point at the same `Rc<PyreFunctionEntry>`
+    // entry.  Aliases already point at the same `Rc<FunctionEntry>`
     // so their `prefill_default_cache` would be redundant; identify
     // unique entries by `Rc::as_ptr` so the dedupe survives any
     // alternate dedup-key shape.  Each unique entry is lifted exactly
     // once (`Rc::as_ptr` identity dedup); aliases share the same
     // pre-filled `FunctionDesc.cache` because they hold the same
-    // `Rc<PyreFunctionEntry>`.
+    // `Rc<FunctionEntry>`.
     //
     // Per-callee failure isolation matches RPython
     // `bookkeeper.py getdesc(pyobj)` semantics: each
@@ -2018,7 +2010,7 @@ pub(crate) fn populate_call_registry_from_call_graphs(
     // that lazy shape by isolating per-callee failures here — but
     // unlike a previous draft that *swallowed* the error outright,
     // the lift error is now stashed on the entry via
-    // `PyreFunctionEntry::record_lift_error` so the next
+    // `FunctionEntry::record_lift_error` so the next
     // `cachedgraph` consumer surfaces the actual producer-side
     // failure instead of falling through to `buildflowgraph`'s
     // generic "missing code object" message
@@ -2031,10 +2023,9 @@ pub(crate) fn populate_call_registry_from_call_graphs(
     // behind every later use-site's generic fallback — a divergence
     // from upstream's per-callable failure model where the original
     // exception propagates.
-    let mut lifted: HashSet<*const PyreFunctionEntry> =
-        HashSet::with_capacity(by_canonical_path.len());
+    let mut lifted: HashSet<*const FunctionEntry> = HashSet::with_capacity(by_canonical_path.len());
     // Each lift failure pushes into the translator's
-    // `_pyre_lift_errors` map keyed by the entry's `HostObject`
+    // `_lift_errors` map keyed by the entry's `HostObject`
     // identity, making the recorded error visible to
     // `buildflowgraph` consumers downstream.  Resolved lazily so
     // test fixtures whose `Bookkeeper` runs without an attached
@@ -2054,7 +2045,7 @@ pub(crate) fn populate_call_registry_from_call_graphs(
     // leaves the slot `None` — the fallback declines and the site fails
     // closed exactly as before.
     {
-        let mut seeded: HashSet<*const PyreFunctionEntry> =
+        let mut seeded: HashSet<*const FunctionEntry> =
             HashSet::with_capacity(by_canonical_path.len());
         for (_key, graph, entry, _signature) in &pending {
             if !seeded.insert(Rc::as_ptr(entry)) {
@@ -2110,7 +2101,7 @@ pub(crate) fn populate_call_registry_from_call_graphs(
                 if let Some(annotator) = registry.bookkeeper().try_annotator() {
                     annotator
                         .translator
-                        ._pyre_lift_errors
+                        ._lift_errors
                         .borrow_mut()
                         .insert(entry.host_object.clone(), message);
                 }
@@ -2146,7 +2137,7 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         let [.., owner, method] = segs else {
             continue;
         };
-        if !bk.is_pyre_struct_root(owner) || bk.pyre_struct_root_has_field(owner, method) {
+        if !bk.is_known_struct_root(owner) || bk.struct_root_has_field(owner, method) {
             continue;
         }
         let class_host = bk.intern_class_by_qualname(owner);
@@ -2184,20 +2175,20 @@ pub(crate) fn populate_call_registry_from_call_graphs(
 /// `PyGraph` here.
 ///
 /// `signature` is the callee's authoritative parameter `Signature`
-/// (the same one stored on the `FunctionDesc` in `PyreCallRegistry`).
+/// (the same one stored on the `FunctionDesc` in `CallRegistry`).
 /// `defaults` is empty — pyre's surface DSL does not yet expose
 /// per-parameter default values; when it does, this helper grows a
 /// `defaults: Vec<Constant>` parameter mirroring upstream
 /// `func.__defaults__`.
 ///
-/// `nested_registry` carries the program-wide `PyreCallRegistry`.
+/// `nested_registry` carries the program-wide `CallRegistry`.
 /// For leaf callees (no `OpKind::Call` ops in the body) the registry
 /// is unused; nested callees recursively consult it as the adapter
 /// processes the callee's own `OpKind::Call` ops.
 pub(crate) fn lift_callee_to_pygraph(
     callee_graph: &LegacyGraph,
     signature: Signature,
-    nested_registry: &PyreCallRegistry,
+    nested_registry: &CallRegistry,
 ) -> Result<Rc<PyGraph>, TyperError> {
     // The adapter also returns `value_to_var` and `constant_concretetypes`
     // side maps, but they are not consumed here.
@@ -2268,7 +2259,7 @@ pub(crate) fn lift_callee_to_pygraph(
 /// (`Func` / `Struct` / `Array` / `Opaque` / `ForwardReference` /
 /// `FixedSizeArray`) or `Address` (no `SomeAddress` port yet) —
 /// the caller skips registration for that fn and the original
-/// "not registered in PyreCallRegistry" Skip path covers it.
+/// "not registered in CallRegistry" Skip path covers it.
 ///
 /// **Why pre-annotated Variable rather than `Constant`.** A
 /// `Constant(default_value)` in the return Link routes through
@@ -2514,11 +2505,11 @@ fn declared_funcptr_type_from_legacy(
 /// `(segments, signature, FUNC.RESULT token)` specs into `registry`.
 /// Each entry is wrapped through [`residual_return_shell`] +
 /// [`build_stub_pygraph_with_result_shell`]
-/// + [`PyreCallRegistry::register_callee`], so subsequent
+/// + [`CallRegistry::register_callee`], so subsequent
 ///   `flowspace_adapter::translate_op` lookups via
 ///   `call_registry.lookup_with_leaf_match` find a registered entry and
 ///   the dual gate no longer Skips with "not registered in
-///   PyreCallRegistry" for these paths.
+///   CallRegistry" for these paths.
 ///
 /// `specs` is typically the output of
 /// `front::mir::collect_unsafe_fn_stubs_from_llbc` (the Charon/LLBC-
@@ -2538,7 +2529,7 @@ fn declared_funcptr_type_from_legacy(
 /// **Annotator-only carrier — never reaches the codewriter.**
 /// The stub graph carries a single return link holding a pre-annotated
 /// Variable, suitable for `RPythonAnnotator` return-type inference via
-/// `cachedgraph` (see `pyre_call_registry::prefill_default_cache`).
+/// `cachedgraph` (see `call_registry::prefill_default_cache`).
 /// Because `CallControl::function_graphs` is populated exclusively
 /// by lowered safe-fn bodies (unsafe fns never produce a flow graph —
 /// they only get a metadata-only stub key), the unsafe stub key
@@ -2556,7 +2547,7 @@ fn declared_funcptr_type_from_legacy(
 /// safe by virtue of the `function_graphs` gate, not by any
 /// `look_inside_graph` policy on the stub itself.
 pub(crate) fn register_unsafe_fn_stubs(
-    registry: &PyreCallRegistry,
+    registry: &CallRegistry,
     specs: &[(Vec<String>, Signature, Option<String>)],
 ) {
     for (segments, signature, return_token) in specs {
@@ -2745,13 +2736,13 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
 /// through the same opaque stub-pygraph carrier
 /// [`register_unsafe_fn_stubs`] uses, so subsequent
 /// `flowspace_adapter::translate_op` `FunctionPath` lookups resolve the
-/// callee instead of raising "not registered in PyreCallRegistry".  Like
+/// callee instead of raising "not registered in CallRegistry".  Like
 /// `register_unsafe_fn_stubs` the registration is annotator-only and
 /// non-overwriting: a path already registered by the `function_graphs`
 /// or unsafe-fn pass wins, and the codewriter residualizes the call
 /// through its fnaddr lowering (these foreign stubs are never present in
 /// `CallControl::function_graphs`, so they never compile into JITCode).
-pub(crate) fn register_foreign_stdlib_externals(registry: &PyreCallRegistry) {
+pub(crate) fn register_foreign_stdlib_externals(registry: &CallRegistry) {
     for (segments, argnames, return_lltype) in FOREIGN_STDLIB_EXTERNALS {
         let signature = Signature::new(
             argnames.iter().map(|n| (*n).to_string()).collect(),
@@ -2784,7 +2775,7 @@ pub(crate) fn register_foreign_stdlib_externals(registry: &PyreCallRegistry) {
 /// declines the `CallTarget::Method` hint for an opaque owner so the call
 /// lowers as `CallTarget::FunctionPath`; registering each path here lets
 /// the residual lookup resolve instead of raising "not registered in
-/// PyreCallRegistry" (and avoids the classdef-less `SomeInstance.getattr`
+/// CallRegistry" (and avoids the classdef-less `SomeInstance.getattr`
 /// panic the Method form would surface).
 ///
 /// The result shell comes from the per-method faithful `ValueType` the
@@ -2794,7 +2785,7 @@ pub(crate) fn register_foreign_stdlib_externals(registry: &PyreCallRegistry) {
 /// Same non-overwriting, annotator-only-carrier contract as
 /// [`register_foreign_stdlib_externals`].
 pub(crate) fn register_foreign_opaque_method_externals(
-    registry: &PyreCallRegistry,
+    registry: &CallRegistry,
     externals: &[(Vec<String>, Signature, crate::model::ValueType)],
 ) {
     for (segments, signature, result_ty) in externals {
@@ -2817,7 +2808,7 @@ pub(crate) fn register_foreign_opaque_method_externals(
 }
 
 /// Test-only restricted entry: only graphs without `OpKind::Call::FunctionPath`
-/// ops resolve through this path.  An empty `PyreCallRegistry` is
+/// ops resolve through this path.  An empty `CallRegistry` is
 /// constructed internally and shared with the annotator; any
 /// `simple_call` op the adapter emits would surface a fail-loud
 /// `TyperError` at `flowspace_adapter::translate_op`'s
@@ -2839,7 +2830,7 @@ pub(crate) fn register_foreign_opaque_method_externals(
 pub fn specialize_legacy_graph(
     legacy: &LegacyGraph,
 ) -> Result<(LegacyToTyped, HashMap<Variable, LowLevelType>), TyperError> {
-    let registry = crate::translator::rtyper::pyre_call_registry::PyreCallRegistry::new(Rc::new(
+    let registry = crate::translator::rtyper::call_registry::CallRegistry::new(Rc::new(
         crate::annotator::bookkeeper::Bookkeeper::new(),
     ));
     specialize_legacy_graph_with_registry_returning_value_to_var(legacy, &registry)
@@ -2862,7 +2853,7 @@ pub fn specialize_legacy_graph(
 /// this so `seed_variable` has type info to attach.
 pub fn specialize_legacy_graph_with_registry_returning_value_to_var(
     legacy: &LegacyGraph,
-    call_registry: &crate::translator::rtyper::pyre_call_registry::PyreCallRegistry,
+    call_registry: &crate::translator::rtyper::call_registry::CallRegistry,
 ) -> Result<(LegacyToTyped, HashMap<Variable, LowLevelType>), TyperError> {
     let (_graph, value_to_var, _value_to_var_candidates, constant_concretetypes) =
         drive_subject(legacy, call_registry, true)?;
@@ -2885,7 +2876,7 @@ pub fn specialize_legacy_graph_with_registry_returning_value_to_var(
 /// flowspace `GraphRef` so the two-phase cache can record its `GraphKey`.
 fn drive_subject(
     legacy: &LegacyGraph,
-    call_registry: &crate::translator::rtyper::pyre_call_registry::PyreCallRegistry,
+    call_registry: &crate::translator::rtyper::call_registry::CallRegistry,
     do_rtype: bool,
 ) -> Result<
     (
@@ -2903,7 +2894,7 @@ fn drive_subject(
     // once per graph (one per `transform_graph_to_jitcode`); the
     // upstream "specialize-once" semantics are reproduced by sharing
     // one annotator + rtyper across subjects through
-    // `PyreCallRegistry::ensure_session` and rtyping only the newly
+    // `CallRegistry::ensure_session` and rtyping only the newly
     // added blocks each entry.  Already-cached PyGraphs hold
     // post-specialize LL ops; re-seeding them into the per-session
     // annotator would let `specialize_more_blocks` walk the LL ops a
@@ -2924,7 +2915,7 @@ fn drive_subject(
     // ── Step 2 — annotator surface ────────────────────────────────
     //
     // The annotator + rtyper are
-    // session-shared through `PyreCallRegistry::ensure_session`,
+    // session-shared through `CallRegistry::ensure_session`,
     // mirroring RPython's "one annotator + one rtyper per Translator"
     // (`translator.py:69-83`).  Each per-graph subject seeds its
     // blocks into the shared annotator; subsequent
@@ -3094,7 +3085,7 @@ fn drive_subject(
     //        immediately before specialization instead (see
     //        `specialize_block`).
     //   2. `self.exceptiondata.finish(self)` — hoisted into
-    //      `PyreCallRegistry::ensure_session` so it runs **once** at
+    //      `CallRegistry::ensure_session` so it runs **once** at
     //      session start (idempotent — `getclassrepr` is cached on
     //      `rtyper.instance_reprs`).
     //   3. `self.already_seen = {}` — pyre keeps `already_seen`
@@ -3189,7 +3180,7 @@ fn drive_subject(
 /// prepass still yields Match for the graphs that completed and a safe
 /// legacy-walker Skip for the rest (zero regression, never the poisoned session).
 pub(crate) fn run_two_phase_prepass(
-    call_registry: &PyreCallRegistry,
+    call_registry: &CallRegistry,
     candidate_graphs: &HashSet<crate::parse::CallPath>,
     function_graphs: &crate::codewriter::call::GraphStore,
 ) {
@@ -3199,11 +3190,11 @@ pub(crate) fn run_two_phase_prepass(
     call_registry.two_phase().prepass_done = true;
 }
 
-/// Whether the `PYRE_RTYPER_VERBOSE` de-aggregating census is enabled.
+/// Whether the `MAJIT_RTYPER_VERBOSE` de-aggregating census is enabled.
 /// Matches the `== "1"` contract the codewriter's coverage gauge uses
-/// (`codewriter.rs`), so a literal `PYRE_RTYPER_VERBOSE=0` stays off.
+/// (`codewriter.rs`), so a literal `MAJIT_RTYPER_VERBOSE=0` stays off.
 fn rtyper_verbose_enabled() -> bool {
-    std::env::var_os("PYRE_RTYPER_VERBOSE").is_some_and(|v| v == "1")
+    std::env::var_os("MAJIT_RTYPER_VERBOSE").is_some_and(|v| v == "1")
 }
 
 /// Map a captured prepass failure reason to its orthodox-disposition
@@ -3278,7 +3269,7 @@ fn classify_unported_reason(reason: &str) -> &'static str {
         "ANNOTATION-SLOT-GAP (cross-block threading)"
     }
     // ── FunctionPath-not-registered family, split by callee nature ──
-    else if reason.contains("not registered in PyreCallRegistry")
+    else if reason.contains("not registered in CallRegistry")
         || reason.contains("translate_op")
         || reason.contains("cachedgraph")
     {
@@ -3349,7 +3340,7 @@ fn classify_unported_reason(reason: &str) -> &'static str {
 }
 
 /// Print a sorted disposition histogram for a prepass phase's failures
-/// (`PYRE_RTYPER_VERBOSE`). The ranked buckets are the legacy-walker
+/// (`MAJIT_RTYPER_VERBOSE`). The ranked buckets are the legacy-walker
 /// deletion worklist; as each disposition's port lands its bucket shrinks.
 fn emit_disposition_histogram(phase: &str, reasons: &[String]) {
     let mut counts: std::collections::BTreeMap<&'static str, usize> =
@@ -3390,7 +3381,7 @@ fn emit_determinism_trace(phase: &str, index: usize, canonical_key: &str) {
 }
 
 fn run_two_phase_prepass_inner(
-    call_registry: &PyreCallRegistry,
+    call_registry: &CallRegistry,
     candidate_graphs: &HashSet<crate::parse::CallPath>,
     function_graphs: &crate::codewriter::call::GraphStore,
 ) {
@@ -3424,7 +3415,7 @@ fn run_two_phase_prepass_inner(
                 let key = path.canonical_key();
                 call_registry.two_phase().subjects.insert(
                     key,
-                    crate::translator::rtyper::pyre_call_registry::TwoPhaseSubject {
+                    crate::translator::rtyper::call_registry::TwoPhaseSubject {
                         graph: graph.clone(),
                         graph_key: crate::flowspace::model::GraphKey::of(&graph),
                         value_to_var,
@@ -3434,7 +3425,7 @@ fn run_two_phase_prepass_inner(
                 );
             }
             ref other @ (Ok(Err(_)) | Err(_)) => {
-                // De-aggregating census (PYRE_RTYPER_VERBOSE): the dual-gate
+                // De-aggregating census (MAJIT_RTYPER_VERBOSE): the dual-gate
                 // otherwise lumps every Phase-A failure under one opaque
                 // "subject not annotated/rtyped" Skip. Surface the per-graph
                 // reason so the onion can be triaged.
@@ -3535,7 +3526,7 @@ fn run_two_phase_prepass_inner(
 /// `unpoison_failed_subject_callees`. The skip set is written into the cache
 /// incrementally so partial progress survives a cut-short call.
 fn run_phase_b_rtype_isolated(
-    call_registry: &PyreCallRegistry,
+    call_registry: &CallRegistry,
     lift_sources: &crate::codewriter::call::GraphStore,
     determinism_trace: bool,
     paths: &[&crate::parse::CallPath],
@@ -3900,7 +3891,7 @@ fn backfill_untyped_call_results(legacy: &LegacyGraph, value_to_var: &LegacyToTy
 /// migration safety oracle) but consumes the cached real types.
 pub(crate) fn dual_gate_outcome_from_cache(
     legacy: &LegacyGraph,
-    call_registry: &PyreCallRegistry,
+    call_registry: &CallRegistry,
     diag_key: &str,
 ) -> Result<DualGateOutcome, String> {
     // Clone the cached real types out so the cache borrow drops before the
@@ -5260,9 +5251,9 @@ mod tests {
         setbinding(&fill, ValueType::Int);
         setbinding(&count, ValueType::Int);
 
-        let registry = crate::translator::rtyper::pyre_call_registry::PyreCallRegistry::new(
-            Rc::new(crate::annotator::bookkeeper::Bookkeeper::new()),
-        );
+        let registry = crate::translator::rtyper::call_registry::CallRegistry::new(Rc::new(
+            crate::annotator::bookkeeper::Bookkeeper::new(),
+        ));
         let (flow_graph, _, _, _) = drive_subject(&graph, &registry, /* do_rtype = */ false)
             .expect("repeat subject must annotate and transform");
         let transformed_ops: Vec<String> = flow_graph
@@ -5429,8 +5420,7 @@ mod tests {
         graph.blocks = vec![startblock, returnblock];
 
         let bookkeeper = std::rc::Rc::new(crate::annotator::bookkeeper::Bookkeeper::new());
-        let registry =
-            crate::translator::rtyper::pyre_call_registry::PyreCallRegistry::new(bookkeeper);
+        let registry = crate::translator::rtyper::call_registry::CallRegistry::new(bookkeeper);
 
         // Leaf callee `fn foo(x: i64) -> i64 { x }` lifted through a
         // child registry; the entry's `FunctionDesc` (whose
@@ -5476,7 +5466,7 @@ mod tests {
         };
         callee_graph.blocks = vec![foo_start, foo_return];
         callee_graph.hints.push("always_inline".to_string());
-        let leaf_registry = crate::translator::rtyper::pyre_call_registry::PyreCallRegistry::new(
+        let leaf_registry = crate::translator::rtyper::call_registry::CallRegistry::new(
             std::rc::Rc::new(crate::annotator::bookkeeper::Bookkeeper::new()),
         );
         setbinding(&foo_v10_var, ValueType::Int);
@@ -5511,7 +5501,7 @@ mod tests {
         // `funcobj.graph` points at after rtyping.
         let callee_graph_ref = pygraph.graph.clone();
         registry.register_callee(
-            crate::translator::rtyper::pyre_call_registry::FunctionPathKey::from_segments(["foo"]),
+            crate::translator::rtyper::call_registry::FunctionPathKey::from_segments(["foo"]),
             crate::flowspace::argument::Signature::new(
                 vec!["x".to_string(), "n".to_string()],
                 None,
@@ -5566,7 +5556,7 @@ mod tests {
         let _lock = anchor_lock();
         use crate::annotator::bookkeeper::Bookkeeper;
         use crate::flowspace::model::{BlockKey, GraphKey};
-        use crate::translator::rtyper::pyre_call_registry::{FunctionPathKey, PyreCallRegistry};
+        use crate::translator::rtyper::call_registry::{CallRegistry, FunctionPathKey};
 
         let mut source = LegacyGraph::new("shared_int_value");
         let vars = mint_vars(&mut source, 2);
@@ -5596,7 +5586,7 @@ mod tests {
         ];
         setbinding(&value, ValueType::Int);
 
-        let registry = PyreCallRegistry::new(Rc::new(Bookkeeper::new()));
+        let registry = CallRegistry::new(Rc::new(Bookkeeper::new()));
         // `mint_vars` allocates unnamed value vars, so the startblock's single
         // inputarg has no source name and takes the positional `arg0`.
         let signature =
@@ -5830,9 +5820,9 @@ mod tests {
     #[test]
     fn register_unsafe_fn_stubs_registers_each_spec_and_skips_compound_returns() {
         use crate::annotator::bookkeeper::Bookkeeper;
-        use crate::translator::rtyper::pyre_call_registry::PyreCallRegistry;
+        use crate::translator::rtyper::call_registry::CallRegistry;
         let bk = std::rc::Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk);
+        let registry = CallRegistry::new(bk);
         let specs = vec![
             (
                 vec!["pyobject".to_string(), "is_none".to_string()],
@@ -5880,7 +5870,7 @@ mod tests {
     /// Pin the layering invariant
     /// that the synthetic stub-pygraph is annotator-only.  The
     /// `register_unsafe_fn_stubs` helper writes the stub into the
-    /// `PyreCallRegistry` cache but does NOT mutate any
+    /// `CallRegistry` cache but does NOT mutate any
     /// `CallControl::function_graphs` map; the codewriter's BFS walks
     /// `function_graphs.keys()` and resolves each call op's target via
     /// `target_to_path_and_graph` which requires the target to be
@@ -5892,7 +5882,7 @@ mod tests {
     fn register_unsafe_fn_stubs_does_not_populate_callcontrol_function_graphs() {
         use crate::annotator::bookkeeper::Bookkeeper;
         use crate::codewriter::call::CallControl;
-        use crate::translator::rtyper::pyre_call_registry::PyreCallRegistry;
+        use crate::translator::rtyper::call_registry::CallRegistry;
         let mut callcontrol = CallControl::new();
         callcontrol.unsafe_fn_stubs = vec![(
             vec!["pyobject".to_string(), "is_none".to_string()],
@@ -5900,7 +5890,7 @@ mod tests {
             Some("bool".to_string()),
         )];
         let bk = std::rc::Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk);
+        let registry = CallRegistry::new(bk);
         register_unsafe_fn_stubs(&registry, &callcontrol.unsafe_fn_stubs);
         // Registry side: the stub is present for `cachedgraph` lookups.
         let key = FunctionPathKey::from_segments(["pyobject".to_string(), "is_none".to_string()]);
@@ -5928,9 +5918,9 @@ mod tests {
         // A path already registered via function_graphs (e.g. a safe fn
         // wearing the same segments) must NOT be overwritten by a stub.
         use crate::annotator::bookkeeper::Bookkeeper;
-        use crate::translator::rtyper::pyre_call_registry::PyreCallRegistry;
+        use crate::translator::rtyper::call_registry::CallRegistry;
         let bk = std::rc::Rc::new(Bookkeeper::new());
-        let registry = PyreCallRegistry::new(bk);
+        let registry = CallRegistry::new(bk);
         let key = FunctionPathKey::from_segments(["pyobject".to_string(), "shared".to_string()]);
         let signature = Signature::new(vec!["x".to_string()], None, None);
         let existing = registry.get_or_register(key.clone(), signature.clone());

--- a/majit/majit-translate/src/translator/rtyper/extregistry.rs
+++ b/majit/majit-translate/src/translator/rtyper/extregistry.rs
@@ -173,7 +173,7 @@ pub enum ExtRegistryEntry {
     ///
     /// `From::from` has no `self` receiver, so the front-end lowers it as a
     /// `simple_call` against the `BigInt.from` host callable (not a
-    /// `CallTarget::FunctionPath` the `PyreCallRegistry` callee-stub path
+    /// `CallTarget::FunctionPath` the `CallRegistry` callee-stub path
     /// handles).  The annotation half is served by the `BigInt.from`
     /// `BUILTIN_ANALYZERS` entry (`annotator/builtin.rs`, `bigint_from` →
     /// the classdef-less `SomeInstance` shell), which

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -478,8 +478,8 @@ fn resolve_result_hlvalue(
 /// `flowcontext.py` → `op.invert`); without static type info,
 /// the adapter cannot discriminate, so fail-loud is the only safe
 /// choice.
-fn normalize_unary_op_name(pyre_name: &str) -> Result<String, TyperError> {
-    match pyre_name {
+fn normalize_unary_op_name(source_name: &str) -> Result<String, TyperError> {
+    match source_name {
         "neg" => Ok("neg".to_string()),
         // RPython `bool` is registered as a unary op at
         // `operation.py add_operator('bool', 1, ..)` and emitted
@@ -564,8 +564,8 @@ fn normalize_unary_op_name(pyre_name: &str) -> Result<String, TyperError> {
 /// (`operation.py:475-510` registers no such binary operator), so the
 /// keyword-suffixed `and_` / `or_` names below are unambiguously the
 /// bitwise registrations.
-fn normalize_binop_name(pyre_name: &str) -> Result<String, TyperError> {
-    let normalized = match pyre_name {
+fn normalize_binop_name(source_name: &str) -> Result<String, TyperError> {
+    let normalized = match source_name {
         "and" | "bitand" => "and_",
         "or" | "bitor" => "or_",
         "bitxor" => "xor",
@@ -1046,7 +1046,7 @@ pub fn translate_op(
     // `rpbc.rs`'s `FunctionRepr::rtype_simple_call`).  Empty registry
     // callsites surface a distinct fail-loud message; producers
     // must pre-register every reachable FunctionPath.
-    call_registry: &crate::translator::rtyper::pyre_call_registry::PyreCallRegistry,
+    call_registry: &crate::translator::rtyper::call_registry::CallRegistry,
 ) -> Result<Vec<FlowspaceOp>, TyperError> {
     // Unit-variant ctors (`StepResult::Continue`, `LoopResult::Done`, …)
     // pre-fold to `Hlvalue::Constant(HostObject(prebuilt_instance))` in the
@@ -1569,7 +1569,7 @@ pub fn translate_op(
             let result = resolve_result_hlvalue(op, value_map)?;
             match target {
                 // `FunctionPath` resolves through
-                // `PyreCallRegistry`, returning the registry entry's
+                // `CallRegistry`, returning the registry entry's
                 // `HostObject::UserFunction` instead of an opaque
                 // wrapper. The rtyper's `pair_simple_call` then
                 // short-circuits on `bookkeeper.descs` (pre-populated
@@ -1753,9 +1753,9 @@ pub fn translate_op(
                         call_args.extend(arg_hls);
                         return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
                     }
-                    // `__pyre_cast_instance` — front-end pointer-downcast
+                    // `__cast_instance_intrinsic` — front-end pointer-downcast
                     // narrow (#298).  `front::mir` emits a synthetic
-                    // `Call(["__pyre_cast_instance", <root>], [operand])`
+                    // `Call(["__cast_instance_intrinsic", <root>], [operand])`
                     // for `obj as *const RegisteredStruct`, stashing the
                     // target struct root in `segments[1]` because the
                     // `Vec<Variable>` arg carrier cannot hold a `Constant`
@@ -1766,20 +1766,20 @@ pub fn translate_op(
                     // trailing `ByteStr` root to type the result
                     // `SomeInstance(root)`, and the typer lowers the call
                     // to a `cast_pointer`.  The callable resolves through
-                    // the `__pyre_cast_instance` HOST_ENV singleton so its
+                    // the `__cast_instance_intrinsic` HOST_ENV singleton so its
                     // Arc identity matches the `BUILTIN_TYPER` key.
-                    if segments.len() == 2 && segments[0] == "__pyre_cast_instance" {
+                    if segments.len() == 2 && segments[0] == "__cast_instance_intrinsic" {
                         if arg_hls.len() != 1 {
                             return Err(TyperError::message(format!(
-                                "__pyre_cast_instance requires exactly one operand, got {}",
+                                "__cast_instance_intrinsic requires exactly one operand, got {}",
                                 arg_hls.len()
                             )));
                         }
                         let callable_host = HOST_ENV
-                            .lookup_builtin("__pyre_cast_instance")
+                            .lookup_builtin("__cast_instance_intrinsic")
                             .ok_or_else(|| {
                                 TyperError::message(
-                                    "__pyre_cast_instance missing from HOST_ENV bootstrap"
+                                    "__cast_instance_intrinsic missing from HOST_ENV bootstrap"
                                         .to_string(),
                                 )
                             })?;
@@ -1793,25 +1793,25 @@ pub fn translate_op(
                         ))));
                         return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
                     }
-                    // `__pyre_cast_address` — the erasing twin of the narrow
+                    // `__cast_address_intrinsic` — the erasing twin of the narrow
                     // above (`front::mir` emits it for `p as *mut u8`).  It
                     // carries no root, so the reconstruction is the plain
                     // `simple_call(callable, operand)`; resolving through the
                     // HOST_ENV singleton keeps the Arc identity that keys its
                     // `BUILTIN_TYPER` entry, which a single-segment path
-                    // consulting the `PyreCallRegistry` first would lose.
-                    if segments.len() == 1 && segments[0] == "__pyre_cast_address" {
+                    // consulting the `CallRegistry` first would lose.
+                    if segments.len() == 1 && segments[0] == "__cast_address_intrinsic" {
                         if arg_hls.len() != 1 {
                             return Err(TyperError::message(format!(
-                                "__pyre_cast_address requires exactly one operand, got {}",
+                                "__cast_address_intrinsic requires exactly one operand, got {}",
                                 arg_hls.len()
                             )));
                         }
                         let callable_host = HOST_ENV
-                            .lookup_builtin("__pyre_cast_address")
+                            .lookup_builtin("__cast_address_intrinsic")
                             .ok_or_else(|| {
                                 TyperError::message(
-                                    "__pyre_cast_address missing from HOST_ENV bootstrap"
+                                    "__cast_address_intrinsic missing from HOST_ENV bootstrap"
                                         .to_string(),
                                 )
                             })?;
@@ -1824,9 +1824,9 @@ pub fn translate_op(
                     }
                     // `front::range_iter`'s synthesized `range(start, stop)`
                     // (the exclusive int-`Range` for-loop divert).  It carries
-                    // the reserved `__pyre_range` spelling rather than a bare
+                    // the reserved `__majit_range` spelling rather than a bare
                     // `["range"]` because the registry ladder below resolves a
-                    // single-segment path against the `PyreCallRegistry`
+                    // single-segment path against the `CallRegistry`
                     // *first* (the `frame.globals`-before-`__builtin__` order
                     // of `flowcontext.py:845-853`), and pyre's registry is one
                     // flat namespace keyed by leaf-only `CallPath`s.  A pyre
@@ -1841,8 +1841,8 @@ pub fn translate_op(
                     // spelling straight to the `HOST_ENV` singleton keeps the
                     // Arc identity that keys `rtype_builtin_range`
                     // (`rrange.py:96-126`), the same discipline the
-                    // `__pyre_cast_instance` arm above documents.
-                    if segments.len() == 1 && segments[0] == "__pyre_range" {
+                    // `__cast_instance_intrinsic` arm above documents.
+                    if segments.len() == 1 && segments[0] == "__majit_range" {
                         let callable_host = HOST_ENV.lookup_builtin("range").ok_or_else(|| {
                             TyperError::message("range missing from HOST_ENV bootstrap".to_string())
                         })?;
@@ -1863,24 +1863,24 @@ pub fn translate_op(
                     // `newstringbuilder` arms already consume, mirroring the
                     // `Vec::push` / `slice.reverse` method arms below.
                     //
-                    // `__pyre_stringbuilder_new` → `newstringbuilder`, forwarding
+                    // `__majit_stringbuilder_new` → `newstringbuilder`, forwarding
                     // the ctor operands verbatim: `new()` carries none and
                     // `with_capacity(n)` carries the size `n`.  The operand count
                     // mirrors `len(hop.args_v)` in
                     // `AbstractStringBuilderRepr.rtyper_new` (rtyper/rbuilder.py),
                     // which `rtype_newstringbuilder` honours — no arg selects
                     // `ll_new(INIT_SIZE)`, the size arg threads `ll_new(n)`.
-                    if segments.len() == 1 && segments[0] == "__pyre_stringbuilder_new" {
+                    if segments.len() == 1 && segments[0] == "__majit_stringbuilder_new" {
                         return Ok(vec![FlowspaceOp::new("newstringbuilder", arg_hls, result)]);
                     }
-                    // `__pyre_stringbuilder_append(recv, piece)` →
+                    // `__majit_stringbuilder_append(recv, piece)` →
                     // `getattr(recv, "append") + simple_call(bound, piece)`,
                     // reaching `StringBuilderRepr::rtype_method("append")`
                     // (rstring.py) — identical to the `Vec::push` arm.
-                    if segments.len() == 1 && segments[0] == "__pyre_stringbuilder_append" {
+                    if segments.len() == 1 && segments[0] == "__majit_stringbuilder_append" {
                         if arg_hls.len() != 2 {
                             return Err(TyperError::message(format!(
-                                "__pyre_stringbuilder_append requires exactly two args \
+                                "__majit_stringbuilder_append requires exactly two args \
                                  (receiver, piece), got {}",
                                 arg_hls.len()
                             )));
@@ -1888,12 +1888,12 @@ pub fn translate_op(
                         let mut iter = arg_hls.into_iter();
                         let receiver = iter.next().ok_or_else(|| {
                             TyperError::message(
-                                "__pyre_stringbuilder_append requires a receiver arg".to_string(),
+                                "__majit_stringbuilder_append requires a receiver arg".to_string(),
                             )
                         })?;
                         let piece = iter.next().ok_or_else(|| {
                             TyperError::message(
-                                "__pyre_stringbuilder_append requires a piece arg".to_string(),
+                                "__majit_stringbuilder_append requires a piece arg".to_string(),
                             )
                         })?;
                         let bound_method = Hlvalue::Variable(Variable::new());
@@ -1911,15 +1911,15 @@ pub fn translate_op(
                             FlowspaceOp::new("simple_call", vec![bound_method, piece], result),
                         ]);
                     }
-                    // `__pyre_stringbuilder_build(recv)` →
+                    // `__majit_stringbuilder_build(recv)` →
                     // `getattr(recv, "build") + simple_call(bound)`, reaching
                     // `StringBuilderRepr::rtype_method("build")`
                     // (rstring.py) → `SomeString` — identical to the
                     // `slice.reverse` arm (no extra args on the bound method).
-                    if segments.len() == 1 && segments[0] == "__pyre_stringbuilder_build" {
+                    if segments.len() == 1 && segments[0] == "__majit_stringbuilder_build" {
                         if arg_hls.len() != 1 {
                             return Err(TyperError::message(format!(
-                                "__pyre_stringbuilder_build requires exactly one receiver arg, \
+                                "__majit_stringbuilder_build requires exactly one receiver arg, \
                                  got {}",
                                 arg_hls.len()
                             )));
@@ -1927,7 +1927,7 @@ pub fn translate_op(
                         let mut iter = arg_hls.into_iter();
                         let receiver = iter.next().ok_or_else(|| {
                             TyperError::message(
-                                "__pyre_stringbuilder_build requires a receiver arg".to_string(),
+                                "__majit_stringbuilder_build requires a receiver arg".to_string(),
                             )
                         })?;
                         let bound_method = Hlvalue::Variable(Variable::new());
@@ -2192,7 +2192,7 @@ pub fn translate_op(
                         ));
                     }
                     let key =
-                        crate::translator::rtyper::pyre_call_registry::FunctionPathKey::from_segments(
+                        crate::translator::rtyper::call_registry::FunctionPathKey::from_segments(
                             segments.iter().cloned(),
                         );
                     // Method-routing for a registered dispatch family
@@ -2246,7 +2246,7 @@ pub fn translate_op(
                     // Three resolution layers, matching upstream's three
                     // dispatch shapes for a dotted call site:
                     //
-                    // 1. `PyreCallRegistry` — user functions registered
+                    // 1. `CallRegistry` — user functions registered
                     //    by the production builder.  Analogous to
                     //    `flowspace/flowcontext.py:LOAD_GLOBAL` reading
                     //    `frame.globals` (user globals) first.
@@ -2306,11 +2306,11 @@ pub fn translate_op(
                         // unresolved so the referencing graph deterministically
                         // Skips to the legacy walker (unbuildable callee →
                         // caller Skips).
-                        if let Some(lift_err) = entry.pyre_lift_error() {
+                        if let Some(lift_err) = entry.lift_error() {
                             return Err(TyperError::message(format!(
                                 "translate_op: OpKind::Call::FunctionPath \
                                  {{ segments: {:?} }} resolves to a \
-                                 PyreCallRegistry entry whose pyre-side lift \
+                                 CallRegistry entry whose source lift \
                                  failed ({lift_err}); the referencing graph \
                                  falls back to the legacy walker. \
                                  Result slot = {}",
@@ -2390,11 +2390,11 @@ pub fn translate_op(
                         // Same fail-closed rule as the exact-lookup branch: a
                         // lift-errored entry is unresolved, so the referencing
                         // graph Skips to the legacy walker.
-                        if let Some(lift_err) = entry.pyre_lift_error() {
+                        if let Some(lift_err) = entry.lift_error() {
                             return Err(TyperError::message(format!(
                                 "translate_op: OpKind::Call::FunctionPath \
                                  {{ segments: {:?} }} leaf-matches a \
-                                 PyreCallRegistry entry whose pyre-side lift \
+                                 CallRegistry entry whose source lift \
                                  failed ({lift_err}); the referencing graph \
                                  falls back to the legacy walker. \
                                  Result slot = {}",
@@ -2406,7 +2406,7 @@ pub fn translate_op(
                     } else {
                         return Err(TyperError::message(format!(
                             "translate_op: OpKind::Call::FunctionPath {{ segments: {:?} }} \
-                             not registered in PyreCallRegistry, not in HOST_ENV \
+                             not registered in CallRegistry, not in HOST_ENV \
                              `__builtin__`, and not a known module-qualified host attribute — \
                              the production builder (a SemanticProgram walker, or a test \
                              fixture building the registry directly) must register the path \
@@ -2552,7 +2552,7 @@ pub fn translate_op(
                         let owner_tail = owner_path.last();
                         let owner_qual = owner_path.join("::");
                         let is_enum_variant =
-                            bk.pyre_struct_fields.borrow().as_ref().is_some_and(|reg| {
+                            bk.struct_fields.borrow().as_ref().is_some_and(|reg| {
                                 reg.is_enum_base(&owner_qual)
                                     || owner_tail.is_some_and(|tail| reg.is_enum_base(tail))
                             });
@@ -2575,7 +2575,7 @@ pub fn translate_op(
                             let colon_qual = format!("{owner_qual}::{name}");
                             let is_closure_root = majit_charon_reader::ullbc::is_closure_leaf(name)
                                 && bk
-                                    .pyre_struct_fields
+                                    .struct_fields
                                     .borrow()
                                     .as_ref()
                                     .is_some_and(|reg| reg.fields.contains_key(&colon_qual));
@@ -2637,10 +2637,10 @@ pub fn translate_op(
                 // inputargs, not temps — so the method getattr would block
                 // on the classdef-less shell.  Narrow the receiver first to
                 // the trait-family base `ClassDef` via the
-                // `__pyre_cast_instance` mechanism (same as the `mir.rs`
-                // path, lowered by `translate_op`'s `__pyre_cast_instance`
+                // `__cast_instance_intrinsic` mechanism (same as the `mir.rs`
+                // path, lowered by `translate_op`'s `__cast_instance_intrinsic`
                 // arm): emit
-                // `simple_call(__pyre_cast_instance, receiver,
+                // `simple_call(__cast_instance_intrinsic, receiver,
                 // Constant(byte_str(base_root)))` producing a narrowed
                 // receiver, then `getattr(narrowed, method_name)`.  The
                 // family base's impl subclasses carry the methods through
@@ -2649,7 +2649,7 @@ pub fn translate_op(
                 // through the ordinary bound-method path
                 // (`rpbc.py FunctionRepr.call`); dispatch stays virtual.
                 //
-                // The cast root must resolve through `pyre_struct_root_classes`
+                // The cast root must resolve through `struct_root_classes`
                 // to the base classdef `register_trait_family` minted under
                 // `canonical_struct_name(base_root)`.  `trait_root` here is
                 // the bare trait leaf (`dyn_indirect_target`), but the family
@@ -2679,10 +2679,10 @@ pub fn translate_op(
                     // trait is a registered dispatch family.
                     let getattr_receiver = if let Some(base_root) = base_root {
                         let callable_host = HOST_ENV
-                            .lookup_builtin("__pyre_cast_instance")
+                            .lookup_builtin("__cast_instance_intrinsic")
                             .ok_or_else(|| {
                                 TyperError::message(
-                                    "__pyre_cast_instance missing from HOST_ENV bootstrap"
+                                    "__cast_instance_intrinsic missing from HOST_ENV bootstrap"
                                         .to_string(),
                                 )
                             })?;
@@ -2926,7 +2926,7 @@ fn post_rtyper_jtransform_variant_name(kind: &OpKind) -> Option<&'static str> {
         // Each front-end `stop_unsupported` / `continue_with_unknown`
         // emit-site is retired by lowering its specific expression
         // form (`ConstStr`, `Range`, `Closure`, etc.).
-        OpKind::Abort { .. } => "Abort (pyre-only abort marker)",
+        OpKind::Abort { .. } => "Abort (runtime extension marker)",
         _ => return None,
     })
 }
@@ -2999,7 +2999,7 @@ fn constant_from_constvalue(value: ConstValue) -> Constant {
 
 fn legacy_const_define_hlvalue(
     op: &SpaceOperation,
-    call_registry: Option<&crate::translator::rtyper::pyre_call_registry::PyreCallRegistry>,
+    call_registry: Option<&crate::translator::rtyper::call_registry::CallRegistry>,
 ) -> Result<Option<Hlvalue>, TyperError> {
     // Const-define ops always carry a result Variable; bail on the
     // (malformed) result-less op so the caller can key the const
@@ -3084,12 +3084,11 @@ fn legacy_const_define_hlvalue(
             let segments = crate::model::fn_const_segments(target).expect("guard checked");
             let call_registry = call_registry.ok_or_else(|| {
                 TyperError::message(format!(
-                    "fn const {:?} requires a PyreCallRegistry to materialise getfunctionptr",
+                    "fn const {:?} requires a CallRegistry to materialise getfunctionptr",
                     segments
                 ))
             })?;
-            let key =
-                crate::translator::rtyper::pyre_call_registry::FunctionPathKey(segments.to_vec());
+            let key = crate::translator::rtyper::call_registry::FunctionPathKey(segments.to_vec());
             let entry = call_registry.lookup_with_leaf_match(&key).ok_or_else(|| {
                 TyperError::message(format!(
                     "fn const {:?} did not resolve to a registered callee",
@@ -3119,7 +3118,7 @@ fn legacy_const_define_hlvalue(
             // `None`; the site then fails closed with the most specific
             // diagnosis, exactly as before.
             use crate::translator::rtyper::lltypesystem::lltype;
-            let lift_error = entry.pyre_lift_error();
+            let lift_error = entry.lift_error();
             let graphs = entry.function_desc.borrow().getgraphs();
             let maybe_graph = graphs.into_iter().next();
             // Precise fn-ptr only when the callee is lifted (cached graph, no
@@ -3423,20 +3422,20 @@ pub(crate) fn derive_subject_inputcells(
                 // root resolver excludes the core/std/alloc container
                 // family precisely so the receiver projects to the
                 // annotator's list model here, not a minted classdef).
-                // `project_pyre_field_type` maps the spelling to
+                // `project_struct_field_type` maps the spelling to
                 // `SomeList(elem)` so a `len()` / iteration on the receiver
                 // resolves as a list op instead of `getattr` over the
                 // classdef-less `SomeInstance(None)` shell.
                 if let (Some(bk), Some(root)) = (bookkeeper, class_root.as_deref())
                     && majit_ir::descr::is_list_container_spelling(root)
                 {
-                    cells.push(bk.project_pyre_field_type(root));
+                    cells.push(bk.project_struct_field_type(root));
                     continue;
                 }
                 // String-typed params are string values, not class
                 // instances: `String` and `str` both map to the byte
                 // string type (`s_str0` = `SomeString(no_nul=True)`,
-                // matching `project_pyre_field_type`).  String literals
+                // matching `project_struct_field_type`).  String literals
                 // lower through `__str_const` to `ConstValue::ByteStr`
                 // (flowspace_adapter, stamped `Ptr(STR)`/`StringRepr`),
                 // so a literal flowing into a `&str`/`String` param must
@@ -3462,11 +3461,7 @@ pub(crate) fn derive_subject_inputcells(
                     // instead of blocking on the classdef-less shell.
                     // Checked before the unique-impl substitution below —
                     // a multi-impl family has no unique impl to fold to.
-                    let family_base = bk
-                        .pyre_trait_family_bases
-                        .borrow()
-                        .get(root.as_str())
-                        .cloned();
+                    let family_base = bk.trait_family_bases.borrow().get(root.as_str()).cloned();
                     if let Some(base_host) = family_base {
                         let cd = bk.getuniqueclassdef(&base_host).map_err(|e| {
                             TyperError::message(format!(
@@ -3493,27 +3488,27 @@ pub(crate) fn derive_subject_inputcells(
                     // that impl type — substitute its struct root and
                     // seed below as if the param were typed concretely.
                     let root = bk
-                        .pyre_trait_unique_impls
+                        .trait_unique_impls
                         .borrow()
                         .get(root)
                         .cloned()
                         .unwrap_or_else(|| root.clone());
                     let root = &root;
                     let known = bk
-                        .pyre_struct_fields
+                        .struct_fields
                         .borrow()
                         .as_ref()
                         .is_some_and(|reg| reg.fields.contains_key(root));
                     if known {
                         // A `&FixedObjectArray` receiver models as its
                         // `_items` element list, not the wrapping struct
-                        // (project_pyre_field_type), so an `arr[idx]` access
+                        // (project_struct_field_type), so an `arr[idx]` access
                         // resolves as a list `getitem` rather than rewriting
                         // to `getattr("__getitem__")`.
                         if majit_ir::descr::canonical_struct_name(root)
                             == "object_array::FixedObjectArray"
                         {
-                            cells.push(bk.project_pyre_field_type(root));
+                            cells.push(bk.project_struct_field_type(root));
                             continue;
                         }
                         let cd = bk.getuniqueclassdef_for_struct_root(root).map_err(|e| {
@@ -3636,7 +3631,7 @@ fn reachable_block_ids(legacy: &FunctionGraph) -> std::collections::HashSet<Bloc
 pub fn function_graph_to_flowspace(
     legacy: &FunctionGraph,
     // Call resolution plumbing — see [`translate_op`].
-    call_registry: &crate::translator::rtyper::pyre_call_registry::PyreCallRegistry,
+    call_registry: &crate::translator::rtyper::call_registry::CallRegistry,
 ) -> Result<FlowspaceAdapterOutput, TyperError> {
     let mut value_to_var: LegacyToTyped = HashMap::new();
     let mut value_to_var_candidates: LegacyToTypedCandidates = HashMap::new();
@@ -4161,8 +4156,8 @@ mod tests {
     use crate::model::{
         Block, BlockId, FunctionGraph as LegacyGraph, OpKind, SpaceOperation, ValueType,
     };
+    use crate::translator::rtyper::call_registry::CallRegistry;
     use crate::translator::rtyper::legacy_annotator::setbinding;
-    use crate::translator::rtyper::pyre_call_registry::PyreCallRegistry;
 
     /// Mint `n` fresh values on `graph`, returned indexed `0..n` so
     /// fixtures can refer to operands / results / inputargs positionally.
@@ -4179,12 +4174,12 @@ mod tests {
         vids.iter().map(|&i| vars[i].clone()).collect()
     }
 
-    /// Helper: empty `PyreCallRegistry` for tests that don't exercise
+    /// Helper: empty `CallRegistry` for tests that don't exercise
     /// the Call resolution path.  The registry's
     /// bookkeeper is freshly minted because translate_op tests don't
     /// share state with an enclosing annotator.
-    fn empty_call_registry() -> PyreCallRegistry {
-        PyreCallRegistry::new(Rc::new(Bookkeeper::new()))
+    fn empty_call_registry() -> CallRegistry {
+        CallRegistry::new(Rc::new(Bookkeeper::new()))
     }
 
     #[test]
@@ -4823,12 +4818,12 @@ mod tests {
     fn translate_op_call_function_path_lowers_to_simple_call() {
         // Call::FunctionPath → `simple_call(callable_host, args...)` per
         // `flowspace/operation.py SimpleCall.opname = 'simple_call'`.
-        // The callable Constant wraps the `PyreCallRegistry` entry's
+        // The callable Constant wraps the `CallRegistry` entry's
         // synthetic `HostObject::UserFunction` so the rtyper's
         // `bookkeeper.getdesc` short-circuits onto the registered
         // FunctionDesc.
         use crate::flowspace::argument::Signature;
-        use crate::translator::rtyper::pyre_call_registry::FunctionPathKey;
+        use crate::translator::rtyper::call_registry::FunctionPathKey;
         let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
         let mut graph = LegacyGraph::new("translate_op_fixture");
         let vars = mint_vars(&mut graph, 11); // vars[0..11]
@@ -5036,7 +5031,7 @@ mod tests {
         // fallback it would error instead.  Locks in the
         // exact-before-leaf-match precedence the resolver depends on.
         use crate::flowspace::argument::Signature;
-        use crate::translator::rtyper::pyre_call_registry::FunctionPathKey;
+        use crate::translator::rtyper::call_registry::FunctionPathKey;
         let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
         let mut graph = LegacyGraph::new("translate_op_fixture");
         let vars = mint_vars(&mut graph, 11); // vars[0..11]
@@ -5095,7 +5090,7 @@ mod tests {
         // captured by a registered `[mymod, ValueError]` free fn through
         // `lookup_with_leaf_match`.
         use crate::flowspace::argument::Signature;
-        use crate::translator::rtyper::pyre_call_registry::FunctionPathKey;
+        use crate::translator::rtyper::call_registry::FunctionPathKey;
         let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
         let mut graph = LegacyGraph::new("translate_op_fixture");
         let vars = mint_vars(&mut graph, 11); // vars[0..11]
@@ -5153,7 +5148,7 @@ mod tests {
 
     #[test]
     fn translate_op_call_function_path_falls_back_to_host_env_builtin() {
-        // Single-segment FunctionPath unregistered in PyreCallRegistry
+        // Single-segment FunctionPath unregistered in CallRegistry
         // falls back to HOST_ENV.lookup_builtin(name), letting frontend
         // `Expr::Cast` lowering emit
         // `Call { target: FunctionPath { segments: vec!["int"] }, args }`
@@ -5199,7 +5194,7 @@ mod tests {
 
     #[test]
     fn translate_op_call_function_path_resolves_host_module_attr_for_lltype_cast() {
-        // Multi-segment FunctionPath unregistered in PyreCallRegistry
+        // Multi-segment FunctionPath unregistered in CallRegistry
         // falls back to Layer 3 (HOST_ENV.import_module + module_get).
         // Mirrors upstream `LOAD_GLOBAL lltype` → `LOAD_ATTR cast_ptr_\
         // to_int` chain (`flowcontext.py:861-866`).  The resolved
@@ -5248,7 +5243,7 @@ mod tests {
     fn translate_op_call_function_path_rejects_unregistered_multi_segment_path() {
         // Defense-in-depth: an arbitrary multi-segment user path
         // (`some.unknown.module.path`) that misses every layer —
-        // PyreCallRegistry, HOST_ENV single-segment builtin, and
+        // CallRegistry, HOST_ENV single-segment builtin, and
         // HOST_ENV module attr (because `some.unknown.module` is not
         // curated in `populate_host_env`) — surfaces a `TyperError`
         // rather than a silent host-attribute resolution.  This pins
@@ -5277,7 +5272,7 @@ mod tests {
             .expect_err("Unregistered FunctionPath must surface TyperError, not silently resolve");
         let msg = format!("{err}");
         assert!(
-            msg.contains("not registered in PyreCallRegistry"),
+            msg.contains("not registered in CallRegistry"),
             "error must name the missing-registration invariant, got: {msg}"
         );
     }
@@ -5374,7 +5369,7 @@ mod tests {
 
     #[test]
     fn translate_op_stringbuilder_new_marker_lowers_to_newstringbuilder() {
-        // Bare `new()` `__pyre_stringbuilder_new` (front builder-mode ctor
+        // Bare `new()` `__majit_stringbuilder_new` (front builder-mode ctor
         // rewrite) → one `newstringbuilder` op with no operands; the annotator
         // types its result `SomeStringBuilder` and `rtype_newstringbuilder`
         // picks `ll_new(INIT_SIZE)` (`len(hop.args_v) == 0`).
@@ -5387,14 +5382,14 @@ mod tests {
             result: Some(vars[1].clone()),
             kind: OpKind::Call {
                 target: crate::model::CallTarget::FunctionPath {
-                    segments: vec!["__pyre_stringbuilder_new".into()],
+                    segments: vec!["__majit_stringbuilder_new".into()],
                 },
                 args: vec![],
                 result_ty: ValueType::Ref(None),
             },
         };
         let translated = translate_op(&op, &value_map, &empty_call_registry())
-            .expect("__pyre_stringbuilder_new marker must lower");
+            .expect("__majit_stringbuilder_new marker must lower");
         assert_eq!(translated.len(), 1);
         assert_eq!(translated[0].opname, "newstringbuilder");
         assert!(translated[0].args.is_empty());
@@ -5403,7 +5398,7 @@ mod tests {
 
     #[test]
     fn translate_op_stringbuilder_new_marker_forwards_with_capacity_size() {
-        // `with_capacity(n)` `__pyre_stringbuilder_new` → `newstringbuilder`
+        // `with_capacity(n)` `__majit_stringbuilder_new` → `newstringbuilder`
         // carrying the size operand `n`.  `rtype_newstringbuilder` then takes
         // the `len(hop.args_v) != 0` branch and threads `ll_new(n)`
         // (rtyper/rbuilder.py) instead of the `INIT_SIZE` default.
@@ -5418,14 +5413,14 @@ mod tests {
             result: Some(vars[1].clone()),
             kind: OpKind::Call {
                 target: crate::model::CallTarget::FunctionPath {
-                    segments: vec!["__pyre_stringbuilder_new".into()],
+                    segments: vec!["__majit_stringbuilder_new".into()],
                 },
                 args: vec![vars[2].clone()],
                 result_ty: ValueType::Ref(None),
             },
         };
         let translated = translate_op(&op, &value_map, &empty_call_registry())
-            .expect("__pyre_stringbuilder_new marker must lower");
+            .expect("__majit_stringbuilder_new marker must lower");
         assert_eq!(translated.len(), 1);
         assert_eq!(translated[0].opname, "newstringbuilder");
         assert_eq!(translated[0].args.len(), 1);
@@ -5435,7 +5430,7 @@ mod tests {
 
     #[test]
     fn translate_op_stringbuilder_append_marker_chains_getattr_simple_call() {
-        // `__pyre_stringbuilder_append(recv, piece)` → `getattr(recv,
+        // `__majit_stringbuilder_append(recv, piece)` → `getattr(recv,
         // "append") + simple_call(bound, piece)`, the same method shape as
         // `Vec::push`; reaches `StringBuilderRepr::rtype_method("append")`.
         let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
@@ -5450,14 +5445,14 @@ mod tests {
             result: Some(vars[3].clone()),
             kind: OpKind::Call {
                 target: crate::model::CallTarget::FunctionPath {
-                    segments: vec!["__pyre_stringbuilder_append".into()],
+                    segments: vec!["__majit_stringbuilder_append".into()],
                 },
                 args: vec![vars[1].clone(), vars[2].clone()],
                 result_ty: ValueType::Void,
             },
         };
         let translated = translate_op(&op, &value_map, &empty_call_registry())
-            .expect("__pyre_stringbuilder_append marker must lower");
+            .expect("__majit_stringbuilder_append marker must lower");
         assert_eq!(translated.len(), 2);
         assert_eq!(translated[0].opname, "getattr");
         assert_eq!(translated[0].args.len(), 2);
@@ -5478,7 +5473,7 @@ mod tests {
 
     #[test]
     fn translate_op_stringbuilder_build_marker_chains_getattr_simple_call() {
-        // `__pyre_stringbuilder_build(recv)` → `getattr(recv, "build") +
+        // `__majit_stringbuilder_build(recv)` → `getattr(recv, "build") +
         // simple_call(bound)`, the same shape as `slice.reverse` (no extra
         // arg); reaches `StringBuilderRepr::rtype_method("build")` →
         // `SomeString`.
@@ -5493,14 +5488,14 @@ mod tests {
             result: Some(vars[2].clone()),
             kind: OpKind::Call {
                 target: crate::model::CallTarget::FunctionPath {
-                    segments: vec!["__pyre_stringbuilder_build".into()],
+                    segments: vec!["__majit_stringbuilder_build".into()],
                 },
                 args: vec![vars[1].clone()],
                 result_ty: ValueType::Ref(None),
             },
         };
         let translated = translate_op(&op, &value_map, &empty_call_registry())
-            .expect("__pyre_stringbuilder_build marker must lower");
+            .expect("__majit_stringbuilder_build marker must lower");
         assert_eq!(translated.len(), 2);
         assert_eq!(translated[0].opname, "getattr");
         assert_eq!(translated[0].args[0], recv);
@@ -6739,7 +6734,7 @@ mod tests {
         use crate::model::CallTarget;
 
         let registry = empty_call_registry();
-        let key = crate::translator::rtyper::pyre_call_registry::FunctionPathKey::from_segments([
+        let key = crate::translator::rtyper::call_registry::FunctionPathKey::from_segments([
             "module", "function",
         ]);
         let func = crate::flowspace::model::GraphFunc::new(

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/llmemory.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/llmemory.rs
@@ -1116,16 +1116,10 @@ pub fn cast_any_ptr(expected: &Ptr, ptr: &_ptr) -> Result<_ptr, String> {
     }
     let is_weakref_ptr = |p: &Ptr| LowLevelType::Ptr(Box::new(p.clone())) == *WEAKREF_PTR;
     if is_weakref_ptr(expected) {
-        return Err(
-            "cast_ptr_to_weakrefptr requires the GC transformer, which pyre does not run"
-                .to_string(),
-        );
+        return Err("cast_ptr_to_weakrefptr requires a configured GC transformer".to_string());
     }
     if is_weakref_ptr(ptrtype) {
-        return Err(
-            "cast_weakrefptr_to_ptr requires the GC transformer, which pyre does not run"
-                .to_string(),
-        );
+        return Err("cast_weakrefptr_to_ptr requires a configured GC transformer".to_string());
     }
     if matches!(expected.TO, PtrTarget::Opaque(_)) || matches!(ptrtype.TO, PtrTarget::Opaque(_)) {
         return cast_opaque_ptr(expected, ptr);

--- a/majit/majit-translate/src/translator/rtyper/mod.rs
+++ b/majit/majit-translate/src/translator/rtyper/mod.rs
@@ -9,7 +9,7 @@
 //!   `legacy_resolve` are transitional bridges between pyre's legacy
 //!   `model::FunctionGraph` and the orthodox
 //!   `flowspace::FunctionGraph` / `RPythonTyper` path.
-//! * `pyre_call_registry` owns symbolic `FunctionPath` -> synthetic
+//! * `call_registry` owns symbolic `FunctionPath` -> synthetic
 //!   `HostObject` / `FunctionDesc` registration, because pyre has no
 //!   CPython callable object identity to key `Bookkeeper.descs`.
 //! * `pairtype` centralizes rtyper-side `class __extend__(pairtype(...))`
@@ -31,6 +31,7 @@
 
 pub mod annlowlevel;
 pub(crate) mod box_str_const_fold;
+pub(crate) mod call_registry;
 pub mod callparse;
 pub mod controllerentry;
 pub(crate) mod cutover;
@@ -48,7 +49,6 @@ pub mod llinterp;
 pub mod lltypesystem;
 pub mod normalizecalls;
 pub(crate) mod pairtype;
-pub(crate) mod pyre_call_registry;
 pub mod raddress;
 pub mod rbool;
 pub mod rbuilder;

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -238,16 +238,16 @@ fn install_default_typers(map: &mut HashMap<HostObject, BuiltinTyperFn>) {
         // WindowsError.__init__; HOST_ENV lookup preserves that conditional.
         ("WindowsError.__init__", rtype_WindowsError__init__),
         // Pyre-internal front-end pointer-downcast narrow (#298).  Keyed
-        // by the `__pyre_cast_instance` HOST_ENV singleton (same Arc the
+        // by the `__cast_instance_intrinsic` HOST_ENV singleton (same Arc the
         // adapter resolves the call's callable to), lowers to a
         // `cast_pointer` into the narrowed `InstanceRepr`.
-        ("__pyre_cast_instance", rtype_pyre_cast_instance),
+        ("__cast_instance_intrinsic", rtype_cast_instance_intrinsic),
         // The erasing twin (`p as *mut u8`).  Its annotator dropped the
         // pointee class, so `hop.r_result` is the classdef-less
         // `InstanceRepr` and the same `cast_pointer` body applies — this
         // time as the upcast direction of `pairtype(InstanceRepr,
         // InstanceRepr).convert_from_to`.
-        ("__pyre_cast_address", rtype_pyre_cast_instance),
+        ("__cast_address_intrinsic", rtype_cast_instance_intrinsic),
     ];
     for (name, typer) in entries {
         if let Some(host) = HOST_ENV.lookup_builtin(name) {
@@ -3622,8 +3622,8 @@ pub fn rtype_cast_int_to_ptr(hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>
 }
 
 /// Typer for both front-end pointer-cast markers — the
-/// `__pyre_cast_instance` downcast narrow (#298) and the
-/// `__pyre_cast_address` erasure.  Either way the annotator has already
+/// `__cast_instance_intrinsic` downcast narrow (#298) and the
+/// `__cast_address_intrinsic` erasure.  Either way the annotator has already
 /// decided the result's `InstanceRepr` (the target root, or the
 /// classdef-less shell), so `hop.r_result` names the destination and the
 /// call lowers to a `cast_pointer` of the pointer operand to that
@@ -3635,18 +3635,16 @@ pub fn rtype_cast_int_to_ptr(hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>
 /// `args[0]` is the pointer operand; the narrow's `args[1]` is the
 /// constant root name (read by the annotator, unused here — it carries
 /// no runtime value).
-pub fn rtype_pyre_cast_instance(
+pub fn rtype_cast_instance_intrinsic(
     hop: &HighLevelOp,
     _kwds_i: &HashMap<String, usize>,
 ) -> RTypeResult {
     use crate::translator::rtyper::rtyper::GenopResult;
 
-    let r_result = hop
-        .r_result
-        .borrow()
-        .as_ref()
-        .cloned()
-        .ok_or_else(|| TyperError::message("rtype_pyre_cast_instance: missing r_result"))?;
+    let r_result =
+        hop.r_result.borrow().as_ref().cloned().ok_or_else(|| {
+            TyperError::message("rtype_cast_instance_intrinsic: missing r_result")
+        })?;
     let result_lltype = r_result.lowleveltype().clone();
     // Validated operand extraction: a malformed call (wrong arity)
     // surfaces a `TyperError` here instead of panicking on a raw

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -5725,7 +5725,7 @@ mod tests {
                 ("parent".to_string(), "TypeObj".to_string()),
             ],
         );
-        ann.bookkeeper.set_pyre_struct_fields(std::rc::Rc::new(reg));
+        ann.bookkeeper.set_struct_fields(std::rc::Rc::new(reg));
         let cd = ann
             .bookkeeper
             .getuniqueclassdef_for_struct_root("Outer")

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -3282,7 +3282,7 @@ pub fn rtyper_makerepr(
         // rweakref.py:13-17
         SomeValue::WeakRef(_) => super::rweakref::weakref_makerepr(rtyper),
         SomeValue::TypeOf(_) => Err(TyperError::missing_rtype_operation(
-            "SomeTypeOf.rtyper_makerepr — no direct upstream counterpart; pyre adaptation",
+            "SomeTypeOf.rtyper_makerepr — no direct upstream counterpart; host-language adaptation",
         )),
         SomeValue::Ptr(ptr) => {
             Ok(std::sync::Arc::new(PtrRepr::new(ptr.ll_ptrtype.clone()))

--- a/majit/majit-translate/src/translator/rtyper/rpbc.rs
+++ b/majit/majit-translate/src/translator/rtyper/rpbc.rs
@@ -1101,10 +1101,10 @@ pub(crate) mod tests {
         use crate::parse::CallPath;
 
         // Control — the fill is engaged and rewrites the marker.
-        let wrapper = CallPath::from_segments(["helpers", "__pyre_wrap_add"]);
+        let wrapper = CallPath::from_segments(["helpers", "__majit_wrap_add"]);
         let mut with_wrappers = CallControl::new();
         with_wrappers
-            .register_function_graph(wrapper.clone(), JitFunctionGraph::new("__pyre_wrap_add"));
+            .register_function_graph(wrapper.clone(), JitFunctionGraph::new("__majit_wrap_add"));
         with_wrappers.register_function_fnaddr(wrapper.clone(), 0x1234);
         assert_eq!(
             with_wrappers.builtin_wrapper_indirect_graphs().to_vec(),

--- a/majit/majit-translate/src/translator/translator.rs
+++ b/majit/majit-translate/src/translator/translator.rs
@@ -262,7 +262,7 @@ pub struct TranslationContext {
     /// `getdesc → newfuncdesc → buildgraph` chain
     /// (`rpython/annotator/bookkeeper.py:353-409`) where the
     /// original exception propagates.
-    pub _pyre_lift_errors: RefCell<HashMap<HostObject, String>>,
+    pub _lift_errors: RefCell<HashMap<HostObject, String>>,
     /// RPython `self.entry_point_graph`. Set by
     /// `RPythonAnnotator.build_types(main_entry_point=True)`.
     pub entry_point_graph: RefCell<Option<GraphRef>>,
@@ -301,7 +301,7 @@ impl TranslationContext {
             graphs: RefCell::new(Vec::new()),
             callgraph: RefCell::new(HashMap::new()),
             _prebuilt_graphs: RefCell::new(HashMap::new()),
-            _pyre_lift_errors: RefCell::new(HashMap::new()),
+            _lift_errors: RefCell::new(HashMap::new()),
             entry_point_graph: RefCell::new(None),
         }
     }
@@ -354,9 +354,9 @@ impl TranslationContext {
         // where the original construction error propagates from the
         // lazy `cachedgraph` consumer
         // (`rpython/annotator/description.py:228`).
-        if let Some(lift_err) = self._pyre_lift_errors.borrow().get(&func).cloned() {
+        if let Some(lift_err) = self._lift_errors.borrow().get(&func).cloned() {
             return Err(format!(
-                "buildflowgraph({}): pyre-side lift failed during \
+                "buildflowgraph({}): source lift failed during \
                  populate_call_registry_from_call_graphs (recorded \
                  lazy-failure error): {lift_err}",
                 graph_func.name,

--- a/majit/majit-translate/tests/common/mod.rs
+++ b/majit/majit-translate/tests/common/mod.rs
@@ -9,7 +9,7 @@ use rustpython_compiler_core::bytecode::CodeObject;
 /// source contains no function body.
 pub fn compile_first_code(src: &str) -> CodeObject {
     let module =
-        rp_compile(src, Mode::Exec, "<pyre>", Default::default()).expect("compile should succeed");
+        rp_compile(src, Mode::Exec, "<flow>", Default::default()).expect("compile should succeed");
     module
         .constants
         .iter()

--- a/majit/majit-translate/tests/test_epic_acceptance_greps.rs
+++ b/majit/majit-translate/tests/test_epic_acceptance_greps.rs
@@ -1,7 +1,7 @@
 //! Source-level acceptance gates for structural RPython parity.
 //!
 //! The tests reject variant-keyed JitCode maps, a separate exception opname
-//! family, and the legacy `compile_pyre_interpreter` entry point. They scan
+//! family, and the legacy `compile_interpreter` entry point. They scan
 //! every MAJIT crate's `src` tree after stripping comments and normalizing
 //! whitespace, with positive controls that prove each selector still matches.
 
@@ -25,8 +25,8 @@ const VARIANT_KEYED_MAP: &[&str] = &[
 
 const NEW_OPNAME_FAMILY: &[&str] = &["_may_raise", "OpKind::Try", "TryOp"];
 
-/// `fn compile_pyre_interpreter` with its whitespace removed.
-const LEGACY_ENTRY_POINT: &[&str] = &["fncompile_pyre_interpreter"];
+/// `fn compile_interpreter` with its whitespace removed.
+const LEGACY_ENTRY_POINT: &[&str] = &["fncompile_interpreter"];
 
 /// Below this the walk is assumed broken rather than the tree assumed empty.
 /// A BRAKE, not a census pin — it is far below the population so that adding
@@ -338,16 +338,16 @@ fn no_new_opname_family_for_exceptions() {
     );
 }
 
-/// The legacy `compile_pyre_interpreter` entry point must not re-emerge. It
+/// The legacy `compile_interpreter` entry point must not re-emerge. It
 /// is replaced with `CodeWriter::make_jitcodes` (upstream `codewriter.py`).
 /// A surviving definition means the pyre-bytecode-walking path lives in
 /// parallel with the graph-keyed one.
 #[test]
-fn no_legacy_compile_pyre_interpreter() {
-    let hits = scan_forbidden("no_legacy_compile_pyre_interpreter", LEGACY_ENTRY_POINT);
+fn no_legacy_interpreter_compiler() {
+    let hits = scan_forbidden("no_legacy_interpreter_compiler", LEGACY_ENTRY_POINT);
     assert!(
         hits.is_empty(),
-        "Plan acceptance violated: `compile_pyre_interpreter` resurfaced. \
+        "Plan acceptance violated: `compile_interpreter` resurfaced. \
          It is replaced with `CodeWriter::make_jitcodes` \
          (`rpython/jit/codewriter/codewriter.py:74`). Remove the legacy \
          definition."
@@ -375,7 +375,7 @@ fn turbofish() { let _ = HashMap::<Instruction, u32>::new(); }
 fn ordered() -> BTreeMap<Instruction, u32> { todo!() }
 fn raising(x: u8) -> bool { x._may_raise() }
 struct S { t: TryOp, k: OpKind::Try }
-fn compile_pyre_interpreter() {}
+fn compile_interpreter() {}
 "###;
 
     let (dense, _lines) = normalise(&strip_comments(SYNTHETIC));
@@ -388,7 +388,7 @@ fn compile_pyre_interpreter() {}
         ("_may_raise", 1),
         ("OpKind::Try", 1),
         ("TryOp", 1),
-        ("fncompile_pyre_interpreter", 1),
+        ("fncompile_interpreter", 1),
     ];
     for &(pattern, want) in expected {
         let got = dense.matches(pattern).count();

--- a/majit/majit-translate/tests/test_fast2locals_codewriter.rs
+++ b/majit/majit-translate/tests/test_fast2locals_codewriter.rs
@@ -108,7 +108,7 @@ fn a_range_loops_next_yields_an_int_element() {
                 ..
             } = &op.kind
                 && segments.len() == 1
-                && segments[0] == "__pyre_range"
+                && segments[0] == "__majit_range"
                 && let Some(result) = &op.result
             {
                 range_results.push(result.clone());

--- a/majit/majit-translate/tests/test_fnptr_indirect.rs
+++ b/majit/majit-translate/tests/test_fnptr_indirect.rs
@@ -1,4 +1,4 @@
-//! `PYRE_FNPTR_INDIRECT` — how a call through a host-registered `fn`
+//! `MAJIT_FNPTR_INDIRECT` — how a call through a host-registered `fn`
 //! pointer lowers, in both states of the switch.
 //!
 //! Its own test binary, holding exactly one `#[test]`, because the switch is
@@ -94,7 +94,7 @@ fn fnptr_indirect_switch_moves_the_lowering_in_both_directions() {
     // environment mutation races.  This file's test binary holds exactly
     // one test, so nothing else in the process reads or writes the
     // environment while it runs.
-    unsafe { std::env::remove_var("PYRE_FNPTR_INDIRECT") };
+    unsafe { std::env::remove_var("MAJIT_FNPTR_INDIRECT") };
     for name in FIXTURES {
         assert_eq!(
             shape_of(&llbc, name),
@@ -106,7 +106,7 @@ fn fnptr_indirect_switch_moves_the_lowering_in_both_directions() {
         );
     }
 
-    unsafe { std::env::set_var("PYRE_FNPTR_INDIRECT", "1") };
+    unsafe { std::env::set_var("MAJIT_FNPTR_INDIRECT", "1") };
     for name in FIXTURES {
         assert_eq!(
             shape_of(&llbc, name),
@@ -118,5 +118,5 @@ fn fnptr_indirect_switch_moves_the_lowering_in_both_directions() {
         );
     }
 
-    unsafe { std::env::remove_var("PYRE_FNPTR_INDIRECT") };
+    unsafe { std::env::remove_var("MAJIT_FNPTR_INDIRECT") };
 }

--- a/majit/majit-translate/tests/test_make_jitcodes_produces_graph_keyed_output.rs
+++ b/majit/majit-translate/tests/test_make_jitcodes_produces_graph_keyed_output.rs
@@ -71,7 +71,7 @@ fn slow_generated_jitcodes_preserve_complete_dispatcher_graph() {
     // Or-pattern, or a missing wildcard without publishing an opcode side
     // table to production consumers.
     let llbc_paths: Vec<std::path::PathBuf> = std::env::split_paths(
-        &std::env::var_os("PYRE_MIR_FRONTEND_LLBC")
+        &std::env::var_os("MAJIT_MIR_FRONTEND_LLBC")
             .expect("ensure_workspace_llbc_env installs the LLBC path list"),
     )
     .collect();
@@ -380,12 +380,12 @@ fn assert_no_instruction_keyed_output_map() {
     );
 }
 
-/// Resolve workspace LLBC artefacts and export `PYRE_MIR_FRONTEND_LLBC`
-/// when they exist. The compact `PYRE_JIT_GRAPH_MODULES` fixture cannot rely on
+/// Resolve workspace LLBC artefacts and export `MAJIT_MIR_FRONTEND_LLBC`
+/// when they exist. The compact `JIT_GRAPH_MODULES` fixture cannot rely on
 /// production auto-discovery, so this release-only test opts in explicitly.
 /// Returns `false` when the artefacts are absent so the caller can skip.
 fn ensure_workspace_llbc_env() -> bool {
-    if std::env::var_os("PYRE_MIR_FRONTEND_LLBC").is_some() {
+    if std::env::var_os("MAJIT_MIR_FRONTEND_LLBC").is_some() {
         return true;
     }
     let workspace_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -412,7 +412,7 @@ fn ensure_workspace_llbc_env() -> bool {
     // SAFETY: `set_var` is unsafe in Rust 2024 because concurrent environment
     // mutation races. This release-only integration test configures the
     // process before the thread-local generated registry is initialized.
-    unsafe { std::env::set_var("PYRE_MIR_FRONTEND_LLBC", joined) };
+    unsafe { std::env::set_var("MAJIT_MIR_FRONTEND_LLBC", joined) };
     true
 }
 

--- a/majit/majit-translate/tests/test_mir_frontend.rs
+++ b/majit/majit-translate/tests/test_mir_frontend.rs
@@ -850,7 +850,7 @@ fn header_read_narrows_to_a_typed_field_read() {
                     ..
                 } if segments.as_slice()
                     == [
-                        "__pyre_cast_instance".to_string(),
+                        "__cast_instance_intrinsic".to_string(),
                         "ObjectHeader".to_string(),
                     ] =>
                 {
@@ -1042,7 +1042,7 @@ fn boxing_cluster_fuses_from_the_host_supplied_class_address() {
             else {
                 continue;
             };
-            if segments.first().map(String::as_str) != Some("__pyre_cast_instance") {
+            if segments.first().map(String::as_str) != Some("__cast_instance_intrinsic") {
                 continue;
             }
             let root = segments.get(1).cloned().unwrap_or_default();

--- a/majit/majit-translate/tests/test_mir_stress.rs
+++ b/majit/majit-translate/tests/test_mir_stress.rs
@@ -3,7 +3,7 @@
 //!
 //! Skipped by default: the snapshot is 133 MB and not checked into git
 //! (regenerable via `scripts/extract-llbc.py`). Set
-//! `PYRE_MIR_STRESS_LLBC=path/to/file.ullbc` to enable, or use the
+//! `MAJIT_MIR_STRESS_LLBC=path/to/file.ullbc` to enable, or use the
 //! default path the extractor writes to.
 
 use majit_charon_reader::Llbc;
@@ -18,7 +18,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 fn stress_path() -> Option<PathBuf> {
-    if let Ok(p) = std::env::var("PYRE_MIR_STRESS_LLBC") {
+    if let Ok(p) = std::env::var("MAJIT_MIR_STRESS_LLBC") {
         return Some(PathBuf::from(p));
     }
     let default = PathBuf::from(concat!(
@@ -520,10 +520,10 @@ fn arm_classifier(llbc: &Llbc) -> String {
 /// on a live `Err(Unsupported)` population and three zeros on an empty one
 /// are different readings, and the tally alone cannot tell them apart.
 #[test]
-#[ignore = "diagnostic; set PYRE_MIR_STRESS_LLBC"]
+#[ignore = "diagnostic; set MAJIT_MIR_STRESS_LLBC"]
 fn classify_uninitialised_local_rpo_vs_loop_carried() {
     let Some(path) = stress_path() else {
-        eprintln!("skip: set PYRE_MIR_STRESS_LLBC");
+        eprintln!("skip: set MAJIT_MIR_STRESS_LLBC");
         return;
     };
     let llbc = Llbc::load(&path).expect("load stress llbc");
@@ -783,11 +783,11 @@ fn classify_unwind_chain(
 
 #[test]
 #[ignore = "requires the 205MB pyre-interpreter.ullbc snapshot; \
-            set PYRE_MIR_STRESS_LLBC"]
+            set MAJIT_MIR_STRESS_LLBC"]
 fn mir_on_unwind_target_taxonomy() {
     let Some(path) = stress_path() else {
         eprintln!(
-            "skip: set PYRE_MIR_STRESS_LLBC or run scripts/extract-llbc.py to make \
+            "skip: set MAJIT_MIR_STRESS_LLBC or run scripts/extract-llbc.py to make \
              build/llbc/pyre-interpreter.ullbc available"
         );
         return;
@@ -918,7 +918,7 @@ fn mir_on_unwind_target_taxonomy() {
 
 #[test]
 #[ignore = "requires the 205MB pyre-interpreter.ullbc snapshot; \
-            set PYRE_MIR_STRESS_LLBC"]
+            set MAJIT_MIR_STRESS_LLBC"]
 fn coverage_gate_accepts_the_real_snapshot() {
     // The fail-loud coverage gate in `build_semantic_program_from_llbc`
     // must return `Ok` over the real snapshot: every current lowering
@@ -927,7 +927,7 @@ fn coverage_gate_accepts_the_real_snapshot() {
     // unrecognised error, this builder returns `Err` and the build
     // (and this test) fails loudly instead of silently dropping the fn.
     let Some(path) = stress_path() else {
-        eprintln!("skip: set PYRE_MIR_STRESS_LLBC");
+        eprintln!("skip: set MAJIT_MIR_STRESS_LLBC");
         return;
     };
     let llbc = Llbc::load(&path).expect("load stress llbc");
@@ -960,14 +960,14 @@ fn coverage_gate_accepts_the_real_snapshot() {
 /// after the change, then `diff`: the expected delta is exactly the 15
 /// forward-ref fns flipping `FAIL`->hash, with zero hash->hash changes.
 #[test]
-#[ignore = "diagnostic; set PYRE_MIR_STRESS_LLBC"]
+#[ignore = "diagnostic; set MAJIT_MIR_STRESS_LLBC"]
 fn dump_lowering_signatures() {
     use majit_translate::model::{ExitSwitch, FunctionGraph, LinkArg};
     use std::collections::HashMap;
     use std::hash::{Hash, Hasher};
 
     let Some(path) = stress_path() else {
-        eprintln!("skip: set PYRE_MIR_STRESS_LLBC");
+        eprintln!("skip: set MAJIT_MIR_STRESS_LLBC");
         return;
     };
     let llbc = Llbc::load(&path).expect("load stress llbc");

--- a/majit/majit-translate/tests/test_phase_d_find_all_graphs_parity.rs
+++ b/majit/majit-translate/tests/test_phase_d_find_all_graphs_parity.rs
@@ -20,7 +20,7 @@
 //!
 //! The test constructs a **minimal synthetic** dispatch graph (no
 //! pyre-interpreter source dependency) so the parity claim is isolated
-//! to BFS + policy interaction. The broader `test_pyre_find_all_graphs`
+//! to BFS + policy interaction. The broader `test_find_all_graphs`
 //! already covers the integration path on the real handler corpus.
 
 use majit_translate::{
@@ -244,7 +244,7 @@ fn find_all_graphs_leaves_unregistered_targets_as_residual() {
     // (`pypy.interpreter.astcompiler.*`, `rpython.rlib.rlocale`, …) so
     // those functions become residual calls even when the BFS would
     // otherwise follow them. Pyre uses a different but structurally
-    // equivalent mechanism: the `PYRE_JIT_GRAPH_MODULES` whitelist plus
+    // equivalent mechanism: the `JIT_GRAPH_MODULES` whitelist plus
     // `register_function_graph` plays the "allowed module" role, and an
     // unregistered callee is treated as residual by construction —
     // `find_all_graphs_bfs` at `call.rs` only pulls a callee into

--- a/majit/majit-translate/tests/test_result_exc_lowering.rs
+++ b/majit/majit-translate/tests/test_result_exc_lowering.rs
@@ -363,7 +363,7 @@ fn constant_message_raise_sites_fuse_their_constructor() {
     // `pyerror_type_error_to_exc_object`, leaving no `PyError` constructor
     // behind: the constructor is transparent, has no host symbol, and one of
     // them anywhere in the body refuses the whole descent.
-    let (fused, materialise, ctors) = raise_path_calls("__pyre_wrap_random");
+    let (fused, materialise, ctors) = raise_path_calls("__majit_wrap_random");
     assert!(fused > 0, "the fusion must fire on a gateway wrapper");
     assert_eq!(ctors, 0, "no PyError constructor may survive");
     assert_eq!(materialise, 0, "no unfused materialisation may survive");
@@ -375,7 +375,7 @@ fn formatted_message_raise_sites_keep_the_two_call_form() {
     // result is not the `box_str_constant` object the helper reads. Those
     // sites must keep the constructor plus `pyerror_to_exc_object`: the
     // fusion is additive and never replaces its own fallback.
-    let (fused, materialise, ctors) = raise_path_calls("__pyre_wrap___class_getitem__");
+    let (fused, materialise, ctors) = raise_path_calls("__majit_wrap___class_getitem__");
     assert_eq!(fused, 0, "a formatted message must not fuse");
     assert!(
         ctors > 0,

--- a/pyre/bench/synth/_pending/caller_f_lasti_across_residual_call.py
+++ b/pyre/bench/synth/_pending/caller_f_lasti_across_residual_call.py
@@ -89,7 +89,7 @@
 # torn at a resume; here nothing resumes, a live reader just reads the field.
 # That filing lists four more refuted attempts -- read it too.
 #
-# HOW THIS SURFACED.  `a67442cccb0` listed `PyreHelperKind::LoadDeref` as a
+# HOW THIS SURFACED.  `a67442cccb0` listed `RuntimeHelperKind::LoadDeref` as a
 # replay-safe read, which classified every freevar-reading callee
 # `DeferredCall` and let it inline; `b6d9cc510cd` then denied such a callee
 # from its first vable escape so the enclosing loop would stop being retired by

--- a/pyre/bench/synth/foriter57/for_attr_abort.py
+++ b/pyre/bench/synth/foriter57/for_attr_abort.py
@@ -9,14 +9,14 @@ def f():
     for x in range(500):
         # `o.n += 1` is a concrete NON-journaled, NON-idempotent heap mutation
         # (a STORE_ATTR via the residual `store_attr_fn`, which carries
-        # `PyreHelperKind::None` and is covered by NO journal) that COMMITS
+        # `RuntimeHelperKind::None` and is covered by NO journal) that COMMITS
         # before a later op in the same iteration aborts the trace.
         # `seen.append` is the abort trigger (its inline sub-walk declines);
         # it exists only to force the in-body abort AFTER the attr store has
         # committed.
         #
         # The OLD R1 guard flagged a body effect ONLY for a tiny allow-list of
-        # `PyreHelperKind`s (`StoreSubscr` / `CallFn` / `SetCurrentException`),
+        # `RuntimeHelperKind`s (`StoreSubscr` / `CallFn` / `SetCurrentException`),
         # so this `None`-tagged store was never flagged: the guard delivered the
         # in-flight FOR_ITER item and re-ran the whole body, DOUBLING the
         # accumulate (o.n over-counts by the number of aborts → 500 + #aborts).

--- a/pyre/bench/synth/foriter57/for_deref_abort.py
+++ b/pyre/bench/synth/foriter57/for_deref_abort.py
@@ -7,7 +7,7 @@ def make():
         for x in range(500):
             # `n += 1` on a closure free variable lowers to STORE_DEREF, whose
             # `store_deref_value` residual is a VALUE-returning (`Ref`) in-place
-            # cell write carrying `PyreHelperKind::StoreDeref`.  It commits a
+            # cell write carrying `RuntimeHelperKind::StoreDeref`.  It commits a
             # NON-journaled heap mutation before the later `seen.append` aborts
             # the trace.
             #

--- a/pyre/bench/synth/foriter57/for_prop_abort.py
+++ b/pyre/bench/synth/foriter57/for_prop_abort.py
@@ -16,7 +16,7 @@ def f():
     seen = []
     for x in range(500):
         # `obj.p` lowers to a value-returning `load_attr` residual
-        # (`PyreHelperKind::None`, `Ref` result, `MayForce`): the OLD R1
+        # (`RuntimeHelperKind::None`, `Ref` result, `MayForce`): the OLD R1
         # write-discriminator (Void result OR a CallFn/StoreSubscr/
         # SetCurrentException/StoreDeref tag) does NOT see it, so its
         # getter side effect (`O.hits += 1`) escaped the body-effect flag.

--- a/pyre/bench/synth/foriter57/for_prop_raise_abort.py
+++ b/pyre/bench/synth/foriter57/for_prop_raise_abort.py
@@ -18,7 +18,7 @@ def f():
     seen = []
     for x in range(500):
         # `obj.p` lowers to a value-returning `load_attr` residual
-        # (`PyreHelperKind::None`, `Ref` result, `MayForce`).  Its getter
+        # (`RuntimeHelperKind::None`, `Ref` result, `MayForce`).  Its getter
         # frame mutates `Obj.hits` and raises; the raise takes the residual's
         # Err arm.  The R1 body-effect marking used to run ONLY on the Ok arm,
         # so the Err arm left the in-flight FOR_ITER item's body-effect flag

--- a/pyre/bench/synth/inline_freevar_after_mayforce.py
+++ b/pyre/bench/synth/inline_freevar_after_mayforce.py
@@ -107,7 +107,7 @@ from fractions import Fraction
 # DO NOT RE-RECORD `loops_compiled` here on a six. Seven is base-dependent,
 # not merely a value some tree happens to produce. Measured across three CI
 # runs: main alone at base `5bf59e1f008` reads seven and passes (32565716769);
-# a branch adding `PyreHelperKind::LoadDeref` to the replay-safe read set reads
+# a branch adding `RuntimeHelperKind::LoadDeref` to the replay-safe read set reads
 # seven on the older base `68a6351bfbf` and passes (32556952922); the *same*
 # six commits on `5bf59e1f008` read six and fail (32572034383). On that branch
 # the loop that goes missing is `forward`'s own portal trace, which vanishes

--- a/pyre/bench/synth/list_append_write_barrier_gc.py
+++ b/pyre/bench/synth/list_append_write_barrier_gc.py
@@ -13,7 +13,7 @@
 # executor.py:446). These cases pin what that suppression must not break: an
 # OLD list whose block is already promoted receiving YOUNG elements. If the
 # store went unremembered, a minor collection would never scan the slot and the
-# element would be freed or read back stale. Run with PYRE_GC_ITEMSBLOCK=0 too
+# element would be freed or read back stale. Run with MAJIT_GC_ITEMSBLOCK=0 too
 # — there the block is std::alloc with no GC header, the barrier on the
 # W_ListObject is load-bearing, and the walker must keep emitting it.
 # Output verified against CPython/PyPy.

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -2097,7 +2097,7 @@ def workspace_member_dirs():
     return members
 
 
-# The package whose build script reads `PYRE_MIR_FRONTEND_LLBC`. `cargo` runs a
+# The package whose build script reads `MAJIT_MIR_FRONTEND_LLBC`. `cargo` runs a
 # build script with its own package directory as the working directory, so that
 # is what a relative entry in the override is relative to — not this script's.
 LLBC_OVERRIDE_BASE = "pyre/pyre-jit-trace"
@@ -2107,7 +2107,7 @@ def llbc_input_paths():
     """The LLBC artefacts the JIT front end will actually read.
 
     `majit_translate::build_semantic_program_via_active_frontend` reads them from
-    `PYRE_MIR_FRONTEND_LLBC` (an OS path-list) before falling back to the
+    `MAJIT_MIR_FRONTEND_LLBC` (an OS path-list) before falling back to the
     workspace `build/llbc`, so a run under that override is built against
     different bytes than the default glob names.
 
@@ -2120,7 +2120,7 @@ def llbc_input_paths():
     value however often the real artefact is rewritten, so `--no-build` would
     approve a generated JIT front end built from an LLBC that has since moved.
     """
-    override = os.environ.get("PYRE_MIR_FRONTEND_LLBC")
+    override = os.environ.get("MAJIT_MIR_FRONTEND_LLBC")
     if override:
         return [
             entry if os.path.isabs(entry)

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -52,9 +52,9 @@ OFF path is a needed safety net. Retire at the listed trigger (A7).
 
 | var | subsystem | retire when |
 |---|---|---|
-| PYRE_MIR_FRAMESTATE | framestate-threaded MIR lowering | MIR front-end #176/#181/#346 |
-| PYRE_GC_ITEMSBLOCK, PYRE_GC_PREBUILT_REMEMBER, PYRE_GC_INTERP, PYRE_GC_INTERP_COLLECT | GC-managed items / prebuilt minor-skip / interpreter allocation + collect rollback | WS3 / #355 / F3 GC rework |
-| PYRE_CL_NO_CLOSING_JUMP | cranelift attached-loop closing jump | #245 cranelift perf (explicit rollback hatch) |
+| MAJIT_MIR_FRAMESTATE | framestate-threaded MIR lowering | MIR front-end #176/#181/#346 |
+| MAJIT_GC_ITEMSBLOCK, PYRE_GC_PREBUILT_REMEMBER, PYRE_GC_INTERP, PYRE_GC_INTERP_COLLECT | GC-managed items / prebuilt minor-skip / interpreter allocation + collect rollback | WS3 / #355 / F3 GC rework |
+| MAJIT_CL_NO_CLOSING_JUMP | cranelift attached-loop closing jump | #245 cranelift perf (explicit rollback hatch) |
 
 `PYRE_GC_INTERP` is default-ON on every target. Its OFF path still selects the
 unmanaged `malloc_typed` stepping-stone allocation and remains a rollback hatch
@@ -67,13 +67,13 @@ Kept as-is; listed for completeness.
 - **Diagnostics (~35, default-OFF)** — print/log/dump/probe/assert only; tooling,
   not experiments: `PYRE_FBW_DEBUG_ABORT`, `_INLINE_DIAG`, `_MF_DIAG`,
   `_STRICT_DIAG`, `PYRE_WALK_PERFN_JITCODE`, `PYRE_DUMP_PERFN_JITCODE`,
-  `PYRE_P2_DIAG`, `PYRE_PCDEP_VALIDATE`, `PYRE_MIR_FRAMESTATE_DEBUG`,
-  `_FRAMESTATE_STRICT`, `PYRE_MIR_FRONTEND_DEBUG`, `PYRE_VSTACK_DIAG`,
+  `PYRE_P2_DIAG`, `PYRE_PCDEP_VALIDATE`, `MAJIT_MIR_FRAMESTATE_DEBUG`,
+  `_FRAMESTATE_STRICT`, `MAJIT_MIR_FRONTEND_DEBUG`, `PYRE_VSTACK_DIAG`,
   `PYRE_PROBE_AUTHORITATIVE`, `_BH_STARTUP`, `_SNAPSHOT`, `_SUBSCR`,
-  `PYRE_S9_PROBE`, `PYRE_PROFILE_DRAIN`, `_PIPELINE`, `PYRE_MFRAME_DIAG`,
-  `PYRE_RTYPER_VERBOSE`, `PYRE_JTRANSFORM_SHADOW`, `PYRE_DIAG124C`, `_51C`,
+  `MAJIT_S9_PROBE`, `MAJIT_PROFILE_DRAIN`, `_PIPELINE`, `PYRE_MFRAME_DIAG`,
+  `MAJIT_RTYPER_VERBOSE`, `MAJIT_JTRANSFORM_SHADOW`, `PYRE_DIAG124C`, `_51C`,
   `_GIN`, `_INLINE_RECOG`, `PYRE_WASM_DUMP_ALL_TRACES`, `_DUMP_BAD_TRACE`,
-  `_EXEC_TRACE`, `_JIT_STATS`, `PYRE_INTERP_RETURN_LOG`, `PYRE_NBODY_DEBUG`,
+  `_EXEC_TRACE`, `_JIT_STATS`, `PYRE_INTERP_RETURN_LOG`, `MAJIT_NBODY_DEBUG`,
   `PYRE_DEBUG_CALL`, `PYRE_DEBUG_CLASS`, `PYRE_DESCR_DEMAND`.
   `PYRE_DESCR_DEMAND` records the distinct dense descriptor indices a run
   actually resolves, so the per-index pool loader can be measured against the
@@ -87,11 +87,11 @@ Kept as-is; listed for completeness.
   §6a2 are wasm A/Bs, kept as the switched-off side of a one-binary
   comparison rather than as experiments.
 - **Config / value / master switches (~16)** — tuning, paths, modes; keep:
-  `PYRE_MIR_FRONTEND_LLBC`, `PYRE_WASM_ENGINE`, `_FUEL`, `_MODULE`, `_NO_CACHE`,
+  `MAJIT_MIR_FRONTEND_LLBC`, `PYRE_WASM_ENGINE`, `_FUEL`, `_MODULE`, `_NO_CACHE`,
   `PYRE_GC_INTERP`, `PYRE_JIT`, `PYRE_NO_JIT`, `PYRE_STDLIB`,
   `PYRE_CHECK_PYPY3`, `PYRE_CHECK_PYTHON3`, `PYRE_SANDBOX_NO_SECCOMP`,
   `PYRE_SHARED_BUILD`, `PYRE_SYNTH_PYPY`, `PYRE_SYNTH_PYRE`, `PYRE_SYNTH_PYTHON`.
-- **Test harness (1)**: `PYRE_MIR_STRESS_LLBC`.
+- **Test harness (1)**: `MAJIT_MIR_STRESS_LLBC`.
 
 ## §6 — The 66 gates the audits never listed (2026-08-07)
 
@@ -207,8 +207,8 @@ build.
 `PYRE_FBW_MAX_SUBWALK_DEPTH`, `PYRE_FBW_MULTIFRAME_DEPTH`,
 `PYRE_FBW_NO_SPECIALIZE`, `PYRE_JD1_THRESHOLD`,
 `PYRE_PCMAP_RECIPE_RESULTCOLOR_AUDIT_PROBE`,
-`PYRE_DTRACE_CONST_FROM`, `PYRE_DTRACE_CONST_TO`,
-`PYRE_TRACE_CALL_DIAG`, `PYRE_TRACE_OPS_DIAG`,
+`MAJIT_DTRACE_CONST_FROM`, `MAJIT_DTRACE_CONST_TO`,
+`MAJIT_TRACE_CALL_DIAG`, `MAJIT_TRACE_OPS_DIAG`,
 `PYRE_WASM_FORCE_CA_TERMINAL_DECLINE`, `PYRE_WASM_FUEL`,
 `PYRE_WASM_GUEST_PROFILE`, `PYRE_WASM_MODULE`.
 
@@ -237,30 +237,30 @@ Each is inert unless set, so none is a removal target by this file's
 already-ON criterion. They are listed so they cannot be missed again.
 
 `PYRE_ALLOCSITES`, `PYRE_BH_NULL_ARG`, `PYRE_BRIDGE_LATCH_AUDIT`,
-`PYRE_CALLEE_RCA`, `PYRE_CATCH_LIVE_CENSUS`,
+`MAJIT_CALLEE_RCA`, `PYRE_CATCH_LIVE_CENSUS`,
 `PYRE_CELL_CENSUS`, `PYRE_CHECK_INHERIT_ENV`,
 `PYRE_DESCR_SPELLING_GATE`,
 `PYRE_DEOPT_PROBE`, `PYRE_DIAG_51C`, `PYRE_DIAG_GIN`, `PYRE_DIAG_INLINE_RECOG`,
-`PYRE_DETERMINISM_TRACE`, `PYRE_DTRACE_CONST_BT`,
-`PYRE_DYNASM_EXEC_DIAG`, `PYRE_FBW_CENSUS`, `PYRE_FBW_DEPTH_CENSUS`,
+`MAJIT_DETERMINISM_TRACE`, `MAJIT_DTRACE_CONST_BT`,
+`MAJIT_DYNASM_EXEC_DIAG`, `PYRE_FBW_CENSUS`, `PYRE_FBW_DEPTH_CENSUS`,
 `PYRE_FBW_DESCENT_SCAN_OFF`, `PYRE_FBW_INLINE_DIAG`,
 `PYRE_FBW_LOOPBODY_SCAN_FULL`, `PYRE_FBW_LOOPBODY_SCAN_LOOP_ONLY`,
 `PYRE_FBW_MF_DIAG`, `PYRE_FBW_REPLAY_DIRTY_BODY`, `PYRE_FBW_SPEC_CENSUS`,
 `PYRE_FBW_STRICT_DIAG`,
 `PYRE_FIELD_IDENTITY_CENSUS`,
 `PYRE_FORITER_INFLIGHT_CENSUS`, `PYRE_FOR_ITER_GATE_DIAG`,
-`PYRE_GC_DIAG`, `PYRE_GC_FREELIST_DIAG`, `PYRE_GEN_ENTRY_DIAG`,
+`PYRE_GC_DIAG`, `MAJIT_GC_FREELIST_DIAG`, `PYRE_GEN_ENTRY_DIAG`,
 `PYRE_JD1_DEBUG`, `PYRE_JD1_DUMP`,
 `PYRE_LB_SITE`, `PYRE_LLBC_SKIP_FINGERPRINT_CHECK`, `PYRE_LLBC_STRICT`,
 `PYRE_M73_BACKXLAT_TWIN_AUDIT`, `PYRE_M73_EMPTYTWIN_CENSUS`,
 `PYRE_M73_LASTINSTR_AUDIT`, `PYRE_M73_MIDBODY_CARRY_AUDIT`,
 `PYRE_MAJIT_STATS_ANCESTOR`, `PYRE_MAJIT_STATS_ROOT_ONLY`, `PYRE_MC_DIAG`,
-`PYRE_MIR_FRAMESTATE_STRICT`, `PYRE_NO_JD1`, `PYRE_NO_UNROLL`,
+`MAJIT_MIR_FRAMESTATE_STRICT`, `PYRE_NO_JD1`, `MAJIT_NO_UNROLL`,
 `PYRE_PCMAP_AFTERRESIDUAL_AUDIT`, `PYRE_PCMAP_CONTAINING_AUDIT`,
 `PYRE_PCMAP_RECIPE_RESULTCOLOR_AUDIT`, `PYRE_PCMAP_RESIDUAL_CENSUS`,
-`PYRE_PORTAL_RCA`, `PYRE_PROBE_BH_STARTUP`, `PYRE_PROBE_SNAPSHOT`,
-`PYRE_PROBE_SUBSCR`, `PYRE_PROFILE_PIPELINE`, `PYRE_QMUT_MAPDICT_FORCE`,
-`PYRE_RERAISE_DIAG`, `PYRE_SIZE_SHELL_OWNERS`, `PYRE_SNAPSHOT_DIAG`,
+`MAJIT_PORTAL_RCA`, `PYRE_PROBE_BH_STARTUP`, `PYRE_PROBE_SNAPSHOT`,
+`MAJIT_PROBE_SUBSCR`, `MAJIT_PROFILE_PIPELINE`, `PYRE_QMUT_MAPDICT_FORCE`,
+`PYRE_RERAISE_DIAG`, `MAJIT_SIZE_SHELL_OWNERS`, `PYRE_SNAPSHOT_DIAG`,
 `PYRE_UNJOURNALED_SITE`,
 `PYRE_VSTACK_EXACT_AUDIT`, `PYRE_VSTACK_KEEP_REORDER`, `PYRE_VSTACK_NO_EXACT`,
 `PYRE_WASM_DUMP_BAD_TRACE`, `PYRE_WASM_EXEC_TRACE`, `PYRE_WASM_FBW_CENSUS`,
@@ -313,20 +313,11 @@ gate restores the whole-environment copy, so the size of that effect stays
 measurable on one binary. It goes when the allowlist stops being the thing
 under measurement.
 
-## §7 — General MAJIT gates
-
-These translator and metainterpreter controls are inert unless explicitly set,
-except for the function-pointer lowering switch, which is a build configuration
-input.
+## §7 — Additional runtime diagnostic
 
 | gate | default polarity | what it gates / retirement condition |
 |---|---|---|
-| `PYRE_CALLEE_CENSUS` | OFF | build-time census of resolved and unresolved callees; retire when all supported callees are classified without this diagnostic |
-| `PYRE_CALLEE_CENSUS_ROWS` | OFF | row cap for that census; retire with `PYRE_CALLEE_CENSUS` |
-| `PYRE_DESCR_POOL_CENSUS` | OFF | reports descriptor interning and duplication; retire when descriptor identity is covered by ordinary tests |
-| `PYRE_FNPTR_INDIRECT` | OFF | enables indirect function-pointer lowering; retained as a build configuration switch |
 | `PYRE_PROBE14` | OFF | reports discarded reference-constant relocations; retire when relocation preservation is covered by ordinary tests |
-| `PYRE_VABLE_IDX_PROBE` | OFF | reports whether virtualizable array indices are constant; retire when all supported index shapes are covered by ordinary tests |
 
 ## Summary
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2900,7 +2900,7 @@ pub fn install_default_builtins(ns: PyObjectRef) {
         // keyword is rejected with "takes no keyword arguments".
         crate::gateway::make_module_builtin_function_with_arity_and_sig(
             "len",
-            __pyre_wrap_builtin_len,
+            __majit_wrap_builtin_len,
             1,
             crate::gateway::Signature::new(vec!["obj"], None, None, 0, 1),
         )
@@ -2911,7 +2911,7 @@ pub fn install_default_builtins(ns: PyObjectRef) {
         // keyword is rejected with "takes no keyword arguments".
         crate::gateway::make_module_builtin_function_with_arity_and_sig(
             "abs",
-            __pyre_wrap_builtin_abs,
+            __majit_wrap_builtin_abs,
             1,
             crate::gateway::Signature::new(vec!["val"], None, None, 0, 1),
         )
@@ -2944,7 +2944,7 @@ pub fn install_default_builtins(ns: PyObjectRef) {
     });
     crate::module_ns_get_or_insert_with(ns, "type", crate::typedef::w_type);
     crate::module_ns_get_or_insert_with(ns, "isinstance", || {
-        make_module_builtin_function_with_arity("isinstance", __pyre_wrap_builtin_isinstance, 2)
+        make_module_builtin_function_with_arity("isinstance", __majit_wrap_builtin_isinstance, 2)
     });
     crate::module_ns_get_or_insert_with(ns, "str", || crate::typedef::gettypeobject(&STR_TYPE));
     crate::module_ns_get_or_insert_with(ns, "repr", || {
@@ -3749,7 +3749,7 @@ pub fn install_default_builtins(ns: PyObjectRef) {
         // `baseobjspace.py:730` keeps that same object as
         // `space.w_default_importlib_import`.
         let w_import =
-            make_module_builtin_function("__import__", __pyre_wrap_builtin_dunder_import);
+            make_module_builtin_function("__import__", __majit_wrap_builtin_dunder_import);
         crate::importing::set_default_importlib_import(w_import);
         w_import
     });
@@ -4441,7 +4441,7 @@ pub(crate) fn builtin_range(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 }
 
 /// True iff `callable` is the builtin `len` function object — a
-/// builtin-code function whose code wraps [`__pyre_wrap_builtin_len`].  The JIT
+/// builtin-code function whose code wraps [`__majit_wrap_builtin_len`].  The JIT
 /// walker uses this to recognize a `len(x)` residual it can lower to the
 /// container's inline length read.
 pub fn is_builtin_len_function(callable: PyObjectRef) -> bool {
@@ -4455,7 +4455,7 @@ pub fn is_builtin_len_function(callable: PyObjectRef) -> bool {
         }
         crate::gateway::builtin_code_fn_eq(
             crate::gateway::builtin_code_get(code),
-            __pyre_wrap_builtin_len as crate::gateway::BuiltinCodeFn,
+            __majit_wrap_builtin_len as crate::gateway::BuiltinCodeFn,
         )
     }
 }
@@ -4595,7 +4595,7 @@ pub fn is_builtin_isinstance_function(callable: PyObjectRef) -> bool {
         }
         crate::gateway::builtin_code_fn_eq(
             crate::gateway::builtin_code_get(code),
-            __pyre_wrap_builtin_isinstance as crate::gateway::BuiltinCodeFn,
+            __majit_wrap_builtin_isinstance as crate::gateway::BuiltinCodeFn,
         )
     }
 }
@@ -4634,7 +4634,7 @@ fn builtin_len(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// wrapper must keep the same shape.
 /// Builtins installed by hand must publish the equivalent `BuiltinCode.func`
 /// PBC member so source translation can discover and codewrite its graph.
-pub fn __pyre_wrap_builtin_len(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_builtin_len(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.len() != 1 {
         return builtin_len(args);
     }
@@ -4645,10 +4645,10 @@ pub fn __pyre_wrap_builtin_len(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
 #[cfg(not(target_arch = "wasm32"))]
 #[linkme::distributed_slice(crate::gateway::BUILTIN_WRAPPER_DESCRIPTORS)]
 #[allow(non_upper_case_globals)]
-static __pyre_wrap_builtin_len_target: crate::gateway::BuiltinWrapperDescriptor =
+static __majit_wrap_builtin_len_target: crate::gateway::BuiltinWrapperDescriptor =
     crate::gateway::BuiltinWrapperDescriptor {
-        path: concat!(module_path!(), "::", "__pyre_wrap_builtin_len"),
-        func: __pyre_wrap_builtin_len,
+        path: concat!(module_path!(), "::", "__majit_wrap_builtin_len"),
+        func: __majit_wrap_builtin_len,
     };
 
 /// `abs(x)` — return the absolute value of a number.
@@ -4790,7 +4790,7 @@ fn abs_bad_operand(obj: PyObjectRef) -> crate::PyError {
     ))
 }
 
-pub fn __pyre_wrap_builtin_abs(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_builtin_abs(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.len() != 1 {
         return builtin_abs(args);
     }
@@ -4801,10 +4801,10 @@ pub fn __pyre_wrap_builtin_abs(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
 #[cfg(not(target_arch = "wasm32"))]
 #[linkme::distributed_slice(crate::gateway::BUILTIN_WRAPPER_DESCRIPTORS)]
 #[allow(non_upper_case_globals)]
-static __pyre_wrap_builtin_abs_target: crate::gateway::BuiltinWrapperDescriptor =
+static __majit_wrap_builtin_abs_target: crate::gateway::BuiltinWrapperDescriptor =
     crate::gateway::BuiltinWrapperDescriptor {
-        path: concat!(module_path!(), "::", "__pyre_wrap_builtin_abs"),
-        func: __pyre_wrap_builtin_abs,
+        path: concat!(module_path!(), "::", "__majit_wrap_builtin_abs"),
+        func: __majit_wrap_builtin_abs,
     };
 
 /// Strip the trailing `__pyre_kw__` dict that `call_with_kwargs`
@@ -4844,7 +4844,7 @@ pub(crate) fn split_builtin_kwargs(args: &[PyObjectRef]) -> (&[PyObjectRef], Opt
 /// so the true positional count is the prefix before the first PY_NULL.
 /// A single named function keeps the count off the annotator's shared
 /// iterator-adapter graph: a `take_while` closure inlined per wrapper gives
-/// every `__pyre_wrap_*` shim its own closure type, and merging those
+/// every `__majit_wrap_*` shim its own closure type, and merging those
 /// distinct types on one `TakeWhile` graph's input has no common base class.
 #[majit_macros::unroll_safe]
 pub(crate) fn leading_non_null_count(args: &[PyObjectRef]) -> usize {
@@ -6306,7 +6306,9 @@ fn builtin_isinstance(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
 /// wrapper must keep the same shape.
 /// Builtins installed by hand must publish the equivalent `BuiltinCode.func`
 /// PBC member so source translation can discover and codewrite its graph.
-pub fn __pyre_wrap_builtin_isinstance(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_builtin_isinstance(
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
     if args.len() != 2 {
         return builtin_isinstance(args);
     }
@@ -6318,10 +6320,10 @@ pub fn __pyre_wrap_builtin_isinstance(args: &[PyObjectRef]) -> Result<PyObjectRe
 #[cfg(not(target_arch = "wasm32"))]
 #[linkme::distributed_slice(crate::gateway::BUILTIN_WRAPPER_DESCRIPTORS)]
 #[allow(non_upper_case_globals)]
-static __pyre_wrap_builtin_isinstance_target: crate::gateway::BuiltinWrapperDescriptor =
+static __majit_wrap_builtin_isinstance_target: crate::gateway::BuiltinWrapperDescriptor =
     crate::gateway::BuiltinWrapperDescriptor {
-        path: concat!(module_path!(), "::", "__pyre_wrap_builtin_isinstance"),
-        func: __pyre_wrap_builtin_isinstance,
+        path: concat!(module_path!(), "::", "__majit_wrap_builtin_isinstance"),
+        func: __majit_wrap_builtin_isinstance,
     };
 
 /// isinstance(obj, cls) for JIT fast path.
@@ -19700,10 +19702,10 @@ fn builtin_dunder_import(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 /// `BuiltinCode.func` wrapper is therefore a member of the annotator's PBC
 /// family and the meta-interpreter can descend through it.  Hand-written
 /// builtins have to publish that wrapper explicitly in pyre (the same shape
-/// used by `__pyre_wrap_builtin_len` below), otherwise an `IMPORT_NAME`
+/// used by `__majit_wrap_builtin_len` below), otherwise an `IMPORT_NAME`
 /// reached through the ordinary CALL path stops at an opaque native function
 /// pointer instead of tracing `dunder_import` / `gcd_import_fast`.
-pub fn __pyre_wrap_builtin_dunder_import(
+pub fn __majit_wrap_builtin_dunder_import(
     args: &[PyObjectRef],
 ) -> Result<PyObjectRef, crate::PyError> {
     builtin_dunder_import(args)
@@ -19712,10 +19714,10 @@ pub fn __pyre_wrap_builtin_dunder_import(
 #[cfg(not(target_arch = "wasm32"))]
 #[linkme::distributed_slice(crate::gateway::BUILTIN_WRAPPER_DESCRIPTORS)]
 #[allow(non_upper_case_globals)]
-static __pyre_wrap_builtin_dunder_import_target: crate::gateway::BuiltinWrapperDescriptor =
+static __majit_wrap_builtin_dunder_import_target: crate::gateway::BuiltinWrapperDescriptor =
     crate::gateway::BuiltinWrapperDescriptor {
-        path: concat!(module_path!(), "::", "__pyre_wrap_builtin_dunder_import"),
-        func: __pyre_wrap_builtin_dunder_import,
+        path: concat!(module_path!(), "::", "__majit_wrap_builtin_dunder_import"),
+        func: __majit_wrap_builtin_dunder_import,
     };
 
 #[cfg(test)]
@@ -20020,7 +20022,7 @@ mod tests {
         crate::typedef::init_typeobjects();
         let isinstance = make_module_builtin_function_with_arity(
             "isinstance",
-            __pyre_wrap_builtin_isinstance,
+            __majit_wrap_builtin_isinstance,
             2,
         );
         let renamed_isinstance =

--- a/pyre/pyre-interpreter/src/cpyext/bytesobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/bytesobject.rs
@@ -143,7 +143,7 @@ pub(super) fn realize_pending(raw: *mut CPyObject) {
     pyobject::link_allocated(
         pyre_object::gc_roots::shadow_stack_get(slot),
         raw,
-        pyobject::REFCNT_FROM_PYRE + refcnt,
+        pyobject::REFCNT_FROM_PYPY + refcnt,
     );
 }
 

--- a/pyre/pyre-interpreter/src/cpyext/frameobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/frameobject.rs
@@ -13,7 +13,7 @@
 //! the one place that turns a mirror into a frame mirror, and it refuses on a
 //! block that was not sized for one.
 
-use super::pyobject::{self, CPyObject, REFCNT_FROM_PYRE};
+use super::pyobject::{self, CPyObject, REFCNT_FROM_PYPY};
 use super::typeobject::CPyTypeObject;
 use pyre_object::{PY_NULL, PyObjectRef};
 use std::collections::HashSet;
@@ -227,7 +227,7 @@ pub(super) fn realize_pending(raw: *mut CPyObject) {
     pyobject::link_allocated(
         boxed.into_raw() as PyObjectRef,
         raw,
-        REFCNT_FROM_PYRE + refcnt,
+        REFCNT_FROM_PYPY + refcnt,
     );
 }
 

--- a/pyre/pyre-interpreter/src/cpyext/gc.rs
+++ b/pyre/pyre-interpreter/src/cpyext/gc.rs
@@ -1,7 +1,7 @@
 //! The cyclic-collection protocol -- `tp_traverse`, `tp_clear`, and the set of
 //! blocks that declare them.
 //!
-//! A mirror's count above [`REFCNT_FROM_PYRE`] is what tells the collector that
+//! A mirror's count above [`REFCNT_FROM_PYPY`] is what tells the collector that
 //! C still holds the object, and that rule alone cannot see a cycle: a block
 //! reachable only from another dead block still carries its reference, so both
 //! stay. Breaking one needs to know which references a block holds, which is

--- a/pyre/pyre-interpreter/src/cpyext/pyobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyobject.rs
@@ -14,7 +14,7 @@
 //! # Ownership
 //!
 //! The link is a `rawrefcount` P-link, and the collector owns it: a mirror
-//! whose count is exactly [`REFCNT_FROM_PYRE`] is referenced by nothing but the
+//! whose count is exactly [`REFCNT_FROM_PYPY`] is referenced by nothing but the
 //! link, so the collector is free to let the interpreter object die and queue
 //! the mirror on its dead list.  [`drain_dead`] is what then runs the mirror's
 //! deallocator.  Nothing in this module roots an interpreter object.
@@ -42,13 +42,13 @@ use std::hash::BuildHasherDefault;
 ///
 /// The collector reads it too, and decides on it, so the constant is defined
 /// where the algorithm is.
-pub use rawrefcount::REFCNT_FROM_PYRE;
+pub use rawrefcount::REFCNT_FROM_PYPY;
 
 /// The count an immortal mirror starts at.
 ///
 /// Type mirrors and the singletons are borrowed by every consumer and never
 /// handed out with an owning reference, so their count must never fall back to
-/// [`REFCNT_FROM_PYRE`] and free them.
+/// [`REFCNT_FROM_PYPY`] and free them.
 pub use rawrefcount::REFCNT_IMMORTAL;
 
 /// C-visible `PyObject`, matching PyPy's `parse/cpyext_object.h` shape.
@@ -166,7 +166,7 @@ pub(super) fn ensure_mirror(w_obj: PyObjectRef) -> *mut CPyObject {
         // second call finds this mirror in the table and terminates.
         let mirror = attach(
             w_obj,
-            REFCNT_FROM_PYRE,
+            REFCNT_FROM_PYPY,
             std::ptr::null_mut(),
             size_of::<super::typeobject::CPyHeapTypeObject>(),
         ) as *mut CPyTypeObject;
@@ -194,7 +194,7 @@ pub(super) fn ensure_mirror(w_obj: PyObjectRef) -> *mut CPyObject {
     }
     let ob_type = type_mirror(w_obj);
     let size = mirror_size(ob_type);
-    let raw = attach(w_obj, REFCNT_FROM_PYRE, ob_type, size);
+    let raw = attach(w_obj, REFCNT_FROM_PYPY, ob_type, size);
     // Each fill allocates, so the object is read back through the mirror
     // before the next one rather than kept in a local: the block's address
     // does not move and the object's does, and the link is what the collector
@@ -301,28 +301,28 @@ pub(super) fn attach_foreign(w_obj: PyObjectRef, raw: *mut CPyObject) {
 /// [`free_block`] later releases it by.
 pub(super) fn link_allocated(w_obj: PyObjectRef, raw: *mut CPyObject, refcnt: isize) {
     debug_assert!(
-        refcnt >= REFCNT_FROM_PYRE,
+        refcnt >= REFCNT_FROM_PYPY,
         "a linked mirror carries the link share"
     );
     unsafe {
         (*raw).ob_refcnt = refcnt;
         (*raw).ob_pyre_link = w_obj;
     }
-    majit_gc::gc_rawrefcount_create_link_pyre(majit_ir::GcRef(w_obj as usize), raw as usize);
+    majit_gc::gc_rawrefcount_create_link_pypy(majit_ir::GcRef(w_obj as usize), raw as usize);
 }
 
 /// `pyobject.py:track_reference` — hand the collector the P-link.
 ///
 /// The mirror's header is already filled at this point, including the
-/// [`REFCNT_FROM_PYRE`] share this link is worth, which is what
+/// [`REFCNT_FROM_PYPY`] share this link is worth, which is what
 /// `track_reference`'s `c_ob_refcnt += REFCNT_FROM_PYPY` establishes.
 fn enter(w_obj: PyObjectRef, raw: *mut CPyObject, size: usize) {
     debug_assert!(
-        unsafe { (*raw).ob_refcnt } >= REFCNT_FROM_PYRE,
+        unsafe { (*raw).ob_refcnt } >= REFCNT_FROM_PYPY,
         "a linked mirror carries the link share"
     );
     record_block(raw as usize, size);
-    majit_gc::gc_rawrefcount_create_link_pyre(majit_ir::GcRef(w_obj as usize), raw as usize);
+    majit_gc::gc_rawrefcount_create_link_pypy(majit_ir::GcRef(w_obj as usize), raw as usize);
 }
 
 /// How large a mirror of `ob_type` has to be.
@@ -489,7 +489,7 @@ pub unsafe fn decref(raw: *mut CPyObject) {
         "decref of a mirror with no references left"
     );
     debug_assert!(
-        unsafe { (*raw).ob_pyre_link.is_null() } || unsafe { (*raw).ob_refcnt } > REFCNT_FROM_PYRE,
+        unsafe { (*raw).ob_pyre_link.is_null() } || unsafe { (*raw).ob_refcnt } > REFCNT_FROM_PYPY,
         "a linked mirror must not be decrefed below the link share"
     );
     unsafe { (*raw).ob_refcnt -= 1 };
@@ -1091,7 +1091,7 @@ pub unsafe extern "C" fn _PyPyre_RefCount(object: *mut CPyObject) -> isize {
     if object.is_null() {
         return 0;
     }
-    unsafe { (*object).ob_refcnt - REFCNT_FROM_PYRE }
+    unsafe { (*object).ob_refcnt - REFCNT_FROM_PYPY }
 }
 
 pub(super) fn ensure_linked() {

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -6,7 +6,7 @@
 //! block of the same shape, so `Py_TYPE(x)->tp_name` reads something either
 //! way.
 
-use super::pyobject::{self, CPyObject, REFCNT_FROM_PYRE, REFCNT_IMMORTAL};
+use super::pyobject::{self, CPyObject, REFCNT_FROM_PYPY, REFCNT_IMMORTAL};
 use pyre_object::{PY_NULL, PyObjectRef};
 use std::ffi::{CStr, CString, c_char, c_int, c_uint, c_void};
 use std::sync::OnceLock;
@@ -6183,7 +6183,7 @@ pub unsafe extern "C" fn PyType_GenericAlloc(
     // collector queues this block for `tp_dealloc`.
     let raw = pyobject::attach(
         pyre_object::gc_roots::shadow_stack_get(instance_slot),
-        REFCNT_FROM_PYRE + 1,
+        REFCNT_FROM_PYPY + 1,
         tp,
         size,
     );
@@ -6312,7 +6312,7 @@ pub unsafe extern "C" fn PyObject_Init(
     let type_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = roots.pin_root(w_type);
     let instance = pyre_object::w_instance_new(pyre_object::gc_roots::shadow_stack_get(type_slot));
-    pyobject::link_allocated(instance, object, REFCNT_FROM_PYRE + 1);
+    pyobject::link_allocated(instance, object, REFCNT_FROM_PYPY + 1);
     object
 }
 

--- a/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
@@ -356,7 +356,7 @@ pub(super) fn realize_pending(raw: *mut CPyObject) {
     pyobject::link_allocated(
         pyre_object::gc_roots::shadow_stack_get(slot),
         raw,
-        pyobject::REFCNT_FROM_PYRE + refcnt,
+        pyobject::REFCNT_FROM_PYPY + refcnt,
     );
 }
 

--- a/pyre/pyre-interpreter/src/jit_builtin_folds.rs
+++ b/pyre/pyre-interpreter/src/jit_builtin_folds.rs
@@ -315,12 +315,12 @@ static BUILTIN_FOLDS: &[BuiltinFold] = &[
     },
     BuiltinFold {
         name: "abs",
-        code_fn: crate::builtins::__pyre_wrap_builtin_abs,
+        code_fn: crate::builtins::__majit_wrap_builtin_abs,
         raw: BuiltinFoldRaw::Int1(jit_builtin_abs_int),
     },
     BuiltinFold {
         name: "abs",
-        code_fn: crate::builtins::__pyre_wrap_builtin_abs,
+        code_fn: crate::builtins::__majit_wrap_builtin_abs,
         raw: BuiltinFoldRaw::Float1(jit_builtin_abs_float),
     },
     BuiltinFold {

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1694,7 +1694,7 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     // odometer bump and the items-block strategy gate: each reads a
     // runtime-mutable global (`COLLECT_STATE` atomic, `EVAL_NESTING` / `POLL_TICK`
     // TLS, the two GC hook fn-pointer cells, `FRAME_ENTRY_COUNT` TLS, the
-    // `PYRE_GC_ITEMSBLOCK` `OnceLock`) — none a build-time constant — so all carry
+    // `MAJIT_GC_ITEMSBLOCK` `OnceLock`) — none a build-time constant — so all carry
     // `#[dont_look_inside]` and bind their `-> bool` / `()` Rust `fn` directly by
     // qualified path (siblings of `gc_interp::enabled`).
     pa0(
@@ -4266,10 +4266,10 @@ mod tests {
     fn jit_trace_fnaddrs_covers_int_bit_length_gateway_wrapper() {
         let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
         let expected =
-            crate::typedef::__pyre_wrap_int_descr_bit_length as *const () as usize as i64;
+            crate::typedef::__majit_wrap_int_descr_bit_length as *const () as usize as i64;
 
         assert_eq!(
-            bindings["pyre_interpreter::typedef::__pyre_wrap_int_descr_bit_length"],
+            bindings["pyre_interpreter::typedef::__majit_wrap_int_descr_bit_length"],
             expected,
         );
     }

--- a/pyre/pyre-interpreter/src/module/_random/macro_smoke.rs
+++ b/pyre/pyre-interpreter/src/module/_random/macro_smoke.rs
@@ -244,10 +244,10 @@ mod tests {
         crate::typedef::init_typeobjects();
         let cls = type_object();
         let seed = w_int_new(37);
-        let obj = __pyre_wrap___new__(&[cls, seed]).expect("synthesized __new__");
+        let obj = __majit_wrap___new__(&[cls, seed]).expect("synthesized __new__");
         let demo = Demo::from_obj(obj).expect("Demo allocation");
         assert_eq!(demo.state, 0);
-        __pyre_wrap___init__(&[obj, seed]).expect("Demo.__init__");
+        __majit_wrap___init__(&[obj, seed]).expect("Demo.__init__");
         assert_eq!(Demo::from_obj(obj).expect("initialized Demo").state, 37);
     }
 
@@ -260,8 +260,8 @@ mod tests {
     fn instance_method_binds_keyword_only_through_signature() {
         crate::typedef::init_typeobjects();
         let cls = type_object();
-        let obj = __pyre_wrap___new__(&[cls]).expect("synthesized __new__");
-        __pyre_wrap___init__(&[obj, w_int_new(7)]).expect("Demo.__init__");
+        let obj = __majit_wrap___new__(&[cls]).expect("synthesized __new__");
+        __majit_wrap___init__(&[obj, w_int_new(7)]).expect("Demo.__init__");
 
         // The `Signature` the instance-method arm derives for
         // `combine(&self, factor, #[kwonly] bias)`: `self` positional-only,
@@ -281,11 +281,12 @@ mod tests {
         )
         .expect("signature binding");
         // 7 * 3 + 5 through the bound (marker-free, PY_NULL-padded) scope.
-        let via_keyword = __pyre_wrap_combine(&bound).expect("keyword-bound combine");
+        let via_keyword = __majit_wrap_combine(&bound).expect("keyword-bound combine");
         assert_eq!(unsafe { w_int_get_value(via_keyword) }, 26);
 
         // The all-positional call omits `bias`, so its `#[default(0)]` applies.
-        let via_positional = __pyre_wrap_combine(&[obj, w_int_new(3)]).expect("positional combine");
+        let via_positional =
+            __majit_wrap_combine(&[obj, w_int_new(3)]).expect("positional combine");
         assert_eq!(unsafe { w_int_get_value(via_positional) }, 21);
     }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -5255,7 +5255,7 @@ fn set_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// generated interp2app function graphs. Publishing the wrapper descriptor
 /// below gives pyre's source translator the same candidate graph and lets a
 /// traced `list.pop()` call descend to `w_list_pop_end_inner`.
-pub fn __pyre_wrap_list_descr_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_list_descr_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::list_method_pop(args)
 }
 
@@ -5264,8 +5264,12 @@ pub fn __pyre_wrap_list_descr_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, c
 #[allow(non_upper_case_globals)]
 static __majit_builtin_wrapper_target_list_descr_pop: crate::gateway::BuiltinWrapperDescriptor =
     crate::gateway::BuiltinWrapperDescriptor {
-        path: concat!(module_path!(), "::", stringify!(__pyre_wrap_list_descr_pop)),
-        func: __pyre_wrap_list_descr_pop,
+        path: concat!(
+            module_path!(),
+            "::",
+            stringify!(__majit_wrap_list_descr_pop)
+        ),
+        func: __majit_wrap_list_descr_pop,
     };
 
 /// Name of `obj`'s type, for operand-type error messages.
@@ -5407,7 +5411,7 @@ fn init_list_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "pop",
-            make_builtin_function("pop", __pyre_wrap_list_descr_pop),
+            make_builtin_function("pop", __majit_wrap_list_descr_pop),
         )
     };
     unsafe {
@@ -18285,7 +18289,7 @@ fn int_cpython_digit_count(w_obj: PyObjectRef) -> Result<i64, crate::PyError> {
 /// function graphs. Publishing the wrapper descriptor below gives pyre's
 /// source translator the same candidate graph and lets a traced
 /// `int.bit_length()` call descend to `rbigint::bit_length_int`.
-pub fn __pyre_wrap_int_descr_bit_length(
+pub fn __majit_wrap_int_descr_bit_length(
     args: &[PyObjectRef],
 ) -> Result<PyObjectRef, crate::PyError> {
     // `intobject.py descr_bit_length` — number of bits in the absolute
@@ -18313,9 +18317,9 @@ static __majit_builtin_wrapper_target_int_descr_bit_length:
     path: concat!(
         module_path!(),
         "::",
-        stringify!(__pyre_wrap_int_descr_bit_length)
+        stringify!(__majit_wrap_int_descr_bit_length)
     ),
-    func: __pyre_wrap_int_descr_bit_length,
+    func: __majit_wrap_int_descr_bit_length,
 };
 
 fn init_int_type(ns: PyObjectRef) {
@@ -18407,7 +18411,7 @@ fn init_int_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "bit_length",
-            make_builtin_function_with_arity("bit_length", __pyre_wrap_int_descr_bit_length, 1),
+            make_builtin_function_with_arity("bit_length", __majit_wrap_int_descr_bit_length, 1),
         )
     };
     unsafe {
@@ -19452,7 +19456,7 @@ fn init_float_type(ns: PyObjectRef) {
             "as_integer_ratio",
             make_builtin_function_with_arity(
                 "as_integer_ratio",
-                __pyre_wrap_float_descr_as_integer_ratio,
+                __majit_wrap_float_descr_as_integer_ratio,
                 1,
             ),
         )
@@ -19802,7 +19806,7 @@ fn float_as_rbigint_ratio(value: f64) -> Result<(BigInt, BigInt), crate::PyError
 }
 
 /// Manual interp2app gateway for `float.as_integer_ratio`.
-pub fn __pyre_wrap_float_descr_as_integer_ratio(
+pub fn __majit_wrap_float_descr_as_integer_ratio(
     args: &[PyObjectRef],
 ) -> Result<PyObjectRef, crate::PyError> {
     float_descr_as_integer_ratio(args)
@@ -19811,14 +19815,14 @@ pub fn __pyre_wrap_float_descr_as_integer_ratio(
 #[cfg(not(target_arch = "wasm32"))]
 #[linkme::distributed_slice(crate::gateway::BUILTIN_WRAPPER_DESCRIPTORS)]
 #[allow(non_upper_case_globals)]
-static __pyre_wrap_float_descr_as_integer_ratio_target: crate::gateway::BuiltinWrapperDescriptor =
+static __majit_wrap_float_descr_as_integer_ratio_target: crate::gateway::BuiltinWrapperDescriptor =
     crate::gateway::BuiltinWrapperDescriptor {
         path: concat!(
             module_path!(),
             "::",
-            "__pyre_wrap_float_descr_as_integer_ratio"
+            "__majit_wrap_float_descr_as_integer_ratio"
         ),
-        func: __pyre_wrap_float_descr_as_integer_ratio,
+        func: __majit_wrap_float_descr_as_integer_ratio,
     };
 
 #[derive(Copy, Clone)]
@@ -20269,17 +20273,17 @@ pub(crate) fn object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
 }
 
 /// Manual interp2app gateway for `object.__new__`.
-pub fn __pyre_wrap_object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_object_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     object_descr_new(args)
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 #[linkme::distributed_slice(crate::gateway::BUILTIN_WRAPPER_DESCRIPTORS)]
 #[allow(non_upper_case_globals)]
-static __pyre_wrap_object_descr_new_target: crate::gateway::BuiltinWrapperDescriptor =
+static __majit_wrap_object_descr_new_target: crate::gateway::BuiltinWrapperDescriptor =
     crate::gateway::BuiltinWrapperDescriptor {
-        path: concat!(module_path!(), "::", "__pyre_wrap_object_descr_new"),
-        func: __pyre_wrap_object_descr_new,
+        path: concat!(module_path!(), "::", "__majit_wrap_object_descr_new"),
+        func: __majit_wrap_object_descr_new,
     };
 
 /// `object.__init__(self)` — no-op base __init__.  Surplus arguments are
@@ -20329,7 +20333,7 @@ fn init_object_type(ns: PyObjectRef) {
             ),
         )
     };
-    let object_new = make_new_descr(__pyre_wrap_object_descr_new);
+    let object_new = make_new_descr(__majit_wrap_object_descr_new);
     unsafe {
         // `make_new_descr` hands back the carrier itself, not a `staticmethod`
         // around it, so the text signature belongs on that object directly.
@@ -27229,7 +27233,7 @@ fn set_op_inplace_xor(
 /// candidate graph and lets the call descend to `w_set_add_hashed_checked`,
 /// the way upstream's tracer descends through `descr_add` into
 /// `W_BaseSetObject.add`.
-pub fn __pyre_wrap_set_descr_add(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub fn __majit_wrap_set_descr_add(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::require_set_receiver(args, "add", true)?;
     crate::type_methods::arity_exact(args, "add", 1)?;
     // `try_hash_value` may run a user `__hash__` that allocates and triggers
@@ -27259,8 +27263,8 @@ pub fn __pyre_wrap_set_descr_add(args: &[PyObjectRef]) -> Result<PyObjectRef, cr
 #[allow(non_upper_case_globals)]
 static __majit_builtin_wrapper_target_set_descr_add: crate::gateway::BuiltinWrapperDescriptor =
     crate::gateway::BuiltinWrapperDescriptor {
-        path: concat!(module_path!(), "::", stringify!(__pyre_wrap_set_descr_add)),
-        func: __pyre_wrap_set_descr_add,
+        path: concat!(module_path!(), "::", stringify!(__majit_wrap_set_descr_add)),
+        func: __majit_wrap_set_descr_add,
     };
 
 fn init_set_type(ns: PyObjectRef) {
@@ -27313,7 +27317,7 @@ fn init_set_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "add",
-            make_builtin_function_with_arity("add", __pyre_wrap_set_descr_add, 2),
+            make_builtin_function_with_arity("add", __majit_wrap_set_descr_add, 2),
         )
     };
     unsafe {

--- a/pyre/pyre-jit-trace/build/prepass.rs
+++ b/pyre/pyre-jit-trace/build/prepass.rs
@@ -183,17 +183,43 @@ impl DeterminismCheck {
 
 const LOWERING_GATE_ENV: [&str; 5] = [
     "PYRE_DYN_INDIRECT",
-    "PYRE_FNPTR_INDIRECT",
-    "PYRE_MIR_FRAMESTATE",
+    "MAJIT_FNPTR_INDIRECT",
+    "MAJIT_MIR_FRAMESTATE",
     "PYRE_OPTION_RESIDUAL_NARROW",
     "PYRE_TUPLE_PER_SHAPE_CLASSDEF",
 ];
+
+const ENGINE_ENV_ALIASES: &[(&str, &str)] = &[
+    ("PYRE_RTYPER_VERBOSE", "MAJIT_RTYPER_VERBOSE"),
+    ("PYRE_CALLEE_CENSUS", "MAJIT_CALLEE_CENSUS"),
+    ("PYRE_CALLEE_CENSUS_ROWS", "MAJIT_CALLEE_CENSUS_ROWS"),
+    ("PYRE_MIR_FRONTEND_LLBC", "MAJIT_MIR_FRONTEND_LLBC"),
+    ("PYRE_PROFILE_PIPELINE", "MAJIT_PROFILE_PIPELINE"),
+    ("PYRE_FNPTR_INDIRECT", "MAJIT_FNPTR_INDIRECT"),
+    ("PYRE_MIR_FRAMESTATE", "MAJIT_MIR_FRAMESTATE"),
+];
+
+fn forward_engine_env_aliases() {
+    for &(runtime_name, engine_name) in ENGINE_ENV_ALIASES {
+        if std::env::var_os(engine_name).is_none()
+            && let Some(value) = std::env::var_os(runtime_name)
+        {
+            // The build script has not created its analysis worker yet, so no
+            // other thread can concurrently read or modify this process's
+            // environment. The worker and majit libraries then see the
+            // engine-owned spelling.
+            unsafe { std::env::set_var(engine_name, value) };
+        }
+    }
+}
 
 /// Entry of the real build: the translation prepass over the LLBC set.
 ///
 /// `build.rs` dispatches here only when the `prepass` feature is on and the
 /// build is not an LLBC extraction; both other cases end in its placeholders.
 pub fn main() {
+    forward_engine_env_aliases();
+
     // Fail fast with an actionable message when the Charon-extracted LLBC
     // artefacts the codegen consumes are absent.  Without this, the missing
     // set surfaces deep inside `real_main` as a worker-thread `panic!`
@@ -232,9 +258,33 @@ pub fn main() {
 /// two-artefact consumers it requires `pyre-jit` too.
 const LLBC_CRATES: &[&str] = &["majit-rlib", "pyre-object", "pyre-interpreter", "pyre-jit"];
 
+fn analysis_llbc_paths(repo_root: &str) -> Vec<String> {
+    if let Some(paths) = std::env::var_os("MAJIT_MIR_FRONTEND_LLBC") {
+        let paths: Vec<String> = std::env::split_paths(&paths)
+            .filter(|path| !path.as_os_str().is_empty())
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect();
+        if !paths.is_empty() {
+            return paths;
+        }
+    }
+
+    let llbc_dir = std::path::Path::new(repo_root).join("build").join("llbc");
+    LLBC_CRATES
+        .iter()
+        .map(|crate_name| llbc_dir.join(format!("{crate_name}.ullbc")))
+        .chain(
+            llbc_layout_sidecars()
+                .into_iter()
+                .map(|name| llbc_dir.join(name)),
+        )
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect()
+}
+
 /// Pre-flight the LLBC prerequisite, mirroring the resolution order in
 /// `majit-translate` (`build_semantic_program_via_active_frontend`):
-/// honour the `PYRE_MIR_FRONTEND_LLBC` override, else require the canonical
+/// honour the `MAJIT_MIR_FRONTEND_LLBC` override, else require the canonical
 /// `build/llbc/{pyre-object,pyre-interpreter,pyre-jit}.ullbc` set. The third
 /// artifact contains the exact `eval::eval_loop_jit` portal.
 ///
@@ -254,7 +304,7 @@ const LLBC_CRATES: &[&str] = &["majit-rlib", "pyre-object", "pyre-interpreter", 
 fn preflight_llbc_or_fail() {
     // Explicit override: trust it and let the translator validate the
     // individual paths (its loader panics per-file with the bad path).
-    if std::env::var_os("PYRE_MIR_FRONTEND_LLBC")
+    if std::env::var_os("MAJIT_MIR_FRONTEND_LLBC")
         .map(|v| std::env::split_paths(&v).any(|p| !p.as_os_str().is_empty()))
         .unwrap_or(false)
     {
@@ -310,7 +360,7 @@ fn preflight_llbc_or_fail() {
     // wasm32, so any other target's sidecars are produced only when the
     // extraction is told this target explicitly.  Advertise it (harmless but
     // redundant for wasm32).  The override must also list the sidecar paths,
-    // since `PYRE_MIR_FRONTEND_LLBC` is treated as the complete input set and
+    // since `MAJIT_MIR_FRONTEND_LLBC` is treated as the complete input set and
     // returns before the sidecar check above.
     let sidecars = llbc_layout_sidecars();
     let (extract_cmd, override_extra) = if sidecars.is_empty() {
@@ -346,7 +396,7 @@ fn preflight_llbc_or_fail() {
    {}\n\
 \n\
  …or point the build at existing artefacts:\n\
-   export PYRE_MIR_FRONTEND_LLBC={}{}\n\
+   export MAJIT_MIR_FRONTEND_LLBC={}{}\n\
 ========================================================================\n",
         missing
             .iter()
@@ -1006,12 +1056,13 @@ fn real_main() {
     // The verbose prepass is a census over every attempted graph. Restoring
     // generated outputs would skip the analysis entirely and leave no
     // `PREPASS phaseA/phaseB fail` lines, contradicting the documented
-    // `PYRE_RTYPER_VERBOSE=1` workflow. The generated artifacts themselves do
+    // `MAJIT_RTYPER_VERBOSE=1` workflow. The generated artifacts themselves do
     // not depend on verbosity, so an ordinary build may still reuse the cache.
-    let verbose_prepass = std::env::var_os("PYRE_RTYPER_VERBOSE").is_some_and(|value| value == "1");
+    let verbose_prepass =
+        std::env::var_os("MAJIT_RTYPER_VERBOSE").is_some_and(|value| value == "1");
     // The callee census is emitted from the analysis itself. A cache restore
     // would print no rows, which is indistinguishable from an empty census.
-    let callee_census = std::env::var_os("PYRE_CALLEE_CENSUS").is_some_and(|value| value == "1");
+    let callee_census = std::env::var_os("MAJIT_CALLEE_CENSUS").is_some_and(|value| value == "1");
     // Restoring the outputs leaves the self-check nothing to compare, so it
     // bypasses the cache for the same reason the verbose prepass does.
     let determinism_check = DeterminismCheck::from_env();
@@ -1041,9 +1092,12 @@ fn real_main() {
     // outputs and the probe subdirectory for the second generation
     // `DeterminismCheck::InProcess` compares against; the parameter shadows
     // the outer `out_dir` so both calls read as "write into out_dir".
+    let llbc_paths = analysis_llbc_paths(&repo_root);
+    let llbc_path_refs: Vec<&str> = llbc_paths.iter().map(String::as_str).collect();
     let generate_into = |out_dir: &str| {
         majit_ir::descr::reset_field_mint_census();
-        let pipeline = majit_translate::analyze_multiple_pipeline_with_modules(
+        let pipeline = majit_translate::analyze_multiple_pipeline_from_llbc_with_modules(
+            &llbc_path_refs,
             &module_path_refs,
             &analyze_config,
             None,
@@ -1776,12 +1830,15 @@ fn emit_rerun_directives(repo_root: &str, source_paths: &[String]) {
     println!("cargo::rerun-if-changed=src/virtualizable_spec.rs");
     println!("cargo::rerun-if-changed=src/call_spec.rs");
     println!("cargo::rerun-if-changed=src/llbc_fingerprint.rs");
-    println!("cargo::rerun-if-env-changed=PYRE_RTYPER_VERBOSE");
-    println!("cargo::rerun-if-env-changed=PYRE_CALLEE_CENSUS");
-    println!("cargo::rerun-if-env-changed=PYRE_CALLEE_CENSUS_ROWS");
+    println!("cargo::rerun-if-env-changed=MAJIT_RTYPER_VERBOSE");
+    println!("cargo::rerun-if-env-changed=MAJIT_CALLEE_CENSUS");
+    println!("cargo::rerun-if-env-changed=MAJIT_CALLEE_CENSUS_ROWS");
     println!("cargo::rerun-if-env-changed=MAJIT_FIELD_MINT_TRACE");
     println!("cargo::rerun-if-env-changed=MAJIT_STRUCT_LAYOUT_CENSUS");
     println!("cargo::rerun-if-env-changed={DETERMINISM_CHECK_ENV}");
+    for &(runtime_name, _) in ENGINE_ENV_ALIASES {
+        println!("cargo::rerun-if-env-changed={runtime_name}");
+    }
     // Re-runs this script without changing anything it hashes. That is the
     // only way to exercise `DeterminismCheck::AgainstCache`, which needs two
     // runs at the *same* cache key: with the gate value held constant Cargo
@@ -1793,11 +1850,11 @@ fn emit_rerun_directives(repo_root: &str, source_paths: &[String]) {
         println!("cargo::rerun-if-env-changed={key}");
     }
     // The mir-frontend analysis derives `jit_trace_gen.rs` from
-    // the workspace LLBC artefacts or the `PYRE_MIR_FRONTEND_LLBC`
+    // the workspace LLBC artefacts or the `MAJIT_MIR_FRONTEND_LLBC`
     // override. Track both so re-extracting LLBC or repointing the override
     // invalidates Cargo's build-script cache and our content cache key.
-    println!("cargo::rerun-if-env-changed=PYRE_MIR_FRONTEND_LLBC");
-    if let Some(paths) = std::env::var_os("PYRE_MIR_FRONTEND_LLBC") {
+    println!("cargo::rerun-if-env-changed=MAJIT_MIR_FRONTEND_LLBC");
+    if let Some(paths) = std::env::var_os("MAJIT_MIR_FRONTEND_LLBC") {
         for path in std::env::split_paths(&paths) {
             if !path.as_os_str().is_empty() {
                 println!("cargo::rerun-if-changed={}", path.display());
@@ -2124,7 +2181,7 @@ fn codegen_cache_key(manifest_dir: &str, repo_root: &str, source_paths: &[String
         h.write_str(&key);
         h.write_str(&value);
     }
-    h.write_os(std::env::var_os("PYRE_MIR_FRONTEND_LLBC"));
+    h.write_os(std::env::var_os("MAJIT_MIR_FRONTEND_LLBC"));
     for key in LOWERING_GATE_ENV {
         h.write_str(key);
         h.write_os(std::env::var_os(key));
@@ -2219,7 +2276,7 @@ fn hash_llbc_inputs(h: &mut CacheHasher, repo_root: &str) {
     // serve stale output and skip re-analysis. The `.ullbc` set is ~660 MB
     // (89 % of it `fun_decls`), so the read costs under a second — still
     // negligible next to the tens of seconds of analysis it gates.
-    if let Some(paths) = std::env::var_os("PYRE_MIR_FRONTEND_LLBC") {
+    if let Some(paths) = std::env::var_os("MAJIT_MIR_FRONTEND_LLBC") {
         for path in std::env::split_paths(&paths) {
             if !path.as_os_str().is_empty() {
                 hash_file_content(h, &path);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -833,7 +833,7 @@ pub(crate) fn fbw_bridge_iter_journal_clear() {
 /// Record the in-flight FOR_ITER continuation (#57 Option C): the consumed
 /// item the `for_iter_next` residual produced and its FOR_ITER body coordinate.
 /// Called from the residual
-/// executor's success arm when the helper is [`PyreHelperKind::ForIterNext`]
+/// executor's success arm when the helper is [`RuntimeHelperKind::ForIterNext`]
 /// and it produced a non-null item (a null item is the exhaustion arm — no
 /// body runs, nothing to deliver).  The stack mirrors loop nesting: a consume
 /// of a DIFFERENT (deeper) FOR_ITER pushes a new entry on top of the loops
@@ -2879,7 +2879,7 @@ fn replay_safety_dump_body(body_code: &[u8], callee_descr_refs: &[DescrRef]) {
                 .and_then(|descr| descr.as_call_descr())
                 .map_or_else(
                     || " helper=<no call descr>".to_string(),
-                    |cd| format!(" helper={:?}", cd.get_extra_info().pyre_helper),
+                    |cd| format!(" helper={:?}", cd.get_extra_info().runtime_helper),
                 )
         } else {
             String::new()
@@ -3125,7 +3125,7 @@ pub(crate) fn fbw_callee_body_replay_scan(
             // contents, writing nothing, and its unbound `NameError` is the
             // same shape as `load_global`'s.  It reached this scan untagged
             // until `load_deref_value` started carrying
-            // `PyreHelperKind::LoadDeref` for the `Cell.get` fold, so the tag
+            // `RuntimeHelperKind::LoadDeref` for the `Cell.get` fold, so the tag
             // it wanted is now here — and it is still not listed.
             //
             // Admitting it classifies every freevar-reading body
@@ -3164,21 +3164,21 @@ pub(crate) fn fbw_callee_body_replay_scan(
             // no empty write set may be claimed for them -- and not about
             // replay: reading a field twice commits nothing either way.
             let replay_safe_read = matches!(
-                ei.pyre_helper,
-                majit_ir::PyreHelperKind::LoadConst
-                    | majit_ir::PyreHelperKind::LoadGlobal
-                    | majit_ir::PyreHelperKind::LoadImport
-                    | majit_ir::PyreHelperKind::LoadImportLocals
-                    | majit_ir::PyreHelperKind::BoxInt
-                    | majit_ir::PyreHelperKind::NewtupleFromArray
-                    | majit_ir::PyreHelperKind::NewlistFromArray
-                    | majit_ir::PyreHelperKind::GetCurrentException
+                ei.runtime_helper,
+                majit_ir::RuntimeHelperKind::LoadConst
+                    | majit_ir::RuntimeHelperKind::LoadGlobal
+                    | majit_ir::RuntimeHelperKind::LoadImport
+                    | majit_ir::RuntimeHelperKind::LoadImportLocals
+                    | majit_ir::RuntimeHelperKind::BoxInt
+                    | majit_ir::RuntimeHelperKind::NewtupleFromArray
+                    | majit_ir::RuntimeHelperKind::NewlistFromArray
+                    | majit_ir::RuntimeHelperKind::GetCurrentException
             );
             // `box_int` is the only generic replay-safe helper here whose
             // result is necessarily numeric.  `load_const` may return a str,
             // tuple, or another nonnumeric immutable value, while the typed
             // jitcode constant pool was classified exactly above.
-            let dst_boxed_int = ei.pyre_helper == majit_ir::PyreHelperKind::BoxInt;
+            let dst_boxed_int = ei.runtime_helper == majit_ir::RuntimeHelperKind::BoxInt;
             let provably_side_effect_free = replay_safe_read
                 || ei.check_is_elidable()
                 || ei.extraeffect == majit_ir::ExtraEffect::LoopInvariant;
@@ -3316,22 +3316,22 @@ pub(crate) fn fbw_callee_body_replay_scan(
                 // `foriter_deferred_admit`'s loop-header check to account for
                 // it (`fbw_callee_body_has_load_method_self_residual`).  Keep
                 // the surface where it was.
-                let defer_truth_or_method_self = match ei.pyre_helper {
-                    majit_ir::PyreHelperKind::LoadMethodSelf => method_form_deferred_helpers,
-                    majit_ir::PyreHelperKind::Truth => true,
+                let defer_truth_or_method_self = match ei.runtime_helper {
+                    majit_ir::RuntimeHelperKind::LoadMethodSelf => method_form_deferred_helpers,
+                    majit_ir::RuntimeHelperKind::Truth => true,
                     _ => false,
                 };
                 let defer_helper = defer_truth_or_method_self
                     || matches!(
-                        ei.pyre_helper,
-                        majit_ir::PyreHelperKind::CallFn
-                            | majit_ir::PyreHelperKind::CallKw
-                            | majit_ir::PyreHelperKind::CallFunctionEx
-                            | majit_ir::PyreHelperKind::RaiseVarargs
-                            | majit_ir::PyreHelperKind::SetCurrentException
-                            | majit_ir::PyreHelperKind::LoadAttr
-                            | majit_ir::PyreHelperKind::BinaryOp
-                            | majit_ir::PyreHelperKind::CompareOp
+                        ei.runtime_helper,
+                        majit_ir::RuntimeHelperKind::CallFn
+                            | majit_ir::RuntimeHelperKind::CallKw
+                            | majit_ir::RuntimeHelperKind::CallFunctionEx
+                            | majit_ir::RuntimeHelperKind::RaiseVarargs
+                            | majit_ir::RuntimeHelperKind::SetCurrentException
+                            | majit_ir::RuntimeHelperKind::LoadAttr
+                            | majit_ir::RuntimeHelperKind::BinaryOp
+                            | majit_ir::RuntimeHelperKind::CompareOp
                     );
                 if defer_helper {
                     deferred_call = true;
@@ -3355,7 +3355,7 @@ pub(crate) fn fbw_callee_body_replay_scan(
                 } else {
                     replay_poison!(
                         poison,
-                        format!("ResidualCallWritesLiveHeap/{:?}", ei.pyre_helper),
+                        format!("ResidualCallWritesLiveHeap/{:?}", ei.runtime_helper),
                         d.pc,
                         d.opname
                     );
@@ -3501,7 +3501,8 @@ pub(crate) fn fbw_callee_body_has_load_method_self_residual(
                 .and_then(|index| callee_descr_refs.get(index))
                 .and_then(|descr| descr.as_call_descr())
                 .is_some_and(|descr| {
-                    descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::LoadMethodSelf
+                    descr.get_extra_info().runtime_helper
+                        == majit_ir::RuntimeHelperKind::LoadMethodSelf
                 })
         {
             return true;
@@ -3525,7 +3526,7 @@ pub(crate) fn fbw_callee_body_has_binary_op_residual(
                 .and_then(|index| callee_descr_refs.get(index))
                 .and_then(|descr| descr.as_call_descr())
                 .is_some_and(|descr| {
-                    descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::BinaryOp
+                    descr.get_extra_info().runtime_helper == majit_ir::RuntimeHelperKind::BinaryOp
                 })
         {
             return true;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -620,7 +620,7 @@ pub(crate) fn callee_body_owns_loop_header(body_code: &[u8]) -> bool {
 fn body_sample_safe_with(
     body_code: &[u8],
     callee_descr_refs: &[DescrRef],
-    pure_helpers: &[majit_ir::PyreHelperKind],
+    pure_helpers: &[majit_ir::RuntimeHelperKind],
 ) -> bool {
     let mut pc = 0usize;
     while pc < body_code.len() {
@@ -661,8 +661,8 @@ pub(crate) fn exception_string_override_sample_safe(
         body_code,
         callee_descr_refs,
         &[
-            majit_ir::PyreHelperKind::LoadConst,
-            majit_ir::PyreHelperKind::BoxInt,
+            majit_ir::RuntimeHelperKind::LoadConst,
+            majit_ir::RuntimeHelperKind::BoxInt,
         ],
     )
 }
@@ -676,7 +676,7 @@ pub(crate) fn exception_string_override_sample_safe(
 /// them apart — but the ones that matter here are separable at run time by the
 /// executed-effect odometer, which is what [`try_walker_inline_index`] consults
 /// once the body has run.  `STORE_ATTR` is a distinct residual
-/// ([`majit_ir::PyreHelperKind::StoreAttr`]) and stays rejected here, so the
+/// ([`majit_ir::RuntimeHelperKind::StoreAttr`]) and stays rejected here, so the
 /// ordinary writing `__index__` never runs at all: it has to be refused before
 /// execution, because by the time the odometer could report it the write has
 /// already happened once.
@@ -685,9 +685,9 @@ pub(crate) fn index_inline_sample_safe(body_code: &[u8], callee_descr_refs: &[De
         body_code,
         callee_descr_refs,
         &[
-            majit_ir::PyreHelperKind::LoadConst,
-            majit_ir::PyreHelperKind::BoxInt,
-            majit_ir::PyreHelperKind::LoadAttr,
+            majit_ir::RuntimeHelperKind::LoadConst,
+            majit_ir::RuntimeHelperKind::BoxInt,
+            majit_ir::RuntimeHelperKind::LoadAttr,
         ],
     )
 }
@@ -732,7 +732,7 @@ pub(crate) fn exception_string_override_straight_line(body_code: &[u8]) -> bool 
 /// resume, never walked.  A blocker sitting on an arm the call at hand does not
 /// take is therefore never reached, and a whole-body scan that declines on it
 /// declines a body the walk would have recorded cleanly.  That is not a corner:
-/// the generated `__pyre_wrap_*` gateways all begin by checking their argument
+/// the generated `__majit_wrap_*` gateways all begin by checking their argument
 /// count and calling `gateway::method_{noarg,arity,min_arity}_failure` on the
 /// reject arm, and those three helpers are `#[dont_look_inside]` precisely so
 /// the formatting stays out of the wrapper's hot JitCode.  Declining on them
@@ -1326,7 +1326,7 @@ pub(crate) fn exception_string_override_has_nested_call(
         }
         if d.opname.starts_with("residual_call")
             && residual_call_helper_kind_in_body(body_code, &d, callee_descr_refs)
-                == Some(majit_ir::PyreHelperKind::CallFn)
+                == Some(majit_ir::RuntimeHelperKind::CallFn)
         {
             return true;
         }
@@ -1541,7 +1541,7 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
     funcptr: OpRef,
     r_args: &[OpRef],
     call_descr: &dyn majit_ir::descr::CallDescr,
-    pyre_helper: majit_ir::PyreHelperKind,
+    runtime_helper: majit_ir::RuntimeHelperKind,
     dst_bank: char,
     dst: usize,
 ) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
@@ -1565,7 +1565,7 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
     let is_being_profiled = ctx.session.borrow().is_being_profiled;
     // Only a genuine `call_fn` residual is a candidate — every
     // container/builtin helper carries a distinct tag.
-    if pyre_helper != majit_ir::PyreHelperKind::CallFn {
+    if runtime_helper != majit_ir::RuntimeHelperKind::CallFn {
         return Ok(None);
     }
     // Positional args only (`r_args = [callable, null_or_self, arg0, ..]`);
@@ -2231,7 +2231,7 @@ pub(crate) fn emit_walker_loop_callee_call_assembler<Sym: WalkSym>(
 /// `call_kw` is excluded for the same reason one step subtler: its list is a
 /// PERMUTATION of the stack rather than a different set of values.  The wire
 /// order is `(callable, null_or_self, kwnames, arg0..arg{n-1})`
-/// (`majit-ir effectinfo.rs` `PyreHelperKind::CallKw`), while `CALL_KW` pops
+/// (`majit-ir effectinfo.rs` `RuntimeHelperKind::CallKw`), while `CALL_KW` pops
 /// `kwnames` FIRST (`eval.rs call_kw`), so the stack image is
 /// `[callable, null_or_self, arg0..arg{n-1}, kwnames]`.  A real `CALL_KW`
 /// always carries a non-empty kwnames tuple, so `n >= 1` on every reachable
@@ -2245,8 +2245,8 @@ pub(crate) fn reconstructed_all_ref_call_stack<Sym: WalkSym>(
     call_descr: &dyn majit_ir::descr::CallDescr,
 ) -> Option<Vec<pyre_object::PyObjectRef>> {
     if !matches!(
-        call_descr.get_extra_info().pyre_helper,
-        majit_ir::PyreHelperKind::CallFn | majit_ir::PyreHelperKind::CallFunctionEx
+        call_descr.get_extra_info().runtime_helper,
+        majit_ir::RuntimeHelperKind::CallFn | majit_ir::RuntimeHelperKind::CallFunctionEx
     ) {
         return None;
     }
@@ -2695,7 +2695,7 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
     funcptr: OpRef,
     r_args: &[OpRef],
     call_descr: &dyn majit_ir::descr::CallDescr,
-    pyre_helper: majit_ir::PyreHelperKind,
+    runtime_helper: majit_ir::RuntimeHelperKind,
     dst_bank: char,
     dst: usize,
 ) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
@@ -2705,8 +2705,8 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
         return Ok(None);
     }
     // Only a genuine Python call helper is an inline target: positional
-    // `call_fn` / `call_fn_N` (`PyreHelperKind::CallFn`) and keyword `call_kw_N`
-    // (`PyreHelperKind::CallKw`), both tagged by the flatten lowering.  Every
+    // `call_fn` / `call_fn_N` (`RuntimeHelperKind::CallFn`) and keyword `call_kw_N`
+    // (`RuntimeHelperKind::CallKw`), both tagged by the flatten lowering.  Every
     // container/builtin helper routed here carries a different tag or `None`
     // (`store_subscr_fn` -> StoreSubscr, `normalize_raise_varargs_fn` /
     // `set_current_exception` -> None).  Without this guard `d[f] = v` with a
@@ -2715,16 +2715,17 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
     // as `f(v)`, skipping the store.  Upstream never inlines a Python call at a
     // residual_call site (inlinable calls get their own inline_call jitcodes);
     // this restores that invariant for the pyre FBW inline-at-residual lever.
-    let is_call_kw = pyre_helper == majit_ir::PyreHelperKind::CallKw;
-    let is_call_function_ex = pyre_helper == majit_ir::PyreHelperKind::CallFunctionEx;
-    if pyre_helper != majit_ir::PyreHelperKind::CallFn && !is_call_kw && !is_call_function_ex {
+    let is_call_kw = runtime_helper == majit_ir::RuntimeHelperKind::CallKw;
+    let is_call_function_ex = runtime_helper == majit_ir::RuntimeHelperKind::CallFunctionEx;
+    if runtime_helper != majit_ir::RuntimeHelperKind::CallFn && !is_call_kw && !is_call_function_ex
+    {
         return Ok(None);
     }
     if fbw_inline_diag_enabled() {
         eprintln!(
             "[inline-entry] pc={} helper={:?} nrefargs={} subwalk={} dst_bank={dst_bank}",
             op.pc,
-            pyre_helper,
+            runtime_helper,
             r_args.len(),
             ctx.fbw_mode.inline_subwalk,
         );
@@ -3224,7 +3225,7 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     code: &[u8],
     ref_operand_offset: usize,
     r_args: &[OpRef],
-    pyre_helper: majit_ir::PyreHelperKind,
+    runtime_helper: majit_ir::RuntimeHelperKind,
     dst_bank: char,
     dst: usize,
 ) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
@@ -3234,7 +3235,7 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
         // that `split_builtin_kwargs` strips — a shape the flat
         // `&[PyObjectRef]` array built below does not construct, so leave those
         // calls to `bh_call_kw_<n>`.
-        || pyre_helper != majit_ir::PyreHelperKind::CallFn
+        || runtime_helper != majit_ir::RuntimeHelperKind::CallFn
         || r_args.len() < 2
         || dst_bank != 'r'
     {
@@ -3279,7 +3280,7 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     // non-Function callable, while `no jitcode for address` names a builtin
     // whose `BuiltinCode.func` is not a member of the PBC family
     // `builtin_wrapper_indirect_graphs` builds — i.e. one registered without a
-    // `__pyre_wrap_*` gateway.  The address is what identifies the missing
+    // `__majit_wrap_*` gateway.  The address is what identifies the missing
     // member, so print it.
     macro_rules! builtin_inline_decline {
         ($why:expr, $addr:expr) => {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2488,7 +2488,7 @@ pub enum DispatchError {
     /// `abort/` (BC_ABORT) reached. The front-end emits this marker for a
     /// graph node with no dedicated `OpKind`; reaching it during a body
     /// walk means the trace contains an untranslatable op and cannot be
-    /// recorded. Blackhole counterpart `handler_abort_marker_pyre`
+    /// recorded. Blackhole counterpart `handler_abort_marker`
     /// (`blackhole.rs`) sets `aborted = true` + `LeaveFrame`; the
     /// walker surfaces it as a typed abort that the production driver
     /// maps to `TraceAction::Abort` (recoverable — may retry later).
@@ -4957,7 +4957,7 @@ fn replace_movable_load_global_namespace_with_frame_globals<Sym: WalkSym>(
     ei: &majit_ir::EffectInfo,
     allboxes: &mut [OpRef],
 ) {
-    if ei.pyre_helper != majit_ir::PyreHelperKind::LoadGlobal {
+    if ei.runtime_helper != majit_ir::RuntimeHelperKind::LoadGlobal {
         return;
     }
     let Some(ns_box) = allboxes.get_mut(1) else {
@@ -6491,7 +6491,7 @@ thread_local! {
 
     /// In-flight FOR_ITER continuation (#57 Option C): `(consumed_item,
     /// body coordinate)` stashed when the FOR_ITER `for_iter_next` residual
-    /// ([`PyreHelperKind::ForIterNext`]) runs concretely on the
+    /// ([`RuntimeHelperKind::ForIterNext`]) runs concretely on the
     /// authoritative walk and advances the real shared heap iterator.  The
     /// advance is an irreversible side effect with no journal undo
     /// (`functional.rs` `current += step`); on a successful CloseLoop commit
@@ -9278,7 +9278,7 @@ fn next_op_is_load_method_self_for_attr<Sym: WalkSym>(
     crate::jitcode_runtime::record_descr_demand(descr_index);
     ctx.descr_refs.at(descr_index).is_some_and(|descr| {
         descr.as_call_descr().is_some_and(|cd| {
-            cd.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::LoadMethodSelf
+            cd.get_extra_info().runtime_helper == majit_ir::RuntimeHelperKind::LoadMethodSelf
         })
     })
 }
@@ -11058,7 +11058,7 @@ fn handle<Sym: WalkSym>(
             Ok((DispatchOutcome::Continue, op.next_pc))
         }
         "abort/" => {
-            // pyre-only `BC_ABORT` marker (`handler_abort_marker_pyre`,
+            // pyre-only `BC_ABORT` marker (`handler_abort_marker`,
             // `blackhole.rs`): the front-end emitted a graph node
             // with no dedicated `OpKind`, so reaching it means the body
             // carries an untranslatable op. The trace cannot be recorded;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1759,7 +1759,7 @@ fn escape_opcode_window_clean(py_pc: usize) -> bool {
 /// `reentrant` is the declared effect class, `EF_ELIDABLE_*`
 /// (`check_is_elidable`) or `EF_LOOPINVARIANT`.  It is deliberately STRICTER
 /// than `provably_side_effect_free`, which additionally exempts
-/// [`majit_ir::PyreHelperKind::ForIterNext`]: that exemption answers a
+/// [`majit_ir::RuntimeHelperKind::ForIterNext`]: that exemption answers a
 /// different question (the consume is the SOURCE of an in-flight item, not a
 /// body effect for it), and a user-defined `__next__` runs user bytecode that
 /// re-executing the opcode would re-run.
@@ -2342,11 +2342,11 @@ pub(crate) fn try_fold_pure_call_via_executor<Sym: WalkSym>(
 /// * `RaiseVarargs` trailing arg — `cause`: `normalize_raise_varargs` carries it
 ///   as the `raise X` (no `from`) sentinel, never dereferenced when null.
 pub(crate) fn mayforce_null_ref_arg_is_checked_sentinel(
-    helper: majit_ir::PyreHelperKind,
+    helper: majit_ir::RuntimeHelperKind,
     arg_index: usize,
     nargs: usize,
 ) -> bool {
-    use majit_ir::PyreHelperKind as K;
+    use majit_ir::RuntimeHelperKind as K;
     match helper {
         K::CallFn | K::CallKw | K::StoreDeref | K::WithExceptStart => arg_index == 1,
         K::CallFunctionEx => arg_index == 1 || arg_index == 3,
@@ -2381,7 +2381,7 @@ pub(crate) fn walker_abort_if_mayforce_null_ref_arg<Sym: WalkSym>(
     // `GcRef(usize::MAX)` means "no concrete known" and is left alone.
     //
     // Exemption: `bh_call_fn_N(callable, null_or_self, args...)`'s
-    let helper = call_descr.get_extra_info().pyre_helper;
+    let helper = call_descr.get_extra_info().runtime_helper;
     let nargs = call_descr.arg_types().len();
     for (i, &ty) in call_descr.arg_types().iter().enumerate() {
         if ty != majit_ir::Type::Ref {
@@ -2406,7 +2406,7 @@ pub(crate) fn walker_abort_if_mayforce_null_ref_arg<Sym: WalkSym>(
                     eprintln!(
                         "[p2-mayforce] NULL Ref arg: pc={pc} call_opcode={call_opcode:?} \
                          helper={:?} arg_index={i} nargs={} funcbox={:?}(={:?})",
-                        call_descr.get_extra_info().pyre_helper,
+                        call_descr.get_extra_info().runtime_helper,
                         call_descr.arg_types().len(),
                         allboxes.first(),
                         allboxes.first().and_then(|&f| ctx.trace_ctx.box_value(f)),
@@ -2519,10 +2519,10 @@ fn carrier_stack_box_for_ref_arg<Sym: WalkSym>(
 fn repair_carrier_call_ref_args<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
     op_pc: usize,
-    helper: majit_ir::PyreHelperKind,
+    helper: majit_ir::RuntimeHelperKind,
     r_args: &mut [OpRef],
 ) {
-    if !ctx.fbw_mode.carrier_resume || helper != majit_ir::PyreHelperKind::CallFn {
+    if !ctx.fbw_mode.carrier_resume || helper != majit_ir::RuntimeHelperKind::CallFn {
         return;
     }
     for arg in r_args.iter_mut() {
@@ -2553,9 +2553,9 @@ fn repair_carrier_call_ref_args<Sym: WalkSym>(
 pub(crate) fn residual_callee_is_walk_self_recursive<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
     allboxes: &[OpRef],
-    helper: majit_ir::PyreHelperKind,
+    helper: majit_ir::RuntimeHelperKind,
 ) -> bool {
-    if helper != majit_ir::PyreHelperKind::CallFn {
+    if helper != majit_ir::RuntimeHelperKind::CallFn {
         return false;
     }
     let sym_ptr = ctx.fbw_mode.snapshot_sym;
@@ -2622,13 +2622,13 @@ pub(crate) fn last_declined_symbolic_site()
 /// the `Void`-result write proxy the same discriminator opens with cannot see
 /// them.  A kind missing from here is a store the executed-effect odometer does
 /// not count, and a nested abort behind it rewinds and runs it twice.
-pub(crate) fn helper_kind_writes_live_heap(helper: majit_ir::PyreHelperKind) -> bool {
+pub(crate) fn helper_kind_writes_live_heap(helper: majit_ir::RuntimeHelperKind) -> bool {
     matches!(
         helper,
-        majit_ir::PyreHelperKind::StoreSubscr
-            | majit_ir::PyreHelperKind::SetCurrentException
-            | majit_ir::PyreHelperKind::StoreDeref
-            | majit_ir::PyreHelperKind::SetAddMethod
+        majit_ir::RuntimeHelperKind::StoreSubscr
+            | majit_ir::RuntimeHelperKind::SetCurrentException
+            | majit_ir::RuntimeHelperKind::StoreDeref
+            | majit_ir::RuntimeHelperKind::SetAddMethod
     )
 }
 
@@ -2756,7 +2756,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // code pointer to `bh_load_const_fn`, which dereferences it via
     // `w_code_get_ptr` and faults.  Leave it symbolic, mirroring the fold's
     // "falls through to the generic record" contract.
-    if call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::LoadConst {
+    if call_descr.get_extra_info().runtime_helper == majit_ir::RuntimeHelperKind::LoadConst {
         return Ok(declined_symbolic(call_opcode));
     }
     let funcptr_val = ctx.trace_ctx.box_value(allboxes[0]);
@@ -2906,7 +2906,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // keyword/star call declined as symbolic here, which drops the
     // recording iteration's call exactly once (`g(i, d=4)` in a hot loop
     // summed to n-1, callee ran n-1 times).
-    let helper = call_descr.get_extra_info().pyre_helper;
+    let helper = call_descr.get_extra_info().runtime_helper;
     for (i, &arg) in args.iter().enumerate() {
         if mayforce_null_ref_arg_is_checked_sentinel(helper, i, args.len()) {
             continue;
@@ -2946,7 +2946,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // normal residual dispatch execute user special methods; its existing
     // user-frame effect accounting handles any later abort.
     let inplace_list_journal: Option<(pyre_object::PyObjectRef, usize, isize)> =
-        if call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::BinaryOp
+        if call_descr.get_extra_info().runtime_helper == majit_ir::RuntimeHelperKind::BinaryOp
             && args.len() >= 3
             && pyre_interpreter::runtime_ops::binary_op_tag_is_inplace(args[2])
             && fbw_foriter_inflight_active()
@@ -2992,7 +2992,9 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // (the same `fbw_list_journal_push_append` contract the fold's own commit uses),
     // making the fall-through abort-safe instead of a silent double.
     let list_append_journal: Option<(pyre_object::PyObjectRef, usize, isize)> =
-        if call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::ListAppendValue {
+        if call_descr.get_extra_info().runtime_helper
+            == majit_ir::RuntimeHelperKind::ListAppendValue
+        {
             let list = args
                 .first()
                 .map(|&a| a as usize as pyre_object::PyObjectRef);
@@ -3073,7 +3075,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     //
     // The OLD allow-list (`StoreSubscr` / `CallFn` / `SetCurrentException`
     // only) MISSED the many statement-level mutators that reach this executor
-    // concretely, succeed, and carry `PyreHelperKind::None` (`store_attr_fn` /
+    // concretely, succeed, and carry `RuntimeHelperKind::None` (`store_attr_fn` /
     // `delete_subscr_fn` / `delete_attr_fn` / `list_extend_fn` / `store_name_fn`
     // / `store_global` / `store_slice` …): a missed mutator is a silent double
     // on a body re-run (correctness-FATAL).  Track residuals that WRITE live
@@ -3102,13 +3104,13 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // Provably read-only/elidable residuals are exempt up front: `@jit.elidable`-
     // class (`check_is_elidable`: `EF_ELIDABLE_*`, the pure executor folds
     // these) or `EF_LOOPINVARIANT` (loop-hoisted).  The `for_iter_next` consume
-    // itself ([`PyreHelperKind::ForIterNext`]) is excluded — it is the SOURCE of
+    // itself ([`RuntimeHelperKind::ForIterNext`]) is excluded — it is the SOURCE of
     // the capture (it runs while the PRIOR iteration's item is still in flight),
     // not a body effect for that prior iteration.  Sampled BEFORE the call so
     // the success arm can flag an effect that committed AFTER the in-flight
     // consume.
     let ei = call_descr.get_extra_info();
-    let helper = ei.pyre_helper;
+    let helper = ei.runtime_helper;
     // The declared re-runnability class, the axis `EffectInfo` is decided on at
     // codewriter time (`jtransform.py:620-630`): re-executing the opcode that
     // contains this residual re-executes the residual, which is harmless only
@@ -3131,7 +3133,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // A subclass/callable override misses pointer/type identity and keeps the
     // ordinary nested-residual decline.
     let observed_exact_scalar_str =
-        helper == majit_ir::PyreHelperKind::CallFn && args.len() == 3 && {
+        helper == majit_ir::RuntimeHelperKind::CallFn && args.len() == 3 && {
             let callable = args[0] as pyre_object::PyObjectRef;
             let operand = args[2] as pyre_object::PyObjectRef;
             let str_type =
@@ -3165,7 +3167,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // `trace_eagerness` cycle later.
     let native_exact_str_replay = !cfg!(target_arch = "wasm32");
     let observed_exact_str_iter = native_exact_str_replay
-        && helper == majit_ir::PyreHelperKind::GetIter
+        && helper == majit_ir::RuntimeHelperKind::GetIter
         && args.len() == 1
         && {
             let operand = args[0] as pyre_object::PyObjectRef;
@@ -3178,7 +3180,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // both canonical builtin-code identity and the observed exact string so a
     // rebound `ord` or a user object cannot enter this replay-safe class.
     let observed_exact_str_ord = native_exact_str_replay
-        && helper == majit_ir::PyreHelperKind::CallFn
+        && helper == majit_ir::RuntimeHelperKind::CallFn
         && args.len() == 3
         && pyre_interpreter::builtins::is_builtin_ord_function(args[0] as pyre_object::PyObjectRef)
         && {
@@ -3198,7 +3200,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // Require the canonical callable and an ordinary class whose metaclass is
     // exactly `type`; tuple/union classinfo and custom `__instancecheck__`
     // remain on the conservative nested-residual decline.
-    let observed_replay_safe_isinstance = helper == majit_ir::PyreHelperKind::CallFn
+    let observed_replay_safe_isinstance = helper == majit_ir::RuntimeHelperKind::CallFn
         && args.len() == 4
         && args[1] == 0
         && pyre_interpreter::builtins::is_builtin_isinstance_function(
@@ -3229,7 +3231,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // every other `CallFn` remains opaque and effectful.  It shares the `CallFn`
     // helper with the `str` and `ord` arms above and is separated from them by
     // the callable identity each one pins, so at most one can hold.
-    let replay_safe_tuple_from_list = helper == majit_ir::PyreHelperKind::CallFn
+    let replay_safe_tuple_from_list = helper == majit_ir::RuntimeHelperKind::CallFn
         && args.len() == 3
         && args[1] == 0
         && args[0] as usize
@@ -3251,7 +3253,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // `[randrange(k) for _ in ...]` body executes, and classifying it as a live
     // heap write refused the in-flight FOR_ITER delivery and dropped the
     // element.
-    let observed_exact_int_index = helper == majit_ir::PyreHelperKind::CallFn
+    let observed_exact_int_index = helper == majit_ir::RuntimeHelperKind::CallFn
         && args.len() == 3
         && args[1] == 0
         && pyre_interpreter::module::operator::is_operator_index_function(
@@ -3275,11 +3277,12 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // allocation helpers, and no helper kind is in both.
     let replay_safe_fresh_allocation = matches!(
         helper,
-        majit_ir::PyreHelperKind::NewtupleFromArray | majit_ir::PyreHelperKind::NewlistFromArray
+        majit_ir::RuntimeHelperKind::NewtupleFromArray
+            | majit_ir::RuntimeHelperKind::NewlistFromArray
     );
     let provably_side_effect_free = reentrant_residual
         || is_rerunnable_bookkeeping
-        || helper == majit_ir::PyreHelperKind::ForIterNext
+        || helper == majit_ir::RuntimeHelperKind::ForIterNext
         || observed_exact_scalar_str
         || observed_exact_str_iter
         || observed_exact_str_ord
@@ -3288,7 +3291,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         || replay_safe_tuple_from_list
         || observed_exact_int_index;
     let writes_live_heap = call_descr.result_type() == majit_ir::Type::Void
-        || (helper == majit_ir::PyreHelperKind::CallFn && !replay_safe_tuple_from_list)
+        || (helper == majit_ir::RuntimeHelperKind::CallFn && !replay_safe_tuple_from_list)
         || helper_kind_writes_live_heap(helper);
     // Inside an inline sub-walk, decline before any residual that is not
     // provably side-effect-free.  Ref-result getters/dunders/user `__next__`
@@ -3456,7 +3459,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // opcode past the recorded body pc — not by a next-instr convention.
     let is_loop_var_binding_store = matches!(
         helper,
-        majit_ir::PyreHelperKind::StoreName | majit_ir::PyreHelperKind::StoreGlobal
+        majit_ir::RuntimeHelperKind::StoreName | majit_ir::RuntimeHelperKind::StoreGlobal
     ) && fbw_foriter_inflight_top_body_pc()
         .is_some_and(|body_pc| body_pc + 1 == ctx.vstack_cur_pypc as usize);
     // PUSH_EXC_INFO's carrier clear is void-returning, so `writes_live_heap`
@@ -3470,7 +3473,8 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // body whose only committed residual was `except`'s clear had its delivery
     // refused and the whole iteration dropped — the outcome the refusal exists
     // to be safer than.
-    let writes_gc_liveness_root_only = helper == majit_ir::PyreHelperKind::ClearInFlightException;
+    let writes_gc_liveness_root_only =
+        helper == majit_ir::RuntimeHelperKind::ClearInFlightException;
     let body_effect_candidate = !provably_side_effect_free
         && !is_idempotent_gc_barrier
         && !is_loop_var_binding_store
@@ -3479,7 +3483,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         && fbw_foriter_inflight_active();
     // #57 Option C (Finding #1, user-frame signal): the Void/helper-tag write
     // discriminator above cannot see a body effect committed through USER
-    // PYTHON CODE by a value-returning (`Ref`), `PyreHelperKind::None`,
+    // PYTHON CODE by a value-returning (`Ref`), `RuntimeHelperKind::None`,
     // `MayForce` residual: `obj.prop` (a `@property` getter / `__getattr__` /
     // descriptor `__get__`), `a + b` / `a == b` (user `__add__` / `__eq__`),
     // `iter(obj)` (user `__iter__`), `str(obj)` / `f"{obj}"` (user `__str__` /
@@ -3501,7 +3505,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // the call so an attempt that aborts mid-way (a kept-stack guard on the
     // exhaustion arm) still records the completion; a successful attempt
     // replaces the entry with a fresh one anyway.
-    if helper == majit_ir::PyreHelperKind::ForIterNext {
+    if helper == majit_ir::RuntimeHelperKind::ForIterNext {
         let body = fbw_foriter_body_from_op_pc(ctx, op_pc)
             .unwrap_or_else(|| InflightForiterBody::Py(ctx.entry_py_pc() as usize + 1));
         fbw_foriter_inflight_mark_attempt(body);
@@ -4110,7 +4114,8 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
             // the in-flight iteration to the live frame instead of dropping
             // it.  A null result is the exhaustion arm (no item, no body
             // runs) — nothing to deliver, leave the stash empty.
-            if call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::ForIterNext
+            if call_descr.get_extra_info().runtime_helper
+                == majit_ir::RuntimeHelperKind::ForIterNext
                 && result_i64 != 0
             {
                 // The body pc is the FOR_ITER continue-arm fallthrough — the
@@ -4630,12 +4635,12 @@ pub(crate) fn residual_call_helper_kind_in_body(
     body_code: &[u8],
     d: &DecodedOp,
     callee_descr_refs: &[DescrRef],
-) -> Option<majit_ir::PyreHelperKind> {
+) -> Option<majit_ir::RuntimeHelperKind> {
     let descr_index = residual_call_descr_index_in_body(body_code, d)?;
     callee_descr_refs
         .get(descr_index)
         .and_then(|descr| descr.as_call_descr())
-        .map(|cd| cd.get_extra_info().pyre_helper)
+        .map(|cd| cd.get_extra_info().runtime_helper)
 }
 
 /// Return the per-function descriptor-pool index carried by a residual call
@@ -4741,7 +4746,7 @@ pub(crate) fn residual_call_specialized_plain_numeric_binop(
         "residual_call_ir_r/iIRd>r" | "residual_call_ir_i/iIRd>i" | "residual_call_ir_v/iIRd"
     ) || !matches!(
         helper,
-        Some(majit_ir::PyreHelperKind::BinaryOp | majit_ir::PyreHelperKind::CompareOp)
+        Some(majit_ir::RuntimeHelperKind::BinaryOp | majit_ir::RuntimeHelperKind::CompareOp)
     ) {
         return None;
     }
@@ -4786,7 +4791,7 @@ pub(crate) fn residual_call_specialized_plain_numeric_binop(
     // like the bitwise binops need.  `CHECK_EXC_MATCH` reuses the `CompareOp`
     // shape with `ISINSTANCE_OP` (tag 10), which is not one of the six and so
     // stays excluded.
-    if helper == Some(majit_ir::PyreHelperKind::CompareOp) {
+    if helper == Some(majit_ir::RuntimeHelperKind::CompareOp) {
         return pyre_interpreter::runtime_ops::compare_op_from_tag(tag)
             .is_some()
             .then_some(SpecializedBinop::Compare);
@@ -4833,7 +4838,7 @@ pub(crate) fn residual_call_store_attr_receiver_reg(
 ) -> Option<u8> {
     if d.key != "residual_call_ir_v/iIRd"
         || residual_call_helper_kind_in_body(body_code, d, callee_descr_refs)
-            != Some(majit_ir::PyreHelperKind::StoreAttr)
+            != Some(majit_ir::RuntimeHelperKind::StoreAttr)
     {
         return None;
     }
@@ -4871,7 +4876,7 @@ pub(crate) fn residual_call_is_exception_match(
 ) -> bool {
     if d.key != "residual_call_ir_r/iIRd>r"
         || residual_call_helper_kind_in_body(body_code, d, callee_descr_refs)
-            != Some(majit_ir::PyreHelperKind::CompareOp)
+            != Some(majit_ir::RuntimeHelperKind::CompareOp)
     {
         return false;
     }
@@ -4909,7 +4914,7 @@ pub(crate) fn residual_call_is_proven_truth(
 ) -> bool {
     if d.key != "residual_call_r_i/iRd>i"
         || residual_call_helper_kind_in_body(body_code, d, callee_descr_refs)
-            != Some(majit_ir::PyreHelperKind::Truth)
+            != Some(majit_ir::RuntimeHelperKind::Truth)
     {
         return false;
     }
@@ -4962,10 +4967,10 @@ pub(crate) fn residual_call_is_proven_truth(
 /// the flush leg that commits the journal instead of replaying the region.
 fn try_walker_force_quasi_immut_namespace_write<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
-    helper: majit_ir::PyreHelperKind,
+    helper: majit_ir::RuntimeHelperKind,
     r_args: &[OpRef],
 ) -> Option<()> {
-    use majit_ir::PyreHelperKind as K;
+    use majit_ir::RuntimeHelperKind as K;
     let is_store = matches!(helper, K::StoreName | K::StoreGlobal);
     if !is_store && !matches!(helper, K::DeleteName | K::DeleteGlobal) {
         return None;
@@ -5185,7 +5190,7 @@ fn mapdict_qmut_force_enabled() -> bool {
 /// exists, unguarded, and is documented here rather than gated.
 ///
 /// The one admission that made closure callees inline, and with them their
-/// cells reach a sub-walk as constants, was `PyreHelperKind::LoadDeref` in
+/// cells reach a sub-walk as constants, was `RuntimeHelperKind::LoadDeref` in
 /// `fbw_state.rs` `replay_safe_read`.  That listing is out — see the note
 /// there and `bench/synth/_pending/caller_f_lasti_across_residual_call.py`.
 fn try_walker_specialize_load_deref<Sym: WalkSym>(
@@ -5289,11 +5294,11 @@ fn walker_pin_plain_ever_mutated<Sym: WalkSym>(
 fn try_walker_force_quasi_immut_mapdict_write<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,
-    helper: majit_ir::PyreHelperKind,
+    helper: majit_ir::RuntimeHelperKind,
     i_args: &[OpRef],
     r_args: &[OpRef],
 ) -> Option<()> {
-    use majit_ir::PyreHelperKind as K;
+    use majit_ir::RuntimeHelperKind as K;
     let is_store = matches!(helper, K::StoreAttr);
     if !is_store && !matches!(helper, K::DeleteAttr) {
         return None;
@@ -5612,7 +5617,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     };
 
     let ei = call_descr.get_extra_info();
-    repair_carrier_call_ref_args(ctx, op.pc, ei.pyre_helper, &mut r_args);
+    repair_carrier_call_ref_args(ctx, op.pc, ei.runtime_helper, &mut r_args);
 
     // A profiled frame owes `c_call` / `c_return` around every builtin call
     // its bytecode makes -- `baseobjspace.py call_valuestack`, `pyopcode.py`
@@ -5624,7 +5629,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     //
     // So decline the walk rather than compile a loop that runs its tail
     // silently.  The three call helpers are the whole population that owes an
-    // event -- every other `PyreHelperKind` reaching this dispatcher erases an
+    // event -- every other `RuntimeHelperKind` reaching this dispatcher erases an
     // operator dispatch, which reports nothing on cpython, pypy3 or pyre
     // alike.  A `CallFn` naming a Python callee owes no `c_call` either, but
     // the fold gives the walker no way to tell, and declining is the safe
@@ -5636,10 +5641,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // unprofiled cell -- see `DispatchError::ProfiledResidualCall`.
     if ctx.session.borrow().is_being_profiled
         && matches!(
-            ei.pyre_helper,
-            majit_ir::PyreHelperKind::CallFn
-                | majit_ir::PyreHelperKind::CallKw
-                | majit_ir::PyreHelperKind::CallFunctionEx
+            ei.runtime_helper,
+            majit_ir::RuntimeHelperKind::CallFn
+                | majit_ir::RuntimeHelperKind::CallKw
+                | majit_ir::RuntimeHelperKind::CallFunctionEx
         )
     {
         return Err(DispatchError::ProfiledResidualCall { pc: op.pc });
@@ -5651,7 +5656,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     clear_walk_exception(ctx);
 
     // Offer the specific pop fold before generic builtin inlining. Now that
-    // `list.pop` has a `__pyre_wrap_*` gateway, the generic path finds its
+    // `list.pop` has a `__majit_wrap_*` gateway, the generic path finds its
     // jitcode and otherwise descends into the wrapper until `w_list_len`'s
     // lock seam. Restrict this to the root walk: guards emitted in an inline
     // subwalk resume at the caller CALL boundary and could repeat an earlier
@@ -5659,7 +5664,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && !ctx.fbw_mode.inline_subwalk
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && try_walker_orthodox_list_pop(ctx, code, op, &r_args, dst)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -5675,7 +5680,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // generic residual (SAFE).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("builtin_len", || {
             try_walker_specialize_builtin_len(ctx, code, op, &r_args, dst)
         })?
@@ -5700,7 +5705,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // which loses the brake rather than applying a wrong one.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && walker_portal_py_code(ctx)
             .is_none_or(|portal| !pyre_interpreter::code_returns_only_constants(portal))
         && try_walker_force_quasi_immut_class_body(ctx, code, op, 1, &r_args)
@@ -5717,7 +5722,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // gateway wrappers.  Enter its generated JitCode before considering the
     // user-function-only full-body walk below.
     if let Some(inlined) =
-        try_walker_inline_builtin_call(ctx, op, code, 1, &r_args, ei.pyre_helper, dst_bank, dst)?
+        try_walker_inline_builtin_call(ctx, op, code, 1, &r_args, ei.runtime_helper, dst_bank, dst)?
     {
         return Ok(inlined);
     }
@@ -5725,7 +5730,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // #62 slice (3c): attempt full-body-walk inline of a user-function call
     // unconditionally. Eligible exact-positional closure-free
     // calls sub-walk the callee body in place of the residual; ineligible
-    // calls (including every non-`call_fn` helper, gated on `pyre_helper`)
+    // calls (including every non-`call_fn` helper, gated on `runtime_helper`)
     // fall through with no IR emitted.
     if let Some(inlined) = try_walker_inline_user_call(
         ctx,
@@ -5735,7 +5740,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         funcptr,
         &r_args,
         call_descr,
-        ei.pyre_helper,
+        ei.runtime_helper,
         dst_bank,
         dst,
     )? {
@@ -5744,7 +5749,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
 
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
     {
         if let Some(inlined) = try_walker_inline_exception_string_override(
             ctx, op, code, funcptr, &r_args, call_descr, dst,
@@ -5776,7 +5781,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         funcptr,
         &r_args,
         call_descr,
-        ei.pyre_helper,
+        ei.runtime_helper,
         dst_bank,
         dst,
     )? {
@@ -5797,12 +5802,12 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
                 _ => None,
             });
             eprintln!(
-                "[fbw-unbound] pc={} regs={:?} r_args={:?} func={:?} pyre_helper={:?}",
+                "[fbw-unbound] pc={} regs={:?} r_args={:?} func={:?} runtime_helper={:?}",
                 op.pc,
                 regs,
                 r_args,
                 funcaddr.map(|a| format!("{a:#x}")),
-                ei.pyre_helper,
+                ei.runtime_helper,
             );
         }
         return Err(e);
@@ -5828,7 +5833,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
             })
             .collect();
         eprintln!(
-            "[PYRE_PROBE_SUBSCR] dispatch_residual_call_iRd_kind pc={} dst_bank={} r_args.len={} funcptr_addr={:?} arg_addrs={:?}",
+            "[MAJIT_PROBE_SUBSCR] dispatch_residual_call_iRd_kind pc={} dst_bank={} r_args.len={} funcptr_addr={:?} arg_addrs={:?}",
             op.pc,
             dst_bank,
             r_args.len(),
@@ -5871,8 +5876,8 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'v'
         && r_args.len() == 3
         && matches!(
-            ei.pyre_helper,
-            majit_ir::PyreHelperKind::StoreName | majit_ir::PyreHelperKind::StoreGlobal
+            ei.runtime_helper,
+            majit_ir::RuntimeHelperKind::StoreName | majit_ir::RuntimeHelperKind::StoreGlobal
         )
         && !walk_body_has_exception_handler(ctx, code)
     {
@@ -5889,7 +5894,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
                 if try_walker_store_name_cell_fold(
                     ctx,
                     op.pc,
-                    ei.pyre_helper,
+                    ei.runtime_helper,
                     frame_ptr,
                     w_name_ptr,
                     value_opref,
@@ -5910,7 +5915,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // uses for its own contract — would double-apply the store or the delete.
     if ctx.is_authoritative_executor
         && dst_bank == 'v'
-        && try_walker_force_quasi_immut_namespace_write(ctx, ei.pyre_helper, &r_args).is_some()
+        && try_walker_force_quasi_immut_namespace_write(ctx, ei.runtime_helper, &r_args).is_some()
     {
         // Carry the reason to the `abort_trace` that follows, the way upstream
         // carries it on the `SwitchToBlackhole` instance (pyjitpl.py:2906-2910).
@@ -5947,7 +5952,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         // (e.g. the `(i % 7)` in `(i % 7) and (i + 3)`) folds to a pure
         // `int_is_true`, eliding the may-force call whose force/exc guards
         // mis-resume the kept short-circuit stack.
-        if ei.pyre_helper == majit_ir::PyreHelperKind::Truth {
+        if ei.runtime_helper == majit_ir::RuntimeHelperKind::Truth {
             if let Some(truth) = spec_gate("truth_int", || {
                 try_walker_specialize_truth_int(ctx, op.pc, r_args[0])
             })? {
@@ -5975,7 +5980,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && r_args.len() == 1
-        && ei.pyre_helper == majit_ir::PyreHelperKind::UnaryPositive
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::UnaryPositive
         && spec_gate("unary_positive_int", || {
             try_walker_specialize_unary_positive_int(ctx, op.pc, r_args[0], dst, dst_bank)
         })?
@@ -5992,7 +5997,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && r_args.len() == 1
-        && ei.pyre_helper == majit_ir::PyreHelperKind::UnaryNegative
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::UnaryNegative
         && spec_gate("unary_negative_int", || {
             try_walker_specialize_unary_negative_int(
                 ctx, op.pc, r_args[0], &allboxes, call_descr, dst, dst_bank,
@@ -6010,7 +6015,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && r_args.len() == 1
-        && ei.pyre_helper == majit_ir::PyreHelperKind::UnaryInvert
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::UnaryInvert
         && spec_gate("unary_invert_int", || {
             try_walker_specialize_unary_invert_int(
                 ctx, op.pc, r_args[0], &allboxes, call_descr, dst, dst_bank,
@@ -6029,7 +6034,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // whose commit/rollback epilogues run on FBW walk ends.
     if ctx.is_authoritative_executor
         && dst_bank == 'v'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::StoreSubscr
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::StoreSubscr
     {
         if spec_gate("store_subscr", || {
             try_walker_specialize_store_subscr(ctx, op.pc, &r_args)
@@ -6062,7 +6067,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
 
     // Range GET_ITER: virtualize exact machine-word `range` into the same
     // `W_IntRangeIterator` shape PyPy's inlined `descr_iter` would trace.
-    if ctx.is_authoritative_executor && ei.pyre_helper == majit_ir::PyreHelperKind::GetIter {
+    if ctx.is_authoritative_executor && ei.runtime_helper == majit_ir::RuntimeHelperKind::GetIter {
         if let Some(iter_op) = spec_gate("get_iter", || {
             try_walker_specialize_get_iter(ctx, op.pc, &r_args, dst, dst_bank)
         })? {
@@ -6082,7 +6087,9 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // The specialization supplies the same Ref result that the residual would,
     // including NULL for exhaustion, so the codewriter's trailing
     // GuardNonnull remains the only loop-exit guard.
-    if ctx.is_authoritative_executor && ei.pyre_helper == majit_ir::PyreHelperKind::ForIterNext {
+    if ctx.is_authoritative_executor
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::ForIterNext
+    {
         if let Some(item_op) = spec_gate("for_iter_next", || {
             try_walker_specialize_for_iter_next(ctx, op.pc, &r_args, dst, dst_bank)
         })? {
@@ -6104,7 +6111,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // reproduce constant-for-constant (SAFE — never declined).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::MakeFunction
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::MakeFunction
         && spec_gate("make_function", || {
             try_walker_specialize_make_function(ctx, op.pc, &r_args, dst, dst_bank)
         })?
@@ -6120,7 +6127,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // opaque residual for any other shape (SAFE — never declined).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::NewtupleFromArray
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::NewtupleFromArray
         && spec_gate("newtuple", || {
             try_walker_specialize_newtuple(ctx, op.pc, &r_args, dst, dst_bank)
         })?
@@ -6137,7 +6144,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // declined).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::NewtupleFromArray
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::NewtupleFromArray
         && spec_gate("newtuple_object", || {
             try_walker_specialize_newtuple_object(ctx, op.pc, &r_args, dst, dst_bank)
         })?
@@ -6157,7 +6164,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // declined.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::NewlistFromArray
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::NewlistFromArray
         && spec_gate("newlist", || {
             try_walker_specialize_newlist(ctx, op.pc, &r_args, dst, dst_bank)
         })?
@@ -6203,7 +6210,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && !ctx.fbw_mode.inline_subwalk
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && try_walker_orthodox_list_append(ctx, code, op, &r_args, dst)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -6220,7 +6227,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && !ctx.fbw_mode.inline_subwalk
         && dst_bank == 'v'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::ListAppendValue
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::ListAppendValue
     {
         // Fold to native array stores when the receiver has spare capacity, or
         // fall through to the generic `jit_list_append` residual below.  The
@@ -6245,7 +6252,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // iterator state and read the resolved entry value live.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("builtin_dict_get", || {
             try_walker_specialize_builtin_dict_get(ctx, code, op, &r_args, dst)
         })?
@@ -6259,7 +6266,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // Non-matching shapes fall through to the generic residual.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("builtin_type_getattr", || {
             try_walker_specialize_builtin_type_getattr(ctx, code, op, &r_args, dst)
         })?
@@ -6274,7 +6281,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // which answers the receiver the instance-shape read declines.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("builtin_getattr", || {
             try_walker_specialize_builtin_getattr(ctx, code, op, &r_args, dst)
         })?
@@ -6288,7 +6295,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // Non-canonical callables and arguments fall through to the residual.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
     {
         if let Some(outcome) = spec_gate("builtin_range", || {
             try_walker_specialize_builtin_range(ctx, code, op, funcptr, &r_args, call_descr, dst)
@@ -6300,7 +6307,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // Virtualize PyPy's exact `zip(tuple0, tuple1, strict=True)` shape.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallKw
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallKw
         && spec_gate("builtin_zip", || {
             try_walker_specialize_builtin_zip(ctx, code, op, &r_args, dst)
         })?
@@ -6320,7 +6327,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // falls through to the generic residual (SAFE).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("builtin_locals", || {
             try_walker_specialize_builtin_locals(ctx, code, op, &r_args, dst)
         })?
@@ -6339,7 +6346,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // through to the generic residual (SAFE).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("sys_getframe", || {
             try_walker_specialize_sys_getframe(ctx, code, op, &r_args, dst)
         })?
@@ -6356,7 +6363,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // non-finite sqrt) falls through to the generic residual (SAFE).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("math_sqrt", || {
             try_walker_specialize_math_sqrt(ctx, code, op, &r_args, dst)
         })?
@@ -6366,7 +6373,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("math_log_trig", || {
             try_walker_specialize_math_log_trig(ctx, code, op, &r_args, dst)
         })?
@@ -6376,7 +6383,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("math_frexp", || {
             try_walker_specialize_math_frexp(ctx, code, op, &r_args, dst)
         })?
@@ -6386,7 +6393,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("math_ldexp", || {
             try_walker_specialize_math_ldexp(ctx, code, op, &r_args, dst)
         })?
@@ -6396,7 +6403,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("math_isqrt", || {
             try_walker_specialize_math_isqrt(ctx, code, op, &r_args, dst)
         })?
@@ -6406,7 +6413,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("math_fabs", || {
             try_walker_specialize_math_fabs(ctx, code, op, &r_args, dst)
         })?
@@ -6416,7 +6423,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("math_float1", || {
             try_walker_specialize_math_float1(ctx, code, op, &r_args, dst)
         })?
@@ -6426,7 +6433,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("math_float2", || {
             try_walker_specialize_math_float2(ctx, code, op, &r_args, dst)
         })?
@@ -6436,7 +6443,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("math_isclose", || {
             try_walker_specialize_math_isclose(ctx, code, op, &r_args, dst, dst_bank)
         })?
@@ -6446,7 +6453,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("builtin_fold1", || {
             try_walker_specialize_builtin_fold1(ctx, code, op, &r_args, dst)
         })?
@@ -6456,7 +6463,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("builtin_fold2", || {
             try_walker_specialize_builtin_fold2(ctx, code, op, &r_args, dst)
         })?
@@ -6466,7 +6473,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("math_floor", || {
             try_walker_specialize_math_round_to_int(
                 ctx,
@@ -6483,7 +6490,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("math_ceil", || {
             try_walker_specialize_math_round_to_int(
                 ctx,
@@ -6500,7 +6507,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("math_trunc", || {
             try_walker_specialize_math_round_to_int(
                 ctx,
@@ -6517,7 +6524,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("int_call", || {
             try_walker_specialize_int_call(ctx, code, op, &r_args, dst)
         })?
@@ -6527,7 +6534,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("bare_super_call", || {
             try_walker_specialize_bare_super_call(ctx, code, op, &r_args, dst)
         })?
@@ -6537,7 +6544,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("float_call", || {
             try_walker_specialize_float_call(ctx, code, op, &r_args, dst)
         })?
@@ -6547,7 +6554,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("str_call", || {
             try_walker_specialize_str_call(ctx, code, op, &r_args, dst)
         })?
@@ -6564,7 +6571,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // through to the generic residual (SAFE).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate("builtin_divmod", || {
             try_walker_specialize_builtin_divmod(ctx, code, op, &r_args, dst)
         })?
@@ -6588,14 +6595,14 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // through to the generic residual (SAFE).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && try_walker_trace_exception_new(ctx, code, op, &r_args, dst)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::RaiseVarargs
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::RaiseVarargs
         && r_args.is_empty()
         && ctx.fbw_mode.current_exception_seed.is_some()
     {
@@ -6617,7 +6624,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::RaiseVarargs
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::RaiseVarargs
         && try_walker_trace_raise_builtin(ctx, code, op, &r_args, dst)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -6627,7 +6634,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // canonical builtin exception class.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::RaiseVarargs
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::RaiseVarargs
         && try_walker_trace_raise_bare_class(ctx, code, op, &r_args, dst)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -6636,7 +6643,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // exc-info-stack residuals to GETFIELD_GC_R / SETFIELD_GC on the EC's
     // `sys_exc_value` slot, and consume the interpreter-only propagation-root
     // clear without recording a runtime CallN. Recognised by the
-    // codewriter-stamped `pyre_helper` tag (not a funcptr address — the
+    // codewriter-stamped `runtime_helper` tag (not a funcptr address — the
     // residual calls the cross-crate `cpu.{get,set}_current_exception_fn`
     // wrappers).  A balanced PUSH save + POP restore on the same descr-
     // identity field is dead-store-eliminated by the heap optimizer, so a
@@ -6645,16 +6652,16 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // CALL that otherwise forces the exception to materialize.
     if ctx.is_authoritative_executor
         && matches!(
-            ei.pyre_helper,
-            majit_ir::PyreHelperKind::GetCurrentException
-                | majit_ir::PyreHelperKind::SetCurrentException
-                | majit_ir::PyreHelperKind::ClearInFlightException
+            ei.runtime_helper,
+            majit_ir::RuntimeHelperKind::GetCurrentException
+                | majit_ir::RuntimeHelperKind::SetCurrentException
+                | majit_ir::RuntimeHelperKind::ClearInFlightException
         )
         && try_walker_lower_exc_info_residual(
             ctx,
             code,
             op,
-            ei.pyre_helper,
+            ei.runtime_helper,
             &r_args,
             dst_bank,
             dst,
@@ -6677,7 +6684,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // the generic path already emits.  A decline leaves every binding
     // untouched.
     //
-    // The substituted descr carries `PyreHelperKind::SetAddMethod` for one
+    // The substituted descr carries `RuntimeHelperKind::SetAddMethod` for one
     // reason: `writes_live_heap` below reads the helper tag and the result
     // type, and the generic call it replaces arrived tagged `CallFn`.  An
     // untagged `MOST_GENERAL` descr with a `Ref` result matches neither, so the
@@ -6691,7 +6698,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // rather than merely survivable by them.
     let set_add_subst = if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
     {
         spec_gate("set_add_method", || {
             try_walker_specialize_set_add_method(ctx, code, op, &r_args)
@@ -7001,8 +7008,8 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // fold gate below runs after the StoreAttr arm's `descr = specialized_
     // descr` reassignment, which the live `original_call_descr` borrow would
     // otherwise forbid (E0506).
-    let pyre_helper_kind = original_call_descr.get_extra_info().pyre_helper;
-    repair_carrier_call_ref_args(ctx, op.pc, pyre_helper_kind, &mut r_args);
+    let runtime_helper_kind = original_call_descr.get_extra_info().runtime_helper;
+    repair_carrier_call_ref_args(ctx, op.pc, runtime_helper_kind, &mut r_args);
     // Void shape `_ir_v/iIRd` (`pyjitpl.py opimpl_residual_call_ir_v =
     // _opimpl_residual_call2`) has no `>X` dst byte; see
     // `dispatch_residual_call_iRd_kind` for the void operand-layout note.
@@ -7040,7 +7047,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         && try_walker_force_quasi_immut_mapdict_write(
             ctx,
             op.pc,
-            pyre_helper_kind,
+            runtime_helper_kind,
             &i_args,
             &r_args,
         )
@@ -7062,7 +7069,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // every shape it cannot reproduce (SAFE — never declined).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && pyre_helper_kind == majit_ir::PyreHelperKind::SetFunctionAttribute
+        && runtime_helper_kind == majit_ir::RuntimeHelperKind::SetFunctionAttribute
         && spec_gate("set_function_attribute", || {
             try_walker_specialize_set_function_attribute(
                 ctx, op.pc, &i_args, &r_args, dst, dst_bank,
@@ -7085,7 +7092,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // could not inline, so the admission is revoked and the callee denied.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && pyre_helper_kind == majit_ir::PyreHelperKind::LoadDeref
+        && runtime_helper_kind == majit_ir::RuntimeHelperKind::LoadDeref
     {
         if let Some(value) = spec_gate("load_deref", || {
             try_walker_specialize_load_deref(ctx, op.pc, &r_args)
@@ -7102,7 +7109,8 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // descriptors, custom hooks, absent/boxed/float slots, and type-changing
     // values retain the original CallMayForceN unchanged.
     if ctx.is_authoritative_executor
-        && original_call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::StoreAttr
+        && original_call_descr.get_extra_info().runtime_helper
+            == majit_ir::RuntimeHelperKind::StoreAttr
     {
         if let (Some(&obj_opref), Some(&value_opref), Some(&code_opref), Some(&namei_opref)) =
             (r_args.first(), r_args.get(1), r_args.get(2), i_args.first())
@@ -7171,7 +7179,9 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // DELETE_ATTR immutable-type raise fold — the deletion twin of the
     // STORE_ATTR fold above.  `bh_delete_attr_fn(obj, code, name_idx)`
     // carries no value operand: r_args = [obj, code], i_args = [name_idx].
-    if ctx.is_authoritative_executor && pyre_helper_kind == majit_ir::PyreHelperKind::DeleteAttr {
+    if ctx.is_authoritative_executor
+        && runtime_helper_kind == majit_ir::RuntimeHelperKind::DeleteAttr
+    {
         if let (Some(&obj_opref), Some(&code_opref), Some(&namei_opref)) =
             (r_args.first(), r_args.get(1), i_args.first())
         {
@@ -7224,7 +7234,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         code,
         1 + i_width,
         &r_args,
-        ei.pyre_helper,
+        ei.runtime_helper,
         dst_bank,
         dst,
     )? {
@@ -7239,7 +7249,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         funcptr,
         &r_args,
         call_descr,
-        ei.pyre_helper,
+        ei.runtime_helper,
         dst_bank,
         dst,
     )? {
@@ -7247,7 +7257,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     }
 
     // A class is not a `Function`, so the user-call route above declined it.
-    if ei.pyre_helper == majit_ir::PyreHelperKind::CallFn {
+    if ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn {
         if let Some(inlined) =
             try_walker_inline_type_call(ctx, op, code, funcptr, &r_args, call_descr, dst_bank, dst)?
         {
@@ -7264,7 +7274,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // have produced — the indexed entry is loop-invariant — and suppress the
     // residual.  Falls through to the generic record when either operand is
     // not concrete (the residual stays correct in that case).
-    if ei.pyre_helper == majit_ir::PyreHelperKind::LoadConst {
+    if ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadConst {
         if let (Some(&idx_opref), Some(&code_opref)) = (i_args.first(), r_args.first()) {
             if let (
                 Some(majit_ir::Value::Int(consti)),
@@ -7314,7 +7324,8 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // `bh_load_global_fn` does and reaches production parity for
     // global-function-call loops when combined with the user-call inlining
     // path. Handler-bearing reachability also includes the builtins fallback.
-    if ctx.is_authoritative_executor && ei.pyre_helper == majit_ir::PyreHelperKind::LoadGlobal {
+    if ctx.is_authoritative_executor && ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadGlobal
+    {
         if let (Some(&namei_opref), Some(&ns_opref), Some(&code_opref)) =
             (i_args.first(), r_args.first(), r_args.get(1))
         {
@@ -7343,7 +7354,8 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
             ctx.trace_ctx.reads_module_global = true;
         }
     }
-    if ctx.is_authoritative_executor && ei.pyre_helper == majit_ir::PyreHelperKind::LoadGlobal {
+    if ctx.is_authoritative_executor && ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadGlobal
+    {
         if let (Some(&namei_opref), Some(&ns_opref), Some(&code_opref)) =
             (i_args.first(), r_args.first(), r_args.get(1))
         {
@@ -7381,7 +7393,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // above.  The residual is `bh_load_name_fn(frame, w_name, namei)`, so
     // r_args = [frame, w_name].  `try_walker_load_name_cell_fold` gates module
     // scope at runtime and routes non-module frames back to this residual.
-    if ctx.is_authoritative_executor && ei.pyre_helper == majit_ir::PyreHelperKind::LoadName {
+    if ctx.is_authoritative_executor && ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadName {
         if let (Some(&frame_opref), Some(&name_opref)) = (r_args.first(), r_args.get(1)) {
             if let (
                 Some(majit_ir::Value::Ref(majit_ir::GcRef(frame_ptr))),
@@ -7435,7 +7447,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // 1.32us per iteration; at the fixture's own 3000 iterations the difference
     // sits under this box's noise floor.
     if ctx.is_authoritative_executor
-        && ei.pyre_helper == majit_ir::PyreHelperKind::LoadName
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadName
         && !walk_body_has_exception_handler(ctx, code)
     {
         if let (Some(&frame_opref), Some(&name_opref)) = (r_args.first(), r_args.get(1)) {
@@ -7463,7 +7475,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // guard proves the attribute is present on this shape), so it is attempted
     // even in handler-bearing bodies; every unfoldable shape falls through to
     // the residual (which keeps its exception guard).
-    if ctx.is_authoritative_executor && ei.pyre_helper == majit_ir::PyreHelperKind::LoadAttr {
+    if ctx.is_authoritative_executor && ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadAttr {
         if let (Some(&obj_opref), Some(&code_opref), Some(&namei_opref)) =
             (r_args.first(), r_args.get(1), i_args.first())
         {
@@ -7564,7 +7576,8 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // STORE_ATTR property setter: the plain-slot store fold above declines a
     // `property` data descriptor; inline its Python setter instead of the
     // opaque `setattr` residual.  `store_attr_fn` r_args = [obj, value, code].
-    if ctx.is_authoritative_executor && ei.pyre_helper == majit_ir::PyreHelperKind::StoreAttr {
+    if ctx.is_authoritative_executor && ei.runtime_helper == majit_ir::RuntimeHelperKind::StoreAttr
+    {
         if let (Some(&obj_opref), Some(&value_opref), Some(&code_opref), Some(&namei_opref)) =
             (r_args.first(), r_args.get(1), r_args.get(2), i_args.first())
         {
@@ -7594,7 +7607,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         }
     }
     if ctx.is_authoritative_executor
-        && ei.pyre_helper == majit_ir::PyreHelperKind::LoadAttr
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadAttr
         && next_op_is_load_method_self_for_attr(code, op, ctx, dst)
     {
         if let (Some(&obj_opref), Some(&code_opref), Some(&namei_opref)) =
@@ -7665,7 +7678,9 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
             }
         }
     }
-    if ctx.is_authoritative_executor && ei.pyre_helper == majit_ir::PyreHelperKind::LoadMethodSelf {
+    if ctx.is_authoritative_executor
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadMethodSelf
+    {
         if let (Some(&namei_opref), Some(&obj_opref), Some(&attr_opref), Some(&code_opref)) =
             (i_args.first(), r_args.first(), r_args.get(1), r_args.get(2))
         {
@@ -7721,7 +7736,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // (`getfield_gc_pure`) forwards through the setfield and the box DCEs
     // when it never escapes.  The concrete shadow carries the authentic
     // boxed pointer so downstream specializations still see a concrete int.
-    if ei.pyre_helper == majit_ir::PyreHelperKind::BoxInt && dst_bank == 'r' {
+    if ei.runtime_helper == majit_ir::RuntimeHelperKind::BoxInt && dst_bank == 'r' {
         if let Some(&raw_arg) = i_args.first() {
             if let Some(boxed_ptr) = walker_execute_may_force_boxed(ctx, &allboxes, call_descr) {
                 let intval =
@@ -7744,12 +7759,12 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // paths.  Falls through to the generic record for
     // non-int operands / deferred operators.
     if matches!(
-        ei.pyre_helper,
-        majit_ir::PyreHelperKind::BinaryOp | majit_ir::PyreHelperKind::CompareOp
+        ei.runtime_helper,
+        majit_ir::RuntimeHelperKind::BinaryOp | majit_ir::RuntimeHelperKind::CompareOp
     ) {
         if let Some(&tag_opref) = i_args.first() {
             if let Some(majit_ir::Value::Int(op_tag)) = ctx.trace_ctx.box_value(tag_opref) {
-                let specialized = if ei.pyre_helper == majit_ir::PyreHelperKind::BinaryOp {
+                let specialized = if ei.runtime_helper == majit_ir::RuntimeHelperKind::BinaryOp {
                     let is_subscr = matches!(
                         pyre_interpreter::runtime_ops::binary_op_from_tag(op_tag),
                         Some(pyre_interpreter::bytecode::BinaryOperator::Subscr)
@@ -7926,14 +7941,14 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 if specialized.is_some() {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
                 }
-                if ei.pyre_helper == majit_ir::PyreHelperKind::BinaryOp {
+                if ei.runtime_helper == majit_ir::RuntimeHelperKind::BinaryOp {
                     if let Some(inlined) = try_walker_inline_user_binop(
                         ctx, op, code, op_tag, &r_args, call_descr, dst, dst_bank,
                     )? {
                         return Ok(inlined);
                     }
                 }
-                if ei.pyre_helper == majit_ir::PyreHelperKind::CompareOp {
+                if ei.runtime_helper == majit_ir::RuntimeHelperKind::CompareOp {
                     if let Some(inlined) = try_walker_inline_user_compareop(
                         ctx, op, code, op_tag, &r_args, call_descr, dst, dst_bank,
                     )? {
@@ -7949,13 +7964,13 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // path's value0/value1 fold).  A non-foldable shape falls through to the
     // opaque residual below — correct, no decline.
     if matches!(
-        ei.pyre_helper,
-        majit_ir::PyreHelperKind::UnpackSequence | majit_ir::PyreHelperKind::UnpackItem
+        ei.runtime_helper,
+        majit_ir::RuntimeHelperKind::UnpackSequence | majit_ir::RuntimeHelperKind::UnpackItem
     ) && spec_gate("unpack", || {
         try_walker_specialize_unpack(
             ctx,
             op.pc,
-            ei.pyre_helper,
+            ei.runtime_helper,
             &i_args,
             &r_args,
             &allboxes,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -153,7 +153,7 @@ fn walker_emit_recorded_builtin_raise<Sym: WalkSym>(
 }
 
 /// #124: walker-native truth specialization for the `truth_fn` residual
-/// (oopspec [`majit_ir::PyreHelperKind::Truth`]).  When the sole Ref operand
+/// (oopspec [`majit_ir::RuntimeHelperKind::Truth`]).  When the sole Ref operand
 /// is a concrete boxed `W_IntObject` (excluding `W_BoolObject`, which shares
 /// the `intval: i64` layout but carries a distinct `BOOL_TYPE` `ob_type`, so
 /// the emitted `GUARD_CLASS INT` would not match it), unbox it
@@ -242,7 +242,7 @@ pub(crate) fn try_walker_specialize_truth_bool<Sym: WalkSym>(
 }
 
 /// #61: walker-native identity fold for the `UNARY_POSITIVE` residual
-/// (oopspec [`majit_ir::PyreHelperKind::UnaryPositive`]).  The object-space
+/// (oopspec [`majit_ir::RuntimeHelperKind::UnaryPositive`]).  The object-space
 /// `pos` on an exact int returns the operand unchanged, so a concrete non-bool
 /// `W_IntObject` operand folds to the operand box itself behind the same guard
 /// prefix the truth / binary int folds emit (a low-bit tag test for a tagged
@@ -403,7 +403,7 @@ fn walker_emit_ovf2long_box<Sym: WalkSym>(
 }
 
 /// #61: walker-native int specialization for the `UNARY_NEGATIVE` residual
-/// (oopspec [`majit_ir::PyreHelperKind::UnaryNegative`]).  `-x` on an exact
+/// (oopspec [`majit_ir::RuntimeHelperKind::UnaryNegative`]).  `-x` on an exact
 /// int is `0 - x`; the object-space `neg` promotes only `-INT_MIN` to a
 /// `W_LongObject` (`intobject.py` `descr_neg` → `_make_ovf2long`).  Since
 /// majit has no overflow-checked unary negate, the fold expresses `-x` as
@@ -484,7 +484,7 @@ pub(crate) fn try_walker_specialize_unary_negative_int<Sym: WalkSym>(
 }
 
 /// #61: walker-native int specialization for the `UNARY_INVERT` residual
-/// (oopspec [`majit_ir::PyreHelperKind::UnaryInvert`]).  `~x` on an exact int
+/// (oopspec [`majit_ir::RuntimeHelperKind::UnaryInvert`]).  `~x` on an exact int
 /// is `!x`, which always fits an i64 (`~INT_MIN == INT_MAX`, `~INT_MAX ==
 /// INT_MIN`), so `descr_invert` never promotes to a long: the fold emits a
 /// plain `IntInvert` behind a `GUARD_CLASS INT`, with no overflow guard.
@@ -1989,7 +1989,7 @@ pub(crate) fn specialised_pair_kind(
 pub(crate) fn try_walker_specialize_unpack<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,
-    helper: majit_ir::PyreHelperKind,
+    helper: majit_ir::RuntimeHelperKind,
     i_args: &[OpRef],
     r_args: &[OpRef],
     allboxes: &[OpRef],
@@ -2036,7 +2036,7 @@ pub(crate) fn try_walker_specialize_unpack<Sym: WalkSym>(
             crate::descr::tuple_wrappeditems_descr(),
         );
         match helper {
-            majit_ir::PyreHelperKind::UnpackSequence => {
+            majit_ir::RuntimeHelperKind::UnpackSequence => {
                 if int_val as usize != concrete_len {
                     return Ok(None);
                 }
@@ -2055,7 +2055,7 @@ pub(crate) fn try_walker_specialize_unpack<Sym: WalkSym>(
                 write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, seq)?;
                 return Ok(Some(()));
             }
-            majit_ir::PyreHelperKind::UnpackItem => {
+            majit_ir::RuntimeHelperKind::UnpackItem => {
                 let index = int_val as usize;
                 if index >= concrete_len {
                     return Ok(None);
@@ -2107,7 +2107,7 @@ pub(crate) fn try_walker_specialize_unpack<Sym: WalkSym>(
     };
     let spec_type = seq_type;
     match helper {
-        majit_ir::PyreHelperKind::UnpackSequence => {
+        majit_ir::RuntimeHelperKind::UnpackSequence => {
             // Either specialisation is always arity 2, so the class guard
             // subsumes the exact-length check `unpack_sequence_fn` performs.
             if int_val != 2 {
@@ -2119,7 +2119,7 @@ pub(crate) fn try_walker_specialize_unpack<Sym: WalkSym>(
             write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, seq)?;
             Ok(Some(()))
         }
-        majit_ir::PyreHelperKind::UnpackItem => {
+        majit_ir::RuntimeHelperKind::UnpackItem => {
             if !(0..2).contains(&int_val) {
                 return Ok(None);
             }
@@ -4439,7 +4439,7 @@ pub(crate) fn try_walker_specialize_store_attr<Sym: WalkSym>(
             majit_ir::ExtraEffect::CannotRaise,
             majit_ir::OopSpecIndex::None,
         );
-        effect.pyre_helper = majit_ir::PyreHelperKind::StoreAttr;
+        effect.runtime_helper = majit_ir::RuntimeHelperKind::StoreAttr;
         let descr = majit_metainterp::make_call_descr_with_effect(
             &[
                 majit_ir::Type::Ref,
@@ -4714,7 +4714,7 @@ pub(crate) fn try_walker_specialize_store_attr<Sym: WalkSym>(
     // virtualizable spill, and the trailing force/exception guards stay exactly
     // as the generic setattr emitted them.
     let mut effect = original_effect.clone();
-    effect.pyre_helper = majit_ir::PyreHelperKind::StoreAttr;
+    effect.runtime_helper = majit_ir::RuntimeHelperKind::StoreAttr;
     let descr = majit_metainterp::make_call_descr_with_effect(
         &[
             majit_ir::Type::Ref,
@@ -4736,7 +4736,7 @@ pub(crate) fn try_walker_specialize_store_attr<Sym: WalkSym>(
 /// #171: FBW virtualization of a non-escaping BUILD_LIST.
 /// `lower_tuple_build_hlop_to_insn` lowers BUILD_LIST to `new_array_clear`
 /// + per-index `setarrayitem_gc` + a `newlist_from_array` residual
-/// (oopspec [`majit_ir::PyreHelperKind::NewlistFromArray`]) whose single
+/// (oopspec [`majit_ir::RuntimeHelperKind::NewlistFromArray`]) whose single
 /// r-arg is the already-built backing array.  Decompose that residual into
 /// the virtualizable `opimpl_newlist` shape (`pyjitpl.py`) —
 /// `new_with_vtable` + `new_array` + `setarrayitem_gc` + `setfield_gc` —
@@ -5073,7 +5073,7 @@ pub(crate) fn try_walker_specialize_newtuple_object<Sym: WalkSym>(
 /// #195 / #73: FBW virtualization of an arity-2 plain-int BUILD_TUPLE.
 /// `lower_tuple_build_hlop_to_insn` lowers BUILD_TUPLE to `new_array_clear`
 /// + per-index `setarrayitem_gc` + a `newtuple_from_array` residual
-/// (oopspec [`majit_ir::PyreHelperKind::NewtupleFromArray`]).  When both
+/// (oopspec [`majit_ir::RuntimeHelperKind::NewtupleFromArray`]).  When both
 /// backing-array elements are concrete plain `W_IntObject`, re-emit the
 /// former trait-side spec_ii shape walker-native
 /// (`new_with_vtable` + `w_class` / `value0` / `value1` `setfield_gc`),
@@ -9701,10 +9701,10 @@ fn next_op_is_f_locals_for_getframe_result<Sym: WalkSym>(
         .and_then(|descr| {
             descr
                 .as_call_descr()
-                .map(|call| call.get_extra_info().pyre_helper)
+                .map(|call| call.get_extra_info().runtime_helper)
         });
     if next.key != "residual_call_ir_r/iIRd>r"
-        || helper_kind != Some(majit_ir::PyreHelperKind::LoadAttr)
+        || helper_kind != Some(majit_ir::RuntimeHelperKind::LoadAttr)
     {
         return false;
     }
@@ -12833,7 +12833,7 @@ pub(crate) fn try_walker_specialize_set_add_method<Sym: WalkSym>(
 }
 
 /// The descr the `s.add(x)` substitution installs: `(Ref, Ref) -> Ref`,
-/// `MOST_GENERAL`, tagged [`majit_ir::PyreHelperKind::SetAddMethod`].
+/// `MOST_GENERAL`, tagged [`majit_ir::RuntimeHelperKind::SetAddMethod`].
 ///
 /// The EI `bind(..., CallFlavor::MayForce)` gives the SET_ADD residual this one
 /// stands in for: `EffectInfo::MOST_GENERAL`, not the analyzer-empty forcing
@@ -12853,7 +12853,7 @@ pub(crate) fn set_add_method_descr() -> DescrRef {
         &[Type::Ref, Type::Ref],
         Type::Ref,
         majit_ir::EffectInfo {
-            pyre_helper: majit_ir::PyreHelperKind::SetAddMethod,
+            runtime_helper: majit_ir::RuntimeHelperKind::SetAddMethod,
             ..default_effect_info()
         },
     )
@@ -14990,7 +14990,7 @@ pub(crate) fn try_walker_trace_readonly_descr_attr_raise<Sym: WalkSym>(
 /// exc-info-stack residuals to GETFIELD_GC_R / SETFIELD_GC on the EC's
 /// `sys_exc_value` slot (`ec_sys_exc_value_descr`), and consume pyre's
 /// propagation-root clear without recording a runtime call.
-/// Recognised by the codewriter-stamped `pyre_helper` tag, NOT a funcptr
+/// Recognised by the codewriter-stamped `runtime_helper` tag, NOT a funcptr
 /// address (the residual calls the cross-crate `cpu.{get,set}_current_
 /// exception_fn` wrappers in `pyre-jit`, which `pyre-jit-trace` cannot name).
 ///
@@ -15027,12 +15027,12 @@ pub(crate) fn try_walker_lower_exc_info_residual<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],
     op: &DecodedOp,
-    pyre_helper: majit_ir::PyreHelperKind,
+    runtime_helper: majit_ir::RuntimeHelperKind,
     r_args: &[OpRef],
     dst_bank: char,
     dst: usize,
 ) -> Result<Option<()>, DispatchError> {
-    if pyre_helper == majit_ir::PyreHelperKind::ClearInFlightException {
+    if runtime_helper == majit_ir::RuntimeHelperKind::ClearInFlightException {
         // The authoritative walk executed record_application_traceback and
         // published its concrete exception in the interpreter-only carrier.
         // Complete that concrete ownership transfer now.  Compiled traceback
@@ -15045,7 +15045,7 @@ pub(crate) fn try_walker_lower_exc_info_residual<Sym: WalkSym>(
         return Ok(Some(()));
     }
 
-    if pyre_helper == majit_ir::PyreHelperKind::GetCurrentException {
+    if runtime_helper == majit_ir::RuntimeHelperKind::GetCurrentException {
         // PUSH_EXC_INFO `prev = ec.sys_exc_value` — `[]→Ref`.
         if !r_args.is_empty() || dst_bank != 'r' {
             return Ok(None);
@@ -16832,7 +16832,7 @@ pub(crate) fn try_walker_load_name_cell_fold<Sym: WalkSym>(
 pub(crate) fn try_walker_store_name_cell_fold<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,
-    helper: majit_ir::PyreHelperKind,
+    helper: majit_ir::RuntimeHelperKind,
     frame_ptr: usize,
     w_name_ptr: usize,
     value_opref: OpRef,
@@ -16852,7 +16852,7 @@ pub(crate) fn try_walker_store_name_cell_fold<Sym: WalkSym>(
     // fold set the module cell.  STORE_GLOBAL names globals outright, and its
     // frame is a function frame whose `w_locals` is legitimately null, so the
     // gate must not apply to it.
-    if helper == majit_ir::PyreHelperKind::StoreName {
+    if helper == majit_ir::RuntimeHelperKind::StoreName {
         let w_locals = frame.get_w_locals();
         if !std::ptr::eq(w_locals, w_globals) {
             return Ok(false);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -47,7 +47,7 @@ fn void_return() -> Vec<u8> {
     ]
 }
 
-/// The generated `__pyre_wrap_*` gateways all put their un-lowerable call — the
+/// The generated `__majit_wrap_*` gateways all put their un-lowerable call — the
 /// `#[dont_look_inside]` arity-error formatter — on the arm the argument-count
 /// check rejects into.  The walk is execution-driven, so a call with the right
 /// count never steps there; declining the wrapper for it refuses a body the
@@ -286,7 +286,9 @@ fn the_substituted_set_add_descr_still_reads_as_a_live_heap_write() {
         "`set.add` returns None, so the Void write proxy cannot see this store"
     );
     assert!(
-        super::residual_call::helper_kind_writes_live_heap(call_descr.get_extra_info().pyre_helper),
+        super::residual_call::helper_kind_writes_live_heap(
+            call_descr.get_extra_info().runtime_helper
+        ),
         "an untagged descr takes the insert out of the executed-effect odometer"
     );
 }
@@ -405,7 +407,7 @@ fn fresh_trace_ctx() -> TraceCtx {
 
 #[test]
 fn builtin_wrapper_heapcache_uses_item_not_length_descr() {
-    let wrapper = named_jitcode("__pyre_wrap_random").expect("random builtin wrapper jitcode");
+    let wrapper = named_jitcode("__majit_wrap_random").expect("random builtin wrapper jitcode");
     let first = crate::jitcode_runtime::decoded_ops(&wrapper.code)
         .next()
         .expect("wrapper first op");
@@ -437,7 +439,7 @@ fn builtin_wrapper_heapcache_uses_item_not_length_descr() {
 #[test]
 fn signature_bound_wrapper_reads_argument_slice_with_distinct_item_descr() {
     let wrapper =
-        named_jitcode("__pyre_wrap_getrandbits").expect("getrandbits builtin wrapper jitcode");
+        named_jitcode("__majit_wrap_getrandbits").expect("getrandbits builtin wrapper jitcode");
     let first = crate::jitcode_runtime::decoded_ops(&wrapper.code)
         .next()
         .expect("wrapper first op");
@@ -448,7 +450,7 @@ fn signature_bound_wrapper_reads_argument_slice_with_distinct_item_descr() {
     // and read that instead.
     //
     // Spelled as the entry callee rather than as "op 0 is not an
-    // `inline_call_*`": no `__pyre_wrap_*` jitcode inline-calls the splitter
+    // `inline_call_*`": no `__majit_wrap_*` jitcode inline-calls the splitter
     // anywhere, so the negative form holds of every wrapper and separates
     // nothing, while the opcode form of op 0 only tracks which helpers the
     // codewriter is currently allowed to descend into.
@@ -13198,9 +13200,9 @@ fn walker_folds_a_float_result_pure_call_from_the_float_return_register() {
 /// residual the walk already ran concretely.
 #[test]
 fn mayforce_null_ref_arg_exempts_the_unread_load_global_namespace() {
-    fn descr_for(pyre_helper: majit_ir::PyreHelperKind) -> DescrRef {
+    fn descr_for(runtime_helper: majit_ir::RuntimeHelperKind) -> DescrRef {
         let mut effect = majit_ir::EffectInfo::default();
-        effect.pyre_helper = pyre_helper;
+        effect.runtime_helper = runtime_helper;
         std::sync::Arc::new(majit_ir::SimpleCallDescr::new(
             9,
             vec![Type::Ref, Type::Ref, Type::Ref, Type::Int],
@@ -13220,8 +13222,8 @@ fn mayforce_null_ref_arg_exempts_the_unread_load_global_namespace() {
         tc.const_ref(0xC0DE_2000),
         tc.const_int(2),
     ];
-    let load_global = descr_for(majit_ir::PyreHelperKind::LoadGlobal);
-    let untagged = descr_for(majit_ir::PyreHelperKind::None);
+    let load_global = descr_for(majit_ir::RuntimeHelperKind::LoadGlobal);
+    let untagged = descr_for(majit_ir::RuntimeHelperKind::None);
 
     let mut regs_i: Vec<OpRef> = Vec::new();
     let mut regs_r: Vec<OpRef> = Vec::new();
@@ -13294,9 +13296,9 @@ fn mayforce_null_ref_arg_exempts_the_unread_load_global_namespace() {
 /// `raise` failed one guard 1786 times and compiled 0 bridges.
 #[test]
 fn mayforce_null_ref_arg_exempts_the_with_except_start_receiver() {
-    fn descr_for(pyre_helper: majit_ir::PyreHelperKind) -> DescrRef {
+    fn descr_for(runtime_helper: majit_ir::RuntimeHelperKind) -> DescrRef {
         let mut effect = majit_ir::EffectInfo::default();
-        effect.pyre_helper = pyre_helper;
+        effect.runtime_helper = runtime_helper;
         std::sync::Arc::new(majit_ir::SimpleCallDescr::new(
             11,
             vec![Type::Ref, Type::Ref, Type::Ref],
@@ -13315,8 +13317,8 @@ fn mayforce_null_ref_arg_exempts_the_with_except_start_receiver() {
         tc.const_ref(0),
         tc.const_ref(0xC0DE_4000),
     ];
-    let with_except_start = descr_for(majit_ir::PyreHelperKind::WithExceptStart);
-    let untagged = descr_for(majit_ir::PyreHelperKind::None);
+    let with_except_start = descr_for(majit_ir::RuntimeHelperKind::WithExceptStart);
+    let untagged = descr_for(majit_ir::RuntimeHelperKind::None);
 
     let mut regs_i: Vec<OpRef> = Vec::new();
     let mut regs_r: Vec<OpRef> = Vec::new();
@@ -13392,7 +13394,7 @@ fn mayforce_null_ref_arg_exempts_the_with_except_start_receiver() {
 #[test]
 fn the_mayforce_null_ref_sentinel_table_names_one_slot_per_helper() {
     use super::residual_call::mayforce_null_ref_arg_is_checked_sentinel as is_sentinel;
-    use majit_ir::PyreHelperKind as K;
+    use majit_ir::RuntimeHelperKind as K;
 
     // (helper, nargs, the exempt indices)
     let table: &[(K, usize, &[usize])] = &[

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -511,7 +511,7 @@ pub fn tuple_getitem_jitcode() -> Option<Arc<JitCode>> {
     get_jitcode_by_index(idx)
 }
 
-/// Deserialized `pipeline.insns` overlaid with `pyre_extension_insns()`
+/// Deserialized `pipeline.insns` overlaid with `extension_insns()`
 /// — the build-observed `Assembler::write_insn` emit set plus the
 /// `_pyre/P` adapter keys that pyre's production blackhole builder
 /// registers via `setup_insns(...)` at runtime.  Both sources must
@@ -522,7 +522,7 @@ pub fn tuple_getitem_jitcode() -> Option<Arc<JitCode>> {
 ///
 /// `Assembler::get_opnum` mirrors RPython
 /// `assembler.py setdefault(key, len(self.insns))`: keys present
-/// in `majit_translate::insns::{wellknown_bh_insns, pyre_extension_insns}`
+/// in `majit_translate::insns::{wellknown_bh_insns, extension_insns}`
 /// reuse their reserved `BC_*` byte for build/runtime stability, and
 /// translator-only keys outside the canonical universe get the lowest
 /// available non-reserved dynamic byte.  Both kinds land here verbatim,
@@ -569,7 +569,7 @@ pub fn build_emitted_insns() -> &'static indexmap::IndexMap<String, u8> {
 static INSNS_OPNAME_TO_BYTE: LazyLock<indexmap::IndexMap<String, u8>> = LazyLock::new(|| {
     let mut table = BUILD_EMITTED_INSNS.clone();
     // Overlay the canonical `wellknown_bh_insns` and pyre-only
-    // `pyre_extension_insns` keys so the runtime table covers every
+    // `extension_insns` keys so the runtime table covers every
     // opname a `BlackholeInterpBuilder` could be asked to dispatch.
     //
     // RPython parity: `blackhole.py BlackholeInterpBuilder.__init__`
@@ -579,7 +579,7 @@ static INSNS_OPNAME_TO_BYTE: LazyLock<indexmap::IndexMap<String, u8>> = LazyLock
     // assembler actually emitted during `make_jitcodes`; canonical
     // opnames the analyzed source set did not exercise (e.g.
     // `ref_guard_value/r`) are absent.  Overlaying
-    // both `wellknown_bh_insns` and `pyre_extension_insns` restores
+    // both `wellknown_bh_insns` and `extension_insns` restores
     // the closed key universe RPython's runtime sees, so callers
     // (`build_default_bh_builder_with_unwired_report`, dispatch
     // tests) treat opname coverage as a property of the codebase,
@@ -602,7 +602,7 @@ static INSNS_OPNAME_TO_BYTE: LazyLock<indexmap::IndexMap<String, u8>> = LazyLock
         }
     }
     overlay_insns(&mut table, &majit_translate::insns::wellknown_bh_insns());
-    overlay_insns(&mut table, &majit_translate::insns::pyre_extension_insns());
+    overlay_insns(&mut table, &majit_translate::insns::extension_insns());
     table
 });
 
@@ -1307,7 +1307,7 @@ pub fn field_position_jit_stats() -> String {
     ) = {
         let gc = majit_ir::descr::gc_cache();
         let guard = gc.lock().unwrap_or_else(|e| e.into_inner());
-        let sample = if std::env::var_os("PYRE_SIZE_SHELL_OWNERS").is_some() {
+        let sample = if std::env::var_os("MAJIT_SIZE_SHELL_OWNERS").is_some() {
             let lines = guard.size_shell_owner_sample(24);
             format!("\n[jit-stats] {}", lines.join("\n[jit-stats] "))
         } else {
@@ -1952,43 +1952,43 @@ pub struct DecodedOp {
 ///
 /// | opname                              | producer (`assembler.rs`)             | payload bytes |
 /// |-------------------------------------|---------------------------------------|---------------|
-/// | `inline_call_pyre_nested`           | `:nested_inline_call_*_typed_args`    | `4 + num_args*3 + 3`  (`sub_idx u16 + num_args u16 + num_args × (kind u8, caller_src u8, callee_dst u8) + return_i u8 + return_r u8 + return_f u8`) |
-/// | `call_assembler_int_pyre`           | `:3429 call_assembler_int_like`       | `5 + num_args*2`  (`target_idx u16 + dst u8 + num_args u16 + num_args × (kind u8, reg u8)`) |
-/// | `call_assembler_ref_pyre`           | `:3451 call_assembler_ref_like`       | same as int |
-/// | `call_assembler_float_pyre`         | `:3489 call_assembler_float_like`     | same as int |
-/// | `call_assembler_void_pyre`          | `:3370 call_assembler_void_like`      | `4 + num_args*2`  (omits `dst u8`) |
-/// | `cond_call_void_pyre`               | `:2642 call_cond_like`                | `4 + arg_count*2`  (`first_reg u8 + fn_ptr_idx u16 + arg_count u8 + arg_count × (kind u8) + arg_count × (reg u8)`) |
-/// | `record_known_result_int_pyre`      | `:2618 call_cond_like`                | same as cond_call |
-/// | `record_known_result_ref_pyre`      | `:2630 call_cond_like`                | same as cond_call |
-/// | `cond_call_value_int_pyre`          | `:2660 call_cond_value_like`          | `5 + arg_count*2`  (cond_call layout + trailing `dst u8`) |
-/// | `cond_call_value_ref_pyre`          | `:2660 call_cond_value_like`          | same as int variant |
+/// | `inline_call_nested_ext`           | `:nested_inline_call_*_typed_args`    | `4 + num_args*3 + 3`  (`sub_idx u16 + num_args u16 + num_args × (kind u8, caller_src u8, callee_dst u8) + return_i u8 + return_r u8 + return_f u8`) |
+/// | `call_assembler_int_ext`           | `:3429 call_assembler_int_like`       | `5 + num_args*2`  (`target_idx u16 + dst u8 + num_args u16 + num_args × (kind u8, reg u8)`) |
+/// | `call_assembler_ref_ext`           | `:3451 call_assembler_ref_like`       | same as int |
+/// | `call_assembler_float_ext`         | `:3489 call_assembler_float_like`     | same as int |
+/// | `call_assembler_void_ext`          | `:3370 call_assembler_void_like`      | `4 + num_args*2`  (omits `dst u8`) |
+/// | `cond_call_void_ext`               | `:2642 call_cond_like`                | `4 + arg_count*2`  (`first_reg u8 + fn_ptr_idx u16 + arg_count u8 + arg_count × (kind u8) + arg_count × (reg u8)`) |
+/// | `record_known_result_int_ext`      | `:2618 call_cond_like`                | same as cond_call |
+/// | `record_known_result_ref_ext`      | `:2630 call_cond_like`                | same as cond_call |
+/// | `cond_call_value_int_ext`          | `:2660 call_cond_value_like`          | `5 + arg_count*2`  (cond_call layout + trailing `dst u8`) |
+/// | `cond_call_value_ref_ext`          | `:2660 call_cond_value_like`          | same as int variant |
 fn pyre_p_payload_len(opname: &str, code: &[u8], cursor: usize) -> Option<usize> {
     match opname {
-        "inline_call_pyre_nested" => {
+        "inline_call_nested_ext" => {
             // sub_idx u16 + num_args u16 + num_args × (kind u8, caller_src
             // u8, callee_dst u8) + return_i u8 + return_r u8 + return_f u8
             let num_args =
                 u16::from_le_bytes([*code.get(cursor + 2)?, *code.get(cursor + 3)?]) as usize;
             Some(4 + num_args * 3 + 3)
         }
-        "call_assembler_int_pyre" | "call_assembler_ref_pyre" | "call_assembler_float_pyre" => {
+        "call_assembler_int_ext" | "call_assembler_ref_ext" | "call_assembler_float_ext" => {
             // target_idx u16 + dst u8 + num_args u16 + num_args × (kind u8, reg u8)
             let num_args =
                 u16::from_le_bytes([*code.get(cursor + 3)?, *code.get(cursor + 4)?]) as usize;
             Some(5 + num_args * 2)
         }
-        "call_assembler_void_pyre" => {
+        "call_assembler_void_ext" => {
             // target_idx u16 + num_args u16 + num_args × (kind u8, reg u8)
             let num_args =
                 u16::from_le_bytes([*code.get(cursor + 2)?, *code.get(cursor + 3)?]) as usize;
             Some(4 + num_args * 2)
         }
-        "cond_call_void_pyre" | "record_known_result_int_pyre" | "record_known_result_ref_pyre" => {
+        "cond_call_void_ext" | "record_known_result_int_ext" | "record_known_result_ref_ext" => {
             // first_reg u8 + fn_ptr_idx u16 + arg_count u8 + arg_count × (kind u8) + arg_count × (reg u8)
             let arg_count = *code.get(cursor + 3)? as usize;
             Some(4 + arg_count * 2)
         }
-        "cond_call_value_int_pyre" | "cond_call_value_ref_pyre" => {
+        "cond_call_value_int_ext" | "cond_call_value_ref_ext" => {
             // cond_call shape + trailing dst u8
             let arg_count = *code.get(cursor + 3)? as usize;
             Some(5 + arg_count * 2)
@@ -2804,7 +2804,7 @@ mod tests {
 
     /// Every key in build-observed `pipeline.insns` that ALSO appears in
     /// the canonical universe (`majit_translate::insns::
-    /// {wellknown_bh_insns, pyre_extension_insns}`) must carry the
+    /// {wellknown_bh_insns, extension_insns}`) must carry the
     /// matching reserved byte.  Translator-only keys allocated by
     /// `Assembler::get_opnum`'s `setdefault` fallback (`assembler.py`
     /// parity) may live in any non-reserved byte, including gaps below
@@ -2821,11 +2821,11 @@ mod tests {
             .into_iter()
             .map(|(k, v)| (k.to_string(), v))
             .collect();
-        for (k, v) in majit_translate::insns::pyre_extension_insns() {
+        for (k, v) in majit_translate::insns::extension_insns() {
             assert!(
                 canonical.insert(k.to_string(), v).is_none(),
                 "duplicate opname {k:?} between wellknown_bh_insns() and \
-                 pyre_extension_insns()",
+                 extension_insns()",
             );
         }
         for (key, &observed_byte) in observed.iter() {
@@ -2841,7 +2841,7 @@ mod tests {
                 assert!(
                     !majit_translate::insns::is_reserved_opcode_byte(observed_byte),
                     "pipeline.insns key {key:?} is absent from \
-                     wellknown_bh_insns() ∪ pyre_extension_insns() but \
+                     wellknown_bh_insns() ∪ extension_insns() but \
                      was assigned reserved byte {observed_byte}; \
                      translator-only dynamic bytes must not collide with \
                      canonical/extension opcodes",
@@ -3263,7 +3263,7 @@ mod tests {
     /// a real jitcode in this binary can carry.  Each must be dispatchable.
     ///
     /// Deliberately NOT asserted over `insns_opname_to_byte()`: that map
-    /// additionally carries the `wellknown_bh_insns` / `pyre_extension_insns`
+    /// additionally carries the `wellknown_bh_insns` / `extension_insns`
     /// overlay, i.e. canonical opnames this build never emitted. Their bytes
     /// cannot appear in any jitcode here, so leaving them unregistered is the
     /// same state upstream is in — its `asm.insns` would not list them either.

--- a/pyre/pyre-jit-trace/src/lib.rs
+++ b/pyre/pyre-jit-trace/src/lib.rs
@@ -169,13 +169,13 @@ const _: () = assert!(
     "pyre's PyFrame virtualizable layout requires exactly one extra red (ec)",
 );
 
-/// `PYRE_PROBE_SUBSCR` env-var gate cached once on first read. The
+/// `MAJIT_PROBE_SUBSCR` env-var gate cached once on first read. The
 /// state.rs/jitcode_dispatch.rs probe sites are on hot paths; sampling
 /// `std::env::var_os` on every cache hit would dominate the cost when
 /// the probe is off.
 pub(crate) fn probe_subscr_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_PROBE_SUBSCR").is_some())
+    *ENABLED.get_or_init(|| std::env::var_os("MAJIT_PROBE_SUBSCR").is_some())
 }
 
 /// Auto-generated trace functions from majit-translate.

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -4343,7 +4343,7 @@ pub(crate) fn opimpl_getfield_gc_i(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
                 {
                     if loaded != cached_int && crate::probe_subscr_enabled() {
                         eprintln!(
-                            "[PYRE_PROBE_SUBSCR] sanity-int-mismatch obj={:?} field_index={} struct_ptr={:#x} descr_pure={} cached={} loaded={}",
+                            "[MAJIT_PROBE_SUBSCR] sanity-int-mismatch obj={:?} field_index={} struct_ptr={:#x} descr_pure={} cached={} loaded={}",
                             obj,
                             field_index,
                             struct_ptr,

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -3356,11 +3356,11 @@ fn try_adopt_multi_frame_blackhole(
         crate::jitcode_runtime::build_default_bh_builder_with_unwired_report();
     // The workspace entry turns this crate's defaults off, so a `pyre-jit`
     // that names no backend no longer forwards one and the call has to be
-    // gated. The predicate is `pyre_production_cpu`'s own: present on wasm32
+    // gated. The predicate is `production_cpu`'s own: present on wasm32
     // regardless of feature, since `BackendImpl` is `WasmBackend` there.
     #[cfg(any(target_arch = "wasm32", feature = "dynasm", feature = "cranelift"))]
     {
-        mf_builder.cpu = Some(majit_metainterp::blackhole::pyre_production_cpu());
+        mf_builder.cpu = Some(majit_metainterp::blackhole::production_cpu());
     }
     let majit_metainterp::MultiFrameBlackholeResult {
         outcome,

--- a/pyre/pyre-jit/Cargo.toml
+++ b/pyre/pyre-jit/Cargo.toml
@@ -24,7 +24,7 @@ jit-audits = ["majit-metainterp/jit-audits", "majit-ir/jit-audits"]
 # can select the MIR front-end from the top level
 # (`cargo build --features pyre-jit/mir-frontend`).  Production
 # validation runs check.py with this enabled and
-# PYRE_MIR_FRONTEND_LLBC pointing at an extracted .ullbc.
+# MAJIT_MIR_FRONTEND_LLBC pointing at an extracted .ullbc.
 mir-frontend = ["majit-translate/mir-frontend"]
 # Collect on every allocation so instance / container GC tracing is
 # exercised eagerly. majit-gc is compiled once per build, so this single

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 use std::cell::UnsafeCell;
 use std::sync::Once;
 
-/// Whether `PYRE_NBODY_DEBUG` is set, cached at first access.
+/// Whether `MAJIT_NBODY_DEBUG` is set, cached at first access.
 ///
 /// `std::env::var_os` acquires a global env lock on every call. Caching
 /// here matches the equivalent helpers in `majit-backend-cranelift` and
@@ -16,7 +16,7 @@ use std::sync::Once;
 /// and are not part of PyPy.
 fn pyre_nbody_debug_enabled() -> bool {
     static ENABLED: std::sync::LazyLock<bool> =
-        std::sync::LazyLock::new(|| std::env::var_os("PYRE_NBODY_DEBUG").is_some());
+        std::sync::LazyLock::new(|| std::env::var_os("MAJIT_NBODY_DEBUG").is_some());
     *ENABLED
 }
 
@@ -7650,7 +7650,7 @@ mod tests_bh_normalize_raise {
     fn bh_normalize_raise_varargs_rejects_builtin_callables_that_are_not_exception_classes() {
         let callable = pyre_interpreter::make_builtin_function(
             "len",
-            pyre_interpreter::builtins::__pyre_wrap_builtin_len,
+            pyre_interpreter::builtins::__majit_wrap_builtin_len,
         );
         let code = compile_exec("").expect("empty module should compile");
         let frame = pyre_interpreter::PyFrame::new(code);

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1768,7 +1768,7 @@ fn build_gc() -> Box<MiniMarkGC> {
     // the default path (`object_array::alloc_*_block_gc` →
     // `try_gc_alloc`); the nursery walker traces each item slot of such
     // a block, and the list/tuple custom traces forward the block
-    // pointer. Under the `PYRE_GC_ITEMSBLOCK=0` fallback the blocks come
+    // pointer. Under the `MAJIT_GC_ITEMSBLOCK=0` fallback the blocks come
     // from `std::alloc` instead and no allocation carries this typeid.
     // See comments on `pyre_jit_trace::descr::PY_OBJECT_ARRAY_GC_TYPE_ID`
     // and `pyre_object::object_array::ItemsBlock` for the companion
@@ -7508,7 +7508,7 @@ fn for_iter_body_op_is_jit_safe(instr: pyre_interpreter::Instruction) -> bool {
             | I::CallKw { .. }
             // CALL_FUNCTION_EX is the same MayForce call boundary as CALL and
             // CALL_KW.  The codewriter lowers it through
-            // PyreHelperKind::CallFunctionEx, and
+            // RuntimeHelperKind::CallFunctionEx, and
             // fbw_callee_body_replay_scan defers CallFn, CallKw, and
             // CallFunctionEx together; omitting only the starred-call spelling
             // here added no safety beyond the Layer 2 defense above.
@@ -7527,7 +7527,7 @@ fn for_iter_body_op_is_jit_safe(instr: pyre_interpreter::Instruction) -> bool {
             | I::BuildSet { .. }
             | I::BuildMap { .. }
             // MAKE_FUNCTION is another fresh-object builder: codewriter.rs
-            // lowers PyreHelperKind::MakeFunction as a Plain allocation that
+            // lowers RuntimeHelperKind::MakeFunction as a Plain allocation that
             // runs no user code and cannot raise. SET_FUNCTION_ATTRIBUTE only
             // initializes that newly-built function's typed fields, likewise
             // without user code or an exception, so replay drops or rebuilds
@@ -10546,7 +10546,7 @@ fn compile_and_run_once(
     let compiled_key = driver.last_compiled_key().unwrap_or(green_key);
     let tracing_finished = !driver.is_tracing();
     if tracing_finished
-        && std::env::var_os("PYRE_DYNASM_EXEC_DIAG").is_some()
+        && std::env::var_os("MAJIT_DYNASM_EXEC_DIAG").is_some()
         && let Some(trace_id) = driver.meta_interp().compiled_root_trace_id(compiled_key)
     {
         eprintln!(

--- a/pyre/pyre-jit/src/jit/assembler.rs
+++ b/pyre/pyre-jit/src/jit/assembler.rs
@@ -154,7 +154,7 @@ impl Assembler {
     /// is dropped instead of appended.
     ///
     /// Seeding is sound because the bytes are not allocated here — they come
-    /// from the fixed `wellknown_bh_insns` / `pyre_extension_insns` tables, so
+    /// from the fixed `wellknown_bh_insns` / `extension_insns` tables, so
     /// the build-time and runtime spellings of an opname already agree on a
     /// byte; the map only records which opnames exist.
     pub fn resuming_build_time_liveness() -> Self {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2083,7 +2083,7 @@ fn record_residual_call_graph_op(
     block: &super::flow::BlockRef,
     fn_idx: u16,
     flavor: CallFlavor,
-    pyre_helper: majit_ir::PyreHelperKind,
+    runtime_helper: majit_ir::RuntimeHelperKind,
     args_i: Vec<super::flow::FlowValue>,
     args_r: Vec<super::flow::FlowValue>,
     args_f: Vec<super::flow::FlowValue>,
@@ -2125,7 +2125,7 @@ fn record_residual_call_graph_op(
     // folds (BoxInt / BinaryOp / CompareOp dispatch in
     // `jitcode_dispatch.rs`); mirrors the tag the dedicated walker-emit
     // builders (`flatten.rs build_*_insn`) attach to the same helpers.
-    effect_info.pyre_helper = pyre_helper;
+    effect_info.runtime_helper = runtime_helper;
     op_args.push(
         super::flatten::intern_call_descr_stub(effect_info, arg_kinds, reskind.to_kind()).into(),
     );
@@ -5279,8 +5279,8 @@ fn filter_liveness_in_place(
                         if matches!(
                             &**descr,
                             super::flatten::DescrOperand::CallDescrStub(stub)
-                                if stub.effect_info.pyre_helper
-                                    == majit_ir::PyreHelperKind::LoadAttr
+                                if stub.effect_info.runtime_helper
+                                    == majit_ir::RuntimeHelperKind::LoadAttr
                         )
                 )
             });
@@ -5853,7 +5853,7 @@ impl CodeWriter {
         // residual producers do; the tag is part of `EffectInfo` and therefore
         // already separates this entry in the cache key.
         let void_word_abi =
-            key.2.is_none() && key.0.pyre_helper == majit_ir::PyreHelperKind::ListAppendValue;
+            key.2.is_none() && key.0.runtime_helper == majit_ir::RuntimeHelperKind::ListAppendValue;
         let mut cache = self.call_descr_stub_cache.lock().unwrap();
         let arc = cache.entry(key.clone()).or_insert_with(|| {
             Arc::new(CallDescrStub {
@@ -7027,7 +7027,7 @@ impl CodeWriter {
                 residual_call!(
                     $fn_idx,
                     $flavor,
-                    majit_ir::PyreHelperKind::None,
+                    majit_ir::RuntimeHelperKind::None,
                     $args_i,
                     $args_r,
                     $args_f,
@@ -7039,7 +7039,7 @@ impl CodeWriter {
             (
                 $fn_idx:expr,
                 $flavor:expr,
-                $pyre_helper:expr,
+                $runtime_helper:expr,
                 $args_i:expr,
                 $args_r:expr,
                 $args_f:expr,
@@ -7052,7 +7052,7 @@ impl CodeWriter {
                     &current_block.block(),
                     $fn_idx,
                     $flavor,
-                    $pyre_helper,
+                    $runtime_helper,
                     $args_i,
                     $args_r,
                     $args_f,
@@ -8869,7 +8869,7 @@ impl CodeWriter {
                             let boxed = residual_call!(
                                 box_int_fn_idx,
                                 CallFlavor::Plain,
-                                majit_ir::PyreHelperKind::BoxInt,
+                                majit_ir::RuntimeHelperKind::BoxInt,
                                 vec![super::flow::Constant::signed(val).into()],
                                 vec![],
                                 vec![],
@@ -9524,7 +9524,7 @@ impl CodeWriter {
                                 let loaded = residual_call!(
                                     load_global_fn_idx,
                                     CallFlavor::Plain,
-                                    majit_ir::PyreHelperKind::LoadGlobal,
+                                    majit_ir::RuntimeHelperKind::LoadGlobal,
                                     vec![super::flow::Constant::signed(raw_namei).into()],
                                     vec![ns_var.into(), code_const, frame_var.into()],
                                     vec![],
@@ -9603,7 +9603,7 @@ impl CodeWriter {
                                     let loaded = residual_call!(
                                         load_global_fn_idx,
                                         CallFlavor::Plain,
-                                        majit_ir::PyreHelperKind::LoadGlobal,
+                                        majit_ir::RuntimeHelperKind::LoadGlobal,
                                         vec![super::flow::Constant::signed(raw_namei).into()],
                                         vec![ns_const, code_const, frame_var.into()],
                                         vec![],
@@ -10043,7 +10043,7 @@ impl CodeWriter {
                                 let normalized_var = residual_call!(
                                     normalize_raise_varargs_fn_idx,
                                     CallFlavor::MayForce,
-                                    majit_ir::PyreHelperKind::RaiseVarargs,
+                                    majit_ir::RuntimeHelperKind::RaiseVarargs,
                                     vec![],
                                     vec![frame_var.into(), exc_fv.into(), cause_fv.into()],
                                     vec![],
@@ -10097,7 +10097,7 @@ impl CodeWriter {
                                     let reraise_value = residual_call!(
                                         reraise_varargs_zero_fn_idx,
                                         CallFlavor::Plain,
-                                        majit_ir::PyreHelperKind::RaiseVarargs,
+                                        majit_ir::RuntimeHelperKind::RaiseVarargs,
                                         vec![],
                                         vec![],
                                         vec![],
@@ -10126,7 +10126,7 @@ impl CodeWriter {
                                     let reraise_value = residual_call!(
                                         get_current_exception_fn_idx,
                                         CallFlavor::PlainCannotRaiseNoHeap,
-                                        majit_ir::PyreHelperKind::GetCurrentException,
+                                        majit_ir::RuntimeHelperKind::GetCurrentException,
                                         vec![],
                                         vec![],
                                         vec![],
@@ -10245,7 +10245,7 @@ impl CodeWriter {
                             let prev_var = residual_call!(
                                 get_current_exception_fn_idx,
                                 CallFlavor::PlainCannotRaiseNoHeap,
-                                majit_ir::PyreHelperKind::GetCurrentException,
+                                majit_ir::RuntimeHelperKind::GetCurrentException,
                                 vec![],
                                 vec![],
                                 vec![],
@@ -10256,7 +10256,7 @@ impl CodeWriter {
                             let _ = residual_call!(
                                 set_current_exception_fn_idx,
                                 CallFlavor::PlainCannotRaiseNoHeap,
-                                majit_ir::PyreHelperKind::SetCurrentException,
+                                majit_ir::RuntimeHelperKind::SetCurrentException,
                                 vec![],
                                 vec![exc_value.clone()],
                                 vec![],
@@ -10275,7 +10275,7 @@ impl CodeWriter {
                             let _ = residual_call!(
                                 clear_in_flight_exception_fn_idx,
                                 CallFlavor::PlainCannotRaiseNoHeap,
-                                majit_ir::PyreHelperKind::ClearInFlightException,
+                                majit_ir::RuntimeHelperKind::ClearInFlightException,
                                 vec![],
                                 vec![],
                                 vec![],
@@ -10361,7 +10361,7 @@ impl CodeWriter {
                             let cmp_result = residual_call!(
                                 compare_fn_idx,
                                 CallFlavor::MayForce,
-                                majit_ir::PyreHelperKind::CompareOp,
+                                majit_ir::RuntimeHelperKind::CompareOp,
                                 vec![
                                     super::flow::Constant::signed(
                                         pyre_interpreter::runtime_ops::ISINSTANCE_OP_TAG,
@@ -10436,7 +10436,7 @@ impl CodeWriter {
                             let _ = residual_call!(
                                 set_current_exception_fn_idx,
                                 CallFlavor::PlainCannotRaiseNoHeap,
-                                majit_ir::PyreHelperKind::SetCurrentException,
+                                majit_ir::RuntimeHelperKind::SetCurrentException,
                                 vec![],
                                 vec![prev_value],
                                 vec![],
@@ -10590,7 +10590,7 @@ impl CodeWriter {
                                 // NULL-ref gate admit that NULL; without it
                                 // every bridge out of a `with` handler is
                                 // refused at this residual.
-                                majit_ir::PyreHelperKind::WithExceptStart,
+                                majit_ir::RuntimeHelperKind::WithExceptStart,
                                 vec![],
                                 vec![exit_func, exit_self, exc],
                                 vec![],
@@ -10963,7 +10963,7 @@ impl CodeWriter {
                             let tuple_var = residual_call!(
                                 unpack_sequence_fn_idx,
                                 CallFlavor::MayForce,
-                                majit_ir::PyreHelperKind::UnpackSequence,
+                                majit_ir::RuntimeHelperKind::UnpackSequence,
                                 vec![super::flow::Constant::signed(n as i64).into()],
                                 vec![seq_value],
                                 vec![],
@@ -11018,7 +11018,7 @@ impl CodeWriter {
                                 let item_var = residual_call!(
                                     unpack_item_fn_idx,
                                     CallFlavor::Plain,
-                                    majit_ir::PyreHelperKind::UnpackItem,
+                                    majit_ir::RuntimeHelperKind::UnpackItem,
                                     vec![super::flow::Constant::signed(k as i64).into()],
                                     vec![tuple_value.clone()],
                                     vec![],
@@ -11047,7 +11047,7 @@ impl CodeWriter {
                             let iter_var = residual_call!(
                                 get_iter_fn_idx,
                                 CallFlavor::MayForce,
-                                majit_ir::PyreHelperKind::GetIter,
+                                majit_ir::RuntimeHelperKind::GetIter,
                                 vec![],
                                 vec![iterable_value],
                                 vec![],
@@ -11138,7 +11138,7 @@ impl CodeWriter {
                             let next_var = residual_call!(
                                 for_iter_next_fn_idx,
                                 CallFlavor::MayForce,
-                                majit_ir::PyreHelperKind::ForIterNext,
+                                majit_ir::RuntimeHelperKind::ForIterNext,
                                 vec![],
                                 vec![iter_value],
                                 vec![],
@@ -11207,7 +11207,7 @@ impl CodeWriter {
                                 &stop_match.block(),
                                 for_iter_exception_match_fn_idx,
                                 CallFlavor::PlainCannotRaise,
-                                majit_ir::PyreHelperKind::ForIterExceptionMatch,
+                                majit_ir::RuntimeHelperKind::ForIterExceptionMatch,
                                 vec![],
                                 vec![
                                     stop_exc_value.into(),
@@ -11668,7 +11668,7 @@ impl CodeWriter {
                             let _ = residual_call!(
                                 list_append_fn_idx,
                                 CallFlavor::Plain,
-                                majit_ir::PyreHelperKind::ListAppendValue,
+                                majit_ir::RuntimeHelperKind::ListAppendValue,
                                 vec![],
                                 vec![list_value.into(), value_value.into()],
                                 vec![],
@@ -12627,7 +12627,7 @@ impl CodeWriter {
                                 let item_var = residual_call!(
                                     unpack_item_fn_idx,
                                     CallFlavor::Plain,
-                                    majit_ir::PyreHelperKind::UnpackItem,
+                                    majit_ir::RuntimeHelperKind::UnpackItem,
                                     vec![super::flow::Constant::signed(k as i64).into()],
                                     vec![tuple_value.clone()],
                                     vec![],
@@ -14276,7 +14276,7 @@ impl CodeWriter {
                         let boxed_lasti = residual_call!(
                             box_int_fn_idx,
                             CallFlavor::Plain,
-                            majit_ir::PyreHelperKind::BoxInt,
+                            majit_ir::RuntimeHelperKind::BoxInt,
                             vec![super::flow::Constant::signed(site.lasti_py_pc as i64).into()],
                             vec![],
                             vec![],
@@ -16485,7 +16485,7 @@ mod tests {
     fn list_append_void_stub_records_ignored_word_abi() {
         let writer = CodeWriter::new();
         let mut effect_info = super::super::flatten::effect_info_for_call_flavor(CallFlavor::Plain);
-        effect_info.pyre_helper = majit_ir::PyreHelperKind::ListAppendValue;
+        effect_info.runtime_helper = majit_ir::RuntimeHelperKind::ListAppendValue;
         let descr = writer.intern_call_descr_stub(effect_info, vec![Kind::Ref, Kind::Ref], None);
         let stub = descr
             .as_any()

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -194,7 +194,7 @@ pub struct Cpu {
     pub dict_merge_fn: extern "C" fn(i64, i64, i64) -> i64,
     /// LIST_APPEND residual — `(list, value) → void` (`list.append(value)`,
     /// list peeked + mutated in place).  The full-body walker's #171 fold
-    /// intercepts it (`PyreHelperKind::ListAppendValue`); this is the decline
+    /// intercepts it (`RuntimeHelperKind::ListAppendValue`); this is the decline
     /// fallback, identical to the residual the retired MIFrame tracer recorded.
     pub list_append_fn: extern "C" fn(i64, i64) -> i64,
     /// DELETE_ATTR residual — `(obj, code, name_idx) → void` (`del obj.name`).

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3801,7 +3801,7 @@ where
         lhs_operand,
         rhs_operand,
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::BinaryOp,
+        majit_ir::RuntimeHelperKind::BinaryOp,
         result_reg,
     ))
 }
@@ -3834,7 +3834,7 @@ pub fn build_binary_op_residual_call_ir_r_insn(
         Operand::Register(Register::new(Kind::Ref, lhs_reg)),
         Operand::Register(Register::new(Kind::Ref, rhs_reg)),
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::BinaryOp,
+        majit_ir::RuntimeHelperKind::BinaryOp,
         Register::new(Kind::Ref, dst_reg),
     )
 }
@@ -3869,7 +3869,7 @@ fn build_residual_call_ir_r_insn_from_operands(
     lhs_operand: Operand,
     rhs_operand: Operand,
     flavor: CallFlavor,
-    pyre_helper: majit_ir::PyreHelperKind,
+    runtime_helper: majit_ir::RuntimeHelperKind,
     dst_reg: Register,
 ) -> Insn {
     let mut effect_info = effect_info_for_call_flavor(flavor);
@@ -3878,11 +3878,11 @@ fn build_residual_call_ir_r_insn_from_operands(
     // specialization (guard_class + getfield_gc + int/float_OP +
     // new_with_vtable) instead of recording an opaque CALL_MAY_FORCE.
     // The walker cannot match the helper by fnaddr (pyre-jit-trace does
-    // not depend on pyre-jit), so the `pyre_helper` tag on the descr's
+    // not depend on pyre-jit), so the `runtime_helper` tag on the descr's
     // EffectInfo is the recognition vehicle (kept off `oopspecindex` so
-    // `has_oopspec()` stays false for ordinary calls). `PyreHelperKind::None`
+    // `has_oopspec()` stays false for ordinary calls). `RuntimeHelperKind::None`
     // for callers that are not a recognized specialization.
-    effect_info.pyre_helper = pyre_helper;
+    effect_info.runtime_helper = runtime_helper;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
@@ -3910,13 +3910,13 @@ fn build_residual_call_ir_r_insn_from_ref_list(
     op_val: i64,
     ref_operands: Vec<Operand>,
     flavor: CallFlavor,
-    pyre_helper: majit_ir::PyreHelperKind,
+    runtime_helper: majit_ir::RuntimeHelperKind,
     dst_reg: Register,
 ) -> Insn {
     let mut arg_kinds = vec![Kind::Ref; ref_operands.len()];
     arg_kinds.push(Kind::Int);
     let mut effect_info = effect_info_for_call_flavor(flavor);
-    effect_info.pyre_helper = pyre_helper;
+    effect_info.runtime_helper = runtime_helper;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds,
@@ -3998,7 +3998,7 @@ where
         lhs_operand,
         rhs_operand,
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::CompareOp,
+        majit_ir::RuntimeHelperKind::CompareOp,
         result_reg,
     ))
 }
@@ -4027,7 +4027,7 @@ pub fn build_compare_op_residual_call_ir_r_insn(
         Operand::Register(Register::new(Kind::Ref, lhs_reg)),
         Operand::Register(Register::new(Kind::Ref, rhs_reg)),
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::CompareOp,
+        majit_ir::RuntimeHelperKind::CompareOp,
         Register::new(Kind::Ref, dst_reg),
     )
 }
@@ -4140,8 +4140,8 @@ fn build_load_global_fn_insn_from_operands(
     // Tag the calldescr so the full-body walker can recognize this as the
     // `LOAD_GLOBAL` module-dict read and emit the cell-cache fold; the
     // recognition reader is dev-gated and default-off (see
-    // PyreHelperKind::LoadGlobal).
-    effect_info.pyre_helper = majit_ir::PyreHelperKind::LoadGlobal;
+    // RuntimeHelperKind::LoadGlobal).
+    effect_info.runtime_helper = majit_ir::RuntimeHelperKind::LoadGlobal;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
@@ -4218,7 +4218,7 @@ pub fn build_load_method_self_fn_residual_call_ir_r_insn(
     dst_reg: u16,
 ) -> Insn {
     let mut effect_info = effect_info_for_call_flavor(CallFlavor::PlainCannotRaise);
-    effect_info.pyre_helper = majit_ir::PyreHelperKind::LoadMethodSelf;
+    effect_info.runtime_helper = majit_ir::RuntimeHelperKind::LoadMethodSelf;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
@@ -4293,7 +4293,7 @@ where
         // Tag so the full-body walker can try the module-scope cell fold
         // (`try_walker_load_name_cell_fold`); the fold falls through to this
         // residual for non-module frames (`w_locals` set).
-        majit_ir::PyreHelperKind::LoadName,
+        majit_ir::RuntimeHelperKind::LoadName,
         dst_reg,
     ))
 }
@@ -4337,7 +4337,7 @@ where
         // in-place store fold (`try_walker_store_name_cell_fold`); the fold
         // falls through to this residual for non-module frames / non-int
         // values / non-cell slots.
-        majit_ir::PyreHelperKind::StoreName,
+        majit_ir::RuntimeHelperKind::StoreName,
     ))
 }
 
@@ -4379,7 +4379,7 @@ where
         true,
         // Tag for the same module-scope IntMutableCell in-place store fold as
         // `lower_store_name_hlop_to_insn` (`try_walker_store_name_cell_fold`).
-        majit_ir::PyreHelperKind::StoreGlobal,
+        majit_ir::RuntimeHelperKind::StoreGlobal,
     ))
 }
 
@@ -4407,7 +4407,7 @@ where
         // Tagged so the walker can run the `jit_force_quasi_immutable` test
         // (`pyjitpl.py:1094-1118`) before executing the delete — `delitem_str`
         // calls `mutated()` on a successful removal.
-        majit_ir::PyreHelperKind::DeleteName,
+        majit_ir::RuntimeHelperKind::DeleteName,
     ))
 }
 
@@ -4419,7 +4419,7 @@ fn lower_frame_only_ref_hlop_to_insn<F, LC>(
     op: &super::flow::SpaceOperation,
     opname: &str,
     fn_idx: u16,
-    pyre_helper: majit_ir::PyreHelperKind,
+    runtime_helper: majit_ir::RuntimeHelperKind,
     get_register: &mut F,
     lower_constant: &mut LC,
 ) -> Option<Insn>
@@ -4439,7 +4439,7 @@ where
         fn_idx,
         vec![frame_operand],
         CallFlavor::Plain,
-        pyre_helper,
+        runtime_helper,
         dst_reg,
     ))
 }
@@ -4459,7 +4459,7 @@ where
         op,
         "load_locals",
         ctx.load_locals_fn_idx,
-        majit_ir::PyreHelperKind::LoadLocals,
+        majit_ir::RuntimeHelperKind::LoadLocals,
         get_register,
         lower_constant,
     )
@@ -4480,7 +4480,7 @@ where
         op,
         "load_build_class",
         ctx.load_build_class_fn_idx,
-        majit_ir::PyreHelperKind::LoadBuildClass,
+        majit_ir::RuntimeHelperKind::LoadBuildClass,
         get_register,
         lower_constant,
     )
@@ -4512,7 +4512,7 @@ where
     // Plain flavor means “no graph was analyzed” and becomes RANDOM_EFFECTS /
     // CALL_MAY_FORCE, contradicting PyPy's zero-forcing IMPORT_NAME trace.
     let mut effect_info = majit_ir::EffectInfo::default();
-    effect_info.pyre_helper = majit_ir::PyreHelperKind::LoadImport;
+    effect_info.runtime_helper = majit_ir::RuntimeHelperKind::LoadImport;
     Some(build_residual_call_r_r_insn_with_effect_info(
         ctx.load_import_fn_idx,
         vec![frame_operand],
@@ -4558,7 +4558,7 @@ where
         op,
         "load_import_locals",
         ctx.load_import_locals_fn_idx,
-        majit_ir::PyreHelperKind::LoadImportLocals,
+        majit_ir::RuntimeHelperKind::LoadImportLocals,
         get_register,
         lower_constant,
     )
@@ -4586,7 +4586,7 @@ where
         CallFlavor::Plain,
         true,
         // See [`lower_delete_name_hlop_to_insn`].
-        majit_ir::PyreHelperKind::DeleteGlobal,
+        majit_ir::RuntimeHelperKind::DeleteGlobal,
     ))
 }
 
@@ -4634,7 +4634,7 @@ pub fn build_call_fn_residual_call_r_r_insn(
         call_fn_idx,
         ref_operands,
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::CallFn,
+        majit_ir::RuntimeHelperKind::CallFn,
         Register::new(Kind::Ref, dst_reg),
     )
 }
@@ -4660,7 +4660,7 @@ pub fn build_get_current_exception_fn_residual_call_r_r_insn(
         get_current_exception_fn_idx,
         Vec::new(),
         CallFlavor::PlainCannotRaiseNoHeap,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::RuntimeHelperKind::None,
         Register::new(Kind::Ref, dst_reg),
     )
 }
@@ -4769,7 +4769,7 @@ where
                 ctx.newtuple_from_array_fn_idx,
                 vec![array_operand],
                 CallFlavor::Plain,
-                majit_ir::PyreHelperKind::NewtupleFromArray,
+                majit_ir::RuntimeHelperKind::NewtupleFromArray,
                 dst_reg,
             ))
         }
@@ -4790,7 +4790,7 @@ where
                 ctx.build_map_from_array_fn_idx,
                 vec![array_operand],
                 CallFlavor::MayForce,
-                majit_ir::PyreHelperKind::None,
+                majit_ir::RuntimeHelperKind::None,
                 dst_reg,
             ))
         }
@@ -4811,7 +4811,7 @@ where
                 ctx.build_set_from_array_fn_idx,
                 vec![array_operand],
                 CallFlavor::MayForce,
-                majit_ir::PyreHelperKind::None,
+                majit_ir::RuntimeHelperKind::None,
                 dst_reg,
             ))
         }
@@ -4837,7 +4837,7 @@ where
                 ctx.call_function_ex_fn_idx,
                 ref_operands,
                 CallFlavor::MayForce,
-                majit_ir::PyreHelperKind::CallFunctionEx,
+                majit_ir::RuntimeHelperKind::CallFunctionEx,
                 dst_reg,
             ))
         }
@@ -4870,7 +4870,7 @@ where
                 ctx.call_kw_idx_by_nargs[nargs],
                 ref_operands,
                 CallFlavor::MayForce,
-                majit_ir::PyreHelperKind::CallKw,
+                majit_ir::RuntimeHelperKind::CallKw,
                 dst_reg,
             ))
         }
@@ -4891,7 +4891,7 @@ where
                 ctx.build_string_from_array_fn_idx,
                 vec![array_operand],
                 CallFlavor::Plain,
-                majit_ir::PyreHelperKind::None,
+                majit_ir::RuntimeHelperKind::None,
                 dst_reg,
             ))
         }
@@ -4920,14 +4920,14 @@ where
             // intercept it and emit the virtualizable decomposed `newlist`
             // shape (`pyjitpl.py opimpl_newlist`) instead of recording the
             // opaque CallR.  Inert on the assembler/baseline path (it reads
-            // fn_idx + args, not `pyre_helper`) and on the legacy trait path
+            // fn_idx + args, not `runtime_helper`) and on the legacy trait path
             // (which never emitted this residual); only the FBW intercept keys
             // on it.
             Some(build_residual_call_r_r_insn_from_operands(
                 ctx.newlist_from_array_fn_idx,
                 vec![array_operand],
                 CallFlavor::Plain,
-                majit_ir::PyreHelperKind::NewlistFromArray,
+                majit_ir::RuntimeHelperKind::NewlistFromArray,
                 dst_reg,
             ))
         }
@@ -4947,7 +4947,7 @@ pub fn build_residual_call_r_r_insn_from_operands(
     fn_idx: u16,
     ref_operands: Vec<Operand>,
     flavor: CallFlavor,
-    pyre_helper: majit_ir::PyreHelperKind,
+    runtime_helper: majit_ir::RuntimeHelperKind,
     dst_reg: Register,
 ) -> Insn {
     // `bh_call_fn_N` dispatches the callable supplied at runtime.  Its target
@@ -4957,12 +4957,12 @@ pub fn build_residual_call_r_r_insn_from_operands(
     // which makes both the tracing heapcache and OptHeap forget values across
     // the residual call.  In particular, a callee can rewrite an
     // `IntMutableCell.intvalue` without changing the module-dict version.
-    let mut effect_info = if pyre_helper == majit_ir::PyreHelperKind::CallFn {
+    let mut effect_info = if runtime_helper == majit_ir::RuntimeHelperKind::CallFn {
         majit_ir::EffectInfo::MOST_GENERAL
     } else {
         effect_info_for_call_flavor(flavor)
     };
-    effect_info.pyre_helper = pyre_helper;
+    effect_info.runtime_helper = runtime_helper;
     build_residual_call_r_r_insn_with_effect_info(fn_idx, ref_operands, effect_info, dst_reg)
 }
 
@@ -5038,7 +5038,7 @@ pub fn build_normalize_raise_varargs_fn_residual_call_r_r_insn(
             cause,
         ],
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::RuntimeHelperKind::None,
         Register::new(Kind::Ref, dst_reg),
     )
 }
@@ -5104,7 +5104,7 @@ fn build_residual_call_ir_r_insn_from_int_only_operands(
     // `box_int_fn` boxes a raw Int into a fresh `PyLong`; tag it so the
     // full-body walker emits the virtualizable `new_with_vtable` +
     // `setfield_gc` form instead of an opaque CanRaise residual.
-    effect_info.pyre_helper = majit_ir::PyreHelperKind::BoxInt;
+    effect_info.runtime_helper = majit_ir::RuntimeHelperKind::BoxInt;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Int],
@@ -5308,7 +5308,7 @@ fn build_residual_call_r_i_insn_from_operands(
     // operand specialises to `guard_class INT` + `getfield intval` +
     // `int_is_true`, eliding the may-force call's GUARD_NOT_FORCED /
     // GUARD_NO_EXCEPTION (mirrors the StoreSubscr / BinaryOp tags).
-    effect_info.pyre_helper = majit_ir::PyreHelperKind::Truth;
+    effect_info.runtime_helper = majit_ir::RuntimeHelperKind::Truth;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref],
@@ -5371,7 +5371,7 @@ where
         vec![obj_operand, key_operand, value_operand],
         CallFlavor::MayForce,
         true,
-        majit_ir::PyreHelperKind::StoreSubscr,
+        majit_ir::RuntimeHelperKind::StoreSubscr,
     ))
 }
 
@@ -5413,7 +5413,7 @@ where
         vec![obj_operand, start_operand, stop_operand, value_operand],
         CallFlavor::MayForce,
         true,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::RuntimeHelperKind::None,
     ))
 }
 
@@ -5730,7 +5730,7 @@ where
     // vehicle (the walker crate cannot match the helper by fnaddr); a decline
     // falls back to this same residual, so tagging is behaviour-preserving when
     // the fold is disabled or the receiver shape is unsupported.
-    effect_info.pyre_helper = majit_ir::PyreHelperKind::LoadAttr;
+    effect_info.runtime_helper = majit_ir::RuntimeHelperKind::LoadAttr;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
@@ -5923,7 +5923,7 @@ where
     // Tag the STORE_ATTR helper calldescr so the full-body walker can replace
     // a plain unboxed same-type integer store with the non-forcing raw write.
     // A declined fold continues with this unchanged MayForce residual.
-    effect_info.pyre_helper = majit_ir::PyreHelperKind::StoreAttr;
+    effect_info.runtime_helper = majit_ir::RuntimeHelperKind::StoreAttr;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
@@ -5977,7 +5977,7 @@ where
         ctx.binary_slice_fn_idx,
         vec![obj, start, stop],
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::RuntimeHelperKind::None,
         dst_reg,
     ))
 }
@@ -6064,7 +6064,7 @@ where
         ctx.format_simple_fn_idx,
         vec![value],
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::RuntimeHelperKind::None,
         dst_reg,
     ))
 }
@@ -6104,7 +6104,7 @@ where
     let mut effect_info = effect_info_for_call_flavor(CallFlavor::Plain);
     // Recognition tag for the walker's `Cell.get` fold; carries no replay-safety
     // standing of its own.
-    effect_info.pyre_helper = majit_ir::PyreHelperKind::LoadDeref;
+    effect_info.runtime_helper = majit_ir::RuntimeHelperKind::LoadDeref;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
@@ -6172,7 +6172,7 @@ where
         // re-running the body doubles the cell write).  The tag is orthogonal
         // to the raise classification: the FOR_ITER body-effect guard keys on
         // this `StoreDeref` helper tag, not on the `PlainCannotRaise` flavor.
-        majit_ir::PyreHelperKind::StoreDeref,
+        majit_ir::RuntimeHelperKind::StoreDeref,
         dst_reg,
     ))
 }
@@ -6261,7 +6261,7 @@ where
         ctx.make_function_fn_idx,
         vec![globals, code],
         CallFlavor::Plain,
-        majit_ir::PyreHelperKind::MakeFunction,
+        majit_ir::RuntimeHelperKind::MakeFunction,
         dst_reg,
     ))
 }
@@ -6298,7 +6298,7 @@ where
         _ => return None,
     };
     let mut effect_info = effect_info_for_call_flavor(CallFlavor::Plain);
-    effect_info.pyre_helper = majit_ir::PyreHelperKind::SetFunctionAttribute;
+    effect_info.runtime_helper = majit_ir::RuntimeHelperKind::SetFunctionAttribute;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
@@ -6347,7 +6347,7 @@ where
         ctx.unary_negative_fn_idx,
         vec![value],
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::UnaryNegative,
+        majit_ir::RuntimeHelperKind::UnaryNegative,
         dst_reg,
     ))
 }
@@ -6383,7 +6383,7 @@ where
         ctx.unary_invert_fn_idx,
         vec![value],
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::UnaryInvert,
+        majit_ir::RuntimeHelperKind::UnaryInvert,
         dst_reg,
     ))
 }
@@ -6419,7 +6419,7 @@ where
         ctx.unary_positive_fn_idx,
         vec![value],
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::UnaryPositive,
+        majit_ir::RuntimeHelperKind::UnaryPositive,
         dst_reg,
     ))
 }
@@ -6454,7 +6454,7 @@ where
         ctx.list_to_tuple_fn_idx,
         vec![value],
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::RuntimeHelperKind::None,
         dst_reg,
     ))
 }
@@ -6486,7 +6486,7 @@ where
         fn_idx,
         vec![subject],
         flavor,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::RuntimeHelperKind::None,
         dst_reg,
     ))
 }
@@ -6585,7 +6585,7 @@ where
         ctx.match_keys_fn_idx,
         vec![subject, keys],
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::RuntimeHelperKind::None,
         dst_reg,
     ))
 }
@@ -6625,7 +6625,7 @@ where
         count,
         vec![subject, cls, kwd_attrs],
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::RuntimeHelperKind::None,
         dst_reg,
     ))
 }
@@ -6661,7 +6661,7 @@ where
         ctx.unary_not_fn_idx,
         vec![value],
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::RuntimeHelperKind::None,
         dst_reg,
     ))
 }
@@ -6698,7 +6698,7 @@ where
         ctx.format_with_spec_fn_idx,
         vec![value, spec],
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::RuntimeHelperKind::None,
         dst_reg,
     ))
 }
@@ -7053,7 +7053,7 @@ where
         vec![obj_operand, key_operand],
         CallFlavor::MayForce,
         true,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::RuntimeHelperKind::None,
     ))
 }
 
@@ -7093,7 +7093,7 @@ where
         vec![list_operand, iterable_operand],
         CallFlavor::MayForce,
         true,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::RuntimeHelperKind::None,
     ))
 }
 
@@ -7138,7 +7138,7 @@ where
         operands,
         CallFlavor::MayForce,
         true,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::RuntimeHelperKind::None,
     ))
 }
 
@@ -7173,7 +7173,7 @@ where
     // the deterministic immutable-type raise to a traced inline exception
     // construction.  A declined fold continues with this unchanged MayForce
     // residual — the tag mirror of `lower_setattr_hlop_to_insn`.
-    effect_info.pyre_helper = majit_ir::PyreHelperKind::DeleteAttr;
+    effect_info.runtime_helper = majit_ir::RuntimeHelperKind::DeleteAttr;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
@@ -7229,7 +7229,7 @@ where
         _ => return None,
     };
     let mut effect_info = effect_info_for_call_flavor(CallFlavor::PlainCannotRaise);
-    effect_info.pyre_helper = majit_ir::PyreHelperKind::LoadMethodSelf;
+    effect_info.runtime_helper = majit_ir::RuntimeHelperKind::LoadMethodSelf;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
@@ -7366,7 +7366,7 @@ where
         ctx.call_fn_idx_by_nargs[nargs],
         operands,
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::CallFn,
+        majit_ir::RuntimeHelperKind::CallFn,
         dst_reg,
     ))
 }
@@ -7392,7 +7392,7 @@ pub fn build_store_subscr_fn_residual_call_r_v_insn(
         ],
         CallFlavor::MayForce,
         true,
-        majit_ir::PyreHelperKind::StoreSubscr,
+        majit_ir::RuntimeHelperKind::StoreSubscr,
     )
 }
 
@@ -7419,7 +7419,7 @@ pub fn build_set_current_exception_fn_residual_call_r_v_insn(
         vec![Operand::Register(Register::new(Kind::Ref, exc_reg))],
         CallFlavor::PlainCannotRaiseNoHeap,
         false,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::RuntimeHelperKind::None,
     )
 }
 
@@ -7437,11 +7437,11 @@ fn build_residual_call_r_v_insn_from_operands(
     ref_operands: Vec<Operand>,
     flavor: CallFlavor,
     void_word_abi: bool,
-    pyre_helper: majit_ir::PyreHelperKind,
+    runtime_helper: majit_ir::RuntimeHelperKind,
 ) -> Insn {
     let arg_kinds = vec![Kind::Ref; ref_operands.len()];
     let mut effect_info = effect_info_for_call_flavor(flavor);
-    effect_info.pyre_helper = pyre_helper;
+    effect_info.runtime_helper = runtime_helper;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds,
@@ -7548,7 +7548,7 @@ fn build_residual_call_ir_r_single_ref_plain_insn_from_operands(
     dst_reg: Register,
 ) -> Insn {
     let mut effect_info = effect_info_for_call_flavor(CallFlavor::Plain);
-    effect_info.pyre_helper = majit_ir::PyreHelperKind::LoadConst;
+    effect_info.runtime_helper = majit_ir::RuntimeHelperKind::LoadConst;
     let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Int],
@@ -9552,7 +9552,7 @@ mod tests {
         // full-body walker can recognize + specialize it (#57); the
         // hand-built dual-write descr must mirror that tag.
         let mut may_force_ei = effect_info_for_call_flavor(CallFlavor::MayForce);
-        may_force_ei.pyre_helper = majit_ir::PyreHelperKind::BinaryOp;
+        may_force_ei.runtime_helper = majit_ir::RuntimeHelperKind::BinaryOp;
         let descr = intern_call_descr_stub(
             may_force_ei,
             vec![Kind::Ref, Kind::Ref, Kind::Int],
@@ -10044,7 +10044,7 @@ mod tests {
         assert_eq!(format!("{lowered:?}"), format!("{prod:?}"));
         // Both paths share `build_residual_call_r_v_insn_from_operands`,
         // so shape equality alone cannot catch the tag regressing to
-        // `PyreHelperKind::None` — pin the value itself.
+        // `RuntimeHelperKind::None` — pin the value itself.
         let Insn::Op { args, .. } = &lowered else {
             panic!("lowered SETITEM must be an Op insn");
         };
@@ -10059,8 +10059,8 @@ mod tests {
             })
             .expect("lowered SETITEM must carry a CallDescrStub descr");
         assert_eq!(
-            stub.effect_info.pyre_helper,
-            majit_ir::PyreHelperKind::StoreSubscr
+            stub.effect_info.runtime_helper,
+            majit_ir::RuntimeHelperKind::StoreSubscr
         );
     }
 
@@ -10293,7 +10293,7 @@ mod tests {
                         DescrOperand::CallDescrStub(stub) => {
                             assert_eq!(stub.arg_kinds, vec![Kind::Ref, Kind::Int]);
                             let mut expected_ei = effect_info_for_call_flavor(CallFlavor::Plain);
-                            expected_ei.pyre_helper = majit_ir::PyreHelperKind::LoadConst;
+                            expected_ei.runtime_helper = majit_ir::RuntimeHelperKind::LoadConst;
                             assert_eq!(stub.effect_info, expected_ei);
                         }
                         other => panic!("expected CallDescrStub, got {other:?}"),
@@ -10359,7 +10359,7 @@ mod tests {
                         DescrOperand::CallDescrStub(stub) => {
                             assert_eq!(stub.arg_kinds, vec![Kind::Ref, Kind::Int]);
                             let mut expected_ei = effect_info_for_call_flavor(CallFlavor::Plain);
-                            expected_ei.pyre_helper = majit_ir::PyreHelperKind::LoadConst;
+                            expected_ei.runtime_helper = majit_ir::RuntimeHelperKind::LoadConst;
                             assert_eq!(stub.effect_info, expected_ei);
                         }
                         other => panic!("expected CallDescrStub, got {other:?}"),
@@ -10393,7 +10393,7 @@ mod tests {
         let descr = intern_call_descr_stub(
             {
                 let mut ei = effect_info_for_call_flavor(CallFlavor::Plain);
-                ei.pyre_helper = majit_ir::PyreHelperKind::LoadConst;
+                ei.runtime_helper = majit_ir::RuntimeHelperKind::LoadConst;
                 ei
             },
             vec![Kind::Ref, Kind::Int],
@@ -10500,7 +10500,7 @@ mod tests {
                             );
                             assert_eq!(stub.effect_info, {
                                 let mut ei = effect_info_for_call_flavor(CallFlavor::Plain);
-                                ei.pyre_helper = majit_ir::PyreHelperKind::LoadGlobal;
+                                ei.runtime_helper = majit_ir::RuntimeHelperKind::LoadGlobal;
                                 ei
                             });
                         }
@@ -10634,7 +10634,7 @@ mod tests {
                             );
                             assert_eq!(stub.effect_info, {
                                 let mut ei = effect_info_for_call_flavor(CallFlavor::Plain);
-                                ei.pyre_helper = majit_ir::PyreHelperKind::LoadGlobal;
+                                ei.runtime_helper = majit_ir::RuntimeHelperKind::LoadGlobal;
                                 ei
                             });
                         }
@@ -10665,7 +10665,7 @@ mod tests {
         let descr = intern_call_descr_stub(
             {
                 let mut ei = effect_info_for_call_flavor(CallFlavor::Plain);
-                ei.pyre_helper = majit_ir::PyreHelperKind::LoadGlobal;
+                ei.runtime_helper = majit_ir::RuntimeHelperKind::LoadGlobal;
                 ei
             },
             vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
@@ -10704,7 +10704,7 @@ mod tests {
         // `EffectInfo::MOST_GENERAL` (`graphanalyze.py:109-112`
         // `top_result()` → `effectinfo.py:285-292`) and share
         // `ExtraEffect::RandomEffects`. What still separates the two
-        // descrs is the `pyre_helper` tag the walker dispatches on.
+        // descrs is the `runtime_helper` tag the walker dispatches on.
         let bin = build_binary_op_residual_call_ir_r_insn(7, 0, 1, 2, 3);
         let glob = build_load_global_fn_residual_call_ir_r_insn(7, 0, 1, 2, 4, 3);
         let bin_descr = match &bin {
@@ -10745,10 +10745,10 @@ mod tests {
         }
         assert_ne!(
             bin_descr, glob_descr,
-            "the two descrs stay distinguishable through `pyre_helper`, \
+            "the two descrs stay distinguishable through `runtime_helper`, \
              which is what the walker's fold recognisers dispatch on"
         );
-        assert_ne!(bin_descr.pyre_helper, glob_descr.pyre_helper);
+        assert_ne!(bin_descr.runtime_helper, glob_descr.runtime_helper);
     }
 
     #[test]
@@ -10828,7 +10828,7 @@ mod tests {
                                 vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Ref]
                             );
                             let mut expected_ei = majit_ir::EffectInfo::MOST_GENERAL;
-                            expected_ei.pyre_helper = majit_ir::PyreHelperKind::CallFn;
+                            expected_ei.runtime_helper = majit_ir::RuntimeHelperKind::CallFn;
                             assert_eq!(stub.effect_info, expected_ei);
                         }
                         other => panic!("expected CallDescrStub, got {other:?}"),
@@ -10912,7 +10912,7 @@ mod tests {
         let arg2 = Variable::new(VariableId(8), Kind::Ref);
         let dst = Variable::new(VariableId(9), Kind::Ref);
         let mut call_fn_ei = majit_ir::EffectInfo::MOST_GENERAL;
-        call_fn_ei.pyre_helper = majit_ir::PyreHelperKind::CallFn;
+        call_fn_ei.runtime_helper = majit_ir::RuntimeHelperKind::CallFn;
         let descr = intern_call_descr_stub(
             call_fn_ei,
             vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Ref, Kind::Ref],
@@ -11002,7 +11002,7 @@ mod tests {
                         DescrOperand::CallDescrStub(stub) => {
                             assert_eq!(stub.arg_kinds, vec![Kind::Int]);
                             let mut expected_ei = effect_info_for_call_flavor(CallFlavor::Plain);
-                            expected_ei.pyre_helper = majit_ir::PyreHelperKind::BoxInt;
+                            expected_ei.runtime_helper = majit_ir::RuntimeHelperKind::BoxInt;
                             assert_eq!(stub.effect_info, expected_ei);
                         }
                         other => panic!("expected CallDescrStub, got {other:?}"),
@@ -11053,7 +11053,7 @@ mod tests {
         let descr = intern_call_descr_stub(
             {
                 let mut ei = effect_info_for_call_flavor(CallFlavor::Plain);
-                ei.pyre_helper = majit_ir::PyreHelperKind::BoxInt;
+                ei.runtime_helper = majit_ir::RuntimeHelperKind::BoxInt;
                 ei
             },
             vec![Kind::Int],
@@ -12833,7 +12833,7 @@ mod tests {
                         DescrOperand::CallDescrStub(stub) => {
                             let mut expected_ei =
                                 effect_info_for_call_flavor(CallFlavor::PlainCannotRaise);
-                            expected_ei.pyre_helper = majit_ir::PyreHelperKind::StoreDeref;
+                            expected_ei.runtime_helper = majit_ir::RuntimeHelperKind::StoreDeref;
                             assert_eq!(
                                 stub.effect_info, expected_ei,
                                 "STORE_DEREF residual must carry PlainCannotRaise + StoreDeref tag"
@@ -13672,8 +13672,8 @@ mod tests {
                     Operand::Descr(descr) => match &**descr {
                         DescrOperand::CallDescrStub(stub) => {
                             assert_eq!(
-                                stub.effect_info.pyre_helper,
-                                majit_ir::PyreHelperKind::LoadImportLocals
+                                stub.effect_info.runtime_helper,
+                                majit_ir::RuntimeHelperKind::LoadImportLocals
                             );
                             // A `CannotRaise` shape here would advertise
                             // concrete-empty readonly and write sets the
@@ -13745,8 +13745,8 @@ mod tests {
                     Operand::Descr(descr) => match &**descr {
                         DescrOperand::CallDescrStub(stub) => {
                             assert_eq!(
-                                stub.effect_info.pyre_helper,
-                                majit_ir::PyreHelperKind::LoadImport
+                                stub.effect_info.runtime_helper,
+                                majit_ir::RuntimeHelperKind::LoadImport
                             );
                             assert_eq!(
                                 stub.effect_info.extraeffect,

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -1808,7 +1808,7 @@ fn expand_pyre_methods(
     // Collect (python_name, wrapper_ident) per method as we rewrite the
     // impl block in-place: every `fn name(&self|&mut self, …)` keeps
     // its typed body untouched so users can call it directly from Rust,
-    // and we synthesise a sibling `pub fn name__pyre_wrapper(args)` as
+    // and we synthesise a sibling `pub fn name__majit_wrapper(args)` as
     // a free-fn inside an attached `mod _pyre_wrappers_<Self>` module.
     let mut wrappers = Vec::<proc_macro2::TokenStream>::new();
     let mut registrations = Vec::<proc_macro2::TokenStream>::new();
@@ -1832,7 +1832,7 @@ fn expand_pyre_methods(
             ));
         }
         let mname = &m.sig.ident;
-        let wrapper_name = format_ident!("__pyre_wrap_{}", mname);
+        let wrapper_name = format_ident!("__majit_wrap_{}", mname);
         let wrapper_target_name = format_ident!("__majit_builtin_wrapper_target_{}", mname);
         let kind = classify_method(m)?;
 

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -2014,7 +2014,7 @@ pub unsafe fn w_list_uses_empty_storage(obj: PyObjectRef) -> bool {
 ///
 /// The tracer uses this to decide whether the recorded trace needs
 /// `list_write_barrier` at all — see `FbwWalkMode::append_inplace_wb_covered`.
-/// A `std::alloc` block (`PYRE_GC_ITEMSBLOCK=0`) answers false: it has no GC
+/// A `std::alloc` block (`MAJIT_GC_ITEMSBLOCK=0`) answers false: it has no GC
 /// header for an array barrier to mark, so the barrier on the enclosing
 /// `W_ListObject` is the only thing keeping the block's slots reachable.
 ///

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -104,7 +104,7 @@ pub struct ArrayToken {
 /// `{length: usize, items: *mut ItemsBlock}` fields directly (no
 /// `PyObjectArray` fat wrapper for list/tuple). The `std::alloc`
 /// `alloc_items_block` / `grow_items_block` below are the
-/// `PYRE_GC_ITEMSBLOCK=0` fallback (provably identical pre-migration
+/// `MAJIT_GC_ITEMSBLOCK=0` fallback (provably identical pre-migration
 /// behaviour).
 #[repr(C)]
 pub struct ItemsBlock {
@@ -587,7 +587,7 @@ pub unsafe fn alloc_cleared_ref_items_block_gc(cap: usize) -> Option<*mut ItemsB
 }
 
 /// Allocate a fresh `ItemsBlock` with the given capacity via
-/// `std::alloc::alloc`. This is the `PYRE_GC_ITEMSBLOCK=0` fallback;
+/// `std::alloc::alloc`. This is the `MAJIT_GC_ITEMSBLOCK=0` fallback;
 /// the default path is the moving-nursery `alloc_items_block_gc` above
 /// (`try_gc_alloc`, caller-side root tracking via `gc_roots::pin_root` +
 /// the block write-barrier). An earlier `try_gc_alloc_stable` attempt was

--- a/pyre/pyre-object/src/tupleobject.rs
+++ b/pyre/pyre-object/src/tupleobject.rs
@@ -361,7 +361,7 @@ fn w_tuple_new_array_backed_impl(
 
     // pop_roots: read the relocated item pointers back out of the shadow
     // stack, then build the items block. On the Phase L2 nursery path
-    // (`PYRE_GC_ITEMSBLOCK`) the block itself is GC-managed and is the
+    // (`MAJIT_GC_ITEMSBLOCK`) the block itself is GC-managed and is the
     // last allocation here, so it stays put until `wrappeditems` is set;
     // `alloc_tuple_items_block_gc` re-pins the relocated values across its
     // own (collecting) block malloc. Gate off it is the std::alloc block.

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -5,7 +5,7 @@
 //! implements the same host-import contract:
 //!
 //!   * the main module (`pyre-wasm` built with `--features wasm-host`) imports
-//!     `pyre_jit.{jit_compile_wasm, jit_execute_wasm, jit_free_wasm}` and
+//!     `majit_host.{jit_compile_wasm, jit_execute_wasm, jit_free_wasm}` and
 //!     exports `memory`, `__indirect_function_table`, `pyre_alloc`,
 //!     `pyre_dealloc`, and `pyre_run_python`;
 //!   * each JIT-emitted trace module imports `env.memory` (shared with the
@@ -1540,7 +1540,7 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>> {
     let mut linker = Linker::new(engine);
 
     linker.func_wrap(
-        "pyre_jit",
+        "majit_host",
         "jit_compile_wasm",
         |mut caller: Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32| -> u32 {
             match jit_compile(&mut caller, bytes_ptr, bytes_len) {
@@ -1554,7 +1554,7 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>> {
     )?;
 
     linker.func_wrap(
-        "pyre_jit",
+        "majit_host",
         "jit_replace_wasm",
         |mut caller: Caller<'_, Host>, func_id: u32, bytes_ptr: u32, bytes_len: u32| -> u32 {
             match jit_replace(&mut caller, func_id, bytes_ptr, bytes_len) {
@@ -1568,7 +1568,7 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>> {
     )?;
 
     linker.func_wrap(
-        "pyre_jit",
+        "majit_host",
         "jit_execute_wasm",
         |mut caller: Caller<'_, Host>, func_id: u32, frame_ptr: u32| -> u32 {
             match jit_execute(&mut caller, func_id, frame_ptr) {
@@ -1582,7 +1582,7 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>> {
     )?;
 
     linker.func_wrap(
-        "pyre_jit",
+        "majit_host",
         "jit_free_wasm",
         |mut caller: Caller<'_, Host>, func_id: u32| {
             // Only a trace slot may be cleared; nulling a main-module slot
@@ -1616,7 +1616,7 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>> {
     // `store_subscr_fn` invoked in a void context) is coerced correctly
     // rather than trapping on an indirect-call type mismatch.
     linker.func_wrap(
-        "pyre_jit",
+        "majit_host",
         "jit_call_host",
         |mut caller: Caller<'_, Host>, frame_ptr: u32| {
             if let Err(e) = jit_call_trampoline(&mut caller, frame_ptr, CALL_RESULT_OFS as u32) {

--- a/pyre/pyre-wasm-runner/src/wasmi_host.rs
+++ b/pyre/pyre-wasm-runner/src/wasmi_host.rs
@@ -2,7 +2,7 @@
 //! under the pure-Rust `wasmi` interpreter instead of wasmtime.
 //!
 //! It satisfies the identical host-import contract as the wasmtime path in
-//! `main.rs` (`pyre_jit.*`, `pyre_host.*`, the per-trace `env.memory` /
+//! `main.rs` (`majit_host.*`, `pyre_host.*`, the per-trace `env.memory` /
 //! `env.jit_call` wiring, and the reflective residual-call trampoline). The
 //! only difference is the runtime: wasmi does not compile the module on load,
 //! so there is no per-process cranelift fixed cost — at the price of slower
@@ -216,7 +216,7 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>, String> {
 
     linker
         .func_wrap(
-            "pyre_jit",
+            "majit_host",
             "jit_compile_wasm",
             |mut caller: Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32| -> u32 {
                 match jit_compile(&mut caller, bytes_ptr, bytes_len) {
@@ -232,7 +232,7 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>, String> {
 
     linker
         .func_wrap(
-            "pyre_jit",
+            "majit_host",
             "jit_replace_wasm",
             |mut caller: Caller<'_, Host>, func_id: u32, bytes_ptr: u32, bytes_len: u32| -> u32 {
                 match jit_replace(&mut caller, func_id, bytes_ptr, bytes_len) {
@@ -248,7 +248,7 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>, String> {
 
     linker
         .func_wrap(
-            "pyre_jit",
+            "majit_host",
             "jit_execute_wasm",
             |mut caller: Caller<'_, Host>, func_id: u32, frame_ptr: u32| -> u32 {
                 match jit_execute(&mut caller, func_id, frame_ptr) {
@@ -264,7 +264,7 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>, String> {
 
     linker
         .func_wrap(
-            "pyre_jit",
+            "majit_host",
             "jit_free_wasm",
             |mut caller: Caller<'_, Host>, func_id: u32| {
                 caller.data_mut().traces.remove(&func_id);
@@ -276,7 +276,7 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>, String> {
     // wasmtime path's `jit_call_host` for the full rationale.
     linker
         .func_wrap(
-            "pyre_jit",
+            "majit_host",
             "jit_call_host",
             |mut caller: Caller<'_, Host>, frame_ptr: u32| {
                 if let Err(e) = jit_call_trampoline(&mut caller, frame_ptr, CALL_RESULT_OFS as u32)

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -131,7 +131,7 @@ static HEAP_PROF_ALLOC: heap_prof::CountingAlloc = heap_prof::CountingAlloc;
 // call it — a residual target whose real signature is not the uniform
 // `(i64…) -> i64` traps. The compiled trace already round-trips such calls
 // through the host (`env.jit_call`); this routes the recording / blackhole
-// path through the symmetric `pyre_jit.jit_call_host` import, which reflects
+// path through the symmetric `majit_host.jit_call_host` import, which reflects
 // the callee's wasm signature and coerces each positional argument.
 #[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
 mod residual_host {
@@ -147,7 +147,7 @@ mod residual_host {
     const MAX_ARGS: usize = 16;
     const SCRATCH_LEN: usize = CALL_ARGS_OFS + MAX_ARGS * 8;
 
-    #[link(wasm_import_module = "pyre_jit")]
+    #[link(wasm_import_module = "majit_host")]
     unsafe extern "C" {
         fn jit_call_host(frame_ptr: u32);
     }

--- a/scripts/check-majit-boundary.py
+++ b/scripts/check-majit-boundary.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Reject pyre-owned identifiers and filenames in the majit subtree."""
+
+from pathlib import Path
+import os
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parent.parent
+MAJIT = ROOT / "majit"
+TOKEN = re.compile(r'//|/\*|r(#{0,255})"|"|[A-Za-z_][A-Za-z0-9_]*')
+
+
+def is_runtime_owned(name: str) -> bool:
+    # Match the project's conventional lower-, upper-, and CamelCase spellings
+    # without misclassifying Python/RPython names such as `PyResult` and
+    # `GetRpyReferentsFn`.
+    return "pyre" in name or "Pyre" in name or "PYRE" in name
+
+
+def code_identifiers(source: str):
+    i = 0
+    while i < len(source):
+        match = TOKEN.search(source, i)
+        if match is None:
+            return
+        token = match.group(0)
+        i = match.end()
+        if token == "//":
+            newline = source.find("\n", i)
+            i = len(source) if newline < 0 else newline + 1
+        elif token == "/*":
+            depth = 1
+            while depth:
+                opening = source.find("/*", i)
+                closing = source.find("*/", i)
+                if closing < 0:
+                    return
+                if 0 <= opening < closing:
+                    depth += 1
+                    i = opening + 2
+                else:
+                    depth -= 1
+                    i = closing + 2
+        elif token == '"':
+            while True:
+                closing = source.find('"', i)
+                if closing < 0:
+                    return
+                escapes = 0
+                cursor = closing - 1
+                while cursor >= 0 and source[cursor] == "\\":
+                    escapes += 1
+                    cursor -= 1
+                i = closing + 1
+                if escapes % 2 == 0:
+                    break
+        elif token.startswith("r") and token.endswith('"'):
+            closing = '"' + "#" * len(match.group(1))
+            end = source.find(closing, i)
+            if end < 0:
+                return
+            i = end + len(closing)
+        else:
+            yield token
+
+
+def main() -> int:
+    failures = []
+    for directory, child_dirs, filenames in os.walk(MAJIT):
+        child_dirs[:] = sorted(name for name in child_dirs if name not in {"target", ".git"})
+        base = Path(directory)
+        for filename in sorted(filenames):
+            path = base / filename
+            if any(is_runtime_owned(part) for part in path.relative_to(MAJIT).parts):
+                failures.append(f"runtime-owned name in path: {path.relative_to(ROOT)}")
+            if path.suffix != ".rs":
+                continue
+            for name in code_identifiers(path.read_text(encoding="utf-8")):
+                if is_runtime_owned(name):
+                    failures.append(
+                        f"runtime-owned Rust identifier {name!r} in {path.relative_to(ROOT)}"
+                    )
+    if failures:
+        print("majit boundary check failed:", file=sys.stderr)
+        print("\n".join(f"  {failure}" for failure in failures), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-rpython-module-parity.py
+++ b/scripts/check-rpython-module-parity.py
@@ -360,7 +360,7 @@ INTENTIONAL_SYMBOL_EXTRA: dict[tuple[str, str], dict[str, dict[str, str]]] = {
             "reset_swap_fallback_hits": "temporary diagnostic counter reset for the legacy cast_ptr_to_int InstanceRepr-to-PtrRepr fallback",
             "rtype_bigint_from": "pyre builtin hook for bigint construction; no upstream RPython builtin object with this exact host name",
             "rtype_malloc_raw": "pyre host-name split for raw malloc lowering; upstream routes through malloc policy helpers",
-            "rtype_pyre_cast_instance": "pyre-internal front-end pointer-downcast helper with no upstream public builtin",
+            "rtype_cast_instance_intrinsic": "pyre-internal front-end pointer-downcast helper with no upstream public builtin",
             "rtype_same_as": "pyre host-name split for same_as lowering; upstream routes through low-level operation helpers",
             "somebuiltin_rtyper_makerepr": "Rust free-function carrier for upstream SomeBuiltin.rtyper_makerepr extension method",
             "somebuiltinmethod_rtyper_makerepr": "Rust free-function carrier for upstream SomeBuiltinMethod.rtyper_makerepr extension method",

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1351,11 +1351,8 @@ def write_readfiles(path: Path, by_crate: dict[str, set[Path]]) -> None:
         {item for crate_files in by_crate.values() for item in crate_files},
         key=lambda item: item.as_posix(),
     )
-    path.write_text(
-        "".join(f"{item.as_posix()}\n" for item in files),
-        encoding="utf-8",
-        newline="\n",
-    )
+    with path.open("w", encoding="utf-8", newline="\n") as output:
+        output.write("".join(f"{item.as_posix()}\n" for item in files))
 
 
 def assert_readfiles_resolve(root: Path, dest: Path, by_crate: dict[str, set[Path]]) -> None:
@@ -2602,9 +2599,8 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
         # compared against a string built in memory with "\n", so a writer
         # that translates makes the artefact describe the same tree
         # differently on Windows than everywhere else.
-        stamp_path.write_text(
-            current_stamp + "\n", encoding="utf-8", newline="\n"
-        )
+        with stamp_path.open("w", encoding="utf-8", newline="\n") as output:
+            output.write(current_stamp + "\n")
         print(
             f"    wrote {dest} ({dest.stat().st_size} bytes),"
             f" stamped in {time.monotonic() - phase_started:.0f} s"


### PR DESCRIPTION
## Summary

- remove Pyre-branded Rust identifiers and filenames from the Majit-owned surface, using engine terms such as `RuntimeHelperKind`, `CallRegistry`, `MAJIT_*`, and `majit_host`
- move Pyre-specific LLBC artifact selection and compatibility aliases into `pyre-jit-trace`, while Majit accepts explicit artifact inputs
- derive translator-local crate identities from loaded LLBC inputs instead of hard-coding Pyre crate roots
- add a CI boundary check that rejects Pyre-branded Rust identifiers or filenames under `majit/`
- keep LLBC extraction working on Python 3.9 when writing fingerprint metadata

## Why

Majit is the translation and meta-tracing engine; Pyre is one consumer. Pyre-owned crate names, environment variables, wrapper ABI names, and artifact discovery inside Majit reversed that dependency boundary and made the engine's generic contracts look consumer-specific. This patch makes the ownership explicit without changing interpreter semantics.

Comments and literal paths that intentionally document or test the Pyre consumer may still mention Pyre. The enforced boundary covers Majit Rust identifiers and filenames.

## Impact

Existing Pyre build inputs remain accepted through aliases owned by the Pyre build layer. New engine-facing names use the `MAJIT_*` namespace, and Pyre chooses and passes its LLBC artifacts explicitly.

## Validation

- regenerated `majit-rlib`, `pyre-object`, `pyre-interpreter`, and `pyre-jit` LLBC artifacts
- `cargo fmt --all -- --check`
- `cargo test --all --features dynasm`
- `python3 scripts/check-majit-boundary.py`
- `python3 pyre/check.py`: all 10 performance fixtures passed on dynasm, Cranelift, and Wasm; synthetic suites passed 478/478 on dynasm and Cranelift and 470/470 on Wasm
