### PR TITLE
cpyext: loading real extension modules, buffer/memoryview GC rooting, and the suite lane that grades them

### DIFF
--- a/include/pyre3.14t/Python.h
+++ b/include/pyre3.14t/Python.h
@@ -11,6 +11,17 @@
 #ifndef Py_PYTHON_H
 #define Py_PYTHON_H
 
+/* A module built inside the interpreter's own tree says so with one of the
+   two spellings below, and the headers under `internal/` are the ones that
+   ask.  Both fold to `Py_BUILD_CORE`, as the reference header does, so a
+   source that sets either reaches them. */
+#if defined(Py_BUILD_CORE_BUILTIN) && !defined(Py_BUILD_CORE)
+#  define Py_BUILD_CORE
+#endif
+#if defined(Py_BUILD_CORE_MODULE) && !defined(Py_BUILD_CORE)
+#  define Py_BUILD_CORE
+#endif
+
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>

--- a/include/pyre3.14t/Python.h
+++ b/include/pyre3.14t/Python.h
@@ -50,6 +50,9 @@
 /* The `datetime` C API's structs, which the entry points below name. */
 #include "datetime.h"
 
+/* `PyTime_t`, which the clock entry points below take and answer with. */
+#include "pytime.h"
+
 /* Every exported entry point. It sits here because the headers above
    name the types it uses, and the ones below define `static inline`
    functions that call it. */

--- a/include/pyre3.14t/internal/pycore_modsupport.h
+++ b/include/pyre3.14t/internal/pycore_modsupport.h
@@ -1,0 +1,55 @@
+/* The argument-parsing entry points Argument Clinic writes calls to.
+ *
+ * CPython keeps these out of the installed headers, so an extension reaching
+ * them is one built inside the interpreter's own tree.  pyre ships them under
+ * `internal/` on the same terms: not ABI an ordinary extension may depend on.
+ *
+ * Each declaration is paired with the fast-path macro its callers expand, so
+ * the common shapes -- no keywords at all, a call already in range -- never
+ * reach the function.
+ */
+#ifndef PYRE_PYCORE_MODSUPPORT_H
+#define PYRE_PYCORE_MODSUPPORT_H
+
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Declared with the other variadic entry points in `modsupport.h`, which
+   `Python.h` includes; the macro is what this header adds. */
+#define _Py_ANY_VARARGS(n) ((n) == PY_SSIZE_T_MAX)
+#define _PyArg_CheckPositional(funcname, nargs, min, max) \
+    ((!_Py_ANY_VARARGS(max) && (min) <= (nargs) && (nargs) <= (max)) \
+     || _PyArg_CheckPositional((funcname), (nargs), (min), (max)))
+
+/* Bind a vectorcall's arguments to `parser`'s parameters, answering the array
+   the caller reads them out of: `args` itself when nothing had to be moved,
+   and otherwise `buf`, filled slot by slot with a missing optional left NULL.
+   Answers NULL with an exception set. */
+PyAPI_FUNC(PyObject * const *) _PyArg_UnpackKeywords(
+    PyObject *const *args,
+    Py_ssize_t nargs,
+    PyObject *kwargs,
+    PyObject *kwnames,
+    struct _PyArg_Parser *parser,
+    int minpos,
+    int maxpos,
+    int minkw,
+    int varpos,
+    PyObject **buf);
+#define _PyArg_UnpackKeywords(args, nargs, kwargs, kwnames, parser, minpos, maxpos, minkw, varpos, buf) \
+    (((minkw) == 0 && (kwargs) == NULL && (kwnames) == NULL && \
+      (minpos) <= (nargs) && ((varpos) || (nargs) <= (maxpos)) && (args) != NULL) ? \
+      (args) : \
+     _PyArg_UnpackKeywords((args), (nargs), (kwargs), (kwnames), (parser), \
+                           (minpos), (maxpos), (minkw), (varpos), (buf)))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !PYRE_PYCORE_MODSUPPORT_H */

--- a/include/pyre3.14t/internal/pycore_namespace.h
+++ b/include/pyre3.14t/internal/pycore_namespace.h
@@ -1,0 +1,25 @@
+/* `_PyNamespace_New`, which builds a `types.SimpleNamespace` from a mapping.
+ *
+ * CPython keeps this out of the installed headers, so an extension reaching
+ * it is one built inside the interpreter's own tree.  pyre ships it under
+ * `internal/` for the same reason and on the same terms: it is not ABI an
+ * ordinary extension may depend on.
+ */
+#ifndef PYRE_PYCORE_NAMESPACE_H
+#define PYRE_PYCORE_NAMESPACE_H
+
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+PyAPI_FUNC(PyObject *) _PyNamespace_New(PyObject *kwds);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !PYRE_PYCORE_NAMESPACE_H */

--- a/include/pyre3.14t/modsupport.h
+++ b/include/pyre3.14t/modsupport.h
@@ -23,6 +23,34 @@ PyAPI_FUNC(int) PyArg_ParseTupleAndKeywords(PyObject *, PyObject *, const char *
                                             PY_CXX_CONST char *const *, ...);
 PyAPI_FUNC(int) PyArg_UnpackTuple(PyObject *, const char *, Py_ssize_t, Py_ssize_t, ...);
 PyAPI_FUNC(int) _PyArg_CheckPositional(const char *, Py_ssize_t, Py_ssize_t, Py_ssize_t);
+
+/* A flag that runs one piece of initialization once, whichever thread arrives
+   first; `std::call_once` is the C++11 spelling of it. */
+typedef struct {
+    uint8_t v;
+} _PyOnceFlag;
+
+/* The keyword table Argument Clinic emits beside a function, together with
+   what the first call through it works out: which parameters are
+   positional-only, and the tuple of interned names the rest are looked up by.
+   Clinic names the fields it fills, so a parser it wrote carries `keywords`,
+   `fname` and sometimes a prebuilt `kwtuple`, and leaves the rest zeroed. */
+typedef struct _PyArg_Parser {
+    const char *format;
+    const char * const *keywords;
+    const char *fname;
+    const char *custom_msg;
+    _PyOnceFlag once;       /* atomic one-time initialization flag */
+    int is_kwtuple_owned;   /* does this parser own the kwtuple object? */
+    int pos;                /* number of positional-only arguments */
+    int min;                /* minimal number of arguments */
+    int max;                /* maximal number of positional arguments */
+    PyObject *kwtuple;      /* tuple of keyword parameter names */
+    struct _PyArg_Parser *next;
+} _PyArg_Parser;
+
+PyAPI_FUNC(int) _PyArg_ParseTupleAndKeywordsFast(PyObject *, PyObject *,
+                                                 struct _PyArg_Parser *, ...);
 PyAPI_FUNC(PyObject *) Py_BuildValue(const char *, ...);
 PyAPI_FUNC(PyObject *) Py_VaBuildValue(const char *, va_list);
 

--- a/include/pyre3.14t/moduleobject.h
+++ b/include/pyre3.14t/moduleobject.h
@@ -27,6 +27,11 @@ struct PyModuleDef_Slot {
 #define Py_mod_multiple_interpreters 3
 #define Py_mod_gil 4
 
+/* The highest slot number defined above, so that anything past it is a slot
+   no reader claims.  `PyModule_FromDefAndSpec` rejects one, and a def that
+   wants to be rejected names `_Py_mod_LAST_SLOT + 1`. */
+#define _Py_mod_LAST_SLOT 4
+
 /* for Py_mod_multiple_interpreters: */
 #define Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED ((void *)0)
 #define Py_MOD_MULTIPLE_INTERPRETERS_SUPPORTED ((void *)1)

--- a/include/pyre3.14t/pymacro.h
+++ b/include/pyre3.14t/pymacro.h
@@ -10,6 +10,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+/* Minimum value between x and y */
+#define Py_MIN(x, y) (((x) > (y)) ? (y) : (x))
+
+/* Maximum value between x and y */
+#define Py_MAX(x, y) (((x) > (y)) ? (x) : (y))
+
 /* Names an argument a function does not read, so the compiler stops warning
    about it: `int func(int a, int Py_UNUSED(b))`. */
 #if defined(__GNUC__) || defined(__clang__)

--- a/include/pyre3.14t/pyre_decl.h
+++ b/include/pyre3.14t/pyre_decl.h
@@ -554,6 +554,15 @@ PyAPI_FUNC(double) PyOS_string_to_double(const char *, char **, PyObject *);
 PyAPI_FUNC(int) Py_IsFinalizing(void);
 PyAPI_FUNC(int) Py_IsInitialized(void);
 
+/* cpyext/pytime.rs */
+PyAPI_FUNC(double) PyTime_AsSecondsDouble(PyTime_t);
+PyAPI_FUNC(int) PyTime_Monotonic(PyTime_t *);
+PyAPI_FUNC(int) PyTime_MonotonicRaw(PyTime_t *);
+PyAPI_FUNC(int) PyTime_PerfCounter(PyTime_t *);
+PyAPI_FUNC(int) PyTime_PerfCounterRaw(PyTime_t *);
+PyAPI_FUNC(int) PyTime_Time(PyTime_t *);
+PyAPI_FUNC(int) PyTime_TimeRaw(PyTime_t *);
+
 /* cpyext/sequence.rs */
 PyAPI_FUNC(int) PySequence_Check(PyObject *);
 PyAPI_FUNC(PyObject *) PySequence_Concat(PyObject *, PyObject *);

--- a/include/pyre3.14t/pyre_decl.h
+++ b/include/pyre3.14t/pyre_decl.h
@@ -360,6 +360,9 @@ PyAPI_FUNC(void *) PyModule_GetState(PyObject *);
 PyAPI_FUNC(PyObject *) PyModule_New(const char *);
 PyAPI_FUNC(PyObject *) PyModule_NewObject(PyObject *);
 PyAPI_FUNC(int) PyModule_SetDocString(PyObject *, const char *);
+PyAPI_FUNC(int) PyState_AddModule(PyObject *, PyModuleDef *);
+PyAPI_FUNC(PyObject *) PyState_FindModule(PyModuleDef *);
+PyAPI_FUNC(int) PyState_RemoveModule(PyModuleDef *);
 
 /* cpyext/number.rs */
 PyAPI_FUNC(int) PyIndex_Check(PyObject *);

--- a/include/pyre3.14t/pyre_decl.h
+++ b/include/pyre3.14t/pyre_decl.h
@@ -6,7 +6,9 @@
  *
  * An export a hand-written header renames to an inline fast path is
  * left out: that header declares it ahead of the rename, which a
- * declaration here would come after.
+ * declaration here would come after.  So is one a header under
+ * `internal/` declares, which is reached by including that header
+ * and not by including `Python.h`.
  */
 #ifndef PYRE_DECL_H
 #define PYRE_DECL_H

--- a/include/pyre3.14t/pytime.h
+++ b/include/pyre3.14t/pytime.h
@@ -1,0 +1,22 @@
+/* The `PyTime_t` clock API.
+ *
+ * A `PyTime_t` is a count of nanoseconds, and the entry points that read a
+ * clock are declared in `pyre_decl.h`.  This header carries the type itself,
+ * which those declarations name, so it is included ahead of them.
+ */
+#ifndef PYRE_PYTIME_H
+#define PYRE_PYTIME_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int64_t PyTime_t;
+#define PyTime_MIN INT64_MIN
+#define PyTime_MAX INT64_MAX
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !PYRE_PYTIME_H */

--- a/lib_pypy/_testbuffer.c
+++ b/lib_pypy/_testbuffer.c
@@ -1,9 +1,6 @@
 /* C Extension module to test all aspects of PEP-3118.
    Written by Stefan Krah. */
 
-
-#define PY_SSIZE_T_CLEAN
-
 #include "Python.h"
 
 
@@ -27,11 +24,13 @@ static PyTypeObject NDArray_Type;
 #define NDArray_Check(v) Py_IS_TYPE(v, &NDArray_Type)
 
 #define CHECK_LIST_OR_TUPLE(v) \
-    if (!PyList_Check(v) && !PyTuple_Check(v)) { \
-        PyErr_SetString(PyExc_TypeError,         \
-            #v " must be a list or a tuple");    \
-        return NULL;                             \
-    }                                            \
+    do { \
+        if (!PyList_Check(v) && !PyTuple_Check(v)) { \
+            PyErr_SetString(PyExc_TypeError, \
+                            #v " must be a list or a tuple"); \
+            return NULL; \
+        } \
+    } while (0)
 
 #define PyMem_XFree(v) \
     do { if (v) PyMem_Free(v); } while (0)
@@ -219,8 +218,9 @@ ndarray_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 }
 
 static void
-ndarray_dealloc(NDArrayObject *self)
+ndarray_dealloc(PyObject *op)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     if (self->head) {
         if (ND_IS_CONSUMER(self)) {
             Py_buffer *base = &self->head->base;
@@ -1183,7 +1183,7 @@ init_ndbuf(PyObject *items, PyObject *shape, PyObject *strides,
     Py_ssize_t itemsize;
 
     /* ndim = len(shape) */
-    CHECK_LIST_OR_TUPLE(shape)
+    CHECK_LIST_OR_TUPLE(shape);
     ndim = PySequence_Fast_GET_SIZE(shape);
     if (ndim > ND_MAX_NDIM) {
         PyErr_Format(PyExc_ValueError,
@@ -1193,7 +1193,7 @@ init_ndbuf(PyObject *items, PyObject *shape, PyObject *strides,
 
     /* len(strides) = len(shape) */
     if (strides) {
-        CHECK_LIST_OR_TUPLE(strides)
+        CHECK_LIST_OR_TUPLE(strides);
         if (PySequence_Fast_GET_SIZE(strides) == 0)
             strides = NULL;
         else if (flags & ND_FORTRAN) {
@@ -1220,12 +1220,12 @@ init_ndbuf(PyObject *items, PyObject *shape, PyObject *strides,
 
     /* convert scalar to list */
     if (ndim == 0) {
-        items = Py_BuildValue("(O)", items);
+        items = PyTuple_Pack(1, items);
         if (items == NULL)
             return NULL;
     }
     else {
-        CHECK_LIST_OR_TUPLE(items)
+        CHECK_LIST_OR_TUPLE(items);
         Py_INCREF(items);
     }
 
@@ -1414,8 +1414,9 @@ ndarray_pop(PyObject *self, PyObject *dummy)
 /**************************************************************************/
 
 static int
-ndarray_getbuf(NDArrayObject *self, Py_buffer *view, int flags)
+ndarray_getbuf(PyObject *op, Py_buffer *view, int flags)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     ndbuf_t *ndbuf = self->head;
     Py_buffer *base = &ndbuf->base;
     int baseflags = ndbuf->flags;
@@ -1524,16 +1525,16 @@ ndarray_getbuf(NDArrayObject *self, Py_buffer *view, int flags)
             return -1;
     }
 
-    view->obj = (PyObject *)self;
-    Py_INCREF(view->obj);
+    view->obj = Py_NewRef(self);
     self->head->exports++;
 
     return 0;
 }
 
 static void
-ndarray_releasebuf(NDArrayObject *self, Py_buffer *view)
+ndarray_releasebuf(PyObject *op, Py_buffer *view)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     if (!ND_IS_CONSUMER(self)) {
         ndbuf_t *ndbuf = view->internal;
         if (--ndbuf->exports == 0 && ndbuf != self->head)
@@ -1542,8 +1543,8 @@ ndarray_releasebuf(NDArrayObject *self, Py_buffer *view)
 }
 
 static PyBufferProcs ndarray_as_buffer = {
-    (getbufferproc)ndarray_getbuf,        /* bf_getbuffer */
-    (releasebufferproc)ndarray_releasebuf /* bf_releasebuffer */
+    ndarray_getbuf,         /* bf_getbuffer */
+    ndarray_releasebuf,     /* bf_releasebuffer */
 };
 
 
@@ -1585,8 +1586,9 @@ ptr_from_index(Py_buffer *base, Py_ssize_t index)
 }
 
 static PyObject *
-ndarray_item(NDArrayObject *self, Py_ssize_t index)
+ndarray_item(PyObject *op, Py_ssize_t index)
 {
+    NDArrayObject *self = (NDArrayObject *)op;
     ndbuf_t *ndbuf = self->head;
     Py_buffer *base = &ndbuf->base;
     char *ptr;
@@ -1777,8 +1779,9 @@ err_nomem:
 }
 
 static PyObject *
-ndarray_subscript(NDArrayObject *self, PyObject *key)
+ndarray_subscript(PyObject *op, PyObject *key)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     NDArrayObject *nd;
     ndbuf_t *ndbuf;
     Py_buffer *base = &self->head->base;
@@ -1788,8 +1791,7 @@ ndarray_subscript(NDArrayObject *self, PyObject *key)
             return unpack_single(base->buf, base->format, base->itemsize);
         }
         else if (key == Py_Ellipsis) {
-            Py_INCREF(self);
-            return (PyObject *)self;
+            return Py_NewRef(self);
         }
         else {
             PyErr_SetString(PyExc_TypeError, "invalid indexing of scalar");
@@ -1800,7 +1802,7 @@ ndarray_subscript(NDArrayObject *self, PyObject *key)
         Py_ssize_t index = PyLong_AsSsize_t(key);
         if (index == -1 && PyErr_Occurred())
             return NULL;
-        return ndarray_item(self, index);
+        return ndarray_item(op, index);
     }
 
     nd = (NDArrayObject *)ndarray_new(&NDArray_Type, NULL, NULL);
@@ -1862,8 +1864,9 @@ err_occurred:
 
 
 static int
-ndarray_ass_subscript(NDArrayObject *self, PyObject *key, PyObject *value)
+ndarray_ass_subscript(PyObject *op, PyObject *key, PyObject *value)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     NDArrayObject *nd;
     Py_buffer *dest = &self->head->base;
     Py_buffer src;
@@ -1907,7 +1910,7 @@ ndarray_ass_subscript(NDArrayObject *self, PyObject *key, PyObject *value)
     if (PyObject_GetBuffer(value, &src, PyBUF_FULL_RO) == -1)
         return -1;
 
-    nd = (NDArrayObject *)ndarray_subscript(self, key);
+    nd = (NDArrayObject *)ndarray_subscript((PyObject*)self, key);
     if (nd != NULL) {
         dest = &nd->head->base;
         ret = copy_buffer(dest, &src);
@@ -1959,15 +1962,15 @@ error:
 
 static PyMappingMethods ndarray_as_mapping = {
     NULL,                                 /* mp_length */
-    (binaryfunc)ndarray_subscript,        /* mp_subscript */
-    (objobjargproc)ndarray_ass_subscript  /* mp_ass_subscript */
+    ndarray_subscript,                    /* mp_subscript */
+    ndarray_ass_subscript                 /* mp_ass_subscript */
 };
 
 static PySequenceMethods ndarray_as_sequence = {
-        0,                                /* sq_length */
-        0,                                /* sq_concat */
-        0,                                /* sq_repeat */
-        (ssizeargfunc)ndarray_item,       /* sq_item */
+    0,              /* sq_length */
+    0,              /* sq_concat */
+    0,              /* sq_repeat */
+    ndarray_item,   /* sq_item */
 };
 
 
@@ -2001,89 +2004,99 @@ ssize_array_as_tuple(Py_ssize_t *array, Py_ssize_t len)
 }
 
 static PyObject *
-ndarray_get_flags(NDArrayObject *self, void *closure)
+ndarray_get_flags(PyObject *op, void *closure)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     return PyLong_FromLong(self->head->flags);
 }
 
 static PyObject *
-ndarray_get_offset(NDArrayObject *self, void *closure)
+ndarray_get_offset(PyObject *op, void *closure)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     ndbuf_t *ndbuf = self->head;
     return PyLong_FromSsize_t(ndbuf->offset);
 }
 
 static PyObject *
-ndarray_get_obj(NDArrayObject *self, void *closure)
+ndarray_get_obj(PyObject *op, void *closure)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     Py_buffer *base = &self->head->base;
 
     if (base->obj == NULL) {
         Py_RETURN_NONE;
     }
-    Py_INCREF(base->obj);
-    return base->obj;
+    return Py_NewRef(base->obj);
 }
 
 static PyObject *
-ndarray_get_nbytes(NDArrayObject *self, void *closure)
+ndarray_get_nbytes(PyObject *op, void *closure)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     Py_buffer *base = &self->head->base;
     return PyLong_FromSsize_t(base->len);
 }
 
 static PyObject *
-ndarray_get_readonly(NDArrayObject *self, void *closure)
+ndarray_get_readonly(PyObject *op, void *closure)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     Py_buffer *base = &self->head->base;
     return PyBool_FromLong(base->readonly);
 }
 
 static PyObject *
-ndarray_get_itemsize(NDArrayObject *self, void *closure)
+ndarray_get_itemsize(PyObject *op, void *closure)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     Py_buffer *base = &self->head->base;
     return PyLong_FromSsize_t(base->itemsize);
 }
 
 static PyObject *
-ndarray_get_format(NDArrayObject *self, void *closure)
+ndarray_get_format(PyObject *op, void *closure)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     Py_buffer *base = &self->head->base;
     const char *fmt = base->format ? base->format : "";
     return PyUnicode_FromString(fmt);
 }
 
 static PyObject *
-ndarray_get_ndim(NDArrayObject *self, void *closure)
+ndarray_get_ndim(PyObject *op, void *closure)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     Py_buffer *base = &self->head->base;
     return PyLong_FromSsize_t(base->ndim);
 }
 
 static PyObject *
-ndarray_get_shape(NDArrayObject *self, void *closure)
+ndarray_get_shape(PyObject *op, void *closure)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     Py_buffer *base = &self->head->base;
     return ssize_array_as_tuple(base->shape, base->ndim);
 }
 
 static PyObject *
-ndarray_get_strides(NDArrayObject *self, void *closure)
+ndarray_get_strides(PyObject *op, void *closure)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     Py_buffer *base = &self->head->base;
     return ssize_array_as_tuple(base->strides, base->ndim);
 }
 
 static PyObject *
-ndarray_get_suboffsets(NDArrayObject *self, void *closure)
+ndarray_get_suboffsets(PyObject *op, void *closure)
 {
+    NDArrayObject *self = (NDArrayObject*)op;
     Py_buffer *base = &self->head->base;
     return ssize_array_as_tuple(base->suboffsets, base->ndim);
 }
 
 static PyObject *
-ndarray_c_contig(PyObject *self, PyObject *dummy)
+ndarray_c_contig(PyObject *self, void *dummy)
 {
     NDArrayObject *nd = (NDArrayObject *)self;
     int ret = PyBuffer_IsContiguous(&nd->head->base, 'C');
@@ -2097,7 +2110,7 @@ ndarray_c_contig(PyObject *self, PyObject *dummy)
 }
 
 static PyObject *
-ndarray_fortran_contig(PyObject *self, PyObject *dummy)
+ndarray_fortran_contig(PyObject *self, void *dummy)
 {
     NDArrayObject *nd = (NDArrayObject *)self;
     int ret = PyBuffer_IsContiguous(&nd->head->base, 'F');
@@ -2111,7 +2124,7 @@ ndarray_fortran_contig(PyObject *self, PyObject *dummy)
 }
 
 static PyObject *
-ndarray_contig(PyObject *self, PyObject *dummy)
+ndarray_contig(PyObject *self, void *dummy)
 {
     NDArrayObject *nd = (NDArrayObject *)self;
     int ret = PyBuffer_IsContiguous(&nd->head->base, 'A');
@@ -2128,21 +2141,21 @@ ndarray_contig(PyObject *self, PyObject *dummy)
 static PyGetSetDef ndarray_getset [] =
 {
   /* ndbuf */
-  { "flags",        (getter)ndarray_get_flags,      NULL, NULL, NULL},
-  { "offset",       (getter)ndarray_get_offset,     NULL, NULL, NULL},
+  { "flags",        ndarray_get_flags,      NULL, NULL, NULL},
+  { "offset",       ndarray_get_offset,     NULL, NULL, NULL},
   /* ndbuf.base */
-  { "obj",          (getter)ndarray_get_obj,        NULL, NULL, NULL},
-  { "nbytes",       (getter)ndarray_get_nbytes,     NULL, NULL, NULL},
-  { "readonly",     (getter)ndarray_get_readonly,   NULL, NULL, NULL},
-  { "itemsize",     (getter)ndarray_get_itemsize,   NULL, NULL, NULL},
-  { "format",       (getter)ndarray_get_format,     NULL, NULL, NULL},
-  { "ndim",         (getter)ndarray_get_ndim,       NULL, NULL, NULL},
-  { "shape",        (getter)ndarray_get_shape,      NULL, NULL, NULL},
-  { "strides",      (getter)ndarray_get_strides,    NULL, NULL, NULL},
-  { "suboffsets",   (getter)ndarray_get_suboffsets, NULL, NULL, NULL},
-  { "c_contiguous", (getter)ndarray_c_contig,       NULL, NULL, NULL},
-  { "f_contiguous", (getter)ndarray_fortran_contig, NULL, NULL, NULL},
-  { "contiguous",   (getter)ndarray_contig,         NULL, NULL, NULL},
+  { "obj",          ndarray_get_obj,        NULL, NULL, NULL},
+  { "nbytes",       ndarray_get_nbytes,     NULL, NULL, NULL},
+  { "readonly",     ndarray_get_readonly,   NULL, NULL, NULL},
+  { "itemsize",     ndarray_get_itemsize,   NULL, NULL, NULL},
+  { "format",       ndarray_get_format,     NULL, NULL, NULL},
+  { "ndim",         ndarray_get_ndim,       NULL, NULL, NULL},
+  { "shape",        ndarray_get_shape,      NULL, NULL, NULL},
+  { "strides",      ndarray_get_strides,    NULL, NULL, NULL},
+  { "suboffsets",   ndarray_get_suboffsets, NULL, NULL, NULL},
+  { "c_contiguous", ndarray_c_contig,       NULL, NULL, NULL},
+  { "f_contiguous", ndarray_fortran_contig, NULL, NULL, NULL},
+  { "contiguous",   ndarray_contig,         NULL, NULL, NULL},
   {NULL}
 };
 
@@ -2559,8 +2572,7 @@ result:
     PyBuffer_Release(&v2);
 
     ret = equal ? Py_True : Py_False;
-    Py_INCREF(ret);
-    return ret;
+    return Py_NewRef(ret);
 }
 
 static PyObject *
@@ -2597,8 +2609,7 @@ is_contiguous(PyObject *self, PyObject *args)
         PyBuffer_Release(&view);
     }
 
-    Py_INCREF(ret);
-    return ret;
+    return Py_NewRef(ret);
 }
 
 static Py_hash_t
@@ -2629,11 +2640,11 @@ ndarray_hash(PyObject *self)
 }
 
 
-static PyMethodDef ndarray_methods [] =
+static PyMethodDef ndarray_methods[] =
 {
     { "tolist", ndarray_tolist, METH_NOARGS, NULL },
     { "tobytes", ndarray_tobytes, METH_NOARGS, NULL },
-    { "push", (PyCFunction)(void(*)(void))ndarray_push, METH_VARARGS|METH_KEYWORDS, NULL },
+    { "push", _PyCFunction_CAST(ndarray_push), METH_VARARGS|METH_KEYWORDS, NULL },
     { "pop", ndarray_pop, METH_NOARGS, NULL },
     { "add_suboffsets", ndarray_add_suboffsets, METH_NOARGS, NULL },
     { "memoryview_from_buffer", ndarray_memoryview_from_buffer, METH_NOARGS, NULL },
@@ -2645,7 +2656,7 @@ static PyTypeObject NDArray_Type = {
     "ndarray",                   /* Name of this type */
     sizeof(NDArrayObject),       /* Basic object size */
     0,                           /* Item size for varobject */
-    (destructor)ndarray_dealloc, /* tp_dealloc */
+    ndarray_dealloc,             /* tp_dealloc */
     0,                           /* tp_vectorcall_offset */
     0,                           /* tp_getattr */
     0,                           /* tp_setattr */
@@ -2654,7 +2665,7 @@ static PyTypeObject NDArray_Type = {
     0,                           /* tp_as_number */
     &ndarray_as_sequence,        /* tp_as_sequence */
     &ndarray_as_mapping,         /* tp_as_mapping */
-    (hashfunc)ndarray_hash,      /* tp_hash */
+    ndarray_hash,                /* tp_hash */
     0,                           /* tp_call */
     0,                           /* tp_str */
     PyObject_GenericGetAttr,     /* tp_getattro */
@@ -2732,7 +2743,7 @@ staticarray_init(PyObject *self, PyObject *args, PyObject *kwds)
 }
 
 static void
-staticarray_dealloc(StaticArrayObject *self)
+staticarray_dealloc(PyObject *self)
 {
     PyObject_Free(self);
 }
@@ -2740,23 +2751,23 @@ staticarray_dealloc(StaticArrayObject *self)
 /* Return a buffer for a PyBUF_FULL_RO request. Flags are not checked,
    which makes this object a non-compliant exporter! */
 static int
-staticarray_getbuf(StaticArrayObject *self, Py_buffer *view, int flags)
+staticarray_getbuf(PyObject *op, Py_buffer *view, int flags)
 {
+    StaticArrayObject *self = (StaticArrayObject *)op;
     *view = static_buffer;
 
     if (self->legacy_mode) {
         view->obj = NULL; /* Don't use this in new code. */
     }
     else {
-        view->obj = (PyObject *)self;
-        Py_INCREF(view->obj);
+        view->obj = Py_NewRef(self);
     }
 
     return 0;
 }
 
 static PyBufferProcs staticarray_as_buffer = {
-    (getbufferproc)staticarray_getbuf, /* bf_getbuffer */
+    staticarray_getbuf,                /* bf_getbuffer */
     NULL,                              /* bf_releasebuffer */
 };
 
@@ -2765,7 +2776,7 @@ static PyTypeObject StaticArray_Type = {
     "staticarray",                   /* Name of this type */
     sizeof(StaticArrayObject),       /* Basic object size */
     0,                               /* Item size for varobject */
-    (destructor)staticarray_dealloc, /* tp_dealloc */
+    staticarray_dealloc,             /* tp_dealloc */
     0,                               /* tp_vectorcall_offset */
     0,                               /* tp_getattr */
     0,                               /* tp_setattr */
@@ -2825,70 +2836,97 @@ static struct PyModuleDef _testbuffermodule = {
     NULL
 };
 
+static int
+_testbuffer_exec(PyObject *mod)
+{
+    Py_SET_TYPE(&NDArray_Type, &PyType_Type);
+    if (PyType_Ready(&NDArray_Type)) {
+        return -1;
+    }
+    if (PyModule_AddType(mod, &NDArray_Type) < 0) {
+        return -1;
+    }
+
+    Py_SET_TYPE(&StaticArray_Type, &PyType_Type);
+    if (PyModule_AddType(mod, &StaticArray_Type) < 0) {
+        return -1;
+    }
+
+    structmodule = PyImport_ImportModule("struct");
+    if (structmodule == NULL) {
+        return -1;
+    }
+
+    Struct = PyObject_GetAttrString(structmodule, "Struct");
+    if (Struct == NULL) {
+        return -1;
+    }
+    calcsize = PyObject_GetAttrString(structmodule, "calcsize");
+    if (calcsize == NULL) {
+        return -1;
+    }
+
+    simple_format = PyUnicode_FromString(simple_fmt);
+    if (simple_format == NULL) {
+        return -1;
+    }
+
+#define ADD_INT_MACRO(mod, macro)                                             \
+    do {                                                                    \
+        if (PyModule_AddIntConstant(mod, #macro, macro) < 0) {                \
+            return -1;                                                      \
+        }                                                                   \
+    } while (0)
+
+    ADD_INT_MACRO(mod, ND_MAX_NDIM);
+    ADD_INT_MACRO(mod, ND_VAREXPORT);
+    ADD_INT_MACRO(mod, ND_WRITABLE);
+    ADD_INT_MACRO(mod, ND_FORTRAN);
+    ADD_INT_MACRO(mod, ND_SCALAR);
+    ADD_INT_MACRO(mod, ND_PIL);
+    ADD_INT_MACRO(mod, ND_GETBUF_FAIL);
+    ADD_INT_MACRO(mod, ND_GETBUF_UNDEFINED);
+    ADD_INT_MACRO(mod, ND_REDIRECT);
+
+    ADD_INT_MACRO(mod, PyBUF_SIMPLE);
+    ADD_INT_MACRO(mod, PyBUF_WRITABLE);
+    ADD_INT_MACRO(mod, PyBUF_FORMAT);
+    ADD_INT_MACRO(mod, PyBUF_ND);
+    ADD_INT_MACRO(mod, PyBUF_STRIDES);
+    ADD_INT_MACRO(mod, PyBUF_INDIRECT);
+    ADD_INT_MACRO(mod, PyBUF_C_CONTIGUOUS);
+    ADD_INT_MACRO(mod, PyBUF_F_CONTIGUOUS);
+    ADD_INT_MACRO(mod, PyBUF_ANY_CONTIGUOUS);
+    ADD_INT_MACRO(mod, PyBUF_FULL);
+    ADD_INT_MACRO(mod, PyBUF_FULL_RO);
+    ADD_INT_MACRO(mod, PyBUF_RECORDS);
+    ADD_INT_MACRO(mod, PyBUF_RECORDS_RO);
+    ADD_INT_MACRO(mod, PyBUF_STRIDED);
+    ADD_INT_MACRO(mod, PyBUF_STRIDED_RO);
+    ADD_INT_MACRO(mod, PyBUF_CONTIG);
+    ADD_INT_MACRO(mod, PyBUF_CONTIG_RO);
+
+    ADD_INT_MACRO(mod, PyBUF_READ);
+    ADD_INT_MACRO(mod, PyBUF_WRITE);
+
+#undef ADD_INT_MACRO
+
+    return 0;
+}
 
 PyMODINIT_FUNC
 PyInit__testbuffer(void)
 {
-    PyObject *m;
-
-    m = PyModule_Create(&_testbuffermodule);
-    if (m == NULL)
+    PyObject *mod = PyModule_Create(&_testbuffermodule);
+    if (mod == NULL) {
         return NULL;
-
-    Py_SET_TYPE(&NDArray_Type, &PyType_Type);
-    Py_INCREF(&NDArray_Type);
-    PyModule_AddObject(m, "ndarray", (PyObject *)&NDArray_Type);
-
-    Py_SET_TYPE(&StaticArray_Type, &PyType_Type);
-    Py_INCREF(&StaticArray_Type);
-    PyModule_AddObject(m, "staticarray", (PyObject *)&StaticArray_Type);
-
-    structmodule = PyImport_ImportModule("struct");
-    if (structmodule == NULL)
+    }
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+#endif
+    if (_testbuffer_exec(mod) < 0) {
+        Py_DECREF(mod);
         return NULL;
-
-    Struct = PyObject_GetAttrString(structmodule, "Struct");
-    calcsize = PyObject_GetAttrString(structmodule, "calcsize");
-    if (Struct == NULL || calcsize == NULL)
-        return NULL;
-
-    simple_format = PyUnicode_FromString(simple_fmt);
-    if (simple_format == NULL)
-        return NULL;
-
-    PyModule_AddIntMacro(m, ND_MAX_NDIM);
-    PyModule_AddIntMacro(m, ND_VAREXPORT);
-    PyModule_AddIntMacro(m, ND_WRITABLE);
-    PyModule_AddIntMacro(m, ND_FORTRAN);
-    PyModule_AddIntMacro(m, ND_SCALAR);
-    PyModule_AddIntMacro(m, ND_PIL);
-    PyModule_AddIntMacro(m, ND_GETBUF_FAIL);
-    PyModule_AddIntMacro(m, ND_GETBUF_UNDEFINED);
-    PyModule_AddIntMacro(m, ND_REDIRECT);
-
-    PyModule_AddIntMacro(m, PyBUF_SIMPLE);
-    PyModule_AddIntMacro(m, PyBUF_WRITABLE);
-    PyModule_AddIntMacro(m, PyBUF_FORMAT);
-    PyModule_AddIntMacro(m, PyBUF_ND);
-    PyModule_AddIntMacro(m, PyBUF_STRIDES);
-    PyModule_AddIntMacro(m, PyBUF_INDIRECT);
-    PyModule_AddIntMacro(m, PyBUF_C_CONTIGUOUS);
-    PyModule_AddIntMacro(m, PyBUF_F_CONTIGUOUS);
-    PyModule_AddIntMacro(m, PyBUF_ANY_CONTIGUOUS);
-    PyModule_AddIntMacro(m, PyBUF_FULL);
-    PyModule_AddIntMacro(m, PyBUF_FULL_RO);
-    PyModule_AddIntMacro(m, PyBUF_RECORDS);
-    PyModule_AddIntMacro(m, PyBUF_RECORDS_RO);
-    PyModule_AddIntMacro(m, PyBUF_STRIDED);
-    PyModule_AddIntMacro(m, PyBUF_STRIDED_RO);
-    PyModule_AddIntMacro(m, PyBUF_CONTIG);
-    PyModule_AddIntMacro(m, PyBUF_CONTIG_RO);
-
-    PyModule_AddIntMacro(m, PyBUF_READ);
-    PyModule_AddIntMacro(m, PyBUF_WRITE);
-
-    return m;
+    }
+    return mod;
 }
-
-
-

--- a/lib_pypy/_testmultiphase.c
+++ b/lib_pypy/_testmultiphase.c
@@ -6,9 +6,8 @@
 #endif
 
 #include "Python.h"
-#ifndef PYPY_VERSION
+#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 #include "pycore_namespace.h"     // _PyNamespace_New()
-#endif
 
 /* State for testing module state access from methods */
 
@@ -29,6 +28,8 @@ typedef struct {
     PyObject            *x_attr;        /* Attributes dictionary */
 } ExampleObject;
 
+#define ExampleObject_CAST(op)  ((ExampleObject *)(op))
+
 typedef struct {
     PyObject *integer;
 } testmultiphase_state;
@@ -40,49 +41,48 @@ typedef struct {
 /* Example methods */
 
 static int
-Example_traverse(ExampleObject *self, visitproc visit, void *arg)
+Example_traverse(PyObject *op, visitproc visit, void *arg)
 {
+    ExampleObject *self = ExampleObject_CAST(op);
     Py_VISIT(self->x_attr);
     return 0;
 }
 
-#ifndef PYPY_VERSION    
 static void
-Example_finalize(ExampleObject *self)
+Example_finalize(PyObject *op)
 {
+    ExampleObject *self = ExampleObject_CAST(op);
     Py_CLEAR(self->x_attr);
 }
-#endif
 
 static PyObject *
-Example_demo(ExampleObject *self, PyObject *args)
+Example_demo(PyObject *op, PyObject *args)
 {
     PyObject *o = NULL;
     if (!PyArg_ParseTuple(args, "|O:demo", &o))
         return NULL;
     if (o != NULL && PyUnicode_Check(o)) {
-        Py_INCREF(o);
-        return o;
+        return Py_NewRef(o);
     }
     Py_RETURN_NONE;
 }
 
-#include "_testmultiphase.c.h"
+#include "clinic/_testmultiphase.c.h"
 
 static PyMethodDef Example_methods[] = {
-    {"demo",            (PyCFunction)Example_demo,  METH_VARARGS,
+    {"demo",            Example_demo,  METH_VARARGS,
         PyDoc_STR("demo() -> None")},
     {NULL,              NULL}           /* sentinel */
 };
 
 static PyObject *
-Example_getattro(ExampleObject *self, PyObject *name)
+Example_getattro(PyObject *op, PyObject *name)
 {
+    ExampleObject *self = ExampleObject_CAST(op);
     if (self->x_attr != NULL) {
         PyObject *v = PyDict_GetItemWithError(self->x_attr, name);
         if (v != NULL) {
-            Py_INCREF(v);
-            return v;
+            return Py_NewRef(v);
         }
         else if (PyErr_Occurred()) {
             return NULL;
@@ -92,8 +92,9 @@ Example_getattro(ExampleObject *self, PyObject *name)
 }
 
 static int
-Example_setattr(ExampleObject *self, const char *name, PyObject *v)
+Example_setattr(PyObject *op, char *name, PyObject *v)
 {
+    ExampleObject *self = ExampleObject_CAST(op);
     if (self->x_attr == NULL) {
         self->x_attr = PyDict_New();
         if (self->x_attr == NULL)
@@ -112,9 +113,7 @@ Example_setattr(ExampleObject *self, const char *name, PyObject *v)
 
 static PyType_Slot Example_Type_slots[] = {
     {Py_tp_doc, "The Example type"},
-#ifndef PYPY_VERSION    
     {Py_tp_finalize, Example_finalize},
-#endif
     {Py_tp_traverse, Example_traverse},
     {Py_tp_getattro, Example_getattro},
     {Py_tp_setattr, Example_setattr},
@@ -142,14 +141,14 @@ _testmultiphase.StateAccessType.get_defining_module
 
 Return the module of the defining class.
 
-Also tests that result of PyType_GetModuleByDef matches defining_class's
-module.
+Also tests that result of PyType_GetModuleByDef matches
+defining_class's module.
 [clinic start generated code]*/
 
 static PyObject *
 _testmultiphase_StateAccessType_get_defining_module_impl(StateAccessTypeObject *self,
                                                          PyTypeObject *cls)
-/*[clinic end generated code: output=ba2a14284a5d0921 input=d2c7245c8a9d06f8]*/
+/*[clinic end generated code: output=ba2a14284a5d0921 input=903e7f66555d65ae]*/
 {
     PyObject *retval;
     retval = PyType_GetModule(cls);
@@ -157,8 +156,7 @@ _testmultiphase_StateAccessType_get_defining_module_impl(StateAccessTypeObject *
         return NULL;
     }
     assert(PyType_GetModuleByDef(Py_TYPE(self), &def_meth_state_access) == retval);
-    Py_INCREF(retval);
-    return retval;
+    return Py_NewRef(retval);
 }
 
 /*[clinic input]
@@ -220,7 +218,7 @@ PyDoc_STRVAR(_StateAccessType_decrement_count__doc__,
 
 // Intentionally does not use Argument Clinic
 static PyObject *
-_StateAccessType_increment_count_noclinic(StateAccessTypeObject *self,
+_StateAccessType_increment_count_noclinic(PyObject *self,
                                           PyTypeObject *defining_class,
                                           PyObject *const *args,
                                           Py_ssize_t nargs,
@@ -392,32 +390,20 @@ static int execfunc(PyObject *m)
 
     /* Add a custom type */
     temp = PyType_FromSpec(&Example_Type_spec);
-    if (temp == NULL) {
-        goto fail;
-    }
-    if (PyModule_AddObject(m, "Example", temp) != 0) {
-        Py_DECREF(temp);
+    if (PyModule_Add(m, "Example", temp) != 0) {
         goto fail;
     }
 
 
     /* Add an exception type */
     temp = PyErr_NewException("_testimportexec.error", NULL, NULL);
-    if (temp == NULL) {
-        goto fail;
-    }
-    if (PyModule_AddObject(m, "error", temp) != 0) {
-        Py_DECREF(temp);
+    if (PyModule_Add(m, "error", temp) != 0) {
         goto fail;
     }
 
     /* Add Str */
     temp = PyType_FromSpec(&Str_Type_spec);
-    if (temp == NULL) {
-        goto fail;
-    }
-    if (PyModule_AddObject(m, "Str", temp) != 0) {
-        Py_DECREF(temp);
+    if (PyModule_Add(m, "Str", temp) != 0) {
         goto fail;
     }
 
@@ -450,6 +436,8 @@ static int execfunc(PyObject *m)
 
 static PyModuleDef_Slot main_slots[] = {
     {Py_mod_exec, execfunc},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
     {0, NULL},
 };
 
@@ -538,13 +526,18 @@ PyInit__testmultiphase_nonmodule_with_methods(void)
 
 /**** Non-ASCII-named modules ****/
 
+static PyModuleDef_Slot nonascii_slots[] = {
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+    {0, NULL},
+};
+
 static PyModuleDef def_nonascii_latin = { \
     PyModuleDef_HEAD_INIT,                      /* m_base */
     "_testmultiphase_nonascii_latin",           /* m_name */
     PyDoc_STR("Module named in Czech"),         /* m_doc */
     0,                                          /* m_size */
     NULL,                                       /* m_methods */
-    NULL,                                       /* m_slots */
+    nonascii_slots,                             /* m_slots */
     NULL,                                       /* m_traverse */
     NULL,                                       /* m_clear */
     NULL,                                       /* m_free */
@@ -562,7 +555,7 @@ static PyModuleDef def_nonascii_kana = { \
     PyDoc_STR("Module named in Japanese"),      /* m_doc */
     0,                                          /* m_size */
     NULL,                                       /* m_methods */
-    NULL,                                       /* m_slots */
+    nonascii_slots,                             /* m_slots */
     NULL,                                       /* m_traverse */
     NULL,                                       /* m_clear */
     NULL,                                       /* m_free */
@@ -690,6 +683,27 @@ PyInit__testmultiphase_export_unreported_exception(void)
 }
 
 static PyObject*
+createfunc_noop(PyObject *spec, PyModuleDef *def)
+{
+    return PyModule_New("spam");
+}
+
+static PyModuleDef_Slot slots_multiple_create_slots[] = {
+    {Py_mod_create, createfunc_noop},
+    {Py_mod_create, createfunc_noop},
+    {0, NULL},
+};
+
+static PyModuleDef def_multiple_create_slots = TEST_MODULE_DEF(
+    "_testmultiphase_multiple_create_slots", slots_multiple_create_slots, NULL);
+
+PyMODINIT_FUNC
+PyInit__testmultiphase_multiple_create_slots(void)
+{
+    return PyModuleDef_Init(&def_multiple_create_slots);
+}
+
+static PyObject*
 createfunc_null(PyObject *spec, PyModuleDef *def)
 {
     return NULL;
@@ -754,6 +768,8 @@ PyInit__testmultiphase_create_unreported_exception(void)
 static PyModuleDef_Slot slots_nonmodule_with_exec_slots[] = {
     {Py_mod_create, createfunc_nonmodule},
     {Py_mod_exec, execfunc},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
     {0, NULL},
 };
 
@@ -774,6 +790,8 @@ execfunc_err(PyObject *mod)
 
 static PyModuleDef_Slot slots_exec_err[] = {
     {Py_mod_exec, execfunc_err},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
     {0, NULL},
 };
 
@@ -795,6 +813,8 @@ execfunc_raise(PyObject *spec)
 
 static PyModuleDef_Slot slots_exec_raise[] = {
     {Py_mod_exec, execfunc_raise},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
     {0, NULL},
 };
 
@@ -816,6 +836,8 @@ execfunc_unreported_exception(PyObject *mod)
 
 static PyModuleDef_Slot slots_exec_unreported_exception[] = {
     {Py_mod_exec, execfunc_unreported_exception},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
     {0, NULL},
 };
 
@@ -840,11 +862,7 @@ meth_state_access_exec(PyObject *m)
     }
 
     temp = PyType_FromModuleAndSpec(m, &StateAccessType_spec, NULL);
-    if (temp == NULL) {
-        return -1;
-    }
-    if (PyModule_AddObject(m, "StateAccessType", temp) != 0) {
-        Py_DECREF(temp);
+    if (PyModule_Add(m, "StateAccessType", temp) != 0) {
         return -1;
     }
 
@@ -854,6 +872,8 @@ meth_state_access_exec(PyObject *m)
 
 static PyModuleDef_Slot meth_state_access_slots[] = {
     {Py_mod_exec, meth_state_access_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
     {0, NULL}
 };
 
@@ -886,6 +906,9 @@ PyInit__test_module_state_shared(void)
     if (module == NULL) {
         return NULL;
     }
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
 
     if (PyModule_AddObjectRef(module, "Error", PyExc_Exception) < 0) {
         Py_DECREF(module);
@@ -895,13 +918,78 @@ PyInit__test_module_state_shared(void)
 }
 
 
-/*** Helper for imp test ***/
+/* multiple interpreters support */
 
-static PyModuleDef imp_dummy_def = TEST_MODULE_DEF("imp_dummy", main_slots, testexport_methods);
+static PyModuleDef_Slot slots_multiple_multiple_interpreters_slots[] = {
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+    {0, NULL},
+};
+
+static PyModuleDef def_multiple_multiple_interpreters_slots = TEST_MODULE_DEF(
+    "_testmultiphase_multiple_multiple_interpreters_slots",
+    slots_multiple_multiple_interpreters_slots,
+    NULL);
 
 PyMODINIT_FUNC
-PyInit_imp_dummy(void)
+PyInit__testmultiphase_multiple_multiple_interpreters_slots(void)
 {
-    return PyModuleDef_Init(&imp_dummy_def);
+    return PyModuleDef_Init(&def_multiple_multiple_interpreters_slots);
 }
 
+static PyModuleDef_Slot non_isolated_slots[] = {
+    {Py_mod_exec, execfunc},
+    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+    {0, NULL},
+};
+
+static PyModuleDef non_isolated_def = TEST_MODULE_DEF("_test_non_isolated",
+                                                      non_isolated_slots,
+                                                      testexport_methods);
+
+PyMODINIT_FUNC
+PyInit__test_non_isolated(void)
+{
+    return PyModuleDef_Init(&non_isolated_def);
+}
+
+
+static PyModuleDef_Slot shared_gil_only_slots[] = {
+    {Py_mod_exec, execfunc},
+    /* Note that Py_MOD_MULTIPLE_INTERPRETERS_SUPPORTED is the default.
+       We put it here explicitly to draw attention to the contrast
+       with Py_MOD_PER_INTERPRETER_GIL_SUPPORTED. */
+    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_SUPPORTED},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+    {0, NULL},
+};
+
+static PyModuleDef shared_gil_only_def = TEST_MODULE_DEF("_test_shared_gil_only",
+                                                         shared_gil_only_slots,
+                                                         testexport_methods);
+
+PyMODINIT_FUNC
+PyInit__test_shared_gil_only(void)
+{
+    return PyModuleDef_Init(&shared_gil_only_def);
+}
+
+
+static PyModuleDef_Slot no_multiple_interpreter_slot_slots[] = {
+    {Py_mod_exec, execfunc},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+    {0, NULL},
+};
+
+static PyModuleDef no_multiple_interpreter_slot_def = TEST_MODULE_DEF(
+    "_test_no_multiple_interpreter_slot",
+    no_multiple_interpreter_slot_slots,
+    testexport_methods);
+
+PyMODINIT_FUNC
+PyInit__test_no_multiple_interpreter_slot(void)
+{
+    return PyModuleDef_Init(&no_multiple_interpreter_slot_def);
+}

--- a/lib_pypy/_testsinglephase.c
+++ b/lib_pypy/_testsinglephase.c
@@ -1,0 +1,809 @@
+
+/* Testing module for single-phase initialization of extension modules
+
+This file contains several distinct modules, meaning each as its own name
+and its own init function (PyInit_...).  The default import system will
+only find the one matching the filename: _testsinglephase.  To load the
+others you must do so manually.  For example:
+
+```python
+name = '_testsinglephase_base_wrapper'
+filename = _testsinglephase.__file__
+loader = importlib.machinery.ExtensionFileLoader(name, filename)
+spec = importlib.util.spec_from_file_location(name, filename, loader=loader)
+mod = importlib._bootstrap._load(spec)
+loader.exec_module(module)
+sys.modules[modname] = module
+```
+
+(The last two lines are just for completeness.)
+
+Here are the modules:
+
+* _testsinglephase
+   * def: _testsinglephase_basic,
+      * m_name: "_testsinglephase"
+      * m_size: -1
+   * state
+      * process-global
+         * <int> initialized_count  (default to -1; will never be 0)
+         * <module_state> module  (see module state below)
+      * module state: no
+      * initial __dict__: see common initial __dict__ below
+   * init function
+      1. create module
+      2. clear <global>.module
+      3. initialize <global>.module: see module state below
+      4. initialize module: set initial __dict__
+      5. increment <global>.initialized_count
+   * functions
+      * (3 common, see below)
+      * initialized_count() - return <global>.module.initialized_count
+   * import system
+      * caches
+         * global extensions cache: yes
+         * def.m_base.m_copy: yes
+         * def.m_base.m_init: no
+         * per-interpreter cache: yes  (all single-phase init modules)
+      * load in main interpreter
+         * initial  (not already in global cache)
+            1. get init function from shared object file
+            2. run init function
+            3. copy __dict__ into def.m_base.m_copy
+            4. set entry in global cache
+            5. set entry in per-interpreter cache
+            6. set entry in sys.modules
+         * reload  (already in sys.modules)
+            1. get def from global cache
+            2. get module from sys.modules
+            3. update module with contents of def.m_base.m_copy
+         * already loaded in other interpreter  (already in global cache)
+            * same as reload, but create new module and update *it*
+         * not in any sys.modules, still in global cache
+            * same as already loaded
+      * load in legacy (non-isolated) interpreter
+         * same as main interpreter
+      * unload: never  (all single-phase init modules)
+* _testsinglephase_basic_wrapper
+   * identical to _testsinglephase except module name
+* _testsinglephase_basic_copy
+   * def: static local variable in init function
+      * m_name: "_testsinglephase_basic_copy"
+      * m_size: -1
+   * state: same as _testsinglephase
+   * init function: same as _testsinglephase
+   * functions: same as _testsinglephase
+   * import system: same as _testsinglephase
+* _testsinglephase_with_reinit
+   * def: _testsinglephase_with_reinit,
+      * m_name: "_testsinglephase_with_reinit"
+      * m_size: 0
+   * state
+      * process-global state: no
+      * module state: no
+      * initial __dict__: see common initial __dict__ below
+   * init function
+      1. create module
+      2. initialize temporary module state (local var): see module state below
+      3. initialize module: set initial __dict__
+   * functions: see common functions below
+   * import system
+      * caches
+         * global extensions cache: only if loaded in main interpreter
+         * def.m_base.m_copy: no
+         * def.m_base.m_init: only if loaded in the main interpreter
+         * per-interpreter cache: yes  (all single-phase init modules)
+      * load in main interpreter
+         * initial  (not already in global cache)
+            * (same as _testsinglephase except step 3)
+            1. get init function from shared object file
+            2. run init function
+            3. set def.m_base.m_init to the init function
+            4. set entry in global cache
+            5. set entry in per-interpreter cache
+            6. set entry in sys.modules
+         * reload  (already in sys.modules)
+            1. get def from global cache
+            2. call def->m_base.m_init to get a new module object
+            3. replace the existing module in sys.modules
+         * already loaded in other interpreter  (already in global cache)
+            * same as reload (since will only be in cache for main interp)
+         * not in any sys.modules, still in global cache
+            * same as already loaded
+      * load in legacy (non-isolated) interpreter
+         * initial  (not already in global cache)
+            * (same as main interpreter except skip steps 3 & 4 there)
+            1. get init function from shared object file
+            2. run init function
+            ...
+            5. set entry in per-interpreter cache
+            6. set entry in sys.modules
+         * reload  (already in sys.modules)
+            * same as initial  (load from scratch)
+         * already loaded in other interpreter  (already in global cache)
+            * same as initial  (load from scratch)
+         * not in any sys.modules, still in global cache
+            * same as initial  (load from scratch)
+      * unload: never  (all single-phase init modules)
+* _testsinglephase_with_state
+   * def: _testsinglephase_with_state,
+      * m_name: "_testsinglephase_with_state"
+      * m_size: sizeof(module_state)
+   * state
+      * process-global: no
+      * module state: see module state below
+      * initial __dict__: see common initial __dict__ below
+   * init function
+      1. create module
+      3. initialize module state: see module state below
+      4. initialize module: set initial __dict__
+      5. increment <global>.initialized_count
+   * functions: see common functions below
+   * import system: same as _testsinglephase_basic_copy
+* _testsinglephase_check_cache_first
+   * def: _testsinglepahse_check_cache_first
+      * m_name: "_testsinglephase_check_cache_first"
+      * m_size: -1
+   * state: none
+   * init function:
+      * tries PyState_FindModule() first
+      * otherwise creates empty module
+   * functions: none
+   * import system: same as _testsinglephase
+* _testsinglephase_with_reinit_check_cache_first
+   * def: _testsinglepahse_with_reinit_check_cache_first
+      * m_name: "_testsinglephase_with_reinit_check_cache_first"
+      * m_size: 0
+   * state: none
+   * init function: same as _testsinglephase_check_cache_first
+   * functions: none
+   * import system: same as _testsinglephase_with_reinit
+* _testsinglephase_with_state_check_cache_first
+   * def: _testsinglepahse_with_state_check_cache_first
+      * m_name: "_testsinglephase_with_state_check_cache_first"
+      * m_size: 42
+   * state: none
+   * init function: same as _testsinglephase_check_cache_first
+   * functions: none
+   * import system: same as _testsinglephase_with_state
+
+* _testsinglephase_circular
+   Regression test for gh-123880.
+   Does not have the common attributes & methods.
+   See test_singlephase_circular test.test_import.SinglephaseInitTests.
+
+Module state:
+
+* fields
+   * <PyTime_t> initialized - when the module was first initialized
+   * <PyObject> *error
+   * <PyObject> *int_const
+   * <PyObject> *str_const
+* initialization
+   1. set state.initialized to the current time
+   2. set state.error to a new exception class
+   3. set state->int_const to int(1969)
+   4. set state->str_const to "something different"
+
+Common initial __dict__:
+
+* error: state.error
+* int_const: state.int_const
+* str_const: state.str_const
+* _module_initialized: state.initialized
+
+Common functions:
+
+* look_up_self() - return the module from the per-interpreter "by-index" cache
+* sum() - return a + b
+* state_initialized() - return state->initialized (or None if m_size == 0)
+
+See Python/import.c, especially the long comments, for more about
+single-phase init modules.
+*/
+
+#ifndef Py_BUILD_CORE_BUILTIN
+#  define Py_BUILD_CORE_MODULE 1
+#endif
+
+//#include <time.h>
+#include "Python.h"
+#include "pycore_namespace.h"     // _PyNamespace_New()
+
+
+typedef struct {
+    PyTime_t initialized;
+    PyObject *error;
+    PyObject *int_const;
+    PyObject *str_const;
+} module_state;
+
+
+/* Process-global state is only used by _testsinglephase
+   since it's the only one that does not support re-init. */
+static struct {
+    int initialized_count;
+    module_state module;
+} global_state = {
+
+#define NOT_INITIALIZED -1
+    .initialized_count = NOT_INITIALIZED,
+};
+
+static void clear_state(module_state *state);
+
+static void
+clear_global_state(void)
+{
+    clear_state(&global_state.module);
+    global_state.initialized_count = NOT_INITIALIZED;
+}
+
+
+static inline module_state *
+get_module_state(PyObject *module)
+{
+    PyModuleDef *def = PyModule_GetDef(module);
+    if (def->m_size == -1) {
+        return &global_state.module;
+    }
+    else if (def->m_size == 0) {
+        return NULL;
+    }
+    else {
+        module_state *state = (module_state*)PyModule_GetState(module);
+        assert(state != NULL);
+        return state;
+    }
+}
+
+static void
+clear_state(module_state *state)
+{
+    state->initialized = 0;
+    Py_CLEAR(state->error);
+    Py_CLEAR(state->int_const);
+    Py_CLEAR(state->str_const);
+}
+
+static int
+_set_initialized(PyTime_t *initialized)
+{
+    /* We go strictly monotonic to ensure each time is unique. */
+    PyTime_t prev;
+    if (PyTime_Monotonic(&prev) != 0) {
+        return -1;
+    }
+    /* We do a busy sleep since the interval should be super short. */
+    PyTime_t t;
+    do {
+        if (PyTime_Monotonic(&t) != 0) {
+            return -1;
+        }
+    } while (t == prev);
+
+    *initialized = t;
+    return 0;
+}
+
+static int
+init_state(module_state *state)
+{
+    assert(state->initialized == 0 &&
+           state->error == NULL &&
+           state->int_const == NULL &&
+           state->str_const == NULL);
+
+    if (_set_initialized(&state->initialized) != 0) {
+        goto error;
+    }
+    assert(state->initialized > 0);
+
+    /* Add an exception type */
+    state->error = PyErr_NewException("_testsinglephase.error", NULL, NULL);
+    if (state->error == NULL) {
+        goto error;
+    }
+
+    state->int_const = PyLong_FromLong(1969);
+    if (state->int_const == NULL) {
+        goto error;
+    }
+
+    state->str_const = PyUnicode_FromString("something different");
+    if (state->str_const == NULL) {
+        goto error;
+    }
+
+    return 0;
+
+error:
+    clear_state(state);
+    return -1;
+}
+
+
+static int
+init_module(PyObject *module, module_state *state)
+{
+    if (PyModule_AddObjectRef(module, "error", state->error) != 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(module, "int_const", state->int_const) != 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(module, "str_const", state->str_const) != 0) {
+        return -1;
+    }
+
+    double d = PyTime_AsSecondsDouble(state->initialized);
+    if (PyModule_Add(module, "_module_initialized", PyFloat_FromDouble(d)) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+
+PyDoc_STRVAR(common_state_initialized_doc,
+"state_initialized()\n\
+\n\
+Return the seconds-since-epoch when the module state was initialized.");
+
+static PyObject *
+common_state_initialized(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    module_state *state = get_module_state(self);
+    if (state == NULL) {
+        Py_RETURN_NONE;
+    }
+    double d = PyTime_AsSecondsDouble(state->initialized);
+    return PyFloat_FromDouble(d);
+}
+
+#define STATE_INITIALIZED_METHODDEF \
+    {"state_initialized", common_state_initialized, METH_NOARGS, \
+     common_state_initialized_doc}
+
+
+PyDoc_STRVAR(common_look_up_self_doc,
+"look_up_self()\n\
+\n\
+Return the module associated with this module's def.m_base.m_index.");
+
+static PyObject *
+common_look_up_self(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    PyModuleDef *def = PyModule_GetDef(self);
+    if (def == NULL) {
+        return NULL;
+    }
+    return Py_NewRef(
+            PyState_FindModule(def));
+}
+
+#define LOOK_UP_SELF_METHODDEF \
+    {"look_up_self", common_look_up_self, METH_NOARGS, common_look_up_self_doc}
+
+
+/* Function of two integers returning integer */
+
+PyDoc_STRVAR(common_sum_doc,
+"sum(i,j)\n\
+\n\
+Return the sum of i and j.");
+
+static PyObject *
+common_sum(PyObject *self, PyObject *args)
+{
+    long i, j;
+    long res;
+    if (!PyArg_ParseTuple(args, "ll:sum", &i, &j))
+        return NULL;
+    res = i + j;
+    return PyLong_FromLong(res);
+}
+
+#define SUM_METHODDEF \
+    {"sum", common_sum, METH_VARARGS, common_sum_doc}
+
+
+PyDoc_STRVAR(basic_initialized_count_doc,
+"initialized_count()\n\
+\n\
+Return how many times the module has been initialized.");
+
+static PyObject *
+basic_initialized_count(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    assert(PyModule_GetDef(self)->m_size == -1);
+    return PyLong_FromLong(global_state.initialized_count);
+}
+
+#define INITIALIZED_COUNT_METHODDEF \
+    {"initialized_count", basic_initialized_count, METH_NOARGS, \
+     basic_initialized_count_doc}
+
+
+PyDoc_STRVAR(basic__clear_globals_doc,
+"_clear_globals()\n\
+\n\
+Free all global state and set it to uninitialized.");
+
+static PyObject *
+basic__clear_globals(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    assert(PyModule_GetDef(self)->m_size == -1);
+    clear_global_state();
+    Py_RETURN_NONE;
+}
+
+#define _CLEAR_GLOBALS_METHODDEF \
+    {"_clear_globals", basic__clear_globals, METH_NOARGS, \
+     basic__clear_globals_doc}
+
+
+PyDoc_STRVAR(basic__clear_module_state_doc, "_clear_module_state()\n\
+\n\
+Free the module state and set it to uninitialized.");
+
+static PyObject *
+basic__clear_module_state(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    module_state *state = get_module_state(self);
+    if (state != NULL) {
+        clear_state(state);
+    }
+    Py_RETURN_NONE;
+}
+
+#define _CLEAR_MODULE_STATE_METHODDEF \
+    {"_clear_module_state", basic__clear_module_state, METH_NOARGS, \
+     basic__clear_module_state_doc}
+
+
+/*********************************************/
+/* the _testsinglephase module (and aliases) */
+/*********************************************/
+
+/* This ia more typical of legacy extensions in the wild:
+   - single-phase init
+   - no module state
+   - does not support repeated initialization
+    (so m_copy is used)
+   - the module def is cached in _PyRuntime.extensions
+     (by name/filename)
+
+   Also note that, because the module has single-phase init,
+   it is cached in interp->module_by_index (using mod->md_def->m_base.m_index).
+ */
+
+static PyMethodDef TestMethods_Basic[] = {
+    LOOK_UP_SELF_METHODDEF,
+    SUM_METHODDEF,
+    STATE_INITIALIZED_METHODDEF,
+    INITIALIZED_COUNT_METHODDEF,
+    _CLEAR_GLOBALS_METHODDEF,
+    {NULL, NULL}           /* sentinel */
+};
+
+static struct PyModuleDef _testsinglephase_basic = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = "_testsinglephase",
+    .m_doc = PyDoc_STR("Test module _testsinglephase"),
+    .m_size = -1,  // no module state
+    .m_methods = TestMethods_Basic,
+};
+
+static PyObject *
+init__testsinglephase_basic(PyModuleDef *def)
+{
+    if (global_state.initialized_count == -1) {
+        global_state.initialized_count = 0;
+    }
+
+    PyObject *module = PyModule_Create(def);
+    if (module == NULL) {
+        return NULL;
+    }
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+
+    module_state *state = &global_state.module;
+    // It may have been set by a previous run or under a different name.
+    clear_state(state);
+    if (init_state(state) < 0) {
+        Py_CLEAR(module);
+        return NULL;
+    }
+
+    if (init_module(module, state) < 0) {
+        Py_CLEAR(module);
+        goto finally;
+    }
+
+    global_state.initialized_count++;
+
+finally:
+    return module;
+}
+
+PyMODINIT_FUNC
+PyInit__testsinglephase(void)
+{
+    return init__testsinglephase_basic(&_testsinglephase_basic);
+}
+
+
+PyMODINIT_FUNC
+PyInit__testsinglephase_basic_wrapper(void)
+{
+    return PyInit__testsinglephase();
+}
+
+
+PyMODINIT_FUNC
+PyInit__testsinglephase_basic_copy(void)
+{
+    static struct PyModuleDef def = {
+        PyModuleDef_HEAD_INIT,
+        .m_name = "_testsinglephase_basic_copy",
+        .m_doc = PyDoc_STR("Test module _testsinglephase_basic_copy"),
+        .m_size = -1,  // no module state
+        .m_methods = TestMethods_Basic,
+    };
+    return init__testsinglephase_basic(&def);
+}
+
+
+/*******************************************/
+/* the _testsinglephase_with_reinit module */
+/*******************************************/
+
+/* This ia less typical of legacy extensions in the wild:
+   - single-phase init  (same as _testsinglephase above)
+   - no module state
+   - supports repeated initialization
+     (so m_copy is not used)
+   - the module def is not cached in _PyRuntime.extensions
+
+   At this point most modules would reach for multi-phase init (PEP 489).
+   However, module state has been around a while (PEP 3121),
+   and most extensions predate multi-phase init.
+
+   (This module is basically the same as _testsinglephase,
+    but supports repeated initialization.)
+ */
+
+static PyMethodDef TestMethods_Reinit[] = {
+    LOOK_UP_SELF_METHODDEF,
+    SUM_METHODDEF,
+    STATE_INITIALIZED_METHODDEF,
+    {NULL, NULL}           /* sentinel */
+};
+
+static struct PyModuleDef _testsinglephase_with_reinit = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = "_testsinglephase_with_reinit",
+    .m_doc = PyDoc_STR("Test module _testsinglephase_with_reinit"),
+    .m_size = 0,
+    .m_methods = TestMethods_Reinit,
+};
+
+PyMODINIT_FUNC
+PyInit__testsinglephase_with_reinit(void)
+{
+    /* We purposefully do not try PyState_FindModule() first here
+       since we want to check the behavior of re-loading the module. */
+    PyObject *module = PyModule_Create(&_testsinglephase_with_reinit);
+    if (module == NULL) {
+        return NULL;
+    }
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+
+    assert(get_module_state(module) == NULL);
+
+    module_state state = {0};
+    if (init_state(&state) < 0) {
+        Py_CLEAR(module);
+        return NULL;
+    }
+
+    if (init_module(module, &state) < 0) {
+        Py_CLEAR(module);
+        goto finally;
+    }
+
+finally:
+    /* We only needed the module state for setting the module attrs. */
+    clear_state(&state);
+    return module;
+}
+
+
+/******************************************/
+/* the _testsinglephase_with_state module */
+/******************************************/
+
+/* This is less typical of legacy extensions in the wild:
+   - single-phase init  (same as _testsinglephase above)
+   - has some module state
+   - supports repeated initialization
+     (so m_copy is not used)
+   - the module def is not cached in _PyRuntime.extensions
+
+   At this point most modules would reach for multi-phase init (PEP 489).
+   However, module state has been around a while (PEP 3121),
+   and most extensions predate multi-phase init.
+ */
+
+static PyMethodDef TestMethods_WithState[] = {
+    LOOK_UP_SELF_METHODDEF,
+    SUM_METHODDEF,
+    STATE_INITIALIZED_METHODDEF,
+    _CLEAR_MODULE_STATE_METHODDEF,
+    {NULL, NULL}           /* sentinel */
+};
+
+static struct PyModuleDef _testsinglephase_with_state = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = "_testsinglephase_with_state",
+    .m_doc = PyDoc_STR("Test module _testsinglephase_with_state"),
+    .m_size = sizeof(module_state),
+    .m_methods = TestMethods_WithState,
+};
+
+PyMODINIT_FUNC
+PyInit__testsinglephase_with_state(void)
+{
+    /* We purposefully do not try PyState_FindModule() first here
+       since we want to check the behavior of re-loading the module. */
+    PyObject *module = PyModule_Create(&_testsinglephase_with_state);
+    if (module == NULL) {
+        return NULL;
+    }
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+
+    module_state *state = get_module_state(module);
+    assert(state != NULL);
+    if (init_state(state) < 0) {
+        Py_CLEAR(module);
+        return NULL;
+    }
+
+    if (init_module(module, state) < 0) {
+        clear_state(state);
+        Py_CLEAR(module);
+        goto finally;
+    }
+
+finally:
+    return module;
+}
+
+
+/****************************************************/
+/* the _testsinglephase_*_check_cache_first modules */
+/****************************************************/
+
+/* Each of these modules should only be freshly loaded.  That means
+   clearing the caches and each module def's m_base after each load. */
+
+static struct PyModuleDef _testsinglephase_check_cache_first = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = "_testsinglephase_check_cache_first",
+    .m_doc = PyDoc_STR("Test module _testsinglephase_check_cache_first"),
+    .m_size = -1,  // no module state
+};
+
+PyMODINIT_FUNC
+PyInit__testsinglephase_check_cache_first(void)
+{
+    assert(_testsinglephase_check_cache_first.m_base.m_index == 0);
+    PyObject *mod = PyState_FindModule(&_testsinglephase_check_cache_first);
+    if (mod != NULL) {
+        return Py_NewRef(mod);
+    }
+    return PyModule_Create(&_testsinglephase_check_cache_first);
+}
+
+
+static struct PyModuleDef _testsinglephase_with_reinit_check_cache_first = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = "_testsinglephase_with_reinit_check_cache_first",
+    .m_doc = PyDoc_STR("Test module _testsinglephase_with_reinit_check_cache_first"),
+    .m_size = 0,  // no module state
+};
+
+PyMODINIT_FUNC
+PyInit__testsinglephase_with_reinit_check_cache_first(void)
+{
+    assert(_testsinglephase_with_reinit_check_cache_first.m_base.m_index == 0);
+    PyObject *mod = PyState_FindModule(&_testsinglephase_with_reinit_check_cache_first);
+    if (mod != NULL) {
+        return Py_NewRef(mod);
+    }
+    return PyModule_Create(&_testsinglephase_with_reinit_check_cache_first);
+}
+
+
+static struct PyModuleDef _testsinglephase_with_state_check_cache_first = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = "_testsinglephase_with_state_check_cache_first",
+    .m_doc = PyDoc_STR("Test module _testsinglephase_with_state_check_cache_first"),
+    .m_size = 42,  // not used
+};
+
+PyMODINIT_FUNC
+PyInit__testsinglephase_with_state_check_cache_first(void)
+{
+    assert(_testsinglephase_with_state_check_cache_first.m_base.m_index == 0);
+    PyObject *mod = PyState_FindModule(&_testsinglephase_with_state_check_cache_first);
+    if (mod != NULL) {
+        return Py_NewRef(mod);
+    }
+    return PyModule_Create(&_testsinglephase_with_state_check_cache_first);
+}
+
+
+/****************************************/
+/* the _testsinglephase_circular module */
+/****************************************/
+
+static PyObject *static_module_circular;
+
+static PyObject *
+circularmod_clear_static_var(PyObject *self, PyObject *arg)
+{
+    PyObject *result = static_module_circular;
+    static_module_circular = NULL;
+    return result;
+}
+
+static struct PyModuleDef _testsinglephase_circular = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = "_testsinglephase_circular",
+    .m_doc = PyDoc_STR("Test module _testsinglephase_circular"),
+    .m_methods = (PyMethodDef[]) {
+        {"clear_static_var", circularmod_clear_static_var, METH_NOARGS,
+         "Clear the static variable and return its previous value."},
+        {NULL, NULL}           /* sentinel */
+    }
+};
+
+PyMODINIT_FUNC
+PyInit__testsinglephase_circular(void)
+{
+    if (!static_module_circular) {
+        static_module_circular = PyModule_Create(&_testsinglephase_circular);
+        if (!static_module_circular) {
+            return NULL;
+        }
+    }
+    static const char helper_mod_name[] = (
+        "test.test_import.data.circular_imports.singlephase");
+    PyObject *helper_mod = PyImport_ImportModule(helper_mod_name);
+    Py_XDECREF(helper_mod);
+    if (!helper_mod) {
+        return NULL;
+    }
+    if(PyModule_AddStringConstant(static_module_circular,
+                                  "helper_mod_name",
+                                  helper_mod_name) < 0) {
+        return NULL;
+    }
+    return Py_NewRef(static_module_circular);
+}
+
+
+PyMODINIT_FUNC
+PyInit__testsinglephase_raise_exception(void)
+{
+    PyErr_SetString(PyExc_RuntimeError, "evil");
+    return NULL;
+}

--- a/lib_pypy/clinic/_testmultiphase.c.h
+++ b/lib_pypy/clinic/_testmultiphase.c.h
@@ -2,14 +2,20 @@
 preserve
 [clinic start generated code]*/
 
+#if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+#  include "pycore_gc.h"          // PyGC_Head
+#  include "pycore_runtime.h"     // _Py_ID()
+#endif
+#include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
+
 PyDoc_STRVAR(_testmultiphase_StateAccessType_get_defining_module__doc__,
 "get_defining_module($self, /)\n"
 "--\n"
 "\n"
 "Return the module of the defining class.\n"
 "\n"
-"Also tests that result of PyType_GetModuleByDef matches defining_class\'s\n"
-"module.");
+"Also tests that result of PyType_GetModuleByDef matches\n"
+"defining_class\'s module.");
 
 #define _TESTMULTIPHASE_STATEACCESSTYPE_GET_DEFINING_MODULE_METHODDEF    \
     {"get_defining_module", _PyCFunction_CAST(_testmultiphase_StateAccessType_get_defining_module), METH_METHOD|METH_FASTCALL|METH_KEYWORDS, _testmultiphase_StateAccessType_get_defining_module__doc__},
@@ -19,13 +25,13 @@ _testmultiphase_StateAccessType_get_defining_module_impl(StateAccessTypeObject *
                                                          PyTypeObject *cls);
 
 static PyObject *
-_testmultiphase_StateAccessType_get_defining_module(StateAccessTypeObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+_testmultiphase_StateAccessType_get_defining_module(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     if (nargs || (kwnames && PyTuple_GET_SIZE(kwnames))) {
         PyErr_SetString(PyExc_TypeError, "get_defining_module() takes no arguments");
         return NULL;
     }
-    return _testmultiphase_StateAccessType_get_defining_module_impl(self, cls);
+    return _testmultiphase_StateAccessType_get_defining_module_impl((StateAccessTypeObject *)self, cls);
 }
 
 PyDoc_STRVAR(_testmultiphase_StateAccessType_getmodulebydef_bad_def__doc__,
@@ -42,13 +48,13 @@ _testmultiphase_StateAccessType_getmodulebydef_bad_def_impl(StateAccessTypeObjec
                                                             PyTypeObject *cls);
 
 static PyObject *
-_testmultiphase_StateAccessType_getmodulebydef_bad_def(StateAccessTypeObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+_testmultiphase_StateAccessType_getmodulebydef_bad_def(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     if (nargs || (kwnames && PyTuple_GET_SIZE(kwnames))) {
         PyErr_SetString(PyExc_TypeError, "getmodulebydef_bad_def() takes no arguments");
         return NULL;
     }
-    return _testmultiphase_StateAccessType_getmodulebydef_bad_def_impl(self, cls);
+    return _testmultiphase_StateAccessType_getmodulebydef_bad_def_impl((StateAccessTypeObject *)self, cls);
 }
 
 PyDoc_STRVAR(_testmultiphase_StateAccessType_increment_count_clinic__doc__,
@@ -70,17 +76,43 @@ _testmultiphase_StateAccessType_increment_count_clinic_impl(StateAccessTypeObjec
                                                             int n, int twice);
 
 static PyObject *
-_testmultiphase_StateAccessType_increment_count_clinic(StateAccessTypeObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+_testmultiphase_StateAccessType_increment_count_clinic(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
+    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+
+    #define NUM_KEYWORDS 2
+    static struct {
+        PyGC_Head _this_is_not_used;
+        PyObject_VAR_HEAD
+        Py_hash_t ob_hash;
+        PyObject *ob_item[NUM_KEYWORDS];
+    } _kwtuple = {
+        .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
+        .ob_hash = -1,
+        .ob_item = { _Py_LATIN1_CHR('n'), &_Py_ID(twice), },
+    };
+    #undef NUM_KEYWORDS
+    #define KWTUPLE (&_kwtuple.ob_base.ob_base)
+
+    #else  // !Py_BUILD_CORE
+    #  define KWTUPLE NULL
+    #endif  // !Py_BUILD_CORE
+
     static const char * const _keywords[] = {"n", "twice", NULL};
-    static _PyArg_Parser _parser = {NULL, _keywords, "increment_count_clinic", 0};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "increment_count_clinic",
+        .kwtuple = KWTUPLE,
+    };
+    #undef KWTUPLE
     PyObject *argsbuf[2];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 0;
     int n = 1;
     int twice = 0;
 
-    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 0, 1, 0, argsbuf);
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
+            /*minpos*/ 0, /*maxpos*/ 1, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
     if (!args) {
         goto exit;
     }
@@ -88,7 +120,7 @@ _testmultiphase_StateAccessType_increment_count_clinic(StateAccessTypeObject *se
         goto skip_optional_pos;
     }
     if (args[0]) {
-        n = _PyLong_AsInt(args[0]);
+        n = PyLong_AsInt(args[0]);
         if (n == -1 && PyErr_Occurred()) {
             goto exit;
         }
@@ -105,7 +137,7 @@ skip_optional_pos:
         goto exit;
     }
 skip_optional_kwonly:
-    return_value = _testmultiphase_StateAccessType_increment_count_clinic_impl(self, cls, n, twice);
+    return_value = _testmultiphase_StateAccessType_increment_count_clinic_impl((StateAccessTypeObject *)self, cls, n, twice);
 
 exit:
     return return_value;
@@ -125,12 +157,12 @@ _testmultiphase_StateAccessType_get_count_impl(StateAccessTypeObject *self,
                                                PyTypeObject *cls);
 
 static PyObject *
-_testmultiphase_StateAccessType_get_count(StateAccessTypeObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+_testmultiphase_StateAccessType_get_count(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     if (nargs || (kwnames && PyTuple_GET_SIZE(kwnames))) {
         PyErr_SetString(PyExc_TypeError, "get_count() takes no arguments");
         return NULL;
     }
-    return _testmultiphase_StateAccessType_get_count_impl(self, cls);
+    return _testmultiphase_StateAccessType_get_count_impl((StateAccessTypeObject *)self, cls);
 }
-/*[clinic end generated code: output=de38f6a82927fb11 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=aff91f6219a7baca input=a9049054013a1b77]*/

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -335,7 +335,12 @@ PERF_RETRY_RUNS = 5 if sys.platform == "win32" else 3
 SYNTHETIC_CPYTHON_REFERENCE_TIMEOUT_S = 5
 CARGO_CONFIG = {
     "dynasm": {
-        "extra": ["--no-default-features", "--features", "dynasm"],
+        # `cpyext`, because the CPython suite step that rides this backend's
+        # Linux leg builds `_testbuffer`, `_testsinglephase` and
+        # `_testmultiphase` against the binary built here: without the feature
+        # `test_buffer` skips `TestBufferProtocol` wholesale, which is 95 of
+        # that module's cases, and `test_importlib.extension` skips too.
+        "extra": ["--no-default-features", "--features", "dynasm,cpyext"],
         "bin": "pyre-dynasm",
     },
     "cranelift": {

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1020,6 +1020,12 @@ def _first_stderr_line(stderr):
     return f"  {reason}"
 
 
+# Characters of a Rust panic's message body to keep. Wide enough for the
+# collector's longest `GC BUG` diagnostic, whose trailing fields are the ones
+# that attribute a crash nobody can reproduce on demand.
+PANIC_BODY_CHARS = 2000
+
+
 def _jit_panic_reason(stderr):
     """Return a failure reason if *stderr* shows a JIT-level Rust panic or a
     nonzero internal_compile_panics stat, else None.
@@ -1051,11 +1057,14 @@ def _jit_panic_reason(stderr):
                 # crash with no way to attribute it. At 400 the two
                 # `invalid type_id` diagnostics, which reach about 800
                 # characters once their eight-word holder and child dumps are
-                # in, are cut inside the first dump.
+                # in, are cut inside the first dump, and at 1200 the major
+                # collector's own is cut at `site=` — dropping both
+                # generations, the remembered-set membership and the enclosing
+                # container.
                 for follow in lines[idx + 1 :]:
                     follow = follow.strip()
                     if follow:
-                        reason += f" | {follow[:1200]}"
+                        reason += f" | {follow[:PANIC_BODY_CHARS]}"
                         break
                 return reason
         return "rust panic"

--- a/pyre/cpython_tests/README.md
+++ b/pyre/cpython_tests/README.md
@@ -17,6 +17,20 @@ pyre's plain-Python runner convention (no pytest / RPython dependency).
   decision never becomes a test-file edit: it lives in the external
   `baseline.json`, so stdlib upgrades stay a clean drop-in (see
   `lib-python/stdlib-upgrade.txt`).
+- **`_testbuffer` is built by the runner.** `test_buffer`'s
+  `TestBufferProtocol` — 95 of that module's cases — is `skipUnless(ndarray)`,
+  and `ndarray` comes from `Modules/_testbuffer.c`, which CPython builds beside
+  its interpreter. The runner compiles `lib_pypy/_testbuffer.c` — that file
+  verbatim, and unchanged across 3.14.6 and 3.14.7 — against
+  `include/pyre3.14t` and puts it on `PYTHONPATH` for that module alone,
+  because several other modules assert on the path their child interpreters
+  inherit. An interpreter without `cpyext`, a platform the feature is not
+  compiled for, or a missing C compiler leaves it unbuilt and the class
+  skipped, as upstream does when the module is absent. The feature also fills
+  `EXTENSION_SUFFIXES`, which unskips `test_importlib.extension.*`; those cases
+  want `_testsinglephase` and `_testmultiphase`, whose sources include
+  `pycore_*` headers pyre does not ship, so `test_importlib` is recorded
+  `FAIL`.
 - **External baseline.** `baseline.json` records the expected status of every
   module per backend. A module recorded `PASS` that stops passing is a
   regression and fails CI. The default gate runs only the `PASS` subset (for CI
@@ -27,7 +41,7 @@ pyre's plain-Python runner convention (no pytest / RPython dependency).
 
 ```sh
 # build the interpreter first
-cargo build --release -p pyrex --bin pyre-dynasm --no-default-features --features dynasm
+cargo build --release -p pyrex --bin pyre-dynasm --no-default-features --features dynasm,cpyext
 
 # gate against the baseline (default: dynasm, JIT on, script mode)
 python3 pyre/cpython_tests/run.py

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -106,7 +106,7 @@
       "dynasm": "PASS"
     },
     "test.test_buffer": {
-      "cranelift": "PASS",
+      "cranelift": "FAIL",
       "dynasm": "FAIL"
     },
     "test.test_bufio": {

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -107,7 +107,7 @@
     },
     "test.test_buffer": {
       "cranelift": "PASS",
-      "dynasm": "PASS"
+      "dynasm": "FAIL"
     },
     "test.test_bufio": {
       "cranelift": "PASS",
@@ -614,7 +614,7 @@
     },
     "test.test_importlib": {
       "cranelift": "PASS",
-      "dynasm": "PASS"
+      "dynasm": "FAIL"
     },
     "test.test_index": {
       "cranelift": "PASS",

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -613,7 +613,7 @@
       "dynasm": "PASS"
     },
     "test.test_importlib": {
-      "cranelift": "PASS",
+      "cranelift": "FAIL",
       "dynasm": "FAIL"
     },
     "test.test_index": {

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -194,6 +194,13 @@ STATS_STDERR_INCOMPATIBLE = {
 
 # ── classification ───────────────────────────────────────────────────
 
+# The collector's `GC BUG` panics carry the holder and child words, both
+# generations, the remembered-set membership and the enclosing container after
+# the `site=` field. At 200 characters every one of them is cut, which leaves a
+# rare crash unattributable from the run it appeared in.
+PANIC_BODY_CHARS = 2000
+
+
 def jit_panic_reason(stderr: str) -> str | None:
     """A JIT-level rust panic or nonzero internal_compile_panics, else None.
 
@@ -217,7 +224,7 @@ def jit_panic_reason(stderr: str) -> str | None:
                 for follow in lines[idx + 1:]:
                     follow = follow.strip()
                     if follow:
-                        reason += f" | {follow[:1200]}"
+                        reason += f" | {follow[:PANIC_BODY_CHARS]}"
                         break
                 return reason
         return "rust panic"

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -169,6 +169,17 @@ def platform_gate(module: str) -> str | None:
     return None if applies(sys.platform) else reason
 
 
+# `Modules/_testbuffer.c` is the exporter `test_buffer`'s `TestBufferProtocol`
+# is `skipUnless`d on, and the only C extension the suite needs.  CPython
+# builds it beside the interpreter; pyre builds it here against the same
+# headers `pyrex`'s cpyext fixtures compile against.  It reaches the modules
+# below and no others: `PYTHONPATH` is language-visible, and several modules
+# assert on the path their own child interpreters inherit.
+TESTBUFFER_SOURCE = ROOT / "lib_pypy" / "_testbuffer.c"
+CPYEXT_INCLUDE = ROOT / "include" / "pyre3.14t"
+EXTENSION_BUILD_DIR = ROOT / "build" / "cpython_tests"
+NEEDS_TEST_EXTENSION = {"test.test_buffer"}
+
 # These modules intentionally assert on a child interpreter's exact stderr.
 # MAJIT_STATS is runner instrumentation rather than language-visible output,
 # so do not inject it into those modules or any subprocesses they spawn.
@@ -598,8 +609,54 @@ def build_cmd(binary: Path, module: str, mode: str) -> list[str]:
     return [str(binary), str(module_path(module))]
 
 
+def build_test_extension(binary: Path) -> tuple[Path | None, str]:
+    """Compile `_testbuffer` for `binary`; answer its directory, or why not.
+
+    An interpreter built without `cpyext`, a platform the feature is not
+    compiled for, and a missing C compiler each leave the extension unbuilt.
+    `test_buffer` then skips `TestBufferProtocol` exactly as it does upstream
+    when the module is absent, rather than failing the run.
+    """
+    if sys.platform not in ("darwin", "linux"):
+        return None, f"cpyext is built for macos and linux, not {sys.platform}"
+    if not TESTBUFFER_SOURCE.is_file():
+        return None, f"{TESTBUFFER_SOURCE} is missing"
+    named = subprocess.run(
+        [str(binary), "-c", "import _imp; print(_imp.extension_suffixes()[0])"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    suffix = named.stdout.strip().splitlines()[-1] if named.stdout.strip() else ""
+    if named.returncode != 0 or not suffix:
+        return None, "the interpreter reported no extension suffix"
+    EXTENSION_BUILD_DIR.mkdir(parents=True, exist_ok=True)
+    extension = EXTENSION_BUILD_DIR / f"_testbuffer{suffix}"
+    compile_cmd = [
+        os.environ.get("CC", "cc"), str(TESTBUFFER_SOURCE),
+        "-I", str(CPYEXT_INCLUDE), "-o", str(extension), "-O2",
+    ]
+    compile_cmd += (
+        ["-bundle", "-undefined", "dynamic_lookup"] if sys.platform == "darwin"
+        else ["-fPIC", "-shared"]
+    )
+    built = subprocess.run(
+        compile_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    if built.returncode != 0:
+        return None, f"{compile_cmd[0]}: {last_stderr_line(built.stderr)}"
+    # Compiling proves the headers agree, not that the interpreter can load
+    # what they describe: a build without cpyext resolves none of the symbols.
+    loaded = subprocess.run(
+        [str(binary), "-c", "import _testbuffer"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        env=dict(os.environ, PYTHONPATH=str(EXTENSION_BUILD_DIR)),
+    )
+    if loaded.returncode != 0:
+        return None, f"built but not importable: {last_stderr_line(loaded.stderr)}"
+    return EXTENSION_BUILD_DIR, ""
+
+
 def run_module(binary: Path, module: str, mode: str, timeout: int,
-               env: dict) -> tuple[str, str]:
+               env: dict, extension_dir: Path | None = None) -> tuple[str, str]:
     # Run in a throwaway cwd so a test writing into '.' never touches the
     # repo (the stdlib is resolved relative to the executable, not cwd).
     # `ignore_cleanup_errors` because a test that leaves a file open takes the
@@ -656,8 +713,15 @@ def run_module(binary: Path, module: str, mode: str, timeout: int,
         else:
             cmd = build_cmd(binary, module, mode)
         module_env = env
-        if module in STATS_STDERR_INCOMPATIBLE:
+        if extension_dir is not None and module in NEEDS_TEST_EXTENSION:
             module_env = env.copy()
+            inherited = module_env.get("PYTHONPATH")
+            module_env["PYTHONPATH"] = os.pathsep.join(
+                [str(extension_dir)] + ([inherited] if inherited else [])
+            )
+        if module in STATS_STDERR_INCOMPATIBLE:
+            if module_env is env:
+                module_env = env.copy()
             module_env.pop("MAJIT_STATS", None)
         if mode == "script" and module == "test.test_regrtest":
             # libregrtest/setup.py:88-96 `setup_process` keeps a non-ASCII
@@ -780,8 +844,11 @@ def main() -> int:
     binary = binary.resolve()
     if not args.list and not binary.exists():
         print(f"error: interpreter not found: {binary}", file=sys.stderr)
+        features = args.backend
+        if sys.platform in ("darwin", "linux"):
+            features += ",cpyext"
         print("       build it with: cargo build --release -p pyrex --bin "
-              f"{BIN_NAME[args.backend]} --no-default-features --features {args.backend}",
+              f"{BIN_NAME[args.backend]} --no-default-features --features {features}",
               file=sys.stderr)
         return 2
 
@@ -810,6 +877,12 @@ def main() -> int:
     env.pop("PYRE_MAJIT_STATS_ANCESTOR", None)
     if args.no_jit:
         env["PYRE_NO_JIT"] = "1"
+
+    extension_dir, unbuilt = build_test_extension(binary)
+    if extension_dir is None:
+        print(f"warning: _testbuffer not built ({unbuilt}) — "
+              f"{'/'.join(sorted(NEEDS_TEST_EXTENSION))} will skip the classes "
+              "that need it", file=sys.stderr)
 
     # Decide which modules to actually run.
     #
@@ -879,14 +952,16 @@ def main() -> int:
     serial_modules = [m for m in to_run if m in SERIAL_MODULES]
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
         futs = {
-            pool.submit(run_module, binary, m, args.mode, args.timeout, env): m
+            pool.submit(run_module, binary, m, args.mode, args.timeout,
+                        env, extension_dir): m
             for m in parallel_modules
         }
         for fut in concurrent.futures.as_completed(futs):
             m = futs[fut]
             record_result(m, fut.result())
     for m in serial_modules:
-        record_result(m, run_module(binary, m, args.mode, args.timeout, env))
+        record_result(m, run_module(binary, m, args.mode, args.timeout,
+                                    env, extension_dir))
     print()
 
     # Summary by status.

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -175,10 +175,18 @@ def platform_gate(module: str) -> str | None:
 # headers `pyrex`'s cpyext fixtures compile against.  It reaches the modules
 # below and no others: `PYTHONPATH` is language-visible, and several modules
 # assert on the path their own child interpreters inherit.
-TESTBUFFER_SOURCE = ROOT / "lib_pypy" / "_testbuffer.c"
+TEST_EXTENSION_SOURCES = {
+    "_testbuffer": ROOT / "lib_pypy" / "_testbuffer.c",
+    "_testsinglephase": ROOT / "lib_pypy" / "_testsinglephase.c",
+    "_testmultiphase": ROOT / "lib_pypy" / "_testmultiphase.c",
+}
 CPYEXT_INCLUDE = ROOT / "include" / "pyre3.14t"
+# The headers CPython keeps out of an installed tree and builds these modules
+# against inside its own: `_PyNamespace_New` and the argument parser Argument
+# Clinic writes calls to both live behind one.
+CPYEXT_INTERNAL_INCLUDE = CPYEXT_INCLUDE / "internal"
 EXTENSION_BUILD_DIR = ROOT / "build" / "cpython_tests"
-NEEDS_TEST_EXTENSION = {"test.test_buffer"}
+NEEDS_TEST_EXTENSION = {"test.test_buffer", "test.test_importlib"}
 
 # These modules intentionally assert on a child interpreter's exact stderr.
 # MAJIT_STATS is runner instrumentation rather than language-visible output,
@@ -616,30 +624,47 @@ def build_cmd(binary: Path, module: str, mode: str) -> list[str]:
     return [str(binary), str(module_path(module))]
 
 
-def build_test_extension(binary: Path) -> tuple[Path | None, str]:
-    """Compile `_testbuffer` for `binary`; answer its directory, or why not.
+def build_test_extensions(binary: Path) -> tuple[Path | None, dict[str, str]]:
+    """Compile the test extensions for `binary`; answer their directory and,
+    per extension, why one is missing.
 
     An interpreter built without `cpyext`, a platform the feature is not
-    compiled for, and a missing C compiler each leave the extension unbuilt.
-    `test_buffer` then skips `TestBufferProtocol` exactly as it does upstream
-    when the module is absent, rather than failing the run.
+    compiled for, and a missing C compiler each leave every extension unbuilt,
+    and the directory is then `None`. A source that fails on its own leaves the
+    others usable, so its reason is reported alone. The tests that need one
+    skip exactly as they do upstream when the module is absent, rather than
+    failing the run.
     """
     if sys.platform not in ("darwin", "linux"):
-        return None, f"cpyext is built for macos and linux, not {sys.platform}"
-    if not TESTBUFFER_SOURCE.is_file():
-        return None, f"{TESTBUFFER_SOURCE} is missing"
+        reason = f"cpyext is built for macos and linux, not {sys.platform}"
+        return None, dict.fromkeys(TEST_EXTENSION_SOURCES, reason)
     named = subprocess.run(
         [str(binary), "-c", "import _imp; print(_imp.extension_suffixes()[0])"],
         capture_output=True, text=True, encoding="utf-8", errors="replace",
     )
     suffix = named.stdout.strip().splitlines()[-1] if named.stdout.strip() else ""
     if named.returncode != 0 or not suffix:
-        return None, "the interpreter reported no extension suffix"
+        reason = "the interpreter reported no extension suffix"
+        return None, dict.fromkeys(TEST_EXTENSION_SOURCES, reason)
     EXTENSION_BUILD_DIR.mkdir(parents=True, exist_ok=True)
-    extension = EXTENSION_BUILD_DIR / f"_testbuffer{suffix}"
+    unbuilt = {}
+    for name, source in TEST_EXTENSION_SOURCES.items():
+        reason = build_one_test_extension(binary, name, source, suffix)
+        if reason:
+            unbuilt[name] = reason
+    return EXTENSION_BUILD_DIR, unbuilt
+
+
+def build_one_test_extension(binary: Path, name: str, source: Path,
+                             suffix: str) -> str:
+    """Compile one extension and prove the interpreter can import it, or say
+    why not."""
+    if not source.is_file():
+        return f"{source} is missing"
     compile_cmd = [
-        os.environ.get("CC", "cc"), str(TESTBUFFER_SOURCE),
-        "-I", str(CPYEXT_INCLUDE), "-o", str(extension), "-O2",
+        os.environ.get("CC", "cc"), str(source),
+        "-I", str(CPYEXT_INCLUDE), "-I", str(CPYEXT_INTERNAL_INCLUDE),
+        "-o", str(EXTENSION_BUILD_DIR / f"{name}{suffix}"), "-O2",
     ]
     compile_cmd += (
         ["-bundle", "-undefined", "dynamic_lookup"] if sys.platform == "darwin"
@@ -649,17 +674,17 @@ def build_test_extension(binary: Path) -> tuple[Path | None, str]:
         compile_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace",
     )
     if built.returncode != 0:
-        return None, f"{compile_cmd[0]}: {last_stderr_line(built.stderr)}"
+        return f"{compile_cmd[0]}: {last_stderr_line(built.stderr)}"
     # Compiling proves the headers agree, not that the interpreter can load
     # what they describe: a build without cpyext resolves none of the symbols.
     loaded = subprocess.run(
-        [str(binary), "-c", "import _testbuffer"],
+        [str(binary), "-c", f"import {name}"],
         capture_output=True, text=True, encoding="utf-8", errors="replace",
         env=dict(os.environ, PYTHONPATH=str(EXTENSION_BUILD_DIR)),
     )
     if loaded.returncode != 0:
-        return None, f"built but not importable: {last_stderr_line(loaded.stderr)}"
-    return EXTENSION_BUILD_DIR, ""
+        return f"built but not importable: {last_stderr_line(loaded.stderr)}"
+    return ""
 
 
 def run_module(binary: Path, module: str, mode: str, timeout: int,
@@ -885,9 +910,9 @@ def main() -> int:
     if args.no_jit:
         env["PYRE_NO_JIT"] = "1"
 
-    extension_dir, unbuilt = build_test_extension(binary)
-    if extension_dir is None:
-        print(f"warning: _testbuffer not built ({unbuilt}) — "
+    extension_dir, unbuilt = build_test_extensions(binary)
+    for name, reason in sorted(unbuilt.items()):
+        print(f"warning: {name} not built ({reason}) — "
               f"{'/'.join(sorted(NEEDS_TEST_EXTENSION))} will skip the classes "
               "that need it", file=sys.stderr)
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -975,18 +975,29 @@ fn memoryview_pack_value(
 }
 
 /// Element-value list of a 1-D view (format-aware per `value_from_bytes`).
-unsafe fn memoryview_values(mv: PyObjectRef) -> Vec<PyObjectRef> {
+/// Each element is pinned as built and read back inside the scope
+/// `w_list_new` runs in, so neither a later element's allocation nor the
+/// list's own can strand an earlier one (`build_list_storage`).
+unsafe fn memoryview_value_list(mv: PyObjectRef) -> PyObjectRef {
     unsafe {
         let itemsize = pyre_object::memoryview::w_memoryview_itemsize(mv) as usize;
         let fmt = pyre_object::memoryview::w_memoryview_format_str(mv);
         let data = memoryview_gather_bytes(mv);
-        let mut items = Vec::new();
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        let mut count = 0;
         let mut base = 0;
         while itemsize > 0 && base + itemsize <= data.len() {
-            items.push(memoryview_unpack_element(fmt, &data, base, itemsize));
+            let _ = pyre_object::gc_roots::pin_root(memoryview_unpack_element(
+                fmt, &data, base, itemsize,
+            ));
             base += itemsize;
+            count += 1;
         }
-        items
+        let items = (0..count)
+            .map(|i| pyre_object::gc_roots::shadow_stack_get(sp + i))
+            .collect();
+        w_list_new(items)
     }
 }
 
@@ -1453,7 +1464,7 @@ fn memoryview_iter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     unsafe {
         memoryview_check_released(mv)?;
         memoryview_adjust_fmt(pyre_object::memoryview::w_memoryview_format_str(mv))?;
-        crate::baseobjspace::iter(w_list_new(memoryview_values(mv)))
+        crate::baseobjspace::iter(memoryview_value_list(mv))
     }
 }
 
@@ -1600,27 +1611,25 @@ unsafe fn memoryview_tolist_rec(
             .get(idim as usize)
             .copied()
             .unwrap_or(0);
-        let mut items = Vec::with_capacity(dimshape.max(0) as usize);
+        // Every element is pinned as built, the sublists included, and read
+        // back inside the scope `w_list_new` runs in (`build_list_storage`).
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        let mut count = 0;
         let mut pos = start;
-        if idim == ndim - 1 {
-            for _ in 0..dimshape {
-                items.push(memoryview_unpack_element(fmt, full, pos as usize, isz));
-                pos += dimstride;
-            }
-        } else {
-            for _ in 0..dimshape {
-                items.push(memoryview_tolist_rec(
-                    mv,
-                    fmt,
-                    full,
-                    isz,
-                    ndim,
-                    idim + 1,
-                    pos,
-                ));
-                pos += dimstride;
-            }
+        for _ in 0..dimshape {
+            let element = if idim == ndim - 1 {
+                memoryview_unpack_element(fmt, full, pos as usize, isz)
+            } else {
+                memoryview_tolist_rec(mv, fmt, full, isz, ndim, idim + 1, pos)
+            };
+            let _ = pyre_object::gc_roots::pin_root(element);
+            pos += dimstride;
+            count += 1;
         }
+        let items = (0..count)
+            .map(|i| pyre_object::gc_roots::shadow_stack_get(sp + i))
+            .collect();
         w_list_new(items)
     }
 }
@@ -1635,7 +1644,7 @@ fn memoryview_tolist(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         memoryview_adjust_fmt(pyre_object::memoryview::w_memoryview_format_str(mv))?;
         let ndim = pyre_object::memoryview::w_memoryview_ndim(mv);
         if ndim == 1 {
-            return Ok(w_list_new(memoryview_values(mv)));
+            return Ok(memoryview_value_list(mv));
         }
         let isz = pyre_object::memoryview::w_memoryview_itemsize(mv) as usize;
         let fmt = pyre_object::memoryview::w_memoryview_format_str(mv);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1625,18 +1625,15 @@ unsafe fn memoryview_tolist_rec(
     }
 }
 
-/// `memoryview.tolist` — the element-value list (format-aware); a 1-D view
-/// is flat, an N-D view nests one list per dimension (`_tolist_rec`).
+/// `memoryview.tolist` — the element-value list (format-aware); a 0-D view
+/// answers its one element bare, a 1-D view is flat, an N-D view nests one
+/// list per dimension (`_tolist_rec`).
 fn memoryview_tolist(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let mv = args.first().copied().unwrap_or(w_none());
     unsafe {
         memoryview_check_released(mv)?;
         memoryview_adjust_fmt(pyre_object::memoryview::w_memoryview_format_str(mv))?;
         let ndim = pyre_object::memoryview::w_memoryview_ndim(mv);
-        if ndim == 0 {
-            // `buffer.py w_tolist` raises for a 0-dim view.
-            return Err(crate::PyError::not_implemented(""));
-        }
         if ndim == 1 {
             return Ok(w_list_new(memoryview_values(mv)));
         }
@@ -1646,6 +1643,9 @@ fn memoryview_tolist(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             .backing()
             .as_bytes();
         let start = pyre_object::memoryview::w_memoryview_offset(mv);
+        if ndim == 0 {
+            return Ok(memoryview_unpack_element(fmt, full, start as usize, isz));
+        }
         Ok(memoryview_tolist_rec(mv, fmt, full, isz, ndim, 0, start))
     }
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -9340,9 +9340,18 @@ fn exception_group_derive_and_copy(
     // _derive_and_copy_attrs: construct the sub-result through the overridable
     // `derive` method so a subclass can control reconstruction (e.g. thread
     // extra constructor args), then copy the metadata attrs onto it.
-    let derive = crate::baseobjspace::getattr_str(w_self, "derive")?;
-    let list = pyre_object::w_list_new(exceptions);
-    let group = crate::call::call_function_impl_result(derive, &[list])?;
+    //
+    // `derive` is a fresh bound method that has to survive building the
+    // argument list, and the group it answers has to survive the attribute
+    // copy, which allocates in turn.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(w_self, "derive")?);
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_list_new(exceptions));
+    let derive = pyre_object::gc_roots::shadow_stack_get(sp);
+    let list = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+    let group =
+        pyre_object::gc_roots::pin_root(crate::call::call_function_impl_result(derive, &[list])?);
     let base_group = lookup_exc_class("BaseExceptionGroup").unwrap();
     if !crate::baseobjspace::isinstance(group, base_group)? {
         return Err(crate::PyError::type_error(
@@ -9350,7 +9359,7 @@ fn exception_group_derive_and_copy(
         ));
     }
     exception_group_copy_attrs(w_self, group)?;
-    Ok(group)
+    Ok(pyre_object::gc_roots::shadow_stack_get(sp + 2))
 }
 
 fn exception_group_subgroup_inner(
@@ -9362,7 +9371,9 @@ fn exception_group_subgroup_inner(
     }
     let (_, exceptions) = exception_group_fields(w_self)?;
     let base_group = lookup_exc_class("BaseExceptionGroup").unwrap();
-    let mut selected = Vec::new();
+    // A selected child can be a freshly derived subgroup and the next child
+    // allocates again, so each is pinned as it arrives (`build_list_storage`).
+    let mut selected = pyre_object::gc_roots::RootedItems::new();
     let mut modified = false;
     for exc in unsafe { pyre_object::w_tuple_items_copy_as_vec(exceptions) } {
         if crate::baseobjspace::isinstance(exc, base_group)? {
@@ -9384,7 +9395,7 @@ fn exception_group_subgroup_inner(
     } else if selected.is_empty() {
         Ok(pyre_object::w_none())
     } else {
-        exception_group_derive_and_copy(w_self, selected)
+        exception_group_derive_and_copy(w_self, selected.take())
     }
 }
 
@@ -9397,34 +9408,52 @@ fn exception_group_split_inner(
     }
     let (_, exceptions) = exception_group_fields(w_self)?;
     let base_group = lookup_exc_class("BaseExceptionGroup").unwrap();
-    let mut matching = Vec::new();
-    let mut nonmatching = Vec::new();
+    // Either side can hold a freshly derived subgroup while a later child is
+    // still recursing and allocating, so every kept child is pinned as it
+    // arrives; both sides share one bracket, because two open brackets pin onto
+    // the same shadow stack and would read each other's slots back
+    // (`build_list_storage`).
+    let mut kept = pyre_object::gc_roots::RootedItems::new();
+    let mut matching_at = Vec::new();
+    let mut nonmatching_at = Vec::new();
     for exc in unsafe { pyre_object::w_tuple_items_copy_as_vec(exceptions) } {
         if crate::baseobjspace::isinstance(exc, base_group)? {
             let (yes, no) = exception_group_split_inner(exc, condition)?;
             if !unsafe { pyre_object::is_none(yes) } {
-                matching.push(yes);
+                matching_at.push(kept.len());
+                kept.push(yes);
             }
             if !unsafe { pyre_object::is_none(no) } {
-                nonmatching.push(no);
+                nonmatching_at.push(kept.len());
+                kept.push(no);
             }
         } else if condition.matches(exc)? {
-            matching.push(exc);
+            matching_at.push(kept.len());
+            kept.push(exc);
         } else {
-            nonmatching.push(exc);
+            nonmatching_at.push(kept.len());
+            kept.push(exc);
         }
     }
-    let yes = if matching.is_empty() {
+    let kept_items = kept.take();
+    let side = |at: &[usize]| -> Vec<PyObjectRef> { at.iter().map(|&i| kept_items[i]).collect() };
+    // Deriving one side allocates, so the group derived for the other side is
+    // pinned across it.
+    let mut derived = pyre_object::gc_roots::RootedItems::new();
+    let yes = if matching_at.is_empty() {
         pyre_object::w_none()
     } else {
-        exception_group_derive_and_copy(w_self, matching)?
+        exception_group_derive_and_copy(w_self, side(&matching_at))?
     };
-    let no = if nonmatching.is_empty() {
+    derived.push(yes);
+    let no = if nonmatching_at.is_empty() {
         pyre_object::w_none()
     } else {
-        exception_group_derive_and_copy(w_self, nonmatching)?
+        exception_group_derive_and_copy(w_self, side(&nonmatching_at))?
     };
-    Ok((yes, no))
+    derived.push(no);
+    let sides = derived.take();
+    Ok((sides[0], sides[1]))
 }
 
 pub(crate) fn exception_group_match(
@@ -17429,7 +17458,9 @@ fn file_method_readlines(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     if args.is_empty() {
         return Err(crate::PyError::type_error("readlines() requires self"));
     }
-    let mut lines = Vec::new();
+    // Every line is freshly allocated and the next `readline` allocates again,
+    // so they are pinned as they arrive (`build_list_storage`).
+    let mut lines = pyre_object::gc_roots::RootedItems::new();
     loop {
         let line = file_method_readline(args)?;
         // readline returns `bytes` in binary mode and `str` otherwise; an
@@ -17446,7 +17477,7 @@ fn file_method_readlines(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
         }
         lines.push(line);
     }
-    Ok(w_list_new(lines))
+    Ok(w_list_new(lines.take()))
 }
 
 /// `_io/interp_fileio.py:write_w` — `space.getarg_w('s*', w_data).as_str()`.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -782,8 +782,11 @@ pub(crate) unsafe fn memoryview_as_bytes(obj: PyObjectRef) -> Option<Vec<u8>> {
     unsafe { pyre_object::memoryview::is_w_memoryview(obj).then(|| memoryview_gather_bytes(obj)) }
 }
 
-/// Little-endian unsigned unpack of one `itemsize`-wide element at byte
-/// offset `base` — the fallback for formats the shared decoder rejects.
+/// Little-endian unpack of one `itemsize`-wide element at byte offset `base`
+/// — the fallback for formats the shared decoder rejects.  A narrower item is
+/// unsigned; a full-word one is the signed reading of those bytes, so a format
+/// whose width is a word and whose values are not signed needs an arm of its
+/// own rather than this.
 ///
 /// `itemsize` is at most the width of the result; a wider item has no integer
 /// to fold into, and the caller answers with its bytes instead.
@@ -823,7 +826,8 @@ fn memoryview_adjust_fmt(fmt: &str) -> Result<(), crate::PyError> {
 /// Box one `itemsize`-wide element at byte offset `base` per the view's
 /// format (`buffer.py value_from_bytes`).  Numeric typecodes route through
 /// the shared array decoder (`unpack_value`); `c` yields a length-1 bytes,
-/// `?` a bool, and any code the decoder rejects falls back to unsigned LE.
+/// `?` a bool, and any code the decoder rejects falls back to a little-endian
+/// read that is signed once the item is a full word wide.
 unsafe fn memoryview_unpack_element(
     fmt: &str,
     data: &[u8],
@@ -839,6 +843,16 @@ unsafe fn memoryview_unpack_element(
             w_float_new(crate::module::r#struct::unpack_half(bits))
         }
         tc => {
+            // `unpack_single` reads `n` as `Py_ssize_t` and `N` and `P` as
+            // `size_t` and `void *`, each one 64-bit word wide here, as
+            // `memoryview_pack_value` writes them.  The array decoder carries
+            // only the codes `array.array` accepts, and the width fallback
+            // below builds a signed value.
+            let tc = match tc {
+                b'n' => b'q',
+                b'N' | b'P' => b'Q',
+                other => other,
+            };
             let w = pyre_object::interp_array::unpack_value(tc, buf);
             if w != pyre_object::PY_NULL {
                 w

--- a/pyre/pyre-interpreter/src/cpyext/buffer.rs
+++ b/pyre/pyre-interpreter/src/cpyext/buffer.rs
@@ -131,9 +131,14 @@ fn format_of(format: *const c_char) -> String {
 }
 
 /// One dimension vector, or the derived default when the exporter answered a
-/// request that does not ask for it -- `init_shape_strides`.
+/// request that does not ask for it -- `init_shape_strides`.  A zero-dimensional
+/// view has no dimensions, and fabricating one leaves every caller reading an
+/// axis its own index vector does not have.
 fn dims(pointer: *const isize, ndim: i64, derived: &[i64]) -> Vec<i64> {
-    if pointer.is_null() || ndim <= 0 {
+    if ndim <= 0 {
+        return Vec::new();
+    }
+    if pointer.is_null() {
         return derived.to_vec();
     }
     (0..ndim as usize)
@@ -482,6 +487,9 @@ pub(super) unsafe extern "C" fn interp_bf_getbuffer(
     // The exporter's own storage, which the collector does not move: the
     // address stays the one C was handed for as long as the export is open.
     let first = unsafe { carrier.backing().as_bytes() }.as_ptr() as usize;
+    // `init_shape_strides` answers NULL for a zero-dimensional view, and an
+    // empty `Vec` hands out a dangling address rather than one.
+    let axes = carrier.ndim() != 0;
     unsafe {
         (*view).buf = (first + carrier.offset() as usize) as *mut c_void;
         (*view).obj = exporter;
@@ -493,11 +501,11 @@ pub(super) unsafe extern "C" fn interp_bf_getbuffer(
             true => export.format.as_mut_ptr() as *mut c_char,
             false => std::ptr::null_mut(),
         };
-        (*view).shape = match flags & PY_BUF_ND == PY_BUF_ND {
+        (*view).shape = match axes && flags & PY_BUF_ND == PY_BUF_ND {
             true => export.shape.as_mut_ptr(),
             false => std::ptr::null_mut(),
         };
-        (*view).strides = match flags & PY_BUF_STRIDES == PY_BUF_STRIDES {
+        (*view).strides = match axes && flags & PY_BUF_STRIDES == PY_BUF_STRIDES {
             true => export.strides.as_mut_ptr(),
             false => std::ptr::null_mut(),
         };
@@ -1098,7 +1106,8 @@ pub unsafe extern "C" fn PyMemoryView_FromBuffer(view: *const CPyBuffer) -> *mut
         return std::ptr::null_mut();
     }
     let (_, strides, itemsize, length) = unsafe { geometry(view) };
-    if strides.first() != Some(&itemsize) || unsafe { (*view).ndim } > 1 {
+    let ndim = unsafe { (*view).ndim };
+    if ndim > 1 || (ndim == 1 && strides.first() != Some(&itemsize)) {
         super::pyerrors::set_pending_error(crate::PyError::new(
             crate::PyErrorKind::BufferError,
             "cpyext: only a contiguous one-dimensional Py_buffer becomes a memoryview",

--- a/pyre/pyre-interpreter/src/cpyext/csources.rs
+++ b/pyre/pyre-interpreter/src/cpyext/csources.rs
@@ -19,6 +19,8 @@ unsafe extern "C" {
     fn PyArg_ParseTupleAndKeywords();
     fn PyArg_UnpackTuple();
     fn _PyArg_CheckPositional();
+    fn _PyArg_ParseTupleAndKeywordsFast();
+    fn _PyArg_UnpackKeywords();
     // `src/modsupport.c`
     fn Py_BuildValue();
     fn Py_VaBuildValue();
@@ -45,6 +47,8 @@ pub(super) fn ensure_linked() {
         PyArg_ParseTupleAndKeywords as *const (),
         PyArg_UnpackTuple as *const (),
         _PyArg_CheckPositional as *const (),
+        _PyArg_ParseTupleAndKeywordsFast as *const (),
+        _PyArg_UnpackKeywords as *const (),
         Py_BuildValue as *const (),
         Py_VaBuildValue as *const (),
         PyObject_CallFunction as *const (),

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -48,6 +48,7 @@ pub mod pyobject;
 pub mod pystate;
 pub mod pystrtod;
 pub mod pythonrun;
+pub mod pytime;
 pub mod sequence;
 pub mod setobject;
 pub mod sliceobject;
@@ -846,6 +847,7 @@ pub fn ensure_linked() {
     pystate::ensure_linked();
     pystrtod::ensure_linked();
     pythonrun::ensure_linked();
+    pytime::ensure_linked();
     bytearrayobject::ensure_linked();
     complexobject::ensure_linked();
     cdatetime::ensure_linked();

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -581,6 +581,15 @@ fn finish_init(
             )
         }));
     }
+    // `importdl.c _Py_ext_module_loader_result_from_module`: this is checked
+    // before the uninitialized-object one, so a module that both left an
+    // exception set and came back untyped is reported as the raise.
+    if let Some(pending) = pyerrors::take_pending_error() {
+        return Err(system_error_from_cause(
+            format!("initialization of {name} raised unreported exception"),
+            pending,
+        ));
+    }
     if unsafe { (*result).ob_type.is_null() } {
         return Err(crate::PyError::new(
             crate::PyErrorKind::SystemError,
@@ -832,6 +841,33 @@ pub(super) fn from_c_result(result: *mut CPyObject) -> Result<PyObjectRef, crate
     let value = unsafe { pyobject::from_ref(result) };
     unsafe { pyobject::decref(result) };
     Ok(value)
+}
+
+/// `_PyErr_FormatFromCause`: a `SystemError` carrying `cause` as both its
+/// `__context__` and its `__cause__`.
+///
+/// An extension that reported success while leaving an exception set has
+/// already lost the raise site, so the exception it left behind is the only
+/// description of what went wrong and is chained onto the report rather than
+/// discarded.
+pub(super) fn system_error_from_cause(
+    message: String,
+    mut cause: crate::PyError,
+) -> crate::PyError {
+    let roots = pyre_object::gc_roots::push_roots();
+    let cause_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(cause.to_exc_object());
+    let mut error = crate::PyError::new(crate::PyErrorKind::SystemError, message);
+    let error_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(error.to_exc_object());
+    let w_cause = pyre_object::gc_roots::shadow_stack_get(cause_slot);
+    let w_error = pyre_object::gc_roots::shadow_stack_get(error_slot);
+    unsafe {
+        pyre_object::interp_exceptions::w_exception_set_context(w_error, w_cause);
+        pyre_object::interp_exceptions::w_exception_set_cause(w_error, w_cause);
+        pyre_object::interp_exceptions::w_exception_set_suppress_context(w_error, true);
+    }
+    unsafe { crate::PyError::from_exc_object(w_error) }
 }
 
 /// `_imp.exec_dynamic` — PyPy `cpyext/api.py:exec_extension_module`.

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -412,7 +412,10 @@ fn missing_init_error(name: &str, path: &Path) -> crate::PyError {
         Err(_) => format!("PyInit_{}", name.rsplit('.').next().unwrap_or(name)),
     };
     extension_import_error(
-        format!("function {symbol} not found in library '{}'", path.display()),
+        format!(
+            "function {symbol} not found in library '{}'",
+            path.display()
+        ),
         name,
         path,
     )

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -533,11 +533,10 @@ pub fn load_extension_module(
     match init_result {
         // `create_cpyext_module` returns straight from the multi-phase branch:
         // the definition, not a copied dictionary, is what a later import
-        // rebuilds the module from.
-        InitResult::MultiPhase(_) => crate::importing::set_sys_module(
-            name,
-            pyre_object::gc_roots::shadow_stack_get(module_slot),
-        ),
+        // rebuilds the module from, and `sys.modules` is the importer's to
+        // write -- a caller that only creates the module and executes it
+        // itself must not find the name there.
+        InitResult::MultiPhase(_) => {}
         InitResult::SinglePhase(_) => fixup_extension(
             pyre_object::gc_roots::shadow_stack_get(module_slot),
             name,

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -451,15 +451,17 @@ pub fn load_extension_module(
             )
         })?;
 
-    let found = match lookup_init(handle, name) {
-        Ok(found) => found,
-        Err(error) => {
-            rustpython_host_env::ctypes::drop_library(handle);
-            return Err(error);
-        }
-    };
+    // Every path from here leaves the library loaded, however it fails.  The
+    // handle cache keeps one `dlopen` count per library and hands the same
+    // handle back to a second open, so closing it here unloads the image
+    // outright -- and a multi-phase module never records its path in
+    // `EXTENSIONS`, so a later load of a *different* name out of the same file
+    // reaches this code while the modules the earlier loads built are still
+    // live.  Their types' `tp_traverse` is then a pointer into text nobody has
+    // mapped, which the next minor collection walks.  Upstream keeps the
+    // library on both of these failures.
+    let found = lookup_init(handle, name)?;
     let Some((protocol, address)) = found else {
-        rustpython_host_env::ctypes::drop_library(handle);
         return Err(missing_init_error(name, path));
     };
 
@@ -486,13 +488,7 @@ pub fn load_extension_module(
         }
     };
 
-    let init_result = match answer {
-        Ok(module) => module,
-        Err(error) => {
-            rustpython_host_env::ctypes::drop_library(handle);
-            return Err(error);
-        }
-    };
+    let init_result = answer?;
     let roots = pyre_object::gc_roots::push_roots();
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = roots.pin_root(init_result.module());

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -39,6 +39,7 @@ pub mod longobject;
 pub mod mapping;
 pub mod methodobject;
 pub mod modsupport;
+pub mod namespaceobject;
 pub mod number;
 pub mod object;
 pub mod osmodule;
@@ -848,6 +849,7 @@ pub fn ensure_linked() {
     pystrtod::ensure_linked();
     pythonrun::ensure_linked();
     pytime::ensure_linked();
+    namespaceobject::ensure_linked();
     bytearrayobject::ensure_linked();
     complexobject::ensure_linked();
     cdatetime::ensure_linked();

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -334,23 +334,59 @@ enum InitProtocol {
 }
 
 impl InitProtocol {
-    fn symbol(self, basename: &str) -> String {
-        match self {
-            InitProtocol::Export => format!("PyModExport_{basename}"),
-            InitProtocol::Init => format!("PyInit_{basename}"),
-        }
+    fn symbol(self, basename: &InitName) -> String {
+        let prefix = match (self, basename.non_ascii) {
+            (InitProtocol::Export, false) => "PyModExport_",
+            (InitProtocol::Export, true) => "PyModExportU_",
+            (InitProtocol::Init, false) => "PyInit_",
+            (InitProtocol::Init, true) => "PyInitU_",
+        };
+        format!("{prefix}{}", basename.text)
     }
 }
 
-fn init_basename(name: &str) -> Result<&str, crate::PyError> {
+/// The variable part of a module's export symbol.
+///
+/// PEP 489: a name outside ASCII is spelled in punycode and looked up under
+/// the `U` prefix instead, so the two namespaces cannot collide.
+struct InitName {
+    text: String,
+    non_ascii: bool,
+}
+
+/// `importdl.c get_encoded_name`: the short name, encoded to ASCII where it
+/// can be and to punycode where it cannot.  `-` is punycode's delimiter and is
+/// not a C identifier character, so it becomes `_`.
+fn init_basename(name: &str) -> Result<InitName, crate::PyError> {
     let basename = name.rsplit('.').next().unwrap_or(name);
-    if !basename.is_ascii() {
-        return Err(crate::PyError::new(
-            crate::PyErrorKind::ImportError,
-            format!("non-ASCII cpyext init names are not implemented yet: {basename}"),
-        ));
+    if basename.is_ascii() {
+        return Ok(InitName {
+            text: basename.to_string(),
+            non_ascii: false,
+        });
     }
-    Ok(basename)
+    // `encode_object` reaches the `punycode` codec, which is written in
+    // Python and allocates, so the name it reads is rooted across the call.
+    let roots = pyre_object::gc_roots::push_roots();
+    let basename_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(pyre_object::w_str_new(basename));
+    let encoded = crate::type_methods::encode_object(
+        pyre_object::gc_roots::shadow_stack_get(basename_slot),
+        "punycode",
+        "strict",
+    )?;
+    let text = String::from_utf8(encoded)
+        .map_err(|_| {
+            crate::PyError::new(
+                crate::PyErrorKind::ImportError,
+                format!("punycode encoding of {basename} is not text"),
+            )
+        })?
+        .replace('-', "_");
+    Ok(InitName {
+        text,
+        non_ascii: true,
+    })
 }
 
 /// The entry point an open library publishes.
@@ -361,7 +397,7 @@ fn init_basename(name: &str) -> Result<&str, crate::PyError> {
 fn lookup_init(handle: usize, name: &str) -> Result<Option<(InitProtocol, usize)>, crate::PyError> {
     let basename = init_basename(name)?;
     for protocol in [InitProtocol::Export, InitProtocol::Init] {
-        if let Some(address) = lookup_init_address(handle, &protocol.symbol(basename)) {
+        if let Some(address) = lookup_init_address(handle, &protocol.symbol(&basename)) {
             return Ok(Some((protocol, address)));
         }
     }
@@ -370,13 +406,13 @@ fn lookup_init(handle: usize, name: &str) -> Result<Option<(InitProtocol, usize)
 
 /// What the lookup reports when neither entry point is there.
 fn missing_init_error(name: &str, path: &Path) -> crate::PyError {
-    let basename = name.rsplit('.').next().unwrap_or(name);
+    let symbol = match init_basename(name) {
+        Ok(basename) => InitProtocol::Init.symbol(&basename),
+        // The name could not be encoded at all, so name it as it was written.
+        Err(_) => format!("PyInit_{}", name.rsplit('.').next().unwrap_or(name)),
+    };
     extension_import_error(
-        format!(
-            "function {} not found in library '{}'",
-            InitProtocol::Init.symbol(basename),
-            path.display()
-        ),
+        format!("function {symbol} not found in library '{}'", path.display()),
         name,
         path,
     )

--- a/pyre/pyre-interpreter/src/cpyext/modsupport.rs
+++ b/pyre/pyre-interpreter/src/cpyext/modsupport.rs
@@ -47,6 +47,7 @@ static MODULE_FIELDS: super::ForkMutex<ModuleTable> = super::ForkMutex::new(
 
 pub(super) unsafe fn after_fork_child() {
     unsafe { MODULE_FIELDS.reinit_after_fork() };
+    unsafe { MODULES_BY_INDEX.reinit_after_fork() };
 }
 
 /// The pair a module has recorded, all zero for one that has recorded none.
@@ -84,6 +85,121 @@ fn set_field(module: PyObjectRef, update: impl FnOnce(&mut ModuleFields)) {
 /// and an extension may still hold the address.
 pub(super) fn forget_module_fields(mirror: usize) {
     MODULE_FIELDS.lock().remove(&mirror);
+}
+
+/// The single-phase modules `PyState_AddModule` has filed, one slot per module
+/// index (`MODULES_BY_INDEX` in `import.c`).  Slot 0 is never used, because a
+/// def carries index 0 until `PyModuleDef_Init` stamps it; an empty slot is
+/// upstream's `None`.
+///
+/// A slot owns its reference, as upstream's list does, so a module filed here
+/// outlives every other name for it.
+static MODULES_BY_INDEX: super::ForkMutex<Vec<usize>> = super::ForkMutex::new(Vec::new());
+
+/// The index a def is filed under (`_get_module_index_from_def`).
+unsafe fn module_index(def: *mut CPyModuleDef) -> isize {
+    unsafe { (*def).m_base.m_index }
+}
+
+/// `_modules_by_index_check` — why an index cannot be read or cleared, or
+/// `None` when it can.
+fn modules_by_index_check(table: &[usize], index: isize) -> Option<&'static str> {
+    if index <= 0 {
+        return Some("invalid module index");
+    }
+    if index as usize >= table.len() {
+        return Some("Module index out of bounds.");
+    }
+    None
+}
+
+/// `PyState_FindModule(def)` — the module filed under a def's index, borrowed.
+///
+/// A def with slots is multi-phase and files nothing, so it answers NULL
+/// rather than reading a slot another def could own.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyState_FindModule(def: *mut CPyModuleDef) -> *mut CPyObject {
+    if def.is_null() {
+        return std::ptr::null_mut();
+    }
+    if unsafe { !(*def).m_slots.is_null() } {
+        return std::ptr::null_mut();
+    }
+    let index = unsafe { module_index(def) };
+    let table = MODULES_BY_INDEX.lock();
+    if modules_by_index_check(&table, index).is_some() {
+        return std::ptr::null_mut();
+    }
+    table[index as usize] as *mut CPyObject
+}
+
+/// `PyState_AddModule(module, def)` — file a single-phase module under its
+/// def's index.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyState_AddModule(
+    module: *mut CPyObject,
+    def: *mut CPyModuleDef,
+) -> c_int {
+    if def.is_null() {
+        super::pyerrors::fatal_error(None, "module definition is NULL");
+    }
+    if unsafe { !(*def).m_slots.is_null() } {
+        super::pyerrors::set_pending_error(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            "PyState_AddModule called on module with slots",
+        ));
+        return -1;
+    }
+    let index = unsafe { module_index(def) };
+    let mut table = MODULES_BY_INDEX.lock();
+    if index > 0 && (index as usize) < table.len() && table[index as usize] == module as usize {
+        super::pyerrors::fatal_error(
+            Some("PyState_AddModule"),
+            &format!("module {module:p} already added"),
+        );
+    }
+    // `_modules_by_index_set` asserts a positive index rather than refusing
+    // one: a def reaching here with 0 has skipped `PyModuleDef_Init`, and the
+    // slot it then writes is the one every reader rejects.
+    debug_assert!(index > 0, "PyState_AddModule on an uninitialized def");
+    if table.len() <= index as usize {
+        table.resize(index as usize + 1, 0);
+    }
+    let previous = std::mem::replace(&mut table[index as usize], module as usize);
+    drop(table);
+    unsafe { super::pyobject::incref(module) };
+    if previous != 0 {
+        unsafe { super::pyobject::decref(previous as *mut CPyObject) };
+    }
+    0
+}
+
+/// `PyState_RemoveModule(def)` — empty the slot a def's index owns.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyState_RemoveModule(def: *mut CPyModuleDef) -> c_int {
+    if def.is_null() {
+        unsafe { super::pyerrors::PyErr_BadInternalCall() };
+        return -1;
+    }
+    if unsafe { !(*def).m_slots.is_null() } {
+        super::pyerrors::set_pending_error(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            "PyState_RemoveModule called on module with slots",
+        ));
+        return -1;
+    }
+    let index = unsafe { module_index(def) };
+    let mut table = MODULES_BY_INDEX.lock();
+    if let Some(err) = modules_by_index_check(&table, index) {
+        drop(table);
+        super::pyerrors::fatal_error(None, err);
+    }
+    let previous = std::mem::replace(&mut table[index as usize], 0);
+    drop(table);
+    if previous != 0 {
+        unsafe { super::pyobject::decref(previous as *mut CPyObject) };
+    }
+    0
 }
 
 static NEXT_MODULE_INDEX: AtomicIsize = AtomicIsize::new(1);
@@ -1113,6 +1229,9 @@ pub(super) fn ensure_linked() {
     std::hint::black_box(PyModule_Create2 as *const ());
     std::hint::black_box(PyModule_GetDict as *const ());
     std::hint::black_box(PyModule_GetState as *const ());
+    std::hint::black_box(PyState_AddModule as *const ());
+    std::hint::black_box(PyState_FindModule as *const ());
+    std::hint::black_box(PyState_RemoveModule as *const ());
     std::hint::black_box(PyModule_GetDef as *const ());
     std::hint::black_box(PyModule_AddObject as *const ());
     std::hint::black_box(PyModule_AddObjectRef as *const ());

--- a/pyre/pyre-interpreter/src/cpyext/modsupport.rs
+++ b/pyre/pyre-interpreter/src/cpyext/modsupport.rs
@@ -669,6 +669,19 @@ pub(super) fn create_module_from_def_and_spec(
             call(spec_ref, def)
         };
         unsafe { pyobject::decref(spec_ref) };
+        // `moduleobject.c PyModule_FromDefAndSpec2`: a create slot that answered
+        // a module while leaving an exception set reported a success it did not
+        // have.  `from_c_result` would report that as an anonymous
+        // `SystemError`, so the module's name and the raise are kept here.
+        if !result.is_null()
+            && let Some(pending) = pyerrors::take_pending_error()
+        {
+            unsafe { pyobject::decref(result) };
+            return Err(super::system_error_from_cause(
+                format!("creation of module {name} raised unreported exception"),
+                pending,
+            ));
+        }
         super::from_c_result(result)?
     };
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
@@ -758,13 +771,13 @@ fn exec_def_of(module: PyObjectRef, def: *mut CPyModuleDef) -> Result<(), crate:
                     )
                 }));
             }
-            if pyerrors::take_pending_error().is_some() {
-                return Err(crate::PyError::new(
-                    crate::PyErrorKind::SystemError,
+            if let Some(pending) = pyerrors::take_pending_error() {
+                return Err(super::system_error_from_cause(
                     format!(
                         "execution of module {} raised unreported exception",
                         text_or_empty(unsafe { (*def).m_name })
                     ),
+                    pending,
                 ));
             }
         }

--- a/pyre/pyre-interpreter/src/cpyext/namespaceobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/namespaceobject.rs
@@ -1,0 +1,50 @@
+//! `types.SimpleNamespace` seen from C -- `Objects/namespaceobject.c`.
+//!
+//! Only the constructor is exported. It is private API, so an extension that
+//! calls it is built against the interpreter's own headers; the two test
+//! modules `test_importlib` gates on are exactly that, and both use it to hand
+//! back an attribute bag rather than a dict.
+
+use super::pyobject::{self, CPyObject};
+
+/// `_PyNamespace_New(kwds)` -- a fresh namespace whose dictionary starts as a
+/// copy of `kwds`, or empty when `kwds` is NULL.
+///
+/// Answers a new reference, or NULL with the exception set.
+///
+/// # Safety
+/// `kwds` must be null or a live mirror of a mapping.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn _PyNamespace_New(kwds: *mut CPyObject) -> *mut CPyObject {
+    let namespace = match crate::module::sys::vm::new_simple_namespace_instance() {
+        Ok(namespace) => namespace,
+        Err(error) => {
+            super::pyerrors::set_pending_error(error);
+            return std::ptr::null_mut();
+        }
+    };
+    if kwds.is_null() {
+        return pyobject::make_ref(namespace);
+    }
+    // Realizing `kwds` and reading the namespace's dictionary both allocate,
+    // and the namespace is a moving object held only by this local.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let namespace_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(namespace);
+    let source = unsafe { pyobject::from_ref(kwds) };
+    let _ = pyre_object::gc_roots::pin_root(source);
+    let namespace = pyre_object::gc_roots::shadow_stack_get(namespace_slot);
+    let dict = crate::baseobjspace::getdict_native(namespace);
+    let _ = pyre_object::gc_roots::pin_root(dict);
+    let source = pyre_object::gc_roots::shadow_stack_get(namespace_slot + 1);
+    let dict = pyre_object::gc_roots::shadow_stack_get(namespace_slot + 2);
+    if let Err(error) = crate::opcode_ops::dict_update_value(dict, source) {
+        super::pyerrors::set_pending_error(error);
+        return std::ptr::null_mut();
+    }
+    pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(namespace_slot))
+}
+
+pub(super) fn ensure_linked() {
+    std::hint::black_box(_PyNamespace_New as *const ());
+}

--- a/pyre/pyre-interpreter/src/cpyext/pytime.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pytime.rs
@@ -1,0 +1,98 @@
+//! The `PyTime_t` clock API.
+//!
+//! `PyTime_t` counts nanoseconds in a signed 64-bit integer. The entry points
+//! answer 0 and store through `result` on success, -1 otherwise; the `Raw`
+//! half differs only in leaving no exception set. pyre's clocks cannot fail,
+//! so every one of them answers 0 — and each reads the same source its
+//! `time` module counterpart does, which is what keeps `PyTime_Monotonic` and
+//! `time.monotonic_ns()` on one timeline.
+
+use std::ffi::{c_double, c_int};
+
+use crate::module::time::interp_time;
+
+/// A count of nanoseconds.
+#[allow(non_camel_case_types)]
+pub type PyTime_t = i64;
+
+/// Nanoseconds in a second, the divisor `PyTime_AsSecondsDouble` splits on.
+const SEC_TO_NS: PyTime_t = 1_000_000_000;
+
+fn monotonic() -> PyTime_t {
+    interp_time::monotonic_nanos() as PyTime_t
+}
+
+fn wall_clock() -> PyTime_t {
+    interp_time::duration_since_epoch().as_nanos() as PyTime_t
+}
+
+/// `PyTime_AsSecondsDouble(t)` — nanoseconds as seconds.
+///
+/// A whole number of seconds is converted from the second count rather than
+/// from the nanosecond one, so a timestamp that is exact stays exact instead
+/// of picking up the rounding of a division by 1e9.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyTime_AsSecondsDouble(t: PyTime_t) -> c_double {
+    if t % SEC_TO_NS == 0 {
+        (t / SEC_TO_NS) as c_double
+    } else {
+        (t as c_double) / 1e9
+    }
+}
+
+/// `PyTime_Monotonic(result)` — a clock that cannot go backwards.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyTime_Monotonic(result: *mut PyTime_t) -> c_int {
+    unsafe { store(result, monotonic()) }
+}
+
+/// `PyTime_MonotonicRaw(result)`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyTime_MonotonicRaw(result: *mut PyTime_t) -> c_int {
+    unsafe { store(result, monotonic()) }
+}
+
+/// `PyTime_PerfCounter(result)` — the highest-resolution clock available,
+/// which is the monotonic one here, as `time.perf_counter_ns()` also reads.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyTime_PerfCounter(result: *mut PyTime_t) -> c_int {
+    unsafe { store(result, monotonic()) }
+}
+
+/// `PyTime_PerfCounterRaw(result)`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyTime_PerfCounterRaw(result: *mut PyTime_t) -> c_int {
+    unsafe { store(result, monotonic()) }
+}
+
+/// `PyTime_Time(result)` — nanoseconds since the epoch.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyTime_Time(result: *mut PyTime_t) -> c_int {
+    unsafe { store(result, wall_clock()) }
+}
+
+/// `PyTime_TimeRaw(result)`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyTime_TimeRaw(result: *mut PyTime_t) -> c_int {
+    unsafe { store(result, wall_clock()) }
+}
+
+/// Write a reading back, answering the 0 every clock here returns.
+///
+/// A null `result` is the caller's error and reaches no clock: the entry
+/// points are declared to take a pointer to write through, and upstream
+/// dereferences it unconditionally.
+unsafe fn store(result: *mut PyTime_t, value: PyTime_t) -> c_int {
+    unsafe { *result = value };
+    0
+}
+
+pub(super) fn ensure_linked() {
+    std::hint::black_box(PyTime_AsSecondsDouble as *const ());
+    std::hint::black_box(PyTime_Monotonic as *const ());
+    std::hint::black_box(PyTime_MonotonicRaw as *const ());
+    std::hint::black_box(PyTime_PerfCounter as *const ());
+    std::hint::black_box(PyTime_PerfCounterRaw as *const ());
+    std::hint::black_box(PyTime_Time as *const ());
+    std::hint::black_box(PyTime_TimeRaw as *const ());
+}

--- a/pyre/pyre-interpreter/src/cpyext/src/getargs.c
+++ b/pyre/pyre-interpreter/src/cpyext/src/getargs.c
@@ -661,3 +661,377 @@ int PyArg_UnpackTuple(PyObject *args, const char *name,
     va_end(va);
     return 1;
 }
+
+/* --- the `_PyArg_Parser` API ------------------------------------------- */
+
+/* `getargs.c scan_keywords`: the leading empty names are the positional-only
+   parameters, and one appearing later is a table nobody can look a keyword up
+   in. */
+static int scan_keywords(const char * const *keywords, int *ptotal, int *pposonly)
+{
+    int i;
+    for (i = 0; keywords[i] && !*keywords[i]; i++) {
+    }
+    *pposonly = i;
+
+    for (; keywords[i]; i++) {
+        if (!*keywords[i]) {
+            PyErr_SetString(PyExc_SystemError, "Empty keyword parameter name");
+            return -1;
+        }
+    }
+    *ptotal = i;
+    return 0;
+}
+
+/* `getargs.c new_kwtuple`: the names past the positional-only ones, interned
+   so that the lookup below is nearly always the pointer comparison. */
+static PyObject *_PyPyre_NewKwtuple(const char * const *keywords, int total, int pos)
+{
+    int nkw = total - pos;
+    PyObject *kwtuple = PyTuple_New(nkw);
+    if (kwtuple == NULL) {
+        return NULL;
+    }
+    keywords += pos;
+    for (int i = 0; i < nkw; i++) {
+        PyObject *str = PyUnicode_InternFromString(keywords[i]);
+        if (str == NULL) {
+            Py_DECREF(kwtuple);
+            return NULL;
+        }
+        PyTuple_SET_ITEM(kwtuple, i, str);
+    }
+    return kwtuple;
+}
+
+/* The name an error message calls the parser's function, and the `;` message
+   that replaces the whole of one.  A format carries both after its units, and
+   a parser Clinic wrote carries `fname` already. */
+static void _PyPyre_ParserNames(const char *format, const char **pfname,
+                                const char **pcustommsg)
+{
+    const char *fname = strchr(format, ':');
+    if (fname != NULL) {
+        *pfname = fname + 1;
+        *pcustommsg = NULL;
+        return;
+    }
+    const char *custommsg = strchr(format, ';');
+    *pfname = NULL;
+    *pcustommsg = custommsg != NULL ? custommsg + 1 : NULL;
+}
+
+#define _PyPyre_ONCE_INITIALIZED 2
+
+/* `getargs.c parser_init` behind `_PyOnceFlag_CallOnce`: work the keyword
+   table out once, and let a call that failed be retried by the next one.
+   Every Python thread runs under one lock, so the flag orders the parsers a
+   thread hands off rather than two threads racing inside one. */
+static int parser_init(struct _PyArg_Parser *parser)
+{
+    if (__atomic_load_n(&parser->once.v, __ATOMIC_ACQUIRE)
+            == _PyPyre_ONCE_INITIALIZED) {
+        return 0;
+    }
+
+    const char * const *keywords = parser->keywords;
+    if (keywords == NULL) {
+        PyErr_BadInternalCall();
+        return -1;
+    }
+
+    int len, pos;
+    if (scan_keywords(keywords, &len, &pos) < 0) {
+        return -1;
+    }
+
+    const char *fname = parser->fname, *custommsg = NULL;
+    if (parser->format != NULL) {
+        _PyPyre_ParserNames(parser->format, &fname, &custommsg);
+    }
+
+    PyObject *kwtuple = parser->kwtuple;
+    int owned = 0;
+    if (kwtuple == NULL) {
+        kwtuple = _PyPyre_NewKwtuple(keywords, len, pos);
+        if (kwtuple == NULL) {
+            return -1;
+        }
+        owned = 1;
+    }
+
+    parser->pos = pos;
+    parser->fname = fname;
+    parser->custom_msg = custommsg;
+    parser->kwtuple = kwtuple;
+    parser->is_kwtuple_owned = owned;
+    __atomic_store_n(&parser->once.v, _PyPyre_ONCE_INITIALIZED, __ATOMIC_RELEASE);
+    return 0;
+}
+
+/* `getargs.c find_keyword`: a keyword's value out of a vectorcall's name
+   tuple.  Both keys are interned, so the first pass finds nearly every one;
+   the second is for the caller that passed a name it built itself. */
+static PyObject *find_keyword(PyObject *kwnames, PyObject *const *kwstack,
+                              PyObject *key)
+{
+    Py_ssize_t nkwargs = PyTuple_GET_SIZE(kwnames);
+    for (Py_ssize_t i = 0; i < nkwargs; i++) {
+        if (PyTuple_GET_ITEM(kwnames, i) == key) {
+            return Py_NewRef(kwstack[i]);
+        }
+    }
+    for (Py_ssize_t i = 0; i < nkwargs; i++) {
+        int equal = PyObject_RichCompareBool(PyTuple_GET_ITEM(kwnames, i), key, Py_EQ);
+        if (equal < 0) {
+            return NULL;
+        }
+        if (equal) {
+            return Py_NewRef(kwstack[i]);
+        }
+    }
+    return NULL;
+}
+
+/* `getargs.c error_unexpected_keyword_arg`: name the keyword that belongs to
+   no parameter.  Reached only once a count has already ruled the call out, so
+   one of the names below is always the offending one. */
+static void _PyPyre_ErrorUnexpectedKeyword(PyObject *kwargs, PyObject *kwnames,
+                                           PyObject *kwtuple, const char *fname)
+{
+    Py_ssize_t j = 0;
+    while (1) {
+        PyObject *keyword;
+        if (kwargs != NULL) {
+            if (!PyDict_Next(kwargs, &j, &keyword, NULL)) {
+                break;
+            }
+        }
+        else {
+            if (j >= PyTuple_GET_SIZE(kwnames)) {
+                break;
+            }
+            keyword = PyTuple_GET_ITEM(kwnames, j);
+            j++;
+        }
+        if (!PyUnicode_Check(keyword)) {
+            PyErr_SetString(PyExc_TypeError, "keywords must be strings");
+            return;
+        }
+        int match = PySequence_Contains(kwtuple, keyword);
+        if (match < 0) {
+            return;
+        }
+        if (!match) {
+            PyErr_Format(PyExc_TypeError,
+                         "%.200s%s got an unexpected keyword argument '%S'",
+                         (fname == NULL) ? "this function" : fname,
+                         (fname == NULL) ? "" : "()",
+                         keyword);
+            return;
+        }
+    }
+    /* Extraneous keywords, and none of them is the one -- which the counts
+       above already proved cannot happen; say so without naming a name. */
+    PyErr_Format(PyExc_TypeError, "invalid keyword argument for %.200s%s",
+                 (fname == NULL) ? "this function" : fname,
+                 (fname == NULL) ? "" : "()");
+}
+
+#undef _PyArg_UnpackKeywords
+
+PyObject * const *_PyArg_UnpackKeywords(PyObject *const *args, Py_ssize_t nargs,
+                                        PyObject *kwargs, PyObject *kwnames,
+                                        struct _PyArg_Parser *parser,
+                                        int minpos, int maxpos, int minkw,
+                                        int varpos, PyObject **buf)
+{
+    PyObject *kwtuple;
+    PyObject *keyword;
+    int i, posonly, minposonly, maxargs;
+    int reqlimit = minkw ? maxpos + minkw : minpos;
+    Py_ssize_t nkwargs;
+    PyObject * const *kwstack = NULL;
+
+    if (parser == NULL) {
+        PyErr_BadInternalCall();
+        return NULL;
+    }
+    if (kwnames != NULL && !PyTuple_Check(kwnames)) {
+        PyErr_BadInternalCall();
+        return NULL;
+    }
+    if (args == NULL && nargs == 0) {
+        args = buf;
+    }
+    if (parser_init(parser) < 0) {
+        return NULL;
+    }
+
+    kwtuple = parser->kwtuple;
+    posonly = parser->pos;
+    minposonly = Py_MIN(posonly, minpos);
+    maxargs = posonly + (int)PyTuple_GET_SIZE(kwtuple);
+
+    if (kwargs != NULL) {
+        nkwargs = PyDict_GET_SIZE(kwargs);
+    }
+    else if (kwnames != NULL) {
+        nkwargs = PyTuple_GET_SIZE(kwnames);
+        kwstack = args + nargs;
+    }
+    else {
+        nkwargs = 0;
+    }
+    if (nkwargs == 0 && minkw == 0 && minpos <= nargs && (varpos || nargs <= maxpos)) {
+        /* Fast path. */
+        return args;
+    }
+    if (!varpos && nargs + nkwargs > maxargs) {
+        /* Saying "keyword" when nargs == 0 keeps the count from reading as a
+           bound on positional arguments the callable does not take. */
+        PyErr_Format(PyExc_TypeError,
+                     "%.200s%s takes at most %d %sargument%s (%zd given)",
+                     (parser->fname == NULL) ? "function" : parser->fname,
+                     (parser->fname == NULL) ? "" : "()",
+                     maxargs,
+                     (nargs == 0) ? "keyword " : "",
+                     (maxargs == 1) ? "" : "s",
+                     nargs + nkwargs);
+        return NULL;
+    }
+    if (!varpos && nargs > maxpos) {
+        if (maxpos == 0) {
+            PyErr_Format(PyExc_TypeError,
+                         "%.200s%s takes no positional arguments",
+                         (parser->fname == NULL) ? "function" : parser->fname,
+                         (parser->fname == NULL) ? "" : "()");
+        }
+        else {
+            PyErr_Format(PyExc_TypeError,
+                         "%.200s%s takes %s %d positional argument%s (%zd given)",
+                         (parser->fname == NULL) ? "function" : parser->fname,
+                         (parser->fname == NULL) ? "" : "()",
+                         (minpos < maxpos) ? "at most" : "exactly",
+                         maxpos,
+                         (maxpos == 1) ? "" : "s",
+                         nargs);
+        }
+        return NULL;
+    }
+    if (nargs < minposonly) {
+        PyErr_Format(PyExc_TypeError,
+                     "%.200s%s takes %s %d positional argument%s (%zd given)",
+                     (parser->fname == NULL) ? "function" : parser->fname,
+                     (parser->fname == NULL) ? "" : "()",
+                     (varpos || minposonly < maxpos) ? "at least" : "exactly",
+                     minposonly,
+                     minposonly == 1 ? "" : "s",
+                     nargs);
+        return NULL;
+    }
+
+    if (varpos) {
+        nargs = Py_MIN(maxpos, nargs);
+    }
+    /* copy tuple args */
+    for (i = 0; i < nargs; i++) {
+        buf[i] = args[i];
+    }
+
+    /* copy keyword args using kwtuple to drive process */
+    for (i = Py_MAX((int)nargs, posonly); i < maxargs; i++) {
+        PyObject *current_arg;
+        if (nkwargs) {
+            keyword = PyTuple_GET_ITEM(kwtuple, i - posonly);
+            if (kwargs != NULL) {
+                if (PyDict_GetItemRef(kwargs, keyword, &current_arg) < 0) {
+                    return NULL;
+                }
+            }
+            else {
+                current_arg = find_keyword(kwnames, kwstack, keyword);
+                if (current_arg == NULL && PyErr_Occurred()) {
+                    return NULL;
+                }
+            }
+        }
+        else if (i >= reqlimit) {
+            break;
+        }
+        else {
+            current_arg = NULL;
+        }
+
+        buf[i] = current_arg;
+
+        if (current_arg) {
+            Py_DECREF(current_arg);
+            --nkwargs;
+        }
+        else if (i < minpos || (maxpos <= i && i < reqlimit)) {
+            /* Less arguments than required */
+            keyword = PyTuple_GET_ITEM(kwtuple, i - posonly);
+            PyErr_Format(PyExc_TypeError,
+                         "%.200s%s missing required argument '%U' (pos %d)",
+                         (parser->fname == NULL) ? "function" : parser->fname,
+                         (parser->fname == NULL) ? "" : "()",
+                         keyword, i + 1);
+            return NULL;
+        }
+    }
+
+    if (nkwargs > 0) {
+        /* make sure there are no arguments given by name and position */
+        for (i = posonly; i < nargs; i++) {
+            PyObject *current_arg;
+            keyword = PyTuple_GET_ITEM(kwtuple, i - posonly);
+            if (kwargs != NULL) {
+                if (PyDict_GetItemRef(kwargs, keyword, &current_arg) < 0) {
+                    return NULL;
+                }
+            }
+            else {
+                current_arg = find_keyword(kwnames, kwstack, keyword);
+                if (current_arg == NULL && PyErr_Occurred()) {
+                    return NULL;
+                }
+            }
+            if (current_arg) {
+                Py_DECREF(current_arg);
+                PyErr_Format(PyExc_TypeError,
+                             "argument for %.200s%s given by name ('%U') "
+                             "and position (%d)",
+                             (parser->fname == NULL) ? "function" : parser->fname,
+                             (parser->fname == NULL) ? "" : "()",
+                             keyword, i + 1);
+                return NULL;
+            }
+        }
+
+        _PyPyre_ErrorUnexpectedKeyword(kwargs, kwnames, kwtuple, parser->fname);
+        return NULL;
+    }
+
+    return buf;
+}
+
+/* `getargs.c _PyArg_ParseTupleAndKeywordsFast`: the parser carries the format
+   and the keyword table the variadic entry point is handed separately, and
+   the walk over them is the same one. */
+int _PyArg_ParseTupleAndKeywordsFast(PyObject *args, PyObject *kwargs,
+                                     struct _PyArg_Parser *parser, ...)
+{
+    if (parser == NULL || parser->format == NULL || parser->keywords == NULL) {
+        PyErr_BadInternalCall();
+        return 0;
+    }
+    va_list va;
+    va_start(va, parser);
+    int parsed = _PyPyre_VaParse(args, kwargs, parser->format,
+                                 (PY_CXX_CONST char *const *)parser->keywords,
+                                 &va, NULL);
+    va_end(va);
+    return parsed;
+}

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -4848,9 +4848,8 @@ fn slot_delattro(slot: *const c_void, args: &[PyObjectRef]) -> Result<PyObjectRe
 /// `PyObject_GetAttr` and `PyObject_SetAttr` raise before the call.
 fn legacy_attribute_name(name: PyObjectRef) -> Result<std::ffi::CString, crate::PyError> {
     let text = crate::baseobjspace::text_w(name)?;
-    std::ffi::CString::new(text).map_err(|_| {
-        crate::PyError::value_error("attribute name must not contain null characters")
-    })
+    std::ffi::CString::new(text)
+        .map_err(|_| crate::PyError::value_error("attribute name must not contain null characters"))
 }
 
 fn slot_getattr(slot: *const c_void, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -4535,8 +4535,6 @@ fn inherit_slots(tp: *mut CPyTypeObject, base: *mut CPyTypeObject) {
         tp_hash,
         tp_call,
         tp_str,
-        tp_getattro,
-        tp_setattro,
         tp_traverse,
         tp_clear,
         tp_richcompare,
@@ -4550,7 +4548,20 @@ fn inherit_slots(tp: *mut CPyTypeObject, base: *mut CPyTypeObject) {
         tp_free,
         tp_finalize,
     );
+    // `inherit_slots` takes each legacy attribute hook together with its
+    // object-key twin: a type that filled either one has declared an attribute
+    // hook of its own, and copying the twin over it would cover that hook,
+    // because `PyObject_GetAttr` and `PyObject_SetAttr` reach the legacy slot
+    // only while the twin is null.
     unsafe {
+        if (*tp).tp_getattr.is_null() && (*tp).tp_getattro.is_null() {
+            (*tp).tp_getattr = (*base).tp_getattr;
+            (*tp).tp_getattro = (*base).tp_getattro;
+        }
+        if (*tp).tp_setattr.is_null() && (*tp).tp_setattro.is_null() {
+            (*tp).tp_setattr = (*base).tp_setattr;
+            (*tp).tp_setattro = (*base).tp_setattro;
+        }
         if (*tp).tp_basicsize == 0 {
             (*tp).tp_basicsize = (*base).tp_basicsize;
         }
@@ -4731,6 +4742,19 @@ fn install_namespace(ns: PyObjectRef, tp: *mut CPyTypeObject) {
             publish(ns, dunder, arity, slot, wrapper);
         }
     }
+    // `slotdefs` carries `TPSLOT(__setattr__, tp_setattr, NULL, NULL, "")` and
+    // publishes no wrapper for it, because `PyObject_SetAttr` reaches the
+    // legacy slot itself once the object-key twin is null.  Attribute access
+    // here resolves the dunder instead, so the fallback is a wrapper.
+    unsafe {
+        if (*tp).tp_getattro.is_null() && !(*tp).tp_getattr.is_null() {
+            publish(ns, "__getattribute__", 2, (*tp).tp_getattr, slot_getattr);
+        }
+        if (*tp).tp_setattro.is_null() && !(*tp).tp_setattr.is_null() {
+            publish(ns, "__setattr__", 3, (*tp).tp_setattr, slot_setattr);
+            publish(ns, "__delattr__", 2, (*tp).tp_setattr, slot_delattr);
+        }
+    }
     // The deletion shares its slot with the assignment above and goes in with
     // it, there being no spelling for a type that has only one of them.
     let descr_set = unsafe { (*tp).tp_descr_set };
@@ -4817,6 +4841,78 @@ fn slot_setattro(slot: *const c_void, args: &[PyObjectRef]) -> Result<PyObjectRe
 
 fn slot_delattro(slot: *const c_void, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     set_attribute(slot, args[0], args[1], None)
+}
+
+/// `tp_getattr` and `tp_setattr` take the name as a `char *`, so a name that is
+/// not text or carries a NUL cannot be handed over -- the refusals
+/// `PyObject_GetAttr` and `PyObject_SetAttr` raise before the call.
+fn legacy_attribute_name(name: PyObjectRef) -> Result<std::ffi::CString, crate::PyError> {
+    let text = crate::baseobjspace::text_w(name)?;
+    std::ffi::CString::new(text).map_err(|_| {
+        crate::PyError::value_error("attribute name must not contain null characters")
+    })
+}
+
+fn slot_getattr(slot: *const c_void, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let name = legacy_attribute_name(args[1])?;
+    let roots = pyre_object::gc_roots::push_roots();
+    let receiver_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(args[0]);
+    let receiver = pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(receiver_slot));
+    let result = unsafe {
+        let call: unsafe extern "C" fn(*mut CPyObject, *mut std::ffi::c_char) -> *mut CPyObject =
+            std::mem::transmute(slot);
+        call(receiver, name.as_ptr().cast_mut())
+    };
+    unsafe { pyobject::decref(receiver) };
+    super::from_c_result(result)
+}
+
+/// The legacy assignment, with a NULL value for the deletion as `tp_setattro`
+/// has.
+fn set_attribute_legacy(
+    slot: *const c_void,
+    w_self: PyObjectRef,
+    name: PyObjectRef,
+    value: Option<PyObjectRef>,
+) -> Result<PyObjectRef, crate::PyError> {
+    let name = legacy_attribute_name(name)?;
+    let roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(w_self);
+    let _ = roots.pin_root(value.unwrap_or_else(pyre_object::w_none));
+    let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
+    let receiver = pyobject::make_ref(reload(0));
+    let item = match value {
+        Some(_) => pyobject::make_ref(reload(1)),
+        None => std::ptr::null_mut(),
+    };
+    let result = unsafe {
+        let call: unsafe extern "C" fn(
+            *mut CPyObject,
+            *mut std::ffi::c_char,
+            *mut CPyObject,
+        ) -> c_int = std::mem::transmute(slot);
+        call(receiver, name.as_ptr().cast_mut(), item)
+    };
+    unsafe {
+        pyobject::decref(receiver);
+        pyobject::decref(item);
+    }
+    if result != 0 {
+        return Err(pending_or(
+            "a cpyext attribute assignment failed without setting an exception",
+        ));
+    }
+    Ok(pyre_object::w_none())
+}
+
+fn slot_setattr(slot: *const c_void, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    set_attribute_legacy(slot, args[0], args[1], Some(args[2]))
+}
+
+fn slot_delattr(slot: *const c_void, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    set_attribute_legacy(slot, args[0], args[1], None)
 }
 
 /// `tp_descr_get(self, obj, type)` — `obj` is NULL for a class access.

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -4352,6 +4352,15 @@ fn load_part(
                 &pathname,
                 pyre_object::gc_roots::shadow_stack_get(module_slot),
             )?;
+            // `_bootstrap._load` writes `sys.modules[spec.name]` between
+            // `create_module` and `exec_module`, and the single-phase branch of
+            // the load above has already registered its own module.  Registering
+            // here is what lets a slot that imports its own module find it,
+            // which is why the source loader does the same before executing.
+            set_sys_module(
+                modulename,
+                pyre_object::gc_roots::shadow_stack_get(module_slot),
+            );
             // `_imp.create_dynamic` leaves the second PEP 489 phase to
             // importlib's `_imp.exec_dynamic`; this importer runs both, so the
             // exec slots run here, after `__spec__` is in place.
@@ -4396,6 +4405,11 @@ fn load_part(
                 unsafe { pyre_object::w_module_get_w_dict(module) },
                 "__path__",
                 pyre_object::gc_roots::shadow_stack_get(list_slot),
+            );
+            // Registered before the exec phase, as in the file branch above.
+            set_sys_module(
+                modulename,
+                pyre_object::gc_roots::shadow_stack_get(module_slot),
             );
             // The exec phase runs after `__spec__` and `__path__`, for the same
             // reason it does in the file branch above.

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -795,7 +795,10 @@ fn init_string_module(ns: PyObjectRef) {
             let parsed = FormatString::from_str(body)
                 .map_err(|_| crate::PyError::value_error("bad format string"))?;
 
-            let mut tuples = Vec::new();
+            // Every tuple, and every string inside it, is freshly allocated and
+            // the next allocation can collect, so each is pinned as it arrives;
+            // the conversion is built last so the pin order is the element order.
+            let mut tuples = pyre_object::gc_roots::RootedItems::new();
             let mut pending: Option<Wtf8Buf> = None;
             for part in parsed.format_parts {
                 match part {
@@ -806,28 +809,36 @@ fn init_string_module(ns: PyObjectRef) {
                         format_spec,
                     } => {
                         let literal = pending.take().unwrap_or_default();
-                        let conversion = match conversion_spec {
-                            Some(c) => pyre_object::w_str_new(&c.to_char_lossy().to_string()),
-                            None => pyre_object::w_none(),
+                        // The tuple's own bracket closes before `tuples` takes
+                        // it: both address the same shadow stack, so an inner
+                        // set still open holds the slots the outer one claims.
+                        let entry = {
+                            let mut fields = pyre_object::gc_roots::RootedItems::new();
+                            fields.push(pyre_object::w_str_from_wtf8(literal));
+                            fields.push(pyre_object::w_str_from_wtf8(field_name));
+                            fields.push(pyre_object::w_str_from_wtf8(format_spec));
+                            fields.push(match conversion_spec {
+                                Some(c) => pyre_object::w_str_new(&c.to_char_lossy().to_string()),
+                                None => pyre_object::w_none(),
+                            });
+                            pyre_object::w_tuple_new(fields.take())
                         };
-                        tuples.push(pyre_object::w_tuple_new(vec![
-                            pyre_object::w_str_from_wtf8(literal),
-                            pyre_object::w_str_from_wtf8(field_name),
-                            pyre_object::w_str_from_wtf8(format_spec),
-                            conversion,
-                        ]));
+                        tuples.push(entry);
                     }
                 }
             }
             if let Some(text) = pending {
-                tuples.push(pyre_object::w_tuple_new(vec![
-                    pyre_object::w_str_from_wtf8(text),
-                    pyre_object::w_none(),
-                    pyre_object::w_none(),
-                    pyre_object::w_none(),
-                ]));
+                let entry = {
+                    let mut fields = pyre_object::gc_roots::RootedItems::new();
+                    fields.push(pyre_object::w_str_from_wtf8(text));
+                    fields.push(pyre_object::w_none());
+                    fields.push(pyre_object::w_none());
+                    fields.push(pyre_object::w_none());
+                    pyre_object::w_tuple_new(fields.take())
+                };
+                tuples.push(entry);
             }
-            Ok(pyre_object::w_list_new(tuples))
+            Ok(pyre_object::w_list_new(tuples.take()))
         }),
     );
     crate::module_ns_store(

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -2039,11 +2039,13 @@ fn array_get_slice(obj: PyObjectRef, meta: &ArrayMeta, slice: PyObjectRef) -> Py
         }
         return Ok(pyre_object::w_str_new(&value));
     }
-    let mut items = Vec::with_capacity(idxs.len());
+    // Each element is freshly boxed and the next index allocates again, so they
+    // are pinned as they arrive.
+    let mut items = pyre_object::gc_roots::RootedItems::new();
     for i in idxs {
         items.push(array_get_index(obj, meta, i)?);
     }
-    Ok(pyre_object::w_list_new(items))
+    Ok(pyre_object::w_list_new(items.take()))
 }
 
 fn array_set_slice(
@@ -2406,13 +2408,15 @@ fn pointer_getitem(args: &[PyObjectRef]) -> PyResult {
             crate::sliceobject::eval_slice_index(start_obj)?
         };
         let stop = crate::sliceobject::eval_slice_index(stop_obj)?;
-        let mut values = Vec::new();
+        // Each element is freshly allocated and the next index allocates again,
+        // so they are pinned as they arrive.
+        let mut values = pyre_object::gc_roots::RootedItems::new();
         let mut index = start;
         while if step > 0 { index < stop } else { index > stop } {
             values.push(pointer_get_index(obj, index as isize)?);
             index = index.saturating_add(step);
         }
-        return Ok(pyre_object::w_list_new(values));
+        return Ok(pyre_object::w_list_new(values.take()));
     }
     if !unsafe { pyre_object::is_int(key) } {
         return Err(crate::PyError::type_error(

--- a/pyre/pyre-interpreter/src/module/_opcode/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_opcode/mod.rs
@@ -115,11 +115,19 @@ fn get_intrinsic2_descs(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
 }
 
 fn get_nb_ops(_: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Ok(w_list_new(
-        oparg::BinaryOperator::iter()
-            .map(|value| w_tuple_new(vec![w_str_new(value.desc()), w_str_new(&value.to_string())]))
-            .collect(),
-    ))
+    // Each name string and each pair tuple is freshly allocated, so both levels
+    // pin as they arrive; the inner bracket closes before its tuple is pinned.
+    let mut rows = pyre_object::gc_roots::RootedItems::new();
+    for value in oparg::BinaryOperator::iter() {
+        let row = {
+            let mut names = pyre_object::gc_roots::RootedItems::new();
+            names.push(w_str_new(value.desc()));
+            names.push(w_str_new(&value.to_string()));
+            w_tuple_new(names.take())
+        };
+        rows.push(row);
+    }
+    Ok(w_list_new(rows.take()))
 }
 
 fn special_method_names_impl() -> PyObjectRef {

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -1574,27 +1574,35 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if head.is_null() {
                         return Err(socket_last_error());
                     }
-                    let mut items = Vec::new();
+                    // Every field and entry is freshly allocated and the next
+                    // one allocates again, so each is pinned as it is produced
+                    // (`build_list_storage`).  The field bracket closes before
+                    // its tuple joins the outer one: the pins share one stack
+                    // and must unwind in order.
+                    let mut items = pyre_object::gc_roots::RootedItems::new();
                     let mut p = head;
                     unsafe {
                         while (*p).if_index != 0 && !(*p).if_name.is_null() {
-                            // An interface name is an OS string: `dev_valid_name`
-                            // rejects only NUL, '/', ':', whitespace, '.' and
-                            // '..', so any other octet is legal.  The sibling
-                            // `if_nametoindex` below fsencodes, so decoding
-                            // here any other way breaks the round trip.
-                            let name = crate::gateway::fsdecode_filename_bytes(
-                                std::ffi::CStr::from_ptr((*p).if_name).to_bytes(),
-                            );
-                            items.push(pyre_object::w_tuple_new(vec![
-                                pyre_object::w_int_new((*p).if_index as i64),
-                                name,
-                            ]));
+                            let entry = {
+                                let mut fields = pyre_object::gc_roots::RootedItems::new();
+                                fields.push(pyre_object::w_int_new((*p).if_index as i64));
+                                // An interface name is an OS string:
+                                // `dev_valid_name` rejects only NUL, '/', ':',
+                                // whitespace, '.' and '..', so any other octet
+                                // is legal.  The sibling `if_nametoindex` below
+                                // fsencodes, so decoding here any other way
+                                // breaks the round trip.
+                                fields.push(crate::gateway::fsdecode_filename_bytes(
+                                    std::ffi::CStr::from_ptr((*p).if_name).to_bytes(),
+                                ));
+                                pyre_object::w_tuple_new(fields.take())
+                            };
+                            items.push(entry);
                             p = p.add(1);
                         }
                         libc::if_freenameindex(head);
                     }
-                    Ok(pyre_object::w_list_new(items))
+                    Ok(pyre_object::w_list_new(items.take()))
                 },
                 0,
             ),
@@ -2209,7 +2217,12 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                 return Err(socket_converted_error("gaierror", Some(rc), &msg));
             }
 
-            let mut items = Vec::new();
+            // Every field and entry is freshly allocated and the next lap
+            // allocates again, so each is pinned as it is produced
+            // (`build_list_storage`).  The field bracket closes before its
+            // tuple joins the outer one: the pins share one stack and must
+            // unwind in order.
+            let mut items = pyre_object::gc_roots::RootedItems::new();
             let mut cur = res;
             unsafe {
                 while !cur.is_null() {
@@ -2231,19 +2244,21 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                         &mut storage as *mut _ as *mut u8,
                         copy_len,
                     );
-                    let addr = unpack_inet_addr(&storage, copy_len as rffi::SockLen);
-                    items.push(pyre_object::w_tuple_new(vec![
-                        pyre_object::w_int_new(ai.ai_family as i64),
-                        pyre_object::w_int_new(ai.ai_socktype as i64),
-                        pyre_object::w_int_new(ai.ai_protocol as i64),
-                        pyre_object::w_str_new(&canon),
-                        addr,
-                    ]));
+                    let entry = {
+                        let mut fields = pyre_object::gc_roots::RootedItems::new();
+                        fields.push(pyre_object::w_int_new(ai.ai_family as i64));
+                        fields.push(pyre_object::w_int_new(ai.ai_socktype as i64));
+                        fields.push(pyre_object::w_int_new(ai.ai_protocol as i64));
+                        fields.push(pyre_object::w_str_new(&canon));
+                        fields.push(unpack_inet_addr(&storage, copy_len as rffi::SockLen));
+                        pyre_object::w_tuple_new(fields.take())
+                    };
+                    items.push(entry);
                     cur = ai.ai_next;
                 }
                 rffi::freeaddrinfo(res);
             }
-            Ok(pyre_object::w_list_new(items))
+            Ok(pyre_object::w_list_new(items.take()))
         }),
     );
 
@@ -4672,8 +4687,12 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             data.truncate(got as usize);
 
             // Walk ancillary data.  Re-run msghdr with the final
-            // controllen so CMSG_* macros see the trimmed buffer.
-            let mut anc_items = Vec::new();
+            // controllen so CMSG_* macros see the trimmed buffer.  Every field
+            // and cmsg tuple is freshly allocated and the next one allocates
+            // again, so each is pinned as it is produced (`build_list_storage`);
+            // the field bracket closes before its tuple joins the outer one,
+            // because the pins share one stack and must unwind in order.
+            let mut anc_items = pyre_object::gc_roots::RootedItems::new();
             if ancbufsize > 0 {
                 let mut iov = libc::iovec {
                     iov_base: data.as_mut_ptr() as *mut libc::c_void,
@@ -4696,11 +4715,14 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                         let payload_len = total - hdr_size;
                         let payload_ptr = libc::CMSG_DATA(cmsg);
                         let payload = std::slice::from_raw_parts(payload_ptr, payload_len).to_vec();
-                        anc_items.push(pyre_object::w_tuple_new(vec![
-                            pyre_object::w_int_new(header.cmsg_level as i64),
-                            pyre_object::w_int_new(header.cmsg_type as i64),
-                            pyre_object::bytesobject::w_bytes_from_bytes(&payload),
-                        ]));
+                        let entry = {
+                            let mut fields = pyre_object::gc_roots::RootedItems::new();
+                            fields.push(pyre_object::w_int_new(header.cmsg_level as i64));
+                            fields.push(pyre_object::w_int_new(header.cmsg_type as i64));
+                            fields.push(pyre_object::bytesobject::w_bytes_from_bytes(&payload));
+                            pyre_object::w_tuple_new(fields.take())
+                        };
+                        anc_items.push(entry);
                         cmsg = libc::CMSG_NXTHDR(&msg, cmsg);
                     }
                 }
@@ -4708,7 +4730,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             let addr = unpack_inet_addr(&storage, msg_namelen);
             Ok(pyre_object::w_tuple_new(vec![
                 pyre_object::bytesobject::w_bytes_from_bytes(&data),
-                pyre_object::w_list_new(anc_items),
+                pyre_object::w_list_new(anc_items.take()),
                 pyre_object::w_int_new(msg_flags as i64),
                 addr,
             ]))
@@ -4828,7 +4850,12 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 crate::module::signal::interp_signal::checksignals_now()?;
             };
 
-            let mut anc_items = Vec::new();
+            // Every field and cmsg tuple is freshly allocated and the next one
+            // allocates again, so each is pinned as it is produced
+            // (`build_list_storage`); the field bracket closes before its tuple
+            // joins the outer one, because the pins share one stack and must
+            // unwind in order.
+            let mut anc_items = pyre_object::gc_roots::RootedItems::new();
             if ancbufsize > 0 && controllen > 0 {
                 let mut dummy_iov = libc::iovec {
                     iov_base: std::ptr::null_mut(),
@@ -4851,11 +4878,14 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                         let payload_len = total - hdr_size;
                         let payload_ptr = libc::CMSG_DATA(cmsg);
                         let payload = std::slice::from_raw_parts(payload_ptr, payload_len).to_vec();
-                        anc_items.push(pyre_object::w_tuple_new(vec![
-                            pyre_object::w_int_new(header.cmsg_level as i64),
-                            pyre_object::w_int_new(header.cmsg_type as i64),
-                            pyre_object::bytesobject::w_bytes_from_bytes(&payload),
-                        ]));
+                        let entry = {
+                            let mut fields = pyre_object::gc_roots::RootedItems::new();
+                            fields.push(pyre_object::w_int_new(header.cmsg_level as i64));
+                            fields.push(pyre_object::w_int_new(header.cmsg_type as i64));
+                            fields.push(pyre_object::bytesobject::w_bytes_from_bytes(&payload));
+                            pyre_object::w_tuple_new(fields.take())
+                        };
+                        anc_items.push(entry);
                         cmsg = libc::CMSG_NXTHDR(&msg, cmsg);
                     }
                 }
@@ -4863,7 +4893,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             let addr = unpack_inet_addr(&storage, msg_namelen);
             Ok(pyre_object::w_tuple_new(vec![
                 pyre_object::w_int_new(got as i64),
-                pyre_object::w_list_new(anc_items),
+                pyre_object::w_list_new(anc_items.take()),
                 pyre_object::w_int_new(msg_flags as i64),
                 addr,
             ]))

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -278,23 +278,37 @@ fn dict_from_pairs(items: &[(&str, PyObjectRef)]) -> PyObjectRef {
 
 fn decoded_name(cert: *const pyre_native::ssl::DecodedCertificate, subject: bool) -> PyObjectRef {
     let rdn_count = unsafe { pyre_native::ssl::certificate_name_rdn_count(cert, subject) };
-    let mut rdns = Vec::with_capacity(rdn_count);
+    // Every tuple here is freshly allocated and the next allocation can collect,
+    // so each level is pinned as it is produced; an inner bracket closes before
+    // its tuple joins the level above, whose slots would otherwise sit inside it.
+    let mut rdns = pyre_object::gc_roots::RootedItems::new();
     for rdn in 0..rdn_count {
         let attribute_count =
             unsafe { pyre_native::ssl::certificate_name_attribute_count(cert, subject, rdn) };
-        let mut attributes = Vec::with_capacity(attribute_count);
-        for attribute in 0..attribute_count {
-            let key = unsafe {
-                pyre_native::ssl::certificate_name_attribute_key(cert, subject, rdn, attribute)
-            };
-            let value = unsafe {
-                pyre_native::ssl::certificate_name_attribute_value(cert, subject, rdn, attribute)
-            };
-            attributes.push(w_tuple_new(vec![w_str_new(&key), w_str_new(&value)]));
-        }
-        rdns.push(w_tuple_new(attributes));
+        let rdn_tuple = {
+            let mut attributes = pyre_object::gc_roots::RootedItems::new();
+            for attribute in 0..attribute_count {
+                let key = unsafe {
+                    pyre_native::ssl::certificate_name_attribute_key(cert, subject, rdn, attribute)
+                };
+                let value = unsafe {
+                    pyre_native::ssl::certificate_name_attribute_value(
+                        cert, subject, rdn, attribute,
+                    )
+                };
+                let attribute_tuple = {
+                    let mut pair = pyre_object::gc_roots::RootedItems::new();
+                    pair.push(w_str_new(&key));
+                    pair.push(w_str_new(&value));
+                    w_tuple_new(pair.take())
+                };
+                attributes.push(attribute_tuple);
+            }
+            w_tuple_new(attributes.take())
+        };
+        rdns.push(rdn_tuple);
     }
-    w_tuple_new(rdns)
+    w_tuple_new(rdns.take())
 }
 
 fn decoded_directory_name(
@@ -302,25 +316,38 @@ fn decoded_directory_name(
     san: usize,
 ) -> PyObjectRef {
     let rdn_count = unsafe { pyre_native::ssl::certificate_san_directory_rdn_count(cert, san) };
-    let mut rdns = Vec::with_capacity(rdn_count);
+    // Same nesting as `decoded_name`: each level is pinned as it is produced and
+    // an inner bracket closes before its tuple joins the level above.
+    let mut rdns = pyre_object::gc_roots::RootedItems::new();
     for rdn in 0..rdn_count {
         let count =
             unsafe { pyre_native::ssl::certificate_san_directory_attribute_count(cert, san, rdn) };
-        let mut attributes = Vec::with_capacity(count);
-        for attribute in 0..count {
-            let key = unsafe {
-                pyre_native::ssl::certificate_san_directory_attribute_key(cert, san, rdn, attribute)
-            };
-            let value = unsafe {
-                pyre_native::ssl::certificate_san_directory_attribute_value(
-                    cert, san, rdn, attribute,
-                )
-            };
-            attributes.push(w_tuple_new(vec![w_str_new(&key), w_str_new(&value)]));
-        }
-        rdns.push(w_tuple_new(attributes));
+        let rdn_tuple = {
+            let mut attributes = pyre_object::gc_roots::RootedItems::new();
+            for attribute in 0..count {
+                let key = unsafe {
+                    pyre_native::ssl::certificate_san_directory_attribute_key(
+                        cert, san, rdn, attribute,
+                    )
+                };
+                let value = unsafe {
+                    pyre_native::ssl::certificate_san_directory_attribute_value(
+                        cert, san, rdn, attribute,
+                    )
+                };
+                let attribute_tuple = {
+                    let mut pair = pyre_object::gc_roots::RootedItems::new();
+                    pair.push(w_str_new(&key));
+                    pair.push(w_str_new(&value));
+                    w_tuple_new(pair.take())
+                };
+                attributes.push(attribute_tuple);
+            }
+            w_tuple_new(attributes.take())
+        };
+        rdns.push(rdn_tuple);
     }
-    w_tuple_new(rdns)
+    w_tuple_new(rdns.take())
 }
 
 fn decoded_urls(
@@ -368,17 +395,25 @@ fn decoded_certificate_dict(cert: *mut pyre_native::ssl::DecodedCertificate) -> 
     }
     let san_count = unsafe { pyre_native::ssl::certificate_san_count(cert) };
     if san_count != 0 {
-        let mut names = Vec::with_capacity(san_count);
+        // Each name tuple is freshly allocated and the next entry allocates
+        // again, so both the pair and the tuples are pinned as they arrive.
+        let mut names = pyre_object::gc_roots::RootedItems::new();
         for index in 0..san_count {
             let kind = unsafe { pyre_native::ssl::certificate_san_kind(cert, index) };
-            let value = if kind == "DirName" {
-                decoded_directory_name(cert, index)
-            } else {
-                w_str_new(&unsafe { pyre_native::ssl::certificate_san_value(cert, index) })
+            let entry = {
+                let mut pair = pyre_object::gc_roots::RootedItems::new();
+                pair.push(w_str_new(kind));
+                let value = if kind == "DirName" {
+                    decoded_directory_name(cert, index)
+                } else {
+                    w_str_new(&unsafe { pyre_native::ssl::certificate_san_value(cert, index) })
+                };
+                pair.push(value);
+                w_tuple_new(pair.take())
             };
-            names.push(w_tuple_new(vec![w_str_new(kind), value]));
+            names.push(entry);
         }
-        unsafe { w_dict_setitem_str(dict, "subjectAltName", w_tuple_new(names)) };
+        unsafe { w_dict_setitem_str(dict, "subjectAltName", w_tuple_new(names.take())) };
     }
     unsafe { pyre_native::ssl::certificate_free(cert) };
     dict
@@ -998,7 +1033,9 @@ mod context_methods {
             #[default(false)] binary_form: bool,
         ) -> Result<PyObjectRef, crate::PyError> {
             let certs = unsafe { pyre_native::ssl::context_ca_certs(self.backend) };
-            let mut result = Vec::with_capacity(certs.len());
+            // Each entry is freshly allocated and decoding the next one allocates
+            // again, so they are pinned as they arrive.
+            let mut result = pyre_object::gc_roots::RootedItems::new();
             for cert in certs {
                 result.push(if binary_form {
                     w_bytes_from_bytes(&cert)
@@ -1007,7 +1044,7 @@ mod context_methods {
                     decoded_certificate_dict(decoded)
                 });
             }
-            Ok(w_list_new(result))
+            Ok(w_list_new(result.take()))
         }
 
         fn set_ciphers(&mut self, cipherlist: PyObjectRef) -> Result<(), crate::PyError> {
@@ -1023,7 +1060,9 @@ mod context_methods {
         /// filter is visible to configuration auditing rather than only to
         /// connection creation.
         fn get_ciphers(&self) -> PyObjectRef {
-            let mut ciphers = Vec::with_capacity(pyre_native::ssl::cipher_count());
+            // Each dict is freshly allocated and building the next one allocates
+            // again, so they are pinned as they arrive.
+            let mut ciphers = pyre_object::gc_roots::RootedItems::new();
             for index in 0..pyre_native::ssl::cipher_count() {
                 if !unsafe { pyre_native::ssl::context_cipher_enabled(self.backend, index) } {
                     continue;
@@ -1050,7 +1089,7 @@ mod context_methods {
                     ("auth", w_str_new(pyre_native::ssl::cipher_auth(index))),
                 ]));
             }
-            w_list_new(ciphers)
+            w_list_new(ciphers.take())
         }
 
         fn session_stats(&self) -> PyObjectRef {
@@ -2007,9 +2046,13 @@ mod ssl_socket_methods {
             if chain.is_empty() {
                 return Ok(w_none());
             }
-            Ok(w_list_new(
-                chain.into_iter().map(allocate_certificate).collect(),
-            ))
+            // Each certificate object is freshly allocated and the next one
+            // allocates again, so they are pinned as they arrive.
+            let mut items = pyre_object::gc_roots::RootedItems::new();
+            for der in chain {
+                items.push(allocate_certificate(der));
+            }
+            Ok(w_list_new(items.take()))
         }
 
         /// PyPy `_cffi_ssl/_stdssl/__init__.py:get_verified_chain`: return the
@@ -2025,9 +2068,13 @@ mod ssl_socket_methods {
             if chain.is_empty() {
                 return Ok(w_none());
             }
-            Ok(w_list_new(
-                chain.into_iter().map(allocate_certificate).collect(),
-            ))
+            // Each certificate object is freshly allocated and the next one
+            // allocates again, so they are pinned as they arrive.
+            let mut items = pyre_object::gc_roots::RootedItems::new();
+            for der in chain {
+                items.push(allocate_certificate(der));
+            }
+            Ok(w_list_new(items.take()))
         }
 
         fn get_channel_binding(

--- a/pyre/pyre-interpreter/src/module/grp/grp.rs
+++ b/pyre/pyre-interpreter/src/module/grp/grp.rs
@@ -185,15 +185,22 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             |_| {
                 #[cfg(feature = "host_env")]
                 {
-                    let items: Vec<pyre_object::PyObjectRef> = rustpython_host_env::grp::getgrall()
-                        .iter()
-                        .map(make_struct_group)
-                        .collect();
-                    Ok(pyre_object::w_list_new(items))
+                    // Each struct_group is freshly allocated and building the
+                    // next one allocates again, so they are pinned as they
+                    // arrive.
+                    let groups = rustpython_host_env::grp::getgrall();
+                    let mut items = pyre_object::gc_roots::RootedItems::new();
+                    for g in groups.iter() {
+                        items.push(make_struct_group(g));
+                    }
+                    Ok(pyre_object::w_list_new(items.take()))
                 }
                 #[cfg(not(feature = "host_env"))]
                 unsafe {
-                    let mut items: Vec<pyre_object::PyObjectRef> = Vec::new();
+                    // Each struct_group is freshly allocated and the next
+                    // `getgrent` entry allocates again, so they are pinned as
+                    // they arrive.
+                    let mut items = pyre_object::gc_roots::RootedItems::new();
                     libc::setgrent();
                     loop {
                         let g = libc::getgrent();
@@ -203,7 +210,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         items.push(make_struct_group_libc(g));
                     }
                     libc::endgrent();
-                    return Ok(pyre_object::w_list_new(items));
+                    return Ok(pyre_object::w_list_new(items.take()));
                 }
             },
             0,

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -4434,8 +4434,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // names the failure.
                 let names = fdlistdir(resolved.as_fd)
                     .map_err(|errno| errno_err_with_filename(errno, resolved.w_path()))?;
-                let items = names.iter().map(|n| fs_name_obj(false, n)).collect();
-                return Ok(pyre_object::w_list_new(items));
+                // Each name is freshly allocated and the next one allocates
+                // again, so they are pinned as they arrive.
+                let mut items = pyre_object::gc_roots::RootedItems::new();
+                for n in &names {
+                    items.push(fs_name_obj(false, n));
+                }
+                return Ok(pyre_object::w_list_new(items.take()));
             }
             let bytes_mode = unsafe { resolved.is_bytes() };
             let path = resolved.as_bytes.as_slice();
@@ -4444,23 +4449,23 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             {
                 let names = crate::host_seam::ops::listdir(path)
                     .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, w_path()))?;
-                let items = names
-                    .into_iter()
-                    .map(|n| fs_name_obj(bytes_mode, &n))
-                    .collect();
-                return Ok(pyre_object::w_list_new(items));
+                let mut items = pyre_object::gc_roots::RootedItems::new();
+                for n in names {
+                    items.push(fs_name_obj(bytes_mode, &n));
+                }
+                return Ok(pyre_object::w_list_new(items.take()));
             }
             #[cfg(not(feature = "sandbox"))]
             {
                 let entries = host_fs::read_dir(path_from_bytes(path).as_ref())
                     .map_err(|e| fs_err_with_filename(e, w_path()))?;
-                let mut items = Vec::new();
+                let mut items = pyre_object::gc_roots::RootedItems::new();
                 for entry in entries {
                     let entry = entry.map_err(|e| fs_err_with_filename(e, w_path()))?;
                     let name = entry.file_name();
                     items.push(fs_name_obj(bytes_mode, name.as_encoded_bytes()));
                 }
-                Ok(pyre_object::w_list_new(items))
+                Ok(pyre_object::w_list_new(items.take()))
             }
         }),
     );
@@ -12552,12 +12557,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             names: std::io::Result<Vec<std::ffi::OsString>>,
         ) -> Result<PyObjectRef, crate::PyError> {
             let names = names.map_err(|e| fs_err_with_filename(e, pyre_object::PY_NULL))?;
-            Ok(pyre_object::w_list_new(
-                names
-                    .iter()
-                    .map(|name| fs_name_obj(false, name.as_encoded_bytes()))
-                    .collect(),
-            ))
+            // Each name is freshly allocated and the next one allocates again,
+            // so they are pinned as they arrive.
+            let mut items = pyre_object::gc_roots::RootedItems::new();
+            for name in &names {
+                items.push(fs_name_obj(false, name.as_encoded_bytes()));
+            }
+            Ok(pyre_object::w_list_new(items.take()))
         }
         crate::module_ns_store(
             ns,

--- a/pyre/pyre-interpreter/src/module/pwd/interp_pwd.rs
+++ b/pyre/pyre-interpreter/src/module/pwd/interp_pwd.rs
@@ -226,17 +226,22 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             |_| {
                 #[cfg(feature = "host_env")]
                 {
-                    let items: Vec<pyre_object::PyObjectRef> = rustpython_host_env::pwd::getpwall()
-                        .iter()
-                        .map(make_struct_passwd)
-                        .collect();
-                    Ok(pyre_object::w_list_new(items))
+                    // Every entry is freshly allocated and the next one allocates
+                    // again, so they are pinned as they arrive (`build_list_storage`).
+                    let mut items = pyre_object::gc_roots::RootedItems::new();
+                    for pw in rustpython_host_env::pwd::getpwall().iter() {
+                        items.push(make_struct_passwd(pw));
+                    }
+                    Ok(pyre_object::w_list_new(items.take()))
                 }
                 // `interp_pwd.py:123-134` — setpwent / loop getpwent /
                 // endpwent.
                 #[cfg(not(feature = "host_env"))]
                 unsafe {
-                    let mut items: Vec<pyre_object::PyObjectRef> = Vec::new();
+                    // Every entry is freshly allocated and the next `getpwent`
+                    // entry allocates again, so they are pinned as they arrive
+                    // (`build_list_storage`).
+                    let mut items = pyre_object::gc_roots::RootedItems::new();
                     libc::setpwent();
                     loop {
                         let pw = libc::getpwent();
@@ -246,7 +251,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         items.push(make_struct_passwd_libc(pw));
                     }
                     libc::endpwent();
-                    return Ok(pyre_object::w_list_new(items));
+                    return Ok(pyre_object::w_list_new(items.take()));
                 }
             },
             0,

--- a/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
+++ b/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
@@ -2203,13 +2203,28 @@ crate::py_module! {
         crate::module_ns_store(ns, "errors", errors);
 
         // features — list of (name, value) capability tuples.
-        let features = w_list_new(vec![
-            w_tuple_new(vec![w_str_new("sizeof(XML_Char)"), w_int_new(1)]),
-            w_tuple_new(vec![w_str_new("sizeof(XML_LChar)"), w_int_new(1)]),
-            w_tuple_new(vec![w_str_new("XML_DTD"), w_int_new(0)]),
-            w_tuple_new(vec![w_str_new("XML_CONTEXT_BYTES"), w_int_new(1024)]),
-            w_tuple_new(vec![w_str_new("XML_NS"), w_int_new(0)]),
-        ]);
+        // Each name, value and tuple allocates while the pieces already built
+        // are named only by a Rust local, so both levels are pinned as they are
+        // produced: the pair until its tuple exists, the tuples until the list
+        // does.  A pair's bracket closes before the tuple joins the outer set —
+        // the outer slots would otherwise sit above it and be popped with it.
+        let mut feature_items = pyre_object::gc_roots::RootedItems::new();
+        for (name, value) in [
+            ("sizeof(XML_Char)", 1),
+            ("sizeof(XML_LChar)", 1),
+            ("XML_DTD", 0),
+            ("XML_CONTEXT_BYTES", 1024),
+            ("XML_NS", 0),
+        ] {
+            let entry = {
+                let mut pair = pyre_object::gc_roots::RootedItems::new();
+                pair.push(w_str_new(name));
+                pair.push(w_int_new(value));
+                w_tuple_new(pair.take())
+            };
+            feature_items.push(entry);
+        }
+        let features = w_list_new(feature_items.take());
         crate::module_ns_store(ns, "features", features);
     },
 }

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -1128,6 +1128,11 @@ impl W_Struct {
     /// [`Parsed::expected_args`] answers; PyPy's object keeps no such field, so
     /// the immutable format is reparsed here rather than cached beside it, as
     /// [`W_Struct::__sizeof__`] already does for the code count.
+    #[cfg(all(
+        feature = "cpyext",
+        not(feature = "sandbox"),
+        any(target_os = "macos", target_os = "linux")
+    ))]
     pub(crate) fn c_size_and_len(&self) -> (i64, i64) {
         if self.size < 0 {
             return (-1, -1);

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -2409,17 +2409,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         pending
     };
     module_ns_store(ns, "argv", argv);
-    // sys.warnoptions
-    module_ns_store(
-        ns,
-        "warnoptions",
-        w_list_new(
-            crate::importing::warnoptions()
-                .iter()
-                .map(|option| crate::gateway::fsdecode_os_str(option))
-                .collect(),
-        ),
-    );
+    // sys.warnoptions — each decoded option is freshly allocated and the next
+    // decode allocates again, so they are pinned as they arrive
+    // (`build_list_storage`).
+    {
+        let mut warnoptions = pyre_object::gc_roots::RootedItems::new();
+        for option in crate::importing::warnoptions() {
+            warnoptions.push(crate::gateway::fsdecode_os_str(&option));
+        }
+        module_ns_store(ns, "warnoptions", w_list_new(warnoptions.take()));
+    }
     // sys.builtin_module_names — tuple of names of modules compiled into
     // the interpreter. PyPy: pypy/module/sys/state.py get_builtin_module_names,
     // which reads the same registry `import` resolves against, so the

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -43,7 +43,7 @@ fn monotonic_seconds() -> f64 {
 
 /// Wall-clock seconds since the unix epoch, falling back to 0 on
 /// `SystemTimeError`.  Routes through `host_env::time` when enabled.
-fn duration_since_epoch() -> std::time::Duration {
+pub(crate) fn duration_since_epoch() -> std::time::Duration {
     #[cfg(feature = "sandbox")]
     {
         let secs = crate::host_seam::ops::time().unwrap_or(0.0).max(0.0);
@@ -237,7 +237,7 @@ pub fn perf_counter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 }
 
 /// Monotonic clock as integer nanoseconds.
-fn monotonic_nanos() -> i128 {
+pub(crate) fn monotonic_nanos() -> i128 {
     #[cfg(all(unix, feature = "host_env"))]
     {
         if let Ok(d) = host_time::clock_gettime(host_time::ClockId::CLOCK_MONOTONIC) {

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -2164,11 +2164,13 @@ pub unsafe fn line_iter_next(obj: PyObjectRef) -> Option<PyObjectRef> {
         }
         let end = bounds.ar_end;
         line_iter_store(it, bounds.cursor());
-        Some(w_tuple_new(vec![
-            w_int_new(start as i64),
-            w_int_new(end as i64),
-            source_offset_converter(line),
-        ]))
+        // Each field is freshly allocated and the next one allocates again,
+        // so they are pinned as they arrive (`build_list_storage`).
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(w_int_new(start as i64));
+        fields.push(w_int_new(end as i64));
+        fields.push(source_offset_converter(line));
+        Some(w_tuple_new(fields.take()))
     }
 }
 
@@ -2232,12 +2234,12 @@ pub unsafe fn positions_iter_next(obj: PyObjectRef) -> Option<PyObjectRef> {
         it.ar_line = saved.ar_line as i64;
         it.computed_line = saved.computed_line as i64;
         it.offset = it.offset.wrapping_add(2);
-        Some(w_tuple_new(vec![
-            source_offset_converter(it.ar_line as i32),
-            source_offset_converter(it.end_line as i32),
-            source_offset_converter(it.column as i32),
-            source_offset_converter(it.end_column as i32),
-        ]))
+        let mut fields = pyre_object::gc_roots::RootedItems::new();
+        fields.push(source_offset_converter(it.ar_line as i32));
+        fields.push(source_offset_converter(it.end_line as i32));
+        fields.push(source_offset_converter(it.column as i32));
+        fields.push(source_offset_converter(it.end_column as i32));
+        Some(w_tuple_new(fields.take()))
     }
 }
 
@@ -2297,7 +2299,11 @@ pub unsafe fn code_lines(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError
 
 /// `int_triple` — the `(a, b, c)` tuple every branch row is reported as.
 fn int_triple(a: i64, b: i64, c: i64) -> PyObjectRef {
-    w_tuple_new(vec![w_int_new(a), w_int_new(b), w_int_new(c)])
+    let mut fields = pyre_object::gc_roots::RootedItems::new();
+    fields.push(w_int_new(a));
+    fields.push(w_int_new(b));
+    fields.push(w_int_new(c));
+    w_tuple_new(fields.take())
 }
 
 /// `branchesiter_next` — the next branch instruction's

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -474,6 +474,101 @@ pub fn push_roots() -> RootScope {
     RootScope::new()
 }
 
+/// A set of freshly allocated items held as GC roots while the rest of the
+/// set is still being built.
+///
+/// A plain `Vec<PyObjectRef>` is not a root area, so an element sitting in one
+/// while a later element allocates is unreachable to the collector: old-gen is
+/// mark-sweep, and an element with no heap edge yet is sweepable rather than
+/// merely immobile. `build_list_storage` states the resulting rule for its
+/// callers -- every element must be pinned, and stay pinned across the block
+/// allocation the constructor itself performs.
+///
+/// Slots are addressed as `base + i`, so only ONE set may be open at a time on
+/// a thread: a second bracket's pins land above this one's base and take the
+/// slots it expects, which would hand back the wrong elements rather than
+/// unrooted ones. Build a nested set inside a block that closes before the
+/// outer `push`, as the `_socket` and `pyexpat` conversions do. A debug build
+/// asserts this.
+///
+/// [`take`](Self::take) borrows, so the bracket outlives the statement that
+/// builds the container:
+///
+/// ```ignore
+/// let mut items = RootedItems::new();
+/// while ... {
+///     items.push(allocating_call(...));
+/// }
+/// w_list_new(items.take())
+/// ```
+pub struct RootedItems {
+    scope: RootScope,
+    base: usize,
+    len: usize,
+}
+
+impl RootedItems {
+    /// Open a bracket for a set that is about to be built.
+    #[inline]
+    pub fn new() -> Self {
+        let scope = push_roots();
+        let base = scope.base();
+        Self {
+            scope,
+            base,
+            len: 0,
+        }
+    }
+
+    /// Pin one more item. Pinning is what makes the earlier ones survive this
+    /// item's allocation, so push each as it is produced rather than in a
+    /// second pass over a `Vec`.
+    #[inline]
+    pub fn push(&mut self, item: PyObjectRef) {
+        self.assert_owns_the_top();
+        let _ = self.scope.pin_root(item);
+        self.len += 1;
+    }
+
+    /// The slots this set reads back are `base..base + len`, which is only
+    /// what it pinned while nothing else pins above it.
+    #[inline]
+    fn assert_owns_the_top(&self) {
+        debug_assert_eq!(
+            shadow_stack_len(),
+            self.base + self.len,
+            "another root bracket is open above this one and its pins take these slots"
+        );
+    }
+
+    /// How many items have been pinned.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Read every pinned item back out of its slot. A relocation between the
+    /// pin and this read rewrote the slot in place, so these are the live
+    /// words. The bracket stays open -- the caller's constructor allocates.
+    pub fn take(&self) -> Vec<PyObjectRef> {
+        self.assert_owns_the_top();
+        (0..self.len)
+            .map(|i| self.scope.get(self.base + i))
+            .collect()
+    }
+}
+
+impl Default for RootedItems {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Pin a [`PyObjectRef`] as a live GC root for the duration of the
 /// surrounding [`RootScope`]. Mirrors RPython's per-livevar
 /// `setarrayitem(rootstk, idx, gcref)` emitted by

--- a/pyre/pyrex/tests/cpyext_object_families.rs
+++ b/pyre/pyrex/tests/cpyext_object_families.rs
@@ -272,6 +272,13 @@ eq('an object with no buffer to export', kind, 'TypeError')
 # is readable, and every operation that would read or write a single element
 # refuses.  `adjust_fmt` is reached before the dimension and before the
 # writability check, so the format is what each of them reports.
+# Three formats one word wide that differ only in signedness.  A reader that
+# takes the item's width and ignores its code answers a word with the top bit
+# set as -1 for all three.
+eq('a signed word', m.mv_word_format('n').tolist(), [-1, 1])
+eq('an unsigned word', m.mv_word_format('N').tolist(), [18446744073709551615, 1])
+eq('a pointer word', m.mv_word_format('P').tolist(), [18446744073709551615, 1])
+
 compound = m.mv_compound_format()
 eq('compound geometry',
    (compound.format, compound.itemsize, compound.nbytes, compound.ndim),

--- a/pyre/pyrex/tests/cpyext_types.rs
+++ b/pyre/pyrex/tests/cpyext_types.rs
@@ -603,6 +603,21 @@ assert driver.describe(bytearray(b'abc')) == (3, 1, 1, 'B', 3, 1)
 assert driver.describe(array.array('i', [1, 2])) == (8, 4, 1, 'i', 2, 4)
 assert driver.describe(memoryview(b'abcd')[1:]) == (3, 1, 1, 'B', 3, 1)
 
+# A view with no dimensions carries no dimension vectors at all: `shape` and
+# `strides` are absent rather than empty, and stay absent through a
+# `memoryview` and back into C.  `PyBuffer_GetPointer` is handed no index for
+# such a view, so a fabricated dimension makes it read one that is not there.
+scalar = m.Scalar(1.5)
+assert driver.describe(scalar) == (8, 8, 0, 'd', -1, -1)
+assert driver.describe(memoryview(scalar)) == (8, 8, 0, 'd', -1, -1)
+assert scalar.at(scalar) == 1.5
+assert scalar.at(memoryview(scalar)) == 1.5
+
+view = memoryview(scalar)
+assert (view.ndim, view.shape, view.strides, view.nbytes) == (0, (), (), 8)
+assert view.tolist() == 1.5
+assert len(bytes(view)) == 8
+
 # A strided export is refused by a request that cannot describe one.
 try:
     driver.read(memoryview(b'abcdef')[::2])

--- a/pyre/pyrex/tests/fixtures/cpyext_object_families.c
+++ b/pyre/pyrex/tests/fixtures/cpyext_object_families.c
@@ -287,6 +287,34 @@ static PyObject *mv_compound_format(PyObject *self, PyObject *unused)
     return PyMemoryView_FromBuffer(&view);
 }
 
+/* Three native formats one word wide, differing only in signedness: `n` is a
+   `Py_ssize_t`, `N` a `size_t` and `P` a `void *`.  A reader that takes the
+   item's width and ignores its code answers a word with the top bit set the
+   same way for all three. */
+static unsigned long long word_storage[2] = {0xffffffffffffffffULL, 1};
+static Py_ssize_t word_shape[1] = {2};
+static Py_ssize_t word_strides[1] = {sizeof(unsigned long long)};
+
+static PyObject *mv_word_format(PyObject *self, PyObject *args)
+{
+    Py_buffer view;
+    const char *format = NULL;
+    (void)self;
+    if (!PyArg_ParseTuple(args, "s", &format)) {
+        return NULL;
+    }
+    memset(&view, 0, sizeof(view));
+    view.buf = word_storage;
+    view.len = (Py_ssize_t)sizeof(word_storage);
+    view.itemsize = (Py_ssize_t)sizeof(word_storage[0]);
+    view.format = (char *)format;
+    view.ndim = 1;
+    view.shape = word_shape;
+    view.strides = word_strides;
+    view.readonly = 1;
+    return PyMemoryView_FromBuffer(&view);
+}
+
 /* ── struct.Struct ── */
 
 /* `_struct.c` keeps the byte size and the value count as fields of
@@ -323,6 +351,7 @@ static PyMethodDef methods[] = {
 
     {"mv_contiguous", mv_contiguous, METH_VARARGS, NULL},
     {"mv_compound_format", mv_compound_format, METH_NOARGS, NULL},
+    {"mv_word_format", mv_word_format, METH_VARARGS, NULL},
 
     M("wr_check", wr_check), M("wr_check_ref", wr_check_ref),
     M("wr_check_proxy", wr_check_proxy), M("wr_new_ref", wr_new_ref),

--- a/pyre/pyrex/tests/fixtures/cpyext_types.c
+++ b/pyre/pyrex/tests/fixtures/cpyext_types.c
@@ -1425,6 +1425,114 @@ static PyTypeObject BlobType = {
     blob_new,                                   /* tp_new */
 };
 
+/* ── Scalar: a view with no dimensions ──────────────────────────────── */
+
+/* An export whose `ndim` is zero holds exactly one element and carries no
+   dimension vectors at all: `init_shape_strides` leaves `shape` and `strides`
+   NULL rather than pointing them at an empty array, and `PyBuffer_GetPointer`
+   reads no index.  `Modules/_testbuffer.c` exports one of these from
+   `ndarray(scalar, shape=())`; this is the same export written out. */
+typedef struct {
+    PyObject_HEAD
+    double value;
+} ScalarObject;
+
+static PyObject *scalar_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    double value = 0.0;
+    if (!PyArg_ParseTuple(args, "|d", &value)) {
+        return NULL;
+    }
+    ScalarObject *self = (ScalarObject *)PyType_GenericAlloc(type, 0);
+    if (self == NULL) {
+        return NULL;
+    }
+    self->value = value;
+    return (PyObject *)self;
+}
+
+static int scalar_getbuffer(PyObject *self, Py_buffer *view, int flags)
+{
+    ScalarObject *scalar = (ScalarObject *)self;
+    view->buf = &scalar->value;
+    view->obj = Py_NewRef(self);
+    view->len = (Py_ssize_t)sizeof(scalar->value);
+    view->itemsize = (Py_ssize_t)sizeof(scalar->value);
+    view->readonly = 1;
+    view->ndim = 0;
+    view->format = (flags & PyBUF_FORMAT) == PyBUF_FORMAT ? "d" : NULL;
+    view->shape = NULL;
+    view->strides = NULL;
+    view->suboffsets = NULL;
+    view->internal = NULL;
+    return 0;
+}
+
+/* The element `PyBuffer_GetPointer` names when the caller has no index to
+   hand it, which is the only way to address a view with no dimensions.  A
+   fabricated dimension makes this read one index past the end of `indices`. */
+static PyObject *scalar_at(PyObject *self, PyObject *source)
+{
+    Py_buffer view;
+    if (PyObject_GetBuffer(source, &view, PyBUF_FULL_RO) < 0) {
+        return NULL;
+    }
+    PyObject *element = PyFloat_FromDouble(*(double *)PyBuffer_GetPointer(&view, NULL));
+    PyBuffer_Release(&view);
+    return element;
+}
+
+static PyMethodDef scalar_methods[] = {
+    {"at", scalar_at, METH_O, "the element a view with no indices names"},
+    {NULL, NULL, 0, NULL},
+};
+
+static PyBufferProcs scalar_as_buffer = {
+    scalar_getbuffer,                           /* bf_getbuffer */
+    0,                                          /* bf_releasebuffer */
+};
+
+static PyTypeObject ScalarType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "cpyext_types.Scalar",                      /* tp_name */
+    sizeof(ScalarObject),                       /* tp_basicsize */
+    0,                                          /* tp_itemsize */
+    0,                                          /* tp_dealloc */
+    0,                                          /* tp_vectorcall_offset */
+    0,                                          /* tp_getattr */
+    0,                                          /* tp_setattr */
+    0,                                          /* tp_as_async */
+    0,                                          /* tp_repr */
+    0,                                          /* tp_as_number */
+    0,                                          /* tp_as_sequence */
+    0,                                          /* tp_as_mapping */
+    0,                                          /* tp_hash */
+    0,                                          /* tp_call */
+    0,                                          /* tp_str */
+    0,                                          /* tp_getattro */
+    0,                                          /* tp_setattro */
+    &scalar_as_buffer,                          /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,                         /* tp_flags */
+    "a scalar exporter defined in C",           /* tp_doc */
+    0,                                          /* tp_traverse */
+    0,                                          /* tp_clear */
+    0,                                          /* tp_richcompare */
+    0,                                          /* tp_weaklistoffset */
+    0,                                          /* tp_iter */
+    0,                                          /* tp_iternext */
+    scalar_methods,                             /* tp_methods */
+    0,                                          /* tp_members */
+    0,                                          /* tp_getset */
+    0,                                          /* tp_base */
+    0,                                          /* tp_dict */
+    0,                                          /* tp_descr_get */
+    0,                                          /* tp_descr_set */
+    0,                                          /* tp_dictoffset */
+    0,                                          /* tp_init */
+    0,                                          /* tp_alloc */
+    scalar_new,                                 /* tp_new */
+};
+
 /* ── Ticker: the async table ────────────────────────────────────────── */
 
 typedef struct {
@@ -2125,6 +2233,9 @@ static int types_exec(PyObject *module)
         return -1;
     }
     if (PyModule_AddType(module, &BlobType) < 0) {
+        return -1;
+    }
+    if (PyModule_AddType(module, &ScalarType) < 0) {
         return -1;
     }
     if (PyModule_AddType(module, &TickerType) < 0) {

--- a/pyre/scripts/cpyext-abi.py
+++ b/pyre/scripts/cpyext-abi.py
@@ -244,8 +244,10 @@ def read_header_inlines():
 
 C_SOURCE_DIR = CPYEXT / "src"
 
+# `stars` takes a `const` between two of them, so that a definition answering
+# `PyObject *const *` is read rather than passed over as no definition at all.
 C_DEFINITION = re.compile(
-    r"^(?P<ret>[A-Za-z_][A-Za-z0-9_ ]*?)\s*(?P<stars>\**)\s*"
+    r"^(?P<ret>[A-Za-z_][A-Za-z0-9_ ]*?)\s*(?P<stars>\**(?:\s*const\s*\**)?)\s*"
     r"(?P<name>[A-Za-z_]\w*)\s*\((?P<params>[^;{]*?)\)\s*\{",
     re.M | re.S)
 
@@ -293,6 +295,23 @@ def read_renamed_exports():
         for match in RENAME.finditer(text):
             if match.group("name") in declared:
                 yield match.group("name")
+
+
+INTERNAL_HEADER_DIR = HEADER_DIR / "internal"
+
+
+def read_internal_declarations():
+    """The entry points only a header under `internal/` declares.
+
+    CPython keeps these out of an installed tree, and pyre ships them on the
+    same terms.  A declaration in the generated header would undo that: it is
+    reached by including `Python.h` alone, which is exactly the extension the
+    internal header is meant to be closed to.
+    """
+    for path in sorted(INTERNAL_HEADER_DIR.glob("*.h")):
+        text = strip_comments(path.read_text(errors="replace"))
+        for match in HAND_DECLARED.finditer(text):
+            yield match.group("name")
 
 
 STATIC = re.compile(
@@ -528,10 +547,10 @@ def check_data(record, typedefs, misspelled):
 
 def command_generate(args):
     declarations, _, _ = load_record()
-    renamed = set(read_renamed_exports())
+    withheld = set(read_renamed_exports()) | set(read_internal_declarations())
     by_module = {}
     for module, name, params, ret in read_exports():
-        if name in renamed:
+        if name in withheld:
             continue
         # CPython's own spelling wherever it has one: `check` has already
         # established the two describe the same call, and the reference
@@ -550,7 +569,9 @@ def command_generate(args):
         " *",
         " * An export a hand-written header renames to an inline fast path is",
         " * left out: that header declares it ahead of the rename, which a",
-        " * declaration here would come after.",
+        " * declaration here would come after.  So is one a header under",
+        " * `internal/` declares, which is reached by including that header",
+        " * and not by including `Python.h`.",
         " */",
         "#ifndef PYRE_DECL_H",
         "#define PYRE_DECL_H",

--- a/pyre/scripts/cpyext-abi.py
+++ b/pyre/scripts/cpyext-abi.py
@@ -143,7 +143,7 @@ SCALARS = {
     "i32": "int32_t", "u32": "uint32_t", "i64": "int64_t", "u64": "uint64_t",
     # Named aliases the Rust side spells the same way the header does, so the
     # comparison is against the reference name rather than its width.
-    "Py_UCS4": "Py_UCS4", "wchar_t": "wchar_t",
+    "Py_UCS4": "Py_UCS4", "wchar_t": "wchar_t", "PyTime_t": "PyTime_t",
     # A Rust function that never returns has no C spelling of its own: the
     # header declares it `void` and marks the fact separately.
     "!": "void",


### PR DESCRIPTION
Eighteen commits, rebased onto `origin/main` at `cef6ccd9334`.

## What is here

Two slices. The first is the buffer/memoryview rooting and lane work this PR
opened with; the second loads real CPython extension modules, which is what put
`test_importlib.extension` back under the gate.

| commit | what it does |
|---|---|
| `196d852931e` | `buffer`: a zero-dimensional view gets no dimension vectors — fixes the segv in `test_ndarray_format_scalar` |
| `ec1301280ef` | `struct`: `c_size_and_len` is gated behind the `cpyext` feature |
| `aa953dd9131` | `builtins`: memoryview element values are pinned while their list is built |
| `b266e616a81` | `memoryview`: an item of format `n`, `N` or `P` is unpacked through its word-wide code |
| `4ee7558814d` | `cpython_tests`: `_testbuffer` is compiled and `test_buffer`'s exporter cases run; `check.py`'s dynasm build gains `cpyext` |
| `d29f9cba22d` | `gc_roots`: `RootedItems` roots freshly allocated items while their list or tuple is built; 29 sites converted |
| `ce0568dce9f` | `cpython_tests`, `check`: `PANIC_BODY_CHARS` keeps 2000 characters of a rust panic's message body |
| `e3e00eecd72` | `cpyext`: an extension library stays loaded when its init fails |
| `1cc601eb5bb` | `cpyext`: the `PyTime_t` clock entry points |
| `89d7e37f446` | `cpyext`: `PyState_AddModule`, `PyState_FindModule`, `PyState_RemoveModule` |
| `02e64097e74` | `cpyext`: `_PyNamespace_New` and the `_PyArg_Parser` API, behind `include/pyre3.14t/internal/` |
| `3e351bce9e2` | `cpython_tests`: `_testsinglephase` and `_testmultiphase` are compiled |
| `62f3e937690` | `cpython_tests`: `test_importlib` recorded FAIL on cranelift |
| `58c6a2043f7` | `cpyext`: a non-ASCII module name is looked up under its punycode init symbol |
| `974d210fe49` | `cpyext`: `tp_setattr` / `tp_getattr` are reachable when the object-key twin is absent |
| `7ed3a39e5e9` | `cpyext`: the multi-phase `sys.modules` write moves to the importer |
| `edfeab474fe` | `cpyext`: an unreported extension exception is chained onto the `SystemError` |
| `ec4324b77dd` | `cpython_tests`: `test_buffer` recorded FAIL on cranelift |

## The extension-loading slice

`test.test_importlib.extension.test_loader` went from 19 failures + 6 errors to
**42 of 43 passing**, identically on both backends.

`e3e00eecd72` is the one with teeth. `load_extension_module` called
`drop_library` on three failure paths, and `host_env::ctypes` keeps one `dlopen`
count per library in a handle cache — so closing it there unloaded the image
outright while modules built by earlier loads of a *different* name out of the
same file were still live. Their types' `tp_traverse` then pointed into text
nobody had mapped, which the next minor collection walked:
`test_importlib` was 5/5 `rc=139` before, 3/3 `rc=1` after. `lldb` put `pc` in a
`---` region with `lr = cpyext::gc::c_edges + 308` under
`MiniMarkGC::rrc_refresh_c_edges`, and `image list` showed `_testmultiphase.so`
gone.

`974d210fe49` follows CPython rather than pypy, which is unusual enough to call
out. `typeobject.c inherit_slots` copies each legacy attribute hook together
with its object-key twin, guarded on *both* being null, and `PyObject_SetAttr`
reaches `tp_setattr` when `tp_setattro` is null. pypy does neither
(`typeobject.py` inherits `tp_setattro` alone and then defaults it to
`PyObject_GenericSetAttr` unconditionally), so `_testmultiphase`'s `Example`
type — which fills `Py_tp_setattr` — never reached its own hook. pyre resolves
`__setattr__` through the MRO even from `PyObject_SetAttr`, so the inherit guard
alone is not enough and the legacy slots get published wrappers.

## Rooting work

`build_list_storage`'s contract is that the caller has pinned every element:
both the unboxing and the block allocation can collect. A census of the sites
feeding `w_list_new` / `w_tuple_new` found 132 candidates, refuted 92 and
confirmed 29; all 29 are converted to the new `RootedItems` bracket.

`RootedItems` addresses slots as `base + i`, so only one set may be open at a
time on a thread. A debug assertion enforces that, and it found five real
nesting bugs introduced during the conversion (`pycode.rs` x3, `importing.rs`
x2) — each fixed by closing the inner bracket inside a `let row = { … };` block.

The rebase moved this one: `main` rewrote `co_lines()` / `co_positions()` into
lazy iterators, which removed the eager row builders this commit had rooted and
reintroduced the same unpinned `vec![w_int_new(..), ..]` shape in
`line_iter_next`, `positions_iter_next` and `int_triple`. The bracket is applied
there instead.

## Verification

* macOS `dynasm` 221 PASS / 0 FAIL, macOS `cranelift` 221 PASS / 0 FAIL, both
  "no regressions", both built after a full `extract-llbc.py` re-extraction
  (all four artefacts were stale after the rebase) and with **no**
  `PYRE_LLBC_SKIP_FINGERPRINT_CHECK`.
* Linux aarch64 in a container, `dynasm,cpyext`: 219 PASS / 0 FAIL. All three
  test extensions build and load on ELF.
* `cargo test --all --no-default-features --features dynasm,cpyext
  --no-fail-fast`: 40 test-result lines, all ok.
* `cpyext-abi.py check` and `generate --check`: clean.

## Baseline

`test_buffer` and `test_importlib` are FAIL on **both** backends.
`d0e05df8b05` recorded only the dynasm half when it turned `_testbuffer` on;
`3c2d383ccef` fixed `test_importlib`'s cranelift row and `ec4324b77dd` fixes
`test_buffer`'s. Both backends report the same 11 failures and 30 errors, so the
stale `PASS` was baseline skew rather than a backend difference.

## Known gaps, not fixed here

**`test_loader`'s last failure** is `test_nonmodule_cases`, which runs
`_test_nonmodule_cases.py` through `script_helper.run_test_script`. That spawns
the interpreter with `-E` (verbose) or `-I` (quiet); both strip `PYTHONPATH`, so
the child cannot see `build/cpython_tests`. pyre's isolated `sys.path` is only
`lib-python/3` plus the two `plat-mac` entries — CPython finds its build tree
through `getpath.c`'s `pybuilddir.txt` and pyre has no equivalent.

**`test_buffer`'s 41 remaining cases** are one gap: `cpyext/buffer.rs :: acquire`
accepts only a contiguous one-dimensional export, which is 22 of the 30 errors.
`pypy/module/cpyext/buffer.py :: CPyBuffer` is the model for the strided and
N-dimensional carrier; suboffsets is the part pypy declines in five places, so
that half follows `Objects/memoryobject.c` (`ADJUST_PTR`, `init_suboffsets`) as
a named CPython-over-pypy deviation.

**A `test_datetime` major-GC panic** seen once under `--jobs 4` in a
memory-capped Linux container:

```
GC BUG: invalid major child type_id=2139190848 at child_addr=0xaaaad0cb9fa0
holder_addr=0xaaaad0cb7f48 holder_type_id=31 slot_addr=0xaaaad0cb8018
holder_offset=Some(208) site=major_fixed_field
```

`holder_offset=208` is `W_BaseException.w_import_msg`. It has not recurred in
four full parallel suite runs or four GC-stress runs of the module. Ruled out by
reading: the `malloc_typed` fallback, an unzeroed slot on the JIT allocation
path, and a missing write barrier in the interpreter. `ce0568dce9f` is what
makes the next occurrence carry the holder and child words, both generations and
the enclosing container.

— *commented by Claude*
