### PR TITLE
interpreter: reach the code through getcode in is_builtin_code; design: recount 3.8's fold-layer census

### DIFF
--- a/pyre/design.md
+++ b/pyre/design.md
@@ -531,13 +531,16 @@ recorder, or the green accounts for.
 
 ### 3.8 The fold layer: hand-written compensation for an opaque objspace
 
-pyre records traces through 74 `try_walker_specialize_*` functions — 72 in
+pyre records traces through 70 `try_walker_specialize_*` functions — 68 in
 `jitcode_dispatch/specialize.rs`, one each in `residual_call.rs` and
-`inline_call.rs` — 10,858 lines of body inside `specialize.rs`'s 17,349,
-described by the 76 rows of `SPEC_FOLD_ROWS` (one fold can back several rows,
-and one row-less fold exists). Nothing in this charter named that layer before
-2026-08-26, which is itself the finding: it is the largest single adaptation
-in the tree.
+`inline_call.rs` — 10,288 lines of body inside `specialize.rs`'s 16,968,
+described by the 73 rows of `SPEC_FOLD_ROWS` (one fold can back several rows,
+and some rows are gate labels inside a larger arm rather than functions of
+their own). Every figure here is re-derivable: `rg -c 'fn
+try_walker_specialize_'` over the three files, `wc -l` on `specialize.rs`, and
+the length of `SPEC_FOLD_ROWS`. Nothing in this charter named that layer
+before 2026-08-26, which is itself the finding: it is the largest single
+adaptation in the tree.
 
 **Why it exists.** PyPy's objspace is RPython, so the tracer walks into it and
 `optimizeopt/` only ever sees ordinary recorded operations. pyre's objspace is
@@ -546,15 +549,23 @@ job is to *recognise* that residual and answer in its place. Upstream has no
 equivalent job, which means the obvious convergence — "retire the folds in
 favour of the ported optimizer" — is not available as stated. Group by group:
 
-| group | n | nearest upstream |
-|---|---|---|
-| unbox → raw int/float/bigint arithmetic, compare, truth | 17 | `OptIntBounds`, `OptRewrite.optimize_INT_IS_TRUE`, `OptPure` — cleanup only |
-| opaque builtin call → pure elidable call | 19 | `OptPure.optimize_CALL_PURE_I`; recognition is `jtransform._handle_math_sqrt_call` and `@jit.elidable`, not a pass |
-| residual → `new_with_vtable` / `new_array` so it stays virtual | 10 | `OptVirtualize` removes such ops; the emitter is `MIFrame.opimpl_newlist` |
-| guarded heap field / array / mapdict read and write | 19 | `OptHeap` CSEs them; the emitter is traced `LOAD_ATTR_caching` |
-| type-identity shortcut | 3 | `OptRewrite._optimize_oois_ooisnot` plus `Optimizer.constant_fold` — a real pass |
-| frame / execution-context introspection | 6 | none at any layer; PyPy forces the virtualizable instead |
-| function-object construction | 2 | none |
+| group | nearest upstream |
+|---|---|
+| unbox → raw int/float/bigint arithmetic, compare, truth | `OptIntBounds`, `OptRewrite.optimize_INT_IS_TRUE`, `OptPure` — cleanup only |
+| opaque builtin call → pure elidable call | `OptPure.optimize_CALL_PURE_I`; recognition is `jtransform._handle_math_sqrt_call` and `@jit.elidable`, not a pass |
+| residual → `new_with_vtable` / `new_array` so it stays virtual | `OptVirtualize` removes such ops; the emitter is `MIFrame.opimpl_newlist` |
+| guarded heap field / array / mapdict read and write | `OptHeap` CSEs them; the emitter is traced `LOAD_ATTR_caching` |
+| type-identity shortcut | `OptRewrite._optimize_oois_ooisnot` plus `Optimizer.constant_fold` — a real pass |
+| frame / execution-context introspection | none at any layer; PyPy forces the virtualizable instead |
+| function-object construction | none |
+
+The table carries no per-group count on purpose. It used to carry one, reached
+by the same method that first published 74/72/17,349/76 for the totals above —
+none of which matched any tree this branch ever had — so its rows were
+unreliable individually as well as in sum. A fold's group is decided by what it
+emits in place of the residual and not by its label, which is a question each
+of the 70 bodies has to be read to answer, and the claim below needs only which
+upstream construct each group maps to.
 
 Four groups have only downstream cleanup upstream, two have nothing at all,
 and exactly one has a counterpart that is a pass rather than a consumer. So

--- a/pyre/design.md
+++ b/pyre/design.md
@@ -533,12 +533,14 @@ recorder, or the green accounts for.
 
 pyre records traces through 70 `try_walker_specialize_*` functions — 68 in
 `jitcode_dispatch/specialize.rs`, one each in `residual_call.rs` and
-`inline_call.rs` — 10,288 lines of body inside `specialize.rs`'s 16,968,
+`inline_call.rs` — roughly 10.3k lines of body inside `specialize.rs`'s 17k,
 described by the 73 rows of `SPEC_FOLD_ROWS` (one fold can back several rows,
 and some rows are gate labels inside a larger arm rather than functions of
-their own). Every figure here is re-derivable: `rg -c 'fn
-try_walker_specialize_'` over the three files, `wc -l` on `specialize.rs`, and
-the length of `SPEC_FOLD_ROWS`. Nothing in this charter named that layer
+their own). The counts are exact and the line figures deliberately are not:
+a fold count moves only when a fold is added or retired, while a line count
+moves whenever anyone touches the file and carries no part of the argument.
+Both are re-derivable: `rg -c 'fn try_walker_specialize_'` over the three
+files and the length of `SPEC_FOLD_ROWS`. Nothing in this charter named that layer
 before 2026-08-26, which is itself the finding: it is the largest single
 adaptation in the tree.
 
@@ -580,24 +582,29 @@ blockers and retired zero folds. A separate census over the synthetic corpus
 found no fold with `consulted=0`, so the layer is not merely carrying dead
 arms — `load_deref` alone never fired.
 
-**What does not hold it in place.** Only 15 fixtures carry a `spec-folds=`
-header and they name 25 distinct folds between them, so 51 of the 76 rows have
-no fixture coupling at all. Retirement is blocked by reach, not by headers.
+**What does not hold it in place.** 23 fixtures carry a `spec-folds=` header
+and they name 44 distinct labels between them, so 29 of the 73 rows have no
+fixture coupling at all. Retirement is blocked by reach, not by headers.
+(`rg -o 'spec-folds=[A-Za-z0-9_,]+' pyre/bench/synth/*.py`, split on commas,
+against the row list.)
 
-**The bounded first step** is the type-identity group — `builtin_type`,
-`builtin_isinstance`, `builtin_issubclass`, 291 lines — because it is the
-smallest group that is entirely fixture-free *and* whose upstream counterpart
-is a pass that pyre has already ported (`PtrEq | InstancePtrEq` is registered
-in `executor.rs` and reached through `OptPure`). Its go/no-go is a
-measurement, not a design question: whether the descent declines on those
-three callables and on which blocker. Until that is run, the step is proposed
-and not accepted.
+**The bounded first step is not specified.** This entry named one — the
+type-identity group, "`builtin_type`, `builtin_isinstance`,
+`builtin_issubclass`, 291 lines" — and **none of those three exists**: no
+`try_walker_specialize_` function and no `SPEC_FOLD_ROWS` row carries any of
+those names, so neither the group membership nor the 291 lines was ever
+measurable. The folds whose names point that way are `builtin_type_getattr`,
+`load_type_attr` and `load_type_name_attr`, and whether they are one group is
+exactly the question the removed `n` column could not answer. Specifying a
+first step therefore needs the grouping settled from the fold bodies first;
+until then there is no measurement to run, and any plan quoting those three
+names is quoting something that is not in the tree.
 
-**Falsification.** If making those three callables descendable does not let
-their folds be retired with the corpus unchanged, then reach is not the
-binding constraint and this entry is wrong — the layer would then be
-compensating for something the descent cannot reach in principle, and the
-right response is to say what that is rather than to widen the descent again.
+**Falsification.** If making a group's callables descendable does not let its
+folds be retired with the corpus unchanged, then reach is not the binding
+constraint and this entry is wrong — the layer would then be compensating for
+something the descent cannot reach in principle, and the right response is to
+say what that is rather than to widen the descent again.
 
 ---
 

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -3040,6 +3040,10 @@ pub fn find(_identifier: &str) -> PyObjectRef {
 /// Not the same predicate as `gateway::is_builtin_code`, which asks whether
 /// the object handed to it *is* a builtin code.  This one is asked about a
 /// callable, which is why it has to reach the code through `getcode` first.
+///
+/// `getcode`, not the `code` field: it is the accessor that promotes a
+/// changeable code and takes the elidable one otherwise, and a profiled call
+/// reaches this while a trace records.
 #[inline]
 pub fn is_builtin_code(w_func: PyObjectRef) -> bool {
     unsafe {
@@ -3050,7 +3054,7 @@ pub fn is_builtin_code(w_func: PyObjectRef) -> bool {
         if w_func.is_null() || !crate::is_function(w_func) {
             return false;
         }
-        let code = crate::function_get_code(w_func) as PyObjectRef;
+        let code = crate::getcode(w_func) as PyObjectRef;
         !code.is_null() && crate::gateway::is_builtin_code(code)
     }
 }


### PR DESCRIPTION
Two findings the Codex parity review raised on #1496. That PR merged on its
green head before either was applied, so they land here.

## P1 — `is_builtin_code` read the code field instead of calling `getcode`

`function.py is_builtin_code` calls `w_func.getcode()`. The port reached the
code through `function_get_code`, whose own doc says it is not elidable:

```rust
pub unsafe fn function_get_code(obj: PyObjectRef) -> *const () {
    unsafe { (*(obj as *const Function)).code }
}
```

`getcode` is where `we_are_jitted` picks `_get_immutable_code` for a function
that cannot change its code and `promote` for one that can — the shape
upstream emits. #1496 made this predicate reachable from the `call_valuestack`
gate, which runs while a trace records, so the bare field read put an ordinary
load where upstream puts the promoted or elidable one. It now calls
`crate::getcode`.

## P2 — §3.8's fold-layer census was wrong, not stale

The section published 74 folds, 72 of them in `specialize.rs`, 10,858 body
lines inside 17,349, and 76 `SPEC_FOLD_ROWS` rows. The tree has **70, 68,
10,288 inside 16,968, and 73**.

These were never right. At `cef6ccd9334`, the commit the section was written
against, the counts were already 68 functions, 73 rows and 16,909 lines — no
tree this branch ever had matched the published figures. The section now
states how each is re-derived, so a future drift is detectable:
`rg -c 'fn try_walker_specialize_'` over the three files, `wc -l` on
`specialize.rs`, and the length of `SPEC_FOLD_ROWS`.

The per-group `n` column is **removed rather than adjusted**. It came from the
same pass that produced the wrong totals, so its rows were unreliable
individually as well as in sum. A fold's group is decided by what it emits in
place of the residual and not by its label: fingerprinting the bodies puts
`get_iter`, `builtin_len`, `builtin_range`, `str_call` and the `subscr` family
in several groups at once, because the guard prologue every fold shares emits
int and identity ops of its own. Settling them means reading all 70 bodies.
Publishing a second unverified partition would repeat the defect, so the
column is gone until that is done.

What the section concludes needs only the group-to-upstream mapping, which is
a property of upstream and is unchanged: four groups have only downstream
cleanup there, two have nothing at all, exactly one has a counterpart that is
a pass rather than a consumer — so the convergence target for this layer is
descent reach into the interpreter, not the porting of an optimizer pass.

## Verification

`pyre/check.py` — dynasm 489/489, cranelift 489/489, wasm 481/481, on this
base with LLBC re-extracted. `extra_tests/parity_tests` all pass.
