### PR TITLE
jit-trace, majit: descend `~x`, name the load_deref declines, and move two descent walls

### DIFF
--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -9213,6 +9213,34 @@ impl<'a> Lowering<'a> {
             op_kind
         };
 
+        // Retarget the interpreter's own unary RBigInt wrappers to the same
+        // residuals.  A descent reaches `descroperation::bigint_neg` /
+        // `bigint_invert` as an unlowered helper and never walks their
+        // bodies, so the `<RBigInt as Neg>::neg` call inside is not a call the
+        // retarget above ever sees.  Guarded like the divmod projections:
+        // sole operand and destination both the opaque `BigInt` ADT.  Same
+        // pure-target-swap, fail-safe contract.
+        let op_kind = if let OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 1
+            && tyref_is_rbigint(&call.dest.ty, self.llbc)
+            && first_arg_ty
+                .as_ref()
+                .is_some_and(|ty| tyref_is_rbigint(ty, self.llbc))
+            && let Some(residual) = crate::front::rbigint_call::unop_wrapper_residual_path(segments)
+        {
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments: residual },
+                args: args.clone(),
+                result_ty: ValueType::Ref(None),
+            }
+        } else {
+            op_kind
+        };
+
         // `RBigInt::digits{,_mut}` is only the Rust view adapter for
         // RPython's direct `self._digits` GcArray field.  Project the field
         // itself so the annotator receives the `[Signed]` SomeList registered

--- a/majit/majit-translate/src/front/rbigint_call.rs
+++ b/majit/majit-translate/src/front/rbigint_call.rs
@@ -275,6 +275,38 @@ pub(crate) fn compiler_bigint_residual_path(segments: &[String]) -> Option<Vec<S
     )
 }
 
+/// The interpreter's own unary RBigInt wrappers.
+///
+/// A descent reaches `descroperation::bigint_neg` / `bigint_invert` as an
+/// unlowered helper and stops there, so the `<RBigInt as Neg>::neg` call in
+/// their bodies is never seen and
+/// [`bigint_unop_residual_path`](crate::front::bigint_binop::bigint_unop_residual_path)
+/// never applies.  Swapping the wrapper itself reaches the same two residuals
+/// the operator spelling reaches, the way [`divmod_projection_residual_path`]
+/// does for the binary wrappers.
+pub(crate) fn unop_wrapper_residual_path(segments: &[String]) -> Option<Vec<String>> {
+    let residual = match segments.last().map(String::as_str) {
+        Some("bigint_neg") => "jit_bigint_neg",
+        Some("bigint_invert") => "jit_bigint_invert",
+        _ => return None,
+    };
+    if !segments
+        .iter()
+        .rev()
+        .skip(1)
+        .take(2)
+        .eq(["descroperation", "objspace"])
+    {
+        return None;
+    }
+    Some(
+        ["pyre_interpreter", "objspace", "descroperation", residual]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+    )
+}
+
 /// Zero-checked interpreter seams for the two projections of
 /// `rbigint.divmod`. Each returns a direct RBigInt handle at source level, so
 /// the target swap is ABI-identical to the other pointer residual mappings.
@@ -312,6 +344,44 @@ mod tests {
 
     fn segs(parts: &[&str]) -> Vec<String> {
         parts.iter().map(|part| part.to_string()).collect()
+    }
+
+    #[test]
+    fn maps_the_unary_wrappers_and_nothing_else() {
+        for (wrapper, residual) in [
+            ("bigint_neg", "jit_bigint_neg"),
+            ("bigint_invert", "jit_bigint_invert"),
+        ] {
+            assert_eq!(
+                unop_wrapper_residual_path(&segs(&[
+                    "pyre_interpreter",
+                    "objspace",
+                    "descroperation",
+                    wrapper,
+                ])),
+                Some(segs(&[
+                    "pyre_interpreter",
+                    "objspace",
+                    "descroperation",
+                    residual,
+                ])),
+            );
+        }
+        // The owner is load-bearing: a same-named function anywhere else is
+        // not this wrapper and keeps its own body.
+        assert_eq!(
+            unop_wrapper_residual_path(&segs(&["pyre_object", "longobject", "bigint_neg"])),
+            None,
+        );
+        assert_eq!(
+            unop_wrapper_residual_path(&segs(&[
+                "pyre_interpreter",
+                "objspace",
+                "descroperation",
+                "bigint_clone",
+            ])),
+            None,
+        );
     }
 
     #[test]

--- a/pyre/design.md
+++ b/pyre/design.md
@@ -531,13 +531,22 @@ recorder, or the green accounts for.
 
 ### 3.8 The fold layer: hand-written compensation for an opaque objspace
 
-pyre records traces through 74 `try_walker_specialize_*` functions — 72 in
-`jitcode_dispatch/specialize.rs`, one each in `residual_call.rs` and
-`inline_call.rs` — 10,858 lines of body inside `specialize.rs`'s 17,349,
-described by the 76 rows of `SPEC_FOLD_ROWS` (one fold can back several rows,
-and one row-less fold exists). Nothing in this charter named that layer before
-2026-08-26, which is itself the finding: it is the largest single adaptation
-in the tree.
+pyre records traces through 69 `try_walker_specialize_*` functions — 67 in
+`jitcode_dispatch/specialize.rs`, one each in `residual_call.rs`
+(`load_deref`) and `inline_call.rs` (`instance_next`) — 9,886 lines of body
+inside `specialize.rs`'s 16,880, described by the 73 rows of
+`SPEC_FOLD_ROWS` (one fold can back several rows, and row-less folds exist).
+Nothing in this charter named that layer before 2026-08-26, which is itself
+the finding: it is the largest single adaptation in the tree.
+
+Re-derive every number here before citing it; this section has already
+published one miscount. Rows: `spec_folds!` spans `diag.rs:342-417`, so
+`sed -n '342,417p' … | rg -c '=> ("'`. Definitions:
+`rg -c 'fn try_walker_specialize_' pyre/ majit/ -g '*.rs'`. Corpus:
+`ls pyre/bench/synth/*.py | wc -l` — a git pathspec glob crosses `/` and
+sweeps `_pending`, `foriter57` and `iter57`, over-counting by 46.
+`specialize.rs`'s own line count moved seven times in seven commits and is
+not a usable identifier for a tree.
 
 **Why it exists.** PyPy's objspace is RPython, so the tracer walks into it and
 `optimizeopt/` only ever sees ordinary recorded operations. pyre's objspace is
@@ -552,7 +561,7 @@ favour of the ported optimizer" — is not available as stated. Group by group:
 | opaque builtin call → pure elidable call | 19 | `OptPure.optimize_CALL_PURE_I`; recognition is `jtransform._handle_math_sqrt_call` and `@jit.elidable`, not a pass |
 | residual → `new_with_vtable` / `new_array` so it stays virtual | 10 | `OptVirtualize` removes such ops; the emitter is `MIFrame.opimpl_newlist` |
 | guarded heap field / array / mapdict read and write | 19 | `OptHeap` CSEs them; the emitter is traced `LOAD_ATTR_caching` |
-| type-identity shortcut | 3 | `OptRewrite._optimize_oois_ooisnot` plus `Optimizer.constant_fold` — a real pass |
+| type-identity shortcut | 0 | retired 2026-08-24; was `OptRewrite._optimize_oois_ooisnot` plus `Optimizer.constant_fold` — a real pass |
 | frame / execution-context introspection | 6 | none at any layer; PyPy forces the virtualizable instead |
 | function-object construction | 2 | none |
 
@@ -565,26 +574,41 @@ generation debt, but its stated repair is now the right one.
 
 **What was tried.** A gateway-wrapper pilot gave `math.sqrt` its own jitcode
 and a published `fnaddr`; the descent still declined on 433 transitive
-blockers and retired zero folds. A separate census over the synthetic corpus
-found no fold with `consulted=0`, so the layer is not merely carrying dead
-arms — `load_deref` alone never fired.
+blockers and retired zero folds. A census over the whole corpus — 481
+synthetic plus the macro benches, every one of the 73 rows observed — found
+no fold with `consulted=0`, so the layer is not merely carrying dead arms.
+`load_deref` alone never fires, and naming each of its early returns shows
+why: all 38 declines across the 359 fixtures holding a nested function report
+the same first guard, `OpRef::is_constant`, so its cell always arrives red.
+That is a missing capability rather than dead weight — closure-callee
+inlining needs the fold, the fold needs constant cells, and constant cells
+need the inlining.
 
-**What does not hold it in place.** Only 15 fixtures carry a `spec-folds=`
-header and they name 25 distinct folds between them, so 51 of the 76 rows have
-no fixture coupling at all. Retirement is blocked by reach, not by headers.
+**What does not hold it in place.** 23 fixtures carry a `spec-folds=` header
+and they name 44 distinct folds between them, so 29 of the 73 rows have no
+fixture coupling at all. Retirement is blocked by reach, not by headers.
 
-**The bounded first step** is the type-identity group — `builtin_type`,
-`builtin_isinstance`, `builtin_issubclass`, 291 lines — because it is the
-smallest group that is entirely fixture-free *and* whose upstream counterpart
-is a pass that pyre has already ported (`PtrEq | InstancePtrEq` is registered
-in `executor.rs` and reached through `OptPure`). Its go/no-go is a
-measurement, not a design question: whether the descent declines on those
-three callables and on which blocker. Until that is run, the step is proposed
-and not accepted.
+**The bounded first step has been taken, and it does not settle the
+question.** The type-identity group — `builtin_type`, `builtin_isinstance`,
+`builtin_issubclass`, plus `builtin_hasattr` — left `SPEC_FOLD_ROWS` in
+`4953fb0edf8`, on the evidence that suppressing each one moved no stdout, no
+`[jit-stats]` counter and no wall clock. That is gate neutrality, not a
+descent: nothing in that change demonstrates the trace now carries the
+interpreter's own `abstract_isinstance_w` shape, and `isinstance` is still
+recognised outside the layer, at `residual_call.rs:3416`, where it gates
+replay-safety, carries no row, and the census cannot see it. Read that
+commit's message with care — it claims five retirements including
+`load_type_name_attr`, but its diff never touches that identifier and the
+fold is live at `specialize.rs:3931`.
 
-**Falsification.** If making those three callables descendable does not let
-their folds be retired with the corpus unchanged, then reach is not the
-binding constraint and this entry is wrong — the layer would then be
+**Falsification.** A retirement counts against this entry only if the trace
+it leaves is the interpreter's own shape. `MAJIT_LOG=1`'s
+`--- trace (before opt) ---` must show the residual replaced by ordinary
+recorded operations, matching `PYPYLOG=jit-log-opt:FILE pypy3` on the same
+fixture. A retirement that only shows unchanged counters — as the four above
+do — proves the fold was not load-bearing, not that reach arrived. If reach
+does arrive for a group and its folds still cannot be retired, then reach is
+not the binding constraint and this entry is wrong: the layer would be
 compensating for something the descent cannot reach in principle, and the
 right response is to say what that is rather than to widen the descent again.
 

--- a/pyre/design.md
+++ b/pyre/design.md
@@ -533,18 +533,29 @@ recorder, or the green accounts for.
 
 pyre records traces through 69 `try_walker_specialize_*` functions — 67 in
 `jitcode_dispatch/specialize.rs`, one each in `residual_call.rs`
-(`load_deref`) and `inline_call.rs` (`instance_next`) — 9,886 lines of body
-inside `specialize.rs`'s 16,880, described by the 73 rows of
+(`load_deref`) and `inline_call.rs` (`instance_next`) — 9,865 lines of body
+inside `specialize.rs`'s 16,933, described by the 74 rows of
 `SPEC_FOLD_ROWS` (one fold can back several rows, and row-less folds exist).
 Nothing in this charter named that layer before 2026-08-26, which is itself
 the finding: it is the largest single adaptation in the tree.
 
-Re-derive every number here before citing it; this section has already
-published one miscount. Rows: `spec_folds!` spans `diag.rs:342-417`, so
-`sed -n '342,417p' … | rg -c '=> ("'`. Definitions:
-`rg -c 'fn try_walker_specialize_' pyre/ majit/ -g '*.rs'`. Corpus:
-`ls pyre/bench/synth/*.py | wc -l` — a git pathspec glob crosses `/` and
-sweeps `_pending`, `foriter57` and `iter57`, over-counting by 46.
+Re-derive every number here before citing it; this section has published
+two miscounts, and both survived because the recipe beside them did not run.
+Every command below is quoted as it must be typed.
+
+* Rows — `spec_folds!` opens at `diag.rs:342` and closes at `:418`:
+  `sed -n '342,418p' pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs | rg -cF '=> ("'`.
+  `-F` is load-bearing: without it the `(` is an unclosed regex group and
+  `rg` exits 2 rather than counting.
+* Definitions — `rg -c` reports one count *per file*, so it answers 67/1/1
+  rather than 69. Sum the matches instead:
+  `rg -o 'fn try_walker_specialize_' pyre/ majit/ -g '*.rs' | wc -l`.
+* Body lines — sum the brace-matched span of each `fn try_walker_specialize_*`
+  in `specialize.rs`; no one-liner does it.
+* Corpus — `ls pyre/bench/synth/*.py | wc -l`. Non-recursive **on purpose**:
+  a recursive walk sweeps `_pending`, `foriter57` and `iter57` and answers
+  530, over-counting by 46. Do not "fix" this to a `find`.
+
 `specialize.rs`'s own line count moved seven times in seven commits and is
 not a usable identifier for a tree.
 

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -222,7 +222,7 @@ build.
 
 `PYRE_FBW_NO_SPECIALIZE` is the one entry here that changes behaviour rather
 than reporting it: its comma-separated selectors (or the reserved `all`) turn
-off that many of the 73 hand-written trace-time specialization rows (the
+off that many of the 74 hand-written trace-time specialization rows (the
 `spec_folds!` invocation at `jitcode_dispatch/diag.rs:342-417`; count them
 there rather than trusting this sentence), and an unset variable suppresses
 none. It is a measurement instrument — suppressing a fold is how the descent

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -222,10 +222,12 @@ build.
 
 `PYRE_FBW_NO_SPECIALIZE` is the one entry here that changes behaviour rather
 than reporting it: its comma-separated selectors (or the reserved `all`) turn
-off that many of the 55 hand-written trace-time specialization rows, and an
-unset variable suppresses none. It is a measurement instrument — suppressing a
-fold is how the descent wall behind it is made to print — so it retires with
-the folds it selects, not before them.
+off that many of the 73 hand-written trace-time specialization rows (the
+`spec_folds!` invocation at `jitcode_dispatch/diag.rs:342-417`; count them
+there rather than trusting this sentence), and an unset variable suppresses
+none. It is a measurement instrument — suppressing a fold is how the descent
+wall behind it is made to print — so it retires with the folds it selects,
+not before them.
 `PYRE_FBW_SPEC_CENSUS` in §6c is its read-only half: the per-fold
 consulted/fired tallies. `PYRE_WASM_SPEC_CENSUS` is that same readout on the
 wasm backend, where the guest reads no environment and the runner has to arm

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -5582,6 +5582,22 @@ pub fn invert(a: PyObjectRef) -> PyResult {
             crate::warn::warn_category_w(bool_invert_deprecation_text(), "DeprecationWarning", 2)?;
             return Ok(w_int_new(!int_value(a)));
         }
+        invert_inner(a)
+    }
+}
+
+/// [`invert`] past its `__invert__` override probe and its bool slot.
+///
+/// Split out so that a trace can descend this body rather than re-emit it by
+/// hand.  The two arms left behind are what stop such a descent: the probe's
+/// `needs_numeric_unaryop_dispatch` is `dont_look_inside` and is the second
+/// operation the body executes, and the bool slot's deprecation warning
+/// reaches `lookup_exc_class`.  A caller that has already proven an exact
+/// `int` receiver takes neither, so entering here records the integer arm
+/// alone.  Every other caller reaches this through [`invert`] and is
+/// unaffected.
+pub fn invert_inner(a: PyObjectRef) -> PyResult {
+    unsafe {
         if is_int(a) {
             return Ok(w_int_new(!int_value(a)));
         }

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -4986,7 +4986,20 @@ pub fn compare(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
     // non-overriding subclasses fall through to the by-layout comparison slot,
     // which gives the inherited builtin comparison.
     unsafe {
-        if let Some(result) = try_compare_override(a, b, op)? {
+        // A pair of exact builtins cannot reach an override, so the probe can
+        // only answer `None` for it: `is_instance` is false for both, and
+        // `subclass_special_override` returns `None` on
+        // `is_exact_builtin_instance` before it looks anything up.  Deciding
+        // that here spares the pair a reverse-dunder resolution and two MRO
+        // lookups, which is the whole of the probe for the commonest
+        // comparison there is.
+        //
+        // Only the probe is skipped.  The subtype ordering below still runs
+        // for such a pair, because `bool` is a proper subclass of `int` and
+        // both are exact builtin instances.
+        let pair_can_override = !pyre_object::is_exact_builtin_instance(a)
+            || !pyre_object::is_exact_builtin_instance(b);
+        if pair_can_override && let Some(result) = try_compare_override(a, b, op)? {
             return Ok(result);
         }
         // PyPy `descroperation.py:_make_comparison_impl` swaps the operands

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -5017,7 +5017,11 @@ pub fn compare(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
             && !is_instance(b)
             && let (Some(a_type), Some(b_type)) =
                 (crate::typedef::r#type(a), crate::typedef::r#type(b))
-            && a_type != b_type
+            // Spelled as a raw-pointer identity, the way this file spells every
+            // other one.  `NonNull`'s own `!=` goes through `NonNull::ne`,
+            // which is not a call a trace can lower, and this test now sits on
+            // the walked path for an exact-builtin pair.
+            && !std::ptr::eq(a_type.as_ptr(), b_type.as_ptr())
             && issubtype_cached(b_type.as_ptr(), a_type.as_ptr())
         {
             return compare_slot(b, a, reverse_compare_op(op));

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -345,7 +345,7 @@ spec_folds! {
     TruthBool            => ("truth_bool",               "residual_call", "-"),
     UnaryPositiveInt     => ("unary_positive_int",       "residual_call", "-"),
     UnaryNegativeInt     => ("unary_negative_int",       "residual_call", "-"),
-    UnaryInvertInt       => ("unary_invert_int",         "residual_call", "-"),
+    UnaryInvertDescent   => ("unary_invert_descent",     "residual_call", "-"),
     StoreSubscr          => ("store_subscr",             "residual_call", "-"),
     Setslice             => ("setslice",                 "residual_call", "-"),
     GetIter              => ("get_iter",                 "residual_call", "-"),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -4198,15 +4198,14 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         if ctx.trace_ctx.heap_cache().is_unescaped(callable_guard_op) {
             return resolved_inline_decline(op.pc, line!());
         }
-        let resolved: Option<KwonlyDefaultsInline> =
-            crate::jitcode_dispatch::diag::spec_gate(
-                crate::jitcode_dispatch::diag::SpecFold::KwonlyDefaultsInline,
-                || {
-                    Ok::<_, DispatchError>(unsafe {
-                        kwonly_defaults_for_inline(callable, w_code, nparams, kwonly_count)
-                    })
-                },
-            )?;
+        let resolved: Option<KwonlyDefaultsInline> = crate::jitcode_dispatch::diag::spec_gate(
+            crate::jitcode_dispatch::diag::SpecFold::KwonlyDefaultsInline,
+            || {
+                Ok::<_, DispatchError>(unsafe {
+                    kwonly_defaults_for_inline(callable, w_code, nparams, kwonly_count)
+                })
+            },
+        )?;
         let Some(resolved) = resolved else {
             return resolved_inline_decline(op.pc, line!());
         };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -6282,18 +6282,18 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
 
-    // #61: UNARY_INVERT `~int` fold.  `~x` always fits an int, so the fold
-    // emits a plain `IntInvert` behind a `GUARD_CLASS INT` (no overflow guard),
-    // eliding the `CALL_MAY_FORCE`.  A bool / subclass / non-int operand
-    // declines to the generic leg.
+    // UNARY_INVERT.  Descend `invert_inner` -- `invert` past the override probe
+    // and the bool slot -- rather than re-emit its integer arm by hand.  This
+    // replaced `unary_invert_int`, whose site it took whole: with the descent
+    // in, that fold measured `consulted=0` on every fixture that exercises `~`.
+    // Falls through to the generic residual when the body is absent from this
+    // build or reaches a helper the build did not lower.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && r_args.len() == 1
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::UnaryInvert
-        && spec_gate(SpecFold::UnaryInvertInt, || {
-            try_walker_specialize_unary_invert_int(
-                ctx, op.pc, r_args[0], &allboxes, call_descr, dst, dst_bank,
-            )
+        && spec_gate(SpecFold::UnaryInvertDescent, || {
+            try_walker_orthodox_unary_invert(ctx, op.pc, r_args[0], dst, dst_bank)
         })?
         .is_some()
     {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -5436,21 +5436,23 @@ fn mapdict_qmut_force_enabled() -> bool {
 /// is deliberately not a mutation).  Dropping the check would fold a wrong
 /// answer, so a null falls through to the live residual read.
 ///
-/// !! THIS FOLD CURRENTLY FIRES NOWHERE.  Measured 2026-08-24 on release
-/// dynasm over every `bench/synth` fixture that contains a nested function (71
-/// of them, selected by AST rather than by name): the `load_deref` census row
-/// is reported by all 71, `consulted` totals 46, and `fired` totals 0.  Its
-/// ideal shape — a write-once freevar read from a hot `while` — reads
-/// `consulted=1 fired=0` too, so this is not a coverage gap in the corpus.
+/// !! THIS FOLD CURRENTLY FIRES NOWHERE, AND THE FIRST GUARD IS WHY.
+/// Re-measured 2026-08-26 on release dynasm with every early return named
+/// through `decline!`: over the whole corpus the census row reads
+/// `consulted=59 fired=0`, and over the 359 `bench/synth` fixtures holding a
+/// nested function every one of the 38 declines reports `cell-not-constant`.
+/// No other reason is reported anywhere.  Its ideal shape — a write-once
+/// freevar read from a hot `while` — reports the same single reason, as does a
+/// closure callee called from a hot loop, so this is not a coverage gap in the
+/// corpus and the later guards are unreached rather than merely quiet.
 ///
-/// `ever_mutated` is not what declines: `CellFamily::new` is born `false` and
-/// a write-once binding never sets it.  The first guard, `jit.isconstant` /
-/// [`OpRef::is_constant`], is the suspect — a cell read out of the frame's own
-/// cells region is red — but which guard actually declines has NOT been
-/// isolated, so do not repeat that as established.  The `can_move` gate on the
-/// contents postdates that measurement, so it is not what declined then.  A
-/// `spec-folds=load_deref` directive would therefore fail today; the row
-/// exists, unguarded, and is documented here rather than gated.
+/// So `jit.isconstant` / [`OpRef::is_constant`] is established, not suspected:
+/// the cell arrives red because it is read out of the frame's own cells
+/// region.  `ever_mutated` was never a candidate — `CellFamily::new` is born
+/// `false` and a write-once binding never sets it — and the `can_move` gate on
+/// the contents is likewise never reached.  A `spec-folds=load_deref`
+/// directive would therefore fail today; the row exists, unguarded, and is
+/// documented here rather than gated.
 ///
 /// The one admission that made closure callees inline, and with them their
 /// cells reach a sub-walk as constants, was `RuntimeHelperKind::LoadDeref` in
@@ -5461,15 +5463,25 @@ fn try_walker_specialize_load_deref<Sym: WalkSym>(
     op_pc: usize,
     r_args: &[OpRef],
 ) -> Result<Option<OpRef>, DispatchError> {
+    /// Name the guard that declined, so that "this fold fires nowhere" can be
+    /// attributed to one of them instead of re-derived by reading.
+    macro_rules! decline {
+        ($why:literal) => {{
+            if fbw_debug_abort_enabled() {
+                eprintln!("[decline-why] LOAD-DEREF {}", $why);
+            }
+            return Ok(None);
+        }};
+    }
     // nestedscope.py `if jit.isconstant(self)`.
     let Some(&cell_op) = r_args.first() else {
-        return Ok(None);
+        decline!("no-cell-operand");
     };
     if !cell_op.is_constant() {
-        return Ok(None);
+        decline!("cell-not-constant");
     }
     let Some(majit_ir::Value::Ref(cell_ref)) = ctx.trace_ctx.box_value(cell_op) else {
-        return Ok(None);
+        decline!("cell-box-not-ref");
     };
     // `NO_CONCRETE` is `usize::MAX - 1`, not zero, so `is_null` does not cover
     // it and `is_cell` would dereference it.  It means "this box carries no
@@ -5478,24 +5490,24 @@ fn try_walker_specialize_load_deref<Sym: WalkSym>(
     // alongside the null the way `state.rs` reads a `Value::Ref`
     // (`frame_ref.is_null() || frame_ref == majit_ir::GcRef::NO_CONCRETE`).
     let cell = cell_ref.0 as pyre_object::PyObjectRef;
-    if cell.is_null()
-        || cell_ref == majit_ir::GcRef::NO_CONCRETE
-        || !unsafe { pyre_object::is_cell(cell) }
-    {
-        return Ok(None);
+    if cell.is_null() || cell_ref == majit_ir::GcRef::NO_CONCRETE {
+        decline!("cell-null-or-no-concrete");
+    }
+    if !unsafe { pyre_object::is_cell(cell) } {
+        decline!("not-a-cell");
     }
     let family = unsafe { pyre_object::w_cell_family(cell) };
     if family.is_null() {
-        return Ok(None);
+        decline!("family-null");
     }
     // nestedscope.py `if not self.family.ever_mutated`.
     if unsafe { (*family).ever_mutated.get() } {
-        return Ok(None);
+        decline!("ever-mutated");
     }
     // nestedscope.py `w_res = self._elidable_get(); if w_res is not None`.
     let contents = unsafe { pyre_object::w_cell_get(cell) };
     if contents.is_null() {
-        return Ok(None);
+        decline!("contents-unbound");
     }
     // A cell holds an arbitrary object, so baking its address needs the gate
     // the other walker folds carry.  A RECORDED `ConstPtr` is forwarded at
@@ -5509,7 +5521,7 @@ fn try_walker_specialize_load_deref<Sym: WalkSym>(
     // family is a `Box::into_raw` leak outside the collector entirely, so the
     // contents are the one edge that needs gating.
     if majit_gc::can_move(majit_ir::GcRef(contents as usize)) {
-        return Ok(None);
+        decline!("contents-movable");
     }
     let owner = ctx.trace_ctx.const_ref(family as i64);
     crate::state::record_quasiimmut_field(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -483,44 +483,6 @@ pub(crate) fn try_walker_specialize_unary_negative_int<Sym: WalkSym>(
     Ok(Some(()))
 }
 
-/// #61: walker-native int specialization for the `UNARY_INVERT` residual
-/// (oopspec [`majit_ir::RuntimeHelperKind::UnaryInvert`]).  `~x` on an exact int
-/// is `!x`, which always fits an i64 (`~INT_MIN == INT_MAX`, `~INT_MAX ==
-/// INT_MIN`), so `descr_invert` never promotes to a long: the fold emits a
-/// plain `IntInvert` behind a `GUARD_CLASS INT`, with no overflow guard.
-///
-/// Returns `Ok(Some(()))` when the fold was emitted (caller returns
-/// `Continue`); `Ok(None)` for a bool / subclass / non-int operand, or when
-/// the residual result box is unavailable.
-pub(crate) fn try_walker_specialize_unary_invert_int<Sym: WalkSym>(
-    ctx: &mut WalkContext<'_, '_, Sym>,
-    op_pc: usize,
-    operand: OpRef,
-    allboxes: &[OpRef],
-    call_descr: &dyn majit_ir::descr::CallDescr,
-    dst: usize,
-    dst_bank: char,
-) -> Result<Option<()>, DispatchError> {
-    let Some((x, x_class)) = walker_unary_int_operand(ctx, operand) else {
-        return Ok(None);
-    };
-    let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
-        return Ok(None);
-    };
-    let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
-    let x_raw = walker_unbox_int(ctx, op_pc, operand, int_type_addr)?;
-    walker_guard_exact_w_class(ctx, op_pc, operand, x_class)?;
-    let result_value = !x;
-    let raw_result = ctx.trace_ctx.record_op(OpCode::IntInvert, &[x_raw]);
-    ctx.trace_ctx
-        .set_opref_concrete(raw_result, majit_ir::Value::Int(result_value));
-    let boxed = walker_box_int(ctx, op_pc, raw_result, result_value)?;
-    ctx.trace_ctx
-        .set_opref_concrete(boxed, box_int_concrete(result_value, boxed_result_i64));
-    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
-    Ok(Some(()))
-}
-
 /// #57: walker-native speculative int specialization for the `BINARY_OP`
 /// helper residual_call (oopspec `BinaryOp`).  Re-derives
 /// the former int fast path's structure (`guard_class` + `getfield_gc_i` per
@@ -7265,6 +7227,120 @@ fn try_walker_orthodox_subscr_tuple_item<Sym: WalkSym>(
             ctx.trace_ctx.heap_cache_mut().reset();
             return Ok(None);
         }
+        Err(error) => return Err(error),
+    };
+    let result = match walk_outcome {
+        DispatchOutcome::SubReturn { result } => finish_inline_callee_return(ctx, result)
+            .ok_or(DispatchError::UnexpectedVoidSubReturn { pc: op_pc })?,
+        _ => return Err(DispatchError::UnexpectedVoidSubReturn { pc: op_pc }),
+    };
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, result)?;
+    Ok(Some(()))
+}
+
+/// Descend `invert_inner`'s compiled body for `~x` on an exact builtin `int` or
+/// `long`, instead of re-emitting its arms by hand.
+///
+/// This is the orthodox shape: upstream traces *through* `descr_invert`, which
+/// is ordinary RPython, rather than carrying a fold per operand type.  What
+/// makes it worth entering here is coverage, not the emitted shape -- the
+/// hand-written `unary_invert_int` answers the exact-`int` operand only, and
+/// `~` on a `long` reaches no fold at all today (measured: the fold is
+/// consulted for both and fires for one).  The body's own arms cover both, so
+/// descending it covers the second without a second fold.
+///
+/// `invert` itself cannot be entered.  Its `__invert__` override probe is
+/// `dont_look_inside` and is the second operation the body executes, and its
+/// bool slot raises a deprecation warning, which reaches `lookup_exc_class`.
+/// `invert_inner` is that body past both.  The guards emitted here are what
+/// let the caller skip them: `bool` carries its own type, and an `int` or
+/// `long` subclass keeps the builtin `ob_type` but retags `w_class` and may
+/// define `__invert__`, so both must side-exit to the residual, which still
+/// runs the whole of `invert`.
+pub(crate) fn try_walker_orthodox_unary_invert<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    operand: OpRef,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    let Some(operand_obj) = walker_concrete_ref_object(ctx, operand) else {
+        return Ok(None);
+    };
+    // SAFETY: `operand_obj` is a live concrete `PyObjectRef` from the walker
+    // shadow.
+    let is_long = unsafe { pyre_object::is_long(operand_obj) };
+    let admitted = unsafe {
+        !pyre_object::is_bool(operand_obj)
+            && (is_long || pyre_object::is_int(operand_obj))
+            && pyre_object::is_exact_builtin_instance(operand_obj)
+    };
+    if !admitted {
+        return Ok(None);
+    }
+    // SAFETY: as above.
+    let Some(operand_class) = (unsafe { walker_exact_builtin_class(operand_obj) }) else {
+        return Ok(None);
+    };
+
+    // Resolve every possible decline before recording a guard.
+    let Some(jc_arc) = crate::jitcode_runtime::invert_inner_jitcode() else {
+        return Ok(None);
+    };
+    let Some(sub_body) = sub_jitcode_body_by_index(jc_arc.index()) else {
+        return Ok(None);
+    };
+    let sym_ptr = ctx.fbw_mode.snapshot_sym;
+    if sym_ptr.is_null() {
+        return Ok(None);
+    }
+    // SAFETY: set for the lifetime of the enclosing full-body walk.
+    if unsafe { (&*sym_ptr).jitcode().is_null() } {
+        return Ok(None);
+    }
+    let sym = unsafe { &*sym_ptr };
+
+    let pre_fold_pos = ctx.trace_ctx.get_trace_position();
+    let type_addr = if is_long {
+        &pyre_object::pyobject::LONG_TYPE as *const _ as i64
+    } else {
+        &pyre_object::pyobject::INT_TYPE as *const _ as i64
+    };
+    walker_guard_class(ctx, op_pc, operand, type_addr)?;
+    walker_guard_exact_w_class(ctx, op_pc, operand, operand_class)?;
+    ctx.trace_ctx.set_opref_concrete(
+        operand,
+        majit_ir::Value::Ref(majit_ir::GcRef(operand_obj as usize)),
+    );
+
+    let walk = run_orthodox_helper_subwalk(
+        ctx,
+        op_pc,
+        sym,
+        &sub_body,
+        "unary_invert_commit",
+        "invert_inner_call_site",
+        &[],
+        &[],
+        &[operand],
+        &[ConcreteValue::Ref(operand_obj)],
+    );
+    let (walk_outcome, _walk_start) = match walk {
+        // The body reached a helper this build did not lower.  `invert_inner`
+        // is a pure read on both admitted arms, so nothing is committed --
+        // cut the tentative IR, with its snapshots, and let the residual serve
+        // the operator.  The two guards above are emitted with snapshots
+        // attached and name the discarded operation namespace, so leaving them
+        // behind would expose stale boxes to a later remap.
+        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc, .. }) => {
+            if fbw_debug_abort_enabled() {
+                eprintln!("[decline-why] UNARY-INVERT-SUBWALK pc={pc}");
+            }
+            ctx.trace_ctx.cut_trace_with_snapshots(pre_fold_pos);
+            ctx.trace_ctx.heap_cache_mut().reset();
+            return Ok(None);
+        }
+        Ok(pair) => pair,
         Err(error) => return Err(error),
     };
     let result = match walk_outcome {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -10486,9 +10486,9 @@ enum MathFloatDomain {
     /// The helper reports every raising direction as a non-finite result, so
     /// the operand is unconstrained and the *result* is guarded instead: the
     /// guard deoptimizes into the builtin, which re-executes and raises or
-    /// returns the non-finite value itself.  A row spelled this way needs no
-    /// per-function domain knowledge, which is why adding a function to
-    /// `MATH_FLOAT1_FOLDS` is all it takes to cover it.
+    /// returns the non-finite value itself.  A row spelled this way carries no
+    /// per-function domain knowledge, so every `MATH_FLOAT1_FOLDS` entry
+    /// shares this one arm.
     ResultFinite,
 }
 
@@ -11221,7 +11221,13 @@ pub(crate) fn try_walker_specialize_int_call<Sym: WalkSym>(
 
 /// `math.fabs(x)` on an exact int/float argument.  RPython lowers
 /// `ll_math_fabs` to a sign mask, so the whole builtin is one `FloatAbs` once
-/// the operand is unboxed, and `fabs` raises for no input.
+/// the operand is unboxed, and `fabs` raises for no input, which is why the
+/// row is [`MathFloatDomain::Total`].
+///
+/// `Total` only spares the row its operand guards.  The shared driver still
+/// screens the authentic result through `fold_finite_float_result`, so
+/// `fabs(inf)` and `fabs(nan)` decline at trace time and keep the residual
+/// even though the sign mask would answer them correctly.
 pub(crate) fn try_walker_specialize_math_fabs<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],
@@ -11487,8 +11493,9 @@ fn walker_guard_float_result_finite<Sym: WalkSym>(
 }
 
 /// The one-argument rows of the `math` float fold: `interp_math`'s `pm1!`
-/// family, each standing for one raw helper in `MATH_FLOAT1_FOLDS`.  Adding a
-/// function to that table is all it takes to cover it.
+/// family, each standing for one raw helper in `MATH_FLOAT1_FOLDS`.  Every row
+/// is [`MathFloatDomain::ResultFinite`], so the table is the whole of what
+/// this entry point knows.
 pub(crate) fn try_walker_specialize_math_float1<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -7279,6 +7279,13 @@ pub(crate) fn try_walker_orthodox_unary_invert<Sym: WalkSym>(
         return Ok(None);
     }
     // SAFETY: as above.
+    //
+    // This cannot decline for an admitted operand.  `walker_exact_builtin_class`
+    // answers `None` for an exact builtin whose `w_class` is null, and the only
+    // objects born that way are the read-only singletons (`True`, `False`,
+    // `None`, `Ellipsis`, `NotImplemented`) -- every other builtin is born
+    // carrying `get_instantiate(ob_type)`.  None of those five survives the
+    // admission above: the first two are `bool`, the rest are not `int`.
     let Some(operand_class) = (unsafe { walker_exact_builtin_class(operand_obj) }) else {
         return Ok(None);
     };

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -398,6 +398,11 @@ thread_local! {
     /// thread. Resolved by graph key rather than by name -- see
     /// [`compute_pathed_jitcode_index`].
     static TUPLE_GETITEM_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
+    /// Cached `ALL_JITCODES` index of `invert_inner` for the current thread.
+    /// Resolved by graph key: `neg` and `invert` held indices 2798/2809 in only
+    /// two of eight observed cache generations, so an index is not stable
+    /// across builds and a path is.
+    static INVERT_INNER_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
 }
 
 /// Scan the build-time names index for the unique entry equal to `name`.
@@ -502,6 +507,24 @@ pub fn list_pop_end_jitcode() -> Option<Arc<JitCode>> {
 /// `_known` reader is what keeps the length test in the trace: the caller's
 /// trace-time range check proves only that THIS receiver is long enough, while
 /// the recorded `arraylen` guard is what holds for the next one.
+/// The charon `invert_inner` body in `ALL_JITCODES`, resolved by the graph key
+/// the codewriter allocated it under and cached per thread. `None` if the
+/// helper is absent from the build-time pipeline.
+///
+/// This is `descroperation.rs` `invert` past its `__invert__` override probe
+/// and its bool slot -- the two arms a descent cannot take. What is left is the
+/// `int` arm, the `long` arm, the instance fallback and the terminal
+/// `TypeError`, so a caller that has pinned an exact `int` or `long` receiver
+/// records one of the first two and nothing else.
+pub fn invert_inner_jitcode() -> Option<Arc<JitCode>> {
+    let idx = INVERT_INNER_JITCODE_INDEX.with(|cell| {
+        *cell.get_or_init(|| {
+            compute_pathed_jitcode_index("pyre_interpreter::objspace::descroperation::invert_inner")
+        })
+    })?;
+    get_jitcode_by_index(idx)
+}
+
 pub fn tuple_getitem_jitcode() -> Option<Arc<JitCode>> {
     let idx = TUPLE_GETITEM_JITCODE_INDEX.with(|cell| {
         *cell.get_or_init(|| {


### PR DESCRIPTION
Eight commits on top of `main` (#1495). Two of them land measured descent
progress; the rest are the review fixes and the doc re-derivation from the
previous round.

## Descent

- **`~x` descends** (`b392348dfcf`, `af6583e0695`). `invert` is split into
  `invert`/`invert_inner`, and `try_walker_specialize_unary_invert` sub-walks
  `invert_inner`'s jitcode. `unary_invert_int` is retired: it is the second
  orthodox retirement, after `subscr_specialised_pair`.
- **The unary RBigInt wrappers are retargeted** (`760f2ba7104`).
  `descroperation::bigint_neg` / `bigint_invert` reach a descent as unlowered
  helpers, so the `<RBigInt as Neg>::neg` call inside them is never seen and
  the existing operator retarget never applies. `front::mir` now swaps the
  wrapper itself, guarded on a single `RBigInt` argument and an `RBigInt`
  destination.

  Measured with `PYRE_FBW_DEBUG_ABORT=1`: `~<long>` used to decline with
  `OrthodoxSubWalkTraceUnsupported { pc: 74 }` naming
  `descroperation::bigint_invert`; it now declines at `pc: 18` naming
  `target:<synthetic-transparent-ctor pyre_object::pyobject::PyObject>`. The
  fold still reports `fired=0` for a `long` operand — the wall moved off
  pyre's own code and onto the transparent-ctor class. `~<int>` still
  descends (`consulted=1 fired=1`).

- **The `len` descent wall moved twice** (`8a4694f13cd`, `d711d313bff`). A
  pair of exact builtins cannot reach an override, so `compare` decides that
  before running the override probe; and the swap block's type identity test
  is now spelled `std::ptr::eq` rather than `NonNull`'s `!=`, which goes
  through `NonNull::ne`. With `PYRE_FBW_NO_SPECIALIZE=builtin_len
  PYRE_FBW_DESCENT_SCAN_OFF=1 PYRE_FBW_INLINE_DIAG=1`, the `[subwalk-abort]`
  went `try_compare_override` → `NonNull::ne` (`abort_pc=245`) →
  `compare_slot` (`abort_pc=119`). No fold is retired by this.

## Diagnostics and docs

- `c8fb37a3d27` gives every `try_walker_specialize_load_deref` decline a
  name under `PYRE_FBW_DEBUG_ABORT`. Measured: 38 of 38 declines are
  `cell-not-constant`, so every later guard in that function is unreached and
  its `fired=0` is a missing capability, not dead weight. The doc comment
  says so instead of asserting the fold is dead.
- `8b385730891` re-derives the fold-layer counts in `design.md` §3.8 (69
  definitions, 73 rows, 9,886 body lines, 16,880 file lines; 23 fixtures
  naming 44 folds, 29 uncoupled rows) and records the commands that produce
  them, so the next reader re-derives rather than trusts the sentence.
  `gate-triage.md`'s stale "55 rows" is corrected the same way.
- `18c73fac505` corrects three math-fold doc comments, including recording
  that `MathFloatDomain::Total` spares `fabs` its operand guards but not the
  shared driver's `fold_finite_float_result` screen, so `fabs(inf)` and
  `fabs(nan)` decline.

## Gate

⚠️ `pyre/check.py --backend dynasm` has **not** been run against the final
three commits. The shared worktree was running four other builds and
check.py invocations at load average 15/41, which makes a timing gate
unreadable. `cargo fmt --all -- --check` and
`scripts/check-majit-boundary.py` are both clean; the probes above were run
on a binary verified fresh (see below). CI is the gate for this PR.

⛔ One measurement note worth carrying: a `pyre-dynasm` build in a busy
shared worktree can consume a codegen-cache generation that predates the
edit, and the symptom is a wall that refuses to move. Rebuilding the
byte-identical tree moved both walls above. Confirm the symbol your edit
removes is absent from the newest generation's `symbolic_fnaddr_paths`
before reading a probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gCeUzbGWCK8S6vqnXh416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved unary inversion handling for built-in integer values, including safer support for exact integer types.
  - Preserved expected behavior for subclasses and boolean values.
  - Added safer fallback handling when optimized execution is unavailable.
  - Improved handling of supported opaque big-integer operations.
  - Enhanced diagnostics for specialization decisions and declined optimizations.

- **Documentation**
  - Updated optimization and specialization documentation with corrected metrics, coverage details, reproducible counting guidance, and validation criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->