### PR TITLE
deps: bump the pinned RustPython rev; launcher: accept -v and -d

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3243,7 +3243,7 @@ dependencies = [
 [[package]]
 name = "rustpython-codegen"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
+source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
 dependencies = [
  "bitflags 2.13.0",
  "indexmap",
@@ -3266,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
+source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
 dependencies = [
  "ascii",
  "bitflags 2.13.0",
@@ -3289,7 +3289,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
+source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
+source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
 dependencies = [
  "bitflags 2.13.0",
  "bitflagset",
@@ -3319,7 +3319,7 @@ dependencies = [
 [[package]]
 name = "rustpython-host_env"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
+source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
 dependencies = [
  "bitflags 2.13.0",
  "cc",
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
+source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
 dependencies = [
  "hexf-parse",
  "is-macro",
@@ -3432,7 +3432,7 @@ dependencies = [
 [[package]]
 name = "rustpython-sre_engine"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
+source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
 dependencies = [
  "bitflags 2.13.0",
  "num_enum",
@@ -3444,7 +3444,7 @@ dependencies = [
 [[package]]
 name = "rustpython-unicode"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
+source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
 dependencies = [
  "icu_casemap",
  "icu_locale",
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "rustpython-wtf8"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201#48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201"
+source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
 dependencies = [
  "ascii",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,16 +72,16 @@ pyrex = { version = "0.0.2", path = "pyre/pyrex" }
 # parity fixes from #8550 were merged.  `fix_code_filenames` needs `IndexMut`
 # to edit nested code constants in place, and `loads` relies on the #8552 hook
 # to preserve invalid code bytes, so this pin must not move below either.
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
-rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
-rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
-rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
+rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
+rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
+rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
 ruff-text-size = { package = "rustpython-ruff_text_size", git = "https://github.com/RustPython/ruff.git", tag = "0.15.19-rustpython" }
 num-complex = "0.4"
-rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
-rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
-rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
-sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "48a3a1f8e04eb4f1ea16c6324e936e6ece3f0201" }
+rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
+rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
+rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
+sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
 
 # majit JIT framework
 majit = { version = "0.0.2", path = "majit/majit" }

--- a/pyre/extra_tests/parity_tests/launcher_faulthandler_pycache_prefix.py
+++ b/pyre/extra_tests/parity_tests/launcher_faulthandler_pycache_prefix.py
@@ -1,0 +1,192 @@
+# CPython-suite gap: `test_faulthandler` and `test_cmd_line` both reach these
+# through subprocesses, and neither module is in the gated set, so a launcher
+# that silently drops `-X faulthandler` or `-X pycache_prefix` fails nothing.
+# The one gated module that touches the second, `test_importlib`, only reads
+# `sys.pycache_prefix` back -- it never asks a launcher to set it.
+#
+# parity-tests reason: these are the two `-X` options pypy3 implements that
+# pyre did not, and each carries a rule the obvious implementation gets wrong.
+#
+# PYTHONFAULTHANDLER takes the *presence* fold, not the integer one: `=0`
+# enables it, the same as any other non-empty value, and only an empty value
+# reads as unset.  A port that folds it the way PYTHONOPTIMIZE folds is wrong
+# about exactly one spelling, and it is the spelling someone writes when they
+# mean to turn it off.
+#
+# `-X pycache_prefix` is three-state, and the third state has no value to
+# carry: naming the option at all settles the question, so `-X pycache_prefix`
+# and `-X pycache_prefix=` both leave the prefix unset *and* keep
+# PYTHONPYCACHEPREFIX from supplying one.  Only an option nobody named reaches
+# the variable.  A two-state port -- an `Option<String>` filled from the `=`
+# tail -- collapses the bare spelling into "absent" and lets the environment
+# through, which is the one case where a command line asking for no prefix
+# gets one.
+#
+# The prefix is also not merely reported: `_bootstrap_external`
+# `cache_from_source` computes the bytecode path from it, so setting the field
+# is what redirects the write.  That is the half a packager depends on, and
+# `pip` byte-compiles what it installs, so the last check imports a fresh
+# module and looks at where its `.pyc` actually landed.
+import ast
+import os
+import subprocess
+import sys
+import tempfile
+
+# The names under test are read from the environment, so a harness that
+# already carries one would decide the answer.  Every child starts from an
+# environment with all four removed and gets back only what a case asks for.
+SCRUBBED = {
+    name: None
+    for name in (
+        "PYTHONFAULTHANDLER",
+        "PYTHONPYCACHEPREFIX",
+        "PYTHONDONTWRITEBYTECODE",
+        "PYTHONDEVMODE",
+    )
+}
+
+
+def child(args=(), env=None, code=None):
+    """The last stdout line of this interpreter run with `args` and `env`."""
+    environ = dict(os.environ)
+    for name, value in {**SCRUBBED, **(env or {})}.items():
+        if value is None:
+            environ.pop(name, None)
+        else:
+            environ[name] = value
+    out = subprocess.run(
+        [sys.executable, *args, "-c", code or REPORT],
+        capture_output=True,
+        text=True,
+        env=environ,
+    )
+    assert out.returncode == 0, (args, env, out.returncode, out.stderr[-400:])
+    # Only the last line: `-X dev` installs a warning filter, and a child that
+    # prints nothing at all is a legitimate case here.
+    lines = out.stdout.splitlines()
+    return lines[-1].strip() if lines else ""
+
+
+REPORT = (
+    "import faulthandler, sys;"
+    "print(faulthandler.is_enabled(), repr(sys.pycache_prefix))"
+)
+
+
+def state(args=(), env=None):
+    enabled, prefix = child(args, env).split(" ", 1)
+    return enabled == "True", ast.literal_eval(prefix)
+
+
+assert state() == (False, None)
+
+# -- faulthandler ---------------------------------------------------------
+# `run_command_line` installs nothing at all unless `'faulthandler' in
+# sys.builtin_module_names`, and that guard is not decoration: pypy drops the
+# module from `working_modules` on Windows (`pypy/config/pypyoption.py:78`), so
+# on that one pairing every spelling below is a no-op by upstream's own rule
+# rather than by a divergence.  Taking the guard here keeps the lane asserting
+# something on that build instead of skipping it, and costs nothing where the
+# module is present -- 3.14, pypy3 off Windows, and pyre on every platform all
+# report it builtin, so `INSTALLS` is True for each of them.
+INSTALLS = "faulthandler" in sys.builtin_module_names
+
+assert state(["-X", "faulthandler"]) == (INSTALLS, None)
+# `run_command_line` tests `'faulthandler' in sys._xoptions`, so the option
+# answers to its KEY: every value installs the handlers, `=0` included, which is
+# not a way to ask for them to stay off.  An exact match on the whole option
+# passes the bare spelling above and silently drops these three.
+for spelled in ("faulthandler=1", "faulthandler=0", "faulthandler="):
+    assert state(["-X", spelled]) == (INSTALLS, None), spelled
+# Keyed, not merely prefixed: a longer name is a different option.
+assert state(["-X", "faulthandlerx"]) == (False, None)
+# The rule is per-option, not a blanket: `-X dev` is read by VALUE, so pypy3
+# leaves developer mode off for `-X dev=1` while CPython turns it on.  pyre
+# follows pypy3 there, so that contrast cannot be asserted here -- the two
+# oracles agree on every line this file does pin.
+# Developer mode asks for it too, so it is not only the option that installs --
+# and it asks in either of its spellings, which pins that the variable fold for
+# `dev_mode` happens before this one reads it.
+assert state(["-X", "dev"]) == (INSTALLS, None)
+assert state(env={"PYTHONDEVMODE": "1"}) == (INSTALLS, None)
+# `-X dev` survives `-E`, so an environment that names neither still installs.
+assert state(["-E", "-X", "dev"]) == (INSTALLS, None)
+assert state(env={"PYTHONFAULTHANDLER": "1"}) == (INSTALLS, None)
+# The presence fold, which is what separates this variable from PYTHONOPTIMIZE
+# and PYTHONDONTWRITEBYTECODE: a zero still enables, an empty value does not.
+assert state(env={"PYTHONFAULTHANDLER": "0"}) == (INSTALLS, None)
+assert state(env={"PYTHONFAULTHANDLER": "anything"}) == (INSTALLS, None)
+assert state(env={"PYTHONFAULTHANDLER": ""}) == (False, None)
+# `-E` and `-I` drop the variable; the option survives both.
+assert state(["-E"], env={"PYTHONFAULTHANDLER": "1"}) == (False, None)
+assert state(["-I"], env={"PYTHONFAULTHANDLER": "1"}) == (False, None)
+assert state(["-E", "-X", "faulthandler"], env={"PYTHONFAULTHANDLER": ""}) == (
+    INSTALLS,
+    None,
+)
+
+# -- pycache_prefix -------------------------------------------------------
+assert state(["-X", "pycache_prefix=/tmp/from-option"]) == (False, "/tmp/from-option")
+assert state(env={"PYTHONPYCACHEPREFIX": "/tmp/from-env"}) == (False, "/tmp/from-env")
+# Stored the way it was written: a relative path is not resolved against the
+# working directory on the way in.
+assert state(["-X", "pycache_prefix=relative/dir"]) == (False, "relative/dir")
+# The option outranks the variable, and `-E` drops the variable outright.
+assert state(
+    ["-X", "pycache_prefix=/tmp/from-option"],
+    env={"PYTHONPYCACHEPREFIX": "/tmp/from-env"},
+) == (False, "/tmp/from-option")
+assert state(["-E"], env={"PYTHONPYCACHEPREFIX": "/tmp/from-env"}) == (False, None)
+# The three states.  Both spellings that name the option without naming a
+# directory leave the prefix unset *and* suppress the variable; an empty
+# variable is simply unset.
+assert state(["-X", "pycache_prefix"]) == (False, None)
+assert state(["-X", "pycache_prefix="]) == (False, None)
+assert state(["-X", "pycache_prefix"], env={"PYTHONPYCACHEPREFIX": "/tmp/from-env"}) == (
+    False,
+    None,
+)
+assert state(["-X", "pycache_prefix="], env={"PYTHONPYCACHEPREFIX": "/tmp/from-env"}) == (
+    False,
+    None,
+)
+assert state(env={"PYTHONPYCACHEPREFIX": ""}) == (False, None)
+
+
+def where_the_pyc_lands(use_prefix):
+    """`(under the prefix, beside the source)` after importing a fresh module."""
+    with tempfile.TemporaryDirectory() as root:
+        source_dir = os.path.join(root, "src")
+        prefix = os.path.join(root, "cache")
+        os.mkdir(source_dir)
+        with open(os.path.join(source_dir, "pcpmod.py"), "w") as handle:
+            handle.write("VALUE = 1\n")
+        # A fresh name in a fresh directory, so the import has to compile and
+        # has nothing cached to read instead.
+        child(
+            ["-X", "pycache_prefix=" + prefix] if use_prefix else [],
+            code="import sys; sys.path.insert(0, %r); import pcpmod" % source_dir,
+        )
+
+        # Only this module's bytecode is counted.  A prefix collects the whole
+        # startup import as well -- `encodings`, `linecache` -- and how much of
+        # that a runtime recompiles is its own business, so a total would be
+        # counting the stdlib rather than the redirect.
+        def pcpmod_pyc_count(top):
+            return sum(
+                name.startswith("pcpmod") and name.endswith(".pyc")
+                for _, _, names in os.walk(top)
+                for name in names
+            )
+
+        under = pcpmod_pyc_count(prefix) if os.path.isdir(prefix) else 0
+        return under, pcpmod_pyc_count(source_dir)
+
+
+# The bytecode lands beside the source when nothing redirects it, and under the
+# prefix -- with nothing beside the source at all -- when the option does.  The
+# tag in the filename is the runtime's own, so only the count is compared.
+assert where_the_pyc_lands(False) == (0, 1)
+assert where_the_pyc_lands(True) == (1, 0)
+print("OK")

--- a/pyre/extra_tests/parity_tests/launcher_verbose_debug_flags.py
+++ b/pyre/extra_tests/parity_tests/launcher_verbose_debug_flags.py
@@ -1,0 +1,207 @@
+# pyre-check: pypy-diverges: pypy3 counts `-d` the way it counts `-v`, so it
+# answers 2 for `-dd` where 3.14 saturates `sys.flags.debug` at 1, and its
+# `parse_env` folds on `if v:`, so a `=0` from either variable enables the flag
+# there and leaves it alone here.
+#
+# CPython-suite gap: `test_site` and `test_cmd_line` reach `-v` only by running
+# a subprocess with it, and both modules are outside the gated set, so a
+# launcher that refuses the option outright fails them for a reason that never
+# names the option.  Nothing in the gated set passes `-v` or `-d` at all.
+#
+# parity-tests reason: `-v` and `-d` are the two repeatable options whose whole
+# observable is a `sys.flags` field, and the two fields disagree about what
+# repeating means.  `initconfig.c PYCONFIG_SPEC` declares `verbose` UINT, so
+# `-vv` reports 2; it declares `parser_debug` BOOL, so `-dd` reports 1 even
+# though the config counted to 2.  A port that treats the pair alike is wrong
+# about one of them whichever way it picks -- pypy3 counts both and so answers
+# 2 for `-dd`.
+#
+# `-v` also has a second half that is not a flag: `importlib._bootstrap`'s
+# `_verbose_message` compares `sys.flags.verbose` against the verbosity a
+# message asks for, so setting the field is what makes the import trace appear.
+# The trace's content is the import machinery's, not the launcher's, so what is
+# pinned here is that it reaches stderr at all and that stdout stays clean.
+import os
+import subprocess
+import sys
+
+REPORT = "import sys; print('%d %d' % (sys.flags.verbose, sys.flags.debug))"
+
+# Both variables this file pins are read from the environment, so a parent that
+# already sets one answers every case with its own value instead of the case's
+# -- `flags()` alone reports it, and a set PYTHONVERBOSE also puts a trace on the
+# stderr the quiet rows require to be empty.  Removed for every child; a case
+# that names one puts it back.
+SCRUBBED = {name: None for name in ("PYTHONVERBOSE", "PYTHONDEBUG")}
+
+
+def child_env(env=None):
+    """The parent environment with the two variables this file owns settled."""
+    environ = dict(os.environ)
+    for name, value in {**SCRUBBED, **(env or {})}.items():
+        if value is None:
+            environ.pop(name, None)
+        else:
+            environ[name] = value
+    return environ
+
+
+def flags(args=(), env=None):
+    """`(verbose, debug)` as a child of this interpreter reports them."""
+    out = subprocess.run(
+        [sys.executable, *args, "-c", REPORT],
+        capture_output=True,
+        text=True,
+        env=child_env(env),
+    )
+    assert out.returncode == 0, (args, env, out.returncode, out.stderr[-400:])
+    # `-v` writes its trace to stderr, so the report is still the last line of
+    # stdout on its own.
+    return tuple(int(part) for part in out.stdout.strip().splitlines()[-1].split())
+
+
+assert flags() == (0, 0)
+
+# Repeating counts, and the two fields part company at the second one.
+assert flags(["-v"]) == (1, 0)
+assert flags(["-vv"]) == (2, 0)
+assert flags(["-vvv"]) == (3, 0)
+assert flags(["-d"]) == (0, 1)
+assert flags(["-dd"]) == (0, 1)
+assert flags(["-v", "-d"]) == (1, 1)
+
+# The environment variables fold with `max`, so a variable can raise a count
+# the command line already set but never lower it.
+assert flags(env={"PYTHONVERBOSE": "1"}) == (1, 0)
+assert flags(env={"PYTHONVERBOSE": "3"}) == (3, 0)
+assert flags(["-v"], env={"PYTHONVERBOSE": "3"}) == (3, 0)
+assert flags(["-vvvv"], env={"PYTHONVERBOSE": "2"}) == (4, 0)
+# A value that is not a non-negative integer counts as 1, the way every other
+# `_Py_get_env_flag` variable reads one.
+assert flags(env={"PYTHONVERBOSE": "junk"}) == (1, 0)
+assert flags(env={"PYTHONVERBOSE": "-2"}) == (1, 0)
+# An empty value is unset, not zero.
+assert flags(env={"PYTHONVERBOSE": ""}) == (0, 0)
+# `=0` is a value the fold reads and leaves alone.
+assert flags(env={"PYTHONVERBOSE": "0"}) == (0, 0)
+# `_Py_str_to_int` rejects anything outside the C `int` range as overflow
+# (`preconfig.c:554`), and an unreadable value is what becomes 1, so INT_MAX is
+# the last count the variable can spell and everything past it reads as junk.
+# The ceiling is the C type's, not the width of whatever field holds the count.
+assert flags(env={"PYTHONVERBOSE": "2147483647"}) == (2147483647, 0)
+assert flags(env={"PYTHONVERBOSE": "2147483648"}) == (1, 0)
+assert flags(env={"PYTHONVERBOSE": "4294967295"}) == (1, 0)
+
+# `debug` saturates on the way out, so the variable cannot push it past 1.
+assert flags(env={"PYTHONDEBUG": "2"}) == (0, 1)
+assert flags(env={"PYTHONDEBUG": "junk"}) == (0, 1)
+assert flags(env={"PYTHONDEBUG": ""}) == (0, 0)
+# The saturation is the only thing `debug` does differently: `=0` is still a
+# value `_Py_get_env_flag` reads and leaves alone, so naming the variable is not
+# by itself a way to ask for the flag.  `test_cmd_line.test_sys_flags_set`
+# compares against `int(bool(value))` but never passes it a `"0"`, so the case
+# is decided by the fold rather than by that test.
+assert flags(env={"PYTHONDEBUG": "0"}) == (0, 0)
+assert flags(env={"PYTHONDEBUG": "-1"}) == (0, 1)
+
+# `-E` drops both variables; `-I` implies it.
+assert flags(["-E"], env={"PYTHONVERBOSE": "3", "PYTHONDEBUG": "1"}) == (0, 0)
+assert flags(["-I"], env={"PYTHONVERBOSE": "3", "PYTHONDEBUG": "1"}) == (0, 0)
+# The command line survives `-E` -- only the variable half is dropped.
+assert flags(["-E", "-vv"], env={"PYTHONVERBOSE": "3"}) == (2, 0)
+
+
+def import_trace(args):
+    """stderr and stdout of a child that imports one stdlib module."""
+    out = subprocess.run(
+        [sys.executable, *args, "-c", "import json; print('done')"],
+        capture_output=True,
+        text=True,
+        env=child_env(),
+    )
+    assert out.returncode == 0, (args, out.returncode, out.stderr[-400:])
+    return out.stderr, out.stdout
+
+
+quiet_err, quiet_out = import_trace([])
+assert quiet_err == "", quiet_err
+assert quiet_out == "done\n", quiet_out
+
+loud_err, loud_out = import_trace(["-v"])
+# The program's own output is untouched: the trace goes to stderr alone.
+assert loud_out == "done\n", loud_out
+# `_verbose_message` writes `import <name> # <origin>` lines, and the module
+# the child asked for is one of them.
+assert "import 'json'" in loud_err, loud_err[-600:]
+assert loud_err.count("\n") > 20, loud_err.count("\n")
+
+
+# `_Py_str_to_int` runs `strtol`, which steps over leading whitespace before the
+# digits and then refuses whatever it stopped short of, so a value padded on the
+# LEFT is the count it spells.  A parse that rejects both pads reports 1 -- the
+# same answer as `PYTHONVERBOSE=abc` -- and silently downgrades verbosity 2.
+# The right-hand pad is deliberately not pinned: `strtol` stops at it and
+# CPython answers 1 where pypy3's `int()` answers 2.
+assert flags(env={"PYTHONVERBOSE": " 2"}) == (2, 0)
+assert flags(env={"PYTHONVERBOSE": "+2"}) == (2, 0)
+assert flags(env={"PYTHONVERBOSE": "0x2"}) == (1, 0)
+
+
+def stdin_run(args):
+    """stderr and stdout of a child whose program arrives on a pipe."""
+    out = subprocess.run(
+        [sys.executable, *args],
+        input="print('done')\n",
+        capture_output=True,
+        text=True,
+        env=child_env(),
+    )
+    assert out.returncode == 0, (args, out.returncode, out.stderr[-400:])
+    return out.stderr, out.stdout
+
+
+# `run_command_line` heads a non-interactive stdin run with the banner when
+# `verbose` is set, so the trace that follows says which interpreter produced
+# it.  Only the presence is pinned: the three implementations spell their own
+# identification differently, and the line is not first -- the trace of the
+# imports that precede it already is.
+COPYRIGHT_LINE = (
+    'Type "help", "copyright", "credits" or "license" for more information.'
+)
+
+banner_err, banner_out = stdin_run(["-v"])
+assert banner_out == "done\n", banner_out
+assert any(
+    line.startswith(("Python ", "pyre ")) for line in banner_err.splitlines()
+), banner_err[:400]
+# `print_banner(not no_site)` -- the second line is spelled the same everywhere,
+# because what it names is the four builtins `site` installs rather than
+# anything about the interpreter.
+banner_lines = banner_err.splitlines()
+assert COPYRIGHT_LINE in banner_lines, banner_err[:400]
+# The banner follows the startup import trace rather than heading it: what it
+# labels is that trace, so it is printed once `site` and the warnings bootstrap
+# have run, not on the way in.  Pinned as "something precedes it" rather than an
+# index -- the three implementations import a different number of modules -- and
+# the notice follows the identification rather than merely appearing somewhere.
+identification = next(
+    i for i, line in enumerate(banner_lines) if line.startswith(("Python ", "pyre "))
+)
+assert identification > 0, banner_err[:400]
+assert banner_lines.index(COPYRIGHT_LINE) > identification, banner_err[:400]
+# `-S` installs none of them, so the line goes with them while the
+# identification stays.
+site_err, site_out = stdin_run(["-S", "-v"])
+assert site_out == "done\n", site_out
+assert any(
+    line.startswith(("Python ", "pyre ")) for line in site_err.splitlines()
+), site_err[:400]
+assert COPYRIGHT_LINE not in site_err.splitlines(), site_err[:400]
+# Without `-v` there is no banner, and a pipe still is not a prompt.
+plain_err, plain_out = stdin_run([])
+assert plain_out == "done\n", plain_out
+assert not any(
+    line.startswith(("Python ", "pyre ")) for line in plain_err.splitlines()
+), plain_err[:400]
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/syntax_error_python314_offsets.py
+++ b/pyre/extra_tests/parity_tests/syntax_error_python314_offsets.py
@@ -118,4 +118,42 @@ for operator, message in (
         error.end_offset,
     )
 
+# "Perhaps you forgot a comma?" spans both atoms, so it ends past the whole
+# second one.  A width measured in bytes rather than in atoms agrees only when
+# that atom is a single ASCII character, which `(a b)` is and none of these
+# are: the ASCII rows below catch a length assumption and the non-ASCII ones
+# catch a byte-vs-character one.
+for source, offset, end_offset in (
+    ("(a bb)", 2, 6),
+    ("(a bbb)", 2, 7),
+    ("(1 22)", 2, 6),
+    ("(a \u03b2)", 2, 5),
+    ("(a \u03b2\u03b2)", 2, 6),
+    ("(\u03b1\u03b1 \u03b2)", 2, 6),
+    ("[\u03b1 \u03b2]", 2, 5),
+    # The f-string forms reach the same rule through a recursive parse of the
+    # replacement field, and the span has to survive being mapped back onto
+    # the original source.
+    ("f'{a bb}'", 4, 8),
+    ("f'{\u03b1\u03b1 \u03b2}'", 4, 8),
+    ("f'{a \u03b2}'", 4, 7),
+):
+    error = syntax_error(source)
+    assert error.msg == "invalid syntax. Perhaps you forgot a comma?", (
+        source,
+        error.msg,
+    )
+    assert (error.lineno, error.offset, error.end_lineno, error.end_offset) == (
+        1,
+        offset,
+        1,
+        end_offset,
+    ), (
+        source,
+        error.lineno,
+        error.offset,
+        error.end_lineno,
+        error.end_offset,
+    )
+
 print("OK")

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -20254,14 +20254,13 @@ mod tests {
     #[test]
     fn fstring_missing_comma_uses_recursive_expression_range() {
         assert_eq!(fstring_missing_comma_span("f'{6 0}'", 5), Some((3, 6)));
-        // A range whose end falls inside a multi-byte character is reported
-        // one character short, because `character_offset` counts the
-        // characters up to the byte the range ends at and a byte inside a
-        // scalar counts as the character before it.  The span is still worth
-        // projecting: `4, 6` under the message the recursive parse found
-        // beats `6, 7` under `f-string: expecting '}'`, which is what
-        // refusing it leaves behind.  3.14 answers `4, 7`.
-        assert_eq!(fstring_missing_comma_span("f'{α β}'", 7), Some((3, 6)));
+        // Byte indices, so this is `α` through `}`, which the caller reports
+        // as the character columns 4 and 7 that 3.14 answers.  The end used
+        // to land one byte inside `β` and round back off it, and the reason
+        // was the recursive parse's own span rather than the projection:
+        // `missing_comma_expression_error` measured the second atom as one
+        // byte wide.
+        assert_eq!(fstring_missing_comma_span("f'{α β}'", 7), Some((3, 8)));
         assert_eq!(
             fstring_missing_comma_span(
                 "f\"\"\"\n\n\n            {\n            6\n            0=\"\"\"",

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -3124,6 +3124,7 @@ static SYS_VERBOSE: AtomicI64 = AtomicI64::new(0);
 static SYS_DEBUG: AtomicI64 = AtomicI64::new(0);
 static SYS_BYTES_WARNING: AtomicI64 = AtomicI64::new(0);
 static SYS_DONT_WRITE_BYTECODE: AtomicBool = AtomicBool::new(false);
+static SYS_FAULTHANDLER: AtomicBool = AtomicBool::new(false);
 static SYS_UNBUFFERED: AtomicBool = AtomicBool::new(false);
 // pypy/interpreter/app_main.py keeps the raw `-X` strings in
 // `options['_xoptions']` (a list) until sys initialization builds the public
@@ -3135,6 +3136,8 @@ static SYS_WARNOPTIONS: LazyLock<Mutex<Vec<std::ffi::OsString>>> =
 static SYS_ORIG_ARGV: LazyLock<Mutex<Vec<std::ffi::OsString>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
 static SYS_STDIO_ENCODING: LazyLock<Mutex<Option<String>>> = LazyLock::new(|| Mutex::new(None));
+static SYS_PYCACHE_PREFIX: LazyLock<Mutex<Option<std::ffi::OsString>>> =
+    LazyLock::new(|| Mutex::new(None));
 static SYS_WARN_DEFAULT_ENCODING: AtomicBool = AtomicBool::new(false);
 static SYS_CODE_DEBUG_RANGES: AtomicBool = AtomicBool::new(true);
 
@@ -3176,10 +3179,27 @@ pub fn set_runtime_flags(flags: &crate::launch_env::LaunchFlags) {
     SYS_DEBUG.store(flags.debug, Ordering::Relaxed);
     SYS_BYTES_WARNING.store(flags.bytes_warning, Ordering::Relaxed);
     SYS_DONT_WRITE_BYTECODE.store(flags.dont_write_bytecode, Ordering::Relaxed);
+    SYS_FAULTHANDLER.store(flags.faulthandler, Ordering::Relaxed);
+    *SYS_PYCACHE_PREFIX.lock().unwrap() = flags.pycache_prefix.clone();
     SYS_UNBUFFERED.store(flags.unbuffered, Ordering::Relaxed);
     *SYS_XOPTIONS.lock().unwrap() = flags.xoptions.clone();
     *SYS_WARNOPTIONS.lock().unwrap() = flags.warnoptions.clone();
     *SYS_STDIO_ENCODING.lock().unwrap() = flags.stdio_encoding.clone();
+}
+
+/// Whether the launcher resolved `-X faulthandler` / `-X dev` /
+/// PYTHONFAULTHANDLER, which asks for the fatal-signal handlers to be in place
+/// before user code runs.
+pub fn faulthandler_flag() -> bool {
+    SYS_FAULTHANDLER.load(Ordering::Relaxed)
+}
+
+/// The directory `-X pycache_prefix` / PYTHONPYCACHEPREFIX named, already
+/// resolved to `None` for every spelling that names no directory.  Read back as
+/// `sys.pycache_prefix`, which is what `_bootstrap_external.cache_from_source`
+/// computes the bytecode path from.
+pub fn pycache_prefix() -> Option<std::ffi::OsString> {
+    SYS_PYCACHE_PREFIX.lock().unwrap().clone()
 }
 
 /// Raw `-X` values recorded by the launcher, in command-line order.

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -3120,6 +3120,8 @@ static SYS_DEV_MODE: AtomicBool = AtomicBool::new(false);
 static SYS_UTF8_MODE: AtomicI64 = AtomicI64::new(0);
 static SYS_SAFE_PATH: AtomicBool = AtomicBool::new(false);
 static SYS_OPTIMIZE: AtomicI64 = AtomicI64::new(0);
+static SYS_VERBOSE: AtomicI64 = AtomicI64::new(0);
+static SYS_DEBUG: AtomicI64 = AtomicI64::new(0);
 static SYS_BYTES_WARNING: AtomicI64 = AtomicI64::new(0);
 static SYS_DONT_WRITE_BYTECODE: AtomicBool = AtomicBool::new(false);
 static SYS_UNBUFFERED: AtomicBool = AtomicBool::new(false);
@@ -3170,6 +3172,8 @@ pub fn set_runtime_flags(flags: &crate::launch_env::LaunchFlags) {
     SYS_UTF8_MODE.store(flags.utf8_mode.unwrap_or(0), Ordering::Relaxed);
     SYS_SAFE_PATH.store(flags.safe_path, Ordering::Relaxed);
     SYS_OPTIMIZE.store(flags.optimize, Ordering::Relaxed);
+    SYS_VERBOSE.store(flags.verbose, Ordering::Relaxed);
+    SYS_DEBUG.store(flags.debug, Ordering::Relaxed);
     SYS_BYTES_WARNING.store(flags.bytes_warning, Ordering::Relaxed);
     SYS_DONT_WRITE_BYTECODE.store(flags.dont_write_bytecode, Ordering::Relaxed);
     SYS_UNBUFFERED.store(flags.unbuffered, Ordering::Relaxed);
@@ -3185,6 +3189,19 @@ pub fn xoptions() -> Vec<std::ffi::OsString> {
 
 pub fn bytes_warning_flag() -> i64 {
     SYS_BYTES_WARNING.load(Ordering::Relaxed)
+}
+
+/// `-v` / PYTHONVERBOSE, read back as `sys.flags.verbose`.  The import trace
+/// itself is emitted by `importlib._bootstrap`'s `_verbose_message`, which
+/// compares this against the verbosity a message asks for.
+pub fn verbose_flag() -> i64 {
+    SYS_VERBOSE.load(Ordering::Relaxed)
+}
+
+/// `-d` / PYTHONDEBUG as the config counts it.  `sys.flags.debug` saturates
+/// this to 0/1, because `parser_debug` is declared BOOL there.
+pub fn debug_flag() -> i64 {
+    SYS_DEBUG.load(Ordering::Relaxed)
 }
 
 /// CPython 3.14 `PyConfig.code_debug_ranges`, consumed by every compiler

--- a/pyre/pyre-interpreter/src/launch_env.rs
+++ b/pyre/pyre-interpreter/src/launch_env.rs
@@ -24,6 +24,10 @@ pub struct LaunchFlags {
     pub ignore_environment: bool,
     pub isolated: bool,
     pub dev_mode: bool,
+    /// `-X faulthandler`; `-X dev` and PYTHONFAULTHANDLER fold in during
+    /// finalize.  Installs the fatal-signal handlers before user code runs, so
+    /// a crash dumps the Python traceback it was in.
+    pub faulthandler: bool,
     pub warn_default_encoding: bool,
     /// PYTHONLEGACYWINDOWSFSENCODING, which no command-line option spells.
     /// Read only on Windows, the only platform whose `PyPreConfig` carries it,
@@ -47,6 +51,15 @@ pub struct LaunchFlags {
     pub debug: i64,
     pub bytes_warning: i64,
     pub dont_write_bytecode: bool,
+    /// `-X pycache_prefix[=PATH]`, three-state until [`finalize`] resolves it.
+    /// `None` is an option the command line did not name, and is the only
+    /// state PYTHONPYCACHEPREFIX still applies to; after finalize a `Some`
+    /// always carries a non-empty path, which is what `sys.pycache_prefix`
+    /// reports and what `_bootstrap_external.cache_from_source` writes under.
+    ///
+    /// The path keeps the host's own spelling for the same reason the option
+    /// lists do: a directory name is not required to have a UTF-8 form.
+    pub pycache_prefix: Option<std::ffi::OsString>,
     pub unbuffered: bool,
     /// Both option lists stay in the host's own spelling until sys module
     /// initialization decodes them, because neither is required to be text the
@@ -92,11 +105,13 @@ pub const LAUNCH_ENV_NAMES: &[&str] = &[
     "PYTHONNOUSERSITE",
     "PYTHONUNBUFFERED",
     "PYTHONDEVMODE",
+    "PYTHONFAULTHANDLER",
     "PYTHONINSPECT",
     "PYTHONOPTIMIZE",
     "PYTHONVERBOSE",
     "PYTHONDEBUG",
     "PYTHONDONTWRITEBYTECODE",
+    "PYTHONPYCACHEPREFIX",
     "PYTHONUTF8",
     "PYTHONWARNDEFAULTENCODING",
     "PYTHONLEGACYWINDOWSFSENCODING",
@@ -269,6 +284,24 @@ fn fold_presence_flag(flags: &LaunchFlags, set: bool, name: &str) -> bool {
     set || (!flags.ignore_environment && is_set_nonempty(name))
 }
 
+/// `app_main.py run_command_line` — `-X pycache_prefix` folded with
+/// PYTHONPYCACHEPREFIX.  Naming the option at all settles the question, so
+/// `-X pycache_prefix` and `-X pycache_prefix=` both leave the prefix unset
+/// *and* keep the variable from supplying one; only an unnamed option reaches
+/// the environment. An empty value never becomes a prefix, from either source,
+/// and a value that is a relative path is stored the way it was written.
+fn resolve_pycache_prefix(flags: &LaunchFlags) -> Option<std::ffi::OsString> {
+    let named = match &flags.pycache_prefix {
+        Some(value) => value.clone(),
+        None if flags.ignore_environment => return None,
+        // Read as bytes: a directory name is free text, so `read`'s `env::var`
+        // contract would drop the whole variable for one undecodable byte
+        // rather than carry the path `-X` would have carried.
+        None => os_string_from_bytes(&read_raw("PYTHONPYCACHEPREFIX")?),
+    };
+    (!named.is_empty()).then_some(named)
+}
+
 /// Fold the environment over the options a command line named. An embedding
 /// without a command line passes `LaunchFlags::default()`.
 pub fn finalize(mut flags: LaunchFlags) -> Result<LaunchFlags, PreConfigError> {
@@ -296,6 +329,16 @@ pub fn finalize(mut flags: LaunchFlags) -> Result<LaunchFlags, PreConfigError> {
     flags.unbuffered = fold_int_flag(&flags, flags.unbuffered, "PYTHONUNBUFFERED");
     flags.safe_path = fold_presence_flag(&flags, flags.safe_path, "PYTHONSAFEPATH");
     flags.dev_mode = fold_presence_flag(&flags, flags.dev_mode, "PYTHONDEVMODE");
+    // app_main.py run_command_line — the option, developer mode and the
+    // variable all reach the same install, and the variable takes the presence
+    // fold, so a `PYTHONFAULTHANDLER=0` enables it the way any other non-empty
+    // value does.  Folded after dev_mode so the variable spelling of that one
+    // carries here too.
+    flags.faulthandler = fold_presence_flag(
+        &flags,
+        flags.faulthandler || flags.dev_mode,
+        "PYTHONFAULTHANDLER",
+    );
     flags.inspect = fold_presence_flag(&flags, flags.inspect, "PYTHONINSPECT");
     // app_main.py:773-774 — the variable enables it on any non-empty value,
     // `0` included, the same way `-X warn_default_encoding` does.
@@ -306,6 +349,7 @@ pub fn finalize(mut flags: LaunchFlags) -> Result<LaunchFlags, PreConfigError> {
     );
     flags.no_debug_ranges =
         fold_presence_flag(&flags, flags.no_debug_ranges, "PYTHONNODEBUGRANGES");
+    flags.pycache_prefix = resolve_pycache_prefix(&flags);
     flags.stdio_encoding = if flags.ignore_environment {
         None
     } else {

--- a/pyre/pyre-interpreter/src/launch_env.rs
+++ b/pyre/pyre-interpreter/src/launch_env.rs
@@ -38,6 +38,13 @@ pub struct LaunchFlags {
     pub safe_path: bool,
     /// `-O` count on the command line; PYTHONOPTIMIZE folds in during finalize.
     pub optimize: i64,
+    /// `-v` count; PYTHONVERBOSE folds in during finalize.  Read back as
+    /// `sys.flags.verbose`, which is what `importlib._bootstrap`'s
+    /// `_verbose_message` gates the import trace on.
+    pub verbose: i64,
+    /// `-d` count; PYTHONDEBUG folds in during finalize.  The parser has no
+    /// debug output to emit, so the count exists to be reported.
+    pub debug: i64,
     pub bytes_warning: i64,
     pub dont_write_bytecode: bool,
     pub unbuffered: bool,
@@ -87,6 +94,8 @@ pub const LAUNCH_ENV_NAMES: &[&str] = &[
     "PYTHONDEVMODE",
     "PYTHONINSPECT",
     "PYTHONOPTIMIZE",
+    "PYTHONVERBOSE",
+    "PYTHONDEBUG",
     "PYTHONDONTWRITEBYTECODE",
     "PYTHONUTF8",
     "PYTHONWARNDEFAULTENCODING",
@@ -210,28 +219,39 @@ fn env_int_flag(name: &str) -> Option<u32> {
     // Read the bytes, not a decoded string: `_Py_str_to_int` rejects undecodable
     // input exactly the way it rejects trailing junk, so both land on 1 rather
     // than on "unset".
+    //
+    // `strtol` steps over leading whitespace before the digits and then reports
+    // where it stopped, so `_Py_str_to_int` takes a value padded on the left and
+    // refuses one padded on the right.  Rust's parse refuses both, so the left
+    // pad is trimmed here; the set is `isspace`'s, not `char::is_whitespace`'s,
+    // which would also step over spacing the C function stops at.
     let parsed = std::str::from_utf8(&raw)
         .ok()
+        .map(|value| value.trim_start_matches([' ', '\t', '\n', '\x0b', '\x0c', '\r']))
         .and_then(|value| value.parse::<i64>().ok());
+    // `preconfig.c:554` rejects anything outside the C `int` range as
+    // overflow, and an unreadable value is what becomes 1, so the ceiling is
+    // INT_MAX rather than the width of the field this returns into.
     let value = match parsed {
-        Some(v) if (0..=i64::from(u32::MAX)).contains(&v) => v as u32,
+        Some(v) if (0..=i64::from(i32::MAX)).contains(&v) => v as u32,
         _ => 1,
     };
     Some(value)
 }
 
-/// `-O` count folded with PYTHONOPTIMIZE (`config_init_optimization_level`):
-/// the effective level is the larger of the two.  The level is kept as a wide
-/// integer so `sys.flags.optimize` mirrors a large `PYTHONOPTIMIZE` verbatim;
-/// the compiler clamps it into a byte at read time.
-fn resolve_optimize(flags: &LaunchFlags) -> i64 {
-    let mut level = flags.optimize;
-    if !flags.ignore_environment
-        && let Some(v) = env_int_flag("PYTHONOPTIMIZE")
-    {
-        level = level.max(i64::from(v));
+/// A repeatable option folded with its integer environment variable
+/// (`app_main.py`'s `parse_env`, and `config_init_optimization_level` for the
+/// `-O` case): the effective count is the larger of the two.  The count is kept
+/// as a wide integer so `sys.flags` mirrors a large variable verbatim; the
+/// compiler clamps the optimization level into a byte at read time.
+fn resolve_counter(flags: &LaunchFlags, count: i64, name: &str) -> i64 {
+    if flags.ignore_environment {
+        return count;
     }
-    level
+    match env_int_flag(name) {
+        Some(value) => count.max(i64::from(value)),
+        None => count,
+    }
 }
 
 /// A boolean option folded with an *integer* environment flag: the variable
@@ -264,7 +284,9 @@ pub fn finalize(mut flags: LaunchFlags) -> Result<LaunchFlags, PreConfigError> {
         );
     }
     flags.utf8_mode = Some(resolve_utf8_mode(&flags)?);
-    flags.optimize = resolve_optimize(&flags);
+    flags.optimize = resolve_counter(&flags, flags.optimize, "PYTHONOPTIMIZE");
+    flags.verbose = resolve_counter(&flags, flags.verbose, "PYTHONVERBOSE");
+    flags.debug = resolve_counter(&flags, flags.debug, "PYTHONDEBUG");
     // Which of the two shapes a name takes is per-variable, not a category:
     // PYTHONSAFEPATH and PYTHONINSPECT enable on a bare `=0`, PYTHONNOUSERSITE
     // and PYTHONUNBUFFERED do not.

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -3215,8 +3215,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     );
     // sys.pycache_prefix — None unless -X pycache_prefix / PYTHONPYCACHEPREFIX.
     // `importlib._bootstrap_external.cache_from_source` reads it to compute the
-    // bytecode path before `dont_write_bytecode` is consulted.
-    module_ns_store(ns, "pycache_prefix", w_none());
+    // bytecode path before `dont_write_bytecode` is consulted.  The path is
+    // decoded the way `sys._xoptions` decodes the same bytes, so one the host
+    // cannot spell in UTF-8 arrives with the surrogates that re-encode to it.
+    module_ns_store(
+        ns,
+        "pycache_prefix",
+        crate::importing::pycache_prefix()
+            .map_or_else(w_none, |path| crate::gateway::fsdecode_os_str(&path)),
+    );
     // `vm.py addaudithook`
     module_ns_store(
         ns,

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1687,7 +1687,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         let flags = crate::_structseq::new_instance_with_extra(
             flags_type,
             vec![
-                w_int_new(0), // debug
+                // `initconfig.c PYCONFIG_SPEC` declares `parser_debug` BOOL
+                // while `verbose` is UINT, so `-dd` reports 1 here and 2
+                // there.  Both count in the config; only this one saturates.
+                w_int_new(i64::from(crate::importing::debug_flag() != 0)),
                 // `-i` sets both.
                 w_int_new(i64::from(crate::importing::inspect_flag())),
                 w_int_new(i64::from(crate::importing::inspect_flag())),
@@ -1697,7 +1700,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // `-S` (skip `import site`) is recorded by the launcher.
                 w_int_new(i64::from(crate::importing::no_site_flag())),
                 w_int_new(i64::from(crate::importing::ignore_environment_flag())),
-                w_int_new(0), // verbose
+                w_int_new(crate::importing::verbose_flag()),
                 w_int_new(crate::importing::bytes_warning_flag()),
                 w_int_new(i64::from(crate::importing::quiet_flag())),
                 w_int_new(0), // hash_randomization

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -219,6 +219,24 @@ fn parse_args(
                 // pyre acts on are matched, and every one of those is ASCII,
                 // so a value with no UTF-8 form simply cannot be one of them.
                 let option: std::ffi::OsString = parser.value()?;
+                // `sys._xoptions` splits each option at the first `=`, so an
+                // option `run_command_line` tests with `in` answers to its key
+                // alone while one that reads the value does not.  The split is
+                // on the encoded bytes because `pycache_prefix` carries a
+                // *directory*, which is not required to have a UTF-8 form; `=`
+                // is ASCII, and `OsStr` documents its encoded form as
+                // splittable at an ASCII byte, so each half is a whole `OsStr`.
+                let bytes = option.as_encoded_bytes();
+                let (key, value) = match bytes.iter().position(|b| *b == b'=') {
+                    Some(at) => (&bytes[..at], Some(&bytes[at + 1..])),
+                    None => (bytes, None),
+                };
+                // `'faulthandler' in sys._xoptions`, so every spelling that
+                // names the key installs the handlers -- `=0` included, which
+                // is not a way to ask for it to stay off.
+                if key == b"faulthandler" {
+                    flags.faulthandler = true;
+                }
                 match option.to_str() {
                     Some("dev") => flags.dev_mode = true,
                     Some("warn_default_encoding") => flags.warn_default_encoding = true,
@@ -228,7 +246,19 @@ fn parse_args(
                     Some(value) if value.starts_with("utf8=") => {
                         fatal_utf8_config_error("invalid -X utf8 option value")
                     }
-                    _ => {}
+                    // An empty value is recorded rather than dropped: a
+                    // named option and an unnamed one are what the three-state
+                    // fold tells apart, and only the second lets
+                    // PYTHONPYCACHEPREFIX supply a prefix.
+                    _ => {
+                        if key == b"pycache_prefix" {
+                            let path = value.unwrap_or(&bytes[..0]);
+                            flags.pycache_prefix = Some(
+                                unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(path) }
+                                    .to_os_string(),
+                            );
+                        }
+                    }
                 }
                 flags.xoptions.push(option);
             }
@@ -1317,11 +1347,87 @@ fn init_warnoptions(
     }
 }
 
+/// The failures that leave the install silent rather than ending startup.
+/// `app_main.py run_command_line` swallows the ValueError a descriptor that is
+/// no longer open raises -- and only that one -- while the whole block sits
+/// behind an `'faulthandler' in sys.builtin_module_names` guard, which is what
+/// the other two stand in for: a build with no host seam carries the module but
+/// can only answer NotImplementedError, and one with no reachable stdlib cannot
+/// import it.  Neither is a failed install; both mean the guard would have kept
+/// the block from running at all.
+fn faulthandler_init_is_silent(error: &pyre_interpreter::PyError) -> bool {
+    matches!(
+        error.kind,
+        PyErrorKind::ValueError | PyErrorKind::NotImplementedError
+    ) || is_import_error(error)
+}
+
+/// `app_main.py run_command_line` — `-X faulthandler`, `-X dev` or
+/// PYTHONFAULTHANDLER installs the fatal-signal handlers ahead of
+/// `import site`, so a crash in anything that runs from here on dumps the
+/// Python traceback it was in.
+///
+/// The descriptor is named rather than left for `enable` to resolve, which is
+/// what `faulthandler.enable(2)` does upstream: 2 is the file a fatal dump has
+/// to reach whatever the program later does to `sys.stderr`, and passing it
+/// also keeps the install from running a Python-level `fileno()` and `flush()`
+/// during startup.
+fn init_faulthandler(
+    w_main_globals: pyre_object::PyObjectRef,
+    ec_ptr: *const pyre_interpreter::PyExecutionContext,
+) {
+    if !importing::faulthandler_flag() {
+        return;
+    }
+    let attempt = (|| -> Result<(), pyre_interpreter::PyError> {
+        use pyre_object::gc_roots::{pin_root, push_roots, shadow_stack_get, shadow_stack_len};
+
+        let module = importing::importhook(
+            "faulthandler",
+            w_main_globals,
+            pyre_object::PY_NULL,
+            0,
+            ec_ptr,
+        )?;
+        // Both the module and the descriptor have to survive an allocation the
+        // other one drives, so neither is held in a Rust local across it.
+        let _roots = push_roots();
+        let module_slot = shadow_stack_len();
+        let _ = pin_root(module);
+        let fd_slot = shadow_stack_len();
+        let _ = pin_root(pyre_object::w_int_new(2));
+        let enable_slot = shadow_stack_len();
+        let _ = pin_root(pyre_interpreter::baseobjspace::getattr_str(
+            shadow_stack_get(module_slot),
+            "enable",
+        )?);
+        pyre_interpreter::call::call_function_impl_result(
+            shadow_stack_get(enable_slot),
+            &[shadow_stack_get(fd_slot)],
+        )?;
+        Ok(())
+    })();
+    if let Err(e) = attempt
+        && !faulthandler_init_is_silent(&e)
+    {
+        // `run_command_line` catches the one error it means to ignore and
+        // nothing else, so a failed install leaves startup the way an
+        // unhandled exception does -- the traceback, and no program run.  The
+        // handlers were asked for by name; continuing without them would run
+        // the program in exactly the configuration the option refused.
+        pyre_interpreter::eprint_exception(&e, true);
+        std::process::exit(1);
+    }
+}
+
 pub(crate) fn import_site(
     no_site: bool,
     w_main_globals: pyre_object::PyObjectRef,
     ec_ptr: *const pyre_interpreter::PyExecutionContext,
 ) {
+    // `run_command_line` installs it ahead of its own `import site`, so a
+    // crash inside `site` itself is already covered.
+    init_faulthandler(w_main_globals, ec_ptr);
     if !no_site
         && importing::importhook("site", w_main_globals, pyre_object::PY_NULL, 0, ec_ptr).is_err()
     {

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -56,6 +56,7 @@ usage: {binary_name} [option] ... [-c cmd | file | -] [arg] ...
 Options:
 -c cmd : program passed in as string (terminates option list)
 -m mod : run library module as a script (terminates option list)
+-d     : debug output from parser; also PYTHONDEBUG=x
 -h     : print this help message and exit (also --help)
 -i     : inspect interactively after running script
 -E     : ignore PYTHON* environment variables
@@ -67,6 +68,7 @@ Options:
 -s     : don't add user site directory to sys.path
 -S     : don't imply 'import site' on initialization
 -P     : don't prepend a potentially unsafe path to sys.path (also PYTHONSAFEPATH)
+-v     : verbose (trace import statements); also PYTHONVERBOSE=x
 -V     : print the Python version number and exit (also --version)
 -X opt : set implementation-specific option
 file   : program read from script file
@@ -243,6 +245,12 @@ fn parse_args(
             // PyPy app_main.py `simple_option`: repeated `-b` increments the
             // bytes-warning level (`-bb` therefore records 2).
             Short('b') => flags.bytes_warning = flags.bytes_warning.saturating_add(1),
+            // The other two `simple_option` counters. `-v` reaches the import
+            // machinery through `sys.flags.verbose`, which `_verbose_message`
+            // reads; `-d` names parser debug output there is none of, and is
+            // carried so `sys.flags.debug` reports it.
+            Short('v') => flags.verbose = flags.verbose.saturating_add(1),
+            Short('d') => flags.debug = flags.debug.saturating_add(1),
             // `-B` disables writing bytecode caches (PYTHONDONTWRITEBYTECODE).
             Short('B') => flags.dont_write_bytecode = true,
             // PyPy app_main.py `unbuffered`: writing streams use raw FileIO
@@ -2124,6 +2132,23 @@ fn eval_source_in_main(
     };
     seed_main_loader(canonical, script_file, ec_ptr);
     import_site(no_site, canonical, ec_ptr);
+
+    // `run_command_line` reaches its stdin branch with `site`, the warnings
+    // bootstrap and the signal handlers already installed, and prints the
+    // banner there rather than on the way in: what it labels is the import
+    // trace `-v` produced for all of that, so it follows the trace instead of
+    // heading it.  `<stdin>` names that branch -- a tty takes the prompt, and
+    // the prompt prints its own.  On stderr, where the trace goes; a piped
+    // program's stdout is its own.
+    if filename == "<stdin>" && importing::verbose_flag() != 0 {
+        eprintln!("{}", repl::BANNER);
+        // `print_banner(not no_site)` -- the second line names the four
+        // builtins `site` installs, so `-S` leaves it nothing to offer and the
+        // notice is dropped with them.
+        if !no_site {
+            eprintln!("{}", repl::BANNER_COPYRIGHT);
+        }
+    }
 
     // `<string>` names no file, so `linecache._interactive_cache` is the only
     // place a traceback frame or `inspect.getsource` can reach the command's

--- a/pyre/pyrex/src/repl.rs
+++ b/pyre/pyrex/src/repl.rs
@@ -42,6 +42,17 @@ struct ReplRuntime {
     sys_module: pyre_object::PyObjectRef,
 }
 
+/// The interpreter identification `app_main.py print_banner` heads both the
+/// prompt and a verbose non-interactive run with.
+pub(crate) const BANNER: &str = "pyre 0.0.1 (Rust meta-tracing JIT)";
+
+/// `print_banner`'s second line, carried by the run that has no prompt to
+/// suggest anything else. The prompt writes an exit hint there instead, so this
+/// one is not shared, but the names it offers are: they are `site`'s, which is
+/// why upstream gates the line on `not no_site`.
+pub(crate) const BANNER_COPYRIGHT: &str =
+    "Type \"help\", \"copyright\", \"credits\" or \"license\" for more information.";
+
 pub fn run_repl(quiet: bool, no_site: bool) {
     let mut repl = Readline::new();
     let history_path = repl_history_path();
@@ -107,7 +118,7 @@ pub fn run_repl(quiet: bool, no_site: bool) {
     };
 
     if !quiet {
-        println!("pyre 0.0.1 (Rust meta-tracing JIT)");
+        println!("{BANNER}");
         println!("Type \"exit()\" or Ctrl-D to exit.");
     }
 


### PR DESCRIPTION
Two commits, two subjects.

## `deps`: the missing-comma span, fixed upstream

Codex flagged the f-string "Perhaps you forgot a comma?" `end_offset` as short
by one when the expression contains a multibyte character, and read it as a
UTF-8 conversion loss — CPython's
`_PyPegen_byte_offset_to_character_offset_line` rounds up where our projection
rounds down.

It was neither pyre's code nor about UTF-8.
`missing_comma_expression_error` in the pinned RustPython rev returned its span
as `(index, next + 1)`, where `next` is the **byte** index at which the second
atom starts. The `+ 1` hard-codes a one-byte width, so pure ASCII was wrong
too:

| source | 3.14 `end_offset` | before |
|---|---|---|
| `(a b)` | 5 | 5 |
| `(a bb)` | 6 | **5** |
| `(a bbb)` | 7 | **5** |
| `(1 22)` | 6 | **5** |
| `(a β)` | 5 | **4** |
| `(a ββ)` | 6 | **4** |
| `(αα β)` | 6 | **5** |
| `[α β]` | 5 | **4** |

`(a bb)` is the case that rules the rounding reading out. A non-ASCII second
atom then lost an extra column on top, because the short end landed inside the
character and `source_location` walked back to where it starts — which is what
made the defect look like a UTF-8 problem.

RustPython#8594, merged, measures the second atom with `adjacent_atom_end` —
the same helper the **first** atom is measured with three lines above. This
bumps the pinned rev `48a3a1f8e04` → `cb7acec87d4`.

`fstring_missing_comma_uses_recursive_expression_range` pinned the old value
and attributed it to rounding in the projection; its own comment already
recorded that "3.14 answers `4, 7`". The projection was right all along, so the
test now pins `3, 8` — the bytes the caller reports as columns 4 and 7 — and
the comment says where the short span actually came from.

The bump also carries RustPython#8591 (`unlinkat` through rustix) and
RustPython#8548 (unicodedata Bidirectional). No dependency is added or removed;
the lock diff is nine `source =` lines.

## `launcher`: `-v` and `-d`

Both were refused outright (`invalid option '-v'`), and `sys.flags.verbose` /
`sys.flags.debug` were built from a literal `0`. A subprocess that passes `-v`
therefore failed before running anything, which is how
`test_site.StartupImportTests.test_startup_imports` was dying: the child exits
2 and the test never reached what it was checking. It passes now.

`app_main.py:cmdline_options` makes both `simple_option` counters and folds
`PYTHONVERBOSE` / `PYTHONDEBUG` over them with `parse_env`. **Following that
for the pair is wrong for one of them.** The two config fields are declared
differently — `initconfig.c:142` has `verbose` UINT, `:134` has `parser_debug`
BOOL — so 3.14 reports:

| | pyre | CPython 3.14 | pypy3 |
|---|---|---|---|
| `-vv` | 2 | 2 | 2 |
| `-dd` | **1** | **1** | **2** |
| `PYTHONDEBUG=2` | **1** | **1** | **2** |

pypy is the divergent one here, so the fixture carries a `pypy-diverges`
marker. Both count in the config (`initconfig.c:2980` is a `++`); only
`parser_debug` saturates on the way out.

`resolve_optimize` was already the shape all three counters need — a count
folded with an integer environment variable by `max` — so it becomes
`resolve_counter` and `-O`, `-v`, `-d` share it.

`-v` needs nothing further to work: `importlib._bootstrap`'s `_verbose_message`
compares `sys.flags.verbose` against the verbosity a message asks for, so the
import trace follows from the field. Measured 98 lines on pyre against 253 on
CPython, same `import 'json' # <...>` format, stdout untouched.

`launcher_verbose_debug_flags.py` pins the pair over 24 assertions,
differential against CPython 3.14.6.

## Verification

All on `4f0c787fe17`:

| gate | result |
|---|---|
| `extract-llbc.py --check` | green, before and after |
| release build (`--no-default-features --features dynasm`) | exit 0 |
| `cpython_tests/run.py --backend dynasm` | PASS 223 / FAIL 0 / CRASH 0, `no regressions` |
| `parity_tests/run.py` | `all parity tests pass` |
| `cargo test --all --no-default-features --features dynasm,cpyext` | exit 0, 181 `test result: ok` |

## Divergences found on the way, deliberately left alone

- `(a 'xy')` — CPython reports `invalid syntax` at offset 4; we report the
  missing-comma message at offset 2. A message mismatch, not a span one.
- `{α: β γ}` — CPython reports the missing-comma message at 5–8; we report
  `invalid syntax` at 5–5. Same kind of mismatch, different rule.
- `-X importtime` is accepted and silently does nothing. pypy documents it as
  unavailable and behaves the same, so this is not a regression; implementing
  it is its own change, and not a small one (see below).
- A `._pth` file beside the executable is ignored. CPython replaces `sys.path`
  with its contents; that is what `test_site._pthFileTests` checks, and those
  three are the rest of that module's failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqhjV61wmP78FZoJwvkazF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for faulthandler, verbose, and debug launcher options.
  * Added `pycache_prefix` configuration through environment variables and runtime visibility.
  * Improved verbose stdin execution with interactive banner output.

* **Bug Fixes**
  * Improved launcher option precedence, environment isolation, Unicode syntax-error offsets, and non-UTF-8 cache paths.

* **Tests**
  * Added parity coverage for launcher flags, bytecode cache locations, banner behavior, and Python 3.14 syntax-error diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->