### PR TITLE
annotator: close two access_directly leaks found against upstream

### DIFF
--- a/majit/majit-rlib/src/debug.rs
+++ b/majit/majit-rlib/src/debug.rs
@@ -1,0 +1,33 @@
+//! `rpython/rlib/debug.py` — the translation-time assertion helpers.
+//!
+//! Each is an identity at runtime; the content is in the
+//! `ExtRegistryEntry.compute_result_annotation` that runs while the
+//! annotator is deriving the argument's annotation. `majit-translate` owns
+//! that half, in `annotator/builtin.rs`, keyed on this module's paths.
+
+/// `check_not_access_directly(arg)` — "check that arg does not have the
+/// `access_directly=True` hint set".
+///
+/// ```python
+/// class Entry(ExtRegistryEntry):
+///     _about_ = check_not_access_directly
+///
+///     def compute_result_annotation(self, s_arg):
+///         assert not s_arg.flags.get('access_directly', False)
+///         return s_arg
+/// ```
+///
+/// Upstream calls it from `baseobjspace.py W_Root.getclass`, whose comment
+/// gives the reason: annotating that method with `access_directly` set
+/// would specialize it, "otherwise every call to getclass (and other
+/// methods) has an extra indirection due to a much more complicated
+/// function set". It is the practical enforcement that the flag stays
+/// confined to the graphs the virtualizable protocol means it for —
+/// `warmspot.py check_access_directly_sanity` is the other, coarser one.
+///
+/// The body is the identity, and `specialize_call` is
+/// `hop.inputarg(hop.args_r[0], arg=0)` — the same identity after rtyping.
+#[inline(always)]
+pub fn check_not_access_directly<T>(arg: T) -> T {
+    arg
+}

--- a/majit/majit-rlib/src/lib.rs
+++ b/majit/majit-rlib/src/lib.rs
@@ -10,6 +10,7 @@
 //! in a crate above the module that allocates it. The module path spells the
 //! upstream package it came from.
 
+pub mod debug;
 pub mod lltypesystem;
 pub mod rbigint;
 

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -379,6 +379,21 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
         "majit_metainterp.jit.we_are_jitted",
         majit_metainterp_bool_flag,
     );
+    // `rlib/jit.py` — the `hint` ExtRegistryEntry's
+    // `compute_result_annotation`, the one place upstream MINTS
+    // `access_directly` onto an annotation. Upstream spells the kwargs on a
+    // single `hint(x, **kwds)`; pyre dispatches one helper per kwarg, so the
+    // branch on which kwargs are present becomes the choice of analyzer.
+    analyzer_for(
+        &mut reg,
+        "majit_metainterp.jit.hint_access_directly",
+        jit_hint_access_directly,
+    );
+    analyzer_for(
+        &mut reg,
+        "majit_metainterp.jit.hint_fresh_virtualizable",
+        jit_hint_fresh_virtualizable,
+    );
     // Rust primitive type conversion impls — all return `SomeInteger`.
     analyzer_for(&mut reg, "u32.from", primitive_integer_conversion);
     analyzer_for(&mut reg, "i64.from", primitive_integer_conversion);
@@ -1596,6 +1611,91 @@ fn foreign_container_ctor(
     )))
 }
 
+/// RPython `rlib/jit.py` — the `hint` ExtRegistryEntry's
+/// `compute_result_annotation`, for the `access_directly=True` spelling.
+///
+/// ```python
+/// s_x = annmodel.not_const(s_x)
+/// ...
+/// if isinstance(s_x, annmodel.SomeInstance):
+///     classdesc = s_x.classdef.classdesc
+///     virtualizable = classdesc.get_param('_virtualizable_')
+///     if s_access_directly.const == True and virtualizable is not None:
+///         flags = s_x.flags.copy()
+///         flags['access_directly'] = True
+///         ...
+///     else:
+///         ...  # delete both flags
+/// return s_x
+/// ```
+///
+/// The `else` arm matters as much as the `if`: a hint on a class that does
+/// not declare `_virtualizable_` STRIPS the flags rather than leaving them,
+/// so the annotation cannot carry `access_directly` off a non-virtualizable.
+///
+/// The consumer is `specialize.py default_specialize`, which flags the
+/// CALLEE a flagged argument reaches — never the function that spells this
+/// hint, whose own arguments arrive unflagged.
+fn jit_hint_access_directly(
+    _bk: &Rc<Bookkeeper>,
+    args_s: &[Option<SomeValue>],
+    _kwds: &HashMap<String, Option<SomeValue>>,
+) -> Result<SomeValue, AnnotatorError> {
+    Ok(hint_virtualizable_flags(args_s, false))
+}
+
+/// RPython `rlib/jit.py`, same entry, for the `fresh_virtualizable=True`
+/// spelling.
+///
+/// Upstream carries both kwargs on one call and asserts against the lone
+/// form — `assert s_access_directly, "lone fresh_virtualizable hint"`. Pyre
+/// splits the call in two, so this helper sets BOTH flags rather than
+/// `fresh_virtualizable` alone; the state upstream asserts against is then
+/// unreachable instead of merely undiagnosed.
+fn jit_hint_fresh_virtualizable(
+    _bk: &Rc<Bookkeeper>,
+    args_s: &[Option<SomeValue>],
+    _kwds: &HashMap<String, Option<SomeValue>>,
+) -> Result<SomeValue, AnnotatorError> {
+    Ok(hint_virtualizable_flags(args_s, true))
+}
+
+/// The body both `hint` spellings share — `rlib/jit.py`'s
+/// `SomeInstance` branch.
+fn hint_virtualizable_flags(args_s: &[Option<SomeValue>], fresh_virtualizable: bool) -> SomeValue {
+    let Some(Some(s_x)) = args_s.first() else {
+        // `hint` is an identity on its argument; with nothing bound there is
+        // nothing to annotate and nothing to flag.
+        return s_impossible_value();
+    };
+    let s_x = super::model::not_const(s_x);
+    let SomeValue::Instance(inst) = &s_x else {
+        // Upstream's `isinstance(s_x, SomeInstance)` guard: every other
+        // annotation falls through to `return s_x` untouched.
+        return s_x;
+    };
+    let is_virtualizable = inst.classdef.as_ref().is_some_and(|classdef| {
+        let classdesc = classdef.borrow().classdesc.clone();
+        let param = classdesc.borrow().get_param("_virtualizable_", None, true);
+        !matches!(param, crate::flowspace::model::ConstValue::None)
+    });
+    let mut flags = inst.flags.clone();
+    if is_virtualizable {
+        flags.insert("access_directly".to_string(), true);
+        if fresh_virtualizable {
+            flags.insert("fresh_virtualizable".to_string(), true);
+        }
+    } else {
+        flags.remove("access_directly");
+        flags.remove("fresh_virtualizable");
+    }
+    SomeValue::Instance(super::model::SomeInstance::new(
+        inst.classdef.clone(),
+        inst.can_be_none,
+        flags,
+    ))
+}
+
 /// Analyzer for the `majit_metainterp` crate's `pub fn -> bool` flag
 /// helpers.  Single implementation covers both `majit_log_enabled()`
 /// (logging gate) and `jit::we_are_jitted()` (JIT-context probe);
@@ -2226,6 +2326,95 @@ mod tests {
 
     fn bk() -> Rc<Bookkeeper> {
         Rc::new(Bookkeeper::new())
+    }
+
+    /// Build a `SomeInstance` whose classdesc does or does not declare
+    /// `_virtualizable_` — `ClassDesc.get_param` reads it off the host class.
+    fn instance_of(
+        bk: &Rc<Bookkeeper>,
+        name: &str,
+        virtualizable: bool,
+        flags: &[&str],
+    ) -> SomeValue {
+        use crate::flowspace::model::{ConstValue, HostObject};
+        let mut members: indexmap::IndexMap<String, ConstValue> = indexmap::IndexMap::new();
+        if virtualizable {
+            members.insert(
+                "_virtualizable_".into(),
+                ConstValue::byte_str("locals_cells_stack_w[*]"),
+            );
+        }
+        let pyobj = HostObject::new_class_with_members(name, vec![], members);
+        let classdesc =
+            super::super::classdesc::ClassDesc::new(bk, pyobj, Some(name.to_string()), None, None)
+                .expect("ClassDesc::new");
+        let classdef = super::super::classdesc::ClassDef::new(bk, &classdesc);
+        let flags = flags
+            .iter()
+            .map(|f| ((*f).to_string(), true))
+            .collect::<std::collections::BTreeMap<_, _>>();
+        SomeValue::Instance(super::super::model::SomeInstance::new(
+            Some(classdef),
+            false,
+            flags,
+        ))
+    }
+
+    fn flags_of(s: &SomeValue) -> Vec<String> {
+        let SomeValue::Instance(inst) = s else {
+            panic!("not an instance: {s:?}")
+        };
+        inst.flags.keys().cloned().collect()
+    }
+
+    /// `rlib/jit.py` mints the flag only when the class declares
+    /// `_virtualizable_`.
+    #[test]
+    fn the_hint_mints_access_directly_on_a_virtualizable() {
+        let bk = bk();
+        let s = instance_of(&bk, "PyFrame", true, &[]);
+        let out = hint_virtualizable_flags(&[Some(s)], false);
+        assert_eq!(flags_of(&out), vec!["access_directly".to_string()]);
+    }
+
+    /// The `fresh_virtualizable` spelling carries `access_directly` with it,
+    /// so the lone form upstream asserts against is unreachable.
+    #[test]
+    fn the_fresh_virtualizable_hint_carries_access_directly_too() {
+        let bk = bk();
+        let s = instance_of(&bk, "PyFrame", true, &[]);
+        let out = hint_virtualizable_flags(&[Some(s)], true);
+        assert_eq!(
+            flags_of(&out),
+            vec![
+                "access_directly".to_string(),
+                "fresh_virtualizable".to_string()
+            ]
+        );
+    }
+
+    /// The `else` arm: a hint on a class with no `_virtualizable_` STRIPS
+    /// both flags rather than leaving them in place.
+    #[test]
+    fn the_hint_strips_the_flags_off_a_non_virtualizable() {
+        let bk = bk();
+        let s = instance_of(
+            &bk,
+            "Plain",
+            false,
+            &["access_directly", "fresh_virtualizable", "other"],
+        );
+        let out = hint_virtualizable_flags(&[Some(s)], false);
+        assert_eq!(flags_of(&out), vec!["other".to_string()]);
+    }
+
+    /// Upstream's `isinstance(s_x, SomeInstance)` guard — anything else
+    /// returns unchanged.
+    #[test]
+    fn the_hint_leaves_a_non_instance_alone() {
+        let s = SomeValue::Integer(SomeInteger::default());
+        let out = hint_virtualizable_flags(&[Some(s.clone())], false);
+        assert_eq!(out, super::super::model::not_const(&s));
     }
 
     fn no_kwds() -> HashMap<String, Option<SomeValue>> {

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -394,6 +394,12 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
         "majit_metainterp.jit.hint_fresh_virtualizable",
         jit_hint_fresh_virtualizable,
     );
+    // `rlib/debug.py` — the assertion half of `check_not_access_directly`.
+    analyzer_for(
+        &mut reg,
+        "majit_rlib.debug.check_not_access_directly",
+        rlib_check_not_access_directly,
+    );
     // Rust primitive type conversion impls — all return `SomeInteger`.
     analyzer_for(&mut reg, "u32.from", primitive_integer_conversion);
     analyzer_for(&mut reg, "i64.from", primitive_integer_conversion);
@@ -1696,6 +1702,37 @@ fn hint_virtualizable_flags(args_s: &[Option<SomeValue>], fresh_virtualizable: b
     ))
 }
 
+/// RPython `rlib/debug.py` — the `check_not_access_directly`
+/// ExtRegistryEntry's `compute_result_annotation`.
+///
+/// ```python
+/// def compute_result_annotation(self, s_arg):
+///     assert not s_arg.flags.get('access_directly', False)
+///     return s_arg
+/// ```
+///
+/// Upstream asserts, i.e. it aborts translation. The failure is a real
+/// defect in the caller — a graph reached the marked function carrying the
+/// virtualizable hint, which would specialize it — so this raises rather
+/// than silently dropping the flag.
+fn rlib_check_not_access_directly(
+    _bk: &Rc<Bookkeeper>,
+    args_s: &[Option<SomeValue>],
+    _kwds: &HashMap<String, Option<SomeValue>>,
+) -> Result<SomeValue, AnnotatorError> {
+    let Some(Some(s_arg)) = args_s.first() else {
+        return Ok(s_impossible_value());
+    };
+    if let SomeValue::Instance(inst) = s_arg
+        && inst.flags.get("access_directly").copied().unwrap_or(false)
+    {
+        return Err(AnnotatorError::new(
+            "check_not_access_directly: argument carries the access_directly hint",
+        ));
+    }
+    Ok(s_arg.clone())
+}
+
 /// Analyzer for the `majit_metainterp` crate's `pub fn -> bool` flag
 /// helpers.  Single implementation covers both `majit_log_enabled()`
 /// (logging gate) and `jit::we_are_jitted()` (JIT-context probe);
@@ -2406,6 +2443,26 @@ mod tests {
         );
         let out = hint_virtualizable_flags(&[Some(s)], false);
         assert_eq!(flags_of(&out), vec!["other".to_string()]);
+    }
+
+    /// `rlib/debug.py` asserts; the port raises instead of dropping the
+    /// flag, because the failure is a defect in the caller.
+    #[test]
+    fn check_not_access_directly_rejects_a_flagged_argument() {
+        let bk = bk();
+        let flagged = instance_of(&bk, "PyFrame", true, &["access_directly"]);
+        assert!(
+            rlib_check_not_access_directly(&bk, &[Some(flagged)], &HashMap::new()).is_err(),
+            "a flagged argument must abort, not pass"
+        );
+
+        let plain = instance_of(&bk, "PyFrame", true, &[]);
+        assert_eq!(
+            rlib_check_not_access_directly(&bk, &[Some(plain.clone())], &HashMap::new())
+                .expect("an unflagged argument passes"),
+            plain,
+            "the entry is an identity on the annotation it accepts"
+        );
     }
 
     /// Upstream's `isinstance(s_x, SomeInstance)` guard — anything else

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -2378,10 +2378,16 @@ impl SomeValue {
             ))),
             SomeValue::List(s) => Ok(SomeValue::List(SomeList::new(s.listdef.clone()))),
             SomeValue::Dict(s) => Ok(SomeValue::Dict(SomeDict::new(s.dictdef.clone()))),
+            // `SomeInstance.noneify` reconstructs as
+            // `SomeInstance(self.classdef, can_be_None=True)`, taking the
+            // `flags={}` default: the flags do NOT survive. Carrying them
+            // over would leave `access_directly` set on an annotation that
+            // reached `None`, and `policy.py:71-83` turns an over-set flag
+            // into an aborted translation, not a missed optimisation.
             SomeValue::Instance(s) => Ok(SomeValue::Instance(SomeInstance::new(
                 s.classdef.clone(),
                 true,
-                s.flags.clone(),
+                std::collections::BTreeMap::new(),
             ))),
             SomeValue::PBC(s) => Ok(SomeValue::PBC(SomePBC::with_subset(
                 s.descriptions.values().cloned(),
@@ -2409,10 +2415,13 @@ impl SomeValue {
                 SomeValue::UnicodeString(SomeUnicodeString::new(false, s.inner.no_nul))
             }
             SomeValue::ByteArray(_) => SomeValue::ByteArray(SomeByteArray::new(false)),
+            // `SomeInstance.nonnoneify` drops the flags for the same
+            // reason `noneify` does — it reconstructs with the `flags={}`
+            // default.
             SomeValue::Instance(s) => SomeValue::Instance(SomeInstance::new(
                 s.classdef.clone(),
                 false,
-                s.flags.clone(),
+                std::collections::BTreeMap::new(),
             )),
             SomeValue::PBC(s) => SomeValue::PBC(SomePBC::with_subset(
                 s.descriptions.values().cloned(),
@@ -4992,6 +5001,32 @@ mod tests {
             panic!("expected SomeInstance");
         };
         assert!(classdef_opt_eq(&inst.classdef, &Some(base)));
+    }
+
+    /// `SomeInstance.noneify` / `nonnoneify` reconstruct with the
+    /// `flags={}` default, so a flag does not cross either of them.
+    /// `intersection_Instance` already does the same. The only flag that
+    /// reaches here in production is `access_directly`, whose consumer
+    /// (`policy.py:71-83`) aborts translation when it is set on a graph the
+    /// codewriter declines — so an over-kept flag is a build failure.
+    #[test]
+    fn noneify_and_nonnoneify_drop_instance_flags() {
+        let mut flags = std::collections::BTreeMap::new();
+        flags.insert("access_directly".to_string(), true);
+        let inst = SomeValue::Instance(SomeInstance::new(None, false, flags));
+
+        let noneified = inst.noneify().expect("instance noneifies");
+        let SomeValue::Instance(n) = &noneified else {
+            panic!("noneify kept the instance shape, got {noneified:?}")
+        };
+        assert!(n.can_be_none);
+        assert!(n.flags.is_empty(), "noneify kept {:?}", n.flags);
+
+        let SomeValue::Instance(nn) = inst.nonnoneify() else {
+            panic!("nonnoneify kept the instance shape")
+        };
+        assert!(!nn.can_be_none);
+        assert!(nn.flags.is_empty(), "nonnoneify kept {:?}", nn.flags);
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -654,6 +654,13 @@ impl GraphStore {
         match self.graphs.get_mut(&key) {
             Some(existing) => {
                 existing.graph.func.merge_from(&graph.func);
+                // Monotonic, like `func`: upstream's aliases are the same
+                // Python graph object, so `graph.access_directly = True`
+                // written through one of them is visible through all. Here
+                // the aliases are separate `FunctionGraph` values folded onto
+                // one `GraphSlot`, so "any alias said true" has to survive
+                // the fold or the flag depends on registration order.
+                existing.graph.access_directly |= graph.access_directly;
                 if !graph.hints.is_empty() {
                     existing.graph.hints = graph.hints;
                 }
@@ -9259,6 +9266,36 @@ pub(crate) fn describe_call(target: &CallTarget) -> Option<CallDescriptor> {
 mod tests {
     use super::*;
     use crate::model::{ExitSwitch, FunctionGraph, Link, LinkArg, ValueType, exception_exitcase};
+
+    /// Two aliases of one source funcobj fold onto a single `GraphSlot`.
+    /// Upstream never faces this — its aliases are the same Python graph
+    /// object — so a flag written through either spelling has to survive the
+    /// fold in both registration orders.
+    #[test]
+    fn access_directly_survives_the_alias_fold_in_either_order() {
+        for flagged_first in [true, false] {
+            let mut store = GraphStore::new();
+            let mut flagged = FunctionGraph::new("dispatch");
+            flagged.access_directly = true;
+            let plain = FunctionGraph::new("dispatch");
+            let (a, b) = if flagged_first {
+                (flagged, plain)
+            } else {
+                (plain, flagged)
+            };
+            store.insert(CallPath::from_segments(["m", "dispatch"]), a);
+            store.insert(CallPath::from_segments(["alias", "dispatch"]), b);
+            for spelling in [["m", "dispatch"], ["alias", "dispatch"]] {
+                assert!(
+                    store
+                        .get(&CallPath::from_segments(spelling))
+                        .expect("registered")
+                        .access_directly,
+                    "flagged_first={flagged_first} lost the flag at {spelling:?}"
+                );
+            }
+        }
+    }
 
     #[test]
     fn serialized_descr_set_keys_ignore_descriptor_address_order() {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -12151,6 +12151,15 @@ impl<'a> Lowering<'a> {
         {
             return Some(arg.clone());
         }
+        // `rlib/debug.py check_not_access_directly` — upstream's
+        // `specialize_call` is `hop.inputarg(hop.args_r[0], arg=0)`, i.e. the
+        // identity once the annotator's assert has run. The assert half is
+        // registered in `annotator/builtin.rs`; this is the other half, and
+        // without it the marker would sit as a residual call on the caller's
+        // path instead of vanishing the way it does upstream.
+        if fmt_path_ends_with(segments, &["debug", "check_not_access_directly"]) {
+            return Some(arg.clone());
+        }
         let [a, b, c] = segments else {
             return None;
         };

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2287,7 +2287,12 @@ pub(crate) fn lift_callee_to_pygraph(
         func,
         signature: RefCell::new(signature),
         defaults: RefCell::new(Some(Vec::new())),
-        access_directly: Cell::new(false),
+        // Carried for the same reason `hints` is, three lines up: this is
+        // one graph reached through two representations, so a flag set on
+        // the legacy side has to survive the lift. The sibling stub
+        // synthesizer below keeps `false` because it has no source graph to
+        // read.
+        access_directly: Cell::new(callee_graph.access_directly),
     });
     Ok(pygraph)
 }

--- a/majit/majit-translate/tests/test_fast2locals_codewriter.rs
+++ b/majit/majit-translate/tests/test_fast2locals_codewriter.rs
@@ -76,6 +76,27 @@ fn call_leafs(graph: &FunctionGraph) -> Vec<String> {
     leafs
 }
 
+/// `rlib/debug.py check_not_access_directly` is the identity after its
+/// annotator assert has run — upstream's `specialize_call` is
+/// `hop.inputarg(hop.args_r[0], arg=0)`. `identity_passthrough_alias` is the
+/// port of that half, and this is the graph that carries the one call
+/// (`typedef::type`, which fuses `space.type` and `W_Root.getclass`). Left
+/// unfolded the marker would sit as a residual call on the type-lookup path.
+#[test]
+fn the_access_directly_marker_folds_out_of_the_type_lookup() {
+    let Some(llbc) = interpreter_llbc() else {
+        return;
+    };
+    let graph = lower_named(&llbc, "typedef::type");
+    assert!(
+        call_leafs(&graph)
+            .iter()
+            .all(|leaf| leaf != "check_not_access_directly"),
+        "the marker must be aliased to its argument, got {:?}",
+        call_leafs(&graph)
+    );
+}
+
 /// `GetSetProperty(PyFrame.fget_getdictscope)`: the wrapper carries the
 /// residual force; `rewrite_op_jit_force_virtualizable` deletes it; the
 /// method itself matches `pyframe.py fget_getdictscope`.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -204,6 +204,14 @@ pub fn r#type(obj: PyObjectRef) -> Option<NonNull<PyObject>> {
     if obj.is_null() {
         return None;
     }
+    // `baseobjspace.py W_Root.getclass` opens with
+    // `check_not_access_directly(self)`, and this function is where that
+    // method's body lives — the doc above records the fusion. Upstream's
+    // reason is written at its call site: annotating the type read with
+    // `access_directly` set specialises it, putting "an extra indirection due
+    // to a much more complicated function set" on every call. This is the one
+    // call, as it is upstream.
+    let obj = majit_rlib::debug::check_not_access_directly(obj);
     // A tagged immediate is an exact builtin `int`; its type object is
     // `gettypefor(&INT_TYPE)`, synthesized before the `w_class`/`ob_type`
     // derefs below (which would fault on the immediate). Gated on


### PR DESCRIPTION
Follow-on to #1534, which landed the `access_directly` carrier on
`FunctionGraph`. Two places lost the flag before it could reach the
`policy.py:71-83` gate.

**`GraphStore::insert` alias fold** carried `func`, `hints` and
`return_type` across two registrations of one source funcobj, but not
`access_directly`, so a flag written through one alias was dropped
whenever another alias had been registered first. Upstream never faces
this — its aliases are the same Python graph object. Folded
monotonically, like `func`. The test goes red only on the registration
order that puts the unflagged alias first.

**`noneify` / `nonnoneify`** carried `s.flags.clone()`. Upstream's
`SomeInstance.noneify` / `nonnoneify` reconstruct as
`SomeInstance(self.classdef, can_be_None=...)`, taking the `flags={}`
default, so no flag crosses either. `intersection_Instance` beside them
already matched. The consumer aborts translation when the flag is set on
a graph the codewriter declines, so an over-kept flag is a build failure
rather than a missed optimisation.

Nothing sets the flag on the production path yet, so no graph changes
answer today.

Audited at the same time and already matching upstream, recorded here so
it is not re-derived: the union rule (`flags.retain` = the pointwise
`(key, value)` intersection — it lives in `annotator/model.rs`, not
`binaryop.rs`), `intersection_Instance`, the `MethodDesc` flag channel
and its flag-keyed interning in `getmethoddesc`,
`MethodDesc::simplify_desc_set`, `rclass.rs`'s `new_instance`
fresh-malloc exemption, and the `dont_look_inside` cut-off that strips
the flag in place.

Still unported, both vacuous until something sets the flag:
`rlib/debug.py check_not_access_directly` and
`warmspot.py check_access_directly_sanity`.

Gates: `cargo fmt --all -- --check`, `scripts/check-majit-boundary.py`,
`cargo test -p majit-translate` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Instance value conversions now consistently clear instance flags.
  - Direct-access behavior is preserved when equivalent function aliases are combined, regardless of registration order.
  - Virtualizable access settings now carry through translation and are validated consistently.

- **Tests**
  - Added coverage confirming flags are cleared during conversions.
  - Added coverage confirming direct-access settings remain intact across alias registration orders.
  - Added coverage for access validation and marker removal during translation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->