### PR TITLE
_ssl: drain a receive's message events before read lets a callback change context

### DIFF
--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -2119,6 +2119,11 @@ mod ssl_socket_methods {
                             break data;
                         }
                         PumpExit::NeedsConfig => {
+                            // The events the acceptor observed belong to the
+                            // context that was current while it read them, so
+                            // they are delivered before the callback below is
+                            // given the chance to choose another one.
+                            settle_received_tls(self)?;
                             unsafe { configure_accepted_server(self as *mut W_SSLSocket) }?
                         }
                         PumpExit::Interrupted => {


### PR DESCRIPTION
Follow-up to #1544, from its Codex parity review.

`read`'s `PumpExit::NeedsConfig` arm ran `configure_accepted_server` straight
away, where `do_handshake`'s runs `settle_received_tls` first. An SNI callback
that answers with a context carrying `_msg_callback` would then be handed the
events the acceptor observed under the previous one — PyPy's `_cffi_ssl` calls
`_msg_callback` synchronously with the context that was current while OpenSSL
parsed the message, so a retroactive delivery to the SNI-selected context is
wrong. Both arms now drain first.

`PumpGoal::Read` never produces `NeedsConfig` — only the `Handshake` arm tests
`connection_waiting_for_server_config` — so the arm is unreachable today. The
asymmetry is what is being fixed.

`cargo check -p pyre-interpreter --features dynasm,cpyext` is clean, and
`cpython_tests` `ssl` is unchanged: `test_ssl_in_multiple_threads` alone, which
fails on a Korean-locale Windows host because a `WSAECONNRESET` string misses
the test's English-only regex — CPython 3.14.2 produces the same string there,
and the test is armed on pyre only because it is gated on
`support.Py_GIL_DISABLED`.
