### PR TITLE
perf: port call_method_opt, cheapen five repeated lookups, publish GC roots as runs

### DIFF
--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -2971,6 +2971,53 @@ pub fn gc_current_object_address(addr: usize) -> usize {
     }
 }
 
+/// The published nursery window `[start, end)` and the tagged-pointer setting,
+/// or `None` when the published fast path is disarmed and the hook chain has
+/// to answer per address.
+///
+/// [`gc_is_nursery_object`] reloads all four published words for every address
+/// it is handed, and [`gc_sync::foreign_mutator_seen`] is a second ordered
+/// load next to it.  A caller normalizing a *run* of shadow-stack slots asks
+/// the identical question once per slot, so `n` livevars pay `2n` ordered
+/// loads to consult operands that are the same for the whole run.  Reading the
+/// window once and testing the range inline turns the per-slot cost into a
+/// compare pair.
+#[inline]
+pub fn published_nursery_window() -> Option<(usize, usize, bool)> {
+    if !PUBLISHED_NURSERY_ARMED.load(std::sync::atomic::Ordering::Acquire) {
+        return None;
+    }
+    Some((
+        PUBLISHED_NURSERY_START.load(std::sync::atomic::Ordering::Relaxed),
+        PUBLISHED_NURSERY_END.load(std::sync::atomic::Ordering::Relaxed),
+        PUBLISHED_NURSERY_TAGGED.load(std::sync::atomic::Ordering::Relaxed),
+    ))
+}
+
+/// [`gc_current_object_address`] against a window a caller already read with
+/// [`published_nursery_window`].
+///
+/// The range test is the whole of `is_nursery_object_start` for the armed
+/// path: `start` is a live mapping, so a null address is below it and needs no
+/// separate test, and the tagged case only has to reject an odd word.
+#[inline]
+pub fn gc_current_object_address_in_window(
+    addr: usize,
+    start: usize,
+    end: usize,
+    tagged: bool,
+) -> usize {
+    if addr < start || addr >= end || (tagged && addr & 1 == 1) {
+        return addr;
+    }
+    let hdr = unsafe { header::header_of(addr) };
+    if unsafe { (*hdr).is_forwarded() } {
+        unsafe { header::GcHeader::forwarding_address(hdr) }
+    } else {
+        addr
+    }
+}
+
 /// Process-global callbacks for registering/removing a Rust-stack slot
 /// as a GC root with the currently active backend. Used by host-side
 /// allocators whose callers need to keep a

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9723,16 +9723,74 @@ static METHOD_CACHE: std::sync::LazyLock<parking_lot::Mutex<MethodCache>> =
 /// is a content hash; use the same FNV-1a content digest over the WTF-8 byte
 /// view.
 fn method_hash(version_tag: u64, name: &Wtf8) -> usize {
-    let mut name_hash: u64 = 0xcbf2_9ce4_8422_2325;
-    for &b in name.as_bytes() {
-        name_hash ^= b as u64;
-        name_hash = name_hash.wrapping_mul(0x0000_0100_0000_01b3);
-    }
     const SHIFT2: u32 = 64 - METHOD_CACHE_SIZE_EXP;
     const SHIFT1: u32 = SHIFT2 - 5;
-    let product = version_tag.wrapping_mul(name_hash);
+    let product = version_tag.wrapping_mul(name_content_hash(name));
     let h = (product ^ (product << SHIFT1)) >> SHIFT2;
     (h as usize) & (METHOD_CACHE_SIZE - 1)
+}
+
+/// The `compute_hash(name)` half of [`method_hash`].
+///
+/// RPython reads a string's hash off the string object, where it is computed
+/// once and cached (`rstr.ll_strhash`), so upstream's probe pays no per-lookup
+/// digest at all.  A borrowed `&Wtf8` carries no such slot, so the digest is
+/// recomputed here — a byte-at-a-time FNV chain over a name that is almost
+/// always a dunder was the single most expensive step of the probe.  This is
+/// the same FNV-1a mixing applied to whole 8-byte words, so a `__init__`-sized
+/// name costs one round instead of eight.  Only the slot the pair lands in
+/// depends on it; the entry's validity is still the exact `(version, name)`
+/// match below.
+#[inline]
+fn name_content_hash(name: &Wtf8) -> u64 {
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let bytes = name.as_bytes();
+    let mut hash = OFFSET ^ (bytes.len() as u64);
+    let mut chunks = bytes.chunks_exact(8);
+    for chunk in &mut chunks {
+        hash ^= u64::from_le_bytes(chunk.try_into().unwrap());
+        hash = hash.wrapping_mul(PRIME);
+    }
+    let rest = chunks.remainder();
+    if !rest.is_empty() {
+        let mut tail = [0u8; 8];
+        tail[..rest.len()].copy_from_slice(rest);
+        hash ^= u64::from_le_bytes(tail);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+/// `typeobject.py:541` `cache.names[method_hash] == name`, and the same
+/// comparison in `mapdict.py`'s `_find_map_attr_cache`.
+///
+/// Upstream compares two interned RPython strings by identity; the cache here
+/// owns a copy of the name, so the comparison is by content.  Slice equality
+/// bottoms out in a `memcmp` call, which for the dunder-sized names that
+/// dominate this probe costs more than the comparison itself — compare whole
+/// words inline instead.
+#[inline]
+pub(crate) fn cache_name_eq(cached: &Wtf8, name: &Wtf8) -> bool {
+    let (a, b) = (cached.as_bytes(), name.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i + 8 <= a.len() {
+        let (x, y) = (&a[i..i + 8], &b[i..i + 8]);
+        if u64::from_ne_bytes(x.try_into().unwrap()) != u64::from_ne_bytes(y.try_into().unwrap()) {
+            return false;
+        }
+        i += 8;
+    }
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
 }
 
 /// typeobject.py `_pure_version_tag` — the `@elidable_promote`
@@ -9867,7 +9925,11 @@ unsafe fn _cached_lookup_where_name(
     // Probe without holding the borrow across the MRO walk below.
     let hit = {
         let cache = METHOD_CACHE.lock();
-        if cache.versions[h] == version_tag && cache.names[h].as_deref() == Some(name) {
+        if cache.versions[h] == version_tag
+            && cache.names[h]
+                .as_deref()
+                .is_some_and(|cached| cache_name_eq(cached, name))
+        {
             // A valid entry with null pointers is the cached negative result.
             Some(cache.lookup_where[h])
         } else {
@@ -13499,19 +13561,115 @@ pub fn call_args_and_c_profile_args(
     pyre_object::gc_roots::shadow_stack_get(result_slot)
 }
 
-/// PyPy: baseobjspace.py `call_method`.
+/// `callmethod.py call_method_opt` — the std objspace's `space.call_method`.
+///
+/// `objspace.py:790` overrides `baseobjspace.py call_method` with this one, so
+/// the plain `getattr` + `call_function` pair below is the FALLBACK arm, not
+/// the whole method.  The fast arm reaches the descriptor on the type and
+/// passes the receiver as its first argument, which is the same call
+/// `object.__getattribute__` would have made after materialising a bound
+/// method — the materialisation is what it skips.
 ///
 /// Returns `PY_NULL` and stashes the error in `PENDING_CALL_ERROR` when
 /// either the attribute lookup or the call itself raises — same bare-
 /// PyObjectRef contract as `call_function_impl_raw`.
 pub fn call_method(obj: PyObjectRef, methname: &str, args: &[PyObjectRef]) -> PyObjectRef {
-    match getattr_str(obj, methname) {
-        Ok(method) => call_function(method, args),
+    match method_descriptor_shortcut(obj, methname) {
+        Ok(Some(w_descr)) => {
+            // `callmethod.py:142` — `space.call_function(w_descr, w_obj, *arg_w)`.
+            // `Arguments.prepend` builds the receiver-first list upstream; the
+            // vector below is that list, filled from the published slots so a
+            // collection inside the fill cannot leave a pre-move address in it.
+            let roots = pyre_object::gc_roots::push_roots();
+            let base = roots.publish(&[w_descr, obj]);
+            let arg_base = roots.publish(args);
+            let mut call_args = Vec::with_capacity(1 + args.len());
+            call_args.push(roots.get(base + 1));
+            for i in 0..args.len() {
+                call_args.push(roots.get(arg_base + i));
+            }
+            call_function(roots.get(base), &call_args)
+        }
+        Ok(None) => match getattr_str(obj, methname) {
+            // `callmethod.py:143-145` — `w_meth = space.getattr(w_obj, w_name)`.
+            Ok(method) => call_function(method, args),
+            Err(e) => {
+                crate::call::set_call_error(e);
+                pyre_object::PY_NULL
+            }
+        },
         Err(e) => {
             crate::call::set_call_error(e);
             pyre_object::PY_NULL
         }
     }
+}
+
+/// `callmethod.py call_method_opt`, for the callers that propagate a
+/// `PyError` rather than reading it back out of `PENDING_CALL_ERROR`.
+pub fn call_method_result(
+    obj: PyObjectRef,
+    methname: &str,
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, PyError> {
+    if let Some(w_descr) = method_descriptor_shortcut(obj, methname)? {
+        let roots = pyre_object::gc_roots::push_roots();
+        let base = roots.publish(&[w_descr, obj]);
+        let arg_base = roots.publish(args);
+        let mut call_args = Vec::with_capacity(1 + args.len());
+        call_args.push(roots.get(base + 1));
+        for i in 0..args.len() {
+            call_args.push(roots.get(arg_base + i));
+        }
+        return crate::call::call_function_impl_result(roots.get(base), &call_args);
+    }
+    let method = getattr_str(obj, methname)?;
+    crate::call::call_function_impl_result(method, args)
+}
+
+/// `callmethod.py call_method_opt:134-142` — the descriptor a method call may
+/// reach without building a bound method, or `None` when the receiver's shape
+/// sends the call through `space.getattr`.
+///
+/// The three conditions are upstream's, in upstream's order: the type answers
+/// attributes through the default `__getattribute__`, the name resolves on the
+/// type to a method descriptor, and the instance carries no entry that would
+/// shadow it.  `getdictvalue` is the one of the three that can run app-level
+/// code (a mapping proxy's `__eq__` on a colliding key), so its error is
+/// surfaced rather than swallowed into a decline.
+fn method_descriptor_shortcut(
+    obj: PyObjectRef,
+    methname: &str,
+) -> Result<Option<PyObjectRef>, PyError> {
+    if obj.is_null() {
+        return Ok(None);
+    }
+    // `callmethod.py:134` — `w_type = space.type(w_obj)`.
+    let Some(w_type) = crate::typedef::r#type(obj) else {
+        return Ok(None);
+    };
+    // `callmethod.py:135` — `if w_type.has_object_getattribute():`.
+    if !unsafe { has_object_getattribute(w_type.as_ptr()) } {
+        return Ok(None);
+    }
+    // `callmethod.py:136` — `w_descr = space.lookup(w_obj, methname)`.
+    let Some(w_descr) = (unsafe { lookup_in_type(w_type.as_ptr(), methname) }) else {
+        return Ok(None);
+    };
+    // `callmethod.py:137` — `space.type(w_descr).flag_method_descriptor`.
+    let Some(w_descr_type) = crate::typedef::r#type(w_descr) else {
+        return Ok(None);
+    };
+    if !unsafe { pyre_object::typeobject::w_type_get_flag_method_descriptor(w_descr_type.as_ptr()) }
+    {
+        return Ok(None);
+    }
+    // `callmethod.py:138-139` — `w_value = w_obj.getdictvalue(space, methname)`;
+    // an instance entry of that name is the bound-method path's answer.
+    if getdictvalue(obj, methname)?.is_some() {
+        return Ok(None);
+    }
+    Ok(Some(w_descr))
 }
 
 /// PyPy: baseobjspace.py `call_function`.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -113,11 +113,9 @@ pub(crate) unsafe fn walk_pending_hash_error_area(
 #[majit_macros::dont_look_inside]
 pub fn clear_method_cache() {
     let mut cache = METHOD_CACHE.lock();
-    cache.versions.fill(0);
-    cache.names.fill(None);
-    cache
-        .lookup_where
-        .fill((std::ptr::null_mut(), std::ptr::null_mut()));
+    for entry in cache.entries.iter_mut() {
+        *entry = MethodCacheEntry::EMPTY;
+    }
 }
 
 /// CPython 3.14 `dict_unhashable_type` (`Objects/dictobject.c`) parity.
@@ -1379,20 +1377,17 @@ pub(crate) unsafe fn get_and_call_function(
     // argument list from the shadow stack.  Both slices are published before the
     // first `normalize_roots` so nothing is still invisible to a foreign
     // collector once this mutator starts entering safepoints.
+    // Every slot access goes through the scope's cached root-stack cell: the
+    // free `gc_roots` functions re-resolve the thread local per call, which on
+    // Darwin is an out-of-line `_tlv_get_addr`, and this arm touches a slot
+    // once per operand and once per argument.  The two slices are adjacent on
+    // the stack, so the whole published set normalizes as one run.
     let _roots = pyre_object::gc_roots::push_roots();
-    let base = pyre_object::gc_roots::publish_roots(&[w_descr, w_obj, w_type]);
-    let args_base = pyre_object::gc_roots::publish_roots(args_w);
-    pyre_object::gc_roots::normalize_roots(base, 3);
-    pyre_object::gc_roots::normalize_roots(args_base, args_w.len());
-    use pyre_object::gc_roots::shadow_stack_get;
-    let w_impl = unsafe {
-        get(
-            shadow_stack_get(base),
-            shadow_stack_get(base + 1),
-            shadow_stack_get(base + 2),
-        )
-    }?
-    .unwrap_or_else(|| shadow_stack_get(base));
+    let base = _roots.publish(&[w_descr, w_obj, w_type]);
+    let args_base = _roots.publish(args_w);
+    _roots.normalize(base, 3 + args_w.len());
+    let w_impl = unsafe { get(_roots.get(base), _roots.get(base + 1), _roots.get(base + 2)) }?
+        .unwrap_or_else(|| _roots.get(base));
     // One `Vec` at every arity, the shape the fast path above already builds:
     // `with_capacity`/`push` lower to `newlist`/`append`.  The fixed
     // `[PY_NULL; N]` leg this replaced ended in `<[T; N]>::index(&array,
@@ -1403,7 +1398,7 @@ pub(crate) unsafe fn get_and_call_function(
     // length, so no push reallocates between the shadow-stack reads.
     let mut reloaded = Vec::with_capacity(args_w.len());
     for i in 0..args_w.len() {
-        reloaded.push(shadow_stack_get(args_base + i));
+        reloaded.push(_roots.get(args_base + i));
     }
     crate::call::call_function_impl_result(w_impl, reloaded.as_slice())
 }
@@ -9691,10 +9686,28 @@ unsafe fn lookup_where_pair_wtf8(
 /// (`typeobject.py:541` `cache.names[method_hash] == name`). A fill owns one
 /// copy; a hit compares the incoming borrowed name without allocating or
 /// entering the Python-string intern table. `None` is an empty slot.
+///
+/// The three arrays upstream keeps are one array of one entry here.  A probe
+/// reads all three of a slot's words and nothing else in the row, so three
+/// parallel `Vec`s make it touch three cache lines to answer one question;
+/// packed, the version test, the name test and the answer share a line.
+#[derive(Clone)]
+struct MethodCacheEntry {
+    version: u64,
+    lookup_where: (PyObjectRef, PyObjectRef),
+    name: Option<Wtf8Buf>,
+}
+
+impl MethodCacheEntry {
+    const EMPTY: Self = Self {
+        version: 0,
+        lookup_where: (std::ptr::null_mut(), std::ptr::null_mut()),
+        name: None,
+    };
+}
+
 struct MethodCache {
-    versions: Vec<u64>,
-    names: Vec<Option<Wtf8Buf>>,
-    lookup_where: Vec<(PyObjectRef, PyObjectRef)>,
+    entries: Vec<MethodCacheEntry>,
 }
 
 // PyPy stores this cache on the shared object space. The mutex below protects
@@ -9709,9 +9722,7 @@ const METHOD_CACHE_SIZE: usize = 1 << METHOD_CACHE_SIZE_EXP;
 static METHOD_CACHE: std::sync::LazyLock<parking_lot::Mutex<MethodCache>> =
     std::sync::LazyLock::new(|| {
         parking_lot::Mutex::new(MethodCache {
-            versions: vec![0u64; METHOD_CACHE_SIZE],
-            names: vec![None; METHOD_CACHE_SIZE],
-            lookup_where: vec![(std::ptr::null_mut(), std::ptr::null_mut()); METHOD_CACHE_SIZE],
+            entries: vec![MethodCacheEntry::EMPTY; METHOD_CACHE_SIZE],
         })
     });
 
@@ -9925,13 +9936,15 @@ unsafe fn _cached_lookup_where_name(
     // Probe without holding the borrow across the MRO walk below.
     let hit = {
         let cache = METHOD_CACHE.lock();
-        if cache.versions[h] == version_tag
-            && cache.names[h]
+        let entry = &cache.entries[h];
+        if entry.version == version_tag
+            && entry
+                .name
                 .as_deref()
                 .is_some_and(|cached| cache_name_eq(cached, name))
         {
             // A valid entry with null pointers is the cached negative result.
-            Some(cache.lookup_where[h])
+            Some(entry.lookup_where)
         } else {
             None
         }
@@ -9945,9 +9958,11 @@ unsafe fn _cached_lookup_where_name(
     // `walk_method_cache_gc`, skipped on clean minor collections.
     pyre_object::gc_roots::mark_prebuilt_roots_dirty();
     let mut cache = METHOD_CACHE.lock();
-    cache.versions[h] = version_tag;
-    cache.names[h] = Some(name.to_owned());
-    cache.lookup_where[h] = tup;
+    cache.entries[h] = MethodCacheEntry {
+        version: version_tag,
+        lookup_where: tup,
+        name: Some(name.to_owned()),
+    };
     tup
 }
 
@@ -9967,7 +9982,11 @@ unsafe fn _cached_lookup_where_name(
 /// must be forwarded here or a later hit would read a stale address.
 pub(crate) unsafe fn walk_method_cache_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) {
     let mut cache = METHOD_CACHE.lock();
-    for (w_class, w_value) in cache.lookup_where.iter_mut() {
+    for MethodCacheEntry {
+        lookup_where: (w_class, w_value),
+        ..
+    } in cache.entries.iter_mut()
+    {
         // Empty / negative-cache slots hold nulls: nothing to forward.
         if !w_class.is_null() {
             forward(w_class);
@@ -13583,6 +13602,10 @@ pub fn call_method(obj: PyObjectRef, methname: &str, args: &[PyObjectRef]) -> Py
             let roots = pyre_object::gc_roots::push_roots();
             let base = roots.publish(&[w_descr, obj]);
             let arg_base = roots.publish(args);
+            // `publish` writes the raw words; the set is only complete once
+            // both slices are on the stack, which is why the forwarding query
+            // runs here rather than per slice.
+            roots.normalize(base, 2 + args.len());
             let mut call_args = Vec::with_capacity(1 + args.len());
             call_args.push(roots.get(base + 1));
             for i in 0..args.len() {
@@ -13616,6 +13639,8 @@ pub fn call_method_result(
         let roots = pyre_object::gc_roots::push_roots();
         let base = roots.publish(&[w_descr, obj]);
         let arg_base = roots.publish(args);
+        // See `call_method`: one query for the whole published set.
+        roots.normalize(base, 2 + args.len());
         let mut call_args = Vec::with_capacity(1 + args.len());
         call_args.push(roots.get(base + 1));
         for i in 0..args.len() {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1066,6 +1066,12 @@ fn call_builtin_code_positional(code: PyObjectRef, args: &[PyObjectRef]) -> PyRe
     // indirect Rust function-pointer call updates the outer shadow slots but
     // not the copied native slice, so mirror the gateway's own root frame and
     // reload immediately before invoking the builtin.
+    //
+    // Pinned one at a time rather than published as a run: the batched shape
+    // reorders this graph's pending-callee queue, and `builtin_code_call_positional`
+    // below then reaches `getcalldescr` for the `BuiltinCodeFn` PBC family while
+    // the witness graph it types the indirect call against is still a shell
+    // whose return type reads Void, which panics the codewriter.
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = _roots.base();
     let _ = _roots.pin_root(code);
@@ -3641,11 +3647,14 @@ pub fn call_function_impl_result(
     // pointers, so establish the same roots before the first collecting call
     // and dispatch from freshly reloaded values.
     let _roots = pyre_object::gc_roots::push_roots();
-    let root_base = _roots.base();
-    let _ = _roots.pin_root(callable);
-    for &arg in args {
-        let _ = _roots.pin_root(arg);
-    }
+    // One publish for the whole livevar set, then one normalize over the run:
+    // `pin_root` per value would query after the first write, and each query
+    // re-reads the nursery window and the foreign-mutator flag that the whole
+    // set shares.  This is the `publish_roots` + `normalize_roots` shape
+    // `pin_roots` documents for a set that does not sit in one slice.
+    let root_base = _roots.publish(&[callable]);
+    let _ = _roots.publish(args);
+    let roots_moved = _roots.normalize_moved(root_base, 1 + args.len());
 
     // A JIT prologue may have published an overflow before entering this
     // residual dispatcher, so preserve that pending exception.  Do not run a
@@ -3664,11 +3673,20 @@ pub fn call_function_impl_result(
     // `<[T; N]>::index(&array, ..len)` and prevented the whole call dispatcher
     // from entering two-phase translation; the meta-tracer can virtualize
     // this orthodox list on the common fixed-arity paths.
-    let mut rooted_args = Vec::with_capacity(args.len());
-    for i in 0..args.len() {
-        rooted_args.push(_roots.get(root_base + 1 + i));
-    }
-    let args = rooted_args.as_slice();
+    //
+    // Only owed when the publish above actually followed a forwarding stub.
+    // The entry stack check cannot collect on its `Ok` leg -- it reads and
+    // clears a thread-local and builds an error on the other one -- so an
+    // unmoved run means the incoming slice already holds the live words, and
+    // rebuilding it would allocate a list per call to copy them.
+    let rooted_args = roots_moved.then(|| {
+        let mut rooted_args = Vec::with_capacity(args.len());
+        for i in 0..args.len() {
+            rooted_args.push(_roots.get(root_base + 1 + i));
+        }
+        rooted_args
+    });
+    let args = rooted_args.as_deref().unwrap_or(args);
 
     // Binding an override descriptor below runs `baseobjspace::get`, whose
     // property and general `__get__` arms execute Python.  That updates the
@@ -3678,7 +3696,7 @@ pub fn call_function_impl_result(
     let reloaded_args = || {
         let mut reloaded = Vec::with_capacity(arg_count);
         for i in 0..arg_count {
-            reloaded.push(pyre_object::gc_roots::shadow_stack_get(root_base + 1 + i));
+            reloaded.push(_roots.get(root_base + 1 + i));
         }
         reloaded
     };

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -6026,6 +6026,7 @@ pub unsafe fn create_all_slots(
                 } else {
                     (*base_layout).typedef_hasdict
                 },
+                dict_data_slot: pyre_object::typeobject::DICT_DATA_SLOT_UNRESOLVED,
             })
         };
         pyre_object::w_type_set_layout(w_type, layout);

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -1310,14 +1310,18 @@ impl MapAttrCache {
 /// object space.  Pyre's free-threaded execution contexts share that space, so
 /// the cache remains process/interpreter-owned and is synchronized rather than
 /// duplicated through TLS.
-static MAP_ATTR_CACHE: LazyLock<Mutex<MapAttrCache>> =
-    LazyLock::new(|| Mutex::new(MapAttrCache::new()));
+// `parking_lot::Mutex` rather than `std::sync::Mutex`: upstream's cache is
+// `space.fromcache(MapAttrCache)`, reached with nothing but the GIL, so every
+// cycle this lock costs is pyre's own.  The std lock adds a poison flag this
+// cache has no use for — the probe below cannot panic while holding it.
+static MAP_ATTR_CACHE: LazyLock<parking_lot::Mutex<MapAttrCache>> =
+    LazyLock::new(|| parking_lot::Mutex::new(MapAttrCache::new()));
 
 /// interp_gc.py — clear `space.fromcache(MapAttrCache)` before an
 /// explicit full collection so cached map nodes do not retain stale entries.
 #[majit_macros::dont_look_inside]
 pub fn clear_map_attr_cache() {
-    MAP_ATTR_CACHE.lock().unwrap().clear();
+    MAP_ATTR_CACHE.lock().clear();
 }
 
 /// `objectmodel.compute_hash(name)` for a (utf8-encoded) str (mapdict.py).
@@ -1367,12 +1371,14 @@ pub unsafe fn find_map_attr(self_node: MapRef, name: &Wtf8, attrkind: u16) -> Op
     let product = attrs_as_int.wrapping_mul(hash_selector) as u64;
     let attr_hash = ((product ^ (product << SHIFT1)) >> SHIFT2) as usize;
 
-    let mut cache = MAP_ATTR_CACHE.lock().unwrap();
+    let mut cache = MAP_ATTR_CACHE.lock();
     // mapdict.py:104 keeps the name by reference; pyre's slot owns its bytes,
     // so a fill that lands on a bucket already naming this attribute keeps the
     // buffer rather than reallocating it.  Which name a bucket holds is fixed
     // by the hash, so this is the ordinary case for a re-filled bucket.
-    let name_matches = cache.names[attr_hash].as_deref() == Some(name);
+    let name_matches = cache.names[attr_hash]
+        .as_deref()
+        .is_some_and(|cached| crate::baseobjspace::cache_name_eq(cached, name));
     if name_matches && cache.attrs[attr_hash] == self_node && cache.indexes[attr_hash] == attrkind {
         let cached = cache.cached_attrs[attr_hash];
         return if cached.is_null() { None } else { Some(cached) };
@@ -6206,7 +6212,7 @@ mod tests {
     #[test]
     fn find_map_attr_cached_matches_uncached_on_hit_and_miss() {
         unsafe {
-            MAP_ATTR_CACHE.lock().unwrap().clear();
+            MAP_ATTR_CACHE.lock().clear();
             let (_term, a, b) = build_chain();
             // first call populates the cache, second hits it
             assert_eq!(find_map_attr(b, wn("a"), DICT), Some(a));

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -718,6 +718,30 @@ pub struct PyCode {
     /// `PY_NULL` until first realized by [`w_code_name_obj`]; the storage,
     /// immortality and root-walk argument are `w_qualname`'s verbatim.
     pub w_name: PyObjectRef,
+    /// The last `(addrq, line)` pair [`w_code_addr2line`] resolved for this
+    /// code object, packed as `addrq << 32 | line as u32`.
+    ///
+    /// `_PyCode_CheckLineNumber` restarts the linetable decode at the first
+    /// range on every call, so an offset deep in a function costs a walk
+    /// proportional to how far in it sits.  The offsets asked about repeat:
+    /// `pytraceback.py record_application_traceback` resolves `tb_lineno` at
+    /// the moment the traceback node is built, so a line that raises in a loop
+    /// asks the same question every iteration, and `f_lineno` on a suspended
+    /// frame does the same.  Both inputs the walk reads — `co_linetable` on
+    /// the `CodeObject` and [`PyCode::co_firstlineno_raw`] — are fixed once
+    /// the wrapper is published (`code.replace` boxes a fresh one), so a
+    /// repeat of the previous question already has its answer.
+    ///
+    /// [`ADDR2LINE_MEMO_EMPTY`] is the unset value: it spells an `addrq` no
+    /// memoised query carries, since the negative offsets answer
+    /// `co_firstlineno` without walking anything.
+    ///
+    /// Direct-mapped over [`ADDR2LINE_MEMO_WAYS`] slots rather than a single
+    /// one: the offsets a loop asks about alternate (the raising instruction
+    /// and the handler that reads `tb_lineno` sit on different lines of the
+    /// same code object), and one slot answers only whichever of them asked
+    /// last.
+    pub addr2line_memo: [std::sync::atomic::AtomicI64; ADDR2LINE_MEMO_WAYS],
 }
 
 /// Field offset of `code_ptr` within `PyCode`.
@@ -730,6 +754,16 @@ pub const CODE_W_WEAKREFLIFELINE_OFFSET: usize = std::mem::offset_of!(PyCode, w_
 pub const CODE_W_QUALNAME_OFFSET: usize = std::mem::offset_of!(PyCode, w_qualname);
 /// Field offset of `w_name` within `PyCode`.
 pub const CODE_W_NAME_OFFSET: usize = std::mem::offset_of!(PyCode, w_name);
+/// Slots in [`PyCode::addr2line_memo`].  A power of two: the slot is picked
+/// by masking the offset.
+pub const ADDR2LINE_MEMO_WAYS: usize = 4;
+
+/// [`PyCode::addr2line_memo`] before any offset has been resolved.
+///
+/// `addrq` is `i32::MIN`, which the memoised arm never stores: it takes only
+/// non-negative offsets.
+pub const ADDR2LINE_MEMO_EMPTY: i64 = i64::MIN;
+
 /// Field offset of `co_firstlineno_raw` within `PyCode`.
 pub const CODE_CO_FIRSTLINENO_RAW_OFFSET: usize = std::mem::offset_of!(PyCode, co_firstlineno_raw);
 /// Field offset of `hidden_applevel` within `PyCode`.
@@ -1153,6 +1187,9 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         co_names_w,
         w_qualname: pyre_object::PY_NULL,
         w_name: pyre_object::PY_NULL,
+        addr2line_memo: std::array::from_fn(|_| {
+            std::sync::atomic::AtomicI64::new(ADDR2LINE_MEMO_EMPTY)
+        }),
     };
     // PyPy's `PyCode` is an ordinary GC object.  Keep the address stable for
     // the raw `code_ptr -> wrapper` JIT seam, but let the collector reclaim
@@ -1401,6 +1438,10 @@ fn box_code_object_with_firstlineno(code: crate::CodeObject, firstlineno: i32) -
     let obj = box_code_object(code);
     unsafe {
         (*(obj as *mut PyCode)).co_firstlineno_raw = firstlineno;
+        // The stamp is one of the two inputs `addr2line_memo` caches against.
+        for slot in &(*(obj as *mut PyCode)).addr2line_memo {
+            slot.store(ADDR2LINE_MEMO_EMPTY, std::sync::atomic::Ordering::Relaxed);
+        }
     }
     // `w_code_new` recorded `first_line_number`, which drops the zero and
     // negative values this stamp carries; re-record the exact one so the
@@ -3421,7 +3462,25 @@ pub unsafe fn w_code_addr2line(w_code: PyObjectRef, addrq: i64) -> i32 {
         if code.is_null() {
             return -1;
         }
-        code_addr2line(&*code, w_code_firstlineno_raw(w_code), addrq)
+        // Only the walking arm is worth remembering: `addrq < 0` answers
+        // `co_firstlineno` without touching the table, and an offset outside
+        // `i32` cannot be spelled in the packed pair.
+        let key = match i32::try_from(addrq) {
+            Ok(offset) if offset >= 0 => offset,
+            _ => return code_addr2line(&*code, w_code_firstlineno_raw(w_code), addrq),
+        };
+        let memo =
+            &(*(w_code as *const PyCode)).addr2line_memo[key as usize & (ADDR2LINE_MEMO_WAYS - 1)];
+        let packed = memo.load(std::sync::atomic::Ordering::Relaxed);
+        if (packed >> 32) as i32 == key {
+            return packed as i32;
+        }
+        let line = code_addr2line(&*code, w_code_firstlineno_raw(w_code), addrq);
+        memo.store(
+            ((key as i64) << 32) | (line as u32 as i64),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        line
     }
 }
 

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1081,8 +1081,12 @@ impl FrameBox {
         // them one at a time would query for forwarding after the first write
         // and let a foreign collection run before the later values were
         // visible.
+        //
+        // Publish and normalize through the bracket's own cell: the free
+        // `pin_roots` resolves the thread-local once per phase, which on
+        // Darwin is an out-of-line `_tlv_get_addr` each time.
         let frame_root = pyre_object::gc_roots::push_roots();
-        let inputs = pyre_object::gc_roots::pin_roots(&[
+        let live = [
             frame.ob_header.w_class,
             frame.pycode as pyre_object::PyObjectRef,
             frame.locals_cells_stack_w as pyre_object::PyObjectRef,
@@ -1093,7 +1097,9 @@ impl FrameBox {
             frame.f_backref as pyre_object::PyObjectRef,
             frame.w_builtin,
             frame.w_globals,
-        ]);
+        ];
+        let inputs = frame_root.publish(&live);
+        frame_root.normalize(inputs, live.len());
         let raw = pyre_object::gc_hook::try_gc_alloc_stable_raw(
             PYFRAME_GC_TYPE_ID,
             std::mem::size_of::<PyFrame>(),
@@ -1105,7 +1111,7 @@ impl FrameBox {
             // GC operation: a contended barrier is an entry safepoint, so an
             // unrooted fresh frame could otherwise be swept by another
             // collector between this allocation and the barrier below.
-            let _ = pyre_object::gc_roots::pin_root(raw as pyre_object::PyObjectRef);
+            let _ = frame_root.pin_root(raw as pyre_object::PyObjectRef);
             // Read back through the bracket's own cell rather than
             // `shadow_stack_get`, which resolves the thread-local per slot.
             frame.ob_header.w_class = frame_root.get(inputs);
@@ -5246,14 +5252,12 @@ impl PyFrame {
         // written before either is queried: a forwarding query is a safepoint,
         // and `args` would still be off the root stack while the scalars ran
         // theirs.
-        let root_base = pyre_object::gc_roots::publish_roots(&[
-            code as PyObjectRef,
-            w_globals,
-            closure,
-            w_builtin,
-        ]);
-        let args_base = pyre_object::gc_roots::publish_roots(args);
-        pyre_object::gc_roots::normalize_roots(root_base, 4 + args.len());
+        //
+        // Through the bracket's own cell rather than the free functions, which
+        // re-resolve the thread local on every call.
+        let root_base = _roots.publish(&[code as PyObjectRef, w_globals, closure, w_builtin]);
+        let args_base = _roots.publish(args);
+        _roots.normalize(root_base, 4 + args.len());
         let code_ref =
             unsafe { &*(crate::w_code_get_ptr(_roots.get(root_base)) as *const CodeObject) };
         let num_locals = code_ref.varnames.len();

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -6354,16 +6354,7 @@ pub fn str_method_translate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 
 // ── Dict methods ─────────────────────────────────────────────────────
 
-/// Layout-slot name reserved for a dict subclass's mapping payload, pyre's
-/// object-resident stand-in for the intrinsic `W_DictMultiObject` field a
-/// PyPy dict subclass carries.
-///
-/// The name holds a space so no class can declare it: `__slots__` entries are
-/// rejected unless they are identifiers. A spellable name would collide — the
-/// user's member is installed first and the reserved name appended after it,
-/// so `dict_data_slot` would answer with the user's index and the mapping
-/// payload would overwrite their slot.
-pub const DICT_DATA_SLOT: &str = "dict subclass w_dict_data";
+pub use pyre_object::typeobject::DICT_DATA_SLOT;
 
 /// Whether a type built on `w_base` owes its instances a reserved
 /// [`DICT_DATA_SLOT`] of their own: the base's instances are dicts, and no
@@ -6383,22 +6374,14 @@ pub unsafe fn base_owes_dict_backing(w_base: PyObjectRef) -> bool {
         if w_base.is_null() {
             return false;
         }
-        let mut layout = pyre_object::w_type_get_layout_ptr(w_base);
+        let layout = pyre_object::w_type_get_layout_ptr(w_base);
         let dict_typedef = &pyre_object::pyobject::DICT_TYPE as *const pyre_object::PyType;
         if layout.is_null() || !std::ptr::eq((*layout).typedef, dict_typedef) {
             return false;
         }
-        while !layout.is_null() {
-            if (*layout)
-                .newslotnames
-                .iter()
-                .any(|name| name == DICT_DATA_SLOT)
-            {
-                return false;
-            }
-            layout = (*layout).base_layout;
-        }
-        true
+        // `Layout::dict_data_slot` already answers for the whole chain — it
+        // is sealed with the base's index when a layout reserves none itself.
+        (*layout).dict_data_slot == pyre_object::typeobject::DICT_DATA_SLOT_UNRESOLVED
     }
 }
 
@@ -6425,22 +6408,19 @@ unsafe fn dict_data_slot(obj: PyObjectRef) -> Option<u32> {
         if w_type.is_null() {
             return None;
         }
-        let mut layout = pyre_object::w_type_get_layout_ptr(w_type);
-        while !layout.is_null() {
-            let current = &*layout;
-            let first_slot = current
-                .nslots
-                .saturating_sub(current.newslotnames.len() as u32);
-            if let Some(offset) = current
-                .newslotnames
-                .iter()
-                .position(|name| name == DICT_DATA_SLOT)
-            {
-                return Some(first_slot + offset as u32);
-            }
-            layout = current.base_layout;
+        let layout = pyre_object::w_type_get_layout_ptr(w_type);
+        if layout.is_null() {
+            return None;
         }
-        None
+        // `typeobject.py create_all_slots` hands each `Member` the index it
+        // resolved while building the layout; the index is never re-derived
+        // from the slot's name afterwards.  `leak_layout` seals this one the
+        // same way, walking `base_layout` once instead of on every read.
+        let slot = (*layout).dict_data_slot;
+        if slot == pyre_object::typeobject::DICT_DATA_SLOT_UNRESOLVED {
+            return None;
+        }
+        Some(slot as u32)
     }
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2568,6 +2568,7 @@ fn new_root_typeobject(name: &str, init: fn(PyObjectRef)) -> PyObjectRef {
             base_layout: std::ptr::null(),
             acceptable_as_base_class: true, // object has __new__
             typedef_hasdict: false,         // object typedef declares no __dict__
+            dict_data_slot: pyre_object::typeobject::DICT_DATA_SLOT_UNRESOLVED,
         });
         pyre_object::w_type_set_layout(type_obj, layout);
         // object: hasdict=False, weakrefable=False (bare object() has no __dict__)
@@ -2694,6 +2695,7 @@ fn new_typeobject_with_metatype_and_layout(
                     base_layout: parent_layout,
                     acceptable_as_base_class: (*parent_layout).acceptable_as_base_class,
                     typedef_hasdict: (*parent_layout).typedef_hasdict,
+                    dict_data_slot: pyre_object::typeobject::DICT_DATA_SLOT_UNRESOLVED,
                 }),
             }
         } else {
@@ -2708,6 +2710,7 @@ fn new_typeobject_with_metatype_and_layout(
                 // that declares `__dict__` does its own dict management, so
                 // mapdict must not add a second one (typeobject.py:253-257).
                 typedef_hasdict: has_dict,
+                dict_data_slot: pyre_object::typeobject::DICT_DATA_SLOT_UNRESOLVED,
             })
         };
         pyre_object::w_type_set_layout(type_obj, layout);
@@ -2809,6 +2812,7 @@ pub fn make_builtin_type_with_bases_and_layout(
                 base_layout: parent_layout,
                 acceptable_as_base_class: has_new,
                 typedef_hasdict: has_dict,
+                dict_data_slot: pyre_object::typeobject::DICT_DATA_SLOT_UNRESOLVED,
             })
         };
         pyre_object::w_type_set_layout(type_obj, layout);
@@ -8535,8 +8539,11 @@ fn dict_view_as_set_op(
         let w_set_type = crate::typedef::gettypeobject(&pyre_object::setobject::SET_TYPE);
         crate::call::call_function_impl_result(w_set_type, &[lhs])?
     };
-    let method = crate::baseobjspace::getattr_str(w_set, methname)?;
-    crate::call::call_function_impl_result(method, &[rhs])?;
+    // `dictmultiobject.py _as_set_op` — `space.call_method(w_set, methname,
+    // w_other)`, which is `callmethod.py call_method_opt`: the in-place set
+    // method is a method descriptor on an instance with no dictionary, so the
+    // call reaches it without materialising a bound method first.
+    crate::baseobjspace::call_method_result(w_set, methname, &[rhs])?;
     Ok(w_set)
 }
 

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -454,15 +454,35 @@ pub fn _wrapkey(key: &str) -> PyObjectRef {
 ///
 /// PyPy erases a real Python `{}` dict — insertion-ordered (since
 /// Python 3.7) and O(1) hashed.  Pyre's port wraps
-/// `indexmap::IndexMap<String, PyObjectRef>`, which provides the same
+/// [`ModuleDictEntries`], which provides the same
 /// insertion-ordered + hashed semantics directly so the strategy
 /// contract on `:188-198 getiter{keys,values,items,reversed}`
 /// continues to honour insertion order while `get` / `set` / `remove`
 /// stay O(1) amortised.
 #[derive(Default)]
 pub struct ModuleDictStorage {
-    pub entries: indexmap::IndexMap<String, PyObjectRef>,
+    pub entries: ModuleDictEntries,
 }
+
+/// The entry table `ModuleDictStorage` holds.
+///
+/// Keyed by the owned name and hashed with
+/// [`crate::dictmultiobject::StrKeyBuildHasher`] rather than Rust's default
+/// `RandomState`: upstream's storage is a plain `{}` over RPython strings,
+/// whose hash is a cheap chain cached on the string object, so a probe on a
+/// global's name costs one load there.
+pub type ModuleDictEntries =
+    indexmap::IndexMap<String, PyObjectRef, crate::dictmultiobject::StrKeyBuildHasher>;
+
+/// The per-name `GlobalCache` registry (`celldict.py self.caches`).
+///
+/// Keyed by global name, so it takes the same hasher
+/// [`ModuleDictEntries`] does.
+pub type GlobalCacheRegistry = std::collections::HashMap<
+    String,
+    std::sync::Arc<std::sync::Mutex<GlobalCache>>,
+    crate::dictmultiobject::StrKeyBuildHasher,
+>;
 
 /// Runtime-assigned GC type id for the [`ModuleDictStorage`] box.
 static MODULE_DICT_STORAGE_GC_TYPE_ID: std::sync::atomic::AtomicU32 =
@@ -490,10 +510,7 @@ pub fn module_dict_storage_gc_type_id() -> u32 {
 /// virtual dict).  The keys are owned `String`s, so no user `__eq__` or
 /// `__hash__` can run inside the boundary at all.
 #[majit_macros::dont_look_inside]
-pub fn module_dict_entries_get(
-    entries: &indexmap::IndexMap<String, PyObjectRef>,
-    key: &str,
-) -> Option<PyObjectRef> {
+pub fn module_dict_entries_get(entries: &ModuleDictEntries, key: &str) -> Option<PyObjectRef> {
     entries.get(key).copied()
 }
 
@@ -510,7 +527,7 @@ pub fn module_dict_entries_get(
 /// copied to the owned `String` the entry table stores inside the boundary.
 #[majit_macros::dont_look_inside]
 pub fn module_dict_entries_insert(
-    entries: &mut indexmap::IndexMap<String, PyObjectRef>,
+    entries: &mut ModuleDictEntries,
     key: &str,
     w_value: PyObjectRef,
 ) -> Option<PyObjectRef> {
@@ -520,7 +537,7 @@ pub fn module_dict_entries_insert(
 impl ModuleDictStorage {
     pub fn new() -> Self {
         Self {
-            entries: indexmap::IndexMap::new(),
+            entries: ModuleDictEntries::default(),
         }
     }
 
@@ -699,9 +716,7 @@ unsafe fn walk_one_global_cache(
 /// strategy-owned registry when multiple Python threads share a module.
 pub struct ModuleDictStrategy {
     pub version: VersionTag,
-    pub caches: std::sync::Mutex<
-        Option<std::collections::HashMap<String, std::sync::Arc<std::sync::Mutex<GlobalCache>>>>,
-    >,
+    pub caches: std::sync::Mutex<Option<GlobalCacheRegistry>>,
     /// The hidden `mutate_version` field for `celldict.py:34
     /// _immutable_fields_ = ["version?"]`.  Each compiled loop whose trace
     /// promoted `self.version` (and folded a module-global lookup keyed on it)
@@ -828,15 +843,25 @@ impl ModuleDictStrategy {
         key: &str,
     ) -> std::sync::Arc<std::sync::Mutex<GlobalCache>> {
         let mut cache_registry = self.caches.lock().unwrap();
-        if cache_registry.is_none() {
-            *cache_registry = Some(std::collections::HashMap::new());
-        }
-        let already_present = match cache_registry.as_ref() {
-            Some(c) => c.contains_key(key),
-            None => false,
+        // `celldict.py`:
+        //     if self.caches is None:
+        //         cache = None
+        //         self.caches = {}
+        //     else:
+        //         cache = self.caches.get(key, None)
+        //
+        // One probe, not a `contains_key` followed by a `get`: `key` is the
+        // global's name and this runs whenever a code object's slot for it is
+        // empty, so the second hash was paid on every hit.
+        let cached = match cache_registry.as_mut() {
+            None => {
+                *cache_registry = Some(GlobalCacheRegistry::default());
+                None
+            }
+            Some(caches) => caches.get(key).cloned(),
         };
-        if already_present {
-            return cache_registry.as_ref().unwrap().get(key).unwrap().clone();
+        if let Some(cache) = cached {
+            return cache;
         }
         let cell = self.getdictvalue_no_unwrapping(storage, key);
         let caches = cache_registry.as_mut().unwrap();

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -123,6 +123,69 @@ impl std::hash::Hasher for ObjectKeyHasher {
 
 pub type ObjectKeyBuildHasher = std::hash::BuildHasherDefault<ObjectKeyHasher>;
 
+/// The hasher for the `&str`-keyed entry tables (`celldict.py`'s module
+/// storage).
+///
+/// RPython hashes a string with `ll_strhash`, a cheap multiply/xor chain whose
+/// result is cached on the string object, so a dict probe on a name costs one
+/// load upstream.  Rust's default `RandomState` is SipHash-1-3, which is a
+/// keyed MAC: it exists to make hash-collision denial of service impractical
+/// for tables fed untrusted keys, and these tables are fed program identifiers.
+/// Every module-global read and write paid that MAC per probe.
+///
+/// FNV-1a over whole 8-byte words, so a name costs one or two rounds rather
+/// than one per byte.  Streaming: `Hash for str` writes the bytes and then a
+/// terminator, so the state carries across `write` calls.
+pub struct StrKeyHasher(u64);
+
+impl Default for StrKeyHasher {
+    #[inline]
+    fn default() -> Self {
+        Self(0xcbf2_9ce4_8422_2325)
+    }
+}
+
+impl StrKeyHasher {
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    #[inline]
+    fn mix(&mut self, word: u64) {
+        self.0 = (self.0 ^ word).wrapping_mul(Self::PRIME);
+    }
+}
+
+impl std::hash::Hasher for StrKeyHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        // One final avalanche so the low bits the table indexes with carry the
+        // whole digest.
+        let h = self.0;
+        (h ^ (h >> 29)).wrapping_mul(0xbf58_476d_1ce4_e5b9) >> 1
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        self.mix(bytes.len() as u64);
+        let mut chunks = bytes.chunks_exact(8);
+        for chunk in &mut chunks {
+            self.mix(u64::from_le_bytes(chunk.try_into().unwrap()));
+        }
+        let rest = chunks.remainder();
+        if !rest.is_empty() {
+            let mut tail = [0u8; 8];
+            tail[..rest.len()].copy_from_slice(rest);
+            self.mix(u64::from_le_bytes(tail));
+        }
+    }
+
+    #[inline]
+    fn write_u8(&mut self, value: u8) {
+        self.mix(value as u64);
+    }
+}
+
+pub type StrKeyBuildHasher = std::hash::BuildHasherDefault<StrKeyHasher>;
+
 /// View a key as `&str` only when it is a str whose backing is valid UTF-8.
 /// A lone-surrogate str returns `None` so the `&str`-keyed proxy fast paths
 /// (which cannot represent it) fall through to the generic object-keyed path.

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -288,6 +288,82 @@ fn with_shadow_stack<R>(f: impl FnOnce(&RootStack) -> R) -> R {
 /// free-threaded synchronization path.
 #[inline]
 fn normalize_published_slot(stack: &RootStack, index: usize) -> PyObjectRef {
+    if let Some((start, end, tagged)) = majit_gc::published_nursery_window()
+        && !majit_gc::gc_sync::foreign_mutator_seen()
+    {
+        // SAFETY: `slot` bounds-checks `index`, which the caller claimed.
+        return unsafe { normalize_slot_in_window(stack.slot(index), start, end, tagged) };
+    }
+    normalize_published_slot_hooked(stack, index)
+}
+
+/// Follow same-thread nursery forwarding for one published slot against a
+/// window the caller already read.
+///
+/// # Safety
+/// `slot` must name a live, writable shadow-stack slot.
+#[inline(always)]
+unsafe fn normalize_slot_in_window(
+    slot: *mut PyObjectRef,
+    start: usize,
+    end: usize,
+    tagged: bool,
+) -> PyObjectRef {
+    // SAFETY: the caller owns the slot for the duration of this call.
+    let root = unsafe { *slot };
+    let current = majit_gc::gc_current_object_address_in_window(root as usize, start, end, tagged)
+        as PyObjectRef;
+    if current != root {
+        // SAFETY: same live slot.
+        unsafe { *slot = current };
+    }
+    current
+}
+
+/// Normalize a contiguous run of already-published roots.
+///
+/// `publish` writes the whole livevar set before any query runs, so one window
+/// read describes every slot in the run; the disarmed and free-threaded paths
+/// stay per-slot because each of their queries is its own safepoint.
+///
+/// Answers whether any slot in the run named a forwarding stub, so a caller
+/// holding a native copy of the same words knows whether it owes a reload.
+#[inline]
+fn normalize_published_run(stack: &RootStack, base: usize, len: usize) -> bool {
+    if len == 0 {
+        return false;
+    }
+    let Some((start, end, tagged)) =
+        majit_gc::published_nursery_window().filter(|_| !majit_gc::gc_sync::foreign_mutator_seen())
+    else {
+        let mut moved = false;
+        for index in base..base + len {
+            // SAFETY: `publish` claimed every index in this range.
+            let before = unsafe { *stack.slot(index) };
+            moved |= normalize_published_slot_hooked(stack, index) != before;
+        }
+        return moved;
+    };
+    assert!(base + len <= stack.len(), "shadow-stack run out of range");
+    // SAFETY: bounds-checked against the live length just above, so every
+    // offset below names a slot inside the one live allocation.
+    let first = unsafe { stack.base.get().add(base) };
+    let mut moved = false;
+    for offset in 0..len {
+        // SAFETY: `offset` is below `len`, which the assertion covers.
+        unsafe {
+            let slot = first.add(offset);
+            let before = *slot;
+            moved |= normalize_slot_in_window(slot, start, end, tagged) != before;
+        }
+    }
+    moved
+}
+
+/// [`normalize_published_slot`] through the hook chain — the shape that has to
+/// answer when no nursery window is published, or when a foreign mutator makes
+/// the query a safepoint.
+fn normalize_published_slot_hooked(stack: &RootStack, index: usize) -> PyObjectRef {
     // SAFETY: callers claimed `index` before entering this helper and keep the
     // surrounding RootScope alive throughout it.
     let mut root = unsafe { *stack.slot(index) };
@@ -424,10 +500,23 @@ impl RootScope {
     pub fn normalize(&self, base: usize, len: usize) {
         #[cfg(debug_assertions)]
         assert_shadow_stack_not_walking();
-        for index in base..base + len {
-            // SAFETY: `publish` claimed every index in this range.
-            normalize_published_slot(unsafe { &*self.stack_slot }, index);
-        }
+        // SAFETY: `publish` claimed every index in this range, and
+        // `stack_slot` is this thread's live root-stack cell.
+        let _ = normalize_published_run(unsafe { &*self.stack_slot }, base, len);
+    }
+
+    /// [`normalize`](Self::normalize), reporting whether any slot in the run
+    /// named a forwarding stub.
+    ///
+    /// A caller that has to rebuild a native view of the run from the slots
+    /// only owes that rebuild when the run actually moved; `false` says the
+    /// words it already holds are the live ones.
+    #[majit_macros::dont_look_inside]
+    pub fn normalize_moved(&self, base: usize, len: usize) -> bool {
+        #[cfg(debug_assertions)]
+        assert_shadow_stack_not_walking();
+        // SAFETY: this thread's live cell; `publish` claimed the range.
+        normalize_published_run(unsafe { &*self.stack_slot }, base, len)
     }
 
     /// Scope-local [`shadow_stack_set`] using the cached cell — the write a

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -43,7 +43,35 @@ pub struct Layout {
     /// staticmethod/classmethod) needs the distinct-TypeDef convergence and is
     /// deferred with it.
     pub typedef_hasdict: bool,
+    /// Absolute slot index of the reserved [`DICT_DATA_SLOT`] payload for
+    /// instances of this layout, or `-1` when no layout in the chain
+    /// reserves one.
+    ///
+    /// `typeobject.py create_all_slots` resolves each slot's index while the
+    /// layout is being built and hands the index to the `Member` it installs;
+    /// nothing re-derives a slot position from its name afterwards.  The
+    /// reserved dict-mapping slot is resolved the same way — [`leak_layout`]
+    /// fills this in for every layout it seals, walking `base_layout` once so
+    /// an inheriting layout answers with the index its base reserved.
+    ///
+    /// Construction sites pass [`DICT_DATA_SLOT_UNRESOLVED`]; the value they
+    /// pass is overwritten.
+    pub dict_data_slot: i32,
 }
+
+/// Layout-slot name reserved for a dict subclass's mapping payload, pyre's
+/// object-resident stand-in for the intrinsic `W_DictMultiObject` field a
+/// PyPy dict subclass carries.
+///
+/// The name holds a space so no class can declare it: `__slots__` entries are
+/// rejected unless they are identifiers.  A spellable name would collide —
+/// the user's member is installed first and the reserved name appended after
+/// it, so the resolved index would be the user's and the mapping payload
+/// would overwrite their slot.
+pub const DICT_DATA_SLOT: &str = "dict subclass w_dict_data";
+
+/// [`Layout::dict_data_slot`] before [`leak_layout`] resolves it.
+pub const DICT_DATA_SLOT_UNRESOLVED: i32 = -1;
 
 impl Layout {
     /// typeobject.py issublayout(parent):
@@ -345,8 +373,34 @@ pub fn name_storage_gc_type_id() -> u32 {
 }
 
 /// Leak a Layout to get a 'static pointer for sharing.
-pub fn leak_layout(layout: Layout) -> *const Layout {
+///
+/// Seals [`Layout::dict_data_slot`] on the way through: the name scan runs
+/// once here rather than on every read of a dict subclass's mapping payload.
+pub fn leak_layout(mut layout: Layout) -> *const Layout {
+    layout.dict_data_slot = resolve_dict_data_slot(&layout);
     crate::lltype::malloc_raw(layout)
+}
+
+/// Absolute index of `layout`'s reserved [`DICT_DATA_SLOT`], own or
+/// inherited, or [`DICT_DATA_SLOT_UNRESOLVED`] when the chain reserves none.
+///
+/// The base's index is already sealed — a base layout is leaked before any
+/// layout can name it — so only this layout's own `newslotnames` is scanned.
+fn resolve_dict_data_slot(layout: &Layout) -> i32 {
+    let first_slot = layout
+        .nslots
+        .saturating_sub(layout.newslotnames.len() as u32);
+    if let Some(offset) = layout
+        .newslotnames
+        .iter()
+        .position(|name| name == DICT_DATA_SLOT)
+    {
+        return (first_slot + offset as u32) as i32;
+    }
+    if layout.base_layout.is_null() {
+        return DICT_DATA_SLOT_UNRESOLVED;
+    }
+    unsafe { (*layout.base_layout).dict_data_slot }
 }
 
 /// Builtin types (`w_type_new_builtin`) are process-global, so their root
@@ -1728,6 +1782,7 @@ pub unsafe fn w_type_set_acceptable_as_base_class(obj: PyObjectRef, v: bool) {
         base_layout: old.base_layout,
         acceptable_as_base_class: v,
         typedef_hasdict: old.typedef_hasdict,
+        dict_data_slot: crate::typeobject::DICT_DATA_SLOT_UNRESOLVED,
     });
     (*(obj as *mut W_TypeObject)).layout = new_layout;
 }
@@ -1993,6 +2048,7 @@ mod tests {
             base_layout: std::ptr::null(),
             acceptable_as_base_class: true,
             typedef_hasdict: false,
+            dict_data_slot: crate::typeobject::DICT_DATA_SLOT_UNRESOLVED,
         });
         let child = leak_layout(Layout {
             typedef: &INSTANCE_TYPE,
@@ -2001,6 +2057,7 @@ mod tests {
             base_layout: root,
             acceptable_as_base_class: true,
             typedef_hasdict: false,
+            dict_data_slot: crate::typeobject::DICT_DATA_SLOT_UNRESOLVED,
         });
         unsafe {
             assert!((*child).issublayout(root));
@@ -2018,6 +2075,7 @@ mod tests {
             base_layout: std::ptr::null(),
             acceptable_as_base_class: true,
             typedef_hasdict: false,
+            dict_data_slot: crate::typeobject::DICT_DATA_SLOT_UNRESOLVED,
         });
         // Same Layout pointer → equal
         assert!(Layout::expands_equal(root, true, true, root, true, true));
@@ -2044,6 +2102,7 @@ mod tests {
                 base_layout: std::ptr::null(),
                 acceptable_as_base_class: true,
                 typedef_hasdict,
+                dict_data_slot: crate::typeobject::DICT_DATA_SLOT_UNRESOLVED,
             });
             w_type_set_layout(w_type, layout);
             w_type_set_hasdict(w_type, true);
@@ -2088,6 +2147,7 @@ mod tests {
             base_layout: std::ptr::null(),
             acceptable_as_base_class: true,
             typedef_hasdict: false,
+            dict_data_slot: crate::typeobject::DICT_DATA_SLOT_UNRESOLVED,
         });
 
         unsafe fn builtin_with_layout(name: &str, layout: *const Layout) -> PyObjectRef {


### PR DESCRIPTION
## Summary

Two commits attacking the interpreter-constant side of the fixtures that `check.py` reports as ≥10x slower than CPython.

**`baseobjspace: port callmethod.py call_method_opt; ...`**

`space.call_method` was `baseobjspace.py call_method` (getattr + call). `objspace.py:790` overrides it with `callmethod.py call_method_opt`, which reaches the type's method descriptor and passes the receiver as its first argument. `call_method` / the new `call_method_result` take that arm, and `typedef.rs dict_view_as_set_op` routes through it.

Four repeated lookups that recompute what is already fixed:
- `_cached_lookup_where_name`'s method-cache probe hashed the name a byte at a time and compared names with slice equality (a `memcmp` call). RPython reads a cached hash off the string object; a borrowed `&Wtf8` has no such slot, so the digest is the same FNV-1a chain applied to whole 8-byte words and the comparison is inlined word-wise. The shared comparator also serves `mapdict.rs find_map_attr`.
- `celldict.rs`'s module-dict entry table and its `GlobalCache` registry hashed program identifiers with `RandomState` (SipHash-1-3); both take an FNV-1a word hasher. `get_global_cache` probes its registry once, as `celldict.py:214-221` does.

**`gc_roots: read the nursery window once per published run; ...`**

`normalize_published_slot` asked `gc_current_object_address` and `gc_sync::foreign_mutator_seen` per slot, and each reloads the four published nursery words behind two acquire loads. New `majit_gc::published_nursery_window` / `gc_current_object_address_in_window` plus `normalize_published_run` read the window once for a whole run. `call::call_function_impl_result`, `pyframe::FrameBox::new`, `PyFrame::finish_for_call_with_globals_obj` and `baseobjspace::get_and_call_function` publish their livevar sets as one run.

`baseobjspace::call_method` and `call_method_result` published their operands without normalizing them; both now normalize the published set.

`call_builtin_code_positional` keeps its per-value pins, with a comment recording why: the batched shape reorders its pending-callee queue and `builtin_code_call_positional` then types its `BuiltinCodeFn` indirect call against a shell witness graph, which panics the codewriter with *"return type Void, but the actual return type is Ref"*. That translator behaviour is a separate latent defect.

### Measured

`pyre/check.py --backend dynasm`: **ALL PASSED 497/497**.

Wall time on a quiet machine, min of 21–25 alternating rounds against a pre-branch binary, startup subtracted, user+sys CPU:

| fixture | before | after | |
|---|---|---|---|
| `abc_instancecheck_weak_cache` | 0.749s | 0.665s | −11.2% |
| `dict_view_set_ops` | 0.449s | 0.401s | −10.7% |
| `class_body_exec_hot_loop` | 0.883s | 0.807s | −8.6% |

### What this does *not* fix

Profiling says the remaining 10–25x is not interpreter constants. On an isolated `a.keys() & b.keys()` loop, PyPy traces 1623 ops → 525 optimized with `nvirtuals=138`, while pyre records 169 and hands the whole `BINARY_OP` to the `bh_binary_op_fn` blackhole residual. `PYRE_FBW_INLINE_DIAG=1` names the causes: builtin methods without a `__majit_wrap_*` gateway have no jitcode (nine gateways exist in the whole interpreter, where `interp2app` makes every PyPy builtin a traceable graph), and for `isinstance` every decline names `pyre_object::gc_roots::RootScope`'s synthetic transparent constructor — RPython inserts shadow-stack pushes *after* translation, pyre writes them in traced source. Separately, `try_gc_alloc_stable_raw` routes every Rust-side `pyre-object` allocation into the mark-sweep old generation rather than the nursery. Both are follow-up work.

## Self-review

<!-- AI-generated patch; the sections below are the author's assessment. -->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.
