### PR TITLE
_ast, _template, typedef, dict: the generated AST node surface, template pickle reducers, builtin typedef ownership and buffer views, and a paired dict strategy swap

### DIFF
--- a/pyre/extra_tests/snippets/builtin_compile.py
+++ b/pyre/extra_tests/snippets/builtin_compile.py
@@ -63,7 +63,11 @@ formatted = assign.value.values[0]
 assert formatted.value.id == "value"
 assert formatted.conversion == ord("r")
 assert formatted.format_spec.values[0].value == ">10"
-assert compile(tree, "<ast>", "exec", ast.PyCF_ONLY_AST) is tree
+roundtripped = compile(tree, "<ast>", "exec", ast.PyCF_ONLY_AST)
+assert roundtripped is not tree
+assert ast.dump(roundtripped, include_attributes=True) == ast.dump(
+    tree, include_attributes=True
+)
 
 tree = ast.parse(
     'match value:\n'

--- a/pyre/pyre-interpreter/src/_structseq.rs
+++ b/pyre/pyre-interpreter/src/_structseq.rs
@@ -63,7 +63,9 @@ fn structseq_registry() -> &'static Mutex<IndexMap<usize, StructSeqDescr>> {
 
 /// Whether `obj` is one of the heap types created by `structseqtype`.
 /// Structseq types are unacceptable as bases but, unlike most types with that
-/// flag, their constructor accepts the `sequence=` and `dict=` keywords.
+/// restriction, their constructor accepts the `sequence=` and `dict=`
+/// keywords.  The restriction belongs to `structseqtype`, not to tuple's
+/// shared TypeDef.
 pub(crate) fn is_structseq_type(obj: PyObjectRef) -> bool {
     structseq_registry()
         .lock()
@@ -833,8 +835,12 @@ fn make_heap_structseq_type(
         pyre_object::w_type_set_layout(cls, parent_layout);
         pyre_object::w_type_set_hasdict(cls, pyre_object::w_type_get_hasdict(base));
         pyre_object::w_type_set_weakrefable(cls, pyre_object::w_type_get_weakrefable(base));
-        // CPython's PyStructSequence types set no acceptable-base flag.
-        pyre_object::w_type_set_acceptable_as_base_class(cls, false);
+        // CPython's PyStructSequence types publish no BASETYPE flag.  Keep
+        // that projection per type: this app-level class shares tuple's
+        // TypeDef, which remains an acceptable base.  `check_and_find_best_base`
+        // mirrors `lib_pypy._structseq.structseqtype.__new__`'s per-structseq
+        // rejection.
+        pyre_object::w_type_suppress_cpython_basetype(cls);
 
         let base_mro = pyre_object::w_type_get_mro(base);
         let mut mro = vec![cls];
@@ -848,4 +854,22 @@ fn make_heap_structseq_type(
         pyre_object::typeobject::w_type_ready(cls);
     }
     pyre_object::gc_roots::shadow_stack_get(cls_slot)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn structseq_base_rejection_does_not_poison_tuple_typedef() {
+        crate::typedef::init_typeobjects();
+        let tuple_type = crate::typedef::gettypeobject(&pyre_object::pyobject::TUPLE_TYPE);
+        let structseq = super::make_struct_seq("test.StructSeq", &["value"]);
+
+        let structseq_bases = pyre_object::w_tuple_new(vec![structseq]);
+        let err = unsafe { crate::call::check_and_find_best_base(structseq_bases) }.unwrap_err();
+        assert_eq!(err.kind, crate::PyErrorKind::TypeError);
+
+        let tuple_bases = pyre_object::w_tuple_new(vec![tuple_type]);
+        let best = unsafe { crate::call::check_and_find_best_base(tuple_bases) }.unwrap();
+        assert!(std::ptr::eq(best, tuple_type));
+    }
 }

--- a/pyre/pyre-interpreter/src/astcompiler/validate.rs
+++ b/pyre/pyre-interpreter/src/astcompiler/validate.rs
@@ -666,6 +666,7 @@ impl AstValidator {
                 Ok(())
             }
             ast::Expr::FString(node) => self.visit_fstring(node),
+            ast::Expr::TString(node) => self.visit_tstring(node),
             ast::Expr::Named(node) => {
                 if !matches!(node.target.as_ref(), ast::Expr::Name(_)) {
                     return Err(validation_type_error("NamedExpr target must be a Name"));
@@ -682,26 +683,63 @@ impl AstValidator {
             | ast::Expr::BooleanLiteral(_)
             | ast::Expr::NoneLiteral(_)
             | ast::Expr::EllipsisLiteral(_)
-            | ast::Expr::TString(_)
             | ast::Expr::IpyEscapeCommand(_) => Ok(()),
         }
+    }
+
+    /// RustPython `_ast::validate::validate_interpolated_elements`: both
+    /// string forms validate the expression and whichever representation of
+    /// the format spec their object-to-native boundary supplied.
+    fn validate_interpolated_elements<'a>(
+        &self,
+        elements: impl IntoIterator<Item = &'a ast::InterpolatedStringElement>,
+    ) -> ValidateResult {
+        for element in elements {
+            if let ast::InterpolatedStringElement::Interpolation(interpolation) = element {
+                self.validate_expr(&interpolation.expression, ast::ExprContext::Load)?;
+                if let Some(spec) = interpolation.runtime_formatted_value_format_spec.as_deref() {
+                    self.validate_expr(spec, ast::ExprContext::Load)?;
+                } else if let Some(spec) =
+                    interpolation.runtime_interpolation_format_spec.as_deref()
+                {
+                    self.validate_expr(spec, ast::ExprContext::Load)?;
+                } else if let Some(spec) = interpolation.format_spec.as_deref() {
+                    self.validate_interpolated_elements(spec.elements.iter())?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_runtime_expr_slots(
+        &self,
+        values: Option<&Vec<Option<ast::Expr>>>,
+    ) -> ValidateResult {
+        if let Some(values) = values {
+            for value in values.iter().flatten() {
+                self.validate_expr(value, ast::ExprContext::Load)?;
+            }
+        }
+        Ok(())
     }
 
     /// The values of a `JoinedStr` reach the compiler AST as the parts to
     /// join, and a `FormattedValue` spec as the expression to format with.
     fn visit_fstring(&self, node: &ast::ExprFString) -> ValidateResult {
+        self.validate_runtime_expr_slots(node.runtime_values.as_ref())?;
         if let Some(values) = node.runtime_joined_str.as_deref() {
             return self.validate_exprs(values, ast::ExprContext::Load);
         }
-        for element in node.value.elements() {
-            if let ast::InterpolatedStringElement::Interpolation(interpolation) = element {
-                self.validate_expr(&interpolation.expression, ast::ExprContext::Load)?;
-                if let Some(spec) = interpolation.runtime_formatted_value_format_spec.as_deref() {
-                    self.validate_expr(spec, ast::ExprContext::Load)?;
-                }
-            }
+        self.validate_interpolated_elements(node.value.elements())
+    }
+
+    /// RustPython `_ast::validate::validate_expr` `Expr::TString` arm.
+    fn visit_tstring(&self, node: &ast::ExprTString) -> ValidateResult {
+        self.validate_runtime_expr_slots(node.runtime_values.as_ref())?;
+        if let Some(values) = node.runtime_template_str.as_deref() {
+            return self.validate_exprs(values, ast::ExprContext::Load);
         }
-        Ok(())
+        self.validate_interpolated_elements(node.value.elements())
     }
 
     fn validate_comprehension(&self, generators: &[ast::Comprehension]) -> ValidateResult {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5761,7 +5761,10 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool, suppress: 
             lookup_where(obj_type.as_ptr(), "__dict__").is_some_and(|(owner, _)| {
                 let layout = pyre_object::w_type_get_layout_ptr(owner);
                 !layout.is_null()
-                    && std::ptr::eq((*layout).typedef, &pyre_object::pyobject::INSTANCE_TYPE)
+                    && std::ptr::eq(
+                        (*(*layout).typedef).instance_type,
+                        &pyre_object::pyobject::INSTANCE_TYPE,
+                    )
             })
         };
         if !module_type.is_null()

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -836,18 +836,24 @@ fn memoryview_adjust_fmt(fmt: &str) -> Result<(), crate::PyError> {
 }
 
 /// Box one `itemsize`-wide element at byte offset `base` per the view's
-/// format (`buffer.py value_from_bytes`).  Numeric typecodes route through
-/// the shared array decoder (`unpack_value`); `c` yields a length-1 bytes,
-/// `?` a bool, and any code the decoder rejects falls back to a little-endian
-/// read that is signed once the item is a full word wide.
+/// format.  PyPy's `buffer.py value_from_bytes` supplies the numeric decoding
+/// shape; CPython 3.14 `unpack_single` supplies the observable rejection of an
+/// unsupported one-character code.  `c` yields a length-1 bytes and `?` a
+/// bool.
 unsafe fn memoryview_unpack_element(
     fmt: &str,
     data: &[u8],
     base: usize,
     itemsize: usize,
-) -> PyObjectRef {
+) -> Result<PyObjectRef, crate::PyError> {
+    if memoryview_native_fmtchar(fmt).is_none() {
+        return Err(crate::PyError::not_implemented(format!(
+            "memoryview: format {} not supported",
+            fmt.strip_prefix('@').unwrap_or(fmt)
+        )));
+    }
     let buf = &data[base..base + itemsize];
-    match memoryview_format_code(fmt) {
+    Ok(match memoryview_format_code(fmt) {
         b'c' => pyre_object::bytesobject::w_bytes_from_bytes(buf),
         b'?' => w_bool_from(buf.iter().any(|&x| x != 0)),
         b'e' => {
@@ -878,7 +884,7 @@ unsafe fn memoryview_unpack_element(
                 pyre_object::bytesobject::w_bytes_from_bytes(buf)
             }
         }
-    }
+    })
 }
 
 /// Pack `w_val` into `itemsize` native-order bytes per `fmt`
@@ -890,6 +896,17 @@ fn memoryview_pack_value(
     itemsize: usize,
     w_val: PyObjectRef,
 ) -> Result<Vec<u8>, crate::PyError> {
+    // CPython 3.14 `pack_single` distinguishes a recognised scalar whose
+    // operand is wrong from a one-character PEP-3118 code memoryview does not
+    // implement at all.  PyPy reaches the same struct-table dispatch through
+    // `BufferView.bytes_from_value`; keep that dispatch boundary explicit so
+    // `s` is not misreported as a bad scalar operand.
+    if memoryview_native_fmtchar(fmt).is_none() {
+        return Err(crate::PyError::not_implemented(format!(
+            "memoryview: format {} not supported",
+            fmt.strip_prefix('@').unwrap_or(fmt)
+        )));
+    }
     // `type_error_int` / `value_error_int` — the wrong kind of object and a
     // value the format cannot hold are reported separately.
     let bad_type =
@@ -974,7 +991,8 @@ fn memoryview_pack_value(
         }
         b'e' => {
             let v = crate::baseobjspace::float_w(w_val).map_err(fix_error)?;
-            crate::module::r#struct::pack_half(v)?
+            crate::module::r#struct::pack_half(v)
+                .map_err(fix_error)?
                 .to_ne_bytes()
                 .to_vec()
         }
@@ -987,6 +1005,12 @@ fn memoryview_pack_value(
                 if d.len() == 1 {
                     return Ok(d.to_vec());
                 }
+                // CPython 3.14 `memoryview.c: pack_single`: an actual bytes
+                // object of the wrong length is a value error.  PyPy's
+                // `BufferView.bytes_from_value` still folds this StructError
+                // into TypeError, so this is the observable 3.14 exception
+                // split over the same single-item packing shape.
+                return Err(bad_value());
             }
             return Err(bad_type());
         }
@@ -999,7 +1023,7 @@ fn memoryview_pack_value(
 /// Each element is pinned as built and read back inside the scope
 /// `w_list_new` runs in, so neither a later element's allocation nor the
 /// list's own can strand an earlier one (`build_list_storage`).
-unsafe fn memoryview_value_list(mv: PyObjectRef) -> PyObjectRef {
+unsafe fn memoryview_value_list(mv: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     unsafe {
         let itemsize = pyre_object::memoryview::w_memoryview_itemsize(mv) as usize;
         let fmt = pyre_object::memoryview::w_memoryview_format_str(mv);
@@ -1009,16 +1033,15 @@ unsafe fn memoryview_value_list(mv: PyObjectRef) -> PyObjectRef {
         let mut count = 0;
         let mut base = 0;
         while itemsize > 0 && base + itemsize <= data.len() {
-            let _ = pyre_object::gc_roots::pin_root(memoryview_unpack_element(
-                fmt, &data, base, itemsize,
-            ));
+            let element = memoryview_unpack_element(fmt, &data, base, itemsize)?;
+            let _ = pyre_object::gc_roots::pin_root(element);
             base += itemsize;
             count += 1;
         }
         let items = (0..count)
             .map(|i| pyre_object::gc_roots::shadow_stack_get(sp + i))
             .collect();
-        w_list_new(items)
+        Ok(w_list_new(items))
     }
 }
 
@@ -1198,7 +1221,7 @@ unsafe fn memoryview_unpack_at(
     indices: &[i64],
     fmt: &str,
     itemsize: usize,
-) -> PyObjectRef {
+) -> Result<PyObjectRef, crate::PyError> {
     unsafe {
         let element = pyre_object::memoryview::w_memoryview_view(mv).element_ptr(indices);
         let bytes = std::slice::from_raw_parts(element, itemsize);
@@ -1265,7 +1288,7 @@ fn memoryview_getitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
             // not `length / itemsize`.
             let index = memoryview_check_dimension(mv, 0, i)?;
             let fmt = w_memoryview_format_str(mv);
-            return Ok(memoryview_unpack_at(mv, &[index], fmt, itemsize as usize));
+            return memoryview_unpack_at(mv, &[index], fmt, itemsize as usize);
         }
         if pyre_object::is_tuple(index) {
             let (all_index, all_slice) = memoryview_tuple_kind(index);
@@ -1285,7 +1308,7 @@ fn memoryview_getitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
                 let indices = memoryview_start_from_tuple(mv, index)?;
                 let itemsize = w_memoryview_itemsize(mv);
                 let fmt = w_memoryview_format_str(mv);
-                return Ok(memoryview_unpack_at(mv, &indices, fmt, itemsize as usize));
+                return memoryview_unpack_at(mv, &indices, fmt, itemsize as usize);
             }
             if all_slice {
                 return Err(crate::PyError::not_implemented(
@@ -1494,6 +1517,15 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
                 "memoryview: invalid slice key, must be int or slice",
             ));
         }
+        // PyPy `W_MemoryView.descr_getitem` rejects an integer selecting the
+        // leading dimension of an N-D view because that would have to return
+        // a sub-view.  Assignment has the same structural boundary: only a
+        // full N-D tuple reaches the scalar packing path above.
+        if w_memoryview_ndim(mv) > 1 {
+            return Err(crate::PyError::not_implemented(
+                "multi-dimensional sub-views are not implemented",
+            ));
+        }
         let i = getindex_w(index)?;
         // `memory_ass_sub`: `__index__` is arbitrary Python code and may have
         // released this view before the offset reads its geometry (gh-92888).
@@ -1570,7 +1602,7 @@ fn memoryview_iter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     unsafe {
         memoryview_check_released(mv)?;
         memoryview_adjust_fmt(pyre_object::memoryview::w_memoryview_format_str(mv))?;
-        crate::baseobjspace::iter(memoryview_value_list(mv))
+        crate::baseobjspace::iter(memoryview_value_list(mv)?)
     }
 }
 
@@ -1704,7 +1736,7 @@ unsafe fn memoryview_tolist_rec(
     isz: usize,
     idim: usize,
     cursor: &mut usize,
-) -> PyObjectRef {
+) -> Result<PyObjectRef, crate::PyError> {
     unsafe {
         let dimshape = shape.get(idim).copied().unwrap_or(0).max(0);
         // Every element is pinned as built, the sublists included, and read
@@ -1719,9 +1751,9 @@ unsafe fn memoryview_tolist_rec(
                 }
                 let at = *cursor;
                 *cursor += isz;
-                memoryview_unpack_element(fmt, data, at, isz)
+                memoryview_unpack_element(fmt, data, at, isz)?
             } else {
-                memoryview_tolist_rec(shape, fmt, data, isz, idim + 1, cursor)
+                memoryview_tolist_rec(shape, fmt, data, isz, idim + 1, cursor)?
             };
             let _ = pyre_object::gc_roots::pin_root(element);
             count += 1;
@@ -1729,7 +1761,7 @@ unsafe fn memoryview_tolist_rec(
         let items = (0..count)
             .map(|i| pyre_object::gc_roots::shadow_stack_get(sp + i))
             .collect();
-        w_list_new(items)
+        Ok(w_list_new(items))
     }
 }
 
@@ -1743,7 +1775,7 @@ fn memoryview_tolist(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         memoryview_adjust_fmt(pyre_object::memoryview::w_memoryview_format_str(mv))?;
         let ndim = pyre_object::memoryview::w_memoryview_ndim(mv);
         if ndim == 1 {
-            return Ok(memoryview_value_list(mv));
+            return memoryview_value_list(mv);
         }
         let isz = pyre_object::memoryview::w_memoryview_itemsize(mv) as usize;
         let fmt = pyre_object::memoryview::w_memoryview_format_str(mv);
@@ -1754,18 +1786,11 @@ fn memoryview_tolist(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
                     "memoryview: unsupported format",
                 ));
             }
-            return Ok(memoryview_unpack_element(fmt, &data, 0, isz));
+            return memoryview_unpack_element(fmt, &data, 0, isz);
         }
         let shape = pyre_object::memoryview::w_memoryview_native_shape(mv);
         let mut cursor = 0;
-        Ok(memoryview_tolist_rec(
-            &shape,
-            fmt,
-            &data,
-            isz,
-            0,
-            &mut cursor,
-        ))
+        memoryview_tolist_rec(&shape, fmt, &data, isz, 0, &mut cursor)
     }
 }
 
@@ -2304,7 +2329,7 @@ unsafe fn memoryview_unpack_compared(
 ) -> Result<PyObjectRef, crate::PyError> {
     unsafe {
         match native {
-            true => Ok(memoryview_unpack_element(fmt, data, base, itemsize)),
+            true => memoryview_unpack_element(fmt, data, base, itemsize),
             false => crate::module::r#struct::unpack_single(fmt, &data[base..base + itemsize]),
         }
     }
@@ -2510,6 +2535,19 @@ unsafe fn memoryview_hash_value(mv: PyObjectRef) -> Result<i64, crate::PyError> 
             if !pyre_object::memoryview::w_memoryview_readonly(mv) {
                 return Err(crate::PyError::value_error(
                     "cannot hash writable memoryview object",
+                ));
+            }
+            // [3.14-spec] CPython `memory_hash` rejects every format except
+            // the native single-character `B`, `b`, and `c`.  PyPy's
+            // `W_MemoryView`'s byte-hash path historically hashes other readonly
+            // formats too; retain its byte-hash/caching structure below but
+            // apply the caller-visible 3.14 format contract here.
+            let fmt = pyre_object::memoryview::w_memoryview_format_str(mv);
+            if !memoryview_native_fmtchar(fmt)
+                .is_some_and(|(code, _)| matches!(code, b'B' | b'b' | b'c'))
+            {
+                return Err(crate::PyError::value_error(
+                    "memoryview: hashing is restricted to formats 'B', 'b' or 'c'",
                 ));
             }
             // CPython 3.14 `memory_hash`: hash the exporter while holding a
@@ -8828,9 +8866,27 @@ fn exception_layout_pytype(name: &str, base: PyObjectRef) -> *const pyre_object:
             if parent.is_null() {
                 &exc::EXCEPTION_TYPE
             } else {
-                (*parent).typedef
+                (*(*parent).typedef).instance_type
             }
         },
+    }
+}
+
+/// PyPy `TypeCache.build`: `_new_exception` assigns
+/// `typedef.applevel_subclasses_base`, and the cache passes that real base's
+/// TypeDef as `overridetypedef`.  Concrete `W_*` exception classes instead
+/// retain their own TypeDef even when the Python-level base is related.
+fn exception_overridetypedef(
+    layout_pytype: *const pyre_object::PyType,
+    base: PyObjectRef,
+) -> *const pyre_object::typeobject::InterpreterTypeDef {
+    unsafe {
+        let parent = pyre_object::w_type_get_layout_ptr(base);
+        if parent.is_null() || !std::ptr::eq((*(*parent).typedef).instance_type, layout_pytype) {
+            std::ptr::null()
+        } else {
+            (*parent).typedef
+        }
     }
 }
 
@@ -8858,7 +8914,8 @@ pub(crate) fn make_exc_type_with_init(
     // rejecting the sibling layouts `(UnicodeTranslateError,
     // UnicodeEncodeError)`.
     let layout_pytype = exception_layout_pytype(name, base);
-    let cls = crate::typedef::make_builtin_type_with_layout(
+    let overridetypedef = exception_overridetypedef(layout_pytype, base);
+    let cls = crate::typedef::make_builtin_type_with_layout_owner(
         name,
         move |ns| {
             // The producer's own root slot tracks its copy of the namespace,
@@ -9342,6 +9399,7 @@ pub(crate) fn make_exc_type_with_init(
         },
         base,
         layout_pytype,
+        overridetypedef,
     );
     if name == "SyntaxError" {
         for member_name in [
@@ -9430,7 +9488,7 @@ pub(crate) fn make_exc_type_multi(
     if let Some(cls) = lookup_exc_class(name) {
         return cls;
     }
-    let cls = crate::typedef::make_builtin_type_with_bases(
+    let cls = crate::typedef::make_builtin_type_with_bases_and_overridetypedef(
         name,
         move |ns| {
             let _roots = pyre_object::gc_roots::push_roots();
@@ -10093,7 +10151,8 @@ fn make_exception_group_type(
         return cls;
     }
     let layout_pytype = exception_layout_pytype(name, bases[0]);
-    let cls = crate::typedef::make_builtin_type_with_bases_and_layout(
+    let overridetypedef = exception_overridetypedef(layout_pytype, bases[0]);
+    let cls = crate::typedef::make_builtin_type_with_bases_and_layout_owner(
         name,
         move |ns| {
             let _roots = pyre_object::gc_roots::push_roots();
@@ -10191,6 +10250,7 @@ fn make_exception_group_type(
         },
         bases,
         layout_pytype,
+        overridetypedef,
     );
     if name == "BaseExceptionGroup" {
         for member_name in ["message", "exceptions"] {
@@ -17522,6 +17582,19 @@ impl WritableBuffer {
         })
     }
 
+    /// `_struct.pack_into` uses the same `space.acquire_writebuf` lease as
+    /// `FileIO.readinto`; only its argument converter owns different wording
+    /// for a rejected exporter.  Keep non-type failures (notably a released
+    /// memoryview's `ValueError`) unchanged.
+    pub(crate) unsafe fn acquire_for_pack_into(obj: PyObjectRef) -> Result<Self, crate::PyError> {
+        unsafe { Self::acquire(obj) }.map_err(|err| match err.kind {
+            crate::PyErrorKind::TypeError => {
+                crate::PyError::type_error("argument must be read-write bytes-like object")
+            }
+            _ => err,
+        })
+    }
+
     pub(crate) unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.address, self.length) }
     }
@@ -20812,8 +20885,33 @@ mod tests {
     #[test]
     fn exception_layouts_follow_concrete_pypy_interpreter_classes() {
         let _ = new_builtin_module_dict();
+        let base_exception = lookup_exc_class("BaseException").unwrap();
+        let exception = lookup_exc_class("Exception").unwrap();
         let value_error = lookup_exc_class("ValueError").unwrap();
         let os_error = lookup_exc_class("OSError").unwrap();
+        let import_error = lookup_exc_class("ImportError").unwrap();
+        let module_not_found = lookup_exc_class("ModuleNotFoundError").unwrap();
+        unsafe {
+            // `TypeCache.build` substitutes `applevel_subclasses_base.typedef`
+            // for `_new_exception` classes, but concrete W_* owners start a
+            // new Layout and their fieldless descendants reuse that one.
+            assert_eq!(
+                pyre_object::w_type_get_layout_ptr(base_exception),
+                pyre_object::w_type_get_layout_ptr(exception),
+            );
+            assert_eq!(
+                pyre_object::w_type_get_layout_ptr(exception),
+                pyre_object::w_type_get_layout_ptr(value_error),
+            );
+            assert_ne!(
+                pyre_object::w_type_get_layout_ptr(exception),
+                pyre_object::w_type_get_layout_ptr(import_error),
+            );
+            assert_eq!(
+                pyre_object::w_type_get_layout_ptr(import_error),
+                pyre_object::w_type_get_layout_ptr(module_not_found),
+            );
+        }
         let compatible = pyre_object::w_tuple_new(vec![value_error, os_error]);
         let best = unsafe { crate::call::check_and_find_best_base(compatible) }.unwrap();
         assert!(std::ptr::eq(best, os_error));

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -14106,6 +14106,17 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         Some(v) => crate::baseobjspace::gateway_int_w(v)?,
         None => -1,
     };
+    // PyPy `PythonAstCompiler.compile_to_ast` passes this keyword-only value
+    // through `CompileInfo.feature_version` to the parser.
+    let feature_version = match kwarg_get(kwargs, "_feature_version") {
+        Some(value) => {
+            let value = crate::baseobjspace::gateway_int_w(value)?;
+            i64::from(i32::try_from(value).map_err(|_| {
+                crate::PyError::overflow_error("Python int too large to convert to C int")
+            })?)
+        }
+        None => -1,
+    };
 
     // Any bit outside the recognised compilation-flag set is rejected.
     let recognized = COMPILER_FLAGS
@@ -14230,6 +14241,7 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
                 opts,
                 syntax_check_only,
                 flags & PYCF_TYPE_COMMENTS != 0,
+                feature_version,
             )
         };
         return result.map_err(|error| {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -14218,20 +14218,17 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         // own `opts` has been moved into by then.
         let retry_opts = opts.clone();
         let result = if source_is_ast {
-            // An already materialised AST under plain `PyCF_ONLY_AST` is
-            // handed straight back, so `compile(tree, ..., PyCF_ONLY_AST) is
-            // tree`.  Re-converting it would hand out a copy instead.
-            if syntax_check_only {
-                Ok(source)
-            } else {
-                crate::module::_ast::convert::preprocess_object_to_object(
-                    source,
-                    "",
-                    mode,
-                    opts,
-                    syntax_check_only,
-                )
-            }
+            // [3.14-spec] CPython `_PyAST_obj2mod` validates the root for the
+            // requested mode and `_PyAST_mod2obj` publishes a fresh tree even
+            // for plain ONLY_AST.  PyPy `compile_to_ast` returns its input
+            // object unchanged; the observable 3.14 copy/TypeError wins here.
+            crate::module::_ast::convert::preprocess_object_to_object(
+                source,
+                "",
+                mode,
+                opts,
+                syntax_check_only,
+            )
         } else {
             crate::module::_ast::convert::parse_to_object_with_opts(
                 source_str

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1387,6 +1387,20 @@ fn call_function_ex_impl(
             .collect()
     };
 
+    // CPython 3.14's AST tp_init is the one builtin constructor that receives
+    // its raw kwargs dict before enforcing string keys.  Preserve that narrow
+    // type-slot boundary; every ordinary callable continues through PyPy's
+    // Arguments merge below, where non-string names are rejected.
+    if !kwargs_or_null().is_null()
+        && let Some(result) = crate::module::_ast::moduledef::call_type_with_raw_kwargs(
+            callable(),
+            &args(),
+            kwargs_or_null(),
+        )
+    {
+        return result;
+    }
+
     // Merge the `**` mapping into the call.  argument.py:106-150
     // `_combine_starstarargs_wrapped` accepts any mapping — the dict fast
     // path or an arbitrary object via `keys()` / `__getitem__` — raising
@@ -5495,7 +5509,7 @@ fn build_class_inner(
 /// Pack `(name, value)` keyword pairs into the `__pyre_kw__`-tagged
 /// trailing dict that the builtin kwargs ABI (`split_builtin_kwargs`)
 /// consumes.  Mirrors the producer in `call_with_kwargs`.
-fn pack_pyre_kwargs(kw_items: &[(PyObjectRef, PyObjectRef)]) -> PyObjectRef {
+pub(crate) fn pack_pyre_kwargs(kw_items: &[(PyObjectRef, PyObjectRef)]) -> PyObjectRef {
     // The dict is born young, and `w_dict_store` allocates when it promotes the
     // strategy — see the bracket in `call_with_kwargs`. `kw_items` is the
     // caller's array of raw references, so the pairs still to be installed are

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -6031,7 +6031,11 @@ pub unsafe fn create_all_slots(
         // typeobject.py:1199-1204: layout computation
         let nslots = base_nslots + newslotnames.len() as u32;
         let typedef = if base_layout.is_null() {
-            &pyre_object::pyobject::INSTANCE_TYPE as *const _
+            pyre_object::typeobject::leak_interpreter_typedef(
+                &pyre_object::pyobject::INSTANCE_TYPE,
+                true,
+                false,
+            )
         } else {
             (*base_layout).typedef
         };
@@ -6043,14 +6047,6 @@ pub unsafe fn create_all_slots(
                 nslots,
                 newslotnames,
                 base_layout,
-                acceptable_as_base_class: true,
-                // typedef.py:51-53: inherit typedef.hasdict along the base
-                // layout chain (terminates at object's Layout = false).
-                typedef_hasdict: if base_layout.is_null() {
-                    false
-                } else {
-                    (*base_layout).typedef_hasdict
-                },
                 dict_data_slot: pyre_object::typeobject::DICT_DATA_SLOT_UNRESOLVED,
             })
         };
@@ -6215,10 +6211,13 @@ pub(crate) unsafe fn check_and_find_best_base(
                     let native_layout_conflict = !layout.is_null()
                         && !std::ptr::eq((*best_layout).typedef, (*layout).typedef)
                         && !std::ptr::eq(
-                            (*best_layout).typedef,
+                            (*(*best_layout).typedef).instance_type,
                             &pyre_object::pyobject::INSTANCE_TYPE,
                         )
-                        && !std::ptr::eq((*layout).typedef, &pyre_object::pyobject::INSTANCE_TYPE)
+                        && !std::ptr::eq(
+                            (*(*layout).typedef).instance_type,
+                            &pyre_object::pyobject::INSTANCE_TYPE,
+                        )
                         && !exception_layouts;
                     if !layout.is_null()
                         && (!(*best_layout).issublayout(layout) || native_layout_conflict)
@@ -6246,7 +6245,7 @@ unsafe fn is_exception_layout(mut layout: *const pyre_object::typeobject::Layout
     unsafe {
         while !layout.is_null() {
             if std::ptr::eq(
-                (*layout).typedef,
+                (*(*layout).typedef).instance_type,
                 &pyre_object::interp_exceptions::EXCEPTION_TYPE,
             ) {
                 return true;
@@ -6260,5 +6259,14 @@ unsafe fn is_exception_layout(mut layout: *const pyre_object::typeobject::Layout
 /// typedef.py `acceptable_as_base_class = '__new__' in rawdict`.
 /// typeobject.py:1116 checks this flag on the bestbase.
 unsafe fn is_acceptable_base_class(w_type: pyre_object::PyObjectRef) -> bool {
-    unsafe { pyre_object::w_type_get_acceptable_as_base_class(w_type) }
+    // [3.14-spec] CPython 3.14 rejects a type whose own
+    // `Py_TPFLAGS_BASETYPE` capability is absent.  PyPy normally owns it
+    // on the shared TypeDef; app-level-shaped stand-ins such as structseqs and
+    // Context enforce the same restriction in their metaclass instead.  Read
+    // pyre's per-type projection after the canonical TypeDef value so those
+    // stand-ins keep PyPy's shared Layout without poisoning tuple/object.
+    unsafe {
+        pyre_object::w_type_get_acceptable_as_base_class(w_type)
+            && !pyre_object::w_type_is_cpython_basetype_suppressed(w_type)
+    }
 }

--- a/pyre/pyre-interpreter/src/cpyext/buffer.rs
+++ b/pyre/pyre-interpreter/src/cpyext/buffer.rs
@@ -281,6 +281,23 @@ fn acquire(
         ));
     }
 
+    // `Py_buffer.obj` is the exporter that owns this particular view, and a
+    // `bf_getbuffer` is allowed to redirect it away from the object the caller
+    // requested.  PyPy's `CPyBuffer.getndim`/`memory_attach` retain the filled
+    // buffer itself, so its `obj` remains authoritative.  Root that owner
+    // before allocating the memoryview header; using `w_obj` here made both
+    // `memoryview.obj` and `bf_releasebuffer` name the redirector instead.
+    let owner_slot = unsafe {
+        let raw = (*view).obj;
+        if raw.is_null() {
+            None
+        } else {
+            let slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = roots.pin_root(pyobject::from_ref(raw));
+            Some(slot)
+        }
+    };
+
     let (address, length, itemsize, readonly, ndim) = unsafe {
         (
             (*view).buf as usize,
@@ -318,7 +335,9 @@ fn acquire(
     let _ = roots.pin_root(pyre_object::w_str_new(&format));
     let reload = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
     let mv = pyre_object::memoryview::w_memoryview_alloc_header(false, true);
-    let r_obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+    let r_obj = owner_slot
+        .map(pyre_object::gc_roots::shadow_stack_get)
+        .unwrap_or_else(pyre_object::w_none);
     let built = carrier_for(
         Geometry {
             address,
@@ -455,17 +474,19 @@ fn release_c_view(view: *mut CPyBuffer) {
 /// `mv` must be a live memoryview and `backing` the object its view names.
 pub unsafe fn release_view(mv: PyObjectRef, backing: PyObjectRef) -> bool {
     use pyre_object::buffer::Buffer;
-    if slot_of(backing, getbuffer_of).is_null() {
-        return false;
-    }
     let carrier = unsafe { pyre_object::memoryview::w_memoryview_view(mv) };
     let Buffer::External { .. } = *carrier.backing() else {
         return false;
     };
     if let Some(view) = take_export(carrier as *const _ as usize) {
         release_c_view(view);
+        return true;
     }
-    true
+    // Preserve the pre-existing derived-view case: its cloned carrier has no
+    // table row of its own, but the C backing still identifies the native
+    // release path.  The table lookup comes first so a legacy export whose
+    // filled `Py_buffer.obj` is NULL is nevertheless freed.
+    !slot_of(backing, getbuffer_of).is_null()
 }
 
 // ── the buffer slots of a synthesized type mirror ───────────────────────
@@ -515,6 +536,14 @@ pub(super) fn declares_buffer(w_type: PyObjectRef) -> bool {
 /// C pointing at the bytes it was taken from.
 struct Export {
     view: *mut CPyObject,
+    /// Whether the input object whose owning reference is already in
+    /// `Py_buffer.obj` is a memoryview with one export count to release.  The
+    /// derived `view` above keeps the underlying bytes alive.  CPython 3.14
+    /// `memory_getbuf` also forbids releasing this source memoryview until
+    /// `PyBuffer_Release`; PyPy `W_MemoryView.buffer_w` deliberately omits
+    /// that count, so this is the caller-visible 3.14 lifetime rule over
+    /// PyPy's derived-view ownership shape.
+    source_is_memoryview: bool,
     format: Vec<u8>,
     shape: Vec<isize>,
     strides: Vec<isize>,
@@ -608,12 +637,21 @@ pub(super) unsafe extern "C" fn interp_bf_getbuffer(
     // Both references first: minting one can move what the other names.
     let holder = pyobject::make_ref(reload(view_slot));
     let exporter = pyobject::make_ref(reload(obj_slot));
+    let source_is_memoryview = unsafe {
+        if pyre_object::memoryview::is_w_memoryview(reload(obj_slot)) {
+            pyre_object::memoryview::w_memoryview_exports_incref(reload(obj_slot));
+            true
+        } else {
+            false
+        }
+    };
     let carrier = unsafe { pyre_object::memoryview::w_memoryview_view(reload(view_slot)) };
     let mut format = unsafe { carrier.format_str() }.as_bytes().to_vec();
     format.push(0);
     let widen = |dims: Vec<i64>| dims.into_iter().map(|extent| extent as isize).collect();
     let mut export = Box::new(Export {
         view: holder,
+        source_is_memoryview,
         format,
         shape: widen(unsafe { carrier.native_shape() }),
         strides: widen(unsafe { carrier.native_strides() }),
@@ -669,7 +707,7 @@ pub(super) unsafe extern "C" fn interp_bf_getbuffer(
 /// exporter's count, and it runs the `__release_buffer__` of a class written
 /// in Python on the way.
 pub(super) unsafe extern "C" fn interp_bf_releasebuffer(
-    _object: *mut CPyObject,
+    object: *mut CPyObject,
     view: *mut CPyBuffer,
 ) {
     if view.is_null() {
@@ -683,6 +721,12 @@ pub(super) unsafe extern "C" fn interp_bf_releasebuffer(
     let export = unsafe { Box::from_raw(internal as *mut Export) };
     release_acquired(unsafe { pyobject::from_ref(export.view) });
     unsafe { pyobject::decref(export.view) };
+    if export.source_is_memoryview && !object.is_null() {
+        // `PyBuffer_Release` clears/decrefs `view.obj` only after this slot
+        // returns, exactly as CPython `memory_releasebuf` relies on.
+        let source = unsafe { pyobject::from_ref(object) };
+        unsafe { pyre_object::memoryview::w_memoryview_exports_decref(source) };
+    }
 }
 
 /// Release a `memoryview` this layer acquired.  A release failure belongs to

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -5380,7 +5380,7 @@ fn instance_layout(w_base: PyObjectRef) -> *const pyre_object::PyType {
     let layout = unsafe { pyre_object::w_type_get_layout_ptr(w_base) };
     match layout.is_null() {
         true => instance,
-        false => unsafe { (*layout).typedef },
+        false => unsafe { (*(*layout).typedef).instance_type },
     }
 }
 
@@ -5425,7 +5425,7 @@ fn resolve_metatype(
     let layout = unsafe { pyre_object::w_type_get_layout_ptr(w_metatype) };
     let laid_out_as_a_type = !layout.is_null()
         && std::ptr::eq(
-            unsafe { (*layout).typedef },
+            unsafe { (*(*layout).typedef).instance_type },
             &pyre_object::pyobject::TYPE_TYPE as *const pyre_object::PyType,
         );
     if !laid_out_as_a_type {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3048,6 +3048,22 @@ unsafe fn load_global_via_cache(
         if raw.mstrategy.is_null() || raw.dstorage.is_null() {
             return Ok(None);
         }
+        // `celldict.py ModuleDictStrategy.switch_to_object_strategy` swaps the
+        // live strategy, so its module-only global-cache method is no longer
+        // available.  Continue through the ordinary mapping lookup just as
+        // `_load_global_fallback` does upstream.
+        if pyre_object::dictmultiobject::w_module_dict_is_object_strategy(w_module_dict) {
+            if let Some(value) = crate::baseobjspace::finditem_str(w_module_dict, name)? {
+                return Ok(Some(value));
+            }
+            if !w_builtin.is_null() && pyre_object::is_module(w_builtin) {
+                let w_builtin_dict = pyre_object::w_module_get_w_dict(w_builtin);
+                if !w_builtin_dict.is_null() {
+                    return crate::baseobjspace::finditem_str(w_builtin_dict, name);
+                }
+            }
+            return Ok(None);
+        }
         // `celldict.py:315-322`: the slow-path install just routes through
         // `w_globals.get_global_cache(varname)` and writes
         // `pycode._globals_caches[nameindex] = cache.ref`.
@@ -3057,8 +3073,9 @@ unsafe fn load_global_via_cache(
         // `builtincache` — that branch is dead in
         // `ModuleDictStrategy::get_global_cache` per its line-by-line port
         // of `celldict.py not space.config.objspace.honor__builtins__`.
-        let strategy = &mut *raw.mstrategy;
-        let storage = &*raw.dstorage;
+        let strategy =
+            pyre_object::dictmultiobject::w_module_dict_module_strategy_mut(w_module_dict);
+        let storage = pyre_object::dictmultiobject::w_module_dict_module_storage(w_module_dict);
         let cache = strategy.get_global_cache(storage, name);
         // `celldict.py:321/353 pycode._globals_caches[nameindex] = cache.ref`.
         if !pycode.is_null() {

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -2915,6 +2915,16 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::typedef::w_object",
         w_object,
     );
+    // `_ast` keeps CPython 3.14's process-wide `Load_singleton` in a rooted
+    // `OnceLock` slot.  Its accessor is opaque for the same reason as the
+    // builtin type accessors above and remains a residual runtime read.
+    let ast_load_singleton: fn() -> pyre_object::PyObjectRef =
+        crate::module::_ast::moduledef::load_singleton;
+    p0(
+        &mut entries,
+        "pyre_interpreter::module::_ast::moduledef::load_singleton",
+        ast_load_singleton,
+    );
 
     // Thread-local / `OnceLock` accessors that carry `#[dont_look_inside]`
     // (the `.with` closure read has no extractable graph): the codewriter

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -246,6 +246,24 @@ impl ObjectConverter {
         })
     }
 
+    /// PyPy `asdl_py.py:get_field_extractor` checks a present required field
+    /// for `None` after fetching it and before converting its ASDL value.
+    fn required_field(
+        &self,
+        object: PyObjectRef,
+        field: &str,
+        node: &str,
+    ) -> AstResult<PyObjectRef> {
+        let value = self.field(object, field, node)?;
+        if unsafe { pyre_object::is_none(value) } {
+            return Err(crate::PyError::value_error(format!(
+                "field '{field}' is required for {}",
+                class_name(object)
+            )));
+        }
+        Ok(value)
+    }
+
     fn optional_field(&self, object: PyObjectRef, field: &str) -> AstResult<Option<PyObjectRef>> {
         match crate::baseobjspace::getattr_str(object, field) {
             Ok(value) if unsafe { pyre_object::is_none(value) } => Ok(None),
@@ -387,7 +405,7 @@ impl ObjectConverter {
         } else if self.is_node(object, "Interactive")? {
             "Interactive"
         } else if self.is_node(object, "Expression")? {
-            let body = self.field(object, "body", "Expression")?;
+            let body = self.required_field(object, "body", "Expression")?;
             return Ok(ast::Mod::Expression(ast::ModExpression {
                 node_index: Default::default(),
                 range: Default::default(),
@@ -417,7 +435,7 @@ impl ObjectConverter {
                 "FunctionDef"
             };
             let name = self.identifier(object, "name", node)?;
-            let args = self.field(object, "args", node)?;
+            let args = self.required_field(object, "args", node)?;
             let parameters = Box::new(self.recurse(|this| this.parameters(args))?);
             let body = self.body(object, "body", node)?;
             let decorator_list = self.decorators(object, node)?;
@@ -444,7 +462,7 @@ impl ObjectConverter {
                 range,
             }))
         } else if self.is_node(object, "Expr")? {
-            let value = self.field(object, "value", "Expr")?;
+            let value = self.required_field(object, "value", "Expr")?;
             Ok(ast::Stmt::Expr(ast::StmtExpr {
                 node_index: Default::default(),
                 range,
@@ -468,7 +486,7 @@ impl ObjectConverter {
                     self.recurse(|this| this.expr(value))
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            let value = self.field(object, "value", "Assign")?;
+            let value = self.required_field(object, "value", "Assign")?;
             Ok(ast::Stmt::Assign(ast::StmtAssign {
                 node_index: Default::default(),
                 range,
@@ -534,7 +552,7 @@ impl ObjectConverter {
             }))
         } else if self.is_node(object, "AugAssign")? {
             let target = self.req_expr(object, "target", "AugAssign")?;
-            let op = self.field(object, "op", "AugAssign")?;
+            let op = self.required_field(object, "op", "AugAssign")?;
             let value = self.req_expr(object, "value", "AugAssign")?;
             Ok(ast::Stmt::AugAssign(ast::StmtAugAssign {
                 node_index: Default::default(),
@@ -1030,7 +1048,7 @@ impl ObjectConverter {
     }
 
     fn match_case(&mut self, object: PyObjectRef) -> AstResult<ast::MatchCase> {
-        let pattern = self.field(object, "pattern", "match_case")?;
+        let pattern = self.required_field(object, "pattern", "match_case")?;
         let pattern = self.recurse(|this| this.pattern(pattern))?;
         Ok(ast::MatchCase {
             range: Default::default(),
@@ -1209,7 +1227,7 @@ impl ObjectConverter {
         field: &str,
         node: &str,
     ) -> AstResult<Box<ast::Expr>> {
-        let value = self.field(object, field, node)?;
+        let value = self.required_field(object, field, node)?;
         Ok(Box::new(self.recurse(|this| this.expr(value))?))
     }
 
@@ -1225,8 +1243,14 @@ impl ObjectConverter {
         field: &str,
         node: &str,
     ) -> AstResult<ast::Identifier> {
+        let value = self.required_field(object, field, node)?;
+        if !unsafe { pyre_object::is_str(value) } {
+            return Err(crate::PyError::type_error(
+                "AST identifier must be of type str",
+            ));
+        }
         Ok(ast::Identifier::new(
-            self.string(object, field, node)?,
+            unsafe { pyre_object::w_str_get_value(value) }.to_string(),
             Default::default(),
         ))
     }
@@ -1296,8 +1320,8 @@ impl ObjectConverter {
     fn expr(&mut self, object: PyObjectRef) -> AstResult<ast::Expr> {
         let range = self.location(object, "expr")?;
         if self.is_node(object, "UnaryOp")? {
-            let operand = self.field(object, "operand", "UnaryOp")?;
-            let op = self.field(object, "op", "UnaryOp")?;
+            let operand = self.required_field(object, "operand", "UnaryOp")?;
+            let op = self.required_field(object, "op", "UnaryOp")?;
             Ok(ast::Expr::UnaryOp(ast::ExprUnaryOp {
                 node_index: Default::default(),
                 range,
@@ -1305,9 +1329,9 @@ impl ObjectConverter {
                 operand: Box::new(self.recurse(|this| this.expr(operand))?),
             }))
         } else if self.is_node(object, "BinOp")? {
-            let left = self.field(object, "left", "BinOp")?;
-            let right = self.field(object, "right", "BinOp")?;
-            let op = self.field(object, "op", "BinOp")?;
+            let left = self.required_field(object, "left", "BinOp")?;
+            let right = self.required_field(object, "right", "BinOp")?;
+            let op = self.required_field(object, "op", "BinOp")?;
             Ok(ast::Expr::BinOp(ast::ExprBinOp {
                 node_index: Default::default(),
                 range,
@@ -1316,7 +1340,7 @@ impl ObjectConverter {
                 right: Box::new(self.recurse(|this| this.expr(right))?),
             }))
         } else if self.is_node(object, "Call")? {
-            let func = self.field(object, "func", "Call")?;
+            let func = self.required_field(object, "func", "Call")?;
             let args = self
                 .list(object, "args", "Call")?
                 .into_iter()
@@ -1344,8 +1368,8 @@ impl ObjectConverter {
                 },
             }))
         } else if self.is_node(object, "Attribute")? {
-            let value = self.field(object, "value", "Attribute")?;
-            let ctx = self.field(object, "ctx", "Attribute")?;
+            let value = self.required_field(object, "value", "Attribute")?;
+            let ctx = self.required_field(object, "ctx", "Attribute")?;
             Ok(ast::Expr::Attribute(ast::ExprAttribute {
                 node_index: Default::default(),
                 range,
@@ -1366,7 +1390,7 @@ impl ObjectConverter {
                     self.recurse(|this| this.expr(element))
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            let ctx = self.context(self.field(object, "ctx", "sequence")?)?;
+            let ctx = self.context(self.required_field(object, "ctx", "sequence")?)?;
             if is_tuple {
                 Ok(ast::Expr::Tuple(ast::ExprTuple {
                     node_index: Default::default(),
@@ -1386,7 +1410,7 @@ impl ObjectConverter {
                 }))
             }
         } else if self.is_node(object, "Name")? {
-            let ctx = self.context(self.field(object, "ctx", "Name")?)?;
+            let ctx = self.context(self.required_field(object, "ctx", "Name")?)?;
             Ok(ast::Expr::Name(ast::ExprName {
                 node_index: Default::default(),
                 range,
@@ -1403,7 +1427,7 @@ impl ObjectConverter {
                 invalid_type: None,
             }))
         } else if self.is_node(object, "BoolOp")? {
-            let op = self.field(object, "op", "BoolOp")?;
+            let op = self.required_field(object, "op", "BoolOp")?;
             Ok(ast::Expr::BoolOp(ast::ExprBoolOp {
                 node_index: Default::default(),
                 range,
@@ -1421,7 +1445,7 @@ impl ObjectConverter {
                 value,
             }))
         } else if self.is_node(object, "Lambda")? {
-            let args = self.field(object, "args", "Lambda")?;
+            let args = self.required_field(object, "args", "Lambda")?;
             let parameters = self.recurse(|this| this.parameters(args))?;
             let body = self.req_expr(object, "body", "Lambda")?;
             Ok(ast::Expr::Lambda(ast::ExprLambda {
@@ -1555,7 +1579,7 @@ impl ObjectConverter {
         } else if self.is_node(object, "Subscript")? {
             let value = self.req_expr(object, "value", "Subscript")?;
             let slice = self.req_expr(object, "slice", "Subscript")?;
-            let ctx = self.context(self.field(object, "ctx", "Subscript")?)?;
+            let ctx = self.context(self.required_field(object, "ctx", "Subscript")?)?;
             Ok(ast::Expr::Subscript(ast::ExprSubscript {
                 node_index: Default::default(),
                 range,
@@ -1565,7 +1589,7 @@ impl ObjectConverter {
             }))
         } else if self.is_node(object, "Starred")? {
             let value = self.req_expr(object, "value", "Starred")?;
-            let ctx = self.context(self.field(object, "ctx", "Starred")?)?;
+            let ctx = self.context(self.required_field(object, "ctx", "Starred")?)?;
             Ok(ast::Expr::Starred(ast::ExprStarred {
                 node_index: Default::default(),
                 range,
@@ -1721,7 +1745,7 @@ impl ObjectConverter {
                 ))
             })
             .transpose()?;
-        let value = self.field(object, "value", "keyword")?;
+        let value = self.required_field(object, "value", "keyword")?;
         Ok(ast::Keyword {
             node_index: Default::default(),
             range,

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -6,7 +6,8 @@
 
 use pyre_object::{PY_NULL, PyObjectRef};
 use rustpython_compiler::codegen::{
-    interpolated_string_literal_value, string_literal_part_value, string_literal_value,
+    interpolated_string_literal_value, interpolation_debug_text, string_literal_part_value,
+    string_literal_value,
 };
 use rustpython_compiler::core::{SourceFile, SourceFileBuilder};
 use rustpython_compiler::{ast, parser};
@@ -1563,6 +1564,14 @@ impl ObjectConverter {
         } else if self.is_node(object, "FormattedValue")? {
             let element = self.interpolation(object)?;
             Ok(fstring(vec![element], None))
+        } else if self.is_node(object, "TemplateStr")? {
+            let range = self.location(object, "TemplateStr")?;
+            let values = self.exprs(object, "values", "TemplateStr")?;
+            Ok(tstring(range, Vec::new(), Some(values)))
+        } else if self.is_node(object, "Interpolation")? {
+            let range = self.location(object, "Interpolation")?;
+            let element = self.tstring_interpolation(object)?;
+            Ok(tstring(range, vec![element], None))
         } else {
             Err(crate::PyError::type_error(crate::display::wtf8_format!(
                 "expected some sort of expr, but got ",
@@ -1573,7 +1582,7 @@ impl ObjectConverter {
 
     fn interpolation(&mut self, object: PyObjectRef) -> AstResult<ast::InterpolatedStringElement> {
         let expression = self.req_expr(object, "value", "FormattedValue")?;
-        let conversion = self.conversion(object)?;
+        let conversion = self.conversion(object, "FormattedValue")?;
         let format_spec = self.opt_expr(object, "format_spec")?;
         Ok(ast::InterpolatedStringElement::Interpolation(
             ast::InterpolatedElement {
@@ -1595,11 +1604,40 @@ impl ObjectConverter {
         ))
     }
 
+    /// RustPython `_ast::string::tstring_interpolation_from_object_with_range`:
+    /// the public `Interpolation` is represented by a one-element native
+    /// t-string.  Its `str` and object-form format spec stay in the runtime
+    /// fields consumed by `compile_runtime_interpolation`.
+    fn tstring_interpolation(
+        &mut self,
+        object: PyObjectRef,
+    ) -> AstResult<ast::InterpolatedStringElement> {
+        let range = self.location(object, "Interpolation")?;
+        let expression = self.req_expr(object, "value", "Interpolation")?;
+        let str_value = self.field(object, "str", "Interpolation")?;
+        let runtime_str = Some(self.constant_value(str_value)?);
+        let conversion = self.conversion(object, "Interpolation")?;
+        let format_spec = self.opt_expr(object, "format_spec")?;
+        Ok(ast::InterpolatedStringElement::Interpolation(
+            ast::InterpolatedElement {
+                node_index: Default::default(),
+                range,
+                expression,
+                debug_text: None,
+                conversion,
+                format_spec: None,
+                runtime_str,
+                runtime_interpolation_format_spec: format_spec,
+                runtime_formatted_value_format_spec: None,
+            },
+        ))
+    }
+
     /// `visit_FormattedValue` (codegen.py) matches `s`, `r` and `a` and
     /// leaves anything else at no conversion at all; 3.14 stops instead, so a
     /// character it does not know is an error here.
-    fn conversion(&self, object: PyObjectRef) -> AstResult<ast::ConversionFlag> {
-        match self.int_field(object, "conversion", "FormattedValue")? {
+    fn conversion(&self, object: PyObjectRef, node: &str) -> AstResult<ast::ConversionFlag> {
+        match self.int_field(object, "conversion", node)? {
             -1 => Ok(ast::ConversionFlag::None),
             value if value == i64::from(b's') => Ok(ast::ConversionFlag::Str),
             value if value == i64::from(b'r') => Ok(ast::ConversionFlag::Repr),
@@ -1841,6 +1879,28 @@ fn fstring(
             flags: ast::FStringFlags::empty(),
         }),
         runtime_joined_str,
+        runtime_values: None,
+    })
+}
+
+/// RustPython `_ast::string::template_str_to_expr`: object-form values ride
+/// beside an otherwise empty native t-string, while a standalone public
+/// `Interpolation` is represented by its single native element.
+fn tstring(
+    range: ruff_text_size::TextRange,
+    elements: Vec<ast::InterpolatedStringElement>,
+    runtime_template_str: Option<Vec<ast::Expr>>,
+) -> ast::Expr {
+    ast::Expr::TString(ast::ExprTString {
+        node_index: Default::default(),
+        range,
+        value: ast::TStringValue::single(ast::TString {
+            node_index: Default::default(),
+            range,
+            elements: elements.into(),
+            flags: ast::TStringFlags::empty(),
+        }),
+        runtime_template_str,
         runtime_values: None,
     })
 }
@@ -2669,8 +2729,9 @@ impl Converter<'_> {
                 ],
             ),
             Expr::FString(n) => self.fstring(n),
-            Expr::TString(_) | Expr::IpyEscapeCommand(_) => Err(crate::PyError::not_implemented(
-                "AST conversion for template strings is not implemented",
+            Expr::TString(n) => self.tstring(n),
+            Expr::IpyEscapeCommand(_) => Err(crate::PyError::not_implemented(
+                "AST conversion for IPython escape commands is not implemented",
             )),
         }
     }
@@ -2722,6 +2783,187 @@ impl Converter<'_> {
         )
     }
 
+    /// RustPython `_ast::string::tstring_to_object`: publish the compiler's
+    /// t-string parts as the 3.14 `TemplateStr`/`Interpolation` public nodes.
+    fn tstring(&self, node: &ast::ExprTString) -> RootedResult {
+        if let Some(values) = node.runtime_template_str.as_deref() {
+            return self.node(
+                "TemplateStr",
+                Some(range(node.range)),
+                &[("values", self.expr_list(values)?)],
+            );
+        }
+        if let Some(values) = node.runtime_values.as_deref() {
+            let values = values
+                .iter()
+                .map(|value| {
+                    value
+                        .as_ref()
+                        .map(|value| self.expr(value))
+                        .transpose()
+                        .map(|value| self.optional(value))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            return self.node(
+                "TemplateStr",
+                Some(range(node.range)),
+                &[("values", self.list(values))],
+            );
+        }
+
+        // RustPython `_ast::string::standalone_tstring_interpolation_to_object`:
+        // an object-form `Interpolation` uses a one-part native t-string as
+        // its carrier and must come back as that node, not as a nested
+        // `TemplateStr`.
+        if let [tstring] = node.value.as_slice() {
+            let mut elements = tstring.elements.iter();
+            if let Some(ast::InterpolatedStringElement::Interpolation(interpolation)) =
+                elements.next()
+                && elements.next().is_none()
+                && interpolation.runtime_str.is_some()
+            {
+                let mut parts = Vec::new();
+                self.template_elements(&tstring.elements, tstring.flags.into(), &mut parts)?;
+                if let [JoinedPart::Value(value)] = parts.as_slice() {
+                    return Ok(*value);
+                }
+            }
+        }
+
+        let mut parts = Vec::new();
+        for tstring in node.value.as_slice() {
+            self.template_elements(&tstring.elements, tstring.flags.into(), &mut parts)?;
+        }
+        let values = self.joined_values(parts)?;
+        self.node(
+            "TemplateStr",
+            Some(range(node.range)),
+            &[("values", self.list(values))],
+        )
+    }
+
+    fn template_elements(
+        &self,
+        elements: &[ast::InterpolatedStringElement],
+        flags: ast::AnyStringFlags,
+        parts: &mut Vec<JoinedPart>,
+    ) -> Result<(), crate::PyError> {
+        use ruff_text_size::Ranged;
+
+        for element in elements {
+            match element {
+                ast::InterpolatedStringElement::Literal(literal) => push_literal(
+                    parts,
+                    range(literal.range),
+                    &interpolated_string_literal_value(&self.source_file, literal, flags),
+                ),
+                ast::InterpolatedStringElement::Interpolation(interpolation) => {
+                    let mut conversion = interpolation.conversion;
+                    let expression_str =
+                        if let Some(runtime_str) = interpolation.runtime_str.as_ref() {
+                            self.constant_value(runtime_str)?
+                        } else if let Some(debug_text) = interpolation.debug_text.as_ref() {
+                            let (text, text_range) = interpolation_debug_text(
+                                &self.source_file,
+                                debug_text,
+                                interpolation.expression.range(),
+                            );
+                            push_literal(parts, range(text_range), Wtf8::new(text.as_str()));
+                            conversion =
+                                debug_conversion(conversion, interpolation.format_spec.is_some());
+                            let expression_range = extend_expr_range_with_wrapping_parens(
+                                self.source,
+                                interpolation.range,
+                                interpolation.expression.range(),
+                            )
+                            .unwrap_or_else(|| interpolation.expression.range());
+                            let (start, end) = range(expression_range);
+                            let expression = self.source[start as usize..end as usize].to_owned();
+                            self.string(&strip_interpolation_expr(
+                                &[
+                                    debug_text.leading.as_str(),
+                                    expression.as_str(),
+                                    debug_text.trailing.as_str(),
+                                ]
+                                .concat(),
+                            ))
+                        } else {
+                            self.string(&self.tstring_interpolation_expr_str(interpolation))
+                        };
+                    let format_spec = if let Some(spec) =
+                        interpolation.runtime_interpolation_format_spec.as_deref()
+                    {
+                        Some(self.expr(spec)?)
+                    } else {
+                        self.format_spec(&interpolation.format_spec, flags)?
+                    };
+                    parts.push(JoinedPart::Value(self.node(
+                        "Interpolation",
+                        Some(range(interpolation.range)),
+                        &[
+                            ("value", self.expr(&interpolation.expression)?),
+                            ("str", expression_str),
+                            (
+                                "conversion",
+                                self.pin(pyre_object::w_int_new(conversion as i8 as i64)),
+                            ),
+                            ("format_spec", self.optional(format_spec)),
+                        ],
+                    )?));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn format_spec(
+        &self,
+        format_spec: &Option<Box<ast::InterpolatedStringFormatSpec>>,
+        flags: ast::AnyStringFlags,
+    ) -> Result<Option<Rooted>, crate::PyError> {
+        format_spec
+            .as_deref()
+            .map(|spec| {
+                let mut spec_parts = Vec::new();
+                self.interpolated_elements(&spec.elements, flags, &mut spec_parts)?;
+                let values = self.joined_values(spec_parts)?;
+                // RustPython `_ast::string::ruff_format_spec_to_joined_str`:
+                // the public `JoinedStr` includes the opening colon while its
+                // constant children begin after it.
+                let (mut start, end) = range(spec.range);
+                if start > 0 && self.source.as_bytes().get(start as usize - 1) == Some(&b':') {
+                    start -= 1;
+                }
+                self.node(
+                    "JoinedStr",
+                    Some((start, end)),
+                    &[("values", self.list(values))],
+                )
+            })
+            .transpose()
+    }
+
+    fn tstring_interpolation_expr_str(&self, interpolation: &ast::InterpolatedElement) -> String {
+        use ruff_text_size::Ranged;
+
+        let interpolation_range = interpolation.range;
+        let expression_range = extend_expr_range_with_wrapping_parens(
+            self.source,
+            interpolation_range,
+            interpolation.expression.range(),
+        )
+        .unwrap_or_else(|| interpolation.expression.range());
+        let after_open_brace = interpolation_range.start() + ruff_text_size::TextSize::from(1);
+        let start = if after_open_brace > expression_range.end() {
+            expression_range.start()
+        } else {
+            after_open_brace
+        };
+        let start = start.to_u32() as usize;
+        let end = expression_range.end().to_u32() as usize;
+        strip_interpolation_expr(&self.source[start..end])
+    }
+
     fn joined_values(&self, parts: Vec<JoinedPart>) -> Result<Vec<Rooted>, crate::PyError> {
         parts
             .into_iter()
@@ -2761,20 +3003,13 @@ impl Converter<'_> {
                             conversion = ast::ConversionFlag::Repr;
                         }
                     }
-                    let format_spec = interpolation
-                        .format_spec
-                        .as_deref()
-                        .map(|spec| {
-                            let mut spec_parts = Vec::new();
-                            self.interpolated_elements(&spec.elements, flags, &mut spec_parts)?;
-                            let values = self.joined_values(spec_parts)?;
-                            self.node(
-                                "JoinedStr",
-                                Some(range(spec.range)),
-                                &[("values", self.list(values))],
-                            )
-                        })
-                        .transpose()?;
+                    let format_spec = if let Some(spec) =
+                        interpolation.runtime_formatted_value_format_spec.as_deref()
+                    {
+                        Some(self.expr(spec)?)
+                    } else {
+                        self.format_spec(&interpolation.format_spec, flags)?
+                    };
                     parts.push(JoinedPart::Value(self.node(
                         "FormattedValue",
                         Some(range(interpolation.range)),
@@ -3401,6 +3636,62 @@ fn strip_debug_comments(text: &str) -> String {
         }
     }
     result
+}
+
+/// RustPython `_ast::string::debug_conversion`, following CPython
+/// `_get_interpolation_conversion` for `{expr=}`.
+fn debug_conversion(conversion: ast::ConversionFlag, has_format_spec: bool) -> ast::ConversionFlag {
+    if matches!(conversion, ast::ConversionFlag::None) && !has_format_spec {
+        ast::ConversionFlag::Repr
+    } else {
+        conversion
+    }
+}
+
+/// RustPython `_ast::string::extend_expr_range_with_wrapping_parens` keeps
+/// parentheses which belong to the spelling stored in `Interpolation.str`.
+fn extend_expr_range_with_wrapping_parens(
+    source: &str,
+    interpolation_range: ruff_text_size::TextRange,
+    expression_range: ruff_text_size::TextRange,
+) -> Option<ruff_text_size::TextRange> {
+    let (interpolation_start, interpolation_end) = range(interpolation_range);
+    let (expression_start, expression_end) = range(expression_range);
+    let left_slice = &source[interpolation_start as usize..expression_start as usize];
+    let (left_index, left_char) = left_slice
+        .char_indices()
+        .rev()
+        .find(|(_, ch)| !ch.is_whitespace())?;
+    if left_char != '(' {
+        return None;
+    }
+
+    let right_slice = &source[expression_end as usize..interpolation_end as usize];
+    let (right_index, right_char) = right_slice
+        .char_indices()
+        .find(|(_, ch)| !ch.is_whitespace())?;
+    if right_char != ')' {
+        return None;
+    }
+
+    Some(ruff_text_size::TextRange::new(
+        (interpolation_start + left_index as u32).into(),
+        (expression_end + right_index as u32 + 1).into(),
+    ))
+}
+
+/// CPython `_strip_interpolation_expr`: remove the debug marker and trailing
+/// whitespace from the expression spelling exposed as `Interpolation.str`.
+fn strip_interpolation_expr(expression: &str) -> String {
+    let mut end = expression.len();
+    for (index, ch) in expression.char_indices().rev() {
+        if ch.is_whitespace() || ch == '=' {
+            end = index;
+        } else {
+            break;
+        }
+    }
+    expression[..end].to_owned()
 }
 
 fn range(range: impl RangeParts) -> (u32, u32) {

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -2160,7 +2160,16 @@ impl Converter<'_> {
         }
         if let Some((start, end)) = range {
             let (lineno, col_offset) = self.location(start as usize);
-            let (end_lineno, end_col_offset) = self.location(end as usize);
+            let (mut end_lineno, mut end_col_offset) = self.location(end as usize);
+            // [3.14-spec] CPython `remove_docstring` replaces a sole optimized
+            // docstring with a four-column synthetic Pass on its start line.
+            // RustPython `remove_docstring_from_body` has to encode that in a
+            // byte TextRange, which crosses a newline for a short multiline
+            // literal; PyPy has no optimized-AST parse path to preserve here.
+            if name == "Pass" && end == start.saturating_add(4) && end_lineno != lineno {
+                end_lineno = lineno;
+                end_col_offset = col_offset.saturating_add(4);
+            }
             for (field, value) in [
                 ("lineno", lineno),
                 ("col_offset", col_offset),

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -308,9 +308,31 @@ impl ObjectConverter {
             Some(value) => self.obj_to_int(value)?,
             None => column,
         };
+
+        // [3.14-spec] CPython `VALIDATE_POSITIONS` rejects these ranges before
+        // code generation.  PyPy `AstValidator` has no corresponding check,
+        // but the invalid range and ValueError are observable at compile().
+        if line > end_line {
+            return Err(crate::PyError::value_error(format!(
+                "AST node line range ({line}, {end_line}) is not valid"
+            )));
+        }
+        if (line < 0 && end_line != line) || (column < 0 && column != end_column) {
+            return Err(crate::PyError::value_error(format!(
+                "AST node column range ({column}, {end_column}) for line range ({line}, {end_line}) is not valid"
+            )));
+        }
+        if line == end_line && column > end_column {
+            return Err(crate::PyError::value_error(format!(
+                "line {line}, column {column}-{end_column} is not a valid range"
+            )));
+        }
+
         let start = self.offset_of(line, column);
-        // A tree can name an end before its start; the compiler indexes the
-        // range and a reversed one would panic, so it collapses to the start.
+        // Zero and negative line numbers are accepted when the paired end
+        // position satisfies the checks above.  The synthetic source maps all
+        // of them to its first line, so preserve that valid input even when
+        // the mapping makes its byte offsets coincide or reverse.
         let end = self.offset_of(end_line, end_column).max(start);
         Ok(ruff_text_size::TextRange::new(start.into(), end.into()))
     }

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -15,6 +15,89 @@ use rustpython_wtf8::{Wtf8, Wtf8Buf};
 
 type AstResult<T> = Result<T, crate::PyError>;
 
+/// RustPython `_ast::should_report_unsupported_syntax_error`: Ruff records
+/// every version-shaped difference, including compatibility syntax CPython
+/// deliberately still accepts for older feature versions.  Only these are
+/// parser errors at the public `feature_version` boundary.
+fn should_report_unsupported_syntax_error(error: &parser::UnsupportedSyntaxError) -> bool {
+    use parser::UnsupportedSyntaxErrorKind as Kind;
+    matches!(
+        error.kind,
+        Kind::Match
+            | Kind::Walrus
+            | Kind::ExceptStar
+            | Kind::PositionalOnlyParameter
+            | Kind::TypeParameterList
+            | Kind::TypeAliasStatement
+            | Kind::TypeParamDefault
+            | Kind::TemplateStrings
+            | Kind::UnparenthesizedExceptionTypes
+            | Kind::LazyImportStatement
+            | Kind::ParenthesizedKeywordArgumentName
+    )
+}
+
+/// CPython `_PyPegen_new_identifier` refuses a lexer name whose NFKC form is
+/// one of the three constant keywords.  Ruff already performs that same NFKC
+/// conversion when it builds the AST, but (unlike CPython) leaves the result
+/// as an identifier.  Inspecting only `Name` tokens keeps this a parser check:
+/// a literal `None`/`True`/`False` token is, of course, valid.
+fn validate_parser_identifiers(source: &str, tokens: &ast::token::Tokens) -> AstResult<()> {
+    for token in tokens.iter() {
+        if token.kind() != ast::token::TokenKind::Name {
+            continue;
+        }
+        let (_, range) = token.as_tuple();
+        let spelling = &source[range.start().to_usize()..range.end().to_usize()];
+        if spelling.is_ascii() {
+            continue;
+        }
+        let normalized = rustpython_unicode::normalize(
+            rustpython_unicode::NormalizeForm::Nfkc,
+            Wtf8::new(spelling),
+        );
+        let normalized = normalized.to_string_lossy();
+        if matches!(normalized.as_ref(), "None" | "True" | "False") {
+            return Err(crate::PyError::value_error(format!(
+                "identifier field can't represent '{normalized}' constant"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Ruff currently records `TypeParamDefault` for `T = int`, but not for the
+/// sibling `*Ts = int` and `**P = int` spellings.  CPython 3.14 applies the
+/// same 3.13 grammar boundary to all three, so fill only that parser metadata
+/// gap after Ruff has produced the native tree.
+fn has_variadic_type_param_default(module: &ast::Mod) -> bool {
+    use ast::visitor::Visitor;
+
+    #[derive(Default)]
+    struct Finder {
+        found: bool,
+    }
+
+    impl<'a> Visitor<'a> for Finder {
+        fn visit_type_param(&mut self, type_param: &'a ast::TypeParam) {
+            self.found |= match type_param {
+                ast::TypeParam::TypeVar(_) => false,
+                ast::TypeParam::TypeVarTuple(node) => node.default.is_some(),
+                ast::TypeParam::ParamSpec(node) => node.default.is_some(),
+            };
+            if !self.found {
+                ast::visitor::walk_type_param(self, type_param);
+            }
+        }
+    }
+
+    let mut finder = Finder::default();
+    if let ast::Mod::Module(module) = module {
+        finder.visit_body(&module.body);
+    }
+    finder.found
+}
+
 /// Convert an interpreter-level `_ast` tree back into Ruff's compiler AST and
 /// compile it.  This is the reverse of `Converter`, corresponding to PyPy's
 /// generated `ast_from_object` boundary.
@@ -1958,6 +2041,7 @@ pub fn parse_to_object(source: &str, mode: crate::compile::Mode) -> crate::PyRes
         crate::compile::CompileOpts::default(),
         true,
         false,
+        -1,
     )
 }
 
@@ -1969,6 +2053,7 @@ pub fn parse_to_object_with_opts(
     opts: crate::compile::CompileOpts,
     syntax_check_only: bool,
     type_comments: bool,
+    feature_version: i64,
 ) -> crate::PyResult {
     // The tokenizer sees a source whose line terminators are all `\n`
     // (`pytokenizer.py:654-662`), so the same rewrite runs here; the nodes and
@@ -1976,26 +2061,49 @@ pub fn parse_to_object_with_opts(
     let source = &*crate::compile::universal_newline(source);
     // A comment leaves no node behind, so a `type_comments=True` parse reads
     // the token list the parser hands back beside the tree.
-    let mut collected = super::type_comments::TypeComments::default();
-    let mut module = match mode {
-        // An expression has none of the five positions a `TYPE_COMMENT` is
-        // accepted in, so the comments are collected here only to be refused.
-        crate::compile::Mode::Eval => parser::parse_expression(source).map(|parsed| {
-            if type_comments {
-                collected = super::type_comments::collect(parsed.tokens(), source);
-            }
-            ast::Mod::Expression(parsed.into_syntax())
-        }),
+    let parse_mode = match mode {
+        crate::compile::Mode::Eval => parser::Mode::Expression,
         crate::compile::Mode::Exec
         | crate::compile::Mode::Single
-        | crate::compile::Mode::BlockExpr => parser::parse_module(source).map(|parsed| {
-            if type_comments {
-                collected = super::type_comments::collect(parsed.tokens(), source);
-            }
-            ast::Mod::Module(parsed.into_syntax())
-        }),
+        | crate::compile::Mode::BlockExpr => parser::Mode::Module,
+    };
+    // PyPy `CompileInfo.feature_version` carries the requested grammar version
+    // into `PythonParser.parse_source`.  CPython 3.14 treats every negative
+    // value and every future minor as the current grammar, so never expose
+    // Ruff's preview 3.15 grammar through this 3.14 boundary.
+    let minor = if feature_version < 0 {
+        14
+    } else {
+        feature_version.min(14) as u8
+    };
+    let options = parser::ParseOptions::from(parse_mode)
+        .with_target_version(ast::PythonVersion { major: 3, minor });
+    let parsed = parser::parse(source, options)
+        .map_err(|error| crate::PyError::syntax_error(error.to_string()))?;
+    // [3.14-spec] CPython `_PyPegen_new_identifier` performs this check as it
+    // interns each identifier.  PyPy `new_identifier` has the same NFKC
+    // spelling, while its parser-owned tree deliberately bypasses
+    // `AstValidator`; keep the check at that parser boundary too.
+    validate_parser_identifiers(source, parsed.tokens())?;
+    if let Some(error) = parsed
+        .unsupported_syntax_errors()
+        .iter()
+        .find(|error| should_report_unsupported_syntax_error(error))
+    {
+        return Err(crate::PyError::syntax_error(error.to_string()));
     }
-    .map_err(|error| crate::PyError::syntax_error(error.to_string()))?;
+    let mut collected = super::type_comments::TypeComments::default();
+    if type_comments {
+        // An expression has none of the five positions a `TYPE_COMMENT` is
+        // accepted in, so the comments are collected here only to be refused.
+        collected = super::type_comments::collect(parsed.tokens(), source);
+    }
+    let mut module = parsed.into_syntax();
+    if minor < 13 && has_variadic_type_param_default(&module) {
+        return Err(crate::PyError::syntax_error(
+            "Type parameter defaults are only supported in Python 3.13 and greater",
+        ));
+    }
     if type_comments {
         collected.attach(&mut module);
         // What attachment left over is a token no rule accepted, which the

--- a/pyre/pyre-interpreter/src/module/_ast/convert.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/convert.rs
@@ -201,7 +201,14 @@ pub fn preprocess_object_to_object(
     } else {
         source
     };
-    module_to_object(module, source, mode, ast_module, &converter.carried_ignores)
+    module_to_object(
+        module,
+        source,
+        mode,
+        ast_module,
+        &converter.carried_ignores,
+        false,
+    )
 }
 
 struct ObjectConverter {
@@ -706,7 +713,7 @@ impl ObjectConverter {
                     let clause_test = self.req_expr(nested, "test", "If")?;
                     let clause_body = self.body(nested, "body", "If")?;
                     elif_else_clauses.push(ast::ElifElseClause {
-                        range,
+                        range: self.location(nested, "If")?,
                         node_index: Default::default(),
                         test: Some(*clause_test),
                         body: clause_body,
@@ -2125,7 +2132,7 @@ pub fn parse_to_object_with_opts(
         0,
         crate::call::take_last_exec_ctx(),
     )?;
-    module_to_object(module, source, mode, ast_module, &collected.ignores)
+    module_to_object(module, source, mode, ast_module, &collected.ignores, true)
 }
 
 fn module_to_object(
@@ -2134,6 +2141,7 @@ fn module_to_object(
     mode: crate::compile::Mode,
     module_object: PyObjectRef,
     ignores: &[super::type_comments::TypeComment],
+    parser_locations: bool,
 ) -> crate::PyResult {
     let _roots = pyre_object::gc_roots::push_roots();
     let ast_module = Rooted(pyre_object::gc_roots::shadow_stack_len());
@@ -2142,6 +2150,7 @@ fn module_to_object(
         source,
         source_file: SourceFileBuilder::new("<unknown>", source).finish(),
         ast_module,
+        parser_locations,
     };
     let root = match module {
         ast::Mod::Expression(module) => converter.node(
@@ -2215,6 +2224,10 @@ struct Converter<'a> {
     /// a `SourceFile` to slice it by range.
     source_file: SourceFile,
     ast_module: Rooted,
+    /// Ruff parser nodes include a few tokens that public PyPy/CPython AST
+    /// locations exclude.  ObjectConverter inputs already carry public
+    /// locations and must never receive those parser-only adaptations again.
+    parser_locations: bool,
 }
 
 impl Converter<'_> {
@@ -2307,6 +2320,47 @@ impl Converter<'_> {
         )
     }
 
+    /// PyPy `BaseParser.set_decorators` attaches decorators while preserving
+    /// the raw FunctionDef/ClassDef `target.location()`.  Ruff instead starts
+    /// the statement range at the first `@`, so recover the first code token
+    /// after the final decorator for the public node's location.
+    fn definition_range(
+        &self,
+        statement: ruff_text_size::TextRange,
+        decorators: &[ast::Decorator],
+    ) -> (u32, u32) {
+        let (start, end) = range(statement);
+        if !self.parser_locations {
+            return (start, end);
+        }
+        let Some(last) = decorators.last() else {
+            return (start, end);
+        };
+        let after_decorator = last.range.end().to_u32();
+        if start > after_decorator {
+            // ObjectConverter already received the public def/class location.
+            return (start, end);
+        }
+        let bytes = self.source.as_bytes();
+        let mut offset = after_decorator as usize;
+        let limit = (end as usize).min(bytes.len());
+        while offset < limit {
+            while offset < limit && matches!(bytes[offset], b' ' | b'\t' | b'\x0c' | b'\n') {
+                offset += 1;
+            }
+            if offset < limit && bytes[offset] == b'#' {
+                while offset < limit && bytes[offset] != b'\n' {
+                    offset += 1;
+                }
+                continue;
+            }
+            if offset < limit {
+                return (offset as u32, end);
+            }
+        }
+        (start, end)
+    }
+
     fn stmt_list(&self, stmts: &[ast::Stmt]) -> RootedResult {
         stmts
             .iter()
@@ -2348,7 +2402,7 @@ impl Converter<'_> {
                     .collect::<Result<Vec<_>, _>>()?;
                 self.node(
                     name,
-                    Some(range(node.range)),
+                    Some(self.definition_range(node.range, &node.decorator_list)),
                     &[
                         ("name", self.string(node.name.as_str())),
                         ("args", self.parameters(&node.parameters)?),
@@ -2389,7 +2443,7 @@ impl Converter<'_> {
                 };
                 self.node(
                     "ClassDef",
-                    Some(range(node.range)),
+                    Some(self.definition_range(node.range, &node.decorator_list)),
                     &[
                         ("name", self.string(node.name.as_str())),
                         ("bases", bases),
@@ -2495,9 +2549,17 @@ impl Converter<'_> {
                 for clause in node.elif_else_clauses.iter().rev() {
                     let body = self.stmt_list(&clause.body)?;
                     if let Some(test) = clause.test.as_ref() {
+                        // PyPy PEG `elif_stmt` is recursive, so its LOCATIONS
+                        // end at the tail of the whole elif/else chain.
+                        let (start, clause_end) = range(clause.range);
+                        let end = if self.parser_locations {
+                            node.range.end().to_u32()
+                        } else {
+                            clause_end
+                        };
                         orelse = vec![self.node(
                             "If",
-                            Some(range(clause.range)),
+                            Some((start, end)),
                             &[
                                 ("test", self.expr(test)?),
                                 ("body", body),
@@ -3475,17 +3537,17 @@ impl Converter<'_> {
         let posonlyargs = p
             .posonlyargs
             .iter()
-            .map(|p| self.parameter(&p.parameter))
+            .map(|p| self.parameter(&p.parameter, 0))
             .collect::<Result<Vec<_>, _>>()?;
         let args = p
             .args
             .iter()
-            .map(|p| self.parameter(&p.parameter))
+            .map(|p| self.parameter(&p.parameter, 0))
             .collect::<Result<Vec<_>, _>>()?;
         let kwonlyargs = p
             .kwonlyargs
             .iter()
-            .map(|p| self.parameter(&p.parameter))
+            .map(|p| self.parameter(&p.parameter, 0))
             .collect::<Result<Vec<_>, _>>()?;
         let mut defaults = Vec::new();
         defaults.extend(
@@ -3515,23 +3577,38 @@ impl Converter<'_> {
                 ("args", self.list(args)),
                 (
                     "vararg",
-                    self.optional(p.vararg.as_deref().map(|v| self.parameter(v)).transpose()?),
+                    self.optional(
+                        p.vararg
+                            .as_deref()
+                            .map(|v| self.parameter(v, 1))
+                            .transpose()?,
+                    ),
                 ),
                 ("kwonlyargs", self.list(kwonlyargs)),
                 ("kw_defaults", self.list(kw_defaults)),
                 (
                     "kwarg",
-                    self.optional(p.kwarg.as_deref().map(|v| self.parameter(v)).transpose()?),
+                    self.optional(
+                        p.kwarg
+                            .as_deref()
+                            .map(|v| self.parameter(v, 2))
+                            .transpose()?,
+                    ),
                 ),
                 ("defaults", self.list(defaults)),
             ],
         )
     }
 
-    fn parameter(&self, p: &ast::Parameter) -> RootedResult {
+    fn parameter(&self, p: &ast::Parameter, star_width: u32) -> RootedResult {
+        let (start, end) = range(p.range);
+        // PyPy PEG `star_etc`/`kwds` build `ast.arg` from `param_no_default`,
+        // after consuming `*` or `**`; Ruff includes those tokens in range.
+        let star_width = if self.parser_locations { star_width } else { 0 };
+        let start = start.saturating_add(star_width).min(end);
         self.node(
             "arg",
-            Some(range(p.range)),
+            Some((start, end)),
             &[
                 ("arg", self.string(p.name.as_str())),
                 (

--- a/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
@@ -7,10 +7,27 @@ use pyre_object::PyObjectRef;
 
 const LOCATION_ATTRIBUTES: &[&str] = &["lineno", "col_offset", "end_lineno", "end_col_offset"];
 
-// CPython 3.14 `ast_state.Load_singleton`, the default for an omitted
-// `expr_context` field.  PyPy keeps generated AST type state process-wide;
-// keep the one movable instance in a registered process-lifetime root slot.
+// CPython 3.14 `ast_state.AST_type` / `Load_singleton`.  PyPy's `State` keeps
+// the generated AST types process-wide; keep both movable objects in
+// registered process-lifetime root slots.
 static LOAD_SINGLETON: std::sync::OnceLock<Box<usize>> = std::sync::OnceLock::new();
+static AST_TYPE: std::sync::OnceLock<Box<usize>> = std::sync::OnceLock::new();
+
+fn register_ast_type(value: PyObjectRef) {
+    let _ = AST_TYPE.get_or_init(|| {
+        let mut slot = Box::new(value as usize);
+        let root = (&mut *slot) as *mut usize as *mut *mut u8;
+        unsafe { pyre_object::gc_hook::try_gc_add_root(root) };
+        slot
+    });
+}
+
+#[majit_macros::dont_look_inside]
+fn ast_type() -> PyObjectRef {
+    **AST_TYPE
+        .get()
+        .expect("_ast AST type initialized before AST operations") as PyObjectRef
+}
 
 fn register_load_singleton(value: PyObjectRef) {
     let _ = LOAD_SINGLETON.get_or_init(|| {
@@ -62,6 +79,195 @@ fn ast_fields_owner_name(w_type: PyObjectRef) -> String {
 
 fn ast_field_repr(field: PyObjectRef) -> Result<rustpython_wtf8::Wtf8Buf, crate::PyError> {
     unsafe { crate::display::py_repr_wtf8(field) }
+}
+
+fn ast_repr_type_name(object: PyObjectRef) -> String {
+    let w_type = crate::typedef::r#type(object)
+        .expect("AST instance has a live type")
+        .as_ptr();
+    if std::ptr::eq(w_type, ast_type()) {
+        // CPython's generated root has the static tp_name `ast.AST`; PyPy's
+        // W_AST TypeDef owns the same root while generated children use their
+        // unqualified ASDL names.
+        "ast.AST".to_owned()
+    } else {
+        unsafe { pyre_object::w_type_get_name(w_type) }.to_owned()
+    }
+}
+
+fn is_ast_instance(object: PyObjectRef) -> bool {
+    let Some(w_type) = crate::typedef::r#type(object) else {
+        return false;
+    };
+    unsafe { pyre_object::w_type_issubtype(w_type.as_ptr(), ast_type()) }
+}
+
+// CPython publishes both methods through `AST_type_slots` (`Py_tp_init` /
+// `Py_tp_repr`), while PyPy's `TypeDef` turns `interp2app(W_AST.descr_*)` into
+// the corresponding wrapper descriptors.  The generated AST root is a heap
+// type built after the ordinary builtin-owner table, so bind its owner
+// explicitly as it is minted.
+static AST_METHOD_OWNER: crate::gateway::MethodOwner = crate::gateway::MethodOwner {
+    type_name: "ast.AST",
+    is_instance: Some(is_ast_instance),
+};
+
+fn ast_slot_wrapper(
+    name: &'static str,
+    function: crate::gateway::BuiltinCodeFn,
+    arity: Option<u16>,
+) -> PyObjectRef {
+    let roots = pyre_object::gc_roots::push_roots();
+    let wrapper = match arity {
+        Some(arity) => crate::gateway::make_slot_wrapper_with_arity(name, function, arity),
+        None => crate::gateway::make_slot_wrapper(name, function),
+    };
+    let wrapper_slot = roots.base();
+    let _ = roots.pin_root(wrapper);
+    let code = unsafe { crate::function::getcode(roots.get(wrapper_slot)) } as PyObjectRef;
+    unsafe { crate::gateway::builtin_code_set_owner(code, &AST_METHOD_OWNER) };
+    let qualname = pyre_object::w_str_new(&format!("AST.{name}"));
+    unsafe {
+        crate::function::function_set_qualname(roots.get(wrapper_slot), qualname);
+        crate::function::function_set_objclass(roots.get(wrapper_slot), ast_type());
+    }
+    roots.get(wrapper_slot)
+}
+
+/// CPython 3.14 `ast_repr_list`, expressed through PyPy object-space sequence
+/// operations.  In particular, list/tuple subclasses keep their `__len__`
+/// and `__getitem__` overrides, and only the first and last items are read.
+fn ast_repr_list(
+    sequence: PyObjectRef,
+    depth: i64,
+) -> Result<rustpython_wtf8::Wtf8Buf, crate::PyError> {
+    let roots = pyre_object::gc_roots::push_roots();
+    let sequence_slot = roots.base();
+    let _ = roots.pin_root(sequence);
+    let sequence = || roots.get(sequence_slot);
+    let length = crate::baseobjspace::len_w(sequence())?;
+    if length == 0 {
+        return unsafe { crate::display::py_repr_wtf8(sequence()) };
+    }
+
+    // Allocate and root the index before re-reading the movable sequence for
+    // the object-space call.
+    let first_index_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(pyre_object::w_int_new(0));
+    let first = crate::baseobjspace::getitem(sequence(), roots.get(first_index_slot))?;
+    let first_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(first);
+    let last_slot = if length > 1 {
+        let last_index_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = roots.pin_root(pyre_object::w_int_new(length - 1));
+        let last = crate::baseobjspace::getitem(sequence(), roots.get(last_index_slot))?;
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = roots.pin_root(last);
+        Some(slot)
+    } else {
+        None
+    };
+
+    let is_list = unsafe { pyre_object::is_list(sequence()) };
+    let mut out = rustpython_wtf8::Wtf8Buf::new();
+    out.push_str(if is_list { "[" } else { "(" });
+    for index in 0..std::cmp::min(length, 2) {
+        if index > 0 {
+            out.push_str(", ");
+        }
+        let item = if index == 0 {
+            roots.get(first_slot)
+        } else {
+            roots.get(last_slot.expect("second AST sequence item was rooted"))
+        };
+        if is_ast_instance(item) {
+            out.push_wtf8(&ast_repr_max_depth(item, depth - 1)?);
+        } else {
+            out.push_wtf8(&unsafe { crate::display::py_repr_wtf8(item)? });
+        }
+        if index == 0 && length > 2 {
+            out.push_str(", ...");
+        }
+    }
+    out.push_str(if is_list { "]" } else { ")" });
+    Ok(out)
+}
+
+/// [3.14-spec] PyPy `W_AST` has no custom repr and no JIT/immutability hint on
+/// the definition; the pinned 3.14 `AST_Tests.test_repr` observes the generated
+/// `ast_repr_max_depth` surface.  Keep PyPy's W_AST owner, subtype tests and
+/// object-space dispatch while porting that bounded formatting walk literally.
+fn ast_repr_max_depth(
+    object: PyObjectRef,
+    depth: i64,
+) -> Result<rustpython_wtf8::Wtf8Buf, crate::PyError> {
+    let roots = pyre_object::gc_roots::push_roots();
+    let object_slot = roots.base();
+    let _ = roots.pin_root(object);
+    let object = || roots.get(object_slot);
+    let type_name = ast_repr_type_name(object());
+    if depth <= 0 {
+        return Ok(rustpython_wtf8::Wtf8Buf::from_string(format!(
+            "{type_name}(...)"
+        )));
+    }
+    let Some(_guard) = crate::display::ReprGuard::enter(object()) else {
+        return Ok(rustpython_wtf8::Wtf8Buf::from_string(format!(
+            "{type_name}(...)"
+        )));
+    };
+
+    let w_type = crate::typedef::r#type(object())
+        .expect("AST instance has a live type")
+        .as_ptr();
+    let type_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(w_type);
+    let fields = crate::baseobjspace::getattr_str(roots.get(type_slot), "_fields")?;
+    let fields_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(fields);
+    let num_fields = crate::baseobjspace::len_w(roots.get(fields_slot))?;
+    if num_fields == 0 {
+        return Ok(rustpython_wtf8::Wtf8Buf::from_string(format!(
+            "{type_name}()"
+        )));
+    }
+
+    let mut out = rustpython_wtf8::Wtf8Buf::from_string(format!("{type_name}("));
+    for index in 0..num_fields {
+        let index_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = roots.pin_root(pyre_object::w_int_new(index));
+        let name =
+            crate::baseobjspace::getitem(roots.get(fields_slot), roots.get(index_slot))?;
+        let name_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = roots.pin_root(name);
+        let value = crate::baseobjspace::getattr(object(), roots.get(name_slot))?;
+        let value_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = roots.pin_root(value);
+        let value = roots.get(value_slot);
+        let value_repr = if unsafe { pyre_object::is_list(value) || pyre_object::is_tuple(value) }
+        {
+            ast_repr_list(value, depth)?
+        } else if is_ast_instance(value) {
+            ast_repr_max_depth(value, depth - 1)?
+        } else {
+            unsafe { crate::display::py_repr_wtf8(value)? }
+        };
+
+        if index > 0 {
+            out.push_str(", ");
+        }
+        out.push_wtf8(crate::baseobjspace::text_wtf8_w(roots.get(name_slot))?);
+        out.push_str("=");
+        out.push_wtf8(&value_repr);
+    }
+    out.push_str(")");
+    Ok(out)
+}
+
+fn ast_repr(args: &[PyObjectRef]) -> crate::PyResult {
+    Ok(pyre_object::w_str_from_wtf8_managed(ast_repr_max_depth(
+        args[0], 3,
+    )?))
 }
 
 fn ast_warn(message: rustpython_wtf8::Wtf8Buf) -> Result<(), crate::PyError> {
@@ -702,16 +908,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // generated AST types report `__module__ == "ast"` (astcompiler/ast.py;
     // the host `_ast.Module.__module__` is likewise `'ast'`).
     let make = |name: &str, base: PyObjectRef, variants: Option<&[&str]>| -> PyObjectRef {
-        // A `dict` header moves, and every store below allocates: the key
-        // string, the value, and the dict's own storage when it grows.
+        // PyPy `State.make_new_type` keeps `w_base` and `w_dict` as wrapped
+        // objects across every allocation in the body.  Publish both here:
+        // the base is also a movable heap type, not a Rust-stable descriptor.
         let roots = pyre_object::gc_roots::push_roots();
-        let dict_slot = roots.base();
+        let base_slot = roots.base();
+        let _ = roots.pin_root(base);
+        let dict_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = roots.pin_root(pyre_object::w_dict_new());
         // `make_type` builds ONE tuple of field names and binds it to both
         // `_fields` and `__match_args__`, so `Expr._fields is
         // Expr.__match_args__`. It is pinned beside the namespace dict because
         // the first store allocates a key string and can grow it.
-        let fields_slot = dict_slot + 1;
+        let fields_slot = pyre_object::gc_roots::shadow_stack_len();
         let _ = roots.pin_root(tuple_of_names(node_fields(name)));
         // The value arrives already built.  Call arguments evaluate left to
         // right, so reading a dict slot inline with an allocating value
@@ -754,10 +963,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // `descr__new__` takes it as a parameter beside `arguments_w`.  Every
         // other caller reaches it through an attribute lookup that supplies
         // one; this one builds the argument list by hand, so it names `type`.
+        let name_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = roots.pin_root(pyre_object::w_str_new(name));
+        let bases_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = roots.pin_root(pyre_object::w_tuple_new(vec![roots.get(base_slot)]));
         let args = [
             crate::typedef::w_type(),
-            pyre_object::w_str_new(name),
-            pyre_object::w_tuple_new(vec![base]),
+            roots.get(name_slot),
+            roots.get(bases_slot),
             roots.get(dict_slot),
         ];
         let typ = crate::builtins::type_descr_new(&args).expect("_ast heap type creation");
@@ -780,13 +993,25 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
 
     // Root: AST(object).
     let ast = make("AST", crate::typedef::w_object(), None);
+    register_ast_type(ast);
+    let method_roots = pyre_object::gc_roots::push_roots();
+    let init_slot = method_roots.base();
+    let _ = method_roots.pin_root(ast_slot_wrapper("__init__", ast_init, None));
+    let repr_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = method_roots.pin_root(ast_slot_wrapper("__repr__", ast_repr, Some(1)));
     crate::baseobjspace::setattr_str(
-        ast,
+        ast_type(),
         "__init__",
-        crate::make_builtin_function("__init__", ast_init),
+        method_roots.get(init_slot),
     )
     .expect("set AST.__init__");
-    crate::module_ns_store(ns, "AST", ast);
+    crate::baseobjspace::setattr_str(
+        ast_type(),
+        "__repr__",
+        method_roots.get(repr_slot),
+    )
+    .expect("set AST.__repr__");
+    crate::module_ns_store(ns, "AST", ast_type());
 
     // Abstract groups (direct AST subclasses) and their concrete members,
     // per the ASDL grammar.
@@ -834,10 +1059,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         ("type_param", &["TypeVar", "ParamSpec", "TypeVarTuple"]),
     ];
     for (group, members) in groups {
-        let g = make(group, ast, Some(members));
-        crate::module_ns_store(ns, group, g);
+        let g = make(group, ast_type(), Some(members));
+        let group_roots = pyre_object::gc_roots::push_roots();
+        let group_slot = group_roots.base();
+        let _ = group_roots.pin_root(g);
+        crate::module_ns_store(ns, group, group_roots.get(group_slot));
         for m in *members {
-            let t = make(m, g, None);
+            let t = make(m, group_roots.get(group_slot), None);
             crate::module_ns_store(ns, m, t);
         }
     }
@@ -847,7 +1075,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "comprehension", "arguments", "arg", "keyword", "alias", "withitem", "match_case",
     ];
     for name in standalone {
-        let t = make(name, ast, None);
+        let t = make(name, ast_type(), None);
         crate::module_ns_store(ns, name, t);
     }
 

--- a/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
@@ -7,8 +7,39 @@ use pyre_object::PyObjectRef;
 
 const LOCATION_ATTRIBUTES: &[&str] = &["lineno", "col_offset", "end_lineno", "end_col_offset"];
 
+// CPython 3.14 `ast_state.Load_singleton`, the default for an omitted
+// `expr_context` field.  PyPy keeps generated AST type state process-wide;
+// keep the one movable instance in a registered process-lifetime root slot.
+static LOAD_SINGLETON: std::sync::OnceLock<Box<usize>> = std::sync::OnceLock::new();
+
+fn register_load_singleton(value: PyObjectRef) {
+    let _ = LOAD_SINGLETON.get_or_init(|| {
+        let mut slot = Box::new(value as usize);
+        let root = (&mut *slot) as *mut usize as *mut *mut u8;
+        unsafe { pyre_object::gc_hook::try_gc_add_root(root) };
+        slot
+    });
+}
+
+#[majit_macros::dont_look_inside]
+pub(crate) fn load_singleton() -> PyObjectRef {
+    **LOAD_SINGLETON
+        .get()
+        .expect("_ast Load singleton initialized before AST construction")
+        as PyObjectRef
+}
+
 fn tuple_of_names(names: &[&str]) -> PyObjectRef {
     pyre_object::w_tuple_new(names.iter().map(|name| pyre_object::w_str_new(name)).collect())
+}
+
+fn ast_instance_type_name(object: PyObjectRef) -> &'static str {
+    // PyPy `W_AST_init` asks `space.type(self)`: every public AST node uses
+    // the common `W_ObjectObject` payload, so its payload vtable only says
+    // `object`; the heap class lives in `w_class`.
+    unsafe {
+        pyre_object::w_type_get_name(pyre_object::w_instance_get_type(object))
+    }
 }
 
 fn ast_init(args: &[PyObjectRef]) -> crate::PyResult {
@@ -31,14 +62,14 @@ fn ast_init(args: &[PyObjectRef]) -> crate::PyResult {
     if values.len() > fields.len() {
         return Err(crate::PyError::type_error(format!(
             "{} constructor takes at most {} positional arguments",
-            unsafe { pyre_object::type_name_of(zelf) },
+            ast_instance_type_name(zelf),
             fields.len()
         )));
     }
-    let mut positional_names = Vec::with_capacity(values.len());
+    let mut assigned_names = Vec::with_capacity(values.len() + kwargs.is_some() as usize);
     for (index, &field) in fields.iter().take(values.len()).enumerate() {
         let name = unsafe { pyre_object::w_str_get_value(field) };
-        positional_names.push(name.to_owned());
+        assigned_names.push(name.to_owned());
         crate::baseobjspace::setattr_str(zelf, name, roots.get(values_base + index))?;
     }
     if let Some(kwargs_slot) = kwargs_slot {
@@ -50,16 +81,106 @@ fn ast_init(args: &[PyObjectRef]) -> crate::PyResult {
             if name == "__pyre_kw__" {
                 continue;
             }
-            if positional_names.iter().any(|positional| positional == name) {
+            if assigned_names.iter().any(|assigned| assigned == name) {
                 return Err(crate::PyError::type_error(format!(
                     "{} got multiple values for argument '{name}'",
-                    unsafe { pyre_object::type_name_of(zelf) }
+                    ast_instance_type_name(zelf)
                 )));
             }
             crate::baseobjspace::setattr_str(zelf, name, roots.get(entries_base + index))?;
+            assigned_names.push(name.to_owned());
+        }
+    }
+    let node = ast_instance_type_name(zelf);
+    for &field in node_sequence_fields(node) {
+        if !assigned_names.iter().any(|assigned| assigned == field) {
+            crate::baseobjspace::setattr_str(zelf, field, pyre_object::w_list_new(Vec::new()))?;
+        }
+    }
+    for &field in node_load_fields(node) {
+        if !assigned_names.iter().any(|assigned| assigned == field) {
+            crate::baseobjspace::setattr_str(zelf, field, load_singleton())?;
         }
     }
     Ok(pyre_object::w_none())
+}
+
+/// Repeated (`*`) ASDL fields.  CPython 3.14 `ast_type_init` installs a fresh
+/// list for each omitted field; this is instance state, never a class default.
+fn node_sequence_fields(name: &str) -> &'static [&'static str] {
+    match name {
+        "Module" => &["body", "type_ignores"],
+        "Interactive" => &["body"],
+        "FunctionType" => &["argtypes"],
+        "FunctionDef" | "AsyncFunctionDef" => &["body", "decorator_list", "type_params"],
+        "ClassDef" => &["bases", "keywords", "body", "decorator_list", "type_params"],
+        "Delete" => &["targets"],
+        "Assign" => &["targets"],
+        "TypeAlias" => &["type_params"],
+        "For" | "AsyncFor" | "While" | "If" => &["body", "orelse"],
+        "With" | "AsyncWith" => &["items", "body"],
+        "Match" => &["cases"],
+        "Try" | "TryStar" => &["body", "handlers", "orelse", "finalbody"],
+        "Import" | "ImportFrom" => &["names"],
+        "Global" | "Nonlocal" => &["names"],
+        "BoolOp" => &["values"],
+        "Dict" => &["keys", "values"],
+        "Set" => &["elts"],
+        "ListComp" | "SetComp" | "GeneratorExp" => &["generators"],
+        "DictComp" => &["generators"],
+        "Compare" => &["ops", "comparators"],
+        "Call" => &["args", "keywords"],
+        "JoinedStr" | "TemplateStr" => &["values"],
+        "List" | "Tuple" => &["elts"],
+        "ExceptHandler" => &["body"],
+        "MatchSequence" | "MatchOr" => &["patterns"],
+        "MatchMapping" => &["keys", "patterns"],
+        "MatchClass" => &["patterns", "kwd_attrs", "kwd_patterns"],
+        "comprehension" => &["ifs"],
+        "arguments" => &["posonlyargs", "args", "kwonlyargs", "kw_defaults", "defaults"],
+        "match_case" => &["body"],
+        _ => &[],
+    }
+}
+
+fn node_load_fields(name: &str) -> &'static [&'static str] {
+    match name {
+        "Attribute" | "Subscript" | "Starred" | "Name" | "List" | "Tuple" => &["ctx"],
+        _ => &[],
+    }
+}
+
+/// Optional (`?`) ASDL fields whose PyPy-generated type dictionary supplies
+/// `None`.  The location entries live on their ASDL owner and are inherited.
+fn node_default_none_fields(name: &str) -> &'static [&'static str] {
+    match name {
+        "stmt" | "expr" | "excepthandler" => &["end_lineno", "end_col_offset"],
+        "FunctionDef" | "AsyncFunctionDef" => &["returns", "type_comment"],
+        "Return" => &["value"],
+        "Assign" => &["type_comment"],
+        "AnnAssign" => &["value"],
+        "For" | "AsyncFor" | "With" | "AsyncWith" => &["type_comment"],
+        "Raise" => &["exc", "cause"],
+        "Assert" => &["msg"],
+        "ImportFrom" => &["module", "level"],
+        "Yield" => &["value"],
+        "FormattedValue" | "Interpolation" => &["format_spec"],
+        "Constant" => &["kind"],
+        "Slice" => &["lower", "upper", "step"],
+        "ExceptHandler" => &["type", "name"],
+        "arguments" => &["vararg", "kwarg"],
+        "arg" => &["annotation", "type_comment", "end_lineno", "end_col_offset"],
+        "keyword" => &["arg", "end_lineno", "end_col_offset"],
+        "alias" => &["asname", "end_lineno", "end_col_offset"],
+        "withitem" => &["optional_vars"],
+        "match_case" => &["guard"],
+        "MatchMapping" => &["rest"],
+        "MatchStar" => &["name"],
+        "MatchAs" => &["pattern", "name"],
+        "TypeVar" => &["bound", "default_value"],
+        "ParamSpec" | "TypeVarTuple" => &["default_value"],
+        _ => &[],
+    }
 }
 
 fn node_fields(name: &str) -> &'static [&'static str] {
@@ -135,8 +256,13 @@ fn node_fields(name: &str) -> &'static [&'static str] {
     }
 }
 
-fn node_has_location(name: &str) -> bool {
-    matches!(name, "FunctionDef" | "AsyncFunctionDef" | "ClassDef" | "Return" | "Delete" | "Assign" | "TypeAlias" | "AugAssign" | "AnnAssign" | "For" | "AsyncFor" | "While" | "If" | "With" | "AsyncWith" | "Match" | "Raise" | "Try" | "TryStar" | "Assert" | "Import" | "ImportFrom" | "Global" | "Nonlocal" | "Expr" | "Pass" | "Break" | "Continue" | "BoolOp" | "NamedExpr" | "BinOp" | "UnaryOp" | "Lambda" | "IfExp" | "Dict" | "Set" | "ListComp" | "SetComp" | "DictComp" | "GeneratorExp" | "Await" | "Yield" | "YieldFrom" | "Compare" | "Call" | "FormattedValue" | "JoinedStr" | "Interpolation" | "TemplateStr" | "Constant" | "Attribute" | "Subscript" | "Starred" | "Name" | "List" | "Tuple" | "Slice" | "ExceptHandler" | "MatchValue" | "MatchSingleton" | "MatchSequence" | "MatchMapping" | "MatchClass" | "MatchStar" | "MatchAs" | "MatchOr" | "TypeVar" | "ParamSpec" | "TypeVarTuple" | "arg" | "keyword" | "alias")
+fn node_attributes(name: &str) -> Option<&'static [&'static str]> {
+    match name {
+        "AST" => Some(&[]),
+        "stmt" | "expr" | "excepthandler" | "pattern" | "type_param" | "arg" | "keyword"
+        | "alias" => Some(LOCATION_ATTRIBUTES),
+        _ => None,
+    }
 }
 
 /// _ast stub — PyPy: pypy/module/_ast/
@@ -199,16 +325,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // its `~`/`^` anchors without it.
         put(dict_slot, "__match_args__", roots.get(fields_slot))
             .expect("set __match_args__ on _ast type namespace");
-        put(
-            dict_slot,
-            "_attributes",
-            tuple_of_names(if node_has_location(name) {
-                LOCATION_ATTRIBUTES
-            } else {
-                &[]
-            }),
-        )
-        .expect("set _attributes on _ast type namespace");
+        if let Some(attributes) = node_attributes(name) {
+            put(dict_slot, "_attributes", tuple_of_names(attributes))
+                .expect("set _attributes on _ast type namespace");
+        }
+        // PyPy `State.make_new_type`: optional ASDL fields are class-level
+        // `None` defaults, inherited from the owner for optional attributes.
+        for &field in node_default_none_fields(name) {
+            put(dict_slot, field, pyre_object::w_none())
+                .expect("set optional AST field default");
+        }
         for &field in node_fields(name) {
             put(field_types_slot, field, crate::typedef::w_object())
                 .expect("set _field_types item");
@@ -287,22 +413,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         let g = make(group, ast);
         crate::module_ns_store(ns, group, g);
         for m in *members {
-            let roots = pyre_object::gc_roots::push_roots();
-            let type_slot = roots.base();
-            let _ = roots.pin_root(make(m, g));
-            // PyPy's generated `W_FormattedValue` and CPython 3.14's
-            // `make_type` declarations expose an omitted optional format
-            // spec as `None` through the class. `Interpolation` is the 3.14
-            // sibling with the same optional field.
-            if matches!(*m, "FormattedValue" | "Interpolation") {
-                crate::baseobjspace::setattr_str(
-                    roots.get(type_slot),
-                    "format_spec",
-                    pyre_object::w_none(),
-                )
-                .expect("set optional AST format_spec default");
-            }
-            crate::module_ns_store(ns, m, roots.get(type_slot));
+            let t = make(m, g);
+            crate::module_ns_store(ns, m, t);
         }
     }
 
@@ -313,6 +425,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         let t = make(name, ast);
         crate::module_ns_store(ns, name, t);
     }
+
+    // CPython 3.14 `ast_state.Load_singleton`: every omitted expression
+    // context receives this same object.  Construct it after the ASDL groups
+    // have published `Load` and keep it outside the public module namespace.
+    let roots = pyre_object::gc_roots::push_roots();
+    let load_type_slot = roots.base();
+    let _ = roots.pin_root(crate::module_ns_get(ns, "Load").expect("_ast.Load registered"));
+    register_load_singleton(pyre_object::w_instance_new(roots.get(load_type_slot)));
 
     // `compile()` / `ast.parse()` flag bitmasks, used by `lib-python/3/ast.py`
     // (`flags = PyCF_ONLY_AST; flags |= PyCF_TYPE_COMMENTS`). Values are

--- a/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
@@ -102,7 +102,9 @@ fn node_fields(name: &str) -> &'static [&'static str] {
         "Compare" => &["left", "ops", "comparators"],
         "Call" => &["func", "args", "keywords"],
         "FormattedValue" => &["value", "conversion", "format_spec"],
+        "Interpolation" => &["value", "str", "conversion", "format_spec"],
         "JoinedStr" => &["values"],
+        "TemplateStr" => &["values"],
         "Constant" => &["value", "kind"],
         "Attribute" => &["value", "attr", "ctx"],
         "Subscript" => &["value", "slice", "ctx"],
@@ -134,7 +136,7 @@ fn node_fields(name: &str) -> &'static [&'static str] {
 }
 
 fn node_has_location(name: &str) -> bool {
-    matches!(name, "FunctionDef" | "AsyncFunctionDef" | "ClassDef" | "Return" | "Delete" | "Assign" | "TypeAlias" | "AugAssign" | "AnnAssign" | "For" | "AsyncFor" | "While" | "If" | "With" | "AsyncWith" | "Match" | "Raise" | "Try" | "TryStar" | "Assert" | "Import" | "ImportFrom" | "Global" | "Nonlocal" | "Expr" | "Pass" | "Break" | "Continue" | "BoolOp" | "NamedExpr" | "BinOp" | "UnaryOp" | "Lambda" | "IfExp" | "Dict" | "Set" | "ListComp" | "SetComp" | "DictComp" | "GeneratorExp" | "Await" | "Yield" | "YieldFrom" | "Compare" | "Call" | "FormattedValue" | "JoinedStr" | "Constant" | "Attribute" | "Subscript" | "Starred" | "Name" | "List" | "Tuple" | "Slice" | "ExceptHandler" | "MatchValue" | "MatchSingleton" | "MatchSequence" | "MatchMapping" | "MatchClass" | "MatchStar" | "MatchAs" | "MatchOr" | "TypeVar" | "ParamSpec" | "TypeVarTuple" | "arg" | "keyword" | "alias")
+    matches!(name, "FunctionDef" | "AsyncFunctionDef" | "ClassDef" | "Return" | "Delete" | "Assign" | "TypeAlias" | "AugAssign" | "AnnAssign" | "For" | "AsyncFor" | "While" | "If" | "With" | "AsyncWith" | "Match" | "Raise" | "Try" | "TryStar" | "Assert" | "Import" | "ImportFrom" | "Global" | "Nonlocal" | "Expr" | "Pass" | "Break" | "Continue" | "BoolOp" | "NamedExpr" | "BinOp" | "UnaryOp" | "Lambda" | "IfExp" | "Dict" | "Set" | "ListComp" | "SetComp" | "DictComp" | "GeneratorExp" | "Await" | "Yield" | "YieldFrom" | "Compare" | "Call" | "FormattedValue" | "JoinedStr" | "Interpolation" | "TemplateStr" | "Constant" | "Attribute" | "Subscript" | "Starred" | "Name" | "List" | "Tuple" | "Slice" | "ExceptHandler" | "MatchValue" | "MatchSingleton" | "MatchSequence" | "MatchMapping" | "MatchClass" | "MatchStar" | "MatchAs" | "MatchOr" | "TypeVar" | "ParamSpec" | "TypeVarTuple" | "arg" | "keyword" | "alias")
 }
 
 /// _ast stub — PyPy: pypy/module/_ast/
@@ -254,8 +256,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             &[
                 "BoolOp", "NamedExpr", "BinOp", "UnaryOp", "Lambda", "IfExp", "Dict", "Set",
                 "ListComp", "SetComp", "DictComp", "GeneratorExp", "Await", "Yield", "YieldFrom",
-                "Compare", "Call", "FormattedValue", "JoinedStr", "Constant", "Attribute",
-                "Subscript", "Starred", "Name", "List", "Tuple", "Slice",
+                "Compare", "Call", "FormattedValue", "Interpolation", "JoinedStr",
+                "TemplateStr", "Constant", "Attribute", "Subscript", "Starred", "Name", "List",
+                "Tuple", "Slice",
             ],
         ),
         ("expr_context", &["Load", "Store", "Del"]),
@@ -284,8 +287,22 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         let g = make(group, ast);
         crate::module_ns_store(ns, group, g);
         for m in *members {
-            let t = make(m, g);
-            crate::module_ns_store(ns, m, t);
+            let roots = pyre_object::gc_roots::push_roots();
+            let type_slot = roots.base();
+            let _ = roots.pin_root(make(m, g));
+            // PyPy's generated `W_FormattedValue` and CPython 3.14's
+            // `make_type` declarations expose an omitted optional format
+            // spec as `None` through the class. `Interpolation` is the 3.14
+            // sibling with the same optional field.
+            if matches!(*m, "FormattedValue" | "Interpolation") {
+                crate::baseobjspace::setattr_str(
+                    roots.get(type_slot),
+                    "format_spec",
+                    pyre_object::w_none(),
+                )
+                .expect("set optional AST format_spec default");
+            }
+            crate::module_ns_store(ns, m, roots.get(type_slot));
         }
     }
 

--- a/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
@@ -42,112 +42,244 @@ fn ast_instance_type_name(object: PyObjectRef) -> &'static str {
     }
 }
 
+fn ast_fields_owner_name(w_type: PyObjectRef) -> String {
+    let name = unsafe { pyre_object::w_type_get_name(w_type) };
+    if name == "AST" {
+        let bases = unsafe { pyre_object::w_type_get_bases(w_type) };
+        if unsafe { pyre_object::w_tuple_len(bases) } == 1
+            && unsafe { pyre_object::w_tuple_getitem(bases, 0) }
+                == Some(crate::typedef::w_object())
+        {
+            // CPython's generated root retains the static tp_name `ast.AST`,
+            // while PyPy `State.make_new_type` owns it as the heap type `AST`.
+            // Keep the PyPy owner/storage and reproduce the 3.14 observable
+            // name only at `ast_type_init`'s missing `_fields` diagnostic.
+            return "ast.AST".to_owned();
+        }
+    }
+    name.to_owned()
+}
+
+fn ast_field_repr(field: PyObjectRef) -> Result<rustpython_wtf8::Wtf8Buf, crate::PyError> {
+    unsafe { crate::display::py_repr_wtf8(field) }
+}
+
+fn ast_warn(message: rustpython_wtf8::Wtf8Buf) -> Result<(), crate::PyError> {
+    crate::warn::warn_category_w(
+        pyre_object::w_str_from_wtf8(message),
+        "DeprecationWarning",
+        2,
+    )
+}
+
+fn expr_context_type() -> PyObjectRef {
+    // CPython `ast_state.expr_context_type`; PyPy's `State` also owns this
+    // generated base beside the Load singleton.  Recover that same base from
+    // the singleton instead of adding a second semantic side table.
+    unsafe {
+        let load_type = pyre_object::w_instance_get_type(load_singleton());
+        let bases = pyre_object::w_type_get_bases(load_type);
+        pyre_object::w_tuple_getitem(bases, 0).expect("Load has expr_context base")
+    }
+}
+
+/// [3.14-spec] PyPy `W_AST_init` only assigns supplied arguments.  The pinned
+/// `ASTConstructorTests` require CPython 3.14 `ast_type_init`'s observable
+/// missing-field defaults/deprecations and unexpected-keyword deprecation.
+/// Keep PyPy's generated-type owner and general object-space dispatch while
+/// porting that constructor decision tree here.
 fn ast_init(args: &[PyObjectRef]) -> crate::PyResult {
     let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
-    let Some((&zelf, values)) = positional.split_first() else {
+    let Some((_, values)) = positional.split_first() else {
         return Err(crate::PyError::type_error("AST.__init__() missing self"));
     };
     // `builtin_code_call` hands the body a native slice the collector does not
-    // update, and every store below allocates — a field value may be a `list`
-    // or a `dict`, and the keyword dict moves too.  The values and the keyword
-    // dict are one livevar set, so both slices are written before either is
-    // queried (a forwarding query is itself a safepoint), and each use reads
-    // its slot back.  `zelf` and the `_fields` strings do not move.
+    // update.  Publish self as well as every value: attribute lookup, equality,
+    // repr, warnings and stores all run Python and may collect.
     let roots = pyre_object::gc_roots::push_roots();
-    let values_base = roots.publish(values);
+    let positional_base = roots.publish(positional);
     let kwargs_slot = kwargs.map(|kwargs| roots.publish(&[kwargs]));
-    roots.normalize(values_base, values.len() + usize::from(kwargs.is_some()));
-    let fields_obj = crate::baseobjspace::getattr_str(zelf, "_fields")?;
-    let fields = unsafe { pyre_object::w_tuple_items_copy_as_vec(fields_obj) };
-    if values.len() > fields.len() {
+    roots.normalize(
+        positional_base,
+        positional.len() + usize::from(kwargs.is_some()),
+    );
+    let zelf = || roots.get(positional_base);
+    let w_type_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(unsafe { pyre_object::w_instance_get_type(zelf()) });
+    let fields_obj =
+        match crate::baseobjspace::findattr_result(roots.get(w_type_slot), "_fields")? {
+            Some(fields_obj) => fields_obj,
+            None => {
+                let owner = ast_fields_owner_name(roots.get(w_type_slot));
+                return Err(crate::PyError::attribute_error_with_context(
+                    format!("type object '{owner}' has no attribute '_fields'"),
+                    roots.get(w_type_slot),
+                    "_fields",
+                ));
+            }
+        };
+    let fields_obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(fields_obj);
+    // PyPy `W_AST_init` uses `space.fixedview`, and CPython uses the sequence
+    // protocol; user subclasses may therefore replace the generated tuple.
+    let fields = crate::baseobjspace::fixedview(roots.get(fields_obj_slot), -1)?;
+    let fields_base = roots.publish(&fields);
+    roots.normalize(fields_base, fields.len());
+    let num_fields = fields.len();
+    if values.len() > num_fields {
         return Err(crate::PyError::type_error(format!(
-            "{} constructor takes at most {} positional arguments",
-            ast_instance_type_name(zelf),
-            fields.len()
+            "{} constructor takes at most {} positional argument{}",
+            ast_instance_type_name(zelf()),
+            num_fields,
+            if num_fields == 1 { "" } else { "s" }
         )));
     }
-    let mut assigned_names = Vec::with_capacity(values.len() + kwargs.is_some() as usize);
-    for (index, &field) in fields.iter().take(values.len()).enumerate() {
-        let name = unsafe { pyre_object::w_str_get_value(field) };
-        assigned_names.push(name.to_owned());
-        crate::baseobjspace::setattr_str(zelf, name, roots.get(values_base + index))?;
+    // CPython `ast_type_init` uses a set, so duplicate or unhashable custom
+    // `_fields` have the same constructor semantics.  Build it through PyPy's
+    // set operation rather than a host side-table.
+    let remaining_fields = pyre_object::w_set_new();
+    let remaining_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(remaining_fields);
+    // Build the raw carrier only after `w_set_new` has had its allocation
+    // safepoint; `builtin_set_add_items` publishes every member before hashing.
+    let rooted_fields: Vec<_> = (0..num_fields)
+        .map(|index| roots.get(fields_base + index))
+        .collect();
+    crate::builtins::builtin_set_add_items(roots.get(remaining_slot), &rooted_fields)?;
+    for index in 0..values.len() {
+        crate::baseobjspace::setattr(
+            zelf(),
+            roots.get(fields_base + index),
+            roots.get(positional_base + index + 1),
+        )?;
+        crate::type_methods::set_discard_checked(
+            roots.get(remaining_slot),
+            roots.get(fields_base + index),
+        )?;
     }
+
+    let mut attributes_slot = None;
     if let Some(kwargs_slot) = kwargs_slot {
-        let entries = unsafe { pyre_object::w_dict_str_entries(roots.get(kwargs_slot)) };
-        let entry_values: Vec<PyObjectRef> = entries.iter().map(|(_, value)| *value).collect();
-        let entries_base = roots.publish(&entry_values);
-        roots.normalize(entries_base, entry_values.len());
-        for (index, (name, _)) in entries.iter().enumerate() {
-            if name == "__pyre_kw__" {
+        let entries = unsafe { pyre_object::w_dict_items(roots.get(kwargs_slot)) };
+        let mut entry_objects = Vec::with_capacity(entries.len() * 2);
+        for &(key, value) in &entries {
+            entry_objects.push(key);
+            entry_objects.push(value);
+        }
+        let entries_base = roots.publish(&entry_objects);
+        roots.normalize(entries_base, entry_objects.len());
+        for index in 0..entries.len() {
+            let key_slot = entries_base + index * 2;
+            let value_slot = key_slot + 1;
+            let key = roots.get(key_slot);
+            if unsafe {
+                pyre_object::is_str(key) && pyre_object::w_str_get_value(key) == "__pyre_kw__"
+            } {
                 continue;
             }
-            if assigned_names.iter().any(|assigned| assigned == name) {
-                return Err(crate::PyError::type_error(format!(
-                    "{} got multiple values for argument '{name}'",
-                    ast_instance_type_name(zelf)
-                )));
+
+            if crate::baseobjspace::contains(roots.get(fields_obj_slot), roots.get(key_slot))? {
+                if !crate::type_methods::set_discard_checked(
+                    roots.get(remaining_slot),
+                    roots.get(key_slot),
+                )? {
+                    let key_repr = ast_field_repr(roots.get(key_slot))?;
+                    return Err(crate::PyError::type_error(crate::display::wtf8_format!(
+                        ast_instance_type_name(zelf()),
+                        " got multiple values for argument ",
+                        key_repr
+                    )));
+                }
+            } else {
+                let attributes = if let Some(slot) = attributes_slot {
+                    roots.get(slot)
+                } else {
+                    let value = crate::baseobjspace::getattr_str(
+                        roots.get(w_type_slot),
+                        "_attributes",
+                    )?;
+                    let slot = pyre_object::gc_roots::shadow_stack_len();
+                    let _ = roots.pin_root(value);
+                    attributes_slot = Some(slot);
+                    roots.get(slot)
+                };
+                if !crate::baseobjspace::contains(attributes, roots.get(key_slot))? {
+                    let key_repr = ast_field_repr(roots.get(key_slot))?;
+                    ast_warn(crate::display::wtf8_format!(
+                        ast_instance_type_name(zelf()),
+                        ".__init__ got an unexpected keyword argument ",
+                        key_repr,
+                        ". Support for arbitrary keyword arguments is deprecated and will be ",
+                        "removed in Python 3.15."
+                    ))?;
+                }
             }
-            crate::baseobjspace::setattr_str(zelf, name, roots.get(entries_base + index))?;
-            assigned_names.push(name.to_owned());
+            crate::baseobjspace::setattr(
+                zelf(),
+                roots.get(key_slot),
+                roots.get(value_slot),
+            )?;
         }
     }
-    let node = ast_instance_type_name(zelf);
-    for &field in node_sequence_fields(node) {
-        if !assigned_names.iter().any(|assigned| assigned == field) {
-            crate::baseobjspace::setattr_str(zelf, field, pyre_object::w_list_new(Vec::new()))?;
-        }
+
+    if unsafe { pyre_object::setobject::w_set_len(roots.get(remaining_slot)) } == 0 {
+        return Ok(pyre_object::w_none());
     }
-    for &field in node_load_fields(node) {
-        if !assigned_names.iter().any(|assigned| assigned == field) {
-            crate::baseobjspace::setattr_str(zelf, field, load_singleton())?;
+    let Some(field_types) =
+        crate::baseobjspace::findattr_result(roots.get(w_type_slot), "_field_types")?
+    else {
+        // CPython 3.14 `ast_type_init`: user AST subclasses without generated
+        // metadata keep the pre-3.13 behavior and leave omitted fields absent.
+        return Ok(pyre_object::w_none());
+    };
+    let field_types_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = roots.pin_root(field_types);
+    let remaining = unsafe { pyre_object::setobject::w_set_items(roots.get(remaining_slot)) };
+    let remaining_base = roots.publish(&remaining);
+    roots.normalize(remaining_base, remaining.len());
+    for index in 0..remaining.len() {
+        let field_slot = remaining_base + index;
+        let Some(field_type) = crate::baseobjspace::finditem(
+            roots.get(field_types_slot),
+            roots.get(field_slot),
+        )?
+        else {
+            let field_repr = ast_field_repr(roots.get(field_slot))?;
+            ast_warn(crate::display::wtf8_format!(
+                "Field ",
+                field_repr,
+                " is missing from ",
+                ast_instance_type_name(zelf()),
+                "._field_types. This will become an error in Python 3.15."
+            ))?;
+            continue;
+        };
+        let field_type_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = roots.pin_root(field_type);
+        if unsafe { pyre_object::is_union(roots.get(field_type_slot)) } {
+            // Optional fields already have their inherited class-level None.
+        } else if unsafe { pyre_object::is_generic_alias(roots.get(field_type_slot)) } {
+            let empty = pyre_object::w_list_new(Vec::new());
+            let empty_slot = pyre_object::gc_roots::shadow_stack_len();
+            let _ = roots.pin_root(empty);
+            crate::baseobjspace::setattr(
+                zelf(),
+                roots.get(field_slot),
+                roots.get(empty_slot),
+            )?;
+        } else if crate::baseobjspace::is_w(roots.get(field_type_slot), expr_context_type()) {
+            crate::baseobjspace::setattr(zelf(), roots.get(field_slot), load_singleton())?;
+        } else {
+            let field_repr = ast_field_repr(roots.get(field_slot))?;
+            ast_warn(crate::display::wtf8_format!(
+                ast_instance_type_name(zelf()),
+                ".__init__ missing 1 required positional argument: ",
+                field_repr,
+                ". This will become an error in Python 3.15."
+            ))?;
         }
     }
     Ok(pyre_object::w_none())
-}
-
-/// Repeated (`*`) ASDL fields.  CPython 3.14 `ast_type_init` installs a fresh
-/// list for each omitted field; this is instance state, never a class default.
-fn node_sequence_fields(name: &str) -> &'static [&'static str] {
-    match name {
-        "Module" => &["body", "type_ignores"],
-        "Interactive" => &["body"],
-        "FunctionType" => &["argtypes"],
-        "FunctionDef" | "AsyncFunctionDef" => &["body", "decorator_list", "type_params"],
-        "ClassDef" => &["bases", "keywords", "body", "decorator_list", "type_params"],
-        "Delete" => &["targets"],
-        "Assign" => &["targets"],
-        "TypeAlias" => &["type_params"],
-        "For" | "AsyncFor" | "While" | "If" => &["body", "orelse"],
-        "With" | "AsyncWith" => &["items", "body"],
-        "Match" => &["cases"],
-        "Try" | "TryStar" => &["body", "handlers", "orelse", "finalbody"],
-        "Import" | "ImportFrom" => &["names"],
-        "Global" | "Nonlocal" => &["names"],
-        "BoolOp" => &["values"],
-        "Dict" => &["keys", "values"],
-        "Set" => &["elts"],
-        "ListComp" | "SetComp" | "GeneratorExp" => &["generators"],
-        "DictComp" => &["generators"],
-        "Compare" => &["ops", "comparators"],
-        "Call" => &["args", "keywords"],
-        "JoinedStr" | "TemplateStr" => &["values"],
-        "List" | "Tuple" => &["elts"],
-        "ExceptHandler" => &["body"],
-        "MatchSequence" | "MatchOr" => &["patterns"],
-        "MatchMapping" => &["keys", "patterns"],
-        "MatchClass" => &["patterns", "kwd_attrs", "kwd_patterns"],
-        "comprehension" => &["ifs"],
-        "arguments" => &["posonlyargs", "args", "kwonlyargs", "kw_defaults", "defaults"],
-        "match_case" => &["body"],
-        _ => &[],
-    }
-}
-
-fn node_load_fields(name: &str) -> &'static [&'static str] {
-    match name {
-        "Attribute" | "Subscript" | "Starred" | "Name" | "List" | "Tuple" => &["ctx"],
-        _ => &[],
-    }
 }
 
 /// Optional (`?`) ASDL fields whose PyPy-generated type dictionary supplies
@@ -256,11 +388,11 @@ fn node_fields(name: &str) -> &'static [&'static str] {
     }
 }
 
-/// `Parser/Python.asdl`: one type spelling per entry in [`node_fields`].
-/// Keeping the ASDL `?`/`*` markers here lets the generated type setup below
-/// build the same union and `list[...]` objects as CPython 3.14
-/// `add_ast_annotations`, while the owner/type creation order remains PyPy's
-/// `State.make_new_type` order.
+/// CPython 3.14 `add_ast_annotations`: one public field-type spelling per
+/// entry in [`node_fields`].  Its generated metadata normalizes the two ASDL
+/// `expr?*` fields to `list[expr]`; [`node_signature`] restores the literal
+/// spelling only for their docs.  The owner/type creation order remains
+/// PyPy's `State.make_new_type` order.
 fn node_field_types(name: &str) -> &'static [&'static str] {
     match name {
         "Module" => &["stmt*", "type_ignore*"],
@@ -371,6 +503,52 @@ fn asdl_field_type(ns: PyObjectRef, spelling: &str) -> crate::PyResult {
     }
 }
 
+fn node_signature(name: &str) -> String {
+    let fields = node_fields(name);
+    let types = node_field_types(name);
+    assert_eq!(fields.len(), types.len(), "ASDL signature fields for {name}");
+    if fields.is_empty() {
+        name.to_owned()
+    } else {
+        let fields = types
+            .iter()
+            .zip(fields)
+            .map(|(typ, field)| {
+                // `Parser/Python.asdl` permits None placeholders in these two
+                // repeated expr fields.  CPython `add_ast_annotations`
+                // deliberately publishes `list[expr]`, while the generated
+                // docstring retains the literal `expr?*` ASDL spelling.
+                let typ = if (name == "Dict" && *field == "keys")
+                    || (name == "arguments" && *field == "kw_defaults")
+                {
+                    "expr?*"
+                } else {
+                    typ
+                };
+                format!("{typ} {field}")
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("{name}({fields})")
+    }
+}
+
+fn node_doc(name: &str, variants: Option<&[&str]>) -> String {
+    let Some(variants) = variants else {
+        return node_signature(name);
+    };
+    let signatures: Vec<_> = variants
+        .iter()
+        .map(|variant| node_signature(variant))
+        .collect();
+    if signatures.iter().all(|signature| !signature.contains('(')) {
+        format!("{name} = {}", signatures.join(" | "))
+    } else {
+        let continuation = format!("\n{}| ", " ".repeat(name.len() + 1));
+        format!("{name} = {}", signatures.join(&continuation))
+    }
+}
+
 /// [3.14-spec] PyPy `State.make_new_type` publishes no field-type metadata,
 /// while the pinned `lib-python/3/test/test_ast/test_ast.py`
 /// `AST_Tests.test_arguments` requires the exact public mapping.  CPython 3.14
@@ -436,7 +614,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // `type(name, (base,), {"__module__": "ast"})` — a fresh heap type. The
     // generated AST types report `__module__ == "ast"` (astcompiler/ast.py;
     // the host `_ast.Module.__module__` is likewise `'ast'`).
-    let make = |name: &str, base: PyObjectRef| -> PyObjectRef {
+    let make = |name: &str, base: PyObjectRef, variants: Option<&[&str]>| -> PyObjectRef {
         // A `dict` header moves, and every store below allocates: the key
         // string, the value, and the dict's own storage when it grows.
         let roots = pyre_object::gc_roots::push_roots();
@@ -495,11 +673,26 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             pyre_object::w_tuple_new(vec![base]),
             roots.get(dict_slot),
         ];
-        crate::builtins::type_descr_new(&args).expect("_ast heap type creation")
+        let typ = crate::builtins::type_descr_new(&args).expect("_ast heap type creation");
+        let type_roots = pyre_object::gc_roots::push_roots();
+        let type_slot = type_roots.base();
+        let _ = type_roots.pin_root(typ);
+        // PyPy `State.make_new_type` assigns its ASDL-generated `doc` after
+        // creating each generated type.  The pre-existing `W_AST` root keeps
+        // its None docstring.
+        if name != "AST" {
+            crate::baseobjspace::setattr_str(
+                type_roots.get(type_slot),
+                "__doc__",
+                pyre_object::w_str_new(&node_doc(name, variants)),
+            )
+            .expect("set generated _ast type doc");
+        }
+        type_roots.get(type_slot)
     };
 
     // Root: AST(object).
-    let ast = make("AST", crate::typedef::w_object());
+    let ast = make("AST", crate::typedef::w_object(), None);
     crate::baseobjspace::setattr_str(
         ast,
         "__init__",
@@ -554,10 +747,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         ("type_param", &["TypeVar", "ParamSpec", "TypeVarTuple"]),
     ];
     for (group, members) in groups {
-        let g = make(group, ast);
+        let g = make(group, ast, Some(members));
         crate::module_ns_store(ns, group, g);
         for m in *members {
-            let t = make(m, g);
+            let t = make(m, g, None);
             crate::module_ns_store(ns, m, t);
         }
     }
@@ -567,7 +760,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "comprehension", "arguments", "arg", "keyword", "alias", "withitem", "match_case",
     ];
     for name in standalone {
-        let t = make(name, ast);
+        let t = make(name, ast, None);
         crate::module_ns_store(ns, name, t);
     }
 

--- a/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
@@ -256,6 +256,165 @@ fn node_fields(name: &str) -> &'static [&'static str] {
     }
 }
 
+/// `Parser/Python.asdl`: one type spelling per entry in [`node_fields`].
+/// Keeping the ASDL `?`/`*` markers here lets the generated type setup below
+/// build the same union and `list[...]` objects as CPython 3.14
+/// `add_ast_annotations`, while the owner/type creation order remains PyPy's
+/// `State.make_new_type` order.
+fn node_field_types(name: &str) -> &'static [&'static str] {
+    match name {
+        "Module" => &["stmt*", "type_ignore*"],
+        "Interactive" => &["stmt*"],
+        "Expression" => &["expr"],
+        "FunctionType" => &["expr*", "expr"],
+        "FunctionDef" | "AsyncFunctionDef" => &[
+            "identifier", "arguments", "stmt*", "expr*", "expr?", "string?", "type_param*",
+        ],
+        "ClassDef" => &[
+            "identifier", "expr*", "keyword*", "stmt*", "expr*", "type_param*",
+        ],
+        "Return" => &["expr?"],
+        "Delete" => &["expr*"],
+        "Assign" => &["expr*", "expr", "string?"],
+        "TypeAlias" => &["expr", "type_param*", "expr"],
+        "AugAssign" => &["expr", "operator", "expr"],
+        "AnnAssign" => &["expr", "expr", "expr?", "int"],
+        "For" | "AsyncFor" => &["expr", "expr", "stmt*", "stmt*", "string?"],
+        "While" | "If" => &["expr", "stmt*", "stmt*"],
+        "With" | "AsyncWith" => &["withitem*", "stmt*", "string?"],
+        "Match" => &["expr", "match_case*"],
+        "Raise" => &["expr?", "expr?"],
+        "Try" | "TryStar" => &["stmt*", "excepthandler*", "stmt*", "stmt*"],
+        "Assert" => &["expr", "expr?"],
+        "Import" => &["alias*"],
+        "ImportFrom" => &["identifier?", "alias*", "int?"],
+        "Global" | "Nonlocal" => &["identifier*"],
+        "Expr" => &["expr"],
+        "Pass" | "Break" | "Continue" => &[],
+        "BoolOp" => &["boolop", "expr*"],
+        "NamedExpr" => &["expr", "expr"],
+        "BinOp" => &["expr", "operator", "expr"],
+        "UnaryOp" => &["unaryop", "expr"],
+        "Lambda" => &["arguments", "expr"],
+        "IfExp" => &["expr", "expr", "expr"],
+        "Dict" => &["expr*", "expr*"],
+        "Set" => &["expr*"],
+        "ListComp" | "SetComp" | "GeneratorExp" => &["expr", "comprehension*"],
+        "DictComp" => &["expr", "expr", "comprehension*"],
+        "Await" | "YieldFrom" => &["expr"],
+        "Yield" => &["expr?"],
+        "Compare" => &["expr", "cmpop*", "expr*"],
+        "Call" => &["expr", "expr*", "keyword*"],
+        "FormattedValue" => &["expr", "int", "expr?"],
+        "Interpolation" => &["expr", "constant", "int", "expr?"],
+        "JoinedStr" | "TemplateStr" => &["expr*"],
+        "Constant" => &["constant", "string?"],
+        "Attribute" => &["expr", "identifier", "expr_context"],
+        "Subscript" => &["expr", "expr", "expr_context"],
+        "Starred" => &["expr", "expr_context"],
+        "Name" => &["identifier", "expr_context"],
+        "List" | "Tuple" => &["expr*", "expr_context"],
+        "Slice" => &["expr?", "expr?", "expr?"],
+        "ExceptHandler" => &["expr?", "identifier?", "stmt*"],
+        "MatchValue" => &["expr"],
+        "MatchSingleton" => &["constant"],
+        "MatchSequence" | "MatchOr" => &["pattern*"],
+        "MatchMapping" => &["expr*", "pattern*", "identifier?"],
+        "MatchClass" => &["expr", "pattern*", "identifier*", "pattern*"],
+        "MatchStar" => &["identifier?"],
+        "MatchAs" => &["pattern?", "identifier?"],
+        "TypeIgnore" => &["int", "string"],
+        "TypeVar" => &["identifier", "expr?", "expr?"],
+        "ParamSpec" | "TypeVarTuple" => &["identifier", "expr?"],
+        "comprehension" => &["expr", "expr", "expr*", "int"],
+        "arguments" => &["arg*", "arg*", "arg?", "arg*", "expr*", "arg?", "expr*"],
+        "arg" => &["identifier", "expr?", "string?"],
+        "keyword" => &["identifier?", "expr"],
+        "alias" => &["identifier", "identifier?"],
+        "withitem" => &["expr", "expr?"],
+        "match_case" => &["pattern", "expr?", "stmt*"],
+        _ => &[],
+    }
+}
+
+fn asdl_base_type(ns: PyObjectRef, name: &str) -> PyObjectRef {
+    match name {
+        "identifier" | "string" => crate::typedef::gettypeobject(&pyre_object::STR_TYPE),
+        "int" => crate::typedef::gettypeobject(&pyre_object::INT_TYPE),
+        "constant" => crate::typedef::w_object(),
+        _ => crate::module_ns_get(ns, name)
+            .unwrap_or_else(|| panic!("_ast ASDL field type {name} was not registered")),
+    }
+}
+
+fn asdl_field_type(ns: PyObjectRef, spelling: &str) -> crate::PyResult {
+    let (base_name, marker) = if let Some(base) = spelling.strip_suffix('*') {
+        (base, '*')
+    } else if let Some(base) = spelling.strip_suffix('?') {
+        (base, '?')
+    } else {
+        (spelling, ' ')
+    };
+    let roots = pyre_object::gc_roots::push_roots();
+    let base_slot = roots.base();
+    let _ = roots.pin_root(asdl_base_type(ns, base_name));
+    match marker {
+        '*' => crate::_pypy_generic_alias::make_generic_alias(
+            crate::typedef::gettypeobject(&pyre_object::LIST_TYPE),
+            roots.get(base_slot),
+        ),
+        '?' => crate::_pypy_generic_alias::create_union(
+            roots.get(base_slot),
+            pyre_object::w_none(),
+        ),
+        _ => Ok(roots.get(base_slot)),
+    }
+}
+
+/// [3.14-spec] PyPy `State.make_new_type` publishes no field-type metadata,
+/// while the pinned `lib-python/3/test/test_ast/test_ast.py`
+/// `AST_Tests.test_arguments` requires the exact public mapping.  CPython 3.14
+/// `add_ast_annotations` attaches it after every ASDL type exists and binds the
+/// same dictionary under both names; keep PyPy's generated type owner/order and
+/// add only that observable metadata here.
+fn install_field_types(ns: PyObjectRef, name: &str) {
+    let fields = node_fields(name);
+    let types = node_field_types(name);
+    assert_eq!(fields.len(), types.len(), "ASDL field/type count for {name}");
+
+    let roots = pyre_object::gc_roots::push_roots();
+    let type_slot = roots.base();
+    let _ = roots.pin_root(crate::module_ns_get(ns, name).expect("_ast node type registered"));
+    let dict_slot = type_slot + 1;
+    let _ = roots.pin_root(pyre_object::w_dict_new());
+    for (&field, &spelling) in fields.iter().zip(types) {
+        let value_roots = pyre_object::gc_roots::push_roots();
+        let value_slot = value_roots.base();
+        let _ = value_roots.pin_root(
+            asdl_field_type(ns, spelling).expect("construct _ast ASDL field type"),
+        );
+        let key = pyre_object::w_str_new(field);
+        crate::baseobjspace::setitem(
+            roots.get(dict_slot),
+            key,
+            value_roots.get(value_slot),
+        )
+        .expect("set _ast ASDL field type");
+    }
+    crate::baseobjspace::setattr_str(
+        roots.get(type_slot),
+        "_field_types",
+        roots.get(dict_slot),
+    )
+    .expect("set _field_types on _ast node type");
+    crate::baseobjspace::setattr_str(
+        roots.get(type_slot),
+        "__annotations__",
+        roots.get(dict_slot),
+    )
+    .expect("set __annotations__ on _ast node type");
+}
+
 fn node_attributes(name: &str) -> Option<&'static [&'static str]> {
     match name {
         "AST" => Some(&[]),
@@ -279,26 +438,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // the host `_ast.Module.__module__` is likewise `'ast'`).
     let make = |name: &str, base: PyObjectRef| -> PyObjectRef {
         // A `dict` header moves, and every store below allocates: the key
-        // string, the value, and the dict's own storage when it grows.  Both
-        // namespace dicts are pinned the moment they are built — the second
-        // pin takes the slot after the first — and the word is read back out
-        // of its slot at every use.
+        // string, the value, and the dict's own storage when it grows.
         let roots = pyre_object::gc_roots::push_roots();
         let dict_slot = roots.base();
         let _ = roots.pin_root(pyre_object::w_dict_new());
-        let field_types_slot = dict_slot + 1;
-        let _ = roots.pin_root(pyre_object::w_dict_new());
         // `make_type` builds ONE tuple of field names and binds it to both
         // `_fields` and `__match_args__`, so `Expr._fields is
-        // Expr.__match_args__`.  It is pinned here, beside the two namespace
-        // dicts, because the first store of it allocates a key string and can
-        // grow the dict it lands in.
-        let fields_slot = field_types_slot + 1;
+        // Expr.__match_args__`. It is pinned beside the namespace dict because
+        // the first store allocates a key string and can grow it.
+        let fields_slot = dict_slot + 1;
         let _ = roots.pin_root(tuple_of_names(node_fields(name)));
         // The value arrives already built.  Call arguments evaluate left to
         // right, so reading a dict slot inline with an allocating value
         // expression would read the slot first and hand over a pre-move word.
-        // `_field_types` is a `dict` too, so the value is rooted as well.
         let put = |target_slot: usize, key: &str, value: PyObjectRef| -> crate::PyResult {
             let value_roots = pyre_object::gc_roots::push_roots();
             let value_slot = value_roots.base();
@@ -313,8 +465,6 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // resolves positional sub-patterns through `__match_args__`, so a
         // `case ast.Expr(expr)` only reaches a field when the node type carries
         // the same field order `_fields` reports.
-        let fields_slot = dict_slot + 2;
-        let _ = roots.pin_root(tuple_of_names(node_fields(name)));
         put(dict_slot, "_fields", roots.get(fields_slot))
             .expect("set _fields on _ast type namespace");
         // Without this name a class pattern carrying positional sub-patterns
@@ -335,12 +485,6 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             put(dict_slot, field, pyre_object::w_none())
                 .expect("set optional AST field default");
         }
-        for &field in node_fields(name) {
-            put(field_types_slot, field, crate::typedef::w_object())
-                .expect("set _field_types item");
-        }
-        put(dict_slot, "_field_types", roots.get(field_types_slot))
-            .expect("set _field_types on _ast type namespace");
         // `type_descr_new` reads the metatype off the first argument, the way
         // `descr__new__` takes it as a parameter beside `arguments_w`.  Every
         // other caller reaches it through an attribute lookup that supplies
@@ -419,11 +563,24 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     }
 
     // Leaf node types that are direct AST subclasses (no further subclasses).
-    for name in &[
+    let standalone = &[
         "comprehension", "arguments", "arg", "keyword", "alias", "withitem", "match_case",
-    ] {
+    ];
+    for name in standalone {
         let t = make(name, ast);
         crate::module_ns_store(ns, name, t);
+    }
+
+    // CPython's generated `add_ast_annotations` runs only after every type has
+    // been created because, for example, FunctionDef refers to `arguments`
+    // and `type_param` types declared later in the ASDL traversal.
+    for (_, members) in groups {
+        for name in *members {
+            install_field_types(ns, name);
+        }
+    }
+    for name in standalone {
+        install_field_types(ns, name);
     }
 
     // CPython 3.14 `ast_state.Load_singleton`: every omitted expression

--- a/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
@@ -72,6 +72,93 @@ fn ast_warn(message: rustpython_wtf8::Wtf8Buf) -> Result<(), crate::PyError> {
     )
 }
 
+fn is_ast_init_descriptor(descr: PyObjectRef) -> bool {
+    if !unsafe { crate::is_function(descr) } {
+        return false;
+    }
+    let code = unsafe { crate::getcode(descr) } as PyObjectRef;
+    (unsafe { crate::is_builtin_code(code) })
+        && crate::gateway::builtin_code_fn_eq(
+            unsafe { crate::gateway::builtin_code_get(code) },
+            ast_init,
+        )
+}
+
+/// [3.14-spec] CPython `ASTConstructorTests.test_non_str_kwarg` observes that
+/// `ast_type_init` receives the raw kwargs dict, while PyPy `Arguments`
+/// rejects a non-text key in `_do_combine_starstarargs_wrapped` before
+/// `W_AST_init`.  Keep that PyPy path for every ordinary callable.  Only when
+/// the live type still owns the generated AST init, inherits `object.__new__`
+/// unchanged, and uses the default metaclass do we invoke those same two
+/// descriptor bodies with pyre's raw builtin-kwargs carrier.
+pub(crate) fn call_type_with_raw_kwargs(
+    w_type: PyObjectRef,
+    positional: &[PyObjectRef],
+    kwargs: PyObjectRef,
+) -> Option<crate::PyResult> {
+    if !unsafe { pyre_object::is_type(w_type) && pyre_object::is_dict(kwargs) } {
+        return None;
+    }
+    let entries = unsafe { pyre_object::w_dict_items(kwargs) };
+    if entries
+        .iter()
+        .all(|(key, _)| unsafe { pyre_object::is_str(*key) })
+    {
+        return None;
+    }
+    if unsafe { pyre_object::w_instance_get_type(w_type) } != crate::typedef::w_type() {
+        return None;
+    }
+    let init_descr = unsafe { crate::baseobjspace::lookup_in_type(w_type, "__init__") }?;
+    if !is_ast_init_descriptor(init_descr) {
+        return None;
+    }
+    let new_descr = unsafe { crate::baseobjspace::lookup_in_type(w_type, "__new__") }?;
+    let object_new = unsafe {
+        crate::baseobjspace::lookup_in_type(crate::typedef::w_object(), "__new__")
+    }?;
+    if new_descr != object_new {
+        return None;
+    }
+
+    Some((|| -> crate::PyResult {
+        // The type, positionals and kwargs entries all cross object.__new__
+        // and ast_type_init, both allocating calls.  Publish the caller-owned
+        // slice before packing the raw carrier and rebuild each argument list
+        // from the forwarded slots.
+        let roots = pyre_object::gc_roots::push_roots();
+        let type_slot = roots.publish(&[w_type]);
+        let positional_base = roots.publish(positional);
+        let kwargs_slot = roots.publish(&[kwargs]);
+        roots.normalize(type_slot, positional.len() + 2);
+        let current_positional = |index: usize| roots.get(positional_base + index);
+
+        let current_entries = unsafe { pyre_object::w_dict_items(roots.get(kwargs_slot)) };
+        let carrier = crate::call::pack_pyre_kwargs(&current_entries);
+        let carrier_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = roots.pin_root(carrier);
+
+        let mut new_args = Vec::with_capacity(positional.len() + 2);
+        new_args.push(roots.get(type_slot));
+        for index in 0..positional.len() {
+            new_args.push(current_positional(index));
+        }
+        new_args.push(roots.get(carrier_slot));
+        let instance = crate::typedef::object_descr_new(&new_args)?;
+        let instance_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = roots.pin_root(instance);
+
+        let mut init_args = Vec::with_capacity(positional.len() + 2);
+        init_args.push(roots.get(instance_slot));
+        for index in 0..positional.len() {
+            init_args.push(current_positional(index));
+        }
+        init_args.push(roots.get(carrier_slot));
+        ast_init(&init_args)?;
+        Ok(roots.get(instance_slot))
+    })())
+}
+
 fn expr_context_type() -> PyObjectRef {
     // CPython `ast_state.expr_context_type`; PyPy's `State` also owns this
     // generated base beside the Load singleton.  Recover that same base from

--- a/pyre/pyre-interpreter/src/module/_blake2/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_blake2/mod.rs
@@ -19,4 +19,14 @@ crate::py_module! {
     appleveldefs: {
         "_blake2_app.py" => ["blake2b", "blake2s"],
     },
+    extra_init: |ns| {
+        // [3.14-spec] Keep PyPy's app-level `_make_blake_type` classes and
+        // their object-owned state, but match CPython 3.14's immutable
+        // non-BASETYPE public types at the subclassing boundary.
+        for name in ["blake2b", "blake2s"] {
+            let ty = crate::module_ns_get(ns, name).expect("_blake2 app-level type installed");
+            crate::typedef::mark_cpython_heap_type(ty, true);
+            unsafe { pyre_object::w_type_suppress_cpython_basetype(ty) };
+        }
+    },
 }

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -34,12 +34,11 @@ type PyResult = Result<PyObjectRef, crate::PyError>;
 /// its ctypes metaclasses are app-level (`class _CDataMeta(type)`,
 /// basics.py:48) and inherit `type`'s instance layout from their base.
 fn make_ctypes_metatype(name: &str, init: impl FnOnce(PyObjectRef)) -> PyObjectRef {
-    let tp = crate::typedef::make_builtin_type_with_layout(
-        name,
-        init,
-        ctype_type(),
-        &pyre_object::pyobject::TYPE_TYPE as *const pyre_object::PyType,
-    );
+    let base = ctype_type();
+    let layout = unsafe { pyre_object::w_type_get_layout_ptr(base) };
+    let tp = crate::typedef::make_builtin_type_with_overridetypedef(name, init, base, unsafe {
+        (*layout).typedef
+    });
     super::finish_cpython_type(tp, "_ctypes", true)
 }
 
@@ -58,11 +57,13 @@ macro_rules! cached_type {
 // metaclass owner for every concrete ctypes metaclass.  Keeping the shared
 // methods here avoids the former pyre-only duplication on every child.
 cached_type!(CTYPE_TYPE, ctype_type, || {
-    let tp = crate::typedef::make_builtin_type_with_layout(
+    let base = crate::typedef::w_type();
+    let layout = unsafe { pyre_object::w_type_get_layout_ptr(base) };
+    let tp = crate::typedef::make_builtin_type_with_overridetypedef(
         "CType_Type",
         install_shared_meta,
-        crate::typedef::w_type(),
-        &pyre_object::pyobject::TYPE_TYPE as *const pyre_object::PyType,
+        base,
+        unsafe { (*layout).typedef },
     );
     super::finish_cpython_type(tp, "_ctypes", true)
 });
@@ -158,7 +159,13 @@ cached_type!(CFIELD, cfield_type, || {
         );
     });
     unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
-    super::finish_cpython_type(tp, "ctypes", true)
+    let tp = super::finish_cpython_type(tp, "ctypes", true);
+    // [3.14-spec] CPython's public `ctypes.CField` descriptor type omits
+    // BASETYPE.  PyPy does not publish this private storage owner at all;
+    // keep pyre's existing descriptor implementation but prevent a user
+    // subclass from acquiring an unsupported layout.
+    unsafe { pyre_object::w_type_suppress_cpython_basetype(tp) };
+    tp
 });
 
 cached_type!(PYCARRAYTYPE, pycarraytype_type, || {

--- a/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
@@ -1122,6 +1122,12 @@ crate::py_module! {
         "get_fips_mode" / 0 = |_| Ok(w_int_new(0)),
     },
     extra_init: |ns| {
+        // [3.14-spec] PyPy owns `HMAC` as the ordinary app-level
+        // `lib_pypy._hashlib.HMAC` class.  CPython 3.14's `_hashlib.HMAC`
+        // rejects use as a base; retain the PyPy class relationship and
+        // suppress only that per-type public capability.
+        let hmac = crate::module_ns_get(ns, "HMAC").expect("_hashlib.HMAC installed");
+        unsafe { pyre_object::w_type_suppress_cpython_basetype(hmac) };
         let _roots = gc_roots::push_roots();
         let mapping_slot = gc_roots::shadow_stack_len();
         let _ = gc_roots::pin_root(w_dict_new());

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -966,23 +966,81 @@ fn init_iobase_type(ns: PyObjectRef) {
 /// it sits in `__new__` rather than in the app-level `__init__`, a subclass
 /// that overrides `__init__` without calling up is registered all the same.
 ///
-/// Every `_io` type keeping the generic instance layout inherits this through
-/// the MRO: `FileIO`, the `_RawIOBase`/`_BufferedIOBase`/`_TextIOBase` bases,
-/// and app-level subclasses of any of them. The typed payloads override
-/// `__new__` and reach the same queue through [`tag_io_instance`].
+/// Each exported type installs its own descriptor, while TypeDef identity
+/// follows PyPy's TypeCache overrides: notably `_RawIOBase` reuses
+/// `W_IOBase.typedef` through `applevel_subclasses_base = W_IOBase`.  Typed
+/// payloads provide their own `__new__` and reach the same queue through
+/// [`tag_io_instance`].
 ///
 /// The extra arguments go to `__init__`; `generic_new_descr` ignores its
 /// `__args__` in the same way.
-fn iobase_new(args: &[PyObjectRef]) -> crate::PyResult {
+fn allocate_iobase_instance(
+    owner: PyObjectRef,
+    owner_name: &str,
+    args: &[PyObjectRef],
+) -> crate::PyResult {
     let (positional, _) = crate::builtins::split_builtin_kwargs(args);
     let Some(&cls) = positional.first() else {
-        return Err(crate::PyError::type_error(
-            "_IOBase.__new__(): not enough arguments",
-        ));
+        return Err(crate::PyError::type_error(format!(
+            "{owner_name}.__new__(): not enough arguments"
+        )));
     };
-    let obj = autoflusher_add(crate::typedef::object_descr_new(&[cls])?);
-    crate::executioncontext::register_finalizer(obj);
-    Ok(obj)
+    crate::typedef::check_user_subclass(owner, cls)?;
+    Ok(tag_io_instance(pyre_object::w_instance_new(cls), cls))
+}
+
+fn iobase_new(args: &[PyObjectRef]) -> crate::PyResult {
+    allocate_iobase_instance(io_base_type(), "_IOBase", args)
+}
+
+fn raw_iobase_new(args: &[PyObjectRef]) -> crate::PyResult {
+    allocate_iobase_instance(raw_iobase_type(), "_RawIOBase", args)
+}
+
+fn buffered_iobase_new(args: &[PyObjectRef]) -> crate::PyResult {
+    allocate_iobase_instance(buffered_iobase_type(), "_BufferedIOBase", args)
+}
+
+fn text_iobase_new(args: &[PyObjectRef]) -> crate::PyResult {
+    allocate_iobase_instance(text_iobase_type(), "_TextIOBase", args)
+}
+
+/// PyPy `W_FileIO.descr_new`: allocate the concrete interpreter owner and run
+/// `W_FileIO.__init__`'s field defaults before the public initializer sees its
+/// arguments.  CPython 3.14 observes an uninitialized FileIO as closed with
+/// mode `wb`; keep that newer public state on the PyPy-shaped instance dict.
+fn fileio_new(args: &[PyObjectRef]) -> crate::PyResult {
+    let obj = allocate_iobase_instance(fileio_type(), "FileIO", args)?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(obj);
+    // Build each value before reloading the receiver.  The allocation may
+    // move it, exactly as in `type_ns_store`.
+    let store = |name: &str, value: PyObjectRef| {
+        crate::baseobjspace::setdictvalue_native(
+            pyre_object::gc_roots::shadow_stack_get(obj_slot),
+            name,
+            value,
+        );
+    };
+    store("__file_fd__", pyre_object::w_int_new(-1));
+    store("__file_closed__", pyre_object::w_bool_from(true));
+    store("__file_closefd__", pyre_object::w_bool_from(true));
+    store("__file_mode__", pyre_object::w_str_new("wb"));
+    store("__file_public_mode__", pyre_object::w_str_new("wb"));
+    store("__file_seekable__", pyre_object::w_none());
+    store(
+        "__file_blksize__",
+        pyre_object::w_int_new(DEFAULT_BUFFER_SIZE),
+    );
+    for name in [
+        "__file_stat_mode__",
+        "__file_stat_size__",
+        "__file_stat_blksize__",
+    ] {
+        store(name, pyre_object::w_none());
+    }
+    Ok(pyre_object::gc_roots::shadow_stack_get(obj_slot))
 }
 
 /// `interp_iobase.py:rawiobase_read_w` — the default raw `read` is a
@@ -1082,6 +1140,11 @@ fn rawiobase_readall(args: &[PyObjectRef]) -> crate::PyResult {
 fn init_rawiobase_type(ns: PyObjectRef) {
     type_method(
         ns,
+        "__new__",
+        crate::typedef::make_new_descr(raw_iobase_new),
+    );
+    type_method(
+        ns,
         "read",
         crate::make_builtin_function("read", rawiobase_read),
     );
@@ -1150,6 +1213,11 @@ fn buffered_iobase_readinto1(args: &[PyObjectRef]) -> crate::PyResult {
 }
 
 fn init_buffered_iobase_type(ns: PyObjectRef) {
+    type_method(
+        ns,
+        "__new__",
+        crate::typedef::make_new_descr(buffered_iobase_new),
+    );
     for (name, function) in [
         (
             "read",
@@ -1208,6 +1276,11 @@ fn text_iobase_none_get(args: &[PyObjectRef]) -> crate::PyResult {
 }
 
 fn init_text_iobase_type(ns: PyObjectRef) {
+    type_method(
+        ns,
+        "__new__",
+        crate::typedef::make_new_descr(text_iobase_new),
+    );
     for (name, function) in [
         ("read", text_iobase_read as crate::gateway::BuiltinCodeFn),
         (
@@ -1258,10 +1331,16 @@ fn io_base_type() -> PyObjectRef {
 pub(super) fn raw_iobase_type() -> PyObjectRef {
     static TYPE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *TYPE.get_or_init(|| {
-        let tp = crate::typedef::make_builtin_type_with_base(
+        let base = io_base_type();
+        let layout = unsafe { pyre_object::w_type_get_layout_ptr(base) };
+        // `W_RawIOBase.typedef.applevel_subclasses_base = W_IOBase`;
+        // `TypeCache.build` therefore supplies W_IOBase's TypeDef as the
+        // override instead of minting a sibling Layout.
+        let tp = crate::typedef::make_builtin_type_with_overridetypedef(
             "_io._RawIOBase",
             init_rawiobase_type,
-            io_base_type(),
+            base,
+            unsafe { (*layout).typedef },
         );
         // `_iomodule.c:ADD_TYPE` creates rawiobase_spec as immutable heap.
         crate::typedef::mark_cpython_heap_type(tp, true);
@@ -1284,6 +1363,11 @@ pub(crate) fn fileio_type() -> PyObjectRef {
         let tp = crate::typedef::make_builtin_type_with_base(
             "_io.FileIO",
             |type_ns| {
+                type_method(
+                    type_ns,
+                    "__new__",
+                    crate::typedef::make_new_descr(fileio_new),
+                );
                 crate::builtins::init_file_wrapper_type(type_ns);
                 crate::builtins::init_fileio_type(type_ns);
                 type_method(

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -855,6 +855,11 @@ crate::py_module! {
                         semlock_rebuild,
                     )),
                 );
+                // PyPy `W_SemLock.typedef` owns `descr_new` in its rawdict,
+                // so `TypeDef.acceptable_as_base_class` is true.  This manual
+                // type installs the same descriptor after construction;
+                // reflect that rawdict result on its own TypeDef now.
+                pyre_object::w_type_set_acceptable_as_base_class(semlock_type, true);
             }
 
             crate::module_ns_store(

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -33,8 +33,8 @@ pub struct W_SSLContext {
     pub num_tickets: i32,
 }
 
-/// `ssl.MemoryBIO` is subclassable in CPython, so it uses the same mapdict
-/// prefix rather than relying on a side table for subclass attributes.
+/// PyPy owns `MemoryBIO` as an app-level class, so it uses the same mapdict
+/// prefix rather than relying on a side table for instance attributes.
 // `_ssl_exec` creates the immutable MemoryBIO module heap type.
 #[crate::pyre_class("_ssl.MemoryBIO", cpython_heaptype)]
 #[derive(Default)]
@@ -2986,6 +2986,15 @@ crate::py_module! {
         "_test_decode_cert" / 1 = test_decode_cert
     },
     extra_init: |ns| {
+        // [3.14-spec] CPython 3.14 rejects each of these immutable module
+        // heap types as a base.  PyPy's shared public pair, `MemoryBIO` and
+        // `SSLSession`, remain app-level classes in `_cffi_ssl._stdssl`;
+        // preserve those owner/storage choices and suppress only the
+        // caller-visible per-type BASETYPE capability.
+        for name in ["MemoryBIO", "SSLSession", "Certificate", "_SSLSocket"] {
+            let ty = crate::module_ns_get(ns, name).expect("_ssl type installed");
+            unsafe { pyre_object::w_type_suppress_cpython_basetype(ty) };
+        }
         // The Windows-only store readers. They live here rather than in
         // `functions:` because that table has no per-entry platform guard, and
         // `ssl.py:257-258` imports both names behind `sys.platform == "win32"`.

--- a/pyre/pyre-interpreter/src/module/_template/_template_app.py
+++ b/pyre/pyre-interpreter/src/module/_template/_template_app.py
@@ -64,6 +64,12 @@ class Interpolation:
         return (f'Interpolation({self._value!r}, {self._expression!r}, '
                 f'{self._conversion!r}, {self._format_spec!r})')
 
+    def __reduce__(self):
+        # CPython 3.14 `interpolation_reduce`: reconstruct through the exact
+        # public type and the four constructor fields, in their storage order.
+        return (type(self), (self._value, self._expression,
+                             self._conversion, self._format_spec))
+
 
 class Template:
     # CPython 3.14 Objects/templateobject.c: template_methods —
@@ -145,17 +151,16 @@ class Template:
                 f'interpolations={self._interpolations!r})')
 
     def __reduce__(self):
-        return (_reconstruct, (self._strings, self._interpolations))
+        # CPython 3.14 `template_reduce` resolves the public app-level helper
+        # instead of making the private runtime module part of the pickle.
+        from string.templatelib import _template_unpickle
+        return (_template_unpickle, (self._strings, self._interpolations))
 
 
 def _concat_boundary(left, right):
     # Merge the touching boundary strings of two templates: the last static
     # string of `left` joins the first of `right`.
     return left[:-1] + (left[-1] + right[0],) + right[1:]
-
-
-def _reconstruct(strings, interpolations):
-    return Template._make(strings, interpolations)
 
 
 def _build_template(strings, interpolations):

--- a/pyre/pyre-interpreter/src/module/_template/_template_app.py
+++ b/pyre/pyre-interpreter/src/module/_template/_template_app.py
@@ -172,8 +172,14 @@ def _build_template(strings, interpolations):
 
 def _build_interpolation(value, expression, conversion, format_spec):
     # BUILD_INTERPOLATION: `conversion` is the opcode's conversion oparg field.
-    return Interpolation(value, expression, _CONVERSIONS[conversion],
-                         format_spec)
+    # CPython `_PyInterpolation_Build` is an internal unchecked constructor;
+    # keep it separate from the validating public constructor above.
+    interpolation = object.__new__(Interpolation)
+    interpolation._value = value
+    interpolation._expression = expression
+    interpolation._conversion = _CONVERSIONS[conversion]
+    interpolation._format_spec = format_spec
+    return interpolation
 
 
 # Present the types as living in their public home, `string.templatelib`, where

--- a/pyre/pyre-interpreter/src/module/_template/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_template/mod.rs
@@ -15,11 +15,16 @@ crate::py_module! {
     extra_init: |ns| {
         // `Template` and `Interpolation` are final: the C runtime types lack
         // `Py_TPFLAGS_BASETYPE`, so `class Sub(Template)` raises TypeError.
-        // App-level classes default to `acceptable_as_base_class=true`, so
-        // flip it off here to reject subclassing.
+        // These app-level classes retain object's TypeDef.  Suppress the
+        // CPython BASETYPE projection per type; mutating the shared TypeDef
+        // would make object itself unacceptable as a base.
         for name in ["Template", "Interpolation"] {
             if let Some(t) = crate::module_ns_get(ns, name) {
-                unsafe { pyre_object::w_type_set_acceptable_as_base_class(t, false) };
+                // CPython 3.14 exposes both as immutable non-heap types.
+                // Keep the PyPy app-level owner internally and project only
+                // the caller-visible static/immutable type capabilities.
+                crate::typedef::mark_cpython_static_extension_type(t);
+                unsafe { pyre_object::w_type_suppress_cpython_basetype(t) };
             }
         }
     },

--- a/pyre/pyre-interpreter/src/module/_template/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_template/mod.rs
@@ -9,7 +9,7 @@ crate::py_module! {
     appleveldefs: {
         "_template_app.py" => [
             "Template", "Interpolation",
-            "_build_template", "_build_interpolation", "_reconstruct",
+            "_build_template", "_build_interpolation",
         ],
     },
     extra_init: |ns| {

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -999,22 +999,32 @@ fn format_gc_stat(value: i64) -> String {
 fn gc_stats_public_type() -> PyObjectRef {
     static TYPE: OnceLock<usize> = OnceLock::new();
     *TYPE.get_or_init(|| {
-        let tp = crate::typedef::make_builtin_type("GcStats", |ns| unsafe {
-            pyre_object::w_dict_setitem_str_no_proxy(
-                ns,
-                "__init__",
-                crate::make_builtin_function_with_arity("__init__", gc_stats_public_init, 2),
-            );
-            pyre_object::w_dict_setitem_str_no_proxy(
-                ns,
-                "__repr__",
-                crate::make_builtin_function_with_arity("__repr__", gc_stats_repr, 1),
-            );
-            pyre_object::w_dict_setitem_str_no_proxy(ns, "__dict__", crate::typedef::dict_descr());
-        });
-        // app_referents.py:GcStats is an ordinary app-level class.
-        unsafe { typeobject::w_type_set_hasdict(tp, true) };
-        tp as usize
+        // PyPy `app_referents.GcStats` is an ordinary app-level class, not a
+        // second interpreter TypeDef beside `referents.W_GcStats`.  Build it
+        // through `type.__new__`, so it inherits object's allocator and owns
+        // the normal mapdict layout an app-level class receives.
+        let roots = pyre_object::gc_roots::push_roots();
+        let ns_slot = roots.base();
+        let _ = roots.pin_root(pyre_object::w_dict_new());
+        let store = |name: &str, value: PyObjectRef| unsafe {
+            pyre_object::w_dict_setitem_str_no_proxy(roots.get(ns_slot), name, value);
+        };
+        store("__module__", w_str_new("gc"));
+        store(
+            "__init__",
+            crate::make_builtin_function_with_arity("__init__", gc_stats_public_init, 2),
+        );
+        store(
+            "__repr__",
+            crate::make_builtin_function_with_arity("__repr__", gc_stats_repr, 1),
+        );
+        let args = [
+            crate::typedef::w_type(),
+            w_str_new("GcStats"),
+            pyre_object::w_tuple_new(vec![crate::typedef::w_object()]),
+            roots.get(ns_slot),
+        ];
+        crate::builtins::type_descr_new(&args).expect("construct app_referents.GcStats") as usize
     }) as PyObjectRef
 }
 

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -264,6 +264,22 @@ crate::py_module! {
         "length_hint"  / * = op_length_hint,
         "_compare_digest" / 2 = op_compare_digest,
     },
+    extra_init: |ns| {
+        // [3.14-spec] PyPy `app_operator.py` deliberately owns these as
+        // ordinary app-level classes, and no JIT/immutability hint decorates
+        // their definitions.  CPython 3.14's three static factory types omit
+        // `Py_TPFLAGS_BASETYPE`; preserve the PyPy classes and suppress only
+        // that caller-visible per-type capability.
+        for name in ["itemgetter", "attrgetter", "methodcaller"] {
+            let ty = crate::module_ns_get(ns, name)
+                .expect("operator app-level factory class must be installed");
+            // CPython exposes these as immutable module heap types.  This is
+            // a public projection only; PyPy's app-level class remains the
+            // implementation and storage owner.
+            crate::typedef::mark_cpython_heap_type(ty, true);
+            unsafe { pyre_object::w_type_suppress_cpython_basetype(ty) };
+        }
+    },
     // The `__lt__ = lt` / `__add__ = add` dunder aliases belong to
     // `operator.py`, which binds them after its `from _operator import *`;
     // this module carries only the names that tail imports.

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -586,9 +586,17 @@ fn pack_values(parsed: &Parsed, values: &[PyObjectRef]) -> Result<Vec<u8>, crate
                 for _ in 0..rep {
                     let arg = values[ai];
                     ai += 1;
-                    let data = unsafe {
-                        accept_bytes(arg, "char format requires a bytes object of length 1")?
-                    };
+                    // PyPy `standardfmttable.pack_char` reaches
+                    // `PackFormatIterator.accept_str_arg` / `space.bytes_w`:
+                    // unlike the `s` and `p` rows, `c` accepts an actual
+                    // bytes object only.  CPython 3.14 has the same observable
+                    // rule (including rejecting a one-byte bytearray).
+                    if !unsafe { bytesobject::is_bytes(arg) } {
+                        return Err(struct_error(
+                            "char format requires a bytes object of length 1",
+                        ));
+                    }
+                    let data = unsafe { bytesobject::w_bytes_data(arg) };
                     if data.len() != 1 {
                         return Err(struct_error(
                             "char format requires a bytes object of length 1",
@@ -674,70 +682,6 @@ fn pack_values(parsed: &Parsed, values: &[PyObjectRef]) -> Result<Vec<u8>, crate
     Ok(out)
 }
 
-/// `space.writebuf_w` — a writable byte slice from a `bytearray` or a
-/// contiguous read-write `memoryview` over one.
-unsafe fn writebuf<'a>(obj: PyObjectRef) -> Result<&'a mut [u8], crate::PyError> {
-    unsafe {
-        if bytearrayobject::is_bytearray(obj) {
-            return Ok(bytearrayobject::w_bytearray_data_mut(obj));
-        }
-        if interp_array::is_array(obj) {
-            return Ok(interp_array::w_array_vec_mut(obj).as_mut_slice());
-        }
-        // `W_MMap.writebuf_w` — the live mapping, unless it was opened
-        // read-only.
-        #[cfg(all(any(unix, windows), not(feature = "sandbox")))]
-        if let Some(view) = crate::module::mmap::interp_mmap::mmap_buffer_view(obj) {
-            let (address, length, readonly) = view?;
-            if !readonly {
-                return Ok(std::slice::from_raw_parts_mut(address as *mut u8, length));
-            }
-        }
-        if memoryview::is_w_memoryview(obj) {
-            crate::builtins::memoryview_check_released(obj)?;
-            if memoryview::w_memoryview_readonly(obj) {
-                return Err(crate::PyError::type_error(
-                    "a read-write bytes-like object is required",
-                ));
-            }
-            let view = memoryview::w_memoryview_view(obj);
-            if crate::builtins::memoryview_contiguity(obj).0 {
-                let off = view.offset() as usize;
-                let len = memoryview::w_memoryview_length(obj) as usize;
-                if let Some(full) = view.backing().as_bytes_mut()
-                    && off <= full.len()
-                    && len <= full.len() - off
-                {
-                    return Ok(&mut full[off..off + len]);
-                }
-            }
-        }
-        Err(crate::PyError::type_error(
-            "argument must be read-write bytes-like object",
-        ))
-    }
-}
-
-/// One export held on a `pack_into` target for as long as the writable slice
-/// is live.  `s_pack_into` keeps the buffer exported across `s_pack_internal`,
-/// so a value coercion that re-enters Python and calls `release()` — or
-/// resizes the exporter — raises instead of leaving the saved slice stale.
-struct PackIntoExport(PyObjectRef);
-
-impl PackIntoExport {
-    /// Returns `None` for an immutable target that carries no export count;
-    /// `writebuf` rejects every unsupported exporter before use.
-    unsafe fn acquire(obj: PyObjectRef) -> Option<Self> {
-        unsafe { crate::builtins::buffer_export_incref(obj).then_some(Self(obj)) }
-    }
-}
-
-impl Drop for PackIntoExport {
-    fn drop(&mut self) {
-        unsafe { crate::builtins::buffer_export_decref(self.0) }
-    }
-}
-
 /// `do_pack_into` — pack `values` into `buffer` starting at `offset`,
 /// resolving a negative offset against the buffer end.
 fn do_pack_into(
@@ -748,8 +692,12 @@ fn do_pack_into(
 ) -> Result<PyObjectRef, crate::PyError> {
     let parsed = parse_format(format)?;
     let size = parsed.calcsize()?;
-    let _export = unsafe { PackIntoExport::acquire(buffer) };
-    let buf = unsafe { writebuf(buffer)? };
+    // PyPy `Struct.pack_into` acquires `space.writebuf_w` once and keeps that
+    // buffer object alive through `s_pack_internal`.  Reuse pyre's common
+    // writable-buffer lease so a C exporter follows the same `bf_getbuffer`
+    // / `bf_releasebuffer` path as every other consumer.
+    let mut export = unsafe { crate::builtins::WritableBuffer::acquire_for_pack_into(buffer) }?;
+    let buf = unsafe { export.as_mut_slice() };
     let buflen = buf.len() as i64;
     let mut offset = offset;
     if offset < 0 {

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -442,7 +442,16 @@ fn simple_namespace_init(args: &[PyObjectRef]) -> crate::PyResult {
 pub(crate) fn simple_namespace_type() -> PyObjectRef {
     static TYPE: OnceLock<usize> = OnceLock::new();
     let raw = *TYPE.get_or_init(|| {
-        let tp = crate::typedef::make_builtin_type("types.SimpleNamespace", |ns| {
+        // PyPy owns this as the app-level class
+        // `lib_pypy._structseq.SimpleNamespace`, so it keeps `object`'s
+        // TypeDef/Layout instead of introducing an interpreter TypeDef merely
+        // because pyre materialises its methods in Rust.
+        let object = crate::typedef::w_object();
+        let object_layout = unsafe { pyre_object::w_type_get_layout_ptr(object) };
+        let object_typedef = unsafe { (*object_layout).typedef };
+        let tp = crate::typedef::make_builtin_type_with_overridetypedef(
+            "types.SimpleNamespace",
+            |ns| {
             unsafe {
                 pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
                     ns,
@@ -500,7 +509,10 @@ pub(crate) fn simple_namespace_type() -> PyObjectRef {
                     crate::typedef::dict_descr(),
                 );
             }
-        });
+            },
+            object,
+            object_typedef,
+        );
         unsafe { w_type_set_hasdict(tp, true) };
         tp as usize
     });

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -2183,8 +2183,10 @@ fn except_hook_args_type() -> PyObjectRef {
         );
         let ty_slot = pin_root_slot(ty);
         unsafe {
-            let ty = pyre_object::gc_roots::shadow_stack_get(ty_slot);
-            pyre_object::w_type_set_acceptable_as_base_class(ty, false);
+            // `make_struct_seq` already applies the per-type CPython BASETYPE
+            // suppression.  Its Layout deliberately retains tuple's TypeDef,
+            // so mutating that shared TypeDef here would make tuple itself
+            // unacceptable as a base.
             let doc =
                 w_str_new("ExceptHookArgs\n\nType used to pass arguments to threading.excepthook.");
             let doc_slot = pin_root_slot(doc);
@@ -2591,7 +2593,16 @@ crate::py_module! {
         // class by `_thread.lock`, so the canonical binding is load-bearing.
         "lock"          => lock_class::type_object(),
         "RLock"         => rlock_class::type_object(),
-        "_ThreadHandle" => handle_class::type_object(),
+        "_ThreadHandle" => {
+            let ty = handle_class::type_object();
+            // [3.14-spec] CPython `ThreadHandle_Type_spec` is an immutable
+            // heap type without `Py_TPFLAGS_BASETYPE`.  PyPy has no public
+            // `_ThreadHandle` class at this version, so retain pyre's
+            // PyPy-shaped interpreter owner and suppress only the observable
+            // per-type subclass capability.
+            unsafe { pyre_object::w_type_suppress_cpython_basetype(ty) };
+            ty
+        },
         "_local"        => local_type(),
         "_ExceptHookArgs" => except_hook_args_type(),
         "TIMEOUT_MAX"   => w_float_new(TIMEOUT_MAX),

--- a/pyre/pyre-interpreter/src/module/zlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/zlib/mod.rs
@@ -690,6 +690,11 @@ fn zdecompress_type() -> PyObjectRef {
         // `zlib_exec` creates ZlibDecompressorType from an immutable heap
         // spec, unlike Compress and Decompress.
         crate::typedef::mark_cpython_heap_type(tp, true);
+        // [3.14-spec] CPython's `ZlibDecompressorType` omits BASETYPE.  PyPy
+        // has no separate `_ZlibDecompressor` owner; keep this existing
+        // compatibility payload isolated and suppress its public base
+        // capability without changing object's TypeDef.
+        unsafe { pyre_object::w_type_suppress_cpython_basetype(tp) };
         pyre_object::pyobject::set_instantiate(
             unsafe { &*<W_ZlibDecompressor as pyre_object::lltype::PyreClassPyTypeOf>::PYTYPE },
             tp,

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -5170,6 +5170,7 @@ pub static MAP_DICT_STRATEGY: MapDictStrategy = MapDictStrategy;
 pub static MAP_DICT_STRATEGY_REF: pyre_object::dictmultiobject::DictStrategyRef =
     pyre_object::dictmultiobject::DictStrategyRef {
         imp: &MAP_DICT_STRATEGY,
+        owner: std::ptr::null_mut(),
     };
 
 impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -460,15 +460,14 @@ pub fn new_dict_terminator(w_cls: PyObjectRef) -> MapRef {
 /// paths (`plain_direct_write` type change / `holder_pick_attr` mismatch), and
 /// the affected instances rebuild boxed storage via `convert_to_boxed`.
 ///
-/// typeobject.py:255-257 builds a `DictTerminator` only when
+/// `W_TypeObject.__init__` builds a `DictTerminator` only when
 /// `self.hasdict and not typedef.hasdict` — a type whose layout typedef
 /// already manages its own dict (e.g. module) gets a `NoDictTerminator`.
-/// `typedef_hasdict` is `Layout.typedef_hasdict` (typedef.py:40). On the
-/// current shared-Layout model it is `false` for every reachable instance
-/// layout (all reuse INSTANCE_TYPE's Layout, whose typedef declares no
-/// `__dict__`), so the term is inert today; populating it `true` for the
-/// dict-managing typedefs is deferred to the distinct-TypeDef convergence
-/// (alongside the parked `Layout.acceptable_as_base_class`).
+/// `typedef_hasdict` is the native-owner projection of
+/// `Layout.typedef.hasdict` (`TypeDef.__init__`).  A concrete RPython owner
+/// manages that dictionary itself; a PyPy app-level-shaped owner collapsed
+/// onto pyre's generic `INSTANCE_TYPE` keeps the same TypeDef metadata but
+/// uses mapdict as its physical dictionary.
 pub fn new_instance_terminator(w_cls: PyObjectRef, hasdict: bool, typedef_hasdict: bool) -> MapRef {
     // `hasdict and not typedef.hasdict`, expressed without a bare `!` so the
     // annotator can lower it on the JIT-reachable terminator path.

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -6388,7 +6388,7 @@ pub unsafe fn base_owes_dict_backing(w_base: PyObjectRef) -> bool {
         }
         let layout = pyre_object::w_type_get_layout_ptr(w_base);
         let dict_typedef = &pyre_object::pyobject::DICT_TYPE as *const pyre_object::PyType;
-        if layout.is_null() || !std::ptr::eq((*layout).typedef, dict_typedef) {
+        if layout.is_null() || !std::ptr::eq((*(*layout).typedef).instance_type, dict_typedef) {
             return false;
         }
         // `Layout::dict_data_slot` already answers for the whole chain — it

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -808,7 +808,18 @@ pub fn init_typeobjects() {
             ),
         ] {
             let w_type = new_typeobject_with_base(name, init, object_type);
-            unsafe { pyre_object::w_type_set_disallow_instantiation(w_type) };
+            unsafe {
+                pyre_object::w_type_set_disallow_instantiation(w_type);
+                // [3.14-spec] `TypeDef.__init__` derives
+                // `acceptable_as_base_class` from `'__new__' in rawdict`, and
+                // typedef.py restates it for `W_LineIterator` outright; none
+                // of the three declares `__new__`, so that rule answers False.
+                // The pinned 3.14 subclasses all three: their `tp_flags` carry
+                // `Py_TPFLAGS_BASETYPE` beside a NULL `tp_new`.  Measured on
+                // 3.14.2 and pinned by
+                // `extra_tests/parity_tests/co_branches_iterator_identity.py`.
+                pyre_object::w_type_set_acceptable_as_base_class(w_type, true);
+            }
             reg.insert(tp, w_type as usize);
         }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2570,12 +2570,10 @@ fn new_root_typeobject(name: &str, init: fn(PyObjectRef)) -> PyObjectRef {
     // typeobject.py setup_builtin_type — root type gets its own Layout.
     unsafe {
         let layout = pyre_object::typeobject::leak_layout(pyre_object::typeobject::Layout {
-            typedef: &INSTANCE_TYPE as *const PyType,
+            typedef: pyre_object::typeobject::leak_interpreter_typedef(&INSTANCE_TYPE, true, false),
             nslots: 0,
             newslotnames: vec![],
             base_layout: std::ptr::null(),
-            acceptable_as_base_class: true, // object has __new__
-            typedef_hasdict: false,         // object typedef declares no __dict__
             dict_data_slot: pyre_object::typeobject::DICT_DATA_SLOT_UNRESOLVED,
         });
         pyre_object::w_type_set_layout(type_obj, layout);
@@ -2601,16 +2599,23 @@ fn new_typeobject_with_base(
 
 /// Create a builtin type with explicit layout PyType.
 ///
-/// typeobject.py setup_builtin_type parity: each builtin type
-/// gets its own Layout based on its instancetypedef. Types that share
-/// the same typedef as their base reuse the parent's Layout object.
+/// `setup_builtin_type` parity: each ordinary builtin call owns a distinct
+/// TypeDef even when its concrete Rust allocation type matches the base.
+/// The explicit `overridetypedef` route below is the only reuse path.
 fn new_typeobject_with_base_and_layout(
     name: &str,
     init: impl FnOnce(PyObjectRef),
     base: PyObjectRef,
     layout_pytype: *const PyType,
 ) -> PyObjectRef {
-    new_typeobject_with_metatype_and_layout(name, init, base, layout_pytype, PY_NULL)
+    new_typeobject_with_metatype_and_layout(
+        name,
+        init,
+        base,
+        layout_pytype,
+        PY_NULL,
+        std::ptr::null(),
+    )
 }
 
 /// [`new_typeobject_with_base_and_layout`] for a type whose own type is not
@@ -2624,6 +2629,7 @@ fn new_typeobject_with_metatype_and_layout(
     base: PyObjectRef,
     layout_pytype: *const PyType,
     w_metatype: PyObjectRef,
+    overridetypedef: *const pyre_object::typeobject::InterpreterTypeDef,
 ) -> PyObjectRef {
     let _roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
@@ -2675,13 +2681,20 @@ fn new_typeobject_with_metatype_and_layout(
     //   return Layout(instancetypedef, 0, base_layout=parent_layout)
     unsafe {
         let parent_layout = pyre_object::w_type_get_layout_ptr(base);
-        let reuse = if !parent_layout.is_null() {
-            std::ptr::eq((*parent_layout).typedef, layout_pytype)
-        } else {
-            false
-        };
         let has_dict = pyre_object::w_dict_getitem_str(ns, "__dict__").is_some();
         let has_weakref = pyre_object::w_dict_getitem_str(ns, "__weakref__").is_some();
+        let typedef = if overridetypedef.is_null() {
+            let has_new = pyre_object::w_dict_getitem_str(ns, "__new__").is_some();
+            let inherited_hasdict = !parent_layout.is_null() && (*(*parent_layout).typedef).hasdict;
+            pyre_object::typeobject::leak_interpreter_typedef(
+                layout_pytype,
+                has_new,
+                has_dict || inherited_hasdict,
+            )
+        } else {
+            overridetypedef
+        };
+        let reuse = !parent_layout.is_null() && std::ptr::eq((*parent_layout).typedef, typedef);
         let layout = if reuse {
             // A `dict` subclass keeps its entries in a reserved layout slot
             // rather than in the dict layout.  `create_all_slots` reserves
@@ -2697,27 +2710,19 @@ fn new_typeobject_with_metatype_and_layout(
             match crate::type_methods::base_owes_dict_backing(base) {
                 false => parent_layout,
                 true => pyre_object::typeobject::leak_layout(pyre_object::typeobject::Layout {
-                    typedef: layout_pytype,
+                    typedef: (*parent_layout).typedef,
                     nslots: (*parent_layout).nslots + 1,
                     newslotnames: vec![crate::type_methods::DICT_DATA_SLOT.to_string()],
                     base_layout: parent_layout,
-                    acceptable_as_base_class: (*parent_layout).acceptable_as_base_class,
-                    typedef_hasdict: (*parent_layout).typedef_hasdict,
                     dict_data_slot: pyre_object::typeobject::DICT_DATA_SLOT_UNRESOLVED,
                 }),
             }
         } else {
-            let has_new = pyre_object::w_dict_getitem_str(ns, "__new__").is_some();
             pyre_object::typeobject::leak_layout(pyre_object::typeobject::Layout {
-                typedef: layout_pytype,
+                typedef,
                 nslots: 0,
                 newslotnames: vec![],
                 base_layout: parent_layout,
-                acceptable_as_base_class: has_new,
-                // typedef.py `hasdict = '__dict__' in rawdict` — a typedef
-                // that declares `__dict__` does its own dict management, so
-                // mapdict must not add a second one (typeobject.py:253-257).
-                typedef_hasdict: has_dict,
                 dict_data_slot: pyre_object::typeobject::DICT_DATA_SLOT_UNRESOLVED,
             })
         };
@@ -2756,27 +2761,33 @@ fn new_typeobject_with_metatype_and_layout(
 /// linearization (`compute_default_mro`).  Used for builtin exception
 /// classes with more than one base, e.g.
 /// `class UnsupportedOperation(OSError, ValueError)`.
-pub fn make_builtin_type_with_bases(
+pub fn make_builtin_type_with_bases_and_overridetypedef(
     name: &str,
     init: impl FnOnce(PyObjectRef),
     bases: &[PyObjectRef],
 ) -> PyObjectRef {
     let base = bases[0];
-    // A multi-base builtin class introduces no instance layout of its own, so
-    // it names the primary base's typedef and the reuse rule below hands back
-    // that same Layout.
-    let layout_pytype = unsafe {
+    // `_new_exception`-style classes use `applevel_subclasses_base` as
+    // TypeCache's `overridetypedef`, so they retain the primary real base's
+    // exact TypeDef and Layout.
+    let overridetypedef = unsafe {
         let parent_layout = pyre_object::w_type_get_layout_ptr(base);
         if parent_layout.is_null() {
-            &INSTANCE_TYPE as *const PyType
+            std::ptr::null()
         } else {
             (*parent_layout).typedef
         }
     };
-    make_builtin_type_with_bases_and_layout(name, init, bases, layout_pytype)
+    let layout_pytype = if overridetypedef.is_null() {
+        &INSTANCE_TYPE as *const PyType
+    } else {
+        unsafe { (*overridetypedef).instance_type }
+    };
+    make_builtin_type_with_bases_and_layout_owner(name, init, bases, layout_pytype, overridetypedef)
 }
 
-/// [`make_builtin_type_with_bases`] with an explicit interpreter TypeDef
+/// [`make_builtin_type_with_bases_and_overridetypedef`] with an explicit
+/// interpreter TypeDef
 /// identity for a concrete class that introduces its own instance Layout.
 ///
 /// PyPy `setup_builtin_type` receives the concrete `instancetypedef` even for
@@ -2789,6 +2800,22 @@ pub fn make_builtin_type_with_bases_and_layout(
     bases: &[PyObjectRef],
     layout_pytype: *const PyType,
 ) -> PyObjectRef {
+    make_builtin_type_with_bases_and_layout_owner(
+        name,
+        init,
+        bases,
+        layout_pytype,
+        std::ptr::null(),
+    )
+}
+
+pub(crate) fn make_builtin_type_with_bases_and_layout_owner(
+    name: &str,
+    init: impl FnOnce(PyObjectRef),
+    bases: &[PyObjectRef],
+    layout_pytype: *const PyType,
+    overridetypedef: *const pyre_object::typeobject::InterpreterTypeDef,
+) -> PyObjectRef {
     let base = bases[0];
     let _roots = pyre_object::gc_roots::push_roots();
     let ns_slot = pyre_object::gc_roots::shadow_stack_len();
@@ -2797,29 +2824,43 @@ pub fn make_builtin_type_with_bases_and_layout(
     init(ns);
     let bases_tuple = w_tuple_new(bases.to_vec());
     let ns = pyre_object::gc_roots::shadow_stack_get(ns_slot);
-    let type_obj = new_builtin_typeobject(name, bases_tuple, ns as *mut u8, layout_pytype, PY_NULL);
+    let parent_layout = unsafe { pyre_object::w_type_get_layout_ptr(base) };
+    let typedef = if overridetypedef.is_null() {
+        let has_new = unsafe { pyre_object::w_dict_getitem_str(ns, "__new__").is_some() };
+        let has_dict = unsafe { pyre_object::w_dict_getitem_str(ns, "__dict__").is_some() };
+        let inherited_hasdict = bases.iter().any(|&base| unsafe {
+            let layout = pyre_object::w_type_get_layout_ptr(base);
+            !layout.is_null() && (*(*layout).typedef).hasdict
+        });
+        pyre_object::typeobject::leak_interpreter_typedef(
+            layout_pytype,
+            has_new,
+            has_dict || inherited_hasdict,
+        )
+    } else {
+        overridetypedef
+    };
+    let type_obj = new_builtin_typeobject(
+        name,
+        bases_tuple,
+        ns as *mut u8,
+        unsafe { (*typedef).instance_type },
+        PY_NULL,
+    );
     let ns = pyre_object::gc_roots::shadow_stack_get(ns_slot);
 
     unsafe {
-        let parent_layout = pyre_object::w_type_get_layout_ptr(base);
-        let reuse = if !parent_layout.is_null() {
-            std::ptr::eq((*parent_layout).typedef, layout_pytype)
-        } else {
-            false
-        };
+        let reuse = !parent_layout.is_null() && std::ptr::eq((*parent_layout).typedef, typedef);
         let has_dict = pyre_object::w_dict_getitem_str(ns, "__dict__").is_some();
         let has_weakref = pyre_object::w_dict_getitem_str(ns, "__weakref__").is_some();
         let layout = if reuse {
             parent_layout
         } else {
-            let has_new = pyre_object::w_dict_getitem_str(ns, "__new__").is_some();
             pyre_object::typeobject::leak_layout(pyre_object::typeobject::Layout {
-                typedef: layout_pytype,
+                typedef,
                 nslots: 0,
                 newslotnames: vec![],
                 base_layout: parent_layout,
-                acceptable_as_base_class: has_new,
-                typedef_hasdict: has_dict,
                 dict_data_slot: pyre_object::typeobject::DICT_DATA_SLOT_UNRESOLVED,
             })
         };
@@ -2850,7 +2891,7 @@ pub fn make_builtin_type_with_bases_and_layout(
 /// Create a named builtin type inheriting from `object`.
 ///
 /// Used by extension modules (e.g. _sre) to define their own types.
-/// typeobject.py `is_heaptype=False` — builtin type.
+/// `W_TypeObject.__init__` receives `is_heaptype=False` for a builtin TypeDef.
 pub fn make_builtin_type(name: &str, init: impl FnOnce(PyObjectRef)) -> PyObjectRef {
     new_typeobject_with_base(name, init, w_object())
 }
@@ -2868,15 +2909,56 @@ pub fn make_builtin_type_with_base(
 /// `layout_pytype` (the `*const PyType` stored in `ob_header.ob_type`
 /// for new instances).  Used for W_Root subclasses that allocate
 /// their own typed payload (e.g. `GetSetProperty`) rather than
-/// piggy-backing on `INSTANCE_TYPE`.  Mirrors `typeobject.py:1273-1280
-/// setup_builtin_type`'s explicit-layout branch.
+/// piggy-backing on `INSTANCE_TYPE`. Mirrors `setup_builtin_type`'s
+/// explicit-layout branch.
 pub fn make_builtin_type_with_layout(
     name: &str,
     init: impl FnOnce(PyObjectRef),
     base: PyObjectRef,
     layout_pytype: *const PyType,
 ) -> PyObjectRef {
-    new_typeobject_with_base_and_layout(name, init, base, layout_pytype)
+    make_builtin_type_with_layout_owner(name, init, base, layout_pytype, std::ptr::null())
+}
+
+/// `setup_builtin_type` with the separate allocation type and TypeCache
+/// `overridetypedef` inputs kept explicit.  A null override means the builtin
+/// owns a fresh TypeDef even when its Rust allocation type matches its base.
+pub(crate) fn make_builtin_type_with_layout_owner(
+    name: &str,
+    init: impl FnOnce(PyObjectRef),
+    base: PyObjectRef,
+    layout_pytype: *const PyType,
+    overridetypedef: *const pyre_object::typeobject::InterpreterTypeDef,
+) -> PyObjectRef {
+    new_typeobject_with_metatype_and_layout(
+        name,
+        init,
+        base,
+        layout_pytype,
+        PY_NULL,
+        overridetypedef,
+    )
+}
+
+/// PyPy `TypeCache.build`: construct a builtin type using an explicit
+/// `overridetypedef` such as an exception's `applevel_subclasses_base`.
+/// The resulting type reuses the base Layout only when that exact TypeDef is
+/// already its owner.
+pub fn make_builtin_type_with_overridetypedef(
+    name: &str,
+    init: impl FnOnce(PyObjectRef),
+    base: PyObjectRef,
+    overridetypedef: *const pyre_object::typeobject::InterpreterTypeDef,
+) -> PyObjectRef {
+    let layout_pytype = unsafe { (*overridetypedef).instance_type };
+    new_typeobject_with_metatype_and_layout(
+        name,
+        init,
+        base,
+        layout_pytype,
+        PY_NULL,
+        overridetypedef,
+    )
 }
 
 /// [3.14-spec] Project a CPython `PyType_From*Spec` owner onto a PyPy builtin
@@ -2908,7 +2990,20 @@ pub fn make_builtin_type_with_metatype(
     layout_pytype: *const PyType,
     w_metatype: PyObjectRef,
 ) -> PyObjectRef {
-    new_typeobject_with_metatype_and_layout(name, init, base, layout_pytype, w_metatype)
+    let parent_layout = unsafe { pyre_object::w_type_get_layout_ptr(base) };
+    let overridetypedef = if parent_layout.is_null() {
+        std::ptr::null()
+    } else {
+        unsafe { (*parent_layout).typedef }
+    };
+    new_typeobject_with_metatype_and_layout(
+        name,
+        init,
+        base,
+        layout_pytype,
+        w_metatype,
+        overridetypedef,
+    )
 }
 
 /// int.__new__(cls, *args) — PyPy: intobject.py descr__new__
@@ -31711,6 +31806,29 @@ mod tests {
                 expected,
                 "{name}.acceptable_as_base_class"
             );
+        }
+    }
+
+    #[test]
+    fn builtin_typedef_identity_is_not_the_rust_allocation_type() {
+        crate::typedef::init_typeobjects();
+        let object_layout =
+            unsafe { pyre_object::w_type_get_layout_ptr(crate::typedef::w_object()) };
+        let mappingproxy_layout = unsafe {
+            pyre_object::w_type_get_layout_ptr(crate::typedef::gettypeobject(
+                &pyre_object::MAPPING_PROXY_TYPE,
+            ))
+        };
+
+        unsafe {
+            assert!(std::ptr::eq(
+                (*(*object_layout).typedef).instance_type,
+                (*(*mappingproxy_layout).typedef).instance_type,
+            ));
+            assert!(!std::ptr::eq(
+                (*object_layout).typedef,
+                (*mappingproxy_layout).typedef,
+            ));
         }
     }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1018,17 +1018,19 @@ unsafe fn ssl_socket_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_
 /// RPython `{str: cell_or_value}` dict) plus
 /// `ModuleDictStrategy.caches` (the per-name `GlobalCache` registry
 /// whose `cell` fields hold live values).  Pyre's W_ModuleDictObject
-/// carries three indirect storages behind raw pointers — none of them
+/// carries two erased fields behind raw pointers — neither is
 /// reachable through inline `gc_ptr_offsets`:
 ///
 ///   * `dstorage` → `ModuleDictStorage.entries` (Vec<(String,
 ///     PyObjectRef)>) — every entry's value
-///   * `mstrategy` → `ModuleDictStrategy.caches` (Option<HashMap<...,
-///     Arc<Mutex<GlobalCache>>>>) — every live cache's `cell`
-///   * `object_storage` → post-`switch_to_object_strategy`
-///     Vec<(PyObjectRef, PyObjectRef)> — both halves of every entry
+///   * `mstrategy` → `DictStrategyRef`, whose traced `owner` points to
+///     `ModuleDictStrategy.caches` while the module strategy is active
 ///
-/// Each of the three is now a GC-managed non-moving storage box (off-GC
+/// After `switch_to_object_strategy`, the same `dstorage` field holds
+/// ObjectDictStorage and `mstrategy` points to the process-wide object holder,
+/// exactly like PyPy's `set_strategy` plus `dstorage` replacement.
+///
+/// Each per-module allocation is a GC-managed non-moving storage box (off-GC
 /// storage), so this trace does two things: it forwards each
 /// box-pointer field slot to grey the box (keeping it off the sweep list,
 /// as `object_object_custom_trace` does for `storage`), then walks the box
@@ -1054,12 +1056,26 @@ unsafe fn module_dict_object_custom_trace(
     if pyre_object::dictmultiobject::is_module_dict(obj) {
         for field in [
             std::ptr::addr_of_mut!(md.dstorage) as *mut *mut u8,
-            std::ptr::addr_of_mut!(md.object_storage) as *mut *mut u8,
             std::ptr::addr_of_mut!(md.mstrategy) as *mut *mut u8,
         ] {
             let boxed = *field;
             if !boxed.is_null() && pyre_object::gc_hook::try_gc_owns_object(boxed) {
                 f(field as *mut majit_ir::GcRef);
+            }
+        }
+        // A module holder owns the concrete ModuleDictStrategy.  Forward the
+        // actual owner slot after forwarding `mstrategy`, so the holder and
+        // its version/cache state have the same reachability chain as PyPy's
+        // strategy instance.  Static strategy holders have a null owner.
+        // Only the per-module holder is collector-owned.  After promotion the
+        // slot points at the immutable process-wide ObjectDictStrategy holder;
+        // do not manufacture a mutable reference to that static.
+        if !md.mstrategy.is_null()
+            && pyre_object::gc_hook::try_gc_owns_object(md.mstrategy as *mut u8)
+        {
+            let holder = &mut *md.mstrategy;
+            if !holder.owner.is_null() && pyre_object::gc_hook::try_gc_owns_object(holder.owner) {
+                f(std::ptr::addr_of_mut!(holder.owner) as *mut majit_ir::GcRef);
             }
         }
     }
@@ -2824,15 +2840,12 @@ fn build_gc() -> Box<MiniMarkGC> {
     // CODE_TYPE (46) and PYTRACEBACK_TYPE (47); placing it between
     // W_DICT and W_SET would shift every subsequent tid by one and
     // break descr ↔ GC tid correspondence.
-    // W_ModuleDictObject carries `dstorage: *mut ModuleDictStorage`
-    // (`Vec<(String, PyObjectRef)>` of cells / raw values),
-    // `mstrategy: *mut ModuleDictStrategy` (whose `caches`
-    // GlobalCache.cell fields hold live cells), and
-    // `object_storage: *mut Vec<(PyObjectRef, PyObjectRef)>` (active
-    // after `switch_to_object_strategy`).  Register a custom trace
-    // hook so the GC walks all three indirect storages — matching
+    // W_ModuleDictObject carries erased `dstorage` and `mstrategy` slots.
+    // The latter points to DictStrategyRef; its owner points to the concrete
+    // ModuleDictStrategy while that strategy is active. Register a custom
+    // trace hook so the GC walks this indirect ownership chain — matching
     // the W_DictObject pattern.
-    // No `.with_destructor_fn`: all three storages are now GC-managed storage
+    // No `.with_destructor_fn`: all per-module storages are GC-managed storage
     // boxes (off-GC storage) whose own tid drop glue
     // (`storage_box_destructor`) is the sole reclaimer. A sweep-time module-dict
     // destructor would race those boxes on the destructor list and double-free —
@@ -4327,11 +4340,11 @@ fn build_gc() -> Box<MiniMarkGC> {
         pyre_object::gc_storage::storage_box_destructor::<pyre_object::kwargsdict::KwargsDictStorage>,
         pyre_object::kwargsdict::set_kwargs_dict_storage_gc_type_id,
     );
-    // Module-dict `dstorage` and `mstrategy` storage boxes (off-GC storage
+    // Module-dict `dstorage`, holder and owner storage boxes (off-GC storage
     // epic S3). `module_dict_object_custom_trace` greys each box through its
     // field slot and `w_module_dict_walk_gc_cells` forwards the interior
     // PyObjectRef slots — same leaf contract as the regular-dict boxes above.
-    // The post-switch `object_storage` reuses the ObjectDictStorage box tid
+    // The post-switch `dstorage` reuses the ObjectDictStorage box tid
     // registered above (identical `IndexMap<ObjectKey, PyObjectRef>` type), so
     // it needs no separate registration. Keep these ids at the absolute tail.
     register_leaf_storage_box::<pyre_object::celldict::ModuleDictStorage>(
@@ -4343,6 +4356,13 @@ fn build_gc() -> Box<MiniMarkGC> {
         &mut gc,
         pyre_object::gc_storage::storage_box_destructor::<pyre_object::celldict::ModuleDictStrategy>,
         pyre_object::celldict::set_module_dict_strategy_gc_type_id,
+    );
+    register_leaf_storage_box::<pyre_object::dictmultiobject::DictStrategyRef>(
+        &mut gc,
+        pyre_object::gc_storage::storage_box_destructor::<
+            pyre_object::dictmultiobject::DictStrategyRef,
+        >,
+        pyre_object::dictmultiobject::set_dict_strategy_ref_gc_type_id,
     );
     // bytearray `data` storage box (off-GC storage). A leaf `Vec<u8>` (no inner
     // refs); `bytearray_object_custom_trace` greys it through the `data` field

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -1275,7 +1275,8 @@ impl crate::dictmultiobject::DictStrategy for ModuleDictStrategy {
     /// (key, cell) from the IndexMap, mutated(), unwrap the cell, and
     /// return (`_wrapkey(space, key)`, `unwrap_cell(space, cell)`).
     /// O(1) via `IndexMap::pop`; after a `switch_to_object_strategy` the
-    /// entries live in `object_storage` and are popped already unwrapped.
+    /// entries live in ObjectDictStrategy's erased storage and are popped
+    /// already unwrapped.
     unsafe fn popitem(&self, w_dict: PyObjectRef) -> Option<(PyObjectRef, PyObjectRef)> {
         if let Some(entries) = crate::dictmultiobject::w_module_dict_object_storage_mut_opt(w_dict)
         {
@@ -1284,14 +1285,11 @@ impl crate::dictmultiobject::DictStrategy for ModuleDictStrategy {
             // through this strategy, so a compiled trace that pinned a global
             // stays valid until `version` is reassigned. `delitem` pairs the
             // two calls the same way on the object-storage arm.
-            let module = &mut *(w_dict as *mut crate::dictmultiobject::W_ModuleDictObject);
-            (*module.mstrategy).mutated();
             crate::dictmultiobject::w_dict_bump_keys_version(w_dict);
             return Some((k.obj, v));
         }
-        let module = &mut *(w_dict as *mut crate::dictmultiobject::W_ModuleDictObject);
-        let strategy = &mut *module.mstrategy;
-        let storage = &mut *module.dstorage;
+        let strategy = crate::dictmultiobject::w_module_dict_module_strategy_mut(w_dict);
+        let storage = crate::dictmultiobject::w_module_dict_module_storage_mut(w_dict);
         let (key, cell) = storage.entries.pop()?;
         strategy.mutated();
         crate::dictmultiobject::w_dict_bump_keys_version(w_dict);
@@ -1308,8 +1306,7 @@ impl crate::dictmultiobject::DictStrategy for ModuleDictStrategy {
         if let Some(entries) = crate::dictmultiobject::w_module_dict_object_storage(w_dict) {
             return entries.iter().rev().map(|(k, &v)| (k.obj, v)).collect();
         }
-        let module = &*(w_dict as *const crate::dictmultiobject::W_ModuleDictObject);
-        let storage = &*module.dstorage;
+        let storage = crate::dictmultiobject::w_module_dict_module_storage(w_dict);
         storage
             .entries
             .iter()
@@ -1336,8 +1333,7 @@ impl crate::dictmultiobject::DictStrategy for ModuleDictStrategy {
             }
             return new_dict;
         }
-        let module = &*(w_dict as *const crate::dictmultiobject::W_ModuleDictObject);
-        let storage = &*module.dstorage;
+        let storage = crate::dictmultiobject::w_module_dict_module_storage(w_dict);
         for (key, &cell) in storage.entries.iter() {
             let unwrapped = unwrap_cell(cell);
             let key_obj = _wrapkey(key);
@@ -1384,9 +1380,8 @@ pub unsafe fn remove_cell(w_dict: PyObjectRef, name: &str) {
     ) {
         return;
     }
-    let module = &mut *(w_dict as *mut crate::dictmultiobject::W_ModuleDictObject);
-    let strategy = &mut *module.mstrategy;
-    let storage = &mut *module.dstorage;
+    let strategy = crate::dictmultiobject::w_module_dict_module_strategy_mut(w_dict);
+    let storage = crate::dictmultiobject::w_module_dict_module_storage_mut(w_dict);
     let Some(w_value) = strategy.getitem_str(storage, name) else {
         return;
     };

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1123,6 +1123,13 @@ dict_storage_gc_type_id!(
     BytesDictStorage,
     "Runtime-assigned GC type id for the `BytesDictStorage` box."
 );
+dict_storage_gc_type_id!(
+    DICT_STRATEGY_REF_GC_TYPE_ID,
+    set_dict_strategy_ref_gc_type_id,
+    dict_strategy_ref_gc_type_id,
+    DictStrategyRef,
+    "Runtime-assigned GC type id for a per-dict `DictStrategyRef` holder."
+);
 
 /// Reclaim an off-GC `ObjectDictStorage` box that is NOT collector-owned.
 ///
@@ -1200,7 +1207,7 @@ pub unsafe fn w_dict_get_strategy(
 ) -> &'static dyn crate::dictmultiobject::DictStrategy {
     if is_module_dict(obj) {
         let strat_ptr = (*(obj as *const W_ModuleDictObject)).mstrategy;
-        return &*strat_ptr;
+        return (*strat_ptr).imp;
     }
     let dict = &*(obj as *const W_DictObject);
     dict.dstrategy.imp
@@ -1225,10 +1232,10 @@ pub unsafe fn w_dict_get_strategy(
 #[inline]
 pub unsafe fn w_dict_set_strategy(obj: PyObjectRef, strategy: &'static DictStrategyRef) {
     if is_module_dict(obj) {
-        panic!(
-            "w_dict_set_strategy: W_ModuleDictObject strategy swap is not the canonical \
-             path; use w_module_dict_switch_to_object_strategy (celldict.py:173-186)"
-        );
+        (*(obj as *mut W_ModuleDictObject)).mstrategy =
+            strategy as *const DictStrategyRef as *mut DictStrategyRef;
+        dict_write_barrier(obj);
+        return;
     }
     let dict = &mut *(obj as *mut W_DictObject);
     dict.dstrategy = strategy;
@@ -1238,7 +1245,7 @@ pub unsafe fn w_dict_set_strategy(obj: PyObjectRef, strategy: &'static DictStrat
 /// global cell fast path.  Returns the insertion-order index of `name`
 /// inside the module dict's `ModuleDictStorage`, or `None` when `obj` is
 /// not a `W_ModuleDictObject` in `ModuleDictStrategy` mode (after
-/// `switch_to_object_strategy` the `object_storage` is authoritative and
+/// `switch_to_object_strategy` the erased `dstorage` holds ObjectDictStorage and
 /// the version-keyed cell path is permanently invalid).  The index is
 /// stable across in-place cell mutation and value overwrite (`IndexMap`
 /// keeps the slot position), so it serves as the elidable lookup key.
@@ -1250,10 +1257,12 @@ pub unsafe fn module_dict_cell_slot_of(obj: PyObjectRef, name: &str) -> Option<u
         return None;
     }
     let md = &*(obj as *const W_ModuleDictObject);
-    if !md.object_storage.is_null() || md.dstorage.is_null() {
+    if w_module_dict_is_object_strategy(obj) || md.dstorage.is_null() {
         return None;
     }
-    (*md.dstorage).entries.get_index_of(name)
+    (*(md.dstorage as *const crate::celldict::ModuleDictStorage))
+        .entries
+        .get_index_of(name)
 }
 
 /// `celldict.py _getdictvalue_no_unwrapping_pure` — the raw stored
@@ -1268,10 +1277,10 @@ pub unsafe fn module_dict_cell_at(obj: PyObjectRef, slot: usize) -> Option<PyObj
         return None;
     }
     let md = &*(obj as *const W_ModuleDictObject);
-    if !md.object_storage.is_null() || md.dstorage.is_null() {
+    if w_module_dict_is_object_strategy(obj) || md.dstorage.is_null() {
         return None;
     }
-    (*md.dstorage)
+    (*(md.dstorage as *const crate::celldict::ModuleDictStorage))
         .entries
         .get_index(slot)
         .map(|(_, v)| *v)
@@ -1291,10 +1300,10 @@ pub unsafe fn module_dict_storage_len(obj: PyObjectRef) -> Option<usize> {
         return None;
     }
     let md = &*(obj as *const W_ModuleDictObject);
-    if !md.object_storage.is_null() || md.dstorage.is_null() {
+    if w_module_dict_is_object_strategy(obj) || md.dstorage.is_null() {
         return None;
     }
-    Some((*md.dstorage).len())
+    Some((*(md.dstorage as *const crate::celldict::ModuleDictStorage)).len())
 }
 
 /// `quasiimmut.py get_current_qmut_instance` for a module dict
@@ -1627,29 +1636,21 @@ pub static MODULE_DICT_TYPE: PyType = new_pytype("dict");
 pub struct W_ModuleDictObject {
     pub ob_header: PyObject,
     /// `dstorage` from `W_DictMultiObject.__slots__` (`dictmultiobject.py`).
-    /// A GC-managed non-moving storage box (off-GC storage);
-    /// reassignment is a `setfield_gc`.  Authoritative while
-    /// `object_storage` is null (ModuleDictStrategy mode); after
-    /// `switch_to_object_strategy` it is cleared and not consulted.
-    pub dstorage: *mut crate::celldict::ModuleDictStorage,
+    /// A GC-managed non-moving erased storage box (off-GC storage).
+    /// Reassignment is a `setfield_gc`; its concrete type follows the live
+    /// strategy exactly as `rerased` storage does upstream.
+    pub dstorage: *mut u8,
     /// `mstrategy` from `W_ModuleDictObject.__slots__` (`:331`).
     /// A GC-managed non-moving storage box (off-GC storage).
-    pub mstrategy: *mut crate::celldict::ModuleDictStrategy,
-    /// `dstorage` after a `switch_to_object_strategy`
-    /// (`celldict.py:173-186`).  Null while the dict is in
-    /// ModuleDictStrategy mode; non-null once a non-str key forces the
-    /// strategy swap.  Holds the unified ObjectKey-keyed entries that
-    /// PyPy keeps inside the new `ObjectDictStrategy` storage after the
-    /// switch — `dstorage`'s entries are drained into this IndexMap in
-    /// their original insertion order so `items()` / `popitem()` LIFO
-    /// parity is preserved across mixed-key inserts.  Backing matches
-    /// `ObjectDictStrategy` (`dictmultiobject.py r_dict(space.eq_w,
-    /// space.hash_w)`) — same `ObjectKey { hash, obj }` precomputed-hash
-    /// + `dict_keys_equal` equality.
-    pub object_storage: *mut ObjectDictStorage,
+    pub mstrategy: *mut DictStrategyRef,
     /// Key-set mutation state corresponding to the live iterator held by
     /// PyPy's ModuleDictStrategy iterator implementation.
     pub keys_version: usize,
+    /// The same iterator restart generation carried by `W_DictObject`.
+    /// Keeping the concrete layouts prefix-identical lets the ordinary
+    /// ObjectDictStrategy operate on a module dict after PyPy's literal
+    /// `mstrategy`/`dstorage` swap.
+    pub clear_gen: usize,
 }
 
 /// GC type id assigned to `W_ModuleDictObject`.  Lands at slot 48,
@@ -1679,7 +1680,7 @@ impl crate::lltype::GcType for W_ModuleDictObject {
 impl W_DictMultiObject for W_ModuleDictObject {
     #[inline]
     fn get_strategy(&self) -> &dyn crate::dictmultiobject::DictStrategy {
-        unsafe { &*self.mstrategy }
+        unsafe { (*self.mstrategy).imp }
     }
 
     /// `celldict.py w_dict.set_strategy(strategy)` — the only
@@ -1690,11 +1691,6 @@ impl W_DictMultiObject for W_ModuleDictObject {
     /// correctly without panicking; non-Object target strategies stay
     /// unreachable per the upstream surface.
     ///
-    /// TODO: pyre carries `object_storage` as a
-    /// side field instead of swapping `dstorage` wholesale (PyPy's
-    /// `w_dict.dstorage = strategy.erase(d_new)`).  The trait method
-    /// hides that adapter from callers; the side-field layout retires
-    /// alongside typed-strategy storage migration.
     fn set_strategy(&mut self, strategy: &'static DictStrategyRef) {
         // Distinct holders have distinct addresses; the singletons they carry
         // are zero-sized, and comparing *those* addresses is not a valid
@@ -1705,8 +1701,7 @@ impl W_DictMultiObject for W_ModuleDictObject {
                  implemented (celldict.py:173-186 is the only documented swap target)"
             );
         }
-        let obj = self as *mut Self as PyObjectRef;
-        unsafe { w_module_dict_switch_to_object_strategy(obj) };
+        self.mstrategy = strategy as *const DictStrategyRef as *mut DictStrategyRef;
     }
 }
 
@@ -1733,16 +1728,34 @@ impl W_DictMultiObject for W_ModuleDictObject {
 /// plain GCREF with no discriminant to erase.
 #[majit_macros::dont_look_inside]
 pub fn w_module_dict_new() -> PyObjectRef {
+    let roots = crate::gc_roots::push_roots();
     let strategy = crate::gc_storage::gc_alloc_storage_box(
         crate::celldict::ModuleDictStrategy::new(),
         crate::celldict::module_dict_strategy_gc_type_id(),
     );
+    let strategy_slot = roots.publish(&[strategy as PyObjectRef]);
+    let strategy = roots.get(strategy_slot) as *mut crate::celldict::ModuleDictStrategy;
+    // The strategy box is non-moving and lives as long as this holder.  The
+    // holder's `owner` word is explicitly traced by the module-dict custom
+    // trace, so extending the reference lifetime expresses that GC ownership
+    // without leaking a process-global strategy.
+    let imp: &'static dyn DictStrategy =
+        unsafe { std::mem::transmute::<&dyn DictStrategy, &'static dyn DictStrategy>(&*strategy) };
+    let strategy_ref = crate::gc_storage::gc_alloc_storage_box(
+        DictStrategyRef {
+            imp,
+            owner: strategy as *mut u8,
+        },
+        dict_strategy_ref_gc_type_id(),
+    );
+    let strategy_ref_slot = roots.publish(&[strategy_ref as PyObjectRef]);
     let storage = unsafe {
         crate::gc_storage::gc_alloc_storage_box(
             (*strategy).get_empty_storage(),
             crate::celldict::module_dict_storage_gc_type_id(),
         )
     };
+    let storage_slot = roots.publish(&[storage as PyObjectRef]);
     crate::lltype::malloc_typed_stable(W_ModuleDictObject {
         ob_header: PyObject {
             // `dictmultiobject.py:67 space.allocate_instance(...,
@@ -1753,10 +1766,10 @@ pub fn w_module_dict_new() -> PyObjectRef {
             ob_type: &MODULE_DICT_TYPE as *const PyType,
             w_class: get_instantiate(&MODULE_DICT_TYPE),
         },
-        dstorage: storage,
-        mstrategy: strategy,
-        object_storage: std::ptr::null_mut(),
+        dstorage: roots.get(storage_slot) as *mut u8,
+        mstrategy: roots.get(strategy_ref_slot) as *mut DictStrategyRef,
         keys_version: 0,
+        clear_gen: 0,
     }) as PyObjectRef
 }
 
@@ -1844,20 +1857,19 @@ macro_rules! lock_dict_refs {
 pub fn module_dict_locks_after_fork_child() {}
 
 /// Predicate: dict is in ObjectDictStrategy mode (post-switch).  When
-/// true, `object_storage` is authoritative and `dstorage` is empty +
-/// not consulted.  Mirrors `W_DictMultiObject.get_strategy()` returning
+/// true, `dstorage` contains ObjectDictStorage. Mirrors
+/// `W_DictMultiObject.get_strategy()` returning
 /// `ObjectDictStrategy` vs `ModuleDictStrategy` (`dictmultiobject.py`).
 ///
 /// # Safety
 /// `obj` must point to a valid `W_ModuleDictObject`.
 #[inline]
 pub unsafe fn w_module_dict_is_object_strategy(obj: PyObjectRef) -> bool {
-    !(*(obj as *const W_ModuleDictObject))
-        .object_storage
-        .is_null()
+    let strategy = (*(obj as *const W_ModuleDictObject)).mstrategy;
+    !strategy.is_null() && (*strategy).strategy_kind() == StrategyKind::Object
 }
 
-/// Read-only view of the unified object_storage IndexMap; returns `None`
+/// Read-only view of ObjectDictStrategy's erased storage; returns `None`
 /// when the dict is still in ModuleDictStrategy mode.
 ///
 /// # Safety
@@ -1865,14 +1877,14 @@ pub unsafe fn w_module_dict_is_object_strategy(obj: PyObjectRef) -> bool {
 #[inline]
 pub unsafe fn w_module_dict_object_storage<'a>(obj: PyObjectRef) -> Option<&'a ObjectDictStorage> {
     let raw = &*(obj as *const W_ModuleDictObject);
-    if raw.object_storage.is_null() {
+    if !w_module_dict_is_object_strategy(obj) {
         None
     } else {
-        Some(&*raw.object_storage)
+        Some(&*(raw.dstorage as *const ObjectDictStorage))
     }
 }
 
-/// Mutable view of the unified object_storage IndexMap; requires the
+/// Mutable view of ObjectDictStrategy's erased storage; requires the
 /// dict to already be in object-strategy mode.
 ///
 /// # Safety
@@ -1881,11 +1893,11 @@ pub unsafe fn w_module_dict_object_storage<'a>(obj: PyObjectRef) -> Option<&'a O
 #[inline]
 pub unsafe fn w_module_dict_object_storage_mut<'a>(obj: PyObjectRef) -> &'a mut ObjectDictStorage {
     let raw = &mut *(obj as *mut W_ModuleDictObject);
-    debug_assert!(!raw.object_storage.is_null());
-    &mut *raw.object_storage
+    debug_assert!(w_module_dict_is_object_strategy(obj));
+    &mut *(raw.dstorage as *mut ObjectDictStorage)
 }
 
-/// Mutable view of the unified object_storage IndexMap when present;
+/// Mutable view of ObjectDictStrategy's erased storage when present;
 /// returns `None` while the dict is still in ModuleDictStrategy mode.
 /// Use this variant when the caller does not control the strategy
 /// state at the call site (e.g. trait-dispatch entry points that
@@ -1898,11 +1910,41 @@ pub unsafe fn w_module_dict_object_storage_mut_opt<'a>(
     obj: PyObjectRef,
 ) -> Option<&'a mut ObjectDictStorage> {
     let raw = &mut *(obj as *mut W_ModuleDictObject);
-    if raw.object_storage.is_null() {
+    if !w_module_dict_is_object_strategy(obj) {
         None
     } else {
-        Some(&mut *raw.object_storage)
+        Some(&mut *(raw.dstorage as *mut ObjectDictStorage))
     }
+}
+
+/// Concrete strategy payload for `ModuleDictStrategy.unerase`.  The erased
+/// dispatch holder is the live `mstrategy`; its traced `owner` carries the
+/// per-module state (version and global caches) while that strategy is active.
+#[inline]
+pub unsafe fn w_module_dict_module_strategy_mut<'a>(
+    obj: PyObjectRef,
+) -> &'a mut crate::celldict::ModuleDictStrategy {
+    let holder = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
+    debug_assert_eq!(holder.strategy_kind(), StrategyKind::Module);
+    debug_assert!(!holder.owner.is_null());
+    &mut *(holder.owner as *mut crate::celldict::ModuleDictStrategy)
+}
+
+/// Concrete storage behind `ModuleDictStrategy.unerase(w_dict.dstorage)`.
+#[inline]
+pub unsafe fn w_module_dict_module_storage_mut<'a>(
+    obj: PyObjectRef,
+) -> &'a mut crate::celldict::ModuleDictStorage {
+    debug_assert!(!w_module_dict_is_object_strategy(obj));
+    &mut *((*(obj as *mut W_ModuleDictObject)).dstorage as *mut crate::celldict::ModuleDictStorage)
+}
+
+#[inline]
+pub unsafe fn w_module_dict_module_storage<'a>(
+    obj: PyObjectRef,
+) -> &'a crate::celldict::ModuleDictStorage {
+    debug_assert!(!w_module_dict_is_object_strategy(obj));
+    &*((*(obj as *const W_ModuleDictObject)).dstorage as *const crate::celldict::ModuleDictStorage)
 }
 
 /// `pypy/objspace/std/celldict.py switch_to_object_strategy`:
@@ -1924,37 +1966,10 @@ pub unsafe fn w_module_dict_object_storage_mut_opt<'a>(
 ///     w_dict.dstorage = strategy.erase(d_new)
 /// ```
 ///
-/// Drains all str entries from `dstorage` into a fresh
-/// `object_storage` Vec, preserving insertion order (PyPy's
-/// `iteritems` over an RPython dict yields insertion order), clears
-/// `dstorage`, and bumps `mstrategy.version` so any quasi-immutable
-/// JIT cache keyed on the previous version invalidates.  After this
-/// call, all reads / writes route through `object_storage` regardless
-/// of key type — matching PyPy's `ObjectDictStrategy` semantics.
-///
-/// **TODO** vs `celldict.py:185-186`:
-/// PyPy actually swaps the strategy (`w_dict.set_strategy(strategy)`)
-/// and replaces `w_dict.dstorage` with the new `strategy.erase(d_new)`
-/// payload.  Pyre carries TWO storages (`dstorage` + `object_storage`)
-/// and flips a flag (`object_storage` non-null) to route reads/writes
-/// to the new container.  Functionally equivalent: after the switch,
-/// `dstorage` is cleared and never consulted; `object_storage` is the
-/// authoritative payload, exactly mirroring the post-`set_strategy`
-/// PyPy state.
-///
-/// **Why it diverges**: full structural parity requires a
-/// `DictStrategy` trait + concrete `ObjectDictStrategy` /
-/// `UnicodeDictStrategy` ports (see `dictmultiobject.py`)
-/// so `set_strategy` can replace both the dispatch object and the
-/// erased storage type uniformly.  That hierarchy is a large effort
-/// (750+ LOC across 4 strategies, 200+ call sites in
-/// `dictmultiobject.py` consuming `w_dict.get_strategy()` and
-/// `space.fromcache(<Strategy>)`).
-///
-/// **Convergence path**: when the strategy hierarchy ports land,
-/// drop `object_storage` and replace this two-slot carrier with a
-/// single `dstorage: *mut dyn DictStorageErased` whose concrete
-/// type is dictated by `mstrategy`'s runtime tag.
+/// Copies all str entries from the old erased ModuleDictStorage into fresh
+/// ObjectDictStorage, preserving insertion order, invalidates the displaced
+/// module caches, then replaces both `mstrategy` and `dstorage`. This is the
+/// literal shape of `celldict.py ModuleDictStrategy.switch_to_object_strategy`.
 ///
 /// No-op when already in object-strategy mode.
 ///
@@ -1968,14 +1983,16 @@ pub unsafe fn w_module_dict_object_storage_mut_opt<'a>(
 pub unsafe fn w_module_dict_switch_to_object_strategy(obj: PyObjectRef) {
     lock_dict_refs!(_module_guard, obj);
     let raw = &mut *(obj as *mut W_ModuleDictObject);
-    if !raw.object_storage.is_null() {
+    if w_module_dict_is_object_strategy(obj) {
         return;
     }
-    // The promotion mints young key objects into the fresh object_storage
+    // The promotion mints young key objects into the fresh object storage
     // (prebuilt-family storage; see `w_module_dict_setitem_str_internal`).
     crate::gc_roots::mark_prebuilt_roots_dirty();
-    let strategy = &mut *raw.mstrategy;
-    let storage = &mut *raw.dstorage;
+    let holder = &mut *raw.mstrategy;
+    debug_assert_eq!(holder.strategy_kind(), StrategyKind::Module);
+    let strategy = &mut *(holder.owner as *mut crate::celldict::ModuleDictStrategy);
+    let storage = &mut *(raw.dstorage as *mut crate::celldict::ModuleDictStorage);
     let mut new_storage = object_dict_storage_with_capacity(storage.entries.len());
     for (k, v) in strategy
         .getiterkeys(storage)
@@ -1984,14 +2001,16 @@ pub unsafe fn w_module_dict_switch_to_object_strategy(obj: PyObjectRef) {
         let key_obj = crate::celldict::_wrapkey(k);
         new_storage.insert(object_key_for(key_obj), v);
     }
-    raw.object_storage =
+    let new_storage =
         crate::gc_storage::gc_alloc_storage_box(new_storage, object_dict_storage_gc_type_id());
-    storage.clear();
     // `celldict.py`: every live GlobalCache becomes invalid
     // because the strategy is being swapped out; the JIT must
     // recompile any trace keyed on the prior version.
     strategy.invalidate_caches();
     strategy.mutated();
+    raw.mstrategy = &OBJECT_DICT_STRATEGY_REF as *const DictStrategyRef as *mut DictStrategyRef;
+    raw.dstorage = new_storage as *mut u8;
+    dict_write_barrier(obj);
 }
 
 /// `dictmultiobject.py _never_equal_to_string`:
@@ -2037,7 +2056,11 @@ pub unsafe fn is_module_dict(obj: PyObjectRef) -> bool {
 pub unsafe fn w_module_dict_get_strategy(
     obj: PyObjectRef,
 ) -> *mut crate::celldict::ModuleDictStrategy {
-    (*(obj as *const W_ModuleDictObject)).mstrategy
+    if w_module_dict_is_object_strategy(obj) {
+        return std::ptr::null_mut();
+    }
+    (*(*(obj as *const W_ModuleDictObject)).mstrategy).owner
+        as *mut crate::celldict::ModuleDictStrategy
 }
 
 /// [`w_module_dict_get_strategy`] for a caller that has not yet proven the
@@ -2068,7 +2091,7 @@ pub unsafe fn w_module_dict_strategy_or_null(
 /// Returns a `usize` that is stable across the dict's lifetime as long
 /// as no strategy transition occurs, and changes whenever the strategy
 /// transitions (e.g. `W_ModuleDictObject::switch_to_object_strategy`
-/// flipping `object_storage` from null to non-null).  Distinct dicts
+/// replacing `mstrategy`). Distinct dicts
 /// MAY share the same id when they share the strategy singleton
 /// (e.g. two regular W_DictObject instances both on
 /// `OBJECT_DICT_STRATEGY`); iterator parity is preserved because
@@ -2080,12 +2103,6 @@ pub unsafe fn w_module_dict_strategy_or_null(
 pub unsafe fn w_dict_strategy_id(obj: PyObjectRef) -> usize {
     if is_module_dict(obj) {
         let m = &*(obj as *const W_ModuleDictObject);
-        if !m.object_storage.is_null() {
-            // `switch_to_object_strategy` flipped the dict; tag with the
-            // object_storage address so the id is distinct from any
-            // pre-switch mstrategy stamp.
-            return m.object_storage as usize;
-        }
         return m.mstrategy as usize;
     }
     let d = &*(obj as *const W_DictObject);
@@ -2175,7 +2192,7 @@ pub unsafe fn w_dict_bump_keys_version(obj: PyObjectRef) {
 pub unsafe fn w_module_dict_get_storage(
     obj: PyObjectRef,
 ) -> *mut crate::celldict::ModuleDictStorage {
-    (*(obj as *const W_ModuleDictObject)).dstorage
+    (*(obj as *const W_ModuleDictObject)).dstorage as *mut crate::celldict::ModuleDictStorage
 }
 
 /// `dictmultiobject.py W_DictMultiObject.setitem_str`
@@ -2238,14 +2255,12 @@ unsafe fn w_module_dict_setitem_str_internal(obj: PyObjectRef, key: &str, w_valu
                 w_dict_bump_keys_version(obj);
             }
         };
-        let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-        strategy.mutated();
         dict_write_barrier(obj);
         return;
     }
     {
-        let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-        let storage = &mut *(*(obj as *mut W_ModuleDictObject)).dstorage;
+        let strategy = w_module_dict_module_strategy_mut(obj);
+        let storage = w_module_dict_module_storage_mut(obj);
         let old_len = storage.len();
         strategy.setitem_str(storage, key, w_value);
         if storage.len() != old_len {
@@ -2271,8 +2286,8 @@ pub unsafe fn w_module_dict_getitem_str(obj: PyObjectRef, key: &str) -> Option<P
         return dict_entries_get_str(entries, key, 0);
     }
     {
-        let strategy = &*(*(obj as *const W_ModuleDictObject)).mstrategy;
-        let storage = &*(*(obj as *const W_ModuleDictObject)).dstorage;
+        let strategy = &*w_module_dict_get_strategy(obj);
+        let storage = w_module_dict_module_storage(obj);
         if let Some(v) = strategy.getitem_str(storage, key) {
             return Some(v);
         }
@@ -2284,7 +2299,7 @@ pub unsafe fn w_module_dict_getitem_str(obj: PyObjectRef, key: &str) -> Option<P
 ///
 /// A module dict's authoritative storage is reached only behind raw
 /// pointers — the `dstorage` cell map, the post-`switch_to_object_strategy`
-/// `object_storage`, and the `mstrategy.caches` cell registry — none of which are inline
+/// erased `dstorage` and the module strategy cache registry — neither is inline
 /// `gc_ptr_offsets`. The non-moving W_ModuleDictObject's registered
 /// `module_dict_object_custom_trace` invokes this walk; the explicit frame
 /// root walker does too for raw globals/builtins carriers. Without the walk,
@@ -2310,14 +2325,8 @@ pub unsafe fn w_module_dict_walk_gc_cells(
         return;
     }
     let md = &mut *(obj as *mut W_ModuleDictObject);
-    if !md.dstorage.is_null() {
-        let storage = &mut *md.dstorage;
-        for value in storage.iter_values_mut() {
-            crate::celldict::walk_module_value_slot(value, visitor);
-        }
-    }
-    if !md.object_storage.is_null() {
-        let object_storage = &mut *md.object_storage;
+    if w_module_dict_is_object_strategy(obj) {
+        let object_storage = &mut *(md.dstorage as *mut ObjectDictStorage);
         for (key, value) in object_storage.iter_mut() {
             // ObjectKey.hash is precomputed and identity-stable across GC
             // moves, so writing through the raw obj slot does not desync
@@ -2326,9 +2335,12 @@ pub unsafe fn w_module_dict_walk_gc_cells(
             visitor(&mut (*key_ptr).obj);
             crate::celldict::walk_module_value_slot(value, visitor);
         }
-    }
-    if !md.mstrategy.is_null() {
-        (*md.mstrategy).walk_cache_cells(visitor);
+    } else {
+        let storage = &mut *(md.dstorage as *mut crate::celldict::ModuleDictStorage);
+        for value in storage.iter_values_mut() {
+            crate::celldict::walk_module_value_slot(value, visitor);
+        }
+        w_module_dict_module_strategy_mut(obj).walk_cache_cells(visitor);
     }
 }
 
@@ -2360,16 +2372,14 @@ unsafe fn w_module_dict_delitem_str_internal(obj: PyObjectRef, key: &str) -> Opt
         let w_key = crate::w_str_new(key);
         let entries = w_module_dict_object_storage_mut(obj);
         if let Some(removed) = entries.shift_remove(&object_key_for(w_key)) {
-            let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-            strategy.mutated();
             w_dict_bump_keys_version(obj);
             return Some(removed);
         }
         return None;
     }
     let removed = {
-        let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-        let storage = &mut *(*(obj as *mut W_ModuleDictObject)).dstorage;
+        let strategy = w_module_dict_module_strategy_mut(obj);
+        let storage = w_module_dict_module_storage_mut(obj);
         strategy.delitem_str(storage, key)
     };
     if removed.is_some() {
@@ -2388,8 +2398,8 @@ pub unsafe fn w_module_dict_length(obj: PyObjectRef) -> usize {
     if let Some(entries) = w_module_dict_object_storage(obj) {
         entries.len()
     } else {
-        let strategy = &*(*(obj as *const W_ModuleDictObject)).mstrategy;
-        let storage = &*(*(obj as *const W_ModuleDictObject)).dstorage;
+        let strategy = &*w_module_dict_get_strategy(obj);
+        let storage = w_module_dict_module_storage(obj);
         strategy.length(storage)
     }
 }
@@ -3511,8 +3521,6 @@ pub unsafe fn w_module_dict_store_inner(obj: PyObjectRef, key: PyObjectRef, valu
     let object_key = object_key_for(key);
     let inserted =
         dict_entries_insert_hashed(entries, object_key.hash, object_key.obj, value).is_none();
-    let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-    strategy.mutated();
     if inserted {
         w_dict_bump_keys_version(obj);
     }
@@ -3549,8 +3557,6 @@ pub unsafe fn w_module_dict_store_inner_checked(
         dict_entries_pop_last(entries);
         return Err(DictKeyError);
     }
-    let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-    strategy.mutated();
     if previous.is_none() {
         w_dict_bump_keys_version(obj);
     }
@@ -3924,8 +3930,6 @@ pub unsafe fn w_dict_delitem_wtf8_no_proxy(obj: PyObjectRef, key: &rustpython_wt
         let w_key = crate::w_str_from_wtf8(key.to_wtf8_buf());
         let removed = entries.shift_remove(&object_key_for(w_key)).is_some();
         if removed {
-            let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-            strategy.mutated();
             w_dict_bump_keys_version(obj);
         }
         return removed;
@@ -4086,8 +4090,6 @@ pub unsafe fn w_dict_delitem_if_value_is_checked(
                 }
                 Some(index) => {
                     entries.shift_remove_index(index);
-                    let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-                    strategy.mutated();
                     w_dict_bump_keys_version(obj);
                     true
                 }
@@ -4115,8 +4117,6 @@ pub unsafe fn w_dict_delitem_if_value_is_checked(
             return Ok(false);
         }
         entries.shift_remove_index(index);
-        let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-        strategy.mutated();
         w_dict_bump_keys_version(obj);
         return Ok(true);
     }
@@ -4240,8 +4240,6 @@ pub unsafe fn w_dict_move_to_end_checked(
                     // invalidated (as in w_dict_delitem_if_value_is_checked).
                     if index != target {
                         entries.move_index(index, target);
-                        let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-                        strategy.mutated();
                         w_dict_bump_keys_version(obj);
                     }
                     true
@@ -4263,8 +4261,6 @@ pub unsafe fn w_dict_move_to_end_checked(
         let target = if last { entries.len() - 1 } else { 0 };
         if index != target {
             entries.move_index(index, target);
-            let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-            strategy.mutated();
             w_dict_bump_keys_version(obj);
         }
         return Ok(true);
@@ -4421,8 +4417,6 @@ pub unsafe fn w_module_dict_delitem_inner(obj: PyObjectRef, key: PyObjectRef) ->
     if w_module_dict_is_object_strategy(obj) {
         let entries = w_module_dict_object_storage_mut(obj);
         if dict_entries_remove_object(entries, key) {
-            let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-            strategy.mutated();
             w_dict_bump_keys_version(obj);
             return true;
         }
@@ -4438,8 +4432,6 @@ pub unsafe fn w_module_dict_delitem_inner(obj: PyObjectRef, key: PyObjectRef) ->
     let obj = _module_guard.root(0);
     let entries = w_module_dict_object_storage_mut(obj);
     if dict_entries_remove_object(entries, key) {
-        let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-        strategy.mutated();
         w_dict_bump_keys_version(obj);
         return true;
     }
@@ -4463,8 +4455,6 @@ pub unsafe fn w_module_dict_delitem_inner_checked(
             return Err(DictKeyError);
         }
         if removed {
-            let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-            strategy.mutated();
             w_dict_bump_keys_version(obj);
             return Ok(true);
         }
@@ -4485,8 +4475,6 @@ pub unsafe fn w_module_dict_delitem_inner_checked(
         return Err(DictKeyError);
     }
     if removed {
-        let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-        strategy.mutated();
         w_dict_bump_keys_version(obj);
         return Ok(true);
     }
@@ -4540,14 +4528,12 @@ pub unsafe fn w_module_dict_clear_inner(obj: PyObjectRef) {
         let entries = w_module_dict_object_storage_mut(obj);
         let changed = !entries.is_empty();
         entries.clear();
-        let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-        strategy.mutated();
         if changed {
             w_dict_bump_keys_version(obj);
         }
     } else {
-        let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
-        let storage = &mut *(*(obj as *mut W_ModuleDictObject)).dstorage;
+        let strategy = w_module_dict_module_strategy_mut(obj);
+        let storage = w_module_dict_module_storage_mut(obj);
         let changed = !storage.is_empty();
         strategy.clear(storage);
         if changed {
@@ -6359,6 +6345,11 @@ pub trait DictStrategy {
 #[repr(C)]
 pub struct DictStrategyRef {
     pub imp: &'static dyn crate::dictmultiobject::DictStrategy,
+    /// GC owner of a per-dict strategy instance.  Stateless
+    /// `space.fromcache(...)` holders leave this null; a module dict's holder
+    /// points at its `ModuleDictStrategy`, matching PyPy's `mstrategy` instance
+    /// while keeping the Rust trait object behind a one-word dict slot.
+    pub owner: *mut u8,
 }
 
 /// The holders below wrap only the stateless unit-struct singletons, which are
@@ -6418,21 +6409,27 @@ pub static INT_DICT_STRATEGY: IntDictStrategy = IntDictStrategy;
 /// are zero-sized and need not be.
 pub static OBJECT_DICT_STRATEGY_REF: DictStrategyRef = DictStrategyRef {
     imp: &OBJECT_DICT_STRATEGY,
+    owner: std::ptr::null_mut(),
 };
 pub static EMPTY_DICT_STRATEGY_REF: DictStrategyRef = DictStrategyRef {
     imp: &EMPTY_DICT_STRATEGY,
+    owner: std::ptr::null_mut(),
 };
 pub static EMPTY_KWARGS_DICT_STRATEGY_REF: DictStrategyRef = DictStrategyRef {
     imp: &EMPTY_KWARGS_DICT_STRATEGY,
+    owner: std::ptr::null_mut(),
 };
 pub static BYTES_DICT_STRATEGY_REF: DictStrategyRef = DictStrategyRef {
     imp: &BYTES_DICT_STRATEGY,
+    owner: std::ptr::null_mut(),
 };
 pub static UNICODE_DICT_STRATEGY_REF: DictStrategyRef = DictStrategyRef {
     imp: &UNICODE_DICT_STRATEGY,
+    owner: std::ptr::null_mut(),
 };
 pub static INT_DICT_STRATEGY_REF: DictStrategyRef = DictStrategyRef {
     imp: &INT_DICT_STRATEGY,
+    owner: std::ptr::null_mut(),
 };
 
 /// `dictmultiobject.py EmptyDictStrategy`.
@@ -8035,6 +8032,37 @@ mod tests {
             assert!(w_dict_delitem_str(md, "alpha"));
             assert!(w_dict_getitem_str(md, "alpha").is_none());
             assert_eq!(w_dict_len(md), 1);
+        }
+    }
+
+    #[test]
+    fn module_dict_strategy_switch_replaces_both_erased_slots() {
+        install_test_hash_hook();
+        let md = w_module_dict_new();
+        unsafe {
+            w_dict_setitem_str(md, "alpha", w_int_new(11));
+            let raw = &*(md as *const W_ModuleDictObject);
+            let module_holder = raw.mstrategy;
+            let module_storage = raw.dstorage;
+
+            w_dict_setitem(md, 7, w_int_new(22));
+
+            let raw = &*(md as *const W_ModuleDictObject);
+            assert!(w_module_dict_is_object_strategy(md));
+            assert_ne!(raw.mstrategy, module_holder);
+            assert_ne!(raw.dstorage, module_storage);
+            assert!(std::ptr::eq(
+                raw.mstrategy,
+                &OBJECT_DICT_STRATEGY_REF as *const DictStrategyRef as *mut DictStrategyRef,
+            ));
+            assert_eq!(
+                w_int_get_value(w_dict_getitem_str(md, "alpha").unwrap()),
+                11
+            );
+            assert_eq!(
+                w_int_get_value(w_dict_lookup(md, w_int_new(7)).unwrap()),
+                22,
+            );
         }
     }
 

--- a/pyre/pyre-object/src/identitydict.rs
+++ b/pyre/pyre-object/src/identitydict.rs
@@ -218,6 +218,7 @@ pub static IDENTITY_DICT_STRATEGY: IdentityDictStrategy = IdentityDictStrategy;
 pub static IDENTITY_DICT_STRATEGY_REF: crate::dictmultiobject::DictStrategyRef =
     crate::dictmultiobject::DictStrategyRef {
         imp: &IDENTITY_DICT_STRATEGY,
+        owner: std::ptr::null_mut(),
     };
 
 impl IdentityDictStrategy {

--- a/pyre/pyre-object/src/kwargsdict.rs
+++ b/pyre/pyre-object/src/kwargsdict.rs
@@ -57,6 +57,7 @@ pub static KWARGS_DICT_STRATEGY: KwargsDictStrategy = KwargsDictStrategy;
 pub static KWARGS_DICT_STRATEGY_REF: crate::dictmultiobject::DictStrategyRef =
     crate::dictmultiobject::DictStrategyRef {
         imp: &KWARGS_DICT_STRATEGY,
+        owner: std::ptr::null_mut(),
     };
 
 /// `KwargsDictStrategy` backing — erased `([], [])` parallel arrays

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -9,40 +9,63 @@
 
 use crate::pyobject::*;
 
+/// `pypy/interpreter/typedef.py TypeDef` metadata used by
+/// `objspace/std/typeobject.py Layout`.
+///
+/// Layout identity and TypeDef identity are different axes in PyPy: derived
+/// layouts retain the interpreter class's TypeDef, while multiple types may
+/// share one Layout.  Keeping these TypeDef fields on Layout forces a layout
+/// clone when bootstrap adjusts `acceptable_as_base_class`, breaking that
+/// identity relationship.
+pub struct InterpreterTypeDef {
+    /// Pyre's allocation-vtable analogue of the RPython interpreter class.
+    pub instance_type: *const PyType,
+    acceptable_as_base_class: std::sync::atomic::AtomicBool,
+    pub hasdict: bool,
+}
+
+impl InterpreterTypeDef {
+    #[inline]
+    pub fn acceptable_as_base_class(&self) -> bool {
+        self.acceptable_as_base_class
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    #[inline]
+    pub fn set_acceptable_as_base_class(&self, value: bool) {
+        self.acceptable_as_base_class
+            .store(value, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// Allocate process-lifetime TypeDef metadata, matching PyPy's module-level
+/// `W_X.typedef` objects.
+pub fn leak_interpreter_typedef(
+    instance_type: *const PyType,
+    acceptable_as_base_class: bool,
+    hasdict: bool,
+) -> *const InterpreterTypeDef {
+    crate::lltype::malloc_raw(InterpreterTypeDef {
+        instance_type,
+        acceptable_as_base_class: std::sync::atomic::AtomicBool::new(acceptable_as_base_class),
+        hasdict,
+    })
+}
+
 /// typeobject.py Layout object.
 ///
 /// Immutable after creation. Shared between types that have the same
 /// instance layout (e.g. a class without __slots__ shares its base's layout).
 /// Identity comparison via pointer equality.
 pub struct Layout {
-    /// typeobject.py:113 — the typedef (PyType) that this layout is for.
-    pub typedef: *const PyType,
-    /// typeobject.py:114 — total number of extra slots.
+    /// `Layout.__init__` — the TypeDef that this layout is for.
+    pub typedef: *const InterpreterTypeDef,
+    /// `Layout.__init__` — total number of extra slots.
     pub nslots: u32,
-    /// typeobject.py:115 — sorted list of slot names introduced by this class.
+    /// `Layout.__init__` — sorted slot names introduced by this class.
     pub newslotnames: Vec<String>,
-    /// typeobject.py:116 — parent layout (identity comparison).
+    /// `Layout.__init__` — parent layout (identity comparison).
     pub base_layout: *const Layout,
-    /// typedef.py — `acceptable_as_base_class = '__new__' in rawdict`.
-    /// TODO: in RPython this lives on TypeDef, accessed
-    /// via `layout.typedef.acceptable_as_base_class`. Stored on Layout
-    /// here because Rust has no TypeDef struct yet — Layout.typedef is
-    /// `*const PyType` (≈ CLASSTYPE), and many types share INSTANCE_TYPE
-    /// but need different acceptable_as_base_class values.
-    /// Convergence: introduce a Rust TypeDef struct, move this field there.
-    pub acceptable_as_base_class: bool,
-    /// typedef.py — `hasdict = '__dict__' in rawdict`: whether the
-    /// low-level typedef already manages its own instance dict (so mapdict
-    /// must NOT add a second one, typeobject.py:255-257).
-    /// TODO: like `acceptable_as_base_class`, this belongs on a Rust TypeDef
-    /// struct (`layout.typedef.hasdict`). It is parked on Layout because
-    /// `typedef` is only a `*const PyType` tag. On the current shared-Layout
-    /// model every reachable instance layout reuses INSTANCE_TYPE's Layout
-    /// (whose typedef declares no `__dict__`), so this is `false` everywhere;
-    /// populating it `true` for the dict-managing typedefs (module/function/
-    /// staticmethod/classmethod) needs the distinct-TypeDef convergence and is
-    /// deferred with it.
-    pub typedef_hasdict: bool,
     /// Absolute slot index of the reserved [`DICT_DATA_SLOT`] payload for
     /// instances of this layout, or `-1` when no layout in the chain
     /// reserves one.
@@ -181,7 +204,7 @@ pub struct W_TypeObject {
     /// needs its own field instead of overloading the PyPy owner bit.
     pub flag_cpython_immutabletype: std::sync::atomic::AtomicBool,
     /// Suppress CPython's public `Py_TPFLAGS_BASETYPE` without changing
-    /// PyPy's load-bearing `Layout.acceptable_as_base_class` field.
+    /// PyPy's load-bearing `TypeDef.acceptable_as_base_class` field.
     ///
     /// PyPy can reject subclassing in a custom metaclass while leaving the
     /// ordinary app-level layout acceptable.  A CPython static counterpart
@@ -831,8 +854,9 @@ pub unsafe fn w_type_get_layout_ptr(obj: PyObjectRef) -> *const Layout {
 }
 
 /// typeobject.py get_full_instance_layout(self).
-/// Returns the Layout.typedef pointer (the PyType describing instance struct).
-/// For backward-compat with existing code that compares PyType pointers.
+/// Returns the allocation-vtable analogue held by `Layout.typedef`.
+/// Kept for existing code that needs the concrete Rust `PyType` rather than
+/// PyPy's distinct TypeDef identity.
 #[inline]
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
@@ -842,7 +866,7 @@ pub unsafe fn w_type_get_layout(obj: PyObjectRef) -> *const PyType {
     if layout.is_null() {
         &INSTANCE_TYPE as *const PyType
     } else {
-        (*layout).typedef
+        (*(*layout).typedef).instance_type
     }
 }
 
@@ -1500,13 +1524,24 @@ pub unsafe fn w_type_is_cpython_immutabletype(obj: PyObjectRef) -> bool {
         .load(std::sync::atomic::Ordering::Acquire)
 }
 
-/// Suppress CPython's public BASETYPE bit while preserving PyPy's canonical
-/// layout-level subclassability field and all of its internal readers.
+/// Suppress CPython's per-type BASETYPE capability while preserving PyPy's
+/// canonical TypeDef-level subclassability field for every type that shares
+/// it.  The public flag projection and type-construction gate both read this
+/// narrower override.
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_type_suppress_cpython_basetype(obj: PyObjectRef) {
     (*(obj as *mut W_TypeObject)).flag_cpython_suppress_basetype = true;
+}
+
+/// Read the per-type CPython BASETYPE suppression without consulting the
+/// shared PyPy TypeDef.
+/// # Safety
+/// The caller must uphold every validity, runtime-type, aliasing, and lifetime
+/// invariant required by the object and pointer arguments for the entire call.
+pub unsafe fn w_type_is_cpython_basetype_suppressed(obj: PyObjectRef) -> bool {
+    (*(obj as *const W_TypeObject)).flag_cpython_suppress_basetype
 }
 
 /// typeobject.py `W_TypeObject.get_flags` — compute PyPy's public type flags
@@ -1561,7 +1596,7 @@ pub unsafe fn w_type_get_flags(obj: PyObjectRef) -> i64 {
         // fields; do not infer ownership merely from the public capability,
         // since module instances own their dict in the builtin layout.
         let layout = t.layout;
-        let typedef_hasdict = !layout.is_null() && (*layout).typedef_hasdict;
+        let typedef_hasdict = !layout.is_null() && (*(*layout).typedef).hasdict;
         if t.hasdict && !typedef_hasdict {
             flags |= MANAGED_DICT;
             // CPython's `type_ready_managed_dict` adds INLINE_VALUES only to
@@ -1688,8 +1723,8 @@ pub unsafe fn w_type_get_flags(obj: PyObjectRef) -> i64 {
     flags
 }
 
-/// typedef.py:43 `acceptable_as_base_class` — read from Layout level.
-/// typeobject.py:1116: w_bestbase.layout.typedef.acceptable_as_base_class
+/// `TypeDef.__init__` owns `acceptable_as_base_class`; TypeDef identity is
+/// reached through `W_TypeObject.acceptable_as_base_class`'s Layout.
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
@@ -1698,12 +1733,18 @@ pub unsafe fn w_type_get_acceptable_as_base_class(obj: PyObjectRef) -> bool {
     if layout.is_null() {
         true
     } else {
-        (*layout).acceptable_as_base_class
+        (*(*layout).typedef).acceptable_as_base_class()
     }
 }
 
-/// typedef.py:40 `hasdict` — read from Layout level.
-/// typeobject.py:255 `typedef = self.layout.typedef; ... not typedef.hasdict`.
+/// Whether the concrete allocation owner handles its TypeDef dictionary
+/// outside mapdict.  In PyPy this is exactly `self.layout.typedef.hasdict`:
+/// each RPython interpreter class named by that TypeDef supplies the native
+/// dict methods.  Pyre collapses app-level-shaped interpreter owners such as
+/// `_io.W_IOBase` onto the generic `W_ObjectObject`/`INSTANCE_TYPE` carrier;
+/// that carrier's dictionary is mapdict itself, so it must not be classified
+/// as an external native dict owner even when the preserved TypeDef metadata
+/// says `hasdict`.
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
@@ -1712,7 +1753,8 @@ pub unsafe fn w_type_get_typedef_hasdict(obj: PyObjectRef) -> bool {
     if layout.is_null() {
         false
     } else {
-        (*layout).typedef_hasdict
+        let typedef = &*(*layout).typedef;
+        typedef.hasdict && !std::ptr::eq(typedef.instance_type, &INSTANCE_TYPE)
     }
 }
 
@@ -1758,33 +1800,20 @@ unsafe fn w_type_has_cpython_managed_weakref(obj: PyObjectRef) -> bool {
     }
     w_type_has_cpython_managed_weakref(bestbase)
 }
-/// Override acceptable_as_base_class by cloning the Layout.
-/// typedef.py:742,765,664 explicit overrides after initial creation.
-/// Layouts may be shared (reused from parent), so we clone to avoid
-/// corrupting the parent type's flag.
+/// Override `TypeDef.acceptable_as_base_class` in place.
+/// PyPy's `Function.typedef`, `Method.typedef`, and `PyCode.typedef` perform
+/// the same explicit override after TypeDef construction.
+/// The TypeDef is the semantic owner; changing this flag must not change
+/// Layout identity.
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_type_set_acceptable_as_base_class(obj: PyObjectRef, v: bool) {
-    let old_layout = (*(obj as *const W_TypeObject)).layout;
-    if old_layout.is_null() {
+    let layout = (*(obj as *const W_TypeObject)).layout;
+    if layout.is_null() {
         return;
     }
-    let old = &*old_layout;
-    if old.acceptable_as_base_class == v {
-        return; // already correct
-    }
-    // Clone with new value to avoid mutating shared Layout.
-    let new_layout = leak_layout(Layout {
-        typedef: old.typedef,
-        nslots: old.nslots,
-        newslotnames: old.newslotnames.clone(),
-        base_layout: old.base_layout,
-        acceptable_as_base_class: v,
-        typedef_hasdict: old.typedef_hasdict,
-        dict_data_slot: crate::typeobject::DICT_DATA_SLOT_UNRESOLVED,
-    });
-    (*(obj as *mut W_TypeObject)).layout = new_layout;
+    (*(*layout).typedef).set_acceptable_as_base_class(v);
 }
 
 // ── Subclass tree (typeobject.py:640-689) ────────────────────────────
@@ -2041,22 +2070,19 @@ mod tests {
 
     #[test]
     fn test_layout_issublayout() {
+        let typedef = leak_interpreter_typedef(&INSTANCE_TYPE, true, false);
         let root = leak_layout(Layout {
-            typedef: &INSTANCE_TYPE,
+            typedef,
             nslots: 0,
             newslotnames: vec![],
             base_layout: std::ptr::null(),
-            acceptable_as_base_class: true,
-            typedef_hasdict: false,
             dict_data_slot: crate::typeobject::DICT_DATA_SLOT_UNRESOLVED,
         });
         let child = leak_layout(Layout {
-            typedef: &INSTANCE_TYPE,
+            typedef,
             nslots: 1,
             newslotnames: vec!["x".to_string()],
             base_layout: root,
-            acceptable_as_base_class: true,
-            typedef_hasdict: false,
             dict_data_slot: crate::typeobject::DICT_DATA_SLOT_UNRESOLVED,
         });
         unsafe {
@@ -2069,18 +2095,41 @@ mod tests {
     #[test]
     fn test_layout_expand_equality() {
         let root = leak_layout(Layout {
-            typedef: &INSTANCE_TYPE,
+            typedef: leak_interpreter_typedef(&INSTANCE_TYPE, true, false),
             nslots: 1,
             newslotnames: vec!["x".to_string()],
             base_layout: std::ptr::null(),
-            acceptable_as_base_class: true,
-            typedef_hasdict: false,
             dict_data_slot: crate::typeobject::DICT_DATA_SLOT_UNRESOLVED,
         });
         // Same Layout pointer → equal
         assert!(Layout::expands_equal(root, true, true, root, true, true));
         // Different hasdict → not equal
         assert!(!Layout::expands_equal(root, true, true, root, false, true));
+    }
+
+    #[test]
+    fn acceptable_as_base_class_mutates_typedef_without_replacing_layout() {
+        let typedef = leak_interpreter_typedef(&INSTANCE_TYPE, true, false);
+        let layout = leak_layout(Layout {
+            typedef,
+            nslots: 0,
+            newslotnames: vec![],
+            base_layout: std::ptr::null(),
+            dict_data_slot: crate::typeobject::DICT_DATA_SLOT_UNRESOLVED,
+        });
+        let w_base = w_type_new("Base", PY_NULL, std::ptr::null_mut());
+        let w_child = w_type_new("Child", PY_NULL, std::ptr::null_mut());
+
+        unsafe {
+            w_type_set_layout(w_base, layout);
+            w_type_set_layout(w_child, layout);
+            w_type_set_acceptable_as_base_class(w_child, false);
+
+            assert_eq!(w_type_get_layout_ptr(w_child), layout);
+            assert_eq!(w_type_get_layout_ptr(w_base), layout);
+            assert!(!w_type_get_acceptable_as_base_class(w_child));
+            assert!(!w_type_get_acceptable_as_base_class(w_base));
+        }
     }
 
     #[test]
@@ -2096,12 +2145,10 @@ mod tests {
         ) -> PyObjectRef {
             let w_type = w_type_new("C", PY_NULL, std::ptr::null_mut());
             let layout = leak_layout(Layout {
-                typedef,
+                typedef: leak_interpreter_typedef(typedef, true, typedef_hasdict),
                 nslots: 0,
                 newslotnames: vec![],
                 base_layout: std::ptr::null(),
-                acceptable_as_base_class: true,
-                typedef_hasdict,
                 dict_data_slot: crate::typeobject::DICT_DATA_SLOT_UNRESOLVED,
             });
             w_type_set_layout(w_type, layout);
@@ -2130,10 +2177,19 @@ mod tests {
             let tuple_subclass = heap_type_with_layout(&TUPLE_TYPE, false);
             assert_eq!(w_type_get_flags(tuple_subclass) & MASK, MANAGED_DICT);
 
+            // A preserved PyPy TypeDef may say its RPython owner has a dict
+            // even though pyre represents that owner with generic
+            // W_ObjectObject storage.  Keep the public TypeDef projection,
+            // but route the physical dictionary through mapdict.
+            let collapsed_owner = heap_type_with_layout(&INSTANCE_TYPE, true);
+            assert_eq!(w_type_get_flags(collapsed_owner) & MASK, 0);
+            assert!(!w_type_get_typedef_hasdict(collapsed_owner));
+
             // A builtin typedef such as module owns its dict directly, so a
             // heap subtype sharing that layout has neither managed bit.
             let native_dict = heap_type_with_layout(&MODULE_TYPE, true);
             assert_eq!(w_type_get_flags(native_dict) & MASK, 0);
+            assert!(w_type_get_typedef_hasdict(native_dict));
         }
     }
 
@@ -2141,12 +2197,10 @@ mod tests {
     fn type_flags_project_managed_weakref_through_the_best_base_owner() {
         const MANAGED_WEAKREF: i64 = 1 << 3;
         let layout = leak_layout(Layout {
-            typedef: &INSTANCE_TYPE,
+            typedef: leak_interpreter_typedef(&INSTANCE_TYPE, true, false),
             nslots: 0,
             newslotnames: vec![],
             base_layout: std::ptr::null(),
-            acceptable_as_base_class: true,
-            typedef_hasdict: false,
             dict_data_slot: crate::typeobject::DICT_DATA_SLOT_UNRESOLVED,
         });
 


### PR DESCRIPTION
Eleven commits on top of `main`, in four groups.

## `_ast` — the generated node surface

`_ast/moduledef.rs` is what PyPy's `State.make_new_type` builds; most of the
observable surface the pinned `lib-python/3/test/test_ast` requires was
missing. Each commit keeps PyPy's generated-type owner, storage and creation
order and adds only the observable the pinned suite pins.

- **`ast: port 3.14 template string nodes`** — the `TemplateStr` and
  `Interpolation` ASDL nodes, their `_ast/convert.rs` converters, and the
  `astcompiler/validate.rs` arms that reach them.
- **`ast: restore generated constructor defaults`** — a repeated (`*`) field
  omitted from the constructor gets a fresh list, an optional (`?`) field the
  generated type dictionary's default, and an `expr_context` field the
  process-wide `Load` singleton, which now lives in a registered
  process-lifetime root slot.
- **`ast: publish generated field type metadata`** — `_field_types` and
  `__annotations__`, built from one ASDL type spelling per field and bound
  under both names after every ASDL type exists (`add_ast_annotations`).
  PyPy publishes no such metadata; `AST_Tests.test_arguments` requires the
  exact mapping.
- **`ast: port generated constructors and signatures`** — `ast_type_init`'s
  decision tree: the missing-field defaults and deprecations, the
  unexpected-keyword deprecation, and the `_fields` diagnostic that names the
  root as `ast.AST`. PyPy's `W_AST_init` only assigns supplied arguments.
- **`ast: preserve raw constructor kwargs`** — PyPy's `Arguments` rejects a
  non-text keyword in `_do_combine_starstarargs_wrapped`, before
  `W_AST_init`; `ast_type_init` receives the raw kwargs dict.
  `call_type_with_raw_kwargs` routes through the raw carrier only when the
  live type still owns the generated AST `__init__`, inherits `object.__new__`
  unchanged, and uses the default metaclass — every other callable keeps
  PyPy's path.
- **`ast: port structural repr`** — `ast_repr_list`, expressed through the
  object-space sequence operations, bound on the generated root as it is
  minted.
- **`ast: validate source position ranges`** — `VALIDATE_POSITIONS`' checks on
  `lineno`/`col_offset` against their `end_` counterparts. PyPy's
  `AstValidator` has no counterpart, but the `ValueError` is observable at
  `compile()`. Zero and negative line numbers stay accepted.
- **`ast: reject None and non-str in required node fields`** —
  `required_field` raises `ValueError: field 'X' is required for <node>` for a
  present-but-`None` required field, matching `get_field_extractor`'s check
  before the ASDL conversion; an identifier field raises
  `TypeError: AST identifier must be of type str` rather than reading a
  non-`str` as one.

## `_template` — pickle reducers

**`template: port 3.14 pickle reducers`** — `Interpolation.__reduce__`
reconstructs through the exact public type and its four constructor fields;
`Template.__reduce__` now names `string.templatelib._template_unpickle`
instead of putting the private runtime module in the pickle, so
`_template_app._reconstruct` is gone.

## `typedef` and the buffer protocol

**`builtins: restore typedef ownership and buffer parity`**

- `setup_builtin_type` parity: an ordinary builtin type owns a distinct
  `TypeDef` even when its Rust allocation type matches its base. The explicit
  `overridetypedef` route (`TypeCache.build`, e.g. an exception's
  `applevel_subclasses_base`) is the only reuse path, and it reuses the base
  Layout only when that exact `TypeDef` is already its owner.
- `cpyext/buffer.rs`: `Py_buffer.obj` is the exporter that owns the view, and
  a `bf_getbuffer` may redirect it. The filled `obj` is now what
  `memoryview.obj` and `bf_releasebuffer` name — previously both named the
  redirector. A legacy export whose filled `obj` is NULL is still freed via
  the table lookup. `interp_bf_getbuffer` counts an export on a source
  memoryview and `interp_bf_releasebuffer` drops it, which PyPy's
  `W_MemoryView.buffer_w` omits.
- The buffer-exporting and typedef-owning types across `_io`, `struct`,
  `_ssl`, `_blake2`, `_hashlib`, `zlib`, `_multiprocessing`, `_ctypes`,
  `thread`, `operator`, `gc` and `sys` follow.

## `dict`

**`dict: swap module strategy and erased storage together`** — a module dict
kept its object-strategy storage in a separate `object_storage` field beside
the erased `dstorage`, so a strategy swap touched two fields and
`w_dict_set_strategy` had to refuse module dicts outright. The module dict now
carries a `DictStrategyRef` holder over the same erased `dstorage` as every
other dict, so the strategy and its storage are replaced together and the
refusal is gone. `celldict`, `identitydict`, `kwargsdict` and the two
`eval.rs` callers follow.

---

CI has not reported on this branch yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Python 3.14 template-string AST support, including `TemplateStr` and `Interpolation` nodes.
  * Improved AST metadata, defaults, representations, source-location validation, and template-string conversions.
  * Added pickling support for template strings and interpolations.

* **Bug Fixes**
  * Improved memoryview packing, unpacking, hashing, and buffer-lifetime handling.
  * Corrected exception types and messages for unsupported formats and invalid buffer operations.
  * Improved module global lookups after dictionary strategy changes.
  * Aligned built-in type subclassing behavior with CPython 3.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->