### PR TITLE
cpython_tests, cpyext, memoryview, _ast: build the test extensions onto sys.path and fix what that reaches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ lib_pypy/_sha3/_sha3_cffi*
 lib_pypy/_blake2/_blake2*_cffi*
 lib_pypy/_blake2/impl/*.o
 lib_pypy/_*test*.pypy*.so
+lib-python/3/_test*.pyre*.so
 lib_pypy/_ctypes/_ctypes_cffi*
 rpython/rlib/rvmprof/src/shared/libbacktrace/config.h
 rpython/rlib/test/_hacked_rbigint.py

--- a/lib-python/3/test/test_import/__init__.py
+++ b/lib-python/3/test/test_import/__init__.py
@@ -2419,6 +2419,7 @@ class SubinterpImportTests(unittest.TestCase):
             self.check_incompatible_fresh(module, isolated=True)
 
     @unittest.skipIf(_testmultiphase is None, "test requires _testmultiphase module")
+    @unittest.skipIf(_testinternalcapi is None, "requires _testinternalcapi")
     def test_multi_init_extension_compat(self):
         # Module with Py_MOD_PER_INTERPRETER_GIL_SUPPORTED
         module = '_testmultiphase'

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -170,11 +170,10 @@ def platform_gate(module: str) -> str | None:
 
 
 # `Modules/_testbuffer.c` is the exporter `test_buffer`'s `TestBufferProtocol`
-# is `skipUnless`d on, and the only C extension the suite needs.  CPython
-# builds it beside the interpreter; pyre builds it here against the same
-# headers `pyrex`'s cpyext fixtures compile against.  It reaches the modules
-# below and no others: `PYTHONPATH` is language-visible, and several modules
-# assert on the path their own child interpreters inherit.
+# is `skipUnless`d on; `_testsinglephase` and `_testmultiphase` are the two
+# `test_importlib.extension` loads as C extensions.  CPython builds all three
+# beside the interpreter; pyre builds them here against the same headers
+# `pyrex`'s cpyext fixtures compile against.
 TEST_EXTENSION_SOURCES = {
     "_testbuffer": ROOT / "lib_pypy" / "_testbuffer.c",
     "_testsinglephase": ROOT / "lib_pypy" / "_testsinglephase.c",
@@ -185,18 +184,18 @@ CPYEXT_INCLUDE = ROOT / "include" / "pyre3.14t"
 # against inside its own: `_PyNamespace_New` and the argument parser Argument
 # Clinic writes calls to both live behind one.
 CPYEXT_INTERNAL_INCLUDE = CPYEXT_INCLUDE / "internal"
-EXTENSION_BUILD_DIR = ROOT / "build" / "cpython_tests"
+# `PYTHONPATH` is language-visible and does not reach a child started with
+# `-E` or `-I`, which `script_helper.run_python_until_end` does whenever the
+# caller passes no environment of its own — `test_importlib.extension`'s
+# `test_nonmodule_cases` runs `_test_nonmodule_cases.py` that way.  So the
+# extensions go on the interpreter's own default `sys.path` instead, whose
+# only entry here is `lib-python/3`.  `_testmultiphase_build.py` does the
+# same, compiling into `lib_pypy` — a source directory `compute_lib_pypy_path`
+# puts on the default path — because `test.importlib` imports the module as a
+# C extension and so cannot be served by a Python shim.  Only these three
+# names become importable; the artefacts are ignored by git.
+EXTENSION_DIR = ROOT / "lib-python" / "3"
 NEEDS_TEST_EXTENSION = {"test.test_buffer", "test.test_importlib"}
-# `PYTHONPATH` does not reach a child started with `-E` or `-I`, and
-# `script_helper.run_python_until_end` starts one whenever the caller passes
-# no environment of its own.  That costs one row today:
-# `test_importlib.extension`'s `test_nonmodule_cases` runs
-# `_test_nonmodule_cases.py` under `-E`, where `_testmultiphase` is not
-# importable and all four of its cases fail.  Reaching that child means
-# putting these modules on the interpreter's own default `sys.path`, whose
-# only entry here is `lib-python/3` — which would also make them importable
-# to every other module in the suite, and the suite branches on whether
-# `import X` succeeds.  That trade is not the runner's to make silently.
 
 # These modules intentionally assert on a child interpreter's exact stderr.
 # MAJIT_STATS is runner instrumentation rather than language-visible output,
@@ -634,20 +633,19 @@ def build_cmd(binary: Path, module: str, mode: str) -> list[str]:
     return [str(binary), str(module_path(module))]
 
 
-def build_test_extensions(binary: Path) -> tuple[Path | None, dict[str, str]]:
-    """Compile the test extensions for `binary`; answer their directory and,
-    per extension, why one is missing.
+def build_test_extensions(binary: Path) -> dict[str, str]:
+    """Compile the test extensions for `binary`; answer, per extension, why
+    one is missing.
 
     An interpreter built without `cpyext`, a platform the feature is not
-    compiled for, and a missing C compiler each leave every extension unbuilt,
-    and the directory is then `None`. A source that fails on its own leaves the
-    others usable, so its reason is reported alone. The tests that need one
-    skip exactly as they do upstream when the module is absent, rather than
-    failing the run.
+    compiled for, and a missing C compiler each leave every extension unbuilt.
+    A source that fails on its own leaves the others usable, so its reason is
+    reported alone. The tests that need one skip exactly as they do upstream
+    when the module is absent, rather than failing the run.
     """
     if sys.platform not in ("darwin", "linux"):
         reason = f"cpyext is built for macos and linux, not {sys.platform}"
-        return None, dict.fromkeys(TEST_EXTENSION_SOURCES, reason)
+        return dict.fromkeys(TEST_EXTENSION_SOURCES, reason)
     named = subprocess.run(
         [str(binary), "-c", "import _imp; print(_imp.extension_suffixes()[0])"],
         capture_output=True, text=True, encoding="utf-8", errors="replace",
@@ -655,14 +653,13 @@ def build_test_extensions(binary: Path) -> tuple[Path | None, dict[str, str]]:
     suffix = named.stdout.strip().splitlines()[-1] if named.stdout.strip() else ""
     if named.returncode != 0 or not suffix:
         reason = "the interpreter reported no extension suffix"
-        return None, dict.fromkeys(TEST_EXTENSION_SOURCES, reason)
-    EXTENSION_BUILD_DIR.mkdir(parents=True, exist_ok=True)
+        return dict.fromkeys(TEST_EXTENSION_SOURCES, reason)
     unbuilt = {}
     for name, source in TEST_EXTENSION_SOURCES.items():
         reason = build_one_test_extension(binary, name, source, suffix)
         if reason:
             unbuilt[name] = reason
-    return EXTENSION_BUILD_DIR, unbuilt
+    return unbuilt
 
 
 def build_one_test_extension(binary: Path, name: str, source: Path,
@@ -674,7 +671,7 @@ def build_one_test_extension(binary: Path, name: str, source: Path,
     compile_cmd = [
         os.environ.get("CC", "cc"), str(source),
         "-I", str(CPYEXT_INCLUDE), "-I", str(CPYEXT_INTERNAL_INCLUDE),
-        "-o", str(EXTENSION_BUILD_DIR / f"{name}{suffix}"), "-O2",
+        "-o", str(EXTENSION_DIR / f"{name}{suffix}"), "-O2",
     ]
     compile_cmd += (
         ["-bundle", "-undefined", "dynamic_lookup"] if sys.platform == "darwin"
@@ -687,10 +684,12 @@ def build_one_test_extension(binary: Path, name: str, source: Path,
         return f"{compile_cmd[0]}: {last_stderr_line(built.stderr)}"
     # Compiling proves the headers agree, not that the interpreter can load
     # what they describe: a build without cpyext resolves none of the symbols.
+    # `-E` because that is the interpreter the tests reach it through, so the
+    # check answers for the default `sys.path` rather than for this process's
+    # environment.
     loaded = subprocess.run(
-        [str(binary), "-c", f"import {name}"],
+        [str(binary), "-E", "-c", f"import {name}"],
         capture_output=True, text=True, encoding="utf-8", errors="replace",
-        env=dict(os.environ, PYTHONPATH=str(EXTENSION_BUILD_DIR)),
     )
     if loaded.returncode != 0:
         return f"built but not importable: {last_stderr_line(loaded.stderr)}"
@@ -698,7 +697,7 @@ def build_one_test_extension(binary: Path, name: str, source: Path,
 
 
 def run_module(binary: Path, module: str, mode: str, timeout: int,
-               env: dict, extension_dir: Path | None = None) -> tuple[str, str]:
+               env: dict) -> tuple[str, str]:
     # Run in a throwaway cwd so a test writing into '.' never touches the
     # repo (the stdlib is resolved relative to the executable, not cwd).
     # `ignore_cleanup_errors` because a test that leaves a file open takes the
@@ -755,12 +754,6 @@ def run_module(binary: Path, module: str, mode: str, timeout: int,
         else:
             cmd = build_cmd(binary, module, mode)
         module_env = env
-        if extension_dir is not None and module in NEEDS_TEST_EXTENSION:
-            module_env = env.copy()
-            inherited = module_env.get("PYTHONPATH")
-            module_env["PYTHONPATH"] = os.pathsep.join(
-                [str(extension_dir)] + ([inherited] if inherited else [])
-            )
         if module in STATS_STDERR_INCOMPATIBLE:
             if module_env is env:
                 module_env = env.copy()
@@ -920,7 +913,7 @@ def main() -> int:
     if args.no_jit:
         env["PYRE_NO_JIT"] = "1"
 
-    extension_dir, unbuilt = build_test_extensions(binary)
+    unbuilt = build_test_extensions(binary)
     for name, reason in sorted(unbuilt.items()):
         print(f"warning: {name} not built ({reason}) — "
               f"{'/'.join(sorted(NEEDS_TEST_EXTENSION))} will skip the classes "
@@ -994,16 +987,14 @@ def main() -> int:
     serial_modules = [m for m in to_run if m in SERIAL_MODULES]
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
         futs = {
-            pool.submit(run_module, binary, m, args.mode, args.timeout,
-                        env, extension_dir): m
+            pool.submit(run_module, binary, m, args.mode, args.timeout, env): m
             for m in parallel_modules
         }
         for fut in concurrent.futures.as_completed(futs):
             m = futs[fut]
             record_result(m, fut.result())
     for m in serial_modules:
-        record_result(m, run_module(binary, m, args.mode, args.timeout,
-                                    env, extension_dir))
+        record_result(m, run_module(binary, m, args.mode, args.timeout, env))
     print()
 
     # Summary by status.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -251,6 +251,18 @@ unsafe fn w_memoryview_cast_1d(mv_src: PyObjectRef, fmt: &str, itemsize: i64) ->
     }
 }
 
+/// `picklebuf_raw` — the 1-D unsigned-byte view over the bytes of a buffer
+/// that is contiguous in either order, in physical order.
+///
+/// `memoryview.cast` refuses a Fortran-contiguous source and is right to: a
+/// cast is defined on C order.  `raw()` is not a cast — it rewrites the view's
+/// format, ndim, itemsize, shape and strides and marks the result contiguous
+/// both ways — so it takes an `'A'`-order source.  The caller owns the
+/// contiguity check; this only reinterprets.
+pub(crate) fn memoryview_raw_bytes(mv: PyObjectRef) -> PyObjectRef {
+    unsafe { w_memoryview_cast_1d(mv, "B", 1) }
+}
+
 /// `descr_cast` with a shape — `_cast_to_1D` then `_cast_to_ND`
 /// (`memoryobject.py:599-603`): a `ViewND` reshaping a fresh `View1D` over
 /// the source view.  The shape / strides tuples are built and pinned inside

--- a/pyre/pyre-interpreter/src/cpyext/modsupport.rs
+++ b/pyre/pyre-interpreter/src/cpyext/modsupport.rs
@@ -249,11 +249,31 @@ fn store(module: PyObjectRef, name: &str, value: PyObjectRef) {
     crate::module_ns_store(module_dict(module), name, value);
 }
 
+/// `_add_methods_to_object` / `modsupport.py:157` — the same store against
+/// whatever a create slot answered.
+///
+/// Only a module has the proxy-free dict [`store`] writes straight through;
+/// anything else takes the ordinary attribute path, which is what upstream
+/// uses for both.
+fn store_on_object(
+    target: PyObjectRef,
+    name: &str,
+    value: PyObjectRef,
+) -> Result<(), crate::PyError> {
+    if unsafe { pyre_object::module::is_module(target) } {
+        store(target, name, value);
+        return Ok(());
+    }
+    crate::baseobjspace::setattr_str(target, name, value).map(drop)
+}
+
 /// `modsupport.py:convert_method_defs`, module branch.
 ///
 /// The table is NUL-name terminated.  `METH_CLASS` / `METH_STATIC` are
 /// rejected here exactly as upstream rejects them for a module-level table;
 /// their type-level meaning arrives with C-defined types.
+///
+/// `module` is whatever the create slot answered, so it need not be one.
 fn convert_method_defs(
     module: PyObjectRef,
     methods: *mut CPyMethodDef,
@@ -287,11 +307,11 @@ fn convert_method_defs(
         )?;
         let function_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = roots.pin_root(function);
-        store(
+        store_on_object(
             pyre_object::gc_roots::shadow_stack_get(module_slot),
             &name,
             pyre_object::gc_roots::shadow_stack_get(function_slot),
-        );
+        )?;
     }
 }
 
@@ -339,6 +359,25 @@ fn populate_module(
         store(reload(module_slot), "__file__", reload(value_slot));
     }
 
+    add_methods_and_doc(reload(module_slot), def, name)
+}
+
+/// The tail of `moduleobject.c PyModule_FromDefAndSpec2`: `m_methods` and
+/// `m_doc` go on whatever the create slot answered, module or not.
+///
+/// `_testmultiphase`'s `nonmodule_with_methods` answers a `SimpleNamespace`
+/// and still declares a method table, which is the case that separates this
+/// from the module-only fields [`populate_module`] sets.
+fn add_methods_and_doc(
+    module: PyObjectRef,
+    def: *mut CPyModuleDef,
+    name: &str,
+) -> Result<PyObjectRef, crate::PyError> {
+    let roots = pyre_object::gc_roots::push_roots();
+    let module_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(module);
+    let reload = |slot| pyre_object::gc_roots::shadow_stack_get(slot);
+
     let w_name = pyre_object::w_str_new(name);
     let name_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = roots.pin_root(w_name);
@@ -353,7 +392,7 @@ fn populate_module(
         let value = pyre_object::w_str_new(&doc);
         let value_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = roots.pin_root(value);
-        store(reload(module_slot), "__doc__", reload(value_slot));
+        store_on_object(reload(module_slot), "__doc__", reload(value_slot))?;
     }
 
     Ok(reload(module_slot))
@@ -706,7 +745,11 @@ pub(super) fn create_module_from_def_and_spec(
                 ),
             ));
         }
-        return Ok(pyre_object::gc_roots::shadow_stack_get(module_slot));
+        return add_methods_and_doc(
+            pyre_object::gc_roots::shadow_stack_get(module_slot),
+            def,
+            name,
+        );
     }
     populate_module(
         pyre_object::gc_roots::shadow_stack_get(module_slot),

--- a/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
@@ -332,6 +332,10 @@ impl W_PickleBuffer {
     /// itemsize 1) that aliases the source and preserves its read-only flag,
     /// regardless of the source's element format; extracting it from a
     /// non-contiguous buffer raises `BufferError`.
+    ///
+    /// `picklebufobject.c:161` asks `PyBuffer_IsContiguous(&view, 'A')`, so a
+    /// Fortran-contiguous buffer qualifies: the bytes are still one run, and
+    /// what `raw()` promises is the physical order, not the logical one.
     fn raw(&self) -> Result<PyObjectRef, PyError> {
         let w_obj = self.w_obj;
         if unsafe { pyre_object::is_none(w_obj) } {
@@ -340,17 +344,16 @@ impl W_PickleBuffer {
         let mv_type = memoryview_type()
             .ok_or_else(|| PyError::runtime_error("memoryview type unavailable"))?;
         let mv = crate::module::_pickle::call_fn(mv_type, &[w_obj])?;
-        // Raw extraction is only defined for a C-contiguous buffer.
-        let w_contig = crate::baseobjspace::getattr_str(mv, "c_contiguous")?;
+        let w_contig = crate::baseobjspace::getattr_str(mv, "contiguous")?;
         if !crate::baseobjspace::is_true(w_contig)? {
             return Err(PyError::new(
                 crate::PyErrorKind::BufferError,
                 "cannot extract raw buffer from non-contiguous buffer",
             ));
         }
-        // Normalize to the raw byte layout via `cast('B')` so an `array('i')`
-        // or other non-`'B'` source still yields a byte view.
-        crate::module::_pickle::call_meth(mv, "cast", &[pyre_object::unicodeobject::w_str_new("B")])
+        // Normalize to the raw byte layout so an `array('i')` or other
+        // non-`'B'` source still yields a byte view.
+        Ok(crate::builtins::memoryview_raw_bytes(mv))
     }
 
     /// PEP 688 exporter slot exposed by CPython 3.14's `pickle.PickleBuffer`.
@@ -533,6 +536,9 @@ fn is_memoryview(obj: PyObjectRef) -> bool {
 /// Extract `(contents, readonly)` from a buffer exporter: `bytes` is
 /// read-only, `bytearray` and `array` are mutable, and a `memoryview` reports
 /// both through its own contents and `readonly` flag.
+///
+/// The contents are the bytes in physical order, which is what the buffer a
+/// `PickleBuffer` saves is defined to be.
 pub(crate) fn buffer_view(obj: PyObjectRef) -> Result<(Vec<u8>, bool), PyError> {
     unsafe {
         if pyre_object::is_bytes(obj) {
@@ -552,7 +558,13 @@ pub(crate) fn buffer_view(obj: PyObjectRef) -> Result<(Vec<u8>, bool), PyError> 
         }
     }
     if is_memoryview(obj) {
-        let w_data = crate::module::_pickle::call_meth(obj, "tobytes", &[])?;
+        // `_pickle.c:2691` writes `view.buf` for `view.len` bytes — the
+        // physical run.  `memoryview.tobytes()` walks the strides instead, and
+        // the two orders differ for a Fortran-contiguous export, so the raw
+        // 1-D reinterpretation is what goes into the stream.  The only caller
+        // has already refused a buffer contiguous in neither order.
+        let raw = crate::builtins::memoryview_raw_bytes(obj);
+        let w_data = crate::module::_pickle::call_meth(raw, "tobytes", &[])?;
         let data = unsafe { pyre_object::bytesobject::w_bytes_data(w_data) }.to_vec();
         let w_ro = crate::baseobjspace::getattr_str(obj, "readonly")?;
         return Ok((data, crate::baseobjspace::is_true(w_ro)?));
@@ -563,13 +575,14 @@ pub(crate) fn buffer_view(obj: PyObjectRef) -> Result<(Vec<u8>, bool), PyError> 
     )))
 }
 
-/// Whether the wrapped exporter's buffer is C-contiguous, matching the
-/// `_pickle` save path's `iscontiguous(buf)` guard. `bytes`/`bytearray`/`array`
-/// are one-dimensional and always contiguous; a `memoryview` reports through
-/// its `c_contiguous` flag.
+/// Whether the wrapped exporter's buffer is contiguous in either order, which
+/// is what `_pickle.c:2683` asks of the one it is about to save.
+///
+/// `bytes`/`bytearray`/`array` are one-dimensional and always contiguous; a
+/// `memoryview` reports through its `contiguous` flag, the `'A'` order one.
 pub(crate) fn is_contiguous(obj: PyObjectRef) -> Result<bool, PyError> {
     if is_memoryview(obj) {
-        let w = crate::baseobjspace::getattr_str(obj, "c_contiguous")?;
+        let w = crate::baseobjspace::getattr_str(obj, "contiguous")?;
         return crate::baseobjspace::is_true(w);
     }
     Ok(true)

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -5,7 +5,12 @@
 //! ordinary heap objects carrying ASDL fields and source locations.
 
 use pyre_object::{PY_NULL, PyObjectRef};
+use rustpython_compiler::codegen::{
+    interpolated_string_literal_value, string_literal_part_value, string_literal_value,
+};
+use rustpython_compiler::core::{SourceFile, SourceFileBuilder};
 use rustpython_compiler::{ast, parser};
+use rustpython_wtf8::{Wtf8, Wtf8Buf};
 
 type AstResult<T> = Result<T, crate::PyError>;
 
@@ -267,7 +272,7 @@ impl ObjectConverter {
                 "AST identifier must be of type str",
             ));
         }
-        Ok(unsafe { pyre_object::w_str_get_value(value).to_string() })
+        Ok(utf8_only(value)?.to_string())
     }
 
     /// How `%R` names the value an error rejected.
@@ -1691,9 +1696,7 @@ impl ObjectConverter {
                 )))
             } else if pyre_object::is_str(object) {
                 Ok(ast::ConstantValue::Str(
-                    pyre_object::w_str_get_value(object)
-                        .to_string()
-                        .into_boxed_str(),
+                    utf8_only(object)?.to_string().into_boxed_str(),
                 ))
             } else if pyre_object::is_bytes(object) {
                 Ok(ast::ConstantValue::Bytes(
@@ -1921,7 +1924,11 @@ fn module_to_object(
     let _roots = pyre_object::gc_roots::push_roots();
     let ast_module = Rooted(pyre_object::gc_roots::shadow_stack_len());
     let _ = pyre_object::gc_roots::pin_root(module_object);
-    let converter = Converter { source, ast_module };
+    let converter = Converter {
+        source,
+        source_file: SourceFileBuilder::new("<unknown>", source).finish(),
+        ast_module,
+    };
     let root = match module {
         ast::Mod::Expression(module) => converter.node(
             "Expression",
@@ -1988,6 +1995,11 @@ type RootedResult = Result<Rooted, crate::PyError>;
 
 struct Converter<'a> {
     source: &'a str,
+    /// A literal's parsed value cannot hold a lone surrogate -- the escape
+    /// decoder answers U+FFFD for one -- so `string_literal_value` and its
+    /// siblings re-read the text the node came from.  They need the source as
+    /// a `SourceFile` to slice it by range.
+    source_file: SourceFile,
     ast_module: Rooted,
 }
 
@@ -2012,6 +2024,10 @@ impl Converter<'_> {
 
     fn string(&self, value: &str) -> Rooted {
         self.pin(pyre_object::w_str_new(value))
+    }
+
+    fn wtf8(&self, value: Wtf8Buf) -> Rooted {
+        self.pin(pyre_object::w_str_from_wtf8(value))
     }
 
     fn none(&self) -> Rooted {
@@ -2551,7 +2567,7 @@ impl Converter<'_> {
             ),
             Expr::StringLiteral(n) => self.constant(
                 range(n.range),
-                self.string(n.value.to_str()),
+                self.wtf8(string_literal_value(&self.source_file, &n.value)),
                 if n.value.is_unicode() {
                     self.string("u")
                 } else {
@@ -2688,11 +2704,13 @@ impl Converter<'_> {
         let mut parts = Vec::new();
         for part in node.value.iter() {
             match part {
-                ast::FStringPart::Literal(literal) => {
-                    push_literal(&mut parts, range(literal.range), &literal.value)
-                }
+                ast::FStringPart::Literal(literal) => push_literal(
+                    &mut parts,
+                    range(literal.range),
+                    &string_literal_part_value(&self.source_file, literal),
+                ),
                 ast::FStringPart::FString(fstring) => {
-                    self.interpolated_elements(&fstring.elements, &mut parts)?
+                    self.interpolated_elements(&fstring.elements, fstring.flags.into(), &mut parts)?
                 }
             }
         }
@@ -2709,7 +2727,7 @@ impl Converter<'_> {
             .into_iter()
             .map(|part| match part {
                 JoinedPart::Literal { start, end, value } => {
-                    self.constant((start, end), self.string(&value), self.none())
+                    self.constant((start, end), self.wtf8(value), self.none())
                 }
                 JoinedPart::Value(value) => Ok(value),
             })
@@ -2719,13 +2737,16 @@ impl Converter<'_> {
     fn interpolated_elements(
         &self,
         elements: &[ast::InterpolatedStringElement],
+        flags: ast::AnyStringFlags,
         parts: &mut Vec<JoinedPart>,
     ) -> Result<(), crate::PyError> {
         for element in elements {
             match element {
-                ast::InterpolatedStringElement::Literal(literal) => {
-                    push_literal(parts, range(literal.range), &literal.value)
-                }
+                ast::InterpolatedStringElement::Literal(literal) => push_literal(
+                    parts,
+                    range(literal.range),
+                    &interpolated_string_literal_value(&self.source_file, literal, flags),
+                ),
                 ast::InterpolatedStringElement::Interpolation(interpolation) => {
                     let mut conversion = interpolation.conversion;
                     if let Some(debug_text) = interpolation.debug_text.as_ref() {
@@ -2745,7 +2766,7 @@ impl Converter<'_> {
                         .as_deref()
                         .map(|spec| {
                             let mut spec_parts = Vec::new();
-                            self.interpolated_elements(&spec.elements, &mut spec_parts)?;
+                            self.interpolated_elements(&spec.elements, flags, &mut spec_parts)?;
                             let values = self.joined_values(spec_parts)?;
                             self.node(
                                 "JoinedStr",
@@ -2794,7 +2815,11 @@ impl Converter<'_> {
                 start.saturating_sub(leading.len() as u32),
                 end + trailing.len() as u32,
             ),
-            &[leading.as_str(), expression, trailing.as_str()].concat(),
+            Wtf8::new(
+                [leading.as_str(), expression, trailing.as_str()]
+                    .concat()
+                    .as_str(),
+            ),
         );
     }
 
@@ -3302,11 +3327,15 @@ fn class_name(object: PyObjectRef) -> &'static str {
 /// implicit concatenation, the text an `=` conversion echoes -- therefore
 /// reaches the tree as one node, not one per piece.
 enum JoinedPart {
-    Literal { start: u32, end: u32, value: String },
+    Literal {
+        start: u32,
+        end: u32,
+        value: Wtf8Buf,
+    },
     Value(Rooted),
 }
 
-fn push_literal(parts: &mut Vec<JoinedPart>, (start, end): (u32, u32), value: &str) {
+fn push_literal(parts: &mut Vec<JoinedPart>, (start, end): (u32, u32), value: &Wtf8) {
     if value.is_empty() {
         return;
     }
@@ -3317,14 +3346,41 @@ fn push_literal(parts: &mut Vec<JoinedPart>, (start, end): (u32, u32), value: &s
     }) = parts.last_mut()
     {
         *last_end = end;
-        last.push_str(value);
+        last.push_wtf8(value);
         return;
     }
     parts.push(JoinedPart::Literal {
         start,
         end,
-        value: value.to_string(),
+        value: value.to_owned(),
     });
+}
+
+/// The `&str` a compiler AST field is, or the refusal `PyUnicode_AsUTF8`
+/// answers with for the same value.
+///
+/// `ast::ConstantValue::Str` and every identifier field are `str`, so a lone
+/// surrogate has nowhere to go on the way back into the compiler.  It gets
+/// there through an ordinary `ast.parse` round trip, since the tree the parse
+/// answers does carry one, and [`w_str_get_value`] would take the process
+/// down over it.
+///
+/// [`w_str_get_value`]: pyre_object::w_str_get_value
+fn utf8_only(value: PyObjectRef) -> AstResult<&'static str> {
+    if let Some(text) = unsafe { pyre_object::w_str_get_value_opt(value) } {
+        return Ok(text);
+    }
+    let position = unsafe { pyre_object::w_str_get_wtf8(value) }
+        .code_points()
+        .position(|point| point.to_char().is_none())
+        .expect("not valid UTF-8, so one of the code points is a surrogate");
+    Err(crate::typedef::unicode_encode_error(
+        "utf-8",
+        value,
+        position,
+        position + 1,
+        "surrogates not allowed",
+    ))
 }
 
 /// A comment inside the braces runs to the end of the line and is no part of


### PR DESCRIPTION
`_testbuffer`, `_testsinglephase` and `_testmultiphase` are built into `lib-python/3` rather than `build/cpython_tests`, so a child started with `-E` or `-I` finds them — `_testmultiphase_build.py` compiles into `lib_pypy` for the same reason, and `compute_lib_pypy_path` puts that on the default path. The `PYTHONPATH` plumbing is gone and the post-build import check runs under `-E`, so it answers for the path the tests actually reach the modules through.

That makes the three modules importable to every suite module. Four rows flipped, and this is what they were covering up.

## A non-module create result never got its methods

`PyModule_FromDefAndSpec2` and `modsupport.py` both fall through to `m_methods` and `m_doc` when the create slot answers something that is not a module; pyre returned first, so `_testmultiphase`'s `nonmodule_with_methods` came back as a bare `SimpleNamespace`. The tail moves into `add_methods_and_doc` and the non-module branch calls it. `store` writes through a module's proxy-free dict, so `store_on_object` takes the ordinary attribute path for anything else.

## `PickleBuffer` was wrong on three axes at once, and C-contiguity hid all three

`_testbuffer.ndarray` reaching the PEP 574 fixtures ran a Fortran-contiguous buffer through them for the first time.

| | pyre | upstream |
|---|---|---|
| contiguity | `c_contiguous` | `PyBuffer_IsContiguous(&view, 'A')` — `picklebufobject.c`, `_pickle.c` |
| `raw()` | `memoryview.cast('B')`, restricted to C-contiguous | `picklebuf_raw` rewrites format/ndim/itemsize/shape/strides |
| in-band bytes | `memoryview.tobytes()` (logical) | `view.buf` for `view.len` (physical) |

`memoryview_raw_bytes` reinterprets without the cast's precondition; the caller keeps the contiguity check. Round-trip now holds for 1-D, 2-D C and 2-D F across protocols 4 and 5 — only proto 5 + F was wrong, since the other five agree when logical and physical order coincide.

## One upstream test guard

`test_multi_init_extension_compat` guards on `_testmultiphase` alone while calling `check_compatible_fresh`, whose child imports `_testinternalcapi`. Its four siblings guard on both; the two tests beside it that call only `check_*_here` correctly do not, and are left alone.

## `ast.parse` dropped a lone surrogate that `compile` kept

A string literal's parsed value is a `str` and the escape decoder answers U+FFFD for a surrogate, so codegen re-reads the text through `string_literal_value`, `string_literal_part_value` and `interpolated_string_literal_value`. The `_ast` bridge did not, and lost the surrogate in all five literal forms — plain, concatenated, f-string, f-string with an expression, and a docstring. It now uses the same three helpers and carries `Wtf8Buf` through `JoinedPart`.

Going back the other way there is nowhere for a surrogate to sit — `ConstantValue::Str` is a `Box<str>` — and `w_str_get_value` panicked. That panic predates this change (a hand-built `ast.Constant` reaches it too) but an ordinary `ast.parse` → `compile` round trip now does. `utf8_only` raises the `UnicodeEncodeError` `PyUnicode_AsUTF8` answers with instead, message for message. Full pypy parity there needs the ruff AST to carry WTF-8 and is not in this change.

## Verification

- CPython suite **221 PASS / 0 FAIL / 36 SKIP, no regressions** (dynasm, jobs=18)
- `test_importlib.extension` 53 tests OK — the row this started from
- `test_import` OK; the guarded test verified to skip on its own
- `test_buffer` unchanged at 7 failures
- `cargo fmt --all -- --check` and `scripts/check-majit-boundary.py` clean

Measured against CPython 3.14 and pypy3 side by side: all five surrogate forms and the `UnicodeEncodeError` text match.