### PR TITLE
jit-trace: wasm word-ABI residual bridges, sub-walk snapshot rollback, and the subscr_specialised_pair retirement

### DIFF
--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -3765,9 +3765,22 @@ impl<'a> Transformer<'a> {
             && let Some(variant) = sum_variant_ctor(target)
             && let ValueType::Ref(Some(owner)) = result_ty
         {
+            // No fallback: `sum_variant_ctor` matched the ctor's variant leaf,
+            // so the result owner is that variant's class and the suffix is
+            // there. Keeping the unstripped owner instead would aim the
+            // `__discriminant` write at the variant class rather than the enum
+            // base, and would send a payload-less variant's allocation back to
+            // the zero-sized descr the walker refuses — both silent, and
+            // neither ever right. Fail where the assumption breaks, like the
+            // `expect` on the ctor's result below.
             let result_base = owner
                 .strip_suffix(format!("::{}", variant.leaf).as_str())
-                .unwrap_or(owner)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "niladic sum variant ctor owner `{owner}` must end with `::{}`",
+                        variant.leaf
+                    )
+                })
                 .to_string();
             let alloc_owner = if variant.carries_payload {
                 owner.clone()
@@ -11782,6 +11795,70 @@ mod tests {
                 && field.owner_root.as_deref()
                     == Some("core::result::Result<i64,PyError>")
                 && value.value == crate::flowspace::model::ConstValue::Int(1)
+        ));
+    }
+
+    /// The payload-less half of the same arm: `Option::None` has no fields, so
+    /// `New` on the variant class would resolve to a zero-sized descr the
+    /// collector never issued a type id for (`UnregisteredNewGcType`). The
+    /// value it builds is a bare tag, which the enum base's shell carries, so
+    /// the allocation goes there while the tag write keeps the base owner the
+    /// payload-carrying variant already uses.
+    #[test]
+    fn niladic_payload_less_variant_allocates_the_enum_base() {
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config);
+        let mut graph = FunctionGraph::new("option_none_malloc");
+        let result_var = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let base = "core::option::Option<i64>".to_string();
+        let owner = format!("{base}::None");
+        let target = CallTarget::synthetic_transparent_ctor_with_owner(
+            vec![
+                "core".to_string(),
+                "option".to_string(),
+                "Option<i64>".to_string(),
+            ],
+            "None",
+        );
+        let result_ty = ValueType::Ref(Some(owner.clone()));
+        let op = SpaceOperation {
+            result: Some(result_var.clone()),
+            kind: OpKind::Call {
+                target: target.clone(),
+                args: vec![],
+                result_ty: result_ty.clone(),
+            },
+        };
+
+        let RewriteResult::Replace(ops) = transformer.rewrite_op_direct_call(
+            &op,
+            &target,
+            &[],
+            &result_ty,
+            "option_none_malloc",
+            &mut graph,
+        ) else {
+            panic!("niladic Option variant must lower to malloc + tag store");
+        };
+        assert_eq!(ops.len(), 2);
+        assert!(matches!(
+            &ops[0],
+            SpaceOperation {
+                result: Some(result),
+                kind: OpKind::New { owner: allocated },
+            } if result == &result_var && allocated == &base
+        ));
+        assert!(matches!(
+            &ops[1].kind,
+            OpKind::FieldWrite {
+                base: write_base,
+                field,
+                value: crate::model::LinkArg::Const(value),
+                ty: ValueType::Int,
+            } if write_base == &result_var
+                && field.name == "__discriminant"
+                && field.owner_root.as_deref() == Some(base.as_str())
+                && value.value == crate::flowspace::model::ConstValue::Int(0)
         ));
     }
 

--- a/pyre/bench/synth/pure_tupleload.py
+++ b/pyre/bench/synth/pure_tupleload.py
@@ -1,6 +1,7 @@
 # pyre-check: max-pypy-ratio=6
-# The ceiling sits between the two measured states: folded this runs 2.6x
-# pypy, and with `subscr_specialised_pair` suppressed about 198x.
+# The ceiling sits between the two measured states: served this runs 2.6x pypy,
+# and with the arity-2 reader off the loop pays the opaque residual (about 198x
+# when the retired `subscr_specialised_pair` fold was the only reader).
 # #171/#11 Approach C, SUBSCRIPT slice: canonical-tuple `t[i]` emits a PURE
 # getarrayitem in the JIT walker (OptPure CSEs / const-folds the element load).
 #
@@ -12,9 +13,10 @@
 # the trace-time `ob_type == &TUPLE_TYPE` gate declines it to the non-pure /
 # residual path. It MUST NOT SIGSEGV and MUST stay correct.
 #
-# Case C builds a fresh arity-2 pair per iteration and reads both halves, which
-# is the `subscr_specialised_pair` fold's own shape. Suppressing that one fold
-# measures 46.3x here (0.092s -> 4.257s), the largest single-fold effect in the
+# Case C builds a fresh arity-2 pair per iteration and reads both halves. This
+# is the shape `subscr_tuple_descent` serves by descending `w_tuple_getitem`;
+# the hand-written `subscr_specialised_pair` reader it replaced measured 46.3x
+# here when suppressed (0.092s -> 4.257s), the largest single-fold effect in the
 # corpus, so this loop is what keeps the ceiling below honest.
 
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4700,6 +4700,22 @@ pub(crate) unsafe fn abs_uses_builtin(obj: PyObjectRef) -> bool {
     .any(|tp| std::ptr::eq(src, pyre_object::get_instantiate(tp)))
 }
 
+/// Word-ABI residual bridge for [`abs_uses_builtin`].
+///
+/// The residual-call ABI is uniformly `(i64xn) -> i64`
+/// (`majit-backend-wasm/src/codegen.rs residual_call_i64_arity`), while
+/// `fn(PyObjectRef) -> bool` is `(i32) -> i32` on wasm32, so publishing the
+/// Rust function itself makes the direct `call_indirect` trap on a table-entry
+/// type mismatch.  Word-width agreement on 64-bit targets hides the
+/// difference there.  `jit_force_vref` (`pyre-jit-trace/src/helpers.rs`) is
+/// the same bridge for the same reason.
+///
+/// The receiver arrives as the residual word carrying a live `PyObjectRef`,
+/// which is what the caller already guarantees for the wrapped call.
+pub(crate) extern "C" fn bh_abs_uses_builtin(obj: i64) -> i64 {
+    i64::from(unsafe { abs_uses_builtin(obj as usize as PyObjectRef) })
+}
+
 fn builtin_abs_obj(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     // operation.py `abs` → `space.abs` → descroperation `_make_unaryop_impl`
     // (`__abs__`).  The exact-type shortcut is `use_special_method_shortcut`:

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1461,19 +1461,28 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     // Two helpers a descent reaches on an executed path and cannot get past:
     // neither is given a jitcode, so the codewriter residualizes the call, and
     // an unpublished residual carries a symbolic funcbox the walker refuses
-    // (`OrthodoxSubWalkTraceUnsupported`). Both signatures are one machine
-    // word per argument and one result word, so the typed helpers bind them.
-    upa1(
+    // (`OrthodoxSubWalkTraceUnsupported`).
+    //
+    // Both bind a word-ABI bridge rather than the Rust `fn`. One machine word
+    // per argument is not the contract the direct residual call emits: it is
+    // uniformly `(i64xn) -> i64` (`majit-backend-wasm/src/codegen.rs`
+    // `residual_call_i64_arity`), and on wasm32 a `PyObjectRef` argument is
+    // `i32` and a `bool` result is `i32`, so the raw functions are `(i32) ->
+    // i32` and `(i32, i32, i32) -> i64` — a table-entry type the
+    // `call_indirect` rejects. The mismatch is invisible on 64-bit targets,
+    // where every word agrees. This is the rule `jit_force_vref`
+    // (`pyre-jit-trace/src/helpers.rs`) and `enabled` below already follow.
+    cpa1(
         &mut entries,
         "pyre_interpreter::builtins::abs_uses_builtin",
         "pyre_interpreter::abs_uses_builtin",
-        crate::builtins::abs_uses_builtin,
+        crate::builtins::bh_abs_uses_builtin,
     );
-    upa3(
+    cpa3(
         &mut entries,
         "pyre_object::bytearrayobject::w_bytearray_find",
         "pyre_object::w_bytearray_find",
-        pyre_object::bytearrayobject::w_bytearray_find,
+        pyre_object::bytearrayobject::bh_w_bytearray_find,
     );
     // `gc_interp::enabled` reads (and lazily inits) the `STATE` atomic, and
     // `longobject::bigint_gc_type_id` /

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -375,7 +375,6 @@ pub const SPEC_FOLD_ROWS: &[(&str, &str, &str)] = &[
     ("unpack",                    "residual_call", "-"),
     ("subscr_tuple_descent",      "specialize",    "subscr"),
     ("subscr_tuple",              "specialize",    "subscr"),
-    ("subscr_specialised_pair",   "specialize",    "subscr"),
     ("subscr_str",                "specialize",    "subscr"),
     ("builtin_divmod_long_int",   "specialize",    "builtin_divmod"),
     ("zip_two_tuple_iters",       "specialize",    "for_iter_next"),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -4995,7 +4995,7 @@ pub(crate) fn try_walker_specialize_newlist<Sym: WalkSym>(
 /// self-consistent, but a side exit hands a real pair — inline `value0` /
 /// `value1`, no `wrappeditems` block — to whatever consumer the trace picked
 /// for the canonical layout, and
-/// [`try_walker_specialize_subscr_specialised_pair`] then reads a field that is
+/// [`try_walker_orthodox_subscr_tuple_item`] then reads a field that is
 /// not there.
 ///
 /// Returns `Ok(Some(()))` when folded; `Ok(None)` falls through to the opaque
@@ -6645,21 +6645,6 @@ pub(crate) fn try_walker_specialize_subscr<Sym: WalkSym>(
         });
     }
 
-    // The arity-2 specialisations reach the same `getitem`, but their items
-    // are the inline `value0`/`value1` slots, so they need their own reader —
-    // which is why the gate above is `ob_type == &TUPLE_TYPE` and not
-    // `is_tuple()`. No `w_class` guard: only a specialisation carries its own
-    // `ob_type`, so a tuple subclass (which keeps `&TUPLE_TYPE`) can never
-    // pass the class guard below.
-    if let Some(pair_kind) = specialised_pair_kind(unsafe { (*list_obj).ob_type }) {
-        return spec_gate("subscr_specialised_pair", || {
-            try_walker_specialize_subscr_specialised_pair(
-                ctx, op_pc, list_op, key_op, list_obj, key_obj, pair_kind, allboxes, call_descr,
-                dst, dst_bank,
-            )
-        });
-    }
-
     // The `dict.lookup` gate.  Both `w_class` checks are load-bearing: a dict
     // SUBCLASS shares `ob_type == &DICT_TYPE` but retags `w_class` and reaches
     // `__missing__` on a miss, and a str SUBCLASS key may override `__hash__` /
@@ -7118,7 +7103,8 @@ pub(crate) fn try_walker_specialize_subscr_tuple<Sym: WalkSym>(
 /// receiver class and item index are both known at trace time, instead of
 /// re-emitting that body's length test and field reads by hand.
 ///
-/// This is the orthodox shape `subscr_specialised_pair` stands in for:
+/// This is the orthodox shape, and it replaced the hand-written
+/// `subscr_specialised_pair` reader that stood in for it:
 /// upstream's `getitem` is an ordinary graph the tracer inlines
 /// (`specialisedtupleobject.py`, whose `getitem` unrolls `iter_n` to the
 /// matching `value%s`), and the callee's `ob_type` chain folds against the
@@ -7364,81 +7350,6 @@ fn try_walker_specialize_subscr_str<Sym: WalkSym>(
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, raw)?;
     Ok(Some(()))
 }
-
-/// SUBSCRIPT arm for the arity-2 tuple specialisations
-/// (`specialisedtupleobject.py getitem`), the analogue of
-/// [`try_walker_specialize_subscr_tuple`] for a receiver whose items are the
-/// inline `value0` / `value1` slots instead of a `wrappeditems` block.
-///
-/// Upstream `getitem` normalises a negative index against the constant
-/// `typelen` and then runs the unrolled `index == i` chain to pick the slot,
-/// so the recorded slot is pinned here with a single `guard_value` on the
-/// unboxed index: it re-proves both the sign test and the comparison at once,
-/// and a literal subscript makes it constant, which the optimizer drops.
-///
-/// The caller matched `ob_type` against one of the three specialisation
-/// classes, which is also why no `w_class` guard follows: a tuple subclass
-/// instance keeps the canonical `ob_type == &TUPLE_TYPE`, so it can neither
-/// reach this arm nor pass the class guard below.
-///
-/// A slice key, a non-int key, or an out-of-range index falls through to the
-/// generic residual (`Ok(None)`), which raises `IndexError` the way `getitem`
-/// does.
-#[allow(clippy::too_many_arguments)]
-fn try_walker_specialize_subscr_specialised_pair<Sym: WalkSym>(
-    ctx: &mut WalkContext<'_, '_, Sym>,
-    op_pc: usize,
-    seq_op: OpRef,
-    key_op: OpRef,
-    seq_obj: pyre_object::PyObjectRef,
-    key_obj: pyre_object::PyObjectRef,
-    pair_kind: SpecialisedPairKind,
-    allboxes: &[OpRef],
-    call_descr: &dyn majit_ir::descr::CallDescr,
-    dst: usize,
-    dst_bank: char,
-) -> Result<Option<()>, DispatchError> {
-    const TYPELEN: i64 = 2;
-    // `bool` shares int's `intval`, so it indexes through its own &BOOL_TYPE
-    // guard in the unbox below.
-    let raw_key = unsafe {
-        if !pyre_object::is_int(key_obj) {
-            return Ok(None);
-        }
-        pyre_object::w_int_get_value(key_obj)
-    };
-    let index = if raw_key < 0 {
-        raw_key + TYPELEN
-    } else {
-        raw_key
-    };
-    if !(0..TYPELEN).contains(&index) {
-        return Ok(None);
-    }
-
-    let spec_type = unsafe { (*seq_obj).ob_type };
-    walker_guard_specialised_pair_class(ctx, op_pc, seq_op, spec_type)?;
-
-    let (idx_type, idx_descr) = crate::state::int_or_bool_unbox_type_descr(key_obj);
-    let raw_index = walker_unbox_int_typed(ctx, op_pc, key_op, idx_type, idx_descr)?;
-    ctx.trace_ctx
-        .set_opref_concrete(raw_index, majit_ir::Value::Int(raw_key));
-    let expected = ctx.trace_ctx.const_int(raw_key);
-    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[raw_index, expected])?;
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .replace_box(raw_index, expected);
-
-    let Some(item) = walker_emit_specialised_pair_item(
-        ctx, op_pc, seq_op, pair_kind, index, allboxes, call_descr,
-    )?
-    else {
-        return Ok(None);
-    };
-    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, item)?;
-    Ok(Some(()))
-}
-
 fn is_builtin_dict_get_function(callable: pyre_object::PyObjectRef) -> bool {
     if callable.is_null() || !unsafe { pyre_interpreter::is_function(callable) } {
         return false;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -7214,11 +7214,17 @@ fn try_walker_orthodox_subscr_tuple_item<Sym: WalkSym>(
         // The body reached a helper this build did not lower.  Nothing is
         // committed yet -- the read has no effect to undo -- so cut the
         // tentative IR and let the generic residual serve the subscript.
+        //
+        // The snapshots go with it: the class guard and the `GuardValue` on
+        // the frozen key are both emitted above with snapshots attached, and
+        // those name the discarded operation namespace, so leaving them in
+        // the side table exposes stale boxes once a later optimizer remaps
+        // every published snapshot.
         Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc, .. }) => {
             if fbw_debug_abort_enabled() {
                 eprintln!("[decline-why] SUBSCR-TUPLE-SUBWALK pc={pc}");
             }
-            ctx.trace_ctx.cut_trace(pre_fold_pos);
+            ctx.trace_ctx.cut_trace_with_snapshots(pre_fold_pos);
             ctx.trace_ctx.heap_cache_mut().reset();
             return Ok(None);
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -4042,7 +4042,7 @@ pub(crate) fn try_walker_specialize_load_type_name_attr<Sym: WalkSym>(
 
 /// Fold `LOAD_ATTR` on a type receiver when
 /// [`pyre_interpreter::type_attr_value_fast_path`] proves that
-/// `typeobject.py:811-828` returns the class-MRO value unchanged.  The exact
+/// `typeobject.py` `getattribute` returns the class-MRO value unchanged.  The exact
 /// receiver and its version tag are pinned before the value is written as a
 /// green constant.  [`pyre_interpreter::mutated`] recursively invalidates
 /// subclasses, so the one receiver pin covers reassignment or deletion on any
@@ -8023,7 +8023,7 @@ pub(crate) fn try_walker_specialize_builtin_len<Sym: WalkSym>(
 
 /// Fold plain `getattr(type, name)` when
 /// [`pyre_interpreter::type_attr_value_fast_path`] proves that
-/// `typeobject.py:811-828` returns the class-MRO value unchanged.  The exact
+/// `typeobject.py` `getattribute` returns the class-MRO value unchanged.  The exact
 /// callable, exact receiver, exact name object, and receiver version are pinned
 /// before the value is written as a green constant.  Pinning the callable makes
 /// a rebound `getattr` side-exit instead of continuing to use the folded value.

--- a/pyre/pyre-object/src/bytearrayobject.rs
+++ b/pyre/pyre-object/src/bytearrayobject.rs
@@ -329,6 +329,21 @@ pub unsafe fn w_bytearray_find(obj: PyObjectRef, value: u8, start: usize) -> i64
     }
 }
 
+/// Word-ABI residual bridge for [`w_bytearray_find`].
+///
+/// The residual-call ABI is uniformly `(i64xn) -> i64`
+/// (`majit-backend-wasm/src/codegen.rs residual_call_i64_arity`), while
+/// `fn(PyObjectRef, u8, usize) -> i64` is `(i32, i32, i32) -> i64` on wasm32,
+/// so publishing the Rust function itself makes the direct `call_indirect`
+/// trap on a table-entry type mismatch.  Word-width agreement on 64-bit
+/// targets hides the difference there.
+///
+/// The three residual words carry the receiver, the byte value and the start
+/// index the wrapped call already requires.
+pub extern "C" fn bh_w_bytearray_find(obj: i64, value: i64, start: i64) -> i64 {
+    unsafe { w_bytearray_find(obj as usize as PyObjectRef, value as u8, start as usize) }
+}
+
 /// Concatenate bytearray + bytes (b'\0' * N pattern).
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime


### PR DESCRIPTION
Follow-up to #1473. Four of that PR's seven review findings are fixed here; one
fold is retired on census evidence.

## Review findings fixed

**Codex P1 — `abs_uses_builtin` residual traps on wasm32** (`jit_fnaddr.rs`)

Confirmed. The residual-call ABI is uniformly `(i64xn) -> i64`
(`majit-backend-wasm/src/codegen.rs` `residual_call_i64_arity`), but
`fn(PyObjectRef) -> bool` lowers to `(i32) -> i32` on wasm32, so the direct
`call_indirect` fails table-entry type validation. `ResidualSlot`/`ResidualRet`
bound arity and word-ness, not wasm type, so nothing caught this.

Added `extern "C"` word-ABI bridges and moved both registrations off the raw-fn
helpers: `abs_uses_builtin` -> `bh_abs_uses_builtin` (`upa1` -> `cpa1`), and the
same defect found by inspection in `w_bytearray_find` -> `bh_w_bytearray_find`
(`upa3` -> `cpa3`).

**CodeRabbit Minor — subscript sub-walk cut leaves snapshots behind** (`specialize.rs`)

Confirmed. `TraceCtx::cut_trace` truncates recorded operations only;
`cut_trace_with_snapshots` also truncates `TraceCtx::snapshots`. The
`OrthodoxSubWalkTraceUnsupported` arm used the former, so discarded guard
snapshots survived the rollback and could expose stale boxes once the fallback
emitted new guards. Switched to `cut_trace_with_snapshots(pre_fold_pos)`.

**CodeRabbit Trivial — niladic ctor owner suffix fell back silently** (`jtransform.rs`)

Confirmed. `strip_suffix` fell back to the unstripped `owner`, which would write
`__discriminant` against the wrong `owner_root` if the `Base::Leaf` convention
drifted. Replaced with a panic and added
`niladic_payload_less_variant_allocates_the_enum_base`, covering the
`carries_payload == false` branch the existing test did not reach.

**CodeRabbit — citation by line number** (`specialize.rs`)

Two `typeobject.py:811-828` references replaced with the symbol name
`getattribute`. Line-number citations go stale; both sites were pre-existing.

## Fold retirement

`subscr_specialised_pair` is removed (`SPEC_FOLD_ROWS` 73 -> 72), along with its
gate site, `try_walker_specialize_subscr_specialised_pair`, and the doc
references that named it.

Evidence: a `PYRE_FBW_SPEC_CENSUS=1` sweep over all 474 corpus fixtures reports
`consulted=0` for this label everywhere. The gate site is never reached, because
`subscr_tuple_descent` takes the site first by descending `w_tuple_getitem`.
This is unreachability, not neutrality — a wall-clock A/B alone would only have
shown equal timings and could not distinguish the two.

## Findings not addressed, and why

**Codex P1 — Option aggregates need a non-overlapping shell.** Premise verified:
`front::mir::synthetic_result_shell` reserves the `[tag@0 | payload@8]` shell
only for `core::result::Result`, and `tyref_is_niche_option_ptr` diverts only
pointer payloads, so a non-pointer niche `Option` can alias its tag with its
payload. The cited witness does not hold: `_abc::simple_weak_set_contains` is
absent from the image and no `Option<bool>` descr exists in it; all 50 measured
`Option::Some` payloads sit at `Ref@0`/size 8. Filed as latent with zero current
reach.

A follow-up check corrected the remedy, not the defect: the guard *is* expressible
in `jtransform` (`self.callcontrol.as_deref()` and `CallControl::struct_layout_for`
are both in scope there), but declining on a disjointness test degenerates to an
unconditional decline of both Option ctor arms, and a decline here is a
per-execution `reject_symbolic_residual_call` abort rather than a compile-time
skip — a guaranteed deopt with no correctness fix under it. The real remedy is to
give `Option` the same synthetic shell `Result` has, in `front::mir`, which is left
for separate work.

**Codex P1 — LLBC assertions should match the consuming build profile.** The
premise is true, but the remedy trades one divergence for another: matching the
dev profile puts `debug_assert!` bodies into every generated JIT path. Left
unchanged; the residual cost is that dev/test builds lose debug-assert coverage
on JIT paths.

**CodeRabbit Major — match the used box by carried producer identity.** The
premise is accurate: `record_imported_preamble_use` stores the carried operand's
`OpRef` while `add_tracked_preamble_op` stores the replay position. The
conclusion does not follow. `used_boxes.push` and `short_preamble_jump.push` are
performed in lockstep, so the two keyings cannot disagree for an entry this
branch inspects. No change.

---

*Reviews adjudicated by Claude.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of payload-less `Option::None` values so they allocate the appropriate enum storage and retain the correct discriminant.
  - Improved reliability of built-in absolute-value and bytearray search operations across supported runtime environments, including WebAssembly.

- **Performance**
  - Streamlined tuple access specialization and tracing behavior for more consistent execution of tuple-based operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->