### PR TITLE
_socket host converters and the Windows connect timeout, a latched fatal alert, and the win32 cpython_tests overlay

### DIFF
--- a/pyre/cpython_tests/baseline.win32-AMD64.json
+++ b/pyre/cpython_tests/baseline.win32-AMD64.json
@@ -2,31 +2,40 @@
   "host": "win32-AMD64",
   "modules": {
     "test.test_eintr": {
-      "dynasm": "SKIP"
+      "dynasm": "SKIP",
+      "reason": "EINTRTests is skipUnless(os.name == 'posix', 'only supported on Unix'), so every case in the module skips and none is left to report a result"
     },
     "test.test_file_eintr": {
-      "dynasm": "SKIP"
+      "dynasm": "SKIP",
+      "reason": "the skipUnless(os.name == 'posix') sits on the TestFileIOSignalInterrupt mixin that every concrete case class inherits from, so every case skips"
     },
     "test.test_import": {
-      "dynasm": "FAIL"
+      "dynasm": "FAIL",
+      "reason": "ImportTests.test_dll_dependency_import is the module's only skipUnless(sys.platform == 'win32') case, and it reads importlib.util.find_spec('_sqlite3').origin: pyre ships no _sqlite3, so find_spec answers None. Not a platform difference in the import machinery -- a missing extension module the POSIX hosts never exercise"
     },
     "test.test_mmap": {
-      "dynasm": "FAIL"
+      "dynasm": "FAIL",
+      "reason": "MmapTests.setUp's os.unlink(TESTFN) raises PermissionError WinError 32 once a preceding case leaves the mapping's file open: finalization is not refcount-prompt and Windows refuses to unlink an open file. 40 of the 51 cases error on that one line; POSIX unlinks an open file and passes"
     },
     "test.test_msvcrt": {
-      "dynasm": "PASS"
+      "dynasm": "PASS",
+      "reason": "Windows-only module: the shared IMPORTERROR is what a POSIX host sees for import msvcrt"
     },
     "test.test_startfile": {
-      "dynasm": "PASS"
+      "dynasm": "PASS",
+      "reason": "Windows-only module: the shared IMPORTERROR is what a POSIX host sees for os.startfile"
     },
     "test.test_venv": {
-      "dynasm": "FAIL"
+      "dynasm": "FAIL",
+      "reason": "EnvBuilder.setup_python's nt branch copies venvlaunchert.exe / venvwlaunchert.exe out of venv/scripts/nt, which holds only activate.bat and deactivate.bat, so Scripts/<exe> is never produced and every case that looks for it fails. The POSIX branch copies the interpreter itself"
     },
     "test.test_winapi": {
-      "dynasm": "PASS"
+      "dynasm": "PASS",
+      "reason": "Windows-only module: the shared IMPORTERROR is what a POSIX host sees for import _winapi"
     },
     "test.test_winreg": {
-      "dynasm": "PASS"
+      "dynasm": "PASS",
+      "reason": "Windows-only module: the shared IMPORTERROR is what a POSIX host sees for import winreg"
     }
   },
   "stdlib_version": "3.14.6"

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -157,9 +157,12 @@ PLATFORM_GATED = {
         lambda p: p != "wasi",
         "cannot create socket on WASI",
     ),
-    # `if not support.has_fork_support: raise unittest.SkipTest(...)`
+    # `if not support.has_fork_support: raise unittest.SkipTest(...)`, and
+    # `has_fork_support` is `hasattr(os, "fork")` minus the platforms that
+    # have the call but cannot use it: `is_emscripten`, `is_wasi`,
+    # `is_apple_mobile` and `is_android`.
     "test.test_fork1": (
-        lambda p: p not in ("win32", "emscripten", "wasi"),
+        lambda p: p not in ("win32", "emscripten", "wasi", "ios", "tvos", "watchos", "android"),
         "os.fork() not available",
     ),
     # `if not hasattr(os, "openpty"): raise unittest.SkipTest(...)`

--- a/pyre/extra_tests/parity_tests/socket_host_idna_conversions.py
+++ b/pyre/extra_tests/parity_tests/socket_host_idna_conversions.py
@@ -1,0 +1,116 @@
+# CPython-suite gap: test_socket does not import, so nothing in the suite runs
+# a host argument through the two converters these entry points split between.
+# parity-tests reason: the three `gethostby*` functions took the address-tuple
+# converter, which hands an ASCII host straight through, and `getaddrinfo` took
+# no codec at all, so a name the `idna` codec refuses reached the resolver and
+# an internationalized name reached it spelled utf-8 rather than ACE.
+
+# pyre-check: pypy-diverges: pins the 3.14 spelling of both converters; pypy3
+# refuses a bytes host to `gethostbyname` with "'str' object expected, got
+# 'bytes' instead", spells the wrong-type and embedded-null messages its own
+# way, and lets the codec's own UnicodeError out of an address tuple.
+
+import socket
+
+IDNA_REFUSED = ("..bad..", "a" * 70 + ".example")
+
+# The name lookups encode every `str` host with the `idna` codec, so a label
+# that is empty or 64 bytes or longer is refused before the resolver sees it.
+for name in IDNA_REFUSED:
+    for call in (
+        lambda h: socket.getaddrinfo(h, 80),
+        socket.gethostbyname,
+        socket.gethostbyname_ex,
+        socket.gethostbyaddr,
+    ):
+        try:
+            call(name)
+        except UnicodeEncodeError as e:
+            assert e.encoding == "idna", e.encoding
+            assert e.object == name, e.object
+        else:
+            raise SystemExit("%r was accepted" % (name,))
+
+# A bytes host already names an encoded host and is passed through untouched.
+assert socket.gethostbyname(b"127.0.0.1") == "127.0.0.1"
+assert socket.gethostbyname(bytearray(b"127.0.0.1")) == "127.0.0.1"
+
+# The wrong type and an embedded null are both TypeErrors naming the function
+# the argument was passed to.
+for bad, spelled in ((42, "int"), (None, "None"), (memoryview(b"x"), "memoryview")):
+    try:
+        socket.gethostbyname(bad)
+    except TypeError as e:
+        assert str(e) == (
+            "gethostbyname() argument 1 must be str, bytes or bytearray, not " + spelled
+        ), str(e)
+    else:
+        raise SystemExit("gethostbyname accepted %r" % (bad,))
+
+for null_host, spelled in (("127.0.0.1\x00zz", "str"), (b"127.0.0.1\x00zz", "bytes")):
+    try:
+        socket.gethostbyname(null_host)
+    except TypeError as e:
+        assert str(e) == (
+            "gethostbyname() argument 1 must be encoded string without null bytes,"
+            " not " + spelled
+        ), str(e)
+    else:
+        raise SystemExit("gethostbyname accepted an embedded null")
+
+# `getaddrinfo` hands its host and its service to the resolver as C strings, so
+# each simply stops at the first null.
+numeric = socket.getaddrinfo("127.0.0.1", 80, socket.AF_INET)
+assert socket.getaddrinfo("127.0.0.1\x00zz", 80, socket.AF_INET) == numeric
+assert socket.getaddrinfo(b"127.0.0.1\x00zz", 80, socket.AF_INET) == numeric
+assert socket.getaddrinfo("127.0.0.1", "80\x00zz", socket.AF_INET) == numeric
+
+# An address tuple takes the other converter: an ASCII `str` never enters the
+# codec, and bytes and bytearray are accepted beside it.
+for host in ("127.0.0.1", b"127.0.0.1", bytearray(b"127.0.0.1")):
+    sock = socket.socket()
+    try:
+        sock.bind((host, 0))
+    finally:
+        sock.close()
+
+for bad, spelled in ((42, "int"), (None, "NoneType"), (memoryview(b"x"), "memoryview")):
+    sock = socket.socket()
+    try:
+        sock.bind((bad, 0))
+    except TypeError as e:
+        assert str(e) == "str, bytes or bytearray expected, not " + spelled, str(e)
+    else:
+        raise SystemExit("bind accepted %r" % (bad,))
+    finally:
+        sock.close()
+
+sock = socket.socket()
+try:
+    sock.bind(("127.0.0.1\x00zz", 0))
+except TypeError as e:
+    assert str(e) == "host name must not contain null character", str(e)
+else:
+    raise SystemExit("bind accepted an embedded null")
+finally:
+    sock.close()
+
+
+# The fast path is the compact-ASCII representation, which no `str` subclass
+# instance has, so a subclass host enters the codec, and a codec failure there
+# is reported as one message rather than as the codec's own error.
+class Host(str):
+    pass
+
+
+sock = socket.socket()
+try:
+    sock.bind((Host("a" * 70 + ".example"), 0))
+except TypeError as e:
+    assert str(e) == "encoding of hostname failed", str(e)
+else:
+    raise SystemExit("bind accepted a subclass host the codec refuses")
+finally:
+    sock.close()
+
+print("OK")

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -2639,8 +2639,8 @@ fn socket_wait_readable(
 /// and the wait for its outcome is explicit; POSIX's `SO_SNDTIMEO` already
 /// bounds the call and keeps the straight-line path.
 ///
-/// Returns the code the attempt reported, `WSAETIMEDOUT` on expiry, so both
-/// `connect` and `connect_ex` can shape it the way each one answers.
+/// Returns the code the attempt reported, so both `connect` and `connect_ex`
+/// can shape it the way each one answers.
 #[cfg(windows)]
 fn socket_connect_timed(
     fd: rffi::Socket,
@@ -2681,7 +2681,12 @@ fn socket_connect_wait(
         return Err(poll_errno);
     }
     if ready == 0 {
-        return Err(rffi::ETIMEDOUT);
+        // `_connect` answers the expiry with `WSAEWOULDBLOCK` — the code the
+        // non-blocking connect itself reported — beside a separate timeout
+        // flag.  `connect_ex` returns that code, and `connect` reads it back
+        // through `socket_io_err_for_operation`, which a positive timeout
+        // turns into the `TimeoutError` the flag stands for.
+        return Err(rffi::WSAEWOULDBLOCK);
     }
     // `SO_ERROR` carries the outcome of a connect that finished after its call
     // returned; zero means it succeeded.

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -29,34 +29,34 @@ use super::rsocket_rffi as rffi;
 /// constants/helpers above are usable, but `socket.socket(...)` raises
 /// the C-extension stub error.
 
-/// `interp_socket.py converted_error` — turn an rsocket
-/// `SocketError` subclass into the matching python-level exception.
+/// `interp_socket.py idna_converter` — turn the host of an address tuple
+/// into the bytes a sockaddr is built from.  Accepts str / bytes /
+/// bytearray, refuses an embedded null, and — unlike `socket_encode_idna`
+/// — hands an ASCII host straight through, so a numeric address or a
+/// plain ASCII name never enters the codec.
 ///
-/// `applevelerrcls` matches the field defined on each rsocket error
-/// class (`rpython/rlib/rsocket.py:1316/1360/1372/1383`):
-///   "error"    → builtin `OSError`
-///   "gaierror" → `_socket.gaierror` (OSError subclass)
-///   "herror"   → `_socket.herror`   (OSError subclass)
-///   "timeout"  → builtin `TimeoutError` (per `get_error()` line 1062-3,
-///                NOT the `_socket.timeout` attribute, which is a
-///                separate OSError subclass exposed for `isinstance` use)
-///
-/// When `errno` is `Some`, builds the exception with `(errno, message)`
-/// like `SocketErrorWithErrno` (`interp_socket.py:1074-1075`); otherwise
-/// only `(message,)` like the plain SocketError (`:1077-1078`).
-/// `interp_socket.py idna_converter` — turn a hostname argument
-/// into a `Vec<u8>` suitable for passing to a DNS resolver.
-///
-/// Accepts str / bytes / bytearray.  For str: tries ASCII first; on
-/// UnicodeEncodeError falls back to the `idna` codec.  Embedded null
-/// bytes raise TypeError (matching `:120-122`).  Other input types
-/// raise TypeError.
+/// Three details follow `getsockaddrarg`'s own converter rather than
+/// `idna_converter`, which spells each of them differently.  The fast
+/// path is gated on the argument being an exact `str`, matching the
+/// compact-ASCII representation no `str` subclass instance has, where
+/// `idna_converter` gates on an ascii *encode* succeeding.  A codec
+/// failure becomes a bare TypeError rather than the codec's own error.
+/// And the wrong-type message names the three accepted types.  MEASURED
+/// 2026-08-27 with `class S(str): pass`: `connect((S("a" * 70), 80))`
+/// answers `TypeError("encoding of hostname failed")` under CPython
+/// 3.14.2 and `gaierror(11001)` under PyPy 7.3.22, and a host whose
+/// first label is empty answers that same TypeError against
+/// `UnicodeError("encoding with 'idna' codec failed ...")`.
 #[cfg(any(unix, windows))]
 fn socket_idna_converter(w_host: pyre_object::PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
+    let wrong_type = |obj: pyre_object::PyObjectRef| {
+        crate::PyError::type_error(format!(
+            "str, bytes or bytearray expected, not {}",
+            crate::type_methods::arg_type_name(obj)
+        ))
+    };
     if w_host.is_null() {
-        return Err(crate::PyError::type_error(
-            "string or unicode text buffer expected, not None",
-        ));
+        return Err(wrong_type(w_host));
     }
     let bytes: Vec<u8> = unsafe {
         if pyre_object::is_str(w_host) {
@@ -64,22 +64,28 @@ fn socket_idna_converter(w_host: pyre_object::PyObjectRef) -> Result<Vec<u8>, cr
             // utf-8 view — one carrying a lone surrogate — reaches the `idna`
             // fallback the same way any other non-ASCII host does.
             let s = pyre_object::unicodeobject::w_str_get_wtf8(w_host);
-            if s.as_bytes().is_ascii() {
+            if pyre_object::is_exact_type(w_host, &pyre_object::STR_TYPE) && s.as_bytes().is_ascii()
+            {
                 s.as_bytes().to_vec()
             } else {
                 // `space.encode_unicode_object(w_host, 'idna', None)`: the
                 // codec runs on the string value itself rather than through
                 // an `encode` attribute lookup, so a `str` subclass cannot
-                // decide how its hostname reaches the resolver, and the
-                // error a caller sees is the codec's own rejection.
-                crate::type_methods::encode_object(w_host, "idna", "strict")?
+                // decide how its hostname reaches the resolver.  Whatever it
+                // raised is dropped for the one message that covers every way
+                // an address host can fail to encode, which also drops a
+                // failure the codec did not cause.
+                crate::type_methods::encode_object(w_host, "idna", "strict")
+                    .map_err(|_| crate::PyError::type_error("encoding of hostname failed"))?
             }
         } else if pyre_object::bytesobject::is_bytes_like(w_host) {
-            pyre_object::w_bytes_data(w_host).to_vec()
+            // The guard admits a bytearray, so the read has to dispatch on
+            // the storage type: `w_bytes_data` would take a
+            // `W_BytearrayObject`'s `*mut Vec<u8>` for a `*const BytesBlock`
+            // and slice from the capacity word.
+            pyre_object::bytesobject::bytes_like_data(w_host).to_vec()
         } else {
-            return Err(crate::PyError::type_error(
-                "string or unicode text buffer expected",
-            ));
+            return Err(wrong_type(w_host));
         }
     };
     if bytes.contains(&0) {
@@ -90,6 +96,99 @@ fn socket_idna_converter(w_host: pyre_object::PyObjectRef) -> Result<Vec<u8>, cr
     Ok(bytes)
 }
 
+/// `interp_func.py encode_idna` — run the `idna` codec over a host
+/// argument with no ASCII shortcut, so an empty label or one 64 bytes or
+/// longer is refused before any resolver sees it and an
+/// internationalized name reaches the resolver in its ACE spelling.
+/// `caller` names the function the argument was passed to.
+///
+/// `encode_idna` hands the argument to the unbound `unicode.encode`, so a
+/// `bytes` or `bytearray` host is a TypeError from the gateway there.  The
+/// `et` argument converter these three entry points parse their host with
+/// accepts both and passes them through untouched, and that is the 3.14
+/// answer.  MEASURED 2026-08-27: `gethostbyname(b"localhost")` and
+/// `gethostbyname(bytearray(b"localhost"))` both answer `"127.0.0.1"`
+/// under CPython 3.14.2, where PyPy 7.3.22 raises
+/// `TypeError("'str' object expected, got 'bytes' instead")`.  Only a
+/// `str` is ever encoded: the bytes forms already name an encoded host.
+#[cfg(any(unix, windows))]
+fn socket_encode_idna(
+    caller: &str,
+    w_host: pyre_object::PyObjectRef,
+) -> Result<Vec<u8>, crate::PyError> {
+    unsafe {
+        if pyre_object::is_str(w_host) {
+            crate::type_methods::encode_object(w_host, "idna", "strict")
+        } else if pyre_object::bytesobject::is_bytes_like(w_host) {
+            Ok(pyre_object::bytesobject::bytes_like_data(w_host).to_vec())
+        } else {
+            Err(crate::PyError::type_error(format!(
+                "{caller}() argument 1 must be str, bytes or bytearray, not {}",
+                crate::type_methods::clinic_arg_type_name(w_host)
+            )))
+        }
+    }
+}
+
+/// The host argument of `gethostbyname`, `gethostbyname_ex` and
+/// `gethostbyaddr`: `socket_encode_idna` followed by the `et` converter's
+/// own `strlen(buf) != size` scan, which refuses a host carrying an
+/// embedded null.  `encode_idna` has no such scan — MEASURED 2026-08-27,
+/// PyPy 7.3.22 resolves a host whose name is followed by a null and more
+/// text as if the text were not there, because the resolver stops at the
+/// null — so the refusal is the 3.14 answer.
+///
+/// The scan runs after the codec, so a host that is both bad idna and
+/// null-bearing reports the codec's error.  The type name the message
+/// wants is read first: the codec runs Python, and `w_host` is a bare
+/// reference that a collection can leave behind.
+#[cfg(any(unix, windows))]
+fn socket_idna_host_arg(
+    caller: &str,
+    w_host: pyre_object::PyObjectRef,
+) -> Result<std::ffi::CString, crate::PyError> {
+    let type_name = crate::type_methods::clinic_arg_type_name(w_host);
+    let bytes = socket_encode_idna(caller, w_host)?;
+    std::ffi::CString::new(bytes).map_err(|_| {
+        crate::PyError::type_error(format!(
+            "{caller}() argument 1 must be encoded string without null bytes, not {type_name}"
+        ))
+    })
+}
+
+/// The C string a `getaddrinfo` argument becomes.  Neither
+/// `interp_func.py getaddrinfo` nor the 3.14 entry point scans its host or
+/// its service for an embedded null: the encoded bytes are handed to
+/// `getaddrinfo` as a C string, so the name simply stops at the first one.
+/// MEASURED 2026-08-27: a host of `"localhost"` followed by a null and
+/// more text resolves to what `"localhost"` alone resolves to under
+/// CPython 3.14.2 and PyPy 7.3.22 alike.
+#[cfg(any(unix, windows))]
+fn socket_cstring_at_nul(mut bytes: Vec<u8>) -> std::ffi::CString {
+    if let Some(nul) = bytes.iter().position(|&b| b == 0) {
+        bytes.truncate(nul);
+    }
+    // The truncation removed every interior null.
+    std::ffi::CString::new(bytes).unwrap()
+}
+
+/// `interp_socket.py converted_error` — turn an rsocket
+/// `SocketError` subclass into the matching python-level exception.
+///
+/// `applevelerrcls` matches the field defined on each rsocket error class
+/// (`rsocket.py` `SocketError`, `GAIError`, `HSocketError`,
+/// `SocketTimeout`):
+///   "error"    → builtin `OSError`
+///   "gaierror" → `_socket.gaierror` (OSError subclass)
+///   "herror"   → `_socket.herror`   (OSError subclass)
+///   "timeout"  → builtin `TimeoutError` (`get_error` answers
+///                `space.w_TimeoutError` for that name, NOT the
+///                `_socket.timeout` attribute, which is a separate
+///                OSError subclass exposed for `isinstance` use)
+///
+/// When `errno` is `Some`, builds the exception with `(errno, message)`
+/// the way `converted_error` does for a `SocketErrorWithErrno`; otherwise
+/// only `(message,)`, like the plain `SocketError`.
 #[cfg(any(unix, windows))]
 fn socket_converted_error(
     applevelerrcls: &str,
@@ -1193,9 +1292,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "gethostbyname() missing argument",
                         ));
                     }
-                    let host_bytes = socket_idna_converter(args[0])?;
-                    let c = std::ffi::CString::new(host_bytes)
-                        .map_err(|_| crate::PyError::value_error("embedded null"))?;
+                    let c = socket_idna_host_arg("gethostbyname", args[0])?;
                     // `rsocket.gethostbyname` is `makeipaddr(name, INETAddress())`
                     // and `socket_gethostbyname` is `setipaddr(name, AF_INET)`:
                     // both resolve, neither calls the `gethostbyname` of the
@@ -1231,9 +1328,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "gethostbyname_ex() missing argument",
                         ));
                     }
-                    let host_bytes = socket_idna_converter(args[0])?;
-                    let c = std::ffi::CString::new(host_bytes)
-                        .map_err(|_| crate::PyError::value_error("embedded null"))?;
+                    let c = socket_idna_host_arg("gethostbyname_ex", args[0])?;
                     // `rsocket.gethostbyname_ex` resolves the name first and
                     // only then reads the `hostent`, so an unresolvable name
                     // reports `gaierror` and a name the resolver knows but the
@@ -1265,9 +1360,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "gethostbyaddr() missing argument",
                         ));
                     }
-                    let host_bytes = socket_idna_converter(args[0])?;
-                    let c = std::ffi::CString::new(host_bytes)
-                        .map_err(|_| crate::PyError::value_error("embedded null"))?;
+                    let c = socket_idna_host_arg("gethostbyaddr", args[0])?;
                     // `rsocket.gethostbyaddr` is `makeipaddr(ip)` — the
                     // argument is resolved for whichever family answers, not
                     // required to be numeric — and only the reverse lookup that
@@ -2123,32 +2216,33 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                     "getaddrinfo() missing host or port",
                 ));
             }
-            // host: None | str
-            let host_obj = args[0];
+            // `socket_encode_idna` runs the codec, which is Python and can
+            // collect, and the native argument slice is only current at
+            // entry: pin the arguments and read each one back from its slot.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let args_base = pyre_object::gc_roots::pin_roots(args);
+            // host: None | bytes | str
+            let host_obj = pyre_object::gc_roots::shadow_stack_get(args_base);
             let host: Option<std::ffi::CString> = unsafe {
                 if pyre_object::is_none(host_obj) {
                     None
                 } else if pyre_object::bytesobject::is_bytes(host_obj) {
-                    Some(
-                        std::ffi::CString::new(
-                            pyre_object::bytesobject::bytes_like_data(host_obj),
-                        )
-                        .map_err(|_| crate::PyError::value_error("embedded null in host"))?,
-                    )
+                    Some(socket_cstring_at_nul(
+                        pyre_object::bytesobject::bytes_like_data(host_obj).to_vec(),
+                    ))
                 } else if pyre_object::is_str(host_obj) {
-                    let s = crate::baseobjspace::str_utf8_w(host_obj)?.to_string();
-                    Some(
-                        std::ffi::CString::new(s.as_bytes())
-                            .map_err(|_| crate::PyError::value_error("embedded null in host"))?,
-                    )
+                    Some(socket_cstring_at_nul(socket_encode_idna(
+                        "getaddrinfo",
+                        host_obj,
+                    )?))
                 } else {
                     return Err(crate::PyError::type_error(
                         "getaddrinfo() argument 1 must be string or None",
                     ));
                 }
             };
-            // port: None | int | str
-            let port_obj = args[1];
+            // port: None | int | bytes | str
+            let port_obj = pyre_object::gc_roots::shadow_stack_get(args_base + 1);
             let port: Option<std::ffi::CString> = unsafe {
                 if pyre_object::is_none(port_obj) {
                     None
@@ -2156,18 +2250,15 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                     let v = pyre_object::w_int_get_value(port_obj);
                     Some(std::ffi::CString::new(format!("{v}")).unwrap())
                 } else if pyre_object::bytesobject::is_bytes(port_obj) {
-                    Some(
-                        std::ffi::CString::new(
-                            pyre_object::bytesobject::bytes_like_data(port_obj),
-                        )
-                        .map_err(|_| crate::PyError::value_error("embedded null in port"))?,
-                    )
+                    Some(socket_cstring_at_nul(
+                        pyre_object::bytesobject::bytes_like_data(port_obj).to_vec(),
+                    ))
                 } else if pyre_object::is_str(port_obj) {
+                    // The service is spelled utf-8 rather than idna:
+                    // `getaddrinfo` encodes it with
+                    // `space.encode_unicode_object(w_port, 'utf-8', 'strict')`.
                     let s = crate::baseobjspace::str_utf8_w(port_obj)?.to_string();
-                    Some(
-                        std::ffi::CString::new(s.as_bytes())
-                            .map_err(|_| crate::PyError::value_error("embedded null in port"))?,
-                    )
+                    Some(socket_cstring_at_nul(s.into_bytes()))
                 } else {
                     return Err(crate::PyError::type_error(
                         "getaddrinfo() argument 2 must be integer or string",
@@ -2178,12 +2269,13 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
             let int_arg =
                 |idx: usize, default: libc::c_int| -> Result<libc::c_int, crate::PyError> {
                     if args.len() > idx {
-                        if !unsafe { pyre_object::is_int(args[idx]) } {
+                        let v = pyre_object::gc_roots::shadow_stack_get(args_base + idx);
+                        if !unsafe { pyre_object::is_int(v) } {
                             return Err(crate::PyError::type_error(
                                 "getaddrinfo: family/type/proto/flags must be integers",
                             ));
                         }
-                        Ok(unsafe { pyre_object::w_int_get_value(args[idx]) } as libc::c_int)
+                        Ok(unsafe { pyre_object::w_int_get_value(v) } as libc::c_int)
                     } else {
                         Ok(default)
                     }
@@ -3426,14 +3518,15 @@ fn pack_inet_addr(
     }
     let host_obj = unsafe { pyre_object::w_tuple_getitem(addr, 0) }
         .ok_or_else(|| crate::PyError::value_error("address: missing host"))?;
+    // `idna_converter` runs the codec for a host that is not a plain ASCII
+    // `str`, which is Python and can collect, so the tuple is pinned across
+    // the conversion and every later read goes through the slot.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let addr_slot = pyre_object::gc_roots::pin_roots(&[addr, host_obj]);
+    let host = socket_idna_converter(pyre_object::gc_roots::shadow_stack_get(addr_slot + 1))?;
+    let addr = pyre_object::gc_roots::shadow_stack_get(addr_slot);
     let port_obj = unsafe { pyre_object::w_tuple_getitem(addr, 1) }
         .ok_or_else(|| crate::PyError::value_error("address: missing port"))?;
-    let host = unsafe {
-        if !pyre_object::is_str(host_obj) {
-            return Err(crate::PyError::type_error("address host must be a string"));
-        }
-        crate::baseobjspace::str_utf8_w(host_obj)?.to_string()
-    };
     if !unsafe { pyre_object::is_int(port_obj) } {
         return Err(crate::PyError::type_error(
             "address port must be an integer",
@@ -3449,14 +3542,24 @@ fn pack_inet_addr(
     }
     let port = (port_raw as u16).to_be();
 
-    let c_host = std::ffi::CString::new(host.as_bytes())
-        .map_err(|_| crate::PyError::value_error("embedded null in host"))?;
+    // The resolver below releases the GIL, so read what is left of the tuple
+    // out of it first; `addr` is a bare reference and a collection that runs
+    // meanwhile can leave it behind.
+    let tuple_int = |index: i64| -> Option<u32> {
+        unsafe { pyre_object::w_tuple_getitem(addr, index) }
+            .map(|v| unsafe { pyre_object::w_int_get_value(v) } as u32)
+    };
+    let flowinfo = if len >= 3 { tuple_int(2) } else { None };
+    let scope_id = if len >= 4 { tuple_int(3) } else { None };
+
+    // `socket_idna_converter` already refused every null.
+    let c_host = std::ffi::CString::new(host).unwrap();
     if family == rffi::AF_INET {
         let sin = unsafe { &mut *(&mut storage as *mut _ as *mut rffi::sockaddr_in) };
         sin.sin_family = rffi::AF_INET as rffi::SaFamily;
         sin.sin_port = port;
         // inet_pton handles both "0.0.0.0" and dotted-quad.
-        let r = if host.is_empty() {
+        let r = if c_host.as_bytes().is_empty() {
             // RSocket.makeipaddr('', result) uses the wildcard address for
             // bind(), as required by socketserver and socket_helper.bind_port.
             rffi::sockaddr_in_set_addr(sin, rffi::INADDR_ANY);
@@ -3484,7 +3587,7 @@ fn pack_inet_addr(
         sin6.sin6_family = rffi::AF_INET6 as rffi::SaFamily;
         sin6.sin6_port = port;
         let mut buf = [0u8; 16];
-        let r = if host.is_empty() {
+        let r = if c_host.as_bytes().is_empty() {
             1
         } else {
             unsafe {
@@ -3505,15 +3608,12 @@ fn pack_inet_addr(
             rffi::sockaddr_in6_set_scope_id(sin6, rffi::sockaddr_in6_get_scope_id(found));
         }
         rffi::sockaddr_in6_set_addr(sin6, buf);
-        if len >= 3
-            && let Some(v) = unsafe { pyre_object::w_tuple_getitem(addr, 2) } {
-                sin6.sin6_flowinfo = unsafe { pyre_object::w_int_get_value(v) } as u32;
-            }
-        if len >= 4
-            && let Some(v) = unsafe { pyre_object::w_tuple_getitem(addr, 3) } {
-                let scope_id = unsafe { pyre_object::w_int_get_value(v) } as u32;
-                rffi::sockaddr_in6_set_scope_id(sin6, scope_id);
-            }
+        if let Some(v) = flowinfo {
+            sin6.sin6_flowinfo = v;
+        }
+        if let Some(v) = scope_id {
+            rffi::sockaddr_in6_set_scope_id(sin6, v);
+        }
         Ok((
             storage,
             core::mem::size_of::<rffi::sockaddr_in6>() as rffi::SockLen,
@@ -4105,7 +4205,17 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let fd = socket_fd(obj)?;
                 let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
                 let proto = socket_get_attr_i64(obj, "_proto") as libc::c_int;
+                // `pack_inet_addr` runs Python for a host that is not a plain
+                // ASCII `str`, so the socket is read back from its slot
+                // rather than from the native argument slice, which is
+                // only current at entry.
+                #[cfg(windows)]
+                let _roots = pyre_object::gc_roots::push_roots();
+                #[cfg(windows)]
+                let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
                 let (storage, slen) = pack_inet_addr("connect", family, proto, args[1])?;
+                #[cfg(windows)]
+                let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
                 #[cfg(windows)]
                 if let Some(timeout) = socket_positive_timeout(obj) {
                     return match socket_connect_timed(fd, &storage, slen, timeout) {
@@ -4152,7 +4262,17 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let fd = socket_fd(obj)?;
                 let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
                 let proto = socket_get_attr_i64(obj, "_proto") as libc::c_int;
+                // `pack_inet_addr` runs Python for a host that is not a plain
+                // ASCII `str`, so the socket is read back from its slot
+                // rather than from the native argument slice, which is
+                // only current at entry.
+                #[cfg(windows)]
+                let _roots = pyre_object::gc_roots::push_roots();
+                #[cfg(windows)]
+                let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
                 let (storage, slen) = pack_inet_addr("connect_ex", family, proto, args[1])?;
+                #[cfg(windows)]
+                let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
                 #[cfg(windows)]
                 if let Some(timeout) = socket_positive_timeout(obj) {
                     let err = socket_connect_timed(fd, &storage, slen, timeout).err();
@@ -4361,7 +4481,14 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let buf = buffer.as_bytes();
                 let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
                 let proto = socket_get_attr_i64(obj, "_proto") as libc::c_int;
+                // `pack_inet_addr` runs Python for a host that is not a plain
+                // ASCII `str`, so the socket is read back from its slot
+                // rather than from the native argument slice, which is
+                // only current at entry.
+                let _roots = pyre_object::gc_roots::push_roots();
+                let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
                 let (storage, slen) = pack_inet_addr("sendto", family, proto, addr_obj)?;
+                let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
                 loop {
                     let (r, errno) = socket_call(|| unsafe {
                         rffi::sendto(
@@ -5038,6 +5165,11 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             } else {
                 0
             };
+            // `pack_inet_addr` runs Python for a host that is not a plain
+            // ASCII `str`, so the socket is read back from its slot rather
+            // than from the native argument slice, which is only current at
+            // entry.  The scope opened above covers the slot.
+            let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
             let (addr_storage, addr_len) =
                 if args.len() >= 5 && !unsafe { pyre_object::is_none(args[4]) } {
                     let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
@@ -5047,6 +5179,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 } else {
                     (None, 0)
                 };
+            let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
 
             // Lay out cmsgs into a single control buffer.
             let total_control: usize = cmsgs

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -2214,8 +2214,7 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                 unsafe { rffi::getaddrinfo(host_ptr, port_ptr, &hints, &mut res) }
             };
             if rc != 0 {
-                let msg = rffi::gai_strerror(rc);
-                return Err(socket_converted_error("gaierror", Some(rc), &msg));
+                return Err(set_gaierror(rc));
             }
 
             // Every field and entry is freshly allocated and the next lap
@@ -2337,8 +2336,7 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                     unsafe { rffi::getaddrinfo(c_host.as_ptr(), c_port.as_ptr(), &hints, &mut res) }
                 };
                 if rc != 0 {
-                    let msg = rffi::gai_strerror(rc);
-                    return Err(socket_converted_error("gaierror", Some(rc), &msg));
+                    return Err(set_gaierror(rc));
                 }
                 let head = res;
                 let ai = unsafe { &*head };
@@ -2380,8 +2378,7 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                 };
                 unsafe { rffi::freeaddrinfo(head) };
                 if nrc != 0 {
-                    let msg = rffi::gai_strerror(nrc);
-                    return Err(socket_converted_error("gaierror", Some(nrc), &msg));
+                    return Err(set_gaierror(nrc));
                 }
                 let host_s = unsafe {
                     std::ffi::CStr::from_ptr(host_buf.as_ptr())
@@ -3191,6 +3188,28 @@ fn c_uint_converter(
     }
 }
 
+/// The failure `getaddrinfo` / `getnameinfo` report through their return code
+/// rather than through `errno`.
+///
+/// `set_gaierror` spells the message `gai_strerror(error)` only where
+/// `HAVE_GAI_STRERROR` is defined, and the Windows build does not define it —
+/// `socket` publishes no `gai_strerror` there either — so the message is the
+/// fixed `"getaddrinfo failed"`.  `rsocket.GAIError.get_msg` answers
+/// `_rsocket_rffi.gai_strerror_str`, which on Windows is
+/// `rwin32.FormatError(errno)`; that spelling is the system message table's,
+/// so it comes back in the host's UI language.  MEASURED 2026-08-27 against
+/// CPython 3.14.2 on a ko-KR host: `socket.getaddrinfo` on an unresolvable
+/// name answers `gaierror(11001, 'getaddrinfo failed')` there and
+/// `gaierror(11001, '<localized>')` under PyPy 7.3.22.
+#[cfg(any(unix, windows))]
+fn set_gaierror(error: libc::c_int) -> crate::PyError {
+    #[cfg(unix)]
+    let message = rffi::gai_strerror(error);
+    #[cfg(windows)]
+    let message = "getaddrinfo failed".to_string();
+    socket_converted_error("gaierror", Some(error), &message)
+}
+
 /// The failure `gethostbyname` / `gethostbyaddr` report, which they leave in
 /// `h_errno` rather than `errno`.
 ///
@@ -3228,8 +3247,8 @@ fn sockaddr_len_of(family: libc::c_int) -> Option<usize> {
 /// bit pattern.  Everything else ends in
 /// `getaddrinfo(name, None, family=family, address_to_fill=result)`, and
 /// `rsocket.py getaddrinfo` answers a non-zero return with
-/// `raise GAIError(error)` — so a name that does not resolve reports
-/// `gaierror(rc, gai_strerror(rc))`, which is what callers classify on.
+/// `raise GAIError(error)` — so a name that does not resolve reports the
+/// `gaierror` `set_gaierror` builds, which is what callers classify on.
 /// gethostbyname is not used here: its process-global result buffer is not
 /// re-entrant and was corrupted by socketserver worker threads.
 #[cfg(any(unix, windows))]
@@ -3272,11 +3291,7 @@ fn resolve_ip_host(
         unsafe { rffi::getaddrinfo(name_ptr, service_ptr, &hints, &mut result) }
     };
     if rc != 0 {
-        return Err(socket_converted_error(
-            "gaierror",
-            Some(rc),
-            &rffi::gai_strerror(rc),
-        ));
+        return Err(set_gaierror(rc));
     }
     let ambiguous_wildcard =
         wildcard && !result.is_null() && !unsafe { &*result }.ai_next.is_null();

--- a/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
@@ -108,10 +108,6 @@ pub const WSAENOTSOCK: i32 = ws::WSAENOTSOCK;
 /// room left, which is the one failure a caller may choose to drop.
 #[cfg(windows)]
 pub const WSAEWOULDBLOCK: i32 = ws::WSAEWOULDBLOCK;
-/// The code an expired wait reports, so a timeout this module times itself
-/// reads back the same as one the host produced.
-#[cfg(windows)]
-pub const ETIMEDOUT: i32 = ws::WSAETIMEDOUT;
 #[cfg(windows)]
 pub const NI_MAXHOST: usize = ws::NI_MAXHOST as usize;
 #[cfg(windows)]

--- a/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
@@ -189,28 +189,15 @@ pub fn error_is_would_block(code: i32) -> bool {
     code == ws::WSAEWOULDBLOCK || code == ws::WSAETIMEDOUT
 }
 
-/// `gai_strerror`.  The symbol is a header-level inline on Windows, where the
-/// `EAI_*` codes are WSA error codes and the system message table describes
-/// them.
+/// `gai_strerror`.  Unix only: the symbol is a header-level inline over the
+/// system message table on Windows, `HAVE_GAI_STRERROR` is not defined for
+/// that build, and `set_gaierror` spells the message itself there, so nothing
+/// asks for it.
 #[cfg(unix)]
 pub fn gai_strerror(code: libc::c_int) -> String {
     unsafe { std::ffi::CStr::from_ptr(libc::gai_strerror(code)) }
         .to_string_lossy()
         .into_owned()
-}
-#[cfg(all(windows, feature = "host_env"))]
-pub fn gai_strerror(code: libc::c_int) -> String {
-    rustpython_host_env::windows::format_error_message(Some(code as u32))
-        .map(|message| {
-            message
-                .trim_end_matches(|c: char| c <= ' ' || c == '.')
-                .to_string()
-        })
-        .unwrap_or_else(|| format!("Unknown error {code}"))
-}
-#[cfg(all(windows, not(feature = "host_env")))]
-pub fn gai_strerror(code: libc::c_int) -> String {
-    format!("Unknown error {code}")
 }
 
 // ── name lookups ──

--- a/pyre/pyre-native/src/ssl.rs
+++ b/pyre/pyre-native/src/ssl.rs
@@ -2939,6 +2939,12 @@ pub struct TlsConnection {
     context_identity: usize,
     server_context: *const Context,
     server_hit_counted: bool,
+    /// `SSL_RECEIVED_SHUTDOWN`: a fatal alert from the peer ends the
+    /// session, and every later operation answers from that state rather
+    /// than from the wire.  rustls latches the same fact inside
+    /// `process_new_packets`, but only a call that consumed fresh
+    /// ciphertext reaches it, so the latch is kept here too.
+    peer_sent_fatal_alert: bool,
 }
 
 impl TlsConnection {
@@ -3046,7 +3052,10 @@ impl TlsConnection {
                 Err(error) => return Err(rustls_error(error)),
             };
             self.pending_received_tls_start += read;
-            inner.process_new_packets().map_err(rustls_protocol_error)?;
+            if let Err(error) = inner.process_new_packets() {
+                self.peer_sent_fatal_alert |= matches!(error, rustls::Error::AlertReceived(_));
+                return Err(rustls_protocol_error(error));
+            }
             self.note_server_resumption();
             self.compact_received_tls();
         }
@@ -3283,6 +3292,7 @@ pub unsafe fn connection_new(
         context_identity: context.identity,
         server_context: std::ptr::null(),
         server_hit_counted: false,
+        peer_sent_fatal_alert: false,
     })))
 }
 
@@ -3533,7 +3543,15 @@ pub unsafe fn connection_write_plain(
     data: &[u8],
 ) -> TlsResult<usize> {
     use std::io::Write;
-    unsafe { (&mut *connection).active_mut()? }
+    let connection = unsafe { &mut *connection };
+    if connection.peer_sent_fatal_alert {
+        return Err((
+            TLS_ERROR_ZERO_RETURN,
+            "TLS/SSL connection has been closed (EOF)".to_string(),
+        ));
+    }
+    connection
+        .active_mut()?
         .writer()
         .write(data)
         .map_err(rustls_error)
@@ -3558,6 +3576,18 @@ pub unsafe fn connection_read_plain(
         Ok(read) => {
             output.truncate(read);
             Ok(output)
+        }
+        // A session the peer ended with a fatal alert has no more plaintext
+        // coming, and `SSL_read` answers `SSL_ERROR_ZERO_RETURN` from
+        // `SSL_RECEIVED_SHUTDOWN` rather than asking the transport again.
+        // rustls' reader reports `WouldBlock` for both, so without the latch
+        // the caller goes back to the socket and reports whatever it finds
+        // there instead of the alert.
+        Err(error)
+            if error.kind() == std::io::ErrorKind::WouldBlock
+                && connection.peer_sent_fatal_alert =>
+        {
+            Ok(Vec::new())
         }
         Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Err((
             TLS_ERROR_WANT_READ,


### PR DESCRIPTION
Four strands, all measured against CPython 3.14.2 and PyPy 7.3.22 on a
Windows host.

## `_socket` host conversion

**`_socket: split the host converters the two upstream entry points use`** —
`interp_func.py encode_idna` and `interp_socket.py idna_converter` are two
separate converters. Only the second was ported, and it was wired to the
three functions that take the first. Consequences, all fixed here:

- an internationalized name reached the resolver spelled utf-8 rather than
  ACE, and a name the `idna` codec refuses (an empty label, a label 64 bytes
  or longer) reached it at all;
- a `bytes` or `bytearray` host was refused by an address tuple, which
  `bind` / `connect` / `connect_ex` / `sendto` / `sendmsg` share;
- a `bytearray` host was read through the bytes-only accessor, which takes a
  `W_BytearrayObject`'s `*mut Vec<u8>` for a `*const BytesBlock` and slices
  from the capacity word;
- `getaddrinfo` refused an embedded null in its host and its service where
  both upstreams stop the name at it.

`socket_encode_idna` now serves `gethostbyname`, `gethostbyname_ex`,
`gethostbyaddr` and the `str` arm of `getaddrinfo`; `socket_idna_converter`
keeps the ASCII-first form and serves `pack_inet_addr` alone.

Running the codec is running Python where none ran before, so `getaddrinfo`
pins its argument slice, `pack_inet_addr` pins the address tuple and reads
`flowinfo` and `scope_id` out of it before the resolver releases the GIL,
and the four callers that use the socket after the conversion pin it across
the call.

`pyre/extra_tests/parity_tests/socket_host_idna_conversions.py` pins the
result; every outcome it covers is byte-identical to CPython 3.14.2.

**`_socket: answer a Windows connect timeout with WSAEWOULDBLOCK`** —
`_connect` reports an expired wait as `(WSAEWOULDBLOCK, True)`: the code the
non-blocking connect itself reported, beside a separate timeout flag. The
wait answered `WSAETIMEDOUT`, so `connect_ex` on a socket carrying a timeout
returned 10060 where CPython returns 10035 — measured against CPython 3.14.2
with a plain `socket.connect_ex` and a 0.0000001s timeout. `connect` is
unaffected: a positive timeout turns either code into `TimeoutError`.

**`_socket: spell a gaierror's message "getaddrinfo failed" on Windows`** —
`gai_strerror` was answered from the system message table there, so the
message came back in the host's UI language. The Windows build defines no
`HAVE_GAI_STRERROR` and `set_gaierror` uses the fixed string in its place;
the four construction sites now route through a `set_gaierror` that does the
same, and the two Windows arms of `rsocket_rffi::gai_strerror` are dropped.

## `_ssl`

**`_ssl: latch a peer's fatal alert`** — `process_new_packets` reports
`AlertReceived` once, on the call that consumed the alert record. A later
read reached rustls' reader, which answers `WouldBlock` for a closed session
as well as for an empty one, so the caller went back to the socket and raised
whatever the transport had; a later write reached `active_mut`. The alert is
now recorded on the connection, a read answers `b""` from it and a write
answers `SSL_ERROR_ZERO_RETURN`. Reproduced without a socket over a
`MemoryBIO` pair, where pyre now answers `b""`, `SSLZeroReturnError`, `b""`
exactly as CPython does.

## `cpython_tests`

- `test_fork1` is gated on every platform `support.has_fork_support`
  excludes — `win32`, `emscripten`, `wasi`, the three Apple mobile
  platforms, and `android` — rather than on `hasattr(os, "fork")` alone.
- Every `baseline.win32-AMD64.json` overlay entry now carries the `reason`
  the schema keeps beside it and `baseline.linux-aarch64.json` already
  spells, naming the case that diverges: `test_import`'s single
  `skipUnless(sys.platform == 'win32')` case reads
  `find_spec('_sqlite3').origin` and pyre ships no `_sqlite3`; `test_mmap`
  loses 40 of 51 cases to a `setUp` that unlinks a file a preceding case
  left mapped, which POSIX permits and Windows refuses; `test_venv`'s `nt`
  branch copies launcher executables that `venv/scripts/nt` does not hold.
