### PR TITLE
majit: prove the width of an indexed array element, and resolve a field member under either spelling

### DIFF
--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -484,7 +484,12 @@ impl Drop for TraceContinuationSuspendGuard {
 /// Diagnostic env gates read once and cached — these are checked on the hot
 /// back-edge / guard-failure paths that run every loop iteration, so re-reading
 /// the environment per call would add a syscall to each iteration.
-pub(crate) fn spdiag_enabled() -> bool {
+///
+/// `MAJIT_SPDIAG`: trace the stack-pointer bookkeeping. Public for the same
+/// reason [`no_bridge_enabled`] is — a frontend that owns state the diagnostic
+/// is about has to report it from its own side, and a variable that only the
+/// metainterp honours reads as broken when a frontend's half stays silent.
+pub fn spdiag_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_SPDIAG").is_some())
 }

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -184,7 +184,7 @@ pub use jitdriver::{
     DeclarativeJitDriver, FlatEntryContract, JitDriver, JitDriverStaticData,
     MultiFrameBlackholeResult, PendingAbortBlackhole, SingleFrameBlackholeResult,
     TraceContinuationSuspendGuard, bridge_fuel_take, current_state_field_fvc_epoch,
-    drive_multi_frame_blackhole, drive_single_frame_blackhole, no_bridge_enabled,
+    drive_multi_frame_blackhole, drive_single_frame_blackhole, no_bridge_enabled, spdiag_enabled,
     trace_continuation_suspended,
 };
 pub use majit_backend::CompiledTraceInfo;

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -9082,17 +9082,29 @@ where
                     .count_ops(OpCode::New, crate::counters::RECORDED_OPS);
                 let sbox_op = ctx.record_op_with_descr(OpCode::New, &[], struct_descr);
                 ctx.set_opref_concrete(sbox_op, Value::Ref(majit_ir::GcRef(struct_ptr as usize)));
+                // `opimpl_newlist_clear` composes `opimpl_new`,
+                // `_opimpl_setfield_gc_any`, `opimpl_new_array_clear` and a
+                // second `_opimpl_setfield_gc_any`; each carries the heapcache
+                // effect stamped alongside it here.
+                ctx.heap_cache_mut().new_object(sbox_op);
 
                 // ── 2. store the length into the header's `length` field. ──
                 ctx.profiler()
                     .count_ops(OpCode::SetfieldGc, crate::counters::OPS);
                 ctx.profiler()
                     .count_ops(OpCode::SetfieldGc, crate::counters::RECORDED_OPS);
+                let length_field_index = length_fielddescr.index();
+                ctx.heapcache_invalidate_caches_varargs(
+                    OpCode::SetfieldGc,
+                    None,
+                    &[sbox_op, length_opref],
+                );
                 ctx.record_op_with_descr(
                     OpCode::SetfieldGc,
                     &[sbox_op, length_opref],
                     length_fielddescr,
                 );
+                ctx.heapcache_setfield_cached(sbox_op, length_field_index, length_opref);
                 if struct_ptr != 0 {
                     unsafe {
                         *((struct_ptr as *mut u8).add(length_offset) as *mut i64) = length_val
@@ -9134,6 +9146,11 @@ where
                     .count_ops(OpCode::NewArrayClear, crate::counters::RECORDED_OPS);
                 let abox_op = ctx.record_new_array_clear(length_opref, array_descr);
                 ctx.set_opref_concrete(abox_op, Value::Ref(majit_ir::GcRef(array_ptr as usize)));
+                // `execute_new_array_clear`'s `heapcache.new_array`. Only a
+                // constant length makes the array a virtual candidate, which is
+                // the `isinstance(lengthbox, Const)` the flag stands for.
+                ctx.heap_cache_mut()
+                    .new_array(abox_op, length_opref, length_opref.is_constant());
 
                 // ── 4. store the items block into the header's `items` field.
                 // A ref store adds a heap edge header→items, so notify the GC
@@ -9142,7 +9159,14 @@ where
                     .count_ops(OpCode::SetfieldGc, crate::counters::OPS);
                 ctx.profiler()
                     .count_ops(OpCode::SetfieldGc, crate::counters::RECORDED_OPS);
+                let items_field_index = items_fielddescr.index();
+                ctx.heapcache_invalidate_caches_varargs(
+                    OpCode::SetfieldGc,
+                    None,
+                    &[sbox_op, abox_op],
+                );
                 ctx.record_op_with_descr(OpCode::SetfieldGc, &[sbox_op, abox_op], items_fielddescr);
+                ctx.heapcache_setfield_cached(sbox_op, items_field_index, abox_op);
                 if struct_ptr != 0 {
                     unsafe { *((struct_ptr as *mut u8).add(items_offset) as *mut i64) = array_ptr };
                     majit_gc::gc_write_barrier(majit_ir::GcRef(struct_ptr as usize));

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -4003,6 +4003,17 @@ where
                     }
                     _ => self.read_int_reg(value_reg),
                 };
+                let field_index = fielddescr.index();
+                // `_record_helper` runs `heapcache.invalidate_caches` before it
+                // appends. `clear_caches_not_necessary` lists SETFIELD_GC, so
+                // only the mark-escaped half runs: a ref written into an
+                // already-escaped struct escapes with it. Same shape as
+                // BC_SETARRAYITEM_GC below.
+                ctx.heapcache_invalidate_caches_varargs(
+                    OpCode::SetfieldGc,
+                    None,
+                    &[struct_opref, value_opref],
+                );
                 ctx.profiler()
                     .count_ops(OpCode::SetfieldGc, crate::counters::OPS);
                 ctx.profiler()
@@ -4012,6 +4023,10 @@ where
                     &[struct_opref, value_opref],
                     fielddescr,
                 );
+                // `execute_setfield_gc`'s trailing `heapcache.setfield`, which
+                // `_opimpl_setfield_gc_any` spells `upd.setfield(valuebox)`.
+                // The cache stores the Box identity, not the value word.
+                ctx.heapcache_setfield_cached(struct_opref, field_index, value_opref);
                 if struct_ptr != 0 {
                     // blackhole.py:1471-1483 stores through the fielddescr,
                     // which carries the field's byte width, and the getfield

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -4733,12 +4733,47 @@ where
                     .wrapping_add(base_size)
                     .wrapping_add((index_value as usize).wrapping_mul(itemsize));
                 let concrete = unsafe { *(item_addr as *const i64) };
-                let opref = if let Some(cached) = cached {
+                let (opref, reg_concrete) = if let Some(cached) = cached {
                     ctx.profiler().count_ops(
                         OpCode::GetarrayitemGcR,
                         crate::pyjitpl::counters::HEAPCACHED_OPS,
                     );
-                    cached
+                    // `_do_getarrayitem_gc_any`'s `typ == 'r'` arm compares the
+                    // freshly executed load against the cached box's
+                    // `tobox.getref_base()`. Same structure as the int/float
+                    // arm above: a mismatch records a fallback op whose result
+                    // is discarded, asserts in debug, and still answers with
+                    // the stale cached box.
+                    let expected = match ctx.box_value(cached) {
+                        Some(Value::Ref(majit_ir::GcRef(p))) => Some(p as i64),
+                        _ => None,
+                    };
+                    let stale = matches!(expected, Some(exp) if exp != concrete);
+                    if stale {
+                        ctx.heapcache_invalidate_caches_varargs(
+                            OpCode::GetarrayitemGcR,
+                            None,
+                            &[array_opref, index_opref],
+                        );
+                        ctx.profiler()
+                            .count_ops(OpCode::GetarrayitemGcR, crate::counters::RECORDED_OPS);
+                        let _ = ctx.record_op_with_descr(
+                            OpCode::GetarrayitemGcR,
+                            &[array_opref, index_opref],
+                            descr,
+                        );
+                        debug_assert!(
+                            false,
+                            "GetarrayitemGcR sanity check failed: \
+                             cached={expected:?} concrete={concrete}",
+                        );
+                    }
+                    let reg_concrete = if stale {
+                        expected.expect("stale only set when expected is Some")
+                    } else {
+                        concrete
+                    };
+                    (cached, reg_concrete)
                 } else {
                     ctx.profiler()
                         .count_ops(OpCode::GetarrayitemGcR, crate::counters::OPS);
@@ -4756,9 +4791,9 @@ where
                         descr_index,
                         opref,
                     );
-                    opref
+                    (opref, concrete)
                 };
-                self.set_ref_reg(dst, Some(opref), Some(concrete));
+                self.set_ref_reg(dst, Some(opref), Some(reg_concrete));
             }
             // blackhole.py:1350-1358 bhimpl_setarrayitem_gc_{i,r,f}: record
             // SetarrayitemGc (a single op-kind whose descr carries the item

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -3955,6 +3955,16 @@ where
                     .count_ops(kind, crate::counters::RECORDED_OPS);
                 let op = ctx.record_op_with_descr(kind, &[], descr);
                 ctx.set_opref_concrete(op, Value::Ref(majit_ir::GcRef(ptr as usize)));
+                // `execute_new` stamps `heapcache.new(resbox)`;
+                // `execute_new_with_vtable` stamps `class_now_known` on top of
+                // it. The vtable written at offset 0 just above is the word
+                // `cls_of_box` reads back, so the class is known here by
+                // construction — a zero one is the "unavailable" spelling and
+                // stays unrecorded.
+                ctx.heap_cache_mut().new_object(op);
+                if with_vtable && vtable != 0 {
+                    ctx.heap_cache_mut().class_now_known(op, vtable as i64);
+                }
                 self.set_ref_reg(dest, Some(op), Some(ptr));
             }
             jitcode::insns::BC_SETFIELD_GC_I

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -4022,15 +4022,27 @@ impl TraceCtx {
             );
             self.promote_int(eqbox, isstandard, 0);
             if isstandard != 0 {
-                // pyjitpl.py:1140-1142 `if box.type == 'r':
+                // `_nonstandard_virtualizable`'s `if box.type == 'r':
                 //     self.metainterp.replace_box(box, standard_box)`.
-                // Virtualizables are always Refs in pyre, so the
-                // `box.type == 'r'` check is unconditional here.
-                // Upstream's `MetaInterp.replace_box` includes a
-                // framestack walk (see `MetaInterp::replace_box` in
-                // pyjitpl.rs); reaching that walk from TraceCtx
-                // requires a MetaInterp backref which does not exist
-                // today — C tracks the architectural move.
+                // Virtualizables are always Refs here, so the
+                // `box.type == 'r'` check is unconditional.
+                //
+                // Upstream's `MetaInterp.replace_box` also walks the
+                // framestack, rewriting the box in every frame's active
+                // registers; this one rewrites only the records `TraceCtx`
+                // owns, so an alias of `vable_opref` sitting in a register
+                // would keep naming the nonstandard box.
+                //
+                // That gap is unreachable rather than tolerated: this arm
+                // needs a vable op whose base is an OpRef other than the
+                // declared virtualizable variable but pointing at the same
+                // frame, and no lowering mints one — a field access becomes
+                // a vable op only for the declared variable, and every
+                // seeding site takes it from the standard box itself, so
+                // the identity check above returns first. A NEW SEEDING
+                // SITE ARMS THIS ARM, and closing the register half then
+                // has to come with it: `TraceCtx` owns no frame registers,
+                // so the pair has to reach whichever walker does.
                 self.replace_box(vable_opref, standard_box);
                 return false;
             }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -7540,14 +7540,34 @@ impl<'a> Lowering<'a> {
                 // escape guard (a failing shape stays residual — safe).  The
                 // read leaf (`index`, a value copy) needs no such guard.
                 let workspace_index = self.is_workspace_index_call(&reg);
+                // `ArrayRead` addresses its element as `base + index *
+                // itemsize`, and the descr the unfenced legs mint carries one
+                // target word as that itemsize.  RPython can leave it implicit
+                // — every non-primitive there IS a one-word GC pointer — but a
+                // Rust `Vec<T>` stores `T` inline, so a `Vec<u8>` strides 1 and
+                // a `Vec<String>` strides 24 while both read 8.  Admit only an
+                // element whose type proves the stride
+                // ([`json_ty_is_word_sized_array_element`]); anything else
+                // falls through to the residual call, where Rust computes the
+                // address.  The workspace arm needs no proof: its `pyre_` fence
+                // admits exactly the three element banks named below, all of
+                // them one word.
+                let element_is_one_word = tyref_index_element_node(&call.dest.ty, self.llbc)
+                    .is_some_and(|elem| json_ty_is_word_sized_array_element(elem, self.llbc));
                 if args.len() == 2
                     && (workspace_index
-                        || (self.is_vec_index_call(&reg)
-                            && (!is_vec_index_mut_regular(&reg, self.llbc)
-                                || add_dest_used_only_as_single_deref(self.body, dest_local)))
-                        || (self.is_slice_scalar_index_call(&reg, second_arg_ty.as_ref())
-                            && (!self.is_slice_scalar_index_mut_call(&reg)
-                                || add_dest_used_only_as_single_deref(self.body, dest_local))))
+                        || (element_is_one_word
+                            && ((self.is_vec_index_call(&reg)
+                                && (!is_vec_index_mut_regular(&reg, self.llbc)
+                                    || add_dest_used_only_as_single_deref(
+                                        self.body, dest_local,
+                                    )))
+                                || (self
+                                    .is_slice_scalar_index_call(&reg, second_arg_ty.as_ref())
+                                    && (!self.is_slice_scalar_index_mut_call(&reg)
+                                        || add_dest_used_only_as_single_deref(
+                                            self.body, dest_local,
+                                        ))))))
                 {
                     let res = self
                         .graph
@@ -17682,6 +17702,101 @@ fn strip_ty_indirections<'l>(
     None
 }
 
+/// The array element type behind an `Index::index` / `IndexMut::index_mut`
+/// destination — exactly one reference level off its `&T` / `&mut T`.
+///
+/// [`strip_ty_wrappers`] cannot do this: it peels `Ref` repeatedly, so over a
+/// `Vec<&i64>`'s `&&i64` it answers `i64`, the element type of neither the
+/// vector nor the borrow.
+fn tyref_index_element_node<'l>(ty: &'l TyRef, llbc: &'l Llbc) -> Option<&'l serde_json::Value> {
+    strip_ty_indirections(tyref_node(ty, llbc)?, llbc)?
+        .as_object()?
+        .get("Ref")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|a| a.get(1))
+}
+
+/// `true` only when an array element of this type provably occupies one target
+/// word — the shape the identity-less array descr minted by the `Vec` and
+/// slice index legs actually describes.
+///
+/// [`ValueType`] cannot answer it. `Unsigned` is width-less, one variant
+/// spanning `u8` through `usize`, and every non-primitive shape — `()` and an
+/// unresolved dedup id included — flattens to `Ref(None)`. A `Vec<u8>` and a
+/// `Vec<String>` are indistinguishable there while striding 1 and 24 bytes, so
+/// the element type has to answer, and only a positive answer counts: a shape
+/// this cannot name stays residual, where Rust computes the address itself.
+fn json_ty_is_word_sized_array_element(node: &serde_json::Value, llbc: &Llbc) -> bool {
+    let Some(obj) = strip_ty_indirections(node, llbc).and_then(serde_json::Value::as_object) else {
+        return false;
+    };
+    // A pointer element — `{"Ref": [region, ty, kind]}` / `{"RawPtr": [ty,
+    // kind]}` — is one word only while it is thin, so it inherits the
+    // question: a pointer to an unsized pointee carries a length or a vtable
+    // beside the address.
+    if let Some(pointee) = obj
+        .get("Ref")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|a| a.get(1))
+        .or_else(|| {
+            obj.get("RawPtr")
+                .and_then(serde_json::Value::as_array)
+                .and_then(|a| a.first())
+        })
+    {
+        return json_ty_is_statically_sized(pointee, llbc);
+    }
+    // Pointer-width scalars. A narrower one strides 1, 2 or 4 while the descr
+    // reads it eight bytes at a time.
+    let Some(lit) = obj.get("Literal").and_then(serde_json::Value::as_object) else {
+        return false;
+    };
+    matches!(
+        lit.get("UInt").and_then(serde_json::Value::as_str),
+        Some("Usize" | "U64")
+    ) || matches!(
+        lit.get("Int").and_then(serde_json::Value::as_str),
+        Some("Isize" | "I64")
+    ) || matches!(
+        lit.get("Float").and_then(serde_json::Value::as_str),
+        Some("F64")
+    )
+}
+
+/// `true` when `node` names a type of compile-time-known size, which is what
+/// makes a pointer to it thin.
+///
+/// Recognition is positive-only, and deliberately so: `[T]`, `str` and
+/// `dyn Trait` each have two Charon spellings — a top-level `{"Slice": elem}`
+/// and the `{"Adt": {"id": {"Builtin": "Slice"}}}` form
+/// [`charon_builtin_adt_to_ast_string`] renders — so a list of the unsized
+/// shapes would answer "sized" for whichever spelling it forgot. A whitelist
+/// answers `false` for both, and for an unresolved trait projection too.
+fn json_ty_is_statically_sized(node: &serde_json::Value, llbc: &Llbc) -> bool {
+    let Some(obj) = strip_ty_indirections(node, llbc).and_then(serde_json::Value::as_object) else {
+        return false;
+    };
+    // A scalar, a fixed-length array, and any pointer (thin or fat) are all
+    // sized values.
+    if obj.contains_key("Literal")
+        || obj.contains_key("Array")
+        || obj.contains_key("Ref")
+        || obj.contains_key("RawPtr")
+    {
+        return true;
+    }
+    let Some(id) = obj
+        .get("Adt")
+        .and_then(serde_json::Value::as_object)
+        .and_then(|adt| adt.get("id"))
+    else {
+        return false;
+    };
+    // The tuple atom and a named `{"Adt": def_id}`; the `Builtin` ids stay
+    // out, so `Slice` and `Str` decline with the top-level spellings.
+    id.as_str() == Some("Tuple") || id.as_object().is_some_and(|m| m.contains_key("Adt"))
+}
+
 /// Does the iterator ADT named by `path` hand back a reference *it* added,
 /// rather than the element itself?
 ///
@@ -22303,8 +22418,8 @@ mod tests {
     use super::{
         DecodedConst, FnPtrFamily, cast_kind_is_raw_ptr, cast_pointer_marker_op,
         charon_const_generic_to_string, charon_type_value_to_ast_string, decode_literal,
-        fn_ptr_family_for, shaped_array_parts, simplify_lowered_graph, tyref_array_suffix,
-        tyref_is_raw_byte_ptr,
+        fn_ptr_family_for, json_ty_is_word_sized_array_element, shaped_array_parts,
+        simplify_lowered_graph, tyref_array_suffix, tyref_is_raw_byte_ptr,
     };
     use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, ValueType};
     use majit_charon_reader::{Llbc, ullbc::TyRef};
@@ -25177,6 +25292,74 @@ mod tests {
             }
         });
         Llbc::from_slice(file.to_string().as_bytes()).expect("fixture Llbc parses")
+    }
+
+    /// The identity-less array descr the `Vec` and slice index legs mint
+    /// describes a one-target-word element, so only an element type that
+    /// proves that width may reach it.  RPython can leave the width implicit
+    /// because every non-primitive there is a one-word GC pointer; a Rust
+    /// `Vec<T>` stores `T` inline, so `Vec<u8>` strides 1 and `Vec<String>`
+    /// strides 24 while the descr reads 8 from both.
+    #[test]
+    fn only_a_word_sized_element_reaches_the_identity_less_array_descr() {
+        let llbc = llbc_with_trait_impls(serde_json::json!([]));
+        let admits = |ty: serde_json::Value| json_ty_is_word_sized_array_element(&ty, &llbc);
+        let uint = |w: &str| serde_json::json!({"Literal": {"UInt": w}});
+        let int = |w: &str| serde_json::json!({"Literal": {"Int": w}});
+        let named_adt = serde_json::json!({"Adt": {"id": {"Adt": 7}, "generics": {"types": []}}});
+        let borrow =
+            |pointee: serde_json::Value| serde_json::json!({"Ref": ["_", pointee, "Shared"]});
+
+        // Pointer-width scalars, and a thin borrow or raw pointer.
+        assert!(admits(int("I64")));
+        assert!(admits(int("Isize")));
+        assert!(admits(uint("Usize")));
+        assert!(admits(serde_json::json!({"Literal": {"Float": "F64"}})));
+        assert!(admits(borrow(named_adt.clone())));
+        assert!(admits(
+            serde_json::json!({"RawPtr": [named_adt.clone(), "Mut"]})
+        ));
+
+        // Narrower scalars — the `bytearray` / `rbigint` digit population,
+        // which `ValueType::Unsigned` cannot distinguish from `usize`.
+        for w in ["U8", "U16", "U32"] {
+            assert!(!admits(uint(w)), "{w} strides narrower than a word");
+        }
+        assert!(!admits(serde_json::json!({"Literal": {"Bool": null}})));
+
+        // A named ADT is the element itself, not a pointer to one, so its
+        // size is whatever the struct is — `String` is three words.
+        assert!(!admits(named_adt));
+    }
+
+    /// `[T]`, `str` and `dyn Trait` each have two Charon spellings — a
+    /// top-level `{"Slice": elem}` and the `{"Adt": {"id": {"Builtin":
+    /// "Slice"}}}` form.  A pointer to any of them is fat, and the width
+    /// proof has to decline BOTH spellings: a list of the unsized shapes
+    /// would answer "sized" for whichever one it forgot.
+    #[test]
+    fn both_charon_spellings_of_an_unsized_pointee_decline() {
+        let llbc = llbc_with_trait_impls(serde_json::json!([]));
+        let borrow = |pointee: serde_json::Value| {
+            json_ty_is_word_sized_array_element(
+                &serde_json::json!({"Ref": ["_", pointee, "Shared"]}),
+                &llbc,
+            )
+        };
+        let u8_ty = serde_json::json!({"Literal": {"UInt": "U8"}});
+        let builtin = |name: &str, args: serde_json::Value| serde_json::json!({"Adt": {"id": {"Builtin": name}, "generics": {"types": args}}});
+
+        assert!(!borrow(serde_json::json!({"Slice": u8_ty.clone()})));
+        assert!(!borrow(builtin(
+            "Slice",
+            serde_json::json!([u8_ty.clone()])
+        )));
+        assert!(!borrow(serde_json::json!({"Str": null})));
+        assert!(!borrow(builtin("Str", serde_json::json!([]))));
+        assert!(!borrow(serde_json::json!({"DynTrait": {}})));
+
+        // A fixed-length array IS sized, so a pointer to one stays thin.
+        assert!(borrow(serde_json::json!({"Array": [u8_ty, "14"]})));
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -7541,22 +7541,25 @@ impl<'a> Lowering<'a> {
                 // read leaf (`index`, a value copy) needs no such guard.
                 let workspace_index = self.is_workspace_index_call(&reg);
                 // `ArrayRead` addresses its element as `base + index *
-                // itemsize`, and the descr the unfenced legs mint carries one
-                // target word as that itemsize.  RPython can leave it implicit
-                // — every non-primitive there IS a one-word GC pointer — but a
-                // Rust `Vec<T>` stores `T` inline, so a `Vec<u8>` strides 1 and
-                // a `Vec<String>` strides 24 while both read 8.  Admit only an
-                // element whose type proves the stride
-                // ([`json_ty_is_word_sized_array_element`]); anything else
-                // falls through to the residual call, where Rust computes the
-                // address.  The workspace arm needs no proof: its `pyre_` fence
-                // admits exactly the three element banks named below, all of
-                // them one word.
-                let element_is_one_word = tyref_index_element_node(&call.dest.ty, self.llbc)
-                    .is_some_and(|elem| json_ty_is_word_sized_array_element(elem, self.llbc));
+                // itemsize`.  RPython can leave that width implicit — every
+                // non-primitive there IS a one-word GC pointer — but a Rust
+                // `Vec<T>` stores `T` inline, so a `Vec<u8>` strides 1 and a
+                // `Vec<String>` strides 24.  A scalar element carries its
+                // spelling as the array identity and the descr computes the
+                // real width from it; a thin pointer needs no spelling.  An
+                // element that is neither falls through to the residual call,
+                // where Rust computes the address itself.  The workspace arm
+                // asks nothing: its `pyre_` fence admits exactly the three
+                // element banks named below, all of them one word.
+                let element_node = tyref_index_element_node(&call.dest.ty, self.llbc);
+                let element_scalar =
+                    element_node.and_then(|elem| json_ty_scalar_element_spelling(elem, self.llbc));
+                let element_is_addressable = element_scalar.is_some()
+                    || element_node
+                        .is_some_and(|elem| json_ty_is_thin_pointer_element(elem, self.llbc));
                 if args.len() == 2
                     && (workspace_index
-                        || (element_is_one_word
+                        || (element_is_addressable
                             && ((self.is_vec_index_call(&reg)
                                 && (!is_vec_index_mut_regular(&reg, self.llbc)
                                     || add_dest_used_only_as_single_deref(
@@ -7597,8 +7600,17 @@ impl<'a> Lowering<'a> {
                     // inherent/trait impls on three concrete types, so
                     // `call.dest.ty` is a resolved associated `Output` at
                     // every one and never lands on that fallback.
-                    let array_type_id = (workspace_index && matches!(item_ty, ValueType::Ref(_)))
-                        .then(|| PYOBJECT_GCARRAY_TYPE_ID.to_string());
+                    let array_type_id = if workspace_index {
+                        matches!(item_ty, ValueType::Ref(_))
+                            .then(|| PYOBJECT_GCARRAY_TYPE_ID.to_string())
+                    } else {
+                        // `get_array_descr` keys the descr cache on the ARRAY
+                        // lltype, so two sites naming the same element name the
+                        // same array — which is what lets the width travel.
+                        // A thin-pointer element stays unnamed: it is the one
+                        // shape the identity-less mint already sizes right.
+                        element_scalar.as_deref().map(|elem| format!("[{elem}]"))
+                    };
                     self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                         result: Some(res.clone()),
                         kind: OpKind::ArrayRead {
@@ -17716,25 +17728,73 @@ fn tyref_index_element_node<'l>(ty: &'l TyRef, llbc: &'l Llbc) -> Option<&'l ser
         .and_then(|a| a.get(1))
 }
 
-/// `true` only when an array element of this type provably occupies one target
-/// word — the shape the identity-less array descr minted by the `Vec` and
-/// slice index legs actually describes.
+/// The Rust spelling of an array element whose exact width `get_type_flag`
+/// computes, to be carried as the array identity.
 ///
-/// [`ValueType`] cannot answer it. `Unsigned` is width-less, one variant
-/// spanning `u8` through `usize`, and every non-primitive shape — `()` and an
-/// unresolved dedup id included — flattens to `Ref(None)`. A `Vec<u8>` and a
-/// `Vec<String>` are indistinguishable there while striding 1 and 24 bytes, so
-/// the element type has to answer, and only a positive answer counts: a shape
-/// this cannot name stays residual, where Rust computes the address itself.
-fn json_ty_is_word_sized_array_element(node: &serde_json::Value, llbc: &Llbc) -> bool {
+/// `get_array_descr` keys on the ARRAY lltype and takes its item size from
+/// `get_array_token`; there is no identity-less array upstream. Naming the
+/// element restores that: `arraydescrof_concrete` reads the real width
+/// instead of assuming one target word, so a `u8` element strides 1 rather
+/// than 8. [`ValueType`] cannot supply it — `Unsigned` is one width-less
+/// variant spanning `u8` through `usize`.
+///
+/// A spelling the flag table does not carry — `char` among them — is not
+/// named, and the caller leaves that site residual rather than describe it
+/// with a width nothing computed.
+fn json_ty_scalar_element_spelling(node: &serde_json::Value, llbc: &Llbc) -> Option<String> {
+    let obj = strip_ty_indirections(node, llbc)?.as_object()?;
+    let lit = obj.get("Literal")?;
+    if lit.as_str() == Some("Bool") {
+        return Some("bool".to_string());
+    }
+    let lit = lit.as_object()?;
+    if lit.contains_key("Bool") {
+        return Some("bool".to_string());
+    }
+    let named = |key: &str, pairs: &[(&str, &str)]| -> Option<String> {
+        let atom = lit.get(key)?.as_str()?;
+        pairs
+            .iter()
+            .find(|(charon, _)| *charon == atom)
+            .map(|(_, rust)| (*rust).to_string())
+    };
+    named(
+        "UInt",
+        &[
+            ("U8", "u8"),
+            ("U16", "u16"),
+            ("U32", "u32"),
+            ("U64", "u64"),
+            ("Usize", "usize"),
+        ],
+    )
+    .or_else(|| {
+        named(
+            "Int",
+            &[
+                ("I8", "i8"),
+                ("I16", "i16"),
+                ("I32", "i32"),
+                ("I64", "i64"),
+                ("Isize", "isize"),
+            ],
+        )
+    })
+    .or_else(|| named("Float", &[("F32", "f32"), ("F64", "f64")]))
+}
+
+/// `true` when an array element of this type is a pointer that occupies one
+/// target word — the width the identity-less descr assumes, and the one shape
+/// that needs no spelling because `get_type_flag`'s reference fallback and
+/// that assumption already agree.
+///
+/// A pointer is one word only while it is thin: a pointer to an unsized
+/// pointee carries a length or a vtable beside the address.
+fn json_ty_is_thin_pointer_element(node: &serde_json::Value, llbc: &Llbc) -> bool {
     let Some(obj) = strip_ty_indirections(node, llbc).and_then(serde_json::Value::as_object) else {
         return false;
     };
-    // A pointer element — `{"Ref": [region, ty, kind]}` / `{"RawPtr": [ty,
-    // kind]}` — is one word only while it is thin, so it inherits the
-    // question: a pointer to an unsized pointee carries a length or a vtable
-    // beside the address.
-    if let Some(pointee) = obj
+    let Some(pointee) = obj
         .get("Ref")
         .and_then(serde_json::Value::as_array)
         .and_then(|a| a.get(1))
@@ -17743,24 +17803,10 @@ fn json_ty_is_word_sized_array_element(node: &serde_json::Value, llbc: &Llbc) ->
                 .and_then(serde_json::Value::as_array)
                 .and_then(|a| a.first())
         })
-    {
-        return json_ty_is_statically_sized(pointee, llbc);
-    }
-    // Pointer-width scalars. A narrower one strides 1, 2 or 4 while the descr
-    // reads it eight bytes at a time.
-    let Some(lit) = obj.get("Literal").and_then(serde_json::Value::as_object) else {
+    else {
         return false;
     };
-    matches!(
-        lit.get("UInt").and_then(serde_json::Value::as_str),
-        Some("Usize" | "U64")
-    ) || matches!(
-        lit.get("Int").and_then(serde_json::Value::as_str),
-        Some("Isize" | "I64")
-    ) || matches!(
-        lit.get("Float").and_then(serde_json::Value::as_str),
-        Some("F64")
-    )
+    json_ty_is_statically_sized(pointee, llbc)
 }
 
 /// `true` when `node` names a type of compile-time-known size, which is what
@@ -22418,8 +22464,8 @@ mod tests {
     use super::{
         DecodedConst, FnPtrFamily, cast_kind_is_raw_ptr, cast_pointer_marker_op,
         charon_const_generic_to_string, charon_type_value_to_ast_string, decode_literal,
-        fn_ptr_family_for, json_ty_is_word_sized_array_element, shaped_array_parts,
-        simplify_lowered_graph, tyref_array_suffix, tyref_is_raw_byte_ptr,
+        fn_ptr_family_for, json_ty_is_thin_pointer_element, json_ty_scalar_element_spelling,
+        shaped_array_parts, simplify_lowered_graph, tyref_array_suffix, tyref_is_raw_byte_ptr,
     };
     use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, ValueType};
     use majit_charon_reader::{Llbc, ullbc::TyRef};
@@ -25294,54 +25340,67 @@ mod tests {
         Llbc::from_slice(file.to_string().as_bytes()).expect("fixture Llbc parses")
     }
 
-    /// The identity-less array descr the `Vec` and slice index legs mint
-    /// describes a one-target-word element, so only an element type that
-    /// proves that width may reach it.  RPython can leave the width implicit
-    /// because every non-primitive there is a one-word GC pointer; a Rust
-    /// `Vec<T>` stores `T` inline, so `Vec<u8>` strides 1 and `Vec<String>`
-    /// strides 24 while the descr reads 8 from both.
+    /// An `ArrayRead` element is addressable two ways: a scalar names its
+    /// spelling so the descr computes the real width, or a thin pointer takes
+    /// the identity-less mint's one-target-word assumption, which is already
+    /// right for it. Anything else — including a scalar `get_type_flag` has no
+    /// row for — is not addressable and the site stays residual.
     #[test]
-    fn only_a_word_sized_element_reaches_the_identity_less_array_descr() {
+    fn a_scalar_element_names_its_width_and_a_thin_pointer_needs_no_name() {
         let llbc = llbc_with_trait_impls(serde_json::json!([]));
-        let admits = |ty: serde_json::Value| json_ty_is_word_sized_array_element(&ty, &llbc);
+        let spelling = |ty: serde_json::Value| json_ty_scalar_element_spelling(&ty, &llbc);
         let uint = |w: &str| serde_json::json!({"Literal": {"UInt": w}});
         let int = |w: &str| serde_json::json!({"Literal": {"Int": w}});
         let named_adt = serde_json::json!({"Adt": {"id": {"Adt": 7}, "generics": {"types": []}}});
-        let borrow =
-            |pointee: serde_json::Value| serde_json::json!({"Ref": ["_", pointee, "Shared"]});
 
-        // Pointer-width scalars, and a thin borrow or raw pointer.
-        assert!(admits(int("I64")));
-        assert!(admits(int("Isize")));
-        assert!(admits(uint("Usize")));
-        assert!(admits(serde_json::json!({"Literal": {"Float": "F64"}})));
-        assert!(admits(borrow(named_adt.clone())));
-        assert!(admits(
-            serde_json::json!({"RawPtr": [named_adt.clone(), "Mut"]})
-        ));
-
-        // Narrower scalars — the `bytearray` / `rbigint` digit population,
-        // which `ValueType::Unsigned` cannot distinguish from `usize`.
-        for w in ["U8", "U16", "U32"] {
-            assert!(!admits(uint(w)), "{w} strides narrower than a word");
+        // Every width `get_type_flag` computes, narrow ones included — these
+        // are the `bytearray` / `rbigint` digit / `rutf8` index populations
+        // that `ValueType::Unsigned` cannot tell apart from `usize`.
+        for (charon, rust) in [
+            ("U8", "u8"),
+            ("U16", "u16"),
+            ("U32", "u32"),
+            ("U64", "u64"),
+            ("Usize", "usize"),
+        ] {
+            assert_eq!(spelling(uint(charon)).as_deref(), Some(rust));
         }
-        assert!(!admits(serde_json::json!({"Literal": {"Bool": null}})));
+        assert_eq!(spelling(int("I16")).as_deref(), Some("i16"));
+        assert_eq!(spelling(int("Isize")).as_deref(), Some("isize"));
+        assert_eq!(
+            spelling(serde_json::json!({"Literal": {"Float": "F32"}})).as_deref(),
+            Some("f32")
+        );
+        assert_eq!(
+            spelling(serde_json::json!({"Literal": {"Bool": null}})).as_deref(),
+            Some("bool")
+        );
 
-        // A named ADT is the element itself, not a pointer to one, so its
-        // size is whatever the struct is — `String` is three words.
-        assert!(!admits(named_adt));
+        // `char` has no `get_type_flag` row, so naming it would hand the descr
+        // a width nothing computed.
+        assert_eq!(spelling(serde_json::json!({"Literal": "Char"})), None);
+        // A named ADT is the element itself, not a pointer to one, so its size
+        // is whatever the struct is — `String` is three words.
+        assert_eq!(spelling(named_adt.clone()), None);
+
+        let thin = |ty: serde_json::Value| json_ty_is_thin_pointer_element(&ty, &llbc);
+        assert!(thin(
+            serde_json::json!({"Ref": ["_", named_adt.clone(), "Shared"]})
+        ));
+        assert!(thin(serde_json::json!({"RawPtr": [named_adt, "Mut"]})));
+        assert!(!thin(uint("U8")));
     }
 
     /// `[T]`, `str` and `dyn Trait` each have two Charon spellings — a
     /// top-level `{"Slice": elem}` and the `{"Adt": {"id": {"Builtin":
-    /// "Slice"}}}` form.  A pointer to any of them is fat, and the width
-    /// proof has to decline BOTH spellings: a list of the unsized shapes
-    /// would answer "sized" for whichever one it forgot.
+    /// "Slice"}}}` form.  A pointer to any of them is fat, and the width proof
+    /// has to decline BOTH spellings: a list of the unsized shapes would
+    /// answer "sized" for whichever one it forgot.
     #[test]
     fn both_charon_spellings_of_an_unsized_pointee_decline() {
         let llbc = llbc_with_trait_impls(serde_json::json!([]));
         let borrow = |pointee: serde_json::Value| {
-            json_ty_is_word_sized_array_element(
+            json_ty_is_thin_pointer_element(
                 &serde_json::json!({"Ref": ["_", pointee, "Shared"]}),
                 &llbc,
             )

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -8120,6 +8120,38 @@ pub fn stale_absent_containers() -> Vec<String> {
         .collect()
 }
 
+/// One struct's field map holds both spellings a field descriptor can carry:
+/// the bare `field` and the `STRUCT.field` form `PyreFieldDescr` stores, which
+/// `get_field_descr` composes, and a single map mixes them — `W_TupleObject`'s holds
+/// `wrappeditems` and `hash` bare beside `PyObject.w_class` and
+/// `W_TupleObject.w_dict`. Which one a field arrives under depends on the
+/// producer that reached it first, so an analyzer member naming the field
+/// bare cannot be resolved by exact match alone. `all_fielddescrs`'s
+/// field-walk already joins the two forms this way.
+///
+/// A suffix hit still has to be unique. Two qualified keys can end in the
+/// same field — an inherited name redeclared by a subclass — and that IS the
+/// identity split the caller must not paper over, so it stays unresolved.
+fn lookup_field_by_either_spelling<'m>(
+    fields: &'m indexmap::IndexMap<String, std::sync::Arc<majit_ir::descr::SimpleFieldDescr>>,
+    field_name: &str,
+) -> Option<&'m std::sync::Arc<majit_ir::descr::SimpleFieldDescr>> {
+    if let Some(fd) = fields.get(field_name) {
+        return Some(fd);
+    }
+    let needle = format!(".{field_name}");
+    let mut hit = None;
+    for (stored, fd) in fields {
+        if stored.ends_with(&needle) {
+            if hit.is_some() {
+                return None;
+            }
+            hit = Some(fd);
+        }
+    }
+    hit
+}
+
 fn descr_from_set_member(m: &majit_ir::effectinfo::DescrSetMember) -> SetMemberLookup {
     use majit_ir::descr::{LLType, gc_cache};
 
@@ -8132,7 +8164,7 @@ fn descr_from_set_member(m: &majit_ir::effectinfo::DescrSetMember) -> SetMemberL
             let struct_key = LLType::Struct(*struct_id);
             let gc = gc_cache().lock().unwrap();
             match gc._cache_field.get(&struct_key) {
-                Some(inner) => match inner.get(field_name.as_str()) {
+                Some(inner) => match lookup_field_by_either_spelling(inner, field_name) {
                     Some(fd) => SetMemberLookup::Resolved(fd.clone() as majit_ir::DescrRef),
                     None => SetMemberLookup::Ambiguous,
                 },


### PR DESCRIPTION
An `ArrayRead` addresses its element as `base + index * itemsize`, and the
descr the `Vec<T>` / `core::slice::index` legs minted carried **one target
word** as that itemsize. RPython can leave that implicit — every non-primitive
there is a one-word GC pointer — but a Rust `Vec<T>` stores `T` inline, so a
`Vec<u8>` strides 1 and a `Vec<String>` strides 24 while both were read 8 bytes
at a time. `ValueType` cannot contradict it: `Unsigned` is one width-less
variant spanning `u8` through `usize`, and every non-primitive shape flattens to
`Ref(None)`.

### The width now comes from the element type

`tyref_index_element_node` peels exactly one reference level off the
`&T` / `&mut T` destination — `strip_ty_wrappers` peels `Ref` repeatedly and its
own doc says it cannot be used for this — and the site then takes one of three
routes:

- **a scalar names itself.** `get_array_descr` keys the descr cache on the ARRAY
  lltype and takes its item size from `get_array_token`; there is no
  identity-less array upstream. `json_ty_scalar_element_spelling` renders the
  Rust spelling of an element whose exact width `get_type_flag` computes, and
  the leg passes it as `array_type_id`, so `u8` strides 1 and `u16` strides 2.
- **a thin pointer stays unnamed** — the identity-less mint already sizes it as
  one target word, and `get_type_flag`'s reference fallback agrees.
- **anything else stays residual**, where Rust computes the address itself:
  multi-word aggregates, `&str`/`&[T]`, and `char`, which has no `get_type_flag`
  row (naming it would hand the descr a width nothing computed).

Thinness is decided by whitelist, deliberately. `[T]`, `str` and `dyn Trait`
each have **two** Charon spellings — a top-level `{"Slice": elem}` and the
`{"Adt": {"id": {"Builtin": "Slice"}}}` form — so a list of the unsized shapes
answers "sized" for whichever one it forgets. An earlier blacklist draft of this
predicate admitted 10 fat pointers and was green on every suite.

Census over the extracted `majit-rlib`, `pyre-object`, `pyre-jit` and
`pyre-interpreter` artefacts, both unfenced legs (the `pyre_`-fenced workspace
leg is unchanged):

| | workspace | scalar (named) | thin pointer | residual |
|---|---|---|---|---|
| majit-rlib | 0 | 5 | 0 | 8 |
| pyre-object | 3 | 4 | 11 | 11 |
| pyre-jit | 15 | 48 | 0 | 209 |
| pyre-interpreter | 35 | 182 | 152 | 156 |

The named elements are 101 `u8`, 43 `i64`, 42 `usize`, 22 `bool`, 9 `u32`,
8 `i16`, 6 `f64`, 3 `u16`, 2 `u64`, 2 `i32`, 1 `isize` — `w_bytearray_getitem`,
`rutf8::create_utf8_index_storage`, the `rbigint` digit readers and
`type_methods::parse_spec` among them. `build_semantic_program_from_llbc` still
accepts all four artefacts.

### A field member is resolvable under either spelling

Changing which producer reaches a field first detonated a latent bug: a field
descriptor reaches `_cache_field` under the bare `field` **or** the
`STRUCT.field` form `get_field_descr` composes, and one struct's map mixes them
— `W_TupleObject`'s holds `wrappeditems` and `hash` beside `PyObject.w_class`
and `W_TupleObject.w_dict`. `descr_from_set_member` looked members up by exact
match only, so a member naming a field bare read as `Ambiguous` whenever the
qualified spelling won the race, and `stamp_effect_info_descr` panicked during
JIT init on every fixture and every backend. The field-walk in `all_fielddescrs`
already joins the two forms by suffix; the resolver now does the same, with a
uniqueness check so a genuine two-keys-one-name split still refuses to resolve.

### Also here

Four `dispatch.rs` arms that record an op by hand were missing the heapcache
effects the funnel's upstream caller performs around the record —
`heapcache.new` + `class_now_known` for `BC_NEW`, the invalidation and
`setfield` for `BC_SETFIELD_GC`, all four ops `BC_NEWLIST_CLEAR` composes, and
the pools `GETARRAYITEM_GC_R` cache hit, which now compares against the concrete
load and records a fallback on mismatch the way `_do_getarrayitem_gc_any` does.
`resume_box_reader.rs` / `box_trace.rs` are the house pattern these follow.

### Gates

- `pyre/check.py` **ALL PASSED** — dynasm 483/483, cranelift 483/483,
  wasm 475/475, 3/3 backend runs. No `.jitstats` baseline moved in either
  direction.
- majit-metainterp 1874, majit-trace 67, majit-translate 3399 (2 new tests),
  majit-macros 166; `cargo check --workspace` under `MAJIT_LLBC_EXTRACTION=1`;
  `cargo fmt --all --check`.
- aheui logo: exit 42, 996310 bytes, md5 `7fcdbfff0af449c4283c008e3ca317ce`,
  `--jit == --no-jit`; metacircular 99bottles: exit 99, 11782 bytes,
  byte-identical.

— *authored by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Exposed stack-pointer diagnostics for frontend integrations.
  - Improved support for resolving serialized fields using qualified names.
  - Added broader support for array element layout and pointer types.

- **Bug Fixes**
  - Improved tracing cache consistency for object allocation, field stores, array reads, and list creation.
  - Corrected handling of scalar element widths and unsupported array element types.

- **Documentation**
  - Expanded guidance for virtualizable tracing behavior and diagnostic reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->