### PR TITLE
wasm: carry a path across the host ABI as filesystem bytes, and refuse an open() that asks for write access

### DIFF
--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -19165,7 +19165,11 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 // resolves modules with: `open()` reaches exactly the files an
                 // import could, and no others.
                 let _ = binary;
-                match crate::importing::read_source_bytes(std::path::Path::new(&path)) {
+                // The bytes the caller spelled, not a re-decoded copy of them:
+                // a name `listdir` reported is a name `open` can be called
+                // with again, whatever bytes it spells.
+                let seam_path = crate::gateway::os_string_from_fs_bytes(path_bytes);
+                match crate::importing::read_source_bytes(std::path::Path::new(&seam_path)) {
                     Ok(bytes) => bytes,
                     Err(_e) if writing => Vec::new(),
                     Err(e) => {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7304,6 +7304,19 @@ pub(crate) mod wasm_errno {
             _ => return None,
         })
     }
+
+    /// The errno a [`crate::importing::SourceProvider`] error stands for.
+    ///
+    /// A provider built to answer `import`'s probes need not be able to serve
+    /// every question the guest puts to it, and refusing is not the same
+    /// answer as a missing file: only the second is what a caller catching
+    /// `FileNotFoundError` is asking about.
+    pub fn seam_errno(e: &std::io::Error) -> i32 {
+        match e.kind() {
+            std::io::ErrorKind::Unsupported => ENOTSUP,
+            _ => ENOENT,
+        }
+    }
 }
 
 /// On Windows `ETIMEDOUT` above is the Winsock code, and the runtime's own
@@ -19145,6 +19158,18 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         any(not(windows), not(feature = "host_env"))
     ))]
     {
+        // The seam is read-only: `SourceProvider` has no writing half, so a
+        // buffer this builtin marks dirty has nowhere to be flushed to.  A
+        // mode that asks for write access is refused here rather than at the
+        // flush that would discover it, so `open(p, "w")` and `open(p, "r+")`
+        // both fail where the file is named.
+        #[cfg(all(feature = "host_env", target_arch = "wasm32"))]
+        if writing || mode.contains('+') {
+            return Err(crate::PyError::os_error_syscall(
+                wasm_errno::ENOTSUP,
+                resolved_path.w_path(),
+            ));
+        }
         let data: Vec<u8> = if reading && !mode.contains('w') && !mode.contains('x') {
             #[cfg(not(feature = "host_env"))]
             {
@@ -19171,10 +19196,9 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 let seam_path = crate::gateway::os_string_from_fs_bytes(path_bytes);
                 match crate::importing::read_source_bytes(std::path::Path::new(&seam_path)) {
                     Ok(bytes) => bytes,
-                    Err(_e) if writing => Vec::new(),
                     Err(e) => {
                         return Err(crate::PyError::os_error_syscall(
-                            io_error_posix_errno(&e, 2),
+                            io_error_posix_errno(&e, wasm_errno::seam_errno(&e)),
                             resolved_path.w_path(),
                         ));
                     }

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1772,9 +1772,12 @@ pub fn os_string_from_fs_bytes(data: &[u8]) -> std::ffi::OsString {
     }
     #[cfg(not(any(unix, windows)))]
     {
-        // No byte spelling on this platform, so the name can only be carried
-        // as the best text representation of these bytes.
-        std::ffi::OsString::from(String::from_utf8_lossy(data).into_owned())
+        // Outside Windows an `OsStr` IS the byte string, on wasm32 as much as
+        // on unix, so these bytes already are its encoding and survive the
+        // round trip `as_encoded_bytes` makes on the way back out.  Carrying
+        // them whole is what lets a name `listdir` reports be a name `stat`
+        // can be called with again.
+        unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(data) }.to_os_string()
     }
 }
 
@@ -2098,12 +2101,12 @@ pub fn fsencode(obj: pyre_object::PyObjectRef) -> Result<Vec<u8>, crate::PyError
 /// Under `surrogatepass` every `str` has a spelling, so the same entry reaches
 /// the host as itself and names a file that is simply not there.
 pub fn fspath_buf(obj: pyre_object::PyObjectRef) -> Result<std::path::PathBuf, crate::PyError> {
-    #[cfg(unix)]
+    // Every target outside Windows spells an `OsStr` as the bytes themselves,
+    // so the filesystem bytes are the name and the escapes fold back into it.
+    #[cfg(not(windows))]
     {
-        use std::os::unix::ffi::OsStringExt;
-        let bytes = fsencode(obj)?;
-        Ok(std::path::PathBuf::from(std::ffi::OsString::from_vec(
-            bytes,
+        Ok(std::path::PathBuf::from(os_string_from_fs_bytes(
+            &fsencode(obj)?,
         )))
     }
     #[cfg(windows)]
@@ -2119,17 +2122,6 @@ pub fn fspath_buf(obj: pyre_object::PyObjectRef) -> Result<std::path::PathBuf, c
         Ok(std::path::PathBuf::from(std::ffi::OsString::from_wide(
             &units,
         )))
-    }
-    #[cfg(not(any(unix, windows)))]
-    {
-        // No byte spelling on this platform, so the host API receives the text
-        // itself and a surrogate has nowhere to go: `str_utf8_w` reports it as
-        // an encoding error. Encoding to bytes and decoding them back lossily
-        // would substitute U+FFFD, which addresses a different name and makes
-        // distinct entries alias onto one another.
-        Ok(std::path::PathBuf::from(crate::baseobjspace::str_utf8_w(
-            obj,
-        )?))
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
@@ -71,11 +71,11 @@ fn stat(args: &[PyObjectRef], default_follow: bool) -> Result<PyObjectRef, crate
     if let Some(v) = crate::builtins::kwarg_get(kwargs, "follow_symlinks") {
         crate::baseobjspace::is_true(v)?;
     }
-    let path = std::path::Path::new(path_str(&resolved.as_bytes));
-    let (mode, size) = if crate::importing::source_is_dir(path) {
+    let path = seam_path(&resolved.as_bytes);
+    let (mode, size) = if crate::importing::source_is_dir(&path) {
         (S_IFDIR | 0o555, 0)
     } else {
-        match crate::importing::source_file_size(path) {
+        match crate::importing::source_file_size(&path) {
             Ok(size) => (S_IFREG | 0o444, size as i64),
             // The seam reports why it could not answer, and the path object the
             // caller passed is what names the failure.
@@ -85,12 +85,12 @@ fn stat(args: &[PyObjectRef], default_follow: bool) -> Result<PyObjectRef, crate
     Ok(make_stat_result(mode, size))
 }
 
-/// The seam takes a `&Path`, which on wasm32 is UTF-8; a path byte with no
-/// UTF-8 spelling cannot address a host file through it either way, so the
-/// lossy spelling is what the seam is asked about and the error it gives back
-/// is reported against the caller's own path object.
-fn path_str(bytes: &[u8]) -> &str {
-    std::str::from_utf8(bytes).unwrap_or("")
+/// The seam takes a `&Path`, and on this target an `OsStr` is the byte string
+/// itself, so the filesystem bytes cross it whole rather than through a text
+/// spelling that a name without one would not survive: an entry `listdir`
+/// reported is an entry `stat` can be called with again.
+fn seam_path(bytes: &[u8]) -> std::path::PathBuf {
+    crate::gateway::os_string_from_fs_bytes(bytes).into()
 }
 
 /// The seam's `io::Error` as the OSError it stands for, named by the path
@@ -159,9 +159,9 @@ fn listdir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // runs exactly once.
     let resolved = crate::gateway::fsencode_path_or_fd_nullable_w(w_path, "listdir", false)?;
     let bytes_mode = unsafe { resolved.is_bytes() };
-    let path = std::path::Path::new(path_str(&resolved.as_bytes));
+    let path = seam_path(&resolved.as_bytes);
     let entries =
-        crate::importing::source_list_dir(path).map_err(|e| seam_error(&e, resolved.w_path()))?;
+        crate::importing::source_list_dir(&path).map_err(|e| seam_error(&e, resolved.w_path()))?;
     // Each name is freshly allocated and the next one allocates again, so they
     // are pinned as they arrive.
     let mut items = pyre_object::gc_roots::RootedItems::new();

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
@@ -95,14 +95,8 @@ fn seam_path(bytes: &[u8]) -> std::path::PathBuf {
 
 /// The seam's `io::Error` as the OSError it stands for, named by the path
 /// object the caller passed rather than by a re-decoded spelling of it.
-///
-/// A provider that answers `import`'s probes need not be able to enumerate a
-/// directory, and refusing is not the same answer as a missing one.
 fn seam_error(e: &std::io::Error, w_path: PyObjectRef) -> crate::PyError {
-    let errno = match e.kind() {
-        std::io::ErrorKind::Unsupported => crate::builtins::wasm_errno::ENOTSUP,
-        _ => crate::builtins::wasm_errno::ENOENT,
-    };
+    let errno = crate::builtins::wasm_errno::seam_errno(e);
     crate::PyError::os_error_syscall(crate::builtins::io_error_posix_errno(e, errno), w_path)
 }
 

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -1736,12 +1736,31 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>> {
     Ok(linker)
 }
 
-/// Read a host path argument out of wasm linear memory as a `String`.
-fn host_path(caller: &mut Caller<'_, Host>, path_ptr: u32, path_len: u32) -> Option<String> {
+/// Read a host path argument out of wasm linear memory as the filesystem name
+/// it spells.
+///
+/// The guest sends the bytes its own `OsStr` is.  On unix those are the bytes
+/// the filesystem takes, and a name with no UTF-8 spelling is one
+/// `host_list_dir` can report -- so it has to be one this can take back.
+fn host_path(
+    caller: &mut Caller<'_, Host>,
+    path_ptr: u32,
+    path_len: u32,
+) -> Option<std::ffi::OsString> {
     let memory = caller.data().memory?;
     let mut bytes = vec![0u8; path_len as usize];
     memory.read(&*caller, path_ptr as usize, &mut bytes).ok()?;
-    String::from_utf8(bytes).ok()
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+        Some(std::ffi::OsString::from_vec(bytes))
+    }
+    // A Windows name is UTF-16, so bytes with no UTF-8 spelling name nothing
+    // there and are refused rather than guessed at.
+    #[cfg(not(unix))]
+    {
+        String::from_utf8(bytes).ok().map(std::ffi::OsString::from)
+    }
 }
 
 /// `pyre_host.host_stdlib_root`: write `$PYRE_STDLIB` into the wasm buffer.

--- a/pyre/pyre-wasm-runner/src/wasmi_host.rs
+++ b/pyre/pyre-wasm-runner/src/wasmi_host.rs
@@ -355,12 +355,31 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>, String> {
     Ok(linker)
 }
 
-/// Read a host path argument out of wasm linear memory as a `String`.
-fn host_path(caller: &mut Caller<'_, Host>, path_ptr: u32, path_len: u32) -> Option<String> {
+/// Read a host path argument out of wasm linear memory as the filesystem name
+/// it spells.
+///
+/// The guest sends the bytes its own `OsStr` is.  On unix those are the bytes
+/// the filesystem takes, and a name with no UTF-8 spelling is one
+/// `host_list_dir` can report -- so it has to be one this can take back.
+fn host_path(
+    caller: &mut Caller<'_, Host>,
+    path_ptr: u32,
+    path_len: u32,
+) -> Option<std::ffi::OsString> {
     let memory = caller.data().memory?;
     let mut bytes = vec![0u8; path_len as usize];
     memory.read(&*caller, path_ptr as usize, &mut bytes).ok()?;
-    String::from_utf8(bytes).ok()
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+        Some(std::ffi::OsString::from_vec(bytes))
+    }
+    // A Windows name is UTF-16, so bytes with no UTF-8 spelling name nothing
+    // there and are refused rather than guessed at.
+    #[cfg(not(unix))]
+    {
+        String::from_utf8(bytes).ok().map(std::ffi::OsString::from)
+    }
 }
 
 /// `pyre_host.host_stdlib_root`: write `$PYRE_STDLIB` into the wasm buffer.

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -282,13 +282,17 @@ mod host_fs_provider {
 
     struct HostFsProvider;
 
+    /// Every path crosses as the bytes an `OsStr` is on this target, not as a
+    /// text spelling of them, so a name with no UTF-8 spelling reaches the
+    /// host intact -- the direction back, `host_list_dir`, already hands such
+    /// names to the guest.
     impl SourceProvider for HostFsProvider {
         fn is_file(&self, path: &Path) -> bool {
-            let p = path.to_string_lossy();
+            let p = path.as_os_str().as_encoded_bytes();
             unsafe { host_file_size(p.as_ptr(), p.len() as u32) >= 0 }
         }
         fn file_size(&self, path: &Path) -> std::io::Result<u64> {
-            let p = path.to_string_lossy();
+            let p = path.as_os_str().as_encoded_bytes();
             let size = unsafe { host_file_size(p.as_ptr(), p.len() as u32) };
             match size < 0 {
                 true => Err(std::io::Error::new(
@@ -299,11 +303,11 @@ mod host_fs_provider {
             }
         }
         fn is_dir(&self, path: &Path) -> bool {
-            let p = path.to_string_lossy();
+            let p = path.as_os_str().as_encoded_bytes();
             unsafe { host_is_dir(p.as_ptr(), p.len() as u32) != 0 }
         }
         fn list_dir(&self, path: &Path) -> std::io::Result<Vec<Vec<u8>>> {
-            let p = path.to_string_lossy();
+            let p = path.as_os_str().as_encoded_bytes();
             let call = |buf: &mut [u8]| unsafe {
                 host_list_dir(
                     p.as_ptr(),
@@ -342,7 +346,7 @@ mod host_fs_provider {
             )))
         }
         fn read_to_bytes(&self, path: &Path) -> std::io::Result<Vec<u8>> {
-            let p = path.to_string_lossy();
+            let p = path.as_os_str().as_encoded_bytes();
             let size = unsafe { host_file_size(p.as_ptr(), p.len() as u32) };
             if size < 0 {
                 return Err(std::io::Error::new(


### PR DESCRIPTION
Follow-up to #1511, from its review: the wasm guest's filesystem seam.

## A path crosses the host ABI as filesystem bytes

`host_list_dir` hands the guest each directory entry as the filesystem's own
bytes, but the way back converted the path to text first — `HostFsProvider`
called `Path::to_string_lossy`, and `interp_posix_wasm`'s `path_str` answered
`""` for bytes with no UTF-8 spelling. A name `os.listdir(b'.')` reported was
therefore not a name `os.stat` could be called with again.

Outside Windows an `OsStr` is the byte string itself, on wasm32 as much as on
unix, so the bytes now travel whole: `os_string_from_fs_bytes` builds the
`OsStr` from them, `HostFsProvider` sends `as_os_str().as_encoded_bytes()`, and
both runner engines rebuild an `OsString` from what arrives.

That makes `fspath_buf`'s unix arm and its non-unix, non-Windows arm identical,
so they are one `#[cfg(not(windows))]` arm — which fixes what a `sys.path`
entry carrying a surrogate escape does on wasm32:

| `sys.path` entry | wasm before | wasm after | native | CPython |
| --- | --- | --- | --- | --- |
| `'\udcff'` (escape) | `UnicodeEncodeError` | `ModuleNotFoundError` | `ModuleNotFoundError` | `ModuleNotFoundError` |
| `'\ud800'` (lone surrogate) | `UnicodeEncodeError` | `UnicodeEncodeError` | `UnicodeEncodeError` | `UnicodeEncodeError` |

## `open()` refuses write access on wasm32

`SourceProvider` has no writing half, and `file_flush_dirty` reaches
`std::fs::write`, which wasm32 does not have. `open(p, "w")` and `open(p, "r+")`
both returned a stream whose mode permits writes and whose first `flush()` or
`close()` failed after the buffer was already dirty. Write access is now refused
at open time with `ENOTSUP` and the path the caller named. The read that remains
classifies the seam's refusal the way `interp_posix_wasm` does — `Unsupported`
is `ENOTSUP`, not the `ENOENT` a missing file gets — through one
`wasm_errno::seam_errno` both readers call.

## Verification

- `pyre/check.py --backend dynasm,wasm`: dynasm 501/501, wasm 494/494, ALL PASSED
- `cargo test --all --no-default-features --features dynasm,cpyext --no-fail-fast`: 8528 passed, 0 failed
- `cargo check` green on native (`dynasm,cpyext`), `wasm32-unknown-unknown` with `wasm-host`, `wasm32-unknown-unknown` with `--no-default-features`, and the runner
- Guest probe through `pyre-wasm-runner`: `listdir` str/bytes round-tripping through `stat`, a non-ASCII name read both ways, all seven write modes refused with `[Errno 45] Operation not supported`, a bytes path with no UTF-8 spelling answering `ENOENT` named by the caller's own bytes rather than by `''`

A filename that is genuinely not UTF-8 could not be created to test against:
APFS refuses one with `[Errno 92] Illegal byte sequence`. That case is reachable
only on a Linux host.

## Not in this PR

CodeRabbit also flagged, outside the diff, that `eval.rs`'s back-edge door mints
a raw `make_green_key` hash and hands it to `maybe_compile_decision` and
`runnable_procedure_token`, both of which document that they need a key that
already names one cell. That looks real — it is the back-edge half of what #1497
fixed at the function-entry door — but it is JIT code this branch does not
otherwise touch.
