### PR TITLE
jit, shutdown, gc: an operand store into the virtualizable identity, and a whole-heap collection per released `__main__` global

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -6789,6 +6789,33 @@ impl MiniMarkGC {
         }
     }
 
+    /// How many objects are registered with a finalizer queue —
+    /// `deal_with_objects_with_finalizers`' working set, young and old.
+    ///
+    /// The destructor lists are deliberately not counted. A destructor is
+    /// RPython's *light* finalizer (`rgc.must_be_light_finalizer`): it may not
+    /// run interpreter code, allocate or resurrect, so nothing the program can
+    /// observe distinguishes the collection it runs in from a later one. In
+    /// pyre they are drop glue — `function_destructor`, `type_object_destructor`,
+    /// `pycode_destructor`, `storage_box_destructor` — so every function, type
+    /// and code object is on those lists and a predicate that counted them
+    /// would never answer zero.
+    pub(crate) fn registered_finalizer_count(&self) -> usize {
+        self.probably_young_objects_with_finalizers.len() + self.old_objects_with_finalizers.len()
+    }
+
+    /// Whether a collection could still hand control back to the program.
+    ///
+    /// `deal_with_objects_with_finalizers` is the one pass that does, and it is
+    /// already guarded on its own queue being non-empty; `rawrefcount` answers
+    /// for the whole of itself, because a collection there can claim a mirror's
+    /// C finalizer and queue its deallocator, and which of its lists that
+    /// reaches is the embedder's business rather than this predicate's. It is
+    /// only ever enabled under `cpyext`.
+    pub(crate) fn has_pending_death_callbacks(&self) -> bool {
+        self.registered_finalizer_count() != 0 || self.rawrefcount_enabled()
+    }
+
     /// incminimark.py `deal_with_objects_with_finalizers`.
     fn deal_with_objects_with_finalizers(&mut self) {
         let mut new_with_finalizer = VecDeque::new();

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -3067,6 +3067,49 @@ pub fn gc_collect_gen(generation: i64) {
     gc_sync::gc_op(|gc| gc.do_collect(generation));
 }
 
+/// Whether a collection could still deliver a finalizer — whether
+/// `deal_with_objects_with_finalizers` has anything registered to pass over, or
+/// `rawrefcount` is live.
+///
+/// `false` means a collection can free memory but cannot run program code, so a
+/// caller that collects only in order to *find* a finalizable object — teardown
+/// releasing one namespace binding at a time — can skip the whole mark-and-sweep
+/// and reach the same observable answer.
+pub fn gc_has_pending_finalizers() -> bool {
+    gc_sync::is_initialized() && gc_sync::gc_query_reentrant(|gc| gc.has_pending_death_callbacks())
+}
+
+/// How many objects are registered with a finalizer queue. A census number, for
+/// diagnostics; [`gc_has_pending_finalizers`] is the question code should ask.
+pub fn gc_registered_finalizer_count() -> usize {
+    if gc_sync::is_initialized() {
+        gc_sync::gc_query_reentrant(|gc| gc.registered_finalizer_count())
+    } else {
+        0
+    }
+}
+
+/// Whether the object at `addr` is itself one the finalizer queue still owes a
+/// delivery — `flags::FINALIZER_REGISTERED` set by
+/// [`GcAllocator::register_finalizer`], minus the two flags that retire it.
+///
+/// This is the whole of `hasuserdel` and more: `allocate_instance` registers
+/// every instance of a `hasuserdel` class, and `_io`, coroutine and weakref
+/// lifeline construction register objects whose *type* carries no such flag.
+/// It answers only for the object itself — another object it is the last
+/// referrer of stays a question only a collection can settle.
+pub fn gc_object_finalizer_pending(addr: usize) -> bool {
+    if !gc_owns_object(addr) {
+        return false;
+    }
+    let hdr = unsafe { header::header_of(addr) };
+    unsafe {
+        (*hdr).has_flag(flags::FINALIZER_REGISTERED)
+            && !(*hdr).has_flag(flags::FINALIZER_RUN)
+            && !(*hdr).has_flag(flags::IGNORE_FINALIZER)
+    }
+}
+
 /// incminimark.py `set_max_heap_size` — the `PYPY_GC_MAX` limit, set from
 /// inside a running process instead of read once at startup.  `0` is
 /// unbounded.

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -3140,10 +3140,19 @@ impl TraceCtx {
             values.len(),
             "set_virtualizable_entry_at: boxes/values length mismatch",
         );
+        // `boxes.len() - 1` is the virtualizable identity
+        // (`virtualizable_boxes[-1]`, appended once by
+        // `init_virtualizable_boxes`), not a state slot: it is the box every
+        // `_nonstandard_virtualizable` check compares against, so a store
+        // landing on it does not corrupt one value, it renames the standard
+        // virtualizable. Nothing may write it through this entry point.
         assert!(
-            index < boxes.len(),
-            "set_virtualizable_entry_at: index {index} out of range for {} slots",
+            index + 1 < boxes.len(),
+            "set_virtualizable_entry_at: index {index} is not a state slot; {} slots carry {} \
+             vable entries plus the virtualizable identity at {}",
             boxes.len(),
+            boxes.len() - 1,
+            boxes.len() - 1,
         );
         boxes[index] = opref;
         values[index] = value;
@@ -5612,10 +5621,26 @@ impl TraceCtx {
 
     /// Compute the flat index into virtualizable_boxes for an array element.
     /// Returns `None` if standard virtualizable is not active or the array field is unknown.
+    ///
+    /// `pyjitpl.py _get_arrayitem_vable_index` gates the same arithmetic on
+    /// `assert 0 <= index < vinfo.get_array_length(virtualizable, arrayindex)`,
+    /// and that assert is load-bearing rather than documentary: the flat space
+    /// runs `[static fields][array 0]..[array n-1][virtualizable identity]`, so
+    /// an index one past the last array is not merely out of the array — it is
+    /// the identity entry `virtualizable_boxes[-1]` that
+    /// `_nonstandard_virtualizable` compares every later vable op against.
+    /// Writing there silently retargets the whole shadow at whatever value the
+    /// store carried. Answer `None` instead: the read paths fall back to a heap
+    /// `GETARRAYITEM_GC_*` and the write path reports `VableArrayStore::
+    /// OutOfVable`, which is the honest outcome for a slot the frame's
+    /// `locals_cells_stack_w` does not have.
     fn vable_array_flat_index(&self, fdescr: &DescrRef, item_index: usize) -> Option<usize> {
         let info = self.virtualizable_info.as_ref()?;
         let lengths = self.virtualizable_array_lengths.as_ref()?;
         let array_idx = info.array_field_by_descr(fdescr)?;
+        if item_index >= *lengths.get(array_idx)? {
+            return None;
+        }
         Some(info.get_index_in_array(array_idx, item_index, lengths))
     }
 

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -239,7 +239,7 @@ its frames on the heap. Lowering it is how the `SubWalkDepthExceeded` decline
 is exercised without building a pathological helper chain; it retires when the
 descent stops recursing on the host stack.
 
-### §6c — Default-OFF diagnostics, censuses and probes (74): keep, cost nothing
+### §6c — Default-OFF diagnostics, censuses and probes (75): keep, cost nothing
 
 Each is inert unless set, so none is a removal target by this file's
 already-ON criterion. They are listed so they cannot be missed again.
@@ -257,7 +257,8 @@ already-ON criterion. They are listed so they cannot be missed again.
 `PYRE_FBW_STRICT_DIAG`,
 `PYRE_FIELD_IDENTITY_CENSUS`,
 `PYRE_FORITER_INFLIGHT_CENSUS`, `PYRE_FOR_ITER_GATE_DIAG`,
-`PYRE_GC_DIAG`, `MAJIT_GC_FREELIST_DIAG`, `PYRE_GEN_ENTRY_DIAG`,
+`PYRE_GC_DIAG`, `MAJIT_GC_FREELIST_DIAG`, `PYRE_GC_SIZE_AUDIT`,
+`PYRE_GEN_ENTRY_DIAG`,
 `PYRE_JD1_DEBUG`, `PYRE_JD1_DUMP`,
 `PYRE_LB_SITE`, `PYRE_LLBC_SKIP_FINGERPRINT_CHECK`, `PYRE_LLBC_STRICT`,
 `PYRE_LOOP_CENSUS`,
@@ -284,6 +285,15 @@ instead of declining before the descent starts. Same shape and same reason as
 `PYRE_WALKABORT_OFF`: the scan decides whether a descent happens at all and its
 cost is invisible in output, so weighing the conservatism against its price
 needs one binary and one variable. It retires when the scan does.
+
+`PYRE_GC_SIZE_AUDIT` makes `finish_alloc_in_oldgen` panic, with a captured
+backtrace, when the block it just carved is smaller than the declared size of
+the type its header names. It is the discriminator between a header stamped
+wrong at allocation and a genuine use-after-free: the collector's own
+`GC BUG` panics fire a whole major later and name the freed object, not the
+site that mis-sized it. Varsize and unregistered type ids are skipped, so it
+answers only where the declared size is authoritative. It retires if the
+check becomes unconditional.
 
 `PYRE_ALLOCSITES` enables stack attribution in the standalone `allocsites`
 example; it is unset by default. Its `AFTER`, `BUDGET`, `EVERY`, and `ROWS`

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -655,6 +655,14 @@ impl ExecutionContext {
         // chain's relink.
         pyre_object::gc_hook::try_gc_write_barrier(frame as *mut u8);
         majit_gc::bh_probe_note_store(frame as usize, crate::pyframe::PYFRAME_F_BACKREF_OFFSET, 1);
+        // A caller that already linked the frame -- `install_current_frame`
+        // sets both ends of this pair -- would make the store below name the
+        // frame itself, and `walk_pyframe_roots` follows `f_backref` with no
+        // cycle guard.
+        debug_assert_ne!(
+            self.topframeref, frame,
+            "ExecutionContext::enter: frame is already the top, so f_backref would name itself",
+        );
         unsafe {
             (*frame).f_backref = self.topframeref;
         }

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -828,6 +828,15 @@ pub(crate) fn function_new_impl(
             unsafe {
                 std::ptr::write(raw as *mut Function, function);
             }
+            // The fields were published by the `ptr::write` above, which no
+            // barrier sees. An old-gen Function that never joins the
+            // remembered set is not scanned by a minor collection, so a
+            // freshly nursery-born `w_func_globals_obj` reached only through
+            // it is neither forwarded nor kept alive. The setters barrier
+            // just ahead of their single store; a bulk write has no such
+            // point, so barrier once behind it for the whole initial set.
+            // Nothing collectable runs in between.
+            function_write_barrier(raw as PyObjectRef);
             return raw as PyObjectRef;
         }
     }

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -694,9 +694,17 @@ pub(crate) fn write_stack_slot(
         // graceful trace abort: the trace is discarded before any code is
         // installed, so the guard resolves through the interpreter instead of
         // crashing the process (mirrors the cross-frame snapshot-gap abort).
+        //
+        // The bound is `len - 1`, not `len`: the last shadow slot is the
+        // virtualizable identity (`virtualizable_boxes[-1]`), the box
+        // `_nonstandard_virtualizable` compares every later vable op against.
+        // One slot past `co_stacksize` lands exactly there, and a store that
+        // reaches it renames the standard virtualizable rather than corrupting
+        // one value — the compiled trace then writes frame fields into
+        // whatever object the push carried.
         if ctx
             .virtualizable_boxes_len()
-            .is_some_and(|len| flat_idx >= len)
+            .is_some_and(|len| flat_idx + 1 >= len)
         {
             crate::state::request_trace_abort();
             return;
@@ -820,6 +828,17 @@ pub(crate) fn swap_stack_slots(
     if sym.owns_virtualizable_shadow() {
         let flat_top = crate::virtualizable_gen::NUM_VABLE_SCALARS + semantic_top;
         let flat_other = crate::virtualizable_gen::NUM_VABLE_SCALARS + semantic_other;
+        // Same `len - 1` bound `write_stack_slot` takes, and for the same
+        // reason: the trailing shadow slot is the virtualizable identity, so a
+        // swap that reaches it would hand the standard-virtualizable box to a
+        // stack slot and a stack value to `virtualizable_boxes[-1]`.
+        if ctx
+            .virtualizable_boxes_len()
+            .is_some_and(|len| flat_top + 1 >= len || flat_other + 1 >= len)
+        {
+            crate::state::request_trace_abort();
+            return;
+        }
         if let (Some((op_top, val_top)), Some((op_other, val_other))) = (
             ctx.virtualizable_entry_at(flat_top),
             ctx.virtualizable_entry_at(flat_other),

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -8537,19 +8537,26 @@ fn eval_with_jit_inner(
             return frame_root.frame().execute_frame_plain(resume);
         }
     }
-    frame_root.frame().fix_array_ptrs();
-    // Set CURRENT_FRAME so zero-arg super() can find __class__ in the caller.
-    let _frame_guard = pyre_interpreter::eval::install_current_frame(frame_root.frame());
-
     // During bridge tracing, concrete force-helper calls use the plain
     // interpreter so they cannot recursively enter warmstate or corrupt the
     // bridge trace's symbolic state.
+    //
+    // Declines before `install_current_frame`, like every decline above it.
+    // Both that helper and `ExecutionContext::enter` link the frame into the
+    // `topframeref`/`f_backref` chain, and `execute_frame_plain` reaches
+    // `enter` through `eval_frame_plain_with_resume`.  Linking twice makes the
+    // second `enter` read the `topframeref` the first one just set to this
+    // same frame, so `f_backref` ends up naming the frame itself and
+    // `walk_pyframe_roots` — which has no cycle guard — never terminates.
     {
         let (drv, _) = driver_pair();
         if drv.is_bridge_tracing() {
             return frame_root.frame().execute_frame_plain(resume);
         }
     }
+    frame_root.frame().fix_array_ptrs();
+    // Set CURRENT_FRAME so zero-arg super() can find __class__ in the caller.
+    let _frame_guard = pyre_interpreter::eval::install_current_frame(frame_root.frame());
 
     // A resumed frame reaches the portal already positioned mid-body, so its
     // payload has to be consumed before the merge point is consulted: the

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -8292,6 +8292,41 @@ impl CodeWriter {
             }};
         }
 
+        // Read a localsplus slot into a value WITHOUT touching the operand
+        // stack — `pyopcode.py`'s bare `self.cells[varindex]` /
+        // `self.locals_cells_stack_w[i]`, which `jtransform.py:1877
+        // do_fixed_list_getitem` lowers to a single `getarrayitem_vable_r`.
+        //
+        // `emit_load_fast_ref!` is the LOAD_FAST *opcode*: that read plus a
+        // `pushvalue`.  A handler that only wants the value in hand must not
+        // borrow a stack slot for it.  The operand stack is the tail of
+        // `locals_cells_stack_w` and is exactly `co_stacksize` slots long, so
+        // a scratch push taken while the stack is already at its compiled
+        // maximum addresses one slot past the array: flat index
+        // `NUM_VABLE_SCALARS + nlocals + co_stacksize` in
+        // `virtualizable_boxes`, which is the trailing virtualizable identity
+        // entry (`virtualizable_boxes[-1]`).  Overwriting it makes every
+        // later vable op read the stored value as the standard virtualizable.
+        macro_rules! emit_read_local_ref {
+            ($reg:expr, $py_pc:expr) => {{
+                let reg = $reg;
+                let read_local_py_pc: i64 = ($py_pc) as i64;
+                let local_slot = local_to_vable_slot(reg as usize) as i64;
+                let v_local_idx: super::flow::FlowValue =
+                    super::flow::Constant::signed(local_slot).into();
+                let v_loaded = emit_graph_op_with_result(
+                    &mut graph,
+                    &current_block.block(),
+                    "getarrayitem_vable_r",
+                    vable_getarrayitem_ref_graph_args(frame_var.into(), v_local_idx.into()),
+                    Kind::Ref,
+                    read_local_py_pc,
+                );
+                let loaded: super::flow::FlowValue = v_loaded.into();
+                loaded
+            }};
+        }
+
         // Post-emit bookkeeping for a stack-pushing handler: append the
         // produced FlowValue to the symbolic stack and run the full
         // `pyframe.py pushvalue` lowering on it.
@@ -13280,9 +13315,14 @@ impl CodeWriter {
                         // `locals_cells_stack_w` holds a cell object
                         // (`initialize_frame_scopes` / MAKE_CELL / the closure
                         // tuple install one), so `i` is the unified localsplus
-                        // index read like LOAD_FAST. The cell is read FIRST so
-                        // it lands above the value on the symbolic stack and
-                        // the two pinned slots stay distinct. The
+                        // index read like LOAD_FAST, but through
+                        // `emit_read_local_ref!`: `pyopcode.py STORE_DEREF`
+                        // reads the cell straight out of `cells[varindex]`,
+                        // and routing it over the operand stack instead
+                        // borrows a slot above the value this opcode pops —
+                        // one past `co_stacksize` whenever the compiler sized
+                        // the stack for that value, which lands on the
+                        // virtualizable identity entry. The
                         // `store_deref_value(cell, value)` HLOp →
                         // `residual_call_r_r(store_deref_value_fn,
                         // ListR[cell, value])` mutates the cell's contents in
@@ -13316,9 +13356,7 @@ impl CodeWriter {
                                     py_pc as i64,
                                 );
                             } else {
-                                emit_load_fast_ref!(current_depth, idx, py_pc);
-                                let _cell_reg = emit_popvalue_ref!(current_depth, py_pc);
-                                let cell_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                                let cell_value = emit_read_local_ref!(idx, py_pc);
                                 let _value_reg = emit_popvalue_ref!(current_depth, py_pc);
                                 let value_value = pop_ref_or_fresh(&mut current_state, &mut graph);
                                 let result_value = emit_graph_op_with_result(

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1484,6 +1484,57 @@ fn release_frees_nothing(value: pyre_object::PyObjectRef) -> bool {
     false
 }
 
+/// Whether releasing this binding leaves the collection that would follow with
+/// no finalizer to deliver — and so whether that whole-heap mark-and-sweep can
+/// be skipped without moving where any `__del__` runs.
+///
+/// `release_frees_nothing` answers first: a value the release removes nothing
+/// from the reachable set can obviously deliver nothing. Past it two questions
+/// remain, and both are `O(1)` where the collection is `O(heap)`:
+///
+/// * Does the collector still owe *any* delivery? `deal_with_objects_with_
+///   finalizers` is the only pass that hands control back to the program, and
+///   with its queues empty a sweep can free memory but cannot run a line of
+///   Python. Re-asked per name because a `__del__` this loop runs can register
+///   one (`test_start_new_thread_at_finalization`'s starts a thread).
+/// * Is *this* object one it owes? `flags::FINALIZER_REGISTERED` is set by
+///   `allocate_instance` for every instance of a `hasuserdel` class and by
+///   `_io`, coroutine and weakref-lifeline construction for objects whose type
+///   carries no such flag, so it is the whole of PyPy's `hasuserdel` test and
+///   more.
+///
+/// The second is where this stops being exact, and deliberately: releasing a
+/// *container* of a finalizable — `holder = [AtFinalization()]` — frees one
+/// that no `O(1)` test on `holder` can see, and its `__del__` then runs at the
+/// walk's trailing collection instead of at its own name, reading `None` for
+/// the `__main__` globals released after it rather than their values. It still
+/// runs. Buying that case back costs a whole-heap mark-and-sweep per name, and
+/// a namespace binds one per function, class and import: releasing `inspect`'s
+/// 182 names as `__main__` was 1.5s of `pyre -m inspect`'s 1.9s against pypy3's
+/// 0.09s total, and `test.test_inspect` pays it four times over in
+/// subprocesses. PyPy itself neither clears `__main__` nor collects here
+/// (`baseobjspace.py finish`), so nothing upstream prices that case higher.
+fn release_delivers_no_finalizer(value: pyre_object::PyObjectRef) -> bool {
+    release_frees_nothing(value)
+        || !majit_gc::gc_has_pending_finalizers()
+        || !majit_gc::gc_object_finalizer_pending(value as usize)
+}
+
+/// `PYRE_GC_DIAG`: how many `__main__` bindings the release walk let go, and
+/// how many of them it collected after. `swept` is the count
+/// [`release_delivers_no_finalizer`] exists to keep near zero; a run where it
+/// tracks `released` is one where the walk is back to a mark-and-sweep per name.
+fn teardown_census(released: usize, swept: usize) {
+    if std::env::var_os("PYRE_GC_DIAG").is_none() {
+        return;
+    }
+    let registered = majit_gc::gc_registered_finalizer_count();
+    eprintln!(
+        "[jit-gc-diag] teardown_released={released} teardown_swept={swept} \
+         finalizers_registered={registered}"
+    );
+}
+
 fn shutdown_module_private_name(name: &rustpython_wtf8::Wtf8) -> bool {
     let bytes = name.as_bytes();
     bytes.first() == Some(&b'_') && bytes.get(1) != Some(&b'_')
@@ -1625,6 +1676,7 @@ fn finalize_runtime(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyExecut
     // its buffered writes.
     pyre_interpreter::module::_io::flush_all_streams();
     let mut swept_something_finalizable = collect_and_run_finalizers(ec_ptr);
+    let (mut released, mut swept) = (0usize, 0usize);
     let mut entries = unsafe { pyre_object::w_dict_str_entries(canonical) };
     entries.reverse();
     for (name, _) in entries {
@@ -1635,14 +1687,17 @@ fn finalize_runtime(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyExecut
         // this loop may have rebound the name, and the decision below is only
         // sound about the value actually being released.
         let value = unsafe { pyre_object::w_dict_getitem_str(canonical, &name) };
-        let frees_nothing = value.is_none_or(release_frees_nothing);
         unsafe {
             pyre_object::w_dict_setitem_str(canonical, &name, pyre_object::w_none());
         }
-        if !frees_nothing {
-            swept_something_finalizable = collect_and_run_finalizers(ec_ptr);
+        released += 1;
+        if value.is_none_or(release_delivers_no_finalizer) {
+            continue;
         }
+        swept += 1;
+        swept_something_finalizable = collect_and_run_finalizers(ec_ptr);
     }
+    teardown_census(released, swept);
     // Close the loop on a swept heap and a drained queue. A release the loop
     // skipped removes nothing from the reachable set, and one it did not is
     // followed immediately by the sweep above, so the only way this heap can

--- a/pyre/pyrex/tests/vable_identity_slot.rs
+++ b/pyre/pyrex/tests/vable_identity_slot.rs
@@ -1,0 +1,111 @@
+//! A traced frame must never store an operand into the virtualizable identity.
+//!
+//! `virtualizable_boxes` is laid out `[static fields][array slots][identity]`,
+//! and the trailing identity entry is the box `_nonstandard_virtualizable`
+//! compares every later vable op against. A store that lands on it does not
+//! corrupt one value — it renames the standard virtualizable, after which the
+//! compiled trace writes `PyFrame` fields into whatever object the store
+//! carried and dereferences that object's `locals_cells_stack_w`.
+//!
+//! The reachable producer was STORE_DEREF: its codewriter lowering read the
+//! cell with the LOAD_FAST *opcode* (a `getarrayitem_vable_r` plus a
+//! `pushvalue`) while its own operand still occupied the top of the stack, so
+//! the scratch push addressed one slot past `co_stacksize` — exactly the
+//! identity entry. A class body is the shape that reaches it with no headroom:
+//! `class C: def m(self): pass` compiles to `co_stacksize=1` with a single
+//! `__classdict__` cellvar, and `STORE_DEREF __classdict__` runs with the
+//! `LOAD_LOCALS` result on the stack.
+//!
+//! The failure is a SIGSEGV inside JIT-generated code with nothing on stdout or
+//! stderr, so this test scores the **exit status**. A harness that only
+//! inspected output would call the crash a pass.
+//!
+//! The trip count has to clear the function-entry trace threshold (~1619), so
+//! it is deliberately well above it rather than tuned to it.
+//!
+//! Do not invoke Cargo from this test: the parent `cargo test` holds the target
+//! directory lock. `CARGO_BIN_EXE_pyre-dynasm` supplies the binary Cargo already
+//! built for this integration test.
+
+// `pyre-dynasm` is `required-features = ["dynasm"]`, so under
+// `--no-default-features` the binary does not exist and `CARGO_BIN_EXE_…` is
+// unset — which would be a compile error rather than a skip. Compile this file
+// to nothing in that configuration instead.
+#![cfg(feature = "dynasm")]
+
+use std::io::Write;
+use std::process::Command;
+
+const PYRE: &str = env!("CARGO_BIN_EXE_pyre-dynasm");
+
+/// Run `source` through the dynasm binary and return `(exit code, stdout)`.
+///
+/// The exit code is `None` for a signal death — which is the whole point of
+/// this test, so it is reported rather than unwrapped.
+fn run(name: &str, source: &str) -> (Option<i32>, String) {
+    let dir =
+        std::env::temp_dir().join(format!("pyre-vable-identity-{name}-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let path = dir.join(format!("{name}.py"));
+    let mut file = std::fs::File::create(&path).expect("scratch script");
+    file.write_all(source.as_bytes()).expect("write script");
+    drop(file);
+
+    let out = Command::new(PYRE)
+        .arg(&path)
+        .output()
+        .expect("run pyre-dynasm");
+    let _ = std::fs::remove_dir_all(&dir);
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+    )
+}
+
+/// A class body carrying a method, entered often enough to be compiled as a
+/// function-entry trace.
+const CLASS_BODY_IN_LOOP: &str = "\
+for i in range(3000):
+    class C:
+        def m(self):
+            return 41 + 1
+print(C.__name__, C().m())
+";
+
+/// The same cell store outside a class body, so a regression that reaches
+/// STORE_DEREF generally — not only through `__classdict__` — is separable.
+const CELL_STORE_IN_LOOP: &str = "\
+def outer(n):
+    total = 0
+    for i in range(n):
+        x = i * 2
+        def inner():
+            return x
+        total += inner()
+    return total
+print(outer(3000))
+";
+
+#[test]
+fn class_body_in_a_loop_survives_being_compiled() {
+    let (code, stdout) = run("class_body", CLASS_BODY_IN_LOOP);
+    assert_eq!(
+        code,
+        Some(0),
+        "a compiled class body must exit cleanly; `None` is a signal death \
+         (the identity-slot clobber segfaults inside JIT code and prints nothing). \
+         stdout: {stdout:?}",
+    );
+    assert_eq!(stdout.trim(), "C 42");
+}
+
+#[test]
+fn cell_store_in_a_loop_survives_being_compiled() {
+    let (code, stdout) = run("cell_store", CELL_STORE_IN_LOOP);
+    assert_eq!(
+        code,
+        Some(0),
+        "a compiled STORE_DEREF loop must exit cleanly. stdout: {stdout:?}",
+    );
+    assert_eq!(stdout.trim(), "8997000");
+}


### PR DESCRIPTION
Five fixes that accumulated on `agent/stdlib-foundations`. They are independent
of each other; the branch is shared, so the first three predate this session's
work on it.

### `jit: keep an operand store out of the virtualizable identity slot`

`class C: def m(self): pass` in a loop past the function-entry threshold
**SIGSEGVs**, with nothing on either stream.

`virtualizable_boxes` is `[static fields][array slots][identity]`, and the
trailing identity entry is the box `_nonstandard_virtualizable` compares every
vable op's frame against. STORE_DEREF's codewriter lowering read the cell with
`emit_load_fast_ref!` — the LOAD_FAST *opcode*, a `getarrayitem_vable_r` plus a
`pushvalue` — while the value it was about to pop still held the top of the
stack, so the scratch push addressed one slot past `co_stacksize`: exactly that
identity entry. A class body reaches it with no headroom (`co_stacksize=1`, one
`__classdict__` cellvar → an 8-slot shadow whose identity is flat 7). The trace
then declared the real frame nonstandard and wrote `PyFrame.last_instr`, the
force token and the exit flush into the Cell; reading the Cell's absent
`locals_cells_stack_w` faulted at `obj - 4` inside the write-barrier fast path.

`emit_read_local_ref!` emits the read alone, which is what `pyopcode.py`
STORE_DEREF's `cells[varindex]` is. Two bounds close the class rather than the
one instance: `vable_array_flat_index` restores `_get_arrayitem_vable_index`'s
`assert 0 <= index < get_array_length` as a `None` return, and
`write_stack_slot` / `swap_stack_slots` bound at `len - 1` — the existing
`>= len` test was one slot too loose and passed exactly this store through.

The regression test scores the **exit status**: the crash prints nothing, so a
harness reading output calls it a pass.

### `shutdown: stop collecting once per released __main__ global`

`finalize_runtime` ran a whole-heap mark-and-sweep after every released
`__main__` binding — 400 globals cost 403 major collections and 3015ms against
pypy3's 54ms. The collection exists to *find* a finalizer, so it is replaced by
two O(1) questions (`gc_has_pending_finalizers`, `gc_object_finalizer_pending`)
where the collection was O(heap). `major` 403 → 3, 3015ms → 115ms;
`pyre -m inspect sys` 1854ms → 179ms; `test.test_inspect` 7.56s → 3.17s with
its 362 tests still passing. The exactness this gives up (a *container* of a
finalizable) and the new `PYRE_GC_DIAG` counters are described in the commit.

### `jit: decline bridge-tracing frames before install_current_frame`

The decline sat between `install_current_frame` and `ExecutionContext::enter`,
which both link a frame into the `topframeref`/`f_backref` chain, so the frame
was linked twice and `f_backref` named the frame itself — and
`walk_pyframe_roots` follows `f_backref` with no cycle guard.

### `function: barrier the old-gen Function after its initializing write`

`function_new_impl` publishes every field with one `ptr::write`, which no write
barrier sees, so an old-gen `Function` never joined the remembered set and a
minor collection did not scan it.

### `gate-triage: add the PYRE_GC_SIZE_AUDIT row`

`every_live_gate_has_a_triage_entry` reported the gate as missing from §6c.

---

### Verification

`cargo test --all --features dynasm` — **8422 passed, 0 failed**, both new
regression tests included, on a tree whose LLBC artefacts had just been
re-extracted (`--check` rc=0, all four fingerprints matching, `window writes: 0
over 280 of 280 closure inputs`).

That run is from the commit before this branch was rebased onto `d0fd532f049`;
the rebase left the patch-id unchanged (`7bb1b577a405`), so it is the same
change on a newer base. `python3 pyre/check.py` has not produced a verdict
locally: two external rebases of this branch landed in the middle of its runs,
which moves the LLBC fingerprints and makes anything after them judge a tree
that no longer exists. CI is the first full run on this base.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added garbage-collection diagnostics for pending finalizers, registered finalizer counts, and object-specific finalizer status.
  * Runtime shutdown now reports collection and released-binding statistics when GC diagnostics are enabled.

* **Bug Fixes**
  * Prevented virtualizable state and stack operations from corrupting identity or frame data.
  * Improved frame-chain safety and garbage-collection tracking.
  * Avoided unnecessary collections during runtime teardown.

* **Documentation**
  * Documented the new GC allocation-size diagnostic and its retirement criteria.

* **Tests**
  * Added regression coverage for virtualizable identity-slot corruption and JIT stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->