### PR TITLE
check: the wasm ratio ceiling's stale allowance claim, the fbw-census ring cutoff, and two inherited reds

### DIFF
--- a/pyre/bench/synth/a_profiler_installed_from_a_call_event_keeps_c_events.py
+++ b/pyre/bench/synth/a_profiler_installed_from_a_call_event_keeps_c_events.py
@@ -1,4 +1,5 @@
 # pyre-check: selfcheck
+# pyre-check: selfcheck-compiles=hot
 # A global trace function installs `sys.setprofile()` from the loop frame's own
 # `call` event, so the frame is already past every gate that decides how it will
 # run by the time it becomes profiled.

--- a/pyre/bench/synth/a_raising_trace_hook_still_owes_the_leave_event.py
+++ b/pyre/bench/synth/a_raising_trace_hook_still_owes_the_leave_event.py
@@ -1,4 +1,5 @@
 # pyre-check: selfcheck
+# pyre-check: selfcheck-compiles=hot
 # A profiler and a trace function are both installed on a loop the JIT already
 # compiled, and the trace callback raises.
 #

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -162,10 +162,17 @@ WASM_TIMEOUT_SCALE = 4.0
 # What does is the rest of the census, and it is worth stating because the
 # ceiling has now been widened twice by a fixture that was never going to be
 # caught by widening it. Two ubuntu runs of one base gate 299 fixtures between
-# them. Outside the two that still carry an allowance (builtin_folds_hot
-# 8.6/9.2x, math_folds_hot 3.9/3.9x) the worst is foriter_make_function_body at
-# 3.74x, then short_circuit_boxed_int_cross_fn 3.0x/3.5x and
-# pickle_terminal_raise_resume steady at 3.4x.
+# them, and the worst is foriter_make_function_body at 3.74x, then
+# short_circuit_boxed_int_cross_fn 3.0x/3.5x and pickle_terminal_raise_resume
+# steady at 3.4x.
+#
+# ⛔Every one of those is a gated reading, not an exempted one: no fixture in
+# the tree carries a `max-wasm-ratio` header any more. This paragraph used to
+# except builtin_folds_hot and math_folds_hot as allowance-holders and no longer
+# can. The ratios are from a base that has since moved -- one later ubuntu run
+# of 249 gated fixtures read pickle_terminal_raise_resume worst at 3.26x with
+# foriter_make_function_body absent from the table, which under the union rule
+# below is a reason to census again, not a refutation of 3.74x.
 #
 # Under the highest-observed-plus-15% rule the allowances are fitted with, that
 # 3.74x asks for 4.30x -- ABOVE this constant. 4.0 is therefore not slack: it

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -232,7 +232,7 @@ its frames on the heap. Lowering it is how the `SubWalkDepthExceeded` decline
 is exercised without building a pathological helper chain; it retires when the
 descent stops recursing on the host stack.
 
-### §6c — Default-OFF diagnostics, censuses and probes (72): keep, cost nothing
+### §6c — Default-OFF diagnostics, censuses and probes (75): keep, cost nothing
 
 Each is inert unless set, so none is a removal target by this file's
 already-ON criterion. They are listed so they cannot be missed again.
@@ -250,8 +250,8 @@ already-ON criterion. They are listed so they cannot be missed again.
 `PYRE_FBW_STRICT_DIAG`,
 `PYRE_FIELD_IDENTITY_CENSUS`,
 `PYRE_FORITER_INFLIGHT_CENSUS`, `PYRE_FOR_ITER_GATE_DIAG`,
-`PYRE_GC_DIAG`, `MAJIT_GC_FREELIST_DIAG`, `PYRE_GEN_ENTRY_DIAG`,
-`PYRE_JD1_DEBUG`, `PYRE_JD1_DUMP`,
+`PYRE_GC_DIAG`, `MAJIT_GC_FREELIST_DIAG`, `PYRE_GC_SIZE_AUDIT`,
+`PYRE_GEN_ENTRY_DIAG`, `PYRE_JD1_DEBUG`, `PYRE_JD1_DUMP`,
 `PYRE_LB_SITE`, `PYRE_LLBC_SKIP_FINGERPRINT_CHECK`, `PYRE_LLBC_STRICT`,
 `PYRE_LOOP_CENSUS`,
 `PYRE_M73_BACKXLAT_TWIN_AUDIT`, `PYRE_M73_EMPTYTWIN_CENSUS`,
@@ -323,6 +323,14 @@ inherited one is startup allocation and moves `guard_failures`; setting the
 gate restores the whole-environment copy, so the size of that effect stays
 measurable on one binary. It goes when the allowlist stops being the thing
 under measurement.
+
+`PYRE_GC_SIZE_AUDIT` is the one entry here that aborts rather than reports: at
+every fixed-size stamp it compares the block's payload against the size the
+type id declares and panics when the block is the smaller of the two. The
+mismatch it looks for is otherwise silent at the stamp and surfaces an
+arbitrary number of collections later in whichever object followed, so the
+audit trades a report for a stack that still holds the caller. It goes when a
+stamp cannot outlive its block's extent.
 
 ## §7 — Additional runtime diagnostic
 

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -866,6 +866,15 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
             const NAME_SLOTS: u32 = 4;
             let mut slot = |i: u32| fbw.call(&mut store, i).unwrap_or(0);
             let walks = slot(0);
+            // `fbw_diag::record` keeps the FIRST `RING_ENTRIES` walks and lets
+            // later ones bump the totals only, while the native reader prints
+            // every walk it takes. A run past the ring therefore hands back a
+            // tally that reads like the whole population and diffs short
+            // against the native one, so name the shortfall instead of leaving
+            // a `sort | uniq -c` over these lines silently truncated.
+            if walks > u64::from(RING_ENTRIES) {
+                eprintln!("[fbw-census] (first {RING_ENTRIES} walks of {walks})");
+            }
             for entry in 0..RING_ENTRIES.min(walks as u32) {
                 let base = RING_BASE + entry * RING_STRIDE;
                 let mut end = String::new();


### PR DESCRIPTION
Two corrections found while attributing `pickle_terminal_raise_resume`'s
wasm/dynasm ratio, plus the two reds this branch's base was carrying.
Nothing here changes a gate or any emitted code.

### `WASM_MAX_DYNASM_RATIO`'s census paragraph named allowance-holders that do not exist

The comment excepted `builtin_folds_hot` and `math_folds_hot` from its
worst-fixture claim as the two that "still carry an allowance". Neither carries
a `# pyre-check: max-wasm-ratio` header, and no other fixture in `pyre/bench`
does either — the only in-tree occurrences are the reader, its error message,
and check.py's own test fixture.

The paragraph's ratios are left as they are, with a note that they come from a
base that has since moved. One later ubuntu run of 249 gated fixtures read
`pickle_terminal_raise_resume` worst at 3.26x with `foriter_make_function_body`
absent from the table, but under the union-of-runs rule the same comment states,
a single run is a reason to census again rather than a refutation of the 3.74x
the following paragraph's arithmetic rests on.

### The wasm fbw-census printed a truncated tally with no mention of the cutoff

`fbw_diag::record` writes the first `RING_ENTRIES` walks into the ring and lets
every later one bump the totals only. The native reader prints a line per walk
it takes, so the two sides are directly diffable only while a run stays inside
the ring. `pickle_terminal_raise_resume` takes **79** walks and printed **24**
lines, which reads like the whole population.

It now prints `[fbw-census] (first 24 walks of 79)` ahead of the records when
the count exceeds the ring, and nothing new for a run inside it. Verified both
directions against a freshly built guest.

### Two selfcheck fixtures did not say what they need compiled

`4630ebc397a` (#1479) added `a_profiler_installed_from_a_call_event_keeps_c_events`
and `a_raising_trace_hook_still_owes_the_leave_event` carrying a bare
`# pyre-check: selfcheck` marker and no directive, which `synth_selfcheck_compiles`
rejects outright — it kills the whole synthetic suite rather than the one fixture.
They were the only two in the tree in that shape.

`PYRE_LOOP_CENSUS=1` prints `[loop-census] loop hot` for both on dynasm and on
wasm, so both now declare `selfcheck-compiles=hot`. Validated through check.py's
own reader and by running the pattern.

### `PYRE_GC_SIZE_AUDIT` was read from the environment with no triage entry

`cef6ccd9334` (#1489) added the size audit's `std::env::var_os` read in
`majit-gc`'s collector without a row, so `every_live_gate_has_a_triage_entry`
failed on all three hosts. It is inert unless set, which puts it in §6c; the
section's stated count was 72 against 74 names already listed, so it now reads
75. The prose notes that it is the one entry there that aborts rather than
reports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Diagnostics**
  * Added an optional garbage-collection size audit that detects undersized blocks and reports failures.
  * Improved diagnostic output when recorded walks exceed the display capacity, clarifying that only the first 24 are shown.

* **Testing**
  * Added compilation checks for additional hot-mode benchmark scenarios.

* **Documentation**
  * Updated WebAssembly ratio-ceiling guidance and revised diagnostic and census counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
