### PR TITLE
majit: three silent wrong answers in the jit_interp lowering, plus _immutable_fields_ and self-recursive #[jit_inline]

### DIFF
--- a/majit/majit-macros/src/jit_interp/codegen_trace.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_trace.rs
@@ -7,7 +7,7 @@ use syn::{Block, Expr, ExprMatch, ItemFn, Stmt};
 
 use super::JitInterpConfig;
 use super::classify::classify_arms;
-use super::jitcode_lower::{self, LowererConfig};
+use super::jitcode_lower::{self, LowererConfig, is_jit_merge_point_macro};
 
 pub fn generate_trace_fn(config: &JitInterpConfig, func: &ItemFn) -> TokenStream {
     let fn_name = &func.sig.ident;
@@ -304,11 +304,62 @@ pub fn generate_trace_fn(config: &JitInterpConfig, func: &ItemFn) -> TokenStream
 }
 
 pub(crate) fn find_dispatch_match(block: &syn::Block) -> Option<&syn::ExprMatch> {
-    // Select the match with the most arms — the dispatch match has many
-    // opcode arms while pre-dispatch branch matches have only a few.
+    // The dispatch match is the one in the portal loop's body, after the merge
+    // point. That is the shape the rest of this machinery already walks —
+    // `find_dispatch_loop_body`, `lower_pre_dispatch_stmts` and
+    // `bind_pre_merge_point_stmts` all locate the same loop — so search there
+    // rather than over the whole function.
+    //
+    // The rule used to be "the match with the most arms, anywhere", on the
+    // reasoning that a dispatch has many opcode arms and a setup match only a
+    // few. Arm count is not a property of being the dispatch: a five-arm
+    // `let x = match ..` in front of a three-opcode dispatch takes its place,
+    // and then `classify_arms` reads that match's arms as the opcodes while
+    // the two pre-dispatch walkers, which find their loop by the dispatch
+    // match it contains, find no loop and silently lower nothing. The portal
+    // compiles a loop that runs none of the interpreter and answers with it.
+    if let Some(body) = portal_loop_body(block) {
+        let mut after_merge_point = Vec::new();
+        let mut seen_merge_point = false;
+        for stmt in &body.stmts {
+            if is_jit_merge_point_macro(stmt) {
+                seen_merge_point = true;
+            } else if seen_merge_point {
+                collect_matches_in_stmt(stmt, &mut after_merge_point);
+            }
+        }
+        if let Some(dispatch) = after_merge_point.into_iter().max_by_key(|m| m.arms.len()) {
+            return Some(dispatch);
+        }
+    }
+
+    // No portal loop this reads, or none of its statements after the merge
+    // point holds a match. Fall back to the old search so a shape outside the
+    // rule above keeps whatever it did before.
     let mut all = Vec::new();
     collect_all_matches(block, &mut all);
     all.into_iter().max_by_key(|m| m.arms.len())
+}
+
+/// The portal loop: a `while`/`loop` statement of the function body whose own
+/// statements open a merge point. `find_dispatch_loop_body` accepts the same
+/// statement positions, recognising the loop by the dispatch match inside it
+/// instead — which is why it cannot be the one to choose that match.
+fn portal_loop_body(func_block: &syn::Block) -> Option<&syn::Block> {
+    func_block.stmts.iter().find_map(|stmt| {
+        let Stmt::Expr(expr, _) = stmt else {
+            return None;
+        };
+        let body = match expr {
+            Expr::While(while_expr) => &while_expr.body,
+            Expr::Loop(loop_expr) => &loop_expr.body,
+            _ => return None,
+        };
+        body.stmts
+            .iter()
+            .any(is_jit_merge_point_macro)
+            .then_some(body)
+    })
 }
 
 fn collect_all_matches<'a>(block: &'a syn::Block, out: &mut Vec<&'a syn::ExprMatch>) {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -1662,7 +1662,7 @@ pub(super) fn find_dispatch_loop_body<'b>(
 }
 
 /// Returns `true` if `stmt` is a `jit_merge_point!()` macro invocation.
-pub(super) fn is_jit_merge_point_macro(stmt: &Stmt) -> bool {
+pub(crate) fn is_jit_merge_point_macro(stmt: &Stmt) -> bool {
     let Stmt::Macro(mac_stmt) = stmt else {
         return false;
     };

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -3096,20 +3096,6 @@ pub(super) fn lower_dispatch_chain(
     default_label
 }
 
-fn is_lowercase_binding_pat(pat: &Pat) -> bool {
-    let Pat::Ident(pi) = pat else {
-        return false;
-    };
-    if pi.subpat.is_some() || pi.mutability.is_some() || pi.by_ref.is_some() {
-        return false;
-    }
-    pi.ident
-        .to_string()
-        .chars()
-        .next()
-        .is_some_and(|c| c.is_ascii_lowercase())
-}
-
 fn pat_contains_range(pat: &Pat) -> bool {
     match pat {
         Pat::Range(_) => true,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -2437,6 +2437,70 @@ pub(super) enum InlineArmOutcome {
     InlinedTerminal,
 }
 
+/// Where the dispatch chain's unmatched-opcode edge goes.
+///
+/// The edge used to be one thing: `default_label`, bound at the portal
+/// function's trailing return (`lower_dispatch_body`). That is right for
+/// `_ => break`, which is what almost every machine here writes — 55 of the
+/// corpus's default arms, plus 30 more that end in a divergent macro. It is
+/// wrong for the other two spellings, and wrongly in the worst way: the walk
+/// reports a finished frame, `take_single_pass_finish` breaks the native loop,
+/// and the portal returns a partial answer while `degraded_dispatch_arms()`
+/// and the arm census both read healthy.
+enum DefaultEdge {
+    /// `_ => break` and the divergent macros: the loop is over, take the
+    /// function's typed return.
+    Return,
+    /// `_ => {}`: fall out of the match and run the next iteration.
+    NextIteration,
+    /// A default arm with a body. It is an arm like any other, just with no
+    /// opcode test in front of it, so lower it as one — a body that cannot
+    /// lower then degrades to an abort stub, which is the fail-closed path
+    /// every other arm already has.
+    LowerAsArm,
+}
+
+fn classify_default_edge(body: &Expr) -> DefaultEdge {
+    fn leaves_the_loop(body: &Expr) -> bool {
+        match body {
+            Expr::Break(_) | Expr::Return(_) => true,
+            Expr::Macro(m) => is_divergent_macro(&m.mac.path),
+            // Only when that is the whole body: an exit preceded by work
+            // would leave the work out of the trace, which is the same loss
+            // one level down.
+            Expr::Block(b) => match b.block.stmts.as_slice() {
+                [Stmt::Expr(expr, _)] => leaves_the_loop(expr),
+                [Stmt::Macro(m)] => is_divergent_macro(&m.mac.path),
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+    if leaves_the_loop(body) {
+        return DefaultEdge::Return;
+    }
+    match body {
+        Expr::Block(b) if b.block.stmts.is_empty() => DefaultEdge::NextIteration,
+        _ => DefaultEdge::LowerAsArm,
+    }
+}
+
+/// Macros that never return, so an arm ending in one cannot fall through.
+fn is_divergent_macro(path: &syn::Path) -> bool {
+    path.segments.last().is_some_and(|seg| {
+        matches!(
+            seg.ident.to_string().as_str(),
+            "panic" | "unreachable" | "todo" | "unimplemented" | "compile_error"
+        )
+    })
+}
+
+/// True for the arm the dispatch chain falls through to: `_`, or a lower-case
+/// binding.
+fn is_default_dispatch_arm(arm: &crate::jit_interp::classify::ClassifiedArm) -> bool {
+    matches!(arm.pat, Pat::Wild(_)) || is_lowercase_binding_pat(&arm.pat)
+}
+
 pub(super) fn lower_dispatch_chain(
     lowerer: &mut Lowerer,
     classified_arms: &[crate::jit_interp::classify::ClassifiedArm],
@@ -2447,6 +2511,31 @@ pub(super) fn lower_dispatch_chain(
     // Allocated before the opcode-reg guard so we always have a label to return.
     let default_label = lowerer.alloc_label();
     lowerer.emit_aux(quote::quote! { let #default_label = __builder.new_label(); });
+
+    // Where the unmatched-opcode edge goes. A match over `u8` needs a default
+    // arm to be exhaustive, so `None` here means this is not a dispatch shape;
+    // leave that case at the return edge it already had.
+    let default_kind = classified_arms
+        .iter()
+        .find(|arm| is_default_dispatch_arm(arm))
+        .map_or(DefaultEdge::Return, |arm| {
+            classify_default_edge(&arm.original_body)
+        });
+    let lower_default_as_arm = matches!(default_kind, DefaultEdge::LowerAsArm);
+    // Bound at the default arm's own body below; the switch's default and the
+    // guard chain's fall-through both target it.
+    let default_body_label = lower_default_as_arm.then(|| {
+        let label = lowerer.alloc_label();
+        lowerer.emit_aux(quote::quote! { let #label = __builder.new_label(); });
+        label
+    });
+    let default_edge = match &default_kind {
+        DefaultEdge::Return => default_label.clone(),
+        DefaultEdge::NextIteration => loop_start_label.clone(),
+        DefaultEdge::LowerAsArm => default_body_label
+            .clone()
+            .expect("allocated on this arm of the same match"),
+    };
 
     // Retrieve the opcode register installed by the opcode-fetch lowerer.
     // Slice ε.1: prefer the consumer's chosen opcode-result name (set by
@@ -2469,7 +2558,7 @@ pub(super) fn lower_dispatch_chain(
     if config.switch_dispatch {
         let mut switch_case_emitters = Vec::new();
         for (arm_idx, arm) in classified_arms.iter().enumerate() {
-            if matches!(arm.pat, Pat::Wild(_)) || is_lowercase_binding_pat(&arm.pat) {
+            if is_default_dispatch_arm(arm) {
                 continue;
             }
             let arm_label = lowerer.alloc_label();
@@ -2503,7 +2592,7 @@ pub(super) fn lower_dispatch_chain(
                 __builder.switch(#opcode_reg as u16, &__switch_cases);
             },
         );
-        lowerer.emit_jump(&default_label);
+        lowerer.emit_jump(&default_edge);
     }
 
     // The denominator for `record_degraded_dispatch_arm` below, staged from the
@@ -2515,7 +2604,7 @@ pub(super) fn lower_dispatch_chain(
         let census_interp = config.state_type_name.clone();
         let census_arms = classified_arms
             .iter()
-            .filter(|arm| !matches!(arm.pat, Pat::Wild(_)) && !is_lowercase_binding_pat(&arm.pat))
+            .filter(|arm| !is_default_dispatch_arm(arm) || lower_default_as_arm)
             .count();
         lowerer.emit_aux(quote::quote! {
             majit_metainterp::record_dispatch_arm_census(#census_interp, #census_arms);
@@ -2526,12 +2615,23 @@ pub(super) fn lower_dispatch_chain(
         // `_` wildcard: skip here; handled by the default GOTO below.
         // All other patterns (including Pat::Ident like `OP_NOP`) are
         // treated as constant tests and emitted as goto_if_not_int_eq.
-        if matches!(arm.pat, Pat::Wild(_)) || is_lowercase_binding_pat(&arm.pat) {
+        let is_default_arm = is_default_dispatch_arm(arm);
+        if is_default_arm && !lower_default_as_arm {
             continue;
         }
 
         let mut skip_label = None;
-        if let Some(match_label) = switch_arm_labels[arm_idx].as_ref() {
+        if is_default_arm {
+            // No opcode test in front of it: this is where every opcode no arm
+            // matched arrives. Rust puts the default arm last, so the previous
+            // arm's skip label falls straight into this body, and the switch
+            // dispatch jumps here explicitly.
+            lowerer.emit_label_def(
+                default_body_label
+                    .as_ref()
+                    .expect("allocated whenever the default arm is lowered as one"),
+            );
+        } else if let Some(match_label) = switch_arm_labels[arm_idx].as_ref() {
             lowerer.emit_label_def(match_label);
         } else if config.switch_dispatch {
             continue;
@@ -3089,9 +3189,11 @@ pub(super) fn lower_dispatch_chain(
 
     // After all arm guards, the default/exit path: unconditional GOTO.
     // default_label is bound at the typed-return emission site in
-    // lower_dispatch_body (Task 1.7).
-    if !config.switch_dispatch {
-        lowerer.emit_jump(&default_label);
+    // lower_dispatch_body (Task 1.7).  `Halt` arms keep jumping there
+    // whatever the default arm says: a `break` arm carries no operand and
+    // reaches the function's typed return for one.
+    if !config.switch_dispatch && !lower_default_as_arm {
+        lowerer.emit_jump(&default_edge);
     }
     default_label
 }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
@@ -125,6 +125,17 @@ pub(super) fn extract_pat_value_tokens(pat: &Pat) -> Option<Vec<TokenStream>> {
     }
 }
 
+/// True when an identifier reads as a constant rather than a binding.
+///
+/// syn parses `OP_NOP => ..` and `other => ..` as the same `Pat::Ident`, and
+/// nothing at proc-macro time can resolve which one it is. Rust's own
+/// convention decides it: `non_upper_case_globals` puts constants in upper
+/// case, so an identifier holding no lower-case letter is one.
+pub(super) fn is_const_ident(ident: &syn::Ident) -> bool {
+    let name = ident.to_string();
+    !name.chars().any(|c| c.is_lowercase())
+}
+
 /// Case emitters for `switch_dispatch`.
 ///
 /// Literal/path/or arms become direct `cases.push((key, label))` statements.

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
@@ -62,29 +62,6 @@ fn pat_lit_int_value(lit: &Lit) -> Option<i64> {
     }
 }
 
-/// Extract integer literal values from a match arm pattern.
-///
-/// Supports `Pat::Lit` (integer, byte and char literals — see
-/// [`pat_lit_int_value`]), `Pat::Or` (multiple patterns like `1 | 2 | 3`), and
-/// `Pat::Path` (constant paths — evaluated at compile time via `#pat as i64`).
-///
-/// Returns `None` if the pattern contains unsupported constructs.
-pub(super) fn extract_pat_literals(pat: &Pat) -> Option<Vec<i64>> {
-    match pat {
-        Pat::Lit(expr_lit) => Some(vec![pat_lit_int_value(&expr_lit.lit)?]),
-        Pat::Or(pat_or) => {
-            let mut values = Vec::new();
-            for case in &pat_or.cases {
-                values.extend(extract_pat_literals(case)?);
-            }
-            Some(values)
-        }
-        // Constant path pattern (e.g., `MY_CONST`): we cannot evaluate
-        // this at proc-macro time, so return None to bail out.
-        _ => None,
-    }
-}
-
 /// Extract pattern values as token expressions for use in generated code.
 ///
 /// Unlike `extract_pat_literals`, this accepts constant paths (`Pat::Path`)
@@ -125,15 +102,35 @@ pub(super) fn extract_pat_value_tokens(pat: &Pat) -> Option<Vec<TokenStream>> {
     }
 }
 
-/// True when an identifier reads as a constant rather than a binding.
+/// True when a match arm's pattern binds a name rather than naming a constant.
 ///
 /// syn parses `OP_NOP => ..` and `other => ..` as the same `Pat::Ident`, and
 /// nothing at proc-macro time can resolve which one it is. Rust's own
-/// convention decides it: `non_upper_case_globals` puts constants in upper
-/// case, so an identifier holding no lower-case letter is one.
-pub(super) fn is_const_ident(ident: &syn::Ident) -> bool {
-    let name = ident.to_string();
-    !name.chars().any(|c| c.is_lowercase())
+/// convention decides it: a binding is `snake_case`, so a pattern whose first
+/// character is a lower-case ASCII letter is one and everything else names a
+/// constant.
+///
+/// The two mistakes are not symmetric, which is why the ambiguous cases resolve
+/// toward "constant". Reading a constant as a binding makes the arm the
+/// catch-all: its guard is never emitted and the jitcode computes one arm for
+/// every discriminant, while the concrete path — real Rust — stays right, so
+/// only a warm-versus-cold answer can see it. Reading a binding as a constant
+/// emits `#name as i64` into the generated builder, which does not compile.
+///
+/// This is the single answer for every arm classifier here: the dispatch
+/// chain, `lower_match_stmt` and `lower_match_value` all consult it.
+pub(super) fn is_lowercase_binding_pat(pat: &Pat) -> bool {
+    let Pat::Ident(pi) = pat else {
+        return false;
+    };
+    if pi.subpat.is_some() || pi.mutability.is_some() || pi.by_ref.is_some() {
+        return false;
+    }
+    pi.ident
+        .to_string()
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_lowercase())
 }
 
 /// Case emitters for `switch_dispatch`.

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
@@ -469,14 +469,34 @@ pub(super) fn extract_branch_int(expr: &Expr) -> Option<i64> {
     }
 }
 
-pub(super) fn inline_builder_path(expr: &Expr) -> Option<Path> {
+/// The memoizing entry point `#[jit_inline]` generates beside `_with_asm`.
+///
+/// `_with_asm` assembles unconditionally; this one is `CallControl.get_jitcode`
+/// — it consults the driver-shared cache first and registers the helper's
+/// identity before assembling, so a helper that calls itself resolves to the
+/// jitcode it is already being built under instead of recursing.
+pub(super) fn inline_shared_path(expr: &Expr) -> Option<Path> {
     let Expr::Path(ExprPath { path, .. }) = expr else {
         return None;
     };
     let mut path = path.clone();
     let last = path.segments.last_mut()?;
-    last.ident = format_ident!("__majit_inline_jitcode_{}_with_asm", last.ident);
+    last.ident = format_ident!("__majit_inline_jitcode_{}_shared", last.ident);
     Some(path)
+}
+
+/// The callee's return kind, as a token.
+///
+/// It used to be read back off the assembled jitcode's trailing return opcode.
+/// A recursive call has no assembled jitcode to read — the callee is the caller,
+/// still under construction — and the kind is a static property of the emit site
+/// anyway, so it is spelled rather than recovered.
+pub(super) fn jit_arg_kind_tokens(kind: BindingKind) -> TokenStream {
+    match kind {
+        BindingKind::Int => quote! { majit_metainterp::JitArgKind::Int },
+        BindingKind::Ref => quote! { majit_metainterp::JitArgKind::Ref },
+        BindingKind::Float => quote! { majit_metainterp::JitArgKind::Float },
+    }
 }
 
 /// Construct the path of the per-helper liveness prebuild fn that

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/jit_state_analysis.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/jit_state_analysis.rs
@@ -140,6 +140,19 @@ impl<'c> Lowerer<'c> {
                 .stmts
                 .iter()
                 .any(|s| self.stmt_references_unknown_local(s)),
+            // A macro invocation's tokens are opaque to this walk. The
+            // question it answers is whether the expression names anything
+            // the generated scope will not carry, and it cannot answer that
+            // about tokens it never reads — so reporting "no reference" is
+            // an assumption, not a finding. `lower_local`'s runtime-constant
+            // fallback reads this as permission to emit the initialiser
+            // verbatim into the `__builder` block, where the portal's own
+            // parameters and locals do not exist: `let bump = pick!(sel);`
+            // ahead of the merge point put `match sel { .. }` in
+            // `__dispatch_jitcode_*`, whose parameters are the assembler and
+            // the driver index. `stmt_contains_call` below scores a macro the
+            // same way, for the same reason.
+            Expr::Macro(_) => true,
             // Literals, returns without expression, etc. are safe.
             _ => false,
         }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
@@ -597,12 +597,21 @@ impl<'c> Lowerer<'c> {
                 Pat::Wild(_) => {
                     default_arm = Some(&arm.body);
                 }
-                Pat::Ident(pat_ident) if pat_ident.subpat.is_none() => {
+                // syn parses `OP_NOP => ..` and `other => ..` identically, so
+                // the name is all there is to go on.  A constant is upper case
+                // (rustc's own `non_upper_case_globals` says so), and reading
+                // one as a binding is the silent failure: the arm becomes the
+                // catch-all, its guard is never emitted, and the jitcode
+                // computes whichever constant arm came last no matter what the
+                // discriminant is, while the concrete path stays right.
+                Pat::Ident(pat_ident)
+                    if pat_ident.subpat.is_none() && !is_const_ident(&pat_ident.ident) =>
+                {
                     default_arm = Some(&arm.body);
                 }
                 _ => {
-                    let literals = extract_pat_literals(&arm.pat)?;
-                    guarded_arms.push((literals, &arm.body));
+                    let values = extract_pat_value_tokens(&arm.pat)?;
+                    guarded_arms.push((values, &arm.body));
                 }
             }
         }
@@ -616,12 +625,12 @@ impl<'c> Lowerer<'c> {
 
         let disc_reg = discriminant.reg;
 
-        for (literals, body) in &guarded_arms {
+        for (values, body) in &guarded_arms {
             let next_label = self.alloc_label();
             self.emit_aux(quote! { let #next_label = __builder.new_label(); });
 
-            if literals.len() == 1 {
-                let value = literals[0];
+            if values.len() == 1 {
+                let value = &values[0];
                 let const_reg = self.alloc_reg();
                 let eq_reg = self.alloc_reg();
                 self.emit_op(
@@ -642,7 +651,7 @@ impl<'c> Lowerer<'c> {
                 );
                 self.emit_conditional_guard(eq_reg, &next_label);
             } else {
-                let first_val = literals[0];
+                let first_val = &values[0];
                 let first_const_reg = self.alloc_reg();
                 let mut or_reg = self.alloc_reg();
                 self.emit_op(
@@ -661,7 +670,7 @@ impl<'c> Lowerer<'c> {
                     ),
                     quote! { __builder.record_binop_i(#or_reg, majit_ir::OpCode::IntEq, #disc_reg, #first_const_reg); },
                 );
-                for &lit_val in &literals[1..] {
+                for lit_val in &values[1..] {
                     let const_reg = self.alloc_reg();
                     let eq_reg = self.alloc_reg();
                     let new_or_reg = self.alloc_reg();

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
@@ -109,14 +109,8 @@ impl<'c> Lowerer<'c> {
                 Pat::Wild(_) => {
                     default_arm = Some(&arm.body);
                 }
-                Pat::Ident(pat_ident) if pat_ident.subpat.is_none() => {
-                    let name = pat_ident.ident.to_string();
-                    if name.starts_with(|c: char| c.is_lowercase()) {
-                        default_arm = Some(&arm.body);
-                    } else {
-                        let tokens = extract_pat_value_tokens(&arm.pat)?;
-                        guarded_arms.push((tokens, &arm.body));
-                    }
+                _ if is_lowercase_binding_pat(&arm.pat) => {
+                    default_arm = Some(&arm.body);
                 }
                 _ => {
                     let tokens = extract_pat_value_tokens(&arm.pat)?;
@@ -598,15 +592,9 @@ impl<'c> Lowerer<'c> {
                     default_arm = Some(&arm.body);
                 }
                 // syn parses `OP_NOP => ..` and `other => ..` identically, so
-                // the name is all there is to go on.  A constant is upper case
-                // (rustc's own `non_upper_case_globals` says so), and reading
-                // one as a binding is the silent failure: the arm becomes the
-                // catch-all, its guard is never emitted, and the jitcode
-                // computes whichever constant arm came last no matter what the
-                // discriminant is, while the concrete path stays right.
-                Pat::Ident(pat_ident)
-                    if pat_ident.subpat.is_none() && !is_const_ident(&pat_ident.ident) =>
-                {
+                // the name is all there is to go on, and `is_lowercase_binding_pat`
+                // is the one place that decides it.
+                _ if is_lowercase_binding_pat(&arm.pat) => {
                     default_arm = Some(&arm.body);
                 }
                 _ => {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -1536,7 +1536,7 @@ impl<'c> Lowerer<'c> {
                     }
                 }
                 crate::jit_interp::CallPolicyKind::InlineVoid => {
-                    let builder_path = inline_builder_path(&call.func)?;
+                    let shared_path = inline_shared_path(&call.func)?;
                     let prebuild_path = inline_prebuild_path(&call.func)?;
                     let (inline_call, post_live) = inline_call_tokens_void(&arg_bindings);
                     let __arg_regs: Vec<Register> =
@@ -1547,8 +1547,8 @@ impl<'c> Lowerer<'c> {
                     self.emit_op(
                         OpMeta::linear(OpKind::InlineCall, __arg_regs, vec![]),
                         quote! {
-                            let __sub_jitcode = #builder_path(__asm);
-                            let __sub_idx = __builder.add_sub_jitcode(__sub_jitcode);
+                            let __sub_edge = #shared_path(__asm);
+                            let __sub_idx = __builder.add_sub_jitcode_ref(__sub_edge);
                             #inline_call
                         },
                     );
@@ -1599,7 +1599,8 @@ impl<'c> Lowerer<'c> {
                     let result_kind = binding_kind_for_inline_policy(kind)
                         .expect("the arm's own patterns are the inline result policies");
                     let throwaway_reg = self.alloc_reg();
-                    let builder_path = inline_builder_path(&call.func)?;
+                    let shared_path = inline_shared_path(&call.func)?;
+                    let sub_return_kind = jit_arg_kind_tokens(result_kind);
                     let prebuild_path = inline_prebuild_path(&call.func)?;
                     let (inline_call, post_live) = inline_call_tokens(&arg_bindings, throwaway_reg);
                     let __arg_regs: Vec<Register> =
@@ -1614,12 +1615,9 @@ impl<'c> Lowerer<'c> {
                             vec![Register::new(result_kind, throwaway_reg)],
                         ),
                         quote! {
-                            use majit_metainterp::jitcode::JitCodeRuntimeExt as _;
-                            let __sub_jitcode = #builder_path(__asm);
-                            let (__sub_return_kind, _) = __sub_jitcode
-                                .trailing_return_info()
-                                .expect("inline helper jitcode must end in a typed return opcode");
-                            let __sub_idx = __builder.add_sub_jitcode(__sub_jitcode);
+                            let __sub_edge = #shared_path(__asm);
+                            let __sub_return_kind = #sub_return_kind;
+                            let __sub_idx = __builder.add_sub_jitcode_ref(__sub_edge);
                             #inline_call
                         },
                     );

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -1036,7 +1036,7 @@ impl<'c> Lowerer<'c> {
         }
         // ref(T) scalar: read into the ref register bank so a subsequent
         // getfield_gc reads its struct base from a real ref value.
-        if let Some((field_index, _)) = config.state_ref_scalars.get(&member_name) {
+        if let Some((field_index, struct_path)) = config.state_ref_scalars.get(&member_name) {
             let fi = *field_index as u16;
             let reg = self.alloc_reg();
             // Declare the ref identity slot as a read so the backward
@@ -1059,7 +1059,11 @@ impl<'c> Lowerer<'c> {
                 reg,
                 kind: BindingKind::Ref,
                 depends_on_stack: false,
-                struct_type: None,
+                // The `ref(T)` declaration's own `T`. `state.<ref>.<member>`
+                // resolves it from this same map one level up, so leaving it
+                // off here is what made the read stop lowering as soon as the
+                // ref was bound to a local first.
+                struct_type: Some(struct_path.clone()),
             });
         }
         if let Some(&field_index) = config.state_float_scalars.get(&member_name) {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -1174,6 +1174,17 @@ impl<'c> Lowerer<'c> {
                             #__fsize,
                             #__fsigned,
                         )],
+                        {
+                            // The struct's own `_immutable_fields_` declaration.  Read through
+                            // an in-scope trait rather than a qualified
+                            // `<T as MajitImmutableFields>::...`, which would select the blanket
+                            // empty default and never see a struct's own declaration.  The import
+                            // is unused exactly when the inherent const wins, which is the common
+                            // case.
+                            #[allow(unused_imports)]
+                            use majit_metainterp::MajitImmutableFields as _;
+                            <#struct_path>::__MAJIT_IMMUTABLE_FIELDS
+                        },
                     );
                     __builder.getfield_gc_r(
                         #result_reg,
@@ -1213,6 +1224,17 @@ impl<'c> Lowerer<'c> {
                             #__fsize,
                             #__fsigned,
                         )],
+                        {
+                            // The struct's own `_immutable_fields_` declaration.  Read through
+                            // an in-scope trait rather than a qualified
+                            // `<T as MajitImmutableFields>::...`, which would select the blanket
+                            // empty default and never see a struct's own declaration.  The import
+                            // is unused exactly when the inherent const wins, which is the common
+                            // case.
+                            #[allow(unused_imports)]
+                            use majit_metainterp::MajitImmutableFields as _;
+                            <#struct_path>::__MAJIT_IMMUTABLE_FIELDS
+                        },
                     );
                     __builder.getfield_gc_i(
                         #result_reg,
@@ -1305,6 +1327,17 @@ impl<'c> Lowerer<'c> {
                             #__fsize,
                             #__fsigned,
                         )],
+                        {
+                            // The struct's own `_immutable_fields_` declaration.  Read through
+                            // an in-scope trait rather than a qualified
+                            // `<T as MajitImmutableFields>::...`, which would select the blanket
+                            // empty default and never see a struct's own declaration.  The import
+                            // is unused exactly when the inherent const wins, which is the common
+                            // case.
+                            #[allow(unused_imports)]
+                            use majit_metainterp::MajitImmutableFields as _;
+                            <#struct_path>::__MAJIT_IMMUTABLE_FIELDS
+                        },
                     );
                     __builder.getfield_gc_r(
                         #result_reg,
@@ -1343,6 +1376,17 @@ impl<'c> Lowerer<'c> {
                             #__fsize,
                             #__fsigned,
                         )],
+                        {
+                            // The struct's own `_immutable_fields_` declaration.  Read through
+                            // an in-scope trait rather than a qualified
+                            // `<T as MajitImmutableFields>::...`, which would select the blanket
+                            // empty default and never see a struct's own declaration.  The import
+                            // is unused exactly when the inherent const wins, which is the common
+                            // case.
+                            #[allow(unused_imports)]
+                            use majit_metainterp::MajitImmutableFields as _;
+                            <#struct_path>::__MAJIT_IMMUTABLE_FIELDS
+                        },
                     );
                     __builder.getfield_gc_i(
                         #result_reg,
@@ -1521,6 +1565,17 @@ impl<'c> Lowerer<'c> {
                         ::core::mem::size_of::<usize>(),
                         false,
                     )],
+                    {
+                        // The struct's own `_immutable_fields_` declaration.  Read through
+                        // an in-scope trait rather than a qualified
+                        // `<T as MajitImmutableFields>::...`, which would select the blanket
+                        // empty default and never see a struct's own declaration.  The import
+                        // is unused exactly when the inherent const wins, which is the common
+                        // case.
+                        #[allow(unused_imports)]
+                        use majit_metainterp::MajitImmutableFields as _;
+                        <#struct_path>::__MAJIT_IMMUTABLE_FIELDS
+                    },
                 );
                 __builder.getfield_gc_r(
                     #buffer_reg,
@@ -1833,6 +1888,17 @@ impl<'c> Lowerer<'c> {
                             #__fsize,
                             #__fsigned,
                         )],
+                        {
+                            // The struct's own `_immutable_fields_` declaration.  Read through
+                            // an in-scope trait rather than a qualified
+                            // `<T as MajitImmutableFields>::...`, which would select the blanket
+                            // empty default and never see a struct's own declaration.  The import
+                            // is unused exactly when the inherent const wins, which is the common
+                            // case.
+                            #[allow(unused_imports)]
+                            use majit_metainterp::MajitImmutableFields as _;
+                            <#struct_path>::__MAJIT_IMMUTABLE_FIELDS
+                        },
                     );
                     __builder.setfield_gc_r(
                         #base_reg,
@@ -1870,6 +1936,17 @@ impl<'c> Lowerer<'c> {
                             #__fsize,
                             #__fsigned,
                         )],
+                        {
+                            // The struct's own `_immutable_fields_` declaration.  Read through
+                            // an in-scope trait rather than a qualified
+                            // `<T as MajitImmutableFields>::...`, which would select the blanket
+                            // empty default and never see a struct's own declaration.  The import
+                            // is unused exactly when the inherent const wins, which is the common
+                            // case.
+                            #[allow(unused_imports)]
+                            use majit_metainterp::MajitImmutableFields as _;
+                            <#struct_path>::__MAJIT_IMMUTABLE_FIELDS
+                        },
                     );
                     __builder.setfield_gc_i(
                         #base_reg,
@@ -1961,6 +2038,17 @@ impl<'c> Lowerer<'c> {
                             #__fsize,
                             #__fsigned,
                         )],
+                        {
+                            // The struct's own `_immutable_fields_` declaration.  Read through
+                            // an in-scope trait rather than a qualified
+                            // `<T as MajitImmutableFields>::...`, which would select the blanket
+                            // empty default and never see a struct's own declaration.  The import
+                            // is unused exactly when the inherent const wins, which is the common
+                            // case.
+                            #[allow(unused_imports)]
+                            use majit_metainterp::MajitImmutableFields as _;
+                            <#struct_path>::__MAJIT_IMMUTABLE_FIELDS
+                        },
                     );
                     __builder.setfield_gc_r(
                         #base_reg,
@@ -1997,6 +2085,17 @@ impl<'c> Lowerer<'c> {
                             #__fsize,
                             #__fsigned,
                         )],
+                        {
+                            // The struct's own `_immutable_fields_` declaration.  Read through
+                            // an in-scope trait rather than a qualified
+                            // `<T as MajitImmutableFields>::...`, which would select the blanket
+                            // empty default and never see a struct's own declaration.  The import
+                            // is unused exactly when the inherent const wins, which is the common
+                            // case.
+                            #[allow(unused_imports)]
+                            use majit_metainterp::MajitImmutableFields as _;
+                            <#struct_path>::__MAJIT_IMMUTABLE_FIELDS
+                        },
                     );
                     __builder.setfield_gc_i(
                         #base_reg,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -947,6 +947,20 @@ impl<'c> Lowerer<'c> {
         Some(binding)
     }
 
+    /// The struct `call_returns` declares for `func`'s result.
+    ///
+    /// A ref-returning call produces a ref binding, and the `result.field`
+    /// after it needs a struct to resolve the field against —
+    /// `lower_ref_binding_getfield` reads exactly this and bails without it,
+    /// which takes the whole dispatch arm down. The concrete path reads the
+    /// same declaration through `RefFieldRewriter`, so a binding that misses
+    /// it still computes the right answer and the loss shows up only as a
+    /// degraded arm.
+    fn declared_return_struct(&self, func: &Expr) -> Option<syn::Path> {
+        let segments = canonical_expr_segments(func)?;
+        self.config?.call_returns.get(&segments).cloned()
+    }
+
     pub(super) fn lower_call_value(&mut self, call: &ExprCall) -> Option<Binding> {
         let policy = self.resolve_call_policy(&call.func)?;
         if call.args.len() > MAX_HELPER_CALL_ARITY {
@@ -1154,18 +1168,11 @@ impl<'c> Lowerer<'c> {
                             quote! { let _ = __builder.live_placeholder(); },
                         );
                     }
-                    // Check `call_returns` config for a declared return
-                    // struct type, enabling subsequent `result.field`
-                    // access to resolve through `ref_fields`.
-                    let func_segments = canonical_expr_segments(func);
-                    let struct_type = func_segments.and_then(|segs| {
-                        self.config.and_then(|c| c.call_returns.get(&segs).cloned())
-                    });
                     return Some(Binding {
                         reg,
                         kind: BindingKind::Ref,
                         depends_on_stack: false,
-                        struct_type,
+                        struct_type: self.declared_return_struct(func),
                     });
                 }
                 crate::jit_interp::CallPolicyKind::NurseryAllocRef => {
@@ -1193,18 +1200,11 @@ impl<'c> Lowerer<'c> {
                             quote! { let _ = __builder.live_placeholder(); },
                         );
                     }
-                    // Check `call_returns` config for a declared return
-                    // struct type, enabling subsequent `result.field`
-                    // access to resolve through `ref_fields`.
-                    let func_segments = canonical_expr_segments(func);
-                    let struct_type = func_segments.and_then(|segs| {
-                        self.config.and_then(|c| c.call_returns.get(&segs).cloned())
-                    });
                     return Some(Binding {
                         reg,
                         kind: BindingKind::Ref,
                         depends_on_stack: false,
-                        struct_type,
+                        struct_type: self.declared_return_struct(func),
                     });
                 }
                 crate::jit_interp::CallPolicyKind::ResidualIntWrapped
@@ -1701,11 +1701,18 @@ impl<'c> Lowerer<'c> {
             );
         }
 
+        // Every `*_ref_wrapped` policy lands here rather than returning
+        // early above, and its result is a ref like theirs.
+        let struct_type = match result_kind {
+            BindingKind::Ref => self.declared_return_struct(func),
+            BindingKind::Int | BindingKind::Float => None,
+        };
+
         Some(Binding {
             reg,
             kind: result_kind,
             depends_on_stack,
-            struct_type: None,
+            struct_type,
         })
     }
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -1381,7 +1381,8 @@ impl<'c> Lowerer<'c> {
                 | crate::jit_interp::CallPolicyKind::InlineRef
                 | crate::jit_interp::CallPolicyKind::InlineFloat => {
                     result_kind = binding_kind_for_inline_policy(kind).unwrap();
-                    let builder_path = inline_builder_path(&call.func)?;
+                    let shared_path = inline_shared_path(&call.func)?;
+                    let sub_return_kind = jit_arg_kind_tokens(result_kind);
                     let prebuild_path = inline_prebuild_path(&call.func)?;
                     let (inline_call, post_live) = inline_call_tokens(&arg_bindings, reg);
                     let __arg_regs: Vec<Register> =
@@ -1405,12 +1406,9 @@ impl<'c> Lowerer<'c> {
                             vec![Register::new(result_kind, reg)],
                         ),
                         quote! {
-                            use majit_metainterp::jitcode::JitCodeRuntimeExt as _;
-                            let __sub_jitcode = #builder_path(__asm);
-                            let (__sub_return_kind, _) = __sub_jitcode
-                                .trailing_return_info()
-                                .expect("inline helper jitcode must end in a typed return opcode");
-                            let __sub_idx = __builder.add_sub_jitcode(__sub_jitcode);
+                            let __sub_edge = #shared_path(__asm);
+                            let __sub_return_kind = #sub_return_kind;
+                            let __sub_idx = __builder.add_sub_jitcode_ref(__sub_edge);
                             #inline_call
                         },
                     );
@@ -1552,13 +1550,14 @@ impl<'c> Lowerer<'c> {
                                     __builder.call_pure_int_canonical_via_target_or_memerror(__fn_idx, #typed_args, #reg);
                                 }
                                 #INT_INLINE => {
-                                    let __builder_fn: fn(&mut majit_metainterp::Assembler) -> majit_metainterp::JitCode =
+                                    // The policy byte hands over `_shared`, not `_with_asm`:
+                                    // the cache probe is what a recursive helper needs.
+                                    let __builder_fn: fn(&mut majit_metainterp::Assembler)
+                                        -> majit_metainterp::jitcode::InlineJitCodeRef =
                                         unsafe { std::mem::transmute(__inline_builder) };
-                                    let __sub_jitcode = __builder_fn(__asm);
-                                    let (__sub_return_kind, _) =
-                                        <majit_metainterp::JitCode as majit_metainterp::jitcode::JitCodeRuntimeExt>::trailing_return_info(&__sub_jitcode)
-                                        .expect("inline helper jitcode must end in a typed return opcode");
-                                    let __sub_idx = __builder.add_sub_jitcode(__sub_jitcode);
+                                    let __sub_edge = __builder_fn(__asm);
+                                    let __sub_return_kind = majit_metainterp::JitArgKind::Int;
+                                    let __sub_idx = __builder.add_sub_jitcode_ref(__sub_edge);
                                     #inline_call
                                 }
                                 #INT_MAY_FORCE => {
@@ -1650,13 +1649,14 @@ impl<'c> Lowerer<'c> {
                                     __builder.call_pure_int_canonical_via_target_or_memerror(__fn_idx, #typed_args, #reg);
                                 }
                                 #INT_INLINE => {
-                                let __builder_fn: fn(&mut majit_metainterp::Assembler) -> majit_metainterp::JitCode =
+                                // The policy byte hands over `_shared`, not `_with_asm`:
+                                // the cache probe is what a recursive helper needs.
+                                let __builder_fn: fn(&mut majit_metainterp::Assembler)
+                                    -> majit_metainterp::jitcode::InlineJitCodeRef =
                                     unsafe { std::mem::transmute(__inline_builder) };
-                                let __sub_jitcode = __builder_fn(__asm);
-                                let (__sub_return_kind, _) =
-                                    <majit_metainterp::JitCode as majit_metainterp::jitcode::JitCodeRuntimeExt>::trailing_return_info(&__sub_jitcode)
-                                    .expect("inline helper jitcode must end in a typed return opcode");
-                                let __sub_idx = __builder.add_sub_jitcode(__sub_jitcode);
+                                let __sub_edge = __builder_fn(__asm);
+                                let __sub_return_kind = majit_metainterp::JitArgKind::Int;
+                                let __sub_idx = __builder.add_sub_jitcode_ref(__sub_edge);
                                 #inline_call
                             }
                             #INT_MAY_FORCE => {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -669,6 +669,17 @@ impl<'c> Lowerer<'c> {
                     #type_id,
                     #headerless,
                     &[ #(#field_layout),* ],
+                    {
+                        // The struct's own `_immutable_fields_` declaration.  Read through
+                        // an in-scope trait rather than a qualified
+                        // `<T as MajitImmutableFields>::...`, which would select the blanket
+                        // empty default and never see a struct's own declaration.  The import
+                        // is unused exactly when the inherent const wins, which is the common
+                        // case.
+                        #[allow(unused_imports)]
+                        use majit_metainterp::MajitImmutableFields as _;
+                        <#struct_path>::__MAJIT_IMMUTABLE_FIELDS
+                    },
                 );
             },
         );

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -37,15 +37,14 @@ mod reexports {
     pub(super) use super::helpers::{
         binding_kind_for_inline_policy, binop_f_emit_tokens, binop_i_emit_tokens,
         block_has_loop_control, expr_has_loop_control, extract_block_tail_int,
-        extract_bool_branch_values, extract_branch_int, extract_pat_literals,
-        extract_pat_switch_case_tokens, extract_pat_value_tokens, extract_stmts,
-        inline_call_tokens, inline_call_tokens_void, inline_float_arg_tokens,
-        inline_int_arg_tokens, inline_prebuild_path, inline_ref_arg_tokens, inline_shared_path,
-        int_arg_regs, is_const_ident, is_supported_float_type, is_supported_int_cast,
-        is_supported_ref_type, is_word_width_int, jit_arg_kind_tokens, opcode_for_assign_binop,
-        opcode_for_assign_binop_f, opcode_for_binop, opcode_for_binop_f, opcode_for_compare_f,
-        stmt_has_loop_control, typed_call_arg_tokens, word_result_addr_for_kind,
-        word_result_addr_tokens,
+        extract_bool_branch_values, extract_branch_int, extract_pat_switch_case_tokens,
+        extract_pat_value_tokens, extract_stmts, inline_call_tokens, inline_call_tokens_void,
+        inline_float_arg_tokens, inline_int_arg_tokens, inline_prebuild_path,
+        inline_ref_arg_tokens, inline_shared_path, int_arg_regs, is_lowercase_binding_pat,
+        is_supported_float_type, is_supported_int_cast, is_supported_ref_type, is_word_width_int,
+        jit_arg_kind_tokens, opcode_for_assign_binop, opcode_for_assign_binop_f, opcode_for_binop,
+        opcode_for_binop_f, opcode_for_compare_f, stmt_has_loop_control, typed_call_arg_tokens,
+        word_result_addr_for_kind, word_result_addr_tokens,
     };
     pub(super) use super::liveness::{
         annotate_live_markers_with_liveness, compute_per_marker_liveness, get_liveness_info,
@@ -2446,27 +2445,6 @@ mod tests {
     fn liveness_triple_empty_when_set_is_empty() {
         let set: BTreeSet<Register> = BTreeSet::new();
         assert_eq!(liveness_triple(&set), (Vec::new(), Vec::new(), Vec::new()));
-    }
-
-    #[test]
-    fn extract_pat_literals_single() {
-        let pat = parse_pat("42");
-        let lits = extract_pat_literals(&pat);
-        assert_eq!(lits, Some(vec![42]));
-    }
-
-    #[test]
-    fn extract_pat_literals_or() {
-        let pat = parse_pat("1 | 2 | 3");
-        let lits = extract_pat_literals(&pat);
-        assert_eq!(lits, Some(vec![1, 2, 3]));
-    }
-
-    #[test]
-    fn extract_pat_literals_wildcard_returns_none() {
-        let pat = parse_pat("_");
-        let lits = extract_pat_literals(&pat);
-        assert_eq!(lits, None);
     }
 
     fn binding(reg: u16, kind: BindingKind) -> Binding {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -19,7 +19,7 @@ pub(crate) use api::{
 };
 #[allow(unused_imports)]
 pub use api::{try_generate_jitcode_body, try_generate_jitcode_body_with_config};
-pub(crate) use dispatch::lower_dispatch_body;
+pub(crate) use dispatch::{is_jit_merge_point_macro, lower_dispatch_body};
 pub(crate) use helpers::classify_param_type;
 pub(super) use helpers::helper_policy_path;
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -39,12 +39,12 @@ mod reexports {
         block_has_loop_control, expr_has_loop_control, extract_block_tail_int,
         extract_bool_branch_values, extract_branch_int, extract_pat_literals,
         extract_pat_switch_case_tokens, extract_pat_value_tokens, extract_stmts,
-        inline_builder_path, inline_call_tokens, inline_call_tokens_void, inline_float_arg_tokens,
-        inline_int_arg_tokens, inline_prebuild_path, inline_ref_arg_tokens, int_arg_regs,
-        is_supported_float_type, is_supported_int_cast, is_supported_ref_type, is_word_width_int,
-        opcode_for_assign_binop, opcode_for_assign_binop_f, opcode_for_binop, opcode_for_binop_f,
-        opcode_for_compare_f, stmt_has_loop_control, typed_call_arg_tokens,
-        word_result_addr_for_kind, word_result_addr_tokens,
+        inline_call_tokens, inline_call_tokens_void, inline_float_arg_tokens,
+        inline_int_arg_tokens, inline_prebuild_path, inline_ref_arg_tokens, inline_shared_path,
+        int_arg_regs, is_supported_float_type, is_supported_int_cast, is_supported_ref_type,
+        is_word_width_int, jit_arg_kind_tokens, opcode_for_assign_binop, opcode_for_assign_binop_f,
+        opcode_for_binop, opcode_for_binop_f, opcode_for_compare_f, stmt_has_loop_control,
+        typed_call_arg_tokens, word_result_addr_for_kind, word_result_addr_tokens,
     };
     pub(super) use super::liveness::{
         annotate_live_markers_with_liveness, compute_per_marker_liveness, get_liveness_info,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -41,10 +41,11 @@ mod reexports {
         extract_pat_switch_case_tokens, extract_pat_value_tokens, extract_stmts,
         inline_call_tokens, inline_call_tokens_void, inline_float_arg_tokens,
         inline_int_arg_tokens, inline_prebuild_path, inline_ref_arg_tokens, inline_shared_path,
-        int_arg_regs, is_supported_float_type, is_supported_int_cast, is_supported_ref_type,
-        is_word_width_int, jit_arg_kind_tokens, opcode_for_assign_binop, opcode_for_assign_binop_f,
-        opcode_for_binop, opcode_for_binop_f, opcode_for_compare_f, stmt_has_loop_control,
-        typed_call_arg_tokens, word_result_addr_for_kind, word_result_addr_tokens,
+        int_arg_regs, is_const_ident, is_supported_float_type, is_supported_int_cast,
+        is_supported_ref_type, is_word_width_int, jit_arg_kind_tokens, opcode_for_assign_binop,
+        opcode_for_assign_binop_f, opcode_for_binop, opcode_for_binop_f, opcode_for_compare_f,
+        stmt_has_loop_control, typed_call_arg_tokens, word_result_addr_for_kind,
+        word_result_addr_tokens,
     };
     pub(super) use super::liveness::{
         annotate_live_markers_with_liveness, compute_per_marker_liveness, get_liveness_info,

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -2291,6 +2291,16 @@ fn transform_function(config: &JitInterpConfig, func: &ItemFn) -> TokenStream {
                         }
                     }
                 }
+                // `let x = state.<ref_scalar>` → the local carries the
+                // `ref(T)` declaration's own pointee. The arm above answers
+                // the field-of-a-ref shape; this one is the ref itself, and
+                // without it `state.sel.value` compiles while the same read
+                // split across two statements does not.
+                if let Some(struct_path) = self.ref_struct_of_base(&init.expr)
+                    && let syn::Pat::Ident(pat_ident) = &local.pat
+                {
+                    self.record_local_ref(&pat_ident.ident.to_string(), struct_path);
+                }
                 // `let x = func(...)` where func is in `call_returns` →
                 // record x as a local ref binding with the declared type.
                 if let Expr::Call(call) = &*init.expr

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -1805,6 +1805,14 @@ fn parse_release_gil_save_err(attr: proc_macro2::TokenStream) -> syn::Result<i32
 /// harvest_immutable_fields_from_llbcs` reads it back into
 /// `SemanticProgram.immutable_fields` — the analog of RPython's
 /// translator reading `cls._immutable_fields_` off the class object.
+///
+/// The proc-macro front end has no such extraction step, so the same
+/// list is published a second way: an inherent associated const
+/// `__MAJIT_IMMUTABLE_FIELDS`, shadowing the empty default on
+/// `majit_metainterp::MajitImmutableFields`.  `jitcode_lower` reads it
+/// at each `register_struct_layout` emit site.  Both publications carry
+/// the entry list verbatim and neither splits it, so the suffix grammar
+/// stays in one place (`majit_translate::model::ImmutableRank::parse`).
 #[proc_macro_attribute]
 pub fn jit_immutable_fields(attr: TokenStream, item: TokenStream) -> TokenStream {
     let entries = parse_macro_input!(attr as ImmutableFieldList);
@@ -1816,12 +1824,25 @@ pub fn jit_immutable_fields(attr: TokenStream, item: TokenStream) -> TokenStream
     // harvester does the splitting, so the suffix grammar stays in one
     // place (`majit_translate::model::ImmutableRank::parse`).
     let joined = entries.0.join(",");
+    // The same declaration, published a second way for the proc-macro front
+    // end.  That path has no Charon extraction to harvest the marker const, so
+    // it reads the ranks straight off the type at the layout emit site;
+    // `majit_metainterp::MajitImmutableFields` supplies the empty default this
+    // shadows, which is what lets a site name a struct that declared nothing.
+    let ident = &item_struct.ident;
+    let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
     quote! {
         #item_struct
 
         #[doc(hidden)]
         #[allow(non_upper_case_globals, dead_code)]
         #vis const #const_name: &'static str = #joined;
+
+        impl #impl_generics #ident #ty_generics #where_clause {
+            #[doc(hidden)]
+            #[allow(non_upper_case_globals, dead_code)]
+            pub const __MAJIT_IMMUTABLE_FIELDS: &'static str = #joined;
+        }
     }
     .into()
 }

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -2616,6 +2616,8 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
         &args.inlined_prefix,
     );
     let helper_with_asm_name = format_ident!("__majit_inline_jitcode_{}_with_asm", sig.ident);
+    let helper_shared_name = format_ident!("__majit_inline_jitcode_{}_shared", sig.ident);
+    let helper_id_name = format_ident!("__majit_inline_jitcode_{}_id", sig.ident);
     let helper_prebuild_name = format_ident!("__majit_inline_jitcode_{}_prebuild", sig.ident);
     let policy_name = format_ident!("__majit_call_policy_{}", sig.ident);
     let helper_source_name = sig.ident.to_string();
@@ -2640,7 +2642,7 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
     let inferred_inline_builder = match helper.return_kind {
-        InlineReturnKind::Int => quote! { #helper_with_asm_name as *const () },
+        InlineReturnKind::Int => quote! { #helper_shared_name as *const () },
         InlineReturnKind::Ref | InlineReturnKind::Float | InlineReturnKind::Void => {
             quote! { std::ptr::null() }
         }
@@ -2715,7 +2717,61 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
         #vis fn #helper_prebuild_name(
             __asm: &mut majit_metainterp::Assembler,
         ) {
+            // `call.py CallControl.unfinished_graphs`: this walk descends into
+            // every statically resolved callee's prebuild, so a helper that
+            // reaches itself would recurse with nothing to stop it and no
+            // `JitCodeBuilder` in scope to decline.  Visiting once is also
+            // semantically free — the body only registers liveness triples,
+            // which `all_liveness_positions` already dedups.
+            if !__asm.enter_inline_prebuild(&#helper_id_name as *const _ as usize) {
+                return;
+            }
             #helper_liveness_prebuild
+        }
+
+        /// The helper's identity, as an address.
+        ///
+        /// `call.py CallControl.jitcodes` keys its cache by the graph object;
+        /// there is no graph object here, so a per-helper static stands in.
+        /// It carries a value so it cannot be merged with another helper's
+        /// marker by identical-code folding, which would silently make two
+        /// helpers share one jitcode.
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        #vis static #helper_id_name: std::sync::atomic::AtomicU8 =
+            std::sync::atomic::AtomicU8::new(0);
+
+        /// `call.py CallControl.get_jitcode` — cache first, then mint the
+        /// identity BEFORE assembling the body.
+        ///
+        /// That order is the whole point.  Upstream registers an empty JitCode
+        /// under the graph and fills it afterwards, so a graph that calls
+        /// itself links to the object it is already registered under.  Here the
+        /// identity comes from `Arc::new_cyclic`, which supplies a `Weak` to the
+        /// allocation before the value exists: the body assembles inside that
+        /// closure, and a self-call re-entering this function finds the
+        /// under-construction slot and takes a back edge instead of assembling
+        /// a second copy.
+        ///
+        /// Nothing inside the closure may upgrade that `Weak` — it does not
+        /// resolve until the value is published.
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        #vis fn #helper_shared_name(
+            __asm: &mut majit_metainterp::Assembler,
+        ) -> majit_metainterp::jitcode::InlineJitCodeRef {
+            let __key = &#helper_id_name as *const _ as usize;
+            if let Some(__hit) = majit_metainterp::jitcode::lookup_inline_jitcode(__asm, __key) {
+                return __hit;
+            }
+            let __arc = std::sync::Arc::new_cyclic(
+                |__weak: &std::sync::Weak<majit_metainterp::JitCode>| {
+                    majit_metainterp::jitcode::begin_inline_jitcode(__asm, __key, __weak.clone());
+                    #helper_with_asm_name(__asm)
+                },
+            );
+            majit_metainterp::jitcode::finish_inline_jitcode(__asm, __key, __arc.clone());
+            majit_metainterp::jitcode::InlineJitCodeRef::Strong(__arc)
         }
 
         #[doc(hidden)]

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -11154,7 +11154,7 @@ fn read_inline_call_jitcode(
         .jitcode
         .descr_at(idx)
         .unwrap_or_else(|| panic!("inline_call: descrs[{idx}] is absent from both descr pools"));
-    if let Some(jitcode) = entry.as_jitcode() {
+    if let Some(jitcode) = entry.as_jitcode_owned() {
         return (
             jitcode.try_index().unwrap_or(0),
             jitcode.fnaddr,
@@ -11723,7 +11723,7 @@ fn handler_inline_call_pyre_nested(
         .exec
         .descrs
         .get(sub_idx)
-        .and_then(crate::jitcode::RuntimeBhDescr::as_jitcode)
+        .and_then(crate::jitcode::RuntimeBhDescr::as_jitcode_owned)
         .unwrap_or_else(|| {
             panic!(
                 "BC_INLINE_CALL: descrs[{sub_idx}] is not a JitCode entry \

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -3550,10 +3550,16 @@ impl JitCodeBuilder {
     /// so an empty declaration reads as "not stated" rather than "takes
     /// nothing", and a genuinely nullary callee is indistinguishable from it.
     fn check_inline_call_arg_classes(&self, sub_jitcode_idx: u16, args: &[(JitArgKind, u16, u16)]) {
+        // `as_jitcode_owned`, so a recursive helper's back edge is checked
+        // like any other callee once it can be — and `let ... else` rather than
+        // an unwrap because it cannot be during the helper's own assembly: the
+        // `Weak` handed out by `Arc::new_cyclic` does not upgrade until the
+        // value is published.  Declining there costs nothing; the callee is
+        // this same jitcode and its own emit sites are checked.
         let Some(callee) = self
             .descrs
             .get(sub_jitcode_idx as usize)
-            .and_then(RuntimeBhDescr::as_jitcode)
+            .and_then(RuntimeBhDescr::as_jitcode_owned)
         else {
             return;
         };
@@ -5303,7 +5309,43 @@ impl JitCodeBuilder {
     /// that already hold a shared handle (e.g. a re-export from
     /// `MetaInterpStaticData::indirectcalltargets`).
     pub fn add_sub_jitcode_arc(&mut self, jitcode: std::sync::Arc<JitCode>) -> u16 {
+        // `assembler.py Assembler._encode_descr` memoises every descr through
+        // `_descr_dict`, and upstream's `JitCode` IS an `AbstractDescr`, so a
+        // jitcode operand goes through that memo like any other.  This was the
+        // one descr kind here that never got it: every other `add_*` on this
+        // builder already dedups by a linear scan.  It matters now because a
+        // helper that names itself twice would otherwise claim two slots for
+        // one callee.
+        if let Some(existing) = self.descrs.iter().position(|entry| {
+            matches!(entry, RuntimeBhDescr::JitCode(arc) if std::sync::Arc::ptr_eq(arc, &jitcode))
+        }) {
+            return existing as u16;
+        }
         self.push_descr_entry(RuntimeBhDescr::JitCode(jitcode))
+    }
+
+    /// Record whichever `j` edge an inline call site resolved.
+    ///
+    /// A back edge is deduped by the address it names rather than by `Arc`
+    /// identity: two `Weak`s cloned from one `Arc::new_cyclic` are distinct
+    /// values naming one allocation, and `Weak::ptr_eq` on an
+    /// under-construction target is the only comparison available — the
+    /// upgrade that `Arc::ptr_eq` would need returns `None` until assembly
+    /// finishes.
+    pub fn add_sub_jitcode_ref(&mut self, edge: crate::jitcode::InlineJitCodeRef) -> u16 {
+        match edge {
+            crate::jitcode::InlineJitCodeRef::Strong(arc) => self.add_sub_jitcode_arc(arc),
+            crate::jitcode::InlineJitCodeRef::BackEdge(weak) => {
+                let target = std::sync::Weak::as_ptr(&weak);
+                if let Some(existing) = self.descrs.iter().position(|entry| {
+                    matches!(entry, RuntimeBhDescr::JitCodeBackEdge(seen)
+                             if std::sync::Weak::as_ptr(seen) == target)
+                }) {
+                    return existing as u16;
+                }
+                self.push_descr_entry(RuntimeBhDescr::JitCodeBackEdge(weak))
+            }
+        }
     }
 
     pub fn add_fn_ptr(&mut self, ptr: *const ()) -> u16 {

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -9,6 +9,7 @@ use std::cmp::max;
 use majit_backend::JitCellToken;
 use majit_ir::OpCode;
 use majit_translate::jitcode::{BhFieldSpec, BhSizeSpec, HEADERLESS_SIZE_OWNER_MARKER};
+use majit_translate::model::ImmutableRank;
 
 use crate::jitcode;
 
@@ -570,6 +571,7 @@ impl JitCodeBuilder {
         type_id: u64,
         headerless: bool,
         fields: &[(usize, bool, &str, usize, bool)],
+        immutable_fields: &str,
     ) {
         self.touch_ref_reg(dest);
         // descr.py get_size_descr + init_size_descr: cache the
@@ -580,7 +582,7 @@ impl JitCodeBuilder {
         // traced.  It just carries no GcHeader, so it must never be
         // subject to GUARD_GC_TYPE (which reads at `ref - GcHeader::SIZE`).
         // `StructPtrInfo.make_guards` gates that guard on `!sd.headerless()`.
-        self.register_struct_layout(size, type_id, true, headerless, fields);
+        self.register_struct_layout(size, type_id, true, headerless, fields, immutable_fields);
         let all_fielddescrs = self
             .struct_size_specs
             .get(&type_id)
@@ -628,8 +630,13 @@ impl JitCodeBuilder {
         is_gc_managed: bool,
         headerless: bool,
         fields: &[(usize, bool, &str, usize, bool)],
+        immutable_fields: &str,
     ) {
         crate::note_struct_layout_registration(fields.len());
+        // `rclass.py _parse_field_list` splits the declaration once per class,
+        // not once per field.  Parsing here lets the merge path and the insert
+        // path below read the same ranks.
+        let ranks = Self::immutable_ranks(immutable_fields);
         // Every emit site re-registers the layout it accesses, so the same few
         // type_ids arrive hundreds of times.  When the spec already lists an
         // offset for each incoming field the merge below pushes nothing, and
@@ -642,7 +649,15 @@ impl JitCodeBuilder {
         // The same walk answers whether the offset that made a field redundant
         // was really *this* field's, so `Self::record_layout_conflicts` runs
         // off it rather than repeating it.
-        if let Some(existing) = self.struct_size_specs.get(&type_id) {
+        if let Some(existing) = self.struct_size_specs.get_mut(&type_id) {
+            // Apply the declaration before the early return decides there is
+            // nothing to do.  A struct's layout accumulates across emit sites
+            // in whatever order they lower, and not every site carries the
+            // declaration — a `new_struct` for a transient allocation names no
+            // struct to read it off.  Deciding on offsets alone would keep
+            // whichever site happened to arrive first.
+            Self::apply_immutable_ranks(&mut existing.all_fielddescrs, &ranks);
+            let existing = &*existing;
             let mut every_offset_known = true;
             for &field in fields {
                 if !Self::record_layout_conflicts(existing, type_id, field) {
@@ -653,7 +668,7 @@ impl JitCodeBuilder {
                 return;
             }
         }
-        let new_fields = Self::field_specs_from_layout(fields);
+        let new_fields = Self::field_specs_from_layout(fields, &ranks);
         // Merge into existing spec if present — each getfield/setfield
         // site registers only the field it accesses, so the complete
         // layout accumulates across multiple register_struct_layout
@@ -790,7 +805,58 @@ impl JitCodeBuilder {
     /// literal of the same struct an identical, deterministic
     /// `all_fielddescrs` order so the `type_id`-keyed cache is not polluted
     /// and the optimizer's `FieldDescr.n()` indexing stays consistent.
-    fn field_specs_from_layout(fields: &[(usize, bool, &str, usize, bool)]) -> Vec<BhFieldSpec> {
+    /// The merged layout recorded for `type_id`, or `None` when no emit site
+    /// has registered one.
+    ///
+    /// A struct's layout accumulates across every site that touches it, so this
+    /// answers what the *last* registration left, not what any single site
+    /// declared.
+    pub fn struct_size_spec(&self, type_id: u64) -> Option<&BhSizeSpec> {
+        self.struct_size_specs.get(&type_id)
+    }
+
+    /// The declared `(field name, rank)` pairs.
+    ///
+    /// The declaration travels from `#[jit_immutable_fields]` to here verbatim
+    /// and is split in exactly one place: `ImmutableRank::parse`, the port of
+    /// `rclass.py _parse_field_list`'s suffix grammar.
+    fn immutable_ranks(immutable_fields: &str) -> Vec<(String, ImmutableRank)> {
+        immutable_fields
+            .split(',')
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+            .map(ImmutableRank::parse)
+            .collect()
+    }
+
+    /// The rank declared for `name`, or `None` when the declaration omits it.
+    fn rank_of(ranks: &[(String, ImmutableRank)], name: &str) -> Option<ImmutableRank> {
+        ranks
+            .iter()
+            .find(|(declared, _)| declared == name)
+            .map(|&(_, rank)| rank)
+    }
+
+    /// Raise already-recorded fields to a declaration that arrived with a
+    /// later emit site.
+    ///
+    /// It only raises.  A field the declaration omits keeps what it has: an
+    /// omission means this site named no declaration, not that the field is
+    /// mutable — and the site that did name one may already have run.
+    fn apply_immutable_ranks(fields: &mut [BhFieldSpec], ranks: &[(String, ImmutableRank)]) {
+        for field in fields.iter_mut() {
+            let Some(rank) = Self::rank_of(ranks, &field.name) else {
+                continue;
+            };
+            field.is_immutable |= rank.is_immutable();
+            field.is_quasi_immutable |= rank.is_quasi_immutable();
+        }
+    }
+
+    fn field_specs_from_layout(
+        fields: &[(usize, bool, &str, usize, bool)],
+        ranks: &[(String, ImmutableRank)],
+    ) -> Vec<BhFieldSpec> {
         let mut ordered: Vec<(usize, bool, &str, usize, bool)> = fields.to_vec();
         ordered.sort_by_key(|&(offset, _, _, _, _)| offset);
         ordered
@@ -829,8 +895,10 @@ impl JitCodeBuilder {
                     field_type,
                     field_flag,
                     is_field_signed,
-                    is_immutable: false,
-                    is_quasi_immutable: false,
+                    is_immutable: Self::rank_of(ranks, name)
+                        .is_some_and(ImmutableRank::is_immutable),
+                    is_quasi_immutable: Self::rank_of(ranks, name)
+                        .is_some_and(ImmutableRank::is_quasi_immutable),
                     index_in_parent: idx,
                     // The emit-site layout table names fields but declares no
                     // header row, so the rebuilding side falls back to the
@@ -936,12 +1004,30 @@ impl JitCodeBuilder {
         // its own width and signedness.  The IR bank the access lands in
         // cannot: every integer read arrives here as `Type::Int` whether the
         // field is a byte or a word.
-        let (field_size, field_flag, is_field_signed) = slot
+        //
+        // Immutability rides the same lookup.  `rclass.py` attaches the
+        // `_immutable_fields_` rank to the field, so the registered layout is
+        // where it lives and this is the only place the emitted access can
+        // read it back.  A miss stays mutable: a field the layout does not
+        // name has no declaration to honour.
+        let (field_size, field_flag, is_field_signed, is_immutable, is_quasi_immutable) = slot
             .map(|idx| {
                 let f = &parent_spec.all_fielddescrs[idx];
-                (f.field_size, f.field_flag, f.is_field_signed)
+                (
+                    f.field_size,
+                    f.field_flag,
+                    f.is_field_signed,
+                    f.is_immutable,
+                    f.is_quasi_immutable,
+                )
             })
-            .unwrap_or((scalar_size(field_type), field_flag, is_field_signed));
+            .unwrap_or((
+                scalar_size(field_type),
+                field_flag,
+                is_field_signed,
+                false,
+                false,
+            ));
         // Carry the scalars only.  `patch_field_descr_parents`, called
         // unconditionally from `try_finish` after the decline early-return,
         // replaces this snapshot with `struct_size_specs`' final merged spec
@@ -964,8 +1050,8 @@ impl JitCodeBuilder {
             field_type,
             field_flag,
             is_field_signed,
-            is_immutable: false,
-            is_quasi_immutable: false,
+            is_immutable,
+            is_quasi_immutable,
             index_in_parent,
             parent: parent.map(std::sync::Arc::new),
             name,
@@ -2052,6 +2138,9 @@ impl JitCodeBuilder {
                     false,
                 ),
             ],
+            // The JIT synthesizes this header; there is no declaring struct to
+            // read a `_immutable_fields_` list off.
+            "",
         );
         let all_fielddescrs = self
             .struct_size_specs
@@ -6486,10 +6575,10 @@ mod tests {
         const TID: u64 = 0x5747_5F49_4458;
         let mut builder = JitCodeBuilder::new();
         // Site 1 registers only the HIGH offset, so the mint ranks it 0.
-        builder.register_struct_layout(24, TID, false, false, &[(16, false, "hi", 8, true)]);
+        builder.register_struct_layout(24, TID, false, false, &[(16, false, "hi", 8, true)], "");
         builder.getfield_gc_i(0, 1, 16, TID, "hi");
         // Site 2 registers the LOW offset; the merge re-indexes to {8→0, 16→1}.
-        builder.register_struct_layout(24, TID, false, false, &[(8, false, "lo", 8, true)]);
+        builder.register_struct_layout(24, TID, false, false, &[(8, false, "lo", 8, true)], "");
         builder.getfield_gc_i(2, 1, 8, TID, "lo");
         let jitcode = builder.finish();
 
@@ -6562,6 +6651,7 @@ mod tests {
                 false,
                 false,
                 &[(8, false, "agg", 8, true), (8, true, "leaf", 8, false)],
+                "",
             );
             builder.getfield_gc_i(0, 1, 8, TID, name);
             // `finish` runs the postcondition under `jit_strict_mode`; a
@@ -6620,17 +6710,29 @@ mod tests {
             (8, true, "leaf", 8, false),
         ];
         assert_eq!(
-            super::field_slot_in(&JitCodeBuilder::field_specs_from_layout(&fields), "leaf", 8,),
+            super::field_slot_in(
+                &JitCodeBuilder::field_specs_from_layout(&fields, &[]),
+                "leaf",
+                8,
+            ),
             Some(2),
             "the name names the field; the shared offset does not",
         );
         assert_eq!(
-            super::field_slot_in(&JitCodeBuilder::field_specs_from_layout(&fields), "", 8),
+            super::field_slot_in(
+                &JitCodeBuilder::field_specs_from_layout(&fields, &[]),
+                "",
+                8
+            ),
             None,
             "without a name the shared offset arbitrates nothing",
         );
         assert_eq!(
-            super::field_slot_in(&JitCodeBuilder::field_specs_from_layout(&fields), "", 0),
+            super::field_slot_in(
+                &JitCodeBuilder::field_specs_from_layout(&fields, &[]),
+                "",
+                0
+            ),
             Some(0),
             "an unambiguous offset still resolves",
         );
@@ -6703,7 +6805,7 @@ mod tests {
     #[test]
     fn canonical_new_struct_emit_uses_size_descr_without_vtable() {
         let mut builder = JitCodeBuilder::new();
-        builder.new_struct(3, 16, 0xCD, false, &[]);
+        builder.new_struct(3, 16, 0xCD, false, &[], "");
         let jitcode = builder.finish();
         let opcode = jitcode::insn_byte("new/d>r");
         assert_eq!(jitcode.code, vec![opcode, 0, 0, 3]);

--- a/majit/majit-metainterp/src/jitcode/mod.rs
+++ b/majit/majit-metainterp/src/jitcode/mod.rs
@@ -242,6 +242,19 @@ pub enum RuntimeBhDescr {
     /// `blackhole.py:150-157` — `argtype == 'j' → descrs[idx]` asserted
     /// `isinstance(value, JitCode)`.
     JitCode(std::sync::Arc<JitCode>),
+    /// The same `j` edge, non-owning: the back edge of a self- or mutually
+    /// recursive `#[jit_inline]` helper, pointing at a jitcode that is still
+    /// being assembled when the edge is recorded.
+    ///
+    /// `CallControl.get_jitcode` hands a recursive graph the shell it is
+    /// already registered under, and CPython's collector reclaims the resulting
+    /// cycle.  `Arc` has no collector, so the ownership classification stands in
+    /// for one: the owning edge keeps the callee alive, the back edge does not,
+    /// and a helper that names itself does not pin itself forever.
+    ///
+    /// Both variants name the same allocation, so everything downstream reads
+    /// identically through [`Self::as_jitcode_owned`].
+    JitCodeBackEdge(std::sync::Weak<JitCode>),
     /// Target function for `BC_CALL_*` / `BC_RESIDUAL_CALL_*`.
     /// RPython `blackhole.py:1225-1256` reads the function address
     /// from an int register (`i` argcode) and the calling convention
@@ -270,9 +283,31 @@ impl RuntimeBhDescr {
 
     /// RPython parity: `isinstance(value, JitCode)` assertion at
     /// `blackhole.py:156`.  Returns the callee JitCode for `BC_INLINE_CALL`.
+    ///
+    /// **Owning edges only.**  A back edge answers `None` here, and callers
+    /// that walk the pool to number or publish sub-jitcodes rely on that:
+    /// `build_jitcode_registry` asserts each sub-jitcode it reaches is unnumbered,
+    /// and a recursive helper's back edge names a jitcode that walk has already
+    /// numbered.  Use [`Self::as_jitcode_owned`] where the question is "what
+    /// does this `j` operand execute".
     pub fn as_jitcode(&self) -> Option<&std::sync::Arc<JitCode>> {
         match self {
             Self::JitCode(arc) => Some(arc),
+            _ => None,
+        }
+    }
+
+    /// The callee a `j` operand names, whichever kind of edge recorded it.
+    ///
+    /// `None` for a back edge whose callee is still under construction — the
+    /// `Weak` cannot be upgraded from inside `Arc::new_cyclic`.  Every caller
+    /// must treat that as "not answerable yet" and decline, never unwrap: it is
+    /// a build-time window, not a missing target, and by the time anything
+    /// executes the `j` operand the upgrade succeeds.
+    pub fn as_jitcode_owned(&self) -> Option<std::sync::Arc<JitCode>> {
+        match self {
+            Self::JitCode(arc) => Some(std::sync::Arc::clone(arc)),
+            Self::JitCodeBackEdge(weak) => weak.upgrade(),
             _ => None,
         }
     }
@@ -292,6 +327,66 @@ impl RuntimeBhDescr {
             _ => None,
         }
     }
+}
+
+/// What the `Assembler`'s helper cache holds for one `#[jit_inline]` helper.
+///
+/// Two states because a recursive helper is reachable while it is still being
+/// assembled, and the answer differs: mid-assembly there is no `Arc` to hand
+/// out yet, only the `Weak` that `Arc::new_cyclic` supplies.
+pub enum InlineJitCodeSlot {
+    /// The body is being assembled right now.  Anything that reaches the helper
+    /// from inside its own assembly gets this.
+    UnderConstruction(std::sync::Weak<JitCode>),
+    /// Assembly finished; later callers link to the finished jitcode directly.
+    Finished(std::sync::Arc<JitCode>),
+}
+
+/// The edge an inline call site should record for a helper.
+pub enum InlineJitCodeRef {
+    /// A normal call: the caller owns a reference to its callee.
+    Strong(std::sync::Arc<JitCode>),
+    /// A recursive call: the callee is (transitively) the caller, so an owning
+    /// edge would be a cycle of `Arc`s that never drops.
+    BackEdge(std::sync::Weak<JitCode>),
+}
+
+/// `call.py CallControl.get_jitcode`'s cache probe.
+///
+/// `None` means this helper has not been entered, and the caller must assemble
+/// it — registering the shell with [`begin_inline_jitcode`] BEFORE the body, so
+/// that a self-call arriving during assembly finds this probe answering.
+pub fn lookup_inline_jitcode(asm: &crate::Assembler, key: usize) -> Option<InlineJitCodeRef> {
+    let slot = asm.inline_jitcode_slot(key)?;
+    match (**slot).downcast_ref::<InlineJitCodeSlot>()? {
+        InlineJitCodeSlot::UnderConstruction(weak) => {
+            Some(InlineJitCodeRef::BackEdge(weak.clone()))
+        }
+        InlineJitCodeSlot::Finished(arc) => {
+            Some(InlineJitCodeRef::Strong(std::sync::Arc::clone(arc)))
+        }
+    }
+}
+
+/// Register the helper's identity before its body exists.
+///
+/// This is the whole mechanism: `make_jitcodes` mints one JitCode per graph up
+/// front and fills bodies afterwards, so the identity a recursive call links to
+/// is available before there is anything to link.
+pub fn begin_inline_jitcode(
+    asm: &mut crate::Assembler,
+    key: usize,
+    weak: std::sync::Weak<JitCode>,
+) {
+    asm.inline_jitcode_insert(
+        key,
+        std::sync::Arc::new(InlineJitCodeSlot::UnderConstruction(weak)),
+    );
+}
+
+/// Publish the finished jitcode, so later call sites take an owning edge.
+pub fn finish_inline_jitcode(asm: &mut crate::Assembler, key: usize, arc: std::sync::Arc<JitCode>) {
+    asm.inline_jitcode_insert(key, std::sync::Arc::new(InlineJitCodeSlot::Finished(arc)));
 }
 
 /// Runtime view of the process-global build-time descriptor pool.

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -877,6 +877,29 @@ pub fn record_struct_layout_conflict(conflict: StructLayoutConflict) {
     conflicts.push(conflict);
 }
 
+/// A struct's `_immutable_fields_` declaration, readable by name.
+///
+/// `rclass.py InstanceRepr` reads `cls._immutable_fields_` off the class
+/// object, and every consumer goes through that one read. The proc-macro front
+/// end has no class object to read: `#[majit_macros::jit_immutable_fields]`
+/// publishes the declaration as an inherent associated const of the same name,
+/// which shadows the empty default below.
+///
+/// The blanket impl is what makes the read unconditional. A layout emit site
+/// names its struct without knowing whether that struct declared anything, and
+/// stable Rust cannot ask; a struct that never opted in answers `""` here
+/// instead of failing to resolve.
+///
+/// Generated code must bring this trait into scope with `use ... as _` and read
+/// `<T>::__MAJIT_IMMUTABLE_FIELDS`. Spelling it
+/// `<T as MajitImmutableFields>::__MAJIT_IMMUTABLE_FIELDS` would select this
+/// default even for a struct that declared one.
+pub trait MajitImmutableFields {
+    const __MAJIT_IMMUTABLE_FIELDS: &'static str = "";
+}
+
+impl<T: ?Sized> MajitImmutableFields for T {}
+
 /// Count `fields` submitted field descriptions.
 pub fn note_struct_layout_registration(fields: usize) {
     STRUCT_LAYOUT_REGISTRATIONS.fetch_add(fields, std::sync::atomic::Ordering::Relaxed);

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -12363,7 +12363,7 @@ mod tests {
         // SizeDescr (size from the per-jitcode descr pool) and binds the
         // allocation pointer to the destination ref register.
         let mut builder = JitCodeBuilder::new();
-        builder.new_struct(0, 16, 0xCD, false, &[]);
+        builder.new_struct(0, 16, 0xCD, false, &[], "");
         let jitcode = builder.finish();
 
         let mut ctx = TraceCtx::for_test(0);
@@ -12488,6 +12488,7 @@ mod tests {
             0xCD,
             false,
             &[(0, false, "value", 8, true), (8, true, "next", 8, false)],
+            "",
         ); // ref reg 0 = Node*
         builder.load_const_i_value(0, 99); // int reg 0 = 99
         builder.setfield_gc_i(0, 0, 0, 0xCD, "value"); // Node.value = 99
@@ -12560,6 +12561,7 @@ mod tests {
             0xCD,
             false,
             &[(0, false, "value", 8, true), (8, true, "next", 8, false)],
+            "",
         );
         builder.load_const_i_value(0, 99);
         builder.setfield_gc_i(0, 0, 0, 0xCD, "value");
@@ -12598,6 +12600,7 @@ mod tests {
             0xCE,
             false,
             &[(0, false, "value", 8, true), (8, true, "next", 8, false)],
+            "",
         );
         builder.setfield_gc_i_c(0, -7, 0, 0xCE, "value"); // Node.value = -7 (inline const)
         let jitcode = builder.finish();

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -6807,16 +6807,20 @@ where
                 let pc = self.frames.current_mut().pc;
                 // RPython `blackhole.py:150-157` — `j` argcode resolves
                 // via `self.descrs[idx]` asserted to be a `JitCode`.
+                // `as_jitcode_owned`, so a recursive helper's back edge resolves
+                // to the same callee an owning edge would.  By the time anything
+                // executes this operand the callee is published, so the `Weak`
+                // upgrades; the `None` window is confined to the helper's own
+                // assembly, which never runs code.
                 let sub_jitcode = self
                     .frames
                     .current_mut()
                     .jitcode
                     .descr_at(sub_idx)
-                    .and_then(crate::jitcode::RuntimeBhDescr::as_jitcode)
+                    .and_then(crate::jitcode::RuntimeBhDescr::as_jitcode_owned)
                     .unwrap_or_else(|| {
                         panic!("BC_INLINE_CALL: descrs[{sub_idx}] is not a JitCode entry")
-                    })
-                    .clone();
+                    });
                 let mut sub_frame = MIFrame::setup(sub_jitcode, 0, None, Some(ctx));
                 ctx.push_inline_frame((sub_idx, pc), u32::MAX);
                 sub_frame.inline_frame = true;

--- a/majit/majit-metainterp/tests/immutable_fields_declaration.rs
+++ b/majit/majit-metainterp/tests/immutable_fields_declaration.rs
@@ -1,0 +1,82 @@
+//! One declaration, two front ends.
+//!
+//! `#[jit_immutable_fields]` was harvested only out of Charon's `global_decls`,
+//! which the proc-macro path never produces.  Rather than add a second place to
+//! write the list, the attribute publishes the same string twice: the marker
+//! const the LLBC harvester reads, and an inherent associated const the layout
+//! emit sites read.
+//!
+//! The second one has to answer for a struct that never declared anything —
+//! an emit site names its struct without knowing — so the reads below cover
+//! both halves.  Reading through the trait explicitly is deliberately *not*
+//! tested as equivalent: it is the spelling generated code must avoid.
+
+use majit_metainterp::MajitImmutableFields as _;
+
+#[majit_macros::jit_immutable_fields("left", "right", "kind", "ch")]
+#[repr(C)]
+struct Declared {
+    kind: u8,
+    ch: u8,
+    marked: u8,
+    left: usize,
+    right: usize,
+}
+
+#[repr(C)]
+struct OptedOut {
+    x: usize,
+}
+
+#[test]
+fn a_declaring_struct_exposes_its_ranks_by_inherent_const() {
+    assert_eq!(
+        <Declared>::__MAJIT_IMMUTABLE_FIELDS,
+        "left,right,kind,ch",
+        "the inherent const must shadow the blanket-trait default",
+    );
+}
+
+#[test]
+fn a_struct_that_never_declared_falls_back_to_empty() {
+    assert_eq!(
+        <OptedOut>::__MAJIT_IMMUTABLE_FIELDS,
+        "",
+        "an emit site names every struct it registers a layout for, including \
+         ones that opted out; the read must resolve rather than fail to compile",
+    );
+}
+
+#[test]
+fn the_marker_const_the_llbc_harvester_reads_still_exists() {
+    // `harvest_immutable_fields_from_llbcs` reads this one.  Publishing the
+    // declaration a second way must not disturb the first.
+    assert_eq!(_immutable_fields_Declared, "left,right,kind,ch");
+}
+
+#[test]
+fn the_two_publications_carry_the_same_list() {
+    assert_eq!(
+        _immutable_fields_Declared,
+        <Declared>::__MAJIT_IMMUTABLE_FIELDS
+    );
+}
+
+#[test]
+fn the_struct_definition_is_left_intact() {
+    // The attribute documents that it does not rewrite the struct.  A field
+    // list that survived expansion is what every downstream `offset_of!` in a
+    // layout emit site depends on.
+    let node = Declared {
+        kind: 0,
+        ch: b'a',
+        marked: 1,
+        left: 0,
+        right: 0,
+    };
+    assert_eq!(node.kind, 0);
+    assert_eq!(node.ch, b'a');
+    assert_eq!(node.marked, 1);
+    assert_eq!(node.left, 0);
+    assert_eq!(node.right, 0);
+}

--- a/majit/majit-metainterp/tests/immutable_fields_layout.rs
+++ b/majit/majit-metainterp/tests/immutable_fields_layout.rs
@@ -1,0 +1,189 @@
+//! `_immutable_fields_` must survive the emit-site layout table.
+//!
+//! The declaration reaches the proc-macro path as a string on the struct, and
+//! the layout table is the only channel between that string and the field
+//! descrs the optimizer reads.  It carried offsets, widths and pointer-ness and
+//! dropped immutability on the floor.
+//!
+//! Registration order is the interesting part.  A struct's layout accumulates
+//! across every emit site that touches it, and not all of them name a declaring
+//! struct — a `new_struct` for a transient allocation names none.  So these
+//! cover a declaration arriving first, arriving last, and never arriving.
+
+use majit_metainterp::JitCodeBuilder;
+
+/// Distinct per test: the layout registry is per-builder, but the conflict
+/// registry these registrations also feed is process-global.
+const TID_RANKS: u64 = 0x494D_4D55_5401;
+const TID_UNDECLARED: u64 = 0x494D_4D55_5402;
+const TID_LATE: u64 = 0x494D_4D55_5403;
+const TID_NEVER: u64 = 0x494D_4D55_5404;
+
+const NODE: &[(usize, bool, &str, usize, bool)] = &[
+    (0, false, "kind", 1, false),
+    (2, false, "marked", 1, false),
+    (8, true, "left", 8, false),
+    (16, false, "version", 8, true),
+];
+
+fn field<'a>(
+    builder: &'a JitCodeBuilder,
+    type_id: u64,
+    name: &str,
+) -> &'a majit_translate::jitcode::BhFieldSpec {
+    builder
+        .struct_size_spec(type_id)
+        .unwrap_or_else(|| panic!("no layout registered for {type_id:#x}"))
+        .all_fielddescrs
+        .iter()
+        .find(|f| f.name == name)
+        .unwrap_or_else(|| panic!("{name} missing from the registered layout"))
+}
+
+#[test]
+fn declared_ranks_land_on_the_field_specs() {
+    let mut builder = JitCodeBuilder::new();
+    builder.register_struct_layout(24, TID_RANKS, false, false, NODE, "kind,left,version?");
+
+    assert!(field(&builder, TID_RANKS, "kind").is_immutable);
+    assert!(field(&builder, TID_RANKS, "left").is_immutable);
+}
+
+#[test]
+fn a_quasi_immutable_entry_is_recorded_as_quasi() {
+    // `rclass.py _parse_field_list`'s `?` suffix.  The two flags are disjoint:
+    // `ImmutableRanking.pure` is false for the quasi ranks, because a
+    // quasi-immutable read is pinned by `record_quasiimmut_field` plus a guard
+    // rather than by the descr's pure flag.  Setting both would make the read
+    // unconditionally foldable and drop the guard that protects it.
+    let mut builder = JitCodeBuilder::new();
+    builder.register_struct_layout(24, TID_RANKS + 16, false, false, NODE, "version?");
+
+    let version = field(&builder, TID_RANKS + 16, "version");
+    assert!(version.is_quasi_immutable);
+    assert!(
+        !version.is_immutable,
+        "the pure flag is false for a quasi rank — the same pair the LLBC front \
+         end writes from `ImmutableRank::is_immutable` / `is_quasi_immutable`",
+    );
+}
+
+#[test]
+fn an_undeclared_field_stays_mutable() {
+    let mut builder = JitCodeBuilder::new();
+    builder.register_struct_layout(24, TID_UNDECLARED, false, false, NODE, "kind,left");
+
+    let marked = field(&builder, TID_UNDECLARED, "marked");
+    assert!(
+        !marked.is_immutable,
+        "the mark is the mutable state; folding its read is wrong code",
+    );
+    assert!(!marked.is_quasi_immutable);
+}
+
+#[test]
+fn a_declaration_arriving_after_an_undeclared_site_still_applies() {
+    // The registration order that would otherwise lose it: a site with no
+    // declaration registers the whole layout first, so every offset is already
+    // known and the second registration has nothing new to append.
+    let mut builder = JitCodeBuilder::new();
+    builder.register_struct_layout(24, TID_LATE, false, false, NODE, "");
+    assert!(!field(&builder, TID_LATE, "left").is_immutable);
+
+    builder.register_struct_layout(24, TID_LATE, false, false, NODE, "kind,left");
+    assert!(
+        field(&builder, TID_LATE, "left").is_immutable,
+        "emit sites lower in an arbitrary order; the declaration must not \
+         depend on arriving first",
+    );
+    assert!(field(&builder, TID_LATE, "kind").is_immutable);
+    assert!(!field(&builder, TID_LATE, "marked").is_immutable);
+}
+
+#[test]
+fn a_later_site_without_a_declaration_does_not_clear_one() {
+    // The mirror image, and the reason the merge only ever raises: a site that
+    // names no declaration is silent about the struct, not a claim that its
+    // fields are mutable.
+    let mut builder = JitCodeBuilder::new();
+    builder.register_struct_layout(24, TID_NEVER, false, false, NODE, "kind,left");
+    builder.register_struct_layout(24, TID_NEVER, false, false, NODE, "");
+
+    assert!(field(&builder, TID_NEVER, "left").is_immutable);
+    assert!(field(&builder, TID_NEVER, "kind").is_immutable);
+}
+
+#[test]
+fn a_struct_that_declares_nothing_has_no_immutable_field() {
+    let mut builder = JitCodeBuilder::new();
+    builder.register_struct_layout(24, TID_NEVER + 16, false, false, NODE, "");
+
+    for (_, _, name, _, _) in NODE {
+        assert!(
+            !field(&builder, TID_NEVER + 16, name).is_immutable,
+            "{name} was declared immutable by nothing",
+        );
+    }
+}
+
+/// The declaration is inert until the *minted descr* carries it.
+///
+/// `BhFieldSpec` is a way station.  What the optimizer reads is the
+/// `CanonicalBhDescr::Field` the emit site mints, and that site resolved its
+/// width, flag and signedness off the registered layout while writing
+/// immutability as a literal `false` — so the whole chain could be correct and
+/// still fold nothing.
+mod minted_descr {
+    use super::*;
+    use majit_metainterp::jitcode::CanonicalBhDescr;
+
+    const TID_MINT: u64 = 0x494D_4D55_5410;
+
+    fn immutability_of(field_name: &str, declaration: &str) -> (bool, bool) {
+        let mut builder = JitCodeBuilder::new();
+        builder.ensure_i_regs(2);
+        builder.ensure_r_regs(2);
+        builder.register_struct_layout(24, TID_MINT, false, false, NODE, declaration);
+        // The access is what mints the descr; registering the layout alone
+        // does not.
+        builder.getfield_gc_i(0, 1, 2, TID_MINT, field_name);
+        let jitcode = builder.finish();
+        jitcode
+            .exec
+            .descrs
+            .iter()
+            .find_map(|entry| match entry.as_bh_descr() {
+                Some(CanonicalBhDescr::Field {
+                    name,
+                    is_immutable,
+                    is_quasi_immutable,
+                    ..
+                }) if name == field_name => Some((*is_immutable, *is_quasi_immutable)),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("no Field descr minted for {field_name}"))
+    }
+
+    #[test]
+    fn a_declared_field_mints_an_immutable_descr() {
+        assert_eq!(
+            immutability_of("marked", "marked"),
+            (true, false),
+            "the declaration must reach the descr the emit site mints, not just \
+             the layout spec it is resolved against",
+        );
+    }
+
+    #[test]
+    fn an_undeclared_field_mints_a_mutable_descr() {
+        assert_eq!(immutability_of("marked", "kind,left"), (false, false));
+    }
+
+    #[test]
+    fn a_quasi_declared_field_mints_a_quasi_descr() {
+        // `is_always_pure` is `is_immutable && !is_quasi_immutable`, so this
+        // pair is what keeps a quasi-immutable read behind its guard instead
+        // of folding it outright.
+        assert_eq!(immutability_of("marked", "marked?"), (false, true));
+    }
+}

--- a/majit/majit-metainterp/tests/jit_inline_self_recursive.rs
+++ b/majit/majit-metainterp/tests/jit_inline_self_recursive.rs
@@ -1,0 +1,193 @@
+//! A `#[jit_inline]` helper that calls itself.
+//!
+//! `codewriter.py CodeWriter.make_jitcodes` emits one JitCode per graph and
+//! links callees by index; `CallControl.get_jitcode` mints and caches an empty
+//! JitCode under the graph BEFORE the body is written, so a graph that calls
+//! itself links to the object it is already registered under. Nothing here did
+//! that: the inline lowering emitted a plain Rust call to the helper's builder,
+//! so `f` calling `f` recursed until the stack was gone — at jitcode-BUILD
+//! time, during warmup, before any tracing.
+//!
+//! It is not a caching problem. `add_sub_jitcode` pushes an `Arc<JitCode>` into
+//! the CURRENT builder's own descr pool, so direct self-recursion asks for a
+//! jitcode whose pool holds an `Arc` to itself. The identity now comes from
+//! `Arc::new_cyclic`, and the self-edge is recorded as a `Weak` — which is what
+//! keeps it from being a cycle of owning references that never drops.
+//!
+//! Reaching the first assertion at all is the first result: before this, the
+//! process died in `dispatch_sum(..)` with a stack overflow.
+//!
+//! The compiled loop, measured (identical on dynasm and cranelift): four
+//! `value` reads and four `next` reads in the preamble, no call of any kind.
+//!
+//! ```text
+//! Label GetfieldGcI GetfieldGcR GetfieldGcI GetfieldGcR GetfieldGcI GetfieldGcR
+//!       GetfieldGcI GetfieldGcR IntAdd IntAdd IntAdd IntAdd IntSub IntIsTrue GuardTrue
+//! Label GetfieldGcR GetfieldGcI GetfieldGcR GetfieldGcI GetfieldGcR
+//!       IntAdd IntAdd IntAdd IntAdd IntSub IntIsTrue GuardTrue Jump
+//! ```
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use majit_ir::OpCode;
+use majit_metainterp::JitDriver;
+
+static COMPILES: AtomicUsize = AtomicUsize::new(0);
+static COMPILED: Mutex<Vec<OpCode>> = Mutex::new(Vec::new());
+
+/// The chain the helper walks. Kept under `MAX_INLINE_DEPTH` so this fixture
+/// measures the build-time defect and nothing else.
+const LINKS: i64 = 4;
+const TICKS: i64 = 400;
+
+#[repr(C)]
+struct Link {
+    value: i64,
+    next: *mut Link,
+}
+
+/// Recursive by construction: the `n > 0` arm calls this same function.
+#[majit_macros::jit_inline(
+    ref_params = { node: ref(Link) },
+    ref_fields = { Link::next => Link },
+    int_fields = { Link::value => i64 },
+)]
+fn sum_chain(node: usize, n: i64) -> i64 {
+    if n <= 0i64 {
+        0i64
+    } else {
+        let v = node.value;
+        let rest = node.next;
+        v + sum_chain(rest, n - 1i64)
+    }
+}
+
+pub type Bytecode = [u8];
+
+struct SumState {
+    head: usize,
+    acc: i64,
+    ticks: i64,
+}
+
+const OP_SUM: u8 = 1;
+const OP_TICK: u8 = 2;
+const OP_HALT: u8 = 3;
+const PROGRAM: [u8; 3] = [OP_SUM, OP_TICK, OP_HALT];
+
+#[majit_macros::jit_interp(
+    state = SumState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = {
+        head: ref(Link),
+        acc: int,
+        ticks: int,
+    },
+    ref_fields = { Link::next => Link },
+    int_fields = { Link::value => i64 },
+    calls = { sum_chain => inline_int },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_sum(program: &Bytecode, threshold: u32, head: usize, ticks: i64) -> i64 {
+    let mut driver: JitDriver<SumState> = JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_gk, _before, _after, opcodes| {
+        COMPILES.fetch_add(1, Ordering::Relaxed);
+        *COMPILED.lock().unwrap() = opcodes.to_vec();
+    });
+    let mut pc: usize = 0;
+    let mut state = SumState {
+        head,
+        acc: 0i64,
+        ticks,
+    };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_SUM => {
+                state.acc = state.acc + sum_chain(state.head, LINKS);
+            }
+            OP_TICK => {
+                state.ticks = state.ticks - 1i64;
+                if state.ticks != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            OP_HALT => break,
+            _ => break,
+        }
+    }
+    state.acc
+}
+
+/// Link `i` holds `i + 1`, so a walk that stops early or repeats a link sums
+/// differently.
+fn chain() -> usize {
+    let mut head: *mut Link = std::ptr::null_mut();
+    for i in (0..LINKS).rev() {
+        head = Box::leak(Box::new(Link {
+            value: i + 1,
+            next: head,
+        })) as *mut Link;
+    }
+    head as usize
+}
+
+fn expected() -> i64 {
+    TICKS * (1..=LINKS).sum::<i64>()
+}
+
+#[test]
+fn a_self_recursive_inline_helper_builds_and_runs() {
+    // Getting here is the first assertion; the old lowering never returned.
+    let cold = dispatch_sum(&PROGRAM, u32::MAX, chain(), TICKS);
+    assert_eq!(cold, expected(), "the cold arm states the answer");
+
+    let warm = dispatch_sum(&PROGRAM, 8, chain(), TICKS);
+    assert_eq!(
+        warm, cold,
+        "the compiled recursive walk disagreed with the interpreter",
+    );
+    assert!(
+        COMPILES.load(Ordering::Relaxed) > 0,
+        "nothing compiled, so the warm answer above was the interpreter's too",
+    );
+}
+
+/// The walk must actually be IN the trace.
+///
+/// A recursive helper that failed to link would degrade to a residual call, and
+/// the answer would still be right — so agreement alone does not say the
+/// self-edge resolved.
+#[test]
+fn the_recursive_walk_is_traced_rather_than_called_out_to() {
+    let _ = dispatch_sum(&PROGRAM, 8, chain(), TICKS);
+    let body = COMPILED.lock().unwrap().clone();
+    assert!(
+        !body.is_empty(),
+        "no compiled loop was recorded, so this census is vacuous",
+    );
+    let value_reads = body.iter().filter(|op| **op == OpCode::GetfieldGcI).count();
+    assert!(
+        value_reads >= LINKS as usize,
+        "the walk contributed {value_reads} `node.value` reads, fewer than the \
+         {LINKS} links it recurses over, so it was not fully traced: {body:#?}",
+    );
+    assert!(
+        !body.iter().any(|op| format!("{op:?}").starts_with("Call")),
+        "the walk left a residual call behind, so the self-edge did not \
+         resolve to a jitcode the tracer could descend into: {body:#?}",
+    );
+}

--- a/majit/majit-metainterp/tests/jit_interp_call_returns_ref.rs
+++ b/majit/majit-metainterp/tests/jit_interp_call_returns_ref.rs
@@ -1,0 +1,200 @@
+//! `call_returns` — the declaration that types a ref-returning call's result.
+//!
+//! A call whose result is a ref produces a ref binding, and `result.field`
+//! after it needs a struct to resolve the field against.
+//! `call_returns = { func => Struct }` is that declaration, and
+//! `lower_ref_binding_getfield` bails without it — so the field read does not
+//! lower, and a statement that does not lower takes its whole dispatch arm
+//! down with it.
+//!
+//! The concrete path reads the same declaration through `RefFieldRewriter`, so
+//! a degraded arm still computes the right answer. Only the arm census can say
+//! it degraded, which is why this file grades that and not the return value.
+//!
+//! Two arms, one difference: `OP_PLAIN` reaches the callee through
+//! `residual_ref` and `OP_WRAPPED` through `residual_ref_wrapped`. The
+//! non-wrapped arm returns early from `lower_call_value` to attach the
+//! declared type; every wrapped policy falls through to the shared tail, which
+//! is where the type has to be attached for all of them.
+//!
+//! No fixture in this corpus used `call_returns`, or any ref call policy,
+//! before this one.
+
+use majit_metainterp::jitcode::insns::BC_GETFIELD_GC_I;
+use majit_metainterp::{Assembler, JitDriver};
+
+/// Two int fields and a self-edge: `value` is what the arms read back through
+/// the returned ref, `next` is what the callees walk.
+#[repr(C)]
+struct Cell {
+    value: i64,
+    next: *mut Cell,
+}
+
+/// The control's callee. `residual_ref` bakes the function address directly,
+/// so this one needs no policy attribute.
+fn plain_next(node: usize) -> *mut Cell {
+    // SAFETY: the fixture hands over a `Cell` it owns for the whole run.
+    unsafe { (*(node as *mut Cell)).next }
+}
+
+/// The subject's callee. `#[dont_look_inside]` emits the
+/// `__majit_call_policy_*` accessor and the `extern "C"` call-target wrappers
+/// that every `*_wrapped` policy resolves; a raw-pointer return is what makes
+/// it the ref member of that family.
+#[majit_macros::dont_look_inside]
+fn wrapped_next(node: usize) -> *mut Cell {
+    // SAFETY: as above.
+    unsafe { (*(node as *mut Cell)).next }
+}
+
+struct CellState {
+    total: i64,
+    head: usize,
+}
+
+pub type Bytecode = [u8];
+
+const OP_PLAIN: u8 = 1;
+const OP_WRAPPED: u8 = 2;
+
+#[majit_macros::jit_interp(
+    state = CellState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = { total: int, head: ref(Cell) },
+    ref_fields = { Cell::next => Cell },
+    int_fields = { Cell::value => i64 },
+    calls = {
+        plain_next => residual_ref,
+        wrapped_next => residual_ref_wrapped,
+    },
+    call_returns = {
+        plain_next => Cell,
+        wrapped_next => Cell,
+    },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_cells(program: &Bytecode, threshold: u32, head: usize) -> i64 {
+    let mut driver: JitDriver<CellState> = JitDriver::new(threshold);
+    let mut pc: usize = 0;
+    let mut state = CellState { total: 0, head };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!();
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            // The control: the arm that has always read `call_returns`.
+            OP_PLAIN => {
+                let n = plain_next(state.head);
+                state.total = state.total + n.value;
+            }
+            // The subject: the same shape through the wrapped policy.
+            OP_WRAPPED => {
+                let n = wrapped_next(state.head);
+                state.total = state.total + n.value;
+            }
+            _ => break,
+        }
+    }
+    state.total
+}
+
+fn build_dispatch_jitcode() -> majit_metainterp::JitCode {
+    let mut asm = Assembler::new();
+    asm.set_canonical_liveness_triple(vec![0], vec![0], vec![]);
+    __prebuild_jitcode_liveness_dispatch_cells(&mut asm);
+    let _ = asm.ensure_canonical_liveness_offset();
+    __dispatch_jitcode_dispatch_cells(&mut asm, 0i64).expect("dispatch lower must succeed")
+}
+
+/// Both arms lower. The control says the fixture is aimed right; the subject
+/// is the one that used to degrade.
+#[test]
+fn a_declared_ref_return_types_its_result_through_a_wrapped_policy() {
+    let _ = build_dispatch_jitcode();
+
+    let census = majit_metainterp::dispatch_arm_census();
+    let counted = census
+        .iter()
+        .find(|e| e.interp == "CellState")
+        .unwrap_or_else(|| panic!("the portal must record its arm count; census={census:?}"));
+    assert_eq!(
+        counted.arms, 2,
+        "OP_PLAIN and OP_WRAPPED are counted; the `_` default is not; \
+         census={census:?}"
+    );
+
+    let degraded: Vec<&'static str> = majit_metainterp::degraded_dispatch_arms()
+        .into_iter()
+        .filter(|e| e.interp == "CellState")
+        .map(|e| e.arm)
+        .collect();
+    assert!(
+        !degraded.contains(&"OP_PLAIN"),
+        "the control degraded, so the fixture is measuring its own mistake and \
+         the subject below says nothing; degraded={degraded:?}"
+    );
+
+    majit_metainterp::assert_no_degraded_dispatch_arms("CellState");
+}
+
+/// Every jitcode body the portal produced: the dispatch JitCode plus each
+/// per-arm sub-JitCode.
+fn all_jitcode_bodies(dispatch_jc: &majit_metainterp::JitCode) -> Vec<Vec<u8>> {
+    let mut bodies = vec![dispatch_jc.code.clone()];
+    bodies.extend(
+        dispatch_jc
+            .exec
+            .descrs
+            .iter()
+            .filter_map(|descr| descr.as_jitcode())
+            .map(|sub| sub.code.clone()),
+    );
+    bodies
+}
+
+/// What an un-degraded arm was supposed to emit. The gate above says the arm
+/// lowered; this says what it lowered TO, so a lowering that dropped the field
+/// read and still reported a whole arm would not pass.
+#[test]
+fn each_arm_reads_the_field_through_a_getfield_gc() {
+    let dispatch_jc = build_dispatch_jitcode();
+    let reads: usize = all_jitcode_bodies(&dispatch_jc)
+        .iter()
+        .map(|body| body.iter().filter(|op| **op == BC_GETFIELD_GC_I).count())
+        .sum();
+    assert_eq!(
+        reads, 2,
+        "one `n.value` per arm; 1 is the wrapped arm degraded to a stub",
+    );
+}
+
+/// The answer. Both arms follow `head.next` and add the `value` they find
+/// there, so the sum names which field was read: 14 is `next.value` twice, and
+/// 2 would be `head.value` — the same shape misread one edge short.
+#[test]
+fn both_policies_read_the_field_behind_the_returned_ref() {
+    let mut tail = Cell {
+        value: 7,
+        next: std::ptr::null_mut(),
+    };
+    let mut head = Cell {
+        value: 1,
+        next: &mut tail as *mut Cell,
+    };
+    let head_addr = &mut head as *mut Cell as usize;
+
+    let program: &Bytecode = &[OP_PLAIN, OP_WRAPPED];
+    assert_eq!(
+        dispatch_cells(program, u32::MAX, head_addr),
+        14,
+        "each arm adds `head.next.value`",
+    );
+}

--- a/majit/majit-metainterp/tests/jit_interp_default_arm_edge.rs
+++ b/majit/majit-metainterp/tests/jit_interp_default_arm_edge.rs
@@ -1,0 +1,369 @@
+//! Where a dispatch match's default arm sends the trace.
+//!
+//! The unmatched-opcode edge used to be one thing: the label bound at the
+//! portal function's trailing return. That is right for `_ => break`, which is
+//! what almost every machine in this corpus writes, and it was applied to the
+//! other spellings too. `_ => {}` means "fall out of the match and run the next
+//! iteration" and `_ => { .. }` means "run this"; both got the return instead,
+//! so the walk reported a finished frame, `take_single_pass_finish` broke the
+//! native loop, and the portal returned a partial answer.
+//!
+//! Nothing reported it. `degraded_dispatch_arms()` was empty and the arm
+//! census was intact, because from the lowerer's side nothing had refused —
+//! the arm was simply never emitted. Measured here before the fix:
+//!
+//! | default arm        | cold  | warm | compiled body     |
+//! |--------------------|-------|------|-------------------|
+//! | `_ => {}`          |  1200 |   27 | `[IntAdd, Finish]` |
+//! | `_ => { acc += N }`| 41200 |  827 | `[IntAdd, Finish]` |
+//!
+//! So the answer is the subject, and the loop shape is what keeps the answer
+//! honest: an interpreter that never entered the JIT agrees with itself too.
+//!
+//! Each machine puts an opcode no arm matches into its program. Without one
+//! the default edge is never walked and none of this can appear.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use majit_ir::OpCode;
+use majit_metainterp::JitDriver;
+
+pub type Bytecode = [u8];
+
+const OP_WORK: u8 = 1;
+const OP_TICK: u8 = 2;
+/// Matched by no arm in any machine below.
+const OP_UNKNOWN: u8 = 9;
+
+const TICKS: i64 = 400;
+const WORK: i64 = 3;
+const DEFAULT_WORK: i64 = 100;
+
+/// One recording slot per machine: these run in the same process and the
+/// compile hook is global to a driver, not to a test.
+struct Recorder {
+    compiles: AtomicUsize,
+    body: Mutex<Vec<OpCode>>,
+}
+
+impl Recorder {
+    const fn new() -> Self {
+        Self {
+            compiles: AtomicUsize::new(0),
+            body: Mutex::new(Vec::new()),
+        }
+    }
+    fn compiled_loop(&self) -> Vec<OpCode> {
+        assert!(
+            self.compiles.load(Ordering::Relaxed) > 0,
+            "nothing compiled, so the warm answer was the interpreter's alone \
+             and every claim below is vacuous",
+        );
+        self.body.lock().unwrap().clone()
+    }
+}
+
+static SKIP: Recorder = Recorder::new();
+static WORKED: Recorder = Recorder::new();
+static EXITED: Recorder = Recorder::new();
+static SWITCHED: Recorder = Recorder::new();
+
+struct SkipState {
+    acc: i64,
+    ticks: i64,
+}
+struct WorkState {
+    acc: i64,
+    ticks: i64,
+}
+struct ExitState {
+    acc: i64,
+    ticks: i64,
+}
+struct SwitchState {
+    acc: i64,
+    ticks: i64,
+}
+
+/// `_ => {}` — go round again.
+#[majit_macros::jit_interp(
+    state = SkipState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = { acc: int, ticks: int },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_skip(program: &Bytecode, threshold: u32, ticks: i64) -> i64 {
+    let mut driver: JitDriver<SkipState> = JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_gk, _before, _after, opcodes| {
+        SKIP.compiles.fetch_add(1, Ordering::Relaxed);
+        *SKIP.body.lock().unwrap() = opcodes.to_vec();
+    });
+    let mut pc: usize = 0;
+    let mut state = SkipState { acc: 0, ticks };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_WORK => {
+                state.acc = state.acc + WORK;
+            }
+            OP_TICK => {
+                state.ticks = state.ticks - 1i64;
+                if state.ticks != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            _ => {}
+        }
+    }
+    state.acc
+}
+
+/// `_ => { .. }` — an arm like any other, with no opcode test in front of it.
+#[majit_macros::jit_interp(
+    state = WorkState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = { acc: int, ticks: int },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_work(program: &Bytecode, threshold: u32, ticks: i64) -> i64 {
+    let mut driver: JitDriver<WorkState> = JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_gk, _before, _after, opcodes| {
+        WORKED.compiles.fetch_add(1, Ordering::Relaxed);
+        *WORKED.body.lock().unwrap() = opcodes.to_vec();
+    });
+    let mut pc: usize = 0;
+    let mut state = WorkState { acc: 0, ticks };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_WORK => {
+                state.acc = state.acc + WORK;
+            }
+            OP_TICK => {
+                state.ticks = state.ticks - 1i64;
+                if state.ticks != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            _ => {
+                state.acc = state.acc + DEFAULT_WORK;
+            }
+        }
+    }
+    state.acc
+}
+
+/// The control: `_ => break`, the spelling 55 of this corpus's default arms
+/// use. It keeps the trailing-return edge it always had, and its program has
+/// no unmatched opcode — reaching one would end the loop on the first pass and
+/// there would be nothing hot to compile.
+#[majit_macros::jit_interp(
+    state = ExitState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = { acc: int, ticks: int },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_exit(program: &Bytecode, threshold: u32, ticks: i64) -> i64 {
+    let mut driver: JitDriver<ExitState> = JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_gk, _before, _after, opcodes| {
+        EXITED.compiles.fetch_add(1, Ordering::Relaxed);
+        *EXITED.body.lock().unwrap() = opcodes.to_vec();
+    });
+    let mut pc: usize = 0;
+    let mut state = ExitState { acc: 0, ticks };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_WORK => {
+                state.acc = state.acc + WORK;
+            }
+            OP_TICK => {
+                state.ticks = state.ticks - 1i64;
+                if state.ticks != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            _ => break,
+        }
+    }
+    state.acc
+}
+
+/// The same default-arm body under `switch_dispatch`, where the switch's own
+/// default is what reaches it rather than a chain of missed guards. The corpus
+/// has exactly one `switch_dispatch` machine and its default arm is
+/// `_ => break`, so this combination had no coverage at all.
+#[majit_macros::jit_interp(
+    state = SwitchState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = { acc: int, ticks: int },
+    switch_dispatch = true,
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_switch(program: &Bytecode, threshold: u32, ticks: i64) -> i64 {
+    let mut driver: JitDriver<SwitchState> = JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_gk, _before, _after, opcodes| {
+        SWITCHED.compiles.fetch_add(1, Ordering::Relaxed);
+        *SWITCHED.body.lock().unwrap() = opcodes.to_vec();
+    });
+    let mut pc: usize = 0;
+    let mut state = SwitchState { acc: 0, ticks };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_WORK => {
+                state.acc = state.acc + WORK;
+            }
+            OP_TICK => {
+                state.ticks = state.ticks - 1i64;
+                if state.ticks != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            _ => {
+                state.acc = state.acc + DEFAULT_WORK;
+            }
+        }
+    }
+    state.acc
+}
+
+fn closes_a_loop(body: &[OpCode]) -> bool {
+    body.contains(&OpCode::Jump) && !body.contains(&OpCode::Finish)
+}
+
+#[test]
+fn an_empty_default_arm_goes_round_again() {
+    let program: &Bytecode = &[OP_WORK, OP_UNKNOWN, OP_TICK];
+    let cold = dispatch_skip(program, u32::MAX, TICKS);
+    assert_eq!(cold, TICKS * WORK, "the cold arm states the answer");
+
+    let warm = dispatch_skip(program, 8, TICKS);
+    assert_eq!(
+        warm, cold,
+        "the portal returned early: a warm answer of one compiled pass past \
+         the threshold is the default edge taking the function's typed return",
+    );
+    let body = SKIP.compiled_loop();
+    assert!(
+        closes_a_loop(&body),
+        "the default arm ended the trace instead of continuing it: {body:?}",
+    );
+}
+
+#[test]
+fn a_default_arm_with_a_body_runs_it() {
+    let program: &Bytecode = &[OP_WORK, OP_UNKNOWN, OP_TICK];
+    let cold = dispatch_work(program, u32::MAX, TICKS);
+    assert_eq!(cold, TICKS * (WORK + DEFAULT_WORK));
+
+    let warm = dispatch_work(program, 8, TICKS);
+    assert_eq!(
+        warm, cold,
+        "the default arm's body is missing from the trace"
+    );
+
+    let body = WORKED.compiled_loop();
+    assert!(closes_a_loop(&body), "{body:?}");
+    // One `IntAdd` per arm that ran. With the default arm dropped the peeled
+    // body carried one, and the answer above could not tell you which.
+    let adds = body.iter().filter(|op| **op == OpCode::IntAdd).count();
+    assert_eq!(
+        adds, 4,
+        "two arms add per pass and the body is peeled, so four: {body:?}",
+    );
+    // The default arm is emitted, so the census counts it: an arm is counted
+    // exactly when the chain emits a body for it.
+    let census = majit_metainterp::dispatch_arm_census();
+    let counted = census
+        .iter()
+        .find(|e| e.interp == "WorkState")
+        .unwrap_or_else(|| panic!("the portal must record its arm count; {census:?}"));
+    assert_eq!(counted.arms, 3, "OP_WORK, OP_TICK and `_`; {census:?}");
+    majit_metainterp::assert_no_degraded_dispatch_arms("WorkState");
+}
+
+/// The control. `_ => break` keeps the trailing-return edge, so this machine
+/// must be untouched by the two above.
+#[test]
+fn a_breaking_default_arm_keeps_the_return_edge() {
+    let program: &Bytecode = &[OP_WORK, OP_TICK];
+    let cold = dispatch_exit(program, u32::MAX, TICKS);
+    assert_eq!(cold, TICKS * WORK);
+    assert_eq!(dispatch_exit(program, 8, TICKS), cold);
+
+    let body = EXITED.compiled_loop();
+    assert!(closes_a_loop(&body), "{body:?}");
+    let census = majit_metainterp::dispatch_arm_census();
+    let counted = census
+        .iter()
+        .find(|e| e.interp == "ExitState")
+        .unwrap_or_else(|| panic!("the portal must record its arm count; {census:?}"));
+    assert_eq!(
+        counted.arms, 2,
+        "OP_WORK and OP_TICK; a `break` default is still the exit edge and \
+         emits no body, so it is still not counted; {census:?}",
+    );
+}
+
+/// `switch_dispatch`: the switch's default target is the arm body, not the
+/// portal's return.
+#[test]
+fn a_switch_dispatch_default_arm_runs_its_body_too() {
+    let program: &Bytecode = &[OP_WORK, OP_UNKNOWN, OP_TICK];
+    let cold = dispatch_switch(program, u32::MAX, TICKS);
+    assert_eq!(cold, TICKS * (WORK + DEFAULT_WORK));
+    assert_eq!(
+        dispatch_switch(program, 8, TICKS),
+        cold,
+        "the switch's default edge took the portal's return",
+    );
+    let body = SWITCHED.compiled_loop();
+    assert!(closes_a_loop(&body), "{body:?}");
+    majit_metainterp::assert_no_degraded_dispatch_arms("SwitchState");
+}

--- a/majit/majit-metainterp/tests/jit_interp_discarded_inline_result.rs
+++ b/majit/majit-metainterp/tests/jit_interp_discarded_inline_result.rs
@@ -137,6 +137,69 @@ fn install() -> (majit_metainterp::JitCode, Vec<u8>) {
     (dispatch_jc, helper_code)
 }
 
+/// The same discarding arm, alone.
+///
+/// The two-arm portal above cannot say WHICH arm registered the helper: the
+/// descr pool memoises a callee, so one entry is what both arms sharing a
+/// splice looks like AND what the binding arm splicing alone looks like. Here
+/// the binding arm does not exist, so the entry can only have come from the
+/// discarding one.
+struct DiscardOnlyState {
+    total: i64,
+    sel: usize,
+}
+
+#[majit_macros::jit_interp(
+    state = DiscardOnlyState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = { total: int, sel: ref(PopStack) },
+    calls = { pop_stack => inline_int },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_discard_only(program: &Bytecode, threshold: u32) -> i64 {
+    let mut driver: JitDriver<DiscardOnlyState> = JitDriver::new(threshold);
+    let mut pc: usize = 0;
+    let mut state = DiscardOnlyState { total: 0, sel: 0 };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!();
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_DISCARD_POP => {
+                pop_stack(state.sel);
+            }
+            OP_BACK => {
+                if state.total != 0 {
+                    pc = 0;
+                    continue;
+                }
+            }
+            _ => break,
+        }
+    }
+    state.total
+}
+
+fn install_discard_only() -> (majit_metainterp::JitCode, Vec<u8>) {
+    let mut asm = Assembler::new();
+    asm.set_canonical_liveness_triple(vec![0], vec![0], vec![]);
+    __prebuild_jitcode_liveness_dispatch_discard_only(&mut asm);
+    let _ = asm.ensure_canonical_liveness_offset();
+    let dispatch_jc = __dispatch_jitcode_dispatch_discard_only(&mut asm, 0i64)
+        .expect("dispatch lower must succeed");
+    let helper_code = __majit_inline_jitcode_pop_stack_with_asm(&mut asm)
+        .code
+        .clone();
+    (dispatch_jc, helper_code)
+}
+
 fn degraded_arms() -> Vec<String> {
     let _ = install();
     majit_metainterp::degraded_dispatch_arms()
@@ -188,35 +251,55 @@ fn a_discarded_inline_int_call_does_not_degrade_its_arm() {
     );
 }
 
-/// …and the arm must carry the splice, not merely avoid degrading. An arm that
-/// lowered while silently dropping the call would pass the test above.
-///
-/// The oracle is the portal's sub-JitCode list — one `add_sub_jitcode` per
-/// splice site — not a byte scan of the bodies. A jitcode body is a bytecode
-/// stream whose operands are bytes too, so `code.contains(&BC_INLINE_CALL)`
-/// answers about any operand that happens to equal that opcode: counting
-/// `BC_INLINE_CALL` bytes here returns 2 even with the discarding arm degraded
-/// to `[BC_ABORT]`, which is exactly the reading this test exists to reject.
-#[test]
-fn the_discarded_call_is_spliced_into_a_jitcode_body() {
-    let (dispatch_jc, helper_code) = install();
-    let sub_bodies: Vec<&[u8]> = dispatch_jc
+fn helper_entries(dispatch_jc: &majit_metainterp::JitCode, helper_code: &[u8]) -> usize {
+    dispatch_jc
         .exec
         .descrs
         .iter()
         .filter_map(|descr| descr.as_jitcode())
-        .map(|sub| sub.code.as_slice())
-        .collect();
-    let helper_splices = sub_bodies
-        .iter()
-        .filter(|body| **body == helper_code.as_slice())
-        .count();
+        .filter(|sub| sub.code.as_slice() == helper_code)
+        .count()
+}
+
+/// …and the arm must carry the splice, not merely avoid degrading. An arm that
+/// lowered while silently dropping the call would pass the test above.
+///
+/// The oracle is the portal's sub-JitCode list, not a byte scan of the bodies.
+/// A jitcode body is a bytecode stream whose operands are bytes too, so
+/// `code.contains(&BC_INLINE_CALL)` answers about any operand that happens to
+/// equal that opcode: counting `BC_INLINE_CALL` bytes here returns 2 even with
+/// the discarding arm degraded to `[BC_ABORT]`, which is exactly the reading
+/// this test exists to reject.
+///
+/// The portal read is `dispatch_discard_only`, whose only caller of `pop_stack`
+/// is the discarding arm. The two-arm portal cannot answer this: a callee is
+/// memoised in the descr pool (`assembler.py Assembler._encode_descr` keeps
+/// `_descr_dict`), so both arms splicing and the binding arm splicing alone
+/// both leave one entry.
+#[test]
+fn the_discarded_call_is_spliced_into_a_jitcode_body() {
+    let (dispatch_jc, helper_code) = install_discard_only();
+    let spliced = helper_entries(&dispatch_jc, &helper_code);
     assert_eq!(
-        helper_splices, 2,
-        "exactly two arms call `pop_stack` — the discarding one and the \
-         binding one — so the portal must register the helper twice. One \
-         registration means the discarding arm dropped its call; \
-         helper={helper_code:?} sub-bodies={sub_bodies:?}"
+        spliced, 1,
+        "the only arm calling `pop_stack` here is the discarding one, so an \
+         unregistered helper means that arm dropped its call; \
+         helper={helper_code:?}"
+    );
+}
+
+/// The memo itself: two arms calling one helper claim one descr slot.
+///
+/// Recorded because the count above reads as a cardinality claim, and this is
+/// the one that would move if the pool stopped memoising.
+#[test]
+fn two_call_sites_share_one_helper_descr() {
+    let (dispatch_jc, helper_code) = install();
+    let spliced = helper_entries(&dispatch_jc, &helper_code);
+    assert_eq!(
+        spliced, 1,
+        "`pop_stack` is one callee named twice, so it takes one descr index; \
+         helper={helper_code:?}"
     );
 }
 

--- a/majit/majit-metainterp/tests/jit_interp_dispatch_match_choice.rs
+++ b/majit/majit-metainterp/tests/jit_interp_dispatch_match_choice.rs
@@ -1,0 +1,350 @@
+//! Which `match` in a portal function is the dispatch.
+//!
+//! `find_dispatch_match` chose the one with the most arms, over every match
+//! anywhere in the function body, on the reasoning that a dispatch has many
+//! opcode arms and a setup match only a few. Arm count is not a property of
+//! being the dispatch. A five-arm `match` beside a three-opcode dispatch takes
+//! its place, and then two things happen at once: `classify_arms` reads that
+//! match's arms as the opcodes, and the two pre-dispatch walkers — which find
+//! their loop by asking which one holds the dispatch match — find no loop and
+//! lower nothing. The portal compiles a loop that runs none of the
+//! interpreter, and answers with it.
+//!
+//! Measured here before the fix, on `dispatch_setup_before`:
+//! cold 1200, warm 24. 24 is the eight interpreted iterations that reach the
+//! threshold; every iteration after that ran the compiled loop, which does
+//! nothing. It compiles clean — no degraded arm, no diagnostic, no warning.
+//!
+//! The arm census is the direct reading: two opcodes means `arms == 2`, and
+//! the five-arm setup match would make it 4. The answer is the consequence.
+//! Both are asserted, because a machine that stopped lowering altogether
+//! would agree with the interpreter by being it.
+//!
+//! Every machine below is the same interpreter. Only where the setup match
+//! sits changes: nowhere, before the loop, inside the loop ahead of the merge
+//! point, and after the loop.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use majit_ir::OpCode;
+use majit_metainterp::JitDriver;
+
+pub type Bytecode = [u8];
+
+const OP_WORK: u8 = 1;
+const OP_TICK: u8 = 2;
+const PROGRAM: [u8; 2] = [OP_WORK, OP_TICK];
+
+const TICKS: i64 = 400;
+const WORK: i64 = 3;
+
+/// One recording slot per machine: these share a process, and the compile
+/// hook belongs to a driver rather than to a test.
+struct Recorder {
+    compiles: AtomicUsize,
+    body: Mutex<Vec<OpCode>>,
+}
+
+impl Recorder {
+    const fn new() -> Self {
+        Self {
+            compiles: AtomicUsize::new(0),
+            body: Mutex::new(Vec::new()),
+        }
+    }
+    fn compiled_loop(&self) -> Vec<OpCode> {
+        assert!(
+            self.compiles.load(Ordering::Relaxed) > 0,
+            "nothing compiled, so the warm answer was the interpreter's alone \
+             and every claim about the trace is vacuous",
+        );
+        self.body.lock().unwrap().clone()
+    }
+}
+
+static BARE: Recorder = Recorder::new();
+static BEFORE: Recorder = Recorder::new();
+static IN_LOOP: Recorder = Recorder::new();
+static AFTER: Recorder = Recorder::new();
+
+struct BareState {
+    acc: i64,
+    ticks: i64,
+}
+struct BeforeState {
+    acc: i64,
+    ticks: i64,
+}
+struct InLoopState {
+    acc: i64,
+    ticks: i64,
+}
+struct AfterState {
+    acc: i64,
+    ticks: i64,
+}
+
+/// The control: no competing match at all.
+#[majit_macros::jit_interp(
+    state = BareState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = { acc: int, ticks: int },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_bare(program: &Bytecode, threshold: u32, ticks: i64, sel: i64) -> i64 {
+    let mut driver: JitDriver<BareState> = JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_gk, _before, _after, opcodes| {
+        BARE.compiles.fetch_add(1, Ordering::Relaxed);
+        *BARE.body.lock().unwrap() = opcodes.to_vec();
+    });
+    let mut pc: usize = 0;
+    let mut state = BareState { acc: 0, ticks };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_WORK => {
+                state.acc = state.acc + WORK;
+            }
+            OP_TICK => {
+                state.ticks = state.ticks - 1i64;
+                if state.ticks != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            _ => break,
+        }
+    }
+    state.acc
+}
+
+/// The setup match ahead of the portal loop. This is the shape that broke.
+#[majit_macros::jit_interp(
+    state = BeforeState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = { acc: int, ticks: int },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_setup_before(program: &Bytecode, threshold: u32, ticks: i64, sel: i64) -> i64 {
+    let mut driver: JitDriver<BeforeState> = JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_gk, _before, _after, opcodes| {
+        BEFORE.compiles.fetch_add(1, Ordering::Relaxed);
+        *BEFORE.body.lock().unwrap() = opcodes.to_vec();
+    });
+    let label = match sel {
+        0i64 => "zero",
+        1i64 => "one",
+        2i64 => "two",
+        3i64 => "three",
+        _ => "many",
+    };
+    let _ = label;
+    let mut pc: usize = 0;
+    let mut state = BeforeState { acc: 0, ticks };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_WORK => {
+                state.acc = state.acc + WORK;
+            }
+            OP_TICK => {
+                state.ticks = state.ticks - 1i64;
+                if state.ticks != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            _ => break,
+        }
+    }
+    state.acc
+}
+
+/// Inside the loop, ahead of the merge point — the region
+/// `bind_pre_merge_point_stmts` walks.
+#[majit_macros::jit_interp(
+    state = InLoopState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = { acc: int, ticks: int },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_setup_in_loop(program: &Bytecode, threshold: u32, ticks: i64, sel: i64) -> i64 {
+    let mut driver: JitDriver<InLoopState> = JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_gk, _before, _after, opcodes| {
+        IN_LOOP.compiles.fetch_add(1, Ordering::Relaxed);
+        *IN_LOOP.body.lock().unwrap() = opcodes.to_vec();
+    });
+    let mut pc: usize = 0;
+    let mut state = InLoopState { acc: 0, ticks };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        let label = match sel {
+            0i64 => "zero",
+            1i64 => "one",
+            2i64 => "two",
+            3i64 => "three",
+            _ => "many",
+        };
+        let _ = label;
+        jit_merge_point!(driver, program, pc; state);
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_WORK => {
+                state.acc = state.acc + WORK;
+            }
+            OP_TICK => {
+                state.ticks = state.ticks - 1i64;
+                if state.ticks != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            _ => break,
+        }
+    }
+    state.acc
+}
+
+/// Behind the loop: the finder walked the whole function body, so a match
+/// after the portal competed too.
+#[majit_macros::jit_interp(
+    state = AfterState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = { acc: int, ticks: int },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_setup_after(program: &Bytecode, threshold: u32, ticks: i64, sel: i64) -> i64 {
+    let mut driver: JitDriver<AfterState> = JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_gk, _before, _after, opcodes| {
+        AFTER.compiles.fetch_add(1, Ordering::Relaxed);
+        *AFTER.body.lock().unwrap() = opcodes.to_vec();
+    });
+    let mut pc: usize = 0;
+    let mut state = AfterState { acc: 0, ticks };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_WORK => {
+                state.acc = state.acc + WORK;
+            }
+            OP_TICK => {
+                state.ticks = state.ticks - 1i64;
+                if state.ticks != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            _ => break,
+        }
+    }
+    let label = match sel {
+        0i64 => "zero",
+        1i64 => "one",
+        2i64 => "two",
+        3i64 => "three",
+        _ => "many",
+    };
+    let _ = label;
+    state.acc
+}
+
+/// What the interpreter alone computes: one `WORK` per tick.
+const EXPECTED: i64 = TICKS * WORK;
+
+fn arms_of(interp: &str) -> usize {
+    majit_metainterp::dispatch_arm_census()
+        .into_iter()
+        .find(|e| e.interp == interp)
+        .unwrap_or_else(|| panic!("no dispatch-arm census for `{interp}`: no portal was installed"))
+        .arms
+}
+
+fn check(name: &'static str, cold: i64, warm: i64, rec: &Recorder) {
+    assert_eq!(cold, EXPECTED, "{name}: the cold arm states the answer");
+    assert_eq!(
+        warm, cold,
+        "{name}: the compiled loop disagreed with the interpreter",
+    );
+    let body = rec.compiled_loop();
+    assert!(
+        body.iter().any(|op| *op == OpCode::IntAdd),
+        "{name}: the compiled loop carries no arithmetic, so it runs none of \
+         the interpreter: {body:#?}",
+    );
+    assert_eq!(
+        arms_of(name),
+        2,
+        "{name}: the portal lowered a different match's arms as its opcodes; \
+         this machine has two, and its five-arm setup match has four besides \
+         the default",
+    );
+    majit_metainterp::assert_no_degraded_dispatch_arms(name);
+}
+
+#[test]
+fn a_setup_match_does_not_displace_the_dispatch() {
+    // The control first: if it fails, the three below measure the fixture.
+    check(
+        "BareState",
+        dispatch_bare(&PROGRAM, u32::MAX, TICKS, 0),
+        dispatch_bare(&PROGRAM, 8, TICKS, 0),
+        &BARE,
+    );
+    check(
+        "BeforeState",
+        dispatch_setup_before(&PROGRAM, u32::MAX, TICKS, 0),
+        dispatch_setup_before(&PROGRAM, 8, TICKS, 0),
+        &BEFORE,
+    );
+    check(
+        "InLoopState",
+        dispatch_setup_in_loop(&PROGRAM, u32::MAX, TICKS, 0),
+        dispatch_setup_in_loop(&PROGRAM, 8, TICKS, 0),
+        &IN_LOOP,
+    );
+    check(
+        "AfterState",
+        dispatch_setup_after(&PROGRAM, u32::MAX, TICKS, 0),
+        dispatch_setup_after(&PROGRAM, 8, TICKS, 0),
+        &AFTER,
+    );
+}

--- a/majit/majit-metainterp/tests/jit_interp_immutable_field_folds.rs
+++ b/majit/majit-metainterp/tests/jit_interp_immutable_field_folds.rs
@@ -1,0 +1,259 @@
+//! `_immutable_fields_` on a `#[jit_interp]` machine, end to end.
+//!
+//! The plumbing tests next door assert that the declaration reaches the minted
+//! descr.  That is necessary and not sufficient: what the declaration is FOR is
+//! `OptHeap::optimize_getfield`'s fold, which fires only when the descr is
+//! always-pure AND the base is a constant.  A chain of reads is where the two
+//! meet — promote the root once and each declared read folds to a constant,
+//! which makes the NEXT read's base constant too, so the whole walk collapses.
+//!
+//! So this is an A/B: two structurally identical machines over two structurally
+//! identical node types, differing only in whether `left` is declared.  Without
+//! the declaration each level costs its own `getfield_gc_r`; with it, none do.
+//!
+//! The undeclared machine is the denominator, and it is asserted FIRST. A low
+//! read count is also what a census over a trace that was never recorded
+//! produces, and a fixture that cannot fail in the other direction has not
+//! measured the fold.
+//!
+//! The two optimized traces, as measured:
+//!
+//! ```text
+//! declared: Label GetfieldGcR GuardValue GetfieldGcI IntAdd IntAdd IntSub
+//!           SetfieldGc IntIsTrue GuardTrue | Label IntAdd ... Jump
+//! plain:    Label GetfieldGcR GuardValue GetfieldGcR GetfieldGcR GetfieldGcI
+//!           IntAdd IntAdd IntSub SetfieldGc IntIsTrue GuardTrue | Label ... Jump
+//! ```
+//!
+//! One `GetfieldGcR` per link without the declaration; with it, only the read
+//! whose base is the red `state.root` survives and the two below it are gone.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use majit_ir::OpCode;
+use majit_metainterp::JitDriver;
+
+/// The chain the machines walk.  Three links, so a walk that folds only its
+/// first level is still distinguishable from one that folds all of them.
+const DEPTH: usize = 3;
+const TICKS: i64 = 400;
+
+// ── The declaring node type ────────────────────────────────────────────────
+
+/// `marked` is deliberately left out: it is the mutable state, and a fixture in
+/// which every field folded would not show that the fold is selective.
+#[majit_macros::jit_immutable_fields("left")]
+#[repr(C)]
+struct DeclaredNode {
+    marked: i64,
+    left: *mut DeclaredNode,
+}
+
+/// Byte-for-byte the same shape, declaring nothing.
+#[repr(C)]
+struct PlainNode {
+    marked: i64,
+    left: *mut PlainNode,
+}
+
+macro_rules! machine {
+    (
+        $node:ident, $state:ident, $dispatch:ident, $compiles:ident, $compiled:ident,
+        $chain:ident, $expected:ident
+    ) => {
+        static $compiles: AtomicUsize = AtomicUsize::new(0);
+        static $compiled: Mutex<Vec<OpCode>> = Mutex::new(Vec::new());
+
+        struct $state {
+            root: usize,
+            acc: i64,
+            ticks: i64,
+        }
+
+        #[majit_macros::jit_interp(
+            state = $state,
+            env = Bytecode,
+            greens = [pc, program],
+            state_fields = {
+                root: ref($node),
+                acc: int,
+                ticks: int,
+            },
+            ref_fields = { $node::left => $node },
+            int_fields = { $node::marked => i64 },
+        )]
+        #[allow(unused_assignments, unused_variables)]
+        fn $dispatch(program: &Bytecode, threshold: u32, root: usize, ticks: i64) -> i64 {
+            let mut driver: JitDriver<$state> = JitDriver::new(threshold);
+            driver.set_on_compile_loop(|_gk, _before, _after, opcodes| {
+                $compiles.fetch_add(1, Ordering::Relaxed);
+                *$compiled.lock().unwrap() = opcodes.to_vec();
+            });
+            let mut pc: usize = 0;
+            let mut state = $state {
+                root,
+                acc: 0i64,
+                ticks,
+            };
+            {
+                use majit_metainterp::JitState as _;
+                state
+                    .build_meta(0, program)
+                    .install_canonical_liveness(&mut driver);
+            }
+
+            while pc < program.len() {
+                jit_merge_point!(driver, program, pc; state);
+                let opcode = program[pc];
+                pc += 1;
+                match opcode {
+                    OP_WALK => {
+                        // One promote, on the FIRST link only.  `state.root` is
+                        // a red ref, so that read emits whatever is declared;
+                        // the promote is what makes its result a constant.
+                        // Every link below it is a declared read off a constant
+                        // base, which is exactly the fold's precondition — so
+                        // with the declaration in place they cost nothing and
+                        // without it each one emits its own reload.
+                        let a = state.root.left;
+                        majit_metainterp::jit::promote(a);
+                        let b = a.left;
+                        let c = b.left;
+                        // The mutable field, read and written off the deepest
+                        // node: the store the walk exists to reach.
+                        let m = c.marked;
+                        c.marked = m + 1i64;
+                        state.acc = state.acc + m;
+                    }
+                    OP_TICK => {
+                        state.ticks = state.ticks - 1i64;
+                        if state.ticks != 0 {
+                            can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                            pc = 0;
+                            continue;
+                        }
+                    }
+                    OP_HALT => break,
+                    _ => break,
+                }
+            }
+            state.acc
+        }
+
+        /// A leaked chain: the machine takes a raw address and the graph must
+        /// outlive every trace that folded a node of it into a constant.
+        fn $chain() -> usize {
+            let mut head: *mut $node = std::ptr::null_mut();
+            for _ in 0..=DEPTH {
+                head = Box::leak(Box::new($node {
+                    marked: 0,
+                    left: head,
+                })) as *mut $node;
+            }
+            head as usize
+        }
+
+        /// Iteration `i` reads the mark left by iteration `i - 1`.
+        fn $expected() -> i64 {
+            (0..TICKS).sum()
+        }
+    };
+}
+
+pub type Bytecode = [u8];
+
+const OP_WALK: u8 = 1;
+const OP_TICK: u8 = 2;
+const OP_HALT: u8 = 3;
+const PROGRAM: [u8; 3] = [OP_WALK, OP_TICK, OP_HALT];
+
+machine!(
+    DeclaredNode,
+    DeclaredState,
+    dispatch_declared,
+    DECLARED_COMPILES,
+    DECLARED_COMPILED,
+    declared_chain,
+    declared_expected
+);
+machine!(
+    PlainNode,
+    PlainState,
+    dispatch_plain,
+    PLAIN_COMPILES,
+    PLAIN_COMPILED,
+    plain_chain,
+    plain_expected
+);
+
+fn census(ops: &[OpCode], want: OpCode) -> usize {
+    ops.iter().filter(|op| **op == want).count()
+}
+
+/// Both machines must answer the same as their own interpreter first.  A trace
+/// census over wrong code grades the wrong thing.
+#[test]
+fn both_machines_agree_warm_and_cold() {
+    let cold = dispatch_declared(&PROGRAM, u32::MAX, declared_chain(), TICKS);
+    let warm = dispatch_declared(&PROGRAM, 8, declared_chain(), TICKS);
+    assert_eq!(cold, declared_expected(), "the cold arm states the answer");
+    assert_eq!(warm, cold, "the declared machine's compiled walk disagreed");
+
+    let cold = dispatch_plain(&PROGRAM, u32::MAX, plain_chain(), TICKS);
+    let warm = dispatch_plain(&PROGRAM, 8, plain_chain(), TICKS);
+    assert_eq!(cold, plain_expected());
+    assert_eq!(
+        warm, cold,
+        "the undeclared machine's compiled walk disagreed"
+    );
+}
+
+#[test]
+fn a_declared_ref_field_folds_where_an_undeclared_one_reloads() {
+    let _ = dispatch_plain(&PROGRAM, 8, plain_chain(), TICKS);
+    assert!(
+        PLAIN_COMPILES.load(Ordering::Relaxed) > 0,
+        "the undeclared machine compiled nothing, so there is no denominator",
+    );
+    let plain = PLAIN_COMPILED.lock().unwrap().clone();
+    let plain_reads = census(&plain, OpCode::GetfieldGcR);
+    assert!(
+        plain_reads > 0,
+        "the undeclared walk emitted no GetfieldGcR at all, so the census below \
+         cannot tell a fold from a walk that was never traced. Trace: {plain:#?}",
+    );
+
+    let _ = dispatch_declared(&PROGRAM, 8, declared_chain(), TICKS);
+    assert!(
+        DECLARED_COMPILES.load(Ordering::Relaxed) > 0,
+        "the declared machine compiled nothing",
+    );
+    let declared = DECLARED_COMPILED.lock().unwrap().clone();
+    let declared_reads = census(&declared, OpCode::GetfieldGcR);
+
+    assert!(
+        declared_reads < plain_reads,
+        "declaring `left` immutable changed nothing: {declared_reads} reads \
+         declared vs {plain_reads} undeclared. Trace: {declared:#?}",
+    );
+    assert_eq!(
+        declared_reads, 1,
+        "only the read off `state.root` should survive — its base is a red ref, \
+         so nothing folds it. The two links below it are declared reads off a \
+         constant base and must both be gone: {declared:#?}",
+    );
+}
+
+/// The mark is the mutable state and must survive as a store.  A fixture whose
+/// every read folded would also pass the census above by folding the whole
+/// body away.
+#[test]
+fn the_undeclared_mutable_field_still_stores() {
+    let _ = dispatch_declared(&PROGRAM, 8, declared_chain(), TICKS);
+    let declared = DECLARED_COMPILED.lock().unwrap().clone();
+    assert!(
+        census(&declared, OpCode::SetfieldGc) > 0,
+        "`marked` is not declared; its store must remain: {declared:#?}",
+    );
+}

--- a/majit/majit-metainterp/tests/jit_interp_macro_init_is_opaque.rs
+++ b/majit/majit-metainterp/tests/jit_interp_macro_init_is_opaque.rs
@@ -1,0 +1,207 @@
+//! A `let` whose initialiser is a macro invocation.
+//!
+//! `lower_local`'s last resort treats an initialiser it could not lower as a
+//! compile-time constant: it emits the original `let x = <init>;` verbatim
+//! into the surrounding `__builder` block and loads `x as i64` as a constant.
+//! That contract holds only while `<init>` names nothing the generated scope
+//! lacks, and the guard on it — `expr_touches_storage` →
+//! `expr_references_unknown_local` — is what checks that: a bare lowercase
+//! identifier is read as a user local and the fallback is refused.
+//!
+//! The walk had no `Expr::Macro` arm, so a macro invocation fell to its
+//! catch-all and reported no reference at all. It cannot know that: the
+//! tokens are opaque to it. `let bump = pick!(sel);` therefore passed the
+//! guard and put `match sel { .. }` inside `__dispatch_jitcode_*`, whose
+//! parameters are the assembler and the driver index:
+//!
+//! ```text
+//! error[E0425]: cannot find value `sel` in this scope
+//!   --> tests/...:19:26
+//!    |
+//! 19 |         let bump = pick!(sel);
+//!    |                          ^^^ not found in this scope
+//! ```
+//!
+//! pointing at a line where `sel` plainly is in scope. This file compiling at
+//! all is the gate; the assertions below say the refusal is the fail-closed
+//! one rather than a silent drop.
+
+use majit_metainterp::JitDriver;
+
+pub type Bytecode = [u8];
+
+const OP_USES: u8 = 1;
+const OP_PLAIN: u8 = 2;
+const OP_TICK: u8 = 3;
+const PROGRAM: [u8; 3] = [OP_USES, OP_PLAIN, OP_TICK];
+
+const TICKS: i64 = 40;
+const PLAIN_WORK: i64 = 3;
+
+/// Opaque to the lowerer, and it names the portal's own parameter.
+macro_rules! pick {
+    ($sel:expr) => {
+        match $sel {
+            0i64 => 5i64,
+            _ => 7i64,
+        }
+    };
+}
+
+struct PreState {
+    acc: i64,
+    ticks: i64,
+}
+struct ArmState {
+    acc: i64,
+    ticks: i64,
+}
+
+/// The macro-initialised `let` sits ahead of the merge point, the region
+/// `bind_pre_merge_point_stmts` walks.
+#[majit_macros::jit_interp(
+    state = PreState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = { acc: int, ticks: int },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_pre(program: &Bytecode, threshold: u32, ticks: i64, sel: i64) -> i64 {
+    let mut driver: JitDriver<PreState> = JitDriver::new(threshold);
+    let mut pc: usize = 0;
+    let mut state = PreState { acc: 0, ticks };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        let bump = pick!(sel);
+        jit_merge_point!(driver, program, pc; state);
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_USES => {
+                state.acc = state.acc + bump;
+            }
+            OP_PLAIN => {
+                state.acc = state.acc + PLAIN_WORK;
+            }
+            OP_TICK => {
+                state.ticks = state.ticks - 1i64;
+                if state.ticks != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            _ => break,
+        }
+    }
+    state.acc
+}
+
+/// The same initialiser inside a dispatch arm, where the refusal produces an
+/// abort stub rather than a silent skip.
+#[majit_macros::jit_interp(
+    state = ArmState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = { acc: int, ticks: int },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_arm(program: &Bytecode, threshold: u32, ticks: i64, sel: i64) -> i64 {
+    let mut driver: JitDriver<ArmState> = JitDriver::new(threshold);
+    let mut pc: usize = 0;
+    let mut state = ArmState { acc: 0, ticks };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_USES => {
+                let n = pick!(sel);
+                state.acc = state.acc + n;
+            }
+            OP_PLAIN => {
+                state.acc = state.acc + PLAIN_WORK;
+            }
+            OP_TICK => {
+                state.ticks = state.ticks - 1i64;
+                if state.ticks != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            _ => break,
+        }
+    }
+    state.acc
+}
+
+fn degraded_of(interp: &str) -> Vec<&'static str> {
+    let mut arms: Vec<&'static str> = majit_metainterp::degraded_dispatch_arms()
+        .into_iter()
+        .filter(|e| e.interp == interp)
+        .map(|e| e.arm)
+        .collect();
+    arms.sort_unstable();
+    arms.dedup();
+    arms
+}
+
+fn arms_of(interp: &str) -> usize {
+    majit_metainterp::dispatch_arm_census()
+        .into_iter()
+        .find(|e| e.interp == interp)
+        .unwrap_or_else(|| panic!("no dispatch-arm census for `{interp}`: no portal was installed"))
+        .arms
+}
+
+/// `sel = 0` picks 5, so each pass adds 5 + `PLAIN_WORK`.
+fn expected() -> i64 {
+    TICKS * (5 + PLAIN_WORK)
+}
+
+#[test]
+fn a_macro_initialiser_is_refused_rather_than_spliced() {
+    for (name, cold, warm) in [
+        (
+            "PreState",
+            dispatch_pre(&PROGRAM, u32::MAX, TICKS, 0),
+            dispatch_pre(&PROGRAM, 8, TICKS, 0),
+        ),
+        (
+            "ArmState",
+            dispatch_arm(&PROGRAM, u32::MAX, TICKS, 0),
+            dispatch_arm(&PROGRAM, 8, TICKS, 0),
+        ),
+    ] {
+        assert_eq!(cold, expected(), "{name}: the cold arm states the answer");
+        assert_eq!(
+            warm, cold,
+            "{name}: the compiled loop disagreed with the interpreter",
+        );
+        assert_eq!(
+            arms_of(name),
+            3,
+            "{name}: the portal did not lower this machine's three opcodes",
+        );
+        assert_eq!(
+            degraded_of(name),
+            vec!["OP_USES"],
+            "{name}: the arm reading the macro-initialised binding must be \
+             recorded as refused — a silent skip would leave the registry \
+             empty and the answer would still be right, because the \
+             interpreter computes it either way",
+        );
+    }
+}

--- a/majit/majit-metainterp/tests/jit_interp_match_const_patterns.rs
+++ b/majit/majit-metainterp/tests/jit_interp_match_const_patterns.rs
@@ -1,0 +1,184 @@
+//! A value-position `match` whose arms name constants.
+//!
+//! syn parses `TAG_A => ..` and `other => ..` as the same `Pat::Ident`, and
+//! `lower_match_value` read every such arm as the catch-all binding. Three
+//! constant arms therefore produced NO guarded arms and a `default_arm` set to
+//! whichever came last, so the jitcode computed that one arm for every
+//! discriminant — while the concrete interpreter, which is real Rust, stayed
+//! right. The trace was wrong and only a warm-versus-cold answer could say so.
+//!
+//! The sibling `lower_dispatch_chain` never had this: it reads its arms with
+//! `extract_pat_value_tokens`, which emits `#path as i64` for the user crate to
+//! resolve. `lower_match_value` now reads them the same way, and treats a
+//! `Pat::Ident` as a binding only when its name holds a lower-case letter.
+//!
+//! The answer is the subject; the guard census is the denominator. A machine
+//! that stopped lowering the arm altogether would agree with the interpreter
+//! too — by being the interpreter.
+//!
+//! The compiled loop, measured:
+//!
+//! ```text
+//! IntAnd GuardValue IntEq GuardTrue IntAdd IntAdd IntSub IntIsTrue GuardTrue Jump
+//! ```
+//!
+//! `IntEq` + `GuardTrue` is the arm the trace took, guarded. Under the old
+//! lowering there was no comparison in the body at all. The tags are given
+//! non-zero values so that comparison stays spelled `IntEq`: against zero the
+//! optimizer rewrites it to `IntIsZero` and the census would have to name both.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use majit_ir::OpCode;
+use majit_metainterp::JitDriver;
+
+static COMPILES: AtomicUsize = AtomicUsize::new(0);
+static COMPILED: Mutex<Vec<OpCode>> = Mutex::new(Vec::new());
+
+/// Distinct per arm and distinct from every tag, so a sum can only come out
+/// right if each tag reached its own arm.
+const TAG_A: i64 = 11;
+const TAG_B: i64 = 22;
+const TAG_C: i64 = 33;
+
+/// The last constant arm. Under the old lowering this was the value every tag
+/// produced in the trace.
+const VALUE_C: i64 = 500;
+
+#[majit_macros::jit_inline]
+fn classify(tag: i64) -> i64 {
+    match tag {
+        TAG_A => 5i64,
+        TAG_B => 50i64,
+        TAG_C => VALUE_C,
+        _ => 9000i64,
+    }
+}
+
+struct TagState {
+    tags: Vec<i64>,
+    pos: i64,
+    acc: i64,
+    ticks: i64,
+}
+
+pub type Bytecode = [u8];
+
+const OP_CLASSIFY: u8 = 1;
+const OP_TICK: u8 = 2;
+const OP_HALT: u8 = 3;
+const PROGRAM: [u8; 3] = [OP_CLASSIFY, OP_TICK, OP_HALT];
+
+/// Four tags, cycled: every arm including the `_` default is reached.
+const TAGS: [i64; 4] = [TAG_A, TAG_B, TAG_C, 7];
+
+const TICKS: i64 = 400;
+
+#[majit_macros::jit_interp(
+    state = TagState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = {
+        tags: [int; virt],
+        pos: int,
+        acc: int,
+        ticks: int,
+    },
+    calls = { classify => inline_int },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_tags(program: &Bytecode, threshold: u32, ticks: i64) -> i64 {
+    let mut driver: JitDriver<TagState> = JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_gk, _before, _after, opcodes| {
+        COMPILES.fetch_add(1, Ordering::Relaxed);
+        *COMPILED.lock().unwrap() = opcodes.to_vec();
+    });
+    let mut pc: usize = 0;
+    let mut state = TagState {
+        tags: TAGS.to_vec(),
+        pos: 0i64,
+        acc: 0i64,
+        ticks,
+    };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_CLASSIFY => {
+                let i = state.pos & 3i64;
+                let t = state.tags[i as usize];
+                state.acc = state.acc + classify(t);
+                state.pos = state.pos + 1i64;
+            }
+            OP_TICK => {
+                state.ticks = state.ticks - 1i64;
+                if state.ticks != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            OP_HALT => break,
+            _ => break,
+        }
+    }
+    state.acc
+}
+
+/// What the interpreter alone computes, spelled independently of `classify`.
+fn expected() -> i64 {
+    let per_tag = [5i64, 50, VALUE_C, 9000];
+    let full = TICKS / 4;
+    let rest = TICKS % 4;
+    let mut total = full * per_tag.iter().sum::<i64>();
+    for (i, v) in per_tag.iter().enumerate() {
+        if (i as i64) < rest {
+            total += v;
+        }
+    }
+    total
+}
+
+#[test]
+fn the_traced_match_sends_each_tag_to_its_own_arm() {
+    let cold = dispatch_tags(&PROGRAM, u32::MAX, TICKS);
+    assert_eq!(cold, expected(), "the cold arm states the answer");
+
+    let warm = dispatch_tags(&PROGRAM, 8, TICKS);
+    assert_eq!(
+        warm, cold,
+        "the compiled match disagreed with the interpreter. \
+         {} per pass would be every tag taking the last constant arm",
+        VALUE_C,
+    );
+    assert!(
+        COMPILES.load(Ordering::Relaxed) > 0,
+        "nothing compiled, so the warm answer above was the interpreter's too",
+    );
+}
+
+/// The denominator: the arms are in the trace as guarded comparisons.
+#[test]
+fn the_constant_arms_are_guarded_in_the_trace() {
+    let _ = dispatch_tags(&PROGRAM, 8, TICKS);
+    let body = COMPILED.lock().unwrap().clone();
+    assert!(
+        !body.is_empty(),
+        "no compiled loop was recorded, so this census is vacuous",
+    );
+    let eqs = body.iter().filter(|op| **op == OpCode::IntEq).count();
+    assert!(
+        eqs > 0,
+        "the match lowered to no comparison at all, so one arm was taken \
+         unconditionally: {body:#?}",
+    );
+}

--- a/majit/majit-metainterp/tests/jit_interp_ref_local_binding.rs
+++ b/majit/majit-metainterp/tests/jit_interp_ref_local_binding.rs
@@ -1,0 +1,156 @@
+//! Binding a `ref(T)` state field to a local before reading a field off it.
+//!
+//! `state.sel.value` lowers as one expression, because that path resolves the
+//! pointee `T` out of the `ref(T)` declaration itself. Split across two
+//! statements the ref becomes an ordinary local binding, and both walks then
+//! have to find the same declaration through that binding. Neither did:
+//! `RefFieldRewriter` never recorded the local, so the concrete arm did not
+//! compile (`usize` has no fields), and `lower_ref_binding_getfield` found no
+//! struct type on the binding, so the arm degraded to a stub.
+//!
+//! The two arms below differ only in that split, and once the concrete side
+//! compiles they agree on the answer — which is why the arm census is what
+//! grades the lowering here.
+
+use majit_metainterp::jitcode::insns::BC_GETFIELD_GC_I;
+use majit_metainterp::{Assembler, JitDriver};
+
+#[repr(C)]
+struct Node {
+    value: i64,
+    next: *mut Node,
+}
+
+struct NodeState {
+    total: i64,
+    sel: usize,
+}
+
+pub type Bytecode = [u8];
+
+/// The control: one expression, `state.sel.value`.
+const OP_DIRECT: u8 = 1;
+/// The subject: the same read with the ref bound first.
+const OP_VIA_LOCAL: u8 = 2;
+
+#[majit_macros::jit_interp(
+    state = NodeState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = { total: int, sel: ref(Node) },
+    ref_fields = { Node::next => Node },
+    int_fields = { Node::value => i64 },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_nodes(program: &Bytecode, threshold: u32, sel: usize) -> i64 {
+    let mut driver: JitDriver<NodeState> = JitDriver::new(threshold);
+    let mut pc: usize = 0;
+    let mut state = NodeState { total: 0, sel };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!();
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_DIRECT => {
+                state.total = state.total + state.sel.value;
+            }
+            OP_VIA_LOCAL => {
+                let n = state.sel;
+                state.total = state.total + n.value;
+            }
+            _ => break,
+        }
+    }
+    state.total
+}
+
+fn build_dispatch_jitcode() -> majit_metainterp::JitCode {
+    let mut asm = Assembler::new();
+    asm.set_canonical_liveness_triple(vec![0], vec![0], vec![]);
+    __prebuild_jitcode_liveness_dispatch_nodes(&mut asm);
+    let _ = asm.ensure_canonical_liveness_offset();
+    __dispatch_jitcode_dispatch_nodes(&mut asm, 0i64).expect("dispatch lower must succeed")
+}
+
+/// Every jitcode body the portal produced: the dispatch JitCode plus each
+/// per-arm sub-JitCode.
+fn all_jitcode_bodies(dispatch_jc: &majit_metainterp::JitCode) -> Vec<Vec<u8>> {
+    let mut bodies = vec![dispatch_jc.code.clone()];
+    bodies.extend(
+        dispatch_jc
+            .exec
+            .descrs
+            .iter()
+            .filter_map(|descr| descr.as_jitcode())
+            .map(|sub| sub.code.clone()),
+    );
+    bodies
+}
+
+#[test]
+fn a_ref_state_field_bound_to_a_local_keeps_its_declared_pointee() {
+    let _ = build_dispatch_jitcode();
+
+    let census = majit_metainterp::dispatch_arm_census();
+    let counted = census
+        .iter()
+        .find(|e| e.interp == "NodeState")
+        .unwrap_or_else(|| panic!("the portal must record its arm count; census={census:?}"));
+    assert_eq!(
+        counted.arms, 2,
+        "OP_DIRECT and OP_VIA_LOCAL are counted; the `_` default is not; \
+         census={census:?}"
+    );
+
+    let degraded: Vec<&'static str> = majit_metainterp::degraded_dispatch_arms()
+        .into_iter()
+        .filter(|e| e.interp == "NodeState")
+        .map(|e| e.arm)
+        .collect();
+    assert!(
+        !degraded.contains(&"OP_DIRECT"),
+        "the control degraded, so the fixture is measuring its own mistake and \
+         the subject says nothing; degraded={degraded:?}"
+    );
+
+    majit_metainterp::assert_no_degraded_dispatch_arms("NodeState");
+}
+
+/// What an un-degraded arm was supposed to emit. The gate above says the arm
+/// lowered; this says what it lowered TO.
+#[test]
+fn each_arm_reads_the_field_through_a_getfield_gc() {
+    let dispatch_jc = build_dispatch_jitcode();
+    let reads: usize = all_jitcode_bodies(&dispatch_jc)
+        .iter()
+        .map(|body| body.iter().filter(|op| **op == BC_GETFIELD_GC_I).count())
+        .sum();
+    assert_eq!(
+        reads, 2,
+        "one `value` read per arm; 1 is the local-binding arm degraded to a stub",
+    );
+}
+
+/// The answer both spellings owe. It is the same either way — which is the
+/// point: the degradation above never showed up here.
+#[test]
+fn both_spellings_read_the_same_field() {
+    let node = Node {
+        value: 5,
+        next: std::ptr::null_mut(),
+    };
+    let sel = &node as *const Node as usize;
+
+    let program: &Bytecode = &[OP_DIRECT, OP_VIA_LOCAL];
+    assert_eq!(
+        dispatch_nodes(program, u32::MAX, sel),
+        10,
+        "each arm adds `sel.value`",
+    );
+}

--- a/majit/majit-metainterp/tests/struct_layout_conflict.rs
+++ b/majit/majit-metainterp/tests/struct_layout_conflict.rs
@@ -49,8 +49,8 @@ fn a_site_re_registering_what_it_already_declared_is_not_a_conflict() {
     let layout = &[(0, true, "head", 8, false), (8, false, "size", 8, true)][..];
     // Two access sites on one struct, each re-declaring the whole layout —
     // the shape `#[jit_interp]` emits, one call per getfield/setfield.
-    builder.register_struct_layout(16, TID_AGREE, false, false, layout);
-    builder.register_struct_layout(16, TID_AGREE, false, false, layout);
+    builder.register_struct_layout(16, TID_AGREE, false, false, layout, "");
+    builder.register_struct_layout(16, TID_AGREE, false, false, layout, "");
     let _ = builder.finish();
 
     assert!(
@@ -79,6 +79,8 @@ fn one_word_declared_a_pointer_and_a_scalar_is_a_conflict() {
         false,
         false,
         &[(0, true, "head", 8, false)],
+        // these tests are about offset disagreement; nothing is declared
+        "",
     );
     builder.register_struct_layout(
         16,
@@ -86,6 +88,8 @@ fn one_word_declared_a_pointer_and_a_scalar_is_a_conflict() {
         false,
         false,
         &[(0, false, "head", 8, true)],
+        // these tests are about offset disagreement; nothing is declared
+        "",
     );
     let _ = builder.finish();
 
@@ -109,13 +113,22 @@ fn one_word_declared_a_pointer_and_a_scalar_is_a_conflict() {
 #[test]
 fn a_sibling_at_an_occupied_offset_is_reported_as_dropped() {
     let mut builder = JitCodeBuilder::new();
-    builder.register_struct_layout(24, TID_SIBLING, false, false, &[(8, false, "agg", 8, true)]);
+    builder.register_struct_layout(
+        24,
+        TID_SIBLING,
+        false,
+        false,
+        &[(8, false, "agg", 8, true)],
+        "",
+    );
     builder.register_struct_layout(
         24,
         TID_SIBLING,
         false,
         false,
         &[(8, true, "leaf", 8, false)],
+        // these tests are about offset disagreement; nothing is declared
+        "",
     );
     let jitcode = builder.finish();
     let _ = jitcode;
@@ -140,8 +153,8 @@ fn a_sibling_at_an_occupied_offset_is_reported_as_dropped() {
 fn the_gate_reports_a_conflict_rather_than_passing_on_it() {
     let mut builder = JitCodeBuilder::new();
     const TID: u64 = 0x4741_5445_4441;
-    builder.register_struct_layout(16, TID, false, false, &[(0, true, "head", 8, false)]);
-    builder.register_struct_layout(16, TID, false, false, &[(0, false, "head", 8, true)]);
+    builder.register_struct_layout(16, TID, false, false, &[(0, true, "head", 8, false)], "");
+    builder.register_struct_layout(16, TID, false, false, &[(0, false, "head", 8, true)], "");
     let _ = builder.finish();
 
     let failure = std::panic::catch_unwind(majit_metainterp::assert_no_struct_layout_conflicts)

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -305,6 +305,30 @@ pub struct Assembler {
     /// the `MAJIT_COVERAGE_PANIC=1` diagnostic so the missing-coloring
     /// panic can cite the offending op.
     current_flatop_debug: Option<String>,
+    /// `call.py CallControl.jitcodes` — the per-graph cache `get_jitcode`
+    /// consults before assembling anything.
+    ///
+    /// Upstream mints an empty JitCode and registers it under the graph
+    /// BEFORE the body is written, so a graph that calls itself links to the
+    /// object it is already registered under instead of assembling a second
+    /// copy.  This is the same cache, keyed by a per-helper identity address,
+    /// and it is what stops a self-recursive `#[jit_inline]` helper from
+    /// recursing forever while its jitcode is being built.
+    ///
+    /// Type-erased because `majit-metainterp` depends on this crate and not the
+    /// other way round; every value is an
+    /// `Arc<majit_metainterp::jitcode::InlineJitCodeSlot>`.  It sits beside
+    /// `indirectcalltargets`, which upstream also keeps as a JitCode-identity
+    /// set on this object.
+    inline_jitcodes: indexmap::IndexMap<usize, std::sync::Arc<dyn std::any::Any + Send + Sync>>,
+    /// `call.py CallControl.unfinished_graphs` membership, for the install-time
+    /// liveness prebuild walk.
+    ///
+    /// That walk is a second recursion with no `JitCodeBuilder` anywhere in
+    /// scope: a helper's prebuild body calls its callees' prebuilds directly,
+    /// so a recursive helper overflows there too, earlier and with nothing to
+    /// catch it.  Membership here is what makes the walk visit each helper once.
+    inline_prebuild_seen: indexmap::IndexSet<usize>,
 }
 
 impl Assembler {
@@ -328,7 +352,40 @@ impl Assembler {
             canonical_liveness_offset: None,
             current_graph_name: None,
             current_flatop_debug: None,
+            inline_jitcodes: indexmap::IndexMap::new(),
+            inline_prebuild_seen: indexmap::IndexSet::new(),
         }
+    }
+
+    /// `call.py CallControl.jitcodes.get(graph)` — the slot registered for
+    /// `key`, or `None` if this helper has not been entered yet.
+    ///
+    /// The caller downcasts; this object cannot name the slot type without
+    /// depending on the crate above it.
+    pub fn inline_jitcode_slot(
+        &self,
+        key: usize,
+    ) -> Option<&std::sync::Arc<dyn std::any::Any + Send + Sync>> {
+        self.inline_jitcodes.get(&key)
+    }
+
+    /// `call.py CallControl.jitcodes[graph] = jitcode`.
+    ///
+    /// Called twice per helper: once with the under-construction slot before
+    /// the body is assembled, once with the finished one after.
+    pub fn inline_jitcode_insert(
+        &mut self,
+        key: usize,
+        slot: std::sync::Arc<dyn std::any::Any + Send + Sync>,
+    ) {
+        self.inline_jitcodes.insert(key, slot);
+    }
+
+    /// Whether this is the first time the liveness prebuild walk has reached
+    /// `key`.  `false` means the walk is already inside this helper and must
+    /// not descend again.
+    pub fn enter_inline_prebuild(&mut self, key: usize) -> bool {
+        self.inline_prebuild_seen.insert(key)
     }
 
     /// Stage the state-field JIT canonical "all-live" triple for lazy

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -1127,6 +1127,7 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
         .map(|(i, d)| match d {
             RuntimeBhDescr::Descr(bh) => crate::descr::make_descr_from_bh(bh),
             RuntimeBhDescr::JitCode(_)
+            | RuntimeBhDescr::JitCodeBackEdge(_)
             | RuntimeBhDescr::Call(_)
             | RuntimeBhDescr::AssemblerToken(_) => crate::descr::make_jitcode_descr(i),
         })

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1815,6 +1815,7 @@ pub(crate) fn sub_jitcode_descr_pool_for_code(code: *const ()) -> Option<SubDesc
             .map(|(i, d)| match d {
                 RuntimeBhDescr::Descr(bh) => crate::descr::make_descr_from_bh(bh),
                 RuntimeBhDescr::JitCode(_)
+                | RuntimeBhDescr::JitCodeBackEdge(_)
                 | RuntimeBhDescr::Call(_)
                 | RuntimeBhDescr::AssemblerToken(_) => crate::descr::make_jitcode_descr(i),
             })

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1439,7 +1439,9 @@ fn dispatch_perfn_frame<Sym: WalkSym>(
             // target straight from `RawDescrPool::PerFn`, not through this
             // adapted `DescrRef` slot; the jitcode-descr stand-in is a
             // fail-loud tripwire for a mis-routed slot.
-            RuntimeBhDescr::JitCode(_) => crate::descr::make_jitcode_descr(i),
+            RuntimeBhDescr::JitCode(_) | RuntimeBhDescr::JitCodeBackEdge(_) => {
+                crate::descr::make_jitcode_descr(i)
+            }
             RuntimeBhDescr::Call(_) | RuntimeBhDescr::AssemblerToken(_) => {
                 crate::descr::make_jitcode_descr(i)
             }


### PR DESCRIPTION
Eleven commits against the `#[jit_interp]` / `#[jit_inline]` lowering, cut out of a
longer branch so they can land on their own. The rest of that branch is a
`majit/examples/regex` matcher and its notes; nothing here depends on it, and no
commit in this PR touches `majit/examples`, the workspace manifest, or the plan
file.

Three of these produced **wrong answers with every instrument reporting healthy** —
no degraded arm, no diagnostic, no warning — so they are the reason for the cut.

### `_immutable_fields_`

- **publish `jit_immutable_fields` as an inherent associated const** — a
  `<T as Trait>::CONST` lookup always picks the blanket default, so the
  declaration is published as an inherent const instead.
- **carry `_immutable_fields_` from a `jit_interp` emit site to the field descr** —
  the declaration reaches the field descr, so the optimizer can fold the load.
- **prove the immutable-field fold end to end on a `jit_interp` machine** — a
  fixture that traces a machine and reads the folded loop.

### `#[jit_inline]`

- **let a `#[jit_inline]` helper call itself** — the inline lowering emitted a plain
  Rust call to the callee's `_with_asm` builder, so a helper naming itself recursed
  at jitcode-build time until the stack was gone, during warmup and before any
  tracing. Closed with an assembler-wide memo and `Arc::new_cyclic`, so the body can
  name a `Weak` to the `Arc` that does not exist yet. `RuntimeBhDescr` gains
  `JitCodeBackEdge(Weak<JitCode>)` for that self-edge.

### Reading match arms

- **read a value-position match's constant arms as constants** — `lower_match_value`
  classified every `Pat::Ident` arm with no subpattern as the catch-all binding, and
  syn parses a constant path that way. Constant arms therefore produced no guarded
  arms and a `default_arm` set to the last of them, so the jitcode computed that one
  arm for every discriminant while the concrete interpreter, being real Rust, stayed
  right.
- **give the three match-arm classifiers one rule** — the three sites that decide
  what an arm is now share one predicate.

### Typing a `ref(T)`

- **type a wrapped ref call's result from `call_returns`** — every `*_ref_wrapped`
  policy fell through to a tail that built its `Binding` with `struct_type: None`, so
  `lower_ref_binding_getfield` had nothing to resolve `result.field` against and
  bailed, taking the whole dispatch arm down as an abort stub.
- **carry a `ref(T)` state field's pointee onto a local binding** — `state.sel.value`
  resolves its pointee out of the `ref(T)` declaration; bound to a local first,
  neither walk found it.

### Dispatch selection and edges

- **route the dispatch default edge by what the default arm says** —
  `lower_dispatch_chain` sent every unmatched opcode to the portal function's
  trailing return. That is the `_ => break` reading; `_ => {}` and a default arm with
  a body do not mean it, and both got the return anyway, so the portal returned a
  partial answer. Nothing had refused, so no census saw it.
- **pick the dispatch match out of the portal loop, not by arm count** —
  `find_dispatch_match` chose the match with the most arms over every match anywhere
  in the portal function. Arm count is not a property of being the dispatch: a
  five-arm `let x = match ..` beside a three-opcode dispatch takes its place, and the
  portal then compiles a loop that runs none of the interpreter and answers with it.
- **read a macro initialiser as a reference the walk cannot see** —
  `expr_references_unknown_local` had no `Expr::Macro` arm, so a macro invocation
  reached its catch-all and reported no reference. It cannot know that; the tokens
  are opaque to it.

### Tests

Ten new fixtures under `majit/majit-metainterp/tests/`, plus two existing ones
adjusted. Each fixture grades on an arm census or a guard census rather than on the
return value, since a machine that stops lowering an arm agrees with the interpreter
by being it.

Gate run on this branch:

```
cargo test --no-fail-fast --no-default-features --features cranelift -p majit-metainterp
cargo fmt --all --check
```
