### PR TITLE
typedef, pycode: the coordinate f_lasti reports for a frame that has not run a traceable instruction

### DIFF
--- a/pyre/extra_tests/parity_tests/f_lasti_names_the_resume_on_the_call_event.py
+++ b/pyre/extra_tests/parity_tests/f_lasti_names_the_resume_on_the_call_event.py
@@ -1,0 +1,139 @@
+# pyre-check: pypy-diverges: `pyframe.py:78` declares `last_instr = -1` and
+# `pyframe.py:335-341` states "Execution starts just after the last_instr.
+# Initially, last_instr is -1", so `fget_f_lasti` (`pyframe.py:771`) hands out
+# `-1` for a frame that has not run an instruction.  3.11 also has no `RESUME`
+# for the coordinate below to name.
+#
+# CPython-suite gap: `test_sys_settrace` never reads `f_lasti`, and the
+# `test_frame` cases that do read it only on a frame that is already running.
+#
+# parity-tests reason: `f_lasti` is `_PyInterpreterFrame_LASTI * 2`
+# (`PyUnstable_InterpreterFrame_GetLasti`, `Python/frame.c`), and the getter
+# turns only a *negative* result into `-1` (`frame_lasti_get_impl`,
+# `Objects/frameobject.c`).  A frame reached by the `call` event has not run a
+# traceable instruction, but its instruction pointer is not a sentinel: the
+# compiler-inserted prologue is consumed by frame setup, so the pointer sits on
+# the first `RESUME` -- `code->_co_firsttraceable`.
+#
+# The gap is only visible when a prologue exists, because `_co_firsttraceable`
+# is 0 without one.  All three shapes below are checked for that reason: a
+# plain function has no prologue, a closure carries `COPY_FREE_VARS`, and a
+# generator carries `RETURN_GENERATOR` / `POP_TOP`.
+#
+# A generator reached through `gi_frame` before its first `send` is the one
+# frame that has run an instruction without reaching its `RESUME`:
+# `RETURN_GENERATOR` is what produced the object being read, so the pointer
+# rests on the instruction after it.  That coordinate is not a constant either
+# -- a closure generator's `COPY_FREE_VARS` shifts `RETURN_GENERATOR` along --
+# and it is one unit short of the `call` event's, so a runtime answering both
+# from `_co_firsttraceable` is wrong for exactly one of them.
+
+import dis
+import sys
+
+
+def first_resume_offset(code):
+    """The byte offset of `code`'s first `RESUME` -- `_co_firsttraceable * 2`."""
+    for instruction in dis.get_instructions(code):
+        if instruction.opname == "RESUME":
+            return instruction.offset
+    raise AssertionError(f"no RESUME in {code.co_name}")
+
+
+def after_return_generator_offset(code):
+    """The byte offset of the instruction following `code`'s `RETURN_GENERATOR`."""
+    instructions = list(dis.get_instructions(code))
+    for position, instruction in enumerate(instructions):
+        if instruction.opname == "RETURN_GENERATOR":
+            return instructions[position + 1].offset
+    raise AssertionError(f"no RETURN_GENERATOR in {code.co_name}")
+
+
+def first_call_event_lasti(call_it, name):
+    """`f_lasti` as the *first* `call` event for `name`'s frame reports it.
+
+    A generator gets one `call` event per resumption, so only the first names
+    the frame that has yet to run a traceable instruction.
+    """
+    seen = []
+
+    def tracer(frame, event, arg):
+        if frame.f_code.co_name == name and event == "call":
+            seen.append(frame.f_lasti)
+        return tracer
+
+    sys.settrace(tracer)
+    try:
+        call_it()
+    finally:
+        sys.settrace(None)
+    assert seen, name
+    return seen[0]
+
+
+def a_plain_function_resumes_at_offset_zero():
+    def plain(n):
+        return n + 1
+
+    assert first_resume_offset(plain.__code__) == 0, "expected no prologue"
+    assert first_call_event_lasti(lambda: plain(1), "plain") == 0
+
+
+def a_closure_resumes_past_its_copy_free_vars():
+    cell = 7
+
+    def reads_the_cell(n):
+        return cell + n
+
+    prologue = [i.opname for i in dis.get_instructions(reads_the_cell.__code__)][:1]
+    assert prologue == ["COPY_FREE_VARS"], prologue
+
+    resume = first_resume_offset(reads_the_cell.__code__)
+    assert resume > 0, resume
+    assert first_call_event_lasti(lambda: reads_the_cell(1), "reads_the_cell") == resume
+
+
+def a_generator_resumes_past_its_return_generator():
+    def counts():
+        yield 1
+
+    prologue = [i.opname for i in dis.get_instructions(counts.__code__)][:2]
+    assert prologue == ["RETURN_GENERATOR", "POP_TOP"], prologue
+
+    resume = first_resume_offset(counts.__code__)
+    assert resume > 0, resume
+    assert first_call_event_lasti(lambda: list(counts()), "counts") == resume
+
+
+def an_unstarted_generator_rests_after_its_return_generator():
+    def counts():
+        yield 1
+
+    cell = 7
+
+    def counts_from_a_cell():
+        yield cell
+
+    for maker in (counts, counts_from_a_cell):
+        code = maker.__code__
+        resting = after_return_generator_offset(code)
+        # One unit short of where the `call` event reports the same frame.
+        assert resting == first_resume_offset(code) - 2, (code.co_name, resting)
+        # The generator is held for the read: a frame object outliving its
+        # generator takes ownership of the frame and reports a coordinate past
+        # the `RESUME` instead, which is not what this pins.
+        held = maker()
+        assert held.gi_frame.f_lasti == resting, code.co_name
+
+    # `COPY_FREE_VARS` shifts the coordinate, so it is not a constant.
+    plain = after_return_generator_offset(counts.__code__)
+    closure = after_return_generator_offset(counts_from_a_cell.__code__)
+    assert closure > plain, (plain, closure)
+
+
+a_plain_function_resumes_at_offset_zero()
+a_closure_resumes_past_its_copy_free_vars()
+a_generator_resumes_past_its_return_generator()
+an_unstarted_generator_rests_after_its_return_generator()
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/no_line_event_on_the_prologue_resume.py
+++ b/pyre/extra_tests/parity_tests/no_line_event_on_the_prologue_resume.py
@@ -11,9 +11,9 @@
 # without the filter reports an extra `line` event at line 0 before the first
 # statement, and `pdb` stops on `<string>(0)` where 3.14 stops on `(1)`.
 #
-# The `call` event's `f_lasti` is deliberately not compared: `_PyInterpreterFrame
-# _LASTI` is 0 while the frame sits on its `RESUME`, where this runtime reports
-# "not started", and that convention gap is a separate open item.
+# The `call` event's `f_lasti` is not compared here, but for a narrower reason:
+# it names the very `_co_firsttraceable` this filter is written against, so
+# `f_lasti_names_the_resume_on_the_call_event.py` pins it on its own.
 #
 # PyPy 7.3.20 is a 3.11 line table whose module body has no line-0 range, so
 # its event list differs for that reason.

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -3477,6 +3477,28 @@ pub fn first_traceable_index(code: &crate::CodeObject) -> usize {
     index
 }
 
+/// The index the frame of a generator that has not been resumed rests on.
+///
+/// `RETURN_GENERATOR` is what builds the generator object, so by the time a
+/// caller holds it that instruction has run and the frame it left behind sits
+/// on the next one.  The index is not a constant: a closure generator's
+/// `COPY_FREE_VARS` precedes `RETURN_GENERATOR` and shifts it along.
+///
+/// `None` for a code object with no `RETURN_GENERATOR`, which is every code
+/// object that is not a generator, coroutine or async generator.
+pub fn after_return_generator_index(code: &crate::CodeObject) -> Option<usize> {
+    use crate::bytecode::Instruction;
+
+    let mut index = 0;
+    while let Some(op) = base_op(code, index) {
+        if matches!(op, Instruction::ReturnGenerator) {
+            return Some(index + 1);
+        }
+        index += 1;
+    }
+    None
+}
+
 /// Whether the instruction at `pc` may be reported to a trace function as the
 /// start of a source line.
 ///

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8251,11 +8251,42 @@ fn init_frame_type(ns: PyObjectRef) {
     // recover the right instruction — the same adaptation `tb_lasti`
     // uses (`typedef.rs` tb_lasti getter).
     //
-    // A negative `last_instr` is the not-yet-started sentinel, not a
-    // coordinate, so it is handed out as-is: `PyFrame_GetLasti` scales only
-    // the non-negative case (`lasti < 0 ? -1 : lasti * sizeof(_Py_CODEUNIT)`)
-    // and `pyframe.py fget_f_lasti` returns `last_instr` unscaled. Scaling it
-    // reported `-2`, a value neither reference produces.
+    // A negative `last_instr` means the frame has not run an instruction, and
+    // that is not a coordinate this getter can hand out: `frame_lasti_get_impl`
+    // turns only a negative `_PyInterpreterFrame_LASTI` into `-1`, and the
+    // pointer is not negative there.  Frame setup consumes the
+    // compiler-inserted prologue, so the pointer rests on the first `RESUME`
+    // -- `code->_co_firsttraceable` -- which is what the `call` event reports:
+    // 0 for a plain function, 2 past a closure's `COPY_FREE_VARS`, 4 past a
+    // generator's `RETURN_GENERATOR` / `POP_TOP`.  Handing out `-1` instead
+    // named a coordinate no frame ever executes.  `pyframe.py fget_f_lasti`
+    // returns `last_instr` unscaled and stops there, so both adaptations live
+    // here rather than in [`PyFrame::fget_f_lasti`].
+    //
+    // A generator is the one shape whose not-yet-started frame rests somewhere
+    // else: `RETURN_GENERATOR` is what built the generator, so the frame it
+    // left behind sits on the instruction after it until the first resumption
+    // walks on to the `RESUME`.  Only the generator's own started flag
+    // separates the two, and the frame is reachable from Python in both states
+    // through `gi_frame`.
+    //
+    // That flag is read through the back-reference, which is cleared when the
+    // generator is collected (`generator_finalize`) and when a generator that
+    // never ran finishes.  A frame that outlives its generator therefore
+    // cannot say which of the two it rests on, and the sentinel stands: the
+    // `RESUME` would be the coordinate for a frame still at its `call` event,
+    // which this one is not.
+    //
+    // The flag alone does not separate a first `send` from a first `throw`,
+    // which marks the generator started and then injects before the `RESUME`
+    // is reached -- that frame is still on the instruction after
+    // `RETURN_GENERATOR`.  Nothing reads it there: the trace events that
+    // would are not emitted for an injection into a generator that never ran,
+    // and the frame is unlinked by the time the call returns.  Whatever
+    // starts emitting them owns that distinction.
+    //
+    // `-1` is left for a code object with no `RESUME` too, where that index
+    // runs past the end and the frame starts no line either.
     let lasti_getter = make_builtin_function_with_arity(
         "f_lasti",
         |args| {
@@ -8263,7 +8294,28 @@ fn init_frame_type(ns: PyObjectRef) {
             if f.is_null() {
                 return Ok(pyre_object::w_none());
             }
-            let lasti = unsafe { &*f }.fget_f_lasti() as i64;
+            let frame = unsafe { &*f };
+            let lasti = frame.fget_f_lasti();
+            let lasti = if lasti < 0 {
+                let code = frame.code();
+                let owner = frame.get_generator();
+                let index = match crate::pycode::after_return_generator_index(code) {
+                    Some(after_return_generator) => (!owner.is_null()).then(|| {
+                        if unsafe { pyre_object::generator::w_generator_is_started(owner) } {
+                            crate::pycode::first_traceable_index(code)
+                        } else {
+                            after_return_generator
+                        }
+                    }),
+                    None => Some(crate::pycode::first_traceable_index(code)),
+                };
+                match index {
+                    Some(index) if index < code.instructions.len() => index as i64,
+                    _ => -1,
+                }
+            } else {
+                lasti as i64
+            };
             Ok(pyre_object::w_int_new(if lasti < 0 {
                 -1
             } else {


### PR DESCRIPTION
## What

`f_lasti` answered `-1` for every frame whose `last_instr` is negative.
`frame_lasti_get_impl` (`Objects/frameobject.c`) maps only a *negative*
`_PyInterpreterFrame_LASTI` to `-1`, and a frame that has not yet run a
traceable instruction is not negative: frame setup consumes the
compiler-inserted prologue, so the pointer already names an instruction.

This was left as an explicit open item by the note at the top of
`no_line_event_on_the_prologue_resume.py`, which is updated here.

### 1. Two coordinates hide behind `last_instr < 0`

Answering both from `_co_firsttraceable` is wrong for exactly one of them:

| frame | coordinate | plain | closure |
|---|---|---|---|
| reached by the `call` event | `_co_firsttraceable`, the first `RESUME` | 0 | 2 |
| generator read through `gi_frame` before its first resumption | the instruction **after** `RETURN_GENERATOR` | 2 | 4 |

`RETURN_GENERATOR` is what built the generator being read, so the frame it left
behind rests on the next instruction — one unit short of the `RESUME` the
`call` event reports later.

Neither index is a constant: `COPY_FREE_VARS` precedes both and shifts them
along, so a hardcoded offset is right for a plain generator and wrong for a
closure one. `after_return_generator_index` joins `first_traceable_index` in
`pycode.rs`, and the `f_lasti` descriptor picks between them on the
generator's own `started` flag. A generator suspended mid-body never reaches
this branch, because its `last_instr` is already `>= 0`.

### 2. What the new fixture pins

`f_lasti_names_the_resume_on_the_call_event.py` covers the `call` event for a
plain function, a closure and a generator — the three prologue shapes, since
`_co_firsttraceable` is 0 without a prologue and the gap is invisible there —
and the unstarted-generator coordinate for a plain and a closure generator, so
the "not a constant" half is guarded too.

The generator is bound to a local before `gi_frame` is read. A frame object
that *outlives* its generator reports a different coordinate — `take_ownership`
(`Objects/frameobject.c`) leaves the pointer past the `RESUME`, giving 6/8
where a held generator gives 2/4. That is a separate behaviour and not what
this fixture pins.

## Divergences declared

`f_lasti_names_the_resume_on_the_call_event.py` carries a
`pyre-check: pypy-diverges` header read out of the vendored PyPy source, not a
version table: `pyframe.py:78` declares `last_instr = -1`, `pyframe.py:335-341`
states "Execution starts just after the last_instr. Initially, last_instr is
-1", and `fget_f_lasti` (`pyframe.py:771`) hands that out. 3.11 also has no
`RESUME` for the coordinate to name.

## Verification

All five coordinates match a CPython 3.14 oracle exactly. `cargo fmt --check`
clean, the LLBC extract is rc=0 with no `error[E`, the build is rc=0, the new
line-citation check is rc=0, and the eight fixtures that read `f_lasti` or
`tb_lasti` all pass. The parity suite reports the new fixture as
`cpython=OK pypy=xfail`.

The two PyPy-lane failures that remain locally
(`foriter_stopiteration_exception_event`, `pickle_pypy_reduce_build_gc`) are
pre-existing, and the local PyPy is a different release from CI's.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracing information for initial function call events, including closures and generators.
  * Corrected frame instruction positions for unstarted generators, making debugger and profiling data more accurate.
  * Preserved existing instruction positions for standard execution paths.

* **Tests**
  * Added coverage validating trace coordinates across plain functions, closures, and generators.
  * Clarified expected behavior for prologue resume events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->