### PR TITLE
jit, interp: split the portal's resume entry from its activation entry, and keep the CALL_ASSEMBLER enter off a virtual ref

### DIFF
--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1451,6 +1451,14 @@ impl TraceCtx {
         virtual_obj: OpRef,
         virtual_obj_ptr: usize,
     ) -> (OpRef, *mut u8) {
+        // virtualref.py `virtual_ref_during_tracing(real_object)` starts with
+        // `assert real_object`: the tracing-time vref exists to name a live
+        // object, and one built over a null would carry a null `forced` that
+        // every non-forcing reader resolves as "still virtual".
+        assert_ne!(
+            virtual_obj_ptr, 0,
+            "opimpl_virtual_ref requires the tracing-time real object"
+        );
         // pyjitpl.py:1804 `vref = vrefinfo.virtual_ref_during_tracing(box)`.
         let vref_ptr = self
             .metainterp_sd

--- a/majit/majit-translate/src/memory/gctransform/framework.rs
+++ b/majit/majit-translate/src/memory/gctransform/framework.rs
@@ -174,7 +174,7 @@ pub const PYTHON_DISPATCH_SEEDS: &[&str] = &[
     "call_jit::bh_call_self_recursive_portal",
     "eval::portal_runner",
     "eval::portal_runner_dispatch",
-    "eval::portal_runner_result",
+    "eval::portal_body_result",
     "eval::portal_activation_result",
     "eval::portal_activation_bracketed",
     "eval::enter_portal",

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -156,25 +156,25 @@ pub fn install_current_frame(frame: &mut PyFrame) -> CurrentFrameGuard {
     // owes the same refusal, because the enter is no longer performed only
     // here: `try_walker_call_assembler_self_recursive`
     // (`pyre-jit-trace/src/jitcode_dispatch/inline_call.rs`) records it ahead
-    // of its CALL_ASSEMBLER, and the force and deopt legs hand that same,
-    // already-entered frame back to the portal.  Already entered means there
-    // is nothing to link; the guard still has to restore what `leave` would,
-    // which is this frame's own `f_backref`.
-    let already_entered = !ec.is_null()
-        && std::ptr::eq(
+    // of its CALL_ASSEMBLER, and the force and deopt legs can hand that same,
+    // already-entered frame to a portal helper.  Already entered means this
+    // guard owns neither the link nor its matching restore; the surrounding
+    // `ExecutionContext.enter`/`leave` scope owns both.
+    let enters_chain = !ec.is_null()
+        && !std::ptr::eq(
             crate::executioncontext::vref_referent(unsafe { (*ec).topframeref }),
             frame as *mut PyFrame,
         );
-    let previous_ec_top = match (ec.is_null(), already_entered) {
-        (true, _) => std::ptr::null_mut(),
-        (false, true) => frame.f_backref,
-        (false, false) => unsafe {
+    let previous_ec_top = if enters_chain {
+        unsafe {
             let top = (*ec).topframeref;
             (*ec).topframeref = frame as *mut PyFrame;
             top
-        },
+        }
+    } else {
+        std::ptr::null_mut()
     };
-    if !already_entered {
+    if enters_chain || ec.is_null() {
         // Barrier for the same reason as `ExecutionContext::enter`: this is a
         // traced `Type::Ref` store and `frame` can be an old-generation frame
         // taking a young predecessor.
@@ -190,7 +190,19 @@ pub fn install_current_frame(frame: &mut PyFrame) -> CurrentFrameGuard {
             previous_ec_top
         };
     }
-    push_current_frame_previous_root(previous, ec, previous_ec_top)
+    // A guard that did not write the execution-context chain owns no restore
+    // either.  The surrounding `ExecutionContext.enter`/`leave` pair keeps
+    // ownership of an already-entered frame; restoring its predecessor here
+    // would unlink the live outer activation when this guard is dropped.
+    push_current_frame_previous_root(
+        previous,
+        if enters_chain {
+            ec
+        } else {
+            std::ptr::null_mut()
+        },
+        previous_ec_top,
+    )
 }
 
 /// Install only the TLS current-frame root.
@@ -5530,6 +5542,36 @@ mod tests {
         let mut frame = PyFrame::new(code);
         let result = frame.execute_frame(None, None);
         (result, frame)
+    }
+
+    // Compiled code can record `ExecutionContext.enter` before handing the
+    // same frame to a portal helper.  Installing the TLS current-frame root in
+    // that helper must neither relink the frame nor unlink the surrounding
+    // activation when the guard is dropped.
+    #[test]
+    fn test_install_current_frame_does_not_own_an_already_entered_chain() {
+        let _ = run_exec_frame("pass");
+        let code = compile_exec("pass").expect("compile failed");
+        let mut frame = PyFrame::new(code);
+        let frame_ptr = frame.as_mut_ptr();
+        let ec = unsafe { (*frame_ptr).execution_context as *mut PyExecutionContext };
+        assert!(!ec.is_null(), "the frame must carry an execution context");
+        let outer_top = unsafe { (*ec).topframeref };
+
+        unsafe { (*ec).enter(frame_ptr) };
+        let linked_backref = unsafe { (*frame_ptr).f_backref };
+        assert_eq!(linked_backref, outer_top);
+
+        {
+            let _guard = install_current_frame(unsafe { &mut *frame_ptr });
+            assert_eq!(unsafe { (*frame_ptr).f_backref }, linked_backref);
+        }
+        assert_eq!(
+            unsafe { (*ec).topframeref },
+            frame_ptr,
+            "the outer enter/leave scope, not the TLS guard, owns the unlink",
+        );
+        unsafe { (*ec).topframeref = outer_top };
     }
 
     // A frame value slot may hold a `JitVirtualRef`, whose leading magic word

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -3431,6 +3431,23 @@ pub(crate) fn walker_ec_leave(
 /// allocation) and is exactly what [`pyre_interpreter::PyExecutionContext::enter`]
 /// stores.
 ///
+/// ⛔ Recording a `VIRTUAL_REF` here instead — the spelling
+/// [`walker_ec_enter`] uses — is not available to this fold, and the
+/// difference is the callee's exit, not the enter.  `optimize_VIRTUAL_REF`
+/// seeds the materialized `JitVirtualRef` with `forced = NULL`
+/// (`virtualize.py:129`), and pyre's two portal doors resolve `topframeref`
+/// through `executioncontext::vref_referent`, which reads `forced` WITHOUT
+/// forcing.  An unforced vref therefore answers NULL at both:
+/// `install_current_frame` (`pyre-interpreter/src/eval.rs`) reads that as
+/// "not yet entered" and re-links the callee onto its own vref, and
+/// `leave_compiled_frame_chain` (`pyre-jit/src/call_jit.rs`) reads it as
+/// "not my frame" and silently declines the restore.  [`walker_ec_enter`]'s
+/// callee is inlined and reaches neither door; this fold's callee reaches
+/// both — `compile_tmp_callback` routes its CALL_ASSEMBLER through
+/// `ll_portal_runner_shim`, and the force/deopt legs call
+/// `jit_force_callee_frame`.  Publishing a vref here needs a signal those
+/// doors can decide without forcing, which does not exist yet.
+///
 /// Upstream reaches `ec.enter` on this path too: `interp_jit.py` puts
 /// `jit_merge_point` on `PyFrame.dispatch`, so the CALL_ASSEMBLER that
 /// replaces the callee's merge point is recorded with `pyframe.py
@@ -3486,6 +3503,55 @@ fn record_ec_leave_frame_chain(ctx: &mut TraceCtx, callee_frame: OpRef, callee_e
         &[callee_ec, f_backref],
         crate::descr::ec_topframeref_descr(),
     );
+}
+
+#[cfg(test)]
+mod portal_frame_chain_tests {
+    use super::*;
+
+    /// The fold's recorded `enter` publishes the callee frame itself, and its
+    /// recorded `leave` restores `f_backref` — neither takes a vref.
+    ///
+    /// The op shape is the contract, because the two portal doors this fold's
+    /// callee reaches (`install_current_frame` and `leave_compiled_frame_chain`)
+    /// resolve `topframeref` through `vref_referent`, which reads
+    /// `JitVirtualRef.forced` without forcing.  `optimize_VIRTUAL_REF` seeds
+    /// that field with `CONST_NULL` (`virtualize.py:129`), so a `VIRTUAL_REF`
+    /// recorded here would answer NULL at both doors: the first re-links the
+    /// callee onto its own vref, the second declines the restore.  See
+    /// [`record_ec_enter_frame_chain`] for the full argument.
+    #[test]
+    fn the_recorded_enter_and_leave_take_no_virtual_ref() {
+        let mut ctx = TraceCtx::for_test_types(&[Type::Ref, Type::Ref]);
+        let frame = OpRef::input_arg_ref(0);
+        let ec = OpRef::input_arg_ref(1);
+
+        record_ec_enter_frame_chain(&mut ctx, frame, ec);
+        record_ec_leave_frame_chain(&mut ctx, frame, ec);
+        assert_eq!(
+            ctx.virtualref_boxes_len(),
+            0,
+            "this level holds no vref, so it owes no virtual_ref_finish and \
+             must not leave `virtualref_boxes` unbalanced at the loop header",
+        );
+
+        let tree_loop = ctx.into_tree_loop();
+        let opcodes: Vec<OpCode> = tree_loop.ops.iter().map(|op| op.opcode).collect();
+        assert_eq!(
+            opcodes,
+            vec![
+                // `frame.f_backref = self.topframeref`
+                OpCode::GetfieldGcR,
+                OpCode::SetfieldGc,
+                // `self.topframeref = jit.virtual_ref(frame)`, whose
+                // interpreter-level reading is the frame pointer itself
+                OpCode::SetfieldGc,
+                // `self.topframeref = frame.f_backref`
+                OpCode::GetfieldGcR,
+                OpCode::SetfieldGc,
+            ],
+        );
+    }
 }
 
 /// Resolve the generated builtin-wrapper argument slice's array-item

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1977,7 +1977,7 @@ fn ca_complete_after_bridge_walk(
     // handle_blackhole_result performs.
     if ca_adopted_frame != 0 && ca_adopted_frame == callee_frame {
         let frame = unsafe { &mut *(ca_adopted_frame as *mut PyFrame) };
-        return match crate::eval::portal_runner_result(frame) {
+        return match crate::eval::portal_body_result(frame) {
             Ok(result) => Some(result as i64),
             Err(mut err) => {
                 let exc_obj = err.to_exc_object();
@@ -3264,7 +3264,7 @@ fn handle_blackhole_result(bh_result: BlackholeResult, _green_key: u64) -> Optio
             let exc_obj = err.to_exc_object();
             if exc_obj != pyre_object::PY_NULL {
                 // Symmetric with the `ContinueRunningNormally` arm's
-                // `portal_runner_result` error fall-through below and with
+                // `portal_body_result` error fall-through below and with
                 // `lib.rs::jit_exc_raise` — every backend's blackhole resume
                 // publishes the pending exception, not just cranelift.
                 store_jit_exception(exc_obj as i64);
@@ -3328,7 +3328,7 @@ fn handle_blackhole_result(bh_result: BlackholeResult, _green_key: u64) -> Optio
             // at its peak stack use.  Re-derive the depth from the resume pc —
             // the CALL_ASSEMBLER-path mirror of the eval.rs CRN handoff.
             crate::eval::correct_resume_vsd(frame, next_instr);
-            match crate::eval::portal_runner_result(frame) {
+            match crate::eval::portal_body_result(frame) {
                 Ok(result) => Some(result as i64),
                 Err(mut err) => {
                     let exc_obj = err.to_exc_object();

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -8853,7 +8853,7 @@ pub(crate) fn pyre_portal_runner(
         );
     }
     frame.set_last_instr_from_next_instr(next_instr);
-    match portal_runner_result(frame) {
+    match portal_body_result(frame) {
         Ok(result) => Ok((BhReturnType::Ref, result as i64)),
         Err(mut err) => Err(JitException::ExitFrameWithExceptionRef(majit_ir::GcRef(
             err.to_exc_object() as usize,
@@ -8864,11 +8864,12 @@ pub(crate) fn pyre_portal_runner(
 /// warmspot.py handle_jitexception.
 ///
 /// RPython: CRN → portal_ptr(*args) re-invokes the interpreter.
-/// pyre: CRN → re-loop eval_loop_jit(frame). This does NOT call
-/// maybe_compile_and_run (warmspot.py:948); portal_ptr is a plain
-/// interpreter dispatch, and pyre's eval_loop_jit is the equivalent.
-/// TODO: exact portal_ptr(*args) parity (currently `continue`
-/// re-enters without re-extracting CRN args from the exception).
+/// Pyre's portal ABI is frame-backed: each CRN producer applies its carried
+/// `next_instr` and reconstructed red state to that same live frame before it
+/// returns this outcome.  Re-looping `eval_loop_jit(frame)` is therefore the
+/// direct `portal_ptr(*args)` body call; it deliberately does not call
+/// `maybe_compile_and_run` again (`warmspot.py ll_portal_runner` owns that
+/// activation-entry step, while `handle_jitexception` does not).
 #[inline(always)]
 fn handle_jitexception(frame: &mut PyFrame) -> PyResult {
     let mut frame_root = FrameRoot::new(frame);
@@ -8902,6 +8903,25 @@ fn handle_jitexception(frame: &mut PyFrame) -> PyResult {
             }
         }
     }
+}
+
+/// Resume the interpreter body of an already-active portal.
+///
+/// `warmspot.py` `handle_jitexception` calls `portal_ptr` for
+/// `ContinueRunningNormally`; it does not call `ll_portal_runner` again.  The
+/// latter is an activation boundary ([`portal_activation_result`] in pyre) and
+/// would charge recursion, reinstall the current frame, and consult
+/// function-entry warmstate a second time.
+pub(crate) fn portal_body_result(frame: &mut PyFrame) -> PyResult {
+    if majit_metainterp::majit_log_enabled() {
+        eprintln!(
+            "[portal-resume] body of {:p} without a second activation bracket",
+            frame as *mut PyFrame,
+        );
+    }
+    let mut frame_root = FrameRoot::new(frame);
+    frame_root.frame().fix_array_ptrs();
+    handle_jitexception(frame_root.frame())
 }
 
 /// True when this frame's exception-table entry for the exit PC expects operand
@@ -9034,21 +9054,8 @@ fn debug_first_arg_int(frame: &PyFrame) -> Option<i64> {
     Some(unsafe { pyre_object::intobject::w_int_get_value(value) })
 }
 
-/// warmspot.py ll_portal_runner parity: execute a frame through the
-/// JIT-enabled portal runner. Used by bhimpl_recursive_call
-/// (blackhole.py:1101-1116) for recursive portal depth.
-///
-/// warmspot.py:941-959:
-///   maybe_compile_and_run(state.increment_function_threshold, *args)
-///   return portal_ptr(*args)
-///
-/// warmspot.py:997-1005: ExitFrameWithExceptionRef → re-raise.
-pub(crate) fn portal_runner_result(frame: &mut PyFrame) -> PyResult {
-    enter_portal(frame, portal_runner_dispatch)
-}
-
-/// [`portal_runner_result`] for an entry that BEGINS the activation rather than
-/// continuing one, so it owes `pyframe.py execute_frame`'s hook bracket.
+/// `warmspot.py ll_portal_runner` for an entry that BEGINS the activation, so
+/// it owes `pyframe.py execute_frame`'s hook bracket.
 ///
 /// The two are separated because pyre's portal is re-entered for reasons
 /// upstream's is not.  A `ContinueRunningNormally` handoff and a
@@ -9090,8 +9097,8 @@ fn enter_portal(frame: &mut PyFrame, body: fn(&mut FrameRoot) -> PyResult) -> Py
     body(&mut frame_root)
 }
 
-/// The dispatch half of `portal_runner_result`, taking the caller's
-/// [`FrameRoot`] rather than a raw frame.
+/// The portal activation's dispatch half, taking the caller's [`FrameRoot`]
+/// rather than a raw frame.
 ///
 /// `try_function_entry_jit` runs compiled code, and it roots the frame only for
 /// its own body: the root is gone by the time it hands back `None`.  The frame
@@ -9190,7 +9197,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
     // detect a body effect that ran through user code.
     pyre_interpreter::call::bump_frame_entry_count();
     // Recursion accounting belongs to the activation seams
-    // (`eval_with_jit_inner` and `portal_runner_result`), not this re-entrant
+    // (`eval_with_jit_inner` and `portal_activation_result`), not this re-entrant
     // dispatch loop.  In particular, `FrameRoot` may have forwarded a moving
     // frame since the seam; keying the same activation again by its new
     // address would spend a second recursion unit.


### PR DESCRIPTION
Follow-up review of the portal work that landed in #1529. The uncommitted
follow-up this started from had never been built — the LLBC artefacts were
stale, so `cargo test` failed at the build script — and a review found one
blocker in it. What lands here is the part that survived review, plus the
reason the rest did not.

## What lands

**1. The portal's resume entry is split from its activation entry.**

`portal_runner_result` becomes `portal_body_result` and is reduced to the
interpreter-body call — `FrameRoot` + `fix_array_ptrs` + `handle_jitexception`
— with no recursion charge, no `install_current_frame`, and no
`try_function_entry_jit`. `warmspot.py handle_jitexception` reaches
`portal_ptr` for `ContinueRunningNormally`, not `ll_portal_runner`, and the
three call sites moved to it all resume a frame whose activation already
began: `pyre_portal_runner`, `ca_complete_after_bridge_walk`, and
`handle_blackhole_result`'s CRN arm. `portal_activation_result` keeps
`ll_portal_runner`. The GC dispatch seed follows the rename.

Reach, measured over 491 synth fixtures with an `eprintln!` at the seam under
the `MAJIT_LOG` gate: **2041 entries across 7 fixtures**, every one an
exception or traceback resume — `exception_raise_caught_same_frame_tb` (397),
`exception_reused_object_tb_not_doubled` (399),
`exception_traceback_frame_lineno` (397), `exception_traceback_lineno_chain`
(199), `loop_callee_shared_mutation` (257),
`short_circuit_falsy_func_entry_resume` (199),
`traceback_inlined_callee_lasti_regression` (193). That diagnostic line stays,
behind the same gate `call_jit.rs` already uses for `[blackhole-resume]`.

**2. `install_current_frame` no longer restores a chain it did not link.**

On the arm where #1529's identity guard finds the frame already entered, the
guard wrote no link — but it still passed the execution context to
`push_current_frame_previous_root`, so its `Drop` wrote `frame.f_backref` back
into `topframeref`. That unlinks an activation that is *still running* when the
portal helper returns to compiled code (`jit_force_callee_frame` forces and
returns; the callee keeps going). It now passes a null context on that arm and
performs no restore. A unit test covers it.

**3. `opimpl_virtual_ref` asserts its tracing-time object is non-null**, which
`virtualref.py virtual_ref_during_tracing` opens with.

## What does NOT land, and why

The follow-up changed `record_ec_enter_frame_chain` to store a recorded
`VIRTUAL_REF` into `ec.topframeref` instead of the callee frame. That reads as
the more orthodox spelling — upstream's `enter` is
`self.topframeref = jit.virtual_ref(frame)`, and the sibling `walker_ec_enter`
really does record one — but it is a blocker here, and the review reached it
independently from four different directions.

`optimize_VIRTUAL_REF` seeds the materialized `JitVirtualRef` with
`forced = CONST_NULL` (`virtualize.py`). pyre has **two portal doors that
share one predicate**, and both resolve `topframeref` through
`executioncontext::vref_referent`, which reads `forced` *without* forcing. An
unforced vref answers NULL at both:

* `install_current_frame` reads NULL as "not yet entered" and **re-links the
  callee onto its own vref** — exactly the `walk_pyframe_roots` self-cycle
  #1529 added that guard to prevent.
* `leave_compiled_frame_chain` reads NULL as "not my frame" and **silently
  declines the restore**, leaking `topframeref` the way `TopFrameRefGuard`'s
  own doc warns.

`walker_ec_enter` gets away with it because its callee is *inlined* and reaches
neither door. This fold's callee reaches both: `compile_tmp_callback` routes
its CALL_ASSEMBLER through `ll_portal_runner_shim`, and the force/deopt legs
call `jit_force_callee_frame`.

So the enter keeps storing the raw frame. Its doc now records the argument, and
a unit test pins the recorded op shape so a re-attempt goes red rather than
silently reintroducing the cycle.

A blanket "vref on top ⇒ skip the enter" is **not** the fix either:
`bh_call_self_recursive_portal` and the `jit_force_*_recursive_call_*` helpers
legitimately begin a new activation while a compiled vref is on top and must
still enter. A sound vref here needs a positive, decidable "entered by compiled
code" signal that both doors read, plus a clear on every deopt exit — a design
step, not a patch, and out of scope for this PR.

Two smaller things also dropped:

* An `already_running` fork inside `run_frame_through_portal`
  (`current_frame() == frame` ⇒ take the resume entry) fired **0 times across
  all 11 recursion/portal fixtures**. Real resumes arrive through the other
  three call sites. An unreached fork that would skip recursion accounting, the
  current-frame install, and function-entry warmstate is a latent behaviour
  split nobody has validated, so it is gone and the thunk calls `portal_runner`
  as before.
* The `selfrec_tail_exception_unwind` `.jitstats` baselines had been edited
  `guard_failures 937 -> 938` on dynasm and cranelift only, leaving wasm at 937.
  With the vref change out, the move does not occur; the baselines are
  unchanged and the fixture passes on all three backends.

## Verification

* `cargo fmt --all -- --check` clean.
* `cargo test --all --no-default-features --features dynasm` — exit 0.
* `python3 pyre/check.py` — **dynasm 505/505, cranelift 505/505, wasm 498/498,
  3/3 backends ALL PASSED**, on base `bb4de56aeae`. PRE and POST stamps agree
  on HEAD, base, `check.py` mtime, and a clean tree.
* #1529's own regression fixture
  (`frame_chain_survives_a_recursive_call_assembler`) and
  `profile_hook_sees_a_recursive_portal_activation` both PASS;
  `list_length_hint_validate`, the hang oracle from #1529, runs in 0.68s.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when execution resumes within an already active code path, helping preserve the correct execution state.
  - Prevented invalid virtual references from being created during tracing.
  - Corrected portal resume handling to distinguish initial entry from re-entry, improving reliability after exceptions and compiled-code transitions.

- **Tests**
  - Added regression coverage for frame-chain preservation and portal transition behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->