### PR TITLE
memoryview: comparison and slice assignment through the struct module, and the buffer geometry a C exporter may carry

### DIFF
--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -187,6 +187,16 @@ CPYEXT_INCLUDE = ROOT / "include" / "pyre3.14t"
 CPYEXT_INTERNAL_INCLUDE = CPYEXT_INCLUDE / "internal"
 EXTENSION_BUILD_DIR = ROOT / "build" / "cpython_tests"
 NEEDS_TEST_EXTENSION = {"test.test_buffer", "test.test_importlib"}
+# `PYTHONPATH` does not reach a child started with `-E` or `-I`, and
+# `script_helper.run_python_until_end` starts one whenever the caller passes
+# no environment of its own.  That costs one row today:
+# `test_importlib.extension`'s `test_nonmodule_cases` runs
+# `_test_nonmodule_cases.py` under `-E`, where `_testmultiphase` is not
+# importable and all four of its cases fail.  Reaching that child means
+# putting these modules on the interpreter's own default `sys.path`, whose
+# only entry here is `lib-python/3` — which would also make them importable
+# to every other module in the suite, and the suite branches on whether
+# `import X` succeeds.  That trade is not the runner's to make silently.
 
 # These modules intentionally assert on a child interpreter's exact stderr.
 # MAJIT_STATS is runner instrumentation rather than language-visible output,

--- a/pyre/docs/cpyext.md
+++ b/pyre/docs/cpyext.md
@@ -564,11 +564,35 @@ Known divergences, each documented at its definition:
   a `bytes` nor a `str` mirror carries the field the reference header reads,
   the storage being a cached copy rather than a tail allocated with the
   object;
-- a C exporter's view must be C-contiguous and free of suboffsets: a strided or
-  indirect export is refused. The `Py_buffer` a `bf_getbuffer` filled in is kept
-  and handed back to `bf_releasebuffer` unchanged -- `internal` is the
-  exporter's own state -- keyed by the exported address, since the interpreter
-  object it belongs to moves and the foreign memory does not;
+- a C exporter's view keeps whatever geometry it declares -- strided,
+  multi-dimensional, or indirect through `suboffsets`. Where a contiguous
+  one-dimensional export becomes the same `RawBufferView` any in-heap exporter
+  produces, everything else rides on a variant carrying its own `shape`,
+  `strides` and `suboffsets`, ported from `CPyBuffer`
+  (`pypy/module/cpyext/buffer.py`). Two deliberate deviations go with it, both
+  toward CPython 3.14 and away from what pypy does today:
+  - **suboffsets are honoured, where pypy declines them.** `BufferView.get_offset`
+    carries `# TODO suboffsets?` at the `ADJUST_PTR` site, `_init_flags` guards
+    `MEMORYVIEW_PIL` behind `if False`, and `w_get_suboffsets` answers `()`
+    unconditionally. pyre implements `HAVE_PTR` / `ADJUST_PTR`, `init_suboffsets`
+    and the `_Py_MEMORYVIEW_PIL` flag rule instead. An element behind a
+    suboffset has no byte offset within the backing, so the address is chained
+    dimension by dimension rather than summed, and the byte-slice bound the
+    direct walk clamps against does not apply to it: past the first
+    dereference the exporter's own pointers are the only description of the
+    target, which is the trust CPython extends as well.
+  - **a slice's length is `product(shape) * itemsize`, where `BufferSlice.getlength`
+    is `shape[0] * itemsize`.** pypy has the same formula in-tree as
+    `bytecount_from_shape`, but nothing reads it back; pyre folded
+    `W_MemoryView.length` into the view, so the arm takes `init_len`'s answer.
+  A window is computed for the storage a strided export addresses, because
+  `Buffer::as_bytes` hands out a bounded slice where CPython and pypy both index
+  a raw pointer: a negative stride reaches below `Py_buffer.buf`, so the block
+  is lowered to the window's low end and the view's offset carries the shift.
+  The `Py_buffer` a `bf_getbuffer` filled in is kept and handed back to
+  `bf_releasebuffer` unchanged -- `internal` is the exporter's own state --
+  keyed by the exported address, since the interpreter object it belongs to
+  moves and the foreign memory does not;
 - a `memoryview` that is never released never ends its export, pyre having no
   reference counting to end it at the last drop;
 - the argument parser words a bad argument its own way: every message is

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -15331,19 +15331,19 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
         }
         // `memoryview` — `memoryobject.py descr_iter` returns
         // `space.newseqiter(self)`; the cursor fetches each element through
-        // `__getitem__`.  Element count is `shape[0]` == length / itemsize.
+        // `__getitem__`.  Element count is `memory_length`'s `shape[0]`, which
+        // is `length / itemsize` only while the view is one-dimensional.
         if pyre_object::memoryview::is_w_memoryview(obj) {
             if pyre_object::memoryview::w_memoryview_released(obj) {
                 return Err(PyError::value_error(
                     "operation forbidden on released memoryview object",
                 ));
             }
-            let itemsize = pyre_object::memoryview::w_memoryview_itemsize(obj);
-            let len = if itemsize > 0 {
-                (pyre_object::memoryview::w_memoryview_length(obj) / itemsize) as usize
-            } else {
-                0
-            };
+            let len = pyre_object::memoryview::w_memoryview_native_shape(obj)
+                .first()
+                .copied()
+                .unwrap_or(0)
+                .max(0) as usize;
             return Ok(pyre_object::w_seq_iter_new(obj, len));
         }
         // pypy/objspace/descroperation.py `def iter(space, w_obj)`

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1389,6 +1389,9 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
             ));
         }
         let i = getindex_w(index)?;
+        // `memory_ass_sub`: `__index__` is arbitrary Python code and may have
+        // released this view before the offset reads its geometry (gh-92888).
+        memoryview_check_released(mv)?;
         let item_offset = memoryview_get_offset(mv, 0, i)?;
         let packed = memoryview_pack_value(&fmt, isz, value)?;
         // Re-check release after value coercion (see tuple path above).

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1225,6 +1225,11 @@ fn memoryview_getitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
         use pyre_object::memoryview::*;
         memoryview_check_released(mv)?;
         let ndim = w_memoryview_ndim(mv);
+        // `memory_subscript`: a zero-dimensional view takes only the empty
+        // tuple, which reads its one element, and `...`, which is itself.
+        if ndim == 0 && pyre_object::pyobject::is_ellipsis(index) {
+            return Ok(mv);
+        }
         if pyre_object::is_slice(index) {
             return memoryview_slice_view(mv, index);
         }
@@ -1306,6 +1311,12 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
         let itemsize = w_memoryview_itemsize(mv);
         let isz = itemsize.max(0) as usize;
         let fmt = w_memoryview_format_str(mv).to_owned();
+        // `memory_ass_sub`: `...` names a zero-dimensional view's one element,
+        // exactly as the empty tuple does.
+        let index = match w_memoryview_ndim(mv) == 0 && pyre_object::pyobject::is_ellipsis(index) {
+            true => pyre_object::w_tuple_new(vec![]),
+            false => index,
+        };
         let count = w_memoryview_native_shape(mv).first().copied().unwrap_or(0);
         let stride0 = w_memoryview_stride0(mv);
         let offset = w_memoryview_offset(mv);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -878,13 +878,25 @@ fn memoryview_pack_value(
     itemsize: usize,
     w_val: PyObjectRef,
 ) -> Result<Vec<u8>, crate::PyError> {
+    // `type_error_int` / `value_error_int` — the wrong kind of object and a
+    // value the format cannot hold are reported separately.
     let bad_type =
         || crate::PyError::type_error(format!("memoryview: invalid type for format '{fmt}'"));
+    let bad_value =
+        || crate::PyError::value_error(format!("memoryview: invalid value for format '{fmt}'"));
+    // `fix_error_int` — a failed coercion is restated as the format's own
+    // error; anything that is neither a type nor a range complaint keeps its
+    // own identity.
+    let fix_error = |err: crate::PyError| match err.kind {
+        crate::PyErrorKind::TypeError => bad_type(),
+        crate::PyErrorKind::OverflowError | crate::PyErrorKind::ValueError => bad_value(),
+        _ => err,
+    };
+    // `err_range`.
     let range = |v: i64, lo: i64, hi: i64| -> Result<(), crate::PyError> {
-        if (lo..=hi).contains(&v) {
-            Ok(())
-        } else {
-            Err(bad_type())
+        match (lo..=hi).contains(&v) {
+            true => Ok(()),
+            false => Err(bad_value()),
         }
     };
     // Integer formats coerce via `__index__` (`pack_single`/`PyNumber_Index`),
@@ -893,15 +905,11 @@ fn memoryview_pack_value(
         if unsafe { pyre_object::is_int_or_long(w_val) } {
             Ok(w_val)
         } else {
-            match unsafe { crate::baseobjspace::space_index(w_val) } {
-                Ok(index) => Ok(index),
-                Err(err) if err.kind == crate::PyErrorKind::TypeError => Err(bad_type()),
-                Err(err) => Err(err),
-            }
+            unsafe { crate::baseobjspace::space_index(w_val) }.map_err(fix_error)
         }
     };
     let int_val = || -> Result<i64, crate::PyError> {
-        crate::baseobjspace::int_w(as_index()?).map_err(|_| bad_type())
+        crate::baseobjspace::int_w(as_index()?).map_err(fix_error)
     };
     let bytes = match memoryview_format_code(fmt) {
         b'b' => {
@@ -939,34 +947,21 @@ fn memoryview_pack_value(
             v.to_ne_bytes().to_vec()
         }
         b'L' | b'Q' | b'N' | b'P' => {
-            let v = crate::baseobjspace::uint_w(as_index()?).map_err(|_| bad_type())?;
+            let v = crate::baseobjspace::uint_w(as_index()?).map_err(fix_error)?;
             v.to_ne_bytes().to_vec()
         }
         b'f' => {
             // `PackFormatIterator.accept_float_arg`: use `space.float_w`,
-            // including a user `__float__`; only TypeError becomes the
-            // memoryview format error and other user exceptions propagate.
-            let v = match crate::baseobjspace::float_w(w_val) {
-                Ok(value) => value,
-                Err(err) if err.kind == crate::PyErrorKind::TypeError => return Err(bad_type()),
-                Err(err) => return Err(err),
-            } as f32;
+            // including a user `__float__`; other user exceptions propagate.
+            let v = crate::baseobjspace::float_w(w_val).map_err(fix_error)? as f32;
             v.to_ne_bytes().to_vec()
         }
         b'd' => {
-            let v = match crate::baseobjspace::float_w(w_val) {
-                Ok(value) => value,
-                Err(err) if err.kind == crate::PyErrorKind::TypeError => return Err(bad_type()),
-                Err(err) => return Err(err),
-            };
+            let v = crate::baseobjspace::float_w(w_val).map_err(fix_error)?;
             v.to_ne_bytes().to_vec()
         }
         b'e' => {
-            let v = match crate::baseobjspace::float_w(w_val) {
-                Ok(value) => value,
-                Err(err) if err.kind == crate::PyErrorKind::TypeError => return Err(bad_type()),
-                Err(err) => return Err(err),
-            };
+            let v = crate::baseobjspace::float_w(w_val).map_err(fix_error)?;
             crate::module::r#struct::pack_half(v)?
                 .to_ne_bytes()
                 .to_vec()

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1115,9 +1115,10 @@ pub(crate) fn strides_from_shape(shape: &[i64], itemsize: i64) -> Vec<i64> {
     s
 }
 
-/// `get_offset` — the byte offset of `index` along dimension `dim`,
-/// bounds-checked against `shape[dim]` (negative indices wrap).
-unsafe fn memoryview_get_offset(
+/// `lookup_dimension` — `index` wrapped into dimension `dim` and bounds-checked
+/// against `shape[dim]`.  The byte arithmetic is `element_ptr`'s, because a
+/// dimension carrying a suboffset has no byte offset to add.
+unsafe fn memoryview_check_dimension(
     mv: PyObjectRef,
     dim: i64,
     index: i64,
@@ -1125,7 +1126,6 @@ unsafe fn memoryview_get_offset(
     use pyre_object::memoryview::*;
     unsafe {
         let shape = w_memoryview_native_shape(mv);
-        let strides = w_memoryview_native_strides(mv);
         let nitems = shape.get(dim as usize).copied().unwrap_or(0);
         let mut idx = index;
         if idx < 0 {
@@ -1137,7 +1137,7 @@ unsafe fn memoryview_get_offset(
                 dim + 1
             )));
         }
-        Ok(strides.get(dim as usize).copied().unwrap_or(0) * idx)
+        Ok(idx)
     }
 }
 
@@ -1151,15 +1151,15 @@ pub(crate) unsafe fn index_check(w: PyObjectRef) -> bool {
     unsafe { pyre_object::is_int(w) || crate::baseobjspace::lookup(w, "__index__").is_some() }
 }
 
-/// `_start_from_tuple` — the summed byte offset of a multi-index tuple
-/// (one integer per dimension).
+/// `_start_from_tuple` — the wrapped, bounds-checked index of every dimension
+/// a multi-index tuple names.
 unsafe fn memoryview_start_from_tuple(
     mv: PyObjectRef,
     index: PyObjectRef,
-) -> Result<i64, crate::PyError> {
+) -> Result<Vec<i64>, crate::PyError> {
     unsafe {
         let n = pyre_object::w_tuple_len(index) as i64;
-        let mut start = 0;
+        let mut indices = Vec::with_capacity(n as usize);
         for dim in 0..n {
             let w = pyre_object::w_tuple_getitem(index, dim).unwrap_or(w_none());
             if !index_check(w) {
@@ -1170,9 +1170,28 @@ unsafe fn memoryview_start_from_tuple(
             // Python code and may release this memoryview before the offset
             // reads its view geometry.
             memoryview_check_released(mv)?;
-            start += memoryview_get_offset(mv, dim, index)?;
+            indices.push(memoryview_check_dimension(mv, dim, index)?);
         }
-        Ok(start)
+        Ok(indices)
+    }
+}
+
+/// The element at `indices`, unpacked through the view's format.  The bytes
+/// come from `ptr_from_index`'s address rather than a byte index, because a
+/// dimension carrying a suboffset dereferences on the way.
+///
+/// # Safety
+/// `indices` must be wrapped and bounds-checked, and the view live.
+unsafe fn memoryview_unpack_at(
+    mv: PyObjectRef,
+    indices: &[i64],
+    fmt: &str,
+    itemsize: usize,
+) -> PyObjectRef {
+    unsafe {
+        let element = pyre_object::memoryview::w_memoryview_view(mv).element_ptr(indices);
+        let bytes = std::slice::from_raw_parts(element, itemsize);
+        memoryview_unpack_element(fmt, bytes, 0, itemsize)
     }
 }
 
@@ -1227,16 +1246,10 @@ fn memoryview_getitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
                 ));
             }
             // `ptr_from_index` -> `lookup_dimension`: the bound is `shape[0]`,
-            // not `length / itemsize`, and the step is `strides[0]`.
-            let base = (w_memoryview_offset(mv) + memoryview_get_offset(mv, 0, i)?) as usize;
-            let full = w_memoryview_view(mv).backing().as_bytes();
+            // not `length / itemsize`.
+            let index = memoryview_check_dimension(mv, 0, i)?;
             let fmt = w_memoryview_format_str(mv);
-            return Ok(memoryview_unpack_element(
-                fmt,
-                full,
-                base,
-                itemsize as usize,
-            ));
+            return Ok(memoryview_unpack_at(mv, &[index], fmt, itemsize as usize));
         }
         if pyre_object::is_tuple(index) {
             let (all_index, all_slice) = memoryview_tuple_kind(index);
@@ -1253,17 +1266,10 @@ fn memoryview_getitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
                         "cannot index {length}-dimension view with {ndim}-element tuple"
                     )));
                 }
-                let start = memoryview_start_from_tuple(mv, index)?;
+                let indices = memoryview_start_from_tuple(mv, index)?;
                 let itemsize = w_memoryview_itemsize(mv);
-                let base = (w_memoryview_offset(mv) + start) as usize;
-                let full = w_memoryview_view(mv).backing().as_bytes();
                 let fmt = w_memoryview_format_str(mv);
-                return Ok(memoryview_unpack_element(
-                    fmt,
-                    full,
-                    base,
-                    itemsize as usize,
-                ));
+                return Ok(memoryview_unpack_at(mv, &indices, fmt, itemsize as usize));
             }
             if all_slice {
                 return Err(crate::PyError::not_implemented(
@@ -1374,13 +1380,11 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
             // released the view (`bytes_from_value` → `_check_released` →
             // `setbytes`).
             memoryview_check_released(mv)?;
-            let start = memoryview_start_from_tuple(mv, index)?;
-            let addr = (offset + start) as usize;
-            let full = w_memoryview_view(mv)
-                .backing()
-                .as_bytes_mut()
+            let indices = memoryview_start_from_tuple(mv, index)?;
+            let target = w_memoryview_view(mv)
+                .element_ptr_mut(&indices)
                 .expect("writable backing checked above");
-            full[addr..addr + isz].copy_from_slice(&packed);
+            std::slice::from_raw_parts_mut(target, isz).copy_from_slice(&packed);
             return Ok(w_none());
         }
         if !index_check(index) {
@@ -1392,16 +1396,14 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
         // `memory_ass_sub`: `__index__` is arbitrary Python code and may have
         // released this view before the offset reads its geometry (gh-92888).
         memoryview_check_released(mv)?;
-        let item_offset = memoryview_get_offset(mv, 0, i)?;
+        let element = memoryview_check_dimension(mv, 0, i)?;
         let packed = memoryview_pack_value(&fmt, isz, value)?;
         // Re-check release after value coercion (see tuple path above).
         memoryview_check_released(mv)?;
-        let addr = (offset + item_offset) as usize;
-        let full = w_memoryview_view(mv)
-            .backing()
-            .as_bytes_mut()
+        let target = w_memoryview_view(mv)
+            .element_ptr_mut(&[element])
             .expect("writable backing checked above");
-        full[addr..addr + isz].copy_from_slice(&packed);
+        std::slice::from_raw_parts_mut(target, isz).copy_from_slice(&packed);
         Ok(w_none())
     }
 }
@@ -1589,44 +1591,37 @@ fn memoryview_len(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
 }
 
-/// `_tolist_rec` — the nested element-value list of dimension `idim` of an
-/// N-D view, reading the raw backing by true strides.  The innermost
-/// dimension unpacks `shape[ndim-1]` elements stepping `pos` by
-/// `strides[ndim-1]`; an outer dimension collects `shape[idim]` sublists,
-/// advancing `start` by `strides[idim]`.
+/// `_tolist_rec` — the nested element-value list of dimension `idim`.  The
+/// elements arrive already in C order from the view's own gather, which is
+/// what applies the strides and follows any suboffsets, so this only groups
+/// `shape[idim]` of them per level.
 unsafe fn memoryview_tolist_rec(
-    mv: PyObjectRef,
+    shape: &[i64],
     fmt: &str,
-    full: &[u8],
+    data: &[u8],
     isz: usize,
-    ndim: i64,
-    idim: i64,
-    start: i64,
+    idim: usize,
+    cursor: &mut usize,
 ) -> PyObjectRef {
-    use pyre_object::memoryview::*;
     unsafe {
-        let dimshape = w_memoryview_native_shape(mv)
-            .get(idim as usize)
-            .copied()
-            .unwrap_or(0);
-        let dimstride = w_memoryview_native_strides(mv)
-            .get(idim as usize)
-            .copied()
-            .unwrap_or(0);
+        let dimshape = shape.get(idim).copied().unwrap_or(0).max(0);
         // Every element is pinned as built, the sublists included, and read
         // back inside the scope `w_list_new` runs in (`build_list_storage`).
         let _roots = pyre_object::gc_roots::push_roots();
         let sp = pyre_object::gc_roots::shadow_stack_len();
         let mut count = 0;
-        let mut pos = start;
         for _ in 0..dimshape {
-            let element = if idim == ndim - 1 {
-                memoryview_unpack_element(fmt, full, pos as usize, isz)
+            let element = if idim + 1 == shape.len() {
+                if *cursor + isz > data.len() {
+                    break;
+                }
+                let at = *cursor;
+                *cursor += isz;
+                memoryview_unpack_element(fmt, data, at, isz)
             } else {
-                memoryview_tolist_rec(mv, fmt, full, isz, ndim, idim + 1, pos)
+                memoryview_tolist_rec(shape, fmt, data, isz, idim + 1, cursor)
             };
             let _ = pyre_object::gc_roots::pin_root(element);
-            pos += dimstride;
             count += 1;
         }
         let items = (0..count)
@@ -1650,14 +1645,25 @@ fn memoryview_tolist(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         }
         let isz = pyre_object::memoryview::w_memoryview_itemsize(mv) as usize;
         let fmt = pyre_object::memoryview::w_memoryview_format_str(mv);
-        let full = pyre_object::memoryview::w_memoryview_view(mv)
-            .backing()
-            .as_bytes();
-        let start = pyre_object::memoryview::w_memoryview_offset(mv);
+        let data = memoryview_gather_bytes(mv);
         if ndim == 0 {
-            return Ok(memoryview_unpack_element(fmt, full, start as usize, isz));
+            if isz == 0 || data.len() < isz {
+                return Err(crate::PyError::not_implemented(
+                    "memoryview: unsupported format",
+                ));
+            }
+            return Ok(memoryview_unpack_element(fmt, &data, 0, isz));
         }
-        Ok(memoryview_tolist_rec(mv, fmt, full, isz, ndim, 0, start))
+        let shape = pyre_object::memoryview::w_memoryview_native_shape(mv);
+        let mut cursor = 0;
+        Ok(memoryview_tolist_rec(
+            &shape,
+            fmt,
+            &data,
+            isz,
+            0,
+            &mut cursor,
+        ))
     }
 }
 
@@ -2442,6 +2448,11 @@ pub(crate) unsafe fn memoryview_contiguity(mv: PyObjectRef) -> (bool, bool) {
         if ndim == 0 {
             return (true, true);
         }
+        // `init_flags`: an indirect view is contiguous in neither order,
+        // whatever its strides say.
+        if !w_memoryview_native_suboffsets(mv).is_empty() {
+            return (false, false);
+        }
         let itemsize = w_memoryview_itemsize(mv);
         let length = w_memoryview_length(mv);
         let shape = w_memoryview_native_shape(mv);
@@ -2486,7 +2497,9 @@ fn memoryview_suboffsets(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     let mv = memoryview_getset_receiver(args);
     unsafe {
         memoryview_check_released(mv)?;
-        Ok(pyre_object::w_tuple_new(vec![]))
+        Ok(memoryview_wrap_dims(
+            &pyre_object::memoryview::w_memoryview_native_suboffsets(mv),
+        ))
     }
 }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1293,6 +1293,100 @@ fn memoryview_getitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     }
 }
 
+/// `equiv_format` reads a leading `@` as the native-order default, so `@i`
+/// and `i` name one layout.
+fn memoryview_native_format(fmt: &str) -> &str {
+    fmt.strip_prefix('@').unwrap_or(fmt)
+}
+
+/// `equiv_structure` — an lvalue slice accepts only an rvalue of the same
+/// format, itemsize, dimensionality and extent.
+///
+/// # Safety
+/// Both arguments must be live, unreleased memoryviews.
+unsafe fn memoryview_equiv_structure(
+    mv: PyObjectRef,
+    src: PyObjectRef,
+    extent: i64,
+    itemsize: usize,
+) -> Result<(), crate::PyError> {
+    unsafe {
+        use pyre_object::memoryview::*;
+        let equivalent = w_memoryview_itemsize(src) as usize == itemsize
+            && memoryview_native_format(w_memoryview_format_str(mv))
+                == memoryview_native_format(w_memoryview_format_str(src))
+            && w_memoryview_ndim(src) == 1
+            && w_memoryview_native_shape(src).first().copied().unwrap_or(0) == extent;
+        match equivalent {
+            true => Ok(()),
+            false => Err(crate::PyError::value_error(
+                "memoryview assignment: lvalue and rvalue have different structures",
+            )),
+        }
+    }
+}
+
+/// `copy_single` — assign an exporter's elements to the positions `indices`
+/// names in a one-dimensional view.
+///
+/// # Safety
+/// `mv` must be a live, unreleased, writable one-dimensional memoryview, and
+/// `indices` must already be bounds-checked against its shape.
+unsafe fn memoryview_copy_single(
+    mv: PyObjectRef,
+    indices: &[i64],
+    itemsize: usize,
+    value: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    unsafe {
+        use pyre_object::memoryview::*;
+        let _roots = pyre_object::gc_roots::push_roots();
+        let base = pyre_object::gc_roots::pin_roots(&[mv, value]);
+        let value = pyre_object::gc_roots::shadow_stack_get(base + 1);
+        // `PyObject_GetBuffer(value, &src, PyBUF_FULL_RO)`: the rvalue has to
+        // export a buffer, and a memoryview already is one.
+        let (src, temporary) = if is_w_memoryview(value) {
+            memoryview_check_released(value)?;
+            (value, false)
+        } else {
+            let view = w_memoryview_new(value)?;
+            let _ = pyre_object::gc_roots::pin_root(view);
+            (pyre_object::gc_roots::shadow_stack_get(base + 2), true)
+        };
+        let mv = pyre_object::gc_roots::shadow_stack_get(base);
+        let copied = (|| -> Result<(), crate::PyError> {
+            // Acquiring the rvalue's buffer runs `__buffer__`, which may have
+            // released this view before the copy reads its geometry
+            // (`CHECK_RELEASED_INT_AGAIN`).
+            memoryview_check_released(mv)?;
+            memoryview_equiv_structure(mv, src, indices.len() as i64, itemsize)?;
+            // `copy_base` reads every rvalue element before it writes any of
+            // them, so an rvalue overlapping the lvalue is not clobbered
+            // part-way through the copy.
+            let mut bounce = Vec::with_capacity(indices.len() * itemsize);
+            for element in 0..indices.len() as i64 {
+                let from = w_memoryview_view(src).element_ptr(&[element]);
+                bounce.extend_from_slice(std::slice::from_raw_parts(from, itemsize));
+            }
+            for (element, &index) in indices.iter().enumerate() {
+                let into = w_memoryview_view(mv)
+                    .element_ptr_mut(&[index])
+                    .expect("writable backing checked above");
+                std::slice::from_raw_parts_mut(into, itemsize)
+                    .copy_from_slice(&bounce[element * itemsize..][..itemsize]);
+            }
+            Ok(())
+        })();
+        if temporary {
+            let release = memoryview_release(&[src]);
+            if copied.is_ok() {
+                release?;
+            }
+        }
+        copied.map(|()| w_none())
+    }
+}
+
 /// `memoryview.__setitem__` — write through to a mutable bytearray-backed
 /// view, packing the value per the view's format (`memoryobject.py
 /// descr_setitem`).  An integer index writes one element; a slice writes a
@@ -1342,28 +1436,7 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
                 indices.push(i);
                 i += step;
             }
-            let src: Vec<u8> = match crate::typedef::buffer_as_bytes_like(value)? {
-                Some(b) => pyre_object::bytesobject::bytes_like_data(b).to_vec(),
-                None => {
-                    return Err(crate::PyError::type_error(
-                        "memoryview: a bytes-like object is required",
-                    ));
-                }
-            };
-            if isz == 0 || src.len() != indices.len() * isz {
-                return Err(crate::PyError::value_error(
-                    "cannot modify size of memoryview object",
-                ));
-            }
-            let full = w_memoryview_view(mv)
-                .backing()
-                .as_bytes_mut()
-                .expect("writable backing checked above");
-            for (k, &idx) in indices.iter().enumerate() {
-                let dst = (offset + idx * stride0) as usize;
-                full[dst..dst + isz].copy_from_slice(&src[k * isz..k * isz + isz]);
-            }
-            return Ok(w_none());
+            return memoryview_copy_single(mv, &indices, isz, value);
         }
         // Multi-index tuple writes one element of an N-D view; an all-slice
         // tuple is multi-dimensional slice assignment (`_setitem_tuple_indexed`).

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1102,7 +1102,7 @@ fn memoryview_native_fmtchar(fmt: &str) -> Option<i64> {
 /// `_strides_from_shape` — C-contiguous strides for `shape`: the last
 /// dimension steps by `itemsize`, each earlier one by the product of the
 /// faster dimensions.
-fn memoryview_strides_from_shape(shape: &[i64], itemsize: i64) -> Vec<i64> {
+pub(crate) fn strides_from_shape(shape: &[i64], itemsize: i64) -> Vec<i64> {
     let ndim = shape.len();
     if ndim == 0 {
         return vec![];
@@ -1794,7 +1794,7 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
                 "memoryview: product(shape) * itemsize != buffer size",
             ));
         }
-        let strides_v = memoryview_strides_from_shape(&dims, new_itemsize);
+        let strides_v = strides_from_shape(&dims, new_itemsize);
         Ok(w_memoryview_cast_nd(
             mv,
             &fmt,

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1871,19 +1871,22 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         if !has_shape {
             return Ok(w_memoryview_cast_1d(mv, &fmt, new_itemsize));
         }
-        // _cast_to_ND: `length = itemsize; for d in shape: length *= d`, then
-        // `length != view.getlength()` rejects.  A negative dimension makes the
-        // product mismatch `total`; checked multiplication keeps an overflow
-        // (which can never equal a real buffer size) a rejection rather than a
-        // debug-build panic.
+        // `copy_shape` then `cast_to_ND`: every extent must be positive — a
+        // dimension may be empty in general, but not for a cast — and only
+        // then does `length != view.getlength()` reject the product.
         let ndim = dims.len() as i64;
         let mut product = new_itemsize;
         for &d in &dims {
+            if d <= 0 {
+                return Err(crate::PyError::value_error(
+                    "memoryview.cast(): elements of shape must be integers > 0",
+                ));
+            }
             match product.checked_mul(d) {
                 Some(p) => product = p,
                 None => {
-                    return Err(crate::PyError::type_error(
-                        "memoryview: product(shape) * itemsize != buffer size",
+                    return Err(crate::PyError::value_error(
+                        "memoryview.cast(): product(shape) > SSIZE_MAX",
                     ));
                 }
             }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1415,11 +1415,18 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
             true => pyre_object::w_tuple_new(vec![]),
             false => index,
         };
+        // Once `...` has become the empty tuple, that tuple is the only key a
+        // zero-dimensional view accepts.
+        if w_memoryview_ndim(mv) == 0
+            && !(pyre_object::is_tuple(index) && pyre_object::w_tuple_len(index) == 0)
+        {
+            return Err(crate::PyError::type_error(
+                "invalid indexing of 0-dim memory",
+            ));
+        }
         let count = w_memoryview_native_shape(mv).first().copied().unwrap_or(0);
-        let stride0 = w_memoryview_stride0(mv);
-        let offset = w_memoryview_offset(mv);
-        // Slice assignment writes the rvalue's element bytes through to the
-        // strided positions of the view (`_setitem_slice`).
+        // Slice assignment copies an exporter's elements into the strided
+        // positions the slice names (`copy_single`).
         if pyre_object::is_slice(index) {
             if w_memoryview_ndim(mv) != 1 {
                 return Err(crate::PyError::not_implemented(

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1217,8 +1217,7 @@ fn memoryview_getitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
                 ));
             }
             let itemsize = w_memoryview_itemsize(mv);
-            let length = w_memoryview_length(mv);
-            let mut i = getindex_w(index)?;
+            let i = getindex_w(index)?;
             // memoryobject.py `descr_getitem`: `_decode_index` may invoke a
             // user `__index__` which releases the view.
             memoryview_check_released(mv)?;
@@ -1227,14 +1226,9 @@ fn memoryview_getitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
                     "multi-dimensional sub-views are not implemented",
                 ));
             }
-            let count = if itemsize > 0 { length / itemsize } else { 0 };
-            if i < 0 {
-                i += count;
-            }
-            if i < 0 || i >= count {
-                return Err(crate::PyError::index_error("index out of bounds"));
-            }
-            let base = (w_memoryview_offset(mv) + i * w_memoryview_stride0(mv)) as usize;
+            // `ptr_from_index` -> `lookup_dimension`: the bound is `shape[0]`,
+            // not `length / itemsize`, and the step is `strides[0]`.
+            let base = (w_memoryview_offset(mv) + memoryview_get_offset(mv, 0, i)?) as usize;
             let full = w_memoryview_view(mv).backing().as_bytes();
             let fmt = w_memoryview_format_str(mv);
             return Ok(memoryview_unpack_element(
@@ -1306,11 +1300,7 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
         let itemsize = w_memoryview_itemsize(mv);
         let isz = itemsize.max(0) as usize;
         let fmt = w_memoryview_format_str(mv).to_owned();
-        let count = if itemsize > 0 {
-            w_memoryview_length(mv) / itemsize
-        } else {
-            0
-        };
+        let count = w_memoryview_native_shape(mv).first().copied().unwrap_or(0);
         let stride0 = w_memoryview_stride0(mv);
         let offset = w_memoryview_offset(mv);
         // Slice assignment writes the rvalue's element bytes through to the
@@ -1398,17 +1388,12 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
                 "memoryview: invalid slice key, must be int or slice",
             ));
         }
-        let mut i = getindex_w(index)?;
-        if i < 0 {
-            i += count;
-        }
-        if i < 0 || i >= count {
-            return Err(crate::PyError::index_error("index out of bounds"));
-        }
+        let i = getindex_w(index)?;
+        let item_offset = memoryview_get_offset(mv, 0, i)?;
         let packed = memoryview_pack_value(&fmt, isz, value)?;
         // Re-check release after value coercion (see tuple path above).
         memoryview_check_released(mv)?;
-        let addr = (offset + i * stride0) as usize;
+        let addr = (offset + item_offset) as usize;
         let full = w_memoryview_view(mv)
             .backing()
             .as_bytes_mut()
@@ -1753,9 +1738,9 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
                 .collect::<Result<_, _>>()?;
             let ndim = dims.len() as i64;
             if ndim > 64 {
-                return Err(crate::PyError::value_error(format!(
-                    "memoryview: number of dimensions must not exceed {ndim}"
-                )));
+                return Err(crate::PyError::value_error(
+                    "memoryview: number of dimensions must not exceed 64",
+                ));
             }
             if ndim > 1 && orig_ndim != 1 {
                 return Err(crate::PyError::type_error(
@@ -2398,7 +2383,12 @@ pub(crate) fn memoryview_delitem(args: &[PyObjectRef]) -> Result<PyObjectRef, cr
 
 /// `_IsCContiguous` — C order has the last (fastest) dimension's stride
 /// equal to `itemsize`, growing by the dimension sizes toward the front.
-fn memoryview_is_c_contiguous(shape: &[i64], strides: &[i64], itemsize: i64) -> bool {
+fn memoryview_is_c_contiguous(shape: &[i64], strides: &[i64], itemsize: i64, length: i64) -> bool {
+    // `len == 0` holds exactly when some extent is zero, and such a view is
+    // contiguous in both orders whatever its strides say.
+    if length == 0 {
+        return true;
+    }
     let ndim = shape.len();
     if ndim == 0 {
         return true;
@@ -2408,10 +2398,8 @@ fn memoryview_is_c_contiguous(shape: &[i64], strides: &[i64], itemsize: i64) -> 
     }
     let mut sd = itemsize;
     for i in (0..ndim).rev() {
-        if shape[i] == 0 {
-            return true;
-        }
-        if strides[i] != sd {
+        // A dimension of one element imposes no step, so its stride is free.
+        if shape[i] > 1 && strides[i] != sd {
             return false;
         }
         sd *= shape[i];
@@ -2421,7 +2409,10 @@ fn memoryview_is_c_contiguous(shape: &[i64], strides: &[i64], itemsize: i64) -> 
 
 /// `_IsFortranContiguous` — Fortran order has the first (fastest)
 /// dimension's stride equal to `itemsize`, growing toward the back.
-fn memoryview_is_f_contiguous(shape: &[i64], strides: &[i64], itemsize: i64) -> bool {
+fn memoryview_is_f_contiguous(shape: &[i64], strides: &[i64], itemsize: i64, length: i64) -> bool {
+    if length == 0 {
+        return true;
+    }
     let ndim = shape.len();
     if ndim == 0 {
         return true;
@@ -2431,10 +2422,7 @@ fn memoryview_is_f_contiguous(shape: &[i64], strides: &[i64], itemsize: i64) -> 
     }
     let mut sd = itemsize;
     for i in 0..ndim {
-        if shape[i] == 0 {
-            return true;
-        }
-        if strides[i] != sd {
+        if shape[i] > 1 && strides[i] != sd {
             return false;
         }
         sd *= shape[i];
@@ -2452,11 +2440,12 @@ pub(crate) unsafe fn memoryview_contiguity(mv: PyObjectRef) -> (bool, bool) {
             return (true, true);
         }
         let itemsize = w_memoryview_itemsize(mv);
+        let length = w_memoryview_length(mv);
         let shape = w_memoryview_native_shape(mv);
         let strides = w_memoryview_native_strides(mv);
         (
-            memoryview_is_c_contiguous(&shape, &strides, itemsize),
-            memoryview_is_f_contiguous(&shape, &strides, itemsize),
+            memoryview_is_c_contiguous(&shape, &strides, itemsize, length),
+            memoryview_is_f_contiguous(&shape, &strides, itemsize, length),
         )
     }
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1081,22 +1081,26 @@ fn memoryview_is_byte_format(fmt: &str) -> bool {
     matches!(memoryview_format_code(fmt), b'b' | b'B' | b'c')
 }
 
-/// `get_native_fmtchar` — the native byte width of a single-character
-/// format (`x` or `@x`), or `None` for an unrecognised / non-native one.
-fn memoryview_native_fmtchar(fmt: &str) -> Option<i64> {
+/// `get_native_fmtchar` — the single-character format (`x` or `@x`) `fmt`
+/// names and its native byte width, or `None` for an unrecognised or
+/// non-native one.
+fn memoryview_native_fmtchar(fmt: &str) -> Option<(u8, i64)> {
     let b = fmt.as_bytes();
     let f = match b.first()? {
         b'@' if b.len() == 2 => b[1],
         _ if b.len() == 1 => b[0],
         _ => return None,
     };
-    Some(match f {
-        b'c' | b'b' | b'B' | b'?' => 1,
-        b'h' | b'H' | b'e' => 2,
-        b'i' | b'I' | b'f' => 4,
-        b'l' | b'L' | b'q' | b'Q' | b'n' | b'N' | b'd' | b'P' => 8,
-        _ => return None,
-    })
+    Some((
+        f,
+        match f {
+            b'c' | b'b' | b'B' | b'?' => 1,
+            b'h' | b'H' | b'e' => 2,
+            b'i' | b'I' | b'f' => 4,
+            b'l' | b'L' | b'q' | b'Q' | b'n' | b'N' | b'd' | b'P' => 8,
+            _ => return None,
+        },
+    ))
 }
 
 /// `_strides_from_shape` — C-contiguous strides for `shape`: the last
@@ -1769,7 +1773,7 @@ fn memoryview_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             }
         }
         // _cast_to_1D: a native single-character destination format.
-        let Some(new_itemsize) = memoryview_native_fmtchar(&fmt) else {
+        let Some((_, new_itemsize)) = memoryview_native_fmtchar(&fmt) else {
             return Err(crate::PyError::value_error(
                 "memoryview: destination format must be a native single \
                  character format prefixed with an optional '@'",
@@ -2197,6 +2201,51 @@ unsafe fn memoryview_released_either(mv: PyObjectRef, other: PyObjectRef) -> boo
     }
 }
 
+/// One item as the value `unpack_cmp` compares it by.
+///
+/// # Safety
+/// `data[base..base + itemsize]` must be in bounds.
+unsafe fn memoryview_unpack_compared(
+    native: bool,
+    fmt: &str,
+    data: &[u8],
+    base: usize,
+    itemsize: usize,
+) -> Result<PyObjectRef, crate::PyError> {
+    unsafe {
+        match native {
+            true => Ok(memoryview_unpack_element(fmt, data, base, itemsize)),
+            false => crate::module::r#struct::unpack_single(fmt, &data[base..base + itemsize]),
+        }
+    }
+}
+
+/// `equiv_shape` — equal dimensionality and equal extents, stopping at the
+/// first extent that is zero.  A dimension with no elements makes every
+/// dimension inside it unobservable, so `[0, 3]` and `[0, 5]` describe the
+/// same (empty) element set.
+///
+/// # Safety
+/// Both arguments must be live, unreleased memoryviews.
+unsafe fn memoryview_equiv_shape(lhs: PyObjectRef, rhs: PyObjectRef) -> bool {
+    unsafe {
+        use pyre_object::memoryview::*;
+        if w_memoryview_ndim(lhs) != w_memoryview_ndim(rhs) {
+            return false;
+        }
+        let rhs = w_memoryview_native_shape(rhs);
+        for (&extent, &other) in w_memoryview_native_shape(lhs).iter().zip(&rhs) {
+            if extent != other {
+                return false;
+            }
+            if extent == 0 {
+                break;
+            }
+        }
+        true
+    }
+}
+
 /// Python 3.14 `memory_richcompare`: equality first requires equivalent
 /// shapes, then compares unpacked element values.  Raw bytes are deliberately
 /// insufficient (`int(1)` and `float(1.0)` compare equal despite different
@@ -2227,11 +2276,7 @@ fn memoryview_compare_eq(args: &[PyObjectRef], name: &str) -> Result<Option<bool
         };
         let lhs = pyre_object::gc_roots::shadow_stack_get(base);
         let comparison = (|| -> Result<bool, crate::PyError> {
-            if pyre_object::memoryview::w_memoryview_ndim(lhs)
-                != pyre_object::memoryview::w_memoryview_ndim(rhs)
-                || pyre_object::memoryview::w_memoryview_native_shape(lhs)
-                    != pyre_object::memoryview::w_memoryview_native_shape(rhs)
-            {
+            if !memoryview_equiv_shape(lhs, rhs) {
                 return Ok(false);
             }
             let lhs_data = memoryview_gather_bytes(lhs);
@@ -2247,21 +2292,36 @@ fn memoryview_compare_eq(args: &[PyObjectRef], name: &str) -> Result<Option<bool
             }
             let lhs_fmt = pyre_object::memoryview::w_memoryview_format_str(lhs);
             let rhs_fmt = pyre_object::memoryview::w_memoryview_format_str(rhs);
+            // `get_native_fmtchar`: only one single-code native format shared
+            // by both sides decodes as a C value.  Anything else — a byte
+            // order prefix, several members, a repeat count — is unpacked by
+            // the struct module, and a format it cannot parse leaves the two
+            // views unequal rather than raising (`fix_struct_error_int`).
+            let code_of = |fmt| memoryview_native_fmtchar(fmt).map(|(code, _)| code);
+            let native = code_of(lhs_fmt).is_some_and(|code| Some(code) == code_of(rhs_fmt));
+            if !native
+                && !(crate::module::r#struct::format_is_supported(lhs_fmt)
+                    && crate::module::r#struct::format_is_supported(rhs_fmt))
+            {
+                return Ok(false);
+            }
             for index in 0..count {
                 let _values = pyre_object::gc_roots::push_roots();
                 let values = pyre_object::gc_roots::shadow_stack_len();
-                let _ = pyre_object::gc_roots::pin_root(memoryview_unpack_element(
+                let _ = pyre_object::gc_roots::pin_root(memoryview_unpack_compared(
+                    native,
                     lhs_fmt,
                     &lhs_data,
                     index * lhs_size,
                     lhs_size,
-                ));
-                let _ = pyre_object::gc_roots::pin_root(memoryview_unpack_element(
+                )?);
+                let _ = pyre_object::gc_roots::pin_root(memoryview_unpack_compared(
+                    native,
                     rhs_fmt,
                     &rhs_data,
                     index * rhs_size,
                     rhs_size,
-                ));
+                )?);
                 if !crate::baseobjspace::eq_w(
                     pyre_object::gc_roots::shadow_stack_get(values),
                     pyre_object::gc_roots::shadow_stack_get(values + 1),

--- a/pyre/pyre-interpreter/src/cpyext/buffer.rs
+++ b/pyre/pyre-interpreter/src/cpyext/buffer.rs
@@ -40,6 +40,7 @@ const PY_BUF_STRIDES: c_int = 0x0010 | PY_BUF_ND;
 const PY_BUF_C_CONTIGUOUS: c_int = 0x0020 | PY_BUF_STRIDES;
 const PY_BUF_F_CONTIGUOUS: c_int = 0x0040 | PY_BUF_STRIDES;
 const PY_BUF_ANY_CONTIGUOUS: c_int = 0x0080 | PY_BUF_STRIDES;
+const PY_BUF_INDIRECT: c_int = 0x0100 | PY_BUF_STRIDES;
 /// `PyBUF_MAX_NDIM` — the dimension count a `Py_buffer` may declare.
 const PY_BUF_MAX_NDIM: i64 = 64;
 const PY_BUF_READ: c_int = 0x100;
@@ -294,12 +295,7 @@ fn acquire(
         release_c_view(view);
         Err(crate::PyError::new(kind, message.to_string()))
     };
-    if unsafe { !(*view).suboffsets.is_null() } {
-        return refuse(
-            crate::PyErrorKind::BufferError,
-            "cpyext: a buffer export with suboffsets is not supported",
-        );
-    }
+    let suboffsets = dims(unsafe { (*view).suboffsets }, ndim);
     if ndim > PY_BUF_MAX_NDIM {
         return refuse(
             crate::PyErrorKind::ValueError,
@@ -318,56 +314,115 @@ fn acquire(
     let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
     let r_obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
-    // The contiguous one-dimensional shape a `RawBufferView` describes, which
-    // is exactly the set this layer accepted before it carried geometry of
-    // its own; everything else rides on its own vectors.
-    let flat = ndim == 1
-        && strides.first() == Some(&itemsize)
-        && shape.first().copied().unwrap_or(0) * itemsize == length;
-    let built = if flat {
-        BufferView::Raw {
-            backing: Buffer::External {
-                w_obj: r_obj,
-                address,
-                size: length as usize,
-                readonly,
-            },
-            w_obj: r_obj,
-            w_fmt: reload(0),
-            itemsize,
+    let built = carrier_for(
+        Geometry {
+            address,
             length,
-        }
-    } else {
-        // A zero-dimensional export addresses one element, but `len` is the
-        // extent its exporter published and the storage behind it is
-        // contiguous, so the window is `len` bytes from `buf`.
-        let (low, high) = if ndim == 0 {
-            (0, length)
-        } else {
-            pyre_object::bufferview::addressable_window(&shape, &strides, itemsize)
-        };
-        BufferView::CBuffer {
-            backing: Buffer::External {
-                w_obj: r_obj,
-                address: (address as isize + low as isize) as usize,
-                size: (high - low).max(0) as usize,
-                readonly,
-            },
-            w_obj: r_obj,
-            w_fmt: reload(0),
             itemsize,
-            length,
+            readonly,
             ndim,
-            offset: -low,
             shape,
             strides,
-            suboffsets: Vec::new(),
-        }
-    };
+            suboffsets,
+        },
+        r_obj,
+        reload(0),
+    );
     let carrier = pyre_object::memoryview::bufferview_alloc(built);
     unsafe { pyre_object::memoryview::w_memoryview_set_view(mv, carrier) };
     record_export(carrier as usize, view);
     Ok(mv)
+}
+
+/// The geometry words a filled `Py_buffer` carries, read once.
+struct Geometry {
+    address: usize,
+    length: i64,
+    itemsize: i64,
+    readonly: bool,
+    ndim: i64,
+    shape: Vec<i64>,
+    strides: Vec<i64>,
+    suboffsets: Vec<i64>,
+}
+
+/// The view a filled `Py_buffer`'s geometry describes.
+///
+/// A one-dimensional export stepping by `itemsize` over exactly its own
+/// length is the shape a `RawBufferView` covers, and is exactly the set this
+/// layer accepted before it carried geometry of its own.  Everything else
+/// rides on its own vectors as a `CPyBuffer`.
+fn carrier_for(
+    geometry: Geometry,
+    w_obj: PyObjectRef,
+    w_fmt: PyObjectRef,
+) -> pyre_object::bufferview::BufferView {
+    use pyre_object::buffer::Buffer;
+    use pyre_object::bufferview::BufferView;
+    let Geometry {
+        address,
+        length,
+        itemsize,
+        readonly,
+        ndim,
+        shape,
+        strides,
+        suboffsets,
+    } = geometry;
+    if ndim == 1
+        && suboffsets.is_empty()
+        && strides.first() == Some(&itemsize)
+        && shape.first().copied().unwrap_or(0) * itemsize == length
+    {
+        return BufferView::Raw {
+            backing: Buffer::External {
+                w_obj,
+                address,
+                size: length.max(0) as usize,
+                readonly,
+            },
+            w_obj,
+            w_fmt,
+            itemsize,
+            length,
+        };
+    }
+    // A zero-dimensional export addresses one element, but `len` is the
+    // extent its exporter published and the storage behind it is contiguous,
+    // so the window is `len` bytes from `buf`.
+    //
+    // An indirect export's storage reaches only as far as the first dimension
+    // whose suboffset dereferences: past that the addresses come from the
+    // exporter's own pointers and no window describes them.  The elements up
+    // to and including that dimension are those pointers, so the window is
+    // measured in pointer widths.
+    let indirect = suboffsets.iter().position(|&suboffset| suboffset >= 0);
+    let (low, high) = match (ndim, indirect) {
+        (0, _) => (0, length),
+        (_, Some(dim)) => pyre_object::bufferview::addressable_window(
+            &shape[..=dim],
+            &strides[..=dim],
+            std::mem::size_of::<*const u8>() as i64,
+        ),
+        (_, None) => pyre_object::bufferview::addressable_window(&shape, &strides, itemsize),
+    };
+    BufferView::CBuffer {
+        backing: Buffer::External {
+            w_obj,
+            address: (address as isize + low as isize) as usize,
+            size: (high - low).max(0) as usize,
+            readonly,
+        },
+        w_obj,
+        w_fmt,
+        itemsize,
+        length,
+        ndim,
+        offset: -low,
+        shape,
+        strides,
+        suboffsets,
+    }
 }
 
 /// Run `bf_releasebuffer` for a structure this layer allocated, drop the
@@ -458,6 +513,7 @@ struct Export {
     format: Vec<u8>,
     shape: Vec<isize>,
     strides: Vec<isize>,
+    suboffsets: Vec<isize>,
 }
 
 /// The live [`Export`] blocks, so a release frees one this layer wrote and
@@ -469,8 +525,12 @@ static GEOMETRIES: super::ForkMutex<BufferSet> =
 /// anything -- `memory_getbuf`'s contiguity checks, in its order.
 ///
 /// `contiguous` is whether the export is contiguous in C and in Fortran
-/// order.
-fn contiguity_refusal(flags: c_int, contiguous: (bool, bool)) -> Option<&'static str> {
+/// order, and `indirect` whether any of its dimensions carries a suboffset.
+fn contiguity_refusal(
+    flags: c_int,
+    contiguous: (bool, bool),
+    indirect: bool,
+) -> Option<&'static str> {
     let requires = |mask| flags & mask == mask;
     let (c_order, fortran) = contiguous;
     if requires(PY_BUF_C_CONTIGUOUS) && !c_order {
@@ -482,12 +542,22 @@ fn contiguity_refusal(flags: c_int, contiguous: (bool, bool)) -> Option<&'static
     if requires(PY_BUF_ANY_CONTIGUOUS) && !(c_order || fortran) {
         return Some("memoryview: underlying buffer is not contiguous");
     }
+    // A request that does not ask to follow pointers cannot read a view whose
+    // elements are behind them.
+    if !requires(PY_BUF_INDIRECT) && indirect {
+        return Some("memoryview: underlying buffer requires suboffsets");
+    }
     // A request with no strides in it reads the address as one contiguous
     // run, which a strided export is not.
-    match requires(PY_BUF_STRIDES) || c_order {
-        true => None,
-        false => Some("memoryview: underlying buffer is not C-contiguous"),
+    if !requires(PY_BUF_STRIDES) && !c_order {
+        return Some("memoryview: underlying buffer is not C-contiguous");
     }
+    // A request with no shape in it reads the bytes as unsigned chars, which
+    // leaves nothing for a format to describe.
+    if !requires(PY_BUF_ND) && requires(PY_BUF_FORMAT) {
+        return Some("memoryview: cannot cast to unsigned bytes if the format flag is present");
+    }
+    None
 }
 
 /// `slotdefs.py slot_from_buffer_w` -- the `bf_getbuffer` of a type this
@@ -519,7 +589,10 @@ pub(super) unsafe extern "C" fn interp_bf_getbuffer(
     let _ = roots.pin_root(w_view);
     let reload = |slot| pyre_object::gc_roots::shadow_stack_get(slot);
     let contiguous = unsafe { crate::builtins::memoryview_contiguity(reload(view_slot)) };
-    if let Some(message) = contiguity_refusal(flags, contiguous) {
+    let indirect = unsafe {
+        !pyre_object::memoryview::w_memoryview_native_suboffsets(reload(view_slot)).is_empty()
+    };
+    if let Some(message) = contiguity_refusal(flags, contiguous, indirect) {
         release_acquired(reload(view_slot));
         super::pyerrors::set_pending_error(crate::PyError::new(
             crate::PyErrorKind::BufferError,
@@ -539,6 +612,7 @@ pub(super) unsafe extern "C" fn interp_bf_getbuffer(
         format,
         shape: widen(unsafe { carrier.native_shape() }),
         strides: widen(unsafe { carrier.native_strides() }),
+        suboffsets: widen(unsafe { carrier.native_suboffsets() }),
     });
     // The exporter's own storage, which the collector does not move: the
     // address stays the one C was handed for as long as the export is open.
@@ -552,7 +626,12 @@ pub(super) unsafe extern "C" fn interp_bf_getbuffer(
         (*view).len = carrier.length() as isize;
         (*view).itemsize = carrier.itemsize() as isize;
         (*view).readonly = carrier.readonly() as c_int;
-        (*view).ndim = carrier.ndim() as c_int;
+        // `memory_getbuf`: a request with no shape in it reads the whole
+        // export as one run of unsigned chars, whatever its own rank.
+        (*view).ndim = match flags & PY_BUF_ND == PY_BUF_ND {
+            true => carrier.ndim() as c_int,
+            false => 1,
+        };
         (*view).format = match flags & PY_BUF_FORMAT == PY_BUF_FORMAT {
             true => export.format.as_mut_ptr() as *mut c_char,
             false => std::ptr::null_mut(),
@@ -565,7 +644,12 @@ pub(super) unsafe extern "C" fn interp_bf_getbuffer(
             true => export.strides.as_mut_ptr(),
             false => std::ptr::null_mut(),
         };
-        (*view).suboffsets = std::ptr::null_mut();
+        (*view).suboffsets = match !export.suboffsets.is_empty()
+            && flags & PY_BUF_INDIRECT == PY_BUF_INDIRECT
+        {
+            true => export.suboffsets.as_mut_ptr(),
+            false => std::ptr::null_mut(),
+        };
         (*view).internal = Box::into_raw(export) as *mut c_void;
         GEOMETRIES.lock().insert((*view).internal as usize);
     }
@@ -840,15 +924,6 @@ pub unsafe extern "C" fn PyBuffer_SizeFromFormat(format: *const c_char) -> isize
 
 // ── the strided copies ──────────────────────────────────────────────────
 
-/// The byte offset of `indices` within `view`.
-fn offset_of(strides: &[i64], indices: &[i64]) -> isize {
-    strides
-        .iter()
-        .zip(indices)
-        .map(|(stride, index)| stride * index)
-        .sum::<i64>() as isize
-}
-
 /// Step `indices` one element in C order (`order == b'C'`) or Fortran order,
 /// answering `false` once the walk is over.
 fn advance(indices: &mut [i64], shape: &[i64], order: u8) -> bool {
@@ -867,33 +942,60 @@ fn advance(indices: &mut [i64], shape: &[i64], order: u8) -> bool {
     false
 }
 
-/// The `(shape, strides, itemsize, total)` a filled `Py_buffer` describes.
+/// The `(shape, strides, suboffsets, itemsize, total)` a filled `Py_buffer`
+/// describes.  An empty `suboffsets` is NULL.
 ///
 /// # Safety
-/// `view` must point at a filled `Py_buffer` with no suboffsets.
-unsafe fn geometry(view: *const CPyBuffer) -> (Vec<i64>, Vec<i64>, i64, i64) {
+/// `view` must point at a filled `Py_buffer`.
+unsafe fn geometry(view: *const CPyBuffer) -> (Vec<i64>, Vec<i64>, Vec<i64>, i64, i64) {
     let ndim = unsafe { (*view).ndim } as i64;
     let itemsize = unsafe { (*view).itemsize } as i64;
     let length = unsafe { (*view).len } as i64;
     let (shape, strides) = unsafe { shape_and_strides(view, ndim, itemsize, length) };
-    (shape, strides, itemsize, length)
+    let suboffsets = dims(unsafe { (*view).suboffsets }, ndim);
+    (shape, strides, suboffsets, itemsize, length)
+}
+
+/// `PyBuffer_GetPointer`'s per-axis chain: advance by each dimension's stride
+/// and follow the pointer a non-negative suboffset names.
+///
+/// # Safety
+/// `view` must point at a filled `Py_buffer`, and `indices` must name one
+/// in-bounds index per dimension.
+unsafe fn element_of(view: *const CPyBuffer, indices: &[i64]) -> *mut u8 {
+    let strides = unsafe { (*view).strides };
+    let suboffsets = unsafe { (*view).suboffsets };
+    let mut pointer = unsafe { (*view).buf } as *mut u8;
+    for (axis, &index) in indices.iter().enumerate() {
+        let stride = match strides.is_null() {
+            true => 0,
+            false => unsafe { *strides.add(axis) as i64 },
+        };
+        pointer = unsafe { pointer.offset((stride * index) as isize) };
+        if !suboffsets.is_null() {
+            let suboffset = unsafe { *suboffsets.add(axis) };
+            if suboffset >= 0 {
+                pointer = unsafe { (*(pointer as *mut *mut u8)).offset(suboffset) };
+            }
+        }
+    }
+    pointer
 }
 
 /// Walk every element of `view` in `order`, handing each element's address and
 /// its position in the contiguous block to `visit`.
 ///
 /// # Safety
-/// `view` must point at a filled `Py_buffer` with no suboffsets.
+/// `view` must point at a filled `Py_buffer`.
 unsafe fn walk(view: *const CPyBuffer, order: u8, mut visit: impl FnMut(*mut u8, usize, usize)) {
-    let (shape, strides, itemsize, _) = unsafe { geometry(view) };
+    let (shape, _, _, itemsize, _) = unsafe { geometry(view) };
     if shape.iter().any(|&extent| extent <= 0) {
         return;
     }
-    let base = unsafe { (*view).buf } as *mut u8;
     let mut indices = vec![0i64; shape.len()];
     let mut position = 0usize;
     loop {
-        let element = unsafe { base.offset(offset_of(&strides, &indices)) };
+        let element = unsafe { element_of(view, &indices) };
         visit(element, position, itemsize as usize);
         position += itemsize as usize;
         if !advance(&mut indices, &shape, order) {
@@ -907,20 +1009,11 @@ pub unsafe extern "C" fn PyBuffer_GetPointer(
     view: *const CPyBuffer,
     indices: *const isize,
 ) -> *mut c_void {
-    let (_, strides, _, _) = unsafe { geometry(view) };
-    let mut pointer = unsafe { (*view).buf } as *mut u8;
-    for (axis, stride) in strides.iter().enumerate() {
-        let index = unsafe { *indices.add(axis) } as i64;
-        pointer = unsafe { pointer.offset((stride * index) as isize) };
-        let suboffsets = unsafe { (*view).suboffsets };
-        if !suboffsets.is_null() {
-            let suboffset = unsafe { *suboffsets.add(axis) };
-            if suboffset >= 0 {
-                pointer = unsafe { (*(pointer as *mut *mut u8)).offset(suboffset) };
-            }
-        }
-    }
-    pointer as *mut c_void
+    let ndim = unsafe { (*view).ndim } as usize;
+    let named: Vec<i64> = (0..ndim)
+        .map(|axis| unsafe { *indices.add(axis) } as i64)
+        .collect();
+    unsafe { element_of(view, &named) as *mut c_void }
 }
 
 #[unsafe(no_mangle)]
@@ -1153,34 +1246,49 @@ pub unsafe extern "C" fn PyMemoryView_FromMemory(
 /// `PyMemoryView_FromBuffer` — the caller hands its filled `Py_buffer` over and
 /// must not release it itself.
 ///
-/// TODO: upstream copies `ndim`, `shape` and `strides` across, and this takes
-/// only a contiguous one-dimensional view.  Nothing measures the gap: the
-/// class that would, `test_buffer`'s `TestBufferProtocol`, is
-/// `skipUnless(ndarray)` and there is no `_testbuffer` to import it from, so
-/// building `lib_pypy/_testbuffer.c` comes before lifting the restriction.
+/// The handed-over structure's `obj` is a borrowed reference that must not be
+/// decremented, so the view carries no exporter and records no export: it
+/// keeps only the geometry and the address.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyMemoryView_FromBuffer(view: *const CPyBuffer) -> *mut CPyObject {
-    if view.is_null() || unsafe { (*view).buf.is_null() } {
+    if view.is_null() {
         unsafe { super::pyerrors::PyErr_BadInternalCall() };
         return std::ptr::null_mut();
     }
-    let (_, strides, itemsize, length) = unsafe { geometry(view) };
-    let ndim = unsafe { (*view).ndim };
-    if ndim > 1 || (ndim == 1 && strides.first() != Some(&itemsize)) {
+    if unsafe { (*view).buf.is_null() } {
+        super::pyerrors::set_pending_error(crate::PyError::value_error(
+            "PyMemoryView_FromBuffer(): info->buf must not be NULL",
+        ));
+        return std::ptr::null_mut();
+    }
+    let (shape, strides, suboffsets, itemsize, length) = unsafe { geometry(view) };
+    let ndim = unsafe { (*view).ndim } as i64;
+    if ndim > PY_BUF_MAX_NDIM {
+        super::pyerrors::set_pending_error(crate::PyError::value_error(
+            "memoryview: number of dimensions must not exceed 64",
+        ));
+        return std::ptr::null_mut();
+    }
+    if shape.len() as i64 != ndim || strides.len() as i64 != ndim {
         super::pyerrors::set_pending_error(crate::PyError::new(
             crate::PyErrorKind::BufferError,
-            "cpyext: only a contiguous one-dimensional Py_buffer becomes a memoryview",
+            "cpyext: a multi-dimensional buffer export must carry a shape",
         ));
         return std::ptr::null_mut();
     }
     let format = format_of(unsafe { (*view).format });
-    let readonly = unsafe { (*view).readonly } != 0;
-    result(Ok(unowned_view(
-        unsafe { (*view).buf } as usize,
-        length,
-        itemsize,
+    result(Ok(unowned_view_nd(
+        Geometry {
+            address: unsafe { (*view).buf } as usize,
+            length,
+            itemsize,
+            readonly: unsafe { (*view).readonly } != 0,
+            ndim,
+            shape,
+            strides,
+            suboffsets,
+        },
         &format,
-        readonly,
     )))
 }
 
@@ -1230,9 +1338,11 @@ pub unsafe extern "C" fn PyMemoryView_GetContiguous(
     }
     let shape = unsafe { view.native_shape() };
     let strides = unsafe { view.native_strides() };
-    let laid_out = contiguous_in(order, &shape, &strides, view.itemsize(), unsafe {
-        view.length()
-    });
+    let indirect = !unsafe { view.native_suboffsets() }.is_empty();
+    let laid_out = !indirect
+        && contiguous_in(order, &shape, &strides, view.itemsize(), unsafe {
+            view.length()
+        });
     if laid_out {
         return pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(slot));
     }
@@ -1242,10 +1352,51 @@ pub unsafe extern "C" fn PyMemoryView_GetContiguous(
             "writable contiguous buffer requested for a non-contiguous object.",
         );
     }
-    refuse(
-        crate::PyErrorKind::NotImplementedError,
-        "creating contiguous readonly buffer from non-contiguous not implemented yet",
-    )
+    // `memory_from_contiguous_copy` — the bytes laid out in `order`, kept in a
+    // `bytes` object so the copy is collected with the view, carrying the
+    // source's format, itemsize and shape with the steps that layout implies.
+    let itemsize = view.itemsize();
+    let fortran = order as u8 == b'F';
+    let format = unsafe { view.format_str() }.to_owned();
+    let block = unsafe { view.gather_order(fortran) };
+    let copy_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(pyre_object::bytesobject::w_bytes_from_bytes(&block));
+    let fmt_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(pyre_object::w_str_new(&format));
+    let copy = pyre_object::gc_roots::shadow_stack_get(copy_slot);
+    let w_fmt = pyre_object::gc_roots::shadow_stack_get(fmt_slot);
+    let out = pyre_object::memoryview::w_memoryview_alloc_header(false, false);
+    let backing = pyre_object::buffer::Buffer::String { w_obj: copy };
+    let length = block.len() as i64;
+    let built = if shape.len() <= 1 {
+        pyre_object::bufferview::BufferView::Raw {
+            backing,
+            w_obj: copy,
+            w_fmt,
+            itemsize,
+            length,
+        }
+    } else {
+        pyre_object::bufferview::BufferView::CBuffer {
+            backing,
+            w_obj: copy,
+            w_fmt,
+            itemsize,
+            length,
+            ndim: shape.len() as i64,
+            offset: 0,
+            strides: pyre_object::bufferview::contiguous_strides(&shape, itemsize, fortran),
+            shape,
+            suboffsets: Vec::new(),
+        }
+    };
+    unsafe {
+        pyre_object::memoryview::w_memoryview_set_view(
+            out,
+            pyre_object::memoryview::bufferview_alloc(built),
+        )
+    };
+    pyobject::make_ref(out)
 }
 
 fn unowned_view(
@@ -1274,6 +1425,27 @@ fn unowned_view(
         itemsize,
         length,
     };
+    unsafe {
+        pyre_object::memoryview::w_memoryview_set_view(
+            mv,
+            pyre_object::memoryview::bufferview_alloc(built),
+        )
+    };
+    mv
+}
+
+/// The [`unowned_view`] sibling for a view that carries geometry of its own.
+fn unowned_view_nd(geometry: Geometry, format: &str) -> PyObjectRef {
+    let roots = pyre_object::gc_roots::push_roots();
+    let fmt_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(pyre_object::w_str_new(format));
+    let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, false);
+    let w_obj = pyre_object::w_none();
+    let built = carrier_for(
+        geometry,
+        w_obj,
+        pyre_object::gc_roots::shadow_stack_get(fmt_slot),
+    );
     unsafe {
         pyre_object::memoryview::w_memoryview_set_view(
             mv,

--- a/pyre/pyre-interpreter/src/cpyext/buffer.rs
+++ b/pyre/pyre-interpreter/src/cpyext/buffer.rs
@@ -147,7 +147,12 @@ fn dims(pointer: *const isize, ndim: i64, derived: &[i64]) -> Vec<i64> {
 }
 
 /// `_IsCContiguous`.
-fn c_contiguous(shape: &[i64], strides: &[i64], itemsize: i64) -> bool {
+fn c_contiguous(shape: &[i64], strides: &[i64], itemsize: i64, length: i64) -> bool {
+    // `len == 0` holds exactly when some extent is zero; such a view is
+    // contiguous in both orders whatever its strides say.
+    if length == 0 {
+        return true;
+    }
     let mut expected = itemsize;
     for (&extent, &stride) in shape.iter().zip(strides).rev() {
         if extent > 1 && stride != expected {
@@ -159,7 +164,10 @@ fn c_contiguous(shape: &[i64], strides: &[i64], itemsize: i64) -> bool {
 }
 
 /// `_IsFortranContiguous`.
-fn fortran_contiguous(shape: &[i64], strides: &[i64], itemsize: i64) -> bool {
+fn fortran_contiguous(shape: &[i64], strides: &[i64], itemsize: i64, length: i64) -> bool {
+    if length == 0 {
+        return true;
+    }
     let mut expected = itemsize;
     for (&extent, &stride) in shape.iter().zip(strides) {
         if extent > 1 && stride != expected {
@@ -256,7 +264,7 @@ fn acquire(
     if unsafe { !(*view).suboffsets.is_null() } {
         return refuse("cpyext: a buffer export with suboffsets is not supported");
     }
-    if ndim > 1 && !c_contiguous(&shape, &strides, itemsize) {
+    if ndim > 1 && !c_contiguous(&shape, &strides, itemsize, length) {
         return refuse("cpyext: a multi-dimensional buffer export must be C-contiguous");
     }
     if ndim == 1 && strides.first() != Some(&itemsize) {
@@ -736,18 +744,25 @@ pub unsafe extern "C" fn PyBuffer_IsContiguous(view: *const CPyBuffer, order: c_
     let elements = if itemsize > 0 { length / itemsize } else { 0 };
     let shape = dims(unsafe { (*view).shape }, ndim, &[elements]);
     let strides = dims(unsafe { (*view).strides }, ndim, &[itemsize]);
-    contiguous_in(order, &shape, &strides, itemsize) as c_int
+    contiguous_in(order, &shape, &strides, itemsize, length) as c_int
 }
 
 /// Whether the geometry is contiguous in `order`, which is `'C'`, `'F'`ortran
 /// or `'A'`ny of the two.  An order that is none of those is not contiguous:
 /// the entry points that reject one do so before asking.
-fn contiguous_in(order: c_char, shape: &[i64], strides: &[i64], itemsize: i64) -> bool {
+fn contiguous_in(
+    order: c_char,
+    shape: &[i64],
+    strides: &[i64],
+    itemsize: i64,
+    length: i64,
+) -> bool {
     match order as u8 {
-        b'C' => c_contiguous(shape, strides, itemsize),
-        b'F' => fortran_contiguous(shape, strides, itemsize),
+        b'C' => c_contiguous(shape, strides, itemsize, length),
+        b'F' => fortran_contiguous(shape, strides, itemsize, length),
         b'A' => {
-            c_contiguous(shape, strides, itemsize) || fortran_contiguous(shape, strides, itemsize)
+            c_contiguous(shape, strides, itemsize, length)
+                || fortran_contiguous(shape, strides, itemsize, length)
         }
         _ => false,
     }
@@ -1171,7 +1186,9 @@ pub unsafe extern "C" fn PyMemoryView_GetContiguous(
     }
     let shape = unsafe { view.native_shape() };
     let strides = unsafe { view.native_strides() };
-    let laid_out = contiguous_in(order, &shape, &strides, view.itemsize());
+    let laid_out = contiguous_in(order, &shape, &strides, view.itemsize(), unsafe {
+        view.length()
+    });
     if laid_out {
         return pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(slot));
     }

--- a/pyre/pyre-interpreter/src/cpyext/buffer.rs
+++ b/pyre/pyre-interpreter/src/cpyext/buffer.rs
@@ -40,6 +40,8 @@ const PY_BUF_STRIDES: c_int = 0x0010 | PY_BUF_ND;
 const PY_BUF_C_CONTIGUOUS: c_int = 0x0020 | PY_BUF_STRIDES;
 const PY_BUF_F_CONTIGUOUS: c_int = 0x0040 | PY_BUF_STRIDES;
 const PY_BUF_ANY_CONTIGUOUS: c_int = 0x0080 | PY_BUF_STRIDES;
+/// `PyBUF_MAX_NDIM` — the dimension count a `Py_buffer` may declare.
+const PY_BUF_MAX_NDIM: i64 = 64;
 const PY_BUF_READ: c_int = 0x100;
 const PY_BUF_WRITE: c_int = 0x200;
 
@@ -130,20 +132,56 @@ fn format_of(format: *const c_char) -> String {
         .into_owned()
 }
 
-/// One dimension vector, or the derived default when the exporter answered a
-/// request that does not ask for it -- `init_shape_strides`.  A zero-dimensional
-/// view has no dimensions, and fabricating one leaves every caller reading an
-/// axis its own index vector does not have.
-fn dims(pointer: *const isize, ndim: i64, derived: &[i64]) -> Vec<i64> {
-    if ndim <= 0 {
+/// One dimension vector as the exporter wrote it, or nothing when it
+/// answered a request that does not ask for one.
+fn dims(pointer: *const isize, ndim: i64) -> Vec<i64> {
+    if ndim <= 0 || pointer.is_null() {
         return Vec::new();
-    }
-    if pointer.is_null() {
-        return derived.to_vec();
     }
     (0..ndim as usize)
         .map(|index| unsafe { *pointer.add(index) } as i64)
         .collect()
+}
+
+/// `init_shape_strides` — the dimension vectors a filled `Py_buffer`
+/// describes, with the ones a request that does not ask for them left NULL
+/// reconstructed.
+///
+/// A zero-dimensional view has no dimensions, and fabricating one leaves
+/// every caller reading an axis its own index vector does not have.  One
+/// dimension derives `[len / itemsize]` and `[itemsize]`.  Beyond that a NULL
+/// `strides` means the C-contiguous layout for `shape`, while a NULL `shape`
+/// describes nothing that can be reconstructed: the vectors come back short
+/// and the caller reports it rather than reading an axis that is not there.
+///
+/// # Safety
+/// `view` must point at a filled `Py_buffer`.
+unsafe fn shape_and_strides(view: *const CPyBuffer, ndim: i64, itemsize: i64, length: i64) -> (Vec<i64>, Vec<i64>) {
+    let (shape_ptr, strides_ptr) = unsafe { ((*view).shape, (*view).strides) };
+    if ndim <= 0 {
+        return (Vec::new(), Vec::new());
+    }
+    if ndim == 1 {
+        let elements = if itemsize > 0 { length / itemsize } else { 0 };
+        let shape = if shape_ptr.is_null() {
+            vec![elements]
+        } else {
+            dims(shape_ptr, 1)
+        };
+        let strides = if strides_ptr.is_null() {
+            vec![itemsize]
+        } else {
+            dims(strides_ptr, 1)
+        };
+        return (shape, strides);
+    }
+    let shape = dims(shape_ptr, ndim);
+    let strides = if strides_ptr.is_null() {
+        crate::builtins::strides_from_shape(&shape, itemsize)
+    } else {
+        dims(strides_ptr, ndim)
+    };
+    (shape, strides)
 }
 
 /// `_IsCContiguous`.
@@ -251,75 +289,85 @@ fn acquire(
         )
     };
     let format = format_of(unsafe { (*view).format });
-    let elements = if itemsize > 0 { length / itemsize } else { 0 };
-    let shape = dims(unsafe { (*view).shape }, ndim, &[elements]);
-    let strides = dims(unsafe { (*view).strides }, ndim, &[itemsize]);
-    let refuse = |message: &str| {
+    let (shape, strides) = unsafe { shape_and_strides(view, ndim, itemsize, length) };
+    let refuse = |kind: crate::PyErrorKind, message: &str| {
         release_c_view(view);
-        Err(crate::PyError::new(
-            crate::PyErrorKind::BufferError,
-            message.to_string(),
-        ))
+        Err(crate::PyError::new(kind, message.to_string()))
     };
     if unsafe { !(*view).suboffsets.is_null() } {
-        return refuse("cpyext: a buffer export with suboffsets is not supported");
+        return refuse(
+            crate::PyErrorKind::BufferError,
+            "cpyext: a buffer export with suboffsets is not supported",
+        );
     }
-    if ndim > 1 && !c_contiguous(&shape, &strides, itemsize, length) {
-        return refuse("cpyext: a multi-dimensional buffer export must be C-contiguous");
+    if ndim > PY_BUF_MAX_NDIM {
+        return refuse(
+            crate::PyErrorKind::ValueError,
+            "memoryview: number of dimensions must not exceed 64",
+        );
     }
-    if ndim == 1 && strides.first() != Some(&itemsize) {
-        return refuse("cpyext: a strided buffer export is not supported");
+    if shape.len() as i64 != ndim || strides.len() as i64 != ndim {
+        return refuse(
+            crate::PyErrorKind::BufferError,
+            "cpyext: a multi-dimensional buffer export must carry a shape",
+        );
     }
 
     let base = pyre_object::gc_roots::shadow_stack_len();
     let _ = roots.pin_root(pyre_object::w_str_new(&format));
-    if ndim != 1 {
-        let _ = roots.pin_root(wrap_dims(&shape));
-        let _ = roots.pin_root(wrap_dims(&strides));
-    }
     let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
     let r_obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
-    let flat = BufferView::Raw {
-        backing: Buffer::External {
+    // The contiguous one-dimensional shape a `RawBufferView` describes, which
+    // is exactly the set this layer accepted before it carried geometry of
+    // its own; everything else rides on its own vectors.
+    let flat = ndim == 1
+        && strides.first() == Some(&itemsize)
+        && shape.first().copied().unwrap_or(0) * itemsize == length;
+    let built = if flat {
+        BufferView::Raw {
+            backing: Buffer::External {
+                w_obj: r_obj,
+                address,
+                size: length as usize,
+                readonly,
+            },
             w_obj: r_obj,
-            address,
-            size: length as usize,
-            readonly,
-        },
-        w_obj: r_obj,
-        w_fmt: reload(0),
-        itemsize,
-        length,
-    };
-    let built = if ndim == 1 {
-        flat
+            w_fmt: reload(0),
+            itemsize,
+            length,
+        }
     } else {
-        BufferView::ViewND {
-            parent: Box::new(flat),
+        // A zero-dimensional export addresses one element, but `len` is the
+        // extent its exporter published and the storage behind it is
+        // contiguous, so the window is `len` bytes from `buf`.
+        let (low, high) = if ndim == 0 {
+            (0, length)
+        } else {
+            pyre_object::bufferview::addressable_window(&shape, &strides, itemsize)
+        };
+        BufferView::CBuffer {
+            backing: Buffer::External {
+                w_obj: r_obj,
+                address: (address as isize + low as isize) as usize,
+                size: (high - low).max(0) as usize,
+                readonly,
+            },
             w_obj: r_obj,
+            w_fmt: reload(0),
+            itemsize,
+            length,
             ndim,
-            w_shape: reload(1),
-            w_strides: reload(2),
+            offset: -low,
+            shape,
+            strides,
+            suboffsets: Vec::new(),
         }
     };
     let carrier = pyre_object::memoryview::bufferview_alloc(built);
     unsafe { pyre_object::memoryview::w_memoryview_set_view(mv, carrier) };
     record_export(carrier as usize, view);
     Ok(mv)
-}
-
-/// A dimension vector as the tuple a `ViewND` rides on.
-fn wrap_dims(dims: &[i64]) -> PyObjectRef {
-    let roots = pyre_object::gc_roots::push_roots();
-    let base = pyre_object::gc_roots::shadow_stack_len();
-    for &extent in dims {
-        let _ = roots.pin_root(pyre_object::w_int_new(extent));
-    }
-    let items = (0..dims.len())
-        .map(|index| pyre_object::gc_roots::shadow_stack_get(base + index))
-        .collect();
-    pyre_object::w_tuple_new(items)
 }
 
 /// Run `bf_releasebuffer` for a structure this layer allocated, drop the
@@ -741,9 +789,7 @@ pub unsafe extern "C" fn PyBuffer_IsContiguous(view: *const CPyBuffer, order: c_
     let ndim = unsafe { (*view).ndim } as i64;
     let itemsize = unsafe { (*view).itemsize } as i64;
     let length = unsafe { (*view).len } as i64;
-    let elements = if itemsize > 0 { length / itemsize } else { 0 };
-    let shape = dims(unsafe { (*view).shape }, ndim, &[elements]);
-    let strides = dims(unsafe { (*view).strides }, ndim, &[itemsize]);
+    let (shape, strides) = unsafe { shape_and_strides(view, ndim, itemsize, length) };
     contiguous_in(order, &shape, &strides, itemsize, length) as c_int
 }
 
@@ -829,9 +875,7 @@ unsafe fn geometry(view: *const CPyBuffer) -> (Vec<i64>, Vec<i64>, i64, i64) {
     let ndim = unsafe { (*view).ndim } as i64;
     let itemsize = unsafe { (*view).itemsize } as i64;
     let length = unsafe { (*view).len } as i64;
-    let elements = if itemsize > 0 { length / itemsize } else { 0 };
-    let shape = dims(unsafe { (*view).shape }, ndim, &[elements]);
-    let strides = dims(unsafe { (*view).strides }, ndim, &[itemsize]);
+    let (shape, strides) = unsafe { shape_and_strides(view, ndim, itemsize, length) };
     (shape, strides, itemsize, length)
 }
 

--- a/pyre/pyre-interpreter/src/cpyext/buffer.rs
+++ b/pyre/pyre-interpreter/src/cpyext/buffer.rs
@@ -1042,6 +1042,15 @@ pub unsafe extern "C" fn PyBuffer_ToContiguous(
         return -1;
     }
     let target = buf as *mut u8;
+    // A view already contiguous in the requested order copies as one run.
+    // This is what 'A' asks for over a Fortran-contiguous source: its own
+    // physical bytes, not the C-order walk below.
+    if unsafe { PyBuffer_IsContiguous(view, order) } != 0 {
+        unsafe {
+            std::ptr::copy_nonoverlapping((*view).buf as *const u8, target, length as usize)
+        };
+        return 0;
+    }
     unsafe {
         walk(view, order as u8, |element, position, itemsize| {
             std::ptr::copy_nonoverlapping(element, target.add(position), itemsize)
@@ -1069,6 +1078,14 @@ pub unsafe extern "C" fn PyBuffer_FromContiguous(
         return -1;
     }
     let source = buf as *const u8;
+    // As in `PyBuffer_ToContiguous`, an already-contiguous destination takes
+    // the whole run at once.
+    if unsafe { PyBuffer_IsContiguous(view, order) } != 0 {
+        unsafe {
+            std::ptr::copy_nonoverlapping(source, (*view).buf as *mut u8, length as usize)
+        };
+        return 0;
+    }
     unsafe {
         walk(view, order as u8, |element, position, itemsize| {
             std::ptr::copy_nonoverlapping(source.add(position), element, itemsize)

--- a/pyre/pyre-interpreter/src/cpyext/buffer.rs
+++ b/pyre/pyre-interpreter/src/cpyext/buffer.rs
@@ -157,7 +157,12 @@ fn dims(pointer: *const isize, ndim: i64) -> Vec<i64> {
 ///
 /// # Safety
 /// `view` must point at a filled `Py_buffer`.
-unsafe fn shape_and_strides(view: *const CPyBuffer, ndim: i64, itemsize: i64, length: i64) -> (Vec<i64>, Vec<i64>) {
+unsafe fn shape_and_strides(
+    view: *const CPyBuffer,
+    ndim: i64,
+    itemsize: i64,
+    length: i64,
+) -> (Vec<i64>, Vec<i64>) {
     let (shape_ptr, strides_ptr) = unsafe { ((*view).shape, (*view).strides) };
     if ndim <= 0 {
         return (Vec::new(), Vec::new());
@@ -644,12 +649,11 @@ pub(super) unsafe extern "C" fn interp_bf_getbuffer(
             true => export.strides.as_mut_ptr(),
             false => std::ptr::null_mut(),
         };
-        (*view).suboffsets = match !export.suboffsets.is_empty()
-            && flags & PY_BUF_INDIRECT == PY_BUF_INDIRECT
-        {
-            true => export.suboffsets.as_mut_ptr(),
-            false => std::ptr::null_mut(),
-        };
+        (*view).suboffsets =
+            match !export.suboffsets.is_empty() && flags & PY_BUF_INDIRECT == PY_BUF_INDIRECT {
+                true => export.suboffsets.as_mut_ptr(),
+                false => std::ptr::null_mut(),
+            };
         (*view).internal = Box::into_raw(export) as *mut c_void;
         GEOMETRIES.lock().insert((*view).internal as usize);
     }
@@ -1046,9 +1050,7 @@ pub unsafe extern "C" fn PyBuffer_ToContiguous(
     // This is what 'A' asks for over a Fortran-contiguous source: its own
     // physical bytes, not the C-order walk below.
     if unsafe { PyBuffer_IsContiguous(view, order) } != 0 {
-        unsafe {
-            std::ptr::copy_nonoverlapping((*view).buf as *const u8, target, length as usize)
-        };
+        unsafe { std::ptr::copy_nonoverlapping((*view).buf as *const u8, target, length as usize) };
         return 0;
     }
     unsafe {
@@ -1081,9 +1083,7 @@ pub unsafe extern "C" fn PyBuffer_FromContiguous(
     // As in `PyBuffer_ToContiguous`, an already-contiguous destination takes
     // the whole run at once.
     if unsafe { PyBuffer_IsContiguous(view, order) } != 0 {
-        unsafe {
-            std::ptr::copy_nonoverlapping(source, (*view).buf as *mut u8, length as usize)
-        };
+        unsafe { std::ptr::copy_nonoverlapping(source, (*view).buf as *mut u8, length as usize) };
         return 0;
     }
     unsafe {

--- a/pyre/pyre-interpreter/src/cpyext/buffer.rs
+++ b/pyre/pyre-interpreter/src/cpyext/buffer.rs
@@ -960,26 +960,39 @@ unsafe fn geometry(view: *const CPyBuffer) -> (Vec<i64>, Vec<i64>, Vec<i64>, i64
 /// and follow the pointer a non-negative suboffset names.
 ///
 /// # Safety
-/// `view` must point at a filled `Py_buffer`, and `indices` must name one
-/// in-bounds index per dimension.
-unsafe fn element_of(view: *const CPyBuffer, indices: &[i64]) -> *mut u8 {
-    let strides = unsafe { (*view).strides };
-    let suboffsets = unsafe { (*view).suboffsets };
-    let mut pointer = unsafe { (*view).buf } as *mut u8;
+/// `base` must address live storage the given geometry describes, and
+/// `indices` must name one in-bounds index per dimension.
+unsafe fn element_at(
+    base: *mut u8,
+    strides: &[i64],
+    suboffsets: &[i64],
+    indices: &[i64],
+) -> *mut u8 {
+    let mut pointer = base;
     for (axis, &index) in indices.iter().enumerate() {
-        let stride = match strides.is_null() {
-            true => 0,
-            false => unsafe { *strides.add(axis) as i64 },
-        };
+        let stride = strides.get(axis).copied().unwrap_or(0);
         pointer = unsafe { pointer.offset((stride * index) as isize) };
-        if !suboffsets.is_null() {
-            let suboffset = unsafe { *suboffsets.add(axis) };
-            if suboffset >= 0 {
-                pointer = unsafe { (*(pointer as *mut *mut u8)).offset(suboffset) };
+        match suboffsets.get(axis).copied() {
+            Some(suboffset) if suboffset >= 0 => {
+                pointer = unsafe { (*(pointer as *mut *mut u8)).offset(suboffset as isize) };
             }
+            _ => {}
         }
     }
     pointer
+}
+
+/// The address of the element `indices` names, over the geometry the view
+/// describes: a request without `PyBUF_STRIDES` leaves `strides` NULL and the
+/// element steps by the C-contiguous strides `init_shape_strides`
+/// reconstructs, not by nothing.
+///
+/// # Safety
+/// `view` must point at a filled `Py_buffer`, and `indices` must already be
+/// bounds-checked against its shape.
+unsafe fn element_of(view: *const CPyBuffer, indices: &[i64]) -> *mut u8 {
+    let (_, strides, suboffsets, _, _) = unsafe { geometry(view) };
+    unsafe { element_at((*view).buf as *mut u8, &strides, &suboffsets, indices) }
 }
 
 /// Walk every element of `view` in `order`, handing each element's address and
@@ -988,14 +1001,15 @@ unsafe fn element_of(view: *const CPyBuffer, indices: &[i64]) -> *mut u8 {
 /// # Safety
 /// `view` must point at a filled `Py_buffer`.
 unsafe fn walk(view: *const CPyBuffer, order: u8, mut visit: impl FnMut(*mut u8, usize, usize)) {
-    let (shape, _, _, itemsize, _) = unsafe { geometry(view) };
+    let (shape, strides, suboffsets, itemsize, _) = unsafe { geometry(view) };
     if shape.iter().any(|&extent| extent <= 0) {
         return;
     }
+    let base = unsafe { (*view).buf } as *mut u8;
     let mut indices = vec![0i64; shape.len()];
     let mut position = 0usize;
     loop {
-        let element = unsafe { element_of(view, &indices) };
+        let element = unsafe { element_at(base, &strides, &suboffsets, &indices) };
         visit(element, position, itemsize as usize);
         position += itemsize as usize;
         if !advance(&mut indices, &shape, order) {

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -870,6 +870,26 @@ fn copy_endian(raw: &[u8], out: &mut [u8], bigendian: bool) {
 
 /// `do_unpack` / `_unpack` — unpack the whole of `buf` (which must be
 /// exactly `calcsize(format)` bytes) according to `format`.
+/// `struct_get_unpacker` — whether an unpacker can be built for `format` at
+/// all.  A format the struct module cannot parse makes two memoryviews
+/// unequal rather than raising, so the caller needs the question answered
+/// separately from unpacking.
+pub(crate) fn format_is_supported(format: &str) -> bool {
+    parse_format(format).is_ok()
+}
+
+/// `struct_unpack_single` — one item's fields, unwrapped when the format
+/// names exactly one of them.
+pub(crate) fn unpack_single(format: &str, item: &[u8]) -> Result<PyObjectRef, crate::PyError> {
+    let unpacked = do_unpack(format, item)?;
+    unsafe {
+        match pyre_object::w_tuple_len(unpacked) {
+            1 => Ok(pyre_object::w_tuple_getitem(unpacked, 0).expect("length checked")),
+            _ => Ok(unpacked),
+        }
+    }
+}
+
 fn do_unpack(format: &str, buf: &[u8]) -> Result<PyObjectRef, crate::PyError> {
     let parsed = parse_format(format)?;
     let size = parsed.calcsize()? as usize;

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1283,6 +1283,26 @@ fn trace_bufferview(
             f(w_strides as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
             trace_bufferview(parent, f);
         }
+        // Named fields, not `..`: `shape` / `strides` / `suboffsets` are
+        // native vectors and the scalars are plain integers, so the ref slots
+        // are exactly `w_obj`, `w_fmt` and the backing.  A field added later
+        // is a compile error here rather than a missed root.
+        pyre_object::bufferview::BufferView::CBuffer {
+            backing,
+            w_obj,
+            w_fmt,
+            itemsize: _,
+            length: _,
+            ndim: _,
+            offset: _,
+            shape: _,
+            strides: _,
+            suboffsets: _,
+        } => {
+            f(w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            f(w_fmt as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            trace_buffer_exporter(backing, f);
+        }
         pyre_object::bufferview::BufferView::Readonly { view, w_obj } => {
             f(w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
             trace_bufferview(view, f);

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -28,6 +28,10 @@ fn copy_base(full: &[u8], base: i64, isz: usize, out: &mut Vec<u8>) {
 /// `_copy_rec` — recursive C-order copy of dimension `idim`.  The innermost
 /// dimension walks `shape[ndim-1]` elements by `strides[ndim-1]`; an outer
 /// dimension recurses `shape[idim]` times, advancing `off` by `strides[idim]`.
+///
+/// A stride of zero addresses the same element at every index of that
+/// dimension, so it is copied `shape[idim]` times rather than skipped:
+/// `_copy_base` stops early only because `range(off, off, 0)` is not a walk.
 #[expect(
     clippy::too_many_arguments,
     reason = "The parameter order mirrors the corresponding RPython translation routine; grouping arguments into a Rust-only context object would obscure line-by-line parity and ownership"
@@ -45,9 +49,6 @@ fn copy_rec(
     let dimshape = shape.get(idim as usize).copied().unwrap_or(0);
     let dimstride = strides.get(idim as usize).copied().unwrap_or(0);
     if idim == ndim - 1 {
-        if dimstride == 0 {
-            return;
-        }
         for _ in 0..dimshape {
             copy_base(full, off, isz, out);
             off += dimstride;
@@ -75,9 +76,6 @@ fn copy_rec_fortran(
     let dimshape = shape.get(idim as usize).copied().unwrap_or(0);
     let dimstride = strides.get(idim as usize).copied().unwrap_or(0);
     if idim == 0 {
-        if dimstride == 0 {
-            return;
-        }
         for _ in 0..dimshape {
             copy_base(full, off, isz, out);
             off += dimstride;
@@ -908,6 +906,15 @@ mod tests {
         assert_eq!(addressable_window(&[0, 3], &[12, 4], 4), (0, 0));
         // A zero-dimensional export still addresses its one element.
         assert_eq!(addressable_window(&[], &[], 8), (0, 8));
+    }
+
+    #[test]
+    fn cbuffer_backing_stays_the_external_export() {
+        // `release_view` ends a foreign export only for a view whose backing
+        // is the `External` block the export handed over; a variant that
+        // stopped answering with one would silently never be released.
+        let view = cbuffer(vec![2, 3], vec![12, 4], 4, 0);
+        assert!(matches!(view.backing(), Buffer::External { .. }));
     }
 
     #[test]

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -108,6 +108,33 @@ unsafe fn read_dims(t: PyObjectRef) -> Vec<i64> {
     }
 }
 
+/// The `[low, high)` byte window a strided geometry can address, relative to
+/// element zero: `low` is the sum of the negative extents a reversed stride
+/// reaches below element zero, `high` the sum of the positive ones plus one
+/// element.  An empty extent addresses nothing, so the window is `(0, 0)`.
+///
+/// This has no upstream twin — `get_offset` and `ADJUST_PTR` both index raw
+/// pointers, which need no window.  It exists because [`Buffer::as_bytes`]
+/// hands out a *bounded* slice and [`copy_base`] drops any element outside
+/// it, so a foreign export whose strides reach below its `buf` must have its
+/// storage lowered to `low` and the shift carried in the view's offset.
+pub fn addressable_window(shape: &[i64], strides: &[i64], itemsize: i64) -> (i64, i64) {
+    if shape.iter().any(|&extent| extent == 0) {
+        return (0, 0);
+    }
+    let mut low = 0;
+    let mut high = itemsize;
+    for (&extent, &stride) in shape.iter().zip(strides) {
+        let span = stride * (extent - 1);
+        if span < 0 {
+            low += span;
+        } else {
+            high += span;
+        }
+    }
+    (low, high)
+}
+
 /// A view of a [`Buffer`]'s bytes with offset / shape / stride geometry and a
 /// buffer-protocol format.
 ///
@@ -177,6 +204,31 @@ pub enum BufferView {
         ndim: i64,
         w_shape: PyObjectRef,
         w_strides: PyObjectRef,
+    },
+    /// `CPyBuffer` (`pypy/module/cpyext/buffer.py`) — a foreign `Py_buffer`'s
+    /// own geometry over the address its exporter handed over.  A root view:
+    /// it holds the storage rather than a parent, exactly as `CPyBuffer`
+    /// holds `self.ptr` / `self.size` instead of subclassing `IndirectView`.
+    ///
+    /// `shape` / `strides` ride as native vectors, as `CPyBuffer` stores
+    /// them as lists, and both have `ndim` entries once `init_shape_strides`
+    /// has reconstructed the ones the exporter left NULL.  `length` is
+    /// `Py_buffer.len` verbatim (`CPyBuffer.size`), which for a 0-dimensional
+    /// or PIL-style export is not `product(shape) * itemsize`.  `offset` is
+    /// the byte position of element zero within `backing`, non-zero when a
+    /// negative stride forced the storage down to the lowest addressable
+    /// byte (see [`addressable_window`]).  An empty `suboffsets` is NULL.
+    CBuffer {
+        backing: Buffer,
+        w_obj: PyObjectRef,
+        w_fmt: PyObjectRef,
+        itemsize: i64,
+        length: i64,
+        ndim: i64,
+        offset: i64,
+        shape: Vec<i64>,
+        strides: Vec<i64>,
+        suboffsets: Vec<i64>,
     },
     /// `ReadonlyWrapper` (`buffer.py`) — `toreadonly`'s wrapper: every
     /// read delegates to the wrapped view, `readonly` is forced true.
@@ -250,6 +302,29 @@ impl BufferView {
                 w_shape: *w_shape,
                 w_strides: *w_strides,
             },
+            BufferView::CBuffer {
+                backing,
+                w_fmt,
+                itemsize,
+                length,
+                ndim,
+                offset,
+                shape,
+                strides,
+                suboffsets,
+                ..
+            } => BufferView::CBuffer {
+                backing: backing.clone(),
+                w_obj: new_obj,
+                w_fmt: *w_fmt,
+                itemsize: *itemsize,
+                length: *length,
+                ndim: *ndim,
+                offset: *offset,
+                shape: shape.clone(),
+                strides: strides.clone(),
+                suboffsets: suboffsets.clone(),
+            },
             BufferView::Readonly { view, .. } => BufferView::Readonly {
                 view: view.clone(),
                 w_obj: new_obj,
@@ -261,7 +336,9 @@ impl BufferView {
     #[inline]
     pub fn backing(&self) -> &Buffer {
         match self {
-            BufferView::Simple { backing, .. } | BufferView::Raw { backing, .. } => backing,
+            BufferView::Simple { backing, .. }
+            | BufferView::Raw { backing, .. }
+            | BufferView::CBuffer { backing, .. } => backing,
             BufferView::Slice { parent, .. }
             | BufferView::View1D { parent, .. }
             | BufferView::ViewND { parent, .. } => parent.backing(),
@@ -277,6 +354,7 @@ impl BufferView {
             | BufferView::Slice { w_obj, .. }
             | BufferView::View1D { w_obj, .. }
             | BufferView::ViewND { w_obj, .. }
+            | BufferView::CBuffer { w_obj, .. }
             | BufferView::Readonly { w_obj, .. } => *w_obj,
         }
     }
@@ -291,9 +369,9 @@ impl BufferView {
         unsafe {
             match self {
                 BufferView::Simple { .. } => "B",
-                BufferView::Raw { w_fmt, .. } | BufferView::View1D { w_fmt, .. } => {
-                    crate::w_str_get_value(*w_fmt)
-                }
+                BufferView::Raw { w_fmt, .. }
+                | BufferView::View1D { w_fmt, .. }
+                | BufferView::CBuffer { w_fmt, .. } => crate::w_str_get_value(*w_fmt),
                 BufferView::Slice { parent, .. } | BufferView::ViewND { parent, .. } => {
                     parent.format_str()
                 }
@@ -335,6 +413,7 @@ impl BufferView {
                     parent, itemsize, ..
                 } => vec![parent.length() / *itemsize],
                 BufferView::ViewND { w_shape, .. } => read_dims(*w_shape),
+                BufferView::CBuffer { shape, .. } => shape.clone(),
                 BufferView::Readonly { view, .. } => view.native_shape(),
             }
         }
@@ -363,6 +442,7 @@ impl BufferView {
                     strides
                 }
                 BufferView::ViewND { w_strides, .. } => read_dims(*w_strides),
+                BufferView::CBuffer { strides, .. } => strides.clone(),
                 BufferView::Readonly { view, .. } => view.native_strides(),
             }
         }
@@ -384,6 +464,9 @@ impl BufferView {
                 } => crate::tupleobject::w_tuple_getitem(*w_strides, 0)
                     .map(|s| crate::intobject::w_int_get_value(s))
                     .unwrap_or_else(|| parent.itemsize()),
+                BufferView::CBuffer {
+                    strides, itemsize, ..
+                } => strides.first().copied().unwrap_or(*itemsize),
                 BufferView::Readonly { view, .. } => view.stride0(),
             }
         }
@@ -391,7 +474,9 @@ impl BufferView {
     #[inline]
     pub fn itemsize(&self) -> i64 {
         match self {
-            BufferView::Raw { itemsize, .. } | BufferView::View1D { itemsize, .. } => *itemsize,
+            BufferView::Raw { itemsize, .. }
+            | BufferView::View1D { itemsize, .. }
+            | BufferView::CBuffer { itemsize, .. } => *itemsize,
             BufferView::Simple { .. } => 1,
             BufferView::Slice { parent, .. } | BufferView::ViewND { parent, .. } => {
                 parent.itemsize()
@@ -405,6 +490,7 @@ impl BufferView {
             BufferView::Simple { .. } | BufferView::Raw { .. } | BufferView::View1D { .. } => 1,
             BufferView::Slice { parent, .. } => parent.ndim(),
             BufferView::ViewND { ndim, .. } => *ndim,
+            BufferView::CBuffer { ndim, .. } => *ndim,
             BufferView::Readonly { view, .. } => view.ndim(),
         }
     }
@@ -427,6 +513,7 @@ impl BufferView {
                 BufferView::View1D { parent, .. } | BufferView::ViewND { parent, .. } => {
                     parent.offset()
                 }
+                BufferView::CBuffer { offset, .. } => *offset,
                 BufferView::Readonly { view, .. } => view.offset(),
             }
         }
@@ -441,7 +528,9 @@ impl BufferView {
     pub unsafe fn length(&self) -> i64 {
         unsafe {
             match self {
-                BufferView::Simple { length, .. } | BufferView::Raw { length, .. } => *length,
+                BufferView::Simple { length, .. }
+                | BufferView::Raw { length, .. }
+                | BufferView::CBuffer { length, .. } => *length,
                 // `init_len` — `product(shape) * itemsize`, so a slice of an
                 // N-dimensional parent keeps the trailing extents.  `length`
                 // is `shape[0]` alone (`BufferSlice.getlength`), which
@@ -473,9 +562,9 @@ impl BufferView {
     #[inline]
     pub fn readonly(&self) -> bool {
         match self {
-            BufferView::Simple { backing, .. } | BufferView::Raw { backing, .. } => {
-                backing.readonly()
-            }
+            BufferView::Simple { backing, .. }
+            | BufferView::Raw { backing, .. }
+            | BufferView::CBuffer { backing, .. } => backing.readonly(),
             BufferView::Slice { parent, .. }
             | BufferView::View1D { parent, .. }
             | BufferView::ViewND { parent, .. } => parent.readonly(),
@@ -540,6 +629,13 @@ impl BufferView {
                 step: pstep * step,
                 length: slicelength,
             },
+            // A foreign export wraps like any other non-specialised parent:
+            // `Slice::offset` is `parent.offset() + start * parent.stride0()`
+            // and `Slice::native_strides` rescales dimension 0 only, which is
+            // `adjust_buf` plus `strides[dim] *= step` at `dim == 0`.  The arm
+            // is spelled out rather than left to the fallback so the
+            // suboffset case has a place to land.
+            BufferView::CBuffer { .. } => wrap(self),
             // A slice of a read-only wrapper stays wrapped (buffer.py:462).
             BufferView::Readonly { w_obj, .. } => BufferView::Readonly {
                 view: Box::new(wrap(self)),
@@ -591,7 +687,8 @@ impl BufferView {
                 BufferView::Readonly { view, .. } => view.as_contiguous_bytes(),
                 BufferView::Slice { .. }
                 | BufferView::View1D { .. }
-                | BufferView::ViewND { .. } => None,
+                | BufferView::ViewND { .. }
+                | BufferView::CBuffer { .. } => None,
             }
         }
     }
@@ -759,6 +856,74 @@ mod tests {
             assert_eq!(s2.offset(), 2);
             assert_eq!(s2.native_strides(), vec![2]);
         }
+    }
+
+    fn cbuffer(shape: Vec<i64>, strides: Vec<i64>, itemsize: i64, offset: i64) -> BufferView {
+        let length = shape.iter().product::<i64>() * itemsize;
+        BufferView::CBuffer {
+            backing: Buffer::External {
+                w_obj: fake(0x3000),
+                address: 0x40000,
+                size: length.max(0) as usize,
+                readonly: false,
+            },
+            w_obj: fake(0x3000),
+            w_fmt: fake(0x3004),
+            itemsize,
+            length,
+            ndim: shape.len() as i64,
+            offset,
+            shape,
+            strides,
+            suboffsets: vec![],
+        }
+    }
+
+    #[test]
+    fn cbuffer_reports_its_stored_geometry() {
+        // A foreign export answers from its own vectors rather than deriving
+        // any of them from a parent, and `length` is `Py_buffer.len` verbatim.
+        let view = cbuffer(vec![2, 3], vec![12, 4], 4, 0);
+        unsafe {
+            assert_eq!(view.native_shape(), vec![2, 3]);
+            assert_eq!(view.native_strides(), vec![12, 4]);
+            assert_eq!(view.stride0(), 12);
+            assert_eq!(view.offset(), 0);
+            assert_eq!(view.length(), 24);
+            assert!(view.as_contiguous_bytes().is_none());
+        }
+        assert_eq!(view.itemsize(), 4);
+        assert_eq!(view.ndim(), 2);
+        assert!(!view.readonly());
+    }
+
+    #[test]
+    fn cbuffer_negative_stride_window_lowers_the_base() {
+        // A reversed dimension addresses bytes below element zero, so the
+        // window starts there and the view's offset carries the shift.
+        assert_eq!(addressable_window(&[4], &[-4], 4), (-12, 4));
+        assert_eq!(addressable_window(&[2, 3], &[12, 4], 4), (0, 24));
+        assert_eq!(addressable_window(&[2, 3], &[12, -4], 4), (-8, 16));
+        // An empty extent addresses nothing whatever the strides say.
+        assert_eq!(addressable_window(&[0, 3], &[12, 4], 4), (0, 0));
+        // A zero-dimensional export still addresses its one element.
+        assert_eq!(addressable_window(&[], &[], 8), (0, 8));
+    }
+
+    #[test]
+    fn slice_of_a_cbuffer_shifts_the_base_and_rescales_dim0() {
+        // The wrapper composes: dimension 0 takes the slice's extent and its
+        // stride is multiplied by the step, later dimensions ride along.
+        let s = unsafe { cbuffer(vec![4, 3], vec![12, 4], 4, 0).new_slice(1, 2, 2) };
+        assert!(matches!(s, BufferView::Slice { .. }));
+        unsafe {
+            assert_eq!(s.native_shape(), vec![2, 3]);
+            assert_eq!(s.native_strides(), vec![24, 4]);
+            assert_eq!(s.offset(), 12);
+            assert_eq!(s.length(), 24);
+        }
+        assert_eq!(s.ndim(), 2);
+        assert_eq!(s.itemsize(), 4);
     }
 
     #[test]

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -1146,7 +1146,14 @@ mod tests {
         // The pointer walk is entered only for a view that has suboffsets;
         // an empty vector keeps the byte-index walk, strides and all.
         let block: [u8; 6] = [1, 2, 3, 4, 5, 6];
-        let view = cbuffer_over(block.as_ptr(), block.len(), vec![2, 3], vec![3, 1], vec![], 1);
+        let view = cbuffer_over(
+            block.as_ptr(),
+            block.len(),
+            vec![2, 3],
+            vec![3, 1],
+            vec![],
+            1,
+        );
         assert_eq!(unsafe { view.gather() }, vec![1, 2, 3, 4, 5, 6]);
         assert_eq!(unsafe { view.gather_order(true) }, vec![1, 4, 2, 5, 3, 6]);
         assert_eq!(unsafe { *view.element_ptr(&[1, 2]) }, 6);

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -442,7 +442,13 @@ impl BufferView {
         unsafe {
             match self {
                 BufferView::Simple { length, .. } | BufferView::Raw { length, .. } => *length,
-                BufferView::Slice { parent, length, .. } => *length * parent.itemsize(),
+                // `init_len` — `product(shape) * itemsize`, so a slice of an
+                // N-dimensional parent keeps the trailing extents.  `length`
+                // is `shape[0]` alone (`BufferSlice.getlength`), which
+                // under-reports by their product.
+                BufferView::Slice { parent, .. } => {
+                    self.native_shape().iter().product::<i64>() * parent.itemsize()
+                }
                 BufferView::View1D { parent, .. } => parent.length(),
                 BufferView::ViewND {
                     parent, w_shape, ..
@@ -752,6 +758,40 @@ mod tests {
         unsafe {
             assert_eq!(s2.offset(), 2);
             assert_eq!(s2.native_strides(), vec![2]);
+        }
+    }
+
+    #[test]
+    fn slice_of_an_nd_view_reports_product_shape_nbytes() {
+        // `init_len` is `product(shape) * itemsize`, so a dimension-0 slice
+        // of an N-dimensional view keeps the trailing extents; reporting
+        // `shape[0]` alone under-reports by their product.
+        let exporter = crate::bytesobject::w_bytes_from_bytes(&[0u8; 10]);
+        let flat = BufferView::Simple {
+            backing: Buffer::String { w_obj: exporter },
+            w_obj: exporter,
+            length: 10,
+        };
+        let dims = |extents: [i64; 2]| {
+            crate::tupleobject::w_tuple_new(
+                extents
+                    .iter()
+                    .map(|&extent| crate::intobject::w_int_new(extent))
+                    .collect(),
+            )
+        };
+        let nd = BufferView::ViewND {
+            parent: Box::new(flat),
+            w_obj: exporter,
+            ndim: 2,
+            w_shape: dims([2, 5]),
+            w_strides: dims([5, 1]),
+        };
+        let s = unsafe { nd.new_slice(0, 2, 1) };
+        unsafe {
+            assert_eq!(s.native_shape(), vec![1, 5]);
+            assert_eq!(s.native_strides(), vec![10, 1]);
+            assert_eq!(s.length(), 5);
         }
     }
 

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -61,6 +61,103 @@ fn copy_rec(
     }
 }
 
+/// `ADJUST_PTR` — follow the pointer stored at `ptr` when dimension `dim`
+/// carries a non-negative suboffset, and leave it alone otherwise.  An empty
+/// slice is identity, exactly as the macro is for a NULL `suboffsets`.
+///
+/// # Safety
+/// When dimension `dim` has a non-negative suboffset, `ptr` must address a
+/// live pointer that the exporter published.
+unsafe fn adjust_ptr(ptr: *const u8, suboffsets: &[i64], dim: usize) -> *const u8 {
+    match suboffsets.get(dim) {
+        Some(&suboffset) if suboffset >= 0 => unsafe {
+            (*ptr.cast::<*const u8>()).offset(suboffset as isize)
+        },
+        _ => ptr,
+    }
+}
+
+/// `init_strides_from_shape` / `init_fortran_strides_from_shape` — the byte
+/// steps of a block laid out contiguously in the requested order.
+pub fn contiguous_strides(shape: &[i64], itemsize: i64, fortran: bool) -> Vec<i64> {
+    let mut strides = vec![0i64; shape.len()];
+    let mut step = itemsize;
+    if fortran {
+        for (dim, &extent) in shape.iter().enumerate() {
+            strides[dim] = step;
+            step *= extent;
+        }
+    } else {
+        for (dim, &extent) in shape.iter().enumerate().rev() {
+            strides[dim] = step;
+            step *= extent;
+        }
+    }
+    strides
+}
+
+/// `copy_rec` for a view whose dimensions carry suboffsets.  The cursor is a
+/// raw pointer because a suboffset dereferences it, so no byte index into the
+/// backing describes the element; the address is chained one dimension at a
+/// time and the stride advances the *un*adjusted cursor.
+///
+/// The source is always walked outermost dimension first, because a pointer
+/// chain has to be followed in the order it was built.  A Fortran-order
+/// result therefore comes from the *destination* steps `dest_strides`
+/// carries, which is how `buffer_to_contiguous` produces one.
+///
+/// # Safety
+/// The geometry must be the one its exporter published, every pointer a
+/// suboffset reaches must be live, and `out` must be `product(shape) * isz`
+/// bytes long.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "The source geometry, the destination geometry and both cursors are each a separate argument; grouping them would hide which side an argument belongs to"
+)]
+unsafe fn copy_rec_indirect(
+    shape: &[i64],
+    strides: &[i64],
+    suboffsets: &[i64],
+    dest_strides: &[i64],
+    idim: usize,
+    ptr: *const u8,
+    dest: i64,
+    isz: usize,
+    out: &mut [u8],
+) {
+    let dimshape = shape.get(idim).copied().unwrap_or(0);
+    let dimstride = strides.get(idim).copied().unwrap_or(0);
+    let deststride = dest_strides.get(idim).copied().unwrap_or(0);
+    let mut cursor = ptr;
+    let mut at = dest;
+    for _ in 0..dimshape {
+        let element = unsafe { adjust_ptr(cursor, suboffsets, idim) };
+        if idim + 1 == shape.len() {
+            let to = at.max(0) as usize;
+            if to + isz <= out.len() {
+                out[to..to + isz]
+                    .copy_from_slice(unsafe { std::slice::from_raw_parts(element, isz) });
+            }
+        } else {
+            unsafe {
+                copy_rec_indirect(
+                    shape,
+                    strides,
+                    suboffsets,
+                    dest_strides,
+                    idim + 1,
+                    element,
+                    at,
+                    isz,
+                    out,
+                )
+            };
+        }
+        cursor = unsafe { cursor.offset(dimstride as isize) };
+        at += deststride;
+    }
+}
+
 /// `buffer_to_contiguous(..., 'F')` — recursive Fortran-order copy.  The
 /// first dimension is innermost, so dimension 0 changes fastest in the
 /// destination byte string (`memoryobject.c:init_fortran_strides_from_shape`).
@@ -204,9 +301,11 @@ pub enum BufferView {
         w_strides: PyObjectRef,
     },
     /// `CPyBuffer` (`pypy/module/cpyext/buffer.py`) — a foreign `Py_buffer`'s
-    /// own geometry over the address its exporter handed over.  A root view:
+    /// own geometry over the storage its exporter handed over.  A root view:
     /// it holds the storage rather than a parent, exactly as `CPyBuffer`
     /// holds `self.ptr` / `self.size` instead of subclassing `IndirectView`.
+    /// The backing is that export's block, or the in-heap copy a contiguous
+    /// materialisation made of it.
     ///
     /// `shape` / `strides` ride as native vectors, as `CPyBuffer` stores
     /// them as lists, and both have `ndim` entries once `init_shape_strides`
@@ -445,6 +544,25 @@ impl BufferView {
             }
         }
     }
+    /// The per-dimension suboffsets (`getsuboffsets`).  Empty is NULL: only a
+    /// foreign export carries any, and every derived view reports its
+    /// parent's.
+    ///
+    /// # Safety
+    /// The view's stored geometry objects must be live.
+    #[inline]
+    pub unsafe fn native_suboffsets(&self) -> Vec<i64> {
+        unsafe {
+            match self {
+                BufferView::Simple { .. } | BufferView::Raw { .. } => Vec::new(),
+                BufferView::CBuffer { suboffsets, .. } => suboffsets.clone(),
+                BufferView::Slice { parent, .. }
+                | BufferView::View1D { parent, .. }
+                | BufferView::ViewND { parent, .. } => parent.native_suboffsets(),
+                BufferView::Readonly { view, .. } => view.native_suboffsets(),
+            }
+        }
+    }
     /// `strides[0]` — the signed byte step between consecutive elements of a
     /// 1-D view, falling back to `itemsize` when the strides are empty.
     ///
@@ -643,6 +761,49 @@ impl BufferView {
         }
     }
 
+    /// `ptr_from_index` / `ptr_from_tuple` — the address of the element at
+    /// `indices`, one wrapped index per dimension.  The address is *chained*
+    /// rather than summed: each dimension's stride advances the cursor and
+    /// `ADJUST_PTR` may then follow a pointer stored there.
+    ///
+    /// # Safety
+    /// `indices` must already be bounds-checked against the shape, and the
+    /// backing export must be live.
+    pub unsafe fn element_ptr(&self, indices: &[i64]) -> *const u8 {
+        unsafe {
+            let base = self.backing().as_bytes().as_ptr();
+            self.walk_to(base, indices)
+        }
+    }
+
+    /// [`element_ptr`](Self::element_ptr) over writable storage, or `None`
+    /// when the backing refuses one.
+    ///
+    /// # Safety
+    /// As [`element_ptr`](Self::element_ptr).
+    pub unsafe fn element_ptr_mut(&self, indices: &[i64]) -> Option<*mut u8> {
+        unsafe {
+            let base = self.backing().as_bytes_mut()?.as_mut_ptr();
+            Some(self.walk_to(base as *const u8, indices) as *mut u8)
+        }
+    }
+
+    /// # Safety
+    /// As [`element_ptr`](Self::element_ptr).
+    unsafe fn walk_to(&self, base: *const u8, indices: &[i64]) -> *const u8 {
+        unsafe {
+            let strides = self.native_strides();
+            let suboffsets = self.native_suboffsets();
+            let mut ptr = base.offset(self.offset() as isize);
+            for (dim, &index) in indices.iter().enumerate() {
+                let stride = strides.get(dim).copied().unwrap_or(0);
+                ptr = ptr.offset((stride * index) as isize);
+                ptr = adjust_ptr(ptr, &suboffsets, dim);
+            }
+            ptr
+        }
+    }
+
     /// The LIVE logical bytes of the view (`buffer.py as_str`), read from the
     /// backing object's own storage — no detached copy — so the view observes
     /// later mutation of a bytearray / array source.  Honours offset / shape /
@@ -720,6 +881,26 @@ impl BufferView {
                 0
             };
             let mut out = Vec::with_capacity(count.max(0) as usize * isz);
+            let suboffsets = self.native_suboffsets();
+            if !suboffsets.is_empty() {
+                // No byte index into the backing describes an element behind a
+                // suboffset, so the walk carries an address instead.  The
+                // bounds clamp `copy_base` applies goes with the index: the
+                // exporter's pointers are the only description of the target.
+                let mut block = vec![0u8; count.max(0) as usize * isz];
+                copy_rec_indirect(
+                    &shape,
+                    &strides,
+                    &suboffsets,
+                    &contiguous_strides(&shape, itemsize, fortran),
+                    0,
+                    full.as_ptr().offset(offset as isize),
+                    0,
+                    isz,
+                    &mut block,
+                );
+                return block;
+            }
             if fortran {
                 copy_rec_fortran(full, &shape, &strides, ndim - 1, offset, isz, &mut out);
             } else {
@@ -906,6 +1087,92 @@ mod tests {
         assert_eq!(addressable_window(&[0, 3], &[12, 4], 4), (0, 0));
         // A zero-dimensional export still addresses its one element.
         assert_eq!(addressable_window(&[], &[], 8), (0, 8));
+    }
+
+    /// A `CBuffer` over `block`, whose address the geometry-only helper above
+    /// never dereferences but these two tests do.
+    fn cbuffer_over(
+        block: *const u8,
+        size: usize,
+        shape: Vec<i64>,
+        strides: Vec<i64>,
+        suboffsets: Vec<i64>,
+        itemsize: i64,
+    ) -> BufferView {
+        BufferView::CBuffer {
+            backing: Buffer::External {
+                w_obj: fake(0x3000),
+                address: block as usize,
+                size,
+                readonly: true,
+            },
+            w_obj: fake(0x3000),
+            w_fmt: fake(0x3004),
+            itemsize,
+            length: shape.iter().product::<i64>() * itemsize,
+            ndim: shape.len() as i64,
+            offset: 0,
+            shape,
+            strides,
+            suboffsets,
+        }
+    }
+
+    #[test]
+    fn indirect_gather_follows_the_row_pointers() {
+        // `ADJUST_PTR`: dimension 0 holds a table of row pointers and its
+        // suboffset is zero, so the walk dereferences the table entry and
+        // continues into the row; dimension 1's -1 leaves the cursor alone.
+        let row0: [u8; 3] = [1, 2, 3];
+        let row1: [u8; 3] = [4, 5, 6];
+        let table: [*const u8; 2] = [row0.as_ptr(), row1.as_ptr()];
+        let view = cbuffer_over(
+            table.as_ptr().cast::<u8>(),
+            std::mem::size_of_val(&table),
+            vec![2, 3],
+            vec![std::mem::size_of::<*const u8>() as i64, 1],
+            vec![0, -1],
+            1,
+        );
+        assert_eq!(unsafe { view.gather() }, vec![1, 2, 3, 4, 5, 6]);
+        // Fortran order reads dimension 0 fastest through the same table.
+        assert_eq!(unsafe { view.gather_order(true) }, vec![1, 4, 2, 5, 3, 6]);
+        // One element, addressed by chaining rather than summing.
+        assert_eq!(unsafe { *view.element_ptr(&[1, 2]) }, 6);
+    }
+
+    #[test]
+    fn direct_gather_is_unchanged_when_suboffsets_are_empty() {
+        // The pointer walk is entered only for a view that has suboffsets;
+        // an empty vector keeps the byte-index walk, strides and all.
+        let block: [u8; 6] = [1, 2, 3, 4, 5, 6];
+        let view = cbuffer_over(block.as_ptr(), block.len(), vec![2, 3], vec![3, 1], vec![], 1);
+        assert_eq!(unsafe { view.gather() }, vec![1, 2, 3, 4, 5, 6]);
+        assert_eq!(unsafe { view.gather_order(true) }, vec![1, 4, 2, 5, 3, 6]);
+        assert_eq!(unsafe { *view.element_ptr(&[1, 2]) }, 6);
+        // A reversed dimension 0 walks backwards from element zero, which
+        // `acquire` makes addressable by lowering the storage to the window's
+        // low end and carrying the shift in the view's offset.
+        let (low, high) = addressable_window(&[2, 3], &[-3, 1], 1);
+        assert_eq!((low, high), (-3, 3));
+        let reversed = BufferView::CBuffer {
+            backing: Buffer::External {
+                w_obj: fake(0x3000),
+                address: unsafe { block.as_ptr().offset(3).offset(low as isize) } as usize,
+                size: (high - low) as usize,
+                readonly: true,
+            },
+            w_obj: fake(0x3000),
+            w_fmt: fake(0x3004),
+            itemsize: 1,
+            length: 6,
+            ndim: 2,
+            offset: -low,
+            shape: vec![2, 3],
+            strides: vec![-3, 1],
+            suboffsets: vec![],
+        };
+        assert_eq!(unsafe { reversed.gather() }, vec![4, 5, 6, 1, 2, 3]);
     }
 
     #[test]

--- a/pyre/pyre-object/src/memoryview.rs
+++ b/pyre/pyre-object/src/memoryview.rs
@@ -445,3 +445,13 @@ pub unsafe fn w_memoryview_native_shape(obj: PyObjectRef) -> Vec<i64> {
 pub unsafe fn w_memoryview_native_strides(obj: PyObjectRef) -> Vec<i64> {
     unsafe { w_memoryview_view(obj).native_strides() }
 }
+
+/// The view's suboffsets as native `i64` byte offsets, empty for a view that
+/// has none (`memoryview.suboffsets`).
+///
+/// # Safety
+/// `obj` must point to a valid `W_MemoryView`.
+#[inline]
+pub unsafe fn w_memoryview_native_suboffsets(obj: PyObjectRef) -> Vec<i64> {
+    unsafe { w_memoryview_view(obj).native_suboffsets() }
+}

--- a/pyre/pyrex/tests/cpyext_object_families.rs
+++ b/pyre/pyrex/tests/cpyext_object_families.rs
@@ -248,12 +248,16 @@ eq('and it writes through to the exporter', data, bytearray(b'zbcdef'))
 eq('a write view over bytes', m.mv_contiguous(b'abcdef', 'w', 'C'),
    ('BufferError', 'underlying buffer is not writable'))
 
-# A strided view is contiguous in no order, and only the read side has a
-# copy to fall back on -- which is not built yet.
-strided = memoryview(bytearray(b'abcdef'))[::2]
-eq('a read view over a strided one', m.mv_contiguous(strided, 'r', 'C'),
-   ('NotImplementedError',
-    'creating contiguous readonly buffer from non-contiguous not implemented yet'))
+# A strided view is contiguous in no order, and only the read side has a copy
+# to fall back on: it gets the selected elements laid out in the asked-for
+# order, over storage of its own rather than the exporter's.
+data = bytearray(b'abcdef')
+strided = memoryview(data)[::2]
+copied = m.mv_contiguous(strided, 'r', 'C')
+eq('a read view over a strided one', bytes(copied), b'ace')
+eq('and the copy is read-only', copied.readonly, True)
+data[0] = ord('z')
+eq('and it does not write through to the exporter', bytes(copied), b'ace')
 eq('a write view over a strided one', m.mv_contiguous(strided, 'w', 'C'),
    ('BufferError',
     'writable contiguous buffer requested for a non-contiguous object.'))


### PR DESCRIPTION
Continues #1487. The suite lane that #1487 added grades `test.test_buffer`;
this branch works that row down from 25 failing cases to 7.

## The buffer geometry a C exporter may carry

`CBuffer` keeps a foreign `Py_buffer`'s own strides, suboffsets and offset
rather than flattening it, so a strided, multi-dimensional or `ND_PIL`
export is imported and re-published as itself. `PyMemoryView_GetContiguous`
materialises its copy instead of raising. A zero-dimensional view takes
`...` as its own index.

## What the remeasurement then found

Grading the row turned up defects the plan had not named:

- **Comparison never used the struct module.** `memory_richcompare` compares
  as C values only when both views name the same single native format code;
  every other format — a byte order prefix, several members, a repeat count
  — is unpacked by the struct module and compared by value, and a format it
  cannot parse leaves the views unequal rather than raising. This one gap
  owned 12 of the 25 failing cases (`Lf5s`/`hf5s`, `!h`/`<l`, `=Qq`/`=qQ`,
  `d b c`, `l x d x`, `array('u')`).
- **`element_of` stepped by zero when `strides` was NULL**, so a view from a
  request without `PyBUF_STRIDES` addressed only its first element. Four
  cases, through `PyBuffer_ToContiguous` and `verify()`.
- **No `PyBuffer_IsContiguous` fast path**, so `'A'` over a
  Fortran-contiguous view transposed it instead of copying its own bytes.
- **Slice assignment read the rvalue as contiguous bytes**, ignoring
  `equiv_structure` and the rvalue's strides. It is now `copy_single`.
- **A failed pack coercion was always a TypeError**; `fix_error_int` keeps
  the type/value distinction.
- **A cast accepted a non-positive extent**, which `copy_shape` refuses.

## Verification

- `test.test_buffer`: 25 failing cases -> 7. The baseline row stays FAIL;
  the remaining seven are `m.obj` identity for a redirecting exporter,
  `__hash__`/`release`/`tolist` refusals, and `struct.pack_into` over a C
  exporter.
- CPython suite: 221 PASS / 0 FAIL, no regressions.
- `cargo test --all --no-default-features --features dynasm,cpyext`: 60
  binaries, 0 failures.
- `cargo fmt --all --check` clean.

## Left open

`test_importlib` is down to one failing case, `test_nonmodule_cases`, whose
child runs under `-E` and so cannot see `PYTHONPATH`. Reaching it means
putting the built test extensions on the interpreter's own default
`sys.path`, which would also expose them to every other module in the suite
— recorded in `run.py` rather than decided there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKvxTiG1M3K7KuKxVVezaX