### PR TITLE
wasm: the guest's clocks, entropy, locks and sockets, the runner's module-cache key, and what a trace emits per access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,6 +2887,7 @@ dependencies = [
 name = "pyre-wasm-runner"
 version = "0.0.2"
 dependencies = [
+ "getrandom 0.4.3",
  "rustc-demangle",
  "sha2 0.10.9",
  "wasmi",

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -4738,14 +4738,14 @@ fn build_function(
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
-                    // if val < 0, use 0; else use val
-                    // Wasm: local.tee + i64.const 0 + local.get + i64.lt_s + select
+                    // `select` answers with the FIRST value when its condition
+                    // holds, so the condition is the one that keeps `val`.
                     let tmp_local = value_types.local(vi); // reuse result local as temp
                     sink.local_tee(tmp_local);
                     sink.i64_const(0);
                     sink.local_get(tmp_local);
                     sink.i64_const(0);
-                    sink.i64_lt_s();
+                    sink.i64_ge_s();
                     sink.select();
                     sink.local_set(value_types.local(vi));
                 }

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -574,6 +574,15 @@ impl<'sink, 'buf> PeepSink<'sink, 'buf> {
         f64_load(memarg: MemArg),
         f64_store(memarg: MemArg),
         i32_load(memarg: MemArg),
+        i64_load16_s(memarg: MemArg),
+        i64_load16_u(memarg: MemArg),
+        i64_load32_s(memarg: MemArg),
+        i64_load32_u(memarg: MemArg),
+        i64_load8_s(memarg: MemArg),
+        i64_load8_u(memarg: MemArg),
+        i64_store16(memarg: MemArg),
+        i64_store32(memarg: MemArg),
+        i64_store8(memarg: MemArg),
         i32_load16_s(memarg: MemArg),
         i32_load16_u(memarg: MemArg),
         i32_load8_s(memarg: MemArg),
@@ -621,38 +630,17 @@ fn emit_jit_call(sink: &mut PeepSink<'_, '_>, jit_call_idx: u32) {
 /// 8 bytes on 64-bit; reading a fixed 8 bytes here would fold in the next
 /// field's bytes on wasm32.
 fn emit_sized_int_load(sink: &mut PeepSink<'_, '_>, offset: u64, size: usize, signed: bool) {
+    // The i64 family loads and extends in one instruction, so the widening
+    // never has to be spelled separately.
     match (size, signed) {
-        (8, _) => {
-            sink.i64_load(mem64(offset));
-        }
-        (4, true) => {
-            sink.i32_load(memarg(offset, 2));
-            sink.i64_extend_i32_s();
-        }
-        (4, false) => {
-            sink.i32_load(memarg(offset, 2));
-            sink.i64_extend_i32_u();
-        }
-        (2, true) => {
-            sink.i32_load16_s(memarg(offset, 1));
-            sink.i64_extend_i32_s();
-        }
-        (2, false) => {
-            sink.i32_load16_u(memarg(offset, 1));
-            sink.i64_extend_i32_u();
-        }
-        (1, true) => {
-            sink.i32_load8_s(memarg(offset, 0));
-            sink.i64_extend_i32_s();
-        }
-        (1, false) => {
-            sink.i32_load8_u(memarg(offset, 0));
-            sink.i64_extend_i32_u();
-        }
-        _ => {
-            sink.i64_load(mem64(offset));
-        }
-    }
+        (4, true) => sink.i64_load32_s(memarg(offset, 2)),
+        (4, false) => sink.i64_load32_u(memarg(offset, 2)),
+        (2, true) => sink.i64_load16_s(memarg(offset, 1)),
+        (2, false) => sink.i64_load16_u(memarg(offset, 1)),
+        (1, true) => sink.i64_load8_s(memarg(offset, 0)),
+        (1, false) => sink.i64_load8_u(memarg(offset, 0)),
+        _ => sink.i64_load(mem64(offset)),
+    };
 }
 
 /// Emit a width-correct integer store. The stack must hold
@@ -660,26 +648,14 @@ fn emit_sized_int_load(sink: &mut PeepSink<'_, '_>, offset: u64, size: usize, si
 /// A fixed 8-byte store would clobber the adjacent field/item (or run past
 /// the array end) for word-sized fields and pointer array items on wasm32.
 fn emit_sized_int_store(sink: &mut PeepSink<'_, '_>, offset: u64, size: usize) {
+    // The i64 family truncates as it stores, so the narrowing never has to be
+    // spelled separately.
     match size {
-        8 => {
-            sink.i64_store(mem64(offset));
-        }
-        4 => {
-            sink.i32_wrap_i64();
-            sink.i32_store(memarg(offset, 2));
-        }
-        2 => {
-            sink.i32_wrap_i64();
-            sink.i32_store16(memarg(offset, 1));
-        }
-        1 => {
-            sink.i32_wrap_i64();
-            sink.i32_store8(memarg(offset, 0));
-        }
-        _ => {
-            sink.i64_store(mem64(offset));
-        }
-    }
+        4 => sink.i64_store32(memarg(offset, 2)),
+        2 => sink.i64_store16(memarg(offset, 1)),
+        1 => sink.i64_store8(memarg(offset, 0)),
+        _ => sink.i64_store(mem64(offset)),
+    };
 }
 
 /// `(field_size, is_signed)` from an op's FieldDescr. A field op always carries
@@ -4397,12 +4373,7 @@ fn build_function(
                     // bytes on wasm32. Reading it as i64 would fold in the
                     // following field's bytes and never match the class
                     // immediate. Load 4 bytes and zero-extend.
-                    sink.i32_load(MemArg {
-                        offset: off,
-                        align: 2,
-                        memory_index: 0,
-                    });
-                    sink.i64_extend_i32_u();
+                    sink.i64_load32_u(memarg(off, 2));
                     emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref());
                     sink.i64_ne();
                 } else {
@@ -4488,13 +4459,9 @@ fn build_function(
                 // so its stable pointer is directly addressable by the trace.
                 if invalidated_flag_addr != 0 {
                     sink.i32_const(invalidated_flag_addr as i32);
-                    sink.i32_load8_u(MemArg {
-                        offset: 0,
-                        align: 0,
-                        memory_index: 0,
-                    });
-                    sink.i32_const(0);
-                    sink.i32_ne();
+                    // The flag byte is the test: `emit_guard_if_exit` opens
+                    // with an `if`, which is already `!= 0`.
+                    sink.i32_load8_u(memarg(0, 0));
                     emit_guard_if_exit(
                         &mut sink,
                         constants,
@@ -4515,12 +4482,15 @@ fn build_function(
                 // trace must not run on holding virtualized fields the force has
                 // already written back, and the virtuals `handle_async_forcing`
                 // materialized are attached for THIS exit's resume to consume.
+                // The bit sits in the upper half of `frame[0]`, so on
+                // little-endian wasm32 it is bit 0 of the i32 at frame offset
+                // 4; masking it leaves the `!= 0` the `if` already applies.
+                const FORCE_TAKEN_HALF_OFS: u64 = 4;
+                const _: () = assert!(FORCE_TAKEN_BIT == 1 << 32);
                 sink.local_get(0);
-                sink.i64_load(mem64(0));
-                sink.i64_const(FORCE_TAKEN_BIT);
-                sink.i64_and();
-                sink.i64_const(0);
-                sink.i64_ne();
+                sink.i32_load(memarg(FORCE_TAKEN_HALF_OFS, 2));
+                sink.i32_const(1);
+                sink.i32_and();
                 emit_guard_if_exit(
                     &mut sink,
                     constants,
@@ -4862,12 +4832,7 @@ fn build_function(
                     sink.i32_wrap_i64();
                     let field_offset = field_offset_from_descr(op);
                     // Load as i32 (pointer on wasm32) and extend to i64
-                    sink.i32_load(MemArg {
-                        offset: field_offset,
-                        align: 2,
-                        memory_index: 0,
-                    });
-                    sink.i64_extend_i32_u();
+                    sink.i64_load32_u(memarg(field_offset, 2));
                     sink.local_set(value_types.local(vi));
                 }
             }
@@ -4933,35 +4898,25 @@ fn build_function(
             OpCode::GetarrayitemGcI | OpCode::GetarrayitemGcPureI | OpCode::GetarrayitemRawI => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    // addr = base + base_size + index * item_size
-                    emit_array_addr(&mut sink, constants, value_types, op);
+                    let base_size = emit_array_addr(&mut sink, constants, value_types, op);
                     let (item_size, signed) = array_item_size_sign_from_descr(op);
-                    emit_sized_int_load(&mut sink, 0, item_size, signed);
+                    emit_sized_int_load(&mut sink, base_size, item_size, signed);
                     sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::GetarrayitemGcR | OpCode::GetarrayitemGcPureR | OpCode::GetarrayitemRawR => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_array_addr(&mut sink, constants, value_types, op);
-                    sink.i32_load(MemArg {
-                        offset: 0,
-                        align: 2,
-                        memory_index: 0,
-                    });
-                    sink.i64_extend_i32_u();
+                    let base_size = emit_array_addr(&mut sink, constants, value_types, op);
+                    sink.i64_load32_u(memarg(base_size, 2));
                     sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::GetarrayitemGcF | OpCode::GetarrayitemGcPureF | OpCode::GetarrayitemRawF => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
-                    emit_array_addr(&mut sink, constants, value_types, op);
-                    sink.f64_load(MemArg {
-                        offset: 0,
-                        align: 3,
-                        memory_index: 0,
-                    });
+                    let base_size = emit_array_addr(&mut sink, constants, value_types, op);
+                    sink.f64_load(mem64(base_size));
                     sink.local_set(value_types.local(vi));
                 }
             }
@@ -4977,17 +4932,17 @@ fn build_function(
                     &same_as_forwardings,
                     &mut wb_applied,
                 );
-                emit_array_addr(&mut sink, constants, value_types, op);
+                let base_size = emit_array_addr(&mut sink, constants, value_types, op);
                 if array_item_is_float_from_descr(op) {
                     emit_resolve_f64(&mut sink, constants, value_types, op.arg(2).to_opref());
-                    sink.f64_store(mem64(0));
+                    sink.f64_store(mem64(base_size));
                 } else {
                     emit_resolve(&mut sink, constants, value_types, op.arg(2).to_opref()); // value
                     // A Ref item is pointer-width (4 bytes on wasm32). Storing a
                     // fixed 8 bytes would clobber the next item, or run past the
                     // array end on the last item and corrupt the heap.
                     let (item_size, _signed) = array_item_size_sign_from_descr(op);
-                    emit_sized_int_store(&mut sink, 0, item_size);
+                    emit_sized_int_store(&mut sink, base_size, item_size);
                 }
             }
 
@@ -5228,17 +5183,13 @@ fn build_function(
                 }
                 sink.i64_const(guard_gc_type_info.base_type_info as i64);
                 sink.i64_add();
-                sink.i64_const(guard_gc_type_info.infobits_offset as i64);
-                sink.i64_add();
                 sink.i32_wrap_i64();
-                // Stack: [..., loc_infobits(i32 addr)]
+                // Stack: [..., loc_type_info(i32 addr)]
 
-                // assembler.py:1940 TEST8 [loc_infobits], IS_OBJECT_FLAG
-                sink.i32_load8_u(MemArg {
-                    offset: 0,
-                    align: 0,
-                    memory_index: 0,
-                });
+                // assembler.py:1940 TEST8 [loc_infobits], IS_OBJECT_FLAG. The
+                // `offset=infobits_offset` of the address computation above is
+                // a constant, so it rides in the load's own MemArg.
+                sink.i32_load8_u(memarg(guard_gc_type_info.infobits_offset as u64, 0));
                 sink.i32_const(guard_gc_type_info.is_object_flag as i32);
                 sink.i32_and();
                 // assembler.py:1942 guard_success_cc = Conditions['NZ']:
@@ -5520,12 +5471,7 @@ fn build_function(
                     let slot =
                         base as u64 + index as u64 * std::mem::size_of::<majit_ir::GcRef>() as u64;
                     sink.i32_const(slot as i32);
-                    sink.i32_load(MemArg {
-                        offset: 0,
-                        align: 2,
-                        memory_index: 0,
-                    });
-                    sink.i64_extend_i32_u();
+                    sink.i64_load32_u(memarg(0, 2));
                     sink.local_set(value_types.local(vi));
                 }
             }
@@ -5819,8 +5765,10 @@ fn build_function(
                 sink.local_get(ca_cfp_local);
                 sink.i64_extend_i32_u();
                 sink.i32_const(dispatch_entry);
-                sink.i32_load(mem32(crate::failguard::WASM_CA_DISPATCH_COMPILED_PTR_OFS));
-                sink.i64_extend_i32_u();
+                sink.i64_load32_u(memarg(
+                    crate::failguard::WASM_CA_DISPATCH_COMPILED_PTR_OFS,
+                    2,
+                ));
                 sink.i32_const(ca.deopt_helper_slot as i32);
                 // call_indirect(table_index, type_index): the shared table is 0.
                 sink.call_indirect(0, ca_helper_type_idx);
@@ -6227,6 +6175,9 @@ fn build_function(
                     sink.local_tee(alloc_scratch_local);
                     sink.i32_const(total_size as i32);
                     sink.i32_add();
+                    // The sum is the committed `nursery_free`, so keep it
+                    // rather than adding it again on the arm that takes it.
+                    sink.local_tee(alloc_size_local);
                     // new_free > *nursery_top → slow path
                     sink.i32_const(na.top_addr as i32);
                     sink.i32_load(MemArg {
@@ -6263,9 +6214,7 @@ fn build_function(
                     sink.else_();
                     // Commit: *nursery_free = free + total.
                     sink.i32_const(na.free_addr as i32);
-                    sink.local_get(alloc_scratch_local);
-                    sink.i32_const(total_size as i32);
-                    sink.i32_add();
+                    sink.local_get(alloc_size_local);
                     sink.i32_store(MemArg {
                         offset: 0,
                         align: 2,
@@ -6500,6 +6449,9 @@ fn build_function(
                     sink.local_tee(alloc_scratch_local);
                     sink.i32_const(total_size as i32);
                     sink.i32_add();
+                    // The sum is the committed `nursery_free`, so keep it
+                    // rather than adding it again on the arm that takes it.
+                    sink.local_tee(alloc_size_local);
                     sink.i32_const(na.top_addr as i32);
                     sink.i32_load(MemArg {
                         offset: 0,
@@ -6536,9 +6488,7 @@ fn build_function(
                     sink.else_();
                     // Commit: *nursery_free = free + total.
                     sink.i32_const(na.free_addr as i32);
-                    sink.local_get(alloc_scratch_local);
-                    sink.i32_const(total_size as i32);
-                    sink.i32_add();
+                    sink.local_get(alloc_size_local);
                     sink.i32_store(MemArg {
                         offset: 0,
                         align: 2,
@@ -7440,27 +7390,29 @@ fn array_len_layout_from_descr(op: &Op) -> (u64, usize) {
     .unwrap_or_else(|| missing_layout_descr("array descr (len layout)", op))
 }
 
-/// Compute array element address: base + base_size + index * item_size.
-/// Leaves i32 address on the wasm stack.
+/// Leave `base + index * item_size` on the wasm stack as an i32 address, and
+/// return the `base_size` displacement the access still owes.
+///
+/// The header is a fixed part of the descr, so it rides in the access's own
+/// MemArg offset instead of being added at run time — the same place the
+/// `getfield` arms put `field_offset_from_descr`.
 fn emit_array_addr(
     sink: &mut PeepSink<'_, '_>,
     constants: &indexmap::IndexMap<u32, i64>,
     value_types: &ValueLocals,
     op: &Op,
-) {
+) -> u64 {
     let (base_size, item_size) = op
         .with_array_descr(|ad| (ad.base_size() as u64, ad.item_size() as u64))
         .unwrap_or_else(|| missing_layout_descr("array descr (base/item size)", op));
     emit_resolve(sink, constants, value_types, op.arg(0).to_opref()); // array ptr
     sink.i32_wrap_i64();
-    // base + base_size + index * item_size
     emit_resolve(sink, constants, value_types, op.arg(1).to_opref()); // index
     sink.i32_wrap_i64();
     sink.i32_const(item_size as i32);
     sink.i32_mul();
     sink.i32_add();
-    sink.i32_const(base_size as i32);
-    sink.i32_add();
+    base_size
 }
 
 // ── Guard emission helpers ──

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -3029,7 +3029,7 @@ fn gc_table_load_inside_a_loop_body_is_emitted_inside_the_loop() {
                     wasmparser::Operator::I32Const { value } if value == gc_table_base as i32 => {
                         gc_table_address_on_stack = true;
                     }
-                    wasmparser::Operator::I32Load { .. } if gc_table_address_on_stack => {
+                    wasmparser::Operator::I64Load32U { .. } if gc_table_address_on_stack => {
                         if control_stack.contains(&true) {
                             loads_inside_loop += 1;
                         } else {

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1772,11 +1772,14 @@ pub fn os_string_from_fs_bytes(data: &[u8]) -> std::ffi::OsString {
     }
     #[cfg(not(any(unix, windows)))]
     {
-        // Outside Windows an `OsStr` IS the byte string, on wasm32 as much as
-        // on unix, so these bytes already are its encoding and survive the
-        // round trip `as_encoded_bytes` makes on the way back out.  Carrying
-        // them whole is what lets a name `listdir` reports be a name `stat`
-        // can be called with again.
+        // SAFETY: outside Windows an `OsStr` IS the byte string, on wasm32 as
+        // much as on unix, so any byte sequence is a valid encoding and these
+        // bytes survive the round trip `as_encoded_bytes` makes on the way
+        // back out.  Carrying them whole is what lets a name `listdir` reports
+        // be a name `stat` can be called with again; the safe `from_vec`
+        // constructor that says the same thing is offered only under
+        // `std::os::unix` and `std::os::wasi`, neither of which this target
+        // has, so the unchecked call is the only spelling available here.
         unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(data) }.to_os_string()
     }
 }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -789,6 +789,12 @@ pub fn install_builtin_modules() {
         pyre_install_module!(select);
         #[cfg(unix)]
         pyre_install_module!(termios);
+        // `socket.py`'s module body subclasses `_socket.socket`, so a module
+        // that is present without the host layer behind it fails the import
+        // with AttributeError -- and `platform._node`, `uuid` and the rest
+        // reach for `socket` inside `try/except ImportError`, which that is
+        // not.  A target with no socket layer has no `_socket` at all.
+        #[cfg(not(target_arch = "wasm32"))]
         pyre_install_module!(_socket);
         #[cfg(not(target_arch = "wasm32"))]
         pyre_install_module!(_ssl);

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -153,6 +153,15 @@ pub trait SourceProvider: Send + Sync {
             "this source provider cannot list a directory",
         ))
     }
+    /// The directory a relative path is resolved against, as the filesystem's
+    /// own bytes.
+    ///
+    /// Defaults to none: a provider serving an in-memory image has no working
+    /// directory to report, and `posix.getcwd` says so rather than naming a
+    /// directory that does not exist.
+    fn cwd(&self) -> Option<Vec<u8>> {
+        None
+    }
 }
 
 #[cfg(feature = "host_env")]
@@ -207,6 +216,11 @@ pub fn source_file_size(path: &Path) -> std::io::Result<u64> {
 #[cfg(feature = "host_env")]
 pub fn source_list_dir(path: &Path) -> std::io::Result<Vec<Vec<u8>>> {
     with_source_provider(|p| p.list_dir(path))
+}
+
+#[cfg(feature = "host_env")]
+pub fn source_cwd() -> Option<Vec<u8>> {
+    with_source_provider(|p| p.cwd())
 }
 
 /// [`read_source_bytes`] decoded as plain UTF-8, for callers that hold a

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -649,7 +649,6 @@ pub fn install_builtin_modules() {
     // Core pyre modules backed by `interpleveldefs` tables.
     pyre_install_module!(math);
     pyre_install_module!(cmath);
-    #[cfg(not(target_arch = "wasm32"))]
     pyre_install_module!(time);
     pyre_install_module!(sys);
     // `moduledef.py applevel_name = '_operator'` — the interp-level table

--- a/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
@@ -57,11 +57,18 @@ fn lookup_digest_name(name: &[u8]) -> Option<&'static str> {
         .map(|(python_name, _)| *python_name)
 }
 
-const HASH_STATE_WORDS: usize = 64;
+/// Read from the contract rather than restated beside it: a second
+/// spelling of the same number is a second thing to get wrong on a target
+/// whose word is not eight bytes.
+const HASH_STATE_WORDS: usize = pyre_native::hash::HASH_STATE_STORAGE_WORDS;
+/// The embedded array's length: the capacity plus the slack the round-up to a
+/// 16-byte boundary consumes.
+const HASH_STATE_SLOTS: usize =
+    HASH_STATE_WORDS + pyre_native::hash::STATE_STORAGE_ALIGN_SLACK_WORDS;
 
 #[repr(C)]
 struct HashStateStorage {
-    words: [usize; HASH_STATE_WORDS + 1],
+    words: [usize; HASH_STATE_SLOTS],
 }
 
 impl HashStateStorage {
@@ -89,10 +96,6 @@ pub struct W_HashState {
 
 impl W_HashState {
     fn new(name: &'static str, data: &[u8]) -> Result<PyObjectRef, crate::PyError> {
-        assert_eq!(
-            HASH_STATE_WORDS,
-            pyre_native::hash::HASH_STATE_STORAGE_WORDS
-        );
         assert_eq!(16, pyre_native::hash::HASH_STATE_STORAGE_ALIGN);
         let _roots = gc_roots::push_roots();
         let name_slot = gc_roots::shadow_stack_len();
@@ -102,7 +105,7 @@ impl W_HashState {
             name: gc_roots::shadow_stack_get(name_slot),
             digest_size: pyre_native::hash::digest_output_size(name).unwrap_or(0) as i64,
             storage: HashStateStorage {
-                words: [0; HASH_STATE_WORDS + 1],
+                words: [0; HASH_STATE_SLOTS],
             },
         });
         let this = W_HashState::from_obj(state).expect("fresh _HashState");
@@ -144,7 +147,7 @@ impl W_HashState {
             name: gc_roots::shadow_stack_get(name_slot),
             digest_size: digest_size as i64,
             storage: HashStateStorage {
-                words: [0; HASH_STATE_WORDS + 1],
+                words: [0; HASH_STATE_SLOTS],
             },
         });
         let this = W_HashState::from_obj(state).expect("fresh BLAKE2 state");
@@ -285,7 +288,7 @@ mod hash_state_class {
                 name: gc_roots::shadow_stack_get(name_slot),
                 digest_size: self.digest_size,
                 storage: HashStateStorage {
-                    words: [0; HASH_STATE_WORDS + 1],
+                    words: [0; HASH_STATE_SLOTS],
                 },
             });
             let clone = W_HashState::from_obj(clone).expect("fresh _HashState");
@@ -397,11 +400,13 @@ fn unsupported_digestmod(msg: &str) -> crate::PyError {
     err
 }
 
-const HMAC_STATE_WORDS: usize = 128;
+const HMAC_STATE_WORDS: usize = pyre_native::hash::HMAC_STATE_STORAGE_WORDS;
+const HMAC_STATE_SLOTS: usize =
+    HMAC_STATE_WORDS + pyre_native::hash::STATE_STORAGE_ALIGN_SLACK_WORDS;
 
 #[repr(C)]
 struct HmacStateStorage {
-    words: [usize; HMAC_STATE_WORDS + 1],
+    words: [usize; HMAC_STATE_SLOTS],
 }
 
 impl HmacStateStorage {
@@ -426,10 +431,6 @@ pub struct W_Hmac {
 
 impl W_Hmac {
     fn new(name: &'static str, key: &[u8], msg: &[u8]) -> Result<PyObjectRef, crate::PyError> {
-        assert_eq!(
-            HMAC_STATE_WORDS,
-            pyre_native::hash::HMAC_STATE_STORAGE_WORDS
-        );
         assert_eq!(16, pyre_native::hash::HMAC_STATE_STORAGE_ALIGN);
         let digest_size = pyre_native::hash::digest_output_size(name)
             .ok_or_else(|| unsupported_digestmod("unsupported hash type"))?;
@@ -444,7 +445,7 @@ impl W_Hmac {
             digest_size: digest_size as i64,
             block_size: block_size as i64,
             storage: HmacStateStorage {
-                words: [0; HMAC_STATE_WORDS + 1],
+                words: [0; HMAC_STATE_SLOTS],
             },
         });
         let this = W_Hmac::from_obj(obj).expect("fresh HMAC");
@@ -551,7 +552,7 @@ mod hmac_class {
                 digest_size: self.digest_size,
                 block_size: self.block_size,
                 storage: HmacStateStorage {
-                    words: [0; HMAC_STATE_WORDS + 1],
+                    words: [0; HMAC_STATE_SLOTS],
                 },
             });
             let clone = W_Hmac::from_obj(obj).expect("fresh HMAC");

--- a/pyre/pyre-interpreter/src/module/_random/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_random/mod.rs
@@ -348,19 +348,12 @@ impl W_Random {
 }
 
 /// Time-based fallback seed — `int(time.time() * 256)`.
+///
+/// Read through the same accessor `time.time()` uses, which is what routes
+/// the reading to the sandbox controller and to the wasm embedder rather than
+/// to a `SystemTime` neither of them has.
 fn seed_from_time() -> u64 {
-    // Under sandbox the clock is read through the trusted controller, not the
-    // host directly.
-    #[cfg(feature = "sandbox")]
-    let secs = crate::host_seam::ops::time().unwrap_or(0.0);
-    #[cfg(not(feature = "sandbox"))]
-    let secs = {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs_f64())
-            .unwrap_or(0.0)
-    };
+    let secs = crate::module::time::interp_time::duration_since_epoch().as_secs_f64();
     (secs * 256.0) as u64
 }
 

--- a/pyre/pyre-interpreter/src/module/_socket/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/mod.rs
@@ -5,9 +5,8 @@
 //! plus address conversion / IDNA / error mapping helpers, and
 //! rsocket_rffi carries the host socket layer both platforms reach it
 //! through.  It exists only where such a layer does: a target that is
-//! neither POSIX nor Windows keeps the module's platform-neutral surface
-//! (the error classes, the byte-order helpers, the default timeout) and
-//! nothing that would need a descriptor behind it.
+//! neither POSIX nor Windows has no `_socket` module at all, which is the
+//! absence `socket.py` and its callers are written against.
 
 #[cfg(any(unix, windows))]
 pub(crate) mod rsocket_rffi;

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
@@ -6,11 +6,13 @@
 //! resolves modules with and traceback rendering reads source lines with.
 //! This module publishes that seam under the names `os.py` reads.
 //!
-//! The list is exactly what `os.py`'s module body needs to run — `environ`,
+//! The list is what `os.py`'s module body needs to run — `environ`,
 //! `_have_functions`, `stat` and `cpu_count` — plus `lstat`, `listdir`,
-//! `fspath` and `stat_result`.  Everything else `os` normally re-exports
-//! stays absent, so `os._exists` answers False for it and `os` builds the
-//! same fallbacks it builds on a platform whose C library lacks the call.
+//! `fspath` and `stat_result`, and the three calls the stdlib reaches for
+//! that the embedder can still answer: `getcwd`, `getcwdb` and `urandom`.
+//! Everything else `os` normally re-exports stays absent, so `os._exists`
+//! answers False for it and `os` builds the same fallbacks it builds on a
+//! platform whose C library lacks the call.
 //!
 //! [`SourceProvider`]: crate::importing::SourceProvider
 
@@ -219,4 +221,61 @@ pub fn register_module(ns: PyObjectRef) {
             0,
         ),
     );
+    // The seam reports the embedder's working directory; without one there is
+    // no directory to name, and `""` is what the syscall arm returns when the
+    // host refuses too.  `posixpath.abspath` is this call, so every relative
+    // path the stdlib resolves goes through it.
+    crate::module_ns_store(
+        ns,
+        "getcwd",
+        crate::make_builtin_function_with_arity(
+            "getcwd",
+            |_args| Ok(crate::gateway::fsdecode_filename_bytes(&cwd_bytes())),
+            0,
+        ),
+    );
+    crate::module_ns_store(
+        ns,
+        "getcwdb",
+        crate::make_builtin_function_with_arity(
+            "getcwdb",
+            |_args| Ok(pyre_object::w_bytes_from_bytes(&cwd_bytes())),
+            0,
+        ),
+    );
+    crate::module_ns_store(
+        ns,
+        "urandom",
+        crate::make_builtin_function_with_arity("urandom", urandom, 1),
+    );
+}
+
+/// The embedder's working directory, or nothing when it reports none.
+fn cwd_bytes() -> Vec<u8> {
+    crate::importing::source_cwd().unwrap_or_default()
+}
+
+/// `posix.urandom(n)` — the same entry point the syscall arm publishes, over
+/// the entropy the embedder supplies.
+///
+/// `random.Random()` and `secrets` are both this call, so a guest without it
+/// cannot import either; the bytes are the host's, not a stream the guest
+/// generates, because that is what the callers are asking for.
+fn urandom(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    crate::gateway::check_declared_arity("urandom", 1, args.len())?;
+    let n = crate::builtins::space_index_w(args[0])?;
+    if n < 0 {
+        return Err(crate::PyError::value_error("negative argument not allowed"));
+    }
+    let n =
+        usize::try_from(n).map_err(|_| crate::PyError::overflow_error("argument out of range"))?;
+    // Reporting an entropy failure rather than absorbing it: the alternative
+    // is handing a caller who asked for unpredictable bytes a buffer of zeros.
+    let buf = crate::importing::host::os::urandom(n).map_err(|e| {
+        crate::PyError::os_error_syscall(
+            crate::builtins::io_error_posix_errno(&e, crate::builtins::wasm_errno::ENOTSUP),
+            pyre_object::w_none(),
+        )
+    })?;
+    Ok(pyre_object::w_bytes_from_bytes(&buf))
 }

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -9,7 +9,13 @@ use parking_lot::{Condvar, Mutex};
 use pyre_object::*;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
 use std::sync::{LazyLock, OnceLock};
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
+// wasm32 has no `Instant` of its own; the deadlines below read the clock the
+// embedder installs, the same one `time.monotonic()` reports.
+#[cfg(target_arch = "wasm32")]
+use crate::module::time::interp_time::Instant;
 
 /// `PY_TIMEOUT_MAX` — the acquire-timeout bound in microseconds.  A POSIX host
 /// waits on a nanosecond deadline and bounds it at `LLONG_MAX / 1000`; Windows

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -12,8 +12,9 @@ use crate::host_seam::sys as libc;
 #[cfg(feature = "host_env")]
 use rustpython_host_env::time as host_time;
 use std::sync::OnceLock;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
-#[cfg(not(feature = "host_env"))]
+#[cfg(not(any(feature = "host_env", target_arch = "wasm32")))]
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Number of fields in `time.struct_time` as seen by C extensions.
@@ -23,37 +24,94 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// count is the same everywhere.
 pub const STRUCT_TM_ITEMS: i64 = 11;
 
+/// The clock a target reads when it has none of its own.
+///
+/// wasm32 has neither a `SystemTime` nor an `Instant`: both panic rather than
+/// answer, which is why `time` was kept out of the module registry there at
+/// all.  The embedder that supplies the filesystem through
+/// [`crate::importing::SourceProvider`] supplies the clock through this.
+#[cfg(target_arch = "wasm32")]
+pub trait ClockProvider: Send + Sync {
+    /// Nanoseconds since the unix epoch.
+    fn wall_nanos(&self) -> i128;
+    /// Nanoseconds on a clock that does not go backwards, counted from an
+    /// origin this only has to keep fixed.
+    fn monotonic_nanos(&self) -> i128;
+    /// Block until `nanos` nanoseconds have passed.
+    fn sleep_nanos(&self, nanos: u64);
+}
+
+#[cfg(target_arch = "wasm32")]
+static CLOCK_PROVIDER: OnceLock<std::sync::Arc<dyn ClockProvider>> = OnceLock::new();
+
+/// Install the clock this module reads.  The wasm bootstrap installs one
+/// before the first `import time`; with none installed every clock reads zero,
+/// which is what a target with no clock can honestly report and is still
+/// non-decreasing.
+#[cfg(target_arch = "wasm32")]
+pub fn install_clock_provider(provider: std::sync::Arc<dyn ClockProvider>) {
+    let _ = CLOCK_PROVIDER.set(provider);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn with_clock<R>(f: impl FnOnce(&dyn ClockProvider) -> R, unclocked: R) -> R {
+    match CLOCK_PROVIDER.get() {
+        Some(provider) => f(&**provider),
+        None => unclocked,
+    }
+}
+
 /// Process-start `Instant` used as the monotonic-clock origin whenever
 /// `clock_gettime(CLOCK_MONOTONIC)` is unavailable.  Keeping a single
 /// baseline preserves `time.monotonic()`'s non-decreasing guarantee.
+#[cfg(not(target_arch = "wasm32"))]
 fn monotonic_baseline() -> Instant {
     static BASELINE: OnceLock<Instant> = OnceLock::new();
     *BASELINE.get_or_init(Instant::now)
 }
 
 fn monotonic_seconds() -> f64 {
-    #[cfg(all(unix, feature = "host_env"))]
+    #[cfg(target_arch = "wasm32")]
     {
-        if let Ok(d) = host_time::clock_gettime(host_time::ClockId::CLOCK_MONOTONIC) {
-            return d.as_secs_f64();
-        }
+        with_clock(|clock| clock.monotonic_nanos(), 0) as f64 / 1e9
     }
-    monotonic_baseline().elapsed().as_secs_f64()
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        #[cfg(all(unix, feature = "host_env"))]
+        {
+            if let Ok(d) = host_time::clock_gettime(host_time::ClockId::CLOCK_MONOTONIC) {
+                return d.as_secs_f64();
+            }
+        }
+        monotonic_baseline().elapsed().as_secs_f64()
+    }
 }
 
 /// Wall-clock seconds since the unix epoch, falling back to 0 on
 /// `SystemTimeError`.  Routes through `host_env::time` when enabled.
 pub(crate) fn duration_since_epoch() -> std::time::Duration {
+    #[cfg(all(target_arch = "wasm32", not(feature = "sandbox")))]
+    {
+        let nanos = with_clock(|clock| clock.wall_nanos(), 0).max(0) as u128;
+        std::time::Duration::new(
+            (nanos / 1_000_000_000) as u64,
+            (nanos % 1_000_000_000) as u32,
+        )
+    }
     #[cfg(feature = "sandbox")]
     {
         let secs = crate::host_seam::ops::time().unwrap_or(0.0).max(0.0);
         std::time::Duration::from_secs_f64(secs)
     }
-    #[cfg(all(feature = "host_env", not(feature = "sandbox")))]
+    #[cfg(all(
+        feature = "host_env",
+        not(feature = "sandbox"),
+        not(target_arch = "wasm32")
+    ))]
     {
         host_time::duration_since_system_now().unwrap_or_default()
     }
-    #[cfg(not(any(feature = "host_env", feature = "sandbox")))]
+    #[cfg(not(any(feature = "host_env", feature = "sandbox", target_arch = "wasm32")))]
     {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -218,7 +276,22 @@ pub fn sleep(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             }
         }
     }
-    #[cfg(not(any(all(unix, feature = "host_env"), feature = "sandbox")))]
+    #[cfg(all(target_arch = "wasm32", not(feature = "sandbox")))]
+    {
+        // The guest has no scheduler of its own, so the wait is the
+        // embedder's to take.
+        let _blocking = crate::module::thread::before_external_block();
+        with_clock(
+            |clock| clock.sleep_nanos(dur.as_nanos().min(u64::MAX as u128) as u64),
+            (),
+        );
+        Ok(w_none())
+    }
+    #[cfg(not(any(
+        all(unix, feature = "host_env"),
+        feature = "sandbox",
+        target_arch = "wasm32"
+    )))]
     {
         let _blocking = crate::module::thread::before_external_block();
         std::thread::sleep(dur);
@@ -238,13 +311,20 @@ pub fn perf_counter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 
 /// Monotonic clock as integer nanoseconds.
 pub(crate) fn monotonic_nanos() -> i128 {
-    #[cfg(all(unix, feature = "host_env"))]
+    #[cfg(target_arch = "wasm32")]
     {
-        if let Ok(d) = host_time::clock_gettime(host_time::ClockId::CLOCK_MONOTONIC) {
-            return d.as_nanos() as i128;
-        }
+        with_clock(|clock| clock.monotonic_nanos(), 0)
     }
-    monotonic_baseline().elapsed().as_nanos() as i128
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        #[cfg(all(unix, feature = "host_env"))]
+        {
+            if let Ok(d) = host_time::clock_gettime(host_time::ClockId::CLOCK_MONOTONIC) {
+                return d.as_nanos() as i128;
+            }
+        }
+        monotonic_baseline().elapsed().as_nanos() as i128
+    }
 }
 
 /// time.monotonic_ns() → int
@@ -299,7 +379,18 @@ pub fn get_time_info(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         "thread_time" => ("GetThreadTimes()", true, false),
         _ => return Err(crate::PyError::value_error("unknown clock")),
     };
-    #[cfg(not(windows))]
+    // The guest makes no syscall: every clock is a question put to the
+    // embedder, and `process_time` is the monotonic one because that is the
+    // only clock this target has.
+    #[cfg(target_arch = "wasm32")]
+    let (implementation, monotonic, adjustable) = match name_str {
+        "time" => ("ClockProvider::wall_nanos()", false, true),
+        "monotonic" | "perf_counter" | "process_time" => {
+            ("ClockProvider::monotonic_nanos()", true, false)
+        }
+        _ => return Err(crate::PyError::value_error("unknown clock")),
+    };
+    #[cfg(all(not(windows), not(target_arch = "wasm32")))]
     let (implementation, monotonic, adjustable) = match name_str {
         "time" => ("clock_gettime(CLOCK_REALTIME)", false, true),
         "monotonic" | "perf_counter" => {
@@ -487,9 +578,9 @@ fn process_time_nanos() -> Result<i128, crate::PyError> {
 
 #[cfg(not(any(all(unix, feature = "host_env"), all(windows, feature = "host_env"))))]
 fn process_time_nanos() -> Result<i128, crate::PyError> {
-    // No host clock available; fall back to the monotonic baseline so
-    // the value is still non-decreasing.
-    Ok(monotonic_baseline().elapsed().as_nanos() as i128)
+    // No process clock available; report the monotonic one, which is
+    // non-decreasing and is the only clock this target has.
+    Ok(monotonic_nanos())
 }
 
 /// `GetThreadTimes`' kernel + user total for the calling thread — the

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -61,6 +61,49 @@ fn with_clock<R>(f: impl FnOnce(&dyn ClockProvider) -> R, unclocked: R) -> R {
     }
 }
 
+/// A reading of the monotonic clock, standing in for `std::time::Instant`.
+///
+/// wasm32 answers `Instant::now()` with a panic rather than a reading, so
+/// every caller that needs a deadline -- a lock wait, a join timeout -- takes
+/// it from the embedder's clock instead, which is the clock
+/// `time.monotonic()` already reports.  Only the surface those callers use is
+/// offered.
+#[cfg(target_arch = "wasm32")]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct Instant(i128);
+
+#[cfg(target_arch = "wasm32")]
+impl Instant {
+    pub(crate) fn now() -> Self {
+        Self(monotonic_nanos())
+    }
+
+    pub(crate) fn elapsed(&self) -> std::time::Duration {
+        Self::now() - *self
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl std::ops::Add<std::time::Duration> for Instant {
+    type Output = Self;
+
+    fn add(self, rhs: std::time::Duration) -> Self {
+        Self(self.0 + rhs.as_nanos() as i128)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl std::ops::Sub for Instant {
+    type Output = std::time::Duration;
+
+    /// Saturating, matching the clock: a reading earlier than `rhs` is a
+    /// duration of zero rather than one that wrapped.
+    fn sub(self, rhs: Self) -> std::time::Duration {
+        let nanos = (self.0 - rhs.0).max(0) as u128;
+        std::time::Duration::from_nanos(nanos.min(u64::MAX as u128) as u64)
+    }
+}
+
 /// Process-start `Instant` used as the monotonic-clock origin whenever
 /// `clock_gettime(CLOCK_MONOTONIC)` is unavailable.  Keeping a single
 /// baseline preserves `time.monotonic()`'s non-decreasing guarantee.

--- a/pyre/pyre-native/src/hash.rs
+++ b/pyre/pyre-native/src/hash.rs
@@ -112,13 +112,32 @@ type LockedHashState = Mutex<HashState>;
 /// Size/alignment contract for the opaque, object-owned storage embedded in
 /// pyre's `_HashState` payload.  The digest implementations are fixed-size
 /// state machines; none owns heap memory or needs drop glue.
-pub const HASH_STATE_STORAGE_WORDS: usize = 64;
+///
+/// The capacity is stated in BYTES because that is what has to hold a state
+/// machine whose size does not follow the target's pointer width.  Stating it
+/// as a word count gave wasm32 half the room a 64-bit target got, and the
+/// runtime check below then aborted the guest on the first `hashlib` digest.
+pub const HASH_STATE_STORAGE_BYTES: usize = 512;
+pub const HASH_STATE_STORAGE_WORDS: usize = HASH_STATE_STORAGE_BYTES / std::mem::size_of::<usize>();
 pub const HASH_STATE_STORAGE_ALIGN: usize = 16;
+
+/// Words a caller embeds beyond the capacity so the payload still fits after
+/// being aligned up to [`HASH_STATE_STORAGE_ALIGN`].
+///
+/// The owning Python object carries only the heap's word alignment, so the
+/// array inside it starts anywhere on a word boundary and the round-up eats
+/// up to one alignment less one word.  A slack stated in words rather than in
+/// bytes is right only where a word is eight bytes wide.
+pub const STATE_STORAGE_ALIGN_SLACK_WORDS: usize =
+    (HASH_STATE_STORAGE_ALIGN - std::mem::size_of::<usize>()) / std::mem::size_of::<usize>();
+
+// The state's size is a compile-time fact on every target, so the target that
+// cannot hold it fails to build rather than trapping in the field.
+const _: () = assert!(std::mem::size_of::<LockedHashState>() <= HASH_STATE_STORAGE_BYTES);
+const _: () = assert!(std::mem::align_of::<LockedHashState>() <= HASH_STATE_STORAGE_ALIGN);
 
 fn check_storage(storage: *mut usize, words: usize) {
     assert!(words >= HASH_STATE_STORAGE_WORDS);
-    assert!(std::mem::size_of::<LockedHashState>() <= words * std::mem::size_of::<usize>());
-    assert!(std::mem::align_of::<LockedHashState>() <= HASH_STATE_STORAGE_ALIGN);
     assert!(!storage.is_null());
     assert_eq!((storage as usize) % HASH_STATE_STORAGE_ALIGN, 0);
 }
@@ -398,13 +417,17 @@ pub fn digest_output_size(name: &str) -> Option<usize> {
 }
 
 type LockedHmacState = Mutex<HmacState>;
-pub const HMAC_STATE_STORAGE_WORDS: usize = 128;
+/// [`HASH_STATE_STORAGE_BYTES`]'s counterpart: an HMAC carries two digest
+/// states, so it is sized in bytes for the same reason.
+pub const HMAC_STATE_STORAGE_BYTES: usize = 1024;
+pub const HMAC_STATE_STORAGE_WORDS: usize = HMAC_STATE_STORAGE_BYTES / std::mem::size_of::<usize>();
 pub const HMAC_STATE_STORAGE_ALIGN: usize = 16;
+
+const _: () = assert!(std::mem::size_of::<LockedHmacState>() <= HMAC_STATE_STORAGE_BYTES);
+const _: () = assert!(std::mem::align_of::<LockedHmacState>() <= HMAC_STATE_STORAGE_ALIGN);
 
 fn check_hmac_storage(storage: *mut usize, words: usize) {
     assert!(words >= HMAC_STATE_STORAGE_WORDS);
-    assert!(std::mem::size_of::<LockedHmacState>() <= words * std::mem::size_of::<usize>());
-    assert!(std::mem::align_of::<LockedHmacState>() <= HMAC_STATE_STORAGE_ALIGN);
     assert!(!storage.is_null());
     assert_eq!((storage as usize) % HMAC_STATE_STORAGE_ALIGN, 0);
 }

--- a/pyre/pyre-wasm-runner/Cargo.toml
+++ b/pyre/pyre-wasm-runner/Cargo.toml
@@ -32,3 +32,6 @@ wasmi = "1.1"
 # Content hash binding the `.cwasm` cache to the exact `.wasm` bytes it was
 # compiled from, so a stale or pre-placed cache is never deserialized.
 sha2 = "0.10"
+# The entropy `pyre_host.host_random` serves the guest. wasm32-unknown-unknown
+# has no OS entropy, so the guest's `os.urandom` and `secrets` are this call.
+getrandom = { workspace = true }

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -1749,7 +1749,102 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>> {
          -> i64 { host_list_dir(&mut caller, path_ptr, path_len, buf_ptr, buf_cap) },
     )?;
 
+    linker.func_wrap(
+        "pyre_host",
+        "host_cwd",
+        |mut caller: Caller<'_, Host>, buf_ptr: u32, buf_cap: u32| -> i64 {
+            host_cwd(&mut caller, buf_ptr, buf_cap)
+        },
+    )?;
+    linker.func_wrap(
+        "pyre_host",
+        "host_random",
+        |mut caller: Caller<'_, Host>, buf_ptr: u32, buf_cap: u32| -> i32 {
+            host_random(&mut caller, buf_ptr, buf_cap)
+        },
+    )?;
+
+    // Host clock imports.  wasm32 has neither a `SystemTime` nor an `Instant`,
+    // so `time` -- and every stdlib module that imports it -- reads the clock
+    // here.  See `pyre-wasm`'s `host_clock`.
+    linker.func_wrap("pyre_host", "host_time_ns", || -> i64 { host_time_ns() })?;
+    linker.func_wrap("pyre_host", "host_monotonic_ns", || -> i64 {
+        host_monotonic_ns()
+    })?;
+    linker.func_wrap("pyre_host", "host_sleep_ns", |nanos: i64| {
+        host_sleep_ns(nanos)
+    })?;
+
     Ok(linker)
+}
+
+/// `pyre_host.host_random`: fill the guest buffer with host entropy.
+///
+/// wasm32-unknown-unknown has no OS entropy of its own, so `os.urandom`,
+/// `secrets` and the string hash key all end up here.
+fn host_random(caller: &mut Caller<'_, Host>, buf_ptr: u32, buf_cap: u32) -> i32 {
+    let Some(memory) = caller.data().memory else {
+        return -1;
+    };
+    let mut bytes = vec![0u8; buf_cap as usize];
+    if getrandom::fill(&mut bytes).is_err() {
+        return -1;
+    }
+    match memory.write(&mut *caller, buf_ptr as usize, &bytes) {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
+}
+
+/// `pyre_host.host_cwd`: write the runner's working directory into the guest
+/// buffer, reporting its length whether or not it fitted.
+fn host_cwd(caller: &mut Caller<'_, Host>, buf_ptr: u32, buf_cap: u32) -> i64 {
+    let Some(memory) = caller.data().memory else {
+        return -1;
+    };
+    let Ok(cwd) = std::env::current_dir() else {
+        return -1;
+    };
+    let bytes = cwd.as_os_str().as_encoded_bytes();
+    if bytes.len() > buf_cap as usize {
+        return bytes.len() as i64;
+    }
+    match memory.write(&mut *caller, buf_ptr as usize, bytes) {
+        Ok(()) => bytes.len() as i64,
+        Err(_) => -1,
+    }
+}
+
+/// `pyre_host.host_time_ns`: nanoseconds since the unix epoch.
+///
+/// The guest has no `SystemTime` of its own -- reading one panics there --
+/// so the wall clock it reports is this one.
+fn host_time_ns() -> i64 {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(d) => d.as_nanos().min(i64::MAX as u128) as i64,
+        Err(_) => -1,
+    }
+}
+
+/// `pyre_host.host_monotonic_ns`: nanoseconds since the runner started.
+///
+/// The origin is taken at the first call and kept for the run, which is all
+/// `time.monotonic()` asks of it: only differences are meaningful, and they
+/// have to not go backwards.
+fn host_monotonic_ns() -> i64 {
+    static ORIGIN: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
+    ORIGIN
+        .get_or_init(std::time::Instant::now)
+        .elapsed()
+        .as_nanos()
+        .min(i64::MAX as u128) as i64
+}
+
+/// `pyre_host.host_sleep_ns`: block the guest for `nanos` nanoseconds.
+fn host_sleep_ns(nanos: i64) {
+    if nanos > 0 {
+        std::thread::sleep(std::time::Duration::from_nanos(nanos as u64));
+    }
 }
 
 /// Read a host path argument out of wasm linear memory as the filesystem name

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -1497,33 +1497,48 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
 /// validates that and errors on mismatch. `deserialize_file` runs trusted
 /// precompiled native code and the `.cwasm` is otherwise independent of the
 /// `.wasm` contents, so the cache is bound to the exact bytes it was produced
-/// from: a sidecar `<module>.cwasm.sha256` records the SHA-256 of those bytes,
-/// and the cache is deserialized only when it matches the current module's
-/// hash. A rebuilt module or a pre-placed `.cwasm` therefore recompiles instead
-/// of running a stale or untrusted artifact. Set `PYRE_WASM_NO_CACHE` to bypass
+/// from: a sidecar `<module>.cwasm.sha256` records the SHA-256 of those bytes
+/// along with the size and mtime they were read at, and the cache is
+/// deserialized only when the module still answers to one of the two. A
+/// rebuilt module or a pre-placed `.cwasm` therefore recompiles instead of
+/// running a stale or untrusted artifact. Set `PYRE_WASM_NO_CACHE` to bypass
 /// the cache entirely.
 ///
 /// `variant` separates the artifacts of engine configurations that emit
 /// different code for the same module; see [`cache_variant`].
 fn load_main_module(engine: &Engine, module_path: &Path, variant: &str) -> Result<Module> {
     let cache_disabled = std::env::var_os("PYRE_WASM_NO_CACHE").is_some();
-    let wasm_bytes = std::fs::read(module_path)
-        .with_context(|| format!("read wasm module {}", module_path.display()))?;
     probe_call_hist_note_module(module_path);
-    let hash = wasm_content_hash(&wasm_bytes);
     let cache_path = cache_path_for(module_path, variant);
     let key_path = cache_key_path_for(module_path, variant);
+    let stamp = file_stamp(module_path);
 
-    if !cache_disabled && cache_key_matches(&key_path, &hash) {
-        // SAFETY: the artifact was produced by this runner's own engine via
-        // `Module::serialize`; `deserialize_file` re-checks engine/version
-        // compatibility and returns Err (not UB) if it cannot be trusted. The
-        // key check above further proves it was compiled from the exact bytes
-        // we just read.
-        match unsafe { Module::deserialize_file(engine, &cache_path) } {
-            Ok(m) => return Ok(m),
-            Err(_) => { /* incompatible cache; recompile below */ }
-        }
+    // Reading and hashing the module is 28MB of work on a path that then
+    // throws the bytes away, and every process start pays it. The sidecar
+    // therefore also records the size and mtime the hash was taken from: while
+    // those still describe the file, the bytes are the bytes that were hashed
+    // and the hash is already known.
+    if !cache_disabled
+        && let Some(stamp) = stamp.as_deref()
+        && cache_key_stamp_matches(&key_path, stamp)
+        && let Some(module) = deserialize_cache(engine, &cache_path)
+    {
+        return Ok(module);
+    }
+
+    let wasm_bytes = std::fs::read(module_path)
+        .with_context(|| format!("read wasm module {}", module_path.display()))?;
+    let hash = wasm_content_hash(&wasm_bytes);
+
+    if !cache_disabled
+        && cache_key_matches(&key_path, &hash)
+        && let Some(module) = deserialize_cache(engine, &cache_path)
+    {
+        // Same bytes under a stamp the sidecar does not name -- a rebuild that
+        // reproduced the module, or a checkout that reset the mtime. Record
+        // the stamp so the next run reaches the cache without hashing.
+        write_cache_key(&key_path, &hash, stamp.as_deref());
+        return Ok(module);
     }
 
     let module = Module::new(engine, &wasm_bytes[..])
@@ -1539,13 +1554,24 @@ fn load_main_module(engine: &Engine, module_path: &Path, variant: &str) -> Resul
         let staged = staged_cache_path_for(&cache_path);
         if std::fs::write(&staged, bytes).is_ok() {
             if std::fs::rename(&staged, &cache_path).is_ok() {
-                let _ = std::fs::write(&key_path, &hash);
+                write_cache_key(&key_path, &hash, stamp.as_deref());
             } else {
                 let _ = std::fs::remove_file(&staged);
             }
         }
     }
     Ok(module)
+}
+
+/// Deserialize the cached artifact, or nothing if it cannot be trusted.
+///
+/// SAFETY: the artifact was produced by this runner's own engine via
+/// `Module::serialize`; `deserialize_file` re-checks engine/version
+/// compatibility and returns Err (not UB) if it cannot be trusted. The caller
+/// has further proved, by hash or by stamp, that it was compiled from the
+/// bytes the module path currently holds.
+fn deserialize_cache(engine: &Engine, cache_path: &Path) -> Option<Module> {
+    unsafe { Module::deserialize_file(engine, cache_path) }.ok()
 }
 
 /// The suffix separating the compiled artifacts of engine configurations that
@@ -1599,9 +1625,53 @@ fn wasm_content_hash(bytes: &[u8]) -> String {
     s
 }
 
+/// Size and mtime of the module file, in the spelling the key sidecar records.
+///
+/// Nothing distinguishes two builds that landed in the same nanosecond at the
+/// same length, which is why this only ever admits a hash that was already
+/// taken: it says the file has not been rewritten since, not what is in it.
+fn file_stamp(module_path: &Path) -> Option<String> {
+    let meta = std::fs::metadata(module_path).ok()?;
+    let mtime = meta
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?;
+    Some(format!(
+        "{} {} {}",
+        meta.len(),
+        mtime.as_secs(),
+        mtime.subsec_nanos()
+    ))
+}
+
+/// The sidecar's hash line, then its stamp line if it has one.
+fn read_cache_key(key_path: &Path) -> Option<(String, Option<String>)> {
+    let text = std::fs::read_to_string(key_path).ok()?;
+    let mut lines = text.lines();
+    let hash = lines.next()?.trim().to_string();
+    let stamp = lines.next().map(|line| line.trim().to_string());
+    Some((hash, stamp))
+}
+
+fn write_cache_key(key_path: &Path, hash: &str, stamp: Option<&str>) {
+    let mut text = String::from(hash);
+    if let Some(stamp) = stamp {
+        text.push('\n');
+        text.push_str(stamp);
+    }
+    let _ = std::fs::write(key_path, text);
+}
+
 /// The cache is usable only if its key sidecar exists and matches `hash`.
 fn cache_key_matches(key_path: &Path, hash: &str) -> bool {
-    matches!(std::fs::read_to_string(key_path), Ok(k) if k.trim() == hash)
+    matches!(read_cache_key(key_path), Some((k, _)) if k == hash)
+}
+
+/// The cache is reachable without hashing only if the sidecar names the stamp
+/// the module file still carries.
+fn cache_key_stamp_matches(key_path: &Path, stamp: &str) -> bool {
+    matches!(read_cache_key(key_path), Some((_, Some(s))) if s == stamp)
 }
 
 fn build_linker(engine: &Engine) -> Result<Linker<Host>> {

--- a/pyre/pyre-wasm-runner/src/wasmi_host.rs
+++ b/pyre/pyre-wasm-runner/src/wasmi_host.rs
@@ -352,7 +352,112 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>, String> {
         )
         .map_err(estr)?;
 
+    linker
+        .func_wrap(
+            "pyre_host",
+            "host_cwd",
+            |mut caller: Caller<'_, Host>, buf_ptr: u32, buf_cap: u32| -> i64 {
+                host_cwd(&mut caller, buf_ptr, buf_cap)
+            },
+        )
+        .map_err(estr)?;
+    linker
+        .func_wrap(
+            "pyre_host",
+            "host_random",
+            |mut caller: Caller<'_, Host>, buf_ptr: u32, buf_cap: u32| -> i32 {
+                host_random(&mut caller, buf_ptr, buf_cap)
+            },
+        )
+        .map_err(estr)?;
+
+    // Host clock imports.  wasm32 has neither a `SystemTime` nor an `Instant`,
+    // so `time` -- and every stdlib module that imports it -- reads the clock
+    // here.  See `pyre-wasm`'s `host_clock`.
+    linker
+        .func_wrap("pyre_host", "host_time_ns", || -> i64 { host_time_ns() })
+        .map_err(estr)?;
+    linker
+        .func_wrap("pyre_host", "host_monotonic_ns", || -> i64 {
+            host_monotonic_ns()
+        })
+        .map_err(estr)?;
+    linker
+        .func_wrap("pyre_host", "host_sleep_ns", |nanos: i64| {
+            host_sleep_ns(nanos)
+        })
+        .map_err(estr)?;
+
     Ok(linker)
+}
+
+/// `pyre_host.host_random`: fill the guest buffer with host entropy.
+///
+/// wasm32-unknown-unknown has no OS entropy of its own, so `os.urandom`,
+/// `secrets` and the string hash key all end up here.
+fn host_random(caller: &mut Caller<'_, Host>, buf_ptr: u32, buf_cap: u32) -> i32 {
+    let Some(memory) = caller.data().memory else {
+        return -1;
+    };
+    let mut bytes = vec![0u8; buf_cap as usize];
+    if getrandom::fill(&mut bytes).is_err() {
+        return -1;
+    }
+    match memory.write(&mut *caller, buf_ptr as usize, &bytes) {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
+}
+
+/// `pyre_host.host_cwd`: write the runner's working directory into the guest
+/// buffer, reporting its length whether or not it fitted.
+fn host_cwd(caller: &mut Caller<'_, Host>, buf_ptr: u32, buf_cap: u32) -> i64 {
+    let Some(memory) = caller.data().memory else {
+        return -1;
+    };
+    let Ok(cwd) = std::env::current_dir() else {
+        return -1;
+    };
+    let bytes = cwd.as_os_str().as_encoded_bytes();
+    if bytes.len() > buf_cap as usize {
+        return bytes.len() as i64;
+    }
+    match memory.write(&mut *caller, buf_ptr as usize, bytes) {
+        Ok(()) => bytes.len() as i64,
+        Err(_) => -1,
+    }
+}
+
+/// `pyre_host.host_time_ns`: nanoseconds since the unix epoch.
+///
+/// The guest has no `SystemTime` of its own -- reading one panics there --
+/// so the wall clock it reports is this one.
+fn host_time_ns() -> i64 {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(d) => d.as_nanos().min(i64::MAX as u128) as i64,
+        Err(_) => -1,
+    }
+}
+
+/// `pyre_host.host_monotonic_ns`: nanoseconds since the runner started.
+///
+/// The origin is taken at the first call and kept for the run, which is all
+/// `time.monotonic()` asks of it: only differences are meaningful, and they
+/// have to not go backwards.
+fn host_monotonic_ns() -> i64 {
+    static ORIGIN: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
+    ORIGIN
+        .get_or_init(std::time::Instant::now)
+        .elapsed()
+        .as_nanos()
+        .min(i64::MAX as u128) as i64
+}
+
+/// `pyre_host.host_sleep_ns`: block the guest for `nanos` nanoseconds.
+fn host_sleep_ns(nanos: i64) {
+    if nanos > 0 {
+        std::thread::sleep(std::time::Duration::from_nanos(nanos as u64));
+    }
 }
 
 /// Read a host path argument out of wasm linear memory as the filesystem name

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -14,13 +14,23 @@ use wasm_bindgen::prelude::*;
 // Native-host (`wasm-host`) builds target wasm32-unknown-unknown, which has no OS
 // entropy. To avoid the wasm-bindgen-based `wasm_js` backend (whose imports a
 // non-JS embedder cannot satisfy), getrandom is wired to its `custom` backend
-// via `--cfg getrandom_backend="custom"`, which calls this hook. pyre seeds only
-// non-cryptographic uses (string hash key, the `random` module) from it, and the
-// values never affect check.py's oracle comparison, so a deterministic
-// SplitMix64 stream is sufficient.
+// via `--cfg getrandom_backend="custom"`, which calls this hook.
+//
+// The embedder has entropy, so this asks it for the bytes: `os.urandom` and
+// `secrets` are the same call, and a stream anyone can recompute is not what
+// either of them promises. Only when the host declines does the SplitMix64
+// fall-back below answer, which keeps the string hash key and the `random`
+// module working on an embedder that supplies no entropy at all.
 #[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
 mod custom_getrandom {
     use core::sync::atomic::{AtomicU64, Ordering};
+
+    #[link(wasm_import_module = "pyre_host")]
+    unsafe extern "C" {
+        /// Fill `[buf, buf+cap)` with entropy; 0 on success, -1 if the host
+        /// has none to give.
+        fn host_random(buf_ptr: *mut u8, buf_cap: u32) -> i32;
+    }
 
     static STATE: AtomicU64 = AtomicU64::new(0x9e37_79b9_7f4a_7c15);
 
@@ -29,6 +39,12 @@ mod custom_getrandom {
         dest: *mut u8,
         len: usize,
     ) -> Result<(), getrandom::Error> {
+        if len == 0 {
+            return Ok(());
+        }
+        if unsafe { host_random(dest, len as u32) } == 0 {
+            return Ok(());
+        }
         let mut i = 0;
         while i < len {
             let mut z = STATE
@@ -247,6 +263,51 @@ mod residual_host {
     }
 }
 
+// Host clock for the native-host (`wasm-host`) build.
+//
+// wasm32 has neither a `SystemTime` nor an `Instant`: both panic rather than
+// answer, which kept `time` -- and the nine stdlib modules that import it --
+// out of the guest entirely.  The runner owns a clock, so the guest asks it
+// the same way it asks for module source.
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+mod host_clock {
+    use pyre_interpreter::module::time::interp_time::ClockProvider;
+
+    #[link(wasm_import_module = "pyre_host")]
+    unsafe extern "C" {
+        /// Nanoseconds since the unix epoch, or -1 if the host has no clock.
+        fn host_time_ns() -> i64;
+        /// Nanoseconds on the host's monotonic clock, counted from an origin
+        /// the host only has to keep fixed for the run.
+        fn host_monotonic_ns() -> i64;
+        /// Block the calling thread for `nanos` nanoseconds.
+        fn host_sleep_ns(nanos: i64);
+    }
+
+    struct HostClock;
+
+    impl ClockProvider for HostClock {
+        fn wall_nanos(&self) -> i128 {
+            unsafe { host_time_ns() as i128 }
+        }
+        fn monotonic_nanos(&self) -> i128 {
+            unsafe { host_monotonic_ns() as i128 }
+        }
+        fn sleep_nanos(&self, nanos: u64) {
+            // An i64 tops out at 292 years, which is longer than any sleep a
+            // caller means, so a wider request is served as the longest one
+            // the call can carry rather than wrapping into a short one.
+            unsafe { host_sleep_ns(nanos.min(i64::MAX as u64) as i64) }
+        }
+    }
+
+    pub fn install() {
+        pyre_interpreter::module::time::interp_time::install_clock_provider(std::sync::Arc::new(
+            HostClock,
+        ));
+    }
+}
+
 // Host-filesystem source provider for the native-host (`wasm-host`) build.
 //
 // wasm32 has no filesystem, but the wasmtime runner does, so module source is
@@ -278,6 +339,10 @@ mod host_fs_provider {
         /// directory.
         fn host_list_dir(path_ptr: *const u8, path_len: u32, buf_ptr: *mut u8, buf_cap: u32)
         -> i64;
+        /// Write the host's working directory into `[buf, buf+cap)`; return
+        /// its byte length (without writing if it exceeds `cap`), or -1 if
+        /// the host has none.
+        fn host_cwd(buf_ptr: *mut u8, buf_cap: u32) -> i64;
     }
 
     struct HostFsProvider;
@@ -344,6 +409,25 @@ mod host_fs_provider {
                 "host_list_dir: {} kept growing",
                 path.display()
             )))
+        }
+        fn cwd(&self) -> Option<Vec<u8>> {
+            // The host reports the length whether or not it fitted and writes
+            // nothing when it did not, so the second round reads a buffer
+            // sized from the first answer.
+            let mut buf = vec![0u8; 256];
+            for _ in 0..4 {
+                let size = unsafe { host_cwd(buf.as_mut_ptr(), buf.len() as u32) };
+                if size < 0 {
+                    return None;
+                }
+                let size = size as usize;
+                if size <= buf.len() {
+                    buf.truncate(size);
+                    return Some(buf);
+                }
+                buf = vec![0u8; size];
+            }
+            None
         }
         fn read_to_bytes(&self, path: &Path) -> std::io::Result<Vec<u8>> {
             let p = path.as_os_str().as_encoded_bytes();
@@ -856,6 +940,7 @@ fn run_python_impl(source: &str) -> String {
             pyre_interpreter::importing::add_sys_path(&dir);
         }
         host_fs_provider::install();
+        host_clock::install();
     }
     install_wasm_print_hook();
     OUTPUT_BUF.with(|buf| buf.borrow_mut().clear());


### PR DESCRIPTION
Defects found by importing the stdlib inside the wasm guest and running what imported, then a pass over what the guest and its runner spend time on. Before this branch the guest could import 69 of 92 stdlib modules probed; `time` alone blocked nine of the twenty-three failures, `os.urandom` and `os.getcwd` another four, and `hashlib` did not fail — it aborted the guest, as did the first `_thread` lock.

## `hashlib` aborted the guest

`pyre-native`'s digest storage contract was a **word** count: 64 words for a hash state, 128 for an HMAC. That is 512 and 1024 bytes where a word is eight bytes and half that on wasm32, so `check_storage`'s size assertion fired on the first `hashlib.md5(b"abc")` and took the guest down rather than raising.

The constants are now stated in bytes with the word counts derived from them. The two runtime size/alignment assertions become `const` assertions, so a target that cannot hold the state fails to build instead of trapping in the field. The extra word each embedded array carried to absorb the round-up to a 16-byte boundary was word-count-shaped for the same reason and covered an eight-byte word only; it is now derived from the target's word size.

## `time` was not in the guest at all

wasm32 has neither a `SystemTime` nor an `Instant` — both panic rather than answer — so `pyre_install_module!(time)` was gated off the target, and with it `datetime`, `logging`, `threading`, `subprocess`, `sysconfig`, `unittest`, `doctest`, `gzip` and `uuid`.

`interp_time` gains a `ClockProvider` seam beside the import machinery's `SourceProvider`, read by `duration_since_epoch`, `monotonic_seconds`, `monotonic_nanos` and `sleep`. The host build installs one backed by three new `pyre_host` imports — `host_time_ns`, `host_monotonic_ns`, `host_sleep_ns` — that both runner engines satisfy. With no provider installed every clock reads zero, which is non-decreasing and is what a target with no clock can honestly report.

The broken-down-time functions (`gmtime`, `localtime`, `strftime`, `ctime`) keep raising `NotImplementedError`, the policy that was already there. `get_time_info` names the calls this target makes rather than the `clock_gettime(CLOCK_REALTIME)` a guest never issues.

## `os.urandom` and `os.getcwd` were absent

`random`, `secrets` and `statistics` read `os.urandom` at import, `site` reads `os.getcwd`, and `posixpath.abspath` is that call on every relative path.

`SourceProvider` gains a `cwd` half, defaulting to none so a provider serving an in-memory image is not made to invent a directory; `pyre-wasm` answers it from a new `host_cwd` import. The wasm `posix` arm publishes `getcwd`, `getcwdb` and `urandom`.

## The guest's entropy was a stream anyone could recompute

`wasm32-unknown-unknown` has no OS entropy, so the host build wired `getrandom` to a custom backend returning a deterministic SplitMix64 stream. That was sized for the string hash key; it is not what `os.urandom` and `secrets` promise, and publishing `os.urandom` would have made the shortfall reachable.

The backend now asks the embedder through a new `host_random` import and falls back to SplitMix64 only when the host declines — which also gives the guest the real hash randomisation the native build already has.

## `_thread` locks aborted the guest

`_thread.allocate_lock().acquire()` reached `std::time::Instant::now()`, which panics on wasm32-unknown-unknown, so the guest went down on the first lock taken — and `threading`, `logging`, `queue` and `_io` all take one. It is the same gap the clock seam above closes, in a module that reads the clock directly rather than through `time`.

`interp_time` grows an `Instant` over the monotonic clock the embedder installs, offering only the surface those deadlines use, and `module::thread` takes that one on wasm32. `_random`'s time-based fallback seed reached `SystemTime::now()` for the same reason; it now reads `duration_since_epoch()`, the accessor `time.time()` uses — which already carries the sandbox arm the fallback was spelling out separately.

## `import socket` raised the wrong exception

`_socket` was installed on wasm32 carrying only its platform-neutral surface — the error classes, the byte-order helpers, the default timeout — because the host socket layer is POSIX/Windows only. But `socket.py`'s module body subclasses `_socket.socket`, so `import socket` failed with `AttributeError`, and the callers that reach for it — `platform._node`, and through it `platform.uname` and `uuid` — guard on `ImportError`. The module is now absent on wasm32, alongside `_signal`, `_ssl` and `mmap`.

## The runner hashed 28MB of wasm on every start

`load_main_module` reached its compiled `.cwasm` only after reading the whole 28MB `.wasm` and taking its SHA-256, on a path that then discards those bytes. The sidecar now records the size and mtime the hash was taken at alongside the hash; a module that still answers to that stamp reaches the cache without being read. A stamp that does not match falls back to the hash, and a matching hash records the new stamp, so a rebuilt or pre-placed artefact still recompiles.

Measured on an empty script: `load_module` 65ms → 4.2ms, and the whole process 0.08s → 0.02s. Every wasm process start pays it. `check.py` subtracts each interpreter's empty-program startup from its ratios, so this lands on wall-clock and CI time rather than on the gate numbers.

## What the JIT emits per trace

Five changes to `majit-backend-wasm`, all local to the emitter:

- `int_force_ge_zero` picked the wrong arm of its `select`. `select` answers with its first operand when the condition holds, so pushing `val`, then `0`, then `val < 0` returned `val` for a negative input — `min(val, 0)` where the op is `max(val, 0)`. `ruleopt/proof.rs` states it as `If(arg0 < 0, 0, arg0)` and the cranelift backend emits `select(a < 0, zero, a)`.
- `emit_sized_int_load` loaded into an i32 and extended; `emit_sized_int_store` wrapped to an i32 before storing. `i64.load32_u` and friends do both in one instruction. Five open-coded `i32.load` + `i64.extend_i32_u` pairs elsewhere fold the same way. On wasm32 every pointer and word-sized field is four bytes, so this is most field, array-item and length accesses.
- `emit_array_addr` added the descr's `base_size` at run time and addressed at offset 0; it now returns that displacement for the access's own MemArg. `GuardIsObject` did the same with `infobits_offset`. Both are the shape the `getfield` arms already use for `field_offset_from_descr`.
- `emit_guard_if_exit` opens with an `if`, which tests i32-nonzero, so `GuardNotInvalidated`'s `i32.const 0; i32.ne` after the flag byte was redundant. `GuardNotForced` masked bit 32 of `frame[0]` with a 64-bit constant; on little-endian wasm32 that is bit 0 of the i32 at frame offset 4, the reading `emit_write_barrier` already takes of the header flags.
- The two fixed-size inline nursery bumps computed `free + total` once for the overflow test and again on the arm that commits it. The first sum is kept now.

## Codex parity review

- **§1** `open()` refusing write modes on wasm-host: **won't-fix (documented)**. That refusal is #1531's fix for Codex's own earlier finding — the seam has no writing half, so a buffer this builtin marks dirty has nowhere to be flushed to. Refusing where the file is named beats failing at the flush that would discover it, and there is no upstream counterpart for a target with no writable filesystem.
- **§2** `OsStr::from_encoded_bytes_unchecked` on arbitrary bytes: **won't-fix, comment strengthened**. wasm32-unknown-unknown's `OsStr` is `sys::os_str::bytes`, the same as unix, so any byte sequence is a valid encoding. The half Codex was missing — that the safe `from_vec` saying the same thing is published only under `std::os::unix` and `std::os::wasi`, neither of which this target has — is now in the `// SAFETY:` comment.
- **§3** two pre-existing findings, both in the non-unix fallback `open()` path: `name` and flush read a lossy `String` pathname rather than the original bytes. **Deferred** — the fix threads the original path object through `W_FileIO`, in the native `_io` layer this branch does not touch.

## Where the guest is now

The 92-module import scan goes from **OK 69 / FAIL 23** to **OK 85 / FAIL 13**. What is left has two roots:

- `os.open` / `O_RDONLY` / `os.readlink` — `doctest`, `glob`, `pathlib`, `shutil`, `sysconfig`, `tarfile`, `tempfile`, `zipfile`. This needs a writable host filesystem ABI and a descriptor table, which is its own design decision rather than a gap to fill.
- `_signal` absent — `signal`, `subprocess`, `timeit`, `unittest`. These import it unguarded, as a platform that always has signals allows.

`_ssl`, `mmap` and `zipimport` are deeper still.

## Verification

`python3 pyre/check.py --backend dynasm,wasm`: dynasm 511/511, wasm 504/504, no jitstats movement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - WebAssembly environments now support `posix.getcwd()`, `posix.getcwdb()`, and `posix.urandom()`.
  - WebAssembly applications receive host-provided working-directory, secure-randomness, clock, and sleep support.
  - Time and monotonic clock behavior is more consistent across supported platforms.

- **Performance**
  - WebAssembly module caching can validate unchanged files faster.
  - Generated WebAssembly memory access and allocation paths are more efficient.

- **Bug Fixes**
  - Corrected integer clamping behavior and improved garbage-collection guard handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->