### PR TITLE
jit-trace: close the kwonly-defaults cell-read race and pin the slot with its quasi-immutable marker; object: intern the module-dict key wrappers

### DIFF
--- a/pyre/bench/synth/kwdefaults_invalidation.py
+++ b/pyre/bench/synth/kwdefaults_invalidation.py
@@ -1,17 +1,17 @@
 # pyre-check: selfcheck
-# pyre-check: selfcheck-compiles=hot
+# pyre-check: selfcheck-compiles=hot,missing_window
 # pyre-check: spec-folds=kwonly_defaults_inline
 # Self-checking guard for the pins under an inlined callee's keyword-only
 # defaults.
 #
 # Seeding those locals no longer probes `__kwdefaults__` per call.  The mapping
 # a definition builds carries a version, so the walker bakes each entry's cell,
-# records a quasi-immutable marker on `Function.w_kw_defs` and one on the
-# mapping's strategy version, drains both with a single `GuardNotInvalidated`,
-# and reads the cell's field live.  Three separate mechanisms therefore stand
-# between a mutation and the next call, and a census can only say the fold
-# fired -- not that the pins are honest.  Each site below moves one of them and
-# prints a wrong number if that one is missing.
+# pins `Function.w_kw_defs` with a `GuardValue`, records a quasi-immutable
+# marker on the mapping's strategy version, drains that marker with a
+# `GuardNotInvalidated`, and reads the cell's field live.  Three separate
+# mechanisms therefore stand between a mutation and the next call, and a census
+# can only say the fold fired -- not that the pins are honest.  Each site below
+# moves one of them and prints a wrong number if that one is missing.
 #
 # Sites:
 #   A  overwrite an existing entry in place.  A cell that already holds an
@@ -22,7 +22,7 @@
 #      the deleted window is observable on its own -- the call must raise
 #      rather than seed a stale default.
 #   C  rebind the attribute.  `f.__kwdefaults__ = d` stores `d` itself, so only
-#      the `Function.w_kw_defs` marker can catch this; the version marker is
+#      the `Function.w_kw_defs` guard can catch this; the version marker is
 #      still watching the old mapping, which no longer answers anything.
 #   D  keep calling after that rebind.  A plain dict has no version to pin, so
 #      the resolve declines and the callee seeds through the ordinary path --
@@ -32,6 +32,23 @@ N = 20000
 
 def g(x, *, step=1, tag="a"):
     return x + step, tag
+
+
+def missing_window(n):
+    """Site B's deleted window, in a loop of its own so it compiles too.
+
+    Left inside `main` this ran interpreted no matter what the header
+    declared -- `selfcheck-compiles` names code objects, and `main` is not
+    one of them -- so the one site that asks a compiled trace to REFUSE a
+    baked default was the one site no compiled trace ever saw.
+    """
+    missing = 0
+    for i in range(n):
+        try:
+            g(i)
+        except TypeError:
+            missing += 1
+    return missing
 
 
 def hot(n, want_step, want_tag):
@@ -58,12 +75,7 @@ def main():
         return 1
 
     del g.__kwdefaults__["tag"]
-    missing = 0
-    for i in range(N):
-        try:
-            g(i)
-        except TypeError:
-            missing += 1
+    missing = missing_window(N)
     if missing != N:
         print(f"FAIL site B seeded a deleted default on {N - missing} of {N} calls")
         return 1

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -5417,28 +5417,43 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         // Taken off `callable_guard_op`, which the resolve proved names
         // `callable`.
         //
-        // `function.py` DOES declare `w_kw_defs?`, and `function_set_kwdefaults`
-        // already notifies `QuasiImmutSlot::WKwDefs`, so the orthodox pin is the
-        // quasi-immutable marker `defs_w` installs a few lines up rather than a
-        // guard.  It is not a drop-in here: that install dereferences
-        // `callable_guard_op`, which is why `defs_w` gates it on
-        // `guards_the_callee_function`, and the callee this fold is for is the
-        // baked module-level one.  Settling that case is what the swap waits on.
+        // `function.py` declares `w_kw_defs?`, and every writer of the slot
+        // funnels through `function_set_kwdefaults` -- `fset_func_kwdefaults`,
+        // `fdel_func_kwdefaults` and the definition path all reach it -- which
+        // notifies `QuasiImmutSlot::WKwDefs`.  The orthodox pin is therefore
+        // the marker, and it costs nothing to flush: the guard below drains
+        // every marker recorded this epoch, and one is going out for the
+        // mapping version regardless.
         //
-        // A `GuardValue` on the slot stands in meanwhile.  It is stricter than
-        // the hint -- a per-call read where upstream pays none -- and sound for
-        // the reason the marker would be: the cells baked below belong to one
-        // mapping, and only pinning the slot that holds it makes that true on
-        // every later execution.  A `f.__kwdefaults__ = {...}` rebind fails the
-        // guard, and so does a callee defined inside the loop, whose next
-        // iteration builds a mapping of its own.
-        walker_guard_function_field(
-            ctx,
-            op.pc,
-            callable_guard_op,
-            crate::descr::function_w_kw_defs_descr(),
-            resolved.mapping as i64,
-        )?;
+        // Available on a constant callable for the reason
+        // `walker_pin_function_code` gives: a marker resolves its owner by raw
+        // address at record and compile time, so it never loads through the
+        // baked `ConstPtr` the guard arm must stay off.  What being constant
+        // adds is the part a marker needs and cannot check for itself -- one
+        // object on every execution, which is what makes watching that object's
+        // slot answer for all of them.  The caller has already refused a callee
+        // the collector can relocate on this arm, so both reads find it where
+        // the constant says it is.
+        //
+        // Off a live operand the callee's identity is not fixed -- two closures
+        // minted from one `def` both satisfy the class-and-code test -- so the
+        // slot is re-read per execution and the `GuardValue` stays.  It is
+        // stricter than the hint and sound for the reason the marker is: the
+        // cells baked below belong to one mapping, and only pinning the slot
+        // that holds it makes that true on every later execution.
+        let kw_defs_descr = crate::descr::function_w_kw_defs_descr();
+        if callable_guard_op.is_constant() {
+            let callable_const = ctx.trace_ctx.const_ref(callable as i64);
+            crate::state::record_quasiimmut_field(ctx.trace_ctx, callable_const, kw_defs_descr);
+        } else {
+            walker_guard_function_field(
+                ctx,
+                op.pc,
+                callable_guard_op,
+                kw_defs_descr,
+                resolved.mapping as i64,
+            )?;
+        }
         // `walker_pin_namespace_version`'s body, opened up: the resolve already
         // read the strategy box and proved it immovable, and there is no way
         // back from here to act on the `Ok(false)` the wrapper would return.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -127,6 +127,9 @@ unsafe fn positional_defaults_for_inline(
 /// One keyword-only parameter's binding: the namespace slot's stored
 /// value-or-cell, and the value that unwraps to.
 struct KwonlyDefaultInline {
+    /// Where the entry sits in the mapping, kept so the emit can read it
+    /// again once the version marker is installed.
+    slot: usize,
     stored: pyre_object::PyObjectRef,
     value: pyre_object::PyObjectRef,
 }
@@ -207,7 +210,11 @@ unsafe fn kwonly_defaults_for_inline(
         if value.is_null() {
             return None;
         }
-        out.push(KwonlyDefaultInline { stored, value });
+        out.push(KwonlyDefaultInline {
+            slot: cell_slot,
+            stored,
+            value,
+        });
     }
     Some(KwonlyDefaultsInline {
         mapping: dict,
@@ -5445,6 +5452,16 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         // this epoch was invalidated, not which.
         walker_flush_guard_not_invalidated(ctx, op.pc)?;
         for (offset, kwonly) in resolved.values.into_iter().enumerate() {
+            // The resolve read this cell before the markers above stood, so a
+            // store from another thread in between bumped a version nothing
+            // was watching and owes no invalidation for it.  Ask the mapping
+            // again now that the watcher is installed: agreeing means the
+            // markers answer for what is about to be baked.
+            if crate::state::module_dict_cell_value_direct(resolved.mapping, kwonly.slot)
+                != Some(kwonly.stored)
+            {
+                return Err(DispatchError::KwonlyDefaultsMappingRacedRecord { pc: op.pc });
+            }
             let (value_op, _) = emit_namespace_cell_value(ctx, op.pc, kwonly.stored)?;
             callee_args[nparams + offset] = value_op;
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2495,6 +2495,18 @@ pub enum DispatchError {
     /// walker surfaces it as a typed abort that the production driver
     /// maps to `TraceAction::Abort` (recoverable — may retry later).
     AbortMarkerReached { pc: usize },
+    /// An inlined callee's keyword-only default mapping moved between the
+    /// record-time resolve and the marker that watches it.
+    /// `kwonly_defaults_for_inline` reads each entry's cell up front, and the
+    /// emit installs `record_quasiimmut_field` on the strategy version only
+    /// once the inline is committed to; a store from another thread in that
+    /// window bumps a version no watcher is registered against yet, so the
+    /// seeding would bake the pre-store cell and never be told.  The emit is
+    /// past the point it can decline from -- the guards for this inline are
+    /// already recorded -- so the walk gives the trace up instead.  The
+    /// sibling `emit_namespace_cell_fold` answers the same window with a
+    /// plain decline, which is why only this site needs a class of its own.
+    KwonlyDefaultsMappingRacedRecord { pc: usize },
     /// Record-time construction of a concrete shadow object failed after the
     /// specialization had emitted IR. Falling through to the generic residual
     /// would retain that partial prologue, so abort the whole walk.
@@ -2759,6 +2771,7 @@ impl DispatchError {
             Self::VableArrayIndexOutOfRange { .. } => "VableArrayIndexOutOfRange",
             Self::VableArrayIndexNotConcrete { .. } => "VableArrayIndexNotConcrete",
             Self::AbortMarkerReached { .. } => "AbortMarkerReached",
+            Self::KwonlyDefaultsMappingRacedRecord { .. } => "KwonlyDefaultsMappingRacedRecord",
             Self::ConcreteShadowAllocationFailed { .. } => "ConcreteShadowAllocationFailed",
             Self::AbortPermanentMarkerReached { .. } => "AbortPermanentMarkerReached",
             Self::MayForceNullRefArgUnsupported { .. } => "MayForceNullRefArgUnsupported",
@@ -2845,6 +2858,7 @@ impl DispatchError {
             | Self::AbortMarkerReached { pc, .. }
             | Self::ConcreteShadowAllocationFailed { pc, .. }
             | Self::AbortPermanentMarkerReached { pc, .. }
+            | Self::KwonlyDefaultsMappingRacedRecord { pc, .. }
             | Self::MayForceNullRefArgUnsupported { pc, .. }
             | Self::VableEscapedDuringResidualCall { pc, .. }
             | Self::GuardSnapshotVableUntyped { pc, .. }
@@ -9593,6 +9607,16 @@ fn emit_namespace_cell_fold<Sym: WalkSym>(
         return Ok(false);
     }
     if !walker_pin_namespace_version(ctx, op_pc, ns)? {
+        return Ok(false);
+    }
+    // The caller read `stored` before the marker above was installed, so a
+    // store from another thread in that window moved the entry while nothing
+    // was watching the version it bumped, and the constant baked below would
+    // be the cell from before it -- for the rest of the loop's life, since no
+    // invalidation is owed for a bump that predates its watcher.  Re-read now
+    // that the watcher stands and decline when the two disagree; single
+    // threaded there is no interval and this always agrees.
+    if crate::state::module_dict_cell_value_direct(ns, slot) != Some(stored) {
         return Ok(false);
     }
     let (result_opref, _) = emit_namespace_cell_value(ctx, op_pc, stored)?;

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -32,7 +32,6 @@
 #![allow(dead_code)]
 
 use crate::pyobject::*;
-use crate::w_str_new;
 
 // ── MutableCell family ──────────────────────────────────────────────
 //
@@ -427,9 +426,19 @@ impl VersionTag {
 /// ```
 ///
 /// Wraps a Rust `&str` key as a Python `str` PyObjectRef.
+///
+/// The canonical object for the characters, not a fresh one.  This storage
+/// half keeps names as Rust strings, so the key object user code sees is
+/// rebuilt on every read, and building it is what two separate defects came
+/// from: `next(iter(d)) is next(iter(d))` answered false where both CPython
+/// and PyPy answer true, and `w_str_new` allocates the immortal flavour, so
+/// nothing reclaimed the copies -- measured over `globals()`, 118 bytes per
+/// key read, 2.1 GB across a 1.2M-iteration walk that a plain dict serves in
+/// a flat 60 MB.  Interning answers both: the table hands back one object per
+/// value, and `intern_wtf8_value` builds nothing on a hit.
 #[inline]
 pub fn _wrapkey(key: &str) -> PyObjectRef {
-    w_str_new(key)
+    crate::intern_str_value(key)
 }
 
 /// Strategy-owned storage for `ModuleDictStrategy`.
@@ -1261,7 +1270,7 @@ impl crate::dictmultiobject::DictStrategy for ModuleDictStrategy {
         let (key, cell) = storage.entries.pop()?;
         strategy.mutated();
         crate::dictmultiobject::w_dict_bump_keys_version(w_dict);
-        Some((crate::w_str_new(&key), unwrap_cell(cell)))
+        Some((_wrapkey(&key), unwrap_cell(cell)))
     }
 
     /// `celldict.py getiterreversed` — reverse iteration
@@ -1280,7 +1289,7 @@ impl crate::dictmultiobject::DictStrategy for ModuleDictStrategy {
             .entries
             .iter()
             .rev()
-            .map(|(k, &cell)| (crate::w_str_new(k), unwrap_cell(cell)))
+            .map(|(k, &cell)| (_wrapkey(k), unwrap_cell(cell)))
             .collect()
     }
 
@@ -1306,7 +1315,7 @@ impl crate::dictmultiobject::DictStrategy for ModuleDictStrategy {
         let storage = &*module.dstorage;
         for (key, &cell) in storage.entries.iter() {
             let unwrapped = unwrap_cell(cell);
-            let key_obj = crate::w_str_new(key);
+            let key_obj = _wrapkey(key);
             crate::dictmultiobject::w_dict_store(new_dict, key_obj, unwrapped);
         }
         new_dict

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -5304,14 +5304,15 @@ pub unsafe fn w_module_dict_items_inner(obj: PyObjectRef) -> Vec<(PyObjectRef, P
     } else {
         let strategy = &*w_module_dict_get_strategy(obj);
         let storage = &*w_module_dict_get_storage(obj);
-        // Wrapping a name allocates, so a value zipped in before a later wrap
-        // would be pre-move in the Rust-heap result.  Wrap every name into a
-        // root slot first, then walk the values — which the cell storage keeps
-        // traced — with no allocation left to run.
+        // Wrapping a name the intern table has not seen allocates, so a value
+        // zipped in before a later wrap would be pre-move in the Rust-heap
+        // result.  Wrap every name into a root slot first, then walk the
+        // values — which the cell storage keeps traced — with no allocation
+        // left to run.
         let roots = crate::gc_roots::push_roots();
         let keys_base = roots.base();
         for k in strategy.getiterkeys(storage) {
-            let _ = roots.pin_root(crate::w_str_new(k));
+            let _ = roots.pin_root(crate::celldict::_wrapkey(k));
         }
         strategy
             .getitervalues(storage)
@@ -5332,12 +5333,13 @@ pub unsafe fn w_module_dict_items_inner(obj: PyObjectRef) -> Vec<(PyObjectRef, P
 /// cannot hold a live iterator ([`DictStrategy::nth_item`]).  Serving that
 /// cursor from the default `nth_item` — `self.items(w_dict).into_iter()
 /// .nth(index)` — makes the stand-in quadratic: [`w_module_dict_items_inner`]
-/// wraps EVERY name with [`crate::w_str_new`], so an `n`-entry dict costs `n`
-/// wraps per step.  Those strings are also the immortal flavour (`w_str_new`
-/// allocates through `malloc_raw`), so nothing reclaims them: measured, a
+/// wraps EVERY name, so an `n`-entry dict costs `n` wraps per step: measured, a
 /// 350-name module dict walked ten times grew peak RSS by 156.8 MB where
 /// CPython grew none, and removing it took 10.3 MB off interpreter startup —
-/// `dir(module)` inside `importlib._bootstrap` pays this walk.
+/// `dir(module)` inside `importlib._bootstrap` pays this walk.  The wrap
+/// itself is [`crate::celldict::_wrapkey`], which interns rather than minting;
+/// what it costs on a repeat is a table hit, and the per-step count is still
+/// what this cursor exists to hold at one.
 ///
 /// # Safety
 /// `obj` must point to a valid `W_ModuleDictObject`.
@@ -5355,7 +5357,7 @@ pub unsafe fn w_module_dict_nth_item_inner(
     // back afterwards — the cell storage keeps it traced.
     let roots = crate::gc_roots::push_roots();
     let key_slot = roots.base();
-    let _ = roots.pin_root(crate::w_str_new(key));
+    let _ = roots.pin_root(crate::celldict::_wrapkey(key));
     let value = strategy.nth_unwrapped_value(&*w_module_dict_get_storage(obj), index)?;
     Some((roots.get(key_slot), value))
 }


### PR DESCRIPTION
Three commits, all on the keyword-only-defaults seeding path landed in #1494
plus one interning fix underneath it.

### `object: intern the module-dict key wrappers`

The str-keyed half of `W_ModuleDictObject` stores names as Rust strings, so the
`str` object a read hands back was rebuilt every time — two reads of one name
returned two objects where a plain dict returns the one it stored, and
`w_str_new` builds the immortal flavour, so nothing reclaimed the copies.

Every wrap now routes through `_wrapkey`, which calls `intern_str_value`.
`popitem`, `getiterreversed`, `copy` and the two `w_module_dict_*_inner` item
readers had their own `w_str_new` calls and now share it.

Measured over `globals()` with a key long enough to miss the interpreter's own
interning: `next(iter(d)) is next(iter(d))` answers true, and a 1.2M-iteration
walk holds **41 MB against 2152 MB**, flat in the iteration count where it had
been linear.

### `jit-trace: re-read a namespace cell once its version watcher stands`

`kwonly_defaults_for_inline` read each entry's cell *before* the fold installed
the quasi-immutable marker on the mapping's strategy version. A store landing
in that window moves the entry while nothing is watching the version it bumps,
and no invalidation is owed for a bump that predates its watcher — so the
constant baked afterwards stayed the cell from before the store for the rest of
the loop's life.

The mapping is asked again once the marker stands, and the fold declines when
the two disagree, under a `DispatchError` of its own so the decline is
attributable. Single threaded there is no interval and the two always agree.

This also fixes the fixture: `kwdefaults_invalidation.py`'s site B — the one
site that asks a *compiled* trace to refuse a baked default — ran interpreted
no matter what its header declared. `selfcheck-compiles` names code objects,
and the deleted window sat inside `main`, which is not one of them. It now
lives in a loop of its own that the header names.

### `jit-trace: pin a constant callee's kwonly defaults with the quasi-immutable marker`

`function.py` declares `w_kw_defs?`, and every writer of the slot funnels
through `function_set_kwdefaults` — `fset_func_kwdefaults`,
`fdel_func_kwdefaults` and the definition path all reach it — which notifies
`QuasiImmutSlot::WKwDefs`. So the fold's per-call `GetfieldGcR` + `GuardValue`
on the slot had a marker available in its place all along.

The comment standing where the guard was said otherwise — that installing a
marker would dereference `callable_guard_op`. That is true of the `defs_w`
install, which passes the operand, but not of `record_quasiimmut_field` itself:
`walker_pin_function_code` passes the raw address, and this same fold already
installs a marker that way for the mapping's strategy version four lines below.

The marker goes out where `callable_guard_op` is constant. A marker watches one
object by raw address and cannot re-check identity; a constant operand names
the same object on every execution, which is what makes watching that object's
slot answer for all of them, and the caller has already refused a callee the
collector can relocate on that arm. Off a live operand the identity is not
fixed — two closures minted from one `def` both satisfy the class-and-code test
— so the guard stays.

**No guard is added**: the `GuardNotInvalidated` already flushed for the mapping
version drains every marker recorded in the epoch. Verified two ways — the
fixture's site C (the `__kwdefaults__` rebind) is exactly what an inert marker
would break and still passes, and a `MAJIT_LOG=1` dump leaves `QuasiimmutField`
as the only op on the `Function.w_kw_defs` descr, with no `GuardValue` or
`GetfieldGcR` beside it.

## Gates

Three legs green at this base: dynasm 494/494, cranelift 494/494, wasm 486/486.

## Not in this PR

`TypeVar('T')` still does not inline, and the lever recorded for it — reading
`w_kw_defs` off `const_ref(callable)` rather than the guard operand, which is
what the third commit builds — is **not** what binds it. Lifting the identity
check on top of this marker moved the declines rather than removing them:
5 at the identity check became 5 at the replay-safety admission, 6 total before
and after. `TypeVar.__init__` is a 16-poison `DeferredCall` body. That
experiment was reverted as behaviour-neutral and unguarded; the wall is the
missing rewind boundary at a non-CALL entry, which is its own piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFbvNce7TD6xB2Xe2Zh3Vs
