### PR TITLE
codecs, interp, majit: the #1482 review follow-ups — a charmap handler hang, the excepthook failure report, decoder buffer shapes, and the suggestion search's units

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -2856,9 +2856,25 @@ fn handle_jitexception(
         Err(JitException::ExitFrameWithExceptionRef(exc_ref)) => exc_ref.0 as i64,
         // The bail leaves by the same exit the pre-walk refusal above takes:
         // no level absorbs it, so the chain is released and it propagates to
-        // `_run_forever`'s caller.  The terminal image belongs to the re-entered
-        // portal's own chain, which released it before reporting the bail, so
-        // there is none to publish here.
+        // `_run_forever`'s caller.
+        //
+        // Unlike that exit, this one publishes no terminal image, and `bh` is
+        // not the image to publish: it is the portal level whose callee chain
+        // stopped, so its stamp names its own CALL rather than where the chain
+        // got to.  The image that would answer belongs to the re-entered
+        // portal, and no channel carries it back -- `portal_runner` returns a
+        // result or a `JitException`, nothing else.
+        //
+        // Reaching this arm at all takes a `portal_runner`, because the only
+        // two ways `handle_jitexception_dispatch` answers with a bail are an
+        // `exc` that already was one -- refused ahead of the walk above -- and
+        // a runner that reported one for a `ContinueRunningNormally`.  Every
+        // caller that runs a program passes `None` there (`run_forever` and
+        // `convert_and_run_from_pyjitpl` both do), so today only this module's
+        // own tests supply one, and they read no terminal image.  Wiring a
+        // real runner is what makes the missing image a resume that repeats
+        // the callee's effects; `trace.rs` already logs that shape as `bail
+        // terminal is not the root frame`.
         Err(exc @ JitException::BailToInterpreter) => {
             builder.release_chain(Some(bh));
             return Err(exc);

--- a/pyre/extra_tests/snippets/charmap_decode_error_handler.py
+++ b/pyre/extra_tests/snippets/charmap_decode_error_handler.py
@@ -61,3 +61,31 @@ for _ in range(30):
 # The same through the stdlib charmap codec, whose table is a real dict.
 for _ in range(30):
     assert data.decode("iso-8859-15", "pyre.charmap.decode.churn") is not None
+
+# A handler position too large for the machine integer keeps the -1 the
+# conversion failure produced: `call_errorhandler` folds a negative position
+# against the length only on the branch where the conversion succeeded, so the
+# bounds test below it rejects this one.  Folding it would reach 0 for a
+# one-byte input and hand the same span back to the handler without end.
+def overflowing(exc):
+    return ("?", 10**100)
+
+codecs.register_error("pyre.charmap.decode.overflow", overflowing)
+try:
+    codecs.charmap_decode(b"\xdd", "pyre.charmap.decode.overflow", TABLE)
+except IndexError as error:
+    assert "position -1" in str(error), str(error)
+else:
+    raise AssertionError("an unrepresentable position should be out of bounds")
+
+# A position the conversion does read is still folded against the length.
+def negative(exc):
+    return ("?", -5)
+
+codecs.register_error("pyre.charmap.decode.negative", negative)
+try:
+    codecs.charmap_decode(b"\xdd", "pyre.charmap.decode.negative", TABLE)
+except IndexError as error:
+    assert "position -4" in str(error), str(error)
+else:
+    raise AssertionError("a position before the input should be out of bounds")

--- a/pyre/extra_tests/snippets/charmap_decode_error_handler.py
+++ b/pyre/extra_tests/snippets/charmap_decode_error_handler.py
@@ -62,17 +62,24 @@ for _ in range(30):
 for _ in range(30):
     assert data.decode("iso-8859-15", "pyre.charmap.decode.churn") is not None
 
-# A handler position too large for the machine integer keeps the -1 the
-# conversion failure produced: `call_errorhandler` folds a negative position
-# against the length only on the branch where the conversion succeeded, so the
-# bounds test below it rejects this one.  Folding it would reach 0 for a
-# one-byte input and hand the same span back to the handler without end.
+# A handler position too large for the machine integer is refused rather than
+# folded.  `call_errorhandler` folds a negative position against the length
+# only on the branch where the conversion succeeded, so the -1 the failure
+# produces reaches the bounds test unfolded and is rejected there; folding it
+# would reach 0 for a one-byte input and hand the same span back to the handler
+# without end, which is the loop this gate exists for.  The two runners refuse
+# in different words -- the conversion's own `OverflowError` is what a
+# `PyArg_ParseTuple` reading the tuple lets out, and the sentinel's
+# `IndexError` is what carrying it to the bounds test produces -- and the
+# assertion each side has to meet is that it refuses at all.
 def overflowing(exc):
     return ("?", 10**100)
 
 codecs.register_error("pyre.charmap.decode.overflow", overflowing)
 try:
     codecs.charmap_decode(b"\xdd", "pyre.charmap.decode.overflow", TABLE)
+except OverflowError:
+    pass
 except IndexError as error:
     assert "position -1" in str(error), str(error)
 else:

--- a/pyre/extra_tests/snippets/charmap_encode_error_handler.py
+++ b/pyre/extra_tests/snippets/charmap_encode_error_handler.py
@@ -121,13 +121,16 @@ else:
 assert codecs.charmap_encode("a", "strict", {97: b"x"}) == (b"x", 1)
 assert codecs.charmap_encode("a", "strict", {97: 120}) == (b"x", 1)
 
-# The encode leg reads a handler position the way the decode leg does.
+# The encode leg reads a handler position the way the decode leg does, and
+# refuses an unrepresentable one in the same two shapes.
 def overflowing(exc):
     return ("?", 10**100)
 
 codecs.register_error("pyre.charmap.encode.overflow", overflowing)
 try:
     codecs.charmap_encode("ሴ", "pyre.charmap.encode.overflow", {})
+except OverflowError:
+    pass
 except IndexError as error:
     assert "position -1" in str(error), str(error)
 else:

--- a/pyre/extra_tests/snippets/charmap_encode_error_handler.py
+++ b/pyre/extra_tests/snippets/charmap_encode_error_handler.py
@@ -108,3 +108,27 @@ except ValueError as error:
     assert str(error) == "boom", str(error)
 else:
     raise AssertionError("the mapping's own error should have propagated")
+
+# The table's value is read with `bytes`: an integer, a `bytes` and `None` are
+# what a mapping may return, and a `bytearray` is none of the three.
+try:
+    codecs.charmap_encode("a", "strict", {97: bytearray(b"x")})
+except TypeError as error:
+    assert "integer, bytes or None" in str(error), str(error)
+else:
+    raise AssertionError("a bytearray table value should be a TypeError")
+
+assert codecs.charmap_encode("a", "strict", {97: b"x"}) == (b"x", 1)
+assert codecs.charmap_encode("a", "strict", {97: 120}) == (b"x", 1)
+
+# The encode leg reads a handler position the way the decode leg does.
+def overflowing(exc):
+    return ("?", 10**100)
+
+codecs.register_error("pyre.charmap.encode.overflow", overflowing)
+try:
+    codecs.charmap_encode("ሴ", "pyre.charmap.encode.overflow", {})
+except IndexError as error:
+    assert "position -1" in str(error), str(error)
+else:
+    raise AssertionError("an unrepresentable position should be out of bounds")

--- a/pyre/extra_tests/snippets/codecs_decoder_buffer_inputs.py
+++ b/pyre/extra_tests/snippets/codecs_decoder_buffer_inputs.py
@@ -1,0 +1,43 @@
+# pyre-check: gate=1
+# Every named decoder unwraps its input the same way: any buffer is read, and
+# a view whose bytes are strided is refused because they are not the sequence
+# the object exposes.  The named codecs used to reach the object's own
+# `decode`, which only `bytes` and `bytearray` have, so a `memoryview` was
+# reported as the wrong argument type instead of being read.
+
+import codecs
+
+DECODERS = [
+    codecs.ascii_decode,
+    codecs.latin_1_decode,
+    codecs.utf_8_decode,
+]
+
+for decode in DECODERS:
+    assert decode(b"abc") == ("abc", 3), decode
+    assert decode(bytearray(b"abc")) == ("abc", 3), decode
+    assert decode(memoryview(b"abc")) == ("abc", 3), decode
+
+assert codecs.charmap_decode(memoryview(b"abc"), "strict", None) == ("abc", 3)
+
+# A strided view says so with the error the acquisition raised, not with the
+# wording that names a wrong argument type.
+strided = memoryview(b"abcdef")[::2]
+for decode in DECODERS:
+    try:
+        decode(strided)
+    except BufferError as error:
+        assert "contiguous" in str(error), str(error)
+    else:
+        raise AssertionError("a strided view should not be readable: %r" % decode)
+
+# Something that is no buffer at all is still the wrong argument type.
+for decode in DECODERS:
+    try:
+        decode(1)
+    except TypeError as error:
+        assert "bytes-like object is required" in str(error), str(error)
+    else:
+        raise AssertionError("an int should not be readable: %r" % decode)
+
+print("OK")

--- a/pyre/extra_tests/snippets/compile_incomplete_input_mode.py
+++ b/pyre/extra_tests/snippets/compile_incomplete_input_mode.py
@@ -1,0 +1,48 @@
+# pyre-check: gate=1
+# `PyCF_ALLOW_INCOMPLETE_INPUT` is read by the parser the mode selects, so the
+# same unfinished source is classified differently in each of the three modes.
+# `_IncompleteInputError` is what tells `codeop` to ask for another line; a
+# mode whose parser has all the input there is reports the ordinary
+# `SyntaxError` instead.
+
+import codeop
+
+ALLOW_INCOMPLETE_INPUT = 0x4000
+
+
+def classify(source, mode):
+    try:
+        compile(source, "<test>", mode, ALLOW_INCOMPLETE_INPUT)
+    except SyntaxError as error:
+        return type(error).__name__
+    return "OK"
+
+# A single-quoted literal still open at the end of the source is more input
+# only for the interactive parser; the block parsers report it as unterminated.
+assert classify("x='a", "single") == "_IncompleteInputError"
+assert classify("x='a", "exec") == "SyntaxError"
+assert classify("x='a", "eval") == "SyntaxError"
+
+# A triple-quoted one runs to the end of the source by construction.
+assert classify("x='''a", "single") == "_IncompleteInputError"
+assert classify("x='''a", "exec") == "_IncompleteInputError"
+
+# `eval` parses one expression and reaches its own end-of-input error ahead of
+# the flag, so nothing that stops mid-expression is unfinished input there.
+assert classify("x=[1,", "eval") == "SyntaxError"
+assert classify("if 1:\n", "eval") == "SyntaxError"
+
+# A source with no statement in it is unfinished for whichever parser wanted
+# one, and `exec` wanted none.
+assert classify("# hi\n", "eval") == "_IncompleteInputError"
+assert classify("# hi\n", "exec") == "OK"
+
+# A program that is wrong where it stands is never unfinished.
+for mode in ("exec", "eval", "single"):
+    assert classify("x=)", mode) == "SyntaxError", mode
+
+# `codeop` is the caller this classification exists for.
+assert codeop.compile_command("x='''a", "<test>", "single") is None
+assert codeop.compile_command("x=1", "<test>", "single") is not None
+
+print("OK")

--- a/pyre/extra_tests/snippets/escape_decode_incremental.py
+++ b/pyre/extra_tests/snippets/escape_decode_incremental.py
@@ -160,4 +160,17 @@ for tail, reason, start, end in SPANS:
     else:
         raise AssertionError("no UnicodeDecodeError for %r" % data)
 
+# The decoders take the same buffer shapes as the rest of the codec entry
+# points: a contiguous view is read, and one whose bytes are strided is not the
+# sequence the object exposes, so acquiring it fails.
+assert codecs.unicode_escape_decode(memoryview(b"ab")) == ("ab", 2)
+assert codecs.raw_unicode_escape_decode(memoryview(b"ab")) == ("ab", 2)
+for decode in (codecs.unicode_escape_decode, codecs.raw_unicode_escape_decode):
+    try:
+        decode(memoryview(b"abcdef")[::2])
+    except BufferError as error:
+        assert "contiguous" in str(error), str(error)
+    else:
+        raise AssertionError("a strided view should not be readable")
+
 print("OK")

--- a/pyre/extra_tests/snippets/excepthook_failure_and_last_vars.py
+++ b/pyre/extra_tests/snippets/excepthook_failure_and_last_vars.py
@@ -33,6 +33,29 @@ assert done.stderr.index("hook exploded") < done.stderr.index(
     "Original exception was:"
 ), done.stderr
 
+# `display_exception` reads the live `sys.stderr`, so an application that
+# replaced the stream reads the whole report on it and the stream underneath
+# stays empty.
+done = run(
+    "import atexit, io, sys\n"
+    "cap = io.StringIO()\n"
+    "sys.stderr = cap\n"
+    "atexit.register(lambda: sys.stdout.write(cap.getvalue()))\n"
+    "def hook(t, v, tb):\n"
+    "    raise RuntimeError('hook exploded')\n"
+    "sys.excepthook = hook\n"
+    "raise ValueError('original boom')\n"
+)
+assert done.returncode == 1, (done.returncode, done.stderr)
+assert done.stderr == "", done.stderr
+assert "RuntimeError: hook exploded" in done.stdout, done.stdout
+assert "Original exception was:" in done.stdout, done.stdout
+assert "ValueError: original boom" in done.stdout, done.stdout
+assert done.stdout.index("hook exploded") < done.stdout.index(
+    "Original exception was:"
+), done.stdout
+
+
 # A hook that is not callable fails the same way.
 done = run("import sys\nsys.excepthook = 42\nraise ValueError('original boom')\n")
 assert done.returncode == 1, done.returncode

--- a/pyre/extra_tests/snippets/excepthook_failure_and_last_vars.py
+++ b/pyre/extra_tests/snippets/excepthook_failure_and_last_vars.py
@@ -1,0 +1,80 @@
+# pyre-check: gate=1
+# `display_exception` sets the sys.last_xxx attributes before it resolves the
+# hook, and a hook that fails does not take the exception it was handed with
+# it: the failure is named, printed, and the original report follows it under
+# `Original exception was:`.  A module run with `-m` ends the same way a script
+# does, so the hook it installed is what reports its failure.
+
+import os
+import subprocess
+import sys
+import tempfile
+
+
+def run(source):
+    return subprocess.run(
+        [sys.executable, "-c", source], capture_output=True, text=True
+    )
+
+
+# A hook that raises: both reports reach stderr, in that order.
+done = run(
+    "import sys\n"
+    "def hook(t, v, tb):\n"
+    "    raise RuntimeError('hook exploded')\n"
+    "sys.excepthook = hook\n"
+    "raise ValueError('original boom')\n"
+)
+assert done.returncode == 1, done.returncode
+assert "hook exploded" in done.stderr, done.stderr
+assert "Original exception was:" in done.stderr, done.stderr
+assert "ValueError: original boom" in done.stderr, done.stderr
+assert done.stderr.index("hook exploded") < done.stderr.index(
+    "Original exception was:"
+), done.stderr
+
+# A hook that is not callable fails the same way.
+done = run("import sys\nsys.excepthook = 42\nraise ValueError('original boom')\n")
+assert done.returncode == 1, done.returncode
+assert "not callable" in done.stderr, done.stderr
+assert "ValueError: original boom" in done.stderr, done.stderr
+
+# The four names a post-mortem debugger reads are in place when the hook runs.
+done = run(
+    "import sys\n"
+    "def hook(t, v, tb):\n"
+    "    print(sys.last_type is t, sys.last_value is v, sys.last_traceback is tb)\n"
+    "    print(sys.last_exc is v)\n"
+    "sys.excepthook = hook\n"
+    "raise ValueError('boom')\n"
+)
+assert done.returncode == 1, (done.returncode, done.stderr)
+assert done.stdout.split() == ["True", "True", "True", "True"], done.stdout
+
+# `-m` reports its failure through the same route, so a hook the module
+# installed is what runs.
+with tempfile.TemporaryDirectory() as directory:
+    package = os.path.join(directory, "pyre_hook_pkg")
+    os.mkdir(package)
+    open(os.path.join(package, "__init__.py"), "w").close()
+    with open(os.path.join(package, "__main__.py"), "w") as handle:
+        handle.write(
+            "import sys\n"
+            "def hook(t, v, tb):\n"
+            "    print('SENTINEL', t.__name__, v)\n"
+            "sys.excepthook = hook\n"
+            "raise ValueError('m-mode boom')\n"
+        )
+    done = subprocess.run(
+        [sys.executable, "-m", "pyre_hook_pkg"],
+        capture_output=True,
+        text=True,
+        cwd=directory,
+    )
+assert done.returncode == 1, (done.returncode, done.stderr)
+assert done.stdout.strip() == "SENTINEL ValueError m-mode boom", (
+    done.stdout,
+    done.stderr,
+)
+
+print("OK")

--- a/pyre/extra_tests/snippets/suggestions_module.py
+++ b/pyre/extra_tests/snippets/suggestions_module.py
@@ -1,0 +1,82 @@
+# pyre-check: gate=1
+# `_suggestions._generate_suggestions` exposes the misspelling search that
+# `traceback._compute_suggestion_error` and `_find_keyword_typos` rank with.
+# The search reads every name through `PyUnicode_AsUTF8AndSize` and indexes the
+# buffer it gets, so each length and each position it measures is a UTF-8 byte;
+# ranking by code points is a different order, not the same one in other units.
+
+import _suggestions
+
+gen = _suggestions._generate_suggestions
+
+assert gen(["hello", "world"], "hell") == "hello"
+# A candidate equal to the name is skipped, so it never suggests itself.
+assert gen(["hell"], "hell") is None
+assert gen(["zzzzzz"], "hell") is None
+assert gen([], "hell") is None
+
+# `MAX_CANDIDATE_ITEMS` is 750, and the set is given up on before any name is
+# read rather than searched and lost.
+assert gen(["hello"] * 749, "hell") == "hello"
+assert gen(["hello"] * 750, "hell") is None
+
+# `PyList_CheckExact`: a tuple and a list subclass are both refused.
+class MyList(list):
+    pass
+
+for wrong_shape in (("hello",), MyList(["hello"])):
+    try:
+        gen(wrong_shape, "hell")
+    except TypeError as error:
+        assert str(error) == "candidates must be a list", str(error)
+    else:
+        raise AssertionError("only an exact list is a candidate set")
+
+try:
+    gen(["hello", 1], "hell")
+except TypeError as error:
+    assert str(error) == "all elements in 'candidates' must be strings", str(error)
+else:
+    raise AssertionError("a non-string candidate is a TypeError")
+
+# The name is converted by the argument clinic, ahead of the body's list test.
+try:
+    gen(1, 1)
+except TypeError as error:
+    assert "argument 2 must be str, not int" in str(error), str(error)
+else:
+    raise AssertionError("a non-str name is a TypeError")
+
+# A lone surrogate has no UTF-8 encoding, so reading it is what fails -- the
+# name is not quietly dropped from the ranking.
+for candidates, name in ((["hello", "\udcff"], "hell"), (["hello"], "\udcff")):
+    try:
+        gen(candidates, name)
+    except UnicodeEncodeError as error:
+        assert "surrogates not allowed" in str(error), str(error)
+    else:
+        raise AssertionError("a lone surrogate has no UTF-8 encoding")
+
+# Names outside ASCII are measured in UTF-8 bytes.  Each of these is decided
+# differently when the same search counts code points instead.
+assert gen(["αaαaa", "日日é"], "αx日é") == "日日é"
+assert gen(["日αaa日日", "éaααé"], "aα日é") is None
+assert gen(["aaαéαx日", "αax"], "α日x") is None
+
+# `_substitution_cost` charges a case-only difference `CASE_COST` where a real
+# substitution costs `MOVE_COST`, so two changes of case beat one of letter.
+assert gen(["helLO", "hellp"], "hello") == "helLO"
+# The ratio cutoff still applies to those cheap edits: five of them are more
+# than a third of the characters involved.
+assert gen(["HELLO"], "hello") is None
+
+# `traceback` is the caller this exists for.
+try:
+    raise AttributeError(name="attrbute", obj=type("C", (), {"attribute": 1})())
+except AttributeError as error:
+    import traceback
+
+    rendered = "".join(traceback.format_exception_only(error))
+    assert "attribute" in rendered, rendered
+
+print("OK")

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4516,33 +4516,50 @@ pub(crate) fn sys_displayhook(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
 /// using the shared structured renderer keeps exception chains and
 /// tracebacks visible to tests that deliberately call the original hook.
 pub(crate) fn sys_excepthook(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let value = args.get(1).copied().unwrap_or_else(w_none);
-    let traceback = args.get(2).copied().unwrap_or_else(w_none);
     // Route through the live `sys.stderr`, not directly through the host
     // seam: tests and applications are allowed to replace `sys.stderr` and
     // `sys.__excepthook__` must honor that replacement.
     let stderr = crate::importing::get_sys_module("sys")
         .and_then(|sys| crate::baseobjspace::getattr_str(sys, "stderr").ok());
+    // Both renderers below run Python -- the stdlib one imports `traceback`,
+    // the built-in one calls `__str__` on the chain -- so each of the three
+    // objects that outlive them is published and read back from its slot; a
+    // Rust local would still name the address it had before a collection moved
+    // the object.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(args.get(1).copied().unwrap_or_else(w_none));
+    let _ = pyre_object::gc_roots::pin_root(args.get(2).copied().unwrap_or_else(w_none));
+    // A stream that is not there is `None` in the slot and `false` beside it;
+    // the two answer different questions and the tests below ask both.
+    let has_stderr = stderr.is_some();
+    let _ = pyre_object::gc_roots::pin_root(match stderr {
+        Some(stream) if !stream.is_null() => stream,
+        _ => w_none(),
+    });
+    let value = || pyre_object::gc_roots::shadow_stack_get(sp);
+    let traceback = || pyre_object::gc_roots::shadow_stack_get(sp + 1);
+    let stderr_slot = || has_stderr.then(|| pyre_object::gc_roots::shadow_stack_get(sp + 2));
     // An application that set `sys.stderr = None` disabled the stream, and
     // `PyErr_Display` returns without printing in that case -- ahead of
     // `_PyErr_Display`, so neither renderer runs, which is why the test sits
     // here rather than beside the write below.  Only a missing `sys` or a
     // failing lookup may fall through to the host seam; treating the two alike
     // leaks the render past the configured sink.
-    if let Some(stderr) = stderr
+    if let Some(stderr) = stderr_slot()
         && (stderr.is_null() || unsafe { pyre_object::is_none(stderr) })
     {
         return Ok(w_none());
     }
     // `_PyErr_Display` offers the exception to the stdlib renderer before
     // reaching its own, and that renderer writes to `sys.stderr` itself.
-    if crate::error::display_through_traceback_module(value, traceback) {
+    if crate::error::display_through_traceback_module(value(), traceback()) {
         return Ok(w_none());
     }
     let mut rendered = Vec::new();
-    crate::error::write_exception_from_parts(&mut rendered, value, traceback)
+    crate::error::write_exception_from_parts(&mut rendered, value(), traceback())
         .map_err(|_| crate::PyError::runtime_error("sys.excepthook: failed to write exception"))?;
-    if let Some(stderr) = stderr {
+    if stderr_slot().is_some() {
         // The render is assembled from text the printer already escaped, so it
         // is well-formed WTF-8; a decode failure would mean a byte no writer
         // put there, and the lossy read is the last resort for it.
@@ -4550,7 +4567,12 @@ pub(crate) fn sys_excepthook(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
             Some(text) => pyre_object::w_str_from_wtf8(text.to_wtf8_buf()),
             None => pyre_object::w_str_new(&String::from_utf8_lossy(&rendered)),
         };
-        let result = crate::baseobjspace::call_method(stderr, "write", &[w_text]);
+        // Read the stream back after that allocation, not before it.
+        let result = crate::baseobjspace::call_method(
+            pyre_object::gc_roots::shadow_stack_get(sp + 2),
+            "write",
+            &[w_text],
+        );
         if result.is_null() {
             let _ = crate::call::take_call_error();
         } else {
@@ -8205,41 +8227,54 @@ fn exc_unicode_translate_error_init(args: &[PyObjectRef]) -> Result<PyObjectRef,
             args.len().saturating_sub(1)
         )));
     }
-    let w_self = args[0];
-    let w_object = args[1];
-    let w_start = args[2];
-    let w_end = args[3];
-    let w_reason = args[4];
+    // The two `w_int_new` calls below allocate, and the arguments live in a
+    // native slice the gateway copied off the shadow stack, which a collection
+    // does not rewrite.  Publish the receiver and the arguments first, then
+    // read each one back from its slot, as `exc_syntax_error_init` does.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::pin_roots(args);
+    let slot = |n: usize| pyre_object::gc_roots::shadow_stack_get(base + n);
     unsafe {
-        if !crate::baseobjspace::isinstance_str_w(w_object) {
+        if !crate::baseobjspace::isinstance_str_w(slot(1)) {
             return Err(crate::PyError::type_error(format!(
                 "argument 1 must be str, not {}",
-                crate::error::type_name_of(w_object)
+                crate::error::type_name_of(slot(1))
             )));
         }
-        let start = unicode_error_index_w(w_start)?;
-        let end = unicode_error_index_w(w_end)?;
-        if !crate::baseobjspace::isinstance_str_w(w_reason) {
+        let start = unicode_error_index_w(slot(2))?;
+        let end = unicode_error_index_w(slot(3))?;
+        if !crate::baseobjspace::isinstance_str_w(slot(4)) {
             return Err(crate::PyError::type_error(format!(
                 "argument 4 must be str, not {}",
-                crate::error::type_name_of(w_reason)
+                crate::error::type_name_of(slot(4))
             )));
         }
-        let w_start_value = pyre_object::w_int_new(start);
-        let w_end_value = pyre_object::w_int_new(end);
-        pyre_object::interp_exceptions::w_exception_set_object(w_self, w_object);
-        pyre_object::interp_exceptions::w_exception_set_start(w_self, w_start_value);
-        pyre_object::interp_exceptions::w_exception_set_end(w_self, w_end_value);
-        pyre_object::interp_exceptions::w_exception_set_reason(w_self, w_reason);
+        // The second allocation can move the first one's result.
+        let values = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(start));
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(end));
+        pyre_object::interp_exceptions::w_exception_set_object(slot(0), slot(1));
+        pyre_object::interp_exceptions::w_exception_set_start(
+            slot(0),
+            pyre_object::gc_roots::shadow_stack_get(values),
+        );
+        pyre_object::interp_exceptions::w_exception_set_end(
+            slot(0),
+            pyre_object::gc_roots::shadow_stack_get(values + 1),
+        );
+        pyre_object::interp_exceptions::w_exception_set_reason(slot(0), slot(4));
         // `W_BaseException.descr_init(self, space, [w_object, w_start,
         // w_end, w_reason])` → `self.args_w = args_w`.  The
         // `W_BaseException.args_w` slot already carries the same
         // tuple shape from `__new__`, so we re-stamp it from the
         // bound init args here for parity with PyPy line 444-445.
         let args_list = pyre_object::interp_exceptions::w_exception_args_new(vec![
-            w_object, w_start, w_end, w_reason,
+            slot(1),
+            slot(2),
+            slot(3),
+            slot(4),
         ]);
-        pyre_object::interp_exceptions::w_exception_set_args(w_self, args_list);
+        pyre_object::interp_exceptions::w_exception_set_args(slot(0), args_list);
     }
     Ok(pyre_object::w_none())
 }
@@ -8257,31 +8292,32 @@ fn exc_unicode_decode_error_init(args: &[PyObjectRef]) -> Result<PyObjectRef, cr
             args.len().saturating_sub(1)
         )));
     }
-    let w_self = args[0];
-    let w_encoding = args[1];
-    let w_object_in = args[2];
-    let w_start = args[3];
-    let w_end = args[4];
-    let w_reason = args[5];
+    // The two `w_int_new` calls below allocate, and the arguments live in a
+    // native slice the gateway copied off the shadow stack, which a collection
+    // does not rewrite.  Publish the receiver and the arguments first, then
+    // read each one back from its slot, as `exc_syntax_error_init` does.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::pin_roots(args);
+    let slot = |n: usize| pyre_object::gc_roots::shadow_stack_get(base + n);
     unsafe {
-        if !crate::baseobjspace::isinstance_str_w(w_encoding) {
+        if !crate::baseobjspace::isinstance_str_w(slot(1)) {
             return Err(crate::PyError::type_error(format!(
                 "argument 1 must be str, not {}",
-                crate::error::type_name_of(w_encoding)
+                crate::error::type_name_of(slot(1))
             )));
         }
-        if !crate::baseobjspace::isinstance_bytes_like_w(w_object_in) {
+        if !crate::baseobjspace::isinstance_bytes_like_w(slot(2)) {
             return Err(crate::PyError::type_error(format!(
                 "a bytes-like object is required, not '{}'",
-                crate::error::type_name_of(w_object_in)
+                crate::error::type_name_of(slot(2))
             )));
         }
-        let start = unicode_error_index_w(w_start)?;
-        let end = unicode_error_index_w(w_end)?;
-        if !crate::baseobjspace::isinstance_str_w(w_reason) {
+        let start = unicode_error_index_w(slot(3))?;
+        let end = unicode_error_index_w(slot(4))?;
+        if !crate::baseobjspace::isinstance_str_w(slot(5)) {
             return Err(crate::PyError::type_error(format!(
                 "argument 5 must be str, not {}",
-                crate::error::type_name_of(w_reason)
+                crate::error::type_name_of(slot(5))
             )));
         }
         // `interp_exceptions.py:1043-1046` — `space.charbuf_w` /
@@ -8303,39 +8339,43 @@ fn exc_unicode_decode_error_init(args: &[PyObjectRef]) -> Result<PyObjectRef, cr
         // bytes subclass → `w_bytes_data` (`W_BytesObject` layout);
         // bytearray (exact or subclass) → `w_bytearray_data`
         // (`W_BytearrayObject` layout).
-        let w_object = if pyre_object::is_bytes(w_object_in) {
-            w_object_in
+        // The coerced bytes and the two integers each outlive an allocation
+        // that follows them, so each is published as it is built.
+        let values = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(if pyre_object::is_bytes(slot(2)) {
+            slot(2)
         } else {
             let bytes_type = crate::typedef::gettypefor(&pyre_object::BYTES_TYPE);
             let inherits_bytes = bytes_type
-                .is_some_and(|bt| crate::baseobjspace::isinstance_w(w_object_in, bt.as_ptr()));
+                .is_some_and(|bt| crate::baseobjspace::isinstance_w(slot(2), bt.as_ptr()));
             let data = if inherits_bytes {
-                pyre_object::bytesobject::w_bytes_data(w_object_in)
+                pyre_object::bytesobject::w_bytes_data(slot(2))
             } else {
-                pyre_object::bytearrayobject::w_bytearray_data(w_object_in)
+                pyre_object::bytearrayobject::w_bytearray_data(slot(2))
             };
             pyre_object::w_bytes_from_bytes(data)
-        };
-        let w_start_value = pyre_object::w_int_new(start);
-        let w_end_value = pyre_object::w_int_new(end);
-        pyre_object::interp_exceptions::w_exception_set_encoding(w_self, w_encoding);
-        pyre_object::interp_exceptions::w_exception_set_object(w_self, w_object);
-        pyre_object::interp_exceptions::w_exception_set_start(w_self, w_start_value);
-        pyre_object::interp_exceptions::w_exception_set_end(w_self, w_end_value);
-        pyre_object::interp_exceptions::w_exception_set_reason(w_self, w_reason);
+        });
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(start));
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(end));
+        let value = |n: usize| pyre_object::gc_roots::shadow_stack_get(values + n);
+        pyre_object::interp_exceptions::w_exception_set_encoding(slot(0), slot(1));
+        pyre_object::interp_exceptions::w_exception_set_object(slot(0), value(0));
+        pyre_object::interp_exceptions::w_exception_set_start(slot(0), value(1));
+        pyre_object::interp_exceptions::w_exception_set_end(slot(0), value(2));
+        pyre_object::interp_exceptions::w_exception_set_reason(slot(0), slot(5));
         // `interp_exceptions.py:1058-1059` — the args list passed to
         // `W_BaseException.descr_init` is the un-coerced
         // `[w_encoding, w_object, w_start, w_end, w_reason]`, so PyPy
         // preserves the original `bytearray` in `e.args[1]` while
         // storing the coerced `bytes` in `e.object`.
         let args_list = pyre_object::interp_exceptions::w_exception_args_new(vec![
-            w_encoding,
-            w_object_in,
-            w_start,
-            w_end,
-            w_reason,
+            slot(1),
+            slot(2),
+            slot(3),
+            slot(4),
+            slot(5),
         ]);
-        pyre_object::interp_exceptions::w_exception_set_args(w_self, args_list);
+        pyre_object::interp_exceptions::w_exception_set_args(slot(0), args_list);
     }
     Ok(pyre_object::w_none())
 }
@@ -8351,44 +8391,57 @@ fn exc_unicode_encode_error_init(args: &[PyObjectRef]) -> Result<PyObjectRef, cr
             args.len().saturating_sub(1)
         )));
     }
-    let w_self = args[0];
-    let w_encoding = args[1];
-    let w_object = args[2];
-    let w_start = args[3];
-    let w_end = args[4];
-    let w_reason = args[5];
+    // The two `w_int_new` calls below allocate, and the arguments live in a
+    // native slice the gateway copied off the shadow stack, which a collection
+    // does not rewrite.  Publish the receiver and the arguments first, then
+    // read each one back from its slot, as `exc_syntax_error_init` does.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::pin_roots(args);
+    let slot = |n: usize| pyre_object::gc_roots::shadow_stack_get(base + n);
     unsafe {
-        if !crate::baseobjspace::isinstance_str_w(w_encoding) {
+        if !crate::baseobjspace::isinstance_str_w(slot(1)) {
             return Err(crate::PyError::type_error(format!(
                 "argument 1 must be str, not {}",
-                crate::error::type_name_of(w_encoding)
+                crate::error::type_name_of(slot(1))
             )));
         }
-        if !crate::baseobjspace::isinstance_str_w(w_object) {
+        if !crate::baseobjspace::isinstance_str_w(slot(2)) {
             return Err(crate::PyError::type_error(format!(
                 "argument 2 must be str, not {}",
-                crate::error::type_name_of(w_object)
+                crate::error::type_name_of(slot(2))
             )));
         }
-        let start = unicode_error_index_w(w_start)?;
-        let end = unicode_error_index_w(w_end)?;
-        if !crate::baseobjspace::isinstance_str_w(w_reason) {
+        let start = unicode_error_index_w(slot(3))?;
+        let end = unicode_error_index_w(slot(4))?;
+        if !crate::baseobjspace::isinstance_str_w(slot(5)) {
             return Err(crate::PyError::type_error(format!(
                 "argument 5 must be str, not {}",
-                crate::error::type_name_of(w_reason)
+                crate::error::type_name_of(slot(5))
             )));
         }
-        let w_start_value = pyre_object::w_int_new(start);
-        let w_end_value = pyre_object::w_int_new(end);
-        pyre_object::interp_exceptions::w_exception_set_encoding(w_self, w_encoding);
-        pyre_object::interp_exceptions::w_exception_set_object(w_self, w_object);
-        pyre_object::interp_exceptions::w_exception_set_start(w_self, w_start_value);
-        pyre_object::interp_exceptions::w_exception_set_end(w_self, w_end_value);
-        pyre_object::interp_exceptions::w_exception_set_reason(w_self, w_reason);
+        // The second allocation can move the first one's result.
+        let values = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(start));
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_int_new(end));
+        pyre_object::interp_exceptions::w_exception_set_encoding(slot(0), slot(1));
+        pyre_object::interp_exceptions::w_exception_set_object(slot(0), slot(2));
+        pyre_object::interp_exceptions::w_exception_set_start(
+            slot(0),
+            pyre_object::gc_roots::shadow_stack_get(values),
+        );
+        pyre_object::interp_exceptions::w_exception_set_end(
+            slot(0),
+            pyre_object::gc_roots::shadow_stack_get(values + 1),
+        );
+        pyre_object::interp_exceptions::w_exception_set_reason(slot(0), slot(5));
         let args_list = pyre_object::interp_exceptions::w_exception_args_new(vec![
-            w_encoding, w_object, w_start, w_end, w_reason,
+            slot(1),
+            slot(2),
+            slot(3),
+            slot(4),
+            slot(5),
         ]);
-        pyre_object::interp_exceptions::w_exception_set_args(w_self, args_list);
+        pyre_object::interp_exceptions::w_exception_set_args(slot(0), args_list);
     }
     Ok(pyre_object::w_none())
 }
@@ -11913,7 +11966,7 @@ pub fn compile_err_to_syntax_error(
     e: crate::compile::CompileError,
     source: &str,
 ) -> crate::PyError {
-    compile_err_to_syntax_error_maybe_incomplete(e, source, false)
+    compile_err_to_syntax_error_maybe_incomplete(e, source, None)
 }
 
 /// Convert Ruff/RustPython's one-based UTF-8 byte column to the one-based
@@ -12777,10 +12830,15 @@ fn unclosed_error_is_fstring(source: &str, raw_index: usize) -> bool {
 /// `PyCF_ALLOW_INCOMPLETE_INPUT` is set.  PyPy's compiler has the same
 /// parser-level distinction through its `compile_command` path; pyre consumes
 /// RustPython's parser, so keep its exact error-shape classification here.
+///
+/// `allow_incomplete` carries the mode the flag was passed with, because
+/// `PyPARSE_ALLOW_INCOMPLETE_INPUT` is read by the parser that the mode
+/// selects and the three parsers do not stop at the same place.  `None` is the
+/// flag left off, where every failure is an ordinary `SyntaxError`.
 fn compile_err_to_syntax_error_maybe_incomplete(
     e: crate::compile::CompileError,
     source: &str,
-    allow_incomplete: bool,
+    allow_incomplete: Option<crate::compile::Mode>,
 ) -> crate::PyError {
     // Every location in `e` indexes the source the compiler was handed, which
     // `compile_source_with_opts` had already run through `universal_newline`.
@@ -12847,12 +12905,16 @@ fn compile_err_to_syntax_error_maybe_incomplete(
         })
     }
 
-    let incomplete = if !allow_incomplete {
-        false
-    } else if holds_no_statement(source) {
-        true
-    } else {
-        match &e {
+    let incomplete = match allow_incomplete {
+        None => false,
+        // A source holding no statement is unfinished for whichever parser
+        // wanted one, so the mode does not enter here.
+        Some(_) if holds_no_statement(source) => true,
+        // `eval` parses one expression and reaches its own end-of-input error
+        // ahead of the flag: a source that stops mid-expression is reported as
+        // the syntax error it is, whatever the flag asks for.
+        Some(crate::compile::Mode::Eval) => false,
+        Some(mode) => match &e {
             crate::compile::CompileError::Parse(error) => match &error.error {
                 ParseErrorType::Lexical(LexicalErrorType::Eof) => true,
                 _ if error.is_unclosed_bracket => true,
@@ -12861,7 +12923,15 @@ fn compile_err_to_syntax_error_maybe_incomplete(
                 )) => true,
                 ParseErrorType::Lexical(LexicalErrorType::UnclosedStringError) => {
                     let loc = error.raw_location.start().to_usize();
-                    opens_triple_quote(source, loc) || string_continues_to_eof(source, loc)
+                    // A triple-quoted literal left open wants more input under
+                    // either parser.  A single-quoted one still open at the end
+                    // of the source is unfinished only for the interactive
+                    // parser, which has another line to read; a block parser
+                    // holds all the input there is and reports the literal as
+                    // unterminated.
+                    opens_triple_quote(source, loc)
+                        || (matches!(mode, crate::compile::Mode::Single)
+                            && string_continues_to_eof(source, loc))
                 }
                 ParseErrorType::OtherError(message)
                     if message.starts_with("Expected an indented block after")
@@ -12912,7 +12982,15 @@ fn compile_err_to_syntax_error_maybe_incomplete(
                     if message.starts_with("unterminated string literal") =>
                 {
                     let loc = error.raw_location.start().to_usize();
-                    opens_triple_quote(source, loc) || string_continues_to_eof(source, loc)
+                    // A triple-quoted literal left open wants more input under
+                    // either parser.  A single-quoted one still open at the end
+                    // of the source is unfinished only for the interactive
+                    // parser, which has another line to read; a block parser
+                    // holds all the input there is and reports the literal as
+                    // unterminated.
+                    opens_triple_quote(source, loc)
+                        || (matches!(mode, crate::compile::Mode::Single)
+                            && string_continues_to_eof(source, loc))
                 }
                 // A closing bracket with no opener, or one that does not
                 // match the opener, is wrong where it stands rather than short
@@ -12931,7 +13009,7 @@ fn compile_err_to_syntax_error_maybe_incomplete(
                 _ => false,
             },
             _ => false,
-        }
+        },
     };
 
     // `syntax_error_subclass` can supply a replacement message, so it
@@ -13826,7 +13904,7 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
                     crate::compile::compile_source_with_opts(text, mode, &filename, retry_opts)
             {
                 return replace_compile_syntax_error_filename(
-                    compile_err_to_syntax_error_maybe_incomplete(structured, text, true),
+                    compile_err_to_syntax_error_maybe_incomplete(structured, text, Some(mode)),
                     &filename,
                     filename_bytes.as_deref(),
                 );
@@ -13842,7 +13920,7 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             compile_err_to_syntax_error_maybe_incomplete(
                 e,
                 source,
-                flags & PYCF_ALLOW_INCOMPLETE_INPUT != 0,
+                (flags & PYCF_ALLOW_INCOMPLETE_INPUT != 0).then_some(mode),
             )
         })
     } else {

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -3145,9 +3145,10 @@ fn render_exc_object_wtf8(exc: PyObjectRef) -> Wtf8Buf {
     render_rooted_exc_object_wtf8(exc_slot)
 }
 
-const MAX_SUGGESTION_CANDIDATES: usize = 750;
+pub(crate) const MAX_SUGGESTION_CANDIDATES: usize = 750;
 const MAX_SUGGESTION_STRING_SIZE: usize = 40;
 const SUGGESTION_MOVE_COST: usize = 2;
+const SUGGESTION_CASE_COST: usize = 1;
 
 fn dict_string_keys(dict: PyObjectRef, names: &mut Vec<String>) {
     if dict.is_null() || !unsafe { pyre_object::is_dict(dict) } {
@@ -3166,18 +3167,24 @@ fn dict_string_keys(dict: PyObjectRef, names: &mut Vec<String>) {
 }
 
 fn suggestion_distance(a: &str, b: &str, max_cost: usize) -> usize {
-    let mut a: Vec<char> = a.chars().collect();
-    let mut b: Vec<char> = b.chars().collect();
+    // `levenshtein_distance` reads each name through `PyUnicode_AsUTF8AndSize`
+    // and indexes the buffer it gets, so every length and every position here
+    // is a UTF-8 byte.  Measuring code points instead moves the ratio cutoff
+    // and the distance itself for any name outside ASCII, which is a different
+    // ranking rather than the same one in other units.
+    let mut a: &[u8] = a.as_bytes();
+    let mut b: &[u8] = b.as_bytes();
     if a == b {
         return 0;
     }
+    // Trim away common affixes.
     while a.first() == b.first() && !a.is_empty() {
-        a.remove(0);
-        b.remove(0);
+        a = &a[1..];
+        b = &b[1..];
     }
     while a.last() == b.last() && !a.is_empty() {
-        a.pop();
-        b.pop();
+        a = &a[..a.len() - 1];
+        b = &b[..b.len() - 1];
     }
     if a.is_empty() || b.is_empty() {
         return SUGGESTION_MOVE_COST * (a.len() + b.len());
@@ -3195,17 +3202,19 @@ fn suggestion_distance(a: &str, b: &str, max_cost: usize) -> usize {
         .map(|index| index * SUGGESTION_MOVE_COST)
         .collect();
     let mut result = 0;
-    for (bindex, bchar) in b.iter().enumerate() {
+    for (bindex, bbyte) in b.iter().enumerate() {
         let mut distance = bindex * SUGGESTION_MOVE_COST;
         result = distance;
         let mut minimum = usize::MAX;
-        for (index, achar) in a.iter().enumerate() {
-            let case_equal = achar.to_lowercase().eq(bchar.to_lowercase());
+        for (index, abyte) in a.iter().enumerate() {
+            // `_substitution_cost` folds case over ASCII alone, so a pair that
+            // differs only outside that range costs a full move.
+            let case_equal = abyte.eq_ignore_ascii_case(bbyte);
             let substitute = distance
-                + if achar == bchar {
+                + if abyte == bbyte {
                     0
                 } else if case_equal {
-                    1
+                    SUGGESTION_CASE_COST
                 } else {
                     SUGGESTION_MOVE_COST
                 };
@@ -3225,7 +3234,9 @@ pub(crate) fn best_suggestion(candidates: &[String], wrong_name: &str) -> Option
     if candidates.len() >= MAX_SUGGESTION_CANDIDATES {
         return None;
     }
-    let wrong_len = wrong_name.chars().count();
+    // The ratio cutoff below is `_Py_CalculateSuggestions`', which sizes each
+    // name by the UTF-8 buffer `PyUnicode_AsUTF8AndSize` returned for it.
+    let wrong_len = wrong_name.len();
     // No candidate has been measured yet, so nothing caps the first one but
     // its own ratio test below.  A name longer than `MAX_SUGGESTION_STRING_SIZE`
     // is not rejected here: `suggestion_distance` applies that limit to what is
@@ -3237,7 +3248,7 @@ pub(crate) fn best_suggestion(candidates: &[String], wrong_name: &str) -> Option
         if candidate == wrong_name {
             continue;
         }
-        let candidate_len = candidate.chars().count();
+        let candidate_len = candidate.len();
         // No more than 1/3 of the involved characters should need changed.
         let mut max_distance = (candidate_len + wrong_len + 3) * SUGGESTION_MOVE_COST / 6;
         // Don't take matches we've already beaten.

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -3954,6 +3954,8 @@ pub fn print_exception_via_excepthook(err: &mut PyError) -> bool {
         return false;
     }
     let _roots = pyre_object::gc_roots::push_roots();
+    let sys_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(sys);
     let hook_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(hook);
     // Materialising the instance is what gives the hook something to report;
@@ -3980,6 +3982,25 @@ pub fn print_exception_via_excepthook(err: &mut PyError) -> bool {
     } else {
         w_tb
     });
+    // `app_main.py display_exception` sets the sys.last_xxx attributes before
+    // it resolves the hook, so a hook that inspects them -- a post-mortem
+    // debugger is the reason they exist -- finds the exception it was handed.
+    // `last_exc` names the exception itself and the three beside it are the
+    // triple that predates it, as `PyErr_PrintEx` stores them.  A store that
+    // fails leaves that one name alone.
+    for (name, slot) in [
+        ("last_exc", exc_slot),
+        ("last_type", type_slot),
+        ("last_value", exc_slot),
+        ("last_traceback", tb_slot),
+    ] {
+        let stored = crate::baseobjspace::setattr_str(
+            pyre_object::gc_roots::shadow_stack_get(sys_slot),
+            name,
+            pyre_object::gc_roots::shadow_stack_get(slot),
+        );
+        drop(stored);
+    }
     let arguments = [
         pyre_object::gc_roots::shadow_stack_get(type_slot),
         pyre_object::gc_roots::shadow_stack_get(exc_slot),
@@ -3989,12 +4010,15 @@ pub fn print_exception_via_excepthook(err: &mut PyError) -> bool {
         pyre_object::gc_roots::shadow_stack_get(hook_slot),
         &arguments,
     );
-    if let Err(mut failure) = reported {
-        failure.write_unraisable(
-            pyre_object::w_none(),
-            rustpython_wtf8::Wtf8::new("Exception ignored in sys.excepthook"),
-            pyre_object::gc_roots::shadow_stack_get(hook_slot),
-        );
+    if let Err(failure) = reported {
+        // `display_exception`'s `except BaseException` arm: the hook is named
+        // as the thing that failed, its own report is printed, and the answer
+        // is that the exception has *not* been reported -- the caller prints it
+        // below the `Original exception was:` header this leaves behind.
+        emit_report_to_host_stderr(b"Error calling sys.excepthook:\n");
+        eprint_exception(&failure, true);
+        emit_report_to_host_stderr(b"\nOriginal exception was:\n");
+        return false;
     }
     true
 }

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -3940,6 +3940,84 @@ pub(crate) fn emit_report_to_host_stderr(buf: &[u8]) {
     }
 }
 
+/// `display_exception`'s `stderr = sys.stderr` — the banner lines its failure
+/// arm prints go to the stream the application configured, not to the host seam
+/// beneath it.  A stream set to `None` disables the report the way
+/// `PyErr_Display` does; only a missing `sys` or a failing lookup falls through
+/// to the seam, because treating the two alike leaks the write past a
+/// configured sink.
+pub(crate) fn emit_report_to_sys_stderr(buf: &[u8]) {
+    let stream = crate::importing::get_sys_module("sys")
+        .and_then(|sys| crate::baseobjspace::getattr_str(sys, "stderr").ok());
+    let Some(stream) = stream else {
+        emit_report_to_host_stderr(buf);
+        return;
+    };
+    if stream.is_null() || unsafe { pyre_object::is_none(stream) } {
+        return;
+    }
+    // The write runs Python, so the stream is published and read back from its
+    // slot: a Rust local would still name the address it had before the
+    // allocation below moved the object.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(stream);
+    // Every caller passes a literal this file holds, so the bytes are
+    // well-formed WTF-8; the lossy read is the last resort for a byte no writer
+    // put there.
+    let w_text = match rustpython_wtf8::Wtf8::from_bytes(buf) {
+        Some(text) => pyre_object::w_str_from_wtf8(text.to_wtf8_buf()),
+        None => pyre_object::w_str_new(&String::from_utf8_lossy(buf)),
+    };
+    // Read the stream back after that allocation, not before it.
+    let result = crate::baseobjspace::call_method(
+        pyre_object::gc_roots::shadow_stack_get(sp),
+        "write",
+        &[w_text],
+    );
+    if result.is_null() {
+        let _ = crate::call::take_call_error();
+        emit_report_to_host_stderr(buf);
+    }
+}
+
+/// `originalexcepthook` for an exception a Rust caller holds: `sys.excepthook`'s
+/// default is the renderer that reaches the live `sys.stderr`, and
+/// `display_exception` hands it each report its failure arm prints.  A hook that
+/// cannot render leaves the host seam as the last sink, which is where a report
+/// with nowhere else to go belongs.
+fn report_through_default_excepthook(failure: &mut PyError) {
+    let exc = failure.to_exc_object();
+    if exc.is_null() {
+        eprint_exception(failure, true);
+        return;
+    }
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(exc);
+    let w_type = crate::baseobjspace::exception_getclass(exc);
+    let _ = pyre_object::gc_roots::pin_root(if w_type.is_null() {
+        pyre_object::w_none()
+    } else {
+        w_type
+    });
+    let w_tb = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc) };
+    unsafe { crate::pytraceback::mark_traceback_escaped(w_tb) };
+    let _ = pyre_object::gc_roots::pin_root(if w_tb.is_null() {
+        pyre_object::w_none()
+    } else {
+        w_tb
+    });
+    let reported = crate::builtins::sys_excepthook(&[
+        pyre_object::gc_roots::shadow_stack_get(sp + 1),
+        pyre_object::gc_roots::shadow_stack_get(sp),
+        pyre_object::gc_roots::shadow_stack_get(sp + 2),
+    ]);
+    if reported.is_err() {
+        eprint_exception(failure, true);
+    }
+}
+
 /// `pythonrun.c _PyErr_Print` for a caller holding the exception rather than
 /// the thread's indicator: every top-level run reports through `sys.excepthook`,
 /// so an application's own hook is what reports the failure it was installed
@@ -3949,26 +4027,16 @@ pub(crate) fn emit_report_to_host_stderr(buf: &[u8]) {
 ///
 /// `false` says there was no hook to reach, which is `_PyErr_PrintEx`'s
 /// `sys.excepthook is missing` arm, and the caller prints the exception itself.
-/// A hook that runs and fails has still reported: its own failure is named as
-/// unraisable, exactly as upstream does, and this answers `true` rather than
-/// printing the exception a second time.
+/// A hook that runs and fails is reported here instead: the failure and the
+/// original both go through the default hook, which is `display_exception`'s
+/// `originalexcepthook`, so this answers `true` and the caller prints nothing.
 pub fn print_exception_via_excepthook(err: &mut PyError) -> bool {
     let Some(sys) = crate::importing::get_sys_module("sys") else {
         return false;
     };
-    // A missing name is a hook that is not there; `None` is a hook that is,
-    // and calling it is what reports it.
-    let Ok(hook) = crate::baseobjspace::getattr_str(sys, "excepthook") else {
-        return false;
-    };
-    if hook.is_null() {
-        return false;
-    }
     let _roots = pyre_object::gc_roots::push_roots();
     let sys_slot = pyre_object::gc_roots::shadow_stack_len();
     let _ = pyre_object::gc_roots::pin_root(sys);
-    let hook_slot = pyre_object::gc_roots::shadow_stack_len();
-    let _ = pyre_object::gc_roots::pin_root(hook);
     // Materialising the instance is what gives the hook something to report;
     // the `PyError`'s own fields are raw and this collector does not scan them,
     // so each of the three arguments is pinned as it is taken.
@@ -4012,6 +4080,22 @@ pub fn print_exception_via_excepthook(err: &mut PyError) -> bool {
         );
         drop(stored);
     }
+    // `display_exception` resolves the hook only once those stores are in
+    // place, so a `sys` whose attribute lookup runs Python -- a module class
+    // with its own `__getattribute__` -- reads the names already written.
+    // A missing name is a hook that is not there; `None` is a hook that is,
+    // and calling it is what reports it.
+    let Ok(hook) = crate::baseobjspace::getattr_str(
+        pyre_object::gc_roots::shadow_stack_get(sys_slot),
+        "excepthook",
+    ) else {
+        return false;
+    };
+    if hook.is_null() {
+        return false;
+    }
+    let hook_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(hook);
     let arguments = [
         pyre_object::gc_roots::shadow_stack_get(type_slot),
         pyre_object::gc_roots::shadow_stack_get(exc_slot),
@@ -4021,15 +4105,29 @@ pub fn print_exception_via_excepthook(err: &mut PyError) -> bool {
         pyre_object::gc_roots::shadow_stack_get(hook_slot),
         &arguments,
     );
-    if let Err(failure) = reported {
+    if let Err(mut failure) = reported {
         // `display_exception`'s `except BaseException` arm: the hook is named
-        // as the thing that failed, its own report is printed, and the answer
-        // is that the exception has *not* been reported -- the caller prints it
-        // below the `Original exception was:` header this leaves behind.
-        emit_report_to_host_stderr(b"Error calling sys.excepthook:\n");
-        eprint_exception(&failure, true);
-        emit_report_to_host_stderr(b"\nOriginal exception was:\n");
-        return false;
+        // as the thing that failed and its own report follows, both on the live
+        // `sys.stderr` the arm reads -- an application that replaced the stream
+        // is where its diagnostics belong, and the host seam beneath it would
+        // miss a capture buffer entirely.
+        emit_report_to_sys_stderr(b"Error calling sys.excepthook:\n");
+        report_through_default_excepthook(&mut failure);
+        emit_report_to_sys_stderr(b"\nOriginal exception was:\n");
+        // The arm falls out of the `try` into `originalexcepthook(etype,
+        // evalue, etraceback)`, so the original is reported from here onto that
+        // same stream.  Leaving it to the caller would split one report across
+        // two sinks, because the caller's printer writes to the seam.
+        if crate::builtins::sys_excepthook(&[
+            pyre_object::gc_roots::shadow_stack_get(type_slot),
+            pyre_object::gc_roots::shadow_stack_get(exc_slot),
+            pyre_object::gc_roots::shadow_stack_get(tb_slot),
+        ])
+        .is_err()
+        {
+            eprint_exception(err, true);
+        }
+        return true;
     }
     true
 }

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -939,14 +939,18 @@ fn decode_with_name(
     fname: &str,
     encoding: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
-    if !unsafe { pyre_object::bytesobject::is_bytes_like(w_obj) } {
-        return Err(bad_buffer_arg(w_obj));
-    }
+    // `make_decoder_wrapper`: decode a bytes buffer and return
+    // `(unicode, bytes_consumed)`.  The input is unwrapped with `bufferstr`,
+    // which reads any buffer -- a `memoryview` included -- and the decoding
+    // itself then runs on the `newbytes` built from what it read.
+    let data = decode_input_bytes(w_obj)?;
     let errors = codec_errors_arg(fname, 2, errors)?;
-    // PyPy `make_decoder_wrapper`: decode a bytes buffer and return
-    // `(unicode, bytes_consumed)`.
-    let consumed = unsafe { pyre_object::bytesobject::bytes_like_data(w_obj).len() };
-    let decode_method = crate::baseobjspace::getattr_str(w_obj, "decode")?;
+    let consumed = data.len();
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(w_bytes_from_bytes(&data));
+    let decode_method =
+        crate::baseobjspace::getattr_str(pyre_object::gc_roots::shadow_stack_get(sp), "decode")?;
     let decoded = crate::call::call_function_impl_result(
         decode_method,
         &[w_str_new(encoding), w_str_new(&errors)],
@@ -957,8 +961,19 @@ fn decode_with_name(
 /// Acquire the read-only bytes of a decoder input, reporting a decode-context
 /// TypeError (rather than the file-write helper's own wording) when the object
 /// is not a bytes-like buffer.
+///
+/// Only that one wording is replaced.  A buffer the decoder may not read --
+/// a strided `memoryview`, which `bufferstr` refuses because the bytes it
+/// would decode are not the ones the object exposes -- has already said so
+/// with the error the acquisition raised, and reporting it as a wrong argument
+/// type instead names the wrong thing.
 fn decode_input_bytes(w_obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
-    unsafe { crate::builtins::file_write_buffer_bytes(w_obj) }.map_err(|_| bad_buffer_arg(w_obj))
+    unsafe { crate::builtins::file_write_buffer_bytes(w_obj) }.map_err(|e| {
+        match e.kind == crate::PyErrorKind::TypeError {
+            true => bad_buffer_arg(w_obj),
+            false => e,
+        }
+    })
 }
 
 /// PyPy `interp_codecs.utf_{16,32}_ex_decode`: the three-value entry point
@@ -1084,8 +1099,11 @@ fn charmap_output(
         }
         Err(e) => return Err(e),
     };
-    if unsafe { pyre_object::bytesobject::is_bytes_like(w_ch) } {
-        out.extend_from_slice(unsafe { pyre_object::bytesobject::bytes_like_data(w_ch) });
+    // `Charmap_Encode.get` tests the table's value with `w_bytes`, so a
+    // `bytearray` falls through to the type error below with everything else
+    // the table is not allowed to give.
+    if unsafe { pyre_object::is_bytes(w_ch) } {
+        out.extend_from_slice(unsafe { pyre_object::bytesobject::w_bytes_data(w_ch) });
         Ok(true)
     } else if unsafe { pyre_object::is_int(w_ch) } {
         let x = unsafe { pyre_object::w_int_get_value(w_ch) };
@@ -1888,19 +1906,14 @@ fn invalid_escape_warning(prefix: &str, sequence: &str, octal: bool) -> String {
 }
 
 /// Acquire a backslash-escape decoder's input.  A `str` answers with its own
-/// bytes and any buffer producer with the bytes it exposes, which is what lets
-/// a `memoryview` -- including a sliced one, whose bytes are not contiguous
-/// with the object it was taken from -- reach the decoder.
+/// bytes; everything else is unwrapped the way the rest of the decoders in
+/// this module unwrap theirs, so the accepted buffer shapes are the same set
+/// and a strided `memoryview` is refused here as it is there.
 fn escape_decoder_input(w_obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
-    if unsafe { pyre_object::bytesobject::is_bytes_like(w_obj) } {
-        Ok(unsafe { pyre_object::bytesobject::bytes_like_data(w_obj) }.to_vec())
-    } else if unsafe { is_str(w_obj) } {
-        Ok(unsafe { w_str_get_wtf8(w_obj) }.as_bytes().to_vec())
-    } else if let Some(src) = crate::typedef::buffer_as_bytes_like(w_obj)? {
-        Ok(unsafe { pyre_object::bytesobject::bytes_like_data(src) }.to_vec())
-    } else {
-        Err(bad_buffer_arg(w_obj))
+    if unsafe { is_str(w_obj) } {
+        return Ok(unsafe { w_str_get_wtf8(w_obj) }.as_bytes().to_vec());
     }
+    decode_input_bytes(w_obj)
 }
 
 fn unicode_escape_decode_impl(

--- a/pyre/pyre-interpreter/src/module/_suggestions/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_suggestions/mod.rs
@@ -22,28 +22,36 @@ fn generate_suggestions(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
             crate::error::type_name_of(item)
         )));
     }
+    // `PyList_CheckExact`, so a list subclass is refused with everything else
+    // that is not a list.
     if !unsafe { is_exact_type(candidates, &LIST_TYPE) } {
         return Err(crate::PyError::type_error("candidates must be a list"));
     }
     let items = unsafe { w_list_items_copy_as_vec(candidates) };
-    let mut names = Vec::with_capacity(items.len());
-    for element in items {
-        if !unsafe { is_str(element) } {
+    for element in &items {
+        if !unsafe { is_str(*element) } {
             return Err(crate::PyError::type_error(
                 "all elements in 'candidates' must be strings",
             ));
         }
-        // A name carrying a lone surrogate has no `&str` view, and the search
-        // compares `char`s.  Drop it from the candidate set rather than
-        // reading it as UTF-8.
-        if let Some(name) = unsafe { w_str_get_value_opt(element) } {
-            names.push(name.to_string());
-        }
     }
-    let Some(wrong_name) = (unsafe { w_str_get_value_opt(item) }) else {
+    // `_Py_CalculateSuggestions` gives up on a set this large before it reads
+    // any name at all, so a candidate that has no UTF-8 encoding is never
+    // reached and never reported here either.
+    if items.len() >= crate::error::MAX_SUGGESTION_CANDIDATES {
         return Ok(w_none());
-    };
-    Ok(match crate::error::best_suggestion(&names, wrong_name) {
+    }
+    // `PyUnicode_AsUTF8AndSize` is what the search reads each name through,
+    // and a lone surrogate has no UTF-8 encoding: the failure is the one the
+    // strict encoder reports, not a name quietly left out of the ranking.
+    // The wrong name is read first, which is the one order in which a
+    // candidate equal to it cannot be the name that reports the failure.
+    let wrong_name = crate::baseobjspace::str_utf8_w(item)?.to_string();
+    let mut names = Vec::with_capacity(items.len());
+    for element in items {
+        names.push(crate::baseobjspace::str_utf8_w(element)?.to_string());
+    }
+    Ok(match crate::error::best_suggestion(&names, &wrong_name) {
         Some(name) => w_str_new(&name),
         None => w_none(),
     })

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -4545,20 +4545,22 @@ fn call_decode_error_handler(
     // in: the reread object (unicodeobject.c insize), or the one it started
     // on (`multibytecodec_decerror`'s `size`).
     let length = new_bytes.as_ref().map_or(data.len(), Vec::len) as i64;
-    let mut newpos =
-        match crate::baseobjspace::int_w(pyre_object::gc_roots::shadow_stack_get(sp + 4)) {
-            Ok(n) => n,
-            Err(e) => {
-                if e.kind == crate::PyErrorKind::OverflowError {
-                    -1
-                } else {
-                    return Err(e);
-                }
+    // interp_codecs.py `call_errorhandler`: the negative fold sits in the
+    // `else` clause of the conversion, so it runs only when `int_w` succeeded.
+    // A position too large for the machine integer becomes -1 and reaches the
+    // bounds test unfolded, which rejects it; folding it would land on 0 for a
+    // one-unit input and hand the same span back to the handler forever.
+    let newpos = match crate::baseobjspace::int_w(pyre_object::gc_roots::shadow_stack_get(sp + 4)) {
+        Ok(n) if n < 0 => n + length,
+        Ok(n) => n,
+        Err(e) => {
+            if e.kind == crate::PyErrorKind::OverflowError {
+                -1
+            } else {
+                return Err(e);
             }
-        };
-    if newpos < 0 {
-        newpos += length;
-    }
+        }
+    };
     if newpos < 0 || newpos > length {
         return Err(crate::PyError::new(
             crate::PyErrorKind::IndexError,
@@ -4644,7 +4646,11 @@ pub(crate) fn call_registered_encode_error_handler(
     // newpos folds against the source CHARACTER length and resumes into the
     // original code-point sequence.
     let length = char_len as i64;
-    let mut newpos = match crate::baseobjspace::int_w(w_newpos) {
+    // The negative fold applies only to a position that converted, exactly as
+    // in the decode branch above: an overflowing one stays -1 so the bounds
+    // test below rejects it.
+    let newpos = match crate::baseobjspace::int_w(w_newpos) {
+        Ok(n) if n < 0 => n + length,
         Ok(n) => n,
         Err(e) => {
             if e.kind == crate::PyErrorKind::OverflowError {
@@ -4654,9 +4660,6 @@ pub(crate) fn call_registered_encode_error_handler(
             }
         }
     };
-    if newpos < 0 {
-        newpos += length;
-    }
     if newpos < 0 || newpos > length {
         return Err(crate::PyError::new(
             crate::PyErrorKind::IndexError,

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1984,21 +1984,11 @@ fn run_module(module: &str, no_site: bool) {
     })();
 
     if let Err(e) = result {
-        if e.kind == PyErrorKind::SystemExit {
-            finalize_system_exit(e, canonical, ec_ptr);
-        }
-        let is_keyboard_interrupt = is_keyboard_interrupt(&e);
-        // targetpypystandalone.py:88 `finally: space.finish()` — finalize on
-        // every exit path, not only on SystemExit.  Print first: the raw
-        // `PyObjectRef` fields of `e` are not GC-visible and `finalize_runtime`
-        // collects.
-        pyre_interpreter::eprint_exception(&e, true);
-        finalize_runtime(canonical, ec_ptr);
-        maybe_print_jit_stats();
-        if is_keyboard_interrupt {
-            terminate_by_sigint();
-        }
-        std::process::exit(1);
+        // `_run_module_as_main` ends the same run as a script does, so its
+        // failure takes the same exit: `app_main.py` reports every top-level
+        // exception through `display_exception`, which is what reaches a
+        // `sys.excepthook` the module installed.
+        handle_main_error(e, canonical, ec_ptr);
     }
     finalize_runtime(canonical, ec_ptr);
     maybe_print_jit_stats();


### PR DESCRIPTION
Follow-ups to the review on #1482, each one checked against CPython 3.14.2 **and** PyPy 7.3.20 before it was written. Nineteen inline findings were triaged; seven were confirmed defects where pyre answered differently from *both* oracles, five were declined because pyre already matches upstream, and the rest are recorded below.

## Confirmed and fixed

| | CPython | PyPy 7.3.20 | pyre (before) |
|---|---|---|---|
| charmap handler position overflow | `OverflowError` | `IndexError: position -1` | **hangs** |
| `sys.excepthook` raises | prints `Original exception was:` + original | same | original exception swallowed |
| `sys.last_exc` / `last_type` / `last_value` / `last_traceback` | all four set | the three that exist at 3.11 | none set |
| `-m` module raises | installed hook runs | same | hook bypassed |
| `charmap_encode` table returns a `bytearray` | `TypeError` | `TypeError` | `(b'x', 1)` |
| `ascii_decode` / `latin_1_decode` of a `memoryview` | `('abc', 3)` | `('abc', 3)` | `TypeError` |
| escape decoders on a strided `memoryview` | `BufferError` | `BufferError` | `('ace', 3)` |

The hang is the one worth reading twice. `interp_codecs.call_errorhandler` folds a negative handler position against the length inside the **`else` clause of the conversion**, so it runs only when `int_w` succeeded; an overflowing position keeps the `-1` and the bounds test rejects it. pyre folded the sentinel too, reached 0 for a one-unit input, and handed the same span back to the handler forever.

Two more, from measuring rather than from a report:

- **`compile()` incomplete-input classification takes the mode.** `PyCF_ALLOW_INCOMPLETE_INPUT` is read by the parser the mode selects. Measuring all 21 cells of *(seven unfinished sources) × (exec, eval, single)* on CPython: pyre matched 15, now matches 19. `eval` reports a source that stops mid-expression as a `SyntaxError`, and a single-quoted literal still open at the end of the source is unfinished input only for `single`. The two remaining cells are RustPython parser differences in `single` mode, not classification, and are not asserted.
- **`_suggestions` measures UTF-8 bytes.** `levenshtein_distance` reads each name through `PyUnicode_AsUTF8AndSize` and indexes that buffer, so every length and the ratio cutoff are byte counts and `_substitution_cost` folds case over ASCII alone. pyre counted code points — a different ranking, not the same one in other units. A search over random non-ASCII inputs found the discriminators, and CPython agrees with the byte model on each: `_generate_suggestions(["αaαaa", "日日é"], "αx日é")` answers `'日日é'`, where counting code points answers `None`. A lone surrogate now reports the strict encoder's `UnicodeEncodeError` instead of being dropped from the candidate set, and the `MAX_CANDIDATE_ITEMS` test runs first because the search gives up on a set that large before it reads any name.

GC rooting: `sys_excepthook` and the three `Unicode*Error` constructors hold a native argument copy across an allocation — the two `w_int_new` calls, or renderers that run Python — and a collection does not rewrite that copy. Each now publishes the receiver and its arguments on the shadow stack and reads them back from their slots, as `exc_syntax_error_init` does.

## Declined, with the evidence

- **"`= *err` moves a non-`Copy` `DispatchError`"** (Critical) — `RaiseException { exc: i64, resume_position: usize }` binds only `Copy` fields and the `Box` lives in a different variant. The build is the refutation.
- **charmap `TypeError` should name the value's own type** — `Charmap_Encode.get` hardcodes `"not str"` upstream too.
- **partial malformed escapes with `final=False`** — PyPy returns `('', 0)`, exactly as pyre does.
- **`_suggestions` should accept `list` subclasses** — CPython uses `PyList_CheckExact` and rejects them.
- **re-extract LLBC** — already done.

## Recorded, not changed

The recursive-portal bail arm in `handle_jitexception` is **not reachable**. `handle_jitexception_dispatch` answers with a bail only for an `exc` that already was one — refused ahead of the walk — or for a runner that reported one; the latter needs a `portal_runner`, and every caller that runs a program passes `None` (`run_forever` hardcodes it, `convert_and_run_from_pyjitpl` passes it). The only `Some` callers are this module's own tests, and they read no terminal image. The comment there claimed the inner chain had released the image; it now records the reachability fact, why `bh` is not the image to publish, and that `trace.rs` already logs the shape if a runner is ever wired.

CodeRabbit's `release_delivers_no_finalizer` note is about #1505's code on main, outside this diff.

## Verification

Seven snippets carry the above, all `gate=1`, all green under CPython and every backend. Full local gate at the reviewed tree, with no HEAD movement during the run:

```
LLBC extract, dynasm / cranelift / wasm guest / wasm runner builds   rc=0
cargo test --all --no-default-features --features dynasm,cpyext      rc=0  (195 suites, 0 failures)
pyre/check.py   ALL PASSED: dynasm 497/497, cranelift 497/497, wasm 489/489, 3/3 backend runs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fro6nx8s5XVU1D9AhTQ31L


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `sys.excepthook` failure reporting, including correct stderr output and preservation of the original exception.
  - Improved `python -m` error handling to consistently honor custom exception hooks.
  - Fixed codec handling for buffer inputs, invalid error-handler positions, and unsupported character-map replacements.
  - Corrected incomplete-input classification across compile modes.
  - Improved name suggestions for Unicode, casing, and invalid candidate values.

- **Tests**
  - Added coverage for codec buffers, error handlers, incomplete input, exception hooks, and suggestion generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->