### PR TITLE
jit: root the replay's ref failargs and decide the pending-fields decline first; diag: size the counter arrays from their labels

### DIFF
--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -95,7 +95,80 @@ use std::sync::{Arc, Mutex};
 /// merge was attempted; 56 = eligible but not deferrable, because the region
 /// carries a `GUARD_NOT_INVALIDATED` whose dependencies would outlive the flag
 /// it reads.
-pub static BRIDGE_DIAG: [AtomicU64; 57] = [const { AtomicU64::new(0) }; 57];
+pub static BRIDGE_DIAG: [AtomicU64; BRIDGE_DIAG_LABELS.len()] =
+    [const { AtomicU64::new(0) }; BRIDGE_DIAG_LABELS.len()];
+
+/// Short key per [`BRIDGE_DIAG`] slot, in index order, spelling the legend
+/// above as something a reader can join against.
+///
+/// This array is the slot count — [`BRIDGE_DIAG`] takes its length from it —
+/// so a tally cannot be added without naming it. The wasm host mirrors these
+/// keys positionally (it links no majit crate) and prints them under
+/// `[jit-stats] bridge_diag`; without a declaration to compare against, a slot
+/// bumped here and unnamed there is simply never reported.
+///
+/// A few slots are legend entries that no site bumps today (a decline that was
+/// split finer, and the two `ml_*` sub-breakdowns). They keep their names so
+/// the indices below them do not move.
+pub const BRIDGE_DIAG_LABELS: &[&str] = &[
+    "entered",
+    "decl_callasm",
+    "decl_multipeel",
+    "decl_notdirect",
+    "decl_refhome",
+    "BRIDGE_OK",
+    "loopclosing",
+    "src_preamble",
+    "ml_descr_none",
+    "ml_unsafe_label",
+    "ml_arity_mismatch",
+    "decl_noadvance",
+    "ca_cell_set",
+    "ca_cells_zero",
+    "accepted_ca",
+    "decl_ca_trampoline",
+    "forced_ca_terminal_decline",
+    "ml_no_descr",
+    "ml_unpublished",
+    "pub_peeled",
+    "pub_flat",
+    "pub_flat_skipped",
+    "label_retracted",
+    "cl_entered",
+    "cl_ok",
+    "cl_decl_unsupported",
+    "cl_decl_host_reject",
+    "cell_set",
+    "cell_missing",
+    "cell_rebridge",
+    "reemit_failed",
+    "reemit_ok",
+    "inline_ok",
+    "inline_decl_not_direct",
+    "inline_decl_not_loop_closing",
+    "inline_decl_not_reemittable",
+    "inline_decl_already_owned",
+    "inline_decl_frame",
+    "inline_decl_not_header",
+    "inline_decl_no_loop_label",
+    "inline_decl_value_layout",
+    "inline_decl_ref_layout",
+    "inline_decl_missing_label",
+    "inline_decl_other",
+    "bridge_param_ok",
+    "bridge_param_decl_source_frame",
+    "bridge_param_decl_arity",
+    "bridge_param_label_suppressed",
+    "inline_decl_label_resume_layout",
+    "inline_decl_call_assembler",
+    "inline_decl_owner_invalidated",
+    "inline_decl_foreign_label",
+    "inline_ok_outside_loop",
+    "inline_decl_no_trip_helper",
+    "inline_deferred",
+    "inline_trip_fired",
+    "inline_decl_defer_invalidation_guard",
+];
 
 #[repr(u8)]
 #[derive(Clone, Copy)]

--- a/majit/majit-backend-wasm/tests/bridge_diag_mirror.rs
+++ b/majit/majit-backend-wasm/tests/bridge_diag_mirror.rs
@@ -1,0 +1,218 @@
+//! Keeps `pyre-wasm-runner`'s positional bridge-diag labels synchronized with
+//! [`majit_backend_wasm::BRIDGE_DIAG_LABELS`].
+//!
+//! The runner is a wasmtime host that reaches the tallies through the
+//! `pyre_jit_bridge_diag` guest export; it links no majit crate, so it
+//! restates the keys as a positional array. `BRIDGE_DIAG` is sized by the
+//! authority array, which catches a tally added without a name on THIS side —
+//! but nothing on the runner's side sees either the count or the spellings.
+//! Both drift shapes are silent: a short mirror stops printing the tail (slot
+//! 56 was bumped in the guest and reported by nobody until this test was
+//! written), and a rename prints every tally from the divergence onward under
+//! the wrong key.
+//!
+//! The authority is LINKED, not parsed. Only the runner is read as text.
+
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    // `<root>/majit/majit-backend-wasm` -> `<root>`
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("CARGO_MANIFEST_DIR has fewer than two ancestors")
+        .to_path_buf()
+}
+
+fn runner_source() -> String {
+    // A missing file must FAIL rather than skip. This test's whole job is to
+    // read that file; one that cannot find it and passes anyway is the failure
+    // mode it exists to prevent, one level up.
+    let path = repo_root().join("pyre/pyre-wasm-runner/src/main.rs");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {} — {e}", path.display()))
+}
+
+/// The string literals of the first array literal following `anchor`.
+///
+/// The anchor is load-bearing and getting it wrong is silent: `main.rs` holds
+/// four positional label arrays, and selecting the wrong one reports total
+/// drift manufactured entirely by the selector. Anchor on the export name,
+/// which occurs once, then step to the `= [` that opens the value — a
+/// declaration can carry a `[` in its TYPE, which scanning for the first `[`
+/// after the anchor would land on.
+fn array_after(text: &str, anchor: &str, what: &str) -> Vec<String> {
+    let at = text
+        .find(anchor)
+        .unwrap_or_else(|| panic!("{what}: anchor {anchor:?} not found"));
+    let eq = text[at..]
+        .find("= [")
+        .unwrap_or_else(|| panic!("{what}: no `= [` after anchor {anchor:?}"))
+        + at;
+    let open = eq + text[eq..].find('[').expect("`= [` contains a `[`");
+
+    let bytes = text.as_bytes();
+    let mut depth = 0usize;
+    let mut end = open;
+    for (i, b) in bytes.iter().enumerate().skip(open) {
+        match b {
+            b'[' => depth += 1,
+            b']' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = i;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    assert!(depth == 0 && end > open, "{what}: unbalanced array literal");
+
+    let mut out = Vec::new();
+    for line in text[open + 1..end].lines() {
+        // Whole-line comments are dropped so a `"` inside prose cannot be
+        // mistaken for an entry. Entries are one per line in both files.
+        let line = line.trim();
+        if line.starts_with("//") {
+            continue;
+        }
+        let mut rest = line;
+        while let Some(s) = rest.find('"') {
+            let after = &rest[s + 1..];
+            let Some(e) = after.find('"') else { break };
+            out.push(after[..e].to_string());
+            rest = &after[e + 1..];
+        }
+    }
+    out
+}
+
+const RUNNER_ANCHOR: &str = "\"pyre_jit_bridge_diag\"";
+
+fn mirror(runner_src: &str) -> Vec<String> {
+    array_after(runner_src, RUNNER_ANCHOR, "runner")
+}
+
+/// The slots whose two spellings disagree, over the shorter of the two.
+fn divergences(authority: &[&str], runner: &[String]) -> Vec<String> {
+    (0..authority.len().min(runner.len()))
+        .filter(|&i| authority[i] != runner[i].as_str())
+        .map(|i| {
+            format!(
+                "  slot {i}: majit={:?} runner={:?}",
+                authority[i], runner[i]
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn the_runner_mirror_matches_bridge_diag_labels() {
+    let runner_src = runner_source();
+    let authority = majit_backend_wasm::BRIDGE_DIAG_LABELS;
+    let runner = mirror(&runner_src);
+
+    assert_eq!(
+        runner.len(),
+        authority.len(),
+        "pyre-wasm-runner's bridge_diag label array has {} entries but \
+         BRIDGE_DIAG_LABELS has {}. A tally was added to one side only. APPEND \
+         it — inserting in the middle silently renames every tally after the \
+         insertion point.\n\
+         BUT FIRST: a count that is far off rather than off by a few means the \
+         {RUNNER_ANCHOR} anchor matched a different array, and the extraction \
+         is at fault rather than the mirror. main.rs holds four positional \
+         label arrays.",
+        runner.len(),
+        authority.len(),
+    );
+
+    let divergent = divergences(authority, &runner);
+    assert!(
+        divergent.is_empty(),
+        "the pyre-wasm-runner bridge_diag mirror no longer matches \
+         majit_backend_wasm::BRIDGE_DIAG_LABELS.\n{}\n\
+         The runner zips these labels against `pyre_jit_bridge_diag(i)` BY \
+         INDEX, so every tally from the first divergent slot onward is printed \
+         under the wrong name — and check.py folds every `[jit-stats]` line \
+         into one flat key->value map, so a wrong name is compared against the \
+         wrong baseline rather than reported as missing. majit is the \
+         authority: `BRIDGE_DIAG` itself is sized by that array's length.",
+        divergent.join("\n"),
+    );
+}
+
+/// POSITIVE CONTROL — proves the test above can fail.
+///
+/// A guard that has never been observed failing asserts nothing. Both drift
+/// shapes are injected into the REAL runner source, in memory, and the checks
+/// are required to catch them. Perturbing the real text rather than a
+/// hand-written fixture is what makes this a control over the ACTUAL
+/// extraction, anchors included.
+///
+/// Nothing is written to disk; the test perturbs an in-memory copy.
+#[test]
+fn the_mirror_check_catches_injected_drift() {
+    let runner_src = runner_source();
+    let authority = majit_backend_wasm::BRIDGE_DIAG_LABELS;
+    let runner = mirror(&runner_src);
+    assert_eq!(
+        runner.len(),
+        authority.len(),
+        "control needs a green starting tree",
+    );
+
+    // Both injections edit only the text FROM the anchor onward, so a comment
+    // elsewhere that happens to quote one of these keys cannot absorb the
+    // perturbation and turn this control silently green.
+    let anchor_at = runner_src
+        .find(RUNNER_ANCHOR)
+        .expect("control: runner anchor already validated above");
+    let (head, tail) = runner_src.split_at(anchor_at);
+    let inject = |from: &str, to: &str| format!("{head}{}", tail.replacen(from, to, 1));
+
+    // Shape 1 — a rename. Only the element-wise comparison can see it, since
+    // the count is unchanged.
+    const INJECTED: &str = "XX_perturbed_by_the_positive_control";
+    let renamed = inject(&format!("\"{}\",", runner[1]), &format!("\"{INJECTED}\","));
+    assert_ne!(renamed, runner_src, "control: rename injection was a no-op");
+    let drifted = mirror(&renamed);
+    assert_eq!(
+        drifted.len(),
+        authority.len(),
+        "a rename must not change the count — otherwise this control proves \
+         the length check, not the comparison",
+    );
+    let caught = divergences(authority, &drifted);
+    // A COUNT is not an identity: exactly one mismatch is also what a
+    // MISALIGNED extraction produces. Pin WHICH slot fired and WHAT it read.
+    assert_eq!(caught.len(), 1, "expected one divergence, got {caught:?}");
+    assert!(
+        caught[0].starts_with("  slot 1: ") && caught[0].contains(INJECTED),
+        "the comparison reported one divergence, but not the one that was \
+         injected — expected slot 1 carrying {INJECTED:?}, got {:?}. The count \
+         matched by coincidence, so this control was passing without observing \
+         the perturbation: suspect the extraction anchor, not `divergences`.",
+        caught[0],
+    );
+
+    // Shape 2 — a dropped slot. Removing the LAST entry leaves every surviving
+    // slot correctly named, so only the length check can catch it. This is the
+    // shape that was live before this file existed.
+    let last = runner.last().expect("runner mirror is empty");
+    let dropped = inject(&format!("\"{last}\",\n"), "");
+    assert_ne!(dropped, runner_src, "control: drop injection was a no-op");
+    let short = mirror(&dropped);
+    assert_eq!(
+        short.len(),
+        authority.len() - 1,
+        "the drop injection did not shorten the extracted array, so the length \
+         assertion in the mirror test is untested",
+    );
+    assert!(
+        divergences(authority, &short).is_empty(),
+        "control assumption broken: dropping the LAST slot should leave every \
+         remaining slot correctly named, so only the length check can catch it",
+    );
+}

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -3036,6 +3036,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                         majit_metainterp::default_bridge_array_descr,
                         __alloc,
                         fail_values,
+                        fail_types,
                     ),
                     None => majit_metainterp::BridgeVirtualCache::new(
                         __bridge_virtual_count,
@@ -3168,6 +3169,14 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                             let __op = majit_metainterp::materialize_bridge_virtual(
                                 ctx, *__vidx, rd_virtuals, resume_data, &mut __bridge_cache,
                             );
+                            // `OpRef::NONE` is the applying reader declining a
+                            // virtual kind it cannot allocate. Binding the field
+                            // to it would leave the walk reading a state field
+                            // the heap does not back, so raise the same decline
+                            // `replay_pending_fields` raises above.
+                            if __op.is_none() {
+                                ctx.mark_bridge_replay_incomplete();
+                            }
                             sym.set_state_field_ref(__k, __op);
                             if __dbg {
                                 eprintln!("  int scalar {} <- reg {} Virtual {}", __k, __target, __vidx);
@@ -3228,6 +3237,10 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                             let __op = majit_metainterp::materialize_bridge_virtual(
                                 ctx, *__vidx, rd_virtuals, resume_data, &mut __bridge_cache,
                             );
+                            // Int twin's reason, same remedy.
+                            if __op.is_none() {
+                                ctx.mark_bridge_replay_incomplete();
+                            }
                             sym.set_state_ref_field_ref(__j, __op);
                             if __dbg {
                                 eprintln!("  ref scalar {} <- reg {} Virtual {}", __j, __target, __vidx);

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
@@ -125,6 +125,13 @@ pub(super) struct Lowerer<'c> {
 pub(super) struct LowerSnapshot {
     statements: usize,
     op_metadata: usize,
+    /// The prebuild accumulator is a second emission stream, so it is
+    /// truncated with the first. An inline call pushes its helper's
+    /// `-live-` prebuild call here and its op into `statements`, and the two
+    /// are only meaningful together: a prebuild left behind by a refused
+    /// lowering registers liveness offsets for a jitcode the parent no
+    /// longer calls.
+    inline_liveness_prebuild: usize,
     next_reg: u16,
     next_label: u16,
     bindings: HashMap<String, Binding>,
@@ -284,6 +291,7 @@ impl<'c> Lowerer<'c> {
         LowerSnapshot {
             statements: self.statements.len(),
             op_metadata: self.op_metadata.len(),
+            inline_liveness_prebuild: self.inline_liveness_prebuild.len(),
             next_reg: self.next_reg,
             next_label: self.next_label,
             bindings: self.bindings.clone(),
@@ -295,6 +303,8 @@ impl<'c> Lowerer<'c> {
     pub(super) fn restore(&mut self, snapshot: LowerSnapshot) {
         self.statements.truncate(snapshot.statements);
         self.op_metadata.truncate(snapshot.op_metadata);
+        self.inline_liveness_prebuild
+            .truncate(snapshot.inline_liveness_prebuild);
         self.next_reg = snapshot.next_reg;
         self.next_label = snapshot.next_label;
         self.bindings = snapshot.bindings;
@@ -302,6 +312,15 @@ impl<'c> Lowerer<'c> {
 
     /// Run a lowering that emits before it can fail, and leave the stream
     /// untouched if it refuses.
+    ///
+    /// The stream is what is put back. The refusal-reason channels
+    /// (`body_failure_reason`, `nested_failure_reasons`) are deliberately not:
+    /// they are the diagnosis, and a refused attempt is often the only place
+    /// the deepest blocker is ever named. [`Self::take_body_failure_reason`]
+    /// joins them behind the reporting lowerer's own reason and dedups, so a
+    /// reason carried out of a discarded attempt can add a clause but can
+    /// never re-head the message — which is the same rule
+    /// [`Self::absorb_nested_failure`] exists to enforce.
     pub(super) fn transactional<T>(
         &mut self,
         lower: impl FnOnce(&mut Self) -> Option<T>,
@@ -375,9 +394,10 @@ impl<'c> Lowerer<'c> {
         } else {
             format_ident!("goto_if_not_int_is_true")
         };
-        // Both forms read an int-banked register per `assembler.py:217 'i'`
-        // argcode — encode the kind into the metadata `Register` so the
-        // liveness walker keeps it under Int.
+        // Both forms read an int-banked register: `assembler.py write_insn`
+        // takes a `Register` operand's argcode from `x.kind[0]`, which is
+        // `'i'` for the int bank — encode the kind into the metadata
+        // `Register` so the liveness walker keeps it under Int.
         self.emit_op(
             OpMeta::conditional_guard(Register::int(cond_reg), target.clone()),
             quote! { __builder.#branch(#cond_reg, #target); },

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4990,6 +4990,32 @@ impl<S: JitState> JitDriver<S> {
     /// therefore sited BEFORE the walk: once the walk has run, the tail has
     /// happened, and handing the same guard to the blackhole would apply it a
     /// second time.
+    /// Whether this guard's resume stream carries deferred heap writes.
+    ///
+    /// Read straight off the guard's own exit layout — the same lookup
+    /// `start_retrace_from_guard` makes for `retrace.storage`, but reachable
+    /// before a trace session exists, so a decline that turns on it does not
+    /// have to open one and tear it down.
+    fn guard_carries_pending_fields(
+        &self,
+        descr_arc: &std::sync::Arc<dyn majit_ir::Descr>,
+    ) -> bool {
+        let Some(descr_fd) = descr_arc.as_fail_descr() else {
+            return false;
+        };
+        let Some(jct) = majit_backend::descr_owning_jct(descr_fd) else {
+            return false;
+        };
+        self.meta
+            .get_compiled_exit_layout_in_trace(
+                jct.green_key(),
+                descr_fd.trace_id(),
+                descr_fd.fail_index_per_trace(),
+            )
+            .and_then(|layout| layout.storage)
+            .is_some_and(|storage| !storage.rd_pendingfields.is_empty())
+    }
+
     fn bridge_from_guard_resume_position(
         &mut self,
         descr_arc: &std::sync::Arc<dyn majit_ir::Descr>,
@@ -5003,6 +5029,31 @@ impl<S: JitState> JitDriver<S> {
         // position to re-enter at; every other JitState resumes through its
         // own frontend.
         let dispatch = self.dispatch_jitcode().cloned()?;
+        // OPEN, and narrower than it was. The reader applies these guards'
+        // writes op-for-op as the blackhole does, and the virtualizable
+        // arrays are now written back from the resume stream, but a
+        // self-interpreting workload still reads one operand twice when these
+        // guards are served — and stops doing so when the virtualizable's
+        // banded arms are put out of reach, so what the walk resumes on is
+        // still described somewhere this entry does not restore. The scalars
+        // are the remaining candidate: they are carried by the state-field
+        // resume mechanism, disjoint from the array restore, and nothing
+        // writes them into the live state before the walk reads through them.
+        //
+        // Sited here rather than in the ladder below because
+        // `compile.py ResumeGuardDescr.handle_fail` runs ONE of resume.py's
+        // two readers per guard and never both: `start_bridge_tracing` asks
+        // for the applying one, which stores the deferred writes on its way
+        // in, and the blackhole arm this decline hands the guard to then
+        // stores them a second time.
+        if self.guard_carries_pending_fields(descr_arc) {
+            let why = GuardResumeDecline::ReplayIncomplete;
+            crate::mc_diag_bump(why.diag_slot());
+            if crate::majit_log_enabled() {
+                eprintln!("[bridge] guard-resume entry declined: {}", why.label());
+            }
+            return None;
+        }
         // No blackhole runs before this entry, so its replay is the one that
         // owes the guard's deferred writes to the heap.
         if !self.start_bridge_tracing(descr_arc, state, env, raw_values, target_pc, true) {
@@ -5026,6 +5077,15 @@ impl<S: JitState> JitDriver<S> {
             // other one is a decline.
             let dispatch_index = dispatch.try_index().ok_or(Decline::NoResumeState)?;
             if frame.jitcode_index as usize != dispatch_index {
+                // Unlike the pending-fields decline this one cannot be
+                // hoisted: the frame it reads only exists once
+                // `rebuild_from_resumedata` has run, which is inside the call
+                // this rung is downstream of. A guard declined here therefore
+                // has had its virtuals allocated and its stores applied once
+                // before the blackhole applies them again — the re-application
+                // is idempotent (the stream carries the values, so neither
+                // pass reads what the other wrote) and the first set of
+                // virtuals becomes garbage.
                 return Err(Decline::ForeignJitcode);
             }
             // `resume.py _prepare_pendingfields` replays the guard's deferred
@@ -5047,27 +5107,9 @@ impl<S: JitState> JitDriver<S> {
             {
                 return Err(Decline::ReplayIncomplete);
             }
-            let has_pending = resume
-                .storage
-                .as_ref()
-                .is_some_and(|storage| !storage.rd_pendingfields.is_empty());
             let fail_types = resume.fail_arg_types.clone();
             let values = frame.values.clone();
             let resume_pc = usize::try_from(frame.pc).map_err(|_| Decline::NoResumeState)?;
-            // OPEN, and narrower than it was. The reader applies these guards'
-            // writes op-for-op as the blackhole does, and the virtualizable
-            // arrays are now written back from the resume stream, but a
-            // self-interpreting workload still reads one operand twice when
-            // these guards are served — and stops doing so when the
-            // virtualizable's banded arms are put out of reach, so what the
-            // walk resumes on is still described somewhere this entry does
-            // not restore. The scalars are the remaining candidate: they are
-            // carried by the state-field resume mechanism, disjoint from the
-            // array restore above, and nothing writes them into the live
-            // state before the walk reads through them.
-            if has_pending {
-                return Err(Decline::ReplayIncomplete);
-            }
             let ctx = self.meta.tracing.as_mut().ok_or(Decline::NoResumeState)?;
             let reg_indices = ctx
                 .bridge_reg_indices()

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -1441,10 +1441,6 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
     let _ = STACK_ALMOST_FULL_FN.set(f);
 }
 
-/// Number of `MC_DIAG` slots. Declared once so the counter array and
-/// `MC_DIAG_LABELS` cannot drift in length — a mismatch is a compile error.
-pub const MC_DIAG_SLOTS: usize = 88;
-
 /// Diagnostic-only guard-failure → bridge-trace gate tallies, read out via
 /// the `pyre_jit_mc_diag` guest export. Index legend: 0 = must_compile_with_values
 /// entered, 1 = declined_bridge_guards short-circuit, 2 = descr_addr==0 skip,
@@ -1657,17 +1653,21 @@ pub const MC_DIAG_SLOTS: usize = 88;
 /// already excluded `has_runnable_compiled_loop` (a driver-side meta table)
 /// while 64 reads `cell.is_compiled()` (the warmstate cell token). The two
 /// disagree in both directions, so **64 counts cell-vs-meta disagreement.**
-pub static MC_DIAG: [std::sync::atomic::AtomicU64; MC_DIAG_SLOTS] = {
+pub static MC_DIAG: [std::sync::atomic::AtomicU64; MC_DIAG_LABELS.len()] = {
     // `AtomicU64` is not `Copy`, but a repeat expression accepts a path to a
-    // const item, so the length is taken from `MC_DIAG_SLOTS` rather than from
+    // const item, so the length is taken from `MC_DIAG_LABELS` rather than from
     // a spelled-out row of elements that has to be recounted by hand.
     const Z: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    [Z; MC_DIAG_SLOTS]
+    [Z; MC_DIAG_LABELS.len()]
 };
 
 /// Short label per [`MC_DIAG`] slot, in index order, so a tally cannot be added
 /// without naming it. Readers join these with the counter values.
-pub const MC_DIAG_LABELS: [&str; MC_DIAG_SLOTS] = [
+///
+/// This array is the slot count: [`MC_DIAG`] takes its length from
+/// `MC_DIAG_LABELS.len()`, so a tally and its name are added in one edit and
+/// neither can be written without the other.
+pub const MC_DIAG_LABELS: &[&str] = &[
     "mc_entered",
     "decl_shortcircuit",
     "descr0_skip",

--- a/majit/majit-metainterp/src/resume_box_reader.rs
+++ b/majit/majit-metainterp/src/resume_box_reader.rs
@@ -60,7 +60,25 @@ pub struct BridgeVirtualCache<'a> {
     /// The guard's fail values, which `resume.py decode_ref` reads a TAGBOX
     /// operand out of (`cpu.get_ref_value(self.deadframe, num)`). Empty for
     /// the recording-only reader, which never needs a concrete.
+    ///
+    /// Int and float failargs only — a ref failarg is read out of
+    /// [`Self::fail_ref_roots`] instead.
     fail_values: &'a [i64],
+    /// The ref-typed fail values, indexed as `fail_values` is and registered
+    /// as resume-construction GC roots.
+    ///
+    /// `decode_ref` reads through `self.deadframe`, an object the collector
+    /// traces and updates, so upstream re-reads a moved address for free. A
+    /// slice copied out of the deadframe does not move with it, and this walk
+    /// allocates: a `bh_new` between the copy and the read collects, and the
+    /// store then targets — or writes — an address that has moved. Rooting
+    /// the copy restores what reading through the deadframe gave.
+    ///
+    /// Only ref-typed slots are carried; every other index holds 0, because
+    /// the root walker hands each slot to the collector as a `GcRef` and an
+    /// int that happens to land in the nursery range would be rewritten as if
+    /// it were a pointer.
+    fail_ref_roots: Vec<i64>,
     /// Addresses of the virtuals the applying reader has allocated, indexed by
     /// virtual number and registered as resume-construction GC roots.
     ///
@@ -108,6 +126,7 @@ impl<'a> BridgeVirtualCache<'a> {
             mint_raw_array_descr,
             executing: None,
             fail_values: &[],
+            fail_ref_roots: Vec::new(),
             concrete_roots: Vec::new(),
             roots_depth: majit_gc::shadow_stack::resume_ref_roots_depth(),
         }
@@ -126,6 +145,7 @@ impl<'a> BridgeVirtualCache<'a> {
         ) -> majit_ir::DescrRef,
         allocator: &'a dyn crate::resume::BlackholeAllocator,
         fail_values: &'a [i64],
+        fail_types: &[majit_ir::Type],
     ) -> Self {
         // Built field by field rather than from `Self::new`: the cache
         // unregisters its roots in `Drop`, and a type that implements `Drop`
@@ -138,15 +158,28 @@ impl<'a> BridgeVirtualCache<'a> {
             mint_raw_array_descr,
             executing: Some(allocator),
             fail_values,
+            fail_ref_roots: fail_values
+                .iter()
+                .enumerate()
+                .map(|(i, &bits)| match fail_types.get(i) {
+                    Some(majit_ir::Type::Ref) => bits,
+                    _ => 0,
+                })
+                .collect(),
             concrete_roots: vec![0i64; size],
             roots_depth: majit_gc::shadow_stack::resume_ref_roots_depth(),
         };
+        // SAFETY, both registrations: each buffer is heap-allocated at a fixed
+        // address, never resized after this point, and unregistered by `Drop`
+        // before the cache dies.
         if size > 0 {
-            // SAFETY: the buffer is heap-allocated at a fixed address, never
-            // resized after this point, and unregistered by `Drop` before the
-            // cache dies.
             unsafe {
                 majit_gc::shadow_stack::push_resume_ref_roots(&mut cache.concrete_roots);
+            }
+        }
+        if !cache.fail_ref_roots.is_empty() {
+            unsafe {
+                majit_gc::shadow_stack::push_resume_ref_roots(&mut cache.fail_ref_roots);
             }
         }
         cache
@@ -183,6 +216,12 @@ impl<'a> BridgeVirtualCache<'a> {
     /// The guard's fail values, for resolving a TAGBOX operand's concrete.
     fn fail_values(&self) -> &'a [i64] {
         self.fail_values
+    }
+
+    /// The address a ref failarg currently lives at, read back through the
+    /// rooted copy so a collection since the guard failed is accounted for.
+    fn fail_ref_root(&self, index: usize) -> Option<i64> {
+        self.fail_ref_roots.get(index).copied()
     }
 
     pub fn get_any(&self, i: usize) -> Option<OpRef> {
@@ -386,11 +425,18 @@ fn operand_concrete(
         return Some(majit_ir::Value::Ref(majit_ir::GcRef(address as usize)));
     }
     if opref.is_input_arg() {
-        let bits = *cache.fail_values().get(opref.raw() as usize)?;
+        let index = opref.raw() as usize;
         return Some(match opref {
-            OpRef::InputArgRef(_) => majit_ir::Value::Ref(majit_ir::GcRef(bits as usize)),
-            OpRef::InputArgFloat(_) => majit_ir::Value::Float(f64::from_bits(bits as u64)),
-            _ => majit_ir::Value::Int(bits),
+            // Through the roots, not through the copy: this walk allocates,
+            // and the address a ref failarg held when the guard failed is not
+            // the address it holds after a `bh_new` collected.
+            OpRef::InputArgRef(_) => {
+                majit_ir::Value::Ref(majit_ir::GcRef(cache.fail_ref_root(index)? as usize))
+            }
+            OpRef::InputArgFloat(_) => {
+                majit_ir::Value::Float(f64::from_bits(*cache.fail_values().get(index)? as u64))
+            }
+            _ => majit_ir::Value::Int(*cache.fail_values().get(index)?),
         });
     }
     ctx.box_value(opref)
@@ -1400,24 +1446,27 @@ pub fn seed_bridge_virtualizable_boxes(
         }
     }
     let mut boxes: Vec<OpRef> = Vec::with_capacity(expected + 1);
+    // `OpRef::NONE` is how the applying reader says it met a virtual kind it
+    // has no allocating twin for. Under that reader the box would name an
+    // object the heap does not hold, and every later vable op reads through
+    // this list, so the seed fails whole rather than binding one slot to
+    // nothing — the same rule `replay_pending_fields` applies. The recording
+    // reader is unaffected: a direct reader allocated for it, and an
+    // unresolved slot there is the pre-existing tolerated case.
     for slot in slots {
-        boxes.push(rebuilt_value_to_opref(
-            ctx,
-            slot,
-            rd_virtuals,
-            resume_data,
-            cache,
-        ));
+        let op = rebuilt_value_to_opref(ctx, slot, rd_virtuals, resume_data, cache);
+        if op.is_none() && cache.allocator().is_some() {
+            return false;
+        }
+        boxes.push(op);
     }
     // virtualizable.py:143-144 "the returned list is in the format expected of
     // virtualizable_boxes, so it ends in the virtualizable itself".
-    boxes.push(rebuilt_value_to_opref(
-        ctx,
-        identity,
-        rd_virtuals,
-        resume_data,
-        cache,
-    ));
+    let identity_op = rebuilt_value_to_opref(ctx, identity, rd_virtuals, resume_data, cache);
+    if identity_op.is_none() && cache.allocator().is_some() {
+        return false;
+    }
+    boxes.push(identity_op);
     values.push(identity_value);
     ctx.set_virtualizable_boxes_with_info(boxes, values, info, &array_lengths);
     // `rebuild_state_after_failure`'s trailing `self.synchronize_virtualizable()`

--- a/majit/majit-metainterp/tests/mc_diag_mirror.rs
+++ b/majit/majit-metainterp/tests/mc_diag_mirror.rs
@@ -2,8 +2,9 @@
 //! `MC_DIAG_LABELS`.
 //!
 //! The runner intentionally does not depend on the metainterpreter crate, so
-//! this test compares the two source declarations and validates the parser
-//! against `MC_DIAG_SLOTS`.
+//! its mirror is read out of its source as text. The authority is LINKED, not
+//! parsed — `MC_DIAG_LABELS` is in scope here — so no anchor can select the
+//! wrong array on that side.
 
 use std::path::{Path, PathBuf};
 
@@ -25,14 +26,12 @@ fn read(path: &Path) -> String {
 
 /// The string literals of the first array literal following `anchor`.
 ///
-/// The anchor is load-bearing on BOTH sides, and getting it wrong is silent:
-///
-/// * `main.rs` has THREE `let labels = [` arrays. A bare `let labels = ` match
-///   takes the first (abort reasons, 6 entries) and reports 64 spurious
-///   mismatches — a total-drift verdict manufactured entirely by the selector.
-/// * `MC_DIAG_LABELS: [&str; MC_DIAG_SLOTS] = [...]` has a bracket in its TYPE.
-///   Scanning for the first `[` after the name lands there and yields 0
-///   entries.
+/// The anchor is load-bearing and getting it wrong is silent: `main.rs` has
+/// THREE `let labels = [` arrays, and a bare `let labels = ` match takes the
+/// first (abort reasons, 6 entries) and reports 64 spurious mismatches — a
+/// total-drift verdict manufactured entirely by the selector. A declaration
+/// can also carry a `[` in its TYPE, which scanning for the first `[` after
+/// the name would land on.
 ///
 /// So: anchor on something unique, then step to the `= [` that opens the value.
 fn array_after(text: &str, anchor: &str, what: &str) -> Vec<String> {
@@ -82,68 +81,37 @@ fn array_after(text: &str, anchor: &str, what: &str) -> Vec<String> {
     out
 }
 
-fn declared_slots(majit_src: &str) -> usize {
-    let anchor = "pub const MC_DIAG_SLOTS: usize = ";
-    let at = majit_src
-        .find(anchor)
-        .expect("majit: `MC_DIAG_SLOTS` declaration not found");
-    let tail = &majit_src[at + anchor.len()..];
-    let digits: String = tail.chars().take_while(|c| c.is_ascii_digit()).collect();
-    digits
-        .parse()
-        .unwrap_or_else(|e| panic!("majit: MC_DIAG_SLOTS is not a number ({digits:?}) — {e}"))
+fn runner_source() -> String {
+    read(&repo_root().join("pyre/pyre-wasm-runner/src/main.rs"))
 }
 
-fn sources() -> (String, String) {
-    let root = repo_root();
+/// The linked authority and the runner's textual mirror of it.
+fn extract(runner_src: &str) -> (&'static [&'static str], Vec<String>) {
     (
-        read(&root.join("majit/majit-metainterp/src/lib.rs")),
-        read(&root.join("pyre/pyre-wasm-runner/src/main.rs")),
+        majit_metainterp::MC_DIAG_LABELS,
+        array_after(runner_src, "\"pyre_jit_mc_diag\"", "runner"),
     )
 }
 
-fn extract(majit_src: &str, runner_src: &str) -> (Vec<String>, Vec<String>, usize) {
-    let slots = declared_slots(majit_src);
-    let majit = array_after(majit_src, "pub const MC_DIAG_LABELS", "majit");
-    let runner = array_after(runner_src, "\"pyre_jit_mc_diag\"", "runner");
-    (majit, runner, slots)
-}
-
 /// The slots whose two spellings disagree, over the shorter of the two.
-fn divergences(majit: &[String], runner: &[String]) -> Vec<String> {
+fn divergences(majit: &[&str], runner: &[String]) -> Vec<String> {
     (0..majit.len().min(runner.len()))
-        .filter(|&i| majit[i] != runner[i])
+        .filter(|&i| majit[i] != runner[i].as_str())
         .map(|i| format!("  slot {i}: majit={:?} runner={:?}", majit[i], runner[i]))
         .collect()
 }
 
-/// Validates the source parser against the compiler-enforced slot count before
-/// using the parser to diagnose mirror drift.
-#[test]
-fn slots_agree_with_the_declared_count() {
-    let (majit_src, runner_src) = sources();
-    let (majit, _runner, slots) = extract(&majit_src, &runner_src);
-    assert_eq!(
-        majit.len(),
-        slots,
-        "the majit-side extraction found {} labels but MC_DIAG_SLOTS is {slots}. \
-         rustc already enforces that array's length, so THE PARSER IN THIS FILE \
-         IS WRONG — do not touch MC_DIAG_LABELS. Most likely the anchor now \
-         matches a different array, or an entry is not one-per-line.",
-        majit.len(),
-    );
-}
-
 #[test]
 fn the_runner_mirror_matches_mc_diag_labels() {
-    let (majit_src, runner_src) = sources();
-    let (majit, runner, slots) = extract(&majit_src, &runner_src);
+    let runner_src = runner_source();
+    let (majit, runner) = extract(&runner_src);
+    let slots = majit.len();
 
     assert_eq!(
         runner.len(),
         slots,
         "pyre-wasm-runner's mc_diag label array has {} entries but \
-         MC_DIAG_SLOTS is {slots}. A new slot was added to \
+         MC_DIAG_LABELS has {slots}. A new slot was added to \
          majit_metainterp::MC_DIAG_LABELS without being appended to the mirror \
          in pyre-wasm-runner/src/main.rs (or vice versa). APPEND it — inserting \
          in the middle silently renames every tally after the insertion point.\n\
@@ -162,13 +130,13 @@ fn the_runner_mirror_matches_mc_diag_labels() {
          The runner zips these labels against `mc_diag(i)` BY INDEX, so every \
          tally from the first divergent slot onward is printed under the wrong \
          name. Fix the mirror in pyre-wasm-runner/src/main.rs to match majit — \
-         majit is the authority, since its array is length-checked against \
-         MC_DIAG itself.",
+         majit is the authority, since `MC_DIAG` itself is sized by that \
+         array's length.",
         divergent.join("\n"),
     );
 }
 
-/// POSITIVE CONTROL — proves the two tests above can fail.
+/// POSITIVE CONTROL — proves the test above can fail.
 ///
 /// A guard that has never been observed failing asserts nothing; `assert!(x
 /// == x)` also passes on every tree. So both drift shapes are injected into
@@ -181,8 +149,9 @@ fn the_runner_mirror_matches_mc_diag_labels() {
 /// Nothing is written to disk; the test perturbs an in-memory copy.
 #[test]
 fn a_perturbed_mirror_is_detected() {
-    let (majit_src, runner_src) = sources();
-    let (majit, runner, slots) = extract(&majit_src, &runner_src);
+    let runner_src = runner_source();
+    let (majit, runner) = extract(&runner_src);
+    let slots = majit.len();
     let last = runner.last().expect("runner mirror is empty").clone();
 
     // `replacen(.., 1)` takes the FIRST occurrence in the whole file, not the
@@ -207,7 +176,7 @@ fn a_perturbed_mirror_is_detected() {
     const INJECTED: &str = "XX_perturbed_by_the_positive_control";
     let renamed = runner_src.replacen(&needle, &format!("\"{INJECTED}\","), 1);
     assert_ne!(renamed, runner_src, "the perturbation did not apply");
-    let (_, perturbed, _) = extract(&majit_src, &renamed);
+    let (_, perturbed) = extract(&renamed);
     assert_eq!(
         perturbed.len(),
         slots,
@@ -248,7 +217,7 @@ fn a_perturbed_mirror_is_detected() {
          check below so a no-op substitution reports itself as such, rather \
          than as `divergences` failing to shorten",
     );
-    let (_, shortened, _) = extract(&majit_src, &deleted);
+    let (_, shortened) = extract(&deleted);
     assert_eq!(
         shortened.len(),
         slots - 1,

--- a/majit/majit-metainterp/tests/runner_label_mirrors.rs
+++ b/majit/majit-metainterp/tests/runner_label_mirrors.rs
@@ -1,10 +1,16 @@
 //! Keeps `pyre-wasm-runner`'s positional diagnostic labels synchronized with
-//! `MC_DIAG_LABELS`.
+//! the majit-metainterp arrays they mirror: `MC_DIAG_LABELS` and
+//! `jitprof::ABORT_COUNTER_KINDS`.
 //!
 //! The runner intentionally does not depend on the metainterpreter crate, so
-//! its mirror is read out of its source as text. The authority is LINKED, not
-//! parsed — `MC_DIAG_LABELS` is in scope here — so no anchor can select the
-//! wrong array on that side.
+//! its mirrors are read out of its source as text. The authorities are LINKED,
+//! not parsed — both are in scope here — so no anchor can select the wrong
+//! array on that side.
+//!
+//! Two drift shapes are silent without this: a short mirror stops printing the
+//! tail, and a rename prints every tally from the divergence onward under the
+//! wrong key — into a flat `key -> value` map that check.py compares against
+//! the wrong baseline rather than reporting as missing.
 
 use std::path::{Path, PathBuf};
 
@@ -228,5 +234,45 @@ fn a_perturbed_mirror_is_detected() {
         "a trailing deletion is invisible to the element-wise comparison by \
          construction — if this fires, `divergences` is no longer bounded by \
          the shorter side and shape 2 is being caught for the wrong reason",
+    );
+}
+
+/// The `Counters.ABORT_*` split behind `loops_aborted`, mirrored the same way
+/// and by the same runner.
+///
+/// The names live on the authority as the second half of each
+/// `ABORT_COUNTER_KINDS` pair, so unlike `MC_DIAG_LABELS` there is no separate
+/// label array to drift against on this side — only the runner's copy can go
+/// stale, and nothing but this test looks at it.
+#[test]
+fn the_runner_mirror_matches_the_abort_counter_kinds() {
+    let runner_src = runner_source();
+    let authority: Vec<&str> = majit_metainterp::jitprof::ABORT_COUNTER_KINDS
+        .iter()
+        .map(|&(_, name)| name)
+        .collect();
+    let runner = array_after(&runner_src, "\"pyre_jit_abort_diag\"", "runner");
+
+    assert_eq!(
+        runner.len(),
+        authority.len(),
+        "pyre-wasm-runner's abort_diag label array has {} entries but \
+         ABORT_COUNTER_KINDS has {}. The runner reads `pyre_jit_abort_diag(i)` \
+         for each label it holds, so a short mirror drops the trailing abort \
+         reasons from the wasm `[jit-stats] abort_diag` line and a long one \
+         prints a reason the profiler never tallies as a flat 0.",
+        runner.len(),
+        authority.len(),
+    );
+
+    let divergent = divergences(&authority, &runner);
+    assert!(
+        divergent.is_empty(),
+        "the pyre-wasm-runner abort_diag mirror no longer matches \
+         majit_metainterp::jitprof::ABORT_COUNTER_KINDS.\n{}\n\
+         `JitProfiler::abort_diag` resolves the index through that array, so \
+         every reason from the first divergent slot onward is printed under \
+         another reason's name.",
+        divergent.join("\n"),
     );
 }

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -238,7 +238,11 @@ impl FunctionQuasiImmutSlots {
 }
 
 /// Number of `?` entries in `function.py:34-42 _immutable_fields_`.
-pub const QUASI_IMMUT_SLOT_COUNT: usize = 9;
+///
+/// Anchored on the highest-numbered [`QuasiImmutSlot`] variant, so an entry
+/// added at the end of that enum extends the bound rather than needing the
+/// count restated here.
+pub const QUASI_IMMUT_SLOT_COUNT: usize = (QuasiImmutSlot::WKwDefs as usize) + 1;
 
 /// Which `_immutable_fields_` `?` entry a quasi-immutable operation names.
 ///

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -490,11 +490,13 @@ fn allocate_ssl_socket(
     const OUTGOING_SLOT: usize = 5;
     const OWNER_SLOT: usize = 6;
     const SERVER_HOSTNAME_SLOT: usize = 7;
-    const SLOT_COUNT: usize = 8;
 
     let _ = ssl_socket_methods::type_object();
     let _roots = pyre_object::gc_roots::push_roots();
-    for value in [
+    // Bound rather than spelled twice: `first` is derived from this array's
+    // own length, so pinning one more value cannot leave the block start
+    // pointing one slot past where the pins actually begin.
+    let pinned = [
         context,
         socket,
         socket_send,
@@ -503,10 +505,11 @@ fn allocate_ssl_socket(
         outgoing,
         owner,
         server_hostname,
-    ] {
+    ];
+    for value in pinned {
         let _ = pyre_object::gc_roots::pin_root(value);
     }
-    let first = pyre_object::gc_roots::shadow_stack_len() - SLOT_COUNT;
+    let first = pyre_object::gc_roots::shadow_stack_len() - pinned.len();
     for slot in [SOCKET_SLOT, OWNER_SLOT] {
         let rooted = unsafe { pyre_object::gc_roots::shadow_stack_get(first + slot) };
         if !unsafe { is_none(rooted) } {

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -6879,9 +6879,9 @@ pub mod fbw_diag {
     /// `fbw_` for the full-body walk, `gate_` for the admission gates that run
     /// before it, `bridge_` for bridge setup.
     ///
-    /// The length is `RING_BASE` because the tallies are exactly the slots
-    /// below the ring.
-    pub const LABELS: [&str; RING_BASE] = [
+    /// This array is the tally count: `RING_BASE` is `LABELS.len()`, because
+    /// the tallies are exactly the slots below the ring.
+    pub const LABELS: &[&str] = &[
         "fbw_walks",
         "fbw_rolled_back_with_effects",
         "fbw_midbody_latch",
@@ -6910,7 +6910,7 @@ pub mod fbw_diag {
     ///
     /// `pyre-wasm-runner` decodes the ring through its OWN copy of this
     /// constant (`main.rs`); the two have to move together.
-    pub const RING_BASE: usize = 19;
+    pub const RING_BASE: usize = LABELS.len();
     pub const RING_ENTRIES: usize = 24;
     pub const RING_STRIDE: usize = 5;
     pub const NAME_SLOTS: usize = 4;

--- a/pyre/pyre-jit-trace/tests/fbw_diag_mirror.rs
+++ b/pyre/pyre-jit-trace/tests/fbw_diag_mirror.rs
@@ -3,13 +3,13 @@
 //!
 //! The runner links no pyre crate — it is a wasmtime host that reaches the
 //! counters through the `pyre_fbw_diag` wasm export — so it cannot import the
-//! authority and instead restates it as a positional array. Both sides are
-//! length-checked by rustc against their own constant (`RING_BASE` here,
-//! `FBW_SLOTS` there), which catches a slot added on one side only; neither
-//! compiler sees the SPELLINGS, so a rename drifts silently and every tally
-//! from the divergence onward is printed under the wrong key. This test
-//! compares the two source declarations as text, the same way
-//! `majit-metainterp/tests/mc_diag_mirror.rs` does for `MC_DIAG_LABELS`.
+//! authority and instead restates it as a positional array. Each side sizes
+//! its own value array from its own labels, which catches a slot added
+//! without a name; neither compiler sees the SPELLINGS, so a rename drifts
+//! silently and every tally from the divergence onward is printed under the
+//! wrong key. Hence this test: the authority is LINKED (`fbw_diag::LABELS` is
+//! in scope), the mirror is read out of the runner's source as text, the same
+//! way `majit-metainterp/tests/mc_diag_mirror.rs` does for `MC_DIAG_LABELS`.
 
 use std::path::{Path, PathBuf};
 
@@ -31,10 +31,9 @@ fn read(path: &Path) -> String {
 
 /// The string literals of the first array literal following `anchor`.
 ///
-/// Both declarations carry a `[` in their TYPE (`[&str; RING_BASE]` /
-/// `[&str; FBW_SLOTS]`), so scanning for the first `[` after the name lands
-/// there and yields zero entries. Anchor on the name, then step to the `= [`
-/// that opens the value.
+/// A declaration can carry a `[` in its TYPE, so scanning for the first `[`
+/// after the name may land there and yield zero entries. Anchor on the name,
+/// then step to the `= [` that opens the value.
 fn array_after(text: &str, anchor: &str, what: &str) -> Vec<String> {
     let at = text
         .find(anchor)
@@ -82,7 +81,24 @@ fn array_after(text: &str, anchor: &str, what: &str) -> Vec<String> {
     out
 }
 
-/// The integer literal a `usize` constant is declared with.
+fn runner_source() -> String {
+    read(&repo_root().join("pyre/pyre-wasm-runner/src/main.rs"))
+}
+
+/// The linked authority and the runner's textual mirror of it.
+///
+/// The authority is not parsed: this test links `pyre-jit-trace`, so
+/// `LABELS` itself is in scope and no anchor can select the wrong array on
+/// that side. Only the runner — which this crate cannot import — is read as
+/// text.
+fn extract(runner_src: &str) -> (&'static [&'static str], Vec<String>) {
+    (
+        pyre_jit_trace::trace::fbw_diag::LABELS,
+        array_after(runner_src, "let fbw_labels", "runner"),
+    )
+}
+
+/// The integer literal a `usize`/`u32` constant is declared with.
 fn declared_count(src: &str, anchor: &str, what: &str) -> usize {
     let at = src
         .find(anchor)
@@ -94,25 +110,10 @@ fn declared_count(src: &str, anchor: &str, what: &str) -> usize {
         .unwrap_or_else(|e| panic!("{what}: count is not a number ({digits:?}) — {e}"))
 }
 
-fn sources() -> (String, String) {
-    let root = repo_root();
-    (
-        read(&root.join("pyre/pyre-jit-trace/src/trace.rs")),
-        read(&root.join("pyre/pyre-wasm-runner/src/main.rs")),
-    )
-}
-
-fn extract(trace_src: &str, runner_src: &str) -> (Vec<String>, Vec<String>, usize) {
-    let slots = declared_count(trace_src, "pub const RING_BASE: usize = ", "pyre-jit-trace");
-    let authority = array_after(trace_src, "pub const LABELS", "pyre-jit-trace");
-    let runner = array_after(runner_src, "let fbw_labels", "runner");
-    (authority, runner, slots)
-}
-
 /// The slots whose two spellings disagree, over the shorter of the two.
-fn divergences(authority: &[String], runner: &[String]) -> Vec<String> {
+fn divergences(authority: &[&str], runner: &[String]) -> Vec<String> {
     (0..authority.len().min(runner.len()))
-        .filter(|&i| authority[i] != runner[i])
+        .filter(|&i| authority[i] != runner[i].as_str())
         .map(|i| {
             format!(
                 "  slot {i}: fbw_diag={:?} runner={:?}",
@@ -122,54 +123,17 @@ fn divergences(authority: &[String], runner: &[String]) -> Vec<String> {
         .collect()
 }
 
-/// Validates the source parser against the compiler-enforced slot count before
-/// using the parser to diagnose mirror drift.
-#[test]
-fn slots_agree_with_the_declared_count() {
-    let (trace_src, runner_src) = sources();
-    let (authority, _runner, slots) = extract(&trace_src, &runner_src);
-    assert_eq!(
-        authority.len(),
-        slots,
-        "the fbw_diag-side extraction found {} labels but RING_BASE is {slots}. \
-         rustc already enforces that array's length, so THE PARSER IN THIS FILE \
-         IS WRONG — do not touch fbw_diag::LABELS. Most likely the anchor now \
-         matches a different array, or an entry is not one-per-line.",
-        authority.len(),
-    );
-}
-
-/// The runner's own constant must agree too — otherwise a slot added on one
-/// side compiles on both and only the zip length changes.
-#[test]
-fn the_runner_declares_the_same_slot_count() {
-    let (trace_src, runner_src) = sources();
-    let slots = declared_count(
-        &trace_src,
-        "pub const RING_BASE: usize = ",
-        "pyre-jit-trace",
-    );
-    let mirrored = declared_count(&runner_src, "const FBW_SLOTS: usize = ", "runner");
-    assert_eq!(
-        mirrored, slots,
-        "pyre-wasm-runner's FBW_SLOTS is {mirrored} but \
-         pyre_jit_trace::trace::fbw_diag::RING_BASE is {slots}. The runner reads \
-         `pyre_fbw_diag(i)` for i in 0..FBW_SLOTS, so a low count silently drops \
-         the tail slots from the wasm `[jit-stats] fbw_diag` line and a high one \
-         reads past the tallies into the ring.",
-    );
-}
-
 #[test]
 fn the_runner_mirror_matches_fbw_diag_labels() {
-    let (trace_src, runner_src) = sources();
-    let (authority, runner, slots) = extract(&trace_src, &runner_src);
+    let runner_src = runner_source();
+    let (authority, runner) = extract(&runner_src);
+    let slots = authority.len();
 
     assert_eq!(
         runner.len(),
         slots,
-        "pyre-wasm-runner's fbw label array has {} entries but RING_BASE is \
-         {slots}. A tally slot was added to fbw_diag::LABELS without being \
+        "pyre-wasm-runner's fbw label array has {} entries but fbw_diag::LABELS \
+         has {slots}. A tally slot was added to fbw_diag::LABELS without being \
          appended to the mirror in pyre-wasm-runner/src/main.rs (or vice versa). \
          APPEND it — inserting in the middle silently renames every tally after \
          the insertion point.\n\
@@ -190,8 +154,8 @@ fn the_runner_mirror_matches_fbw_diag_labels() {
          key->value map, so a wrong name is compared against the wrong baseline \
          rather than reported as missing. Fix the mirror in \
          pyre-wasm-runner/src/main.rs to match pyre-jit-trace, which is the \
-         authority: its array is length-checked against RING_BASE, which is the \
-         same constant the counter array itself is sized by.",
+         authority: `RING_BASE` — the offset the counter array itself is laid \
+         out against — is that array's own length.",
         divergent.join("\n"),
     );
 }
@@ -297,8 +261,9 @@ fn each_label_sits_at_its_own_slot_constant() {
 /// anchors — the part that is easiest to get silently wrong — untested.
 #[test]
 fn the_mirror_check_catches_injected_drift() {
-    let (trace_src, runner_src) = sources();
-    let (authority, runner, slots) = extract(&trace_src, &runner_src);
+    let runner_src = runner_source();
+    let (authority, runner) = extract(&runner_src);
+    let slots = authority.len();
     assert_eq!(runner.len(), slots, "control needs a green starting tree");
 
     // Both injections edit only the text FROM the anchor onward, so a future
@@ -341,4 +306,40 @@ fn the_mirror_check_catches_injected_drift() {
         "control assumption broken: dropping the LAST slot should leave every \
          remaining slot correctly named, so only the length check can catch it",
     );
+}
+
+/// The ring GEOMETRY is mirrored too, and unlike the labels it is four bare
+/// integers with nothing to derive them from on the runner's side.
+///
+/// `RING_BASE` is now `LABELS.len()` here, so a tally added on the authority
+/// side moves the ring's start — and the runner, which decodes the ring by
+/// arithmetic on its own copy, would keep reading from the old offset and
+/// print the tail of the tallies as if it were a walk's outcome name. The
+/// label comparison above cannot see that: the runner's LABEL array and its
+/// RING constants are independent declarations.
+#[test]
+fn the_runner_mirrors_the_ring_layout() {
+    use pyre_jit_trace::trace::fbw_diag as d;
+
+    let runner_src = runner_source();
+    for (anchor, authority, name) in [
+        ("const RING_BASE: u32 = ", d::RING_BASE, "RING_BASE"),
+        (
+            "const RING_ENTRIES: u32 = ",
+            d::RING_ENTRIES,
+            "RING_ENTRIES",
+        ),
+        ("const RING_STRIDE: u32 = ", d::RING_STRIDE, "RING_STRIDE"),
+        ("const NAME_SLOTS: u32 = ", d::NAME_SLOTS, "NAME_SLOTS"),
+    ] {
+        let mirrored = declared_count(&runner_src, anchor, "runner");
+        assert_eq!(
+            mirrored, authority,
+            "pyre-wasm-runner declares {name} = {mirrored} but \
+             pyre_jit_trace::trace::fbw_diag::{name} is {authority}. The runner \
+             indexes the `pyre_fbw_diag` export with `RING_BASE + entry * \
+             RING_STRIDE`, so a stale copy decodes the wrong words and prints \
+             them as a walk outcome rather than failing.",
+        );
+    }
 }

--- a/pyre/pyre-jit-trace/tests/fbw_diag_mirror.rs
+++ b/pyre/pyre-jit-trace/tests/fbw_diag_mirror.rs
@@ -9,7 +9,7 @@
 //! silently and every tally from the divergence onward is printed under the
 //! wrong key. Hence this test: the authority is LINKED (`fbw_diag::LABELS` is
 //! in scope), the mirror is read out of the runner's source as text, the same
-//! way `majit-metainterp/tests/mc_diag_mirror.rs` does for `MC_DIAG_LABELS`.
+//! way `majit-metainterp/tests/runner_label_mirrors.rs` does for `MC_DIAG_LABELS`.
 
 use std::path::{Path, PathBuf};
 
@@ -98,16 +98,23 @@ fn extract(runner_src: &str) -> (&'static [&'static str], Vec<String>) {
     )
 }
 
-/// The integer literal a `usize`/`u32` constant is declared with.
-fn declared_count(src: &str, anchor: &str, what: &str) -> usize {
+/// The integer literal a constant is declared with, decimal or `0x` hex.
+///
+/// Hex is accepted because the bit-layout half of the mirror is only readable
+/// as masks — a `FIELD_MASK` spelled `65535` to keep a decimal-only parser
+/// happy would trade the thing being guarded for the guard.
+fn declared_int(src: &str, anchor: &str, what: &str) -> u64 {
     let at = src
         .find(anchor)
         .unwrap_or_else(|| panic!("{what}: {anchor:?} declaration not found"));
-    let tail = &src[at + anchor.len()..];
-    let digits: String = tail.chars().take_while(|c| c.is_ascii_digit()).collect();
-    digits
-        .parse()
-        .unwrap_or_else(|e| panic!("{what}: count is not a number ({digits:?}) — {e}"))
+    let tail = src[at + anchor.len()..].trim_start();
+    let (radix, rest) = match tail.strip_prefix("0x") {
+        Some(rest) => (16, rest),
+        None => (10, tail),
+    };
+    let digits: String = rest.chars().take_while(|c| c.is_digit(radix)).collect();
+    u64::from_str_radix(&digits, radix)
+        .unwrap_or_else(|e| panic!("{what}: {anchor:?} is not a number ({digits:?}) — {e}"))
 }
 
 /// The slots whose two spellings disagree, over the shorter of the two.
@@ -308,37 +315,73 @@ fn the_mirror_check_catches_injected_drift() {
     );
 }
 
-/// The ring GEOMETRY is mirrored too, and unlike the labels it is four bare
-/// integers with nothing to derive them from on the runner's side.
+/// The ring GEOMETRY and BIT LAYOUT are mirrored too, and unlike the labels
+/// they are bare integers with nothing to derive them from on the runner's
+/// side.
 ///
-/// `RING_BASE` is now `LABELS.len()` here, so a tally added on the authority
-/// side moves the ring's start — and the runner, which decodes the ring by
-/// arithmetic on its own copy, would keep reading from the old offset and
-/// print the tail of the tallies as if it were a walk's outcome name. The
-/// label comparison above cannot see that: the runner's LABEL array and its
-/// RING constants are independent declarations.
+/// `RING_BASE` is `LABELS.len()` here, so a tally added on the authority side
+/// moves the ring's start — and the runner, which decodes the ring by
+/// arithmetic on its own copies, would keep reading from the old offset and
+/// print the tail of the tallies as if it were a walk's outcome name. Renumber
+/// a `SHIFT_*` instead and every census line reports one field's value under
+/// another field's name. The label comparison above cannot see either: the
+/// runner's LABEL array and its layout constants are independent
+/// declarations.
 #[test]
 fn the_runner_mirrors_the_ring_layout() {
     use pyre_jit_trace::trace::fbw_diag as d;
 
     let runner_src = runner_source();
     for (anchor, authority, name) in [
-        ("const RING_BASE: u32 = ", d::RING_BASE, "RING_BASE"),
+        ("const RING_BASE: u32 = ", d::RING_BASE as u64, "RING_BASE"),
         (
             "const RING_ENTRIES: u32 = ",
-            d::RING_ENTRIES,
+            d::RING_ENTRIES as u64,
             "RING_ENTRIES",
         ),
-        ("const RING_STRIDE: u32 = ", d::RING_STRIDE, "RING_STRIDE"),
-        ("const NAME_SLOTS: u32 = ", d::NAME_SLOTS, "NAME_SLOTS"),
+        (
+            "const RING_STRIDE: u32 = ",
+            d::RING_STRIDE as u64,
+            "RING_STRIDE",
+        ),
+        (
+            "const NAME_SLOTS: u32 = ",
+            d::NAME_SLOTS as u64,
+            "NAME_SLOTS",
+        ),
+        ("const FLAG_VALID: u64 = ", d::FLAG_VALID, "FLAG_VALID"),
+        (
+            "const FLAG_COMMITTED: u64 = ",
+            d::FLAG_COMMITTED,
+            "FLAG_COMMITTED",
+        ),
+        ("const FLAG_BRIDGE: u64 = ", d::FLAG_BRIDGE, "FLAG_BRIDGE"),
+        (
+            "const SHIFT_EFFECTS: u32 = ",
+            d::SHIFT_EFFECTS as u64,
+            "SHIFT_EFFECTS",
+        ),
+        (
+            "const SHIFT_JOURNAL: u32 = ",
+            d::SHIFT_JOURNAL as u64,
+            "SHIFT_JOURNAL",
+        ),
+        (
+            "const SHIFT_EXEC_MF: u32 = ",
+            d::SHIFT_EXEC_MF as u64,
+            "SHIFT_EXEC_MF",
+        ),
+        ("const SHIFT_LEG: u32 = ", d::SHIFT_LEG as u64, "SHIFT_LEG"),
+        ("const FIELD_MASK: u64 = ", d::FIELD_MASK, "FIELD_MASK"),
     ] {
-        let mirrored = declared_count(&runner_src, anchor, "runner");
+        let mirrored = declared_int(&runner_src, anchor, "runner");
         assert_eq!(
             mirrored, authority,
             "pyre-wasm-runner declares {name} = {mirrored} but \
              pyre_jit_trace::trace::fbw_diag::{name} is {authority}. The runner \
              indexes the `pyre_fbw_diag` export with `RING_BASE + entry * \
-             RING_STRIDE`, so a stale copy decodes the wrong words and prints \
+             RING_STRIDE` and unpacks the counter slot with the `SHIFT_*` / \
+             `FLAG_*` set, so a stale copy decodes the wrong words and prints \
              them as a walk outcome rather than failing.",
         );
     }

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -742,11 +742,11 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
             }
             eprintln!("[jit-stats] abort_diag {}", parts.join(" "));
         }
-        // compile_bridge outcome tallies (diagnostic). 0=entered 1=declCALL_ASM
-        // 2=declMultiPeel 3=declNotDirect 4=declRefHome 5=BRIDGE_OK
-        // 6=loopClosing 7=srcHasPreamble 15=declCAHostTrampoline,
-        // 16=forced terminal-decline regression hook. 48=inline LABEL-resume
-        // layout decline.
+        // compile_bridge outcome tallies (diagnostic). POSITIONAL MIRROR of
+        // `majit_backend_wasm::BRIDGE_DIAG_LABELS`, which carries the legend
+        // for every slot; the runner links no majit crate, so a slot added
+        // there must be APPENDED here or its tally is bumped in the guest and
+        // reported by nobody.
         if let Ok(diag) = instance.get_typed_func::<u32, u64>(&mut store, "pyre_jit_bridge_diag") {
             let labels = [
                 "entered",
@@ -805,6 +805,7 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
                 "inline_decl_no_trip_helper",
                 "inline_deferred",
                 "inline_trip_fired",
+                "inline_decl_defer_invalidation_guard",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {
@@ -860,10 +861,24 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
         // PYRE_WASM_JIT_STATS, so printing them here would have kept them off
         // every gated wasm run.
         if let Ok(fbw) = instance.get_typed_func::<u32, u64>(&mut store, "pyre_fbw_diag") {
+            // POSITIONAL MIRROR of the ring geometry and bit layout in
+            // `pyre_jit_trace::trace::fbw_diag`. The runner links no pyre
+            // crate and decodes the ring by arithmetic on these, so a stale
+            // copy reads the wrong words and prints them as a walk outcome
+            // instead of failing. Named rather than spelled inline so the
+            // mirror is something a test can compare.
             const RING_BASE: u32 = 19;
             const RING_ENTRIES: u32 = 24;
             const RING_STRIDE: u32 = 5;
             const NAME_SLOTS: u32 = 4;
+            const FLAG_VALID: u64 = 0x1;
+            const FLAG_COMMITTED: u64 = 0x2;
+            const FLAG_BRIDGE: u64 = 0x4;
+            const SHIFT_EFFECTS: u32 = 8;
+            const SHIFT_JOURNAL: u32 = 24;
+            const SHIFT_EXEC_MF: u32 = 40;
+            const SHIFT_LEG: u32 = 56;
+            const FIELD_MASK: u64 = 0xffff;
             let mut slot = |i: u32| fbw.call(&mut store, i).unwrap_or(0);
             let walks = slot(0);
             // `fbw_diag::record` keeps the FIRST `RING_ENTRIES` walks and lets
@@ -888,19 +903,21 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
                     }
                 }
                 let flags = slot(base + NAME_SLOTS);
-                if flags & 1 == 0 {
+                if flags & FLAG_VALID == 0 {
                     continue;
                 }
-                let field = |shift: u32| (flags >> shift) & 0xffff;
+                let field = |shift: u32| (flags >> shift) & FIELD_MASK;
                 eprintln!(
                     "[fbw-census] end={end} committed={} leg={} bridge={} exec_mf={} \
                      effects={} journaled={}",
-                    flags & (1 << 1) != 0,
-                    (flags >> 56) & 0xff,
-                    flags & (1 << 2) != 0,
-                    field(40),
-                    field(8),
-                    field(24),
+                    flags & FLAG_COMMITTED != 0,
+                    // The leg is the top byte, so the shift already isolates
+                    // it; the mask keeps the width of the read on the page.
+                    (flags >> SHIFT_LEG) & 0xff,
+                    flags & FLAG_BRIDGE != 0,
+                    field(SHIFT_EXEC_MF),
+                    field(SHIFT_EFFECTS),
+                    field(SHIFT_JOURNAL),
                 );
             }
         }

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -1176,11 +1176,10 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
         // to 0 when the export is absent, which reads as healthy. Hence the one
         // lookup feeding the refusal below, and hence this line — not the
         // counter line — being where those four keys are emitted now.
-        // Both arrays take their length from this one constant, so a label
-        // added without a slot (or the reverse) is a compile error rather than
-        // a `zip` that silently drops the tail.
-        const FBW_SLOTS: usize = 19;
-        let fbw_labels: [&str; FBW_SLOTS] = [
+        // The value array is built FROM the label array below, so a label
+        // added without a slot (or the reverse) is impossible to write rather
+        // than a `zip` that silently drops the tail.
+        let fbw_labels = [
             "fbw_walks",
             "fbw_rolled_back_with_effects",
             "fbw_midbody_latch",
@@ -1204,7 +1203,7 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
         let fbw_slots = match instance
             .get_typed_func::<u32, u64>(&mut store, "pyre_fbw_diag")
             .and_then(|f| {
-                let mut values = [0u64; FBW_SLOTS];
+                let mut values = fbw_labels.map(|_| 0u64);
                 for (slot, value) in values.iter_mut().enumerate() {
                     *value = f.call(&mut store, slot as u32)?;
                 }
@@ -1213,7 +1212,7 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
             Ok(values) => values,
             Err(_) => {
                 missing.push("pyre_fbw_diag");
-                [0; FBW_SLOTS]
+                fbw_labels.map(|_| 0u64)
             }
         };
         if !missing.is_empty() {


### PR DESCRIPTION
Three commits on top of `main`.

## `jit: root the replay's ref failargs, and decide the pending-fields decline first`

Follow-up to the review on #1513, which is merged.

- **The replay's ref failargs were unrooted.** `decode_ref` upstream reads through the deadframe (`cpu.get_ref_value(self.deadframe, num)`), a GC object the collector traces and updates, so a moved address arrives already re-read. majit copies the fail values into a plain `Vec`, which the collector does not walk. `BridgeVirtualCache` now carries a `fail_ref_roots` alongside `fail_values` and registers it on the shadow stack; only ref-typed slots are rooted, since the walker hands each slot to the collector as `&mut GcRef` and an int in the nursery range would be rewritten as a pointer. `executing()` takes `fail_types` for that split.
- **The pending-fields decline ran after the replay had already applied writes.** The rung is now decided before `start_bridge_tracing`, via `guard_carries_pending_fields`, so a guard that will be declined never gets its resume data applied twice. The `ForeignJitcode` rung stays where it is — the frame it tests exists only after `rebuild_from_resumedata` — with a comment saying so and why its re-application is idempotent.
- **`seed_bridge_virtualizable_boxes` ignored `OpRef::NONE`.** Array items and the trailing identity box are now checked, and the seed returns `false` under an applying cache; both `RebuiltValue::Virtual` arms of the generated `setup_bridge_sym` call `mark_bridge_replay_incomplete()`.
- `LowerSnapshot` gained `inline_liveness_prebuild` so `transactional` rolls it back; the refusal-reason channels are deliberately *not* rolled back, and `transactional`'s doc now says why.
- A stale `rebuild_state_after_failure` parity TODO claimed the closing `synchronize_virtualizable()` could not be wired; it can and is, so the comment now describes `ctx.synchronize_virtualizable_after_guard_failure()` and the `JitState` opt-out. One `assembler.py:217` citation became `assembler.py write_insn` / `x.kind[0]`.

One review point is **not** adopted: the multi-frame gate it flagged is pre-existing on `main` from #773, not introduced here.

## `diag: size the counter arrays from their labels instead of a restated count`

`MC_DIAG_SLOTS`, `fbw_diag::RING_BASE` and the runner's `FBW_SLOTS` each spelled out a number the label array beside them already carried.

| before | after |
|---|---|
| `MC_DIAG: [AtomicU64; MC_DIAG_SLOTS]` | `[AtomicU64; MC_DIAG_LABELS.len()]`, `MC_DIAG_LABELS: &[&str]` |
| `LABELS: [&str; RING_BASE]` | `LABELS: &[&str]`, `RING_BASE = LABELS.len()` |
| `let fbw_labels: [&str; FBW_SLOTS]` | `let fbw_labels = [...]`, values via `fbw_labels.map()` |
| `QUASI_IMMUT_SLOT_COUNT = 9` | `(QuasiImmutSlot::WKwDefs as usize) + 1`, as `EXC_KIND_COUNT` is written |
| `_ssl`'s `SLOT_COUNT = 8` | the pinned array's own `len()` |

Both label counts are unchanged: 88 and 19.

The two mirror tests parsed those constants out of the source to validate their own extraction. Each links the authority crate, so they now read `MC_DIAG_LABELS` / `fbw_diag::LABELS` directly and parse only the runner, which they cannot import; the parser-validation tests and `declared_slots` go with the constants.

`fbw_diag_mirror` gains `the_runner_mirrors_the_ring_layout`. `RING_BASE` is now `LABELS.len()`, so a tally added on the authority side moves the ring's start — and the runner's own `RING_BASE`/`RING_ENTRIES`/`RING_STRIDE`/`NAME_SLOTS`, which it decodes the ring by arithmetic on, were checked by nothing. Confirmed it fails: flipping the runner's `RING_ENTRIES` to 25 reddens it, and reverting restores green.

## `diag: name the wasm bridge_diag slots and guard the runner's remaining mirrors`

`pyre-wasm-runner` links no pyre or majit crate, so every diagnostic it prints is a **positional mirror** restated by hand. It holds four label arrays and a copy of the fbw ring layout. Two of the arrays and none of the layout were compared against anything, on either side.

- **`BRIDGE_DIAG` had no authority array at all.** The legend lived in prose above a hand-counted `[AtomicU64; 57]`. It now takes its length from a new `BRIDGE_DIAG_LABELS`, and `majit-backend-wasm/tests/bridge_diag_mirror.rs` compares the runner's copy against it.
- **That comparison closed a live gap.** `diag_bump(56)` fires in the wasm backend — the `GUARD_NOT_INVALIDATED` inline-defer decline — but the runner's array ended at slot 55, so the tally was bumped in the guest and reported by nobody. Appended as `inline_decl_defer_invalidation_guard`.
- **`abort_diag` was unguarded.** Its labels mirror `jitprof::ABORT_COUNTER_KINDS`; `mc_diag_mirror.rs` becomes `runner_label_mirrors.rs` and checks both majit-metainterp-owned mirrors.
- **The ring bit layout was bare magic.** The runner decoded the packed counter slot with `1 << 1`, `>> 56` and `& 0xffff`. Those are now named after the `fbw_diag` constants they mirror, and `the_runner_mirrors_the_ring_layout` checks all twelve — geometry and bit layout — through a `declared_int` that accepts hex so a mask stays readable at its declaration.

Every new check was confirmed to fail on injected drift and pass on revert: a renumbered `SHIFT_JOURNAL`, a renamed `force_quasiimmut`, and (via the bridge mirror's own positive control) a renamed and a dropped slot.

Not expanded into: the `heap_bucket` loop mirrors `pyre-wasm`'s `NBUCKETS`, but that constant is `pub(super)` in a wasm32-only crate the runner cannot link, and a drift there changes how many buckets print rather than what any of them is called.

## Verification

- `cargo test --all --no-run --no-default-features --features dynasm,cpyext` — exit 0, no error lines
- `cargo test -p majit-metainterp --no-default-features --features dynasm` — 59 test binaries, 0 failed
- `cargo test -p majit-backend-wasm` — 11 + 2 + 68 passed, 0 failed
- mirrors: `runner_label_mirrors` 3/3, `fbw_diag_mirror` 4/4, `bridge_diag_mirror` 2/2
- `cargo fmt --all -- --check` clean; `scripts/check-majit-boundary.py` exit 0

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIT bridge replay handling for deferred writes and unresolved virtual values.
  * Preserved required reference data during garbage collection to make bridge resumption more reliable.
  * Prevented diagnostic label and value mismatches in JIT statistics.

* **Tests**
  * Added coverage to verify diagnostic labels, counters, and layout metadata remain synchronized across components.

* **Maintenance**
  * Diagnostic and runtime slot counts now derive automatically from their label or enum definitions, reducing drift when entries change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->