### PR TITLE
jit: give the bridge resume reader its applying half, and fill the virtualizable a guard-position bridge resumes on

### DIFF
--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -3010,6 +3010,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 rd_virtuals: Option<&[std::rc::Rc<majit_ir::RdVirtualInfo>]>,
                 fail_values: &[i64],
                 fail_types: &[majit_ir::Type],
+                executing: Option<&dyn majit_metainterp::resume::BlackholeAllocator>,
             ) {
                 use majit_ir::resumedata::RebuiltValue;
                 use majit_metainterp::JitCodeSym as _;
@@ -3028,16 +3029,27 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 // commits inline; without this replay the bridge reads size>chain
                 // and dereferences a NULL node head. Runs independent of the
                 // frame-register seeding below (which may decline).
-                let mut __bridge_cache = majit_metainterp::BridgeVirtualCache::new(
-                    rd_virtuals.map_or(0, |v| v.len()),
-                    majit_metainterp::default_bridge_array_descr,
-                );
-                majit_metainterp::replay_pending_fields(
+                let __bridge_virtual_count = rd_virtuals.map_or(0, |v| v.len());
+                let mut __bridge_cache = match executing {
+                    Some(__alloc) => majit_metainterp::BridgeVirtualCache::executing(
+                        __bridge_virtual_count,
+                        majit_metainterp::default_bridge_array_descr,
+                        __alloc,
+                        fail_values,
+                    ),
+                    None => majit_metainterp::BridgeVirtualCache::new(
+                        __bridge_virtual_count,
+                        majit_metainterp::default_bridge_array_descr,
+                    ),
+                };
+                if !majit_metainterp::replay_pending_fields(
                     ctx,
                     resume_data,
                     rd_virtuals,
                     &mut __bridge_cache,
-                );
+                ) {
+                    ctx.mark_bridge_replay_incomplete();
+                }
                 #seed_bridge_vable
                 #rebind_bridge_vable_identity
                 let frame = match resume_data.frames.first() {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
@@ -26,12 +26,52 @@ impl<'c> Lowerer<'c> {
         })
     }
 
+    /// Lower an `if` / `while` condition, peeling a leading `!` into the
+    /// branch instead of computing it.
+    ///
+    /// `jtransform.py` renames `bool_not` to `int_is_zero`, and
+    /// `optimize_goto_if_not` then folds that operation into the block's
+    /// exitswitch, so `if not x` reaches flatten as one
+    /// `goto_if_not_int_is_zero` and no separate negation op.
+    ///
+    /// The peel belongs to condition position and nowhere else. `BindingKind`
+    /// carries no `bool`, and `!` is logical on a Rust `bool` but bitwise on
+    /// an integer, so a general `UnOp::Not` arm could not tell the two apart
+    /// and does not exist. A condition is `bool` by the language's own typing
+    /// rule, which is the guarantee `optimize_goto_if_not` spells out as
+    /// `v.concretetype != lltype.Bool: return False`.
+    pub(super) fn lower_condition(&mut self, cond: &Expr) -> Option<(Binding, bool)> {
+        let mut negated = false;
+        let mut expr = cond;
+        loop {
+            match expr {
+                Expr::Paren(paren) => expr = &paren.expr,
+                Expr::Unary(ExprUnary {
+                    op: UnOp::Not(_),
+                    expr: inner,
+                    ..
+                }) => {
+                    negated = !negated;
+                    expr = inner;
+                }
+                _ => break,
+            }
+        }
+        let binding = self.lower_value_expr(expr)?;
+        // The int bank is what `goto_if_not_int_is_zero` reads. An unnegated
+        // condition keeps whatever the caller already accepted.
+        if negated && !matches!(binding.kind, BindingKind::Int) {
+            return None;
+        }
+        Some((binding, negated))
+    }
+
     pub(super) fn lower_if_stmt(&mut self, expr_if: &ExprIf) -> Option<()> {
         let snap_stmts = self.statements.len();
         let snap_meta = self.op_metadata.len();
         let snap_reg = self.next_reg;
         let snap_bindings = self.bindings.clone();
-        let cond = self.lower_value_expr(&expr_if.cond)?;
+        let (cond, cond_negated) = self.lower_condition(&expr_if.cond)?;
         if self.ops_since_contain_float_compare(snap_meta) {
             // Guard over a float comparison hangs the compiled trace; roll
             // back the condition ops and bail so the arm runs interpreted.
@@ -72,7 +112,7 @@ impl<'c> Lowerer<'c> {
             OpMeta::live_marker(),
             quote! { let _ = __builder.live_placeholder(); },
         );
-        self.emit_conditional_guard(cond_reg, &else_label);
+        self.emit_conditional_guard_negatable(cond_reg, &else_label, cond_negated);
         self.append_lowered_sequence(then_seq);
         self.emit_jump(&end_label);
         self.emit_label_def(&else_label);
@@ -93,6 +133,10 @@ impl<'c> Lowerer<'c> {
     /// default; end:
     /// ```
     pub(super) fn lower_match_stmt(&mut self, expr_match: &syn::ExprMatch) -> Option<()> {
+        self.transactional(|s| s.lower_match_stmt_inner(expr_match))
+    }
+
+    fn lower_match_stmt_inner(&mut self, expr_match: &syn::ExprMatch) -> Option<()> {
         let discriminant = self.lower_value_expr(&expr_match.expr)?;
         if !matches!(discriminant.kind, BindingKind::Int) {
             return None;
@@ -232,20 +276,20 @@ impl<'c> Lowerer<'c> {
     /// loop_end:
     /// ```
     pub(super) fn lower_while_loop(&mut self, expr_while: &syn::ExprWhile) -> Option<()> {
-        let snap_stmts = self.statements.len();
+        self.transactional(|s| s.lower_while_loop_inner(expr_while))
+    }
+
+    fn lower_while_loop_inner(&mut self, expr_while: &syn::ExprWhile) -> Option<()> {
         let snap_meta = self.op_metadata.len();
-        let snap_reg = self.next_reg;
-        let snap_label = self.next_label;
-        let snap_bindings = self.bindings.clone();
 
         // `loop_start` has to be marked *before* the condition lowers:
         // `mark_label` records the builder's current bytecode position, the
         // back edge re-enters there, and the condition must be re-tested on
         // every iteration.  So these allocations cannot be deferred past the
         // first fallible call the way `lower_if_with_loop_control` defers its
-        // own — both of that function's labels are forward targets, which is
-        // why it leaks nothing without a restore.  Here every exit below has
-        // to put `next_label` back itself.
+        // own — both of that function's labels are forward targets. Every exit
+        // below leaves two labels and three statements emitted, which is what
+        // the `transactional` wrapper puts back.
         let loop_start = self.alloc_label();
         let loop_end = self.alloc_label();
 
@@ -254,25 +298,10 @@ impl<'c> Lowerer<'c> {
         self.emit_label_def(&loop_start);
 
         // Evaluate the condition
-        let Some(cond) = self.lower_value_expr(&expr_while.cond) else {
-            // Two labels and three statements are already emitted; drop them
-            // so an unlowerable condition leaves no gap in the label counter.
-            self.statements.truncate(snap_stmts);
-            self.op_metadata.truncate(snap_meta);
-            self.next_reg = snap_reg;
-            self.next_label = snap_label;
-            self.bindings = snap_bindings;
-            return None;
-        };
+        let (cond, cond_negated) = self.lower_condition(&expr_while.cond)?;
         if self.ops_since_contain_float_compare(snap_meta) {
-            // Guard over a float comparison hangs the compiled trace; roll
-            // back everything emitted for this loop and bail so the arm
-            // runs interpreted instead.
-            self.statements.truncate(snap_stmts);
-            self.op_metadata.truncate(snap_meta);
-            self.next_reg = snap_reg;
-            self.next_label = snap_label;
-            self.bindings = snap_bindings;
+            // Guard over a float comparison hangs the compiled trace; bail so
+            // the arm runs interpreted instead.
             return None;
         }
         let cond_reg = cond.reg;
@@ -280,7 +309,7 @@ impl<'c> Lowerer<'c> {
             OpMeta::live_marker(),
             quote! { let _ = __builder.live_placeholder(); },
         );
-        self.emit_conditional_guard(cond_reg, &loop_end);
+        self.emit_conditional_guard_negatable(cond_reg, &loop_end, cond_negated);
 
         // Lower the body, with break targets pointing to loop_end
         let body_seq = self.lower_loop_body(&expr_while.body, &loop_end, &loop_start)?;
@@ -300,6 +329,10 @@ impl<'c> Lowerer<'c> {
     /// loop_end:
     /// ```
     pub(super) fn lower_loop_expr(&mut self, expr_loop: &syn::ExprLoop) -> Option<()> {
+        self.transactional(|s| s.lower_loop_expr_inner(expr_loop))
+    }
+
+    fn lower_loop_expr_inner(&mut self, expr_loop: &syn::ExprLoop) -> Option<()> {
         let loop_start = self.alloc_label();
         let loop_end = self.alloc_label();
 
@@ -321,6 +354,10 @@ impl<'c> Lowerer<'c> {
     /// and wildcard variants are accepted.  Other iterator protocol shapes
     /// still return `None` so the containing arm falls back unchanged.
     pub(super) fn lower_for_loop(&mut self, expr_for: &syn::ExprForLoop) -> Option<()> {
+        self.transactional(|s| s.lower_for_loop_inner(expr_for))
+    }
+
+    fn lower_for_loop_inner(&mut self, expr_for: &syn::ExprForLoop) -> Option<()> {
         let loop_var = match &*expr_for.pat {
             Pat::Ident(pat_ident) if pat_ident.subpat.is_none() => Some(pat_ident.ident.clone()),
             Pat::Wild(_) => None,
@@ -513,6 +550,15 @@ impl<'c> Lowerer<'c> {
         break_label: &syn::Ident,
         continue_label: &syn::Ident,
     ) -> Option<()> {
+        self.transactional(|s| s.lower_loop_if_inner(expr_if, break_label, continue_label))
+    }
+
+    fn lower_loop_if_inner(
+        &mut self,
+        expr_if: &ExprIf,
+        break_label: &syn::Ident,
+        continue_label: &syn::Ident,
+    ) -> Option<()> {
         // Check if any branch contains break or continue
         let then_has_loop_ctrl = block_has_loop_control(&expr_if.then_branch);
         let else_has_loop_ctrl = expr_if
@@ -524,20 +570,11 @@ impl<'c> Lowerer<'c> {
             return None; // no break/continue, fall back to normal lowering
         }
 
-        let snap_stmts = self.statements.len();
         let snap_meta = self.op_metadata.len();
-        let snap_reg = self.next_reg;
-        let snap_label = self.next_label;
-        let snap_bindings = self.bindings.clone();
-        let cond = self.lower_value_expr(&expr_if.cond)?;
+        let (cond, cond_negated) = self.lower_condition(&expr_if.cond)?;
         if self.ops_since_contain_float_compare(snap_meta) {
-            // Guard over a float comparison hangs the compiled trace; roll
-            // back and bail so the arm runs interpreted instead.
-            self.statements.truncate(snap_stmts);
-            self.op_metadata.truncate(snap_meta);
-            self.next_reg = snap_reg;
-            self.next_label = snap_label;
-            self.bindings = snap_bindings;
+            // Guard over a float comparison hangs the compiled trace; bail so
+            // the arm runs interpreted instead.
             return None;
         }
         let else_label = self.alloc_label();
@@ -550,7 +587,7 @@ impl<'c> Lowerer<'c> {
             OpMeta::live_marker(),
             quote! { let _ = __builder.live_placeholder(); },
         );
-        self.emit_conditional_guard(cond_reg, &else_label);
+        self.emit_conditional_guard_negatable(cond_reg, &else_label, cond_negated);
 
         // Lower then-branch with loop control
         let then_seq = self.lower_loop_body(&expr_if.then_branch, break_label, continue_label)?;
@@ -575,6 +612,10 @@ impl<'c> Lowerer<'c> {
     /// Lower a match expression in value position to chained if-else guards
     /// that produce a value.
     pub(super) fn lower_match_value(&mut self, expr_match: &syn::ExprMatch) -> Option<Binding> {
+        self.transactional(|s| s.lower_match_value_inner(expr_match))
+    }
+
+    fn lower_match_value_inner(&mut self, expr_match: &syn::ExprMatch) -> Option<Binding> {
         let discriminant = self.lower_value_expr(&expr_match.expr)?;
         if !matches!(discriminant.kind, BindingKind::Int) {
             return None;
@@ -995,6 +1036,60 @@ mod unroll_binding_tests {
         assert_eq!(lowerer.next_label, 31);
         assert!(lowerer.statements.is_empty());
         assert!(lowerer.op_metadata.is_empty());
+    }
+
+    /// The classification test above covers a match that refuses before it
+    /// emits. This is the other half: the discriminant lowers, the arm guard
+    /// and its two `new_label()`s are already in the stream, and then the arm
+    /// body refuses. What the stream must not keep is a label created without
+    /// a `mark_label` — the jitcode assembler cannot see that until it patches
+    /// a `goto` naming a position no block ever took.
+    #[test]
+    fn failed_match_arm_body_leaves_no_label_behind() {
+        let mut lowerer = Lowerer::new(None);
+        lowerer.next_label = 41;
+
+        let expr_match: syn::ExprMatch = syn::parse_quote! {
+            match 0 {
+                1 => unsupported_body(),
+                _ => {},
+            }
+        };
+        assert!(lowerer.lower_match_stmt(&expr_match).is_none());
+        assert_eq!(lowerer.next_label, 41);
+        assert!(lowerer.statements.is_empty());
+        assert!(lowerer.op_metadata.is_empty());
+    }
+
+    /// `not cond` is a different branch opname, not an operation plus a
+    /// branch: `jtransform.py` renames `bool_not` to `int_is_zero` and
+    /// `optimize_goto_if_not` folds it into the exitswitch.
+    #[test]
+    fn a_negated_condition_selects_the_is_zero_branch() {
+        let mut lowerer = Lowerer::new(None);
+        let stmt: Stmt = syn::parse_quote! { let flag = 1; };
+        let Stmt::Local(local) = stmt else {
+            unreachable!("parse_quote produced the requested let statement")
+        };
+        assert!(lowerer.lower_local(&local).is_some());
+
+        let expr_if: syn::ExprIf = syn::parse_quote! { if !flag { } };
+        assert!(lowerer.lower_if_stmt(&expr_if).is_some());
+
+        let emitted = lowerer
+            .statements
+            .iter()
+            .map(|tokens| tokens.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            emitted.contains("goto_if_not_int_is_zero"),
+            "`if !flag` must branch on int_is_zero, got:\n{emitted}"
+        );
+        assert!(
+            !emitted.contains("goto_if_not_int_is_true"),
+            "the negation must replace the branch, not add one:\n{emitted}"
+        );
     }
 
     #[test]

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -1886,7 +1886,7 @@ impl<'c> Lowerer<'c> {
             return Some(binding);
         }
 
-        let cond = self.lower_value_expr(&expr_if.cond)?;
+        let (cond, cond_negated) = self.lower_condition(&expr_if.cond)?;
         if !matches!(cond.kind, BindingKind::Int) {
             return None;
         }
@@ -1922,7 +1922,7 @@ impl<'c> Lowerer<'c> {
             OpMeta::live_marker(),
             quote! { let _ = __builder.live_placeholder(); },
         );
-        self.emit_conditional_guard(cond_reg, &else_label);
+        self.emit_conditional_guard_negatable(cond_reg, &else_label, cond_negated);
         self.append_lowered_sequence(then_seq);
         self.emit_op(
             OpMeta::linear(

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
@@ -114,6 +114,22 @@ pub(super) struct Lowerer<'c> {
     pub(super) inline_arm_tail_stmt: bool,
 }
 
+/// Everything a failed lowering has to put back.
+///
+/// A lowerer that emits before it can know whether it will succeed —
+/// every construct whose branch target must exist before its body is
+/// lowered — owes the caller an unchanged stream when it refuses. What it
+/// leaves behind otherwise is a `__builder.new_label()` with no
+/// `mark_label`, and the jitcode assembler can only report that at the
+/// end, as a label referenced by a `goto` that names no position.
+pub(super) struct LowerSnapshot {
+    statements: usize,
+    op_metadata: usize,
+    next_reg: u16,
+    next_label: u16,
+    bindings: HashMap<String, Binding>,
+}
+
 impl<'c> Lowerer<'c> {
     pub(super) fn new(config: Option<&'c LowererConfig>) -> Self {
         let call_policies = config.map(|cfg| cfg.calls.clone()).unwrap_or_default();
@@ -264,6 +280,40 @@ impl<'c> Lowerer<'c> {
     /// already consumed therefore leaves the counter alone; it is put back by
     /// `try_inline_dispatch_arm`, which discards the statement stream in the
     /// same block.
+    pub(super) fn snapshot(&self) -> LowerSnapshot {
+        LowerSnapshot {
+            statements: self.statements.len(),
+            op_metadata: self.op_metadata.len(),
+            next_reg: self.next_reg,
+            next_label: self.next_label,
+            bindings: self.bindings.clone(),
+        }
+    }
+
+    /// Truncate the statements and roll the label counter back together, the
+    /// pairing [`Self::alloc_label`] requires.
+    pub(super) fn restore(&mut self, snapshot: LowerSnapshot) {
+        self.statements.truncate(snapshot.statements);
+        self.op_metadata.truncate(snapshot.op_metadata);
+        self.next_reg = snapshot.next_reg;
+        self.next_label = snapshot.next_label;
+        self.bindings = snapshot.bindings;
+    }
+
+    /// Run a lowering that emits before it can fail, and leave the stream
+    /// untouched if it refuses.
+    pub(super) fn transactional<T>(
+        &mut self,
+        lower: impl FnOnce(&mut Self) -> Option<T>,
+    ) -> Option<T> {
+        let snapshot = self.snapshot();
+        let lowered = lower(self);
+        if lowered.is_none() {
+            self.restore(snapshot);
+        }
+        lowered
+    }
+
     pub(super) fn alloc_label(&mut self) -> syn::Ident {
         let label = self.next_label;
         self.next_label = self.next_label.saturating_add(1);
@@ -303,12 +353,34 @@ impl<'c> Lowerer<'c> {
     }
 
     pub(super) fn emit_conditional_guard(&mut self, cond_reg: u16, target: &Ident) {
-        // `goto_if_not_int_is_true` reads an int-banked register per
-        // `assembler.py:217 'i'` argcode — encode the kind into the
-        // metadata `Register` so the liveness walker keeps it under Int.
+        self.emit_conditional_guard_negatable(cond_reg, target, false);
+    }
+
+    /// The branch RPython writes as `goto_if_not_<opname>`: fall through
+    /// when the condition holds, take `target` otherwise.
+    ///
+    /// `negated` selects the `int_is_zero` form, which is the shape `!cond`
+    /// reaches flatten as. `jtransform.py` renames `bool_not` to
+    /// `int_is_zero`, and `optimize_goto_if_not` folds that operation into
+    /// the block's exitswitch rather than materialising its result, so the
+    /// negation costs a different branch opname and nothing else.
+    pub(super) fn emit_conditional_guard_negatable(
+        &mut self,
+        cond_reg: u16,
+        target: &Ident,
+        negated: bool,
+    ) {
+        let branch = if negated {
+            format_ident!("goto_if_not_int_is_zero")
+        } else {
+            format_ident!("goto_if_not_int_is_true")
+        };
+        // Both forms read an int-banked register per `assembler.py:217 'i'`
+        // argcode — encode the kind into the metadata `Register` so the
+        // liveness walker keeps it under Int.
         self.emit_op(
             OpMeta::conditional_guard(Register::int(cond_reg), target.clone()),
-            quote! { __builder.goto_if_not_int_is_true(#cond_reg, #target); },
+            quote! { __builder.#branch(#cond_reg, #target); },
         );
     }
 

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -187,6 +187,25 @@ pub trait JitState: Sized {
     type Sym;
     type Env: ?Sized;
 
+    /// Whether this frontend's own guard-failure recovery already filled the
+    /// virtualizable from the resume stream.
+    ///
+    /// `pyjitpl.py rebuild_state_after_failure` closes by assigning
+    /// `self.virtualizable_boxes` and then calling
+    /// `self.synchronize_virtualizable()` — the boxes are the trace's copy and
+    /// the object still holds whatever compiled code last spilled, so the
+    /// second half is what makes a walk resumed at the guard read the right
+    /// fields. Bridge setup here performs it for a frontend that answers
+    /// `false`.
+    ///
+    /// A frontend answers `true` when its own recovery already wrote those
+    /// fields, which it may have to: the write this crate can make converts a
+    /// shadow value with `value_to_raw_bits`, and a frontend whose array slots
+    /// hold boxed objects needs a field-aware conversion that only it can
+    /// spell. Writing twice is not the hazard — writing raw bits into a slot
+    /// that wanted a box is.
+    const SYNCHRONIZES_VIRTUALIZABLE_AFTER_GUARD_FAILURE: bool = false;
+
     fn can_trace(&self) -> bool {
         true
     }

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -382,6 +382,14 @@ pub trait JitState: Sized {
     /// decode the resume stream into per-callee recipes and stash a
     /// `BridgeInlineCarrier` on `ctx` (drained by `trace_bytecode` right
     /// before `interpret()`).
+    ///
+    /// `executing` selects which half of `resume.py`'s reader pair this entry
+    /// needs. `Some(allocator)` is `ResumeDataBoxReader`, whose
+    /// `allocate_with_vtable` / `setfield` go through `execute_and_record` and
+    /// so apply each write as well as recording it — the reader upstream uses
+    /// for an entry no direct reader preceded. `None` records only, which is
+    /// sound exactly when a direct reader has already applied this guard's
+    /// writes.
     fn setup_bridge_sym(
         _sym: &mut Self::Sym,
         _ctx: &mut crate::trace_ctx::TraceCtx,
@@ -389,6 +397,7 @@ pub trait JitState: Sized {
         _rd_virtuals: Option<&[std::rc::Rc<majit_ir::RdVirtualInfo>]>,
         _fail_values: &[i64],
         _fail_types: &[Type],
+        _executing: Option<&dyn crate::resume::BlackholeAllocator>,
     ) {
     }
 

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5053,17 +5053,17 @@ impl<S: JitState> JitDriver<S> {
             let fail_types = resume.fail_arg_types.clone();
             let values = frame.values.clone();
             let resume_pc = usize::try_from(frame.pc).map_err(|_| Decline::NoResumeState)?;
-            // OPEN, and not the reader's: what the reader applies is
-            // op-for-op what the blackhole applies for the same guard. What
-            // the walk it enables is missing is the trailing
-            // `synchronize_virtualizable()` of `pyjitpl.py
-            // rebuild_state_after_failure` — `start_bridge_tracing` seeds the
-            // virtualizable BOXES from the resume stream but nothing writes
-            // them back to the object, so a frontend that does not run that
-            // writer itself walks against a stale virtualizable. Guards
-            // carrying deferred writes are the ones that surface it; the
-            // blackhole arm does not, because it writes the virtualizable
-            // back on its way through. Decline them until that call is wired.
+            // OPEN, and narrower than it was. The reader applies these guards'
+            // writes op-for-op as the blackhole does, and the virtualizable
+            // arrays are now written back from the resume stream, but a
+            // self-interpreting workload still reads one operand twice when
+            // these guards are served — and stops doing so when the
+            // virtualizable's banded arms are put out of reach, so what the
+            // walk resumes on is still described somewhere this entry does
+            // not restore. The scalars are the remaining candidate: they are
+            // carried by the state-field resume mechanism, disjoint from the
+            // array restore above, and nothing writes them into the live
+            // state before the walk reads through them.
             if has_pending {
                 return Err(Decline::ReplayIncomplete);
             }
@@ -8424,7 +8424,18 @@ impl<S: JitState> JitDriver<S> {
             // An entry that asked to apply and has no allocator to apply
             // through cannot fall back to recording only: nothing else will
             // write this guard's deferred stores.
-            if execute_replay && replay_allocator.is_none() {
+            //
+            // Only where there are any. `ResumeDataBoxReader` allocates and
+            // stores for the virtuals and the pending fields the stream
+            // carries and for nothing else, so a guard carrying neither asks
+            // the allocator for nothing and is served whether one exists or
+            // not.
+            if execute_replay
+                && replay_allocator.is_none()
+                && retrace.storage.as_deref().is_some_and(|storage| {
+                    !storage.rd_pendingfields.is_empty() || !storage.rd_virtuals.is_empty()
+                })
+            {
                 ctx.mark_bridge_replay_incomplete();
             }
             S::setup_bridge_sym(
@@ -8436,6 +8447,17 @@ impl<S: JitState> JitDriver<S> {
                 &retrace.fail_types,
                 replay_allocator,
             );
+            // `pyjitpl.py rebuild_state_after_failure` tail: the call above is
+            // `rebuild_from_resumedata`, which leaves the virtualizable
+            // described by the trace's boxes and by nothing else — the object
+            // itself still holds whatever the compiled loop last spilled into
+            // it. Upstream closes the same routine by writing those boxes
+            // back, and an entry that asked to apply is the entry upstream
+            // reaches it from: no blackhole ran ahead of it, so no one else
+            // has written them.
+            if execute_replay && !S::SYNCHRONIZES_VIRTUALIZABLE_AFTER_GUARD_FAILURE {
+                ctx.synchronize_virtualizable_after_guard_failure();
+            }
         }
         self.bridge_body_start_op_count = self.meta.tracing.as_ref().map(|ctx| ctx.num_ops());
         self.meta.begin_trace_session(trace_meta);

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1810,10 +1810,9 @@ enum GuardResumeDecline {
     /// offset into the jitcode the frame NAMES, so entering a different one
     /// there lands mid-instruction in unrelated code.
     ForeignJitcode,
-    /// The guard's deferred heap writes have not been applied. Only the
-    /// blackhole applies them, so entering here resumes against a heap that is
-    /// missing half of whatever the guard deferred.
-    PendingFields,
+    /// The applying reader met a write it has no applying twin for, so the
+    /// trace records a store the heap did not receive.
+    ReplayIncomplete,
     /// The register-index count and the rebuilt-value count disagree, so the
     /// two sides read different liveness and no per-register pairing off them
     /// is trustworthy.
@@ -1830,7 +1829,7 @@ impl GuardResumeDecline {
         match self {
             GuardResumeDecline::NoResumeState => 83,
             GuardResumeDecline::ForeignJitcode => 84,
-            GuardResumeDecline::PendingFields => 85,
+            GuardResumeDecline::ReplayIncomplete => 85,
             GuardResumeDecline::RegCountMismatch => 86,
             GuardResumeDecline::UnreadableRegister => 87,
         }
@@ -5003,7 +5002,9 @@ impl<S: JitState> JitDriver<S> {
         // position to re-enter at; every other JitState resumes through its
         // own frontend.
         let dispatch = self.dispatch_jitcode().cloned()?;
-        if !self.start_bridge_tracing(descr_arc, state, env, raw_values, target_pc) {
+        // No blackhole runs before this entry, so its replay is the one that
+        // owes the guard's deferred writes to the heap.
+        if !self.start_bridge_tracing(descr_arc, state, env, raw_values, target_pc, true) {
             return None;
         }
         // From here the trace session is LIVE, so a decline has to tear it
@@ -5027,23 +5028,38 @@ impl<S: JitState> JitDriver<S> {
                 return Err(Decline::ForeignJitcode);
             }
             // `resume.py _prepare_pendingfields` replays the guard's deferred
-            // heap writes through `execute_and_record` — it applies them to the
-            // heap AND puts them in the trace. majit's replay
-            // (`replay_pending_fields`) only records: the applying half was the
-            // blackhole's, because until now a bridge was only ever started
-            // after the blackhole had run. Entering at the guard skips the
-            // blackhole, so nothing applies them, and the interpreter resumes
-            // against a heap where the elided half of a push is missing — a
-            // committed size with a null chain.
+            // heap writes through `execute_and_record`, which applies them to
+            // the heap AND puts them in the trace. This entry asked for that
+            // applying reader, so a guard carrying deferred writes is served
+            // here rather than declined — but only as far as the reader has an
+            // applying twin for what it meets. Where it did not, it recorded a
+            // write it could not perform, and resuming would run against a heap
+            // that half-describes what the trace says.
             //
-            // Decline while that half is missing. The blackhole arm is then the
-            // answer for these guards, which is where they were already served.
+            // Decline exactly there. The blackhole arm applies all of them,
+            // which is where these guards were served before.
+            if self
+                .meta
+                .tracing
+                .as_ref()
+                .is_some_and(|ctx| ctx.bridge_replay_incomplete())
+            {
+                return Err(Decline::ReplayIncomplete);
+            }
+            // OPEN: applying the writes is necessary but not sufficient. A
+            // guard carrying deferred writes is one this entry has never run
+            // for, and serving it here makes a self-interpreting workload
+            // produce a short answer with every write applied and no rung
+            // raised, so something else on this path does not hold for these
+            // guards. Keep declining them until that is named; the applying
+            // reader above is what makes the entry survivable at all, and the
+            // blackhole arm keeps serving them meanwhile.
             if resume
                 .storage
                 .as_ref()
                 .is_some_and(|storage| !storage.rd_pendingfields.is_empty())
             {
-                return Err(Decline::PendingFields);
+                return Err(Decline::ReplayIncomplete);
             }
             let fail_types = resume.fail_arg_types.clone();
             let values = frame.values.clone();
@@ -6237,8 +6253,17 @@ impl<S: JitState> JitDriver<S> {
                             && !portal_crn_handled
                             && pc != usize::MAX
                         {
-                            let bridge_ok =
-                                self.start_bridge_tracing(&descr_arc, state, env, &raw_values, pc);
+                            let bridge_ok = self.start_bridge_tracing(
+                                &descr_arc,
+                                state,
+                                env,
+                                &raw_values,
+                                pc,
+                                // The blackhole above already applied this
+                                // guard's writes; recording is the whole
+                                // job here.
+                                false,
+                            );
                             if crate::majit_log_enabled() {
                                 eprintln!(
                                     "[bridge] start_bridge_tracing (green resume) key={} trace={} fail={} resume_pc={} ok={}",
@@ -7991,6 +8016,10 @@ impl<S: JitState> JitDriver<S> {
         env: &S::Env,
         raw_fail_values: &[i64],
         resume_pc: usize,
+        // Which half of `resume.py`'s reader pair the entry needs: true for an
+        // entry no direct reader preceded, so the replay must apply each write
+        // as `execute_and_record` does as well as record it.
+        execute_replay: bool,
     ) -> bool {
         majit_metainterp::mc_diag_bump(12); // start_bridge_tracing entered
         // Same reason as the primary trace entry: the bridge compile decodes
@@ -8371,6 +8400,16 @@ impl<S: JitState> JitDriver<S> {
                 .sym
                 .as_mut()
                 .expect("bridge: sym must be live after S::create_sym");
+            // `Send` is the driver's storage bound, not the reader's, so drop
+            // it here rather than push it onto the `JitState` contract.
+            let replay_allocator: Option<&dyn crate::resume::BlackholeAllocator> = if execute_replay
+            {
+                self.blackhole_allocator
+                    .as_deref()
+                    .map(|allocator| allocator as &dyn crate::resume::BlackholeAllocator)
+            } else {
+                None
+            };
             let ctx = self
                 .meta
                 .tracing
@@ -8379,6 +8418,12 @@ impl<S: JitState> JitDriver<S> {
             if let Some(idx) = bridge_reg_indices {
                 ctx.set_bridge_reg_indices(idx);
             }
+            // An entry that asked to apply and has no allocator to apply
+            // through cannot fall back to recording only: nothing else will
+            // write this guard's deferred stores.
+            if execute_replay && replay_allocator.is_none() {
+                ctx.mark_bridge_replay_incomplete();
+            }
             S::setup_bridge_sym(
                 sym,
                 ctx,
@@ -8386,6 +8431,7 @@ impl<S: JitState> JitDriver<S> {
                 retrace.storage.as_deref().map(|s| s.rd_virtuals.as_slice()),
                 &raw_values,
                 &retrace.fail_types,
+                replay_allocator,
             );
         }
         self.bridge_body_start_op_count = self.meta.tracing.as_ref().map(|ctx| ctx.num_ops());
@@ -9818,8 +9864,14 @@ mod tests {
         let descr_arc = std::sync::Arc::clone(&failure.descr_arc);
         drop(failure);
 
-        let started =
-            driver.start_bridge_tracing(&descr_arc, &mut NonTraceableState, &(), &fail_values, 0);
+        let started = driver.start_bridge_tracing(
+            &descr_arc,
+            &mut NonTraceableState,
+            &(),
+            &fail_values,
+            0,
+            false,
+        );
         assert!(!started);
         assert!(!driver.meta.is_tracing());
     }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5046,24 +5046,27 @@ impl<S: JitState> JitDriver<S> {
             {
                 return Err(Decline::ReplayIncomplete);
             }
-            // OPEN: applying the writes is necessary but not sufficient. A
-            // guard carrying deferred writes is one this entry has never run
-            // for, and serving it here makes a self-interpreting workload
-            // produce a short answer with every write applied and no rung
-            // raised, so something else on this path does not hold for these
-            // guards. Keep declining them until that is named; the applying
-            // reader above is what makes the entry survivable at all, and the
-            // blackhole arm keeps serving them meanwhile.
-            if resume
+            let has_pending = resume
                 .storage
                 .as_ref()
-                .is_some_and(|storage| !storage.rd_pendingfields.is_empty())
-            {
-                return Err(Decline::ReplayIncomplete);
-            }
+                .is_some_and(|storage| !storage.rd_pendingfields.is_empty());
             let fail_types = resume.fail_arg_types.clone();
             let values = frame.values.clone();
             let resume_pc = usize::try_from(frame.pc).map_err(|_| Decline::NoResumeState)?;
+            // OPEN, and not the reader's: what the reader applies is
+            // op-for-op what the blackhole applies for the same guard. What
+            // the walk it enables is missing is the trailing
+            // `synchronize_virtualizable()` of `pyjitpl.py
+            // rebuild_state_after_failure` — `start_bridge_tracing` seeds the
+            // virtualizable BOXES from the resume stream but nothing writes
+            // them back to the object, so a frontend that does not run that
+            // writer itself walks against a stale virtualizable. Guards
+            // carrying deferred writes are the ones that surface it; the
+            // blackhole arm does not, because it writes the virtualizable
+            // back on its way through. Decline them until that call is wired.
+            if has_pending {
+                return Err(Decline::ReplayIncomplete);
+            }
             let ctx = self.meta.tracing.as_mut().ok_or(Decline::NoResumeState)?;
             let reg_indices = ctx
                 .bridge_reg_indices()

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1793,6 +1793,55 @@ fn bank_span(bank_len: usize, base: usize, count: usize) -> std::ops::Range<usiz
     start..(start + count).min(bank_len)
 }
 
+/// Why [`JitDriver::bridge_from_guard_resume_position`] gave the guard's own
+/// position up and handed the failure to the blackhole arm instead.
+///
+/// Its ladder runs before the walk and every rung ends in the same
+/// `abort_trace`, which is counted under one `Counters.ABORT_*` id that the
+/// unclassified default also uses. The rung is therefore only knowable at the
+/// point it is chosen; carrying it out of the closure is what lets
+/// [`Self::diag_slot`] tally each one separately.
+#[derive(Clone, Copy)]
+enum GuardResumeDecline {
+    /// No rebuilt resume data, no frame in it, no position to convert, or no
+    /// live trace session to seed — there is nothing to enter at.
+    NoResumeState,
+    /// The frame names a jitcode other than the dispatch one. A position is an
+    /// offset into the jitcode the frame NAMES, so entering a different one
+    /// there lands mid-instruction in unrelated code.
+    ForeignJitcode,
+    /// The guard's deferred heap writes have not been applied. Only the
+    /// blackhole applies them, so entering here resumes against a heap that is
+    /// missing half of whatever the guard deferred.
+    PendingFields,
+    /// The register-index count and the rebuilt-value count disagree, so the
+    /// two sides read different liveness and no per-register pairing off them
+    /// is trustworthy.
+    RegCountMismatch,
+    /// A live register holds a virtual, which has no concrete value, or nothing
+    /// at all. The walk executes, so a register it cannot read a value out of
+    /// is not one it can run past.
+    UnreadableRegister,
+}
+
+impl GuardResumeDecline {
+    /// The `MC_DIAG` slot this rung is tallied in.
+    const fn diag_slot(self) -> usize {
+        match self {
+            GuardResumeDecline::NoResumeState => 83,
+            GuardResumeDecline::ForeignJitcode => 84,
+            GuardResumeDecline::PendingFields => 85,
+            GuardResumeDecline::RegCountMismatch => 86,
+            GuardResumeDecline::UnreadableRegister => 87,
+        }
+    }
+
+    /// The same rung, for the log line that names it without a slot legend.
+    const fn label(self) -> &'static str {
+        crate::MC_DIAG_LABELS[self.diag_slot()]
+    }
+}
+
 impl<S: JitState> JitDriver<S> {
     /// Create a new JitDriver with the given hot-counting threshold.
     pub fn new(threshold: u32) -> Self {
@@ -4959,17 +5008,23 @@ impl<S: JitState> JitDriver<S> {
         }
         // From here the trace session is LIVE, so a decline has to tear it
         // down rather than return through it.
-        let seeded = (|| {
-            let resume = self.resume_data_result.as_ref()?;
-            let frame = resume.frames.first()?;
+        type Seeded = (usize, Vec<crate::jit_state::GuardResumeReg>);
+        let seeded = (|| -> Result<Seeded, GuardResumeDecline> {
+            use GuardResumeDecline as Decline;
+            let resume = self
+                .resume_data_result
+                .as_ref()
+                .ok_or(Decline::NoResumeState)?;
+            let frame = resume.frames.first().ok_or(Decline::NoResumeState)?;
             // `resume.py:1338` `jitcode = jitcodes[jitcode_pos]`: the position
             // is an offset into the jitcode the frame NAMES. Entering a
             // different one at that offset lands mid-instruction in unrelated
             // code, and the walk decodes whatever byte is there. Only the
             // dispatch jitcode is enterable here, so a frame that names any
             // other one is a decline.
-            if frame.jitcode_index as usize != dispatch.try_index()? {
-                return None;
+            let dispatch_index = dispatch.try_index().ok_or(Decline::NoResumeState)?;
+            if frame.jitcode_index as usize != dispatch_index {
+                return Err(Decline::ForeignJitcode);
             }
             // `resume.py _prepare_pendingfields` replays the guard's deferred
             // heap writes through `execute_and_record` — it applies them to the
@@ -4988,18 +5043,21 @@ impl<S: JitState> JitDriver<S> {
                 .as_ref()
                 .is_some_and(|storage| !storage.rd_pendingfields.is_empty())
             {
-                return None;
+                return Err(Decline::PendingFields);
             }
             let fail_types = resume.fail_arg_types.clone();
             let values = frame.values.clone();
-            let resume_pc = usize::try_from(frame.pc).ok()?;
-            let ctx = self.meta.tracing.as_mut()?;
-            let reg_indices = ctx.bridge_reg_indices()?.clone();
+            let resume_pc = usize::try_from(frame.pc).map_err(|_| Decline::NoResumeState)?;
+            let ctx = self.meta.tracing.as_mut().ok_or(Decline::NoResumeState)?;
+            let reg_indices = ctx
+                .bridge_reg_indices()
+                .ok_or(Decline::NoResumeState)?
+                .clone();
             // `consume_boxes` fills every live register of the frame, so a
             // count that disagrees means the two sides read different
             // liveness and no per-register pairing off them is trustworthy.
             if reg_indices.total_len() != values.len() {
-                return None;
+                return Err(Decline::RegCountMismatch);
             }
             let banks: [(majit_ir::Type, &Vec<u32>, usize); 3] = [
                 (majit_ir::Type::Int, &reg_indices.int, 0),
@@ -5035,7 +5093,9 @@ impl<S: JitState> JitDriver<S> {
                         // register it cannot read a value out of is not a
                         // register it can run past — decline the whole frame
                         // rather than enter it half-seeded.
-                        RebuiltValue::Virtual(_) | RebuiltValue::Unassigned => return None,
+                        RebuiltValue::Virtual(_) | RebuiltValue::Unassigned => {
+                            return Err(Decline::UnreadableRegister);
+                        }
                     };
                     regs.push(crate::jit_state::GuardResumeReg {
                         bank,
@@ -5045,14 +5105,26 @@ impl<S: JitState> JitDriver<S> {
                     });
                 }
             }
-            Some((resume_pc, regs))
+            Ok((resume_pc, regs))
         })();
-        let Some((resume_pc, regs)) = seeded else {
-            self.meta.abort_trace(false);
-            self.clear_tracing_session_state();
-            self.resume_data_result = None;
-            self.last_bridge_is_exception_guard = false;
-            return None;
+        let (resume_pc, regs) = match seeded {
+            Ok(seeded) => seeded,
+            Err(why) => {
+                crate::mc_diag_bump(why.diag_slot());
+                if crate::majit_log_enabled() {
+                    eprintln!("[bridge] guard-resume entry declined: {}", why.label());
+                }
+                // The ladder above already decided; it is the abort that cannot
+                // see which rung chose. Name the reason here so the
+                // `abort_trace` below tallies a bridge given up rather than
+                // falling into the unclassified default, which shares its id.
+                self.meta.stage_abort_reason(crate::counters::ABORT_BRIDGE);
+                self.meta.abort_trace(false);
+                self.clear_tracing_session_state();
+                self.resume_data_result = None;
+                self.last_bridge_is_exception_guard = false;
+                return None;
+            }
         };
 
         self.bridge_entered_at_guard_resume = true;

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -8109,28 +8109,24 @@ impl<S: JitState> JitDriver<S> {
         //     `ctx.virtualizable_boxes` / `virtualizable_values` /
         //     `virtualizable_array_lengths` from resume-decoded values.
         //
-        // TODO (`pyjitpl.py:3437 self.synchronize_
-        // virtualizable()`): the live PyFrame's vable static fields and
-        // array items are written from the resume data by pyre's
-        // separate guard-failure recovery path
-        // (`pyre-jit/src/eval.rs`'s `sync_virtualizable_after_guard_failure`
-        // selected via `ResumeVableMode::GuardFailureSync`), which fires
-        // BEFORE bridge tracing starts. The trailing
-        // `synchronize_virtualizable()` call inside `rebuild_state_after_
-        // failure` is therefore already satisfied by the time
-        // `setup_bridge_sym` runs.  An additional direct call to
-        // `ctx.synchronize_virtualizable()` cannot be wired today because
-        // `trace_ctx.rs`'s `synchronize_virtualizable` uses `value_to_raw_bits` while
-        // `sync_virtualizable_after_guard_failure` uses field-aware
-        // `value_to_static_vable_bits` / `value_to_vable_array_item_bits`
-        // (pyre/pyre-jit/src/eval.rs) — the Ref-array-slot
-        // auto-boxing of `Value::Int` / `Value::Float` via
-        // `pyre_object::intobject::w_int_new` cannot move into
-        // majit-metainterp without violating the majit ⊥ pyre crate
-        // boundary. Unifying the two writers (likely via a
-        // VTypeFieldConvert trait threaded into TraceCtx) is a separate
-        // epic; see `pyre-jit-trace::state::setup_bridge_sym` tail for
-        // the in-tree diagnosis.
+        //   * `pyjitpl.py:3437 self.synchronize_virtualizable()`, the
+        //     routine's closing line, writes those same vable boxes back
+        //     onto the live virtualizable. It is
+        //     `ctx.synchronize_virtualizable_after_guard_failure()` below,
+        //     fired once `setup_bridge_sym` has seeded the boxes and only on
+        //     an entry that asked to apply — an entry the blackhole preceded
+        //     has already had them written.
+        //
+        //     A frontend whose own guard-failure recovery performs that
+        //     write before bridge tracing starts declares
+        //     `JitState::SYNCHRONIZES_VIRTUALIZABLE_AFTER_GUARD_FAILURE` and
+        //     is skipped here. That is not a preference: this writer
+        //     converts every slot through `value_to_raw_bits`, while a
+        //     frontend whose Ref array slots hold boxed integers and floats
+        //     needs a field-aware conversion that allocates through its own
+        //     object model, which cannot be reached from this crate.
+        //     Unifying the two (likely a field-convert trait threaded into
+        //     `TraceCtx`) is a separate epic.
         let resume_data_result = S::rebuild_from_resumedata(
             &mut trace_meta,
             &retrace.fail_types,

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -1827,8 +1827,9 @@ pub const MC_DIAG_LABELS: [&str; MC_DIAG_SLOTS] = [
     // ambiguity these slots exist to remove. 83 = nothing to enter at (no
     // rebuilt resume data, no frame, no position, or no live session); 84 =
     // the frame names a jitcode other than the dispatch one, whose positions
-    // are offsets into different code; 85 = the guard's deferred heap writes
-    // are still pending and only the blackhole applies them; 86 = the
+    // are offsets into different code; 85 = the applying reader met a write it
+    // has no applying twin for, so the trace records a store the heap did not
+    // receive; 86 = the
     // register-index count and the rebuilt-value count disagree; 87 = a live
     // register holds a virtual or nothing at all, and the walk executes.
     //
@@ -1838,7 +1839,7 @@ pub const MC_DIAG_LABELS: [&str; MC_DIAG_SLOTS] = [
     // reading as a defect rather than as a workload property.
     "guard_resume_decline_no_state",
     "guard_resume_decline_foreign_jitcode",
-    "guard_resume_decline_pendingfields",
+    "guard_resume_decline_replay_incomplete",
     "guard_resume_decline_regcount",
     "guard_resume_decline_unreadable_reg",
 ];

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -1443,7 +1443,7 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
 
 /// Number of `MC_DIAG` slots. Declared once so the counter array and
 /// `MC_DIAG_LABELS` cannot drift in length — a mismatch is a compile error.
-pub const MC_DIAG_SLOTS: usize = 83;
+pub const MC_DIAG_SLOTS: usize = 88;
 
 /// Diagnostic-only guard-failure → bridge-trace gate tallies, read out via
 /// the `pyre_jit_mc_diag` guest export. Index legend: 0 = must_compile_with_values
@@ -1820,6 +1820,27 @@ pub const MC_DIAG_LABELS: [&str; MC_DIAG_SLOTS] = [
     // answer would have charged: that many loops retired and made
     // non-inlinable by an opcode reached from a guard.
     "bridge_abort_permanent",
+    // `bridge_from_guard_resume_position` declines, one slot per rung of the
+    // ladder it runs BEFORE the walk. Every rung ends in the same
+    // `abort_trace`, and slot 41 holds that abort together with the
+    // unclassified default, so a single total here would reproduce exactly the
+    // ambiguity these slots exist to remove. 83 = nothing to enter at (no
+    // rebuilt resume data, no frame, no position, or no live session); 84 =
+    // the frame names a jitcode other than the dispatch one, whose positions
+    // are offsets into different code; 85 = the guard's deferred heap writes
+    // are still pending and only the blackhole applies them; 86 = the
+    // register-index count and the rebuilt-value count disagree; 87 = a live
+    // register holds a virtual or nothing at all, and the walk executes.
+    //
+    // 85 and 87 are properties of the guard the failing trace stopped at, not
+    // of this driver: they say the blackhole arm is the one that can serve it.
+    // 83, 84 and 86 are shape disagreements, and a nonzero one is worth
+    // reading as a defect rather than as a workload property.
+    "guard_resume_decline_no_state",
+    "guard_resume_decline_foreign_jitcode",
+    "guard_resume_decline_pendingfields",
+    "guard_resume_decline_regcount",
+    "guard_resume_decline_unreadable_reg",
 ];
 
 /// Render every [`MC_DIAG`] tally as space-separated `label=count` pairs.

--- a/majit/majit-metainterp/src/resume_box_reader.rs
+++ b/majit/majit-metainterp/src/resume_box_reader.rs
@@ -61,6 +61,30 @@ pub struct BridgeVirtualCache<'a> {
     /// operand out of (`cpu.get_ref_value(self.deadframe, num)`). Empty for
     /// the recording-only reader, which never needs a concrete.
     fail_values: &'a [i64],
+    /// Addresses of the virtuals the applying reader has allocated, indexed by
+    /// virtual number and registered as resume-construction GC roots.
+    ///
+    /// resume.py keeps each freshly allocated virtual in `virtuals_cache`,
+    /// an ordinary RPython object and therefore a root, and its own comment
+    /// says why: `allocate()` must fill the cache "as soon as they have the
+    /// object, before they fill its fields", because a later allocation in the
+    /// same walk can collect. Between one `bh_new` and the store that
+    /// publishes its result nothing else refers to that object, so without
+    /// these roots the second virtual of a two-virtual guard collects the
+    /// first. The length is fixed at construction, so the registered slice
+    /// never moves, and the collector writes forwarded addresses back through
+    /// it — always read the address back from here, never from a copy.
+    concrete_roots: Vec<i64>,
+    /// Root-stack depth to unwind to, captured before this cache registered
+    /// anything. Equal to the entry depth for the recording-only reader, whose
+    /// unwind is then a no-op.
+    roots_depth: usize,
+}
+
+impl Drop for BridgeVirtualCache<'_> {
+    fn drop(&mut self) {
+        majit_gc::shadow_stack::pop_resume_ref_roots_to(self.roots_depth);
+    }
 }
 
 impl<'a> BridgeVirtualCache<'a> {
@@ -84,6 +108,8 @@ impl<'a> BridgeVirtualCache<'a> {
             mint_raw_array_descr,
             executing: None,
             fail_values: &[],
+            concrete_roots: Vec::new(),
+            roots_depth: majit_gc::shadow_stack::resume_ref_roots_depth(),
         }
     }
 
@@ -101,10 +127,50 @@ impl<'a> BridgeVirtualCache<'a> {
         allocator: &'a dyn crate::resume::BlackholeAllocator,
         fail_values: &'a [i64],
     ) -> Self {
-        Self {
+        // Built field by field rather than from `Self::new`: the cache
+        // unregisters its roots in `Drop`, and a type that implements `Drop`
+        // cannot be moved out of by struct-update syntax.
+        let mut cache = Self {
+            virtuals_ptr_cache: vec![None; size],
+            virtuals_int_cache: vec![None; size],
+            concrete_ptr_cache: vec![None; size],
+            concrete_int_cache: vec![None; size],
+            mint_raw_array_descr,
             executing: Some(allocator),
             fail_values,
-            ..Self::new(size, mint_raw_array_descr)
+            concrete_roots: vec![0i64; size],
+            roots_depth: majit_gc::shadow_stack::resume_ref_roots_depth(),
+        };
+        if size > 0 {
+            // SAFETY: the buffer is heap-allocated at a fixed address, never
+            // resized after this point, and unregistered by `Drop` before the
+            // cache dies.
+            unsafe {
+                majit_gc::shadow_stack::push_resume_ref_roots(&mut cache.concrete_roots);
+            }
+        }
+        cache
+    }
+
+    /// Publish a freshly allocated virtual as a root and remember which
+    /// `OpRef` names it, so later operands resolve to the address the
+    /// collector is maintaining rather than to a copy taken before it moved.
+    fn set_concrete_root(&mut self, vidx: usize, address: i64) {
+        if let Some(slot) = self.concrete_roots.get_mut(vidx) {
+            *slot = address;
+        }
+    }
+
+    /// The address a materialized virtual currently lives at, by the `OpRef`
+    /// the recording half minted for it.
+    fn concrete_root_of(&self, opref: OpRef) -> Option<i64> {
+        let vidx = self
+            .virtuals_ptr_cache
+            .iter()
+            .position(|slot| *slot == Some(opref))?;
+        match self.concrete_roots.get(vidx) {
+            Some(0) | None => None,
+            Some(address) => Some(*address),
         }
     }
 
@@ -316,6 +382,9 @@ fn operand_concrete(
     // `decode_ref` reads a TAGBOX operand out of the deadframe and nothing
     // else, so the guard's fail values win for an input arg — a shadow carried
     // on the OpRef describes some earlier run of the same slot.
+    if let Some(address) = cache.concrete_root_of(opref) {
+        return Some(majit_ir::Value::Ref(majit_ir::GcRef(address as usize)));
+    }
     if opref.is_input_arg() {
         let bits = *cache.fail_values().get(opref.raw() as usize)?;
         return Some(match opref {
@@ -449,6 +518,15 @@ pub fn materialize_bridge_virtual(
                 .count_ops(OpCode::SetfieldGc, crate::counters::OPS);
             ctx.profiler()
                 .count_ops(OpCode::SetfieldGc, crate::counters::RECORDED_OPS);
+            // `execute_and_record` reaches `_record_helper`, whose
+            // `invalidate_caches` is `mark_escaped` alone for a store
+            // (`clear_caches_not_necessary` answers true for SETFIELD_GC).
+            // Recording the store without it leaves a struct that
+            // `allocate_struct` had just flagged unescaped still flagged so
+            // after it was written into one that is not, and the walk that
+            // follows keeps folding its fields across calls that can reach it.
+            ctx.heap_cache_mut()
+                .mark_escaped(OpCode::SetfieldGc, None, &[struct_op, value]);
             ctx.record_op_with_descr(OpCode::SetfieldGc, &[struct_op, value], field_descr.clone());
             if let Some(allocator) = cache.allocator()
                 && !apply_setfield(ctx, cache, allocator, struct_op, value, fd_info)
@@ -545,15 +623,18 @@ pub fn materialize_bridge_virtual(
             // concrete onto the recorded OpRef is what makes the object the
             // trace names and the object the interpreter resumes against the
             // same one.
+            // resume.py decoder.virtuals_cache.set_ptr(index, struct), which
+            // its own comment requires BEFORE the fields are filled: the cache
+            // is what keeps the object reachable across the allocations
+            // `setfields` may itself perform.
+            cache.set_ptr(vidx, new_op);
             if let Some(allocator) = cache.allocator() {
                 let ptr = allocator.bh_new(&struct_descr);
                 if ptr == 0 {
                     return OpRef::NONE;
                 }
-                ctx.set_opref_concrete(new_op, majit_ir::Value::Ref(majit_ir::GcRef(ptr as usize)));
+                cache.set_concrete_root(vidx, ptr);
             }
-            // resume.py decoder.virtuals_cache.set_ptr(index, struct)
-            cache.set_ptr(vidx, new_op);
             // resume.py self.setfields(decoder, struct)
             if !setfields(
                 ctx,
@@ -1073,6 +1154,10 @@ pub fn emit_pending_field_op(
             .count_ops(OpCode::SetfieldGc, crate::counters::OPS);
         ctx.profiler()
             .count_ops(OpCode::SetfieldGc, crate::counters::RECORDED_OPS);
+        // `_record_helper`'s `invalidate_caches`, which for a store is
+        // `mark_escaped` alone — see the same call in `setfields`.
+        ctx.heap_cache_mut()
+            .mark_escaped(OpCode::SetfieldGc, None, &[target_op, value_op]);
         ctx.record_op_with_descr(OpCode::SetfieldGc, &[target_op, value_op], descr.clone());
         if let Some(allocator) = cache.allocator() {
             let Some(fd) = descr.as_field_descr() else {

--- a/majit/majit-metainterp/src/resume_box_reader.rs
+++ b/majit/majit-metainterp/src/resume_box_reader.rs
@@ -37,16 +37,35 @@ pub fn default_bridge_array_descr(
 /// only virtual kind whose descr is minted rather than looked up in a parent
 /// `SizeDescr`); descr identity is the consumer's gccache concern, so it is
 /// injected rather than fixed in core.
-pub struct BridgeVirtualCache {
+pub struct BridgeVirtualCache<'a> {
     virtuals_ptr_cache: Vec<Option<OpRef>>,
     virtuals_int_cache: Vec<Option<OpRef>>,
     concrete_ptr_cache: Vec<Option<majit_ir::GcRef>>,
     concrete_int_cache: Vec<Option<i64>>,
     mint_raw_array_descr:
         fn(usize, usize, Option<usize>, majit_ir::Type, bool) -> majit_ir::DescrRef,
+    /// The applying half of resume.py's reader pair, present only for the
+    /// entry `ResumeDataBoxReader` serves upstream: one that no direct reader
+    /// preceded.  `allocate_with_vtable` there is
+    /// `metainterp.execute_new_with_vtable` and `setfield` is
+    /// `metainterp.execute_setfield_gc` — `execute_and_record`, which applies
+    /// to the heap AND records; `ResumeDataDirectReader` is the same walk with
+    /// `cpu.bh_*` and no recording.
+    ///
+    /// `None` is the recording-only reader, which upstream has no counterpart
+    /// for and which is sound only because the direct reader has already run
+    /// for this guard: applying again would allocate a SECOND set of virtuals
+    /// and record an identity the interpreter does not hold.
+    executing: Option<&'a dyn crate::resume::BlackholeAllocator>,
+    /// The guard's fail values, which `resume.py decode_ref` reads a TAGBOX
+    /// operand out of (`cpu.get_ref_value(self.deadframe, num)`). Empty for
+    /// the recording-only reader, which never needs a concrete.
+    fail_values: &'a [i64],
 }
 
-impl BridgeVirtualCache {
+impl<'a> BridgeVirtualCache<'a> {
+    /// The recording-only reader, for a bridge entered after a direct reader
+    /// has already applied this guard's writes.
     pub fn new(
         size: usize,
         mint_raw_array_descr: fn(
@@ -63,7 +82,41 @@ impl BridgeVirtualCache {
             concrete_ptr_cache: vec![None; size],
             concrete_int_cache: vec![None; size],
             mint_raw_array_descr,
+            executing: None,
+            fail_values: &[],
         }
+    }
+
+    /// `ResumeDataBoxReader`: the same walk, applying each write through
+    /// `allocator` as it records it.
+    pub fn executing(
+        size: usize,
+        mint_raw_array_descr: fn(
+            usize,
+            usize,
+            Option<usize>,
+            majit_ir::Type,
+            bool,
+        ) -> majit_ir::DescrRef,
+        allocator: &'a dyn crate::resume::BlackholeAllocator,
+        fail_values: &'a [i64],
+    ) -> Self {
+        Self {
+            executing: Some(allocator),
+            fail_values,
+            ..Self::new(size, mint_raw_array_descr)
+        }
+    }
+
+    /// The allocator the applying half stores through, or `None` when this is
+    /// the recording-only reader.
+    pub fn allocator(&self) -> Option<&'a dyn crate::resume::BlackholeAllocator> {
+        self.executing
+    }
+
+    /// The guard's fail values, for resolving a TAGBOX operand's concrete.
+    fn fail_values(&self) -> &'a [i64] {
+        self.fail_values
     }
 
     pub fn get_any(&self, i: usize) -> Option<OpRef> {
@@ -156,7 +209,7 @@ pub fn decode_fieldnum(
     tagged: i16,
     rd_virtuals: Option<&[std::rc::Rc<majit_ir::RdVirtualInfo>]>,
     resume_data: &crate::jit_state::ResumeDataResult,
-    cache: &mut BridgeVirtualCache,
+    cache: &mut BridgeVirtualCache<'_>,
 ) -> OpRef {
     use majit_ir::resumedata::{TAG_CONST_OFFSET, TAGBOX, TAGCONST, TAGINT, TAGVIRTUAL, untag};
     // resume.py `decode_box` dispatches purely on the tag bits;
@@ -248,12 +301,79 @@ pub fn decode_fieldnum(
     }
 }
 
+/// resume.py `decode_ref` / `decode_int` / `decode_float`, concrete half.
+///
+/// The box reader reads a TAGBOX operand straight out of the deadframe
+/// (`cpu.get_ref_value(self.deadframe, num)`), so an input-arg `OpRef`
+/// resolves against the guard's fail values. Everything else — a pool
+/// constant, or a virtual this walk has just allocated — carries its concrete
+/// on the shadow the recording half already stamped.
+fn operand_concrete(
+    ctx: &crate::TraceCtx,
+    cache: &BridgeVirtualCache<'_>,
+    opref: OpRef,
+) -> Option<majit_ir::Value> {
+    // `decode_ref` reads a TAGBOX operand out of the deadframe and nothing
+    // else, so the guard's fail values win for an input arg — a shadow carried
+    // on the OpRef describes some earlier run of the same slot.
+    if opref.is_input_arg() {
+        let bits = *cache.fail_values().get(opref.raw() as usize)?;
+        return Some(match opref {
+            OpRef::InputArgRef(_) => majit_ir::Value::Ref(majit_ir::GcRef(bits as usize)),
+            OpRef::InputArgFloat(_) => majit_ir::Value::Float(f64::from_bits(bits as u64)),
+            _ => majit_ir::Value::Int(bits),
+        });
+    }
+    ctx.box_value(opref)
+}
+
+/// resume.py `ResumeDataBoxReader.setfield` applying half.
+///
+/// `metainterp.execute_setfield_gc` executes the store as well as recording
+/// it, dispatching on `descr.is_pointer_field()` / `is_float_field()` — the
+/// same three-way split `ResumeDataDirectReader.setfield` makes over
+/// `cpu.bh_setfield_gc_{r,f,i}`.
+///
+/// Returns `false` when the store cannot be applied: a target or value whose
+/// concrete this walk never learned, or a value whose bank disagrees with the
+/// field's. A recorded write whose heap half did not happen would leave the
+/// bridge reading state the interpreter does not hold, so the caller must fail
+/// the whole entry rather than carry on.
+fn apply_setfield(
+    ctx: &crate::TraceCtx,
+    cache: &BridgeVirtualCache<'_>,
+    allocator: &dyn crate::resume::BlackholeAllocator,
+    struct_op: OpRef,
+    value_op: OpRef,
+    info: &majit_ir::FieldDescrInfo,
+) -> bool {
+    use majit_ir::Value;
+    let Some(Value::Ref(target)) = operand_concrete(ctx, cache, struct_op) else {
+        return false;
+    };
+    let Some(value) = operand_concrete(ctx, cache, value_op) else {
+        return false;
+    };
+    let target = target.as_usize() as i64;
+    match (info.field_type, value) {
+        (majit_ir::Type::Ref, Value::Ref(r)) => {
+            allocator.bh_setfield_gc_r(target, r.as_usize() as i64, info)
+        }
+        (majit_ir::Type::Float, Value::Float(f)) => {
+            allocator.bh_setfield_gc_f(target, f.to_bits() as i64, info)
+        }
+        (majit_ir::Type::Int, Value::Int(i)) => allocator.bh_setfield_gc_i(target, i, info),
+        _ => return false,
+    }
+    true
+}
+
 pub fn materialize_bridge_virtual(
     ctx: &mut crate::TraceCtx,
     vidx: usize,
     rd_virtuals: Option<&[std::rc::Rc<majit_ir::RdVirtualInfo>]>,
     resume_data: &crate::jit_state::ResumeDataResult,
-    cache: &mut BridgeVirtualCache,
+    cache: &mut BridgeVirtualCache<'_>,
 ) -> OpRef {
     use majit_ir::OpCode;
     use majit_ir::resumedata::{TAG_CONST_OFFSET, TAGBOX, TAGCONST, TAGINT, TAGVIRTUAL, untag};
@@ -292,8 +412,8 @@ pub fn materialize_bridge_virtual(
         parent_descr: majit_ir::DescrRef,
         rd_virtuals: Option<&[std::rc::Rc<majit_ir::RdVirtualInfo>]>,
         resume_data: &crate::jit_state::ResumeDataResult,
-        cache: &mut BridgeVirtualCache,
-    ) {
+        cache: &mut BridgeVirtualCache<'_>,
+    ) -> bool {
         // resume.py setfields — range(len(fielddescrs)), index
         // fieldnums[i]. The len-equality assert (resume.py:606) is in
         // debug_prints, not this allocate path: a short fieldnums raises
@@ -306,6 +426,13 @@ pub fn materialize_bridge_virtual(
             }
             let value = decode_fieldnum(ctx, fnum, rd_virtuals, resume_data, cache);
             if value.is_none() {
+                // The recording reader can leave a field it could not decode to
+                // whatever the allocation already holds; the applying one
+                // cannot, because that field is the heap the bridge resumes
+                // against.
+                if cache.allocator().is_some() {
+                    return false;
+                }
                 continue;
             }
             // resume.py self.setfields → decoder.setfield(struct,
@@ -323,6 +450,11 @@ pub fn materialize_bridge_virtual(
             ctx.profiler()
                 .count_ops(OpCode::SetfieldGc, crate::counters::RECORDED_OPS);
             ctx.record_op_with_descr(OpCode::SetfieldGc, &[struct_op, value], field_descr.clone());
+            if let Some(allocator) = cache.allocator()
+                && !apply_setfield(ctx, cache, allocator, struct_op, value, fd_info)
+            {
+                return false;
+            }
             // Bridge virtual rematerialisation — `upd.setfield(valuebox)`
             // parity: cache stores the Box identity (`value` OpRef).
             // Cache-hit readers resolve the intrinsic value via
@@ -335,6 +467,18 @@ pub fn materialize_bridge_virtual(
             // return `None` so the downstream sanity check skips.
             ctx.heapcache_setfield_cached(struct_op, fd_info.index, value);
         }
+        true
+    }
+
+    // Only `VStructInfo` has its applying twin wired here (`bh_new` plus the
+    // `setfields` stores). Recording a NEW the heap does not hold would give
+    // the trace an identity the interpreter cannot resume against, so the
+    // applying reader declines every other kind instead. The recording reader
+    // is unaffected: a direct reader has already allocated for it.
+    if cache.allocator().is_some()
+        && !matches!(entry.as_ref(), majit_ir::RdVirtualInfo::VStructInfo { .. })
+    {
+        return OpRef::NONE;
     }
 
     match entry.as_ref() {
@@ -358,7 +502,7 @@ pub fn materialize_bridge_virtual(
             // resume.py decoder.virtuals_cache.set_ptr(index, struct)
             cache.set_ptr(vidx, new_op);
             // resume.py self.setfields(decoder, struct)
-            setfields(
+            if !setfields(
                 ctx,
                 new_op,
                 fielddescrs,
@@ -367,7 +511,9 @@ pub fn materialize_bridge_virtual(
                 rd_virtuals,
                 resume_data,
                 cache,
-            );
+            ) {
+                return OpRef::NONE;
+            }
             if crate::majit_log_enabled() {
                 eprintln!(
                     "[jit][bridge-virtual] vidx={} VirtualInfo → OpRef::from_raw({})",
@@ -393,10 +539,23 @@ pub fn materialize_bridge_virtual(
                 .count_ops(OpCode::New, crate::counters::RECORDED_OPS);
             let new_op = ctx.record_op_with_descr(OpCode::New, &[], struct_descr.clone());
             ctx.heap_cache_mut().new_object(new_op);
+            // resume.py `allocate_struct` is `metainterp.execute_new(typedescr)`
+            // for the box reader and `cpu.bh_new(typedescr)` for the direct one:
+            // both allocate, and only the first also records. Stamping the
+            // concrete onto the recorded OpRef is what makes the object the
+            // trace names and the object the interpreter resumes against the
+            // same one.
+            if let Some(allocator) = cache.allocator() {
+                let ptr = allocator.bh_new(&struct_descr);
+                if ptr == 0 {
+                    return OpRef::NONE;
+                }
+                ctx.set_opref_concrete(new_op, majit_ir::Value::Ref(majit_ir::GcRef(ptr as usize)));
+            }
             // resume.py decoder.virtuals_cache.set_ptr(index, struct)
             cache.set_ptr(vidx, new_op);
             // resume.py self.setfields(decoder, struct)
-            setfields(
+            if !setfields(
                 ctx,
                 new_op,
                 fielddescrs,
@@ -405,7 +564,9 @@ pub fn materialize_bridge_virtual(
                 rd_virtuals,
                 resume_data,
                 cache,
-            );
+            ) {
+                return OpRef::NONE;
+            }
             if crate::majit_log_enabled() {
                 eprintln!(
                     "[jit][bridge-virtual] vidx={} VStructInfo → OpRef::from_raw({})",
@@ -875,7 +1036,7 @@ pub fn rebuilt_value_to_opref(
     v: &majit_ir::resumedata::RebuiltValue,
     rd_virtuals: Option<&[std::rc::Rc<majit_ir::RdVirtualInfo>]>,
     resume_data: &crate::jit_state::ResumeDataResult,
-    cache: &mut BridgeVirtualCache,
+    cache: &mut BridgeVirtualCache<'_>,
 ) -> OpRef {
     use majit_ir::resumedata::RebuiltValue;
     match v {
@@ -902,7 +1063,8 @@ pub fn emit_pending_field_op(
     value_op: OpRef,
     item_index: i32,
     descr: &majit_ir::DescrRef,
-) {
+    cache: &BridgeVirtualCache<'_>,
+) -> bool {
     use majit_ir::OpCode;
     if item_index < 0 {
         // resume.py `_prepare_pendingfields` replays through
@@ -912,8 +1074,28 @@ pub fn emit_pending_field_op(
         ctx.profiler()
             .count_ops(OpCode::SetfieldGc, crate::counters::RECORDED_OPS);
         ctx.record_op_with_descr(OpCode::SetfieldGc, &[target_op, value_op], descr.clone());
+        if let Some(allocator) = cache.allocator() {
+            let Some(fd) = descr.as_field_descr() else {
+                return false;
+            };
+            let info = majit_ir::FieldDescrInfo {
+                index: descr.index(),
+                offset: fd.offset(),
+                field_type: fd.field_type(),
+                field_size: fd.field_size(),
+            };
+            if !apply_setfield(ctx, cache, allocator, target_op, value_op, &info) {
+                return false;
+            }
+        }
         ctx.heapcache_setfield_cached(target_op, descr.index(), value_op);
     } else {
+        // No applying twin is wired for the array element form, so a reader
+        // that must apply declines rather than record a write the heap will
+        // not have.
+        if cache.allocator().is_some() {
+            return false;
+        }
         let index_op = ctx.const_int(item_index as i64);
         ctx.profiler()
             .count_ops(OpCode::SetarrayitemGc, crate::counters::OPS);
@@ -926,6 +1108,7 @@ pub fn emit_pending_field_op(
         );
         ctx.heapcache_setarrayitem(target_op, index_op, descr.index(), value_op);
     }
+    true
 }
 
 /// resume.py `_prepare_pendingfields` (box-reader flavour): replay the
@@ -938,14 +1121,14 @@ pub fn replay_pending_fields(
     ctx: &mut crate::TraceCtx,
     resume_data: &crate::jit_state::ResumeDataResult,
     rd_virtuals: Option<&[std::rc::Rc<majit_ir::RdVirtualInfo>]>,
-    cache: &mut BridgeVirtualCache,
-) {
+    cache: &mut BridgeVirtualCache<'_>,
+) -> bool {
     let __diag = std::env::var_os("MAJIT_BRIDGE_DIAG").is_some();
     let Some(storage) = resume_data.storage.as_ref() else {
         if __diag {
             eprintln!("[replay] storage=None (no pendingfields replayed)");
         }
-        return;
+        return true;
     };
     if __diag {
         eprintln!(
@@ -963,6 +1146,9 @@ pub fn replay_pending_fields(
                     "[replay]   pending item_index={} descr=None SKIP",
                     pending.item_index
                 );
+            }
+            if cache.allocator().is_some() {
+                return false;
             }
             continue;
         };
@@ -1003,6 +1189,9 @@ pub fn replay_pending_fields(
                     value_op.is_none()
                 );
             }
+            if cache.allocator().is_some() {
+                return false;
+            }
             continue;
         }
         if __diag {
@@ -1012,8 +1201,11 @@ pub fn replay_pending_fields(
                 value_op.raw()
             );
         }
-        emit_pending_field_op(ctx, target_op, value_op, pending.item_index, descr);
+        if !emit_pending_field_op(ctx, target_op, value_op, pending.item_index, descr, cache) {
+            return false;
+        }
     }
+    true
 }
 
 /// `pyjitpl.py rebuild_state_after_failure`:
@@ -1043,7 +1235,7 @@ pub fn seed_bridge_virtualizable_boxes(
     info: &crate::virtualizable::VirtualizableInfo,
     rd_virtuals: Option<&[std::rc::Rc<majit_ir::RdVirtualInfo>]>,
     resume_data: &crate::jit_state::ResumeDataResult,
-    cache: &mut BridgeVirtualCache,
+    cache: &mut BridgeVirtualCache<'_>,
     fail_values: &[i64],
 ) -> bool {
     use majit_ir::resumedata::RebuiltValue;

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -719,6 +719,14 @@ pub struct TraceCtx {
     /// `descr_arc.is_guard_exc()` and read by static bridge setup/walkers
     /// that only receive `TraceCtx`.
     pub(crate) bridge_source_is_exception_guard: bool,
+    /// Set when a bridge-entry resume replay ran as the applying reader and
+    /// met a write it could not apply. The trace then holds recorded writes
+    /// whose heap half did not happen, so the entry that asked for that reader
+    /// must decline rather than resume against a heap it half-described.
+    ///
+    /// Only `resume.py`'s box reader can raise it: the recording-only walk has
+    /// nothing to apply and leaves it false.
+    pub(crate) bridge_replay_incomplete: bool,
 }
 
 /// A decoded-but-not-yet-built description of one inlined
@@ -1767,6 +1775,7 @@ impl TraceCtx {
             bridge_inline_carrier: None,
             bridge_reg_indices: None,
             bridge_source_is_exception_guard: false,
+            bridge_replay_incomplete: false,
         }
     }
 
@@ -1863,6 +1872,7 @@ impl TraceCtx {
             bridge_inline_carrier: None,
             bridge_reg_indices: None,
             bridge_source_is_exception_guard: false,
+            bridge_replay_incomplete: false,
         }
     }
 
@@ -2049,6 +2059,18 @@ impl TraceCtx {
     /// wrapping the same producer `Rc`.
     pub fn operand_for(&self, opref: OpRef) -> majit_ir::operand::Operand {
         self.recorder.box_for_operand(opref)
+    }
+
+    /// Report that the applying half of the bridge-entry replay could not
+    /// finish. See [`TraceCtx::bridge_replay_incomplete`].
+    pub fn mark_bridge_replay_incomplete(&mut self) {
+        self.bridge_replay_incomplete = true;
+    }
+
+    /// Whether [`TraceCtx::mark_bridge_replay_incomplete`] fired for this
+    /// bridge entry.
+    pub fn bridge_replay_incomplete(&self) -> bool {
+        self.bridge_replay_incomplete
     }
 
     pub fn box_value(&self, opref: OpRef) -> Option<Value> {

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -2807,6 +2807,29 @@ impl TraceCtx {
     /// identity untouched. No-op when the heap pointer, `virtualizable_info`,
     /// or `virtualizable_values` is unavailable.
     pub fn synchronize_virtualizable(&self) {
+        self.write_virtualizable_back(true);
+    }
+
+    /// The same write at the one moment the carve-out below does not apply:
+    /// `pyjitpl.py rebuild_state_after_failure`'s closing
+    /// `self.synchronize_virtualizable()`.
+    ///
+    /// A guard has just failed out of compiled code and nothing has run the
+    /// outer executor since, so the resume stream is the only description of
+    /// the virtualizable that exists and every field is this write's to make —
+    /// including the arrays an executor would otherwise own. A frontend whose
+    /// own guard-failure recovery already performed it does not reach here;
+    /// `JitState::SYNCHRONIZES_VIRTUALIZABLE_AFTER_GUARD_FAILURE` is how it
+    /// says so.
+    pub fn synchronize_virtualizable_after_guard_failure(&self) {
+        self.write_virtualizable_back(false);
+    }
+
+    /// `virtualizable.py write_boxes` over the whole shadow.
+    ///
+    /// `skip_outer_owned_arrays` is the tracing-time carve-out described at
+    /// its own test below; the guard-failure caller clears it.
+    fn write_virtualizable_back(&self, skip_outer_owned_arrays: bool) {
         let Some(heap_ptr) = self.virtualizable_heap_ptr else {
             return;
         };
@@ -2848,12 +2871,14 @@ impl TraceCtx {
         // clobber the outer executor's writes. The heap is authoritative, so
         // skip the write-back during tracing — the resume path performs its
         // own field-aware flush on guard failure.
-        if info.array_fields.iter().any(|a| {
-            matches!(
-                a.storage,
-                crate::virtualizable::VableArrayStorage::RustVec { .. }
-            )
-        }) {
+        if skip_outer_owned_arrays
+            && info.array_fields.iter().any(|a| {
+                matches!(
+                    a.storage,
+                    crate::virtualizable::VableArrayStorage::RustVec { .. }
+                )
+            })
+        {
             return;
         }
         // Safety: `heap_ptr` is cached at trace/bridge entry from

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -10162,6 +10162,14 @@ impl JitState for PyreJitState {
     type Sym = PyreSym;
     type Env = PyreEnv;
 
+    /// `sync_virtualizable_after_guard_failure` has already run by the time
+    /// bridge setup is reached: guard-failure recovery selects it through
+    /// `ResumeVableMode::GuardFailureSync`, and it writes each slot through
+    /// `value_to_static_vable_bits` / `value_to_vable_array_item_bits`, which
+    /// box an unwrapped `Value::Int` / `Value::Float` back into an object
+    /// before it lands in a slot the frame reads as one.
+    const SYNCHRONIZES_VIRTUALIZABLE_AFTER_GUARD_FAILURE: bool = true;
+
     fn build_meta(&self, _header_pc: usize, _env: &Self::Env) -> Self::Meta {
         let num_locals = self.local_count();
         let vsd = self.valuestackdepth();

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -8141,7 +8141,7 @@ fn overlay_stream_ref_slots(
     fail_values: &[i64],
     fail_types: &[Type],
     backend: &dyn majit_backend::Backend,
-    cache: &mut BridgeVirtualCache,
+    cache: &mut BridgeVirtualCache<'_>,
 ) {
     for &(pos, slot) in stream_slots {
         let (box_ref, value) = bridge_decode_box(
@@ -8191,7 +8191,7 @@ fn reconstruct_inline_recipe(
     fail_values: &[i64],
     fail_types: &[Type],
     backend: &dyn majit_backend::Backend,
-    cache: &mut BridgeVirtualCache,
+    cache: &mut BridgeVirtualCache<'_>,
     in_a_call: bool,
     pending_ref_array_writes: &[PendingRefArrayWrite],
 ) -> Option<ReconstructRecipe> {
@@ -8908,7 +8908,7 @@ fn bridge_decode_box(
     fail_values: &[i64],
     fail_types: &[Type],
     backend: &dyn majit_backend::Backend,
-    cache: &mut BridgeVirtualCache,
+    cache: &mut BridgeVirtualCache<'_>,
 ) -> (OpRef, majit_ir::Value) {
     use majit_ir::resumedata::RebuiltValue;
     let callinfocollection = ctx.callinfocollection.clone();
@@ -8985,7 +8985,7 @@ fn prepare_bridge_pending_fields(
     fail_values: &[i64],
     fail_types: &[Type],
     backend: &dyn majit_backend::Backend,
-    cache: &mut BridgeVirtualCache,
+    cache: &mut BridgeVirtualCache<'_>,
 ) -> Vec<PendingRefArrayWrite> {
     let mut pending_ref_array_writes = Vec::new();
     let Some(storage) = resume_data.storage.as_ref() else {
@@ -9154,12 +9154,16 @@ fn prepare_bridge_pending_fields(
             // asserts only the fieldbox is virtual), so the bridge-body read hits
             // the plain get heapcache path with no on-hit sanity load, and the
             // replayed store runs at bridge entry before any body op.
+            // The direct reader that preceded this entry applied these writes
+            // already, so this cache is the recording-only one and the call
+            // records without storing.
             majit_metainterp::emit_pending_field_op(
                 ctx,
                 target_op,
                 value_op,
                 pending.item_index,
                 descr,
+                cache,
             );
         }
     }
@@ -9178,7 +9182,7 @@ fn decode_tagged_concrete(
     storage: Option<&std::sync::Arc<majit_metainterp::resume::ResumeStorage>>,
     backend: &dyn majit_backend::Backend,
     callinfocollection: Option<&std::sync::Arc<majit_ir::CallInfoCollection>>,
-    cache: &mut BridgeVirtualCache,
+    cache: &mut BridgeVirtualCache<'_>,
 ) -> i64 {
     use majit_ir::resumedata::{
         NULLREF, TAG_CONST_OFFSET, TAGBOX, TAGCONST, TAGINT, TAGVIRTUAL, UNINITIALIZED_TAG, untag,
@@ -9295,7 +9299,7 @@ fn decode_tagged_for_kind(
     storage: Option<&std::sync::Arc<majit_metainterp::resume::ResumeStorage>>,
     backend: &dyn majit_backend::Backend,
     callinfocollection: Option<&std::sync::Arc<majit_ir::CallInfoCollection>>,
-    cache: &mut BridgeVirtualCache,
+    cache: &mut BridgeVirtualCache<'_>,
 ) -> i64 {
     decode_tagged_concrete(
         tagged,
@@ -9320,7 +9324,7 @@ fn setfield_concrete_from_tagged(
     num_failargs: i32,
     storage: Option<&std::sync::Arc<majit_metainterp::resume::ResumeStorage>>,
     callinfocollection: Option<&std::sync::Arc<majit_ir::CallInfoCollection>>,
-    cache: &mut BridgeVirtualCache,
+    cache: &mut BridgeVirtualCache<'_>,
 ) {
     let descr = bh_field_descr_from_info(fd);
     match fd.field_type {
@@ -9381,7 +9385,7 @@ fn setarrayitem_concrete_from_tagged(
     num_failargs: i32,
     storage: Option<&std::sync::Arc<majit_metainterp::resume::ResumeStorage>>,
     callinfocollection: Option<&std::sync::Arc<majit_ir::CallInfoCollection>>,
-    cache: &mut BridgeVirtualCache,
+    cache: &mut BridgeVirtualCache<'_>,
 ) {
     if arraydescr.is_array_of_pointers() {
         let value = decode_tagged_for_kind(
@@ -9449,7 +9453,7 @@ fn setinteriorfield_concrete_from_tagged(
     num_failargs: i32,
     storage: Option<&std::sync::Arc<majit_metainterp::resume::ResumeStorage>>,
     callinfocollection: Option<&std::sync::Arc<majit_ir::CallInfoCollection>>,
-    cache: &mut BridgeVirtualCache,
+    cache: &mut BridgeVirtualCache<'_>,
 ) {
     let ifd = interior_descr
         .as_interior_field_descr()
@@ -9549,7 +9553,7 @@ fn materialize_concrete_virtual_ptr(
     storage: Option<&std::sync::Arc<majit_metainterp::resume::ResumeStorage>>,
     backend: &dyn majit_backend::Backend,
     callinfocollection: Option<&std::sync::Arc<majit_ir::CallInfoCollection>>,
-    cache: &mut BridgeVirtualCache,
+    cache: &mut BridgeVirtualCache<'_>,
 ) -> majit_ir::GcRef {
     if let Some(cached) = cache.get_concrete_ptr(vidx) {
         return cached;
@@ -9970,7 +9974,7 @@ fn materialize_concrete_virtual_int(
     storage: Option<&std::sync::Arc<majit_metainterp::resume::ResumeStorage>>,
     backend: &dyn majit_backend::Backend,
     callinfocollection: Option<&std::sync::Arc<majit_ir::CallInfoCollection>>,
-    cache: &mut BridgeVirtualCache,
+    cache: &mut BridgeVirtualCache<'_>,
 ) -> i64 {
     if let Some(cached) = cache.get_concrete_int(vidx) {
         return cached;
@@ -10441,9 +10445,22 @@ impl JitState for PyreJitState {
         rd_virtuals: Option<&[std::rc::Rc<majit_ir::RdVirtualInfo>]>,
         fail_values: &[i64],
         fail_types: &[Type],
+        executing: Option<&dyn majit_metainterp::resume::BlackholeAllocator>,
     ) {
         if resume_data.frames.is_empty() {
             return;
+        }
+        // This walk still records without applying, so it can serve an entry
+        // that asked for the applying reader only while there is nothing to
+        // apply. A guard carrying deferred heap writes has to keep going
+        // through the arm that applies them.
+        if executing.is_some()
+            && resume_data
+                .storage
+                .as_ref()
+                .is_some_and(|storage| !storage.rd_pendingfields.is_empty())
+        {
+            ctx.mark_bridge_replay_incomplete();
         }
 
         // virtualizable.py load_list_of_boxes parity: decode each
@@ -14365,6 +14382,7 @@ mod tests {
             None,
             &fail_values,
             &fail_types,
+            None,
         );
 
         assert_eq!(sym.valuestackdepth, 3);

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3590,7 +3590,18 @@ pub fn trace_and_compile_from_bridge(
     // compile.py:714: start_retrace_from_guard + set bridge_info.
     let started = {
         let (driver, _) = crate::eval::driver_pair();
-        driver.start_bridge_tracing(descr_arc, &mut jit_state, &env, raw_values, resume_pc)
+        driver.start_bridge_tracing(
+            descr_arc,
+            &mut jit_state,
+            &env,
+            raw_values,
+            resume_pc,
+            // `decode_and_restore_guard_failure` has already walked this
+            // guard's resume data applying every write — `replay_pending_fields`
+            // for the deferred stores, `ResumeVableMode::GuardFailureSync` for
+            // the virtualizable — so the replay owes recording only.
+            false,
+        )
     };
     if !started {
         if majit_metainterp::majit_log_enabled() {

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -994,6 +994,11 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
                 "abort_ceiling_banned",
                 "abort_ceiling_refused",
                 "bridge_abort_permanent",
+                "guard_resume_decline_no_state",
+                "guard_resume_decline_foreign_jitcode",
+                "guard_resume_decline_pendingfields",
+                "guard_resume_decline_regcount",
+                "guard_resume_decline_unreadable_reg",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -996,7 +996,7 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
                 "bridge_abort_permanent",
                 "guard_resume_decline_no_state",
                 "guard_resume_decline_foreign_jitcode",
-                "guard_resume_decline_pendingfields",
+                "guard_resume_decline_replay_incomplete",
                 "guard_resume_decline_regcount",
                 "guard_resume_decline_unreadable_reg",
             ];


### PR DESCRIPTION
`compile.py handle_fail` is an if/else: a guard that `must_compile()` traces a bridge from its own position, and one that does not resumes in the blackhole. majit's guard-position arm had been declining a large class of guards, silently and for reasons nothing recorded. This branch names the declines, gives the reader the half of `resume.py` it was missing, and closes one of the two parity gaps that kept the entry from serving them.

## Naming the declines

`bridge_from_guard_resume_position`'s pre-walk ladder had ten exits and no instrumentation, so every one of them fell through `AbortReason::Generic` and was tallied under `ABORT_BRIDGE`'s id together with real bridge giveups. The ladder now returns a `GuardResumeDecline`, five new `mc_diag` slots count the rungs, and the abort stages `ABORT_BRIDGE` explicitly. On the aheui corpus every aborted trace resolved to exactly one rung.

## The applying reader

`resume.py` has two readers and no third. `ResumeDataBoxReader` (tracing) allocates and stores through `metainterp.execute_new` / `execute_setfield_gc` — it applies to the heap **and** records into the trace. `ResumeDataDirectReader` (blackhole) applies only. majit had neither on this path: it recorded without applying, which is sound only because a blackhole had already run, and no blackhole runs ahead of a guard-position entry.

`BridgeVirtualCache::executing` is the applying half. `VStructInfo` allocates through the frontend's `BlackholeAllocator::bh_new` and stores through `bh_setfield_gc_{i,r,f}`; every other virtual kind and the array-element pending field decline rather than record a write the heap will not hold.

The cache now also owns a fixed-length address array registered as GC roots and unregistered in `Drop`, and fills its pointer slot before it allocates — `resume.py`'s own comment on `virtuals_cache` requires that order, because a later allocation in the same walk can collect. The reader's two `SETFIELD_GC` sites call `mark_escaped`, which `execute_setfield_gc` reaches through `_record_helper` → `invalidate_caches` and which for a store is `mark_escaped` alone.

## Filling the virtualizable

`pyjitpl.py rebuild_state_after_failure` ends by assigning `self.virtualizable_boxes` and calling `self.synchronize_virtualizable()`. majit did the first half only, so the object still held whatever the compiled loop last spilled. pyre never saw it because its own guard-failure recovery writes those fields first; a frontend without that recovery had no writer at all. `TraceCtx::synchronize_virtualizable_after_guard_failure` is that write, and `JitState::SYNCHRONIZES_VIRTUALIZABLE_AFTER_GUARD_FAILURE` is how a frontend says it already performed it.

## Measured

* `pi.jinseo` stops aborting a trace on both arms — the pair of jit-stats rows that had been red.
* logo is byte-identical to the committed output and to the no-JIT run (996310 bytes, exit 42).
* aheui: metacircular 58/58, opcensus clean, jit-stats 62 default + 62 jitstress, 0 failed.
* `cargo test -p majit-metainterp --features dynasm` green; `cargo test -p aheui-runtime -p aheui-jit` green; `cargo check -p pyre-jit-trace` green.

## Still open

The entry declines a guard whose `rd_pendingfields` is non-empty. Serving those takes `quine.puzzlet.40col [jitstress]` from 3 aborted traces and 908 guard failures to none and 708 and compiles 2 bridges where it compiles none, but a self-interpreting workload then reads one operand twice. It stops doing so when the virtualizable's banded arms are put out of reach, so something the walk resumes on is still described where this entry does not restore it — the scalars, carried by the state-field resume mechanism and disjoint from the array restore, are what is left. The comment at the rung says so.

Two things are ruled out by measurement rather than argument: the applying reader is correct — instrumenting the frontend allocator and running with the guard declining puts both readers in one process, and all 93 apply groups are op-for-op identical — and "apply, then decline, answer is right" proves nothing about the apply, because the blackhole repeats every store with its own objects.

— *authored by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved guard-resume handling by applying deferred updates during execution when possible.
  * Added clearer diagnostics for bridge declines, including incomplete replay and invalid resume state.
  * Added direct support for negated conditions in compiled control flow.

* **Bug Fixes**
  * Prevented incomplete bridge replays from being treated as successful.
  * Improved cleanup when conditional or match lowering fails.
  * Enhanced virtualizable state synchronization after guard failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->