### PR TITLE
jit-trace: the compiled list store's lower bound, the bigint shift count's width, and folds emitted from rows

### DIFF
--- a/pyre/bench/synth/a_compiled_list_store_deopts_for_a_negative_index.py
+++ b/pyre/bench/synth/a_compiled_list_store_deopts_for_a_negative_index.py
@@ -1,0 +1,108 @@
+# pyre-check: selfcheck
+# pyre-check: selfcheck-compiles=store_hot,read_hot
+# A store recorded from a non-negative index must still deopt when a later
+# index is NEGATIVE.  `space.setitem` remaps a negative index to `index + len`
+# (listobject.py), so a direct items-block store that only proved
+# `raw_index < len` addresses before the start of the array: the write is lost
+# and it lands on the word ahead of the items, not on `lst[-1]`.
+#
+# THE ASSERTION IS TWO-SIDED ON PURPOSE.  Checking only that `lst[-1]` reads
+# back the value passes even when the store went out of range, because the read
+# arm has its own lower-bound guard and deopts.  The neighbours must be checked
+# too, and so must the tail: an out-of-range write lands on the items block's
+# own header, which a later `append` reads.
+#
+# The read arms are covered here as well so that the list, tuple and store
+# arms cannot drift apart -- all three take the same shared bounds guard.
+WARM = 6000  # past the loop threshold (1039) many times over
+NEG = 5  # enough re-entries to reach the compiled store, not just the prologue
+
+
+def store_hot(n, seq, idx, mkval):
+    for i in range(n):
+        seq[idx] = mkval(i)
+    return seq
+
+
+def read_hot(n, seq, idx):
+    total = 0
+    for _ in range(n):
+        total += seq[idx]
+    return total
+
+
+CASES = (
+    # (name, fresh list, mkval, readable)
+    ('object', lambda: ['a', 'b', 'c', 'd'], lambda i: str(i), False),
+    ('int', lambda: [0, 0, 0, 0], lambda i: i, True),
+    ('float', lambda: [0.0, 0.0, 0.0, 0.0], lambda i: i * 1.0, True),
+)
+
+
+def check_store(name, fresh, mkval, failures):
+    seq = fresh()
+    store_hot(WARM, seq, 1, mkval)  # compile the store at a non-negative index
+    untouched = [seq[0], seq[2]]
+    # Re-enter the SAME trace: same callable (a fresh one would side-exit on the
+    # callable guard before reaching the store) and enough iterations to get
+    # past the entry threshold, with only the index sign changed.
+    store_hot(NEG, seq, -1, mkval)
+    want = mkval(NEG - 1)
+    if seq[3] != want:
+        failures.append('%s: lst[-1] left index 3 as %r, expected %r — the '
+                        'store did not remap the negative index'
+                        % (name, seq[3], want))
+    if [seq[0], seq[2]] != untouched:
+        failures.append('%s: neighbours moved to %r, expected %r'
+                        % (name, [seq[0], seq[2]], untouched))
+    if len(seq) != 4:
+        failures.append('%s: len is %d after the negative store, expected 4'
+                        % (name, len(seq)))
+    # An out-of-range write lands on the items block's header, so the next
+    # growth reads a corrupted capacity.
+    seq.append(mkval(1))
+    if len(seq) != 5 or seq[3] != want:
+        failures.append('%s: append gave %r, expected the tail intact and len 5'
+                        % (name, seq))
+    # Both bounds must still raise rather than take the direct store.
+    for bad in (len(seq), -len(seq) - 1):
+        try:
+            store_hot(NEG, seq, bad, mkval)
+        except IndexError:
+            pass
+        else:
+            failures.append('%s: lst[%d] = v did not raise IndexError' % (name, bad))
+
+
+def check_read(name, fresh, mkval, failures):
+    seq = fresh()
+    for i in range(4):
+        seq[i] = mkval(i + 1)
+    for target, kind in ((seq, ''), (tuple(seq), ' tuple')):
+        read_hot(WARM, target, 1)  # compile the read at a non-negative index
+        for idx in (-1, -4):
+            got = read_hot(NEG, target, idx)
+            want = NEG * target[len(target) + idx]
+            if got != want:
+                failures.append('%s%s: [%d] read %r over %d iterations, '
+                                'expected %r'
+                                % (name, kind, idx, got, NEG, want))
+
+
+def main():
+    failures = []
+    for name, fresh, mkval, readable in CASES:
+        check_store(name, fresh, mkval, failures)
+        if readable:
+            check_read(name, fresh, mkval, failures)
+    if failures:
+        for line in failures:
+            print('FAIL', line)
+        return 1
+    print('PASS a compiled list store deopts for a negative index')
+    return 0
+
+
+import sys
+
+sys.exit(main())

--- a/pyre/bench/synth/a_math_fold_recorded_on_an_int_deopts_for_a_subclass.py
+++ b/pyre/bench/synth/a_math_fold_recorded_on_an_int_deopts_for_a_subclass.py
@@ -1,0 +1,117 @@
+# pyre-check: selfcheck
+# pyre-check: selfcheck-compiles=hot1,hot2
+# A `math` fold recorded on an exact `int` must stop answering once the operand
+# is an `int` subclass.
+#
+# The coercion every float fold shares unboxes behind a `guard_class` on
+# `ob_type`, which a numeric subclass shares with its builtin; what separates
+# the two is `w_class`, and `w_class` is what decides whether `try_get_double`
+# finds an overridden `__float__`.  Four of the eleven arms that coerce an
+# operand to a float used to leave that pin to the caller and never emit it, so
+# a loop compiled on `2` kept computing `tan(2.0)` for a `MyInt(2)` whose
+# `__float__` answers `100.0`.  The pin now belongs to the coercion, so no arm
+# can be written without it.
+#
+# THE ORACLE IS THIS INTERPRETER, not another implementation.  `math.log` reads
+# its argument without consulting `__float__` here and in CPython, while pypy
+# does consult it; the invariant that holds regardless is that the compiled
+# loop answers what this build's own interpreter answers, and calls `__float__`
+# as often as it does.
+#
+# THE COUNT IS THE TEST.  A fold that keeps answering calls `__float__` once —
+# for the single interpreted iteration before the loop is entered — and then
+# never again, whatever the value it produces.  The values are checked too, but
+# a row whose two answers happen to agree would still be caught by its count.
+import math
+
+WARM = 6000
+
+
+class MyInt(int):
+    def __float__(self):
+        CALLS[0] += 1
+        return 100.0
+
+
+CALLS = [0]
+
+
+def hot1(n, fn, x):
+    total = 0.0
+    for _ in range(n):
+        total += fn(x)
+    return total
+
+
+def hot2(n, fn, x, y):
+    total = 0.0
+    for _ in range(n):
+        total += fn(x, y)
+    return total
+
+
+# (name, warm-up operands, operands whose first is the subclass).  Every row is
+# a fold arm: sqrt / log+cos+sin / fabs / isclose have their own, the rest are
+# rows of the generic one- and two-argument tables.
+CASES = (
+    ("sqrt", (2,), (MyInt(2),)),
+    ("log", (2,), (MyInt(2),)),
+    ("cos", (2,), (MyInt(2),)),
+    ("sin", (2,), (MyInt(2),)),
+    ("fabs", (2,), (MyInt(2),)),
+    ("tan", (2,), (MyInt(2),)),
+    ("exp", (2,), (MyInt(2),)),
+    ("atan", (2,), (MyInt(2),)),
+    ("degrees", (2,), (MyInt(2),)),
+    ("pow", (2, 3), (MyInt(2), 3)),
+    ("fmod", (2, 3), (MyInt(2), 3)),
+    ("copysign", (2, 3), (MyInt(2), 3)),
+    ("remainder", (2, 3), (MyInt(2), 3)),
+    ("atan2", (2, 3), (MyInt(2), 3)),
+    # `isclose` answers False either way on `(2, 3)`, so give it a pair whose
+    # two readings disagree.
+    ("isclose", (2, 100), (MyInt(2), 100)),
+)
+
+
+def measure(name, warm_args, test_args):
+    fn = getattr(math, name)
+    runner = hot1 if len(test_args) == 1 else hot2
+
+    # What one interpreted call does on this build, before anything is warm.
+    CALLS[0] = 0
+    want = float(fn(*test_args))
+    per_call = CALLS[0]
+
+    runner(WARM, fn, *warm_args)
+    CALLS[0] = 0
+    total = runner(WARM, fn, *test_args)
+    return total / WARM, want, CALLS[0], per_call * WARM
+
+
+def main():
+    failures = []
+    for name, warm_args, test_args in CASES:
+        got, want, calls, owed = measure(name, warm_args, test_args)
+        if calls != owed:
+            failures.append(
+                "math.%s called __float__ %d times over %d iterations, owed %d "
+                "— the compiled loop is answering for the subclass it was not "
+                "recorded on" % (name, calls, WARM, owed)
+            )
+        if abs(got - want) > abs(want) * 1e-12:
+            failures.append(
+                "math.%s compiled to %r, this interpreter answers %r"
+                % (name, got, want)
+            )
+    if failures:
+        for line in failures:
+            print("FAIL", line)
+        return 1
+    print("PASS every math float fold deopts for an int subclass")
+    return 0
+
+
+import sys
+
+sys.exit(main())

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -733,7 +733,12 @@ pub extern "C" fn jit_bigint_invert(a: i64) -> pyre_object::longobject::JitBigIn
 // first operand being the opaque `BigInt` ADT and the second being an
 // integer. See the operator-residual module note above.
 
-/// `rbigint.lshift` by a machine `usize` — `&BigInt << (b as usize)`.
+/// `rbigint.lshift(a, count)`, with the count kept as the `i64` `lshift`
+/// takes.  Narrowing it to a machine `usize` first truncates a count of
+/// 2**32 or more on a 32-bit target, which answers with the operand shifted
+/// by the low word instead of by the count.  A count the result cannot
+/// represent publishes MemoryError and answers null, as
+/// [`jit_bigint_lshift_count`] does; `Shl` would panic instead.
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_shl(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {
     let a = a as *const BigInt;
@@ -741,13 +746,26 @@ pub extern "C" fn jit_bigint_shl(a: i64, b: i64) -> pyre_object::longobject::Jit
         if b == 0 || (&*a).get_sign() == 0 {
             return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
         }
-        pyre_object::longobject::encode_jit_bigint_result(
-            pyre_object::longobject::alloc_bigint_nursery_collecting(&*a << (b as usize)),
-        )
+        match (&*a).lshift(b) {
+            Ok(value) => pyre_object::longobject::encode_jit_bigint_result(
+                pyre_object::longobject::alloc_bigint_nursery_collecting(value),
+            ),
+            Err(_) => {
+                crate::runtime_ops::jit_publish_exception(
+                    pyre_object::interp_exceptions::memory_error_singleton(),
+                );
+                pyre_object::longobject::encode_jit_bigint_result(std::ptr::null_mut())
+            }
+        }
     }
 }
 
-/// `rbigint.rshift` by a machine `usize` — `&BigInt >> (b as usize)`.
+/// `rbigint.rshift(a, count)`, with the count kept as the `i64` `rshift`
+/// takes.  Narrowing it to a machine `usize` first truncates a count of
+/// 2**32 or more on a 32-bit target, which answers with the operand
+/// unshifted where the shift is a total right shift.  A negative count
+/// publishes MemoryError and answers null rather than panicking through
+/// `Shr`; the JIT arm guards it non-negative before the call.
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_shr(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {
     let a = a as *const BigInt;
@@ -755,9 +773,17 @@ pub extern "C" fn jit_bigint_shr(a: i64, b: i64) -> pyre_object::longobject::Jit
         if b == 0 {
             return pyre_object::longobject::encode_jit_bigint_result(a as *mut BigInt);
         }
-        pyre_object::longobject::encode_jit_bigint_result(
-            pyre_object::longobject::alloc_bigint_nursery_collecting(&*a >> (b as usize)),
-        )
+        match (&*a).rshift(b, false) {
+            Ok(value) => pyre_object::longobject::encode_jit_bigint_result(
+                pyre_object::longobject::alloc_bigint_nursery_collecting(value),
+            ),
+            Err(_) => {
+                crate::runtime_ops::jit_publish_exception(
+                    pyre_object::interp_exceptions::memory_error_singleton(),
+                );
+                pyre_object::longobject::encode_jit_bigint_result(std::ptr::null_mut())
+            }
+        }
     }
 }
 
@@ -5855,6 +5881,32 @@ mod tests {
             let m = jit_w_long_mod_raw(a as i64, b as i64) as *mut BigInt;
             assert_eq!(*m, x.r#mod(&y).expect("test divisor is nonzero"));
         }
+    }
+
+    /// A shift count wider than a machine word must shift by the count, not by
+    /// its low word.  `usize` is 32 bits on wasm32 while `intval` is `i64` on
+    /// every target, so `2**33` reaches these residuals as an ordinary
+    /// `W_IntObject`; narrowing it first answered `x >> 2**33` with `x`.
+    ///
+    /// This discriminates only on a 32-bit target — on a 64-bit host the
+    /// narrowing that used to be here was lossless, so both spellings pass.
+    #[test]
+    fn test_rbigint_shift_residuals_take_a_count_wider_than_a_machine_word() {
+        let wide = 1i64 << 33;
+        let positive = BigInt::one().lshift(200).unwrap().int_add(12345);
+        let negative = positive.neg();
+        let p = pyre_object::longobject::alloc_bigint_nursery(positive);
+        let n = pyre_object::longobject::alloc_bigint_nursery(negative);
+
+        // Arithmetic right shift: to zero, and to -1 for a negative operand.
+        assert!(unsafe { &*decoded_bigint_result(jit_bigint_shr(p as i64, wide)) }.get_sign() == 0);
+        assert_eq!(
+            unsafe { &*decoded_bigint_result(jit_bigint_shr(n as i64, wide)) }.toint(),
+            Ok(-1)
+        );
+        // `jit_bigint_shl` takes the identical route (`lshift(b)`), but a count
+        // this wide asks it for a result of hundreds of megabytes, so it is not
+        // asserted here.
     }
 
     #[test]

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -304,86 +304,117 @@ pub fn skip_python_trivia_forward(code: &pyre_interpreter::CodeObject, mut py_pc
 /// `parent` marks the second row as a split of the first so the reader does not
 /// sum them.
 ///
-/// Spelled as a slice rather than an array so that adding a row cannot leave a
-/// hand-written length behind it: `SPEC_FOLD_COUNT` reads `len()`, which is a
-/// `const fn`, and every other reader iterates.
+/// Nothing about a row is written twice: `SPEC_FOLD_COUNT` reads `len()`, and
+/// the `SpecFold` a call site names is generated from the same list, so adding
+/// a row cannot leave a hand-written length or a stale label behind it.
+/// Declare the fold table.  The rows are the source: the `SpecFold` variants a
+/// call site names, the `SPEC_FOLD_ROWS` the census prints, and the width of
+/// the counter arrays all come out of the same list, in the same order, so a
+/// row and its call site cannot disagree.  A label that is not a row does not
+/// compile, and a row no site names is an unconstructed variant, which
+/// `dead_code` reports.
+macro_rules! spec_folds {
+    ($($variant:ident => ($label:literal, $site:literal, $parent:literal),)*) => {
+        /// The row a gated call site names.  Its discriminant is that row's
+        /// index into the counter arrays, which is why the two orders are one
+        /// order.
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        pub(crate) enum SpecFold {
+            $($variant,)*
+        }
+
+        impl SpecFold {
+            /// This row's index into [`SPEC_FOLD_ROWS`] and the counter arrays.
+            const fn index(self) -> usize {
+                self as usize
+            }
+        }
+
+        #[rustfmt::skip]
+        pub const SPEC_FOLD_ROWS: &[(&str, &str, &str)] = &[
+            // (label, site, parent)
+            $(($label, $site, $parent),)*
+        ];
+    };
+}
+
 #[rustfmt::skip]
-pub const SPEC_FOLD_ROWS: &[(&str, &str, &str)] = &[
-    // (label, site, parent)
-    ("truth_int",                 "residual_call", "-"),
-    ("truth_bool",                "residual_call", "-"),
-    ("unary_positive_int",        "residual_call", "-"),
-    ("unary_negative_int",        "residual_call", "-"),
-    ("unary_invert_int",          "residual_call", "-"),
-    ("store_subscr",              "residual_call", "-"),
-    ("setslice",                  "residual_call", "-"),
-    ("get_iter",                  "residual_call", "-"),
-    ("for_iter_next",             "residual_call", "-"),
-    ("make_function",             "residual_call", "-"),
-    ("set_function_attribute",    "residual_call", "-"),
-    ("newtuple",                  "residual_call", "-"),
-    ("newtuple_object",           "residual_call", "-"),
-    ("newlist",                   "residual_call", "-"),
-    ("builtin_len",               "residual_call", "-"),
-    ("builtin_dict_get",          "residual_call", "-"),
-    ("builtin_type_getattr",      "residual_call", "-"),
-    ("builtin_getattr",           "residual_call", "-"),
-    ("builtin_range",             "residual_call", "-"),
-    ("builtin_zip",               "residual_call", "-"),
-    ("builtin_locals",            "residual_call", "-"),
-    ("sys_getframe",              "residual_call", "-"),
-    ("math_sqrt",                 "residual_call", "-"),
-    ("math_log_trig",             "residual_call", "-"),
-    ("math_frexp",                "residual_call", "-"),
-    ("math_ldexp",                "residual_call", "-"),
-    ("math_isqrt",                "residual_call", "-"),
-    ("math_fabs",                 "residual_call", "-"),
-    ("math_float1",               "residual_call", "-"),
-    ("math_float2",               "residual_call", "-"),
-    ("math_isclose",              "residual_call", "-"),
-    ("builtin_fold1",             "residual_call", "-"),
-    ("builtin_fold2",             "residual_call", "-"),
-    ("math_floor",                "residual_call", "-"),
-    ("math_ceil",                 "residual_call", "-"),
-    ("math_trunc",                "residual_call", "-"),
-    ("int_call",                  "residual_call", "-"),
-    ("float_call",                "residual_call", "-"),
-    ("str_call",                  "residual_call", "-"),
-    ("builtin_divmod",            "residual_call", "-"),
-    ("set_add_method",            "residual_call", "-"),
-    ("store_attr_direct",         "residual_call", "-"),
-    ("store_attr_residual",       "residual_call", "store_attr_direct"),
-    ("load_attr",                 "residual_call", "-"),
-    ("load_type_name_attr",       "residual_call", "-"),
-    ("load_type_attr",            "residual_call", "-"),
-    ("load_method_attr",          "residual_call", "-"),
-    ("load_classmethod_attr",     "residual_call", "-"),
-    ("load_bound_method_attr",    "residual_call", "-"),
-    ("subscr",                    "residual_call", "-"),
-    ("binary_op_int",             "residual_call", "-"),
-    ("binary_op_long_int",        "residual_call", "-"),
-    ("binary_op_long_int_shift",  "residual_call", "-"),
-    ("binary_op_long_int_div",    "residual_call", "-"),
-    ("binary_op_long_int_pow",    "residual_call", "-"),
-    ("binary_op_long",            "residual_call", "-"),
-    ("truediv_op_long",           "residual_call", "-"),
-    ("binary_op_float",           "residual_call", "-"),
-    ("compare_op_int",            "residual_call", "-"),
-    ("compare_op_long_int",       "residual_call", "-"),
-    ("compare_op_long",           "residual_call", "-"),
-    ("compare_op_float",          "residual_call", "-"),
-    ("unpack",                    "residual_call", "-"),
-    ("subscr_tuple_descent",      "specialize",    "subscr"),
-    ("subscr_tuple",              "specialize",    "subscr"),
-    ("subscr_str",                "specialize",    "subscr"),
-    ("builtin_divmod_long_int",   "specialize",    "builtin_divmod"),
-    ("zip_two_tuple_iters",       "specialize",    "for_iter_next"),
-    ("instance_next",             "residual_call", "-"),
-    ("frame_lasti",               "specialize",    "load_attr"),
-    ("load_deref",                "residual_call", "-"),
-    ("frame_lineno",              "specialize",    "load_attr"),
-    ("bare_super_call",           "residual_call", "-"),
-];
+spec_folds! {
+    // variant                    label                       site             parent
+    TruthInt             => ("truth_int",                "residual_call", "-"),
+    TruthBool            => ("truth_bool",               "residual_call", "-"),
+    UnaryPositiveInt     => ("unary_positive_int",       "residual_call", "-"),
+    UnaryNegativeInt     => ("unary_negative_int",       "residual_call", "-"),
+    UnaryInvertInt       => ("unary_invert_int",         "residual_call", "-"),
+    StoreSubscr          => ("store_subscr",             "residual_call", "-"),
+    Setslice             => ("setslice",                 "residual_call", "-"),
+    GetIter              => ("get_iter",                 "residual_call", "-"),
+    ForIterNext          => ("for_iter_next",            "residual_call", "-"),
+    MakeFunction         => ("make_function",            "residual_call", "-"),
+    SetFunctionAttribute => ("set_function_attribute",   "residual_call", "-"),
+    Newtuple             => ("newtuple",                 "residual_call", "-"),
+    NewtupleObject       => ("newtuple_object",          "residual_call", "-"),
+    Newlist              => ("newlist",                  "residual_call", "-"),
+    BuiltinLen           => ("builtin_len",              "residual_call", "-"),
+    BuiltinDictGet       => ("builtin_dict_get",         "residual_call", "-"),
+    BuiltinTypeGetattr   => ("builtin_type_getattr",     "residual_call", "-"),
+    BuiltinGetattr       => ("builtin_getattr",          "residual_call", "-"),
+    BuiltinRange         => ("builtin_range",            "residual_call", "-"),
+    BuiltinZip           => ("builtin_zip",              "residual_call", "-"),
+    BuiltinLocals        => ("builtin_locals",           "residual_call", "-"),
+    SysGetframe          => ("sys_getframe",             "residual_call", "-"),
+    MathSqrt             => ("math_sqrt",                "residual_call", "-"),
+    MathLogTrig          => ("math_log_trig",            "residual_call", "-"),
+    MathFrexp            => ("math_frexp",               "residual_call", "-"),
+    MathLdexp            => ("math_ldexp",               "residual_call", "-"),
+    MathIsqrt            => ("math_isqrt",               "residual_call", "-"),
+    MathFabs             => ("math_fabs",                "residual_call", "-"),
+    MathFloat1           => ("math_float1",              "residual_call", "-"),
+    MathFloat2           => ("math_float2",              "residual_call", "-"),
+    MathIsclose          => ("math_isclose",             "residual_call", "-"),
+    BuiltinFold1         => ("builtin_fold1",            "residual_call", "-"),
+    BuiltinFold2         => ("builtin_fold2",            "residual_call", "-"),
+    MathFloor            => ("math_floor",               "residual_call", "-"),
+    MathCeil             => ("math_ceil",                "residual_call", "-"),
+    MathTrunc            => ("math_trunc",               "residual_call", "-"),
+    IntCall              => ("int_call",                 "residual_call", "-"),
+    FloatCall            => ("float_call",               "residual_call", "-"),
+    StrCall              => ("str_call",                 "residual_call", "-"),
+    BuiltinDivmod        => ("builtin_divmod",           "residual_call", "-"),
+    SetAddMethod         => ("set_add_method",           "residual_call", "-"),
+    StoreAttrDirect      => ("store_attr_direct",        "residual_call", "-"),
+    StoreAttrResidual    => ("store_attr_residual",      "residual_call", "store_attr_direct"),
+    LoadAttr             => ("load_attr",                "residual_call", "-"),
+    LoadTypeNameAttr     => ("load_type_name_attr",      "residual_call", "-"),
+    LoadTypeAttr         => ("load_type_attr",           "residual_call", "-"),
+    LoadMethodAttr       => ("load_method_attr",         "residual_call", "-"),
+    LoadClassmethodAttr  => ("load_classmethod_attr",    "residual_call", "-"),
+    LoadBoundMethodAttr  => ("load_bound_method_attr",   "residual_call", "-"),
+    Subscr               => ("subscr",                   "residual_call", "-"),
+    BinaryOpInt          => ("binary_op_int",            "residual_call", "-"),
+    BinaryOpLongInt      => ("binary_op_long_int",       "residual_call", "-"),
+    BinaryOpLongIntShift => ("binary_op_long_int_shift", "residual_call", "-"),
+    BinaryOpLongIntDiv   => ("binary_op_long_int_div",   "residual_call", "-"),
+    BinaryOpLongIntPow   => ("binary_op_long_int_pow",   "residual_call", "-"),
+    BinaryOpLong         => ("binary_op_long",           "residual_call", "-"),
+    TruedivOpLong        => ("truediv_op_long",          "residual_call", "-"),
+    BinaryOpFloat        => ("binary_op_float",          "residual_call", "-"),
+    CompareOpInt         => ("compare_op_int",           "residual_call", "-"),
+    CompareOpLongInt     => ("compare_op_long_int",      "residual_call", "-"),
+    CompareOpLong        => ("compare_op_long",          "residual_call", "-"),
+    CompareOpFloat       => ("compare_op_float",         "residual_call", "-"),
+    Unpack               => ("unpack",                   "residual_call", "-"),
+    SubscrTupleDescent   => ("subscr_tuple_descent",     "specialize",    "subscr"),
+    SubscrTuple          => ("subscr_tuple",             "specialize",    "subscr"),
+    SubscrStr            => ("subscr_str",               "specialize",    "subscr"),
+    BuiltinDivmodLongInt => ("builtin_divmod_long_int",  "specialize",    "builtin_divmod"),
+    ZipTwoTupleIters     => ("zip_two_tuple_iters",      "specialize",    "for_iter_next"),
+    InstanceNext         => ("instance_next",            "residual_call", "-"),
+    FrameLasti           => ("frame_lasti",              "specialize",    "load_attr"),
+    LoadDeref            => ("load_deref",               "residual_call", "-"),
+    FrameLineno          => ("frame_lineno",             "specialize",    "load_attr"),
+    BareSuperCall        => ("bare_super_call",          "residual_call", "-"),
+}
 
 const SPEC_FOLD_COUNT: usize = SPEC_FOLD_ROWS.len();
 
@@ -402,10 +433,6 @@ static SPEC_SUPPRESSED: [std::sync::atomic::AtomicU64; SPEC_FOLD_COUNT] = {
     const Z: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     [Z; SPEC_FOLD_COUNT]
 };
-/// A label passed to a gate that `SPEC_FOLD_ROWS` does not carry.  A nonzero
-/// value means a typo at a call site; the summary reports it rather than
-/// silently dropping the row.
-static SPEC_UNKNOWN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 static INSTANCE_NEXT_FORITER_ROUTE_GUARDS_KEYED: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 static INSTANCE_NEXT_FORITER_CALLEE_GUARDS_CAPTURED: std::sync::atomic::AtomicU64 =
@@ -624,7 +651,7 @@ fn spec_row_index(name: &str) -> Option<usize> {
 /// it is counted as consulted and never as fired.
 #[inline]
 pub(crate) fn spec_gate<T, E>(
-    name: &'static str,
+    fold: SpecFold,
     call: impl FnOnce() -> Result<Option<T>, E>,
 ) -> Result<Option<T>, E> {
     // Neither axis armed: one cached load, one predictable branch, then the
@@ -632,10 +659,7 @@ pub(crate) fn spec_gate<T, E>(
     if !spec_instrumented() {
         return call();
     }
-    let Some(idx) = spec_row_index(name) else {
-        SPEC_UNKNOWN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        return call();
-    };
+    let idx = fold.index();
     if spec_suppressed_mask().get(idx) {
         SPEC_SUPPRESSED[idx].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         return Ok(None);
@@ -667,13 +691,10 @@ pub(super) fn spec_gate_store_attr<E>(
     if !spec_instrumented() {
         return call();
     }
-    let (Some(direct_idx), Some(residual_idx)) = (
-        spec_row_index("store_attr_direct"),
-        spec_row_index("store_attr_residual"),
-    ) else {
-        SPEC_UNKNOWN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        return call();
-    };
+    let (direct_idx, residual_idx) = (
+        SpecFold::StoreAttrDirect.index(),
+        SpecFold::StoreAttrResidual.index(),
+    );
     let mask = spec_suppressed_mask();
     if mask.get(direct_idx) || mask.get(residual_idx) {
         SPEC_SUPPRESSED[direct_idx].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -742,9 +763,8 @@ pub fn spec_census_summary() -> String {
         spec_suppress_unknown().join(",")
     };
     let mut summary = format!(
-        "[spec-census] folds={} consulted_total={consulted_total} fired_total={fired_total} unknown_labels={} suppressed_total={suppressed_total} suppressed_names={suppressed_names} suppress_unknown={suppress_unknown}\n",
+        "[spec-census] folds={} consulted_total={consulted_total} fired_total={fired_total} suppressed_total={suppressed_total} suppressed_names={suppressed_names} suppress_unknown={suppress_unknown}\n",
         rows.len(),
-        SPEC_UNKNOWN.load(ordering),
     );
     summary.push_str(&format!(
         "[spec-census] instance_next_foriter route_guards_keyed={} callee_guards_captured={} callee_guards_keyed={}\n",

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -824,6 +824,14 @@ fn descent_unlowered_helper_scan_enabled() -> bool {
 /// This is deliberately separate from the memoized decision above: production
 /// needs only the effect-aware verdict, while the diagnostic pays to enumerate
 /// the whole body and every callee named by `inline_call_*`.
+///
+/// The blockers print as bare symbolic funcbox hashes, which name nothing on
+/// their own. The hash-to-path map is not in the binary — it is snapshotted by
+/// the translation pipeline (`symbolic_fnaddr_paths_snapshot`) and written to
+/// the codegen cache, so resolve a hash by reading `symbolic_fnaddr_paths` out
+/// of the newest `build/pyre-jit-trace-cache/*/*/jit_metadata.json` (newest by
+/// mtime — older generations hold different jitcode indices for the same path).
+/// A hash whose high bit is set is stored there as a negative `i64`.
 fn log_descent_unlowered_helper_blockers(jitcode_index: usize) {
     if !fbw_inline_diag_enabled() {
         return;
@@ -848,6 +856,105 @@ fn log_descent_unlowered_helper_blockers(jitcode_index: usize) {
         "[builtin-inline-blockers] jitcode={jitcode_index} n={} {named}",
         blockers.len()
     );
+
+    let mut reachable = Vec::new();
+    collect_descent_effect_aware_blockers(
+        jitcode_index,
+        false,
+        &mut std::collections::HashSet::new(),
+        &mut reachable,
+    );
+    let after_effect = reachable.iter().filter(|&&(_, effect)| effect).count();
+    let named = reachable
+        .iter()
+        .map(|&(blocker, effect)| format!("{blocker:#x}{}", if effect { "*" } else { "" }))
+        .collect::<Vec<_>>()
+        .join(",");
+    eprintln!(
+        "[builtin-inline-reachable] jitcode={jitcode_index} n={} after_effect={after_effect} {named}",
+        reachable.len()
+    );
+}
+
+/// Every un-lowered helper an effect-aware walk of `jitcode_index` reaches,
+/// each paired with whether an effect had already been applied on some path to
+/// it — the `*` suffix in the `[builtin-inline-reachable]` line.
+///
+/// [`summarize_descent_blockers`] answers the production question, "does this
+/// descent abort unrewindably", and so stops at the first blocker on each path
+/// and names one.  Removing a wall asks the other question: what stands behind
+/// that first blocker, because clearing it only moves the decline to the next.
+/// This walk therefore records a blocker and keeps going, which turns the
+/// decline into a work list — and, read against
+/// [`collect_descent_unlowered_helper_blockers`]'s whole-body census, separates
+/// the helpers a descent can actually reach from the ones sitting on arms it
+/// never takes.
+///
+/// The two lists are not one walk with a flag because they answer to different
+/// costs: the census enumerates bytes, while this reruns the dataflow.
+///
+/// Blockers found in an `inline_call` callee are appended after the caller's
+/// own rather than interleaved at the call, so this is walk order per body and
+/// not strictly byte order across the descent.  The first blocker is already
+/// named by the decline line; what this adds is the set.
+///
+/// A body is walked at most once per entry-effect state rather than once per
+/// path reaching it.  Both are sound for a set, but re-walking runs this
+/// body-wide fixpoint once per path through the callee DAG, which does not
+/// terminate in practice: the whole-body census next door survives the same
+/// shape only because its per-body cost is one linear decode.
+fn collect_descent_effect_aware_blockers(
+    jitcode_index: usize,
+    entry_effect: bool,
+    visited: &mut std::collections::HashSet<(usize, bool)>,
+    out: &mut Vec<(i64, bool)>,
+) {
+    if !visited.insert((jitcode_index, entry_effect)) {
+        return;
+    }
+    let Some(jitcode) = crate::jitcode_runtime::get_jitcode_ref_by_index(jitcode_index) else {
+        return;
+    };
+    let descrs = crate::jitcode_runtime::descr_ref_table();
+    // Collected rather than recorded in place: both hooks would otherwise hold
+    // `out` borrowed at once.
+    let mut here: Vec<(i64, bool)> = Vec::new();
+    let mut callees: Vec<(usize, bool)> = Vec::new();
+    summarize_body_blockers_with(
+        jitcode.code.as_slice(),
+        jitcode.num_regs_i(),
+        jitcode.constants_i.as_slice(),
+        |descr_index, caller_effect| {
+            let callee = descrs
+                .at(descr_index)
+                .and_then(|descr| descr.as_jitcode_descr().map(|jc| jc.jitcode_index()))?;
+            callees.push((callee, caller_effect));
+            // The memoizing entry point, so a cycle among callees terminates
+            // inside it rather than through this walk's own `seen`.
+            Some(descent_blocker_summary(callee))
+        },
+        &mut |blocker, effect| {
+            here.push((blocker, effect));
+            false
+        },
+    );
+    for (blocker, effect) in here {
+        record_reachable_blocker(out, blocker, entry_effect || effect);
+    }
+    for (callee, caller_effect) in callees {
+        collect_descent_effect_aware_blockers(callee, entry_effect || caller_effect, visited, out);
+    }
+}
+
+/// Add one blocker to the reachable list, keeping the first sighting's position
+/// and widening its effect flag: reaching the same helper once with an effect
+/// behind it is what makes it a decline, however many effect-free paths also
+/// reach it.
+fn record_reachable_blocker(out: &mut Vec<(i64, bool)>, blocker: i64, effect: bool) {
+    match out.iter_mut().find(|(known, _)| *known == blocker) {
+        Some((_, known_effect)) => *known_effect |= effect,
+        None => out.push((blocker, effect)),
+    }
 }
 
 /// Collect the distinct symbolic funcboxes in a body's decoded byte stream and
@@ -1060,6 +1167,35 @@ pub(crate) fn summarize_body_blockers(
     constants_i: &[i64],
     mut callee_summary: impl FnMut(usize) -> Option<DescentBlockerSummary>,
 ) -> DescentBlockerSummary {
+    summarize_body_blockers_with(
+        code,
+        num_regs_i,
+        constants_i,
+        |descr_index, _caller_effect| callee_summary(descr_index),
+        &mut |_blocker, _effect| true,
+    )
+}
+
+/// [`summarize_body_blockers`] with the two hooks the diagnostic needs.
+///
+/// `on_blocker` is told each blocker and whether an effect had been applied
+/// before it, and answers whether the walk stops there.  The production
+/// summary stops, because that is where the descent aborts; a walk that wants
+/// what stands *behind* the first blocker keeps going, treating the call as
+/// having returned an unknown value — which is what the destination-blanking
+/// below already does for any non-`int_copy` write.
+///
+/// `callee_summary` is additionally told the caller's effect state at the
+/// `inline_call`, which the summary itself does not need — it folds the two
+/// cases through `blocker_after_effect.or(blocker_effect_free)` — but which a
+/// walk descending into the callee needs to classify what it finds there.
+fn summarize_body_blockers_with(
+    code: &[u8],
+    num_regs_i: usize,
+    constants_i: &[i64],
+    mut callee_summary: impl FnMut(usize, bool) -> Option<DescentBlockerSummary>,
+    on_blocker: &mut dyn FnMut(i64, bool) -> bool,
+) -> DescentBlockerSummary {
     let mut summary = DescentBlockerSummary::default();
 
     // Instruction starts, so a decoded branch target that lands mid-op (or
@@ -1164,21 +1300,23 @@ pub(crate) fn summarize_body_blockers(
             if let Some(Some(fnaddr)) = known_i.get(funcbox)
                 && majit_translate::codewriter::call::is_symbolic_fnaddr(*fnaddr)
             {
-                // The walk stops here, so this op has no successors.
                 let slot = if effect {
                     &mut summary.blocker_after_effect
                 } else {
                     &mut summary.blocker_effect_free
                 };
                 slot.get_or_insert(*fnaddr);
-                continue;
+                if on_blocker(*fnaddr, effect) {
+                    // The walk stops here, so this op has no successors.
+                    continue;
+                }
             }
         } else if d.opname.starts_with("inline_call") {
             // `inline_call_*` opens with the `d` descr operand, a two-byte
             // index into the descriptor pool, naming the callee JitCode.
             let descr_index = code.get(d.pc + 1).copied().unwrap_or(0) as usize
                 | ((code.get(d.pc + 2).copied().unwrap_or(0) as usize) << 8);
-            if let Some(callee) = callee_summary(descr_index) {
+            if let Some(callee) = callee_summary(descr_index, effect) {
                 // Entering with an effect behind us turns every blocker the
                 // callee holds into one that cannot be rewound.
                 let after = if effect {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -8474,6 +8474,18 @@ fn walker_guard_int_exact_as_float<Sym: WalkSym>(
 /// A float arithmetic operand legitimately rounds (`space.float_w`), but a
 /// comparison is decided against the int's exact value (`_compare`), so only
 /// the compare specialization sets it.
+///
+/// The int arm pins `w_class` here rather than leaving it to the caller.  The
+/// unbox proves `ob_type`, which an `int` subclass shares with `int`, while
+/// every gate that admits one of these folds read `w_class`; without the pin a
+/// trace recorded on an exact int keeps answering for a subclass whose
+/// `__float__` returns something else.  Making it part of the coercion is what
+/// keeps the obligation from being restated — and forgotten — per arm.
+/// The float arm carries no pin: reading a `float` subclass's payload is what
+/// `try_get_double` does too, so the coerced value is the one the builtin would
+/// have seen.  An operation that instead *dispatches* on the operand's class
+/// (`space.add`, `space.lt`) needs the float arm pinned as well and takes
+/// [`walker_coerce_dispatching_operand_to_float`].
 fn walker_coerce_operand_to_float<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,
@@ -8498,6 +8510,31 @@ fn walker_coerce_operand_to_float<Sym: WalkSym>(
     };
     ctx.trace_ctx
         .set_opref_concrete(raw, majit_ir::Value::Float(val));
+    if is_int {
+        walker_guard_exact_w_class(ctx, op_pc, obj, walker_numeric_builtin_class(concrete_obj))?;
+    }
+    Ok(raw)
+}
+
+/// [`walker_coerce_operand_to_float`] for an operation that dispatches on the
+/// operand's Python-level class instead of only reading its payload.  A `float`
+/// subclass overriding `__add__` / `__lt__` reaches a different implementation
+/// than the one recorded, and the unbox proves only `ob_type`, so pin `w_class`
+/// on that arm too.
+fn walker_coerce_dispatching_operand_to_float<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    obj: OpRef,
+    concrete_obj: pyre_object::PyObjectRef,
+    is_int: bool,
+    val: f64,
+    exact_int: bool,
+) -> Result<OpRef, DispatchError> {
+    let raw =
+        walker_coerce_operand_to_float(ctx, op_pc, obj, concrete_obj, is_int, val, exact_int)?;
+    if !is_int {
+        walker_guard_exact_w_class(ctx, op_pc, obj, walker_numeric_builtin_class(concrete_obj))?;
+    }
     Ok(raw)
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -5944,7 +5944,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("builtin_len", || {
+        && spec_gate(SpecFold::BuiltinLen, || {
             try_walker_specialize_builtin_len(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6216,7 +6216,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         // `int_is_true`, eliding the may-force call whose force/exc guards
         // mis-resume the kept short-circuit stack.
         if ei.runtime_helper == majit_ir::RuntimeHelperKind::Truth {
-            if let Some(truth) = spec_gate("truth_int", || {
+            if let Some(truth) = spec_gate(SpecFold::TruthInt, || {
                 try_walker_specialize_truth_int(ctx, op.pc, r_args[0])
             })? {
                 write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, truth)?;
@@ -6225,7 +6225,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
             // The boxed bool a residual `COMPARE_OP` leaves behind — the int
             // arm above guards `INT_TYPE` and declines it, so without this the
             // test on every `if a == b:` stays a second may-force call.
-            if let Some(truth) = spec_gate("truth_bool", || {
+            if let Some(truth) = spec_gate(SpecFold::TruthBool, || {
                 try_walker_specialize_truth_bool(ctx, op.pc, r_args[0])
             })? {
                 write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, truth)?;
@@ -6244,7 +6244,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'r'
         && r_args.len() == 1
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::UnaryPositive
-        && spec_gate("unary_positive_int", || {
+        && spec_gate(SpecFold::UnaryPositiveInt, || {
             try_walker_specialize_unary_positive_int(ctx, op.pc, r_args[0], dst, dst_bank)
         })?
         .is_some()
@@ -6261,7 +6261,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'r'
         && r_args.len() == 1
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::UnaryNegative
-        && spec_gate("unary_negative_int", || {
+        && spec_gate(SpecFold::UnaryNegativeInt, || {
             try_walker_specialize_unary_negative_int(
                 ctx, op.pc, r_args[0], &allboxes, call_descr, dst, dst_bank,
             )
@@ -6279,7 +6279,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'r'
         && r_args.len() == 1
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::UnaryInvert
-        && spec_gate("unary_invert_int", || {
+        && spec_gate(SpecFold::UnaryInvertInt, || {
             try_walker_specialize_unary_invert_int(
                 ctx, op.pc, r_args[0], &allboxes, call_descr, dst, dst_bank,
             )
@@ -6299,7 +6299,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'v'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::StoreSubscr
     {
-        if spec_gate("store_subscr", || {
+        if spec_gate(SpecFold::StoreSubscr, || {
             try_walker_specialize_store_subscr(ctx, op.pc, &r_args)
         })?
         .is_some()
@@ -6312,7 +6312,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         // a virtualizable BUILD_LIST source temp is consumed without forcing.
         // Declines to the opaque residual for any shape it cannot reproduce
         // faithfully (SAFE — always byte-correct).
-        if spec_gate("setslice", || {
+        if spec_gate(SpecFold::Setslice, || {
             try_walker_specialize_setslice(ctx, op.pc, &r_args)
         })?
         .is_some()
@@ -6331,7 +6331,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // Range GET_ITER: virtualize exact machine-word `range` into the same
     // `W_IntRangeIterator` shape PyPy's inlined `descr_iter` would trace.
     if ctx.is_authoritative_executor && ei.runtime_helper == majit_ir::RuntimeHelperKind::GetIter {
-        if let Some(iter_op) = spec_gate("get_iter", || {
+        if let Some(iter_op) = spec_gate(SpecFold::GetIter, || {
             try_walker_specialize_get_iter(ctx, op.pc, &r_args, dst, dst_bank)
         })? {
             write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, iter_op)?;
@@ -6353,13 +6353,13 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::ForIterNext
     {
-        if let Some(item_op) = spec_gate("for_iter_next", || {
+        if let Some(item_op) = spec_gate(SpecFold::ForIterNext, || {
             try_walker_specialize_for_iter_next(ctx, op.pc, &r_args, dst, dst_bank)
         })? {
             write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, item_op)?;
             return Ok((DispatchOutcome::Continue, op.next_pc));
         }
-        if let Some(inlined) = spec_gate("instance_next", || {
+        if let Some(inlined) = spec_gate(SpecFold::InstanceNext, || {
             try_walker_specialize_instance_next(
                 ctx, op, code, funcptr, &r_args, call_descr, dst, dst_bank,
             )
@@ -6375,7 +6375,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::MakeFunction
-        && spec_gate("make_function", || {
+        && spec_gate(SpecFold::MakeFunction, || {
             try_walker_specialize_make_function(ctx, op.pc, &r_args, dst, dst_bank)
         })?
         .is_some()
@@ -6391,7 +6391,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::NewtupleFromArray
-        && spec_gate("newtuple", || {
+        && spec_gate(SpecFold::Newtuple, || {
             try_walker_specialize_newtuple(ctx, op.pc, &r_args, dst, dst_bank)
         })?
         .is_some()
@@ -6408,7 +6408,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::NewtupleFromArray
-        && spec_gate("newtuple_object", || {
+        && spec_gate(SpecFold::NewtupleObject, || {
             try_walker_specialize_newtuple_object(ctx, op.pc, &r_args, dst, dst_bank)
         })?
         .is_some()
@@ -6428,7 +6428,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::NewlistFromArray
-        && spec_gate("newlist", || {
+        && spec_gate(SpecFold::Newlist, || {
             try_walker_specialize_newlist(ctx, op.pc, &r_args, dst, dst_bank)
         })?
         .is_some()
@@ -6516,7 +6516,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("builtin_dict_get", || {
+        && spec_gate(SpecFold::BuiltinDictGet, || {
             try_walker_specialize_builtin_dict_get(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6530,7 +6530,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("builtin_type_getattr", || {
+        && spec_gate(SpecFold::BuiltinTypeGetattr, || {
             try_walker_specialize_builtin_type_getattr(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6545,7 +6545,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("builtin_getattr", || {
+        && spec_gate(SpecFold::BuiltinGetattr, || {
             try_walker_specialize_builtin_getattr(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6560,7 +6560,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
     {
-        if let Some(outcome) = spec_gate("builtin_range", || {
+        if let Some(outcome) = spec_gate(SpecFold::BuiltinRange, || {
             try_walker_specialize_builtin_range(ctx, code, op, funcptr, &r_args, call_descr, dst)
         })? {
             return Ok((outcome, op.next_pc));
@@ -6571,7 +6571,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallKw
-        && spec_gate("builtin_zip", || {
+        && spec_gate(SpecFold::BuiltinZip, || {
             try_walker_specialize_builtin_zip(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6591,7 +6591,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("builtin_locals", || {
+        && spec_gate(SpecFold::BuiltinLocals, || {
             try_walker_specialize_builtin_locals(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6610,7 +6610,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("sys_getframe", || {
+        && spec_gate(SpecFold::SysGetframe, || {
             try_walker_specialize_sys_getframe(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6627,7 +6627,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("math_sqrt", || {
+        && spec_gate(SpecFold::MathSqrt, || {
             try_walker_specialize_math_sqrt(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6637,7 +6637,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("math_log_trig", || {
+        && spec_gate(SpecFold::MathLogTrig, || {
             try_walker_specialize_math_log_trig(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6647,7 +6647,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("math_frexp", || {
+        && spec_gate(SpecFold::MathFrexp, || {
             try_walker_specialize_math_frexp(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6657,7 +6657,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("math_ldexp", || {
+        && spec_gate(SpecFold::MathLdexp, || {
             try_walker_specialize_math_ldexp(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6667,7 +6667,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("math_isqrt", || {
+        && spec_gate(SpecFold::MathIsqrt, || {
             try_walker_specialize_math_isqrt(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6677,7 +6677,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("math_fabs", || {
+        && spec_gate(SpecFold::MathFabs, || {
             try_walker_specialize_math_fabs(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6687,7 +6687,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("math_float1", || {
+        && spec_gate(SpecFold::MathFloat1, || {
             try_walker_specialize_math_float1(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6697,7 +6697,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("math_float2", || {
+        && spec_gate(SpecFold::MathFloat2, || {
             try_walker_specialize_math_float2(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6707,7 +6707,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("math_isclose", || {
+        && spec_gate(SpecFold::MathIsclose, || {
             try_walker_specialize_math_isclose(ctx, code, op, &r_args, dst, dst_bank)
         })?
         .is_some()
@@ -6717,7 +6717,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("builtin_fold1", || {
+        && spec_gate(SpecFold::BuiltinFold1, || {
             try_walker_specialize_builtin_fold1(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6727,7 +6727,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("builtin_fold2", || {
+        && spec_gate(SpecFold::BuiltinFold2, || {
             try_walker_specialize_builtin_fold2(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6737,7 +6737,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("math_floor", || {
+        && spec_gate(SpecFold::MathFloor, || {
             try_walker_specialize_math_round_to_int(
                 ctx,
                 code,
@@ -6754,7 +6754,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("math_ceil", || {
+        && spec_gate(SpecFold::MathCeil, || {
             try_walker_specialize_math_round_to_int(
                 ctx,
                 code,
@@ -6771,7 +6771,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("math_trunc", || {
+        && spec_gate(SpecFold::MathTrunc, || {
             try_walker_specialize_math_round_to_int(
                 ctx,
                 code,
@@ -6788,7 +6788,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("int_call", || {
+        && spec_gate(SpecFold::IntCall, || {
             try_walker_specialize_int_call(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6798,7 +6798,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("bare_super_call", || {
+        && spec_gate(SpecFold::BareSuperCall, || {
             try_walker_specialize_bare_super_call(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6808,7 +6808,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("float_call", || {
+        && spec_gate(SpecFold::FloatCall, || {
             try_walker_specialize_float_call(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6818,7 +6818,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("str_call", || {
+        && spec_gate(SpecFold::StrCall, || {
             try_walker_specialize_str_call(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6835,7 +6835,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
-        && spec_gate("builtin_divmod", || {
+        && spec_gate(SpecFold::BuiltinDivmod, || {
             try_walker_specialize_builtin_divmod(ctx, code, op, &r_args, dst)
         })?
         .is_some()
@@ -6963,7 +6963,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'r'
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
     {
-        spec_gate("set_add_method", || {
+        spec_gate(SpecFold::SetAddMethod, || {
             try_walker_specialize_set_add_method(ctx, code, op, &r_args)
         })?
     } else {
@@ -7333,7 +7333,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && runtime_helper_kind == majit_ir::RuntimeHelperKind::SetFunctionAttribute
-        && spec_gate("set_function_attribute", || {
+        && spec_gate(SpecFold::SetFunctionAttribute, || {
             try_walker_specialize_set_function_attribute(
                 ctx, op.pc, &i_args, &r_args, dst, dst_bank,
             )
@@ -7357,7 +7357,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         && dst_bank == 'r'
         && runtime_helper_kind == majit_ir::RuntimeHelperKind::LoadDeref
     {
-        if let Some(value) = spec_gate("load_deref", || {
+        if let Some(value) = spec_gate(SpecFold::LoadDeref, || {
             try_walker_specialize_load_deref(ctx, op.pc, &r_args)
         })? {
             write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, value)?;
@@ -7757,7 +7757,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 // operand, so the lookup has to reach it already resolved.
                 let attr_name = walker_load_name_from_code(w_code_ptr, namei as usize);
                 if let Some(attr_name) = attr_name.as_deref()
-                    && spec_gate("load_attr", || {
+                    && spec_gate(SpecFold::LoadAttr, || {
                         try_walker_specialize_load_attr(
                             ctx, op.pc, obj_opref, attr_name, dst, dst_bank,
                         )
@@ -7769,7 +7769,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 // The plain-slot fold wants a mapdict instance and declines a
                 // class; `Cls.__name__` reads the slot the metatype getset
                 // returns instead.
-                if spec_gate("load_type_name_attr", || {
+                if spec_gate(SpecFold::LoadTypeNameAttr, || {
                     try_walker_specialize_load_type_name_attr(
                         ctx,
                         op.pc,
@@ -7818,7 +7818,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 }
                 // A type receiver whose class-MRO value needs no descriptor
                 // binding folds to that value under receiver + version pins.
-                if spec_gate("load_type_attr", || {
+                if spec_gate(SpecFold::LoadTypeAttr, || {
                     try_walker_specialize_load_type_attr(
                         ctx,
                         op.pc,
@@ -7883,7 +7883,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 ctx.trace_ctx.box_value(code_opref),
                 ctx.trace_ctx.box_value(namei_opref),
             ) {
-                if spec_gate("load_method_attr", || {
+                if spec_gate(SpecFold::LoadMethodAttr, || {
                     try_walker_specialize_load_method_attr(
                         ctx,
                         op.pc,
@@ -7903,7 +7903,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 // declines (non-instance receiver, non-method descriptor).
                 // Write the classmethod's `__func__` so the paired
                 // `load_method_self` binds the class and the CALL inlines it.
-                if spec_gate("load_classmethod_attr", || {
+                if spec_gate(SpecFold::LoadClassmethodAttr, || {
                     try_walker_specialize_load_classmethod_attr(
                         ctx,
                         op.pc,
@@ -7923,7 +7923,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 // builtin receiver (`lst.append`) leaves `getattr` to build a
                 // `Method`.  Emit that construction instead of the opaque
                 // residual so it virtualizes into the following CALL.
-                if spec_gate("load_bound_method_attr", || {
+                if spec_gate(SpecFold::LoadBoundMethodAttr, || {
                     try_walker_specialize_load_bound_method_attr(
                         ctx,
                         op.pc,
@@ -8045,7 +8045,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                         }
                         // BINARY_SUBSCR list[int] getitem (int/float storage);
                         // falls through to the generic may-force leg otherwise.
-                        spec_gate("subscr", || {
+                        spec_gate(SpecFold::Subscr, || {
                             try_walker_specialize_subscr(
                                 ctx, op.pc, &r_args, &allboxes, call_descr, dst, dst_bank,
                             )
@@ -8053,7 +8053,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                     } else {
                         // int specialization first; float (incl. mixed int/float)
                         // as a fallback so two-int operands keep int arithmetic.
-                        if let Some(outcome) = spec_gate("binary_op_int", || {
+                        if let Some(outcome) = spec_gate(SpecFold::BinaryOpInt, || {
                             try_walker_specialize_binary_op_int(
                                 ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
                             )
@@ -8063,7 +8063,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                         // longobject.py `_make_generic_descr_binop` and
                         // `descr_sub` use the rbigint.int_* family for
                         // mixed Long/Int operands.
-                        let mut specialized = spec_gate("binary_op_long_int", || {
+                        let mut specialized = spec_gate(SpecFold::BinaryOpLongInt, || {
                             try_walker_specialize_binary_op_long_int(
                                 ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
                             )
@@ -8072,12 +8072,14 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                             // `_make_descr_binop` gives shifts with an Int
                             // count their own `_int_lshift` / `_int_rshift`
                             // path before Long/Long.
-                            if let Some(outcome) = spec_gate("binary_op_long_int_shift", || {
-                                try_walker_specialize_binary_op_long_int_shift(
-                                    ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
-                                    dst_bank,
-                                )
-                            })? {
+                            if let Some(outcome) =
+                                spec_gate(SpecFold::BinaryOpLongIntShift, || {
+                                    try_walker_specialize_binary_op_long_int_shift(
+                                        ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
+                                        dst_bank,
+                                    )
+                                })?
+                            {
                                 return Ok((outcome, op.next_pc));
                             }
                         }
@@ -8086,7 +8088,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                             // an Int divisor keeps its machine word instead of
                             // being widened to a bigint, and `_int_mod`'s
                             // result is a machine int rather than a long.
-                            if let Some(outcome) = spec_gate("binary_op_long_int_div", || {
+                            if let Some(outcome) = spec_gate(SpecFold::BinaryOpLongIntDiv, || {
                                 try_walker_specialize_binary_op_long_int_div(
                                     ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
                                     dst_bank,
@@ -8099,7 +8101,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                             // `descr_pow` keeps a `W_IntObject` exponent
                             // unwrapped and calls `rbigint.int_pow`; only a
                             // long exponent reaches `rbigint.pow`.
-                            specialized = spec_gate("binary_op_long_int_pow", || {
+                            specialized = spec_gate(SpecFold::BinaryOpLongIntPow, || {
                                 try_walker_specialize_binary_op_long_int_pow(
                                     ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
                                     dst_bank,
@@ -8110,7 +8112,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                             // W_LongObject operands take the long fast path
                             // before float so bigint arithmetic retains its
                             // payload representation.
-                            specialized = spec_gate("binary_op_long", || {
+                            specialized = spec_gate(SpecFold::BinaryOpLong, || {
                                 try_walker_specialize_binary_op_long(
                                     ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
                                     dst_bank,
@@ -8120,7 +8122,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                         if specialized.is_none() {
                             // Two-long true-divide → float fast path
                             // (CallPureF + wrapfloat).
-                            specialized = spec_gate("truediv_op_long", || {
+                            specialized = spec_gate(SpecFold::TruedivOpLong, || {
                                 try_walker_specialize_truediv_op_long(
                                     ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
                                     dst_bank,
@@ -8128,7 +8130,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                             })?;
                         }
                         if specialized.is_none() {
-                            if let Some(outcome) = spec_gate("binary_op_float", || {
+                            if let Some(outcome) = spec_gate(SpecFold::BinaryOpFloat, || {
                                 try_walker_specialize_binary_op_float(
                                     ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
                                     dst_bank,
@@ -8172,26 +8174,26 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 } else {
                     // int compare first; then long (two-bigint operands keep
                     // bigint comparison); float (incl. mixed int/float) last.
-                    match spec_gate("compare_op_int", || {
+                    match spec_gate(SpecFold::CompareOpInt, || {
                         try_walker_specialize_compare_op_int(
                             ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
                         )
                     })? {
                         Some(()) => Some(()),
-                        None => match spec_gate("compare_op_long_int", || {
+                        None => match spec_gate(SpecFold::CompareOpLongInt, || {
                             try_walker_specialize_compare_op_long_int(
                                 ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
                             )
                         })? {
                             Some(()) => Some(()),
-                            None => match spec_gate("compare_op_long", || {
+                            None => match spec_gate(SpecFold::CompareOpLong, || {
                                 try_walker_specialize_compare_op_long(
                                     ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
                                     dst_bank,
                                 )
                             })? {
                                 Some(()) => Some(()),
-                                None => spec_gate("compare_op_float", || {
+                                None => spec_gate(SpecFold::CompareOpFloat, || {
                                     try_walker_specialize_compare_op_float(
                                         ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
                                         dst_bank,
@@ -8229,7 +8231,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     if matches!(
         ei.runtime_helper,
         majit_ir::RuntimeHelperKind::UnpackSequence | majit_ir::RuntimeHelperKind::UnpackItem
-    ) && spec_gate("unpack", || {
+    ) && spec_gate(SpecFold::Unpack, || {
         try_walker_specialize_unpack(
             ctx,
             op.pc,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -6538,6 +6538,39 @@ pub(crate) fn try_walker_specialize_binary_op_float<Sym: WalkSym>(
     Ok(Some(DispatchOutcome::Continue))
 }
 
+/// Two-sided bounds guard `0 <= raw_index < len` for a direct element access.
+///
+/// The trace is recorded from a non-negative observed index, but a later
+/// NEGATIVE index would still satisfy `raw_index < len` and reach the element
+/// having proved nothing about its sign.  `space.getitem` / `space.setitem`
+/// remap a negative index to `index + len` (listobject.py, tupleobject.py), so
+/// the direct access would address before the start of the array; the
+/// lower-bound guard deopts such an index to re-execute that remap generically.
+///
+/// Both halves are emitted here so that an indexing arm cannot take one without
+/// the other.
+fn walker_emit_index_bounds_guards<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    raw_index: OpRef,
+    index: i64,
+    lenbox: OpRef,
+    concrete_len: usize,
+) -> Result<(), DispatchError> {
+    let zero = ctx.trace_ctx.const_int(0);
+    let nonneg = ctx.trace_ctx.record_op(OpCode::IntGe, &[raw_index, zero]);
+    ctx.trace_ctx
+        .set_opref_concrete(nonneg, majit_ir::Value::Int((index >= 0) as i64));
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[nonneg])?;
+    let in_bounds = ctx.trace_ctx.record_op(OpCode::IntLt, &[raw_index, lenbox]);
+    ctx.trace_ctx.set_opref_concrete(
+        in_bounds,
+        majit_ir::Value::Int(((index as usize) < concrete_len) as i64),
+    );
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[in_bounds])?;
+    Ok(())
+}
+
 /// #62: walker-native speculative specialization for the `BINARY_SUBSCR`
 /// helper residual_call (oopspec `BinaryOp`, op_tag `Subscr`).  Ports
 /// the former subscription/list-strategy path for the object-, int-, and
@@ -6884,30 +6917,15 @@ pub(crate) fn try_walker_specialize_subscr<Sym: WalkSym>(
     ctx.trace_ctx
         .set_opref_concrete(raw_index, majit_ir::Value::Int(index));
 
-    // Two-sided bounds guard `0 <= raw_index < len`.  Object storage keeps the
-    // inline `length` field (rlist.py); int/float storage read the typed
-    // items-array length field.  The trace is recorded from a non-negative
-    // observed index, but a later NEGATIVE index would still satisfy
-    // `raw_index < len` and reach the element load out of range; `space.getitem`
-    // treats a negative index as `index + len` (listobject.py), so the
-    // lower-bound guard deopts to re-execute that remap generically.
+    // Object storage keeps the inline `length` field (rlist.py); int/float
+    // storage read the typed items-array length field.
     let len_descr = match sid {
         0 => crate::descr::list_length_descr(),
         1 => crate::descr::list_int_items_len_descr(),
         _ => crate::descr::list_float_items_len_descr(),
     };
     let lenbox = crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, list_op, len_descr);
-    let zero = ctx.trace_ctx.const_int(0);
-    let nonneg = ctx.trace_ctx.record_op(OpCode::IntGe, &[raw_index, zero]);
-    ctx.trace_ctx
-        .set_opref_concrete(nonneg, majit_ir::Value::Int((index >= 0) as i64));
-    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[nonneg])?;
-    let in_bounds = ctx.trace_ctx.record_op(OpCode::IntLt, &[raw_index, lenbox]);
-    ctx.trace_ctx.set_opref_concrete(
-        in_bounds,
-        majit_ir::Value::Int(((index as usize) < concrete_len) as i64),
-    );
-    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[in_bounds])?;
+    walker_emit_index_bounds_guards(ctx, op_pc, raw_index, index, lenbox, concrete_len)?;
 
     // Element load.  Object storage reads the boxed Ref directly from the
     // `Ptr(GcArray(OBJECTPTR))` items block (no unbox/rebox).  Int/float
@@ -7069,23 +7087,7 @@ pub(crate) fn try_walker_specialize_subscr_tuple<Sym: WalkSym>(
         items_block,
         crate::state::pyobject_gcarray_descr(),
     );
-    // Two-sided bounds guard `0 <= raw_index < len`.  The trace is recorded
-    // from a non-negative observed index, but a later NEGATIVE index would
-    // still satisfy `raw_index < len` and reach the PURE element load out of
-    // range.  `space.getitem` treats a negative index as `index + len`
-    // (tupleobject.py); the lower-bound guard deopts so that remap
-    // re-executes generically instead of reading before the array.
-    let zero = ctx.trace_ctx.const_int(0);
-    let nonneg = ctx.trace_ctx.record_op(OpCode::IntGe, &[raw_index, zero]);
-    ctx.trace_ctx
-        .set_opref_concrete(nonneg, majit_ir::Value::Int((index >= 0) as i64));
-    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[nonneg])?;
-    let in_bounds = ctx.trace_ctx.record_op(OpCode::IntLt, &[raw_index, lenbox]);
-    ctx.trace_ctx.set_opref_concrete(
-        in_bounds,
-        majit_ir::Value::Int(((index as usize) < concrete_len) as i64),
-    );
-    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[in_bounds])?;
+    walker_emit_index_bounds_guards(ctx, op_pc, raw_index, index, lenbox, concrete_len)?;
 
     // PURE element load.  Object storage reads the boxed Ref directly from
     // the immutable `Ptr(GcArray(OBJECTPTR))` body (no unbox/rebox).
@@ -15222,7 +15224,8 @@ pub(crate) fn try_walker_specialize_store_subscr<Sym: WalkSym>(
     ctx.trace_ctx
         .set_opref_concrete(raw_index, majit_ir::Value::Int(index));
 
-    // Bounds guard (non-negative index path): IntLt(raw_index, len).
+    // Object storage keeps the inline `length` field (rlist.py); int/float
+    // storage read the typed items-array length field.
     let len_descr = match sid {
         0 => crate::descr::list_length_descr(),
         1 => crate::descr::list_int_items_len_descr(),
@@ -15230,12 +15233,7 @@ pub(crate) fn try_walker_specialize_store_subscr<Sym: WalkSym>(
         _ => unreachable!(),
     };
     let lenbox = crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, list_op, len_descr);
-    let in_bounds = ctx.trace_ctx.record_op(OpCode::IntLt, &[raw_index, lenbox]);
-    ctx.trace_ctx.set_opref_concrete(
-        in_bounds,
-        majit_ir::Value::Int(((index as usize) < concrete_len) as i64),
-    );
-    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[in_bounds])?;
+    walker_emit_index_bounds_guards(ctx, op_pc, raw_index, index, lenbox, concrete_len)?;
 
     // Store the reference directly for ObjectListStrategy; only the typed
     // strategies unwrap their payload.  The object arm is what keeps Python

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3118,7 +3118,7 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
     }
     if name == "f_lasti"
         && unsafe { (*concrete_obj).ob_type } == &pyre_interpreter::pyframe::FRAME_TYPE
-        && spec_gate("frame_lasti", || {
+        && spec_gate(SpecFold::FrameLasti, || {
             try_walker_specialize_frame_lasti(ctx, op_pc, obj, concrete_obj, dst, dst_bank)
         })?
         .is_some()
@@ -3127,7 +3127,7 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
     }
     if name == "f_lineno"
         && unsafe { (*concrete_obj).ob_type } == &pyre_interpreter::pyframe::FRAME_TYPE
-        && spec_gate("frame_lineno", || {
+        && spec_gate(SpecFold::FrameLineno, || {
             try_walker_specialize_frame_lineno(ctx, op_pc, obj, concrete_obj, dst, dst_bank)
         })?
         .is_some()
@@ -6615,7 +6615,7 @@ pub(crate) fn try_walker_specialize_subscr<Sym: WalkSym>(
     // `selfrec_bridge_nontail_promote` loses a bridge to `abrt_bridge` and runs
     // 2.4x slower.  `try_walker_specialize_subscr_tuple` keeps that arm.
     if specialised_pair_kind(unsafe { (*list_obj).ob_type }).is_some() {
-        if let Some(hit) = spec_gate("subscr_tuple_descent", || {
+        if let Some(hit) = spec_gate(SpecFold::SubscrTupleDescent, || {
             try_walker_orthodox_subscr_tuple_item(
                 ctx, op_pc, list_op, key_op, list_obj, key_obj, dst, dst_bank,
             )
@@ -6625,7 +6625,7 @@ pub(crate) fn try_walker_specialize_subscr<Sym: WalkSym>(
     }
 
     if tuple_canonical {
-        return spec_gate("subscr_tuple", || {
+        return spec_gate(SpecFold::SubscrTuple, || {
             try_walker_specialize_subscr_tuple(
                 ctx, op_pc, list_op, key_op, list_obj, key_obj, allboxes, call_descr, dst, dst_bank,
             )
@@ -6638,7 +6638,7 @@ pub(crate) fn try_walker_specialize_subscr<Sym: WalkSym>(
     // variable-width UTF-8 and a fixed-stride read would be wrong the moment
     // the string is not ASCII.
     if unsafe { pyre_object::is_exact_type(list_obj, &pyre_object::STR_TYPE) } {
-        return spec_gate("subscr_str", || {
+        return spec_gate(SpecFold::SubscrStr, || {
             try_walker_specialize_subscr_str(
                 ctx, op_pc, list_op, key_op, list_obj, key_obj, allboxes, call_descr, dst, dst_bank,
             )
@@ -12143,7 +12143,7 @@ pub(crate) fn try_walker_specialize_builtin_divmod<Sym: WalkSym>(
     if !is_exact_int(lhs_obj) || !is_exact_int(rhs_obj) {
         // `_make_descr_binop(_divmod, _int_divmod)` (longobject.py) keeps a
         // dedicated long/int arm; every other operand shape stays generic.
-        return spec_gate("builtin_divmod_long_int", || {
+        return spec_gate(SpecFold::BuiltinDivmodLongInt, || {
             try_walker_specialize_builtin_divmod_long_int(
                 ctx,
                 op,
@@ -15907,7 +15907,7 @@ pub(crate) fn try_walker_specialize_for_iter_next<Sym: WalkSym>(
         return Ok(None);
     };
     if unsafe { pyre_object::functional::is_zip(iter_obj) } {
-        return spec_gate("zip_two_tuple_iters", || {
+        return spec_gate(SpecFold::ZipTwoTupleIters, || {
             try_walker_specialize_zip_two_tuple_iters(ctx, op_pc, iter_op, iter_obj)
         });
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -10459,7 +10459,7 @@ fn walker_specialize_math_float<Sym: WalkSym>(
     arity: usize,
     row: impl FnOnce(pyre_object::PyObjectRef) -> Option<(MathFloatDomain, MathFloatEmit)>,
 ) -> Result<Option<()>, DispatchError> {
-    let Some((concrete_callable, operands)) =
+    let Some((concrete_callable, mut operands)) =
         plain_builtin_call_concretes(ctx, code, op, r_args, arity)
     else {
         return Ok(None);
@@ -10496,6 +10496,19 @@ fn walker_specialize_math_float<Sym: WalkSym>(
     let Ok(boxed_result) = boxed_result else {
         return Ok(None);
     };
+    // The call above allocates, so the operand pointers read before it may have
+    // been forwarded.  Re-fetch them from the walker's op cells, which the
+    // collector does update, before anything reads through them again
+    // (`try_walker_specialize_builtin_divmod_long_int` takes the same route).
+    // The callable needs no re-fetch: a module's builtin function outlives
+    // every nursery it could have been born in, while these operands are the
+    // loop's own boxes.
+    for (slot, &arg) in operands[..arity].iter_mut().zip(&r_args[2..2 + arity]) {
+        let Some(refetched) = walker_concrete_ref_object(ctx, arg) else {
+            return Ok(None);
+        };
+        *slot = refetched;
+    }
     let Some(result_value) = fold_finite_float_result(boxed_result) else {
         return Ok(None);
     };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -6438,12 +6438,12 @@ pub(crate) fn try_walker_specialize_binary_op_float<Sym: WalkSym>(
             return Ok(None);
         };
 
-        let _lhs_raw =
-            walker_coerce_operand_to_float(ctx, op_pc, lhs, lhs_obj, lhs_is_int, lhs_f64, false)?;
-        walker_guard_exact_w_class(ctx, op_pc, lhs, walker_numeric_builtin_class(lhs_obj))?;
-        let rhs_raw =
-            walker_coerce_operand_to_float(ctx, op_pc, rhs, rhs_obj, rhs_is_int, rhs_f64, false)?;
-        walker_guard_exact_w_class(ctx, op_pc, rhs, walker_numeric_builtin_class(rhs_obj))?;
+        let _lhs_raw = walker_coerce_dispatching_operand_to_float(
+            ctx, op_pc, lhs, lhs_obj, lhs_is_int, lhs_f64, false,
+        )?;
+        let rhs_raw = walker_coerce_dispatching_operand_to_float(
+            ctx, op_pc, rhs, rhs_obj, rhs_is_int, rhs_f64, false,
+        )?;
         let rhs_zero = walker_float_eq_const(ctx, rhs_raw, 0.0, 1);
         walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[rhs_zero])?;
         return Ok(Some(walker_emit_recorded_builtin_raise(ctx, ec, exc, kind)));
@@ -6469,12 +6469,12 @@ pub(crate) fn try_walker_specialize_binary_op_float<Sym: WalkSym>(
     }
 
     // --- emit the specialized IR (walker-native) ---
-    let lhs_raw =
-        walker_coerce_operand_to_float(ctx, op_pc, lhs, lhs_obj, lhs_is_int, lhs_f64, false)?;
-    walker_guard_exact_w_class(ctx, op_pc, lhs, walker_numeric_builtin_class(lhs_obj))?;
-    let rhs_raw =
-        walker_coerce_operand_to_float(ctx, op_pc, rhs, rhs_obj, rhs_is_int, rhs_f64, false)?;
-    walker_guard_exact_w_class(ctx, op_pc, rhs, walker_numeric_builtin_class(rhs_obj))?;
+    let lhs_raw = walker_coerce_dispatching_operand_to_float(
+        ctx, op_pc, lhs, lhs_obj, lhs_is_int, lhs_f64, false,
+    )?;
+    let rhs_raw = walker_coerce_dispatching_operand_to_float(
+        ctx, op_pc, rhs, rhs_obj, rhs_is_int, rhs_f64, false,
+    )?;
     // rint.py `_ovf_zer` analogue for float true-division: emit a
     // `float_eq(rhs, 0.0) → guard_false` precondition ahead of the bare
     // `FloatTrueDiv` llop so a future zero divisor deopts to the checked
@@ -10298,126 +10298,251 @@ pub(crate) fn try_walker_specialize_sys_getframe<Sym: WalkSym>(
     Ok(Some(()))
 }
 
-/// `math.sqrt(x)` on an exact int/float argument: inline the domain-guarded
-/// pure `CALL_F(sqrt_nonneg_jit)` (ll_math.rs `ll_math_sqrt` → `sqrt_nonneg`,
-/// EF_ELIDABLE_CANNOT_RAISE) instead of the opaque
-/// `bh_call_fn(sqrt_builtin, NULL, x)` residual, so the result `W_FloatObject`
-/// virtualizes.  Two guards pin the branches of `ll_math_sqrt`: `x >= 0` (the
-/// ValueError direction) and `isfinite(x)` (NaN/±inf take the residual).  A
-/// negative argument raises in the concrete pre-exec below and declines to the
-/// generic residual (which records the raise).  Any non-matching shape falls
-/// through to the generic residual (SAFE).
-pub(crate) fn try_walker_specialize_math_sqrt<Sym: WalkSym>(
+// ── the generated `math` float folds ──────────────────────────────────
+//
+// The five entry points below are one row each: they name the callable they
+// answer for and hand the driver the two facts that differ between rows —
+// which branches of the body the trace has to pin, and what the compiled loop
+// computes.  Everything else — operand classification, the authentic
+// pre-execution, the callable pin, the coercions, the cross-check and the
+// boxing — is written once, here.  Upstream reaches the same surface the same
+// way: `intobject.py`'s `_make_descr_binop` emits one body per row from a
+// table instead of repeating it, and the codewriter looks its builtin
+// lowerings up by name in `support.py`'s `_ll_<arity>_<oopspec>` table.
+
+/// What a row's compiled body computes from the coerced operand(s).
+#[derive(Clone, Copy)]
+enum MathFloatEmit {
+    /// A pure `CALL_F` into the row's raw helper — the shape a translated
+    /// `ll_math_*` call carries once its exceptional branches are pinned.
+    Call1(extern "C" fn(f64) -> f64),
+    /// The two-operand form of [`MathFloatEmit::Call1`].
+    Call2(extern "C" fn(f64, f64) -> f64),
+    /// A bare IR op, for a row whose whole body is one machine instruction.
+    /// The `f64` function beside it is that same computation, for the
+    /// cross-check below.
+    Unary(OpCode, fn(f64) -> f64),
+}
+
+impl MathFloatEmit {
+    /// Positional argument count this emission answers for.
+    fn arity(self) -> usize {
+        match self {
+            Self::Call1(_) | Self::Unary(..) => 1,
+            Self::Call2(_) => 2,
+        }
+    }
+
+    /// The value the compiled body produces for these operands.
+    fn evaluate(self, values: &[f64]) -> f64 {
+        match self {
+            Self::Call1(raw) => raw(values[0]),
+            Self::Call2(raw) => raw(values[0], values[1]),
+            Self::Unary(_, compute) => compute(values[0]),
+        }
+    }
+}
+
+/// The branches of a row's body the trace has to pin before its
+/// [`MathFloatEmit`] stands for the whole builtin.
+#[derive(Clone, Copy, PartialEq)]
+enum MathFloatDomain {
+    /// `ll_math_sqrt`: not negative, and finite.
+    NonNegativeFinite,
+    /// `ll_math_log`: strictly positive, and finite.
+    PositiveFinite,
+    /// `ll_math_{cos,sin}`: finite.
+    Finite,
+    /// The body raises for no input and cannot leave the float domain, so the
+    /// operand needs no pinning at all.
+    Total,
+    /// The helper reports every raising direction as a non-finite result, so
+    /// the operand is unconstrained and the *result* is guarded instead: the
+    /// guard deoptimizes into the builtin, which re-executes and raises or
+    /// returns the non-finite value itself.  A row spelled this way needs no
+    /// per-function domain knowledge, which is why adding a function to
+    /// `MATH_FLOAT1_FOLDS` is all it takes to cover it.
+    ResultFinite,
+}
+
+impl MathFloatDomain {
+    /// Whether these concrete operands are inside the arm the row lowers.  A
+    /// `false` keeps the residual, which re-executes the builtin.
+    fn admits(self, values: &[f64]) -> bool {
+        let x = values[0];
+        match self {
+            Self::NonNegativeFinite => x.is_finite() && x >= 0.0,
+            Self::PositiveFinite => x.is_finite() && x > 0.0,
+            Self::Finite => x.is_finite(),
+            Self::Total | Self::ResultFinite => true,
+        }
+    }
+
+    /// Emit the guards that hold the compiled loop inside that arm.
+    fn emit_operand_guards<Sym: WalkSym>(
+        self,
+        ctx: &mut WalkContext<'_, '_, Sym>,
+        pc: usize,
+        x: OpRef,
+    ) -> Result<(), DispatchError> {
+        if matches!(self, Self::Total | Self::ResultFinite) {
+            return Ok(());
+        }
+        let zero = ctx.trace_ctx.const_float(0.0f64.to_bits() as i64);
+        match self {
+            // `x >= 0`, the `ValueError` direction of `ll_math_sqrt`.
+            Self::NonNegativeFinite => {
+                walker_float_cmp_guard(ctx, pc, OpCode::FloatLt, &[x, zero], false)?
+            }
+            // `x > 0`, the domain of `ll_math_log`.
+            Self::PositiveFinite => {
+                walker_float_cmp_guard(ctx, pc, OpCode::FloatLt, &[zero, x], true)?
+            }
+            Self::Finite => {}
+            Self::Total | Self::ResultFinite => unreachable!("returned above"),
+        }
+        // `isfinite(x)`: `x - x == 0` holds exactly for the finite values,
+        // signed zero included, so NaN and ±inf take the residual.
+        let diff = ctx.trace_ctx.record_op(OpCode::FloatSub, &[x, x]);
+        ctx.trace_ctx
+            .set_opref_concrete(diff, majit_ir::Value::Float(0.0));
+        walker_float_cmp_guard(ctx, pc, OpCode::FloatEq, &[diff, zero], true)
+    }
+}
+
+/// One pure elidable `CALL_F` into a raw float helper, stamped with the value
+/// it produced concretely.  `EF_ELIDABLE_CANNOT_RAISE` is what lets the
+/// optimizer hoist it out of a loop and keep the result box virtual.
+fn walker_call_pure_float<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    raw_fn: *const (),
+    args: &[OpRef],
+    values: &[f64],
+    result_value: f64,
+) -> OpRef {
+    let types = [majit_ir::Type::Float; 2];
+    let concrete = [
+        majit_ir::Value::Int(raw_fn as i64),
+        majit_ir::Value::Float(values[0]),
+        majit_ir::Value::Float(values[values.len() - 1]),
+    ];
+    let raw = ctx.trace_ctx.call_typed_with_effect_pure(
+        OpCode::CallF,
+        raw_fn,
+        args,
+        &types[..args.len()],
+        majit_ir::Type::Float,
+        majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        &concrete[..args.len() + 1],
+        majit_ir::Value::Float(result_value),
+    );
+    ctx.trace_ctx
+        .set_opref_concrete(raw, majit_ir::Value::Float(result_value));
+    raw
+}
+
+/// The body every `math` float fold shares.  `row` recognizes the callable
+/// this entry point answers for and returns the row's two variable facts.
+///
+/// The residual this replaces costs an argument tuple, a builtin dispatch, a
+/// `try_get_double` per operand and a `W_FloatObject` allocation, once per
+/// loop iteration; what goes in its place is the unboxed operand, the row's
+/// emission and an inline `wrapfloat` the optimizer can keep virtual.
+fn walker_specialize_math_float<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],
     op: &DecodedOp,
     r_args: &[OpRef],
     dst: usize,
+    arity: usize,
+    row: impl FnOnce(pyre_object::PyObjectRef) -> Option<(MathFloatDomain, MathFloatEmit)>,
 ) -> Result<Option<()>, DispatchError> {
-    // Plain `bh_call_fn(callable, PY_NULL, arg)` shape only.
-    if r_args.len() != 3 {
-        return Ok(None);
-    }
-    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
-    let (
-        ConcreteValue::Ref(concrete_callable),
-        ConcreteValue::Ref(null_or_self),
-        ConcreteValue::Ref(arg_obj),
-    ) = (arg_concretes[0], arg_concretes[1], arg_concretes[2])
+    let Some((concrete_callable, operands)) =
+        plain_builtin_call_concretes(ctx, code, op, r_args, arity)
     else {
         return Ok(None);
     };
-    // A non-null `null_or_self` is a bound receiver `bh_call_fn_impl` prepends
-    // as arg0 — not a plain `sqrt(x)` call.
-    if concrete_callable.is_null() || !null_or_self.is_null() || arg_obj.is_null() {
+    let Some((domain, emit)) = row(concrete_callable) else {
         return Ok(None);
-    }
-    if !pyre_interpreter::module::math::interp_math::is_math_sqrt_function(concrete_callable) {
-        return Ok(None);
-    }
-    // Exact int/bool/float argument only — a numeric subclass keeps the builtin
-    // `ob_type` layout but a Python-visible `w_class`, and the `guard_class`
-    // the coercion emits reads `ob_type`, so it would not catch the subclass.
-    let (is_int, val) = unsafe {
-        if !pyre_object::is_exact_builtin_instance(arg_obj) {
-            return Ok(None);
-        }
-        // `bool` shares `W_IntObject`'s `intval`; it coerces through the int arm
-        // via its own `&BOOL_TYPE` guard inside `walker_coerce_operand_to_float`.
-        if pyre_object::is_int(arg_obj) {
-            (true, pyre_object::w_int_get_value(arg_obj) as f64)
-        } else if pyre_object::is_float(arg_obj) {
-            (false, pyre_object::w_float_get_value(arg_obj))
-        } else {
-            return Ok(None);
-        }
     };
-    // Cold domain: NaN/±inf and negatives take the opaque residual (the
-    // negative direction also raises in the concrete pre-exec below).
-    if !(val.is_finite() && val >= 0.0) {
+    debug_assert_eq!(
+        arity,
+        emit.arity(),
+        "a row's emission disagrees with the call shape its entry point reads"
+    );
+    // Exact `int`/`bool`/`float` operands only: a numeric subclass keeps the
+    // builtin `ob_type` but carries its own `w_class`, and may override
+    // `__float__`.
+    let mut coerced = [(false, 0.0f64); 2];
+    for (slot, &obj) in coerced.iter_mut().zip(&operands[..arity]) {
+        let Some(operand) = fold_float_operand(obj) else {
+            return Ok(None);
+        };
+        *slot = operand;
+    }
+    let values = [coerced[0].1, coerced[1].1];
+    if !domain.admits(&values[..arity]) {
         return Ok(None);
     }
     // Authentic boxed result, produced on the plain eval loop exactly as the
-    // skipped residual would.  Declines on any raise (defensive; the cold
-    // domain is already excluded above).
+    // skipped residual would.  A raise, a non-float result and a non-finite
+    // one all keep the residual.
     let boxed_result = {
         let _plain_guard = pyre_interpreter::call::force_plain_eval();
-        pyre_interpreter::call::call_function_impl_result(concrete_callable, &[arg_obj])
+        pyre_interpreter::call::call_function_impl_result(concrete_callable, &operands[..arity])
     };
     let Ok(boxed_result) = boxed_result else {
         return Ok(None);
     };
+    let Some(result_value) = fold_finite_float_result(boxed_result) else {
+        return Ok(None);
+    };
+    // The compiled loop runs the row's emission, not the builtin it stands
+    // for.  Compare the two on these operands and keep the residual when they
+    // differ, so a row that disagrees is never compiled into the loop.  By
+    // bits, which `==` cannot do: it cannot tell `-0.0` from `0.0`, and which
+    // one is answered with is observable through `copysign`.
+    if emit.evaluate(&values[..arity]).to_bits() != result_value.to_bits() {
+        return Ok(None);
+    }
 
-    // --- emit the specialized IR (walker-native) ---
-    // Pin the callable identity (the module-attr fold usually makes it a
-    // constant already; guard only when it is not).
-    let callable_op = r_args[0];
-    if !callable_op.is_constant() {
-        let expected = ctx.trace_ctx.const_ref(concrete_callable as i64);
-        ctx.trace_ctx
-            .record_guard(OpCode::GuardValue, &[callable_op, expected], 0);
-        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-        ctx.trace_ctx
-            .heap_cache_mut()
-            .replace_box(callable_op, expected);
+    walker_guard_fold_callable(ctx, op.pc, r_args[0], concrete_callable)?;
+    let x = walker_coerce_operand_to_float(
+        ctx,
+        op.pc,
+        r_args[2],
+        operands[0],
+        coerced[0].0,
+        values[0],
+        false,
+    )?;
+    domain.emit_operand_guards(ctx, op.pc, x)?;
+    let raw = match emit {
+        MathFloatEmit::Unary(opcode, _) => {
+            let raw = ctx.trace_ctx.record_op(opcode, &[x]);
+            ctx.trace_ctx
+                .set_opref_concrete(raw, majit_ir::Value::Float(result_value));
+            raw
+        }
+        MathFloatEmit::Call1(raw_fn) => {
+            walker_call_pure_float(ctx, raw_fn as *const (), &[x], &values[..1], result_value)
+        }
+        MathFloatEmit::Call2(raw_fn) => {
+            let y = walker_coerce_operand_to_float(
+                ctx,
+                op.pc,
+                r_args[3],
+                operands[1],
+                coerced[1].0,
+                values[1],
+                false,
+            )?;
+            walker_call_pure_float(ctx, raw_fn as *const (), &[x, y], &values, result_value)
+        }
+    };
+    if domain == MathFloatDomain::ResultFinite {
+        walker_guard_float_result_finite(ctx, op.pc, raw)?;
     }
-    // Coerce the argument to a raw float (int → guard_class + unbox +
-    // CastIntToFloat; float → guard_class + unbox).
-    let x = walker_coerce_operand_to_float(ctx, op.pc, r_args[2], arg_obj, is_int, val, false)?;
-    if is_int {
-        // The interpreter's `try_get_double` reads an int payload only for an
-        // exact builtin: a subclass may override `__float__`, and the unbox
-        // guard proves only `ob_type`, which the subclass shares.  The float
-        // arm needs no pin -- that coercion short-circuits on the float layout
-        // and ignores an override there too.
-        walker_guard_exact_w_class(ctx, op.pc, r_args[2], walker_numeric_builtin_class(arg_obj))?;
-    }
-    // `ll_math_sqrt` domain guards: `if x < 0.0` (FloatLt pinned false) and
-    // `if isfinite(x)` (FloatSub(x,x) == 0 pinned true — excludes NaN/±inf).
-    let zero = ctx.trace_ctx.const_float(0.0f64.to_bits() as i64);
-    walker_float_cmp_guard(ctx, op.pc, OpCode::FloatLt, &[x, zero], false)?;
-    let diff = ctx.trace_ctx.record_op(OpCode::FloatSub, &[x, x]);
-    ctx.trace_ctx
-        .set_opref_concrete(diff, majit_ir::Value::Float(0.0));
-    walker_float_cmp_guard(ctx, op.pc, OpCode::FloatEq, &[diff, zero], true)?;
-    // The pure elidable libm sqrt: EF_ELIDABLE_CANNOT_RAISE → CALL_F, no
-    // trailing guard, foldable/hoistable.
-    let result_val = unsafe { pyre_object::w_float_get_value(boxed_result) };
-    let raw = ctx.trace_ctx.call_typed_with_effect_pure(
-        OpCode::CallF,
-        crate::trace_opcode::sqrt_nonneg_jit as *const (),
-        &[x],
-        &[majit_ir::Type::Float],
-        majit_ir::Type::Float,
-        majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
-        &[
-            majit_ir::Value::Int(crate::trace_opcode::sqrt_nonneg_jit as *const () as i64),
-            majit_ir::Value::Float(val),
-        ],
-        majit_ir::Value::Float(result_val),
-    );
-    ctx.trace_ctx
-        .set_opref_concrete(raw, majit_ir::Value::Float(result_val));
     let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw);
     ctx.trace_ctx.set_opref_concrete(
         boxed,
@@ -10427,11 +10552,29 @@ pub(crate) fn try_walker_specialize_math_sqrt<Sym: WalkSym>(
     Ok(Some(()))
 }
 
-/// `math.log/cos/sin(x)` on an exact int/float argument.  This is the direct
-/// RPython `ll_math_{log,cos,sin}` shape: pin the domain branch, unbox the
-/// numeric operand, emit the raw pure `CALL_F`, and leave the result box
-/// virtualizable.  Rebound callables, subclasses, exceptional domains, and
-/// non-numeric inputs retain the ordinary residual call.
+/// `math.sqrt(x)` on an exact int/float argument: the domain-guarded pure
+/// `CALL_F(sqrt_nonneg_jit)` (ll_math.rs `ll_math_sqrt` → `sqrt_nonneg`) in
+/// place of the opaque `bh_call_fn(sqrt_builtin, NULL, x)` residual.  A
+/// negative argument raises in the authentic pre-execution and declines to the
+/// generic residual, which records the raise.
+pub(crate) fn try_walker_specialize_math_sqrt<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    code: &[u8],
+    op: &DecodedOp,
+    r_args: &[OpRef],
+    dst: usize,
+) -> Result<Option<()>, DispatchError> {
+    walker_specialize_math_float(ctx, code, op, r_args, dst, 1, |callable| {
+        pyre_interpreter::module::math::interp_math::is_math_sqrt_function(callable).then_some((
+            MathFloatDomain::NonNegativeFinite,
+            MathFloatEmit::Call1(crate::trace_opcode::sqrt_nonneg_jit),
+        ))
+    })
+}
+
+/// `math.log/cos/sin(x)` on an exact int/float argument — the direct
+/// `ll_math_{log,cos,sin}` shape, whose exceptional branch is pinned rather
+/// than guarded after the fact.
 pub(crate) fn try_walker_specialize_math_log_trig<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],
@@ -10439,117 +10582,27 @@ pub(crate) fn try_walker_specialize_math_log_trig<Sym: WalkSym>(
     r_args: &[OpRef],
     dst: usize,
 ) -> Result<Option<()>, DispatchError> {
-    if r_args.len() != 3 {
-        return Ok(None);
-    }
-    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
-    let (
-        ConcreteValue::Ref(concrete_callable),
-        ConcreteValue::Ref(null_or_self),
-        ConcreteValue::Ref(arg_obj),
-    ) = (arg_concretes[0], arg_concretes[1], arg_concretes[2])
-    else {
-        return Ok(None);
-    };
-    if concrete_callable.is_null() || !null_or_self.is_null() || arg_obj.is_null() {
-        return Ok(None);
-    }
-    // Carry `is_log` out of the branch that knows it. Recovering it afterwards
-    // by comparing `raw_fn` against `math_log_positive_jit` would make the
-    // domain guard below depend on the three helpers keeping distinct
-    // addresses, which is a linker property, not a source one.
-    let (raw_fn, is_log) =
-        if pyre_interpreter::module::math::interp_math::is_math_log_function(concrete_callable) {
-            (
-                crate::trace_opcode::math_log_positive_jit as *const (),
-                true,
-            )
-        } else if pyre_interpreter::module::math::interp_math::is_math_cos_function(
-            concrete_callable,
-        ) {
-            (crate::trace_opcode::math_cos_finite_jit as *const (), false)
-        } else if pyre_interpreter::module::math::interp_math::is_math_sin_function(
-            concrete_callable,
-        ) {
-            (crate::trace_opcode::math_sin_finite_jit as *const (), false)
+    walker_specialize_math_float(ctx, code, op, r_args, dst, 1, |callable| {
+        use pyre_interpreter::module::math::interp_math;
+        if interp_math::is_math_log_function(callable) {
+            Some((
+                MathFloatDomain::PositiveFinite,
+                MathFloatEmit::Call1(crate::trace_opcode::math_log_positive_jit),
+            ))
+        } else if interp_math::is_math_cos_function(callable) {
+            Some((
+                MathFloatDomain::Finite,
+                MathFloatEmit::Call1(crate::trace_opcode::math_cos_finite_jit),
+            ))
+        } else if interp_math::is_math_sin_function(callable) {
+            Some((
+                MathFloatDomain::Finite,
+                MathFloatEmit::Call1(crate::trace_opcode::math_sin_finite_jit),
+            ))
         } else {
-            return Ok(None);
-        };
-    let (is_int, val) = unsafe {
-        if !pyre_object::is_exact_builtin_instance(arg_obj) {
-            return Ok(None);
+            None
         }
-        if pyre_object::is_int(arg_obj) {
-            (true, pyre_object::w_int_get_value(arg_obj) as f64)
-        } else if pyre_object::is_float(arg_obj) {
-            (false, pyre_object::w_float_get_value(arg_obj))
-        } else {
-            return Ok(None);
-        }
-    };
-    // The hot RPython branches used here are log(finite positive) and
-    // trig(finite).  Cold NaN/inf/domain cases stay on the exact builtin.
-    if !val.is_finite() || (is_log && val <= 0.0) {
-        return Ok(None);
-    }
-    let boxed_result = {
-        let _plain_guard = pyre_interpreter::call::force_plain_eval();
-        pyre_interpreter::call::call_function_impl_result(concrete_callable, &[arg_obj])
-    };
-    let Ok(boxed_result) = boxed_result else {
-        return Ok(None);
-    };
-
-    let callable_op = r_args[0];
-    if !callable_op.is_constant() {
-        let expected = ctx.trace_ctx.const_ref(concrete_callable as i64);
-        ctx.trace_ctx
-            .record_guard(OpCode::GuardValue, &[callable_op, expected], 0);
-        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-        ctx.trace_ctx
-            .heap_cache_mut()
-            .replace_box(callable_op, expected);
-    }
-    let x = walker_coerce_operand_to_float(ctx, op.pc, r_args[2], arg_obj, is_int, val, false)?;
-    if is_int {
-        // The interpreter's `try_get_double` reads an int payload only for an
-        // exact builtin: a subclass may override `__float__`, and the unbox
-        // guard proves only `ob_type`, which the subclass shares.  The float
-        // arm needs no pin -- that coercion short-circuits on the float layout
-        // and ignores an override there too.
-        walker_guard_exact_w_class(ctx, op.pc, r_args[2], walker_numeric_builtin_class(arg_obj))?;
-    }
-    let zero = ctx.trace_ctx.const_float(0.0f64.to_bits() as i64);
-    if is_log {
-        walker_float_cmp_guard(ctx, op.pc, OpCode::FloatLt, &[zero, x], true)?;
-    }
-    let diff = ctx.trace_ctx.record_op(OpCode::FloatSub, &[x, x]);
-    ctx.trace_ctx
-        .set_opref_concrete(diff, majit_ir::Value::Float(0.0));
-    walker_float_cmp_guard(ctx, op.pc, OpCode::FloatEq, &[diff, zero], true)?;
-    let result_val = unsafe { pyre_object::w_float_get_value(boxed_result) };
-    let raw = ctx.trace_ctx.call_typed_with_effect_pure(
-        OpCode::CallF,
-        raw_fn,
-        &[x],
-        &[majit_ir::Type::Float],
-        majit_ir::Type::Float,
-        majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
-        &[
-            majit_ir::Value::Int(raw_fn as i64),
-            majit_ir::Value::Float(val),
-        ],
-        majit_ir::Value::Float(result_val),
-    );
-    ctx.trace_ctx
-        .set_opref_concrete(raw, majit_ir::Value::Float(result_val));
-    let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw);
-    ctx.trace_ctx.set_opref_concrete(
-        boxed,
-        majit_ir::Value::Ref(majit_ir::GcRef(boxed_result as usize)),
-    );
-    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', boxed)?;
-    Ok(Some(()))
+    })
 }
 
 /// `math.frexp(x)` on an exact int/float argument.  RPython lowers
@@ -10627,14 +10680,6 @@ pub(crate) fn try_walker_specialize_math_frexp<Sym: WalkSym>(
             .replace_box(callable_op, expected);
     }
     let x = walker_coerce_operand_to_float(ctx, op.pc, r_args[2], arg_obj, is_int, x_value, false)?;
-    if is_int {
-        // The interpreter's `try_get_double` reads an int payload only for an
-        // exact builtin: a subclass may override `__float__`, and the unbox
-        // guard proves only `ob_type`, which the subclass shares.  The float
-        // arm needs no pin -- that coercion short-circuits on the float layout
-        // and ignores an override there too.
-        walker_guard_exact_w_class(ctx, op.pc, r_args[2], walker_numeric_builtin_class(arg_obj))?;
-    }
     let mantissa = ctx.trace_ctx.call_typed_with_effect_pure(
         OpCode::CallF,
         pyre_interpreter::module::math::interp_math::jit_math_frexp_mantissa as *const (),
@@ -10779,14 +10824,6 @@ pub(crate) fn try_walker_specialize_math_ldexp<Sym: WalkSym>(
             .replace_box(callable_op, expected);
     }
     let x = walker_coerce_operand_to_float(ctx, op.pc, r_args[2], x_obj, x_is_int, x_value, false)?;
-    if x_is_int {
-        // The interpreter's `try_get_double` reads an int payload only for an
-        // exact builtin: a subclass may override `__float__`, and the unbox
-        // guard proves only `ob_type`, which the subclass shares.  The float
-        // arm needs no pin -- that coercion short-circuits on the float layout
-        // and ignores an override there too.
-        walker_guard_exact_w_class(ctx, op.pc, r_args[2], walker_numeric_builtin_class(x_obj))?;
-    }
     let (exp_type_addr, exp_descr) = crate::state::int_or_bool_unbox_type_descr(exp_obj);
     let exp = walker_unbox_int_typed(ctx, op.pc, r_args[3], exp_type_addr, exp_descr)?;
     ctx.trace_ctx
@@ -11042,13 +11079,9 @@ pub(crate) fn try_walker_specialize_int_call<Sym: WalkSym>(
     Ok(Some(()))
 }
 
-/// `math.fabs(x)` on an exact int/float argument.  `interp_math.py`'s `fabs` is
-/// `math1(space, math.fabs, w_x)`, and RPython lowers `ll_math_fabs` to a sign
-/// mask, so the whole builtin is one `FloatAbs` once the operand is unboxed.
-/// `fabs` is total — it raises for no input and needs no domain guard — so the
-/// only guards are the operand's own class and exact-`w_class` checks.
-/// Rebound callables, numeric subclasses, and non-numeric inputs retain the
-/// ordinary residual call.
+/// `math.fabs(x)` on an exact int/float argument.  RPython lowers
+/// `ll_math_fabs` to a sign mask, so the whole builtin is one `FloatAbs` once
+/// the operand is unboxed, and `fabs` raises for no input.
 pub(crate) fn try_walker_specialize_math_fabs<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],
@@ -11056,79 +11089,12 @@ pub(crate) fn try_walker_specialize_math_fabs<Sym: WalkSym>(
     r_args: &[OpRef],
     dst: usize,
 ) -> Result<Option<()>, DispatchError> {
-    if r_args.len() != 3 {
-        return Ok(None);
-    }
-    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
-    let (
-        ConcreteValue::Ref(concrete_callable),
-        ConcreteValue::Ref(null_or_self),
-        ConcreteValue::Ref(arg_obj),
-    ) = (arg_concretes[0], arg_concretes[1], arg_concretes[2])
-    else {
-        return Ok(None);
-    };
-    if concrete_callable.is_null() || !null_or_self.is_null() || arg_obj.is_null() {
-        return Ok(None);
-    }
-    if !pyre_interpreter::module::math::interp_math::is_math_fabs_function(concrete_callable) {
-        return Ok(None);
-    }
-    let (is_int, val) = unsafe {
-        if !pyre_object::is_exact_builtin_instance(arg_obj) {
-            return Ok(None);
-        }
-        if pyre_object::is_int(arg_obj) {
-            (true, pyre_object::w_int_get_value(arg_obj) as f64)
-        } else if pyre_object::is_float(arg_obj) {
-            (false, pyre_object::w_float_get_value(arg_obj))
-        } else {
-            return Ok(None);
-        }
-    };
-    let boxed_result = {
-        let _plain_guard = pyre_interpreter::call::force_plain_eval();
-        pyre_interpreter::call::call_function_impl_result(concrete_callable, &[arg_obj])
-    };
-    let Ok(boxed_result) = boxed_result else {
-        return Ok(None);
-    };
-
-    // `w_float_get_value` reads the payload without checking the box, and a
-    // non-float here would be read as one rather than rejected, so the value
-    // the trace records would be a number with no relation to the answer.
-    if !unsafe { pyre_object::is_float(boxed_result) } {
-        return Ok(None);
-    }
-    let result_val = unsafe { pyre_object::w_float_get_value(boxed_result) };
-    // The trace computes `FloatAbs` over the coerced operand, so an int too
-    // large to be an exact `f64` would have the trace answering for a value
-    // the builtin never saw.  Compare the two on this operand, by bits so the
-    // two zeroes stay distinct.
-    if val.abs().to_bits() != result_val.to_bits() {
-        return Ok(None);
-    }
-    let callable_op = r_args[0];
-    if !callable_op.is_constant() {
-        let expected = ctx.trace_ctx.const_ref(concrete_callable as i64);
-        ctx.trace_ctx
-            .record_guard(OpCode::GuardValue, &[callable_op, expected], 0);
-        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-        ctx.trace_ctx
-            .heap_cache_mut()
-            .replace_box(callable_op, expected);
-    }
-    let x = walker_coerce_operand_to_float(ctx, op.pc, r_args[2], arg_obj, is_int, val, false)?;
-    let raw = ctx.trace_ctx.record_op(OpCode::FloatAbs, &[x]);
-    ctx.trace_ctx
-        .set_opref_concrete(raw, majit_ir::Value::Float(result_val));
-    let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw);
-    ctx.trace_ctx.set_opref_concrete(
-        boxed,
-        majit_ir::Value::Ref(majit_ir::GcRef(boxed_result as usize)),
-    );
-    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', boxed)?;
-    Ok(Some(()))
+    walker_specialize_math_float(ctx, code, op, r_args, dst, 1, |callable| {
+        pyre_interpreter::module::math::interp_math::is_math_fabs_function(callable).then_some((
+            MathFloatDomain::Total,
+            MathFloatEmit::Unary(OpCode::FloatAbs, f64::abs),
+        ))
+    })
 }
 
 /// Which reduction `try_walker_specialize_math_round_to_int` is folding.
@@ -11380,22 +11346,9 @@ fn walker_guard_float_result_finite<Sym: WalkSym>(
     walker_float_cmp_guard(ctx, pc, OpCode::FloatEq, &[diff, zero], true)
 }
 
-/// The one-argument half of the generic `math` float fold.
-///
-/// `interp_math`'s `pm1!` family is a single `pymath` call wrapped in the
-/// boxing and error mapping the module needs; the walker otherwise sees only
-/// the opaque `bh_call_fn(builtin, NULL, x)` residual, so a numeric loop pays
-/// an argument tuple, a `W_FloatObject` allocation and a full builtin dispatch
-/// per iteration.  Emit instead the unboxed operand, one pure elidable
-/// `CALL_F` into that function's raw helper, and an inline `wrapfloat`.
-///
-/// The helper reports every raising direction as NaN, so the trailing
-/// finite-result guard is what keeps this correct for arbitrary operands: it
-/// deoptimizes into the builtin, which re-executes and raises or returns the
-/// non-finite value itself.  The fold therefore needs no per-function domain
-/// knowledge, and adding a function to `MATH_FLOAT1_FOLDS` is all it takes to
-/// cover it.  Rebound callables, numeric subclasses and non-numeric operands
-/// retain the generic residual path (SAFE).
+/// The one-argument rows of the `math` float fold: `interp_math`'s `pm1!`
+/// family, each standing for one raw helper in `MATH_FLOAT1_FOLDS`.  Adding a
+/// function to that table is all it takes to cover it.
 pub(crate) fn try_walker_specialize_math_float1<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],
@@ -11403,74 +11356,16 @@ pub(crate) fn try_walker_specialize_math_float1<Sym: WalkSym>(
     r_args: &[OpRef],
     dst: usize,
 ) -> Result<Option<()>, DispatchError> {
-    let Some((concrete_callable, operands)) =
-        plain_builtin_call_concretes(ctx, code, op, r_args, 1)
-    else {
-        return Ok(None);
-    };
-    let Some(raw_fn) =
-        pyre_interpreter::module::math::interp_math::math_float1_fold_helper(concrete_callable)
-    else {
-        return Ok(None);
-    };
-    let Some((is_int, value)) = fold_float_operand(operands[0]) else {
-        return Ok(None);
-    };
-    // Authentic boxed result, produced on the plain eval loop exactly as the
-    // skipped residual would.  A raise, a non-float result, or a non-finite
-    // one all record a guard that would fail on the operand it was recorded
-    // from, so keep the residual for them.
-    let boxed_result = {
-        let _plain_guard = pyre_interpreter::call::force_plain_eval();
-        pyre_interpreter::call::call_function_impl_result(concrete_callable, &[operands[0]])
-    };
-    let Ok(boxed_result) = boxed_result else {
-        return Ok(None);
-    };
-    let Some(result_value) = fold_finite_float_result(boxed_result) else {
-        return Ok(None);
-    };
-    // The compiled loop calls the raw helper, not the function it stands for.
-    // Compare the two on this operand and keep the residual when they differ,
-    // so a helper that disagrees is not compiled into the loop.  Bit equality
-    // rather than `==`, which cannot tell the two zeroes apart.
-    if raw_fn(value).to_bits() != result_value.to_bits() {
-        return Ok(None);
-    }
-
-    walker_guard_fold_callable(ctx, op.pc, r_args[0], concrete_callable)?;
-    let x =
-        walker_coerce_operand_to_float(ctx, op.pc, r_args[2], operands[0], is_int, value, false)?;
-    let raw = ctx.trace_ctx.call_typed_with_effect_pure(
-        OpCode::CallF,
-        raw_fn as *const (),
-        &[x],
-        &[majit_ir::Type::Float],
-        majit_ir::Type::Float,
-        majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
-        &[
-            majit_ir::Value::Int(raw_fn as *const () as i64),
-            majit_ir::Value::Float(value),
-        ],
-        majit_ir::Value::Float(result_value),
-    );
-    ctx.trace_ctx
-        .set_opref_concrete(raw, majit_ir::Value::Float(result_value));
-    walker_guard_float_result_finite(ctx, op.pc, raw)?;
-    let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw);
-    ctx.trace_ctx.set_opref_concrete(
-        boxed,
-        majit_ir::Value::Ref(majit_ir::GcRef(boxed_result as usize)),
-    );
-    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', boxed)?;
-    Ok(Some(()))
+    walker_specialize_math_float(ctx, code, op, r_args, dst, 1, |callable| {
+        pyre_interpreter::module::math::interp_math::math_float1_fold_helper(callable)
+            .map(|raw| (MathFloatDomain::ResultFinite, MathFloatEmit::Call1(raw)))
+    })
 }
 
-/// The two-argument half of the generic `math` float fold — `pow`, `fmod`,
-/// `copysign`, `remainder` and `atan2`.  Same shape and same soundness
-/// argument as [`try_walker_specialize_math_float1`]; the finite-result guard
-/// carries `pow`'s `ValueError` (`pow(0.0, -2.0)`) and `OverflowError`
-/// (`pow(1e100, 1e100)`) directions back to the builtin.
+/// The two-argument rows — `pow`, `fmod`, `copysign`, `remainder` and
+/// `atan2`.  The finite-result guard carries `pow`'s `ValueError`
+/// (`pow(0.0, -2.0)`) and `OverflowError` (`pow(1e100, 1e100)`) directions
+/// back to the builtin.
 pub(crate) fn try_walker_specialize_math_float2<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],
@@ -11478,82 +11373,10 @@ pub(crate) fn try_walker_specialize_math_float2<Sym: WalkSym>(
     r_args: &[OpRef],
     dst: usize,
 ) -> Result<Option<()>, DispatchError> {
-    let Some((concrete_callable, operands)) =
-        plain_builtin_call_concretes(ctx, code, op, r_args, 2)
-    else {
-        return Ok(None);
-    };
-    let Some(raw_fn) =
-        pyre_interpreter::module::math::interp_math::math_float2_fold_helper(concrete_callable)
-    else {
-        return Ok(None);
-    };
-    let (Some((x_is_int, x_value)), Some((y_is_int, y_value))) = (
-        fold_float_operand(operands[0]),
-        fold_float_operand(operands[1]),
-    ) else {
-        return Ok(None);
-    };
-    let boxed_result = {
-        let _plain_guard = pyre_interpreter::call::force_plain_eval();
-        pyre_interpreter::call::call_function_impl_result(concrete_callable, &operands)
-    };
-    let Ok(boxed_result) = boxed_result else {
-        return Ok(None);
-    };
-    let Some(result_value) = fold_finite_float_result(boxed_result) else {
-        return Ok(None);
-    };
-    // Same cross-check as the one-argument half: the compiled loop calls the
-    // raw helper, so a helper that disagrees with the function it stands for
-    // must not be compiled into it.
-    if raw_fn(x_value, y_value).to_bits() != result_value.to_bits() {
-        return Ok(None);
-    }
-
-    walker_guard_fold_callable(ctx, op.pc, r_args[0], concrete_callable)?;
-    let x = walker_coerce_operand_to_float(
-        ctx,
-        op.pc,
-        r_args[2],
-        operands[0],
-        x_is_int,
-        x_value,
-        false,
-    )?;
-    let y = walker_coerce_operand_to_float(
-        ctx,
-        op.pc,
-        r_args[3],
-        operands[1],
-        y_is_int,
-        y_value,
-        false,
-    )?;
-    let raw = ctx.trace_ctx.call_typed_with_effect_pure(
-        OpCode::CallF,
-        raw_fn as *const (),
-        &[x, y],
-        &[majit_ir::Type::Float, majit_ir::Type::Float],
-        majit_ir::Type::Float,
-        majit_metainterp::ELIDABLE_CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
-        &[
-            majit_ir::Value::Int(raw_fn as *const () as i64),
-            majit_ir::Value::Float(x_value),
-            majit_ir::Value::Float(y_value),
-        ],
-        majit_ir::Value::Float(result_value),
-    );
-    ctx.trace_ctx
-        .set_opref_concrete(raw, majit_ir::Value::Float(result_value));
-    walker_guard_float_result_finite(ctx, op.pc, raw)?;
-    let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw);
-    ctx.trace_ctx.set_opref_concrete(
-        boxed,
-        majit_ir::Value::Ref(majit_ir::GcRef(boxed_result as usize)),
-    );
-    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', boxed)?;
-    Ok(Some(()))
+    walker_specialize_math_float(ctx, code, op, r_args, dst, 2, |callable| {
+        pyre_interpreter::module::math::interp_math::math_float2_fold_helper(callable)
+            .map(|raw| (MathFloatDomain::ResultFinite, MathFloatEmit::Call2(raw)))
+    })
 }
 
 /// `math.isclose(a, b)` with both tolerances defaulted.
@@ -12071,12 +11894,10 @@ pub(crate) fn try_walker_specialize_float_call<Sym: WalkSym>(
     let arg_op = r_args[2];
     if is_int {
         // int/bool → CastIntToFloat + inline wrapfloat (no residual call).
+        // The coercion pins `w_class`: `builtin_float` reads an int payload only
+        // for an exact builtin, so an `int` subclass overriding `__float__` must
+        // side-exit.  The float arm below pins its own for the same reason.
         let raw = walker_coerce_operand_to_float(ctx, op.pc, arg_op, arg_obj, true, val, false)?;
-        // `builtin_float` reads an int payload only for an exact builtin, so an
-        // `int` subclass overriding `__float__` must side-exit; the unbox guard
-        // proves only `ob_type`, which the subclass shares.  The float arm below
-        // pins its own `w_class` for the same reason.
-        walker_guard_exact_w_class(ctx, op.pc, arg_op, walker_numeric_builtin_class(arg_obj))?;
         let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw);
         ctx.trace_ctx.set_opref_concrete(
             boxed,
@@ -16570,15 +16391,15 @@ pub(crate) fn try_walker_specialize_compare_op_float<Sym: WalkSym>(
     }
 
     // --- emit the specialized IR (walker-native) ---
-    let lhs_raw =
-        walker_coerce_operand_to_float(ctx, op_pc, lhs, lhs_obj, lhs_is_int, lhs_f64, true)?;
-    // The coercion proves `ob_type`, which an `int`/`float` subclass shares with
-    // its builtin; the operand gate read `w_class`, so pin that too or the
-    // compiled guard admits the subclass and answers with `FloatLt`.
-    walker_guard_exact_w_class(ctx, op_pc, lhs, walker_numeric_builtin_class(lhs_obj))?;
-    let rhs_raw =
-        walker_coerce_operand_to_float(ctx, op_pc, rhs, rhs_obj, rhs_is_int, rhs_f64, true)?;
-    walker_guard_exact_w_class(ctx, op_pc, rhs, walker_numeric_builtin_class(rhs_obj))?;
+    // `_compare` reaches `__lt__` and friends, which a `float` subclass can
+    // override, so both arms are pinned: the dispatching coercion adds the float
+    // one on top of the int pin every coercion carries.
+    let lhs_raw = walker_coerce_dispatching_operand_to_float(
+        ctx, op_pc, lhs, lhs_obj, lhs_is_int, lhs_f64, true,
+    )?;
+    let rhs_raw = walker_coerce_dispatching_operand_to_float(
+        ctx, op_pc, rhs, rhs_obj, rhs_is_int, rhs_f64, true,
+    )?;
     let truth = ctx.trace_ctx.record_op(cmp, &[lhs_raw, rhs_raw]);
     let folded =
         majit_metainterp::eval_float_cmp(cmp, lhs_f64.to_bits() as i64, rhs_f64.to_bits() as i64);


### PR DESCRIPTION
Five commits on top of the effect-aware blocker report. Three are wrong-answer
fixes found by auditing the hand-written trace-time specializations for a duty
one arm keeps and its sibling drops; two move a duty or a table into shared code
so an arm cannot drop it again.

## Wrong answers

**`store_subscr` proved only the upper bound** (`specialize.rs`)

`try_walker_specialize_store_subscr` emitted `IntLt(raw_index, len)` and nothing
else, while both read arms emitted `IntGe(raw_index, 0)` first. `IntLt` is
signed on every backend (`j2plan` `SignedLt`, cranelift
`IntCC::SignedLessThan`, wasm `I64LtS`), so a negative index passed and reached
`SetarrayitemGc` with the raw word. `space.setitem` remaps a negative index to
`index + len` (`listobject.py`); the trace did not, so the store addressed
before the items.

Attributed on one binary:

```
lst = [0,0,0,0]; hot(30000, lst, 1); hot(5, lst, -1)
fold on                              -> [0, 29999, 0, 0]
PYRE_FBW_NO_SPECIALIZE=store_subscr  -> [0, 29999, 0, 4]   (== cpython == pypy)
```

Both halves now live in `walker_emit_index_bounds_guards`, which all three
indexing arms call.

`a_compiled_list_store_deopts_for_a_negative_index` covers the three list
strategies plus the list and tuple reads. Without the lower bound it
**segfaults**: the out-of-range write lands on the items block header, which a
later `append` reads back as a capacity. Two fixture shapes false-green against
the unfixed store and are documented in the file — a single re-entry iteration
never reaches the compiled store, and a fresh callable side-exits on the
callable guard first.

**The bigint shift residuals narrowed their count to `usize`** (`descroperation.rs`)

`jit_bigint_shl` / `jit_bigint_shr` spelled the shift `&*a << (b as usize)`.
`usize` is 32 bits on wasm32 while `intval` is `i64` on every target and
`CAN_BE_TAGGED` is false, so `2**33` arrives as an ordinary `W_IntObject`; the
`b == 0` early return tests the unnarrowed `i64` and does not fire, and the
shift then runs by 0. `x >> 2**33` answered `x` instead of `0`. The lshift twin
`jit_bigint_lshift_count` was already `i64`-clean, which is what made the pair
readable as an asymmetry.

Both now pass the count unnarrowed and take `jit_bigint_lshift_count`'s failure
arm — publish MemoryError, answer null — rather than `Shl`/`Shr`'s `expect`,
which panics. Both carry `elidable_or_memerror`, so that is the channel they
declare.

This one has no red control on a 64-bit host: `as usize` is lossless here, so
the added test passes before and after and discriminates only on a 32-bit
target. It is a read-the-code fix with a regression test, not a measured one.

**The math float driver held its operands across an allocating call** (`specialize.rs`)

`walker_specialize_math_float` read its operand pointers before
`call_function_impl_result` and passed the same words to
`walker_coerce_operand_to_float` after it. That call allocates, so a collection
under it forwards the operands and leaves those words stale.
`try_walker_specialize_builtin_divmod_long_int` states the duty and re-reads
them from the walker's op cells, which is what this now does. The callable is
not re-fetched: a module's builtin function outlives every nursery it could have
been born in, while the operands are the loop's own boxes.

## Duties and tables moved into shared code

**`w_class` is pinned inside the float coercion**

Four of eleven float-coercing arms (`math_fabs`, `math_float1`, `math_float2`,
`math_isclose`) omitted `walker_guard_exact_w_class`, so a numeric subclass
overriding `__float__` kept answering from the compiled trace: `__float__` ran
once in 6000 iterations. The pin moved into `walker_coerce_operand_to_float`,
and the arms that dispatch on the operand's Python-level class rather than its
payload take `walker_coerce_dispatching_operand_to_float` instead.

The five math float folds are now one driver plus five rows
(`MathFloatDomain`, `MathFloatEmit`) rather than five hand-written arms, in the
shape `intobject.py`'s `_make_generic_descr_binop` uses. All five still fire.

**The fold rows name themselves**

`SPEC_FOLD_ROWS` was a `&[(&str, &str, &str)]` and `spec_gate` took a string
literal resolved by a linear scan over 73 names, so a label naming no row
counted nowhere and a row nobody named was invisible. A `spec_folds!` macro now
emits the `SpecFold` enum and the table from one list: a misspelled label is a
compile error and an unnamed row is a `variant is never constructed` warning.
`SPEC_UNKNOWN` and the `unknown_labels=` summary field are removed as
unreachable.

## Where the generation stops

The long/bigint arithmetic family (8 arms, 1289 LOC) is deliberately **not**
converted. It needs 11 knobs over 8 rows with per-row lowerings that are
load-bearing — `pow`'s `fits_int` guard sits before its call and `shift`'s after
it and they answer opposite directions; `div` carries a second complete
recorded-raise emission path, which is why it returns `DispatchOutcome` rather
than `()`. Upstream's own `_make_descr_binop(func, ovf, ovf2small, ovf_func)`
stops at four knobs and still emits tight code per row. At 11 the table is as
complex as the arms it would replace.

`binary_op_int`, the file's largest arm at 274 LOC, is already this shape —
its own comment reads `// INT_BINOP_TABLE -> (OpCode, has_overflow,
needs_concrete_check)`.

## Claims that did not survive

Three further asymmetries were checked and refuted rather than fixed, two of
them on prose the tree already carries within 200 lines of the arm:

- `load_method_attr` "dropped" the inline-subwalk gate its two siblings have.
  The gate's criterion is the fold's own re-appliable effect, not that it emits
  guards; `load_type_attr` says so verbatim. A repro with a side effect
  sequenced before the method load, the pin broken mid-loop, and the fold
  confirmed firing showed no doubling at depth 1 or 2.
- three attr arms bake a `ConstRef` with no `can_move` gate. The discharge site
  names them as deliberate exemptions.
- the zip/tuple arm re-reads a pre-allocation raw word. `set_opref_concrete` is
  the rooting mechanism; `walk_active_trace_refs` forwards recorded op value
  cells in place.

## Gate

`ALL PASSED: dynasm 491/491`, on this branch's current base
(`gc: the young raw-malloced generation`). `cargo fmt --all -- --check` and
`scripts/check-majit-boundary.py` clean.

`cargo test --all --no-default-features --features dynasm,cpyext --no-fail-fast`:
8468 tests across 192 binaries, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gCeUzbGWCK8S6vqnXh416


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of very large integer bit shifts, including reliable behavior on 32-bit systems and appropriate memory errors.
  * Prevented optimized numeric operations from being incorrectly reused for integer or float subclasses.
  * Improved diagnostics for optimization blockers and effect-aware execution paths.

* **Tests**
  * Added coverage for negative list indexing, subclass-aware math operations, and large integer shifts.

* **Performance**
  * Streamlined specialization tracking and numeric dispatch for more consistent optimized execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->