### PR TITLE
 advance PyPy-faithful rtyper cutover (#346)

### DIFF
--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -40,6 +40,7 @@ cover the condition they diagnose.
 | `MAJIT_PROBE_SUBSCR` | OFF | Reports subscription tracing and dispatch decisions; remove when the relevant opcode paths have focused coverage. |
 | `MAJIT_PROFILE_DRAIN` | OFF | Profiles codewriter queue draining; remove when pipeline performance no longer needs phase attribution. |
 | `MAJIT_PROFILE_PIPELINE` | OFF | Reports translation phase time and memory; retain while translation performance needs phase attribution. |
+| `MAJIT_RTYPER_FRONTIER` | OFF | Makes the flowspace adapter resume past an unresolvable call and report the subject's whole call-wall set instead of the first; remove when the census no longer needs sole-blocker ranking. |
 | `MAJIT_RTYPER_VERBOSE` | OFF | Emits per-graph rtyper failure census rows; remove when all supported graphs translate or fail through stable classifications. |
 | `MAJIT_S9_PROBE` | OFF | Records optimizer stage-nine diagnostics; remove when that stage has focused invariant coverage. |
 | `MAJIT_SIZE_SHELL_OWNERS` | OFF | Reports owners of size-descriptor shells; remove when shell identity is enforced structurally. |

--- a/majit/majit-charon-reader/src/lib.rs
+++ b/majit/majit-charon-reader/src/lib.rs
@@ -326,6 +326,18 @@ impl Llbc {
     pub fn crate_name(&self) -> &str {
         &self.file.translated.crate_name
     }
+
+    /// The one pointer width, in bytes, shared by every extraction target in
+    /// this artefact.  RPython's translator carries this on its target system
+    /// configuration; Charon's ordered `target_information` rows are the
+    /// corresponding source of truth here.  Missing or conflicting rows stay
+    /// unresolved so width-sensitive lowerings fail closed.
+    pub fn target_pointer_size(&self) -> Option<u8> {
+        let mut rows = self.file.translated.target_information.iter();
+        let width = rows.next()?.value.target_pointer_size;
+        rows.all(|row| row.value.target_pointer_size == width)
+            .then_some(width)
+    }
 }
 
 /// Scan the raw LLBC bytes for every inline

--- a/majit/majit-charon-reader/src/schema.rs
+++ b/majit/majit-charon-reader/src/schema.rs
@@ -17,6 +17,12 @@ pub struct LlbcFile {
 #[derive(Debug, Deserialize)]
 pub struct Translated {
     pub crate_name: String,
+    /// Extraction target metadata. Charon serializes this as an ordered
+    /// sequence because one artefact can in principle name several targets;
+    /// preserving that shape lets consumers require one unambiguous pointer
+    /// width instead of silently choosing a map winner.
+    #[serde(default)]
+    pub target_information: Vec<TargetInformationEntry>,
     pub fun_decls: Vec<Option<crate::ullbc::FunDecl>>,
     /// Static / const items the MIR references via `Place::Global` and
     /// `Operand::Const(Global { ... })`. Indexed by `def_id` (the same
@@ -40,7 +46,7 @@ pub struct Translated {
     /// trait-associated-type resolution.
     ///
     /// Every other top-level surface Charon emits (`ordered_decls`,
-    /// `options`, `target_information`, `item_names`,
+    /// `options`, `item_names`,
     /// `assoc_item_names`, `short_names`, …) is intentionally not
     /// modelled: serde skips unknown fields without allocating, which
     /// both keeps the loader resilient to Charon's release-to-release
@@ -71,4 +77,16 @@ pub struct SourceFile {
     /// [`crate::Llbc::file_path`] so a variant this crate has never seen
     /// loads rather than failing the whole artefact.
     pub name: Value,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TargetInformationEntry {
+    pub key: String,
+    pub value: TargetInformation,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TargetInformation {
+    pub target_pointer_size: u8,
+    pub is_little_endian: bool,
 }

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -4831,8 +4831,19 @@ pub trait FieldDescr: Descr {
         ""
     }
 
-    /// descr.py:220-233 cache key (`fieldname`). Defaults to the
-    /// display name for descriptor implementations without a separate key.
+    /// The `fieldname` half of `get_field_descr`'s `cache[STRUCT][fieldname]`
+    /// key (`descr.py`). Defaults to the display name for descriptor
+    /// implementations without a separate key.
+    ///
+    /// That default is only right while every impl either overrides BOTH or
+    /// NEITHER. An impl overriding `field_name` alone would return the full
+    /// `STRUCT.fieldname` here and compare "apart" against a bare key in
+    /// `slot_holds_field`. Today that is latent: the two production impls are
+    /// `SimpleFieldDescr` (both) and `VRefFieldDescr` (neither, so both sides
+    /// are empty and the offset-only fallback applies), and every other
+    /// override is `#[cfg(test)]`. Defaulting to `""` instead would NOT be
+    /// the fix — the field lookups in this file compare `field_key()` to
+    /// select a field, and an empty key there collapses distinct fields.
     fn field_key(&self) -> &str {
         self.field_name()
     }

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -2631,17 +2631,26 @@ fn field_slot_disagreement(
 
 /// Whether `slot` and `field` name the same field.
 ///
-/// Both halves must agree. `field_key()` is `descr.py:220-233`'s fieldname
-/// cache key, and therefore the structural equivalent of the name on the one
-/// RPython FieldDescr object. `field_name()` is only its display label and may
-/// retain a different LLBC spelling of the same StructId
-/// (`option::Option.__discriminant` vs
-/// `core::option::Option.__discriminant`). The key is not always carried — the
-/// flattened inline aggregates (`ob_header`, an enum's `__pos_0`) reach here
-/// under the documented empty-name fallback — so it is compared only when
-/// both sides have one, and the offset is compared always. Neither alone is
-/// sufficient: a key can be absent, and a flattened layout puts an aggregate
-/// and its first leaf at one address (`heaptracker.py:68-69`).
+/// Both halves must agree. `field_key()` is the FIELDNAME half of
+/// `get_field_descr`'s cache key (`descr.py`, `cache[STRUCT][fieldname]`) —
+/// only the half: upstream keys on the owning STRUCT as well, and carries the
+/// owner on the descr itself as `name = '%s.%s' % (STRUCT._name, fieldname)`
+/// plus `get_parent_descr()`. This comparison deliberately drops the owner,
+/// because `field_name()` may retain a different LLBC spelling of the same
+/// StructId (`option::Option.__discriminant` vs
+/// `core::option::Option.__discriminant`) and comparing those answers "apart"
+/// for one class. The cost is that a field of one struct claiming a slot in
+/// another struct's descr is no longer detected when the two share a leaf
+/// name AND an offset. Converging means resolving the owner to a StructId —
+/// the same move `unique_trait_impl_roots` made — and comparing that
+/// alongside the leaf, not restoring the full-name comparison.
+///
+/// The key is not always carried — the flattened inline aggregates
+/// (`ob_header`, an enum's `__pos_0`) reach here under the documented
+/// empty-name fallback — so it is compared only when both sides have one, and
+/// the offset is compared always. Neither alone is sufficient: a key can be
+/// absent, and a flattened layout puts an aggregate and its first leaf at one
+/// address (`heaptracker.py:68-69`).
 pub(crate) fn slot_holds_field(slot: &dyn FieldDescr, field: &dyn FieldDescr) -> bool {
     let named_apart = !field.field_key().is_empty()
         && !slot.field_key().is_empty()

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -2631,17 +2631,21 @@ fn field_slot_disagreement(
 
 /// Whether `slot` and `field` name the same field.
 ///
-/// Both halves must agree. The name is the better key but is not always
-/// carried — the flattened inline aggregates (`ob_header`, an enum's `__pos_0`)
-/// reach here under the documented empty-name fallback — so the name is
-/// compared only when both sides have one, and the offset is compared always.
-/// Neither alone is sufficient: a name can be absent, and a flattened layout
-/// puts an aggregate and its first leaf at one address
-/// (`heaptracker.py:68-69`).
+/// Both halves must agree. `field_key()` is `descr.py:220-233`'s fieldname
+/// cache key, and therefore the structural equivalent of the name on the one
+/// RPython FieldDescr object. `field_name()` is only its display label and may
+/// retain a different LLBC spelling of the same StructId
+/// (`option::Option.__discriminant` vs
+/// `core::option::Option.__discriminant`). The key is not always carried — the
+/// flattened inline aggregates (`ob_header`, an enum's `__pos_0`) reach here
+/// under the documented empty-name fallback — so it is compared only when
+/// both sides have one, and the offset is compared always. Neither alone is
+/// sufficient: a key can be absent, and a flattened layout puts an aggregate
+/// and its first leaf at one address (`heaptracker.py:68-69`).
 pub(crate) fn slot_holds_field(slot: &dyn FieldDescr, field: &dyn FieldDescr) -> bool {
-    let named_apart = !field.field_name().is_empty()
-        && !slot.field_name().is_empty()
-        && slot.field_name() != field.field_name();
+    let named_apart = !field.field_key().is_empty()
+        && !slot.field_key().is_empty()
+        && slot.field_key() != field.field_key();
     !named_apart && slot.offset() == field.offset()
 }
 
@@ -3499,6 +3503,46 @@ mod tests {
             .with_flag(flag);
         fd.index_in_parent = index_in_parent;
         Arc::new(fd) as DescrRef
+    }
+
+    #[test]
+    fn slot_identity_uses_field_key_across_owner_spelling_aliases() {
+        let slot = majit_ir::SimpleFieldDescr::new_with_name(
+            0,
+            0,
+            8,
+            Type::Int,
+            false,
+            majit_ir::ArrayFlag::Signed,
+            "core::option::Option.__discriminant".to_string(),
+            "__discriminant".to_string(),
+        );
+        let alias = majit_ir::SimpleFieldDescr::new_with_name(
+            0,
+            0,
+            8,
+            Type::Int,
+            false,
+            majit_ir::ArrayFlag::Signed,
+            "option::Option.__discriminant".to_string(),
+            "__discriminant".to_string(),
+        );
+        assert!(
+            slot_holds_field(&slot, &alias),
+            "display aliases of one STRUCT.fieldname identify one RPython field descr"
+        );
+
+        let other = majit_ir::SimpleFieldDescr::new_with_name(
+            0,
+            0,
+            8,
+            Type::Int,
+            false,
+            majit_ir::ArrayFlag::Signed,
+            "core::option::Option.__pos_0".to_string(),
+            "__pos_0".to_string(),
+        );
+        assert!(!slot_holds_field(&slot, &other));
     }
 
     fn assign_positions(ops: &mut [Op]) {

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -1927,6 +1927,10 @@ impl Bookkeeper {
         self.getuniqueclassdef(&host)
     }
 
+    /// TODO: no upstream equivalent.  The closest thing upstream,
+    /// `Bookkeeper.getdesc` / `getuniqueclassdef` (`bookkeeper.py:168-172`,
+    /// `:353-363`), keys identity on the Python object; pyre has no such
+    /// object and keys on a qualname.
     /// Resolve the subclass `ClassDef` for one variant of a Rust enum —
     /// a subclass of the enum's discriminant-only base. Composes the canonical
     /// interning primitives rather than minting a parallel enum-class
@@ -1961,7 +1965,7 @@ impl Bookkeeper {
         let variant_host = self.intern_enum_variant_host(enum_root, variant_name);
         // Project the variant's OWN payload rows onto the subclass —
         // the RPython sum-type layout where each subclass carries its
-        // own fields (`rclass.py:82-88`), the base only the discriminant.
+        // own fields (`rclass.py:499-518`), the base only the discriminant.
         // A getattr on a narrowed `SomeInstance(variant)` then resolves
         // the payload on the variant via the MRO (variant → base), with
         // the variant's own field type.  The rows are registered under
@@ -2078,7 +2082,8 @@ impl Bookkeeper {
 
     /// Intern (first-mint-wins) and return the canonical variant-subclass
     /// `HostObject` for `{enum_root}::{variant_name}`, wiring the enum's
-    /// discriminant-only base as its sole `__bases__` (`rclass.py:82-88`).
+    /// discriminant-only base as its sole `__bases__` (`rclass.py:517-518`:
+    /// `self.rbase = getinstancerepr(rtyper, self.classdef.basedef, ...)`).
     ///
     /// Both the discriminant-narrowing path
     /// ([`Self::getuniqueclassdef_for_enum_variant`]) and the variant
@@ -2182,6 +2187,10 @@ impl Bookkeeper {
         Some(ktd)
     }
 
+    /// TODO: no upstream equivalent.  The closest thing upstream,
+    /// `Bookkeeper.getdesc` / `getuniqueclassdef` (`bookkeeper.py:168-172`,
+    /// `:353-363`), keys identity on the Python object; pyre has no such
+    /// object and keys on a qualname.
     /// Project one struct's registry rows into its `ClassDef.attrs`
     /// — the pass-2 body of [`Self::getuniqueclassdef_for_struct_root`].
     fn project_struct_rows(self: &Rc<Self>, n: &str) -> Result<(), AnnotatorError> {
@@ -2353,6 +2362,10 @@ impl Bookkeeper {
         Ok(())
     }
 
+    /// TODO: no upstream equivalent.  The closest thing upstream,
+    /// `Bookkeeper.getdesc` / `getuniqueclassdef` (`bookkeeper.py:168-172`,
+    /// `:353-363`), keys identity on the Python object; pyre has no such
+    /// object and keys on a qualname.
     /// Resolve a struct type-root name to its canonical host class
     /// `HostObject`, minting it on first sight and caching by name in
     /// [`Self::struct_root_classes`].  Because `HostObject`
@@ -2408,24 +2421,7 @@ impl Bookkeeper {
         let mut chain: Vec<String> = Vec::new();
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut base_host: Option<HostObject> = None;
-        // A Rust declaration reaches the annotator under three spellings:
-        // crate-included `pyre_object::unicodeobject::W_UnicodeObject`,
-        // crate-relative `unicodeobject::W_UnicodeObject`, and a dotted
-        // constructor qualname.  RPython keys all reads and constructors on
-        // the one live class object (`bookkeeper.py getdesc(cls)`), so strip
-        // exactly one registered local-crate prefix and normalize dots before
-        // the first cache lookup.  Keep the crate-relative module path: the
-        // chain walk below still sees `ob_header`/`base` and preserves the
-        // superclass, unlike collapsing directly to an ambiguous bare leaf.
-        let lookup = name.replace('.', "::");
-        let initial = lookup
-            .split_once("::")
-            .filter(|(root, _)| {
-                name.contains('.') || crate::local_crates::is_local_crate_root(root)
-            })
-            .map(|(_, rest)| rest.to_string())
-            .unwrap_or(lookup);
-        let mut cur = initial;
+        let mut cur = normalize_class_qualname(name);
         loop {
             let key = majit_ir::descr::canonical_struct_name(&cur);
             if let Some(existing) = self.struct_root_classes.borrow().get(&key) {
@@ -2445,7 +2441,7 @@ impl Bookkeeper {
                 let lookup = cur.replace('.', "::");
                 // An enum-variant key `{enum_base}::{variant}` subclasses its
                 // enum base — the discriminant-only sum-type root
-                // (`rclass.py:82-88`).  Checked before the header convention
+                // (`rclass.py:499-518`).  Checked before the header convention
                 // because a variant's first field is its payload, not a
                 // header: without this the session prologue
                 // (`CallRegistry::ensure_session`), which pre-mints every
@@ -2516,6 +2512,10 @@ impl Bookkeeper {
         base_host.expect("chain holds at least `name` itself")
     }
 
+    /// TODO: no upstream equivalent.  The closest thing upstream,
+    /// `Bookkeeper.getdesc` / `getuniqueclassdef` (`bookkeeper.py:168-172`,
+    /// `:353-363`), keys identity on the Python object; pyre has no such
+    /// object and keys on a qualname.
     /// [`Self::intern_class_by_qualname`] with explicit `__bases__` for
     /// the first mint.  First-mint wins: a cache hit returns the
     /// existing class regardless of `bases`, so every site minting a
@@ -2527,7 +2527,14 @@ impl Bookkeeper {
         name: &str,
         bases: Vec<HostObject>,
     ) -> HostObject {
-        let key = majit_ir::descr::canonical_struct_name(name);
+        // Same normalization as [`Self::intern_class_by_qualname`]: both
+        // entry points answer one identity question, so they must derive one
+        // key.  Keying only the base through the strip splits every enum
+        // variant in two — `pyre_object::m::E` and `m::E` intern to one base
+        // but to `pyre_object::m::E::Some` and `m::E::Some` — which is the
+        // sibling-classdef split `intern_enum_variant_host`'s contract
+        // forbids.
+        let key = majit_ir::descr::canonical_struct_name(&normalize_class_qualname(name));
         if let Some(existing) = self.struct_root_classes.borrow().get(&key) {
             return existing.clone();
         }
@@ -2552,11 +2559,17 @@ impl Bookkeeper {
             .is_some_and(|reg| reg.fields.contains_key(name))
     }
 
-    /// True when type-root `root`'s registry rows include a field named
-    /// `name`.  The cutover's class-dict method population consults this
-    /// so a method member never shadows a same-named instance field — a
-    /// function source for a field attribute would union-conflict in
-    /// `generalize_attr`.
+    /// TODO: no upstream equivalent.  The closest thing upstream,
+    /// `Bookkeeper.getdesc` / `getuniqueclassdef` (`bookkeeper.py:168-172`,
+    /// `:353-363`), keys identity on the Python object; pyre has no such
+    /// object and keys on a qualname.
+    /// True when type-root `root` OWNS a field named `name`, or when any
+    /// variant of it does — the enum sum-type layout puts a payload row on
+    /// the variant, not on the discriminant-only base, so an owner-only test
+    /// would miss it (`owner_or_variant_has_field`, `front/semantic.rs`).
+    /// The cutover's class-dict method population consults this so a method
+    /// member never shadows a same-named instance field — a function source
+    /// for a field attribute would union-conflict in `generalize_attr`.
     pub fn struct_root_has_field(&self, root: &str, name: &str) -> bool {
         self.struct_fields
             .borrow()
@@ -2657,7 +2670,7 @@ impl Bookkeeper {
             // the registered-struct arm below produces `Impossible` and
             // blocks `ConstantData::Str.value`.
             // `BytesBlock` is pyre's concrete storage port of RPython `STR`:
-            // a length header followed by the variable-sized `chars` array.
+            // a `hash` header (`STR.become(GcStruct('rpy_string', ('hash', Signed), ...)`, `rstr.py:1226-1228`) followed by the `chars` array, whose length is the array's own length word.
             // `bytes_block_chars` folds the Rust raw-slice view back to this
             // owner, so the owner must carry the same `SomeString` annotation
             // as the slice it represents, not a nominal Rust-struct class.
@@ -3789,6 +3802,34 @@ impl Default for Bookkeeper {
     }
 }
 
+/// One spelling rule for the class cache key, shared by
+/// [`Bookkeeper::intern_class_by_qualname`] and
+/// [`Bookkeeper::intern_class_by_qualname_with_bases`].
+///
+/// A Rust declaration reaches the annotator under three spellings:
+/// crate-included `pyre_object::unicodeobject::W_UnicodeObject`,
+/// crate-relative `unicodeobject::W_UnicodeObject`, and a dotted constructor
+/// qualname.  RPython keys all reads and constructors on the one live class
+/// object (`bookkeeper.py:361-363` — `obj_key = Constant(pyobj)`), so strip
+/// exactly one registered local-crate prefix and normalize dots.
+///
+/// Strip only while a module path survives.  Collapsing
+/// `pyre_object::PyObject` to the bare `PyObject` is what
+/// `harden_duplicate_leaf_metadata` exists to undo — the chain walk needs
+/// `ob_header` / `base` to reach the superclass, and a bare leaf collides
+/// across modules.
+pub(crate) fn normalize_class_qualname(name: &str) -> String {
+    let lookup = name.replace('.', "::");
+    lookup
+        .split_once("::")
+        .filter(|(root, rest)| {
+            rest.contains("::")
+                && (name.contains('.') || crate::local_crates::is_local_crate_root(root))
+        })
+        .map(|(_, rest)| rest.to_string())
+        .unwrap_or(lookup)
+}
+
 /// Walk `field_ty`'s type-string structure and collect every bare-named
 /// type that the `StructFieldRegistry` recognises.  Used by
 /// [`Bookkeeper::getuniqueclassdef_for_struct_root`]'s pass-1 discovery
@@ -4537,7 +4578,7 @@ mod tests {
     }
 
     #[test]
-    fn pyobjectref_field_alias_projects_to_pyobject_class_identity() {
+    fn struct_root_alias_and_registered_root_share_one_classdef() {
         use crate::annotator::model::SomeValue;
         use crate::front::StructFieldRegistry;
 
@@ -4557,11 +4598,11 @@ mod tests {
             panic!("PyObjectRef must project to the PyObject instance annotation")
         };
         let alias_class = alias_item.classdef.expect("typed PyObjectRef classdef");
-        let pyobject_class = bk
+        let root_classdef = bk
             .getuniqueclassdef_for_struct_root("pyobject::PyObject")
             .expect("PyObject classdef");
         assert!(
-            Rc::ptr_eq(&alias_class, &pyobject_class),
+            Rc::ptr_eq(&alias_class, &root_classdef),
             "the source alias and registered PyObject root must share one ClassDef"
         );
 
@@ -4575,7 +4616,7 @@ mod tests {
             array_item
                 .classdef
                 .as_ref()
-                .is_some_and(|classdef| Rc::ptr_eq(classdef, &pyobject_class))
+                .is_some_and(|classdef| Rc::ptr_eq(classdef, &root_classdef))
         );
 
         let SomeValue::List(qualified_array) =
@@ -4590,12 +4631,12 @@ mod tests {
             qualified_item
                 .classdef
                 .as_ref()
-                .is_some_and(|classdef| Rc::ptr_eq(classdef, &pyobject_class))
+                .is_some_and(|classdef| Rc::ptr_eq(classdef, &root_classdef))
         );
     }
 
     #[test]
-    fn qualified_fixed_object_array_projects_typed_pyobject_items() {
+    fn qualified_fixed_object_array_projects_typed_instance_items() {
         use crate::annotator::model::SomeValue;
         use crate::front::StructFieldRegistry;
 
@@ -4633,7 +4674,7 @@ mod tests {
 
     #[test]
     #[ignore]
-    fn real_llbc_pyframe_locals_array_projects_typed_pyobject_items() {
+    fn real_llbc_pyframe_locals_array_projects_typed_instance_items() {
         use crate::annotator::model::SomeValue;
         use majit_charon_reader::Llbc;
 
@@ -4887,7 +4928,8 @@ mod tests {
         // `intern_enum_variant_host`) and the discriminant-NARROWING path
         // (`getuniqueclassdef_for_enum_variant`) must resolve the SAME
         // class object — RPython's single-class-per-variant identity
-        // (`rclass.py:82-88`) — and it must carry the variant's payload
+        // (`ClassDesc.getuniqueclassdef`, `classdesc.py:699-702`) — and it
+        // must carry the variant's payload
         // attr.  Before the unification the ctor minted a dotted-qualname
         // sibling classdef with no payload attrs.
         use crate::front::StructFieldRegistry;

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -4525,14 +4525,14 @@ mod tests {
         let bk = bk();
         assert!(
             matches!(
-                bk.project_pyre_field_type("BytesBlock"),
+                bk.project_struct_field_type("BytesBlock"),
                 SomeValue::String(_)
             ),
             "BytesBlock is the owner of RPython STR.chars, not a nominal instance"
         );
         assert!(
             matches!(
-                bk.project_pyre_field_type("*const BytesBlock"),
+                bk.project_struct_field_type("*const BytesBlock"),
                 SomeValue::String(_)
             ),
             "a BytesBlock pointer must keep the same string annotation"

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -1982,7 +1982,22 @@ impl Bookkeeper {
             let Some(n) = next else { break };
             self.project_struct_rows(&n)?;
         }
-        self.getuniqueclassdef(&variant_host)
+        let classdef = self.getuniqueclassdef(&variant_host)?;
+        // Every payload row on a Rust enum variant is assigned by that
+        // variant's constructor. In RPython terms these are mutable instance
+        // attributes, not readonly class attributes: `Attribute.modified`
+        // runs during annotation before `InstanceRepr._setup_repr` builds its
+        // field table. Pyre pre-mints variants at session start so inheritance
+        // ids stay stable; mark the projected payload rows at that same point
+        // to preserve RPython's attrs-before-repr ordering even when another
+        // subject caches the repr before this constructor is annotated.
+        {
+            let mut classdef_mut = classdef.borrow_mut();
+            for attr in classdef_mut.attrs.values_mut() {
+                attr.modified(Some(&classdef))?;
+            }
+        }
+        Ok(classdef)
     }
 
     /// Register a trait family for receiver-driven method dispatch: a base
@@ -2171,11 +2186,13 @@ impl Bookkeeper {
     /// — the pass-2 body of [`Self::getuniqueclassdef_for_struct_root`].
     fn project_struct_rows(self: &Rc<Self>, n: &str) -> Result<(), AnnotatorError> {
         // A monomorphised generic spelling (`Option<*mut PyObject>`,
-        // `Result<Tuple>`) shares the bare template's rows; the registry
-        // only carries the un-suffixed key (`Option`/`option::Option`).
-        // Strip the `<…>` argument span so the lookup resolves under the
-        // template key — matching `StructFieldRegistry::lookup_fields`,
-        // which the bare-`reg.fields.get` here bypasses.
+        // `Result<Tuple>`) normally shares the bare template's rows. A
+        // payload variant is different: `register_ref_enum_instantiation_rows`
+        // publishes an exact suffixed key with its substituted payload type.
+        // Consult that exact key first, then strip the `<…>` argument span
+        // only as the template fallback — matching
+        // `StructFieldRegistry::lookup_fields` while preserving the concrete
+        // variant row RPython's completed ClassDef would carry.
         //
         // A per-shape positional aggregate (`Tuple<FrameDebugData>` or
         // `Array<PyObjectRef;2>`) is the exception: it has no template — its
@@ -2210,9 +2227,11 @@ impl Bookkeeper {
                 {
                     r.fields.get(n).cloned()
                 } else {
-                    r.fields
-                        .get(majit_ir::descr::strip_generic_args(n).as_ref())
-                        .cloned()
+                    r.fields.get(n).cloned().or_else(|| {
+                        r.fields
+                            .get(majit_ir::descr::strip_generic_args(n).as_ref())
+                            .cloned()
+                    })
                 }
             }) {
                 Some(f) => f,
@@ -2234,30 +2253,26 @@ impl Bookkeeper {
         }
         // A per-instantiation variant carries concrete payload rows keyed
         // under its full `<…>`-suffixed spelling
-        // (`Option<*mut PyObject>::Some` → `__pos_0: *mut PyObject`,
-        // registered by `register_ref_enum_instantiation_rows`), while the
-        // stripped template row is the generic `??TypeVar` that projects to
-        // `Impossible`.  Substitute a template field's type with the exact
-        // key's concrete type ONLY for a RAW-POINTER payload: a pointer
-        // resolves to its pointee struct root (`PyObject`) independent of
-        // spelling, so projecting it here needs no constructor to flow the
-        // value and cannot collide with a differently-spelled named-ADT
-        // payload at `generalize_attr`.  A named heap-ADT payload
-        // (`Result<_, DictKeyError>::Err`) keeps the template `Impossible`
-        // and is filled by the constructor's `setattr` under its own
-        // qualname spelling, unchanged.  Without this, a residual-return
-        // `Option<*mut PyObject>` narrowed to `SomeInstance(Some)` re-blocks
-        // its `__pos_0` payload read on an `Impossible` attr.
-        // The narrowed `Option<*mut PyObject>` residual result is the consumer
-        // of the per-instantiation raw-pointer payload row, so project the two
-        // as one slice.
+        // (`Option<Vec<u8>>::Some` → `__pos_0: Vec<u8>`, registered by
+        // `register_ref_enum_instantiation_rows`), while the stripped
+        // template row is the generic `??TypeVar` that projects to
+        // `Impossible`. Substitute that unresolved template field with the
+        // exact row. The registrar has already rejected unresolved,
+        // multi-word, and layout-ambiguous payloads, so every row reaching
+        // this point is safe to project.
+        //
+        // This ordering is load-bearing parity with RPython:
+        // `RPythonTyper.specialize` runs only after annotation has completed
+        // every `ClassDef.attrs` entry. Pyre's incremental session can cache
+        // an `InstanceRepr` before a later constructor flows its `setattr`;
+        // pre-projecting the concrete row keeps repr setup independent of
+        // subject order instead of relying on that constructor side effect.
         {
             let guard = self.struct_fields.borrow();
             if let Some(exact) = guard.as_ref().and_then(|r| r.fields.get(n)) {
                 for (fname, fty) in &mut fields {
                     if let Some((_, exact_ty)) = exact.iter().find(|(en, _)| en == fname) {
-                        let t = exact_ty.trim();
-                        if t.starts_with("*mut ") || t.starts_with("*const ") {
+                        if fty.contains("??") && !exact_ty.contains("??") {
                             *fty = exact_ty.clone();
                         }
                     }
@@ -2365,8 +2380,10 @@ impl Bookkeeper {
     /// one struct intern to one `HostObject` — name strings are a
     /// resolution input, never the identity itself
     /// (`getuniqueclassdef(cls)` keys by class object,
-    /// bookkeeper.py:339).  Dotted qualnames pass through unchanged; a
-    /// bare leaf whose origin was tombstoned by
+    /// bookkeeper.py:168).  Crate-included `::` names and dotted
+    /// constructor qualnames shed exactly one local-crate segment and
+    /// converge on the crate-relative key before this walk; a bare leaf
+    /// whose origin was tombstoned by
     /// `harden_duplicate_leaf_metadata` stays unresolved and keeps an
     /// attrs-empty classdef because the field registry withdrew the
     /// bare alias.
@@ -2391,46 +2408,23 @@ impl Bookkeeper {
         let mut chain: Vec<String> = Vec::new();
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut base_host: Option<HostObject> = None;
-        // A normal Rust struct constructor arrives from
-        // `SyntheticTransparentCtor` under Charon's dotted,
-        // crate-included spelling (`pyre_object.celldict.VersionTag`), while
-        // field projection names the same declaration by the crate-relative
-        // registry identity (`celldict::VersionTag`).  RPython keys both on
-        // the one class object, so normalize the constructor spelling before
-        // the first cache lookup when the declaration is a plain non-header
-        // struct.  Header-bearing classes must keep the existing chain walk:
-        // first-minting them directly under the leaf identity loses their
-        // `ob_header`/`base` superclass, the measured W_Root cascade described
-        // in `annotator::model::same_struct_identity`.
-        let initial = self
-            .struct_fields
-            .borrow()
-            .as_ref()
-            .and_then(|reg| {
-                if name.contains("::") || !name.contains('.') {
-                    return None;
-                }
-                let lookup = name.replace('.', "::");
-                if reg.is_enum_base(&lookup)
-                    || lookup
-                        .rsplit_once("::")
-                        .is_some_and(|(parent, _)| reg.is_enum_base(parent))
-                {
-                    return None;
-                }
-                let (first_name, _) = reg.fields.get(&lookup)?.first()?;
-                if first_name == "ob_header" || first_name == "base" {
-                    return None;
-                }
-                Some(
-                    lookup
-                        .split_once("::")
-                        .map(|(_, rest)| rest)
-                        .unwrap_or(&lookup)
-                        .to_string(),
-                )
+        // A Rust declaration reaches the annotator under three spellings:
+        // crate-included `pyre_object::unicodeobject::W_UnicodeObject`,
+        // crate-relative `unicodeobject::W_UnicodeObject`, and a dotted
+        // constructor qualname.  RPython keys all reads and constructors on
+        // the one live class object (`bookkeeper.py getdesc(cls)`), so strip
+        // exactly one registered local-crate prefix and normalize dots before
+        // the first cache lookup.  Keep the crate-relative module path: the
+        // chain walk below still sees `ob_header`/`base` and preserves the
+        // superclass, unlike collapsing directly to an ambiguous bare leaf.
+        let lookup = name.replace('.', "::");
+        let initial = lookup
+            .split_once("::")
+            .filter(|(root, _)| {
+                name.contains('.') || crate::local_crates::is_local_crate_root(root)
             })
-            .unwrap_or_else(|| name.to_string());
+            .map(|(_, rest)| rest.to_string())
+            .unwrap_or(lookup);
         let mut cur = initial;
         loop {
             let key = majit_ir::descr::canonical_struct_name(&cur);
@@ -2444,16 +2438,10 @@ impl Bookkeeper {
             seen.insert(cur.rsplit("::").next().unwrap_or(&cur).to_string());
             chain.push(cur.clone());
             let next = self.struct_fields.borrow().as_ref().and_then(|reg| {
-                // A constructor mints its class under the dot-joined,
-                // crate-included qualname (`pyre_object.intobject.
-                // W_IntObject`, flowspace_adapter `SyntheticTransparentCtor`
-                // arm), but `struct_fields` is keyed by the `::` `name_path`
-                // (`pyre_object::intobject::W_IntObject`) and the bare leaf.
-                // Reduce `.`→`::` for the registry lookups ONLY, so the
-                // header chain resolves the base for a dot-joined ctor
-                // qualname too — the classdef cache key (`key` above) keeps
-                // the raw spelling, so this seeds the base without collapsing
-                // the ctor class onto the `::`-spelled field-read class.
+                // Constructor, crate-included, and crate-relative spellings
+                // have already converged before entering the walk.  Keep this
+                // reduction local too because subsequent header/enum links
+                // can still be emitted as dotted registry names.
                 let lookup = cur.replace('.', "::");
                 // An enum-variant key `{enum_base}::{variant}` subclasses its
                 // enum base — the discriminant-only sum-type root
@@ -2489,7 +2477,16 @@ impl Bookkeeper {
                         return Some(bare_leaf.to_string());
                     }
                 }
-                let (first_name, first_ty) = reg.fields.get(&lookup)?.first()?;
+                // The registry publishes a full declaration path and a bare
+                // convenience alias.  `harden_duplicate_leaf_metadata`
+                // withdraws the latter when it is not injective, so falling
+                // back to it is the name-carrier equivalent of resolving one
+                // live class object and fails closed on duplicate leaves.
+                let rows = reg.fields.get(&lookup).or_else(|| {
+                    let leaf = lookup.rsplit("::").next()?;
+                    reg.fields.get(leaf)
+                })?;
+                let (first_name, first_ty) = rows.first()?;
                 // Only header-conventional first fields mark subclassing
                 // (`ob_header: PyObject` / `base: FrameBlock`).  A
                 // by-value first field of another registered type is
@@ -4724,6 +4721,46 @@ mod tests {
     }
 
     #[test]
+    fn header_struct_spellings_reuse_one_class_identity_and_base() {
+        use crate::front::StructFieldRegistry;
+
+        let previous_roots = crate::local_crates::local_crate_roots();
+        crate::local_crates::register_local_crate_roots(["fixture_crate".to_string()]);
+
+        let bk = bk();
+        let mut reg = StructFieldRegistry::default();
+        let rows = vec![
+            ("ob_header".to_string(), "PyObject".to_string()),
+            ("value".to_string(), "*mut Wtf8Buf".to_string()),
+        ];
+        reg.fields.insert(
+            "fixture_crate::unicodeobject::W_UnicodeObject".to_string(),
+            rows.clone(),
+        );
+        reg.fields.insert("W_UnicodeObject".to_string(), rows);
+        reg.fields.insert(
+            "PyObject".to_string(),
+            vec![("ob_type".to_string(), "*const PyType".to_string())],
+        );
+        bk.set_struct_fields(Rc::new(reg));
+
+        let from_field = bk.intern_class_by_qualname("unicodeobject::W_UnicodeObject");
+        let from_full =
+            bk.intern_class_by_qualname("fixture_crate::unicodeobject::W_UnicodeObject");
+        let from_ctor = bk.intern_class_by_qualname("fixture_crate.unicodeobject.W_UnicodeObject");
+        assert_eq!(from_field, from_full);
+        assert_eq!(from_field, from_ctor);
+
+        let classdef = bk.getuniqueclassdef(&from_field).expect("header classdef");
+        assert!(
+            classdef.borrow().basedef.is_some(),
+            "normalizing the class identity must retain its embedded-header base"
+        );
+
+        crate::local_crates::register_local_crate_roots(previous_roots);
+    }
+
+    #[test]
     fn getuniqueclassdef_for_enum_variant_subclasses_the_base() {
         use crate::annotator::model::{SomeInstance, SomeValue};
         use crate::front::StructFieldRegistry;
@@ -6804,6 +6841,20 @@ mod tests {
         let ok_cd = bk
             .getuniqueclassdef_for_enum_variant("Result<Vec<*mut PyObject>,PyErr>", "Ok")
             .expect("Result::Ok");
+        for (name, classdef) in [("Option::Some", &some_cd), ("Result::Ok", &ok_cd)] {
+            let attrs = classdef.borrow();
+            assert!(
+                matches!(
+                    attrs.attrs.get("__pos_0").map(|attr| &attr.s_value),
+                    Some(SomeValue::List(_))
+                ),
+                "{name} concrete Vec payload must be projected before repr setup"
+            );
+            assert!(
+                !attrs.attrs["__pos_0"].readonly,
+                "{name} constructor payload must be an instance field before repr setup"
+            );
+        }
         for (field, classdef) in [("__pos_0", some_cd.clone()), ("__pos_1", ok_cd.clone())] {
             ClassDef::generalize_attr(
                 &tuple_cd,

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -4592,15 +4592,18 @@ mod tests {
         );
         bk.set_struct_fields(Rc::new(reg));
 
-        let SomeValue::List(array) = bk.project_struct_field_type(
-            "*mut pyre_object::object_array::FixedObjectArray",
-        ) else {
+        let SomeValue::List(array) =
+            bk.project_struct_field_type("*mut pyre_object::object_array::FixedObjectArray")
+        else {
             panic!("qualified FixedObjectArray pointer must project to its item list")
         };
         let SomeValue::Instance(item) = array.listdef.s_value() else {
             panic!("FixedObjectArray item must be a PyObject instance")
         };
-        assert!(item.classdef.is_some(), "PyObject item must keep its ClassDef");
+        assert!(
+            item.classdef.is_some(),
+            "PyObject item must keep its ClassDef"
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -2659,7 +2659,14 @@ impl Bookkeeper {
             // exact annotation too.  Leaving the dependency-opaque name to
             // the registered-struct arm below produces `Impossible` and
             // blocks `ConstantData::Str.value`.
-            "String" | "str" | "Wtf8" | "Wtf8Buf" => return super::model::s_str0(),
+            // `BytesBlock` is pyre's concrete storage port of RPython `STR`:
+            // a length header followed by the variable-sized `chars` array.
+            // `bytes_block_chars` folds the Rust raw-slice view back to this
+            // owner, so the owner must carry the same `SomeString` annotation
+            // as the slice it represents, not a nominal Rust-struct class.
+            "String" | "str" | "Wtf8" | "Wtf8Buf" | "BytesBlock" => {
+                return super::model::s_str0();
+            }
             // `malachite_bigint::BigInt` is deliberately foreign and opaque
             // to translation.  Its sanctioned conversion seam is a residual
             // call, but the value occupying `ConstantData::Integer.value`
@@ -4508,6 +4515,27 @@ mod tests {
         assert!(
             Rc::ptr_eq(&code_cd, &template),
             "RPython has one CodeObject class, not per-generic classdefs"
+        );
+    }
+
+    #[test]
+    fn bytes_block_projects_to_rpython_string_storage() {
+        use crate::annotator::model::SomeValue;
+
+        let bk = bk();
+        assert!(
+            matches!(
+                bk.project_pyre_field_type("BytesBlock"),
+                SomeValue::String(_)
+            ),
+            "BytesBlock is the owner of RPython STR.chars, not a nominal instance"
+        );
+        assert!(
+            matches!(
+                bk.project_pyre_field_type("*const BytesBlock"),
+                SomeValue::String(_)
+            ),
+            "a BytesBlock pointer must keep the same string annotation"
         );
     }
 

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -2391,7 +2391,47 @@ impl Bookkeeper {
         let mut chain: Vec<String> = Vec::new();
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut base_host: Option<HostObject> = None;
-        let mut cur = name.to_string();
+        // A normal Rust struct constructor arrives from
+        // `SyntheticTransparentCtor` under Charon's dotted,
+        // crate-included spelling (`pyre_object.celldict.VersionTag`), while
+        // field projection names the same declaration by the crate-relative
+        // registry identity (`celldict::VersionTag`).  RPython keys both on
+        // the one class object, so normalize the constructor spelling before
+        // the first cache lookup when the declaration is a plain non-header
+        // struct.  Header-bearing classes must keep the existing chain walk:
+        // first-minting them directly under the leaf identity loses their
+        // `ob_header`/`base` superclass, the measured W_Root cascade described
+        // in `annotator::model::same_struct_identity`.
+        let initial = self
+            .struct_fields
+            .borrow()
+            .as_ref()
+            .and_then(|reg| {
+                if name.contains("::") || !name.contains('.') {
+                    return None;
+                }
+                let lookup = name.replace('.', "::");
+                if reg.is_enum_base(&lookup)
+                    || lookup
+                        .rsplit_once("::")
+                        .is_some_and(|(parent, _)| reg.is_enum_base(parent))
+                {
+                    return None;
+                }
+                let (first_name, _) = reg.fields.get(&lookup)?.first()?;
+                if first_name == "ob_header" || first_name == "base" {
+                    return None;
+                }
+                Some(
+                    lookup
+                        .split_once("::")
+                        .map(|(_, rest)| rest)
+                        .unwrap_or(&lookup)
+                        .to_string(),
+                )
+            })
+            .unwrap_or_else(|| name.to_string());
+        let mut cur = initial;
         loop {
             let key = majit_ir::descr::canonical_struct_name(&cur);
             if let Some(existing) = self.struct_root_classes.borrow().get(&key) {
@@ -2521,11 +2561,10 @@ impl Bookkeeper {
     /// function source for a field attribute would union-conflict in
     /// `generalize_attr`.
     pub fn struct_root_has_field(&self, root: &str, name: &str) -> bool {
-        self.struct_fields.borrow().as_ref().is_some_and(|reg| {
-            reg.fields
-                .get(root)
-                .is_some_and(|rows| rows.iter().any(|(field, _)| field == name))
-        })
+        self.struct_fields
+            .borrow()
+            .as_ref()
+            .is_some_and(|reg| reg.owner_or_variant_has_field(root, name))
     }
 
     /// TODO: no upstream equivalent.  Project a Rust type
@@ -2540,6 +2579,19 @@ impl Bookkeeper {
     /// entry; unknown bare names fall to `Impossible`.
     pub fn project_struct_field_type(self: &Rc<Self>, field_ty: &str) -> SomeValue {
         let t = field_ty.trim();
+        // `pyre_object::PyObjectRef` is a Rust type alias for
+        // `*mut pyobject::PyObject`.  Charon expands aliases in MIR type
+        // nodes, but the source-derived struct-field registry deliberately
+        // keeps the source spelling, so flexible-array tails such as
+        // `FixedObjectArray._items: [PyObjectRef; 0]` reach this projector
+        // with the alias still intact.  RPython has no alias object at this
+        // point: the corresponding `W_Root` array item is the root instance
+        // annotation itself.  Resolve the alias before the ordinary named
+        // struct arm so list item repr construction sees that same root
+        // `ClassDef`, rather than minting a classdef-less placeholder.
+        if t == "PyObjectRef" || t.ends_with("::PyObjectRef") {
+            return self.project_struct_field_type("pyobject::PyObject");
+        }
         // A raw-pointer field (`*const T` / `*mut T`) holds a one-word
         // pointer, not a `T`.  Projecting the pointee is right for an
         // aggregate target (`*mut Vec<T>` / `*mut Struct`): the structural
@@ -2737,7 +2789,11 @@ impl Bookkeeper {
         // array arm above to `SomeList(item=SomeInstance(PyObjectRef),
         // resized=false)`, giving a typed element rather than a
         // classdef-less stub.
-        if majit_ir::descr::canonical_struct_name(stripped) == "object_array::FixedObjectArray" {
+        let canonical_stripped = majit_ir::descr::canonical_struct_name(stripped);
+        if canonical_stripped == "FixedObjectArray"
+            || canonical_stripped == "object_array::FixedObjectArray"
+            || canonical_stripped.ends_with("::object_array::FixedObjectArray")
+        {
             let items_ty = self
                 .struct_fields
                 .borrow()
@@ -4453,6 +4509,187 @@ mod tests {
             Rc::ptr_eq(&code_cd, &template),
             "RPython has one CodeObject class, not per-generic classdefs"
         );
+    }
+
+    #[test]
+    fn pyobjectref_field_alias_projects_to_pyobject_class_identity() {
+        use crate::annotator::model::SomeValue;
+        use crate::front::StructFieldRegistry;
+
+        let bk = bk();
+        let mut reg = StructFieldRegistry::default();
+        reg.fields.insert(
+            "pyobject::PyObject".to_string(),
+            vec![("type_ptr".to_string(), "usize".to_string())],
+        );
+        reg.fields.insert(
+            "PyObject".to_string(),
+            reg.fields["pyobject::PyObject"].clone(),
+        );
+        bk.set_struct_fields(Rc::new(reg));
+
+        let SomeValue::Instance(alias_item) = bk.project_struct_field_type("PyObjectRef") else {
+            panic!("PyObjectRef must project to the PyObject instance annotation")
+        };
+        let alias_class = alias_item.classdef.expect("typed PyObjectRef classdef");
+        let pyobject_class = bk
+            .getuniqueclassdef_for_struct_root("pyobject::PyObject")
+            .expect("PyObject classdef");
+        assert!(
+            Rc::ptr_eq(&alias_class, &pyobject_class),
+            "the source alias and registered PyObject root must share one ClassDef"
+        );
+
+        let SomeValue::List(array) = bk.project_struct_field_type("[PyObjectRef; 0]") else {
+            panic!("a PyObjectRef array tail must project to a list")
+        };
+        let SomeValue::Instance(array_item) = array.listdef.s_value() else {
+            panic!("the projected array item must be a PyObject instance")
+        };
+        assert!(
+            array_item
+                .classdef
+                .as_ref()
+                .is_some_and(|classdef| Rc::ptr_eq(classdef, &pyobject_class))
+        );
+
+        let SomeValue::List(qualified_array) =
+            bk.project_struct_field_type("[pyre_object::PyObjectRef; 0]")
+        else {
+            panic!("a qualified PyObjectRef array tail must project to a list")
+        };
+        let SomeValue::Instance(qualified_item) = qualified_array.listdef.s_value() else {
+            panic!("the qualified array item must be a PyObject instance")
+        };
+        assert!(
+            qualified_item
+                .classdef
+                .as_ref()
+                .is_some_and(|classdef| Rc::ptr_eq(classdef, &pyobject_class))
+        );
+    }
+
+    #[test]
+    fn qualified_fixed_object_array_projects_typed_pyobject_items() {
+        use crate::annotator::model::SomeValue;
+        use crate::front::StructFieldRegistry;
+
+        let bk = bk();
+        let mut reg = StructFieldRegistry::default();
+        reg.fields.insert(
+            "pyre_object::object_array::FixedObjectArray".to_string(),
+            vec![
+                ("len".to_string(), "usize".to_string()),
+                (
+                    "_items".to_string(),
+                    "[pyre_object::PyObjectRef; 0]".to_string(),
+                ),
+            ],
+        );
+        reg.fields.insert(
+            "pyobject::PyObject".to_string(),
+            vec![("type_ptr".to_string(), "usize".to_string())],
+        );
+        bk.set_struct_fields(Rc::new(reg));
+
+        let SomeValue::List(array) = bk.project_struct_field_type(
+            "*mut pyre_object::object_array::FixedObjectArray",
+        ) else {
+            panic!("qualified FixedObjectArray pointer must project to its item list")
+        };
+        let SomeValue::Instance(item) = array.listdef.s_value() else {
+            panic!("FixedObjectArray item must be a PyObject instance")
+        };
+        assert!(item.classdef.is_some(), "PyObject item must keep its ClassDef");
+    }
+
+    #[test]
+    #[ignore]
+    fn real_llbc_pyframe_locals_array_projects_typed_pyobject_items() {
+        use crate::annotator::model::SomeValue;
+        use majit_charon_reader::Llbc;
+
+        let interpreter_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let object_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let interpreter = Llbc::load(interpreter_path).expect("load real interpreter LLBC");
+        let object = Llbc::load(object_path).expect("load real object LLBC");
+        let program = crate::front::mir::build_semantic_program_from_llbcs_with_static_addrs_and_function_names(
+            &[object, interpreter],
+            crate::HostStaticAddrs::default(),
+            &["pyframe"],
+            &["__metadata_only__"],
+        )
+        .expect("derive real interpreter metadata");
+        let field_ty = program
+            .struct_fields
+            .field_type("PyFrame", "locals_cells_stack_w")
+            .expect("PyFrame locals array field")
+            .to_string();
+        let fixed_array_rows: Vec<_> = program
+            .struct_fields
+            .fields
+            .iter()
+            .filter(|(key, _)| key.ends_with("FixedObjectArray"))
+            .map(|(key, rows)| (key.clone(), rows.clone()))
+            .collect();
+        majit_ir::descr::register_struct_origins(program.struct_origins);
+
+        let bk = bk();
+        bk.set_struct_fields(Rc::new(program.struct_fields));
+        let pyframe = bk
+            .getuniqueclassdef_for_struct_root("PyFrame")
+            .expect("PyFrame classdef");
+        let locals = pyframe
+            .borrow()
+            .attrs
+            .get("locals_cells_stack_w")
+            .expect("locals array attr")
+            .s_value
+            .clone();
+        let SomeValue::List(array) = locals else {
+            panic!(
+                "{field_ty} must project to a list, got {locals:?}; registry rows: {fixed_array_rows:?}"
+            )
+        };
+        let SomeValue::Instance(item) = array.listdef.s_value() else {
+            panic!("{field_ty} item must be an instance")
+        };
+        assert!(
+            item.classdef.is_some(),
+            "{field_ty} item must retain the PyObject ClassDef"
+        );
+    }
+
+    #[test]
+    fn nonheader_dotted_constructor_reuses_crate_relative_struct_identity() {
+        use crate::front::StructFieldRegistry;
+
+        let bk = bk();
+        let mut reg = StructFieldRegistry::default();
+        let rows = vec![("__pos_0".to_string(), "u64".to_string())];
+        reg.fields.insert(
+            "pyre_object::celldict::VersionTag".to_string(),
+            rows.clone(),
+        );
+        reg.fields.insert("VersionTag".to_string(), rows);
+        bk.set_struct_fields(Rc::new(reg));
+
+        let from_field = bk.intern_class_by_qualname("celldict::VersionTag");
+        let from_ctor = bk.intern_class_by_qualname("pyre_object.celldict.VersionTag");
+        assert_eq!(from_field, from_ctor);
+        let field_class = bk
+            .getuniqueclassdef(&from_field)
+            .expect("field-side VersionTag classdef");
+        let ctor_class = bk
+            .getuniqueclassdef(&from_ctor)
+            .expect("constructor-side VersionTag classdef");
+        assert!(Rc::ptr_eq(&field_class, &ctor_class));
     }
 
     #[test]

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -296,7 +296,11 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
     // Keyed by the qualname the HOST_ENV `pyre_object.lltype` module assigns
     // (`flowspace/model.rs`); recognising it as a builtin keeps its body out
     // of the looked-inside set (the `<T as GcType>::type_id()` accessor wall).
-    analyzer_for(&mut reg, "pyre_object.lltype.malloc", malloc_typed_alloc);
+    analyzer_for(
+        &mut reg,
+        crate::runtime_names::modules::MALLOC,
+        malloc_typed_alloc,
+    );
     analyzer_for(
         &mut reg,
         crate::runtime_names::modules::MALLOC_TYPED,
@@ -1468,12 +1472,21 @@ fn cast_address_intrinsic(
     )))
 }
 
-/// Annotation of the Rust-adapter spelling of
-/// `rgc.ll_arraymove(array, source_start, dest_start, length)`.
+/// Annotation of the Rust-adapter spelling of `ll_arraymove`.
 ///
 /// The MIR front has already recovered a logical list-items array from the
-/// raw pointers before emitting this call.  Preserve the exact upstream
-/// surface: one list plus three integer indices, no result value.
+/// raw pointers before emitting this call, so the receiver arrives as the
+/// list, matching the list-taking spelling `rlist.ll_arraymove`
+/// (`rpython/rtyper/rlist.py:561-564`) rather than the ll-items one
+/// (`rgc.ll_arraymove`, `rpython/rlib/rgc.py:415-418`), which takes
+/// `lst.ll_items()`.
+///
+/// The declared signature is the whole surface, and both spellings declare
+/// the same one: `@signature(types.any(), types.int(), types.int(),
+/// types.int(), returns=types.none())` and `@enforceargs(None, int, int,
+/// int)`.  `types.any()` / `None` constrain the receiver not at all, so this
+/// port constrains it not at all either — only the three indices are checked,
+/// and there is no result.
 fn ll_arraymove_intrinsic(
     _bk: &Rc<Bookkeeper>,
     args_s: &[Option<SomeValue>],
@@ -1482,14 +1495,6 @@ fn ll_arraymove_intrinsic(
     if !kwds.is_empty() || args_s.len() != 4 {
         return Err(AnnotatorError::new(
             "__majit_ll_arraymove expects (array, source_start, dest_start, length)",
-        ));
-    }
-    if !matches!(
-        arg_at(args_s, 0, crate::runtime_names::shims::LL_ARRAYMOVE),
-        SomeValue::List(_)
-    ) {
-        return Err(AnnotatorError::new(
-            "__majit_ll_arraymove array argument must be SomeList",
         ));
     }
     for index in 1..4 {
@@ -1524,12 +1529,16 @@ fn ll_arraymove_intrinsic(
 /// A root the bookkeeper deliberately models as a non-instance value —
 /// a `FixedObjectArray` projected to its `_items` element list, a
 /// `Wtf8Buf` to a byte string (`project_struct_field_type`,
-/// in `bookkeeper.rs`) — arrives with a `SomeList`/`SomeString`
-/// operand rather than a pointer.  Its access lowers through
-/// `getitem`/byte reads, not a named-field getattr, so the narrow is a
-/// no-op: the operand passes through unchanged, exactly as the erasure
-/// twin `cast_address_intrinsic` handles a `SomeList` for a `Vec` whose
-/// address was erased.
+/// in `bookkeeper.rs`) — has its access lowered through `getitem`/byte
+/// reads, not a named-field getattr.  An operand that ALREADY carries the
+/// modelled variant (`SomeList` for a list root, `SomeString` for a string
+/// root) passes through unchanged, exactly as the erasure twin
+/// `cast_address_intrinsic` handles a `SomeList` for a `Vec` whose address
+/// was erased.  A pointer-shaped operand (`SomeInstance` / `SomePtr` /
+/// `SomeAddress`), which is what the GCREF and `GcArray` boundaries hand in,
+/// is narrowed to the root's projected annotation instead — carrying the
+/// operand's nullability, since `cast_opaque_ptr` answers
+/// `nullptr(PTRTYPE.TO)` for a null (`lltype.py:1008-1010`).
 fn cast_instance_intrinsic(
     bk: &Rc<Bookkeeper>,
     args_s: &[Option<SomeValue>],
@@ -1569,15 +1578,40 @@ fn cast_instance_intrinsic(
     } else {
         bk.project_struct_field_type(&root)
     };
-    // `GCRefRepr.recast` is the symmetric external-item boundary used by
-    // rlist: a GCREF read from `GcArray(GCREF)` becomes its concrete external
-    // pointer (StringRepr here) through cast_opaque_ptr.  The synthetic marker
-    // carries that target spelling; return the projected string for any GC
-    // pointer source, while an already-string source is the identity.
+    // Nullability travels with the value, not with the target spelling: a
+    // downcast of a nullable pointer is itself nullable, and a null operand
+    // is a legal one — `cast_opaque_ptr` answers `nullptr(PTRTYPE.TO)` for it
+    // (`lltype.py:1008-1010`).  Computed here so the target-spelling arms
+    // below cannot bypass it the way the block further down already honours
+    // it for the instance case.
+    let operand_can_be_none = match operand {
+        SomeValue::Instance(inst) => inst.can_be_none,
+        SomeValue::String(str_) => str_.inner.can_be_none,
+        SomeValue::None_(_) => true,
+        _ => false,
+    };
+    let with_nullability = |mut projected: SomeValue| {
+        if let SomeValue::String(str_) = &mut projected {
+            str_.inner.can_be_none = operand_can_be_none;
+        }
+        projected
+    };
+    // The symmetric external-item boundary rlist uses: a GCREF read from
+    // `GcArray(GCREF)` becomes its concrete external pointer (StringRepr
+    // here).  `AbstractBaseListRepr.recast` (`rpython/rtyper/rlist.py:67-68`)
+    // is the external/internal convert, and the GCREF half of it is
+    // `pairtype(GCRefRepr, Repr).convert_from_to`
+    // (`rpython/rtyper/lltypesystem/rgcref.py:61-65`), which genops
+    // `cast_opaque_ptr`.  The synthetic marker carries that target spelling;
+    // return the projected string for any GC pointer source, while an
+    // already-string source is the identity.
     if matches!(&projected, SomeValue::String(_)) {
         return match operand {
             SomeValue::String(_) => Ok(operand.clone()),
-            SomeValue::Instance(_) | SomeValue::Ptr(_) | SomeValue::Address(_) => Ok(projected),
+            SomeValue::Instance(_)
+            | SomeValue::Ptr(_)
+            | SomeValue::Address(_)
+            | SomeValue::None_(_) => Ok(with_nullability(projected)),
             other => Err(AnnotatorError::new(format!(
                 "__cast_instance_intrinsic: non-pointer operand for string root {root:?}: {other:?}"
             ))),
@@ -1589,7 +1623,8 @@ fn cast_instance_intrinsic(
             | SomeValue::Instance(_)
             | SomeValue::List(_)
             | SomeValue::Ptr(_)
-            | SomeValue::Address(_) => Ok(projected),
+            | SomeValue::Address(_)
+            | SomeValue::None_(_) => Ok(projected),
             other => Err(AnnotatorError::new(format!(
                 "__cast_instance_intrinsic: non-GC-pointer operand for GCREF: {other:?}"
             ))),
@@ -1603,10 +1638,16 @@ fn cast_instance_intrinsic(
     // GcArray lowleveltype that an RPython erase/unerase boundary produces.
     // Reaching the marker proves the pointer is immediately dereferenced, so
     // a null value is not an observable successful path.
+    // `SomeList` carries no `can_be_None` — upstream's does not either — so
+    // the nullability computed above has nowhere to land on this arm; a null
+    // operand is still admitted rather than hard-errored.
     if matches!(&projected, SomeValue::List(_)) {
         return match operand {
             SomeValue::List(_) => Ok(operand.clone()),
-            SomeValue::Instance(_) | SomeValue::Ptr(_) | SomeValue::Address(_) => Ok(projected),
+            SomeValue::Instance(_)
+            | SomeValue::Ptr(_)
+            | SomeValue::Address(_)
+            | SomeValue::None_(_) => Ok(projected),
             other => Err(AnnotatorError::new(format!(
                 "__cast_instance_intrinsic: non-pointer operand for list root {root:?}: {other:?}"
             ))),
@@ -1614,10 +1655,11 @@ fn cast_instance_intrinsic(
     }
     // Carry the operand's nullability onto the downcast result instead
     // of unconditionally narrowing to non-None: a downcast of a nullable
-    // pointer is itself nullable.
+    // pointer is itself nullable.  Same rule as `operand_can_be_none` above,
+    // spelled out here because this arm also has to classify the operand
+    // variant it does not recognise.
     let can_be_none = match operand {
-        SomeValue::Instance(inst) => inst.can_be_none,
-        SomeValue::None_(_) => true,
+        SomeValue::Instance(_) | SomeValue::None_(_) => operand_can_be_none,
         SomeValue::Ptr(_) | SomeValue::Address(_) => false,
         other => {
             // A root the bookkeeper models as a list or string (a
@@ -2096,9 +2138,13 @@ fn malloc_typed_alloc(
     }
     match arg_at(args_s, 0, "malloc[_typed]") {
         SomeValue::Instance(inst) => {
-            // lltype.py `malloc(T)`: only `isinstance(T, Struct)`
-            // is mallocable; everything else falls to
-            // `raise TypeError("malloc: unmallocable type")`. A classdef-less
+            // lltype.py `malloc(T)` (`:2202-2210`) admits `Struct`, `Array`
+            // and `OpaqueType`; anything else falls to
+            // `raise TypeError("malloc: unmallocable type")`.  Only the
+            // `Struct` arm is reachable through this marker.  (Its result is
+            // modelled as a `SomeInstance` rather than upstream `ann_malloc`'s
+            // `SomePtr(Ptr(s_T.const))` — pyre's instance annotation IS the
+            // struct-pointer annotation.)  A classdef-less
             // `SomeInstance` (object-only; `SomeInstance(classdef=None)`)
             // carries no concrete struct, so it is that `else` arm — reject
             // it here instead of boxing a typeless value the downstream
@@ -2651,7 +2697,7 @@ mod tests {
         assert!(is_registered("zip"));
         assert!(is_registered("min"));
         assert!(is_registered("max"));
-        assert!(is_registered("pyre_object.lltype.malloc"));
+        assert!(is_registered(crate::runtime_names::modules::MALLOC));
     }
 
     #[test]

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -292,10 +292,11 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
     // lltype HOST_ENV module assigns (`flowspace/model.rs`'s
     // `bootstrap_std_modules`).
     analyzer_for(&mut reg, "lltype.cast_pointer", lltype_cast_pointer);
-    // `pyre_object::lltype::malloc_typed` — the GC allocation intrinsic.
+    // `pyre_object::lltype::malloc[_typed]` — GC allocation intrinsics.
     // Keyed by the qualname the HOST_ENV `pyre_object.lltype` module assigns
     // (`flowspace/model.rs`); recognising it as a builtin keeps its body out
     // of the looked-inside set (the `<T as GcType>::type_id()` accessor wall).
+    analyzer_for(&mut reg, "pyre_object.lltype.malloc", malloc_typed_alloc);
     analyzer_for(
         &mut reg,
         crate::runtime_names::modules::MALLOC_TYPED,
@@ -1974,12 +1975,14 @@ fn lltype_cast_pointer(
     )))
 }
 
-/// Analyzer for `pyre_object::lltype::malloc_typed::<T>(value: T) -> *mut T`
-/// — the GC allocation intrinsic (`lltype.malloc(STRUCT, flavor='gc')`
-/// parity).  Registered as a builtin so the body is NEVER looked-inside:
-/// it calls `<T as GcType>::type_id()`, a trait accessor that lowers to the
-/// unregistered bare-leaf path `["GcType","type_id"]` (no flowable graph),
-/// which would poison every boxing caller's lift.  A successful malloc
+/// Analyzer for `pyre_object::lltype::malloc[_typed]::<T>(value: T) -> *mut T`
+/// — the GC allocation intrinsics (`lltype.malloc(STRUCT, flavor='gc')`
+/// parity). Registered as builtins so their allocator implementations are
+/// NEVER looked-inside. In particular, `malloc_typed` calls
+/// `<T as GcType>::type_id()`, a trait accessor with no flowable graph, while
+/// the untyped `malloc` reaches the host GC-header allocator. Both are the
+/// source spelling consumed by `fuse_boxing_alloc`, just as RPython's rtyper
+/// emits one `malloc` op for `jtransform.rewrite_op_malloc`. A successful malloc
 /// returns a non-null heap pointer to the same struct the argument
 /// constructs, so the result is `SomeInstance(T)` with `can_be_none =
 /// false` (OOM takes the MemoryError exception edge, not a null result).
@@ -1992,10 +1995,10 @@ fn malloc_typed_alloc(
 ) -> Result<SomeValue, AnnotatorError> {
     if !kwds.is_empty() || args_s.len() != 1 {
         return Err(AnnotatorError::new(
-            "malloc_typed() expects a single (value) positional argument",
+            "malloc[_typed]() expects a single (value) positional argument",
         ));
     }
-    match arg_at(args_s, 0, "malloc_typed") {
+    match arg_at(args_s, 0, "malloc[_typed]") {
         SomeValue::Instance(inst) => {
             // lltype.py `malloc(T)`: only `isinstance(T, Struct)`
             // is mallocable; everything else falls to
@@ -2014,7 +2017,7 @@ fn malloc_typed_alloc(
             )))
         }
         other => Err(AnnotatorError::new(format!(
-            "malloc_typed(): expected a struct value to box, got {other:?}"
+            "malloc[_typed](): expected a struct value to box, got {other:?}"
         ))),
     }
 }
@@ -2552,6 +2555,7 @@ mod tests {
         assert!(is_registered("zip"));
         assert!(is_registered("min"));
         assert!(is_registered("max"));
+        assert!(is_registered("pyre_object.lltype.malloc"));
     }
 
     #[test]

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -1516,7 +1516,43 @@ fn cast_instance_intrinsic(
         }
     };
     let operand = arg_at(args_s, 0, crate::runtime_names::shims::CAST_INSTANCE);
-    let projected = bk.project_struct_field_type(&root);
+    let projected = if root == "GCREF" {
+        // RPython GC-transform root slots are llmemory.GCREF.  Rust spells
+        // the helper parameter/return as PyObjectRef, but that carrier must
+        // not mint a W_Root instance annotation: every concrete GC pointer
+        // is cast_opaque_ptr'd into this slot and restored afterward.
+        crate::translator::rtyper::llannotation::lltype_to_annotation(
+            crate::translator::rtyper::lltypesystem::lltype::GCREF.clone(),
+        )
+    } else {
+        bk.project_struct_field_type(&root)
+    };
+    // `GCRefRepr.recast` is the symmetric external-item boundary used by
+    // rlist: a GCREF read from `GcArray(GCREF)` becomes its concrete external
+    // pointer (StringRepr here) through cast_opaque_ptr.  The synthetic marker
+    // carries that target spelling; return the projected string for any GC
+    // pointer source, while an already-string source is the identity.
+    if matches!(&projected, SomeValue::String(_)) {
+        return match operand {
+            SomeValue::String(_) => Ok(operand.clone()),
+            SomeValue::Instance(_) | SomeValue::Ptr(_) | SomeValue::Address(_) => Ok(projected),
+            other => Err(AnnotatorError::new(format!(
+                "__cast_instance_intrinsic: non-pointer operand for string root {root:?}: {other:?}"
+            ))),
+        };
+    }
+    if root == "GCREF" {
+        return match operand {
+            SomeValue::String(_)
+            | SomeValue::Instance(_)
+            | SomeValue::List(_)
+            | SomeValue::Ptr(_)
+            | SomeValue::Address(_) => Ok(projected),
+            other => Err(AnnotatorError::new(format!(
+                "__cast_instance_intrinsic: non-GC-pointer operand for GCREF: {other:?}"
+            ))),
+        };
+    }
     // A physical `TypedItemsBlock` pointer is the Rust owner for RPython's
     // direct `GcArray(Signed|Float)`. The MIR front records that cast as this
     // same pointer-narrow marker with a `[i64]` / `[f64]` target spelling.

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -366,6 +366,11 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
         crate::runtime_names::shims::CAST_ADDRESS,
         cast_address_intrinsic,
     );
+    analyzer_for(
+        &mut reg,
+        crate::runtime_names::shims::LL_ARRAYMOVE,
+        ll_arraymove_intrinsic,
+    );
     // Rust `String::new()` / `String::with_capacity(n)` construct an empty
     // owned UTF-8 buffer; both annotate as a mutable `SomeString` so the
     // `String.new` / `String.with_capacity` HOST_ENV stubs do not reach the
@@ -1461,6 +1466,43 @@ fn cast_address_intrinsic(
         can_be_none,
         std::collections::BTreeMap::new(),
     )))
+}
+
+/// Annotation of the Rust-adapter spelling of
+/// `rgc.ll_arraymove(array, source_start, dest_start, length)`.
+///
+/// The MIR front has already recovered a logical list-items array from the
+/// raw pointers before emitting this call.  Preserve the exact upstream
+/// surface: one list plus three integer indices, no result value.
+fn ll_arraymove_intrinsic(
+    _bk: &Rc<Bookkeeper>,
+    args_s: &[Option<SomeValue>],
+    kwds: &HashMap<String, Option<SomeValue>>,
+) -> Result<SomeValue, AnnotatorError> {
+    if !kwds.is_empty() || args_s.len() != 4 {
+        return Err(AnnotatorError::new(
+            "__majit_ll_arraymove expects (array, source_start, dest_start, length)",
+        ));
+    }
+    if !matches!(
+        arg_at(args_s, 0, crate::runtime_names::shims::LL_ARRAYMOVE),
+        SomeValue::List(_)
+    ) {
+        return Err(AnnotatorError::new(
+            "__majit_ll_arraymove array argument must be SomeList",
+        ));
+    }
+    for index in 1..4 {
+        if !matches!(
+            arg_at(args_s, index, crate::runtime_names::shims::LL_ARRAYMOVE),
+            SomeValue::Integer(_)
+        ) {
+            return Err(AnnotatorError::new(format!(
+                "__majit_ll_arraymove argument {index} must be SomeInteger"
+            )));
+        }
+    }
+    Ok(s_none())
 }
 
 /// Analyzer for `__cast_instance_intrinsic` — the front-end pointer-downcast

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -1515,10 +1515,28 @@ fn cast_instance_intrinsic(
             ));
         }
     };
+    let operand = arg_at(args_s, 0, crate::runtime_names::shims::CAST_INSTANCE);
+    let projected = bk.project_struct_field_type(&root);
+    // A physical `TypedItemsBlock` pointer is the Rust owner for RPython's
+    // direct `GcArray(Signed|Float)`. The MIR front records that cast as this
+    // same pointer-narrow marker with a `[i64]` / `[f64]` target spelling.
+    // Return the target SomeList annotation so `getitem` dispatches through
+    // ListRepr; the typer below emits the same `cast_pointer` to the target
+    // GcArray lowleveltype that an RPython erase/unerase boundary produces.
+    // Reaching the marker proves the pointer is immediately dereferenced, so
+    // a null value is not an observable successful path.
+    if matches!(&projected, SomeValue::List(_)) {
+        return match operand {
+            SomeValue::List(_) => Ok(operand.clone()),
+            SomeValue::Instance(_) | SomeValue::Ptr(_) | SomeValue::Address(_) => Ok(projected),
+            other => Err(AnnotatorError::new(format!(
+                "__cast_instance_intrinsic: non-pointer operand for list root {root:?}: {other:?}"
+            ))),
+        };
+    }
     // Carry the operand's nullability onto the downcast result instead
     // of unconditionally narrowing to non-None: a downcast of a nullable
     // pointer is itself nullable.
-    let operand = arg_at(args_s, 0, crate::runtime_names::shims::CAST_INSTANCE);
     let can_be_none = match operand {
         SomeValue::Instance(inst) => inst.can_be_none,
         SomeValue::None_(_) => true,
@@ -1536,7 +1554,7 @@ fn cast_instance_intrinsic(
             // (rclass.py:1035) constrains only the destination repr, not
             // the operand shape.  A genuine variant mismatch is still a
             // producer bug, surfaced with the root that was expected.
-            if bk.project_struct_field_type(&root).tag() == other.tag() {
+            if projected.tag() == other.tag() {
                 return Ok(operand.clone());
             }
             return Err(AnnotatorError::new(format!(

--- a/majit/majit-translate/src/annotator/classdesc.rs
+++ b/majit/majit-translate/src/annotator/classdesc.rs
@@ -2927,9 +2927,13 @@ impl ClassDef {
 
         // upstream: remove attribute from subclasses, merging into newattr.
         for subdef in Self::getallsubdefs(this) {
-            let existing = subdef.borrow_mut().attrs.remove(attr);
+            // classdesc.py merges before `del subdef.attrs[attr]`. Clone the
+            // existing value to release the RefCell borrow, but preserve that
+            // ordering: a failed union must not delete shared ClassDef state.
+            let existing = subdef.borrow().attrs.get(attr).cloned();
             if let Some(subattr) = existing {
                 newattr.merge(&subattr, this)?;
+                subdef.borrow_mut().attrs.remove(attr);
             }
             // accumulate attr_sources from all subclasses.
             let taken = subdef.borrow_mut().attr_sources.remove(attr);
@@ -3878,6 +3882,42 @@ mod tests {
         ClassDef::generalize_attr(&cd, "x", Some(SomeValue::Integer(SomeInteger::default())))
             .expect("generalize_attr must succeed without sources");
         assert!(cd.borrow().attrs.contains_key("x"));
+    }
+
+    #[test]
+    fn classdef_failed_generalize_preserves_subclass_attribute() {
+        let bk = make_bk();
+        let base_desc = make_classdesc(&bk, "pkg.Base");
+        let base = ClassDesc::getuniqueclassdef(&base_desc).expect("base classdef");
+        let child_desc = make_classdesc(&bk, "pkg.Child");
+        child_desc.borrow_mut().basedesc = Some(base_desc);
+        let child = ClassDesc::getuniqueclassdef(&child_desc).expect("child classdef");
+
+        let mut existing = Attribute::new("payload");
+        existing.s_value = SomeValue::Integer(SomeInteger::default());
+        child
+            .borrow_mut()
+            .attrs
+            .insert("payload".to_string(), existing);
+
+        let result = ClassDef::generalize_attr(
+            &base,
+            "payload",
+            Some(SomeValue::String(SomeString::default())),
+        );
+        assert!(result.is_err(), "int and string attrs must not unify");
+        assert!(
+            matches!(
+                child
+                    .borrow()
+                    .attrs
+                    .get("payload")
+                    .map(|attr| &attr.s_value),
+                Some(SomeValue::Integer(_))
+            ),
+            "classdesc.py merges before deleting the subclass attr, so a failed union must preserve it"
+        );
+        assert!(!base.borrow().attrs.contains_key("payload"));
     }
 
     #[test]

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -227,13 +227,12 @@ pub fn commonbase(cls1: KnownType, cls2: KnownType) -> KnownType {
 /// `::` form (the spelling `canonical_struct_name` already yields for the
 /// field-read side) and compare.
 ///
-/// Normal non-header constructors now normalize at
-/// `Bookkeeper::intern_class_by_qualname`, while header-bearing structs retain
-/// their full base-chain walk (collapsing those early caused a measured +184
-/// phaseA cascade across `_io`/`_pickle`).  Keep this compare-time fallback for
-/// registry-absent or ambiguous constructor spellings: it fires only where
-/// `commonbase` is already None, which the base-bearing `W_*` structs never
-/// reach because they share `W_Root`.
+/// Constructors and field reads now normalize at
+/// `Bookkeeper::intern_class_by_qualname`, including header-bearing structs;
+/// normalization keeps the crate-relative module path so their full base-chain
+/// walk still runs.  Keep this compare-time fallback for registry-absent or
+/// ambiguous constructor spellings: it fires only where `commonbase` is
+/// already None.
 fn same_struct_identity(a: &str, b: &str) -> bool {
     fn identity(name: &str) -> String {
         if !name.contains("::")

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -233,16 +233,27 @@ pub fn commonbase(cls1: KnownType, cls2: KnownType) -> KnownType {
 /// walk still runs.  Keep this compare-time fallback for registry-absent or
 /// ambiguous constructor spellings: it fires only where `commonbase` is
 /// already None.
+///
+/// It runs the intern's own key derivation — [`normalize_class_qualname`] then
+/// `canonical_struct_name` — rather than a second rule of its own.  A separate
+/// rule disagreed on exactly the spelling the intern was written for: the local
+/// dotted-only strip answered `false` for
+/// `("pyre_object::m::T", "m::T")` while the intern maps both to `m::T`.
+/// Upstream keys identity on the object in one place
+/// (`bookkeeper.py:361-363`), so one derivation is the shape to hold.
+///
+/// Caution carried forward: collapsing an `ob_header`-bearing `W_*` struct
+/// EARLY — that is, keying `struct_root_classes` on the collapse — starved its
+/// base-chain walk, so it minted base-less under first-mint-wins and lost its
+/// `W_Root` base, a measured +184 phaseA cascade across `_io`/`_pickle`.  The
+/// normalization above is a crate-root strip only; it does not collapse the
+/// module path, so the walk still runs.  Any future widening of it has to
+/// re-measure that number.
 fn same_struct_identity(a: &str, b: &str) -> bool {
     fn identity(name: &str) -> String {
-        if !name.contains("::")
-            && !name.contains('<')
-            && name.contains('.')
-            && let Some((_crate, rest)) = name.split_once('.')
-        {
-            return rest.replace('.', "::");
-        }
-        majit_ir::descr::canonical_struct_name(name)
+        majit_ir::descr::canonical_struct_name(
+            &crate::annotator::bookkeeper::normalize_class_qualname(name),
+        )
     }
     identity(a) == identity(b)
 }

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -227,13 +227,13 @@ pub fn commonbase(cls1: KnownType, cls2: KnownType) -> KnownType {
 /// `::` form (the spelling `canonical_struct_name` already yields for the
 /// field-read side) and compare.
 ///
-/// Deliberately a COMPARE-time identity, NOT an interning cache key: keying
-/// `struct_root_classes` on this collapse starves the header/base-chain
-/// walk for `ob_header`-bearing `W_*` structs (they mint base-less under
-/// first-mint-wins and lose their `W_Root` base — a measured +184 phaseA
-/// cascade across `_io`/`_pickle`).  This check fires only where
+/// Normal non-header constructors now normalize at
+/// `Bookkeeper::intern_class_by_qualname`, while header-bearing structs retain
+/// their full base-chain walk (collapsing those early caused a measured +184
+/// phaseA cascade across `_io`/`_pickle`).  Keep this compare-time fallback for
+/// registry-absent or ambiguous constructor spellings: it fires only where
 /// `commonbase` is already None, which the base-bearing `W_*` structs never
-/// reach (they share `W_Root`), so it cannot perturb them.
+/// reach because they share `W_Root`.
 fn same_struct_identity(a: &str, b: &str) -> bool {
     fn identity(name: &str) -> String {
         if !name.contains("::")

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1521,6 +1521,21 @@ impl Assembler {
                 let opnum = self.get_opnum(&key);
                 state.code[startposition] = opnum;
             }
+            OpKind::ConstUInt(val) => {
+                let (idx, src_argcode) =
+                    self.emit_const_i_allow_short(*val as i64, use_c_form("int_copy"), state);
+                state.code.push(idx);
+                argcodes.push(src_argcode);
+                if let Some(result) = op.result.as_ref() {
+                    argcodes.push('>');
+                    let (reg, kc) = self.lookup_reg_with_kind_var(result, regallocs);
+                    argcodes.push(kc);
+                    state.code.push(reg);
+                }
+                let key = format!("int_copy/{argcodes}");
+                let opnum = self.get_opnum(&key);
+                state.code[startposition] = opnum;
+            }
 
             // RPython folds `lltype.Bool` to kind `'int'` at codewriter
             // (`flatten.py:getkind`), so `ConstBool` materialises through
@@ -2881,6 +2896,7 @@ impl Assembler {
             match kind {
                 OpKind::Input { .. } => "Input",
                 OpKind::ConstInt(_) => "ConstInt",
+                OpKind::ConstUInt(_) => "ConstUInt",
                 OpKind::ConstInt128(_) => "ConstInt128",
                 OpKind::ConstUInt128(_) => "ConstUInt128",
                 OpKind::ConstBool(_) => "ConstBool",
@@ -4721,7 +4737,7 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
         OpKind::Input { ty, .. } => format!("input_{}", value_type_to_kind(ty)),
         // RPython: ConstInt is NOT a standalone op; see encode_op comment.
         // Pyre materialises constants as an int_copy from pool-region reg.
-        OpKind::ConstInt(_) => "int_copy".into(),
+        OpKind::ConstInt(_) | OpKind::ConstUInt(_) => "int_copy".into(),
         OpKind::ConstInt128(_) | OpKind::ConstUInt128(_) => {
             panic!("getkind: 128-bit integer constant is too large (history.py:62)")
         }

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -8816,6 +8816,7 @@ fn op_can_raise(op: &OpKind) -> RaiseClass {
         // RPython LL: same_as, cast_*, hint → cannot raise
         OpKind::Input { .. }
         | OpKind::ConstInt(_)
+        | OpKind::ConstUInt(_)
         | OpKind::ConstInt128(_)
         | OpKind::ConstUInt128(_)
         | OpKind::ConstBool(_)

--- a/majit/majit-translate/src/codewriter/format.rs
+++ b/majit/majit-translate/src/codewriter/format.rs
@@ -489,6 +489,7 @@ fn op_name(op: &crate::model::SpaceOperation) -> String {
     match &op.kind {
         OpKind::Call { .. } => "call".to_string(),
         OpKind::ConstInt(_) => "const_int".to_string(),
+        OpKind::ConstUInt(_) => "const_uint".to_string(),
         OpKind::ConstFloat(_) => "const_float".to_string(),
         OpKind::ConstStr(_) => "const_str".to_string(),
         OpKind::CallElidable {
@@ -601,6 +602,9 @@ fn op_args_repr(op: &crate::model::SpaceOperation) -> String {
         }
         // format.py `'$%r' % (x.value,)` — constants print as $<value>.
         OpKind::ConstInt(value) => {
+            let _ = write!(out, "${value}");
+        }
+        OpKind::ConstUInt(value) => {
             let _ = write!(out, "${value}");
         }
         OpKind::ConstFloat(bits) => {
@@ -794,7 +798,7 @@ fn op_result_kind(kind: &crate::model::OpKind) -> RegKind {
             'f' => RegKind::Float,
             _ => RegKind::Ref,
         },
-        OpKind::ConstInt(_) => RegKind::Int,
+        OpKind::ConstInt(_) | OpKind::ConstUInt(_) => RegKind::Int,
         OpKind::ConstFloat(_) => RegKind::Float,
         OpKind::ConstStr(_) => RegKind::Ref,
         OpKind::ConstBool(_) => RegKind::Int,

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -7209,6 +7209,7 @@ fn remap_op(
     let kind = match &op.kind {
         OpKind::Input { .. }
         | OpKind::ConstInt(_)
+        | OpKind::ConstUInt(_)
         | OpKind::ConstInt128(_)
         | OpKind::ConstUInt128(_)
         | OpKind::ConstBool(_)

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -640,6 +640,7 @@ fn is_source_constant_variable(
             }
             match &op.kind {
                 OpKind::ConstInt(_)
+                | OpKind::ConstUInt(_)
                 | OpKind::ConstBool(_)
                 | OpKind::ConstFloat(_)
                 | OpKind::ConstStr(_)
@@ -7100,7 +7101,9 @@ fn array_has_nonconstant_index_read(
                         .iter()
                         .find(|block| block.id == block_id)
                         .and_then(|block| block.operations.get(op_index))
-                        .is_some_and(|op| matches!(op.kind, OpKind::ConstInt(_)))
+                        .is_some_and(|op| {
+                            matches!(op.kind, OpKind::ConstInt(_) | OpKind::ConstUInt(_))
+                        })
                 },
             )
         })

--- a/majit/majit-translate/src/codewriter/type_state.rs
+++ b/majit/majit-translate/src/codewriter/type_state.rs
@@ -116,6 +116,7 @@ fn concrete_if_known(concrete: ConcreteType) -> Option<ConcreteType> {
 pub(crate) fn authoritative_result_type_from_op(kind: &OpKind) -> Option<ConcreteType> {
     match kind {
         OpKind::ConstInt(_) => Some(ConcreteType::Signed),
+        OpKind::ConstUInt(_) => Some(ConcreteType::Signed),
         OpKind::ConstInt128(_) | OpKind::ConstUInt128(_) => None,
         OpKind::ConstBool(_) => Some(ConcreteType::Signed),
         // `_we_are_jitted` symbolic — `Bool` concretetype folds to int

--- a/majit/majit-translate/src/decline.rs
+++ b/majit/majit-translate/src/decline.rs
@@ -7,14 +7,15 @@
 //! consulted and said no, or was never reached at all.  Reading a jitcode
 //! list by hand is currently the only way to tell those apart.
 //!
-//! Upstream is loud exactly where this pipeline is silent:
-//! `rpython/jit/codewriter/jtransform.py`'s `_handle_list_call` raises
-//! `NotImplementedError("prebuilt lists cannot be virtual")` rather than
-//! falling through to a residual, so an unhandled shape stops translation
-//! with its own name attached.  This module does NOT turn any decline into
-//! an error — every gate keeps its exact current control flow — it only
-//! records that the decline happened and why, so the same information
-//! upstream would have raised is at least countable here.
+//! Upstream does not stop translation either, but it carries the reason as
+//! a value: `_handle_list_call` raises `NotSupported(prefix + oopspec_name)`
+//! (`rpython/jit/codewriter/jtransform.py:1796`), naming the shape it
+//! refused, and `rewrite_op_direct_call` catches it and falls through to a
+//! residual call (`jtransform.py:512-520`).  The refusal is equally silent
+//! at the end — but at the point of refusal the reason existed.  This module
+//! does NOT turn any decline into an error — every gate keeps its exact
+//! current control flow — it only records the reason where it still exists,
+//! so it survives the fall through to a residual.
 //!
 //! # Contract
 //!

--- a/majit/majit-translate/src/flowspace/flowcontext.rs
+++ b/majit/majit-translate/src/flowspace/flowcontext.rs
@@ -1935,6 +1935,7 @@ impl FlowContext {
                     BuiltinException::UnicodeDecodeError => "UnicodeDecodeError",
                     BuiltinException::ZeroDivisionError => "ZeroDivisionError",
                     BuiltinException::OverflowError => "OverflowError",
+                    BuiltinException::MemoryError => "MemoryError",
                     BuiltinException::IndexError => "IndexError",
                     BuiltinException::KeyError => "KeyError",
                     BuiltinException::StopIteration => "StopIteration",

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -1734,6 +1734,15 @@ impl HostEnv {
             crate::runtime_names::shims::CAST_ADDRESS,
             HostObject::new_builtin_callable(crate::runtime_names::shims::CAST_ADDRESS),
         );
+        // Front-end spelling of the exact RPython `rgc.ll_arraymove` helper.
+        // Rust source reaches the same operation as `ptr::copy`; the MIR
+        // adapter reconstructs the array plus logical source/destination
+        // indices before resolving this singleton through the annotator and
+        // rtyper registries.
+        self.insert_builtin(
+            crate::runtime_names::shims::LL_ARRAYMOVE,
+            HostObject::new_builtin_callable(crate::runtime_names::shims::LL_ARRAYMOVE),
+        );
     }
 
     fn bootstrap_std_modules(&mut self) {

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -2323,7 +2323,7 @@ impl HostEnv {
                 .expect("core.ptr.null_mut bound above"),
         );
 
-        // `pyre_object::lltype::malloc_typed` — the GC allocation intrinsic
+        // `pyre_object::lltype::malloc[_typed]` — GC allocation intrinsics
         // (`lltype.malloc(STRUCT, flavor='gc')` parity).  Exposed as a host
         // builtin so its body is never looked-inside; the `malloc_typed_alloc`
         // analyzer types the result as `SomeInstance(T)`.  Callsites carry the
@@ -2331,6 +2331,10 @@ impl HostEnv {
         // which `translate_op`'s Layer-3b resolves via this module
         // (prefix `pyre_object.lltype`, leaf `malloc_typed`).
         let lltype_module = HostObject::new_module(crate::runtime_names::modules::OBJECT_LLTYPE);
+        lltype_module.module_set(
+            "malloc",
+            HostObject::new_builtin_callable("pyre_object.lltype.malloc"),
+        );
         lltype_module.module_set(
             "malloc_typed",
             HostObject::new_builtin_callable(crate::runtime_names::modules::MALLOC_TYPED),

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -2342,7 +2342,7 @@ impl HostEnv {
         let lltype_module = HostObject::new_module(crate::runtime_names::modules::OBJECT_LLTYPE);
         lltype_module.module_set(
             "malloc",
-            HostObject::new_builtin_callable("pyre_object.lltype.malloc"),
+            HostObject::new_builtin_callable(crate::runtime_names::modules::MALLOC),
         );
         lltype_module.module_set(
             "malloc_typed",

--- a/majit/majit-translate/src/flowspace/operation.rs
+++ b/majit/majit-translate/src/flowspace/operation.rs
@@ -174,6 +174,12 @@ pub enum OpKind {
     NewDict,
     NewTuple,
     NewList,
+    /// `objectmodel.newlist_hint(sizehint)`'s ExtRegistry specialization.
+    /// RPython does not expose this as an ordinary operation.py subclass;
+    /// pyre gives the specialization a synthetic high-level opname so the
+    /// Rust `try_vec_with_capacity` spelling can enter the same annotator and
+    /// rtyper path without translating the Rust allocator body.
+    NewListHint,
     /// `StringBuilder()` / `UnicodeBuilder()` construction.  A pyre
     /// adaptation of the RPython `rlib.rstring` ExtRegistryEntry ctor
     /// (`simple_call` on the builder class → `SomeStringBuilder`,
@@ -205,6 +211,7 @@ pub enum BuiltinException {
     UnicodeDecodeError,
     ZeroDivisionError,
     OverflowError,
+    MemoryError,
     IndexError,
     KeyError,
     StopIteration,
@@ -222,6 +229,7 @@ impl BuiltinException {
             BuiltinException::UnicodeDecodeError => "UnicodeDecodeError",
             BuiltinException::ZeroDivisionError => "ZeroDivisionError",
             BuiltinException::OverflowError => "OverflowError",
+            BuiltinException::MemoryError => "MemoryError",
             BuiltinException::IndexError => "IndexError",
             BuiltinException::KeyError => "KeyError",
             BuiltinException::StopIteration => "StopIteration",
@@ -347,6 +355,7 @@ impl OpKind {
             "newdict" => OpKind::NewDict,
             "newtuple" => OpKind::NewTuple,
             "newlist" => OpKind::NewList,
+            "newlist_hint" => OpKind::NewListHint,
             "newstringbuilder" => OpKind::NewStringBuilder,
             "pow" => OpKind::Pow,
             "iter" => OpKind::Iter,
@@ -454,6 +463,7 @@ impl OpKind {
             OpKind::NewDict => "newdict",
             OpKind::NewTuple => "newtuple",
             OpKind::NewList => "newlist",
+            OpKind::NewListHint => "newlist_hint",
             OpKind::NewStringBuilder => "newstringbuilder",
             OpKind::Pow => "pow",
             OpKind::Iter => "iter",
@@ -577,6 +587,10 @@ impl OpKind {
             | OpKind::SimpleCall
             | OpKind::CallArgs
             | OpKind::Hint => None,
+
+            // Pyre's synthetic spelling of the one-argument
+            // `newlist_hint(sizehint)` ExtRegistry specialization.
+            OpKind::NewListHint => Some(1),
         }
     }
 
@@ -704,6 +718,7 @@ impl OpKind {
             | OpKind::Hint
             | OpKind::NewDict
             | OpKind::NewList
+            | OpKind::NewListHint
             | OpKind::NewStringBuilder
             | OpKind::Iter
             | OpKind::Next
@@ -838,6 +853,7 @@ impl OpKind {
             | OpKind::NewDict
             | OpKind::NewTuple
             | OpKind::NewList
+            | OpKind::NewListHint
             | OpKind::NewStringBuilder
             | OpKind::Pow => Dispatch::None,
         }
@@ -891,6 +907,10 @@ impl OpKind {
             // Explicit HLOperation subclasses with custom canraise.
             OpKind::GetAttr | OpKind::Iter => &[],
             OpKind::Next => &[StopIteration, RuntimeError],
+            // `objectmodel.newlist_hint` specializes through
+            // `hop.exception_is_here()`; allocation failure is the only
+            // exception admitted by the fallible Rust source helper.
+            OpKind::NewListHint => &[MemoryError],
 
             // operation.py:728-731.
             OpKind::GetItem | OpKind::GetItemIdx | OpKind::SetItem | OpKind::DelItem => {
@@ -2432,6 +2452,14 @@ impl HLOperation {
                     // operation.py — NewList.consider.
                     OpKind::NewList => {
                         let list = annotator.bookkeeper.newlist(&args_s, None)?;
+                        Ok(Some(SomeValue::List(list)))
+                    }
+                    // objectmodel.py `Entry.compute_result_annotation`:
+                    // create an empty list and mark it resized.  The size
+                    // hint affects allocation only, not the item annotation.
+                    OpKind::NewListHint => {
+                        let list = annotator.bookkeeper.newlist(&[], None)?;
+                        list.listdef.resize()?;
                         Ok(Some(SomeValue::List(list)))
                     }
                     // `StringBuilder()` construction — the ExtRegistryEntry

--- a/majit/majit-translate/src/front/bool_then.rs
+++ b/majit/majit-translate/src/front/bool_then.rs
@@ -83,6 +83,16 @@ pub(crate) struct BoolThenSite {
     /// `call_once` result kind (`then`) or the captured value kind
     /// (`then_some`), and the `Some::__pos_0` field kind.
     pub payload_ty: ValueType,
+    /// True when the result is a one-word nullable pointer.  RPython's
+    /// `SomePtr(can_be_None=True)` carries no Option aggregate: `Some(x)` is
+    /// `x` itself and `None` is null.  The consumer folds use this same flag,
+    /// so the producer must choose the identical representation.
+    pub niche: bool,
+    /// Concrete pointee class carried by a niche pointer payload.  Rust's raw
+    /// pointer spelling otherwise erases to a classless `Ref`; RPython keeps
+    /// the corresponding `SomeInstance(W_Root-subclass)` across the closure
+    /// call, so restore that annotation before forwarding `Some(payload)`.
+    pub payload_narrow_root: Option<String>,
 }
 
 /// Rewrite every recorded `bool::then` call site into the short-circuit
@@ -227,13 +237,23 @@ fn rewire_one_bool_then_site(graph: &mut FunctionGraph, site: &BoolThenSite) -> 
         }
         None => env_in_then,
     };
-    let some_var = emit_option_variant(
+    let payload = crate::front::option_map_or::emit_narrow(
         graph,
         then_bb,
-        &site.option_owner,
-        1,
-        Some((&site.some_owner, payload, site.payload_ty.clone())),
+        payload,
+        &site.payload_narrow_root,
     );
+    let some_var = if site.niche {
+        payload
+    } else {
+        emit_option_variant(
+            graph,
+            then_bb,
+            &site.option_owner,
+            1,
+            Some((&site.some_owner, payload, site.payload_ty.clone())),
+        )
+    };
     let then_link_args = reproduce_exit_args(
         &saved_exit,
         &opt_val,
@@ -245,7 +265,12 @@ fn rewire_one_bool_then_site(graph: &mut FunctionGraph, site: &BoolThenSite) -> 
     close_goto_mixed(graph, then_bb, b_target, then_link_args);
 
     // `else_bb`: opt = None.
-    let none_var = emit_option_variant(graph, else_bb, &site.option_owner, 0, None);
+    let none_var = if site.niche {
+        let null = graph.push_null_mut_ptr(else_bb);
+        crate::front::option_map_or::emit_narrow(graph, else_bb, null, &site.payload_narrow_root)
+    } else {
+        emit_option_variant(graph, else_bb, &site.option_owner, 0, None)
+    };
     let else_link_args = reproduce_exit_args(
         &saved_exit,
         &opt_val,

--- a/majit/majit-translate/src/front/bool_then.rs
+++ b/majit/majit-translate/src/front/bool_then.rs
@@ -333,9 +333,11 @@ pub(crate) fn reproduce_exit_args(
 }
 
 /// Build an `Option` variant aggregate in `block` and return its value —
-/// the enum-root ctor + `__discriminant` write (+ `__pos_0` payload write
-/// for `Some`), the same transparent-ctor + `FieldWrite` chain
-/// `Rvalue::Aggregate` emits (`front::mir` `emit_tagged_pair_aggregate`).
+/// the concrete variant-subclass ctor + `__discriminant` write (+ `__pos_0`
+/// payload write for `Some`), the same transparent-ctor + `FieldWrite` chain
+/// a static `Rvalue::Aggregate` emits.  The two arm values union to their
+/// common enum base at the join; each arm itself retains the variant class
+/// that owns its fields (`rclass.py:82-88`).
 /// `disc` is the variant tag (`Some` = 1, `None` = 0); `payload` is
 /// `Some((some_owner, value, value_ty))` for `Some`, `None` for `None`.
 pub(crate) fn emit_option_variant(
@@ -346,7 +348,12 @@ pub(crate) fn emit_option_variant(
     payload: Option<(&str, Variable, ValueType)>,
 ) -> Variable {
     let res = graph.alloc_value_var();
-    push_option_ctor(graph, block, res.clone(), option_owner);
+    let variant = match disc {
+        0 => "None",
+        1 => "Some",
+        other => panic!("emit_option_variant: Option discriminant must be 0 or 1, got {other}"),
+    };
+    push_option_variant_ctor(graph, block, res.clone(), option_owner, variant);
     // `__discriminant` keys the enum root (tag offset 0 of every variant);
     // materialize the tag as a `ConstInt` value, matching the aggregate
     // path's `FieldWrite { value: Value(..) }` shape.
@@ -386,7 +393,7 @@ fn push_option_ctor(
     result: Variable,
     option_owner: &str,
 ) {
-    let mut owner_path: Vec<String> = option_owner.split("::").map(str::to_string).collect();
+    let mut owner_path = crate::model::split_qualified_path(option_owner);
     let ctor_name = owner_path.pop().unwrap_or_default();
     let ctor_target = if owner_path.is_empty() {
         CallTarget::synthetic_transparent_ctor(ctor_name)
@@ -399,6 +406,29 @@ fn push_option_ctor(
             target: ctor_target,
             args: Vec::new(),
             result_ty: ValueType::Ref(Some(option_owner.to_string())),
+        },
+    });
+}
+
+/// Push a statically-known `Option::Some` / `Option::None` subclass ctor.
+/// Keep the entire instantiated enum path as the owner and append the variant
+/// leaf; the flowspace adapter then interns it through
+/// `Bookkeeper::intern_enum_variant_host`, the same class object used by
+/// discriminant narrowing.
+fn push_option_variant_ctor(
+    graph: &mut FunctionGraph,
+    block: BlockId,
+    result: Variable,
+    option_owner: &str,
+    variant: &str,
+) {
+    let owner_path = crate::model::split_qualified_path(option_owner);
+    graph.block_mut(block).operations.push(SpaceOperation {
+        result: Some(result),
+        kind: OpKind::Call {
+            target: CallTarget::synthetic_transparent_ctor_with_owner(owner_path, variant),
+            args: Vec::new(),
+            result_ty: ValueType::Ref(Some(format!("{option_owner}::{variant}"))),
         },
     });
 }
@@ -463,4 +493,80 @@ pub(crate) fn close_goto_mixed(
 ) {
     let link = Link::new_mixed(args, target, None);
     graph.set_control_flow_metadata(block, None, vec![link]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn static_option_aggregate_constructs_the_variant_subclass() {
+        let mut graph = FunctionGraph::new("static_option");
+        let block = graph.startblock;
+        let owner = "core::option::Option<Result<*mut pyobject::PyObject,error::PyError>>";
+        let payload = graph.alloc_value_var();
+        let result = emit_option_variant(
+            &mut graph,
+            block,
+            owner,
+            1,
+            Some((&format!("{owner}::Some"), payload, ValueType::Ref(None))),
+        );
+
+        match &graph.block(block).operations[0] {
+            SpaceOperation {
+                result: Some(actual),
+                kind:
+                    OpKind::Call {
+                        target: CallTarget::SyntheticTransparentCtor { name, owner_path },
+                        result_ty: ValueType::Ref(Some(result_root)),
+                        ..
+                    },
+            } => {
+                assert_eq!(actual, &result);
+                assert_eq!(name, "Some");
+                assert_eq!(
+                    owner_path,
+                    &[
+                        "core".to_string(),
+                        "option".to_string(),
+                        "Option<Result<*mut pyobject::PyObject,error::PyError>>".to_string(),
+                    ]
+                );
+                assert_eq!(result_root, &format!("{owner}::Some"));
+            }
+            other => panic!("static Option must construct its Some subclass: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dynamic_option_aggregate_keeps_the_enum_base() {
+        let mut graph = FunctionGraph::new("dynamic_option");
+        let block = graph.startblock;
+        let owner = "core::option::Option<Result<*mut pyobject::PyObject,error::PyError>>";
+        let result = graph.alloc_value_var();
+        let disc = graph.alloc_value_var();
+        emit_option_variant_dynamic(&mut graph, block, result.clone(), owner, disc, None);
+
+        match &graph.block(block).operations[0] {
+            SpaceOperation {
+                result: Some(actual),
+                kind:
+                    OpKind::Call {
+                        target: CallTarget::SyntheticTransparentCtor { name, owner_path },
+                        result_ty: ValueType::Ref(Some(result_root)),
+                        ..
+                    },
+            } => {
+                assert_eq!(actual, &result);
+                assert_eq!(
+                    name,
+                    "Option<Result<*mut pyobject::PyObject,error::PyError>>"
+                );
+                assert_eq!(owner_path, &["core".to_string(), "option".to_string()]);
+                assert_eq!(result_root, owner);
+            }
+            other => panic!("dynamic Option must construct its enum base: {other:?}"),
+        }
+    }
 }

--- a/majit/majit-translate/src/front/bool_then.rs
+++ b/majit/majit-translate/src/front/bool_then.rs
@@ -518,7 +518,10 @@ mod tests {
                 result: Some(actual),
                 kind:
                     OpKind::Call {
-                        target: CallTarget::SyntheticTransparentCtor { name, owner_path },
+                        target:
+                            CallTarget::SyntheticTransparentCtor {
+                                name, owner_path, ..
+                            },
                         result_ty: ValueType::Ref(Some(result_root)),
                         ..
                     },
@@ -553,7 +556,10 @@ mod tests {
                 result: Some(actual),
                 kind:
                     OpKind::Call {
-                        target: CallTarget::SyntheticTransparentCtor { name, owner_path },
+                        target:
+                            CallTarget::SyntheticTransparentCtor {
+                                name, owner_path, ..
+                            },
                         result_ty: ValueType::Ref(Some(result_root)),
                         ..
                     },

--- a/majit/majit-translate/src/front/bool_then.rs
+++ b/majit/majit-translate/src/front/bool_then.rs
@@ -337,7 +337,7 @@ pub(crate) fn reproduce_exit_args(
 /// payload write for `Some`), the same transparent-ctor + `FieldWrite` chain
 /// a static `Rvalue::Aggregate` emits.  The two arm values union to their
 /// common enum base at the join; each arm itself retains the variant class
-/// that owns its fields (`rclass.py:82-88`).
+/// that owns its fields (`rclass.py:499-518`).
 /// `disc` is the variant tag (`Some` = 1, `None` = 0); `payload` is
 /// `Some((some_owner, value, value_ty))` for `Some`, `None` for `None`.
 pub(crate) fn emit_option_variant(
@@ -373,6 +373,20 @@ pub(crate) fn emit_option_variant(
 /// `0`/`1` integer value (`None` = 0, `Some` = 1).  Same transparent-ctor +
 /// `FieldWrite` chain as [`emit_option_variant`], only the discriminant is a
 /// live value instead of a materialized `ConstInt`.
+///
+/// **And the ctor is the enum ROOT, not the variant subclass** — that is the
+/// one place the two emitters differ, and it is keyed on exactly this
+/// difference.  A runtime `disc` names no variant, so no variant identity can
+/// annotate the destination; the root is the `SomeInstance(enum)` that
+/// multi-assigned locals union against (`<other> ∪ int` UnionError in
+/// `mergeinputargs` otherwise).  The same rule, for the same reason, governs
+/// `front::mir`'s `emit_tagged_pair_aggregate`.  Read together: a
+/// STATICALLY known tag builds the variant subclass that owns the payload
+/// row (`rclass.py:499-518`); a RUNTIME tag builds the root and writes
+/// `__pos_0` under the success variant's key, which `resolve_adt_field`
+/// reads back variant-qualified.  Making this arm variant-selecting instead
+/// would mean branching on `disc` at every such site — the branch these
+/// folds exist to avoid.
 pub(crate) fn emit_option_variant_dynamic(
     graph: &mut FunctionGraph,
     block: BlockId,

--- a/majit/majit-translate/src/front/from_size_align.rs
+++ b/majit/majit-translate/src/front/from_size_align.rs
@@ -212,6 +212,9 @@ fn rewire_one_from_size_align_site(
         .flat_map(|b| &b.operations)
         .find_map(|op| match &op.kind {
             OpKind::ConstInt(n) if op.result.as_ref() == Some(&align_arg) => Some(*n),
+            OpKind::ConstUInt(n) if op.result.as_ref() == Some(&align_arg) => {
+                i64::try_from(*n).ok()
+            }
             _ => None,
         })
         .ok_or_else(|| format!("{name}: from_size_align align arg is not a folded ConstInt"))?;
@@ -394,6 +397,9 @@ fn rewire_one_from_size_align_expect_site(
         .flat_map(|b| &b.operations)
         .find_map(|op| match &op.kind {
             OpKind::ConstInt(n) if op.result.as_ref() == Some(&align_arg) => Some(*n),
+            OpKind::ConstUInt(n) if op.result.as_ref() == Some(&align_arg) => {
+                i64::try_from(*n).ok()
+            }
             _ => None,
         })
         .ok_or_else(|| format!("{name}: from_size_align align arg is not a folded ConstInt"))?;

--- a/majit/majit-translate/src/front/from_size_align.rs
+++ b/majit/majit-translate/src/front/from_size_align.rs
@@ -516,7 +516,7 @@ fn build_layout_aggregate(
     size: Variable,
     align: Variable,
 ) {
-    let mut owner_path: Vec<String> = layout_owner.split("::").map(str::to_string).collect();
+    let mut owner_path = crate::model::split_qualified_path(layout_owner);
     let ctor_name = owner_path.pop().unwrap_or_default();
     let ctor_target = if owner_path.is_empty() {
         CallTarget::synthetic_transparent_ctor(ctor_name)

--- a/majit/majit-translate/src/front/iter_next.rs
+++ b/majit/majit-translate/src/front/iter_next.rs
@@ -332,8 +332,45 @@ fn stopiteration_exitcase() -> ExitCase {
     ExitCase::Const(ConstValue::builtin("StopIteration"))
 }
 
+/// Split the nullable-pointer form of an Option switch into `(None, Some)`.
+/// `front::mir::lower_niche_option_switch` closes `ptr != null` through
+/// `set_branch`, so false is None and true is Some.  This is the flow-graph
+/// shape RPython itself uses for a maybe-null pointer (`ptr_nonzero`).
+fn split_niche_bool_exits(exits: &[Link], name: &str) -> Result<(Link, Link), String> {
+    if exits.len() != 2 {
+        return Err(format!(
+            "{name}: niche Option switch has {} exits, expected 2",
+            exits.len()
+        ));
+    }
+    let mut none: Option<Link> = None;
+    let mut some: Option<Link> = None;
+    for link in exits {
+        match link.exitcase {
+            Some(ExitCase::Bool(false)) => none = Some(link.clone()),
+            Some(ExitCase::Bool(true)) => some = Some(link.clone()),
+            _ => {
+                return Err(format!(
+                    "{name}: niche Option switch has non-bool exit case {:?}",
+                    link.exitcase
+                ));
+            }
+        }
+    }
+    match (none, some) {
+        (Some(none), Some(some)) => Ok((none, some)),
+        _ => Err(format!(
+            "{name}: niche Option switch lacks the false/true pair"
+        )),
+    }
+}
+
 fn int_const(i: i64) -> LinkArg {
     LinkArg::Const(Constant::new(ConstValue::Int(i)))
+}
+
+fn bool_const(value: bool) -> LinkArg {
+    LinkArg::Const(Constant::new(ConstValue::Bool(value)))
 }
 
 /// Rewrite every recorded `next()` call site into the `next` op +
@@ -527,34 +564,132 @@ fn rewire_one_next_site(
         .map_err(|e| format!("{name}: next call block exit: {e}"))?;
     assert_single_pred(graph, c, &name)?;
 
-    // Block C: `d = opt.__discriminant`; `switch d { 0 → None, 1 → Some }`.
-    let (disc_idx, disc_var) = graph.blocks[c]
-        .operations
-        .iter()
-        .enumerate()
-        .find_map(|(i, op)| match &op.kind {
-            OpKind::FieldRead { base, field, .. }
-                if *base == opt_c && field.name == "__discriminant" =>
-            {
-                op.result.clone().map(|r| (i, r))
+    // Block C has one of the two representation-faithful Option tests:
+    //
+    // * aggregate Option: `d = opt.__discriminant`; switch 0/1;
+    // * one-word niche Option: `d = bool(opt != null_mut())`; switch false/true.
+    //
+    // The latter is `ptr_nonzero` in an RPython graph. Rust uses it for a
+    // by-value array/Vec iterator whose T is itself a non-null pointer. The
+    // front folds the niche before this post-pass runs, so accepting both
+    // shapes here is required for one list-iterator representation rather
+    // than a separate Rust-specific iterator path.
+    let aggregate_disc =
+        graph.blocks[c]
+            .operations
+            .iter()
+            .enumerate()
+            .find_map(|(i, op)| match &op.kind {
+                OpKind::FieldRead { base, field, .. }
+                    if *base == opt_c && field.name == "__discriminant" =>
+                {
+                    op.result.clone().map(|r| (i, r))
+                }
+                _ => None,
+            });
+    let (none_link, some_link, aggregate_payload, branch_value_vars) = if let Some((
+        disc_idx,
+        disc_var,
+    )) = aggregate_disc
+    {
+        match &graph.blocks[c].exitswitch {
+            Some(ExitSwitch::Value(v)) if *v == disc_var => {}
+            other => {
+                return Err(format!(
+                    "{name}: block {c} exitswitch {other:?} is not the Option discriminant switch"
+                ));
             }
-            _ => None,
-        })
-        .ok_or_else(|| format!("{name}: block {c} lacks the Option __discriminant read"))?;
-    match &graph.blocks[c].exitswitch {
-        Some(ExitSwitch::Value(v)) if *v == disc_var => {}
-        other => {
-            return Err(format!(
-                "{name}: block {c} exitswitch {other:?} is not the Option discriminant switch"
-            ));
         }
-    }
-    // Block C is bypassed; only the discriminant read may carry an effect.
-    assert_block_pure_besides(graph, c, &[disc_idx], "discriminant", &name)?;
-
-    // Option discriminant: None = 0, Some = 1.  `split_diamond_exits`
-    // returns `(case 0, case 1)` = `(None arm, Some arm)`.
-    let (none_link, some_link) = split_diamond_exits(&graph.blocks[c].exits, &name)?;
+        // Block C is bypassed; only the discriminant read may carry an
+        // effect in the aggregate shape.
+        assert_block_pure_besides(graph, c, &[disc_idx], "discriminant", &name)?;
+        let (none_link, some_link) = split_diamond_exits(&graph.blocks[c].exits, &name)?;
+        let branch_value_vars = vec![disc_var.clone()];
+        (none_link, some_link, true, branch_value_vars)
+    } else {
+        // Find `ne(opt_c, null)` and prove the other operand is the
+        // adjacent pure `core::ptr::null_mut` source the niche fold emits.
+        let (ne_idx, ne_var, null_var) = graph.blocks[c]
+                .operations
+                .iter()
+                .enumerate()
+                .find_map(|(i, op)| match (&op.kind, op.result.as_ref()) {
+                    (
+                        OpKind::BinOp {
+                            op,
+                            lhs,
+                            rhs,
+                            ..
+                        },
+                        Some(result),
+                    ) if op == "ne" && (*lhs == opt_c || *rhs == opt_c) => Some((
+                        i,
+                        result.clone(),
+                        if *lhs == opt_c {
+                            rhs.clone()
+                        } else {
+                            lhs.clone()
+                        },
+                    )),
+                    _ => None,
+                })
+                .ok_or_else(|| {
+                    format!(
+                        "{name}: block {c} lacks both an Option __discriminant read and a nullable-pointer test"
+                    )
+                })?;
+        let null_idx = graph.blocks[c]
+            .operations
+            .iter()
+            .enumerate()
+            .find_map(|(i, op)| {
+                (op.result.as_ref() == Some(&null_var)
+                    && matches!(
+                        &op.kind,
+                        OpKind::Call {
+                            target: CallTarget::FunctionPath { segments },
+                            args,
+                            ..
+                        } if args.is_empty()
+                            && segments == &["core", "ptr", "null_mut"]
+                    ))
+                .then_some(i)
+            })
+            .ok_or_else(|| {
+                format!("{name}: block {c} nullable-pointer test has no null_mut source")
+            })?;
+        let (bool_idx, bool_var) = graph.blocks[c]
+            .operations
+            .iter()
+            .enumerate()
+            .find_map(|(i, op)| match (&op.kind, op.result.as_ref()) {
+                (OpKind::UnaryOp { op, operand, .. }, Some(result))
+                    if op == "bool" && *operand == ne_var =>
+                {
+                    Some((i, result.clone()))
+                }
+                _ => None,
+            })
+            .ok_or_else(|| format!("{name}: block {c} nullable-pointer test lacks bool wrap"))?;
+        match &graph.blocks[c].exitswitch {
+            Some(ExitSwitch::Value(v)) if *v == bool_var => {}
+            other => {
+                return Err(format!(
+                    "{name}: block {c} exitswitch {other:?} is not the niche Option bool switch"
+                ));
+            }
+        }
+        assert_block_pure_besides(
+            graph,
+            c,
+            &[null_idx, ne_idx, bool_idx],
+            "nullable-pointer discriminant",
+            &name,
+        )?;
+        let (none_link, some_link) = split_niche_bool_exits(&graph.blocks[c].exits, &name)?;
+        let branch_value_vars = vec![ne_var, bool_var.clone()];
+        (none_link, some_link, false, branch_value_vars)
+    };
     let some_target = some_link.target;
     let none_target = none_link.target;
 
@@ -569,11 +704,21 @@ fn rewire_one_next_site(
             LinkArg::Value(v) => {
                 if *v == opt_c {
                     normal_args.push(LinkArg::Value(opt.clone()));
-                    payload_positions.push(i);
-                } else if *v == disc_var {
-                    normal_args.push(int_const(1));
+                    // Aggregate Some arms still read `__pos_0`; a nullable
+                    // pointer is already its payload, so there is no field
+                    // read to collapse in the niche form.
+                    if aggregate_payload {
+                        payload_positions.push(i);
+                    }
+                } else if branch_value_vars.contains(v) {
+                    normal_args.push(if aggregate_payload {
+                        int_const(1)
+                    } else {
+                        bool_const(true)
+                    });
                 } else {
-                    let v_a = back_substitute(graph, &[(a, c)], v, &name)?;
+                    let v_a = back_substitute(graph, &[(a, c)], v, &name)
+                        .map_err(|e| format!("{e}; Some-link source variable id {}", v.id()))?;
                     normal_args.push(LinkArg::Value(v_a));
                 }
             }
@@ -665,9 +810,16 @@ fn rewire_one_next_site(
         }
         match arg {
             LinkArg::Const(c0) => none_args.push(LinkArg::Const(c0.clone())),
-            LinkArg::Value(v) if *v == disc_var => none_args.push(int_const(0)),
+            LinkArg::Value(v) if branch_value_vars.contains(v) => {
+                none_args.push(if aggregate_payload {
+                    int_const(0)
+                } else {
+                    bool_const(false)
+                });
+            }
             LinkArg::Value(v) => {
-                let v_a = back_substitute(graph, &[(a, c)], v, &name)?;
+                let v_a = back_substitute(graph, &[(a, c)], v, &name)
+                    .map_err(|e| format!("{e}; None-link source variable id {}", v.id()))?;
                 none_args.push(LinkArg::Value(v_a));
             }
         }
@@ -844,5 +996,18 @@ mod tests {
                 "{recorded:?} element must not be retyped as a GC reference",
             );
         }
+    }
+
+    #[test]
+    fn nullable_pointer_option_exits_split_false_none_true_some() {
+        let none_target = crate::model::BlockId(3);
+        let some_target = crate::model::BlockId(4);
+        let exits = vec![
+            Link::new_mixed(Vec::new(), some_target, Some(ExitCase::Bool(true))),
+            Link::new_mixed(Vec::new(), none_target, Some(ExitCase::Bool(false))),
+        ];
+        let (none, some) = split_niche_bool_exits(&exits, "test").expect("split niche exits");
+        assert_eq!(none.target, none_target);
+        assert_eq!(some.target, some_target);
     }
 }

--- a/majit/majit-translate/src/front/iter_next.rs
+++ b/majit/majit-translate/src/front/iter_next.rs
@@ -15,8 +15,11 @@
 //! lowered (in MIR) as a `__discriminant` read on `opt` plus a two-way
 //! `switchInt` (None = 0, Some = 1).  RPython's `next` op returns the
 //! element directly and raises `StopIteration` at exhaustion
-//! (`rpython/flowspace/operation.py` `next`; the annotator's
-//! `op.next.can_only_throw` is `[StopIteration, RuntimeError]`).  This
+//! (`Next.canraise = [StopIteration, RuntimeError]`,
+//! `rpython/flowspace/operation.py:594-599`; the annotator narrows that per
+//! container — `SomeIterator.next.can_only_throw` is the callable
+//! `_can_only_throw`, which appends `RuntimeError` only for a `SomeDict`
+//! container, `rpython/annotator/unaryop.py:811-829`).  This
 //! module rewrites the value-encoded Option diamond into that exception
 //! representation — the mirror of [`crate::front::result_exc`]'s
 //! `Result`/`?` rewrite.  The Option diamond is the same shape minus the
@@ -26,9 +29,9 @@
 //! gates on the iterator tracing back to an `iter` op
 //! (`originates_from_iter_op`), so only a list iterator reaches it, and
 //! `ListIteratorRepr::rtype_next` raises solely `StopIteration` — the
-//! block carries no catch-all propagation edge (the `RuntimeError` half
-//! of `next`'s conservative `can_only_throw` is dict-iterator mutation
-//! detection that never fires here, and `flowin` drops the unhandled
+//! block carries no catch-all propagation edge (the `RuntimeError` half is
+//! `Next.canraise`'s conservative pair, which `_can_only_throw` already
+//! drops for a non-dict container, and `flowin` drops the unhandled
 //! remainder).
 //!
 //! ## The rewrite (`rewire_one_next_site`)

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -32967,6 +32967,25 @@ mod tests {
             residual.is_empty(),
             "owned Wtf8Buf appends must lift to StringBuilder operations: {residual:#?}"
         );
+        let residual_vec_indexes: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if super::fmt_path_ends_with(segments, &["vec", "Vec", "index"])
+                )
+            })
+            .collect();
+        assert!(
+            residual_vec_indexes.is_empty(),
+            "repr string lists must iterate without a fat-pointer Vec::index: \
+             {residual_vec_indexes:#?}"
+        );
         for block in &graph.blocks {
             let mut defined: std::collections::HashSet<u64> =
                 block.inputargs.iter().map(|var| var.id()).collect();
@@ -33116,11 +33135,11 @@ mod tests {
     /// Real-LLBC anchors for three roots that spell one PyPy operation —
     /// an ordinary list read — over three different host containers.
     ///
-    /// Only `combine_starargs_wrapped` may lower: its elements are object
-    /// pointers, one target word each, so the emitted getarrayitem's stride
-    /// is the host stride.  `dict_repr` and `bind_builtin_kwargs` are held
-    /// here as counter-examples on purpose; being the same PyPy shape is not
-    /// what makes a read addressable, the element width is.
+    /// `combine_starargs_wrapped` lowers because its elements are object
+    /// pointers, one target word each. `dict_repr` must first flatten its
+    /// host-width key/value pairs into the same one-word rooted-list shape.
+    /// `bind_builtin_kwargs` remains the counter-example: being the same PyPy
+    /// shape is not what makes a read addressable, the element width is.
     #[test]
     #[ignore]
     fn pypy_list_item_roots_have_no_residual_vec_index() {
@@ -33154,32 +33173,20 @@ mod tests {
             "argument-list concatenation indexes object pointers, one target \
              word each, so its getitems must not remain Vec::index"
         );
-        // The other two are NOT in that set, and must not be added by widening
-        // the element gate.  Both are the same PyPy list read over a host
-        // container whose element is WIDER than one word, and no translation
-        // replaces the container:
-        //
-        // * `dict_repr` indexes `w_dict_items`'s
-        //   `Vec<(PyObjectRef, PyObjectRef)>`.  PyPy's `dictmultiobject.py`
-        //   pair really is one GC pointer per item, but only inside a list the
-        //   translation builds; here it is an INLINE 16-byte tuple, so a
-        //   one-word getarrayitem would read each pair's key twice and never
-        //   its value.
-        // * `bind_builtin_kwargs` indexes `names: &[&str]`.  PyPy's
-        //   `Signature.argnames` is a list of `Ptr(STR)`, but `&str` is a
-        //   two-word fat pointer here, so the same read would land mid-element
-        //   from the second name on.
-        //
-        // Lowering either means giving the pyre side a managed list — the one
-        // container whose items are one GCREF each — not relaxing the width
-        // proof in the element gate.
-        for fname in ["dict_repr", "bind_builtin_kwargs"] {
-            assert!(
-                residual_vec_indexes(fname) > 0,
-                "{fname}: a wider-than-one-word host element must keep its \
-                 residual Vec::index"
-            );
-        }
+        assert_eq!(
+            residual_vec_indexes("dict_repr"),
+            0,
+            "dict_repr must flatten host-width pairs before translated reads"
+        );
+        // `bind_builtin_kwargs` indexes `names: &[&str]`. PyPy's
+        // `Signature.argnames` is a list of `Ptr(STR)`, but `&str` is a
+        // two-word fat pointer here, so a one-word getarrayitem would land
+        // mid-element from the second name on. Lowering it requires a managed
+        // string list, not a wider element gate.
+        assert!(
+            residual_vec_indexes("bind_builtin_kwargs") > 0,
+            "a wider-than-one-word host element must keep its residual Vec::index"
+        );
     }
 
     /// `exception_descr_str_wtf8` indexes the Python unicode carrier through

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8726,8 +8726,8 @@ impl<'a> Lowering<'a> {
                 // therefore the same array value in the translated model, and its
                 // length is the block capacity the descr reports.  Fold only these
                 // capacity-length enclosing accessors, not arbitrary raw slices
-                // (`object_items_slice` uses the logical list length, not the
-                // capacity — see [`is_container_items_view_from_raw_parts`]).
+                // (an object list's logical length can differ from its items
+                // block capacity — see [`is_container_items_view_from_raw_parts`]).
                 if args.len() == 2 && self.is_container_items_view_from_raw_parts(&reg) {
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
@@ -8857,6 +8857,52 @@ impl<'a> Lowering<'a> {
                             op: "lt".to_string(),
                             lhs: bits.clone(),
                             rhs: zero.clone(),
+                            result_ty: ValueType::Int,
+                        },
+                    });
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
+                // `f64::is_sign_positive(x)` is the complementary sign-bit
+                // test, `float2longlong(x) >= 0`. PyPy spells the complex repr
+                // decision as `math.copysign(1.0, x) == 1.0`; both must inspect
+                // the sign bit so +0.0/-0.0 remain distinct.
+                if args.len() == 1 && self.is_f64_is_sign_positive(&reg) {
+                    let bits = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(bits.clone()),
+                        kind: OpKind::Call {
+                            target: CallTarget::FunctionPath {
+                                segments: vec![
+                                    "longlong2float".to_string(),
+                                    "float2longlong".to_string(),
+                                ],
+                            },
+                            args: vec![args[0].clone()],
+                            result_ty: ValueType::Int,
+                        },
+                    });
+                    let zero = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(zero.clone()),
+                        kind: OpKind::ConstInt(0),
+                    });
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::BinOp {
+                            op: "ge".to_string(),
+                            lhs: bits,
+                            rhs: zero,
                             result_ty: ValueType::Int,
                         },
                     });
@@ -9654,6 +9700,29 @@ impl<'a> Lowering<'a> {
             OpKind::Hint {
                 value: args[0].clone(),
                 kind,
+            }
+        } else {
+            op_kind
+        };
+
+        // PyPy float repr and each complex repr component call
+        // `rfloat.formatd`, an external returning one low-level `STR` GC
+        // pointer. RustPython's equivalent host formatters return a three-word
+        // Rust `String`, which the residual ABI cannot express. Retarget only
+        // those exact formatting boundaries to one-word `BytesBlock*`
+        // wrappers; the complex sign/parenthesis builder remains in its graph.
+        let op_kind = if let OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 1
+            && let Some(residual) = crate::front::rfloat_call::repr_residual_path(segments)
+        {
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments: residual },
+                args: args.clone(),
+                result_ty: ValueType::Ref(None),
             }
         } else {
             op_kind
@@ -11458,13 +11527,12 @@ impl<'a> Lowering<'a> {
     /// Only capacity-length views qualify: `digits` builds its slice with
     /// `from_raw_parts(base, capacity)` (the block header's own length), so the
     /// header-alias descr (which reports capacity) preserves the length exactly.
-    /// `W_ListObject::object_items_slice{,_mut}` is deliberately EXCLUDED — it
-    /// uses `from_raw_parts(base, self.length)`, the *logical* list length,
-    /// which is `< capacity` when the block is over-allocated (e.g. after
-    /// `pop`).  Aliasing it to the header would make `items.len()` report
-    /// capacity, so `w_list_getitem` would accept an index in
-    /// `[length, capacity)` and return a stale slot instead of raising.  Fold
-    /// only the capacity-length enclosing accessors, not arbitrary raw slices.
+    /// Object-list storage is deliberately excluded: its *logical* list
+    /// length is `< capacity` when the block is over-allocated (e.g. after
+    /// `pop`). Aliasing a logical-length view to the header would make a
+    /// consumer observe capacity and accept an index in `[length, capacity)`.
+    /// The object-list port therefore follows `rlist.ll_getitem_fast` and
+    /// reads `length` plus the indexed item directly, without a raw slice.
     fn is_container_items_view_from_raw_parts(&self, reg: &RegularCall) -> bool {
         if !(self.graph.name.ends_with("rbigint::<Impl>::digits")
             || self.graph.name.ends_with("rbigint::<Impl>::digits_mut"))
@@ -12302,6 +12370,19 @@ impl<'a> Lowering<'a> {
         self.llbc
             .fn_by_id(*id)
             .is_some_and(|fd| fd.item_meta.name_path() == "core::f64::<Impl>::is_sign_negative")
+    }
+
+    /// `f64::is_sign_positive(self)` — the positive half of the same sign-bit
+    /// primitive as [`Self::is_f64_is_sign_negative`]. Reinterpret the f64 as
+    /// a signed i64 and test `>= 0`; a numerical comparison with zero would
+    /// incorrectly classify `-0.0` and sign-bit-set NaN.
+    fn is_f64_is_sign_positive(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc
+            .fn_by_id(*id)
+            .is_some_and(|fd| fd.item_meta.name_path() == "core::f64::<Impl>::is_sign_positive")
     }
 
     /// `majit_metainterp::jit::promote(x)` = `hint(x, promote=True)`
@@ -29020,7 +29101,7 @@ mod tests {
                         value: crate::model::LinkArg::Value(value),
                         array_type_id: Some(array_type_id),
                         ..
-                    } if value == cast_result && array_type_id == super::PYOBJECT_GCARRAY_TYPE_ID
+                    } if value == cast_result && array_type_id == super::OBJECT_REF_GCARRAY_TYPE_ID
                 )
             })
         });
@@ -29644,20 +29725,19 @@ mod tests {
         );
     }
 
-    /// `W_ListObject::object_items_slice` builds its slice with
-    /// `from_raw_parts(base, self.length)` (the LOGICAL list length, `<`
-    /// capacity for an over-allocated block), so it must NOT fold to the
-    /// items-block header (whose gcarray descr reports capacity). The residual
-    /// `from_raw_parts` call must survive. Loads the pyre-object LLBC (the
-    /// accessor lives in `pyre_object::listobject`), so ignored by default.
+    /// RPython `ll_getitem_fast` indexes a list's items array after checking
+    /// the list's logical length. The pyre object-list path must keep that
+    /// direct shape instead of manufacturing a Rust fat slice with
+    /// `from_raw_parts(base, self.length)`: such a slice is neither an RPython
+    /// source operation nor representable by the one-word GC-array model.
+    /// Loads the pyre-object LLBC, so ignored by default.
     #[test]
     #[ignore]
-    fn object_items_slice_keeps_residual_from_raw_parts_not_header_alias() {
+    fn object_list_getitem_keeps_logical_length_without_a_raw_slice() {
         use crate::model::{CallTarget, OpKind};
         let path = crate::runtime_names::artifacts::OBJECT_ULLBC;
         let llbc = Llbc::load(path).expect("load pyre-object LLBC");
-        let graph =
-            super::lower_function(&llbc, "object_items_slice").expect("lower object_items_slice");
+        let graph = super::lower_function(&llbc, "w_list_getitem").expect("lower w_list_getitem");
         let from_raw_parts_calls = graph
             .blocks
             .iter()
@@ -29670,10 +29750,120 @@ mod tests {
                 )
             })
             .count();
+        assert_eq!(
+            from_raw_parts_calls, 0,
+            "object-list getitem must read logical length and items directly, \
+             like rlist.ll_getitem_fast"
+        );
+    }
+
+    /// PyPy `float_repr` reaches `rfloat.formatd`, whose translated return is
+    /// one low-level string pointer. The real interpreter LLBC must therefore
+    /// retarget RustPython's three-word `String` formatter to the one-word
+    /// `BytesBlock*` residual wrapper.
+    #[test]
+    #[ignore]
+    fn float_repr_uses_the_rpython_string_residual_abi() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load pyre-interpreter LLBC");
+        let graph =
+            super::lower_function(&llbc, "format_float_repr").expect("lower format_float_repr");
+        let paths: Vec<Vec<String>> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| block.operations.iter())
+            .filter_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } => Some(segments.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(paths.iter().any(|segments| {
+            segments
+                == &[
+                    "pyre_interpreter".to_string(),
+                    "display".to_string(),
+                    "jit_format_float_repr_rstr".to_string(),
+                ]
+        }));
+        assert!(!paths.iter().any(|segments| {
+            segments
+                == &[
+                    "rustpython_literal".to_string(),
+                    "float".to_string(),
+                    "to_string".to_string(),
+                ]
+        }));
+    }
+
+    /// PyPy's complex repr keeps its positive-zero/sign branch in
+    /// `W_ComplexObject.descr_repr` and calls `repr_format` for each component.
+    /// The interpreter graph must retain that shape rather than collapsing the
+    /// whole operation into RustPython's foreign complex formatter.
+    #[test]
+    #[ignore]
+    fn complex_repr_keeps_the_pypy_builder_and_float_formatter_calls() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load pyre-interpreter LLBC");
+        let graph =
+            super::lower_function(&llbc, "complex_repr_string").expect("lower complex repr");
+        let paths: Vec<Vec<String>> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| block.operations.iter())
+            .filter_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } => Some(segments.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(paths.iter().any(|segments| {
+            segments
+                == &[
+                    "pyre_interpreter".to_string(),
+                    "typedef".to_string(),
+                    "jit_format_complex_component_repr_rstr".to_string(),
+                ]
+        }));
+        assert!(!paths.iter().any(|segments| {
+            segments
+                == &[
+                    "rustpython_literal".to_string(),
+                    "complex".to_string(),
+                    "to_string".to_string(),
+                ]
+        }));
+        assert!(!paths.iter().any(|segments| {
+            segments
+                == &[
+                    "core".to_string(),
+                    "f64".to_string(),
+                    "<Impl>".to_string(),
+                    "is_sign_positive".to_string(),
+                ]
+        }));
+        assert!(paths.iter().any(|segments| {
+            segments == &["longlong2float".to_string(), "float2longlong".to_string()]
+        }));
         assert!(
-            from_raw_parts_calls >= 1,
-            "object_items_slice must keep its residual from_raw_parts (logical \
-             length != capacity), not alias to the items-block header"
+            !paths.iter().any(|segments| {
+                segments
+                    .last()
+                    .is_some_and(|leaf| leaf == "push" || leaf == "push_str")
+            }),
+            "complex repr String appends must use the RPython builder lift: {paths:#?}"
         );
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2858,11 +2858,17 @@ fn simplify_lowered_graph(
     // eagerly so the direct-scan passes see the same surface
     // `iterblocks()` exposes upstream.
     crate::model::clear_unreachable_blocks(graph);
+    // Rust's `ptr::write(raw as *mut T, T { .. })` is the source spelling of
+    // RPython's already-allocated object followed by one setfield per member.
+    // Lower that aggregate copy before allocation fusion so generic
+    // `core::ptr::write<T>` never becomes one shared FunctionDesc whose `T`
+    // argument would merge unrelated object classes.
+    let mut dirty = crate::model::lower_struct_ptr_writes(graph, struct_field_attrs) > 0;
     // Lower the boxing-constructor idiom `malloc_typed(W_FloatObject{…})`
     // to a native `NewWithVtable` + payload store before the dead-aggregate
     // sweep, which then reclaims the orphaned construct-on-stack ctor and
     // header field writes.
-    let mut dirty = crate::model::fuse_boxing_alloc(graph, struct_field_attrs) > 0;
+    dirty |= crate::model::fuse_boxing_alloc(graph, struct_field_attrs) > 0;
     // Reclaim boxing-cluster remnants (fused header ctors/casts, and a
     // `vec![…]` box whose consumer became a `newlist`) using dependency-flow
     // liveness (`transform_dead_op_vars`, simplify.py) with the
@@ -28511,6 +28517,61 @@ mod tests {
             narrowed_none,
             "the niche None arm must be the same nullable PyObject/W_Root repr as the Some arm"
         );
+    }
+
+    #[test]
+    #[ignore]
+    fn struct_ptr_write_lowers_to_per_field_initialization() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        for (name, owner, expected_fields) in [
+            ("w_cell_new", "Cell", &["ob", "contents", "family"][..]),
+            (
+                "w_long_from_raw",
+                "W_LongObject",
+                &["ob_header", "value"][..],
+            ),
+        ] {
+            let graph = super::lower_function(&llbc, name).expect("lower function");
+            assert!(
+                !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                    matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if segments == &["core", "ptr", "write"])
+                }),
+                "{name}: generic core::ptr::write must not survive as a shared callee"
+            );
+            let destination = graph
+                .blocks
+                .iter()
+                .flat_map(|b| &b.operations)
+                .find_map(|op| match (&op.result, &op.kind) {
+                    (
+                        Some(result),
+                        OpKind::Call {
+                            target: CallTarget::FunctionPath { segments },
+                            ..
+                        },
+                    ) if segments == &["__pyre_cast_instance", owner] => Some(result),
+                    _ => None,
+                })
+                .expect("typed raw allocation destination");
+            let fields: Vec<_> = graph
+                .blocks
+                .iter()
+                .flat_map(|b| &b.operations)
+                .filter_map(|op| match &op.kind {
+                    OpKind::FieldWrite { base, field, .. } if base == destination => {
+                        Some(field.name.as_str())
+                    }
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(fields, expected_fields, "{name}: source field order");
+        }
     }
 
     /// PyPy's `_match_keywords` indexes its small signature and argument

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -12698,6 +12698,7 @@ impl<'a> Lowering<'a> {
         let (option_owner, some_owner, payload_ty) = self.resolve_bool_then_option_dest(dest_ty)?;
         Some(crate::front::slice_first::SliceFirstSite {
             result_var: result_var.clone(),
+            index: None,
             option_owner,
             some_owner,
             payload_ty,
@@ -28671,6 +28672,33 @@ mod tests {
         assert!(
             !residuals.contains("unicodeobject::w_str_get_hash"),
             "the ordinary scalar memo read remains visible to the generated JIT"
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn deque_compare_scalar_slice_get_lowers_to_a_guarded_item_read() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "deque_compare").expect("lower deque_compare");
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments == &["core".to_string(), "slice".to_string(), "<Impl>".to_string(), "get".to_string()])
+            }),
+            "scalar slice get must not survive as an opaque core call"
+        );
+        assert!(
+            graph
+                .blocks
+                .iter()
+                .flat_map(|b| &b.operations)
+                .any(|op| matches!(op.kind, OpKind::ArrayRead { .. })),
+            "the successful get arm must read the guarded element"
         );
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2650,6 +2650,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
                 &mut lo.graph,
                 &closure_select_outcome.result_exc_calls,
                 result_exc_callee,
+                static_addrs.error_carrier,
             )
             .map_err(LowerError::Unsupported)?;
         }
@@ -13893,19 +13894,22 @@ impl<'a> Lowering<'a> {
             | ClosureCombinator::IsSomeAnd => clone_tyref(dest_ty),
         };
         let call_result_ty = tyref_to_value_type(&call_result_tyref, self.llbc);
-        let call_once_result_exc =
-            crate::front::result_exc::tyref_is_result_of_pyerror(&call_result_tyref, self.llbc)
-                .then(|| {
-                    let suffix = crate::front::result_exc::tyref_result_instantiation_suffix(
-                        &call_result_tyref,
-                        self.llbc,
-                    );
-                    let payload_ty =
-                        crate::front::result_exc::tyref_result_ok(&call_result_tyref, self.llbc)
-                            .map(|ty| tyref_to_value_type(&ty, self.llbc))
-                            .unwrap_or(ValueType::Ref(None));
-                    (suffix, payload_ty)
-                });
+        let call_once_result_exc = crate::front::result_exc::tyref_is_result_of_carrier(
+            &call_result_tyref,
+            self.llbc,
+            self.static_addrs.error_carrier,
+        )
+        .then(|| {
+            let suffix = crate::front::result_exc::tyref_result_instantiation_suffix(
+                &call_result_tyref,
+                self.llbc,
+            );
+            let payload_ty =
+                crate::front::result_exc::tyref_result_ok(&call_result_tyref, self.llbc)
+                    .map(|ty| tyref_to_value_type(&ty, self.llbc))
+                    .unwrap_or(ValueType::Ref(None));
+            (suffix, payload_ty)
+        });
         let niche = self.tyref_is_niche_option_ptr(recv_ty);
         // `map`/`and_then` BUILD their result `Option<U>`; the other combinators
         // build none.  `U` is the dest payload, not the receiver's `T`, so the

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -28523,11 +28523,22 @@ mod tests {
     #[ignore]
     fn struct_ptr_write_lowers_to_per_field_initialization() {
         use crate::model::{CallTarget, OpKind};
-        let path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../build/llbc/pyre-object.ullbc"
-        );
-        let llbc = Llbc::load(path).expect("load real LLBC");
+        let root = concat!(env!("CARGO_MANIFEST_DIR"), "/../../build/llbc/");
+        let llbcs = [
+            Llbc::load(format!("{root}pyre-object.ullbc")).expect("load pyre-object LLBC"),
+            Llbc::load(format!("{root}pyre-interpreter.ullbc"))
+                .expect("load pyre-interpreter LLBC"),
+            Llbc::load(format!("{root}pyre-jit.ullbc")).expect("load pyre-jit LLBC"),
+        ];
+        let names = ["w_cell_new", "w_long_from_raw", "w_str_from_wtf8_managed"];
+        let program =
+            super::build_semantic_program_from_llbcs_with_static_addrs_and_function_names(
+                &llbcs,
+                crate::HostStaticAddrs::default(),
+                &[],
+                &names,
+            )
+            .expect("build production-shaped semantic program");
         for (name, owner, expected_fields) in [
             ("w_cell_new", "Cell", &["ob", "contents", "family"][..]),
             (
@@ -28535,8 +28546,26 @@ mod tests {
                 "W_LongObject",
                 &["ob_header", "value"][..],
             ),
+            (
+                "w_str_from_wtf8_managed",
+                "W_UnicodeObject",
+                &[
+                    "ob_header",
+                    "value",
+                    "byte_len",
+                    "len",
+                    "w_slots",
+                    "index_storage",
+                    "hash",
+                ][..],
+            ),
         ] {
-            let graph = super::lower_function(&llbc, name).expect("lower function");
+            let graph = &program
+                .functions
+                .iter()
+                .find(|function| function.name == name)
+                .unwrap_or_else(|| panic!("missing semantic function {name}"))
+                .graph;
             assert!(
                 !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
                     matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -7911,17 +7911,42 @@ impl<'a> Lowering<'a> {
                 // escape guard (a failing shape stays residual — safe).  The
                 // read leaf (`index`, a value copy) needs no such guard.
                 let workspace_index = self.is_workspace_index_call(&reg);
+                // `&vec[..]` / `&mut vec[..]` is Rust's whole-list borrowed
+                // view (`Index<RangeFull>`). RPython has no borrow wrapper:
+                // both sides are the same `SomeList` value.  Preserve that
+                // identity before the scalar element arm; Range/RangeFrom/
+                // RangeTo remain real getslice operations.
+                if args.len() == 2 && is_vec_rangefull_index_regular(&reg, self.llbc) {
+                    self.local_var[dest_local] = Some(args[0].clone());
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // `ArrayRead` addresses its element as `base + index *
-                // itemsize`.  RPython can leave that width implicit — every
-                // non-primitive there IS a one-word GC pointer — but a Rust
-                // `Vec<T>` stores `T` inline, so a `Vec<u8>` strides 1 and a
-                // `Vec<String>` strides 24.  An element that is neither a
-                // sizable scalar nor a thin pointer falls through to the
-                // residual call, where Rust computes the address itself.
+                // itemsize`.  A scalar host element carries its spelling as
+                // the array identity so the descr computes the exact width;
+                // a thin pointer, or a source value translated to RPython's
+                // one-word GC pointer repr, needs only that pointer identity.
+                // Any other inline Rust ADT falls through to the residual
+                // call: assigning it a target-word stride would be false.
+                // The workspace arm asks nothing: its `pyre_` fence admits
+                // exactly the three element banks named below, all one word.
                 let element_node = tyref_index_element_node(&call.dest.ty, self.llbc);
                 let element_scalar =
                     element_node.and_then(|elem| json_ty_scalar_element_spelling(elem, self.llbc));
-                let element_is_addressable = element_scalar.is_some()
+                // RPython's string list item is one GC pointer
+                // (`lltypesystem/rstr.py:229-230`, `StringRepr.lowleveltype =
+                // Ptr(STR)`).  Rust's `&str` is a fat pointer before source
+                // translation, but the translated value is the same
+                // `SomeString` / `Ptr(STR)` used for `String`, `Wtf8`, and
+                // `Wtf8Buf` everywhere else in this front end.  Name that
+                // translated element `str` so `get_array_descr` computes the
+                // RPython pointer item, never the host Rust width.
+                let element_rpython_ref = element_node
+                    .and_then(|elem| json_ty_rpython_gc_pointer_element_spelling(elem, self.llbc));
+                let element_spelling = element_scalar.or(element_rpython_ref);
+                let element_is_addressable = element_spelling.is_some()
                     || element_node
                         .is_some_and(|elem| json_ty_is_thin_pointer_element(elem, self.llbc));
                 let index_leg = args.len() == 2
@@ -8008,7 +8033,7 @@ impl<'a> Lowering<'a> {
                         // non-`Ref` element at 8 bytes, so a narrow int read
                         // through such a receiver would stride past its
                         // neighbours.
-                        element_scalar
+                        element_spelling
                             .as_deref()
                             .map(|elem| format!("[{elem}]"))
                             .or_else(|| {
@@ -16401,10 +16426,25 @@ fn constants_call_leaf(reg: &RegularCall, llbc: &Llbc) -> Option<&'static str> {
 /// same gate is shared by the call-lowering intercept and the deferred-write
 /// liveness pre-pass.
 fn vec_index_regular_leaf(reg: &RegularCall, llbc: &Llbc) -> Option<&'static str> {
+    let leaf = vec_index_regular_unchecked_leaf(reg, llbc)?;
+    let int_indexed = reg
+        .generics
+        .get("types")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|tys| tys.get(1))
+        .and_then(|t| serde_json::from_value::<TyRef>(t.clone()).ok())
+        .is_some_and(|t| vec_index_type_is_scalar(&t, llbc));
+    int_indexed.then_some(leaf)
+}
+
+/// The Vec Index/IndexMut leaf before classifying its index argument.  Scalar
+/// element access and the `RangeFull` whole-list identity share this exact
+/// owner proof but intentionally take different lowerings.
+fn vec_index_regular_unchecked_leaf(reg: &RegularCall, llbc: &Llbc) -> Option<&'static str> {
     let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
         return None;
     };
-    let leaf = llbc.fn_by_id(*id).and_then(|fd| {
+    llbc.fn_by_id(*id).and_then(|fd| {
         impl_method_owner_for_fundecl(llbc, fd).and_then(|(owner, leaf)| {
             if owner != "vec::Vec" {
                 return None;
@@ -16415,15 +16455,23 @@ fn vec_index_regular_leaf(reg: &RegularCall, llbc: &Llbc) -> Option<&'static str
                 _ => None,
             }
         })
-    })?;
-    let int_indexed = reg
-        .generics
+    })
+}
+
+/// `Vec<T>::index(_mut)(RangeFull)` creates only a borrowed whole-list view.
+/// The translated RPython list model has no distinct borrow/slice wrapper, so
+/// the callsite aliases the receiver instead of residualizing a Rust trait
+/// shim.
+fn is_vec_rangefull_index_regular(reg: &RegularCall, llbc: &Llbc) -> bool {
+    if vec_index_regular_unchecked_leaf(reg, llbc).is_none() {
+        return false;
+    }
+    reg.generics
         .get("types")
         .and_then(serde_json::Value::as_array)
         .and_then(|tys| tys.get(1))
         .and_then(|t| serde_json::from_value::<TyRef>(t.clone()).ok())
-        .is_some_and(|t| vec_index_type_is_scalar(&t, llbc));
-    int_indexed.then_some(leaf)
+        .is_some_and(|t| tyref_to_ast_string(&t, llbc) == "RangeFull")
 }
 
 /// Whether `ty` is an index type [`vec_index_regular_leaf`] may lower to a
@@ -19484,6 +19532,34 @@ fn json_ty_is_thin_pointer_element(node: &serde_json::Value, llbc: &Llbc) -> boo
         return false;
     };
     json_ty_is_statically_sized(pointee, llbc)
+}
+
+/// The element spelling of source values whose RPython repr is a one-word GC
+/// pointer even though their Rust source representation is wider.
+///
+/// RPython strings are `Ptr(STR)` (`lltypesystem/rstr.py:229-230`) and
+/// non-empty tuples are `Ptr(GcStruct(...))` (`rtuple.py:116-126`).  These are
+/// exactly the two non-scalar value families a PyPy list stores by reference;
+/// admitting arbitrary named Rust ADTs here would falsely shrink inline host
+/// structs to one word.
+fn json_ty_rpython_gc_pointer_element_spelling(
+    node: &serde_json::Value,
+    llbc: &Llbc,
+) -> Option<String> {
+    let ty = TyRef::Other(node.clone());
+    if tyref_is_string_value(&ty, llbc) {
+        return Some("str".to_string());
+    }
+    let node = strip_ty_indirections(node, llbc)?;
+    let adt = node.as_object()?.get("Adt")?.as_object()?;
+    if adt.get("id").and_then(serde_json::Value::as_str) != Some("Tuple") {
+        return None;
+    }
+    let types = adt.get("generics")?.as_object()?.get("types")?.as_array()?;
+    if types.is_empty() {
+        return None;
+    }
+    Some(charon_type_value_to_ast_string(node, llbc, 0))
 }
 
 /// `true` when `node` names a type of compile-time-known size, which is what
@@ -24578,7 +24654,8 @@ mod tests {
     use super::{
         DecodedConst, FnPtrFamily, cast_kind_is_raw_ptr, cast_pointer_marker_op,
         charon_const_generic_to_string, charon_type_value_to_ast_string, decode_literal,
-        fn_ptr_family_for, json_ty_is_thin_pointer_element, json_ty_scalar_element_spelling,
+        fn_ptr_family_for, json_ty_is_thin_pointer_element,
+        json_ty_rpython_gc_pointer_element_spelling, json_ty_scalar_element_spelling,
         shaped_array_parts, simplify_lowered_graph, tyref_array_suffix, tyref_is_raw_byte_ptr,
     };
     use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, ValueType};
@@ -27524,6 +27601,43 @@ mod tests {
         assert!(!thin(uint("U8")));
     }
 
+    /// RPython stores strings and non-empty tuples as GC pointers inside a
+    /// list (`rstr.py:229-230`, `rtuple.py:116-126`).  The MIR source types
+    /// can be wider (`&str`, an inline Rust tuple), but their translated list
+    /// element repr must retain the upstream one-word shape.  An arbitrary
+    /// named ADT remains excluded.
+    #[test]
+    fn rpython_string_and_tuple_list_items_are_gc_pointer_elements() {
+        let llbc = llbc_with_trait_impls(serde_json::json!([]));
+        let spelling =
+            |ty: serde_json::Value| json_ty_rpython_gc_pointer_element_spelling(&ty, &llbc);
+        let str_ty = serde_json::json!({
+            "Adt": {
+                "id": {"Builtin": "Str"},
+                "generics": {"types": []}
+            }
+        });
+        assert_eq!(spelling(str_ty).as_deref(), Some("str"));
+
+        let tuple_ty = serde_json::json!({
+            "Adt": {
+                "id": "Tuple",
+                "generics": {
+                    "types": [
+                        {"Literal": {"UInt": "U8"}},
+                        {"RawPtr": [{"Literal": {"Int": "I64"}}, "Mut"]}
+                    ]
+                }
+            }
+        });
+        assert_eq!(spelling(tuple_ty).as_deref(), Some("(u8,*mut i64)"));
+
+        let named_adt = serde_json::json!({
+            "Adt": {"id": {"Adt": 7}, "generics": {"types": []}}
+        });
+        assert_eq!(spelling(named_adt), None);
+    }
+
     /// `[T]`, `str` and `dyn Trait` each have two Charon spellings — a
     /// top-level `{"Slice": elem}` and the `{"Adt": {"id": {"Builtin":
     /// "Slice"}}}` form.  A pointer to any of them is fat, and the width proof
@@ -30464,7 +30578,7 @@ mod tests {
     /// call that prevents the whole builtin-call chain from being annotated.
     #[test]
     #[ignore]
-    fn bind_kwargs_scalar_slice_indexes_lower_to_array_reads() {
+    fn bind_kwargs_indexes_lower_to_array_reads() {
         use crate::model::{CallTarget, OpKind};
         let path = crate::runtime_names::artifacts::INTERPRETER_ULLBC;
         let llbc = Llbc::load(path).expect("load real LLBC");
@@ -30495,6 +30609,26 @@ mod tests {
             residual_scalar_indexes.len(),
             0,
             "scalar SliceIndex<usize> calls must become getitem operations"
+        );
+        let residual_vec_indexes: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if super::fmt_path_ends_with(segments, &["vec", "Vec", "index"])
+                )
+            })
+            .collect();
+        assert_eq!(
+            residual_vec_indexes.len(),
+            0,
+            "PyPy argument.py list getitems must not remain opaque Vec::index calls: \
+             {residual_vec_indexes:#?}"
         );
         assert!(
             graph
@@ -30551,6 +30685,47 @@ mod tests {
             }),
             "From<bool> for usize should use RPython's cast_bool_to_uint path"
         );
+    }
+
+    /// Real-LLBC anchors for the three roots that previously left
+    /// `vec::Vec::index` opaque. Their corresponding PyPy operations are
+    /// ordinary list reads: argument-list concatenation, dict-item tuple
+    /// reads, and gateway keyword-name/value matching.
+    #[test]
+    #[ignore]
+    fn pypy_list_item_roots_have_no_residual_vec_index() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        for fname in [
+            "combine_starargs_wrapped",
+            "dict_repr",
+            "bind_builtin_kwargs",
+        ] {
+            let graph = super::lower_function(&llbc, fname)
+                .unwrap_or_else(|err| panic!("lower {fname}: {err}"));
+            let residual: Vec<_> = graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .filter(|op| {
+                    matches!(
+                        &op.kind,
+                        OpKind::Call {
+                            target: CallTarget::FunctionPath { segments },
+                            ..
+                        } if super::fmt_path_ends_with(segments, &["vec", "Vec", "index"])
+                    )
+                })
+                .collect();
+            assert!(
+                residual.is_empty(),
+                "{fname}: PyPy list getitems must not remain Vec::index: {residual:#?}"
+            );
+        }
     }
 
     /// `basename_start` indexes `path[drive..]` with a runtime `usize`

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3235,6 +3235,11 @@ struct Lowering<'a> {
     /// (statement assigns + call destinations).  Guard set for
     /// [`Lowering::const_discriminant_locals`].
     multi_assigned_locals: std::collections::HashSet<usize>,
+    /// String variables whose Rust source obtained a `&[u8]` through
+    /// `str`/`Wtf8::as_bytes`. RPython stores UTF-8/WTF-8 in a byte string,
+    /// where `ord(s[i])` is the scalar byte read; the consumer gate below
+    /// uses this provenance to emit exactly that pair of flowspace ops.
+    string_byte_view_locals: Vec<usize>,
     /// Result `Variable`s of calls to callees whose declared result is
     /// `Result<T, PyError>`.  Each
     /// heads a `Try::branch` diamond that
@@ -3545,6 +3550,7 @@ impl<'a> Lowering<'a> {
             atomic_ordering_locals: std::collections::HashMap::new(),
             const_discriminant_locals: std::collections::HashMap::new(),
             multi_assigned_locals: compute_multi_assigned_locals(body),
+            string_byte_view_locals: Vec::new(),
             result_exc_call_results: Vec::new(),
             next_call_results: Vec::new(),
             checked_arith_call_results: Vec::new(),
@@ -6166,22 +6172,37 @@ impl<'a> Lowering<'a> {
                     && let Some(index_payload) = v.as_object().and_then(|m| m.get("Index"))
                 {
                     let idx_var = self.index_offset_var(mir_bb, index_payload)?;
+                    let string_byte_view = self
+                        .string_byte_view_locals
+                        .iter()
+                        .any(|&local| place_references_local(&inner, local));
                     let (array_type_id, nolength) = array_projection_metadata(&inner.ty, self.llbc);
                     let base = self.resolve_place(mir_bb, *inner)?;
                     let bb_id = self.block_id[mir_bb];
                     let res = self
                         .graph
                         .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
-                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
-                        result: Some(res.clone()),
-                        kind: OpKind::ArrayRead {
+                    let kind = if string_byte_view {
+                        OpKind::Call {
+                            target: CallTarget::FunctionPath {
+                                segments: vec!["__string_byte_getitem".to_string()],
+                            },
+                            args: vec![base, idx_var],
+                            result_ty: ValueType::Int,
+                        }
+                    } else {
+                        OpKind::ArrayRead {
                             base,
                             index: idx_var,
                             item_ty: tyref_to_value_type(&place_ty, self.llbc),
                             array_type_id,
                             nolength,
                             pure: false,
-                        },
+                        }
+                    };
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind,
                     });
                     return Ok(res);
                 }
@@ -7943,18 +7964,15 @@ impl<'a> Lowering<'a> {
                 // receiver (the `Cannot find attribute "as_bytes" on String`
                 // wall).
                 //
-                // Sound only for len / equality / iteration consumers.  A
-                // scalar index (`as_bytes()[i]`) lowers to `getitem` on
-                // `StringRepr`, which yields a `Char`, not the `u8` the Rust
-                // source expects; that mismatch currently fails rtype — there
-                // is no `(CharRepr, IntegerRepr)` eq/arithmetic pairtype — so
-                // the subject fail-safe residualizes rather than miscompiling.
-                // Do NOT add a `(CharRepr, IntegerRepr)` eq arm (or otherwise
-                // let a char read byte-compare) without lowering a real
-                // byte-slice view here first, or those indexed uses would
-                // silently gain character semantics.
+                // Scalar consumers are recorded as byte views and lower to
+                // RPython's literal `ord(s[i])` pair below. This is distinct
+                // from unicode code-point indexing: the receiver here is the
+                // UTF-8/WTF-8 storage exposed explicitly by `as_bytes`.
                 if args.len() == 1 && self.is_string_as_bytes_identity(&reg, first_arg_ty.as_ref())
                 {
+                    if !self.string_byte_view_locals.contains(&dest_local) {
+                        self.string_byte_view_locals.push(dest_local);
+                    }
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
@@ -8026,6 +8044,52 @@ impl<'a> Lowering<'a> {
                 // RangeTo remain real getslice operations.
                 if args.len() == 2 && is_vec_rangefull_index_regular(&reg, self.llbc) {
                     self.local_var[dest_local] = Some(args[0].clone());
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
+                // RPython's UTF-8 carrier is a byte string. A Rust
+                // `as_bytes()[i]` over the frontend's string identity is
+                // therefore `ord(s[i])`, not a list/array element load and
+                // not unicode code-point indexing. Keep it as a synthetic
+                // marker until the flowspace adapter can create the Char
+                // intermediate required by `ord`.
+                if args.len() == 2
+                    && arg_locals
+                        .first()
+                        .copied()
+                        .flatten()
+                        .is_some_and(|local| self.string_byte_view_locals.contains(&local))
+                    && self.is_slice_scalar_index_call(&reg, second_arg_ty.as_ref())
+                    && !self.is_slice_scalar_index_mut_call(&reg)
+                {
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::Call {
+                            target: CallTarget::FunctionPath {
+                                segments: vec!["__string_byte_getitem".to_string()],
+                            },
+                            args: vec![args[0].clone(), args[1].clone()],
+                            // `ord` returns RPython Signed. Rust's `u8`
+                            // spelling is representation detail here.
+                            result_ty: ValueType::Int,
+                        },
+                    });
+                    self.index_elem_alias.insert(
+                        dest_local,
+                        IndexElemAlias {
+                            base_local: arg_locals.first().copied().flatten(),
+                            base_var: args[0].clone(),
+                            index_local: arg_locals.get(1).copied().flatten(),
+                            index_var: args[1].clone(),
+                            array_type_id: None,
+                        },
+                    );
+                    self.local_var[dest_local] = Some(res);
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
                     self.graph.set_goto(bb_id, target_bb, link_args);
@@ -31510,31 +31574,27 @@ mod tests {
         }
     }
 
-    /// `basename_start` indexes `path[drive..]` with a runtime `usize`
-    /// RangeFrom. RPython represents this as `getslice(start, None)`, so the
-    /// core SliceIndex shim must be gone before annotation.
+    /// `exception_descr_str_wtf8` indexes the Python unicode carrier through
+    /// `Wtf8::index(RangeFrom)`. The frontend already models Wtf8 as
+    /// RPython's string repr, so this is its ordinary `getslice(start, None)`
+    /// and the Rust trait shim must be gone before annotation.
     #[test]
     #[ignore]
-    fn basename_start_rangefrom_lowers_to_getslice_marker() {
+    fn wtf8_rangefrom_lowers_to_getslice_marker() {
         use crate::model::{CallTarget, OpKind};
         let path = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../../build/llbc/pyre-interpreter.ullbc"
         );
         let llbc = Llbc::load(path).expect("load real LLBC");
-        let graph = super::lower_function(&llbc, "basename_start").expect("lower basename_start");
+        let graph = super::lower_function(&llbc, "exception_descr_str_wtf8")
+            .expect("lower exception_descr_str_wtf8");
         assert!(
             !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
                 matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
-                    if segments == &[
-                        "core".to_string(),
-                        "slice".to_string(),
-                        "index".to_string(),
-                        "<Impl>".to_string(),
-                        "index".to_string(),
-                    ])
+                    if segments == &["Wtf8".to_string(), "index".to_string()])
             }),
-            "RangeFrom SliceIndex call must not survive as an opaque core call"
+            "Wtf8 RangeFrom index must not survive as an opaque foreign call"
         );
         assert!(
             graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
@@ -31542,6 +31602,86 @@ mod tests {
                     if segments == &["__getslice_rangefrom".to_string()])
             }),
             "runtime RangeFrom should use the post-annotation getslice marker"
+        );
+    }
+
+    /// PyPy `typeobject._check_surrogate` delegates to the elidable
+    /// `rutf8.check_utf8`; it does not build a unicode iterator in the caller.
+    /// Keep that exact boundary visible in the real extracted graph.
+    #[test]
+    #[ignore]
+    fn check_surrogate_calls_rutf8_without_wtf8_iterator_next() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "check_surrogate").expect("lower check_surrogate");
+        let call_paths: Vec<&[String]> = graph
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } => Some(segments.as_slice()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            call_paths.iter().any(|segments| {
+                segments.ends_with(&["rutf8".to_string(), "check_utf8".to_string()])
+            }),
+            "PyPy's rutf8.check_utf8 boundary must remain in the caller"
+        );
+        assert!(
+            !call_paths
+                .iter()
+                .any(|segments| matches!(*segments, [owner, method]
+                    if owner == "Wtf8CodePoints" && (method == "next" || method == "nth"))),
+            "the local Wtf8 iterator reimplementation must not return: {call_paths:#?}"
+        );
+    }
+
+    /// RPython `rutf8.codepoint_at_pos` reads each encoded byte as
+    /// `ord(code[pos])`. The Rust byte view must retain that exact string
+    /// getitem + ord shape and never fall back to the crate iterator.
+    #[test]
+    #[ignore]
+    fn rutf8_codepoint_at_pos_lowers_byte_reads_to_ord() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph =
+            super::lower_function(&llbc, "codepoint_at_pos").expect("lower rutf8.codepoint_at_pos");
+        let paths: Vec<&[String]> = graph
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } => Some(segments.as_slice()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            paths
+                .iter()
+                .any(|segments| *segments == ["__string_byte_getitem"]),
+            "byte reads must reach the adapter's getitem + ord marker: {paths:#?}"
+        );
+        assert!(
+            !paths
+                .iter()
+                .any(|segments| *segments == ["Wtf8CodePoints", "next"]),
+            "RPython's direct decoder must not be replaced by Wtf8 iteration"
         );
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4736,7 +4736,7 @@ impl<'a> Lowering<'a> {
             result: Some(narrowed.clone()),
             kind: OpKind::Call {
                 target: CallTarget::FunctionPath {
-                    segments: vec!["__pyre_cast_instance".to_string(), root.to_string()],
+                    segments: vec!["__cast_instance_intrinsic".to_string(), root.to_string()],
                 },
                 args: vec![value],
                 result_ty: ValueType::Ref(Some(root.to_string())),
@@ -6308,7 +6308,7 @@ impl<'a> Lowering<'a> {
                         kind: OpKind::Call {
                             target: CallTarget::FunctionPath {
                                 segments: vec![
-                                    "__pyre_cast_instance".to_string(),
+                                    "__cast_instance_intrinsic".to_string(),
                                     "PyObject".to_string(),
                                 ],
                             },
@@ -8097,7 +8097,7 @@ impl<'a> Lowering<'a> {
                             kind: OpKind::Call {
                                 target: CallTarget::FunctionPath {
                                     segments: vec![
-                                        "__pyre_cast_instance".to_string(),
+                                        "__cast_instance_intrinsic".to_string(),
                                         root.clone(),
                                     ],
                                 },
@@ -28888,7 +28888,7 @@ mod tests {
                         target: CallTarget::FunctionPath { segments },
                         ..
                     } if segments == &[
-                        "__pyre_cast_instance".to_string(),
+                        "__cast_instance_intrinsic".to_string(),
                         "PyObject".to_string(),
                     ]
                 ) && matches!(
@@ -28936,7 +28936,10 @@ mod tests {
                         target: CallTarget::FunctionPath { segments },
                         ..
                     } if segments.as_slice()
-                        == ["__pyre_cast_instance".to_string(), "PyObject".to_string()]
+                        == [
+                            "__cast_instance_intrinsic".to_string(),
+                            "PyObject".to_string(),
+                        ]
                 )
             })
         });
@@ -29235,7 +29238,7 @@ mod tests {
                 OpKind::Call {
                     target: CallTarget::FunctionPath { segments },
                     ..
-                } if segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                } if segments.first().map(String::as_str) == Some("__cast_instance_intrinsic")
                     && segments.get(1).is_some_and(|root| root.ends_with("PyObject"))
             )
         });
@@ -29933,7 +29936,7 @@ mod tests {
                 OpKind::Call {
                     target: CallTarget::FunctionPath { segments },
                     ..
-                } if segments == &["__pyre_cast_instance", "PyObject"]
+                } if segments == &["__cast_instance_intrinsic", "PyObject"]
             )
         };
         let join = graph.blocks.iter().find_map(|block| {
@@ -30038,7 +30041,7 @@ mod tests {
                             target: CallTarget::FunctionPath { segments },
                             ..
                         },
-                    ) if segments == &["__pyre_cast_instance", owner] => Some(result),
+                    ) if segments == &["__cast_instance_intrinsic", owner] => Some(result),
                     _ => None,
                 })
                 .expect("typed raw allocation destination");
@@ -30617,9 +30620,9 @@ mod tests {
             "{owner}.exc_object must retain its concrete object-pointer spelling, got {ty}"
         );
         let bk = std::rc::Rc::new(crate::annotator::bookkeeper::Bookkeeper::new());
-        bk.set_pyre_struct_fields(std::rc::Rc::new(fields));
+        bk.set_struct_fields(std::rc::Rc::new(fields));
         let crate::annotator::model::SomeValue::Instance(projected) =
-            bk.project_pyre_field_type(&ty)
+            bk.project_struct_field_type(&ty)
         else {
             panic!("{owner}.exc_object field must project to an instance annotation")
         };
@@ -30667,7 +30670,7 @@ mod tests {
                             OpKind::Call {
                                 target: CallTarget::FunctionPath { segments },
                                 ..
-                            } if segments == &["__pyre_cast_instance", "PyObject"]
+                            } if segments == &["__cast_instance_intrinsic", "PyObject"]
                         )
                 }),
                 "PyError::{field_name} null must retain the declared PyObject class"
@@ -30720,7 +30723,7 @@ mod tests {
                                 OpKind::Call {
                                     target: CallTarget::FunctionPath { segments },
                                     ..
-                                } if segments == &["__pyre_cast_instance", "PyObject"]
+                                } if segments == &["__cast_instance_intrinsic", "PyObject"]
                             )
                     }),
                 "PyError::{} projection write must retain the declared PyObject class",

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -9218,6 +9218,16 @@ impl<'a> Lowering<'a> {
                 )? {
                     return Ok(());
                 }
+                if self.try_lower_wtf8_as_str(
+                    mir_bb,
+                    &segments,
+                    &args,
+                    dest_local,
+                    &call.dest.ty,
+                    target,
+                )? {
+                    return Ok(());
+                }
                 // `RBigInt::{one,zero}()` — a 0-arg constructor returning the
                 // translated one-GC-reference bigint. Emit the same constant
                 // through the pointer-ABI `rbigint.fromint` residual instead
@@ -14273,6 +14283,122 @@ impl<'a> Lowering<'a> {
         Ok(true)
     }
 
+    /// Lower `Wtf8::as_str() -> Result<&str, Utf8Error>` to the same
+    /// runtime-tagged aggregate a translated RPython validity test followed
+    /// by the string value would produce.
+    ///
+    /// PyPy's unicode value can carry lone surrogates, while the Rust host
+    /// API exposes that distinction through `Result`.  The validity decision
+    /// therefore remains a red residual scalar (`wtf8_key_is_utf8`), and only
+    /// the `Ok` payload is the identity string value.  Folding the whole call
+    /// to the receiver would incorrectly delete the lone-surrogate arm.
+    ///
+    /// This lowering is restricted to the current interpreter shape, whose
+    /// `Wtf8::as_str` callers inspect only the tag and the `Ok` string.  A
+    /// caller that consumes `Utf8Error` would require a separate
+    /// foreign-boundary port of `valid_up_to` / `error_len`; this adapter must
+    /// not be generalized to such a call site by pretending that payload has
+    /// an RPython layout.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The parameter order mirrors the corresponding RPython translation routine; grouping arguments into a Rust-only context object would obscure line-by-line parity and ownership"
+    )]
+    fn try_lower_wtf8_as_str(
+        &mut self,
+        mir_bb: usize,
+        segments: &[String],
+        args: &[Variable],
+        dest_local: usize,
+        dest_ty: &TyRef,
+        target: usize,
+    ) -> Result<bool, LowerError> {
+        if segments != ["Wtf8", "as_str"] {
+            return Ok(false);
+        }
+        let [arg] = args else {
+            return Ok(false);
+        };
+        let Some(ok_ty) = self.tyref_adt_type_arg(dest_ty, 0) else {
+            return Ok(false);
+        };
+        if !tyref_strips_to_str(&ok_ty, self.llbc) {
+            return Ok(false);
+        }
+        let Some(err_ty) = self.tyref_adt_type_arg(dest_ty, 1) else {
+            return Ok(false);
+        };
+        let err_is_utf8 = self
+            .tyref_adt_def_id(&err_ty)
+            .and_then(|id| self.llbc.type_by_id(id))
+            .is_some_and(|td| td.item_meta.name_path().ends_with("::Utf8Error"));
+        if !err_is_utf8 {
+            return Ok(false);
+        }
+        let Some(def_id) = self.tyref_adt_def_id(dest_ty) else {
+            return Ok(false);
+        };
+        let Some(td) = self.llbc.type_by_id(def_id) else {
+            return Ok(false);
+        };
+        let owner = format!(
+            "{}{}",
+            td.item_meta.name_path(),
+            tyref_enum_instantiation_suffix(dest_ty, self.llbc)
+        );
+        let bb_id = self.block_id[mir_bb];
+        let push_op = |graph: &mut FunctionGraph, kind: OpKind| {
+            let res = graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+            graph.block_mut(bb_id).operations.push(SpaceOperation {
+                result: Some(res.clone()),
+                kind,
+            });
+            res
+        };
+        let valid = push_op(
+            &mut self.graph,
+            OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec![
+                        "pyre_object".to_string(),
+                        "dictmultiobject".to_string(),
+                        "wtf8_key_is_utf8".to_string(),
+                    ],
+                },
+                args: vec![arg.clone()],
+                result_ty: ValueType::Bool,
+            },
+        );
+        // Result convention is Ok=0 / Err=1.  Comparing the validity bool
+        // with False therefore has exactly the required integer tag while
+        // preserving the runtime arm.  This is the same flowspace shape as
+        // the ordinary Rust `!bool` lowering above: RPython has no logical
+        // `not` operation, because `UNARY_NOT` becomes a truth test plus a
+        // branch in `flowcontext.py`; a scalar negation is `eq(b, False)`.
+        let false_var = push_op(&mut self.graph, OpKind::ConstBool(false));
+        let disc = push_op(
+            &mut self.graph,
+            OpKind::BinOp {
+                op: "eq".to_string(),
+                lhs: valid,
+                rhs: false_var,
+                result_ty: ValueType::Int,
+            },
+        );
+        let payload_owner =
+            Self::tagged_pair_payload_owner(td, &owner, 0).unwrap_or_else(|| owner.clone());
+        self.emit_tagged_pair_aggregate_typed(
+            mir_bb,
+            &owner,
+            &payload_owner,
+            disc,
+            arg.clone(),
+            ValueType::Str,
+            dest_local,
+            target,
+        )?;
+        Ok(true)
+    }
+
     /// Lower the infallible `usize::try_from(<u8|u16|u32>)`
     /// (`core::convert::num::ptr_try_from_impls::<Impl>::try_from`,
     /// Opaque in the LLBC like every core fn) to its decomposed
@@ -15091,6 +15217,33 @@ impl<'a> Lowering<'a> {
         dest_local: usize,
         target: usize,
     ) -> Result<(), LowerError> {
+        self.emit_tagged_pair_aggregate_typed(
+            mir_bb,
+            owner,
+            payload_owner,
+            disc,
+            payload,
+            ValueType::Int,
+            dest_local,
+            target,
+        )
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The parameter order mirrors the corresponding RPython translation routine; grouping arguments into a Rust-only context object would obscure line-by-line parity and ownership"
+    )]
+    fn emit_tagged_pair_aggregate_typed(
+        &mut self,
+        mir_bb: usize,
+        owner: &str,
+        payload_owner: &str,
+        disc: Variable,
+        payload: Variable,
+        payload_ty: ValueType,
+        dest_local: usize,
+        target: usize,
+    ) -> Result<(), LowerError> {
         let bb_id = self.block_id[mir_bb];
         let mut owner_path: Vec<String> = owner.split("::").map(str::to_string).collect();
         let ctor_name = owner_path.pop().unwrap_or_default();
@@ -15110,17 +15263,16 @@ impl<'a> Lowering<'a> {
                 result_ty: ValueType::Ref(Some(owner.to_string())),
             },
         });
-        // Both decomposed fields carry integers: the `__discriminant`
-        // tag is an `i64` (matching the `Rvalue::Discriminant`
-        // `FieldRead` and the `i64` field registration) and the
-        // `__pos_0` payload is the negated / widened integer the
-        // `checked_neg` / `usize::try_from` callers materialize.  A
-        // `Ref` field type here would disagree with that registration.
-        // `__discriminant` keys the root (tag offset 0); `__pos_0` keys
-        // the success variant so its exact offset matches the read.
-        for (name, value, field_owner) in [
-            ("__discriminant", disc, owner),
-            ("__pos_0", payload, payload_owner),
+        // The `__discriminant` tag is always an `i64` (matching the
+        // `Rvalue::Discriminant` `FieldRead` and field registration).
+        // The success payload keeps the producer's actual low-level type:
+        // integer for checked arithmetic / widening, string for the
+        // `Wtf8::as_str` validity decomposition.  `__discriminant` keys the
+        // root (tag offset 0); `__pos_0` keys the success variant so its exact
+        // offset and type match the read.
+        for (name, value, field_owner, ty) in [
+            ("__discriminant", disc, owner, ValueType::Int),
+            ("__pos_0", payload, payload_owner, payload_ty),
         ] {
             self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                 result: None,
@@ -15134,7 +15286,7 @@ impl<'a> Lowering<'a> {
                         taken_by_address: false,
                     },
                     value: LinkArg::Value(value),
-                    ty: ValueType::Int,
+                    ty,
                 },
             });
         }
@@ -30208,6 +30360,50 @@ mod tests {
                 "missing builder marker {marker}"
             );
         }
+    }
+
+    /// `Wtf8::as_str` is fallible for a lone surrogate.  PyPy keeps the
+    /// unicode value plus the runtime validity branch; the lifted graph must
+    /// therefore contain the scalar validity residual and a tagged Result,
+    /// not a residual Rust `Result<&str, Utf8Error>` call or an unconditional
+    /// string identity.
+    #[test]
+    #[ignore]
+    fn wtf8_as_str_lowers_to_runtime_tagged_string_result() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph =
+            super::lower_function(&llbc, "wtf8_display_string").expect("lower wtf8_display_string");
+
+        let ops: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .collect();
+        assert!(
+            !ops.iter().any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments == &["Wtf8", "as_str"])
+            }),
+            "the foreign Rust Result must not cross the translated graph: {graph:#?}"
+        );
+        assert!(
+            ops.iter().any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, result_ty: ValueType::Bool, .. }
+                    if segments.last().map(String::as_str) == Some("wtf8_key_is_utf8"))
+            }),
+            "the lone-surrogate decision must remain a runtime scalar: {graph:#?}"
+        );
+        assert!(
+            ops.iter().any(|op| {
+                matches!(&op.kind, OpKind::FieldWrite { field, ty: ValueType::Str, .. }
+                    if field.name == "__pos_0" && field.owner_root.as_deref().is_some_and(|owner| owner.ends_with("::Ok")))
+            }),
+            "the Result Ok payload must keep the lifted string repr: {graph:#?}"
+        );
     }
 
     /// Every local UTF-8 accumulator in PyPy's repr helpers is a

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -13949,7 +13949,9 @@ impl<'a> Lowering<'a> {
                 return Some(root);
             }
             let pointee = obj.get("Ref")?.as_array()?.get(1)?;
-            return adt_node_class_root(strip_ty_wrappers(pointee, self.llbc)?, self.llbc);
+            let pointee = strip_ty_wrappers(pointee, self.llbc)?;
+            return raw_ptr_pointee_class_root(pointee, self.llbc)
+                .or_else(|| adt_node_class_root(pointee, self.llbc));
         }
     }
 
@@ -14108,12 +14110,18 @@ impl<'a> Lowering<'a> {
     ) -> Option<crate::front::slice_first::SliceFirstSite> {
         let (option_owner, some_owner, payload_ty) =
             self.resolve_option_consumer_owners(dest_ty)?;
+        let niche = self.tyref_is_niche_option_ptr(dest_ty);
+        let payload_narrow_root = niche
+            .then(|| self.option_niche_payload_class_root(dest_ty))
+            .flatten();
         Some(crate::front::slice_first::SliceFirstSite {
             result_var: result_var.clone(),
             access: crate::front::slice_first::SliceAccess::First,
             option_owner,
             some_owner,
             payload_ty,
+            niche,
+            payload_narrow_root,
         })
     }
 
@@ -14151,12 +14159,18 @@ impl<'a> Lowering<'a> {
             "site-recognized (ACCEPT, not a decline)",
             &self.graph.name,
         );
+        let niche = self.tyref_is_niche_option_ptr(dest_ty);
+        let payload_narrow_root = niche
+            .then(|| self.option_niche_payload_class_root(dest_ty))
+            .flatten();
         Some(crate::front::slice_get::SliceGetSite {
             result_var: result_var.clone(),
             option_owner,
             some_owner,
             payload_ty: item_ty,
             array_type_id,
+            niche,
+            payload_narrow_root,
         })
     }
 
@@ -14768,17 +14782,32 @@ impl<'a> Lowering<'a> {
         // `getdebug_data() -> Option<&FrameDebugData>` is a live shared-ref
         // producer reaching here; its `FrameDebugData` pointee is Sized
         // (carries a concrete layout size).
-        if let Some(shared_pointee) = type_node_shared_ref_pointee(payload, self.llbc)
-            && let Some(stripped) = strip_ty_wrappers(shared_pointee, self.llbc)
-            && let Some(def_id) = adt_node_def_id(stripped)
-            && self
-                .llbc
-                .type_by_id(def_id)
-                .and_then(|td| td.layout_for_target(&std::env::var("TARGET").unwrap_or_default()))
-                .and_then(|l| l.size)
-                .is_some()
-        {
-            return true;
+        if let Some(shared_pointee) = type_node_shared_ref_pointee(payload, self.llbc) {
+            let Some(stripped) = strip_ty_wrappers(shared_pointee, self.llbc) else {
+                return false;
+            };
+            // `&*mut T` is a thin shared reference even though its pointee is
+            // itself a raw pointer rather than a nominal ADT.  This is the
+            // shape of `<[*mut PyObject]>::get`: `Option<&PyObjectRef>` is one
+            // nullable reference word, and its successful value is the list
+            // item pointer.  RPython has no Option aggregate here; it is the
+            // same `SomeInstance(T, can_be_None=True)` pointer lattice as the
+            // direct `&T` nominal-ADT arm below.
+            if type_node_raw_ptr_pointee(stripped, self.llbc).is_some() {
+                return true;
+            }
+            if let Some(def_id) = adt_node_def_id(stripped)
+                && self
+                    .llbc
+                    .type_by_id(def_id)
+                    .and_then(|td| {
+                        td.layout_for_target(&std::env::var("TARGET").unwrap_or_default())
+                    })
+                    .and_then(|l| l.size)
+                    .is_some()
+            {
+                return true;
+            }
         }
         // A direct raw pointer to a nominal ADT is the one-word address of
         // that aggregate in these graphs. Keep the concrete-layout gate even
@@ -32702,6 +32731,42 @@ mod tests {
                 .flat_map(|b| &b.operations)
                 .any(|op| matches!(op.kind, OpKind::ArrayRead { .. })),
             "the successful get arm must read the guarded element"
+        );
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::SyntheticTransparentCtor {
+                            name,
+                            owner_path,
+                            ..
+                        },
+                        ..
+                    } if (name == "Some" || name == "None")
+                        && owner_path.iter().any(|part| part.contains("Option<*mut PyObject>"))
+                ) || matches!(
+                    &op.kind,
+                    OpKind::FieldWrite { field, .. }
+                        if field
+                            .owner_root
+                            .as_deref()
+                            .is_some_and(|owner| owner.starts_with("core::option::Option<"))
+                )
+            }),
+            "Option<&PyObjectRef> must stay a nullable PyObject pointer, not an Option aggregate"
+        );
+        assert!(
+            graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments == &["core", "ptr", "null_mut"]
+                )
+            }),
+            "the out-of-bounds arm must materialize the nullable pointer's null"
         );
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -72,7 +72,8 @@
 //!   - `Assert` — strip and forward to the success target.
 //!
 //! ### Constants
-//!   - `Scalar(Signed|Unsigned|Isize|Usize)` → `ConstInt`.
+//!   - `Scalar(Signed|Isize)` → `ConstInt`; `Scalar(Unsigned|Usize)` →
+//!     `ConstUInt`.
 //!   - `Bool` → `ConstBool`. `Float` → `ConstFloat`.
 //!   - `Str` / `Char` / `ByteStr` → synthetic `Call(__str_const)`.
 //!   - `FnDef` → synthetic 0-arg `Call(FunctionPath)`.
@@ -2876,10 +2877,10 @@ fn simplify_lowered_graph(
     // `core::ptr::write<T>` never becomes one shared FunctionDesc whose `T`
     // argument would merge unrelated object classes.
     let mut dirty = crate::model::lower_struct_ptr_writes(graph, struct_field_attrs) > 0;
-    // Lower the boxing-constructor idiom `malloc_typed(W_FloatObject{…})`
-    // to a native `NewWithVtable` + payload store before the dead-aggregate
-    // sweep, which then reclaims the orphaned construct-on-stack ctor and
-    // header field writes.
+    // Lower the allocation idiom `malloc[_typed](W_Object { ... })` to a
+    // native `NewWithVtable` + payload stores before the dead-aggregate sweep,
+    // which then reclaims the orphaned construct-on-stack ctor and header
+    // field writes.
     dirty |= crate::model::fuse_boxing_alloc(graph, struct_field_attrs) > 0;
     // Reclaim boxing-cluster remnants (fused header ctors/casts, and a
     // `vec![…]` box whose consumer became a `newlist`) using dependency-flow
@@ -4957,6 +4958,26 @@ impl<'a> Lowering<'a> {
                             res,
                         ));
                     }
+                    // Pointer -> unsigned-word cast is two operations in
+                    // RPython, not a `cast_ptr_to_int` whose result is merely
+                    // labelled Unsigned.  `rbuiltin.py:528-539`
+                    // (`rtype_cast_primitive`) first emits
+                    // `cast_ptr_to_int(..., resulttype=Signed)` and then
+                    // `gen_cast(..., TGT=Unsigned)`.  Rust's `p as usize`
+                    // reaches this arm directly, so materialise that same
+                    // sequence: the inner call produces the orthodox Signed
+                    // address integer and `r_uint` performs the second,
+                    // same-word retype.  Omitting it leaves `p as usize`
+                    // annotated `SomeInteger()` and makes it fail to join a
+                    // genuine `0usize` (`SomeInteger(unsigned=True)`).
+                    if matches!(src_kind, Some(ValueType::Ref(_)))
+                        && matches!(dst_kind, ValueType::Unsigned)
+                    {
+                        let bb_id = self.block_id[mir_bb];
+                        let (retype, result) =
+                            push_ptr_to_unsigned_cast(&mut self.graph, bb_id, arg);
+                        return Ok((Some(retype), result));
+                    }
                     return Ok(
                         match src_kind
                             .as_ref()
@@ -5778,6 +5799,7 @@ impl<'a> Lowering<'a> {
     ) -> Result<Variable, LowerError> {
         let op = match decode_constant(self.llbc, value)? {
             DecodedConst::Int(n) => OpKind::ConstInt(n),
+            DecodedConst::UInt(n) => OpKind::ConstUInt(n),
             DecodedConst::Int128(n) => OpKind::ConstInt128(n),
             DecodedConst::UInt128(n) => OpKind::ConstUInt128(n),
             DecodedConst::Bool(b) => OpKind::ConstBool(b),
@@ -6984,6 +7006,7 @@ impl<'a> Lowering<'a> {
         }
         match decode_literal(found?).ok()? {
             DecodedConst::Int(n) => Some(OpKind::ConstInt(n)),
+            DecodedConst::UInt(n) => Some(OpKind::ConstUInt(n)),
             DecodedConst::Int128(n) => Some(OpKind::ConstInt128(n)),
             DecodedConst::UInt128(n) => Some(OpKind::ConstUInt128(n)),
             DecodedConst::Bool(b) => Some(OpKind::ConstBool(b)),
@@ -17470,12 +17493,13 @@ pub fn collect_unsafe_fn_stubs_from_llbc(
 /// `allocate_stable(payload: Self)`.
 ///
 /// Each builds `Self { ob: <header>, ..payload }` then calls
-/// `lltype::malloc_typed[_stable]` — a non-numeric boxing allocation with no
-/// ported general `malloc->new` lowering (`fuse_boxing_alloc` rewrites only
-/// the numeric boxes `W_Float`/`W_Int`/`W_Complex`/`W_Long`; every other
-/// mallocable struct hits the fail-closed `flowspace_adapter` guard).  So the
-/// constructor body cannot be traced; the faithful treatment is the
-/// `register_external` analog — residualize the whole `allocate` call.
+/// `lltype::malloc_typed[_stable]`.  The concrete caller-side allocation
+/// clusters now lower generically through `fuse_boxing_alloc`, but this shared
+/// `Self` body has no concrete registered struct layout/type identity at its
+/// own translation boundary.  It therefore cannot prove the malloc-to-new
+/// rewrite and hits the fail-closed `flowspace_adapter` guard.  The faithful
+/// treatment of that generic wrapper is the `register_external` analog —
+/// residualize the whole `allocate` call.
 /// [`Lowering::impl_method_owner`] declines the `CallTarget::Method` hint for
 /// the `payload`-named `Self` argument (routing through
 /// `CallTarget::FunctionPath`); this collection feeds the matching registry
@@ -18192,6 +18216,52 @@ fn cast_call_segments(src: &ValueType, dst: &ValueType) -> Option<Vec<String>> {
         // pair touching Void/State/Unknown): alias the operand.
         _ => None,
     }
+}
+
+/// Emit RPython's pointer-to-Unsigned primitive cast sequence.
+///
+/// `rbuiltin.py:528-539` first produces a Signed address integer with
+/// `cast_ptr_to_int`, then applies `gen_cast(..., Unsigned)`.  The caller
+/// appends the returned `r_uint` operation after the Signed producer pushed
+/// here, preserving that ordering while fitting [`Lowering::build_rvalue`]'s
+/// one-returned-operation interface.
+fn push_ptr_to_unsigned_cast(
+    graph: &mut FunctionGraph,
+    bb_id: BlockId,
+    arg: Variable,
+) -> (OpKind, Variable) {
+    let signed = graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+    graph.block_mut(bb_id).operations.push(SpaceOperation {
+        result: Some(signed.clone()),
+        kind: OpKind::Call {
+            target: CallTarget::FunctionPath {
+                segments: [
+                    "rpython",
+                    "rtyper",
+                    "lltypesystem",
+                    "lltype",
+                    "cast_ptr_to_int",
+                ]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            },
+            args: vec![arg],
+            result_ty: ValueType::Int,
+        },
+    });
+    let result = graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+    let retype = OpKind::Call {
+        target: CallTarget::FunctionPath {
+            segments: ["rpython", "rlib", "rarithmetic", "r_uint"]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+        },
+        args: vec![signed],
+        result_ty: ValueType::Unsigned,
+    };
+    (retype, result)
 }
 
 fn tyref_to_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
@@ -21463,6 +21533,7 @@ fn rvalue_variant_name(rv: &Rvalue) -> &'static str {
 /// emit. Widen as the corpus grows past `straight_line_add`.
 enum DecodedConst {
     Int(i64),
+    UInt(u64),
     Int128(i128),
     UInt128(u128),
     Bool(bool),
@@ -21721,7 +21792,7 @@ fn const_eval_core_num_associated_const(llbc: &Llbc, def_id: u64) -> Option<Cons
 fn const_lit_to_op(value: ConstLit) -> Option<OpKind> {
     match value {
         ConstLit::Int(n) => Some(OpKind::ConstInt(n)),
-        ConstLit::UInt(n) => Some(OpKind::ConstInt(n as i64)),
+        ConstLit::UInt(n) => Some(OpKind::ConstUInt(n)),
         ConstLit::Bool(b) => Some(OpKind::ConstBool(b)),
         ConstLit::Float(bits) => Some(OpKind::ConstFloat(bits)),
         ConstLit::Checked(..) | ConstLit::CheckedUInt(..) => None,
@@ -22122,11 +22193,10 @@ fn decode_literal(lit: &serde_json::Value) -> Result<DecodedConst, LowerError> {
                         .parse()
                         .map_err(|e| LowerError::Schema(format!("Scalar Signed parse: {e}")))?,
                 ),
-                "Unsigned" | "Usize" => DecodedConst::Int(
+                "Unsigned" | "Usize" => DecodedConst::UInt(
                     v_str
                         .parse::<u64>()
-                        .map_err(|e| LowerError::Schema(format!("Scalar Unsigned parse: {e}")))?
-                        as i64,
+                        .map_err(|e| LowerError::Schema(format!("Scalar Unsigned parse: {e}")))?,
                 ),
                 _ => {
                     return Err(LowerError::Unsupported(format!(
@@ -24614,6 +24684,7 @@ fn panic_block_is_pure_message(block: &crate::model::Block) -> bool {
     for op in &block.operations {
         let pure = match &op.kind {
             OpKind::ConstInt(_)
+            | OpKind::ConstUInt(_)
             | OpKind::ConstBool(_)
             | OpKind::ConstFloat(_)
             | OpKind::ConstRef(_)
@@ -24746,7 +24817,8 @@ mod tests {
         charon_const_generic_to_string, charon_type_value_to_ast_string, decode_literal,
         fn_ptr_family_for, json_ty_is_thin_pointer_element,
         json_ty_rpython_gc_pointer_element_spelling, json_ty_scalar_element_spelling,
-        shaped_array_parts, simplify_lowered_graph, tyref_array_suffix, tyref_is_raw_byte_ptr,
+        push_ptr_to_unsigned_cast, shaped_array_parts, simplify_lowered_graph, tyref_array_suffix,
+        tyref_is_raw_byte_ptr,
     };
     use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, ValueType};
     use majit_charon_reader::{Llbc, ullbc::TyRef};
@@ -24883,6 +24955,16 @@ mod tests {
         assert!(matches!(
             decode_literal(&unsigned).expect("decode U128"),
             DecodedConst::UInt128(value) if value == u128::MAX
+        ));
+
+        let word = serde_json::json!({
+            "Scalar": {
+                "Unsigned": ["Usize", "624"]
+            }
+        });
+        assert!(matches!(
+            decode_literal(&word).expect("decode usize"),
+            DecodedConst::UInt(624)
         ));
     }
 
@@ -28368,6 +28450,56 @@ mod tests {
         ));
         assert!(!cast_kind_is_raw_ptr(&serde_json::json!("Unsize")));
         assert!(!cast_kind_is_raw_ptr(&serde_json::json!({"Scalar": []})));
+    }
+
+    #[test]
+    fn pointer_to_usize_cast_keeps_rpython_signed_then_unsigned_sequence() {
+        let mut graph = FunctionGraph::new("test");
+        let entry = graph.startblock;
+        let ptr = graph
+            .push_op_var(entry, OpKind::ConstRefAddr(0x1000), true)
+            .expect("pointer value");
+
+        let (retype, result) = push_ptr_to_unsigned_cast(&mut graph, entry, ptr.clone());
+        graph
+            .block_mut(entry)
+            .operations
+            .push(crate::model::SpaceOperation {
+                result: Some(result.clone()),
+                kind: retype,
+            });
+
+        let ops = &graph.block(entry).operations;
+        let (signed, signed_arg) = match &ops[1] {
+            crate::model::SpaceOperation {
+                result: Some(signed),
+                kind:
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        args,
+                        result_ty: ValueType::Int,
+                    },
+            } if segments.last().map(String::as_str) == Some("cast_ptr_to_int") => {
+                (signed, &args[0])
+            }
+            other => panic!("first cast must be Signed cast_ptr_to_int: {other:?}"),
+        };
+        assert_eq!(signed_arg, &ptr);
+        match &ops[2] {
+            crate::model::SpaceOperation {
+                result: Some(actual_result),
+                kind:
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        args,
+                        result_ty: ValueType::Unsigned,
+                    },
+            } if segments.last().map(String::as_str) == Some("r_uint") => {
+                assert_eq!(actual_result, &result);
+                assert_eq!(&args[0], signed);
+            }
+            other => panic!("second cast must retype to Unsigned with r_uint: {other:?}"),
+        }
     }
 
     /// Only a byte pointee spells the type-erased address; a pointee-typed

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -7335,7 +7335,7 @@ impl<'a> Lowering<'a> {
                 // `SomeInstance(Struct, can_be_None=True)`: narrow to the
                 // payload class directly so a generated gateway wrapper's
                 // successful match arm can dispatch `self.method()`.
-                .or_else(|| self.option_ref_payload_class_root(&call.dest.ty))
+                .or_else(|| self.option_niche_payload_class_root(&call.dest.ty))
                 // A `dont_look_inside` residual returning `Option<*mut PyObject>`
                 // erases the same way — `dont_look_inside_return_token` maps it to
                 // the `ref` GCREF token, so `result_ty` is `Ref(None)` too — but its
@@ -7835,6 +7835,17 @@ impl<'a> Lowering<'a> {
                 if let Some((item_ty, array_type_id)) = index_element
                     && (workspace_index || array_type_id.is_some() || element_is_addressable)
                 {
+                    // A trait-associated `Index::Output` can stay a TypeVar
+                    // in this call's destination even though the workspace
+                    // gate has resolved the concrete receiver. In that case
+                    // `result_narrow_root` cannot recover the pointee name,
+                    // but the canonical object-array identity is already the
+                    // positive proof that the element is `PyObjectRef` (the
+                    // int/float workspaces have non-Ref banks).
+                    let item_narrow_root = result_narrow_root.clone().or_else(|| {
+                        (array_type_id.as_deref() == Some(OBJECT_REF_GCARRAY_TYPE_ID))
+                            .then(|| "PyObject".to_string())
+                    });
                     let res = self
                         .graph
                         .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
@@ -7859,7 +7870,31 @@ impl<'a> Lowering<'a> {
                             array_type_id,
                         },
                     );
-                    self.local_var[dest_local] = Some(res);
+                    // This intercept returns before the generic call-result
+                    // tail below.  Repeat its registered-pointee narrow so
+                    // `rlist.py:recast` exposes the concrete W_Root-equivalent
+                    // repr after the GCREF-backed getarrayitem.
+                    if let Some(root) = item_narrow_root {
+                        let narrowed = self
+                            .graph
+                            .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                        self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                            result: Some(narrowed.clone()),
+                            kind: OpKind::Call {
+                                target: CallTarget::FunctionPath {
+                                    segments: vec![
+                                        "__pyre_cast_instance".to_string(),
+                                        root.clone(),
+                                    ],
+                                },
+                                args: vec![res],
+                                result_ty: ValueType::Ref(Some(root)),
+                            },
+                        });
+                        self.local_var[dest_local] = Some(narrowed);
+                    } else {
+                        self.local_var[dest_local] = Some(res);
+                    }
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
                     self.graph.set_goto(bb_id, target_bb, link_args);
@@ -12401,13 +12436,14 @@ impl<'a> Lowering<'a> {
         ))
     }
 
-    /// Registered ADT pointee of `Option<&T>` / `Option<&mut T>`.
+    /// Registered ADT pointee of a one-word niche `Option<&T>` /
+    /// `Option<&mut T>` / `Option<*mut T>`.
     ///
     /// Rust uses the null pointer niche for this Option shape. It therefore
     /// maps to RPython's nullable `SomeInstance(T)`, not to an Option
     /// container class with `__discriminant` / `__pos_0` fields.
-    fn option_ref_payload_class_root(&self, dest_ty: &TyRef) -> Option<String> {
-        if !crate::front::result_exc::tyref_is_option(dest_ty, self.llbc) {
+    fn option_niche_payload_class_root(&self, dest_ty: &TyRef) -> Option<String> {
+        if !self.tyref_is_niche_option_ptr(dest_ty) {
             return None;
         }
         let mut payload = tyref_node(dest_ty, self.llbc)?
@@ -12429,6 +12465,9 @@ impl<'a> Lowering<'a> {
             {
                 payload = &parts[1];
                 continue;
+            }
+            if let Some(root) = raw_ptr_pointee_class_root(payload, self.llbc) {
+                return Some(root);
             }
             let pointee = obj.get("Ref")?.as_array()?.get(1)?;
             return adt_node_class_root(strip_ty_wrappers(pointee, self.llbc)?, self.llbc);
@@ -27718,6 +27757,40 @@ mod tests {
         assert_eq!(
             transparent_ctors, 0,
             "Some(raw nominal pointer) must be the payload identity, with no Option aggregate"
+        );
+    }
+
+    /// Real-LLBC anchor for the `FixedObjectArray` Index intercept.  The
+    /// intercept returns before `lower_call`'s ordinary result-narrowing tail,
+    /// so an object element must carry its own `PyObject` narrow immediately
+    /// after the lifted ArrayRead.  Ignored by default because it loads the
+    /// large interpreter snapshot.
+    #[test]
+    #[ignore]
+    fn load_local_value_arrayread_narrows_pyobject_item() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real interpreter LLBC");
+        let graph = super::lower_function(
+            &llbc,
+            "pyre_interpreter::eval::<Impl>::load_local_value",
+        )
+        .expect("lower eval::<Impl>::load_local_value");
+        let has_pyobject_narrow = graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                    && segments.get(1).is_some_and(|root| root.ends_with("PyObject"))
+            )
+        });
+        assert!(
+            has_pyobject_narrow,
+            "FixedObjectArray getitem must recast its GCREF item to PyObject"
         );
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -9342,6 +9342,11 @@ impl<'a> Lowering<'a> {
                 )? {
                     return Ok(());
                 }
+                if self.try_lower_word_rotate(
+                    mir_bb, &reg.kind, &segments, &args, dest_local, target,
+                )? {
+                    return Ok(());
+                }
                 if self.try_lower_usize_try_from(
                     mir_bb,
                     &reg.kind,
@@ -14186,6 +14191,119 @@ impl<'a> Lowering<'a> {
             },
         });
         self.local_var[dest_local] = Some(res);
+        let target_bb = self.block_id[target];
+        let link_args = self.edge_args(mir_bb, target)?;
+        self.graph.set_goto(bb_id, target_bb, link_args);
+        Ok(true)
+    }
+
+    /// Lower a constant `u64`/`usize::rotate_left` to the unsigned
+    /// shift/or expansion used by PyPy's 64-bit tuple hash
+    /// (`tupleobject.py:370-374`, `xxrotate`).  Core integer method bodies are
+    /// opaque in LLBC; leaving this as a call therefore hides a primitive
+    /// RPython operation behind an unregistrable Rust helper.
+    ///
+    /// Keep the gate deliberately narrow: the receiver must be a word-sized
+    /// unsigned integer and the count must be a graph constant.  A signed
+    /// receiver would require an explicit unsigned reinterpretation before
+    /// the right shift, and a variable Rust count needs the full modulo-word
+    /// normalization.  Neither is present in the current RPython-shaped
+    /// source, so those forms remain residual instead of being guessed at.
+    fn try_lower_word_rotate(
+        &mut self,
+        mir_bb: usize,
+        kind: &CallKind,
+        segments: &[String],
+        args: &[Variable],
+        dest_local: usize,
+        target: usize,
+    ) -> Result<bool, LowerError> {
+        let [first, .., module, impl_seg, leaf] = segments else {
+            return Ok(false);
+        };
+        if first.as_str() != "core"
+            || module.as_str() != "num"
+            || impl_seg.as_str() != "<Impl>"
+            || leaf.as_str() != "rotate_left"
+        {
+            return Ok(false);
+        }
+        let [value, count] = args else {
+            return Ok(false);
+        };
+        let CallKind::Fun(FunId::Regular { id }) = kind else {
+            return Ok(false);
+        };
+        let Some(fd) = self.llbc.fn_by_id(*id) else {
+            return Ok(false);
+        };
+        let Some(receiver_ty) = fd.signature.inputs.first() else {
+            return Ok(false);
+        };
+        if !matches!(
+            self.tyref_literal_uint_atom(receiver_ty),
+            Some("U64" | "Usize")
+        ) {
+            return Ok(false);
+        }
+        let Some(raw_count) = self
+            .graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .find_map(|op| {
+                (op.result.as_ref() == Some(count))
+                    .then(|| match &op.kind {
+                        OpKind::ConstInt(n) if *n >= 0 => Some(*n as u64),
+                        OpKind::ConstUInt(n) => Some(*n),
+                        _ => None,
+                    })
+                    .flatten()
+            })
+        else {
+            return Ok(false);
+        };
+        let count = (raw_count & 63) as i64;
+        let complement = (64 - count) & 63;
+        let bb_id = self.block_id[mir_bb];
+        let push_op = |graph: &mut FunctionGraph, kind: OpKind| {
+            let result = graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+            graph.block_mut(bb_id).operations.push(SpaceOperation {
+                result: Some(result.clone()),
+                kind,
+            });
+            result
+        };
+        let count = push_op(&mut self.graph, OpKind::ConstInt(count));
+        let left = push_op(
+            &mut self.graph,
+            OpKind::BinOp {
+                op: "lshift".to_string(),
+                lhs: value.clone(),
+                rhs: count,
+                result_ty: ValueType::Unsigned,
+            },
+        );
+        let complement = push_op(&mut self.graph, OpKind::ConstInt(complement));
+        let right = push_op(
+            &mut self.graph,
+            OpKind::BinOp {
+                op: "rshift".to_string(),
+                lhs: value.clone(),
+                rhs: complement,
+                result_ty: ValueType::Unsigned,
+            },
+        );
+        let result = push_op(
+            &mut self.graph,
+            OpKind::BinOp {
+                op: "or".to_string(),
+                lhs: left,
+                rhs: right,
+                result_ty: ValueType::Unsigned,
+            },
+        );
+        self.local_var[dest_local] = Some(result);
         let target_bb = self.block_id[target];
         let link_args = self.edge_args(mir_bb, target)?;
         self.graph.set_goto(bb_id, target_bb, link_args);
@@ -31735,6 +31853,113 @@ mod tests {
                     if op == "add")
             }),
             "the formatted overflow message must retain the native string-concat expansion"
+        );
+    }
+
+    /// A by-value fixed array is an RPython list-model iteration source, just
+    /// like the already-covered `&[T]` loop: its `IntoIter::next` must become
+    /// the native `iter`/`next` vertical rather than remain a foreign core
+    /// call.  Loads the real interpreter LLBC, so ignored by default.
+    #[test]
+    #[ignore]
+    fn fixed_array_for_loop_has_no_residual_into_iter_next() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "memoryview_is_native_buffer_descr")
+            .expect("lower memoryview_is_native_buffer_descr");
+        let residual: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if segments.last().map(String::as_str) == Some("next") => Some(segments.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            residual.is_empty(),
+            "fixed-array for-loop left residual next calls: {residual:?}"
+        );
+    }
+
+    /// RPython evaluates `SHIFT`, `HASH_BITS`, `_HASH_SHIFT`, and
+    /// `HASH_MODULUS` while building `_hash_long`'s flow graph.  The extracted
+    /// Rust graph must likewise contain their integer literals, not synthetic
+    /// zero-argument accessors that the annotator cannot resolve.  Loads the
+    /// real interpreter LLBC, so ignored by default.
+    #[test]
+    #[ignore]
+    fn hash_long_has_no_residual_constant_accessors() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "_hash_long").expect("lower _hash_long");
+        let residual: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if matches!(
+                    segments.last().map(String::as_str),
+                    Some("SHIFT" | "HASH_BITS" | "HASH_SHIFT" | "HASH_MODULUS")
+                ) =>
+                {
+                    Some(segments.clone())
+                }
+                _ => None,
+            })
+            .collect();
+        assert!(
+            residual.is_empty(),
+            "_hash_long left residual constant accessors: {residual:?}"
+        );
+    }
+
+    /// CPython 3.14's hashable-slice mixer spells PyPy's `xxrotate` expansion
+    /// as Rust `u64::rotate_left`.  The front must recover the same unsigned
+    /// shift/or graph rather than leave the opaque core method behind.
+    #[test]
+    #[ignore]
+    fn slice_hash_has_no_residual_rotate_left() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph =
+            super::lower_function(&llbc, "slice_hash_value").expect("lower slice_hash_value");
+        let residual = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.last().map(String::as_str) == Some("rotate_left")
+                )
+            })
+            .count();
+        assert_eq!(residual, 0, "slice hash left rotate_left residuals");
+        assert!(
+            graph.blocks.iter().flat_map(|block| &block.operations).any(
+                |op| matches!(&op.kind, OpKind::BinOp { op, result_ty: ValueType::Unsigned, .. }
+                    if op == "or")
+            ),
+            "slice hash must contain PyPy's unsigned shift/or rotate expansion"
         );
     }
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8318,6 +8318,19 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `Atomic*::from_ptr(p)` creates a borrowed atomic view over
+                // the same address; it neither allocates nor changes the
+                // pointer representation.  The translated object model keeps
+                // these slots as their upstream scalar fields (for example
+                // unicode `hash`, `rstr.py:411-412`), so alias the view to the
+                // field pointer exactly like the raw-pointer casts above.
+                if args.len() == 1 && self.is_atomic_from_ptr_identity(&reg) {
+                    self.local_var[dest_local] = Some(args[0].clone());
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // `<Atomic*>::load(&self, ordering)` — a relaxed read of a
                 // layout-transparent atomic.  `&self` already aliases the
                 // inner field read, so alias the destination to it (the
@@ -11029,6 +11042,20 @@ impl<'a> Lowering<'a> {
                         .next()
                         .is_some_and(|leaf| leaf.starts_with("Atomic"))
             })
+        })
+    }
+
+    /// `core::sync::atomic::Atomic*::from_ptr(p)` is a layout-transparent
+    /// pointer view.  Match the exact core associated function and require an
+    /// atomic output wrapper so unrelated `from_ptr` constructors (notably
+    /// `CStr::from_ptr`) keep their own semantics.
+    fn is_atomic_from_ptr_identity(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc.fn_by_id(*id).is_some_and(|fd| {
+            fd.item_meta.name_path() == "core::sync::atomic::<Impl>::from_ptr"
+                && tyref_atomic_inner_value_type(&fd.signature.output, self.llbc).is_some()
         })
     }
 
@@ -28601,6 +28628,31 @@ mod tests {
                 .collect();
             assert_eq!(fields, expected_fields, "{name}: source field order");
         }
+    }
+
+    #[test]
+    #[ignore]
+    fn atomic_from_ptr_lowers_to_an_identity_view() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "hash_slot").expect("lower hash_slot");
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.last().map(String::as_str) == Some("from_ptr"))
+            }),
+            "AtomicI64::from_ptr must not survive as a graph-less core call"
+        );
+        assert!(
+            graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::FieldRead { field, .. } if field.name == "hash")
+            }),
+            "the identity view must retain its underlying unicode hash-field read"
+        );
     }
 
     /// PyPy's `_match_keywords` indexes its small signature and argument

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -7524,6 +7524,16 @@ impl<'a> Lowering<'a> {
             Operand::Copy(p) | Operand::Move(p) => Some(clone_tyref(&p.ty)),
             Operand::Const(_) => None,
         });
+        // A literal scalar index (`slice.get(1)`) has no Place type to retain
+        // in `second_arg_ty`.  Charon still records the method's `I` type in
+        // the regular-call generics, so classify the `get` before consuming
+        // `call.func`.  This is the same two-source type test used for
+        // `SliceIndex::index` below and keeps Range* implementations on the
+        // separate getslice lowering.
+        let slice_get_index_is_scalar = match &call.func {
+            CallFunc::Regular(reg) => self.is_slice_get_scalar_call(reg, second_arg_ty.as_ref()),
+            _ => false,
+        };
         for op in call.args {
             args.push(self.resolve_operand(mir_bb, op)?);
         }
@@ -10293,6 +10303,32 @@ impl<'a> Lowering<'a> {
         {
             self.slice_get_sites.push(site);
         }
+        // `<[T]>::get(slice, start..)` returns an Option subslice.  Preserve
+        // that Option shape with the same guarded diamond as scalar `get`, but
+        // make the successful payload RPython's `getslice(start, None)`.  The
+        // RangeFrom aggregate was captured at construction time; exact value
+        // identity keeps this arm separate from arbitrary SliceIndex impls.
+        if let OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 2
+            && fmt_path_ends_with(segments, &["slice", "<Impl>", "get"])
+            && !slice_get_index_is_scalar
+            && let Some(range_site) = self
+                .slice_index_rangefrom_sites
+                .iter()
+                .find(|range_site| range_site.range_result == args[1])
+                .cloned()
+            && let Some(mut site) = self.recognize_slice_first_site(&call.dest.ty, &result_var)
+        {
+            site.access = crate::front::slice_first::SliceAccess::RangeFrom {
+                range: range_site.range_result,
+                start: range_site.start,
+            };
+            self.slice_first_sites.push(site);
+        }
         // Capture `{uN}::saturating_sub(a, b)` sites for the unsigned clamp
         // diamond `front::saturating_sub` synthesizes.  `saturating_sub` is a
         // foreign leaf (its `Self` is a primitive integer, so `lower_call`
@@ -10975,6 +11011,31 @@ impl<'a> Lowering<'a> {
                 .and_then(|ty| serde_json::from_value::<TyRef>(ty.clone()).ok())
                 .is_some_and(|ty| vec_index_type_is_scalar(&ty, self.llbc));
         is_index && callsite_index_is_scalar
+    }
+
+    /// `<[T]>::get::<I>(slice, index)` with a scalar `I`.  For a local index,
+    /// MIR supplies the type through the operand Place; for a literal index it
+    /// only survives in Charon's method generics (`[T, I]`).  Preserve that
+    /// distinction so `get(1)` takes the guarded-item Option diamond while
+    /// `get(1..)` continues through `front::slice_index` as a subslice.
+    fn is_slice_get_scalar_call(&self, reg: &RegularCall, index_ty: Option<&TyRef>) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        let is_get = self
+            .llbc
+            .fn_by_id(*id)
+            .is_some_and(|fd| fd.item_meta.name_path() == "core::slice::<Impl>::get");
+        let callsite_index_is_scalar = index_ty
+            .is_some_and(|ty| vec_index_type_is_scalar(ty, self.llbc))
+            || reg
+                .generics
+                .get("types")
+                .and_then(serde_json::Value::as_array)
+                .and_then(|types| types.get(1))
+                .and_then(|ty| serde_json::from_value::<TyRef>(ty.clone()).ok())
+                .is_some_and(|ty| vec_index_type_is_scalar(&ty, self.llbc));
+        is_get && callsite_index_is_scalar
     }
 
     fn is_slice_scalar_index_mut_call(&self, reg: &RegularCall) -> bool {
@@ -12785,23 +12846,23 @@ impl<'a> Lowering<'a> {
     /// Resolve a recognized `<[T]>::first(slice)` call into a
     /// [`crate::front::slice_first::SliceFirstSite`] — the `Option` enum root +
     /// `Some` variant owners the length-checked diamond post-pass spells its
-    /// arms with.  Gated on [`Self::option_residual_narrow_root`] returning
-    /// `Some`: that is exactly the shape `lower_call` appends a trailing
-    /// `__cast_instance_intrinsic` narrowing to (the cast the post-pass absorbs and
-    /// re-applies per arm), and it declines a value-slice `Option<u8>` /
-    /// `Option<i64>` (no registered pointee root) cleanly, leaving the residual
-    /// call for the census Skip.  `None` when the destination is not a
-    /// resolvable narrow-root `Option`.
+    /// arms with.  The post-pass accepts both representations that
+    /// `lower_call` can produce: a reference-payload result followed by
+    /// `__cast_instance_intrinsic`, and a value-payload `Option<u8>` / `Option<i64>`
+    /// with no trailing cast.  Reuse the consumer-owner spelling so unsigned
+    /// payloads stay on the bare `Option` root used by checked arithmetic,
+    /// while other payloads keep their per-instantiation class.  `None` when
+    /// the destination is not a resolvable `Option`.
     fn recognize_slice_first_site(
         &self,
         dest_ty: &TyRef,
         result_var: &Variable,
     ) -> Option<crate::front::slice_first::SliceFirstSite> {
-        self.option_residual_narrow_root(dest_ty)?;
-        let (option_owner, some_owner, payload_ty) = self.resolve_bool_then_option_dest(dest_ty)?;
+        let (option_owner, some_owner, payload_ty) =
+            self.resolve_option_consumer_owners(dest_ty)?;
         Some(crate::front::slice_first::SliceFirstSite {
             result_var: result_var.clone(),
-            index: None,
+            access: crate::front::slice_first::SliceAccess::First,
             option_owner,
             some_owner,
             payload_ty,
@@ -28973,6 +29034,78 @@ mod tests {
                 .flat_map(|b| &b.operations)
                 .any(|op| matches!(op.kind, OpKind::ArrayRead { .. })),
             "the successful get arm must read the guarded element"
+        );
+    }
+
+    /// Slice `get` is not object-pointer-specific, and a literal index has no
+    /// Place type.  This production helper exercises both the generalized
+    /// Option payload recognizer and its generic-type fallback for `get(1)`.
+    #[test]
+    #[ignore]
+    fn slice_get_constant_index_lowers_to_a_guarded_item_read() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let name = "pyre_interpreter::module::unicodedata::char_and_default";
+        let graph = super::lower_function(&llbc, name)
+            .unwrap_or_else(|err| panic!("lower {name}: {err:?}"));
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments == &["core", "slice", "<Impl>", "get"])
+            }),
+            "{name}: scalar slice get must not survive as an opaque core call"
+        );
+        assert!(
+            graph
+                .blocks
+                .iter()
+                .flat_map(|b| &b.operations)
+                .any(|op| matches!(op.kind, OpKind::ArrayRead { .. })),
+            "{name}: successful get arm must read the guarded item"
+        );
+    }
+
+    /// `args.get(1..).unwrap_or(&[])` is Rust's checked spelling of PyPy's
+    /// ordinary `args[1:]`.  Keep `get`'s Option semantics in a `start <= len`
+    /// diamond and materialize the successful payload as the deferred
+    /// `getslice(start, None)` marker.
+    #[test]
+    #[ignore]
+    fn slice_get_rangefrom_lowers_to_a_guarded_getslice() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let name = "pyre_interpreter::module::unicodedata::ucd_method_args";
+        let graph = super::lower_function(&llbc, name)
+            .unwrap_or_else(|err| panic!("lower {name}: {err:?}"));
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments == &["core", "slice", "<Impl>", "get"])
+            }),
+            "{name}: RangeFrom slice get must not survive as an opaque core call"
+        );
+        assert!(
+            graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments == &["__getslice_rangefrom"])
+            }),
+            "{name}: successful get arm must carry the deferred getslice"
+        );
+        assert!(
+            graph
+                .blocks
+                .iter()
+                .flat_map(|b| &b.operations)
+                .any(|op| matches!(&op.kind, OpKind::BinOp { op, .. } if op == "le")),
+            "{name}: RangeFrom get must guard start <= len"
         );
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8623,6 +8623,24 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `bytes_block_chars` is the Rust storage adapter for
+                // RPython's `STR.chars`: its `BytesBlock.length` is exactly
+                // the gcarray descr's `len_offset`, and `chars` begins at the
+                // descr's `base_size`.  Recover the owning block from the
+                // address-taken `chars` FieldRead and alias the returned slice
+                // to that header.  This is deliberately function-scoped;
+                // arbitrary `from_raw_parts(p, n)` cannot discard `n` (for
+                // example a list's logical length may be below capacity).
+                if args.len() == 2
+                    && let Some(block) =
+                        self.bytes_block_header_from_raw_parts(bb_id, &reg, &args[0])
+                {
+                    self.local_var[dest_local] = Some(block);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // `RBigInt::digits{,_mut}` is a Rust view adapter around a
                 // typed-items GcArray:
                 // `slice::from_raw_parts(items_base(block), capacity)`.  The
@@ -11366,6 +11384,49 @@ impl<'a> Lowering<'a> {
                 "core::slice::raw::from_raw_parts" | "core::slice::raw::from_raw_parts_mut"
             )
         })
+    }
+
+    /// Return the owning `BytesBlock` for the exact
+    /// `bytes_block_chars(block)` raw-slice constructor.
+    ///
+    /// RPython's `STR` is a length-prefixed GC struct with a variable-sized
+    /// `chars` array (`rpython/rtyper/lltypesystem/rstr.py`).  pyre's
+    /// `BytesBlock` deliberately has the same descr-visible shape: `length`
+    /// is the array length and the address-taken `chars` field is item zero.
+    /// The lifted value is therefore the block header, not the interior
+    /// `chars` address.  Matching the defining FieldRead also proves this is
+    /// that layout adapter rather than an unrelated raw slice in the helper.
+    fn bytes_block_header_from_raw_parts(
+        &self,
+        bb_id: BlockId,
+        reg: &RegularCall,
+        chars: &Variable,
+    ) -> Option<Variable> {
+        if self.graph.name != "pyre_object::bytesobject::bytes_block_chars" {
+            return None;
+        }
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return None;
+        };
+        if self.llbc.fn_by_id(*id)?.item_meta.name_path() != "core::slice::raw::from_raw_parts" {
+            return None;
+        }
+        self.graph
+            .block(bb_id)
+            .operations
+            .iter()
+            .rev()
+            .find_map(|op| match (&op.result, &op.kind) {
+                (Some(result), OpKind::FieldRead { base, field, .. })
+                    if result == chars
+                        && field.name == "chars"
+                        && field.owner_root.as_deref() == Some("BytesBlock")
+                        && field.taken_by_address =>
+                {
+                    Some(base.clone())
+                }
+                _ => None,
+            })
     }
 
     /// `*items_block_items_base(block).add(idx)` — a list / tuple
@@ -29264,6 +29325,60 @@ mod tests {
             from_raw_parts_calls, 0,
             "rbigint digits (capacity-length view) must still fold to the \
              items-block header, leaving no residual from_raw_parts"
+        );
+    }
+
+    /// `bytes_block_chars` exposes the variable-sized `chars` array whose
+    /// length is the same `BytesBlock.length` consumed by the gcarray descr.
+    /// It is therefore the bytes-string twin of RPython `STR.chars`: the
+    /// `from_raw_parts(chars, length)` view must fold to the managed block
+    /// instead of surviving as an opaque Rust call. Loads the real
+    /// pyre-object LLBC, so ignored by default.
+    #[test]
+    #[ignore]
+    fn bytes_block_chars_folds_header_length_view() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load pyre-object LLBC");
+        let graph =
+            super::lower_function(&llbc, "bytes_block_chars").expect("lower bytes_block_chars");
+        let residual = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if segments.last().map(String::as_str) == Some("from_raw_parts")
+                )
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            residual.is_empty(),
+            "bytes_block_chars must lower to the managed bytes-block array; \
+             residual calls: {residual:#?}; graph: {graph:#?}"
+        );
+        let dead_storage_reads = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::FieldRead { field, .. }
+                        if field.owner_root.as_deref() == Some("BytesBlock")
+                            && matches!(field.name.as_str(), "chars" | "length")
+                )
+            })
+            .count();
+        assert_eq!(
+            dead_storage_reads, 0,
+            "the owner alias must let the ordinary dead-op pass remove the \
+             interior chars/length shell; graph: {graph:#?}"
         );
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -9665,6 +9665,9 @@ impl<'a> Lowering<'a> {
         // assignment nor descending into the classdef-less `_digits` field is
         // correct. Retarget the exact receiver/result pair to the GC-aware
         // shallow-clone residual.
+        let inside_dont_look_inside = self
+            .dont_look_inside
+            .contains(&strip_crate_prefix(&self.graph.name));
         let op_kind = if let OpKind::Call { target, args, .. } = &op_kind
             && args.len() == 1
             && first_arg_ty
@@ -10063,11 +10066,17 @@ impl<'a> Lowering<'a> {
                 .as_ref()
                 .is_some_and(|ty| tyref_is_rbigint(ty, self.llbc))
             && let Some((segments, scalar_result)) = match target {
-                CallTarget::FunctionPath { segments } => segments
-                    .last()
-                    .and_then(|leaf| crate::front::rbigint_call::scalar_residual_for_method(leaf)),
+                CallTarget::FunctionPath { segments } => segments.last().and_then(|leaf| {
+                    crate::front::rbigint_call::scalar_residual_for_method(
+                        leaf,
+                        inside_dont_look_inside,
+                    )
+                }),
                 CallTarget::Method { name, .. } => {
-                    crate::front::rbigint_call::scalar_residual_for_method(name)
+                    crate::front::rbigint_call::scalar_residual_for_method(
+                        name,
+                        inside_dont_look_inside,
+                    )
                 }
                 _ => None,
             } {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -6159,6 +6159,40 @@ impl<'a> Lowering<'a> {
                     return Ok(res);
                 }
                 let segments = self.global_segments(mir_bb, id)?;
+                // `pyre_object::pyobject::PY_NULL` is the Rust spelling of
+                // the `None` stored in PyPy's `locals_cells_stack_w` slots
+                // (`pyframe.py`: `[None] * size`, plus the pop/drop clears).
+                // Preserve the high-level W_Root boundary: construct the
+                // repr-adaptive nullable pointer, then narrow it to the
+                // declared `PyObjectRef` pointee class.  Leaving the computed
+                // const to `const_eval_global` produces a bare nullable
+                // `SomeInstance(None)`; unioning that into the fixed object
+                // array erases its `PyObject` external item repr, whereas
+                // upstream's `SomeNone ∪ SomeInstance(W_Root)` keeps W_Root
+                // and only sets `can_be_None`.
+                if fmt_path_ends_with(&segments, &["pyobject", "PY_NULL"])
+                    && tyref_class_root(&place_ty, self.llbc).as_deref() == Some("PyObject")
+                {
+                    let bb_id = self.block_id[mir_bb];
+                    let raw = self.graph.push_null_mut_ptr(bb_id);
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::Call {
+                            target: CallTarget::FunctionPath {
+                                segments: vec![
+                                    "__pyre_cast_instance".to_string(),
+                                    "PyObject".to_string(),
+                                ],
+                            },
+                            args: vec![raw],
+                            result_ty: ValueType::Ref(Some("PyObject".to_string())),
+                        },
+                    });
+                    return Ok(res);
+                }
                 // A class-singleton static (`&SLICE_TYPE`, `&CEL_INT_CLASS`):
                 // narrow the raw address through
                 // `__cast_instance_intrinsic[<root>]` so the read types
@@ -27465,6 +27499,21 @@ mod tests {
         let path = crate::runtime_names::artifacts::INTERPRETER_ULLBC;
         let llbc = Llbc::load(path).expect("load real LLBC");
         let graph = super::lower_function(&llbc, "set_locals_w").expect("lower set_locals_w");
+        let value_input_root = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .find_map(|op| match &op.kind {
+                OpKind::Input {
+                    name, class_root, ..
+                } if name == "value" => class_root.as_deref(),
+                _ => None,
+            });
+        assert_eq!(
+            value_input_root,
+            Some("PyObject"),
+            "PyObjectRef input must retain the W_Root-equivalent class identity"
+        );
         let residual = graph
             .blocks
             .iter()
@@ -27490,6 +27539,45 @@ mod tests {
         assert!(
             array_writes >= 1,
             "set_locals_w: expected at least one native ArrayWrite (setarrayitem_gc)"
+        );
+    }
+
+    /// PyPy's frame stack clears store `None` into a `W_Root` list.  The Rust
+    /// sentinel `PY_NULL` must therefore retain the `PyObject` class boundary
+    /// while becoming nullable; a classdef-less null would widen the shared
+    /// `FixedObjectArray` item to the erased top reference.
+    #[test]
+    #[ignore]
+    fn popvalue_py_null_narrows_to_nullable_pyobject() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(
+            &llbc,
+            "pyre_interpreter::pyframe::<Impl>::popvalue_maybe_none",
+        )
+        .expect("lower PyFrame::popvalue_maybe_none");
+        let has_nullable_pyobject = graph.blocks.iter().any(|block| {
+            block.operations.windows(2).any(|ops| {
+                matches!(
+                    &ops[0].kind,
+                    OpKind::Call { target, .. } if target.to_string() == "core::ptr::null_mut"
+                ) && matches!(
+                    &ops[1].kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.as_slice()
+                        == ["__pyre_cast_instance".to_string(), "PyObject".to_string()]
+                )
+            })
+        });
+        assert!(
+            has_nullable_pyobject,
+            "PY_NULL stack clear must lower as null_mut followed by a PyObject narrow"
         );
     }
 
@@ -27773,11 +27861,9 @@ mod tests {
             "/../../build/llbc/pyre-interpreter.ullbc"
         );
         let llbc = Llbc::load(path).expect("load real interpreter LLBC");
-        let graph = super::lower_function(
-            &llbc,
-            "pyre_interpreter::eval::<Impl>::load_local_value",
-        )
-        .expect("lower eval::<Impl>::load_local_value");
+        let graph =
+            super::lower_function(&llbc, "pyre_interpreter::eval::<Impl>::load_local_value")
+                .expect("lower eval::<Impl>::load_local_value");
         let has_pyobject_narrow = graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
             matches!(
                 &op.kind,
@@ -28265,12 +28351,12 @@ mod tests {
     /// to Charon and blocks the dispatcher from two-phase translation.
     #[test]
     #[ignore]
-    fn call_function_impl_result_has_no_residual_array_index() {
+    fn get_and_call_function_has_no_residual_array_index() {
         use crate::model::OpKind;
         let path = crate::runtime_names::artifacts::INTERPRETER_ULLBC;
         let llbc = Llbc::load(path).expect("load real LLBC");
-        let graph = super::lower_function(&llbc, "call_function_impl_result")
-            .expect("lower call_function_impl_result");
+        let graph = super::lower_function(&llbc, "get_and_call_function")
+            .expect("lower get_and_call_function");
         let calls_path = |want: &[&str]| -> usize {
             let want: Vec<String> = want.iter().map(|s| s.to_string()).collect();
             graph
@@ -28297,6 +28383,40 @@ mod tests {
             calls_path(&["__getslice_rangeto"]),
             0,
             "no RangeTo getslice call is planted without an immutability proof"
+        );
+    }
+
+    /// The generator throw producer validates its preserved positional count
+    /// as 1..=3.  Delegation must keep those fixed call shapes visible rather
+    /// than routing them through `<[T; 3]>::index(&args, ..argc)`.
+    #[test]
+    #[ignore]
+    fn throw_yield_from_has_no_residual_array_index() {
+        use crate::model::OpKind;
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph =
+            super::lower_function(&llbc, "throw_yield_from").expect("lower throw_yield_from");
+        let residual = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: crate::model::CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments == &["core", "array", "<Impl>", "index"]
+                )
+            })
+            .count();
+        assert_eq!(
+            residual, 0,
+            "fixed throw arities must not leave an array index"
         );
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8917,6 +8917,17 @@ impl<'a> Lowering<'a> {
                 )? {
                     return Ok(());
                 }
+                if self.try_lower_i64_to_i32_try_from(
+                    mir_bb,
+                    &reg.kind,
+                    &segments,
+                    &args,
+                    dest_local,
+                    &call.dest.ty,
+                    target,
+                )? {
+                    return Ok(());
+                }
                 if self.try_lower_num_from(
                     mir_bb,
                     &reg.kind,
@@ -14003,6 +14014,129 @@ impl<'a> Lowering<'a> {
         let target_bb = self.block_id[target];
         let link_args = self.edge_args(mir_bb, target)?;
         self.graph.set_goto(bb_id, target_bb, link_args);
+        Ok(true)
+    }
+
+    /// Lower the fallible `i32::try_from(i64)` core shell to the checked
+    /// narrowing shape PyPy writes directly in
+    /// `ObjSpace.c_int_w` (`baseobjspace.py:2082-2088`): the value succeeds
+    /// exactly when `INT_MIN <= value <= INT_MAX`. Rust carries the two
+    /// branches in a `Result<i32, TryFromIntError>`, so preserve that source
+    /// CFG by materializing `Ok=0` / `Err=1` and leaving the caller's match
+    /// arms untouched.
+    ///
+    /// The payload aliases the i64 carrier. Narrow integer widths do not have
+    /// a distinct JIT register bank, and it is read only on the proven-in-range
+    /// Ok arm; this is the same value-preserving representation rule used by
+    /// [`Self::try_lower_usize_try_from`]. Other source/destination pairs stay
+    /// residual until their own bounds and signedness rules are ported.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The parameter order mirrors the corresponding RPython translation routine; grouping arguments into a Rust-only context object would obscure line-by-line parity and ownership"
+    )]
+    fn try_lower_i64_to_i32_try_from(
+        &mut self,
+        mir_bb: usize,
+        kind: &CallKind,
+        segments: &[String],
+        args: &[Variable],
+        dest_local: usize,
+        dest_ty: &TyRef,
+        target: usize,
+    ) -> Result<bool, LowerError> {
+        let [first, .., module, impl_seg, leaf] = segments else {
+            return Ok(false);
+        };
+        if first.as_str() != "core"
+            || module.as_str() != "num"
+            || impl_seg.as_str() != "<Impl>"
+            || leaf.as_str() != "try_from"
+        {
+            return Ok(false);
+        }
+        let [arg] = args else {
+            return Ok(false);
+        };
+        let CallKind::Fun(FunId::Regular { id }) = kind else {
+            return Ok(false);
+        };
+        let Some(fd) = self.llbc.fn_by_id(*id) else {
+            return Ok(false);
+        };
+        let Some(src) = fd.signature.inputs.first() else {
+            return Ok(false);
+        };
+        if !matches!(self.tyref_literal_int_atom(src), Some("I64" | "Isize")) {
+            return Ok(false);
+        }
+        let Some(success_ty) = self.tyref_adt_type_arg(dest_ty, 0) else {
+            return Ok(false);
+        };
+        if self.tyref_literal_int_atom(&success_ty) != Some("I32") {
+            return Ok(false);
+        }
+        let Some(def_id) = self.tyref_adt_def_id(dest_ty) else {
+            return Ok(false);
+        };
+        let Some(td) = self.llbc.type_by_id(def_id) else {
+            return Ok(false);
+        };
+        let owner = format!(
+            "{}{}",
+            td.item_meta.name_path(),
+            tyref_enum_instantiation_suffix(dest_ty, self.llbc)
+        );
+        let bb_id = self.block_id[mir_bb];
+        let push_op = |graph: &mut FunctionGraph, kind: OpKind| {
+            let result = graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+            graph.block_mut(bb_id).operations.push(SpaceOperation {
+                result: Some(result.clone()),
+                kind,
+            });
+            result
+        };
+        let min = push_op(&mut self.graph, OpKind::ConstInt(i32::MIN as i64));
+        let below = push_op(
+            &mut self.graph,
+            OpKind::BinOp {
+                op: "lt".to_string(),
+                lhs: arg.clone(),
+                rhs: min,
+                result_ty: ValueType::Int,
+            },
+        );
+        let max = push_op(&mut self.graph, OpKind::ConstInt(i32::MAX as i64));
+        let above = push_op(
+            &mut self.graph,
+            OpKind::BinOp {
+                op: "gt".to_string(),
+                lhs: arg.clone(),
+                rhs: max,
+                result_ty: ValueType::Int,
+            },
+        );
+        // The predicates are mutually exclusive, so their sum is exactly the
+        // Result discriminant: 0 in range (Ok), 1 out of range (Err).
+        let disc = push_op(
+            &mut self.graph,
+            OpKind::BinOp {
+                op: "add".to_string(),
+                lhs: below,
+                rhs: above,
+                result_ty: ValueType::Int,
+            },
+        );
+        let payload_owner =
+            Self::tagged_pair_payload_owner(td, &owner, 0).unwrap_or_else(|| owner.clone());
+        self.emit_tagged_pair_aggregate(
+            mir_bb,
+            &owner,
+            &payload_owner,
+            disc,
+            arg.clone(),
+            dest_local,
+            target,
+        )?;
         Ok(true)
     }
 
@@ -26165,6 +26299,54 @@ mod tests {
             }),
             "u32 destination must not use the i64 fits/discriminant lowering"
         );
+    }
+
+    /// PyPy's `ObjSpace.c_int_w` performs the same signed 32-bit bounds
+    /// check explicitly. Anchor Rust's `i32::try_from(i64)` spelling in both
+    /// the interpreter helper and the int-or-float list strategy: neither may
+    /// retain an opaque core call, and both must keep a runtime Result tag.
+    #[test]
+    #[ignore]
+    fn i64_to_i32_try_from_real_sites_lower_to_checked_result() {
+        use crate::model::{CallTarget, OpKind};
+
+        for (relpath, fname) in [
+            ("/../../build/llbc/pyre-interpreter.ullbc", "index_c_int_w"),
+            (
+                "/../../build/llbc/pyre-object.ullbc",
+                "int_or_float_encode_int",
+            ),
+        ] {
+            let path = format!("{}{relpath}", env!("CARGO_MANIFEST_DIR"));
+            let llbc = Llbc::load(path).unwrap_or_else(|e| panic!("load {fname} LLBC: {e}"));
+            let graph = super::lower_function(&llbc, fname)
+                .unwrap_or_else(|e| panic!("lower {fname}: {e:?}"));
+            assert!(
+                !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                    matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if super::fmt_path_ends_with(
+                            segments,
+                            &["convert", "num", "<Impl>", "try_from"],
+                        ))
+                }),
+                "{fname}: checked narrowing must not remain an opaque core call"
+            );
+            for expected in ["lt", "gt", "add"] {
+                assert!(
+                    graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                        matches!(&op.kind, OpKind::BinOp { op, .. } if op == expected)
+                    }),
+                    "{fname}: missing checked-narrowing {expected} op"
+                );
+            }
+            assert!(
+                graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                    matches!(&op.kind, OpKind::FieldWrite { field, .. }
+                        if field.name == "__discriminant")
+                }),
+                "{fname}: Result discriminant must remain runtime data"
+            );
+        }
     }
 
     /// Minimal `Llbc` carrying only `trait_impls` — the surface

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2256,9 +2256,8 @@ pub(crate) fn lower_fun_decl_with_static_addrs_and_attrs(
 }
 
 /// The MIR locals that can be a fresh string-builder accumulator: the
-/// destination of a `Wtf8Buf` / `String` `new` / `with_capacity` /
-/// `from_string` CALL
-/// terminator in the accumulator range `(arg_count+1..n_locals)`.
+/// destination of an [`is_str_builder_ctor`] CALL terminator in the
+/// accumulator range `(arg_count+1..n_locals)`.
 ///
 /// [`is_fresh_str_builder`] sets its `ctor_def` flag only in the
 /// call-terminator arm, so no other local can pass it — iterating these
@@ -2275,10 +2274,7 @@ fn builder_ctor_dest_locals<'a>(
         if let Ok(TermKind::Call { call, .. }) = bb.term()
             && let PlaceKind::Local(i) = call.dest.kind
             && (arg_count + 1..n_locals).contains(&(i as usize))
-            && matches!(
-                wtf8buf_method_leaf(llbc, &call),
-                Some("new") | Some("with_capacity") | Some("from_string")
-            )
+            && is_str_builder_ctor(wtf8buf_method_leaf(llbc, &call))
         {
             Some(i as usize)
         } else {
@@ -16965,11 +16961,43 @@ fn is_str_builder_owner(owner: Option<&str>) -> bool {
     matches!(owner, Some("Wtf8Buf") | Some("String"))
 }
 
+/// The owner of a *seed* constructor — one called on a borrowed string to
+/// build a fresh buffer, rather than one called on the buffer itself.
+///
+/// `Wtf8::to_wtf8_buf(&self) -> Wtf8Buf` is `Wtf8Buf { bytes:
+/// self.bytes.to_vec() }`: an unconditional fresh allocation holding a copy of
+/// the receiver, which is what `Wtf8Buf::from_string` already contributes on
+/// the owned side.  Seeding an accumulator from an existing string is the
+/// shape `do_stringformat` (`rstr.py`) builds, and a slice feeding one is
+/// sound because upstream's `getslice` is a copy, not a view
+/// (`ll_stringslice_startonly`, `rstr.py`).
+fn is_str_builder_seed_owner(owner: Option<&str>) -> bool {
+    matches!(owner, Some("Wtf8"))
+}
+
+/// Whether a [`str_builder_ctor_leaf`] leaf CONSTRUCTS a fresh buffer, as
+/// opposed to appending to one already built.
+///
+/// Named once because [`builder_ctor_dest_locals`] and
+/// [`is_fresh_str_builder`] must agree: the first selects the candidate
+/// locals, the second proves each one has no second definition.  Two
+/// hand-kept copies of this set would let a leaf be a candidate that can
+/// never pass, or pass a local the candidate scan never offers.
+fn is_str_builder_ctor(leaf: Option<&str>) -> bool {
+    matches!(
+        leaf,
+        Some("new") | Some("with_capacity") | Some("from_string") | Some("to_wtf8_buf")
+    )
+}
+
 /// The string-builder ctor leaf a MIR call resolves to, restricted to the
-/// fresh-buffer constructors this pass models (`new` / `with_capacity` /
-/// `from_string`) on a `Wtf8Buf` or `String`; `None` for any other callee.  The cheap leaf check
-/// runs before the impl-owner resolution so the type lookup only fires for the
-/// candidate names.  Appends are recognised separately by
+/// fresh-buffer constructors this pass models — `new` / `with_capacity` /
+/// `from_string` on a `Wtf8Buf` or `String`, and `to_wtf8_buf` on the borrowed
+/// `Wtf8` ([`is_str_builder_seed_owner`]); `None` for any other callee.  Each
+/// leaf carries the owner predicate it is admitted under, because a seed ctor
+/// is called on the borrowed string and the rest on the buffer.  The cheap
+/// leaf check runs before the impl-owner resolution so the type lookup only
+/// fires for the candidate names.  Appends are recognised separately by
 /// [`str_builder_append_args`].
 fn wtf8buf_method_leaf(llbc: &Llbc, call: &CallPayload) -> Option<&'static str> {
     let CallFunc::Regular(reg) = &call.func else {
@@ -16984,16 +17012,18 @@ fn str_builder_ctor_leaf(llbc: &Llbc, reg: &RegularCall) -> Option<&'static str>
     };
     let fd = llbc.fn_by_id(*id)?;
     let np = fd.item_meta.name_path();
-    let leaf = match np.rsplit("::").next()? {
-        "new" => "new",
-        "with_capacity" => "with_capacity",
-        "from_string" => "from_string",
-        "push" => "push",
-        "push_str" => "push_str",
-        "push_wtf8" => "push_wtf8",
-        _ => return None,
-    };
-    is_str_builder_owner(deref_impl_owner_leaf(llbc, fd).as_deref()).then_some(leaf)
+    let (leaf, owner_accepted): (&'static str, fn(Option<&str>) -> bool) =
+        match np.rsplit("::").next()? {
+            "new" => ("new", is_str_builder_owner),
+            "with_capacity" => ("with_capacity", is_str_builder_owner),
+            "from_string" => ("from_string", is_str_builder_owner),
+            "to_wtf8_buf" => ("to_wtf8_buf", is_str_builder_seed_owner),
+            "push" => ("push", is_str_builder_owner),
+            "push_str" => ("push_str", is_str_builder_owner),
+            "push_wtf8" => ("push_wtf8", is_str_builder_owner),
+            _ => return None,
+        };
+    owner_accepted(deref_impl_owner_leaf(llbc, fd).as_deref()).then_some(leaf)
 }
 
 /// If `reg` is a functional-concat string append, its `(accumulator, piece)`
@@ -17452,9 +17482,9 @@ fn append_arg_of_borrow(
 }
 
 /// Whether MIR local `c` is a fresh owned string-builder accumulator: it has
-/// exactly one def and that def is a `Wtf8Buf` / `String` `new` /
-/// `with_capacity` / `from_string` call.  A local with a second def, or one defined by a
-/// non-ctor rvalue, is not a fresh accumulator and keeps its residual.
+/// exactly one def and that def is an [`is_str_builder_ctor`] call.  A local
+/// with a second def, or one defined by a non-ctor rvalue, is not a fresh
+/// accumulator and keeps its residual.
 fn is_fresh_str_builder(body: &Unstructured, llbc: &Llbc, c: usize) -> bool {
     let mut def_count = 0usize;
     let mut ctor_def = false;
@@ -17470,10 +17500,7 @@ fn is_fresh_str_builder(body: &Unstructured, llbc: &Llbc, c: usize) -> bool {
             && matches!(call.dest.kind, PlaceKind::Local(i) if i as usize == c)
         {
             def_count += 1;
-            ctor_def = matches!(
-                wtf8buf_method_leaf(llbc, &call),
-                Some("new") | Some("with_capacity") | Some("from_string")
-            );
+            ctor_def = is_str_builder_ctor(wtf8buf_method_leaf(llbc, &call));
         }
     }
     def_count == 1 && ctor_def
@@ -17483,13 +17510,13 @@ fn is_fresh_str_builder(body: &Unstructured, llbc: &Llbc, c: usize) -> bool {
 /// local `rt` passed as the append's accumulator argument (`push` / `push_str` /
 /// `push_wtf8` receiver, or `Wtf8Piece::push_onto` `&mut buf` argument).  `rt`
 /// borrows the accumulator directly (method autoref) or through a single
-/// two-phase reborrow; the owning `buf` is the fresh `new` / `with_capacity`
-/// local whose every borrow feeds such an append and whose append-receiver set
+/// two-phase reborrow; the owning `buf` is the [`is_str_builder_ctor`] local
+/// whose every borrow feeds such an append and whose append-receiver set
 /// ([`clean_accumulator_ref_temps`]) contains `rt`.  Resolved on demand from
 /// the MIR body, so the recognizer keeps no per-local side table; the append
 /// call-lowering arm then rebinds `buf`'s slot to `ll_strconcat(buf, piece)`.
 fn append_accumulator_of_arg_temp(body: &Unstructured, llbc: &Llbc, rt: usize) -> Option<usize> {
-    // Only a `Wtf8Buf` / `String` ctor dest can pass [`is_fresh_str_builder`]
+    // Only an [`is_str_builder_ctor`] dest can pass [`is_fresh_str_builder`]
     // ([`builder_ctor_dest_locals`], which already excludes locals 0 / the
     // parameters), and a ref-temp borrows exactly one local so at most one
     // accumulator's receiver set contains `rt`; check those candidates instead

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -308,6 +308,7 @@ fn build_semantic_program_from_llbcs_with_static_addrs_filtered(
             &mut acc.struct_fields,
             &mut acc.struct_origins,
             &mut acc.enum_variant_by_discriminant,
+            Some(&acc.struct_ids),
         );
     }
     Ok(
@@ -841,6 +842,7 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
         &mut struct_fields,
         &mut struct_origins,
         &mut enum_variant_by_discriminant,
+        Some(&struct_ids),
     );
 
     // Per-instantiation enum-variant pre-registration source (#100): a
@@ -1500,16 +1502,20 @@ fn derive_program_metadata(
                         (fname, field_ty)
                     })
                     .collect();
+                let canonical_name = strip_crate_prefix(&name);
                 struct_fields.fields.insert(name.clone(), rows.clone());
+                struct_fields
+                    .fields
+                    .insert(canonical_name.clone(), rows.clone());
                 struct_fields.fields.insert(leaf.clone(), rows);
                 // Object identity for this struct type, minted from the
                 // crate-stripped qualified path — the spelling the descr
                 // layer keys `LLType::Struct` on and the runtime macro
                 // publishes.  Every name spelling (full-crate, stripped,
                 // bare leaf) resolves to it through the resolver table.
-                let sid = majit_ir::descr::StructId::from_canonical(&strip_crate_prefix(&name));
+                let sid = majit_ir::descr::StructId::from_canonical(&canonical_name);
                 record_struct_id(&mut struct_ids, name.clone(), sid);
-                record_struct_id(&mut struct_ids, strip_crate_prefix(&name), sid);
+                record_struct_id(&mut struct_ids, canonical_name.clone(), sid);
                 record_struct_id(&mut struct_ids, leaf.clone(), sid);
                 // Exact field byte offsets from Charon's resolved layout
                 // (the true Rust layout, not the heuristic).  Field index
@@ -1560,8 +1566,9 @@ fn derive_program_metadata(
                         (fname, tyref_to_attr_value_type(&f.ty, llbc))
                     })
                     .collect();
-                struct_field_attrs.insert(strip_crate_prefix(&name), attr_rows);
+                struct_field_attrs.insert(canonical_name.clone(), attr_rows);
                 known_struct_names.insert(name);
+                known_struct_names.insert(canonical_name);
                 known_struct_names.insert(leaf);
             }
             TypeDeclKind::Enum(variants) => {
@@ -1972,9 +1979,10 @@ fn derive_program_metadata(
 /// are distinct entries by construction and there is no bare alias to
 /// withdraw.
 ///
-/// Derived purely from the current qualified (`::`-containing) keys, so
-/// the pass is idempotent and safe to re-run after the cross-LLBC
-/// merge re-introduces a per-crate-unique alias.
+/// Derived from the current qualified (`::`-containing) keys after collapsing
+/// their full/canonical spellings through the existing `StructId` object
+/// identity.  The pass is therefore idempotent and safe to re-run after the
+/// cross-LLBC merge re-introduces a per-crate-unique alias.
 fn harden_duplicate_leaf_metadata(
     struct_fields: &mut crate::front::semantic::StructFieldRegistry,
     struct_origins: &mut std::collections::HashMap<String, String>,
@@ -1982,7 +1990,29 @@ fn harden_duplicate_leaf_metadata(
         String,
         std::collections::HashMap<i64, String>,
     >,
+    struct_ids: Option<&std::collections::HashMap<String, Option<majit_ir::descr::StructId>>>,
 ) {
+    // RPython groups aliases by the live class object, never by spelling.
+    // `StructId` is pyre's existing object-identity carrier: discard a
+    // crate-included/canonical duplicate before comparing declaration rows,
+    // and discard a resolver-tombstoned alias (`None`) because it denotes no
+    // unique declaration.  Tests that exercise this helper in isolation pass
+    // no identity table and retain the original spelling-based behavior.
+    fn unique_declarations<'a>(
+        keys: &[&'a str],
+        struct_ids: Option<&std::collections::HashMap<String, Option<majit_ir::descr::StructId>>>,
+    ) -> Vec<&'a str> {
+        let mut seen = std::collections::HashSet::new();
+        let mut unique = Vec::with_capacity(keys.len());
+        for key in keys {
+            match struct_ids.and_then(|ids| ids.get(*key)) {
+                Some(Some(id)) if seen.insert(*id) => unique.push(*key),
+                Some(Some(_)) | Some(None) => {}
+                None => unique.push(*key),
+            }
+        }
+        unique
+    }
     let mut by_leaf: std::collections::HashMap<&str, Vec<&str>> = std::collections::HashMap::new();
     for key in struct_fields.fields.keys() {
         if let Some((head, leaf)) = key.rsplit_once("::") {
@@ -2006,7 +2036,8 @@ fn harden_duplicate_leaf_metadata(
     }
     let mut drop_field_aliases: Vec<String> = Vec::new();
     let mut tombstone_origins: Vec<String> = Vec::new();
-    for (leaf, quals) in &by_leaf {
+    for (leaf, aliases) in &by_leaf {
+        let quals = unique_declarations(aliases, struct_ids);
         if quals.len() < 2 {
             continue;
         }
@@ -2017,17 +2048,23 @@ fn harden_duplicate_leaf_metadata(
         {
             drop_field_aliases.push((*leaf).to_string());
         }
-        let first_module = strip_crate_prefix(quals[0])
-            .rsplit_once("::")
-            .map(|(m, _)| m.to_string())
-            .unwrap_or_default();
-        if quals[1..].iter().any(|q| {
-            strip_crate_prefix(q)
+        // Two surviving identity-backed keys are necessarily two distinct
+        // declarations.  The fallback module comparison preserves the
+        // isolated helper tests and metadata without a resolver table.
+        let distinct_identity = struct_ids.is_some() || {
+            let first_module = strip_crate_prefix(quals[0])
                 .rsplit_once("::")
-                .map(|(m, _)| m)
-                .unwrap_or_default()
-                != first_module
-        }) {
+                .map(|(m, _)| m.to_string())
+                .unwrap_or_default();
+            quals[1..].iter().any(|q| {
+                strip_crate_prefix(q)
+                    .rsplit_once("::")
+                    .map(|(m, _)| m)
+                    .unwrap_or_default()
+                    != first_module
+            })
+        };
+        if distinct_identity {
             tombstone_origins.push((*leaf).to_string());
         }
     }
@@ -2065,7 +2102,8 @@ fn harden_duplicate_leaf_metadata(
         }
     }
     let mut drop_variant_aliases: Vec<String> = Vec::new();
-    for (alias, quals) in &variant_by_alias {
+    for (alias, aliases) in &variant_by_alias {
+        let quals = unique_declarations(aliases, struct_ids);
         if quals.len() < 2 {
             continue;
         }
@@ -2094,7 +2132,8 @@ fn harden_duplicate_leaf_metadata(
         }
     }
     let mut drop_enum_aliases: Vec<String> = Vec::new();
-    for (leaf, quals) in &enum_by_leaf {
+    for (leaf, aliases) in &enum_by_leaf {
+        let quals = unique_declarations(aliases, struct_ids);
         if quals.len() < 2 {
             continue;
         }
@@ -2592,14 +2631,29 @@ fn lower_unstructured_with_static_addrs_and_attrs(
         // `__discriminant` diamond, same post-lowering shape and fail-safe
         // contract as `map_or`; gate the reachability sweep on an actual
         // rewrite.
-        let closure_select_rewritten = if lo.closure_select_sites.is_empty() {
-            0
+        let closure_select_outcome = if lo.closure_select_sites.is_empty() {
+            crate::front::option_closure_select::ClosureSelectRewriteOutcome::default()
         } else {
             crate::front::option_closure_select::rewire_closure_select_call_sites(
                 &mut lo.graph,
                 &lo.closure_select_sites,
             )
         };
+        // This late combinator pass synthesizes `call_once` sites after the
+        // first Result-exception pass.  A closure returning
+        // `Result<T, PyError>` uses the translated exception ABI, while
+        // `map`/`unwrap_or_else` retain that Result as an ordinary value.
+        // Apply the same custom-consumer catch-and-rewrap rule as a source MIR
+        // call so the combinator receives an `Ok`/`Err` shell again.
+        if !closure_select_outcome.result_exc_calls.is_empty() {
+            crate::front::result_exc::rewire_result_exc_call_sites(
+                &mut lo.graph,
+                &closure_select_outcome.result_exc_calls,
+                result_exc_callee,
+            )
+            .map_err(LowerError::Unsupported)?;
+        }
+        let closure_select_rewritten = closure_select_outcome.rewritten;
         // The `(a..=b).contains(&x)` fold (`front::range_contains`) splices
         // the residual `contains` method call in place with native
         // `bitand(le(a, x), ge(b, x))` compares and removes the paired
@@ -7091,9 +7145,15 @@ impl<'a> Lowering<'a> {
                             let Operand::Const(value) = op else {
                                 return None;
                             };
-                            let DecodedConst::Int(n) = decode_constant(self.llbc, value).ok()?
-                            else {
-                                return None;
+                            let n = match decode_constant(self.llbc, value).ok()? {
+                                DecodedConst::Int(n) => n,
+                                // Current Charon preserves a byte-string
+                                // aggregate's `u8` bank. The RPython
+                                // prebuilt ll_array constant uses the same
+                                // signed integer literal carrier after the
+                                // checked, value-preserving conversion.
+                                DecodedConst::UInt(n) => i64::try_from(n).ok()?,
+                                _ => return None,
                             };
                             vals.push(n);
                         }
@@ -7625,9 +7685,13 @@ impl<'a> Lowering<'a> {
         // `call.func`.  This is the same two-source type test used for
         // `SliceIndex::index` below and keeps Range* implementations on the
         // separate getslice lowering.
-        let slice_get_index_is_scalar = match &call.func {
-            CallFunc::Regular(reg) => self.is_slice_get_scalar_call(reg, second_arg_ty.as_ref()),
-            _ => false,
+        let (slice_get_index_is_scalar, slice_get_element) = match &call.func {
+            CallFunc::Regular(reg) => {
+                let scalar = self.is_slice_get_scalar_call(reg, second_arg_ty.as_ref());
+                let element = scalar.then(|| self.slice_get_element(reg)).flatten();
+                (scalar, element)
+            }
+            _ => (false, None),
         };
         for op in call.args {
             args.push(self.resolve_operand(mir_bb, op)?);
@@ -7711,6 +7775,27 @@ impl<'a> Lowering<'a> {
                         kind: OpKind::ConstBool(true),
                     });
                     self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
+                // `gc_alloc_storage_box(Wtf8Buf, tid) -> *mut Wtf8Buf` is
+                // only the Rust ownership spelling of PyPy's direct `_utf8`
+                // RPython-string field.  The input value has already become
+                // the allocated `rpy_string`; a second nominal Wtf8Buf box
+                // does not exist in the translated object model.  Alias this
+                // one specialization to its value, exactly like
+                // `malloc_raw_alloc` round-trips a `SomeString`.  Every other
+                // `gc_alloc_storage_box<T>` keeps its translated GC-box body.
+                if args.len() == 2
+                    && self.is_string_storage_box_identity(
+                        &reg,
+                        first_arg_ty.as_ref(),
+                        &call.dest.ty,
+                    )
+                {
+                    self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
                     self.graph.set_goto(bb_id, target_bb, link_args);
@@ -10589,8 +10674,10 @@ impl<'a> Lowering<'a> {
         } = &op_kind
             && args.len() == 2
             && fmt_path_ends_with(segments, &["slice", "<Impl>", "get"])
+            && slice_get_index_is_scalar
+            && let Some((item_ty, array_type_id)) = slice_get_element.clone()
             && let Some(site) =
-                self.recognize_slice_get_site(&call.dest.ty, second_arg_ty.as_ref(), &result_var)
+                self.recognize_slice_get_site(&call.dest.ty, &result_var, item_ty, array_type_id)
         {
             self.slice_get_sites.push(site);
         }
@@ -11329,6 +11416,35 @@ impl<'a> Lowering<'a> {
         is_get && callsite_index_is_scalar
     }
 
+    /// ARRAY identity proof for the scalar-index `<[T]>::get` rewrite.
+    ///
+    /// This is the `get` counterpart of the `Index::index` element gate: a
+    /// scalar or an RPython GC-pointer value carries an element spelling so
+    /// the descr computes its exact stride; a thin pointer is already one
+    /// word and needs no identity. Any other inline Rust aggregate declines.
+    /// The outer `Option` is the proof, while the inner one is the optional
+    /// ARRAY identity (`Some(None)` means the proven thin-pointer case).
+    fn slice_get_element(&self, reg: &RegularCall) -> Option<(ValueType, Option<String>)> {
+        let element_ty = reg
+            .generics
+            .get("types")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|types| types.first())
+            .and_then(|ty| serde_json::from_value::<TyRef>(ty.clone()).ok())?;
+        let element = tyref_node(&element_ty, self.llbc)?;
+        // `get` returns `Option<&T>`, but its devirtualized ArrayRead is the
+        // same RPython getarrayitem operation as `Index::index`: it produces
+        // T, not a Rust slot reference.  Read the bank from the call's T
+        // generic before looking at the reference-wrapped destination.
+        let item_ty = tyref_to_value_type(&element_ty, self.llbc);
+        if let Some(spelling) = json_ty_scalar_element_spelling(element, self.llbc)
+            .or_else(|| json_ty_rpython_gc_pointer_element_spelling(element, self.llbc))
+        {
+            return Some((item_ty, Some(format!("[{spelling}]"))));
+        }
+        json_ty_is_thin_pointer_element(element, self.llbc).then_some((item_ty, None))
+    }
+
     fn is_slice_scalar_index_mut_call(&self, reg: &RegularCall) -> bool {
         let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
             return false;
@@ -11901,6 +12017,28 @@ impl<'a> Lowering<'a> {
             return false;
         }
         first_arg_ty.is_some_and(|ty| tyref_is_string_value(ty, self.llbc))
+    }
+
+    /// `pyre_object::gc_storage::gc_alloc_storage_box::<Wtf8Buf>` is the
+    /// physical Rust owner for a value that the translated model already
+    /// represents as one RPython string.  Admit only the exact string-family
+    /// input and exactly-one-raw-pointer string-family result; other storage
+    /// boxes retain their allocation body.
+    fn is_string_storage_box_identity(
+        &self,
+        reg: &RegularCall,
+        first_arg_ty: Option<&TyRef>,
+        dest_ty: &TyRef,
+    ) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        let Some(fd) = self.llbc.fn_by_id(*id) else {
+            return false;
+        };
+        fd.item_meta.name_path() == "pyre_object::gc_storage::gc_alloc_storage_box"
+            && first_arg_ty.is_some_and(|ty| tyref_is_string_value(ty, self.llbc))
+            && tyref_raw_ptr_pointee_is_string_value(dest_ty, self.llbc)
     }
 
     /// `Option::<&T>::copied` / `Option::<T: Clone>::cloned` — reads the
@@ -13243,49 +13381,22 @@ impl<'a> Lowering<'a> {
     /// + `Some` variant owners [`Self::recognize_slice_first_site`] resolves,
     /// plus the `SliceIndex` instantiation gate `first` has no need of.
     ///
-    /// `<[T]>::get` is generic over `SliceIndex`, and only its scalar
-    /// instantiation returns `Option<&T>`.  Every range one (`Range`,
-    /// `RangeTo`, `RangeFrom`, `RangeFull`, `RangeInclusive`,
-    /// `RangeToInclusive`) returns `Option<&[T]>`, whose payload is a
-    /// SUB-SLICE: an element read at the range's start would hand the consumer
-    /// a `T` where a `[T]` is expected.  Pin the scalar one by the index
-    /// operand's declared `usize` — the same discriminator
-    /// [`Self::is_slice_scalar_index_call`] uses to separate `<[T]>::index`'s
-    /// scalar impl from its range ones.  A literal subscript arrives as an
-    /// `Operand::Const`, for which no `index_ty` is captured, so it declines
-    /// too: the residual call and its census Skip both survive.
-    ///
-    /// [`Self::option_residual_narrow_root`] refuses the range forms a second
-    /// time — a `[T]` payload is the `Slice` builtin, which has no ADT def-id
-    /// and so no registered narrow root — and is load-bearing for `get` for
-    /// the reason it is for `first`: it is exactly the shape `lower_call`
-    /// appends a trailing `__pyre_cast_instance` narrowing to, the cast the
-    /// post-pass absorbs and re-applies per arm.  It also declines a
-    /// value-slice `Option<u8>` / `Option<i64>` cleanly.
+    /// The call site has already proved the `SliceIndex` instantiation is
+    /// scalar through [`Self::is_slice_get_scalar_call`], using either the
+    /// operand Place type or (for a literal index) the method generic.  Resolve
+    /// the destination with the same consumer-owner rule used by checked
+    /// arithmetic and `Option` consumers: reference payloads may carry the
+    /// trailing narrowing cast the post-pass absorbs, while scalar payloads
+    /// (`Option<u8>`, `Option<i64>`, …) remain value-banked and have no cast.
     fn recognize_slice_get_site(
         &self,
         dest_ty: &TyRef,
-        index_ty: Option<&TyRef>,
         result_var: &Variable,
+        item_ty: ValueType,
+        array_type_id: Option<String>,
     ) -> Option<crate::front::slice_get::SliceGetSite> {
-        if index_ty.and_then(|ty| self.tyref_literal_uint_atom(ty)) != Some("Usize") {
-            crate::decline::record_named(
-                crate::decline::gate::SLICE_GET_SITE,
-                "index-not-usize",
-                &self.graph.name,
-            );
-            return None;
-        }
-        if self.option_residual_narrow_root(dest_ty).is_none() {
-            crate::decline::record_named(
-                crate::decline::gate::SLICE_GET_SITE,
-                "payload-has-no-narrow-root",
-                &self.graph.name,
-            );
-            return None;
-        }
-        let Some((option_owner, some_owner, payload_ty)) =
-            self.resolve_bool_then_option_dest(dest_ty)
+        let Some((option_owner, some_owner, _reference_payload_ty)) =
+            self.resolve_option_consumer_owners(dest_ty)
         else {
             crate::decline::record_named(
                 crate::decline::gate::SLICE_GET_SITE,
@@ -13303,7 +13414,8 @@ impl<'a> Lowering<'a> {
             result_var: result_var.clone(),
             option_owner,
             some_owner,
-            payload_ty,
+            payload_ty: item_ty,
+            array_type_id,
         })
     }
 
@@ -13702,13 +13814,29 @@ impl<'a> Lowering<'a> {
         // is `Option<T>` and its closure returns that same `Option<T>`;
         // `unwrap_or_else`'s dest is the bare `T`; `is_some_and`'s closure and
         // dest are both `bool`.
-        let call_result_ty = match kind {
-            ClosureCombinator::Map => self.tyref_option_payload_value_type(dest_ty)?,
+        let call_result_tyref = match kind {
+            ClosureCombinator::Map => {
+                crate::front::result_exc::tyref_option_payload(dest_ty, self.llbc)?
+            }
             ClosureCombinator::AndThen
             | ClosureCombinator::OrElse
             | ClosureCombinator::UnwrapOrElse
-            | ClosureCombinator::IsSomeAnd => tyref_to_value_type(dest_ty, self.llbc),
+            | ClosureCombinator::IsSomeAnd => clone_tyref(dest_ty),
         };
+        let call_result_ty = tyref_to_value_type(&call_result_tyref, self.llbc);
+        let call_once_result_exc =
+            crate::front::result_exc::tyref_is_result_of_pyerror(&call_result_tyref, self.llbc)
+                .then(|| {
+                    let suffix = crate::front::result_exc::tyref_result_instantiation_suffix(
+                        &call_result_tyref,
+                        self.llbc,
+                    );
+                    let payload_ty =
+                        crate::front::result_exc::tyref_result_ok(&call_result_tyref, self.llbc)
+                            .map(|ty| tyref_to_value_type(&ty, self.llbc))
+                            .unwrap_or(ValueType::Ref(None));
+                    (suffix, payload_ty)
+                });
         let niche = self.tyref_is_niche_option_ptr(recv_ty);
         // `map`/`and_then` BUILD their result `Option<U>`; the other combinators
         // build none.  `U` is the dest payload, not the receiver's `T`, so the
@@ -13740,6 +13868,7 @@ impl<'a> Lowering<'a> {
             call_result_ty,
             args_tuple_suffix,
             niche,
+            call_once_result_exc,
         })
     }
 
@@ -15383,7 +15512,7 @@ impl<'a> Lowering<'a> {
         target: usize,
     ) -> Result<(), LowerError> {
         let bb_id = self.block_id[mir_bb];
-        let mut owner_path: Vec<String> = owner.split("::").map(str::to_string).collect();
+        let mut owner_path = crate::model::split_qualified_path(owner);
         let ctor_name = owner_path.pop().unwrap_or_default();
         let ctor_target = if owner_path.is_empty() {
             CallTarget::synthetic_transparent_ctor(ctor_name.clone())
@@ -18385,15 +18514,15 @@ fn tyref_to_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
     }
     // A `str`/`String`/`Wtf8`/`Wtf8Buf` value is the single immutable
     // rpy_string in the value model (`tyref_is_string_value`), matching
-    // upstream's one string type (`rstr.py`).  A bare string-family value
-    // (parameter, return, local) seeds `SomeString` so it stays the string
-    // lattice node at every site instead of a classdef-carrying
-    // `SomeInstance(Wtf8Buf)`: a `Wtf8Buf` value stored into a `*mut Wtf8Buf`
-    // field flows `SomeString` through `malloc_raw` (which round-trips a
-    // non-`Instance` payload unchanged), keeping the field repr
-    // `Ptr(rpy_string)` consistent with the `getattr` + deref-to-`&Wtf8`
-    // read that reports the field as a string.
-    if tyref_is_string_value(ty, llbc) {
+    // upstream's one string type (`rstr.py`).  The exactly-one-raw-pointer
+    // form is the same translated value for pyre's owning storage spelling:
+    // both `malloc_raw(Wtf8Buf)` and `gc_alloc_storage_box(Wtf8Buf)` return
+    // `*mut Wtf8Buf`, while PyPy passes its `_utf8` RPython string through
+    // those sites directly.  Preserve `SomeString` on the return/phi as well
+    // as on the struct field; otherwise the GC-box success arm injects a
+    // nominal `SomeInstance(Wtf8Buf)` and generalizes `_utf8` away from its
+    // `StringRepr`.
+    if tyref_is_string_value(ty, llbc) || tyref_raw_ptr_pointee_is_string_value(ty, llbc) {
         return ValueType::Str;
     }
     ValueType::Ref(None)
@@ -18903,8 +19032,12 @@ fn tyref_to_attr_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
     // valuetype_to_someshell) instead of the classdef-less `Ref(None)`
     // SomeInstance the fallback yields; the latter walls when the first
     // typed string write unions `String ∪ Instance(classdef-less)` with no
-    // pair(SomeString, SomeInstance).union() handler.
-    if tyref_is_string_value(ty, llbc) {
+    // pair(SomeString, SomeInstance).union() handler.  The raw-pointer form
+    // is the same translated value when a Rust object field owns the buffer
+    // behind `*mut Wtf8Buf` (`W_UnicodeObject.value`): PyPy's corresponding
+    // `_utf8` field is an RPython string, while Charon's exact layout still
+    // records the physical pointer-sized slot independently.
+    if tyref_is_string_value(ty, llbc) || tyref_raw_ptr_pointee_is_string_value(ty, llbc) {
         return ValueType::Str;
     }
     ValueType::Ref(None)
@@ -18986,6 +19119,26 @@ fn tyref_is_string_value(ty: &TyRef, llbc: &Llbc) -> bool {
     let Some(node) = tyref_node(ty, llbc).and_then(|n| strip_ty_wrappers(n, llbc)) else {
         return false;
     };
+    node_is_string_value(node, llbc)
+}
+
+/// Whether the pointee of exactly one raw-pointer layer is a string-family
+/// value.  This is deliberately narrower than teaching
+/// [`strip_ty_wrappers`] to erase `RawPtr`: ordinary typed raw pointers retain
+/// their pointee identity; only field-annotation projection asks whether the
+/// pointer is the storage spelling of RPython's string value.
+fn tyref_raw_ptr_pointee_is_string_value(ty: &TyRef, llbc: &Llbc) -> bool {
+    let Some(pointee) = tyref_node(ty, llbc)
+        .and_then(|n| strip_ty_wrappers(n, llbc))
+        .and_then(|n| n.as_object()?.get("RawPtr")?.as_array()?.first())
+        .and_then(|n| strip_ty_wrappers(n, llbc))
+    else {
+        return false;
+    };
+    node_is_string_value(pointee, llbc)
+}
+
+fn node_is_string_value(node: &serde_json::Value, llbc: &Llbc) -> bool {
     // `{Builtin: "Str"}` — the bare `str` value (no ADT def-id).
     if node
         .get("Adt")
@@ -19817,12 +19970,12 @@ fn typevar_bound_index(node: &serde_json::Value) -> Option<u64> {
 }
 
 /// True when fn-level type variable `var_index` carries an
-/// `Into<String>` trait clause.  The clause's trait generics spell
+/// `Into<String>` / `Into<Wtf8Buf>` trait clause.  The clause's trait generics spell
 /// `[<subject>, <target>]`; the subject must be our variable and the
-/// target must resolve to the `alloc::string::String` ADT, with the
+/// target must resolve to the translated string-value family, with the
 /// trait decl's leaf name `Into` (a `From<String>` bound has the same
 /// generics shape but means the *opposite* conversion).
-fn typevar_bounded_by_into_string(
+fn typevar_bounded_by_into_string_value(
     var_index: u64,
     fn_generics: &serde_json::Value,
     llbc: &Llbc,
@@ -19888,9 +20041,8 @@ fn typevar_bounded_by_into_string(
         }
         let target_is_string = types
             .get(1)
-            .and_then(|t| resolve_tyexpr_to_adt_def_id_free(llbc, t))
-            .and_then(|id| llbc.type_by_id(id))
-            .is_some_and(|td| td.item_meta.name_path() == "alloc::string::String");
+            .and_then(|target| strip(llbc, target))
+            .is_some_and(|target| node_is_string_value(target, llbc));
         if target_is_string {
             return true;
         }
@@ -19930,14 +20082,15 @@ fn tyref_generic_trait_bound_root(
         TyRef::Dedup { id } => llbc.dedup_body(*id)?,
     };
     let param_index = typevar_bound_index(strip_ty_wrappers(node, llbc)?)?;
-    // `T: Into<String>` — the conventional message-parameter bound
-    // (`PyError::type_error(msg: impl Into<String>)`).  Such a variable
-    // is a string at the annotation level (the model maps `String` and
-    // `str` to one string type), so it resolves to the `"String"` root
+    // `T: Into<String>` / `T: Into<Wtf8Buf>` — the conventional
+    // message-parameter bound (`PyError::new(message: impl Into<Wtf8Buf>)`).
+    // Such a variable is a string at the annotation level (the model maps
+    // `String`, `str`, `Wtf8`, and `Wtf8Buf` to one string type), so it
+    // resolves to the `"String"` root
     // and the input-cell derivation seeds `s_unicode0` instead of a
     // classdef-less instance shell whose field writes would poison
     // classdef attr cells.
-    if typevar_bounded_by_into_string(param_index, generics, llbc) {
+    if typevar_bounded_by_into_string_value(param_index, generics, llbc) {
         return Some("String".to_string());
     }
     for clause in generics.get("trait_clauses")?.as_array()? {
@@ -21285,7 +21438,7 @@ fn transparent_inherent_method_path(reg: &RegularCall, llbc: &Llbc) -> Option<Ve
     if !llbc.type_by_id(owner_id)?.is_repr_transparent() {
         return None;
     }
-    let mut path = owner.split("::").map(str::to_string).collect::<Vec<_>>();
+    let mut path = crate::model::split_qualified_path(&owner);
     path.push(method);
     Some(path)
 }
@@ -22619,10 +22772,13 @@ fn read_array_literal_elements(
     Some(by_index.into_iter().map(|(_, v)| v).collect())
 }
 
-/// Resolve a Variable to the `i64` of the `ConstInt` op that produces it,
-/// following cross-block links via [`resolve_to_producer_op`]. Used to
-/// read the packed-format pieces byte array (each `__pos_i` element is a
-/// `ConstInt` byte).
+/// Resolve a Variable to the `i64` value of the integer constant op that
+/// produces it, following cross-block links via
+/// [`resolve_to_producer_op`].  Packed-format pieces are `[u8; N]`, so the
+/// ordinary lowering now preserves each byte as `ConstUInt`; older/synthetic
+/// fixtures may still spell the same in-range byte as `ConstInt`.  Accept both
+/// at this byte-decoding boundary without changing either SSA value's unsigned
+/// annotation.
 fn resolve_const_int(
     graph: &FunctionGraph,
     var: &crate::flowspace::model::Variable,
@@ -22632,6 +22788,7 @@ fn resolve_const_int(
     let block = graph.blocks.iter().find(|b| b.id == block_id)?;
     match &block.operations.get(idx)?.kind {
         OpKind::ConstInt(n) => Some(*n),
+        OpKind::ConstUInt(n) => i64::try_from(*n).ok(),
         _ => None,
     }
 }
@@ -25646,7 +25803,7 @@ mod tests {
         };
 
         // Build the pieces array the way the front-end lowers it: an
-        // `Array` ctor followed by `__pos_i` FieldWrites of ConstInt
+        // `Array` ctor followed by `__pos_i` FieldWrites of ConstUInt
         // bytes. Template for `format!("hi{}")` → pieces ["hi", ""],
         // one placeholder = bytes [2, 'h', 'i', 0xC0, 0].
         let mut graph = FunctionGraph::new("arraylit");
@@ -25660,12 +25817,12 @@ mod tests {
                 result_ty: ValueType::Ref(Some("Array".to_string())),
             },
         });
-        let bytes = [2i64, 104, 105, 0xC0, 0];
+        let bytes = [2u64, 104, 105, 0xC0, 0];
         for (i, b) in bytes.iter().enumerate() {
             let v = Variable::new();
             graph.block_mut(a).operations.push(SpaceOperation {
                 result: Some(v.clone()),
-                kind: OpKind::ConstInt(*b),
+                kind: OpKind::ConstUInt(*b),
             });
             graph.block_mut(a).operations.push(SpaceOperation {
                 result: None,
@@ -26948,6 +27105,53 @@ mod tests {
         );
     }
 
+    /// Anchor PyPy's single string-valued `W_UnicodeObject._utf8` shape to
+    /// the real pyre-object LLBC.  Rust stores that value behind
+    /// `*mut Wtf8Buf`, but both its canonical annotation metadata and the
+    /// managed storage-box call must collapse to the one RPython string value.
+    #[test]
+    #[ignore]
+    fn unicode_storage_matches_real_object_llbc() {
+        use crate::model::{CallTarget, OpKind, ValueType};
+
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real pyre-object LLBC");
+        let (_, _, fields, _, _, attrs, _, _) = super::derive_program_metadata(&llbc);
+        assert!(
+            fields
+                .fields
+                .get("pyre_object::unicodeobject::W_UnicodeObject")
+                .is_some_and(
+                    |rows| rows.contains(&("value".to_string(), "*mut Wtf8Buf".to_string()))
+                ),
+            "the declaration metadata must retain the physical storage row"
+        );
+        assert!(
+            attrs
+                .get("unicodeobject::W_UnicodeObject")
+                .is_some_and(|rows| rows.contains(&("value".to_string(), ValueType::Str))),
+            "W_UnicodeObject.value must project as PyPy's string-valued _utf8 field"
+        );
+
+        let graph = super::lower_function(&llbc, "w_str_from_wtf8_managed")
+            .expect("lower managed string constructor");
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if super::fmt_path_ends_with(segments, &["gc_alloc_storage_box"])
+                )
+            }),
+            "the Wtf8 storage box must be an RPython-string identity"
+        );
+    }
+
     /// Anchor compiler-core's exact
     /// `Constants(Box<[C]>)::{deref,index}` storage shape to the real
     /// interpreter LLBC.  `constant_at` must project the wrapper's sole field
@@ -27023,7 +27227,6 @@ mod tests {
                 ("im".to_string(), ValueType::Float),
             ])
         );
-
         let constant_at = super::lower_function(&llbc, "constant_at")
             .expect("lower ConstantOpcodeHandler::constant_at");
         let constant_ops: Vec<_> = constant_at
@@ -28536,6 +28739,106 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn string_storage_pointer_seeds_the_rpython_string_field_repr() {
+        let wtf8buf = serde_json::json!({
+            "def_id": 1,
+            "item_meta": {
+                "name": [
+                    {"Ident": ["rustpython_wtf8", 0]},
+                    {"Ident": ["Wtf8Buf", 0]}
+                ],
+                "span": {"data": {
+                    "file_id": 0,
+                    "beg": {"line": 1, "col": 0},
+                    "end": {"line": 1, "col": 16}
+                }},
+                "source_text": "pub struct Wtf8Buf { ... }",
+                "attr_info": {
+                    "attributes": [], "inline": null, "rename": null, "public": true
+                },
+                "is_local": false
+            },
+            "kind": "Opaque",
+            "layout": null
+        });
+        let file = serde_json::json!({
+            "charon_version": "0.1.201",
+            "has_errors": false,
+            "translated": {
+                "crate_name": "fixture",
+                "type_decls": [null, wtf8buf],
+                "fun_decls": [],
+                "global_decls": [],
+                "trait_decls": [null, {
+                    "def_id": 1,
+                    "item_meta": {
+                        "name": [
+                            {"Ident": ["core", 0]},
+                            {"Ident": ["convert", 0]},
+                            {"Ident": ["Into", 0]}
+                        ],
+                        "span": {"data": {
+                            "file_id": 0,
+                            "beg": {"line": 1, "col": 0},
+                            "end": {"line": 1, "col": 16}
+                        }},
+                        "source_text": "pub trait Into<T> { ... }",
+                        "attr_info": {
+                            "attributes": [], "inline": null, "rename": null, "public": true
+                        },
+                        "is_local": false
+                    }
+                }],
+                "trait_impls": []
+            }
+        });
+        let llbc = Llbc::from_slice(file.to_string().as_bytes()).expect("fixture Llbc parses");
+        let pointee = serde_json::json!({
+            "Adt": {"id": {"Adt": 1}, "generics": {"types": []}}
+        });
+        let storage_ptr = TyRef::Other(serde_json::json!({
+            "RawPtr": [pointee, "Mut"]
+        }));
+
+        assert_eq!(
+            super::tyref_to_attr_value_type(&storage_ptr, &llbc),
+            ValueType::Str,
+            "W_UnicodeObject.value is the Rust storage spelling of PyPy's string-valued _utf8 field"
+        );
+        assert_eq!(
+            super::tyref_to_value_type(&storage_ptr, &llbc),
+            ValueType::Str,
+            "the owning storage pointer must remain the same RPython string at return and phi sites"
+        );
+        assert_eq!(
+            super::tyref_to_value_type(&TyRef::Other(pointee.clone()), &llbc),
+            ValueType::Str,
+            "a bare Wtf8Buf value is the same RPython string representation"
+        );
+
+        let generic_message = TyRef::Other(serde_json::json!({
+            "TypeVar": {"Bound": [0, 0]}
+        }));
+        let generics = serde_json::json!({
+            "trait_clauses": [{
+                "trait_": {"skip_binder": {
+                    "id": 1,
+                    "generics": {"types": [
+                        {"TypeVar": {"Bound": [1, 0]}},
+                        pointee
+                    ]}
+                }}
+            }]
+        });
+        assert_eq!(
+            super::tyref_generic_trait_bound_root(&generic_message, &llbc, Some(&generics),)
+                .as_deref(),
+            Some("String"),
+            "impl Into<Wtf8Buf> message parameters seed the one RPython string input cell"
+        );
+    }
+
     fn rows(spec: &[(&str, &str)]) -> Vec<(String, String)> {
         spec.iter()
             .map(|(n, t)| (n.to_string(), t.to_string()))
@@ -28563,7 +28866,7 @@ mod tests {
         origins.insert("FrameBlock".to_string(), "pyopcode".to_string());
         let mut enums = std::collections::HashMap::new();
 
-        harden_duplicate_leaf_metadata(&mut reg, &mut origins, &mut enums);
+        harden_duplicate_leaf_metadata(&mut reg, &mut origins, &mut enums, None);
 
         assert!(
             !reg.fields.contains_key("FrameBlock"),
@@ -28597,10 +28900,40 @@ mod tests {
         origins.insert("Point".to_string(), "eval".to_string());
         let mut enums = std::collections::HashMap::new();
 
-        harden_duplicate_leaf_metadata(&mut reg, &mut origins, &mut enums);
+        harden_duplicate_leaf_metadata(&mut reg, &mut origins, &mut enums, None);
 
         assert_eq!(reg.fields.get("Point"), Some(&shape));
         assert_eq!(origins.get("Point").map(String::as_str), Some("eval"));
+    }
+
+    #[test]
+    fn harden_deduplicates_full_and_canonical_aliases_by_struct_identity() {
+        let mut reg = crate::front::semantic::StructFieldRegistry::default();
+        let shape = rows(&[("ob_header", "PyObject"), ("value", "*mut Wtf8Buf")]);
+        let full = "pyre_object::unicodeobject::W_UnicodeObject";
+        let canonical = "unicodeobject::W_UnicodeObject";
+        reg.fields.insert(full.to_string(), shape.clone());
+        reg.fields.insert(canonical.to_string(), shape.clone());
+        reg.fields
+            .insert("W_UnicodeObject".to_string(), shape.clone());
+        let mut origins = std::collections::HashMap::new();
+        origins.insert("W_UnicodeObject".to_string(), "unicodeobject".to_string());
+        let mut enums = std::collections::HashMap::new();
+        let sid = majit_ir::descr::StructId::from_canonical(canonical);
+        let ids = std::collections::HashMap::from([
+            (full.to_string(), Some(sid)),
+            (canonical.to_string(), Some(sid)),
+            ("W_UnicodeObject".to_string(), Some(sid)),
+        ]);
+
+        harden_duplicate_leaf_metadata(&mut reg, &mut origins, &mut enums, Some(&ids));
+
+        assert_eq!(reg.fields.get("W_UnicodeObject"), Some(&shape));
+        assert_eq!(
+            origins.get("W_UnicodeObject").map(String::as_str),
+            Some("unicodeobject"),
+            "two spellings of one StructId must not tombstone its origin"
+        );
     }
 
     #[test]
@@ -28626,7 +28959,7 @@ mod tests {
         reg.fields.insert("StepResult".to_string(), disc.clone());
         reg.fields.insert("Verdict".to_string(), disc.clone());
 
-        harden_duplicate_leaf_metadata(&mut reg, &mut origins, &mut enums);
+        harden_duplicate_leaf_metadata(&mut reg, &mut origins, &mut enums, None);
 
         assert!(
             !enums.contains_key("StepResult"),
@@ -28665,7 +28998,7 @@ mod tests {
         origins.insert("W_IntObject".to_string(), "intobject".to_string());
         let mut enums = std::collections::HashMap::new();
 
-        harden_duplicate_leaf_metadata(&mut reg, &mut origins, &mut enums);
+        harden_duplicate_leaf_metadata(&mut reg, &mut origins, &mut enums, None);
 
         assert_eq!(reg.fields.get("W_IntObject"), Some(&shape));
         assert_eq!(
@@ -28703,7 +29036,7 @@ mod tests {
         let mut origins = std::collections::HashMap::new();
         let mut enums = std::collections::HashMap::new();
 
-        harden_duplicate_leaf_metadata(&mut reg, &mut origins, &mut enums);
+        harden_duplicate_leaf_metadata(&mut reg, &mut origins, &mut enums, None);
 
         assert!(
             !reg.fields.contains_key("Outcome::Ok"),
@@ -31280,6 +31613,128 @@ mod tests {
             calls_path(&["__getslice_minusone"]),
             1,
             "the marker strip must use the len-minus-one slice helper"
+        );
+    }
+
+    /// PyPy's rStringIO and buffered I/O implementations use ordinary
+    /// `buffer[start:end]` list slices. The Rust port spells those as a
+    /// `SliceIndex<Range<usize>>` call, which must recover RPython's direct
+    /// `getslice` operation without adding a non-upstream dominator proof.
+    #[test]
+    #[ignore]
+    fn pypy_buffer_ranges_lower_to_getslice() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        for fname in ["read_bytes", "parse_length_prefixed_protocols"] {
+            let graph = super::lower_function(&llbc, fname)
+                .unwrap_or_else(|err| panic!("lower {fname}: {err}"));
+            assert!(
+                !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                    matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if super::fmt_path_ends_with(segments, &["core", "slice", "index", "<Impl>", "index"]))
+                }),
+                "{fname}: PyPy list slice must not remain an opaque Rust index"
+            );
+            assert!(
+                graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                    matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if segments == &["__getslice_range".to_string()])
+                }),
+                "{fname}: Range slice must use the RPython getslice marker"
+            );
+        }
+    }
+
+    /// `forwarded_exporter` uses
+    /// `W_PickleBuffer::from_obj(obj).map(|pb| -> Result<_, PyError> { ... })`.
+    /// The closure graph follows the uniform Result exception ABI, while
+    /// `Option::map` must retain that Result as data inside `Some`; anchor the
+    /// late synthesized call to the ordinary catch-and-rewrap caller rule.
+    #[test]
+    #[ignore]
+    fn forwarded_exporter_map_rewraps_scoped_result() {
+        use crate::model::{CallTarget, ExitSwitch, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph =
+            super::lower_function(&llbc, "forwarded_exporter").expect("lower forwarded_exporter");
+
+        let call_block = graph
+            .blocks
+            .iter()
+            .find(|block| {
+                block.operations.iter().any(|op| {
+                    matches!(
+                        &op.kind,
+                        OpKind::Call {
+                            target: CallTarget::Method { name, .. },
+                            ..
+                        } if name == "call_once"
+                    )
+                })
+            })
+            .expect("Option::map closure call_once block");
+        assert!(
+            matches!(call_block.exitswitch, Some(ExitSwitch::LastException)),
+            "the Result-returning closure call must expose normal/exception successors"
+        );
+        for variant in ["Ok", "Err"] {
+            assert_eq!(
+                graph
+                    .blocks
+                    .iter()
+                    .flat_map(|block| &block.operations)
+                    .filter(|op| matches!(
+                        &op.kind,
+                        OpKind::Call {
+                            target: CallTarget::SyntheticTransparentCtor { name, .. },
+                            ..
+                        } if name == variant
+                    ))
+                    .count(),
+                1,
+                "the caller must rebuild one Result::{variant} shell"
+            );
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn check_len_result_uint_format_template_collapses() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph =
+            super::lower_function(&llbc, "_check_len_result").expect("lower _check_len_result");
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if super::fmt_path_ends_with(segments, &["Argument", "new_display"])
+                        || super::is_arguments_new_path(segments)
+                        || super::fmt_path_ends_with(segments, &["fmt", "format"])
+                )
+            }),
+            "the unsigned `[u8; N]` template must collapse to native RPython string operations"
+        );
+        assert!(
+            graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::BinOp { op, result_ty: ValueType::Ref(None), .. }
+                    if op == "add")
+            }),
+            "the formatted overflow message must retain the native string-concat expansion"
         );
     }
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2293,6 +2293,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             || !lo.next_call_results.is_empty()
             || !lo.checked_arith_call_results.is_empty()
             || !lo.option_try_sites.is_empty()
+            || !lo.slice_index_rangefrom_sites.is_empty()
             || !lo.slice_index_range_sites.is_empty()
             || !lo.slice_index_rangeto_sites.is_empty()
         {
@@ -2307,6 +2308,12 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             simplify_lowered_graph(&mut lo.graph, struct_field_attrs, false);
         }
         let mut tail_forwarded_returns = 0usize;
+        if !lo.slice_index_rangefrom_sites.is_empty() {
+            crate::front::slice_index::rewire_slice_index_rangefrom_sites(
+                &mut lo.graph,
+                &lo.slice_index_rangefrom_sites,
+            );
+        }
         if !lo.slice_index_range_sites.is_empty() {
             crate::front::slice_index::rewire_slice_index_range_sites(
                 &mut lo.graph,
@@ -3240,6 +3247,11 @@ struct Lowering<'a> {
     /// `front::range_iter` post-pass synthesizes so the `next`-diamond folds
     /// the loop (see [`crate::front::range_iter::RangeNewSite`]).
     range_iter_new_sites: Vec<crate::front::range_iter::RangeNewSite>,
+    /// RangeFrom aggregates retained for the orthodox
+    /// `getslice(start, None)` rewrite. The slice-index consumer proves the
+    /// bound is a `usize`, hence non-negative as required by RPython's
+    /// `decompose_slice_args`.
+    slice_index_rangefrom_sites: Vec<crate::front::slice_index::SliceIndexRangeFromSite>,
     /// RangeTo aggregates retained as candidates for the slice-index
     /// recognizer. The end's unsigned coloring is captured from MIR here,
     /// before the operand can become a block inputarg.
@@ -3486,6 +3498,7 @@ impl<'a> Lowering<'a> {
             saturating_sub_sites: Vec::new(),
             range_inclusive_new_sites: Vec::new(),
             range_iter_new_sites: Vec::new(),
+            slice_index_rangefrom_sites: Vec::new(),
             slice_index_rangeto_sites: Vec::new(),
             slice_index_range_sites: Vec::new(),
             range_contains_sites: Vec::new(),
@@ -4512,7 +4525,7 @@ impl<'a> Lowering<'a> {
         mir_bb: usize,
         inner: Place,
         elem: ProjectionElem,
-        value: LinkArg,
+        mut value: LinkArg,
         dest_ty: &TyRef,
     ) -> Result<(), LowerError> {
         // A plain `*p = v` (`__deref_write` Call below) reads a
@@ -4609,12 +4622,28 @@ impl<'a> Lowering<'a> {
                     // fallback keeps non-Adt containers lowering as
                     // before.
                     let (field, ty) = match self.resolve_adt_field(field_payload) {
-                        Some((owner_root, field_name, _field_ty, owner_id)) => (
-                            FieldDescriptor::new(field_name, Some(owner_root))
-                                .with_owner_id(owner_id)
-                                .with_base_is_deref(base_is_deref),
-                            tyref_to_value_type(dest_ty, self.llbc),
-                        ),
+                        Some((owner_root, field_name, _field_ty, owner_id)) => {
+                            // Rust type-checks every assignment against the
+                            // projected place's substituted field type.  A
+                            // raw pointer to a named ADT is therefore the
+                            // same typed nullable instance slot as a field
+                            // initialized by an aggregate: preserve that
+                            // class on ordinary `self.field = value` writes
+                            // too.  Otherwise one classdef-less raw value
+                            // generalizes the session-global ClassDef attr to
+                            // the root object repr before a later getattr is
+                            // rtyped.  RPython's SomeNone union instead keeps
+                            // the declared SomeInstance class and merely sets
+                            // `can_be_None`.
+                            value =
+                                self.narrow_typed_nullable_field_value(bb_id, value, Some(dest_ty));
+                            (
+                                FieldDescriptor::new(field_name, Some(owner_root))
+                                    .with_owner_id(owner_id)
+                                    .with_base_is_deref(base_is_deref),
+                                tyref_to_value_type(dest_ty, self.llbc),
+                            )
+                        }
                         None => (
                             FieldDescriptor::new(field_label_from_payload(field_payload), None),
                             ValueType::Int,
@@ -4653,6 +4682,48 @@ impl<'a> Lowering<'a> {
             kind: op,
         });
         Ok(())
+    }
+
+    /// Preserve the declared class of a raw-pointer field value.
+    ///
+    /// RPython represents a nullable instance attribute as
+    /// `SomeInstance(classdef, can_be_None=True)`.  Rust spells the same slot
+    /// as `*mut/*const NamedAdt`, but a producer such as `null_mut()` begins as
+    /// a classdef-less pointer.  The Rust field type-check is the proof needed
+    /// to narrow that producer before `setattr`; this is an identity cast for
+    /// non-null values and a typed null for null values.
+    fn narrow_typed_nullable_field_value(
+        &mut self,
+        bb_id: BlockId,
+        value: LinkArg,
+        declared_ty: Option<&TyRef>,
+    ) -> LinkArg {
+        let Some(root) = declared_ty.and_then(|ty| {
+            tyref_node(ty, self.llbc)
+                .and_then(|n| strip_ty_wrappers(n, self.llbc))
+                .and_then(|n| raw_ptr_pointee_class_root(n, self.llbc))
+        }) else {
+            return value;
+        };
+        let LinkArg::Value(value) = value else {
+            // Ref-kind constants are materialized calls in this frontend;
+            // only scalar constants can remain inline in a FieldWrite.
+            return value;
+        };
+        let narrowed = self
+            .graph
+            .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+        self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+            result: Some(narrowed.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec!["__pyre_cast_instance".to_string(), root.clone()],
+                },
+                args: vec![value],
+                result_ty: ValueType::Ref(Some(root)),
+            },
+        });
+        LinkArg::Value(narrowed)
     }
 
     /// Extract the `offset` operand from an `Index { offset, from_end }`
@@ -5213,7 +5284,7 @@ impl<'a> Lowering<'a> {
                                 tyref_positional_aggregate_suffix(dest_ty, self.llbc)
                             );
                             let positional = (0..arg_vars.len())
-                                .map(|i| (format!("__pos_{i}"), String::new()))
+                                .map(|i| (format!("__pos_{i}"), String::new(), None))
                                 .collect();
                             // Not an Adt at all, so there is no struct decl to
                             // stand behind an allocation rewrite.
@@ -5300,8 +5371,17 @@ impl<'a> Lowering<'a> {
                         },
                     );
                 }
-                // RangeFrom alone stays dormant: its Void ConstNone stop has
-                // no regalloc coloring on the legacy-walker path.
+                if owner_path.as_slice() == ["core", "ops", "range"]
+                    && ctor_name == "RangeFrom"
+                    && arg_vars.len() == 1
+                {
+                    self.slice_index_rangefrom_sites.push(
+                        crate::front::slice_index::SliceIndexRangeFromSite {
+                            range_result: res.clone(),
+                            start: arg_vars[0].clone(),
+                        },
+                    );
+                }
                 // Surface every operand through a separate FieldWrite so
                 // the field-to-value binding survives into the
                 // codewriter / annotator.  Field names default to
@@ -5311,8 +5391,9 @@ impl<'a> Lowering<'a> {
                 for (i, value) in arg_vars.into_iter().enumerate() {
                     let (name, field_ty) = field_rows
                         .get(i)
-                        .cloned()
+                        .map(|(name, field_ty, _)| (name.clone(), field_ty.clone()))
                         .unwrap_or_else(|| (format!("__pos_{i}"), String::new()));
+                    let declared_ty = field_rows.get(i).and_then(|(_, _, ty)| ty.as_ref());
                     // `_names_without_voids()` / `heaptracker.py:104-105`: a
                     // zero-sized field occupies no storage and gets no slot,
                     // so no write is generated for it.
@@ -5321,6 +5402,15 @@ impl<'a> Lowering<'a> {
                     {
                         continue;
                     }
+                    let value = self
+                        .narrow_typed_nullable_field_value(
+                            bb_id,
+                            LinkArg::Value(value),
+                            declared_ty,
+                        )
+                        .as_variable()
+                        .expect("aggregate field operand stays materialized")
+                        .clone();
                     self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                         result: None,
                         kind: OpKind::FieldWrite {
@@ -6501,7 +6591,7 @@ impl<'a> Lowering<'a> {
     ) -> Option<(
         Vec<String>,
         String,
-        Vec<(String, String)>,
+        Vec<(String, String, Option<TyRef>)>,
         majit_ir::descr::StructId,
         bool,
     )> {
@@ -6530,13 +6620,14 @@ impl<'a> Lowering<'a> {
         let owner_path = segments;
         match (&td.kind, variant_idx) {
             (TypeDeclKind::Struct(fields), None) | (TypeDeclKind::Struct(fields), Some(_)) => {
-                let field_rows: Vec<(String, String)> = fields
+                let field_rows: Vec<(String, String, Option<TyRef>)> = fields
                     .iter()
                     .enumerate()
                     .map(|(i, f)| {
                         (
                             f.name.clone().unwrap_or_else(|| format!("__pos_{i}")),
                             tyref_to_ast_string(&f.ty, self.llbc),
+                            Some(clone_tyref(&f.ty)),
                         )
                     })
                     .collect();
@@ -6568,7 +6659,7 @@ impl<'a> Lowering<'a> {
                     None => type_leaf,
                 };
                 variant_owner.push(leaf);
-                let field_rows: Vec<(String, String)> = v
+                let field_rows: Vec<(String, String, Option<TyRef>)> = v
                     .fields
                     .iter()
                     .enumerate()
@@ -6576,6 +6667,7 @@ impl<'a> Lowering<'a> {
                         (
                             f.name.clone().unwrap_or_else(|| format!("__pos_{i}")),
                             tyref_to_ast_string(&f.ty, self.llbc),
+                            Some(clone_tyref(&f.ty)),
                         )
                     })
                     .collect();
@@ -28977,6 +29069,186 @@ mod tests {
             }),
             "From<bool> for usize should use RPython's cast_bool_to_uint path"
         );
+    }
+
+    /// `basename_start` indexes `path[drive..]` with a runtime `usize`
+    /// RangeFrom. RPython represents this as `getslice(start, None)`, so the
+    /// core SliceIndex shim must be gone before annotation.
+    #[test]
+    #[ignore]
+    fn basename_start_rangefrom_lowers_to_getslice_marker() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "basename_start").expect("lower basename_start");
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments == &[
+                        "core".to_string(),
+                        "slice".to_string(),
+                        "index".to_string(),
+                        "<Impl>".to_string(),
+                        "index".to_string(),
+                    ])
+            }),
+            "RangeFrom SliceIndex call must not survive as an opaque core call"
+        );
+        assert!(
+            graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments == &["__getslice_rangefrom".to_string()])
+            }),
+            "runtime RangeFrom should use the post-annotation getslice marker"
+        );
+    }
+
+    /// The exception carrier's cached object is PyPy's `W_Root` field. Its
+    /// registry spelling must retain `PyObjectRef`; erasing it to a generic
+    /// reference makes `InstanceRepr._setup_repr` choose the root object
+    /// pointer while field reads expect the concrete PyObject repr.
+    #[test]
+    #[ignore]
+    fn pyerror_exc_object_registry_retains_pyobjectref() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let (_, _, fields, _, _, _, _, _) = super::derive_program_metadata(&llbc);
+        let (owner, ty) = fields
+            .fields
+            .iter()
+            .filter(|(owner, _)| owner.ends_with("PyError"))
+            .find_map(|(owner, rows)| {
+                rows.iter()
+                    .find(|(name, _)| name == "exc_object")
+                    .map(|(_, ty)| (owner.as_str(), ty.as_str()))
+            })
+            .map(|(owner, ty)| (owner.to_string(), ty.to_string()))
+            .expect("PyError.exc_object registry row");
+        assert!(
+            ty == "PyObjectRef"
+                || ty.ends_with("::PyObjectRef")
+                || ty.ends_with("pyobject::PyObject")
+                || ty == "*mut PyObject",
+            "{owner}.exc_object must retain its concrete object-pointer spelling, got {ty}"
+        );
+        let bk = std::rc::Rc::new(crate::annotator::bookkeeper::Bookkeeper::new());
+        bk.set_pyre_struct_fields(std::rc::Rc::new(fields));
+        let crate::annotator::model::SomeValue::Instance(projected) =
+            bk.project_pyre_field_type(&ty)
+        else {
+            panic!("{owner}.exc_object field must project to an instance annotation")
+        };
+        assert!(
+            projected.classdef.is_some(),
+            "{owner}.exc_object field must project to the concrete PyObject class"
+        );
+    }
+
+    /// `PyError::new` initializes three `PyObjectRef` fields with
+    /// `null_mut()`. These are typed nullable W_Root slots, not erased root
+    /// references; each aggregate write must consume a PyObject-narrowed
+    /// value so `InstanceRepr._setup_repr` and later reads agree.
+    #[test]
+    #[ignore]
+    fn pyerror_new_narrows_null_object_fields() {
+        use crate::model::{CallTarget, LinkArg, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "pyre_interpreter::error::<Impl>::new")
+            .expect("lower PyError::new");
+        for field_name in ["exc_object", "w_name_context", "w_obj_context"] {
+            let value = graph
+                .blocks
+                .iter()
+                .flat_map(|b| &b.operations)
+                .find_map(|op| match &op.kind {
+                    OpKind::FieldWrite { field, value, .. } if field.name == field_name => {
+                        match value {
+                            LinkArg::Value(value) => Some(value.clone()),
+                            LinkArg::Const(_) => None,
+                        }
+                    }
+                    _ => None,
+                })
+                .unwrap_or_else(|| panic!("PyError::{field_name} aggregate write"));
+            assert!(
+                graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                    op.result.as_ref() == Some(&value)
+                        && matches!(
+                            &op.kind,
+                            OpKind::Call {
+                                target: CallTarget::FunctionPath { segments },
+                                ..
+                            } if segments == &["__pyre_cast_instance", "PyObject"]
+                        )
+                }),
+                "PyError::{field_name} null must retain the declared PyObject class"
+            );
+        }
+    }
+
+    /// The same declared-slot rule applies after construction.  PyPy's
+    /// `OperationError` object attributes never lose their W_Root class when
+    /// assigned in a method, so an ordinary MIR projection write must carry
+    /// the same narrowing as a struct-literal initializer.
+    #[test]
+    #[ignore]
+    fn pyerror_projection_writes_retain_pyobject_class() {
+        use crate::model::{CallTarget, LinkArg, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(
+            &llbc,
+            "pyre_interpreter::error::<Impl>::enrich_attribute_error",
+        )
+        .expect("lower PyError::enrich_attribute_error");
+        let mut writes = 0;
+        for op in graph.blocks.iter().flat_map(|b| &b.operations) {
+            let OpKind::FieldWrite { field, value, .. } = &op.kind else {
+                continue;
+            };
+            if !matches!(field.name.as_str(), "w_name_context" | "w_obj_context") {
+                continue;
+            }
+            writes += 1;
+            let LinkArg::Value(value) = value else {
+                panic!(
+                    "PyError::{} write must use a materialized object value",
+                    field.name
+                )
+            };
+            assert!(
+                graph
+                    .blocks
+                    .iter()
+                    .flat_map(|b| &b.operations)
+                    .any(|producer| {
+                        producer.result.as_ref() == Some(value)
+                            && matches!(
+                                &producer.kind,
+                                OpKind::Call {
+                                    target: CallTarget::FunctionPath { segments },
+                                    ..
+                                } if segments == &["__pyre_cast_instance", "PyObject"]
+                            )
+                    }),
+                "PyError::{} projection write must retain the declared PyObject class",
+                field.name
+            );
+        }
+        assert!(writes >= 2, "expected both PyError context-field writes");
     }
 
     /// `split_builtin_kwargs` returns `&args[..args.len() - 1]` after proving

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -10402,9 +10402,6 @@ impl<'a> Lowering<'a> {
         // assignment nor descending into the classdef-less `_digits` field is
         // correct. Retarget the exact receiver/result pair to the GC-aware
         // shallow-clone residual.
-        let inside_dont_look_inside = self
-            .dont_look_inside
-            .contains(&strip_crate_prefix(&self.graph.name));
         let op_kind = if let OpKind::Call { target, args, .. } = &op_kind
             && args.len() == 1
             && first_arg_ty
@@ -10803,17 +10800,11 @@ impl<'a> Lowering<'a> {
                 .as_ref()
                 .is_some_and(|ty| tyref_is_rbigint(ty, self.llbc))
             && let Some((segments, scalar_result)) = match target {
-                CallTarget::FunctionPath { segments } => segments.last().and_then(|leaf| {
-                    crate::front::rbigint_call::scalar_residual_for_method(
-                        leaf,
-                        inside_dont_look_inside,
-                    )
-                }),
+                CallTarget::FunctionPath { segments } => segments
+                    .last()
+                    .and_then(|leaf| crate::front::rbigint_call::scalar_residual_for_method(leaf)),
                 CallTarget::Method { name, .. } => {
-                    crate::front::rbigint_call::scalar_residual_for_method(
-                        name,
-                        inside_dont_look_inside,
-                    )
+                    crate::front::rbigint_call::scalar_residual_for_method(name)
                 }
                 _ => None,
             } {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5594,8 +5594,6 @@ impl<'a> Lowering<'a> {
                     self.range_iter_new_sites
                         .push(crate::front::range_iter::RangeNewSite {
                             result_var: res.clone(),
-                            start: arg_vars[0].clone(),
-                            end: arg_vars[1].clone(),
                         });
                     self.slice_index_range_sites.push(
                         crate::front::slice_index::SliceIndexRangeSite {
@@ -33843,6 +33841,67 @@ mod tests {
                     if op == "or")
             ),
             "slice hash must contain PyPy's unsigned shift/or rotate expansion"
+        );
+    }
+
+    /// `w_method_new` pins three roots with `for slot in save_point..save_point
+    /// + 3`.  RPython represents that loop through `builtin_range` and
+    /// `RangeIteratorRepr`; the Rust `core::ops::range::Range<usize>` shell
+    /// must therefore be consumed by `front::range_iter`, not enter the
+    /// annotator as one shared foreign ClassDef whose `start` field can merge
+    /// with unrelated Range instantiations.  Loads the real object LLBC, so
+    /// ignored by default.
+    #[test]
+    #[ignore]
+    fn method_root_scan_uses_rpython_range_iterator() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real object LLBC");
+        let graph = super::lower_function(&llbc, "pyre_object::function::w_method_new")
+            .expect("lower w_method_new");
+        let operations: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .collect();
+
+        let range_shells: Vec<_> = operations
+            .iter()
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        result_ty: ValueType::Ref(Some(owner)),
+                        ..
+                    } if owner.ends_with("ops::range::Range")
+                )
+            })
+            .collect();
+        assert!(
+            range_shells.is_empty(),
+            "the Rust Range shell must be consumed before annotation: {range_shells:#?}"
+        );
+        assert!(
+            operations.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if segments == &[crate::runtime_names::shims::RANGE.to_string()]
+            )),
+            "w_method_new must route its root scan through RPython builtin_range"
+        );
+        assert!(
+            operations.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if segments == &["__iter_next".to_string()]
+            )),
+            "w_method_new must lower the range loop through the native next op"
         );
     }
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4710,6 +4710,20 @@ impl<'a> Lowering<'a> {
         }) else {
             return value;
         };
+        self.narrow_value_to_instance_root(bb_id, value, &root)
+    }
+
+    /// Re-express a GC-reference value at a statically-known RPython
+    /// instance boundary.  Rust raw pointers erase the pointee in
+    /// [`ValueType::Ref(None)`], while the corresponding RPython value keeps
+    /// its `SomeInstance(classdef)` (for example `PyObjectRef` is W_Root).
+    /// The marker is a same-bank identity and rtypes to `cast_opaque_ptr`.
+    fn narrow_value_to_instance_root(
+        &mut self,
+        bb_id: BlockId,
+        value: LinkArg,
+        root: &str,
+    ) -> LinkArg {
         let LinkArg::Value(value) = value else {
             // Ref-kind constants are materialized calls in this frontend;
             // only scalar constants can remain inline in a FieldWrite.
@@ -4722,10 +4736,10 @@ impl<'a> Lowering<'a> {
             result: Some(narrowed.clone()),
             kind: OpKind::Call {
                 target: CallTarget::FunctionPath {
-                    segments: vec!["__pyre_cast_instance".to_string(), root.clone()],
+                    segments: vec!["__pyre_cast_instance".to_string(), root.to_string()],
                 },
                 args: vec![value],
-                result_ty: ValueType::Ref(Some(root)),
+                result_ty: ValueType::Ref(Some(root.to_string())),
             },
         });
         LinkArg::Value(narrowed)
@@ -4877,6 +4891,15 @@ impl<'a> Lowering<'a> {
                     let src_root = self.operand_class_root(&operand);
                     let arg = self.resolve_operand(mir_bb, operand)?;
                     let dst_kind = tyref_to_value_type(dest_ty, self.llbc);
+                    // The Rust-only current-address adapter is erased as a
+                    // whole GCREF identity.  Its `ptr -> usize -> ptr`
+                    // round-trip exists only to call the host GC query; once
+                    // that query is replaced by RPython's root-reload model,
+                    // retaining either bank crossing would manufacture an
+                    // address integer absent from the upstream graph.
+                    if self.is_gc_current_object_address_adapter_graph() {
+                        return Ok((None, arg));
+                    }
                     // Signedness-flipping int cast (`w_tuple_len(obj) as i64`)
                     // — aliasing keeps the source `r_uint` annotation on the
                     // signed destination, tripping the SomeInteger signedness
@@ -8189,12 +8212,23 @@ impl<'a> Lowering<'a> {
                 // annotator.  The call returns `()`; its dead destination
                 // binds to a fresh Void var.
                 if args.len() == 3 && self.is_object_array_set_ref_call(&reg) {
+                    // `FixedObjectArray._items` is `[PyObjectRef; 0]`, the
+                    // Rust storage spelling of PyPy's fixed `[W_Root]` list.
+                    // Preserve that external item annotation before the
+                    // setitem generalizes its ListDef.  The internal list
+                    // repr remains GCREF and rlist's recast lowers this marker
+                    // to the same `cast_opaque_ptr` PyPy emits.
+                    let value = self.narrow_value_to_instance_root(
+                        bb_id,
+                        LinkArg::Value(args[2].clone()),
+                        "PyObject",
+                    );
                     self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                         result: None,
                         kind: OpKind::ArrayWrite {
                             base: args[0].clone(),
                             index: args[1].clone(),
-                            value: LinkArg::Value(args[2].clone()),
+                            value,
                             item_ty: ValueType::Ref(None),
                             array_type_id: Some(OBJECT_REF_GCARRAY_TYPE_ID.to_string()),
                             nolength: false,
@@ -8500,6 +8534,24 @@ impl<'a> Lowering<'a> {
                     } else {
                         self.local_var[dest_local] = Some(args[0].clone());
                     }
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
+                // `try_gc_current_object_address(p)` is a Rust-interpreter
+                // adapter for the root reload RPython inserts after a
+                // collecting call (`gc_pop_roots` -> `gc_restore_root`,
+                // `memory/gctransform/shadowcolor.py`).  The translated JIT
+                // graph already carries `p` as a GC reference whose backend
+                // root map is rewritten when an object moves, so tracing the
+                // forwarding-stub query would duplicate the GC transform and
+                // expose a Rust-only `majit_gc` helper that has no PyPy graph
+                // counterpart.  Erase only the adapter's own one-call body;
+                // integer/raw-address uses elsewhere must keep their runtime
+                // normalization.
+                if args.len() == 1 && self.is_gc_current_object_address_adapter(&reg) {
+                    self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
                     self.graph.set_goto(bb_id, target_bb, link_args);
@@ -11427,6 +11479,29 @@ impl<'a> Lowering<'a> {
                 }
                 _ => None,
             })
+    }
+
+    /// Whether this is the sole Rust-only forwarding query inside
+    /// `pyre_object::gc_hook::try_gc_current_object_address`.
+    ///
+    /// RPython never emits such a source-level helper: its GC transformer
+    /// reloads every live GC variable from the shadow stack after a safepoint.
+    /// Keep the match graph-scoped so runtime consumers that deliberately
+    /// normalize a stored raw address are not rewritten as identities.
+    fn is_gc_current_object_address_adapter(&self, reg: &RegularCall) -> bool {
+        if !self.is_gc_current_object_address_adapter_graph() {
+            return false;
+        }
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc
+            .fn_by_id(*id)
+            .is_some_and(|fd| fd.item_meta.name_path() == "majit_gc::gc_current_object_address")
+    }
+
+    fn is_gc_current_object_address_adapter_graph(&self) -> bool {
+        self.graph.name == "pyre_object::gc_hook::try_gc_current_object_address"
     }
 
     /// `*items_block_items_base(block).add(idx)` — a list / tuple
@@ -28650,6 +28725,34 @@ mod tests {
             array_writes >= 1,
             "set_locals_w: expected at least one native ArrayWrite (setarrayitem_gc)"
         );
+        let typed_store = graph.blocks.iter().any(|block| {
+            block.operations.windows(2).any(|ops| {
+                let Some(cast_result) = ops[0].result.as_ref() else {
+                    return false;
+                };
+                matches!(
+                    &ops[0].kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments == &[
+                        "__pyre_cast_instance".to_string(),
+                        "PyObject".to_string(),
+                    ]
+                ) && matches!(
+                    &ops[1].kind,
+                    OpKind::ArrayWrite {
+                        value: crate::model::LinkArg::Value(value),
+                        array_type_id: Some(array_type_id),
+                        ..
+                    } if value == cast_result && array_type_id == super::PYOBJECT_GCARRAY_TYPE_ID
+                )
+            })
+        });
+        assert!(
+            typed_store,
+            "set_locals_w: PyObjectRef store must preserve the W_Root external item repr"
+        );
     }
 
     /// PyPy's frame stack clears store `None` into a `W_Root` list.  The Rust
@@ -29379,6 +29482,59 @@ mod tests {
             dead_storage_reads, 0,
             "the owner alias must let the ordinary dead-op pass remove the \
              interior chars/length shell; graph: {graph:#?}"
+        );
+    }
+
+    /// The Rust interpreter reloads a possibly-moved pointer explicitly;
+    /// RPython's translated graph instead gets the updated GCREF from
+    /// `gc_restore_root`.  The source adapter must therefore lower to an
+    /// identity graph and must not leak the `majit_gc` query into annotation.
+    /// Loads the real pyre-object LLBC, so ignored by default.
+    #[test]
+    #[ignore]
+    fn gc_current_object_address_adapter_folds_to_identity() {
+        use crate::model::{CallTarget, LinkArg, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load pyre-object LLBC");
+        let graph = super::lower_function(&llbc, "try_gc_current_object_address")
+            .expect("lower try_gc_current_object_address");
+        let residual = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if segments.last().map(String::as_str)
+                            == Some("gc_current_object_address")
+                )
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            residual.is_empty(),
+            "the RPython-shaped graph reloads its GCREF from the root map; \
+             residual forwarding queries: {residual:#?}; graph: {graph:#?}"
+        );
+
+        let input = graph
+            .block(graph.startblock)
+            .inputargs
+            .first()
+            .expect("adapter input");
+        let returned = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.exits.iter())
+            .find(|link| link.target == graph.returnblock)
+            .and_then(|link| link.args.first())
+            .expect("adapter return link");
+        assert!(
+            matches!(returned, LinkArg::Value(value) if value == input),
+            "the adapter must return its input GCREF unchanged; graph: {graph:#?}"
         );
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2518,10 +2518,14 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             // the suffixed producers reaching the returnblock (ref/str/float
             // payloads); the `Int`/`Unsigned`/niche carve-out stays bare.
             let return_owner = lo.resolve_option_return_owner(&fd.signature.output);
+            let return_niche = lo.tyref_is_niche_option_ptr(&fd.signature.output);
+            let return_narrow_root = lo.option_niche_payload_class_root(&fd.signature.output);
             crate::front::option_try::rewire_option_try_call_sites(
                 &mut lo.graph,
                 &lo.option_try_sites,
                 return_owner.as_deref(),
+                return_niche,
+                return_narrow_root.as_deref(),
             )
         };
         // The `bool::then` short-circuit rewrite (`front::bool_then`) splits
@@ -30700,6 +30704,82 @@ mod tests {
         assert!(
             niche_try_switches >= 1,
             "lookup: expected a niche `?` `ne` null-test switch block"
+        );
+
+        // The `?` break arm returns the enclosing `Option<PyObjectRef>`'s
+        // `None`.  That type is a nullable PyObject pointer, not a constructed
+        // Rust `Option::None` instance.  Pin both halves of the representation:
+        // no Option None ctor survives, and a null pointer narrowed to
+        // PyObject is forwarded to the return block.
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::SyntheticTransparentCtor {
+                            name,
+                            owner_path,
+                            ..
+                        },
+                        ..
+                    } if name == "None" && owner_path.iter().any(|part| part == "Option")
+                )
+            }),
+            "lookup: niche `?` break arm must not construct Option::None"
+        );
+        let null_results: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if segments
+                    == &[
+                        "core".to_string(),
+                        "ptr".to_string(),
+                        "null_mut".to_string(),
+                    ] =>
+                {
+                    op.result.clone()
+                }
+                _ => None,
+            })
+            .collect();
+        let narrowed_nulls: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    args,
+                    ..
+                } if segments
+                    == &[
+                        crate::runtime_names::shims::CAST_INSTANCE.to_string(),
+                        "PyObject".to_string(),
+                    ]
+                    && args.len() == 1
+                    && null_results.contains(&args[0]) =>
+                {
+                    op.result.clone()
+                }
+                _ => None,
+            })
+            .collect();
+        assert!(
+            graph
+                .blocks
+                .iter()
+                .any(|block| block.exits.iter().any(|link| {
+                    link.target == graph.returnblock
+                        && link.args.iter().any(
+                            |arg| matches!(arg, LinkArg::Value(v) if narrowed_nulls.contains(v)),
+                        )
+                })),
+            "lookup: niche `?` break arm must return a PyObject-narrowed null"
         );
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2212,7 +2212,8 @@ pub(crate) fn lower_fun_decl_with_static_addrs_and_attrs(
 }
 
 /// The MIR locals that can be a fresh string-builder accumulator: the
-/// destination of a `Wtf8Buf` / `String` `new` / `with_capacity` CALL
+/// destination of a `Wtf8Buf` / `String` `new` / `with_capacity` /
+/// `from_string` CALL
 /// terminator in the accumulator range `(arg_count+1..n_locals)`.
 ///
 /// [`is_fresh_str_builder`] sets its `ctor_def` flag only in the
@@ -2232,7 +2233,7 @@ fn builder_ctor_dest_locals<'a>(
             && (arg_count + 1..n_locals).contains(&(i as usize))
             && matches!(
                 wtf8buf_method_leaf(llbc, &call),
-                Some("new") | Some("with_capacity")
+                Some("new") | Some("with_capacity") | Some("from_string")
             )
         {
             Some(i as usize)
@@ -2652,6 +2653,10 @@ fn lower_unstructured_with_static_addrs_and_attrs(
         // the legacy walker and codewriter already handle, so it runs
         // unconditionally.
         let mut fmt_collapsed = collapse_fmt_chains(&mut lo.graph);
+        // The bytearray repr's sole non-default format is `\\x{c:02x}`.
+        // PyPy spells it as two nibble lookups in a constant hex table; lower
+        // the proven-u8 Rust fmt shell to that same source-level shape.
+        fmt_collapsed += collapse_lower_hex_byte_fmt_chains(&mut lo.graph);
         // Constant `format!("literal")` — a zero-placeholder format charon has
         // already folded to the fully-rendered constant string, so the format
         // op's argument is a bare `__str_const` with no pieces/args chain.
@@ -3104,7 +3109,7 @@ struct Lowering<'a> {
     binop_result_locals: std::collections::HashSet<usize>,
     /// Whether this function contains a builder-form accumulator. The canonical
     /// lowering sets it directly from [`graph_has_builder_accumulator`]; ctor /
-    /// append / terminal-`move` sites then emit the
+    /// append / terminal-materialisation sites then emit the
     /// `__majit_stringbuilder_{new,append,build}` markers (`flowspace_adapter` →
     /// `newstringbuilder` / `append` / `build`) instead of a parallel
     /// `ll_strconcat` graph. Whether a given local *is* such an
@@ -3513,7 +3518,7 @@ impl<'a> Lowering<'a> {
     }
 
     /// Switch this lowering to builder form so the ctor / append /
-    /// terminal-`move` sites of a builder-mode accumulator
+    /// terminal materialisation sites of a builder-mode accumulator
     /// ([`is_builder_mode_accumulator`]) emit the `StringBuilder` markers
     /// instead of `ll_strconcat`. The canonical frontend selects this before
     /// lowering whenever [`graph_has_builder_accumulator`] succeeds.
@@ -5600,8 +5605,9 @@ impl<'a> Lowering<'a> {
             Operand::Copy(place) => self.resolve_place(mir_bb, place),
             Operand::Move(place) => {
                 // A `move c` of a builder-mode accumulator is its single
-                // `ll_build` materialisation point (`accumulator_move_site_count
-                // == 1`).  Emit the `__majit_stringbuilder_build` marker
+                // `ll_build` materialisation point
+                // (`accumulator_materialization_site_count == 1`). Emit the
+                // `__majit_stringbuilder_build` marker
                 // (`flowspace_adapter` → getattr("build") + simple_call →
                 // `SomeString`) instead of moving the concat accumulator out.
                 // Only a bare `Local(c)` move qualifies; a projection falls
@@ -6977,7 +6983,8 @@ impl<'a> Lowering<'a> {
     }
 
     /// Fold a `NamedConst` global whose initializer builds a fixed-size
-    /// array of integer literals (`OP_STACKDEL: [i32; N] = [c0, c1, …]`)
+    /// array of integer literals (`OP_STACKDEL: [i32; N] = [c0, c1, …]`),
+    /// or borrows that literal (`HEX: &[u8; N] = b"..."`),
     /// into the synthetic prebuilt-constant-array define-op the adapter
     /// re-folds to `Constant(list)`
     /// (`flowspace_adapter.rs::is_const_int_array_define`).  A
@@ -6987,13 +6994,21 @@ impl<'a> Lowering<'a> {
     /// literals here lets that read resolve against a constant base
     /// instead of a residual accessor `Call` no registry can bind.
     ///
-    /// Accepts only the exact `_0 = [c0, c1, …]; return` shape: a single
-    /// `Array` aggregate assigned to `_0` whose operands are all integer
-    /// literals, over linear `Goto`s to a `Return`.  Anything richer
-    /// (computed elements, non-integer items, a `Repeat` fill, a second
-    /// `_0` write) returns `None` and keeps the residual accessor path;
-    /// so does a foreign const whose init body Charon left opaque (no
-    /// readable body to bake).
+    /// Accepts only the exact `_0 = [c0, c1, …]; return` shape, or the
+    /// borrow spelling Charon emits for a byte string:
+    ///
+    /// ```text
+    /// _array = [c0, c1, …]
+    /// _borrow = &_array
+    /// _0 = move _borrow
+    /// return
+    /// ```
+    ///
+    /// The array operands must all be integer literals and control flow may
+    /// contain only linear `Goto`s to a `Return`.  Anything richer (computed
+    /// elements, non-integer items, a `Repeat` fill, an extra assignment)
+    /// returns `None` and keeps the residual accessor path; so does a foreign
+    /// const whose init body Charon left opaque (no readable body to bake).
     fn fold_named_const_int_array_global(&self, def_id: u64) -> Option<OpKind> {
         let gd = self.llbc.global_by_id(def_id)?;
         if gd
@@ -7006,20 +7021,23 @@ impl<'a> Lowering<'a> {
         }
         let init_id = gd.rest.get("init")?.as_u64()?;
         let body = self.llbc.fn_by_id(init_id)?.unstructured()?;
-        let mut items: Option<Vec<i64>> = None;
+        let mut array: Option<(u64, Vec<i64>)> = None;
+        let mut borrow: Option<(u64, u64)> = None;
+        let mut return_alias: Option<u64> = None;
         for block in &body.body {
             for stmt in &block.statements {
                 match stmt.stmt_kind() {
                     Ok(StmtKind::StorageLive(_))
                     | Ok(StmtKind::StorageDead(_))
                     | Ok(StmtKind::PlaceMention(_)) => {}
-                    Ok(StmtKind::Assign(place, Rvalue::Aggregate(kind, operands)))
-                        if matches!(place.kind, PlaceKind::Local(0)) =>
-                    {
+                    Ok(StmtKind::Assign(place, Rvalue::Aggregate(kind, operands))) => {
                         // Only a fixed-size `Array` aggregate of integer
                         // literals; a `Repeat` fill or an Adt aggregate is
-                        // out of scope, as is a second `_0`-defining assign.
-                        if aggregate_ctor_name(&kind) != "Array" || items.is_some() {
+                        // out of scope, as is a second array definition.
+                        let PlaceKind::Local(dst) = place.kind else {
+                            return None;
+                        };
+                        if aggregate_ctor_name(&kind) != "Array" || array.is_some() {
                             return None;
                         }
                         let mut vals = Vec::with_capacity(operands.len());
@@ -7033,11 +7051,34 @@ impl<'a> Lowering<'a> {
                             };
                             vals.push(n);
                         }
-                        items = Some(vals);
+                        array = Some((dst, vals));
                     }
-                    // Any other statement (a write to a temporary or a
-                    // richer `_0` definition) means the array is computed,
-                    // not a literal aggregate.
+                    Ok(StmtKind::Assign(place, Rvalue::Ref { place: source, .. })) => {
+                        let (PlaceKind::Local(dst), PlaceKind::Local(source)) =
+                            (place.kind, source.kind)
+                        else {
+                            return None;
+                        };
+                        if borrow.replace((dst, source)).is_some() {
+                            return None;
+                        }
+                    }
+                    Ok(StmtKind::Assign(place, Rvalue::Use(operand)))
+                        if matches!(place.kind, PlaceKind::Local(0)) =>
+                    {
+                        let source = match operand {
+                            Operand::Copy(place) | Operand::Move(place) => match place.kind {
+                                PlaceKind::Local(source) => source,
+                                _ => return None,
+                            },
+                            Operand::Const(_) => return None,
+                        };
+                        if return_alias.replace(source).is_some() {
+                            return None;
+                        }
+                    }
+                    // Any other statement means the array is computed, or
+                    // the borrow escapes through a shape we cannot prove.
                     _ => return None,
                 }
             }
@@ -7046,7 +7087,15 @@ impl<'a> Lowering<'a> {
                 _ => return None,
             }
         }
-        let items = items?;
+        let (array_local, items) = array?;
+        match (borrow, return_alias) {
+            // Direct fixed-size array constant: `_0 = [..]`.
+            (None, None) if array_local == 0 => {}
+            // Borrowed byte-string constant: `_borrow = &_array; _0 = _borrow`.
+            (Some((borrow_local, borrowed_local)), Some(returned_local))
+                if borrowed_local == array_local && returned_local == borrow_local => {}
+            _ => return None,
+        }
         // The annotator infers the list's element type from the baked
         // literals, so an empty array carries no element type; leave it
         // to the residual path.
@@ -8261,7 +8310,8 @@ impl<'a> Lowering<'a> {
                     return Ok(());
                 }
                 // Builder-mode ctor. In the canonical builder-form lowering, the
-                // single `Wtf8Buf`/`String` `new`/`with_capacity` def of a
+                // single `Wtf8Buf`/`String` `new`/`with_capacity`/`from_string`
+                // def of a
                 // builder-mode accumulator (its dest local, proven single-def
                 // by that ctor in [`is_fresh_str_builder`]) mints the
                 // `StringBuilder` once via the `__majit_stringbuilder_new`
@@ -8278,6 +8328,7 @@ impl<'a> Lowering<'a> {
                 // `AbstractStringBuilderRepr.rtyper_new` (rtyper/rbuilder.py) —
                 // no arg selects `ll_new(INIT_SIZE)`, the size arg threads
                 // `ll_new(n)`.
+                let builder_ctor_leaf = str_builder_ctor_leaf(self.llbc, &reg);
                 if self.builder_mode
                     && is_builder_mode_accumulator(self.body, self.llbc, dest_local)
                 {
@@ -8292,19 +8343,44 @@ impl<'a> Lowering<'a> {
                                     crate::runtime_names::shims::STRINGBUILDER_NEW.to_string(),
                                 ],
                             },
-                            args,
+                            args: if builder_ctor_leaf == Some("with_capacity") {
+                                args.clone()
+                            } else {
+                                Vec::new()
+                            },
                             result_ty: ValueType::Ref(None),
                         },
                     });
+                    // `Wtf8Buf::from_string(initial)` is the Rust ownership
+                    // spelling of an RPython builder followed by its first
+                    // append.  Keep the initial value as an append operand;
+                    // passing it to `new` would misread it as the optional
+                    // integer capacity argument.
+                    if builder_ctor_leaf == Some("from_string") {
+                        let void = self
+                            .graph
+                            .alloc_value_var_with_type(crate::model::ConcreteType::Void);
+                        self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                            result: Some(void),
+                            kind: OpKind::Call {
+                                target: CallTarget::FunctionPath {
+                                    segments: vec!["__majit_stringbuilder_append".to_string()],
+                                },
+                                args: vec![res.clone(), args[0].clone()],
+                                result_ty: ValueType::Void,
+                            },
+                        });
+                    }
                     self.local_var[dest_local] = Some(res);
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
-                // `Wtf8Buf` / `String`::push_str(&mut buf, s) / push_wtf8(&mut
-                // buf, w) — and the argument-swapped `Wtf8Piece::push_onto(&s,
-                // &mut buf)` — an accumulator append.  A `Wtf8Buf` / `String`
+                // `String::push(&mut buf, ch)`, `Wtf8Buf` /
+                // `String`::push_str(&mut buf, s), or push_wtf8(&mut buf, w) —
+                // and the argument-swapped `Wtf8Piece::push_onto(&s, &mut
+                // buf)` — an accumulator append.  A `Wtf8Buf` / `String`
                 // lifts to the single immutable `ValueType::Str`, so there is
                 // no builder to mutate in place; model the append functionally
                 // as `buf = ll_strconcat(buf, piece)` (the `add` BinOp the
@@ -8312,7 +8388,7 @@ impl<'a> Lowering<'a> {
                 // MIR local so its later reads — and the loop-header phi that
                 // threads it across the back-edge — observe the concatenated
                 // string.  `str_builder_append_args` gives the accumulator and
-                // piece arg positions (push_str / push_wtf8: acc 0, piece 1;
+                // piece arg positions (push / push_str / push_wtf8: acc 0, piece 1;
                 // push_onto: acc 1, piece 0).  The `&mut buf` accumulator
                 // arrives as a per-site ref-temp; `append_accumulator_of_arg_temp`
                 // traces it back to `buf` on demand from the MIR body, resolving
@@ -8339,6 +8415,15 @@ impl<'a> Lowering<'a> {
                     let acc_val = self.local_var[buf_local]
                         .clone()
                         .unwrap_or_else(|| args[acc_i].clone());
+                    let piece_val = if self.builder_mode
+                        && let Some(piece_temp) = arg_locals.get(piece_i).copied().flatten()
+                        && let Some(piece_builder) =
+                            append_piece_accumulator_of_arg_temp(self.body, self.llbc, piece_temp)
+                    {
+                        self.resolve_builder_build(mir_bb, piece_builder)?
+                    } else {
+                        args[piece_i].clone()
+                    };
                     if self.builder_mode
                         && is_builder_mode_accumulator(self.body, self.llbc, buf_local)
                     {
@@ -8359,12 +8444,12 @@ impl<'a> Lowering<'a> {
                                             .to_string(),
                                     ],
                                 },
-                                args: vec![acc_val, args[piece_i].clone()],
+                                args: vec![acc_val, piece_val],
                                 result_ty: ValueType::Void,
                             },
                         });
                     } else {
-                        let concat = emit_str_add(&mut self.graph, bb_id, &acc_val, &args[piece_i]);
+                        let concat = emit_str_add(&mut self.graph, bb_id, &acc_val, &piece_val);
                         self.local_var[buf_local] = Some(concat);
                     }
                     self.local_var[dest_local] = Some(
@@ -15333,7 +15418,8 @@ fn compute_multi_assigned_locals(body: &Unstructured) -> std::collections::HashS
 /// The owning type of a functional-concat string builder: `Wtf8Buf` (the
 /// interpreter's repr accumulator) or std `String` (the byte / leaf / module
 /// repr helpers).  Both annotate to the immutable `ValueType::Str`, so a
-/// `push_str` append models identically as `buf = ll_strconcat(buf, arg)`;
+/// `push` / `push_str` append models identically as
+/// `buf = ll_strconcat(buf, arg)`;
 /// `push_wtf8` is `Wtf8Buf`-only but the leaf gate never matches it on a
 /// `String`, so one owner set serves both.
 fn is_str_builder_owner(owner: Option<&str>) -> bool {
@@ -15341,8 +15427,8 @@ fn is_str_builder_owner(owner: Option<&str>) -> bool {
 }
 
 /// The string-builder ctor leaf a MIR call resolves to, restricted to the
-/// fresh-buffer constructors this pass models (`new` / `with_capacity`) on a
-/// `Wtf8Buf` or `String`; `None` for any other callee.  The cheap leaf check
+/// fresh-buffer constructors this pass models (`new` / `with_capacity` /
+/// `from_string`) on a `Wtf8Buf` or `String`; `None` for any other callee.  The cheap leaf check
 /// runs before the impl-owner resolution so the type lookup only fires for the
 /// candidate names.  Appends are recognised separately by
 /// [`str_builder_append_args`].
@@ -15350,6 +15436,10 @@ fn wtf8buf_method_leaf(llbc: &Llbc, call: &CallPayload) -> Option<&'static str> 
     let CallFunc::Regular(reg) = &call.func else {
         return None;
     };
+    str_builder_ctor_leaf(llbc, reg)
+}
+
+fn str_builder_ctor_leaf(llbc: &Llbc, reg: &RegularCall) -> Option<&'static str> {
     let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
         return None;
     };
@@ -15358,6 +15448,8 @@ fn wtf8buf_method_leaf(llbc: &Llbc, call: &CallPayload) -> Option<&'static str> 
     let leaf = match np.rsplit("::").next()? {
         "new" => "new",
         "with_capacity" => "with_capacity",
+        "from_string" => "from_string",
+        "push" => "push",
         "push_str" => "push_str",
         "push_wtf8" => "push_wtf8",
         _ => return None,
@@ -15366,9 +15458,11 @@ fn wtf8buf_method_leaf(llbc: &Llbc, call: &CallPayload) -> Option<&'static str> 
 }
 
 /// If `reg` is a functional-concat string append, its `(accumulator, piece)`
-/// argument positions.  `push_str` / `push_wtf8` (on `Wtf8Buf` / `String`)
-/// take the accumulator as `&mut self` (arg 0) and the appended piece as
-/// arg 1.  `Wtf8Piece::push_onto(&self, out: &mut Wtf8Buf)` swaps them: the
+/// argument positions.  `push` / `push_str` / `push_wtf8` (on `String` /
+/// `Wtf8Buf`) take the accumulator as `&mut self` (arg 0) and the appended
+/// piece as arg 1.  `String::push(char)` is upstream
+/// `AbstractStringBuilderRepr.rtype_method_append`'s `SomeChar` arm;
+/// `Wtf8Piece::push_onto(&self, out: &mut Wtf8Buf)` swaps the arguments: the
 /// piece is `self` (arg 0) and the accumulator is `out` (arg 1).  Every
 /// `Wtf8Piece` impl body is `out.push_str(self)` / `out.push_wtf8(self)`, so
 /// `out = out ++ self` models all of them; the accumulator gate
@@ -15381,7 +15475,7 @@ fn str_builder_append_args(llbc: &Llbc, reg: &RegularCall) -> Option<(usize, usi
     let fd = llbc.fn_by_id(*id)?;
     let np = fd.item_meta.name_path();
     match np.rsplit("::").next()? {
-        "push_str" | "push_wtf8" => {
+        "push" | "push_str" | "push_wtf8" => {
             is_str_builder_owner(deref_impl_owner_leaf(llbc, fd).as_deref()).then_some((0, 1))
         }
         // `Wtf8Piece::push_onto`: the `str` / `String` / `Wtf8` impls live
@@ -15425,14 +15519,16 @@ fn operand_reads_local(op: &Operand, l: usize) -> bool {
     matches!(op, Operand::Copy(p) | Operand::Move(p) if place_references_local(p, l))
 }
 
-/// Whether a `&(mut) buf` ref-temp `rt` is used exactly once — as the
-/// accumulator argument of a recognised append (`push_str` / `push_wtf8`
-/// arg 0, or `Wtf8Piece::push_onto` arg 1) — and nowhere else, so rebinding
-/// `buf` to the concat captures the whole mutation.  A ref-temp that also
-/// escapes elsewhere would leave that other reader observing the pre-append
-/// buffer, so it declines.
-fn ref_temp_is_sole_append_receiver(body: &Unstructured, llbc: &Llbc, rt: usize) -> bool {
-    let mut receiver = 0usize;
+/// Whether a builder borrow temp is used exactly once in the selected role of
+/// a recognised append (`accumulator == true` selects the receiver, false the
+/// appended piece) and nowhere else.  A temp that also escapes declines.
+fn ref_temp_is_sole_append_arg(
+    body: &Unstructured,
+    llbc: &Llbc,
+    rt: usize,
+    accumulator: bool,
+) -> bool {
+    let mut selected = 0usize;
     let mut other = 0usize;
     for bb in &body.body {
         for st in &bb.statements {
@@ -15459,10 +15555,9 @@ fn ref_temp_is_sole_append_receiver(body: &Unstructured, llbc: &Llbc, rt: usize)
         }
         match bb.term() {
             Ok(TermKind::Call { call, .. }) => {
-                let acc_idx = match &call.func {
-                    CallFunc::Regular(reg) => {
-                        str_builder_append_args(llbc, reg).map(|(acc, _)| acc)
-                    }
+                let selected_idx = match &call.func {
+                    CallFunc::Regular(reg) => str_builder_append_args(llbc, reg)
+                        .map(|(acc, piece)| if accumulator { acc } else { piece }),
                     _ => None,
                 };
                 if let CallFunc::Dynamic(op) = &call.func
@@ -15472,8 +15567,8 @@ fn ref_temp_is_sole_append_receiver(body: &Unstructured, llbc: &Llbc, rt: usize)
                 }
                 for (i, arg) in call.args.iter().enumerate() {
                     if operand_reads_local(arg, rt) {
-                        if acc_idx == Some(i) {
-                            receiver += 1;
+                        if selected_idx == Some(i) {
+                            selected += 1;
                         } else {
                             other += 1;
                         }
@@ -15493,7 +15588,7 @@ fn ref_temp_is_sole_append_receiver(body: &Unstructured, llbc: &Llbc, rt: usize)
             _ => {}
         }
     }
-    receiver == 1 && other == 0
+    selected == 1 && other == 0
 }
 
 /// Given a single-def `Wtf8Buf::new` / `with_capacity` accumulator local
@@ -15606,14 +15701,19 @@ fn clean_accumulator_ref_temps(body: &Unstructured, llbc: &Llbc, c: usize) -> Op
     }
     let mut receivers = Vec::with_capacity(ref_temps.len());
     for &rt in &ref_temps {
-        receivers.push(append_receiver_of_borrow(body, llbc, rt)?);
+        if let Some(receiver) = append_receiver_of_borrow(body, llbc, rt) {
+            receivers.push(receiver);
+        } else if append_piece_of_borrow(body, llbc, rt).is_none() {
+            return None;
+        }
     }
     Some(receivers)
 }
 
 /// Resolve a direct `&(mut) buf` borrow temp `rt` to the temp actually passed
 /// as the append's accumulator argument.  A method-autoref receiver
-/// (`buf.push_str(s)`) reaches the call unchanged, so `rt` is itself the sole
+/// (`buf.push(ch)` / `buf.push_str(s)`) reaches the call unchanged, so `rt` is
+/// itself the sole
 /// append receiver.  An explicit `&mut buf` argument (`Wtf8Piece::push_onto(&s,
 /// &mut buf)`) is a two-phase reborrow — `rt := &Mut buf; recv := &TwoPhaseMut
 /// *rt` — so the call receives `recv` instead; accept it when `rt`'s only use
@@ -15621,7 +15721,109 @@ fn clean_accumulator_ref_temps(body: &Unstructured, llbc: &Llbc, c: usize) -> Op
 /// returned temp is the call's accumulator-argument local the append arm
 /// resolves against ([`append_accumulator_of_arg_temp`]).
 fn append_receiver_of_borrow(body: &Unstructured, llbc: &Llbc, rt: usize) -> Option<usize> {
-    if ref_temp_is_sole_append_receiver(body, llbc, rt) {
+    append_arg_of_borrow(body, llbc, rt, true)
+}
+
+fn append_piece_of_borrow(body: &Unstructured, llbc: &Llbc, rt: usize) -> Option<usize> {
+    let mut current = rt;
+    for _ in 0..8 {
+        if ref_temp_is_sole_append_arg(body, llbc, current, false) {
+            return Some(current);
+        }
+        current = sole_string_alias_successor(body, llbc, current)?;
+    }
+    None
+}
+
+/// Follow one Rust reference/coercion shell which the lowered string value
+/// model aliases away: an immediate reborrow, or `Deref::deref` between two
+/// string-family types.  The source temp must have exactly this one use.
+fn sole_string_alias_successor(body: &Unstructured, llbc: &Llbc, source: usize) -> Option<usize> {
+    fn record(slot: &mut Option<usize>, other: &mut usize, candidate: usize) {
+        if slot.replace(candidate).is_some() {
+            *other += 1;
+        }
+    }
+    let mut successor: Option<usize> = None;
+    let mut other = 0usize;
+    for block in &body.body {
+        for stmt in &block.statements {
+            match stmt.stmt_kind() {
+                Ok(StmtKind::Assign(place, rvalue)) => {
+                    if let Rvalue::Ref { place: inner, .. } | Rvalue::RawPtr { place: inner, .. } =
+                        &rvalue
+                        && place_is_immediate_deref_of(inner, source)
+                    {
+                        if let PlaceKind::Local(dest) = place.kind {
+                            record(&mut successor, &mut other, dest as usize);
+                        } else {
+                            other += 1;
+                        }
+                        continue;
+                    }
+                    let (mut derefs, mut others) = (0usize, 0usize);
+                    scan_rvalue_dest_ref(&rvalue, source, &mut derefs, &mut others);
+                    other += derefs + others;
+                    if matches!(&place.kind, PlaceKind::Projection(..))
+                        && place_references_local(&place, source)
+                    {
+                        other += 1;
+                    }
+                }
+                Ok(StmtKind::Assert(assert)) => {
+                    other += usize::from(operand_reads_local(&assert.cond, source));
+                }
+                _ => {}
+            }
+        }
+        match block.term() {
+            Ok(TermKind::Call { call, .. }) => {
+                let reads = call
+                    .args
+                    .iter()
+                    .filter(|arg| operand_reads_local(arg, source))
+                    .count();
+                let string_deref = if reads == 1 && call.args.len() == 1 {
+                    matches!(&call.func, CallFunc::Regular(reg) if is_deref_call(reg, llbc))
+                        && operand_tyref(&call.args[0])
+                            .is_some_and(|ty| tyref_is_string_value(ty, llbc))
+                        && tyref_is_string_value(&call.dest.ty, llbc)
+                } else {
+                    false
+                };
+                if string_deref {
+                    if let PlaceKind::Local(dest) = call.dest.kind {
+                        record(&mut successor, &mut other, dest as usize);
+                    } else {
+                        other += 1;
+                    }
+                } else {
+                    other += reads;
+                }
+                if let CallFunc::Dynamic(op) = &call.func {
+                    other += usize::from(operand_reads_local(op, source));
+                }
+            }
+            Ok(TermKind::Switch { discr, .. }) => {
+                other += usize::from(operand_reads_local(&discr, source));
+            }
+            Ok(TermKind::Assert { assert, .. }) => {
+                other += usize::from(operand_reads_local(&assert.cond, source));
+            }
+            _ => {}
+        }
+    }
+    (other == 0).then_some(successor?)
+}
+
+fn append_arg_of_borrow(
+    body: &Unstructured,
+    llbc: &Llbc,
+    rt: usize,
+    accumulator: bool,
+) -> Option<usize> {
+    let is_selected = |candidate| ref_temp_is_sole_append_arg(body, llbc, candidate, accumulator);
+    if is_selected(rt) {
         return Some(rt);
     }
     let mut recv: Option<usize> = None;
@@ -15689,12 +15891,12 @@ fn append_receiver_of_borrow(body: &Unstructured, llbc: &Llbc, rt: usize) -> Opt
     if other != 0 {
         return None;
     }
-    ref_temp_is_sole_append_receiver(body, llbc, recv).then_some(recv)
+    is_selected(recv).then_some(recv)
 }
 
 /// Whether MIR local `c` is a fresh owned string-builder accumulator: it has
 /// exactly one def and that def is a `Wtf8Buf` / `String` `new` /
-/// `with_capacity` call.  A local with a second def, or one defined by a
+/// `with_capacity` / `from_string` call.  A local with a second def, or one defined by a
 /// non-ctor rvalue, is not a fresh accumulator and keeps its residual.
 fn is_fresh_str_builder(body: &Unstructured, llbc: &Llbc, c: usize) -> bool {
     let mut def_count = 0usize;
@@ -15713,7 +15915,7 @@ fn is_fresh_str_builder(body: &Unstructured, llbc: &Llbc, c: usize) -> bool {
             def_count += 1;
             ctor_def = matches!(
                 wtf8buf_method_leaf(llbc, &call),
-                Some("new") | Some("with_capacity")
+                Some("new") | Some("with_capacity") | Some("from_string")
             );
         }
     }
@@ -15721,7 +15923,7 @@ fn is_fresh_str_builder(body: &Unstructured, llbc: &Llbc, c: usize) -> bool {
 }
 
 /// Resolve the accumulator local a recognised append rebinds, given the MIR
-/// local `rt` passed as the append's accumulator argument (`push_str` /
+/// local `rt` passed as the append's accumulator argument (`push` / `push_str` /
 /// `push_wtf8` receiver, or `Wtf8Piece::push_onto` `&mut buf` argument).  `rt`
 /// borrows the accumulator directly (method autoref) or through a single
 /// two-phase reborrow; the owning `buf` is the fresh `new` / `with_capacity`
@@ -15743,6 +15945,38 @@ fn append_accumulator_of_arg_temp(body: &Unstructured, llbc: &Llbc, rt: usize) -
     })
 }
 
+/// Resolve a shared-borrow temp used as an append piece to the completed
+/// inner builder it borrows.  Membership is proven from the MIR definition of
+/// `rt` and the same single-use append-piece test accepted by
+/// [`clean_accumulator_ref_temps`].
+fn append_piece_accumulator_of_arg_temp(
+    body: &Unstructured,
+    llbc: &Llbc,
+    rt: usize,
+) -> Option<usize> {
+    for candidate in builder_ctor_dest_locals(body, llbc) {
+        if !is_builder_mode_accumulator(body, llbc, candidate) {
+            continue;
+        }
+        for block in &body.body {
+            for stmt in &block.statements {
+                let Ok(StmtKind::Assign(place, Rvalue::Ref { place: source, .. })) =
+                    stmt.stmt_kind()
+                else {
+                    continue;
+                };
+                if matches!(source.kind, PlaceKind::Local(i) if i as usize == candidate)
+                    && let PlaceKind::Local(direct_borrow) = place.kind
+                    && append_piece_of_borrow(body, llbc, direct_borrow as usize) == Some(rt)
+                {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Count the by-value consumptions (`move c`) of a fresh accumulator local
 /// `c`.  [`clean_accumulator_ref_temps`] already proves every other use of `c`
 /// is the ctor def or an append borrow, so each `move c` is a terminal
@@ -15750,12 +15984,20 @@ fn append_accumulator_of_arg_temp(body: &Unstructured, llbc: &Llbc, rt: usize) -
 /// must run `ll_build`.  Counted so the builder lift only fires when the build
 /// point is unambiguous (see [`is_builder_mode_accumulator`]).
 #[allow(dead_code)] // wired into the ctor/append/terminal arms in this change
-fn accumulator_move_site_count(body: &Unstructured, c: usize) -> usize {
+fn accumulator_materialization_site_count(body: &Unstructured, llbc: &Llbc, c: usize) -> usize {
     let is_move = |op: &Operand| c_operand_kind(op, c) == Some(true);
     let mut moves = 0usize;
     for bb in &body.body {
         for st in &bb.statements {
             if let Ok(StmtKind::Assign(_, rvalue)) = st.stmt_kind() {
+                if let Rvalue::Ref { place: source, .. } = &rvalue
+                    && matches!(source.kind, PlaceKind::Local(i) if i as usize == c)
+                    && let Ok(StmtKind::Assign(place, _)) = st.stmt_kind()
+                    && let PlaceKind::Local(rt) = place.kind
+                    && append_piece_of_borrow(body, llbc, rt as usize).is_some()
+                {
+                    moves += 1;
+                }
                 match &rvalue {
                     Rvalue::Use(op)
                     | Rvalue::UnaryOp(_, op)
@@ -15797,8 +16039,9 @@ fn accumulator_move_site_count(body: &Unstructured, c: usize) -> usize {
 /// * a single-def `Wtf8Buf` / `String` `new` / `with_capacity` ctor
 ///   ([`is_fresh_str_builder`]),
 /// * every borrow of `c` an append ([`clean_accumulator_ref_temps`]), and
-/// * exactly one by-value terminal consumption ([`accumulator_move_site_count`])
-///   — the single `ll_build` materialisation point.
+/// * exactly one terminal consumption
+///   ([`accumulator_materialization_site_count`]) — a by-value move or an
+///   inner-builder append piece, both spelling the single `ll_build` point.
 ///
 /// Zero or several terminal moves keep the `ll_strconcat` fallback so the
 /// builder rewrite only fires where the ctor, the appends, and the one build
@@ -15808,7 +16051,7 @@ fn accumulator_move_site_count(body: &Unstructured, c: usize) -> usize {
 fn is_builder_mode_accumulator(body: &Unstructured, llbc: &Llbc, c: usize) -> bool {
     is_fresh_str_builder(body, llbc, c)
         && clean_accumulator_ref_temps(body, llbc, c).is_some()
-        && accumulator_move_site_count(body, c) == 1
+        && accumulator_materialization_site_count(body, llbc, c) == 1
 }
 
 /// Whether a statically-resolved [`RegularCall`] is a workspace
@@ -21651,19 +21894,26 @@ fn block_reachable(graph: &FunctionGraph, target: BlockId) -> bool {
 /// - terminator: a `0x00` byte (only at a segment boundary; `0`/`0xC0`
 ///   bytes inside a literal are consumed by its length prefix).
 ///
-/// Returns `(pieces, arg_indices)` where `arg_indices` holds the argument
+/// Returns `(pieces, placeholders)` where each placeholder records its
+/// argument index plus the static formatting fields encoded in the template.
+/// `FmtPlaceholder::is_default()` is the old `0xC0`/`0xC8` subset; retaining
+/// the fields lets a later parity rewrite recognize the one non-default shape
+/// used by `bytearray_repr_string` without treating arbitrary Rust formatting
+/// as RPython string operations.
+///
+/// `placeholders[*].arg_index` holds the argument
 /// index each placeholder renders (one per placeholder, so `pieces.len() ==
-/// arg_indices.len() + 1`).  A sequential `0xC0` auto-increments; a reused
+/// placeholders.len() + 1`).  A sequential `0xC0` auto-increments; a reused
 /// `0xC8` index points back at an already-seen argument, so the distinct
 /// argument count is `max(arg_indices) + 1`, which can be less than the
 /// placeholder count.  Returns `None` (bail, leaving the graph untouched)
 /// on any high-bit control byte other than `0xC0`/`0xC8` — a format spec
 /// with width/precision/fill or a named argument — and on non-UTF-8
 /// literal bytes.
-fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, Vec<usize>)> {
+fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, Vec<FmtPlaceholder>)> {
     let mut pieces: Vec<String> = Vec::new();
     let mut current = String::new();
-    let mut indices: Vec<usize> = Vec::new();
+    let mut placeholders: Vec<FmtPlaceholder> = Vec::new();
     let mut auto = 0usize; // next sequential argument index
     let mut i = 0;
     let mut terminated = false;
@@ -21676,19 +21926,58 @@ fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, Vec<usize>)
             }
             terminated = true;
             break;
-        } else if b == 0xC0 {
-            // sequential placeholder: renders the next argument in order
+        } else if b >= 0xC0 {
+            // `core::fmt::Arguments`' packed placeholder grammar (the pinned
+            // Rust core `fmt/mod.rs`): low bits select optional u32 flags,
+            // u16 width, u16 precision, and u16 argument-index fields; bits
+            // 4/5 mark indirect width/precision.  Decode all field lengths so
+            // embedded zero bytes are never mistaken for the terminator.
             pieces.push(std::mem::take(&mut current));
-            indices.push(auto);
-            auto += 1;
             i += 1;
-        } else if b == 0xC8 {
-            // explicit / reused placeholder: `0xC8` + little-endian u16 index
-            let lo = *bytes.get(i + 1)? as usize;
-            let hi = *bytes.get(i + 2)? as usize;
-            pieces.push(std::mem::take(&mut current));
-            indices.push(lo | (hi << 8));
-            i += 3;
+            let read_u16 = |at: &mut usize| -> Option<u16> {
+                let lo = *bytes.get(*at)?;
+                let hi = *bytes.get(*at + 1)?;
+                *at += 2;
+                Some(u16::from_le_bytes([lo, hi]))
+            };
+            let read_u32 = |at: &mut usize| -> Option<u32> {
+                let b0 = *bytes.get(*at)?;
+                let b1 = *bytes.get(*at + 1)?;
+                let b2 = *bytes.get(*at + 2)?;
+                let b3 = *bytes.get(*at + 3)?;
+                *at += 4;
+                Some(u32::from_le_bytes([b0, b1, b2, b3]))
+            };
+            let flags = if b & 0x01 != 0 {
+                Some(read_u32(&mut i)?)
+            } else {
+                None
+            };
+            let width = if b & 0x02 != 0 {
+                Some(read_u16(&mut i)?)
+            } else {
+                None
+            };
+            let precision = if b & 0x04 != 0 {
+                Some(read_u16(&mut i)?)
+            } else {
+                None
+            };
+            let arg_index = if b & 0x08 != 0 {
+                usize::from(read_u16(&mut i)?)
+            } else {
+                let index = auto;
+                auto += 1;
+                index
+            };
+            placeholders.push(FmtPlaceholder {
+                arg_index,
+                flags,
+                width,
+                precision,
+                width_indirect: b & 0x10 != 0,
+                precision_indirect: b & 0x20 != 0,
+            });
         } else if b == 0x80 {
             // long literal segment: `0x80` + little-endian u16 length,
             // then that many UTF-8 bytes (a 128+ byte literal that the
@@ -21709,7 +21998,7 @@ fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, Vec<usize>)
             current.push_str(std::str::from_utf8(seg).ok()?);
             i = end;
         } else {
-            // any other control byte = format spec / named arg: bail
+            // 0x81..0xBF are neither literal lengths nor placeholders.
             return None;
         }
     }
@@ -21720,7 +22009,45 @@ fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, Vec<usize>)
         return None;
     }
     pieces.push(current);
-    Some((pieces, indices))
+    Some((pieces, placeholders))
+}
+
+/// Static formatting fields carried by one packed `fmt::Arguments`
+/// placeholder.  This mirrors the storage shape documented in the pinned
+/// Rust core; it is a Vec entry in template order, not a side-table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FmtPlaceholder {
+    arg_index: usize,
+    flags: Option<u32>,
+    width: Option<u16>,
+    precision: Option<u16>,
+    width_indirect: bool,
+    precision_indirect: bool,
+}
+
+impl FmtPlaceholder {
+    fn is_default(self) -> bool {
+        self.flags.is_none()
+            && self.width.is_none()
+            && self.precision.is_none()
+            && !self.width_indirect
+            && !self.precision_indirect
+    }
+
+    /// Rust `{:02x}` as emitted for the `u8` in
+    /// `display::bytearray_repr_string`: space fill + unknown alignment,
+    /// sign-aware zero padding, width present and equal to two.
+    fn is_lower_hex_byte_02(self) -> bool {
+        const FILL_SPACE: u32 = b' ' as u32;
+        const ZERO_PAD: u32 = 1 << 24;
+        const WIDTH_PRESENT: u32 = 1 << 27;
+        const ALIGN_UNKNOWN: u32 = 3 << 29;
+        self.flags == Some(FILL_SPACE | ZERO_PAD | WIDTH_PRESENT | ALIGN_UNKNOWN)
+            && self.width == Some(2)
+            && self.precision.is_none()
+            && !self.width_indirect
+            && !self.precision_indirect
+    }
 }
 
 /// Read an `Array` aggregate literal: given the Variable holding a
@@ -21793,6 +22120,7 @@ fn resolve_const_int(
 enum FmtArgKind {
     Display,
     Debug,
+    LowerHex,
 }
 
 /// One placeholder argument recovered from a `format_args!` chain: the
@@ -21815,7 +22143,7 @@ struct FmtArg {
 struct FmtChain {
     pieces: Vec<String>,
     args: Vec<FmtArg>,
-    arg_indices: Vec<usize>,
+    placeholders: Vec<FmtPlaceholder>,
 }
 
 /// Match a `FunctionPath`'s trailing segments against `tail`, so a
@@ -21851,6 +22179,8 @@ fn fmt_argument_ctor_kind(segments: &[String]) -> Option<FmtArgKind> {
         Some(FmtArgKind::Display)
     } else if fmt_path_ends_with(segments, &["Argument", "new_debug"]) {
         Some(FmtArgKind::Debug)
+    } else if fmt_path_ends_with(segments, &["Argument", "new_lower_hex"]) {
+        Some(FmtArgKind::LowerHex)
     } else {
         None
     }
@@ -21966,18 +22296,25 @@ fn extract_fmt_chain(
     for v in &piece_byte_vars {
         bytes.push(u8::try_from(resolve_const_int(graph, v)?).ok()?);
     }
-    let (pieces, arg_indices) = decode_packed_format_pieces(&bytes)?;
+    let (pieces, placeholders) = decode_packed_format_pieces(&bytes)?;
     // Args: an `Array` of `Argument::new_display|new_debug(&v)` ctors, one
     // per *distinct* argument.  The args array holds the distinct arguments;
     // reused placeholders (`0xC8`) point back at an earlier index, so the
     // distinct count is `max(arg_indices) + 1` — bail unless it matches the
     // args array, and every placeholder index must be in range.
     let arg_elems = read_array_literal_elements(graph, &args_var)?;
-    let distinct = arg_indices.iter().map(|i| i + 1).max().unwrap_or(0);
+    let distinct = placeholders
+        .iter()
+        .map(|placeholder| placeholder.arg_index + 1)
+        .max()
+        .unwrap_or(0);
     if arg_elems.len() != distinct {
         return None;
     }
-    if arg_indices.iter().any(|&i| i >= arg_elems.len()) {
+    if placeholders
+        .iter()
+        .any(|placeholder| placeholder.arg_index >= arg_elems.len())
+    {
         return None;
     }
     let mut args = Vec::with_capacity(arg_elems.len());
@@ -21987,7 +22324,7 @@ fn extract_fmt_chain(
     Some(FmtChain {
         pieces,
         args,
-        arg_indices,
+        placeholders,
     })
 }
 
@@ -22057,7 +22394,8 @@ fn emit_fmt_concat(graph: &mut FunctionGraph, bb_id: BlockId, chain: &FmtChain) 
     // Walk placeholders in template order via `arg_indices`; a reused
     // argument re-renders the same recovered value (`str(&str)` is pure, so
     // referencing the value var twice is sound).
-    for (i, &ai) in chain.arg_indices.iter().enumerate() {
+    for (i, placeholder) in chain.placeholders.iter().enumerate() {
+        let ai = placeholder.arg_index;
         acc = emit_str_add(graph, bb_id, &acc, &chain.args[ai].value);
         let next_piece = emit_str_const(graph, bb_id, &chain.pieces[i + 1]);
         acc = emit_str_add(graph, bb_id, &acc, &next_piece);
@@ -22138,6 +22476,125 @@ fn emit_fmt_expansion_ops(
     ops
 }
 
+/// Expand the byte-only `{:02x}` in `bytearray_repr_string` to the exact
+/// operations PyPy uses in `bytearrayobject.py::descr_repr`:
+///
+/// ```python
+/// digits = "0123456789abcdef"
+/// digits[n >> 4] + digits[n & 0xF]
+/// ```
+///
+/// The caller proves the formatted value came from a `(u8,)` argument tuple,
+/// so two digits are complete (never truncating a wider integer).  Each
+/// getitem annotates as `SomeChar`; `str(char)` follows
+/// `AbstractCharRepr.ll_str -> ll_chr2str`, and the final `add` is ordinary
+/// `StringRepr` concatenation.  No Rust fmt runtime or new helper survives.
+fn emit_lower_hex_byte_02_ops(
+    graph: &mut FunctionGraph,
+    value: &Variable,
+    result: Variable,
+) -> Vec<SpaceOperation> {
+    use crate::model::{CallTarget, OpKind, ValueType};
+    let alloc = |graph: &mut FunctionGraph| {
+        graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown)
+    };
+    let mut ops = Vec::new();
+
+    let digits = alloc(graph);
+    ops.push(SpaceOperation {
+        result: Some(digits.clone()),
+        kind: OpKind::Call {
+            target: CallTarget::FunctionPath {
+                segments: vec!["__str_const".to_string(), "0123456789abcdef".to_string()],
+            },
+            args: vec![],
+            result_ty: ValueType::Ref(None),
+        },
+    });
+    let four = alloc(graph);
+    ops.push(SpaceOperation {
+        result: Some(four.clone()),
+        kind: OpKind::ConstInt(4),
+    });
+    let fifteen = alloc(graph);
+    ops.push(SpaceOperation {
+        result: Some(fifteen.clone()),
+        kind: OpKind::ConstInt(15),
+    });
+    let hi_index = alloc(graph);
+    ops.push(SpaceOperation {
+        result: Some(hi_index.clone()),
+        kind: OpKind::BinOp {
+            op: "rshift".to_string(),
+            lhs: value.clone(),
+            rhs: four,
+            result_ty: ValueType::Int,
+        },
+    });
+    let lo_index = alloc(graph);
+    ops.push(SpaceOperation {
+        result: Some(lo_index.clone()),
+        kind: OpKind::BinOp {
+            op: "and".to_string(),
+            lhs: value.clone(),
+            rhs: fifteen,
+            result_ty: ValueType::Int,
+        },
+    });
+    let hi_char = alloc(graph);
+    ops.push(SpaceOperation {
+        result: Some(hi_char.clone()),
+        kind: OpKind::ArrayRead {
+            base: digits.clone(),
+            index: hi_index,
+            item_ty: ValueType::Int,
+            array_type_id: None,
+            nolength: false,
+            pure: true,
+        },
+    });
+    let lo_char = alloc(graph);
+    ops.push(SpaceOperation {
+        result: Some(lo_char.clone()),
+        kind: OpKind::ArrayRead {
+            base: digits,
+            index: lo_index,
+            item_ty: ValueType::Int,
+            array_type_id: None,
+            nolength: false,
+            pure: true,
+        },
+    });
+    let hi = alloc(graph);
+    ops.push(SpaceOperation {
+        result: Some(hi.clone()),
+        kind: OpKind::UnaryOp {
+            op: "str".to_string(),
+            operand: hi_char,
+            result_ty: ValueType::Str,
+        },
+    });
+    let lo = alloc(graph);
+    ops.push(SpaceOperation {
+        result: Some(lo.clone()),
+        kind: OpKind::UnaryOp {
+            op: "str".to_string(),
+            operand: lo_char,
+            result_ty: ValueType::Str,
+        },
+    });
+    ops.push(SpaceOperation {
+        result: Some(result),
+        kind: OpKind::BinOp {
+            op: "add".to_string(),
+            lhs: hi,
+            rhs: lo,
+            result_ty: ValueType::Str,
+        },
+    });
+    ops
+}
+
 /// The unique `Link` feeding `target`'s inputarg at `pos`: the source
 /// block id, its exit index, and the threaded value Variable. Returns
 /// `None` when `target` has more than one predecessor (a phi merge, so
@@ -22202,12 +22659,17 @@ struct FmtCollapse {
 struct SingleArgFmtChainNav {
     /// The render kind of the single argument (`Display` / `Debug`).
     kind: FmtArgKind,
+    /// Static options and argument index decoded from the packed template.
+    placeholder: FmtPlaceholder,
     /// The literal template pieces around the single placeholder.
     pieces: Vec<String>,
     /// The `alloc::fmt::format` result var.
     format_result: Variable,
     /// The single rendered value (the tuple field source).
     context: Variable,
+    /// The argument tuple is exactly Rust `(u8,)`; used by the LowerHex
+    /// parity collapse to prove that two hexadecimal digits cannot truncate.
+    context_is_u8: bool,
     /// `(block, exit_index, arg_pos, replacement)` — re-thread the deleted
     /// chain value the link forwarded onto a still-live value so no link
     /// references a deleted result var after the chain ops are removed.
@@ -22247,15 +22709,16 @@ fn navigate_single_arg_fmt_chain(
         _ => return None,
     };
     let chain = extract_fmt_chain(graph, &fmt_args)?;
-    if chain.args.len() != 1 || chain.arg_indices.len() != 1 {
+    if chain.args.len() != 1 || chain.placeholders.len() != 1 {
         // scope: exactly one argument rendered by exactly one placeholder.
         // A single argument reused across several placeholders (`{0}…{0}`)
-        // has `arg_indices.len() > 1` and stays residual here (none of the
+        // has `placeholders.len() > 1` and stays residual here (none of the
         // census walls), rather than mis-driving the single-placeholder
         // expansion below.
         return None;
     }
     let kind = chain.args[0].kind;
+    let placeholder = chain.placeholders[0];
     let pieces = chain.pieces.clone();
 
     // `fmt_args` reaches Bf as an inputarg threaded from Bp's
@@ -22313,6 +22776,13 @@ fn navigate_single_arg_fmt_chain(
     })?;
     // The rendered value written into the argument tuple field.
     let context = unwrap_fmt_arg_tuple_ref(graph, &arg_ref)?;
+    let context_is_u8 = block_0.operations.iter().any(|op| {
+        matches!(&op.kind,
+            OpKind::Call {
+                target: CallTarget::SyntheticTransparentCtor { name, .. },
+                ..
+            } if op.result.as_ref().map(|r| r.id()) == Some(tuple_var.id()) && name == "Tuple<u8>")
+    });
 
     // Thread `context` straight through the slots the chain values used:
     // B0→Bp forwards `context` where it forwarded `new_*`, Bp→Bf forwards
@@ -22335,9 +22805,11 @@ fn navigate_single_arg_fmt_chain(
 
     Some(SingleArgFmtChainNav {
         kind,
+        placeholder,
         pieces,
         format_result,
         context,
+        context_is_u8,
         link_rewrites,
         dead_results,
         dead_bases,
@@ -22350,7 +22822,7 @@ fn navigate_single_arg_fmt_chain(
 /// leaves the graph untouched.
 fn collect_fmt_collapse(graph: &FunctionGraph, bf: BlockId, fi: usize) -> Option<FmtCollapse> {
     let nav = navigate_single_arg_fmt_chain(graph, bf, fi)?;
-    if nav.kind != FmtArgKind::Display {
+    if nav.kind != FmtArgKind::Display || !nav.placeholder.is_default() {
         // `str(value)` renders Display; `{:?}` Debug has no native rstr
         // counterpart, so leave a Debug chain to `collapse_debug_enum_fmt_chains`.
         return None;
@@ -22455,6 +22927,127 @@ fn collapse_fmt_chains(graph: &mut FunctionGraph) -> usize {
             continue;
         };
         let expansion = emit_fmt_expansion_ops(graph, &site.pieces, &value, result);
+        graph
+            .block_mut(site.format_block)
+            .operations
+            .splice(idx..idx + 1, expansion);
+    }
+    sites.len()
+}
+
+/// A byte `{:02x}` chain whose Rust formatting shell can be replaced by
+/// PyPy's two-nibble lookup while reusing the common single-argument chain
+/// deletion plan.
+struct LowerHexByteFmtCollapse {
+    format_block: BlockId,
+    format_result: u64,
+    link_rewrites: Vec<(BlockId, usize, usize, Variable)>,
+    dead_results: Vec<u64>,
+    dead_bases: Vec<u64>,
+}
+
+fn collect_lower_hex_byte_fmt_collapse(
+    graph: &FunctionGraph,
+    bf: BlockId,
+    fi: usize,
+) -> Option<LowerHexByteFmtCollapse> {
+    let nav = navigate_single_arg_fmt_chain(graph, bf, fi)?;
+    if nav.kind != FmtArgKind::LowerHex
+        || !nav.placeholder.is_lower_hex_byte_02()
+        || !nav.context_is_u8
+        || nav.pieces != ["\\x".to_string(), String::new()]
+    {
+        return None;
+    }
+    Some(LowerHexByteFmtCollapse {
+        format_block: bf,
+        format_result: nav.format_result.id(),
+        link_rewrites: nav.link_rewrites,
+        dead_results: nav.dead_results,
+        dead_bases: nav.dead_bases,
+    })
+}
+
+/// Replace the exact `format!("\\x{c:02x}")` shell used by the bytearray
+/// repr loop with PyPy's `"0123456789abcdef"[c >> 4]` / `[c & 0xF]`
+/// implementation.  The packed template, `new_lower_hex` ctor, argument tuple
+/// and `alloc::fmt::format` all disappear; only RPython-native integer,
+/// string-getitem and string-concat operations remain.
+fn collapse_lower_hex_byte_fmt_chains(graph: &mut FunctionGraph) -> usize {
+    use crate::model::{CallTarget, LinkArg, OpKind};
+    let sites: Vec<_> = graph
+        .blocks
+        .iter()
+        .flat_map(|block| {
+            block
+                .operations
+                .iter()
+                .enumerate()
+                .filter_map(move |(fi, op)| match &op.kind {
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if fmt_path_ends_with(segments, &["fmt", "format"]) => Some((block.id, fi)),
+                    _ => None,
+                })
+        })
+        .filter_map(|(bid, fi)| collect_lower_hex_byte_fmt_collapse(graph, bid, fi))
+        .collect();
+    if sites.is_empty() {
+        return 0;
+    }
+
+    for site in &sites {
+        for (bid, ei, pos, replacement) in &site.link_rewrites {
+            if let Some(link) = graph.block_mut(*bid).exits.get_mut(*ei)
+                && let Some(arg) = link.args.get_mut(*pos)
+            {
+                *arg = LinkArg::Value(replacement.clone());
+            }
+        }
+    }
+    let dead_results: std::collections::HashSet<u64> = sites
+        .iter()
+        .flat_map(|site| site.dead_results.iter().copied())
+        .collect();
+    let dead_bases: std::collections::HashSet<u64> = sites
+        .iter()
+        .flat_map(|site| site.dead_bases.iter().copied())
+        .collect();
+    for block in &mut graph.blocks {
+        block.operations.retain(|op| {
+            if op
+                .result
+                .as_ref()
+                .is_some_and(|result| dead_results.contains(&result.id()))
+            {
+                return false;
+            }
+            !matches!(&op.kind, OpKind::FieldWrite { base, .. } if dead_bases.contains(&base.id()))
+        });
+    }
+    for site in &sites {
+        let Some((idx, value, result)) = graph
+            .blocks
+            .iter()
+            .find(|block| block.id == site.format_block)
+            .and_then(|block| {
+                let idx = block.operations.iter().position(|op| {
+                    op.result.as_ref().map(|result| result.id()) == Some(site.format_result)
+                })?;
+                let value = match &block.operations[idx].kind {
+                    OpKind::Call { args, .. } => args.first()?.clone(),
+                    _ => return None,
+                };
+                Some((idx, value, block.operations[idx].result.clone()?))
+            })
+        else {
+            continue;
+        };
+        // The original context value was defined in B0.  After link rewrites,
+        // the format op's own argument Variable is Bf's inputarg carrying that
+        // value; use it so every emitted operand is defined in this block.
+        let expansion = emit_lower_hex_byte_02_ops(graph, &value, result);
         graph
             .block_mut(site.format_block)
             .operations
@@ -22906,7 +23499,12 @@ fn collect_fmt_collapse_multi(
     if chain.args.len() < 2 {
         return None; // single-argument chains handled by `collapse_fmt_chains`
     }
-    if chain.args.iter().any(|a| a.kind != FmtArgKind::Display) {
+    if chain.args.iter().any(|a| a.kind != FmtArgKind::Display)
+        || chain
+            .placeholders
+            .iter()
+            .any(|placeholder| !placeholder.is_default())
+    {
         // `{:?}` Debug over an enum has no native rstr render (no
         // `rtype_str` on enum reprs); leave Debug chains residual.
         return None;
@@ -22980,7 +23578,11 @@ fn collect_fmt_collapse_multi(
         args_block,
         arguments_var,
         arg_elem_vars,
-        arg_indices: chain.arg_indices,
+        arg_indices: chain
+            .placeholders
+            .iter()
+            .map(|placeholder| placeholder.arg_index)
+            .collect(),
         pieces,
         new_display_ops,
         format_block: bf,
@@ -23077,7 +23679,18 @@ fn collapse_fmt_chains_multi(graph: &mut FunctionGraph) -> usize {
                     kind: FmtArgKind::Display,
                 })
                 .collect(),
-            arg_indices: site.arg_indices.clone(),
+            placeholders: site
+                .arg_indices
+                .iter()
+                .map(|&arg_index| FmtPlaceholder {
+                    arg_index,
+                    flags: None,
+                    width: None,
+                    precision: None,
+                    width_indirect: false,
+                    precision_indirect: false,
+                })
+                .collect(),
         };
         let folded = emit_fmt_concat(graph, site.args_block, &fold_chain);
         // 4. Re-thread the folded String onto the link that forwarded the
@@ -23242,7 +23855,7 @@ fn collect_debug_enum_fmt_collapse(
     // gate below selects only the `{:?}` renders, and the navigation also
     // supplies the residual-chain delete / re-thread plan the switch needs.
     let nav = navigate_single_arg_fmt_chain(graph, bf, fi)?;
-    if nav.kind != FmtArgKind::Debug {
+    if nav.kind != FmtArgKind::Debug || !nav.placeholder.is_default() {
         return None; // Display is handled by `collapse_fmt_chains`
     }
     // The rendered value is the enum being `Debug`-formatted.
@@ -24337,7 +24950,10 @@ mod tests {
             pieces,
             vec!["stack underflow during ".to_string(), String::new()]
         );
-        assert_eq!(indices, vec![0]);
+        assert_eq!(
+            indices.iter().map(|p| p.arg_index).collect::<Vec<_>>(),
+            vec![0]
+        );
 
         // `format!("{} indices must be integers or slices, not {}", ..)`
         let (pieces, indices) = decode_packed_format_pieces(&[
@@ -24354,7 +24970,10 @@ mod tests {
                 String::new(),
             ]
         );
-        assert_eq!(indices, vec![0, 1]);
+        assert_eq!(
+            indices.iter().map(|p| p.arg_index).collect::<Vec<_>>(),
+            vec![0, 1]
+        );
 
         // `format!("'{}' object does not support item assignment", ..)`
         let (pieces, indices) = decode_packed_format_pieces(&[
@@ -24370,7 +24989,10 @@ mod tests {
                 "' object does not support item assignment".to_string(),
             ]
         );
-        assert_eq!(indices, vec![0]);
+        assert_eq!(
+            indices.iter().map(|p| p.arg_index).collect::<Vec<_>>(),
+            vec![0]
+        );
 
         // `format!("__init__() should return None, not '{}'", ..)`
         let (pieces, indices) = decode_packed_format_pieces(&[
@@ -24386,7 +25008,10 @@ mod tests {
                 "'".to_string(),
             ]
         );
-        assert_eq!(indices, vec![0]);
+        assert_eq!(
+            indices.iter().map(|p| p.arg_index).collect::<Vec<_>>(),
+            vec![0]
+        );
 
         // `format!("can only concatenate {a} (not \"{b}\") to {a}", ..)` —
         // the `add`-operand error tail (descroperation.rs), where the first
@@ -24408,24 +25033,41 @@ mod tests {
                 String::new(),
             ]
         );
-        assert_eq!(indices, vec![0, 1, 0]);
+        assert_eq!(
+            indices.iter().map(|p| p.arg_index).collect::<Vec<_>>(),
+            vec![0, 1, 0]
+        );
 
         // A template naming arguments 1 and 3 explicitly (`0xC8` + u16 index
         // each): three sequential `0xC0` then two explicit reuses.
         let (pieces, indices) =
             decode_packed_format_pieces(&[192, 192, 192, 200, 1, 0, 200, 3, 0, 0]).unwrap();
         assert_eq!(pieces.len(), 6);
-        assert_eq!(indices, vec![0, 1, 2, 1, 3]);
+        assert_eq!(
+            indices.iter().map(|p| p.arg_index).collect::<Vec<_>>(),
+            vec![0, 1, 2, 1, 3]
+        );
     }
 
     #[test]
     fn decode_packed_format_pieces_bails_and_handles_edges() {
         use super::decode_packed_format_pieces;
 
-        // A control byte other than 0xC0 / 0xC8 (e.g. a width/precision
-        // format-spec) must bail so the recognizer leaves the graph alone.
+        // A flags-bearing placeholder truncated before its four-byte flags
+        // field, and the reserved 0x80 long-literal marker without a length,
+        // must bail.
         assert_eq!(decode_packed_format_pieces(&[0xC1, 0]), None);
         assert_eq!(decode_packed_format_pieces(&[0x80, 0]), None);
+
+        // Verbatim `format!("\\x{c:02x}")` template from the production
+        // LLBC.  0xC3 selects flags+width; 0x69000020 is space fill,
+        // sign-aware zero-pad, width-present, unknown alignment.
+        let (pieces, placeholders) =
+            decode_packed_format_pieces(&[2, b'\\', b'x', 0xC3, 0x20, 0, 0, 0x69, 2, 0, 0])
+                .unwrap();
+        assert_eq!(pieces, ["\\x".to_string(), String::new()]);
+        assert_eq!(placeholders.len(), 1);
+        assert!(placeholders[0].is_lower_hex_byte_02());
 
         // A literal length that overruns the buffer bails.
         assert_eq!(decode_packed_format_pieces(&[5, 65, 66, 0]), None);
@@ -24446,13 +25088,16 @@ mod tests {
         // Literal-only template (no placeholders) → single piece, no args.
         let (pieces, indices) = decode_packed_format_pieces(&[2, 104, 105, 0]).unwrap();
         assert_eq!(pieces, vec!["hi".to_string()]);
-        assert_eq!(indices, Vec::<usize>::new());
+        assert!(indices.is_empty());
 
         // Two consecutive literal segments accumulate into one piece
         // (how a >127-byte literal is split); one placeholder follows.
         let (pieces, indices) = decode_packed_format_pieces(&[1, 97, 1, 98, 192, 0]).unwrap();
         assert_eq!(pieces, vec!["ab".to_string(), String::new()]);
-        assert_eq!(indices, vec![0]);
+        assert_eq!(
+            indices.iter().map(|p| p.arg_index).collect::<Vec<_>>(),
+            vec![0]
+        );
     }
 
     #[test]
@@ -24505,7 +25150,10 @@ mod tests {
         assert_eq!(decoded, vec![2, 104, 105, 0xC0, 0]);
         let (pieces, indices) = decode_packed_format_pieces(&decoded).unwrap();
         assert_eq!(pieces, vec!["hi".to_string(), String::new()]);
-        assert_eq!(indices, vec![0]);
+        assert_eq!(
+            indices.iter().map(|p| p.arg_index).collect::<Vec<_>>(),
+            vec![0]
+        );
 
         // A non-Array producer (plain ConstInt) is rejected.
         assert_eq!(read_array_literal_elements(&graph, &elements[0]), None);
@@ -25566,7 +26214,7 @@ mod tests {
 
     #[test]
     fn emit_fmt_concat_builds_interleaved_str_add_fold() {
-        use super::{FmtArg, FmtArgKind, FmtChain, emit_fmt_concat};
+        use super::{FmtArg, FmtArgKind, FmtChain, FmtPlaceholder, emit_fmt_concat};
         use crate::flowspace::model::Variable;
         use crate::model::{CallTarget, FunctionGraph, OpKind};
 
@@ -25587,7 +26235,24 @@ mod tests {
                     kind: FmtArgKind::Display,
                 },
             ],
-            arg_indices: vec![0, 1],
+            placeholders: vec![
+                FmtPlaceholder {
+                    arg_index: 0,
+                    flags: None,
+                    width: None,
+                    precision: None,
+                    width_indirect: false,
+                    precision_indirect: false,
+                },
+                FmtPlaceholder {
+                    arg_index: 1,
+                    flags: None,
+                    width: None,
+                    precision: None,
+                    width_indirect: false,
+                    precision_indirect: false,
+                },
+            ],
         };
         let result = emit_fmt_concat(&mut graph, bb, &chain);
 
@@ -27609,7 +28274,10 @@ mod tests {
         bytes.push(0x00); // terminator
         let (pieces, indices) = decode_packed_format_pieces(&bytes).unwrap();
         assert_eq!(pieces, vec!["ab".to_string(), tail.to_string()]);
-        assert_eq!(indices, vec![0]);
+        assert_eq!(
+            indices.iter().map(|p| p.arg_index).collect::<Vec<_>>(),
+            vec![0]
+        );
 
         // A long-literal marker whose declared length overruns the buffer
         // bails (no OOB, fail-safe residual).
@@ -29107,6 +29775,217 @@ mod tests {
                 .any(|op| matches!(&op.kind, OpKind::BinOp { op, .. } if op == "le")),
             "{name}: RangeFrom get must guard start <= len"
         );
+    }
+
+    /// RPython `AbstractStringBuilderRepr.rtype_method_append` accepts both a
+    /// whole string and `SomeChar`.  `bytearray_repr_string` mixes
+    /// `String::push_str` and `String::push(char)` in one loop, so omitting the
+    /// char arm prevents the whole fresh accumulator from lifting.
+    #[test]
+    #[ignore]
+    fn bytearray_repr_mixed_string_appends_lift_to_rpython_builder() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "bytearray_repr_string")
+            .expect("lower bytearray_repr_string");
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.last().is_some_and(|leaf| leaf == "push" || leaf == "push_str"))
+            }),
+            "String::push/push_str must not survive the RPython builder lift"
+        );
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.iter().any(|segment| segment == "fmt")
+                        || segments.last().is_some_and(|leaf| leaf == "new_lower_hex"))
+            }),
+            "Rust fmt shell must collapse to PyPy's two-nibble lookup"
+        );
+        for opname in ["rshift", "and"] {
+            assert!(
+                graph
+                    .blocks
+                    .iter()
+                    .flat_map(|b| &b.operations)
+                    .any(|op| { matches!(&op.kind, OpKind::BinOp { op, .. } if op == opname) }),
+                "missing PyPy byte-hex operation {opname}"
+            );
+        }
+        for marker in [
+            "__majit_stringbuilder_new",
+            "__majit_stringbuilder_append",
+            "__majit_stringbuilder_build",
+        ] {
+            assert!(
+                graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                    matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if segments == &[marker])
+                }),
+                "missing builder marker {marker}"
+            );
+        }
+        for block in &graph.blocks {
+            let mut defined: std::collections::HashSet<u64> =
+                block.inputargs.iter().map(|var| var.id()).collect();
+            for op in &block.operations {
+                for operand in crate::inline::op_variable_refs(&op.kind) {
+                    assert!(
+                        defined.contains(&operand.id()),
+                        "block {:?} uses undefined operand {:?} in {:?}",
+                        block.id,
+                        operand,
+                        op.kind
+                    );
+                }
+                if let Some(result) = &op.result {
+                    defined.insert(result.id());
+                }
+            }
+        }
+    }
+
+    /// PyPy's `bytesobject.py::string_escape_encode` is an ordinary
+    /// StringBuilder loop.  The interpreter now carries that loop directly,
+    /// so the frozen production LLBC must lower without the former external
+    /// `rustpython_literal::escape::AsciiEscape` iterator.
+    #[test]
+    #[ignore]
+    fn bytes_repr_lifts_without_external_ascii_escape() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph =
+            super::lower_function(&llbc, "bytes_repr_string").expect("lower bytes_repr_string");
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.iter().any(|segment| segment == "AsciiEscape"))
+            }),
+            "external AsciiEscape must not survive the PyPy loop port"
+        );
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.last().is_some_and(|segment| segment == "HEX"))
+            }),
+            "the borrowed HEX table must be a prebuilt constant, not an accessor call"
+        );
+        for marker in [
+            "__majit_stringbuilder_new",
+            "__majit_stringbuilder_append",
+            "__majit_stringbuilder_build",
+        ] {
+            assert!(
+                graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                    matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if segments == &[marker])
+                }),
+                "missing builder marker {marker}"
+            );
+        }
+    }
+
+    /// PyPy's `unicodeobject.py::_repr_function` is the ordinary
+    /// `rutf8.make_utf8_escape_function(pass_printable=True, quotes=True)`
+    /// StringBuilder loop.  The production graph must retain that loop and
+    /// its prebuilt lowercase-hex table without the former RustPython escape
+    /// iterator or a named-const accessor.
+    #[test]
+    #[ignore]
+    fn unicode_repr_lifts_without_external_unicode_escape() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph =
+            super::lower_function(&llbc, "format_wtf8_repr").expect("lower format_wtf8_repr");
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.iter().any(|segment| segment == "UnicodeEscape"))
+            }),
+            "external UnicodeEscape must not survive the PyPy loop port"
+        );
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.last().is_some_and(|segment| segment == "HEX"))
+            }),
+            "the borrowed HEX table must be a prebuilt constant, not an accessor call"
+        );
+        for marker in [
+            "__majit_stringbuilder_new",
+            "__majit_stringbuilder_append",
+            "__majit_stringbuilder_build",
+        ] {
+            assert!(
+                graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                    matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if segments == &[marker])
+                }),
+                "missing builder marker {marker}"
+            );
+        }
+    }
+
+    /// Every local UTF-8 accumulator in PyPy's repr helpers is a
+    /// `StringBuilder`; the large `py_repr_wtf8` dispatcher must therefore
+    /// eliminate the Rust `Wtf8Buf` mutation shell as well as the smaller
+    /// leaf helpers do.
+    #[test]
+    #[ignore]
+    fn py_repr_wtf8_lifts_owned_wtf8buf_appends() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "py_repr_wtf8").expect("lower py_repr_wtf8");
+        let residual: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| {
+                block.operations.iter().filter_map(move |op| {
+                    matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if segments == &["Wtf8Buf", "push_wtf8"])
+                    .then_some((block.id, op))
+                })
+            })
+            .collect();
+        assert!(
+            residual.is_empty(),
+            "owned Wtf8Buf appends must lift to StringBuilder operations: {residual:#?}"
+        );
+        for block in &graph.blocks {
+            let mut defined: std::collections::HashSet<u64> =
+                block.inputargs.iter().map(|var| var.id()).collect();
+            for op in &block.operations {
+                for operand in crate::inline::op_variable_refs(&op.kind) {
+                    assert!(
+                        defined.contains(&operand.id()),
+                        "block {:?} uses undefined operand {:?} in {:?}",
+                        block.id,
+                        operand,
+                        op.kind
+                    );
+                }
+                if let Some(result) = &op.result {
+                    defined.insert(result.id());
+                }
+            }
+        }
     }
 
     /// PyPy's `_match_keywords` indexes its small signature and argument

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4641,6 +4641,18 @@ impl<'a> Lowering<'a> {
                     // to the recorded Variable for a constant operand.
                     let arr = self.realias_operand(alias.base_local, alias.base_var);
                     let idx = self.realias_operand(alias.index_local, alias.index_var);
+                    let arr = if matches!(alias.array_type_id.as_deref(), Some("[i64]" | "[f64]")) {
+                        self.narrow_value_to_instance_root(
+                            bb_id,
+                            LinkArg::Value(arr),
+                            alias.array_type_id.as_deref().expect("matched Some above"),
+                        )
+                        .as_variable()
+                        .expect("a materialized typed-items base stays a Variable")
+                        .clone()
+                    } else {
+                        arr
+                    };
                     OpKind::ArrayWrite {
                         base: arr,
                         index: idx,
@@ -8393,6 +8405,60 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // Scalar twin of the object-items arm above:
+                // `*typed_items_block_items_base(block).cast::<i64|f64>()
+                // .add(idx)` is RPython's getarrayitem on
+                // `GcArray(Signed|Float)`. The accessor has already collapsed
+                // its interior pointer to the block header, so use the typed
+                // array identity to restore both header offset and item bank.
+                // The shared escape gate proves the `.add` result is consumed
+                // by exactly one dereference and never used as a raw pointer.
+                if let Some((item_ty, array_type_id)) = self.typed_items_elem_ptr_add(
+                    &reg,
+                    args.len(),
+                    &arg_locals,
+                    first_arg_ty.as_ref(),
+                    dest_local,
+                ) {
+                    let base = self
+                        .narrow_value_to_instance_root(
+                            bb_id,
+                            LinkArg::Value(args[0].clone()),
+                            &array_type_id,
+                        )
+                        .as_variable()
+                        .expect("a materialized typed-items base stays a Variable")
+                        .clone();
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::ArrayRead {
+                            base: base.clone(),
+                            index: args[1].clone(),
+                            item_ty,
+                            array_type_id: Some(array_type_id.clone()),
+                            nolength: false,
+                            pure: false,
+                        },
+                    });
+                    self.index_elem_alias.insert(
+                        dest_local,
+                        IndexElemAlias {
+                            base_local: arg_locals.first().copied().flatten(),
+                            base_var: base,
+                            index_local: arg_locals.get(1).copied().flatten(),
+                            index_var: args[1].clone(),
+                            array_type_id: Some(array_type_id),
+                        },
+                    );
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // `FixedObjectArray::set_ref(self, index, value)` — the
                 // length-prefixed array's GC-published element store.  The
                 // method body hand-rolls the write-barrier dance
@@ -10878,13 +10944,15 @@ impl<'a> Lowering<'a> {
         {
             self.unwrap_or_sites.push(site);
         }
-        // Capture `Option::unwrap(opt)` sites for the discriminant guard
-        // `front::option_unwrap` synthesizes.  Like `unwrap_or`, `unwrap`'s body
-        // is Opaque (foreign `core`) and its receiver is the `Option` ADT, so
-        // `first_is_self` routes it to a `CallTarget::Method` (receiver in
-        // `args[0]`, the sole argument).  `recognize_unwrap_site` confirms the
-        // receiver is an `Option` (not `Result`).  A resolution miss leaves the
-        // residual call — an unregistered callee the rtyper census Skips.
+        // Capture `Option::unwrap(opt)` / plain-error `Result::unwrap(res)`
+        // sites for the discriminant guard `front::option_unwrap` synthesizes.
+        // Like `unwrap_or`, `unwrap`'s body is Opaque (foreign `core`) and its
+        // receiver is the enum ADT, so `first_is_self` routes it to a
+        // `CallTarget::Method` (receiver in `args[0]`, the sole argument).
+        // `recognize_unwrap_site` records the payload-tag polarity and excludes
+        // the exception carrier Result owned by `front::result_exc`. A
+        // resolution miss leaves the residual call — an unregistered callee
+        // the rtyper census Skips.
         if let OpKind::Call {
             target: CallTarget::Method { name, .. },
             args,
@@ -11862,6 +11930,34 @@ impl<'a> Lowering<'a> {
             self.body,
             self.llbc,
         )
+    }
+
+    /// Scalar `GcArray(Signed|Float)` counterpart of
+    /// [`Self::is_list_items_elem_ptr_add`]. Returns the RPython item bank and
+    /// ARRAY identity when the pointer traces to
+    /// `typed_items_block_items_base`, names an `i64`/`f64` element, and is
+    /// consumed by one immediate dereference.
+    fn typed_items_elem_ptr_add(
+        &self,
+        reg: &RegularCall,
+        args_len: usize,
+        arg_locals: &[Option<usize>],
+        first_arg_ty: Option<&TyRef>,
+        dest_local: usize,
+    ) -> Option<(ValueType, String)> {
+        if !is_typed_items_elem_ptr_add_parts(
+            reg,
+            args_len,
+            arg_locals.first().copied().flatten(),
+            first_arg_ty,
+            arg_locals.get(1).copied().flatten(),
+            dest_local,
+            self.body,
+            self.llbc,
+        ) {
+            return None;
+        }
+        raw_ptr_typed_items_element(first_arg_ty?, self.llbc)
     }
 
     /// `<*const T>::cast_mut` / `<*mut T>::cast_const` — pointer casts that
@@ -13601,30 +13697,56 @@ impl<'a> Lowering<'a> {
         })
     }
 
-    /// Resolve a recognized `Option::unwrap(opt)` call into an
-    /// [`crate::front::option_unwrap::UnwrapSite`] — the `Option` enum root +
-    /// `Some` variant owners and the payload type the discriminant-guard
-    /// post-pass needs.  `None` (leaving the residual call) when the receiver
-    /// type is not a resolvable `Option`.  Guards on `Option` specifically —
-    /// `Result::unwrap` shares the method name but its `Ok`/`Err` tags do not
-    /// match `Some`=1/`None`=0.
+    /// Resolve a recognized `Option::unwrap(opt)` / plain-error
+    /// `Result::unwrap(res)` call into an
+    /// [`crate::front::option_unwrap::UnwrapSite`] — the enum root, payload
+    /// variant owner, payload type, and discriminant polarity the guard
+    /// post-pass needs. `Result<T, PyError>` remains the exception transform's
+    /// domain and is deliberately excluded. `None` leaves the residual call.
     fn recognize_unwrap_site(
         &self,
         recv_ty: Option<&TyRef>,
         result_var: &Variable,
     ) -> Option<crate::front::option_unwrap::UnwrapSite> {
         let recv_ty = recv_ty?;
-        if !crate::front::result_exc::tyref_is_option(recv_ty, self.llbc) {
+        let is_option = crate::front::result_exc::tyref_is_option(recv_ty, self.llbc);
+        let (enum_owner, payload_owner, payload_on_disc_true, niche) = if is_option {
+            let (option_owner, some_owner, _) = self.resolve_option_consumer_owners(recv_ty)?;
+            (
+                option_owner,
+                some_owner,
+                true,
+                self.tyref_is_niche_option_ptr(recv_ty),
+            )
+        } else if crate::front::result_exc::tyref_is_result(recv_ty, self.llbc)
+            && !crate::front::result_exc::tyref_is_result_of_carrier(
+                recv_ty,
+                self.llbc,
+                self.static_addrs.error_carrier,
+            )
+        {
+            let def_id = self.tyref_adt_def_id(recv_ty)?;
+            let td = self.llbc.type_by_id(def_id)?;
+            // Match the per-instantiation owner minted by checked conversion
+            // producers (`Result<usize, TryFromIntError>`, etc.). A bare
+            // Result root would split the producer and consumer classdefs.
+            let enum_owner = format!(
+                "{}{}",
+                td.item_meta.name_path(),
+                tyref_enum_instantiation_suffix(recv_ty, self.llbc)
+            );
+            let payload_owner = Self::tagged_pair_payload_owner(td, &enum_owner, 0)?;
+            (enum_owner, payload_owner, false, false)
+        } else {
             return None;
-        }
-        let (option_owner, some_owner, payload_ty) =
-            self.resolve_option_consumer_owners(recv_ty)?;
-        let niche = self.tyref_is_niche_option_ptr(recv_ty);
+        };
+        let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
         Some(crate::front::option_unwrap::UnwrapSite {
             result_var: result_var.clone(),
-            option_owner,
-            some_owner,
+            enum_owner,
+            payload_owner,
             payload_ty,
+            payload_on_disc_true,
             niche,
         })
     }
@@ -14852,7 +14974,10 @@ impl<'a> Lowering<'a> {
         Ok(true)
     }
 
-    /// Lower the infallible `usize::try_from(<u8|u16|u32>)`
+    /// Lower Rust's checked integer-to-`usize` shell to the same primitive
+    /// comparisons and cast operations RPython emits for integer reprs.
+    ///
+    /// The infallible `usize::try_from(<u8|u16|u32>)`
     /// (`core::convert::num::ptr_try_from_impls::<Impl>::try_from`,
     /// Opaque in the LLBC like every core fn) to its decomposed
     /// always-`Ok` shape: `__discriminant = 0` (`Result`'s `Ok` tag)
@@ -14863,10 +14988,14 @@ impl<'a> Lowering<'a> {
     /// (`pyopcode.rs` `u32_as_usize` / `raise_kind_as_usize`), whose
     /// `Err` arm is statically dead for the `U8`/`U16`/`U32` sources
     /// filtered on below — narrower than `usize` on every target pyre
-    /// builds for, wasm32 included.  Impls with word-sized-or-wider
-    /// inputs — the genuinely fallible directions of the same impl
-    /// group — keep the `Call` form, so this filter must not be
-    /// widened to `U64` on the strength of the host being 64-bit.
+    /// builds for, wasm32 included.  A same-width signed source (`isize`, or
+    /// `i64` in a 64-bit LLBC corpus) is fallible only for negative values.
+    /// Preserve Rust's observable `Result` branch as a runtime tag and cast
+    /// its success payload with RPython's `cast_int_to_uint` spelling
+    /// (`rint.py:200-205`).  The cast is total and may run eagerly on the Err
+    /// arm because that payload is dead there.  Fixed-width `i64` is admitted
+    /// only when Charon's target metadata proves an eight-byte pointer; wider
+    /// signed sources on a narrower target remain fail-closed.
     #[expect(
         clippy::too_many_arguments,
         reason = "The parameter order mirrors the corresponding RPython translation routine; grouping arguments into a Rust-only context object would obscure line-by-line parity and ownership"
@@ -14903,10 +15032,22 @@ impl<'a> Lowering<'a> {
         let Some(src) = fd.signature.inputs.first() else {
             return Ok(false);
         };
-        if !matches!(
+        let src_is_small_uint = matches!(
             self.tyref_literal_uint_atom(src),
             Some("U8" | "U16" | "U32")
-        ) {
+        );
+        let src_is_signed_word = match self.tyref_literal_int_atom(src) {
+            Some("Isize") => true,
+            Some("I64") => self.llbc.target_pointer_size() == Some(8),
+            _ => false,
+        };
+        if !src_is_small_uint && !src_is_signed_word {
+            return Ok(false);
+        }
+        let Some(success_ty) = self.tyref_adt_type_arg(dest_ty, 0) else {
+            return Ok(false);
+        };
+        if self.tyref_literal_uint_atom(&success_ty) != Some("Usize") {
             return Ok(false);
         }
         let Some(def_id) = self.tyref_adt_def_id(dest_ty) else {
@@ -14926,6 +15067,56 @@ impl<'a> Lowering<'a> {
             tyref_enum_instantiation_suffix(dest_ty, self.llbc)
         );
         let arg = arg.clone();
+        if src_is_signed_word {
+            let bb_id = self.block_id[mir_bb];
+            let push_op = |graph: &mut FunctionGraph, kind: OpKind| {
+                let result = graph.alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                graph.block_mut(bb_id).operations.push(SpaceOperation {
+                    result: Some(result.clone()),
+                    kind,
+                });
+                result
+            };
+            let zero = push_op(&mut self.graph, OpKind::ConstInt(0));
+            // Result convention: Ok=0, Err=1.  For equal-width signed →
+            // unsigned conversion the sign test is the complete overflow
+            // predicate.
+            let disc = push_op(
+                &mut self.graph,
+                OpKind::BinOp {
+                    op: "lt".to_string(),
+                    lhs: arg.clone(),
+                    rhs: zero,
+                    result_ty: ValueType::Int,
+                },
+            );
+            let payload = push_op(
+                &mut self.graph,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: ["rpython", "rlib", "rarithmetic", "r_uint"]
+                            .into_iter()
+                            .map(str::to_string)
+                            .collect(),
+                    },
+                    args: vec![arg],
+                    result_ty: ValueType::Unsigned,
+                },
+            );
+            let payload_owner =
+                Self::tagged_pair_payload_owner(td, &owner, 0).unwrap_or_else(|| owner.clone());
+            self.emit_tagged_pair_aggregate_typed(
+                mir_bb,
+                &owner,
+                &payload_owner,
+                disc,
+                payload,
+                ValueType::Unsigned,
+                dest_local,
+                target,
+            )?;
+            return Ok(true);
+        }
         if self.multi_assigned_locals.contains(&dest_local) {
             // A re-bindable local may later carry a runtime `Result`,
             // so the constant tag can't be recorded and consumers
@@ -16973,6 +17164,17 @@ fn regular_call_is_items_block_accessor(reg: &RegularCall, llbc: &Llbc) -> bool 
         .is_some_and(|fd| is_object_items_block_base_accessor(fd.item_meta.name_path().as_str()))
 }
 
+/// The scalar `TypedItemsBlock` accessor, kept separate from the object-array
+/// pair because its consumers must emit `GcArray(Signed|Float)` operations,
+/// never reference-array operations.
+fn regular_call_is_typed_items_block_accessor(reg: &RegularCall, llbc: &Llbc) -> bool {
+    let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+        return false;
+    };
+    llbc.fn_by_id(*id)
+        .is_some_and(|fd| is_typed_items_block_base_accessor(fd.item_meta.name_path().as_str()))
+}
+
 /// The [`TyRef`] of a plain-place [`Operand`], or `None` for a
 /// constant.  The borrow tracks the operand, so callers reading a
 /// receiver type from a raw `CallPayload` (the deferred-write liveness
@@ -17009,6 +17211,29 @@ fn is_list_items_elem_ptr_add_parts(
         && add_dest_used_only_as_single_deref(body, dest_local)
 }
 
+/// Scalar half of brick 3. The physical `TypedItemsBlock` stores only the two
+/// RPython array families declared by `rlist.rs`: `GcArray(Signed)` (`i64`)
+/// and `GcArray(Float)` (`f64`). Other raw-pointer pointees remain residual.
+#[allow(clippy::too_many_arguments)]
+fn is_typed_items_elem_ptr_add_parts(
+    reg: &RegularCall,
+    args_len: usize,
+    base_local: Option<usize>,
+    base_ty: Option<&TyRef>,
+    index_local: Option<usize>,
+    dest_local: usize,
+    body: &Unstructured,
+    llbc: &Llbc,
+) -> bool {
+    args_len == 2
+        && regular_call_is_ptr_add(reg, llbc)
+        && base_ty.is_some_and(|ty| raw_ptr_typed_items_element(ty, llbc).is_some())
+        && index_local.is_some()
+        && base_local
+            .is_some_and(|base| base_traces_to_typed_items_block_accessor(body, base, llbc))
+        && add_dest_used_only_as_single_deref(body, dest_local)
+}
+
 /// Whether MIR local `base` — the receiver of a `*base.add(idx)` over
 /// `*mut PyObjectRef` — traces, through plain `Copy` / `Move` aliases,
 /// to the result of an `items_block_items_base` / `items_block_items_ptr`
@@ -17022,6 +17247,33 @@ fn is_list_items_elem_ptr_add_parts(
 /// `add` and falls to the legacy walker.  A multiply-defined or
 /// non-`Copy`-produced local is ambiguous and rejected.
 fn base_traces_to_items_block_accessor(body: &Unstructured, base: usize, llbc: &Llbc) -> bool {
+    base_traces_to_items_block_accessor_matching(
+        body,
+        base,
+        llbc,
+        regular_call_is_items_block_accessor,
+    )
+}
+
+fn base_traces_to_typed_items_block_accessor(
+    body: &Unstructured,
+    base: usize,
+    llbc: &Llbc,
+) -> bool {
+    base_traces_to_items_block_accessor_matching(
+        body,
+        base,
+        llbc,
+        regular_call_is_typed_items_block_accessor,
+    )
+}
+
+fn base_traces_to_items_block_accessor_matching(
+    body: &Unstructured,
+    base: usize,
+    llbc: &Llbc,
+    matches_accessor: fn(&RegularCall, &Llbc) -> bool,
+) -> bool {
     let mut cur = base;
     for _ in 0..32 {
         let mut producers = 0usize;
@@ -17030,11 +17282,46 @@ fn base_traces_to_items_block_accessor(body: &Unstructured, base: usize, llbc: &
         for bb in &body.body {
             for stmt in &bb.statements {
                 if let Ok(StmtKind::Assign(place, rvalue)) = stmt.stmt_kind()
-                    && matches!(place.kind, PlaceKind::Local(i) if i as usize == cur)
+                    && matches!(&place.kind, PlaceKind::Local(i) if *i as usize == cur)
                 {
                     producers += 1;
-                    if let Rvalue::Use(op) = &rvalue {
-                        copy_src = operand_local(Some(op));
+                    match &rvalue {
+                        Rvalue::Use(op) => copy_src = operand_local(Some(op)),
+                        // `typed_items_block_items_base(..) as *const i64`
+                        // changes only the raw-pointer pointee spelling. The
+                        // address is identical, so follow it exactly as
+                        // RPython follows `cast_pointer` while retaining the
+                        // final pointee type for the array descr.
+                        Rvalue::Cast(_, op, target_ty)
+                            if tyref_node(target_ty, llbc)
+                                .and_then(|node| type_node_raw_ptr_pointee(node, llbc))
+                                .is_some()
+                                && operand_tyref(op).is_some_and(|source_ty| {
+                                    tyref_node(source_ty, llbc)
+                                        .and_then(|node| type_node_raw_ptr_pointee(node, llbc))
+                                        .is_some()
+                                }) =>
+                        {
+                            copy_src = operand_local(Some(op));
+                        }
+                        // Charon also serializes raw pointer casts through its
+                        // older `UnaryOp({Cast: RawPtr(..)}, operand)` form.
+                        // It is the same address-preserving cast as the
+                        // dedicated `Rvalue::Cast` arm above.
+                        Rvalue::UnaryOp(kind, op)
+                            if unary_op_is_cast(kind)
+                                && tyref_node(&place.ty, llbc)
+                                    .and_then(|node| type_node_raw_ptr_pointee(node, llbc))
+                                    .is_some()
+                                && operand_tyref(op).is_some_and(|source_ty| {
+                                    tyref_node(source_ty, llbc)
+                                        .and_then(|node| type_node_raw_ptr_pointee(node, llbc))
+                                        .is_some()
+                                }) =>
+                        {
+                            copy_src = operand_local(Some(op));
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -17043,7 +17330,7 @@ fn base_traces_to_items_block_accessor(body: &Unstructured, base: usize, llbc: &
             {
                 producers += 1;
                 if let CallFunc::Regular(reg) = &call.func
-                    && regular_call_is_items_block_accessor(reg, llbc)
+                    && matches_accessor(reg, llbc)
                 {
                     is_accessor = true;
                 }
@@ -17288,6 +17575,16 @@ fn compute_index_write_extra_live(body: &Unstructured, llbc: &Llbc) -> Vec<Vec<u
             || (is_vec_index_mut_regular(reg, llbc)
                 && add_dest_used_only_as_single_deref(body, p as usize))
             || is_list_items_elem_ptr_add_parts(
+                reg,
+                call.args.len(),
+                operand_local(call.args.first()),
+                call.args.first().and_then(operand_tyref),
+                operand_local(call.args.get(1)),
+                p as usize,
+                body,
+                llbc,
+            )
+            || is_typed_items_elem_ptr_add_parts(
                 reg,
                 call.args.len(),
                 operand_local(call.args.first()),
@@ -19725,6 +20022,21 @@ fn is_object_ref_items_ptr(ty: &TyRef, llbc: &Llbc) -> bool {
     raw_ptr_pointee_class_root(inner, llbc).is_some()
 }
 
+/// RPython item bank and ARRAY identity carried by a raw pointer into a
+/// `TypedItemsBlock`. That block is exactly `GcArray(Signed)` or
+/// `GcArray(Float)`, so admit only the two source spellings its runtime layout
+/// documents; the ARRAY name supplies the 8-byte stride and header offset.
+fn raw_ptr_typed_items_element(ty: &TyRef, llbc: &Llbc) -> Option<(ValueType, String)> {
+    let pointee = type_node_raw_ptr_pointee(tyref_node(ty, llbc)?, llbc)?;
+    let spelling = json_ty_scalar_element_spelling(pointee, llbc)?;
+    if !matches!(spelling.as_str(), "i64" | "f64") {
+        return None;
+    }
+    let pointee = strip_ty_indirections(pointee, llbc)?;
+    let item_ty = tyref_to_value_type(&TyRef::Other(pointee.clone()), llbc);
+    Some((item_ty, format!("[{spelling}]")))
+}
+
 /// The `__cast_pointer/<Root>` marker call — front::mir's carrier for
 /// the upstream `cast_pointer(PTRTYPE, ptr)` op (lltype.py).  The
 /// target class travels in the path (same `Vec<Variable>`-carrier
@@ -21696,6 +22008,10 @@ fn is_object_items_block_base_accessor(name: &str) -> bool {
         || path_ends_with_segments(name, "object_array::items_block_items_ptr")
 }
 
+fn is_typed_items_block_base_accessor(name: &str) -> bool {
+    path_ends_with_segments(name, "rlist::typed_items_block_items_base")
+}
+
 /// True for the `ItemsBlock` / `TypedItemsBlock` items-base accessor bodies
 /// whose `.add(*_ITEMS_OFFSET)` the front-end collapses to the
 /// receiver (see [`Lowering::is_items_block_base_ptr_add`]).
@@ -21708,8 +22024,7 @@ fn is_object_items_block_base_accessor(name: &str) -> bool {
 /// — the element side is refused by [`is_object_ref_items_ptr`] as well, so the
 /// two gates agree by construction rather than by coincidence.
 fn graph_is_items_block_base_accessor(name: &str) -> bool {
-    is_object_items_block_base_accessor(name)
-        || path_ends_with_segments(name, "rlist::typed_items_block_items_base")
+    is_object_items_block_base_accessor(name) || is_typed_items_block_base_accessor(name)
 }
 
 /// One path segment, with a raw-identifier prefix removed.  `r#struct` and
@@ -25754,12 +26069,10 @@ mod tests {
 
     /// brick 1 collapses an accessor to its receiver — the block header — and
     /// only brick 3's `base_size`-bearing array descr adds the item offset
-    /// back. So every REFERENCE accessor brick 1 rewrites must also be one
-    /// brick 3 recognises, or the residual `.add` strides from the length
-    /// word. The typed accessor is the deliberate exception: brick 1 collapses
-    /// it, and its scalar element is refused on the element side instead
-    /// (`is_object_ref_items_ptr`), so no `Ref`-typed array op is minted for a
-    /// `u64` block.
+    /// back. Every accessor brick 1 rewrites must therefore have a matching
+    /// brick-3 family: object accessors use `GcArray(OBJECTPTR)`, while the
+    /// typed accessor is deliberately excluded from that predicate and uses
+    /// the separate `GcArray(Signed|Float)` gate.
     #[test]
     fn the_two_bricks_agree_on_every_reference_items_base_accessor() {
         use super::{graph_is_items_block_base_accessor, is_object_items_block_base_accessor};
@@ -25776,7 +26089,8 @@ mod tests {
             assert!(graph_is_items_block_base_accessor(name));
         }
 
-        // The typed block: brick 1 only.
+        // The typed block is not an object-array accessor; its own brick-3
+        // gate supplies the scalar array operation.
         let typed = "majit_rlib::lltypesystem::rlist::typed_items_block_items_base";
         assert!(graph_is_items_block_base_accessor(typed));
         assert!(!is_object_items_block_base_accessor(typed));
@@ -30200,6 +30514,79 @@ mod tests {
             program.struct_ids.get(frame_owner).copied().flatten(),
             Some(pyframe_ids[0]),
             "the retained owner spelling must resolve to the frame's StructId"
+        );
+    }
+
+    /// `range_list_length` stores the PyPy strategy length in an RPython
+    /// Signed cell and converts it to Rust's indexing carrier.  The opaque
+    /// core `TryFrom` shell must be decomposed by the MIR front rather than
+    /// surviving as a residual foreign call that blocks the whole list
+    /// strategy closure.
+    #[test]
+    #[ignore]
+    fn range_list_length_lowers_signed_to_usize_try_from() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real object LLBC");
+        let source = super::lower_function(&llbc, "pyre_object::listobject::range_state_value")
+            .expect("lower listobject::range_state_value");
+        assert!(
+            source
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| matches!(
+                    &op.kind,
+                    OpKind::ArrayRead {
+                        item_ty: ValueType::Int,
+                        array_type_id: Some(array_type_id),
+                        ..
+                    } if array_type_id == "[i64]"
+                )),
+            "TypedItemsBlock i64 dereference must be a GcArray(Signed) read"
+        );
+        let graph = super::lower_function(&llbc, "pyre_object::listobject::range_list_length")
+            .expect("lower listobject::range_list_length");
+        let residuals: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if segments
+                    .iter()
+                    .any(|segment| segment == "ptr_try_from_impls") =>
+                {
+                    Some(segments.join("::"))
+                }
+                _ => None,
+            })
+            .collect();
+        assert!(
+            residuals.is_empty(),
+            "signed-to-usize conversion must not leave an opaque core call: {residuals:?}"
+        );
+        let unwrap_residuals = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::Method { name, .. },
+                        ..
+                    } if name == "unwrap"
+                )
+            })
+            .count();
+        assert_eq!(
+            unwrap_residuals, 0,
+            "checked conversion Result::unwrap must become a discriminant guard"
         );
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -6566,6 +6566,7 @@ impl<'a> Lowering<'a> {
                 let op = self
                     .static_addr_op(&segments)
                     .or_else(|| self.static_int_value_op(&segments))
+                    .or_else(|| known_array_layout_const(&segments))
                     .or_else(|| self.const_eval_global(id))
                     .or_else(|| self.fold_size_const_global(id))
                     .or_else(|| self.fold_named_const_int_array_global(id))
@@ -11791,7 +11792,9 @@ impl<'a> Lowering<'a> {
     /// descr-based consumption is safe to alias to its receiver.
     fn is_items_block_base_ptr_add(&self, reg: &RegularCall) -> bool {
         graph_is_items_block_base_accessor(&self.graph.name)
-            && regular_call_is_ptr_add(reg, self.llbc)
+            && (regular_call_is_ptr_add(reg, self.llbc)
+                || (is_typed_array_base_adapter(&self.graph.name)
+                    && regular_call_is_ptr_wrapping_add(reg, self.llbc)))
     }
 
     /// `slice::from_raw_parts{,_mut}` inside a container's items-view adapter:
@@ -17143,6 +17146,25 @@ fn regular_call_is_ptr_add(reg: &RegularCall, llbc: &Llbc) -> bool {
     })
 }
 
+/// The wrapping twin used only by `IntArray::base` / `FloatArray::base`.
+/// Their null storage form deliberately computes an aligned, non-null address
+/// for Rust's zero-length slice contract, while every live element access has
+/// first installed a real `TypedItemsBlock`.  In the translated graph that
+/// live path is RPython's `l.items` GcArray header, just like the direct
+/// `typed_items_block_items_base` accessor.
+fn regular_call_is_ptr_wrapping_add(reg: &RegularCall, llbc: &Llbc) -> bool {
+    let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+        return false;
+    };
+    llbc.fn_by_id(*id).is_some_and(|fd| {
+        matches!(
+            fd.item_meta.name_path().as_str(),
+            "core::ptr::mut_ptr::<Impl>::wrapping_add"
+                | "core::ptr::const_ptr::<Impl>::wrapping_add"
+        )
+    })
+}
+
 /// Whether a statically-resolved [`RegularCall`] is one of the two
 /// `ItemsBlock` items-base accessors brick 1 rewrites to return the
 /// block *header* pointer (`items_block_items_base` /
@@ -17171,8 +17193,10 @@ fn regular_call_is_typed_items_block_accessor(reg: &RegularCall, llbc: &Llbc) ->
     let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
         return false;
     };
-    llbc.fn_by_id(*id)
-        .is_some_and(|fd| is_typed_items_block_base_accessor(fd.item_meta.name_path().as_str()))
+    llbc.fn_by_id(*id).is_some_and(|fd| {
+        let name = fd.item_meta.name_path();
+        is_typed_items_block_base_accessor(&name) || is_typed_array_base_adapter(&name)
+    })
 }
 
 /// The [`TyRef`] of a plain-place [`Operand`], or `None` for a
@@ -22012,6 +22036,15 @@ fn is_typed_items_block_base_accessor(name: &str) -> bool {
     path_ends_with_segments(name, "rlist::typed_items_block_items_base")
 }
 
+/// Scalar storage adapters for PyPy's `GcArray(Signed|Float)` list items.
+/// These spell the physical header offset locally because their empty Rust
+/// arrays need a non-null zero-length-slice address; for every live element
+/// access the block is non-null and the translated value is still `l.items`.
+fn is_typed_array_base_adapter(name: &str) -> bool {
+    path_ends_with_segments(name, "int_array::<Impl>::base")
+        || path_ends_with_segments(name, "float_array::<Impl>::base")
+}
+
 /// True for the `ItemsBlock` / `TypedItemsBlock` items-base accessor bodies
 /// whose `.add(*_ITEMS_OFFSET)` the front-end collapses to the
 /// receiver (see [`Lowering::is_items_block_base_ptr_add`]).
@@ -22024,7 +22057,9 @@ fn is_typed_items_block_base_accessor(name: &str) -> bool {
 /// — the element side is refused by [`is_object_ref_items_ptr`] as well, so the
 /// two gates agree by construction rather than by coincidence.
 fn graph_is_items_block_base_accessor(name: &str) -> bool {
-    is_object_items_block_base_accessor(name) || is_typed_items_block_base_accessor(name)
+    is_object_items_block_base_accessor(name)
+        || is_typed_items_block_base_accessor(name)
+        || is_typed_array_base_adapter(name)
 }
 
 /// One path segment, with a raw-identifier prefix removed.  `r#struct` and
@@ -22109,6 +22144,23 @@ fn primitive_float_const(segments: &[String]) -> Option<OpKind> {
         _ => return None,
     };
     Some(OpKind::ConstFloat(bits))
+}
+
+/// Target-layout value of the scalar GcArray's items offset.  Charon leaves
+/// Rust's `offset_of!(TypedItemsBlock, items)` initializer opaque, but the
+/// translated lltype fixes the same layout structurally: one target-word
+/// length header followed by an 8-byte-aligned Signed/Float item array
+/// (`rlist.py:84,116`).  This is the front-end counterpart of
+/// `CallControl::array_items_base`; it derives the target value instead of
+/// importing a host-runtime constant or registering a fake residual getter.
+fn known_array_layout_const(segments: &[String]) -> Option<OpKind> {
+    let path = segments.join("::");
+    if !path_ends_with_segments(&path, "rlist::TYPED_ITEMS_BLOCK_ITEMS_OFFSET") {
+        return None;
+    }
+    let word = crate::layout::target_word_size();
+    let items_offset = word.div_ceil(8) * 8;
+    Some(OpKind::ConstInt(items_offset as i64))
 }
 
 /// Supply the value of a `CodeFlags` associated constant. `bitflags!`
@@ -26052,6 +26104,12 @@ mod tests {
         assert!(graph_is_items_block_base_accessor(
             "majit_rlib::lltypesystem::rlist::typed_items_block_items_base"
         ));
+        assert!(graph_is_items_block_base_accessor(
+            "pyre_object::int_array::<Impl>::base"
+        ));
+        assert!(graph_is_items_block_base_accessor(
+            "pyre_object::float_array::<Impl>::base"
+        ));
 
         // Bodies that dereference a `.add(NAMED_OFFSET)` interior pointer
         // in place must NOT be aliased — the offset is load-bearing.
@@ -26064,6 +26122,9 @@ mod tests {
         // A leaf collision in another module must not widen the gate.
         assert!(!graph_is_items_block_base_accessor(
             "pyre_object::other_mod::items_block_items_base_helper"
+        ));
+        assert!(!graph_is_items_block_base_accessor(
+            "pyre_object::my_int_array::<Impl>::base"
         ));
     }
 
@@ -30588,6 +30649,76 @@ mod tests {
             unwrap_residuals, 0,
             "checked conversion Result::unwrap must become a discriminant guard"
         );
+    }
+
+    /// The scalar unwrapped-list storage adapters are Rust spellings of
+    /// RPython's `l.items` GcArray.  A live `push` must therefore end in the
+    /// same `setarrayitem` shape as `rlist.ll_append_noresize`, never in the
+    /// synthetic raw-pointer write that blocks annotation.  The adapter body
+    /// itself must also be free of the opaque Rust `offset_of!` getter; its
+    /// target-layout constant is part of the translated GcArray shape.
+    #[test]
+    #[ignore]
+    fn unwrapped_array_pushes_lower_to_rpython_gcarray_writes() {
+        use crate::model::{CallTarget, OpKind};
+
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real object LLBC");
+        for (base, function, expected_array) in [
+            (
+                "pyre_object::int_array::<Impl>::base",
+                "pyre_object::int_array::<Impl>::push",
+                "[i64]",
+            ),
+            (
+                "pyre_object::float_array::<Impl>::base",
+                "pyre_object::float_array::<Impl>::push",
+                "[f64]",
+            ),
+        ] {
+            let base_graph = super::lower_function(&llbc, base)
+                .unwrap_or_else(|err| panic!("lower {base}: {err}"));
+            assert!(
+                !base_graph.blocks.iter().flat_map(|block| &block.operations).any(|op| matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.last().is_some_and(|leaf| leaf == "TYPED_ITEMS_BLOCK_ITEMS_OFFSET")
+                )),
+                "{base} must fold the target-layout items offset"
+            );
+            let graph = super::lower_function(&llbc, function)
+                .unwrap_or_else(|err| panic!("lower {function}: {err}"));
+            let operations: Vec<_> = graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .collect();
+            assert!(
+                operations.iter().any(|op| matches!(
+                    &op.kind,
+                    OpKind::ArrayWrite {
+                        array_type_id: Some(array_type_id),
+                        ..
+                    } if array_type_id == expected_array
+                )),
+                "{function} must write {expected_array} through setarrayitem"
+            );
+            assert!(
+                !operations.iter().any(|op| matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments == &["__deref_write".to_string()]
+                )),
+                "{function} must not retain a raw-pointer write"
+            );
+        }
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -33174,6 +33174,11 @@ mod tests {
              word each, so its getitems must not remain Vec::index"
         );
         assert_eq!(
+            residual_vec_indexes("load_const_value"),
+            0,
+            "slice-constant handler values must cross the scalar SliceIndex boundary"
+        );
+        assert_eq!(
             residual_vec_indexes("dict_repr"),
             0,
             "dict_repr must flatten host-width pairs before translated reads"

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -32987,29 +32987,26 @@ mod tests {
         }
     }
 
-    /// PyPy's `_match_keywords` indexes its small signature and argument
-    /// lists with ordinary `getitem`.  The Rust `SliceIndex<usize>` shim must
-    /// lower to the same ArrayRead shape instead of remaining an opaque core
-    /// call that prevents the whole builtin-call chain from being annotated.
-    ///
-    /// The `arguments_w` side reaches that shape: its elements are object
-    /// pointers, one target word each, so the ArrayRead's stride is the host
-    /// stride.  `Signature.argnames` does NOT, and must keep its residual
-    /// `Vec::index`: PyPy's `Signature.argnames` is an RPython list of
-    /// `Ptr(STR)` (`rstr.py`, `StringRepr`), but pyre spells it
-    /// `Vec<&'static str>` — a two-word fat pointer per element — and no
-    /// translation converts the container.  Admitting it would make
-    /// `getarrayitem` compute `base + i * 8` over 16-byte elements.  The
-    /// convergence path is on the pyre side: give `Signature` a managed
-    /// string list, the one container whose items really are one GCREF each,
-    /// and this call joins the addressable set through the same
-    /// `first_arg_is_string_array_view` proof the items view already uses.
+    /// PyPy's `_match_keywords` indexes its small argument lists with ordinary
+    /// `getitem`, while `Signature.find_argname` is `@jit.elidable`.  Pyre must
+    /// preserve both boundaries: the signature's host `Vec<&str>` stays behind
+    /// the pure residual call, and `keyword_names_w` / `keywords_w` remain
+    /// parallel one-word GC-pointer lists (represented by shadow-stack slot
+    /// indices in the hand-written root scaffold).  No fat-pointer
+    /// `Vec<Wtf8Buf>::index` may escape into the translated binder graph.
     #[test]
     #[ignore]
     fn bind_kwargs_indexes_lower_to_array_reads() {
         use crate::model::{CallTarget, OpKind};
         let path = crate::runtime_names::artifacts::INTERPRETER_ULLBC;
         let llbc = Llbc::load(path).expect("load real LLBC");
+        let hints = crate::front::llbc_hints::harvest_hints_from_llbcs(std::slice::from_ref(&llbc));
+        assert!(
+            hints
+                .get("gateway::<Impl>::find_argname")
+                .is_some_and(|values| values.iter().any(|hint| hint == "elidable")),
+            "Signature.find_argname must retain PyPy's @jit.elidable marker"
+        );
         let graph = super::lower_function(&llbc, "bind_kwargs_to_signature")
             .expect("lower bind_kwargs_to_signature");
 
@@ -33052,12 +33049,12 @@ mod tests {
                 )
             })
             .collect();
-        assert!(
-            !residual_vec_indexes.is_empty(),
-            "`Signature.argnames: Vec<&'static str>` must keep its residual \
-             Vec::index until the container becomes a managed string list; \
-             a one-word ArrayRead over two-word elements reads the wrong \
-             address from the second element on"
+        assert_eq!(
+            residual_vec_indexes.len(),
+            0,
+            "keyword_names_w/keywords_w must lower through their one-word \
+             rooted-list representation; a residual Vec::index blocks the \
+             whole builtin-call chain: {residual_vec_indexes:#?}"
         );
         assert!(
             graph

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -28655,6 +28655,25 @@ mod tests {
         );
     }
 
+    #[test]
+    #[ignore]
+    fn unicode_hash_atomic_store_is_the_exact_residual_choke_point() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let residuals = super::dont_look_inside_set_of(&llbc);
+        assert!(
+            residuals.contains("unicodeobject::w_str_set_hash"),
+            "the foreign AtomicI64::store must stay behind its pyre-owned wrapper"
+        );
+        assert!(
+            !residuals.contains("unicodeobject::w_str_get_hash"),
+            "the ordinary scalar memo read remains visible to the generated JIT"
+        );
+    }
+
     /// PyPy's `_match_keywords` indexes its small signature and argument
     /// lists with ordinary `getitem`.  The Rust `SliceIndex<usize>` shim must
     /// lower to the same ArrayRead shape instead of remaining an opaque core

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4704,6 +4704,62 @@ impl<'a> Lowering<'a> {
                         array_type_id: alias.array_type_id.clone(),
                         nolength: false,
                     }
+                } else if let Some(owner) = self.string_array_remove_owner() {
+                    // Tail of RPython `ll_delitem_nonneg`: after
+                    // `ll_arraymove`, clear `l[newlength]` to the null GC
+                    // pointer before shrinking the logical length.  Rust
+                    // spells this one site as `*p = null_mut()`, but the
+                    // translated operation is a setitem on the same
+                    // GcArray(GCREF) as the move.
+                    let list = self
+                        .local_var
+                        .get(1)
+                        .and_then(Option::as_ref)
+                        .cloned()
+                        .ok_or_else(|| {
+                            LowerError::Unsupported(format!(
+                                "bb{mir_bb}: string-array remove lost self before null clear"
+                            ))
+                        })?;
+                    let block = self.emit_string_array_items_read(bb_id, list.clone(), owner);
+                    let arr = self
+                        .narrow_value_to_instance_root(
+                            bb_id,
+                            LinkArg::Value(block),
+                            STRING_GCREF_GCARRAY_TYPE_ID,
+                        )
+                        .as_variable()
+                        .expect("a string-items view stays a Variable")
+                        .clone();
+                    let length = self.emit_string_array_len_read(bb_id, list, owner);
+                    let one = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(one.clone()),
+                        kind: OpKind::ConstUInt(1),
+                    });
+                    let newlength = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(newlength.clone()),
+                        kind: OpKind::BinOp {
+                            op: "sub".to_string(),
+                            lhs: length,
+                            rhs: one,
+                            result_ty: ValueType::Unsigned,
+                        },
+                    });
+                    value = self.narrow_value_to_instance_root(bb_id, value, "str");
+                    OpKind::ArrayWrite {
+                        base: arr,
+                        index: newlength,
+                        value: value.clone(),
+                        item_ty: ValueType::Str,
+                        array_type_id: Some(STRING_GCREF_GCARRAY_TYPE_ID.to_string()),
+                        nolength: false,
+                    }
                 } else {
                     // `*p = val` — no IR-level FieldWrite/ArrayWrite
                     // fits.  Emit a synthetic 2-arg Call so the write
@@ -8443,6 +8499,104 @@ impl<'a> Lowering<'a> {
                         },
                     });
                     self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
+                // `BytesArray::remove` / `UnicodeArray::remove` spell
+                // `rlist.ll_delitem_nonneg`'s overlap-safe
+                // `ll_arraymove(l, index + 1, index, newlength - index)` as
+                // raw `ptr::copy(src, dst, count)`.  Recover the logical
+                // GcArray plus those three indices here and route the call to
+                // the exact RPython helper marker.  The match is both
+                // graph-scoped and callee-exact; an arbitrary raw copy keeps
+                // its Rust semantics.
+                if args.len() == 3 && self.is_string_array_remove_ptr_copy(&reg) {
+                    let owner = self
+                        .string_array_remove_owner()
+                        .expect("ptr-copy gate proved a string-array remove owner");
+                    let list = self
+                        .local_var
+                        .get(1)
+                        .and_then(Option::as_ref)
+                        .cloned()
+                        .ok_or_else(|| {
+                            LowerError::Unsupported(format!(
+                                "bb{mir_bb}: string-array remove lost self before ll_arraymove"
+                            ))
+                        })?;
+                    let index = self
+                        .local_var
+                        .get(2)
+                        .and_then(Option::as_ref)
+                        .cloned()
+                        .ok_or_else(|| {
+                            LowerError::Unsupported(format!(
+                                "bb{mir_bb}: string-array remove lost index before ll_arraymove"
+                            ))
+                        })?;
+                    let block = self.emit_string_array_items_read(bb_id, list, owner);
+                    let array = self
+                        .narrow_value_to_instance_root(
+                            bb_id,
+                            LinkArg::Value(block),
+                            STRING_GCREF_GCARRAY_TYPE_ID,
+                        )
+                        .as_variable()
+                        .expect("a string-items view stays a Variable")
+                        .clone();
+                    let one = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(one.clone()),
+                        kind: OpKind::ConstUInt(1),
+                    });
+                    let source_start = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(source_start.clone()),
+                        kind: OpKind::BinOp {
+                            op: "add".to_string(),
+                            lhs: index.clone(),
+                            rhs: one,
+                            result_ty: ValueType::Unsigned,
+                        },
+                    });
+                    let result = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Void);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(result.clone()),
+                        kind: OpKind::Call {
+                            target: CallTarget::FunctionPath {
+                                segments: vec![
+                                    crate::runtime_names::shims::LL_ARRAYMOVE.to_string(),
+                                ],
+                            },
+                            args: vec![array, source_start, index, args[2].clone()],
+                            result_ty: ValueType::Void,
+                        },
+                    });
+                    self.local_var[dest_local] = Some(result);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
+                // Every raw pointer offset in those same adapters feeds only
+                // the `ptr::copy` or the final null clear reconstructed above
+                // and below.  Once the logical indices are recovered, the
+                // interior pointer has no translated value of its own; alias
+                // it to its base so no Rust pointer arithmetic leaks into the
+                // RPython graph.
+                if args.len() == 2
+                    && self.string_array_remove_owner().is_some()
+                    && regular_call_is_ptr_add(&reg, self.llbc)
+                {
+                    self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
                     self.graph.set_goto(bb_id, target_bb, link_args);
@@ -12739,6 +12893,31 @@ impl<'a> Lowering<'a> {
         }
     }
 
+    /// Owner of the two Rust storage adapters whose `remove` body is the
+    /// concrete spelling of RPython `rlist.ll_delitem_nonneg`.
+    fn string_array_remove_owner(&self) -> Option<&'static str> {
+        match self.graph.name.as_str() {
+            "pyre_object::bytes_array::<Impl>::remove" => Some("BytesArray"),
+            "pyre_object::unicode_array::<Impl>::remove" => Some("UnicodeArray"),
+            _ => None,
+        }
+    }
+
+    /// `std::ptr::copy` inside the exact string-list `remove` adapters.  The
+    /// caller reconstructs the logical array and indices and emits the
+    /// RPython `rgc.ll_arraymove` marker; no arbitrary raw copy qualifies.
+    fn is_string_array_remove_ptr_copy(&self, reg: &RegularCall) -> bool {
+        if self.string_array_remove_owner().is_none() {
+            return false;
+        }
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc
+            .fn_by_id(*id)
+            .is_some_and(|fd| fd.item_meta.name_path() == "core::ptr::copy")
+    }
+
     /// The body-side `from_raw_parts` half of
     /// [`Self::string_array_slice_view_owner`].
     fn is_string_array_view_from_raw_parts(&self, reg: &RegularCall) -> bool {
@@ -12788,6 +12967,34 @@ impl<'a> Lowering<'a> {
                     majit_ir::descr::StructId::from_canonical(canonical_owner),
                 )),
                 ty: ValueType::Ref(None),
+                pure: false,
+            },
+        });
+        result
+    }
+
+    fn emit_string_array_len_read(
+        &mut self,
+        bb_id: BlockId,
+        base: Variable,
+        owner: &str,
+    ) -> Variable {
+        let result = self
+            .graph
+            .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+        let canonical_owner = match owner {
+            "BytesArray" => "bytes_array::BytesArray",
+            "UnicodeArray" => "unicode_array::UnicodeArray",
+            _ => unreachable!("string array owner is closed"),
+        };
+        self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+            result: Some(result.clone()),
+            kind: OpKind::FieldRead {
+                base,
+                field: FieldDescriptor::new("len", Some(owner.to_string())).with_owner_id(Some(
+                    majit_ir::descr::StructId::from_canonical(canonical_owner),
+                )),
+                ty: ValueType::Unsigned,
                 pure: false,
             },
         });
@@ -31157,6 +31364,8 @@ mod tests {
         for function in [
             "pyre_object::bytes_array::<Impl>::pop",
             "pyre_object::unicode_array::<Impl>::pop",
+            "pyre_object::bytes_array::<Impl>::remove",
+            "pyre_object::unicode_array::<Impl>::remove",
         ] {
             let graph = super::lower_function(&llbc, function)
                 .unwrap_or_else(|err| panic!("lower {function}: {err}"));
@@ -31199,6 +31408,29 @@ mod tests {
                 )),
                 "{function} must not retain a Rust raw-slice/read-write boundary"
             );
+            if function.ends_with("::remove") {
+                assert!(
+                    operations.iter().any(|operation| matches!(
+                        &operation.kind,
+                        OpKind::Call {
+                            target: CallTarget::FunctionPath { segments },
+                            ..
+                        } if segments == &[crate::runtime_names::shims::LL_ARRAYMOVE.to_string()]
+                    )),
+                    "{function} must restore ptr::copy to RPython rgc.ll_arraymove"
+                );
+                assert!(
+                    !operations.iter().any(|operation| matches!(
+                        &operation.kind,
+                        OpKind::Call {
+                            target: CallTarget::FunctionPath { segments },
+                            ..
+                        } if segments.as_slice() == ["core", "ptr", "copy"]
+                            || segments.as_slice() == ["core", "ptr", "mut_ptr", "<Impl>", "add"]
+                    )),
+                    "{function} must not retain Rust pointer-copy arithmetic"
+                );
+            }
         }
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2330,6 +2330,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
         && crate::front::result_exc::tyref_result_ok_is_unit(&fd.signature.output, llbc);
     let finish = |lo: &mut Lowering<'_>| -> Result<(), LowerError> {
         if !lo.result_exc_call_results.is_empty()
+            || !lo.option_ok_or_else_try_sites.is_empty()
             || result_exc_callee
             || !lo.next_call_results.is_empty()
             || !lo.checked_arith_call_results.is_empty()
@@ -2377,6 +2378,16 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             .map_err(LowerError::Unsupported)?;
             tail_forwarded_returns = outcome.tail_forwards;
         }
+        let option_ok_or_else_try_rewritten = if lo.option_ok_or_else_try_sites.is_empty() {
+            0
+        } else {
+            crate::front::result_exc::rewire_option_ok_or_else_try_sites(
+                &mut lo.graph,
+                &lo.option_ok_or_else_try_sites,
+                result_exc_callee,
+                static_addrs.error_carrier,
+            )
+        };
         if result_exc_callee {
             crate::front::result_exc::lower_result_exc_returns(
                 &mut lo.graph,
@@ -2687,6 +2698,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
         }
         if !lo.result_exc_call_results.is_empty()
             || result_exc_callee
+            || option_ok_or_else_try_rewritten > 0
             || next_rewritten > 0
             || checked_arith_rewritten > 0
             || checked_arith_uint_rewritten > 0
@@ -3278,6 +3290,13 @@ struct Lowering<'a> {
     /// per-instantiation `<…>` suffix (Ref-shaped payloads only) keying
     /// the rebuilt `Ok`/`Err` shells' ClassDef per instantiation.
     result_exc_call_results: Vec<(Variable, Option<String>, ValueType)>,
+    /// Foreign `Option::ok_or_else(opt, closure)` results consumed immediately
+    /// by `?`, recorded for the combined value-or-exception rewrite in
+    /// [`crate::front::result_exc::rewire_option_ok_or_else_try_sites`].
+    /// This cannot share `result_exc_call_results`: the Option combinator is
+    /// not itself a translated scoped callee, so its `Result` shell must be
+    /// removed together with the Option select.
+    option_ok_or_else_try_sites: Vec<crate::front::result_exc::OptionOkOrElseTrySite>,
     /// `Iterator::next()` call results (`Option<T>`-typed) recorded for
     /// the `next`-diamond rewiring pass (`front::iter_next`) that runs
     /// after the body lowering completes.  The paired [`ValueType`] is the
@@ -3601,6 +3620,7 @@ impl<'a> Lowering<'a> {
             string_byte_view_locals: Vec::new(),
             string_array_view_locals: Vec::new(),
             result_exc_call_results: Vec::new(),
+            option_ok_or_else_try_sites: Vec::new(),
             next_call_results: Vec::new(),
             checked_arith_call_results: Vec::new(),
             checked_arith_uint_sites: Vec::new(),
@@ -10987,10 +11007,35 @@ impl<'a> Lowering<'a> {
             .graph
             .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
         self.local_var[dest_local] = Some(result_var.clone());
+        // `Option::ok_or_else(opt, closure)?` is one combined value-or-raise
+        // boundary in the translated graph.  Record it separately from an
+        // ordinary scoped `Result` call: `ok_or_else` is a foreign core
+        // combinator, and lowering only the downstream `?` would leave that
+        // unregistered residual (while lowering only the Option select would
+        // materialise the Result shell RPython never has).
+        let captured_option_ok_or_else_try = if let OpKind::Call {
+            target: CallTarget::Method { name, .. },
+            args,
+            ..
+        } = &op_kind
+            && name == "ok_or_else"
+            && args.len() == 2
+            && let Some(site) = self.recognize_option_ok_or_else_try_site(
+                first_arg_ty.as_ref(),
+                second_arg_ty.as_ref(),
+                &call.dest.ty,
+                &result_var,
+            ) {
+            self.option_ok_or_else_try_sites.push(site);
+            true
+        } else {
+            false
+        };
         // Capture scoped `Result<T, PyError>` call results for the
         // `?`-diamond rewiring pass (`front::result_exc`) that runs
         // after the body lowering completes.
         if let OpKind::Call { .. } = &op_kind
+            && !captured_option_ok_or_else_try
             && callee_name_path.is_some()
             && crate::front::result_exc::tyref_is_result_of_carrier(
                 &call.dest.ty,
@@ -14545,6 +14590,48 @@ impl<'a> Lowering<'a> {
             result_ty,
             args_tuple_suffix,
             niche,
+        })
+    }
+
+    /// Resolve `Option::ok_or_else(opt, closure) -> Result<T, E>` for the
+    /// combined Option-select + immediate-`?` exception rewrite.
+    ///
+    /// The destination must use the configured exception carrier; this keeps
+    /// ordinary `ok_or_else` values and non-Python error domains as residual
+    /// Rust combinators.  The post-pass additionally proves the compiler's
+    /// private `Try::branch` diamond before it mutates the graph.
+    fn recognize_option_ok_or_else_try_site(
+        &self,
+        recv_ty: Option<&TyRef>,
+        env_ty: Option<&TyRef>,
+        dest_ty: &TyRef,
+        result_var: &Variable,
+    ) -> Option<crate::front::result_exc::OptionOkOrElseTrySite> {
+        let recv_ty = recv_ty?;
+        if !crate::front::result_exc::tyref_is_option(recv_ty, self.llbc)
+            || !crate::front::result_exc::tyref_is_result_of_carrier(
+                dest_ty,
+                self.llbc,
+                self.static_addrs.error_carrier,
+            )
+        {
+            return None;
+        }
+        let (option_owner, some_owner, payload_ty) =
+            self.resolve_option_consumer_owners(recv_ty)?;
+        let env_def_id = self.tyref_ref_adt_def_id(env_ty?)?;
+        let call_once_owner = self.llbc.type_by_id(env_def_id)?.item_meta.name_path();
+        let error_ty = crate::front::result_exc::tyref_result_err(dest_ty, self.llbc)
+            .map(|ty| tyref_to_value_type(&ty, self.llbc))
+            .unwrap_or(ValueType::Ref(None));
+        Some(crate::front::result_exc::OptionOkOrElseTrySite {
+            result_var: result_var.clone(),
+            option_owner,
+            some_owner,
+            call_once_owner,
+            payload_ty,
+            error_ty,
+            niche: self.tyref_is_niche_option_ptr(recv_ty),
         })
     }
 
@@ -33760,6 +33847,72 @@ mod tests {
                 "the caller must rebuild one Result::{variant} shell"
             );
         }
+    }
+
+    /// PyPy's `_IOBase.writelines_w` receives `self` directly from the
+    /// gateway and raises on a missing receiver.  The Rust gateway spells the
+    /// same boundary as `args.first().copied().ok_or_else(...)?`; after the
+    /// combined lowering neither the foreign Option combinator nor the Result
+    /// `?` shell may survive, and the niladic closure's error must terminate on
+    /// the graph exception edge.
+    #[test]
+    #[ignore]
+    fn iobase_writelines_ok_or_else_try_is_value_or_exception() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function_with_static_addrs(
+            &llbc,
+            "iobase_writelines",
+            crate::HostStaticAddrs {
+                error_carrier: crate::ErrorCarrierSpec {
+                    carrier_path: "pyre_interpreter::error::PyError",
+                    carrier_wrappers: &[],
+                    to_exc_object: Some(&["pyre_interpreter", "error", "pyerror_to_exc_object"]),
+                    from_exc_object: Some(("PyError", "from_exc_object")),
+                },
+                ..crate::HostStaticAddrs::default()
+            },
+        )
+        .expect("lower iobase_writelines");
+
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::Method { name, .. },
+                        ..
+                    } if name == "ok_or_else"
+                )
+            }),
+            "the foreign Option::ok_or_else residual must be gone"
+        );
+        let error_arm = graph
+            .blocks
+            .iter()
+            .find(|block| {
+                block.operations.iter().any(|op| {
+                    matches!(
+                        &op.kind,
+                        OpKind::Call {
+                            target: CallTarget::Method { name, .. },
+                            ..
+                        } if name == "call_once"
+                    )
+                })
+            })
+            .expect("the None arm calls its error closure");
+        assert!(
+            error_arm
+                .exits
+                .iter()
+                .any(|link| link.target == graph.exceptblock),
+            "the None arm must raise through the native graph exception edge"
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -12598,6 +12598,10 @@ impl<'a> Lowering<'a> {
         result_var: &Variable,
     ) -> Option<crate::front::bool_then::BoolThenSite> {
         let (option_owner, some_owner, payload_ty) = self.resolve_bool_then_option_dest(dest_ty)?;
+        let niche = self.tyref_is_niche_option_ptr(dest_ty);
+        let payload_narrow_root = niche
+            .then(|| self.option_niche_payload_class_root(dest_ty))
+            .flatten();
         // Closure env ADT → its `name_path` is the `call_once` inherent
         // method owner (`resolve_impl_owner_adt_def_id_free` records the
         // same spelling for the closure's transparent `call_once` body).
@@ -12610,6 +12614,8 @@ impl<'a> Lowering<'a> {
             option_owner,
             some_owner,
             payload_ty,
+            niche,
+            payload_narrow_root,
         })
     }
 
@@ -12625,12 +12631,18 @@ impl<'a> Lowering<'a> {
         result_var: &Variable,
     ) -> Option<crate::front::bool_then::BoolThenSite> {
         let (option_owner, some_owner, payload_ty) = self.resolve_bool_then_option_dest(dest_ty)?;
+        let niche = self.tyref_is_niche_option_ptr(dest_ty);
+        let payload_narrow_root = niche
+            .then(|| self.option_niche_payload_class_root(dest_ty))
+            .flatten();
         Some(crate::front::bool_then::BoolThenSite {
             result_var: result_var.clone(),
             call_once_owner: None,
             option_owner,
             some_owner,
             payload_ty,
+            niche,
+            payload_narrow_root,
         })
     }
 
@@ -28417,6 +28429,87 @@ mod tests {
         assert_eq!(
             residual, 0,
             "fixed throw arities must not leave an array index"
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn clear_references_niche_bool_then_has_no_option_aggregate() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph =
+            super::lower_function(&llbc, "clear_references").expect("lower clear_references");
+        let option_aggregate_ops = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .filter(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::SyntheticTransparentCtor { name, .. },
+                    ..
+                } => name == "Option<*mut PyObject>",
+                OpKind::FieldWrite { field, .. } => {
+                    field.name == "__discriminant"
+                        && field
+                            .owner_root
+                            .as_deref()
+                            .is_some_and(|owner| owner.contains("Option<*mut PyObject>"))
+                }
+                _ => false,
+            })
+            .count();
+        assert_eq!(
+            option_aggregate_ops, 0,
+            "bool::then producing Option<PyObjectRef> must use RPython's nullable-pointer \
+             representation (Some(ptr)=ptr, None=null), not an Option aggregate"
+        );
+        let is_pyobject_narrow = |op: &crate::model::SpaceOperation| {
+            matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if segments == &["__pyre_cast_instance", "PyObject"]
+            )
+        };
+        let join = graph.blocks.iter().find_map(|block| {
+            let has_call_once = block.operations.iter().any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::Method { name, .. },
+                        ..
+                    } if name == "call_once"
+                )
+            });
+            (has_call_once && block.operations.iter().any(is_pyobject_narrow))
+                .then(|| block.exits.first().map(|link| link.target))
+                .flatten()
+        });
+        assert!(
+            join.is_some(),
+            "the niche Some payload must retain PyObject/W_Root class identity across call_once"
+        );
+        let narrowed_none = graph.blocks.iter().any(|block| {
+            block.exits.first().map(|link| link.target) == join
+                && block.operations.iter().any(|op| {
+                    matches!(
+                        &op.kind,
+                        OpKind::Call {
+                            target: CallTarget::FunctionPath { segments },
+                            ..
+                        } if segments == &["core", "ptr", "null_mut"]
+                    )
+                })
+                && block.operations.iter().any(is_pyobject_narrow)
+        });
+        assert!(
+            narrowed_none,
+            "the niche None arm must be the same nullable PyObject/W_Root repr as the Some arm"
         );
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -30103,6 +30103,106 @@ mod tests {
         );
     }
 
+    /// A translated opcode helper is a PyPy frame method, not a generic
+    /// classdef-less reference.  Its receiver is the per-frame red argument
+    /// that owns `pycode`, globals, and locals, so the front must retain the
+    /// concrete `PyFrame` root on the corresponding Input operation.
+    #[test]
+    #[ignore]
+    fn opcode_impl_receiver_keeps_pyframe_input_root() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real interpreter LLBC");
+        let graph = super::lower_function(&llbc, "pyre_interpreter::eval::<Impl>::pop_value")
+            .expect("lower eval::<Impl>::pop_value");
+        let receiver = graph
+            .block(graph.startblock)
+            .operations
+            .iter()
+            .find_map(|op| match &op.kind {
+                OpKind::Input { class_root, .. }
+                    if op.result.as_ref() == graph.block(graph.startblock).inputargs.first() =>
+                {
+                    class_root.as_deref()
+                }
+                _ => None,
+            });
+        assert_eq!(
+            receiver,
+            Some("PyFrame"),
+            "opcode impl receiver must retain the concrete per-frame red identity"
+        );
+
+        let program =
+            super::build_semantic_program_from_llbcs_with_static_addrs_and_function_names(
+                &[llbc],
+                crate::HostStaticAddrs::default(),
+                &[],
+                &["pop_value", "pop_top", "build_list", "opcode_build_list"],
+            )
+            .expect("build filtered opcode program");
+        let pyframe_roots: Vec<_> = program
+            .struct_fields
+            .fields
+            .keys()
+            .filter(|root| root.rsplit("::").next() == Some("PyFrame"))
+            .cloned()
+            .collect();
+        assert!(
+            pyframe_roots.len() > 1,
+            "fixture must exercise more than one lookup spelling"
+        );
+        let mut pyframe_ids: Vec<_> = pyframe_roots
+            .iter()
+            .map(|root| {
+                program
+                    .struct_ids
+                    .get(root)
+                    .copied()
+                    .flatten()
+                    .expect("every qualified PyFrame alias has an identity")
+            })
+            .collect();
+        pyframe_ids.sort();
+        pyframe_ids.dedup();
+        assert_eq!(
+            pyframe_ids.len(),
+            1,
+            "all PyFrame lookup spellings must name one class identity"
+        );
+
+        let mut trait_impl_owners = crate::TraitImplOwners::new();
+        for function in &program.functions {
+            let (Some(trait_qualified), Some(owner)) =
+                (&function.trait_qualified, &function.self_ty_root)
+            else {
+                continue;
+            };
+            trait_impl_owners
+                .entry(trait_qualified.clone())
+                .or_default()
+                .insert(owner.clone());
+        }
+        let unique_impls = crate::unique_trait_impl_roots(&program, trait_impl_owners);
+        let frame_owner = unique_impls
+            .iter()
+            .find(|(trait_name, _)| trait_name.ends_with("::OpcodeStepExecutor"))
+            .map(|(_, owner)| owner)
+            .expect("OpcodeStepExecutor has one concrete owner");
+        assert!(
+            frame_owner.ends_with("::PyFrame"),
+            "the production unique-impl census must preserve the qualified frame owner: \
+             {frame_owner:?}"
+        );
+        assert_eq!(
+            program.struct_ids.get(frame_owner).copied().flatten(),
+            Some(pyframe_ids[0]),
+            "the retained owner spelling must resolve to the frame's StructId"
+        );
+    }
+
     #[test]
     fn niche_option_raw_scalar_ptr_remains_aggregate() {
         let payload = serde_json::json!({

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1054,7 +1054,9 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
             .and_then(|p| p.rsplit("::").next())
             .map(str::to_string)
             .or_else(|| trait_default_owner_for_fundecl(fd, &known_trait_names));
-        let returns_objectptr = output_type_is_objectptr(&fd.signature.output, llbc);
+        let gcref_result = gc_root_gcref_result_path(&fn_path);
+        let returns_objectptr =
+            output_type_is_objectptr(&fd.signature.output, llbc) && !gcref_result;
         // Stamp the FUNC.RESULT token for `dont_look_inside` callees only
         // (keyed exactly as `merge_hints_from_llbcs`), so the narrow
         // codewriter surface stays restricted to opaque stubs; every
@@ -1068,7 +1070,9 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
         let stamp_return_token = dont_look_inside.contains(&fn_path)
             || elidable_residual.contains(&fn_path)
             || (trait_root.is_some() && self_ty_root.is_none());
-        let return_type = if stamp_return_token {
+        let return_type = if gcref_result {
+            Some(crate::translator::rtyper::cutover::GCREF_RETURN_TYPE.to_string())
+        } else if stamp_return_token {
             dont_look_inside_return_token(&fd.signature.output, llbc, static_addrs.error_carrier)
         } else {
             None
@@ -3078,6 +3082,12 @@ impl std::error::Error for LowerError {}
 /// returns no descr-set key, `canonicalize_keyed_descrs` drops the whole
 /// set, and the callee's `EffectInfo` degrades to `EF_RANDOM_EFFECTS`.
 const OBJECT_REF_GCARRAY_TYPE_ID: &str = "majit::object_ref_gcarray";
+/// PyPy `BytesListStrategy` / `AsciiListStrategy` expose `SomeString`
+/// elements, while `rmodel.externalvsinternal(..., gcref=True)` stores those
+/// GC pointers in `GcArray(GCREF)`.  The logical list identity must therefore
+/// remain `[str]`; the rtyper's ordinary ListRepr recast supplies the
+/// STRPTR↔GCREF conversion at each item boundary.
+const STRING_GCREF_GCARRAY_TYPE_ID: &str = "[str]";
 
 /// The `(base, index)` operands of a devirtualized workspace index call,
 /// recorded for the paired `*p = v` write.  Each operand keeps the
@@ -3091,6 +3101,10 @@ struct IndexElemAlias {
     base_var: Variable,
     index_local: Option<usize>,
     index_var: Variable,
+    /// External item bank the source-level list exposes.  This can differ
+    /// from the Rust pointee spelling: `[str]` is physically `GcArray(GCREF)`
+    /// but its get/set boundary is `StringRepr`.
+    item_ty: ValueType,
     /// Identity the paired write must repeat, so `arr[i] = v` keys the
     /// same ARRAY as the `arr[i]` read that recorded this alias.
     array_type_id: Option<String>,
@@ -3427,44 +3441,56 @@ impl<'a> Lowering<'a> {
             // trait's qualified path instead, which the adapter
             // resolves through the unique-impl map
             // (`trait_unique_impls`, keyed by qualified path).
-            let class_root = match &ty {
-                ValueType::Ref(_) => tyref_input_class_root(&local.ty, llbc)
-                    // A `&str` / `str` param strips to the `str` builtin
-                    // (not an ADT), so `tyref_class_root` answers `None`;
-                    // name it `"str"` so `derive_subject_inputcells` seeds
-                    // the byte `SomeString` (`s_str0`) instead of the
-                    // abstract `SomeInstance(None)` a `Ref(None)` projects
-                    // to.  A string param compared against a string literal
-                    // then rtypes as `pair(StringRepr, StringRepr)` rather
-                    // than walling at `pair(InstanceRepr, StringRepr)`.
-                    .or_else(|| tyref_strips_to_str(&local.ty, llbc).then(|| "str".to_string()))
-                    .or_else(|| tyref_generic_trait_bound_root(&local.ty, llbc, generics))
-                    // A list-typed param (`Vec<T>`, `&[T]`, …) has no
-                    // named-ADT leaf — `tyref_class_root` answers `None`
-                    // because `adt_node_class_root` excludes the
-                    // core/std/alloc container family from classdef
-                    // minting.  Carry its full monomorphic spelling so
-                    // `derive_subject_inputcells` projects it through the
-                    // annotator's list model (`project_struct_field_type`)
-                    // instead of the classdef-less `SomeInstance(None)`
-                    // shell, on which a `len()` / iteration would wall at
-                    // `getattr` over a classdef-less instance.
-                    .or_else(|| {
-                        let spelling = tyref_to_ast_string(&local.ty, llbc);
-                        majit_ir::descr::is_list_container_spelling(&spelling).then_some(spelling)
-                    }),
-                // A fieldless enum is `Int`-colored (`tyref_to_value_type`),
-                // so it takes the non-`Ref` arm and would otherwise carry no
-                // `class_root`.  Its variant-name metadata is a side table
-                // keyed by the enum type (the RPython "names by int" model),
-                // not a field on the value; carry the crate-stripped enum
-                // path so the `Debug`-fmt collapse can recover the enum
-                // identity from the value's origin (`debug_enum_disc_owner`)
-                // now that no `__discriminant` field read remains to scavenge.
-                // `derive_subject_inputcells` only consumes `class_root` on
-                // the `Ref` arm, so the annotation seed stays a plain
-                // `SomeInteger`.
-                _ => tyref_fieldless_enum_class_root(&local.ty, llbc),
+            let class_root = if i == 1 && gc_root_pin_path(&graph.name) {
+                // RPython's GC transformer publishes every live GC pointer
+                // through llmemory.GCREF, then casts the restored word back
+                // to its source repr.  Rust's `PyObjectRef` parameter is the
+                // physical carrier for that opaque slot, not a W_Root
+                // instance.  Preserve the GCREF input boundary explicitly so
+                // StringRepr and InstanceRepr callers never meet in one
+                // source-level FunctionDesc cell.
+                Some("GCREF".to_string())
+            } else {
+                match &ty {
+                    ValueType::Ref(_) => tyref_input_class_root(&local.ty, llbc)
+                        // A `&str` / `str` param strips to the `str` builtin
+                        // (not an ADT), so `tyref_class_root` answers `None`;
+                        // name it `"str"` so `derive_subject_inputcells` seeds
+                        // the byte `SomeString` (`s_str0`) instead of the
+                        // abstract `SomeInstance(None)` a `Ref(None)` projects
+                        // to.  A string param compared against a string literal
+                        // then rtypes as `pair(StringRepr, StringRepr)` rather
+                        // than walling at `pair(InstanceRepr, StringRepr)`.
+                        .or_else(|| tyref_strips_to_str(&local.ty, llbc).then(|| "str".to_string()))
+                        .or_else(|| tyref_generic_trait_bound_root(&local.ty, llbc, generics))
+                        // A list-typed param (`Vec<T>`, `&[T]`, …) has no
+                        // named-ADT leaf — `tyref_class_root` answers `None`
+                        // because `adt_node_class_root` excludes the
+                        // core/std/alloc container family from classdef
+                        // minting.  Carry its full monomorphic spelling so
+                        // `derive_subject_inputcells` projects it through the
+                        // annotator's list model (`project_struct_field_type`)
+                        // instead of the classdef-less `SomeInstance(None)`
+                        // shell, on which a `len()` / iteration would wall at
+                        // `getattr` over a classdef-less instance.
+                        .or_else(|| {
+                            let spelling = tyref_to_ast_string(&local.ty, llbc);
+                            majit_ir::descr::is_list_container_spelling(&spelling)
+                                .then_some(spelling)
+                        }),
+                    // A fieldless enum is `Int`-colored (`tyref_to_value_type`),
+                    // so it takes the non-`Ref` arm and would otherwise carry no
+                    // `class_root`.  Its variant-name metadata is a side table
+                    // keyed by the enum type (the RPython "names by int" model),
+                    // not a field on the value; carry the crate-stripped enum
+                    // path so the `Debug`-fmt collapse can recover the enum
+                    // identity from the value's origin (`debug_enum_disc_owner`)
+                    // now that no `__discriminant` field read remains to scavenge.
+                    // `derive_subject_inputcells` only consumes `class_root` on
+                    // the `Ref` arm, so the annotation seed stays a plain
+                    // `SomeInteger`.
+                    _ => tyref_fieldless_enum_class_root(&local.ty, llbc),
+                }
             };
             input_ops.push(SpaceOperation {
                 result: Some(var.clone()),
@@ -4641,7 +4667,18 @@ impl<'a> Lowering<'a> {
                     // to the recorded Variable for a constant operand.
                     let arr = self.realias_operand(alias.base_local, alias.base_var);
                     let idx = self.realias_operand(alias.index_local, alias.index_var);
-                    let arr = if matches!(alias.array_type_id.as_deref(), Some("[i64]" | "[f64]")) {
+                    if alias.array_type_id.as_deref() == Some(STRING_GCREF_GCARRAY_TYPE_ID) {
+                        // The manual Rust shadow-stack reload is the internal
+                        // GCREF word. At the source graph boundary RPython's
+                        // rlist recasts it to the external StringRepr before
+                        // setitem; the typer lowers this marker back to the
+                        // exact cast_opaque_ptr operation.
+                        value = self.narrow_value_to_instance_root(bb_id, value, "str");
+                    }
+                    let arr = if matches!(
+                        alias.array_type_id.as_deref(),
+                        Some("[i64]" | "[f64]" | STRING_GCREF_GCARRAY_TYPE_ID)
+                    ) {
                         self.narrow_value_to_instance_root(
                             bb_id,
                             LinkArg::Value(arr),
@@ -4657,7 +4694,7 @@ impl<'a> Lowering<'a> {
                         base: arr,
                         index: idx,
                         value: value.clone(),
-                        item_ty: tyref_to_value_type(dest_ty, self.llbc),
+                        item_ty: alias.item_ty,
                         array_type_id: alias.array_type_id.clone(),
                         nolength: false,
                     }
@@ -7607,6 +7644,12 @@ impl<'a> Lowering<'a> {
         on_unwind: usize,
     ) -> Result<(), LowerError> {
         let bb_id = self.block_id[mir_bb];
+        let callee_pin_gcref_arg = match &call.func {
+            CallFunc::Regular(reg) => regular_call_name_path(reg, self.llbc)
+                .as_deref()
+                .is_some_and(gc_root_pin_path),
+            _ => false,
+        };
 
         // Destination must be a plain `Local(i)` — projection-typed
         // destinations are not produced for monomorphized calls in any
@@ -7784,6 +7827,24 @@ impl<'a> Lowering<'a> {
                         self.graph.set_goto(bb_id, target_bb, link_args);
                         return Ok(());
                     }
+                }
+                // Rust exposes RPython's generated shadow-stack publication
+                // as a normal `pin_root(PyObjectRef)` call.  Its parameter is
+                // actually `llmemory.GCREF`, irrespective of the source
+                // pointer's external repr.  Cast every caller to that opaque
+                // slot before FunctionDesc propagation so strings, W_Root
+                // instances, and other GC pointers do not union at the
+                // helper's single input cell.
+                if callee_pin_gcref_arg && args.len() == 1 {
+                    args[0] = self
+                        .narrow_value_to_instance_root(
+                            bb_id,
+                            LinkArg::Value(args[0].clone()),
+                            "GCREF",
+                        )
+                        .as_variable()
+                        .expect("a materialized GC root stays a Variable")
+                        .clone();
                 }
                 // `we_are_jitted()` is true during tracing and blackholing
                 // (rlib/jit.py:355-358); the rtyper folds the surviving
@@ -8100,6 +8161,7 @@ impl<'a> Lowering<'a> {
                             base_var: args[0].clone(),
                             index_local: arg_locals.get(1).copied().flatten(),
                             index_var: args[1].clone(),
+                            item_ty: ValueType::Int,
                             array_type_id: None,
                         },
                     );
@@ -8279,7 +8341,7 @@ impl<'a> Lowering<'a> {
                         kind: OpKind::ArrayRead {
                             base: args[0].clone(),
                             index: args[1].clone(),
-                            item_ty,
+                            item_ty: item_ty.clone(),
                             array_type_id: array_type_id.clone(),
                             nolength: false,
                             pure: false,
@@ -8292,6 +8354,7 @@ impl<'a> Lowering<'a> {
                             base_var: args[0].clone(),
                             index_local: arg_locals.get(1).copied().flatten(),
                             index_var: args[1].clone(),
+                            item_ty,
                             array_type_id,
                         },
                     );
@@ -8369,6 +8432,61 @@ impl<'a> Lowering<'a> {
                 // pointer-walking callers (`object_insert` / `_remove` /
                 // `_splice`) keep their `add` and fall to the legacy
                 // walker.
+                // `BytesArray::base` / `UnicodeArray::base` address the same
+                // physical `ItemsBlock` as the object arm below, but PyPy's
+                // `BytesListStrategy` and `AsciiListStrategy` expose an
+                // RPython `str` item.  `rmodel.externalvsinternal` stores that
+                // GC pointer as GCREF; it does not erase the ListDef's
+                // external SomeString annotation.  Recover `[str]` here so
+                // getitem/setitem use StringRepr at the graph boundary and
+                // GCRefRepr only inside the ARRAY.
+                if let Some((item_ty, array_type_id)) = self.string_items_elem_ptr_add(
+                    &reg,
+                    args.len(),
+                    &arg_locals,
+                    first_arg_ty.as_ref(),
+                    dest_local,
+                ) {
+                    let base = self
+                        .narrow_value_to_instance_root(
+                            bb_id,
+                            LinkArg::Value(args[0].clone()),
+                            &array_type_id,
+                        )
+                        .as_variable()
+                        .expect("a materialized string-items base stays a Variable")
+                        .clone();
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::ArrayRead {
+                            base: base.clone(),
+                            index: args[1].clone(),
+                            item_ty: item_ty.clone(),
+                            array_type_id: Some(array_type_id.clone()),
+                            nolength: false,
+                            pure: false,
+                        },
+                    });
+                    self.index_elem_alias.insert(
+                        dest_local,
+                        IndexElemAlias {
+                            base_local: arg_locals.first().copied().flatten(),
+                            base_var: base,
+                            index_local: arg_locals.get(1).copied().flatten(),
+                            index_var: args[1].clone(),
+                            item_ty,
+                            array_type_id: Some(array_type_id),
+                        },
+                    );
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 if self.is_list_items_elem_ptr_add(
                     &reg,
                     args.len(),
@@ -8397,6 +8515,7 @@ impl<'a> Lowering<'a> {
                             base_var: args[0].clone(),
                             index_local: arg_locals.get(1).copied().flatten(),
                             index_var: args[1].clone(),
+                            item_ty: ValueType::Ref(None),
                             array_type_id: Some(OBJECT_REF_GCARRAY_TYPE_ID.to_string()),
                         },
                     );
@@ -8438,7 +8557,7 @@ impl<'a> Lowering<'a> {
                         kind: OpKind::ArrayRead {
                             base: base.clone(),
                             index: args[1].clone(),
-                            item_ty,
+                            item_ty: item_ty.clone(),
                             array_type_id: Some(array_type_id.clone()),
                             nolength: false,
                             pure: false,
@@ -8451,6 +8570,7 @@ impl<'a> Lowering<'a> {
                             base_var: base,
                             index_local: arg_locals.get(1).copied().flatten(),
                             index_var: args[1].clone(),
+                            item_ty,
                             array_type_id: Some(array_type_id),
                         },
                     );
@@ -11933,6 +12053,34 @@ impl<'a> Lowering<'a> {
             self.body,
             self.llbc,
         )
+    }
+
+    /// PyPy's unwrapped byte / ASCII list storage.  Rust reaches the shared
+    /// `ItemsBlock` through `BytesArray::base` / `UnicodeArray::base`, but the
+    /// source-level element remains `str`: `AbstractUnwrappedStrategy`
+    /// appends the result of `bytes_w` / `utf8_w`, and
+    /// `externalvsinternal(..., gcref=True)` alone changes its physical
+    /// storage to GCREF.  Return the logical `[str]` ARRAY identity so the
+    /// ordinary ListRepr performs that recast.
+    fn string_items_elem_ptr_add(
+        &self,
+        reg: &RegularCall,
+        args_len: usize,
+        arg_locals: &[Option<usize>],
+        first_arg_ty: Option<&TyRef>,
+        dest_local: usize,
+    ) -> Option<(ValueType, String)> {
+        is_string_items_elem_ptr_add_parts(
+            reg,
+            args_len,
+            arg_locals.first().copied().flatten(),
+            first_arg_ty,
+            arg_locals.get(1).copied().flatten(),
+            dest_local,
+            self.body,
+            self.llbc,
+        )
+        .then(|| (ValueType::Str, STRING_GCREF_GCARRAY_TYPE_ID.to_string()))
     }
 
     /// Scalar `GcArray(Signed|Float)` counterpart of
@@ -17186,6 +17334,33 @@ fn regular_call_is_items_block_accessor(reg: &RegularCall, llbc: &Llbc) -> bool 
         .is_some_and(|fd| is_object_items_block_base_accessor(fd.item_meta.name_path().as_str()))
 }
 
+fn regular_call_name_path(reg: &RegularCall, llbc: &Llbc) -> Option<String> {
+    let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+        return None;
+    };
+    llbc.fn_by_id(*id).map(|fd| fd.item_meta.name_path())
+}
+
+/// True for the root-stack publication helper.  Both the free function and
+/// `RootScope` method spell the last two semantic components `gc_roots` and
+/// `pin_root`, with an optional `<Impl>` segment between them.
+fn gc_root_pin_path(name: &str) -> bool {
+    let segments: Vec<&str> = name.split("::").collect();
+    segments.last() == Some(&"pin_root") && segments.iter().any(|s| *s == "gc_roots")
+}
+
+/// Root-stack operations whose PyObjectRef return is the physical spelling
+/// of `llmemory.GCREF`, not a W_Root instance.  Upstream's GC transformer
+/// restores the original external repr after reading this opaque word.
+fn gc_root_gcref_result_path(name: &str) -> bool {
+    let segments: Vec<&str> = name.split("::").collect();
+    segments.iter().any(|s| *s == "gc_roots")
+        && matches!(
+            segments.last(),
+            Some(&"pin_root") | Some(&"shadow_stack_get")
+        )
+}
+
 /// The scalar `TypedItemsBlock` accessor, kept separate from the object-array
 /// pair because its consumers must emit `GcArray(Signed|Float)` operations,
 /// never reference-array operations.
@@ -17197,6 +17372,19 @@ fn regular_call_is_typed_items_block_accessor(reg: &RegularCall, llbc: &Llbc) ->
         let name = fd.item_meta.name_path();
         is_typed_items_block_base_accessor(&name) || is_typed_array_base_adapter(&name)
     })
+}
+
+/// The two unwrapped-string adapters whose Rust return type is the physical
+/// `*mut PyObjectRef`, while their RPython list item is externally `str` and
+/// internally GCREF.  Keep these out of the generic object-array predicate:
+/// sharing the machine word does not make `[str]` and `[W_Root]` the same
+/// ListDef / ARRAY identity upstream.
+fn regular_call_is_string_items_block_accessor(reg: &RegularCall, llbc: &Llbc) -> bool {
+    let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+        return false;
+    };
+    llbc.fn_by_id(*id)
+        .is_some_and(|fd| is_string_array_base_adapter(&fd.item_meta.name_path()))
 }
 
 /// The [`TyRef`] of a plain-place [`Operand`], or `None` for a
@@ -17255,6 +17443,35 @@ fn is_typed_items_elem_ptr_add_parts(
         && index_local.is_some()
         && base_local
             .is_some_and(|base| base_traces_to_typed_items_block_accessor(body, base, llbc))
+        && add_dest_used_only_as_single_deref(body, dest_local)
+}
+
+/// String-list half of brick 3.  The pointee is physically PyObjectRef/GCREF,
+/// but only the two named adapters prove that it is the internal storage of a
+/// `SomeList(SomeString)` rather than a list of W_Root instances.
+#[allow(clippy::too_many_arguments)]
+fn is_string_items_elem_ptr_add_parts(
+    reg: &RegularCall,
+    args_len: usize,
+    base_local: Option<usize>,
+    base_ty: Option<&TyRef>,
+    index_local: Option<usize>,
+    dest_local: usize,
+    body: &Unstructured,
+    llbc: &Llbc,
+) -> bool {
+    args_len == 2
+        && regular_call_is_ptr_add(reg, llbc)
+        && base_ty.is_some_and(|ty| is_object_ref_items_ptr(ty, llbc))
+        && index_local.is_some()
+        && base_local.is_some_and(|base| {
+            base_traces_to_items_block_accessor_matching(
+                body,
+                base,
+                llbc,
+                regular_call_is_string_items_block_accessor,
+            )
+        })
         && add_dest_used_only_as_single_deref(body, dest_local)
 }
 
@@ -19618,8 +19835,9 @@ fn tyref_strips_to_str(ty: &TyRef, llbc: &Llbc) -> bool {
 
 /// Whether a `TyRef` resolves (behind `Ref` / dedup wrappers) to a
 /// string-family value: the `alloc::string::String` ADT, the
-/// `rustpython_wtf8` `Wtf8` / `Wtf8Buf` wrappers, or the `{Builtin: "Str"}`
-/// node (the bare `str` deref destination).  All four project to the
+/// `rustpython_wtf8` `Wtf8` / `Wtf8Buf` wrappers, pyre's `BytesBlock`
+/// owner for RPython `STR`, or the `{Builtin: "Str"}` node (the bare `str`
+/// deref destination).  All of them project to the
 /// single immutable `s_unicode0` value, so a `deref` between any two of
 /// them is value-identity.
 fn tyref_is_string_value(ty: &TyRef, llbc: &Llbc) -> bool {
@@ -19656,13 +19874,20 @@ fn node_is_string_value(node: &serde_json::Value, llbc: &Llbc) -> bool {
     {
         return true;
     }
-    // Named string ADTs: `alloc::string::String` and the WTF-8 wrappers.
+    // Named string ADTs: `alloc::string::String`, the WTF-8 wrappers, and
+    // pyre's variable-sized `BytesBlock` owner for RPython `STR.chars`.
+    // Bookkeeper::project_struct_field_type already makes this exact
+    // projection; keeping the MIR input classifier in sync prevents a
+    // function argument from reintroducing a nominal BytesBlock instance.
     adt_node_def_id(node)
         .and_then(|id| llbc.type_by_id(id))
         .is_some_and(|td| {
             let np = td.item_meta.name_path();
             np == "alloc::string::String"
-                || matches!(np.rsplit("::").next(), Some("Wtf8" | "Wtf8Buf"))
+                || matches!(
+                    np.rsplit("::").next(),
+                    Some("Wtf8" | "Wtf8Buf" | "BytesBlock")
+                )
         })
 }
 
@@ -22045,6 +22270,11 @@ fn is_typed_array_base_adapter(name: &str) -> bool {
         || path_ends_with_segments(name, "float_array::<Impl>::base")
 }
 
+fn is_string_array_base_adapter(name: &str) -> bool {
+    path_ends_with_segments(name, "bytes_array::<Impl>::base")
+        || path_ends_with_segments(name, "unicode_array::<Impl>::base")
+}
+
 /// True for the `ItemsBlock` / `TypedItemsBlock` items-base accessor bodies
 /// whose `.add(*_ITEMS_OFFSET)` the front-end collapses to the
 /// receiver (see [`Lowering::is_items_block_base_ptr_add`]).
@@ -22060,6 +22290,7 @@ fn graph_is_items_block_base_accessor(name: &str) -> bool {
     is_object_items_block_base_accessor(name)
         || is_typed_items_block_base_accessor(name)
         || is_typed_array_base_adapter(name)
+        || is_string_array_base_adapter(name)
 }
 
 /// One path segment, with a raw-identifier prefix removed.  `r#struct` and
@@ -30667,28 +30898,50 @@ mod tests {
             "/../../build/llbc/pyre-object.ullbc"
         );
         let llbc = Llbc::load(path).expect("load real object LLBC");
-        for (base, function, expected_array) in [
+        for (base, function, expected_array, expected_item, offset_leaf) in [
             (
                 "pyre_object::int_array::<Impl>::base",
                 "pyre_object::int_array::<Impl>::push",
                 "[i64]",
+                ValueType::Int,
+                "TYPED_ITEMS_BLOCK_ITEMS_OFFSET",
             ),
             (
                 "pyre_object::float_array::<Impl>::base",
                 "pyre_object::float_array::<Impl>::push",
                 "[f64]",
+                ValueType::Float,
+                "TYPED_ITEMS_BLOCK_ITEMS_OFFSET",
+            ),
+            (
+                "pyre_object::bytes_array::<Impl>::base",
+                "pyre_object::bytes_array::<Impl>::push",
+                super::STRING_GCREF_GCARRAY_TYPE_ID,
+                ValueType::Str,
+                "ITEMS_BLOCK_ITEMS_OFFSET",
+            ),
+            (
+                "pyre_object::unicode_array::<Impl>::base",
+                "pyre_object::unicode_array::<Impl>::push",
+                super::STRING_GCREF_GCARRAY_TYPE_ID,
+                ValueType::Str,
+                "ITEMS_BLOCK_ITEMS_OFFSET",
             ),
         ] {
             let base_graph = super::lower_function(&llbc, base)
                 .unwrap_or_else(|err| panic!("lower {base}: {err}"));
             assert!(
-                !base_graph.blocks.iter().flat_map(|block| &block.operations).any(|op| matches!(
-                    &op.kind,
-                    OpKind::Call {
-                        target: CallTarget::FunctionPath { segments },
-                        ..
-                    } if segments.last().is_some_and(|leaf| leaf == "TYPED_ITEMS_BLOCK_ITEMS_OFFSET")
-                )),
+                !base_graph
+                    .blocks
+                    .iter()
+                    .flat_map(|block| &block.operations)
+                    .any(|op| matches!(
+                        &op.kind,
+                        OpKind::Call {
+                            target: CallTarget::FunctionPath { segments },
+                            ..
+                        } if segments.last().is_some_and(|leaf| leaf == offset_leaf)
+                    )),
                 "{base} must fold the target-layout items offset"
             );
             let graph = super::lower_function(&llbc, function)
@@ -30702,11 +30955,12 @@ mod tests {
                 operations.iter().any(|op| matches!(
                     &op.kind,
                     OpKind::ArrayWrite {
+                        item_ty,
                         array_type_id: Some(array_type_id),
                         ..
-                    } if array_type_id == expected_array
+                    } if array_type_id == expected_array && item_ty == &expected_item
                 )),
-                "{function} must write {expected_array} through setarrayitem"
+                "{function} must write {expected_array}/{expected_item:?} through setarrayitem"
             );
             assert!(
                 !operations.iter().any(|op| matches!(

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -31888,6 +31888,90 @@ mod tests {
         );
     }
 
+    /// Native lock acquisition and the process-global method metadata lookup
+    /// are genuine runtime boundaries.  PyPy reaches the former through
+    /// `rthread.py`'s `llexternal` calls; none may expose Rust's
+    /// `Result<_, PoisonError<_>>::unwrap_or_else` shell to the source graph.
+    #[test]
+    #[ignore]
+    fn native_lock_and_method_metadata_leaves_are_residual() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let residuals = super::dont_look_inside_set_of(&llbc);
+        for expected in [
+            "module::_queue::queue_lock",
+            "module::_queue::simplequeue_wait_for_item",
+            "module::thread::lock_class::lock_state",
+            "module::thread::lock_class::<Impl>::acquire_timed",
+            "module::thread::rlock_class::lock_state",
+            "module::thread::rlock_class::<Impl>::acquire_timed",
+            "function::object_class_method_name",
+        ] {
+            assert!(
+                residuals.contains(expected),
+                "native/runtime leaf {expected} must remain residual; got {residuals:?}"
+            );
+        }
+    }
+
+    /// PyPy's deque mutation marker is an object-resident `lock` identity:
+    /// `modified` stores None, `getlock` lazily stores a new fieldless object,
+    /// and `checklock` compares that field by identity.  The Rust source graph
+    /// must therefore expose ordinary field traffic, never the former
+    /// counter's `core::ptr::read_volatile` shell.
+    #[test]
+    #[ignore]
+    fn deque_mutation_marker_uses_pypy_lock_identity_fields() {
+        use crate::model::{CallTarget, OpKind};
+
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        for name in [
+            "pyre_interpreter::module::_collections::modified",
+            "pyre_interpreter::module::_collections::lock_valid",
+        ] {
+            let graph = super::lower_function(&llbc, name)
+                .unwrap_or_else(|error| panic!("lower {name}: {error}"));
+            assert!(
+                !graph
+                    .blocks
+                    .iter()
+                    .flat_map(|block| &block.operations)
+                    .any(|op| {
+                        matches!(
+                            &op.kind,
+                            OpKind::Call {
+                                target: CallTarget::FunctionPath { segments },
+                                ..
+                            } if super::fmt_path_ends_with(segments, &["ptr", "read_volatile"])
+                                || super::fmt_path_ends_with(segments, &["ptr", "write_volatile"])
+                        )
+                    }),
+                "{name}: PyPy lock identity must not retain volatile-counter calls"
+            );
+            assert!(
+                graph
+                    .blocks
+                    .iter()
+                    .flat_map(|block| &block.operations)
+                    .any(|op| {
+                        matches!(
+                            &op.kind,
+                            OpKind::FieldRead { field, .. } | OpKind::FieldWrite { field, .. }
+                                if field.name == "lock"
+                        )
+                    }),
+                "{name}: expected an object-resident W_Deque.lock access"
+            );
+        }
+    }
+
     /// RPython evaluates `SHIFT`, `HASH_BITS`, `_HASH_SHIFT`, and
     /// `HASH_MODULUS` while building `_hash_long`'s flow graph.  The extracted
     /// Rust graph must likewise contain their integer literals, not synthetic

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1611,7 +1611,7 @@ fn derive_program_metadata(
                 // Register the enum base class in `struct_fields` with
                 // only the synthetic `__discriminant` tag — the sum-type
                 // base carries the discriminant, each variant subclass
-                // carries its OWN payload fields (`rclass.py:82-88`,
+                // carries its OWN payload fields (`rclass.py:499-518`,
                 // registered below under `{enum}::{variant}` keys and
                 // projected onto the variant classdef by
                 // `getuniqueclassdef_for_enum_variant`).
@@ -1673,7 +1673,7 @@ fn derive_program_metadata(
                 // Per-variant field rows + exact offsets under
                 // `{enum}::{variant}` keys — the RPython sum-type subclass
                 // layout where each variant carries its OWN fields, the base
-                // only the discriminant (`rclass.py:82-88`).  These feed the
+                // only the discriminant (`rclass.py:499-518`).  These feed the
                 // variant subclasses (their `getuniqueclassdef_for_enum_variant`
                 // attr projection) and the per-variant runtime offsets.
                 // Dual-published under the qualified and bare-leaf spellings
@@ -3256,10 +3256,19 @@ struct Lowering<'a> {
     /// uses this provenance to emit exactly that pair of flowspace ops.
     string_byte_view_locals: Vec<usize>,
     /// MIR locals holding the `ll_items(l)` view returned by the string-list
-    /// slice adapters.  Rust spells the element as a concrete raw pointer,
-    /// but both byte and unicode strategies expose the same external `str`
-    /// over one internal `GcArray(GCREF)`.
-    string_array_view_locals: Vec<usize>,
+    /// slice adapters, each paired with the list's LOGICAL length.  Rust
+    /// spells the element as a concrete raw pointer, but both byte and
+    /// unicode strategies expose the same external `str` over one internal
+    /// `GcArray(GCREF)`.
+    ///
+    /// The pair exists because the fold drops the fat slice's second word.
+    /// That word is `l.length`, which upstream keeps strictly apart from the
+    /// array header's `ll_fixed_length` / `arraylen_gc`
+    /// (`rlist.py:365-375, 395-397`: `ll_length` reads `l.length` while
+    /// `ll_getitem_fast` asserts against it).  A `Rvalue::Len` over one of
+    /// these locals answers with the recorded length, never with `__len` of
+    /// the header, which is the CAPACITY.
+    string_array_view_locals: Vec<(usize, Variable)>,
     /// Result `Variable`s of calls to callees whose declared result is
     /// `Result<T, PyError>`.  Each
     /// heads a `Try::branch` diamond that
@@ -3446,14 +3455,21 @@ impl<'a> Lowering<'a> {
             // trait's qualified path instead, which the adapter
             // resolves through the unique-impl map
             // (`trait_unique_impls`, keyed by qualified path).
-            let class_root = if i == 1 && gc_root_pin_path(&graph.name) {
-                // RPython's GC transformer publishes every live GC pointer
-                // through llmemory.GCREF, then casts the restored word back
-                // to its source repr.  Rust's `PyObjectRef` parameter is the
-                // physical carrier for that opaque slot, not a W_Root
-                // instance.  Preserve the GCREF input boundary explicitly so
-                // StringRepr and InstanceRepr callers never meet in one
-                // source-level FunctionDesc cell.
+            // RPython's GC transformer casts a GC helper's pointer *argument*
+            // to `llmemory.GCREF` before the call — `gct_gc_identityhash`
+            // (`framework.py:1174-1182`) does
+            // `[v_ptr] = hop.spaceop.args; v_ptr = hop.genop("cast_opaque_ptr",
+            // [v_ptr], resulttype=llmemory.GCREF)`.  Rust's `PyObjectRef`
+            // parameter is the physical carrier for that opaque slot, not a
+            // W_Root instance.  Preserve the GCREF input boundary explicitly so
+            // StringRepr and InstanceRepr callers never meet in one
+            // source-level FunctionDesc cell.
+            //
+            // Key it on the LAST parameter, never on index 1: both spellings
+            // `gc_root_pin_path` admits take exactly one `PyObjectRef`, but the
+            // `RootScope` method form puts `&self` first, so stamping index 1
+            // there annotates the receiver and leaves the GC pointer untouched.
+            let class_root = if i == arg_count && gc_root_pin_path(&graph.name) {
                 Some("GCREF".to_string())
             } else {
                 match &ty {
@@ -5132,8 +5148,8 @@ impl<'a> Lowering<'a> {
                     }
                     // Pointer -> unsigned-word cast is two operations in
                     // RPython, not a `cast_ptr_to_int` whose result is merely
-                    // labelled Unsigned.  `rbuiltin.py:528-539`
-                    // (`rtype_cast_primitive`) first emits
+                    // labelled Unsigned.  `rbuiltin.py`'s `gen_cast` (which
+                    // `rtype_cast_primitive` delegates to) first emits
                     // `cast_ptr_to_int(..., resulttype=Signed)` and then
                     // `gen_cast(..., TGT=Unsigned)`.  Rust's `p as usize`
                     // reaches this arm directly, so materialise that same
@@ -5350,6 +5366,18 @@ impl<'a> Lowering<'a> {
             // `Len(place)` — slice / array length. Synthetic 1-arg
             // call; needs no descriptor for now.
             Rvalue::Len(place) => {
+                // A string-list items view is one word — the `GcArray` header
+                // — so `__len` over it is `ll_fixed_length` / `arraylen_gc`,
+                // the CAPACITY.  `ll_length` reads the list's own `l.length`
+                // (`rlist.py:365-366`), which the fold recorded; answer with
+                // that, and keep the two apart exactly as upstream does.
+                if let Some((_, logical_len)) = self
+                    .string_array_view_locals
+                    .iter()
+                    .find(|(local, _)| place_references_local(&place, *local))
+                {
+                    return Ok((None, logical_len.clone()));
+                }
                 let base = self.resolve_place(mir_bb, place)?;
                 let res = self
                     .graph
@@ -5615,7 +5643,8 @@ impl<'a> Lowering<'a> {
                         .map(|(name, field_ty, _)| (name.clone(), field_ty.clone()))
                         .unwrap_or_else(|| (format!("__pos_{i}"), String::new()));
                     let declared_ty = field_rows.get(i).and_then(|(_, _, ty)| ty.as_ref());
-                    // `_names_without_voids()` / `heaptracker.py:104-105`: a
+                    // `_names_without_voids()` (`lltype.py:333`) /
+                    // `heaptracker.py:100-101`: a
                     // zero-sized field occupies no storage and gets no slot,
                     // so no write is generated for it.
                     if crate::codewriter::call::get_type_flag(&field_ty).1
@@ -6291,7 +6320,7 @@ impl<'a> Lowering<'a> {
                     let string_array_view = self
                         .string_array_view_locals
                         .iter()
-                        .any(|&local| place_references_local(&inner, local));
+                        .any(|(local, _)| place_references_local(&inner, *local));
                     let (mut array_type_id, nolength) =
                         array_projection_metadata(&inner.ty, self.llbc);
                     if string_array_view {
@@ -7849,9 +7878,9 @@ impl<'a> Lowering<'a> {
             args.push(self.resolve_operand(mir_bb, op)?);
         }
         let first_arg_is_string_array_view = args.first().is_some_and(|arg| {
-            self.string_array_view_locals.iter().any(|&local| {
+            self.string_array_view_locals.iter().any(|(local, _)| {
                 self.local_var
-                    .get(local)
+                    .get(*local)
                     .and_then(Option::as_ref)
                     .is_some_and(|current| current == arg)
             })
@@ -7910,18 +7939,25 @@ impl<'a> Lowering<'a> {
                         return Ok(());
                     }
                 }
-                // Rust exposes RPython's generated shadow-stack publication
-                // as a normal `pin_root(PyObjectRef)` call.  Its parameter is
-                // actually `llmemory.GCREF`, irrespective of the source
-                // pointer's external repr.  Cast every caller to that opaque
-                // slot before FunctionDesc propagation so strings, W_Root
-                // instances, and other GC pointers do not union at the
-                // helper's single input cell.
-                if callee_pin_gcref_arg && args.len() == 1 {
-                    args[0] = self
+                // Rust exposes RPython's generated shadow-stack publication as
+                // a normal `pin_root(PyObjectRef)` call.  Its pointer argument
+                // is actually `llmemory.GCREF`, irrespective of the source
+                // pointer's external repr, so cast it the way
+                // `gct_gc_identityhash` casts a GC helper's pointer argument
+                // (`framework.py:1174-1182`) — before FunctionDesc propagation,
+                // so strings, W_Root instances, and other GC pointers do not
+                // union at the helper's single input cell.
+                //
+                // The pointer is the LAST argument: the `RootScope` method form
+                // `gc_root_pin_path` also admits passes `&self` first, and
+                // gating on `args.len() == 1` skipped it entirely, leaving the
+                // definition-side stamp and the call site disagreeing about the
+                // same callee.
+                if callee_pin_gcref_arg && let Some(last) = args.len().checked_sub(1) {
+                    args[last] = self
                         .narrow_value_to_instance_root(
                             bb_id,
-                            LinkArg::Value(args[0].clone()),
+                            LinkArg::Value(args[last].clone()),
                             "GCREF",
                         )
                         .as_variable()
@@ -8236,17 +8272,16 @@ impl<'a> Lowering<'a> {
                             result_ty: ValueType::Int,
                         },
                     });
-                    self.index_elem_alias.insert(
-                        dest_local,
-                        IndexElemAlias {
-                            base_local: arg_locals.first().copied().flatten(),
-                            base_var: args[0].clone(),
-                            index_local: arg_locals.get(1).copied().flatten(),
-                            index_var: args[1].clone(),
-                            item_ty: ValueType::Int,
-                            array_type_id: None,
-                        },
-                    );
+                    // No `index_elem_alias` entry.  That table exists so a
+                    // paired `*p = v` becomes an `ArrayWrite` over the same
+                    // base, and this base is a `StringRepr` value — upstream
+                    // has no `setitem` on one (`rstr.py` offers only
+                    // `ll_str2mutable` / `mutable_str` for writes), so the
+                    // write half cannot exist.  The arm is already guarded by
+                    // `!is_slice_scalar_index_mut_call`, but recording an
+                    // alias whose pairing would mint an op RPython does not
+                    // have is a latent illegal-op source, and it also feeds
+                    // `compute_index_write_extra_live`'s liveness reasoning.
                     self.local_var[dest_local] = Some(res);
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
@@ -8265,17 +8300,23 @@ impl<'a> Lowering<'a> {
                 let element_node = tyref_index_element_node(&call.dest.ty, self.llbc);
                 let element_scalar =
                     element_node.and_then(|elem| json_ty_scalar_element_spelling(elem, self.llbc));
-                // RPython's string list item is one GC pointer
-                // (`lltypesystem/rstr.py:229-230`, `StringRepr.lowleveltype =
-                // Ptr(STR)`).  Rust's `&str` is a fat pointer before source
-                // translation, but the translated value is the same
-                // `SomeString` / `Ptr(STR)` used for `String`, `Wtf8`, and
-                // `Wtf8Buf` everywhere else in this front end.  Name that
-                // translated element `str` so `get_array_descr` computes the
-                // RPython pointer item, never the host Rust width.
-                let element_rpython_ref = element_node
-                    .and_then(|elem| json_ty_rpython_gc_pointer_element_spelling(elem, self.llbc));
-                let element_spelling = element_scalar.or(element_rpython_ref);
+                // A string-family or tuple element gets NO spelling here, even
+                // though `StringRepr.lowleveltype = Ptr(STR)` (`rstr.py`,
+                // `StringRepr`) and `TUPLE_TYPE` (`rtuple.py`) really are one
+                // GC pointer inside an RPython list.  Those describe the repr
+                // of a list the translation BUILDS; the container under this
+                // arm is a host Rust one that no translation replaces, and the
+                // read strides over its real memory.  `&str` is two words
+                // there, `String`/`Wtf8Buf` three, and `(Wtf8Buf,
+                // PyObjectRef)` four, so naming any of them a one-word item
+                // reads the wrong address from the second element on.  The
+                // managed `GcArray(GCREF)` items view — the one container that
+                // IS one word per item — carries its own proof
+                // (`first_arg_is_string_array_view`) and mints
+                // `STRING_GCREF_GCARRAY_TYPE_ID` below without asking here;
+                // routing host containers through the same `[str]` identity
+                // would also alias them into that array's `_cache_array` slot.
+                let element_spelling = element_scalar;
                 let element_is_addressable = element_spelling.is_some()
                     || element_node
                         .is_some_and(|elem| json_ty_is_thin_pointer_element(elem, self.llbc));
@@ -8961,6 +9002,15 @@ impl<'a> Lowering<'a> {
                     // append.  Keep the initial value as an append operand;
                     // passing it to `new` would misread it as the optional
                     // integer capacity argument.
+                    //
+                    // So the builder is born at `INIT_SIZE`, not at
+                    // `len(initial)`.  That is the size RPython source with
+                    // this shape gets: `b = StringBuilder(); b.append(s)`
+                    // reaches `rtyper_new` with `len(hop.args_v) == 0`
+                    // (`rtyper/rbuilder.py:8-14`).  `convert_const`'s
+                    // `ll_new(len(s))` (`:57-63`) is the PREBUILT-constant
+                    // path — a builder already built at translation time —
+                    // and is not this callsite.
                     if builder_ctor_leaf == Some("from_string") {
                         let void = self
                             .graph
@@ -9132,7 +9182,7 @@ impl<'a> Lowering<'a> {
                 // the same address; it neither allocates nor changes the
                 // pointer representation.  The translated object model keeps
                 // these slots as their upstream scalar fields (for example
-                // unicode `hash`, `rstr.py:411-412`), so alias the view to the
+                // unicode `hash`, `rstr.py:1238`), so alias the view to the
                 // field pointer exactly like the raw-pointer casts above.
                 if args.len() == 1 && self.is_atomic_from_ptr_identity(&reg) {
                     self.local_var[dest_local] = Some(args[0].clone());
@@ -9283,8 +9333,15 @@ impl<'a> Lowering<'a> {
                             .expect("a string-items view stays a Variable")
                             .clone(),
                     );
-                    if !self.string_array_view_locals.contains(&dest_local) {
-                        self.string_array_view_locals.push(dest_local);
+                    // The dropped second word IS `l.length`; keep it so a
+                    // `Rvalue::Len` over the view answers with it.
+                    if !self
+                        .string_array_view_locals
+                        .iter()
+                        .any(|(local, _)| *local == dest_local)
+                    {
+                        self.string_array_view_locals
+                            .push((dest_local, args[1].clone()));
                     }
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
@@ -9663,6 +9720,8 @@ impl<'a> Lowering<'a> {
                     && let Some(owner) = self.string_array_slice_view_owner(&reg)
                 {
                     let block = self.emit_string_array_items_read(bb_id, args[0].clone(), owner);
+                    let logical_len =
+                        self.emit_string_array_len_read(bb_id, args[0].clone(), owner);
                     let view = self.narrow_value_to_instance_root(
                         bb_id,
                         LinkArg::Value(block),
@@ -9673,8 +9732,15 @@ impl<'a> Lowering<'a> {
                             .expect("a string-items view stays a Variable")
                             .clone(),
                     );
-                    if !self.string_array_view_locals.contains(&dest_local) {
-                        self.string_array_view_locals.push(dest_local);
+                    // Same pairing as the `from_raw_parts` fold above: the
+                    // view is the header, `l.length` is its own field.
+                    if !self
+                        .string_array_view_locals
+                        .iter()
+                        .any(|(local, _)| *local == dest_local)
+                    {
+                        self.string_array_view_locals
+                            .push((dest_local, logical_len));
                     }
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
@@ -11919,9 +11985,11 @@ impl<'a> Lowering<'a> {
     /// ARRAY identity proof for the scalar-index `<[T]>::get` rewrite.
     ///
     /// This is the `get` counterpart of the `Index::index` element gate: a
-    /// scalar or an RPython GC-pointer value carries an element spelling so
-    /// the descr computes its exact stride; a thin pointer is already one
-    /// word and needs no identity. Any other inline Rust aggregate declines.
+    /// scalar carries an element spelling so the descr computes its exact
+    /// stride; a thin pointer is already one word and needs no identity. Any
+    /// other inline Rust aggregate declines — including a string or tuple
+    /// element, which is one GC pointer only inside a list the translation
+    /// builds, never inside the host slice this call reads.
     /// The outer `Option` is the proof, while the inner one is the optional
     /// ARRAY identity (`Some(None)` means the proven thin-pointer case).
     fn slice_get_element(&self, reg: &RegularCall) -> Option<(ValueType, Option<String>)> {
@@ -11937,9 +12005,7 @@ impl<'a> Lowering<'a> {
         // T, not a Rust slot reference.  Read the bank from the call's T
         // generic before looking at the reference-wrapped destination.
         let item_ty = tyref_to_value_type(&element_ty, self.llbc);
-        if let Some(spelling) = json_ty_scalar_element_spelling(element, self.llbc)
-            .or_else(|| json_ty_rpython_gc_pointer_element_spelling(element, self.llbc))
-        {
+        if let Some(spelling) = json_ty_scalar_element_spelling(element, self.llbc) {
             return Some((item_ty, Some(format!("[{spelling}]"))));
         }
         json_ty_is_thin_pointer_element(element, self.llbc).then_some((item_ty, None))
@@ -12973,6 +13039,10 @@ impl<'a> Lowering<'a> {
         result
     }
 
+    /// The logical `l.length` of a string-list storage record — the second
+    /// word the `from_raw_parts` view fold drops.  Upstream reads it as the
+    /// list's own field (`ll_length`, `rlist.py:365-366`), strictly apart
+    /// from the array header's `ll_fixed_length` / `arraylen_gc`.
     fn emit_string_array_len_read(
         &mut self,
         bb_id: BlockId,
@@ -14946,10 +15016,17 @@ impl<'a> Lowering<'a> {
         let Some(receiver_ty) = fd.signature.inputs.first() else {
             return Ok(false);
         };
-        if !matches!(
-            self.tyref_literal_uint_atom(receiver_ty),
-            Some("U64" | "Usize")
-        ) {
+        // Upstream picks the rotate constants from the word width
+        // (`tupleobject.py`: `if sys.maxint == 2 ** 31 - 1` chooses
+        // `(x << 13) | (x >> 19)`, the else arm `(x << 31) | (x >> 33)`).
+        // The fold below is that 64-bit arm, so `u64` always qualifies and
+        // `usize` only where the target word IS eight bytes.
+        let width_matches_the_64_bit_arm = match self.tyref_literal_uint_atom(receiver_ty) {
+            Some("U64") => true,
+            Some("Usize") => crate::layout::target_word_size() == 8,
+            _ => false,
+        };
+        if !width_matches_the_64_bit_arm {
             return Ok(false);
         }
         let Some(raw_count) = self
@@ -15679,7 +15756,7 @@ impl<'a> Lowering<'a> {
 
     /// Lower the fallible `i32::try_from(i64)` core shell to the checked
     /// narrowing shape PyPy writes directly in
-    /// `ObjSpace.c_int_w` (`baseobjspace.py:2082-2088`): the value succeeds
+    /// `ObjSpace.c_int_w` (`baseobjspace.py:2062-2068`): the value succeeds
     /// exactly when `INT_MIN <= value <= INT_MAX`. Rust carries the two
     /// branches in a `Result<i32, TryFromIntError>`, so preserve that source
     /// CFG by materializing `Ok=0` / `Err=1` and leaving the caller's match
@@ -15775,12 +15852,15 @@ impl<'a> Lowering<'a> {
                 result_ty: ValueType::Int,
             },
         );
-        // The predicates are mutually exclusive, so their sum is exactly the
-        // Result discriminant: 0 in range (Ok), 1 out of range (Err).
+        // `c_int_w` joins the two bound tests with `or`
+        // (`baseobjspace.py:2066`), so join them with the registered `or_`
+        // operator (`operation.py:486`) rather than with arithmetic: the
+        // result is the Result discriminant, 0 in range (Ok), 1 out of range
+        // (Err).
         let disc = push_op(
             &mut self.graph,
             OpKind::BinOp {
-                op: "add".to_string(),
+                op: "or".to_string(),
                 lhs: below,
                 rhs: above,
                 result_ty: ValueType::Int,
@@ -16363,6 +16443,17 @@ impl<'a> Lowering<'a> {
     /// `Result::Ok`) — so its runtime offset matches the
     /// `resolve_adt_field` read, which is variant-qualified
     /// (`{enum_leaf}::{variant}`).
+    ///
+    /// **Precondition on the caller.**  The write is unconditional: the
+    /// payload lands under the success variant on the failure arm too.  The
+    /// tagged pair has one payload slot, so nothing is corrupted, but a
+    /// failure variant whose payload some consumer READS would read this
+    /// value under a variant-qualified key that was never written.  Every
+    /// caller here fails with a payload no consumer reads —
+    /// `Option::None` carries none, and `i32::try_from`'s
+    /// `TryFromIntError(())` is the unit — so the read cannot occur.  A new
+    /// caller whose failure arm carries live data must branch instead of
+    /// reusing this tail.
     #[expect(
         clippy::too_many_arguments,
         reason = "The parameter order mirrors the corresponding RPython translation routine; grouping arguments into a Rust-only context object would obscure line-by-line parity and ownership"
@@ -17172,9 +17263,19 @@ fn append_receiver_of_borrow(body: &Unstructured, llbc: &Llbc, rt: usize) -> Opt
     append_arg_of_borrow(body, llbc, rt, true)
 }
 
+/// [`append_receiver_of_borrow`]'s twin for the appended PIECE: walk the
+/// reference/coercion shells the lowered string model aliases away
+/// ([`sole_string_alias_successor`]) until one of them is the sole
+/// non-accumulator argument of an append call, and return that temp.
+///
+/// The walk is bounded because it is a walk over MIR temps and nothing
+/// proves the alias chain acyclic; eight hops is far past every chain the
+/// real LLBC produces (`&Wtf8Buf` -> `&Wtf8` -> `&str` is three), and a
+/// chain longer than that simply declines the builder lift and leaves the
+/// residual — the same fail-safe every recognizer in this file takes.
 fn append_piece_of_borrow(body: &Unstructured, llbc: &Llbc, rt: usize) -> Option<usize> {
     let mut current = rt;
-    for _ in 0..8 {
+    for _ in 0..ALIAS_WALK_HOPS {
         if ref_temp_is_sole_append_arg(body, llbc, current, false) {
             return Some(current);
         }
@@ -17182,6 +17283,10 @@ fn append_piece_of_borrow(body: &Unstructured, llbc: &Llbc, rt: usize) -> Option
     }
     None
 }
+
+/// Hop budget for a reference/coercion alias walk over MIR temps.  See
+/// [`append_piece_of_borrow`] for why it is bounded and why eight.
+const ALIAS_WALK_HOPS: usize = 8;
 
 /// Follow one Rust reference/coercion shell which the lowered string value
 /// model aliases away: an immediate reborrow, or `Deref::deref` between two
@@ -17264,6 +17369,10 @@ fn sole_string_alias_successor(body: &Unstructured, llbc: &Llbc, source: usize) 
     (other == 0).then_some(successor?)
 }
 
+/// The shared body behind [`append_receiver_of_borrow`] (`accumulator =
+/// true`) and its piece-side caller: return `rt` when it already is the
+/// selected append argument, else the single temp that borrows it and is.
+/// More than one such borrower is ambiguous and declines.
 fn append_arg_of_borrow(
     body: &Unstructured,
     llbc: &Llbc,
@@ -17716,13 +17825,24 @@ fn gc_root_pin_path(name: &str) -> bool {
 
 /// Root-stack operations whose PyObjectRef return is the physical spelling
 /// of `llmemory.GCREF`, not a W_Root instance.  Upstream's GC transformer
-/// restores the original external repr after reading this opaque word.
+/// gives such a helper call a GCREF result and casts it back to the concrete
+/// repr at the use site — `gct_weakref_create` (`framework.py:1151-1154`)
+/// does `genop("direct_call", ..., resulttype=llmemory.GCREF)` followed by
+/// `genop("cast_opaque_ptr", [v_result], resulttype=WEAKREFPTR)`.
+///
+/// `RootScope::get` is admitted alongside `shadow_stack_get`: its own source
+/// doc calls it "scope-local [`shadow_stack_get`] using the cached cell", and
+/// it is the read half of the `pin_root` write half stamped above.  Leaving
+/// it out publishes a root through the opaque slot and reads it back as a
+/// W_Root instance, re-creating on the read side exactly the StringRepr-meets-
+/// InstanceRepr union the write-side stamp exists to remove.  `get` is the
+/// only such leaf in `gc_roots`, so the match stays unambiguous.
 fn gc_root_gcref_result_path(name: &str) -> bool {
     let segments: Vec<&str> = name.split("::").collect();
     segments.iter().any(|s| *s == "gc_roots")
         && matches!(
             segments.last(),
-            Some(&"pin_root") | Some(&"shadow_stack_get")
+            Some(&"pin_root") | Some(&"shadow_stack_get") | Some(&"get")
         )
 }
 
@@ -18191,6 +18311,16 @@ fn compute_index_write_extra_live(body: &Unstructured, llbc: &Llbc) -> Vec<Vec<u
                 llbc,
             )
             || is_typed_items_elem_ptr_add_parts(
+                reg,
+                call.args.len(),
+                operand_local(call.args.first()),
+                call.args.first().and_then(operand_tyref),
+                operand_local(call.args.get(1)),
+                p as usize,
+                body,
+                llbc,
+            )
+            || is_string_items_elem_ptr_add_parts(
                 reg,
                 call.args.len(),
                 operand_local(call.args.first()),
@@ -19438,7 +19568,7 @@ fn cast_call_segments(src: &ValueType, dst: &ValueType) -> Option<Vec<String>> {
 
 /// Emit RPython's pointer-to-Unsigned primitive cast sequence.
 ///
-/// `rbuiltin.py:528-539` first produces a Signed address integer with
+/// `rbuiltin.py`'s `gen_cast` first produces a Signed address integer with
 /// `cast_ptr_to_int`, then applies `gen_cast(..., Unsigned)`.  The caller
 /// appends the returned `r_uint` operation after the Signed producer pushed
 /// here, preserving that ordering while fitting [`Lowering::build_rvalue`]'s
@@ -20959,34 +21089,6 @@ fn json_ty_is_thin_pointer_element(node: &serde_json::Value, llbc: &Llbc) -> boo
     json_ty_is_statically_sized(pointee, llbc)
 }
 
-/// The element spelling of source values whose RPython repr is a one-word GC
-/// pointer even though their Rust source representation is wider.
-///
-/// RPython strings are `Ptr(STR)` (`lltypesystem/rstr.py:229-230`) and
-/// non-empty tuples are `Ptr(GcStruct(...))` (`rtuple.py:116-126`).  These are
-/// exactly the two non-scalar value families a PyPy list stores by reference;
-/// admitting arbitrary named Rust ADTs here would falsely shrink inline host
-/// structs to one word.
-fn json_ty_rpython_gc_pointer_element_spelling(
-    node: &serde_json::Value,
-    llbc: &Llbc,
-) -> Option<String> {
-    let ty = TyRef::Other(node.clone());
-    if tyref_is_string_value(&ty, llbc) {
-        return Some("str".to_string());
-    }
-    let node = strip_ty_indirections(node, llbc)?;
-    let adt = node.as_object()?.get("Adt")?.as_object()?;
-    if adt.get("id").and_then(serde_json::Value::as_str) != Some("Tuple") {
-        return None;
-    }
-    let types = adt.get("generics")?.as_object()?.get("types")?.as_array()?;
-    if types.is_empty() {
-        return None;
-    }
-    Some(charon_type_value_to_ast_string(node, llbc, 0))
-}
-
 /// `true` when `node` names a type of compile-time-known size, which is what
 /// makes a pointer to it thin.
 ///
@@ -21087,6 +21189,12 @@ fn typevar_bound_index(node: &serde_json::Value) -> Option<u64> {
 /// target must resolve to the translated string-value family, with the
 /// trait decl's leaf name `Into` (a `From<String>` bound has the same
 /// generics shape but means the *opposite* conversion).
+///
+/// The target test is [`node_is_string_value`], whose family is `str`,
+/// `String`, `Wtf8`, `Wtf8Buf` AND `BytesBlock` — so an `Into<BytesBlock>`
+/// bound would resolve here too.  No such bound exists in the source today;
+/// if one appears, note that `BytesBlock` is the low-level `STR` owner rather
+/// than a source-level message type and may want excluding.
 fn typevar_bounded_by_into_string_value(
     var_index: u64,
     fn_generics: &serde_json::Value,
@@ -22651,6 +22759,14 @@ fn is_string_array_base_adapter(name: &str) -> bool {
 /// invariant above from pulling a scalar block into the `Ref`-typed array ops
 /// — the element side is refused by [`is_object_ref_items_ptr`] as well, so the
 /// two gates agree by construction rather than by coincidence.
+/// The `is_string_array_base_adapter` arm is currently INERT through the sole
+/// consumer [`Lowering::is_items_block_base_ptr_add`], which also requires a
+/// `ptr::add` / `wrapping_add` in the same body: `BytesArray::base` /
+/// `UnicodeArray::base` are `items_block_items_base(self.block)`, a call, and
+/// carry no `.add` to collapse.  It is kept so the predicate answers the
+/// question its name asks for the whole family, and it becomes live the
+/// moment either body spells the offset itself — but do not read a passing
+/// `offset_leaf` assertion over those two graphs as evidence that it fired.
 fn graph_is_items_block_base_accessor(name: &str) -> bool {
     is_object_items_block_base_accessor(name)
         || is_typed_items_block_base_accessor(name)
@@ -22744,18 +22860,28 @@ fn primitive_float_const(segments: &[String]) -> Option<OpKind> {
 
 /// Target-layout value of the scalar GcArray's items offset.  Charon leaves
 /// Rust's `offset_of!(TypedItemsBlock, items)` initializer opaque, but the
-/// translated lltype fixes the same layout structurally: one target-word
-/// length header followed by an 8-byte-aligned Signed/Float item array
-/// (`rlist.py:84,116`).  This is the front-end counterpart of
-/// `CallControl::array_items_base`; it derives the target value instead of
-/// importing a host-runtime constant or registering a fake residual getter.
+/// translated lltype fixes the same layout structurally: a length header
+/// followed inline by the `GcArray(Signed|Float)` items
+/// (`get_itemarray_lowleveltype`, `rlist.py:84`).
+///
+/// The derivation is `align_of::<u64>()` padding of that header, not "one
+/// target word": the Rust body is `#[repr(C)] { capacity: usize, items:
+/// [u64; 0] }` (`majit/majit-rlib/src/lltypesystem/rlist.rs:165-171`), whose
+/// 8-byte item alignment rounds a 4- or 8-byte header up to the same 8.  The
+/// offset is therefore width-independent, which is why reading `word` from
+/// [`crate::layout::target_word_size`] here rather than from Charon's
+/// `target_pointer_size` cannot change the answer.
+///
+/// This is the front-end counterpart of `CallControl::array_items_base`; it
+/// derives the target value instead of importing a host-runtime constant or
+/// registering a fake residual getter.
 fn known_array_layout_const(segments: &[String]) -> Option<OpKind> {
     let path = segments.join("::");
     if !path_ends_with_segments(&path, "rlist::TYPED_ITEMS_BLOCK_ITEMS_OFFSET") {
         return None;
     }
-    let word = crate::layout::target_word_size();
-    let items_offset = word.div_ceil(8) * 8;
+    let header = crate::layout::target_word_size();
+    let items_offset = header.next_multiple_of(align_of::<u64>());
     Some(OpKind::ConstInt(items_offset as i64))
 }
 
@@ -23709,14 +23835,17 @@ fn block_reachable(graph: &FunctionGraph, target: BlockId) -> bool {
 ///   current piece — the encoding a literal of 128+ bytes takes (a single
 ///   length byte tops out at `0x7F`), e.g. the 130-byte deprecation tail
 ///   in `space_int` / `space_index`;
-/// - sequential placeholder: the single byte `0xC0` — closes the current
-///   piece, begins the next, and renders the next argument in order (the
-///   Display-vs-Debug choice lives in the parallel args array, not in this
-///   template, so a placeholder carries no kind);
-/// - explicit / reused placeholder: `0xC8` followed by a little-endian
-///   `u16` argument index — a 3-byte token that renders `args[index]`, so
-///   a `{0}…{0}` template that names one argument twice packs two `0xC8`
-///   tokens pointing at index `0`;
+/// - placeholder: any byte `>= 0xC0`, whose low bits select which optional
+///   fields follow it, each little-endian: `0x01` a `u32` flag word, `0x02`
+///   a `u16` width, `0x04` a `u16` precision, `0x08` a `u16` argument index.
+///   Without `0x08` the placeholder is sequential and takes the next
+///   argument in order.  A bare `0xC0` is therefore the plain `{}` and
+///   `0xC8` + `u16` the explicit `{0}`, but they are two points in one
+///   grammar, not two tokens: every field length is decoded so an embedded
+///   zero byte is never mistaken for the terminator.  Bits `0x10` / `0x20`
+///   mark an indirect width / precision (`{:1$}`), whose encoding this
+///   decoder does not know, so it bails on them.  The Display-vs-Debug
+///   choice lives in the parallel args array, not in this template;
 /// - terminator: a `0x00` byte (only at a segment boundary; `0`/`0xC0`
 ///   bytes inside a literal are consumed by its length prefix).
 ///
@@ -23733,9 +23862,11 @@ fn block_reachable(graph: &FunctionGraph, target: BlockId) -> bool {
 /// `0xC8` index points back at an already-seen argument, so the distinct
 /// argument count is `max(arg_indices) + 1`, which can be less than the
 /// placeholder count.  Returns `None` (bail, leaving the graph untouched)
-/// on any high-bit control byte other than `0xC0`/`0xC8` — a format spec
-/// with width/precision/fill or a named argument — and on non-UTF-8
-/// literal bytes.
+/// on `0x81..=0xBF` (neither a literal length nor a placeholder), on an
+/// indirect width/precision bit, on a truncated field, on a missing `0x00`
+/// terminator, and on non-UTF-8 literal bytes.  A placeholder that carries
+/// flags/width/precision is decoded rather than refused; refusing it is the
+/// job of `FmtPlaceholder::is_default()`, which every collapse consults.
 fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, Vec<FmtPlaceholder>)> {
     let mut pieces: Vec<String> = Vec::new();
     let mut current = String::new();
@@ -23796,13 +23927,23 @@ fn decode_packed_format_pieces(bytes: &[u8]) -> Option<(Vec<String>, Vec<FmtPlac
                 auto += 1;
                 index
             };
+            // An indirect width/precision (`{:1$}`) names an argument for
+            // the field instead of inlining it, and this decoder does not
+            // know how many bytes that costs.  Guessing would desync the
+            // byte stream, and a desync that happened to land on one default
+            // placeholder would be accepted by the collapses downstream —
+            // so refuse the template outright.  No consumer accepts a
+            // non-default placeholder anyway.
+            if b & 0x30 != 0 {
+                return None;
+            }
             placeholders.push(FmtPlaceholder {
                 arg_index,
                 flags,
                 width,
                 precision,
-                width_indirect: b & 0x10 != 0,
-                precision_indirect: b & 0x20 != 0,
+                width_indirect: false,
+                precision_indirect: false,
             });
         } else if b == 0x80 {
             // long literal segment: `0x80` + little-endian u16 length,
@@ -24306,21 +24447,33 @@ fn emit_fmt_expansion_ops(
     ops
 }
 
-/// Expand the byte-only `{:02x}` in `bytearray_repr_string` to the exact
-/// operations PyPy uses in `bytearrayobject.py::descr_repr`:
+/// Expand a byte-only `{:02x}` placeholder to the nibble lookup PyPy uses in
+/// `bytearrayobject.py::descr_repr` (`bytearrayobject.py:286-290`):
 ///
 /// ```python
-/// digits = "0123456789abcdef"
-/// digits[n >> 4] + digits[n & 0xF]
+///             elif not '\x20' <= c < '\x7f':
+///                 n = ord(c)
+///                 buf.append('\\x')
+///                 buf.append("0123456789abcdef"[n >> 4])
+///                 buf.append("0123456789abcdef"[n & 0xF])
 /// ```
+///
+/// Upstream appends three values into a `StringBuilder`; the Rust shell this
+/// replaces is a `format!` that *returns* a `String`, so the same three values
+/// are folded left through `add` (`ll_strconcat`) into the displaced format
+/// result instead.  `pieces` carries the template's literal halves — for the
+/// `format!("\\x{c:02x}")` shell that is `["\\x", ""]`, and the leading `\x`
+/// is upstream's first `buf.append`, so it must be emitted, not merely
+/// matched.
 ///
 /// The caller proves the formatted value came from a `(u8,)` argument tuple,
 /// so two digits are complete (never truncating a wider integer).  Each
 /// getitem annotates as `SomeChar`; `str(char)` follows
-/// `AbstractCharRepr.ll_str -> ll_chr2str`, and the final `add` is ordinary
-/// `StringRepr` concatenation.  No Rust fmt runtime or new helper survives.
+/// `AbstractCharRepr.ll_str -> ll_chr2str` (`rstr.py:554-555`).  No Rust fmt
+/// runtime or new helper survives.
 fn emit_lower_hex_byte_02_ops(
     graph: &mut FunctionGraph,
+    pieces: &[String],
     value: &Variable,
     result: Variable,
 ) -> Vec<SpaceOperation> {
@@ -24413,15 +24566,60 @@ fn emit_lower_hex_byte_02_ops(
             result_ty: ValueType::Str,
         },
     });
-    ops.push(SpaceOperation {
-        result: Some(result),
-        kind: OpKind::BinOp {
-            op: "add".to_string(),
-            lhs: hi,
-            rhs: lo,
-            result_ty: ValueType::Str,
-        },
-    });
+    // Upstream's `buf.append('\\x')` — the template's leading literal — comes
+    // first, then the two nibble characters.  A non-empty trailing piece is
+    // appended last; the `["\\x", ""]` shell has none.
+    let mut parts: Vec<Variable> = Vec::new();
+    if !pieces[0].is_empty() {
+        let literal = alloc(graph);
+        ops.push(SpaceOperation {
+            result: Some(literal.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec!["__str_const".to_string(), pieces[0].clone()],
+                },
+                args: vec![],
+                result_ty: ValueType::Ref(None),
+            },
+        });
+        parts.push(literal);
+    }
+    parts.push(hi);
+    parts.push(lo);
+    if pieces.len() > 1 && !pieces[1].is_empty() {
+        let literal = alloc(graph);
+        ops.push(SpaceOperation {
+            result: Some(literal.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec!["__str_const".to_string(), pieces[1].clone()],
+                },
+                args: vec![],
+                result_ty: ValueType::Ref(None),
+            },
+        });
+        parts.push(literal);
+    }
+    // Left-fold the parts through `add` (`ll_strconcat`).
+    let mut acc = parts[0].clone();
+    for part in &parts[1..] {
+        let sum = alloc(graph);
+        ops.push(SpaceOperation {
+            result: Some(sum.clone()),
+            kind: OpKind::BinOp {
+                op: "add".to_string(),
+                lhs: acc.clone(),
+                rhs: part.clone(),
+                result_ty: ValueType::Str,
+            },
+        });
+        acc = sum;
+    }
+    // Reuse the displaced format result var on the final op so the downstream
+    // link still forwards the rendered String.
+    if let Some(last) = ops.last_mut() {
+        last.result = Some(result);
+    }
     ops
 }
 
@@ -24771,6 +24969,10 @@ fn collapse_fmt_chains(graph: &mut FunctionGraph) -> usize {
 struct LowerHexByteFmtCollapse {
     format_block: BlockId,
     format_result: u64,
+    /// The template's literal halves, carried so the expansion re-emits the
+    /// leading `\x` — upstream's first `buf.append` — instead of consuming it
+    /// as a match condition only.
+    pieces: Vec<String>,
     link_rewrites: Vec<(BlockId, usize, usize, Variable)>,
     dead_results: Vec<u64>,
     dead_bases: Vec<u64>,
@@ -24792,6 +24994,7 @@ fn collect_lower_hex_byte_fmt_collapse(
     Some(LowerHexByteFmtCollapse {
         format_block: bf,
         format_result: nav.format_result.id(),
+        pieces: nav.pieces,
         link_rewrites: nav.link_rewrites,
         dead_results: nav.dead_results,
         dead_bases: nav.dead_bases,
@@ -24877,7 +25080,7 @@ fn collapse_lower_hex_byte_fmt_chains(graph: &mut FunctionGraph) -> usize {
         // The original context value was defined in B0.  After link rewrites,
         // the format op's own argument Variable is Bf's inputarg carrying that
         // value; use it so every emitted operand is defined in this block.
-        let expansion = emit_lower_hex_byte_02_ops(graph, &value, result);
+        let expansion = emit_lower_hex_byte_02_ops(graph, &site.pieces, &value, result);
         graph
             .block_mut(site.format_block)
             .operations
@@ -26121,8 +26324,7 @@ mod tests {
     use super::{
         DecodedConst, FnPtrFamily, cast_kind_is_raw_ptr, cast_pointer_marker_op,
         charon_const_generic_to_string, charon_type_value_to_ast_string, decode_literal,
-        fn_ptr_family_for, json_ty_is_thin_pointer_element,
-        json_ty_rpython_gc_pointer_element_spelling, json_ty_scalar_element_spelling,
+        fn_ptr_family_for, json_ty_is_thin_pointer_element, json_ty_scalar_element_spelling,
         push_ptr_to_unsigned_cast, shaped_array_parts, simplify_lowered_graph, tyref_array_suffix,
         tyref_is_raw_byte_ptr,
     };
@@ -28549,16 +28751,21 @@ mod tests {
             boxed_handlers, 1,
             "real LOAD_CONST bigint handler must use the RBigInt pointer boxing ABI"
         );
-        // Pins the whole ArrayRead population of `load_const_value`, not just
-        // its presence — so an added or removed indexed read reds here.
+        // PyPy walks `co_consts_w`, a list of GC pointers.  This function
+        // walks the compiler's `Vec<ConstantData>` instead, whose enum values
+        // are inline Rust aggregates and are wider than one target word.  No
+        // translation replaces that host container, so manufacturing a
+        // one-word ArrayRead would stride into the middle of an element.  Keep
+        // the Vec read residual until ConstantData is projected into the
+        // PyPy-shaped managed constants list.
         assert_eq!(
             load_ops
                 .iter()
                 .filter(|op| matches!(op.kind, OpKind::ArrayRead { .. }))
                 .count(),
-            3
+            0
         );
-        assert!(!load_ops.iter().any(|op| {
+        assert!(load_ops.iter().any(|op| {
             matches!(
                 &op.kind,
                 OpKind::Call {
@@ -29046,7 +29253,9 @@ mod tests {
                 }),
                 "{fname}: checked narrowing must not remain an opaque core call"
             );
-            for expected in ["lt", "gt", "add"] {
+            // `or`, not a sum: `c_int_w` writes
+            // `value < INT_MIN or value > INT_MAX` (`baseobjspace.py:2066`).
+            for expected in ["lt", "gt", "or"] {
                 assert!(
                     graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
                         matches!(&op.kind, OpKind::BinOp { op, .. } if op == expected)
@@ -29131,43 +29340,6 @@ mod tests {
         ));
         assert!(thin(serde_json::json!({"RawPtr": [named_adt, "Mut"]})));
         assert!(!thin(uint("U8")));
-    }
-
-    /// RPython stores strings and non-empty tuples as GC pointers inside a
-    /// list (`rstr.py:229-230`, `rtuple.py:116-126`).  The MIR source types
-    /// can be wider (`&str`, an inline Rust tuple), but their translated list
-    /// element repr must retain the upstream one-word shape.  An arbitrary
-    /// named ADT remains excluded.
-    #[test]
-    fn rpython_string_and_tuple_list_items_are_gc_pointer_elements() {
-        let llbc = llbc_with_trait_impls(serde_json::json!([]));
-        let spelling =
-            |ty: serde_json::Value| json_ty_rpython_gc_pointer_element_spelling(&ty, &llbc);
-        let str_ty = serde_json::json!({
-            "Adt": {
-                "id": {"Builtin": "Str"},
-                "generics": {"types": []}
-            }
-        });
-        assert_eq!(spelling(str_ty).as_deref(), Some("str"));
-
-        let tuple_ty = serde_json::json!({
-            "Adt": {
-                "id": "Tuple",
-                "generics": {
-                    "types": [
-                        {"Literal": {"UInt": "U8"}},
-                        {"RawPtr": [{"Literal": {"Int": "I64"}}, "Mut"]}
-                    ]
-                }
-            }
-        });
-        assert_eq!(spelling(tuple_ty).as_deref(), Some("(u8,*mut i64)"));
-
-        let named_adt = serde_json::json!({
-            "Adt": {"id": {"Adt": 7}, "generics": {"types": []}}
-        });
-        assert_eq!(spelling(named_adt), None);
     }
 
     /// `[T]`, `str` and `dyn Trait` each have two Charon spellings — a
@@ -30739,7 +30911,7 @@ mod tests {
     /// `FixedObjectArray` item to the erased top reference.
     #[test]
     #[ignore]
-    fn popvalue_py_null_narrows_to_nullable_pyobject() {
+    fn popvalue_py_null_narrows_to_nullable_instance() {
         use crate::model::{CallTarget, OpKind};
         let path = concat!(
             env!("CARGO_MANIFEST_DIR"),
@@ -30751,7 +30923,7 @@ mod tests {
             "pyre_interpreter::pyframe::<Impl>::popvalue_maybe_none",
         )
         .expect("lower PyFrame::popvalue_maybe_none");
-        let has_nullable_pyobject = graph.blocks.iter().any(|block| {
+        let has_nullable_instance = graph.blocks.iter().any(|block| {
             block.operations.windows(2).any(|ops| {
                 matches!(
                     &ops[0].kind,
@@ -30770,7 +30942,7 @@ mod tests {
             })
         });
         assert!(
-            has_nullable_pyobject,
+            has_nullable_instance,
             "PY_NULL stack clear must lower as null_mut followed by a PyObject narrow"
         );
     }
@@ -31049,7 +31221,7 @@ mod tests {
     /// large interpreter snapshot.
     #[test]
     #[ignore]
-    fn load_local_value_arrayread_narrows_pyobject_item() {
+    fn load_local_value_arrayread_narrows_instance_item() {
         let path = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../../build/llbc/pyre-interpreter.ullbc"
@@ -31058,7 +31230,7 @@ mod tests {
         let graph =
             super::lower_function(&llbc, "pyre_interpreter::eval::<Impl>::load_local_value")
                 .expect("lower eval::<Impl>::load_local_value");
-        let has_pyobject_narrow = graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+        let has_instance_narrow = graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
             matches!(
                 &op.kind,
                 OpKind::Call {
@@ -31069,7 +31241,7 @@ mod tests {
             )
         });
         assert!(
-            has_pyobject_narrow,
+            has_instance_narrow,
             "FixedObjectArray getitem must recast its GCREF item to PyObject"
         );
     }
@@ -31263,52 +31435,59 @@ mod tests {
             "/../../build/llbc/pyre-object.ullbc"
         );
         let llbc = Llbc::load(path).expect("load real object LLBC");
+        // `offset_leaf` is `None` for the two string rows on purpose: their
+        // `base` is `items_block_items_base(self.block)`, a call with no
+        // offset constant in the body, so a "no surviving offset read"
+        // assertion over them would hold whatever the fold did.  Their real
+        // content is the `push` half below.
         for (base, function, expected_array, expected_item, offset_leaf) in [
             (
                 "pyre_object::int_array::<Impl>::base",
                 "pyre_object::int_array::<Impl>::push",
                 "[i64]",
                 ValueType::Int,
-                "TYPED_ITEMS_BLOCK_ITEMS_OFFSET",
+                Some("TYPED_ITEMS_BLOCK_ITEMS_OFFSET"),
             ),
             (
                 "pyre_object::float_array::<Impl>::base",
                 "pyre_object::float_array::<Impl>::push",
                 "[f64]",
                 ValueType::Float,
-                "TYPED_ITEMS_BLOCK_ITEMS_OFFSET",
+                Some("TYPED_ITEMS_BLOCK_ITEMS_OFFSET"),
             ),
             (
                 "pyre_object::bytes_array::<Impl>::base",
                 "pyre_object::bytes_array::<Impl>::push",
                 super::STRING_GCREF_GCARRAY_TYPE_ID,
                 ValueType::Str,
-                "ITEMS_BLOCK_ITEMS_OFFSET",
+                None,
             ),
             (
                 "pyre_object::unicode_array::<Impl>::base",
                 "pyre_object::unicode_array::<Impl>::push",
                 super::STRING_GCREF_GCARRAY_TYPE_ID,
                 ValueType::Str,
-                "ITEMS_BLOCK_ITEMS_OFFSET",
+                None,
             ),
         ] {
-            let base_graph = super::lower_function(&llbc, base)
-                .unwrap_or_else(|err| panic!("lower {base}: {err}"));
-            assert!(
-                !base_graph
-                    .blocks
-                    .iter()
-                    .flat_map(|block| &block.operations)
-                    .any(|op| matches!(
-                        &op.kind,
-                        OpKind::Call {
-                            target: CallTarget::FunctionPath { segments },
-                            ..
-                        } if segments.last().is_some_and(|leaf| leaf == offset_leaf)
-                    )),
-                "{base} must fold the target-layout items offset"
-            );
+            if let Some(offset_leaf) = offset_leaf {
+                let base_graph = super::lower_function(&llbc, base)
+                    .unwrap_or_else(|err| panic!("lower {base}: {err}"));
+                assert!(
+                    !base_graph
+                        .blocks
+                        .iter()
+                        .flat_map(|block| &block.operations)
+                        .any(|op| matches!(
+                            &op.kind,
+                            OpKind::Call {
+                                target: CallTarget::FunctionPath { segments },
+                                ..
+                            } if segments.last().is_some_and(|leaf| leaf == offset_leaf)
+                        )),
+                    "{base} must fold the target-layout items offset"
+                );
+            }
             let graph = super::lower_function(&llbc, function)
                 .unwrap_or_else(|err| panic!("lower {function}: {err}"));
             let operations: Vec<_> = graph
@@ -31697,9 +31876,13 @@ mod tests {
             .blocks
             .iter()
             .flat_map(|b| b.operations.iter())
-            .filter(
-                |op| matches!(&op.kind, OpKind::FieldRead { field, .. } if field.name == "__pos_0"),
-            )
+            .filter(|op| {
+                matches!(&op.kind, OpKind::FieldRead { field, .. }
+                if field.name == "__pos_0"
+                    && field.owner_root.as_deref().is_some_and(|owner| {
+                        owner.contains("Option") && owner.ends_with("::Some")
+                    }))
+            })
             .count();
         assert_eq!(
             pos0_reads, 0,
@@ -32225,7 +32408,7 @@ mod tests {
             "bool::then producing Option<PyObjectRef> must use RPython's nullable-pointer \
              representation (Some(ptr)=ptr, None=null), not an Option aggregate"
         );
-        let is_pyobject_narrow = |op: &crate::model::SpaceOperation| {
+        let is_instance_narrow = |op: &crate::model::SpaceOperation| {
             matches!(
                 &op.kind,
                 OpKind::Call {
@@ -32244,7 +32427,7 @@ mod tests {
                     } if name == "call_once"
                 )
             });
-            (has_call_once && block.operations.iter().any(is_pyobject_narrow))
+            (has_call_once && block.operations.iter().any(is_instance_narrow))
                 .then(|| block.exits.first().map(|link| link.target))
                 .flatten()
         });
@@ -32263,7 +32446,7 @@ mod tests {
                         } if segments == &["core", "ptr", "null_mut"]
                     )
                 })
-                && block.operations.iter().any(is_pyobject_narrow)
+                && block.operations.iter().any(is_instance_narrow)
         });
         assert!(
             narrowed_none,
@@ -32498,6 +32681,48 @@ mod tests {
         );
     }
 
+    /// `bytearrayobject.py:286-290` appends three values for a non-printable
+    /// byte — `'\\x'` and the two nibble characters.  The expansion consumed
+    /// the template's `\x` piece as a match condition only, so a JIT-compiled
+    /// repr rendered `bytearray(b'ff')` where CPython renders
+    /// `bytearray(b'\xff')`.  Assert the literal is emitted and folded first.
+    #[test]
+    fn lower_hex_byte_02_expansion_emits_the_backslash_x_literal() {
+        use crate::model::{CallTarget, ConcreteType, FunctionGraph, OpKind};
+        let mut graph = FunctionGraph::new("t");
+        let value = graph.alloc_value_var_with_type(ConcreteType::Unknown);
+        let result = graph.alloc_value_var_with_type(ConcreteType::Unknown);
+        let pieces = vec!["\\x".to_string(), String::new()];
+        let ops = super::emit_lower_hex_byte_02_ops(&mut graph, &pieces, &value, result.clone());
+
+        let literal = ops
+            .iter()
+            .find(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.first().is_some_and(|s| s == "__str_const")
+                        && segments.get(1).is_some_and(|s| s == "\\x"))
+            })
+            .expect("the template's leading `\\x` must be emitted, not only matched");
+        let literal = literal.result.clone().expect("__str_const has a result");
+
+        // `'\\x'` is upstream's FIRST buf.append, so it must be the left
+        // operand of the first concat.
+        let first_add = ops
+            .iter()
+            .find(|op| matches!(&op.kind, OpKind::BinOp { op, .. } if op == "add"))
+            .expect("the parts fold through add");
+        let OpKind::BinOp { lhs, .. } = &first_add.kind else {
+            unreachable!("matched an add above")
+        };
+        assert_eq!(lhs.id(), literal.id(), "`\\x` must be concatenated first");
+
+        assert_eq!(
+            ops.last().and_then(|op| op.result.clone()).map(|v| v.id()),
+            Some(result.id()),
+            "the final op must reuse the displaced format result var"
+        );
+    }
+
     /// RPython `AbstractStringBuilderRepr.rtype_method_append` accepts both a
     /// whole string and `SomeChar`.  `bytearray_repr_string` mixes
     /// `String::push_str` and `String::push(char)` in one loop, so omitting the
@@ -32527,6 +32752,15 @@ mod tests {
                         || segments.last().is_some_and(|leaf| leaf == "new_lower_hex"))
             }),
             "Rust fmt shell must collapse to PyPy's two-nibble lookup"
+        );
+        assert!(
+            graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.first().is_some_and(|s| s == "__str_const")
+                        && segments.get(1).is_some_and(|s| s == "\\x"))
+            }),
+            "the collapse must keep upstream's `buf.append('\\\\x')` \
+             (bytearrayobject.py:288), not drop it with the fmt shell"
         );
         for opname in ["rshift", "and"] {
             assert!(
@@ -32757,6 +32991,19 @@ mod tests {
     /// lists with ordinary `getitem`.  The Rust `SliceIndex<usize>` shim must
     /// lower to the same ArrayRead shape instead of remaining an opaque core
     /// call that prevents the whole builtin-call chain from being annotated.
+    ///
+    /// The `arguments_w` side reaches that shape: its elements are object
+    /// pointers, one target word each, so the ArrayRead's stride is the host
+    /// stride.  `Signature.argnames` does NOT, and must keep its residual
+    /// `Vec::index`: PyPy's `Signature.argnames` is an RPython list of
+    /// `Ptr(STR)` (`rstr.py`, `StringRepr`), but pyre spells it
+    /// `Vec<&'static str>` — a two-word fat pointer per element — and no
+    /// translation converts the container.  Admitting it would make
+    /// `getarrayitem` compute `base + i * 8` over 16-byte elements.  The
+    /// convergence path is on the pyre side: give `Signature` a managed
+    /// string list, the one container whose items really are one GCREF each,
+    /// and this call joins the addressable set through the same
+    /// `first_arg_is_string_array_view` proof the items view already uses.
     #[test]
     #[ignore]
     fn bind_kwargs_indexes_lower_to_array_reads() {
@@ -32805,11 +33052,12 @@ mod tests {
                 )
             })
             .collect();
-        assert_eq!(
-            residual_vec_indexes.len(),
-            0,
-            "PyPy argument.py list getitems must not remain opaque Vec::index calls: \
-             {residual_vec_indexes:#?}"
+        assert!(
+            !residual_vec_indexes.is_empty(),
+            "`Signature.argnames: Vec<&'static str>` must keep its residual \
+             Vec::index until the container becomes a managed string list; \
+             a one-word ArrayRead over two-word elements reads the wrong \
+             address from the second element on"
         );
         assert!(
             graph
@@ -32868,10 +33116,14 @@ mod tests {
         );
     }
 
-    /// Real-LLBC anchors for the three roots that previously left
-    /// `vec::Vec::index` opaque. Their corresponding PyPy operations are
-    /// ordinary list reads: argument-list concatenation, dict-item tuple
-    /// reads, and gateway keyword-name/value matching.
+    /// Real-LLBC anchors for three roots that spell one PyPy operation —
+    /// an ordinary list read — over three different host containers.
+    ///
+    /// Only `combine_starargs_wrapped` may lower: its elements are object
+    /// pointers, one target word each, so the emitted getarrayitem's stride
+    /// is the host stride.  `dict_repr` and `bind_builtin_kwargs` are held
+    /// here as counter-examples on purpose; being the same PyPy shape is not
+    /// what makes a read addressable, the element width is.
     #[test]
     #[ignore]
     fn pypy_list_item_roots_have_no_residual_vec_index() {
@@ -32881,14 +33133,10 @@ mod tests {
             "/../../build/llbc/pyre-interpreter.ullbc"
         );
         let llbc = Llbc::load(path).expect("load real LLBC");
-        for fname in [
-            "combine_starargs_wrapped",
-            "dict_repr",
-            "bind_builtin_kwargs",
-        ] {
+        let residual_vec_indexes = |fname: &str| {
             let graph = super::lower_function(&llbc, fname)
                 .unwrap_or_else(|err| panic!("lower {fname}: {err}"));
-            let residual: Vec<_> = graph
+            graph
                 .blocks
                 .iter()
                 .flat_map(|block| &block.operations)
@@ -32901,10 +33149,38 @@ mod tests {
                         } if super::fmt_path_ends_with(segments, &["vec", "Vec", "index"])
                     )
                 })
-                .collect();
+                .count()
+        };
+        assert_eq!(
+            residual_vec_indexes("combine_starargs_wrapped"),
+            0,
+            "argument-list concatenation indexes object pointers, one target \
+             word each, so its getitems must not remain Vec::index"
+        );
+        // The other two are NOT in that set, and must not be added by widening
+        // the element gate.  Both are the same PyPy list read over a host
+        // container whose element is WIDER than one word, and no translation
+        // replaces the container:
+        //
+        // * `dict_repr` indexes `w_dict_items`'s
+        //   `Vec<(PyObjectRef, PyObjectRef)>`.  PyPy's `dictmultiobject.py`
+        //   pair really is one GC pointer per item, but only inside a list the
+        //   translation builds; here it is an INLINE 16-byte tuple, so a
+        //   one-word getarrayitem would read each pair's key twice and never
+        //   its value.
+        // * `bind_builtin_kwargs` indexes `names: &[&str]`.  PyPy's
+        //   `Signature.argnames` is a list of `Ptr(STR)`, but `&str` is a
+        //   two-word fat pointer here, so the same read would land mid-element
+        //   from the second name on.
+        //
+        // Lowering either means giving the pyre side a managed list — the one
+        // container whose items are one GCREF each — not relaxing the width
+        // proof in the element gate.
+        for fname in ["dict_repr", "bind_builtin_kwargs"] {
             assert!(
-                residual.is_empty(),
-                "{fname}: PyPy list getitems must not remain Vec::index: {residual:#?}"
+                residual_vec_indexes(fname) > 0,
+                "{fname}: a wider-than-one-word host element must keep its \
+                 residual Vec::index"
             );
         }
     }
@@ -33026,7 +33302,7 @@ mod tests {
     /// pointer while field reads expect the concrete PyObject repr.
     #[test]
     #[ignore]
-    fn pyerror_exc_object_registry_retains_pyobjectref() {
+    fn pyerror_exc_object_registry_retains_instance_ref() {
         let path = concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../../build/llbc/pyre-interpreter.ullbc"
@@ -33116,7 +33392,7 @@ mod tests {
     /// the same narrowing as a struct-literal initializer.
     #[test]
     #[ignore]
-    fn pyerror_projection_writes_retain_pyobject_class() {
+    fn pyerror_projection_writes_retain_instance_class() {
         use crate::model::{CallTarget, LinkArg, OpKind};
         let path = concat!(
             env!("CARGO_MANIFEST_DIR"),
@@ -33256,8 +33532,26 @@ mod tests {
             "/../../build/llbc/pyre-interpreter.ullbc"
         );
         let llbc = Llbc::load(path).expect("load real LLBC");
-        let graph =
-            super::lower_function(&llbc, "forwarded_exporter").expect("lower forwarded_exporter");
+        // `lower_function`'s default host table names NO error carrier, and
+        // the carrier is what `tyref_is_result_of_carrier` compares `E`
+        // against — with the default the closure's `Result<*mut PyObject,
+        // PyError>` is not a scoped result, `call_once_result_exc` stays
+        // `None`, and the rewrap this test grades can never be reached.
+        // Pass the same spec `pyre-jit-trace`'s prepass installs.
+        let graph = super::lower_function_with_static_addrs(
+            &llbc,
+            "forwarded_exporter",
+            crate::HostStaticAddrs {
+                error_carrier: crate::ErrorCarrierSpec {
+                    carrier_path: "pyre_interpreter::error::PyError",
+                    carrier_wrappers: &[],
+                    to_exc_object: Some(&["pyre_interpreter", "error", "pyerror_to_exc_object"]),
+                    from_exc_object: Some(("PyError", "from_exc_object")),
+                },
+                ..crate::HostStaticAddrs::default()
+            },
+        )
+        .expect("lower forwarded_exporter");
 
         let call_block = graph
             .blocks
@@ -33409,6 +33703,9 @@ mod tests {
         let llbc = Llbc::load(path).expect("load real LLBC");
         for name in [
             "pyre_interpreter::module::_collections::modified",
+            // `checklock`'s comparison half — the graph that carries the
+            // `self.lock` field read.  `checklock` itself only wraps it in
+            // the `RuntimeError` raise.
             "pyre_interpreter::module::_collections::lock_valid",
         ] {
             let graph = super::lower_function(&llbc, name)

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3255,6 +3255,11 @@ struct Lowering<'a> {
     /// where `ord(s[i])` is the scalar byte read; the consumer gate below
     /// uses this provenance to emit exactly that pair of flowspace ops.
     string_byte_view_locals: Vec<usize>,
+    /// MIR locals holding the `ll_items(l)` view returned by the string-list
+    /// slice adapters.  Rust spells the element as a concrete raw pointer,
+    /// but both byte and unicode strategies expose the same external `str`
+    /// over one internal `GcArray(GCREF)`.
+    string_array_view_locals: Vec<usize>,
     /// Result `Variable`s of calls to callees whose declared result is
     /// `Result<T, PyError>`.  Each
     /// heads a `Try::branch` diamond that
@@ -3578,6 +3583,7 @@ impl<'a> Lowering<'a> {
             const_discriminant_locals: std::collections::HashMap::new(),
             multi_assigned_locals: compute_multi_assigned_locals(body),
             string_byte_view_locals: Vec::new(),
+            string_array_view_locals: Vec::new(),
             result_exc_call_results: Vec::new(),
             next_call_results: Vec::new(),
             checked_arith_call_results: Vec::new(),
@@ -6226,7 +6232,15 @@ impl<'a> Lowering<'a> {
                         .string_byte_view_locals
                         .iter()
                         .any(|&local| place_references_local(&inner, local));
-                    let (array_type_id, nolength) = array_projection_metadata(&inner.ty, self.llbc);
+                    let string_array_view = self
+                        .string_array_view_locals
+                        .iter()
+                        .any(|&local| place_references_local(&inner, local));
+                    let (mut array_type_id, nolength) =
+                        array_projection_metadata(&inner.ty, self.llbc);
+                    if string_array_view {
+                        array_type_id = Some(STRING_GCREF_GCARRAY_TYPE_ID.to_string());
+                    }
                     let base = self.resolve_place(mir_bb, *inner)?;
                     let bb_id = self.block_id[mir_bb];
                     let res = self
@@ -6244,7 +6258,11 @@ impl<'a> Lowering<'a> {
                         OpKind::ArrayRead {
                             base,
                             index: idx_var,
-                            item_ty: tyref_to_value_type(&place_ty, self.llbc),
+                            item_ty: if string_array_view {
+                                ValueType::Str
+                            } else {
+                                tyref_to_value_type(&place_ty, self.llbc)
+                            },
                             array_type_id,
                             nolength,
                             pure: false,
@@ -7774,6 +7792,14 @@ impl<'a> Lowering<'a> {
         for op in call.args {
             args.push(self.resolve_operand(mir_bb, op)?);
         }
+        let first_arg_is_string_array_view = args.first().is_some_and(|arg| {
+            self.string_array_view_locals.iter().any(|&local| {
+                self.local_var
+                    .get(local)
+                    .and_then(Option::as_ref)
+                    .is_some_and(|current| current == arg)
+            })
+        });
 
         let class = call.func.classify();
         // Full `name_path()` of a `CallKind::Fun` callee, captured for the
@@ -8242,6 +8268,12 @@ impl<'a> Lowering<'a> {
                 // ([`narrow_item_array_type_id`]); a `Vec<u8>` read strides by
                 // 8 without it.
                 let index_element = index_leg.then(|| {
+                    if first_arg_is_string_array_view {
+                        return (
+                            ValueType::Str,
+                            Some(STRING_GCREF_GCARRAY_TYPE_ID.to_string()),
+                        );
+                    }
                     let item_ty = tyref_deref_value_type(&call.dest.ty, self.llbc);
                     // The `pyre_`-fenced workspace arm has exactly three
                     // element banks — `FixedObjectArray`, `IntArray`,
@@ -9078,6 +9110,33 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `BytesArray::as_slice` / `UnicodeArray::as_slice` are the
+                // Rust fat-slice spelling around RPython's `ll_items(l)`.
+                // Their caller keeps the separate logical `l.length`; the
+                // one-word translated value is therefore the backing
+                // `GcArray(GCREF)`, with its external item kept as `str`.
+                // Fold only these two adapter bodies: an arbitrary
+                // `from_raw_parts(base, logical_len)` cannot discard its
+                // second word.
+                if args.len() == 2 && self.is_string_array_view_from_raw_parts(&reg) {
+                    let view = self.narrow_value_to_instance_root(
+                        bb_id,
+                        LinkArg::Value(args[0].clone()),
+                        STRING_GCREF_GCARRAY_TYPE_ID,
+                    );
+                    self.local_var[dest_local] = Some(
+                        view.as_variable()
+                            .expect("a string-items view stays a Variable")
+                            .clone(),
+                    );
+                    if !self.string_array_view_locals.contains(&dest_local) {
+                        self.string_array_view_locals.push(dest_local);
+                    }
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // `RBigInt::digits{,_mut}` is a Rust view adapter around a
                 // typed-items GcArray:
                 // `slice::from_raw_parts(items_base(block), capacity)`.  The
@@ -9435,6 +9494,34 @@ impl<'a> Lowering<'a> {
                         },
                     });
                     self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
+                // `BytesArray::as_slice` / `UnicodeArray::as_slice` expose
+                // the backing items field, not the enclosing `{ block, len }`
+                // storage record.  This is RPython `ll_items(l)`: read the
+                // `block` field and project it to the logical `[str]` array
+                // before the consumer's getitem.  The caller's explicit
+                // `self.len` check remains the logical-length guard.
+                if args.len() == 1
+                    && let Some(owner) = self.string_array_slice_view_owner(&reg)
+                {
+                    let block = self.emit_string_array_items_read(bb_id, args[0].clone(), owner);
+                    let view = self.narrow_value_to_instance_root(
+                        bb_id,
+                        LinkArg::Value(block),
+                        STRING_GCREF_GCARRAY_TYPE_ID,
+                    );
+                    self.local_var[dest_local] = Some(
+                        view.as_variable()
+                            .expect("a string-items view stays a Variable")
+                            .clone(),
+                    );
+                    if !self.string_array_view_locals.contains(&dest_local) {
+                        self.string_array_view_locals.push(dest_local);
+                    }
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
                     self.graph.set_goto(bb_id, target_bb, link_args);
@@ -12634,6 +12721,77 @@ impl<'a> Lowering<'a> {
                     | "pyre_object::float_array::<Impl>::as_mut_slice"
             )
         })
+    }
+
+    /// Return the source owner for the string-list items-view adapters.
+    /// RPython's `ll_items(l)` reads the `items` field from the resized list;
+    /// pyre's source spelling calls that field `block`.
+    fn string_array_slice_view_owner(&self, reg: &RegularCall) -> Option<&'static str> {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return None;
+        };
+        match self.llbc.fn_by_id(*id)?.item_meta.name_path().as_str() {
+            "pyre_object::bytes_array::<Impl>::as_slice"
+            | "pyre_object::bytes_array::<Impl>::as_mut_slice" => Some("BytesArray"),
+            "pyre_object::unicode_array::<Impl>::as_slice"
+            | "pyre_object::unicode_array::<Impl>::as_mut_slice" => Some("UnicodeArray"),
+            _ => None,
+        }
+    }
+
+    /// The body-side `from_raw_parts` half of
+    /// [`Self::string_array_slice_view_owner`].
+    fn is_string_array_view_from_raw_parts(&self, reg: &RegularCall) -> bool {
+        if !(self.graph.name.ends_with("bytes_array::<Impl>::as_slice")
+            || self
+                .graph
+                .name
+                .ends_with("bytes_array::<Impl>::as_mut_slice")
+            || self.graph.name.ends_with("unicode_array::<Impl>::as_slice")
+            || self
+                .graph
+                .name
+                .ends_with("unicode_array::<Impl>::as_mut_slice"))
+        {
+            return false;
+        }
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc.fn_by_id(*id).is_some_and(|fd| {
+            matches!(
+                fd.item_meta.name_path().as_str(),
+                "core::slice::raw::from_raw_parts" | "core::slice::raw::from_raw_parts_mut"
+            )
+        })
+    }
+
+    fn emit_string_array_items_read(
+        &mut self,
+        bb_id: BlockId,
+        base: Variable,
+        owner: &str,
+    ) -> Variable {
+        let result = self
+            .graph
+            .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+        let canonical_owner = match owner {
+            "BytesArray" => "bytes_array::BytesArray",
+            "UnicodeArray" => "unicode_array::UnicodeArray",
+            _ => unreachable!("string array owner is closed"),
+        };
+        self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+            result: Some(result.clone()),
+            kind: OpKind::FieldRead {
+                base,
+                field: FieldDescriptor::new("block", Some(owner.to_string())).with_owner_id(Some(
+                    majit_ir::descr::StructId::from_canonical(canonical_owner),
+                )),
+                ty: ValueType::Ref(None),
+                pure: false,
+            },
+        });
+        result
     }
 
     /// `<[T]>::as_ptr` — the data-pointer projection of a slice receiver.  In
@@ -30882,7 +31040,7 @@ mod tests {
         );
     }
 
-    /// The scalar unwrapped-list storage adapters are Rust spellings of
+    /// The unwrapped-list storage adapters are Rust spellings of
     /// RPython's `l.items` GcArray.  A live `push` must therefore end in the
     /// same `setarrayitem` shape as `rlist.ll_append_noresize`, never in the
     /// synthetic raw-pointer write that blocks annotation.  The adapter body
@@ -30971,6 +31129,75 @@ mod tests {
                     } if segments == &["__deref_write".to_string()]
                 )),
                 "{function} must not retain a raw-pointer write"
+            );
+        }
+
+        for function in [
+            "pyre_object::bytes_array::<Impl>::as_slice",
+            "pyre_object::unicode_array::<Impl>::as_slice",
+        ] {
+            let graph = super::lower_function(&llbc, function)
+                .unwrap_or_else(|err| panic!("lower {function}: {err}"));
+            assert!(
+                !graph
+                    .blocks
+                    .iter()
+                    .flat_map(|block| &block.operations)
+                    .any(|op| matches!(
+                        &op.kind,
+                        OpKind::Call {
+                            target: CallTarget::FunctionPath { segments },
+                            ..
+                        } if segments.last().is_some_and(|leaf| leaf == "from_raw_parts")
+                    )),
+                "{function} must be the direct RPython list-items view"
+            );
+        }
+
+        for function in [
+            "pyre_object::bytes_array::<Impl>::pop",
+            "pyre_object::unicode_array::<Impl>::pop",
+        ] {
+            let graph = super::lower_function(&llbc, function)
+                .unwrap_or_else(|err| panic!("lower {function}: {err}"));
+            let operations: Vec<_> = graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .collect();
+            assert!(
+                operations.iter().any(|operation| matches!(
+                    &operation.kind,
+                    OpKind::ArrayRead {
+                        item_ty: ValueType::Str,
+                        array_type_id: Some(array_type_id),
+                        ..
+                    } if array_type_id == super::STRING_GCREF_GCARRAY_TYPE_ID
+                )),
+                "{function} must read its external string through GcArray(GCREF)"
+            );
+            assert!(
+                operations.iter().any(|operation| matches!(
+                    &operation.kind,
+                    OpKind::ArrayWrite {
+                        item_ty: ValueType::Str,
+                        array_type_id: Some(array_type_id),
+                        ..
+                    } if array_type_id == super::STRING_GCREF_GCARRAY_TYPE_ID
+                )),
+                "{function} must clear the released slot through the same GcArray(GCREF)"
+            );
+            assert!(
+                !operations.iter().any(|operation| matches!(
+                    &operation.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.last().is_some_and(|leaf| {
+                        leaf == "from_raw_parts" || leaf == "__deref_write"
+                    })
+                )),
+                "{function} must not retain a Rust raw-slice/read-write boundary"
             );
         }
     }

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! This module bridges **Rust source (`syn::ItemFn`)** to the **`FunctionGraph`** type that the rest of the codewriter pipeline (`jtransform`, `flatten`, `regalloc`, `liveness`, `assembler`) consumes.
 //!
-//! RPython has no direct counterpart. In upstream, `rpython/jit/codewriter/codewriter.py CodeWriter.make_jitcodes()` is handed `translator.graphs` — graphs already produced by `rpython/rtyper/` from RPython source. The codewriter never sees interpreter source files.
+//! RPython has no direct counterpart. In upstream, `rpython/jit/codewriter/codewriter.py` `CodeWriter.make_jitcodes()` (`:74-79`) takes only `verbose`: the graphs reach it through `self.callcontrol.enum_pending_graphs()`, already rtyped by `rpython/rtyper/` from RPython source. The codewriter never sees interpreter source files.
 //!
 //! pyre cannot inherit that assumption. Rust functions must become `FunctionGraph`s somewhere, and this module is where. Every file under `front/` is Rust-specific lowering that has no RPython structural match.
 //!

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -86,6 +86,7 @@ pub(crate) mod range_contains;
 pub(crate) mod range_iter;
 pub(crate) mod rbigint_call;
 pub(crate) mod result_exc;
+pub(crate) mod rfloat_call;
 pub(crate) mod saturating_sub;
 pub mod semantic;
 pub(crate) mod slice_first;

--- a/majit/majit-translate/src/front/option_closure_select.rs
+++ b/majit/majit-translate/src/front/option_closure_select.rs
@@ -110,28 +110,46 @@ pub(crate) struct ClosureSelectSite {
     /// itself (identity), not a `__pos_0` field read.  (The closure `Args`
     /// tuple `__pos_0` write is unaffected — that is a real `Tuple` field.)
     pub niche: bool,
+    /// A closure whose declared result is `Result<T, PyError>` is translated
+    /// uniformly to the graph exception ABI: it returns `T` and raises for
+    /// `Err`.  These combinators retain that Result as data, so their
+    /// synthesized call must pass through `result_exc`'s catch-and-rewrap
+    /// caller rule before the combinator consumes it.  Carries the Result
+    /// instantiation suffix and its `Ok` payload kind.
+    pub call_once_result_exc: Option<(Option<String>, ValueType)>,
+}
+
+#[derive(Default)]
+pub(crate) struct ClosureSelectRewriteOutcome {
+    pub rewritten: usize,
+    pub result_exc_calls: Vec<(Variable, Option<String>, ValueType)>,
 }
 
 /// Rewrite every recorded closure-select call site into the discriminant
 /// diamond.  Fail-safe: a site whose block does not fit the residual-call shape
-/// is left untouched (Skip).  Returns the number of sites rewritten.
+/// is left untouched (Skip).  Returns the number of sites rewritten plus any
+/// synthesized scoped `call_once` results for the ordinary `result_exc`
+/// caller rule.
 pub(crate) fn rewire_closure_select_call_sites(
     graph: &mut FunctionGraph,
     sites: &[ClosureSelectSite],
-) -> usize {
-    let mut rewritten = 0;
+) -> ClosureSelectRewriteOutcome {
+    let mut outcome = ClosureSelectRewriteOutcome::default();
     for site in sites {
-        if rewire_one_closure_select_site(graph, site).is_ok() {
-            rewritten += 1;
+        if let Ok(result_exc_call) = rewire_one_closure_select_site(graph, site) {
+            outcome.rewritten += 1;
+            if let Some(call) = result_exc_call {
+                outcome.result_exc_calls.push(call);
+            }
         }
     }
-    rewritten
+    outcome
 }
 
 fn rewire_one_closure_select_site(
     graph: &mut FunctionGraph,
     site: &ClosureSelectSite,
-) -> Result<(), String> {
+) -> Result<Option<(Variable, Option<String>, ValueType)>, String> {
     let name = graph.name.clone();
     // Block A: the residual call producing `result_var`.
     let a = graph
@@ -245,11 +263,16 @@ fn rewire_one_closure_select_site(
     // --- `then_bb` (`Some`) ---
     let opt_in_then = map_source(&then_sources, &then_inputs, &opt)
         .ok_or_else(|| format!("{name}: Option value not threaded into Some arm"))?;
-    let then_value = match site.kind {
+    let mut synthesized_result_exc = None;
+    let (then_value, then_finish_bb, then_finish_inputs) = match site.kind {
         // `or_else` forwards the whole receiver `Option` unchanged — no `__pos_0`.
-        ClosureCombinator::OrElse => opt_in_then,
+        ClosureCombinator::OrElse => (opt_in_then, then_bb, then_inputs.clone()),
         // `unwrap_or_else` forwards the bare payload.
-        ClosureCombinator::UnwrapOrElse => read_some_payload(graph, then_bb, opt_in_then, site),
+        ClosureCombinator::UnwrapOrElse => (
+            read_some_payload(graph, then_bb, opt_in_then, site),
+            then_bb,
+            then_inputs.clone(),
+        ),
         // `map`/`and_then`/`is_some_and` run the closure on the payload.
         ClosureCombinator::Map | ClosureCombinator::AndThen | ClosureCombinator::IsSomeAnd => {
             let payload = read_some_payload(graph, then_bb, opt_in_then, site);
@@ -264,7 +287,25 @@ fn rewire_one_closure_select_site(
                 site.call_result_ty.clone(),
                 &site.args_tuple_suffix,
             );
-            match site.kind {
+            let (finish_bb, finish_inputs, call_result) = if let Some((suffix, payload_ty)) =
+                &site.call_once_result_exc
+            {
+                let (finish_bb, finish_inputs) =
+                    graph.create_block_with_arg_vars(then_sources.len() + 1);
+                let mut args: Vec<LinkArg> =
+                    then_inputs.iter().cloned().map(LinkArg::Value).collect();
+                args.push(LinkArg::Value(call_result.clone()));
+                close_goto_mixed(graph, then_bb, finish_bb, args);
+                synthesized_result_exc = Some((call_result, suffix.clone(), payload_ty.clone()));
+                (
+                    finish_bb,
+                    finish_inputs[..then_sources.len()].to_vec(),
+                    finish_inputs[then_sources.len()].clone(),
+                )
+            } else {
+                (then_bb, then_inputs.clone(), call_result)
+            };
+            let value = match site.kind {
                 // `map` wraps the closure result back into `Some(U)` — except
                 // that a niche `Option` is a one-word pointer with no aggregate
                 // `__discriminant` / `__pos_0`, where `Some(x)` is `x` itself.
@@ -274,7 +315,7 @@ fn rewire_one_closure_select_site(
                     } else {
                         emit_option_variant(
                             graph,
-                            then_bb,
+                            finish_bb,
                             &site.result_option_owner,
                             1,
                             Some((
@@ -288,30 +329,39 @@ fn rewire_one_closure_select_site(
                 // `and_then`'s closure already returns `Option<U>`;
                 // `is_some_and`'s already returns the `bool`.
                 _ => call_result,
-            }
+            };
+            (value, finish_bb, finish_inputs)
         }
     };
-    let then_result = emit_narrow(graph, then_bb, then_value, &narrow_root);
+    let then_result = emit_narrow(graph, then_finish_bb, then_value, &narrow_root);
     let then_link_args = reproduce_exit_args(
         &saved_exit,
         &flow_result,
         &then_result,
         &then_sources,
-        &then_inputs,
+        &then_finish_inputs,
         &name,
     )?;
-    close_goto_mixed(graph, then_bb, b_target, then_link_args);
+    close_goto_mixed(graph, then_finish_bb, b_target, then_link_args);
 
     // --- `else_bb` (`None`) ---
-    let else_value = match site.kind {
+    let (else_value, else_finish_bb, else_finish_inputs) = match site.kind {
         // `map`/`and_then` build a fresh `None`.
         ClosureCombinator::Map | ClosureCombinator::AndThen => {
             // A niche `Option` is a one-word pointer with no aggregate
             // `__discriminant` / `__pos_0`: `None` is null.
             if site.result_niche {
-                graph.push_null_mut_ptr(else_bb)
+                (
+                    graph.push_null_mut_ptr(else_bb),
+                    else_bb,
+                    else_inputs.clone(),
+                )
             } else {
-                emit_option_variant(graph, else_bb, &site.result_option_owner, 0, None)
+                (
+                    emit_option_variant(graph, else_bb, &site.result_option_owner, 0, None),
+                    else_bb,
+                    else_inputs.clone(),
+                )
             }
         }
         // `is_some_and` yields the constant `false` — no closure, no `Option`.
@@ -321,14 +371,14 @@ fn rewire_one_closure_select_site(
                 result: Some(false_var.clone()),
                 kind: OpKind::ConstInt(0),
             });
-            false_var
+            (false_var, else_bb, else_inputs.clone())
         }
         // `unwrap_or_else`/`or_else` run their niladic closure and forward its
         // result (`T` for `unwrap_or_else`, `Option<T>` for `or_else`).
         ClosureCombinator::UnwrapOrElse | ClosureCombinator::OrElse => {
             let env_in_else = map_source(&else_sources, &else_inputs, &env)
                 .ok_or_else(|| format!("{name}: closure env not threaded into None arm"))?;
-            emit_call_once(
+            let call_result = emit_call_once(
                 graph,
                 else_bb,
                 env_in_else,
@@ -336,19 +386,35 @@ fn rewire_one_closure_select_site(
                 &site.call_once_owner,
                 site.call_result_ty.clone(),
                 &site.args_tuple_suffix,
-            )
+            );
+            if let Some((suffix, payload_ty)) = &site.call_once_result_exc {
+                let (finish_bb, finish_inputs) =
+                    graph.create_block_with_arg_vars(else_sources.len() + 1);
+                let mut args: Vec<LinkArg> =
+                    else_inputs.iter().cloned().map(LinkArg::Value).collect();
+                args.push(LinkArg::Value(call_result.clone()));
+                close_goto_mixed(graph, else_bb, finish_bb, args);
+                synthesized_result_exc = Some((call_result, suffix.clone(), payload_ty.clone()));
+                (
+                    finish_inputs[else_sources.len()].clone(),
+                    finish_bb,
+                    finish_inputs[..else_sources.len()].to_vec(),
+                )
+            } else {
+                (call_result, else_bb, else_inputs.clone())
+            }
         }
     };
-    let else_result = emit_narrow(graph, else_bb, else_value, &narrow_root);
+    let else_result = emit_narrow(graph, else_finish_bb, else_value, &narrow_root);
     let else_link_args = reproduce_exit_args(
         &saved_exit,
         &flow_result,
         &else_result,
         &else_sources,
-        &else_inputs,
+        &else_finish_inputs,
         &name,
     )?;
-    close_goto_mixed(graph, else_bb, b_target, else_link_args);
+    close_goto_mixed(graph, else_finish_bb, b_target, else_link_args);
 
     // A: drop the residual call (+ absorbed cast), read the discriminant, branch
     // on `bool(disc)` (Option tags None=0 / Some=1 → the Some arm is `then`).
@@ -391,7 +457,7 @@ fn rewire_one_closure_select_site(
         });
     }
     graph.set_branch(a_id, disc, then_bb, then_sources, else_bb, else_sources);
-    Ok(())
+    Ok(synthesized_result_exc)
 }
 
 /// Read `opt.__pos_0` (the `Some` payload) in `block`, returning the payload
@@ -523,6 +589,7 @@ mod tests {
             result_option_owner: RESULT_OPTION.into(),
             result_some_owner: RESULT_SOME.into(),
             result_niche,
+            call_once_result_exc: None,
         }
     }
 
@@ -547,8 +614,8 @@ mod tests {
         let (b, _b_args) = g.create_block_with_arg_vars(1);
         g.set_return(b, None);
         g.set_goto(a, b, vec![result.clone()]);
-        let rewritten = rewire_closure_select_call_sites(&mut g, &[site(kind, result)]);
-        assert_eq!(rewritten, 1, "the {method} site must be rewritten");
+        let outcome = rewire_closure_select_call_sites(&mut g, &[site(kind, result)]);
+        assert_eq!(outcome.rewritten, 1, "the {method} site must be rewritten");
         (g, a.0)
     }
 
@@ -588,10 +655,10 @@ mod tests {
     }
 
     fn count_ctors(g: &FunctionGraph) -> usize {
-        count_calls(
-            g,
-            |t| matches!(t, CallTarget::SyntheticTransparentCtor { name, .. } if name == "Option"),
-        )
+        count_calls(g, |t| {
+            matches!(t, CallTarget::SyntheticTransparentCtor { name, .. }
+                if matches!(name.as_str(), "Some" | "None"))
+        })
     }
 
     fn count_null_mut(g: &FunctionGraph) -> usize {
@@ -630,6 +697,78 @@ mod tests {
             vec!["Tuple".to_string(), RESULT_SOME.to_string()],
             "the Some(U) payload keys the result Some variant"
         );
+    }
+
+    #[test]
+    fn map_rewraps_a_scoped_result_closure_before_building_some() {
+        let mut g = FunctionGraph::new("test_closure_select_result");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let env = g.push_op_var(a, OpKind::ConstInt(7), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: CallTarget::method("map", Some(RECV_OPTION.into())),
+                    args: vec![opt, env],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![result.clone()]);
+        let mut result_site = site(ClosureCombinator::Map, result);
+        result_site.call_result_ty = ValueType::Ref(None);
+        result_site.call_once_result_exc = Some((
+            Some("<*mut PyObject,PyError>".to_string()),
+            ValueType::Ref(Some("PyObject".to_string())),
+        ));
+
+        let outcome = rewire_closure_select_call_sites(&mut g, &[result_site]);
+        assert_eq!(outcome.rewritten, 1);
+        assert_eq!(outcome.result_exc_calls.len(), 1);
+        let result_outcome = crate::front::result_exc::rewire_result_exc_call_sites(
+            &mut g,
+            &outcome.result_exc_calls,
+            false,
+        )
+        .expect("the synthesized call has the ordinary custom-consumer shape");
+        assert_eq!(result_outcome.rewrapped, 1);
+
+        let call_block = g
+            .blocks
+            .iter()
+            .find(|block| {
+                block.operations.iter().any(|op| {
+                    matches!(
+                        &op.kind,
+                        OpKind::Call {
+                            target: CallTarget::Method { name, .. },
+                            ..
+                        } if name == "call_once"
+                    )
+                })
+            })
+            .expect("call_once block");
+        assert!(
+            matches!(
+                call_block.exitswitch,
+                Some(crate::model::ExitSwitch::LastException)
+            ),
+            "the scoped closure call must use the graph exception ABI"
+        );
+        for variant in ["Ok", "Err"] {
+            assert_eq!(
+                count_calls(&g, |target| matches!(
+                    target,
+                    CallTarget::SyntheticTransparentCtor { name, .. } if name == variant
+                )),
+                1,
+                "the caller must rebuild exactly one Result::{variant} shell"
+            );
+        }
     }
 
     #[test]
@@ -678,10 +817,10 @@ mod tests {
         let (b, _b_args) = g.create_block_with_arg_vars(1);
         g.set_return(b, None);
         g.set_goto(a, b, vec![result.clone()]);
-        let rewritten =
+        let outcome =
             rewire_closure_select_call_sites(&mut g, &[site_with_result_niche(kind, result, true)]);
         assert_eq!(
-            rewritten, 1,
+            outcome.rewritten, 1,
             "the niche-result {method} site must be rewritten"
         );
         g
@@ -865,9 +1004,9 @@ mod tests {
             .unwrap();
         g.push_op_var(a, OpKind::ConstInt(9), true).unwrap();
         g.set_return(a, None);
-        let rewritten =
+        let outcome =
             rewire_closure_select_call_sites(&mut g, &[site(ClosureCombinator::Map, result)]);
-        assert_eq!(rewritten, 0, "a non-last-op call declines");
+        assert_eq!(outcome.rewritten, 0, "a non-last-op call declines");
         assert!(
             !residual_gone(&g, "map"),
             "residual call survives on decline"

--- a/majit/majit-translate/src/front/option_closure_select.rs
+++ b/majit/majit-translate/src/front/option_closure_select.rs
@@ -498,7 +498,7 @@ fn read_some_payload(
 /// the single closure argument (a `(x,)` tuple) or `None` for a niladic closure
 /// (an empty tuple the opaque body ignores) — the same `Args`-tuple shape
 /// `Rvalue::Aggregate` emits.
-fn emit_call_once(
+pub(crate) fn emit_call_once(
     graph: &mut FunctionGraph,
     block: BlockId,
     env: Variable,

--- a/majit/majit-translate/src/front/option_closure_select.rs
+++ b/majit/majit-translate/src/front/option_closure_select.rs
@@ -733,6 +733,12 @@ mod tests {
             &mut g,
             &outcome.result_exc_calls,
             false,
+            crate::ErrorCarrierSpec {
+                carrier_path: "pyre_interpreter::error::PyError",
+                carrier_wrappers: &["alloc::boxed::Box"],
+                to_exc_object: Some(&["pyre_interpreter", "error", "pyerror_to_exc_object"]),
+                from_exc_object: Some(("PyError", "from_exc_object")),
+            },
         )
         .expect("the synthesized call has the ordinary custom-consumer shape");
         assert_eq!(result_outcome.rewrapped, 1);

--- a/majit/majit-translate/src/front/option_try.rs
+++ b/majit/majit-translate/src/front/option_try.rs
@@ -73,15 +73,26 @@ pub(crate) struct OptionTryStats {
 
 /// Rewrite every recorded `Option` `Try::branch` site.  `return_option_owner`
 /// is the enclosing function's declared `Option<U>` root; `None` means the
-/// function is not Option-returning, so all sites decline.
+/// function is not Option-returning, so all sites decline. `return_niche` and
+/// `return_narrow_root` describe the enclosing return Option independently of
+/// the branched Option: a niche return builds a narrowed null instead of an
+/// enum `Option::None` aggregate.
 pub(crate) fn rewire_option_try_call_sites(
     graph: &mut FunctionGraph,
     sites: &[OptionTrySite],
     return_option_owner: Option<&str>,
+    return_niche: bool,
+    return_narrow_root: Option<&str>,
 ) -> OptionTryStats {
     let mut stats = OptionTryStats::default();
     for site in sites {
-        match rewire_one_option_try_site(graph, site, return_option_owner) {
+        match rewire_one_option_try_site(
+            graph,
+            site,
+            return_option_owner,
+            return_niche,
+            return_narrow_root,
+        ) {
             Ok(()) => stats.rewritten += 1,
             Err(decline) => {
                 stats.declined += 1;
@@ -101,6 +112,8 @@ fn rewire_one_option_try_site(
     graph: &mut FunctionGraph,
     site: &OptionTrySite,
     return_option_owner: Option<&str>,
+    return_niche: bool,
+    return_narrow_root: Option<&str>,
 ) -> Result<(), String> {
     let name = graph.name.clone();
     let Some(return_option_owner) = return_option_owner else {
@@ -268,7 +281,20 @@ fn rewire_one_option_try_site(
         collapse_pos0_read(graph, continue_link.target, pos, &name)?;
     }
 
-    let none = emit_option_variant(graph, none_bb, return_option_owner, 0, None);
+    // The break arm returns the enclosing function's `None`, whose physical
+    // shape is governed by the RETURN Option, independently of the branched
+    // Option above.  A niche `Option<PyObjectRef>` is RPython's nullable
+    // `SomeInstance(PyObject)`: emit the null pointer and restore the pointee
+    // ClassDef narrowing, exactly as the ordinary MIR aggregate fold does for
+    // `None`.  Building an `Option::None` aggregate here made the returnblock
+    // try to union that enum variant with the `PyObject` success value.
+    let none = if return_niche {
+        let null = graph.push_null_mut_ptr(none_bb);
+        let narrow_root = return_narrow_root.map(str::to_owned);
+        crate::front::option_map_or::emit_narrow(graph, none_bb, null, &narrow_root)
+    } else {
+        emit_option_variant(graph, none_bb, return_option_owner, 0, None)
+    };
     graph.set_control_flow_metadata(
         none_bb,
         None,

--- a/majit/majit-translate/src/front/option_unwrap.rs
+++ b/majit/majit-translate/src/front/option_unwrap.rs
@@ -1,39 +1,40 @@
-//! `Option::unwrap(opt)` → discriminant guard + payload extraction.
+//! `Option::unwrap(opt)` / `Result::unwrap(res)` → discriminant guard +
+//! payload extraction.
 //!
 //! ## Positioning
 //!
-//! `core::option::<Impl>::unwrap` is a foreign combinator whose body is Opaque
-//! in the LLBC (Charon cannot extract `core`), so the caller emits a residual
-//! `unwrap` call — an unregistered callee the rtyper census Skips.  Like
+//! `core::{option,result}::<Impl>::unwrap` is a foreign combinator whose body
+//! is Opaque in the LLBC (Charon cannot extract `core`), so the caller emits a
+//! residual `unwrap` call — an unregistered callee the rtyper census Skips. Like
 //! [`crate::front::option_unwrap_or`] the combinator's match lives inside the
 //! opaque body: at the call site there is only `result = unwrap(opt)` flowing
 //! on.  This pass creates the guard the combinator's semantics imply:
 //!
 //! ```text
-//!     result = opt.unwrap()               // residual `unwrap` call
+//!     result = recv.unwrap()              // residual `unwrap` call
 //! becomes
-//!     if opt.__discriminant == 1 { result = opt.__pos_0 } else { <panic> }
+//!     if recv is the payload variant { result = recv.__pos_0 } else { <panic> }
 //! ```
 //!
-//! Unlike `unwrap_or` there is no default: `Option::unwrap` panics on `None`.
-//! The `None` arm is therefore not a value path but an implicit-`AssertionError`
+//! Unlike `unwrap_or` there is no default: `unwrap` panics on the non-payload
+//! variant.  That arm is therefore not a value path but an implicit-`AssertionError`
 //! raise ([`FunctionGraph::set_raise_implicit`]) — the "shouldn't occur at
 //! run-time" shape [`crate::model::remove_assertion_errors`] prunes, matching
-//! `unwrap`'s never-`None` contract.  The `Some` arm reads `opt.__pos_0` exactly
-//! as `unwrap_or`'s does.  `Option`'s tags are `None = 0` / `Some = 1`, so
-//! branching on `bool(disc)` selects the `Some` arm.
+//! `unwrap`'s successful-path contract.  The payload arm reads
+//! `recv.__pos_0` exactly as `unwrap_or`'s does. `Option`'s payload tag is
+//! `Some = 1`; `Result`'s is `Ok = 0`, so the recorded polarity selects the
+//! correct `bool(disc)` arm.
 //!
 //! ## The rewrite (`rewire_one_unwrap_site`)
 //!
 //! Block A holds the residual `unwrap` call producing `result` as its last op,
 //! closed by `lower_call` with a single forwarding exit to block B (the
 //! continuation consuming `result`).  The rewrite:
-//! 1. drops the `unwrap` call, reads `disc = opt.__discriminant`, and closes A
+//! 1. drops the `unwrap` call, reads `disc = recv.__discriminant`, and closes A
 //!    with a `bool(disc)` branch to two fresh arms;
-//! 2. the `then_bb` (`Some`) arm reads `opt.__pos_0` and forwards it to B as
+//! 2. the payload arm reads `recv.__pos_0` and forwards it to B as
 //!    the `result` slot, threading every other live value through;
-//! 3. the `else_bb` (`None`) arm raises the implicit `AssertionError` (no edge
-//!    to B — the `None` path never produces a `result`).
+//! 3. the non-payload arm raises the implicit `AssertionError` (no edge to B).
 //!
 //! It is **fail-safe**: any structural mismatch returns `Err`, the caller
 //! leaves the residual call untouched, and the unregistered `unwrap` callee
@@ -43,23 +44,27 @@ use crate::flowspace::model::Variable;
 use crate::front::bool_then::{close_goto_mixed, map_source, reproduce_exit_args};
 use crate::model::{FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType};
 
-/// A recognized `Option::unwrap(opt)` call site captured during body lowering
+/// A recognized `Option::unwrap(opt)` / `Result::unwrap(res)` call site
+/// captured during body lowering
 /// (`front::mir` `recognize_unwrap_site`).  The owner strings are resolved at
-/// the recording site where the receiver `Option` type is in hand; the
+/// the recording site where the receiver enum type is in hand; the
 /// post-pass only needs them to spell the `__discriminant` / `__pos_0` field
-/// reads in the synthesized `Some` arm.
+/// reads in the synthesized payload arm.
 #[derive(Clone)]
 pub(crate) struct UnwrapSite {
     /// The `unwrap` call result (the payload `T` value) — locates block A.
     pub result_var: Variable,
-    /// The `Option` enum root `name_path` — the `__discriminant` field owner.
-    pub option_owner: String,
-    /// The `Option::Some` variant `name_path` — the `__pos_0` payload field
+    /// The enum root `name_path` — the `__discriminant` field owner.
+    pub enum_owner: String,
+    /// The payload variant `name_path` (`Option::Some` / `Result::Ok`) — the
+    /// `__pos_0` payload field
     /// owner (matching the variant-qualified `resolve_adt_field` read owner).
-    pub some_owner: String,
-    /// The `Option`'s payload `T` projected to a [`ValueType`] — the
-    /// `Some::__pos_0` field kind and the extracted result kind.
+    pub payload_owner: String,
+    /// The enum's payload `T` projected to a [`ValueType`] — the `__pos_0`
+    /// field kind and the extracted result kind.
     pub payload_ty: ValueType,
+    /// True for `Option::Some = 1`; false for `Result::Ok = 0`.
+    pub payload_on_disc_true: bool,
     /// True when the receiver is a niche `Option<NonNull<_>>` — a one-word
     /// pointer with no aggregate `__discriminant` / `__pos_0`.  The `Some`-arm
     /// discriminant is then `opt != null` and the payload is the base pointer
@@ -67,7 +72,8 @@ pub(crate) struct UnwrapSite {
     pub niche: bool,
 }
 
-/// Rewrite every recorded `Option::unwrap` call site into the discriminant
+/// Rewrite every recorded `Option::unwrap` / `Result::unwrap` call site into
+/// the discriminant
 /// guard.  Fail-safe: a site whose block does not fit the residual-call shape
 /// is left untouched (Skip), so a mismatch never regresses a graph the legacy
 /// walker already handled.  Returns the number of sites rewritten.
@@ -106,8 +112,8 @@ fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Resul
             "{name}: unwrap call is not the last op of block {a}"
         ));
     }
-    // Capture the receiver `Option` operand (the sole argument).
-    let opt = match &graph.blocks[a].operations[call_idx].kind {
+    // Capture the receiver enum operand (the sole argument).
+    let recv = match &graph.blocks[a].operations[call_idx].kind {
         OpKind::Call { args, .. } if args.len() == 1 => args[0].clone(),
         other => {
             return Err(format!(
@@ -132,8 +138,8 @@ fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Resul
     let b_target = saved_exit.target;
 
     // `carried` = the distinct live Values A forwards to B other than the
-    // payload itself; each must be threaded through the `Some` arm to reach B.
-    // The `None` arm raises and never reaches B, so it carries nothing.
+    // payload itself; each must be threaded through the payload arm to reach B.
+    // The non-payload arm raises and never reaches B, so it carries nothing.
     let mut carried: Vec<Variable> = Vec::new();
     for arg in &saved_exit.args {
         if let LinkArg::Value(v) = arg
@@ -146,31 +152,31 @@ fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Resul
 
     // --- All structural validation passed; mutate the graph. ---
 
-    // `then_bb` (`Some`) carries `carried` plus `opt` (the base for the
-    // `__pos_0` read); `else_bb` (`None`) has no inputs — it raises.  The
-    // source-var lists double as the branch link args.
-    let mut then_sources = carried.clone();
-    if !then_sources.contains(&opt) {
-        then_sources.push(opt.clone());
+    // `payload_bb` carries `carried` plus `recv` (the base for the `__pos_0`
+    // read); `failure_bb` has no inputs — it raises. The source-var list also
+    // serves as the branch link args.
+    let mut payload_sources = carried.clone();
+    if !payload_sources.contains(&recv) {
+        payload_sources.push(recv.clone());
     }
-    let (then_bb, then_inputs) = graph.create_block_with_arg_vars(then_sources.len());
-    let (else_bb, _else_inputs) = graph.create_block_with_arg_vars(0);
+    let (payload_bb, payload_inputs) = graph.create_block_with_arg_vars(payload_sources.len());
+    let (failure_bb, _failure_inputs) = graph.create_block_with_arg_vars(0);
 
     // `then_bb`: payload = opt.__pos_0.  A niche `Option<NonNull>` has no
     // aggregate `__pos_0`; the payload IS the base pointer (identity).
-    let opt_in_then = map_source(&then_sources, &then_inputs, &opt)
-        .ok_or_else(|| format!("{name}: Option value not threaded into Some arm"))?;
+    let recv_in_payload = map_source(&payload_sources, &payload_inputs, &recv)
+        .ok_or_else(|| format!("{name}: enum value not threaded into payload arm"))?;
     let payload = if site.niche {
-        opt_in_then
+        recv_in_payload
     } else {
         let payload = graph.alloc_value_var();
-        graph.block_mut(then_bb).operations.push(SpaceOperation {
+        graph.block_mut(payload_bb).operations.push(SpaceOperation {
             result: Some(payload.clone()),
             kind: OpKind::FieldRead {
-                base: opt_in_then,
+                base: recv_in_payload,
                 field: FieldDescriptor {
                     name: "__pos_0".to_string(),
-                    owner_root: Some(site.some_owner.clone()),
+                    owner_root: Some(site.payload_owner.clone()),
                     owner_id: None,
                     base_is_deref: None,
                     taken_by_address: false,
@@ -181,24 +187,22 @@ fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Resul
         });
         payload
     };
-    let then_link_args = reproduce_exit_args(
+    let payload_link_args = reproduce_exit_args(
         &saved_exit,
         &site.result_var,
         &payload,
-        &then_sources,
-        &then_inputs,
+        &payload_sources,
+        &payload_inputs,
         &name,
     )?;
-    close_goto_mixed(graph, then_bb, b_target, then_link_args);
+    close_goto_mixed(graph, payload_bb, b_target, payload_link_args);
 
-    // `else_bb` (`None`): raise the implicit `AssertionError` — `unwrap` panics
-    // on `None`, and the never-`None` contract makes this the "shouldn't occur"
-    // shape `remove_assertion_errors` prunes.
-    graph.set_raise_implicit(else_bb, "Option::unwrap on None value");
+    // The non-payload arm raises: `unwrap` panics on `None` / `Err`.
+    graph.set_raise_implicit(failure_bb, "unwrap on non-payload variant");
 
     // A: drop the residual `unwrap` call, read the discriminant, branch on it.
-    // `Option` tags None=0 / Some=1, so `bool(disc)` selects the `Some` (then)
-    // arm.  The receiver construction ops stay as A's tail.
+    // The receiver construction ops stay as A's tail. `Option::Some = 1`, so
+    // its payload is the true arm; `Result::Ok = 0`, so its payload is false.
     let a_id = graph.blocks[a].id;
     graph.blocks[a].operations.remove(call_idx);
     let disc = graph.alloc_value_var();
@@ -213,7 +217,7 @@ fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Resul
             result: Some(disc.clone()),
             kind: OpKind::BinOp {
                 op: "ne".to_string(),
-                lhs: opt.clone(),
+                lhs: recv.clone(),
                 rhs: nullc,
                 result_ty: ValueType::Int,
             },
@@ -222,10 +226,10 @@ fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Resul
         graph.block_mut(a_id).operations.push(SpaceOperation {
             result: Some(disc.clone()),
             kind: OpKind::FieldRead {
-                base: opt.clone(),
+                base: recv.clone(),
                 field: FieldDescriptor {
                     name: "__discriminant".to_string(),
-                    owner_root: Some(site.option_owner.clone()),
+                    owner_root: Some(site.enum_owner.clone()),
                     owner_id: None,
                     base_is_deref: None,
                     taken_by_address: false,
@@ -235,7 +239,25 @@ fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Resul
             },
         });
     }
-    graph.set_branch(a_id, disc, then_bb, then_sources, else_bb, Vec::new());
+    if site.payload_on_disc_true {
+        graph.set_branch(
+            a_id,
+            disc,
+            payload_bb,
+            payload_sources,
+            failure_bb,
+            Vec::new(),
+        );
+    } else {
+        graph.set_branch(
+            a_id,
+            disc,
+            failure_bb,
+            Vec::new(),
+            payload_bb,
+            payload_sources,
+        );
+    }
     Ok(())
 }
 
@@ -276,9 +298,10 @@ mod tests {
             &mut g,
             &[UnwrapSite {
                 result_var: result.clone(),
-                option_owner: "core::option::Option".to_string(),
-                some_owner: "core::option::Option::Some".to_string(),
+                enum_owner: "core::option::Option".to_string(),
+                payload_owner: "core::option::Option::Some".to_string(),
                 payload_ty: ValueType::Int,
+                payload_on_disc_true: true,
                 niche: false,
             }],
         );
@@ -321,6 +344,72 @@ mod tests {
         assert_eq!(raises, 1, "the None arm raises to exceptblock");
     }
 
+    /// `Result::Ok = 0`, so its payload arm is the `bool(disc)`-false exit;
+    /// the true (`Err`) exit raises. This is the mirror of `Option::Some = 1`.
+    #[test]
+    fn rewrite_lifts_result_unwrap_payload_on_disc_false() {
+        use crate::model::ExitCase;
+
+        let mut g = FunctionGraph::new("test_result_unwrap");
+        let a = g.startblock;
+        let recv = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: unwrap_target(),
+                    args: vec![recv],
+                    result_ty: ValueType::Unsigned,
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![result.clone()]);
+
+        let rewritten = rewire_unwrap_call_sites(
+            &mut g,
+            &[UnwrapSite {
+                result_var: result,
+                enum_owner: "core::result::Result<usize,TryFromIntError>".into(),
+                payload_owner: "core::result::Result<usize,TryFromIntError>::Ok".into(),
+                payload_ty: ValueType::Unsigned,
+                payload_on_disc_true: false,
+                niche: false,
+            }],
+        );
+        assert_eq!(rewritten, 1, "the Result unwrap site must be rewritten");
+
+        let reads_pos0 = |bb: usize| {
+            g.blocks[bb].operations.iter().any(
+                |op| matches!(&op.kind, OpKind::FieldRead { field, .. } if field.name == "__pos_0"),
+            )
+        };
+        for link in &g.blocks[a.0].exits {
+            match &link.exitcase {
+                Some(ExitCase::Bool(false)) => {
+                    assert!(reads_pos0(link.target.0), "Ok arm reads the payload");
+                    assert!(
+                        g.blocks[link.target.0]
+                            .exits
+                            .iter()
+                            .any(|arm| arm.target == b),
+                        "Ok arm reaches the continuation"
+                    );
+                }
+                Some(ExitCase::Bool(true)) => assert!(
+                    g.blocks[link.target.0]
+                        .exits
+                        .iter()
+                        .any(|arm| arm.target == g.exceptblock),
+                    "Err arm raises"
+                ),
+                other => panic!("unexpected branch exitcase {other:?}"),
+            }
+        }
+    }
+
     /// A producer op that is not a 1-arg call declines (fail-safe).
     #[test]
     fn rewrite_declines_when_producer_not_unary_call() {
@@ -345,9 +434,10 @@ mod tests {
             &mut g,
             &[UnwrapSite {
                 result_var: result,
-                option_owner: "core::option::Option".to_string(),
-                some_owner: "core::option::Option::Some".to_string(),
+                enum_owner: "core::option::Option".to_string(),
+                payload_owner: "core::option::Option::Some".to_string(),
                 payload_ty: ValueType::Int,
+                payload_on_disc_true: true,
                 niche: false,
             }],
         );

--- a/majit/majit-translate/src/front/range_iter.rs
+++ b/majit/majit-translate/src/front/range_iter.rs
@@ -58,17 +58,13 @@ use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, SpaceOperation, V
 /// A recognized exclusive int-`Range { start, end }` aggregate captured
 /// during body lowering (`front::mir`'s `Rvalue::Aggregate` arm).  Carries
 /// the ctor result (the range value the reflexive `into_iter` aliases into
-/// the loop iterator) and the two int bounds threaded into the `range()`
-/// builtin call.
+/// the loop iterator). The bounds are read from the live post-simplify
+/// FieldWrite chain when the pass runs.
 #[derive(Clone)]
 pub(crate) struct RangeNewSite {
     /// The `SyntheticTransparentCtor` result (the `Range` value) — locates
     /// the ctor op and the `next` iterator's backward-traced origin.
     pub result_var: Variable,
-    /// Lower bound `a` — the `range(a, b)` start argument.
-    pub start: Variable,
-    /// Upper bound `b` — the `range(a, b)` stop argument.
-    pub end: Variable,
 }
 
 /// Rewrite every captured exclusive-int-`Range` aggregate that feeds a
@@ -196,12 +192,20 @@ fn rewire_one_range_iter_site(
         ));
     }
 
-    // 4. The bounds must be defined so the `range()` call is well-formed.
-    if !graph_defines(graph, &site.start) || !graph_defines(graph, &site.end) {
+    // 4. Re-read the bounds from the live FieldWrite chain.  The capture is
+    //    made while lowering the MIR aggregate, but `simplify_lowered_graph`
+    //    runs before this pass and can replace a bound Variable while
+    //    updating its consumers.  The surviving FieldWrites are therefore
+    //    the authoritative post-simplify flow-graph values — exactly the
+    //    graph the annotator will consume.  Keeping the captured Variables
+    //    here made a valid loop decline when (for example) `save_point` was
+    //    forwarded through an emptied block in `w_method_new`.
+    let (start, end) = live_range_bounds(graph, &res).ok_or_else(|| {
+        format!("{name}: range construction has no unique live start/end FieldWrite pair")
+    })?;
+    if !graph_defines(graph, &start) || !graph_defines(graph, &end) {
         return Err(format!("{name}: range bounds are not defined in the graph"));
     }
-    let start = site.start.clone();
-    let end = site.end.clone();
 
     // 5. Remove every `start` / `end` `FieldWrite` on the range value (any
     //    block): after the divert `res` is a `SomeIterator`, so a surviving
@@ -367,6 +371,41 @@ fn graph_defines(graph: &FunctionGraph, var: &Variable) -> bool {
     })
 }
 
+/// The unique post-simplification `start` / `end` values written into one
+/// captured `Range` shell.  A duplicate, missing, or non-variable field value
+/// declines: the consumer rewrite is valid only for the exact two-field Rust
+/// `Range { start, end }` construction shape.
+fn live_range_bounds(
+    graph: &FunctionGraph,
+    range_result: &Variable,
+) -> Option<(Variable, Variable)> {
+    let mut start = None;
+    let mut end = None;
+    for op in graph.blocks.iter().flat_map(|block| &block.operations) {
+        let OpKind::FieldWrite {
+            base,
+            field,
+            value: LinkArg::Value(value),
+            ..
+        } = &op.kind
+        else {
+            continue;
+        };
+        if base != range_result {
+            continue;
+        }
+        let slot = match field.name.as_str() {
+            "start" => &mut start,
+            "end" => &mut end,
+            _ => continue,
+        };
+        if slot.replace(value.clone()).is_some() {
+            return None;
+        }
+    }
+    Some((start?, end?))
+}
+
 /// `t = range(start, end)` — the `range` builtin call the adapter resolves
 /// through `HOST_ENV.lookup_builtin("range")` → `SomeBuiltin("range")` →
 /// `builtin_range` (a `SomeList` carrying `range_step`).
@@ -517,8 +556,6 @@ mod tests {
             &mut g,
             &[RangeNewSite {
                 result_var: range.clone(),
-                start: a,
-                end: b,
             }],
             &[opt],
         );
@@ -592,8 +629,6 @@ mod tests {
             &mut g,
             &[RangeNewSite {
                 result_var: range.clone(),
-                start: a,
-                end: b,
             }],
             &[opt],
         );
@@ -671,8 +706,6 @@ mod tests {
             &mut g,
             &[RangeNewSite {
                 result_var: range.clone(),
-                start: a,
-                end: b,
             }],
             &[opt],
         );

--- a/majit/majit-translate/src/front/rbigint_call.rs
+++ b/majit/majit-translate/src/front/rbigint_call.rs
@@ -118,16 +118,30 @@ pub(crate) fn scalar_residual_for_method(
     leaf: &str,
     inside_dont_look_inside: bool,
 ) -> Option<(Vec<String>, ScalarResult)> {
-    // `rbigint.py:_AsDouble` is itself `@jit.dont_look_inside`, but
-    // GraphAnalyzer still walks its untranslated graph to compute effects.
-    // Keep the original `RBigInt.bit_length()` / `bit_count()` calls in such
-    // a graph.  Retargeting them to the interpreter-facing residual wrappers
-    // would add `jit_publish_exception(PyError(...).to_exc_object())` and its
-    // GC write barrier to a source graph where upstream carries only the
-    // ordinary OverflowError control-flow edge.  That false write then makes
-    // an enclosing elidable bigint helper fail `getcalldescr` with
-    // EF_RANDOM_EFFECTS.  Trace-visible callers still need the residual ABI,
-    // so only the effect-analysis body of an opaque caller declines it.
+    // NEW-DEVIATION, with a convergence path.  Upstream reads
+    // `_jit_look_inside_` in exactly one place — `JitPolicy.look_inside_graph`
+    // (`rpython/jit/codewriter/policy.py:48-58`) — to decide trace-vs-call.
+    // It never changes which operations a graph CONTAINS: `_AsDouble`'s
+    // flowgraph holds the same `direct_call(rbigint.bit_length)` whether or
+    // not it is opaque (`rpython/rlib/jit.py:133-140`).  Branching the emitted
+    // callee on the hint, as below, has no upstream counterpart.
+    //
+    // Why it is here: `rbigint.py:_AsDouble` is itself `@jit.dont_look_inside`,
+    // but GraphAnalyzer still walks its untranslated graph to compute effects.
+    // Retargeting its `bit_length` to the interpreter-facing residual wrapper
+    // adds `jit_publish_exception(PyError(...).to_exc_object())` and its GC
+    // write barrier to a source graph where upstream carries only the ordinary
+    // OverflowError control-flow edge.  That false write makes an enclosing
+    // elidable bigint helper fail `getcalldescr` with EF_RANDOM_EFFECTS.
+    //
+    // The defect is therefore the WRAPPER's effect, not the caller's hint.
+    // Converging means one of: (a) give the residual wrapper the uniform
+    // `front::result_exc` exception ABI so an OverflowError travels on the
+    // exception link instead of a heap publish — the shape
+    // `exceptiontransform.py` gives every raising graph; or (b) declare the
+    // publish's `EffectInfo` so it is not EF_RANDOM_EFFECTS.  Either lets one
+    // lowering serve both callers and this parameter goes away.  Until then
+    // the gate stays, because the alternative is a miscompiled effect set.
     if inside_dont_look_inside && matches!(leaf, "bit_length" | "bit_count") {
         return None;
     }

--- a/majit/majit-translate/src/front/rbigint_call.rs
+++ b/majit/majit-translate/src/front/rbigint_call.rs
@@ -120,28 +120,34 @@ pub(crate) fn scalar_residual_for_method(
 ) -> Option<(Vec<String>, ScalarResult)> {
     // NEW-DEVIATION, with a convergence path.  Upstream reads
     // `_jit_look_inside_` in exactly one place — `JitPolicy.look_inside_graph`
-    // (`rpython/jit/codewriter/policy.py:48-58`) — to decide trace-vs-call.
-    // It never changes which operations a graph CONTAINS: `_AsDouble`'s
-    // flowgraph holds the same `direct_call(rbigint.bit_length)` whether or
-    // not it is opaque (`rpython/rlib/jit.py:133-140`).  Branching the emitted
-    // callee on the hint, as below, has no upstream counterpart.
+    // (`rpython/jit/codewriter/policy.py`) — to decide trace-vs-call.  It never
+    // changes which operations a graph CONTAINS: `rbigint._AsDouble`'s
+    // flowgraph holds the same `direct_call(rbigint.bit_length)` whether or not
+    // `jit.dont_look_inside` (`rpython/rlib/jit.py`) marked it opaque.
+    // Branching the emitted callee on the hint, as below, has no upstream
+    // counterpart.
     //
-    // Why it is here: `rbigint.py:_AsDouble` is itself `@jit.dont_look_inside`,
-    // but GraphAnalyzer still walks its untranslated graph to compute effects.
-    // Retargeting its `bit_length` to the interpreter-facing residual wrapper
-    // adds `jit_publish_exception(PyError(...).to_exc_object())` and its GC
-    // write barrier to a source graph where upstream carries only the ordinary
-    // OverflowError control-flow edge.  That false write makes an enclosing
-    // elidable bigint helper fail `getcalldescr` with EF_RANDOM_EFFECTS.
+    // Why it is here, measured: `bit_length` / `bit_count` are the only scalar
+    // queries whose Rust signature is `Result<i64, RBigIntError>` — the
+    // value-encoded `ovfcheck` idiom, since both are `@jit.elidable` and raise
+    // OverflowError (`rpython/rlib/rbigint.py`).  This mapper's residual
+    // returns a bare Signed word, so the retarget ERASES that `Result`, while
+    // the caller's `?` diamond survives untouched: with the gate lifted,
+    // `_AsDouble` holds `jit_bigint_bit_length -> Int` still feeding
+    // `Try::branch` / `from_residual`, i.e. a `__discriminant` read on an
+    // integer.  `pyre_interpreter::typedef::long_bit_length` records the same
+    // erasure from the caller's side and works around it with its own
+    // `dont_look_inside` boundary.  The defect is a MISCOMPILE, not merely the
+    // wrapper's effect classification.
     //
-    // The defect is therefore the WRAPPER's effect, not the caller's hint.
-    // Converging means one of: (a) give the residual wrapper the uniform
-    // `front::result_exc` exception ABI so an OverflowError travels on the
-    // exception link instead of a heap publish — the shape
-    // `exceptiontransform.py` gives every raising graph; or (b) declare the
-    // publish's `EffectInfo` so it is not EF_RANDOM_EFFECTS.  Either lets one
-    // lowering serve both callers and this parameter goes away.  Until then
-    // the gate stays, because the alternative is a miscompiled effect set.
+    // Converging is `simplify.transform_ovfcheck`'s move, which
+    // [`crate::front::checked_arith`] already performs for the
+    // `checked_*` + `Option` spelling of the same idiom: rewrite the caller's
+    // diamond into an `OverflowError` exception edge — normal exit to the `Ok`
+    // arm carrying the bare word, raising exit to the `Err` arm — and do it
+    // atomically with the retarget, so a shape the rewrite declines keeps the
+    // unerased `bit_length` call and no hint is consulted anywhere.  Until that
+    // lands the gate stays, because the alternative is a miscompiled graph.
     if inside_dont_look_inside && matches!(leaf, "bit_length" | "bit_count") {
         return None;
     }

--- a/majit/majit-translate/src/front/rbigint_call.rs
+++ b/majit/majit-translate/src/front/rbigint_call.rs
@@ -114,7 +114,23 @@ pub(crate) fn long_box_residual_path(segments: &[String]) -> Option<Vec<String>>
 
 /// Bare-payload residual for scalar RBigInt queries. The caller has already
 /// proved exact RBigInt receiver identity.
-pub(crate) fn scalar_residual_for_method(leaf: &str) -> Option<(Vec<String>, ScalarResult)> {
+pub(crate) fn scalar_residual_for_method(
+    leaf: &str,
+    inside_dont_look_inside: bool,
+) -> Option<(Vec<String>, ScalarResult)> {
+    // `rbigint.py:_AsDouble` is itself `@jit.dont_look_inside`, but
+    // GraphAnalyzer still walks its untranslated graph to compute effects.
+    // Keep the original `RBigInt.bit_length()` / `bit_count()` calls in such
+    // a graph.  Retargeting them to the interpreter-facing residual wrappers
+    // would add `jit_publish_exception(PyError(...).to_exc_object())` and its
+    // GC write barrier to a source graph where upstream carries only the
+    // ordinary OverflowError control-flow edge.  That false write then makes
+    // an enclosing elidable bigint helper fail `getcalldescr` with
+    // EF_RANDOM_EFFECTS.  Trace-visible callers still need the residual ABI,
+    // so only the effect-analysis body of an opaque caller declines it.
+    if inside_dont_look_inside && matches!(leaf, "bit_length" | "bit_count") {
+        return None;
+    }
     let (module, residual, result) = match leaf {
         "get_sign" => (
             RESIDUAL_MODULE.as_slice(),
@@ -506,7 +522,7 @@ mod tests {
     #[test]
     fn maps_scalar_queries_with_their_result_bank() {
         assert_eq!(
-            scalar_residual_for_method("get_sign"),
+            scalar_residual_for_method("get_sign", false),
             Some((
                 segs(&[
                     crate::runtime_names::crates::OBJECT,
@@ -517,7 +533,7 @@ mod tests {
             ))
         );
         assert_eq!(
-            scalar_residual_for_method("is_zero"),
+            scalar_residual_for_method("is_zero", false),
             Some((
                 segs(&[
                     crate::runtime_names::crates::OBJECT,
@@ -528,7 +544,7 @@ mod tests {
             ))
         );
         assert_eq!(
-            scalar_residual_for_method("bit_length"),
+            scalar_residual_for_method("bit_length", false),
             Some((
                 segs(&[
                     crate::runtime_names::crates::INTERPRETER,
@@ -539,7 +555,10 @@ mod tests {
                 ScalarResult::Int
             ))
         );
-        assert!(scalar_residual_for_method("add").is_none());
+        assert_eq!(scalar_residual_for_method("bit_length", true), None);
+        assert_eq!(scalar_residual_for_method("bit_count", true), None);
+        assert!(scalar_residual_for_method("get_sign", true).is_some());
+        assert!(scalar_residual_for_method("add", false).is_none());
     }
 
     #[test]

--- a/majit/majit-translate/src/front/rbigint_call.rs
+++ b/majit/majit-translate/src/front/rbigint_call.rs
@@ -8,11 +8,6 @@
 //! [`crate::front::bigint_binop`].
 
 const RESIDUAL_MODULE: [&str; 2] = [crate::runtime_names::crates::OBJECT, "longobject"];
-const RAISING_SCALAR_RESIDUAL_MODULE: [&str; 3] = [
-    crate::runtime_names::crates::INTERPRETER,
-    "objspace",
-    "descroperation",
-];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ScalarResult {
@@ -114,43 +109,20 @@ pub(crate) fn long_box_residual_path(segments: &[String]) -> Option<Vec<String>>
 
 /// Bare-payload residual for scalar RBigInt queries. The caller has already
 /// proved exact RBigInt receiver identity.
-pub(crate) fn scalar_residual_for_method(
-    leaf: &str,
-    inside_dont_look_inside: bool,
-) -> Option<(Vec<String>, ScalarResult)> {
-    // NEW-DEVIATION, with a convergence path.  Upstream reads
-    // `_jit_look_inside_` in exactly one place — `JitPolicy.look_inside_graph`
-    // (`rpython/jit/codewriter/policy.py`) — to decide trace-vs-call.  It never
-    // changes which operations a graph CONTAINS: `rbigint._AsDouble`'s
-    // flowgraph holds the same `direct_call(rbigint.bit_length)` whether or not
-    // `jit.dont_look_inside` (`rpython/rlib/jit.py`) marked it opaque.
-    // Branching the emitted callee on the hint, as below, has no upstream
-    // counterpart.
-    //
-    // Why it is here, measured: `bit_length` / `bit_count` are the only scalar
-    // queries whose Rust signature is `Result<i64, RBigIntError>` — the
-    // value-encoded `ovfcheck` idiom, since both are `@jit.elidable` and raise
-    // OverflowError (`rpython/rlib/rbigint.py`).  This mapper's residual
-    // returns a bare Signed word, so the retarget ERASES that `Result`, while
-    // the caller's `?` diamond survives untouched: with the gate lifted,
-    // `_AsDouble` holds `jit_bigint_bit_length -> Int` still feeding
-    // `Try::branch` / `from_residual`, i.e. a `__discriminant` read on an
-    // integer.  `pyre_interpreter::typedef::long_bit_length` records the same
-    // erasure from the caller's side and works around it with its own
-    // `dont_look_inside` boundary.  The defect is a MISCOMPILE, not merely the
-    // wrapper's effect classification.
-    //
-    // Converging is `simplify.transform_ovfcheck`'s move, which
-    // [`crate::front::checked_arith`] already performs for the
-    // `checked_*` + `Option` spelling of the same idiom: rewrite the caller's
-    // diamond into an `OverflowError` exception edge — normal exit to the `Ok`
-    // arm carrying the bare word, raising exit to the `Err` arm — and do it
-    // atomically with the retarget, so a shape the rewrite declines keeps the
-    // unerased `bit_length` call and no hint is consulted anywhere.  Until that
-    // lands the gate stays, because the alternative is a miscompiled graph.
-    if inside_dont_look_inside && matches!(leaf, "bit_length" | "bit_count") {
-        return None;
-    }
+///
+/// Every mapped method returns a plain machine word in Rust, so retargeting it
+/// to a one-word residual preserves the call's type.  `bit_length` /
+/// `bit_count` are deliberately absent even though `rbigint.bit_length` /
+/// `rbigint.bit_count` (`rpython/rlib/rbigint.py`) are `@jit.elidable` like the
+/// rest: both raise OverflowError through `ovfcheck`, so their Rust signature
+/// is `Result<i64, RBigIntError>` and a one-word residual would ERASE that
+/// `Result` under a caller that still destructures it.  Upstream mints no
+/// residual for them either — they are ordinary elidable graphs the codewriter
+/// traces — so the parity shape and the sound shape agree.  Converging further
+/// means `simplify.transform_ovfcheck`'s rewrite, which
+/// [`crate::front::checked_arith`] already performs for the `checked_*` +
+/// `Option` spelling of the same idiom.
+pub(crate) fn scalar_residual_for_method(leaf: &str) -> Option<(Vec<String>, ScalarResult)> {
     let (module, residual, result) = match leaf {
         "get_sign" => (
             RESIDUAL_MODULE.as_slice(),
@@ -185,16 +157,6 @@ pub(crate) fn scalar_residual_for_method(
         "hash" => (
             RESIDUAL_MODULE.as_slice(),
             "jit_bigint_hash",
-            ScalarResult::Int,
-        ),
-        "bit_length" => (
-            RAISING_SCALAR_RESIDUAL_MODULE.as_slice(),
-            "jit_bigint_bit_length",
-            ScalarResult::Int,
-        ),
-        "bit_count" => (
-            RAISING_SCALAR_RESIDUAL_MODULE.as_slice(),
-            "jit_bigint_bit_count",
             ScalarResult::Int,
         ),
         _ => return None,
@@ -542,7 +504,7 @@ mod tests {
     #[test]
     fn maps_scalar_queries_with_their_result_bank() {
         assert_eq!(
-            scalar_residual_for_method("get_sign", false),
+            scalar_residual_for_method("get_sign"),
             Some((
                 segs(&[
                     crate::runtime_names::crates::OBJECT,
@@ -553,7 +515,7 @@ mod tests {
             ))
         );
         assert_eq!(
-            scalar_residual_for_method("is_zero", false),
+            scalar_residual_for_method("is_zero"),
             Some((
                 segs(&[
                     crate::runtime_names::crates::OBJECT,
@@ -563,22 +525,12 @@ mod tests {
                 ScalarResult::Bool
             ))
         );
-        assert_eq!(
-            scalar_residual_for_method("bit_length", false),
-            Some((
-                segs(&[
-                    crate::runtime_names::crates::INTERPRETER,
-                    "objspace",
-                    "descroperation",
-                    "jit_bigint_bit_length",
-                ]),
-                ScalarResult::Int
-            ))
-        );
-        assert_eq!(scalar_residual_for_method("bit_length", true), None);
-        assert_eq!(scalar_residual_for_method("bit_count", true), None);
-        assert!(scalar_residual_for_method("get_sign", true).is_some());
-        assert!(scalar_residual_for_method("add", false).is_none());
+        // `bit_length` / `bit_count` return `Result<i64, RBigIntError>` —
+        // `ovfcheck`'s value encoding — so no one-word residual may claim
+        // them; see this mapper's note.
+        assert_eq!(scalar_residual_for_method("bit_length"), None);
+        assert_eq!(scalar_residual_for_method("bit_count"), None);
+        assert!(scalar_residual_for_method("add").is_none());
     }
 
     #[test]

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -2563,7 +2563,8 @@ pub(crate) fn back_substitute(
         else {
             return Err(format!(
                 "{name}: continue-arm value is defined inside diamond block \
-                 {succ} and cannot be carried across the rewired call edge"
+                 {succ} (variable id {}) and cannot be carried across the rewired call edge",
+                current.id()
             ));
         };
         let [link] = graph.blocks[pred].exits.as_slice() else {

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -403,12 +403,13 @@ pub(crate) fn lower_result_exc_returns(
     // per-graph reason is not recoverable from any output.  Record it here,
     // where the reason still exists.
     //
-    // Upstream is loud in the equivalent position:
-    // `rpython/jit/codewriter/jtransform.py`'s `_handle_list_call` raises
-    // `NotImplementedError("prebuilt lists cannot be virtual")` rather than
-    // falling through to a residual.  This does not change the decline into
-    // an error — the fail-safe residual is deliberate here — it only makes
-    // the refusal countable.
+    // Upstream carries the reason as a value in the equivalent position:
+    // `_handle_list_call` raises `NotSupported(prefix + oopspec_name)`
+    // (`rpython/jit/codewriter/jtransform.py:1796`), naming the shape it
+    // refused, before `rewrite_op_direct_call` catches it and falls through
+    // to a residual call (`jtransform.py:512-520`).  The fail-safe residual
+    // is the same here — this only records the reason before it is
+    // discarded, so the refusal stays countable.
     let outcome = lower_result_exc_returns_inner(graph, tail_forwarded_returns, spec);
     if let Err(msg) = &outcome {
         crate::decline::record_reason(

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -50,6 +50,12 @@
 //!   `Link.last_exception`), which `flatten.rs` already turns into
 //!   `catch_exception` / rethrow shapes.
 //!
+//! - **Option-to-error rule** ([`rewire_option_ok_or_else_try_sites`]):
+//!   `Option::ok_or_else(...)?` is fused as one value-or-exception branch.
+//!   The Some arm forwards the payload directly; the None arm invokes the
+//!   niladic error closure and raises its materialised exception.  Neither the
+//!   foreign Option combinator nor its transient Result shell survives.
+//!
 //! ## Scope discipline
 //!
 //! Both rules must apply together per callee: a transformed callee
@@ -290,6 +296,22 @@ fn result_ok_slot<'l>(ty: &'l TyRef, llbc: &'l Llbc) -> Option<&'l serde_json::V
         .and_then(|t| t.get(0))
 }
 
+/// The `Err` payload slot of a `Result<T, E>` type value.
+fn result_err_slot<'l>(ty: &'l TyRef, llbc: &'l Llbc) -> Option<&'l serde_json::Value> {
+    let body = match ty {
+        TyRef::Inline { value: (_, v) } => v,
+        TyRef::Other(v) => v,
+        TyRef::Dedup { id } => llbc.dedup_body(*id)?,
+    };
+    if adt_path_of(body, llbc).as_deref() != Some("core::result::Result") {
+        return None;
+    }
+    body.get("Adt")
+        .and_then(|a| a.get("generics"))
+        .and_then(|g| g.get("types"))
+        .and_then(|t| t.get(1))
+}
+
 /// The `Ok` payload of a `Result<T, PyError>` as its own [`TyRef`], or
 /// `None` when `ty` is not a `Result`.
 ///
@@ -299,6 +321,11 @@ fn result_ok_slot<'l>(ty: &'l TyRef, llbc: &'l Llbc) -> Option<&'l serde_json::V
 /// callee's result therefore have to read `T`, not the `Result` ADT.
 pub(crate) fn tyref_result_ok(ty: &TyRef, llbc: &Llbc) -> Option<TyRef> {
     result_ok_slot(ty, llbc).and_then(|slot| serde_json::from_value(slot.clone()).ok())
+}
+
+/// The `E` payload of a `Result<T, E>` as its own [`TyRef`].
+pub(crate) fn tyref_result_err(ty: &TyRef, llbc: &Llbc) -> Option<TyRef> {
+    result_err_slot(ty, llbc).and_then(|slot| serde_json::from_value(slot.clone()).ok())
 }
 
 /// The `T` payload slot of an `Option<T>` type value, or `None` when `ty` is
@@ -657,29 +684,7 @@ fn lower_result_exc_returns_inner(
             // A carrier that declares no materialiser is already one such
             // value — a single owned word — so the payload is forwarded
             // into the raise unchanged and no call is emitted at all.
-            let v_exc = match spec.to_exc_object {
-                Some(segments) => graph
-                    .push_op_var(
-                        block_id,
-                        OpKind::Call {
-                            // The free-function spelling, not the method: it is
-                            // `dont_look_inside` and its address is published, so
-                            // the raise site records one residual call instead of
-                            // inlining the materialisation body — whose GC-root,
-                            // `w_exception_new_empty_impl`, WTF-8 and allocation
-                            // calls would otherwise sit in this JitCode and refuse
-                            // every descent that reaches it.
-                            target: CallTarget::FunctionPath {
-                                segments: segments.iter().copied().map(str::to_string).collect(),
-                            },
-                            args: vec![payload],
-                            result_ty: ValueType::Ref(None),
-                        },
-                        true,
-                    )
-                    .expect("to_exc_object call must produce a value"),
-                None => payload,
-            };
+            let v_exc = materialize_error_to_exc_object(graph, block_id, payload, spec);
             // `graph.set_raise_values(block, etype, evalue)`. The `etype`
             // link arg is write-only: `make_return`'s 2-arg arm emits
             // `raise <args[1]>` and never reads `args[0]`
@@ -721,6 +726,37 @@ fn lower_result_exc_returns_inner(
         ));
     }
     Ok(rewritten)
+}
+
+/// Materialise the carrier payload in the trace-level exception-value domain.
+///
+/// The free-function spelling is intentional: the helper is
+/// `dont_look_inside` and its published residual address keeps the carrier's
+/// allocation/rooting implementation out of the caller JitCode.  A consumer
+/// whose carrier already is the exception value declares no helper and gets
+/// the identity path.
+fn materialize_error_to_exc_object(
+    graph: &mut FunctionGraph,
+    block: BlockId,
+    payload: Variable,
+    spec: crate::ErrorCarrierSpec<'_>,
+) -> Variable {
+    match spec.to_exc_object {
+        Some(segments) => graph
+            .push_op_var(
+                block,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: segments.iter().copied().map(str::to_string).collect(),
+                    },
+                    args: vec![payload],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .expect("to_exc_object call must produce a value"),
+        None => payload,
+    }
 }
 
 /// True when some block's `Call` result flows straight to `returnblock`
@@ -1155,6 +1191,27 @@ pub(crate) struct RewireOutcome {
     pub fused: usize,
 }
 
+/// A foreign `Option::ok_or_else(opt, closure)` whose `Result<T, E>` is
+/// consumed immediately by Rust's `?` diamond.
+///
+/// RPython never materialises either shell at this boundary: for the motivating
+/// gateway, PyPy's `W_IOBase.writelines_w(self, space, w_lines)` receives the
+/// value directly and raises on the graph exception edge
+/// (`pypy/module/_io/interp_iobase.py:303-323`).  The MIR frontend records the
+/// owners while the concrete `Option<T>` / closure / `Result<T, E>` types are
+/// still available, then [`rewire_option_ok_or_else_try_sites`] restores that
+/// same value-or-raise graph shape after lowering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OptionOkOrElseTrySite {
+    pub result_var: Variable,
+    pub option_owner: String,
+    pub some_owner: String,
+    pub call_once_owner: String,
+    pub payload_ty: ValueType,
+    pub error_ty: ValueType,
+    pub niche: bool,
+}
+
 /// Per-site disposition for [`rewire_one_call_site`].
 enum SiteOutcome {
     Diamond,
@@ -1188,6 +1245,7 @@ pub(crate) fn rewire_result_exc_call_sites(
             payload_ty,
             enclosing_scoped,
             spec,
+            true,
         );
         let site = match site {
             Ok(site) => site,
@@ -1215,6 +1273,224 @@ pub(crate) fn rewire_result_exc_call_sites(
     Ok(outcome)
 }
 
+/// Fuse `Option::ok_or_else(...)?` into one Option test whose `Some` arm
+/// forwards `T` and whose `None` arm calls the niladic error closure and
+/// raises through the graph's native exception edge.
+///
+/// This is deliberately a combined rewrite.  Treating `ok_or_else` as an
+/// ordinary Option closure-select would build a `Result`, while treating it
+/// only as an ordinary scoped Result call would leave the foreign method as a
+/// residual.  RPython's flow graph has neither shell: it carries the value on
+/// the normal edge and the exception object on the exceptional edge
+/// (`rpython/translator/exceptiontransform.py:212-242`,
+/// `rpython/jit/codewriter/jtransform.py:406-469`).
+///
+/// The ordinary `?` matcher validates before its sole fallible mutation (the
+/// positional payload collapse).  The Option splice begins only after that
+/// matcher reports a complete private diamond; from there its sources are
+/// derived directly from the already-validated normal link, so no second
+/// decline point exists.  A mismatch therefore keeps the byte-identical
+/// residual call for the legacy fallback without cloning a potentially large
+/// portal graph per site.
+pub(crate) fn rewire_option_ok_or_else_try_sites(
+    graph: &mut FunctionGraph,
+    sites: &[OptionOkOrElseTrySite],
+    enclosing_scoped: bool,
+    spec: crate::ErrorCarrierSpec<'_>,
+) -> usize {
+    let mut rewritten = 0usize;
+    for site in sites {
+        match rewire_one_option_ok_or_else_try_site(graph, site, enclosing_scoped, spec) {
+            Ok(()) => rewritten += 1,
+            Err(msg) => {
+                crate::decline::record_reason(
+                    RESULT_EXC_CALLER_GATE,
+                    "option-ok-or-else-try-declined",
+                    &msg,
+                    &graph.name,
+                );
+            }
+        }
+    }
+    rewritten
+}
+
+fn rewire_one_option_ok_or_else_try_site(
+    graph: &mut FunctionGraph,
+    site: &OptionOkOrElseTrySite,
+    enclosing_scoped: bool,
+    spec: crate::ErrorCarrierSpec<'_>,
+) -> Result<(), String> {
+    use crate::front::bool_then::{close_goto_mixed, map_source, reproduce_exit_args};
+
+    let name = graph.name.clone();
+    let a = graph
+        .blocks
+        .iter()
+        .position(|block| {
+            block
+                .operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&site.result_var))
+        })
+        .ok_or_else(|| format!("{name}: ok_or_else result var has no producer block"))?;
+    let call_idx = graph.blocks[a]
+        .operations
+        .iter()
+        .position(|op| op.result.as_ref() == Some(&site.result_var))
+        .ok_or_else(|| format!("{name}: ok_or_else producer op vanished"))?;
+    if call_idx + 1 != graph.blocks[a].operations.len() {
+        return Err(format!(
+            "{name}: ok_or_else call is not the last operation of block {a}"
+        ));
+    }
+    let (opt, env) = match &graph.blocks[a].operations[call_idx].kind {
+        OpKind::Call {
+            target: CallTarget::Method { name, .. },
+            args,
+            ..
+        } if name == "ok_or_else" && args.len() == 2 => (args[0].clone(), args[1].clone()),
+        other => {
+            return Err(format!(
+                "{name}: recorded ok_or_else site has a different producer: {other:?}"
+            ));
+        }
+    };
+
+    let result_shape = rewire_one_call_site(
+        graph,
+        &site.result_var,
+        "",
+        &site.payload_ty,
+        enclosing_scoped,
+        spec,
+        false,
+    )?;
+    if !matches!(result_shape, SiteOutcome::Diamond) {
+        return Err(format!(
+            "{name}: ok_or_else result is not consumed by an immediate `?` diamond"
+        ));
+    }
+
+    let a_id = graph.blocks[a].id;
+    debug_assert!(matches!(
+        graph.blocks[a].exitswitch,
+        Some(ExitSwitch::LastException)
+    ));
+    debug_assert_eq!(graph.blocks[a].exits.len(), 2);
+    let normal = graph.blocks[a]
+        .exits
+        .iter()
+        .find(|link| link.exitcase.is_none())
+        .cloned()
+        .expect("the Result diamond rewrite always installs one normal exit");
+
+    let mut carried = Vec::new();
+    for arg in &normal.args {
+        if let LinkArg::Value(v) = arg
+            && *v != site.result_var
+            && !carried.contains(v)
+        {
+            carried.push(v.clone());
+        }
+    }
+    let mut some_sources = carried.clone();
+    if !some_sources.contains(&opt) {
+        some_sources.push(opt.clone());
+    }
+    let (some_bb, some_inputs) = graph.create_block_with_arg_vars(some_sources.len());
+    let (none_bb, none_inputs) = graph.create_block_with_arg_vars(1);
+
+    let opt_in_some = map_source(&some_sources, &some_inputs, &opt)
+        .expect("some_sources explicitly includes the Option value");
+    let payload = if site.niche {
+        opt_in_some
+    } else {
+        let payload = graph.alloc_value_var();
+        graph
+            .block_mut(some_bb)
+            .operations
+            .push(crate::model::SpaceOperation {
+                result: Some(payload.clone()),
+                kind: OpKind::FieldRead {
+                    base: opt_in_some,
+                    field: crate::model::FieldDescriptor {
+                        name: "__pos_0".to_string(),
+                        owner_root: Some(site.some_owner.clone()),
+                        owner_id: None,
+                        base_is_deref: None,
+                        taken_by_address: false,
+                    },
+                    ty: site.payload_ty.clone(),
+                    pure: true,
+                },
+            });
+        payload
+    };
+    let some_args = reproduce_exit_args(
+        &normal,
+        &site.result_var,
+        &payload,
+        &some_sources,
+        &some_inputs,
+        &name,
+    )
+    .expect("some_sources contains every non-result value from the normal link");
+    close_goto_mixed(graph, some_bb, normal.target, some_args);
+
+    let env_in_none = none_inputs[0].clone();
+    let error = crate::front::option_closure_select::emit_call_once(
+        graph,
+        none_bb,
+        env_in_none,
+        None,
+        &site.call_once_owner,
+        site.error_ty.clone(),
+        "",
+    );
+    let exc = materialize_error_to_exc_object(graph, none_bb, error, spec);
+    graph.set_raise_values(none_bb, exc.clone(), exc);
+
+    graph.blocks[a].operations.truncate(call_idx);
+    let disc = graph.alloc_value_var();
+    if site.niche {
+        let null = graph.push_null_mut_ptr(a_id);
+        graph
+            .block_mut(a_id)
+            .operations
+            .push(crate::model::SpaceOperation {
+                result: Some(disc.clone()),
+                kind: OpKind::BinOp {
+                    op: "ne".to_string(),
+                    lhs: opt.clone(),
+                    rhs: null,
+                    result_ty: ValueType::Int,
+                },
+            });
+    } else {
+        graph
+            .block_mut(a_id)
+            .operations
+            .push(crate::model::SpaceOperation {
+                result: Some(disc.clone()),
+                kind: OpKind::FieldRead {
+                    base: opt.clone(),
+                    field: crate::model::FieldDescriptor {
+                        name: "__discriminant".to_string(),
+                        owner_root: Some(site.option_owner.clone()),
+                        owner_id: None,
+                        base_is_deref: None,
+                        taken_by_address: false,
+                    },
+                    ty: ValueType::Int,
+                    pure: true,
+                },
+            });
+    }
+    graph.set_branch(a_id, disc, some_bb, some_sources, none_bb, vec![env]);
+    Ok(())
+}
+
 fn rewire_one_call_site(
     graph: &mut FunctionGraph,
     r: &Variable,
@@ -1222,6 +1498,7 @@ fn rewire_one_call_site(
     payload_ty: &ValueType,
     enclosing_scoped: bool,
     spec: crate::ErrorCarrierSpec<'_>,
+    allow_fallback: bool,
 ) -> Result<SiteOutcome, String> {
     let name = graph.name.clone();
     // Block A: contains the call producing `r`; closed by lower_call
@@ -1256,6 +1533,11 @@ fn rewire_one_call_site(
         )
     });
     let Some(branch_op_idx) = branch_op_idx else {
+        if !allow_fallback {
+            return Err(format!(
+                "{name}: scoped call result has no immediate Result::branch consumer"
+            ));
+        }
         // No `Result::branch` op → a hand-written `match` consumer.  The
         // drain-loop `match next()` fusion recognises its exact shape and
         // rewrites it into an exception-edge handler with an object-level
@@ -1328,6 +1610,11 @@ fn rewire_one_call_site(
     // AST-import code, off every hot path, but it is a real change to
     // pyre's compiled surface and any jitstats move traces here first.
     if assert_single_pred(graph, b, &name).is_err() {
+        if !allow_fallback {
+            return Err(format!(
+                "{name}: Result::branch block {b} is shared by multiple predecessors"
+            ));
+        }
         catch_and_rewrap(graph, a, r, suffix, payload_ty, spec)?;
         return Ok(SiteOutcome::Rewrapped);
     }
@@ -1342,6 +1629,11 @@ fn rewire_one_call_site(
     let (c, cf_c) =
         follow_single_exit(graph, b, &cf).map_err(|e| format!("{name}: branch block exit: {e}"))?;
     if assert_single_pred(graph, c, &name).is_err() {
+        if !allow_fallback {
+            return Err(format!(
+                "{name}: ControlFlow discriminant block {c} is shared by multiple predecessors"
+            ));
+        }
         catch_and_rewrap(graph, a, r, suffix, payload_ty, spec)?;
         return Ok(SiteOutcome::Rewrapped);
     }

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -788,6 +788,7 @@ pub(crate) fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
     match kind {
         OpKind::Input { .. }
         | OpKind::ConstInt(_)
+        | OpKind::ConstUInt(_)
         | OpKind::ConstInt128(_)
         | OpKind::ConstUInt128(_)
         | OpKind::ConstBool(_)

--- a/majit/majit-translate/src/front/rfloat_call.rs
+++ b/majit/majit-translate/src/front/rfloat_call.rs
@@ -1,0 +1,62 @@
+//! RPython `rfloat.formatd` residual-call retargets.
+//!
+//! PyPy's `float_repr` calls `rpython.rlib.rfloat.formatd`, whose translated
+//! result is one `STR` GC pointer. RustPython's formatter instead returns a
+//! three-word Rust `String`, which the residual-call ABI cannot return. The
+//! interpreter publishes an exact one-word `BytesBlock*` wrapper; this module
+//! selects that wrapper without teaching the parity layers a Rust ABI.
+
+const FLOAT_TO_STRING: &[&str] = &["rustpython_literal", "float", "to_string"];
+const FLOAT_RESIDUAL: &[&str] = &["pyre_interpreter", "display", "jit_format_float_repr_rstr"];
+const COMPLEX_COMPONENT: &[&str] = &[
+    "pyre_interpreter",
+    "typedef",
+    "format_complex_component_repr",
+];
+const COMPLEX_COMPONENT_RESIDUAL: &[&str] = &[
+    "pyre_interpreter",
+    "typedef",
+    "jit_format_complex_component_repr_rstr",
+];
+
+pub(crate) fn repr_residual_path(segments: &[String]) -> Option<Vec<String>> {
+    let path: Vec<&str> = segments.iter().map(String::as_str).collect();
+    let residual = if path == FLOAT_TO_STRING {
+        FLOAT_RESIDUAL
+    } else if path == COMPLEX_COMPONENT {
+        COMPLEX_COMPONENT_RESIDUAL
+    } else {
+        return None;
+    };
+    Some(residual.iter().map(|part| (*part).to_string()).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn segs(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|part| (*part).to_string()).collect()
+    }
+
+    #[test]
+    fn retargets_only_the_exact_rustpython_float_repr_formatter() {
+        assert_eq!(
+            repr_residual_path(&segs(FLOAT_TO_STRING)),
+            Some(segs(FLOAT_RESIDUAL))
+        );
+        assert!(repr_residual_path(&segs(&["float", "to_string"])).is_none());
+        assert!(
+            repr_residual_path(&segs(&["rustpython_literal", "complex", "to_string"])).is_none()
+        );
+    }
+
+    #[test]
+    fn retargets_only_the_pypy_complex_component_formatter_boundary() {
+        assert_eq!(
+            repr_residual_path(&segs(COMPLEX_COMPONENT)),
+            Some(segs(COMPLEX_COMPONENT_RESIDUAL))
+        );
+        assert!(repr_residual_path(&segs(&["typedef", "format_complex_component_repr"])).is_none());
+    }
+}

--- a/majit/majit-translate/src/front/rfloat_call.rs
+++ b/majit/majit-translate/src/front/rfloat_call.rs
@@ -1,10 +1,18 @@
-//! RPython `rfloat.formatd` residual-call retargets.
+//! Float/complex `repr` residual-call retargets.
 //!
-//! PyPy's `float_repr` calls `rpython.rlib.rfloat.formatd`, whose translated
-//! result is one `STR` GC pointer. RustPython's formatter instead returns a
-//! three-word Rust `String`, which the residual-call ABI cannot return. The
-//! interpreter publishes an exact one-word `BytesBlock*` wrapper; this module
-//! selects that wrapper without teaching the parity layers a Rust ABI.
+//! The two arms mirror `float2string` / `float_repr`
+//! (`pypy/objspace/std/floatobject.py:36-50`) and `repr_format` /
+//! `format_float` (`pypy/objspace/std/complexobject.py:120-133`).  Neither
+//! ports `rpython.rlib.rfloat.formatd` itself: upstream reaches it only
+//! indirectly (`float_repr` -> `float2string` -> `formatd`, and only on the
+//! `isfinite` branch), while these arms retarget RustPython/pyre formatters.
+//!
+//! What the retarget is for: the translated `formatd` result is one `STR` GC
+//! pointer, but RustPython's formatter returns a three-word Rust `String`,
+//! which the residual-call ABI cannot return.  The interpreter publishes an
+//! exact one-word `BytesBlock*` wrapper; this module selects that wrapper
+//! without teaching the parity layers a Rust ABI.  Structurally this is the
+//! [`crate::front::rbigint_call`] residual-retarget family.
 
 const FLOAT_TO_STRING: &[&str] = &["rustpython_literal", "float", "to_string"];
 const FLOAT_RESIDUAL: &[&str] = &["pyre_interpreter", "display", "jit_format_float_repr_rstr"];

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -156,6 +156,31 @@ impl StructFieldRegistry {
             .is_some_and(|rows| matches!(rows, [(name, _)] if name == "__discriminant"))
     }
 
+    /// Whether `owner` itself, or one of its enum variants, declares
+    /// `field_name`.
+    ///
+    /// Rust keeps fields and methods in separate namespaces, while the
+    /// RPython class model used by the annotator has one attribute namespace.
+    /// A method on an enum base therefore also collides with a same-named
+    /// payload field on a variant: seeding that method on the base would make
+    /// the variant constructor inherit a function as the field's default.
+    pub fn owner_or_variant_has_field(&self, owner: &str, field_name: &str) -> bool {
+        if self.field_type(owner, field_name).is_some() {
+            return true;
+        }
+        if !self.is_enum_base(owner) {
+            return false;
+        }
+        let canonical_owner = majit_ir::descr::canonical_struct_name(owner);
+        self.fields.iter().any(|(key, rows)| {
+            let Some((parent, _variant)) = key.rsplit_once("::") else {
+                return false;
+            };
+            majit_ir::descr::canonical_struct_name(parent) == canonical_owner
+                && rows.iter().any(|(field, _)| field == field_name)
+        })
+    }
+
     fn lookup_fields(&self, owner: &str) -> Option<&[(String, String)]> {
         // A per-instantiation enum spelling (`Result<Tuple>`,
         // `Result<Tuple>::Ok`) shares the bare template's rows: the
@@ -1700,5 +1725,21 @@ mod tests {
             !owner_tail.is_some_and(|t| reg.is_enum_base(t)),
             "bare-tail-only probe misses under collision"
         );
+    }
+
+    #[test]
+    fn enum_base_method_collides_with_variant_payload_field() {
+        let mut reg = StructFieldRegistry::default();
+        let base = vec![("__discriminant".to_string(), "i64".to_string())];
+        let variant = vec![("w_obj".to_string(), "PyObjectRef".to_string())];
+        reg.fields.insert("buffer::Buffer".to_string(), base.clone());
+        reg.fields.insert("Buffer".to_string(), base);
+        reg.fields
+            .insert("buffer::Buffer::Array".to_string(), variant.clone());
+        reg.fields.insert("Buffer::Array".to_string(), variant);
+
+        assert!(reg.owner_or_variant_has_field("buffer::Buffer", "w_obj"));
+        assert!(reg.owner_or_variant_has_field("Buffer", "w_obj"));
+        assert!(!reg.owner_or_variant_has_field("buffer::Buffer", "readonly"));
     }
 }

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -1732,7 +1732,8 @@ mod tests {
         let mut reg = StructFieldRegistry::default();
         let base = vec![("__discriminant".to_string(), "i64".to_string())];
         let variant = vec![("w_obj".to_string(), "PyObjectRef".to_string())];
-        reg.fields.insert("buffer::Buffer".to_string(), base.clone());
+        reg.fields
+            .insert("buffer::Buffer".to_string(), base.clone());
         reg.fields.insert("Buffer".to_string(), base);
         reg.fields
             .insert("buffer::Buffer::Array".to_string(), variant.clone());

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -138,7 +138,7 @@ impl StructFieldRegistry {
     }
 
     /// True when `owner` is registered as an enum base class — its sole
-    /// row is the synthetic `__discriminant` tag (`rclass.py:82-88`: the
+    /// row is the synthetic `__discriminant` tag (`rclass.py:499-518`: the
     /// sum-type base carries only the discriminant, each variant subclass
     /// carries its own payload fields under `{enum}::{variant}` keys).  A
     /// struct or non-enum owner has its own field rows and returns false.

--- a/majit/majit-translate/src/front/slice_first.rs
+++ b/majit/majit-translate/src/front/slice_first.rs
@@ -1,4 +1,4 @@
-//! `<[T]>::first(slice)` → length-checked `Option<&T>` diamond.
+//! `<[T]>::first/get(slice, index)` → length-checked `Option` diamond.
 //!
 //! ## Positioning
 //!
@@ -29,21 +29,20 @@
 //!
 //! `first` returns `Option<&T>`, but the `Some` payload is materialised by
 //! `OpKind::ArrayRead` (element 0), which yields the element VALUE, not a
-//! pointer-to-slot.  In the list model a `&T` and a `T` are the same one GC
-//! pointer word, and no consumer derefs a slot-pointer (there is no `copied`
-//! pass that would; the front has no pointer-to-slot op at all).  So the
-//! `&T`-vs-`T` distinction collapses harmlessly, and the value payload is both
-//! the only representable and the correct choice.  The receiver is a
-//! `SomeList`-modelled slice (its `Input` op carries the list-container
-//! `class_root`), so `__len` and the element read repr-dispatch to
+//! pointer-to-slot.  RPython's list model likewise returns the item value from
+//! `getitem`; no surviving consumer dereferences a Rust slot pointer.  This is
+//! true for both GC-reference items and scalar items (`u8`, `i64`, …), and the
+//! site's `payload_ty` keeps their register bank exact.  The receiver is a
+//! `SomeList`-modelled slice, so `__len` and the element read repr-dispatch to
 //! `arraylen_gc` / `getarrayitem` on the underlying length-prefixed GcArray.
 //!
 //! ## The rewrite (`rewire_one_slice_first_site`)
 //!
 //! Block A holds the residual `first` call producing `opt`.  Because
-//! `Option<&PyObjectRef>` triggers `option_residual_narrow_root`, `lower_call`
-//! appends a trailing `__cast_instance_intrinsic` after the call, so the call is NOT
-//! A's last op — the block-A skeleton absorbs that optional cast, exactly as
+//! A reference-payload `Option<&PyObjectRef>` may append a trailing
+//! `__cast_instance_intrinsic` after the call, so the call is not A's last op; a
+//! scalar-payload `Option<u8>` has no such cast.  The block-A skeleton accepts
+//! both shapes and absorbs the optional cast, exactly as
 //! [`crate::front::option_map_or`] does.  The rewrite:
 //! 1. drops the `first` call (+ absorbed cast) and closes A with a
 //!    `bool(len(slice) > 0)` branch to two fresh arms;
@@ -74,6 +73,10 @@ pub(crate) struct SliceFirstSite {
     /// The `first` call result (the `Option<&T>` value) — locates block A.  The
     /// slice operand is read from that located call's `args[0]`.
     pub result_var: Variable,
+    /// The access performed in the successful arm.  `RangeFrom` retains both
+    /// the transparent range shell (for its exclusive-consumer proof/removal)
+    /// and its scalar start bound (for the RPython `getslice(start, None)`).
+    pub access: SliceAccess,
     /// The `Option` enum root `name_path` (per-instantiation, suffixed) — the
     /// ctor owner for the `Some`/`None` aggregates.
     pub option_owner: String,
@@ -83,6 +86,13 @@ pub(crate) struct SliceFirstSite {
     /// The `Option`'s payload `&T` projected to a [`ValueType`] — the
     /// `Some::__pos_0` field kind (`Ref(None)` for `Option<&PyObjectRef>`).
     pub payload_ty: ValueType,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum SliceAccess {
+    First,
+    Index(Variable),
+    RangeFrom { range: Variable, start: Variable },
 }
 
 /// Rewrite every recorded `<[T]>::first` call site into the length-checked
@@ -168,15 +178,32 @@ fn rewire_one_slice_first_site(
         ));
     };
 
-    // Capture the slice receiver operand.
-    let slice = match &graph.blocks[a].operations[ci].kind {
-        OpKind::Call { args, .. } if args.len() == 1 => args[0].clone(),
+    // Capture the slice receiver and validate the recorded access operand.
+    let slice = match (&graph.blocks[a].operations[ci].kind, &site.access) {
+        (OpKind::Call { args, .. }, SliceAccess::First) if args.len() == 1 => args[0].clone(),
+        (OpKind::Call { args, .. }, SliceAccess::Index(recorded))
+            if args.len() == 2 && args[1] == *recorded =>
+        {
+            args[0].clone()
+        }
+        (OpKind::Call { args, .. }, SliceAccess::RangeFrom { range, .. })
+            if args.len() == 2 && args[1] == *range =>
+        {
+            args[0].clone()
+        }
         other => {
             return Err(format!(
-                "{name}: slice::first producer op is not a 1-arg call: {other:?}"
+                "{name}: slice first/get producer does not match its recorded operands: {other:?}"
             ));
         }
     };
+    if let SliceAccess::RangeFrom { range, .. } = &site.access
+        && !crate::front::slice_index::range_feeds_only_index(graph, range, &site.result_var, false)
+    {
+        return Err(format!(
+            "{name}: RangeFrom value has a non-get consumer — declining"
+        ));
+    }
 
     // A's single exit → B (the continuation consuming the Option).  Must be a
     // plain goto — `lower_call` closes with exactly this shape.
@@ -215,35 +242,68 @@ fn rewire_one_slice_first_site(
     if !then_sources.contains(&slice) {
         then_sources.push(slice.clone());
     }
+    let success_operand = match &site.access {
+        SliceAccess::First => None,
+        SliceAccess::Index(index) => Some(index),
+        SliceAccess::RangeFrom { start, .. } => Some(start),
+    };
+    if let Some(operand) = success_operand
+        && !then_sources.contains(operand)
+    {
+        then_sources.push(operand.clone());
+    }
     let (then_bb, then_inputs) = graph.create_block_with_arg_vars(then_sources.len());
     let (else_bb, else_inputs) = graph.create_block_with_arg_vars(carried.len());
 
-    // `then_bb`: elem = slice[0]; opt = Some(elem).
+    // `then_bb`: item = slice[0/i] or slice[start..]; opt = Some(item).
     let slice_in_then = map_source(&then_sources, &then_inputs, &slice)
         .ok_or_else(|| format!("{name}: slice not threaded into Some arm"))?;
-    let idx0 = graph.alloc_value_var();
-    graph.block_mut(then_bb).operations.push(SpaceOperation {
-        result: Some(idx0.clone()),
-        kind: OpKind::ConstInt(0),
-    });
-    let elem = graph.alloc_value_var();
-    graph.block_mut(then_bb).operations.push(SpaceOperation {
-        result: Some(elem.clone()),
-        kind: OpKind::ArrayRead {
-            base: slice_in_then,
-            // The element read and the `Some::__pos_0` field write below
-            // consume the same `elem`, so the read's declared element type
-            // must be the payload type the field carries (`site.payload_ty`,
-            // `Ref(None)` for `Option<&PyObjectRef>`) — a hardcoded `Ref(None)`
-            // would disagree for any instantiation whose payload projects to
-            // another `ValueType`.
-            item_ty: site.payload_ty.clone(),
-            index: idx0,
-            array_type_id: None,
-            nolength: false,
-            pure: false,
-        },
-    });
+    let elem = match &site.access {
+        SliceAccess::First | SliceAccess::Index(_) => {
+            let item_index = if let SliceAccess::Index(index) = &site.access {
+                map_source(&then_sources, &then_inputs, index)
+                    .ok_or_else(|| format!("{name}: slice index not threaded into Some arm"))?
+            } else {
+                let idx0 = graph.alloc_value_var();
+                graph.block_mut(then_bb).operations.push(SpaceOperation {
+                    result: Some(idx0.clone()),
+                    kind: OpKind::ConstInt(0),
+                });
+                idx0
+            };
+            let elem = graph.alloc_value_var();
+            graph.block_mut(then_bb).operations.push(SpaceOperation {
+                result: Some(elem.clone()),
+                kind: OpKind::ArrayRead {
+                    base: slice_in_then,
+                    // The element read and the `Some::__pos_0` field write
+                    // consume the same value, so their register banks match.
+                    item_ty: site.payload_ty.clone(),
+                    index: item_index,
+                    array_type_id: None,
+                    nolength: false,
+                    pure: false,
+                },
+            });
+            elem
+        }
+        SliceAccess::RangeFrom { start, .. } => {
+            let start_in_then = map_source(&then_sources, &then_inputs, start)
+                .ok_or_else(|| format!("{name}: RangeFrom start not threaded into Some arm"))?;
+            let subslice = graph.alloc_value_var();
+            graph.block_mut(then_bb).operations.push(SpaceOperation {
+                result: Some(subslice.clone()),
+                kind: OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec!["__getslice_rangefrom".to_string()],
+                    },
+                    args: vec![slice_in_then, start_in_then],
+                    result_ty: site.payload_ty.clone(),
+                },
+            });
+            subslice
+        }
+    };
     let some_var = emit_option_variant(
         graph,
         then_bb,
@@ -296,21 +356,73 @@ fn rewire_one_slice_first_site(
             result_ty: ValueType::Int,
         },
     });
-    let zero = graph.alloc_value_var();
-    graph.block_mut(a_id).operations.push(SpaceOperation {
-        result: Some(zero.clone()),
-        kind: OpKind::ConstInt(0),
-    });
     let cond = graph.alloc_value_var();
-    graph.block_mut(a_id).operations.push(SpaceOperation {
-        result: Some(cond.clone()),
-        kind: OpKind::BinOp {
-            op: "gt".to_string(),
-            lhs: len,
-            rhs: zero,
-            result_ty: ValueType::Int,
-        },
-    });
+    if let SliceAccess::Index(index) | SliceAccess::RangeFrom { start: index, .. } = &site.access {
+        // Rust's scalar slice index is `usize`.  Compare it with an unsigned
+        // view of the RPython list length, then let `rtype_getitem` perform
+        // its ordinary index conversion for the guarded element read.
+        let len_u = graph.alloc_value_var();
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(len_u.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec![
+                        "rpython".to_string(),
+                        "rlib".to_string(),
+                        "rarithmetic".to_string(),
+                        "r_uint".to_string(),
+                    ],
+                },
+                args: vec![len],
+                result_ty: ValueType::Unsigned,
+            },
+        });
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(cond.clone()),
+            kind: OpKind::BinOp {
+                op: if matches!(&site.access, SliceAccess::RangeFrom { .. }) {
+                    "le".to_string()
+                } else {
+                    "lt".to_string()
+                },
+                lhs: index.clone(),
+                rhs: len_u,
+                result_ty: ValueType::Int,
+            },
+        });
+    } else {
+        let zero = graph.alloc_value_var();
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(zero.clone()),
+            kind: OpKind::ConstInt(0),
+        });
+        graph.block_mut(a_id).operations.push(SpaceOperation {
+            result: Some(cond.clone()),
+            kind: OpKind::BinOp {
+                op: "gt".to_string(),
+                lhs: len,
+                rhs: zero,
+                result_ty: ValueType::Int,
+            },
+        });
+    }
+    if let SliceAccess::RangeFrom { range, .. } = &site.access {
+        for block in &mut graph.blocks {
+            block.operations.retain(|op| {
+                let is_field_write =
+                    matches!(&op.kind, OpKind::FieldWrite { base, .. } if base == range);
+                let is_ctor = op.result.as_ref() == Some(range)
+                    && matches!(
+                        &op.kind,
+                        OpKind::Call {
+                            target: CallTarget::SyntheticTransparentCtor { .. },
+                            ..
+                        }
+                    );
+                !(is_field_write || is_ctor)
+            });
+        }
+    }
     graph.set_branch(a_id, cond, then_bb, then_sources, else_bb, carried);
     Ok(())
 }
@@ -323,6 +435,7 @@ mod tests {
     fn slice_first_site(result_var: Variable) -> SliceFirstSite {
         SliceFirstSite {
             result_var,
+            access: SliceAccess::First,
             option_owner: "core::option::Option".into(),
             some_owner: "core::option::Option::Some".into(),
             payload_ty: ValueType::Ref(None),
@@ -410,6 +523,80 @@ mod tests {
             })
             .count();
         assert_eq!(disc_writes, 2, "both arms write a discriminant");
+    }
+
+    /// A scalar slice item uses the integer register bank throughout the
+    /// guarded diamond.  This is the ordinary RPython `getitem` result shape,
+    /// not a pointer-to-slot and not a classed-instance-only special case.
+    #[test]
+    fn rewrite_lifts_scalar_get_with_unsigned_payload() {
+        let mut g = FunctionGraph::new("test_slice_get_u8");
+        let a = g.startblock;
+        let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let index = g.push_op_var(a, OpKind::ConstInt(2), true).unwrap();
+        let opt = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec![
+                            "core".into(),
+                            "slice".into(),
+                            "<Impl>".into(),
+                            "get".into(),
+                        ],
+                    },
+                    args: vec![slice, index.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![opt.clone()]);
+
+        let mut site = slice_first_site(opt);
+        site.access = SliceAccess::Index(index);
+        site.payload_ty = ValueType::Unsigned;
+        assert_eq!(rewire_slice_first_call_sites(&mut g, &[site]), 1);
+        assert!(
+            !g.blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.last().map(String::as_str) == Some("get")
+                ))
+        );
+        assert!(
+            g.blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| matches!(
+                    &op.kind,
+                    OpKind::ArrayRead {
+                        item_ty: ValueType::Unsigned,
+                        ..
+                    }
+                ))
+        );
+        assert!(
+            g.blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| matches!(
+                    &op.kind,
+                    OpKind::FieldWrite {
+                        field,
+                        ty: ValueType::Unsigned,
+                        ..
+                    } if field.name == "__pos_0"
+                ))
+        );
     }
 
     /// The production shape: an `Option<&RegisteredStruct>` result appends a

--- a/majit/majit-translate/src/front/slice_first.rs
+++ b/majit/majit-translate/src/front/slice_first.rs
@@ -1,4 +1,4 @@
-//! `<[T]>::first/get(slice, index)` → length-checked `Option` diamond.
+//! `<[T]>::first(slice)` and checked `get(start..)` → `Option` diamonds.
 //!
 //! ## Positioning
 //!
@@ -24,6 +24,12 @@
 //! the call's own block before the consumer's discriminant switch) cannot
 //! express `first`; a post-pass that splits block A into a guarded Some/None
 //! diamond can.
+//!
+//! The same control-flow skeleton handles the RangeFrom `get(start..)` form
+//! retained by the #346 slice-range port: its successful arm emits the
+//! ordinary RPython `getslice(start, None)` marker and its guard is
+//! `start <= len(slice)`.  Scalar `get(i)` belongs to the dedicated
+//! [`crate::front::slice_get`] pass from origin/main.
 //!
 //! ## Payload representation
 //!
@@ -91,7 +97,6 @@ pub(crate) struct SliceFirstSite {
 #[derive(Clone, Debug)]
 pub(crate) enum SliceAccess {
     First,
-    Index(Variable),
     RangeFrom { range: Variable, start: Variable },
 }
 
@@ -181,11 +186,6 @@ fn rewire_one_slice_first_site(
     // Capture the slice receiver and validate the recorded access operand.
     let slice = match (&graph.blocks[a].operations[ci].kind, &site.access) {
         (OpKind::Call { args, .. }, SliceAccess::First) if args.len() == 1 => args[0].clone(),
-        (OpKind::Call { args, .. }, SliceAccess::Index(recorded))
-            if args.len() == 2 && args[1] == *recorded =>
-        {
-            args[0].clone()
-        }
         (OpKind::Call { args, .. }, SliceAccess::RangeFrom { range, .. })
             if args.len() == 2 && args[1] == *range =>
         {
@@ -244,7 +244,6 @@ fn rewire_one_slice_first_site(
     }
     let success_operand = match &site.access {
         SliceAccess::First => None,
-        SliceAccess::Index(index) => Some(index),
         SliceAccess::RangeFrom { start, .. } => Some(start),
     };
     if let Some(operand) = success_operand
@@ -255,22 +254,16 @@ fn rewire_one_slice_first_site(
     let (then_bb, then_inputs) = graph.create_block_with_arg_vars(then_sources.len());
     let (else_bb, else_inputs) = graph.create_block_with_arg_vars(carried.len());
 
-    // `then_bb`: item = slice[0/i] or slice[start..]; opt = Some(item).
+    // `then_bb`: item = slice[0] or slice[start..]; opt = Some(item).
     let slice_in_then = map_source(&then_sources, &then_inputs, &slice)
         .ok_or_else(|| format!("{name}: slice not threaded into Some arm"))?;
     let elem = match &site.access {
-        SliceAccess::First | SliceAccess::Index(_) => {
-            let item_index = if let SliceAccess::Index(index) = &site.access {
-                map_source(&then_sources, &then_inputs, index)
-                    .ok_or_else(|| format!("{name}: slice index not threaded into Some arm"))?
-            } else {
-                let idx0 = graph.alloc_value_var();
-                graph.block_mut(then_bb).operations.push(SpaceOperation {
-                    result: Some(idx0.clone()),
-                    kind: OpKind::ConstInt(0),
-                });
-                idx0
-            };
+        SliceAccess::First => {
+            let item_index = graph.alloc_value_var();
+            graph.block_mut(then_bb).operations.push(SpaceOperation {
+                result: Some(item_index.clone()),
+                kind: OpKind::ConstInt(0),
+            });
             let elem = graph.alloc_value_var();
             graph.block_mut(then_bb).operations.push(SpaceOperation {
                 result: Some(elem.clone()),
@@ -357,10 +350,9 @@ fn rewire_one_slice_first_site(
         },
     });
     let cond = graph.alloc_value_var();
-    if let SliceAccess::Index(index) | SliceAccess::RangeFrom { start: index, .. } = &site.access {
-        // Rust's scalar slice index is `usize`.  Compare it with an unsigned
-        // view of the RPython list length, then let `rtype_getitem` perform
-        // its ordinary index conversion for the guarded element read.
+    if let SliceAccess::RangeFrom { start: index, .. } = &site.access {
+        // A RangeFrom start is `usize`.  Compare it with an unsigned view of
+        // the RPython list length; `start == len` is the valid empty suffix.
         let len_u = graph.alloc_value_var();
         graph.block_mut(a_id).operations.push(SpaceOperation {
             result: Some(len_u.clone()),
@@ -380,11 +372,7 @@ fn rewire_one_slice_first_site(
         graph.block_mut(a_id).operations.push(SpaceOperation {
             result: Some(cond.clone()),
             kind: OpKind::BinOp {
-                op: if matches!(&site.access, SliceAccess::RangeFrom { .. }) {
-                    "le".to_string()
-                } else {
-                    "lt".to_string()
-                },
+                op: "le".to_string(),
                 lhs: index.clone(),
                 rhs: len_u,
                 result_ty: ValueType::Int,
@@ -523,80 +511,6 @@ mod tests {
             })
             .count();
         assert_eq!(disc_writes, 2, "both arms write a discriminant");
-    }
-
-    /// A scalar slice item uses the integer register bank throughout the
-    /// guarded diamond.  This is the ordinary RPython `getitem` result shape,
-    /// not a pointer-to-slot and not a classed-instance-only special case.
-    #[test]
-    fn rewrite_lifts_scalar_get_with_unsigned_payload() {
-        let mut g = FunctionGraph::new("test_slice_get_u8");
-        let a = g.startblock;
-        let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
-        let index = g.push_op_var(a, OpKind::ConstInt(2), true).unwrap();
-        let opt = g
-            .push_op_var(
-                a,
-                OpKind::Call {
-                    target: CallTarget::FunctionPath {
-                        segments: vec![
-                            "core".into(),
-                            "slice".into(),
-                            "<Impl>".into(),
-                            "get".into(),
-                        ],
-                    },
-                    args: vec![slice, index.clone()],
-                    result_ty: ValueType::Ref(None),
-                },
-                true,
-            )
-            .unwrap();
-        let (b, _) = g.create_block_with_arg_vars(1);
-        g.set_return(b, None);
-        g.set_goto(a, b, vec![opt.clone()]);
-
-        let mut site = slice_first_site(opt);
-        site.access = SliceAccess::Index(index);
-        site.payload_ty = ValueType::Unsigned;
-        assert_eq!(rewire_slice_first_call_sites(&mut g, &[site]), 1);
-        assert!(
-            !g.blocks
-                .iter()
-                .flat_map(|block| &block.operations)
-                .any(|op| matches!(
-                    &op.kind,
-                    OpKind::Call {
-                        target: CallTarget::FunctionPath { segments },
-                        ..
-                    } if segments.last().map(String::as_str) == Some("get")
-                ))
-        );
-        assert!(
-            g.blocks
-                .iter()
-                .flat_map(|block| &block.operations)
-                .any(|op| matches!(
-                    &op.kind,
-                    OpKind::ArrayRead {
-                        item_ty: ValueType::Unsigned,
-                        ..
-                    }
-                ))
-        );
-        assert!(
-            g.blocks
-                .iter()
-                .flat_map(|block| &block.operations)
-                .any(|op| matches!(
-                    &op.kind,
-                    OpKind::FieldWrite {
-                        field,
-                        ty: ValueType::Unsigned,
-                        ..
-                    } if field.name == "__pos_0"
-                ))
-        );
     }
 
     /// The production shape: an `Option<&RegisteredStruct>` result appends a

--- a/majit/majit-translate/src/front/slice_first.rs
+++ b/majit/majit-translate/src/front/slice_first.rs
@@ -52,9 +52,11 @@
 //! [`crate::front::option_map_or`] does.  The rewrite:
 //! 1. drops the `first` call (+ absorbed cast) and closes A with a
 //!    `bool(len(slice) > 0)` branch to two fresh arms;
-//! 2. the `then_bb` arm reads `slice[0]` and wraps it in `Some`
-//!    (`__discriminant = 1` / `__pos_0 = elem`);
-//! 3. the `else_bb` arm builds `None` (`__discriminant = 0`);
+//! 2. the `then_bb` arm reads `slice[0]` and wraps it in `Some`; a one-word
+//!    reference niche forwards the typed payload directly, while value
+//!    payloads build `__discriminant = 1` / `__pos_0 = elem`;
+//! 3. the `else_bb` arm emits a typed null for that niche, or an aggregate
+//!    `None` (`__discriminant = 0`) for value payloads;
 //! 4. both arms re-apply the absorbed narrowing and forward to B, reproducing
 //!    A's original exit args with the `opt` slot sourced from the arm's
 //!    `Some`/`None` value and every other live value threaded through.
@@ -92,6 +94,13 @@ pub(crate) struct SliceFirstSite {
     /// The `Option`'s payload `&T` projected to a [`ValueType`] — the
     /// `Some::__pos_0` field kind (`Ref(None)` for `Option<&PyObjectRef>`).
     pub payload_ty: ValueType,
+    /// True when the result is the one-word nullable-reference Option niche.
+    /// RPython represents that as the payload instance with
+    /// `can_be_None=True`, without an Option aggregate.
+    pub niche: bool,
+    /// Concrete payload class retained on both the successful pointer and
+    /// the null arm of a niche result.
+    pub payload_narrow_root: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -297,14 +306,18 @@ fn rewire_one_slice_first_site(
             subslice
         }
     };
-    let some_var = emit_option_variant(
-        graph,
-        then_bb,
-        &site.option_owner,
-        1,
-        Some((&site.some_owner, elem, site.payload_ty.clone())),
-    );
-    let then_result = emit_narrow(graph, then_bb, some_var, &narrow_root);
+    let then_result = if site.niche {
+        emit_narrow(graph, then_bb, elem, &site.payload_narrow_root)
+    } else {
+        let some_var = emit_option_variant(
+            graph,
+            then_bb,
+            &site.option_owner,
+            1,
+            Some((&site.some_owner, elem, site.payload_ty.clone())),
+        );
+        emit_narrow(graph, then_bb, some_var, &narrow_root)
+    };
     let then_link_args = reproduce_exit_args(
         &saved_exit,
         &flow_result,
@@ -316,8 +329,13 @@ fn rewire_one_slice_first_site(
     close_goto_mixed(graph, then_bb, b_target, then_link_args);
 
     // `else_bb`: opt = None.
-    let none_var = emit_option_variant(graph, else_bb, &site.option_owner, 0, None);
-    let else_result = emit_narrow(graph, else_bb, none_var, &narrow_root);
+    let else_result = if site.niche {
+        let null = graph.push_null_mut_ptr(else_bb);
+        emit_narrow(graph, else_bb, null, &site.payload_narrow_root)
+    } else {
+        let none_var = emit_option_variant(graph, else_bb, &site.option_owner, 0, None);
+        emit_narrow(graph, else_bb, none_var, &narrow_root)
+    };
     let else_link_args = reproduce_exit_args(
         &saved_exit,
         &flow_result,
@@ -427,6 +445,8 @@ mod tests {
             option_owner: "core::option::Option".into(),
             some_owner: "core::option::Option::Some".into(),
             payload_ty: ValueType::Ref(None),
+            niche: false,
+            payload_narrow_root: None,
         }
     }
 

--- a/majit/majit-translate/src/front/slice_get.rs
+++ b/majit/majit-translate/src/front/slice_get.rs
@@ -37,19 +37,21 @@
 //! instantiation has the shape this diamond encodes.  `get(0..2)` returns
 //! `Option<&[T]>` — a sub-slice, not an element — and an `ArrayRead` at the
 //! range's start would hand the consumer a `T` where a `[T]` is expected.
-//! `front::mir` `recognize_slice_get_site` therefore pins the instantiation by
-//! the index operand's declared `usize` before a site is recorded at all, so
-//! every range form falls through and keeps its residual call.
+//! `front::mir` therefore pins the instantiation through
+//! `is_slice_get_scalar_call`: a local index uses the operand's declared
+//! `usize`, while a literal uses the method's `I` generic.  Every range form
+//! falls through to the range lowering instead of being mistaken for an item
+//! read.
 //!
 //! ## Payload representation
 //!
 //! `get` returns `Option<&T>`, but the `Some` payload is materialised by
 //! `OpKind::ArrayRead`, which yields the element VALUE, not a pointer-to-slot.
-//! In the list model a `&T` and a `T` are the same one GC pointer word, and no
-//! consumer derefs a slot-pointer (there is no `copied` pass that would; the
-//! front has no pointer-to-slot op at all).  So the `&T`-vs-`T` distinction
-//! collapses harmlessly, and the value payload is both the only representable
-//! and the correct choice.  The receiver is a `SomeList`-modelled slice (its
+//! In the list model a `&T` and a `T` use the same item register — a GC pointer
+//! for object items and the scalar bank for `u8`/`i64` items — and no consumer
+//! derefs a slot-pointer.  The site's payload type therefore comes from the
+//! destination `Option` consumer shape rather than being hard-coded to a
+//! reference.  The receiver is a `SomeList`-modelled slice (its
 //! `Input` op carries the list-container `class_root`), so `__len` and the
 //! element read repr-dispatch to `arraylen_gc` / `getarrayitem` on the
 //! underlying length-prefixed GcArray.
@@ -97,9 +99,14 @@ pub(crate) struct SliceGetSite {
     /// The `Option::Some` variant `name_path` — the `__pos_0` payload field
     /// owner (matching the variant-qualified `resolve_adt_field` read owner).
     pub some_owner: String,
-    /// The `Option`'s payload `&T` projected to a [`ValueType`] — the
-    /// `Some::__pos_0` field kind (`Ref(None)` for `Option<&PyObjectRef>`).
+    /// The slice element `T` projected to a [`ValueType`] — the devirtualized
+    /// `ArrayRead` and `Some::__pos_0` field kind. Rust spells the source
+    /// result `Option<&T>`, but RPython's getarrayitem yields the value `T`.
     pub payload_ty: ValueType,
+    /// Concrete ARRAY identity carrying the scalar/RPython item spelling to
+    /// the descr, or `None` only for a proven thin-pointer element whose
+    /// identity-less descr already has the correct one-word stride.
+    pub array_type_id: Option<String>,
 }
 
 /// Rewrite every recorded `<[T]>::get` call site into the bounds-checked
@@ -246,13 +253,12 @@ fn rewire_one_slice_get_site(graph: &mut FunctionGraph, site: &SliceGetSite) -> 
             base: slice_in_then,
             // The element read and the `Some::__pos_0` field write below
             // consume the same `elem`, so the read's declared element type
-            // must be the payload type the field carries (`site.payload_ty`,
-            // `Ref(None)` for `Option<&PyObjectRef>`) — a hardcoded `Ref(None)`
-            // would disagree for any instantiation whose payload projects to
-            // another `ValueType`.
+            // must be the value type the devirtualized `T` carries
+            // (`site.payload_ty`, `Ref(None)` for a GC-pointer element) — a
+            // hardcoded `Ref(None)` would disagree for scalar elements.
             item_ty: site.payload_ty.clone(),
             index: index_in_then,
-            array_type_id: None,
+            array_type_id: site.array_type_id.clone(),
             nolength: false,
             pure: false,
         },
@@ -337,6 +343,7 @@ mod tests {
             option_owner: "core::option::Option".into(),
             some_owner: "core::option::Option::Some".into(),
             payload_ty: ValueType::Ref(None),
+            array_type_id: None,
         }
     }
 
@@ -436,6 +443,50 @@ mod tests {
             })
             .count();
         assert_eq!(disc_writes, 2, "both arms write a discriminant");
+    }
+
+    /// A scalar slice item uses the integer register bank throughout the
+    /// guarded diamond.  This is the ordinary RPython `getitem` result shape,
+    /// not a pointer-to-slot or an object-pointer-only special case.
+    #[test]
+    fn rewrite_preserves_unsigned_item_payload() {
+        let mut g = FunctionGraph::new("test_slice_get_u8");
+        let a = g.startblock;
+        let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let index = g.push_op_var(a, OpKind::ConstInt(2), true).unwrap();
+        let opt = emit_call(&mut g, a, vec![slice, index]);
+        let (b, _) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![opt.clone()]);
+
+        let mut site = slice_get_site(opt);
+        site.payload_ty = ValueType::Unsigned;
+        assert_eq!(rewire_slice_get_call_sites(&mut g, &[site]), 1);
+        assert!(
+            g.blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| matches!(
+                    &op.kind,
+                    OpKind::ArrayRead {
+                        item_ty: ValueType::Unsigned,
+                        ..
+                    }
+                ))
+        );
+        assert!(
+            g.blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| matches!(
+                    &op.kind,
+                    OpKind::FieldWrite {
+                        field,
+                        ty: ValueType::Unsigned,
+                        ..
+                    } if field.name == "__pos_0"
+                ))
+        );
     }
 
     /// The production shape: an `Option<&RegisteredStruct>` result appends a

--- a/majit/majit-translate/src/front/slice_get.rs
+++ b/majit/majit-translate/src/front/slice_get.rs
@@ -65,9 +65,11 @@
 //! [`crate::front::option_map_or`] does.  The rewrite:
 //! 1. drops the `get` call (+ absorbed cast) and closes A with a
 //!    `bool(i < len(slice))` branch to two fresh arms;
-//! 2. the `then_bb` arm reads `slice[i]` and wraps it in `Some`
-//!    (`__discriminant = 1` / `__pos_0 = elem`);
-//! 3. the `else_bb` arm builds `None` (`__discriminant = 0`);
+//! 2. the `then_bb` arm reads `slice[i]` and wraps it in `Some`; a one-word
+//!    reference niche forwards the typed payload directly, while value
+//!    payloads build `__discriminant = 1` / `__pos_0 = elem`;
+//! 3. the `else_bb` arm emits a typed null for that niche, or an aggregate
+//!    `None` (`__discriminant = 0`) for value payloads;
 //! 4. both arms re-apply the absorbed narrowing and forward to B, reproducing
 //!    A's original exit args with the `opt` slot sourced from the arm's
 //!    `Some`/`None` value and every other live value threaded through.
@@ -107,6 +109,14 @@ pub(crate) struct SliceGetSite {
     /// the descr, or `None` only for a proven thin-pointer element whose
     /// identity-less descr already has the correct one-word stride.
     pub array_type_id: Option<String>,
+    /// True when `Option<&T>` is Rust's one-word nullable-reference niche.
+    /// RPython carries this as the payload annotation with `can_be_None=True`,
+    /// not as an Option object with discriminant and payload fields.
+    pub niche: bool,
+    /// Concrete payload class for a niche reference.  In particular,
+    /// `<[*mut PyObject]>::get` returns `Option<&PyObjectRef>`: the successful
+    /// list item and the null arm must both retain the `PyObject` ClassDef.
+    pub payload_narrow_root: Option<String>,
 }
 
 /// Rewrite every recorded `<[T]>::get` call site into the bounds-checked
@@ -263,14 +273,18 @@ fn rewire_one_slice_get_site(graph: &mut FunctionGraph, site: &SliceGetSite) -> 
             pure: false,
         },
     });
-    let some_var = emit_option_variant(
-        graph,
-        then_bb,
-        &site.option_owner,
-        1,
-        Some((&site.some_owner, elem, site.payload_ty.clone())),
-    );
-    let then_result = emit_narrow(graph, then_bb, some_var, &narrow_root);
+    let then_result = if site.niche {
+        emit_narrow(graph, then_bb, elem, &site.payload_narrow_root)
+    } else {
+        let some_var = emit_option_variant(
+            graph,
+            then_bb,
+            &site.option_owner,
+            1,
+            Some((&site.some_owner, elem, site.payload_ty.clone())),
+        );
+        emit_narrow(graph, then_bb, some_var, &narrow_root)
+    };
     let then_link_args = reproduce_exit_args(
         &saved_exit,
         &flow_result,
@@ -282,8 +296,13 @@ fn rewire_one_slice_get_site(graph: &mut FunctionGraph, site: &SliceGetSite) -> 
     close_goto_mixed(graph, then_bb, b_target, then_link_args);
 
     // `else_bb`: opt = None.
-    let none_var = emit_option_variant(graph, else_bb, &site.option_owner, 0, None);
-    let else_result = emit_narrow(graph, else_bb, none_var, &narrow_root);
+    let else_result = if site.niche {
+        let null = graph.push_null_mut_ptr(else_bb);
+        emit_narrow(graph, else_bb, null, &site.payload_narrow_root)
+    } else {
+        let none_var = emit_option_variant(graph, else_bb, &site.option_owner, 0, None);
+        emit_narrow(graph, else_bb, none_var, &narrow_root)
+    };
     let else_link_args = reproduce_exit_args(
         &saved_exit,
         &flow_result,
@@ -344,6 +363,8 @@ mod tests {
             some_owner: "core::option::Option::Some".into(),
             payload_ty: ValueType::Ref(None),
             array_type_id: None,
+            niche: false,
+            payload_narrow_root: None,
         }
     }
 
@@ -443,6 +464,71 @@ mod tests {
             })
             .count();
         assert_eq!(disc_writes, 2, "both arms write a discriminant");
+    }
+
+    /// `slice: &[*mut PyObject]` makes `get` return
+    /// `Option<&PyObjectRef>`, a nullable shared reference.  Its RPython shape
+    /// is one maybe-null `SomeInstance(PyObject)`, so neither arm may mint the
+    /// Rust Option aggregate used by scalar/value payloads.
+    #[test]
+    fn rewrite_niche_get_forwards_typed_payload_or_null() {
+        let mut g = FunctionGraph::new("test_slice_get_niche");
+        let a = g.startblock;
+        let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let index = g.push_op_var(a, OpKind::ConstInt(3), true).unwrap();
+        let opt = emit_call(&mut g, a, vec![slice, index]);
+        let narrowed = emit_narrow(&mut g, a, opt.clone(), &Some("PyObject".into()));
+        let (b, _) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![narrowed]);
+
+        let mut site = slice_get_site(opt);
+        site.niche = true;
+        site.payload_narrow_root = Some("PyObject".into());
+        assert_eq!(rewire_slice_get_call_sites(&mut g, &[site]), 1);
+
+        assert!(
+            !g.blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| {
+                    matches!(
+                        &op.kind,
+                        OpKind::FieldWrite { field, .. }
+                            if field.name == "__discriminant" || field.name == "__pos_0"
+                    )
+                }),
+            "a niche Option has no aggregate fields"
+        );
+        assert!(
+            g.blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| {
+                    matches!(
+                        &op.kind,
+                        OpKind::Call {
+                            target: CallTarget::FunctionPath { segments },
+                            ..
+                        } if segments == &["core", "ptr", "null_mut"]
+                    )
+                })
+        );
+        let payload_narrows = g
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments == &[crate::runtime_names::shims::CAST_INSTANCE, "PyObject"]
+                )
+            })
+            .count();
+        assert_eq!(payload_narrows, 2, "payload and null keep one ClassDef");
     }
 
     /// A scalar slice item uses the integer register bank throughout the

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -1,18 +1,22 @@
 //! `&s[k..]` / `&s[..k]` sub-slice indexes → orthodox `getslice` copies.
 //!
 //! These recognizers are CAPSTONES, not independently wired primitives.
-//! RangeFrom is carried as a synthetic marker until the flowspace adapter,
-//! where it expands to `getslice(slice, start, None)` after annotation. This
-//! keeps the Void `None` bound out of any graph that drops to the legacy
-//! walker, matching the existing Range/RangeTo marker split.
+//! Range/RangeFrom are carried as synthetic markers until the flowspace
+//! adapter, where they expand to ordinary `getslice` operations. This keeps
+//! the slice operation out of any graph that drops to the legacy walker,
+//! matching the existing RangeTo marker split.
 //!
 //! The `ll_listslice_startstop` clamp (`rpython/rtyper/rlist.py`)
 //! repairs the oversized result of an unsigned `len - 1` wrap. The MinusOne
 //! shape is admitted because `len - 1 <= len` is proven for this receiver;
-//! a general RangeTo stop has no `end <= len` proof and is declined. The
-//! frontend also strips Rust's own range checks: `TermKind::Assert` branches
-//! unconditionally to success, citing `backendopt/removeassert.py`, because
-//! those checks have no Python-observable meaning.
+//! a general RangeTo stop has no `end <= len` proof and is declined. A full
+//! `Range { start, end }`, however, is the direct Rust spelling used by the
+//! interpreter where PyPy writes `buffer[start:end]` (`RStringIO.read`,
+//! `W_BufferedWriter._write_buf` and siblings). RPython emits `getslice`
+//! without a translator-side dominator proof. The frontend likewise strips
+//! Rust's implicit range assertions as `TermKind::Assert`, following
+//! `backendopt/removeassert.py`; retaining an extra proof only for the opaque
+//! `Index::index` shim would be a non-upstream control-flow restriction.
 //!
 //! The earlier failure was an unwired frontend `getslice` planted before a
 //! graph fell through the legacy walker. Every admitted path now uses an
@@ -97,9 +101,9 @@ pub(crate) struct SliceIndexRangeToSite {
 }
 
 /// A recognized `Range { start, end }` aggregate feeding a residual scalar
-/// slice-index call.  This is RPython's ordinary `getslice(start, stop)`
-/// shape; bounds are retained separately so the transparent Rust range shell
-/// can be removed after the consumer proof succeeds.
+/// slice-index call. This is RPython's ordinary `getslice(start, stop)` shape;
+/// bounds are retained separately so the transparent Rust range shell can be
+/// removed after the exact-consumer proof succeeds.
 #[derive(Clone)]
 pub(crate) struct SliceIndexRangeSite {
     pub range_result: Variable,
@@ -301,16 +305,6 @@ fn rewire_one_slice_index_site(
         SliceIndexBounds::Range { start, end } => {
             if !graph_defines(graph, start) || !graph_defines(graph, end) {
                 return Err(format!("{name}: Range bounds are not defined in the graph"));
-            }
-            if !range_end_matches_slice_len(graph, end, &slice) {
-                return Err(format!(
-                    "{name}: Range end is not the indexed slice length — declining"
-                ));
-            }
-            if !range_start_is_bounded_by_end(graph, start, end, &range) {
-                return Err(format!(
-                    "{name}: Range start <= end is not proven at the index — declining"
-                ));
             }
         }
         SliceIndexBounds::MinusOne { end } => {
@@ -990,169 +984,12 @@ fn minus_one_end_matches(graph: &FunctionGraph, end: &Variable, slice: &Variable
             && matches!(&op.kind, OpKind::ArrayLen { base, .. }
                 if resolve_block_alias(graph, base).as_ref() == Some(&slice))
     });
-    let has_one = graph
-        .blocks
-        .iter()
-        .flat_map(|b| &b.operations)
-        .any(|op| op.result.as_ref() == Some(&rhs) && matches!(&op.kind, OpKind::ConstInt(1)));
+    // The subtraction is unsigned, so Charon's faithful literal spelling is
+    // `ConstUInt(1)`.  `const_int_value` accepts both integer banks only for
+    // this compile-time equality proof; it does not change the SSA value's
+    // unsigned annotation used by the guard and slice lowering.
+    let has_one = const_int_value(graph, &rhs) == Some(1);
     has_len && has_one
-}
-
-/// Prove that the Range stop is exactly `len(slice)`.  Rust's slice index
-/// would reject an oversized stop while RPython's list-slice helper clamps,
-/// so the rewrite is admitted only when both expressions denote the same
-/// length read (following block aliases).
-fn range_end_matches_slice_len(graph: &FunctionGraph, end: &Variable, slice: &Variable) -> bool {
-    let Some(end) = resolve_block_alias(graph, end) else {
-        return false;
-    };
-    let Some(slice) = resolve_block_alias(graph, slice) else {
-        return false;
-    };
-    graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
-        op.result.as_ref() == Some(&end)
-            && matches!(
-                &op.kind,
-                OpKind::ArrayLen { base, .. }
-                    if resolve_block_alias(graph, base).as_ref() == Some(&slice)
-            )
-    })
-}
-
-/// Prove `start <= end` on the control-flow edge reaching this Range index.
-/// A zero start is immediate because the Range element type is `usize`;
-/// otherwise require a dominating comparison edge.  This preserves Rust's
-/// bounds semantics while lowering the already-proven slice to RPython's
-/// `getslice` operation.
-fn range_start_is_bounded_by_end(
-    graph: &FunctionGraph,
-    start: &Variable,
-    end: &Variable,
-    range: &Variable,
-) -> bool {
-    if const_int_value(graph, start) == Some(0) {
-        return true;
-    }
-    let Some(start_root) = resolve_block_alias(graph, start) else {
-        return false;
-    };
-    let Some(end_root) = resolve_block_alias(graph, end) else {
-        return false;
-    };
-    let Some(index_block) = graph.blocks.iter().find_map(|b| {
-        b.operations.iter().find_map(|op| {
-            (is_slice_range_index_call(&op.kind)
-                && matches!(&op.kind, OpKind::Call { args, .. } if args.get(1) == Some(range)))
-            .then_some(b.id)
-        })
-    }) else {
-        return false;
-    };
-
-    let mut dominators: std::collections::HashMap<
-        crate::model::BlockId,
-        std::collections::HashSet<crate::model::BlockId>,
-    > = graph
-        .blocks
-        .iter()
-        .map(|b| (b.id, graph.blocks.iter().map(|x| x.id).collect()))
-        .collect();
-    dominators.insert(graph.startblock, [graph.startblock].into_iter().collect());
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for block in &graph.blocks {
-            if block.id == graph.startblock {
-                continue;
-            }
-            let preds = graph.predecessors(block.id);
-            if preds.is_empty() {
-                continue;
-            }
-            let mut next: std::collections::HashSet<_> = dominators[&preds[0]].clone();
-            for pred in &preds[1..] {
-                next.retain(|id| dominators[pred].contains(id));
-            }
-            next.insert(block.id);
-            if next != dominators[&block.id] {
-                dominators.insert(block.id, next);
-                changed = true;
-            }
-        }
-    }
-
-    for candidate in &graph.blocks {
-        if candidate.id == index_block || !dominators[&index_block].contains(&candidate.id) {
-            continue;
-        }
-        let Some(crate::model::ExitSwitch::Value(switch)) = &candidate.exitswitch else {
-            continue;
-        };
-        let Some((op, lhs, rhs)) = comparison_variables_for_switch(graph, switch) else {
-            continue;
-        };
-        let Some(lhs) = resolve_block_alias(graph, &lhs) else {
-            continue;
-        };
-        let Some(rhs) = resolve_block_alias(graph, &rhs) else {
-            continue;
-        };
-        let success = match (lhs == start_root, rhs == end_root, op.as_str()) {
-            (true, true, "le" | "lt") => Some(true),
-            (true, true, "gt" | "ge") => Some(false),
-            _ if lhs == end_root && rhs == start_root => match op.as_str() {
-                "ge" | "gt" => Some(true),
-                "lt" | "le" => Some(false),
-                _ => None,
-            },
-            _ => None,
-        };
-        let Some(success) = success else { continue };
-        let mut true_target = None;
-        let mut false_target = None;
-        for link in &candidate.exits {
-            match link.exitcase {
-                Some(crate::model::ExitCase::Bool(true)) => true_target = Some(link.target),
-                Some(crate::model::ExitCase::Bool(false)) => false_target = Some(link.target),
-                _ => {}
-            }
-        }
-        let (Some(true_target), Some(false_target)) = (true_target, false_target) else {
-            continue;
-        };
-        let proving = if success { true_target } else { false_target };
-        let rejecting = if success { false_target } else { true_target };
-        if reaches_without_retesting(graph, proving, index_block, candidate.id)
-            && !reaches_without_retesting(graph, rejecting, index_block, candidate.id)
-        {
-            return true;
-        }
-    }
-    false
-}
-
-fn comparison_variables_for_switch(
-    graph: &FunctionGraph,
-    switch: &Variable,
-) -> Option<(String, Variable, Variable)> {
-    let switch = resolve_block_alias(graph, switch)?;
-    let (op, lhs, rhs) = graph
-        .blocks
-        .iter()
-        .flat_map(|b| &b.operations)
-        .find_map(|candidate| {
-            if candidate.result.as_ref() != Some(&switch) {
-                return None;
-            }
-            match &candidate.kind {
-                OpKind::BinOp { op, lhs, rhs, .. } => Some((op.clone(), lhs.clone(), rhs.clone())),
-                OpKind::UnaryOp { op, operand, .. } if op == "bool" => {
-                    comparison_variables_for_switch(graph, operand)
-                }
-                _ => None,
-            }
-        })?;
-    Some((op, lhs, rhs))
 }
 
 /// `true` when `kind` is a residual `core::slice::index::<Impl>::index` call —
@@ -2650,7 +2487,7 @@ mod tests {
                 true,
             )
             .unwrap();
-        let one = g.push_op_var(b, OpKind::ConstInt(1), true).unwrap();
+        let one = g.push_op_var(b, OpKind::ConstUInt(1), true).unwrap();
         let end = g
             .push_op_var(
                 b,

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -536,6 +536,7 @@ fn const_int_value(graph: &FunctionGraph, var: &Variable) -> Option<i64> {
         .find_map(|op| {
             (op.result.as_ref() == Some(&var)).then_some(match op.kind {
                 OpKind::ConstInt(value) => Some(value),
+                OpKind::ConstUInt(value) => i64::try_from(value).ok(),
                 _ => None,
             })?
         })
@@ -803,6 +804,7 @@ fn array_len_base_is_stable(
         let operations = &block.operations[start..end];
         operations.iter().all(|op| match &op.kind {
             OpKind::ConstInt(_)
+            | OpKind::ConstUInt(_)
             | OpKind::ConstInt128(_)
             | OpKind::ConstUInt128(_)
             | OpKind::ConstBool(_)

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -1,13 +1,10 @@
 //! `&s[k..]` / `&s[..k]` sub-slice indexes → orthodox `getslice` copies.
 //!
-//! ## Status: RangeFrom dormant
-//!
-//! These recognizers are CAPSTONES, not independently wired primitives. The
-//! RangeFrom arm is built and unit-tested but is not captured or invoked from
-//! `front::mir`: its rewrite plants a Void `ConstNone` stop, which had no
-//! regalloc coloring when the rewritten
-//! `pyre_interpreter::module::_io::buffered_rwpair::<Impl>::readinto` graph
-//! dropped to the legacy walker.
+//! These recognizers are CAPSTONES, not independently wired primitives.
+//! RangeFrom is carried as a synthetic marker until the flowspace adapter,
+//! where it expands to `getslice(slice, start, None)` after annotation. This
+//! keeps the Void `None` bound out of any graph that drops to the legacy
+//! walker, matching the existing Range/RangeTo marker split.
 //!
 //! The `ll_listslice_startstop` clamp (`rpython/rtyper/rlist.py`)
 //! repairs the oversized result of an unsigned `len - 1` wrap. The MinusOne
@@ -18,12 +15,9 @@
 //! those checks have no Python-observable meaning.
 //!
 //! The earlier failure was an unwired frontend `getslice` planted before a
-//! graph fell through the legacy walker. The admitted MinusOne path uses an
-//! unregistered synthetic call, expanded only by the rtyper flowspace
-//! adapter, so no frontend `getslice` is planted. RangeFrom alone stays
-//! dormant because its Void `ConstNone` stop has no regalloc coloring on that
-//! path.
-#![allow(dead_code)]
+//! graph fell through the legacy walker. Every admitted path now uses an
+//! unregistered synthetic call expanded only by the rtyper flowspace adapter,
+//! so no frontend `getslice` or Void bound is planted.
 //!
 //! ## Positioning
 //!
@@ -54,10 +48,9 @@
 //!
 //! The `getslice` operand contract (`decompose_slice_args`,
 //! `rtyper.rs`) selects `SliceKind::StartOnly` when args[2] (`stop`)
-//! annotates as a constant `None`; `k` (a proven-nonneg / const start) becomes
-//! args[1]. The stop operand is a fresh [`OpKind::ConstNone`] — the annotator
-//! constant `None` (`Void` `concretetype`), which folds to `SomeValue::None_`
-//! so the `stop_is_none` branch fires and the `len-k` copy runs at runtime.
+//! annotates as a constant `None`; `k` (a proven-nonnegative `usize` start)
+//! becomes args[1]. The adapter supplies the annotated constant `None`, so the
+//! `stop_is_none` branch fires and the `len-k` copy runs at runtime.
 //!
 //! ## Consumer gate + fail-safe (the UNWIRED hazard)
 //!
@@ -285,19 +278,11 @@ fn rewire_one_slice_index_site(
         ));
     }
 
-    // 3. Validate the selected bounds before mutating. Both bounds must be a
-    // NON-NEGATIVE CONSTANT. `decompose_slice_args`
-    //     (rtyper.rs) raises "slice start must be proved
-    //     non-negative" for a `nonneg==false` runtime `SomeInteger` start, and
-    //     a `usize` literal decodes to a bare `OpKind::ConstInt(k)` with no
-    //     `Unsigned`/nonneg annotation (only its value is ≥ 0). A runtime
-    //     start could annotate `nonneg==false`, making the getslice fail to
-    //     rtype → the graph drops to legacy carrying a bare unwired `getslice`
-    //     → the unwired-opname snapshot breaks. Restricting to a const k ≥ 0
-    //     (the `&s[1..]` / `&s[k..]` literal shape, which
-    //     `immutablevalue(ConstInt(k))` annotates `nonneg = k>=0`) keeps every
-    //     rewritten graph lift-able; a computed start declines cleanly
-    //     (residual, census Skip). RangeTo's constant-nonnegative gate is only
+    // 3. Validate the selected bounds before mutating. `decompose_slice_args`
+    // (rtyper.rs) requires a non-negative start. A RangeFrom slice-index
+    // consumer statically selects `SliceIndex<usize>`, so its bound retains
+    // the unsigned/nonnegative annotation even when computed; the marker is
+    // expanded only after annotation. RangeTo's proof gate is only
     //     the secondary blocker: activating it admitted bare unwired
     //     `getslice/rii>r` from `split_builtin_kwargs` and
     //     `do_warn_explicit`; both measured ends were `args.len() - 1`,
@@ -310,11 +295,6 @@ fn rewire_one_slice_index_site(
             if !graph_defines(graph, start) {
                 return Err(format!(
                     "{name}: RangeFrom start is not defined in the graph"
-                ));
-            }
-            if !bound_is_const_nonneg(graph, start) {
-                return Err(format!(
-                    "{name}: RangeFrom start is not a non-negative constant — declining"
                 ));
             }
         }
@@ -430,20 +410,16 @@ fn rewire_one_slice_index_site(
             };
         }
         SliceIndexBounds::RangeFrom { start } => {
-            let synthetic_bound = graph.alloc_value_var();
             graph.blocks[rb].operations[ri] = SpaceOperation {
                 result: Some(index_result),
-                kind: OpKind::GetSlice {
-                    args: vec![slice, start.clone(), synthetic_bound.clone()],
+                kind: OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec!["__getslice_rangefrom".to_string()],
+                    },
+                    args: vec![slice, start.clone()],
+                    result_ty: index_result_ty,
                 },
             };
-            graph.blocks[rb].operations.insert(
-                ri,
-                SpaceOperation {
-                    result: Some(synthetic_bound),
-                    kind: OpKind::ConstNone,
-                },
-            );
         }
     }
     Ok(())
@@ -1321,21 +1297,6 @@ fn graph_defines(graph: &FunctionGraph, var: &Variable) -> bool {
             || b.operations
                 .iter()
                 .any(|op| op.result.as_ref() == Some(var))
-    })
-}
-
-/// `true` when `var` is produced by an `OpKind::ConstInt(k)` op with `k >= 0`
-/// — the `&s[k..]` literal start `decompose_slice_args` selects `StartOnly`
-/// for. A `usize` slice literal decodes to `ConstInt(k)` (`decode_literal`
-/// collapses `Usize` into `DecodedConst::Int`), which
-/// `immutablevalue(ConstInt(k))` annotates as `SomeInteger` with
-/// `nonneg = k>=0`, so a const k ≥ 0 satisfies the getslice nonneg contract
-/// without a computed-stop hazard.
-fn bound_is_const_nonneg(graph: &FunctionGraph, var: &Variable) -> bool {
-    graph.blocks.iter().any(|b| {
-        b.operations.iter().any(|op| {
-            op.result.as_ref() == Some(var) && matches!(&op.kind, OpKind::ConstInt(k) if *k >= 0)
-        })
     })
 }
 
@@ -2644,27 +2605,30 @@ mod tests {
         );
         assert!(!has_start_write, "start FieldWrite removed");
 
-        // A single `getslice` op with 3 args (slice, k, None) is emitted, its
-        // stop operand produced by a `ConstNone` op.
-        let getslice_ops: Vec<_> = g
+        // A single marker with (slice, k) is emitted. The adapter adds the
+        // constant None only after annotation, so an unrelated phaseA failure
+        // cannot leak an unwired getslice into the legacy walker.
+        let marker_ops: Vec<_> = g
             .blocks
             .iter()
             .flat_map(|blk| &blk.operations)
-            .filter(|op| matches!(&op.kind, OpKind::GetSlice { .. }))
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments == &["__getslice_rangefrom".to_string()]
+                )
+            })
             .collect();
-        assert_eq!(getslice_ops.len(), 1, "exactly one getslice op");
-        let OpKind::GetSlice { args } = &getslice_ops[0].kind else {
+        assert_eq!(marker_ops.len(), 1, "exactly one RangeFrom marker");
+        let OpKind::Call { args, .. } = &marker_ops[0].kind else {
             unreachable!()
         };
-        assert_eq!(args.len(), 3, "getslice has [slice, start, stop]");
+        assert_eq!(args.len(), 2, "marker has [slice, start]");
         assert_eq!(args[0], slice, "arg0 = slice receiver");
         assert_eq!(args[1], k, "arg1 = const start k");
-        let stop = &args[2];
-        let stop_is_const_none =
-            g.blocks.iter().flat_map(|blk| &blk.operations).any(|op| {
-                op.result.as_ref() == Some(stop) && matches!(&op.kind, OpKind::ConstNone)
-            });
-        assert!(stop_is_const_none, "arg2 = ConstNone (StartOnly stop)");
     }
 
     #[test]
@@ -3016,11 +2980,11 @@ mod tests {
         ]));
     }
 
-    /// A RangeFrom whose start is a RUNTIME value (not a const) declines: a
-    /// non-nonneg runtime start would fail `decompose_slice_args` and drop the
-    /// graph to legacy carrying a bare unwired `getslice`.
+    /// A RangeFrom whose `usize` start is a runtime value is retained as a
+    /// marker; its unsigned annotation proves the start nonnegative to
+    /// `decompose_slice_args` when the adapter expands it.
     #[test]
-    fn rewrite_declines_runtime_start() {
+    fn rewrite_lifts_runtime_unsigned_start() {
         let mut g = FunctionGraph::new("test_slice_index_runtime");
         let a = g.startblock;
         let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
@@ -3033,7 +2997,7 @@ mod tests {
                     op: "add".into(),
                     lhs: x.clone(),
                     rhs: x.clone(),
-                    result_ty: ValueType::Int,
+                    result_ty: ValueType::Unsigned,
                 },
                 true,
             )
@@ -3073,21 +3037,21 @@ mod tests {
             start: start.clone(),
         };
         let rewritten = rewire_slice_index_rangefrom_sites(&mut g, &[site]);
-        assert_eq!(rewritten, 0, "runtime start declines");
-        // The residual call and ctor survive untouched (census Skip).
+        assert_eq!(rewritten, 1, "runtime unsigned start is rewritten");
         assert!(
             g.blocks
                 .iter()
                 .flat_map(|blk| &blk.operations)
-                .any(|op| is_slice_range_index_call(&op.kind)),
-            "residual slice::index call left in place"
-        );
-        assert!(
-            !g.blocks
-                .iter()
-                .flat_map(|blk| &blk.operations)
-                .any(|op| matches!(&op.kind, OpKind::GetSlice { .. })),
-            "no getslice planted on decline"
+                .any(|op| matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        args,
+                        ..
+                    } if segments == &["__getslice_rangefrom".to_string()]
+                        && args == &[slice.clone(), start.clone()]
+                )),
+            "runtime RangeFrom becomes an adapter marker"
         );
     }
 

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -7,17 +7,28 @@
 //! the slice operation out of any graph that drops to the legacy walker,
 //! matching the existing RangeTo marker split.
 //!
-//! The `ll_listslice_startstop` clamp (`rpython/rtyper/rlist.py`)
-//! repairs the oversized result of an unsigned `len - 1` wrap. The MinusOne
-//! shape is admitted because `len - 1 <= len` is proven for this receiver;
-//! a general RangeTo stop has no `end <= len` proof and is declined. A full
-//! `Range { start, end }`, however, is the direct Rust spelling used by the
-//! interpreter where PyPy writes `buffer[start:end]` (`RStringIO.read`,
-//! `W_BufferedWriter._write_buf` and siblings). RPython emits `getslice`
-//! without a translator-side dominator proof. The frontend likewise strips
+//! No arm carries an `end <= len` proof, and upstream asks for none:
+//! `ll_listslice_startstop` (`rpython/rtyper/rlist.py:893-903`) CLAMPS an
+//! oversized stop (`if stop > length: stop = length`) and states the rest as
+//! `ll_assert`s, which translate out.  Non-negativity is proven one layer up,
+//! in the annotator (`check_negative_slice`, `rpython/annotator/unaryop.py:437-443`),
+//! and pyre's port raises there identically.  A `Range { start, end }` is the
+//! direct Rust spelling of what PyPy writes as `buffer[start:end]`
+//! (`RStringIO.read`, `rpython/rlib/rStringIO.py:148`;
+//! `BufferedMixin._raw_write`, `pypy/module/_io/interp_bufferedio.py:456`),
+//! so it is admitted on the same terms.  The frontend likewise strips
 //! Rust's implicit range assertions as `TermKind::Assert`, following
 //! `backendopt/removeassert.py`; retaining an extra proof only for the opaque
 //! `Index::index` shim would be a non-upstream control-flow restriction.
+//!
+//! A bare `RangeTo` still declines, and NOT for a semantic reason — upstream
+//! would clamp it like any other stop.  It declines because the ops it lowers
+//! to are not yet wired downstream: admitting it planted bare `getslice/rii>r`
+//! from `split_builtin_kwargs` and `do_warn_explicit` that nothing consumes.
+//! `MinusOne` and `StaticLength` are the two RangeTo shapes whose stop the
+//! rewrite can name at the callsite, so only they are carved out.  When the
+//! unwired `getslice/rii>r` is handled, the RangeTo decline should go: one
+//! rule for every stop is the upstream shape.
 //!
 //! The earlier failure was an unwired frontend `getslice` planted before a
 //! graph fell through the legacy walker. Every admitted path now uses an
@@ -221,8 +232,13 @@ fn rewire_one_slice_index_rangeto_site(
     } else if rangeto_static_length_bound_matches(graph, &site.end, &slice, range) {
         SliceIndexBounds::StaticLength { end: &site.end }
     } else {
+        // Not a bounds decline — `ll_listslice_startstop` would clamp this
+        // stop.  The two shapes above are the ones whose stop this rewrite can
+        // name at the callsite; a general one lowers to a `getslice/rii>r`
+        // nothing downstream consumes yet (see the module header).
         return Err(format!(
-            "{}: RangeTo stop has no proof that end <= slice length — declining",
+            "{}: RangeTo stop is neither the MinusOne nor the static-length \
+             shape — declining until a general getslice is wired",
             graph.name
         ));
     };
@@ -285,17 +301,16 @@ fn rewire_one_slice_index_site(
     }
 
     // 3. Validate the selected bounds before mutating. `decompose_slice_args`
-    // (rtyper.rs) requires a non-negative start. A RangeFrom slice-index
-    // consumer statically selects `SliceIndex<usize>`, so its bound retains
-    // the unsigned/nonnegative annotation even when computed; the marker is
-    // expanded only after annotation. RangeTo's proof gate is only
-    //     the secondary blocker: activating it admitted bare unwired
-    //     `getslice/rii>r` from `split_builtin_kwargs` and
-    //     `do_warn_explicit`; both measured ends were `args.len() - 1`,
-    //     statically unsigned but not constant, so an unsigned-only gate would
-    //     not decline them. A general RangeTo stop also lacks the primary
-    //     `end <= slice.len()` proof: the StartStop helper clamps an oversized
-    //     stop (`rlist.rs`), whereas Rust indexing panics.
+    // (rtyper.rs) requires a non-negative start.  A slice-index consumer
+    // statically selects `SliceIndex<usize>`, so its bounds retain the
+    // unsigned/nonnegative annotation even when computed; the marker is
+    // expanded only after annotation.  Nothing more is asked, because upstream
+    // asks nothing more: `ll_listslice_startstop`
+    // (`rpython/rtyper/rlist.py:893-903`) clamps an oversized stop and states
+    // `start <= length` / `stop >= start` as `ll_assert`s.  The one extra
+    // check below is `MinusOne`, whose end must really be
+    // `sub(ArrayLen(slice), 1)` — that is the shape recognition itself, not a
+    // bounds proof.
     match bounds {
         SliceIndexBounds::RangeFrom { start } => {
             if !graph_defines(graph, start) {
@@ -1020,7 +1035,12 @@ fn slice_index_segments_match(segments: &[String]) -> bool {
     // not a foreign method to residualize. PyPy's unicode paths use ordinary
     // slicing and RPython lowers both string and list slices through
     // `rtype_getslice`.
-    if segments == ["Wtf8", "index"] {
+    //
+    // `rustpython_wtf8::Wtf8` sits at its crate root, so its impl-owner
+    // spelling carries no module segment and the anchored form IS two
+    // segments; the crate-qualified spelling is accepted alongside it so the
+    // arm is anchored wherever the crate name survives.
+    if segments == ["Wtf8", "index"] || segments == ["rustpython_wtf8", "Wtf8", "index"] {
         return true;
     }
     let n = segments.len();

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -1,4 +1,5 @@
-//! `&s[k..]` / `&s[..k]` sub-slice indexes → orthodox `getslice` copies.
+//! `&s[k..]` / `&s[..k]` sub-slice and WTF-8 string indexes → orthodox
+//! `getslice` copies.
 //!
 //! These recognizers are CAPSTONES, not independently wired primitives.
 //! Range/RangeFrom are carried as synthetic markers until the flowspace
@@ -29,8 +30,9 @@
 //! `<[T] as Index<RangeFrom<usize>>>::index(s, RangeFrom { start: k })`.
 //! Its sibling `&s[..k]` uses `RangeTo { end: k }` and rewrites to
 //! `getslice(s, 0, k)` (`SliceKind::StartStop`).
-//! `lower_call` keeps `core::slice::index::<Impl>::index` as an unregistered
-//! residual (the gh#346 census wall), and the `RangeFrom { start }` operand is
+//! `lower_call` keeps `core::slice::index::<Impl>::index` and
+//! `rustpython_wtf8::Wtf8::index` as unregistered residuals (the gh#346 census
+//! wall), and the `RangeFrom { start }` operand is
 //! built by `front::mir`'s `Rvalue::Aggregate` arm as a
 //! `SyntheticTransparentCtor("RangeFrom")` + `FieldWrite("start")` chain —
 //! i.e. `SomeInstance(classdef='core.ops.range.RangeFrom')`, the same shape
@@ -992,8 +994,9 @@ fn minus_one_end_matches(graph: &FunctionGraph, end: &Variable, slice: &Variable
     has_len && has_one
 }
 
-/// `true` when `kind` is a residual `core::slice::index::<Impl>::index` call —
-/// the `&s[range]` sub-slice residual whose `range` operand this pass folds.
+/// `true` when `kind` is a residual range-index call over either a Rust slice
+/// or the WTF-8 string view used for Python unicode — the `&s[range]`
+/// residual whose `range` operand this pass folds.
 /// The scalar `Vec`/`Constants` integer index is intercepted earlier in
 /// `lower_call` (`is_vec_index_regular` / `constants_call_leaf`), so only the
 /// range-indexed slice residual reaches here.
@@ -1011,6 +1014,15 @@ fn is_slice_range_index_call(kind: &OpKind) -> bool {
 /// Charon runs `monomorphize:false`, so the callee keeps the inherent-impl
 /// path `core::slice::index::<Impl>::index`.
 fn slice_index_segments_match(segments: &[String]) -> bool {
+    // `Wtf8` is the frontend's RPython `SomeString` spelling (mir.rs maps
+    // Wtf8/Wtf8Buf/String/str to ValueType::Str). Its Index<Range*> impl is
+    // therefore the same `str[start:stop]` operation as the slice spelling,
+    // not a foreign method to residualize. PyPy's unicode paths use ordinary
+    // slicing and RPython lowers both string and list slices through
+    // `rtype_getslice`.
+    if segments == ["Wtf8", "index"] {
+        return true;
+    }
     let n = segments.len();
     if n < 4 || segments.first().map(String::as_str) != Some("core") {
         return false;

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -1195,7 +1195,7 @@ fn slice_index_segments_match(segments: &[String]) -> bool {
     clippy::mutable_key_type,
     reason = "Eq and Hash use immutable identity/value data; interior mutation is excluded, matching RPython identity-keyed dict semantics"
 )]
-fn range_feeds_only_index(
+pub(crate) fn range_feeds_only_index(
     graph: &FunctionGraph,
     range_result: &Variable,
     index_result: &Variable,

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -431,6 +431,7 @@ pub(crate) fn remap_op_kind(
             class_root: class_root.clone(),
         },
         OpKind::ConstInt(v) => OpKind::ConstInt(*v),
+        OpKind::ConstUInt(v) => OpKind::ConstUInt(*v),
         OpKind::ConstInt128(v) => OpKind::ConstInt128(*v),
         OpKind::ConstUInt128(v) => OpKind::ConstUInt128(*v),
         OpKind::ConstBool(v) => OpKind::ConstBool(*v),
@@ -914,6 +915,7 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
     match kind {
         OpKind::Input { .. }
         | OpKind::ConstInt(_)
+        | OpKind::ConstUInt(_)
         | OpKind::ConstInt128(_)
         | OpKind::ConstUInt128(_)
         | OpKind::ConstBool(_)
@@ -1188,6 +1190,7 @@ pub fn is_pure_op(kind: &OpKind) -> bool {
         // dependency-routing classification.
         OpKind::Input { .. }
         | OpKind::ConstInt(_)
+        | OpKind::ConstUInt(_)
         | OpKind::ConstInt128(_)
         | OpKind::ConstUInt128(_)
         | OpKind::ConstBool(_)

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -795,6 +795,95 @@ fn struct_layout_census_enabled() -> bool {
         .is_some_and(|value| value == std::ffi::OsStr::new("1"))
 }
 
+/// Count distinct struct *identities* per bare leaf for unique trait-impl
+/// devirtualization.
+///
+/// RPython's bookkeeper keys classes by the class object itself, so several
+/// lookup spellings for one class never make it ambiguous.  The LLBC metadata
+/// deliberately publishes full-crate, crate-relative, and bare aliases for
+/// one Rust type; count their shared [`majit_ir::descr::StructId`] once.  A
+/// qualified spelling whose identity is missing remains fail-closed by using
+/// its own path-derived id.  The small per-leaf `Vec` mirrors identity lookup
+/// without introducing an unordered side set.
+fn distinct_struct_identities_by_leaf(
+    program: &front::SemanticProgram,
+) -> std::collections::HashMap<String, Vec<majit_ir::descr::StructId>> {
+    let mut by_leaf: std::collections::HashMap<String, Vec<majit_ir::descr::StructId>> =
+        std::collections::HashMap::new();
+    for key in program.struct_fields.fields.keys() {
+        let Some((_, leaf)) = key.rsplit_once("::") else {
+            continue;
+        };
+        let identity = program
+            .struct_ids
+            .get(key)
+            .copied()
+            .flatten()
+            .unwrap_or_else(|| majit_ir::descr::StructId::from_canonical(key));
+        let identities = by_leaf.entry(leaf.to_string()).or_default();
+        if !identities.contains(&identity) {
+            identities.push(identity);
+        }
+    }
+    by_leaf
+}
+
+type TraitImplOwners = std::collections::HashMap<String, std::collections::BTreeSet<String>>;
+
+/// Resolve a trait's sole concrete owner to the struct root used by the
+/// annotator, preserving class identity across the LLBC registry's aliases.
+fn unique_trait_impl_roots(
+    program: &front::SemanticProgram,
+    trait_impl_owners: TraitImplOwners,
+) -> std::collections::HashMap<String, String> {
+    let struct_leaf_identities = distinct_struct_identities_by_leaf(program);
+    trait_impl_owners
+        .into_iter()
+        .filter_map(|(trait_qualified, owners)| {
+            if owners.len() != 1 {
+                return None;
+            }
+            let owner = owners.into_iter().next().unwrap();
+            let leaf = owner.rsplit("::").next().unwrap_or(&owner).to_string();
+            let identities = struct_leaf_identities.get(leaf.as_str());
+            // A bare owner has no namespace left to disambiguate.  Accept it
+            // only when every qualified registry spelling resolves to one
+            // StructId; two identities sharing the leaf stay fail-closed.
+            if !owner.contains("::") && identities.is_some_and(|ids| ids.len() > 1) {
+                return None;
+            }
+            let owner_id = program
+                .struct_ids
+                .get(&owner)
+                .copied()
+                .flatten()
+                .or_else(|| identities.and_then(|ids| (ids.len() == 1).then_some(ids[0])))?;
+            // RPython carries the class / lltype object, so every spelling of
+            // one identity reaches one descriptor cache entry.  The Rust
+            // pipeline still transports a string at this seam; choose the
+            // fully crate-qualified registry spelling deterministically so a
+            // method owner such as `option::Option` and its SizeDescr owner
+            // `core::option::Option` cannot split one field object by name.
+            let canonical_owner = program
+                .struct_fields
+                .fields
+                .keys()
+                .filter(|candidate| {
+                    program.struct_ids.get(*candidate).copied().flatten() == Some(owner_id)
+                })
+                .max_by(|left, right| {
+                    left.matches("::")
+                        .count()
+                        .cmp(&right.matches("::").count())
+                        .then_with(|| left.len().cmp(&right.len()))
+                        .then_with(|| right.cmp(left))
+                })
+                .cloned()?;
+            Some((trait_qualified, canonical_owner))
+        })
+        .collect()
+}
+
 #[expect(
     clippy::arc_with_non_send_sync,
     reason = "Arc preserves shared runtime descriptor/JitCode identity while non-Send translator payload remains confined to the single-threaded build phase"
@@ -1593,10 +1682,7 @@ fn analyze_pipeline_from_module_paths(
     // through this map).  Unlike the direct-path registration below,
     // this is annotation-only metadata — it pulls no graph bodies into
     // callers.
-    let mut trait_impl_owners: std::collections::HashMap<
-        String,
-        std::collections::BTreeSet<String>,
-    > = std::collections::HashMap::new();
+    let mut trait_impl_owners: TraitImplOwners = std::collections::HashMap::new();
     for (_, trait_qualified, _, owner, _, _, _) in &concrete_trait_methods {
         // Keyed by the trait's qualified `name_path()` — two distinct
         // traits sharing a leaf name must not pool their impl owners
@@ -1607,19 +1693,11 @@ fn analyze_pipeline_from_module_paths(
             .or_default()
             .insert(owner.clone());
     }
-    // Leaf names shared by more than one qualified struct in the
-    // field registry: a unique-impl entry whose owner collapses to
-    // such a leaf could seed the receiver with the OTHER same-named
-    // struct's classdef, so those entries are dropped (fail-safe: the
-    // receiver keeps the classdef-less shell and the block stays
-    // census-visible).
-    let mut struct_leaf_counts: std::collections::HashMap<&str, usize> =
-        std::collections::HashMap::new();
-    for key in program.struct_fields.fields.keys() {
-        if let Some((_, leaf)) = key.rsplit_once("::") {
-            *struct_leaf_counts.entry(leaf).or_default() += 1;
-        }
-    }
+    // Leaf names shared by more than one distinct struct identity: a
+    // unique-impl entry whose owner collapses to such a leaf could seed the
+    // receiver with the OTHER same-named class, so those entries are dropped.
+    // Multiple lookup aliases of one StructId are one RPython class object and
+    // must not make that class ambiguous.
     // Opt-in receiver-driven dispatch families (receiver-dispatch configuration): a consumer
     // names `>=2`-impl trait qualified paths
     // whose `dyn Trait` receivers should annotate to a base ClassDef
@@ -1697,23 +1775,7 @@ fn analyze_pipeline_from_module_paths(
         trait_family_registrations.extend(auto);
     }
     call_control.set_trait_family_registrations(trait_family_registrations);
-    let trait_unique_impls: std::collections::HashMap<String, String> = trait_impl_owners
-        .into_iter()
-        .filter_map(|(trait_qualified, owners)| {
-            if owners.len() != 1 {
-                return None;
-            }
-            let owner = owners.into_iter().next().unwrap();
-            // `self_ty_root` may be module-qualified
-            // (`pyframe::PyFrame`); the struct-field registry and
-            // `getuniqueclassdef_for_struct_root` key on the leaf.
-            let leaf = owner.rsplit("::").next().unwrap_or(&owner).to_string();
-            if struct_leaf_counts.get(leaf.as_str()).copied().unwrap_or(0) > 1 {
-                return None;
-            }
-            Some((trait_qualified, leaf))
-        })
-        .collect();
+    let trait_unique_impls = unique_trait_impl_roots(&program, trait_impl_owners);
     call_control.set_trait_unique_impls(trait_unique_impls);
     for (trait_leaf, _, method_name, _owner, return_type, hints, graph) in &concrete_trait_methods {
         let key = (trait_leaf.clone(), method_name.clone());
@@ -2418,6 +2480,57 @@ pub mod rlib;
 #[cfg(test)]
 mod portal_driver_tests {
     use super::*;
+
+    #[test]
+    fn unique_impl_leaf_census_deduplicates_aliases_by_struct_identity() {
+        let mut program = front::SemanticProgram::default();
+        let pyframe = majit_ir::descr::StructId::from_canonical("pyframe::PyFrame");
+        for alias in [
+            "PyFrame",
+            "pyframe::PyFrame",
+            "pyre_interpreter::pyframe::PyFrame",
+        ] {
+            program
+                .struct_fields
+                .fields
+                .insert(alias.to_string(), Vec::new());
+            program.struct_ids.insert(alias.to_string(), Some(pyframe));
+        }
+        let identities = distinct_struct_identities_by_leaf(&program);
+        assert_eq!(
+            identities.get("PyFrame").map(Vec::len),
+            Some(1),
+            "lookup aliases of one RPython class identity are not ambiguous"
+        );
+
+        let mut owners = TraitImplOwners::new();
+        owners
+            .entry("pyre_interpreter::pyopcode::OpcodeStepExecutor".to_string())
+            .or_default()
+            .insert("pyframe::PyFrame".to_string());
+        let unique = unique_trait_impl_roots(&program, owners);
+        assert_eq!(
+            unique.get("pyre_interpreter::pyopcode::OpcodeStepExecutor"),
+            Some(&"pyre_interpreter::pyframe::PyFrame".to_string()),
+            "one class identity uses its fully-qualified registry spelling"
+        );
+
+        let foreign = "other_runtime::PyFrame";
+        program
+            .struct_fields
+            .fields
+            .insert(foreign.to_string(), Vec::new());
+        program.struct_ids.insert(
+            foreign.to_string(),
+            Some(majit_ir::descr::StructId::from_canonical(foreign)),
+        );
+        let identities = distinct_struct_identities_by_leaf(&program);
+        assert_eq!(
+            identities.get("PyFrame").map(Vec::len),
+            Some(2),
+            "genuinely distinct same-leaf classes remain ambiguous"
+        );
+    }
 
     fn driver(portal: CallPath) -> pipeline::JitDriverSpec {
         pipeline::JitDriverSpec {

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -805,6 +805,11 @@ fn struct_layout_census_enabled() -> bool {
 /// qualified spelling whose identity is missing remains fail-closed by using
 /// its own path-derived id.  The small per-leaf `Vec` mirrors identity lookup
 /// without introducing an unordered side set.
+///
+/// The caller drops any unique-impl entry whose owner collapses to a leaf
+/// this reports more than once: such an entry could seed the receiver with
+/// the OTHER same-named class.  Multiple lookup aliases of one `StructId`
+/// are one RPython class object and must not make that class ambiguous.
 fn distinct_struct_identities_by_leaf(
     program: &front::SemanticProgram,
 ) -> std::collections::HashMap<String, Vec<majit_ir::descr::StructId>> {
@@ -1693,11 +1698,6 @@ fn analyze_pipeline_from_module_paths(
             .or_default()
             .insert(owner.clone());
     }
-    // Leaf names shared by more than one distinct struct identity: a
-    // unique-impl entry whose owner collapses to such a leaf could seed the
-    // receiver with the OTHER same-named class, so those entries are dropped.
-    // Multiple lookup aliases of one StructId are one RPython class object and
-    // must not make that class ambiguous.
     // Opt-in receiver-driven dispatch families (receiver-dispatch configuration): a consumer
     // names `>=2`-impl trait qualified paths
     // whose `dyn Trait` receivers should annotate to a base ClassDef

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -438,6 +438,41 @@ impl CallTarget {
     }
 }
 
+/// Split a Rust-qualified type path at top-level `::` separators while
+/// preserving separators inside generic arguments as part of the owning
+/// segment.  Charon's named owner is already a structural path; reconstructing
+/// a synthetic ctor from a rendered instantiation such as
+/// `core::option::Option<Result<*mut m::Object, e::Error>>` must therefore
+/// yield `core`, `option`, `Option<Result<*mut m::Object, e::Error>>`, not
+/// split the payload's module paths into false owner segments.
+pub(crate) fn split_qualified_path(path: &str) -> Vec<String> {
+    let bytes = path.as_bytes();
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    let mut depth = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'<' => depth += 1,
+            b'>' => depth = depth.saturating_sub(1),
+            b':' if depth == 0 && bytes.get(i + 1) == Some(&b':') => {
+                if start < i {
+                    out.push(path[start..i].to_string());
+                }
+                i += 2;
+                start = i;
+                continue;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if start < path.len() {
+        out.push(path[start..].to_string());
+    }
+    out
+}
+
 impl fmt::Display for CallTarget {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -7012,6 +7047,20 @@ mod tests {
             "Leaf",
         );
         assert_eq!(nested.path_segments(), Some(vec!["outer", "Inner", "Leaf"]));
+    }
+
+    #[test]
+    fn qualified_path_split_preserves_paths_inside_generic_arguments() {
+        assert_eq!(
+            split_qualified_path(
+                "core::option::Option<Result<*mut pyobject::PyObject,error::PyError>>"
+            ),
+            vec![
+                "core",
+                "option",
+                "Option<Result<*mut pyobject::PyObject,error::PyError>>",
+            ]
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -3059,6 +3059,175 @@ pub fn remove_dead_aggregates(graph: &mut FunctionGraph) -> usize {
     total_removed
 }
 
+/// Lower `core::ptr::write(raw as *mut T, T { fields... })` to field stores.
+///
+/// This is the Rust-source spelling of RPython's ordinary alloc-then-init
+/// graph shape: after `malloc(T)`, each member is written with its own
+/// `setfield`.  Charon extracts `ptr::write` as one generic FunDecl plus a
+/// concrete `generics.types[0]` at every call site.  Routing all those calls
+/// through one `FunctionPath(["core", "ptr", "write"])` therefore collapses
+/// the monomorphisations onto one `FunctionDesc`; the whole-program annotator
+/// then tries to union unrelated aggregate arguments (observed first as
+/// `W_LongObject ∪ Cell`).  RPython has no corresponding callable or union:
+/// the stores are operations in each caller graph.
+///
+/// The MIR front has already made the concrete type explicit on both sides:
+/// the destination is a `__pyre_cast_instance(T)` result and the value is a
+/// `SyntheticTransparentCtor(T)` followed by ordered `FieldWrite`s.  Replace
+/// only that exact same-block cluster, preserving the source field order and
+/// values while retargeting each store to the destination.  The call's unit
+/// result, when still carried by MIR bookkeeping, becomes a `ConstNone` with
+/// the same `Void` representation.  Any indirect, cross-block,
+/// mismatched-owner, or incomplete spelling is left untouched to fail loud
+/// rather than guessing at a memory layout.
+pub fn lower_struct_ptr_writes(
+    graph: &mut FunctionGraph,
+    struct_field_attrs: &std::collections::HashMap<String, Vec<(String, ValueType)>>,
+) -> usize {
+    use crate::flowspace::model::Variable;
+
+    fn registered_layout<'a>(
+        owner: &str,
+        struct_field_attrs: &'a std::collections::HashMap<String, Vec<(String, ValueType)>>,
+    ) -> Option<&'a Vec<(String, ValueType)>> {
+        if let Some(exact) = struct_field_attrs.get(owner) {
+            return Some(exact);
+        }
+        let mut leaf_matches = struct_field_attrs
+            .iter()
+            .filter(|(key, _)| key.rsplit("::").next() == Some(owner));
+        let (_, only) = leaf_matches.next()?;
+        (leaf_matches.next().is_none()).then_some(only)
+    }
+
+    #[derive(Clone)]
+    struct Rewrite {
+        block: usize,
+        op: usize,
+        destination: Variable,
+        stores: Vec<(FieldDescriptor, LinkArg, ValueType)>,
+        result: Option<Variable>,
+    }
+
+    let mut rewrites = Vec::new();
+    for (bi, block) in graph.blocks.iter().enumerate() {
+        for (oi, op) in block.operations.iter().enumerate() {
+            let OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                args,
+                result_ty: ValueType::Void,
+            } = &op.kind
+            else {
+                continue;
+            };
+            if args.len() != 2
+                || !segments
+                    .iter()
+                    .map(String::as_str)
+                    .eq(["core", "ptr", "write"])
+            {
+                continue;
+            }
+            let destination = &args[0];
+            let aggregate = &args[1];
+            let destination_owner = block.operations[..oi].iter().find_map(|candidate| {
+                match (&candidate.result, &candidate.kind) {
+                    (
+                        Some(result),
+                        OpKind::Call {
+                            target: CallTarget::FunctionPath { segments },
+                            args,
+                            ..
+                        },
+                    ) if result == destination
+                        && args.len() == 1
+                        && segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                        && segments.len() == 2 =>
+                    {
+                        Some(segments[1].as_str())
+                    }
+                    _ => None,
+                }
+            });
+            let aggregate_owner = block.operations[..oi].iter().find_map(|candidate| {
+                match (&candidate.result, &candidate.kind) {
+                    (
+                        Some(result),
+                        OpKind::Call {
+                            target: CallTarget::SyntheticTransparentCtor { name, .. },
+                            ..
+                        },
+                    ) if result == aggregate => Some(name.as_str()),
+                    _ => None,
+                }
+            });
+            if destination_owner.is_none() || destination_owner != aggregate_owner {
+                continue;
+            }
+            let stores: Vec<_> = block.operations[..oi]
+                .iter()
+                .filter_map(|candidate| match &candidate.kind {
+                    OpKind::FieldWrite {
+                        base,
+                        field,
+                        value,
+                        ty,
+                    } if base == aggregate => Some((field.clone(), value.clone(), ty.clone())),
+                    _ => None,
+                })
+                .collect();
+            let Some(layout) = registered_layout(
+                destination_owner.expect("owner equality checked"),
+                struct_field_attrs,
+            ) else {
+                continue;
+            };
+            if !stores
+                .iter()
+                .map(|(field, _, _)| field.name.as_str())
+                .eq(layout.iter().map(|(name, _)| name.as_str()))
+            {
+                continue;
+            }
+            rewrites.push(Rewrite {
+                block: bi,
+                op: oi,
+                destination: destination.clone(),
+                stores,
+                result: op.result.clone(),
+            });
+        }
+    }
+
+    let rewritten = rewrites.len();
+    for rewrite in rewrites.into_iter().rev() {
+        let block = &mut graph.blocks[rewrite.block];
+        let mut replacement: Vec<_> = rewrite
+            .stores
+            .into_iter()
+            .map(|(field, value, ty)| SpaceOperation {
+                result: None,
+                kind: OpKind::FieldWrite {
+                    base: rewrite.destination.clone(),
+                    field,
+                    value,
+                    ty,
+                },
+            })
+            .collect();
+        if let Some(result) = rewrite.result {
+            replacement.push(SpaceOperation {
+                result: Some(result),
+                kind: OpKind::ConstNone,
+            });
+        }
+        block
+            .operations
+            .splice(rewrite.op..=rewrite.op, replacement);
+    }
+    rewritten
+}
+
 /// Fuse the boxing-constructor idiom into a native GC allocation.
 ///
 /// pyre's boxing constructors (`floatobject::w_float_new` etc.) are written

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -3072,7 +3072,7 @@ pub fn remove_dead_aggregates(graph: &mut FunctionGraph) -> usize {
 /// the stores are operations in each caller graph.
 ///
 /// The MIR front has already made the concrete type explicit on both sides:
-/// the destination is a `__pyre_cast_instance(T)` result and the value is a
+/// the destination is a `__cast_instance_intrinsic(T)` result and the value is a
 /// `SyntheticTransparentCtor(T)` followed by ordered `FieldWrite`s.  Calls in
 /// the source often split the aggregate from the stable allocation with
 /// residual GC hooks; resolve only phis whose every incoming path reaches the
@@ -3182,7 +3182,8 @@ pub fn lower_struct_ptr_writes(
                         },
                     ) if result == destination
                         && args.len() == 1
-                        && segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                        && segments.first().map(String::as_str)
+                            == Some("__cast_instance_intrinsic")
                         && segments.len() == 2 =>
                     {
                         Some(segments[1].as_str())

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -679,6 +679,11 @@ pub enum OpKind {
         class_root: Option<String>,
     },
     ConstInt(i64),
+    /// Word-sized unsigned integer constant. RPython stores the same Python
+    /// integer value as `ConstInt`, but its `Constant.concretetype` is
+    /// `lltype.Unsigned`; keeping the source tag prevents `r_uint ∪ int`
+    /// merges when MIR joins an unsigned literal with another `usize` value.
+    ConstUInt(u64),
     /// Translation-time `r_longlonglong` constant. This carrier may
     /// appear in flow/rtyping graphs but must never be coerced into a
     /// JIT register-kind `ConstInt`.
@@ -2802,6 +2807,10 @@ pub fn fold_constant_exitswitch(graph: &mut FunctionGraph) -> usize {
         let (bool_case, int_case) = match kind {
             Some(OpKind::ConstBool(b)) => (Some(*b), Some(i64::from(*b))),
             Some(OpKind::ConstInt(n)) => ((*n == 0 || *n == 1).then_some(*n != 0), Some(*n)),
+            Some(OpKind::ConstUInt(n)) => (
+                (*n == 0 || *n == 1).then_some(*n != 0),
+                i64::try_from(*n).ok(),
+            ),
             _ => continue,
         };
         let block = &graph.blocks[block_idx];
@@ -3399,12 +3408,15 @@ pub fn fuse_boxing_alloc(
         Some(only)
     }
 
-    let is_malloc_typed = |target: &CallTarget| -> bool {
+    let is_gc_malloc = |target: &CallTarget| -> bool {
         matches!(target, CallTarget::FunctionPath { segments }
             if segments.len() >= 2
                 && matches!(
                     segments[segments.len() - 1].as_str(),
-                    "malloc_typed" | "malloc_typed_managed" | "malloc_typed_stable"
+                    "malloc"
+                        | "malloc_typed"
+                        | "malloc_typed_managed"
+                        | "malloc_typed_stable"
                 )
                 && segments[segments.len() - 2] == "lltype")
     };
@@ -3822,7 +3834,7 @@ pub fn fuse_boxing_alloc(
             let OpKind::Call { target, args, .. } = &op.kind else {
                 continue;
             };
-            if !is_malloc_typed(target) || args.len() != 1 {
+            if !is_gc_malloc(target) || args.len() != 1 {
                 continue;
             }
             let Some(result) = &op.result else {
@@ -9366,7 +9378,7 @@ mod tests {
                         segments: vec![
                             crate::runtime_names::crates::OBJECT.into(),
                             "lltype".into(),
-                            "malloc_typed".into(),
+                            "malloc".into(),
                         ],
                     },
                     args: vec![agg.clone()],

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2842,10 +2842,9 @@ pub fn fold_constant_exitswitch(graph: &mut FunctionGraph) -> usize {
         let (bool_case, int_case) = match kind {
             Some(OpKind::ConstBool(b)) => (Some(*b), Some(i64::from(*b))),
             Some(OpKind::ConstInt(n)) => ((*n == 0 || *n == 1).then_some(*n != 0), Some(*n)),
-            Some(OpKind::ConstUInt(n)) => (
-                (*n == 0 || *n == 1).then_some(*n != 0),
-                i64::try_from(*n).ok(),
-            ),
+            Some(OpKind::ConstUInt(n)) => {
+                ((*n == 0 || *n == 1).then_some(*n != 0), Some(*n as i64))
+            }
             _ => continue,
         };
         let block = &graph.blocks[block_idx];
@@ -2865,7 +2864,8 @@ pub fn fold_constant_exitswitch(graph: &mut FunctionGraph) -> usize {
         // one survivor (`assert len(newexits) == 1`), falling back to the
         // `"default"` catch-all only when none match: a constant matching
         // two arms is a malformed switch that checkgraph's exitcase
-        // uniqueness invariant (`flowspace/model.py:686`) forbids.
+        // uniqueness invariant (`flowspace/model.py`, `checkgraph`:
+        // `assert len(allexitcases) == len(block.exits)`) forbids.
         let matching: Vec<usize> = block
             .exits
             .iter()
@@ -3252,6 +3252,17 @@ pub fn lower_struct_ptr_writes(
             if destination_owner.is_none() || destination_owner != aggregate_owner {
                 continue;
             }
+            // KNOWN GAP: this scans EVERY block, and each matched store's
+            // `value` is spliced verbatim into the call's block below. Only
+            // the `base` is proven in scope (`producer_root`); the `value` is
+            // not. `checkgraph` (`flowspace/model.py`) resets its `vars` per
+            // block and errors on a cross-block use, so a store whose value is
+            // defined in a block that does not reach the call builds a graph
+            // the port's own checker rejects — and nothing in `front::mir`
+            // calls `checkgraph`, so it surfaces later in `translator`.
+            // Restricting the scan to the call's own block is the fail-closed
+            // fix, but it also drops the multi-block shape this pass exists
+            // for; the real fix is a dominance test on each `value`.
             let stores: Vec<_> = graph
                 .blocks
                 .iter()

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -3073,13 +3073,15 @@ pub fn remove_dead_aggregates(graph: &mut FunctionGraph) -> usize {
 ///
 /// The MIR front has already made the concrete type explicit on both sides:
 /// the destination is a `__pyre_cast_instance(T)` result and the value is a
-/// `SyntheticTransparentCtor(T)` followed by ordered `FieldWrite`s.  Replace
-/// only that exact same-block cluster, preserving the source field order and
-/// values while retargeting each store to the destination.  The call's unit
-/// result, when still carried by MIR bookkeeping, becomes a `ConstNone` with
-/// the same `Void` representation.  Any indirect, cross-block,
-/// mismatched-owner, or incomplete spelling is left untouched to fail loud
-/// rather than guessing at a memory layout.
+/// `SyntheticTransparentCtor(T)` followed by ordered `FieldWrite`s.  Calls in
+/// the source often split the aggregate from the stable allocation with
+/// residual GC hooks; resolve only phis whose every incoming path reaches the
+/// same constructor, then re-emit the registered complete field layout in
+/// declaration order at the destination.  The call's unit result, when still
+/// carried by MIR bookkeeping, becomes a `ConstNone` with the same `Void`
+/// representation.  Any indirect, disagreeing-phi, mismatched-owner, or
+/// incomplete spelling is left untouched to fail loud rather than guessing at
+/// a memory layout.
 pub fn lower_struct_ptr_writes(
     graph: &mut FunctionGraph,
     struct_field_attrs: &std::collections::HashMap<String, Vec<(String, ValueType)>>,
@@ -3098,6 +3100,43 @@ pub fn lower_struct_ptr_writes(
             .filter(|(key, _)| key.rsplit("::").next() == Some(owner));
         let (_, only) = leaf_matches.next()?;
         (leaf_matches.next().is_none()).then_some(only)
+    }
+
+    fn producer_root(graph: &FunctionGraph, var: &Variable, depth: u32) -> Option<Variable> {
+        if depth == 0 {
+            return None;
+        }
+        if graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .any(|op| op.result.as_ref() == Some(var))
+        {
+            return Some(var.clone());
+        }
+        let (target, slot) = graph.blocks.iter().find_map(|block| {
+            block
+                .inputargs
+                .iter()
+                .position(|input| input == var)
+                .map(|slot| (block.id, slot))
+        })?;
+        let mut root: Option<Variable> = None;
+        let mut saw_predecessor = false;
+        for link in graph.blocks.iter().flat_map(|block| &block.exits) {
+            if link.target != target {
+                continue;
+            }
+            saw_predecessor = true;
+            let incoming = link.args.get(slot)?.as_variable()?;
+            let incoming_root = producer_root(graph, incoming, depth - 1)?;
+            match &root {
+                None => root = Some(incoming_root),
+                Some(seen) if seen == &incoming_root => {}
+                Some(_) => return None,
+            }
+        }
+        saw_predecessor.then_some(root).flatten()
     }
 
     #[derive(Clone)]
@@ -3129,7 +3168,9 @@ pub fn lower_struct_ptr_writes(
                 continue;
             }
             let destination = &args[0];
-            let aggregate = &args[1];
+            let Some(aggregate) = producer_root(graph, &args[1], 16) else {
+                continue;
+            };
             let destination_owner = block.operations[..oi].iter().find_map(|candidate| {
                 match (&candidate.result, &candidate.kind) {
                     (
@@ -3149,30 +3190,36 @@ pub fn lower_struct_ptr_writes(
                     _ => None,
                 }
             });
-            let aggregate_owner = block.operations[..oi].iter().find_map(|candidate| {
-                match (&candidate.result, &candidate.kind) {
+            let aggregate_owner = graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .find_map(|candidate| match (&candidate.result, &candidate.kind) {
                     (
                         Some(result),
                         OpKind::Call {
                             target: CallTarget::SyntheticTransparentCtor { name, .. },
                             ..
                         },
-                    ) if result == aggregate => Some(name.as_str()),
+                    ) if result == &aggregate => Some(name.as_str()),
                     _ => None,
-                }
-            });
+                });
             if destination_owner.is_none() || destination_owner != aggregate_owner {
                 continue;
             }
-            let stores: Vec<_> = block.operations[..oi]
+            let stores: Vec<_> = graph
+                .blocks
                 .iter()
+                .flat_map(|block| &block.operations)
                 .filter_map(|candidate| match &candidate.kind {
                     OpKind::FieldWrite {
                         base,
                         field,
                         value,
                         ty,
-                    } if base == aggregate => Some((field.clone(), value.clone(), ty.clone())),
+                    } if producer_root(graph, base, 16).as_ref() == Some(&aggregate) => {
+                        Some((field.clone(), value.clone(), ty.clone()))
+                    }
                     _ => None,
                 })
                 .collect();
@@ -3182,18 +3229,31 @@ pub fn lower_struct_ptr_writes(
             ) else {
                 continue;
             };
-            if !stores
-                .iter()
-                .map(|(field, _, _)| field.name.as_str())
-                .eq(layout.iter().map(|(name, _)| name.as_str()))
-            {
+            if stores.len() != layout.len() {
+                continue;
+            }
+            let mut ordered_stores = Vec::with_capacity(layout.len());
+            let mut complete = true;
+            for (name, _) in layout {
+                let mut matches = stores.iter().filter(|(field, _, _)| &field.name == name);
+                let Some(store) = matches.next() else {
+                    complete = false;
+                    break;
+                };
+                if matches.next().is_some() {
+                    complete = false;
+                    break;
+                }
+                ordered_stores.push(store.clone());
+            }
+            if !complete {
                 continue;
             }
             rewrites.push(Rewrite {
                 block: bi,
                 op: oi,
                 destination: destination.clone(),
-                stores,
+                stores: ordered_stores,
                 result: op.result.clone(),
             });
         }

--- a/majit/majit-translate/src/runtime_names.rs
+++ b/majit/majit-translate/src/runtime_names.rs
@@ -91,8 +91,10 @@ pub(crate) mod artifacts {
         concat!(env!("CARGO_MANIFEST_DIR"), "/../charon-corpus/corpus.ullbc");
 }
 
-/// Host shims — callables the consumer exports for the flowspace HOST_ENV that
-/// have no RPython counterpart, so no upstream name to port.
+/// Host adapter spellings — callables the consumer exports for the flowspace
+/// HOST_ENV when Rust source has no directly importable RPython callable.
+/// Most are translation-only shims; `LL_ARRAYMOVE` explicitly restores the
+/// corresponding RPython operation at a proven adapter boundary.
 ///
 /// Registered in `flowspace::model`, given an annotator in
 /// `annotator::builtin`, and resolved in `translator::rtyper`. All three must
@@ -104,6 +106,9 @@ pub(crate) mod shims {
     pub(crate) const STRINGBUILDER_NEW: &str = "__majit_stringbuilder_new";
     pub(crate) const STRINGBUILDER_APPEND: &str = "__majit_stringbuilder_append";
     pub(crate) const STRINGBUILDER_BUILD: &str = "__majit_stringbuilder_build";
+    /// Rust `ptr::copy` at a proven list-storage adapter boundary, restored
+    /// to RPython `rgc.ll_arraymove(array, source_start, dest_start, length)`.
+    pub(crate) const LL_ARRAYMOVE: &str = "__majit_ll_arraymove";
     /// Prefix, not a whole name: the wrapping arithmetic shims are
     /// `__majit_wrap_<op>`, matched by prefix where the op is not known.
     pub(crate) const WRAP_PREFIX: &str = "__majit_wrap_";

--- a/majit/majit-translate/src/runtime_names.rs
+++ b/majit/majit-translate/src/runtime_names.rs
@@ -93,8 +93,14 @@ pub(crate) mod artifacts {
 
 /// Host adapter spellings — callables the consumer exports for the flowspace
 /// HOST_ENV when Rust source has no directly importable RPython callable.
-/// Most are translation-only shims; `LL_ARRAYMOVE` explicitly restores the
-/// corresponding RPython operation at a proven adapter boundary.
+/// Most are translation-only shims. `LL_ARRAYMOVE` is the one exception: it
+/// names a callable RPython does have (`rpython/rtyper/rlist.py`,
+/// `ll_arraymove`, wrapping `rgc.ll_arraymove`), reached here through a
+/// proven adapter boundary because neither `rlist.ll_arraymove` nor its
+/// caller `ll_delitem_nonneg` is built yet. The restoration reaches the
+/// rtyper only: no `list.ll_arraymove` oopspec and no `OS_ARRAYMOVE`
+/// (`jit/codewriter/effectinfo.py`) are emitted, so the codewriter still
+/// produces a residual call where upstream produces the operation.
 ///
 /// Registered in `flowspace::model`, given an annotator in
 /// `annotator::builtin`, and resolved in `translator::rtyper`. All three must
@@ -123,6 +129,7 @@ pub(crate) mod modules {
     /// value.
     pub(crate) const OBJECT_MODEL: &str = "pyre_object.pyobject";
     pub(crate) const OBJECT_LLTYPE: &str = "pyre_object.lltype";
+    pub(crate) const MALLOC: &str = "pyre_object.lltype.malloc";
     pub(crate) const MALLOC_TYPED: &str = "pyre_object.lltype.malloc_typed";
     pub(crate) const MALLOC_TYPED_MANAGED: &str = "pyre_object.lltype.malloc_typed_managed";
     pub(crate) const MALLOC_TYPED_STABLE: &str = "pyre_object.lltype.malloc_typed_stable";

--- a/majit/majit-translate/src/translator/rtyper/call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/call_registry.rs
@@ -66,7 +66,9 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use crate::annotator::bookkeeper::Bookkeeper;
-use crate::annotator::description::{DescEntry, FunctionDesc, GraphCacheKey};
+use crate::annotator::description::{AnnSignature, DescEntry, FunctionDesc, GraphCacheKey};
+use crate::annotator::model::{SomeInstance, SomeValue};
+use crate::annotator::signature::{ParamType, TypeMarker};
 use crate::flowspace::argument::Signature;
 use crate::flowspace::model::{ConstValue, Constant, GraphFunc, HostObject};
 use crate::flowspace::pygraph::PyGraph;
@@ -97,6 +99,27 @@ impl FunctionPathKey {
     pub fn name(&self) -> &str {
         self.0.last().map(|s| s.as_str()).unwrap_or("")
     }
+}
+
+/// Whether `name` is one of the residual ABI shims that materialises the
+/// Python exception object carried by an `OperationError`.
+///
+/// Their Rust signatures use `*mut PyObject` so the residual trampoline stays
+/// one-word-in/one-word-out, but the value visible to the translated
+/// interpreter is an exception *instance*.  This is the same distinction
+/// RPython's `_signature_` makes between a low-level ABI spelling and the
+/// annotator-level result.
+pub(crate) fn is_exception_object_materializer(name: &str) -> bool {
+    matches!(
+        name,
+        "pyerror_to_exc_object" | "pyerror_type_error_to_exc_object"
+    )
+}
+
+/// The annotator-level result shared by the exception materialisers'
+/// `_signature_` and their `dont_look_inside` stub graph.
+pub(crate) fn exception_object_result_annotation() -> SomeValue {
+    SomeValue::Instance(SomeInstance::new(None, false, Default::default()))
 }
 
 /// Per-path registry entry.  Each entry owns:
@@ -457,7 +480,9 @@ impl CallRegistry {
                 continue;
             }
             let qualified_owner = segs[..segs.len() - 1].join("::");
-            if reg.fields.contains_key(&qualified_owner) {
+            if reg.fields.contains_key(&qualified_owner)
+                && !reg.owner_or_variant_has_field(&qualified_owner, method)
+            {
                 let class_host = self.bookkeeper.intern_class_by_qualname(&qualified_owner);
                 class_host.class_set(
                     method.clone(),
@@ -468,6 +493,9 @@ impl CallRegistry {
                 continue;
             }
             if leaf_struct_counts.get(owner.as_str()).copied().unwrap_or(0) > 1 {
+                continue;
+            }
+            if reg.owner_or_variant_has_field(owner, method) {
                 continue;
             }
             let class_host = self.bookkeeper.intern_class_by_qualname(owner);
@@ -885,14 +913,38 @@ impl CallRegistry {
             Constant::new(ConstValue::Dict(HashMap::new())),
         );
         let host_object = HostObject::new_user_function(graph_func);
-        let function_desc = Rc::new(RefCell::new(FunctionDesc::new(
+        let exception_object_result = is_exception_object_materializer(key.name());
+        let signature_arg_count = signature.argnames.len();
+        let mut function_desc = FunctionDesc::new(
             self.bookkeeper.clone(),
             Some(host_object.clone()),
             name,
             signature,
             None,
             None,
-        )));
+        );
+        if exception_object_result {
+            // These two `dont_look_inside` functions use raw pointers only
+            // for Rust's one-word residual-call ABI.  Semantically they
+            // return the normalized exception instance carried by
+            // `OperationError`, which is an RPython `SomeInstance` and whose
+            // low-level representation is still `OBJECTPTR`.
+            //
+            // Express that distinction through RPython's own `_signature_`
+            // path (`description.py FunctionDesc.pycall`): arguments remain
+            // unconstrained, while the result is the classdef-less root
+            // instance.  This lets `op.type(evalue)` dispatch through
+            // `InstanceRepr.rtype_type`, as it does upstream, without
+            // inventing a `PtrRepr.rtype_type` operation that RPython does
+            // not have.
+            function_desc.annsignature = Some(Rc::new(AnnSignature {
+                params: (0..signature_arg_count)
+                    .map(|_| ParamType::Marker(TypeMarker::AnyType))
+                    .collect(),
+                result: ParamType::Annotation(Box::new(exception_object_result_annotation())),
+            }));
+        }
+        let function_desc = Rc::new(RefCell::new(function_desc));
         // Pre-register in bookkeeper.descs so the rtyper's
         // getdesc(host_object) lookup short-circuits at the cache.
         self.bookkeeper.descs.borrow_mut().insert(
@@ -1080,6 +1132,42 @@ mod tests {
              through the is_user_function() arm (bookkeeper.rs:955-956)"
         );
         assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn exception_materializers_publish_instance_result_signature() {
+        let bk = Rc::new(Bookkeeper::new());
+        let registry = CallRegistry::new(bk);
+        for leaf in ["pyerror_to_exc_object", "pyerror_type_error_to_exc_object"] {
+            let entry = registry.get_or_register(
+                FunctionPathKey::from_segments(["pyre_interpreter", "error", leaf]),
+                signature(&["arg"]),
+            );
+            let fd = entry.function_desc.borrow();
+            let annsig = fd
+                .annsignature
+                .as_ref()
+                .expect("exception materializer needs an annotation signature");
+            assert_eq!(annsig.params.len(), 1);
+            assert!(matches!(
+                annsig.params[0],
+                ParamType::Marker(TypeMarker::AnyType)
+            ));
+            let ParamType::Annotation(result) = &annsig.result else {
+                panic!("exception materializer result must be an explicit annotation");
+            };
+            let SomeValue::Instance(instance) = result.as_ref() else {
+                panic!("exception materializer result must be SomeInstance");
+            };
+            assert!(instance.classdef.is_none());
+            assert!(!instance.can_be_none);
+        }
+
+        let ordinary = registry.get_or_register(
+            FunctionPathKey::from_segments(["pyre_interpreter", "other"]),
+            signature(&["arg"]),
+        );
+        assert!(ordinary.function_desc.borrow().annsignature.is_none());
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1045,76 +1045,73 @@ fn switch_discriminant_read_vars(graph: &LegacyGraph) -> std::collections::HashS
     out
 }
 
-/// Results of a variant-payload `FieldRead` whose *only* op consumer is a
-/// `FieldWrite` of the same field name — the extract-then-repack of an
+/// Results of a variant-payload `FieldRead` whose *only* op consumer is the
+/// value position of a `FieldWrite` — the extract-then-repack of an
 /// identity `match` re-wrap (`match step { Return(v) => Ok(Return(v)),
 /// CloseLoop { jump_args, loop_header_pc } => Ok(CloseLoop { .. }), … }`,
 /// `pyopcode.rs:1945`).  Each arm reads the incoming variant's payload
 /// (`FieldRead("__pos_0" | "loop_header_pc", owner = StepResult::Variant)`)
 /// and immediately writes it into a freshly-built outgoing variant
-/// (`FieldWrite(same field, owner = StepResult<…>::Variant)`).
+/// (`FieldWrite(_, owner = StepResult<…>::Variant)`).  Rust tuple variants
+/// can rename the storage field while preserving the value — notably
+/// `Option::Some.__pos_0` → `StepResult::CloseLoop.jump_args` — so field-name
+/// equality is not part of the identity relation.
 ///
 /// The real path lowers the enclosing `Result` through the uniform
 /// exception-transform (`front/result_exc.rs`), which recognises the `Ok(step)`
 /// identity and **elides** the whole extract-repack, so the legacy read result
 /// is never typed under its own Variable identity (`real=None`) — the same
 /// rebuilt-block artifact as [`switch_discriminant_read_vars`], for the payload
-/// projection rather than the tag.  Requiring the sole op-use to be a same-name
-/// `FieldWrite` keeps this from over-reaching a payload the arm actually
-/// consumes (a non-identity `match` that transforms the value flows the read
-/// into some other op, so it is excluded).
+/// projection rather than the tag.  Requiring the sole op-use to be the raw
+/// value operand of a `FieldWrite` keeps this from over-reaching a payload the
+/// arm actually consumes: any transform or call is another op-use and excludes
+/// the candidate.
 #[expect(
     clippy::mutable_key_type,
     reason = "Eq and Hash use immutable identity/value data; interior mutation is excluded, matching RPython identity-keyed dict semantics"
 )]
 fn repack_payload_read_vars(graph: &LegacyGraph) -> std::collections::HashSet<Variable> {
     use crate::model::OpKind;
-    // For each candidate FieldRead result, the field name it reads.
-    let mut read_field: HashMap<Variable, String> = HashMap::new();
+    let mut read_results = std::collections::HashSet::new();
     for block in &graph.blocks {
         for op in &block.operations {
             if let (Some(r), OpKind::FieldRead { field, .. }) = (&op.result, &op.kind)
                 && field.name != "__discriminant"
             {
-                read_field.insert(r.clone(), field.name.clone());
+                read_results.insert(r.clone());
             }
         }
     }
-    if read_field.is_empty() {
+    if read_results.is_empty() {
         return std::collections::HashSet::new();
     }
     // Tally every op-use of each candidate: `repack` counts a use as the
-    // `value` operand of a same-field `FieldWrite`; `other` counts any other
-    // op-use.  A candidate survives only when it has ≥1 repack use and no
-    // other use (a genuinely consumed payload has an `other` use).
-    let mut repack_use: HashMap<Variable, bool> = HashMap::new();
+    // `value` operand of a `FieldWrite`; `other` counts any other op-use. A
+    // candidate survives only when it has ≥1 repack use and no other use.
+    let mut repack_use = std::collections::HashSet::new();
     let mut other_use: std::collections::HashSet<Variable> = std::collections::HashSet::new();
     for block in &graph.blocks {
         for op in &block.operations {
-            // A same-field `FieldWrite` value operand is the repack use; the
-            // `base` operand (the target struct) is a different use and is
-            // handled by the generic operand scan below.
+            // A `FieldWrite` value operand is the repack use; the base operand
+            // is handled by the generic operand scan below.
             if let OpKind::FieldWrite {
-                field,
                 value: crate::model::LinkArg::Value(v),
                 ..
             } = &op.kind
-                && let Some(read_name) = read_field.get(v)
-                && *read_name == field.name
+                && read_results.contains(v)
             {
-                repack_use.insert(v.clone(), true);
+                repack_use.insert(v.clone());
             }
             for used in crate::front::result_exc::op_operand_vars(&op.kind) {
-                if !read_field.contains_key(&used) {
+                if !read_results.contains(&used) {
                     continue;
                 }
-                // Re-derive whether THIS op is the matching same-field
-                // `FieldWrite` value use; every other operand position counts
-                // as an `other` use that disqualifies the candidate.
+                // Every position other than the FieldWrite's raw value is an
+                // actual use that disqualifies the candidate.
                 let is_repack_value = matches!(
                     &op.kind,
-                    OpKind::FieldWrite { field, value: crate::model::LinkArg::Value(vv), .. }
-                        if vv == &used && read_field.get(&used) == Some(&field.name)
+                    OpKind::FieldWrite { value: crate::model::LinkArg::Value(vv), .. }
+                        if vv == &used
                 );
                 if !is_repack_value {
                     other_use.insert(used);
@@ -1122,9 +1119,9 @@ fn repack_payload_read_vars(graph: &LegacyGraph) -> std::collections::HashSet<Va
             }
         }
     }
-    read_field
-        .into_keys()
-        .filter(|v| repack_use.contains_key(v) && !other_use.contains(v))
+    read_results
+        .into_iter()
+        .filter(|v| repack_use.contains(v) && !other_use.contains(v))
         .collect()
 }
 
@@ -3368,6 +3365,7 @@ fn drive_subject(
 
     if do_rtype {
         select_rtyped_representatives(&mut value_to_var, &value_to_var_candidates)?;
+        reconcile_projection_aliases(legacy, &mut value_to_var);
     }
     Ok((
         graph,
@@ -4035,6 +4033,135 @@ fn run_phase_b_rtype_isolated(
     // lands, take()+finish() rtyper.annmixlevel here.
 }
 
+/// Reconnect a legacy [`crate::model::OpKind::Hint`] result to the typed
+/// representative of its operand when the real path removed the result
+/// identity.
+///
+/// The flowspace adapter emits `same_as(value)` for a Hint
+/// (`flowspace_adapter.rs`), and RPython's rtyper treats `same_as` as an
+/// internal rename.  Its JIT codewriter then returns `None` from
+/// `rewrite_op_hint` specifically to force `op.result` equal to `op.args[0]`
+/// (`rpython/jit/codewriter/jtransform.py:608-614`).  The typed graph can
+/// therefore contain only the operand representative while the legacy graph
+/// still names the result.  Restoring that alias in the existing adapter map
+/// preserves the one upstream value; it does not invent a type or suppress a
+/// genuine kind conflict.  An already-typed result mapping wins; an adapter
+/// placeholder whose `concretetype` is still empty is the erased identity and
+/// is replaced.
+#[expect(
+    clippy::mutable_key_type,
+    reason = "Eq and Hash use immutable identity/value data; interior mutation is excluded, matching RPython identity-keyed dict semantics"
+)]
+fn reconcile_elided_hint_results(legacy: &LegacyGraph, value_to_var: &mut LegacyToTyped) {
+    for block in &legacy.blocks {
+        for op in &block.operations {
+            let crate::model::OpKind::Hint { value, .. } = &op.kind else {
+                continue;
+            };
+            let Some(result) = &op.result else {
+                continue;
+            };
+            if value_to_var
+                .get(result)
+                .is_some_and(|typed| typed.concretetype().is_some())
+            {
+                continue;
+            }
+            let Some(operand_twin) = value_to_var.get(value).cloned() else {
+                continue;
+            };
+            value_to_var.insert(result.clone(), operand_twin);
+        }
+    }
+}
+
+/// Reconnect a block inputarg to the typed representative shared by all of
+/// its incoming phi arguments when flowspace simplification removed the
+/// inputarg identity.
+///
+/// RPython `remove_identical_vars_SSA` unions an input with its incoming
+/// value when every `phi_arg` has the same union-find representative
+/// (`rpython/translator/simplify.py:548-601`).  A one-predecessor phi is the
+/// common case.  `join_blocks` performs the same rename while merging a
+/// linear edge (`simplify.py:271-315`).  The adapter map predates those
+/// mutations, so its original inputarg twin may remain untyped even though
+/// every surviving operation was renamed to the predecessor's typed value.
+///
+/// Reproduce only that upstream identity relation in the projection map:
+/// every incoming argument must be a Variable, already have a positively
+/// typed representative, and resolve to the exact same representative.
+/// Conflicting phi inputs and already-typed inputargs are left untouched.
+/// Iterate to a fixpoint because upstream's union-find collapses chains of
+/// single-predecessor blocks transitively.
+#[expect(
+    clippy::mutable_key_type,
+    reason = "Eq and Hash use immutable identity/value data; interior mutation is excluded, matching RPython identity-keyed dict semantics"
+)]
+fn reconcile_elided_phi_inputargs(legacy: &LegacyGraph, value_to_var: &mut LegacyToTyped) {
+    loop {
+        let mut aliases = Vec::new();
+        for target in &legacy.blocks {
+            if target.id == legacy.startblock
+                || target.id == legacy.returnblock
+                || target.id == legacy.exceptblock
+            {
+                continue;
+            }
+            for (column, input) in target.inputargs.iter().enumerate() {
+                if value_to_var
+                    .get(input)
+                    .is_some_and(|typed| typed.concretetype().is_some())
+                {
+                    continue;
+                }
+                let mut saw_incoming = false;
+                let mut shared: Option<Variable> = None;
+                let mut valid = true;
+                for source in &legacy.blocks {
+                    for link in source.exits.iter().filter(|link| link.target == target.id) {
+                        saw_incoming = true;
+                        let Some(crate::model::LinkArg::Value(source_var)) = link.args.get(column)
+                        else {
+                            valid = false;
+                            break;
+                        };
+                        let Some(source_typed) = value_to_var
+                            .get(source_var)
+                            .filter(|typed| typed.concretetype().is_some())
+                        else {
+                            valid = false;
+                            break;
+                        };
+                        if shared
+                            .as_ref()
+                            .is_some_and(|representative| representative != source_typed)
+                        {
+                            valid = false;
+                            break;
+                        }
+                        shared.get_or_insert_with(|| source_typed.clone());
+                    }
+                    if !valid {
+                        break;
+                    }
+                }
+                if valid
+                    && saw_incoming
+                    && let Some(shared) = shared
+                {
+                    aliases.push((input.clone(), shared));
+                }
+            }
+        }
+        if aliases.is_empty() {
+            break;
+        }
+        for (input, shared) in aliases {
+            value_to_var.insert(input, shared);
+        }
+    }
+}
+
 /// Backfill the low-level type of a call-result Variable the real path
 /// left untyped, from the front-end `OpKind::Call { result_ty }` the
 /// call site declared.
@@ -4053,12 +4180,19 @@ fn run_phase_b_rtype_isolated(
 ///
 /// Mirror that single rule into the real path so the two converge: for a
 /// call result whose declared `result_ty` projects to `GcRef`, stamp the
-/// canonical `GCREF` pointer onto the twin.  Scoped to `Ref` only — an
-/// `Int`/`Float`/`Void` *declared* result (`result_ty`) is a genuine kind
-/// question, not the erased-pointer gap, and `GcRef` is the sole kind
-/// whose value is unconditionally colorable (the `Void` slot has no
-/// regalloc class — see the `collect_divergences` `object_key_for_checked`
-/// note).
+/// canonical `GCREF` pointer onto the twin.
+///
+/// One equally erased scalar shape is admitted, but only at the producer
+/// which proves it: `front::option_closure_select` replaces
+/// `Option::unwrap_or_else` with the direct discriminant diamond RPython's
+/// closure-free source would have built and synthesizes a closure
+/// `call_once` in the `None` arm.  Charon retains the concrete `FnOnce::Output`
+/// as that op's `result_ty` but does not monomorphize it into the registered
+/// closure method, so the real rtyper can default the live result to `Void`.
+/// For that synthesized closure call alone, carry a declared `Signed` or
+/// `Float` result onto the twin.  An ordinary scalar call is deliberately not
+/// covered: its `Signed`/`Float` versus `Void` pairing remains a genuine kind
+/// divergence and falls back to legacy.
 ///
 /// Overrides both the untyped (`None`) twin and a twin the rtyper
 /// collapsed to `Void`: a call the front-end declared pointer-returning
@@ -4069,8 +4203,8 @@ fn run_phase_b_rtype_isolated(
 /// projection to unit.  It would otherwise be colored by
 /// `emit_call_result_arg` (the op's declared non-void `result_kind`
 /// forces the `>X` result argcode, `assembler.rs:2226`) and panic in
-/// `lookup_coloring`.  A twin the rtyper *positively* typed `Signed` /
-/// `Float` is left untouched — that is a real kind conflict → Skip.
+/// `lookup_coloring`.  A twin the rtyper positively typed to another non-void
+/// kind is left untouched — that is a real kind conflict → Skip.
 #[expect(
     clippy::mutable_key_type,
     reason = "Eq and Hash use immutable identity/value data; interior mutation is excluded, matching RPython identity-keyed dict semantics"
@@ -4079,12 +4213,34 @@ fn backfill_untyped_call_results(legacy: &LegacyGraph, value_to_var: &LegacyToTy
     use crate::translator::rtyper::lltypesystem::lltype::GCREF;
     for block in &legacy.blocks {
         for op in &block.operations {
-            let crate::model::OpKind::Call { result_ty, .. } = &op.kind else {
+            let crate::model::OpKind::Call {
+                target, result_ty, ..
+            } = &op.kind
+            else {
                 continue;
             };
-            if valuetype_to_concrete(result_ty) != ConcreteType::GcRef {
+            let declared_kind = valuetype_to_concrete(result_ty);
+            let closure_call_once = matches!(
+                target,
+                crate::model::CallTarget::Method {
+                    name,
+                    receiver_root: Some(root),
+                    ..
+                } if name == "call_once"
+                    && root.rsplit("::").next().is_some_and(
+                        majit_charon_reader::ullbc::is_closure_leaf
+                    )
+            );
+            let declared_lltype = match declared_kind {
+                ConcreteType::GcRef => Some(GCREF.clone()),
+                ConcreteType::Signed | ConcreteType::Float if closure_call_once => {
+                    crate::model::concrete_to_canonical_lltype(declared_kind)
+                }
+                _ => None,
+            };
+            let Some(declared_lltype) = declared_lltype else {
                 continue;
-            }
+            };
             let Some(legacy_result) = &op.result else {
                 continue;
             };
@@ -4095,10 +4251,22 @@ fn backfill_untyped_call_results(legacy: &LegacyGraph, value_to_var: &LegacyToTy
                 .concretetype()
                 .map(|lltype| lowleveltype_to_concrete(&lltype).unwrap_or(ConcreteType::Unknown));
             if matches!(twin_kind, None | Some(ConcreteType::Void)) {
-                typed.set_concretetype(Some(GCREF.clone()));
+                typed.set_concretetype(Some(declared_lltype));
             }
         }
     }
+}
+
+/// Apply projection repairs in dependency order.
+///
+/// Declared call results and `same_as` hints are phi sources in real portal
+/// graphs, so their representatives must be recovered before the transitive
+/// phi-union pass.  Keeping the order here prevents the direct and cached
+/// dual-gate paths from drifting apart.
+fn reconcile_projection_aliases(legacy: &LegacyGraph, value_to_var: &mut LegacyToTyped) {
+    backfill_untyped_call_results(legacy, value_to_var);
+    reconcile_elided_hint_results(legacy, value_to_var);
+    reconcile_elided_phi_inputargs(legacy, value_to_var);
 }
 
 /// Two-phase publish: derive the [`DualGateOutcome`] for `legacy` from the
@@ -4139,6 +4307,7 @@ pub(crate) fn dual_gate_outcome_from_cache(
     };
     select_rtyped_representatives(&mut value_to_var, &value_to_var_candidates)
         .map_err(|e| e.to_string())?;
+    reconcile_projection_aliases(legacy, &mut value_to_var);
 
     // Validate the cached lltypes project to concrete kinds (the Step-4 check
     // deferred from `drive_subject`, which did not rtype in Phase A).
@@ -4159,13 +4328,6 @@ pub(crate) fn dual_gate_outcome_from_cache(
             ));
         }
     }
-
-    // Carry the front-end call `result_ty` into the real path: stamp the
-    // canonical `GCREF` onto call results the rtyper left untyped because
-    // Charon erased their generic `<E>::Value` associated return type. This
-    // mirrors the legacy walker's identical `result_ty`-driven typing so the
-    // two paths converge instead of diverging at `real=Unknown`.
-    backfill_untyped_call_results(legacy, &value_to_var);
 
     // Legacy-baseline comparison oracle (the `dual_gate_check_with_registry`
     // pattern): the real path is trusted only when it agrees with the proven
@@ -4238,6 +4400,197 @@ mod tests {
         vids: &[usize],
     ) -> Vec<crate::flowspace::model::Variable> {
         vids.iter().map(|&i| vars[i].clone()).collect()
+    }
+
+    fn hint_alias_fixture() -> (LegacyGraph, Variable, Variable, LegacyToTyped) {
+        let mut graph = LegacyGraph::new("hint_alias_fixture");
+        let value = graph.alloc_value_var();
+        let result = graph.alloc_value_var();
+        let startblock = graph.startblock;
+        graph
+            .block_mut(startblock)
+            .operations
+            .push(crate::model::SpaceOperation {
+                result: Some(result.clone()),
+                kind: crate::model::OpKind::Hint {
+                    value: value.clone(),
+                    kind: crate::hints::HintKind::Promote,
+                },
+            });
+        let typed_value = Variable::new();
+        typed_value.set_concretetype(Some(
+            crate::translator::rtyper::lltypesystem::lltype::GCREF.clone(),
+        ));
+        let value_to_var = HashMap::from([(value, typed_value.clone())]);
+        (graph, result, typed_value, value_to_var)
+    }
+
+    #[test]
+    fn reconcile_elided_hint_results_reuses_the_operand_representative() {
+        let (graph, result, typed_value, mut value_to_var) = hint_alias_fixture();
+        reconcile_elided_hint_results(&graph, &mut value_to_var);
+        assert_eq!(
+            value_to_var.get(&result),
+            Some(&typed_value),
+            "RPython's same_as elimination must preserve one representative for value and result"
+        );
+    }
+
+    #[test]
+    fn reconcile_elided_hint_results_replaces_an_untyped_placeholder() {
+        let (graph, result, typed_value, mut value_to_var) = hint_alias_fixture();
+        value_to_var.insert(result.clone(), Variable::new());
+        reconcile_elided_hint_results(&graph, &mut value_to_var);
+        assert_eq!(
+            value_to_var.get(&result),
+            Some(&typed_value),
+            "an empty same_as result twin is the erased alias, not an authoritative type"
+        );
+    }
+
+    #[test]
+    fn reconcile_elided_hint_results_preserves_an_existing_result_mapping() {
+        let (graph, result, _typed_value, mut value_to_var) = hint_alias_fixture();
+        let typed_result = Variable::new();
+        typed_result.set_concretetype(Some(LowLevelType::Signed));
+        value_to_var.insert(result.clone(), typed_result.clone());
+        reconcile_elided_hint_results(&graph, &mut value_to_var);
+        assert_eq!(
+            value_to_var.get(&result),
+            Some(&typed_result),
+            "an independently typed result is authoritative and must not be overwritten"
+        );
+    }
+
+    #[test]
+    fn reconcile_elided_phi_inputargs_follows_a_transitive_single_predecessor_chain() {
+        let mut graph = LegacyGraph::new("phi_alias_chain");
+        let source = graph.alloc_value_var();
+        graph.block_mut(graph.startblock).inputargs = vec![source.clone()];
+        let (middle_id, middle_args) = graph.create_block_with_arg_vars(1);
+        let middle = middle_args[0].clone();
+        let (tail_id, tail_args) = graph.create_block_with_arg_vars(1);
+        let tail = tail_args[0].clone();
+        graph.block_mut(graph.startblock).exits = vec![crate::model::Link::new_mixed(
+            vec![LinkArg::Value(source.clone())],
+            middle_id,
+            None,
+        )];
+        graph.block_mut(middle_id).exits = vec![crate::model::Link::new_mixed(
+            vec![LinkArg::Value(middle.clone())],
+            tail_id,
+            None,
+        )];
+
+        let typed_source = Variable::new();
+        typed_source.set_concretetype(Some(
+            crate::translator::rtyper::lltypesystem::lltype::GCREF.clone(),
+        ));
+        let mut value_to_var = HashMap::from([
+            (source, typed_source.clone()),
+            (middle.clone(), Variable::new()),
+            (tail.clone(), Variable::new()),
+        ]);
+
+        reconcile_elided_phi_inputargs(&graph, &mut value_to_var);
+        assert_eq!(value_to_var.get(&middle), Some(&typed_source));
+        assert_eq!(value_to_var.get(&tail), Some(&typed_source));
+    }
+
+    #[test]
+    fn reconcile_elided_phi_inputargs_requires_one_shared_representative() {
+        let mut graph = LegacyGraph::new("phi_alias_conflict");
+        let left = graph.alloc_value_var();
+        let right = graph.alloc_value_var();
+        graph.block_mut(graph.startblock).inputargs = vec![left.clone(), right.clone()];
+        let (target_id, target_args) = graph.create_block_with_arg_vars(1);
+        let target = target_args[0].clone();
+        graph.block_mut(graph.startblock).exits = vec![
+            crate::model::Link::new_mixed(vec![LinkArg::Value(left.clone())], target_id, None),
+            crate::model::Link::new_mixed(vec![LinkArg::Value(right.clone())], target_id, None),
+        ];
+        let typed_left = Variable::new();
+        typed_left.set_concretetype(Some(
+            crate::translator::rtyper::lltypesystem::lltype::GCREF.clone(),
+        ));
+        let typed_right = Variable::new();
+        typed_right.set_concretetype(Some(
+            crate::translator::rtyper::lltypesystem::lltype::GCREF.clone(),
+        ));
+        let untyped_target = Variable::new();
+        let mut value_to_var = HashMap::from([
+            (left, typed_left),
+            (right, typed_right),
+            (target.clone(), untyped_target.clone()),
+        ]);
+
+        reconcile_elided_phi_inputargs(&graph, &mut value_to_var);
+        assert_eq!(
+            value_to_var.get(&target),
+            Some(&untyped_target),
+            "same kind is insufficient: upstream unions exact phi representatives"
+        );
+    }
+
+    fn backfill_call_result_fixture(
+        target: crate::model::CallTarget,
+        result_ty: ValueType,
+    ) -> (LegacyGraph, Variable, LegacyToTyped) {
+        let mut graph = LegacyGraph::new("backfill_call_result_fixture");
+        let result = graph.alloc_value_var();
+        graph
+            .block_mut(graph.startblock)
+            .operations
+            .push(crate::model::SpaceOperation {
+                result: Some(result.clone()),
+                kind: crate::model::OpKind::Call {
+                    target,
+                    args: Vec::new(),
+                    result_ty,
+                },
+            });
+        let typed = Variable::new();
+        typed.set_concretetype(Some(LowLevelType::Void));
+        let value_to_var = HashMap::from([(result.clone(), typed)]);
+        (graph, result, value_to_var)
+    }
+
+    #[test]
+    fn backfill_untyped_call_results_carries_synthesized_closure_scalar_output() {
+        for (result_ty, expected) in [
+            (ValueType::Int, ConcreteType::Signed),
+            (ValueType::Float, ConcreteType::Float),
+        ] {
+            let (graph, result, value_to_var) = backfill_call_result_fixture(
+                crate::model::CallTarget::method(
+                    "call_once",
+                    Some("module::function::closure#2".to_string()),
+                ),
+                result_ty,
+            );
+            backfill_untyped_call_results(&graph, &value_to_var);
+            assert_eq!(
+                kind_of_in(&value_to_var, &result),
+                expected,
+                "the closure's declared FnOnce::Output must survive Charon erasure"
+            );
+        }
+    }
+
+    #[test]
+    fn backfill_untyped_call_results_leaves_ordinary_scalar_conflict_visible() {
+        let (graph, result, value_to_var) = backfill_call_result_fixture(
+            crate::model::CallTarget::FunctionPath {
+                segments: vec!["ordinary_scalar_call".to_string()],
+            },
+            ValueType::Int,
+        );
+        backfill_untyped_call_results(&graph, &value_to_var);
+        assert_eq!(
+            kind_of_in(&value_to_var, &result),
+            ConcreteType::Void,
+            "an ordinary Signed/Void conflict must still reach the dual-gate divergence"
+        );
     }
 
     #[test]
@@ -4929,7 +5282,7 @@ mod tests {
     }
 
     /// Build a single block that reads `base.field` into `pay` and, when
-    /// `repack` is set, writes `pay` back into `dst.field` (the extract→repack
+    /// `repack` is set, writes `pay` into `dst.jump_args` (the extract→repack
     /// of an identity `match` re-wrap).  With `repack=false` the read result
     /// is instead fed to a `Call` (a genuine consumer), so it is NOT a repack
     /// payload.
@@ -4963,7 +5316,7 @@ mod tests {
                 kind: crate::model::OpKind::FieldWrite {
                     base: dst.clone(),
                     field: crate::model::FieldDescriptor {
-                        name: "loop_header_pc".to_string(),
+                        name: "jump_args".to_string(),
                         owner_root: Some(
                             "pyre_interpreter::pyopcode::StepResult<*mut PyObject>::CloseLoop"
                                 .to_string(),
@@ -5024,14 +5377,14 @@ mod tests {
     }
 
     #[test]
-    fn repack_payload_read_vars_classifies_only_same_field_writeback() {
-        // A payload read whose sole consumer is a same-field `FieldWrite` is
-        // the extract→repack artifact and is classified; the same read fed to
-        // any other op (here a `Call`) is a genuine use and is NOT classified.
+    fn repack_payload_read_vars_classifies_cross_variant_writeback() {
+        // A payload read whose sole consumer is a `FieldWrite` remains the raw
+        // extract→repack value even when Rust's destination variant renames
+        // the field; the same read fed to a Call is a genuine use.
         let (repack_graph, pay_r, _) = build_payload_graph(true);
         assert!(
             repack_payload_read_vars(&repack_graph).contains(&pay_r),
-            "a payload read consumed only by a same-field FieldWrite is classified"
+            "a payload read consumed only by a cross-variant FieldWrite is classified"
         );
         let (consumed_graph, pay_c, _) = build_payload_graph(false);
         assert!(

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1128,6 +1128,93 @@ fn repack_payload_read_vars(graph: &LegacyGraph) -> std::collections::HashSet<Va
         .collect()
 }
 
+/// Variant-carrier input Variables whose only observable work is the
+/// extract→repack payload reads classified by
+/// [`repack_payload_read_vars`].  The Result/StepResult exception transform
+/// elides the entire identity arm, including this block-local carrier, so the
+/// real flowspace graph has neither a typed representative for the carrier nor
+/// for its payload reads.  This is the inputarg counterpart of the payload
+/// result identity reconciliation above.
+///
+/// Keep the classification structural and narrow: every op-use of the carrier
+/// must be as the base of an already-classified payload read, it must not feed
+/// an exitswitch, and it must not be forwarded by a link.  A carrier used by
+/// any real computation therefore remains a divergence.  This mirrors the
+/// identity removal performed by the upstream-style flowspace simplification;
+/// it does not assign a type or invent a parallel side table.
+#[expect(
+    clippy::mutable_key_type,
+    reason = "Eq and Hash use immutable identity/value data; interior mutation is excluded, matching RPython identity-keyed dict semantics"
+)]
+fn repack_payload_carrier_vars(graph: &LegacyGraph) -> std::collections::HashSet<Variable> {
+    use crate::model::{ExitSwitch, LinkArg, OpKind};
+
+    let payloads = repack_payload_read_vars(graph);
+    let block_inputargs: std::collections::HashSet<_> = graph
+        .blocks
+        .iter()
+        .filter(|block| {
+            block.id != graph.startblock
+                && block.id != graph.returnblock
+                && block.id != graph.exceptblock
+        })
+        .flat_map(|block| block.inputargs.iter().cloned())
+        .collect();
+    let mut carriers = std::collections::HashSet::new();
+    for block in &graph.blocks {
+        for op in &block.operations {
+            if let (Some(result), OpKind::FieldRead { base, field, .. }) = (&op.result, &op.kind)
+                && field.name != "__discriminant"
+                && payloads.contains(result)
+                && block_inputargs.contains(base)
+            {
+                carriers.insert(base.clone());
+            }
+        }
+    }
+    if carriers.is_empty() {
+        return carriers;
+    }
+
+    let mut disqualified = std::collections::HashSet::new();
+    for block in &graph.blocks {
+        for op in &block.operations {
+            for used in crate::front::result_exc::op_operand_vars(&op.kind) {
+                if !carriers.contains(&used) {
+                    continue;
+                }
+                let is_elided_payload_base = matches!(
+                    (&op.result, &op.kind),
+                    (Some(result), OpKind::FieldRead { base, field, .. })
+                        if base == &used
+                            && field.name != "__discriminant"
+                            && payloads.contains(result)
+                );
+                if !is_elided_payload_base {
+                    disqualified.insert(used);
+                }
+            }
+        }
+        match &block.exitswitch {
+            Some(ExitSwitch::Value(var)) if carriers.contains(var) => {
+                disqualified.insert(var.clone());
+            }
+            Some(ExitSwitch::Fused { args, .. }) => {
+                disqualified.extend(args.iter().filter(|var| carriers.contains(*var)).cloned());
+            }
+            _ => {}
+        }
+        for link in &block.exits {
+            disqualified.extend(link.args.iter().filter_map(|arg| match arg {
+                LinkArg::Value(var) if carriers.contains(var) => Some(var.clone()),
+                _ => None,
+            }));
+        }
+    }
+    carriers.retain(|var| !disqualified.contains(var));
+    carriers
+}
+
 /// Whether an op's result may be dropped when unread, mirroring RPython's
 /// `transform_dead_op_vars` `canremove(op, block)` gate (`simplify.py`):
 /// only side-effect-free ops (`op.opname in CanRemove`) have their result
@@ -1190,6 +1277,7 @@ fn collect_divergences(
     let dead_op_results = dead_op_result_vars(legacy_graph);
     let switch_discriminant_reads = switch_discriminant_read_vars(legacy_graph);
     let repack_payload_reads = repack_payload_read_vars(legacy_graph);
+    let repack_payload_carriers = repack_payload_carrier_vars(legacy_graph);
     let mut divergences = Vec::new();
     for (pos, var) in legacy_graph.iter_variables().iter().enumerate() {
         // `iterblocks()` parity: the real path annotates only the
@@ -1319,6 +1407,11 @@ fn collect_divergences(
         // [`repack_payload_read_vars`].
         let real_elided_repack_payload =
             real_present.is_none() && repack_payload_reads.contains(var);
+        // The block-local variant carrier feeding only the elided payload
+        // reads disappears with the same identity arm.  It has no typed twin,
+        // but no surviving real-path operation consumes it either.
+        let real_elided_repack_carrier =
+            real_present.is_none() && repack_payload_carriers.contains(var);
         let diverges = if real_refines_gcref_to_void
             || real_refines_gcref_to_signed
             || real_refines_gcref_to_float
@@ -1326,6 +1419,7 @@ fn collect_divergences(
             || real_dropped_dead_op_result
             || real_rebuilt_switch_discriminant
             || real_elided_repack_payload
+            || real_elided_repack_carrier
         {
             false
         } else if legacy_kind != ConcreteType::Unknown {
@@ -4839,12 +4933,14 @@ mod tests {
     /// of an identity `match` re-wrap).  With `repack=false` the read result
     /// is instead fed to a `Call` (a genuine consumer), so it is NOT a repack
     /// payload.
-    fn build_payload_graph(repack: bool) -> (LegacyGraph, Variable) {
+    fn build_payload_graph(repack: bool) -> (LegacyGraph, Variable, Variable) {
         let mut graph = LegacyGraph::new("payload_probe");
-        let vars = mint_vars(&mut graph, 4);
-        let base = vars[0].clone();
-        let pay = vars[1].clone();
-        let dst = vars[2].clone();
+        let vars = mint_vars(&mut graph, 5);
+        let source = vars[0].clone();
+        let base = vars[1].clone();
+        let pay = vars[2].clone();
+        let dst = vars[3].clone();
+        let mid_id = crate::model::BlockId(7);
         let field = crate::model::FieldDescriptor {
             name: "loop_header_pc".to_string(),
             owner_root: Some("StepResult::CloseLoop".to_string()),
@@ -4892,17 +4988,39 @@ mod tests {
                 },
             }
         };
-        let block = Block {
+        let startblock = Block {
             id: graph.startblock,
             inputargs: block_inputargs(&vars, &[0]),
+            operations: vec![],
+            exitswitch: None,
+            exits: vec![crate::model::Link::new_mixed(
+                vec![LinkArg::Value(source)],
+                mid_id,
+                None,
+            )],
+            framestate: None,
+            dead: false,
+        };
+        let midblock = Block {
+            id: mid_id,
+            inputargs: block_inputargs(&vars, &[1]),
             operations: vec![read, consumer],
             exitswitch: None,
             exits: vec![link_to_returnblock(vec![], graph.returnblock)],
             framestate: None,
             dead: false,
         };
-        graph.blocks = vec![block];
-        (graph, pay)
+        let returnblock = Block {
+            id: graph.returnblock,
+            inputargs: vec![],
+            operations: vec![],
+            exitswitch: None,
+            exits: vec![],
+            framestate: None,
+            dead: false,
+        };
+        graph.blocks = vec![startblock, midblock, returnblock];
+        (graph, pay, base)
     }
 
     #[test]
@@ -4910,15 +5028,55 @@ mod tests {
         // A payload read whose sole consumer is a same-field `FieldWrite` is
         // the extract→repack artifact and is classified; the same read fed to
         // any other op (here a `Call`) is a genuine use and is NOT classified.
-        let (repack_graph, pay_r) = build_payload_graph(true);
+        let (repack_graph, pay_r, _) = build_payload_graph(true);
         assert!(
             repack_payload_read_vars(&repack_graph).contains(&pay_r),
             "a payload read consumed only by a same-field FieldWrite is classified"
         );
-        let (consumed_graph, pay_c) = build_payload_graph(false);
+        let (consumed_graph, pay_c, _) = build_payload_graph(false);
         assert!(
             !repack_payload_read_vars(&consumed_graph).contains(&pay_c),
             "a payload read fed to a real consumer is NOT classified"
+        );
+    }
+
+    #[test]
+    fn repack_payload_carrier_vars_require_only_elided_payload_reads() {
+        let (repack_graph, _, carrier) = build_payload_graph(true);
+        assert!(
+            repack_payload_carrier_vars(&repack_graph).contains(&carrier),
+            "the block-local carrier used only by identity-repack reads is classified"
+        );
+
+        let (mut consumed_graph, _, consumed_carrier) = build_payload_graph(true);
+        let mid = consumed_graph
+            .blocks
+            .iter_mut()
+            .find(|block| block.id == crate::model::BlockId(7))
+            .expect("payload middle block");
+        mid.operations.push(crate::model::SpaceOperation {
+            result: None,
+            kind: crate::model::OpKind::Call {
+                target: crate::model::CallTarget::FunctionPath {
+                    segments: vec!["consume_carrier".into()],
+                },
+                args: vec![consumed_carrier.clone()],
+                result_ty: ValueType::Void,
+            },
+        });
+        assert!(
+            !repack_payload_carrier_vars(&consumed_graph).contains(&consumed_carrier),
+            "any non-repack use must keep the carrier as a real divergence"
+        );
+    }
+
+    #[test]
+    fn collect_divergences_accepts_elided_repack_carrier() {
+        let (graph, _, carrier) = build_payload_graph(true);
+        crate::model::FunctionGraph::set_concretetype_of_inline(&carrier, ConcreteType::GcRef);
+        assert!(
+            collect_divergences(&HashMap::new(), &graph).is_empty(),
+            "an identity arm carrier removed with all its payload reads has no surviving real-path use"
         );
     }
 

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -62,15 +62,14 @@ use crate::flowspace::model::{
 use crate::flowspace::pygraph::PyGraph;
 use crate::model::FunctionGraph as LegacyGraph;
 use crate::translator::rtyper::call_registry::{CallRegistry, FunctionEntry, FunctionPathKey};
+use crate::translator::rtyper::call_registry::{
+    exception_object_result_annotation, is_exception_object_materializer,
+};
 use crate::translator::rtyper::error::TyperError;
 use crate::translator::rtyper::flowspace_adapter::{
     FlowspaceAdapterOutput, LegacyToTyped, LegacyToTypedCandidates,
 };
 use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
-use crate::translator::rtyper::call_registry::{
-    exception_object_result_annotation,
-    is_exception_object_materializer,
-};
 
 /// The `graph.return_type` marker the front-end stamps on a
 /// `dont_look_inside` callee that returns `*mut PyObject` (a
@@ -1153,6 +1152,7 @@ fn op_result_can_remove(kind: &crate::model::OpKind) -> bool {
             | OpKind::NewList { .. }
             | OpKind::GetSlice { .. }
             | OpKind::ConstInt(_)
+            | OpKind::ConstUInt(_)
             | OpKind::ConstBool(_)
             | OpKind::ConstFloat(_)
             | OpKind::ConstRef(_)
@@ -1728,15 +1728,11 @@ pub(crate) fn unported_category(msg: &str) -> Option<&'static str> {
     if msg.contains("noneify() not supported") {
         return Some("noneify-on-ptr");
     }
-    // `flowspace_adapter::translate_op` rejected an UNFUSED
-    // `lltype::malloc_typed` `FunctionPath` (the finding's "option (b)"
-    // fail-closed guard).  `fuse_boxing_alloc` rewrites only the three
-    // numeric boxing structs to `NewWithVtable`; every other mallocable
-    // GC struct's `malloc_typed` survives with no ported
-    // `jtransform.rewrite_op_malloc` general lowering, so the adapter
-    // fails loud rather than matching a wrong residual `simple_call`.
-    // Skip-classify so the census falls back to the legacy walker until
-    // the general malloc->new path lands (boxing-lowering epic #134/#142).
+    // `flowspace_adapter::translate_op` rejected an UNFUSED GC malloc
+    // `FunctionPath`. `fuse_boxing_alloc` is the general source-aggregate to
+    // `NewWithVtable` lowering; a cluster whose owner/header/payload cannot be
+    // proven stays fail-closed here instead of becoming a residual allocator
+    // call with the wrong JIT semantics.
     if msg.contains("survived fuse_boxing_alloc unfused") {
         return Some("malloc-typed-unfused");
     }
@@ -1881,39 +1877,27 @@ pub(crate) fn populate_call_registry_from_call_graphs(
     for (path, graph) in function_graphs.iter() {
         let key = FunctionPathKey::from_segments(path.segments.iter().cloned());
         let canonical_strip = canonical_dedup_key(path);
-        // `pyre_object::lltype::malloc_typed` is the GC allocation intrinsic,
-        // recognised as a host builtin (annotator `malloc_typed_alloc`, HOST_ENV
-        // `pyre_object.lltype` module).  Its real body calls the un-flowable
-        // `<T as GcType>::type_id()` trait accessor, so lifting it records a
-        // poison lift-error that surfaces on the first boxing caller.  Skip
+        // `pyre_object::lltype::malloc[_typed]` are GC allocation intrinsics,
+        // recognised as host builtins (annotator `malloc_typed_alloc`, HOST_ENV
+        // `pyre_object.lltype` module). Their real bodies enter the host
+        // allocator (`malloc_typed` first reads the un-flowable
+        // `<T as GcType>::type_id()` trait accessor), so lifting either records
+        // a poison lift-error that surfaces on the first boxing caller. Skip
         // registering it as a user function: with no registry entry, callsites
         // resolve to the HOST_ENV builtin (translate_op Layer-3b) instead of
         // this failed user-graph entry (Layer-1 `call_registry.lookup`).
         //
-        // NARROW-LOWERING HAZARD — the HOST_ENV resolution is faithful ONLY for
-        // the numeric boxing structs (`W_FloatObject`/`W_IntObject`/
-        // `W_ComplexObject`/`W_LongObject`, per `model.rs payload_fields`) that
-        // `fuse_boxing_alloc` rewrites to a native
-        // `NewWithVtable` during MIR `simplify_lowered_graph`
-        // (`front/mir.rs:1409`, `model.rs` `payload_fields`) — *before* the
-        // rtyper runs, so a numeric `malloc_typed` never reaches Layer-3b.
-        // Upstream `jtransform.rewrite_op_malloc` (`jtransform.py`) lowers
-        // EVERY mallocable GC struct to `new`/`new_with_vtable`; pyre has not
-        // ported that general path. So an UNFUSED `malloc_typed` (any non-numeric
-        // struct — `W_BytesObject`, `W_UnicodeObject`, the dict family, …)
-        // survives to Layer-3b and resolves to a residual `simple_call` carrying
-        // a symbolic fnaddr the executor cannot run. This is currently LATENT,
-        // not a live miscompile: the production tracer is FBW (non-numeric boxes
-        // run the genuine runtime `malloc_typed` GC helper), and the rtyper op
-        // stream is Path-2 census-only, never the assembled stream. Before any
-        // non-numeric box constructor is promoted toward Path-2 codegen, a
-        // fail-closed guard (the finding's "option (b)") must land FIRST in
-        // `flowspace_adapter::translate_op` — reject a surviving `[.., "lltype",
-        // "malloc_typed"]` `FunctionPath` with a `TyperError` (classified in
-        // `is_known_unported`) so the graph census-Skips to the legacy walker
-        // instead of silently matching a wrong residual call. Tracked by the
-        // boxing-lowering epic (#134/#142).
-        if canonical_strip == ["lltype", "malloc_typed"]
+        // `fuse_boxing_alloc` now derives every payload from the registered
+        // struct layout and rewrites a proven `malloc[_typed](T { ... })`
+        // cluster to `NewWithVtable` plus setfields, matching
+        // `jtransform.rewrite_op_malloc` (`jtransform.py`).  A surviving call
+        // is still not a residual boundary: it means the frontend could not
+        // prove the allocation header/type identity.  The fail-closed guard in
+        // `flowspace_adapter::translate_op` therefore rejects every surviving
+        // `malloc`, `malloc_typed`, or `malloc_typed_managed` call instead of
+        // emitting an executable symbolic fnaddr.
+        if canonical_strip == ["lltype", "malloc"]
+            || canonical_strip == ["lltype", "malloc_typed"]
             || canonical_strip == ["lltype", "malloc_typed_managed"]
         {
             crate::decline::record(
@@ -3335,11 +3319,9 @@ fn classify_unported_reason(reason: &str) -> &'static str {
     {
         "FRONTEND-TYPED-PTR (address-of-local / host-static / null)"
     } else if reason.contains("survived fuse_boxing_alloc unfused") {
-        // A non-numeric boxing struct's `lltype::malloc_typed` reached the
-        // adapter with no `NewWithVtable` fusion and no ported general
-        // malloc->new lowering (`flowspace_adapter::translate_op` fail-closed
-        // guard). The boxing-lowering epic (#134/#142) drains this bucket.
-        "UNFUSED-MALLOC (non-numeric boxing struct)"
+        // A GC allocation reached the adapter without the frontend proving
+        // its header/type identity and lowering it to `NewWithVtable`.
+        "UNFUSED-MALLOC (unproven GC allocation header)"
     } else if reason.contains("dict key eq function not wired") {
         // `OrderedDictRepr::require_direct_compare_key` fail-closed gate —
         // a dict key repr with a custom `get_ll_eq_function` (str, instance)

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -3661,8 +3661,7 @@ fn run_two_phase_prepass_inner(
                     // MAJIT_RTYPER_FRONTIER: the adapter's whole call-wall set
                     // for this subject, not just the wall it stopped at. One
                     // line per wall, so the record splits without a banner.
-                    for wall in
-                        crate::translator::rtyper::flowspace_adapter::take_frontier_walls()
+                    for wall in crate::translator::rtyper::flowspace_adapter::take_frontier_walls()
                     {
                         eprintln!("[PREPASS phaseA wall] {:?}: {wall}", path);
                     }

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -81,6 +81,12 @@ use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
 /// readable Rust return type.
 pub(crate) const OBJECTPTR_RETURN_TYPE: &str = "*mut PyObject";
 
+/// Residual FUNC.RESULT token for the opaque root-stack word used by
+/// RPython's GC transformer.  It is ref-kind like OBJECTPTR but retains the
+/// `Ptr(GcOpaque("GCREF"))` low-level identity required for
+/// `cast_opaque_ptr` back to StringRepr / InstanceRepr.
+pub(crate) const GCREF_RETURN_TYPE: &str = "gcref";
+
 /// Project a post-`specialize` `LowLevelType` back to the legacy
 /// `ConcreteType` bucket the codewriter consumes (Signed / Float /
 /// GcRef / Void).
@@ -2473,6 +2479,13 @@ pub(crate) fn default_someshell_for_lltype(
 pub(crate) fn residual_return_shell(
     token: Option<&str>,
 ) -> Option<crate::annotator::model::SomeValue> {
+    if token == Some(GCREF_RETURN_TYPE) {
+        return Some(
+            crate::translator::rtyper::llannotation::lltype_to_annotation(
+                crate::translator::rtyper::lltypesystem::lltype::GCREF.clone(),
+            ),
+        );
+    }
     if token == Some("ref") {
         return Some(
             crate::codewriter::annotation_state::valuetype_to_someshell(
@@ -2513,6 +2526,9 @@ fn return_token_to_lltype(token: Option<&str>) -> Option<LowLevelType> {
     match token {
         None | Some("()") => Some(LowLevelType::Void),
         Some("ref") => Some(crate::translator::rtyper::rclass::OBJECTPTR.clone()),
+        Some(s) if s == GCREF_RETURN_TYPE => {
+            Some(crate::translator::rtyper::lltypesystem::lltype::GCREF.clone())
+        }
         Some("bool") => Some(LowLevelType::Bool),
         Some("i64") => Some(LowLevelType::Signed),
         Some("u64") => Some(LowLevelType::Unsigned),
@@ -2565,17 +2581,24 @@ fn declared_funcptr_type_from_legacy(
 ) -> Option<crate::translator::rtyper::lltypesystem::lltype::FuncType> {
     use crate::model::OpKind;
     let startblock = legacy.blocks.iter().find(|b| b.id == legacy.startblock)?;
-    let mut input_ty: HashMap<crate::flowspace::model::Variable, &crate::model::ValueType> =
-        HashMap::new();
+    let mut input_ty: HashMap<
+        crate::flowspace::model::Variable,
+        (&crate::model::ValueType, &Option<String>),
+    > = HashMap::new();
     for op in &startblock.operations {
-        if let (Some(result), OpKind::Input { ty, .. }) = (op.result.as_ref(), &op.kind) {
-            input_ty.insert(result.clone(), ty);
+        if let (Some(result), OpKind::Input { ty, class_root, .. }) = (op.result.as_ref(), &op.kind)
+        {
+            input_ty.insert(result.clone(), (ty, class_root));
         }
     }
     let mut args = Vec::with_capacity(startblock.inputargs.len());
     for var in &startblock.inputargs {
-        let ty = input_ty.get(var)?;
-        args.push(valuetype_to_lltype(ty)?);
+        let (ty, class_root) = input_ty.get(var)?;
+        args.push(if class_root.as_deref() == Some("GCREF") {
+            crate::translator::rtyper::lltypesystem::lltype::GCREF.clone()
+        } else {
+            valuetype_to_lltype(ty)?
+        });
     }
     let result = return_token_to_lltype(legacy.return_type.as_deref())?;
     Some(crate::translator::rtyper::lltypesystem::lltype::FuncType { args, result })

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -3658,6 +3658,14 @@ fn run_two_phase_prepass_inner(
                     };
                     eprintln!("[PREPASS phaseA fail] {:?}: {reason}", path);
                     phase_a_reasons.push(reason);
+                    // MAJIT_RTYPER_FRONTIER: the adapter's whole call-wall set
+                    // for this subject, not just the wall it stopped at. One
+                    // line per wall, so the record splits without a banner.
+                    for wall in
+                        crate::translator::rtyper::flowspace_adapter::take_frontier_walls()
+                    {
+                        eprintln!("[PREPASS phaseA wall] {:?}: {wall}", path);
+                    }
                 }
                 // Annotate-half failed (or panicked): repair shared-callee state
                 // and leave the graph uncached so publish Skips it to the legacy

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -67,6 +67,10 @@ use crate::translator::rtyper::flowspace_adapter::{
     FlowspaceAdapterOutput, LegacyToTyped, LegacyToTypedCandidates,
 };
 use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
+use crate::translator::rtyper::call_registry::{
+    exception_object_result_annotation,
+    is_exception_object_materializer,
+};
 
 /// The `graph.return_type` marker the front-end stamps on a
 /// `dont_look_inside` callee that returns `*mut PyObject` (a
@@ -2139,7 +2143,18 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         let residualize = graph.hints.iter().any(|h| h == "dont_look_inside")
             || graph.hints.iter().any(|h| h == "elidable");
         if residualize {
-            let result_shell = residual_return_shell(graph.return_type.as_deref());
+            // The materialisers' raw `*mut PyObject` return is only their
+            // residual-call ABI.  Their FunctionDesc carries the orthodox
+            // `_signature_`-style SomeInstance result, so the synthetic
+            // annotator graph must carry that same result on its return link.
+            // Leaving the generic OBJECTPTR/SomePtr shell here makes Phase B
+            // insert a PtrRepr -> InstanceRepr conversion that upstream never
+            // has, then the first failed specialization replaces the shared
+            // stub and strands every later caller on an unbound return var.
+            let result_shell = residual_stub_result_shell(
+                entry.function_desc.borrow().name.as_str(),
+                graph.return_type.as_deref(),
+            );
             if let Some(result_shell) = result_shell {
                 let stub = build_stub_pygraph_with_result_shell(
                     graph.name.clone(),
@@ -2483,6 +2498,25 @@ pub(crate) fn residual_return_shell(
         );
     }
     return_token_to_lltype(token).and_then(|ll| default_someshell_for_lltype(&ll))
+}
+
+/// Choose the annotation carried by a `dont_look_inside` stub's return link.
+///
+/// Normally the front-end's FUNC.RESULT token is the semantic annotation
+/// source.  The two exception materialisers are the deliberate exception:
+/// their `*mut PyObject` token describes only the residual trampoline ABI,
+/// while their registered `_signature_` describes the interpreter-visible
+/// exception instance.  The cached stub must agree with that signature, just
+/// as an upstream flow graph constrained by `_signature_` does.
+fn residual_stub_result_shell(
+    function_name: &str,
+    token: Option<&str>,
+) -> Option<crate::annotator::model::SomeValue> {
+    if is_exception_object_materializer(function_name) {
+        Some(exception_object_result_annotation())
+    } else {
+        residual_return_shell(token)
+    }
 }
 
 /// Project a FUNC.RESULT token (the `return_type` string) to its
@@ -5853,6 +5887,28 @@ mod tests {
         let s = default_someshell_for_lltype(&LowLevelType::Address)
             .expect("Address must project to SomeAddress");
         assert!(matches!(s, SomeValue::Address(_)), "got {s:?}");
+    }
+
+    #[test]
+    fn exception_materializer_stub_uses_semantic_instance_result() {
+        use crate::annotator::model::SomeValue;
+
+        for name in ["pyerror_to_exc_object", "pyerror_type_error_to_exc_object"] {
+            let shell = residual_stub_result_shell(name, Some(OBJECTPTR_RETURN_TYPE))
+                .expect("exception materializer must have a result shell");
+            let SomeValue::Instance(instance) = shell else {
+                panic!("{name}: raw pointer ABI must not leak into annotation")
+            };
+            assert!(instance.classdef.is_none());
+            assert!(!instance.can_be_none);
+        }
+
+        let ordinary = residual_stub_result_shell("ordinary", Some(OBJECTPTR_RETURN_TYPE))
+            .expect("ordinary object-pointer residual must have a result shell");
+        assert!(
+            matches!(ordinary, SomeValue::Ptr(_)),
+            "ordinary object-pointer residuals keep their typed Ptr shell"
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -3362,11 +3362,11 @@ fn link_extravar_to_hlvalue(
 /// position order.
 ///
 /// Resolution order per inputarg `vid`:
-/// 1. `legacy.variable(vid).annotation` — minimal fixtures supply
-///    Variable-shape annotations explicitly via
+/// 1. Matching `OpKind::Input { ty, class_root }` op result == `vid` at the
+///    startblock — the source-typed production graph from `front::mir`.
+/// 2. `legacy.variable(vid).annotation` — fallback for minimal fixtures that
+///    have no production-shape Input op and explicitly seed the Variable via
 ///    `legacy_annotator::setbinding(&var, ty)`.
-/// 2. Matching `OpKind::Input { ty }` op result == `vid` at the
-///    startblock — production graphs from `front::mir`.
 ///
 /// Errors:
 ///
@@ -3415,15 +3415,12 @@ pub(crate) fn derive_subject_inputcells(
     }
     let mut cells = Vec::with_capacity(startblock.inputargs.len());
     for (idx, var) in startblock.inputargs.iter().enumerate() {
-        // 1. Explicit SomeValue seed published onto
-        //    `var.annotation` (test fixtures seed via
-        //    `legacy_annotator::setbinding(&var, ty)` before invoking
-        //    this function).
-        if let Some(rc) = var.annotation.borrow().as_ref() {
-            cells.push((**rc).clone());
-            continue;
-        }
-        // 2. Front-end Input op at the startblock.
+        // 1. Front-end Input op at the startblock.  This is the source-type
+        // authority, just as RPython seeds a function from its signature and
+        // then lets call propagation widen that cell.  In particular, do not
+        // let a classdef-less annotation left on the legacy graph erase a
+        // richer `PyObjectRef`/W_Root class_root: that stale slot is an input
+        // from the transitional walker, not an RPython annotation source.
         if let Some(&(ty, class_root)) = input_by_result.get(var) {
             let shell = valuetype_to_someshell(ty).ok_or_else(|| {
                 TyperError::message(format!(
@@ -3577,6 +3574,13 @@ pub(crate) fn derive_subject_inputcells(
                 }
             }
             cells.push(shell);
+            continue;
+        }
+        // 2. Explicit SomeValue fallback published onto `var.annotation`.
+        // Production front graphs always took the Input arm above; only
+        // hand-built fixtures without Input ops rely on this path.
+        if let Some(rc) = var.annotation.borrow().as_ref() {
+            cells.push((**rc).clone());
             continue;
         }
         // No further fallback: every typed parameter emits the Input
@@ -4725,6 +4729,47 @@ mod tests {
             "z: Ref -> SomeInstance(classdef=None), got {:?}",
             cells[2],
         );
+    }
+
+    #[test]
+    fn derive_subject_inputcells_prefers_source_root_over_legacy_shell() {
+        let mut graph = LegacyGraph::new("set_locals_w");
+        let entry = graph.startblock;
+        let value = graph
+            .push_op_var(
+                entry,
+                OpKind::Input {
+                    name: "value".to_string(),
+                    ty: ValueType::Ref(None),
+                    class_root: Some("PyObject".to_string()),
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_inputarg_var(entry, value.clone());
+
+        // Transitional legacy annotation loses the pointee class.  The
+        // source Input still says PyObjectRef, corresponding to W_Root in
+        // PyPy, and must be the authoritative initial cell.
+        setbinding(&value, ValueType::Ref(None));
+        let bk = Rc::new(Bookkeeper::new());
+        let mut fields = crate::front::StructFieldRegistry::default();
+        fields.fields.insert(
+            "PyObject".to_string(),
+            vec![("type_ptr".to_string(), "usize".to_string())],
+        );
+        bk.set_pyre_struct_fields(Rc::new(fields));
+
+        let cells = derive_subject_inputcells(&graph, Some(&bk))
+            .expect("source-typed PyObject input must seed a concrete class");
+        let SomeValue::Instance(value) = &cells[0] else {
+            panic!("PyObjectRef must seed SomeInstance, got {:?}", cells[0])
+        };
+        let classdef = value
+            .classdef
+            .as_ref()
+            .expect("source class_root must replace the classdef-less legacy shell");
+        assert_eq!(classdef.borrow().name, "PyObject");
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -835,6 +835,21 @@ fn is_vec_ctor_segments(segments: &[String]) -> bool {
         && (segments[2] == "with_capacity" || segments[2] == "new")
 }
 
+/// `pyre_interpreter::builtins::try_pyobject_vec_with_capacity(sizehint)` is
+/// the Rust source spelling of RPython's `objectmodel.newlist_hint(sizehint)`.
+///
+/// The helper is deliberately an opaque source-translation boundary, just as
+/// upstream's function is handled by an ExtRegistryEntry instead of tracing
+/// its Python body.  Its ordinary interpreter body still performs the
+/// fallible Rust reservation; translated callers take this exact path into
+/// `rtype_newlist_hint` and therefore retain both the capacity hint and the
+/// MemoryError edge.
+fn is_try_pyobject_vec_with_capacity_segments(segments: &[String]) -> bool {
+    segments.len() >= 2
+        && segments[segments.len() - 2] == "builtins"
+        && segments[segments.len() - 1] == "try_pyobject_vec_with_capacity"
+}
+
 /// `alloc::vec::from_elem(elem, count)` (Rust MIR `vec![elem; count]`) —
 /// the repeated resizable-list constructor.  Routed in [`translate_op`] to
 /// `newlist(elem)` + `mul(list, count)`, the same `[a] * b` shape that
@@ -2109,6 +2124,21 @@ pub fn translate_op(
                     // dropped — see [`is_vec_ctor_segments`].
                     if is_vec_ctor_segments(segments) {
                         return Ok(vec![FlowspaceOp::new("newlist", vec![], result)]);
+                    }
+                    // `try_pyobject_vec_with_capacity(sizehint)?` is the
+                    // fallible Rust spelling of
+                    // `objectmodel.newlist_hint(sizehint)`. The
+                    // Result-to-exception pass has already made this call's
+                    // result the normal-edge Vec payload, so the synthetic op
+                    // has precisely the upstream one-argument/result shape.
+                    if is_try_pyobject_vec_with_capacity_segments(segments) {
+                        if arg_hls.len() != 1 {
+                            return Err(TyperError::message(format!(
+                                "try_pyobject_vec_with_capacity requires exactly one size hint, got {}",
+                                arg_hls.len()
+                            )));
+                        }
+                        return Ok(vec![FlowspaceOp::new("newlist_hint", arg_hls, result)]);
                     }
                     // `vec![elem; count]` lowers (in Rust MIR) to a call to
                     // `alloc::vec::from_elem(elem, count)`. Emit the same
@@ -5084,6 +5114,38 @@ mod tests {
         assert_eq!(translated[1].args[0], translated[0].result);
         assert_eq!(translated[1].args[1], count);
         assert_eq!(translated[1].result, result);
+    }
+
+    #[test]
+    fn translate_op_try_pyobject_vec_with_capacity_becomes_newlist_hint() {
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let mut graph = LegacyGraph::new("translate_op_newlist_hint_fixture");
+        let vars = mint_vars(&mut graph, 2);
+        let hint = Hlvalue::Variable(Variable::new());
+        let result = Hlvalue::Variable(Variable::new());
+        value_map.insert(vars[0].clone(), hint.clone());
+        value_map.insert(vars[1].clone(), result.clone());
+        let op = SpaceOperation {
+            result: Some(vars[1].clone()),
+            kind: OpKind::Call {
+                target: crate::model::CallTarget::FunctionPath {
+                    segments: vec![
+                        "pyre_interpreter".into(),
+                        "builtins".into(),
+                        "try_pyobject_vec_with_capacity".into(),
+                    ],
+                },
+                args: vec![vars[0].clone()],
+                result_ty: ValueType::Ref(None),
+            },
+        };
+        let translated = translate_op(&op, &value_map, &empty_call_registry())
+            .expect("try_pyobject_vec_with_capacity must lower as the newlist_hint intrinsic");
+        assert_eq!(translated.len(), 1);
+        assert_eq!(translated[0].opname, "newlist_hint");
+        assert_eq!(translated[0].args, vec![hint]);
+        assert_eq!(translated[0].result, result);
+        assert!(op_canraise(&op.kind));
     }
 
     /// The frontend cannot see the adapter's expansion: `lower_function`

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1064,6 +1064,210 @@ pub(crate) fn op_canraise(kind: &OpKind) -> bool {
     clippy::mutable_key_type,
     reason = "Eq and Hash use immutable identity/value data; interior mutation is excluded, matching RPython identity-keyed dict semantics"
 )]
+/// Census-only accumulation of a graph's *whole* unresolvable-callee set.
+///
+/// The adapter is first-fail: [`function_graph_to_flowspace`] returns on the
+/// first op it cannot translate, so `MAJIT_RTYPER_VERBOSE`'s
+/// `[PREPASS phaseA fail]` row names one wall per graph even when the graph
+/// stands behind several.  Ranking walls by that row therefore ranks *first*
+/// walls, and closing the top one relocates its graphs to their next wall
+/// instead of lifting them — measured on `Wtf8Buf::push_str`, where the wall
+/// fell 15 → 5 and the census total did not move.
+///
+/// `MAJIT_RTYPER_FRONTIER` keeps the scan going past a failed **call** op so
+/// the row can name the whole set.  Upstream spells the same distinction
+/// `keepgoing` (`annrpython.py`): its `flowin` records the error in
+/// `self.errors`, adds the block to `self.failed_blocks` and returns instead of
+/// raising, and `complete` reports every recorded error together.  Pyre's
+/// annotator ports that flag (`RPythonAnnotator::keepgoing`), but the walls
+/// counted here are raised one layer earlier — in this adapter, before the
+/// annotator sees the graph — so the same behaviour is spelled here.
+///
+/// **Only call ops resume.**  A call's resolution failure is a function of the
+/// callee path and the registry alone, so skipping it invents no wall; any
+/// other op's failure may be a consequence of an operand this scan skipped,
+/// and resuming past it would manufacture walls that do not exist.  The
+/// skipped call's result is bound to a placeholder so later ops still resolve
+/// their operands — a census-only graph that is discarded, since the adapter
+/// still returns the first error and the subject still fails exactly as it
+/// does with the gate off.
+mod frontier {
+    use super::TyperError;
+    use std::cell::RefCell;
+
+    #[derive(Default)]
+    struct Frame {
+        /// Every distinct wall seen in this adapter run, in discovery order.
+        walls: Vec<String>,
+        /// The wall the gate-off run would have stopped at.
+        first: Option<TyperError>,
+    }
+
+    thread_local! {
+        /// One frame per active adapter run.  A run is re-entrant: resolving a
+        /// call can lift the callee's source, which runs the adapter again, and
+        /// a flat slot would let the inner run adopt the outer run's `first`.
+        static STACK: RefCell<Vec<Frame>> = const { RefCell::new(Vec::new()) };
+        /// Walls of the last outermost run, awaiting [`super::take_frontier_walls`].
+        static LAST: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+    }
+
+    /// Whether `MAJIT_RTYPER_FRONTIER` is on.  Same `== "1"` contract as
+    /// `MAJIT_RTYPER_VERBOSE`, so a literal `0` stays off.
+    pub(super) fn enabled() -> bool {
+        std::env::var_os("MAJIT_RTYPER_FRONTIER").is_some_and(|v| v == "1")
+    }
+
+    /// Guard for one adapter run.  Collecting is scoped to its lifetime.
+    pub(super) struct Guard {
+        active: bool,
+    }
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            if !self.active {
+                return;
+            }
+            let frame = STACK.with(|s| s.borrow_mut().pop()).unwrap_or_default();
+            STACK.with(|s| {
+                let mut stack = s.borrow_mut();
+                match stack.last_mut() {
+                    // An inner run's walls block the outer run too — its
+                    // failure is what the outer call reports — so they join the
+                    // caller's set rather than being dropped.
+                    Some(outer) => {
+                        for wall in frame.walls {
+                            if !outer.walls.contains(&wall) {
+                                outer.walls.push(wall);
+                            }
+                        }
+                    }
+                    None => LAST.with(|l| *l.borrow_mut() = frame.walls),
+                }
+            });
+        }
+    }
+
+    /// Begin collecting for one adapter run.
+    pub(super) fn enter() -> Guard {
+        let active = enabled();
+        if active {
+            STACK.with(|s| {
+                let mut stack = s.borrow_mut();
+                // An outermost run owns the next census row: drop the previous
+                // run's set now, so a subject whose adapter is never reached
+                // reports nothing rather than its predecessor's walls.
+                if stack.is_empty() {
+                    LAST.with(|l| l.borrow_mut().clear());
+                }
+                stack.push(Frame::default());
+            });
+        }
+        Guard { active }
+    }
+
+    /// Whether `err`, raised on `op`, may be skipped and the run resumed.
+    /// Records the wall as a side effect when it may.
+    pub(super) fn resume(op: &super::SpaceOperation, err: &TyperError) -> bool {
+        if !matches!(op.kind, super::OpKind::Call { .. }) {
+            return false;
+        }
+        STACK.with(|s| {
+            let mut stack = s.borrow_mut();
+            let Some(frame) = stack.last_mut() else {
+                return false;
+            };
+            // One line per wall: the registry message is a paragraph, and a
+            // multi-line census record is unparseable without a banner to split
+            // on.
+            let text = err
+                .to_string()
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ");
+            if !frame.walls.contains(&text) {
+                frame.walls.push(text);
+            }
+            frame.first.get_or_insert_with(|| err.clone());
+            true
+        })
+    }
+
+    /// The error the gate-off run would have returned, if this run skipped a
+    /// wall.
+    pub(super) fn pending_error() -> Option<TyperError> {
+        STACK.with(|s| s.borrow().last().and_then(|f| f.first.clone()))
+    }
+
+    /// Take the wall set of the last completed outermost run.
+    pub(super) fn take_last() -> Vec<String> {
+        LAST.with(|l| std::mem::take(&mut *l.borrow_mut()))
+    }
+}
+
+/// Read the wall set [`frontier`] collected for the subject just translated.
+/// Empty unless `MAJIT_RTYPER_FRONTIER` is on.
+pub fn take_frontier_walls() -> Vec<String> {
+    frontier::take_last()
+}
+
+/// [`legacy_const_define_hlvalue`], resuming past a skippable call wall under
+/// [`frontier`].
+///
+/// The unresolvable fn-const is stood in for by a
+/// [`ConstValue::Placeholder`] constant rather than reported as "not a const
+/// define": the const-define pass is graph-wide, so demoting the value to a
+/// block-local Variable would leave every other block using it undefined.
+fn legacy_const_define_hlvalue_or_frontier(
+    op: &SpaceOperation,
+    call_registry: Option<&crate::translator::rtyper::call_registry::CallRegistry>,
+) -> Result<Option<Hlvalue>, TyperError> {
+    match legacy_const_define_hlvalue(op, call_registry) {
+        Err(err) if frontier::resume(op, &err) => Ok(Some(Hlvalue::Constant(
+            constant_from_constvalue(ConstValue::Placeholder),
+        ))),
+        other => other,
+    }
+}
+
+/// [`translate_op`], resuming past a skippable call wall under [`frontier`].
+///
+/// The skipped call is replaced by a `direct_call` on a
+/// [`ConstValue::Placeholder`] callee, not dropped.  Both halves are forced by
+/// [`crate::flowspace::model`]'s structural check: the caller has already
+/// seeded the call's result Variable and a later block reads it through a
+/// Link, so some op must define it; and a `canraise` block's last op may not
+/// be `same_as`, so the stand-in has to stay a call.  It is census-only —
+/// this graph is discarded, since [`function_graph_to_flowspace`] reports the
+/// wall.
+fn translate_op_or_frontier(
+    op: &SpaceOperation,
+    value_map: &HashMap<Variable, Hlvalue>,
+    call_registry: &crate::translator::rtyper::call_registry::CallRegistry,
+) -> Result<Vec<FlowspaceOp>, TyperError> {
+    match translate_op(op, value_map, call_registry) {
+        Err(err) if frontier::resume(op, &err) => {
+            let Some(result) = op.result.as_ref() else {
+                return Ok(Vec::new());
+            };
+            let result = lookup_operand(value_map, result, op, "result")?;
+            // Already stood in for by
+            // [`legacy_const_define_hlvalue_or_frontier`] — the constant needs
+            // no defining op.
+            if matches!(result, Hlvalue::Constant(_)) {
+                return Ok(Vec::new());
+            }
+            let placeholder = Hlvalue::Constant(constant_from_constvalue(ConstValue::Placeholder));
+            Ok(vec![FlowspaceOp::new(
+                "direct_call",
+                vec![placeholder],
+                result,
+            )])
+        }
+        other => other,
+    }
+}
+
 pub fn translate_op(
     op: &SpaceOperation,
     value_map: &HashMap<Variable, Hlvalue>,
@@ -3731,6 +3935,45 @@ fn reachable_block_ids(legacy: &FunctionGraph) -> std::collections::HashSet<Bloc
     seen
 }
 
+/// `RPythonTyper.specialize`'s per-graph entry: build the flowspace view of one
+/// legacy graph.
+///
+/// Under `MAJIT_RTYPER_FRONTIER` the run resumes past every unresolvable call
+/// instead of stopping at the first, so [`take_frontier_walls`] can report the
+/// subject's whole call-wall set.  Resuming is census-only: the graph it builds
+/// is discarded, and the error reported here is the one the gate-off run would
+/// have returned, so the subject fails identically either way.
+///
+/// **Only call ops resume.**  A call's resolution failure is a function of the
+/// callee path and the registry alone, so skipping it invents no wall; any
+/// other op's failure may be a consequence of an operand the run skipped, and
+/// resuming past it would manufacture walls that do not exist.  Such an op
+/// still stops the run — its error is then replaced by the recorded first wall,
+/// which is where the gate-off run stopped.
+///
+/// Measured on the `pyre-jit-trace` prepass census: the gate-off phase-A
+/// failure set is reproducible (1681 subjects, twice, byte-identical), and the
+/// gate moves exactly one of them — `_io::stringio::W_StringIO::default` stops
+/// panicking in annotate and reaches phase B instead.  Read the ranking as
+/// carrying that one-subject error bar.
+pub fn function_graph_to_flowspace(
+    legacy: &FunctionGraph,
+    call_registry: &crate::translator::rtyper::call_registry::CallRegistry,
+) -> Result<FlowspaceAdapterOutput, TyperError> {
+    let _guard = frontier::enter();
+    let result = function_graph_to_flowspace_inner(legacy, call_registry);
+    match frontier::pending_error() {
+        Some(first) => Err(first),
+        None => result,
+    }
+}
+
+/// Translate one legacy graph, reporting the first wall it hits.
+///
+/// Under [`frontier`] the run resumes past a skippable call wall, so the error
+/// this returns need not be the one it stopped at —
+/// [`function_graph_to_flowspace`] restores it.
+///
 /// One-way conversion from the legacy `crate::model::FunctionGraph`
 /// into a `flowspace::FunctionGraph` whose blocks carry `Hlvalue`
 /// operands and per-value `SomeValue` annotations on its `Variable`s.
@@ -3777,7 +4020,7 @@ fn reachable_block_ids(legacy: &FunctionGraph) -> std::collections::HashSet<Bloc
     clippy::mutable_key_type,
     reason = "Eq and Hash use immutable identity/value data; interior mutation is excluded, matching RPython identity-keyed dict semantics"
 )]
-pub fn function_graph_to_flowspace(
+fn function_graph_to_flowspace_inner(
     legacy: &FunctionGraph,
     // Call resolution plumbing — see [`translate_op`].
     call_registry: &crate::translator::rtyper::call_registry::CallRegistry,
@@ -3801,7 +4044,7 @@ pub fn function_graph_to_flowspace(
             continue;
         }
         for legacy_op in &legacy_block.operations {
-            if let Some(hlvalue) = legacy_const_define_hlvalue(legacy_op, Some(call_registry))? {
+            if let Some(hlvalue) = legacy_const_define_hlvalue_or_frontier(legacy_op, Some(call_registry))? {
                 // `legacy_const_define_hlvalue` only returns `Some` for ops
                 // with a result Variable, so this is always present here.
                 let Some(result_var) = legacy_op.result.as_ref() else {
@@ -4052,14 +4295,14 @@ pub fn function_graph_to_flowspace(
             })
             .collect();
         for legacy_op in &legacy_block.operations {
-            if let Some(hlvalue) = legacy_const_define_hlvalue(legacy_op, Some(call_registry))? {
+            if let Some(hlvalue) = legacy_const_define_hlvalue_or_frontier(legacy_op, Some(call_registry))? {
                 if let Some(result_var) = legacy_op.result.as_ref() {
                     value_map.insert(result_var.clone(), hlvalue.clone());
                     if let Some(name) = legacy.value_name_for(result_var) {
                         name_to_value.insert(name.to_string(), hlvalue);
                     }
                 }
-                translated_ops.extend(translate_op(legacy_op, &value_map, call_registry)?);
+                translated_ops.extend(translate_op_or_frontier(legacy_op, &value_map, call_registry)?);
                 continue;
             }
 
@@ -4123,7 +4366,7 @@ pub fn function_graph_to_flowspace(
                         )));
                     }
                 }
-                translated_ops.extend(translate_op(legacy_op, &value_map, call_registry)?);
+                translated_ops.extend(translate_op_or_frontier(legacy_op, &value_map, call_registry)?);
                 continue;
             }
 
@@ -4189,7 +4432,7 @@ pub fn function_graph_to_flowspace(
             {
                 continue;
             }
-            translated_ops.extend(translate_op(legacy_op, &value_map, call_registry)?);
+            translated_ops.extend(translate_op_or_frontier(legacy_op, &value_map, call_registry)?);
             if let Some(result_var) = legacy_op.result.as_ref()
                 && let Some(name) = legacy.value_name_for(result_var)
                 && let Some(value) = value_map.get(result_var).cloned()

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -4044,7 +4044,9 @@ fn function_graph_to_flowspace_inner(
             continue;
         }
         for legacy_op in &legacy_block.operations {
-            if let Some(hlvalue) = legacy_const_define_hlvalue_or_frontier(legacy_op, Some(call_registry))? {
+            if let Some(hlvalue) =
+                legacy_const_define_hlvalue_or_frontier(legacy_op, Some(call_registry))?
+            {
                 // `legacy_const_define_hlvalue` only returns `Some` for ops
                 // with a result Variable, so this is always present here.
                 let Some(result_var) = legacy_op.result.as_ref() else {
@@ -4295,14 +4297,20 @@ fn function_graph_to_flowspace_inner(
             })
             .collect();
         for legacy_op in &legacy_block.operations {
-            if let Some(hlvalue) = legacy_const_define_hlvalue_or_frontier(legacy_op, Some(call_registry))? {
+            if let Some(hlvalue) =
+                legacy_const_define_hlvalue_or_frontier(legacy_op, Some(call_registry))?
+            {
                 if let Some(result_var) = legacy_op.result.as_ref() {
                     value_map.insert(result_var.clone(), hlvalue.clone());
                     if let Some(name) = legacy.value_name_for(result_var) {
                         name_to_value.insert(name.to_string(), hlvalue);
                     }
                 }
-                translated_ops.extend(translate_op_or_frontier(legacy_op, &value_map, call_registry)?);
+                translated_ops.extend(translate_op_or_frontier(
+                    legacy_op,
+                    &value_map,
+                    call_registry,
+                )?);
                 continue;
             }
 
@@ -4366,7 +4374,11 @@ fn function_graph_to_flowspace_inner(
                         )));
                     }
                 }
-                translated_ops.extend(translate_op_or_frontier(legacy_op, &value_map, call_registry)?);
+                translated_ops.extend(translate_op_or_frontier(
+                    legacy_op,
+                    &value_map,
+                    call_registry,
+                )?);
                 continue;
             }
 
@@ -4432,7 +4444,11 @@ fn function_graph_to_flowspace_inner(
             {
                 continue;
             }
-            translated_ops.extend(translate_op_or_frontier(legacy_op, &value_map, call_registry)?);
+            translated_ops.extend(translate_op_or_frontier(
+                legacy_op,
+                &value_map,
+                call_registry,
+            )?);
             if let Some(result_var) = legacy_op.result.as_ref()
                 && let Some(name) = legacy.value_name_for(result_var)
                 && let Some(value) = value_map.get(result_var).cloned()

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -322,6 +322,15 @@ pub fn build_value_to_hlvalue_map(
                         )),
                     );
                 }
+                OpKind::ConstUInt(n) => {
+                    map.insert(
+                        result,
+                        Hlvalue::Constant(Constant::with_concretetype(
+                            ConstValue::Int(*n as i64),
+                            LowLevelType::Unsigned,
+                        )),
+                    );
+                }
                 OpKind::ConstBool(b) => {
                     map.insert(
                         result,
@@ -1084,6 +1093,7 @@ pub fn translate_op(
         // ─── Skipped: fully consumed by other adapter infrastructure ───
         OpKind::Input { .. } => Ok(Vec::new()),
         OpKind::ConstInt(_)
+        | OpKind::ConstUInt(_)
         | OpKind::ConstBool(_)
         | OpKind::ConstFloat(_)
         | OpKind::ConstRefNull
@@ -2187,7 +2197,7 @@ pub fn translate_op(
                             return Ok(vec![FlowspaceOp::new(opname, arg_hls, result)]);
                         }
                     }
-                    // Fail-closed on an UNFUSED `lltype::malloc_typed`.  A boxing
+                    // Fail-closed on an UNFUSED `lltype::malloc[_typed]`. A GC
                     // struct gets its `NewWithVtable` lowering before the rtyper
                     // runs only where `fuse_boxing_alloc` (`model.rs`) could
                     // resolve the cluster's header: a constant `ob_type`
@@ -2211,14 +2221,14 @@ pub fn translate_op(
                         && segments[segments.len() - 2] == "lltype"
                         && matches!(
                             segments[segments.len() - 1].as_str(),
-                            "malloc_typed" | "malloc_typed_managed"
+                            "malloc" | "malloc_typed" | "malloc_typed_managed"
                         )
                     {
                         return Err(TyperError::message(
-                            "`lltype::malloc_typed[_managed]` survived fuse_boxing_alloc unfused; \
+                            "`lltype::malloc[_typed/_managed]` survived fuse_boxing_alloc unfused; \
                              the cluster's header did not resolve to a constant type \
-                             pointer standing for its own `w_class`, and no general \
-                             malloc->new lowering is ported"
+                             pointer standing for its own `w_class`, so no safe \
+                             malloc->new lowering could be proven"
                                 .to_string(),
                         ));
                     }
@@ -2860,6 +2870,7 @@ fn opkind_variant_name(kind: &OpKind) -> &'static str {
     match kind {
         OpKind::Input { .. } => "Input",
         OpKind::ConstInt(_) => "ConstInt",
+        OpKind::ConstUInt(_) => "ConstUInt",
         OpKind::ConstBool(_) => "ConstBool",
         OpKind::ConstSymbolic { .. } => "ConstSymbolic",
         OpKind::ConstFloat(_) => "ConstFloat",
@@ -3044,6 +3055,10 @@ fn legacy_const_define_hlvalue(
         OpKind::ConstInt(n) => Ok(Some(Hlvalue::Constant(Constant::with_concretetype(
             ConstValue::Int(*n),
             LowLevelType::Signed,
+        )))),
+        OpKind::ConstUInt(n) => Ok(Some(Hlvalue::Constant(Constant::with_concretetype(
+            ConstValue::Int(*n as i64),
+            LowLevelType::Unsigned,
         )))),
         OpKind::ConstInt128(n) => Ok(Some(Hlvalue::Constant(Constant::with_concretetype(
             ConstValue::Int128(*n),

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1678,6 +1678,21 @@ pub fn translate_op(
                         // interpreter sites ported from `buffer[start:end]`.
                         return Ok(vec![FlowspaceOp::new("getslice", arg_hls, result)]);
                     }
+                    // Rust `Wtf8::as_bytes()[i]` is the byte-string operation
+                    // PyPy writes as `ord(utf8[i])` throughout rutf8.py. The
+                    // string repr's `getitem` yields SomeChar; preserve that
+                    // intermediate and let the ordinary `ord` rtyper turn it
+                    // into Signed.
+                    if segments.as_slice() == ["__string_byte_getitem"] && arg_hls.len() == 2 {
+                        let mut args = arg_hls.into_iter();
+                        let string = args.next().expect("string byte-view arg");
+                        let index = args.next().expect("string byte index arg");
+                        let byte = Hlvalue::Variable(Variable::new());
+                        return Ok(vec![
+                            FlowspaceOp::new("getitem", vec![string, index], byte.clone()),
+                            FlowspaceOp::new("ord", vec![byte], result),
+                        ]);
+                    }
                     // `[v; N]` array literal.  `front::mir` lowers
                     // `Rvalue::Repeat` to the `__array_repeat` synthetic
                     // carrying `(fill, count)` whenever the count decodes.

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1870,6 +1870,32 @@ pub fn translate_op(
                         call_args.extend(arg_hls);
                         return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
                     }
+                    // Exact RPython `rgc.ll_arraymove` call reconstructed by
+                    // the MIR list-storage adapter from Rust `ptr::copy`.
+                    if segments.len() == 1
+                        && segments[0] == crate::runtime_names::shims::LL_ARRAYMOVE
+                    {
+                        if arg_hls.len() != 4 {
+                            return Err(TyperError::message(format!(
+                                "__majit_ll_arraymove requires exactly four args, got {}",
+                                arg_hls.len()
+                            )));
+                        }
+                        let callable_host = HOST_ENV
+                            .lookup_builtin(crate::runtime_names::shims::LL_ARRAYMOVE)
+                            .ok_or_else(|| {
+                                TyperError::message(
+                                    "__majit_ll_arraymove missing from HOST_ENV bootstrap"
+                                        .to_string(),
+                                )
+                            })?;
+                        let mut call_args = Vec::with_capacity(arg_hls.len() + 1);
+                        call_args.push(Hlvalue::Constant(Constant::new(ConstValue::HostObject(
+                            callable_host,
+                        ))));
+                        call_args.extend(arg_hls);
+                        return Ok(vec![FlowspaceOp::new("simple_call", call_args, result)]);
+                    }
                     // `front::range_iter`'s synthesized `range(start, stop)`
                     // (the exclusive int-`Range` for-loop divert).  It carries
                     // the reserved `__majit_range` spelling rather than a bare

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -844,7 +844,7 @@ fn is_vec_ctor_segments(segments: &[String]) -> bool {
 /// fallible Rust reservation; translated callers take this exact path into
 /// `rtype_newlist_hint` and therefore retain both the capacity hint and the
 /// MemoryError edge.
-fn is_try_pyobject_vec_with_capacity_segments(segments: &[String]) -> bool {
+fn is_runtime_newlist_hint_segments(segments: &[String]) -> bool {
     segments.len() >= 2
         && segments[segments.len() - 2] == "builtins"
         && segments[segments.len() - 1] == "try_pyobject_vec_with_capacity"
@@ -2131,7 +2131,7 @@ pub fn translate_op(
                     // Result-to-exception pass has already made this call's
                     // result the normal-edge Vec payload, so the synthetic op
                     // has precisely the upstream one-argument/result shape.
-                    if is_try_pyobject_vec_with_capacity_segments(segments) {
+                    if is_runtime_newlist_hint_segments(segments) {
                         if arg_hls.len() != 1 {
                             return Err(TyperError::message(format!(
                                 "try_pyobject_vec_with_capacity requires exactly one size hint, got {}",
@@ -5117,7 +5117,7 @@ mod tests {
     }
 
     #[test]
-    fn translate_op_try_pyobject_vec_with_capacity_becomes_newlist_hint() {
+    fn translate_runtime_capacity_helper_becomes_newlist_hint() {
         let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
         let mut graph = LegacyGraph::new("translate_op_newlist_hint_fixture");
         let vars = mint_vars(&mut graph, 2);

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -3488,7 +3488,7 @@ pub(crate) fn derive_subject_inputcells(
                 // nominal instance.  The MIR front folds
                 // `bytes_block_chars`'s exact `(chars, length)` raw-slice
                 // view back to this header, so seed the header with the same
-                // `SomeString` cell that `project_pyre_field_type` assigns it.
+                // `SomeString` cell that `project_struct_field_type` assigns it.
                 // A generic raw-slice owner does not take this path.
                 if class_root.as_deref() == Some("BytesBlock") {
                     cells.push(crate::annotator::model::s_str0());
@@ -4758,7 +4758,7 @@ mod tests {
             "PyObject".to_string(),
             vec![("type_ptr".to_string(), "usize".to_string())],
         );
-        bk.set_pyre_struct_fields(Rc::new(fields));
+        bk.set_struct_fields(Rc::new(fields));
 
         let cells = derive_subject_inputcells(&graph, Some(&bk))
             .expect("source-typed PyObject input must seed a concrete class");

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -3486,6 +3486,17 @@ pub(crate) fn derive_subject_inputcells(
                     cells.push(crate::annotator::model::s_str0());
                     continue;
                 }
+                // `BytesBlock` is the low-level owner of Python bytes'
+                // RPython-shaped `STR.chars` storage, not a user-visible
+                // nominal instance.  The MIR front folds
+                // `bytes_block_chars`'s exact `(chars, length)` raw-slice
+                // view back to this header, so seed the header with the same
+                // `SomeString` cell that `project_pyre_field_type` assigns it.
+                // A generic raw-slice owner does not take this path.
+                if class_root.as_deref() == Some("BytesBlock") {
+                    cells.push(crate::annotator::model::s_str0());
+                    continue;
+                }
                 if let (Some(root), Some(bk)) = (class_root.as_ref(), bookkeeper) {
                     // A registered receiver-driven dispatch family (issue
                     // #346): a `dyn Trait` receiver whose bound-trait

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -4089,7 +4089,7 @@ pub fn function_graph_to_flowspace(
                     legacy_link.target, legacy_block.id,
                 ))
             })?;
-            let args: Vec<Hlvalue> = legacy_link
+            let mut args: Vec<Hlvalue> = legacy_link
                 .args
                 .iter()
                 .enumerate()
@@ -4103,6 +4103,37 @@ pub fn function_graph_to_flowspace(
                     )
                 })
                 .collect::<Result<Vec<_>, _>>()?;
+            // RPython `FlowContext.exc_from_raise` always computes
+            // `w_type = op.type(w_value)` before constructing the
+            // `(w_type, w_value)` link to `exceptblock`
+            // (`flowspace/flowcontext.py:629-630`).  Pyre's pre-flowspace
+            // model historically elided that operation and used the
+            // exception value in both slots because `flatten.make_return`
+            // only emits the second slot.  The rtyper observes the link
+            // earlier, however: `_convert_link` assigns
+            // `ExceptionData.r_exception_type` to slot 0 and must therefore
+            // receive the class representation, not the instance
+            // representation.
+            //
+            // Restore the upstream flowspace shape at this adapter boundary.
+            // Limit the reconstruction to the exact legacy adaptation:
+            // a direct, non-LastException link to `exceptblock` whose two
+            // arguments are the same Variable.  Ordinary exception edges
+            // already carry their distinct link-scoped `(last_exception,
+            // last_exc_value)` variables and must remain untouched.
+            let duplicated_direct_raise = legacy_link.target == legacy.exceptblock
+                && legacy_link.last_exception.is_none()
+                && legacy_link.last_exc_value.is_none()
+                && matches!(
+                    legacy_link.args.as_slice(),
+                    [LinkArg::Value(etype), LinkArg::Value(evalue)] if etype == evalue
+                );
+            if duplicated_direct_raise {
+                let evalue = args[1].clone();
+                let etype = Hlvalue::Variable(Variable::new());
+                translated_ops.push(FlowspaceOp::new("type", vec![evalue], etype.clone()));
+                args[0] = etype;
+            }
             let exitcase = exitcase_to_hlvalue(legacy_link.exitcase.as_ref());
             let mut link = FlowspaceLink::new(args, Some(target), exitcase);
             // RPython `Link.__init__` (`flowspace/model.rs:Link::new`) leaves
@@ -6527,6 +6558,66 @@ mod tests {
             exc_link.last_exc_value.as_ref(),
             "exception value arg must reuse link.last_exc_value Variable"
         );
+    }
+
+    #[test]
+    fn function_graph_to_flowspace_restores_type_op_for_duplicated_direct_raise() {
+        // `front::exc_from_raise` / `front::result_exc` historically encode a
+        // direct raise as `(evalue, evalue)` because the final `raise`
+        // bytecode reads only slot 1.  RPython's rtyper sees this graph before
+        // flattening and requires slot 0 to be the result of `type(evalue)`.
+        let mut graph = LegacyGraph::new("direct_raise");
+        let vars = mint_vars(&mut graph, 5);
+        setbinding(&vars[1], ValueType::Ref(None));
+
+        let startblock = Block {
+            id: graph.startblock,
+            inputargs: block_inputargs(&vars, &[1]),
+            operations: vec![],
+            exitswitch: None,
+            exits: vec![crate::model::Link::new_mixed(
+                vec![
+                    LinkArg::Value(vars[1].clone()),
+                    LinkArg::Value(vars[1].clone()),
+                ],
+                graph.exceptblock,
+                None,
+            )],
+            framestate: None,
+            dead: false,
+        };
+        let returnblock = Block {
+            id: graph.returnblock,
+            inputargs: block_inputargs(&vars, &[2]),
+            operations: vec![],
+            exitswitch: None,
+            exits: vec![],
+            framestate: None,
+            dead: false,
+        };
+        let exceptblock = Block {
+            id: graph.exceptblock,
+            inputargs: block_inputargs(&vars, &[3, 4]),
+            operations: vec![],
+            exitswitch: None,
+            exits: vec![],
+            framestate: None,
+            dead: false,
+        };
+        graph.blocks = vec![startblock, returnblock, exceptblock];
+
+        let output = function_graph_to_flowspace(&graph, &empty_call_registry())
+            .expect("direct raise graph assembles");
+        let flowspace_graph = output.graph.borrow();
+        let startblock = flowspace_graph.startblock.borrow();
+        let [type_op] = startblock.operations.as_slice() else {
+            panic!("direct raise must gain exactly one type operation");
+        };
+        assert_eq!(type_op.opname, "type");
+        let exc_link = startblock.exits[0].borrow();
+        assert_eq!(type_op.args, vec![exc_link.args[1].clone().unwrap()]);
+        assert_eq!(exc_link.args[0].as_ref(), Some(&type_op.result));
+        assert_ne!(exc_link.args[0], exc_link.args[1]);
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -3478,6 +3478,20 @@ pub(crate) fn derive_subject_inputcells(
             // classdef-less shell, narrowed by call-propagation as before
             // (`description.py FunctionDesc.pycall`).
             if matches!(ty, crate::model::ValueType::Ref(_)) {
+                // Rust's `gc_roots::pin_root(PyObjectRef)` parameter is the
+                // source spelling of RPython GC-transformer's opaque root
+                // slot.  The front marks that exact input as `GCREF`; seed a
+                // SomePtr(GCREF), not the W_Root-like SomeInstance fallback,
+                // so heterogeneous StringRepr / InstanceRepr livevars meet
+                // only after their ordinary cast_opaque_ptr conversion.
+                if class_root.as_deref() == Some("GCREF") {
+                    cells.push(
+                        crate::translator::rtyper::llannotation::lltype_to_annotation(
+                            crate::translator::rtyper::lltypesystem::lltype::GCREF.clone(),
+                        ),
+                    );
+                    continue;
+                }
                 // A list-typed param (`Vec<T>`, `&[T]`, …) carries its
                 // full monomorphic spelling as `class_root` (the named-ADT
                 // root resolver excludes the core/std/alloc container

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1644,6 +1644,24 @@ pub fn translate_op(
                             result,
                         )]);
                     }
+                    if segments.as_slice() == ["__getslice_rangefrom"] && arg_hls.len() == 2 {
+                        // slice, start -> getslice(slice, start, None).
+                        // RPython `decompose_slice_args` selects StartOnly;
+                        // the frontend records only SliceIndex<usize>
+                        // consumers, which prove the runtime start nonnegative.
+                        let mut args = arg_hls.into_iter();
+                        let slice = args.next().expect("slice arg");
+                        let start = args.next().expect("RangeFrom start arg");
+                        return Ok(vec![FlowspaceOp::new(
+                            "getslice",
+                            vec![
+                                slice,
+                                start,
+                                Hlvalue::Constant(Constant::new(ConstValue::None)),
+                            ],
+                            result,
+                        )]);
+                    }
                     if segments.as_slice() == ["__getslice_range"] && arg_hls.len() == 3 {
                         // slice, start, end -> getslice(slice, start, end)
                         // The frontend plants this marker only after proving
@@ -5063,6 +5081,40 @@ mod tests {
             Hlvalue::Constant(Constant::new(ConstValue::Int(0)))
         );
         assert_eq!(translated[0].args[2], end);
+        assert_eq!(translated[0].result, result);
+    }
+
+    #[test]
+    fn translate_op_getslice_rangefrom_expands_after_annotation() {
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let mut graph = LegacyGraph::new("translate_op_getslice_rangefrom_fixture");
+        let vars = mint_vars(&mut graph, 3);
+        let slice = Hlvalue::Variable(Variable::new());
+        let start = Hlvalue::Variable(Variable::new());
+        let result = Hlvalue::Variable(Variable::new());
+        value_map.insert(vars[0].clone(), slice.clone());
+        value_map.insert(vars[1].clone(), start.clone());
+        value_map.insert(vars[2].clone(), result.clone());
+        let op = SpaceOperation {
+            result: Some(vars[2].clone()),
+            kind: OpKind::Call {
+                target: crate::model::CallTarget::FunctionPath {
+                    segments: vec!["__getslice_rangefrom".into()],
+                },
+                args: vec![vars[0].clone(), vars[1].clone()],
+                result_ty: ValueType::Ref(None),
+            },
+        };
+        let translated = translate_op(&op, &value_map, &empty_call_registry())
+            .expect("RangeFrom marker must lower");
+        assert_eq!(translated.len(), 1);
+        assert_eq!(translated[0].opname, "getslice");
+        assert_eq!(translated[0].args[0], slice);
+        assert_eq!(translated[0].args[1], start);
+        assert_eq!(
+            translated[0].args[2],
+            Hlvalue::Constant(Constant::new(ConstValue::None))
+        );
         assert_eq!(translated[0].result, result);
     }
 

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1674,10 +1674,8 @@ pub fn translate_op(
                     }
                     if segments.as_slice() == ["__getslice_range"] && arg_hls.len() == 3 {
                         // slice, start, end -> getslice(slice, start, end)
-                        // The frontend plants this marker only after proving
-                        // `0 <= start <= end == len(slice)`, preserving Rust's
-                        // checked Range semantics before entering RPython's
-                        // startstop list-slice lowering.
+                        // This is the direct RPython flow-space shape for the
+                        // interpreter sites ported from `buffer[start:end]`.
                         return Ok(vec![FlowspaceOp::new("getslice", arg_hls, result)]);
                     }
                     // `[v; N]` array literal.  `front::mir` lowers

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -265,6 +265,7 @@ fn infer_op_type(kind: &OpKind) -> ValueType {
     match kind {
         OpKind::Input { ty, .. } => ty.clone(),
         OpKind::ConstInt(_) => ValueType::Int,
+        OpKind::ConstUInt(_) => ValueType::Unsigned,
         OpKind::ConstInt128(_) => ValueType::Int128,
         OpKind::ConstUInt128(_) => ValueType::UInt128,
         OpKind::ConstBool(_) => ValueType::Bool,

--- a/majit/majit-translate/src/translator/rtyper/legacy_resolve.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_resolve.rs
@@ -559,6 +559,9 @@ fn maybe_seed_concrete_type(dst: &Variable, src_ty: ConcreteType) -> bool {
 fn infer_concrete_from_op(kind: &OpKind) -> ConcreteType {
     match kind {
         OpKind::ConstInt(_) => ConcreteType::Signed,
+        // Unsigned shares the JIT integer register bank with Signed; the
+        // annotation/repr distinction is carried separately.
+        OpKind::ConstUInt(_) => ConcreteType::Signed,
         // RPython `getkind(lltype.Bool) == 'int'` (flatten.py:getkind);
         // codewriter folds Bool storage to int kind.
         OpKind::ConstBool(_) => ConcreteType::Signed,

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -3662,11 +3662,39 @@ pub fn rtype_cast_instance_intrinsic(
     let r_arg0 = arg_repr(hop, 0)?;
     let v_ptr = hop.inputarg(&r_arg0, 0)?;
     hop.exception_cannot_occur()?;
-    Ok(hop.genop(
-        "cast_pointer",
-        vec![v_ptr],
-        GenopResult::LLType(result_lltype),
-    ))
+    if r_arg0.lowleveltype() == &result_lltype {
+        return Ok(Some(v_ptr));
+    }
+    // RPython `rmodel.externalvsinternal(..., gcref=True)` converts a
+    // concrete GC pointer to/from llmemory.GCREF with `cast_opaque_ptr`
+    // (`rgcref.py:52-63`).  The same marker also carries ordinary
+    // class-pointer narrows, which remain `cast_pointer` per rclass.py.
+    let gcref = crate::translator::rtyper::lltypesystem::lltype::GCREF.clone();
+    if r_result.class_name() == "StringRepr" && r_arg0.lowleveltype() != &gcref {
+        // The MIR call-result narrow has already restored the generic
+        // PyObjectRef carrier to its W_Root-shaped external pointer.  A
+        // string-list store immediately recasts that same root-stack word to
+        // StringRepr.  Upstream performs both edges through GCRefRepr, so
+        // materialize the exact concrete→GCREF→STRPTR pair instead of an
+        // invalid cast_pointer between unrelated GC structs.
+        let Some(v_gcref) = hop.genop("cast_opaque_ptr", vec![v_ptr], GenopResult::LLType(gcref))
+        else {
+            return Err(TyperError::message(
+                "rtype_cast_instance_intrinsic: cast to GCREF produced no value",
+            ));
+        };
+        return Ok(hop.genop(
+            "cast_opaque_ptr",
+            vec![v_gcref],
+            GenopResult::LLType(result_lltype),
+        ));
+    }
+    let opname = if r_arg0.lowleveltype() == &gcref || result_lltype == gcref {
+        "cast_opaque_ptr"
+    } else {
+        "cast_pointer"
+    };
+    Ok(hop.genop(opname, vec![v_ptr], GenopResult::LLType(result_lltype)))
 }
 
 #[cfg(test)]

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -254,6 +254,10 @@ fn install_default_typers(map: &mut HashMap<HostObject, BuiltinTyperFn>) {
             crate::runtime_names::shims::CAST_ADDRESS,
             rtype_cast_instance_intrinsic,
         ),
+        (
+            crate::runtime_names::shims::LL_ARRAYMOVE,
+            rtype_ll_arraymove_intrinsic,
+        ),
     ];
     for (name, typer) in entries {
         if let Some(host) = HOST_ENV.lookup_builtin(name) {
@@ -3695,6 +3699,60 @@ pub fn rtype_cast_instance_intrinsic(
         "cast_pointer"
     };
     Ok(hop.genop(opname, vec![v_ptr], GenopResult::LLType(result_lltype)))
+}
+
+/// Restore the MIR adapter marker to RPython
+/// `rgc.ll_arraymove(array, source_start, dest_start, length)`.
+///
+/// The currently admitted producer is `ll_delitem_nonneg`'s leftward move
+/// (`source_start = dest_start + 1`).  Its `delta < 0` slow path in
+/// `rpython/rlib/rgc.py` copies forward, exactly the general element-copy
+/// helper used here.  The helper retains upstream's one-array, four-argument
+/// call shape and its overlap semantics for this proven direction.
+pub fn rtype_ll_arraymove_intrinsic(
+    hop: &HighLevelOp,
+    _kwds_i: &HashMap<String, usize>,
+) -> RTypeResult {
+    use crate::translator::rtyper::rlist::{
+        FixedSizeListRepr, build_ll_arraymove_left_helper_graph,
+    };
+
+    let r_array = arg_repr(hop, 0)?;
+    let any_array: &dyn std::any::Any = r_array.as_ref();
+    let fixed = any_array
+        .downcast_ref::<FixedSizeListRepr>()
+        .ok_or_else(|| {
+            TyperError::message(
+                "rtype_ll_arraymove_intrinsic requires FixedSizeListRepr items".to_string(),
+            )
+        })?;
+    let item_lltype = fixed.item_lowleveltype();
+    let array_lltype = r_array.lowleveltype().clone();
+    let mut args = hop.inputargs(vec![
+        ConvertedTo::Repr(r_array.as_ref()),
+        ConvertedTo::LowLevelType(&LowLevelType::Signed),
+        ConvertedTo::LowLevelType(&LowLevelType::Signed),
+        ConvertedTo::LowLevelType(&LowLevelType::Signed),
+    ])?;
+    let array = args.remove(0);
+    let source_start = args.remove(0);
+    let dest_start = args.remove(0);
+    let length = args.remove(0);
+    let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+        "ll_arraymove".to_string(),
+        vec![
+            array_lltype,
+            LowLevelType::Signed,
+            LowLevelType::Signed,
+            LowLevelType::Signed,
+        ],
+        LowLevelType::Void,
+        move |_rtyper, _args, _result| {
+            build_ll_arraymove_left_helper_graph("ll_arraymove", item_lltype.clone())
+        },
+    )?;
+    hop.exception_cannot_occur()?;
+    hop.gendirectcall(&helper, vec![array, source_start, dest_start, length])
 }
 
 #[cfg(test)]

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -3671,27 +3671,52 @@ pub fn rtype_cast_instance_intrinsic(
     }
     // RPython `rmodel.externalvsinternal(..., gcref=True)` converts a
     // concrete GC pointer to/from llmemory.GCREF with `cast_opaque_ptr`
-    // (`rgcref.py:52-63`).  The same marker also carries ordinary
+    // (`rgcref.py:61-71`).  The same marker also carries ordinary
     // class-pointer narrows, which remain `cast_pointer` per rclass.py.
     let gcref = crate::translator::rtyper::lltypesystem::lltype::GCREF.clone();
-    if r_result.class_name() == "StringRepr" && r_arg0.lowleveltype() != &gcref {
-        // The MIR call-result narrow has already restored the generic
-        // PyObjectRef carrier to its W_Root-shaped external pointer.  A
-        // string-list store immediately recasts that same root-stack word to
-        // StringRepr.  Upstream performs both edges through GCRefRepr, so
-        // materialize the exact concrete→GCREF→STRPTR pair instead of an
-        // invalid cast_pointer between unrelated GC structs.
-        let Some(v_gcref) = hop.genop("cast_opaque_ptr", vec![v_ptr], GenopResult::LLType(gcref))
+    // `cast_pointer` is legal only between related structs: upstream decides
+    // that with `castable(PTRTYPE, CURTYPE)` (`lltype.py:944-961`), which
+    // raises `InvalidCast` for an unrelated pair.  An unrelated pair of GC
+    // pointers is exactly the erasure RPython routes through
+    // `llmemory.GCREF` — `pairtype(Repr, GCRefRepr).convert_from_to` casts
+    // the source to GCREF and `pairtype(GCRefRepr, Repr).convert_from_to`
+    // casts GCREF to the destination (`rgcref.py:61-71`).  Call those two
+    // ported functions rather than re-emitting their ops, so a destination
+    // that is not a GC pointer refuses here as it does upstream instead of
+    // producing an invalid `cast_pointer`.
+    if r_arg0.lowleveltype() != &gcref
+        && result_lltype != gcref
+        && let (LowLevelType::Ptr(cur), LowLevelType::Ptr(dest)) =
+            (r_arg0.lowleveltype(), &result_lltype)
+        && crate::translator::rtyper::lltypesystem::lltype::castable(dest, cur).is_err()
+    {
+        use crate::translator::rtyper::lltypesystem::rgcref::{
+            GCRefRepr, pair_gcref_repr_convert_from_to, pair_repr_gcref_convert_from_to,
+        };
+        let r_gcref = GCRefRepr::make(r_arg0.clone(), &hop.rtyper.gcrefreprcache) as Arc<dyn Repr>;
+        let mut llops = hop.llops.borrow_mut();
+        let Some(v_gcref) =
+            pair_repr_gcref_convert_from_to(r_arg0.as_ref(), r_gcref.as_ref(), &v_ptr, &mut llops)?
         else {
             return Err(TyperError::message(
-                "rtype_cast_instance_intrinsic: cast to GCREF produced no value",
+                "rtype_cast_instance_intrinsic: conversion to GCREF produced no value",
             ));
         };
-        return Ok(hop.genop(
-            "cast_opaque_ptr",
-            vec![v_gcref],
-            GenopResult::LLType(result_lltype),
-        ));
+        let Some(v_result) = pair_gcref_repr_convert_from_to(
+            r_gcref.as_ref(),
+            r_result.as_ref(),
+            &v_gcref,
+            &mut llops,
+        )?
+        else {
+            return Err(TyperError::message(format!(
+                "rtype_cast_instance_intrinsic: {:?} is not castable from {:?} and \
+                 pairtype(GCRefRepr, Repr).convert_from_to refuses a non-GC destination",
+                result_lltype,
+                r_arg0.lowleveltype(),
+            )));
+        };
+        return Ok(Some(v_result));
     }
     let opname = if r_arg0.lowleveltype() == &gcref || result_lltype == gcref {
         "cast_opaque_ptr"
@@ -3738,8 +3763,13 @@ pub fn rtype_ll_arraymove_intrinsic(
     let source_start = args.remove(0);
     let dest_start = args.remove(0);
     let length = args.remove(0);
+    // Minted as `ll_arraymove_left`, not `ll_arraymove`: the graph is only
+    // upstream's `delta < 0` arm, and `lowlevel_helper_function_with_builder`
+    // caches on `(name, args, result)`.  A right-move producer would present
+    // the identical key and receive this left-only loop, which smears the
+    // first element across the overlap.
     let helper = hop.rtyper.lowlevel_helper_function_with_builder(
-        "ll_arraymove".to_string(),
+        "ll_arraymove_left".to_string(),
         vec![
             array_lltype,
             LowLevelType::Signed,
@@ -3748,7 +3778,7 @@ pub fn rtype_ll_arraymove_intrinsic(
         ],
         LowLevelType::Void,
         move |_rtyper, _args, _result| {
-            build_ll_arraymove_left_helper_graph("ll_arraymove", item_lltype.clone())
+            build_ll_arraymove_left_helper_graph("ll_arraymove_left", item_lltype.clone())
         },
     )?;
     hop.exception_cannot_occur()?;

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -3311,6 +3311,79 @@ impl Repr for InstanceRepr {
         ReprClassId::InstanceRepr
     }
 
+    /// RPython `InstanceRepr.rtype_type(self, hop)` (rclass.py):
+    ///
+    /// ```python
+    /// def rtype_type(self, hop):
+    ///     if hop.s_result.is_constant():
+    ///         return hop.inputconst(hop.r_result, hop.s_result.const)
+    ///     instance_repr = self.common_repr()
+    ///     vinst, = hop.inputargs(instance_repr)
+    ///     if hop.args_s[0].can_be_none():
+    ///         return hop.gendirectcall(ll_inst_type, vinst)
+    ///     else:
+    ///         return instance_repr.getfield(vinst, '__class__', hop.llops)
+    /// ```
+    fn rtype_type(&self, hop: &HighLevelOp) -> RTypeResult {
+        use crate::annotator::model::SomeObjectTrait;
+        use crate::translator::rtyper::rtyper::ConvertedTo;
+
+        // upstream: `if hop.s_result.is_constant(): ...`.
+        let s_result = hop
+            .s_result
+            .borrow()
+            .clone()
+            .ok_or_else(|| TyperError::message("InstanceRepr.rtype_type: s_result missing"))?;
+        if s_result.is_constant() {
+            let r_result =
+                hop.r_result.borrow().clone().ok_or_else(|| {
+                    TyperError::message("InstanceRepr.rtype_type: r_result missing")
+                })?;
+            let value = s_result
+                .const_()
+                .expect("s_result.is_constant() implies const_() is Some");
+            return HighLevelOp::inputconst(ConvertedTo::Repr(r_result.as_ref()), value)
+                .map(Hlvalue::Constant)
+                .map(Some);
+        }
+
+        // upstream: `instance_repr = self.common_repr();
+        //            vinst, = hop.inputargs(instance_repr)`.
+        let instance_repr = self.common_repr()?;
+        let mut vinst =
+            hop.inputargs(vec![ConvertedTo::Repr(instance_repr.as_ref() as &dyn Repr)])?;
+        let vinst = vinst
+            .pop()
+            .expect("one converted argument for unary type operation");
+
+        // upstream: `if hop.args_s[0].can_be_none():
+        //                return hop.gendirectcall(ll_inst_type, vinst)`.
+        let can_be_none = hop
+            .args_s
+            .borrow()
+            .first()
+            .ok_or_else(|| TyperError::message("InstanceRepr.rtype_type: args_s[0] missing"))?
+            .can_be_none();
+        if can_be_none {
+            let rtyper = self.rtyper.upgrade().ok_or_else(|| {
+                TyperError::message("InstanceRepr.rtype_type: rtyper weak ref expired")
+            })?;
+            let helper = rtyper.lowlevel_helper_function(
+                "ll_inst_type",
+                vec![instance_repr.lowleveltype().clone()],
+                CLASSTYPE.clone(),
+            )?;
+            return hop.gendirectcall(&helper, vec![vinst]);
+        }
+
+        // upstream non-null arm: read the root instance's `__class__`
+        // field directly.
+        let mut llops = hop.llops.borrow_mut();
+        let vtype =
+            instance_repr.getfield(vinst, "__class__", &mut llops, false, &Flags::default())?;
+        Ok(Some(Hlvalue::Variable(vtype)))
+    }
+
     /// RPython `InstanceRepr.rtype_getattr(self, hop)` (rclass.py):
     ///
     /// ```python
@@ -5615,6 +5688,51 @@ mod tests {
         assert_eq!(mangled, "typeptr");
         assert_eq!(field_repr.lowleveltype(), &CLASSTYPE.clone());
         assert!(repr.allinstancefields().contains_key("__class__"));
+    }
+
+    #[test]
+    fn instance_repr_rtype_type_nonnull_reads_class_field() {
+        use crate::annotator::model::{SomeInstance, SomeObject, SomeTypeOf, SomeValue};
+        use crate::flowspace::model::SpaceOperation;
+        use std::cell::RefCell as StdRef;
+
+        let rtyper = fresh_rtyper();
+        let repr = getinstancerepr(&rtyper, None, Flavor::Gc).expect("root instance repr");
+        Repr::setup(repr.as_ref()).expect("setup root instance repr");
+
+        let v_obj = Variable::new();
+        v_obj.set_concretetype(Some(repr.lowleveltype().clone()));
+        let v_obj_h = Hlvalue::Variable(v_obj.clone());
+        let v_result = Variable::new();
+        let spaceop =
+            SpaceOperation::new("type", vec![v_obj_h.clone()], Hlvalue::Variable(v_result));
+        let llops = Rc::new(StdRef::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper.clone(), spaceop, Vec::new(), llops);
+        hop.args_v.borrow_mut().push(v_obj_h);
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::Instance(SomeInstance {
+                base: SomeObject::default(),
+                classdef: None,
+                can_be_none: false,
+                flags: Default::default(),
+            }));
+        hop.args_r.borrow_mut().push(Some(repr.clone()));
+        *hop.s_result.borrow_mut() = Some(SomeValue::TypeOf(SomeTypeOf::new(vec![Rc::new(v_obj)])));
+        *hop.r_result.borrow_mut() = Some(get_type_repr(&rtyper).expect("type repr"));
+
+        let out = repr
+            .rtype_type(&hop)
+            .expect("nonnull instance type() must rtype")
+            .expect("type() returns a class pointer");
+        assert!(matches!(out, Hlvalue::Variable(_)));
+        let ops = hop.llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "getfield");
+        let Hlvalue::Variable(result) = &ops.ops[0].result else {
+            panic!("getfield result must be a Variable")
+        };
+        assert_eq!(result.concretetype(), Some(CLASSTYPE.clone()));
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -5591,6 +5591,65 @@ mod tests {
     }
 
     #[test]
+    fn preminted_generic_enum_variant_repr_contains_payload_field() {
+        use crate::annotator::annrpython::RPythonAnnotator;
+        use crate::front::StructFieldRegistry;
+        use std::collections::HashMap;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata");
+
+        let root = "option::Option<Vec<u8>>";
+        let variant = "option::Option<Vec<u8>>::Some";
+        let mut fields = StructFieldRegistry::default();
+        fields.fields.insert(
+            "option::Option".to_string(),
+            vec![("__discriminant".to_string(), "i64".to_string())],
+        );
+        fields.fields.insert(
+            "option::Option::Some".to_string(),
+            vec![("__pos_0".to_string(), "??T".to_string())],
+        );
+        fields.fields.insert(
+            variant.to_string(),
+            vec![("__pos_0".to_string(), "Vec<u8>".to_string())],
+        );
+        ann.bookkeeper.set_struct_fields(Rc::new(fields));
+
+        let mut variants = HashMap::new();
+        variants.insert(
+            root.to_string(),
+            HashMap::from([(0, "Some".to_string()), (1, "None".to_string())]),
+        );
+        ann.bookkeeper
+            .set_enum_variant_by_discriminant(Rc::new(variants));
+
+        // CallRegistry::ensure_session projects every registry root first,
+        // then pre-mints the enum subtree before any subject is rtyped.
+        for name in ann.bookkeeper.struct_root_names() {
+            ann.bookkeeper
+                .getuniqueclassdef_for_struct_root(&name)
+                .expect("project struct root");
+        }
+        ann.bookkeeper.pre_register_enum_variant_classes();
+
+        let classdef = ann
+            .bookkeeper
+            .getuniqueclassdef_for_enum_variant(root, "Some")
+            .expect("resolve preminted Some classdef");
+        let repr = getinstancerepr(&rtyper, Some(&classdef), Flavor::Gc)
+            .expect("build preminted Some repr");
+        Repr::setup(repr.as_ref()).expect("setup preminted Some repr");
+        assert!(
+            repr.fields().contains_key("__pos_0"),
+            "variant payload must be present when InstanceRepr is first set up"
+        );
+    }
+
+    #[test]
     fn instance_repr_pyerror_to_exc_object_emits_residual_direct_call() {
         use crate::annotator::annrpython::RPythonAnnotator;
         use crate::annotator::model::{SomeInstance, SomeObject, SomeValue};

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -2802,24 +2802,51 @@ pub(crate) fn build_ll_arraycopy_general_helper_graph(
     ))
 }
 
-/// Synthesise the forward-copy branch of
-/// `rgc.ll_arraymove(array, source_start, dest_start, length)`
-/// (`rpython/rlib/rgc.py:415-456`) with the upstream four-argument shape.
+/// Synthesise the `delta < 0` branch of `rgc.ll_arraymove`
+/// (`rpython/rlib/rgc.py`, `ll_arraymove`) with the upstream four-argument
+/// shape.
 ///
 /// The caller proves `source_start > dest_start`, which is upstream's
 /// `delta < 0` case.  Copying from low to high indices is therefore the
-/// overlap-safe direction used by RPython's slow path:
+/// overlap-safe direction, and upstream spells it:
 ///
 /// ```python
-/// i = 0
-/// while i < length:
-///     array[dest_start + i] = array[source_start + i]
-///     i += 1
+/// delta = dest_start - source_start
+/// if delta < 0:
+///     i = source_start
+///     stop = source_start + length
+///     while i < stop:
+///         copy_item(array, array, i, i + delta)
+///         i += 1
 /// ```
 ///
-/// Lowering each assignment as `setarrayitem` retains pyre's ordinary GC
-/// write barrier.  This is stronger than upstream's bulk-move fast path and
-/// has the same pointer-reachability semantics.
+/// The emitted loop rebases that induction variable to zero — `i` runs
+/// `0..length` and both ends are offset — instead of carrying `delta` and
+/// `stop`.  The two are equal at every index; the rebase exists because the
+/// caller already reconstructed `(source_start, dest_start, length)` from
+/// MIR and never materialised a `delta`.
+///
+/// Three parts of `ll_arraymove` are NOT emitted, and each is a named gap
+/// rather than a simplification:
+///
+/// * The `length <= 1` head.  Upstream's own comment says it is there "to
+///   ensure that we get a proper effectinfo.write_descrs_arrays", not for
+///   speed, and the minted helper carries no `list.ll_arraymove` oopspec
+///   either — the same pairing `ll_arraycopy` is still missing.
+/// * The `delta > 0` arm and the `raw_memmove_no_free` fast path.  Only the
+///   left move exists, which is why the helper is minted as
+///   `ll_arraymove_left`: the rtyper caches low-level helpers on
+///   `(name, args, result)`, and a right-move producer — `insert`'s
+///   `ll_arraymove(l, index, index + 1, length - index)` — would have the
+///   identical key and silently receive this graph.
+/// * The `must_split_gc_address_space()` / `_contains_gcptr` dispatch.  The
+///   body below IS upstream's split-address-space branch, taken
+///   unconditionally; note that this is exactly the branch in which upstream
+///   does not emit `gc_writebarrier_before_move`, since that call is the
+///   `elif`.  Per-item `setarrayitem` marks its own cards, so no card can go
+///   stale here, but the barrier llop does exist
+///   (`lltypesystem::lloperation`) and emitting the dispatch is the
+///   convergence path.
 pub(crate) fn build_ll_arraymove_left_helper_graph(
     name: &str,
     item_lltype: LowLevelType,

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -90,6 +90,10 @@ impl FixedSizeListRepr {
             external_item_repr,
         })
     }
+
+    pub(crate) fn item_lowleveltype(&self) -> LowLevelType {
+        self.item_repr.lowleveltype().clone()
+    }
 }
 
 /// RPython `AbstractBaseListRepr.recast(self, llops, v)` (`rlist.py`):
@@ -2617,7 +2621,7 @@ fn build_ll_arraycopy_helper_graph(
 /// fast-path machinery of upstream `rgc.ll_arraycopy` is a translation-time
 /// concern; the lowered body is the bare element loop (`getarrayitem` +
 /// `setarrayitem`).
-fn build_ll_arraycopy_general_helper_graph(
+pub(crate) fn build_ll_arraycopy_general_helper_graph(
     name: &str,
     item_lltype: LowLevelType,
 ) -> Result<PyGraph, TyperError> {
@@ -2790,6 +2794,195 @@ fn build_ll_arraycopy_general_helper_graph(
         vec![
             "source".to_string(),
             "dest".to_string(),
+            "source_start".to_string(),
+            "dest_start".to_string(),
+            "length".to_string(),
+        ],
+        func,
+    ))
+}
+
+/// Synthesise the forward-copy branch of
+/// `rgc.ll_arraymove(array, source_start, dest_start, length)`
+/// (`rpython/rlib/rgc.py:415-456`) with the upstream four-argument shape.
+///
+/// The caller proves `source_start > dest_start`, which is upstream's
+/// `delta < 0` case.  Copying from low to high indices is therefore the
+/// overlap-safe direction used by RPython's slow path:
+///
+/// ```python
+/// i = 0
+/// while i < length:
+///     array[dest_start + i] = array[source_start + i]
+///     i += 1
+/// ```
+///
+/// Lowering each assignment as `setarrayitem` retains pyre's ordinary GC
+/// write barrier.  This is stronger than upstream's bulk-move fast path and
+/// has the same pointer-reachability semantics.
+pub(crate) fn build_ll_arraymove_left_helper_graph(
+    name: &str,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let items_ptr = items_array_ptr_lltype(&item_lltype);
+
+    let array = variable_with_lltype("array", items_ptr.clone());
+    let src_start = variable_with_lltype("source_start", LowLevelType::Signed);
+    let dst_start = variable_with_lltype("dest_start", LowLevelType::Signed);
+    let length = variable_with_lltype("length", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(array.clone()),
+        Hlvalue::Variable(src_start.clone()),
+        Hlvalue::Variable(dst_start.clone()),
+        Hlvalue::Variable(length.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", LowLevelType::Void);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // Loop blocks carry (array, source_start, dest_start, length, i).
+    let array_c = variable_with_lltype("array", items_ptr.clone());
+    let src_start_c = variable_with_lltype("source_start", LowLevelType::Signed);
+    let dst_start_c = variable_with_lltype("dest_start", LowLevelType::Signed);
+    let length_c = variable_with_lltype("length", LowLevelType::Signed);
+    let i_c = variable_with_lltype("i", LowLevelType::Signed);
+    let block_cond = Block::shared(vec![
+        Hlvalue::Variable(array_c.clone()),
+        Hlvalue::Variable(src_start_c.clone()),
+        Hlvalue::Variable(dst_start_c.clone()),
+        Hlvalue::Variable(length_c.clone()),
+        Hlvalue::Variable(i_c.clone()),
+    ]);
+
+    let array_b = variable_with_lltype("array", items_ptr.clone());
+    let src_start_b = variable_with_lltype("source_start", LowLevelType::Signed);
+    let dst_start_b = variable_with_lltype("dest_start", LowLevelType::Signed);
+    let length_b = variable_with_lltype("length", LowLevelType::Signed);
+    let i_b = variable_with_lltype("i", LowLevelType::Signed);
+    let block_body = Block::shared(vec![
+        Hlvalue::Variable(array_b.clone()),
+        Hlvalue::Variable(src_start_b.clone()),
+        Hlvalue::Variable(dst_start_b.clone()),
+        Hlvalue::Variable(length_b.clone()),
+        Hlvalue::Variable(i_b.clone()),
+    ]);
+
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(array),
+                Hlvalue::Variable(src_start),
+                Hlvalue::Variable(dst_start),
+                Hlvalue::Variable(length),
+                signed_const(0),
+            ],
+            Some(block_cond.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let cond = variable_with_lltype("cond", LowLevelType::Bool);
+    block_cond.borrow_mut().operations.push(SpaceOperation::new(
+        "int_lt",
+        vec![
+            Hlvalue::Variable(i_c.clone()),
+            Hlvalue::Variable(length_c.clone()),
+        ],
+        Hlvalue::Variable(cond.clone()),
+    ));
+    block_cond.borrow_mut().exitswitch = Some(Hlvalue::Variable(cond));
+    block_cond.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(array_c),
+                Hlvalue::Variable(src_start_c),
+                Hlvalue::Variable(dst_start_c),
+                Hlvalue::Variable(length_c),
+                Hlvalue::Variable(i_c),
+            ],
+            Some(block_body.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![none_void_const()],
+            Some(graph.returnblock.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    let source_index = variable_with_lltype("source_index", LowLevelType::Signed);
+    block_body.borrow_mut().operations.push(SpaceOperation::new(
+        "int_add",
+        vec![
+            Hlvalue::Variable(src_start_b.clone()),
+            Hlvalue::Variable(i_b.clone()),
+        ],
+        Hlvalue::Variable(source_index.clone()),
+    ));
+    let dest_index = variable_with_lltype("dest_index", LowLevelType::Signed);
+    block_body.borrow_mut().operations.push(SpaceOperation::new(
+        "int_add",
+        vec![
+            Hlvalue::Variable(dst_start_b.clone()),
+            Hlvalue::Variable(i_b.clone()),
+        ],
+        Hlvalue::Variable(dest_index.clone()),
+    ));
+    let item = variable_with_lltype("item", item_lltype);
+    block_body.borrow_mut().operations.push(SpaceOperation::new(
+        "getarrayitem",
+        vec![
+            Hlvalue::Variable(array_b.clone()),
+            Hlvalue::Variable(source_index),
+        ],
+        Hlvalue::Variable(item.clone()),
+    ));
+    let store_void = variable_with_lltype("store", LowLevelType::Void);
+    block_body.borrow_mut().operations.push(SpaceOperation::new(
+        "setarrayitem",
+        vec![
+            Hlvalue::Variable(array_b.clone()),
+            Hlvalue::Variable(dest_index),
+            Hlvalue::Variable(item),
+        ],
+        Hlvalue::Variable(store_void),
+    ));
+    let i_next = variable_with_lltype("i", LowLevelType::Signed);
+    block_body.borrow_mut().operations.push(SpaceOperation::new(
+        "int_add",
+        vec![Hlvalue::Variable(i_b), signed_const(1)],
+        Hlvalue::Variable(i_next.clone()),
+    ));
+    block_body.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(array_b),
+                Hlvalue::Variable(src_start_b),
+                Hlvalue::Variable(dst_start_b),
+                Hlvalue::Variable(length_b),
+                Hlvalue::Variable(i_next),
+            ],
+            Some(block_cond),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec![
+            "array".to_string(),
             "source_start".to_string(),
             "dest_start".to_string(),
             "length".to_string(),

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -453,6 +453,62 @@ pub fn rtype_newlist(hop: &HighLevelOp) -> RTypeResult {
     ))
 }
 
+/// RPython `objectmodel.py`'s `newlist_hint` ExtRegistry specialization and
+/// `lltypesystem/rlist.py:ll_newlist_hint`:
+///
+/// ```python
+/// def specialize_call(self, hop):
+///     v_hint = hop.inputarg(lltype.Signed, 0)
+///     r_list = hop.r_result
+///     hop.exception_is_here()
+///     return hop.gendirectcall(r_list.LIST.ll_newlist_hint, v_hint)
+///
+/// def ll_newlist_hint(LIST, lengthhint):
+///     ll_assert(lengthhint >= 0, "negative list length")
+///     l = malloc(LIST)
+///     l.length = 0
+///     l.items = malloc(LIST.items.TO, lengthhint)
+///     return l
+/// ```
+///
+/// The annotator marks the result resized, so only [`ListRepr`] is valid.
+/// Capacity and logical length intentionally differ: the backing array uses
+/// `lengthhint`, while the list header starts at zero for subsequent append.
+pub fn rtype_newlist_hint(hop: &HighLevelOp) -> RTypeResult {
+    if hop.nb_args() != 1 {
+        return Err(TyperError::message(format!(
+            "rtype_newlist_hint: expected one size hint, got {}",
+            hop.nb_args()
+        )));
+    }
+    let r_result = hop
+        .r_result
+        .borrow()
+        .clone()
+        .ok_or_else(|| TyperError::message("rtype_newlist_hint: r_result missing"))?;
+    let any_r: &dyn std::any::Any = r_result.as_ref();
+    let r_list = any_r.downcast_ref::<ListRepr>().ok_or_else(|| {
+        TyperError::message("rtype_newlist_hint: hop.r_result is not a resized ListRepr")
+    })?;
+    let v_hint = hop.inputarg(ConvertedTo::LowLevelType(&LowLevelType::Signed), 0)?;
+    hop.exception_is_here()?;
+    let ptr_lltype = r_list.lltype.clone();
+    let item_lltype = r_list.item_repr.lowleveltype().clone();
+    let helper = {
+        let ptr = ptr_lltype.clone();
+        let item = item_lltype.clone();
+        hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_newlist_hint".to_string(),
+            vec![LowLevelType::Signed],
+            ptr_lltype,
+            move |_rtyper, _args, _result| {
+                build_ll_newlist_hint_helper_graph("ll_newlist_hint", ptr.clone(), item.clone())
+            },
+        )?
+    };
+    hop.gendirectcall(&helper, vec![v_hint])
+}
+
 /// Repr-generic body of [`rtype_newlist`], shared by the resized `ListRepr`
 /// and the fixed-size `FixedSizeListRepr`. The `LIST.ll_newlist(n)` +
 /// positional `ll_setitem_fast` shape is identical; only the receiver layout
@@ -3633,6 +3689,28 @@ pub(crate) fn build_ll_newlist_helper_graph(
     ptr_lltype: LowLevelType,
     item_lltype: LowLevelType,
 ) -> Result<PyGraph, TyperError> {
+    build_ll_newlist_helper_graph_inner(name, layout, ptr_lltype, item_lltype, false)
+}
+
+/// Synthesise the resized-list-only `ll_newlist_hint` helper.  Kept separate
+/// from [`build_ll_newlist_helper_graph`] at the public surface because these
+/// are distinct ADT methods upstream and therefore distinct memoized helper
+/// graphs.
+fn build_ll_newlist_hint_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    build_ll_newlist_helper_graph_inner(name, ListLayout::Resized, ptr_lltype, item_lltype, true)
+}
+
+fn build_ll_newlist_helper_graph_inner(
+    name: &str,
+    layout: ListLayout,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+    length_is_hint: bool,
+) -> Result<PyGraph, TyperError> {
     use crate::translator::rtyper::rmodel::{gc_flavor_const, lowlevel_type_const};
     let length_arg = variable_with_lltype("length", LowLevelType::Signed);
     let startblock = Block::shared(vec![Hlvalue::Variable(length_arg.clone())]);
@@ -3643,6 +3721,31 @@ pub(crate) fn build_ll_newlist_helper_graph(
         Hlvalue::Variable(return_var),
     );
     let array_type = LowLevelType::Array(Box::new(Array::gc(item_lltype.clone())));
+
+    if length_is_hint {
+        // lltypesystem/rlist.py `ll_newlist_hint` begins with
+        // `ll_assert(lengthhint >= 0, "negative list length")`.
+        let nonnegative = variable_with_lltype("nonnegative", LowLevelType::Bool);
+        startblock.borrow_mut().operations.push(SpaceOperation::new(
+            "int_ge",
+            vec![
+                Hlvalue::Variable(length_arg.clone()),
+                constant_with_lltype(ConstValue::Int(0), LowLevelType::Signed),
+            ],
+            Hlvalue::Variable(nonnegative.clone()),
+        ));
+        startblock.borrow_mut().operations.push(SpaceOperation::new(
+            "debug_assert",
+            vec![
+                Hlvalue::Variable(nonnegative),
+                constant_with_lltype(
+                    ConstValue::byte_str("negative list length"),
+                    LowLevelType::Void,
+                ),
+            ],
+            Hlvalue::Variable(variable_with_lltype("v", LowLevelType::Void)),
+        ));
+    }
 
     let new_lst = match layout {
         ListLayout::Fixed => {
@@ -3696,7 +3799,11 @@ pub(crate) fn build_ll_newlist_helper_graph(
                 vec![
                     Hlvalue::Variable(header.clone()),
                     void_field_const("length"),
-                    Hlvalue::Variable(length_arg),
+                    if length_is_hint {
+                        signed_const(0)
+                    } else {
+                        Hlvalue::Variable(length_arg)
+                    },
                 ],
                 Hlvalue::Variable(variable_with_lltype("v", LowLevelType::Void)),
             ));
@@ -7087,7 +7194,7 @@ mod tests {
     use crate::annotator::model::{SomeInteger, SomeList, SomeValue};
     use crate::flowspace::model::Variable;
     use crate::translator::rtyper::pairtype::ReprClassId;
-    use crate::translator::rtyper::rint::{IntegerRepr, signed_repr};
+    use crate::translator::rtyper::rint::{IntegerRepr, signed_repr, unsigned_repr};
     use crate::translator::rtyper::rmodel::rtyper_makerepr;
     use crate::translator::rtyper::rtyper::{HighLevelOp, LowLevelOpList};
 
@@ -7131,6 +7238,99 @@ mod tests {
             matches!(items_ptr.TO, PtrTarget::Array(_)),
             "items must point to a GcArray"
         );
+    }
+
+    #[test]
+    fn ll_newlist_hint_uses_hint_for_storage_but_zero_for_length() {
+        let rtyper = fresh_rtyper();
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        let repr = ListRepr::new(&rtyper, r_int).expect("ListRepr::new");
+        let graph = build_ll_newlist_hint_helper_graph(
+            "ll_newlist_hint",
+            repr.lltype.clone(),
+            LowLevelType::Signed,
+        )
+        .expect("build ll_newlist_hint");
+        let block = graph.graph.borrow().startblock.clone();
+        let block = block.borrow();
+        assert!(
+            block
+                .operations
+                .iter()
+                .any(|op| op.opname == "debug_assert"),
+            "ll_newlist_hint must retain upstream's nonnegative assertion"
+        );
+        let malloc_items = block
+            .operations
+            .iter()
+            .find(|op| op.opname == "malloc_varsize")
+            .expect("hint helper allocates the backing array");
+        assert!(
+            matches!(&malloc_items.args[2], Hlvalue::Variable(v) if v.name().starts_with("length")),
+            "backing allocation must use the size hint: {:?}",
+            malloc_items.args
+        );
+        let set_length = block
+            .operations
+            .iter()
+            .find(|op| {
+                op.opname == "setfield"
+                    && matches!(&op.args[1], Hlvalue::Constant(c) if matches!(&c.value, ConstValue::ByteStr(name) if name == b"length"))
+            })
+            .expect("hint helper initializes the logical length");
+        assert!(
+            matches!(&set_length.args[2], Hlvalue::Constant(c) if c.value == ConstValue::Int(0)),
+            "logical length must start at zero: {:?}",
+            set_length.args
+        );
+    }
+
+    #[test]
+    fn translate_operation_newlist_hint_accepts_rust_usize_and_calls_helper() {
+        use crate::flowspace::model::SpaceOperation;
+        use std::cell::RefCell as StdRef;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let r_item: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        let r_list: Arc<dyn Repr> =
+            Arc::new(ListRepr::new(&rtyper, r_item).expect("ListRepr::new"));
+        let r_hint: Arc<dyn Repr> = unsigned_repr();
+        let hint = Variable::new();
+        hint.set_concretetype(Some(LowLevelType::Unsigned));
+        let hint_h = Hlvalue::Variable(hint);
+        let result = Variable::new();
+        let spaceop = SpaceOperation::new(
+            "newlist_hint",
+            vec![hint_h.clone()],
+            Hlvalue::Variable(result),
+        );
+        let llops = Rc::new(StdRef::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper.clone(), spaceop, Vec::new(), llops);
+        hop.args_v.borrow_mut().push(hint_h);
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::Integer(SomeInteger::new(true, true)));
+        hop.args_r.borrow_mut().push(Some(r_hint));
+        *hop.r_result.borrow_mut() = Some(r_list);
+
+        rtyper
+            .translate_operation(&hop)
+            .expect("newlist_hint dispatch")
+            .expect("newlist_hint result");
+        let ops = hop.llops.borrow();
+        assert!(
+            ops.ops.iter().any(|op| op.opname == "cast_uint_to_int"),
+            "Rust usize hint must enter upstream's Signed specialization"
+        );
+        assert!(
+            ops.ops.iter().any(|op| op.opname == "direct_call"),
+            "newlist_hint must call ll_newlist_hint"
+        );
+        assert!(ops._called_exception_is_here_or_cannot_occur);
     }
 
     /// `translate_operation("newlist")` routes to [`rtype_newlist`], which

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -2729,6 +2729,10 @@ pub enum ReprKey {
     /// RPython `SomeType.rtyper_makekey = (self.__class__,)`
     /// (rclass.py:463-464).
     Type,
+    /// `SomeTypeOf` inherits `SomeType.rtyper_makekey`; because the method
+    /// returns `(self.__class__,)`, all `SomeTypeOf` annotations share their
+    /// own bucket, distinct from the `SomeType` bucket.
+    TypeOf,
     /// RPython `SomeIterator.rtyper_makekey` (rmodel.py).
     ///
     /// ```python
@@ -2919,6 +2923,10 @@ pub fn rtyper_makekey(s_obj: &crate::annotator::model::SomeValue) -> ReprKey {
         }
         // rclass.py: SomeType.rtyper_makekey = (self.__class__,).
         SomeValue::Type(_) => ReprKey::Type,
+        // `SomeTypeOf(SomeType)` inherits the same method.  Upstream keys on
+        // `self.__class__`, so this is a separate singleton key even though
+        // both annotations select the same RootClassRepr.
+        SomeValue::TypeOf(_) => ReprKey::TypeOf,
         // rmodel.py — SomeIterator.rtyper_makekey recursively
         // keys on container + variant tuple.
         SomeValue::Iterator(s) => ReprKey::Iterator {
@@ -3281,9 +3289,10 @@ pub fn rtyper_makerepr(
         )),
         // rweakref.py:13-17
         SomeValue::WeakRef(_) => super::rweakref::weakref_makerepr(rtyper),
-        SomeValue::TypeOf(_) => Err(TyperError::missing_rtype_operation(
-            "SomeTypeOf.rtyper_makerepr — no direct upstream counterpart; host-language adaptation",
-        )),
+        // `SomeTypeOf` is a subclass of `SomeType` and inherits
+        // `rclass.py::__extend__(SomeType).rtyper_makerepr`, which returns
+        // `get_type_repr(rtyper)`.
+        SomeValue::TypeOf(_) => crate::translator::rtyper::rclass::get_type_repr(rtyper),
         SomeValue::Ptr(ptr) => {
             Ok(std::sync::Arc::new(PtrRepr::new(ptr.ll_ptrtype.clone()))
                 as std::sync::Arc<dyn Repr>)
@@ -4358,6 +4367,17 @@ mod tests {
     }
 
     #[test]
+    fn rtyper_makekey_sometypeof_is_distinct_variant_singleton() {
+        use crate::annotator::model::SomeTypeOf;
+        use crate::flowspace::model::Variable;
+        let first = SomeValue::TypeOf(SomeTypeOf::new(vec![Rc::new(Variable::new())]));
+        let second = SomeValue::TypeOf(SomeTypeOf::new(vec![Rc::new(Variable::new())]));
+        assert_eq!(rtyper_makekey(&first), ReprKey::TypeOf);
+        assert_eq!(rtyper_makekey(&second), ReprKey::TypeOf);
+        assert_ne!(rtyper_makekey(&first), ReprKey::Type);
+    }
+
+    #[test]
     fn rtyper_makerepr_someinstance_returns_instance_repr_when_initialized() {
         use crate::annotator::classdesc::ClassDef;
         use crate::annotator::model::SomeInstance;
@@ -4413,6 +4433,19 @@ mod tests {
         rtyper.initialize_exceptiondata().expect("init");
 
         let sv = SomeValue::Type(SomeType::new());
+        let repr = rtyper_makerepr(&sv, &rtyper).expect("rtyper_makerepr");
+        assert_eq!(repr.class_name(), "RootClassRepr");
+    }
+
+    #[test]
+    fn rtyper_makerepr_sometypeof_inherits_rootclass_repr() {
+        use crate::annotator::model::SomeTypeOf;
+        use crate::flowspace::model::Variable;
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper.initialize_exceptiondata().expect("init");
+
+        let sv = SomeValue::TypeOf(SomeTypeOf::new(vec![Rc::new(Variable::new())]));
         let repr = rtyper_makerepr(&sv, &rtyper).expect("rtyper_makerepr");
         assert_eq!(repr.class_name(), "RootClassRepr");
     }

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -3200,6 +3200,7 @@ fn lowlevel_helper_graph(
         "ll_isinstance_pytype" => {
             lowlevel_isinstance_pytype_helper_graph(rtyper, name, args, result)
         }
+        "ll_inst_type" => lowlevel_inst_type_helper_graph(name, args, result),
         "ll_type" => lowlevel_type_helper_graph(name, args, result),
         _ => Ok(synthetic_lowlevel_helper_graph(name, args, result)),
     }
@@ -3511,6 +3512,104 @@ fn lowlevel_type_helper_graph(
         Hlvalue::Variable(typeptr.clone()),
     ));
     startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(typeptr)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(graph, argnames, func))
+}
+
+/// RPython `ll_inst_type(obj)` (rclass.py):
+///
+/// ```python
+/// def ll_inst_type(obj):
+///     if obj:
+///         return obj.typeptr
+///     else:
+///         return nullptr(OBJECT_VTABLE)
+/// ```
+///
+/// `obj` has already been converted through `InstanceRepr.common_repr`, so
+/// it is either OBJECTPTR or NONGCOBJECTPTR and both layouts expose the same
+/// `typeptr: CLASSTYPE` field.
+fn lowlevel_inst_type_helper_graph(
+    name: &str,
+    args: &[LowLevelType],
+    result: &LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    if !(args.len() == 1 && (args[0] == *OBJECTPTR || args[0] == *NONGCOBJECTPTR))
+        || result != &CLASSTYPE.clone()
+    {
+        return Err(TyperError::message(format!(
+            "{name} expects ((OBJECTPTR|NONGCOBJECTPTR)) -> CLASSTYPE, got ({args:?}) -> {result:?}"
+        )));
+    }
+    let obj_lltype = args[0].clone();
+    let LowLevelType::Ptr(class_ptr) = CLASSTYPE.clone() else {
+        unreachable!("CLASSTYPE is a pointer")
+    };
+    let null_type = constant_with_lltype(
+        ConstValue::LLPtr(Box::new(class_ptr.as_ref().clone()._defl())),
+        CLASSTYPE.clone(),
+    );
+
+    let argnames = vec!["arg0".to_string()];
+    let obj0 = variable_with_lltype("arg0", obj_lltype.clone());
+    let is_nonnull = variable_with_lltype("is_nonnull", LowLevelType::Bool);
+    let obj1 = variable_with_lltype("obj", obj_lltype);
+    let typeptr = variable_with_lltype("typeptr", CLASSTYPE.clone());
+    let return_var = variable_with_lltype("result", CLASSTYPE.clone());
+
+    let startblock = Block::shared(vec![Hlvalue::Variable(obj0.clone())]);
+    let readblock = Block::shared(vec![Hlvalue::Variable(obj1.clone())]);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "ptr_nonzero",
+        vec![Hlvalue::Variable(obj0.clone())],
+        Hlvalue::Variable(is_nonnull.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(is_nonnull));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(obj0)],
+            Some(readblock.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(true),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+        Link::new(
+            vec![null_type],
+            Some(graph.returnblock.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(false),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+    ]);
+
+    readblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(obj1), void_field_const("typeptr")],
+        Hlvalue::Variable(typeptr.clone()),
+    ));
+    readblock.closeblock(vec![
         Link::new(
             vec![Hlvalue::Variable(typeptr)],
             Some(graph.returnblock.clone()),
@@ -8630,5 +8729,42 @@ mod tests {
         };
         assert_eq!(field, "ob_type");
         assert_eq!(cb.operations[1].opname, "direct_call");
+    }
+
+    #[test]
+    fn inst_type_helper_graph_null_checks_then_reads_typeptr() {
+        let pygraph = lowlevel_inst_type_helper_graph(
+            "ll_inst_type",
+            &[OBJECTPTR.clone()],
+            &CLASSTYPE.clone(),
+        )
+        .expect("ll_inst_type must build");
+        let graph = pygraph.graph.borrow();
+        let start = graph.startblock.borrow();
+        assert_eq!(start.operations.len(), 1);
+        assert_eq!(start.operations[0].opname, "ptr_nonzero");
+        assert_eq!(start.exits.len(), 2);
+
+        let readblock = start.exits[0]
+            .borrow()
+            .target
+            .clone()
+            .expect("nonnull link has a read block");
+        let read = readblock.borrow();
+        assert_eq!(read.operations.len(), 1);
+        assert_eq!(read.operations[0].opname, "getfield");
+        let Hlvalue::Constant(field) = &read.operations[0].args[1] else {
+            panic!("getfield name must be constant")
+        };
+        assert_eq!(field.value, ConstValue::byte_str("typeptr"));
+
+        let null_link = start.exits[1].borrow();
+        let Some(Some(Hlvalue::Constant(null_type))) = null_link.args.first() else {
+            panic!("null arm must return a pointer constant")
+        };
+        let ConstValue::LLPtr(null_type) = &null_type.value else {
+            panic!("null arm must carry LLPtr")
+        };
+        assert!(!null_type.nonzero());
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -2245,6 +2245,10 @@ impl RPythonTyper {
             // function `rlist.rtype_newlist(hop)` (`ll_newlist` +
             // positional `ll_setitem_fast`). No per-Repr dispatch.
             "newlist" => super::rlist::rtype_newlist(hop),
+            // `objectmodel.newlist_hint` ExtRegistry specialization:
+            // allocate resized-list storage from the hint while keeping the
+            // logical length zero and preserving the MemoryError edge.
+            "newlist_hint" => super::rlist::rtype_newlist_hint(hop),
             // rtyper.py — `translate_op_alloc_and_set` calls the
             // free function `rlist.rtype_alloc_and_set(hop)` (`ll_newlist`
             // + `ll_alloc_and_set`). No per-Repr dispatch.

--- a/majit/majit-translate/tests/test_mir_frontend.rs
+++ b/majit/majit-translate/tests/test_mir_frontend.rs
@@ -1425,13 +1425,13 @@ fn a_scalar_element_indexes_to_an_int_banked_array_read() {
 
     let got = slot_read_shape("scalar_slot_get");
     assert_eq!(
-        got.residual_gets, 1,
-        "the `get` spelling leaves its call residual for a scalar element too",
+        got.residual_gets, 0,
+        "the scalar `get` spelling lowers to the guarded item read",
     );
-    assert!(
-        got.array_reads.is_empty(),
-        "the `get` spelling emits no ArrayRead, got {:?}",
+    assert_eq!(
         got.array_reads,
+        vec![ValueType::Int],
+        "the scalar `get` spelling reads the i64 payload in the int bank",
     );
 }
 

--- a/majit/majit-translate/tests/test_rbigint_mir.rs
+++ b/majit/majit-translate/tests/test_rbigint_mir.rs
@@ -60,11 +60,10 @@ fn load_rbigint_llbcs() -> Option<Vec<Llbc>> {
 
 /// `_AsDouble` consumes `bit_length()` with `?`, so the `Result<i64,
 /// RBigIntError>` it returns is destructured by a live `Try::branch` /
-/// `from_residual` diamond.  The scalar residual returns a bare Signed word,
-/// which erases that `Result`: retargeting here leaves the diamond reading
-/// `__discriminant` off an integer.  This asserts the erasure does not happen
-/// — it fails as soon as `scalar_residual_for_method`'s gate stops declining,
-/// with `jit_bigint_bit_length` appearing beside the surviving `branch`.
+/// `from_residual` diamond.  A one-word scalar residual would erase that
+/// `Result` and leave the diamond reading `__discriminant` off an integer, so
+/// `scalar_residual_for_method` maps neither `bit_length` nor `bit_count` —
+/// matching upstream, which mints no residual for them either.
 #[test]
 fn as_double_effect_graph_keeps_upstream_bit_length_call() {
     let Some(llbcs) = load_rbigint_llbcs() else {
@@ -95,7 +94,46 @@ fn as_double_effect_graph_keeps_upstream_bit_length_call() {
     );
     assert!(
         calls.iter().all(|name| name != "jit_bigint_bit_length"),
-        "_AsDouble must not acquire the interpreter exception-publishing wrapper: {calls:?}",
+        "_AsDouble must not acquire a one-word residual for a Result-returning \
+         call: {calls:?}",
+    );
+}
+
+/// The same erasure, on the side the `?` diamond does not cover.
+/// `rbigint_to_compiler_bigint` spells its `bit_length()` consumption as
+/// `.expect(..)`, so a one-word residual leaves `Result::expect` applied to a
+/// machine word.  Unlike `_AsDouble` this graph carries no `dont_look_inside`
+/// marker, which is why the caller's hint could never have been the predicate
+/// that kept the mapping sound.
+#[test]
+fn compiler_bigint_conversion_keeps_upstream_bit_length_call() {
+    if !std::path::Path::new(INTERPRETER_LLBC).is_file() {
+        eprintln!(
+            "skipping: {INTERPRETER_LLBC} is missing; run \
+             `python3 scripts/extract-llbc.py pyre-interpreter`"
+        );
+        return;
+    }
+    let llbc = Llbc::load(INTERPRETER_LLBC).expect("load pyre-interpreter.ullbc");
+    let graph = lower_function(&llbc, "rbigint_to_compiler_bigint")
+        .expect("lower rbigint_to_compiler_bigint");
+    let residuals: Vec<String> = graph
+        .blocks
+        .iter()
+        .flat_map(|block| block.operations.iter())
+        .filter_map(|op| match &op.kind {
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                ..
+            } => Some(segments.join("::")),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        residuals
+            .iter()
+            .all(|path| !path.ends_with("jit_bigint_bit_length")),
+        "an `.expect()` consumer must not receive a one-word residual: {residuals:?}",
     );
 }
 
@@ -1342,19 +1380,6 @@ fn dependent_crate_rbigint_identity_retargets_opaque_llbc_declaration() {
         assert!(
             !values.iter().any(|hint| hint == "elidable_or_memerror"),
             "{path} comparison must not advertise an allocation edge: {values:?}"
-        );
-    }
-    for path in [
-        "objspace::descroperation::jit_bigint_bit_length",
-        "objspace::descroperation::jit_bigint_bit_count",
-    ] {
-        let values = hints
-            .get(path)
-            .unwrap_or_else(|| panic!("missing pointer-ABI wrapper hints for {path}"));
-        assert!(values.iter().any(|hint| hint == "elidable"));
-        assert!(
-            !values.iter().any(|hint| hint == "elidable_cannot_raise"),
-            "{path} must preserve rbigint ovfcheck's OverflowError edge, got {values:?}"
         );
     }
     let program = build_semantic_program_from_llbcs_with_static_addrs_and_function_names(

--- a/majit/majit-translate/tests/test_rbigint_mir.rs
+++ b/majit/majit-translate/tests/test_rbigint_mir.rs
@@ -58,6 +58,13 @@ fn load_rbigint_llbcs() -> Option<Vec<Llbc>> {
     ])
 }
 
+/// `_AsDouble` consumes `bit_length()` with `?`, so the `Result<i64,
+/// RBigIntError>` it returns is destructured by a live `Try::branch` /
+/// `from_residual` diamond.  The scalar residual returns a bare Signed word,
+/// which erases that `Result`: retargeting here leaves the diamond reading
+/// `__discriminant` off an integer.  This asserts the erasure does not happen
+/// — it fails as soon as `scalar_residual_for_method`'s gate stops declining,
+/// with `jit_bigint_bit_length` appearing beside the surviving `branch`.
 #[test]
 fn as_double_effect_graph_keeps_upstream_bit_length_call() {
     let Some(llbcs) = load_rbigint_llbcs() else {

--- a/majit/majit-translate/tests/test_rbigint_mir.rs
+++ b/majit/majit-translate/tests/test_rbigint_mir.rs
@@ -12,7 +12,7 @@ use majit_translate::{
         llbc_hints::harvest_hints_from_llbcs,
         mir::{
             build_semantic_program_from_llbcs_with_static_addrs_and_function_names,
-            build_semantic_program_from_llbcs_with_static_addrs_and_module_paths,
+            build_semantic_program_from_llbcs_with_static_addrs_and_module_paths, lower_function,
         },
     },
     model::{CallTarget, OpKind, ValueType},
@@ -56,6 +56,40 @@ fn load_rbigint_llbcs() -> Option<Vec<Llbc>> {
         Llbc::load(RLIB_LLBC).expect("load majit-rlib.ullbc"),
         Llbc::load(OBJECT_LLBC).expect("load pyre-object.ullbc"),
     ])
+}
+
+#[test]
+fn as_double_effect_graph_keeps_upstream_bit_length_call() {
+    let Some(llbcs) = load_rbigint_llbcs() else {
+        return;
+    };
+    let graph = lower_function(&llbcs[0], "rbigint::_AsDouble")
+        .or_else(|_| lower_function(&llbcs[0], "_AsDouble"))
+        .expect("lower rbigint::_AsDouble");
+    let calls: Vec<String> = graph
+        .blocks
+        .iter()
+        .flat_map(|block| block.operations.iter())
+        .filter_map(|op| match &op.kind {
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                ..
+            } => segments.last().cloned(),
+            OpKind::Call {
+                target: CallTarget::Method { name, .. },
+                ..
+            } => Some(name.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        calls.iter().any(|name| name == "bit_length"),
+        "_AsDouble must retain upstream RBigInt::bit_length for effect analysis: {calls:?}",
+    );
+    assert!(
+        calls.iter().all(|name| name != "jit_bigint_bit_length"),
+        "_AsDouble must not acquire the interpreter exception-publishing wrapper: {calls:?}",
+    );
 }
 
 fn assert_source_order(source: &str, fragments: &[&str]) {

--- a/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
+++ b/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
@@ -1513,11 +1513,13 @@ pub(crate) unsafe fn repr(obj: PyObjectRef) -> Result<rustpython_wtf8::Wtf8Buf, 
 /// `[Wtf8Buf]` has no `join` for.
 fn join_wtf8(parts: &[rustpython_wtf8::Wtf8Buf], sep: &str) -> rustpython_wtf8::Wtf8Buf {
     let mut out = rustpython_wtf8::Wtf8Buf::new();
-    for (index, part) in parts.iter().enumerate() {
+    let mut index = 0;
+    while index < parts.len() {
         if index > 0 {
             out.push_str(sep);
         }
-        out.push_wtf8(part);
+        out.push_wtf8(&parts[index]);
+        index += 1;
     }
     out
 }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -11644,6 +11644,40 @@ unsafe fn descr_not_settable_error(descr: PyObjectRef) -> crate::PyError {
     )
 }
 
+/// Cold message materialisation for `typedef.py Member.typecheck`.
+///
+/// Upstream keeps the receiver check in the translated descriptor path and
+/// constructs the `%N`/`%T` message through `oefmt` only after it fails.  All
+/// of pyre's Member entry points share the same error half, matching the one
+/// upstream method instead of duplicating message construction per entry.
+pub(crate) unsafe fn member_typecheck_error(
+    descr: PyObjectRef,
+    obj: PyObjectRef,
+) -> crate::PyError {
+    let w_cls = pyre_object::w_member_get_cls(descr);
+    crate::PyError::type_error(format!(
+        "descriptor '{}' for '{}' objects doesn't apply to '{}' object",
+        pyre_object::w_member_get_name(descr),
+        pyre_object::w_type_get_name(w_cls),
+        pyre_object::type_name_of(obj),
+    ))
+}
+
+/// Cold empty-slot error from `Member.descr_member_get`.
+///
+/// `[3.14-spec]` PyPy `typedef.py:513-515` spells this through `%T`, which
+/// reports the bare type name.  CPython 3.14 exposes the heap type's qualified
+/// name here, pinned by `lib-python/3/test/test_descr.py:1311`; retain pyre's
+/// `getfulltypename` result while keeping eager message construction behind
+/// the same rejected-access boundary as upstream's `oefmt`.
+unsafe fn member_missing_error(obj: PyObjectRef, slot_name: &str) -> crate::PyError {
+    PyError::attribute_error(format!(
+        "'{}' object has no attribute '{}'",
+        getfulltypename(obj),
+        slot_name,
+    ))
+}
+
 /// Call a descriptor's __get__ method.
 ///
 /// PyPy: descroperation.py `space.get(w_descr, w_obj)` →
@@ -11739,13 +11773,7 @@ pub(crate) unsafe fn get(
         // typedef.py: self.typecheck(space, w_obj) → TypeError
         let w_cls = pyre_object::w_member_get_cls(descr);
         if !w_cls.is_null() && is_type(w_cls) && !isinstance_w(obj, w_cls) {
-            let slot_name = pyre_object::w_member_get_name(descr);
-            return Err(crate::PyError::type_error(format!(
-                "descriptor '{}' for '{}' objects doesn't apply to '{}' object",
-                slot_name,
-                pyre_object::w_type_get_name(w_cls),
-                (*(*obj).ob_type).name,
-            )));
+            return Err(member_typecheck_error(descr, obj));
         }
         // CPython 3.14 `PyFunction_Type` exposes five `PyMemberDef`
         // descriptors whose values live in the native Function fields rather
@@ -11769,15 +11797,8 @@ pub(crate) unsafe fn get(
         // typedef.py:512-516: if w_result is None: raise
         // AttributeError("'%T' object has no attribute '%s'")
         if found.is_none() {
-            // An unset slot names the type by its `module.__qualname__`, which
-            // is what `test_descr.test_slots` pins; the bare `%T` name belongs
-            // to the misses `raiseattrerror` reports.
             let slot_name = pyre_object::w_member_get_name(descr);
-            return Err(PyError::attribute_error(format!(
-                "'{}' object has no attribute '{}'",
-                getfulltypename(obj),
-                slot_name,
-            )));
+            return Err(member_missing_error(obj, slot_name));
         }
         return Ok(found);
     }
@@ -11841,13 +11862,7 @@ unsafe fn set(
         // typedef.py: self.typecheck(space, w_obj) → TypeError
         let w_cls = pyre_object::w_member_get_cls(descr);
         if !w_cls.is_null() && is_type(w_cls) && !isinstance_w(obj, w_cls) {
-            let slot_name = pyre_object::w_member_get_name(descr);
-            return Err(crate::PyError::type_error(format!(
-                "descriptor '{}' for '{}' objects doesn't apply to '{}' object",
-                slot_name,
-                pyre_object::w_type_get_name(w_cls),
-                (*(*obj).ob_type).name,
-            )));
+            return Err(member_typecheck_error(descr, obj));
         }
         if pyre_object::w_member_is_direct(descr) {
             crate::typedef::direct_member_set(descr, obj, value)?;
@@ -11908,13 +11923,7 @@ unsafe fn delete(descr: PyObjectRef, obj: PyObjectRef) -> Result<(), crate::PyEr
     if pyre_object::is_member(descr) {
         let w_cls = pyre_object::w_member_get_cls(descr);
         if !w_cls.is_null() && is_type(w_cls) && !isinstance_w(obj, w_cls) {
-            let slot_name = pyre_object::w_member_get_name(descr);
-            return Err(crate::PyError::type_error(format!(
-                "descriptor '{}' for '{}' objects doesn't apply to '{}' object",
-                slot_name,
-                pyre_object::w_type_get_name(w_cls),
-                (*(*obj).ob_type).name,
-            )));
+            return Err(member_typecheck_error(descr, obj));
         }
         if pyre_object::w_member_is_direct(descr) {
             crate::typedef::direct_member_delete(descr, obj)?;

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3641,9 +3641,10 @@ unsafe fn pull_iterator_tuple(
             Err(e) => return Err(e),
         }
     }
-    let items: Vec<PyObjectRef> = (0..n)
-        .map(|k| pyre_object::gc_roots::shadow_stack_get(base + k))
-        .collect();
+    let mut items = Vec::with_capacity(n);
+    for index in 0..n {
+        items.push(pyre_object::gc_roots::shadow_stack_get(base + index));
+    }
     Ok(Some(items))
 }
 
@@ -9616,7 +9617,7 @@ pub unsafe fn mutated(w_type: PyObjectRef, key: Option<&str>) {
     }
     // typeobject.py:288-291 — walk direct subclasses recursively.
     let subs = pyre_object::typeobject::w_type_get_subclasses(w_type, false);
-    for w_sub in subs {
+    for &w_sub in &subs {
         mutated(w_sub, key);
     }
 }
@@ -14966,9 +14967,13 @@ fn _unpackiterable_known_length_jitlook(
             got = count,
         )));
     }
-    Ok((0..count)
-        .map(|index| pyre_object::gc_roots::shadow_stack_get(root_base + 1 + index))
-        .collect())
+    let mut items = Vec::with_capacity(count);
+    for index in 0..count {
+        items.push(pyre_object::gc_roots::shadow_stack_get(
+            root_base + 1 + index,
+        ));
+    }
+    Ok(items)
 }
 
 /// pypy/interpreter/baseobjspace.py:1159-1163 base default + the
@@ -15528,7 +15533,10 @@ unsafe fn builtin_iter_override(
         )));
     }
     let w_iter = crate::call::call_function_impl_result(method, &[obj])?;
-    iter_check_is_iterator(w_iter).map(Some)
+    match iter_check_is_iterator(w_iter) {
+        Ok(w_iter) => Ok(Some(w_iter)),
+        Err(err) => Err(err),
+    }
 }
 
 /// `iter(obj)` — PyPy: space.iter(w_obj)
@@ -16450,10 +16458,10 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     }
                 }
             }
-            let items = item_slots
-                .into_iter()
-                .map(pyre_object::gc_roots::shadow_stack_get)
-                .collect();
+            let mut items = Vec::with_capacity(item_slots.len());
+            for slot in item_slots {
+                items.push(pyre_object::gc_roots::shadow_stack_get(slot));
+            }
             return Ok(pyre_object::w_tuple_new(items));
         }
         // itertools.product — PyPy W_Product.fill_next_result /
@@ -16498,12 +16506,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     let _ = pyre_object::gc_roots::pin_root(item);
                     item_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
                 }
-                let initial = pyre_object::w_list_new(
-                    item_slots
-                        .into_iter()
-                        .map(pyre_object::gc_roots::shadow_stack_get)
-                        .collect(),
-                );
+                let mut initial_items = Vec::with_capacity(item_slots.len());
+                for slot in item_slots {
+                    initial_items.push(pyre_object::gc_roots::shadow_stack_get(slot));
+                }
+                let initial = pyre_object::w_list_new(initial_items);
                 let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
                 (*(w_self as *mut pyre_object::interp_itertools::W_Product)).lst = initial;
                 pyre_object::gc_hook::try_gc_write_barrier(w_self as *mut u8);
@@ -16575,12 +16582,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 let _ = pyre_object::gc_roots::pin_root(item);
                 result_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
             }
-            return Ok(pyre_object::w_tuple_new(
-                result_slots
-                    .into_iter()
-                    .map(pyre_object::gc_roots::shadow_stack_get)
-                    .collect(),
-            ));
+            let mut result = Vec::with_capacity(result_slots.len());
+            for slot in result_slots {
+                result.push(pyre_object::gc_roots::shadow_stack_get(slot));
+            }
+            return Ok(pyre_object::w_tuple_new(result));
         }
         // itertools.combinations — PyPy W_Combinations.descr_next.
         if pyre_object::interp_itertools::is_combinations(obj) {
@@ -16618,12 +16624,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     let _ = pyre_object::gc_roots::pin_root(item);
                     item_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
                 }
-                pyre_object::w_list_new(
-                    item_slots
-                        .into_iter()
-                        .map(pyre_object::gc_roots::shadow_stack_get)
-                        .collect(),
-                )
+                let mut items = Vec::with_capacity(item_slots.len());
+                for slot in item_slots {
+                    items.push(pyre_object::gc_roots::shadow_stack_get(slot));
+                }
+                pyre_object::w_list_new(items)
             } else {
                 // Copy the previous result before mutating, exactly as
                 // `result_w = self.last_result_w[:]`.
@@ -16634,12 +16639,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     let _ = pyre_object::gc_roots::pin_root(item);
                     old_item_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
                 }
-                let result = pyre_object::w_list_new(
-                    old_item_slots
-                        .into_iter()
-                        .map(pyre_object::gc_roots::shadow_stack_get)
-                        .collect(),
-                );
+                let mut old_items = Vec::with_capacity(old_item_slots.len());
+                for slot in old_item_slots {
+                    old_items.push(pyre_object::gc_roots::shadow_stack_get(slot));
+                }
+                let result = pyre_object::w_list_new(old_items);
                 let result = pyre_object::gc_roots::pin_root(result);
                 let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
@@ -16727,12 +16731,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 let _ = pyre_object::gc_roots::pin_root(item);
                 result_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
             }
-            return Ok(pyre_object::w_tuple_new(
-                result_slots
-                    .into_iter()
-                    .map(pyre_object::gc_roots::shadow_stack_get)
-                    .collect(),
-            ));
+            let mut result = Vec::with_capacity(result_slots.len());
+            for slot in result_slots {
+                result.push(pyre_object::gc_roots::shadow_stack_get(slot));
+            }
+            return Ok(pyre_object::w_tuple_new(result));
         }
         // itertools.combinations_with_replacement — PyPy
         // W_CombinationsWithReplacement.descr_next inherits the combinations
@@ -16775,12 +16778,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     let _ = pyre_object::gc_roots::pin_root(item);
                     item_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
                 }
-                pyre_object::w_list_new(
-                    item_slots
-                        .into_iter()
-                        .map(pyre_object::gc_roots::shadow_stack_get)
-                        .collect(),
-                )
+                let mut items = Vec::with_capacity(item_slots.len());
+                for slot in item_slots {
+                    items.push(pyre_object::gc_roots::shadow_stack_get(slot));
+                }
+                pyre_object::w_list_new(items)
             } else {
                 let mut old_item_slots = Vec::with_capacity(r);
                 for i in 0..r {
@@ -16789,12 +16791,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     let _ = pyre_object::gc_roots::pin_root(item);
                     old_item_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
                 }
-                let result = pyre_object::w_list_new(
-                    old_item_slots
-                        .into_iter()
-                        .map(pyre_object::gc_roots::shadow_stack_get)
-                        .collect(),
-                );
+                let mut old_items = Vec::with_capacity(old_item_slots.len());
+                for slot in old_item_slots {
+                    old_items.push(pyre_object::gc_roots::shadow_stack_get(slot));
+                }
+                let result = pyre_object::w_list_new(old_items);
                 let result = pyre_object::gc_roots::pin_root(result);
                 let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
@@ -16867,12 +16868,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 let _ = pyre_object::gc_roots::pin_root(item);
                 result_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
             }
-            return Ok(pyre_object::w_tuple_new(
-                result_slots
-                    .into_iter()
-                    .map(pyre_object::gc_roots::shadow_stack_get)
-                    .collect(),
-            ));
+            let mut result = Vec::with_capacity(result_slots.len());
+            for slot in result_slots {
+                result.push(pyre_object::gc_roots::shadow_stack_get(slot));
+            }
+            return Ok(pyre_object::w_tuple_new(result));
         }
         // itertools.permutations — PyPy W_Permutations.descr_next.
         if pyre_object::interp_itertools::is_permutations(obj) {
@@ -16913,12 +16913,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 let _ = pyre_object::gc_roots::pin_root(item);
                 result_item_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
             }
-            let result = pyre_object::w_tuple_new(
-                result_item_slots
-                    .into_iter()
-                    .map(pyre_object::gc_roots::shadow_stack_get)
-                    .collect(),
-            );
+            let mut result_items = Vec::with_capacity(result_item_slots.len());
+            for slot in result_item_slots {
+                result_items.push(pyre_object::gc_roots::shadow_stack_get(slot));
+            }
+            let result = pyre_object::w_tuple_new(result_items);
             let _ = pyre_object::gc_roots::pin_root(result);
             let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9192,8 +9192,8 @@ pub fn str_utf8_w(obj: PyObjectRef) -> Result<&'static str, PyError> {
             Err(crate::typedef::unicode_encode_error(
                 "utf-8",
                 obj,
-                pos,
-                pos + 1,
+                pos as i64,
+                (pos + 1) as i64,
                 "surrogates not allowed",
             ))
         }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1370,7 +1370,9 @@ pub(crate) unsafe fn get_and_call_function(
     _roots.normalize(base, 3 + args_w.len());
     let w_impl = unsafe { get(_roots.get(base), _roots.get(base + 1), _roots.get(base + 2)) }?
         .unwrap_or_else(|| _roots.get(base));
-    // One `Vec` at every arity, the shape the fast path above already builds:
+    // PyPy `descroperation.py:get_and_call_function` constructs
+    // `Arguments(space, list(args_w))`. One `Vec` at every arity preserves
+    // that shape and matches the fast path above:
     // `with_capacity`/`push` lower to `newlist`/`append`.  The fixed
     // `[PY_NULL; N]` leg this replaced ended in `<[T; N]>::index(&array,
     // ..len)` — a RangeTo subslice stays an inherent-impl call where a scalar
@@ -10913,8 +10915,10 @@ unsafe fn is_object_getattribute_descr(w_descr: PyObjectRef) -> bool {
 /// `typeobject.py:1322` — identity anchor for the canonical
 /// `W_TypeObject.descr_getattribute` wrapper installed on `type`.
 unsafe fn is_type_getattribute_descr(w_descr: PyObjectRef) -> bool {
-    lookup_in_type_where(crate::typedef::w_type(), "__getattribute__")
-        .is_some_and(|d| std::ptr::eq(w_descr, d))
+    match lookup_in_type_where(crate::typedef::w_type(), "__getattribute__") {
+        Some(d) => std::ptr::eq(w_descr, d),
+        None => false,
+    }
 }
 
 /// module.py `Module.descr_getattribute` is the default attribute slot for
@@ -10924,9 +10928,13 @@ unsafe fn is_module_getattribute_descr(w_descr: PyObjectRef) -> bool {
     let w_module_type =
         crate::typedef::gettypefor(&pyre_object::MODULE_TYPE as *const pyre_object::PyType)
             .map_or(PY_NULL, |p| p.as_ptr());
-    !w_module_type.is_null()
-        && lookup_in_type_where(w_module_type, "__getattribute__")
-            .is_some_and(|d| std::ptr::eq(w_descr, d))
+    if w_module_type.is_null() {
+        return false;
+    }
+    match lookup_in_type_where(w_module_type, "__getattribute__") {
+        Some(d) => std::ptr::eq(w_descr, d),
+        None => false,
+    }
 }
 
 /// Module-specialized companion of `getattribute_if_not_from_object`.
@@ -18637,8 +18645,15 @@ fn throw_yield_from(
     };
     if let Some((args, argc)) = throw_args {
         // PEP 380 delegation forwards exactly the original positional throw
-        // arguments, rather than a synthesized exception instance.
-        return crate::call::call_function_impl_result(throw, &args[..argc]);
+        // arguments, rather than a synthesized exception instance.  The
+        // producer validates `argc` as 1..=3; spell those fixed call shapes
+        // directly so translation does not detour through Rust's opaque
+        // `<[T; 3]>::index(&args, ..argc)` helper.
+        return match argc {
+            1 => crate::call::call_function_impl_result(throw, &[args[0]]),
+            2 => crate::call::call_function_impl_result(throw, &[args[0], args[1]]),
+            _ => crate::call::call_function_impl_result(throw, &args),
+        };
     }
     let w_exc = err.to_exc_object();
     let w_type = crate::typedef::r#type(w_exc).map_or(pyre_object::PY_NULL, |p| p.as_ptr());

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -15764,21 +15764,32 @@ fn unhashable_type_error(obj: PyObjectRef) -> crate::PyError {
 /// numeric values land on the same residue.
 const HASH_BITS: i64 = 61;
 const HASH_MODULUS: u64 = (1u64 << HASH_BITS) - 1;
-/// `floatobject.py` HASH_NAN sentinel.
-const HASH_NAN: i64 = 0;
-
-/// Numeric hash of a machine-word integer: reduce `a` modulo the
-/// Mersenne prime `HASH_MODULUS = 2**61 - 1` (the residue keeps `a`'s
-/// sign) and bump a `-1` result to `-2`.  Delegated to
-/// `rustpython_common::hash`; `mod_int` is `value % HASH_MODULUS` and
-/// `fix_sentinel` is the `-1 -> -2` guard.  Shares the reduction with
-/// `_hash_long`, so `hash(42) == hash(2**100 + 42)`-class invariants
-/// hold.  `mod_int`/`fix_sentinel` are `const fn`, so this inlines to
-/// the same arithmetic the hand-rolled port produced.
+const HASH_INF: i64 = 314_159;
+// tupleobject.py's 64-bit `r_ulonglong` xxHash constants.
+const XXPRIME_1: u64 = 11_400_714_785_074_694_791;
+const XXPRIME_2: u64 = 14_029_467_366_897_019_727;
+const XXPRIME_5: u64 = 2_870_177_450_012_600_261;
+// pypy/objspace/std/longobject.py imports rbigint.SHIFT, then defines
+// `_HASH_SHIFT = SHIFT % HASH_BITS`.  RPython's flowspace receives both as
+// already-folded host integers; mirror that graph shape inside this LLBC
+// artefact because Charon keeps a cross-artefact const read opaque.
+const RBIGINT_SHIFT: i64 = 63;
+const HASH_SHIFT: i64 = RBIGINT_SHIFT % HASH_BITS;
+const _: () = assert!(RBIGINT_SHIFT == majit_rlib::rbigint::SHIFT);
+/// Numeric hash of a machine-word integer — the literal branch-free port of
+/// `pypy/objspace/std/intobject.py::_hash_int`.  Keep the Mersenne reduction
+/// in interpreter source: it is part of the translated RPython graph, not an
+/// opaque Rust-library helper.  The unsigned multiply computes `abs(a)` even
+/// for `i64::MIN`, the residue keeps the original sign, and the final subtract
+/// maps the reserved `-1` hash to `-2`.
 #[inline]
 pub(crate) fn _hash_int(a: i64) -> i64 {
-    use rustpython_common::hash;
-    hash::fix_sentinel(hash::mod_int(a))
+    let sign = 1 - ((a < 0) as i64 * 2);
+    let mut x = (a as u64).wrapping_mul(sign as u64);
+    x = (x & HASH_MODULUS) + (x >> HASH_BITS);
+    x -= HASH_MODULUS * ((x >= HASH_MODULUS) as u64);
+    let h = (x as i64) * sign;
+    h - ((h == -1) as i64)
 }
 
 /// pypy/objspace/std/longobject.py `_hash_long`.
@@ -15787,14 +15798,13 @@ pub(crate) fn _hash_int(a: i64) -> i64 {
 /// `2**61 - 1`, then apply the sign and the `-1 -> -2` sentinel rule.
 #[inline]
 pub(crate) fn _hash_long(v: &BigInt) -> i64 {
-    const HASH_SHIFT: i64 = majit_rlib::rbigint::SHIFT % HASH_BITS;
     let mut i = v.numdigits();
     let mut x = 0_u64;
     while i > 0 {
         i -= 1;
         x = ((x << HASH_SHIFT) & HASH_MODULUS) + (x >> (HASH_BITS - HASH_SHIFT));
         x += v.udigit(i);
-        if majit_rlib::rbigint::SHIFT > HASH_BITS {
+        if RBIGINT_SHIFT > HASH_BITS {
             x = (x & HASH_MODULUS) + (x >> HASH_BITS);
         }
         if x >= HASH_MODULUS {
@@ -15805,38 +15815,84 @@ pub(crate) fn _hash_long(v: &BigInt) -> i64 {
     hash - (hash == -1) as i64
 }
 
-/// Numeric hash of a `float`.  `rustpython_common::hash::hash_float`
-/// reduces the mantissa/exponent modulo the Mersenne prime
-/// `HASH_MODULUS = 2**61 - 1` (keeping the sign), so `hash(2.0) == hash(2)`
-/// and the `±inf` sentinels are `±314159`; subnormals decompose exactly.
-/// It returns `None` for NaN.  Object-aware callers replace that case with
-/// `default_identity_hash`; `_hash_float` retains PyPy's internal sentinel
-/// for call sites that have no wrapped object.
+/// Literal port of `pypy/objspace/std/floatobject.py::_hash_float`.
+/// NaN identity hashing is handled by the wrapped-object caller, as in PyPy;
+/// this helper receives finite values or infinities only.
 #[inline]
 pub(crate) fn _hash_float(v: f64) -> i64 {
-    rustpython_common::hash::hash_float(v).unwrap_or(HASH_NAN)
+    if v.is_infinite() {
+        return if v > 0.0 { HASH_INF } else { -HASH_INF };
+    }
+
+    let (mut m, mut e) = crate::typedef::float_frexp(v);
+    let mut sign = 1_i64;
+    if m < 0.0 {
+        sign = -1;
+        m = -m;
+    }
+
+    let mut x = 0_u64;
+    while m != 0.0 {
+        x = ((x << 28) & HASH_MODULUS) | (x >> (HASH_BITS - 28));
+        m *= 268_435_456.0;
+        e -= 28;
+        let y = m as u64;
+        m -= y as f64;
+        x += y;
+        if x >= HASH_MODULUS {
+            x -= HASH_MODULUS;
+        }
+    }
+
+    let hash_bits = HASH_BITS as i32;
+    e = if e >= 0 {
+        e % hash_bits
+    } else {
+        hash_bits - 1 - ((-1 - e) % hash_bits)
+    };
+    x = ((x << e) & HASH_MODULUS) | (x >> (hash_bits - e));
+
+    let hash = (x as i64) * sign;
+    hash - (hash == -1) as i64
 }
 
-/// `tupleobject.py descr_hash` — the xxHash sequence hash, delegated
-/// to `rustpython_common::hash::hash_tuple`.  The caller has already computed
-/// each element's hash into `items`, so the fold is infallible here.
-///
-/// The shared fold reproduces the accumulator loop and length mangle exactly.
-/// It also corrects the `acc == (uint)-1` sentinel: `tupleobject.py:403`
-/// computes `acc += (acc == -1) * (1546275796 + 1)`, so a wrapped `acc` of
-/// `-1` becomes `1546275796` — the value CPython's `tuplehash` also returns.
-/// The prior local port set the result to `1546275796 + 1` instead of adding
-/// to `acc`, an off-by-one in that (2**-64-probability) case; delegation fixes
-/// it.
+/// Literal `tupleobject.py descr_hash` xxHash sequence fold over already
+/// computed element hashes.
 #[inline]
 fn _hash_tuple_xx(items: &[i64]) -> i64 {
-    _hash_tuple_xx_iter(items.iter().copied())
+    let mut acc = XXPRIME_5;
+    let mut i = 0_usize;
+    while i < items.len() {
+        let lane = items[i];
+        acc = acc.wrapping_add((lane as u64).wrapping_mul(XXPRIME_2));
+        acc = (acc << 31) | (acc >> 33);
+        acc = acc.wrapping_mul(XXPRIME_1);
+        i += 1;
+    }
+    acc = acc.wrapping_add((items.len() as u64) ^ (XXPRIME_5 ^ 3_527_539));
+    acc = acc.wrapping_add((acc == u64::MAX) as u64 * (1_546_275_796 + 1));
+    acc as i64
 }
 
-/// `_hash_tuple_xx` over element digests produced on the fly.
-fn _hash_tuple_xx_iter(items: impl Iterator<Item = i64>) -> i64 {
-    rustpython_common::hash::hash_tuple(items.map(Ok::<i64, ()>))
-        .expect("element hashes are precomputed, so the fold cannot fail")
+/// `tupleobject.py::_descr_hash_jitdriver`: hash the live wrapped-item
+/// storage with an explicit index loop.  This keeps the dynamic path out of
+/// Rust's generic `Iterator` hierarchy, which has no RPython owner/repr.
+unsafe fn _hash_tuple_xx_storage(obj: PyObjectRef) -> i64 {
+    let len = w_tuple_len(obj);
+    let mut acc = XXPRIME_5;
+    let mut i = 0_usize;
+    while i < len {
+        if let Some(item) = w_tuple_getitem(obj, i as i64) {
+            let lane = hash_value(item) as u64;
+            acc = acc.wrapping_add(lane.wrapping_mul(XXPRIME_2));
+            acc = (acc << 31) | (acc >> 33);
+            acc = acc.wrapping_mul(XXPRIME_1);
+        }
+        i += 1;
+    }
+    acc = acc.wrapping_add((len as u64) ^ (XXPRIME_5 ^ 3_527_539));
+    acc = acc.wrapping_add((acc == u64::MAX) as u64 * (1_546_275_796 + 1));
+    acc as i64
 }
 
 /// CPython/PyPy's deterministic seed expansion
@@ -15984,22 +16040,24 @@ pub fn hash_str_bytes(bytes: &[u8]) -> i64 {
     _hash_unicode(wtf8)
 }
 
-/// `setobject.py W_FrozensetObject.descr_hash` — the order-independent
-/// XOR-fold, delegated to `rustpython_common::hash::FrozenSetHash`.  The caller
-/// has already computed each element's hash into `items`.
-///
-/// The shared accumulator is bit-identical: its `shuffle_bits`
-/// `((h ^ 89869747) ^ (h << 16)) * 3644798167` equals the port's
-/// `(h ^ (h << 16) ^ 89869747) * (1822399083 * 2 + 1)` (xor is associative;
-/// `3644798167 == 1822399083 * 2 + 1`), and the seed `(len + 1) * 1927868237`,
-/// the final dispersion, and the `-1 -> 590923713` sentinel all match.
+/// Literal `setobject.py W_FrozensetObject.descr_hash` order-independent
+/// XOR-fold.  The caller has already computed each element's hash into
+/// `items`; `u64` is RPython's `r_uint` on pyre's supported 64-bit target.
 #[inline]
 fn _hash_frozenset(items: &[i64]) -> i64 {
-    let mut acc = rustpython_common::hash::FrozenSetHash::new(items.len());
-    for &item_hash in items {
-        acc.add(item_hash);
+    let multi = 1_822_399_083_u64
+        .wrapping_add(1_822_399_083)
+        .wrapping_add(1);
+    let mut hash = 1_927_868_237_u64.wrapping_mul(items.len() as u64 + 1);
+    for &h in items {
+        let h = h as u64;
+        let value = (h ^ (h << 16) ^ 89_869_747).wrapping_mul(multi);
+        hash ^= value;
     }
-    acc.finish()
+    hash ^= (hash >> 11) ^ (hash >> 25);
+    hash = hash.wrapping_mul(69_069).wrapping_add(907_133_923);
+    let hash = hash as i64;
+    if hash == -1 { 590_923_713 } else { hash }
 }
 
 /// CPython 3.14 consumes the digests cached in the set table and caches the
@@ -16103,9 +16161,7 @@ pub fn hash_value(obj: PyObjectRef) -> i64 {
             if let Some(hash) = pyre_object::w_tuple_cached_hash(obj) {
                 return hash;
             }
-            let n = w_tuple_len(obj) as i64;
-            let hash =
-                _hash_tuple_xx_iter((0..n).filter_map(|i| w_tuple_getitem(obj, i).map(hash_value)));
+            let hash = _hash_tuple_xx_storage(obj);
             pyre_object::w_tuple_set_cached_hash(obj, hash);
             return hash;
         }
@@ -21625,12 +21681,13 @@ mod tests {
         }
     }
 
-    /// `_hash_float` delegates to `rustpython_common::hash::hash_float`,
-    /// which reproduces the reference `hash(5e-324) == 16777216` for
-    /// subnormals, the `hash(2.0) == hash(2)` integral invariant, and the
-    /// `±inf`/NaN sentinels.
+    /// The literal PyPy `_hash_float` port reproduces the reference
+    /// `hash(5e-324) == 16777216` for subnormals, the
+    /// `hash(2.0) == hash(2)` integral invariant, and the `±inf` sentinels.
+    /// RustPython's implementation remains an independent finite-input
+    /// differential oracle, not part of the translated interpreter body.
     #[test]
-    fn float_hash_delegates_to_common() {
+    fn float_hash_matches_pypy_algorithm() {
         use rustpython_common::hash;
         // Subnormal reference point (the value that motivated the fix).
         assert_eq!(_hash_float(f64::from_bits(1)), 16777216);
@@ -21641,9 +21698,6 @@ mod tests {
         assert_eq!(_hash_float(-0.0), 0);
         assert_eq!(_hash_float(f64::INFINITY), 314159);
         assert_eq!(_hash_float(f64::NEG_INFINITY), -314159);
-        // NaN hashes to HASH_NAN here; common returns None for it.
-        assert_eq!(_hash_float(f64::NAN), HASH_NAN);
-        assert_eq!(hash::hash_float(f64::NAN), None);
         // Differential battery of tricky finite floats: `_hash_float` must
         // equal `Some(hash_float(f))` on every one.
         let cases = [
@@ -21708,9 +21762,9 @@ mod tests {
         );
     }
 
-    /// Tuple and frozenset hashes delegate to `rustpython_common::hash`
-    /// (`hash_tuple` / `FrozenSetHash`).  Both fold only element hashes and are
-    /// seed-independent, so the values are fixed and match CPython 3.14.
+    /// Tuple and frozenset hashes use their literal upstream folds. Both
+    /// consume only element hashes and are seed-independent, so the values are
+    /// fixed and match CPython 3.14.
     /// `_hash_tuple_xx` / `_hash_frozenset` take the already-computed element
     /// hashes; small ints hash to themselves and `hash(-1) == -2`.
     #[test]

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5163,9 +5163,13 @@ pub(crate) fn split_builtin_kwargs(args: &[PyObjectRef]) -> (&[PyObjectRef], Opt
 /// every `__majit_wrap_*` shim its own closure type, and merging those
 /// distinct types on one `TakeWhile` graph's input has no common base class.
 #[majit_macros::unroll_safe]
-pub(crate) fn leading_non_null_count(args: &[PyObjectRef]) -> usize {
-    let mut count = 0;
-    while count < args.len() && !args[count].is_null() {
+pub(crate) fn leading_non_null_count(args: &[PyObjectRef]) -> i64 {
+    // PyPy `argument.py:_match_signature` keeps `num_args`, `upfront`, and
+    // every derived argument count as ordinary RPython Signed values.  Rust
+    // slice indexing needs `usize`, but that is an indexing adapter, not the
+    // semantic type of the gateway count.
+    let mut count = 0i64;
+    while count < args.len() as i64 && !args[count as usize].is_null() {
         count += 1;
     }
     count

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6002,21 +6002,23 @@ fn precheck_for_new(w_type: PyObjectRef) -> Result<(), crate::PyError> {
 /// view (reading the name as `&str` would fail on the surrogate) and raise
 /// `UnicodeEncodeError('utf8', name, pos, pos + 1, 'surrogates not allowed')`
 /// at the first one, matching `check_utf8(name, allow_surrogates=False)`.
+/// Keep the call itself: upstream marks `_check_utf8` `jit.elidable`, so the
+/// validator is a load-bearing part of the JIT shape rather than an iterator
+/// scan to re-express locally. `CheckError.pos` is the byte position PyPy
+/// forwards unchanged into the exception.
 pub(crate) fn check_surrogate(w_name: PyObjectRef) -> Result<(), crate::PyError> {
     let wtf8 = unsafe { pyre_object::w_str_get_wtf8(w_name) };
-    let mut pos = 0usize;
-    for cp in wtf8.code_points() {
-        let c = cp.to_u32();
-        if (0xd800..=0xdfff).contains(&c) {
-            return Err(crate::typedef::unicode_encode_error(
-                "utf8",
-                w_name,
-                pos,
-                pos + 1,
-                "surrogates not allowed",
-            ));
-        }
-        pos += 1;
+    if let Err(e) = pyre_object::rutf8::check_utf8(wtf8.as_bytes(), false) {
+        // RPython's CheckError position, `e.pos + 1`, and the exception's
+        // start/end fields are all Signed; keep that type through the call.
+        let pos = e.pos;
+        return Err(crate::typedef::unicode_encode_error(
+            "utf8",
+            w_name,
+            pos,
+            pos + 1,
+            "surrogates not allowed",
+        ));
     }
     Ok(())
 }
@@ -10942,8 +10944,8 @@ fn unicode_to_decimal_w(
                 return Err(crate::typedef::unicode_encode_error(
                     "utf-8",
                     w_unistr,
-                    pos,
-                    pos + 1,
+                    pos as i64,
+                    (pos + 1) as i64,
                     "surrogates not allowed",
                 ));
             };
@@ -10959,8 +10961,8 @@ fn unicode_to_decimal_w(
             return Err(crate::typedef::unicode_encode_error(
                 "utf-8",
                 w_unistr,
-                pos,
-                pos + 1,
+                pos as i64,
+                (pos + 1) as i64,
                 "surrogates not allowed",
             ));
         };

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5998,20 +5998,31 @@ fn precheck_for_new(w_type: PyObjectRef) -> Result<(), crate::PyError> {
 }
 
 /// typeobject.py `_check_surrogate` — a type name may not contain a
-/// lone surrogate.  Scan the code points through the surrogate-aware WTF-8
-/// view (reading the name as `&str` would fail on the surrogate) and raise
+/// lone surrogate.  Validate through the surrogate-aware WTF-8 view (reading
+/// the name as `&str` would fail on the surrogate) and raise
 /// `UnicodeEncodeError('utf8', name, pos, pos + 1, 'surrogates not allowed')`
 /// at the first one, matching `check_utf8(name, allow_surrogates=False)`.
 /// Keep the call itself: upstream marks `_check_utf8` `jit.elidable`, so the
 /// validator is a load-bearing part of the JIT shape rather than an iterator
-/// scan to re-express locally. `CheckError.pos` is the byte position PyPy
-/// forwards unchanged into the exception.
+/// scan to re-express locally.
+///
+/// `CheckError.pos` is a BYTE offset — `_check_utf8` walks `s[pos]` — and
+/// `_check_surrogate` forwards it unchanged, but `UnicodeEncodeError` is
+/// consumed as a code-point index: `descr_str` reads `self.object[self.start]`
+/// (`interp_exceptions.py`, `W_UnicodeEncodeError.descr_str`) and `.start` is
+/// user-visible. Upstream is inconsistent between the two, and CPython 3.14
+/// reports the code-point index, so convert here rather than propagate the
+/// byte offset.  Oracle evidence (pinned CPython 3.14.6 versus local PyPy):
+/// `type('\u00e9\ud800', (), {})` reports `.start/.end == (1, 2)` on CPython
+/// and `(2, 3)` on PyPy.  Those exception attributes are observable, so the
+/// CPython 3.14 specification wins while the surrounding PyPy call shape is
+/// retained.
 pub(crate) fn check_surrogate(w_name: PyObjectRef) -> Result<(), crate::PyError> {
     let wtf8 = unsafe { pyre_object::w_str_get_wtf8(w_name) };
     if let Err(e) = pyre_object::rutf8::check_utf8(wtf8.as_bytes(), false) {
         // RPython's CheckError position, `e.pos + 1`, and the exception's
         // start/end fields are all Signed; keep that type through the call.
-        let pos = e.pos;
+        let pos = pyre_object::rutf8::codepoints_in_utf8(wtf8, 0, e.pos as usize) as i64;
         return Err(crate::typedef::unicode_encode_error(
             "utf8",
             w_name,
@@ -15799,6 +15810,7 @@ pub(crate) fn _hash_int(a: i64) -> i64 {
 /// Reduce the 63-bit rbigint digits modulo the Mersenne prime
 /// `2**61 - 1`, then apply the sign and the `-1 -> -2` sentinel rule.
 #[inline]
+#[majit_macros::elidable]
 pub(crate) fn _hash_long(v: &BigInt) -> i64 {
     let mut i = v.numdigits();
     let mut x = 0_u64;
@@ -15821,6 +15833,7 @@ pub(crate) fn _hash_long(v: &BigInt) -> i64 {
 /// NaN identity hashing is handled by the wrapped-object caller, as in PyPy;
 /// this helper receives finite values or infinities only.
 #[inline]
+#[majit_macros::elidable]
 pub(crate) fn _hash_float(v: f64) -> i64 {
     if v.is_infinite() {
         return if v > 0.0 { HASH_INF } else { -HASH_INF };
@@ -15876,20 +15889,33 @@ fn _hash_tuple_xx(items: &[i64]) -> i64 {
     acc as i64
 }
 
-/// `tupleobject.py::_descr_hash_jitdriver`: hash the live wrapped-item
-/// storage with an explicit index loop.  This keeps the dynamic path out of
-/// Rust's generic `Iterator` hierarchy, which has no RPython owner/repr.
+/// Hash the live wrapped-item storage with an explicit index loop, keeping
+/// the dynamic path out of Rust's generic `Iterator` hierarchy, which has no
+/// RPython owner/repr.
+///
+/// This is the BODY of `tupleobject.py`'s `_descr_hash_jitdriver`, not that
+/// method: the port carries neither its `hash_driver.jit_merge_point(w_type=
+/// space.type(self.wrappeditems[0]))` nor the `_unroll_condition()` fork that
+/// chooses between it and the `@jit.unroll_safe` `_descr_hash_unroll` arm.
+/// Restoring the fork needs `jit.loop_unrolling_heuristic` and an
+/// `UNROLL_CUTOFF`, neither of which exists here yet; until then the
+/// jitdriver arm is the only one, so the short-tuple unrolled path upstream
+/// takes is never taken.
 unsafe fn _hash_tuple_xx_storage(obj: PyObjectRef) -> i64 {
     let len = w_tuple_len(obj);
     let mut acc = XXPRIME_5;
     let mut i = 0_usize;
     while i < len {
-        if let Some(item) = w_tuple_getitem(obj, i as i64) {
-            let lane = hash_value(item) as u64;
-            acc = acc.wrapping_add(lane.wrapping_mul(XXPRIME_2));
-            acc = (acc << 31) | (acc >> 33);
-            acc = acc.wrapping_mul(XXPRIME_1);
-        }
+        // `i < len` bounds the read, so upstream's `wrappeditems[i]` cannot be
+        // absent.  Skipping the lane instead would fold a shorter sequence
+        // while the `acc += len` tail below still counts it, i.e. answer a
+        // hash for a tuple that does not exist.
+        let item = w_tuple_getitem(obj, i as i64)
+            .expect("tuple index below w_tuple_len is always present");
+        let lane = hash_value(item) as u64;
+        acc = acc.wrapping_add(lane.wrapping_mul(XXPRIME_2));
+        acc = (acc << 31) | (acc >> 33);
+        acc = acc.wrapping_mul(XXPRIME_1);
         i += 1;
     }
     acc = acc.wrapping_add((len as u64) ^ (XXPRIME_5 ^ 3_527_539));
@@ -21189,6 +21215,23 @@ static __majit_wrap_builtin_dunder_import_target: crate::gateway::BuiltinWrapper
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn check_surrogate_reports_codepoint_position_like_cpython_314() {
+        let _ = new_builtin_module_dict();
+        let mut name = rustpython_wtf8::Wtf8Buf::new();
+        name.push(rustpython_wtf8::CodePoint::from_char('\u{e9}'));
+        name.push(rustpython_wtf8::CodePoint::from_u32(0xd800).unwrap());
+        let w_name = pyre_object::w_str_from_wtf8(name);
+
+        let error = check_surrogate(w_name).expect_err("a lone surrogate must be rejected");
+        assert_eq!(error.kind, crate::PyErrorKind::UnicodeEncodeError);
+        let start =
+            unsafe { pyre_object::interp_exceptions::w_exception_get_start(error.exc_object) };
+        let end = unsafe { pyre_object::interp_exceptions::w_exception_get_end(error.exc_object) };
+        assert_eq!(unsafe { pyre_object::w_int_get_value(start) }, 1);
+        assert_eq!(unsafe { pyre_object::w_int_get_value(end) }, 2);
+    }
 
     /// Several threads installing the builtins at once all finish.
     ///

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -11585,6 +11585,19 @@ pub fn try_vec_with_capacity<T>(count: usize) -> Result<Vec<T>, crate::PyError> 
     Ok(out)
 }
 
+/// `objectmodel.newlist_hint` for a `PyObjectRef` item list.
+///
+/// RPython handles `newlist_hint` through an ExtRegistry specialization:
+/// translation does not inspect the helper body, but emits
+/// `LIST.ll_newlist_hint` directly.  Rust generic calls are monomorphized into
+/// their caller before the LLBC front end sees them, so this non-generic seam
+/// carries the equivalent translation boundary. `flowspace_adapter` replaces
+/// the call with `newlist_hint`; generated JitCode never residualizes it.
+#[majit_macros::dont_look_inside]
+pub fn try_pyobject_vec_with_capacity(count: usize) -> Result<Vec<PyObjectRef>, crate::PyError> {
+    try_vec_with_capacity(count)
+}
+
 /// The `Wtf8Buf` counterpart of [`try_vec_with_capacity`], for the str
 /// methods that size their buffer from a caller-supplied `width`.
 pub fn try_wtf8_with_capacity(

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -834,14 +834,14 @@ fn builtin_keyword_failure(
 /// same graph boundary explicitly.
 #[inline(never)]
 fn make_user_call_frame(
-    w_code: *const (),
+    w_code: PyObjectRef,
     args: &[PyObjectRef],
     w_globals: PyObjectRef,
     execution_context: *const crate::PyExecutionContext,
     closure: PyObjectRef,
 ) -> Result<crate::pyframe::FrameBox, crate::PyError> {
     let frame = PyFrame::try_new_for_call_with_closure_and_globals_obj(
-        w_code,
+        w_code as *const (),
         args,
         w_globals,
         execution_context,
@@ -971,7 +971,7 @@ pub fn call_user_function_resolved(
     if crate::pyframe::code_flags_make_generator(code_ref.flags) {
         let gen_frame =
             crate::pyframe::FrameBox::new(PyFrame::try_new_for_call_with_closure_and_globals_obj(
-                w_code,
+                w_code as *const (),
                 args,
                 w_globals,
                 execution_context,
@@ -985,7 +985,7 @@ pub fn call_user_function_resolved(
 
     let mut func_frame =
         crate::pyframe::FrameBox::new(PyFrame::try_new_for_call_with_closure_and_globals_obj(
-            w_code,
+            w_code as *const (),
             args,
             w_globals,
             execution_context,
@@ -2118,7 +2118,7 @@ pub fn call_user_function_plain_with_ctx(
     if crate::pyframe::code_flags_make_generator(code_ref.flags) {
         let gen_frame =
             crate::pyframe::FrameBox::new(PyFrame::try_new_for_call_with_closure_and_globals_obj(
-                w_code,
+                w_code as *const (),
                 &final_args,
                 w_globals,
                 execution_context,
@@ -2130,7 +2130,7 @@ pub fn call_user_function_plain_with_ctx(
 
     let mut func_frame =
         crate::pyframe::FrameBox::new(PyFrame::try_new_for_call_with_closure_and_globals_obj(
-            w_code,
+            w_code as *const (),
             &final_args,
             w_globals,
             execution_context,
@@ -3362,7 +3362,7 @@ fn call_with_kwargs_in_ctx_impl(
             let closure = unsafe { function_get_closure(current_callable()) };
             let mut func_frame = crate::pyframe::FrameBox::new(
                 crate::pyframe::PyFrame::try_new_for_call_with_closure_and_globals_obj(
-                    w_code,
+                    w_code as *const (),
                     &final_args,
                     w_globals,
                     execution_context,
@@ -4168,7 +4168,7 @@ fn call_user_function_with_args(func: PyObjectRef, args: &[PyObjectRef]) -> PyOb
     if crate::pyframe::code_flags_make_generator(code_ref.flags) {
         let gen_frame = crate::pyframe::FrameBox::new(
             match PyFrame::try_new_for_call_with_closure_and_globals_obj(
-                w_code,
+                w_code as *const (),
                 &final_args,
                 w_globals,
                 exec_ctx,
@@ -4193,7 +4193,7 @@ fn call_user_function_with_args(func: PyObjectRef, args: &[PyObjectRef]) -> PyOb
 
     let mut frame = crate::pyframe::FrameBox::new(
         match PyFrame::try_new_for_call_with_closure_and_globals_obj(
-            w_code,
+            w_code as *const (),
             &final_args,
             w_globals,
             exec_ctx,
@@ -4257,7 +4257,7 @@ fn call_user_function_resolved_frameless(func: PyObjectRef, args: &[PyObjectRef]
 
     let mut frame =
         crate::pyframe::FrameBox::new(PyFrame::new_for_call_with_closure_and_globals_obj(
-            w_code,
+            w_code as *const (),
             args,
             w_globals,
             exec_ctx,
@@ -5035,7 +5035,7 @@ fn build_class_inner(
 
     let mut frame =
         crate::pyframe::FrameBox::new(PyFrame::try_new_for_call_with_closure_and_globals_obj(
-            w_code,
+            w_code as *const (),
             &[],
             w_globals,
             exec_ctx,

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2682,10 +2682,7 @@ pub(crate) fn bind_kwargs_to_signature(
                     break;
                 }
                 if !result[pi].is_null() {
-                    return Err(crate::PyError::type_error(format!(
-                        "{}() got multiple values for argument '{}'",
-                        fname, key
-                    )));
+                    return builtin_multiple_values_failure(fname, key);
                 }
                 result[pi] = *value;
                 matched = true;
@@ -2727,14 +2724,7 @@ pub(crate) fn bind_kwargs_to_signature(
     // argument.py:289 — too-many-positionals is raised last, after the
     // keyword-matching errors above.
     if too_many_args {
-        return Err(crate::PyError::type_error(format!(
-            "{}() takes {} positional argument{} but {} {} given",
-            fname,
-            n_pos_params,
-            if n_pos_params != 1 { "s" } else { "" },
-            n_pos,
-            if n_pos != 1 { "were" } else { "was" },
-        )));
+        return builtin_too_many_positional_failure(fname, n_pos_params as i64, n_pos as i64);
     }
 
     // Pack `*args` / `**kwargs` tails — argument.py _match_signature 207-259.
@@ -2793,6 +2783,42 @@ pub(crate) fn bind_kwargs_to_signature(
     }
 
     Ok(result)
+}
+
+/// Cold `ArgErrMultipleValues.getmsg` materialisation.
+///
+/// PyPy's `_match_signature` returns `ArgErrMultipleValues(argname)` and
+/// `Arguments.parse_obj` formats it only on the rejected-call path.  Pyre's
+/// `PyError` carries the eager message, so centralize that materialisation in
+/// the corresponding rejected-call helper instead of duplicating it in every
+/// generated gateway graph that calls the matcher.
+#[cold]
+fn builtin_multiple_values_failure(
+    fname: &str,
+    key: &Wtf8Buf,
+) -> Result<Vec<PyObjectRef>, PyError> {
+    Err(PyError::type_error(format!(
+        "{}() got multiple values for argument '{}'",
+        fname, key
+    )))
+}
+
+/// Cold `ArgErrTooMany.getmsg` materialisation; see
+/// [`builtin_multiple_values_failure`].
+#[cold]
+fn builtin_too_many_positional_failure(
+    fname: &str,
+    expected: i64,
+    given: i64,
+) -> Result<Vec<PyObjectRef>, PyError> {
+    Err(PyError::type_error(format!(
+        "{}() takes {} positional argument{} but {} {} given",
+        fname,
+        expected,
+        if expected != 1 { "s" } else { "" },
+        given,
+        if given != 1 { "were" } else { "was" },
+    )))
 }
 
 /// [`call_with_kwargs_in_ctx`] reached from a frame.  Installs the caller
@@ -3692,6 +3718,18 @@ fn log_call_error(message: &str) {
     let _ = message;
 }
 
+/// Cold `descroperation.py call` non-callable error materialisation.
+///
+/// Upstream raises this through `oefmt("'%T' object is not callable")`; the
+/// translated dispatch keeps all successful callable arms visible while this
+/// eager Rust message remains on the rejected arm only.
+fn not_callable_error(callable: PyObjectRef) -> PyError {
+    let type_name = crate::typedef::r#type(callable)
+        .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
+        .unwrap_or_else(|| unsafe { (*(*callable).ob_type).name });
+    PyError::type_error(format!("'{type_name}' object is not callable"))
+}
+
 pub(crate) fn call_function_impl(callable: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRef {
     call_function_impl_raw(callable, args)
 }
@@ -3876,12 +3914,7 @@ pub fn call_function_impl_result(
             return call_function_impl_result(call_fn, &current_args);
         }
     }
-    let type_name = crate::typedef::r#type(callable)
-        .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
-        .unwrap_or_else(|| unsafe { (*(*callable).ob_type).name });
-    Err(PyError::type_error(format!(
-        "'{type_name}' object is not callable"
-    )))
+    Err(not_callable_error(callable))
 }
 
 /// CPython: typeobject.c calculate_metaclass

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2026,9 +2026,12 @@ fn call_non_function_callable_with_mode(
         user_call_slot(pyre_object::gc_roots::shadow_stack_get(user_call_root_base))?
     {
         let current_callable = pyre_object::gc_roots::shadow_stack_get(user_call_root_base);
-        let current_args: Vec<PyObjectRef> = (0..args.len())
-            .map(|i| pyre_object::gc_roots::shadow_stack_get(user_call_root_base + 1 + i))
-            .collect();
+        let mut current_args = Vec::with_capacity(args.len());
+        for i in 0..args.len() {
+            current_args.push(pyre_object::gc_roots::shadow_stack_get(
+                user_call_root_base + 1 + i,
+            ));
+        }
         if prepend_receiver {
             let mut call_args = Vec::with_capacity(1 + current_args.len());
             call_args.push(current_callable);

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -405,6 +405,33 @@ pub fn get_eval_fn() -> EvalFn {
     }
 }
 
+/// Execute a newly-created frame through the process-selected evaluator using
+/// the one-word residual ABI.
+///
+/// PyPy's translated `Function.call_args` calls `new_frame.run()` directly;
+/// pyre's lower interpreter crate instead receives the JIT-aware evaluator
+/// through [`EVAL_OVERRIDE`]. That dependency seam is host plumbing, not a
+/// source-level PBC. Keep it opaque to the translated caller and publish the
+/// ordinary result/exception split through the same pending-error channel as
+/// the other bare-`PyObjectRef` call boundaries.
+///
+/// The native helper may enter `eval_with_jit`, and therefore the portal,
+/// while executing a residual call. This is the RPython
+/// `cpu.bh_call_r(translated_func, ...)` behavior: residual means opaque to
+/// the enclosing trace, not that nested translated execution has its JIT
+/// disabled.
+#[majit_macros::dont_look_inside]
+pub fn eval_current_frame_raw(frame: &mut PyFrame) -> PyObjectRef {
+    clear_call_error();
+    match get_eval_fn()(frame, None) {
+        Ok(value) => value,
+        Err(error) => {
+            set_call_error(error);
+            PY_NULL
+        }
+    }
+}
+
 // ── JIT parameter injection ──────────────────────────────────────
 //
 // `pypy/interpreter/executioncontext.py settrace` invokes
@@ -947,7 +974,12 @@ pub fn call_user_function_with_ctx(
     };
     func_frame.fix_array_ptrs();
     let _callee_locals_root = FrameLocalsRoot::new_mut(&mut func_frame);
-    get_eval_fn()(&mut func_frame, None)
+    let result = eval_current_frame_raw(&mut func_frame);
+    if result.is_null() {
+        Err(take_call_error().unwrap_or_else(|| crate::PyError::value_error("call failed")))
+    } else {
+        Ok(result)
+    }
 }
 
 /// Call a user function with pre-resolved args (scope already packed by

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2640,24 +2640,48 @@ pub(crate) fn bind_kwargs_to_signature(
     // on the same call wins first.
     let too_many_args = n_pos > n_pos_params && !has_varargs;
 
-    let mut result = vec![pyre_object::PY_NULL; nparams];
+    // `argument.py` receives `arguments_w`, `keyword_names_w`, and
+    // `keywords_w` as three GC-pointer lists.  The public Rust call surface
+    // carries keyword names as host Wtf8 buffers instead, so materialise the
+    // wrapped-name list once and keep all three lists on the shadow stack.
+    // This is the manual counterpart of the GC transform rooting those live
+    // RPython lists across each name allocation.
+    let roots = pyre_object::gc_roots::push_roots();
+    let pos_args_slot = roots.base();
+    for &value in pos_args {
+        let _ = roots.pin_root(value);
+    }
+    let keyword_values_slot = pos_args_slot + pos_args.len();
+    for (_, value) in kwargs {
+        let _ = roots.pin_root(*value);
+    }
+    let keyword_names_slot = keyword_values_slot + kwargs.len();
+    for (key, _) in kwargs {
+        let w_key = pyre_object::w_str_from_wtf8_managed(key.clone());
+        let _ = roots.pin_root(w_key);
+    }
+    let result_slot = keyword_names_slot + kwargs.len();
+    for _ in 0..nparams {
+        let _ = roots.pin_root(pyre_object::PY_NULL);
+    }
     for i in 0..n_pos.min(n_pos_params) {
-        result[i] = pos_args[i];
+        roots.set(result_slot + i, roots.get(pos_args_slot + i));
     }
 
     // _match_keywords — match each keyword to a param name by index.
     // `argument.py:_collect_keyword_args` keeps keyword names and values in
-    // parallel lists (`keyword_names_w`, `keywords_w`) and uses the mapping
-    // only to select unmatched positions.  Preserve that storage shape: an
-    // inline Rust `(Wtf8Buf, PyObjectRef)` tuple would otherwise become a
-    // list-of-inline-structs that RPython never has.
-    let mut extra_kw_names: Vec<Wtf8Buf> = Vec::new();
-    let mut extra_kw_values: Vec<PyObjectRef> = Vec::new();
+    // parallel lists (`keyword_names_w`, `keywords_w`) and uses
+    // `kwds_mapping` only to select unmatched positions.  Preserve that
+    // storage shape by recording the unmatched indices into the two rooted
+    // lists above; an inline Rust `(Wtf8Buf, PyObjectRef)` tuple would become
+    // a list-of-inline-structs that RPython never has.
+    let mut extra_kw_indices: Vec<usize> = Vec::new();
     let mut unmatched_kw_names: Vec<Wtf8Buf> = Vec::new();
     // argument.py:469,481-484 — collected across the whole loop, reported
     // together instead of raising on the first violation found.
     let mut posonly_kwds: Vec<String> = Vec::new();
-    for (key, value) in kwargs {
+    let mut kw_index = 0usize;
+    for (key, _) in kwargs {
         // A lone-surrogate keyword name (not valid UTF-8) never equals a
         // source-level parameter name, so it falls straight to **kwargs or
         // the unexpected-keyword error below.
@@ -2666,42 +2690,43 @@ pub(crate) fn bind_kwargs_to_signature(
         } else {
             None
         };
+        // argument.py `_match_keywords` delegates this lookup to the
+        // elidable Signature method.  Keep that boundary: translating the
+        // host `Vec<&str>` iteration here would expose Rust's fat-pointer
+        // storage to the RPython-shaped low-level array model.
+        let pi = if let Some(name) = key_str {
+            sig.find_argname(name)
+        } else {
+            -1
+        };
         let mut matched = false;
-        for pi in 0..nparams {
-            if key_str == Some(sig.argnames[pi]) {
-                // argument.py:474 — positional-only param passed by keyword:
-                // absorb into **kwargs if present, else error.
-                if pi < posonly {
-                    if has_varkw {
-                        break;
-                    }
+        if pi >= 0 {
+            let pi = pi as usize;
+            // argument.py:474 — positional-only param passed by keyword:
+            // absorb into **kwargs if present, else error.
+            if pi < posonly {
+                if !has_varkw {
                     // argument.py:481-484 — collect and keep scanning
                     // remaining keywords instead of raising immediately.
                     posonly_kwds.push(key.to_string());
                     matched = true;
-                    break;
                 }
-                if !result[pi].is_null() {
+            } else {
+                if !roots.get(result_slot + pi).is_null() {
                     return builtin_multiple_values_failure(fname, key);
                 }
-                result[pi] = *value;
+                roots.set(result_slot + pi, roots.get(keyword_values_slot + kw_index));
                 matched = true;
-                break;
             }
         }
         if !matched {
             if has_varkw {
-                // The name stays a `Wtf8Buf` until the packing bracket below.
-                // Interning it here would allocate once per unmatched keyword,
-                // and every one of those is a safepoint that relocates the
-                // values already accumulated — and the bound parameters in
-                // `result` — while nothing names them.
-                extra_kw_names.push(key.clone());
-                extra_kw_values.push(*value);
+                extra_kw_indices.push(kw_index);
             } else {
                 unmatched_kw_names.push(key.clone());
             }
         }
+        kw_index += 1;
     }
 
     // argument.py — ArgErrPosonlyAsKwds, raised after the full
@@ -2728,27 +2753,28 @@ pub(crate) fn bind_kwargs_to_signature(
     }
 
     // Pack `*args` / `**kwargs` tails — argument.py _match_signature 207-259.
-    // The bound parameters, the unmatched keyword values and both tail objects
-    // are all raw copies held across the packing allocations; see the same
-    // bracket in `resolve_kwargs`, including why a star-less signature returns
-    // before it.  Keyword names are non-GC Wtf8 buffers and remain in their
-    // parallel list.
+    // The bound parameters, keyword names, and keyword values are reloaded
+    // from their rooted parallel lists across the packing allocations.  Here
+    // the bracket starts before keyword matching because materialising PyPy's
+    // `keyword_names_w` list itself can collect.
     if !has_varargs && !has_varkw {
+        let mut result = Vec::with_capacity(nparams);
+        for i in 0..nparams {
+            result.push(roots.get(result_slot + i));
+        }
         return Ok(result);
     }
-    let roots = pyre_object::gc_roots::push_roots();
-    let result_slot = roots.base();
-    for &value in &result {
-        let _ = roots.pin_root(value);
-    }
-    let extra_slot = result_slot + result.len();
-    for &value in &extra_kw_values {
-        let _ = roots.pin_root(value);
-    }
-    let varargs_slot = extra_slot + extra_kw_values.len();
+    let varargs_slot = result_slot + nparams;
     if has_varargs {
         let extra_pos: Vec<PyObjectRef> = if n_pos > n_pos_params {
-            pos_args[n_pos_params..n_pos].to_vec()
+            // argument.py `_match_signature` slices `args_w[input_argcount:]`.
+            // Reload the rooted list first so the Rust slice contains the
+            // post-collection addresses, then preserve that upstream slice.
+            let mut rooted_pos_args = Vec::with_capacity(n_pos);
+            for i in 0..n_pos {
+                rooted_pos_args.push(roots.get(pos_args_slot + i));
+            }
+            rooted_pos_args.as_slice()[n_pos_params..n_pos].to_vec()
         } else {
             vec![]
         };
@@ -2757,22 +2783,22 @@ pub(crate) fn bind_kwargs_to_signature(
     let varkw_slot = varargs_slot + usize::from(has_varargs);
     if has_varkw {
         let _ = roots.pin_root(pyre_object::w_dict_new_kwargs());
-        // The index loop lowers to direct element loads; iterator adapters are residual calls.
+        // The index loop lowers to direct one-word element loads; iterator
+        // adapters are residual calls.
         #[allow(clippy::needless_range_loop)]
-        for i in 0..extra_kw_names.len() {
-            let key = &extra_kw_names[i];
+        for i in 0..extra_kw_indices.len() {
+            let kw_index = extra_kw_indices[i];
             unsafe {
-                // The key allocation runs first: as the second argument it
-                // would be evaluated after the receiver, handing
-                // `w_dict_store` the pre-collection dict address.
-                let w_key = pyre_object::w_str_from_wtf8_managed(key.clone());
-                pyre_object::w_dict_store(roots.get(varkw_slot), w_key, roots.get(extra_slot + i));
+                pyre_object::w_dict_store(
+                    roots.get(varkw_slot),
+                    roots.get(keyword_names_slot + kw_index),
+                    roots.get(keyword_values_slot + kw_index),
+                );
             }
         }
     }
-    let result_len = result.len();
-    let mut result: Vec<PyObjectRef> = Vec::with_capacity(result_len);
-    for i in 0..result_len {
+    let mut result: Vec<PyObjectRef> = Vec::with_capacity(nparams);
+    for i in 0..nparams {
         result.push(roots.get(result_slot + i));
     }
     if has_varargs {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2614,7 +2614,13 @@ pub(crate) fn bind_kwargs_to_signature(
     }
 
     // _match_keywords — match each keyword to a param name by index.
-    let mut extra_kwargs: Vec<(Wtf8Buf, PyObjectRef)> = Vec::new();
+    // `argument.py:_collect_keyword_args` keeps keyword names and values in
+    // parallel lists (`keyword_names_w`, `keywords_w`) and uses the mapping
+    // only to select unmatched positions.  Preserve that storage shape: an
+    // inline Rust `(Wtf8Buf, PyObjectRef)` tuple would otherwise become a
+    // list-of-inline-structs that RPython never has.
+    let mut extra_kw_names: Vec<Wtf8Buf> = Vec::new();
+    let mut extra_kw_values: Vec<PyObjectRef> = Vec::new();
     let mut unmatched_kw_names: Vec<Wtf8Buf> = Vec::new();
     // argument.py:469,481-484 — collected across the whole loop, reported
     // together instead of raising on the first violation found.
@@ -2661,7 +2667,8 @@ pub(crate) fn bind_kwargs_to_signature(
                 // and every one of those is a safepoint that relocates the
                 // values already accumulated — and the bound parameters in
                 // `result` — while nothing names them.
-                extra_kwargs.push((key.clone(), *value));
+                extra_kw_names.push(key.clone());
+                extra_kw_values.push(*value);
             } else {
                 unmatched_kw_names.push(key.clone());
             }
@@ -2699,10 +2706,11 @@ pub(crate) fn bind_kwargs_to_signature(
     }
 
     // Pack `*args` / `**kwargs` tails — argument.py _match_signature 207-259.
-    // The bound parameters, the unmatched keyword pairs and both tail objects
+    // The bound parameters, the unmatched keyword values and both tail objects
     // are all raw copies held across the packing allocations; see the same
     // bracket in `resolve_kwargs`, including why a star-less signature returns
-    // before it.
+    // before it.  Keyword names are non-GC Wtf8 buffers and remain in their
+    // parallel list.
     if !has_varargs && !has_varkw {
         return Ok(result);
     }
@@ -2712,10 +2720,10 @@ pub(crate) fn bind_kwargs_to_signature(
         let _ = roots.pin_root(value);
     }
     let extra_slot = result_slot + result.len();
-    for &(_, value) in &extra_kwargs {
+    for &value in &extra_kw_values {
         let _ = roots.pin_root(value);
     }
-    let varargs_slot = extra_slot + extra_kwargs.len();
+    let varargs_slot = extra_slot + extra_kw_values.len();
     if has_varargs {
         let extra_pos: Vec<PyObjectRef> = if n_pos > n_pos_params {
             pos_args[n_pos_params..n_pos].to_vec()
@@ -2729,8 +2737,8 @@ pub(crate) fn bind_kwargs_to_signature(
         let _ = roots.pin_root(pyre_object::w_dict_new_kwargs());
         // The index loop lowers to direct element loads; iterator adapters are residual calls.
         #[allow(clippy::needless_range_loop)]
-        for i in 0..extra_kwargs.len() {
-            let key = &extra_kwargs[i].0;
+        for i in 0..extra_kw_names.len() {
+            let key = &extra_kw_names[i];
             unsafe {
                 // The key allocation runs first: as the second argument it
                 // would be evaluated after the receiver, handing

--- a/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
@@ -1049,8 +1049,8 @@ pub unsafe extern "C" fn PyUnicode_EncodeLocale(
         super::pyerrors::set_pending_error(crate::typedef::unicode_encode_error(
             LOCALE_CODEC,
             value,
-            position,
-            position + 1,
+            position as i64,
+            (position + 1) as i64,
             "encoding error",
         ));
         return std::ptr::null_mut();

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -270,6 +270,7 @@ pub(crate) fn bytearray_repr_string(data: &[u8], class_name: &str) -> String {
 /// table.  Keep this loop in interpreter source so translation sees the same
 /// StringBuilder/character operations as PyPy instead of an opaque external
 /// Rust formatting iterator.
+#[majit_macros::elidable]
 pub(crate) fn bytes_repr_string(data: &[u8]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     let quote = if data.contains(&b'\'') && !data.contains(&b'"') {

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -154,16 +154,66 @@ pub(crate) fn format_float_repr(val: f64) -> String {
     rustpython_literal::float::to_string(val)
 }
 
-/// `repr`-style string escaping: pick the outer quote (prefer `'`, switch
-/// to `"` when the value contains `'` but not `"`), escape the backslash,
-/// the chosen quote, whitespace and non-printable code points, and render
-/// lone surrogates as `\uXXXX`. Delegates to the shared escape engine in
-/// `rustpython_literal::escape`.
+/// `unicodedb.isprintable` in PyPy's `rutf8.make_utf8_escape_function` is a
+/// pure generated-table lookup.  Keep the same scalar call boundary around
+/// pyre's Unicode database provider, including the upstream guarantee that a
+/// lone surrogate is not printable.
+#[majit_macros::elidable_cannot_raise]
+fn repr_codepoint_is_printable(code: u32) -> bool {
+    char::from_u32(code).is_some_and(rustpython_unicode::classify::is_printable)
+}
+
+/// `rutf8.make_utf8_escape_function(pass_printable=True, quotes=True)` —
+/// choose the outer quote, then append printable code points or lowercase
+/// `\x` / `\u` / `\U` escapes to a StringBuilder.  PyPy marks the generated
+/// `_repr_function` `@jit.elidable`; preserve that call policy and keep the
+/// loop in interpreter source so source translation sees its real semantics.
+#[majit_macros::elidable]
 pub(crate) fn format_wtf8_repr(s: &Wtf8) -> String {
-    use rustpython_literal::escape::{Quote, UnicodeEscape};
-    let escape = UnicodeEscape::with_preferred_quote(s, Quote::Single);
-    let mut out = String::new();
-    escape.str_repr().write(&mut out).unwrap();
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let quote = if s.as_bytes().contains(&b'\'') && !s.as_bytes().contains(&b'"') {
+        b'"'
+    } else {
+        b'\''
+    };
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push(quote as char);
+    let mut pos = 0;
+    while pos < s.len() {
+        let code = pyre_object::rutf8::codepoint_at_pos(s, pos).to_u32();
+        if code == quote as u32 || code == b'\\' as u32 {
+            out.push('\\');
+            out.push(code as u8 as char);
+        } else if code == b'\t' as u32 {
+            out.push_str("\\t");
+        } else if code == b'\n' as u32 {
+            out.push_str("\\n");
+        } else if code == b'\r' as u32 {
+            out.push_str("\\r");
+        } else if repr_codepoint_is_printable(code) {
+            // A printable code point is necessarily a Unicode scalar (the
+            // helper rejects surrogates), so the conversion cannot fail.
+            out.push(char::from_u32(code).expect("printable code point is a scalar"));
+        } else {
+            let digits = if code >= 0x10000 {
+                out.push_str("\\U");
+                8
+            } else if code >= 0x100 {
+                out.push_str("\\u");
+                4
+            } else {
+                out.push_str("\\x");
+                2
+            };
+            let mut shift = digits * 4;
+            while shift != 0 {
+                shift -= 4;
+                out.push(HEX[((code >> shift) & 0x0f) as usize] as char);
+            }
+        }
+        pos = pyre_object::rutf8::next_codepoint_pos(s, pos);
+    }
+    out.push(quote as char);
     out
 }
 
@@ -198,6 +248,45 @@ pub(crate) fn bytearray_repr_string(data: &[u8], class_name: &str) -> String {
     }
     out.push(quote as char);
     out.push(')');
+    out
+}
+
+/// `bytesobject.py::string_escape_encode(data, quotes=True)` — bytes repr.
+/// PyPy chooses `"` only when the input contains `'` and not `"`, escapes
+/// the chosen quote and backslash, names tab/newline/carriage-return, and
+/// renders every other non-printable byte through the constant lowercase hex
+/// table.  Keep this loop in interpreter source so translation sees the same
+/// StringBuilder/character operations as PyPy instead of an opaque external
+/// Rust formatting iterator.
+pub(crate) fn bytes_repr_string(data: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let quote = if data.contains(&b'\'') && !data.contains(&b'"') {
+        b'"'
+    } else {
+        b'\''
+    };
+    let mut out = String::with_capacity(data.len() + 2);
+    out.push('b');
+    out.push(quote as char);
+    for &c in data {
+        if c == b'\\' || c == quote {
+            out.push('\\');
+            out.push(c as char);
+        } else if c == b'\t' {
+            out.push_str("\\t");
+        } else if c == b'\r' {
+            out.push_str("\\r");
+        } else if c == b'\n' {
+            out.push_str("\\n");
+        } else if !(0x20..0x7f).contains(&c) {
+            out.push_str("\\x");
+            out.push(HEX[(c >> 4) as usize] as char);
+            out.push(HEX[(c & 0x0f) as usize] as char);
+        } else {
+            out.push(c as char);
+        }
+    }
+    out.push(quote as char);
     out
 }
 
@@ -902,10 +991,7 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
                 // shared bytes escaper cannot express it.
                 bytearray_repr_string(data, "bytearray")
             } else {
-                let escape = rustpython_literal::escape::AsciiEscape::new_repr(data);
-                let mut body = String::new();
-                escape.bytes_repr().write(&mut body).unwrap();
-                body
+                bytes_repr_string(data)
             }
         } else if pyre_object::is_set_or_frozenset(obj) {
             return set_repr_wtf8(obj);
@@ -1073,11 +1159,11 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
                 }
             }
             let mut joined = Wtf8Buf::new();
-            for (index, part) in parts.iter().enumerate() {
+            for index in 0..parts.len() {
                 if index > 0 {
                     joined.push_str(" | ");
                 }
-                joined.push_wtf8(part);
+                joined.push_wtf8(&parts[index]);
             }
             return Ok(joined);
         } else if std::ptr::eq(tp, &pyre_object::GENERIC_ALIAS_TYPE as *const PyType) {
@@ -2217,7 +2303,33 @@ impl fmt::Display for PyDisplay {
 
 #[cfg(test)]
 mod tests {
-    use super::nt_drive_len;
+    use super::{bytes_repr_string, format_wtf8_repr, nt_drive_len};
+    use rustpython_wtf8::{CodePoint, Wtf8Buf};
+
+    #[test]
+    fn bytes_repr_matches_pypy_quote_and_escape_edges() {
+        assert_eq!(bytes_repr_string(b""), "b''");
+        assert_eq!(bytes_repr_string(b"a'b"), "b\"a'b\"");
+        assert_eq!(bytes_repr_string(b"a\"b"), "b'a\"b'");
+        assert_eq!(bytes_repr_string(b"a'\"b"), "b'a\\'\"b'");
+        assert_eq!(
+            bytes_repr_string(&[0, 9, 10, 13, 31, 32, 92, 126, 127, 255]),
+            "b'\\x00\\t\\n\\r\\x1f \\\\~\\x7f\\xff'"
+        );
+    }
+
+    #[test]
+    fn unicode_repr_matches_pypy_quote_printable_and_surrogate_edges() {
+        assert_eq!(format_wtf8_repr(Wtf8Buf::from("a'b").as_ref()), "\"a'b\"");
+        assert_eq!(format_wtf8_repr(Wtf8Buf::from("a\"b").as_ref()), "'a\"b'");
+        assert_eq!(
+            format_wtf8_repr(Wtf8Buf::from("\0\t\n\r ☃\u{e0020}").as_ref()),
+            "'\\x00\\t\\n\\r ☃\\U000e0020'"
+        );
+        let mut surrogate = Wtf8Buf::from("x");
+        surrogate.push(CodePoint::from_u32(0xd800).unwrap());
+        assert_eq!(format_wtf8_repr(&surrogate), "'x\\ud800'");
+    }
 
     /// Every expectation is `len(ntpath.splitdrive(p)[0].encode())` for the
     /// same input.

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -154,6 +154,18 @@ pub(crate) fn format_float_repr(val: f64) -> String {
     rustpython_literal::float::to_string(val)
 }
 
+/// RPython `rfloat.formatd` residual ABI for the generated JIT.
+///
+/// Upstream returns one low-level `STR` GC pointer. The host formatter returns
+/// a three-word Rust `String`, so the source translator retargets only that
+/// formatter call to this wrapper and keeps the bytes in the managed
+/// length-prefixed block used for translated RPython strings.
+#[majit_macros::dont_look_inside]
+pub fn jit_format_float_repr_rstr(val: f64) -> *mut pyre_object::bytesobject::BytesBlock {
+    let text = rustpython_literal::float::to_string(val);
+    pyre_object::bytesobject::alloc_bytes_block(text.as_bytes())
+}
+
 /// `unicodedb.isprintable` in PyPy's `rutf8.make_utf8_escape_function` is a
 /// pure generated-table lookup.  Keep the same scalar call boundary around
 /// pyre's Unicode database provider, including the upstream guarantee that a
@@ -2303,7 +2315,10 @@ impl fmt::Display for PyDisplay {
 
 #[cfg(test)]
 mod tests {
-    use super::{bytes_repr_string, format_wtf8_repr, nt_drive_len};
+    use super::{
+        bytes_repr_string, format_float_repr, format_wtf8_repr, jit_format_float_repr_rstr,
+        nt_drive_len,
+    };
     use rustpython_wtf8::{CodePoint, Wtf8Buf};
 
     #[test]
@@ -2329,6 +2344,15 @@ mod tests {
         let mut surrogate = Wtf8Buf::from("x");
         surrogate.push(CodePoint::from_u32(0xd800).unwrap());
         assert_eq!(format_wtf8_repr(&surrogate), "'x\\ud800'");
+    }
+
+    #[test]
+    fn float_repr_residual_returns_the_same_lowlevel_string_bytes() {
+        for value in [0.0, -0.0, 1.5, f64::INFINITY, f64::NEG_INFINITY, f64::NAN] {
+            let block = jit_format_float_repr_rstr(value);
+            let bytes = unsafe { pyre_object::bytesobject::bytes_block_chars(block) };
+            assert_eq!(bytes, format_float_repr(value).as_bytes());
+        }
     }
 
     /// Every expectation is `len(ntpath.splitdrive(p)[0].encode())` for the

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -192,7 +192,7 @@ pub(crate) fn format_wtf8_repr(s: &Wtf8) -> String {
     out.push(quote as char);
     let mut pos = 0;
     while pos < s.len() {
-        let code = pyre_object::rutf8::codepoint_at_pos(s, pos).to_u32();
+        let code = pyre_object::rutf8::codepoint_at_pos(s, pos) as u32;
         if code == quote as u32 || code == b'\\' as u32 {
             out.push('\\');
             out.push(code as u8 as char);
@@ -1807,10 +1807,18 @@ fn nt_drive_len(path: &[u8]) -> usize {
 fn basename_start(path: &[u8]) -> usize {
     let windows = cfg!(windows);
     let drive = if windows { nt_drive_len(path) } else { 0 };
-    path[drive..]
-        .iter()
-        .rposition(|&b| b == b'/' || (windows && b == b'\\'))
-        .map_or(drive, |i| drive + i + 1)
+    // `os.path.basename` bottoms out at the last separator search. Spell the
+    // same reverse index walk directly, as RPython's string `rfind` does,
+    // rather than introducing Rust's closure-bearing `Iter::rposition` graph.
+    let mut i = path.len();
+    while i > drive {
+        i -= 1;
+        let b = path[i];
+        if b == b'/' || (windows && b == b'\\') {
+            return i + 1;
+        }
+    }
+    drive
 }
 
 /// The WTF-8 carrying subset of `W_BaseException.descr_str`: a base
@@ -2316,8 +2324,8 @@ impl fmt::Display for PyDisplay {
 #[cfg(test)]
 mod tests {
     use super::{
-        bytes_repr_string, format_float_repr, format_wtf8_repr, jit_format_float_repr_rstr,
-        nt_drive_len,
+        basename_start, bytes_repr_string, format_float_repr, format_wtf8_repr,
+        jit_format_float_repr_rstr, nt_drive_len,
     };
     use rustpython_wtf8::{CodePoint, Wtf8Buf};
 
@@ -2396,5 +2404,15 @@ mod tests {
         assert_eq!(nt_drive_len(br"\dir\enc.py"), 0);
         assert_eq!(nt_drive_len(b"enc.py"), 0);
         assert_eq!(nt_drive_len(b""), 0);
+    }
+
+    #[test]
+    fn basename_start_matches_platform_separator_search() {
+        assert_eq!(basename_start(b"dir/enc.py"), 4);
+        assert_eq!(basename_start(b"enc.py"), 0);
+        assert_eq!(basename_start(b"dir/"), 4);
+        assert_eq!(basename_start(b""), 0);
+        #[cfg(not(windows))]
+        assert_eq!(basename_start(br"dir\enc.py"), 0);
     }
 }

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -422,8 +422,7 @@ pub unsafe fn dict_repr(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     // taken before a collection addresses the pre-move object.
     let _roots = pyre_object::gc_roots::push_roots();
     let mut flat: Vec<PyObjectRef> = Vec::with_capacity(entries.len() * 2);
-    for i in 0..entries.len() {
-        let (k, v) = entries[i];
+    for &(k, v) in entries.as_slice() {
         flat.push(k);
         flat.push(v);
     }
@@ -1172,11 +1171,13 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
                 }
             }
             let mut joined = Wtf8Buf::new();
-            for index in 0..parts.len() {
-                if index > 0 {
+            let mut first = true;
+            for part in parts.as_slice() {
+                if !first {
                     joined.push_str(" | ");
                 }
-                joined.push_wtf8(&parts[index]);
+                joined.push_wtf8(part);
+                first = false;
             }
             return Ok(joined);
         } else if std::ptr::eq(tp, &pyre_object::GENERIC_ALIAS_TYPE as *const PyType) {

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -1672,10 +1672,11 @@ impl ExecutionContext {
         // Enumerating a dict materialises key objects and can collect.  Keep
         // only owned key strings across that operation; raw values must be
         // looked up again after the module allocation.
-        let keys: Vec<String> = unsafe { pyre_object::w_dict_str_entries(self.builtins_module) }
-            .into_iter()
-            .map(|(key, _)| key)
-            .collect();
+        let entries = unsafe { pyre_object::w_dict_str_entries(self.builtins_module) };
+        let mut keys = Vec::with_capacity(entries.len());
+        for (key, _) in entries {
+            keys.push(key);
+        }
         let module = pyre_object::w_module_new_aliasing_dict("builtins", self.builtins_module);
         // function.py BuiltinFunction.w_moduleobj. The defining
         // module object does not exist while `new_builtin_module_dict` fills

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -364,7 +364,7 @@ pub fn maybe_register_user_finalizer(obj: PyObjectRef) {
 /// registers no finalizer here, so there is nothing for it to withhold.  `_io`
 /// wants the other guard and carries its own
 /// (`_io::maybe_unregister_rpython_finalizer_io`).
-// `rgc.py:743-750` puts `@jit.dont_look_inside` on this exact helper.  Its
+// `rgc.py`'s `may_ignore_finalizer` carries `@jit.dont_look_inside`.  Its
 // collector hook is runtime state, so the translated trace must retain one
 // residual call instead of reading the process-global hook while translating.
 #[majit_macros::dont_look_inside]

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -364,6 +364,10 @@ pub fn maybe_register_user_finalizer(obj: PyObjectRef) {
 /// registers no finalizer here, so there is nothing for it to withhold.  `_io`
 /// wants the other guard and carries its own
 /// (`_io::maybe_unregister_rpython_finalizer_io`).
+// `rgc.py:743-750` puts `@jit.dont_look_inside` on this exact helper.  Its
+// collector hook is runtime state, so the translated trace must retain one
+// residual call instead of reading the process-global hook while translating.
+#[majit_macros::dont_look_inside]
 pub fn may_ignore_finalizer(obj: PyObjectRef) {
     pyre_object::gc_hook::try_gc_ignore_finalizer(obj);
 }

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1387,13 +1387,13 @@ pub unsafe fn getcode(obj: PyObjectRef) -> PyObjectRef {
         let func = obj as *const Function;
         if majit_metainterp::jit::we_are_jitted() {
             if !(*func).can_change_code {
-                // function.py:80-81
+                // function.py `Function.getcode`: the immutable-code arm.
                 return _get_immutable_code(obj);
             }
-            // function.py:82
+            // function.py `Function.getcode`: `jit.promote(self.code)`.
             return majit_metainterp::jit::promote((*func).code as usize) as PyObjectRef;
         }
-        // function.py:83
+        // function.py `Function.getcode`: the untraced `return self.code`.
         (*func).code as PyObjectRef
     }
 }

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -984,13 +984,13 @@ pub unsafe fn _check_code_mutable(func: PyObjectRef, attr: &str) -> Result<(), c
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
-pub unsafe fn _get_immutable_code(func: PyObjectRef) -> *const () {
+pub unsafe fn _get_immutable_code(func: PyObjectRef) -> PyObjectRef {
     // function.py:25
     debug_assert!(
         !unsafe { (*(func as *const Function)).can_change_code },
         "_get_immutable_code called on function with can_change_code=true"
     );
-    unsafe { (*(func as *const Function)).code }
+    unsafe { (*(func as *const Function)).code as PyObjectRef }
 }
 
 /// Check if an object is a user-defined function.
@@ -1382,7 +1382,7 @@ pub unsafe fn is_function_with_fixed_code(obj: PyObjectRef) -> bool {
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
-pub unsafe fn getcode(obj: PyObjectRef) -> *const () {
+pub unsafe fn getcode(obj: PyObjectRef) -> PyObjectRef {
     unsafe {
         let func = obj as *const Function;
         if majit_metainterp::jit::we_are_jitted() {
@@ -1391,10 +1391,10 @@ pub unsafe fn getcode(obj: PyObjectRef) -> *const () {
                 return _get_immutable_code(obj);
             }
             // function.py:82
-            return majit_metainterp::jit::promote((*func).code as usize) as *const ();
+            return majit_metainterp::jit::promote((*func).code as usize) as PyObjectRef;
         }
         // function.py:83
-        (*func).code
+        (*func).code as PyObjectRef
     }
 }
 
@@ -2367,7 +2367,7 @@ pub unsafe fn fdel_func_kwdefaults(obj: PyObjectRef) -> Result<(), crate::PyErro
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
-pub unsafe fn function_get_func_code(obj: PyObjectRef) -> *const () {
+pub unsafe fn function_get_func_code(obj: PyObjectRef) -> PyObjectRef {
     unsafe { getcode(obj) }
 }
 
@@ -3660,7 +3660,7 @@ pub fn funccall(func: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRef {
 /// paired `direct_fn` returns the same `(type, value, traceback)` tuple as the
 /// regular closure but skips the builtin-call setup.
 type ExcInfoDirectFn = fn() -> PyObjectRef;
-static SYS_EXC_INFO_CODE: std::sync::atomic::AtomicPtr<()> =
+static SYS_EXC_INFO_CODE: std::sync::atomic::AtomicPtr<PyObject> =
     std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
 static SYS_EXC_INFO_DIRECT_FN: std::sync::OnceLock<ExcInfoDirectFn> = std::sync::OnceLock::new();
 
@@ -3670,8 +3670,8 @@ static SYS_EXC_INFO_DIRECT_FN: std::sync::OnceLock<ExcInfoDirectFn> = std::sync:
 /// `code` pointer is the BuiltinCode object underlying the `exc_info`
 /// builtin function; `direct_fn` is the JIT-direct equivalent of the
 /// closure body. `funccall_valuestack` consults both to take the fast path.
-pub fn register_sys_exc_info_path(code: *const (), direct_fn: ExcInfoDirectFn) {
-    SYS_EXC_INFO_CODE.store(code.cast_mut(), std::sync::atomic::Ordering::Release);
+pub fn register_sys_exc_info_path(code: PyObjectRef, direct_fn: ExcInfoDirectFn) {
+    SYS_EXC_INFO_CODE.store(code, std::sync::atomic::Ordering::Release);
     // Reinitializing the sys module may replace its BuiltinCode object, but
     // every instance is backed by the same `exc_info_direct` symbol. Preserve
     // the object-space-wide helper installed by the first initialization.
@@ -3679,7 +3679,7 @@ pub fn register_sys_exc_info_path(code: *const (), direct_fn: ExcInfoDirectFn) {
 }
 
 #[inline]
-fn sys_exc_info_code() -> *const () {
+fn sys_exc_info_code() -> PyObjectRef {
     SYS_EXC_INFO_CODE.load(std::sync::atomic::Ordering::Acquire)
 }
 
@@ -3881,7 +3881,7 @@ pub fn funccall_valuestack(
 /// without intermediate Vec allocation.
 fn _flat_pycall(
     func: PyObjectRef,
-    code: *const (),
+    code: PyObjectRef,
     nargs: usize,
     frame: &mut crate::pyframe::PyFrame,
     dropvalues: usize,
@@ -3901,7 +3901,7 @@ fn _flat_pycall(
     // frame - GC_HEADER_SIZE) rather than a bare interpreter-stack frame.
     let mut new_frame = crate::pyframe::FrameBox::new(
         match crate::pyframe::PyFrame::try_new_for_call_with_closure_and_globals_obj(
-            code,
+            code as *const (),
             &[], // locals filled below directly from stack
             w_globals,
             crate::call::getexecutioncontext(),
@@ -3965,7 +3965,7 @@ fn _flat_pycall(
 /// verified as a tuple by the caller in `funccall_valuestack`).
 fn _flat_pycall_defaults(
     func: PyObjectRef,
-    code: *const (),
+    code: PyObjectRef,
     nargs: usize,
     frame: &mut crate::pyframe::PyFrame,
     defs: PyObjectRef,
@@ -3980,7 +3980,7 @@ fn _flat_pycall_defaults(
     // FrameBox: header-bearing heap frame for the JIT write barrier.
     let mut new_frame = crate::pyframe::FrameBox::new(
         match crate::pyframe::PyFrame::try_new_for_call_with_closure_and_globals_obj(
-            code,
+            code as *const (),
             &[], // locals filled below
             w_globals,
             crate::call::getexecutioncontext(),

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -3459,6 +3459,14 @@ pub fn register_object_class_method(name: &'static str, function: PyObjectRef) {
 }
 
 /// The name `object` publishes `function` under, if it publishes it at all.
+///
+/// This process-global registry is the runtime metadata carrier for the
+/// documented CPython-3.14 METH_CLASS observable above.  It is not a
+/// trace-time constant: keep its mutex and moving-GC root table behind one
+/// residual lookup, just as PyPy keeps host/runtime metadata operations out of
+/// the object-space trace.  The returned static name remains ordinary data to
+/// the caller.
+#[majit_macros::dont_look_inside]
 fn object_class_method_name(function: PyObjectRef) -> Option<&'static str> {
     OBJECT_CLASS_METHODS
         .lock()

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -3095,12 +3095,12 @@ pub fn immutable_unique_id(obj: PyObjectRef) -> Option<PyObjectRef> {
                 ));
             }
             let base: i64 = if len == 1 {
-                let codepoint = pyre_object::unicodeobject::w_str_get_wtf8(obj)
-                    .code_points()
-                    .next()
-                    .expect("len==1 str has a code point")
-                    .to_u32();
-                !(codepoint as i64)
+                let cp = pyre_object::rutf8::codepoint_at_pos(
+                    pyre_object::unicodeobject::w_str_get_wtf8(obj),
+                    0,
+                );
+                // `(neg << IDTAG_SHIFT) | IDTAG_SPECIAL` == `+` (low 4 bits 0).
+                !cp
             } else {
                 257
             };

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -513,7 +513,7 @@ pub type BuiltinCodeFn = fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
 pub fn method_arity_failure(
     name: &str,
     expected: &str,
-    given: usize,
+    given: i64,
 ) -> Result<PyObjectRef, crate::PyError> {
     Err(crate::PyError::type_error(format!(
         "{name}() takes {expected} ({given} given)"
@@ -530,7 +530,7 @@ pub fn method_arity_failure(
 pub fn method_noarg_failure(
     args: &[PyObjectRef],
     name: &str,
-    receiver_slots: usize,
+    receiver_slots: i64,
 ) -> Result<PyObjectRef, crate::PyError> {
     if crate::builtins::has_builtin_kwargs(args) {
         Err(crate::PyError::type_error(format!(
@@ -540,7 +540,7 @@ pub fn method_noarg_failure(
         method_arity_failure(
             name,
             "no arguments",
-            args.len().saturating_sub(receiver_slots),
+            (args.len() as i64 - receiver_slots).max(0),
         )
     }
 }
@@ -553,8 +553,8 @@ pub fn method_noarg_failure(
 #[majit_macros::dont_look_inside]
 pub fn method_min_arity_failure(
     name: &str,
-    min: usize,
-    given: usize,
+    min: i64,
+    given: i64,
 ) -> Result<PyObjectRef, crate::PyError> {
     Err(crate::PyError::type_error(format!(
         "{name} expected at least {min} argument{}, got {given}",

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -2080,8 +2080,8 @@ pub fn fsencode(obj: pyre_object::PyObjectRef) -> Result<Vec<u8>, crate::PyError
             return Err(crate::typedef::unicode_encode_error(
                 "utf-8",
                 obj,
-                pos,
-                pos + 1,
+                pos as i64,
+                (pos + 1) as i64,
                 "surrogates not allowed",
             ));
         }

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -156,6 +156,7 @@ impl Signature {
     ///         pass
     ///     return -1
     /// ```
+    #[majit_macros::elidable]
     pub fn find_argname(&self, name: &str) -> isize {
         for (i, arg) in self.argnames.iter().enumerate() {
             if *arg == name {
@@ -179,6 +180,7 @@ impl Signature {
     /// raw `&str`; pyre delegates to `find_argname` after unwrapping the
     /// PyObject via `w_str_get_value`.  Non-string `w_name` returns `-1`
     /// (matches PyPy's RPython unwrap-or-fail semantics for strings).
+    #[majit_macros::elidable]
     pub fn find_w_argname(&self, w_name: PyObjectRef) -> isize {
         if w_name.is_null() {
             return -1;

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -5231,15 +5231,17 @@ fn handle_fromlist_fast(
     };
     let import_slot = shadow_stack_len();
     let _ = pin_root(w_import);
-    crate::call::call_function_impl_result(
+    match crate::call::call_function_impl_result(
         shadow_stack_get(handle_slot),
         &[
             shadow_stack_get(mod_slot),
             shadow_stack_get(fromlist_slot),
             shadow_stack_get(import_slot),
         ],
-    )
-    .map(Some)
+    ) {
+        Ok(w_result) => Ok(Some(w_result)),
+        Err(err) => Err(err),
+    }
 }
 
 /// `builtins.__import__` — `interp___import__`: a fast path answering

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -4688,7 +4688,7 @@ mod tests {
         assert_eq!(bindings["pyre_object::safepoint"], safepoint);
     }
 
-    /// `rgc.py:743-750` keeps `may_ignore_finalizer` opaque.  Both names the
+    /// `rgc.py` keeps `may_ignore_finalizer` opaque with `@jit.dont_look_inside`.  Both names the
     /// LLBC call-path resolver can produce must therefore bind the live helper
     /// address or the residual call would carry an unpatchable symbolic hash.
     #[test]

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1806,6 +1806,16 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::call::eval_current_frame_raw",
         crate::call::eval_current_frame_raw,
     );
+    p1(
+        &mut entries,
+        "pyre_interpreter::display::jit_format_float_repr_rstr",
+        crate::display::jit_format_float_repr_rstr,
+    );
+    p1(
+        &mut entries,
+        "pyre_interpreter::typedef::jit_format_complex_component_repr_rstr",
+        crate::typedef::jit_format_complex_component_repr_rstr,
+    );
     p0(
         &mut entries,
         "pyre_interpreter::call::py_recursion_depth",

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -2193,16 +2193,6 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::jit_bigint_hash",
         pyre_object::jit_bigint_hash,
     );
-    cp1(
-        &mut entries,
-        "pyre_interpreter::objspace::descroperation::jit_bigint_bit_length",
-        crate::objspace::descroperation::jit_bigint_bit_length,
-    );
-    cp1(
-        &mut entries,
-        "pyre_interpreter::objspace::descroperation::jit_bigint_bit_count",
-        crate::objspace::descroperation::jit_bigint_bit_count,
-    );
     pa1(
         &mut entries,
         "pyre_object::longobject::jit_bigint_to_i64_value",

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1781,6 +1781,15 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::try_gc_collect_oldgen",
         pyre_object::gc_hook::try_gc_collect_oldgen,
     );
+    // `rgc.may_ignore_finalizer` is itself `@jit.dont_look_inside`; publish
+    // the matching interpreter helper so its opaque graph becomes a real
+    // residual call rather than a symbolic placeholder.
+    pa1(
+        &mut entries,
+        "pyre_interpreter::executioncontext::may_ignore_finalizer",
+        "pyre_interpreter::may_ignore_finalizer",
+        crate::executioncontext::may_ignore_finalizer,
+    );
     pa0(
         &mut entries,
         "pyre_object::object_array::itemsblock_gc_enabled",
@@ -4589,6 +4598,21 @@ mod tests {
         let safepoint = pyre_object::gc_interp::safepoint as *const () as usize as i64;
         assert_eq!(bindings["pyre_object::gc_interp::safepoint"], safepoint);
         assert_eq!(bindings["pyre_object::safepoint"], safepoint);
+    }
+
+    /// `rgc.py:743-750` keeps `may_ignore_finalizer` opaque.  Both names the
+    /// LLBC call-path resolver can produce must therefore bind the live helper
+    /// address or the residual call would carry an unpatchable symbolic hash.
+    #[test]
+    fn jit_trace_fnaddrs_covers_may_ignore_finalizer() {
+        let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
+        let expected = crate::executioncontext::may_ignore_finalizer as *const () as usize as i64;
+
+        assert_eq!(
+            bindings["pyre_interpreter::executioncontext::may_ignore_finalizer"],
+            expected
+        );
+        assert_eq!(bindings["pyre_interpreter::may_ignore_finalizer"], expected);
     }
 
     /// `is_pyframe_operand_stack_accessor` must recognise the funcptr the

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1801,6 +1801,11 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::call::bump_frame_entry_count",
         crate::call::bump_frame_entry_count,
     );
+    p1(
+        &mut entries,
+        "pyre_interpreter::call::eval_current_frame_raw",
+        crate::call::eval_current_frame_raw,
+    );
     p0(
         &mut entries,
         "pyre_interpreter::call::py_recursion_depth",

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -3895,6 +3895,10 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
             &crate::function::SLOT_WRAPPER_TYPE as *const _ as i64,
         ),
         (
+            "function::METHOD_WRAPPER_TYPE",
+            &crate::function::METHOD_WRAPPER_TYPE as *const _ as i64,
+        ),
+        (
             "function::METHOD_DESCRIPTOR_TYPE",
             &crate::function::METHOD_DESCRIPTOR_TYPE as *const _ as i64,
         ),
@@ -3998,13 +4002,55 @@ pub fn jit_static_ref_addrs() -> Vec<(&'static str, i64)> {
             "dictmultiobject::INT_DICT_STRATEGY",
             dictmultiobject::INT_DICT_STRATEGY
         ),
+        // A translated `W_DictObject.dstrategy` holds the address of the
+        // non-zero-sized holder, not the zero-sized strategy implementation.
+        // These are the concrete prebuilt instances corresponding to PyPy's
+        // `space.fromcache(StrategyClass)` results and are therefore GCREF
+        // constants in the translated graph, exactly like the implementation
+        // rows above but with the identity the live dict slot actually reads.
+        ref_addr!(
+            "dictmultiobject::OBJECT_DICT_STRATEGY_REF",
+            dictmultiobject::OBJECT_DICT_STRATEGY_REF
+        ),
+        ref_addr!(
+            "dictmultiobject::EMPTY_DICT_STRATEGY_REF",
+            dictmultiobject::EMPTY_DICT_STRATEGY_REF
+        ),
+        ref_addr!(
+            "dictmultiobject::EMPTY_KWARGS_DICT_STRATEGY_REF",
+            dictmultiobject::EMPTY_KWARGS_DICT_STRATEGY_REF
+        ),
+        ref_addr!(
+            "dictmultiobject::BYTES_DICT_STRATEGY_REF",
+            dictmultiobject::BYTES_DICT_STRATEGY_REF
+        ),
+        ref_addr!(
+            "dictmultiobject::UNICODE_DICT_STRATEGY_REF",
+            dictmultiobject::UNICODE_DICT_STRATEGY_REF
+        ),
+        ref_addr!(
+            "dictmultiobject::INT_DICT_STRATEGY_REF",
+            dictmultiobject::INT_DICT_STRATEGY_REF
+        ),
         ref_addr!(
             "identitydict::IDENTITY_DICT_STRATEGY",
             identitydict::IDENTITY_DICT_STRATEGY
         ),
         ref_addr!(
+            "identitydict::IDENTITY_DICT_STRATEGY_REF",
+            identitydict::IDENTITY_DICT_STRATEGY_REF
+        ),
+        ref_addr!(
             "kwargsdict::KWARGS_DICT_STRATEGY",
             kwargsdict::KWARGS_DICT_STRATEGY
+        ),
+        ref_addr!(
+            "kwargsdict::KWARGS_DICT_STRATEGY_REF",
+            kwargsdict::KWARGS_DICT_STRATEGY_REF
+        ),
+        (
+            "objspace::std::mapdict::MAP_DICT_STRATEGY_REF",
+            &crate::objspace::std::mapdict::MAP_DICT_STRATEGY_REF as *const _ as i64,
         ),
         // Prebuilt object singletons (`None` / `NotImplemented` /
         // `Ellipsis` / `True` / `False`).  The accessors `w_none`,
@@ -4112,7 +4158,8 @@ pub fn jit_static_int_values() -> Vec<(&'static str, i64)> {
 mod tests {
     use super::{
         is_list_write_barrier, is_pyframe_operand_stack_accessor,
-        is_rerunnable_bookkeeping_residual, jit_static_pytype_addrs, jit_trace_fnaddrs,
+        is_rerunnable_bookkeeping_residual, jit_static_pytype_addrs, jit_static_ref_addrs,
+        jit_trace_fnaddrs,
     };
     use std::collections::HashMap;
 
@@ -4290,6 +4337,32 @@ mod tests {
         assert_eq!(
             bindings["function::METHOD_DESCRIPTOR_TYPE"],
             &crate::function::METHOD_DESCRIPTOR_TYPE as *const _ as i64
+        );
+        assert_eq!(
+            bindings["function::METHOD_WRAPPER_TYPE"],
+            &crate::function::METHOD_WRAPPER_TYPE as *const _ as i64
+        );
+    }
+
+    #[test]
+    fn jit_static_ref_addrs_covers_live_dict_strategy_holders() {
+        let bindings: HashMap<&'static str, i64> = jit_static_ref_addrs().into_iter().collect();
+
+        assert_eq!(
+            bindings["dictmultiobject::OBJECT_DICT_STRATEGY_REF"],
+            &pyre_object::dictmultiobject::OBJECT_DICT_STRATEGY_REF as *const _ as i64
+        );
+        assert_eq!(
+            bindings["identitydict::IDENTITY_DICT_STRATEGY_REF"],
+            &pyre_object::identitydict::IDENTITY_DICT_STRATEGY_REF as *const _ as i64
+        );
+        assert_eq!(
+            bindings["kwargsdict::KWARGS_DICT_STRATEGY_REF"],
+            &pyre_object::kwargsdict::KWARGS_DICT_STRATEGY_REF as *const _ as i64
+        );
+        assert_eq!(
+            bindings["objspace::std::mapdict::MAP_DICT_STRATEGY_REF"],
+            &crate::objspace::std::mapdict::MAP_DICT_STRATEGY_REF as *const _ as i64
         );
     }
 

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -3852,8 +3852,8 @@ fn utf8_only(value: PyObjectRef) -> AstResult<&'static str> {
     Err(crate::typedef::unicode_encode_error(
         "utf-8",
         value,
-        position,
-        position + 1,
+        position as i64,
+        (position + 1) as i64,
         "surrogates not allowed",
     ))
 }

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -1194,8 +1194,8 @@ fn charmap_encode_impl(
                 return Err(crate::typedef::unicode_encode_error(
                     "charmap",
                     pyre_object::gc_roots::shadow_stack_get(sp),
-                    start,
-                    end,
+                    start as i64,
+                    end as i64,
                     "character maps to <undefined>",
                 ));
             }
@@ -1227,8 +1227,8 @@ fn charmap_encode_impl(
                                 return Err(crate::typedef::unicode_encode_error(
                                     "charmap",
                                     pyre_object::gc_roots::shadow_stack_get(sp),
-                                    start,
-                                    end,
+                                    start as i64,
+                                    end as i64,
                                     "character maps to <undefined>",
                                 ));
                             }

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -265,6 +265,12 @@ fn modified(self_obj: PyObjectRef) {
 }
 
 /// `interp_deque.py getlock`: lazily install and return one identity token.
+///
+/// This STORES into `self.lock` on the first call, exactly as upstream's
+/// `self.lock = Lock()` does, so every method that reaches it owns the deque
+/// mutably — `_find_or_count`, `index`, `iter` and `compare` all call
+/// `self.getlock()` upstream.  A `&self` receiver here would let rustc mark
+/// the parameter `noalias readonly` and then store through it.
 fn getlock(self_obj: PyObjectRef) -> PyObjectRef {
     let _roots = pyre_object::gc_roots::push_roots();
     let self_obj = pyre_object::gc_roots::pin_root(self_obj);
@@ -282,8 +288,8 @@ fn getlock(self_obj: PyObjectRef) -> PyObjectRef {
     token
 }
 
-/// `interp_deque.py checklock` — raise `RuntimeError` if the deque
-/// was mutated since `lock` was taken.
+/// `lock is not self.lock` — the identity test inside `interp_deque.py`'s
+/// `checklock`, split out so the raise can stay in the caller.
 // Keep the native interpreter's post-callback read out of the caller's alias
 // scope.  This is not a JIT opacity hint: source translation still sees the
 // ordinary field read below, exactly like PyPy's `lock is self.lock`.
@@ -297,6 +303,8 @@ fn lock_valid(self_obj: PyObjectRef, lock: PyObjectRef) -> bool {
     current == lock
 }
 
+/// `interp_deque.py checklock` — raise `RuntimeError` if the deque was
+/// mutated since `lock` was taken.
 fn checklock(self_obj: PyObjectRef, lock: PyObjectRef) -> Result<(), crate::PyError> {
     if !lock_valid(self_obj, lock) {
         return Err(crate::PyError::runtime_error(
@@ -1023,8 +1031,8 @@ impl W_Deque {
         // the reverse of `iterable`.
         extend_from_iterable(self_obj, iterable, false)
     }
-    fn count(&self, x: PyObjectRef) -> Result<i64, crate::PyError> {
-        let self_obj = self as *const W_Deque as PyObjectRef;
+    fn count(&mut self, x: PyObjectRef) -> Result<i64, crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
         let lock = getlock(self_obj);
         let mut n = 0i64;
         for it in snapshot(self_obj) {
@@ -1080,8 +1088,8 @@ impl W_Deque {
             )),
         }
     }
-    fn __contains__(&self, x: PyObjectRef) -> Result<bool, crate::PyError> {
-        let self_obj = self as *const W_Deque as PyObjectRef;
+    fn __contains__(&mut self, x: PyObjectRef) -> Result<bool, crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
         let lock = getlock(self_obj);
         for it in snapshot(self_obj) {
             let equal = crate::baseobjspace::eq_w(it, x)?;
@@ -1161,12 +1169,12 @@ impl W_Deque {
         Ok(())
     }
     fn index(
-        &self,
+        &mut self,
         x: PyObjectRef,
         start: Option<PyObjectRef>,
         stop: Option<PyObjectRef>,
     ) -> Result<i64, crate::PyError> {
-        let self_obj = self as *const W_Deque as PyObjectRef;
+        let self_obj = self as *mut W_Deque as PyObjectRef;
         let items = snapshot(self_obj);
         let len = items.len() as i64;
         // `space.iter(self)` takes the lock before `unwrap_start_stop`,
@@ -1250,12 +1258,12 @@ impl W_Deque {
         let self_obj = self as *const W_Deque as PyObjectRef;
         deque_len(self_obj)
     }
-    fn __iter__(&self) -> Result<PyObjectRef, crate::PyError> {
-        let self_obj = self as *const W_Deque as PyObjectRef;
+    fn __iter__(&mut self) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
         Ok(deque_iter::make(self_obj, 0))
     }
-    fn __reversed__(&self) -> PyObjectRef {
-        let self_obj = self as *const W_Deque as PyObjectRef;
+    fn __reversed__(&mut self) -> PyObjectRef {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
         deque_rev_iter::make(self_obj, 0)
     }
     fn __getitem__(&self, index: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
@@ -1298,28 +1306,28 @@ impl W_Deque {
         store(self_obj, items);
         Ok(())
     }
-    fn __eq__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-        let self_obj = self as *const W_Deque as PyObjectRef;
+    fn __eq__(&mut self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
         deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Eq)
     }
-    fn __ne__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-        let self_obj = self as *const W_Deque as PyObjectRef;
+    fn __ne__(&mut self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
         deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Ne)
     }
-    fn __lt__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-        let self_obj = self as *const W_Deque as PyObjectRef;
+    fn __lt__(&mut self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
         deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Lt)
     }
-    fn __le__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-        let self_obj = self as *const W_Deque as PyObjectRef;
+    fn __le__(&mut self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
         deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Le)
     }
-    fn __gt__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-        let self_obj = self as *const W_Deque as PyObjectRef;
+    fn __gt__(&mut self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
         deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Gt)
     }
-    fn __ge__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-        let self_obj = self as *const W_Deque as PyObjectRef;
+    fn __ge__(&mut self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = self as *mut W_Deque as PyObjectRef;
         deque_compare(self_obj, other, crate::baseobjspace::CompareOp::Ge)
     }
     fn __add__(&self, other: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -147,22 +147,19 @@ pub(crate) fn is_deque(obj: PyObjectRef) -> bool {
 
 /// Read one app-level `__slots__` entry from a deque subclass.
 pub(crate) unsafe fn deque_slot_get(obj: PyObjectRef, index: usize) -> Option<PyObjectRef> {
-    unsafe { pyre_object::slots::slot_get(obj, index, deque_slots_field) }
+    let slots = unsafe { (*(obj as *const W_Deque)).w_slots };
+    unsafe { pyre_object::slots::slot_get(slots, index) }
 }
 
 /// Write one app-level `__slots__` entry on a deque subclass.
 pub(crate) unsafe fn deque_slot_set(obj: PyObjectRef, index: usize, value: PyObjectRef) {
-    unsafe { pyre_object::slots::slot_set(obj, index, value, deque_slots_field) }
+    pyre_object::slot_set_direct!(obj, index, value, W_Deque, w_slots)
 }
 
 /// Clear one app-level `__slots__` entry on a deque subclass.
 pub(crate) unsafe fn deque_slot_del(obj: PyObjectRef, index: usize) -> bool {
-    unsafe { pyre_object::slots::slot_del(obj, index, deque_slots_field) }
-}
-
-/// Address of `W_Deque::w_slots` for the shared native-subclass slot helpers.
-unsafe fn deque_slots_field(obj: PyObjectRef) -> *mut PyObjectRef {
-    unsafe { &mut (*(obj as *mut W_Deque)).w_slots }
+    let slots = unsafe { (*(obj as *const W_Deque)).w_slots };
+    unsafe { pyre_object::slots::slot_del(slots, index) }
 }
 
 /// Snapshot the backing list into a `Vec`.

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -48,6 +48,26 @@ pub mod deque_block {
 
 use deque_block::W_DequeBlock;
 
+/// `interp_deque.py Lock`: a fieldless GC object used only as an identity
+/// token.  It is deliberately an object, not a counter — `W_Deque.lock` and
+/// each iterator hold the same token until a mutation replaces the deque field
+/// with `None`, exactly like PyPy.
+pub mod deque_lock {
+    use pyre_object::*;
+
+    #[crate::pyre_class("_collections._deque_lock")]
+    pub struct W_DequeLock {}
+
+    pub fn new() -> PyObjectRef {
+        W_DequeLock::allocate_stable(W_DequeLock {
+            ob: PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
+            },
+        })
+    }
+}
+
 /// `pypy/module/_collections/interp_deque.py` — `W_Deque` surface
 /// (append / appendleft / pop / popleft / clear / extend / extendleft /
 /// rotate / count / remove / reverse / index / copy + container and repr
@@ -63,8 +83,9 @@ pub struct W_Deque {
     len: i64,
     /// Bound: `-1` = unbounded, `>= 0` = the maxlen. Validated non-negative at `__init__`.
     maxlen: i64,
-    /// Lightweight iteration-lock counter (`interp_deque.py` `state`); bumped on every mutation.
-    state: i64,
+    /// `interp_deque.py W_Deque.lock`: `None` until observed, then a unique
+    /// fieldless `Lock` identity; every mutation stores `None` again.
+    lock: PyObjectRef,
     /// PyPy `BaseUserClassMapdict` indexed storage for a deque subclass's
     /// app-level `__slots__`.  The translated user layout owns these values;
     /// pyre's fixed native payload keeps the equivalent object-resident list.
@@ -234,47 +255,50 @@ fn clear_blocks(self_obj: PyObjectRef) {
     modified(self_obj);
 }
 
-/// `interp_deque.py modified` — lightweight iteration lock.  Any
-/// mutation invalidates the outstanding lock so an in-progress
-/// `count` / `index` / `remove` / `__contains__` / comparison detects
-/// it.  PyPy invalidates a `Lock` object identity; pyre realizes the
-/// same as a monotonic `state` counter: every mutation bumps it, and
-/// `checklock` raises when the snapshot no longer matches.
-fn lock_state(self_obj: PyObjectRef) -> i64 {
-    // Volatile read: a `checklock` re-read must observe a `state` bump made
-    // by a re-entrant mutation from an intervening user callback (`eq_w`).
-    // A plain field read is cached across that callback because the payload
-    // escaped and is mutated through a non-receiver pointer, which the
-    // `&self`/`&mut self` receiver's aliasing guarantee forbids the compiler
-    // from expecting.
-    let base = self_obj as *const W_Deque;
-    if base.is_null() {
-        return 0;
-    }
-    unsafe { std::ptr::read_volatile(std::ptr::addr_of!((*base).state)) }
-}
-
+/// `interp_deque.py modified`: invalidate the current identity token.
 fn modified(self_obj: PyObjectRef) {
-    // Volatile bump paired with `lock_state`'s volatile read (see there).
     let base = self_obj as *mut W_Deque;
     if base.is_null() {
         return;
     }
-    unsafe {
-        let p = std::ptr::addr_of_mut!((*base).state);
-        std::ptr::write_volatile(p, std::ptr::read_volatile(p).wrapping_add(1));
-    }
+    unsafe { (*base).lock = PY_NULL };
 }
 
-/// `interp_deque.py getlock` — snapshot the current lock token.
-fn getlock(self_obj: PyObjectRef) -> i64 {
-    lock_state(self_obj)
+/// `interp_deque.py getlock`: lazily install and return one identity token.
+fn getlock(self_obj: PyObjectRef) -> PyObjectRef {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let self_obj = pyre_object::gc_roots::pin_root(self_obj);
+    let _deque_guard = unsafe { w_deque_lock(self_obj) };
+    let base = self_obj as *mut W_Deque;
+    if base.is_null() {
+        return PY_NULL;
+    }
+    let current = unsafe { (*base).lock };
+    if !current.is_null() {
+        return current;
+    }
+    let token = deque_lock::new();
+    unsafe { (*base).lock = token };
+    token
 }
 
 /// `interp_deque.py checklock` — raise `RuntimeError` if the deque
 /// was mutated since `lock` was taken.
-fn checklock(self_obj: PyObjectRef, lock: i64) -> Result<(), crate::PyError> {
-    if lock_state(self_obj) != lock {
+// Keep the native interpreter's post-callback read out of the caller's alias
+// scope.  This is not a JIT opacity hint: source translation still sees the
+// ordinary field read below, exactly like PyPy's `lock is self.lock`.
+#[inline(never)]
+fn lock_valid(self_obj: PyObjectRef, lock: PyObjectRef) -> bool {
+    let current = if self_obj.is_null() {
+        PY_NULL
+    } else {
+        unsafe { (*(self_obj as *const W_Deque)).lock }
+    };
+    current == lock
+}
+
+fn checklock(self_obj: PyObjectRef, lock: PyObjectRef) -> Result<(), crate::PyError> {
+    if !lock_valid(self_obj, lock) {
         return Err(crate::PyError::runtime_error(
             "deque mutated during iteration",
         ));
@@ -316,7 +340,7 @@ pub mod deque_iter {
         block: PyObjectRef,
         index: i64,
         counter: i64,
-        lock: i64,
+        lock: PyObjectRef,
     }
 
     fn constructor_args(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
@@ -391,20 +415,20 @@ pub mod deque_iter {
 
     pub fn make(deque: PyObjectRef, requested: i64) -> PyObjectRef {
         let _ = type_object();
-        let (len, mut block_obj, mut index) = W_Deque::from_obj(deque)
-            .map(|deque| (deque.len, deque.leftblock, deque.leftindex))
-            .unwrap_or((0, PY_NULL, 0));
-        let requested_index = requested.max(0);
-        let mut remaining = requested_index;
-        while remaining > 0 && remaining < len {
-            let available = BLOCKLEN - index;
-            if remaining < available {
-                index += remaining;
-                remaining = 0;
-            } else {
-                remaining -= available;
-                block_obj = block(block_obj).rightlink;
-                index = 0;
+        // `W_DequeIter.__init__` receives an already-checked W_Deque and reads
+        // these attributes directly; do not manufacture an Option/tuple
+        // side-shape that has no counterpart in the RPython graph.
+        let deque_ref = unsafe { &*(deque as *const W_Deque) };
+        let len = deque_ref.len;
+        let mut block_obj = deque_ref.leftblock;
+        let mut index = deque_ref.leftindex;
+        let mut counter = len;
+        // `W_DequeIter._move_to`: a negative pickle index leaves the freshly
+        // initialized iterator alone; a live position is located in one step.
+        if requested >= 0 {
+            counter = len - requested;
+            if counter > 0 {
+                (block_obj, index) = super::locate(deque, requested);
             }
         }
         let _roots = pyre_object::gc_roots::push_roots();
@@ -417,7 +441,7 @@ pub mod deque_iter {
             deque,
             block: block_obj,
             index,
-            counter: len - requested_index,
+            counter,
             lock: getlock(deque),
         })
     }
@@ -444,7 +468,7 @@ pub mod deque_rev_iter {
         block: PyObjectRef,
         index: i64,
         counter: i64,
-        lock: i64,
+        lock: PyObjectRef,
     }
 
     #[crate::pyre_methods]
@@ -511,20 +535,18 @@ pub mod deque_rev_iter {
 
     pub fn make(deque: PyObjectRef, requested: i64) -> PyObjectRef {
         let _ = type_object();
-        let (len, mut block_obj, mut index) = W_Deque::from_obj(deque)
-            .map(|deque| (deque.len, deque.rightblock, deque.rightindex))
-            .unwrap_or((0, PY_NULL, 0));
-        let offset = requested.max(0);
-        let mut remaining = offset;
-        while remaining > 0 && remaining < len {
-            let available = index + 1;
-            if remaining < available {
-                index -= remaining;
-                remaining = 0;
-            } else {
-                remaining -= available;
-                block_obj = block(block_obj).leftlink;
-                index = BLOCKLEN - 1;
+        // PyPy's reverse iterator likewise reads its checked deque directly.
+        let deque_ref = unsafe { &*(deque as *const W_Deque) };
+        let len = deque_ref.len;
+        let mut block_obj = deque_ref.rightblock;
+        let mut index = deque_ref.rightindex;
+        let mut counter = len;
+        // `W_DequeRevIter._move_to` locates from the left using the remaining
+        // length, rather than maintaining a second reverse block walk.
+        if requested >= 0 {
+            counter = len - requested;
+            if counter > 0 {
+                (block_obj, index) = super::locate(deque, counter - 1);
             }
         }
         let _roots = pyre_object::gc_roots::push_roots();
@@ -537,7 +559,7 @@ pub mod deque_rev_iter {
             deque,
             block: block_obj,
             index,
-            counter: len - offset,
+            counter,
             lock: getlock(deque),
         })
     }
@@ -919,7 +941,7 @@ impl W_Deque {
             rightindex: CENTER,
             len: 0,
             maxlen: -1,
-            state: 0,
+            lock: PY_NULL,
             w_slots: PY_NULL,
         })
     }
@@ -960,7 +982,7 @@ impl W_Deque {
         // Reinitialize by clearing, but only when non-empty (`init`:
         // `if self.len > 0: self.clear()`). `store` bumps the iteration lock
         // (`modified`) so an outstanding scan of an existing deque detects the
-        // reset; an already-empty deque leaves `state` untouched, so re-init
+        // reset; an already-empty deque leaves `lock` untouched, so re-init
         // while iterating an empty deque yields StopIteration, not a mutation
         // RuntimeError.
         if deque_len(self_obj) > 0 {
@@ -1025,7 +1047,7 @@ impl W_Deque {
             // IndexError (PyPy's older block-list port reports RuntimeError).
             // The comparison may have cleared or otherwise resized the live
             // deque, so do not continue against the stale snapshot.
-            if lock_state(self_obj) != lock {
+            if !lock_valid(self_obj, lock) {
                 return Err(crate::PyError::index_error(
                     "deque mutated during iteration",
                 ));
@@ -1044,7 +1066,7 @@ impl W_Deque {
                 // so a mutation that landed after the last comparison is
                 // reported rather than silently overwritten by the snapshot.
                 let _deque_guard = unsafe { w_deque_lock(self_obj) };
-                if lock_state(self_obj) != lock {
+                if !lock_valid(self_obj, lock) {
                     return Err(crate::PyError::index_error(
                         "deque mutated during iteration",
                     ));

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -563,7 +563,7 @@ pub mod deque_rev_iter {
 fn extend_from_iterable(
     self_obj: PyObjectRef,
     iterable: PyObjectRef,
-    append: fn(PyObjectRef, PyObjectRef),
+    is_extend_right: bool,
 ) -> Result<(), crate::PyError> {
     let items = crate::builtins::collect_iterable(iterable)?;
     let _roots = pyre_object::gc_roots::push_roots();
@@ -571,10 +571,17 @@ fn extend_from_iterable(
     let _ = pyre_object::gc_roots::pin_root(self_obj);
     let item_base = pyre_object::gc_roots::pin_roots(&items);
     for index in 0..items.len() {
-        append(
-            pyre_object::gc_roots::shadow_stack_get(deque_slot),
-            pyre_object::gc_roots::shadow_stack_get(item_base + index),
-        );
+        let deque = pyre_object::gc_roots::shadow_stack_get(deque_slot);
+        let item = pyre_object::gc_roots::shadow_stack_get(item_base + index);
+        // interp_deque.py:_extend keeps `is_extend_right` as the green
+        // direction and performs the direct append/appendleft dispatch in
+        // the loop.  Preserve that shape instead of passing a Rust function
+        // pointer, which invents an indirect call that RPython never has.
+        if is_extend_right {
+            append_right(deque, item);
+        } else {
+            append_left(deque, item);
+        }
     }
     Ok(())
 }
@@ -963,7 +970,7 @@ impl W_Deque {
             clear_blocks(self_obj);
         }
         if let Some(it) = iterable {
-            extend_from_iterable(self_obj, it, append_right)?;
+            extend_from_iterable(self_obj, it, true)?;
         }
         Ok(())
     }
@@ -989,13 +996,13 @@ impl W_Deque {
     }
     fn extend(&mut self, iterable: PyObjectRef) -> Result<(), crate::PyError> {
         let self_obj = self as *mut W_Deque as PyObjectRef;
-        extend_from_iterable(self_obj, iterable, append_right)
+        extend_from_iterable(self_obj, iterable, true)
     }
     fn extendleft(&mut self, iterable: PyObjectRef) -> Result<(), crate::PyError> {
         let self_obj = self as *mut W_Deque as PyObjectRef;
         // Each element is appended on the left, so the result is
         // the reverse of `iterable`.
-        extend_from_iterable(self_obj, iterable, append_left)
+        extend_from_iterable(self_obj, iterable, false)
     }
     fn count(&self, x: PyObjectRef) -> Result<i64, crate::PyError> {
         let self_obj = self as *const W_Deque as PyObjectRef;

--- a/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
@@ -375,8 +375,8 @@ fn check_digest_name(name_obj: PyObjectRef) -> Result<(), crate::PyError> {
         return Err(crate::typedef::unicode_encode_error(
             "utf-8",
             name_obj,
-            pos,
-            pos + 1,
+            pos as i64,
+            (pos + 1) as i64,
             "surrogates not allowed",
         ));
     }

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -444,9 +444,15 @@ impl W_TextIOWrapper {
             if !pyre_object::is_str(newline) {
                 return Err(crate::PyError::type_error("illegal newline type"));
             }
-            let value = pyre_object::w_str_get_wtf8(newline)
-                .as_str()
-                .map_err(|_| crate::PyError::value_error("illegal newline value"))?;
+            // `interp_textio.py unwrap_newline` performs a direct
+            // `space.utf8_w` conversion followed by the value branch.  Spell
+            // the fallible host conversion as the same direct branch instead
+            // of introducing Rust's generic `Result::map_err` closure into
+            // the translated graph.
+            let value = match pyre_object::w_str_get_wtf8(newline).as_str() {
+                Ok(value) => value,
+                Err(_) => return Err(crate::PyError::value_error("illegal newline value")),
+            };
             if !matches!(value, "" | "\n" | "\r" | "\r\n") {
                 return Err(crate::PyError::value_error(format!(
                     "illegal newline value: {value}"

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -454,6 +454,10 @@ impl W_TextIOWrapper {
                 Err(_) => return Err(crate::PyError::value_error("illegal newline value")),
             };
             if !matches!(value, "" | "\n" | "\r" | "\r\n") {
+                // Unquoted on purpose. `interp_textio.py`'s `unwrap_newline`
+                // raises with `%R`, but CPython 3.14 prints the value bare
+                // (`illegal newline value: x`), and the observable text is
+                // CPython's. Do not "restore" the repr quoting.
                 return Err(crate::PyError::value_error(format!(
                     "illegal newline value: {value}"
                 )));

--- a/pyre/pyre-interpreter/src/module/_multibytecodec/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multibytecodec/mod.rs
@@ -331,8 +331,8 @@ fn encode_impl(
                 return Err(crate::typedef::unicode_encode_error(
                     name,
                     roots.get(input_slot),
-                    start,
-                    end,
+                    start as i64,
+                    end as i64,
                     reason,
                 ));
             }

--- a/pyre/pyre-interpreter/src/module/_pickle/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/mod.rs
@@ -621,7 +621,7 @@ pub(crate) fn str_from_utf8(data: &[u8]) -> Result<PyObjectRef, PyError> {
     // which admits sequences that hold no code point at all, and it is
     // reported at the position that validator stopped at.
     let s = pyre_object::rutf8::wtf8_from_bytes(data, true)
-        .map_err(|error| crate::typedef::utf8_decode_error_from(data, error.pos))?;
+        .map_err(|error| crate::typedef::utf8_decode_error_from(data, error.pos as usize))?;
     Ok(pyre_object::unicodeobject::w_str_from_wtf8_managed(
         s.to_owned(),
     ))

--- a/pyre/pyre-interpreter/src/module/_queue/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_queue/mod.rs
@@ -27,6 +27,14 @@ const _: () = assert!(
     "W_SimpleQueue must keep W_ObjectObject's storage offset"
 );
 
+/// Only the native acquire is opaque to the tracer; queue operations performed
+/// while the guard is held stay look-inside.  This is the same split as
+/// `pyre_object::listobject::w_list_lock` and PyPy's `rthread.Lock`: the
+/// wrapper remains RPython while `c_thread_acquirelock{,_timed}` is an
+/// `llexternal` (`rpython/rlib/rthread.py:60-90,160-200`).  Rust's
+/// `Result<Guard, PoisonError<Guard>>` is consequently an implementation ABI
+/// inside the residual native-lock leaf, not a trace-visible value shape.
+#[majit_macros::dont_look_inside]
 fn queue_lock<'a>(
     mutex: &'a Mutex<VecDeque<PyObjectRef>>,
 ) -> MutexGuard<'a, VecDeque<PyObjectRef>> {
@@ -109,20 +117,22 @@ fn simplequeue_put(queue: &W_SimpleQueue, item: PyObjectRef) -> PyObjectRef {
     w_none()
 }
 
-fn simplequeue_get(
+/// Wait until the native queue condition has made an item available.
+///
+/// This is the synchronization primitive, corresponding to the external
+/// acquire beneath PyPy's `rthread.Lock`/semaphore.  The caller keeps timeout
+/// parsing, the non-blocking fast path, and the eventual deque pop visible to
+/// the trace; only the host mutex/condvar wait and Rust poison ABI are opaque.
+#[majit_macros::dont_look_inside]
+fn simplequeue_wait_for_item(
     queue: &W_SimpleQueue,
-    block: bool,
-    timeout: PyObjectRef,
-) -> Result<PyObjectRef, crate::PyError> {
-    let timeout = parse_timeout(block, timeout)?;
+    timeout: Option<f64>,
+) -> Result<MutexGuard<'_, VecDeque<PyObjectRef>>, crate::PyError> {
     let mut guard = queue_lock(&queue.queue);
-    if !block {
-        return guard.pop_front().ok_or_else(empty_error);
-    }
     let deadline = deadline_from_timeout(timeout);
     loop {
-        if let Some(item) = guard.pop_front() {
-            return Ok(item);
+        if !guard.is_empty() {
+            return Ok(guard);
         }
         let blocked = crate::module::thread::before_external_block();
         if let Some(deadline) = deadline {
@@ -147,6 +157,24 @@ fn simplequeue_get(
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             drop(blocked);
         }
+    }
+}
+
+fn simplequeue_get(
+    queue: &W_SimpleQueue,
+    block: bool,
+    timeout: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    let timeout = parse_timeout(block, timeout)?;
+    let mut guard = if block {
+        simplequeue_wait_for_item(queue, timeout)?
+    } else {
+        queue_lock(&queue.queue)
+    };
+    if let Some(item) = guard.pop_front() {
+        Ok(item)
+    } else {
+        Err(empty_error())
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/_queue/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_queue/mod.rs
@@ -1,4 +1,14 @@
 //! `_queue` accelerator module.
+//!
+//! PRE-EXISTING-ADAPTATION: PyPy does NOT ship this module. `pypy/module/`
+//! has no `_queue`, and `lib-python/3/queue.py` falls back to its own
+//! `_PySimpleQueue` when the import fails, so upstream's `SimpleQueue` is
+//! pure Python. The spec here is therefore CPython's
+//! `Modules/_queuemodule.c`, not an RPython module.
+//!
+//! The `rthread` citations below are an ANALOGY for where the JIT boundary
+//! belongs — a native blocking primitive is residual in RPython too — and
+//! not a claim of provenance for this type.
 
 use pyre_object::*;
 use std::collections::VecDeque;

--- a/pyre/pyre-interpreter/src/module/_random/macro_smoke.rs
+++ b/pyre/pyre-interpreter/src/module/_random/macro_smoke.rs
@@ -199,6 +199,40 @@ mod tests {
     }
 
     #[test]
+    fn unmatched_keywords_pack_from_parallel_rooted_lists() {
+        crate::typedef::init_typeobjects();
+        let signature = crate::gateway::Signature::new(
+            vec!["head"],
+            None,
+            Some("kwargs"),
+            /*kwonlyargcount*/ 0,
+            /*posonlyargcount*/ 0,
+        );
+        let bound = crate::call::bind_kwargs_to_signature(
+            &signature,
+            "probe",
+            &[w_int_new(1)],
+            &[
+                (rustpython_wtf8::Wtf8Buf::from("alpha"), w_int_new(2)),
+                (rustpython_wtf8::Wtf8Buf::from("beta"), w_int_new(3)),
+            ],
+        )
+        .expect("unmatched keywords should pack into **kwargs");
+        assert_eq!(bound.len(), 2);
+        let w_kwargs = bound[1];
+        let w_alpha = unsafe {
+            pyre_object::dictmultiobject::w_dict_getitem_str(w_kwargs, "alpha")
+                .expect("alpha in **kwargs")
+        };
+        let w_beta = unsafe {
+            pyre_object::dictmultiobject::w_dict_getitem_str(w_kwargs, "beta")
+                .expect("beta in **kwargs")
+        };
+        assert_eq!(unsafe { w_int_get_value(w_alpha) }, 2);
+        assert_eq!(unsafe { w_int_get_value(w_beta) }, 3);
+    }
+
+    #[test]
     fn posonly_marker_makes_leading_param_positional_only() {
         crate::typedef::init_typeobjects();
         let signature = _posonly_bound_probe_pyre_sig().expect("derived signature");

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -561,8 +561,8 @@ fn ascii_module_name(w_name: pyre_object::PyObjectRef) -> Result<String, crate::
         return Err(crate::typedef::unicode_encode_error(
             "ascii",
             w_name,
-            pos,
-            pos + 1,
+            pos as i64,
+            (pos + 1) as i64,
             "ordinal not in range(128)",
         ));
     }

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -616,7 +616,10 @@ impl FileReader {
 /// wire reader's own error type.
 fn strict_wtf8(bytes: &[u8], errors: ErrorSink) -> Result<&Wtf8, wire::MarshalError> {
     pyre_object::rutf8::wtf8_from_bytes(bytes, true).map_err(|error| {
-        errors.remember(crate::typedef::utf8_decode_error_from(bytes, error.pos));
+        errors.remember(crate::typedef::utf8_decode_error_from(
+            bytes,
+            error.pos as usize,
+        ));
         wire::MarshalError::InvalidUtf8
     })
 }

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -682,15 +682,6 @@ const RPY_LOCK_FAILURE: i64 = 0;
 const RPY_LOCK_ACQUIRED: i64 = 1;
 const RPY_LOCK_INTR: i64 = 2;
 
-/// A `pthread_mutex_t` has no poison state — `thread_pthread.c` inspects only
-/// the status code — so a panic taken while lock bookkeeping was held must not
-/// turn every later acquire into an error.
-fn lock_state<T>(mutex: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
-    mutex
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-}
-
 /// `os_lock.py parse_acquire_args`.  The result is the `microseconds`
 /// argument of the `RPyThreadAcquireLockTimed` ABI: negative blocks forever,
 /// zero polls once.
@@ -821,6 +812,18 @@ mod lock_class {
     // would swallow exactly the wakeup that carries the interrupt.
     use std::sync::{Condvar, Mutex};
 
+    /// Native mutex acquisition is the residual `RPyThreadAcquireLock*`
+    /// primitive (`rpython/rlib/rthread.py:60-90,160-200`).  Keep the Python
+    /// lock algorithms visible while hiding Rust's poison-Result ABI inside
+    /// the same external boundary.  A `pthread_mutex_t` has no poison state,
+    /// so recovery returns the guard exactly as the platform primitive does.
+    #[majit_macros::dont_look_inside]
+    fn lock_state(mutex: &Mutex<bool>) -> std::sync::MutexGuard<'_, bool> {
+        mutex
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
     // CPython 3.14 Modules/_threadmodule.c builds lock_type_spec as an
     // immutable module heap type.
     #[crate::pyre_class("_thread.lock", cpython_heaptype)]
@@ -848,6 +851,7 @@ mod lock_class {
         /// `thread_pthread.c:427-485 RPyThreadAcquireLockTimed`, the mutex and
         /// condition-variable build — the shape this lock has — with
         /// `intr_flag=1`, which is what `rthread.py:195` passes.
+        #[majit_macros::dont_look_inside]
         fn acquire_timed(&self, microseconds: i64) -> i64 {
             // A potentially blocking native lock wait leaves the collector's
             // RUNNING census.  This does not serialize Python execution.  The
@@ -968,6 +972,17 @@ mod rlock_class {
         owner: i64,
     }
 
+    /// RLock bookkeeping is visible to the generated JIT, but acquiring its
+    /// native mutex is the same residual `RPyThreadAcquireLock*` primitive as
+    /// the non-recursive lock.  Rust poisoning has no RPython counterpart and
+    /// stays inside this host boundary.
+    #[majit_macros::dont_look_inside]
+    fn lock_state(mutex: &Mutex<RLockState>) -> std::sync::MutexGuard<'_, RLockState> {
+        mutex
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
     // Modules/_threadmodule.c builds rlock_type_spec as immutable heap type.
     #[crate::pyre_class("_thread.RLock", cpython_heaptype)]
     #[derive(Default)]
@@ -1003,6 +1018,7 @@ mod rlock_class {
         /// because the GIL serializes them; free-threaded pyre has no such
         /// serialization, so ownership is claimed under the same mutex the
         /// wait releases — the place `thread_pthread.c:479` sets `locked`.
+        #[majit_macros::dont_look_inside]
         fn acquire_timed(&self, microseconds: i64, ident: i64) -> i64 {
             let _blocked = before_external_block();
             let mut state = lock_state(&self.state);

--- a/pyre/pyre-interpreter/src/module/unicodedata/mod.rs
+++ b/pyre/pyre-interpreter/src/module/unicodedata/mod.rs
@@ -246,9 +246,23 @@ fn normalize_form(func: &str, obj: PyObjectRef) -> Result<NormalizeForm, PyError
             "{func}() argument 1 must be str, not {ty}"
         )));
     }
-    let s = unsafe { w_str_get_wtf8(obj) }.as_str().unwrap_or_default();
-    s.parse::<NormalizeForm>()
-        .map_err(|()| PyError::value_error("invalid normalization form"))
+    let s = unsafe { w_str_get_wtf8(obj) };
+    // `interp_ucd.py UCD.normalize` selects the four forms with an explicit
+    // source-order string branch.  Keep that graph shape instead of routing
+    // through Rust's generic `FromStr::from_str` + `Result::map_err`, which
+    // has no RPython counterpart and hides the useful constant comparisons
+    // behind two foreign generic calls.
+    if s == "NFC" {
+        Ok(NormalizeForm::Nfc)
+    } else if s == "NFD" {
+        Ok(NormalizeForm::Nfd)
+    } else if s == "NFKC" {
+        Ok(NormalizeForm::Nfkc)
+    } else if s == "NFKD" {
+        Ok(NormalizeForm::Nfkd)
+    } else {
+        Err(PyError::value_error("invalid normalization form"))
+    }
 }
 
 /// Borrow the string argument to be normalized (`unistr`).

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -2186,10 +2186,11 @@ pub(crate) unsafe fn list_repeat(list: PyObjectRef, n: PyObjectRef) -> PyResult 
     if cap > (isize::MAX as usize) / std::mem::size_of::<PyObjectRef>() {
         return Err(PyError::new(PyErrorKind::MemoryError, ""));
     }
-    let mut items: Vec<PyObjectRef> = Vec::new();
-    items
-        .try_reserve_exact(cap)
-        .map_err(|_| PyError::new(PyErrorKind::MemoryError, ""))?;
+    // RPython `ll_mul` allocates the result through `ll_newlist(resultlen)`;
+    // the fallible Rust helper is translated as `newlist_hint(cap)`, keeping
+    // both the preallocation and its MemoryError edge without exposing
+    // `Vec::try_reserve_exact` to source translation.
+    let mut items: Vec<PyObjectRef> = crate::builtins::try_pyobject_vec_with_capacity(cap)?;
     for _ in 0..count {
         for i in 0..len {
             if let Some(item) = w_list_getitem(list, i as i64) {

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -3463,8 +3463,8 @@ pub fn mul(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
         // sequences.  A sequence subclass that overrides `__mul__`/`__rmul__`
         // must reach its override first — `LM([1]) * 2` is `LM.__mul__`, not a
         // list repetition — the same gate the concat branches of `add` apply.
-        const MUL_SPECIALS: &[&str] = &["__mul__", "__rmul__"];
-        if (seq_repeat_override(a, MUL_SPECIALS) || seq_repeat_override(b, MUL_SPECIALS))
+        if (seq_repeat_override(a, &["__mul__", "__rmul__"])
+            || seq_repeat_override(b, &["__mul__", "__rmul__"]))
             && let Some(result) =
                 try_dispatch_binary_special(&mut a, &mut b, "__mul__", "__rmul__")?
         {

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -227,42 +227,6 @@ fn bigint_to_f64(a: BigInt) -> f64 {
     jit_bigint_to_f64_or_inf(&a)
 }
 
-/// `rbigint.bit_length` / `rbigint.bit_count` scalar residual core.
-///
-/// Both methods are `@jit.elidable` and can raise OverflowError through
-/// RPython's `ovfcheck`, so these wrappers publish the exception for the
-/// trailing `GUARD_NO_EXCEPTION` instead of using a cannot-raise residual.
-#[inline]
-fn bigint_checked_scalar(value: &BigInt, bit_count: bool) -> i64 {
-    let result = if bit_count {
-        value.bit_count()
-    } else {
-        value.bit_length()
-    };
-    match result {
-        Ok(value) => value,
-        Err(majit_rlib::rbigint::RBigIntError::Overflow) => {
-            crate::runtime_ops::jit_publish_exception(
-                PyError::overflow_error("too many digits in integer").to_exc_object(),
-            );
-            0
-        }
-        Err(_) => unreachable!("bit_length/bit_count only raise OverflowError"),
-    }
-}
-
-#[majit_macros::elidable]
-pub extern "C" fn jit_bigint_bit_length(value: i64) -> i64 {
-    let value = unsafe { &*(value as *const BigInt) };
-    bigint_checked_scalar(value, false)
-}
-
-#[majit_macros::elidable]
-pub extern "C" fn jit_bigint_bit_count(value: i64) -> i64 {
-    let value = unsafe { &*(value as *const BigInt) };
-    bigint_checked_scalar(value, true)
-}
-
 /// RPython `_divrem`'s truncated quotient over two bare RBigInt payloads.
 /// Allocates the result via the COLLECTING nursery (a gcmap-rooted residual,
 /// its operand pointers rooted across the alloc), matching the arithmetic

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -48,9 +48,6 @@ pub fn binary_value(
     b: PyObjectRef,
     op: BinaryOperator,
 ) -> Result<PyObjectRef, PyError> {
-    if op == BinaryOperator::InplacePower {
-        return crate::objspace::descroperation::inplace_pow(a, b);
-    }
     // descroperation.py `inplace_impl` — consult the in-place
     // special first; fall through to the binary op below when absent or
     // `NotImplemented`.
@@ -80,21 +77,10 @@ pub fn binary_value(
         BinaryOperator::Remainder | BinaryOperator::InplaceRemainder => mod_(a, b),
         BinaryOperator::TrueDivide | BinaryOperator::InplaceTrueDivide => truediv(a, b),
         BinaryOperator::Power => pow(a, b),
-        BinaryOperator::InplacePower => match pow(a, b) {
-            Err(err)
-                if err.kind == crate::PyErrorKind::TypeError
-                    && err
-                        .message
-                        .starts_with("unsupported operand type(s) for ** or pow():") =>
-            {
-                Err(crate::PyError::type_error(format!(
-                    "unsupported operand type(s) for **=: '{}' and '{}'",
-                    crate::baseobjspace::object_functionstr_type_name(a),
-                    crate::baseobjspace::object_functionstr_type_name(b),
-                )))
-            }
-            result => result,
-        },
+        // PyPy `pyopcode.py:INPLACE_POWER` calls `space.inplace_pow`
+        // directly; unlike the generated `inplace_impl` family this operation
+        // has its own three-argument-aware dispatch in descroperation.py.
+        BinaryOperator::InplacePower => crate::objspace::descroperation::inplace_pow(a, b),
         BinaryOperator::Lshift | BinaryOperator::InplaceLshift => lshift(a, b),
         BinaryOperator::MatrixMultiply | BinaryOperator::InplaceMatrixMultiply => matmul(a, b),
         BinaryOperator::Rshift | BinaryOperator::InplaceRshift => rshift(a, b),

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -696,7 +696,11 @@ pub fn dict_update_value(dict: PyObjectRef, source: PyObjectRef) -> Result<(), P
             let dict_slot = pyre_object::gc_roots::shadow_stack_len();
             let _ = pyre_object::gc_roots::pin_root(dict);
             let entries = pyre_object::w_dict_items(source);
-            let flat: Vec<PyObjectRef> = entries.iter().flat_map(|&(k, v)| [k, v]).collect();
+            let mut flat = Vec::with_capacity(entries.len() * 2);
+            for &(key, value) in &entries {
+                flat.push(key);
+                flat.push(value);
+            }
             let pair_base = pyre_object::gc_roots::pin_roots(&flat);
             for index in 0..entries.len() {
                 pyre_object::w_dict_store(

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -738,8 +738,8 @@ pub fn dict_update_value(dict: PyObjectRef, source: PyObjectRef) -> Result<(), P
         let dict = pyre_object::gc_roots::pin_root(dict);
         let source = pyre_object::gc_roots::pin_root(source);
         let key_base = sp + 2;
-        for key in keys {
-            let _ = pyre_object::gc_roots::pin_root(key);
+        for index in 0..keys.len() {
+            let _ = pyre_object::gc_roots::pin_root(keys[index]);
         }
         let key_len = pyre_object::gc_roots::shadow_stack_len() - key_base;
         for i in 0..key_len {

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -535,7 +535,10 @@ pub mod frame_locals_proxy {
                     roots.get(pairs_base + index * 2 + 1),
                 ]));
             }
-            let out: Vec<PyObjectRef> = (0..items.len()).map(|i| roots.get(out_base + i)).collect();
+            let mut out = Vec::with_capacity(items.len());
+            for i in 0..items.len() {
+                out.push(roots.get(out_base + i));
+            }
             Ok(pyre_object::w_list_new(out))
         }
 
@@ -647,8 +650,10 @@ pub mod frame_locals_proxy {
             }
             let extra_slot = args_base + nargs;
             let _ = roots.pin_root(extra);
-            let call_args: Vec<PyObjectRef> =
-                (0..nargs).map(|i| roots.get(args_base + i)).collect();
+            let mut call_args = Vec::with_capacity(nargs);
+            for i in 0..nargs {
+                call_args.push(roots.get(args_base + i));
+            }
             let result = crate::baseobjspace::call_method(roots.get(extra_slot), "pop", &call_args);
             if result.is_null() {
                 Err(crate::call::take_call_error()

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -592,6 +592,7 @@ fn load_const_value<H: ConstantOpcodeHandler + ?Sized>(
                 items.push(load_const_value(handler, element)?);
             }
             if items.len() == 3 {
+                let items = items.as_slice();
                 handler.slice_constant(items[0], items[1], items[2])
             } else {
                 handler.build_tuple(&items)

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -3757,8 +3757,8 @@ pub(crate) fn encode_utf8_with_errors(
                     return Err(crate::typedef::unicode_encode_error(
                         "utf-8",
                         w_object,
-                        index,
-                        error_end,
+                        index as i64,
+                        error_end as i64,
                         "surrogates not allowed",
                     ));
                 }
@@ -3767,8 +3767,8 @@ pub(crate) fn encode_utf8_with_errors(
                 return Err(crate::typedef::unicode_encode_error(
                     "utf-8",
                     w_object,
-                    index,
-                    error_end,
+                    index as i64,
+                    error_end as i64,
                     "surrogates not allowed",
                 ));
             }
@@ -3801,8 +3801,8 @@ pub(crate) fn encode_utf8_with_errors(
                                 return Err(crate::typedef::unicode_encode_error(
                                     "utf-8",
                                     w_object,
-                                    index,
-                                    error_end,
+                                    index as i64,
+                                    error_end as i64,
                                     "surrogates not allowed",
                                 ));
                             }
@@ -4140,8 +4140,8 @@ fn encode_narrow(
                 return Err(crate::typedef::unicode_encode_error(
                     enc_name,
                     pyre_object::gc_roots::shadow_stack_get(source_slot),
-                    start,
-                    end,
+                    start as i64,
+                    end as i64,
                     range_msg,
                 ));
             }
@@ -4181,8 +4181,8 @@ fn encode_narrow(
                                 return Err(crate::typedef::unicode_encode_error(
                                     enc_name,
                                     pyre_object::gc_roots::shadow_stack_get(source_slot),
-                                    start,
-                                    end,
+                                    start as i64,
+                                    end as i64,
                                     range_msg,
                                 ));
                             }
@@ -4326,8 +4326,8 @@ fn encode_utf16_32_impl(
                 return Err(crate::typedef::unicode_encode_error(
                     codec,
                     pyre_object::gc_roots::shadow_stack_get(object_slot),
-                    index,
-                    index + 1,
+                    index as i64,
+                    (index + 1) as i64,
                     "surrogates not allowed",
                 ));
             }
@@ -4348,8 +4348,8 @@ fn encode_utf16_32_impl(
                                 return Err(crate::typedef::unicode_encode_error(
                                     codec,
                                     pyre_object::gc_roots::shadow_stack_get(object_slot),
-                                    index,
-                                    index + 1,
+                                    index as i64,
+                                    (index + 1) as i64,
                                     "surrogates not allowed",
                                 ));
                             }
@@ -4362,8 +4362,8 @@ fn encode_utf16_32_impl(
                             return Err(crate::typedef::unicode_encode_error(
                                 codec,
                                 pyre_object::gc_roots::shadow_stack_get(object_slot),
-                                index,
-                                index + 1,
+                                index as i64,
+                                (index + 1) as i64,
                                 "surrogates not allowed",
                             ));
                         }
@@ -4674,7 +4674,8 @@ pub(crate) fn call_registered_encode_error_handler(
     })?;
 
     let w_exc =
-        crate::typedef::unicode_encode_error(codec, source, start, end, reason).to_exc_object();
+        crate::typedef::unicode_encode_error(codec, source, start as i64, end as i64, reason)
+            .to_exc_object();
     let w_res = crate::baseobjspace::call_function(w_handler, &[w_exc]);
     if w_res.is_null() {
         return Err(crate::call::take_call_error()

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -16143,13 +16143,7 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                         && pyre_object::is_type(w_cls)
                         && !crate::baseobjspace::isinstance_w(obj, w_cls)
                     {
-                        let slot_name = pyre_object::w_member_get_name(descr);
-                        return Err(crate::PyError::type_error(format!(
-                            "descriptor '{}' for '{}' objects doesn't apply to '{}' object",
-                            slot_name,
-                            pyre_object::w_type_get_name(w_cls),
-                            pyre_object::type_name_of(obj),
-                        )));
+                        return Err(crate::baseobjspace::member_typecheck_error(descr, obj));
                     }
                 }
                 if unsafe { pyre_object::w_member_is_direct(descr) } {
@@ -16195,13 +16189,7 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                         && pyre_object::is_type(w_cls)
                         && !crate::baseobjspace::isinstance_w(obj, w_cls)
                     {
-                        let slot_name = pyre_object::w_member_get_name(descr);
-                        return Err(crate::PyError::type_error(format!(
-                            "descriptor '{}' for '{}' objects doesn't apply to '{}' object",
-                            slot_name,
-                            pyre_object::w_type_get_name(w_cls),
-                            pyre_object::type_name_of(obj),
-                        )));
+                        return Err(crate::baseobjspace::member_typecheck_error(descr, obj));
                     }
                 }
                 if unsafe { pyre_object::w_member_is_direct(descr) } {
@@ -16246,13 +16234,7 @@ fn init_member_descriptor_type(ns: PyObjectRef) {
                         && pyre_object::is_type(w_cls)
                         && !crate::baseobjspace::isinstance_w(obj, w_cls)
                     {
-                        let slot_name = pyre_object::w_member_get_name(descr);
-                        return Err(crate::PyError::type_error(format!(
-                            "descriptor '{}' for '{}' objects doesn't apply to '{}' object",
-                            slot_name,
-                            pyre_object::w_type_get_name(w_cls),
-                            pyre_object::type_name_of(obj),
-                        )));
+                        return Err(crate::baseobjspace::member_typecheck_error(descr, obj));
                     }
                 }
                 if unsafe { pyre_object::w_member_is_direct(descr) } {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -19017,10 +19017,51 @@ fn init_int_type(ns: PyObjectRef) {
         unsafe { crate::function::fset_func_text_signature(function, w_str_new(text_signature)) };
     }
 }
-/// Complex `repr` (`Xj` for a pure-`+0` real part, else `(re±imj)`),
-/// delegated to `rustpython_literal::complex::to_string`.
+/// `complexobject.py repr_format` — `rfloat.formatd(x, 'r', 0)` without the
+/// `DTSF_ADD_DOT_0` flag used by float repr.  RustPython keeps that spelling
+/// inside its complex formatter; selecting a pure-imaginary value exposes the
+/// same component text to the interpreter path.
+pub(crate) fn format_complex_component_repr(val: f64) -> String {
+    let mut out = rustpython_literal::complex::to_string(0.0, val);
+    debug_assert!(out.ends_with('j'));
+    out.pop();
+    out
+}
+
+/// RPython `rfloat.formatd` residual ABI for a complex repr component.
+///
+/// The translator replaces only the component-format call with this one-word
+/// low-level string result.  The surrounding positive-zero/sign/parenthesis
+/// builder remains visible in `complex_repr_string`, matching PyPy.
+#[majit_macros::dont_look_inside]
+pub fn jit_format_complex_component_repr_rstr(
+    val: f64,
+) -> *mut pyre_object::bytesobject::BytesBlock {
+    let text = format_complex_component_repr(val);
+    pyre_object::bytesobject::alloc_bytes_block(text.as_bytes())
+}
+
+/// `complexobject.py W_ComplexObject.descr_repr` — a pure positive-zero real
+/// part uses `Xj`; every other value uses `(re±imj)`.  Keep the branch and the
+/// two `repr_format` calls visible to source translation, just as PyPy does,
+/// instead of delegating the whole operation to a foreign Rust formatter.
 pub(crate) fn complex_repr_string(re: f64, im: f64) -> String {
-    rustpython_literal::complex::to_string(re, im)
+    if re == 0.0 && re.is_sign_positive() {
+        let mut out = String::new();
+        out.push_str(&format_complex_component_repr(im));
+        out.push_str("j");
+        return out;
+    }
+
+    let mut out = String::new();
+    out.push_str("(");
+    out.push_str(&format_complex_component_repr(re));
+    if im.is_sign_positive() || im.is_nan() {
+        out.push_str("+");
+    }
+    out.push_str(&format_complex_component_repr(im));
+    out.push_str("j)");
+    out
 }
 
 fn init_complex_type(ns: PyObjectRef) {
@@ -31491,6 +31532,33 @@ fn descr_get_weakref(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn complex_repr_keeps_pypy_positive_zero_and_sign_rules() {
+        for (re, im, expected) in [
+            (0.0, 2.0, "2j"),
+            (-0.0, 2.0, "(-0+2j)"),
+            (1.0, 2.0, "(1+2j)"),
+            (1.0, -2.0, "(1-2j)"),
+            (1.0, f64::NAN, "(1+nanj)"),
+            (f64::INFINITY, f64::NEG_INFINITY, "(inf-infj)"),
+            (0.0, -0.0, "-0j"),
+        ] {
+            assert_eq!(super::complex_repr_string(re, im), expected);
+        }
+    }
+
+    #[test]
+    fn complex_component_residual_returns_the_same_lowlevel_string_bytes() {
+        for value in [0.0, -0.0, 1.5, f64::INFINITY, f64::NEG_INFINITY, f64::NAN] {
+            let block = super::jit_format_complex_component_repr_rstr(value);
+            let bytes = unsafe { pyre_object::bytesobject::bytes_block_chars(block) };
+            assert_eq!(
+                bytes,
+                super::format_complex_component_repr(value).as_bytes()
+            );
+        }
+    }
+
     #[test]
     fn module_init_retains_a_surrogate_name_object() {
         let module = pyre_object::w_module_new_managed("");

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -18999,15 +18999,32 @@ fn init_int_type(ns: PyObjectRef) {
         unsafe { crate::function::fset_func_text_signature(function, w_str_new(text_signature)) };
     }
 }
-/// `complexobject.py repr_format` — `rfloat.formatd(x, 'r', 0)` without the
-/// `DTSF_ADD_DOT_0` flag used by float repr.  RustPython keeps that spelling
-/// inside its complex formatter; selecting a pure-imaginary value exposes the
-/// same component text to the interpreter path.
+/// `complexobject.py repr_format` — `format_float(x, 'r', 0)`, i.e.
+/// `rfloat.formatd(x, 'r', 0)` without the `DTSF_ADD_DOT_0` flag used by float
+/// repr.
+///
+/// `format_float` names the infinities and NaN itself and only then reaches
+/// `formatd`, so those three arms are spelled here rather than inherited from
+/// the Rust formatter. The finite case still selects a pure-imaginary value
+/// out of the complex formatter, which keeps the `formatd` spelling: `strip`
+/// rather than `pop`, because a `debug_assert` on the `j` compiles out in
+/// release and a bare `pop` would then truncate a real character.
 pub(crate) fn format_complex_component_repr(val: f64) -> String {
-    let mut out = rustpython_literal::complex::to_string(0.0, val);
-    debug_assert!(out.ends_with('j'));
-    out.pop();
-    out
+    if val.is_infinite() {
+        return if val > 0.0 {
+            "inf".to_string()
+        } else {
+            "-inf".to_string()
+        };
+    }
+    if val.is_nan() {
+        return "nan".to_string();
+    }
+    let out = rustpython_literal::complex::to_string(0.0, val);
+    match out.strip_suffix('j') {
+        Some(component) => component.to_string(),
+        None => out,
+    }
 }
 
 /// RPython `rfloat.formatd` residual ABI for a complex repr component.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -23805,42 +23805,6 @@ pub(crate) fn unicode_decode_error(
     }
 }
 
-/// interp_exceptions.py W_UnicodeEncodeError.descr_str format.
-/// `w_object` is the str being encoded; the bad code point is read at
-/// `start` through the surrogate-aware WTF-8 view.
-fn unicode_encode_error_msg(
-    codec: &str,
-    w_object: PyObjectRef,
-    start: usize,
-    end: usize,
-    reason: &str,
-) -> String {
-    if end == start + 1 {
-        let badchar = unsafe {
-            pyre_object::w_str_get_wtf8(w_object)
-                .code_points()
-                .nth(start)
-                .map(|c| c.to_u32())
-                .unwrap_or(0)
-        };
-        let badchar_repr = if badchar <= 0xff {
-            format!("'\\x{badchar:02x}'")
-        } else if badchar <= 0xffff {
-            format!("'\\u{badchar:04x}'")
-        } else {
-            format!("'\\U{badchar:08x}'")
-        };
-        format!(
-            "'{codec}' codec can't encode character {badchar_repr} in position {start}: {reason}"
-        )
-    } else {
-        format!(
-            "'{codec}' codec can't encode characters in position {start}-{}: {reason}",
-            end - 1
-        )
-    }
-}
-
 /// `str.encode('utf-8')` under the default error handler, for a consumer that
 /// can only hold a Rust `str` — the compiler's source text, the tokenizer's
 /// input line.
@@ -23859,8 +23823,8 @@ pub(crate) fn utf8_strict_w(text: Wtf8Buf) -> Result<String, crate::PyError> {
     Err(unicode_encode_error(
         "utf-8",
         pyre_object::w_str_from_wtf8(text),
-        position,
-        position + 1,
+        position as i64,
+        (position + 1) as i64,
         "surrogates not allowed",
     ))
 }
@@ -23875,20 +23839,19 @@ pub(crate) fn utf8_strict_w(text: Wtf8Buf) -> Result<String, crate::PyError> {
 pub(crate) fn unicode_encode_error(
     encoding: &str,
     w_object: PyObjectRef,
-    start: usize,
-    end: usize,
+    start: i64,
+    end: i64,
     reason: &str,
 ) -> crate::PyError {
     let w_encoding = pyre_object::w_str_new(encoding);
-    let w_start = pyre_object::w_int_new(start as i64);
-    let w_end = pyre_object::w_int_new(end as i64);
+    let w_start = pyre_object::w_int_new(start);
+    let w_end = pyre_object::w_int_new(end);
     let w_reason = pyre_object::w_str_new(reason);
-    // Eager message for PyError.message; descr_str recomputes the same text
-    // from the fields (display.rs unicode_encode_error_str).
-    let msg = unicode_encode_error_msg(encoding, w_object, start, end, reason);
-    let exc = pyre_object::interp_exceptions::w_exception_new(
+    // PyPy stores the five fields/args here and formats them only from
+    // `W_UnicodeEncodeError.descr_str`. `PyError::from_exc_object` follows
+    // the same lazy display path, so do not precompute a parallel message.
+    let exc = pyre_object::interp_exceptions::w_exception_new_empty(
         pyre_object::interp_exceptions::ExcKind::UnicodeEncodeError,
-        &msg,
     );
     unsafe {
         pyre_object::interp_exceptions::w_exception_set_encoding(exc, w_encoding);

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -18318,14 +18318,11 @@ type DunderFn = fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>;
 /// edge, in the same shape as `descroperation`'s `bigint_lshift_count` /
 /// `bigint_pow_nomod`.
 ///
-/// `RBigInt::bit_length` returns `Result<i64, RBigIntError>`, but
-/// `scalar_residual_for_method` retargets the call to the raising scalar
-/// residual `jit_bigint_bit_length`, whose result is a bare Signed word and
-/// whose error travels the implicit exception edge. A caller that destructures
-/// the pre-retarget `Result` in a lowered graph reads `__discriminant` /
-/// `__pos_0` off that erased word — an integer used as an aggregate base.
-/// Keeping the match behind this boundary converts the carrier to the
-/// `Result<_, PyError>` the exception transform models.
+/// `RBigInt::bit_length` returns `Result<i64, RBigIntError>` — `ovfcheck`'s
+/// value encoding — and the front's exception transform is scoped to the
+/// `Result<_, PyError>` carrier, so this converts the one to the other at a
+/// single place instead of leaving every `int.bit_length()` caller to
+/// destructure the rbigint-local error type.
 #[majit_macros::dont_look_inside]
 fn long_bit_length(value: &BigInt) -> Result<i64, crate::PyError> {
     match value.bit_length() {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -20002,7 +20002,7 @@ pub(crate) fn float_to_pyint(v: f64, mode: FloatToIntMode) -> Result<PyObjectRef
 /// IEEE-754 bits are decomposed directly: clearing the stored exponent
 /// to `0x3fe` lands the value in `[0.5, 1)`.  Subnormals are first
 /// scaled into the normal range by `2**54`.
-fn float_frexp(x: f64) -> (f64, i32) {
+pub(crate) fn float_frexp(x: f64) -> (f64, i32) {
     if x == 0.0 {
         return (x, 0);
     }

--- a/pyre/pyre-interpreter/src/unicodehelper_win32.rs
+++ b/pyre/pyre-interpreter/src/unicodehelper_win32.rs
@@ -405,8 +405,8 @@ fn encode_errors(
                         return Err(crate::typedef::unicode_encode_error(
                             &encoding,
                             w_unicode,
-                            pos,
-                            pos + 1,
+                            pos as i64,
+                            (pos + 1) as i64,
                             "unable to encode error handler result to ASCII",
                         ));
                     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -676,6 +676,17 @@ fn builtin_wrapper_heapcache_uses_item_not_length_descr() {
 }
 
 #[test]
+fn gateway_positional_count_uses_rpython_signed() {
+    let count = named_jitcode("leading_non_null_count")
+        .expect("gateway positional-count helper jitcode");
+    assert_eq!(count.calldescr.result_type, 'i');
+    assert!(
+        count.calldescr.result_signed,
+        "PyPy argument.py keeps num_args/upfront/input_argcount as RPython Signed"
+    );
+}
+
+#[test]
 fn signature_bound_wrapper_reads_argument_slice_with_distinct_item_descr() {
     let wrapper =
         named_jitcode("__majit_wrap_getrandbits").expect("getrandbits builtin wrapper jitcode");

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -677,8 +677,8 @@ fn builtin_wrapper_heapcache_uses_item_not_length_descr() {
 
 #[test]
 fn gateway_positional_count_uses_rpython_signed() {
-    let count = named_jitcode("leading_non_null_count")
-        .expect("gateway positional-count helper jitcode");
+    let count =
+        named_jitcode("leading_non_null_count").expect("gateway positional-count helper jitcode");
     assert_eq!(count.calldescr.result_type, 'i');
     assert!(
         count.calldescr.result_signed,

--- a/pyre/pyre-jit-trace/src/pyre_cpu.rs
+++ b/pyre/pyre-jit-trace/src/pyre_cpu.rs
@@ -282,7 +282,11 @@ impl Cpu for PyreCpu {
         if storage.is_null() {
             return s.code_points().nth(i).map(|c| c.to_u32() as i64);
         }
-        Some(pyre_object::rutf8::codepoint_at_index(s, unsafe { &*storage }, i).to_u32() as i64)
+        Some(pyre_object::rutf8::codepoint_at_index(
+            s,
+            unsafe { &*storage },
+            i,
+        ))
     }
 }
 

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4790,7 +4790,7 @@ pub fn create_callee_frame_impl_pub(caller_frame: i64, callable: i64, args: &[Py
 
 fn fill_positional_defaults_for_jit_call<'a>(
     callable: PyObjectRef,
-    w_code: *const (),
+    w_code: PyObjectRef,
     args: &'a [PyObjectRef],
 ) -> Cow<'a, [PyObjectRef]> {
     let defaults = unsafe { function_get_defaults(callable) };
@@ -4799,8 +4799,7 @@ fn fill_positional_defaults_for_jit_call<'a>(
     }
 
     let code = unsafe {
-        &*(pyre_interpreter::w_code_get_ptr(w_code as PyObjectRef)
-            as *const pyre_interpreter::CodeObject)
+        &*(pyre_interpreter::w_code_get_ptr(w_code) as *const pyre_interpreter::CodeObject)
     };
     let nparams = code.arg_count as usize;
     if args.len() >= nparams {
@@ -4918,7 +4917,7 @@ fn create_callee_frame_in_ctx(
     let args = fill_positional_defaults_for_jit_call(callable, w_code, args);
     let args = args.as_ref();
 
-    alloc_callee_frame(w_code, args, w_globals, execution_context) as i64
+    alloc_callee_frame(w_code as *const (), args, w_globals, execution_context) as i64
 }
 
 #[majit_macros::dont_look_inside]
@@ -5146,7 +5145,7 @@ fn bh_call_self_recursive_portal(
     }
     let parent_frame = unsafe { &*parent_frame_ptr };
     let callable_code = unsafe { pyre_interpreter::getcode(callable) };
-    if parent_frame.pycode != callable_code {
+    if parent_frame.pycode != callable_code as *const () {
         return None;
     }
     if !recursive_force_cache_safe(callable) {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4861,7 +4861,7 @@ fn create_callee_frame_impl_1_boxed(
     let args = args.as_ref();
 
     alloc_callee_frame(
-        w_code,
+        w_code as *const (),
         args,
         w_globals,
         pyre_interpreter::call::getexecutioncontext(),

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4719,6 +4719,22 @@ fn build_gc() -> Box<MiniMarkGC> {
     ));
     pyre_object::bytesobject::set_bytes_block_gc_type_id(bytes_block_tid);
 
+    // `interp_deque.py Lock` is a fieldless internal GC identity token, not a
+    // Python-visible rclass. Register it without a vtable or subclass-range
+    // alias; W_Deque and its iterators carry the token through their ordinary
+    // traced pointer fields. It must be at the absolute tail: unlike PyPy's
+    // symbolic gctypelayout ids, this collector's ids are registration-order
+    // positions, so inserting the internal token beside Block would renumber
+    // every established Python-visible rclass registered after it.
+    let deque_lock_descr =
+        <pyre_interpreter::module::_collections::deque_lock::W_DequeLock
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR;
+    let deque_lock_tid = gc.register_type(TypeInfo::with_gc_ptrs(
+        deque_lock_descr.object_size,
+        deque_lock_descr.ptr_offsets.to_vec(),
+    ));
+    deque_lock_descr.gc_type_id.set(deque_lock_tid);
+
     // ── GC-root registration completeness oracle ─────────────────────────
     // Every `#[pyre_class]` type appends its descriptor to the whole-program
     // `PYRE_CLASS_DESCRIPTORS` slice. A type with inline managed children must

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -203,7 +203,7 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
             // supplied positionals; the Signature binder has already
             // rejected genuine positional overflow before entering here.
             quote! {
-                if __pyre_positional_count > #total
+                if __pyre_positional_count > #total as i64
                     && args.len() != __PYRE_PARAM_NAMES.len()
                 {
                     return ::std::result::Result::Err(crate::PyError::type_error(#too_many));
@@ -211,13 +211,13 @@ fn expand_pyre_function(func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
             }
         } else {
             quote! {
-                if __pyre_positional_count > #total {
+                if __pyre_positional_count > #total as i64 {
                     return ::std::result::Result::Err(crate::PyError::type_error(#too_many));
                 }
             }
         };
         quote! {
-            if __pyre_positional_count < #required {
+            if __pyre_positional_count < #required as i64 {
                 return ::std::result::Result::Err(crate::PyError::type_error(#too_few));
             }
             #too_many_guard
@@ -2040,10 +2040,14 @@ fn expand_pyre_methods(
                         return crate::gateway::method_noarg_failure(
                             args,
                             #arity_name,
-                            #receiver_slots,
+                            #receiver_slots as i64,
                         );
                     }
-                    let __pyre_positional_count = args.len();
+                    // PyPy `argument.py:_match_signature` carries argument
+                    // counts as RPython Signed.  Keep this generated gateway
+                    // local in that type; `usize` belongs only at Rust slice
+                    // indexing boundaries.
+                    let __pyre_positional_count = args.len() as i64;
                 }
             } else {
                 quote! {
@@ -2127,27 +2131,37 @@ fn expand_pyre_methods(
                         crate::gateway::method_arity_failure(
                             #arity_name,
                             #expected,
-                            __pyre_positional_count.saturating_sub(#receiver_slots),
+                            __pyre_user_positional_count,
                         )
                     }
                 } else {
                     quote! {
                         crate::gateway::method_min_arity_failure(
                             #arity_name,
-                            #visible_required,
-                            __pyre_positional_count.saturating_sub(#receiver_slots),
+                            #visible_required as i64,
+                            __pyre_user_positional_count,
                         )
                     }
                 };
                 quote! {
-                    if __pyre_positional_count < #expected_min {
+                    // PyPy's `input_argcount`/`upfront` calculation is
+                    // ordinary Signed arithmetic.  Spell out the lower
+                    // bound instead of introducing Rust's integer-method
+                    // call into every generated gateway graph.
+                    let __pyre_user_positional_count =
+                        if __pyre_positional_count > #receiver_slots as i64 {
+                            __pyre_positional_count - #receiver_slots as i64
+                        } else {
+                            0i64
+                        };
+                    if __pyre_positional_count < #expected_min as i64 {
                         return #too_few;
                     }
-                    if __pyre_positional_count > #expected_total {
+                    if __pyre_positional_count > #expected_total as i64 {
                         return crate::gateway::method_arity_failure(
                             #arity_name,
                             #expected,
-                            __pyre_positional_count.saturating_sub(#receiver_slots),
+                            __pyre_user_positional_count,
                         );
                     }
                 }

--- a/pyre/pyre-object/src/complexobject.rs
+++ b/pyre/pyre-object/src/complexobject.rs
@@ -118,33 +118,27 @@ pub unsafe fn w_complex_setdict(obj: PyObjectRef, w_dict: PyObjectRef) {
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
-/// Address of `W_ComplexObject::w_slots` for the shared slot helpers.
-///
-/// # Safety
-/// `obj` must point to a valid `W_ComplexObject`.
-unsafe fn complex_slots_field(obj: PyObjectRef) -> *mut PyObjectRef {
-    unsafe { &mut (*(obj as *mut W_ComplexObject)).w_slots }
-}
-
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_complex_slot_get(obj: PyObjectRef, index: usize) -> Option<PyObjectRef> {
-    unsafe { crate::slots::slot_get(obj, index, complex_slots_field) }
+    let slots = unsafe { (*(obj as *const W_ComplexObject)).w_slots };
+    unsafe { crate::slots::slot_get(slots, index) }
 }
 
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_complex_slot_set(obj: PyObjectRef, index: usize, value: PyObjectRef) {
-    unsafe { crate::slots::slot_set(obj, index, value, complex_slots_field) }
+    crate::slot_set_direct!(obj, index, value, W_ComplexObject, w_slots)
 }
 
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_complex_slot_del(obj: PyObjectRef, index: usize) -> bool {
-    unsafe { crate::slots::slot_del(obj, index, complex_slots_field) }
+    let slots = unsafe { (*(obj as *const W_ComplexObject)).w_slots };
+    unsafe { crate::slots::slot_del(slots, index) }
 }
 
 #[cfg(test)]

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -5544,16 +5544,16 @@ pub unsafe fn w_module_dict_values_inner(obj: PyObjectRef) -> Vec<PyObjectRef> {
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_dict_str_entries(obj: PyObjectRef) -> Vec<(String, PyObjectRef)> {
-    w_dict_items(obj)
-        .into_iter()
-        .filter_map(|(k, v)| {
-            if crate::is_str(k) {
-                crate::w_str_get_value_opt(k).map(|s| (s.to_string(), v))
-            } else {
-                None
+    let source = w_dict_items(obj);
+    let mut entries = Vec::with_capacity(source.len());
+    for (key, value) in source {
+        if crate::is_str(key) {
+            if let Some(key) = crate::w_str_get_value_opt(key) {
+                entries.push((key.to_string(), value));
             }
-        })
-        .collect()
+        }
+    }
+    entries
 }
 
 /// Iterate over (key_wtf8, value) pairs, preserving lone-surrogate keys.
@@ -5576,16 +5576,14 @@ pub unsafe fn w_dict_str_entries(obj: PyObjectRef) -> Vec<(String, PyObjectRef)>
 pub unsafe fn w_dict_str_entries_wtf8(
     obj: PyObjectRef,
 ) -> Vec<(rustpython_wtf8::Wtf8Buf, PyObjectRef)> {
-    w_dict_items(obj)
-        .into_iter()
-        .filter_map(|(k, v)| {
-            if crate::is_str(k) {
-                Some((crate::w_str_get_wtf8(k).to_owned(), v))
-            } else {
-                None
-            }
-        })
-        .collect()
+    let source = w_dict_items(obj);
+    let mut entries = Vec::with_capacity(source.len());
+    for (key, value) in source {
+        if crate::is_str(key) {
+            entries.push((crate::w_str_get_wtf8(key).to_owned(), value));
+        }
+    }
+    entries
 }
 
 // ____________________________________________________________

--- a/pyre/pyre-object/src/floatobject.rs
+++ b/pyre/pyre-object/src/floatobject.rs
@@ -141,33 +141,27 @@ pub unsafe fn w_float_setdict(obj: PyObjectRef, w_dict: PyObjectRef) {
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
-/// Address of `W_FloatObject::w_slots` for the shared slot helpers.
-///
-/// # Safety
-/// `obj` must point to a valid `W_FloatObject`.
-unsafe fn float_slots_field(obj: PyObjectRef) -> *mut PyObjectRef {
-    unsafe { &mut (*(obj as *mut W_FloatObject)).w_slots }
-}
-
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_float_slot_get(obj: PyObjectRef, index: usize) -> Option<PyObjectRef> {
-    unsafe { crate::slots::slot_get(obj, index, float_slots_field) }
+    let slots = unsafe { (*(obj as *const W_FloatObject)).w_slots };
+    unsafe { crate::slots::slot_get(slots, index) }
 }
 
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_float_slot_set(obj: PyObjectRef, index: usize, value: PyObjectRef) {
-    unsafe { crate::slots::slot_set(obj, index, value, float_slots_field) }
+    crate::slot_set_direct!(obj, index, value, W_FloatObject, w_slots)
 }
 
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_float_slot_del(obj: PyObjectRef, index: usize) -> bool {
-    unsafe { crate::slots::slot_del(obj, index, float_slots_field) }
+    let slots = unsafe { (*(obj as *const W_FloatObject)).w_slots };
+    unsafe { crate::slots::slot_del(slots, index) }
 }
 
 #[majit_macros::dont_look_inside]

--- a/pyre/pyre-object/src/interp_array.rs
+++ b/pyre/pyre-object/src/interp_array.rs
@@ -142,20 +142,13 @@ pub unsafe fn w_array_setweakref(obj: PyObjectRef, lifeline: PyObjectRef) {
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
-/// Address of `W_Array::w_slots` for the shared slot helpers.
-///
-/// # Safety
-/// `obj` must point to a valid `W_Array`.
-unsafe fn array_slots_field(obj: PyObjectRef) -> *mut PyObjectRef {
-    unsafe { &mut (*(obj as *mut W_Array)).w_slots }
-}
-
 /// Read one app-level `__slots__` entry from an array subclass.
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_array_slot_get(obj: PyObjectRef, index: usize) -> Option<PyObjectRef> {
-    unsafe { crate::slots::slot_get(obj, index, array_slots_field) }
+    let slots = unsafe { (*(obj as *const W_Array)).w_slots };
+    unsafe { crate::slots::slot_get(slots, index) }
 }
 
 /// Write one app-level `__slots__` entry on an array subclass.
@@ -163,7 +156,7 @@ pub unsafe fn w_array_slot_get(obj: PyObjectRef, index: usize) -> Option<PyObjec
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_array_slot_set(obj: PyObjectRef, index: usize, value: PyObjectRef) {
-    unsafe { crate::slots::slot_set(obj, index, value, array_slots_field) }
+    crate::slot_set_direct!(obj, index, value, W_Array, w_slots)
 }
 
 /// Clear one app-level `__slots__` entry on an array subclass.
@@ -171,7 +164,8 @@ pub unsafe fn w_array_slot_set(obj: PyObjectRef, index: usize, value: PyObjectRe
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_array_slot_del(obj: PyObjectRef, index: usize) -> bool {
-    unsafe { crate::slots::slot_del(obj, index, array_slots_field) }
+    let slots = unsafe { (*(obj as *const W_Array)).w_slots };
+    unsafe { crate::slots::slot_del(slots, index) }
 }
 
 /// # Safety

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1098,22 +1098,23 @@ fn boxed_from_int_or_float(values: &[i64]) -> Vec<PyObjectRef> {
         };
         let _ = crate::gc_roots::pin_root(item);
     }
-    (0..values.len())
-        .map(|i| crate::gc_roots::shadow_stack_get(root_base + i))
-        .collect()
+    let mut items = Vec::with_capacity(values.len());
+    for i in 0..values.len() {
+        items.push(crate::gc_roots::shadow_stack_get(root_base + i));
+    }
+    items
 }
 
 /// listobject.py IntegerListStrategy.switch_to_int_or_float_strategy.
 unsafe fn integer_to_int_or_float(list: &mut W_ListObject) -> bool {
-    let Some(values) = list
-        .int_items
-        .as_slice()
-        .iter()
-        .map(|&value| int_or_float_encode_int(value))
-        .collect::<Option<Vec<_>>>()
-    else {
-        return false;
-    };
+    let source = list.int_items.as_slice();
+    let mut values = Vec::with_capacity(source.len());
+    for &value in source {
+        let Some(encoded) = int_or_float_encode_int(value) else {
+            return false;
+        };
+        values.push(encoded);
+    }
     list.int_items.install(IntArray::from_vec(values));
     list.strategy = ListStrategy::IntOrFloat;
     true
@@ -1121,15 +1122,14 @@ unsafe fn integer_to_int_or_float(list: &mut W_ListObject) -> bool {
 
 /// listobject.py FloatListStrategy.switch_to_int_or_float_strategy.
 unsafe fn float_to_int_or_float(list: &mut W_ListObject) -> bool {
-    let Some(values) = list
-        .float_items
-        .as_slice()
-        .iter()
-        .map(|&value| int_or_float_encode_float(value))
-        .collect::<Option<Vec<_>>>()
-    else {
-        return false;
-    };
+    let source = list.float_items.as_slice();
+    let mut values = Vec::with_capacity(source.len());
+    for &value in source {
+        let Some(encoded) = int_or_float_encode_float(value) else {
+            return false;
+        };
+        values.push(encoded);
+    }
     list.int_items.install(IntArray::from_vec(values));
     list.float_items.install(FloatArray::from_vec(Vec::new()));
     list.strategy = ListStrategy::IntOrFloat;
@@ -1142,9 +1142,11 @@ fn boxed_from_ints(values: &[i64]) -> Vec<PyObjectRef> {
     for &value in values {
         let _ = crate::gc_roots::pin_root(w_int_new(value));
     }
-    (0..values.len())
-        .map(|i| crate::gc_roots::shadow_stack_get(root_base + i))
-        .collect()
+    let mut items = Vec::with_capacity(values.len());
+    for i in 0..values.len() {
+        items.push(crate::gc_roots::shadow_stack_get(root_base + i));
+    }
+    items
 }
 
 fn boxed_from_floats(values: &[f64]) -> Vec<PyObjectRef> {
@@ -1153,9 +1155,11 @@ fn boxed_from_floats(values: &[f64]) -> Vec<PyObjectRef> {
     for &value in values {
         let _ = crate::gc_roots::pin_root(w_float_new(value));
     }
-    (0..values.len())
-        .map(|i| crate::gc_roots::shadow_stack_get(root_base + i))
-        .collect()
+    let mut items = Vec::with_capacity(values.len());
+    for i in 0..values.len() {
+        items.push(crate::gc_roots::shadow_stack_get(root_base + i));
+    }
+    items
 }
 
 #[inline]
@@ -1223,9 +1227,7 @@ unsafe fn boxed_from_ascii(obj_slot: usize) -> Vec<PyObjectRef> {
 /// non-numeric element, so its unboxed backing storage is bulk re-boxed into
 /// an Object-strategy items block one time.
 ///
-/// `dont_look_inside`: the transition drives Vec/collect allocation the tracer
-/// cannot model — `boxed_from_ints` / `boxed_from_floats` build a fresh
-/// `Vec<PyObjectRef>` via `.map(...).collect()`, and
+/// `dont_look_inside`: the transition drives bulk backing-storage replacement;
 /// `set_object_items_from_vec` / `IntArray::from_vec` / `FloatArray::from_vec`
 /// tear down the typed storage through raw-Vec construction. Residualize the
 /// whole cold transition via the registered fnaddr so the hot append/setitem

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -3191,9 +3191,11 @@ unsafe fn temporarily_as_objects(list: &W_ListObject) -> Vec<PyObjectRef> {
             for &v in items {
                 let _ = crate::gc_roots::pin_root(w_int_new(v));
             }
-            (0..items.len())
-                .map(|i| crate::gc_roots::shadow_stack_get(root_base + i))
-                .collect()
+            let mut objects = Vec::with_capacity(items.len());
+            for i in 0..items.len() {
+                objects.push(crate::gc_roots::shadow_stack_get(root_base + i));
+            }
+            objects
         }
         ListStrategy::IntOrFloat => boxed_from_int_or_float(list.int_items.as_slice()),
         ListStrategy::Float => {
@@ -3203,9 +3205,11 @@ unsafe fn temporarily_as_objects(list: &W_ListObject) -> Vec<PyObjectRef> {
             for &v in items {
                 let _ = crate::gc_roots::pin_root(w_float_new(v));
             }
-            (0..items.len())
-                .map(|i| crate::gc_roots::shadow_stack_get(root_base + i))
-                .collect()
+            let mut objects = Vec::with_capacity(items.len());
+            for i in 0..items.len() {
+                objects.push(crate::gc_roots::shadow_stack_get(root_base + i));
+            }
+            objects
         }
         ListStrategy::Bytes => {
             // The wraps allocate, so the list has to be reachable by slot for

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -345,20 +345,6 @@ impl W_ListObject {
         self.allocated = self.resized_allocation(old_size, self.live_len()) as isize;
     }
 
-    /// Borrow a slice over object-strategy items. Must only be called
-    /// when `self.strategy == ListStrategy::Object`.
-    #[inline]
-    unsafe fn object_items_slice(&self) -> &[PyObjectRef] {
-        let base = items_block_items_base(self.items);
-        std::slice::from_raw_parts(base, self.length_relaxed())
-    }
-
-    #[inline]
-    unsafe fn object_items_slice_mut(&mut self) -> &mut [PyObjectRef] {
-        let base = items_block_items_base(self.items);
-        std::slice::from_raw_parts_mut(base, self.length_relaxed())
-    }
-
     #[inline]
     unsafe fn object_items_capacity(&self) -> usize {
         items_block_capacity(self.items)
@@ -711,7 +697,19 @@ impl W_ListObject {
         // new reference, so it owes the same barrier as the shifts above.
         let obj = list_before_move_barrier(self as *mut W_ListObject as PyObjectRef);
         let this = &mut *(obj as *mut W_ListObject);
-        this.object_items_slice_mut().reverse();
+        // rlist.py:ll_reverse operates on the logical list directly through
+        // ll_getitem_fast / ll_setitem_fast. Keep that shape here instead of
+        // manufacturing a Rust fat slice over the over-allocated items block.
+        let base = items_block_items_base(this.items);
+        let mut i = 0;
+        let mut length_1_i = this.length_relaxed() as isize - 1;
+        while i < length_1_i {
+            let tmp = *base.add(i as usize);
+            *base.add(i as usize) = *base.add(length_1_i as usize);
+            *base.add(length_1_i as usize) = tmp;
+            i += 1;
+            length_1_i -= 1;
+        }
     }
 
     unsafe fn object_drain(&mut self, range: std::ops::Range<usize>) {
@@ -806,7 +804,13 @@ impl W_ListObject {
     }
 
     unsafe fn object_to_vec(&self) -> Vec<PyObjectRef> {
-        self.object_items_slice().to_vec()
+        let base = items_block_items_base(self.items);
+        let length = self.length_relaxed();
+        let mut result = Vec::with_capacity(length);
+        for i in 0..length {
+            result.push(*base.add(i));
+        }
+        result
     }
 
     /// Free the current `items` block and install a freshly allocated
@@ -2229,13 +2233,13 @@ pub unsafe fn w_list_getitem(obj: PyObjectRef, index: i64) -> Option<PyObjectRef
             Some(w_int_new(range_list_item_unchecked(list, idx as usize)))
         }
         ListStrategy::Object => {
-            let items = list.object_items_slice();
-            let len = items.len() as i64;
+            let len = list.length_relaxed() as i64;
             let idx = if index < 0 { index + len } else { index };
             if idx < 0 || idx >= len {
                 return None;
             }
-            Some(items[idx as usize])
+            let base = items_block_items_base(list.items);
+            Some(*base.add(idx as usize))
         }
         ListStrategy::Integer => {
             let len = ll_list_int_length(list) as i64;
@@ -2319,8 +2323,8 @@ pub unsafe fn w_list_setitem(obj: PyObjectRef, index: i64, value: PyObjectRef) -
             let value = prepare_list_ref_store(obj, value);
             let obj = crate::gc_roots::shadow_stack_get(root_base);
             let list = &mut *(obj as *mut W_ListObject);
-            let items = list.object_items_slice_mut();
-            items[idx as usize] = value;
+            let base = items_block_items_base(list.items);
+            *base.add(idx as usize) = value;
             true
         }
         ListStrategy::Integer => {
@@ -3162,10 +3166,7 @@ pub unsafe fn w_list_items_copy_as_vec(obj: PyObjectRef) -> Vec<PyObjectRef> {
 pub unsafe fn w_list_object_items_ptr_len(obj: PyObjectRef) -> Option<(*const PyObjectRef, usize)> {
     let list = &*(obj as *const W_ListObject);
     match list.strategy {
-        ListStrategy::Object => {
-            let items = list.object_items_slice();
-            Some((items.as_ptr(), items.len()))
-        }
+        ListStrategy::Object => Some((items_block_items_base(list.items), list.length_relaxed())),
         _ => None,
     }
 }

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -697,9 +697,16 @@ impl W_ListObject {
         // new reference, so it owes the same barrier as the shifts above.
         let obj = list_before_move_barrier(self as *mut W_ListObject as PyObjectRef);
         let this = &mut *(obj as *mut W_ListObject);
-        // rlist.py:ll_reverse operates on the logical list directly through
-        // ll_getitem_fast / ll_setitem_fast. Keep that shape here instead of
-        // manufacturing a Rust fat slice over the over-allocated items block.
+        // `rlist.py`'s `ll_reverse` operates on the logical list directly
+        // through ll_getitem_fast / ll_setitem_fast. Keep that shape here
+        // instead of manufacturing a Rust fat slice over the over-allocated
+        // items block.
+        //
+        // Its `@jit.look_inside_iff(lambda l: jit.isvirtual(l) and
+        // jit.isconstant(l.ll_length()))` is not carried: pyre has no
+        // `jit.isvirtual` / `jit.isconstant` intrinsic, so the predicate
+        // cannot be spelled — the same gap the four `look_inside_iff` notes
+        // in `dictmultiobject.rs` record.
         let base = items_block_items_base(this.items);
         let mut i = 0;
         let mut length_1_i = this.length_relaxed() as isize - 1;
@@ -1140,6 +1147,25 @@ unsafe fn float_to_int_or_float(list: &mut W_ListObject) -> bool {
     true
 }
 
+/// Wrap an unboxed run into objects, the preallocate-and-index shape
+/// `listobject.py`'s `getitems_copy` uses.
+///
+/// The loop shape matches; the BODY does not. Upstream reuses one wrapper
+/// across a run of consecutive-equal unwrapped values —
+/// `if jit.we_are_jitted() or not self._quick_cmp(item, prevvalue)` guards
+/// the re-wrap, with `_quick_cmp` being `a == b` for `IntegerListStrategy`
+/// and `a is b` for `ObjectListStrategy`. pyre wraps every element, so
+/// `[1000] * 3` promoted out of the integer strategy yields three distinct
+/// objects where upstream's interpreter yields three references to one.
+///
+/// Not ported here because upstream itself gives the reuse up under
+/// `jit.we_are_jitted()`, so the identity is not a stable observable to
+/// match; porting it means carrying `prevvalue`/`_quick_cmp` per strategy.
+/// The two hints on the same function — `getitems_unroll =
+/// jit.unroll_safe(...)` and `getitems_copy = jit.look_inside_iff(lambda
+/// self, w_list: w_list._unrolling_heuristic())(...)` — are likewise absent;
+/// `look_inside_iff` needs `jit.isvirtual`/`isconstant`, which pyre has no
+/// intrinsic for yet.
 fn boxed_from_ints(values: &[i64]) -> Vec<PyObjectRef> {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();

--- a/pyre/pyre-object/src/objectobject.rs
+++ b/pyre/pyre-object/src/objectobject.rs
@@ -95,11 +95,21 @@ pub fn w_instance_new(w_type: PyObjectRef) -> PyObjectRef {
     obj
 }
 
-/// Keep construction at the allocation boundary. RPython's
-/// `instantiate(cls)` exposes the exact `GcStruct` to `rtype_malloc`, which
-/// emits `malloc(STRUCT)` and lets `jtransform.rewrite_op_malloc` select
-/// `new_with_vtable`. Passing an already-built aggregate across this helper
-/// boundary hides the struct and its field stores from that lowering.
+/// Keep construction at the allocation boundary, so the struct and its field
+/// stores stay in one graph for `jtransform.rewrite_op_malloc` to reach.
+///
+/// Upstream's `instantiate(cls)` is NOT typed by `rtype_malloc` (that one is
+/// `@typer_for(lltype.malloc)`); it goes `rtype_instantiate` ->
+/// `rclass.rtype_new_instance` -> `RInstance.new_instance`, which emits the
+/// `malloc` op itself and then stores each field one at a time
+/// (`rclass.py`, `new_instance`: `genop('malloc', ...)` followed by
+/// `self.setfield(vptr, '__class__', ...)` and one `setfield` per default).
+/// This function is not that shape: it still builds a whole
+/// `W_ObjectObject` and `ptr::write`s it into raw bytes obtained from
+/// `try_gc_alloc_stable_raw(id, size)`, which carries no `malloc(STRUCT)`
+/// operand for `heaptracker.get_vtable_for_gcstruct` to read. Converging
+/// means allocating zeroed and storing `ob_type`, `w_class`, `map` and
+/// `storage` individually, in `new_instance`'s order.
 ///
 /// Allocate a `W_ObjectObject` through the GC. The header is stamped
 /// with [`W_OBJECT_OBJECT_GC_TYPE_ID`] so `object_object_custom_trace`

--- a/pyre/pyre-object/src/objectobject.rs
+++ b/pyre/pyre-object/src/objectobject.rs
@@ -88,49 +88,19 @@ pub fn w_instance_new(w_type: PyObjectRef) -> PyObjectRef {
     // keeps the built-in static `PyType` case (e.g. `INT_TYPE`) untouched.
     let _roots = crate::gc_roots::push_roots();
     let w_type = crate::gc_roots::pin_root(w_type);
-    let obj = alloc_instance_object(W_ObjectObject {
-        ob_header: PyObject {
-            ob_type: &INSTANCE_TYPE as *const PyType,
-            w_class: w_type,
-        },
-        // `mapdict.py user_setup` → `_mapdict_init_empty(
-        // w_subtype.terminator)` (`mapdict.py:908-910`): the instance map is
-        // the owning type's terminator from construction, and `storage = None`.
-        //
-        // Reading it here rather than installing it on first attribute access
-        // is what makes `_get_mapdict_map`'s `jit.promote(self.map)` promotable.
-        // A deferred install leaves every fresh instance at zero until the
-        // first access, so the promoted map guard the JIT bakes — recorded
-        // AFTER that install, hence naming the terminator — cannot hold on the
-        // next iteration's fresh instance. It then fails on every pass through
-        // a loop that constructs an object and touches an attribute, and each
-        // failure is a full deopt.
-        //
-        // Zero stays legal: `pyre-object` cannot build a terminator (it lives
-        // in the interpreter's mapdict layer and `pyre-object` must not depend
-        // on it), so a type whose terminator has not been created yet still
-        // gets one from `ensure_mapdict_initialized` on first access — which
-        // also stores it on the type, so every later instance is eager.
-        //
-        // The `is_type` test is what makes reading the field safe: `w_type` is
-        // a `W_TypeObject` on every interpreter path, but the allocator is also
-        // driven with a sentinel that has no type layout behind it, and the
-        // terminator field would be read off whatever that address points at.
-        map: unsafe {
-            if crate::typeobject::is_type(w_type) {
-                crate::typeobject::w_type_get_terminator(w_type) as usize
-            } else {
-                0
-            }
-        },
-        storage: std::ptr::null_mut(),
-    });
+    let obj = alloc_instance_object(w_type);
     // objspace.py `allocate_instance`: types with `hasuserdel` register the
     // fresh instance on `space.finalizer_queue` immediately after allocation.
     crate::gc_hook::maybe_register_finalizer(obj);
     obj
 }
 
+/// Keep construction at the allocation boundary. RPython's
+/// `instantiate(cls)` exposes the exact `GcStruct` to `rtype_malloc`, which
+/// emits `malloc(STRUCT)` and lets `jtransform.rewrite_op_malloc` select
+/// `new_with_vtable`. Passing an already-built aggregate across this helper
+/// boundary hides the struct and its field stores from that lowering.
+///
 /// Allocate a `W_ObjectObject` through the GC. The header is stamped
 /// with [`W_OBJECT_OBJECT_GC_TYPE_ID`] so `object_object_custom_trace`
 /// roots the `storage` value slots and dead instances are reclaimed.
@@ -162,7 +132,37 @@ pub fn w_instance_new(w_type: PyObjectRef) -> PyObjectRef {
 /// unchanged, and every non-microbenchmark fixture moves within noise.
 /// Real convergence needs host-side allocation that may collect, which in
 /// turn needs every allocation site to root the raw pointers it holds.
-fn alloc_instance_object(value: W_ObjectObject) -> PyObjectRef {
+fn alloc_instance_object(w_class: PyObjectRef) -> PyObjectRef {
+    // `mapdict.py user_setup` → `_mapdict_init_empty(
+    // w_subtype.terminator)` (`mapdict.py:908-910`): the instance map is
+    // the owning type's terminator from construction, and `storage = None`.
+    //
+    // Reading it before allocation rather than installing it on first
+    // attribute access is what makes `_get_mapdict_map`'s
+    // `jit.promote(self.map)` promotable. A deferred install leaves every
+    // fresh instance at zero until the first access, so the promoted map guard
+    // the JIT bakes cannot hold on the next iteration's fresh instance.
+    //
+    // Zero stays legal: `pyre-object` cannot build a terminator (it lives in
+    // the interpreter's mapdict layer), so a type whose terminator has not
+    // been created yet gets one on first access. The `is_type` test keeps the
+    // sentinel used by single-crate tests from being dereferenced as a type.
+    let map = unsafe {
+        if crate::typeobject::is_type(w_class) {
+            crate::typeobject::w_type_get_terminator(w_class) as usize
+        } else {
+            0
+        }
+    };
+    let value = W_ObjectObject {
+        ob_header: PyObject {
+            ob_type: &INSTANCE_TYPE as *const PyType,
+            w_class,
+        },
+        map,
+        storage: std::ptr::null_mut(),
+    };
+
     let raw =
         crate::gc_hook::try_gc_alloc_stable_raw(W_OBJECT_OBJECT_GC_TYPE_ID, W_OBJECT_OBJECT_SIZE);
     if !raw.is_null() {

--- a/pyre/pyre-object/src/rutf8.rs
+++ b/pyre/pyre-object/src/rutf8.rs
@@ -195,6 +195,7 @@ pub fn invalid_byte_2_of_4(ch1: u8, ch2: u8) -> bool {
 /// `_check_utf8`'s ones'-complement return and the `CheckError` its caller
 /// raises from it are one `Result` here.  Upstream's `start`/`stop` window is
 /// left out: every pyre caller validates a whole buffer.
+#[majit_macros::elidable]
 pub fn check_utf8(s: &[u8], allow_surrogates: bool) -> Result<i64, CheckError> {
     // RPython's `start`, `stop`, `pos`, and return value are all Signed.
     // Convert only where Rust's slice API requires an unsigned index.
@@ -308,6 +309,7 @@ pub fn wtf8_from_bytes(s: &[u8], allow_surrogates: bool) -> Result<&Wtf8, CheckE
 ///
 /// Counts the bytes that are *not* continuation bytes, which upstream spells as
 /// a signed-char comparison against `-0x40`.
+#[majit_macros::elidable]
 pub fn codepoints_in_utf8(value: &Wtf8, start: usize, end: usize) -> usize {
     let value = value.as_bytes();
     let end = end.min(value.len());
@@ -368,6 +370,7 @@ pub fn create_utf8_index_storage(utf8: &Wtf8, utf8len: usize) -> Utf8IndexStorag
 /// `codepoint_position_at_index` (`rutf8.py`) — the byte offset of code
 /// point `index`, which must not exceed the string's code point count.
 #[inline]
+#[majit_macros::elidable]
 pub fn codepoint_position_at_index(utf8: &Wtf8, storage: &[Utf8LocElem], index: usize) -> usize {
     let elem = &storage[index >> 6];
     let bytepos = elem.baseindex as usize + elem.ofs[(index >> 2) & 0x0F] as usize;
@@ -386,6 +389,7 @@ pub fn codepoint_position_at_index(utf8: &Wtf8, storage: &[Utf8LocElem], index: 
 /// elidable call; both spellings walk to the same byte offset, so this is the
 /// composition of the two.
 #[inline]
+#[majit_macros::elidable]
 pub fn codepoint_at_index(utf8: &Wtf8, storage: &[Utf8LocElem], index: usize) -> i64 {
     codepoint_at_pos(utf8, codepoint_position_at_index(utf8, storage, index))
 }
@@ -397,6 +401,7 @@ pub fn codepoint_at_index(utf8: &Wtf8, storage: &[Utf8LocElem], index: usize) ->
 /// Upstream's leading `if bytepos < 0: return bytepos` guard carries `str.find`
 /// misses through; pyre's search returns `Option`, so the caller handles a miss
 /// and this takes an offset that is always real.
+#[majit_macros::elidable]
 pub fn codepoint_index_at_byte_position(
     utf8: &Wtf8,
     storage: &[Utf8LocElem],

--- a/pyre/pyre-object/src/rutf8.rs
+++ b/pyre/pyre-object/src/rutf8.rs
@@ -53,7 +53,7 @@
 //! `not jit.we_are_jitted()`) is left out: it computes the same value as the
 //! comparison ladder it sits in front of.
 
-use rustpython_wtf8::{CodePoint, Wtf8};
+use rustpython_wtf8::Wtf8;
 
 /// `UTF8_INDEX_STORAGE`'s element (`rutf8.py`) — `baseindex` is the
 /// byte offset the 64-code-point group starts at, and `ofs[i]` the byte delta
@@ -114,14 +114,27 @@ pub fn prev_codepoint_pos(code: &Wtf8, pos: usize) -> usize {
 /// `codepoint_at_pos` (`rutf8.py`) — the code point starting at byte `pos`.
 ///
 /// Assumes valid WTF-8 with `pos` on a boundary before the end, as upstream
-/// does ("no checking!").  The decode itself goes through the crate rather than
-/// a second copy of its bit arithmetic.
+/// does ("no checking!"). Returns RPython's signed integer code point and
+/// keeps the upstream bit arithmetic literal so the JIT sees the same graph.
 #[inline]
-pub fn codepoint_at_pos(code: &Wtf8, pos: usize) -> CodePoint {
-    let end = next_codepoint_pos(code, pos);
-    code.get(pos..end)
-        .and_then(|one| one.code_points().next())
-        .expect("codepoint_at_pos: pos is not a code point boundary")
+pub fn codepoint_at_pos(code: &Wtf8, pos: usize) -> i64 {
+    let code = code.as_bytes();
+    let len = code.len();
+    let ordch1 = code[pos] as i64;
+    if ordch1 <= 0x7f || pos + 1 >= len {
+        return ordch1;
+    }
+    let ordch2 = code[pos + 1] as i64;
+    if ordch1 <= 0xdf || pos + 2 >= len {
+        return (ordch1 << 6) + ordch2 - ((0xc0 << 6) + 0x80);
+    }
+    let ordch3 = code[pos + 2] as i64;
+    if ordch1 <= 0xef || pos + 3 >= len {
+        return (ordch1 << 12) + (ordch2 << 6) + ordch3 - ((0xe0 << 12) + (0x80 << 6) + 0x80);
+    }
+    let ordch4 = code[pos + 3] as i64;
+    (ordch1 << 18) + (ordch2 << 12) + (ordch3 << 6) + ordch4
+        - ((0xf0 << 18) + (0x80 << 12) + (0x80 << 6) + 0x80)
 }
 
 /// `codepoint_before_pos` (`rutf8.py`) — the code point immediately before
@@ -132,14 +145,16 @@ pub fn codepoint_at_pos(code: &Wtf8, pos: usize) -> CodePoint {
 /// code point by construction, and inherits `prev_codepoint_pos`'s handling of
 /// a `pos` one past the end.
 #[inline]
-pub fn codepoint_before_pos(code: &Wtf8, pos: usize) -> CodePoint {
+pub fn codepoint_before_pos(code: &Wtf8, pos: usize) -> i64 {
     codepoint_at_pos(code, prev_codepoint_pos(code, pos))
 }
 
 /// `CheckError` (`rutf8.py`) — the byte position `check_utf8` stopped at.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CheckError {
-    pub pos: usize,
+    /// RPython `CheckError.pos` is a normal Signed integer. Keep the stored
+    /// field signed; convert only at Rust slice-index API boundaries.
+    pub pos: i64,
 }
 
 /// `_invalid_cont_byte` (`rutf8.py`) — a byte outside `0x80..=0xBF`, which
@@ -180,12 +195,14 @@ pub fn invalid_byte_2_of_4(ch1: u8, ch2: u8) -> bool {
 /// `_check_utf8`'s ones'-complement return and the `CheckError` its caller
 /// raises from it are one `Result` here.  Upstream's `start`/`stop` window is
 /// left out: every pyre caller validates a whole buffer.
-pub fn check_utf8(s: &[u8], allow_surrogates: bool) -> Result<usize, CheckError> {
-    let end = s.len();
-    let mut pos = 0;
-    let mut continuation_bytes = 0;
+pub fn check_utf8(s: &[u8], allow_surrogates: bool) -> Result<i64, CheckError> {
+    // RPython's `start`, `stop`, `pos`, and return value are all Signed.
+    // Convert only where Rust's slice API requires an unsigned index.
+    let end = s.len() as i64;
+    let mut pos = 0i64;
+    let mut continuation_bytes = 0i64;
     while pos < end {
-        let ordch1 = s[pos];
+        let ordch1 = s[pos as usize];
         pos += 1;
         // fast path for ASCII
         if ordch1 <= 0x7F {
@@ -198,7 +215,7 @@ pub fn check_utf8(s: &[u8], allow_surrogates: bool) -> Result<usize, CheckError>
             if pos >= end {
                 return Err(CheckError { pos: pos - 1 });
             }
-            let ordch2 = s[pos];
+            let ordch2 = s[pos as usize];
             pos += 1;
             if invalid_cont_byte(ordch2) {
                 return Err(CheckError { pos: pos - 2 });
@@ -210,8 +227,8 @@ pub fn check_utf8(s: &[u8], allow_surrogates: bool) -> Result<usize, CheckError>
             if pos + 2 > end {
                 return Err(CheckError { pos: pos - 1 });
             }
-            let ordch2 = s[pos];
-            let ordch3 = s[pos + 1];
+            let ordch2 = s[pos as usize];
+            let ordch3 = s[(pos + 1) as usize];
             pos += 2;
             if invalid_byte_2_of_3(ordch1, ordch2, allow_surrogates) || invalid_cont_byte(ordch3) {
                 return Err(CheckError { pos: pos - 3 });
@@ -223,9 +240,9 @@ pub fn check_utf8(s: &[u8], allow_surrogates: bool) -> Result<usize, CheckError>
             if pos + 3 > end {
                 return Err(CheckError { pos: pos - 1 });
             }
-            let ordch2 = s[pos];
-            let ordch3 = s[pos + 1];
-            let ordch4 = s[pos + 2];
+            let ordch2 = s[pos as usize];
+            let ordch3 = s[(pos + 1) as usize];
+            let ordch4 = s[(pos + 2) as usize];
             pos += 3;
             if invalid_byte_2_of_4(ordch1, ordch2)
                 || invalid_cont_byte(ordch3)
@@ -266,7 +283,7 @@ pub fn wtf8_from_bytes(s: &[u8], allow_surrogates: bool) -> Result<&Wtf8, CheckE
         return match std::str::from_utf8(s) {
             Ok(valid) => Ok(Wtf8::new(valid)),
             Err(error) => Err(CheckError {
-                pos: error.valid_up_to(),
+                pos: error.valid_up_to() as i64,
             }),
         };
     }
@@ -278,7 +295,7 @@ pub fn wtf8_from_bytes(s: &[u8], allow_surrogates: bool) -> Result<&Wtf8, CheckE
         // may follow before the scan resumes.
         match s[pos..] {
             [0xED, 0xA0..=0xBF, 0x80..=0xBF, ..] => pos += 3,
-            _ => return Err(CheckError { pos }),
+            _ => return Err(CheckError { pos: pos as i64 }),
         }
     }
     // SAFETY: every sequence in `s` is well formed, and admitting the
@@ -369,7 +386,7 @@ pub fn codepoint_position_at_index(utf8: &Wtf8, storage: &[Utf8LocElem], index: 
 /// elidable call; both spellings walk to the same byte offset, so this is the
 /// composition of the two.
 #[inline]
-pub fn codepoint_at_index(utf8: &Wtf8, storage: &[Utf8LocElem], index: usize) -> CodePoint {
+pub fn codepoint_at_index(utf8: &Wtf8, storage: &[Utf8LocElem], index: usize) -> i64 {
     codepoint_at_pos(utf8, codepoint_position_at_index(utf8, storage, index))
 }
 
@@ -446,7 +463,7 @@ pub fn codepoint_index_at_byte_position(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustpython_wtf8::Wtf8Buf;
+    use rustpython_wtf8::{CodePoint, Wtf8Buf};
 
     #[test]
     fn check_utf8_counts_code_points() {
@@ -567,11 +584,12 @@ mod tests {
         // walks to, which is the disagreement the whole check exists to stop.
         let buf = Wtf8Buf::from_string("a\u{e9}\u{4e2d}\u{10000}".repeat(40));
         let len = check_utf8(buf.as_bytes(), true).unwrap();
-        assert_eq!(len, buf.code_points().count());
+        assert_eq!(len, buf.code_points().count() as i64);
+        let len = len as usize;
         let storage = create_utf8_index_storage(&buf, len);
         assert_eq!(
             codepoint_at_index(&buf, &storage, len - 1),
-            buf.code_points().last().unwrap()
+            buf.code_points().last().unwrap().to_u32() as i64
         );
     }
 
@@ -672,8 +690,8 @@ mod tests {
                 let storage = create_utf8_index_storage(&buf, expected.len());
                 for (index, &cp) in expected.iter().enumerate() {
                     assert_eq!(
-                        codepoint_at_index(&buf, &storage, index).to_u32(),
-                        cp.to_u32(),
+                        codepoint_at_index(&buf, &storage, index),
+                        cp.to_u32() as i64,
                         "{kind} * {repeat}, index {index}",
                     );
                 }

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -1211,7 +1211,11 @@ pub unsafe fn w_set_key_at(
 pub unsafe fn w_set_items(obj: PyObjectRef) -> Vec<PyObjectRef> {
     let _set_guard = w_set_lock(obj);
     let s = &*(obj as *const W_SetObject);
-    (*s.items).keys().map(|key| key.obj).collect()
+    let mut items = Vec::with_capacity((*s.items).len());
+    for key in (*s.items).keys() {
+        items.push(key.obj);
+    }
+    items
 }
 
 /// Walk, in place, every element `PyObjectRef` slot of a set for GC root

--- a/pyre/pyre-object/src/slots.rs
+++ b/pyre/pyre-object/src/slots.rs
@@ -1,30 +1,18 @@
 //! Shared `__slots__` storage helpers for native subclasses (float, complex).
 //!
 //! Each host object stores its `__slots__` values in a list held by a
-//! `w_slots: PyObjectRef` field.  Callers pass an accessor that yields that
-//! field's address from the object pointer, so a single implementation serves
-//! every layout without duplicating the GC-rooting dance.
+//! `w_slots: PyObjectRef` field. Reads and deletes take that storage value
+//! directly, like mapdict's `getslotvalue`. Growing writes use a compile-time
+//! expansion so each concrete layout reloads its own field after a GC move;
+//! no runtime function-pointer dispatch exists in the translated graph.
 
 use crate::pyobject::*;
-
-/// Field accessor: given an object pointer, return the address of its
-/// `w_slots` field.
-///
-/// # Safety
-/// The accessor is called only with a pointer to the concrete host struct it
-/// was written for.
-pub type SlotsField = unsafe fn(PyObjectRef) -> *mut PyObjectRef;
 
 /// Read slot `index`, or `None` when unset (null list or null entry).
 ///
 /// # Safety
-/// `obj` must be a valid pointer to the host struct `slots_field` targets.
-pub unsafe fn slot_get(
-    obj: PyObjectRef,
-    index: usize,
-    slots_field: SlotsField,
-) -> Option<PyObjectRef> {
-    let slots = unsafe { *slots_field(obj) };
+/// `slots` must be null or a valid slot-storage list.
+pub unsafe fn slot_get(slots: PyObjectRef, index: usize) -> Option<PyObjectRef> {
     if slots.is_null() {
         return None;
     }
@@ -32,54 +20,54 @@ pub unsafe fn slot_get(
         .filter(|value| !value.is_null())
 }
 
-/// Store `value` into slot `index`, growing (or creating) the backing list as
-/// needed.  Creating or growing the list allocates, and `w_list_new` /
-/// `w_list_append` are GC safepoints that can relocate `obj`, `value`, and the
-/// list itself, so pin them and reload the receiver after every allocation
-/// before storing through it.
+/// Expand mapdict-style slot storage into a concrete host layout.
 ///
-/// # Safety
-/// `obj` must be a valid pointer to the host struct `slots_field` targets.
-pub unsafe fn slot_set(
-    obj: PyObjectRef,
-    index: usize,
-    value: PyObjectRef,
-    slots_field: SlotsField,
-) {
-    let slots = unsafe { *slots_field(obj) };
-    if !slots.is_null() && unsafe { crate::listobject::w_list_len(slots) } > index {
-        unsafe { crate::listobject::w_list_setitem(slots, index as i64, value) };
-        return;
-    }
-    let _roots = crate::gc_roots::push_roots();
-    let root_base = crate::gc_roots::shadow_stack_len();
-    let _ = crate::gc_roots::pin_root(obj);
-    let _ = crate::gc_roots::pin_root(value);
-    if slots.is_null() {
-        let new_slots = crate::listobject::w_list_new(vec![PY_NULL; index + 1]);
-        let obj = crate::gc_roots::shadow_stack_get(root_base);
-        unsafe { *slots_field(obj) = new_slots };
-        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
-    } else {
-        let mut slots = slots;
-        while unsafe { crate::listobject::w_list_len(slots) } <= index {
-            unsafe { crate::listobject::w_list_append(slots, PY_NULL) };
-            let obj = crate::gc_roots::shadow_stack_get(root_base);
-            slots = unsafe { *slots_field(obj) };
+/// PyPy's `BaseUserClassMapdict` implementation accesses one known storage
+/// field directly. Pyre currently has several native host layouts carrying
+/// that field, so a Rust function-pointer accessor would add an indirect call
+/// absent upstream. This macro is the static equivalent of the common base
+/// method: after expansion Charon sees only direct `$field` reads/writes on
+/// `$ty`, including the required reload after each allocating list grow.
+#[macro_export]
+macro_rules! slot_set_direct {
+    ($obj:expr, $index:expr, $value:expr, $ty:ty, $field:ident) => {{
+        let obj = $obj;
+        let index = $index;
+        let value = $value;
+        let slots = unsafe { (*(obj as *const $ty)).$field };
+        if !slots.is_null() && unsafe { $crate::listobject::w_list_len(slots) } > index {
+            unsafe { $crate::listobject::w_list_setitem(slots, index as i64, value) };
+        } else {
+            let _roots = $crate::gc_roots::push_roots();
+            let root_base = $crate::gc_roots::shadow_stack_len();
+            let _ = $crate::gc_roots::pin_root(obj);
+            let _ = $crate::gc_roots::pin_root(value);
+            if slots.is_null() {
+                let new_slots = $crate::listobject::w_list_new(vec![$crate::PY_NULL; index + 1]);
+                let obj = $crate::gc_roots::shadow_stack_get(root_base);
+                unsafe { (*(obj as *mut $ty)).$field = new_slots };
+                $crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+            } else {
+                let mut slots = slots;
+                while unsafe { $crate::listobject::w_list_len(slots) } <= index {
+                    unsafe { $crate::listobject::w_list_append(slots, $crate::PY_NULL) };
+                    let obj = $crate::gc_roots::shadow_stack_get(root_base);
+                    slots = unsafe { (*(obj as *const $ty)).$field };
+                }
+            }
+            let obj = $crate::gc_roots::shadow_stack_get(root_base);
+            let slots = unsafe { (*(obj as *const $ty)).$field };
+            let value = $crate::gc_roots::shadow_stack_get(root_base + 1);
+            unsafe { $crate::listobject::w_list_setitem(slots, index as i64, value) };
         }
-    }
-    let obj = crate::gc_roots::shadow_stack_get(root_base);
-    let slots = unsafe { *slots_field(obj) };
-    let value = crate::gc_roots::shadow_stack_get(root_base + 1);
-    unsafe { crate::listobject::w_list_setitem(slots, index as i64, value) };
+    }};
 }
 
 /// Clear slot `index`, returning whether it held a value beforehand.
 ///
 /// # Safety
-/// `obj` must be a valid pointer to the host struct `slots_field` targets.
-pub unsafe fn slot_del(obj: PyObjectRef, index: usize, slots_field: SlotsField) -> bool {
-    let slots = unsafe { *slots_field(obj) };
+/// `slots` must be null or a valid slot-storage list.
+pub unsafe fn slot_del(slots: PyObjectRef, index: usize) -> bool {
     if slots.is_null() || unsafe { crate::listobject::w_list_len(slots) } <= index {
         return false;
     }

--- a/pyre/pyre-object/src/slots.rs
+++ b/pyre/pyre-object/src/slots.rs
@@ -2,9 +2,20 @@
 //!
 //! Each host object stores its `__slots__` values in a list held by a
 //! `w_slots: PyObjectRef` field. Reads and deletes take that storage value
-//! directly, like mapdict's `getslotvalue`. Growing writes use a compile-time
-//! expansion so each concrete layout reloads its own field after a GC move;
-//! no runtime function-pointer dispatch exists in the translated graph.
+//! directly, the way `mapdict.py`'s `MapdictStorageMixin._mapdict_read_storage`
+//! does (`return self.storage[storageindex]`) — NOT the way
+//! `BaseUserClassMapdict.getslotvalue` does, which reaches the value through
+//! the promoted map with `attrkind = SLOTS_STARTING_FROM + slotindex`.
+//! Growing writes use a compile-time expansion so each concrete layout
+//! reloads its own field after a GC move; no runtime function-pointer
+//! dispatch exists in the translated graph.
+//!
+//! PRE-EXISTING-ADAPTATION: the storage OWNER differs from upstream. pyre
+//! indexes a `w_slots` list by slot index and [`slot_del`] writes `PY_NULL`
+//! into it; `mapdict.py`'s `delslotvalue` deletes the attribute from the map
+//! and installs a new storage+map pair. Nothing here is the mapdict
+//! attribute machinery, so read the citations above as naming the shape of
+//! one read, not as a claim of mapdict parity.
 
 use crate::pyobject::*;
 
@@ -22,12 +33,16 @@ pub unsafe fn slot_get(slots: PyObjectRef, index: usize) -> Option<PyObjectRef> 
 
 /// Expand mapdict-style slot storage into a concrete host layout.
 ///
-/// PyPy's `BaseUserClassMapdict` implementation accesses one known storage
-/// field directly. Pyre currently has several native host layouts carrying
-/// that field, so a Rust function-pointer accessor would add an indirect call
-/// absent upstream. This macro is the static equivalent of the common base
-/// method: after expansion Charon sees only direct `$field` reads/writes on
-/// `$ty`, including the required reload after each allocating list grow.
+/// Upstream copies the storage accessors INTO each concrete class at
+/// translation time — `mapdict.py` spells it
+/// `objectmodel.import_from_mixin(MapdictStorageMixin)` plus
+/// `_share_methods(BaseUserClassMapdict, Object)` — so every class ends up
+/// with its own direct `self.storage[...]` access and no dispatch. Pyre has
+/// several native host layouts carrying the field, and a Rust
+/// function-pointer accessor would add an indirect call upstream does not
+/// have. This macro is that same translation-time method copy: after
+/// expansion Charon sees only direct `$field` reads/writes on `$ty`,
+/// including the required reload after each allocating list grow.
 #[macro_export]
 macro_rules! slot_set_direct {
     ($obj:expr, $index:expr, $value:expr, $ty:ty, $field:ident) => {{

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -946,13 +946,16 @@ unsafe fn hash_slot<'a>(obj: PyObjectRef) -> &'a std::sync::atomic::AtomicI64 {
 }
 
 /// Publish a computed digest into the memo slot, `rstr.py:411-412`.  Upstream
-/// reaches the field through `conditional_call_elidable`, which likewise
-/// tolerates a repeated computation; [`hash_slot`] carries why a racing
-/// repeat is harmless here.
+/// performs that write inside `LLHelpers._ll_strhash`, whose decorators are
+/// `@dont_inline` and `@jit.dont_look_inside`; the Rust atomic store is the
+/// corresponding foreign-opaque implementation boundary.  The surrounding
+/// memo read and branch remain visible, while [`hash_slot`] carries why a
+/// racing repeat is harmless here.
 ///
 /// # Safety
 /// `obj` must be a `W_UnicodeObject`.
 #[inline]
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_str_set_hash(obj: PyObjectRef, hash: i64) {
     unsafe { hash_slot(obj) }.store(hash, std::sync::atomic::Ordering::Relaxed);
 }

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -906,9 +906,14 @@ pub unsafe fn w_str_eq_w(obj: PyObjectRef, w_other: PyObjectRef) -> bool {
     }
 }
 
-/// `rstr.py ll_strhash` — the memoized digest, or zero while it has
-/// not been computed yet ("our malloc initializes the memory to zero, so we
-/// use zero as the value of a string whose hash is not computed yet").
+/// The memoized digest, or zero while it has not been computed yet.
+///
+/// The slot caches the PYTHON-VISIBLE `hash()` — `builtins::hash_value` writes
+/// `_hash_unicode` here and returns it — so this is CPython's `unicode_hash`
+/// cache, not RPython's `STR.hash`. `ll_strhash` (`rstr.py`) is the right
+/// analogue for the SHAPE ("read the memo, compute while it reads zero", and
+/// zero because the allocation is born zeroed), but not for the VALUE: see
+/// [`w_str_set_hash`] for why `_ll_strhash`'s sentinel is deliberately absent.
 ///
 /// # Safety
 /// `obj` must be a `W_UnicodeObject`.
@@ -939,12 +944,23 @@ unsafe fn hash_slot<'a>(obj: PyObjectRef) -> &'a std::sync::atomic::AtomicI64 {
     }
 }
 
-/// Publish a computed digest into the memo slot, `rstr.py:411-412`.  Upstream
-/// performs that write inside `LLHelpers._ll_strhash`, whose decorators are
-/// `@dont_inline` and `@jit.dont_look_inside`; the Rust atomic store is the
-/// corresponding foreign-opaque implementation boundary.  The surrounding
-/// memo read and branch remain visible, while [`hash_slot`] carries why a
-/// racing repeat is harmless here.
+/// Publish a computed digest into the memo slot.  Upstream performs the
+/// corresponding write inside `LLHelpers._ll_strhash` (`rstr.py`), whose
+/// decorators are `@dont_inline` and `@jit.dont_look_inside`; the Rust atomic
+/// store is the corresponding foreign-opaque implementation boundary.  The
+/// surrounding memo read and branch remain visible, while [`hash_slot`]
+/// carries why a racing repeat is harmless here.
+///
+/// `_ll_strhash`'s neighbouring `if x == 0: x = 29872897` is NOT ported, and
+/// must not be.  Upstream substitutes because `STR.hash` is an internal
+/// digest nobody observes, so a real zero can be replaced to keep zero
+/// meaning "not computed". This slot holds the Python-level `hash()`, and
+/// `hash("")` is 0 in CPython 3.14; substituting would make it 29872897.
+/// The cost of keeping CPython's value is that `""` re-hashes on every
+/// lookup — the answer is the same, so this is a missed memo, not a wrong
+/// one. CPython avoids both by sentinelling on `-1` and remapping a computed
+/// `-1` to `-2`; adopting that is the convergence path, and it would move
+/// every reader that currently spells the sentinel `0`.
 ///
 /// # Safety
 /// `obj` must be a `W_UnicodeObject`.
@@ -954,18 +970,23 @@ pub unsafe fn w_str_set_hash(obj: PyObjectRef, hash: i64) {
     unsafe { hash_slot(obj) }.store(hash, std::sync::atomic::Ordering::Relaxed);
 }
 
-/// `rstr.py ll_strhash` — read the memo, and compute the digest only
-/// while the slot still reads zero:
+/// Read the memo, and compute the digest only while the slot still reads
+/// zero.  `rstr.py`'s `ll_strhash` is the same shape:
 ///
 /// ```python
 /// def ll_strhash(s):
-///     if not s:
+///     if s:
+///         return jit.conditional_call_elidable(s.hash,
+///                                              LLHelpers._ll_strhash, s)
+///     else:
 ///         return 0
-///     x = s.hash
-///     if x == 0:
-///         x = LLHelpers._ll_strhash(s)
-///     return x
 /// ```
+///
+/// The branch here is an ordinary one; upstream spells it as
+/// `jit.conditional_call_elidable`, which pyre has no equivalent of yet, so
+/// the JIT sees a plain memo read and call rather than the elidable
+/// conditional.  See [`w_str_set_hash`] for why the value written differs
+/// from `_ll_strhash`'s.
 ///
 /// The digest is the one [`crate::dict_eq_hook::try_hash_str`] produces, so a
 /// key hashed here lands in the bucket a borrowed-`&str` probe would have

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -589,7 +589,8 @@ pub fn w_str_subclass_from_wtf8(value: Wtf8Buf, w_class: PyObjectRef) -> PyObjec
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_str_slot_get(obj: PyObjectRef, index: usize) -> Option<PyObjectRef> {
-    unsafe { crate::slots::slot_get(obj, index, str_slots_field) }
+    let slots = unsafe { (*(obj as *const W_UnicodeObject)).w_slots };
+    unsafe { crate::slots::slot_get(slots, index) }
 }
 
 /// Write one app-level `__slots__` entry on a `str` subclass.
@@ -597,7 +598,7 @@ pub unsafe fn w_str_slot_get(obj: PyObjectRef, index: usize) -> Option<PyObjectR
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_str_slot_set(obj: PyObjectRef, index: usize, value: PyObjectRef) {
-    unsafe { crate::slots::slot_set(obj, index, value, str_slots_field) }
+    crate::slot_set_direct!(obj, index, value, W_UnicodeObject, w_slots)
 }
 
 /// Clear one app-level `__slots__` entry on a `str` subclass.
@@ -605,15 +606,8 @@ pub unsafe fn w_str_slot_set(obj: PyObjectRef, index: usize, value: PyObjectRef)
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_str_slot_del(obj: PyObjectRef, index: usize) -> bool {
-    unsafe { crate::slots::slot_del(obj, index, str_slots_field) }
-}
-
-/// Address of `W_UnicodeObject::w_slots` for the shared slot helpers.
-///
-/// # Safety
-/// `obj` must point to a valid `W_UnicodeObject`.
-unsafe fn str_slots_field(obj: PyObjectRef) -> *mut PyObjectRef {
-    unsafe { &mut (*(obj as *mut W_UnicodeObject)).w_slots }
+    let slots = unsafe { (*(obj as *const W_UnicodeObject)).w_slots };
+    unsafe { crate::slots::slot_del(slots, index) }
 }
 
 /// FNV-1a over the key bytes, the digest the type-lookup method cache already

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -1158,7 +1158,9 @@ pub unsafe fn w_str_codepoint_at(obj: PyObjectRef, index: usize) -> Option<CodeP
                 .and_then(|one| one.code_points().next());
         }
         let storage = w_str_get_index_storage(obj);
-        Some(crate::rutf8::codepoint_at_index(value, &*storage, index))
+        Some(CodePoint::from_u32_unchecked(
+            crate::rutf8::codepoint_at_index(value, &*storage, index) as u32,
+        ))
     }
 }
 

--- a/pyre/pyre-object/src/weakref.rs
+++ b/pyre/pyre-object/src/weakref.rs
@@ -166,33 +166,27 @@ pub unsafe fn w_weakref_object_set_hash(obj: PyObjectRef, value: PyObjectRef) {
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
-/// Address of `W_Weakref::w_slots` for the shared slot helpers.
-///
-/// # Safety
-/// `obj` must point to a valid `W_Weakref`.
-unsafe fn weakref_slots_field(obj: PyObjectRef) -> *mut PyObjectRef {
-    unsafe { &mut (*(obj as *mut W_Weakref)).w_slots }
-}
-
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_weakref_object_slot_get(obj: PyObjectRef, index: usize) -> Option<PyObjectRef> {
-    unsafe { crate::slots::slot_get(obj, index, weakref_slots_field) }
+    let slots = unsafe { (*(obj as *const W_Weakref)).w_slots };
+    unsafe { crate::slots::slot_get(slots, index) }
 }
 
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_weakref_object_slot_set(obj: PyObjectRef, index: usize, value: PyObjectRef) {
-    unsafe { crate::slots::slot_set(obj, index, value, weakref_slots_field) }
+    crate::slot_set_direct!(obj, index, value, W_Weakref, w_slots)
 }
 
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_weakref_object_slot_del(obj: PyObjectRef, index: usize) -> bool {
-    unsafe { crate::slots::slot_del(obj, index, weakref_slots_field) }
+    let slots = unsafe { (*(obj as *const W_Weakref)).w_slots };
+    unsafe { crate::slots::slot_del(slots, index) }
 }
 
 /// GC type id for the WEAKREF GcStruct. Registered by


### PR DESCRIPTION
## Summary

This draft advances #346 by replacing Rust-shaped producer and identity paths with the PyPy/RPython shapes expected by the ordinary annotator and rtyper.

- preserve signed, nullable-object, typed-pointer, slice, list-element, GCREF, and frame-value representations instead of widening the annotation lattice
- lower iterator, checked-conversion, slice indexing, atomic pointer view, numeric hash, and string/WTF-8 mechanics into corresponding RPython operations
- restore PyPy ownership and materialization shapes for strings, lists, repr builders, locks, queues, and deques
- keep exception/result closure lowering compatible with the embedder-supplied ErrorCarrierSpec
- preserve class identity in unique trait-impl discovery and compare virtual field slots by RPython descriptor identity
- recognize TypedItemsBlock and scalar IntArray/FloatArray adapters as RPython typed GC arrays
- recognize BytesArray/UnicodeArray storage as a logical string list whose physical item representation is GcArray(GCREF)
- carry GC root-stack parameters and results as llmemory.GCREF, with ordinary cast_opaque_ptr conversion back to StringRepr or InstanceRepr

The newest slice closes the two remaining BytesArray/UnicodeArray `remove` failures. The MIR adapter now reconstructs Rust's overlap-safe `ptr::copy` as the exact four-argument RPython `rgc.ll_arraymove(array, source_start, dest_start, length)` operation, uses the upstream forward-copy direction for `ll_delitem_nonneg`'s left shift, and clears the released tail slot through the same GcArray(GCREF). The match is restricted to the two proven remove graphs, so unrelated raw pointer copies retain their Rust semantics.

## Why

The recurring failures are producer-shape and identity defects. Rust iterators, range indexing, usize, eager error formatting, inline Rust aggregate layouts, and erased typed-storage pointers survived into graphs whose RPython counterparts carry signed indices, ord(s[i]), one-word GC references, typed GC arrays, or lazy exception objects.

These fixes keep the PyPy/RPython ownership and lowering shapes. They do not add blanket generic-ClassDef splitting, permissive union rules, TLS ownership, per-box side tables, or a shared portal-frame anchor.

## Validation

- `cargo fmt --all -- --check` and `git diff --check` passed
- real-LLBC `unwrapped_array_pushes_lower_to_rpython_gcarray_writes` passed, including BytesArray/UnicodeArray `as_slice`, `pop`, and `remove`
- verbose prepass census: phase-A 1626, phase-B 0; phase-A was 1632 before the string-list slices
- `cargo check --all --features dynasm` passed
- `cargo test --all --features dynasm` passed
- release dynasm benchmark suite passed 10/10
- after the final main rebase, the clean seven-file patch passed `cargo check -p majit-translate` and the real-LLBC remove regression again
- the source change is translator-only; stale baseline LLBC artefacts were re-extracted for validation and were not committed
- branch was published with `--force-with-lease`

## Remaining work

This is a validated intermediate slice, not the terminal #346 cutover. The remaining string-list cluster is `install` and `with_capacity`: install needs field-level list storage replacement, and with_capacity still reaches the allocation-hook wall. Failed phase-A subjects still take the existing skip fallback, so terminal skip/divergence zero criteria have not been claimed. The wider remaining phase-A subjects, legacy walker deletion, and terminal fixed-corpus zero-count criteria remain follow-up work under #346.

Refs #346.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved translation support for list sizing hints, array moves, slicing, floating-point and complex-number formatting, and option/result handling.
  * Added support for unsigned integer constants and broader pointer and type conversions.
  * Improved compatibility with Python string, Unicode, hashing, and complex-number behaviors.
* **Bug Fixes**
  * Fixed field identity handling across naming aliases and preserved subclass attributes during type merging.
  * Improved exception reporting, Unicode error positions, deque mutation detection, and call argument handling.
* **Diagnostics**
  * Added an optional frontier gate that reports all unresolved call boundaries during translation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->