### PR TITLE
pyre-object, majit-translate: relaxed atomics for the container length slots and the `<Atomic*>::store` lowering they need; plus the two gates main is red on

### DIFF
--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -17418,6 +17418,18 @@ fn tyref_input_class_root(ty: &TyRef, llbc: &Llbc) -> Option<String> {
 /// ranges are plain int fields, so a field of one types as that inner
 /// value and its `load`/`store` fold to it (`is_atomic_load`).
 fn tyref_atomic_inner_value_type(ty: &TyRef, llbc: &Llbc) -> Option<ValueType> {
+    match tyref_atomic_leaf(ty, llbc)? {
+        "AtomicPtr" => Some(ValueType::Ref(None)),
+        "AtomicBool" => Some(ValueType::Bool),
+        l if l.starts_with("AtomicI") => Some(ValueType::Int),
+        l if l.starts_with("AtomicU") => Some(ValueType::Unsigned),
+        _ => None,
+    }
+}
+
+/// The `Atomic*` leaf ident of a `core::sync::atomic` type, or `None` when
+/// `ty` is not a std atomic.
+fn tyref_atomic_leaf<'l>(ty: &'l TyRef, llbc: &'l Llbc) -> Option<&'l str> {
     let node = strip_ty_wrappers(tyref_node(ty, llbc)?, llbc)?;
     let id = adt_node_def_id(node)?;
     let name = &llbc.type_by_id(id)?.item_meta.name;
@@ -17441,11 +17453,28 @@ fn tyref_atomic_inner_value_type(ty: &TyRef, llbc: &Llbc) -> Option<ValueType> {
     if !in_atomic_mod {
         return None;
     }
-    match leaf {
-        "AtomicPtr" => Some(ValueType::Ref(None)),
-        "AtomicBool" => Some(ValueType::Bool),
-        l if l.starts_with("AtomicI") => Some(ValueType::Int),
-        l if l.starts_with("AtomicU") => Some(ValueType::Unsigned),
+    Some(leaf)
+}
+
+/// The inner scalar of a `core::sync::atomic` integer/bool wrapper, spelled
+/// as the Rust primitive the wrapper is layout-transparent over
+/// (`AtomicUsize` → `usize`), or `None` for anything else.
+///
+/// `AtomicPtr` is deliberately absent: its inner value is a pointer, which
+/// is already what an unrecognised name answers.
+fn tyref_atomic_inner_scalar_str(ty: &TyRef, llbc: &Llbc) -> Option<&'static str> {
+    match tyref_atomic_leaf(ty, llbc)? {
+        "AtomicBool" => Some("bool"),
+        "AtomicI8" => Some("i8"),
+        "AtomicI16" => Some("i16"),
+        "AtomicI32" => Some("i32"),
+        "AtomicI64" => Some("i64"),
+        "AtomicIsize" => Some("isize"),
+        "AtomicU8" => Some("u8"),
+        "AtomicU16" => Some("u16"),
+        "AtomicU32" => Some("u32"),
+        "AtomicU64" => Some("u64"),
+        "AtomicUsize" => Some("usize"),
         _ => None,
     }
 }
@@ -18496,6 +18525,16 @@ fn tyref_to_ast_string(ty: &TyRef, llbc: &Llbc) -> String {
 }
 
 fn tyref_to_field_layout_string(ty: &TyRef, llbc: &Llbc) -> String {
+    // An atomic wrapper is layout-transparent over its inner scalar, and the
+    // typed side already models a field of one as that inner value
+    // (`tyref_atomic_inner_value_type`).  Spell the field with the scalar so
+    // the string-keyed layout tables — `get_type_flag`, `type_flag_from_str`,
+    // the annotator's field projection — reach the same answer instead of
+    // falling to their unknown-name GC-pointer wildcard, which would mint a
+    // `Ref` field descr against the runtime's `Int` publish.
+    if let Some(scalar) = tyref_atomic_inner_scalar_str(ty, llbc) {
+        return scalar.to_string();
+    }
     let Some(node) = tyref_node(ty, llbc) else {
         return tyref_to_ast_string(ty, llbc);
     };
@@ -25952,6 +25991,92 @@ mod tests {
         assert_eq!(
             super::tyref_to_value_type(&word_ty, &llbc),
             crate::model::ValueType::Int
+        );
+    }
+
+    #[test]
+    fn atomic_field_layout_string_is_the_inner_scalar() {
+        let atomic_decl = |def_id: u64, leaf: &str, size: u64| {
+            serde_json::json!({
+                "def_id": def_id,
+                "item_meta": {
+                    "name": [
+                        {"Ident": ["core", 0]},
+                        {"Ident": ["sync", 0]},
+                        {"Ident": ["atomic", 0]},
+                        {"Ident": [leaf, 0]}
+                    ],
+                    "span": {"data": {
+                        "file_id": 0,
+                        "beg": {"line": 1, "col": 0},
+                        "end": {"line": 1, "col": 8}
+                    }},
+                    "source_text": "pub struct Atomic;",
+                    "attr_info": {"attributes": [], "inline": null, "rename": null, "public": true},
+                    "is_local": false
+                },
+                // Opaque: the scalar spelling comes from the wrapper's own
+                // name, not from reading its `UnsafeCell` payload, which a
+                // dependency artefact does not carry.
+                "kind": "Opaque",
+                "layout": [{
+                    "key": "x86_64-unknown-linux-gnu",
+                    "value": {
+                        "size": size,
+                        "align": size,
+                        "variant_layouts": [{"field_offsets": [0]}],
+                        "repr": {"repr_algo": "Rust", "transparent": false}
+                    }
+                }]
+            })
+        };
+        let file = serde_json::json!({
+            "charon_version": "0.1.201",
+            "has_errors": false,
+            "translated": {
+                "crate_name": "fixture",
+                "type_decls": [
+                    null,
+                    atomic_decl(1, "AtomicUsize", 8),
+                    atomic_decl(2, "AtomicPtr", 8)
+                ],
+                "fun_decls": [],
+                "global_decls": [],
+                "trait_decls": [],
+                "trait_impls": []
+            }
+        });
+        let llbc = Llbc::from_slice(file.to_string().as_bytes()).expect("fixture Llbc parses");
+        let adt_ty = |def_id: u64, args: serde_json::Value| {
+            serde_json::from_value::<super::TyRef>(serde_json::json!({
+                "HashConsedValue": [8, {
+                    "Adt": {"id": {"Adt": def_id}, "generics": {"types": args}}
+                }]
+            }))
+            .expect("fixture TyRef parses")
+        };
+
+        // An integer atomic spells as the scalar it is layout-transparent
+        // over, so the string-keyed field tables land on the same `Int` the
+        // runtime publishes rather than their unknown-name `Ref` wildcard.
+        let usize_ty = adt_ty(1, serde_json::json!([]));
+        assert_eq!(
+            super::tyref_to_field_layout_string(&usize_ty, &llbc),
+            "usize"
+        );
+        assert_eq!(
+            crate::codewriter::call::get_type_flag("usize").1,
+            majit_ir::value::Type::Int
+        );
+
+        // `AtomicPtr` keeps the wrapper spelling: its inner value is a
+        // pointer, which is what the wildcard already answers.
+        let ptr_ty = adt_ty(2, serde_json::json!([{"Literal": {"UInt": "U8"}}]));
+        let ptr_str = super::tyref_to_field_layout_string(&ptr_ty, &llbc);
+        assert_eq!(ptr_str, "AtomicPtr<u8>");
+        assert_eq!(
+            crate::codewriter::call::get_type_flag(&ptr_str).1,
+            majit_ir::value::Type::Ref
         );
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3069,6 +3069,18 @@ struct Lowering<'a> {
     /// carries a stale place, and keyed on the referent being an atomic so a
     /// body's ordinary borrows never enter the map.
     atomic_ref_place: std::collections::HashMap<usize, Place>,
+    /// MIR locals bound to a `core::sync::atomic::Ordering` value, mapped to
+    /// the variant's name.
+    ///
+    /// Charon does not hand the ordering to `load` / `store` as a constant
+    /// operand: it assigns `_i = Ordering::<V>` as a fieldless-enum
+    /// `Aggregate` and passes `move _i`, so the variant is only knowable from
+    /// that statement.  [`Lowering::is_atomic_store`]'s arm folds a `Relaxed`
+    /// store and nothing else — a `Release` store lowered as an unordered
+    /// `FieldWrite` would DROP a barrier the residual call it replaces still
+    /// performs (`w_type_set_version_tag` publishes `version_tag` with
+    /// `Release` against an `Acquire` reader).
+    atomic_ordering_locals: std::collections::HashMap<usize, String>,
     /// MIR locals whose enum discriminant is a translation-time
     /// constant: single-assignment locals bound by an always-`Ok`
     /// decomposed conversion ([`Lowering::try_lower_usize_try_from`]).
@@ -3381,6 +3393,7 @@ impl<'a> Lowering<'a> {
             builder_mode: false,
             index_elem_alias: std::collections::HashMap::new(),
             atomic_ref_place: std::collections::HashMap::new(),
+            atomic_ordering_locals: std::collections::HashMap::new(),
             const_discriminant_locals: std::collections::HashMap::new(),
             multi_assigned_locals: compute_multi_assigned_locals(body),
             result_exc_call_results: Vec::new(),
@@ -4239,6 +4252,16 @@ impl<'a> Lowering<'a> {
                     }
                     None => {
                         self.atomic_ref_place.remove(&(i as usize));
+                    }
+                }
+                // `_i = Ordering::<V>` — the ordering the store arm has to
+                // read before it may fold.  Same last-write-wins discipline.
+                match self.atomic_ordering_variant(&rvalue) {
+                    Some(name) => {
+                        self.atomic_ordering_locals.insert(i as usize, name);
+                    }
+                    None => {
+                        self.atomic_ordering_locals.remove(&(i as usize));
                     }
                 }
                 // Capture the construction `owner_root` if this binding
@@ -8065,7 +8088,25 @@ impl<'a> Lowering<'a> {
                 // an acquire or a release could not be expressed here whether
                 // this arm fired or not.  Relaxed, the only ordering pyre
                 // writes, IS this store exactly.
-                if args.len() == 3 && self.is_atomic_store(&reg) {
+                //
+                // ONLY a `Relaxed` store folds.  A stronger ordering is not
+                // decoration: `w_type_set_version_tag` publishes `version_tag`
+                // with `Release` against `w_type_get_version_tag`'s `Acquire`
+                // reader, and today that store reaches the CALL, which performs
+                // the release.  Replacing it with an unordered `FieldWrite`
+                // would let a traced class mutation publish the new cache key
+                // before the dictionary changes behind it are visible.  So the
+                // ordering is read (`atomic_ordering_locals`) and anything but
+                // `Relaxed` keeps the residual call it has today.
+                if args.len() == 3
+                    && self.is_atomic_store(&reg)
+                    && arg_locals
+                        .get(2)
+                        .copied()
+                        .flatten()
+                        .and_then(|l| self.atomic_ordering_locals.get(&l))
+                        .is_some_and(|ordering| ordering == "Relaxed")
+                {
                     // A receiver this body did not bind as a borrow of a
                     // field — or one borrowing a whole local rather than a
                     // field of one — leaves no place to write to.  Fall
@@ -10611,6 +10652,35 @@ impl<'a> Lowering<'a> {
     /// write emits, so `lower_call` lowers it to the same `FieldWrite`.
     fn is_atomic_store(&self, reg: &RegularCall) -> bool {
         self.is_atomic_method(reg, "store")
+    }
+
+    /// The `core::sync::atomic::Ordering` variant name an `Rvalue::Aggregate`
+    /// builds, or `None` when the rvalue is not one.
+    ///
+    /// Keyed on the enum's own path and read back by variant NAME rather than
+    /// index, so a reordering of `Ordering`'s variants cannot silently turn a
+    /// `Release` into a `Relaxed`.
+    fn atomic_ordering_variant(&self, rvalue: &Rvalue) -> Option<String> {
+        let Rvalue::Aggregate(kind, _) = rvalue else {
+            return None;
+        };
+        // Same head shapes `resolve_aggregate_adt` decodes: a bare `type_id`
+        // or a full `TypeDeclRef` object.
+        let adt = kind.as_object()?.get("Adt")?.as_array()?;
+        let head = adt.first()?;
+        let type_id = match head.as_u64() {
+            Some(id) => id,
+            None => head.get("id")?.get("Adt")?.as_u64()?,
+        };
+        let td = self.llbc.type_by_id(type_id)?;
+        if td.item_meta.name_path() != "core::sync::atomic::Ordering" {
+            return None;
+        }
+        let TypeDeclKind::Enum(variants) = &td.kind else {
+            return None;
+        };
+        let variant_idx = adt.get(1).and_then(serde_json::Value::as_u64)? as usize;
+        Some(variants.get(variant_idx)?.name.clone())
     }
 
     /// `<core::sync::atomic::Atomic*>::<method>(&self, ..)` — an inherent

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3059,15 +3059,22 @@ struct Lowering<'a> {
     /// Variable for a base/index without a backing local (a constant).
     index_elem_alias: std::collections::HashMap<usize, IndexElemAlias>,
     /// MIR locals bound by `_i = &place` where `place` is a
-    /// `core::sync::atomic` slot, mapped to that borrowed place.
+    /// `core::sync::atomic` slot, mapped to the place they borrowed.
     ///
     /// `<Atomic*>::store(&self, v, ord)` is a call, so the write target
     /// survives only as the receiver operand; the load fold gets away with
     /// aliasing the receiver Variable because a read needs no place, but a
-    /// write does.  Recorded last-write-wins like
-    /// [`Lowering::positional_aggregate_locals`], so a rebound local never
-    /// carries a stale place, and keyed on the referent being an atomic so a
-    /// body's ordinary borrows never enter the map.
+    /// write does.  Keyed on the referent being an atomic, so a body's
+    /// ordinary borrows never enter the map.
+    ///
+    /// Only locals outside [`Lowering::multi_assigned_locals`] enter, the
+    /// same restriction [`Lowering::const_discriminant_locals`] carries and
+    /// for the same reason: MIR locals are not SSA and this map is not a
+    /// flow-state, so a local borrowed from `&a` in one block and `&b` in
+    /// another would hand the store whichever block happened to be lowered
+    /// last rather than the definition that reaches it — a write to the
+    /// wrong field.  A local assigned once in the whole body carries the
+    /// reaching place at every use of it; a rebound one stays a call.
     atomic_ref_place: std::collections::HashMap<usize, Place>,
     /// MIR locals bound to a `core::sync::atomic::Ordering` value, mapped to
     /// the variant's name.
@@ -3079,7 +3086,9 @@ struct Lowering<'a> {
     /// store and nothing else — a `Release` store lowered as an unordered
     /// `FieldWrite` would DROP a barrier the residual call it replaces still
     /// performs (`w_type_set_version_tag` publishes `version_tag` with
-    /// `Release` against an `Acquire` reader).
+    /// `Release` against an `Acquire` reader).  Which makes reading the WRONG
+    /// variant a dropped barrier, so this map carries the single-assignment
+    /// restriction for the same reason [`Lowering::atomic_ref_place`] does.
     atomic_ordering_locals: std::collections::HashMap<usize, String>,
     /// MIR locals whose enum discriminant is a translation-time
     /// constant: single-assignment locals bound by an always-`Ok`
@@ -4246,22 +4255,14 @@ impl<'a> Lowering<'a> {
                 // `<Atomic*>::store` through this local can write to the
                 // place rather than to the value it resolved to.  Read
                 // before `build_rvalue` consumes the rvalue.
-                match atomic_ref_referent(&rvalue, self.llbc) {
-                    Some(place) => {
+                if !self.multi_assigned_locals.contains(&(i as usize)) {
+                    if let Some(place) = atomic_ref_referent(&rvalue, self.llbc) {
                         self.atomic_ref_place.insert(i as usize, place);
                     }
-                    None => {
-                        self.atomic_ref_place.remove(&(i as usize));
-                    }
-                }
-                // `_i = Ordering::<V>` — the ordering the store arm has to
-                // read before it may fold.  Same last-write-wins discipline.
-                match self.atomic_ordering_variant(&rvalue) {
-                    Some(name) => {
+                    // `_i = Ordering::<V>` — the ordering the store arm has
+                    // to read before it may fold.
+                    if let Some(name) = self.atomic_ordering_variant(&rvalue) {
                         self.atomic_ordering_locals.insert(i as usize, name);
-                    }
-                    None => {
-                        self.atomic_ordering_locals.remove(&(i as usize));
                     }
                 }
                 // Capture the construction `owner_root` if this binding
@@ -8109,16 +8110,19 @@ impl<'a> Lowering<'a> {
                 {
                     // A receiver this body did not bind as a borrow of a
                     // field — or one borrowing a whole local rather than a
-                    // field of one — leaves no place to write to.  Fall
-                    // through to the ordinary call path, which is what an
-                    // unrecognised `store` already lowers to, rather than
-                    // inventing a target or failing a graph that compiles
-                    // today.
+                    // field of one, or one rebound elsewhere in the body —
+                    // leaves no place to write to.  Fall through to the
+                    // ordinary call path, which is what an unrecognised
+                    // `store` already lowers to, rather than inventing a
+                    // target or failing a graph that compiles today.  The
+                    // place is copied, not taken: one borrow stored through
+                    // twice folds both times.
                     let referent = arg_locals
                         .first()
                         .copied()
                         .flatten()
-                        .and_then(|l| self.atomic_ref_place.remove(&l));
+                        .and_then(|l| self.atomic_ref_place.get(&l))
+                        .map(clone_place);
                     if let Some(referent) = referent {
                         let field_ty = clone_tyref(&referent.ty);
                         if let PlaceKind::Projection(inner, elem) = referent.kind {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8082,13 +8082,26 @@ impl<'a> Lowering<'a> {
                 // gets away with aliasing the receiver Variable; a write does,
                 // so recover the borrowed slot from the `&self` operand
                 // ([`Lowering::atomic_ref_place`]) and emit the same
-                // `FieldWrite` a plain `slot = value` assignment would.  The
-                // ordering arg is discarded, as it is on the load: the traced
-                // model has no fences at all — every field write in a walked
-                // body is already an unordered store — so a body that needed
-                // an acquire or a release could not be expressed here whether
-                // this arm fired or not.  Relaxed, the only ordering pyre
-                // writes, IS this store exactly.
+                // `FieldWrite` a plain `slot = value` assignment would.
+                //
+                // PRECONDITION, and it is a real one: a `FieldWrite` lowers to
+                // one plain machine store, which implements a RELAXED atomic
+                // store only where that store is single-copy atomic — i.e. the
+                // backend emits ONE store for the slot's width.  It does on
+                // every target pyre emits for: `mov` / `str` for a naturally
+                // aligned word or narrower on x86_64 and aarch64, and `iN.store`
+                // for every atomic width on wasm32.  Relaxed buys freedom from
+                // tearing and nothing else — no fence, no `lock` prefix — so
+                // under that condition the emitted access IS the access the
+                // residual call would have performed.  What would break it is a
+                // slot the backend has to split: an `AtomicU64` field on a
+                // 32-bit NATIVE target, which pyre has none of.  The threshold
+                // is deliberately NOT checked here: it is a per-backend store
+                // granularity, not a front-end fact, and spelling it as
+                // `target_word_size()` would decline `AtomicI64` on wasm32,
+                // where `i64.store` is a single instruction.  Adding such a
+                // target means teaching the BACKEND, or declining there.
+                // The load fold rests on the same precondition.
                 //
                 // ONLY a `Relaxed` store folds.  A stronger ordering is not
                 // decoration: `w_type_set_version_tag` publishes `version_tag`

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3058,6 +3058,17 @@ struct Lowering<'a> {
     /// `local_var` by local and only falls back to the recorded
     /// Variable for a base/index without a backing local (a constant).
     index_elem_alias: std::collections::HashMap<usize, IndexElemAlias>,
+    /// MIR locals bound by `_i = &place` where `place` is a
+    /// `core::sync::atomic` slot, mapped to that borrowed place.
+    ///
+    /// `<Atomic*>::store(&self, v, ord)` is a call, so the write target
+    /// survives only as the receiver operand; the load fold gets away with
+    /// aliasing the receiver Variable because a read needs no place, but a
+    /// write does.  Recorded last-write-wins like
+    /// [`Lowering::positional_aggregate_locals`], so a rebound local never
+    /// carries a stale place, and keyed on the referent being an atomic so a
+    /// body's ordinary borrows never enter the map.
+    atomic_ref_place: std::collections::HashMap<usize, Place>,
     /// MIR locals whose enum discriminant is a translation-time
     /// constant: single-assignment locals bound by an always-`Ok`
     /// decomposed conversion ([`Lowering::try_lower_usize_try_from`]).
@@ -3369,6 +3380,7 @@ impl<'a> Lowering<'a> {
             binop_result_locals: compute_binop_result_locals(body),
             builder_mode: false,
             index_elem_alias: std::collections::HashMap::new(),
+            atomic_ref_place: std::collections::HashMap::new(),
             const_discriminant_locals: std::collections::HashMap::new(),
             multi_assigned_locals: compute_multi_assigned_locals(body),
             result_exc_call_results: Vec::new(),
@@ -4217,6 +4229,18 @@ impl<'a> Lowering<'a> {
         let dest_ty = clone_tyref(&dest.ty);
         match dest.kind {
             PlaceKind::Local(i) => {
+                // `_i = &atomic_slot` — remember the referent so a later
+                // `<Atomic*>::store` through this local can write to the
+                // place rather than to the value it resolved to.  Read
+                // before `build_rvalue` consumes the rvalue.
+                match atomic_ref_referent(&rvalue, self.llbc) {
+                    Some(place) => {
+                        self.atomic_ref_place.insert(i as usize, place);
+                    }
+                    None => {
+                        self.atomic_ref_place.remove(&(i as usize));
+                    }
+                }
                 // Capture the construction `owner_root` if this binding
                 // is a positional aggregate, before `build_rvalue`
                 // consumes the rvalue, so `.N` reads of the local can
@@ -8029,6 +8053,50 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `<Atomic*>::store(&self, value, ordering)` — the write twin
+                // of the load fold above.  A read needs no place, so the load
+                // gets away with aliasing the receiver Variable; a write does,
+                // so recover the borrowed slot from the `&self` operand
+                // ([`Lowering::atomic_ref_place`]) and emit the same
+                // `FieldWrite` a plain `slot = value` assignment would.  The
+                // ordering arg is discarded, as it is on the load: the traced
+                // model has no fences at all — every field write in a walked
+                // body is already an unordered store — so a body that needed
+                // an acquire or a release could not be expressed here whether
+                // this arm fired or not.  Relaxed, the only ordering pyre
+                // writes, IS this store exactly.
+                if args.len() == 3 && self.is_atomic_store(&reg) {
+                    // A receiver this body did not bind as a borrow of a
+                    // field — or one borrowing a whole local rather than a
+                    // field of one — leaves no place to write to.  Fall
+                    // through to the ordinary call path, which is what an
+                    // unrecognised `store` already lowers to, rather than
+                    // inventing a target or failing a graph that compiles
+                    // today.
+                    let referent = arg_locals
+                        .first()
+                        .copied()
+                        .flatten()
+                        .and_then(|l| self.atomic_ref_place.remove(&l));
+                    if let Some(referent) = referent {
+                        let field_ty = clone_tyref(&referent.ty);
+                        if let PlaceKind::Projection(inner, elem) = referent.kind {
+                            let value = LinkArg::Value(args[1].clone());
+                            self.emit_projection_write(mir_bb, *inner, elem, value, &field_ty)?;
+                            // `store` returns `()`; the destination binds a
+                            // Void the same way the stringbuilder-append
+                            // marker above does.
+                            self.local_var[dest_local] = Some(
+                                self.graph
+                                    .alloc_value_var_with_type(crate::model::ConcreteType::Void),
+                            );
+                            let target_bb = self.block_id[target];
+                            let link_args = self.edge_args(mir_bb, target)?;
+                            self.graph.set_goto(bb_id, target_bb, link_args);
+                            return Ok(());
+                        }
+                    }
+                }
                 // `(block as *mut u8).add(ITEMS_BLOCK_ITEMS_OFFSET)` inside
                 // an `ItemsBlock` items-base accessor — the interior items
                 // pointer the runtime reads through a `base_size`-bearing
@@ -10534,6 +10602,21 @@ impl<'a> Lowering<'a> {
     /// excludes unrelated inherent `load` methods, and the method name
     /// never reaches the rtyper as a `ptr.getattr`.
     fn is_atomic_load(&self, reg: &RegularCall) -> bool {
+        self.is_atomic_method(reg, "load")
+    }
+
+    /// `<core::sync::atomic::Atomic*>::store(&self, value, ordering)` — the
+    /// write twin of [`Lowering::is_atomic_load`].  A relaxed store to a
+    /// layout-transparent atomic is the same machine store a plain field
+    /// write emits, so `lower_call` lowers it to the same `FieldWrite`.
+    fn is_atomic_store(&self, reg: &RegularCall) -> bool {
+        self.is_atomic_method(reg, "store")
+    }
+
+    /// `<core::sync::atomic::Atomic*>::<method>(&self, ..)` — an inherent
+    /// method of a std atomic, keyed on the receiver's type so a user type
+    /// with a `load` / `store` method of its own does not match.
+    fn is_atomic_method(&self, reg: &RegularCall, method: &str) -> bool {
         let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
             return false;
         };
@@ -10541,7 +10624,7 @@ impl<'a> Lowering<'a> {
             return false;
         };
         let name = fd.item_meta.name_path();
-        if name.rsplit("::").next() != Some("load") {
+        if name.rsplit("::").next() != Some(method) {
             return false;
         }
         fd.signature.inputs.first().is_some_and(|t| {
@@ -16489,6 +16572,45 @@ fn inline_adt_def_id(body: &serde_json::Value) -> Option<u64> {
 /// Clone a [`TyRef`] (no `Clone` impl on the schema enum).  Used by
 /// [`Lowering::resolve_adt_field`] when handing the resolved field's
 /// type to [`tyref_to_value_type`].
+/// The borrowed place behind `_i = &place` / `&raw place`, cloned out of the
+/// rvalue, when `place` names a `core::sync::atomic` slot.  Nothing else is
+/// recorded: the only consumer is [`Lowering::is_atomic_store`]'s write
+/// target.
+fn atomic_ref_referent(rvalue: &Rvalue, llbc: &Llbc) -> Option<Place> {
+    let place = match rvalue {
+        Rvalue::Ref { place, .. } | Rvalue::RawPtr { place, .. } => place,
+        _ => return None,
+    };
+    tyref_atomic_inner_value_type(&place.ty, llbc)?;
+    Some(clone_place(place))
+}
+
+/// Charon's `Place` carries a `TyRef`, which is not `Clone` (see
+/// [`clone_tyref`]); this is the same by-hand deep copy for a whole place.
+fn clone_place(p: &Place) -> Place {
+    Place {
+        kind: match &p.kind {
+            PlaceKind::Local(i) => PlaceKind::Local(*i),
+            PlaceKind::Projection(inner, elem) => {
+                PlaceKind::Projection(Box::new(clone_place(inner)), clone_projection_elem(elem))
+            }
+            PlaceKind::Global { generics, id } => PlaceKind::Global {
+                generics: generics.clone(),
+                id: *id,
+            },
+            PlaceKind::Unknown => PlaceKind::Unknown,
+        },
+        ty: clone_tyref(&p.ty),
+    }
+}
+
+fn clone_projection_elem(e: &ProjectionElem) -> ProjectionElem {
+    match e {
+        ProjectionElem::Atom(s) => ProjectionElem::Atom(s.clone()),
+        ProjectionElem::Tagged(v) => ProjectionElem::Tagged(v.clone()),
+    }
+}
+
 fn clone_tyref(ty: &TyRef) -> TyRef {
     match ty {
         TyRef::Dedup { id } => TyRef::Dedup { id: *id },

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -4198,15 +4198,14 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         if ctx.trace_ctx.heap_cache().is_unescaped(callable_guard_op) {
             return resolved_inline_decline(op.pc, line!());
         }
-        let resolved: Option<KwonlyDefaultsInline> =
-            crate::jitcode_dispatch::diag::spec_gate(
-                crate::jitcode_dispatch::diag::SpecFold::KwonlyDefaultsInline,
-                || {
-                    Ok::<_, DispatchError>(unsafe {
-                        kwonly_defaults_for_inline(callable, w_code, nparams, kwonly_count)
-                    })
-                },
-            )?;
+        let resolved: Option<KwonlyDefaultsInline> = crate::jitcode_dispatch::diag::spec_gate(
+            crate::jitcode_dispatch::diag::SpecFold::KwonlyDefaultsInline,
+            || {
+                Ok::<_, DispatchError>(unsafe {
+                    kwonly_defaults_for_inline(callable, w_code, nparams, kwonly_count)
+                })
+            },
+        )?;
         let Some(resolved) = resolved else {
             return resolved_inline_decline(op.pc, line!());
         };

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1177,7 +1177,7 @@ unsafe fn list_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit
         } else {
             // std::alloc stationary block: forward each live element in place.
             let base = unsafe { pyre_object::object_array::items_block_items_base(list.items) };
-            for i in 0..list.length {
+            for i in 0..list.length_relaxed() {
                 f(unsafe { base.add(i) } as *mut majit_ir::GcRef);
             }
         }

--- a/pyre/pyre-object/src/bytearrayobject.rs
+++ b/pyre/pyre-object/src/bytearrayobject.rs
@@ -3,6 +3,7 @@
 //! PyPy equivalent: pypy/objspace/std/bytearrayobject.py
 
 use crate::pyobject::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub static BYTEARRAY_TYPE: PyType = crate::pyobject::new_pytype("bytearray");
 
@@ -25,7 +26,19 @@ pub struct W_BytearrayObject {
     ///
     /// [`w_bytearray_sync_alloc`] is what keeps this current.  Every mutator
     /// that changes the buffer's length already has to call it, for `alloc`.
-    pub length: usize,
+    ///
+    /// Read WITHOUT a lock, so the slot is an atomic rather than a plain
+    /// `usize`.  `Include/cpython/listobject.h PyList_GET_SIZE` answers a length
+    /// under `Py_GIL_DISABLED` as `_Py_atomic_load_ssize_relaxed(&ob_size)` — a
+    /// relaxed atomic load and no critical section — so a reader is entitled to
+    /// a value from either side of a concurrent mutation but never to a torn
+    /// one.  The JIT's `len` fold lowers to exactly that load through
+    /// `bytearray_length_descr`, while [`w_bytearray_sync_alloc`] writes it;
+    /// only an atomic makes that pair defined.
+    ///
+    /// Same size and bit validity as `usize`, so `offset_of!` and the JIT's
+    /// `Type::Int` read are unchanged.
+    pub length: AtomicUsize,
     /// CPython `PyByteArrayObject.ob_alloc`, including the trailing NUL byte.
     ///
     /// This cannot be derived from `Vec::capacity()`: Rust's allocator uses a
@@ -45,6 +58,20 @@ pub struct W_BytearrayObject {
 
 /// GC type id assigned to `W_BytearrayObject` at JitDriver init time.
 pub const W_BYTEARRAY_GC_TYPE_ID: u32 = 28;
+
+impl W_BytearrayObject {
+    /// `_Py_atomic_load_ssize_relaxed(&ob_size)` on the byte count.
+    #[inline]
+    pub fn length_relaxed(&self) -> usize {
+        self.length.load(Ordering::Relaxed)
+    }
+
+    /// `_Py_atomic_store_ssize_relaxed(&ob_size, n)` on the same slot.
+    #[inline]
+    pub fn set_length_relaxed(&self, n: usize) {
+        self.length.store(n, Ordering::Relaxed);
+    }
+}
 
 /// Fixed payload size (`framework.py:811`).
 pub const W_BYTEARRAY_OBJECT_SIZE: usize = std::mem::size_of::<W_BytearrayObject>();
@@ -97,7 +124,7 @@ fn w_bytearray_alloc(buf: Vec<u8>) -> PyObjectRef {
     let body = W_BytearrayObject {
         ob_header: header,
         data,
-        length,
+        length: AtomicUsize::new(length),
         alloc,
         logical_offset: 0,
         exports: 0,
@@ -165,7 +192,7 @@ pub fn w_bytearray_subclass_from_bytes(bytes: &[u8], w_class: PyObjectRef) -> Py
             w_class: crate::gc_roots::shadow_stack_get(root_base),
         },
         data: crate::lltype::malloc_raw(bytes.to_vec()),
-        length: bytes.len(),
+        length: AtomicUsize::new(bytes.len()),
         alloc: if bytes.is_empty() { 0 } else { bytes.len() + 1 },
         logical_offset: 0,
         exports: 0,
@@ -236,12 +263,12 @@ pub unsafe fn w_bytearray_len(obj: PyObjectRef) -> usize {
         // `length` would be a wrong length in compiled code rather than a
         // wrong answer here.  Debug builds turn that into a test failure.
         debug_assert_eq!(
-            ba.length,
+            ba.length_relaxed(),
             (*ba.data).len(),
             "bytearray length is stale: a mutator changed the buffer without \
              calling w_bytearray_sync_alloc"
         );
-        ba.length
+        ba.length_relaxed()
     }
 }
 
@@ -263,7 +290,7 @@ pub unsafe fn w_bytearray_sync_alloc(obj: PyObjectRef, old_size: usize) {
         let size = (*ba.data).len();
         // Above the early return: `length` tracks every change, while `alloc`
         // only moves when the resize policy says it should.
-        ba.length = size;
+        ba.set_length_relaxed(size);
         if size == old_size {
             return;
         }

--- a/pyre/pyre-object/src/float_array.rs
+++ b/pyre/pyre-object/src/float_array.rs
@@ -1,4 +1,5 @@
 use std::ops::{Index, IndexMut};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::object_array::{
     TYPED_ITEMS_BLOCK_ITEMS_OFFSET, TypedItemsBlock, alloc_typed_items_block,
@@ -23,14 +24,40 @@ pub struct FloatArray {
     /// form ([`FloatArray::empty`]), where the live length and the allocated
     /// capacity are both zero.
     pub block: *mut TypedItemsBlock,
-    /// Live length (rlist.py `("length", Signed)`).
-    len: usize,
+    /// Live length (rlist.py `("length", Signed)`), read WITHOUT a lock.
+    ///
+    /// `Include/cpython/listobject.h PyList_GET_SIZE` answers a length under
+    /// `Py_GIL_DISABLED` as `_Py_atomic_load_ssize_relaxed(&ob_size)` — a
+    /// relaxed atomic load, no critical section — so a reader is entitled to a
+    /// value from either side of a concurrent mutation but never to a torn one.
+    /// The JIT's `len` fold lowers to exactly that load, addressing this slot
+    /// by [`FLOAT_ARRAY_LEN_OFFSET`], which is why it cannot be a plain
+    /// `usize`: the methods below write it while a compiled loop is reading it,
+    /// and only an atomic makes that pair defined.  Every write here is a
+    /// relaxed store for the same reason — `&mut self` bounds no raw-pointer
+    /// reader, so `get_mut()` would put the plain store straight back.
+    ///
+    /// Same size and bit validity as `usize`, so `offset_of!` and the JIT's
+    /// `Type::Int` read are unchanged.
+    len: AtomicUsize,
 }
 
 pub const FLOAT_ARRAY_BLOCK_OFFSET: usize = std::mem::offset_of!(FloatArray, block);
 pub const FLOAT_ARRAY_LEN_OFFSET: usize = std::mem::offset_of!(FloatArray, len);
 
 impl FloatArray {
+    /// `_Py_atomic_load_ssize_relaxed(&ob_size)`.
+    #[inline]
+    fn len_relaxed(&self) -> usize {
+        self.len.load(Ordering::Relaxed)
+    }
+
+    /// `_Py_atomic_store_ssize_relaxed(&ob_size, n)`.
+    #[inline]
+    fn set_len_relaxed(&self, n: usize) {
+        self.len.store(n, Ordering::Relaxed);
+    }
+
     /// Items base pointer (`&l.items[0]`), derived from `block`. The
     /// [`crate::int_array::IntArray::base`] twin — see it for why the empty
     /// form's null `block` is offset rather than branched on.
@@ -45,7 +72,7 @@ impl FloatArray {
     pub fn empty() -> Self {
         Self {
             block: std::ptr::null_mut(),
-            len: 0,
+            len: AtomicUsize::new(0),
         }
     }
 
@@ -53,7 +80,7 @@ impl FloatArray {
         let len = values.len();
         let arr = Self {
             block: unsafe { alloc_typed_items_block(len, gc_float_array_gc_type_id()) },
-            len,
+            len: AtomicUsize::new(len),
         };
         unsafe {
             std::ptr::copy_nonoverlapping(values.as_ptr(), arr.base(), len);
@@ -98,7 +125,7 @@ impl FloatArray {
 
     #[inline]
     pub fn spare_capacity(&self) -> usize {
-        self.capacity().saturating_sub(self.len)
+        self.capacity().saturating_sub(self.len_relaxed())
     }
 
     /// Allocated capacity (block header). The no-resize append fast path
@@ -122,7 +149,7 @@ impl FloatArray {
             new_len <= cap,
             "FloatArray::set_len precondition violated: new_len ({new_len}) > capacity ({cap})"
         );
-        self.len = new_len;
+        self.set_len_relaxed(new_len);
     }
 
     /// Float list storage is always a separate block (no inline buffer);
@@ -140,30 +167,30 @@ impl FloatArray {
             grow_typed_items_block(
                 self.block,
                 target_cap,
-                self.len,
+                self.len_relaxed(),
                 gc_float_array_gc_type_id(),
             )
         };
     }
 
     pub fn push(&mut self, value: f64) {
-        if self.len == self.capacity() {
-            self.grow(self.len + 1);
+        if self.len_relaxed() == self.capacity() {
+            self.grow(self.len_relaxed() + 1);
         }
         unsafe {
-            *self.base().add(self.len) = value;
+            *self.base().add(self.len_relaxed()) = value;
         }
-        self.len += 1;
+        self.set_len_relaxed(self.len_relaxed() + 1);
     }
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.len
+        self.len_relaxed()
     }
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len == 0
+        self.len_relaxed() == 0
     }
 
     pub fn to_vec(&self) -> Vec<f64> {
@@ -171,41 +198,41 @@ impl FloatArray {
     }
 
     pub fn as_slice(&self) -> &[f64] {
-        unsafe { std::slice::from_raw_parts(self.base(), self.len) }
+        unsafe { std::slice::from_raw_parts(self.base(), self.len_relaxed()) }
     }
 
     pub fn as_mut_slice(&mut self) -> &mut [f64] {
-        unsafe { std::slice::from_raw_parts_mut(self.base(), self.len) }
+        unsafe { std::slice::from_raw_parts_mut(self.base(), self.len_relaxed()) }
     }
 
     pub fn insert(&mut self, index: usize, value: f64) {
-        assert!(index <= self.len);
-        if self.len == self.capacity() {
-            self.grow(self.len + 1);
+        assert!(index <= self.len_relaxed());
+        if self.len_relaxed() == self.capacity() {
+            self.grow(self.len_relaxed() + 1);
         }
         unsafe {
             let p = self.base().add(index);
-            std::ptr::copy(p, p.add(1), self.len - index);
+            std::ptr::copy(p, p.add(1), self.len_relaxed() - index);
             *p = value;
         }
-        self.len += 1;
+        self.set_len_relaxed(self.len_relaxed() + 1);
     }
 
     pub fn remove(&mut self, index: usize) -> f64 {
-        assert!(index < self.len);
+        assert!(index < self.len_relaxed());
         let value = self.as_slice()[index];
         unsafe {
             let p = self.base().add(index);
-            std::ptr::copy(p.add(1), p, self.len - index - 1);
+            std::ptr::copy(p.add(1), p, self.len_relaxed() - index - 1);
         }
-        self.len -= 1;
+        self.set_len_relaxed(self.len_relaxed() - 1);
         value
     }
 
     pub fn pop(&mut self) -> f64 {
-        assert!(self.len > 0);
-        let value = self.as_slice()[self.len - 1];
-        self.len -= 1;
+        assert!(self.len_relaxed() > 0);
+        let value = self.as_slice()[self.len_relaxed() - 1];
+        self.set_len_relaxed(self.len_relaxed() - 1);
         value
     }
 
@@ -214,7 +241,7 @@ impl FloatArray {
     }
 
     pub fn splice(&mut self, start: usize, remove_count: usize, new_values: &[f64]) {
-        let old_len = self.len;
+        let old_len = self.len_relaxed();
         let s = start.min(old_len);
         let slicelength = remove_count.min(old_len - s);
         let len2 = new_values.len();
@@ -231,7 +258,7 @@ impl FloatArray {
                     old_len - s - slicelength,
                 );
             }
-            self.len = new_len;
+            self.set_len_relaxed(new_len);
         } else if slicelength > len2 {
             unsafe {
                 let base = self.base();
@@ -241,7 +268,7 @@ impl FloatArray {
                     old_len - s - slicelength,
                 );
             }
-            self.len = new_len;
+            self.set_len_relaxed(new_len);
         }
         if len2 > 0 {
             self.as_mut_slice()[s..s + len2].copy_from_slice(new_values);
@@ -251,20 +278,20 @@ impl FloatArray {
     pub fn drain(&mut self, range: std::ops::Range<usize>) {
         let start = range.start;
         let end = range.end;
-        assert!(start <= end && end <= self.len);
+        assert!(start <= end && end <= self.len_relaxed());
         let count = end - start;
         if count == 0 {
             return;
         }
         unsafe {
             let p = self.base().add(start);
-            std::ptr::copy(p.add(count), p, self.len - end);
+            std::ptr::copy(p.add(count), p, self.len_relaxed() - end);
         }
-        self.len -= count;
+        self.set_len_relaxed(self.len_relaxed() - count);
     }
 
     pub fn clear(&mut self) {
-        self.len = 0;
+        self.set_len_relaxed(0);
     }
 }
 

--- a/pyre/pyre-object/src/int_array.rs
+++ b/pyre/pyre-object/src/int_array.rs
@@ -1,4 +1,5 @@
 use std::ops::{Index, IndexMut};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::object_array::{
     TYPED_ITEMS_BLOCK_ITEMS_OFFSET, TypedItemsBlock, alloc_typed_items_block,
@@ -27,14 +28,40 @@ pub struct IntArray {
     /// empty form ([`IntArray::empty`]), where the live length and the
     /// allocated capacity are both zero.
     pub block: *mut TypedItemsBlock,
-    /// Live length (rlist.py `("length", Signed)`).
-    len: usize,
+    /// Live length (rlist.py `("length", Signed)`), read WITHOUT a lock.
+    ///
+    /// `Include/cpython/listobject.h PyList_GET_SIZE` answers a length under
+    /// `Py_GIL_DISABLED` as `_Py_atomic_load_ssize_relaxed(&ob_size)` — a
+    /// relaxed atomic load, no critical section — so a reader is entitled to a
+    /// value from either side of a concurrent mutation but never to a torn one.
+    /// The JIT's `len` fold lowers to exactly that load, addressing this slot
+    /// by [`INT_ARRAY_LEN_OFFSET`], which is why it cannot be a plain
+    /// `usize`: the methods below write it while a compiled loop is reading it,
+    /// and only an atomic makes that pair defined.  Every write here is a
+    /// relaxed store for the same reason — `&mut self` bounds no raw-pointer
+    /// reader, so `get_mut()` would put the plain store straight back.
+    ///
+    /// Same size and bit validity as `usize`, so `offset_of!` and the JIT's
+    /// `Type::Int` read are unchanged.
+    len: AtomicUsize,
 }
 
 pub const INT_ARRAY_BLOCK_OFFSET: usize = std::mem::offset_of!(IntArray, block);
 pub const INT_ARRAY_LEN_OFFSET: usize = std::mem::offset_of!(IntArray, len);
 
 impl IntArray {
+    /// `_Py_atomic_load_ssize_relaxed(&ob_size)`.
+    #[inline]
+    fn len_relaxed(&self) -> usize {
+        self.len.load(Ordering::Relaxed)
+    }
+
+    /// `_Py_atomic_store_ssize_relaxed(&ob_size, n)`.
+    #[inline]
+    fn set_len_relaxed(&self, n: usize) {
+        self.len.store(n, Ordering::Relaxed);
+    }
+
     /// Items base pointer (`&l.items[0]`), derived from `block`.
     ///
     /// `wrapping_add`, so the empty form's null `block` yields the items offset
@@ -63,7 +90,7 @@ impl IntArray {
     pub fn empty() -> Self {
         Self {
             block: std::ptr::null_mut(),
-            len: 0,
+            len: AtomicUsize::new(0),
         }
     }
 
@@ -71,7 +98,7 @@ impl IntArray {
         let len = values.len();
         let arr = Self {
             block: unsafe { alloc_typed_items_block(len, gc_int_array_gc_type_id()) },
-            len,
+            len: AtomicUsize::new(len),
         };
         unsafe {
             std::ptr::copy_nonoverlapping(values.as_ptr(), arr.base(), len);
@@ -141,7 +168,7 @@ impl IntArray {
 
     #[inline]
     pub fn spare_capacity(&self) -> usize {
-        self.capacity().saturating_sub(self.len)
+        self.capacity().saturating_sub(self.len_relaxed())
     }
 
     /// Allocated capacity (block header). The no-resize append fast path
@@ -166,7 +193,7 @@ impl IntArray {
             new_len <= cap,
             "IntArray::set_len precondition violated: new_len ({new_len}) > capacity ({cap})"
         );
-        self.len = new_len;
+        self.set_len_relaxed(new_len);
     }
 
     /// Integer list storage is always a separate block (no inline buffer).
@@ -180,36 +207,41 @@ impl IntArray {
             .max(self.capacity().saturating_mul(2))
             .max(INT_ARRAY_INLINE_CAP);
         self.block = unsafe {
-            grow_typed_items_block(self.block, target_cap, self.len, gc_int_array_gc_type_id())
+            grow_typed_items_block(
+                self.block,
+                target_cap,
+                self.len_relaxed(),
+                gc_int_array_gc_type_id(),
+            )
         };
     }
 
     pub fn push(&mut self, value: i64) {
-        if self.len == self.capacity() {
-            self.grow(self.len + 1);
+        if self.len_relaxed() == self.capacity() {
+            self.grow(self.len_relaxed() + 1);
         }
         unsafe {
-            *self.base().add(self.len) = value;
+            *self.base().add(self.len_relaxed()) = value;
         }
-        self.len += 1;
+        self.set_len_relaxed(self.len_relaxed() + 1);
     }
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.len
+        self.len_relaxed()
     }
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len == 0
+        self.len_relaxed() == 0
     }
 
     pub fn as_slice(&self) -> &[i64] {
-        unsafe { std::slice::from_raw_parts(self.base(), self.len) }
+        unsafe { std::slice::from_raw_parts(self.base(), self.len_relaxed()) }
     }
 
     pub fn as_mut_slice(&mut self) -> &mut [i64] {
-        unsafe { std::slice::from_raw_parts_mut(self.base(), self.len) }
+        unsafe { std::slice::from_raw_parts_mut(self.base(), self.len_relaxed()) }
     }
 
     pub fn to_vec(&self) -> Vec<i64> {
@@ -217,33 +249,33 @@ impl IntArray {
     }
 
     pub fn insert(&mut self, index: usize, value: i64) {
-        assert!(index <= self.len);
-        if self.len == self.capacity() {
-            self.grow(self.len + 1);
+        assert!(index <= self.len_relaxed());
+        if self.len_relaxed() == self.capacity() {
+            self.grow(self.len_relaxed() + 1);
         }
         unsafe {
             let p = self.base().add(index);
-            std::ptr::copy(p, p.add(1), self.len - index);
+            std::ptr::copy(p, p.add(1), self.len_relaxed() - index);
             *p = value;
         }
-        self.len += 1;
+        self.set_len_relaxed(self.len_relaxed() + 1);
     }
 
     pub fn remove(&mut self, index: usize) -> i64 {
-        assert!(index < self.len);
+        assert!(index < self.len_relaxed());
         let value = self.as_slice()[index];
         unsafe {
             let p = self.base().add(index);
-            std::ptr::copy(p.add(1), p, self.len - index - 1);
+            std::ptr::copy(p.add(1), p, self.len_relaxed() - index - 1);
         }
-        self.len -= 1;
+        self.set_len_relaxed(self.len_relaxed() - 1);
         value
     }
 
     pub fn pop(&mut self) -> i64 {
-        assert!(self.len > 0);
-        let value = self.as_slice()[self.len - 1];
-        self.len -= 1;
+        assert!(self.len_relaxed() > 0);
+        let value = self.as_slice()[self.len_relaxed() - 1];
+        self.set_len_relaxed(self.len_relaxed() - 1);
         value
     }
 
@@ -252,7 +284,7 @@ impl IntArray {
     }
 
     pub fn splice(&mut self, start: usize, remove_count: usize, new_values: &[i64]) {
-        let old_len = self.len;
+        let old_len = self.len_relaxed();
         let s = start.min(old_len);
         let slicelength = remove_count.min(old_len - s);
         let len2 = new_values.len();
@@ -269,7 +301,7 @@ impl IntArray {
                     old_len - s - slicelength,
                 );
             }
-            self.len = new_len;
+            self.set_len_relaxed(new_len);
         } else if slicelength > len2 {
             unsafe {
                 let base = self.base();
@@ -279,7 +311,7 @@ impl IntArray {
                     old_len - s - slicelength,
                 );
             }
-            self.len = new_len;
+            self.set_len_relaxed(new_len);
         }
         if len2 > 0 {
             self.as_mut_slice()[s..s + len2].copy_from_slice(new_values);
@@ -289,20 +321,20 @@ impl IntArray {
     pub fn drain(&mut self, range: std::ops::Range<usize>) {
         let start = range.start;
         let end = range.end;
-        assert!(start <= end && end <= self.len);
+        assert!(start <= end && end <= self.len_relaxed());
         let count = end - start;
         if count == 0 {
             return;
         }
         unsafe {
             let p = self.base().add(start);
-            std::ptr::copy(p.add(count), p, self.len - end);
+            std::ptr::copy(p.add(count), p, self.len_relaxed() - end);
         }
-        self.len -= count;
+        self.set_len_relaxed(self.len_relaxed() - count);
     }
 
     pub fn clear(&mut self) {
-        self.len = 0;
+        self.set_len_relaxed(0);
     }
 }
 

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -28,6 +28,7 @@ use crate::{
 };
 use std::cell::UnsafeCell;
 use std::sync::LazyLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 // PyPy's list strategy/storage transitions are indivisible under its GIL.
 // Pyre keeps the list itself as the sole semantic owner and uses only narrow
@@ -148,7 +149,21 @@ pub struct W_ListObject {
     /// switch rewrites both together — typed-strategy operations do
     /// NOT update this field. Callers must read length via
     /// `w_list_len()` which dispatches on strategy.
-    pub length: usize,
+    ///
+    /// Read WITHOUT the list lock, so the slot is an atomic rather than a plain
+    /// `usize`.  `Include/cpython/listobject.h PyList_GET_SIZE` answers a length
+    /// under `Py_GIL_DISABLED` as `_Py_atomic_load_ssize_relaxed(&ob_size)` — a
+    /// relaxed atomic load and no critical section — so a reader is entitled to
+    /// a value from either side of a concurrent mutation but never to a torn
+    /// one.  The JIT's `len` fold lowers to exactly that load through
+    /// `list_length_descr`, and the mutators below write it while a compiled
+    /// loop is reading; only an atomic makes that pair defined.  The writes are
+    /// relaxed stores for the same reason — `&mut self` bounds no raw-pointer
+    /// reader, so `get_mut()` would put the plain store straight back.
+    ///
+    /// Same size and bit validity as `usize`, so `offset_of!` and the JIT's
+    /// `Type::Int` read are unchanged.
+    pub length: AtomicUsize,
     /// `Ptr(GcArray(OBJECTPTR))` — rlist.py:116 `l.items`. Points at
     /// the `ItemsBlock` whose offset-0 header is the allocated
     /// capacity (= upstream `len(l.items)` per rlist.py:251). Null
@@ -177,11 +192,27 @@ pub const W_LIST_GC_TYPE_ID: u32 = 7;
 pub const W_LIST_OBJECT_SIZE: usize = std::mem::size_of::<W_ListObject>();
 
 impl W_ListObject {
+    /// `_Py_atomic_load_ssize_relaxed(&ob_size)` on the Object-strategy length.
+    ///
+    /// Not the list's length — that is `w_list_len`, which dispatches on the
+    /// strategy.  This is the raw slot, valid only where the caller has already
+    /// established the Object strategy.
+    #[inline]
+    pub fn length_relaxed(&self) -> usize {
+        self.length.load(Ordering::Relaxed)
+    }
+
+    /// `_Py_atomic_store_ssize_relaxed(&ob_size, n)` on the same slot.
+    #[inline]
+    pub fn set_length_relaxed(&self, n: usize) {
+        self.length.store(n, Ordering::Relaxed);
+    }
+
     #[inline]
     fn live_len(&self) -> usize {
         match self.strategy {
             ListStrategy::Empty => 0,
-            ListStrategy::Object => self.length,
+            ListStrategy::Object => self.length_relaxed(),
             // Direct rlist `length` field reads keep this helper in the
             // annotator's structural subset; the public `.len()` wrappers are
             // host collection conveniences that translate as `__len__`.
@@ -221,13 +252,13 @@ impl W_ListObject {
     #[inline]
     unsafe fn object_items_slice(&self) -> &[PyObjectRef] {
         let base = items_block_items_base(self.items);
-        std::slice::from_raw_parts(base, self.length)
+        std::slice::from_raw_parts(base, self.length_relaxed())
     }
 
     #[inline]
     unsafe fn object_items_slice_mut(&mut self) -> &mut [PyObjectRef] {
         let base = items_block_items_base(self.items);
-        std::slice::from_raw_parts_mut(base, self.length)
+        std::slice::from_raw_parts_mut(base, self.length_relaxed())
     }
 
     #[inline]
@@ -237,7 +268,8 @@ impl W_ListObject {
 
     #[inline]
     unsafe fn object_spare_capacity(&self) -> usize {
-        self.object_items_capacity().saturating_sub(self.length)
+        self.object_items_capacity()
+            .saturating_sub(self.length_relaxed())
     }
 
     /// Grow `items` to accommodate at least `min_cap` slots. Upstream
@@ -262,7 +294,7 @@ impl W_ListObject {
         let new_items_slot = crate::gc_roots::shadow_stack_len();
         let obj = crate::gc_roots::shadow_stack_get(obj_slot);
         let list = &mut *(obj as *mut W_ListObject);
-        let new_items = grow_list_items_block_gc(list.items, target_cap, list.length);
+        let new_items = grow_list_items_block_gc(list.items, target_cap, list.length_relaxed());
         let _ = crate::gc_roots::pin_root(new_items as PyObjectRef);
         // framework.py's GC transform places the owner write barrier directly
         // before SETFIELD_GC. Keep the old block installed while the barrier
@@ -361,7 +393,7 @@ impl W_ListObject {
         // returns it relocated. The in-place store below stays outside the
         // boundary so the spare-capacity fold still lowers it. No-op grow
         // under the std::alloc fallback.
-        let value = if list.length == list.object_items_capacity() {
+        let value = if list.length_relaxed() == list.object_items_capacity() {
             w_list_grow_items_block(obj, crate::gc_roots::shadow_stack_get(root_base + 1))
         } else {
             crate::gc_roots::shadow_stack_get(root_base + 1)
@@ -371,8 +403,8 @@ impl W_ListObject {
         let obj = crate::gc_roots::shadow_stack_get(root_base);
         let list = &mut *(obj as *mut W_ListObject);
         let base = items_block_items_base(list.items);
-        *base.add(list.length) = value;
-        list.length += 1;
+        *base.add(list.length_relaxed()) = value;
+        list.set_length_relaxed(list.length_relaxed() + 1);
     }
 
     unsafe fn object_insert(&mut self, index: usize, value: PyObjectRef) {
@@ -382,11 +414,11 @@ impl W_ListObject {
         crate::gc_roots::normalize_roots(root_base, 2);
         let obj = crate::gc_roots::shadow_stack_get(root_base);
         let list = &mut *(obj as *mut W_ListObject);
-        assert!(index <= list.length);
+        assert!(index <= list.length_relaxed());
         // Same grow-then-store shape as `object_push`: at capacity, route the
         // grow through the `dont_look_inside` boundary, which roots `value`
         // across the (collecting) resize and returns it relocated.
-        let value = if list.length == list.object_items_capacity() {
+        let value = if list.length_relaxed() == list.object_items_capacity() {
             w_list_grow_items_block(obj, crate::gc_roots::shadow_stack_get(root_base + 1))
         } else {
             crate::gc_roots::shadow_stack_get(root_base + 1)
@@ -397,30 +429,30 @@ impl W_ListObject {
         let list = &mut *(obj as *mut W_ListObject);
         let base = items_block_items_base(list.items);
         let p = base.add(index);
-        std::ptr::copy(p, p.add(1), list.length - index);
+        std::ptr::copy(p, p.add(1), list.length_relaxed() - index);
         *p = value;
-        list.length += 1;
+        list.set_length_relaxed(list.length_relaxed() + 1);
     }
 
     unsafe fn object_remove(&mut self, index: usize) -> PyObjectRef {
-        assert!(index < self.length);
+        assert!(index < self.length_relaxed());
         let base = items_block_items_base(self.items);
         let value = *base.add(index);
         let p = base.add(index);
-        std::ptr::copy(p.add(1), p, self.length - index - 1);
+        std::ptr::copy(p.add(1), p, self.length_relaxed() - index - 1);
         // Phase L2: the varsize walker forwards items[0..capacity], so clear the
         // vacated tail slot the shift left holding a stale duplicate.
-        *base.add(self.length - 1) = PY_NULL;
-        self.length -= 1;
+        *base.add(self.length_relaxed() - 1) = PY_NULL;
+        self.set_length_relaxed(self.length_relaxed() - 1);
         value
     }
 
     unsafe fn object_pop(&mut self) -> PyObjectRef {
-        assert!(self.length > 0);
+        assert!(self.length_relaxed() > 0);
         let base = items_block_items_base(self.items);
-        let value = *base.add(self.length - 1);
-        *base.add(self.length - 1) = PY_NULL;
-        self.length -= 1;
+        let value = *base.add(self.length_relaxed() - 1);
+        *base.add(self.length_relaxed() - 1) = PY_NULL;
+        self.set_length_relaxed(self.length_relaxed() - 1);
         value
     }
 
@@ -431,19 +463,19 @@ impl W_ListObject {
     unsafe fn object_drain(&mut self, range: std::ops::Range<usize>) {
         let start = range.start;
         let end = range.end;
-        assert!(start <= end && end <= self.length);
+        assert!(start <= end && end <= self.length_relaxed());
         let count = end - start;
         if count == 0 {
             return;
         }
         let base = items_block_items_base(self.items);
         let p = base.add(start);
-        std::ptr::copy(p.add(count), p, self.length - end);
-        let old_len = self.length;
-        self.length -= count;
+        std::ptr::copy(p.add(count), p, self.length_relaxed() - end);
+        let old_len = self.length_relaxed();
+        self.set_length_relaxed(self.length_relaxed() - count);
         // Phase L2: clear the vacated tail [new_len..old_len] the shift left
         // holding stale duplicates, so the varsize walker (0..capacity) skips them.
-        for i in self.length..old_len {
+        for i in self.length_relaxed()..old_len {
             *base.add(i) = PY_NULL;
         }
     }
@@ -454,7 +486,7 @@ impl W_ListObject {
         remove_count: usize,
         new_values: &[PyObjectRef],
     ) {
-        let old_len = self.length;
+        let old_len = self.length_relaxed();
         let s = start.min(old_len);
         let slicelength = remove_count.min(old_len - s);
         let len2 = new_values.len();
@@ -482,7 +514,7 @@ impl W_ListObject {
                     base.add(s + len2),
                     old_len - s - slicelength,
                 );
-                list.length = new_len;
+                list.set_length_relaxed(new_len);
             } else {
                 let base = items_block_items_base(list.items);
                 std::ptr::copy(
@@ -490,7 +522,7 @@ impl W_ListObject {
                     base.add(s + len2),
                     old_len - s - slicelength,
                 );
-                list.length = new_len;
+                list.set_length_relaxed(new_len);
             }
         } else if slicelength > len2 {
             let base = items_block_items_base(list.items);
@@ -503,7 +535,7 @@ impl W_ListObject {
             for i in new_len..old_len {
                 *base.add(i) = PY_NULL;
             }
-            list.length = new_len;
+            list.set_length_relaxed(new_len);
         }
         if len2 > 0 {
             let obj = crate::gc_roots::shadow_stack_get(obj_slot);
@@ -550,7 +582,7 @@ impl W_ListObject {
         let list = &mut *(obj as *mut W_ListObject);
         let old_items = list.items;
         list.items = crate::gc_roots::shadow_stack_get(new_items_slot) as *mut ItemsBlock;
-        list.length = rooted_values.len();
+        list.set_length_relaxed(rooted_values.len());
         dealloc_list_items_block(old_items);
     }
 
@@ -559,7 +591,7 @@ impl W_ListObject {
     unsafe fn drop_object_items(&mut self) {
         dealloc_list_items_block(self.items);
         self.items = std::ptr::null_mut();
-        self.length = 0;
+        self.set_length_relaxed(0);
     }
 }
 
@@ -602,7 +634,7 @@ pub unsafe fn w_list_grow_items_block(obj: PyObjectRef, value: PyObjectRef) -> P
     let _ = crate::gc_roots::pin_root(value);
     let obj = crate::gc_roots::shadow_stack_get(save);
     let list = &mut *(obj as *mut W_ListObject);
-    W_ListObject::object_grow(obj, list.length + 1);
+    W_ListObject::object_grow(obj, list.length_relaxed() + 1);
     crate::gc_roots::shadow_stack_get(save + 1)
 }
 
@@ -1350,7 +1382,7 @@ pub fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy)
         let boxed = Box::new(W_ListObject {
             ob_header: header,
             allocated: items.len() as isize,
-            length,
+            length: AtomicUsize::new(length),
             items: items_block,
             strategy,
             int_items,
@@ -1366,7 +1398,7 @@ pub fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy)
             W_ListObject {
                 ob_header: header,
                 allocated: items.len() as isize,
-                length,
+                length: AtomicUsize::new(length),
                 items: items_block,
                 strategy,
                 int_items,
@@ -1541,7 +1573,7 @@ pub fn ll_list_float_set_len(l: &mut W_ListObject, n: usize) {
 /// (rlist.py:116 `l.length`).
 #[majit_macros::oopspec("list.obj_len(l)")]
 pub fn ll_list_obj_length(l: &W_ListObject) -> usize {
-    l.length
+    l.length_relaxed()
 }
 
 /// Allocated capacity for the Object strategy — the `items` block's
@@ -1555,7 +1587,7 @@ pub fn ll_list_obj_capacity(l: &W_ListObject) -> usize {
 /// `l.length = newsize`, rlist.py:293).
 #[majit_macros::oopspec("list.obj_set_len(l, n)")]
 pub fn ll_list_obj_set_len(l: &mut W_ListObject, n: usize) {
-    l.length = n;
+    l.set_length_relaxed(n);
 }
 
 /// `ll_setitem_fast` for the Object strategy: a GC-ref store at a
@@ -1661,7 +1693,7 @@ pub unsafe fn w_list_setitem(obj: PyObjectRef, index: i64, value: PyObjectRef) -
         // listobject.py EmptyListStrategy.setitem raises IndexError.
         ListStrategy::Empty => false,
         ListStrategy::Object => {
-            let len = list.length as i64;
+            let len = list.length_relaxed() as i64;
             let idx = if index < 0 { index + len } else { index };
             if idx < 0 || idx >= len {
                 return false;
@@ -2072,7 +2104,7 @@ pub unsafe fn w_list_len(obj: PyObjectRef) -> usize {
     match list.strategy {
         // listobject.py EmptyListStrategy.length returns 0.
         ListStrategy::Empty => 0,
-        ListStrategy::Object => list.length,
+        ListStrategy::Object => list.length_relaxed(),
         ListStrategy::Integer => ll_list_int_length(list),
         ListStrategy::IntOrFloat => list.int_items.len(),
         ListStrategy::Float => list.float_items.len(),
@@ -2456,7 +2488,7 @@ pub unsafe fn w_list_insert(obj: PyObjectRef, index: i64, value: PyObjectRef) {
             }
         }
         ListStrategy::Object => {
-            let idx = normalize_insert_index(index, list.length);
+            let idx = normalize_insert_index(index, list.length_relaxed());
             list.object_insert(idx, value);
             let obj = crate::gc_roots::shadow_stack_get(root_base);
             list_write_barrier(obj);
@@ -2550,7 +2582,7 @@ pub unsafe fn w_list_pop(obj: PyObjectRef, index: i64) -> Option<PyObjectRef> {
             Some(w_float_new(item))
         }
         ListStrategy::Object => {
-            let len = list.length as i64;
+            let len = list.length_relaxed() as i64;
             if len == 0 {
                 return None;
             }
@@ -2603,7 +2635,7 @@ pub unsafe fn w_list_pop_end(obj: PyObjectRef) -> Option<PyObjectRef> {
         ListStrategy::Integer => ll_list_int_length(list),
         ListStrategy::IntOrFloat => list.int_items.len(),
         ListStrategy::Float => list.float_items.len(),
-        ListStrategy::Object => list.length,
+        ListStrategy::Object => list.length_relaxed(),
         ListStrategy::Bytes => list.bytes_items.len(),
     };
     if length == 0 {
@@ -2773,7 +2805,7 @@ pub unsafe fn w_list_init_items(obj: PyObjectRef, items: Vec<PyObjectRef>) {
     if let Some(s) = block_root {
         storage.block = crate::gc_roots::shadow_stack_get(s) as *mut ItemsBlock;
     }
-    list.length = storage.length;
+    list.set_length_relaxed(storage.length);
     list.items = storage.block;
     list.strategy = strategy;
     list.int_items = storage.int_items;
@@ -2899,7 +2931,7 @@ pub unsafe fn w_list_delslice(obj: PyObjectRef, start: usize, end: usize) {
             }
         }
         ListStrategy::Object => {
-            let len = list.length;
+            let len = list.length_relaxed();
             let s = start.min(len);
             let e = end.min(len);
             if s < e {

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -15,6 +15,7 @@ use pyre_macros::pyre_class;
 use std::cell::UnsafeCell;
 use std::hash::BuildHasher;
 use std::sync::LazyLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub static SET_TYPE: PyType = crate::pyobject::new_pytype("set");
 pub static FROZENSET_TYPE: PyType = crate::pyobject::new_pytype("frozenset");
@@ -117,9 +118,36 @@ pub unsafe fn w_set_iter_set_index(obj: PyObjectRef, index: usize) {
 pub struct W_SetObject {
     pub ob_header: PyObject,
     pub items: *mut SetItemsStorage,
-    pub len: usize,
+    /// Element count, read WITHOUT the stripe lock.
+    ///
+    /// `Objects/setobject.c set_len` answers `len(s)` as
+    /// `FT_ATOMIC_LOAD_SSIZE_RELAXED(so->used)` — a relaxed atomic load and no
+    /// critical section — so a reader is entitled to a value from either side
+    /// of a concurrent mutation but never to a torn one.  The JIT's `len` fold
+    /// lowers to exactly that load (`set_len_descr`), which is why the slot
+    /// cannot be a plain `usize`: the mutators below write it while a compiled
+    /// loop is reading, and only an atomic makes that pair defined.
+    ///
+    /// Same size and bit validity as `usize`, so the descriptor group keeps
+    /// reading it as `Type::Int` at `offset_of!` — the shape
+    /// `W_TupleObject.hash` already uses.
+    pub len: AtomicUsize,
     /// setobject.py `W_FrozensetObject.hash = DEFAULT_HASH`.
     pub hash: i64,
+}
+
+impl W_SetObject {
+    /// `FT_ATOMIC_LOAD_SSIZE_RELAXED(so->used)`.
+    #[inline]
+    pub fn len_relaxed(&self) -> usize {
+        self.len.load(Ordering::Relaxed)
+    }
+
+    /// `FT_ATOMIC_STORE_SSIZE_RELAXED(so->used, n)`.
+    #[inline]
+    pub fn set_len_relaxed(&self, n: usize) {
+        self.len.store(n, Ordering::Relaxed);
+    }
 }
 
 /// GC type id assigned to `W_SetObject` at JitDriver init time.
@@ -317,7 +345,7 @@ pub fn w_set_new() -> PyObjectRef {
                 W_SetObject {
                     ob_header: header,
                     items,
-                    len: 0,
+                    len: AtomicUsize::new(0),
                     hash: -1,
                 },
             );
@@ -327,7 +355,7 @@ pub fn w_set_new() -> PyObjectRef {
         crate::lltype::malloc_typed(W_SetObject {
             ob_header: header,
             items,
-            len: 0,
+            len: AtomicUsize::new(0),
             hash: -1,
         }) as PyObjectRef
     }
@@ -355,7 +383,7 @@ pub fn w_frozenset_new() -> PyObjectRef {
                 W_SetObject {
                     ob_header: header,
                     items,
-                    len: 0,
+                    len: AtomicUsize::new(0),
                     hash: -1,
                 },
             );
@@ -365,7 +393,7 @@ pub fn w_frozenset_new() -> PyObjectRef {
         crate::lltype::malloc_typed(W_SetObject {
             ob_header: header,
             items,
-            len: 0,
+            len: AtomicUsize::new(0),
             hash: -1,
         }) as PyObjectRef
     }
@@ -585,7 +613,7 @@ pub unsafe fn w_set_discard_key_checked(
         match index {
             Some(index) => {
                 set_remove_index(s.items, index);
-                s.len = (*s.items).len();
+                s.set_len_relaxed((*s.items).len());
                 s.hash = -1;
                 true
             }
@@ -603,7 +631,7 @@ pub unsafe fn w_set_discard_key_checked(
         // leaving the live storage untouched (`discard` of an absent element).
         set_remove_index(items, index);
         let s = &mut *(obj as *mut W_SetObject);
-        s.len = (*s.items).len();
+        s.set_len_relaxed((*s.items).len());
         s.hash = -1;
         return Ok(true);
     }
@@ -673,7 +701,7 @@ pub unsafe fn w_set_clear(obj: PyObjectRef) {
     let s = &mut *(obj as *mut W_SetObject);
     s.items =
         crate::gc_storage::gc_alloc_storage_box(SetItemsStorage::default(), set_items_gc_type_id());
-    s.len = 0;
+    s.set_len_relaxed(0);
     s.hash = -1;
     set_write_barrier(obj);
 }
@@ -691,7 +719,7 @@ pub unsafe fn w_set_popitem(obj: PyObjectRef) -> Option<PyObjectRef> {
     let s = &mut *(obj as *mut W_SetObject);
     let entries = &mut *s.items;
     let (key, ()) = entries.pop()?;
-    s.len -= 1;
+    s.set_len_relaxed(s.len_relaxed() - 1);
     s.hash = -1;
     Some(key.obj)
 }
@@ -728,7 +756,7 @@ pub unsafe fn w_set_copy_storage_from(dst: PyObjectRef, src: PyObjectRef) {
     let d = &mut *(dst as *mut W_SetObject);
     let copied = (*(*(src as *const W_SetObject)).items).clone();
     d.items = crate::gc_storage::gc_alloc_storage_box(copied, set_items_gc_type_id());
-    d.len = (*d.items).len();
+    d.set_len_relaxed((*d.items).len());
     d.hash = -1;
     set_write_barrier(dst);
 }
@@ -921,7 +949,7 @@ unsafe fn w_set_insert_key_into(
         // comparisons and cannot break either.
         entries.insert(key, ());
         let set = &mut *(dst as *mut W_SetObject);
-        set.len = (*set.items).len();
+        set.set_len_relaxed((*set.items).len());
         set.hash = -1;
         set_write_barrier(dst);
     }) {
@@ -941,7 +969,7 @@ unsafe fn w_set_insert_key_into(
         RawEntryMut::Occupied(_) => unreachable!("a never-matching raw probe is vacant"),
     }
     let set = &mut *(dst as *mut W_SetObject);
-    set.len = (*set.items).len();
+    set.set_len_relaxed((*set.items).len());
     set.hash = -1;
     set_write_barrier(dst);
     Ok(())
@@ -1023,7 +1051,7 @@ unsafe fn w_set_remove_key_for_update(
         if let Some(index) = index {
             set_remove_index(items, index);
             let set = &mut *(dst as *mut W_SetObject);
-            set.len -= 1;
+            set.set_len_relaxed(set.len_relaxed() - 1);
             set.hash = -1;
         }
     }) {
@@ -1068,7 +1096,7 @@ unsafe fn w_set_remove_key_for_update(
         if let Some(index) = found {
             set_remove_index(items, index);
             let set = &mut *(dst as *mut W_SetObject);
-            set.len -= 1;
+            set.set_len_relaxed(set.len_relaxed() - 1);
             set.hash = -1;
         }
         return Ok(());
@@ -1077,11 +1105,17 @@ unsafe fn w_set_remove_key_for_update(
 
 /// Number of elements in the set.
 ///
+/// Takes no stripe lock, matching `Objects/setobject.c set_len`:
+/// `FT_ATOMIC_LOAD_SSIZE_RELAXED(so->used)`.  A lock here would be stricter
+/// than the spec and would not buy anything — every mutator publishes the
+/// count with a relaxed store while holding the stripe, so the value read is
+/// from one side of a concurrent mutation either way, and the JIT's `len` fold
+/// lowers to this same unlocked load.
+///
 /// # Safety
 /// `obj` must point to a valid `W_SetObject`.
 pub unsafe fn w_set_len(obj: PyObjectRef) -> usize {
-    let _set_guard = w_set_lock(obj);
-    (*(obj as *const W_SetObject)).len
+    (*(obj as *const W_SetObject)).len_relaxed()
 }
 
 /// Cached frozenset hash; `-1` is the uncomputed sentinel.


### PR DESCRIPTION
## Relaxed atomics for the container length slots

`W_SetObject.len`, `W_ListObject.length`, `IntArray.len`, `FloatArray.len` and
`W_BytearrayObject.length` are each read by compiled code through a field descr
**without taking the container's lock**, while the mutators next to them write
the same slot. `Objects/setobject.c set_len` answers `len(s)` as
`FT_ATOMIC_LOAD_SSIZE_RELAXED(so->used)` and `PyList_GET_SIZE` under
`Py_GIL_DISABLED` is `_Py_atomic_load_ssize_relaxed(&ob_size)` — a relaxed
atomic load, no critical section — so the five slots become `AtomicUsize` and
every access **from the Rust interpreter** is a relaxed load or store.
`w_set_len` drops its stripe lock to match `set_len`. `str` / `bytes` / `range`
/ `tuple` lengths are immutable and are not touched.

`AtomicUsize` has the same size and bit validity as `usize`, so the
`offset_of!` descrs and their `Type::Int` reads are unchanged.

**What this does not cover, and it is not "the same instruction".** The
blackhole interpreter executes a folded `SetfieldGc` through
`bh_setfield_gc_i` → `llmodel::write_int_at_mem` → `(addr as *mut i64)
.write_unaligned(..)`, and that is rustc-compiled Rust, so racing it against a
`len_relaxed()` is a data race in the Rust model rather than an aligned word
store. The compiled backends emit plain stores too, but those are not
rustc-compiled and an aligned word store is single-copy atomic on every target
pyre emits for.

That race is **not introduced here**: before this branch the slot was a plain
`usize` and both sides were non-atomic. This branch removes the interpreter
half. Closing the other half wants an `is_atomic` bit on the field descr,
honored by the blackhole and by dynasm / cranelift / wasm — it crosses the
serialized `descrs.bin` boundary and three backends, so it is its own change.
Filed, not done here.

### the part that made this more than a type change

**`pyre-object: relaxed atomics for the container length slots` alone would
have regressed `list.append`.** The MIR front-end
folds `<Atomic*>::load` (`a83cb5cd91a`, #164) but had no `store` arm, because
nothing walked wrote an atomic at the time. `IntArray::push` *is* walked —
that is why `list.append` compiles with no residual call at all — so an
unrecognised store there becomes one.

`majit-translate: lower `<Atomic*>::store` to the field write it is` adds it. A read needs no place, which is why the load fold gets
away with aliasing the receiver Variable; a write does, so `atomic_ref_place`
records the referent of `_i = &<atomic slot>` (keyed on the referent being an
atomic, so ordinary borrows never enter the map) and the store arm hands it to
`emit_projection_write` — the same `FieldWrite` a plain `slot = value`
assignment emits. ULLBC guarantees the shape: a call argument is an `Operand`
and `&x` is an `Rvalue`, so the borrow is always materialised into a local
first. A receiver it cannot recover falls through to the ordinary call path,
which is what an unrecognised `store` already lowered to, so nothing that
compiles today can regress.

**Only a `Relaxed` store folds** (`fold only a relaxed `<Atomic*>::store``). The first version of this arm
folded every ordering, on the argument that the traced model has no fences so a
release could not be expressed here anyway. That is half true and the wrong
half is decisive: today a `Release` store lowers to a *residual call*, and the
call runs the real function, so the release actually happens — folding it to an
inline unordered `FieldWrite` deletes a barrier rather than failing to express
one. `w_type_set_version_tag` publishes `version_tag` with `Release` against
`w_type_get_version_tag`'s `Acquire`, and `pyre-object` alone holds ~20
`Ordering::Release` stores. So the arm reads the ordering and folds nothing
else; anything stronger keeps the call it has today.

Charon does not hand the ordering over as a constant operand — it assigns
`_i = Ordering::<V>` as a fieldless-enum `Aggregate` and passes `move _i` — so
`atomic_ordering_locals` tracks it the same way the receiver is tracked, and
reads the variant's **name** out of the enum decl rather than its index.

Both side maps are restricted to locals outside `multi_assigned_locals`
(`the atomic store fold only reads single-assignment locals`), the restriction
`const_discriminant_locals` already carries.
MIR locals are not SSA: a local borrowed from `&a` in one block and `&b` in
another would otherwise hand the store whichever block was lowered last, which
need not be the definition reaching it. A local assigned once in the whole body
carries the reaching value at every use of it; a rebound one stays a call.

### that the arm actually fires, two-sided

The optimised `list.append` trace carries
`SetfieldGc(v8, v68) descr=<SimpleFieldDescr { name: "W_ListObject.int_items.len",
offset: 56, field_size: 8, field_type: Int, flag: Unsigned, … }>`, four
`SetarrayitemGc`, five `ArraylenGc`, and **zero** `CallMayForce` / residual
calls — re-measured after the single-assignment restriction, which did not cost
the fold.

That the field write is not simply an inlined-away store: `pyre-object.ullbc`
names `"store"` 14 times, **all** inside `core::sync::atomic`, and
`atomic_store_relaxed` zero times. The store reaches the front-end as a call —
the position `lower_call` would have emitted a residual `Call` for.

## verification

The first measured tree — the five slots plus the store fold, before the
layout-string commit — was locally green everywhere: LLBC re-extract 0 and
`--check` 0, all four targets built, `cargo check --workspace
--no-default-features --features dynasm,cpyext` 0, `gate_triage_complete` 6/6,
`check.py` ALL PASSED 489/489 dynasm, 489/489 cranelift, 481/481 wasm.

Its CI came back green on every `check.py` leg (ubuntu, macOS, windows),
sandbox e2e and dispatcher-graph, and **red on `cargo test` on all three
OSes** — a gate no local command I had run covers:

```
get_field_descr cache hit for length disagrees with the caller:
  cached    "W_ListObject.length"             (… type Int  …)
  vs requested "listobject::W_ListObject.length" (… type Ref …)
```

`majit-translate` answers "what type is this field" from two different inputs
and they have to agree. The TyRef-keyed side (`tyref_atomic_inner_value_type`)
has known about atomics since #164; the **string**-keyed side does not, and
`tyref_to_field_layout_string` spelled the field with the wrapper's own leaf,
`"AtomicUsize"`. No string table carries that name, and every one of them falls
through to `_ => (ArrayFlag::Pointer, Type::Ref, word)` — silently. So the
analyzer minted `W_ListObject.length` as a `Ref` descr against the runtime's
`Int` publish. The pre-existing atomic fields (`W_TypeObject.version_tag`,
`W_TupleObject.hash`, `PyType.subclassrange_*`) never tripped it because the
string mint only runs when the runtime published no descr for that
`(struct, field)`, and for those it always had.

`an atomic field's layout string is its inner scalar` normalises in
`tyref_to_field_layout_string`, one edit for all three string consumers
(`get_type_flag`, `type_flag_from_str`, the annotator's field projection): an
integer or bool wrapper spells as the scalar it is layout-transparent over.
`AtomicPtr` keeps the wrapper spelling — its inner value is a pointer, which is
what the wildcard already answers. The function had the precedent in place
already; it normalises `#[repr(transparent)]` scalar wrappers for exactly this
reason, and std's atomics are `#[repr(C, align(N))]`, so they missed that arm.
A unit test pins both directions.

That fixed it two-sidedly. Locally `cargo test --all --no-default-features
--features dynasm,cpyext` went to exit 0 over 191 test binaries, including the
`driver_finish_setup_installs_blackhole_control_opcodes` that was red; and on
CI **all 18 checks passed, red 0** — the three `cargo test` legs flipped green
and the Codex parity review reported None on all three of its sections.

The branch was then rebased onto current `main` — the gate-triage commit it
used to carry was dropped, because #1498 had already made `PYRE_GC_SIZE_AUDIT`
a single §7 row and re-adding it under §5 was exactly the duplication that
makes the document non-self-contained — and everything re-measured on that
base: LLBC re-extract 0 and `--check` 0, all four targets rebuilt, `check.py`
ALL PASSED 489/489 dynasm, 489/489 cranelift, 481/481 wasm, and `cargo test
--all --no-default-features --features dynasm,cpyext --no-fail-fast` exit 0
over 192 test binaries.

The `list.append` probe still reads the same on that tree — `SetfieldGc(v8,
v68) descr=<SimpleFieldDescr { name: "W_ListObject.int_items.len", offset: 56,
field_size: 8, field_type: Int, … }>`, four `SetarrayitemGc`, five
`ArraylenGc`, zero `CallMayForce` — so the single-assignment restriction did
not cost the fold.

> An earlier attempt at that same tree exited 101 on two tests, and they are
> **pre-existing flakes, not this branch**. Both assert on process-global state
> that `cargo test`'s parallel harness races:
> `majit-metainterp`'s `jit_interp_label_entry_deopt_resume` shares one `static
> COMPILES` between the two tests in the file, so one storing 0 and asserting 0
> races the other incrementing it; and `failguard.rs`'s `FAIL_DESCR_REGISTRY`
> takes its lock twice under a comment that reads "the wasm host is
> single-threaded, so no other compile can interleave between the two calls",
> which the harness makes false (and its assert is a `debug_assert_eq!`, so it
> is debug-only). Re-running the identical command on the identical tree came
> back exit 0. Under CPU contention the two binaries fail 8/24 and 1/24
> respectively while passing 12/12 when run alone; neither crate is touched
> here, and neither test feeds the LLBC front-end this branch changes. Worth
> fixing, separately.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01783Hwr6otwNdWo2BrtJeUg




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved concurrent length tracking for lists, sets, bytearrays, and numeric arrays.
  * Reduced synchronization overhead for selected collection size reads and updates.
  * Improved JIT handling of collection lengths during execution.

* **Reliability**
  * Enhanced atomic operation handling for supported fields and pointer-based values.
  * Preserved existing collection behavior while improving safety during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->