### PR TITLE
jit-trace: fail closed on a descent callee the scan cannot obtain; llbc: stamp the artefact bytes and gate the build on them; pyre-object: key the set table with the digest it already carries

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -195,9 +195,13 @@ jobs:
     # hashes. Restored without it, every consumer falls back to the whole cargo
     # closure and computes a digest that CANNOT equal the narrow one the stamp
     # beside it records, so all four crates read STALE while the artefact is
-    # current. The `llbc2-` prefix retires the keys whose payload predates it —
-    # the key is the wide digest, which no edit to the extraction driver moves,
-    # so without a new namespace the shapeless entries would restore forever.
+    # current. The prefix carries a generation, and it retires the keys whose
+    # payload predates it — the key is the wide digest, which no edit to the
+    # extraction driver moves, so without a new namespace the shapeless entries
+    # would restore forever, and an exact hit skips the Extract step that would
+    # otherwise re-judge them. `llbc3-` is the generation whose stamps carry
+    # `artefacts=`, the field recording the artefact bytes the stamp was
+    # written beside; a stamp without that field is refused, not compared.
     #
     # Each entry also takes a `restore-keys` prefix, so a miss falls back to
     # this crate's most recent entry instead of restoring nothing. The exact
@@ -220,9 +224,9 @@ jobs:
           build/llbc/majit-rlib.ullbc.fingerprint
           build/llbc/majit-rlib.ullbc.readfiles
           build/llbc/majit-rlib.*.layouts.ullbc
-        key: llbc2-majit-rlib-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.majit_rlib }}
+        key: llbc3-majit-rlib-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.majit_rlib }}
         restore-keys: |
-          llbc2-majit-rlib-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-
+          llbc3-majit-rlib-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-
     - name: Cache LLBC (pyre-object)
       id: llbc-cache-object
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -232,9 +236,9 @@ jobs:
           build/llbc/pyre-object.ullbc.fingerprint
           build/llbc/pyre-object.ullbc.readfiles
           build/llbc/pyre-object.*.layouts.ullbc
-        key: llbc2-pyre-object-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.pyre_object }}
+        key: llbc3-pyre-object-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.pyre_object }}
         restore-keys: |
-          llbc2-pyre-object-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-
+          llbc3-pyre-object-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-
     - name: Cache LLBC (pyre-interpreter)
       id: llbc-cache-interpreter
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -244,9 +248,9 @@ jobs:
           build/llbc/pyre-interpreter.ullbc.fingerprint
           build/llbc/pyre-interpreter.ullbc.readfiles
           build/llbc/pyre-interpreter.*.layouts.ullbc
-        key: llbc2-pyre-interpreter-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.pyre_interpreter }}
+        key: llbc3-pyre-interpreter-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.pyre_interpreter }}
         restore-keys: |
-          llbc2-pyre-interpreter-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-
+          llbc3-pyre-interpreter-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-
     - name: Cache LLBC (pyre-jit)
       id: llbc-cache-jit
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -255,9 +259,9 @@ jobs:
           build/llbc/pyre-jit.ullbc
           build/llbc/pyre-jit.ullbc.fingerprint
           build/llbc/pyre-jit.ullbc.readfiles
-        key: llbc2-pyre-jit-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.pyre_jit }}
+        key: llbc3-pyre-jit-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.pyre_jit }}
         restore-keys: |
-          llbc2-pyre-jit-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-
+          llbc3-pyre-jit-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-
     - name: Extract LLBC
       # Runs only when some crate's cache missed. extract-llbc.py self-skips
       # the crates whose .ullbc + matching .fingerprint stamp were restored

--- a/.github/workflows/pyre-cpython-weekly.yml
+++ b/.github/workflows/pyre-cpython-weekly.yml
@@ -71,12 +71,12 @@ jobs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: build/llbc
-        key: llbc-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.value }}
+        key: llbc3-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-${{ steps.llbc-fingerprint.outputs.value }}
         # A miss with no prefix to fall back on restores nothing and re-extracts
         # all four crates. A loose restore is safe: `extract-llbc.py` re-judges
         # each crate against the tree and re-extracts the ones that moved.
         restore-keys: |
-          llbc-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-
+          llbc3-${{ runner.os }}-${{ runner.arch }}-${{ env.CHARON_VERSION }}-
     - name: Extract LLBC
       if: steps.llbc-cache.outputs.cache-hit != 'true'
       shell: bash

--- a/pyre/pyre-jit-trace/build/prepass.rs
+++ b/pyre/pyre-jit-trace/build/prepass.rs
@@ -472,11 +472,18 @@ fn llbc_current_fingerprint(
 /// skips a crate whose stamp still matches, so this is the comparison the
 /// producer trusts, evaluated by the consumer.
 ///
-/// `source=` and `external=` remain stale gates. `closure=` preserves the old
-/// whole-cargo-closure hash, but a mismatch there alone warns: the artefact's
-/// declared inputs did not move, while a trait impl outside its file table can
-/// still affect method resolution. The standalone `--check` uses the same
-/// three-way verdict.
+/// `source=`, `external=` and `artefacts=` are stale gates. `closure=`
+/// preserves the old whole-cargo-closure hash, but a mismatch there alone
+/// warns: the artefact's declared inputs did not move, while a trait impl
+/// outside its file table can still affect method resolution. The standalone
+/// `--check` uses the same three-way verdict.
+///
+/// `artefacts=` is the only one of the four that describes an OUTPUT. The
+/// input fields answer "would a fresh extraction write different bytes"; a
+/// build killed part-way through a Charon write leaves a short artefact under
+/// a stamp whose inputs have not moved, and all three answer "current" over
+/// it. Comparing it here, rather than only in `--check`, is what keeps a plain
+/// `cargo build` from consuming those bytes.
 ///
 /// A stale artefact fails the build.  It was warning-only, on the argument
 /// that the build still works for everything whose layout did not move; the
@@ -584,6 +591,15 @@ fn fail_if_llbc_stale(repo_root: &std::path::Path) {
             unknown.push((crate_name, "stamp carries no external= line"));
             continue;
         };
+        // Required for the same reason, and the only field here that describes
+        // what is IN `build/llbc` rather than what went into it.  A stamp too
+        // old to carry it cannot answer whether these are still the bytes
+        // extraction wrote, and "nobody checked" is not a licence to read
+        // their offsets.
+        let Some(recorded_artefacts) = stamp_field(&stamp, "artefacts=") else {
+            unknown.push((crate_name, "stamp carries no artefacts= line"));
+            continue;
+        };
         let Some(recorded_platform) = stamp_field(&stamp, "platform=") else {
             unknown.push((crate_name, "stamp carries no platform= line"));
             continue;
@@ -614,6 +630,14 @@ fn fail_if_llbc_stale(repo_root: &std::path::Path) {
         }
         if recorded_external != current.external {
             stale.push((crate_name, "external", recorded_external, current.external));
+        }
+        if recorded_artefacts != current.artefacts {
+            stale.push((
+                crate_name,
+                "artefacts",
+                recorded_artefacts,
+                current.artefacts,
+            ));
         }
         if source_matches && recorded_closure != current.closure {
             closure_warnings.push(crate_name);
@@ -650,6 +674,17 @@ fn fail_if_llbc_stale(repo_root: &std::path::Path) {
         "cargo::warning"
     };
     for (crate_name, field, recorded, current) in &stale {
+        // Both sides are a per-file list, so printing them the way a digest is
+        // printed would put kilobytes on one cargo line and still not say
+        // which file moved.  `--check` renders that with `artefact_diff`.
+        if *field == "artefacts" {
+            println!(
+                "{directive}=LLBC STALE: {crate_name}.ullbc, or a layout sidecar beside it, is \
+                 not the bytes its stamp was written over; run \
+                 `python3 scripts/extract-llbc.py --check` for which file and how it differs"
+            );
+            continue;
+        }
         // The other fields are hashes of the tree; `platform` is not.
         let subject = if *field == "platform" {
             "this build is"

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -916,10 +916,28 @@ fn collect_descent_unlowered_helper_blockers(
     blockers
 }
 
+/// The answer for a region of a descent the scan did not walk.
+///
+/// `may_execute_effect` because an unwalked region can have done anything, and
+/// `body_not_walked` because that is the condition itself; `descent_decline`
+/// reads the second alone as a refusal, so this is the fail-closed answer to
+/// "what does this body hold".
+fn body_not_walked() -> DescentBlockerSummary {
+    DescentBlockerSummary {
+        may_execute_effect: true,
+        body_not_walked: true,
+        ..DescentBlockerSummary::default()
+    }
+}
+
 /// Memoizing entry point for [`summarize_descent_blockers`].
 fn descent_blocker_summary(jitcode_index: usize) -> DescentBlockerSummary {
     let Some(jitcode) = crate::jitcode_runtime::get_jitcode_ref_by_index(jitcode_index) else {
-        return DescentBlockerSummary::default();
+        // The same condition the descent answers `body_not_walked` for, one
+        // level up and with nothing walked at all.  Unreachable from the gate,
+        // which holds the `JitCode` this index came off; see the note in
+        // `summarize_descent_blockers`.
+        return body_not_walked();
     };
     jitcode.descent_blocker_summary(|| summarize_descent_blockers(jitcode_index, &mut Vec::new()))
 }
@@ -996,9 +1014,22 @@ fn summarize_descent_blockers(
         };
     }
     let Some(jitcode) = crate::jitcode_runtime::get_jitcode_ref_by_index(jitcode_index) else {
-        // No installed body means no descent, so there is nothing to answer
-        // for; the caller declines on the same lookup.
-        return DescentBlockerSummary::default();
+        // A body the scan cannot obtain is a callee it holds nothing about, so
+        // it answers the same way as an `inline_call` whose descr names no
+        // JitCode.  Returning the default instead would say "executes no
+        // effect, holds no blocker" — the most permissive answer there is,
+        // reached by not looking — and would also let the blocker behind such a
+        // call read as effect-free, which asserts a rewind covers it.
+        //
+        // Unreachable in a consistent build, and not for the reason the entry
+        // point's own lookup suggests: `descent_blocker_summary` resolves the
+        // index before calling here, so at the top level this repeats a lookup
+        // that just succeeded and only the `inline_call` descent can arrive
+        // with an index of its own.  `get_jitcode_ref_by_index` answers `None`
+        // only past the end of the table — inside it, the cell is loaded on
+        // demand — and every `JitCode` descr names an index inside it: 2335 of
+        // 2335 in this build, over a table of 2905 whose indices are dense.
+        return body_not_walked();
     };
     seen.push(jitcode_index);
     let descrs = crate::jitcode_runtime::descr_ref_table();
@@ -1054,11 +1085,7 @@ pub(crate) fn summarize_body_blockers(
         // walking a graph already known to be partial can only produce an
         // answer that admits for the wrong reason.  Say what is actually
         // known instead.
-        return DescentBlockerSummary {
-            may_execute_effect: true,
-            body_not_walked: true,
-            ..DescentBlockerSummary::default()
-        };
+        return body_not_walked();
     }
 
     let mut entry_known = vec![None; num_regs_i + constants_i.len()];

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -244,6 +244,48 @@ fn an_inline_call_whose_callee_does_not_resolve_is_a_decline() {
     assert!(summary.may_execute_effect);
 }
 
+/// Every `JitCode` descr names a body the jitcode table holds.
+///
+/// The descent scan answers `body_not_walked` — which declines the descent —
+/// when `get_jitcode_ref_by_index` produces nothing, and that function answers
+/// `None` only past the end of the table.  So whether that arm is ever taken
+/// is exactly this question, and the generated tables settle it rather than a
+/// run does.  Asserted rather than measured once: the comment on the arm says
+/// "unreachable in a consistent build", and this is the consistency it means.
+#[test]
+fn every_jitcode_descr_names_an_installed_body() {
+    let jitcodes = crate::jitcode_runtime::jitcode_count();
+    let descrs = crate::jitcode_runtime::descr_ref_table();
+    let mut named = 0usize;
+    let mut out_of_range = Vec::new();
+    for slot in 0..descrs.len() {
+        let Some(index) = descrs
+            .at(slot)
+            .and_then(|descr| descr.as_jitcode_descr().map(|jc| jc.jitcode_index()))
+        else {
+            continue;
+        };
+        named += 1;
+        if index >= jitcodes {
+            out_of_range.push((slot, index));
+        }
+    }
+    // A table holding no JitCode descr at all would pass the assertion below
+    // while proving nothing, which is the shape of a test that cannot fail.
+    assert!(
+        named > 0,
+        "no JitCode descr among {} descrs -- this test proves nothing here",
+        descrs.len()
+    );
+    assert!(
+        out_of_range.is_empty(),
+        "{} of {named} JitCode descrs name an index outside the {jitcodes}-entry \
+         jitcode table: {out_of_range:?}",
+        out_of_range.len(),
+    );
+    eprintln!("[density] {named} JitCode descrs over {jitcodes} jitcodes");
+}
+
 /// A body the decoder cannot read to the end declines on that alone.  The
 /// instruction starts would otherwise name a prefix, and the `push!` gate drops
 /// targets that are not starts — so every path out of the undecodable byte

--- a/pyre/pyre-jit-trace/src/llbc_fingerprint.rs
+++ b/pyre/pyre-jit-trace/src/llbc_fingerprint.rs
@@ -190,14 +190,22 @@ pub struct FingerprintFields {
     /// repository — the common case.  Kept opaque; this side does not model
     /// the encoding, only whether the value moved.
     pub external: String,
+    /// `artefacts=` verbatim: one `<file name>=<size>:<sha256>` per artefact
+    /// the crate writes, space-separated and `shlex`-quoted.  The only field
+    /// here that describes an OUTPUT rather than an input: the other three
+    /// answer "would a fresh extraction write different bytes", this one
+    /// answers "are these still the bytes it wrote".  Kept opaque for the same
+    /// reason as `external=`.
+    pub artefacts: String,
 }
 
 /// Parse all required fields out of `--fingerprint`'s stdout.
 ///
-/// `external=` is required rather than defaulted to empty.  The driver prints
-/// it on every invocation, so an output without it is a shape this reader does
-/// not model, and defaulting would read "nothing outside the repo" off an
-/// answer that never made that claim.  Its absence collapses to `None` — the
+/// `external=` and `artefacts=` are required rather than defaulted to empty.
+/// The driver prints both on every invocation, so an output without one is a
+/// shape this reader does not model, and defaulting would read "nothing
+/// outside the repo" — or "the bytes are the ones extraction wrote" — off an
+/// answer that never made that claim.  Their absence collapses to `None` — the
 /// oracle did not answer — which is the same disposition an unparseable digest
 /// gets, and which a caller reports rather than passes over in silence.
 pub fn parse_fingerprint_fields(stdout: &str) -> Option<FingerprintFields> {
@@ -208,5 +216,6 @@ pub fn parse_fingerprint_fields(stdout: &str) -> Option<FingerprintFields> {
         source: parse_fingerprint_stdout(stdout)?,
         closure: closure_is_hash.then_some(closure)?,
         external: stamp_field(stdout, "external=")?,
+        artefacts: stamp_field(stdout, "artefacts=")?,
     })
 }

--- a/pyre/pyre-jit-trace/tests/llbc_fingerprint_format_test.rs
+++ b/pyre/pyre-jit-trace/tests/llbc_fingerprint_format_test.rs
@@ -24,6 +24,11 @@ const HASH: &str = "d9b2992606c82b29c531f4f4d6a42e43808564620ab63d781eba135f9307
 // swapped the two, cannot pass. `fail_if_llbc_stale` splits stale from warning
 // on exactly that pair, so the binding is what these tests have to pin.
 const CLOSURE_HASH: &str = "1de0e0c0e50a19e0ea1eb03c8ed0da4b8f3c78dfd3a86d5f6f65f2d0d9f7c4a1";
+// One `artefacts=` line in the producer's encoding: `<file>=<size>:<sha256>`,
+// space-separated and `shlex`-quoted.  Kept opaque by the consumer, so what
+// these tests pin is that it is REQUIRED and passed through verbatim.
+const ARTEFACTS: &str = "artefacts=pyre-object.ullbc=67998098:\
+                         f1c317ad3657d8fed8ef70214c13c196e078195d86b62f67a84149d8e7ca64af";
 
 /// Walk up from this crate until the extraction driver is found.
 fn repo_root() -> Option<std::path::PathBuf> {
@@ -96,18 +101,28 @@ fn real_driver_output_parses() {
 }
 
 #[test]
-fn parses_the_current_three_field_output() {
-    let stdout = format!("source={HASH}\nclosure={CLOSURE_HASH}\nexternal=\n");
+fn parses_the_current_four_field_output() {
+    let stdout = format!("source={HASH}\nclosure={CLOSURE_HASH}\nexternal=\n{ARTEFACTS}\n");
     assert_eq!(parse_fingerprint_stdout(&stdout).as_deref(), Some(HASH));
-    let fields = parse_fingerprint_fields(&stdout).expect("three-field output must parse");
+    let fields = parse_fingerprint_fields(&stdout).expect("four-field output must parse");
     assert_eq!(fields.source, HASH);
     assert_eq!(fields.closure, CLOSURE_HASH);
     assert_eq!(fields.external, "");
+    assert_eq!(fields.artefacts, ARTEFACTS.trim_start_matches("artefacts="));
+}
+
+/// `artefacts=` is the field the build-time gate needs to see a truncated or
+/// swapped artefact at all, so an output missing it is an unmodelled shape
+/// rather than one to read as "the bytes are fine".
+#[test]
+fn output_without_artefacts_is_rejected() {
+    let stdout = format!("source={HASH}\nclosure={CLOSURE_HASH}\nexternal=\n");
+    assert_eq!(parse_fingerprint_fields(&stdout), None);
 }
 
 #[test]
 fn field_order_does_not_matter() {
-    let stdout = format!("external=\nclosure={CLOSURE_HASH}\nsource={HASH}\n");
+    let stdout = format!("{ARTEFACTS}\nexternal=\nclosure={CLOSURE_HASH}\nsource={HASH}\n");
     assert_eq!(parse_fingerprint_stdout(&stdout).as_deref(), Some(HASH));
     let fields = parse_fingerprint_fields(&stdout).expect("reordered output must parse");
     assert_eq!(fields.source, HASH);
@@ -116,7 +131,8 @@ fn field_order_does_not_matter() {
 
 #[test]
 fn an_unknown_trailing_field_is_ignored() {
-    let stdout = format!("source={HASH}\nclosure={HASH}\nexternal=\nsomething_new=42\n");
+    let stdout =
+        format!("source={HASH}\nclosure={HASH}\nexternal=\n{ARTEFACTS}\nsomething_new=42\n");
     assert_eq!(parse_fingerprint_stdout(&stdout).as_deref(), Some(HASH));
 }
 
@@ -148,13 +164,13 @@ fn empty_output_is_rejected() {
 
 #[test]
 fn output_without_closure_is_rejected() {
-    let stdout = format!("source={HASH}\nexternal=\n");
+    let stdout = format!("source={HASH}\nexternal=\n{ARTEFACTS}\n");
     assert_eq!(parse_fingerprint_fields(&stdout), None);
 }
 
 #[test]
 fn a_non_hash_closure_is_rejected() {
-    let stdout = format!("source={HASH}\nclosure=unknown\nexternal=\n");
+    let stdout = format!("source={HASH}\nclosure=unknown\nexternal=\n{ARTEFACTS}\n");
     assert_eq!(parse_fingerprint_fields(&stdout), None);
 }
 

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -126,7 +126,17 @@ pub struct W_SetObject {
 pub const W_SET_GC_TYPE_ID: u32 = 30;
 
 /// GC-managed element table shared by `set` and `frozenset` bodies.
-pub type SetItemsStorage = indexmap::IndexMap<crate::dictmultiobject::ObjectKey, ()>;
+///
+/// Keyed with [`ObjectKeyBuildHasher`](crate::dictmultiobject::ObjectKeyBuildHasher),
+/// the same hasher `ObjectDictStorage` uses: `ObjectKey.hash` already *is*
+/// `space.hash_w(obj)`, so the default `RandomState` would SipHash a digest
+/// that is itself the hash. `rordereddict` feeds the cached integer straight
+/// into the table; the multiply only spreads it into hashbrown's control bits.
+pub type SetItemsStorage = indexmap::IndexMap<
+    crate::dictmultiobject::ObjectKey,
+    (),
+    crate::dictmultiobject::ObjectKeyBuildHasher,
+>;
 
 /// Remove the entry at `index` in O(1).
 ///
@@ -280,13 +290,13 @@ fn set_write_barrier(obj: PyObjectRef) {
 /// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py`), the
 /// `w_dict_new` twin: the body builds the host `SetItemsStorage`
 /// (`IndexMap<ObjectKey, ()>`) box before the object is allocated, so the
-/// foreign `IndexMap::new` construction is an unported host container op.
+/// foreign `IndexMap::default` construction is an unported host container op.
 /// Tracing into it carries that op into the caller; residualising the whole
 /// constructor models it by signature — a plain `PyObjectRef` GCREF.
 #[majit_macros::dont_look_inside]
 pub fn w_set_new() -> PyObjectRef {
     let items =
-        crate::gc_storage::gc_alloc_storage_box(SetItemsStorage::new(), set_items_gc_type_id());
+        crate::gc_storage::gc_alloc_storage_box(SetItemsStorage::default(), set_items_gc_type_id());
     let header = PyObject {
         ob_type: &SET_TYPE as *const PyType,
         w_class: get_instantiate(&SET_TYPE),
@@ -327,12 +337,12 @@ pub fn w_set_new() -> PyObjectRef {
 ///
 /// Same body as [`w_set_new`] with the constant `&FROZENSET_TYPE` baked
 /// into `ob_type`; see that constructor for the GC old-gen rationale.
-/// `#[dont_look_inside]` for the same `IndexMap::new` storage-box reason as
+/// `#[dont_look_inside]` for the same `IndexMap::default` storage-box reason as
 /// [`w_set_new`].
 #[majit_macros::dont_look_inside]
 pub fn w_frozenset_new() -> PyObjectRef {
     let items =
-        crate::gc_storage::gc_alloc_storage_box(SetItemsStorage::new(), set_items_gc_type_id());
+        crate::gc_storage::gc_alloc_storage_box(SetItemsStorage::default(), set_items_gc_type_id());
     let header = PyObject {
         ob_type: &FROZENSET_TYPE as *const PyType,
         w_class: get_instantiate(&FROZENSET_TYPE),
@@ -662,7 +672,7 @@ pub unsafe fn w_set_clear(obj: PyObjectRef) {
     let _set_guard = w_set_lock(obj);
     let s = &mut *(obj as *mut W_SetObject);
     s.items =
-        crate::gc_storage::gc_alloc_storage_box(SetItemsStorage::new(), set_items_gc_type_id());
+        crate::gc_storage::gc_alloc_storage_box(SetItemsStorage::default(), set_items_gc_type_id());
     s.len = 0;
     s.hash = -1;
     set_write_barrier(obj);

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1118,7 +1118,7 @@ def external_fingerprint(eng: Engine, crates: list[str], cargo_features: str) ->
 
     `shlex.quote` per entry, space-separated: a root label is a filesystem path
     and may hold a space or a quote, and the value has to survive as ONE line
-    of a line-oriented stamp. `parse_external` is the inverse.
+    of a line-oriented stamp. `parse_packed` is the inverse.
 
     One stamp KEY, not one key per root. `STAMP_KEYS` is a fixed schema and
     `check` refuses a stamp missing any member of it; deriving the key set from
@@ -1133,11 +1133,13 @@ def external_fingerprint(eng: Engine, crates: list[str], cargo_features: str) ->
     )
 
 
-def parse_external(value: str) -> dict[str, str]:
-    """Split an `external=` stamp value into `{root label: digest}`.
+def parse_packed(value: str) -> dict[str, str]:
+    """Split a packed `<label>=<value>` stamp field into its entries.
 
-    Inverse of `external_fingerprint`'s encoding. `rpartition`, not `partition`:
-    a label may contain `=`, and the hex digest that follows never does.
+    Two fields pack a list into one line this way, `external=` and
+    `artefacts=`; this is the inverse of both encodings. `rpartition`, not
+    `partition`: a label may contain `=`, and the value that follows never
+    does.
     """
     entries: dict[str, str] = {}
     for token in shlex.split(value):
@@ -1155,8 +1157,8 @@ def external_diff(crate: str, recorded: str, expected: str) -> list[str]:
     the repo changed" — a guard that fires without informing, which is the
     shape this field is structured to avoid.
     """
-    was = parse_external(recorded)
-    now = parse_external(expected)
+    was = parse_packed(recorded)
+    now = parse_packed(expected)
     lines: list[str] = []
     for label in sorted(set(was) | set(now)):
         if label not in now:
@@ -1181,6 +1183,107 @@ def external_diff(crate: str, recorded: str, expected: str) -> list[str]:
             f"engine"
         )
     return lines
+
+
+def artefact_token(path: Path) -> str:
+    """One artefact's contribution to `artefacts=`: its size and its digest.
+
+    `missing` rather than a raise. Both sides of the comparison run this, and
+    the side reading the tree has to be able to say "the file the stamp
+    describes is not there" instead of ending the run.
+    """
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return "missing"
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return f"{size}:{digest.hexdigest()}"
+
+
+def describe_artefact(token: str) -> str:
+    """Render one `artefacts=` token for a reader.
+
+    The size is spelled out and the digest abbreviated: a digest pair says
+    only "these differ", where a size pair usually says how.
+    """
+    if token == "missing":
+        return "not there"
+    size, sep, digest = token.partition(":")
+    if not sep:
+        return f"{token!r}, which is not a token this engine writes"
+    return f"{size} bytes, sha256 {digest[:12]}"
+
+
+def artefact_diff(crate: str, recorded: str, expected: str) -> list[str]:
+    """Name WHICH artefact moved, rather than printing two packed lists."""
+    was = parse_packed(recorded)
+    now = parse_packed(expected)
+    lines: list[str] = []
+    for name in sorted(set(was) | set(now)):
+        if name not in now:
+            lines.append(
+                f"{crate}: artefacts: {name!r} is no longer one of this "
+                f"crate's artefacts, but the stamp was written over it"
+            )
+        elif name not in was:
+            lines.append(
+                f"{crate}: artefacts: {name!r} is an artefact the stamp never "
+                f"covered"
+            )
+        elif was[name] != now[name]:
+            lines.append(
+                f"{crate}: artefacts: {name}: stamped "
+                f"{describe_artefact(was[name])}, on disk "
+                f"{describe_artefact(now[name])}"
+            )
+    if not lines:
+        # The packed values differ while every artefact agrees: an encoding
+        # this engine did not write. Reporting nothing here would turn a
+        # mismatch into a silent pass.
+        lines.append(
+            f"{crate}: artefacts: {recorded!r} does not match {expected!r} "
+            f"although every artefact agrees — the value was not written by "
+            f"this engine"
+        )
+    return lines
+
+
+def artefacts_fingerprint(eng: Engine, spec: CrateSpec, dest_dir: Path) -> str:
+    """`artefacts=`'s stamp value: the bytes this stamp was written beside.
+
+    Every other field describes an INPUT, and together they answer "would a
+    fresh extraction write different bytes here". None of them answers "are
+    these still the bytes that extraction wrote". Charon writes its artefact
+    straight to its final path and `write_layout_sidecar` writes the reduced
+    sidecar the same way, so a run killed part-way through either leaves a
+    short file behind — while the previous run's stamp, describing sources
+    that have not moved, stays on disk and goes on reading current. The
+    0-byte test in `check` catches only the kill that landed before the first
+    byte.
+
+    Cost, since `check` recomputes this on every run and a build script runs
+    one: 0.5 s of CPU, 0.7 s of wall clock, over the 980 MB the four pyre
+    artefacts and their sidecars occupy, against the 2.6 s of CPU a check
+    costs without it. Measured with the artefacts in the page cache; a cold
+    read adds its own time.
+    """
+    names = [spec.output_name]
+    names += [spec.layout_sidecar_name(t) for t in crate_layout_targets(eng, spec)]
+    # `shlex.quote` per entry for the same reason `external=` does it: the
+    # value has to survive as ONE line of a line-oriented stamp, and
+    # `parse_packed` splits it back with `shlex.split`.
+    return " ".join(
+        shlex.quote(f"{name}={artefact_token(dest_dir / name)}") for name in names
+    )
+
+
+# The two fields that pack a list into one value. Printing either as an opaque
+# string would hand the reader kilobytes and no answer, so each has a renderer
+# that names the entry that moved.
+PACKED_FIELD_DIFFS = {"external": external_diff, "artefacts": artefact_diff}
 
 
 def _repo_fingerprint(
@@ -1427,6 +1530,7 @@ def stamp_for(
     charon_flags: list[str],
     layout_targets: list[str],
     layout_flags: list[str],
+    artefacts: str,
 ) -> str:
     return "\n".join(
         [
@@ -1455,6 +1559,10 @@ def stamp_for(
             # checkout changed" call for different actions, and collapsing
             # them would repeat the mistake this field exists to fix.
             f"external={external_fingerprint(eng, [crate], cargo_features)}",
+            # The one field about the OUTPUT rather than its inputs: the
+            # artefact bytes, and the layout sidecars beside them, as they
+            # stood when this stamp was written. See `artefacts_fingerprint`.
+            f"artefacts={artefacts}",
         ]
     )
 
@@ -1477,6 +1585,7 @@ STAMP_KEYS = (
     "source",
     "closure",
     "external",
+    "artefacts",
 )
 
 
@@ -2267,6 +2376,7 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
             charon_flags=charon_flags,
             layout_targets=crate_layout_targets(eng, spec),
             layout_flags=layout_flags,
+            artefacts=artefacts_fingerprint(eng, spec, dest_dir),
         )
 
         sidecars = [
@@ -2585,6 +2695,7 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
             charon_flags=charon_flags,
             layout_targets=crate_layout_targets(eng, spec),
             layout_flags=layout_flags,
+            artefacts=artefacts_fingerprint(eng, spec, dest_dir),
         )
         before = parse_stamp(stamp)
         after = parse_stamp(current_stamp)
@@ -2623,6 +2734,11 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
 
 def check(eng: Engine, args: argparse.Namespace) -> None:
     """Refuse an artefact whose stamp does not match the tree it sits beside.
+
+    Or whose own bytes are not the ones that stamp was written beside: a
+    Charon pass writes straight to the artefact's final path, so a run killed
+    part-way leaves a short file under a stamp that still describes unmoved
+    sources. See `artefacts_fingerprint`.
 
     `extract` already computes this comparison — it is the `skipping <crate>
     (fingerprint unchanged)` test — but only a caller who runs the extractor
@@ -2713,6 +2829,10 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
         # most useful on exactly the paths that refuse.
         report_provenance(dest)
 
+        # `artefacts=` covers these too, and says more about them, but this
+        # line is the one that names what a reader loses — and the only one
+        # that survives the arms below, each of which `continue`s on a stamp
+        # that cannot be compared at all.
         for target in crate_layout_targets(eng, spec):
             sidecar = dest_dir / spec.layout_sidecar_name(target)
             if not sidecar.exists() or sidecar.stat().st_size == 0:
@@ -2785,6 +2905,7 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
             charon_flags=charon_crate_flags(spec, features),
             layout_targets=crate_layout_targets(eng, spec),
             layout_flags=crate_layout_flags(spec, features, flags),
+            artefacts=artefacts_fingerprint(eng, spec, dest_dir),
         )
         if text == expected + "\n":
             print(f"    fingerprint matches the tree (source={recorded['source']})")
@@ -2818,17 +2939,37 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
             )
             continue
         for key in differing:
-            if key == "external":
-                # Two packed per-root lists, not two hashes: printing them as
-                # opaque values would hand the reader kilobytes and no answer.
-                stale.extend(
-                    external_diff(crate, recorded[key], want.get(key, ""))
-                )
+            render = PACKED_FIELD_DIFFS.get(key)
+            if render is not None:
+                stale.extend(render(crate, recorded[key], want.get(key, "")))
                 continue
             stale.append(
                 f"{crate}: {key}: artefact says {recorded[key]!r}, "
                 f"tree says {want.get(key)!r}"
             )
+
+    # Files in the artefact directory that no crate claims. Reported, never
+    # gated: nothing reads them, so they cannot make a read unsound — but the
+    # directory is what a person browses, and a sidecar left behind by a
+    # retired layout target sits beside the live ones looking every bit as
+    # current. Scanned against EVERY spec's names rather than the requested
+    # crates, so checking one crate does not report the other three's
+    # artefacts as strays.
+    claimed = set()
+    for spec in eng.specs.values():
+        claimed.add(spec.output_name)
+        claimed.update(
+            spec.layout_sidecar_name(target)
+            for target in crate_layout_targets(eng, spec)
+        )
+    strays = sorted(
+        path.name for path in dest_dir.glob("*.ullbc") if path.name not in claimed
+    )
+    if strays:
+        print()
+        print(f"    NOTE: {len(strays)} file(s) under {dest_dir} no crate claims:")
+        for name in strays:
+            print(f"        {name}")
 
     # Exit 0 requires a positive match for every requested crate, and at least
     # one crate to have been requested. Both halves matter: an empty list has no
@@ -3003,6 +3144,42 @@ def self_test_readfiles_rooting() -> None:
         else:
             raise SystemExit("self-test FAILED: a crate-rooted read set was accepted")
     print("  read-set rooting and cross-target merge: ok")
+
+
+def self_test_artefact_tokens() -> None:
+    """Drive `artefact_token` over states a live artefact cannot be caught in.
+
+    The failure `artefacts=` exists for — a write cut short — leaves a file
+    that is neither absent nor 0 bytes, and that is the one state the artefact
+    checks around it cannot tell from a complete extraction.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "probe.ullbc"
+        path.write_bytes(b"x" * 4096)
+        whole = artefact_token(path)
+        path.write_bytes(b"x" * 4095)
+        short = artefact_token(path)
+        path.write_bytes(b"y" * 4096)
+        swapped = artefact_token(path)
+        path.unlink()
+        gone = artefact_token(path)
+    if gone != "missing":
+        raise SystemExit(
+            f"self-test FAILED: artefact_token reports {gone!r} for a file "
+            f"that is not there"
+        )
+    if len({whole, short, swapped, gone}) != 4:
+        raise SystemExit(
+            f"self-test FAILED: artefact_token does not separate {whole!r} "
+            f"(whole), {short!r} (truncated), {swapped!r} (same size, other "
+            f"bytes) and {gone!r} (absent)"
+        )
+    if describe_artefact(short) == describe_artefact(swapped):
+        raise SystemExit(
+            f"self-test FAILED: a truncated and a swapped artefact both read "
+            f"as {describe_artefact(short)!r}"
+        )
+    print("  artefact tokens separate whole/truncated/swapped/absent: ok")
 
 
 def self_test_provenance_rendering() -> None:
@@ -3395,6 +3572,9 @@ def run_cli(
         # parser and the stamp: folding the cross-target tables in, and
         # refusing names that do not resolve from the repository root.
         self_test_readfiles_rooting()
+        # Same reason, and the only cover `artefacts=` can have: every artefact
+        # this repository has stamped was written whole.
+        self_test_artefact_tokens()
         # Same reason, one artefact along: `--check` renders provenance on every
         # run and exercises neither of its conditional lines, because ordinary
         # sidecars describe steady, complete extractions.

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1428,10 +1428,21 @@ def charon_paths(charon_root: Path) -> tuple[str, Path, Path]:
     return platform_key, charon_dest, charon_dest / charon_exe
 
 
-def llbc_dest(out_dir: Path, root: Path) -> Path:
+def llbc_dest_path(out_dir: Path, root: Path) -> Path:
+    """Where artefacts live, without creating it.
+
+    Split from `llbc_dest` for `--fingerprint`, which now reports on those
+    files: a read-only instrument that silently creates a directory is one
+    whose answer is no longer about the tree it was asked about.
+    """
     dest = Path(os.environ.get("LLBC_DEST", out_dir))
     if not dest.is_absolute():
         dest = root / dest
+    return dest
+
+
+def llbc_dest(out_dir: Path, root: Path) -> Path:
+    dest = llbc_dest_path(out_dir, root)
     dest.mkdir(parents=True, exist_ok=True)
     return dest
 
@@ -3557,10 +3568,24 @@ def run_cli(
             if args.per_crate
             else [("", crates)]
         )
+        dest_dir = llbc_dest_path(eng.out_dir, eng.root)
         for suffix, group in groups:
             print(f"source{suffix}={source_fingerprint(eng, group, cargo_features)}")
             print(f"closure{suffix}={closure_fingerprint(eng, group, cargo_features)}")
             print(f"external{suffix}={external_fingerprint(eng, group, cargo_features)}")
+            # The one field here that describes an OUTPUT.  Without it the
+            # build-time gate -- which asks this subcommand and nothing else --
+            # accepts a truncated or swapped artefact whose sources have not
+            # moved, which is the case `artefacts=` was written for.  Absent
+            # files answer `missing`, so asking before extraction (the CI cache
+            # key does) costs nothing and reads as "not there yet".
+            print(
+                f"artefacts{suffix}="
+                + " ".join(
+                    artefacts_fingerprint(eng, eng.spec(crate), dest_dir)
+                    for crate in group
+                )
+            )
         return
     if args.per_crate:
         parser.error("--per-crate only applies with --fingerprint")


### PR DESCRIPTION
Four changes, each measured before it was made. 1 and 2 are follow-ups #1463 named as deliberately not done; 3 answers the Codex P1 raised against 2 on this PR; 4 fell out of measuring #1463's remaining `set.add` gap, and that measurement refutes the follow-up #1463 named for it.

Commits are in the order they were made, so 4 precedes 3 in the log.

## 1. An uninstalled descent callee no longer reads as a transparent one

`summarize_descent_blockers` answered `DescentBlockerSummary::default()` when
`get_jitcode_ref_by_index` produced nothing — "executes no effect, holds no
blocker", the most permissive answer available, arrived at by not looking. It
also let a blocker sitting behind such a call be reported as effect-free, which
asserts that a rewind covers it. It now answers `may_execute_effect` +
`body_not_walked`, the same answer the `inline_call` arm gives when a descr
does not resolve to a JitCode, and the same one the partial-decode arm in that
function already gave. All three go through one constructor now, and the
memoizing entry point's own copy of the lookup stops defaulting too.

**The branch is unreachable, and I said in the #1463 review reply that it would
stay until that was measured. It now is:**

| | |
|---|---|
| jitcodes in the build's table | 2899 |
| `JitCode` descrs | 2329 |
| descrs naming an index outside the table | **0** |

`get_jitcode_ref_by_index` returns `None` only past the end of the table —
inside it the cell is loaded on demand — so no index a descr can carry reaches
this arm. Note also that the comment's own justification ("the caller declines
on the same lookup") described a path that never arrives there:
`descent_blocker_summary` resolves the index *before* calling in, so only the
recursive `inline_call` descent can arrive with an index of its own. The
comment now says which of the two it is.

Those two counts are a property of the generated tables, not of a run, so they
are asserted rather than quoted: `every_jitcode_descr_names_an_installed_body`
walks the descr table and fails on any index past the end. It also refuses a
table with no `JitCode` descr at all, which would otherwise pass while proving
nothing. (The counts moved between two runs of this branch — 2335/2905 before
\#1473 landed, 2329/2899 after — which is exactly why a number in a comment
was the wrong place to keep this.)

Same standing as the three inert-but-documented changes that landed in #1463:
no behaviour moves, the fail-open stops being the thing a future reader has to
re-derive.

## 2. The fingerprint stamp now covers the artefact bytes

`--check` compared a stamp against the tree it describes and tested the
artefact itself only for existing and for being more than 0 bytes. Charon
writes its artefact straight to the final path and `write_layout_sidecar`
writes the reduced sidecar the same way, so **a run killed part-way leaves a
short file while the previous run's stamp — describing sources that have not
moved — stays beside it and goes on reading current.** The 0-byte test catches
only the kill that landed before the first byte.

(The TODO for this said "the `*.layouts.ullbc` sidecars are outside `--check`".
Half right: `--check` already tested each sidecar for existence and 0 bytes,
and the sidecar passes' own sources already feed `source=`. The gap was the
BYTES, and it was never sidecar-specific — the host artefact had it too.)

`artefacts=` records size + sha256 for the host artefact and every layout
sidecar; `check` recomputes and compares them, and names the file that moved:

```
pyre-jit: artefacts: pyre-jit.ullbc: stamped 131493947 bytes, sha256 eaa8ceed37e9,
                                     on disk 131493946 bytes, sha256 2523f33fba94
pyre-object: artefacts: pyre-object.wasm32-unknown-unknown.layouts.ullbc:
             stamped 1490769 bytes, sha256 08579e2bb745,
             on disk 1662051 bytes, sha256 2ab6123961c4
```

Both rows are from a control run against a clone of `build/llbc`: one byte off
the end of a host artefact, and a sidecar swapped for another target's. The
unmodified clone passes.

**Cost**, since `check` recomputes this on every run and a build script runs
one: 0.5 s of CPU (0.7 s wall) over the 980 MB the four artefacts and their
sidecars occupy, against the 2.6 s of CPU a check costs without it.

Two smaller things in the same change:

* `--self-test` gains the state no artefact on disk is in — a file that is
  neither absent nor empty. Negative controls: a size-only token and a token
  that never reports `missing` are both refused by it.
* `--check` names the files under the artefact directory that no crate claims,
  as a note rather than a refusal. Here that is the two
  `x86_64-apple-darwin.layouts.ullbc` sidecars a retired layout target left
  behind, which is what made the original TODO say the sidecars were unexamined.

**Landing cost:** every stamp already on disk lacks the new field and is
refused until re-extracted — the arm that reports this was written for exactly
this case when `external=` was added. The CI cache keys move to `llbc3-` for
the same reason: an exact key hit skips the Extract step, so without a new
namespace an entry stamped by the older engine would restore and then be
refused.

## Verification

One tree, stage by stage at `dc751528a5`, each stage re-checking the SHA at its
start and its end. The two commits were folded afterwards (the test moved into
the commit whose claim it checks); `git diff dc751528a5 HEAD` is empty, so the
tree these numbers describe is the tree here.

| stage | result |
|---|---|
| `extract-llbc.py` (4 crates) | rc 0 |
| `extract-llbc.py --check` | rc 0 |
| a second `extract-llbc.py` | all four `skipping (fingerprint unchanged)` — the extract-side and check-side `artefacts=` agree |
| `--self-test` | passes; the new case refuses a size-only token and a token that never reports `missing` |
| control on a clone of `build/llbc` | unmodified clone rc 0; one byte off a host artefact rc 1; a sidecar swapped for another target's rc 1 |
| dynasm / cranelift / wasm module / wasm runner | all built |
| `check.py --no-build` | **dynasm 484/484, cranelift 484/484, wasm 476/476, 3/3 backend runs** |
| `cargo test --all --features dynasm,cpyext` | rc 0, 181 test binaries |

Base is `origin/main` 268ffd1bda3. An
earlier run of the same stages was thrown away rather than reported: a rebase
landed while `cargo test` was compiling, so cargo linked the `pyre-interpreter`
it had already built from the pre-rebase sources against the post-rebase
`descr.rs`, and the compile error it produced named a constant that is present
and unconditional in the tree. Nothing was judged by that run.

Note for whoever lands this: the first CI run after it will re-extract all four
crates on every platform, because the cache keys move to `llbc3-`. That is the
one-time cost of the stamp format change, the same one `llbc2-` paid.

## 3. `artefacts=` is now a gate on the path that reads the bytes  *(Codex P1 on this PR)*

Item 2 stamped the artefact bytes and compared them in `--check`. It did not
close the hole it was written for: `fail_if_llbc_stale` — the gate a plain
`cargo build` runs — asks `extract-llbc.py --fingerprint`, and that subcommand
printed `source=`, `closure=` and `external=` only. A truncated or swapped
`.ullbc` under an unchanged source hash therefore passed the build and the
prepass consumed it.

`--fingerprint` now prints `artefacts=` too, `FingerprintFields` carries it,
and the gate reads a mismatch as **stale** and an absent stamp line as
**unknown** — the same disposition `external=` already had. The stale line for
this field names the crate and points at `--check` instead of putting two
per-file lists on one cargo line. `llbc_dest_path` splits the directory
computation off `llbc_dest` so that `--fingerprint`, a read-only instrument,
does not create `build/llbc` as a side effect.

End-to-end control, on the real tree, with one byte of `pyre-object.ullbc`
flipped so the **size is unchanged** and only the digest moves:

| | |
|---|---|
| `--check` | rc 1 — `stamped 67826052 bytes, sha256 7ab5482ded4e, on disk 67826052 bytes, sha256 07460e03586b` |
| `cargo build` | **rc 101**, `cargo::error=LLBC STALE: pyre-object.ullbc, or a layout sidecar beside it, is not the bytes its stamp was written over` |
| `source=` among the reasons | **0** — the hole is exactly what the source hash cannot see |
| restored (bytes + mtime) | `--check` rc 0, build rc 0, no `LLBC STALE` line |

Writing that control turned up one thing worth recording: `llbc_layout_sidecars()`
is empty for a native build, so cargo does not `rerun-if-changed` the
cross-target sidecars there. A byte written into one does not re-arm the build
script at all — the gate covers every sidecar `artefacts=` names once it runs,
but it has to be triggered by something cargo watches. The first attempt at
this control corrupted a wasm sidecar and came back green for that reason, not
because the gate was inert.

## 4. The set element table is keyed with the digest it already carries

Not from #1463's list — it fell out of measuring #1463's remaining
`set.add` gap (see below). `SetItemsStorage` was `IndexMap<ObjectKey, ()>`,
i.e. the default `RandomState`, so every set operation SipHashed a value that
*is* `space.hash_w(obj)`. `ObjectDictStorage`, in the same file's neighbour,
already carries `ObjectKeyBuildHasher` — the multiply written for exactly this.

`box_probe.py`, `add_fresh` warm over 700k iterations, dynasm, six interleaved
rounds against the pre-change binary from the same tree:

| | round 1 | 2 | 3 | 4 | 5 | 6 | min |
|---|---|---|---|---|---|---|---|
| before | 24.0 | 24.1 | 27.3 | 23.9 | 26.1 | 24.2 | 23.9 ms |
| after | 18.5 | 18.9 | 19.2 | 18.6 | 18.8 | 19.0 | **18.5 ms** |

Every run of one arm beats every run of the other. Net of the 0.5 ms loop, the
store itself goes 23.4 → 18.0 ms (**−23%**). Mechanism confirmed separately: in
a 6 s `sample` window the base binary has SipHash/`RandomState` frames and the
new one has **zero**. `synth/set_add_method_call` reads 9.5x / 11.6x / 13.5x
against the 12.0x / 12.3x / 14.2x its own comment records.

Set iteration order stops varying with the `RandomState` seed. Dicts already
behaved that way, and CPython/PyPy feed the Python hash straight into their
tables too. `check.py` is green on all three backends over that change.

### What this does *not* fix, and why #1463's stated follow-up was wrong

#1463 named `GuardNotForced` as the rest of the `set.add` gap. Measured, it
is not:

- **Boxing is free.** `add_preboxed` avoids every allocation *and* pays an
  extra list getitem, and lands on the same time as `add_fresh`.
- **`list.append` compiles to no call at all** — it guards
  `W_ListObject.strategy == 1` and stores the unboxed int with
  `SetarrayitemGc`. `set.add` cannot, because `W_SetObject` has exactly one
  strategy, as `setobject.rs`'s own module comment says.
- **`sample`, 4592 samples:** 86% is inside the residual helper's body
  (`dict_keys_equal`, `w_set_lock`, `pin_root`, `try_hash_value`, the macOS TLV
  thunk); ~11% is everything the JIT emitted, loop included. The force
  protocol cannot be worth more than a tenth of the gap.

The real lever is an integer set strategy (`setobject.py IntegerSetStrategy`),
which is a project rather than a follow-up. Recorded, not started.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LLBC freshness checks by validating generated artifact files and detecting missing, changed, or unexpected outputs.
  * Added clearer guidance when LLBC artifacts are stale or require regeneration.
  * Improved safety when analyzing incomplete or undecodable runtime code by treating uncertain regions conservatively.
  * Corrected set and frozenset storage initialization for more consistent hashing behavior.

* **Maintenance**
  * Updated CI caching to use the new LLBC artifact-aware cache format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->