### PR TITLE
cpyext, _ctypes: an address hasher, a tuple mirror's own items, and one question for a teardown's fourteen side tables

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5449,6 +5449,17 @@ pub(crate) fn setdictvalue_native(obj: PyObjectRef, name: &str, value: PyObjectR
     setdictvalue(obj, name, value).unwrap_or(false)
 }
 
+/// [`getdictvalue`] under the same restriction as [`getdict_native`]: the
+/// receiver's dictionary is a plain field or mapdict slot, so resolving it
+/// cannot run Python and the read is infallible.
+///
+/// The probe that can raise needs a stored non-string key whose hash collides
+/// with `name`, which a reserved internal key never has, so the `unwrap_or`
+/// here reports no attribute rather than hiding one.
+pub(crate) fn getdictvalue_native(obj: PyObjectRef, name: &str) -> Option<PyObjectRef> {
+    getdictvalue(obj, name).unwrap_or(None)
+}
+
 /// `baseobjspace.py W_Root.getdictvalue`.
 ///
 /// ```python

--- a/pyre/pyre-interpreter/src/cpyext/address_table.rs
+++ b/pyre/pyre-interpreter/src/cpyext/address_table.rs
@@ -1,0 +1,92 @@
+//! Hashing for the side tables this layer keys on a mirror address.
+//!
+//! Every one of them stores what a block at a fixed address is: its size, the
+//! items it handed out, the bytes it exposes.  A mirror address is already a
+//! well-spread 64-bit value, so the SipHash the standard hasher runs over it
+//! buys nothing and costs more than the lookup it guards -- and these tables
+//! are read on the reference-counting path, once per `incref`/`decref`, which
+//! is the hottest thing a C extension does.
+//!
+//! This is the address counterpart of
+//! [`pyre_object::dictmultiobject::ObjectKeyHasher`], and takes its mangling
+//! from `majit_gc::address_dict::AddressHasher`, which does the same job for
+//! the collector's own address tables.
+
+use std::hash::{BuildHasherDefault, Hasher};
+
+/// Odd 64-bit multiplier (2^64 / golden ratio).
+const SPREAD_MULTIPLIER: u64 = 0x9E37_79B9_7F4A_7C15;
+
+#[derive(Default)]
+pub(super) struct AddressHasher(u64);
+
+impl AddressHasher {
+    /// A block address is aligned, so its trailing bits are zero and a table
+    /// indexing on those alone would pile every key into one bucket;
+    /// `rpython/memory/support.py:10-14 mangle_hash` folds the high bits down
+    /// over them.  `HashMap` reads the hash a second way -- the top 7 bits
+    /// become the entry's control byte -- and a heap address leaves those
+    /// zero, so the multiply carries the mangled value back over the whole
+    /// word.  The low half still depends only on the low half, so the bucket
+    /// index keeps the mangled distribution.
+    #[inline]
+    fn spread(value: u64) -> u64 {
+        (value ^ (value >> 4)).wrapping_mul(SPREAD_MULTIPLIER)
+    }
+}
+
+impl Hasher for AddressHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    /// These tables are `usize`-keyed, so `write_usize` is the path taken.
+    /// Keep a deterministic fallback for the `Hasher` contract.
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let mut value = 0_u64;
+        for (shift, byte) in bytes.iter().copied().take(8).enumerate() {
+            value |= (byte as u64) << (shift * 8);
+        }
+        self.0 = Self::spread(value);
+    }
+
+    #[inline]
+    fn write_usize(&mut self, value: usize) {
+        self.0 = Self::spread(value as u64);
+    }
+}
+
+/// Const-constructible, which is what lets these tables be `static`.
+pub(super) type AddressBuildHasher = BuildHasherDefault<AddressHasher>;
+pub(super) type AddressMap<V> = std::collections::HashMap<usize, V, AddressBuildHasher>;
+pub(super) type AddressSet = std::collections::HashSet<usize, AddressBuildHasher>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::hash::Hash;
+
+    fn hash_of(address: usize) -> u64 {
+        let mut hasher = AddressHasher::default();
+        address.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn aligned_addresses_differ_in_the_control_byte() {
+        // Sixteen-byte-aligned blocks are the shape a mirror allocator hands
+        // out; SipHash is not needed to tell them apart, but the top bits do
+        // have to move, or every entry carries the same control byte.
+        let top_bits: std::collections::HashSet<u64> =
+            (0..64).map(|i| hash_of(0x1_0000 + i * 16) >> 57).collect();
+        assert!(top_bits.len() > 32, "control bytes collapsed: {top_bits:?}");
+    }
+
+    #[test]
+    fn a_key_hashes_to_one_value() {
+        assert_eq!(hash_of(0x1_0000), hash_of(0x1_0000));
+        assert_ne!(hash_of(0x1_0000), hash_of(0x1_0010));
+    }
+}

--- a/pyre/pyre-interpreter/src/cpyext/address_table.rs
+++ b/pyre/pyre-interpreter/src/cpyext/address_table.rs
@@ -64,6 +64,71 @@ pub(super) type AddressBuildHasher = BuildHasherDefault<AddressHasher>;
 pub(super) type AddressMap<V> = std::collections::HashMap<usize, V, AddressBuildHasher>;
 pub(super) type AddressSet = std::collections::HashSet<usize, AddressBuildHasher>;
 
+/// An address a side table has been told to key an entry under.
+///
+/// Minting one enters it in [`HOLDERS`], and only [`hold`] can mint one, so
+/// the set is what every table put together holds.  That is the whole point:
+/// tearing a mirror down asks fourteen tables to release what they keyed by
+/// its address, and five of them are never empty for a program that imported
+/// anything -- a module's fields, a type's name, the tracked set -- so the
+/// per-table [`AddressTable::is_empty`] answer never fires for them and each
+/// costs a lock and a probe that finds nothing.  One question to [`HOLDERS`]
+/// settles all fourteen.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) struct Held(usize);
+
+impl Held {
+    pub(super) fn address(self) -> usize {
+        self.0
+    }
+}
+
+// A `Held` hashes and compares exactly as the address it wraps -- the derive
+// forwards to the single field -- so a table keyed on one is still read with a
+// plain `usize`, and only writing to it needs the mint.
+impl std::borrow::Borrow<usize> for Held {
+    fn borrow(&self) -> &usize {
+        &self.0
+    }
+}
+
+/// Every address some side table keys an entry under.
+///
+/// Entries only ever leave at a teardown, which drops the address from every
+/// table at once.  A table that gives an entry up on its own -- the untrack a
+/// C extension performs, say -- leaves this one stale, which costs that block
+/// a walk of the cascade it could have skipped and is otherwise harmless.
+static HOLDERS: AddressTable<AddressSet> = AddressTable::new(
+    std::collections::HashSet::with_hasher(BuildHasherDefault::new()),
+);
+
+/// Key `address` for a table, entering it in [`HOLDERS`].
+pub(super) fn hold(address: usize) -> Held {
+    HOLDERS.lock().insert(address);
+    Held(address)
+}
+
+/// Whether any table has something keyed by `address`, dropping the record.
+///
+/// The teardown spelling: the caller is about to ask every table to release
+/// what it holds, and a `false` here says none of them will find anything.
+pub(super) fn release_hold(address: usize) -> bool {
+    if HOLDERS.is_empty() {
+        return false;
+    }
+    HOLDERS.lock().remove(&address)
+}
+
+/// # Safety
+/// Only in a forked child, where the thread that held the lock is gone.
+pub(super) unsafe fn after_fork_child() {
+    unsafe { HOLDERS.reinit_after_fork() };
+}
+
+/// A table whose keys are minted by [`hold`], so that [`HOLDERS`] lists them.
+pub(super) type HeldMap<V> = std::collections::HashMap<Held, V, AddressBuildHasher>;
+pub(super) type HeldSet = std::collections::HashSet<Held, AddressBuildHasher>;
+
 /// A collection whose entry count is what decides whether it holds anything.
 pub(super) trait Populated {
     fn population(&self) -> usize;
@@ -76,6 +141,18 @@ impl<V> Populated for AddressMap<V> {
 }
 
 impl Populated for AddressSet {
+    fn population(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<V> Populated for HeldMap<V> {
+    fn population(&self) -> usize {
+        self.len()
+    }
+}
+
+impl Populated for HeldSet {
     fn population(&self) -> usize {
         self.len()
     }
@@ -135,7 +212,7 @@ impl<C: Populated> AddressTable<C> {
     }
 }
 
-impl<V> AddressTable<AddressMap<V>> {
+impl<V> AddressTable<HeldMap<V>> {
     /// Take what this table keyed by `address`, if anything.
     ///
     /// This is the teardown spelling: a mirror reaching it has no references
@@ -149,7 +226,7 @@ impl<V> AddressTable<AddressMap<V>> {
     }
 }
 
-impl AddressTable<AddressSet> {
+impl AddressTable<HeldSet> {
     /// Drop `address` from this table, answering whether it was there.
     ///
     /// The empty case is decided as it is in [`AddressTable::take`].
@@ -207,6 +284,30 @@ mod tests {
         let top_bits: std::collections::HashSet<u64> =
             (0..64).map(|i| hash_of(0x1_0000 + i * 16) >> 57).collect();
         assert!(top_bits.len() > 32, "control bytes collapsed: {top_bits:?}");
+    }
+
+    /// A table keyed by [`Held`] is still read with a plain address, which is
+    /// the whole reason only writing to one needs the mint.  `Borrow` requires
+    /// the two spellings to hash and compare alike for that to be sound.
+    #[test]
+    fn a_held_key_is_found_by_its_plain_address() {
+        let mut table: HeldMap<u8> = HeldMap::default();
+        table.insert(hold(0x4000), 7);
+        assert_eq!(table.get(&0x4000_usize), Some(&7));
+        assert_eq!(table.remove(&0x4000_usize), Some(7));
+        assert!(table.is_empty());
+        assert!(release_hold(0x4000));
+    }
+
+    /// The set is what every table put together holds, so a teardown that
+    /// finds nothing under an address may skip all of them.
+    #[test]
+    fn an_address_is_listed_until_it_is_released() {
+        let held = hold(0x5000);
+        assert_eq!(held.address(), 0x5000);
+        assert!(release_hold(0x5000), "holding an address lists it");
+        assert!(!release_hold(0x5000), "releasing it takes it off the list");
+        assert!(!release_hold(0x5010), "an address never held is not listed");
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/cpyext/address_table.rs
+++ b/pyre/pyre-interpreter/src/cpyext/address_table.rs
@@ -13,6 +13,7 @@
 //! the collector's own address tables.
 
 use std::hash::{BuildHasherDefault, Hasher};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Odd 64-bit multiplier (2^64 / golden ratio).
 const SPREAD_MULTIPLIER: u64 = 0x9E37_79B9_7F4A_7C15;
@@ -62,6 +63,130 @@ impl Hasher for AddressHasher {
 pub(super) type AddressBuildHasher = BuildHasherDefault<AddressHasher>;
 pub(super) type AddressMap<V> = std::collections::HashMap<usize, V, AddressBuildHasher>;
 pub(super) type AddressSet = std::collections::HashSet<usize, AddressBuildHasher>;
+
+/// A collection whose entry count is what decides whether it holds anything.
+pub(super) trait Populated {
+    fn population(&self) -> usize;
+}
+
+impl<V> Populated for AddressMap<V> {
+    fn population(&self) -> usize {
+        self.len()
+    }
+}
+
+impl Populated for AddressSet {
+    fn population(&self) -> usize {
+        self.len()
+    }
+}
+
+/// A side table keyed on a mirror address, publishing how much it holds.
+///
+/// Tearing a mirror down asks every one of these tables to release whatever it
+/// keyed by that address, and for most programs almost none of them hold
+/// anything: an extension that never builds a `datetime` leaves that table
+/// empty for the whole run, and one that never hands C a borrowed reference
+/// leaves `BORROWED` empty.  Asking is otherwise a mutex and a probe each,
+/// once per teardown, so the count is published outside the lock and an empty
+/// table answers [`AddressTable::is_empty`] without taking it.
+///
+/// The count is republished when a guard is dropped rather than by each
+/// mutating call, which is what lets every caller keep using the collection
+/// directly through the guard.
+pub(super) struct AddressTable<C> {
+    entries: super::ForkMutex<C>,
+    population: AtomicUsize,
+}
+
+// SAFETY: the payload is reachable only through `entries`, whose own `Sync`
+// carries the same bound.
+unsafe impl<C: Send> Sync for AddressTable<C> {}
+
+impl<C: Populated> AddressTable<C> {
+    pub(super) const fn new(entries: C) -> Self {
+        Self {
+            entries: super::ForkMutex::new(entries),
+            population: AtomicUsize::new(0),
+        }
+    }
+
+    pub(super) fn lock(&self) -> AddressTableGuard<'_, C> {
+        AddressTableGuard {
+            entries: self.entries.lock(),
+            population: &self.population,
+        }
+    }
+
+    /// Whether the table holds nothing, without taking its lock.
+    ///
+    /// A teardown reaching this has the mirror's last reference, so no other
+    /// thread is entering the table under that address; the acquire pairs with
+    /// the release a guard makes before it unlocks, so a count read here is
+    /// one some thread actually published.
+    pub(super) fn is_empty(&self) -> bool {
+        self.population.load(Ordering::Acquire) == 0
+    }
+
+    /// # Safety
+    /// Only in a forked child, where the thread that held the lock is gone.
+    pub(super) unsafe fn reinit_after_fork(&self) {
+        unsafe { self.entries.reinit_after_fork() };
+    }
+}
+
+impl<V> AddressTable<AddressMap<V>> {
+    /// Take what this table keyed by `address`, if anything.
+    ///
+    /// This is the teardown spelling: a mirror reaching it has no references
+    /// left, so no other thread is entering the table under its address, and a
+    /// table that reads empty stays empty for every key that matters here.
+    pub(super) fn take(&self, address: usize) -> Option<V> {
+        if self.is_empty() {
+            return None;
+        }
+        self.lock().remove(&address)
+    }
+}
+
+impl AddressTable<AddressSet> {
+    /// Drop `address` from this table, answering whether it was there.
+    ///
+    /// The empty case is decided as it is in [`AddressTable::take`].
+    pub(super) fn discard(&self, address: usize) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+        self.lock().remove(&address)
+    }
+}
+
+/// Holds a table open, and republishes its population on the way out.
+pub(super) struct AddressTableGuard<'a, C: Populated> {
+    entries: parking_lot::MutexGuard<'a, C>,
+    population: &'a AtomicUsize,
+}
+
+impl<C: Populated> Drop for AddressTableGuard<'_, C> {
+    fn drop(&mut self) {
+        self.population
+            .store(self.entries.population(), Ordering::Release);
+    }
+}
+
+impl<C: Populated> std::ops::Deref for AddressTableGuard<'_, C> {
+    type Target = C;
+
+    fn deref(&self) -> &C {
+        &self.entries
+    }
+}
+
+impl<C: Populated> std::ops::DerefMut for AddressTableGuard<'_, C> {
+    fn deref_mut(&mut self) -> &mut C {
+        &mut self.entries
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/pyre/pyre-interpreter/src/cpyext/buffer.rs
+++ b/pyre/pyre-interpreter/src/cpyext/buffer.rs
@@ -79,8 +79,8 @@ fn releasebuffer_of(tp: *mut CPyTypeObject) -> *const c_void {
 /// Keyed by an address this layer handed out, so the hasher is never fed a key
 /// C chose; the default one is spelled out because it is the const-
 /// constructible form a `static` needs.
-type BufferTable = HashMap<usize, usize, BuildHasherDefault<std::hash::DefaultHasher>>;
-type BufferSet = HashSet<usize, BuildHasherDefault<std::hash::DefaultHasher>>;
+type BufferTable = super::address_table::AddressMap<usize>;
+type BufferSet = super::address_table::AddressSet;
 
 /// The `Py_buffer` behind each live `memoryview` this layer built, keyed by the
 /// `BufferView` that memoryview carries.

--- a/pyre/pyre-interpreter/src/cpyext/bytesobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/bytesobject.rs
@@ -26,7 +26,7 @@ pub unsafe extern "C" fn PyBytes_FromString(text: *const c_char) -> *mut CPyObje
 /// — so `PyBytes_AS_STRING` hands out one address before and after the `bytes`
 /// exists.  This set only records which mirrors have not been read as a value
 /// yet.
-type PendingSet = HashSet<usize, BuildHasherDefault<std::hash::DefaultHasher>>;
+type PendingSet = super::address_table::AddressSet;
 static PENDING: super::ForkMutex<PendingSet> =
     super::ForkMutex::new(HashSet::with_hasher(BuildHasherDefault::new()));
 

--- a/pyre/pyre-interpreter/src/cpyext/bytesobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/bytesobject.rs
@@ -27,8 +27,10 @@ pub unsafe extern "C" fn PyBytes_FromString(text: *const c_char) -> *mut CPyObje
 /// exists.  This set only records which mirrors have not been read as a value
 /// yet.
 type PendingSet = super::address_table::AddressSet;
-static PENDING: super::ForkMutex<PendingSet> =
-    super::ForkMutex::new(HashSet::with_hasher(BuildHasherDefault::new()));
+use super::address_table::AddressTable;
+
+static PENDING: AddressTable<PendingSet> =
+    AddressTable::new(HashSet::with_hasher(BuildHasherDefault::new()));
 
 pub(super) unsafe fn after_fork_child() {
     unsafe { PENDING.reinit_after_fork() };
@@ -36,7 +38,7 @@ pub(super) unsafe fn after_fork_child() {
 
 /// Drop what a dying mirror recorded here.
 pub(super) fn forget_pending(mirror: usize) {
-    PENDING.lock().remove(&mirror);
+    PENDING.discard(mirror);
 }
 
 /// Whether `raw` is a mirror [`PyBytes_FromStringAndSize`] handed out and

--- a/pyre/pyre-interpreter/src/cpyext/bytesobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/bytesobject.rs
@@ -26,8 +26,8 @@ pub unsafe extern "C" fn PyBytes_FromString(text: *const c_char) -> *mut CPyObje
 /// — so `PyBytes_AS_STRING` hands out one address before and after the `bytes`
 /// exists.  This set only records which mirrors have not been read as a value
 /// yet.
-type PendingSet = super::address_table::AddressSet;
-use super::address_table::AddressTable;
+type PendingSet = super::address_table::HeldSet;
+use super::address_table::{AddressTable, hold};
 
 static PENDING: AddressTable<PendingSet> =
     AddressTable::new(HashSet::with_hasher(BuildHasherDefault::new()));
@@ -110,7 +110,7 @@ pub unsafe extern "C" fn PyBytes_FromStringAndSize(
         // answers the requested length while C is still writing the buffer.
         (*(raw as *mut CPyVarObject)).ob_size = size;
     }
-    PENDING.lock().insert(raw as usize);
+    PENDING.lock().insert(hold(raw as usize));
     // The terminator `cached_bytes` appends is the NUL upstream's `ob_sval`
     // carries past `ob_size`.
     unsafe { pyobject::cached_bytes(raw, || data) };

--- a/pyre/pyre-interpreter/src/cpyext/cdatetime.rs
+++ b/pyre/pyre-interpreter/src/cpyext/cdatetime.rs
@@ -721,8 +721,7 @@ pub unsafe extern "C" fn PyDateTime_TIME_GET_TZINFO(object: *mut c_void) -> *mut
 
 // ── the fields a block carries ──────────────────────────────────────────
 
-type BlockSet =
-    std::collections::HashSet<usize, std::hash::BuildHasherDefault<std::hash::DefaultHasher>>;
+type BlockSet = super::address_table::AddressSet;
 
 /// The blocks [`attach`] filled a `tzinfo` reference into.
 ///

--- a/pyre/pyre-interpreter/src/cpyext/cdatetime.rs
+++ b/pyre/pyre-interpreter/src/cpyext/cdatetime.rs
@@ -728,8 +728,10 @@ type BlockSet = super::address_table::AddressSet;
 /// A set of addresses rather than a size test, for the reason
 /// `pyerrors::ATTACHED` states: what decides whether the word at that offset
 /// is a reference is whether this module wrote it.
-static ATTACHED: super::ForkMutex<BlockSet> =
-    super::ForkMutex::new(BlockSet::with_hasher(std::hash::BuildHasherDefault::new()));
+use super::address_table::AddressTable;
+
+static ATTACHED: AddressTable<BlockSet> =
+    AddressTable::new(BlockSet::with_hasher(std::hash::BuildHasherDefault::new()));
 
 /// Which of the two blocks with fields a class of the `datetime` module takes
 /// — `cdatetime.py:143-160 init_datetime`'s three `basestruct`s, of which
@@ -863,7 +865,7 @@ pub(super) fn attach(raw: *mut CPyObject, w_obj: PyObjectRef) {
 /// Release the reference a `time` or `datetime` mirror owns —
 /// `cdatetime.py:191-204 type_dealloc`.
 pub(super) fn forget_block(raw: *mut CPyObject) {
-    if !ATTACHED.lock().remove(&(raw as usize)) {
+    if !ATTACHED.discard(raw as usize) {
         return;
     }
     let block = raw as *mut CPyDateTimeWithTZInfo;

--- a/pyre/pyre-interpreter/src/cpyext/cdatetime.rs
+++ b/pyre/pyre-interpreter/src/cpyext/cdatetime.rs
@@ -721,14 +721,14 @@ pub unsafe extern "C" fn PyDateTime_TIME_GET_TZINFO(object: *mut c_void) -> *mut
 
 // ── the fields a block carries ──────────────────────────────────────────
 
-type BlockSet = super::address_table::AddressSet;
+type BlockSet = super::address_table::HeldSet;
 
 /// The blocks [`attach`] filled a `tzinfo` reference into.
 ///
 /// A set of addresses rather than a size test, for the reason
 /// `pyerrors::ATTACHED` states: what decides whether the word at that offset
 /// is a reference is whether this module wrote it.
-use super::address_table::AddressTable;
+use super::address_table::{AddressTable, hold};
 
 static ATTACHED: AddressTable<BlockSet> =
     AddressTable::new(BlockSet::with_hasher(std::hash::BuildHasherDefault::new()));
@@ -858,7 +858,7 @@ pub(super) fn attach(raw: *mut CPyObject, w_obj: PyObjectRef) {
         };
     }
     if has {
-        ATTACHED.lock().insert(raw as usize);
+        ATTACHED.lock().insert(hold(raw as usize));
     }
 }
 

--- a/pyre/pyre-interpreter/src/cpyext/dictobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/dictobject.rs
@@ -814,9 +814,11 @@ pub unsafe extern "C" fn PyDict_MergeFromSeq2(
 /// reference is held here instead, keyed by the mirror's address; it is the
 /// reference, not this table, that roots the list.
 type SnapshotMap = super::address_table::AddressMap<usize>;
-static ITERATION_KEYS: super::ForkMutex<SnapshotMap> = super::ForkMutex::new(
-    SnapshotMap::with_hasher(std::hash::BuildHasherDefault::new()),
-);
+use super::address_table::AddressTable;
+
+static ITERATION_KEYS: AddressTable<SnapshotMap> = AddressTable::new(SnapshotMap::with_hasher(
+    std::hash::BuildHasherDefault::new(),
+));
 
 /// The lock word can be held by a thread the child does not have; the
 /// snapshots the payload names are still mapped, because `fork` copies the
@@ -923,7 +925,7 @@ pub unsafe extern "C" fn PyDict_Next(
 /// A caller that stops walking before the end never reaches the arm that frees
 /// it, so the mirror's own deallocation is the other end of that lifetime.
 pub(super) fn forget_iteration(mirror: usize) {
-    if let Some(held) = ITERATION_KEYS.lock().remove(&mirror) {
+    if let Some(held) = ITERATION_KEYS.take(mirror) {
         unsafe { pyobject::decref(held as *mut CPyObject) };
     }
 }

--- a/pyre/pyre-interpreter/src/cpyext/dictobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/dictobject.rs
@@ -813,11 +813,7 @@ pub unsafe extern "C" fn PyDict_MergeFromSeq2(
 /// (`dictobject.py:301-311`).  Pyre's mirror has no such field, so the
 /// reference is held here instead, keyed by the mirror's address; it is the
 /// reference, not this table, that roots the list.
-type SnapshotMap = std::collections::HashMap<
-    usize,
-    usize,
-    std::hash::BuildHasherDefault<std::hash::DefaultHasher>,
->;
+type SnapshotMap = super::address_table::AddressMap<usize>;
 static ITERATION_KEYS: super::ForkMutex<SnapshotMap> = super::ForkMutex::new(
     SnapshotMap::with_hasher(std::hash::BuildHasherDefault::new()),
 );

--- a/pyre/pyre-interpreter/src/cpyext/dictobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/dictobject.rs
@@ -813,8 +813,8 @@ pub unsafe extern "C" fn PyDict_MergeFromSeq2(
 /// (`dictobject.py:301-311`).  Pyre's mirror has no such field, so the
 /// reference is held here instead, keyed by the mirror's address; it is the
 /// reference, not this table, that roots the list.
-type SnapshotMap = super::address_table::AddressMap<usize>;
-use super::address_table::AddressTable;
+type SnapshotMap = super::address_table::HeldMap<usize>;
+use super::address_table::{AddressTable, hold};
 
 static ITERATION_KEYS: AddressTable<SnapshotMap> = AddressTable::new(SnapshotMap::with_hasher(
     std::hash::BuildHasherDefault::new(),
@@ -867,7 +867,9 @@ pub unsafe extern "C" fn PyDict_Next(
         .map(|(key, _)| key)
         .collect();
         let held = pyobject::make_ref(pyre_object::listobject::w_list_new(keys));
-        let previous = ITERATION_KEYS.lock().insert(object as usize, held as usize);
+        let previous = ITERATION_KEYS
+            .lock()
+            .insert(hold(object as usize), held as usize);
         if let Some(previous) = previous {
             unsafe { pyobject::decref(previous as *mut CPyObject) };
         }

--- a/pyre/pyre-interpreter/src/cpyext/frameobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/frameobject.rs
@@ -52,8 +52,10 @@ const _: () = {
 type PendingSet = super::address_table::AddressSet;
 
 /// Mirrors [`PyFrame_New`] handed out that have no interpreter frame yet.
-static PENDING: super::ForkMutex<PendingSet> =
-    super::ForkMutex::new(HashSet::with_hasher(BuildHasherDefault::new()));
+use super::address_table::AddressTable;
+
+static PENDING: AddressTable<PendingSet> =
+    AddressTable::new(HashSet::with_hasher(BuildHasherDefault::new()));
 
 pub(super) unsafe fn after_fork_child() {
     unsafe { PENDING.reinit_after_fork() };
@@ -150,7 +152,7 @@ pub(super) fn attach(raw: *mut CPyObject, w_obj: PyObjectRef) {
 /// Reached from `pyobject::dealloc`, which runs it while the block is still
 /// live and before anything can hand the address back out.
 pub(super) fn forget_block(raw: *mut CPyObject) {
-    PENDING.lock().remove(&(raw as usize));
+    PENDING.discard(raw as usize);
     let Some(py_frame) = fields(raw) else {
         return;
     };

--- a/pyre/pyre-interpreter/src/cpyext/frameobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/frameobject.rs
@@ -49,10 +49,10 @@ const _: () = {
     assert!(size_of::<CPyFrameObject>() == 64);
 };
 
-type PendingSet = super::address_table::AddressSet;
+type PendingSet = super::address_table::HeldSet;
 
 /// Mirrors [`PyFrame_New`] handed out that have no interpreter frame yet.
-use super::address_table::AddressTable;
+use super::address_table::{AddressTable, hold};
 
 static PENDING: AddressTable<PendingSet> =
     AddressTable::new(HashSet::with_hasher(BuildHasherDefault::new()));
@@ -146,13 +146,17 @@ pub(super) fn attach(raw: *mut CPyObject, w_obj: PyObjectRef) {
     }
 }
 
+/// Drop the record that a frame mirror is still owed its fields.
+pub(super) fn forget_pending(raw: *mut CPyObject) {
+    PENDING.discard(raw as usize);
+}
+
 /// Release the references a frame mirror owns — `frameobject.py:52-60
 /// frame_dealloc`.
 ///
 /// Reached from `pyobject::dealloc`, which runs it while the block is still
 /// live and before anything can hand the address back out.
 pub(super) fn forget_block(raw: *mut CPyObject) {
-    PENDING.discard(raw as usize);
     let Some(py_frame) = fields(raw) else {
         return;
     };
@@ -272,7 +276,7 @@ pub unsafe extern "C" fn PyFrame_New(
         (*raw).ob_pyre_link = PY_NULL;
         (*raw).ob_type = ob_type;
     }
-    PENDING.lock().insert(raw as usize);
+    PENDING.lock().insert(hold(raw as usize));
     let py_frame = raw as *mut CPyFrameObject;
     unsafe {
         (*py_frame).f_code = pyobject::make_ref(w_code);

--- a/pyre/pyre-interpreter/src/cpyext/frameobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/frameobject.rs
@@ -49,7 +49,7 @@ const _: () = {
     assert!(size_of::<CPyFrameObject>() == 64);
 };
 
-type PendingSet = HashSet<usize, BuildHasherDefault<std::hash::DefaultHasher>>;
+type PendingSet = super::address_table::AddressSet;
 
 /// Mirrors [`PyFrame_New`] handed out that have no interpreter frame yet.
 static PENDING: super::ForkMutex<PendingSet> =

--- a/pyre/pyre-interpreter/src/cpyext/gc.rs
+++ b/pyre/pyre-interpreter/src/cpyext/gc.rs
@@ -28,8 +28,7 @@ use std::ffi::{c_int, c_void};
 /// question here is only ever "is this block one of them", so a set of
 /// addresses is enough. An address is stable for a block's life, and
 /// [`forget`] is called from `dealloc` before the block is released.
-type TrackedSet =
-    std::collections::HashSet<usize, std::hash::BuildHasherDefault<std::hash::DefaultHasher>>;
+type TrackedSet = super::address_table::AddressSet;
 static TRACKED: super::ForkMutex<TrackedSet> =
     super::ForkMutex::new(TrackedSet::with_hasher(std::hash::BuildHasherDefault::new()));
 

--- a/pyre/pyre-interpreter/src/cpyext/gc.rs
+++ b/pyre/pyre-interpreter/src/cpyext/gc.rs
@@ -29,8 +29,10 @@ use std::ffi::{c_int, c_void};
 /// addresses is enough. An address is stable for a block's life, and
 /// [`forget`] is called from `dealloc` before the block is released.
 type TrackedSet = super::address_table::AddressSet;
-static TRACKED: super::ForkMutex<TrackedSet> =
-    super::ForkMutex::new(TrackedSet::with_hasher(std::hash::BuildHasherDefault::new()));
+use super::address_table::AddressTable;
+
+static TRACKED: AddressTable<TrackedSet> =
+    AddressTable::new(TrackedSet::with_hasher(std::hash::BuildHasherDefault::new()));
 
 /// The blocks whose `tp_finalize` has already run.
 ///
@@ -41,8 +43,8 @@ static TRACKED: super::ForkMutex<TrackedSet> =
 /// rather than in `dealloc`, which runs before `tp_dealloc` -- that is the
 /// moment a second deallocation still has to read it -- and clearing at
 /// release is also what keeps a recycled address from inheriting a stale one.
-static FINALIZED: super::ForkMutex<TrackedSet> =
-    super::ForkMutex::new(TrackedSet::with_hasher(std::hash::BuildHasherDefault::new()));
+static FINALIZED: AddressTable<TrackedSet> =
+    AddressTable::new(TrackedSet::with_hasher(std::hash::BuildHasherDefault::new()));
 
 pub(super) unsafe fn after_fork_child() {
     unsafe { TRACKED.reinit_after_fork() };
@@ -61,7 +63,7 @@ pub(super) fn mark_finalized(raw: usize) {
 
 /// Drop the finalized flag for a block that is being released.
 pub(super) fn forget_finalized(raw: usize) {
-    FINALIZED.lock().remove(&raw);
+    FINALIZED.discard(raw);
 }
 
 /// Claim the finalizer of a block whose linked object the collector has just
@@ -138,7 +140,7 @@ pub(super) fn track(raw: *mut CPyObject) {
 /// Drop a block from the tracked set -- `PyObject_GC_UnTrack`, and the release
 /// `dealloc` performs for a block that never untracked itself.
 pub(super) fn forget(raw: usize) {
-    TRACKED.lock().remove(&raw);
+    TRACKED.discard(raw);
 }
 
 /// Every tracked block, as addresses.

--- a/pyre/pyre-interpreter/src/cpyext/gc.rs
+++ b/pyre/pyre-interpreter/src/cpyext/gc.rs
@@ -28,8 +28,8 @@ use std::ffi::{c_int, c_void};
 /// question here is only ever "is this block one of them", so a set of
 /// addresses is enough. An address is stable for a block's life, and
 /// [`forget`] is called from `dealloc` before the block is released.
-type TrackedSet = super::address_table::AddressSet;
-use super::address_table::AddressTable;
+type TrackedSet = super::address_table::HeldSet;
+use super::address_table::{AddressTable, hold};
 
 static TRACKED: AddressTable<TrackedSet> =
     AddressTable::new(TrackedSet::with_hasher(std::hash::BuildHasherDefault::new()));
@@ -58,7 +58,7 @@ pub(super) fn is_finalized(raw: usize) -> bool {
 
 /// Record that `tp_finalize` has run for the block at `raw`.
 pub(super) fn mark_finalized(raw: usize) {
-    FINALIZED.lock().insert(raw);
+    FINALIZED.lock().insert(hold(raw));
 }
 
 /// Drop the finalized flag for a block that is being released.
@@ -84,7 +84,7 @@ pub(super) fn claim_finalizer(raw: usize) -> bool {
     if !has_gc(tp) || unsafe { (*tp).tp_finalize }.is_null() {
         return false;
     }
-    FINALIZED.lock().insert(raw)
+    FINALIZED.lock().insert(hold(raw))
 }
 
 /// Run the finalizer [`claim_finalizer`] promised.
@@ -134,7 +134,7 @@ pub(super) fn track(raw: *mut CPyObject) {
     if unsafe { (*raw).ob_pyre_link }.is_null() {
         return;
     }
-    TRACKED.lock().insert(raw as usize);
+    TRACKED.lock().insert(hold(raw as usize));
 }
 
 /// Drop a block from the tracked set -- `PyObject_GC_UnTrack`, and the release
@@ -148,7 +148,7 @@ pub(super) fn forget(raw: usize) {
 /// A copy rather than a guard: the collector calls `tp_traverse` while walking
 /// this, and an extension's traverse may reach code that tracks or untracks.
 pub(super) fn tracked_blocks() -> Vec<usize> {
-    TRACKED.lock().iter().copied().collect()
+    TRACKED.lock().iter().map(|held| held.address()).collect()
 }
 
 /// `tp_traverse`, read straight off the block's type.

--- a/pyre/pyre-interpreter/src/cpyext/methodobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/methodobject.rs
@@ -83,7 +83,7 @@ const RESERVED_KEYS: &[&str] = &[
 #[derive(Default)]
 struct MethodDefTable {
     rows: Vec<usize>,
-    index_of: HashMap<usize, usize, BuildHasherDefault<std::hash::DefaultHasher>>,
+    index_of: super::address_table::AddressMap<usize>,
 }
 
 static METHOD_DEFS: super::ForkMutex<MethodDefTable> = super::ForkMutex::new(MethodDefTable {

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -210,6 +210,7 @@ pub fn after_fork_child() {
     unsafe {
         EXTENSIONS.reinit_after_fork();
         PACKAGE_CONTEXT.reinit_after_fork();
+        address_table::after_fork_child();
         pyobject::after_fork_child();
         typeobject::after_fork_child();
         modsupport::after_fork_child();

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -994,7 +994,9 @@ mod tests {
     /// The `BoundFamily.taken` locks are a field of a table rather than a
     /// static of their own; `typeobject::after_fork_child` walks
     /// `BOUND_FAMILIES` to reach them.
-
+    ///
+    /// An [`address_table::AddressTable`] holds one of these locks, so its
+    /// statics are checked under the same rule.
     #[test]
     fn every_fork_lock_is_reset_in_the_child() {
         let sources = sources();
@@ -1006,6 +1008,7 @@ mod tests {
                     continue;
                 };
                 if !declaration.contains("ForkMutex<")
+                    && !declaration.contains("AddressTable<")
                     && !declaration.contains("ForkExtensionLoadLock")
                 {
                     continue;

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -15,6 +15,7 @@
     any(target_os = "macos", target_os = "linux")
 ))]
 
+mod address_table;
 pub mod buffer;
 pub mod bytearrayobject;
 pub mod bytesobject;
@@ -993,6 +994,7 @@ mod tests {
     /// The `BoundFamily.taken` locks are a field of a table rather than a
     /// static of their own; `typeobject::after_fork_child` walks
     /// `BOUND_FAMILIES` to reach them.
+
     #[test]
     fn every_fork_lock_is_reset_in_the_child() {
         let sources = sources();

--- a/pyre/pyre-interpreter/src/cpyext/modsupport.rs
+++ b/pyre/pyre-interpreter/src/cpyext/modsupport.rs
@@ -39,8 +39,7 @@ struct ModuleFields {
     md_state: usize,
 }
 
-type ModuleTable =
-    std::collections::HashMap<usize, ModuleFields, BuildHasherDefault<std::hash::DefaultHasher>>;
+type ModuleTable = super::address_table::AddressMap<ModuleFields>;
 static MODULE_FIELDS: super::ForkMutex<ModuleTable> = super::ForkMutex::new(
     std::collections::HashMap::with_hasher(BuildHasherDefault::new()),
 );

--- a/pyre/pyre-interpreter/src/cpyext/modsupport.rs
+++ b/pyre/pyre-interpreter/src/cpyext/modsupport.rs
@@ -40,7 +40,9 @@ struct ModuleFields {
 }
 
 type ModuleTable = super::address_table::AddressMap<ModuleFields>;
-static MODULE_FIELDS: super::ForkMutex<ModuleTable> = super::ForkMutex::new(
+use super::address_table::AddressTable;
+
+static MODULE_FIELDS: AddressTable<ModuleTable> = AddressTable::new(
     std::collections::HashMap::with_hasher(BuildHasherDefault::new()),
 );
 
@@ -83,7 +85,7 @@ fn set_field(module: PyObjectRef, update: impl FnOnce(&mut ModuleFields)) {
 /// The state block itself is not freed: pyre has no module deallocation path,
 /// and an extension may still hold the address.
 pub(super) fn forget_module_fields(mirror: usize) {
-    MODULE_FIELDS.lock().remove(&mirror);
+    MODULE_FIELDS.take(mirror);
 }
 
 /// The single-phase modules `PyState_AddModule` has filed, one slot per module

--- a/pyre/pyre-interpreter/src/cpyext/modsupport.rs
+++ b/pyre/pyre-interpreter/src/cpyext/modsupport.rs
@@ -39,8 +39,8 @@ struct ModuleFields {
     md_state: usize,
 }
 
-type ModuleTable = super::address_table::AddressMap<ModuleFields>;
-use super::address_table::AddressTable;
+type ModuleTable = super::address_table::HeldMap<ModuleFields>;
+use super::address_table::{AddressTable, hold};
 
 static MODULE_FIELDS: AddressTable<ModuleTable> = AddressTable::new(
     std::collections::HashMap::with_hasher(BuildHasherDefault::new()),
@@ -77,7 +77,7 @@ fn set_field(module: PyObjectRef, update: impl FnOnce(&mut ModuleFields)) {
     if mirror == 0 {
         return;
     }
-    update(MODULE_FIELDS.lock().entry(mirror).or_default());
+    update(MODULE_FIELDS.lock().entry(hold(mirror)).or_default());
 }
 
 /// Drop what a dying module mirror recorded.

--- a/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
@@ -120,7 +120,7 @@ const _: () = {
     assert!(size_of::<CPyStopIterationObject>() == 4 * size_of::<usize>());
 };
 
-type BlockSet = super::address_table::AddressSet;
+type BlockSet = super::address_table::HeldSet;
 
 /// The mirrors [`attach`] filled, which is what says whose `value` is a
 /// reference to release.
@@ -129,7 +129,7 @@ type BlockSet = super::address_table::AddressSet;
 /// class derived from `StopIteration` has a type mirror of its own, and asking
 /// the size instead is what turns an unrelated C type's storage into a
 /// reference to decrement.
-use super::address_table::AddressTable;
+use super::address_table::{AddressTable, hold};
 
 static ATTACHED: AddressTable<BlockSet> =
     AddressTable::new(BlockSet::with_hasher(std::hash::BuildHasherDefault::new()));
@@ -186,7 +186,7 @@ pub(super) fn attach(raw: *mut CPyObject, w_obj: PyObjectRef) {
     );
     let value = pyobject::make_ref(unsafe { crate::baseobjspace::stopiteration_value(w_obj) });
     unsafe { (*(raw as *mut CPyStopIterationObject)).value = value };
-    ATTACHED.lock().insert(raw as usize);
+    ATTACHED.lock().insert(hold(raw as usize));
 }
 
 /// Release the reference a `StopIteration` mirror owns — `pyerrors.py:45-50

--- a/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
@@ -129,8 +129,10 @@ type BlockSet = super::address_table::AddressSet;
 /// class derived from `StopIteration` has a type mirror of its own, and asking
 /// the size instead is what turns an unrelated C type's storage into a
 /// reference to decrement.
-static ATTACHED: super::ForkMutex<BlockSet> =
-    super::ForkMutex::new(BlockSet::with_hasher(std::hash::BuildHasherDefault::new()));
+use super::address_table::AddressTable;
+
+static ATTACHED: AddressTable<BlockSet> =
+    AddressTable::new(BlockSet::with_hasher(std::hash::BuildHasherDefault::new()));
 
 pub(super) unsafe fn after_fork_child() {
     unsafe { ATTACHED.reinit_after_fork() };
@@ -190,7 +192,7 @@ pub(super) fn attach(raw: *mut CPyObject, w_obj: PyObjectRef) {
 /// Release the reference a `StopIteration` mirror owns — `pyerrors.py:45-50
 /// stopiteration_dealloc`.
 pub(super) fn forget_block(raw: *mut CPyObject) {
-    if !ATTACHED.lock().remove(&(raw as usize)) {
+    if !ATTACHED.discard(raw as usize) {
         return;
     }
     let py_stopiteration = raw as *mut CPyStopIterationObject;

--- a/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
@@ -120,8 +120,7 @@ const _: () = {
     assert!(size_of::<CPyStopIterationObject>() == 4 * size_of::<usize>());
 };
 
-type BlockSet =
-    std::collections::HashSet<usize, std::hash::BuildHasherDefault<std::hash::DefaultHasher>>;
+type BlockSet = super::address_table::AddressSet;
 
 /// The mirrors [`attach`] filled, which is what says whose `value` is a
 /// reference to release.

--- a/pyre/pyre-interpreter/src/cpyext/pyobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyobject.rs
@@ -98,7 +98,7 @@ struct Block {
 /// about a link is now asked; this survives only because a mirror block's size
 /// is not something the collector has any reason to know.  Its keys are mirror
 /// addresses, which never move, so it needs no collection-time maintenance.
-type BlockSizes = HashMap<usize, Block, BuildHasherDefault<std::hash::DefaultHasher>>;
+type BlockSizes = super::address_table::AddressMap<Block>;
 static BLOCK_SIZES: ForkMutex<BlockSizes> =
     ForkMutex::new(HashMap::with_hasher(BuildHasherDefault::new()));
 
@@ -728,8 +728,8 @@ pub fn drain_dead() {
 /// that root belongs to -- [`borrowed_edges`].  Without that the retention above
 /// is unbounded rather than merely wide: an item referring back to its container
 /// keeps the container, which is what would release the entry.
-type BorrowSet = std::collections::HashSet<usize, BuildHasherDefault<std::hash::DefaultHasher>>;
-type BorrowMap = HashMap<usize, BorrowSet, BuildHasherDefault<std::hash::DefaultHasher>>;
+type BorrowSet = super::address_table::AddressSet;
+type BorrowMap = super::address_table::AddressMap<BorrowSet>;
 static BORROWED: ForkMutex<BorrowMap> =
     ForkMutex::new(HashMap::with_hasher(BuildHasherDefault::new()));
 
@@ -803,7 +803,7 @@ pub(super) fn borrowed_edges(edges: &mut Vec<(usize, Vec<usize>)>) {
 /// through `PyTuple_GET_ITEM` is borrowed from the container, and it stays
 /// good for as long as the container does because the array holds it.
 /// Held as addresses, which a mirror pointer is and a `Send` bound accepts.
-type ItemCache = HashMap<usize, Box<[usize]>, BuildHasherDefault<std::hash::DefaultHasher>>;
+type ItemCache = super::address_table::AddressMap<Box<[usize]>>;
 static ITEM_ARRAYS: ForkMutex<ItemCache> =
     ForkMutex::new(HashMap::with_hasher(BuildHasherDefault::new()));
 
@@ -899,7 +899,7 @@ fn forget_items(raw: usize) {
 /// hand out a stable, NUL-terminated address, and the interpreter's own storage
 /// is neither NUL-terminated nor at a fixed address.  It is a side table rather
 /// than a field so that a mirror block is exactly what its type declares.
-type ByteCache = HashMap<usize, Box<[u8]>, BuildHasherDefault<std::hash::DefaultHasher>>;
+type ByteCache = super::address_table::AddressMap<Box<[u8]>>;
 static BYTE_CACHE: ForkMutex<ByteCache> =
     ForkMutex::new(HashMap::with_hasher(BuildHasherDefault::new()));
 

--- a/pyre/pyre-interpreter/src/cpyext/pyobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyobject.rs
@@ -521,22 +521,33 @@ unsafe fn dealloc(raw: *mut CPyObject) {
     // Everything this layer holds on the mirror's behalf goes before
     // `tp_dealloc` can free the block out from under it.  A borrow it owns may
     // be the last reference to its own container, so that recursion runs here.
-    release_borrowed(raw);
-    BYTE_CACHE.take(address);
-    forget_items(address);
-    super::dictobject::forget_iteration(address);
-    super::modsupport::forget_module_fields(address);
-    super::unicodeobject::forget_block(address);
-    super::bytesobject::forget_pending(address);
+    // Only a block some table keyed an entry under is walked.  `release_hold`
+    // answers for all fourteen at once, which the tables cannot do for
+    // themselves: five of them are never empty for a program that imported
+    // anything -- a module's fields, a type's name, the tracked set -- so
+    // `AddressTable::is_empty` never fires for those and each costs a lock and
+    // a probe that finds nothing.
+    if super::address_table::release_hold(address) {
+        release_borrowed(raw);
+        BYTE_CACHE.take(address);
+        forget_items(address);
+        super::dictobject::forget_iteration(address);
+        super::modsupport::forget_module_fields(address);
+        super::unicodeobject::forget_block(address);
+        super::bytesobject::forget_pending(address);
+        super::frameobject::forget_pending(raw);
+        super::pyerrors::forget_block(raw);
+        super::cdatetime::forget_block(raw);
+        super::typeobject::forget_descriptor_block(raw);
+        unsafe { super::typeobject::forget_type_mirror(raw) };
+        super::gc::forget(address);
+    }
+    // What a block carries in its own fields is there whether or not a table
+    // keyed anything under its address.
     super::tupleobject::forget_block(raw);
     super::frameobject::forget_block(raw);
     super::sliceobject::forget_block(raw);
-    super::pyerrors::forget_block(raw);
-    super::cdatetime::forget_block(raw);
     super::methodobject::forget_block(raw);
-    super::typeobject::forget_descriptor_block(raw);
-    unsafe { super::typeobject::forget_type_mirror(raw) };
-    super::gc::forget(address);
     let block = block_at(address);
     let returned = if let Some(tp_dealloc) = unsafe { super::typeobject::tp_dealloc_of(raw) } {
         let call: unsafe extern "C" fn(*mut CPyObject) = unsafe { std::mem::transmute(tp_dealloc) };
@@ -732,8 +743,8 @@ pub fn drain_dead() {
 /// is unbounded rather than merely wide: an item referring back to its container
 /// keeps the container, which is what would release the entry.
 type BorrowSet = super::address_table::AddressSet;
-type BorrowMap = super::address_table::AddressMap<BorrowSet>;
-use super::address_table::AddressTable;
+type BorrowMap = super::address_table::HeldMap<BorrowSet>;
+use super::address_table::{AddressTable, hold};
 
 static BORROWED: AddressTable<BorrowMap> =
     AddressTable::new(HashMap::with_hasher(BuildHasherDefault::new()));
@@ -754,7 +765,7 @@ pub(super) fn borrow_from(container: *mut CPyObject, w_item: PyObjectRef) -> *mu
     }
     let mut borrowed = BORROWED.lock();
     let fresh = borrowed
-        .entry(container as usize)
+        .entry(hold(container as usize))
         .or_default()
         .insert(item as usize);
     if !fresh {
@@ -791,7 +802,7 @@ pub(super) fn borrowed_edges(edges: &mut Vec<(usize, Vec<usize>)>) {
         if items.is_empty() {
             continue;
         }
-        edges.push((container, items.iter().copied().collect()));
+        edges.push((container.address(), items.iter().copied().collect()));
     }
 }
 
@@ -808,7 +819,7 @@ pub(super) fn borrowed_edges(edges: &mut Vec<(usize, Vec<usize>)>) {
 /// through `PyTuple_GET_ITEM` is borrowed from the container, and it stays
 /// good for as long as the container does because the array holds it.
 /// Held as addresses, which a mirror pointer is and a `Send` bound accepts.
-type ItemCache = super::address_table::AddressMap<Box<[usize]>>;
+type ItemCache = super::address_table::HeldMap<Box<[usize]>>;
 static ITEM_ARRAYS: AddressTable<ItemCache> =
     AddressTable::new(HashMap::with_hasher(BuildHasherDefault::new()));
 
@@ -828,7 +839,7 @@ pub(super) fn publish_items(raw: *mut CPyObject, items: Vec<usize>) -> *mut *mut
             .is_some_and(|array| array[..] == items[..]);
         let spare = match unchanged {
             true => Some(items.into_boxed_slice()),
-            false => cache.insert(raw as usize, items.into_boxed_slice()),
+            false => cache.insert(hold(raw as usize), items.into_boxed_slice()),
         };
         (
             cache[&(raw as usize)].as_ptr() as *mut *mut CPyObject,
@@ -904,7 +915,7 @@ fn forget_items(raw: usize) {
 /// hand out a stable, NUL-terminated address, and the interpreter's own storage
 /// is neither NUL-terminated nor at a fixed address.  It is a side table rather
 /// than a field so that a mirror block is exactly what its type declares.
-type ByteCache = super::address_table::AddressMap<Box<[u8]>>;
+type ByteCache = super::address_table::HeldMap<Box<[u8]>>;
 static BYTE_CACHE: AddressTable<ByteCache> =
     AddressTable::new(HashMap::with_hasher(BuildHasherDefault::new()));
 
@@ -922,7 +933,7 @@ pub(super) unsafe fn cached_bytes(
     produce: impl FnOnce() -> Vec<u8>,
 ) -> (*const c_char, usize) {
     let mut cache = BYTE_CACHE.lock();
-    let entry = cache.entry(raw as usize).or_insert_with(|| {
+    let entry = cache.entry(hold(raw as usize)).or_insert_with(|| {
         let mut bytes = produce();
         bytes.push(0);
         bytes.into_boxed_slice()

--- a/pyre/pyre-interpreter/src/cpyext/pyobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyobject.rs
@@ -520,7 +520,7 @@ unsafe fn dealloc(raw: *mut CPyObject) {
     // `tp_dealloc` can free the block out from under it.  A borrow it owns may
     // be the last reference to its own container, so that recursion runs here.
     release_borrowed(raw);
-    BYTE_CACHE.lock().remove(&address);
+    BYTE_CACHE.take(address);
     forget_items(address);
     super::dictobject::forget_iteration(address);
     super::modsupport::forget_module_fields(address);
@@ -730,8 +730,10 @@ pub fn drain_dead() {
 /// keeps the container, which is what would release the entry.
 type BorrowSet = super::address_table::AddressSet;
 type BorrowMap = super::address_table::AddressMap<BorrowSet>;
-static BORROWED: ForkMutex<BorrowMap> =
-    ForkMutex::new(HashMap::with_hasher(BuildHasherDefault::new()));
+use super::address_table::AddressTable;
+
+static BORROWED: AddressTable<BorrowMap> =
+    AddressTable::new(HashMap::with_hasher(BuildHasherDefault::new()));
 
 /// A borrowed reference to `w_item`, owned by `container`'s mirror.
 ///
@@ -761,7 +763,7 @@ pub(super) fn borrow_from(container: *mut CPyObject, w_item: PyObjectRef) -> *mu
 
 /// Release everything a dying container mirror borrowed on C's behalf.
 fn release_borrowed(container: *mut CPyObject) {
-    let owned = BORROWED.lock().remove(&(container as usize));
+    let owned = BORROWED.take(container as usize);
     for item in owned.into_iter().flatten() {
         unsafe { decref(item as *mut CPyObject) };
     }
@@ -804,8 +806,8 @@ pub(super) fn borrowed_edges(edges: &mut Vec<(usize, Vec<usize>)>) {
 /// good for as long as the container does because the array holds it.
 /// Held as addresses, which a mirror pointer is and a `Send` bound accepts.
 type ItemCache = super::address_table::AddressMap<Box<[usize]>>;
-static ITEM_ARRAYS: ForkMutex<ItemCache> =
-    ForkMutex::new(HashMap::with_hasher(BuildHasherDefault::new()));
+static ITEM_ARRAYS: AddressTable<ItemCache> =
+    AddressTable::new(HashMap::with_hasher(BuildHasherDefault::new()));
 
 /// Give `raw`'s array `items` and answer where they sit.
 ///
@@ -888,7 +890,7 @@ pub(super) fn replace_cached_item(
 /// Drop the array a dying container mirror handed out, and the references it
 /// owned with it.
 fn forget_items(raw: usize) {
-    let array = ITEM_ARRAYS.lock().remove(&raw);
+    let array = ITEM_ARRAYS.take(raw);
     release_item_array(array);
 }
 
@@ -900,8 +902,8 @@ fn forget_items(raw: usize) {
 /// is neither NUL-terminated nor at a fixed address.  It is a side table rather
 /// than a field so that a mirror block is exactly what its type declares.
 type ByteCache = super::address_table::AddressMap<Box<[u8]>>;
-static BYTE_CACHE: ForkMutex<ByteCache> =
-    ForkMutex::new(HashMap::with_hasher(BuildHasherDefault::new()));
+static BYTE_CACHE: AddressTable<ByteCache> =
+    AddressTable::new(HashMap::with_hasher(BuildHasherDefault::new()));
 
 /// The mirror's cached bytes and their length, without the terminator.
 ///

--- a/pyre/pyre-interpreter/src/cpyext/pyobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyobject.rs
@@ -193,7 +193,9 @@ pub(super) fn ensure_mirror(w_obj: PyObjectRef) -> *mut CPyObject {
         return mirror as *mut CPyObject;
     }
     let ob_type = type_mirror(w_obj);
-    let size = mirror_size(ob_type);
+    // `allocate`'s `size += itemcount * itemsize`: a tuple's items are part of
+    // its block, which is what lets `PyTuple_GET_ITEM` read one as a field.
+    let size = mirror_size(ob_type) + super::tupleobject::item_bytes(w_obj, ob_type);
     let raw = attach(w_obj, REFCNT_FROM_PYPY, ob_type, size);
     // Each fill allocates, so the object is read back through the mirror
     // before the next one rather than kept in a local: the block's address
@@ -526,6 +528,7 @@ unsafe fn dealloc(raw: *mut CPyObject) {
     super::modsupport::forget_module_fields(address);
     super::unicodeobject::forget_block(address);
     super::bytesobject::forget_pending(address);
+    super::tupleobject::forget_block(raw);
     super::frameobject::forget_block(raw);
     super::sliceobject::forget_block(raw);
     super::pyerrors::forget_block(raw);

--- a/pyre/pyre-interpreter/src/cpyext/tupleobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/tupleobject.rs
@@ -2,8 +2,127 @@
 
 use super::object::argument;
 use super::pyobject::{self, CPyObject};
+use super::typeobject::{CPyTypeObject, CPyVarObject};
 use pyre_object::PyObjectRef;
 use std::ffi::c_int;
+
+/// `PyTupleObject` -- the header, and the items that follow it.
+///
+/// `tupleobject.py:31-35 PyTupleObjectFields` gives the mirror an array of
+/// `ob_size` `PyObject *`, filled when the mirror is built, so that
+/// `PyTuple_GET_ITEM` reads a slot the way CPython's macro does.  The array is
+/// the mirror's own rather than a view on the tuple, and has to be: the
+/// arity-2 specialisations of `specialisedtupleobject.py` build a fresh item
+/// on every read, so a borrowed reference into one would name something
+/// nothing keeps alive.
+///
+/// `ob_item` is declared at one slot, which is what `tupleobject.h` spells;
+/// [`item_bytes`] is what decides how many the block really has.
+#[repr(C)]
+pub struct CPyTupleObject {
+    pub ob_base: CPyVarObject,
+    pub ob_item: [*mut CPyObject; 1],
+}
+
+/// The array follows the header with nothing between, which is what lets a
+/// block hold it and a reader find it.
+const _: () = assert!(
+    std::mem::offset_of!(CPyTupleObject, ob_item) == size_of::<CPyVarObject>(),
+    "a tuple mirror's items start where its header ends"
+);
+
+/// Whether a mirror of `ob_type` carries its items in its own block.
+///
+/// The array starts where the header ends, so only a tuple whose type declared
+/// nothing past it has the room; one that added fields of its own keeps the
+/// array beside the block instead, which is what
+/// [`pyobject::items_or_build`] answers with.  The flag is what makes the
+/// layout a tuple's rather than that of any other type sized like one.
+fn carries_items(ob_type: *mut CPyTypeObject) -> bool {
+    if ob_type.is_null() {
+        return false;
+    }
+    let flags = unsafe { (*ob_type).tp_flags };
+    flags & super::typeobject::PY_TPFLAGS_TUPLE_SUBCLASS != 0
+        && unsafe { (*ob_type).tp_basicsize } == size_of::<CPyVarObject>() as isize
+}
+
+/// `pyobject.py:96-100 allocate`'s `size += itemcount * itemsize`, for the one
+/// type whose items live in its block.
+pub(super) fn item_bytes(w_obj: PyObjectRef, ob_type: *mut CPyTypeObject) -> usize {
+    if !carries_items(ob_type) || unsafe { !pyre_object::is_tuple(w_obj) } {
+        return 0;
+    }
+    unsafe { pyre_object::tupleobject::w_tuple_len(w_obj) }
+        .saturating_mul(size_of::<*mut CPyObject>())
+}
+
+/// Where `raw`'s items sit, for a block that carries them.
+///
+/// The count is `ob_size`, which [`super::typeobject::stamp_ob_size`] filled
+/// from the same length [`item_bytes`] sized the block by.
+fn items_in_block(raw: *mut CPyObject) -> Option<(*mut *mut CPyObject, usize)> {
+    if raw.is_null() || !carries_items(unsafe { (*raw).ob_type }) {
+        return None;
+    }
+    let length = unsafe { (*(raw as *mut CPyVarObject)).ob_size }.max(0) as usize;
+    // Reached from the block's base rather than through the declared slot: an
+    // empty tuple's block ends where its array starts, and that address is
+    // still the one a reader is handed.
+    let items = unsafe { raw.byte_add(size_of::<CPyVarObject>()) } as *mut *mut CPyObject;
+    Some((items, length))
+}
+
+/// Give the block the items it does not yet hold --
+/// `tupleobject.py:70-96 tuple_attach`, run on the first read rather than when
+/// the mirror is built.
+///
+/// Upstream fills the array before `track_reference` publishes the mirror, so
+/// nothing can reach a half-filled one.  Here the link is created first, and
+/// `make_ref` below reaches `ensure_mirror` again -- for a type, all the way
+/// into `finish_interpreter_type`, which walks the very MRO tuple being filled.
+/// Filling on demand keeps that recursion out of mirror creation, and a NUL
+/// slot is what marks one still owed: a slot holding a genuine NUL resolves to
+/// NUL again, so a repeated pass is the same answer rather than a second
+/// reference.
+fn fill_missing(raw: *mut CPyObject, items: *mut *mut CPyObject, length: usize) {
+    for index in 0..length {
+        if !unsafe { items.add(index).read() }.is_null() {
+            continue;
+        }
+        // Read the tuple back through the mirror before each `make_ref`: that
+        // call allocates, and the tuple moves under a collection where the
+        // block does not.
+        let w_tuple = unsafe { pyobject::from_ref(raw) };
+        if w_tuple.is_null() || unsafe { !pyre_object::is_tuple(w_tuple) } {
+            return;
+        }
+        let item = unsafe { pyre_object::tupleobject::w_tuple_getitem(w_tuple, index as i64) };
+        let Some(item) = item else { continue };
+        let entry = pyobject::make_ref(item);
+        // Written only if the slot is still owed: the `make_ref` above can
+        // reach a reader that filled it, and two references would be one more
+        // than the block gives back.
+        match unsafe { items.add(index).read() }.is_null() {
+            true => unsafe { items.add(index).write(entry) },
+            false => unsafe { pyobject::decref(entry) },
+        }
+    }
+}
+
+/// Give back the references a dying tuple mirror's items owned --
+/// `tupleobject.py tuple_dealloc`.
+pub(super) fn forget_block(raw: *mut CPyObject) {
+    let Some((items, length)) = items_in_block(raw) else {
+        return;
+    };
+    for index in 0..length {
+        // Cleared before the release: a deallocator this runs can reach the
+        // same block, and has to find a slot it will not release twice.
+        let entry = unsafe { items.add(index).replace(std::ptr::null_mut()) };
+        unsafe { pyobject::decref(entry) };
+    }
+}
 
 /// A tuple of NULL slots for the caller to fill through `PyTuple_SetItem`.
 ///
@@ -114,6 +233,10 @@ pub unsafe extern "C" fn _PyTuple_ITEMS(object: *mut CPyObject) -> *mut *mut CPy
     let Some(value) = tuple_value(object) else {
         return std::ptr::null_mut();
     };
+    if let Some((items, length)) = items_in_block(object) {
+        fill_missing(object, items, length);
+        return items;
+    }
     pyobject::items_or_build(object, || {
         let length = unsafe { pyre_object::tupleobject::w_tuple_len(value) };
         (0..length)
@@ -131,6 +254,25 @@ pub unsafe extern "C" fn _PyTuple_ITEMS(object: *mut CPyObject) -> *mut *mut CPy
             })
             .collect()
     })
+}
+
+/// Put `item` in slot `index` of whichever array `object` hands out, answering
+/// with what it displaced.
+///
+/// A caller holding the address `PyTuple_GET_ITEM` gave it reads the new value
+/// through it, so the slot is written wherever the array lives.
+fn replace_item(
+    object: *mut CPyObject,
+    index: usize,
+    item: *mut CPyObject,
+) -> Option<*mut CPyObject> {
+    let Some((items, length)) = items_in_block(object) else {
+        return pyobject::replace_cached_item(object, index, item);
+    };
+    if index >= length {
+        return None;
+    }
+    Some(unsafe { items.add(index).replace(item) })
 }
 
 /// `PyTuple_SET_ITEM(op, i, v)` -- slot `i` is given `v`, whatever it held
@@ -166,7 +308,7 @@ pub unsafe extern "C" fn _PyTuple_SET_ITEM(
     };
     if written.is_some() {
         // What comes back is dropped rather than released: see above.
-        pyobject::replace_cached_item(object, index as usize, item);
+        replace_item(object, index as usize, item);
     }
 }
 
@@ -211,7 +353,7 @@ pub unsafe extern "C" fn PyTuple_SetItem(
     // value through it, so the slot is written rather than the array rebuilt,
     // and the stolen reference is what the array is given.  Where there is no
     // array to take it, it is released here instead.
-    match pyobject::replace_cached_item(object, index as usize, item) {
+    match replace_item(object, index as usize, item) {
         Some(previous) => unsafe { pyobject::decref(previous) },
         None => unsafe { pyobject::decref(item) },
     }

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -543,11 +543,7 @@ fn builtin_type(layout: &'static pyre_object::pyobject::PyType) -> PyObjectRef {
 /// the type, so the string has to outlive every read of the field and die with
 /// the mirror rather than with this call.  Keyed by the mirror's address, which
 /// is fixed for its life; [`forget_type_name`] is what releases it.
-type NameTable = std::collections::HashMap<
-    usize,
-    CString,
-    std::hash::BuildHasherDefault<std::hash::DefaultHasher>,
->;
+type NameTable = super::address_table::AddressMap<CString>;
 static TYPE_NAMES: super::ForkMutex<NameTable> =
     super::ForkMutex::new(NameTable::with_hasher(std::hash::BuildHasherDefault::new()));
 
@@ -1555,8 +1551,7 @@ static BOUND_MINTED: super::ForkMutex<BoundAddresses> = super::ForkMutex::new(
     BoundAddresses::with_hasher(std::hash::BuildHasherDefault::new()),
 );
 
-type BoundAddresses =
-    std::collections::HashSet<usize, std::hash::BuildHasherDefault<std::hash::DefaultHasher>>;
+type BoundAddresses = super::address_table::AddressSet;
 
 type BoundNames = std::collections::HashMap<
     (usize, &'static str),
@@ -4334,11 +4329,7 @@ fn install_protocols(ns: PyObjectRef, tp: *mut CPyTypeObject) {
 /// A filled block, against the address of the [`CPyWrapperBase`] allocated for
 /// it -- 0 for every family that has none.  An address rather than a pointer
 /// because the table is shared across threads and a raw pointer is not.
-type BlockSet = std::collections::HashMap<
-    usize,
-    usize,
-    std::hash::BuildHasherDefault<std::hash::DefaultHasher>,
->;
+type BlockSet = super::address_table::AddressMap<usize>;
 
 /// The blocks [`descriptor_attach`] filled, and so the ones whose references
 /// are this module's to release.
@@ -5313,11 +5304,9 @@ fn ready(tp: *mut CPyTypeObject, w_metaclass: PyObjectRef) -> Result<(), crate::
 /// checked the field answers "does this type have a `tp_new`", which is yes for
 /// every readied type.  What the check asks is the narrower question this
 /// records: did the extension declare one.
-static DECLARED_TP_NEW: super::ForkMutex<
-    std::collections::HashSet<usize, std::hash::BuildHasherDefault<std::hash::DefaultHasher>>,
-> = super::ForkMutex::new(std::collections::HashSet::with_hasher(
-    std::hash::BuildHasherDefault::new(),
-));
+static DECLARED_TP_NEW: super::ForkMutex<super::address_table::AddressSet> = super::ForkMutex::new(
+    super::address_table::AddressSet::with_hasher(std::hash::BuildHasherDefault::new()),
+);
 
 fn record_declared_tp_new(tp: *mut CPyTypeObject) {
     if unsafe { (*tp).tp_new.is_null() } {
@@ -5862,11 +5851,7 @@ fn single_base(bases: PyObjectRef) -> Result<*mut CPyTypeObject, crate::PyError>
 /// leaked deliberately, so the key is stable for the life of the process.  The
 /// module is held as an owned mirror reference, and it is that reference — not
 /// the table — that roots it.
-type TypeSideTable = std::collections::HashMap<
-    usize,
-    usize,
-    std::hash::BuildHasherDefault<std::hash::DefaultHasher>,
->;
+type TypeSideTable = super::address_table::AddressMap<usize>;
 static TYPE_MODULES: super::ForkMutex<TypeSideTable> = super::ForkMutex::new(
     TypeSideTable::with_hasher(std::hash::BuildHasherDefault::new()),
 );

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -543,8 +543,8 @@ fn builtin_type(layout: &'static pyre_object::pyobject::PyType) -> PyObjectRef {
 /// the type, so the string has to outlive every read of the field and die with
 /// the mirror rather than with this call.  Keyed by the mirror's address, which
 /// is fixed for its life; [`forget_type_name`] is what releases it.
-type NameTable = super::address_table::AddressMap<CString>;
-use super::address_table::AddressTable;
+type NameTable = super::address_table::HeldMap<CString>;
+use super::address_table::{AddressTable, hold};
 
 static TYPE_NAMES: AddressTable<NameTable> =
     AddressTable::new(NameTable::with_hasher(std::hash::BuildHasherDefault::new()));
@@ -600,7 +600,7 @@ pub(super) fn type_mirror_edges(edges: &mut Vec<(usize, Vec<usize>)>) {
     let names = TYPE_NAMES.lock();
     edges.reserve(names.len());
     for &block in names.keys() {
-        let mirror = block as *mut CPyTypeObject;
+        let mirror = block.address() as *mut CPyTypeObject;
         let base = unsafe { (*mirror).tp_base };
         let base = match is_heap_type(mirror) && !base.is_null() {
             true => unsafe { &raw mut (*base).ob_base.ob_base },
@@ -619,7 +619,7 @@ pub(super) fn type_mirror_edges(edges: &mut Vec<(usize, Vec<usize>)>) {
         .map(|raw| raw as usize)
         .collect();
         if !referents.is_empty() {
-            edges.push((block, referents));
+            edges.push((block.address(), referents));
         }
     }
 }
@@ -881,7 +881,7 @@ pub(super) fn describe_interpreter_type(mirror: *mut CPyTypeObject, w_type: PyOb
             (*mirror).tp_weaklistoffset = (*base).tp_weaklistoffset;
         }
     }
-    TYPE_NAMES.lock().insert(mirror as usize, name);
+    TYPE_NAMES.lock().insert(hold(mirror as usize), name);
 }
 
 /// The mirror of the base whose instance layout `w_type` extends —
@@ -4331,7 +4331,7 @@ fn install_protocols(ns: PyObjectRef, tp: *mut CPyTypeObject) {
 /// A filled block, against the address of the [`CPyWrapperBase`] allocated for
 /// it -- 0 for every family that has none.  An address rather than a pointer
 /// because the table is shared across threads and a raw pointer is not.
-type BlockSet = super::address_table::AddressMap<usize>;
+type BlockSet = super::address_table::HeldMap<usize>;
 
 /// The blocks [`descriptor_attach`] filled, and so the ones whose references
 /// are this module's to release.
@@ -4446,7 +4446,7 @@ pub(super) fn descriptor_attach(raw: *mut CPyObject, w_obj: PyObjectRef) {
         }
         0
     };
-    DESCRIPTOR_BLOCKS.lock().insert(raw as usize, base);
+    DESCRIPTOR_BLOCKS.lock().insert(hold(raw as usize), base);
 }
 
 /// Release what a descriptor block owns — `typeobject.py descr_dealloc` and

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -544,8 +544,10 @@ fn builtin_type(layout: &'static pyre_object::pyobject::PyType) -> PyObjectRef {
 /// the mirror rather than with this call.  Keyed by the mirror's address, which
 /// is fixed for its life; [`forget_type_name`] is what releases it.
 type NameTable = super::address_table::AddressMap<CString>;
-static TYPE_NAMES: super::ForkMutex<NameTable> =
-    super::ForkMutex::new(NameTable::with_hasher(std::hash::BuildHasherDefault::new()));
+use super::address_table::AddressTable;
+
+static TYPE_NAMES: AddressTable<NameTable> =
+    AddressTable::new(NameTable::with_hasher(std::hash::BuildHasherDefault::new()));
 
 /// `typeobject.py:708-722 type_dealloc` — release what a synthesized mirror's
 /// own fields hold, and the string behind `tp_name`.
@@ -559,7 +561,7 @@ static TYPE_NAMES: super::ForkMutex<NameTable> =
 /// # Safety
 /// `raw` must be a live block whose count has fallen to zero.
 pub(super) unsafe fn forget_type_mirror(raw: *mut CPyObject) {
-    if TYPE_NAMES.lock().remove(&(raw as usize)).is_none() {
+    if TYPE_NAMES.take(raw as usize).is_none() {
         return;
     }
     let mirror = raw as *mut CPyTypeObject;
@@ -4333,8 +4335,8 @@ type BlockSet = super::address_table::AddressMap<usize>;
 
 /// The blocks [`descriptor_attach`] filled, and so the ones whose references
 /// are this module's to release.
-static DESCRIPTOR_BLOCKS: super::ForkMutex<BlockSet> =
-    super::ForkMutex::new(BlockSet::with_hasher(std::hash::BuildHasherDefault::new()));
+static DESCRIPTOR_BLOCKS: AddressTable<BlockSet> =
+    AddressTable::new(BlockSet::with_hasher(std::hash::BuildHasherDefault::new()));
 
 /// Whether `w_type` is one of this module's descriptor carriers.
 ///
@@ -4450,7 +4452,7 @@ pub(super) fn descriptor_attach(raw: *mut CPyObject, w_obj: PyObjectRef) {
 /// Release what a descriptor block owns — `typeobject.py descr_dealloc` and
 /// `wrapper_dealloc`, which frees the wrapper block on top of it.
 pub(super) fn forget_descriptor_block(raw: *mut CPyObject) {
-    let Some(base) = DESCRIPTOR_BLOCKS.lock().remove(&(raw as usize)) else {
+    let Some(base) = DESCRIPTOR_BLOCKS.take(raw as usize) else {
         return;
     };
     let descr = raw as *mut CPyDescrObject;

--- a/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
@@ -168,7 +168,7 @@ struct Block {
     pending: bool,
 }
 
-type BlockTable = HashMap<usize, Block, BuildHasherDefault<std::hash::DefaultHasher>>;
+type BlockTable = super::address_table::AddressMap<Block>;
 static BLOCKS: super::ForkMutex<BlockTable> =
     super::ForkMutex::new(HashMap::with_hasher(BuildHasherDefault::new()));
 

--- a/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
@@ -168,8 +168,8 @@ struct Block {
     pending: bool,
 }
 
-type BlockTable = super::address_table::AddressMap<Block>;
-use super::address_table::AddressTable;
+type BlockTable = super::address_table::HeldMap<Block>;
+use super::address_table::{AddressTable, hold};
 
 static BLOCKS: AddressTable<BlockTable> =
     AddressTable::new(HashMap::with_hasher(BuildHasherDefault::new()));
@@ -256,7 +256,7 @@ fn canonical(raw: *mut CPyObject) -> Option<(c_int, usize, bool, *mut u8)> {
             return None;
         }
         let block = encode(w_obj);
-        BLOCKS.lock().entry(raw as usize).or_insert(block);
+        BLOCKS.lock().entry(hold(raw as usize)).or_insert(block);
     }
     let mut table = BLOCKS.lock();
     let block = table.get_mut(&(raw as usize))?;
@@ -309,7 +309,7 @@ pub unsafe extern "C" fn PyUnicode_New(size: isize, maxchar: Py_UCS4) -> *mut CP
         (*raw).ob_type = ob_type;
     }
     BLOCKS.lock().insert(
-        raw as usize,
+        hold(raw as usize),
         Block {
             kind,
             length: size as usize,

--- a/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
@@ -169,8 +169,10 @@ struct Block {
 }
 
 type BlockTable = super::address_table::AddressMap<Block>;
-static BLOCKS: super::ForkMutex<BlockTable> =
-    super::ForkMutex::new(HashMap::with_hasher(BuildHasherDefault::new()));
+use super::address_table::AddressTable;
+
+static BLOCKS: AddressTable<BlockTable> =
+    AddressTable::new(HashMap::with_hasher(BuildHasherDefault::new()));
 
 pub(super) unsafe fn after_fork_child() {
     unsafe { BLOCKS.reinit_after_fork() };
@@ -178,7 +180,7 @@ pub(super) unsafe fn after_fork_child() {
 
 /// Drop what a dying mirror's canonical form occupied.
 pub(super) fn forget_block(mirror: usize) {
-    BLOCKS.lock().remove(&mirror);
+    BLOCKS.take(mirror);
 }
 
 /// Whether `raw` is a string [`PyUnicode_New`] handed out and nothing has read

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -11,6 +11,7 @@
 //! than cached in a per-type `StgInfo`.  Reading `_type_` off the class also
 //! transparently handles user subclasses (`class MyInt(c_int)`).
 
+use super::stginfo::ParamFunc;
 use super::type_ns_store;
 use pyre_object::PyObjectRef;
 use rustpython_host_env::ctypes as host_ctypes;
@@ -812,7 +813,7 @@ pub(crate) fn cdata_buffer_view(
     let info = super::stginfo::stginfo_of(cls);
     let kind = info
         .map(super::stginfo::stginfo_paramfunc)
-        .unwrap_or_default();
+        .unwrap_or(ParamFunc::Other);
     let shape = ctype_shape(cls);
     let leaf = ctype_leaf(cls);
     let is_funcptr =
@@ -824,7 +825,7 @@ pub(crate) fn cdata_buffer_view(
     };
     let format = if is_funcptr {
         "X{}".to_string()
-    } else if kind == "union" {
+    } else if kind == ParamFunc::Union {
         "B".to_string()
     } else {
         ctype_pep3118_format(cls, None)
@@ -835,7 +836,7 @@ pub(crate) fn cdata_buffer_view(
 fn ctype_shape(mut cls: PyObjectRef) -> Vec<usize> {
     let mut shape = Vec::new();
     while let Some(info) = super::stginfo::stginfo_of(cls) {
-        if super::stginfo::stginfo_paramfunc(info) != "array" {
+        if super::stginfo::stginfo_paramfunc(info) != ParamFunc::Array {
             break;
         }
         shape.push(super::stginfo::stginfo_length(info));
@@ -849,7 +850,7 @@ fn ctype_shape(mut cls: PyObjectRef) -> Vec<usize> {
 
 fn ctype_leaf(mut cls: PyObjectRef) -> PyObjectRef {
     while let Some(info) = super::stginfo::stginfo_of(cls) {
-        if super::stginfo::stginfo_paramfunc(info) != "array" {
+        if super::stginfo::stginfo_paramfunc(info) != ParamFunc::Array {
             break;
         }
         let Some(proto) = super::stginfo::stginfo_proto(info) else {
@@ -864,13 +865,13 @@ pub(super) fn ctype_pep3118_format(cls: PyObjectRef, forced_big: Option<bool>) -
     let info = super::stginfo::stginfo_of(cls);
     let kind = info
         .map(super::stginfo::stginfo_paramfunc)
-        .unwrap_or_default();
-    match kind.as_str() {
-        "array" => info
+        .unwrap_or(ParamFunc::Other);
+    match kind {
+        ParamFunc::Array => info
             .and_then(super::stginfo::stginfo_proto)
             .map(|proto| ctype_pep3118_format(proto, forced_big))
             .unwrap_or_else(|| "B".to_string()),
-        "pointer" => {
+        ParamFunc::Pointer => {
             if let Some(snapshot) = info.and_then(super::stginfo::stginfo_format) {
                 return snapshot;
             }
@@ -895,8 +896,8 @@ pub(super) fn ctype_pep3118_format(cls: PyObjectRef, forced_big: Option<bool>) -
                 .unwrap_or_else(|| "B".to_string());
             format!("&{inner}")
         }
-        "struct" => struct_pep3118_format(cls),
-        "union" => "B".to_string(),
+        ParamFunc::Struct => struct_pep3118_format(cls),
+        ParamFunc::Union => "B".to_string(),
         _ => {
             let Some(code) = type_code_of(cls).and_then(|s| s.chars().next()) else {
                 return "B".to_string();
@@ -1392,9 +1393,113 @@ pub(super) fn share_objects_for_cast(result: PyObjectRef, source: PyObjectRef) {
 
 // ── type-code metadata (StgInfo equivalent, derived from `_type_`) ─────
 
+/// A ctypes type code: the single character `_type_` names, or the `"void"`
+/// [`super::funcptr::build_layout`] gives a zero-sized member.
+///
+/// It carries its own bytes rather than a `String` because a foreign call
+/// reads one per argument and one for the return value, and a heap allocation
+/// per read is most of what such a call does.
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub(super) struct TypeCode {
+    bytes: [u8; Self::CAPACITY],
+    len: u8,
+}
+
+impl TypeCode {
+    /// Wide enough for `"void"`; every other code is one character.
+    pub(super) const CAPACITY: usize = 4;
+
+    /// The code `text` spells, or `None` when it is longer than any code is.
+    pub(super) fn new(text: &str) -> Option<Self> {
+        let src = text.as_bytes();
+        if src.len() > Self::CAPACITY {
+            return None;
+        }
+        let mut bytes = [0u8; Self::CAPACITY];
+        bytes[..src.len()].copy_from_slice(src);
+        Some(TypeCode {
+            bytes,
+            len: src.len() as u8,
+        })
+    }
+
+    /// The code one character spells.  `const` so a caller naming a fixed code
+    /// spends nothing on it.
+    pub(super) const fn from_char(code: char) -> Self {
+        assert!(code.is_ascii(), "a ctypes type code is ASCII");
+        TypeCode {
+            bytes: [code as u8, 0, 0, 0],
+            len: 1,
+        }
+    }
+
+    /// The code's bytes, nul-padded to a fixed width.  No code contains a nul,
+    /// so this round trips through [`TypeCode::from_padded`].
+    pub(super) fn padded(self) -> [u8; Self::CAPACITY] {
+        self.bytes
+    }
+
+    /// The code [`TypeCode::padded`] wrote.
+    pub(super) fn from_padded(bytes: [u8; Self::CAPACITY]) -> Self {
+        let len = bytes
+            .iter()
+            .position(|&byte| byte == 0)
+            .unwrap_or(Self::CAPACITY);
+        TypeCode {
+            bytes,
+            len: len as u8,
+        }
+    }
+
+    pub(super) fn as_str(&self) -> &str {
+        // The bytes came from a `&str` and were copied whole, so the prefix is
+        // itself a code point boundary.
+        core::str::from_utf8(&self.bytes[..self.len as usize]).unwrap_or("")
+    }
+
+    /// The one character a simple-type code is, or `None` for `"void"` and the
+    /// empty code.
+    pub(super) fn as_char(&self) -> Option<char> {
+        let mut chars = self.as_str().chars();
+        chars.next().filter(|_| chars.next().is_none())
+    }
+}
+
+impl core::ops::Deref for TypeCode {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl core::fmt::Display for TypeCode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl core::fmt::Debug for TypeCode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(self.as_str(), f)
+    }
+}
+
+impl PartialEq<str> for TypeCode {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<&str> for TypeCode {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
 /// The single-char ctypes `_type_` of `cls` (a type), read off the MRO.
 /// Returns `None` when the attribute is absent or not a string.
-pub(super) fn type_code_of(cls: PyObjectRef) -> Option<String> {
+pub(super) fn type_code_of(cls: PyObjectRef) -> Option<TypeCode> {
     if cls.is_null() || !unsafe { pyre_object::is_type(cls) } {
         return None;
     }
@@ -1402,7 +1507,7 @@ pub(super) fn type_code_of(cls: PyObjectRef) -> Option<String> {
     if !unsafe { pyre_object::is_str(v) } {
         return None;
     }
-    Some(unsafe { pyre_object::w_str_get_value(v) }.to_string())
+    TypeCode::new(unsafe { pyre_object::w_str_get_value_opt(v) }?)
 }
 
 /// Whether `obj` is a (subclass) type of `_SimpleCData`.

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -14,8 +14,8 @@
 //! to `CallArg::Aggregate` / `CallRet::Aggregate`; a pointer-typed `restype`
 //! wraps the returned address in a fresh instance.
 
-use super::cdata;
-use super::stginfo;
+use super::cdata::{self, TypeCode};
+use super::stginfo::{self, ParamFunc};
 use super::type_ns_store;
 use pyre_object::PyObjectRef;
 use rustpython_host_env::ctypes as host_ctypes;
@@ -29,6 +29,9 @@ pub(super) const FUNCFLAG_USE_ERRNO: i64 = 0x8;
 /// and no call made since can have overwritten it.
 pub(super) const FUNCFLAG_USE_LASTERROR: i64 = 0x10;
 
+/// The `restype` a CDLL function has when none is declared: `c_int`.
+const DEFAULT_RESTYPE_CODE: TypeCode = TypeCode::from_char('i');
+
 /// Reserved instance-dict keys.
 const PTR_KEY: &str = "_ptr";
 const RESTYPE_KEY: &str = "_restype";
@@ -36,6 +39,9 @@ const ARGTYPES_KEY: &str = "_argtypes";
 pub(super) const CALLABLE_KEY: &str = "_callable";
 const ERRCHECK_KEY: &str = "_errcheck";
 const PARAMFLAGS_KEY: &str = "_paramflags";
+/// Reserved instance-dict key holding what the declarations have settled about
+/// this function's calls — see [`Settled`].
+const PLAN_KEY: &str = "_plan";
 #[cfg(windows)]
 const INDEX_KEY: &str = "_index";
 #[cfg(windows)]
@@ -381,18 +387,269 @@ fn resolve_from_tuple(t: PyObjectRef) -> Result<usize, crate::PyError> {
 // ── restype / argtypes descriptors ────────────────────────────────────
 
 pub(super) fn instance_get(obj: PyObjectRef, key: &str) -> Option<PyObjectRef> {
-    let d = crate::baseobjspace::getdict_native(obj);
-    if d.is_null() {
-        return None;
-    }
-    unsafe { pyre_object::w_dict_getitem_str(d, key) }
+    // The dictionary `getdict` would answer is a view onto the instance's own
+    // mapdict storage and the read goes through to it either way, so this asks
+    // the storage directly and leaves the view unbuilt.
+    crate::baseobjspace::getdictvalue_native(obj, key)
 }
 
 fn instance_set(obj: PyObjectRef, key: &str, value: PyObjectRef) {
     let d = crate::baseobjspace::getdict_native(obj);
-    if !d.is_null() {
-        unsafe { pyre_object::w_dict_setitem_str(d, key, value) };
+    if d.is_null() {
+        return;
     }
+    // Every key here is one a [`CallPlan`] was settled from, so the write goes
+    // with the plan dropped — `_setargtypes` / `_setrestype` drop `self._ptr`
+    // for the same reason.  Either store can grow the dict and so move it, and
+    // the value is live across the first, so both go through root slots.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(d);
+    let value_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(value);
+    unsafe {
+        pyre_object::w_dict_setitem_str(
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            key,
+            pyre_object::gc_roots::shadow_stack_get(value_slot),
+        );
+        drop_settled(pyre_object::gc_roots::shadow_stack_get(dict_slot));
+    }
+}
+
+// ── settled call plan ─────────────────────────────────────────────────
+
+/// Arguments a call hands over without a heap allocation of its own.  A wider
+/// signature is rare enough that the allocation does not matter.
+const INLINE_CALL_ARGS: usize = 8;
+
+/// The most declared arguments a [`CallPlan`] carries.  A signature wider than
+/// this settles nothing and re-derives per call, which costs only the functions
+/// nobody calls in a loop.
+const PLAN_MAX_ARGS: usize = 8;
+
+/// What the declarations have settled about a function's calls.
+#[derive(Clone, Copy)]
+enum Settled {
+    /// The plan a repeat call runs from.
+    Plan(CallPlan),
+    /// There is nothing to settle: a paramflag, an `errcheck`, a
+    /// `_check_retval_`, a COM index or an aggregate in the signature puts the
+    /// call past what a plan describes.  Recorded so that the finding is made
+    /// once rather than at every call.
+    Unplannable,
+}
+
+/// Everything about a call that the declarations fix, derived once.
+///
+/// `_ctypes/function.py` keeps the prepared call in `self._ptr` and drops it in
+/// `_setargtypes` / `_setrestype`; this is the same cache under the same
+/// invalidation — [`instance_set`] and [`store_funcptr_addr`] are every write
+/// that can change an answer in it.  A class-level `_restype_` / `_argtypes_` /
+/// `_flags_` write goes through neither, so the record also carries the type's
+/// version tag and is re-derived once that moves.
+///
+/// The carrier is an opaque `bytes` in the instance dict rather than a Rust
+/// side table so that it holds no object reference across a collection and dies
+/// with the instance it describes.
+#[derive(Clone, Copy)]
+struct CallPlan {
+    addr: usize,
+    flags: i64,
+    /// `Ret::Void` or `Ret::Code` only: the other two name a type, and a plan
+    /// carries no object references.
+    ret: Ret,
+    args: [ArgKind; PLAN_MAX_ARGS],
+    arg_count: usize,
+}
+
+impl CallPlan {
+    /// The declared argument shapes, in order.
+    fn kinds(&self) -> &[ArgKind] {
+        &self.args[..self.arg_count]
+    }
+}
+
+/// Byte layout of the stored record: a kind byte, the type version tag it was
+/// settled under, then — for a plan — the call's fixed values and one record
+/// per declared argument.
+mod plan_bytes {
+    /// Leading byte: this instance settles into no plan.
+    pub(super) const UNPLANNABLE: u8 = 0;
+    /// Leading byte: a plan follows.
+    pub(super) const PLAN: u8 = 1;
+    /// Argument record byte: a pointer-kind argtype.
+    pub(super) const ARG_POINTER: u8 = 0;
+    /// Argument record byte: a simple argtype, followed by its code.
+    pub(super) const ARG_SIMPLE: u8 = 1;
+    /// Return record byte: the call returns nothing.
+    pub(super) const RET_VOID: u8 = 0;
+    /// Return record byte: a simple return, followed by its code.
+    pub(super) const RET_CODE: u8 = 1;
+}
+
+/// The plan `obj` has settled into, or `None` when it has settled nothing yet.
+fn settled(obj: PyObjectRef) -> Option<Settled> {
+    let stored = instance_get(obj, PLAN_KEY)?;
+    if !unsafe { pyre_object::bytesobject::is_bytes(stored) } {
+        return None;
+    }
+    let record = unsafe { pyre_object::bytesobject::w_bytes_data(stored) };
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    decode_settled(record, unsafe {
+        crate::baseobjspace::w_type_version_tag(cls)
+    })
+}
+
+/// Read a stored record back, refusing one settled under a different version of
+/// the type.
+fn decode_settled(record: &[u8], version_tag: u64) -> Option<Settled> {
+    let mut cursor = Cursor::new(record);
+    let kind = cursor.byte()?;
+    if cursor.u64()? != version_tag || version_tag == 0 {
+        return None;
+    }
+    if kind == plan_bytes::UNPLANNABLE {
+        return Some(Settled::Unplannable);
+    }
+    if kind != plan_bytes::PLAN {
+        return None;
+    }
+    let addr = cursor.u64()? as usize;
+    let flags = cursor.u64()? as i64;
+    let ret = match cursor.byte()? {
+        plan_bytes::RET_VOID => Ret::Void,
+        plan_bytes::RET_CODE => Ret::Code(TypeCode::from_padded(cursor.code()?)),
+        _ => return None,
+    };
+    let arg_count = cursor.byte()? as usize;
+    if arg_count > PLAN_MAX_ARGS {
+        return None;
+    }
+    let mut args = [ArgKind::Pointer; PLAN_MAX_ARGS];
+    for slot in args.iter_mut().take(arg_count) {
+        *slot = match cursor.byte()? {
+            plan_bytes::ARG_POINTER => ArgKind::Pointer,
+            plan_bytes::ARG_SIMPLE => ArgKind::Simple(TypeCode::from_padded(cursor.code()?)),
+            _ => return None,
+        };
+    }
+    Some(Settled::Plan(CallPlan {
+        addr,
+        flags,
+        ret,
+        args,
+        arg_count,
+    }))
+}
+
+/// A reader over a stored record that answers `None` rather than panicking on a
+/// record shorter than it claims to be.
+struct Cursor<'a> {
+    record: &'a [u8],
+    at: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(record: &'a [u8]) -> Self {
+        Cursor { record, at: 0 }
+    }
+
+    fn take<const N: usize>(&mut self) -> Option<[u8; N]> {
+        let bytes = self.record.get(self.at..self.at + N)?.try_into().ok()?;
+        self.at += N;
+        Some(bytes)
+    }
+
+    fn byte(&mut self) -> Option<u8> {
+        self.take::<1>().map(|bytes| bytes[0])
+    }
+
+    fn u64(&mut self) -> Option<u64> {
+        self.take().map(u64::from_ne_bytes)
+    }
+
+    fn code(&mut self) -> Option<[u8; TypeCode::CAPACITY]> {
+        self.take()
+    }
+}
+
+/// The record [`decode_settled`] reads.
+fn encode_settled(settled: Settled, version_tag: u64) -> Vec<u8> {
+    let mut record = Vec::new();
+    let plan = match settled {
+        Settled::Unplannable => {
+            record.push(plan_bytes::UNPLANNABLE);
+            record.extend_from_slice(&version_tag.to_ne_bytes());
+            return record;
+        }
+        Settled::Plan(plan) => plan,
+    };
+    record.push(plan_bytes::PLAN);
+    record.extend_from_slice(&version_tag.to_ne_bytes());
+    record.extend_from_slice(&(plan.addr as u64).to_ne_bytes());
+    record.extend_from_slice(&(plan.flags as u64).to_ne_bytes());
+    match plan.ret {
+        Ret::Code(code) => {
+            record.push(plan_bytes::RET_CODE);
+            record.extend_from_slice(&code.padded());
+        }
+        // `Ret::Pointer` / `Ret::Aggregate` never reach a plan; both name a
+        // type, and `store_settled` refuses them.
+        _ => record.push(plan_bytes::RET_VOID),
+    }
+    record.push(plan.arg_count as u8);
+    for kind in plan.kinds() {
+        match kind {
+            ArgKind::Simple(code) => {
+                record.push(plan_bytes::ARG_SIMPLE);
+                record.extend_from_slice(&code.padded());
+            }
+            // Same: `store_settled` refuses an aggregate argtype.
+            _ => record.push(plan_bytes::ARG_POINTER),
+        }
+    }
+    record
+}
+
+/// Drop whatever `dict` had settled, so the next call derives it again.
+///
+/// # Safety
+/// `dict` must be a live instance dictionary.
+unsafe fn drop_settled(dict: PyObjectRef) {
+    // Dropping one that was never settled is not an error.
+    unsafe { pyre_object::dictmultiobject::w_dict_delitem_str(dict, PLAN_KEY) };
+}
+
+/// Record what this call settled, so the next one runs from it.
+fn store_settled(obj: PyObjectRef, settled: Settled) {
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let version_tag = unsafe { crate::baseobjspace::w_type_version_tag(cls) };
+    // A type with no version tag cannot be told apart from one that has since
+    // changed, so nothing is settled against it.
+    if version_tag == 0 {
+        return;
+    }
+    let record = encode_settled(settled, version_tag);
+    // The `bytes` allocation moves the instance, so the dict is read off the
+    // instance only after it, out of a root slot.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(obj);
+    let stored = pyre_object::bytesobject::w_bytes_from_bytes(&record);
+    let stored_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(stored);
+    let d = crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(obj_slot));
+    if d.is_null() {
+        return;
+    }
+    unsafe {
+        pyre_object::w_dict_setitem_str(
+            d,
+            PLAN_KEY,
+            pyre_object::gc_roots::shadow_stack_get(stored_slot),
+        )
+    };
 }
 
 fn restype_getter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -464,7 +721,10 @@ fn errcheck_deleter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     let d = crate::baseobjspace::getdict_native(args[1]);
     if !d.is_null() {
         // Deleting one that was never set is not an error.
-        unsafe { pyre_object::dictmultiobject::w_dict_delitem_str(d, ERRCHECK_KEY) };
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_delitem_str(d, ERRCHECK_KEY);
+            drop_settled(d);
+        }
     }
     Ok(pyre_object::w_none())
 }
@@ -490,9 +750,10 @@ fn reject_kwargs(kwargs: Option<PyObjectRef>) -> Result<(), crate::PyError> {
 // ── call ──────────────────────────────────────────────────────────────
 
 /// Resolved return-type selector.
+#[derive(Clone, Copy)]
 pub(super) enum Ret {
     Void,
-    Code(String),
+    Code(TypeCode),
     /// A pointer metaclass type (`POINTER(T)`): the result address is wrapped
     /// in a fresh instance of this type.
     Pointer(PyObjectRef),
@@ -507,15 +768,15 @@ pub(super) fn resolve_restype(obj: PyObjectRef) -> Result<Ret, crate::PyError> {
         .or_else(|| unsafe { crate::baseobjspace::lookup_in_type(cls, "_restype_") });
     match rt {
         // CDLL functions default to c_int when no restype is set.
-        None => Ok(Ret::Code("i".to_string())),
+        None => Ok(Ret::Code(DEFAULT_RESTYPE_CODE)),
         Some(o) if unsafe { pyre_object::is_none(o) } => Ok(Ret::Void),
         Some(o) => {
             // A `_Pointer` subtype returns a live pointer instance; a
             // struct/union subtype returns a by-value aggregate instance.
             if let Some(info) = stginfo::stginfo_of(o) {
-                match stginfo::stginfo_paramfunc(info).as_str() {
-                    "pointer" => return Ok(Ret::Pointer(o)),
-                    "struct" | "union" => return Ok(Ret::Aggregate(o)),
+                match stginfo::stginfo_paramfunc(info) {
+                    ParamFunc::Pointer => return Ok(Ret::Pointer(o)),
+                    ParamFunc::Struct | ParamFunc::Union => return Ok(Ret::Aggregate(o)),
                     _ => {}
                 }
             }
@@ -647,8 +908,8 @@ fn type_display_name(obj: PyObjectRef) -> String {
 fn check_outarg_type(at: PyObjectRef, index: usize) -> Result<(), crate::PyError> {
     if let Some(info) = stginfo::stginfo_of(at)
         && matches!(
-            stginfo::stginfo_paramfunc(info).as_str(),
-            "pointer" | "array"
+            stginfo::stginfo_paramfunc(info),
+            ParamFunc::Pointer | ParamFunc::Array
         )
     {
         return Ok(());
@@ -786,7 +1047,9 @@ pub(super) fn store_funcptr_addr(obj: PyObjectRef, addr: usize) -> Result<(), cr
             pyre_object::gc_roots::shadow_stack_get(dict_slot),
             PTR_KEY,
             pyre_object::gc_roots::shadow_stack_get(addr_slot),
-        )
+        );
+        // The address a plan calls through is the one being replaced here.
+        drop_settled(pyre_object::gc_roots::shadow_stack_get(dict_slot));
     };
     let bytes = host_ctypes::simple_storage_value_to_bytes_endian(
         "P",
@@ -800,7 +1063,7 @@ pub(super) fn store_funcptr_addr(obj: PyObjectRef, addr: usize) -> Result<(), cr
 /// Owned argument data whose buffers must outlive the borrowed `CallArg`s
 /// handed to `call`.
 enum OwnedArg {
-    Typed(String, Vec<u8>),
+    Typed(TypeCode, Vec<u8>),
     Int(i32),
     Double(f64),
     Pointer(usize),
@@ -892,10 +1155,21 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // A keyword argument only ever names a paramflag, and one that names
     // nothing is not an error — it simply goes unread.
     let (inargs, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
-    if funcptr_addr(self_obj) == 0 && instance_get(self_obj, CALLABLE_KEY).is_some() {
+    let settled_already = settled(self_obj);
+    // A plan that turns out not to describe this call after all leaves the
+    // general path to derive it again and record what it finds.
+    let mut settled_stands = settled_already.is_some();
+    if let Some(Settled::Plan(plan)) = settled_already {
+        match call_settled(self_obj, &plan, inargs)? {
+            Some(value) => return Ok(value),
+            None => settled_stands = false,
+        }
+    }
+    let addr = funcptr_addr(self_obj);
+    if addr == 0 && instance_get(self_obj, CALLABLE_KEY).is_some() {
         return call_python_callback(self_obj, inargs);
     }
-    match funcptr_addr(self_obj) {
+    match addr {
         INTERNAL_CAST_ADDR => return internal_cast(inargs),
         INTERNAL_STRING_AT_ADDR => return internal_string_at(inargs),
         INTERNAL_WSTRING_AT_ADDR => return internal_wstring_at(inargs),
@@ -921,6 +1195,7 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let com: Option<(usize, usize)> = None;
 
     let argtypes = resolve_argtypes(self_obj);
+    let paramflags = instance_get(self_obj, PARAMFLAGS_KEY);
     let callargs = build_callargs(self_obj, argtypes.as_deref(), inargs, kwargs, com.is_some())?;
     let call_args = callargs.args.as_slice();
 
@@ -933,16 +1208,22 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         owned.push(OwnedArg::Pointer(this_ptr));
     }
 
-    match argtypes {
+    // What each declared argtype lowers to, kept so that a repeat call can run
+    // from it instead of asking the types again.
+    let mut kinds: Vec<ArgKind> = Vec::new();
+    match &argtypes {
         Some(argtypes) => {
-            for (i, at) in argtypes.iter().enumerate() {
+            for (i, &at) in argtypes.iter().enumerate() {
                 let arg = *call_args.get(i).ok_or_else(|| {
                     crate::PyError::type_error(format!(
                         "this function takes at least {} argument(s)",
                         argtypes.len()
                     ))
                 })?;
-                owned.push(marshal_typed_arg(arg, *at, &mut keepalive)?);
+                let kind = classify_argtype(at)
+                    .ok_or_else(|| crate::PyError::type_error("argtype has no valid '_type_'"))?;
+                kinds.push(kind);
+                owned.push(marshal_typed_arg(arg, at, kind, &mut keepalive)?);
             }
             // Variadic tail (printf-style): arguments past the declared
             // argtypes are marshalled by the default conversion rules.
@@ -958,6 +1239,92 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
 
     let ret = resolve_restype(self_obj)?;
+    let flags = funcptr_flags(self_obj);
+    let result = invoke(call_address(addr, com), &owned, ret, flags)?;
+    // `owned` / `keepalive` must outlive the call above.
+    drop(keepalive);
+    // A COM method constructed with an interface id answers the plain status,
+    // and asks the callee what went wrong when that status is a failure; the
+    // restype never gets a look in.
+    let checker = resolve_checker(self_obj);
+    let value = match com_status(self_obj, com, &result) {
+        Some(status) => status?,
+        None => {
+            let value = build_return_value(ret, result)?;
+            match checker {
+                Some(checker) => crate::call::call_function_impl_result(checker, &[value])?,
+                None => value,
+            }
+        }
+    };
+    let errcheck = instance_get(self_obj, ERRCHECK_KEY);
+    let value = match apply_errcheck(self_obj, value, call_args)? {
+        Some(forced) => forced,
+        None => build_result(value, &callargs)?,
+    };
+    if !settled_stands {
+        store_settled(
+            self_obj,
+            plan_of_call(
+                addr,
+                flags,
+                ret,
+                &kinds,
+                com.is_some() || checker.is_some() || errcheck.is_some() || paramflags.is_some(),
+            ),
+        );
+    }
+    Ok(value)
+}
+
+/// The address a call is made through: a COM method's comes out of the
+/// interface vtable, everything else calls the stored `_ptr`.
+fn call_address(addr: usize, com: Option<(usize, usize)>) -> usize {
+    match com {
+        Some((_, method)) => method,
+        None => addr,
+    }
+}
+
+/// What this call settles, for the next one to run from.
+///
+/// `past_a_plan` is the caller's finding that something outside the argument
+/// and return shapes — a COM index, a `_check_retval_`, an `errcheck`, a
+/// paramflag — has a say in the answer or in which arguments the call is made
+/// with.
+fn plan_of_call(
+    addr: usize,
+    flags: i64,
+    ret: Ret,
+    kinds: &[ArgKind],
+    past_a_plan: bool,
+) -> Settled {
+    let describable = !past_a_plan
+        && kinds.len() <= PLAN_MAX_ARGS
+        && matches!(ret, Ret::Void | Ret::Code(_))
+        && !kinds.iter().any(|kind| *kind == ArgKind::Aggregate);
+    if !describable {
+        return Settled::Unplannable;
+    }
+    let mut args = [ArgKind::Pointer; PLAN_MAX_ARGS];
+    args[..kinds.len()].copy_from_slice(kinds);
+    Settled::Plan(CallPlan {
+        addr,
+        flags,
+        ret,
+        args,
+        arg_count: kinds.len(),
+    })
+}
+
+/// Hand the marshalled arguments to the foreign function and answer its raw
+/// result.
+fn invoke(
+    addr: usize,
+    owned: &[OwnedArg],
+    ret: Ret,
+    flags: i64,
+) -> Result<host_ctypes::CallValue, crate::PyError> {
     // Build the aggregate return layout (if any) up front so it outlives the
     // borrowed `CallRet` handed to the call.
     let ret_layout = match &ret {
@@ -974,47 +1341,84 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     };
 
     // Borrow the owned data as `CallArg`s; these borrows end with the call.
-    let host_args: Vec<host_ctypes::CallArg> = owned.iter().map(owned_arg_as_call_arg).collect();
-
-    let addr = match com {
-        Some((_, method)) => method,
-        None => funcptr_addr(self_obj),
+    // A signature no wider than the inline row is handed over without a heap
+    // allocation of its own, which is otherwise a whole allocation per call.
+    let mut inline = [host_ctypes::CallArg::Int(0); INLINE_CALL_ARGS];
+    let mut spilled: Vec<host_ctypes::CallArg> = Vec::new();
+    let host_args: &[host_ctypes::CallArg] = if owned.len() <= INLINE_CALL_ARGS {
+        for (slot, arg) in inline.iter_mut().zip(owned) {
+            *slot = owned_arg_as_call_arg(arg);
+        }
+        &inline[..owned.len()]
+    } else {
+        spilled.extend(owned.iter().map(owned_arg_as_call_arg));
+        &spilled
     };
-    let flags = funcptr_flags(self_obj);
+
     let options = host_ctypes::CallOptions {
         use_errno: flags & FUNCFLAG_USE_ERRNO != 0,
         use_last_error: flags & FUNCFLAG_USE_LASTERROR != 0,
     };
     // `clibffi.py:350-352` declares `ffi_call` with the default
     // `releasegil='auto'`, i.e. released: the callee is arbitrary foreign code
-    // and may block on another Python thread's progress.  `owned` / `keepalive`
-    // hold the marshalled buffers across the released window.  Being arbitrary
-    // foreign code is also why the call goes inside `seh::guard`, which is what
-    // stands between a faulting callee and the process.
+    // and may block on another Python thread's progress.  The caller's `owned`
+    // / `keepalive` hold the marshalled buffers across the released window.
+    // Being arbitrary foreign code is also why the call goes inside
+    // `seh::guard`, which is what stands between a faulting callee and the
+    // process.
     let result = {
         let _blocked = crate::module::thread::before_external_block();
-        super::seh::guard(|| host_ctypes::call(addr, &host_args, restype, options))
+        super::seh::guard(|| host_ctypes::call(addr, host_args, restype, options))
     };
+    result?.map_err(call_error)
+}
+
+/// `__call__` for a function whose declarations have already settled into a
+/// [`CallPlan`] — `_getfuncptr` answering out of `self._ptr`.
+///
+/// Answers `None` when the plan turns out not to describe this call after all,
+/// which leaves the general path to derive it again.
+fn call_settled(
+    self_obj: PyObjectRef,
+    plan: &CallPlan,
+    inargs: &[PyObjectRef],
+) -> Result<Option<PyObjectRef>, crate::PyError> {
+    let kinds = plan.kinds();
+    if inargs.len() < kinds.len() {
+        return Err(crate::PyError::type_error(format!(
+            "this function takes at least {} argument(s)",
+            kinds.len()
+        )));
+    }
+    // Only a pointer argtype is still wanted as an object; a simple one is
+    // fully described by the code the plan carries.
+    let argtypes = if kinds.iter().any(|kind| *kind == ArgKind::Pointer) {
+        let argtypes = resolve_argtypes(self_obj);
+        if argtypes.as_ref().is_none_or(|at| at.len() < kinds.len()) {
+            return Ok(None);
+        }
+        argtypes
+    } else {
+        None
+    };
+    let mut owned: Vec<OwnedArg> = Vec::with_capacity(inargs.len());
+    let mut keepalive: Vec<Vec<u8>> = Vec::new();
+    for (i, &arg) in inargs.iter().enumerate() {
+        owned.push(match kinds.get(i) {
+            Some(ArgKind::Simple(tc)) => marshal_simple_arg(arg, *tc)?,
+            Some(_) => {
+                let at = argtypes.as_ref().expect("a pointer argtype was resolved")[i];
+                OwnedArg::Pointer(pointer_argument_addr(arg, at, &mut keepalive)?)
+            }
+            // Variadic tail (printf-style): arguments past the declared
+            // argtypes are marshalled by the default conversion rules.
+            None => marshal_default_arg(arg, &mut keepalive)?,
+        });
+    }
+    let result = invoke(plan.addr, &owned, plan.ret, plan.flags)?;
     // `owned` / `keepalive` must outlive the call above.
     drop(keepalive);
-    let result = result?.map_err(call_error)?;
-    // A COM method constructed with an interface id answers the plain status,
-    // and asks the callee what went wrong when that status is a failure; the
-    // restype never gets a look in.
-    let value = match com_status(self_obj, com, &result) {
-        Some(status) => status?,
-        None => {
-            let value = build_return_value(ret, result)?;
-            match resolve_checker(self_obj) {
-                Some(checker) => crate::call::call_function_impl_result(checker, &[value])?,
-                None => value,
-            }
-        }
-    };
-    match apply_errcheck(self_obj, value, call_args)? {
-        Some(forced) => Ok(forced),
-        None => build_result(value, &callargs),
-    }
+    build_return_value(plan.ret, result).map(Some)
 }
 
 /// The status word a returned scalar carries.  A COM method answers an
@@ -1210,7 +1614,7 @@ fn get_arg(
 /// type being its own such thing.
 fn out_parameter(at: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     let info = stginfo::stginfo_of(at);
-    if info.is_some_and(|info| stginfo::stginfo_paramfunc(info) == "array") {
+    if info.is_some_and(|info| stginfo::stginfo_paramfunc(info) == ParamFunc::Array) {
         return crate::call::type_call_instantiate(at, &[]);
     }
     match info.and_then(stginfo::stginfo_proto) {
@@ -1324,7 +1728,7 @@ fn argument_address(obj: PyObjectRef) -> Result<usize, crate::PyError> {
     if cdata::is_cdata_instance(obj) {
         let cls = unsafe { pyre_object::w_instance_get_type(obj) };
         if let Some(info) = stginfo::stginfo_of(cls)
-            && stginfo::stginfo_paramfunc(info) == "pointer"
+            && stginfo::stginfo_paramfunc(info) == ParamFunc::Pointer
         {
             return Ok(host_ctypes::read_pointer_from_buffer(
                 cdata::cdata_bytes(obj).unwrap_or(&[]),
@@ -1356,7 +1760,7 @@ fn internal_cast(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // `_ctypes.c cast_check_pointertype`: a pointer type, a function-pointer
     // type, or a simple type whose code is one of the pointer-shaped ones.
     let is_pointer = stginfo::stginfo_of(target)
-        .is_some_and(|i| stginfo::stginfo_paramfunc(i) == "pointer")
+        .is_some_and(|i| stginfo::stginfo_paramfunc(i) == ParamFunc::Pointer)
         || is_funcptr_type(target)
         || cdata::type_code_of(target)
             .is_some_and(|tc| matches!(tc.as_str(), "s" | "P" | "z" | "U" | "Z" | "X" | "O"));
@@ -1598,28 +2002,54 @@ fn internal_pyos_snprintf(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     Ok(pyre_object::w_int_new(rendered.len() as i64))
 }
 
-/// The `StgInfo.paramfunc` of a cdata instance's type ("simple"/"array"/
-/// "pointer"/"struct"/"union"), or empty when it carries no `StgInfo`.
-fn cdata_paramfunc(obj: PyObjectRef) -> String {
+/// The `StgInfo.paramfunc` of a cdata instance's type, or
+/// [`ParamFunc::Other`] when it carries no `StgInfo`.
+fn cdata_paramfunc(obj: PyObjectRef) -> ParamFunc {
     let cls = unsafe { pyre_object::w_instance_get_type(obj) };
     stginfo::stginfo_of(cls)
         .map(stginfo::stginfo_paramfunc)
-        .unwrap_or_default()
+        .unwrap_or(ParamFunc::Other)
+}
+
+/// What a declared argument type lowers to.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum ArgKind {
+    /// A pointer metaclass type, an array type — which decays — or a simple
+    /// pointer code like `P`/`z`/`Z`.
+    Pointer,
+    /// A struct or union, passed by value.
+    Aggregate,
+    /// A simple type, passed as the bytes its code describes.
+    Simple(TypeCode),
+}
+
+/// Settle what argument type `at` lowers to.
+///
+/// The three questions a marshalled argument asks — pointer? aggregate? which
+/// code? — all read the same `StgInfo` and the same `_type_`, so they are
+/// asked together and the reads happen once.
+pub(super) fn classify_argtype(at: PyObjectRef) -> Option<ArgKind> {
+    let info = stginfo::stginfo_of(at);
+    let paramfunc = info.map_or(ParamFunc::Other, stginfo::stginfo_paramfunc);
+    if info.is_some_and(|i| stginfo::stginfo_flags(i) & stginfo::TYPEFLAG_ISPOINTER != 0)
+        || paramfunc == ParamFunc::Array
+    {
+        return Some(ArgKind::Pointer);
+    }
+    let code = cdata::type_code_of(at);
+    if code.is_some_and(|c| cdata::is_pointer_code(&c)) || is_funcptr_type(at) {
+        return Some(ArgKind::Pointer);
+    }
+    if matches!(paramfunc, ParamFunc::Struct | ParamFunc::Union) {
+        return Some(ArgKind::Aggregate);
+    }
+    code.map(ArgKind::Simple)
 }
 
 /// Whether argument type `at` lowers to a pointer (a pointer metaclass type,
 /// an array type — which decays — or a simple pointer code like `P`/`z`/`Z`).
 pub(super) fn argtype_is_pointer_kind(at: PyObjectRef) -> bool {
-    if let Some(info) = stginfo::stginfo_of(at) {
-        if stginfo::stginfo_flags(info) & stginfo::TYPEFLAG_ISPOINTER != 0 {
-            return true;
-        }
-        if stginfo::stginfo_paramfunc(info) == "array" {
-            return true;
-        }
-    }
-    matches!(cdata::type_code_of(at).as_deref(), Some(c) if cdata::is_pointer_code(c))
-        || is_funcptr_type(at)
+    classify_argtype(at) == Some(ArgKind::Pointer)
 }
 
 /// Whether `t` is a concrete foreign-function type (`CFUNCTYPE`/`WINFUNCTYPE`).
@@ -1632,13 +2062,6 @@ pub(super) fn is_funcptr_type(t: PyObjectRef) -> bool {
 
 fn is_funcptr_instance(obj: PyObjectRef) -> bool {
     !obj.is_null() && unsafe { crate::baseobjspace::isinstance_w(obj, cfuncptr_type()) }
-}
-
-/// Whether type `t` is a by-value aggregate (struct or union).
-fn is_aggregate_type(t: PyObjectRef) -> bool {
-    stginfo::stginfo_of(t)
-        .map(stginfo::stginfo_paramfunc)
-        .is_some_and(|pf| pf == "struct" || pf == "union")
 }
 
 /// Append the field types declared in one `_fields_` sequence to `out`
@@ -1701,18 +2124,17 @@ pub(super) fn build_layout(t: PyObjectRef) -> Result<host_ctypes::CTypeLayout, c
         .ok_or_else(|| crate::PyError::type_error("type has no ctypes layout info"))?;
     let size = stginfo::stginfo_size(info);
     let paramfunc = stginfo::stginfo_paramfunc(info);
-    match paramfunc.as_str() {
-        "simple" => {
+    match paramfunc {
+        ParamFunc::Simple => {
             let tc = cdata::type_code_of(t)
                 .ok_or_else(|| crate::PyError::type_error("simple type has no '_type_'"))?;
             let ch = tc
-                .chars()
-                .next()
+                .as_char()
                 .ok_or_else(|| crate::PyError::type_error("empty '_type_' code"))?;
             Ok(CTypeLayout::Simple(ch))
         }
-        "pointer" => Ok(CTypeLayout::Pointer),
-        "array" => {
+        ParamFunc::Pointer => Ok(CTypeLayout::Pointer),
+        ParamFunc::Array => {
             let element = stginfo::stginfo_proto(info)
                 .ok_or_else(|| crate::PyError::type_error("array type has no element type"))?;
             Ok(CTypeLayout::Array {
@@ -1721,12 +2143,12 @@ pub(super) fn build_layout(t: PyObjectRef) -> Result<host_ctypes::CTypeLayout, c
                 size,
             })
         }
-        "struct" | "union" => {
+        ParamFunc::Struct | ParamFunc::Union => {
             let mut fields = Vec::new();
             for ft in struct_field_types(t)? {
                 fields.push(build_layout(ft)?);
             }
-            if paramfunc == "union" {
+            if paramfunc == ParamFunc::Union {
                 Ok(CTypeLayout::Union { fields, size })
             } else {
                 Ok(CTypeLayout::Struct { fields, size })
@@ -1769,26 +2191,29 @@ fn make_aggregate_instance(ty: PyObjectRef, bytes: &[u8]) -> Result<PyObjectRef,
     Ok(obj)
 }
 
-/// Marshal one argument that has an explicit `argtype` `at`.
+/// Marshal one argument that has an explicit `argtype` `at`, already settled
+/// into the shape `kind` names.
 fn marshal_typed_arg(
     arg: PyObjectRef,
     at: PyObjectRef,
+    kind: ArgKind,
     keepalive: &mut Vec<Vec<u8>>,
 ) -> Result<OwnedArg, crate::PyError> {
-    if argtype_is_pointer_kind(at) {
-        return Ok(OwnedArg::Pointer(pointer_argument_addr(
+    match kind {
+        ArgKind::Pointer => Ok(OwnedArg::Pointer(pointer_argument_addr(
             arg, at, keepalive,
-        )?));
+        )?)),
+        ArgKind::Aggregate => marshal_aggregate_arg(arg, at),
+        ArgKind::Simple(tc) => marshal_simple_arg(arg, tc),
     }
-    // A by-value struct/union argtype.
-    if is_aggregate_type(at) {
-        return marshal_aggregate_arg(arg, at);
-    }
-    let tc = cdata::type_code_of(at)
-        .ok_or_else(|| crate::PyError::type_error("argtype has no valid '_type_'"))?;
-    // `PyCSimpleType.from_param` hands an instance of the argtype itself
-    // straight through and converts anything else, so a mismatched cdata
-    // cannot be reinterpreted through the wrong argtype.
+}
+
+/// Marshal one argument against the simple type code `tc`.
+///
+/// `PyCSimpleType.from_param` hands an instance of the argtype itself straight
+/// through and converts anything else, so a mismatched cdata cannot be
+/// reinterpreted through the wrong argtype.
+fn marshal_simple_arg(arg: PyObjectRef, tc: TypeCode) -> Result<OwnedArg, crate::PyError> {
     if let Some(bytes) = cdata::same_type_bytes(&tc, arg) {
         return Ok(OwnedArg::Typed(tc, bytes));
     }
@@ -1819,16 +2244,16 @@ fn marshal_default_arg(
     // Aggregate / pointer cdata: arrays and pointers decay to a pointer; a
     // struct/union with no `byref()` is passed by value.
     if cdata::is_cdata_instance(arg) {
-        match cdata_paramfunc(arg).as_str() {
-            "pointer" => {
+        match cdata_paramfunc(arg) {
+            ParamFunc::Pointer => {
                 return Ok(OwnedArg::Pointer(host_ctypes::read_pointer_from_buffer(
                     cdata::cdata_bytes(arg).unwrap_or(&[]),
                 )));
             }
-            "array" => {
+            ParamFunc::Array => {
                 return Ok(OwnedArg::Pointer(cdata::cdata_addr(arg).unwrap_or(0)));
             }
-            "struct" | "union" => {
+            ParamFunc::Struct | ParamFunc::Union => {
                 let cls = unsafe { pyre_object::w_instance_get_type(arg) };
                 return marshal_aggregate_arg(arg, cls);
             }
@@ -1863,7 +2288,7 @@ fn pointer_argument_addr(
     keepalive: &mut Vec<Vec<u8>>,
 ) -> Result<usize, crate::PyError> {
     if let Some(info) = stginfo::stginfo_of(at)
-        && stginfo::stginfo_paramfunc(info) == "pointer"
+        && stginfo::stginfo_paramfunc(info) == ParamFunc::Pointer
         && let Some(proto) = stginfo::stginfo_proto(info)
         && unsafe { pyre_object::is_type(proto) }
         && unsafe { crate::baseobjspace::isinstance_w(arg, proto) }
@@ -1895,8 +2320,8 @@ pub(super) fn resolve_pointer_addr(
     }
     if cdata::is_cdata_instance(arg) {
         // `_Pointer` → stored address; `Array`/`Structure` → buffer address.
-        return Ok(match cdata_paramfunc(arg).as_str() {
-            "pointer" => {
+        return Ok(match cdata_paramfunc(arg) {
+            ParamFunc::Pointer => {
                 host_ctypes::read_pointer_from_buffer(cdata::cdata_bytes(arg).unwrap_or(&[]))
             }
             _ => cdata::cdata_addr(arg).unwrap_or(0),

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -15,7 +15,7 @@
 //! `StgInfo.pointer_type` and read back through the `__pointer_type__` getset.
 
 use super::cdata;
-use super::stginfo::{self, StgInfoData};
+use super::stginfo::{self, ParamFunc, StgInfoData};
 use super::type_ns_store;
 use majit_rlib::rbigint::RBigInt as BigInt;
 use pyre_object::PyObjectRef;
@@ -393,7 +393,7 @@ fn pointer_set_type(args: &[PyObjectRef]) -> PyResult {
     let mut data = StgInfoData::new(
         host_ctypes::pointer_size(),
         host_ctypes::simple_type_align("P").unwrap_or(host_ctypes::pointer_size()),
-        "pointer",
+        ParamFunc::Pointer,
     );
     data.element_size = stginfo::field_size_of(proto).unwrap_or(0);
     data.length = 1;
@@ -469,8 +469,8 @@ fn simple_init_stginfo(cls: PyObjectRef) -> PyResult {
     }
     let size = host_ctypes::simple_type_size(&tc).ok_or_else(cdata::invalid_type_code_error)?;
     let align = host_ctypes::simple_type_align(&tc).ok_or_else(cdata::invalid_type_code_error)?;
-    let mut data = StgInfoData::new(size, align, "simple");
-    data.format = Some(tc.clone());
+    let mut data = StgInfoData::new(size, align, ParamFunc::Simple);
+    data.format = Some(tc.to_string());
     if host_ctypes::simple_type_is_pointer(&tc) {
         data.flags |= stginfo::TYPEFLAG_ISPOINTER;
     }
@@ -750,7 +750,7 @@ fn mark_type_final(ty: PyObjectRef, size: usize, align: usize) {
     match stginfo::stginfo_of(ty) {
         Some(info) => stginfo::stginfo_mark_final(info),
         None => {
-            let mut data = StgInfoData::new(size, align, "simple");
+            let mut data = StgInfoData::new(size, align, ParamFunc::Simple);
             data.flags |= stginfo::DICTFLAG_FINAL;
             stginfo::stginfo_set(ty, stginfo::stginfo_new(data));
         }
@@ -767,7 +767,11 @@ fn struct_union_init_stginfo(cls: PyObjectRef, is_union: bool) -> PyResult {
     match own_fields {
         Some(fields) => process_fields(cls, fields, is_union),
         None => {
-            let paramfunc = if is_union { "union" } else { "struct" };
+            let paramfunc = if is_union {
+                ParamFunc::Union
+            } else {
+                ParamFunc::Struct
+            };
             match first_base_stginfo(cls) {
                 Some(base_info) => {
                     let mut data = StgInfoData::new(
@@ -812,7 +816,7 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
                 "'{name}' is specified in _anonymous_ but not in _fields_"
             )));
         };
-        if !matches!(proto_kind(entry.ty).as_str(), "struct" | "union") {
+        if !matches!(proto_kind(entry.ty), ParamFunc::Struct | ParamFunc::Union) {
             return Err(crate::PyError::type_error(
                 "anonymous field must be a structure or union",
             ));
@@ -871,7 +875,7 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
         let name = &entry.name;
         let ftype = entry.ty;
         if is_swapped
-            && (matches!(proto_kind(ftype).as_str(), "pointer")
+            && (proto_kind(ftype) == ParamFunc::Pointer
                 || cdata::type_code_of(ftype)
                     .is_some_and(|code| matches!(code.as_str(), "u" | "P" | "z" | "Z" | "O")))
         {
@@ -997,7 +1001,11 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
     let mut data = StgInfoData::new(
         aligned,
         total_align,
-        if is_union { "union" } else { "struct" },
+        if is_union {
+            ParamFunc::Union
+        } else {
+            ParamFunc::Struct
+        },
     );
     // Field count includes the inherited prefix, not just the own fields.
     data.length = base_length + entries.len();
@@ -1098,7 +1106,7 @@ fn fields_set(args: &[PyObjectRef]) -> PyResult {
     if stginfo::stginfo_is_final(info) {
         return Err(crate::PyError::attribute_error("_fields_ is final"));
     }
-    let is_union = stginfo::stginfo_paramfunc(info) == "union";
+    let is_union = stginfo::stginfo_paramfunc(info) == ParamFunc::Union;
     process_fields(cls, value, is_union)
 }
 
@@ -1190,18 +1198,19 @@ fn native_uint_to_bytes(value: u64, size: usize) -> Vec<u8> {
     }
 }
 
-/// The storage kind of a field's `proto` ("simple"/"struct"/"union"/…).
-fn proto_kind(proto: PyObjectRef) -> String {
+/// The storage kind of a field's `proto`.  A type with no `StgInfo` of its own
+/// is simple when it names a `_type_` code, and nothing otherwise.
+fn proto_kind(proto: PyObjectRef) -> ParamFunc {
     if let Some(info) = stginfo::stginfo_of(proto) {
         let pf = stginfo::stginfo_paramfunc(info);
-        if !pf.is_empty() {
+        if pf != ParamFunc::Other {
             return pf;
         }
     }
     if cdata::type_code_of(proto).is_some() {
-        return "simple".to_string();
+        return ParamFunc::Simple;
     }
-    String::new()
+    ParamFunc::Other
 }
 
 fn field_needs_swap(obj: PyObjectRef, proto: PyObjectRef, size: usize) -> bool {
@@ -1228,8 +1237,8 @@ fn cfield_get(args: &[PyObjectRef]) -> PyResult {
     let size = cf_usize(cfield, "byte_size");
     let index = cf_usize(cfield, "index");
 
-    match proto_kind(proto).as_str() {
-        "simple" => {
+    match proto_kind(proto) {
+        ParamFunc::Simple => {
             let tc = cdata::type_code_of(proto)
                 .ok_or_else(|| crate::PyError::type_error("field has no '_type_'"))?;
             let all = cdata::cdata_bytes(obj)
@@ -1261,7 +1270,7 @@ fn cfield_get(args: &[PyObjectRef]) -> PyResult {
             }
             Ok(cdata::decode_slot(&tc, &field_bytes))
         }
-        "array" => {
+        ParamFunc::Array => {
             let element = stginfo::stginfo_of(proto).and_then(stginfo::stginfo_proto);
             let all = cdata::cdata_bytes(obj)
                 .ok_or_else(|| crate::PyError::type_error("instance has no buffer"))?;
@@ -1279,7 +1288,7 @@ fn cfield_get(args: &[PyObjectRef]) -> PyResult {
                 _ => Ok(cdata::make_indexed_subview(proto, obj, offset, size, index)),
             }
         }
-        "struct" | "union" | "pointer" => {
+        ParamFunc::Struct | ParamFunc::Union | ParamFunc::Pointer => {
             Ok(cdata::make_indexed_subview(proto, obj, offset, size, index))
         }
         _ => Err(crate::PyError::type_error("field type has no storage info")),
@@ -1298,8 +1307,8 @@ fn cfield_set(args: &[PyObjectRef]) -> PyResult {
     let size = cf_usize(cfield, "byte_size");
     let index = cf_usize(cfield, "index");
 
-    match proto_kind(proto).as_str() {
-        "simple" => {
+    match proto_kind(proto) {
+        ParamFunc::Simple => {
             let tc = cdata::type_code_of(proto)
                 .ok_or_else(|| crate::PyError::type_error("field has no '_type_'"))?;
             if cf_bool(cfield, "is_bitfield") {
@@ -1340,7 +1349,7 @@ fn cfield_set(args: &[PyObjectRef]) -> PyResult {
             }
             Ok(pyre_object::w_none())
         }
-        "pointer" => {
+        ParamFunc::Pointer => {
             if unsafe { pyre_object::is_none(value) } {
                 cdata::cdata_write(obj, offset, &vec![0; size]);
                 return Ok(pyre_object::w_none());
@@ -1350,7 +1359,7 @@ fn cfield_set(args: &[PyObjectRef]) -> PyResult {
             let array_decay = if cdata::is_cdata_instance(value) {
                 let value_cls = unsafe { pyre_object::w_instance_get_type(value) };
                 stginfo::stginfo_of(value_cls)
-                    .filter(|&i| stginfo::stginfo_paramfunc(i) == "array")
+                    .filter(|&i| stginfo::stginfo_paramfunc(i) == ParamFunc::Array)
                     .and_then(stginfo::stginfo_proto)
                     == expected
             } else {
@@ -1378,7 +1387,7 @@ fn cfield_set(args: &[PyObjectRef]) -> PyResult {
             cdata::keep_ref(obj, &index.to_string(), keep);
             Ok(pyre_object::w_none())
         }
-        "array" => {
+        ParamFunc::Array => {
             let element = stginfo::stginfo_of(proto).and_then(stginfo::stginfo_proto);
             match element.and_then(cdata::type_code_of).as_deref() {
                 Some("c") => {
@@ -1438,7 +1447,7 @@ fn cfield_set(args: &[PyObjectRef]) -> PyResult {
             }
         }
         // Structures and unions are copied by value.
-        "struct" | "union" => {
+        ParamFunc::Struct | ParamFunc::Union => {
             if !unsafe { crate::baseobjspace::isinstance_w(value, proto) } {
                 return Err(crate::PyError::type_error("incompatible types"));
             }
@@ -1772,7 +1781,7 @@ fn array_init_stginfo(cls: PyObjectRef) -> PyResult {
         return Err(crate::PyError::overflow_error("array too large"));
     }
 
-    let mut data = StgInfoData::new(elem_size * length, elem_align, "array");
+    let mut data = StgInfoData::new(elem_size * length, elem_align, ParamFunc::Array);
     data.length = length;
     data.element_size = elem_size;
     data.proto = Some(elem);
@@ -1925,8 +1934,8 @@ fn array_getitem(args: &[PyObjectRef]) -> PyResult {
 
 fn array_get_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize) -> PyResult {
     let offset = idx * meta.element_size;
-    match proto_kind(meta.proto).as_str() {
-        "simple" => {
+    match proto_kind(meta.proto) {
+        ParamFunc::Simple => {
             let tc = cdata::type_code_of(meta.proto)
                 .ok_or_else(|| crate::PyError::type_error("element has no '_type_'"))?;
             let all = cdata::cdata_bytes(obj)
@@ -1935,13 +1944,9 @@ fn array_get_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize) -> PyResult {
             let start = offset.min(end);
             Ok(cdata::decode_slot(&tc, &all[start..end]))
         }
-        "struct" | "union" | "array" | "pointer" => Ok(cdata::make_indexed_subview(
-            meta.proto,
-            obj,
-            offset,
-            meta.element_size,
-            idx,
-        )),
+        ParamFunc::Struct | ParamFunc::Union | ParamFunc::Array | ParamFunc::Pointer => Ok(
+            cdata::make_indexed_subview(meta.proto, obj, offset, meta.element_size, idx),
+        ),
         _ => Err(crate::PyError::type_error(
             "element type has no storage info",
         )),
@@ -1965,8 +1970,8 @@ fn array_setitem(args: &[PyObjectRef]) -> PyResult {
 
 fn array_set_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize, value: PyObjectRef) -> PyResult {
     let offset = idx * meta.element_size;
-    match proto_kind(meta.proto).as_str() {
-        "simple" => {
+    match proto_kind(meta.proto) {
+        ParamFunc::Simple => {
             let tc = cdata::type_code_of(meta.proto)
                 .ok_or_else(|| crate::PyError::type_error("element has no '_type_'"))?;
             let bytes = cdata::encode_instance_or_value(&tc, value, obj, &idx.to_string())?;
@@ -1977,7 +1982,7 @@ fn array_set_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize, value: PyObje
             }
             Ok(pyre_object::w_none())
         }
-        "struct" | "union" | "array" | "pointer" => {
+        ParamFunc::Struct | ParamFunc::Union | ParamFunc::Array | ParamFunc::Pointer => {
             if !unsafe { crate::baseobjspace::isinstance_w(value, meta.proto) } {
                 return Err(crate::PyError::type_error("incompatible types"));
             }
@@ -2227,7 +2232,7 @@ fn pointer_init_stginfo(cls: PyObjectRef) -> PyResult {
         return Err(crate::PyError::type_error("_type_ must have storage info"));
     }
     let psize = host_ctypes::pointer_size();
-    let mut data = StgInfoData::new(psize, psize, "pointer");
+    let mut data = StgInfoData::new(psize, psize, ParamFunc::Pointer);
     data.length = 1;
     data.flags |= stginfo::TYPEFLAG_ISPOINTER;
     data.proto = proto;
@@ -2237,7 +2242,7 @@ fn pointer_init_stginfo(cls: PyObjectRef) -> PyResult {
                 let mut dims = Vec::new();
                 let mut current = p;
                 while let Some(info) = stginfo::stginfo_of(current) {
-                    if stginfo::stginfo_paramfunc(info) != "array" {
+                    if stginfo::stginfo_paramfunc(info) != ParamFunc::Array {
                         break;
                     }
                     dims.push(stginfo::stginfo_length(info));
@@ -2272,7 +2277,7 @@ fn pointer_init_stginfo(cls: PyObjectRef) -> PyResult {
             None => {
                 let size = stginfo::field_size_of(p).unwrap_or(0);
                 let align = stginfo::field_align_of(p).unwrap_or(1);
-                let info = stginfo::stginfo_new(StgInfoData::new(size, align, "simple"));
+                let info = stginfo::stginfo_new(StgInfoData::new(size, align, ParamFunc::Simple));
                 stginfo::stginfo_set(p, info);
                 info
             }
@@ -2432,8 +2437,8 @@ fn pointer_get_index(obj: PyObjectRef, index: isize) -> PyResult {
         return Err(crate::PyError::value_error("NULL pointer access"));
     }
     let addr = host_ctypes::pointer_item_address(ptr, index, element_size);
-    match proto_kind(proto).as_str() {
-        "simple" => {
+    match proto_kind(proto) {
+        ParamFunc::Simple => {
             let tc = cdata::type_code_of(proto)
                 .ok_or_else(|| crate::PyError::type_error("element has no '_type_'"))?;
             let bytes = unsafe { host_ctypes::borrow_memory(addr as *const u8, element_size) };
@@ -2458,8 +2463,8 @@ fn pointer_setitem(args: &[PyObjectRef]) -> PyResult {
     }
     let index = unsafe { pyre_object::w_int_get_value(key) } as isize;
     let addr = host_ctypes::pointer_item_address(ptr, index, element_size);
-    match proto_kind(proto).as_str() {
-        "simple" => {
+    match proto_kind(proto) {
+        ParamFunc::Simple => {
             let tc = cdata::type_code_of(proto)
                 .ok_or_else(|| crate::PyError::type_error("element has no '_type_'"))?;
             let bytes = cdata::encode_instance_or_value(&tc, value, obj, &index.to_string())?;

--- a/pyre/pyre-interpreter/src/module/_ctypes/stginfo.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/stginfo.rs
@@ -43,6 +43,47 @@ fn stginfo_type() -> PyObjectRef {
     }) as PyObjectRef
 }
 
+/// `StgInfo.paramfunc` — the storage shape a ctypes type has.
+///
+/// The carrier keeps it spelled out as a string, so a shape is one comparison
+/// on the way in and out rather than a fresh allocation at every read.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum ParamFunc {
+    Simple,
+    Array,
+    Pointer,
+    Struct,
+    Union,
+    /// A carrier with no `paramfunc`, or one naming a shape this build has no
+    /// arm for.
+    Other,
+}
+
+impl ParamFunc {
+    /// The spelling the carrier stores.
+    fn name(self) -> &'static str {
+        match self {
+            ParamFunc::Simple => "simple",
+            ParamFunc::Array => "array",
+            ParamFunc::Pointer => "pointer",
+            ParamFunc::Struct => "struct",
+            ParamFunc::Union => "union",
+            ParamFunc::Other => "",
+        }
+    }
+
+    fn from_name(name: &str) -> Self {
+        match name {
+            "simple" => ParamFunc::Simple,
+            "array" => ParamFunc::Array,
+            "pointer" => ParamFunc::Pointer,
+            "struct" => ParamFunc::Struct,
+            "union" => ParamFunc::Union,
+            _ => ParamFunc::Other,
+        }
+    }
+}
+
 /// Field values for [`stginfo_new`].
 pub(super) struct StgInfoData {
     pub size: usize,
@@ -50,7 +91,7 @@ pub(super) struct StgInfoData {
     pub length: usize,
     pub element_size: usize,
     pub flags: i64,
-    pub paramfunc: &'static str,
+    pub paramfunc: ParamFunc,
     pub proto: Option<PyObjectRef>,
     pub format: Option<String>,
     pub big_endian: bool,
@@ -58,7 +99,7 @@ pub(super) struct StgInfoData {
 
 impl StgInfoData {
     /// A minimal simple/aggregate carrier of the given size and alignment.
-    pub(super) fn new(size: usize, align: usize, paramfunc: &'static str) -> Self {
+    pub(super) fn new(size: usize, align: usize, paramfunc: ParamFunc) -> Self {
         StgInfoData {
             size,
             align: align.max(1),
@@ -102,7 +143,11 @@ pub(super) fn stginfo_new(data: StgInfoData) -> PyObjectRef {
             pyre_object::w_int_new(data.element_size as i64),
         );
         pyre_object::w_dict_setitem_str(d, K_FLAGS, pyre_object::w_int_new(data.flags));
-        pyre_object::w_dict_setitem_str(d, K_PARAMFUNC, pyre_object::w_str_new(data.paramfunc));
+        pyre_object::w_dict_setitem_str(
+            d,
+            K_PARAMFUNC,
+            pyre_object::w_str_new(data.paramfunc.name()),
+        );
         pyre_object::w_dict_setitem_str(d, K_PROTO, data.proto.unwrap_or_else(pyre_object::w_none));
         pyre_object::w_dict_setitem_str(
             d,
@@ -156,12 +201,15 @@ pub(super) fn stginfo_flags(info: PyObjectRef) -> i64 {
     get_int(info, K_FLAGS)
 }
 
-pub(super) fn stginfo_paramfunc(info: PyObjectRef) -> String {
+pub(super) fn stginfo_paramfunc(info: PyObjectRef) -> ParamFunc {
     match unsafe { pyre_object::w_dict_getitem_str(dict_of(info), K_PARAMFUNC) } {
         Some(o) if unsafe { pyre_object::is_str(o) } => {
-            unsafe { pyre_object::w_str_get_value(o) }.to_string()
+            match unsafe { pyre_object::w_str_get_value_opt(o) } {
+                Some(name) => ParamFunc::from_name(name),
+                None => ParamFunc::Other,
+            }
         }
-        _ => String::new(),
+        _ => ParamFunc::Other,
     }
 }
 


### PR DESCRIPTION
Five commits on the cpyext / `_ctypes` boundary, found by measuring where a cffi
call spends its time. pyre and CPython run the identical `_cffi_backend.c`, so
the gap between them is this layer and nothing else.

### `_ctypes: settle a foreign call's declarations into a stored plan`

A foreign call re-derived its argument and return declarations on every
invocation. They are settled once into a stored plan. This does not touch the
cffi path; on raw `ctypes` it is worth 3.0–3.4x.

### `cpyext: hash a mirror address without SipHash`

The side tables this layer keys on a mirror address are read once per
`incref` / `decref`. A mirror address is already a well-spread 64-bit value, so
they now take the mangling `majit_gc::address_dict::AddressHasher` uses rather
than SipHash.

### `cpyext: let an empty address table answer without its lock`

A teardown asks fourteen tables to release what they keyed by the address.
`AddressTable` publishes its entry count beside the lock so an empty one answers
without acquiring. Counted: 61.4% of the lookups take that exit on a cffi call
loop, 63.3% on a mirror birth-and-teardown loop, 55.9% on the backend driver.

### `cpyext: carry a tuple mirror's items in its own block`

A tuple mirror's items lived in a side table; they now sit in the block, which
is what lets `PyTuple_GET_ITEM` read one as a field — `tuple_attach` upstream.
The block is filled on first read rather than at mirror creation: `ensure_mirror`
tracks before it attaches, so filling at creation let a reentrant reader see the
MRO tuple with NUL slots and skip a base, which cost the type its inherited
`tp_as_buffer`. `publish_items` leaves the profile entirely.

### `cpyext: settle a mirror teardown's side tables with one question`

The cascade was 16.81 lookups per teardown — 125,130,310 over 7,445,643 — and
the ~48.3M that took a lock found **34** things. The per-table empty guard cannot
help the five tables that matter, because a module's fields, a type's name and
the tracked set are never empty once anything is imported.

Those tables are now keyed by `Held` instead of a bare address. Only `hold` mints
one and it registers the address in `HOLDERS`, so that set is what all fourteen
put together hold; `Held` borrows as its `usize`, so reads stay plain and only
writes need the mint — which makes a forgotten registration a compile error
rather than a silent leak. `dealloc` asks once: **16.81 lookups become 1**.

## Measurement

Work removed is counted, not timed — this machine's benchmark spread is over 100%
of the minimum, so it cannot resolve a single-digit percentage. Priced against a
microbench over fourteen distinct `parking_lot` statics (lock and probe 1.63 ns,
empty-table load 0.59 ns), the last commit takes the cascade from 35.0 ns to
3.6 ns for a cffi call making 2.1 teardowns.

Where the clock could see it, on the cffi ABI benchmark (interleaved pairs,
min-of-N), the series is:

| | abs(int) | pow(double,double) |
|---|---|---|
| before | 285.7 ms | 222.8 ms |
| after the first four | 244.6 ms | 175.0 ms |

## Verification

`pyre/cpython_tests/run.py --backend dynasm`: **221 PASS, 0 FAIL, 0 CRASH, no
regressions**. 440 lib unit tests, `cargo fmt --all -- --check` and
`scripts/check-majit-boundary.py` clean, and both cffi drivers answer
`CFFI-ABI-OK` / `CFFI-BACKEND-OK`.

That suite run was made on the previous base; the branch was rebased onto
`bd0908bb9df` afterwards and has been type-checked and unit-tested there, so CI
is the authority for the gate on this base.

— *commented by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for inline tuple item storage in C-compatible tuple objects.
  - Improved ctypes function calls with cached call plans, typed parameter handling, and optimized argument storage.
  - Expanded support for aggregate, pointer, array, structure, and union ctypes values.

- **Bug Fixes**
  - Improved cleanup and lifecycle tracking for interpreter and extension objects.
  - Enhanced behavior after process forks to maintain reliable object and buffer tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->