### PR TITLE
majit-metainterp: four fixed costs out of the JIT entry door

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -25855,8 +25855,17 @@ mod tests {
         held.clear();
     }
 
+    /// The deadframe goes before the backend, and dropping it there is what
+    /// nulls the frame's `jf_gcmap`.
+    ///
+    /// The order is the contract, not a preference: the deadframe IS the
+    /// jitframe, so this write — like every accessor on it — goes into the
+    /// collector's heap, and a deadframe dropped after the backend that owns
+    /// that heap writes into a freed arena. The test used to assert the
+    /// opposite order was safe, from when a deadframe copied its values out and
+    /// held no address into the heap at all.
     #[test]
-    fn test_deadframe_drop_after_backend_drop_is_safe() {
+    fn test_deadframe_drop_nulls_the_frames_gcmap_before_the_backend_goes() {
         let mut gc = MiniMarkGC::with_config(GcConfig {
             nursery_size: 160,
             large_object_threshold: 1024,
@@ -25881,8 +25890,19 @@ mod tests {
         backend.compile_loop(&inputargs, &ops, &token).unwrap();
 
         let frame = backend.execute_token(&token, &[Value::Ref(root)]);
-        drop(backend);
+        let jf = frame
+            .as_jitframe()
+            .expect("cranelift deadframes are JitFrameDeadFrame")
+            .jf_gcref();
         drop(frame);
+        // Nothing allocates between the release and this read, so the frame is
+        // still where the root last named it.
+        let gcmap = unsafe { *((jf.0 + JF_GCMAP_OFS as usize) as *const usize) };
+        assert_eq!(
+            gcmap, 0,
+            "a released deadframe must leave no map for a later collection to custom-trace it through"
+        );
+        drop(backend);
     }
 
     #[test]

--- a/majit/majit-backend/src/deadframe.rs
+++ b/majit/majit-backend/src/deadframe.rs
@@ -538,6 +538,10 @@ impl Drop for JitFrameDeadFrame {
     /// traces it at all — and only an owning deadframe, because a `borrowing`
     /// one stands for a frame whose compiled run is still inside the residual
     /// call that pushed the map.
+    ///
+    /// The write is into the collector's heap, so it holds the same rule the
+    /// accessors above hold: this deadframe must not outlive the collector that
+    /// allocated its frame (see [`crate::DeadFrame`]).
     fn drop(&mut self) {
         if let JitFrameRoot::Slot(guard) = &self.jf_root {
             if self.owns_gcmap {

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1686,6 +1686,13 @@ unsafe impl Sync for JitCellToken {}
 /// a foreign thread's slot. That is what the guard's own thread-pinning
 /// enforces, and it is the rule for the enum as a whole — the erased variant
 /// states no weaker one, so its payload carries no `Send` bound either.
+///
+/// **A [`DeadFrame::JitFrame`] is heap-confined as well**: it must not outlive
+/// the collector its frame was allocated from. The deadframe IS the jitframe,
+/// so every accessor dereferences that memory and the drop writes `jf_gcmap`
+/// back into it; once the collector is gone the address names a freed arena.
+/// The rule is the ordering and not a liveness test on the drop, because a test
+/// there would only move the fault to the first read.
 pub enum DeadFrame {
     /// `llmodel.py:328` — the deadframe IS the jitframe the run returned,
     /// held in a GC root slot because the collector may move it.

--- a/majit/majit-ir/src/value.rs
+++ b/majit/majit-ir/src/value.rs
@@ -140,6 +140,21 @@ impl Value {
         }
     }
 
+    /// Machine-word projection: the integer for `Int`, the pointer bits for
+    /// `Ref`, the bit pattern for `Float`, and zero for `Void` — the encoding
+    /// a compiled exit's slots are read out of the frame in.
+    ///
+    /// The `Void` arm is why this is not [`Const::as_raw_i64`]: a `Const` has
+    /// no void variant, and an exit slot does.
+    pub fn as_raw_i64(&self) -> i64 {
+        match self {
+            Value::Int(v) => *v,
+            Value::Ref(v) => v.as_usize() as i64,
+            Value::Float(v) => v.to_bits() as i64,
+            Value::Void => 0,
+        }
+    }
+
     /// Project a `Value` into a `Const`.  Mirrors RPython where
     /// `ConstInt`/`ConstFloat`/`ConstPtr` (history.py/261/307) are
     /// the only concrete constant classes — there is no `ConstVoid`,

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -144,18 +144,29 @@ const EXIT_VALUE_INLINE: usize = 8;
 
 /// Storage for one exit's decoded values, as machine words.
 ///
-/// Both this and [`ExitValues`] are written once per exit from a compiled
-/// entry and read by the guard, blackhole and finish arms downstream. Holding
-/// them inline keeps the ordinary entry from asking the allocator for a buffer
-/// it will free before the next one; an exit wider than [`EXIT_VALUE_INLINE`]
-/// spills to the heap and pays exactly what it paid before.
+/// Written by the raw run path, and by the guard-failure and detailed-run arms
+/// that ask [`raw_exit_values`] for one. Holding it inline keeps those from
+/// asking the allocator for a buffer they free before the next entry; an exit
+/// wider than [`EXIT_VALUE_INLINE`] spills to the heap and pays exactly what it
+/// paid before.
 pub type ExitRawValues = smallvec::SmallVec<[i64; EXIT_VALUE_INLINE]>;
 
 /// Storage for one exit's decoded values, typed — see [`ExitRawValues`].
 ///
-/// A `Value` is two words, so this array is the more expensive half of the
-/// pair and is what bounds [`EXIT_VALUE_INLINE`] from above.
+/// A `Value` is two words, so this array is the more expensive half of the pair
+/// and is what bounds [`EXIT_VALUE_INLINE`] from above. It is also the only
+/// half a [`CompileResult`] carries, because the other is a projection of it.
 pub type ExitValues = smallvec::SmallVec<[Value; EXIT_VALUE_INLINE]>;
+
+/// Project decoded exit slots back to the machine words they were read as.
+///
+/// [`Value::as_raw_i64`] is exact for every slot type a fail-arg list can hold,
+/// so this recovers what a second list built beside [`ExitValues`] would have
+/// held. Its callers are the guard-failure and detailed-run arms, which then
+/// own the buffer; the steady finish exit calls nothing here.
+pub fn raw_exit_values(typed: &[Value]) -> ExitRawValues {
+    typed.iter().map(Value::as_raw_i64).collect()
+}
 
 /// Static exit metadata for a compiled guard or finish point.
 #[derive(Debug, Clone)]
@@ -219,7 +230,13 @@ impl CompiledExitLayout {
 
 /// Typed result from running compiled code.
 pub struct CompileResult<M> {
-    pub values: ExitRawValues,
+    /// The exit slots this run left through.
+    ///
+    /// The machine-word list that used to sit beside this one is gone: every
+    /// reader of it is on the guard-failure or detailed-run path, so a steady
+    /// finish exit built one per entry and dropped it unread, moving eighty
+    /// bytes through each by-value return of this struct on the way. Those
+    /// readers call [`raw_exit_values`] on this list instead.
     pub typed_values: ExitValues,
     /// Snapshot of the compiled entry's metadata taken *before*
     /// `execute_token`, mirroring `warmstate.py` `execute_assembler`'s hold on

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -164,6 +164,13 @@ pub type ExitValues = smallvec::SmallVec<[Value; EXIT_VALUE_INLINE]>;
 /// so this recovers what a second list built beside [`ExitValues`] would have
 /// held. Its callers are the guard-failure and detailed-run arms, which then
 /// own the buffer; the steady finish exit calls nothing here.
+///
+/// Upstream has no list of this shape to be faithful to: a final descriptor
+/// reads the single slot its own type calls for straight off the deadframe
+/// (`DoneWithThisFrameDescrInt` / `Ref` / `Float`, each with its own
+/// `get_result`), so a machine-word vector covering every slot is a Rust-side
+/// convenience. It therefore belongs with the two readers that want one, not on
+/// the result every entry returns.
 pub fn raw_exit_values(typed: &[Value]) -> ExitRawValues {
     typed.iter().map(Value::as_raw_i64).collect()
 }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1681,7 +1681,13 @@ pub struct JitDriver<S: JitState> {
     /// entry finds this slot empty and starts from fresh ones. Nesting
     /// therefore costs what it costs today and never aliases; only the
     /// outermost entry's buffers survive to be reused.
-    entry_scratch: EntryScratch,
+    ///
+    /// Held behind a pointer because the hand-out and the hand-back are moves:
+    /// the struct is five `Vec` headers, so an inline slot moved a hundred and
+    /// twenty bytes out of this field and the same back into it on every entry,
+    /// for buffers whose contents never move at all. `None` is the window
+    /// between the two, which is what a nested entry finds.
+    entry_scratch: Option<Box<EntryScratch>>,
 }
 
 /// Per-entry scratch owned by [`JitDriver`]; see [`JitDriver::entry_scratch`].
@@ -1869,7 +1875,7 @@ impl<S: JitState> JitDriver<S> {
             portal_runner: None,
             portal_jd_index: None,
             state_field_fvc: None,
-            entry_scratch: EntryScratch::default(),
+            entry_scratch: Some(Box::default()),
             #[expect(
                 clippy::arc_with_non_send_sync,
                 reason = "Arc preserves shared JitCode/descriptor identity across compiled artifacts; the non-Send translator payload is confined to the single-threaded build phase and is never transferred between threads"
@@ -6620,8 +6626,12 @@ impl<S: JitState> JitDriver<S> {
     /// The buffers arrive with their previous contents dropped and their
     /// capacity kept. `vable_arrays` keeps its outer elements so the inner
     /// buffers survive too — see `JitState::export_virtualizable_boxes_into`.
-    fn take_entry_scratch(&mut self) -> EntryScratch {
-        let mut scratch = std::mem::take(&mut self.entry_scratch);
+    ///
+    /// A nested entry finds the slot empty and builds its own set, which is the
+    /// `unwrap_or_default` arm; the allocation it costs is the price of nesting
+    /// and not of the ordinary entry, which finds the box the last one returned.
+    fn take_entry_scratch(&mut self) -> Box<EntryScratch> {
+        let mut scratch = self.entry_scratch.take().unwrap_or_default();
         scratch.live_values.clear();
         scratch.raw.clear();
         scratch.types.clear();
@@ -6633,8 +6643,8 @@ impl<S: JitState> JitDriver<S> {
     }
 
     /// Return the buffers [`Self::take_entry_scratch`] handed out.
-    fn entry_scratch_out(&mut self, scratch: EntryScratch) {
-        self.entry_scratch = scratch;
+    fn entry_scratch_out(&mut self, scratch: Box<EntryScratch>) {
+        self.entry_scratch = Some(scratch);
     }
 
     /// The driver's static data, resolved once and then shared.

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -7622,19 +7622,23 @@ impl<S: JitState> JitDriver<S> {
     /// The resolved key travels back with the token because a caller that goes
     /// on to run needs it, and because the `compiled_loops` half of the
     /// predicate is keyed by it.
+    ///
+    /// The `compiled_loops` half is asked FIRST, as the gate the token read
+    /// sits behind. Both conjuncts are pure reads of the same key, so the order
+    /// does not change the answer, but their costs are not alike: the frontend
+    /// half is one hash probe, and the token read is a `Weak::upgrade` and the
+    /// `Arc` drop that answers it, one atomic each. A key with no compiled
+    /// entry — which is every key a door declines on — now stops at the probe.
     #[inline]
     pub fn resolved_runnable_procedure_token(
         &self,
         green_key_hash: u64,
         make_green_key: impl FnOnce() -> GreenKey,
     ) -> (u64, Option<std::sync::Arc<majit_backend::JitCellToken>>) {
-        let (cell_key, token) = self
-            .meta
-            .resolved_entry_procedure_token(green_key_hash, make_green_key);
-        (
-            cell_key,
-            token.filter(|_| self.meta.get_compiled_meta(cell_key).is_some()),
-        )
+        self.meta
+            .resolved_entry_procedure_token(green_key_hash, make_green_key, |cell_key| {
+                self.meta.get_compiled_meta(cell_key).is_some()
+            })
     }
 
     /// The token [`Self::has_runnable_compiled_loop`] says yes about, handed

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5781,7 +5781,10 @@ impl<S: JitState> JitDriver<S> {
                 .exit_layout
                 .take()
                 .expect("a guard exit carries its exit layout");
-            let raw_values = result.values.clone();
+            // Projected here rather than carried on the result: only this arm
+            // and the detailed run below read machine words, and building the
+            // list on every entry charged the finish exit for both.
+            let raw_values = crate::compile::raw_exit_values(&result.typed_values);
             let descr_arc = std::sync::Arc::clone(&result.descr_arc);
             let guard_value_operand = result.guard_value_operand;
             // blackhole.py `_prepare_resume_from_failure(deadframe)`:
@@ -7369,10 +7372,11 @@ impl<S: JitState> JitDriver<S> {
         // The pointer travels; the layout behind it is opened past the finish
         // arm below, which is the one that carries none.
         let exit_layout = result.exit_layout.take();
+        // Projected first: the take below is what leaves `typed_values` empty.
+        let raw_values = crate::compile::raw_exit_values(&result.typed_values).into_vec();
         // Taken, not copied: every field this arm needs is read out here and
-        // `result` is dropped just below, so neither buffer has a reader left.
+        // `result` is dropped just below, so the buffer has no reader left.
         let typed_values = std::mem::take(&mut result.typed_values).into_vec();
-        let raw_values = std::mem::take(&mut result.values).into_vec();
         let guard_value_operand = result.guard_value_operand;
         // llmodel.py grab_exc_value: the pending exception captured at
         // guard failure travels with the GuardFailure outcome so the
@@ -9967,7 +9971,7 @@ mod tests {
             .meta
             .run_compiled_detailed(green_key, &[0])
             .expect("guard should fail");
-        let fail_values = failure.values.clone();
+        let fail_values = crate::compile::raw_exit_values(&failure.typed_values);
         let descr_arc = std::sync::Arc::clone(&failure.descr_arc);
         drop(failure);
 

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -7599,6 +7599,34 @@ impl<S: JitState> JitDriver<S> {
         self.runnable_procedure_token(green_key).is_some()
     }
 
+    /// [`Self::resolve_cell_key`] and [`Self::runnable_procedure_token`] from
+    /// one walk of the cell chain.
+    ///
+    /// The two together are what a door holding a raw bucket hash asks: which
+    /// cell do my greens own, and does that cell have code to enter. Asked
+    /// separately they walk the chain twice for the same cell — see
+    /// [`MetaInterp::resolved_entry_procedure_token`]. The answer is identical
+    /// to resolving first and then asking; this only stops paying for the
+    /// second walk.
+    ///
+    /// The resolved key travels back with the token because a caller that goes
+    /// on to run needs it, and because the `compiled_loops` half of the
+    /// predicate is keyed by it.
+    #[inline]
+    pub fn resolved_runnable_procedure_token(
+        &self,
+        green_key_hash: u64,
+        make_green_key: impl FnOnce() -> GreenKey,
+    ) -> (u64, Option<std::sync::Arc<majit_backend::JitCellToken>>) {
+        let (cell_key, token) = self
+            .meta
+            .resolved_entry_procedure_token(green_key_hash, make_green_key);
+        (
+            cell_key,
+            token.filter(|_| self.meta.get_compiled_meta(cell_key).is_some()),
+        )
+    }
+
     /// The token [`Self::has_runnable_compiled_loop`] says yes about, handed
     /// back so a door can carry it into the run instead of resolving the cell a
     /// second time.

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -208,6 +208,12 @@ pub use jitdriver::{BackEdgeStageRepeats, back_edge_stage_passes, set_back_edge_
 // this probe: the frame build it prices is the backend's, so the count for that
 // one arm is set through `majit_backend` and only its loop is in the backend.
 pub use majit_backend::CompiledTraceInfo;
+/// The object a door carries from its entry decision into the run.
+///
+/// Re-exported because [`JitDriver::runnable_procedure_token`] and
+/// [`JitDriver::resolved_runnable_procedure_token`] hand one to callers
+/// outside this crate, which have no other way to name its type.
+pub use majit_backend::JitCellToken;
 #[cfg(feature = "__execute-stage-probe")]
 pub use majit_backend::deadframe::{frame_build_passes, set_frame_build_repeats};
 #[cfg(feature = "__execute-stage-probe")]

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -178,6 +178,7 @@ pub use call_descr::{
 pub use compile::{
     make_fail_descr, make_fail_descr_typed, make_finish_fail_descr_typed,
     make_resume_guard_descr_instance_next_foriter, make_resume_guard_descr_range_foriter,
+    raw_exit_values,
 };
 pub use io_buffer::{
     emit_commit_io, encode_decimal_i64, io_buffer_commit, io_buffer_discard, io_buffer_write,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11052,7 +11052,6 @@ impl<M: Clone> MetaInterp<M> {
             self.record_guard_failure_event(green_key, trace_id, fail_index, back_edge_poll);
         }
 
-        let exit_arity = exit_types.len();
         // FINISH descrs are singletons (`DONE_WITH_THIS_FRAME_DESCR_*` /
         // `EXIT_FRAME_WITH_EXCEPTION_DESCR_REF_CL`) with `trace_id == 0`
         // and `fail_index == u32::MAX`; they carry no per-trace exit
@@ -11106,31 +11105,7 @@ impl<M: Clone> MetaInterp<M> {
         {
             layout.exit_types.resize(exit_types.len(), Type::Int);
         }
-        let mut values = ExitRawValues::with_capacity(exit_arity);
-        let mut typed_values = ExitValues::with_capacity(exit_arity);
-        for (i, &tp) in exit_types.iter().enumerate() {
-            match tp {
-                Type::Int => {
-                    let value = self.backend.get_int_value(&frame, i);
-                    values.push(value);
-                    typed_values.push(Value::Int(value));
-                }
-                Type::Ref => {
-                    let value = self.backend.get_ref_value(&frame, i);
-                    values.push(value.as_usize() as i64);
-                    typed_values.push(Value::Ref(value));
-                }
-                Type::Float => {
-                    let value = self.backend.get_float_value(&frame, i);
-                    values.push(value.to_bits() as i64);
-                    typed_values.push(Value::Float(value));
-                }
-                Type::Void => {
-                    values.push(0);
-                    typed_values.push(Value::Void);
-                }
-            }
-        }
+        let typed_values = Self::decode_exit_slots(&self.backend, &frame, exit_types);
         let savedata = self.backend.get_savedata_ref(&frame);
         // pyjitpl.py:3119-3123: exc_class = ptr2int(exception_obj.typeptr)
         let exc_value_ref = self.backend.grab_exc_value(&frame);
@@ -11147,7 +11122,6 @@ impl<M: Clone> MetaInterp<M> {
         };
 
         Some(CompileResult {
-            values,
             typed_values,
             meta,
             fail_index,
@@ -11218,41 +11192,32 @@ impl<M: Clone> MetaInterp<M> {
 
     /// `compile.py _DoneWithThisFrameDescr.get_result` and
     /// `handle_fail`'s exit read: decode a returned frame's exit slots into the
-    /// raw and typed lists every consumer of a compiled run reads.
+    /// typed list every consumer of a compiled run reads.
     ///
     /// The slot types come from the descr the run ended on, so this is the one
     /// step both outcomes of a compiled entry share.
+    ///
+    /// Only the typed list is built. The machine-word list beside it used to be
+    /// built here too and travelled out on the result, but its four readers are
+    /// all on the guard-failure and detailed-run paths, so a steady finish exit
+    /// built and dropped one per entry; they call [`raw_exit_values`] on the
+    /// typed list instead, which is [`Value::as_raw_i64`] per slot and loses
+    /// nothing.
     fn decode_exit_slots(
         backend: &BackendImpl,
         frame: &majit_backend::DeadFrame,
         exit_types: &[Type],
-    ) -> (ExitRawValues, ExitValues) {
-        let mut values = ExitRawValues::with_capacity(exit_types.len());
+    ) -> ExitValues {
         let mut typed_values = ExitValues::with_capacity(exit_types.len());
         for (i, &tp) in exit_types.iter().enumerate() {
-            match tp {
-                Type::Int => {
-                    let value = backend.get_int_value(frame, i);
-                    values.push(value);
-                    typed_values.push(Value::Int(value));
-                }
-                Type::Ref => {
-                    let value = backend.get_ref_value(frame, i);
-                    values.push(value.as_usize() as i64);
-                    typed_values.push(Value::Ref(value));
-                }
-                Type::Float => {
-                    let value = backend.get_float_value(frame, i);
-                    values.push(value.to_bits() as i64);
-                    typed_values.push(Value::Float(value));
-                }
-                Type::Void => {
-                    values.push(0);
-                    typed_values.push(Value::Void);
-                }
-            }
+            typed_values.push(match tp {
+                Type::Int => Value::Int(backend.get_int_value(frame, i)),
+                Type::Ref => Value::Ref(backend.get_ref_value(frame, i)),
+                Type::Float => Value::Float(backend.get_float_value(frame, i)),
+                Type::Void => Value::Void,
+            });
         }
-        (values, typed_values)
+        typed_values
     }
 
     /// `warmstate.py execute_assembler(loop_token, *args)`: the run
@@ -11342,11 +11307,11 @@ impl<M: Clone> MetaInterp<M> {
         let exit_types: &[Type] = descr.fail_arg_types();
         // The exit slots are read for both outcomes, so they are decoded before
         // the split rather than once in each arm.
-        let (values, typed_values) = Self::decode_exit_slots(&self.backend, &frame, exit_types);
+        let typed_values = Self::decode_exit_slots(&self.backend, &frame, exit_types);
         // The deadframe decode, amplified. It READS the frame the run returned
-        // and builds two fresh lists; it does not touch the frame, so it
-        // repeats. Each pass drops what it built, which is the same drop the
-        // shipping pass eventually pays for its own.
+        // and builds a fresh list; it does not touch the frame, so it repeats.
+        // Each pass drops what it built, which is the same drop the shipping
+        // pass eventually pays for its own.
         #[cfg(feature = "__execute-stage-probe")]
         {
             count_execute_stage_passes(ExecuteStage::Decode, stage_repeats.decode);
@@ -11391,7 +11356,6 @@ impl<M: Clone> MetaInterp<M> {
             // and JUMP arms have returned, so a layout built here would be
             // copied out of this result and dropped without a reader.
             return CompileResult {
-                values,
                 typed_values,
                 meta,
                 fail_index,
@@ -11483,7 +11447,6 @@ impl<M: Clone> MetaInterp<M> {
         };
 
         CompileResult {
-            values,
             typed_values,
             meta,
             fail_index,
@@ -12272,6 +12235,28 @@ impl<M: Clone> MetaInterp<M> {
         self.warm_state
             .get_procedure_token(green_key)
             .filter(|token| token.has_compiled_code())
+    }
+
+    /// [`Self::resolve_cell_key`] and [`Self::entry_procedure_token`] from one
+    /// walk of the cell chain, reporting the key it resolved beside the token.
+    ///
+    /// A door holding a raw bucket hash owes both — the resolve, so its
+    /// decision is about the cell its greens own, and the token, so the run it
+    /// hands on enters that same cell's code. Asking for them separately walks
+    /// the chain twice; see [`WarmState::resolved_cell_procedure_token`].
+    ///
+    /// The key comes back because the second conjunct of the runnable predicate
+    /// reads `compiled_loops`, which is indexed by that key and is not a cell
+    /// walk, so the caller still needs it.
+    pub fn resolved_entry_procedure_token(
+        &self,
+        green_key_hash: u64,
+        make_green_key: impl FnOnce() -> majit_ir::GreenKey,
+    ) -> (u64, Option<std::sync::Arc<JitCellToken>>) {
+        let (cell_key, token) = self
+            .warm_state
+            .resolved_cell_procedure_token(green_key_hash, make_green_key);
+        (cell_key, token.filter(|token| token.has_compiled_code()))
     }
 
     /// [`Self::has_compiled_loop`] with both flag reads removed, for pricing
@@ -14814,7 +14799,7 @@ impl<M: Clone> MetaInterp<M> {
         let fail_index = result.fail_index;
         let trace_id = result.trace_id;
         let is_finish = result.is_finish;
-        let values = result.values.to_vec();
+        let values = crate::compile::raw_exit_values(&result.typed_values).into_vec();
         let typed_values = result.typed_values.clone();
         let savedata = result.savedata;
         let exception = result.exception.clone();

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -12248,14 +12248,18 @@ impl<M: Clone> MetaInterp<M> {
     /// The key comes back because the second conjunct of the runnable predicate
     /// reads `compiled_loops`, which is indexed by that key and is not a cell
     /// walk, so the caller still needs it.
+    /// `gate` runs on the resolved key before the token is read — see
+    /// [`WarmState::resolved_cell_procedure_token`] for why a caller would
+    /// want that.
     pub fn resolved_entry_procedure_token(
         &self,
         green_key_hash: u64,
         make_green_key: impl FnOnce() -> majit_ir::GreenKey,
+        gate: impl FnOnce(u64) -> bool,
     ) -> (u64, Option<std::sync::Arc<JitCellToken>>) {
-        let (cell_key, token) = self
-            .warm_state
-            .resolved_cell_procedure_token(green_key_hash, make_green_key);
+        let (cell_key, token) =
+            self.warm_state
+                .resolved_cell_procedure_token(green_key_hash, make_green_key, gate);
         (cell_key, token.filter(|token| token.has_compiled_code()))
     }
 

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -2919,10 +2919,23 @@ impl WarmEnterState {
     /// key filed under a different bucket, so the token read has to go through
     /// [`Self::get_procedure_token`], which maps it. On an ambiguous bucket the
     /// greens are what settle it, exactly as [`Self::resolve_cell_key`] says.
+    /// `gate` runs on the resolved key, BEFORE the token is read.
+    ///
+    /// Reading a token is a `Weak::upgrade` and the `Arc` drop that answers it
+    /// — one atomic each. A caller whose real question is a conjunction of that
+    /// read and something cheaper about the same key wants the cheap half
+    /// first, and cannot have it while the resolve and the read are one step:
+    /// the cheap half needs the resolved key, which only the walk produces.
+    ///
+    /// The resolve is unaffected — the key comes back whatever `gate` answers,
+    /// and a refused gate reports no token, which is what the conjunction was
+    /// going to conclude anyway. A caller with no second conjunct passes a gate
+    /// that always accepts.
     pub fn resolved_cell_procedure_token(
         &self,
         hash: u64,
         make_key: impl FnOnce() -> GreenKey,
+        gate: impl FnOnce(u64) -> bool,
     ) -> (u64, Option<Arc<JitCellToken>>) {
         let mut count = 0usize;
         let mut found: Option<(&BaseJitCell, u64)> = None;
@@ -2939,11 +2952,22 @@ impl WarmEnterState {
             cell = c.next.as_deref();
         }
         match (count, found) {
-            (1, Some((cell, cell_key))) => (cell_key, cell.get_procedure_token()),
-            (0, _) => (hash, self.get_procedure_token(hash)),
+            (1, Some((cell, cell_key))) => (
+                cell_key,
+                gate(cell_key).then(|| cell.get_procedure_token()).flatten(),
+            ),
+            (0, _) => (
+                hash,
+                gate(hash).then(|| self.get_procedure_token(hash)).flatten(),
+            ),
             _ => {
                 let cell_key = self.cell_key_for(&make_key()).unwrap_or(hash);
-                (cell_key, self.get_procedure_token(cell_key))
+                (
+                    cell_key,
+                    gate(cell_key)
+                        .then(|| self.get_procedure_token(cell_key))
+                        .flatten(),
+                )
             }
         }
     }

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -2904,6 +2904,50 @@ impl WarmEnterState {
         }
     }
 
+    /// [`Self::resolve_cell_key`] and [`Self::get_procedure_token`] answered
+    /// from ONE walk of the bucket.
+    ///
+    /// A door that resolves a hash and then reads the resolved key's token
+    /// walked the same chain twice for the same cell: `cell_keys_at` finds the
+    /// cell and returns only its key, and `cell_by_key` then walks back to it.
+    /// The single-candidate case — the one a door is in whenever the bucket
+    /// holds exactly this key's cell — has the cell in hand at the moment the
+    /// count reaches one, so the token is read there.
+    ///
+    /// The other two cases are the second walk, unchanged. On a miss the key a
+    /// later install would take is `hash`, but `hash` may itself be a minted
+    /// key filed under a different bucket, so the token read has to go through
+    /// [`Self::get_procedure_token`], which maps it. On an ambiguous bucket the
+    /// greens are what settle it, exactly as [`Self::resolve_cell_key`] says.
+    pub fn resolved_cell_procedure_token(
+        &self,
+        hash: u64,
+        make_key: impl FnOnce() -> GreenKey,
+    ) -> (u64, Option<Arc<JitCellToken>>) {
+        let mut count = 0usize;
+        let mut found: Option<(&BaseJitCell, u64)> = None;
+        let mut cell = self.lookup_chain(hash);
+        while let Some(c) = cell {
+            if let Some(cell_key) = c.cell_key
+                && self.bucket_of(cell_key) == hash
+            {
+                count += 1;
+                if found.is_none() {
+                    found = Some((c, cell_key));
+                }
+            }
+            cell = c.next.as_deref();
+        }
+        match (count, found) {
+            (1, Some((cell, cell_key))) => (cell_key, cell.get_procedure_token()),
+            (0, _) => (hash, self.get_procedure_token(hash)),
+            _ => {
+                let cell_key = self.cell_key_for(&make_key()).unwrap_or(hash);
+                (cell_key, self.get_procedure_token(cell_key))
+            }
+        }
+    }
+
     /// The key of the one cell `hash` owns, if it owns exactly one.
     ///
     /// The entry path's allocation-free half. One candidate means the walk

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2202,7 +2202,8 @@ fn jit_blackhole_resume_from_guard(
 /// copy as a GC root for the duration of `blackhole_from_resumedata`.
 ///
 /// `deadframe` is an off-heap copy of the guard-failure values
-/// (`result.values`).  The collector is moving, so a minor collection
+/// (`raw_exit_values` over the result's exit slots).  The collector is moving,
+/// so a minor collection
 /// triggered while `blackhole_from_resumedata` lazily materializes virtuals
 /// (`getvirtual_ptr` → allocator) relocates the boxed objects and leaves the
 /// copy holding from-space pointers; `resume.rs::decode_ref` then reads

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7152,7 +7152,7 @@ fn drive_unpack_iterable_trace(
                         r.is_exit_frame_with_exception,
                         r.fail_index,
                         r.exit_layout.as_ref().is_some_and(|l| l.storage.is_some()),
-                        r.values.clone(),
+                        majit_metainterp::raw_exit_values(&r.typed_values),
                         r.exit_layout.clone(),
                         r.exception.exc_value,
                     )


### PR DESCRIPTION
Five commits on the JIT entry door in `majit-metainterp`. Four remove work the
door was doing per entry; the fifth records why one of them has no upstream
counterpart.

### What changed

- **`CompileResult`'s machine-word exit list is gone.** The struct carried both
  a typed `ExitValues` and a raw `i64` list built beside it. Every reader of the
  raw one is on the guard-failure or detailed-run path, so a steady finish exit
  built the list per entry, moved it through each by-value return, and dropped
  it unread. Those two readers now project it themselves via `raw_exit_values`.

- **A door's cell resolve and its token read come from one bucket walk.**
  `resolve_cell_key` found the cell and returned only its key; `cell_by_key`
  then walked the same chain back to the same cell. `resolved_cell_procedure_token`
  answers both from the single walk. The ambiguous-bucket and miss arms are
  unchanged, so the full-hash fallback is preserved.

- **The per-entry scratch is held behind a pointer.** `EntryScratch` is five
  `Vec` headers; the hand-out and hand-back are moves, so an inline slot moved
  120 bytes out of the field and the same back in on every entry, for buffers
  whose contents never move. A nested entry still gets independent storage.

- **The runnable predicate asks its cheap conjunct first.** The `compiled_loops`
  half is one hash probe; the token read is a `Weak::upgrade` plus the `Arc` drop
  that answers it. Both are pure reads of the same key, so the order does not
  change the answer — a key with no compiled entry now stops at the probe.

### Measurement

JIT entry fixed cost **135 ns → 107 ns** (−27 ns, −20%), consistent across three
interleaved OLD/NEW pairs. `E3 rest` (result construction and drops) went to
zero; `E3d` 13.2 → 10.0. Disassembly: −202 instructions across the three hot
entry functions.

Two of the four cuts measured **zero** on this box — the fused cell walk and the
conjunct reorder. They are kept on the grounds that neither is ever the more
expensive order, and the null result is recorded in their commit messages rather
than being presented as a win. This machine is shared and was running at load
averages of 15–415 during the work, so wall-clock absolutes are not usable;
grading was by interleaved same-binary A/B deltas and instruction counts.

### Verification

- `python3 pyre/check.py` — ALL PASSED: dynasm 502/502, cranelift 502/502,
  wasm 495/495, 3/3 backends, zero FAIL lines.
- `cargo check --workspace --all-targets --no-default-features --features dynasm,cpyext` — clean.
- `cargo fmt --all -- --check` and `scripts/check-majit-boundary.py` — both clean.
- Codex parity review over exactly this diff: sections 1, 2 and 3 all **None**;
  four structural adaptations, three of which already cited their upstream
  decision point in-code. The fourth is what the last commit adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011capRVFH2W4gwGQNWYCxEx

— *commented by Claude*
