### PR TITLE
jit-trace: fold len() on an exact set or frozenset to a field read

### DIFF
--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1457,6 +1457,69 @@ static W_BYTEARRAY_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|
     )
 });
 
+/// `W_SetObject`, the body `set` and `frozenset` share.
+///
+/// `setobject.py W_BaseSetObject.length` is `self.strategy.length(self)`; pyre
+/// keeps the count in a field of the body instead, so the answer is one read
+/// once the receiver's class is pinned.  `len` is declared MUTABLE even though
+/// a published `frozenset` never moves it: the field is the same slot on both
+/// types and every mutator that moves the count -- `w_set_add`,
+/// `w_set_discard`, `w_set_clear`, `w_set_popitem` and the bulk updates --
+/// stores through `set_len_relaxed`, so a read must not hoist out of a loop
+/// that can mutate the receiver.  The slot is an `AtomicUsize` written
+/// `Relaxed`; the descr declares it `Type::Int` at `offset_of!`, the same
+/// declaration `W_ListObject.length` and `W_BytearrayObject.length` carry
+/// over their own atomic slots.
+///
+/// One STRUCT gets one def-path-keyed group (see [`DECLARED_GROUPS`]), so the
+/// vtable here is `SET_TYPE` and a `frozenset` receiver reads its length
+/// through the same field descr.  The parent vtable is consulted in exactly
+/// one place — `protect_speculative_field`, off `optimizeopt`'s
+/// `GETFIELD_GC_PURE_*` branch — and a mutable field never reaches it, which
+/// is the same declaration `set` requires on its own.  Registering a second
+/// group under this def path would not give `frozenset` its own vtable
+/// anyway: `register_keyed_size` arbitrates by field count with both vtables
+/// non-zero, so an equal-length twin loses the slot, and `_cache_field`
+/// re-parenting would cross-wire the two.
+static W_SET_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
+    build_object_descr_group_with_def_path(
+        pyre_object::setobject::W_SET_OBJECT_SIZE,
+        W_SET_GC_TYPE_ID,
+        &pyre_object::setobject::SET_TYPE as *const _ as usize,
+        &[
+            (
+                "items",
+                std::mem::offset_of!(pyre_object::setobject::W_SetObject, items),
+                std::mem::size_of::<*mut pyre_object::setobject::SetItemsStorage>(),
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "len",
+                std::mem::offset_of!(pyre_object::setobject::W_SetObject, len),
+                std::mem::size_of::<usize>(),
+                Type::Int,
+                false,
+                false,
+                false,
+            ),
+            (
+                "hash",
+                std::mem::offset_of!(pyre_object::setobject::W_SetObject, hash),
+                std::mem::size_of::<i64>(),
+                Type::Int,
+                true,
+                false,
+                false,
+            ),
+        ],
+        "W_SetObject",
+        "setobject::W_SetObject",
+    )
+});
+
 static RANGE_ITER_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     build_object_descr_group_with_def_path(
         std::mem::size_of::<pyre_object::functional::W_IntRangeIterator>(),
@@ -4351,6 +4414,12 @@ pub fn bytearray_length_descr() -> DescrRef {
     field_descr_from_group(&W_BYTEARRAY_DESCR_GROUP, 1)
 }
 
+/// `W_SetObject.len` — the count `setobject.py`'s `length` answers with,
+/// reached there through the strategy. Mutable; see [`W_SET_DESCR_GROUP`].
+pub fn set_len_descr() -> DescrRef {
+    field_descr_from_group(&W_SET_DESCR_GROUP, 1)
+}
+
 pub fn str_len_descr() -> DescrRef {
     // Python len(str) returns codepoint count.
     // unicodeobject.py W_UnicodeObject._len() → _length field.
@@ -6785,6 +6854,9 @@ static DECLARED_GROUPS: &[(&str, fn())] = &[
     }),
     ("bytearrayobject::W_BytearrayObject", || {
         LazyLock::force(&W_BYTEARRAY_DESCR_GROUP);
+    }),
+    ("setobject::W_SetObject", || {
+        LazyLock::force(&W_SET_DESCR_GROUP);
     }),
     ("functional::W_IntRangeIterator", || {
         LazyLock::force(&RANGE_ITER_DESCR_GROUP);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -8114,6 +8114,10 @@ enum BuiltinLenSource {
     /// length off the RPython list in `self._data`; pyre mirrors that count
     /// into a field.  Mutable, unlike [`BuiltinLenSource::BytesField`].
     BytearrayField,
+    /// `W_SetObject.len` — `setobject.py W_BaseSetObject.length` answers
+    /// `self.strategy.length(self)`; pyre keeps the count on the body, so the
+    /// read is the same shape as [`BuiltinLenSource::BytearrayField`].
+    SetField,
     /// `tupleobject.py` carries no separate length field, so the length is
     /// `arraylen_gc(wrappeditems)`.
     TupleArrayLen,
@@ -8126,8 +8130,9 @@ enum BuiltinLenSource {
 }
 
 /// `len(x)` on an exact canonical `W_ListObject` / `W_UnicodeObject` /
-/// `W_BytesObject` / `W_BytearrayObject` / `W_TupleObject` / `W_Range`, or on
-/// an arity-2 tuple specialisation:
+/// `W_BytesObject` / `W_BytearrayObject` / `W_SetObject` (as either `set` or
+/// `frozenset`) / `W_TupleObject` / `W_Range`, or on an arity-2 tuple
+/// specialisation:
 /// lower the opaque `bh_call_fn(len_builtin, PY_NULL, x)` residual to the
 /// inline length read the meta-tracer produces upstream
 /// (descroperation.py `_len`): `guard_value(callable)` +
@@ -8139,7 +8144,10 @@ enum BuiltinLenSource {
 ///
 /// Returns `None` (fall through to the generic residual, SAFE) for any
 /// other shape: non-list/str/tuple arg, a subclass, a bound receiver, or wrong
-/// arity.
+/// arity.  `dict` is one of those: `W_DictObject` carries no length word at
+/// all -- `dictmultiobject.py length` goes through the strategy to
+/// `len(unerase(dstorage))`, and pyre's storage is an `IndexMap` whose count
+/// is not a field the trace can read.
 pub(crate) fn try_walker_specialize_builtin_len<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],
@@ -8236,6 +8244,22 @@ pub(crate) fn try_walker_specialize_builtin_len<Sym: WalkSym>(
                 Some(exact),
                 BuiltinLenSource::BytearrayField,
                 pyre_object::bytearrayobject::w_bytearray_len(list_obj),
+            )
+        } else if std::ptr::eq(ob_type, &pyre_object::setobject::SET_TYPE)
+            || std::ptr::eq(ob_type, &pyre_object::setobject::FROZENSET_TYPE)
+        {
+            // Two types over one `W_SetObject` body, so the only thing the two
+            // differ in is which of them the class guard pins — and `ob_type`
+            // is already the one that matched.
+            let exact = pyre_object::pyobject::get_instantiate(&*ob_type);
+            if !std::ptr::eq(w_class, exact) {
+                return Ok(None);
+            }
+            (
+                ob_type as i64,
+                Some(exact),
+                BuiltinLenSource::SetField,
+                pyre_object::setobject::w_set_len(list_obj),
             )
         } else if std::ptr::eq(ob_type, &pyre_object::pyobject::TUPLE_TYPE) {
             let exact = pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::TUPLE_TYPE);
@@ -8413,6 +8437,11 @@ pub(crate) fn try_walker_specialize_builtin_len<Sym: WalkSym>(
             ctx.trace_ctx,
             list_op,
             crate::descr::bytearray_length_descr(),
+        ),
+        BuiltinLenSource::SetField => crate::state::opimpl_getfield_gc_i(
+            ctx.trace_ctx,
+            list_op,
+            crate::descr::set_len_descr(),
         ),
         BuiltinLenSource::RangeField => unreachable!("range returned its wrapped length above"),
         // `specialisedtupleobject.py length()` returns the constant


### PR DESCRIPTION
`try_walker_specialize_builtin_len` folds `len(x)` to a field read for an exact
`list` / `str` / `bytes` / `bytearray` / `tuple` / `range` and the arity-2 tuple
specialisations. `set` and `frozenset` were not in that ladder, so both fell
through to the generic `bh_call_fn(len, PY_NULL, x)` residual — **2
`CallMayForceR` per compiled loop** (preamble and peeled body), 82 optimized ops
where a covered type compiles 64.

`W_SetObject.len` is a plain field, so the arm is the same shape as
`BuiltinLenSource::BytesField`: `GuardClass` + exact `w_class` guard + one
`GetfieldGcI` + `wrapint`.

## One struct, two types, one descr group

`set` and `frozenset` share `W_SetObject`, and a descr group is keyed by def
path, so there is one group and its vtable is `SET_TYPE`; `frozenset` reads its
length through the same field descr.

That is sound because the parent vtable is consulted in exactly one place —
`protect_speculative_field`, off `optimizeopt`'s `GETFIELD_GC_PURE_*` branch
with a constant receiver — which a **mutable** field never reaches, and `len`
has to be mutable for `set` anyway (`w_set_add` / `w_set_remove` write it).

Registering a second group under the same def path would not give `frozenset`
its own vtable in any case: `register_keyed_size` arbitrates by field count
with both vtables non-zero, so an equal-length twin loses the slot, and its
`_cache_field` re-parenting would cross-wire the two.

## Measurements

One type per **process**, module-level loop, 500k iterations, dynasm vs pypy.
(The obvious harness is wrong here: seven legs built from one `make()` closure
share a single code object, so they share the JIT green key and the numbers
come out ordered by position in the list rather than by type.)

| receiver | before | after | pypy |
|---|---|---|---|
| `set` | 42.14 ms | **0.66 ms** | 0.48 |
| `frozenset` | 43.93 ms | **0.65 ms** | 0.48 |
| `dict` | 62.90 ms | 62.90 ms — untouched | 0.51 |
| `list` / `str` (controls) | 0.65 / 0.66 | unmoved | |

Residual calls in the optimized loop: `set` and `frozenset` **2 → 0** (82 → 64
ops); `dict` 2 → 2; `list` / `str` / `bytes` 0 → 0.

## How the arm was graded

`PYRE_FBW_SPEC_CENSUS=1` reports per-fold `consulted` / `fired`, which is what
says *which* arm fired — timing alone cannot.

| | before | after (dynasm & cranelift) |
|---|---|---|
| `set`, `frozenset` | `consulted=1 fired=0` | `fired=1` |
| `dict` | `fired=0` | `fired=0` |
| `list` | `fired=1` | `fired=1` |
| `set` subclass overriding `__len__` | — | `fired=0`, residual kept |

Correctness is checked against values computed without `len`: sizes for both
types, **mutation under the compiled loop** (grow 0 → 100k and shrink back,
proving the read did not hoist), `set` / `frozenset` subclasses that override
`__len__` (must answer 4242 / 777, i.e. must decline), a plain subclass, and a
site alternating `set` and `frozenset`. Clean on dynasm, cranelift and CPython
3.14.

Existing fixtures cover it — `synth/set_update_hot`, `synth/set_key_protocol`
and `synth/dict_set` all flip `builtin_len fired` 0 → 1. (`.jitstats` does not
move: `fired` is not a recorded counter, so for a fold the census is the
coverage instrument and a jitstats delta is not.)

## `dict` is deliberately left out

`W_DictObject` carries no length word at all. `dictmultiobject.py length` is
`self.get_strategy().length(self)` and every strategy answers
`len(unerase(dstorage))`, where the storage is a bare `indexmap::IndexMap` —
and that type is `opacity: Foreign` with no fields in
`build/llbc/pyre-object.<target>.layouts.ullbc`, so there is no offset to mint
a descr from. RPython's own answer is a field (`rordereddict`
`num_live_items`), so a readable length word on the storage box is the
orthodox fix; it is a larger change than an arm and is not attempted here.

## Verification

Green at base `ab4379acdd9` (the pre-merge tip of #1488, whose content is now
in `main` via 1579a6a2411): LLBC re-extract + `--check`, all four builds,
`check.py` **dynasm 484/484 / cranelift 484/484 / wasm 476/476**, `cargo test
--all` 181 binaries, `cargo fmt --check`.

The commit cherry-picks cleanly onto the current `main` (no conflict, identical
99+/3− diff), but that re-verification was **not** re-run at this sha — CI is
the gate here.

One `cargo test --all` run showed `majit-backend-wasm`
`straightline_trace_defers_host_module_until_execution` failing with *"fail
descr registered out of lockstep with its global fail_index"*. That is
unrelated: `majit-backend-wasm` has no dependency edge to any `pyre-*` crate,
and `failguard.rs` calls `fail_descr_base()` and `register_fail_descrs()`
non-atomically against a process-global registry whose own doc comment assumes
a single-threaded host — a `cargo test` thread race. A re-run was 181/181.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved performance of `len()` for exact `set` and `frozenset` values by reading their size directly during optimized execution.
  * Added efficient length retrieval for sets, reducing overhead when repeatedly checking collection sizes.
  * Existing behavior remains unchanged for other collection types and non-exact subclasses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->