### PR TITLE
gc: the no-identity struct key that lent W_BaseException's type id to every keyless allocation; warnings: the ResourceWarning source object

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2505,6 +2505,49 @@ impl MiniMarkGC {
         Some(self.finish_alloc_in_oldgen(type_id, total_size, ptr))
     }
 
+    /// `PYRE_GC_SIZE_AUDIT`: refuse a block too small for the type its header
+    /// is about to claim.
+    ///
+    /// The header carries the type id and nothing else; the block's extent
+    /// comes from the caller's `total_size`. When the two disagree the
+    /// collector reads the neighbouring blocks as if they were this object's
+    /// fields, and the first symptom appears an arbitrary number of
+    /// collections later, in whichever object happened to follow. Ask at the
+    /// stamp instead, where the caller is still on the stack.
+    ///
+    /// Varsize types are exempt: their items live past `size` and the length
+    /// is not readable here.
+    fn audit_allocation_size(&self, type_id: u32, total_size: usize, obj_addr: usize, kind: &str) {
+        static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        if !*ENABLED.get_or_init(|| std::env::var_os("PYRE_GC_SIZE_AUDIT").is_some()) {
+            return;
+        }
+        if (type_id as usize) >= self.types.len() {
+            return;
+        }
+        let info = self.types.get(type_id);
+        if info.item_size != 0 {
+            return;
+        }
+        let declared = info.size;
+        let payload = total_size.saturating_sub(GcHeader::SIZE);
+        if payload >= declared {
+            return;
+        }
+        panic!(
+            "GC SIZE AUDIT: {kind} allocation at {obj_addr:#x} stamps type_id={type_id} \
+             (declared payload {declared} bytes, {} gc offsets, is_object={}) but the block \
+             carries only {payload} payload bytes (total_size={total_size}). \
+             gc_state={:?} minors={} majors={}\nbacktrace:\n{}",
+            info.gc_ptr_offsets.len(),
+            info.is_object,
+            self.gc_state,
+            self.minor_collections,
+            self.major_collections,
+            std::backtrace::Backtrace::force_capture(),
+        );
+    }
+
     fn finish_alloc_in_oldgen(&mut self, type_id: u32, total_size: usize, ptr: *mut u8) -> GcRef {
         if crate::bh_probe_enabled() {
             let lo = self.nursery.start_ptr() as usize;
@@ -2522,6 +2565,7 @@ impl MiniMarkGC {
         self.bytes_made_old_since_cycle =
             self.bytes_made_old_since_cycle.saturating_add(total_size);
         let obj_addr = (ptr as usize) + GcHeader::SIZE;
+        self.audit_allocation_size(type_id, total_size, obj_addr, "oldgen");
         if crate::gc_lifetime_log_enabled() {
             // Pairs with `[gc][free]`: whether a dangling reference names an
             // object freed after the referrer was born, or one already dead

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -44,6 +44,12 @@ pub(crate) fn resolve_gc_tid(
     if stamped_tid != 0 {
         return Some(stamped_tid);
     }
+    // Zero is the no-STRUCT-identity sentinel, not a key: resolving it would
+    // certify this descr against whichever group was published under the
+    // sentinel, and the guard would then pin a layout nothing here has.
+    if cache_key == 0 {
+        return None;
+    }
     let cache = majit_ir::descr::gc_cache().lock().ok()?;
     resolve(&cache, cache_key).filter(|&tid| tid != 0)
 }

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -2070,6 +2070,14 @@ impl BhDescr {
     /// a struct/array cache slot).  Backends call this instead of
     /// `get_type_id() as u32` so a materialized object carries a header the
     /// collector can trace.
+    ///
+    /// Zero is the no-STRUCT-identity sentinel and never a key — the same
+    /// carve-out `field_descr_ref_from_bh` (`majit-metainterp`) and
+    /// `simple_descr_group_from_bh_size` (`pyre-jit-trace`) already take on
+    /// the mint side.  Resolving it would hand whichever group is published
+    /// under the sentinel its `type_id`, while the block stays sized by THIS
+    /// descr — and the collector then walks the foreign type's GC offsets
+    /// straight off the end of the block.
     pub fn resolve_gc_tid(&self) -> u32 {
         if let BhDescr::Array { gc_type_id, .. } = self
             && *gc_type_id != 0
@@ -2077,16 +2085,20 @@ impl BhDescr {
             return *gc_type_id;
         }
         let raw = self.get_type_id();
-        let resolved = match self {
-            BhDescr::Size { .. } => majit_ir::descr::gc_cache()
-                .lock()
-                .expect("gc_cache poisoned")
-                .resolve_struct_tid(raw),
-            BhDescr::Array { .. } => majit_ir::descr::gc_cache()
-                .lock()
-                .expect("gc_cache poisoned")
-                .resolve_array_tid(raw),
-            _ => None,
+        let resolved = if raw == 0 {
+            None
+        } else {
+            match self {
+                BhDescr::Size { .. } => majit_ir::descr::gc_cache()
+                    .lock()
+                    .expect("gc_cache poisoned")
+                    .resolve_struct_tid(raw),
+                BhDescr::Array { .. } => majit_ir::descr::gc_cache()
+                    .lock()
+                    .expect("gc_cache poisoned")
+                    .resolve_array_tid(raw),
+                _ => None,
+            }
         };
         resolved.unwrap_or(raw as u32)
     }
@@ -2102,16 +2114,20 @@ impl BhDescr {
             return Some(*gc_type_id);
         }
         let raw = self.get_type_id();
-        let resolved = match self {
-            BhDescr::Size { .. } => majit_ir::descr::gc_cache()
-                .lock()
-                .expect("gc_cache poisoned")
-                .resolve_struct_tid(raw),
-            BhDescr::Array { .. } => majit_ir::descr::gc_cache()
-                .lock()
-                .expect("gc_cache poisoned")
-                .resolve_array_tid(raw),
-            _ => None,
+        let resolved = if raw == 0 {
+            None
+        } else {
+            match self {
+                BhDescr::Size { .. } => majit_ir::descr::gc_cache()
+                    .lock()
+                    .expect("gc_cache poisoned")
+                    .resolve_struct_tid(raw),
+                BhDescr::Array { .. } => majit_ir::descr::gc_cache()
+                    .lock()
+                    .expect("gc_cache poisoned")
+                    .resolve_array_tid(raw),
+                _ => None,
+            }
         };
         if matches!(self, BhDescr::Size { .. })
             && resolved.is_some_and(|tid| majit_ir::descr::struct_tid_is_unresolved(raw, tid))
@@ -2422,6 +2438,54 @@ mod tests {
             // both resolve to `false` and the layout comparison is unaffected.
             is_class_word: None,
         }
+    }
+
+    fn size_descr_with_key(size: usize, type_id: u64) -> BhDescr {
+        BhDescr::Size {
+            size,
+            type_id,
+            vtable: 0,
+            owner: String::new(),
+            all_fielddescrs: Vec::new(),
+            is_gc_managed: true,
+        }
+    }
+
+    #[test]
+    fn a_keyless_size_descr_does_not_inherit_the_sentinel_slots_tid() {
+        // Publish a real group under the no-identity key, the way a STRUCT
+        // that stays out of both name registries used to.
+        let planted = majit_ir::descr::make_size_descr_full(0, 328, 31);
+        majit_ir::descr::gc_cache()
+            .lock()
+            .expect("gc_cache poisoned")
+            .register_keyed_size(majit_ir::descr::LLType::Struct(0), planted);
+        assert_eq!(
+            majit_ir::descr::gc_cache()
+                .lock()
+                .expect("gc_cache poisoned")
+                .resolve_struct_tid(0),
+            Some(31),
+            "the plant must occupy the sentinel slot, or this test proves nothing"
+        );
+
+        // A descr that carries no STRUCT identity must not be sized by itself
+        // and headered by the planted group: the collector would read 328
+        // bytes of GC offsets out of a 24-byte block.
+        assert_eq!(size_descr_with_key(24, 0).resolve_gc_tid(), 0);
+        assert_eq!(
+            size_descr_with_key(24, 0).resolved_gc_tid_checked(),
+            Some(0)
+        );
+
+        // A descr that does carry one still resolves through the cache.
+        let key = majit_ir::descr::path_hash("jitcode_tests::KeyedStruct");
+        let keyed = majit_ir::descr::make_size_descr_full(0, 24, 9);
+        majit_ir::descr::gc_cache()
+            .lock()
+            .expect("gc_cache poisoned")
+            .register_keyed_size(majit_ir::descr::LLType::Struct(key), keyed);
+        assert_eq!(size_descr_with_key(24, key).resolve_gc_tid(), 9);
     }
 
     #[test]

--- a/pyre/bench/synth/_pending/caller_f_lasti_across_residual_call.py
+++ b/pyre/bench/synth/_pending/caller_f_lasti_across_residual_call.py
@@ -120,6 +120,59 @@
 # kept failing to do.  Measure before choosing -- and note the snap has NOT been
 # implemented or tested, only shown to produce the right number by hand.
 #
+# ===== 2026-08-25: THE READER-SIDE SNAP IS REFUTED =====
+#
+# The section above left "which side owns the conversion" open and leaned
+# reader-side.  Do not implement it.  A snap inside `fget_f_lasti` breaks two
+# gated fixtures by construction, because the getset is NOT the only producer
+# of a Python-visible `f_lasti`:
+#
+#   * COMPILED code answers the read from `try_walker_specialize_frame_lasti`,
+#     which emits a trace constant `py_pc as i64 * 2` (`specialize.rs`) without
+#     going near `fget_f_lasti` (`pyframe.rs`, one caller, `typedef.rs:8222`).
+#     `bench/synth/frame_lasti_fold_callee_and_bridge` asserts `len(seen) == 1`
+#     across BOTH channels, so snapping one of them makes the two disagree
+#     wherever the raw value is already an instruction -- which is everywhere
+#     except this defect.
+#   * `tb_lasti` is minted from the RAW word: `pytraceback.rs` stores
+#     `last_instruction * 2` verbatim.  `traceback_inlined_callee_lasti_regression`
+#     (:41, :77-81) and `frame_lasti_fold_foreign_frames` (:48, :65-68) both
+#     assert `f_lasti == tb_lasti`, so a snap on one side alone breaks them.
+#   * upstream reads through the getset and needs it raw
+#     (`pypy/interpreter/pyframe.py:675`).
+#
+# A SECOND OBSERVABLE BREAK, not yet exercised by any fixture: a cache-region
+# `last_instr` also makes `frame.f_lineno = N` fail with "can't jump from
+# unreachable code".  `mark_stacks` steps `i + cache_entries + 1`
+# (`pyframe.rs:2238-2239`), so every cache index keeps `MARK_UNINITIALIZED`
+# (`:2029`) and `fset_f_lineno` indexes one of them.  CPython cannot hit this:
+# `TARGET(CALL)` sets `frame->instr_ptr = next_instr` BEFORE `next_instr += 4`,
+# so `_PyInterpreterFrame_LASTI` names the CALL for the callee's whole lifetime
+# and `frame_lineno_set` indexes `stacks[...]` with no snapping at all.  That is
+# the invariant this defect violates, and it says the fix belongs at the WRITER.
+#
+# But the narrow writer change -- "store the CALL's own index" -- is also wrong:
+# the stored value has an exact `+1` inverse applied by every resume consumer
+# (`pyframe.rs:5014` `next_instr() = last_instr + 1`, `eval.rs:12971`
+# `vable_ni = value + 1`), and that derived coordinate becomes `resume_pc`
+# (`eval.rs:12452`), the frame's re-entry point (`call_jit.rs:3522`), the bridge
+# walk's `start_pc`/`lasti_pc` (`trace.rs:1160-1183`) and the green/decline key
+# (`trace.rs:3620-3623`).  Storing `CALL` would make all of those resume at the
+# CALL's FIRST cache word.  It moves the defect onto the resume path.
+#
+# So the honest scope: of 33 field-read sites, only three want the resume
+# coordinate (`PyFrame::next_instr()`, `resume_execute_frame`, and the opaque
+# save/restore pairs); every other reader wants the executing instruction.  A
+# real fix makes `next_instr()` cache-aware and moves the whole `pc - 1` writer
+# family (`state.rs:5728/5744/5929/6249/6442` plus the two `resume_snapshot.rs`
+# sites) and the interpreter's own `set_last_instr_from_next_instr(opcode_pc + 1)`
+# round trip (`pyre-interpreter/src/eval.rs:2338`) together.  There is also no
+# backward helper to build on: `skip_python_trivia_forward` (`diag.rs:254`),
+# `semantic_fallthrough_pc` (`pyjitpl.rs:19`) and all three `skip_caches` copies
+# walk FORWARD, and `decode_instruction_at` backs up over `ExtendedArg` only.
+#
+# That is an epic, not a fix.  Leave the defect filed.
+#
 # NOT the same defect as `_pending/loop_callee_for_header_resume.py`, though it
 # is the same field: there the triple `(last_instr, valuestackdepth, cells)` is
 # torn at a resume; here nothing resumes, a live reader just reads the field.

--- a/pyre/bench/synth/_pending/caller_f_lasti_across_residual_call.py
+++ b/pyre/bench/synth/_pending/caller_f_lasti_across_residual_call.py
@@ -84,6 +84,42 @@
 #     caller-frame-read-from-inside-a-callee receiver, so it is not in play.
 #   * OptHeap eliding the publish: it keeps and hoists the store.
 #
+# ===== 2026-08-25: THE WRONG VALUE IS NOT AN INSTRUCTION AT ALL =====
+#
+# Re-measured after the rebase onto `b9c76982bd6`; the defect is unchanged on
+# both backends, and CPython names the correct answer:
+#
+#   pyre     f_lasti values: [(52, 11074), (58, 8926)]   FAIL
+#   cpython  f_lasti values: [(52, 20000)]               PASS
+#
+# `dis` on `main()` places `CALL` at offset 52 and the next real instruction,
+# `STORE_FAST`, at 60.  So the CALL owns 52..59 -- three cache entries at 54,
+# 56, 58 -- and the wrong answer 58 is the CALL's LAST CACHE SLOT.  It is not a
+# rival instruction offset; it is not an instruction boundary at all.
+#
+# That reframes where the fix can go.  Every refuted line above targets the
+# WRITER or the record ORDER.  The reader was never examined, and CPython holds
+# an invariant the reader currently breaks: `f_lasti` always names an
+# instruction (`_PyInterpreterFrame_LASTI` is derived from `instr_ptr`), never a
+# cache slot.  Snapping a stored `last_instr` that lands inside an instruction's
+# cache region back to its owning instruction turns 58 into 52 -- the measured
+# correct answer -- and touches no resume consumer, because the blackhole and
+# the vable sync read the field directly, not through the getset.
+#
+# The getter is `pyframe.rs` `fget_f_lasti` (returns `self.last_instr` bare,
+# mirroring `pyframe.py fget_f_lasti`), scaled by 2 at `typedef.rs:8222`.
+#
+# !! The open design question is WHICH side owns the conversion, and it is a
+# real one, not a formality.  The stored value is deliberately a RESUME
+# coordinate (`resume_snapshot.rs:680` and `:2624`, both `pc - 1`, with a
+# comment saying a stale one makes a guard resume at the loop header).  Upstream
+# PyPy has no adaptive caches, so its one convention is unambiguous; 3.14's
+# adaptive bytecode is what splits it.  A reader-side snap keeps every resume
+# consumer untouched but leaves two conventions in one slot; a writer-side fix
+# has to satisfy the resume path first and is what the eight refutations above
+# kept failing to do.  Measure before choosing -- and note the snap has NOT been
+# implemented or tested, only shown to produce the right number by hand.
+#
 # NOT the same defect as `_pending/loop_callee_for_header_resume.py`, though it
 # is the same field: there the triple `(last_instr, valuestackdepth, cells)` is
 # torn at a resume; here nothing resumes, a live reader just reads the field.

--- a/pyre/bench/synth/exception_value_op_caught.py
+++ b/pyre/bench/synth/exception_value_op_caught.py
@@ -1,7 +1,10 @@
-# pyre-check: max-pypy-ratio=52
-# pypy's exec time is pinned to the startup-subtraction floor here, so the
-# ratio is not a measurement: the ceiling is twice the slowest ratio the CI
-# runners observe (25.1x), rounded up.
+# No `max-pypy-ratio`: pypy's exec time here sits at the startup-subtraction
+# floor, so the printed ratio is a quotient by a clamped denominator rather
+# than a measurement, and which side of the floor it lands on flips run to run
+# -- which decides whether the ceiling is applied at all.  A ceiling read off
+# such a number gates noise; 175 of the 463 fixtures state none for the same
+# reason, and the ratio is still printed on every run.  This fixture's gates
+# are its three-backend jit-stats baselines.
 N = 100000
 
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -16170,12 +16170,17 @@ fn fileio_method_dealloc_warn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
         .copied()
         .ok_or_else(|| crate::PyError::type_error("_dealloc_warn() requires self"))?;
     if !file_is_closed(self_obj) && file_closefd(self_obj) && file_get_fd(self_obj).is_some() {
-        let source = args.get(1).copied().unwrap_or(self_obj);
-        let repr = unsafe { crate::display::py_repr_wtf8(source)? };
-        crate::warn::warn_category(
+        let _roots = pyre_object::gc_roots::push_roots();
+        let source =
+            crate::module::_warnings::pin_root_slot(args.get(1).copied().unwrap_or(self_obj));
+        let repr = unsafe {
+            crate::display::py_repr_wtf8(pyre_object::gc_roots::shadow_stack_get(source))?
+        };
+        crate::warn::warn_category_source(
             &format!("unclosed file {}", repr.to_string_lossy()),
             "ResourceWarning",
             1,
+            pyre_object::gc_roots::shadow_stack_get(source),
         )?;
     }
     Ok(w_none())

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -3619,10 +3619,11 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let fd = rffi::socket_from_i64(socket_get_attr_i64(obj, "_fd"));
                 if !rffi::is_invalid(fd) {
                     if let Ok(repr) = unsafe { crate::display::py_repr_wtf8(obj) } {
-                        let _ = crate::warn::warn_category(
+                        let _ = crate::warn::warn_category_source(
                             &format!("unclosed {}", repr.to_string_lossy()),
                             "ResourceWarning",
                             1,
+                            obj,
                         );
                     }
                     let _ = unsafe { rffi::close(fd) };

--- a/pyre/pyre-interpreter/src/module/_warnings/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_warnings/mod.rs
@@ -5,7 +5,7 @@ use pyre_object::*;
 
 const VERSION_ATTR: &str = "_filters_version_state";
 
-fn pin_root_slot(value: PyObjectRef) -> usize {
+pub(crate) fn pin_root_slot(value: PyObjectRef) -> usize {
     let _ = pyre_object::gc_roots::pin_root(value);
     pyre_object::gc_roots::shadow_stack_len() - 1
 }

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -6270,7 +6270,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             ),
             Err(_) => "unclosed scandir iterator".to_string(),
         };
-        if let Err(mut error) = crate::warn::warn_category(&message, "ResourceWarning", 1) {
+        if let Err(mut error) =
+            crate::warn::warn_category_source(&message, "ResourceWarning", 1, self_obj)
+        {
             // `W_ScandirIterator._finalize_` reports a warning promoted to an
             // error as unraisable because finalization cannot propagate it.
             error.write_unraisable(

--- a/pyre/pyre-interpreter/src/warn.rs
+++ b/pyre/pyre-interpreter/src/warn.rs
@@ -44,6 +44,31 @@ pub fn warn_category(
     warn_category_w(pyre_object::w_str_new(msg), category_name, stacklevel)
 }
 
+/// `PyErr_ResourceWarning(source, stacklevel, format, ...)` -- the same warning
+/// carrying the object it is about.
+///
+/// `_py_warnings._formatwarnmsg_impl` reads `msg.source`: with it the message
+/// gains the object's allocation traceback, or the "Enable tracemalloc to get
+/// the object allocation traceback" line when tracing is off.  A warning
+/// raised with no source gets neither line, so every finalizer that reports an
+/// unclosed resource passes itself.
+pub fn warn_category_source(
+    msg: &str,
+    category_name: &str,
+    stacklevel: i64,
+    source: PyObjectRef,
+) -> Result<(), crate::PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let source_slot = crate::module::_warnings::pin_root_slot(source);
+    let msg_slot = crate::module::_warnings::pin_root_slot(pyre_object::w_str_new(msg));
+    warn_category_w_source(
+        pyre_object::gc_roots::shadow_stack_get(msg_slot),
+        category_name,
+        stacklevel,
+        pyre_object::gc_roots::shadow_stack_get(source_slot),
+    )
+}
+
 /// `space.warn(w_msg, w_warningcls, stacklevel)` — hands the message to
 /// `_warnings.do_warn` with `stacklevel - 1`, so the filters, the module
 /// `__warningregistry__` and `warnings.catch_warnings(record=True)` all
@@ -52,6 +77,15 @@ pub fn warn_category_w(
     w_msg: PyObjectRef,
     category_name: &str,
     stacklevel: i64,
+) -> Result<(), crate::PyError> {
+    warn_category_w_source(w_msg, category_name, stacklevel, pyre_object::PY_NULL)
+}
+
+fn warn_category_w_source(
+    w_msg: PyObjectRef,
+    category_name: &str,
+    stacklevel: i64,
+    source: PyObjectRef,
 ) -> Result<(), crate::PyError> {
     // Upstream reaches the filters and the once-registry through
     // `space.fromcache(State)`, which exists from space construction and which
@@ -70,7 +104,7 @@ pub fn warn_category_w(
         warn(&text, category_name);
         return Ok(());
     };
-    crate::module::_warnings::do_warn(w_msg, category, stacklevel - 1, pyre_object::PY_NULL, &[])
+    crate::module::_warnings::do_warn(w_msg, category, stacklevel - 1, source, &[])
 }
 
 /// `do_warn_explicit`'s stderr format without the location prefix, for

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -776,6 +776,34 @@ fn build_object_descr_group_with_def_path(
         def_path,
         &[],
         &[],
+        "",
+    )
+}
+
+/// [`build_object_descr_group_with_def_path`] for a STRUCT that must stay out
+/// of BOTH name registries — one whose per-instance vtable differs while the
+/// layout does not, so a shared name slot would be first-write-wins and lose
+/// the other vtables — yet still needs a `gc_cache._cache_size` identity.
+/// `cache_key_name` supplies that identity directly; without it the group
+/// lands on the no-identity key and its `type_id` becomes the header tid for
+/// every keyless struct the blackhole and resume paths allocate.
+fn build_object_descr_group_keyed_only(
+    obj_size: usize,
+    type_id: u32,
+    vtable: usize,
+    fields: &[(&'static str, usize, usize, Type, bool, bool, bool)],
+    cache_key_name: &str,
+) -> PyreObjectDescrGroup {
+    build_object_descr_group_with_extra_gc_edges(
+        obj_size,
+        type_id,
+        vtable,
+        fields,
+        "",
+        "",
+        &[],
+        &[],
+        cache_key_name,
     )
 }
 
@@ -797,6 +825,7 @@ fn build_object_descr_group_with_field_indices(
         def_path,
         &[],
         field_indices,
+        "",
     )
 }
 
@@ -816,8 +845,17 @@ fn build_object_descr_group_with_extra_gc_edges(
     def_path: &str,
     extra_gc_edges: &[Arc<dyn FieldDescr>],
     field_indices: &[u32],
+    cache_key_name: &str,
 ) -> PyreObjectDescrGroup {
-    let cache_key = if !def_path.is_empty() {
+    // `cache_key_name` names the `gc_cache._cache_size` STRUCT identity for a
+    // group that publishes under neither name registry.  Zero is the
+    // no-STRUCT-identity sentinel, not a key: a group keyed there collapses
+    // onto whichever no-name group is inserted first, and `resolve_gc_tid`
+    // then hands that group's `type_id` to every header write whose descr
+    // carries no key — stamping one STRUCT's tid on another STRUCT's block.
+    let cache_key = if !cache_key_name.is_empty() {
+        majit_ir::descr::path_hash(cache_key_name)
+    } else if !def_path.is_empty() {
         majit_ir::descr::path_hash(def_path)
     } else if !simple_name.is_empty() {
         majit_ir::descr::path_hash(simple_name)
@@ -2721,6 +2759,7 @@ static PYFRAME_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
         "pyframe::PyFrame",
         std::slice::from_ref(&PYFRAME_VABLE_TOKEN_FIELD_DESCR),
         &[],
+        "",
     )
 });
 
@@ -4455,7 +4494,7 @@ pub fn specialised_tuple_oo_size_descr() -> DescrRef {
 /// is written separately by the raise lowering; the remaining pointer slots
 /// stay zeroed by GC pointer clearing (PY_NULL), matching `w_exception_new_empty`.
 fn build_w_exception_group(kind: ExcKind) -> PyreObjectDescrGroup {
-    build_object_descr_group_with_def_path(
+    build_object_descr_group_keyed_only(
         W_BASE_EXCEPTION_SIZE,
         W_BASE_EXCEPTION_GC_TYPE_ID,
         exc_kind_to_pytype(kind) as *const _ as usize,
@@ -4816,12 +4855,15 @@ fn build_w_exception_group(kind: ExcKind) -> PyreObjectDescrGroup {
                 false,
             ),
         ],
-        // Empty name: the per-kind vtable means a shared "W_BaseException"
-        // name-registry slot would be first-write-wins and lose the other
-        // kinds' vtables.  NewWithVtable embeds the SizeDescr in the op, so
-        // the name-registry publish is not needed here.
-        "",
-        "",
+        // Out of both name registries: the per-kind vtable means a shared
+        // "W_BaseException" name-registry slot would be first-write-wins and
+        // lose the other kinds' vtables.  NewWithVtable embeds the SizeDescr
+        // in the op, so the name-registry publish is not needed here.  The
+        // `_cache_size` identity is still required: `resolve_gc_tid` reads the
+        // header tid for a serialized `BhDescr` out of that slot, and every
+        // kind shares one layout and one `W_BASE_EXCEPTION_GC_TYPE_ID`, so one
+        // key for all of them is exactly the STRUCT identity they have.
+        "W_BaseException",
     )
 }
 
@@ -4920,7 +4962,7 @@ static PYTRACEBACK_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|
         PYTRACEBACK_W_CODE_OFFSET, PYTRACEBACK_W_NEXT_OFFSET,
     };
 
-    build_object_descr_group_with_def_path(
+    build_object_descr_group_keyed_only(
         PYTRACEBACK_OBJECT_SIZE,
         PYTRACEBACK_GC_TYPE_ID,
         &PYTRACEBACK_TYPE as *const _ as usize,
@@ -4980,8 +5022,10 @@ static PYTRACEBACK_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|
                 false,
             ),
         ],
-        "",
-        "",
+        // Out of both name registries, but the `_cache_size` STRUCT identity
+        // still has to be its own: sharing the no-identity key hands
+        // `PYTRACEBACK_GC_TYPE_ID` to every keyless struct header write.
+        "PyTraceback",
     )
 });
 
@@ -5317,6 +5361,43 @@ pub fn pyframe_flags_descr() -> DescrRef {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every group that stays out of both name registries still needs a
+    /// `gc_cache._cache_size` STRUCT identity.  Sharing the no-identity key
+    /// makes whichever group lands there the header tid for every keyless
+    /// struct the blackhole and resume paths allocate, so a 24-byte block gets
+    /// stamped `W_BASE_EXCEPTION_GC_TYPE_ID` and the collector then reads 36
+    /// GC offsets across its neighbours.
+    #[test]
+    fn name_registry_less_groups_still_carry_a_cache_size_identity() {
+        let (exception, ..) = w_exception_descrs(ExcKind::ValueError);
+        let exception = exception.as_size_descr().expect("exception SizeDescr");
+        assert_ne!(exception.cache_key(), 0);
+        assert_eq!(
+            majit_ir::descr::gc_cache()
+                .lock()
+                .expect("gc_cache poisoned")
+                .resolve_struct_tid(exception.cache_key()),
+            Some(W_BASE_EXCEPTION_GC_TYPE_ID)
+        );
+
+        let traceback = pytraceback_size_descr();
+        let traceback = traceback.as_size_descr().expect("PyTraceback SizeDescr");
+        assert_ne!(traceback.cache_key(), 0);
+        assert_ne!(traceback.cache_key(), exception.cache_key());
+
+        // And neither of them may be reachable through the sentinel: that is
+        // the slot a serialized `BhDescr` with no key lands on.
+        let sentinel = majit_ir::descr::gc_cache()
+            .lock()
+            .expect("gc_cache poisoned")
+            .resolve_struct_tid(0);
+        assert_ne!(sentinel, Some(W_BASE_EXCEPTION_GC_TYPE_ID));
+        assert_ne!(
+            sentinel,
+            Some(pyre_interpreter::pytraceback::PYTRACEBACK_GC_TYPE_ID)
+        );
+    }
 
     #[test]
     fn native_user_mapdict_fields_replace_prepass_placeholder_indices() {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4510,6 +4510,7 @@ fn build_gc() -> Box<MiniMarkGC> {
              next collection. Register each in build_gc: {unregistered:?}",
         );
     }
+
     // rclass.py — assign subclassrange_{min,max} to each
     // vtable entry. freeze_types() runs assign_inheritance_ids
     // (normalizecalls.py:373-389), then we write the computed ranges
@@ -11506,8 +11507,14 @@ fn allocate_with_vtable(descr: &dyn majit_ir::SizeDescr) -> usize {
     let vtable = descr.vtable();
     let bh_descr = majit_translate::jitcode::BhDescr::Size {
         size,
-        // `descr.py` cache identity via `SizeDescr.cache_key()`.
-        type_id: descr.cache_key(),
+        // `resolve_gc_tid`'s producer contract: `allocate_with_vtable` widens
+        // the descr's own dense tid into the slot rather than serializing the
+        // `cache_key`, so the header the block gets is the layout the block
+        // was sized for.  The `BlackholeAllocator::allocate_with_vtable`
+        // sibling already does this; routing through the keyed cache instead
+        // resolves whatever group holds this descr's key — and a descr minted
+        // without one (`make_size_descr_with_vtable`) carries key 0.
+        type_id: descr.type_id() as u64,
         vtable: vtable as u64,
         owner: String::new(),
         all_fielddescrs: majit_translate::jitcode::bh_field_specs_from_size_descr(descr),


### PR DESCRIPTION
## `jit, gc:` the no-identity struct key (`c31bad5a296`)

The intermittent `GC BUG: invalid major child type_id=…` on `test.test_datetime`
is a tid/size mismatch stamped at **allocation**, not a use-after-free.

`build_w_exception_group` and `PYTRACEBACK_DESCR_GROUP` pass an empty
`simple_name` and `def_path` so they stay out of both name registries. The
factory derived `cache_key = 0` from that and published both groups into
`_cache_size[LLType::Struct(0)]`.

`BhDescr::Size.type_id` carries that cache-key namespace, not the dense tid, and
`resolve_gc_tid` maps it back through `_cache_size`. A descr minted by
`make_size_descr_with_vtable` / `make_size_descr_full` carries key 0 — so a
**keyless** descr resolved the sentinel slot and inherited whichever group sat
there, while the block stayed sized by the descr itself:

```
bh_alloc_struct -> alloc_oldgen_typed(31, 24)
  => a 32-byte arena block whose header claims a 328-byte W_BaseException
     with 36 GC offsets
  => the next major mark reads the neighbouring blocks as its fields
```

That is why every sighting reported `holder_type_id=31`, and why the invalid
child tid differed run to run — it is whatever precedes an arena page.

Zero is the documented no-STRUCT-identity sentinel; `field_descr_ref_from_bh`
and `simple_descr_group_from_bh_size` already carve it out on the mint side.
`resolve_gc_tid` did not.

**The change**

- `build_object_descr_group_with_extra_gc_edges` takes a `cache_key_name`, and a
  new `build_object_descr_group_keyed_only` wrapper supplies a `_cache_size`
  identity **without** either name-registry publish. The exception groups key on
  `"W_BaseException"` — one layout and one `W_BASE_EXCEPTION_GC_TYPE_ID` across
  every `ExcKind`, and the per-kind vtable rides on the *returned* group, not the
  cached one — and the traceback group on `"PyTraceback"`.
- `resolve_gc_tid`, `resolved_gc_tid_checked` and
  `optimizeopt::info::resolve_gc_tid` no longer consult the cache for key 0.
- The free `allocate_with_vtable` serializes `descr.type_id()` rather than
  `descr.cache_key()` — the producer contract `resolve_gc_tid` documents and its
  `BlackholeAllocator` sibling already kept.
- `PYRE_GC_SIZE_AUDIT` (opt-in) panics with a backtrace when an old-gen
  allocation stamps a fixed-size type whose declared payload exceeds the block.
  It is what named this site, and it is the regression detector for the class.

**Verification**

| check | before | after |
|---|---|---|
| `PYRE_GC_SIZE_AUDIT=1 … test_strptime.py` | panics on run 1 | 3/3 rc=0 |
| `test_strptime.py` ×10 (scored by exit status) | 10/10 crash under the dangling detector | 10/10 rc=0 |
| `test_datetime.py` ×3 | — | 3/3 rc=0 |
| `PYPY_GC_NURSERY=262144 -c 'print("ok")'` ×3 | — | 3/3 rc=0 |
| CPython suite (dynasm, 4 jobs) | — | **223 PASS / 0 FAIL / 0 CRASH**, no regressions |
| `cargo test -p majit-translate` | — | 3282 passed / 0 failed |
| `cargo test -p pyre-jit-trace` | — | 399 passed / 0 failed |

Two unit tests pin the rule: a keyless `BhDescr::Size` must not inherit a
planted sentinel-slot tid, and neither name-registry-less group may be reachable
through the sentinel.

## `warnings:` the ResourceWarning source object (`34013dd8b46`)

`do_warn` has taken a `source` parameter all along, but `warn_category` and
`warn_category_w` passed `PY_NULL` for every caller, so all three finalizers that
report an unclosed resource dropped it — and `_formatwarnmsg_impl` gates its whole
tracemalloc block on `msg.source is not None`, so the trailing "Enable tracemalloc
to get the object allocation traceback" line was never emitted. Adds
`warn_category_source` and routes `FileIO._dealloc_warn`, the `scandir` iterator
finalizer and `socket.__del__` through it.

`test.test_warnings` stays FAIL: `test_tracemalloc` also needs the warning reported
at the refcount drop and a working `_tracemalloc`.

## `bench/`

Three recording-only commits: the pypy ratio ceiling on
`exception_value_op_caught`, and two `_pending` notes refuting the reader-side
`f_lasti` snap.

## Correction to an earlier revision of this description

An earlier revision of this description claimed `cargo test -p
majit-metainterp --lib` does not compile. That was my invocation error, not a
defect: the crate has no default backend (`majit/majit-metainterp/Cargo.toml` —
"Backend selection is mandatory and intentionally has no default"), so the bare
form stops at `pyjitpl.rs:94`'s `compile_error!` and the `[TerminalExitLayout]`
errors are cascade fallout from it. Build it the way CI does —
`cargo test --all --no-default-features --features dynasm,cpyext`, or
`cargo test -p majit-metainterp --lib --features dynasm` for the single crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuYePQknDcMCUsy8omQ1fh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource warnings for unclosed files, sockets, and directory iterators by associating each warning with the relevant object.
  * Fixed edge cases in garbage-collection type identification and allocation checks, improving runtime reliability.
  * Corrected handling of descriptors without cache identities to prevent incorrect type resolution.

* **Diagnostics**
  * Added an opt-in garbage-collection size audit to detect undersized allocations with detailed diagnostic information.

* **Documentation**
  * Added investigation notes for a pending residual-call traceback issue.
  * Clarified benchmark configuration and expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
