### PR TITLE
check: name the fixtures whose max-pypy-ratio no run evaluated; bench: answer why the vref reproducer's arm stopped firing

### DIFF
--- a/pyre/bench/synth/_pending/exception_tb_f_locals_vref_root_walk.py
+++ b/pyre/bench/synth/_pending/exception_tb_f_locals_vref_root_walk.py
@@ -6,10 +6,10 @@
 # closure_per_call overlay over — two counters there disagreed with themselves
 # across jobs, one toward its shared value and one away from it — so a
 # `.cranelift.win32.jitstats` overlay cannot hold this either, and a missing
-# baseline is a hard fail rather than an opt-out. The walker guard therefore has
-# no suite gate; this file is the reproduction, and it is correct on all three
-# native backends and PYRE_NO_JIT=1 at every size of a 512K-32M PYPY_GC_NURSERY
-# sweep.
+# baseline is a hard fail rather than an opt-out. The walker guard had no suite
+# gate when that was written -- #1060 gave it one the next day, see ANSWERED
+# below -- and this file is the reproduction, correct on all three native
+# backends and PYRE_NO_JIT=1 at every size of a 512K-32M PYPY_GC_NURSERY sweep.
 #
 # ⛔ MEASURED 2026-08-24 at be1d37c1f94: IT NO LONGER DISCRIMINATES ITS GUARD.
 # Removing `forward_virtual_ref_forced`'s value-stack arm from
@@ -33,9 +33,45 @@
 # `is_exception` still dereferences `ob_type`, so the arm is not redundant --
 # its input has disappeared.
 #
-# That is worth a look on its own: a vref that stops reaching a frame slot is
-# either a deliberate earlier force or the virtualizable optimisation quietly
-# not applying where it used to.
+# ⛔ ANSWERED 2026-08-26 at 4953fb0edf8: NEITHER READING HOLDS. The vrefs are
+# still built, and the guard already has a gate that is not this file.
+#
+# Measured with birth/force counters in `virtualref.rs` (`alloc_virtual_ref`,
+# `force_virtual`) and hit counters on both `forward_virtual_ref_forced` call
+# sites in `walk_pyframe_roots_area`:
+#
+#   this file, cranelift AND dynasm, at `15000 head` and at the default
+#     alloc=8, force=4, value-stack arm hits=0 over 16-63 slot walks
+#   the f_backref arm -- the SAME helper one block earlier in the same walk
+#     0 here, but 1 on exception_residual_raise_caught_in_frame.py
+#   the 70 synth fixtures naming f_locals/tb_frame/__traceback__/f_back/
+#   _getframe, cranelift: value-stack arm hits 0 on all 70
+#
+# Eight vrefs are built on this shape at every size tried, so the virtualizable
+# optimisation is applying and the "quietly not applying" reading is out. The
+# f_backref line is the positive control the note above lacked: the helper is
+# live and has a producer -- `inline_call.rs walker_ec_enter` stores the
+# concrete vref into `ec.topframeref` and threads the caller's into
+# `frame.f_backref`. Both are frame-shaped fields. Neither is a
+# `locals_cells_stack_w` slot, and it is the value-stack arm specifically that
+# has nothing feeding it.
+#
+# ⛔ The birth counter sees TRACING-time births only. A vref materialized by
+# compiled code is allocated through NEW_WITH_VTABLE (`optimizeopt/
+# virtualize.rs` stamps JIT_VIRTUAL_REF_VTABLE there), which this counter never
+# observes -- `alloc=8` bounds the tracing population, not the runtime one. The
+# runtime population is why the arm exists, so its emptiness is measured here
+# only through the arm's own 0 hits.
+#
+# The gate: #1060 (`fa2eda0bd8e`) extracted the slot body as
+# `walk_frame_value_slot` and covered the arm with
+# `test_frame_value_slot_holding_a_virtual_ref_skips_the_pyobject_walks`
+# (`pyre-interpreter/src/eval.rs`), which hand-builds a vref and asserts the
+# visitor is handed exactly the slot and then the vref's own `forced` field.
+# That PR recorded that removing the early return aborts the test with SIGABRT,
+# and CI runs it on every push (`pyre-ci.yml`, `cargo test --all
+# --no-default-features --features dynasm,cpyext`). Promoting this file would
+# spend three backend runs re-gating what one unit test already holds.
 #
 # When it is promoted, `# pyre-check: selfcheck` is the shape, and the baseline
 # blocker above dissolves rather than needing an overlay: `run_selfcheck` takes

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -2886,6 +2886,7 @@ class Check:
         # applied. Reported in the summary: an unevaluated gate otherwise
         # prints the same green as a satisfied one.
         self.wasm_ratio_ungated = []
+        self.pypy_ratio_ungated = []
         # (bench name, ceiling, measured ratio or None) for fixtures whose
         # header raised the ratio above WASM_MAX_DYNASM_RATIO, for the same
         # reason as the line above: a gate widened for a fixture and a gate the
@@ -4012,6 +4013,18 @@ class Check:
                 ratio = _ratio(elapsed, t_pypy)
 
         if vs_pypy and t_pypy not in (None, "-"):
+            # A clamped baseline declines BOTH bounds in `_performance_gate_passed`,
+            # so a fixture can carry a `max-pypy-ratio` that no run has ever
+            # applied. The comparison table already prints `~` on the row, but a
+            # marker per row is not a set anyone can review, and absence of the
+            # directive exempts a fixture entirely -- so a ceiling that never
+            # arms reads exactly like one that holds. Named for the same reason
+            # the wasm ratio is.
+            if (
+                self._baseline_exec_time_clamped("pypy", float(t_pypy))
+                and name not in self.pypy_ratio_ungated
+            ):
+                self.pypy_ratio_ungated.append(name)
             minimum = perf_gate_floor(vs_pypy)
             passed, bound, checked_elapsed, checked_baseline, retry_note = self._performance_gate_passed(
                 backend, script, timeout, elapsed, vs_pypy, float(t_pypy),
@@ -4664,6 +4677,18 @@ class Check:
                 dim(
                     f"cpython reference skipped (>{SYNTHETIC_CPYTHON_REFERENCE_TIMEOUT_S:g}s) "
                     f"for {len(self.cpython_reference_skips)}: {names}"
+                )
+            )
+        # A `max-pypy-ratio` whose baseline was pinned to the floor every time
+        # it ran is a recorded number nobody checked.
+        if self.pypy_ratio_ungated:
+            names = ", ".join(self.pypy_ratio_ungated)
+            print(
+                dim(
+                    "max-pypy-ratio not evaluated for "
+                    f"{len(self.pypy_ratio_ungated)} fixture(s): pypy's "
+                    "execution-only time was clamped to the floor, so no ratio "
+                    f"gate was applied to them: {names}"
                 )
             )
         # A wasm run with no usable dynasm denominator beside it leaves


### PR DESCRIPTION
Two independent items, both from the queue #1467 left open.

## 1. `check.py`: report `max-pypy-ratio` gates that no run evaluated

`_performance_gate_passed` declines **both** bounds when startup subtraction
pins the pypy baseline to `EXEC_TIME_FLOOR_S`, so a fixture can carry a
`max-pypy-ratio` that has never been applied. The comparison table already
prints `~` on such a row, but a marker per row is not a set anyone can review —
and because absence of the directive exempts a fixture entirely, a ceiling that
never arms reads exactly like one that holds.

The summary now also names the set, the way it already does for the wasm ratio
and for skipped cpython references. Deleting the inert directives was considered
and rejected: `wasm_ratio_gate`'s absence means `WASM_MAX_DYNASM_RATIO`, while
`synth_perf_gate`/`synth_rss_gate` absence exempts a fixture, so removing them
would be a real weakening rather than a tidy-up.

Measured on `--synthetic-pattern 'attr_*.py'` against dynasm — 3 of 5 reported,
exactly the three rows the table marks `~`, with the two `?` rows (ceiling *is*
applied) correctly excluded:

```
max-pypy-ratio not evaluated for 3 fixture(s): pypy's execution-only time was
clamped to the floor, so no ratio gate was applied to them: synth/attr_delete,
synth/attr_instance_shadows_class, synth/attr_store_cache
```

## 2. `_pending/exception_tb_f_locals_vref_root_walk.py`: the open question, answered

The header left two readings for a `JitVirtualRef` no longer reaching
`locals_cells_stack_w` — a deliberate earlier force, or the virtualizable
optimisation quietly not applying (which would be a perf regression). Measured
at `4953fb0edf8` with birth/force counters in `virtualref.rs`
(`alloc_virtual_ref`, `force_virtual`) and hit counters on **both**
`forward_virtual_ref_forced` call sites in `walk_pyframe_roots_area`:

| | alloc | force | value-slot arm | f_backref arm |
|---|---|---|---|---|
| this file, cranelift **and** dynasm, `15000 head` and default | 8 | 4 | **0** (16–63 slot walks) | 0 |
| the 70 synth fixtures naming `f_locals`/`tb_frame`/`__traceback__`/`f_back`/`_getframe`, cranelift | — | — | **0 on all 70** | 1 (`exception_residual_raise_caught_in_frame.py`) |

**Neither reading holds.** Eight vrefs are built on this shape at every size
tried, so the optimisation is applying — no perf regression. The value-stack arm
is the one with no producer: `walker_ec_enter` (`inline_call.rs`) stores the
concrete vref into `ec.topframeref` and threads the caller's into
`frame.f_backref`, both frame-shaped fields, neither a `locals_cells_stack_w`
slot.

**And the guard was never ungated.** #1060 (`fa2eda0bd8e`), landing one day after
the guard, covered the arm with
`test_frame_value_slot_holding_a_virtual_ref_skips_the_pyobject_walks`
(`pyre-interpreter/src/eval.rs`) *precisely because* "the bench fixture that
exercised it does not run in the suite", and recorded that removing the early
return aborts it with SIGABRT. CI runs it every push. The header's "no suite
gate" line is corrected; promoting this file would spend three backend runs
re-gating what one unit test already holds.

Two limits are recorded in the header rather than papered over:

- the birth counter sees **tracing-time** births only — compiled code
  materializes a vref through `NEW_WITH_VTABLE` (`optimizeopt/virtualize.rs`),
  which it never observes, so `alloc=8` bounds the tracing population and not
  the runtime one that the arm exists for;
- the `f_backref` arm chosen as a positive control **also read 0** on this
  fixture. Liveness came from the 70-fixture sweep finding the single firing
  case, not from the control.

No production code changes: item 2 is comment-only, and the counters used for it
were reverted before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark reports now separately identify fixtures where the configured PyPy performance limit could not be evaluated because startup-adjusted timing reached the minimum threshold.
  * Reports include the configured ratio ceiling for these fixtures for clearer interpretation.

* **Documentation**
  * Updated reproduction notes with later test-suite results and benchmark measurements.
  * Clarified coverage from existing frame-walking tests and documented observed execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->