### PR TITLE
jit-trace, interp: bracket the self-recursive CALL_ASSEMBLER with ec enter/leave

### DIFF
--- a/pyre/bench/synth/frame_chain_survives_a_recursive_call_assembler.py
+++ b/pyre/bench/synth/frame_chain_survives_a_recursive_call_assembler.py
@@ -1,0 +1,106 @@
+# pyre-check: selfcheck
+# pyre-check: selfcheck-compiles=hot,root:rec
+# The `root:` arm is the premise, not a relaxation: the activations this
+# fixture walks are owed precisely because `rec` compiles and its recursive
+# call is folded into `CALL_ASSEMBLER`. A `rec` that stopped compiling would
+# make every walk below pass without testing anything.
+# A warm self-recursive callee reaches its own compiled loop through
+# `CALL_ASSEMBLER`, and the callee frame that fold hands the assembler is built
+# out of recorded operations rather than by the interpreter's call door.
+#
+# `pyframe.py execute_frame` runs `ec.enter(self)` before the merge point and
+# `ec.leave(...)` in a `finally` after it, which is what puts an activation on
+# the `topframeref` / `f_backref` chain `sys._getframe` walks. Upstream's merge
+# point is on `PyFrame.dispatch` (`interp_jit.py`), so a CALL_ASSEMBLER that
+# replaces it is recorded with the enter already traced ahead of it. pyre's
+# portal sits one level up, at `execute_frame`, so the fold jumped over both
+# halves: the frame it minted was never linked, and every activation the
+# assembler ran was invisible to a stack walk.
+#
+# THE SHAPE IS THE TEST: `rec(DEPTH)` is exactly DEPTH + 1 activations of `rec`,
+# stacked contiguously between the probe and the caller. Measured before the
+# fix the walk found ONE `rec` frame at every depth — the outermost, the only
+# one that still went through the interpreter — so `f_back` ran straight from
+# the innermost body to the module frame.
+#
+# TWO DEPTHS ARE ALSO A TEST: a chain that is linked for the first level only,
+# or that is off by a constant, tracks neither. The two walks must differ by
+# exactly the difference between the depths.
+import sys
+
+WARM = 3000  # past the loop threshold (1039) many times over
+WARM_DEPTH = 20  # the warm-up must RECURSE, or the fold never fires
+DEPTHS = (3, 12)
+
+
+def chain():
+    names = []
+    frame = sys._getframe()
+    while frame is not None:
+        names.append(frame.f_code.co_name)
+        frame = frame.f_back
+    return names
+
+
+def rec(n):
+    if n <= 0:
+        return chain()
+    return rec(n - 1)
+
+
+def hot(n):
+    total = 0
+    for _ in range(n):
+        total = (total + len(rec(WARM_DEPTH))) % 1000003
+    return total
+
+
+def rec_frames(names):
+    # `chain` is names[0]; count the contiguous `rec` activations above the
+    # caller that requested the walk.
+    count = 0
+    for name in names[1:]:
+        if name != 'rec':
+            break
+        count += 1
+    return count
+
+
+def main():
+    failures = []
+    # Compile `rec` first so the walks below run against compiled code rather
+    # than against a cold frame the interpreter would have chained anyway.
+    hot(WARM)
+    walked = []
+    for depth in DEPTHS:
+        names = rec(depth)
+        got = rec_frames(names)
+        walked.append(got)
+        if got != depth + 1:
+            failures.append(
+                'rec(%d): the f_back chain holds %d `rec` frames, owed %d — '
+                'the activations CALL_ASSEMBLER ran are missing from it (%r)'
+                % (depth, got, depth + 1, names[: depth + 3])
+            )
+        if names[-1] != '<module>':
+            failures.append(
+                'rec(%d): the chain ends at %r, not the module frame'
+                % (depth, names[-1])
+            )
+    grew = walked[1] - walked[0]
+    owed = DEPTHS[1] - DEPTHS[0]
+    if grew != owed:
+        failures.append(
+            'the chain grew by %d frames from depth %d to depth %d, owed %d — '
+            'it does not track the recursion depth'
+            % (grew, DEPTHS[0], DEPTHS[1], owed)
+        )
+    if failures:
+        for line in failures:
+            print('FAIL', line)
+        return 1
+    print('PASS a recursive CALL_ASSEMBLER activation stays on the frame chain')
+    return 0
+
+
+sys.exit(main())

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -150,29 +150,46 @@ pub fn install_current_frame(frame: &mut PyFrame) -> CurrentFrameGuard {
     // `ExecutionContext::enter` before installing TLS-only state, but
     // the JIT portal path enters through this helper directly.
     let ec = frame.execution_context as *mut PyExecutionContext;
-    let previous_ec_top = if ec.is_null() {
-        std::ptr::null_mut()
-    } else {
-        unsafe {
+    // `ExecutionContext::enter` refuses a frame that is already the top —
+    // relinking it would make `f_backref` name the frame itself, and
+    // `walk_pyframe_roots` follows `f_backref` with no cycle guard.  This door
+    // owes the same refusal, because the enter is no longer performed only
+    // here: `try_walker_call_assembler_self_recursive`
+    // (`pyre-jit-trace/src/jitcode_dispatch/inline_call.rs`) records it ahead
+    // of its CALL_ASSEMBLER, and the force and deopt legs hand that same,
+    // already-entered frame back to the portal.  Already entered means there
+    // is nothing to link; the guard still has to restore what `leave` would,
+    // which is this frame's own `f_backref`.
+    let already_entered = !ec.is_null()
+        && std::ptr::eq(
+            crate::executioncontext::vref_referent(unsafe { (*ec).topframeref }),
+            frame as *mut PyFrame,
+        );
+    let previous_ec_top = match (ec.is_null(), already_entered) {
+        (true, _) => std::ptr::null_mut(),
+        (false, true) => frame.f_backref,
+        (false, false) => unsafe {
             let top = (*ec).topframeref;
             (*ec).topframeref = frame as *mut PyFrame;
             top
-        }
+        },
     };
-    // Barrier for the same reason as `ExecutionContext::enter`: this is a
-    // traced `Type::Ref` store and `frame` can be an old-generation frame
-    // taking a young predecessor.
-    pyre_object::gc_hook::try_gc_write_barrier(frame as *mut PyFrame as *mut u8);
-    majit_gc::bh_probe_note_store(
-        frame as *mut PyFrame as usize,
-        crate::pyframe::PYFRAME_F_BACKREF_OFFSET,
-        3,
-    );
-    frame.f_backref = if ec.is_null() {
-        previous
-    } else {
-        previous_ec_top
-    };
+    if !already_entered {
+        // Barrier for the same reason as `ExecutionContext::enter`: this is a
+        // traced `Type::Ref` store and `frame` can be an old-generation frame
+        // taking a young predecessor.
+        pyre_object::gc_hook::try_gc_write_barrier(frame as *mut PyFrame as *mut u8);
+        majit_gc::bh_probe_note_store(
+            frame as *mut PyFrame as usize,
+            crate::pyframe::PYFRAME_F_BACKREF_OFFSET,
+            3,
+        );
+        frame.f_backref = if ec.is_null() {
+            previous
+        } else {
+            previous_ec_top
+        };
+    }
     push_current_frame_previous_root(previous, ec, previous_ec_top)
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1980,6 +1980,13 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
         ec,
     );
 
+    // `pyframe.py execute_frame`'s `ec.enter(self)`, which upstream records
+    // ahead of the callee's `jit_merge_point` and this fold otherwise jumps
+    // over: without it the activation the CALL_ASSEMBLER runs never reaches
+    // `topframeref`, so `sys._getframe().f_back` walks straight from the
+    // callee's callee to this caller and every level in between is missing.
+    record_ec_enter_frame_chain(ctx.trace_ctx, callee_frame, ec);
+
     // do_residual_call step 1 (`pyjitpl.py`): FORCE_TOKEN +
     // SETFIELD_GC(vable_token) before the assembler call.
     maybe_walker_vable_and_vrefs_before_residual_call(ctx, op.pc);
@@ -2150,6 +2157,20 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
     // `pyjitpl.py:2080-2081` keeps the assembler virtualizable alive after
     // the force guard has captured its resume data.
     ctx.trace_ctx.record_op(OpCode::Keepalive, &[callee_frame]);
+    // `execute_frame`'s `finally: ec.leave(...)`.  A `finally` runs on every
+    // exit, and compiled code has no such construct, so the restore is
+    // recorded at the earliest point the call is known to have returned:
+    // after GUARD_NOT_FORCED, which `pyjitpl.py:2049-2079` keeps adjacent to
+    // the call, and BEFORE the exception guard.  Recording it past the
+    // exception guard instead would skip the restore on exactly the exit that
+    // needs it — a raising callee deopts at the guard, leaving the callee
+    // frame published in `topframeref` for the next `enter` to chain onto, and
+    // the root walker then traverses a chain that grows once per raise
+    // (`walk_pyframe_roots_area` took 100% of a profile of
+    // `synth/list_length_hint_validate`, which raises on four of every six
+    // calls).  The residual exposure — a failing GUARD_NOT_FORCED — is the one
+    // `TopFrameRefGuard` (`pyre-jit/src/eval.rs`) already covers.
+    record_ec_leave_frame_chain(ctx.trace_ctx, callee_frame, ec);
     // pyjitpl.py `handle_possible_exception`.
     if exec_raised {
         // Raising branch (pyjitpl.py): `GUARD_EXCEPTION` with
@@ -3365,6 +3386,82 @@ pub(crate) fn walker_ec_leave(
     }
     // `jit.virtual_ref_finish(frame_vref, frame)`.
     ctx.opimpl_virtual_ref_finish(callee_frame);
+}
+
+/// `executioncontext.py ExecutionContext.enter`'s frame-chain half, recorded
+/// with no concrete shadow.
+///
+/// ```python
+/// frame.f_backref = self.topframeref
+/// self.topframeref = jit.virtual_ref(frame)
+/// ```
+///
+/// [`walker_ec_enter`] is the seeded-callee form: it has a live callee frame
+/// at recording time, so it mirrors every store concretely and takes a real
+/// vref of the frame.  The CALL_ASSEMBLER folds build their callee frame out
+/// of recorded operations alone — `emit_new_pyframe_inline_with_params` never
+/// materializes one during the walk — so there is nothing to store into and
+/// nothing to take a vref of until the compiled loop runs.  What is recorded
+/// here is the interpreter-level reading of `jit.virtual_ref(frame)`, which
+/// is the frame pointer itself (`_jit_vref.py lowleveltype = OBJECTPTR`, no
+/// allocation) and is exactly what [`pyre_interpreter::PyExecutionContext::enter`]
+/// stores.
+///
+/// Upstream reaches `ec.enter` on this path too: `interp_jit.py` puts
+/// `jit_merge_point` on `PyFrame.dispatch`, so the CALL_ASSEMBLER that
+/// replaces the callee's merge point is recorded with `pyframe.py
+/// execute_frame`'s `ec.enter(self)` already traced ahead of it.  pyre's
+/// portal sits one level up, at `execute_frame` itself, so the fold jumps
+/// over the enter unless it records it here.
+fn record_ec_enter_frame_chain(ctx: &mut TraceCtx, callee_frame: OpRef, callee_ec: OpRef) {
+    let caller_topframeref = ctx.record_op_with_descr(
+        OpCode::GetfieldGcR,
+        &[callee_ec],
+        crate::descr::ec_topframeref_descr(),
+    );
+    ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[callee_frame, caller_topframeref],
+        crate::descr::pyframe_f_backref_descr(),
+    );
+    ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[callee_ec, callee_frame],
+        crate::descr::ec_topframeref_descr(),
+    );
+}
+
+/// `executioncontext.py ExecutionContext.leave`'s frame-chain half, in
+/// `execute_frame`'s `finally` position, recorded with no concrete shadow.
+///
+/// ```python
+/// self.topframeref = frame.f_backref
+/// ```
+///
+/// No parens on `f_backref`, so a caller frame that stayed virtual stays
+/// virtual.  The escape branch and `virtual_ref_finish` that [`walker_ec_leave`]
+/// carries have no counterpart here for the same reason the enter takes no
+/// vref: this level never held one.  The profile-hook half stays with
+/// [`pyre_interpreter::PyExecutionContext::leave`] — see [`walker_ec_leave`]
+/// for why the portal-driver GREEN makes that split sound.
+///
+/// Record this at the earliest point the call is known to have returned, not
+/// on the trace's fall-through tail: a guard recorded ahead of it skips it on
+/// the exit it is needed for, and every skipped restore leaves a frame
+/// published in `topframeref` that the next `enter` chains onto.  The portal's
+/// `TopFrameRefGuard` (`pyre-jit/src/eval.rs`) balances the slot only when the
+/// activation itself ends, which is far too late for a loop that raises.
+fn record_ec_leave_frame_chain(ctx: &mut TraceCtx, callee_frame: OpRef, callee_ec: OpRef) {
+    let f_backref = ctx.record_op_with_descr(
+        OpCode::GetfieldGcR,
+        &[callee_frame],
+        crate::descr::pyframe_f_backref_descr(),
+    );
+    ctx.record_op_with_descr(
+        OpCode::SetfieldGc,
+        &[callee_ec, f_backref],
+        crate::descr::ec_topframeref_descr(),
+    );
 }
 
 /// Resolve the generated builtin-wrapper argument slice's array-item


### PR DESCRIPTION
`try_walker_call_assembler_self_recursive` built its callee `PyFrame` and emitted
`CALL_ASSEMBLER` without recording `ExecutionContext.enter` or `leave`. The minted
frame never reached `topframeref`, so every activation the assembler ran was absent
from the `f_backref` chain that `sys._getframe` walks.

```python
def f(n):
    if n <= 0:
        return depth_here()
    return f(n - 1)

for _ in range(3000):
    f(20)
print(f(50))
```

| | before | after | cpython 3.14 | pypy3 |
|---|---|---|---|---|
| depth of warm `f(50)` | **3** | 53 | 53 | 53 |
| `f_back` names, warm `f(6)` | 3 | 9 | 9 | 9 |
| `sys._getframe(4)` in warm recursion | `ValueError` | `f` | `f` | `f` |

Cold execution was already correct; the deviation appeared only once the callee was
warm enough for the fold to fire.

## Why the fold owes the bracket

`interp_jit.py` puts `jit_merge_point` on `PyFrame.dispatch`, so a `CALL_ASSEMBLER`
that replaces the callee's merge point is recorded with `pyframe.py execute_frame`'s
`ec.enter(self)` already traced ahead of it. pyre's portal sits one level up, at
`execute_frame` itself, so a fold that jumps the portal has to carry the bracket.
This is the same structural deviation as #1517's portal work, one fold further in.

The emitted trace now carries both halves:

```
v53 = GetfieldGcR(v42)   SetfieldGc(v45, v53)   SetfieldGc(v42, v45)   # ec.enter
v59 = CallAssemblerR(v45, v42) ; GuardNotForced ; Keepalive
v63 = GetfieldGcR(v45)   SetfieldGc(v42, v63)                          # ec.leave
                                                     ; GuardNoException
```

`leave` is recorded after `GUARD_NOT_FORCED`, which `pyjitpl.py:2049-2079` keeps
adjacent to the call, and **ahead of the exception guard**. Compiled code has no
`finally`; recording it on the fall-through tail instead skips the restore on
exactly the exit that needs it, since a raising callee deopts at that guard.

## The second half: the enter creates a self-cycle

Recording the enter turned `synth/list_length_hint_validate` from 0.7s into a hang
on dynasm *and* cranelift. `install_current_frame` relinks unconditionally:

```rust
topframeref = frame;
frame.f_backref = previous_top;
```

The force and deopt legs hand the *already-entered* frame back to the portal, so
`previous_top` is the frame and `f_backref` names itself. `walk_pyframe_roots`
follows `f_backref` with no cycle guard, and the whole run went into
`walk_pyframe_roots_area`. `ExecutionContext::enter` guards this with a
`debug_assert_ne!` — which release does not compile — but this door had none,
because until now nothing else performed the enter.

It now refuses a frame the execution context already names, the way
`leave_compiled_frame_chain` does, and the guard restores what `leave` would: the
frame's own `f_backref`.

## Test

`pyre/bench/synth/frame_chain_survives_a_recursive_call_assembler.py` walks the
chain from a warm self-recursive callee at two depths, and checks the walk tracks
the depth difference.

Red/green verified on one commit by rebuilding with the three call sites disabled:

```
FAIL rec(3): the f_back chain holds 1 `rec` frames, owed 4
FAIL rec(12): the f_back chain holds 1 `rec` frames, owed 13
FAIL the chain grew by 0 frames from depth 3 to depth 12, owed 9
```

A first version of the fixture warmed at depth 0 and was **inert** — the fold never
fired (`CallAssemblerR` count 0) and it passed for free. It now warms at depth 20.

## Gate

`pyre/check.py` on this base: dynasm 502/502, cranelift 502/502, wasm 495/495,
3/3 backends, with matching PRE/POST stamps on HEAD, `check.py`, and the tree.

## Not in this PR

A warm recursive *raise* builds 9 `tb_next` nodes where cpython and pypy3 build 10.
It is pre-existing — an Aug-26 binary shows the same 9 — and a different mechanism
(the traceback node chain, whose JIT-side callers already carry deliberate
de-duplication in `call_jit.rs`), so it is left for its own change.

Also worth recording: `sys.setrecursionlimit` is *not* honoured as a frame counter
for warm recursion, but pypy3 behaves the same way (its limit is native-stack
based), so that is not a deviation to fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCct5Z2Yn3Be6Pz22GgNZw
