### PR TITLE
codecs, interp, jit: the codec error registry, UnicodeError positions, exception display and suggestions, and PR #1466 review follow-ups

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -7071,6 +7071,13 @@ impl MiniMarkGC {
         }
     }
 
+    /// incminimark.py `max_heap_size_already_raised`, read from outside this
+    /// module.  See `crate::gc_max_heap_already_raised` for what the answer is
+    /// used to decide.
+    pub fn max_heap_already_raised(&self) -> bool {
+        self.max_heap_size_already_raised
+    }
+
     /// incminimark.py `collect_step`.
     pub fn collect_step(&mut self) -> crate::GcStepTransition {
         let _stw = if crate::gc_sync::stw_required() {

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -3117,6 +3117,19 @@ pub fn gc_set_max_heap_size(size: usize) {
     gc_sync::gc_op(|gc| gc.set_max_heap_size(size));
 }
 
+/// incminimark.py `max_heap_size_already_raised` — whether the program has
+/// already been handed the one `MemoryError` a bounded heap owes it.
+///
+/// The next breach after that one ends the process, so this is what a caller
+/// asks before running Python on its behalf: a module body, a finalizer or any
+/// other nested dispatch collects on a heap that is by definition at its limit,
+/// and the abort takes away whatever the caller had not finished writing.
+/// Unbounded heaps never set it, so the question answers `false` unless a limit
+/// is in force.
+pub fn gc_max_heap_already_raised() -> bool {
+    gc_sync::gc_op(|gc| gc.max_heap_already_raised())
+}
+
 /// rgc.py `move_out_of_nursery` — "Returns another object which is a copy of
 /// obj; but at any point (either now or in the future) the returned object
 /// might suddenly become identical to the one returned.  NOTE: Only use for

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -2222,6 +2222,24 @@ impl Default for BlackholeInterpBuilder {
     }
 }
 
+/// `blackhole.py _get_method`: the generated handler wrapper assigns
+/// `self.position` and only then re-raises, so a raising instruction leaves the
+/// frame pointing past itself.  Only `RaiseException` carries a coordinate
+/// because only it is read again -- `handle_exception_in_frame` is the sole
+/// consumer of `position` on an error path, and the two control-flow errors end
+/// the frame without another dispatch.
+///
+/// `BlackholeInterpreter::dispatch_step` applies this for the trait path; the
+/// two loops below reach the dispatch table directly, so they apply it here.
+fn sync_raise_position(bh: &mut BlackholeInterpreter, err: &DispatchError) {
+    if let DispatchError::RaiseException {
+        resume_position, ..
+    } = *err
+    {
+        bh.position = resume_position;
+    }
+}
+
 impl BlackholeInterpBuilder {
     pub fn new() -> Self {
         Self {
@@ -2429,7 +2447,13 @@ impl BlackholeInterpBuilder {
             if opcode >= self.dispatch_table.len() {
                 panic!("bad opcode {opcode} at position {}", position - 1);
             }
-            position = self.dispatch_table[opcode](bh, code, position)?;
+            position = match self.dispatch_table[opcode](bh, code, position) {
+                Ok(next) => next,
+                Err(err) => {
+                    sync_raise_position(bh, &err);
+                    return Err(err);
+                }
+            };
         }
     }
 
@@ -2483,7 +2507,13 @@ impl BlackholeInterpBuilder {
             let opname = self._insns[opcode_idx].as_str();
             probe(&*bh, pc, opcode, opname);
             position += 1;
-            position = self.dispatch_table[opcode_idx](bh, code, position)?;
+            position = match self.dispatch_table[opcode_idx](bh, code, position) {
+                Ok(next) => next,
+                Err(err) => {
+                    sync_raise_position(bh, &err);
+                    return Err(err);
+                }
+            };
         }
     }
 
@@ -2638,9 +2668,12 @@ fn handle_jitexception_dispatch(
 /// warmspot.py: result = handle_jitexception(e)
 /// warmspot.py:1041-1050: bhcaller._setup_return_value_{i,r,f}(result)
 ///
-/// Returns Ok(()) on success (return value set in bhcaller),
-/// or Err(exc_value) if the exception should be propagated as a
-/// regular exception (ExitFrameWithExceptionRef).
+/// Returns Ok(()) on success (return value set in bhcaller), or the
+/// `JitException` this level could not absorb: `ExitFrameWithExceptionRef`,
+/// which the caller propagates as a regular exception, or the pyre-only
+/// `BailToInterpreter`, which no portal level can absorb at all -- there is no
+/// result to install and no exception to deliver, only a frame the interpreter
+/// has to take back.
 #[expect(
     clippy::type_complexity,
     reason = "This is the literal nested tuple/list/dict/callable shape at an RPython parity boundary; a wrapper would change structural ownership, while a one-use alias would conceal the audited upstream shape"
@@ -2649,7 +2682,7 @@ fn handle_jitexception_in_portal(
     bhcaller: &mut BlackholeInterpreter,
     exc: JitException,
     portal_runner: Option<&dyn Fn(&JitException) -> Result<(BhReturnType, i64), JitException>>,
-) -> Result<(), i64> {
+) -> Result<(), JitException> {
     // warmspot.py handle_jitexception: while True loop.
     // ContinueRunningNormally → portal_runner → may raise JitException → loop.
     let mut current_exc = exc;
@@ -2665,9 +2698,18 @@ fn handle_jitexception_in_portal(
                 }
                 return Ok(());
             }
-            Err(JitException::ExitFrameWithExceptionRef(exc_ref)) => {
+            Err(exc @ JitException::ExitFrameWithExceptionRef(_)) => {
                 // warmspot.py:998-1005: raise as regular exception
-                return Err(exc_ref.0 as i64);
+                return Err(exc);
+            }
+            // A `portal_runner` that re-entered the portal and hit an
+            // `abort_permanent` marker or an unresolved callee reports the bail
+            // here.  `handle_jitexception` refuses one before its walk for the
+            // same reason this arm refuses to redispatch it: dispatching a bail
+            // neither invokes the runner nor changes the exception, so looping
+            // back would spin on the same value forever.
+            Err(exc @ JitException::BailToInterpreter) => {
+                return Err(exc);
             }
             Err(next_exc) => {
                 // warmspot.py:967-968, 979-980: JitException from portal_runner
@@ -2785,9 +2827,21 @@ fn handle_jitexception(
     //
     // In Rust we can do this directly since JitException carries the result.
     let caller = bh.nextblackholeinterp.as_mut().unwrap();
-    let current_exc = match handle_jitexception_in_portal(caller, exc, portal_runner) {
+    let portal_outcome = handle_jitexception_in_portal(caller, exc, portal_runner);
+    let current_exc = match portal_outcome {
         Ok(()) => 0,
-        Err(regular_exc) => regular_exc,
+        Err(JitException::ExitFrameWithExceptionRef(exc_ref)) => exc_ref.0 as i64,
+        // The bail leaves by the same exit the pre-walk refusal above takes:
+        // no level absorbs it, so the chain is released and it propagates to
+        // `_run_forever`'s caller.  The terminal image belongs to the re-entered
+        // portal's own chain, which released it before reporting the bail, so
+        // there is none to publish here.
+        Err(exc @ JitException::BailToInterpreter) => {
+            builder.release_chain(Some(bh));
+            return Err(exc);
+        }
+        // `handle_jitexception_in_portal` returns only those two.
+        Err(other) => unreachable!("portal level reported {other:?}"),
     };
     // blackhole.py:1780: return blackholeinterp, lle
     Ok((bh, current_exc))

--- a/pyre/extra_tests/parity_tests/exception_inline_scalar_fields_jit.py
+++ b/pyre/extra_tests/parity_tests/exception_inline_scalar_fields_jit.py
@@ -65,22 +65,38 @@ def check_explicit_cause():
 
 
 def check_rendered_implicit_context():
+    seen = set()
     rendered = ""
-    for _ in range(N):
+    for index in range(N):
         try:
             try:
                 raise KeyError("inner")
             except KeyError:
                 raise ValueError("outer")
         except ValueError as exc:
-            stream = io.StringIO()
-            previous = sys.stderr
-            sys.stderr = stream
-            try:
-                sys.excepthook(type(exc), exc, exc.__traceback__)
-            finally:
-                sys.stderr = previous
-            rendered = stream.getvalue()
+            # The fields this loop exists to virtualize, read on every
+            # iteration. The render is `traceback._print_exception_bltin`,
+            # which `sys.excepthook` reaches the way `_PyErr_Display` does:
+            # app-level, and costing more per call than the whole rest of this
+            # file. It runs on the last iteration, inside the loop body so it
+            # still renders an exception the compiled loop produced.
+            seen.add(
+                (
+                    exc.__suppress_context__,
+                    type(exc.__context__),
+                    exc.__traceback__ is not None,
+                )
+            )
+            if index == N - 1:
+                stream = io.StringIO()
+                previous = sys.stderr
+                sys.stderr = stream
+                try:
+                    sys.excepthook(type(exc), exc, exc.__traceback__)
+                finally:
+                    sys.stderr = previous
+                rendered = stream.getvalue()
+    assert seen == {(False, KeyError, True)}, seen
     assert "During handling of the above exception" in rendered, rendered
 
 

--- a/pyre/extra_tests/parity_tests/with_exit_suppression_after_branch.py
+++ b/pyre/extra_tests/parity_tests/with_exit_suppression_after_branch.py
@@ -1,10 +1,13 @@
 # CPython-suite gap: the suite has no hot loop where a branch arm holds more
 # than one suppressing `with`, so nothing exercises a second `__exit__` on a
 # compiled path.
-# parity-tests reason: this guards the blackhole's `guard_class` result, which
-# a resumed exception match reads to pick the handler. With that register left
-# unwritten the second block's `__exit__` was never reached and the raise
-# escaped the loop.
+# parity-tests reason: this is the shape a resumed exception match picks a
+# handler on. It was written from a repro whose second `__exit__` was never
+# reached, at a tree where `Backend::bh_classof` answered 0 and
+# `goto_if_exception_mismatch` compared that against the bounding vtable.
+# Reverting that commit no longer reproduces the escape here -- nor does it in
+# the repro itself -- so what this file pins is the shape's parity, not that
+# one register.
 
 """A second suppressing `with` in a branch arm still runs its `__exit__`.
 
@@ -16,6 +19,13 @@ are kept here as the boundary.
 Counting happens in the loop and the assertions run after it -- an assertion
 inside the body reads the counters and stops the loop compiling, which would
 leave the compiled path untested.
+
+Every loop here is a `while`. `for_iter_body_op_is_jit_safe` is an allowlist
+naming neither `LoadSpecial` nor `WithExceptStart`, so a `with` inside a `for`
+body declines the whole region: on `for` these shapes compiled two loops, took
+no guard failure at all and entered no blackhole, while on `while` they compile
+six loops and seven bridges, take 1595 guard failures and run the blackhole's
+`_run_forever` 1588 times.
 """
 
 ROUNDS = 20000
@@ -47,7 +57,8 @@ def two_blocks_in_a_branch():
     cm = Suppress(log)
     taken = 0
     escaped = 0
-    for i in range(ROUNDS):
+    i = 0
+    while i < ROUNDS:
         if i % 100 - 50 > 0:
             taken += 1
         else:
@@ -58,6 +69,7 @@ def two_blocks_in_a_branch():
                     raise ValueError(2)
             except ValueError:
                 escaped += 1
+        i += 1
     return taken, escaped, len(log)
 
 
@@ -65,18 +77,19 @@ def three_blocks_in_a_branch():
     log = []
     cm = Suppress(log)
     escaped = 0
-    for i in range(ROUNDS):
-        if i % 100 - 50 > 0:
-            continue
-        try:
-            with cm:
-                raise ValueError(1)
-            with cm:
-                raise ValueError(2)
-            with cm:
-                raise ValueError(3)
-        except ValueError:
-            escaped += 1
+    i = 0
+    while i < ROUNDS:
+        if i % 100 - 50 <= 0:
+            try:
+                with cm:
+                    raise ValueError(1)
+                with cm:
+                    raise ValueError(2)
+                with cm:
+                    raise ValueError(3)
+            except ValueError:
+                escaped += 1
+        i += 1
     return escaped, len(log)
 
 
@@ -84,19 +97,20 @@ def branch_arm_hands_back_to_an_outer_handler():
     """A non-suppressing `__exit__` must still reach the enclosing `except`."""
     cm = Reraise()
     caught = 0
-    for i in range(ROUNDS):
-        if i % 100 - 50 > 0:
-            continue
-        try:
-            with cm:
-                raise ValueError(1)
-        except ValueError:
-            caught += 1
-        try:
-            with cm:
-                raise ValueError(2)
-        except ValueError:
-            caught += 1
+    i = 0
+    while i < ROUNDS:
+        if i % 100 - 50 <= 0:
+            try:
+                with cm:
+                    raise ValueError(1)
+            except ValueError:
+                caught += 1
+            try:
+                with cm:
+                    raise ValueError(2)
+            except ValueError:
+                caught += 1
+        i += 1
     return caught
 
 
@@ -105,14 +119,15 @@ def one_block_in_a_branch():
     log = []
     cm = Suppress(log)
     escaped = 0
-    for i in range(ROUNDS):
-        if i % 100 - 50 > 0:
-            continue
-        try:
-            with cm:
-                raise ValueError(1)
-        except ValueError:
-            escaped += 1
+    i = 0
+    while i < ROUNDS:
+        if i % 100 - 50 <= 0:
+            try:
+                with cm:
+                    raise ValueError(1)
+            except ValueError:
+                escaped += 1
+        i += 1
     return escaped, len(log)
 
 
@@ -121,7 +136,8 @@ def two_blocks_without_a_branch():
     log = []
     cm = Suppress(log)
     escaped = 0
-    for _ in range(ROUNDS):
+    i = 0
+    while i < ROUNDS:
         try:
             with cm:
                 raise ValueError(1)
@@ -129,6 +145,7 @@ def two_blocks_without_a_branch():
                 raise ValueError(2)
         except ValueError:
             escaped += 1
+        i += 1
     return escaped, len(log)
 
 

--- a/pyre/extra_tests/snippets/charmap_decode_error_handler.py
+++ b/pyre/extra_tests/snippets/charmap_decode_error_handler.py
@@ -1,0 +1,63 @@
+# pyre-check: gate=1
+# The decode leg of `charmap_encode_error_handler`: a byte the table leaves
+# undefined goes to the registered handler, and the table itself may be an
+# object with a `__getitem__` of its own.  Both run Python from inside the
+# decode loop, which is also what makes this a pressure test for the input and
+# the table staying reachable across those calls.
+
+import codecs
+
+TABLE = {i: chr(i) for i in range(256) if i != 0xDD}
+
+assert codecs.charmap_decode(b"abc", "strict", TABLE) == ("abc", 3)
+
+# An undefined byte reaches the handler with the codec name and the span.
+seen = []
+
+def spy(exc):
+    seen.append((exc.encoding, exc.object, exc.start, exc.end, exc.reason))
+    return ("<?>", exc.end)
+
+codecs.register_error("pyre.charmap.decode.spy", spy)
+assert codecs.charmap_decode(b"a\xddb", "pyre.charmap.decode.spy", TABLE) == ("a<?>b", 3)
+assert seen == [("charmap", b"a\xddb", 1, 2, "character maps to <undefined>")], seen
+
+# The builtin names still answer.
+assert codecs.charmap_decode(b"a\xddb", "ignore", TABLE) == ("ab", 3)
+assert codecs.charmap_decode(b"a\xddb", "replace", TABLE) == ("a�b", 3)
+try:
+    codecs.charmap_decode(b"a\xddb", "strict", TABLE)
+except UnicodeDecodeError as exc:
+    assert exc.encoding == "charmap", exc.encoding
+    assert (exc.start, exc.end) == (1, 2), (exc.start, exc.end)
+else:
+    raise AssertionError("strict should have refused the undefined byte")
+
+# A table raising something of its own is not read as "undefined".
+class Raising(dict):
+    def __getitem__(self, key):
+        raise ValueError("boom")
+
+try:
+    codecs.charmap_decode(b"a", "strict", Raising())
+except ValueError as error:
+    assert str(error) == "boom", str(error)
+else:
+    raise AssertionError("the table's own error should have propagated")
+
+# Pressure: many handler calls, each allocating, over a table and an input that
+# both have to stay reachable for the whole decode.
+def churn(exc):
+    _ = [bytearray(64) for _ in range(400)]
+    return ("y" * 300, exc.end)
+
+codecs.register_error("pyre.charmap.decode.churn", churn)
+data = (b"a" * 20 + b"\xdd") * 40
+for _ in range(30):
+    decoded, consumed = codecs.charmap_decode(data, "pyre.charmap.decode.churn", TABLE)
+    assert consumed == len(data), (consumed, len(data))
+    assert decoded.count("y") == 300 * 40, decoded.count("y")
+
+# The same through the stdlib charmap codec, whose table is a real dict.
+for _ in range(30):
+    assert data.decode("iso-8859-15", "pyre.charmap.decode.churn") is not None

--- a/pyre/extra_tests/snippets/charmap_encode_error_handler.py
+++ b/pyre/extra_tests/snippets/charmap_encode_error_handler.py
@@ -1,0 +1,110 @@
+# pyre-check: gate=1
+# `charmap_encode` routes characters the table leaves undefined through the
+# error handler registered under `errors`, rather than deciding for itself.
+# A run of undefined characters is reported as one span, and a `str`
+# replacement is mapped through the table in turn -- which is why using
+# `"replace"` with a charmap requires the table to have an entry for `?`.
+
+import codecs
+
+TABLE = {ord(c): bytes(2 * c.upper(), "ascii") for c in "abcdefgh"}
+
+assert codecs.charmap_encode("abc", "strict", TABLE)[0] == b"AABBCC"
+
+# The replacement goes through the table, so it fails while `?` is unmapped
+# and succeeds once the table can encode it.
+try:
+    codecs.charmap_encode("abcDEF", "replace", TABLE)
+except UnicodeEncodeError:
+    pass
+else:
+    raise AssertionError("an unmapped '?' should have refused the replacement")
+
+TABLE[ord("?")] = b"XYZ"
+assert codecs.charmap_encode("abcDEF", "replace", TABLE)[0] == b"AABBCCXYZXYZXYZ"
+
+# A table value of the wrong type is a TypeError, not an encode error.
+TABLE[ord("?")] = "XYZ"
+try:
+    codecs.charmap_encode("abcDEF", "replace", TABLE)
+except TypeError:
+    pass
+else:
+    raise AssertionError("a str table value should have been refused")
+del TABLE[ord("?")]
+
+# The raised error carries the codec name, the whole input, and the span.
+try:
+    codecs.charmap_encode("\xff", "strict", {})
+except UnicodeEncodeError as exc:
+    assert exc.encoding == "charmap", exc.encoding
+    assert exc.object == "\xff", exc.object
+    assert (exc.start, exc.end) == (0, 1), (exc.start, exc.end)
+    assert exc.reason == "character maps to <undefined>", exc.reason
+    assert str(exc), "the error should render a message"
+else:
+    raise AssertionError("an empty table should have refused '\\xff'")
+
+# Consecutive undefined characters collapse into a single span.
+seen = []
+
+def spy(exc):
+    seen.append((exc.start, exc.end, exc.object, exc.encoding, exc.reason))
+    return ("", exc.end)
+
+codecs.register_error("pyre.charmap.spy", spy)
+assert codecs.charmap_encode("a\xff\xfe\xfdb", "pyre.charmap.spy",
+                             {ord("a"): b"A", ord("b"): b"B"}) == (b"AB", 5)
+assert seen == [(1, 4, "a\xff\xfe\xfdb", "charmap",
+                 "character maps to <undefined>")], seen
+
+try:
+    codecs.charmap_encode("\xff\xfe\xfd", "strict", {})
+except UnicodeEncodeError as exc:
+    assert (exc.start, exc.end) == (0, 3), (exc.start, exc.end)
+
+# A handler returning a result of the wrong shape is a TypeError.
+codecs.register_error("pyre.charmap.bad", lambda exc: 42)
+try:
+    "\u3042".encode("iso-8859-15", "pyre.charmap.bad")
+except TypeError:
+    pass
+else:
+    raise AssertionError("a non-tuple handler result should have been refused")
+
+# A handler whose replacement is itself unencodable reports the span that was
+# originally undefined, not the replacement's own position.
+class Rewinding:
+    def __init__(self):
+        self.count = 0
+    def __call__(self, exc):
+        if self.count > 0:
+            self.count -= 1
+            return ("\udcff", 0)
+        return ("\udcff", exc.end)
+
+rewinding = Rewinding()
+codecs.register_error("pyre.charmap.rewind", rewinding)
+rewinding.count = 5
+try:
+    "abcd\udc80".encode("iso-8859-15", "pyre.charmap.rewind")
+except UnicodeEncodeError as exc:
+    assert (exc.start, exc.end) == (4, 5), (exc.start, exc.end)
+    assert exc.object == "abcd\udc80", exc.object
+else:
+    raise AssertionError("an unencodable replacement should have raised")
+
+# `ignore` drops the run and still reports the whole input as consumed.
+assert codecs.charmap_encode("\xff", "ignore", {0xFF: None}) == (b"", 1)
+
+# A mapping raising something of its own is not read as "undefined".
+class Raising(dict):
+    def __getitem__(self, key):
+        raise ValueError("boom")
+
+try:
+    codecs.charmap_encode("\xff", "strict", Raising())
+except ValueError as error:
+    assert str(error) == "boom", str(error)
+else:
+    raise AssertionError("the mapping's own error should have propagated")

--- a/pyre/extra_tests/snippets/codecs_arbitrary_dispatch.py
+++ b/pyre/extra_tests/snippets/codecs_arbitrary_dispatch.py
@@ -1,0 +1,130 @@
+# pyre-check: gate=1
+"""`codecs.encode` / `codecs.decode` reach the registry, not the text model.
+
+`PyCodec_Encode` places no restriction on either side of the codec: it looks the
+name up without the text-encoding test and answers with whatever the registered
+coder's first result element is.  The `errors` argument is likewise not
+invented -- omitting it calls the coder with one argument.  Every `_codecs`
+entry point spells the strict handler as `None` too.
+"""
+import codecs
+
+
+def raises(exc, pattern, fn, what):
+    try:
+        fn()
+    except exc as e:
+        assert pattern in str(e), "%s: %r lacks %r" % (what, str(e), pattern)
+        return
+    except BaseException as e:  # noqa: BLE001
+        raise AssertionError("%s: raised %r, wanted %s" % (what, e, exc.__name__))
+    raise AssertionError("%s: no %s" % (what, exc.__name__))
+
+
+CALLS = []
+
+
+def make(name, encoder, decoder):
+    def search(query, _name=name, _e=encoder, _d=decoder):
+        if query == _name:
+            return codecs.CodecInfo(_e, _d, name=_name)
+        return None
+
+    codecs.register(search)
+
+
+def enc(*args, **kwds):
+    CALLS.append(("encode", len(args)))
+    return "not bytes!", 0
+
+
+def dec(*args, **kwds):
+    CALLS.append(("decode", len(args)))
+    return b"not str!", 0
+
+
+make("pyre_arbitrary", enc, dec)
+
+# The output type is not policed, and the input is passed on as it stands.
+for obj in (None, object(), "text", b"bytes", 17):
+    assert codecs.encode(obj, "pyre_arbitrary") == "not bytes!", obj
+    assert codecs.decode(obj, "pyre_arbitrary") == b"not str!", obj
+
+# An omitted `errors` is not invented; supplying one adds the argument.
+CALLS.clear()
+codecs.encode(None, "pyre_arbitrary")
+codecs.decode(None, "pyre_arbitrary")
+assert CALLS == [("encode", 1), ("decode", 1)], CALLS
+CALLS.clear()
+codecs.encode(None, "pyre_arbitrary", "replace")
+codecs.decode(None, "pyre_arbitrary", "replace")
+assert CALLS == [("encode", 2), ("decode", 2)], CALLS
+# `None` is a value, not an omission: the coder is not asked to accept it.
+raises(TypeError, "encode() argument 'errors' must be str, not None",
+       lambda: codecs.encode(None, "pyre_arbitrary", None), "errors=None")
+
+# The text model still refuses what the arbitrary path allows.
+raises(TypeError, "instead of 'bytes'", lambda: "s".encode("pyre_arbitrary"),
+       "str.encode still checks")
+raises(TypeError, "instead of 'str'", lambda: b"b".decode("pyre_arbitrary"),
+       "bytes.decode still checks")
+
+# A coder that does not answer with a 2-tuple is reported, whatever it returns.
+for i, bad in enumerate([None, ("x",), ("x", 0, 1), "ab", ["x", 0]]):
+    name = "pyre_badcoder%d" % i
+    make(name, lambda *a, _b=bad, **k: _b, dec)
+    raises(TypeError, "encoder must return a tuple (object, integer)",
+           lambda n=name: codecs.encode(None, n), "bad encoder result %r" % (bad,))
+
+make("pyre_baddecoder", enc, lambda *a, **k: None)
+raises(TypeError, "decoder must return a tuple (object,integer)",
+       lambda: codecs.decode(None, "pyre_baddecoder"), "bad decoder result")
+
+# Argument reporting.
+raises(LookupError, "unknown encoding: pyre_no_such",
+       lambda: codecs.encode(None, "pyre_no_such"), "unknown encode")
+raises(LookupError, "unknown encoding: pyre_no_such",
+       lambda: codecs.decode(None, "pyre_no_such"), "unknown decode")
+raises(TypeError, "encode() argument 'encoding' must be str, not int",
+       lambda: codecs.encode(None, 5), "encoding type")
+raises(TypeError, "decode() argument 'encoding' must be str, not int",
+       lambda: codecs.decode(None, 5), "decoding type")
+raises(TypeError, "encode() argument 'errors' must be str, not int",
+       lambda: codecs.encode(None, "pyre_arbitrary", 5), "errors type")
+
+# The ordinary codecs keep working, by keyword as well as by position.
+assert codecs.encode("abc") == b"abc"
+assert codecs.decode(b"abc") == "abc"
+assert codecs.encode("\xe4\xf6\xfc", "latin-1") == b"\xe4\xf6\xfc"
+assert codecs.decode(b"\xe4\xf6\xfc", "latin-1") == "\xe4\xf6\xfc"
+assert codecs.encode(obj="\xe4\xf6\xfc", encoding="latin-1") == b"\xe4\xf6\xfc"
+assert codecs.decode(obj=b"[\xff]", encoding="ascii", errors="ignore") == "[]"
+assert codecs.encode("[\xff]", "ascii", errors="ignore") == b"[]"
+
+# A text codec still reports a wrong-typed input itself.
+raises(TypeError, "must be str", lambda: codecs.encode(b"x", "utf-8"),
+       "bytes to a text encoder")
+
+
+# --- `errors=None` names the strict handler at every entry point ------------
+NONE_CASES = [
+    ("unicode_escape_decode", codecs.unicode_escape_decode, (b"a",), ("a", 1)),
+    ("raw_unicode_escape_decode", codecs.raw_unicode_escape_decode, (b"a",), ("a", 1)),
+    ("escape_decode", codecs.escape_decode, (b"a",), (b"a", 1)),
+    ("charmap_decode", codecs.charmap_decode, (b"a",), ("a", 1)),
+    ("utf_8_decode", codecs.utf_8_decode, (b"a",), ("a", 1)),
+    ("ascii_decode", codecs.ascii_decode, (b"a",), ("a", 1)),
+    ("latin_1_decode", codecs.latin_1_decode, (b"a",), ("a", 1)),
+    ("charmap_encode", codecs.charmap_encode, ("a",), (b"a", 1)),
+    ("ascii_encode", codecs.ascii_encode, ("a",), (b"a", 1)),
+    ("utf_8_encode", codecs.utf_8_encode, ("a",), (b"a", 1)),
+]
+for label, fn, args, want in NONE_CASES:
+    got = fn(*args, None)
+    assert got == want, "%s(errors=None): %r != %r" % (label, got, want)
+
+# A name that is neither a str nor None is still refused.
+for label, fn, args, _want in NONE_CASES:
+    raises(TypeError, "", lambda f=fn, a=args: f(*a, 5), "%s(errors=5)" % label)
+
+print("OK")

--- a/pyre/extra_tests/snippets/codecs_error_registry.py
+++ b/pyre/extra_tests/snippets/codecs_error_registry.py
@@ -1,0 +1,47 @@
+# pyre-check: gate=1
+# `_codecs._unregister_error` drops a handler `register_error` installed.
+# The eight handlers the codec loops reach by name cannot be dropped, because
+# those lookups would then have no answer.
+
+import codecs
+from _codecs import _unregister_error
+
+BUILTIN = (
+    "strict", "ignore", "replace", "xmlcharrefreplace", "backslashreplace",
+    "namereplace", "surrogateescape", "surrogatepass",
+)
+
+for name in BUILTIN:
+    try:
+        _unregister_error(name)
+    except ValueError as error:
+        assert str(error) == f"cannot un-register built-in error handler '{name}'", str(error)
+    else:
+        raise AssertionError(f"{name} was un-registered")
+    # It still answers after the refusal.
+    assert codecs.lookup_error(name) is not None
+
+def handler(exc):
+    return ("", exc.end)
+
+codecs.register_error("pyre.registry.custom", handler)
+assert codecs.lookup_error("pyre.registry.custom") is handler
+
+# Removing it reports that something was there; removing it again does not.
+assert _unregister_error("pyre.registry.custom") is True
+assert _unregister_error("pyre.registry.custom") is False
+assert _unregister_error("pyre.registry.never-registered") is False
+
+try:
+    codecs.lookup_error("pyre.registry.custom")
+except LookupError as error:
+    assert "pyre.registry.custom" in str(error), str(error)
+else:
+    raise AssertionError("the handler answered after being un-registered")
+
+try:
+    _unregister_error(1)
+except TypeError as error:
+    assert str(error) == "_unregister_error() argument must be str, not int", str(error)
+else:
+    raise AssertionError("a non-str name was accepted")

--- a/pyre/extra_tests/snippets/escape_decode_incremental.py
+++ b/pyre/extra_tests/snippets/escape_decode_incremental.py
@@ -1,0 +1,163 @@
+# pyre-check: gate=1
+"""Incremental and sentinel behaviour of the backslash-escape codecs.
+
+`unicode_escape_decode` and `raw_unicode_escape_decode` take a `final` flag.
+While it is false the caller may still supply more input, so an escape running
+off the end of the chunk is left unconsumed instead of reported; only a
+sequence the chunk already decides reaches the error handler.  `charmap_decode`
+reads U+FFFE as "undefined" however the table spells it.
+"""
+import codecs
+
+BS = chr(92)
+
+
+def check(got, want, what):
+    assert got == want, "%s: %r != %r" % (what, got, want)
+
+
+def raises(exc, fn, what):
+    try:
+        fn()
+    except exc:
+        return
+    except BaseException as e:  # noqa: BLE001
+        raise AssertionError("%s: raised %r, wanted %s" % (what, e, exc.__name__))
+    raise AssertionError("%s: no %s" % (what, exc.__name__))
+
+
+# --- unicode_escape: an escape running off the end is held back -------------
+for tail in ["", "u", "u12", "u123", "x", "x4", "U", "U000", "N", "N{", "N{GREEK"]:
+    data = (BS + tail).encode()
+    check(codecs.unicode_escape_decode(data, "strict", False), ("", 0),
+          "ue hold back %r" % data)
+    raises(UnicodeDecodeError,
+           lambda d=data: codecs.unicode_escape_decode(d, "strict", True),
+           "ue final %r" % data)
+
+# What precedes the held-back escape is still decoded and counted.
+check(codecs.unicode_escape_decode(("a" + BS + "u12").encode(), "strict", False),
+      ("a", 1), "ue prefix kept")
+check(codecs.unicode_escape_decode(("a" + BS + "u1234" + BS + "x").encode(), "strict", False),
+      ("a" + chr(0x1234), 7), "ue decoded prefix kept")
+
+# A sequence the chunk decides is reported whether or not more input follows.
+for tail in ["x4z", "xzz", "u12zz", "Nx"]:
+    data = (BS + tail).encode()
+    for is_final in (False, True):
+        raises(UnicodeDecodeError,
+               lambda d=data, f=is_final: codecs.unicode_escape_decode(d, "strict", f),
+               "ue decided %r final=%s" % (data, is_final))
+
+# A complete escape is unaffected by the flag.
+for is_final in (False, True):
+    check(codecs.unicode_escape_decode((BS + "u1234").encode(), "strict", is_final),
+          (chr(0x1234), 6), "ue complete final=%s" % is_final)
+    check(codecs.unicode_escape_decode((BS + "5").encode(), "strict", is_final),
+          (chr(5), 2), "ue octal final=%s" % is_final)
+
+# Holding back precedes the error handler, so a non-strict name changes nothing.
+for handler in ("replace", "ignore", "backslashreplace"):
+    check(codecs.unicode_escape_decode((BS + "u12").encode(), handler, False), ("", 0),
+          "ue hold back beats %s" % handler)
+
+# `final` defaults to true.
+raises(UnicodeDecodeError, lambda: codecs.unicode_escape_decode((BS + "u12").encode()),
+       "ue default final")
+
+
+# --- raw_unicode_escape: only \uXXXX and \UXXXXXXXX are escapes -------------
+for tail in ["", "u", "u1", "u12", "u123", "U", "U0001"]:
+    data = (BS + tail).encode()
+    check(codecs.raw_unicode_escape_decode(data, "strict", False), ("", 0),
+          "rue hold back %r" % data)
+
+# A lone backslash is literal once no more input can arrive.
+check(codecs.raw_unicode_escape_decode(BS.encode(), "strict", True), (BS, 1),
+      "rue lone backslash")
+# Bytes that cannot introduce an escape are literal even mid-stream.
+for tail in ["x", "z", "N{A"]:
+    data = (BS + tail).encode()
+    want = (BS + tail, len(data))
+    for is_final in (False, True):
+        check(codecs.raw_unicode_escape_decode(data, "strict", is_final), want,
+              "rue literal %r final=%s" % (data, is_final))
+
+# Four bytes that are not hex are decided, so they report.
+raises(UnicodeDecodeError,
+       lambda: codecs.raw_unicode_escape_decode((BS + "u12zz").encode(), "strict", False),
+       "rue decided")
+raises(UnicodeDecodeError,
+       lambda: codecs.raw_unicode_escape_decode((BS + "u12").encode()),
+       "rue default final")
+
+check(codecs.raw_unicode_escape_decode(("a" + BS + "u12").encode(), "strict", False),
+      ("a", 1), "rue prefix kept")
+
+# str and any buffer producer are accepted, not just bytes.
+check(codecs.raw_unicode_escape_decode(BS + "u1234"), (chr(0x1234), 6), "rue str input")
+check(codecs.raw_unicode_escape_decode(memoryview((BS + "u1234").encode())),
+      (chr(0x1234), 6), "rue memoryview input")
+check(codecs.unicode_escape_decode(memoryview((BS + "u1234").encode())),
+      (chr(0x1234), 6), "ue memoryview input")
+
+
+# --- charmap_decode: U+FFFE means undefined, as an int or as a str ----------
+a, b = ord("a"), ord("b")
+data = bytes([0, 1, 2])
+for table in ({0: a, 1: b, 2: 0xFFFE}, {0: a, 1: b, 2: chr(0xFFFE)}, {0: a, 1: b}):
+    raises(UnicodeDecodeError,
+           lambda t=table: codecs.charmap_decode(data, "strict", t),
+           "charmap undefined %r" % (table,))
+    check(codecs.charmap_decode(data, "replace", table), ("ab" + chr(0xFFFD), 3),
+          "charmap replace %r" % (table,))
+    check(codecs.charmap_decode(data, "backslashreplace", table),
+          ("ab" + BS + "x02", 3), "charmap backslashreplace %r" % (table,))
+
+# A code point outside the Unicode range is a TypeError, not an undefined byte.
+raises(TypeError,
+       lambda: codecs.charmap_decode(data, "strict", {0: 0x110000, 1: b, 2: a}),
+       "charmap out of range")
+
+
+# --- escape_encode quotes an apostrophe, not a double quote -----------------
+check(codecs.escape_encode(b"a'b" + chr(34).encode()), (b"a" + BS.encode() + b"'b" + chr(34).encode(), 4),
+      "escape_encode apostrophe")
+
+
+# --- \N{NAME} resolves through the character database ----------------------
+def esc(name):
+    return codecs.unicode_escape_decode((BS + "N{" + name + "}").encode())
+
+
+check(esc("GREEK SMALL LETTER ALPHA"), (chr(0x3B1), 28), "N named")
+check(esc("greek small letter alpha"), (chr(0x3B1), 28), "N name is case-blind")
+check(esc("NUL"), (chr(0), 7), "N alias")
+check(esc("LATIN SMALL LETTER A"), ("a", 24), "N ascii name")
+check(esc("CJK UNIFIED IDEOGRAPH-4E00"), (chr(0x4E00), 30), "N generated name")
+
+# Only a name that names ONE character resolves; a named sequence does not,
+# even though `unicodedata.lookup` answers for it.
+raises(UnicodeDecodeError, lambda: esc("KEYCAP DIGIT ZERO"), "N named sequence")
+raises(UnicodeDecodeError, lambda: esc("NOTANAME"), "N unknown name")
+
+# An empty, unterminated, or brace-less name is malformed rather than unknown,
+# and each spelling reports its own span.
+SPANS = [
+    ("N{}", "malformed", 0, 3),
+    ("N{ABC", "malformed", 0, 6),
+    ("N", "malformed", 0, 2),
+    ("Nx", "malformed", 0, 2),
+    ("N{NOTANAME}", "unknown Unicode character name", 0, 12),
+]
+for tail, reason, start, end in SPANS:
+    data = (BS + tail).encode()
+    try:
+        codecs.unicode_escape_decode(data)
+    except UnicodeDecodeError as e:
+        assert reason in e.reason, (tail, e.reason)
+        assert (e.start, e.end) == (start, end), (tail, e.start, e.end)
+    else:
+        raise AssertionError("no UnicodeDecodeError for %r" % data)
+
+print("OK")

--- a/pyre/extra_tests/snippets/invalid_escape_deprecation.py
+++ b/pyre/extra_tests/snippets/invalid_escape_deprecation.py
@@ -1,0 +1,48 @@
+# pyre-check: gate=1
+# Decoding an escape the syntax does not define reports it once, naming the
+# sequence as a literal of the type being produced.  Only the first such
+# escape in an input is reported.
+
+import codecs
+import warnings
+
+def decoded(fn):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = fn()
+    return result, [(w.category, str(w.message)) for w in caught]
+
+SUFFIX = "Such sequences will not work in the future. "
+
+for source, text, sequence, octal in (
+    (br"\z", "\\z", "z", False),
+    (br"\8", "\\8", "8", False),
+    (br"\501", "Ł", "501", True),
+    (br"\777", "ǿ", "777", True),
+):
+    kind = "an invalid octal escape sequence" if octal else "an invalid escape sequence"
+
+    result, caught = decoded(lambda s=source: s.decode("unicode-escape"))
+    assert result == text, (source, result)
+    assert len(caught) == 1, (source, caught)
+    category, message = caught[0]
+    assert category is DeprecationWarning, category
+    assert message == f'"\\{sequence}" is {kind}. {SUFFIX}', message
+
+    result, caught = decoded(lambda s=source: codecs.escape_decode(s))
+    assert len(caught) == 1, (source, caught)
+    category, message = caught[0]
+    assert category is DeprecationWarning, category
+    # The bytes transform names the sequence as a bytes literal.
+    assert message == f'b"\\{sequence}" is {kind}. {SUFFIX}', message
+
+# A defined escape says nothing, and `\377` still fits a byte.
+for source in (br"\n", br"\x41", br"\377", br"\\z"):
+    for decode in (lambda s: s.decode("unicode-escape"), codecs.escape_decode):
+        _, caught = decoded(lambda s=source, d=decode: d(s))
+        assert caught == [], (source, caught)
+
+# Only the first offending escape is reported.
+_, caught = decoded(lambda: br"\z\q\w".decode("unicode-escape"))
+assert len(caught) == 1, caught
+assert '"\\z"' in caught[0][1], caught[0][1]

--- a/pyre/extra_tests/snippets/unicode_error_position_ctor.py
+++ b/pyre/extra_tests/snippets/unicode_error_position_ctor.py
@@ -1,0 +1,75 @@
+# pyre-check: gate=1
+# The `start` / `end` arguments to a `Unicode*Error` are `Py_ssize_t`, so the
+# constructor converts them through the index protocol and stores the number.
+# `args` is untouched by that conversion and keeps what the caller passed,
+# which is the same split `object` already has: the slot holds the coerced
+# value while `args` holds the original.
+
+class MyInt(int):
+    pass
+
+class Indexable:
+    def __index__(self):
+        return 3
+
+def errors(kind, start, end=1):
+    if kind == "decode":
+        return UnicodeDecodeError("utf-8", b"xy", start, end, "r")
+    if kind == "encode":
+        return UnicodeEncodeError("utf-8", "xy", start, end, "r")
+    return UnicodeTranslateError("xy", start, end, "r")
+
+for kind in ("decode", "encode", "translate"):
+    # The stored position is a plain int whatever shape it arrived in.
+    for value, expected in ((1, 1), (True, 1), (MyInt(0), 0), (Indexable(), 3), (-5, -5)):
+        exc = errors(kind, value)
+        assert exc.start == expected, (kind, value, exc.start)
+        assert type(exc.start) is int, (kind, value, type(exc.start))
+
+    # Anything the index protocol cannot answer is refused, and names itself.
+    for value, name in (("x", "str"), (None, "NoneType"), (1.0, "float")):
+        try:
+            errors(kind, value)
+        except TypeError as error:
+            assert str(error) == f"'{name}' object cannot be interpreted as an integer", (
+                kind, value, str(error),
+            )
+        else:
+            raise AssertionError(f"{kind} accepted a {name} position")
+
+    # A value past the platform word is an OverflowError, not a stored bignum.
+    try:
+        errors(kind, 10 ** 30)
+    except OverflowError as error:
+        assert str(error) == "Python int too large to convert to C ssize_t", str(error)
+    else:
+        raise AssertionError(f"{kind} accepted an oversize position")
+
+# `args` keeps the objects the caller handed over, unconverted.
+exc = UnicodeDecodeError("utf-8", bytearray(b"xy"), True, MyInt(1), "r")
+assert exc.args == ("utf-8", bytearray(b"xy"), True, 1, "r"), exc.args
+assert [type(a).__name__ for a in exc.args] == [
+    "str", "bytearray", "bool", "MyInt", "str",
+], [type(a).__name__ for a in exc.args]
+# ... while the slots hold the converted values.
+assert type(exc.start) is int and type(exc.end) is int
+assert exc.object == b"xy" and type(exc.object) is bytes
+
+# An argument of the wrong type names that type rather than a placeholder.
+for call, message in (
+    (lambda: UnicodeDecodeError(1, b"xy", 0, 1, "r"), "argument 1 must be str, not int"),
+    (lambda: UnicodeDecodeError("utf-8", 1, 0, 1, "r"),
+     "a bytes-like object is required, not 'int'"),
+    (lambda: UnicodeDecodeError("utf-8", b"xy", 0, 1, 1), "argument 5 must be str, not int"),
+    (lambda: UnicodeEncodeError(1, "xy", 0, 1, "r"), "argument 1 must be str, not int"),
+    (lambda: UnicodeEncodeError("utf-8", 1, 0, 1, "r"), "argument 2 must be str, not int"),
+    (lambda: UnicodeEncodeError("utf-8", "xy", 0, 1, 1), "argument 5 must be str, not int"),
+    (lambda: UnicodeTranslateError(1, 0, 1, "r"), "argument 1 must be str, not int"),
+    (lambda: UnicodeTranslateError("xy", 0, 1, 1), "argument 4 must be str, not int"),
+):
+    try:
+        call()
+    except TypeError as error:
+        assert str(error) == message, (str(error), message)
+    else:
+        raise AssertionError(f"expected {message!r}")

--- a/pyre/extra_tests/snippets/unicode_error_position_setters.py
+++ b/pyre/extra_tests/snippets/unicode_error_position_setters.py
@@ -1,0 +1,60 @@
+# pyre-check: gate=1
+# `UnicodeError.start` / `.end` are `Py_T_PYSSIZET` members, so
+# `PyMember_SetOne` admits only a real `int` for a write.  `object`,
+# `encoding` and `reason` are object members and take anything, which is
+# what lets `str()` embed a stringified non-str reason.
+
+
+class MyInt(int):
+    pass
+
+
+class Indexable:
+    def __index__(self):
+        return 0
+
+
+def errors(kind):
+    if kind == "decode":
+        return UnicodeDecodeError("utf-8", b"xy", 0, 1, "r")
+    if kind == "encode":
+        return UnicodeEncodeError("utf-8", "xy", 0, 1, "r")
+    return UnicodeTranslateError("xy", 0, 1, "r")
+
+
+ACCEPTED = [1, True, MyInt(0)]
+# An `__index__` alone is not an `int`, and neither is a float.
+REFUSED = ["x", None, 1.0, Indexable()]
+
+for kind in ("decode", "encode", "translate"):
+    for attribute in ("start", "end"):
+        for value in ACCEPTED:
+            exc = errors(kind)
+            setattr(exc, attribute, value)
+            assert getattr(exc, attribute) == value, (kind, attribute, value)
+        for value in REFUSED:
+            exc = errors(kind)
+            try:
+                setattr(exc, attribute, value)
+            except TypeError as error:
+                assert str(error) == "an integer is required", (
+                    kind,
+                    attribute,
+                    value,
+                    str(error),
+                )
+            else:
+                raise AssertionError(f"{kind}.{attribute} = {value!r} was accepted")
+            # The refused write left the slot alone.
+            assert getattr(exc, attribute) == (0 if attribute == "start" else 1)
+            str(exc)
+
+    # The object members take a non-str without complaint.
+    for attribute in ("object", "reason") + (() if kind == "translate" else ("encoding",)):
+        exc = errors(kind)
+        setattr(exc, attribute, 0x345)
+        assert getattr(exc, attribute) == 0x345
+
+decoded = errors("decode")
+decoded.reason = 0x345
+assert str(decoded).endswith(": 837"), str(decoded)

--- a/pyre/extra_tests/snippets/unicode_error_position_setters.py
+++ b/pyre/extra_tests/snippets/unicode_error_position_setters.py
@@ -32,6 +32,10 @@ for kind in ("decode", "encode", "translate"):
             exc = errors(kind)
             setattr(exc, attribute, value)
             assert getattr(exc, attribute) == value, (kind, attribute, value)
+            # The slot holds the number, not the object it was written with.
+            assert type(getattr(exc, attribute)) is int, (
+                kind, attribute, value, type(getattr(exc, attribute)),
+            )
         for value in REFUSED:
             exc = errors(kind)
             try:
@@ -48,6 +52,16 @@ for kind in ("decode", "encode", "translate"):
             # The refused write left the slot alone.
             assert getattr(exc, attribute) == (0 if attribute == "start" else 1)
             str(exc)
+
+        # A value the word cannot hold is refused too, and says so differently.
+        exc = errors(kind)
+        try:
+            setattr(exc, attribute, 10 ** 30)
+        except OverflowError as error:
+            assert str(error) == "Python int too large to convert to C ssize_t", str(error)
+        else:
+            raise AssertionError(f"{kind}.{attribute} accepted an oversize value")
+        assert getattr(exc, attribute) == (0 if attribute == "start" else 1)
 
     # The object members take a non-str without complaint.
     for attribute in ("object", "reason") + (() if kind == "translate" else ("encoding",)):

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8104,6 +8104,23 @@ fn exc_unicode_encode_error(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     Ok(exc)
 }
 
+/// Convert a Unicode error bound through `__index__` and enforce the
+/// platform's `Py_ssize_t` range before storing it as a plain integer.
+pub(crate) fn unicode_error_index_w(w_value: PyObjectRef) -> Result<i64, crate::PyError> {
+    let value = space_index_w(w_value).map_err(|err| {
+        if err.kind == crate::PyErrorKind::OverflowError
+            && err.message_text() == "int too large to convert to int"
+        {
+            crate::PyError::overflow_error("Python int too large to convert to C ssize_t")
+        } else {
+            err
+        }
+    })?;
+    isize::try_from(value)
+        .map(|value| value as i64)
+        .map_err(|_| crate::PyError::overflow_error("Python int too large to convert to C ssize_t"))
+}
+
 /// `pypy/module/exceptions/interp_exceptions.py:433-445
 /// W_UnicodeTranslateError.descr_init` —
 ///
@@ -8138,24 +8155,24 @@ fn exc_unicode_translate_error_init(args: &[PyObjectRef]) -> Result<PyObjectRef,
     let w_reason = args[4];
     unsafe {
         if !crate::baseobjspace::isinstance_str_w(w_object) {
-            return Err(crate::PyError::type_error(
-                "argument 1 must be str, not other",
-            ));
+            return Err(crate::PyError::type_error(format!(
+                "argument 1 must be str, not {}",
+                crate::error::type_name_of(w_object)
+            )));
         }
-        if !crate::baseobjspace::isinstance_int_w(w_start) {
-            return Err(crate::PyError::type_error("an integer is required"));
-        }
-        if !crate::baseobjspace::isinstance_int_w(w_end) {
-            return Err(crate::PyError::type_error("an integer is required"));
-        }
+        let start = unicode_error_index_w(w_start)?;
+        let end = unicode_error_index_w(w_end)?;
         if !crate::baseobjspace::isinstance_str_w(w_reason) {
-            return Err(crate::PyError::type_error(
-                "argument 4 must be str, not other",
-            ));
+            return Err(crate::PyError::type_error(format!(
+                "argument 4 must be str, not {}",
+                crate::error::type_name_of(w_reason)
+            )));
         }
+        let w_start_value = pyre_object::w_int_new(start);
+        let w_end_value = pyre_object::w_int_new(end);
         pyre_object::interp_exceptions::w_exception_set_object(w_self, w_object);
-        pyre_object::interp_exceptions::w_exception_set_start(w_self, w_start);
-        pyre_object::interp_exceptions::w_exception_set_end(w_self, w_end);
+        pyre_object::interp_exceptions::w_exception_set_start(w_self, w_start_value);
+        pyre_object::interp_exceptions::w_exception_set_end(w_self, w_end_value);
         pyre_object::interp_exceptions::w_exception_set_reason(w_self, w_reason);
         // `W_BaseException.descr_init(self, space, [w_object, w_start,
         // w_end, w_reason])` → `self.args_w = args_w`.  The
@@ -8191,25 +8208,24 @@ fn exc_unicode_decode_error_init(args: &[PyObjectRef]) -> Result<PyObjectRef, cr
     let w_reason = args[5];
     unsafe {
         if !crate::baseobjspace::isinstance_str_w(w_encoding) {
-            return Err(crate::PyError::type_error(
-                "argument 1 must be str, not other",
-            ));
+            return Err(crate::PyError::type_error(format!(
+                "argument 1 must be str, not {}",
+                crate::error::type_name_of(w_encoding)
+            )));
         }
         if !crate::baseobjspace::isinstance_bytes_like_w(w_object_in) {
-            return Err(crate::PyError::type_error(
-                "argument 2 must be bytes-like, not other",
-            ));
+            return Err(crate::PyError::type_error(format!(
+                "a bytes-like object is required, not '{}'",
+                crate::error::type_name_of(w_object_in)
+            )));
         }
-        if !crate::baseobjspace::isinstance_int_w(w_start) {
-            return Err(crate::PyError::type_error("an integer is required"));
-        }
-        if !crate::baseobjspace::isinstance_int_w(w_end) {
-            return Err(crate::PyError::type_error("an integer is required"));
-        }
+        let start = unicode_error_index_w(w_start)?;
+        let end = unicode_error_index_w(w_end)?;
         if !crate::baseobjspace::isinstance_str_w(w_reason) {
-            return Err(crate::PyError::type_error(
-                "argument 5 must be str, not other",
-            ));
+            return Err(crate::PyError::type_error(format!(
+                "argument 5 must be str, not {}",
+                crate::error::type_name_of(w_reason)
+            )));
         }
         // `interp_exceptions.py:1043-1046` — `space.charbuf_w` /
         // `space.newbytes` coerce buffer-protocol producers
@@ -8243,10 +8259,12 @@ fn exc_unicode_decode_error_init(args: &[PyObjectRef]) -> Result<PyObjectRef, cr
             };
             pyre_object::w_bytes_from_bytes(data)
         };
+        let w_start_value = pyre_object::w_int_new(start);
+        let w_end_value = pyre_object::w_int_new(end);
         pyre_object::interp_exceptions::w_exception_set_encoding(w_self, w_encoding);
         pyre_object::interp_exceptions::w_exception_set_object(w_self, w_object);
-        pyre_object::interp_exceptions::w_exception_set_start(w_self, w_start);
-        pyre_object::interp_exceptions::w_exception_set_end(w_self, w_end);
+        pyre_object::interp_exceptions::w_exception_set_start(w_self, w_start_value);
+        pyre_object::interp_exceptions::w_exception_set_end(w_self, w_end_value);
         pyre_object::interp_exceptions::w_exception_set_reason(w_self, w_reason);
         // `interp_exceptions.py:1058-1059` — the args list passed to
         // `W_BaseException.descr_init` is the un-coerced
@@ -8284,30 +8302,31 @@ fn exc_unicode_encode_error_init(args: &[PyObjectRef]) -> Result<PyObjectRef, cr
     let w_reason = args[5];
     unsafe {
         if !crate::baseobjspace::isinstance_str_w(w_encoding) {
-            return Err(crate::PyError::type_error(
-                "argument 1 must be str, not other",
-            ));
+            return Err(crate::PyError::type_error(format!(
+                "argument 1 must be str, not {}",
+                crate::error::type_name_of(w_encoding)
+            )));
         }
         if !crate::baseobjspace::isinstance_str_w(w_object) {
-            return Err(crate::PyError::type_error(
-                "argument 2 must be str, not other",
-            ));
+            return Err(crate::PyError::type_error(format!(
+                "argument 2 must be str, not {}",
+                crate::error::type_name_of(w_object)
+            )));
         }
-        if !crate::baseobjspace::isinstance_int_w(w_start) {
-            return Err(crate::PyError::type_error("an integer is required"));
-        }
-        if !crate::baseobjspace::isinstance_int_w(w_end) {
-            return Err(crate::PyError::type_error("an integer is required"));
-        }
+        let start = unicode_error_index_w(w_start)?;
+        let end = unicode_error_index_w(w_end)?;
         if !crate::baseobjspace::isinstance_str_w(w_reason) {
-            return Err(crate::PyError::type_error(
-                "argument 5 must be str, not other",
-            ));
+            return Err(crate::PyError::type_error(format!(
+                "argument 5 must be str, not {}",
+                crate::error::type_name_of(w_reason)
+            )));
         }
+        let w_start_value = pyre_object::w_int_new(start);
+        let w_end_value = pyre_object::w_int_new(end);
         pyre_object::interp_exceptions::w_exception_set_encoding(w_self, w_encoding);
         pyre_object::interp_exceptions::w_exception_set_object(w_self, w_object);
-        pyre_object::interp_exceptions::w_exception_set_start(w_self, w_start);
-        pyre_object::interp_exceptions::w_exception_set_end(w_self, w_end);
+        pyre_object::interp_exceptions::w_exception_set_start(w_self, w_start_value);
+        pyre_object::interp_exceptions::w_exception_set_end(w_self, w_end_value);
         pyre_object::interp_exceptions::w_exception_set_reason(w_self, w_reason);
         let args_list = pyre_object::interp_exceptions::w_exception_args_new(vec![
             w_encoding, w_object, w_start, w_end, w_reason,

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4502,22 +4502,31 @@ pub(crate) fn sys_displayhook(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
 pub(crate) fn sys_excepthook(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let value = args.get(1).copied().unwrap_or_else(w_none);
     let traceback = args.get(2).copied().unwrap_or_else(w_none);
-    let mut rendered = Vec::new();
-    crate::error::write_exception_from_parts(&mut rendered, value, traceback)
-        .map_err(|_| crate::PyError::runtime_error("sys.excepthook: failed to write exception"))?;
     // Route through the live `sys.stderr`, not directly through the host
     // seam: tests and applications are allowed to replace `sys.stderr` and
     // `sys.__excepthook__` must honor that replacement.
     let stderr = crate::importing::get_sys_module("sys")
         .and_then(|sys| crate::baseobjspace::getattr_str(sys, "stderr").ok());
+    // An application that set `sys.stderr = None` disabled the stream, and
+    // `PyErr_Display` returns without printing in that case -- ahead of
+    // `_PyErr_Display`, so neither renderer runs, which is why the test sits
+    // here rather than beside the write below.  Only a missing `sys` or a
+    // failing lookup may fall through to the host seam; treating the two alike
+    // leaks the render past the configured sink.
+    if let Some(stderr) = stderr
+        && (stderr.is_null() || unsafe { pyre_object::is_none(stderr) })
+    {
+        return Ok(w_none());
+    }
+    // `_PyErr_Display` offers the exception to the stdlib renderer before
+    // reaching its own, and that renderer writes to `sys.stderr` itself.
+    if crate::error::display_through_traceback_module(value, traceback) {
+        return Ok(w_none());
+    }
+    let mut rendered = Vec::new();
+    crate::error::write_exception_from_parts(&mut rendered, value, traceback)
+        .map_err(|_| crate::PyError::runtime_error("sys.excepthook: failed to write exception"))?;
     if let Some(stderr) = stderr {
-        // An application that set `sys.stderr = None` disabled the stream, and
-        // `_PyErr_Display` returns without printing in that case.  Only a
-        // missing `sys` or a failing lookup may fall through to the host seam;
-        // treating the two alike leaks the render past the configured sink.
-        if stderr.is_null() || unsafe { pyre_object::is_none(stderr) } {
-            return Ok(w_none());
-        }
         // The render is assembled from text the printer already escaped, so it
         // is well-formed WTF-8; a decode failure would mean a byte no writer
         // put there, and the lossy read is the last resort for it.
@@ -9651,19 +9660,27 @@ fn exception_group_split_inner(
     Ok((sides[0], sides[1]))
 }
 
+/// `ceval.c _PyEval_ExceptionGroupMatch`, answering `CHECK_EG_MATCH`.
+///
+/// The third element is true exactly when `matching` is a group this call built
+/// around a non-group exception.  Such a wrapper is born here with an empty
+/// traceback and upstream gives it an entry for the frame running the opcode,
+/// which is the frame a later re-raise reports the group as passing through;
+/// only the caller holds that frame, so the decision travels out instead of the
+/// record.
 pub(crate) fn exception_group_match(
     w_exc: PyObjectRef,
     w_type: PyObjectRef,
-) -> Result<(PyObjectRef, PyObjectRef), crate::PyError> {
+) -> Result<(PyObjectRef, PyObjectRef, bool), crate::PyError> {
     let base_group = lookup_exc_class("BaseExceptionGroup").unwrap();
     if crate::eval::check_exc_match_against(w_exc, w_type) {
         if crate::baseobjspace::isinstance(w_exc, base_group)? {
-            return Ok((w_exc, pyre_object::w_none()));
+            return Ok((w_exc, pyre_object::w_none(), false));
         }
         let message = unsafe { pyre_object::w_str_new("") };
         let exceptions = pyre_object::w_tuple_new(vec![w_exc]);
         let group = exception_group_new(&[base_group, message, exceptions])?;
-        return Ok((group, pyre_object::w_none()));
+        return Ok((group, pyre_object::w_none(), true));
     }
     if crate::baseobjspace::isinstance(w_exc, base_group)? {
         // Partial match: call the (overridable) `split` method and validate it
@@ -9686,9 +9703,9 @@ pub(crate) fn exception_group_match(
         // the first two elements (match, rest) are used.
         let matching = unsafe { pyre_object::w_tuple_getitem(pair, 0) }.unwrap();
         let rest = unsafe { pyre_object::w_tuple_getitem(pair, 1) }.unwrap();
-        return Ok((matching, rest));
+        return Ok((matching, rest, false));
     }
-    Ok((pyre_object::w_none(), w_exc))
+    Ok((pyre_object::w_none(), w_exc, false))
 }
 
 fn exception_group_notes(w_exc: PyObjectRef) -> Result<Option<PyObjectRef>, crate::PyError> {
@@ -12704,12 +12721,61 @@ fn compile_err_to_syntax_error_maybe_incomplete(
     // so the byte comparison is exact.
     fn opens_triple_quote(source: &str, loc: usize) -> bool {
         let bytes = source.as_bytes();
-        bytes.get(loc).is_some_and(|quote| {
-            bytes.get(loc + 1) == Some(quote) && bytes.get(loc + 2) == Some(quote)
+        // The location names the literal, and a literal starts at its prefix:
+        // `rb"""` opens its triple quote two bytes further on than `"""` does.
+        // `tokenize.py StringPrefix` admits at most two prefix letters.
+        let start = (loc..loc + 2)
+            .take_while(|index| bytes.get(*index).is_some_and(u8::is_ascii_alphabetic))
+            .last()
+            .map_or(loc, |index| index + 1);
+        bytes.get(start).is_some_and(|quote| {
+            bytes.get(start + 1) == Some(quote) && bytes.get(start + 2) == Some(quote)
         })
     }
 
-    let incomplete = if allow_incomplete {
+    // A single-quoted string that meets a newline is over -- that is where
+    // `tok_get_normal_mode` reports `unterminated string literal` -- unless a
+    // continuation took the newline, which carries the string onto the next
+    // line. Reach the end of the source while it is still open and the
+    // tokenizer stops at `E_EOFS` instead, which is more input wanted rather
+    // than a bad program.
+    //
+    // So the string runs to the end only when every newline between its quote
+    // and the end sits behind a continuation; the text after the final newline
+    // has no newline to escape and is where the string is allowed to still be
+    // open. A backslash escapes the character after it, so it is the parity of
+    // the run ending a line that says whether that line's newline was taken.
+    // `a = 'a`, `a = 'a\` and `a = 'a\\` all reach the end still open, while
+    // `a = 'a` and `a = 'a\\` each followed by a newline meet it unescaped and
+    // are errors -- which is how `codeop._maybe_compile`, retrying every
+    // command with one newline appended, tells the two apart.
+    fn ends_open_backslash_run(segment: &str) -> bool {
+        segment.bytes().rev().take_while(|&b| b == b'\\').count() % 2 == 1
+    }
+
+    fn string_continues_to_eof(source: &str, loc: usize) -> bool {
+        source.get(loc..).is_some_and(|tail| {
+            let mut segments = tail.split('\n');
+            segments.next_back();
+            segments.all(ends_open_backslash_run)
+        })
+    }
+
+    // A source holding nothing but blank lines and comments has no statement
+    // to fail on, so the parser can only have run out of input: `eval` wants
+    // an expression and the tokenizer reaches EOF still looking for one.
+    fn holds_no_statement(source: &str) -> bool {
+        source.lines().all(|line| {
+            let line = line.trim_start();
+            line.is_empty() || line.starts_with('#')
+        })
+    }
+
+    let incomplete = if !allow_incomplete {
+        false
+    } else if holds_no_statement(source) {
+        true
+    } else {
         match &e {
             crate::compile::CompileError::Parse(error) => match &error.error {
                 ParseErrorType::Lexical(LexicalErrorType::Eof) => true,
@@ -12718,7 +12784,8 @@ fn compile_err_to_syntax_error_maybe_incomplete(
                     InterpolatedStringErrorType::UnterminatedTripleQuotedString,
                 )) => true,
                 ParseErrorType::Lexical(LexicalErrorType::UnclosedStringError) => {
-                    opens_triple_quote(source, error.raw_location.start().to_usize())
+                    let loc = error.raw_location.start().to_usize();
+                    opens_triple_quote(source, loc) || string_continues_to_eof(source, loc)
                 }
                 ParseErrorType::OtherError(message)
                     if message.starts_with("Expected an indented block after")
@@ -12747,10 +12814,40 @@ fn compile_err_to_syntax_error_maybe_incomplete(
                 // but the newline retry as this `OtherError` shape.  CPython
                 // keeps both attempts incomplete; preserve RustPython's
                 // triple-quote test across that parser-shape variation.
+                // `unterminated_string_message` writes `triple-quoted` only
+                // for a literal opened with three quotes, so the message is
+                // itself the evidence and no position has to be read: such a
+                // literal runs to the end of the source by construction, which
+                // is `E_EOFS` -- more input wanted.  `raw_location` cannot
+                // answer it anyway, being ruff's own range rather than the one
+                // the CPython-shaped override reports; for `f"""` the two sit
+                // on different offsets.
                 ParseErrorType::OtherError(message)
-                    if message.starts_with("unterminated triple-quoted string literal") =>
+                    if message.starts_with("unterminated triple-quoted ") =>
                 {
-                    opens_triple_quote(source, error.raw_location.start().to_usize())
+                    true
+                }
+                // The single-quoted spelling arrives the same way, and the
+                // generic arm below reads only whether the source ends on a
+                // newline -- which answers `a = 'a` but gets `a = 'a\` with one
+                // appended wrong, the one shape `codeop._maybe_compile` builds
+                // for every command it retries.
+                ParseErrorType::OtherError(message)
+                    if message.starts_with("unterminated string literal") =>
+                {
+                    let loc = error.raw_location.start().to_usize();
+                    opens_triple_quote(source, loc) || string_continues_to_eof(source, loc)
+                }
+                // A closing bracket with no opener, or one that does not
+                // match the opener, is wrong where it stands rather than short
+                // of input: the tokenizer reports it away from `E_EOF`, so no
+                // continuation makes it parse.  `'x' was never closed` is the
+                // opposite case and `is_unclosed_bracket` answers it above.
+                ParseErrorType::OtherError(message)
+                    if message.starts_with("unmatched ")
+                        || message.starts_with("closing parenthesis ") =>
+                {
+                    false
                 }
                 ParseErrorType::OtherError(_) => {
                     error.raw_location.end().to_usize() >= source.len() && !source.ends_with('\n')
@@ -12759,8 +12856,6 @@ fn compile_err_to_syntax_error_maybe_incomplete(
             },
             _ => false,
         }
-    } else {
-        false
     };
 
     // `syntax_error_subclass` can supply a replacement message, so it
@@ -12801,6 +12896,55 @@ fn compile_err_to_syntax_error_maybe_incomplete(
                 } else {
                     format!("invalid character '{tok}' (U+{code:04X})")
                 }
+            }
+            // The generic parse failures.  CPython's grammar reports a
+            // specific message only where an `invalid_*` rule matches and
+            // spells `invalid syntax` for everything else, so ruff's own
+            // wording for the same shapes is renamed rather than kept: two
+            // statements sharing a line (`x = 1 y = 2`, `impor math`,
+            // `asynch def f(): pass`), a statement that never started
+            // (`x := 0`), and an unmet token expectation (`del x y`,
+            // `for x im n:`).  The arms above stay ahead of these, and a later
+            // one that recognizes a shape CPython does name keeps overwriting
+            // the message the way the fstring and scope-conflict passes below
+            // already do.
+            //
+            // `traceback._find_keyword_typos` also depends on this: it offers a
+            // misspelled keyword only for a SyntaxError whose message is
+            // exactly `invalid syntax`, and a keyword typo reaches the parser
+            // as a name opening a second statement on the line.
+            ParseErrorType::SimpleStatementsOnSameLine
+            | ParseErrorType::SimpleAndCompoundStatementOnSameLine
+            | ParseErrorType::ExpectedToken { .. } => "invalid syntax".to_owned(),
+            ParseErrorType::OtherError(message) if message == "Expected a statement" => {
+                "invalid syntax".to_owned()
+            }
+            // `ast.c` reports these three through `ast_error`, lower-case and
+            // with `follows` where ruff writes `cannot follow`.
+            ParseErrorType::PositionalAfterKeywordArgument => {
+                "positional argument follows keyword argument".to_owned()
+            }
+            ParseErrorType::PositionalAfterKeywordUnpacking => {
+                "positional argument follows keyword argument unpacking".to_owned()
+            }
+            ParseErrorType::InvalidArgumentUnpackingOrder => {
+                "iterable argument unpacking follows keyword argument unpacking".to_owned()
+            }
+            // The grammar names this one where a call argument is a bare
+            // comprehension: `f(x for x in y, 1)`, `sum(x for x in y, 2)`,
+            // `foo(x, y for y in z, p)`.  A comprehension in a subscript is a
+            // different rejection and reaches a different variant, which is why
+            // renaming this one does not touch `a[x for x in y]`.
+            ParseErrorType::UnparenthesizedGeneratorExpression => {
+                "Generator expression must be parenthesized".to_owned()
+            }
+            // `tok_get_normal_mode` says what it found rather than what it
+            // wanted: a backslash is a continuation only when the newline is
+            // the next character, and anything else after it -- a space, a
+            // comment -- ends the line there.  Running out of source instead is
+            // a different rejection and keeps its own wording.
+            ParseErrorType::Lexical(LexicalErrorType::LineContinuationError) => {
+                "unexpected character after line continuation character".to_owned()
             }
             _ => e.to_string(),
         }
@@ -13000,6 +13144,48 @@ fn compile_err_to_syntax_error_maybe_incomplete(
     // is the remaining retag.
     if let Some((name, _)) = subclass {
         error.retag_exception_class(name);
+    }
+    // `pegen.c _PyPegen_set_syntax_error_metadata` hangs the parser's own view
+    // of the failure on the exception -- the start of the last statement it
+    // finished, and the whole source -- and `traceback._find_keyword_typos`
+    // re-tokenizes that slice to offer a misspelled keyword.  Only the parser
+    // records it; a codegen SyntaxError carries none, and the incomplete-input
+    // retag has returned above without one, as upstream's does.
+    //
+    // pyre always parses from a string, so the source is the one in hand.  The
+    // statement start is parser state the ruff error does not carry, and `0` is
+    // what the parser itself records until a statement finishes -- what all but
+    // two of `TestKeywordTypoSuggestions.TYPO_CASES` are given, the other two
+    // getting `1`, which the helper floors to the same slice index as `0`.
+    // Where a statement has finished the constant widens that slice rather than
+    // narrowing it, so the helper's own 1024-character ceiling turns the
+    // suggestion off earlier on a long file, and it keeps the line numbers the
+    // helper reports absolute instead of relative to the slice.
+    if parser_error {
+        // The exception is materialised and pinned before the tuple elements
+        // are built: until it is stamped it lives only in this Rust `PyError`,
+        // which the collector does not scan, so an allocation below could sweep
+        // it.  Each element is likewise pinned as it is made and reloaded at the
+        // end, the discipline `syntax_error_located` uses for the details tuple.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let exc_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(error.to_exc_object());
+        let source_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new(source));
+        let zero_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(0));
+        let zero = pyre_object::gc_roots::shadow_stack_get(zero_slot);
+        let metadata = pyre_object::w_tuple_new(vec![
+            zero,
+            zero,
+            pyre_object::gc_roots::shadow_stack_get(source_slot),
+        ]);
+        unsafe {
+            pyre_object::interp_exceptions::w_exception_set_syntax_metadata(
+                pyre_object::gc_roots::shadow_stack_get(exc_slot),
+                metadata,
+            );
+        }
     }
     error
 }
@@ -13512,6 +13698,9 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         // plain ONLY_AST runs syntax-only preprocessing; OPTIMIZED_AST
         // includes ONLY_AST and enables constant folding.
         let syntax_check_only = flags & PYCF_OPTIMIZED_AST == PYCF_ONLY_AST;
+        // Kept for the incomplete-input retry below, which the tree builder's
+        // own `opts` has been moved into by then.
+        let retry_opts = opts.clone();
         let result = if source_is_ast {
             // An already materialised AST under plain `PyCF_ONLY_AST` is
             // handed straight back, so `compile(tree, ..., PyCF_ONLY_AST) is
@@ -13539,6 +13728,33 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             )
         };
         return result.map_err(|error| {
+            // `PyCF_ALLOW_INCOMPLETE_INPUT` is a parser flag upstream
+            // (`PyPARSE_ALLOW_INCOMPLETE_INPUT`, read by `_PyPegen_run_parser`),
+            // so asking for a tree answers `_IncompleteInputError` exactly where
+            // asking for code does.  That is the request
+            // `traceback._find_keyword_typos` makes of every keyword it offers:
+            // it accepts a candidate whose source compiles *or* is incomplete,
+            // and a suite header left open by the slice it cut is the ordinary
+            // outcome -- so a plain SyntaxError here rejects every suggestion
+            // whose statement spans more than the failing line.
+            //
+            // The tree builder reports a parse failure without the structure
+            // that decision reads, so the source goes through the compiling
+            // parser to get it; that parse stops at the same failure and never
+            // reaches code generation, and it runs only for a source that has
+            // already failed under the flag -- which is `codeop` and that
+            // helper, nothing else.
+            if flags & PYCF_ALLOW_INCOMPLETE_INPUT != 0
+                && let Some(text) = source_str.as_deref()
+                && let Err(structured) =
+                    crate::compile::compile_source_with_opts(text, mode, &filename, retry_opts)
+            {
+                return replace_compile_syntax_error_filename(
+                    compile_err_to_syntax_error_maybe_incomplete(structured, text, true),
+                    &filename,
+                    filename_bytes.as_deref(),
+                );
+            }
             replace_compile_syntax_error_filename(error, &filename, filename_bytes.as_deref())
         });
     }

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -4644,7 +4644,14 @@ pub fn build_class_body_namespace_is_module_dict(args: &[PyObjectRef]) -> bool {
                     .is_some_and(pyre_object::kw_marker::is_kw_marker_sentinel)
             };
         if is_kwds {
-            if unsafe { pyre_object::w_dict_getitem_str(last, "metaclass") }.is_some() {
+            // An explicit `metaclass=type` still reaches `descr___prepare__`,
+            // which answers `newdict(module=True)`, so the body runs in a
+            // module dict exactly as the implicit winner does.  Any other
+            // metaclass may define its own `__prepare__` and is undecidable
+            // from here.  The base test below keeps the winner `type`.
+            if let Some(metaclass) = unsafe { pyre_object::w_dict_getitem_str(last, "metaclass") }
+                && !std::ptr::eq(metaclass, crate::typedef::w_type())
+            {
                 return false;
             }
             base_args = &base_args[..base_args.len() - 1];

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -2390,6 +2390,72 @@ pub fn write_exception<W: Write>(
     writer.write_all(b"\n")
 }
 
+/// `pythonrun.c _PyErr_Display`'s first attempt, which runs before the printer
+/// [`write_exception_from_parts`] is.  The stdlib renderer is where a report
+/// gains what only Python-level code produces: `_find_keyword_typos` rewrites a
+/// bare `invalid syntax` into one naming the keyword the author meant, reading
+/// the `_metadata` the parser hangs on the exception, and nothing in this file
+/// offers that.
+///
+/// `false` says the module was not reachable, the attribute was absent or not
+/// callable, or the call raised -- upstream's `fallback:` label, where the
+/// pending failure is dropped and the caller prints the exception itself.  A
+/// shutdown that has already taken `traceback` apart arrives as that same
+/// `false`, which is what keeps a late report printable at all.
+///
+/// The traceback is installed on the exception first because that is the only
+/// place the stdlib renderer looks for it; [`write_exception_from_parts`]
+/// performs the same install, and doing it twice writes the slot once.
+pub fn display_through_traceback_module(exc_value: PyObjectRef, exc_tb: PyObjectRef) -> bool {
+    if exc_value.is_null() || !unsafe { pyre_object::is_exception(exc_value) } {
+        return false;
+    }
+    let _roots = pyre_object::gc_roots::push_roots();
+    let exc_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(exc_value);
+    if !exc_tb.is_null()
+        && !unsafe { pyre_object::is_none(exc_tb) }
+        && unsafe { crate::pytraceback::is_pytraceback(exc_tb) }
+        && unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc_value).is_null() }
+    {
+        unsafe {
+            pyre_object::interp_exceptions::w_exception_set_traceback(exc_value, exc_tb);
+        }
+    }
+    let ec = crate::call::getexecutioncontext();
+    let Ok(module) = crate::importing::importhook(
+        "traceback",
+        pyre_object::PY_NULL,
+        pyre_object::PY_NULL,
+        0,
+        ec,
+    ) else {
+        return false;
+    };
+    let module_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(module);
+    let Ok(printer) = crate::baseobjspace::getattr_str(
+        pyre_object::gc_roots::shadow_stack_get(module_slot),
+        "_print_exception_bltin",
+    ) else {
+        return false;
+    };
+    if printer.is_null() || !crate::baseobjspace::callable_w(printer) {
+        return false;
+    }
+    let printer_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(printer);
+    let result = crate::baseobjspace::call_function(
+        pyre_object::gc_roots::shadow_stack_get(printer_slot),
+        &[pyre_object::gc_roots::shadow_stack_get(exc_slot)],
+    );
+    if result.is_null() {
+        let _ = crate::call::take_call_error();
+        return false;
+    }
+    true
+}
+
 /// CPython 3.14 `_PyErr_Display(file, exc_type, exc_value, exc_tb)` shape used
 /// by `_thread._excepthook`.
 ///
@@ -3141,23 +3207,31 @@ fn suggestion_distance(a: &str, b: &str, max_cost: usize) -> usize {
 }
 
 pub(crate) fn best_suggestion(candidates: &[String], wrong_name: &str) -> Option<String> {
-    if candidates.len() > MAX_SUGGESTION_CANDIDATES
-        || wrong_name.chars().count() > MAX_SUGGESTION_STRING_SIZE
-    {
+    if candidates.len() >= MAX_SUGGESTION_CANDIDATES {
         return None;
     }
     let wrong_len = wrong_name.chars().count();
-    let mut best_distance = wrong_len;
+    // No candidate has been measured yet, so nothing caps the first one but
+    // its own ratio test below.  A name longer than `MAX_SUGGESTION_STRING_SIZE`
+    // is not rejected here: `suggestion_distance` applies that limit to what is
+    // left after the common affixes are trimmed, so a long name still matches a
+    // candidate it mostly shares.
+    let mut best_distance = usize::MAX;
     let mut suggestion = None;
     for candidate in candidates {
         if candidate == wrong_name {
             continue;
         }
         let candidate_len = candidate.chars().count();
+        // No more than 1/3 of the involved characters should need changed.
         let mut max_distance = (candidate_len + wrong_len + 3) * SUGGESTION_MOVE_COST / 6;
-        max_distance = max_distance.min(best_distance);
+        // Don't take matches we've already beaten.
+        max_distance = max_distance.min(best_distance.saturating_sub(1));
         let distance = suggestion_distance(wrong_name, candidate, max_distance);
-        if distance <= max_distance && (suggestion.is_none() || distance < best_distance) {
+        if distance > max_distance {
+            continue;
+        }
+        if suggestion.is_none() || distance < best_distance {
             suggestion = Some(candidate.clone());
             best_distance = distance;
         }
@@ -3838,6 +3912,76 @@ pub(crate) fn emit_report_to_host_stderr(buf: &[u8]) {
             crate::host_seam::emit_stderr(text.as_bytes());
         }
     }
+}
+
+/// `pythonrun.c _PyErr_Print` for a caller holding the exception rather than
+/// the thread's indicator: every top-level run reports through `sys.excepthook`,
+/// so an application's own hook is what reports the failure it was installed
+/// for, and the default hook is what carries the report to the stdlib renderer
+/// -- which is where a `SyntaxError` gains the misspelled-keyword suggestion
+/// that no printer in this file produces.
+///
+/// `false` says there was no hook to reach, which is `_PyErr_PrintEx`'s
+/// `sys.excepthook is missing` arm, and the caller prints the exception itself.
+/// A hook that runs and fails has still reported: its own failure is named as
+/// unraisable, exactly as upstream does, and this answers `true` rather than
+/// printing the exception a second time.
+pub fn print_exception_via_excepthook(err: &mut PyError) -> bool {
+    let Some(sys) = crate::importing::get_sys_module("sys") else {
+        return false;
+    };
+    // A missing name is a hook that is not there; `None` is a hook that is,
+    // and calling it is what reports it.
+    let Ok(hook) = crate::baseobjspace::getattr_str(sys, "excepthook") else {
+        return false;
+    };
+    if hook.is_null() {
+        return false;
+    }
+    let _roots = pyre_object::gc_roots::push_roots();
+    let hook_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(hook);
+    // Materialising the instance is what gives the hook something to report;
+    // the `PyError`'s own fields are raw and this collector does not scan them,
+    // so each of the three arguments is pinned as it is taken.
+    let exc = err.to_exc_object();
+    if exc.is_null() {
+        return false;
+    }
+    let exc_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(exc);
+    let w_type = crate::baseobjspace::exception_getclass(exc);
+    let type_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(if w_type.is_null() {
+        pyre_object::w_none()
+    } else {
+        w_type
+    });
+    let w_tb = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc) };
+    unsafe { crate::pytraceback::mark_traceback_escaped(w_tb) };
+    let tb_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(if w_tb.is_null() {
+        pyre_object::w_none()
+    } else {
+        w_tb
+    });
+    let arguments = [
+        pyre_object::gc_roots::shadow_stack_get(type_slot),
+        pyre_object::gc_roots::shadow_stack_get(exc_slot),
+        pyre_object::gc_roots::shadow_stack_get(tb_slot),
+    ];
+    let reported = crate::call::call_function_impl_result(
+        pyre_object::gc_roots::shadow_stack_get(hook_slot),
+        &arguments,
+    );
+    if let Err(mut failure) = reported {
+        failure.write_unraisable(
+            pyre_object::w_none(),
+            rustpython_wtf8::Wtf8::new("Exception ignored in sys.excepthook"),
+            pyre_object::gc_roots::shadow_stack_get(hook_slot),
+        );
+    }
+    true
 }
 
 pub fn eprint_exception(err: &PyError, include_traceback: bool) {

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -2410,6 +2410,15 @@ pub fn display_through_traceback_module(exc_value: PyObjectRef, exc_tb: PyObject
     if exc_value.is_null() || !unsafe { pyre_object::is_exception(exc_value) } {
         return false;
     }
+    // A bounded heap has one `MemoryError` to give and aborts on the breach
+    // after it.  Reaching the stdlib renderer imports `traceback`, whose module
+    // body is a nested dispatch loop whose first safepoint collects over a heap
+    // already at its limit -- so the report this route exists to write is
+    // exactly what that abort takes away.  Declining leaves the built-in
+    // renderer below, which reaches stderr without running a module body.
+    if majit_gc::gc_max_heap_already_raised() {
+        return false;
+    }
     let _roots = pyre_object::gc_roots::push_roots();
     let exc_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(exc_value);

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -4412,8 +4412,8 @@ impl OpcodeStepExecutor for PyFrame {
         validate_check_eg_match_class(exc_type)?;
         let exc_value = self.pop();
         let anchor = FrameAnchor::new(self);
-        let (matching, rest) = if unsafe { pyre_object::is_none(exc_value) } {
-            (pyre_object::w_none(), pyre_object::w_none())
+        let (matching, rest, wrapped_naked) = if unsafe { pyre_object::is_none(exc_value) } {
+            (pyre_object::w_none(), pyre_object::w_none(), false)
         } else {
             crate::builtins::exception_group_match(exc_value, exc_type)?
         };
@@ -4421,6 +4421,22 @@ impl OpcodeStepExecutor for PyFrame {
         Self::push_anchored(&anchor, matching)?;
         if !unsafe { pyre_object::is_none(matching) } {
             set_current_exception(matching);
+        }
+        if wrapped_naked {
+            // The wrapper this opcode just built has an empty traceback, and the
+            // exception inside it keeps its own chain, so nothing else ever names
+            // this frame on the group.  A group re-raised out of the `except*`
+            // clause reports only the frames it passes through afterwards without
+            // the entry made here.  Both values are on the value stack already,
+            // so the node allocation cannot collect them.
+            let frame = unsafe { &mut *anchor.live() };
+            unsafe {
+                crate::pytraceback::record_application_traceback(
+                    matching,
+                    frame as *mut PyFrame,
+                    frame.last_instr as i64,
+                );
+            }
         }
         Ok(())
     }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -655,6 +655,7 @@ pub fn install_builtin_modules() {
     pyre_install_module!(_collections);
     pyre_install_module!(_ast);
     pyre_install_module!(_opcode);
+    pyre_install_module!(_suggestions);
     pyre_install_module!("_imp"(imp));
 
     // importlib package and its submodules load their real source from disk:

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -10,6 +10,45 @@ use std::sync::atomic::{AtomicPtr, Ordering};
 use pyre_object::*;
 use rustpython_wtf8::{CodePoint, Wtf8Buf};
 
+/// `_PyArg_BadArgument` — how a clinic-converted argument is reported.  A
+/// one-argument function names no position; `None` names itself where every
+/// other value names its type.
+fn bad_arg(fname: &str, pos: Option<usize>, want: &str, w_obj: PyObjectRef) -> crate::PyError {
+    let at = match pos {
+        Some(n) => format!(" {n}"),
+        None => String::new(),
+    };
+    crate::PyError::type_error(format!(
+        "{fname}() argument{at} must be {want}, not {}",
+        crate::type_methods::clinic_arg_type_name(w_obj)
+    ))
+}
+
+/// The `Py_buffer` converter's own wording, which names neither the function
+/// nor the position and quotes the type it was handed.
+fn bad_buffer_arg(w_obj: PyObjectRef) -> crate::PyError {
+    crate::PyError::type_error(format!(
+        "a bytes-like object is required, not '{}'",
+        crate::type_methods::arg_type_name(w_obj)
+    ))
+}
+
+/// `str(accept={str, NoneType})` — a codec's handler name, which `None`
+/// spells as `strict`.
+fn codec_errors_arg(
+    fname: &str,
+    pos: usize,
+    w_errors: PyObjectRef,
+) -> Result<String, crate::PyError> {
+    if unsafe { pyre_object::is_none(w_errors) } {
+        Ok("strict".to_string())
+    } else if unsafe { is_str(w_errors) } {
+        Ok(crate::baseobjspace::str_utf8_w(w_errors)?.to_string())
+    } else {
+        Err(bad_arg(fname, Some(pos), "str or None", w_errors))
+    }
+}
+
 struct CodecState {
     codec_search_path: PyObjectRef,
     codec_search_cache: PyObjectRef,
@@ -474,7 +513,7 @@ pub(crate) fn validate_error_handler(errors: &str) -> Result<(), crate::PyError>
     } else {
         Err(crate::PyError::new(
             crate::PyErrorKind::LookupError,
-            format!("unknown error handler name {errors}"),
+            format!("unknown error handler name '{errors}'"),
         ))
     }
 }
@@ -492,9 +531,7 @@ fn lookup_error(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         ));
     };
     if !unsafe { is_str(w_errors) } {
-        return Err(crate::PyError::type_error(
-            "lookup_error() argument must be str",
-        ));
+        return Err(bad_arg("lookup_error", None, "str", w_errors));
     }
     let errors = crate::baseobjspace::str_utf8_w(w_errors)?;
     if let Some(w_handler) = with_codec_state(|state| unsafe {
@@ -504,7 +541,7 @@ fn lookup_error(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
     Err(crate::PyError::new(
         crate::PyErrorKind::LookupError,
-        format!("unknown error handler name {errors}"),
+        format!("unknown error handler name '{errors}'"),
     ))
 }
 
@@ -515,9 +552,7 @@ fn register_error(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         ));
     };
     if !unsafe { is_str(w_errors) } {
-        return Err(crate::PyError::type_error(
-            "register_error() argument 1 must be str",
-        ));
+        return Err(bad_arg("register_error", Some(1), "str", w_errors));
     }
     if !is_callable(w_handler) {
         return Err(crate::PyError::type_error("argument must be callable"));
@@ -531,6 +566,43 @@ fn register_error(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         );
     });
     Ok(w_none())
+}
+
+/// `_codecs__unregister_error` — drop a handler previously installed by
+/// `register_error`.  Returns whether a handler of that name was registered,
+/// so removing an unknown name is not an error.  The eight handlers installed
+/// by [`register_builtin_error_handlers`] are refused: the codec loops reach
+/// them by name, so un-registering one would leave those lookups unanswerable.
+fn unregister_error(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let Some(w_errors) = args.first().copied() else {
+        return Err(crate::PyError::type_error(
+            "_unregister_error() missing argument",
+        ));
+    };
+    if !unsafe { is_str(w_errors) } {
+        return Err(bad_arg("_unregister_error", None, "str", w_errors));
+    }
+    let errors = crate::baseobjspace::str_utf8_w(w_errors)?;
+    if matches!(
+        errors,
+        "strict"
+            | "ignore"
+            | "replace"
+            | "xmlcharrefreplace"
+            | "backslashreplace"
+            | "surrogateescape"
+            | "surrogatepass"
+            | "namereplace"
+    ) {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::ValueError,
+            format!("cannot un-register built-in error handler '{errors}'"),
+        ));
+    }
+    let removed = with_codec_state(|state| unsafe {
+        pyre_object::dictmultiobject::w_dict_delitem_str(state.codec_error_registry, errors)
+    });
+    Ok(w_bool_from(removed))
 }
 
 fn register_codec(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -588,7 +660,7 @@ fn lookup_codec(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         return Err(crate::PyError::type_error("lookup() missing encoding"));
     };
     if !unsafe { is_str(w_encoding) } {
-        return Err(crate::PyError::type_error("lookup() argument must be str"));
+        return Err(bad_arg("lookup", None, "str", w_encoding));
     }
     let encoding = crate::baseobjspace::str_utf8_w(w_encoding)?.to_string();
     // PyPy's `space.text0_w` gateway rejects this before normalization.  A
@@ -698,16 +770,73 @@ fn call_codec(
         }
     };
     if !unsafe { pyre_object::is_tuple(w_res) } || unsafe { pyre_object::w_tuple_len(w_res) } != 2 {
+        // The two messages are spelled differently upstream -- the decoder's
+        // has no space after the comma -- and the difference is observable.
         let msg = if action.starts_with("en") {
             "encoder must return a tuple (object, integer)".to_string()
         } else if action.starts_with("de") {
-            "decoder must return a tuple (object, integer)".to_string()
+            "decoder must return a tuple (object,integer)".to_string()
         } else {
             format!("{action} must return a tuple (object, integer)")
         };
         return Err(crate::PyError::type_error(msg));
     }
     Ok(unsafe { pyre_object::w_tuple_getitem(w_res, 0).unwrap_or_else(w_none) })
+}
+
+/// `PyCodec_Encode` / `PyCodec_Decode` — the arbitrary-object entry points.
+///
+/// Unlike `str.encode` / `bytes.decode` these place no restriction on either
+/// side: the codec is looked up without the text-encoding test and its coder is
+/// handed the object as it stands, so a codec answering with something other
+/// than `bytes` (or `str`) is answered with, rather than reported.  An `errors`
+/// argument that was not supplied is not invented either -- the coder is called
+/// with one argument, which is what lets a coder taking only the object work.
+fn codec_encode_or_decode(
+    w_obj: PyObjectRef,
+    w_encoding: PyObjectRef,
+    w_errors: Option<PyObjectRef>,
+    encode: bool,
+) -> Result<PyObjectRef, crate::PyError> {
+    let name = if encode { "encode" } else { "decode" };
+    if !unsafe { is_str(w_encoding) } {
+        return Err(crate::PyError::type_error(format!(
+            "{name}() argument 'encoding' must be str, not {}",
+            crate::type_methods::clinic_arg_type_name(w_encoding)
+        )));
+    }
+    // Only an omitted argument is absent: `None` is a value the coder is not
+    // asked to accept, so it is refused the way any other non-`str` is.
+    let errors = match w_errors {
+        None => None,
+        Some(w_errors) if unsafe { is_str(w_errors) } => {
+            Some(crate::baseobjspace::str_utf8_w(w_errors)?.to_string())
+        }
+        Some(w_errors) => {
+            return Err(crate::PyError::type_error(format!(
+                "{name}() argument 'errors' must be str, not {}",
+                crate::type_methods::clinic_arg_type_name(w_errors)
+            )));
+        }
+    };
+    // The lookup runs Python -- an uncached name imports its `encodings`
+    // module and calls every registered search function -- so the object
+    // outlives it on the shadow stack rather than in a plain local.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_obj);
+    let encoding = crate::baseobjspace::str_utf8_w(w_encoding)?.to_string();
+    let w_codec_info = lookup_codec(&[w_str_new(&encoding)])?;
+    let w_coder = unsafe {
+        pyre_object::w_tuple_getitem(w_codec_info, i64::from(!encode)).unwrap_or_else(w_none)
+    };
+    call_codec(
+        w_coder,
+        pyre_object::gc_roots::shadow_stack_get(sp),
+        if encode { "encoding" } else { "decoding" },
+        &encoding,
+        errors.as_deref(),
+    )
 }
 
 pub(crate) fn encode_text_codec(
@@ -784,16 +913,20 @@ fn forget_codec(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 fn encode_with_name(
     w_obj: PyObjectRef,
     errors: PyObjectRef,
+    fname: &str,
     encoding: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
     if !unsafe { is_str(w_obj) } {
-        return Err(crate::PyError::type_error("encoder argument must be str"));
+        return Err(bad_arg(fname, Some(1), "str", w_obj));
     }
+    let errors = codec_errors_arg(fname, 2, errors)?;
     // PyPy `make_encoder_wrapper`: convert to unicode, call unicodehelper
     // encoder, return `(bytes, unicode_length)`.
     let encode_method = crate::baseobjspace::getattr_str(w_obj, "encode")?;
-    let encoded =
-        crate::call::call_function_impl_result(encode_method, &[w_str_new(encoding), errors])?;
+    let encoded = crate::call::call_function_impl_result(
+        encode_method,
+        &[w_str_new(encoding), w_str_new(&errors)],
+    )?;
     Ok(w_tuple_new(vec![
         encoded,
         w_int_new(unsafe { pyre_object::w_str_len(w_obj) } as i64),
@@ -803,19 +936,21 @@ fn encode_with_name(
 fn decode_with_name(
     w_obj: PyObjectRef,
     errors: PyObjectRef,
+    fname: &str,
     encoding: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
     if !unsafe { pyre_object::bytesobject::is_bytes_like(w_obj) } {
-        return Err(crate::PyError::type_error(
-            "decoder argument must be bytes-like",
-        ));
+        return Err(bad_buffer_arg(w_obj));
     }
+    let errors = codec_errors_arg(fname, 2, errors)?;
     // PyPy `make_decoder_wrapper`: decode a bytes buffer and return
     // `(unicode, bytes_consumed)`.
     let consumed = unsafe { pyre_object::bytesobject::bytes_like_data(w_obj).len() };
     let decode_method = crate::baseobjspace::getattr_str(w_obj, "decode")?;
-    let decoded =
-        crate::call::call_function_impl_result(decode_method, &[w_str_new(encoding), errors])?;
+    let decoded = crate::call::call_function_impl_result(
+        decode_method,
+        &[w_str_new(encoding), w_str_new(&errors)],
+    )?;
     Ok(w_tuple_new(vec![decoded, w_int_new(consumed as i64)]))
 }
 
@@ -823,12 +958,7 @@ fn decode_with_name(
 /// TypeError (rather than the file-write helper's own wording) when the object
 /// is not a bytes-like buffer.
 fn decode_input_bytes(w_obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
-    unsafe { crate::builtins::file_write_buffer_bytes(w_obj) }.map_err(|_| {
-        crate::PyError::type_error(format!(
-            "a bytes-like object is required, not '{}'",
-            crate::type_methods::arg_type_name(w_obj)
-        ))
-    })
+    unsafe { crate::builtins::file_write_buffer_bytes(w_obj) }.map_err(|_| bad_buffer_arg(w_obj))
 }
 
 /// PyPy `interp_codecs.utf_{16,32}_ex_decode`: the three-value entry point
@@ -840,15 +970,10 @@ fn utf16_32_ex_decode_impl(
     byteorder: i64,
     w_final: PyObjectRef,
     is32: bool,
+    fname: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let errors = if unsafe { pyre_object::is_none(errors) } {
-        "strict"
-    } else if unsafe { is_str(errors) } {
-        crate::baseobjspace::str_utf8_w(errors)?
-    } else {
-        return Err(crate::PyError::type_error("errors must be str or None"));
-    };
     let data = decode_input_bytes(w_obj)?;
+    let errors = codec_errors_arg(fname, 2, errors)?;
     let fixed_be = match byteorder {
         0 => None,
         -1 => Some(false),
@@ -860,7 +985,7 @@ fn utf16_32_ex_decode_impl(
         is32,
         fixed_be,
         codec,
-        errors,
+        &errors,
         crate::baseobjspace::is_true(w_final)?,
     )?;
     Ok(w_tuple_new(vec![
@@ -880,21 +1005,16 @@ fn utf16_32_decode_impl(
     is32: bool,
     fixed_be: Option<bool>,
     codec: &str,
+    fname: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let errors = if unsafe { pyre_object::is_none(errors) } {
-        "strict"
-    } else if unsafe { is_str(errors) } {
-        crate::baseobjspace::str_utf8_w(errors)?
-    } else {
-        return Err(crate::PyError::type_error("errors must be str or None"));
-    };
     let data = decode_input_bytes(w_obj)?;
+    let errors = codec_errors_arg(fname, 2, errors)?;
     let (decoded, consumed, _) = crate::type_methods::decode_utf16_32_helper(
         &data,
         is32,
         fixed_be,
         codec,
-        errors,
+        &errors,
         crate::baseobjspace::is_true(w_final)?,
     )?;
     Ok(w_tuple_new(vec![
@@ -911,20 +1031,14 @@ fn utf8_decode_impl(
     errors: PyObjectRef,
     w_final: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let errors = if unsafe { pyre_object::is_none(errors) } {
-        "strict"
-    } else if unsafe { is_str(errors) } {
-        crate::baseobjspace::str_utf8_w(errors)?
-    } else {
-        return Err(crate::PyError::type_error("errors must be str or None"));
-    };
     let data = decode_input_bytes(w_obj)?;
+    let errors = codec_errors_arg("utf_8_decode", 2, errors)?;
     // `interp_codecs.utf_8_decode`: `surrogatepass` is the one handler that
     // decodes a complete ED A0..BF 80..BF sequence in the state machine and
     // retains an incomplete one for the next chunk.
     let (decoded, consumed) = crate::typedef::decode_utf8_with_errors_incremental(
         &data,
-        errors,
+        &errors,
         crate::baseobjspace::is_true(w_final)?,
         errors == "surrogatepass",
     )?;
@@ -934,81 +1048,211 @@ fn utf8_decode_impl(
     ]))
 }
 
+/// `charmapencode_lookup` — map one code point through the encoding table and
+/// append its bytes to `out`.
+///
+/// Answers `false` for a character the table leaves undefined, which a missing
+/// key and an explicit `None` value both express; the caller turns a run of
+/// those into one error span.  A mapping that raises anything other than
+/// `LookupError` / `KeyError` propagates, so a `__getitem__` of its own is not
+/// mistaken for "undefined".
+fn charmap_output(
+    w_mapping: PyObjectRef,
+    cp: u32,
+    out: &mut Vec<u8>,
+) -> Result<bool, crate::PyError> {
+    if unsafe { is_str(w_mapping) } && cp as usize >= unsafe { w_str_len(w_mapping) } {
+        return Ok(false);
+    }
+    // Minting the key can collect, and a table read can run a `__getitem__` of
+    // its own, so the table is pinned and re-read rather than carried across
+    // either in a plain local.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_mapping);
+    let w_key = pyre_object::gc_roots::pin_root(w_int_new(cp as i64));
+    let w_mapping = pyre_object::gc_roots::shadow_stack_get(sp);
+    let w_ch = match crate::baseobjspace::getitem(w_mapping, w_key) {
+        Ok(w_ch) => w_ch,
+        Err(e)
+            if matches!(
+                e.kind,
+                crate::PyErrorKind::LookupError | crate::PyErrorKind::KeyError
+            ) =>
+        {
+            return Ok(false);
+        }
+        Err(e) => return Err(e),
+    };
+    if unsafe { pyre_object::bytesobject::is_bytes_like(w_ch) } {
+        out.extend_from_slice(unsafe { pyre_object::bytesobject::bytes_like_data(w_ch) });
+        Ok(true)
+    } else if unsafe { pyre_object::is_int(w_ch) } {
+        let x = unsafe { pyre_object::w_int_get_value(w_ch) };
+        if !(0..256).contains(&x) {
+            return Err(crate::PyError::type_error(
+                "character mapping must be in range(256)",
+            ));
+        }
+        out.push(x as u8);
+        Ok(true)
+    } else if unsafe { pyre_object::is_none(w_ch) } {
+        Ok(false)
+    } else {
+        Err(crate::PyError::type_error(
+            "character mapping must return integer, bytes or None, not str",
+        ))
+    }
+}
+
+/// `utf8_encode_charmap` — encode through a code-point-to-bytes table.
+///
+/// Characters the table leaves undefined are gathered into one run and handed
+/// to the error handler registered under `errors`, so a handler sees a single
+/// span rather than one call per character.  A `str` replacement is mapped
+/// through the table in turn — that is what lets `"replace"` emit whatever the
+/// table gives for `?` — and a replacement the table cannot encode reports the
+/// span that was originally undefined, not the replacement's own position.
 fn charmap_encode_impl(
     w_unicode: PyObjectRef,
     errors: PyObjectRef,
     w_mapping: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
     if unsafe { pyre_object::is_none(w_mapping) } {
-        return encode_with_name(w_unicode, errors, "latin-1");
+        return encode_with_name(w_unicode, errors, "charmap_encode", "latin-1");
     }
     if !unsafe { is_str(w_unicode) } {
-        return Err(crate::PyError::type_error(
-            "charmap_encode() argument must be str",
-        ));
+        return Err(bad_arg("charmap_encode", Some(1), "str", w_unicode));
     }
-    let errors_s = if unsafe { is_str(errors) } {
-        crate::baseobjspace::str_utf8_w(errors)?
-    } else {
-        "strict"
-    };
+    // The loop below runs a Python error handler, which can move the string
+    // the name was read out of, so the name is owned rather than viewed.
+    let errors_s = codec_errors_arg("charmap_encode", 2, errors)?;
+    let cps: Vec<u32> = unsafe { w_str_get_wtf8(w_unicode) }
+        .code_points()
+        .map(|cp| cp.to_u32())
+        .collect();
+    let char_len = cps.len();
     let mut out = Vec::new();
-    for cp in unsafe { w_str_get_wtf8(w_unicode) }.code_points() {
-        let w_ch = match crate::baseobjspace::getitem(w_mapping, w_int_new(cp.to_u32() as i64)) {
-            Ok(w_ch) => w_ch,
-            Err(e)
-                if matches!(
-                    e.kind,
-                    crate::PyErrorKind::LookupError | crate::PyErrorKind::KeyError
-                ) =>
-            {
-                match errors_s {
-                    "ignore" => continue,
-                    "replace" => {
-                        out.push(b'?');
-                        continue;
-                    }
-                    _ => {
-                        return Err(crate::PyError::new(
-                            crate::PyErrorKind::UnicodeEncodeError,
-                            "character maps to <undefined>",
-                        ));
-                    }
-                }
+    // The code points are copied out above, so only the two objects have to
+    // survive the collections a table read or a handler call can trigger.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_unicode);
+    let _ = pyre_object::gc_roots::pin_root(w_mapping);
+    let mut i = 0usize;
+    while i < char_len {
+        if charmap_output(
+            pyre_object::gc_roots::shadow_stack_get(sp + 1),
+            cps[i],
+            &mut out,
+        )? {
+            i += 1;
+            continue;
+        }
+
+        let start = i;
+        let mut end = i + 1;
+        let mut probe = Vec::new();
+        while end < char_len {
+            probe.clear();
+            if charmap_output(
+                pyre_object::gc_roots::shadow_stack_get(sp + 1),
+                cps[end],
+                &mut probe,
+            )? {
+                break;
             }
-            Err(e) => return Err(e),
-        };
-        if unsafe { pyre_object::bytesobject::is_bytes_like(w_ch) } {
-            out.extend_from_slice(unsafe { pyre_object::bytesobject::bytes_like_data(w_ch) });
-        } else if unsafe { pyre_object::is_int(w_ch) } {
-            let x = unsafe { pyre_object::w_int_get_value(w_ch) };
-            if !(0..256).contains(&x) {
-                return Err(crate::PyError::type_error(
-                    "character mapping must be in range(256)",
+            end += 1;
+        }
+
+        match errors_s.as_str() {
+            "strict" => {
+                return Err(crate::typedef::unicode_encode_error(
+                    "charmap",
+                    pyre_object::gc_roots::shadow_stack_get(sp),
+                    start,
+                    end,
+                    "character maps to <undefined>",
                 ));
             }
-            out.push(x as u8);
-        } else if unsafe { pyre_object::is_none(w_ch) } {
-            match errors_s {
-                "ignore" => {}
-                "replace" => out.push(b'?'),
-                _ => {
-                    return Err(crate::PyError::new(
-                        crate::PyErrorKind::UnicodeEncodeError,
-                        "character maps to <undefined>",
-                    ));
-                }
+            "ignore" => {
+                i = end;
             }
-        } else {
-            return Err(crate::PyError::type_error(
-                "character mapping must return integer, bytes or None, not str",
-            ));
+            _ => {
+                let (replacement, newpos) =
+                    crate::type_methods::call_registered_encode_error_handler(
+                        &errors_s,
+                        "charmap",
+                        pyre_object::gc_roots::shadow_stack_get(sp),
+                        char_len,
+                        start,
+                        end,
+                        "character maps to <undefined>",
+                    )?;
+                match replacement {
+                    crate::type_methods::EncodeReplacement::Bytes(bytes) => {
+                        out.extend_from_slice(&bytes);
+                    }
+                    crate::type_methods::EncodeReplacement::Str(replacement_cps) => {
+                        for replacement_cp in replacement_cps {
+                            if !charmap_output(
+                                pyre_object::gc_roots::shadow_stack_get(sp + 1),
+                                replacement_cp,
+                                &mut out,
+                            )? {
+                                return Err(crate::typedef::unicode_encode_error(
+                                    "charmap",
+                                    pyre_object::gc_roots::shadow_stack_get(sp),
+                                    start,
+                                    end,
+                                    "character maps to <undefined>",
+                                ));
+                            }
+                        }
+                    }
+                }
+                i = newpos;
+            }
         }
     }
+    // The reported count is the input's own length, which the handler cannot
+    // change however far it moved the resume position.
+    let char_count = unsafe { pyre_object::w_str_len(pyre_object::gc_roots::shadow_stack_get(sp)) };
+    // Pinned because minting the bytes below can collect and move it.
+    let _ = pyre_object::gc_roots::pin_root(w_int_new(char_count as i64));
+    let w_encoded = w_bytes_from_bytes(&out);
     Ok(w_tuple_new(vec![
-        w_bytes_from_bytes(&out),
-        w_int_new(unsafe { pyre_object::w_str_len(w_unicode) } as i64),
+        w_encoded,
+        pyre_object::gc_roots::shadow_stack_get(sp + 2),
     ]))
+}
+
+/// `charmapdecode_lookup` — read one byte's entry out of a decoding table.
+///
+/// Answers `None` for a byte the table has no entry for.  Minting the key can
+/// collect and a table can carry a `__getitem__` of its own, so the table is
+/// pinned across both and re-read rather than carried in a plain local.
+fn charmap_decode_lookup(
+    w_mapping: PyObjectRef,
+    b: u8,
+) -> Result<Option<PyObjectRef>, crate::PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_mapping);
+    let w_key = pyre_object::gc_roots::pin_root(w_int_new(b as i64));
+    let w_mapping = pyre_object::gc_roots::shadow_stack_get(sp);
+    match crate::baseobjspace::getitem(w_mapping, w_key) {
+        Ok(w_ch) => Ok(Some(w_ch)),
+        Err(e)
+            if matches!(
+                e.kind,
+                crate::PyErrorKind::LookupError | crate::PyErrorKind::KeyError
+            ) =>
+        {
+            Ok(None)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 fn charmap_decode_impl(
@@ -1017,25 +1261,27 @@ fn charmap_decode_impl(
     w_mapping: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
     if unsafe { pyre_object::is_none(w_mapping) } {
-        return decode_with_name(w_obj, errors, "latin-1");
+        return decode_with_name(w_obj, errors, "charmap_decode", "latin-1");
     }
     if !unsafe { pyre_object::bytesobject::is_bytes_like(w_obj) } {
-        return Err(crate::PyError::type_error(
-            "charmap_decode() argument must be bytes-like",
-        ));
+        return Err(bad_buffer_arg(w_obj));
     }
-    let errors_s = if unsafe { is_str(errors) } {
-        crate::baseobjspace::str_utf8_w(errors)?
-    } else {
-        "strict"
-    };
+    // The loop below runs a table's own `__getitem__` and an error handler, so
+    // a name viewed out of the string it was read from would not survive it.
+    let errors_s = codec_errors_arg("charmap_decode", 2, errors)?;
     // A custom error handler may replace `exc.object`; decoding then resumes
     // from the new bytes (`data`).
-    let mut data: std::borrow::Cow<[u8]> =
-        std::borrow::Cow::Borrowed(unsafe { pyre_object::bytesobject::bytes_like_data(w_obj) });
+    // The input is copied rather than viewed: those same calls can collect, and
+    // a slice into the object's live buffer would not survive it moving.
+    let mut data: Vec<u8> = unsafe { pyre_object::bytesobject::bytes_like_data(w_obj) }.to_vec();
     // charmap_decode reports the number of input bytes consumed, which stays
     // the original length even if a handler replaces `exc.object`.
     let orig_len = data.len();
+    // Only the table has to outlive those calls; a string table's code points
+    // are copied out of it up front.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_mapping);
     let mapping_chars: Option<Vec<_>> = if unsafe { is_str(w_mapping) } {
         Some(
             unsafe { w_str_get_wtf8(w_mapping) }
@@ -1056,18 +1302,7 @@ fn charmap_decode_impl(
                 w_str_from_wtf8(one)
             })
         } else {
-            match crate::baseobjspace::getitem(w_mapping, w_int_new(b as i64)) {
-                Ok(w_ch) => Some(w_ch),
-                Err(e)
-                    if matches!(
-                        e.kind,
-                        crate::PyErrorKind::LookupError | crate::PyErrorKind::KeyError
-                    ) =>
-                {
-                    None
-                }
-                Err(e) => return Err(e),
-            }
+            charmap_decode_lookup(pyre_object::gc_roots::shadow_stack_get(sp), b)?
         };
         // A mapped char maps to itself unless it signals "undefined" (a missing
         // entry, the `￾` sentinel, or `None`).
@@ -1086,9 +1321,14 @@ fn charmap_decode_impl(
                         "character mapping must be in range(0x110000)",
                     ));
                 }
-                out.push(rustpython_wtf8::CodePoint::from_u32(x as u32).unwrap());
-                i += 1;
-                continue;
+                // The sentinel says "undefined" whichever way the table spells
+                // it, so an integer entry falls through to the error handler
+                // exactly as the one-character string does.
+                if x != 0xFFFE {
+                    out.push(rustpython_wtf8::CodePoint::from_u32(x as u32).unwrap());
+                    i += 1;
+                    continue;
+                }
             } else if !unsafe { pyre_object::is_none(w_ch) } {
                 return Err(crate::PyError::type_error(
                     "character mapping must return integer, None or str",
@@ -1097,7 +1337,7 @@ fn charmap_decode_impl(
         }
         // The byte maps to <undefined>: run the decode error handler over the
         // single byte at `i` (`str_decode_charmap` span `pos .. pos + 1`).
-        match errors_s {
+        match errors_s.as_str() {
             "ignore" => i += 1,
             "replace" => {
                 out.push_char('\u{FFFD}');
@@ -1121,7 +1361,7 @@ fn charmap_decode_impl(
             }
             _ => {
                 let (np, nb) = crate::type_methods::call_registered_decode_error_handler(
-                    errors_s,
+                    &errors_s,
                     "charmap",
                     &data[..],
                     i,
@@ -1130,7 +1370,7 @@ fn charmap_decode_impl(
                     &mut out,
                 )?;
                 if let Some(nb) = nb {
-                    data = std::borrow::Cow::Owned(nb);
+                    data = nb;
                 }
                 i = np;
             }
@@ -1194,12 +1434,14 @@ fn utf7_encode_unit(out: &mut Vec<u8>, unit: u32, base64bits: &mut u32, base64bu
     *base64buffer &= (1 << *base64bits) - 1;
 }
 
-fn utf7_encode_impl(w_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+fn utf7_encode_impl(
+    w_obj: PyObjectRef,
+    errors: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
     if !unsafe { is_str(w_obj) } {
-        return Err(crate::PyError::type_error(
-            "utf_7_encode() argument must be str",
-        ));
+        return Err(bad_arg("utf_7_encode", Some(1), "str", w_obj));
     }
+    let _errors = codec_errors_arg("utf_7_encode", 2, errors)?;
     // PyPy `unicodehelper.py:utf8_encode_utf_7`.
     let mut out = Vec::new();
     let mut in_shift = false;
@@ -1313,16 +1555,11 @@ fn utf7_decode_impl(
     is_final: bool,
 ) -> Result<PyObjectRef, crate::PyError> {
     if !unsafe { pyre_object::bytesobject::is_bytes_like(w_obj) } {
-        return Err(crate::PyError::type_error(
-            "utf_7_decode() argument must be bytes-like",
-        ));
+        return Err(bad_buffer_arg(w_obj));
     }
     // PyPy `unicodehelper.py:str_decode_utf_7`.
-    let errors_s = if unsafe { is_str(errors) } {
-        crate::baseobjspace::str_utf8_w(errors)?
-    } else {
-        "strict"
-    };
+    let errors_s = codec_errors_arg("utf_7_decode", 2, errors)?;
+    let errors_s = errors_s.as_str();
     // A custom error handler may replace `exc.object`; decoding then resumes
     // from the new bytes (`data`).
     let mut data: std::borrow::Cow<[u8]> =
@@ -1496,12 +1733,14 @@ fn push_ascii_hex_escape(out: &mut Vec<u8>, prefix: u8, cp: u32, digits: usize) 
     }
 }
 
-fn unicode_escape_encode_impl(w_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+fn unicode_escape_encode_impl(
+    w_obj: PyObjectRef,
+    errors: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
     if !unsafe { is_str(w_obj) } {
-        return Err(crate::PyError::type_error(
-            "unicode_escape_encode() argument must be str",
-        ));
+        return Err(bad_arg("unicode_escape_encode", Some(1), "str", w_obj));
     }
+    let _errors = codec_errors_arg("unicode_escape_encode", 2, errors)?;
     // PyPy `unicodehelper.py:utf8_encode_unicode_escape`.
     let mut out = Vec::new();
     for cp in unsafe { w_str_get_wtf8(w_obj) }.code_points() {
@@ -1632,24 +1871,46 @@ fn unicode_escape_hex(
     unicode_escape_run_error(data, out, pos_delta, pos - 2, endinpos, message, errors)
 }
 
+/// The `DeprecationWarning` text an unrecognised escape earns while decoding.
+///
+/// `prefix` distinguishes the two decoders: the bytes-to-bytes transform names
+/// the sequence as a `bytes` literal, the text one as a `str` literal.  The
+/// wording stops after the "will not work in the future" sentence -- the longer
+/// report carrying a "Did you mean" suggestion belongs to the compiler, which
+/// has the surrounding literal to suggest a raw string for.
+fn invalid_escape_warning(prefix: &str, sequence: &str, octal: bool) -> String {
+    let kind = if octal {
+        "an invalid octal escape sequence"
+    } else {
+        "an invalid escape sequence"
+    };
+    format!("{prefix}\"\\{sequence}\" is {kind}. Such sequences will not work in the future. ")
+}
+
+/// Acquire a backslash-escape decoder's input.  A `str` answers with its own
+/// bytes and any buffer producer with the bytes it exposes, which is what lets
+/// a `memoryview` -- including a sliced one, whose bytes are not contiguous
+/// with the object it was taken from -- reach the decoder.
+fn escape_decoder_input(w_obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
+    if unsafe { pyre_object::bytesobject::is_bytes_like(w_obj) } {
+        Ok(unsafe { pyre_object::bytesobject::bytes_like_data(w_obj) }.to_vec())
+    } else if unsafe { is_str(w_obj) } {
+        Ok(unsafe { w_str_get_wtf8(w_obj) }.as_bytes().to_vec())
+    } else if let Some(src) = crate::typedef::buffer_as_bytes_like(w_obj)? {
+        Ok(unsafe { pyre_object::bytesobject::bytes_like_data(src) }.to_vec())
+    } else {
+        Err(bad_buffer_arg(w_obj))
+    }
+}
+
 fn unicode_escape_decode_impl(
     w_obj: PyObjectRef,
     errors: PyObjectRef,
+    final_: bool,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let initial: Vec<u8> = if unsafe { pyre_object::bytesobject::is_bytes_like(w_obj) } {
-        unsafe { pyre_object::bytesobject::bytes_like_data(w_obj) }.to_vec()
-    } else if unsafe { is_str(w_obj) } {
-        unsafe { w_str_get_wtf8(w_obj) }.as_bytes().to_vec()
-    } else {
-        return Err(crate::PyError::type_error(
-            "unicode_escape_decode() argument must be bytes-like or str",
-        ));
-    };
-    let errors_s = if unsafe { is_str(errors) } {
-        crate::baseobjspace::str_utf8_w(errors)?
-    } else {
-        "strict"
-    };
+    let initial = escape_decoder_input(w_obj)?;
+    let errors_s = codec_errors_arg("unicode_escape_decode", 2, errors)?;
+    let errors_s = errors_s.as_str();
     // `unicodehelper.py:str_decode_unicode_escape` (final=True). A custom error
     // handler may replace `exc.object`; decoding then resumes from the new
     // bytes (`data`), and `pos_delta` keeps the reported consumed count
@@ -1658,6 +1919,7 @@ fn unicode_escape_decode_impl(
     let mut out = rustpython_wtf8::Wtf8Buf::new();
     let mut pos = 0usize;
     let mut pos_delta = 0i64;
+    let mut first_escape_warning: Option<String> = None;
     while pos < data.len() {
         let ch = data[pos];
         if ch != b'\\' {
@@ -1668,6 +1930,12 @@ fn unicode_escape_decode_impl(
         let escape_start = pos;
         pos += 1;
         if pos >= data.len() {
+            if !final_ {
+                // More input may follow, so the backslash is left unconsumed
+                // rather than reported: what it introduces is still unknown.
+                pos = escape_start;
+                break;
+            }
             let end = data.len();
             pos = unicode_escape_run_error(
                 &mut data,
@@ -1695,12 +1963,23 @@ fn unicode_escape_decode_impl(
             b'v' => out.push_char('\x0b'),
             b'a' => out.push_char('\x07'),
             b'0'..=b'7' => {
+                let octal_start = pos - 1;
                 let mut value = (ch - b'0') as u32;
                 for _ in 0..2 {
                     if pos < data.len() && matches!(data[pos], b'0'..=b'7') {
                         value = (value << 3) + (data[pos] - b'0') as u32;
                         pos += 1;
                     }
+                }
+                // Only three octal digits are read, so the largest escape is
+                // `\777`; anything past `\377` leaves the byte range the
+                // sequence is written to address.
+                if value > 0o377 && first_escape_warning.is_none() {
+                    first_escape_warning = Some(invalid_escape_warning(
+                        "",
+                        &String::from_utf8_lossy(&data[octal_start..pos]),
+                        true,
+                    ));
                 }
                 out.push(rustpython_wtf8::CodePoint::from_u32(value).unwrap());
             }
@@ -1710,6 +1989,14 @@ fn unicode_escape_decode_impl(
                     b'u' => (4usize, "truncated \\uXXXX escape"),
                     _ => (8usize, "truncated \\UXXXXXXXX escape"),
                 };
+                if !final_ && pos + digits > data.len() {
+                    // The escape runs off the end of this chunk; the digits it
+                    // is missing can still arrive.  A sequence the chunk does
+                    // decide -- four bytes that are not all hex -- is reported
+                    // here whether or not more input follows.
+                    pos = escape_start;
+                    break;
+                }
                 pos = unicode_escape_hex(
                     &mut data,
                     &mut out,
@@ -1721,18 +2008,48 @@ fn unicode_escape_decode_impl(
                 )?;
             }
             b'N' => {
-                // pyre has no Unicode-name database, so a `\N` escape never
-                // resolves; it is always reported as an error.
+                // `\N{NAME}` is resolved through the character database.  Only
+                // a name that names one character resolves, so a named
+                // sequence is reported as unknown; a name that is empty,
+                // unterminated, or not introduced by a brace at all is
+                // malformed instead, and each spelling reports its own span.
                 let (msg, end) = if pos < data.len() && data[pos] == b'{' {
-                    let mut look = pos + 1;
+                    let name_start = pos + 1;
+                    let mut look = name_start;
                     while look < data.len() && data[look] != b'}' {
                         look += 1;
                     }
-                    if look < data.len() && data[look] == b'}' {
-                        ("unknown Unicode character name", look + 1)
-                    } else {
+                    if look >= data.len() {
+                        if !final_ {
+                            // The closing brace can arrive with the next chunk.
+                            pos = escape_start;
+                            break;
+                        }
                         ("malformed \\N character escape", data.len())
+                    } else if look == name_start {
+                        // An empty name is not a name to look up.
+                        ("malformed \\N character escape", name_start)
+                    } else {
+                        // Owned so the database read does not borrow `data`,
+                        // which the error path below hands out mutably.
+                        let name = String::from_utf8(data[name_start..look].to_vec()).ok();
+                        match name
+                            .as_deref()
+                            .and_then(rustpython_unicode::lookup_character)
+                        {
+                            Some(ch) => {
+                                out.push_char(ch);
+                                pos = look + 1;
+                                continue;
+                            }
+                            None => ("unknown Unicode character name", look + 1),
+                        }
                     }
+                } else if pos >= data.len() && !final_ {
+                    // `\N` at the very end: the byte deciding whether a name
+                    // follows has not arrived yet.
+                    pos = escape_start;
+                    break;
                 } else {
                     ("malformed \\N character escape", pos)
                 };
@@ -1747,14 +2064,42 @@ fn unicode_escape_decode_impl(
                 )?;
             }
             _ => {
+                if first_escape_warning.is_none() {
+                    first_escape_warning = Some(invalid_escape_warning(
+                        "",
+                        &char::from(ch).to_string(),
+                        false,
+                    ));
+                }
                 out.push_char('\\');
                 out.push(rustpython_wtf8::CodePoint::from_u32(ch as u32).unwrap());
             }
         }
     }
+    if let Some(message) = first_escape_warning {
+        crate::warn::warn_deprecation(&message)?;
+    }
     Ok(w_tuple_new(vec![
         w_str_from_wtf8_managed(out),
         w_int_new(pos as i64 + pos_delta),
+    ]))
+}
+
+/// `unicode_escape_decode`'s raw counterpart: only `\uXXXX` and
+/// `\UXXXXXXXX` are escapes, every other byte -- a lone backslash included --
+/// standing for its own Latin-1 code point.
+fn raw_unicode_escape_decode_impl(
+    w_obj: PyObjectRef,
+    errors: PyObjectRef,
+    final_: bool,
+) -> Result<PyObjectRef, crate::PyError> {
+    let data = escape_decoder_input(w_obj)?;
+    let errors_s = codec_errors_arg("raw_unicode_escape_decode", 2, errors)?;
+    let (out, consumed) =
+        crate::type_methods::decode_raw_unicode_escape_stateful(&data, &errors_s, final_)?;
+    Ok(w_tuple_new(vec![
+        w_str_from_wtf8_managed(out),
+        w_int_new(consumed as i64),
     ]))
 }
 
@@ -1770,17 +2115,10 @@ fn escape_decode_impl(
     } else if let Some(src) = crate::typedef::buffer_as_bytes_like(w_obj)? {
         unsafe { pyre_object::bytesobject::bytes_like_data(src) }.to_vec()
     } else {
-        return Err(crate::PyError::type_error(
-            "escape_decode() argument must be bytes-like or str",
-        ));
+        return Err(bad_buffer_arg(w_obj));
     };
-    let errors_s = if unsafe { is_str(errors) } {
-        crate::baseobjspace::str_utf8_w(errors)?
-    } else if unsafe { pyre_object::is_none(errors) } {
-        "strict"
-    } else {
-        return Err(crate::PyError::type_error("errors must be str or None"));
-    };
+    let errors_s = codec_errors_arg("escape_decode", 2, errors)?;
+    let errors_s = errors_s.as_str();
 
     let mut out = Vec::with_capacity(data.len());
     let mut pos = 0usize;
@@ -1823,9 +2161,10 @@ fn escape_decode_impl(
                     .iter()
                     .fold(0u16, |value, digit| value * 8 + (digit - b'0') as u16);
                 if raw >= 256 && first_escape_warning.is_none() {
-                    first_escape_warning = Some(format!(
-                        "invalid octal escape sequence '\\{}'",
-                        String::from_utf8_lossy(&data[octal_start..pos])
+                    first_escape_warning = Some(invalid_escape_warning(
+                        "b",
+                        &String::from_utf8_lossy(&data[octal_start..pos]),
+                        true,
                     ));
                 }
                 out.push(raw as u8);
@@ -1862,8 +2201,11 @@ fn escape_decode_impl(
                 out.push(b'\\');
                 pos -= 1;
                 if first_escape_warning.is_none() {
-                    first_escape_warning =
-                        Some(format!("invalid escape sequence '\\{}'", char::from(other)));
+                    first_escape_warning = Some(invalid_escape_warning(
+                        "b",
+                        &char::from(other).to_string(),
+                        false,
+                    ));
                 }
             }
         }
@@ -1880,13 +2222,14 @@ fn escape_decode_impl(
 
 /// `interp_codecs.py escape_encode` / `string_escape_encode(data,
 /// quote=False)` — the inverse bytes transform.
-fn escape_encode_impl(w_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+fn escape_encode_impl(
+    w_obj: PyObjectRef,
+    errors: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
     if !unsafe { is_bytes(w_obj) } {
-        return Err(crate::PyError::type_error(format!(
-            "escape_encode() argument 1 must be bytes, not {}",
-            crate::type_methods::arg_type_name(w_obj)
-        )));
+        return Err(bad_arg("escape_encode", Some(1), "bytes", w_obj));
     }
+    let _errors = codec_errors_arg("escape_encode", 2, errors)?;
     let data = unsafe { pyre_object::bytesobject::w_bytes_data(w_obj) };
     let mut out = Vec::with_capacity(data.len());
     for byte in data {
@@ -1895,6 +2238,7 @@ fn escape_encode_impl(w_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError>
             b'\n' => out.extend_from_slice(b"\\n"),
             b'\r' => out.extend_from_slice(b"\\r"),
             b'\\' => out.extend_from_slice(b"\\\\"),
+            b'\'' => out.extend_from_slice(b"\\'"),
             0x20..=0x7e => out.push(*byte),
             value => out.extend_from_slice(format!("\\x{value:02x}").as_bytes()),
         }
@@ -1912,9 +2256,7 @@ fn charmap_build(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         ));
     };
     if !unsafe { is_str(chars) } {
-        return Err(crate::PyError::type_error(
-            "charmap_build() argument must be str",
-        ));
+        return Err(bad_arg("charmap_build", None, "str", chars));
     }
 
     // PyPy `interp_codecs.py charmap_build`: build a dict mapping
@@ -1932,15 +2274,6 @@ fn charmap_build(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(w_charmap)
 }
 
-/// `_PyArg_BadArgument`, which names the argument by its position rather
-/// than by the name the signature gives it.
-fn bad_argument(name: &str, position: usize, expected: &str, w_obj: PyObjectRef) -> crate::PyError {
-    crate::PyError::type_error(format!(
-        "{name}() argument {position} must be {expected}, not {}",
-        crate::type_methods::arg_type_name(w_obj)
-    ))
-}
-
 /// The `errors` argument the code page entry points share: `None` is
 /// `strict`, a `str` is itself, and nothing else is accepted.
 #[cfg(windows)]
@@ -1948,14 +2281,8 @@ fn code_page_errors(
     name: &str,
     position: usize,
     w_errors: PyObjectRef,
-) -> Result<&'static str, crate::PyError> {
-    if unsafe { pyre_object::is_none(w_errors) } {
-        return Ok("strict");
-    }
-    if !unsafe { is_str(w_errors) } {
-        return Err(bad_argument(name, position, "str or None", w_errors));
-    }
-    crate::baseobjspace::str_utf8_w(w_errors)
+) -> Result<String, crate::PyError> {
+    codec_errors_arg(name, position, w_errors)
 }
 
 /// The code page number argument.  A negative number names no code page and
@@ -1980,10 +2307,10 @@ fn code_page_encode_impl(
     w_errors: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
     if !unsafe { is_str(w_str) } {
-        return Err(bad_argument(name, position, "str", w_str));
+        return Err(bad_arg(name, Some(position), "str", w_str));
     }
     let errors = code_page_errors(name, position + 1, w_errors)?;
-    let bytes = crate::unicodehelper_win32::encode_code_page(code_page, w_str, errors)?;
+    let bytes = crate::unicodehelper_win32::encode_code_page(code_page, w_str, &errors)?;
     Ok(w_tuple_new(vec![
         pyre_object::bytesobject::w_bytes_from_bytes(&bytes),
         w_int_new(unsafe { w_str_len(w_str) } as i64),
@@ -2004,7 +2331,7 @@ fn code_page_decode_impl(
     let errors = code_page_errors(name, position + 1, w_errors)?;
     let is_final = crate::baseobjspace::is_true(w_final)?;
     let (text, consumed) =
-        crate::unicodehelper_win32::decode_code_page(code_page, &data, errors, is_final)?;
+        crate::unicodehelper_win32::decode_code_page(code_page, &data, &errors, is_final)?;
     // `final` is the caller promising that no continuation is coming, so the
     // whole buffer reads as consumed: nothing is being held back for one.
     let consumed = if is_final { data.len() } else { consumed };
@@ -2090,9 +2417,6 @@ crate::py_module! {
             data: PyObjectRef,
             #[default(w_none())] errors: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            if !unsafe { pyre_object::is_none(errors) || is_str(errors) } {
-                return Err(bad_argument("readbuffer_encode", 2, "str or None", errors));
-            }
             // `Py_buffer(accept={str, buffer})`: a str contributes its own
             // UTF-8 bytes, anything else the buffer it exposes.
             let bytes = if unsafe { is_str(data) } {
@@ -2100,6 +2424,7 @@ crate::py_module! {
             } else {
                 decode_input_bytes(data)?
             };
+            let _errors = codec_errors_arg("readbuffer_encode", 2, errors)?;
             Ok(w_tuple_new(vec![
                 pyre_object::bytesobject::w_bytes_from_bytes(&bytes),
                 w_int_new(bytes.len() as i64),
@@ -2109,33 +2434,33 @@ crate::py_module! {
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            encode_with_name(obj, errors, "ascii")
+            encode_with_name(obj, errors, "ascii_encode", "ascii")
         }
         fn ascii_decode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
             #[default(w_bool_from(false))] _final: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            decode_with_name(obj, errors, "ascii")
+            decode_with_name(obj, errors, "ascii_decode", "ascii")
         }
         fn latin_1_encode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            encode_with_name(obj, errors, "latin-1")
+            encode_with_name(obj, errors, "latin_1_encode", "latin-1")
         }
         fn latin_1_decode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
             #[default(w_bool_from(false))] _final: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            decode_with_name(obj, errors, "latin-1")
+            decode_with_name(obj, errors, "latin_1_decode", "latin-1")
         }
         fn utf_8_encode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            encode_with_name(obj, errors, "utf-8")
+            encode_with_name(obj, errors, "utf_8_encode", "utf-8")
         }
         fn utf_8_decode(
             obj: PyObjectRef,
@@ -2148,14 +2473,14 @@ crate::py_module! {
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            encode_with_name(obj, errors, "utf-16")
+            encode_with_name(obj, errors, "utf_16_encode", "utf-16")
         }
         fn utf_16_decode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
             #[default(w_bool_from(false))] final_: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            utf16_32_decode_impl(obj, errors, final_, false, None, "utf16")
+            utf16_32_decode_impl(obj, errors, final_, false, None, "utf16", "utf_16_decode")
         }
         fn utf_16_ex_decode(
             obj: PyObjectRef,
@@ -2163,46 +2488,62 @@ crate::py_module! {
             #[default(0i64)] byteorder: i64,
             #[default(w_bool_from(false))] final_: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            utf16_32_ex_decode_impl(obj, errors, byteorder, final_, false)
+            utf16_32_ex_decode_impl(obj, errors, byteorder, final_, false, "utf_16_ex_decode")
         }
         fn utf_16_be_encode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            encode_with_name(obj, errors, "utf-16-be")
+            encode_with_name(obj, errors, "utf_16_be_encode", "utf-16-be")
         }
         fn utf_16_be_decode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
             #[default(w_bool_from(false))] final_: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            utf16_32_decode_impl(obj, errors, final_, false, Some(true), "utf16-be")
+            utf16_32_decode_impl(
+                obj,
+                errors,
+                final_,
+                false,
+                Some(true),
+                "utf16-be",
+                "utf_16_be_decode",
+            )
         }
         fn utf_16_le_encode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            encode_with_name(obj, errors, "utf-16-le")
+            encode_with_name(obj, errors, "utf_16_le_encode", "utf-16-le")
         }
         fn utf_16_le_decode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
             #[default(w_bool_from(false))] final_: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            utf16_32_decode_impl(obj, errors, final_, false, Some(false), "utf16-le")
+            utf16_32_decode_impl(
+                obj,
+                errors,
+                final_,
+                false,
+                Some(false),
+                "utf16-le",
+                "utf_16_le_decode",
+            )
         }
         fn utf_32_encode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            encode_with_name(obj, errors, "utf-32")
+            encode_with_name(obj, errors, "utf_32_encode", "utf-32")
         }
         fn utf_32_decode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
             #[default(w_bool_from(false))] final_: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            utf16_32_decode_impl(obj, errors, final_, true, None, "utf32")
+            utf16_32_decode_impl(obj, errors, final_, true, None, "utf32", "utf_32_decode")
         }
         fn utf_32_ex_decode(
             obj: PyObjectRef,
@@ -2210,52 +2551,73 @@ crate::py_module! {
             #[default(0i64)] byteorder: i64,
             #[default(w_bool_from(false))] final_: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            utf16_32_ex_decode_impl(obj, errors, byteorder, final_, true)
+            utf16_32_ex_decode_impl(obj, errors, byteorder, final_, true, "utf_32_ex_decode")
         }
         fn utf_32_be_encode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            encode_with_name(obj, errors, "utf-32-be")
+            encode_with_name(obj, errors, "utf_32_be_encode", "utf-32-be")
         }
         fn utf_32_be_decode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
             #[default(w_bool_from(false))] final_: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            utf16_32_decode_impl(obj, errors, final_, true, Some(true), "utf32-be")
+            utf16_32_decode_impl(
+                obj,
+                errors,
+                final_,
+                true,
+                Some(true),
+                "utf32-be",
+                "utf_32_be_decode",
+            )
         }
         fn utf_32_le_encode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            encode_with_name(obj, errors, "utf-32-le")
+            encode_with_name(obj, errors, "utf_32_le_encode", "utf-32-le")
         }
         fn utf_32_le_decode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
             #[default(w_bool_from(false))] final_: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            utf16_32_decode_impl(obj, errors, final_, true, Some(false), "utf32-le")
+            utf16_32_decode_impl(
+                obj,
+                errors,
+                final_,
+                true,
+                Some(false),
+                "utf32-le",
+                "utf_32_le_decode",
+            )
         }
         fn raw_unicode_escape_encode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            encode_with_name(obj, errors, "raw-unicode-escape")
+            encode_with_name(
+                obj,
+                errors,
+                "raw_unicode_escape_encode",
+                "raw-unicode-escape",
+            )
         }
         fn raw_unicode_escape_decode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
-            #[default(w_bool_from(false))] _final: PyObjectRef,
+            #[default(w_bool_from(true))] final_: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            decode_with_name(obj, errors, "raw-unicode-escape")
+            raw_unicode_escape_decode_impl(obj, errors, crate::baseobjspace::is_true(final_)?)
         }
         fn utf_7_encode(
             obj: PyObjectRef,
-            #[default(w_str_new("strict"))] _errors: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            utf7_encode_impl(obj)
+            utf7_encode_impl(obj, errors)
         }
         fn utf_7_decode(
             obj: PyObjectRef,
@@ -2266,16 +2628,16 @@ crate::py_module! {
         }
         fn unicode_escape_encode(
             obj: PyObjectRef,
-            #[default(w_str_new("strict"))] _errors: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            unicode_escape_encode_impl(obj)
+            unicode_escape_encode_impl(obj, errors)
         }
         fn unicode_escape_decode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
-            #[default(w_bool_from(false))] _final: PyObjectRef,
+            #[default(w_bool_from(true))] final_: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            unicode_escape_decode_impl(obj, errors)
+            unicode_escape_decode_impl(obj, errors, crate::baseobjspace::is_true(final_)?)
         }
         fn escape_decode(
             obj: PyObjectRef,
@@ -2285,9 +2647,9 @@ crate::py_module! {
         }
         fn escape_encode(
             obj: PyObjectRef,
-            #[default(w_str_new("strict"))] _errors: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
         ) -> Result<PyObjectRef, crate::PyError> {
-            escape_encode_impl(obj)
+            escape_encode_impl(obj, errors)
         }
         fn charmap_encode(
             obj: PyObjectRef,
@@ -2303,39 +2665,25 @@ crate::py_module! {
         ) -> Result<PyObjectRef, crate::PyError> {
             charmap_decode_impl(obj, errors, mapping)
         }
-        // `encode(obj, encoding='utf-8', errors='strict')` — text path of
-        // `PyCodec_Encode`: a str is encoded via `str.encode`; anything
-        // else passes through unchanged.
         fn encode(
             obj: PyObjectRef,
             #[default(w_str_new("utf-8"))] encoding: PyObjectRef,
-            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            errors: Option<PyObjectRef>,
         ) -> Result<PyObjectRef, crate::PyError> {
-            if unsafe { is_str(obj) } {
-                let m = crate::baseobjspace::getattr_str(obj, "encode")?;
-                return crate::call::call_function_impl_result(m, &[encoding, errors]);
-            }
-            Ok(obj)
+            codec_encode_or_decode(obj, encoding, errors, true)
         }
-        // `decode(obj, encoding='utf-8', errors='strict')` — text path of
-        // `PyCodec_Decode`: bytes / bytearray decode via `.decode`;
-        // anything else passes through unchanged.
         fn decode(
             obj: PyObjectRef,
             #[default(w_str_new("utf-8"))] encoding: PyObjectRef,
-            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            errors: Option<PyObjectRef>,
         ) -> Result<PyObjectRef, crate::PyError> {
-            if unsafe { is_bytes(obj) || is_bytearray(obj) } {
-                let m = crate::baseobjspace::getattr_str(obj, "decode")?;
-                return crate::call::call_function_impl_result(m, &[encoding, errors]);
-            }
-            Ok(obj)
+            codec_encode_or_decode(obj, encoding, errors, false)
         }
     },
     functions: {
         "lookup_error"     / 1 = lookup_error,
         "register_error"   / 2 = register_error,
-        "_unregister_error" / 1 = |_| Ok(w_bool_from(false)),
+        "_unregister_error" / 1 = unregister_error,
         "register"       / 1 = register_codec,
         "unregister"     / 1 = unregister,
         "lookup"         / 1 = lookup_codec,

--- a/pyre/pyre-interpreter/src/module/_suggestions/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_suggestions/mod.rs
@@ -1,0 +1,57 @@
+//! _suggestions module — `Modules/_suggestions.c`.
+//!
+//! Exposes the interpreter's misspelling search to Python.  `traceback.py`
+//! reaches it from `_compute_suggestion_error` and `_find_keyword_typos`,
+//! and falls back to `difflib.get_close_matches` when the import fails.  The
+//! fallback ranks candidates by a different metric, so the reported
+//! suggestion only matches while this module is importable.
+
+use pyre_object::*;
+
+fn generate_suggestions(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (Some(candidates), Some(item)) = (args.first().copied(), args.get(1).copied()) else {
+        return Err(crate::PyError::type_error(
+            "_generate_suggestions expected 2 arguments",
+        ));
+    };
+    // The `unicode` converter runs while the arguments are parsed, so a
+    // non-`str` name is reported ahead of the list test in the body.
+    if !unsafe { is_str(item) } {
+        return Err(crate::PyError::type_error(format!(
+            "_generate_suggestions() argument 2 must be str, not {}",
+            crate::error::type_name_of(item)
+        )));
+    }
+    if !unsafe { is_exact_type(candidates, &LIST_TYPE) } {
+        return Err(crate::PyError::type_error("candidates must be a list"));
+    }
+    let items = unsafe { w_list_items_copy_as_vec(candidates) };
+    let mut names = Vec::with_capacity(items.len());
+    for element in items {
+        if !unsafe { is_str(element) } {
+            return Err(crate::PyError::type_error(
+                "all elements in 'candidates' must be strings",
+            ));
+        }
+        // A name carrying a lone surrogate has no `&str` view, and the search
+        // compares `char`s.  Drop it from the candidate set rather than
+        // reading it as UTF-8.
+        if let Some(name) = unsafe { w_str_get_value_opt(element) } {
+            names.push(name.to_string());
+        }
+    }
+    let Some(wrong_name) = (unsafe { w_str_get_value_opt(item) }) else {
+        return Ok(w_none());
+    };
+    Ok(match crate::error::best_suggestion(&names, wrong_name) {
+        Some(name) => w_str_new(&name),
+        None => w_none(),
+    })
+}
+
+crate::py_module! {
+    "_suggestions",
+    functions: {
+        "_generate_suggestions" / 2 = generate_suggestions,
+    },
+}

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -83,6 +83,7 @@ pub mod _ssl;
 pub mod _stat;
 #[allow(non_snake_case)]
 pub mod _statistics;
+pub mod _suggestions;
 #[allow(non_snake_case)]
 pub mod _symtable;
 #[allow(non_snake_case)]

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -3902,10 +3902,28 @@ pub fn encode_raw_unicode_escape(s: &Wtf8) -> Vec<u8> {
 /// `\UXXXXXXXX` escape; any other byte (including a lone backslash or a
 /// malformed escape) is taken as a Latin-1 code point.
 pub fn decode_raw_unicode_escape(data: &[u8], errors: &str) -> Result<Wtf8Buf, crate::PyError> {
+    Ok(decode_raw_unicode_escape_stateful(data, errors, true)?.0)
+}
+
+/// `unicodeobject.c:_PyUnicode_DecodeRawUnicodeEscapeStateful` — the form that
+/// answers how many input bytes were consumed alongside the text.
+///
+/// While `final_` is false more input may still follow, so an escape that runs
+/// off the end of this chunk is left unconsumed rather than reported: the
+/// digits it is missing can arrive in the next call.  Only a sequence this
+/// chunk already decides -- `\u12zz`, which has its four bytes and they are
+/// not all hex -- reaches the error handler.
+pub fn decode_raw_unicode_escape_stateful(
+    data: &[u8],
+    errors: &str,
+    final_: bool,
+) -> Result<(Wtf8Buf, usize), crate::PyError> {
     let mut out = Wtf8Buf::new();
     // A custom error handler may replace exc.object; decoding then resumes
-    // from the new bytes (`buf`).
+    // from the new bytes (`buf`), and `pos_delta` keeps the reported consumed
+    // count relative to the original input length.
     let mut buf: std::borrow::Cow<[u8]> = std::borrow::Cow::Borrowed(data);
+    let mut pos_delta = 0i64;
     let mut i = 0usize;
     while i < buf.len() {
         let b = buf[i];
@@ -3928,6 +3946,9 @@ pub fn decode_raw_unicode_escape(data: &[u8], errors: &str) -> Result<Wtf8Buf, c
         if want != 0 {
             let escape_start = i;
             let digits_start = i + 2;
+            if !final_ && digits_start + want > buf.len() {
+                return Ok((out, (escape_start as i64 + pos_delta).max(0) as usize));
+            }
             let available_end = (digits_start + want).min(buf.len());
             let mut hex_end = digits_start;
             while hex_end < available_end && buf[hex_end].is_ascii_hexdigit() {
@@ -3977,6 +3998,7 @@ pub fn decode_raw_unicode_escape(data: &[u8], errors: &str) -> Result<Wtf8Buf, c
                         &mut out,
                     )?;
                     if let Some(nb) = nb {
+                        pos_delta += buf.len() as i64 - nb.len() as i64;
                         buf = std::borrow::Cow::Owned(nb);
                     }
                     i = np;
@@ -3987,6 +4009,10 @@ pub fn decode_raw_unicode_escape(data: &[u8], errors: &str) -> Result<Wtf8Buf, c
             continue;
         }
         // Not a valid escape — emit both bytes literally as Latin-1.
+        if kind.is_none() && !final_ {
+            // A trailing backslash may yet turn out to introduce `\uXXXX`.
+            return Ok((out, (i as i64 + pos_delta).max(0) as usize));
+        }
         out.push_char(b as char);
         if let Some(next) = kind {
             out.push_char(next as char);
@@ -3995,7 +4021,7 @@ pub fn decode_raw_unicode_escape(data: &[u8], errors: &str) -> Result<Wtf8Buf, c
             i += 1;
         }
     }
-    Ok(out)
+    Ok((out, (buf.len() as i64 + pos_delta).max(0) as usize))
 }
 
 fn encode_narrow(
@@ -4006,6 +4032,9 @@ fn encode_narrow(
     range_msg: &str,
     errors: &str,
 ) -> Result<Vec<u8>, crate::PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let source_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(source);
     let cps: Vec<u32> = s.code_points().map(|c| c.to_u32()).collect();
     let mut out: Vec<u8> = Vec::with_capacity(cps.len());
     let mut i = 0usize;
@@ -4042,7 +4071,11 @@ fn encode_narrow(
             // narrow codec re-raises the original UnicodeEncodeError.
             "strict" | "surrogateescape" | "surrogatepass" => {
                 return Err(crate::typedef::unicode_encode_error(
-                    enc_name, source, start, end, range_msg,
+                    enc_name,
+                    pyre_object::gc_roots::shadow_stack_get(source_slot),
+                    start,
+                    end,
+                    range_msg,
                 ));
             }
             "ignore" => {}
@@ -4068,7 +4101,7 @@ fn encode_narrow(
                 let (rep, newpos) = call_registered_encode_error_handler(
                     errors,
                     enc_name,
-                    source,
+                    pyre_object::gc_roots::shadow_stack_get(source_slot),
                     cps.len(),
                     start,
                     end,
@@ -4079,7 +4112,11 @@ fn encode_narrow(
                         for rc in rcps {
                             if rc > max_cp {
                                 return Err(crate::typedef::unicode_encode_error(
-                                    enc_name, source, start, end, range_msg,
+                                    enc_name,
+                                    pyre_object::gc_roots::shadow_stack_get(source_slot),
+                                    start,
+                                    end,
+                                    range_msg,
                                 ));
                             }
                             out.push(rc as u8);
@@ -4174,6 +4211,9 @@ fn encode_utf16_32_impl(
     w_object: PyObjectRef,
     errors: &str,
 ) -> Result<Vec<u8>, crate::PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let object_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_object);
     let mut out = Vec::new();
     if bom {
         emit_scalar(&mut out, 0xFEFF, is32, big_endian);
@@ -4218,7 +4258,7 @@ fn encode_utf16_32_impl(
             "strict" | "surrogateescape" => {
                 return Err(crate::typedef::unicode_encode_error(
                     codec,
-                    w_object,
+                    pyre_object::gc_roots::shadow_stack_get(object_slot),
                     index,
                     index + 1,
                     "surrogates not allowed",
@@ -4228,7 +4268,7 @@ fn encode_utf16_32_impl(
                 let (rep, newpos) = call_registered_encode_error_handler(
                     errors,
                     codec,
-                    w_object,
+                    pyre_object::gc_roots::shadow_stack_get(object_slot),
                     cps.len(),
                     index,
                     index + 1,
@@ -4240,7 +4280,7 @@ fn encode_utf16_32_impl(
                             if rc >= 0x80 {
                                 return Err(crate::typedef::unicode_encode_error(
                                     codec,
-                                    w_object,
+                                    pyre_object::gc_roots::shadow_stack_get(object_slot),
                                     index,
                                     index + 1,
                                     "surrogates not allowed",
@@ -4254,7 +4294,7 @@ fn encode_utf16_32_impl(
                         if b.len() % unit != 0 {
                             return Err(crate::typedef::unicode_encode_error(
                                 codec,
-                                w_object,
+                                pyre_object::gc_roots::shadow_stack_get(object_slot),
                                 index,
                                 index + 1,
                                 "surrogates not allowed",
@@ -4441,23 +4481,39 @@ fn call_decode_error_handler(
             format!("unknown error handler name '{err_mode}'"),
         )
     })?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_handler);
 
     let w_exc =
         crate::typedef::unicode_decode_error(codec, data, start, end, reason).to_exc_object();
-    let w_res = crate::baseobjspace::call_function(w_handler, &[w_exc]);
+    let _ = pyre_object::gc_roots::pin_root(w_exc);
+    let w_res = crate::baseobjspace::call_function(
+        pyre_object::gc_roots::shadow_stack_get(sp),
+        &[pyre_object::gc_roots::shadow_stack_get(sp + 1)],
+    );
     if w_res.is_null() {
         return Err(crate::call::take_call_error()
             .unwrap_or_else(|| crate::PyError::type_error("error handler failed")));
     }
+    let _ = pyre_object::gc_roots::pin_root(w_res);
 
-    if !unsafe { pyre_object::is_tuple(w_res) } || unsafe { pyre_object::w_tuple_len(w_res) } != 2 {
+    if !unsafe { pyre_object::is_tuple(pyre_object::gc_roots::shadow_stack_get(sp + 2)) }
+        || unsafe { pyre_object::w_tuple_len(pyre_object::gc_roots::shadow_stack_get(sp + 2)) } != 2
+    {
         return Err(crate::PyError::type_error(
             "decoding error handler must return (str, int) tuple",
         ));
     }
-    let w_replace = unsafe { pyre_object::w_tuple_getitem(w_res, 0).unwrap() };
-    let w_newpos = unsafe { pyre_object::w_tuple_getitem(w_res, 1).unwrap() };
-    if !unsafe { pyre_object::is_str(w_replace) } {
+    let w_replace = unsafe {
+        pyre_object::w_tuple_getitem(pyre_object::gc_roots::shadow_stack_get(sp + 2), 0).unwrap()
+    };
+    let _ = pyre_object::gc_roots::pin_root(w_replace);
+    let w_newpos = unsafe {
+        pyre_object::w_tuple_getitem(pyre_object::gc_roots::shadow_stack_get(sp + 2), 1).unwrap()
+    };
+    let _ = pyre_object::gc_roots::pin_root(w_newpos);
+    if !unsafe { pyre_object::is_str(pyre_object::gc_roots::shadow_stack_get(sp + 3)) } {
         return Err(crate::PyError::type_error(
             "decoding error handler must return (str, int) tuple",
         ));
@@ -4469,13 +4525,17 @@ fn call_decode_error_handler(
     // decode C code checks PyBytes_Check on the reread object).
     let new_bytes = match resume_in {
         DecodeResume::RereadObject => {
-            let w_obj = unsafe { pyre_object::interp_exceptions::w_exception_get_object(w_exc) };
+            let w_obj = unsafe {
+                pyre_object::interp_exceptions::w_exception_get_object(
+                    pyre_object::gc_roots::shadow_stack_get(sp + 1),
+                )
+            };
             if !unsafe { pyre_object::bytesobject::is_bytes(w_obj) } {
                 return Err(crate::PyError::type_error(
                     "UnicodeError 'object' attribute must be a bytes",
                 ));
             }
-            Some(unsafe { pyre_object::bytesobject::bytes_like_data(w_obj) })
+            Some(unsafe { pyre_object::bytesobject::bytes_like_data(w_obj) }.to_vec())
         }
         #[cfg(not(target_arch = "wasm32"))]
         DecodeResume::OriginalInput => None,
@@ -4484,17 +4544,18 @@ fn call_decode_error_handler(
     // newpos folds against the length of whichever buffer decoding resumes
     // in: the reread object (unicodeobject.c insize), or the one it started
     // on (`multibytecodec_decerror`'s `size`).
-    let length = new_bytes.map_or(data.len(), <[u8]>::len) as i64;
-    let mut newpos = match crate::baseobjspace::int_w(w_newpos) {
-        Ok(n) => n,
-        Err(e) => {
-            if e.kind == crate::PyErrorKind::OverflowError {
-                -1
-            } else {
-                return Err(e);
+    let length = new_bytes.as_ref().map_or(data.len(), Vec::len) as i64;
+    let mut newpos =
+        match crate::baseobjspace::int_w(pyre_object::gc_roots::shadow_stack_get(sp + 4)) {
+            Ok(n) => n,
+            Err(e) => {
+                if e.kind == crate::PyErrorKind::OverflowError {
+                    -1
+                } else {
+                    return Err(e);
+                }
             }
-        }
-    };
+        };
     if newpos < 0 {
         newpos += length;
     }
@@ -4505,9 +4566,11 @@ fn call_decode_error_handler(
         ));
     }
 
-    out.push_wtf8(unsafe { pyre_object::w_str_get_wtf8(w_replace) });
+    out.push_wtf8(unsafe {
+        pyre_object::w_str_get_wtf8(pyre_object::gc_roots::shadow_stack_get(sp + 3))
+    });
     let resume = match new_bytes {
-        Some(bytes) if bytes != data => Some(bytes.to_vec()),
+        Some(bytes) if bytes.as_slice() != data => Some(bytes),
         _ => None,
     };
     Ok((newpos as usize, resume))

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -13699,6 +13699,21 @@ pub(crate) unsafe fn direct_member_get(member: PyObjectRef, obj: PyObjectRef) ->
     }
 }
 
+/// Typecheck a write to a `Unicode*Error` `start` / `end` slot.
+///
+/// Those two are `Py_T_PYSSIZET` members, and `PyMember_SetOne` admits only a
+/// real `int` for one: an object carrying nothing but `__index__` is refused,
+/// which is why the test is `isinstance(value, int)` and not the wider
+/// conversion `descr_init` would reach for.  The slot itself holds the object,
+/// as `readwrite_attrproperty_w` does, so the check is all that stands between
+/// a write and a `descr_str` that would go on to format a non-number.
+fn unicode_error_position_w(value: PyObjectRef) -> Result<(), crate::PyError> {
+    if unsafe { crate::baseobjspace::isinstance_int_w(value) } {
+        return Ok(());
+    }
+    Err(crate::PyError::type_error("an integer is required"))
+}
+
 pub(crate) unsafe fn direct_member_set(
     member: PyObjectRef,
     obj: PyObjectRef,
@@ -13836,10 +13851,12 @@ pub(crate) unsafe fn direct_member_set(
             Ok(pyre_object::w_none())
         }
         pyre_object::MEMBER_UNICODE_ERROR_START => {
+            unicode_error_position_w(value)?;
             unsafe { pyre_object::interp_exceptions::w_exception_set_start(obj, value) };
             Ok(pyre_object::w_none())
         }
         pyre_object::MEMBER_UNICODE_ERROR_END => {
+            unicode_error_position_w(value)?;
             unsafe { pyre_object::interp_exceptions::w_exception_set_end(obj, value) };
             Ok(pyre_object::w_none())
         }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -13707,11 +13707,16 @@ pub(crate) unsafe fn direct_member_get(member: PyObjectRef, obj: PyObjectRef) ->
 /// conversion `descr_init` would reach for.  The slot itself holds the object,
 /// as `readwrite_attrproperty_w` does, so the check is all that stands between
 /// a write and a `descr_str` that would go on to format a non-number.
-fn unicode_error_position_w(value: PyObjectRef) -> Result<(), crate::PyError> {
-    if unsafe { crate::baseobjspace::isinstance_int_w(value) } {
-        return Ok(());
+fn unicode_error_position_w(value: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    if !unsafe { crate::baseobjspace::isinstance_int_w(value) } {
+        return Err(crate::PyError::type_error("an integer is required"));
     }
-    Err(crate::PyError::type_error("an integer is required"))
+    // The slot holds a `Py_ssize_t`, so the write stores the number rather than
+    // the object it arrived in: reading `start` back gives a plain `int` even
+    // where a `bool` or an `int` subclass was assigned, and a value the word
+    // cannot hold is refused here rather than surfacing later in `descr_str`.
+    let position = crate::builtins::unicode_error_index_w(value)?;
+    Ok(pyre_object::w_int_new(position))
 }
 
 pub(crate) unsafe fn direct_member_set(
@@ -13851,13 +13856,13 @@ pub(crate) unsafe fn direct_member_set(
             Ok(pyre_object::w_none())
         }
         pyre_object::MEMBER_UNICODE_ERROR_START => {
-            unicode_error_position_w(value)?;
-            unsafe { pyre_object::interp_exceptions::w_exception_set_start(obj, value) };
+            let position = unicode_error_position_w(value)?;
+            unsafe { pyre_object::interp_exceptions::w_exception_set_start(obj, position) };
             Ok(pyre_object::w_none())
         }
         pyre_object::MEMBER_UNICODE_ERROR_END => {
-            unicode_error_position_w(value)?;
-            unsafe { pyre_object::interp_exceptions::w_exception_set_end(obj, value) };
+            let position = unicode_error_position_w(value)?;
+            unsafe { pyre_object::interp_exceptions::w_exception_set_end(obj, position) };
             Ok(pyre_object::w_none())
         }
         pyre_object::MEMBER_UNICODE_ERROR_REASON => {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -5320,15 +5320,29 @@ fn try_walker_force_quasi_immut_namespace_write<Sym: WalkSym>(
     Some(())
 }
 
-/// The `CodeObject` of the frame the walk is currently in.
+/// The `CodeObject` of the frame the walk is currently in: the innermost
+/// inlined callee while a sub-walk is in progress, else the portal frame.
 ///
-/// Every `__build_class__` the walker meets is reached with an empty
-/// `WalkSession::framestack` — a class statement is never inside an inlined
-/// callee sub-walk — so the portal jitcode's own code object is the code
-/// running the statement.
-fn walker_portal_py_code<Sym: WalkSym>(
+/// A sub-walk inherits `FbwWalkMode::snapshot_sym` from its parent, so that
+/// field names the walk's outermost frame however deep the descent is. A
+/// helper holding a class statement is an ordinary inline candidate — the
+/// admission that declines one today is the generic replay-safety screen, not
+/// a rule about `__build_class__` — so reading the snapshot root would decide
+/// a callee's class statement by its caller's returns. `WalkSession::framestack`
+/// carries the callee levels, and its top is the frame executing the opcode;
+/// this is the same derivation `ActiveResumeFrame::current` performs, so the
+/// gate and the snapshot encoder name one consistent active frame.
+fn walker_active_py_code<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
 ) -> Option<&'static pyre_interpreter::CodeObject> {
+    // Bound before the branch so the session borrow ends with this statement.
+    let innermost = super::fbw_state::fbw_innermost_inline_callee_key(ctx);
+    if let Some(callee_w_code) = innermost {
+        let index = crate::state::ensure_jitcode_index(callee_w_code as *const ())?;
+        let payload = crate::state::pyjitcode_for_jitcode_index(index)?;
+        let code_ptr = payload.code_ptr;
+        return (!code_ptr.is_null()).then(|| unsafe { &*code_ptr });
+    }
     let sym = ctx.fbw_mode.snapshot_sym;
     if sym.is_null() {
         return None;
@@ -5980,8 +5994,8 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && walker_portal_py_code(ctx)
-            .is_none_or(|portal| !pyre_interpreter::code_returns_only_constants(portal))
+        && walker_active_py_code(ctx)
+            .is_none_or(|active| !pyre_interpreter::code_returns_only_constants(active))
         && try_walker_force_quasi_immut_class_body(ctx, code, op, 1, &r_args)
     {
         // Carry the reason to the `abort_trace` that follows, the way upstream

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -3475,7 +3475,37 @@ fn try_adopt_multi_frame_blackhole(
         // the frame instead of out of the green list.  Declining is not
         // available after the drive — see this path's note on post-drive
         // declines.
+        //
+        // The coordinate is the ROOT's.  Unlike the raise arm below, a bail
+        // does not walk the chain to the portal before taking its terminal
+        // image (`blackhole.rs handle_jitexception` refuses one ahead of that
+        // walk), so the terminal is whichever level stopped — and a level
+        // below the root leaves the root stamped at its own CALL.  Resuming
+        // there re-enters a callee that has already run part of its body.
+        // Handing the chain back instead of the root alone is a handoff pyre
+        // does not have, so the mismatch is reported rather than repaired:
+        // the same shape, and the same reporting, as the portal CRN/frame
+        // identity mismatch `eval.rs pyre_portal_runner` logs.
         majit_metainterp::jitexc::JitException::BailToInterpreter => {
+            if majit_metainterp::majit_log_enabled()
+                && let Some(image) = mf_terminal.as_ref()
+                && let Ok(index) = i32::try_from(image.jitcode_index)
+                && let Some(terminal) = crate::state::pyjitcode_for_jitcode_index(index)
+                && !terminal.code_ptr.is_null()
+                && !std::ptr::eq(terminal.code_ptr as *const (), unsafe {
+                    (*(root_addr as *const pyre_interpreter::PyFrame)).pycode
+                })
+            {
+                eprintln!(
+                    "[blackhole-resume] bail terminal is not the root frame: \
+                     terminal jitcode={} code={:p} root code={:p} — the root's \
+                     stamped coordinate names its own CALL, not where the chain \
+                     stopped",
+                    image.jitcode_index,
+                    terminal.code_ptr,
+                    unsafe { (*(root_addr as *const pyre_interpreter::PyFrame)).pycode },
+                );
+            }
             let resume_py_pc = frame_resume_py_pc(root_addr);
             adopt_blackhole_crn(cf_addr, root_addr, resume_py_pc);
             WALK_END_RESTART_PC.with(|slot| slot.set(Some(resume_py_pc)));

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2844,6 +2844,14 @@ fn try_adopt_single_frame_blackhole(
         // available after the drive — see this path's note on post-drive
         // declines.
         majit_metainterp::jitexc::JitException::BailToInterpreter => {
+            // Reported on the way through, alongside the multi-frame arm's
+            // report of the same handoff: a census that speaks only when the
+            // coordinate is wrong cannot separate `never wrong` from `never
+            // reached`, and only the single-frame arm can say the chain had one
+            // level and therefore no coordinate to get wrong.
+            if majit_metainterp::majit_log_enabled() {
+                eprintln!("[blackhole-resume] single-frame bail");
+            }
             let resume_py_pc = frame_resume_py_pc(forwarded_root_addr);
             adopt_blackhole_crn(cf_addr, forwarded_root_addr, resume_py_pc);
             sfdbg!("adopted bail with resume_py_pc={resume_py_pc}");
@@ -3487,6 +3495,11 @@ fn try_adopt_multi_frame_blackhole(
         // the same shape, and the same reporting, as the portal CRN/frame
         // identity mismatch `eval.rs pyre_portal_runner` logs.
         majit_metainterp::jitexc::JitException::BailToInterpreter => {
+            // The arrival, ahead of the mismatch report below, so a run that
+            // never mismatches still says whether it ever got here.
+            if majit_metainterp::majit_log_enabled() {
+                eprintln!("[blackhole-resume] multi-frame bail");
+            }
             if majit_metainterp::majit_log_enabled()
                 && let Some(image) = mf_terminal.as_ref()
                 && let Ok(index) = i32::try_from(image.jitcode_index)

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2752,6 +2752,25 @@ pub fn blackhole_resume_via_rd_numb(
             {
                 let (frame_reg, _) =
                     pyre_jit_trace::state::portal_red_regs_at(jitcode_index as i32);
+                // #1311: the admission below is a bare `!= 0`, and a word that
+                // is neither zero nor a frame has reached it — one dump held an
+                // aligned heap address that was not a `PyFrame`, another the
+                // tagged word `2`, and `record_application_traceback` then
+                // dereferenced it.  Which frame of the chain contributes the bad
+                // red, and whether the register is the wrong one for this
+                // jitcode or was simply never filled, are questions the whole
+                // bank answers and the admitted value alone does not, so report
+                // it beside the index read from it.  A report and not a test:
+                // rejecting the word here would exchange the fault for a
+                // silently missing traceback node while the wrong word kept
+                // flowing.
+                if majit_metainterp::bh_debug_enabled() {
+                    eprintln!(
+                        "[bh-chain] frame={frame_index} jitcode={jitcode_index} \
+                         frame_reg={frame_reg} registers_r={:x?}",
+                        frame.registers_r,
+                    );
+                }
                 if frame_reg != u16::MAX {
                     if let Some(&frame_ptr) = frame.registers_r.get(frame_reg as usize) {
                         if frame_ptr != 0 {

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1633,6 +1633,67 @@ fn clear_shutdown_modules(
     collect_and_run_finalizers(ec_ptr);
 }
 
+/// `pylifecycle.c finalize_modules_delete_special`, the step `finalize_modules`
+/// takes before it releases any module namespace.
+///
+/// `sys` and `builtins` are torn down last of all, so a user value parked on
+/// one of them outlives every destructor that might complain about it; upstream
+/// clears the usual hiding places up front for that reason.
+///
+/// `sys.meta_path` is among them, and clearing it is what makes an import
+/// attempted from a `__del__` running this late raise `ImportError` instead of
+/// succeeding.  `finalize_modules` reaches that state for every module because
+/// it goes on to empty `sys.modules`, which this step does not: a module
+/// already imported stays importable from a destructor running here.
+///
+/// The three standard streams are restored from their `__`-prefixed originals
+/// rather than cleared, so a destructor still has somewhere to write.
+fn finalize_delete_special() {
+    // `path_hooks` and `path_importer_cache` are cleared by
+    // `_PyImport_FiniExternal`, past where this runs, so they are not here.
+    const SYS_CLEARED: [&str; 10] = [
+        "path",
+        "argv",
+        "ps1",
+        "ps2",
+        "last_exc",
+        "last_type",
+        "last_value",
+        "last_traceback",
+        "__interactivehook__",
+        "meta_path",
+    ];
+    const SYS_STREAMS: [(&str, &str); 3] = [
+        ("stdin", "__stdin__"),
+        ("stdout", "__stdout__"),
+        ("stderr", "__stderr__"),
+    ];
+    if let Some(builtins) = pyre_interpreter::importing::get_sys_module("builtins") {
+        let dict = unsafe { pyre_object::w_module_get_w_dict(builtins) };
+        if !dict.is_null() {
+            unsafe { pyre_object::w_dict_setitem_str(dict, "_", pyre_object::w_none()) };
+        }
+    }
+    let Some(sys) = pyre_interpreter::importing::get_sys_module("sys") else {
+        return;
+    };
+    let dict = unsafe { pyre_object::w_module_get_w_dict(sys) };
+    if dict.is_null() {
+        return;
+    }
+    for name in SYS_CLEARED {
+        // `_PySys_ClearAttrString` binds `None` rather than deleting the name,
+        // so a late reader finds a value that is not there instead of a name
+        // that is not there.
+        unsafe { pyre_object::w_dict_setitem_str(dict, name, pyre_object::w_none()) };
+    }
+    for (name, original) in SYS_STREAMS {
+        let value = unsafe { pyre_object::w_dict_getitem_str(dict, original) }
+            .unwrap_or_else(pyre_object::w_none);
+        unsafe { pyre_object::w_dict_setitem_str(dict, name, value) };
+    }
+}
+
 /// PyPy `ObjSpace.finish()` / module teardown ordering: join non-daemon
 /// threads, collect already-unreachable cycles, then release `__main__`
 /// globals from newest to oldest while the older globals their `__del__`
@@ -1675,6 +1736,10 @@ fn finalize_runtime(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyExecut
     // itself holds, so without this a stream owned by any other module loses
     // its buffered writes.
     pyre_interpreter::module::_io::flush_all_streams();
+    // `finalize_modules` opens with this and every release below is its module
+    // teardown, so the clearing has to precede the whole walk rather than sit
+    // beside `clear_shutdown_modules`.
+    finalize_delete_special();
     let mut swept_something_finalizable = collect_and_run_finalizers(ec_ptr);
     let (mut released, mut swept) = (0usize, 0usize);
     let mut entries = unsafe { pyre_object::w_dict_str_entries(canonical) };
@@ -2023,7 +2088,14 @@ fn handle_main_error(
     // on every exit path, not only on SystemExit.  Print first: the raw
     // `PyObjectRef` fields of `e` are not GC-visible and
     // `finalize_runtime` collects.
-    pyre_interpreter::eprint_exception(&e, true);
+    //
+    // `PyErr_Print` is what ends a top-level run upstream, and it reports
+    // through `sys.excepthook`; the direct print is the arm it takes when there
+    // is no hook to reach.
+    let mut e = e;
+    if !pyre_interpreter::error::print_exception_via_excepthook(&mut e) {
+        pyre_interpreter::eprint_exception(&e, true);
+    }
     finalize_runtime(canonical, ec_ptr);
     maybe_print_jit_stats();
     if is_keyboard_interrupt {
@@ -2052,8 +2124,14 @@ fn eval_source_in_main(
         Err(e) => {
             // Render the `File "…", line N` + source + caret + `SyntaxError:`
             // banner for the malformed source, matching an interactive run.
-            let err = pyre_interpreter::compile_err_to_syntax_error(e, source);
-            pyre_interpreter::eprint_syntax_error(&err);
+            // A main file that will not compile is reported by the same
+            // `PyErr_Print` every other top-level failure is, so the hook sees
+            // it too and the stdlib renderer is what offers the keyword the
+            // author meant.
+            let mut err = pyre_interpreter::compile_err_to_syntax_error(e, source);
+            if !pyre_interpreter::error::print_exception_via_excepthook(&mut err) {
+                pyre_interpreter::eprint_syntax_error(&err);
+            }
             std::process::exit(1);
         }
     };


### PR DESCRIPTION
Rebased onto current `main`. Four commits:

**`jit, majit, extra_tests: PR #1466 review follow-ups`** — the raise-path
position sync, the portal's `JitException` / `BailToInterpreter` transport, the
class-body quasi-immutable question read off the *active* frame rather than the
portal, and `metaclass=type` classified like the implicit default.

**`interp, pyrex, jit: exception display, keyword-typo suggestions, incomplete-input classification`**
— `CHECK_EG_MATCH` stamping a frame on the group `except*` builds,
`SyntaxError._metadata`, `PyCF_ALLOW_INCOMPLETE_INPUT` under `PyCF_ONLY_AST`,
the `sys.excepthook` / `traceback._print_exception_bltin` route, and a
`_suggestions` module following `_Py_CalculateSuggestions`.

**`interp: UnicodeError.start/.end refuse a non-int write`** — the two slots are
`Py_T_PYSSIZET` members, so `PyMember_SetOne` admits only a real `int`;
`e.start = 'x'; str(e)` used to render a position of `x`.

**`codecs: route encode/decode errors through the registry and report arguments as the clinic does`**
— thirteen defects, each first measured against CPython 3.14.2:

| | |
|---|---|
| `charmap_encode` | never called the registered handler; indexed a `str` table without bounds |
| `charmap_decode` | an integer `0xFFFE` was not undefined |
| `unicode_escape_decode` / `raw_unicode_escape_decode` | ignored `final`, so a split chunk raised |
| `raw_unicode_escape_decode` | rejected `str` and `memoryview`; delegated to `bytes.decode` |
| `\N{NAME}` | never resolved, though the character database was already there |
| `codecs.encode` / `codecs.decode` | returned the input instead of calling the codec |
| `_codecs._unregister_error` | a stub returning `False` |
| `Unicode*Error.__init__` | no `__index__` conversion, no `Py_ssize_t` store, no range check |
| escapes | missing/wrong `DeprecationWarning`; `escape_encode` did not quote `'` |
| `errors=None` | refused at eight entry points |
| argument reporting | 78 message divergences, including the encoder/decoder tuple-message space asymmetry |
| GC | `charmap_encode` / `charmap_decode` were measured regressions; three more sites rooted preventively |

Verification, on both backends against CPython 3.14.2: 16 probes × 2 backends
all match; eight new gated snippets pass under CPython and both backends; the
GC-pressure repros produce byte-identical output. `test_codeccallbacks` 23
failures → 0. `test_codecs` 38 → 5, all `unknown encoding: big5`.

Out of scope, stated rather than hidden:

- **CJK codecs.** `_codecs_tw` / `_codecs_cn` / `_codecs_kr` / `_codecs_hk` /
  `_codecs_iso2022` are not built — only `_codecs_jp` is. The sources are
  already vendored under `pypy/module/_multibytecodec/src/cjkcodecs/` and the
  wiring is mechanical, but it is a separate feature area and adding C
  translation units belongs in its own PR.
- **`test_traceback`'s remaining three**: `_testcapi`, a GBK codec, and the
  `sys.modules` teardown GC invariant.
- The GC rooting in `call_decode_error_handler`, `encode_narrow` and
  `encode_utf16_32_impl` is **preventive** — a structural hazard, not a
  reproduced failure. The other two were reproduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added broader codec support, incremental Unicode escape decoding, custom error-handler management, and misspelling suggestions in tracebacks.
  * Improved `sys.excepthook` integration, traceback rendering, syntax diagnostics, and incomplete-input handling.

* **Bug Fixes**
  * Improved exception propagation and resumption across compiled and interpreted execution.
  * Fixed Unicode error validation, codec argument handling, class namespace detection, and exception-group traceback behavior.

* **Tests**
  * Expanded coverage for codecs, Unicode errors, exception suppression, traceback rendering, and loop control flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->