### PR TITLE
gc_roots: port the shadowcolor split — naive brackets plus the optimiser that colours them

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -584,6 +584,15 @@ jobs:
         cargo test --release -p majit-translate \
           --test test_make_jitcodes_produces_graph_keyed_output
 
+    # The hand-written GC root brackets, held to what the analysis can prove.
+    # This job is where the gate is cheapest: all four artefacts are already on
+    # disk and the scan is ~25 s. Hanging it off `prepare` instead would put it
+    # on every downstream job's critical path.
+    - name: Check the GC root brackets
+      run: |
+        cargo build -p majit-translate --release --example gc-root-reachability
+        python3 scripts/check-gc-root-brackets.py
+
   pyre-check-linux:
     name: pyre/check.py ${{ matrix.label }} (ubuntu-24.04)
     runs-on: ubuntu-24.04

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -589,6 +589,10 @@ jobs:
     # disk and the scan is ~25 s. Hanging it off `prepare` instead would put it
     # on every downstream job's critical path.
     - name: Check the GC root brackets
+      env:
+        # The checkout is shallow and holds no `main` ref, so the gate cannot
+        # work out for itself which base its numbers were measured over.
+        PYRE_GC_GATE_BASE: ${{ github.event.pull_request.base.sha }}
       run: |
         cargo build -p majit-translate --release --example gc-root-reachability
         python3 scripts/check-gc-root-brackets.py

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ serde_json = { version = "1", features = ["raw_value"] }
 bincode = "1.3"
 
 # proc-macro / codegen
-syn = { version = "2", features = ["full", "visit"] }
+syn = { version = "2", features = ["full", "visit", "visit-mut"] }
 quote = "1"
 proc-macro2 = "1"
 

--- a/majit/gc-root-brackets.baseline.json
+++ b/majit/gc-root-brackets.baseline.json
@@ -1,16 +1,16 @@
 {
-  "base": "479d8b89d4391023972eac0a0eb5b16d0bf9aafb",
+  "base": "903151ee679ae81c7817341478a26ec1f6b2c4df",
   "brackets_reaching_no_collection": 3,
   "frame_tier1_calls": 0,
   "frame_tier1_calls_fns": 0,
-  "frames_across_collecting": 9,
+  "frames_across_collecting": 10,
   "frames_across_collecting_fns": 4,
   "tier15_calls": 0,
   "tier15_calls_fns": 0,
   "tier1_calls": 9,
   "tier1_calls_fns": 7,
-  "unbracketed_calls": 2065,
-  "unbracketed_calls_fns": 825,
+  "unbracketed_calls": 2073,
+  "unbracketed_calls_fns": 830,
   "unmatched_seeds": [
     "majit_gc::standalone_alloc_fast_nursery_collecting_typed_rooted",
     "majit_gc::standalone_alloc_nursery_collecting_typed_rooted"

--- a/majit/gc-root-brackets.baseline.json
+++ b/majit/gc-root-brackets.baseline.json
@@ -1,4 +1,5 @@
 {
+  "base": "479d8b89d4391023972eac0a0eb5b16d0bf9aafb",
   "brackets_reaching_no_collection": 3,
   "frame_tier1_calls": 0,
   "frame_tier1_calls_fns": 0,
@@ -8,8 +9,8 @@
   "tier15_calls_fns": 0,
   "tier1_calls": 9,
   "tier1_calls_fns": 7,
-  "unbracketed_calls": 2057,
-  "unbracketed_calls_fns": 821,
+  "unbracketed_calls": 2065,
+  "unbracketed_calls_fns": 825,
   "unmatched_seeds": [
     "majit_gc::standalone_alloc_fast_nursery_collecting_typed_rooted",
     "majit_gc::standalone_alloc_nursery_collecting_typed_rooted"

--- a/majit/gc-root-brackets.baseline.json
+++ b/majit/gc-root-brackets.baseline.json
@@ -8,8 +8,8 @@
   "tier15_calls_fns": 0,
   "tier1_calls": 9,
   "tier1_calls_fns": 7,
-  "unbracketed_calls": 2068,
-  "unbracketed_calls_fns": 828,
+  "unbracketed_calls": 2057,
+  "unbracketed_calls_fns": 821,
   "unmatched_seeds": [
     "majit_gc::standalone_alloc_fast_nursery_collecting_typed_rooted",
     "majit_gc::standalone_alloc_nursery_collecting_typed_rooted"

--- a/majit/gc-root-brackets.baseline.json
+++ b/majit/gc-root-brackets.baseline.json
@@ -1,18 +1,38 @@
 {
-  "base": "903151ee679ae81c7817341478a26ec1f6b2c4df",
-  "brackets_reaching_no_collection": 3,
-  "frame_tier1_calls": 0,
-  "frame_tier1_calls_fns": 0,
-  "frames_across_collecting": 10,
-  "frames_across_collecting_fns": 4,
-  "tier15_calls": 0,
-  "tier15_calls_fns": 0,
-  "tier1_calls": 9,
-  "tier1_calls_fns": 7,
-  "unbracketed_calls": 2073,
-  "unbracketed_calls_fns": 830,
-  "unmatched_seeds": [
-    "majit_gc::standalone_alloc_fast_nursery_collecting_typed_rooted",
-    "majit_gc::standalone_alloc_nursery_collecting_typed_rooted"
-  ]
+  "darwin": {
+    "base": "903151ee679ae81c7817341478a26ec1f6b2c4df",
+    "brackets_reaching_no_collection": 3,
+    "frame_tier1_calls": 0,
+    "frame_tier1_calls_fns": 0,
+    "frames_across_collecting": 10,
+    "frames_across_collecting_fns": 4,
+    "tier15_calls": 0,
+    "tier15_calls_fns": 0,
+    "tier1_calls": 9,
+    "tier1_calls_fns": 7,
+    "unbracketed_calls": 2073,
+    "unbracketed_calls_fns": 830,
+    "unmatched_seeds": [
+      "majit_gc::standalone_alloc_fast_nursery_collecting_typed_rooted",
+      "majit_gc::standalone_alloc_nursery_collecting_typed_rooted"
+    ]
+  },
+  "linux": {
+    "base": "903151ee679ae81c7817341478a26ec1f6b2c4df",
+    "brackets_reaching_no_collection": 3,
+    "frame_tier1_calls": 0,
+    "frame_tier1_calls_fns": 0,
+    "frames_across_collecting": 10,
+    "frames_across_collecting_fns": 4,
+    "tier15_calls": 0,
+    "tier15_calls_fns": 0,
+    "tier1_calls": 9,
+    "tier1_calls_fns": 7,
+    "unbracketed_calls": 2078,
+    "unbracketed_calls_fns": 832,
+    "unmatched_seeds": [
+      "majit_gc::standalone_alloc_fast_nursery_collecting_typed_rooted",
+      "majit_gc::standalone_alloc_nursery_collecting_typed_rooted"
+    ]
+  }
 }

--- a/majit/gc-root-brackets.baseline.json
+++ b/majit/gc-root-brackets.baseline.json
@@ -1,0 +1,17 @@
+{
+  "brackets_reaching_no_collection": 3,
+  "frame_tier1_calls": 0,
+  "frame_tier1_calls_fns": 0,
+  "frames_across_collecting": 9,
+  "frames_across_collecting_fns": 4,
+  "tier15_calls": 0,
+  "tier15_calls_fns": 0,
+  "tier1_calls": 9,
+  "tier1_calls_fns": 7,
+  "unbracketed_calls": 2068,
+  "unbracketed_calls_fns": 828,
+  "unmatched_seeds": [
+    "majit_gc::standalone_alloc_fast_nursery_collecting_typed_rooted",
+    "majit_gc::standalone_alloc_nursery_collecting_typed_rooted"
+  ]
+}

--- a/majit/majit-translate/examples/gc-root-reachability.rs
+++ b/majit/majit-translate/examples/gc-root-reachability.rs
@@ -218,21 +218,30 @@ fn main() {
             cg.indirect.len()
         );
 
-        // Judge the hand-written brackets: a `push_roots()` scope can only be
-        // protecting against a collection if its own function can reach one.
-        // This is a *necessary* condition, so a function that fails it holds a
-        // bracket that nothing in this crate can justify.
+        // Judge the hand-written brackets: a root scope can only be protecting
+        // against a collection if its own function can reach one.  This is a
+        // *necessary* condition, so a function that fails it holds a bracket
+        // that nothing in this crate can justify.
+        //
+        // Two functions open one.  `push_roots` is the naive per-operation
+        // bracket `shadowstack.py` emits; `enter_roots_frame` is the single
+        // coloured frame `shadowcolor.py`'s passes reduce a graph to, which
+        // `#[gc_roots]` produces.  A scan that knew only the first would read
+        // every transformed function as unbracketed -- and would go quieter,
+        // not louder, as more of the interpreter moved across.
         let pin_ids: Vec<u64> = cg
             .names
             .iter()
-            .filter(|(_, n)| n.ends_with("gc_roots::push_roots"))
+            .filter(|(_, n)| {
+                n.ends_with("gc_roots::push_roots") || n.ends_with("gc_roots::enter_roots_frame")
+            })
             .map(|(&id, _)| id)
             .collect();
         if pin_ids.is_empty() {
             // Not a reason to stop: an artefact that brackets nothing is the
             // one most likely to hold defects, and the liveness scan below is
             // exactly what answers for it.
-            println!("   (no gc_roots::push_roots in this artefact's name table)");
+            println!("   (no gc_roots root-scope opener in this artefact's name table)");
         }
         let mut bracketed: Vec<u64> = cg
             .callees

--- a/majit/majit-translate/src/memory/gctransform/framework.rs
+++ b/majit/majit-translate/src/memory/gctransform/framework.rs
@@ -213,7 +213,9 @@ pub const COLLECTING_SEEDS: &[&str] = &[
     "majit_gc::alloc_fast_nursery_collecting_typed_rooted",
     "majit_gc::standalone_alloc_nursery_collecting_typed_rooted",
     "majit_gc::standalone_alloc_fast_nursery_collecting_typed_rooted",
-    "majit_gc::collect_full",
+    // The generation-carrying entry every backend trampoline dispatches to;
+    // `collect_full` is its `gen = 2` shim and no extracted crate calls it.
+    "majit_gc::collect_generation",
     "majit_gc::collect_step",
     "majit_gc::collect_oldgen_nonmoving",
     // The host hook the interpreter reaches them through.

--- a/majit/majit-translate/src/memory/gctransform/mod.rs
+++ b/majit/majit-translate/src/memory/gctransform/mod.rs
@@ -8,12 +8,10 @@
 //! `pypy/objspace/std/listobject.py descr_index` names its receiver and its
 //! needle as plain locals.
 //!
-//! pyre's interpreter is compiled by rustc, so there is no flow graph for a
-//! `hop.genop` to write into and the bracket is written by hand
-//! (`pyre_object::gc_roots`).  What this module ports is therefore the
-//! *analysis* half: the same questions, answered over the ULLBC charon emits
-//! for those crates, so a hand-written bracket can be checked instead of
-//! trusted.
+//! pyre's interpreter is compiled by rustc, so its hand-written bracket is
+//! checked over ULLBC by [`liveness`].  The generated translator graph is a
+//! separate owner: [`shadowcolor`] is the strict flowspace-graph port used
+//! after `gc_push_roots` / `gc_pop_roots` have been emitted there.
 //!
 //! # Why not the insertion half
 //!
@@ -28,9 +26,10 @@
 //! *answer* `framework.py`'s question about that code, but nothing written
 //! back into it would reach the binary.
 //!
-//! So the hand-written brackets stay, and this module exists to stop them
-//! being taken on trust: `liveness::scan` reports the calls that can collect
-//! with a GC pointer live across them and no bracket, and reports what it had
-//! to withhold rather than counting it clean.
+//! So the hand-written brackets stay, and `liveness::scan` reports the calls
+//! that can collect with a GC pointer live across them and no bracket.  This
+//! does not replace the ordinary translator-side transformation: that remains
+//! the flow-graph algorithm in `shadowcolor.py`, ported by [`shadowcolor`].
 pub mod framework;
 pub mod liveness;
+pub mod shadowcolor;

--- a/majit/majit-translate/src/memory/gctransform/shadowcolor.rs
+++ b/majit/majit-translate/src/memory/gctransform/shadowcolor.rs
@@ -1,0 +1,1562 @@
+//! Strict port of `rpython/memory/gctransform/shadowcolor.py`.
+//!
+//! The pass runs on the original flowspace graph, after
+//! `gc_push_roots`/`gc_pop_roots` insertion and before backend lowering.  Rust
+//! uses `Rc<RefCell<_>>` identity wrappers where upstream uses Python object
+//! identity; the graph algorithm and its phase ordering are otherwise kept at
+//! the upstream symbols named below.
+
+#![expect(
+    clippy::mutable_key_type,
+    reason = "RPython keys these tables by Variable/Constant object identity; their Rust hashes exclude the mutable annotation and concretetype cells"
+)]
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+
+use crate::flowspace::model::{
+    Block, BlockKey, BlockRef, BlockRefExt, ConstValue, Constant, FunctionGraph, Hlvalue, Link,
+    LinkKey, LinkRef, SpaceOperation, Variable, checkgraph, mkentrymap,
+};
+use crate::tool::algo::regalloc::{FlowRegAllocator, perform_flowspace_register_allocation};
+use crate::tool::algo::unionfind::UnionFind;
+use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
+use crate::translator::simplify::join_blocks;
+use crate::translator::unsimplify::{
+    insert_empty_block, insert_empty_startblock, split_block, varoftype,
+};
+
+type VarSet = FxHashSet<Variable>;
+type VarMap<T> = FxHashMap<Variable, T>;
+
+/// `shadowcolor.py::GCBitmaskTooLong`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GCBitmaskTooLong {
+    graph: String,
+}
+
+impl fmt::Display for GCBitmaskTooLong {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "the graph {:?} is too complex: cannot create a bitmask telling than more than 31/63 shadowstack entries are unused",
+            self.graph
+        )
+    }
+}
+
+impl std::error::Error for GCBitmaskTooLong {}
+
+/// `shadowcolor.py::PostProcessCheckError`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PostProcessCheckError(pub String);
+
+impl fmt::Display for PostProcessCheckError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for PostProcessCheckError {}
+
+/// `shadowcolor.py::is_trivial_rewrite`.
+pub fn is_trivial_rewrite(op: &SpaceOperation) -> bool {
+    matches!(
+        op.opname.as_str(),
+        "same_as" | "cast_pointer" | "cast_opaque_ptr"
+    ) && matches!(op.args.first(), Some(Hlvalue::Variable(_)))
+}
+
+/// `shadowcolor.py::find_predecessors`.
+pub fn find_predecessors(
+    graph: &mut FunctionGraph,
+    mut pending_pred: Vec<(BlockRef, Variable)>,
+) -> VarSet {
+    let mut entrymap = mkentrymap(graph);
+    if entrymap
+        .get(&BlockKey::of(&graph.startblock))
+        .map_or(0, Vec::len)
+        != 1
+    {
+        insert_empty_startblock(graph);
+        entrymap = mkentrymap(graph);
+    }
+
+    let mut pred: VarSet = pending_pred.iter().map(|(_, var)| var.clone()).collect();
+    while let Some((block, var)) = pending_pred.pop() {
+        let input_index = block
+            .borrow()
+            .inputargs
+            .iter()
+            .position(|value| value == &Hlvalue::Variable(var.clone()));
+        if let Some(var_index) = input_index {
+            for link in entrymap.get(&BlockKey::of(&block)).into_iter().flatten() {
+                let link = link.borrow();
+                let Some(prevblock) = link.prevblock.as_ref().and_then(|weak| weak.upgrade())
+                else {
+                    continue;
+                };
+                if let Some(Some(Hlvalue::Variable(source))) = link.args.get(var_index)
+                    && pred.insert(source.clone())
+                {
+                    pending_pred.push((prevblock, source.clone()));
+                }
+            }
+        } else {
+            let operations = block.borrow().operations.clone();
+            for op in operations {
+                if op.result == Hlvalue::Variable(var.clone()) {
+                    if is_trivial_rewrite(&op)
+                        && let Hlvalue::Variable(source) = &op.args[0]
+                        && pred.insert(source.clone())
+                    {
+                        pending_pred.push((block.clone(), source.clone()));
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    pred
+}
+
+/// `shadowcolor.py::find_successors`.
+pub fn find_successors(
+    _graph: &FunctionGraph,
+    mut pending_succ: Vec<(BlockRef, Variable)>,
+) -> VarSet {
+    let mut succ: VarSet = pending_succ.iter().map(|(_, var)| var.clone()).collect();
+    while let Some((block, var)) = pending_succ.pop() {
+        let (operations, exits) = {
+            let block = block.borrow();
+            (block.operations.clone(), block.exits.clone())
+        };
+        for op in operations {
+            if op.args.first() == Some(&Hlvalue::Variable(var.clone()))
+                && is_trivial_rewrite(&op)
+                && let Hlvalue::Variable(result) = &op.result
+                && succ.insert(result.clone())
+            {
+                pending_succ.push((block.clone(), result.clone()));
+            }
+        }
+        for link in exits {
+            let (args, target) = {
+                let link = link.borrow();
+                (link.args.clone(), link.target.clone().expect("link.target"))
+            };
+            for (index, value) in args.iter().enumerate() {
+                if value.as_ref() == Some(&Hlvalue::Variable(var.clone()))
+                    && let Hlvalue::Variable(target_var) = &target.borrow().inputargs[index]
+                    && succ.insert(target_var.clone())
+                {
+                    pending_succ.push((target.clone(), target_var.clone()));
+                }
+            }
+        }
+    }
+    succ
+}
+
+/// `shadowcolor.py::find_interesting_variables`.
+pub fn find_interesting_variables(graph: &mut FunctionGraph) -> Option<VarSet> {
+    let mut pending_pred = Vec::new();
+    let mut pending_succ = Vec::new();
+    let mut interesting_vars = VarSet::default();
+    for block in graph.iterblocks() {
+        for op in &block.borrow().operations {
+            if op.opname == "gc_push_roots" {
+                for value in &op.args {
+                    if let Hlvalue::Variable(var) = value {
+                        interesting_vars.insert(var.clone());
+                        pending_pred.push((block.clone(), var.clone()));
+                    }
+                }
+            } else if op.opname == "gc_pop_roots" {
+                for value in &op.args {
+                    if let Hlvalue::Variable(var) = value {
+                        assert!(
+                            interesting_vars.contains(var),
+                            "root must be pushed just above"
+                        );
+                        pending_succ.push((block.clone(), var.clone()));
+                    }
+                }
+            }
+        }
+    }
+    if interesting_vars.is_empty() {
+        return None;
+    }
+    let pred = find_predecessors(graph, pending_pred);
+    let succ = find_successors(graph, pending_succ);
+    interesting_vars.extend(pred.intersection(&succ).cloned());
+    Some(interesting_vars)
+}
+
+/// `shadowcolor.py::allocate_registers`.
+pub fn allocate_registers(graph: &mut FunctionGraph) -> Option<FlowRegAllocator> {
+    let interesting_vars = find_interesting_variables(graph)?;
+    Some(perform_flowspace_register_allocation(graph, &|var| {
+        interesting_vars.contains(var)
+    }))
+}
+
+fn signed_constant(value: i64) -> Hlvalue {
+    Hlvalue::Constant(Constant::with_concretetype(
+        ConstValue::Int(value),
+        LowLevelType::Signed,
+    ))
+}
+
+/// `shadowcolor.py::_gc_save_root`.
+fn gc_save_root(index: usize, value: Hlvalue) -> SpaceOperation {
+    SpaceOperation::new(
+        "gc_save_root",
+        vec![signed_constant(index as i64), value],
+        Hlvalue::Variable(varoftype(LowLevelType::Void, None)),
+    )
+}
+
+/// `shadowcolor.py::_gc_restore_root`.
+fn gc_restore_root(index: usize, value: Hlvalue) -> SpaceOperation {
+    SpaceOperation::new(
+        "gc_restore_root",
+        vec![signed_constant(index as i64), value],
+        Hlvalue::Variable(varoftype(LowLevelType::Void, None)),
+    )
+}
+
+/// `shadowcolor.py::make_bitmask`.
+pub fn make_bitmask(
+    filled: &[bool],
+    graph: impl Into<String>,
+) -> Result<(Option<usize>, Option<i64>), GCBitmaskTooLong> {
+    let graph = graph.into();
+    if filled.iter().all(|filled| *filled) {
+        return Ok((None, None));
+    }
+    let mut bitmask: u128 = 0;
+    let mut last_index = 0;
+    for (index, is_filled) in filled.iter().enumerate() {
+        if !is_filled {
+            let shift = index - last_index;
+            if bitmask != 0
+                && (shift >= isize::BITS as usize || bitmask > (isize::MAX as u128 >> shift))
+            {
+                return Err(GCBitmaskTooLong { graph });
+            }
+            bitmask <<= shift;
+            last_index = index;
+            bitmask |= 1;
+        }
+    }
+    assert_eq!(bitmask & 1, 1);
+    if bitmask > isize::MAX as u128 {
+        return Err(GCBitmaskTooLong { graph });
+    }
+    let bitmask = bitmask as i64;
+    assert!(bitmask > 0);
+    Ok((Some(last_index), Some(bitmask)))
+}
+
+/// `shadowcolor.py::expand_one_push_roots`.
+pub fn expand_one_push_roots(
+    regalloc: Option<&FlowRegAllocator>,
+    args: &[Variable],
+    graph: &str,
+) -> Result<Vec<SpaceOperation>, GCBitmaskTooLong> {
+    let Some(regalloc) = regalloc else {
+        assert!(args.is_empty());
+        return Ok(Vec::new());
+    };
+    let mut filled = vec![false; regalloc.numcolors];
+    let mut result = Vec::new();
+    for var in args {
+        let index = regalloc.getcolor(var);
+        assert!(!filled[index]);
+        filled[index] = true;
+        result.push(gc_save_root(index, Hlvalue::Variable(var.clone())));
+    }
+    let (bitmask_index, bitmask) = make_bitmask(&filled, graph)?;
+    if let (Some(bitmask_index), Some(bitmask)) = (bitmask_index, bitmask) {
+        result.push(gc_save_root(bitmask_index, signed_constant(bitmask)));
+    }
+    Ok(result)
+}
+
+/// `shadowcolor.py::expand_one_pop_roots`.
+pub fn expand_one_pop_roots(
+    regalloc: Option<&FlowRegAllocator>,
+    args: &[Variable],
+) -> Vec<SpaceOperation> {
+    let Some(regalloc) = regalloc else {
+        assert!(args.is_empty());
+        return Vec::new();
+    };
+    args.iter()
+        .map(|var| gc_restore_root(regalloc.getcolor(var), Hlvalue::Variable(var.clone())))
+        .collect()
+}
+
+/// `shadowcolor.py::expand_push_roots`.
+pub fn expand_push_roots(
+    graph: &FunctionGraph,
+    regalloc: Option<&FlowRegAllocator>,
+) -> Result<(), GCBitmaskTooLong> {
+    for block in graph.iterblocks() {
+        let operations = block.borrow().operations.clone();
+        let mut any_change = false;
+        let mut newops = Vec::new();
+        for op in operations {
+            if op.opname == "gc_push_roots" {
+                let args: Vec<_> = op
+                    .args
+                    .iter()
+                    .filter_map(|value| match value {
+                        Hlvalue::Variable(var) => Some(var.clone()),
+                        _ => None,
+                    })
+                    .collect();
+                newops.extend(expand_one_push_roots(regalloc, &args, &graph.name)?);
+                any_change = true;
+            } else {
+                newops.push(op);
+            }
+        }
+        if any_change {
+            block.borrow_mut().operations = newops;
+        }
+    }
+    Ok(())
+}
+
+fn constant_int(value: &Hlvalue) -> Option<i64> {
+    match value {
+        Hlvalue::Constant(Constant {
+            value: ConstValue::Int(value),
+            ..
+        }) => Some(*value),
+        _ => None,
+    }
+}
+
+fn is_signed_constant(value: &Hlvalue) -> bool {
+    matches!(
+        value,
+        Hlvalue::Constant(Constant {
+            concretetype: Some(LowLevelType::Signed),
+            ..
+        })
+    )
+}
+
+#[derive(Clone)]
+struct SaveSite {
+    block_key: BlockKey,
+    block: BlockRef,
+    operation: SpaceOperation,
+}
+
+impl PartialEq for SaveSite {
+    fn eq(&self, other: &Self) -> bool {
+        self.block_key == other.block_key && self.operation == other.operation
+    }
+}
+
+impl Eq for SaveSite {}
+
+impl std::hash::Hash for SaveSite {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::hash::Hash::hash(&self.block_key, state);
+        std::hash::Hash::hash(&self.operation, state);
+    }
+}
+
+struct PushPart {
+    index: usize,
+    variables: VarSet,
+    save_sites: HashSet<SaveSite>,
+}
+
+/// `shadowcolor.py::move_pushes_earlier`.
+pub fn move_pushes_earlier(graph: &FunctionGraph, regalloc: Option<&FlowRegAllocator>) {
+    let Some(regalloc) = regalloc else {
+        return;
+    };
+
+    let entrymap = mkentrymap(graph);
+    assert_eq!(entrymap[&BlockKey::of(&graph.startblock)].len(), 1);
+
+    let mut inputvars: VarMap<(BlockRef, usize)> = VarMap::default();
+    for block in graph.iterblocks() {
+        for (index, value) in block.borrow().inputargs.iter().enumerate() {
+            if let Hlvalue::Variable(var) = value {
+                inputvars.insert(var.clone(), (block.clone(), index));
+            }
+        }
+    }
+
+    let mut parts = Vec::new();
+    for index in 0..regalloc.numcolors {
+        let mut unionfind = UnionFind::new(|_: &Variable| ());
+        let mut successors = VarSet::default();
+
+        for block in graph.iterblocks() {
+            let operations = block.borrow().operations.clone();
+            let Some(pop) = operations
+                .iter()
+                .rev()
+                .find(|operation| operation.opname == "gc_pop_roots")
+            else {
+                continue;
+            };
+            let Some(var) = pop.args.iter().find_map(|value| match value {
+                Hlvalue::Variable(var) if regalloc.checkcolor(var, index) => Some(var.clone()),
+                _ => None,
+            }) else {
+                continue;
+            };
+
+            let mut succ = VarSet::default();
+            let mut pending_succ = vec![(block.clone(), var)];
+            while let Some((block1, var1)) = pending_succ.pop() {
+                assert!(regalloc.checkcolor(&var1, index));
+                let (operations, exits) = {
+                    let block1 = block1.borrow();
+                    (block1.operations.clone(), block1.exits.clone())
+                };
+                for operation in operations {
+                    if is_trivial_rewrite(&operation)
+                        && operation.args[0] == Hlvalue::Variable(var1.clone())
+                        && let Hlvalue::Variable(result) = operation.result
+                        && regalloc.checkcolor(&result, index)
+                    {
+                        pending_succ.push((block1.clone(), result));
+                    }
+                }
+                for link in exits {
+                    let (args, target) = {
+                        let link = link.borrow();
+                        (link.args.clone(), link.target.clone().expect("link.target"))
+                    };
+                    for (arg_index, value) in args.iter().enumerate() {
+                        if value.as_ref() != Some(&Hlvalue::Variable(var1.clone())) {
+                            continue;
+                        }
+                        let Hlvalue::Variable(target_var) =
+                            target.borrow().inputargs[arg_index].clone()
+                        else {
+                            continue;
+                        };
+                        if succ.contains(&target_var) || !regalloc.checkcolor(&target_var, index) {
+                            continue;
+                        }
+                        succ.insert(target_var.clone());
+                        let has_barrier = target.borrow().operations.iter().any(|operation| {
+                            matches!(operation.opname.as_str(), "gc_save_root" | "gc_pop_roots")
+                        });
+                        if !has_barrier {
+                            pending_succ.push((target.clone(), target_var));
+                        }
+                    }
+                }
+            }
+            let succ_list: Vec<_> = succ.iter().cloned().collect();
+            unionfind.union_list(&succ_list);
+            successors.extend(succ);
+        }
+
+        let mut save_sites_by_pred: VarMap<HashSet<SaveSite>> = VarMap::default();
+        for block in graph.iterblocks() {
+            let operations = block.borrow().operations.clone();
+            let mut found = None;
+            for (opindex, operation) in operations.iter().enumerate() {
+                if operation.opname != "gc_save_root" {
+                    continue;
+                }
+                if is_signed_constant(&operation.args[1]) {
+                    break;
+                }
+                if constant_int(&operation.args[0]) == Some(index as i64) {
+                    found = Some((opindex, operation.clone()));
+                    break;
+                }
+            }
+            let Some((opindex, operation)) = found else {
+                continue;
+            };
+            let Hlvalue::Variable(saved_var) = operation.args[1].clone() else {
+                continue;
+            };
+            let site = SaveSite {
+                block_key: BlockKey::of(&block),
+                block: block.clone(),
+                operation,
+            };
+            let mut pred = VarSet::default();
+            let mut pending_pred = vec![(block.clone(), saved_var, opindex)];
+            while let Some((block1, mut var1, opindex1)) = pending_pred.pop() {
+                assert_eq!(regalloc.getcolor(&var1), index);
+                let operations = block1.borrow().operations.clone();
+                let mut reached_input = true;
+                for operation in operations[..opindex1].iter().rev() {
+                    if operation.opname == "gc_pop_roots" {
+                        reached_input = false;
+                        break;
+                    }
+                    if operation.result == Hlvalue::Variable(var1.clone()) {
+                        if !is_trivial_rewrite(operation) {
+                            reached_input = false;
+                            break;
+                        }
+                        let Hlvalue::Variable(source) = &operation.args[0] else {
+                            reached_input = false;
+                            break;
+                        };
+                        if !regalloc.checkcolor(source, index) {
+                            reached_input = false;
+                            break;
+                        }
+                        var1 = source.clone();
+                    }
+                }
+                if !reached_input {
+                    continue;
+                }
+                let varindex = block1
+                    .borrow()
+                    .inputargs
+                    .iter()
+                    .position(|value| value == &Hlvalue::Variable(var1.clone()))
+                    .expect("predecessor variable is a block input");
+                if !pred.insert(var1.clone()) {
+                    continue;
+                }
+                for link in entrymap.get(&BlockKey::of(&block1)).into_iter().flatten() {
+                    let link = link.borrow();
+                    let Some(prevblock) = link.prevblock.as_ref().and_then(|weak| weak.upgrade())
+                    else {
+                        continue;
+                    };
+                    if let Some(Some(Hlvalue::Variable(source))) = link.args.get(varindex)
+                        && !pred.contains(source)
+                        && regalloc.checkcolor(source, index)
+                    {
+                        pending_pred.push((
+                            prevblock.clone(),
+                            source.clone(),
+                            prevblock.borrow().operations.len(),
+                        ));
+                    }
+                }
+            }
+            let pred_list: Vec<_> = pred.iter().cloned().collect();
+            unionfind.union_list(&pred_list);
+            for var in pred {
+                save_sites_by_pred
+                    .entry(var)
+                    .or_default()
+                    .insert(site.clone());
+            }
+        }
+
+        let matching: Vec<_> = successors
+            .intersection(&save_sites_by_pred.keys().cloned().collect())
+            .cloned()
+            .collect();
+        let mut part_index_by_rep: VarMap<usize> = VarMap::default();
+        for var in matching {
+            let representative = unionfind.find_rep(var.clone());
+            let part_index = if let Some(part_index) = part_index_by_rep.get(&representative) {
+                *part_index
+            } else {
+                let part_index = parts.len();
+                parts.push(PushPart {
+                    index,
+                    variables: VarSet::default(),
+                    save_sites: HashSet::new(),
+                });
+                part_index_by_rep.insert(representative, part_index);
+                part_index
+            };
+            let part = &mut parts[part_index];
+            part.variables.insert(var.clone());
+            part.save_sites
+                .extend(save_sites_by_pred[&var].iter().cloned());
+        }
+    }
+
+    parts.sort_by(|left, right| {
+        let left = left.variables.len() as f64 / left.save_sites.len() as f64;
+        let right = right.variables.len() as f64 / right.save_sites.len() as f64;
+        left.partial_cmp(&right).unwrap()
+    });
+
+    let mut variables_along_changes: VarMap<(BlockRef, usize)> = VarMap::default();
+    let mut live_at_start_of_block: HashSet<(BlockKey, usize)> = HashSet::new();
+    let mut insert_gc_push_root: HashMap<LinkKey, (LinkRef, Vec<(usize, Hlvalue)>)> =
+        HashMap::new();
+
+    for part in parts {
+        if part.variables.iter().any(|var| {
+            let block = &inputvars[var].0;
+            live_at_start_of_block.contains(&(BlockKey::of(block), part.index))
+        }) {
+            continue;
+        }
+        if part
+            .save_sites
+            .iter()
+            .any(|site| !site.block.borrow().operations.contains(&site.operation))
+        {
+            continue;
+        }
+        for var in &part.variables {
+            assert_eq!(regalloc.getcolor(var), part.index);
+            assert!(!variables_along_changes.contains_key(var));
+        }
+
+        let mut success_count = 0;
+        let mut mark = Vec::new();
+        for var in &part.variables {
+            let (block, varindex) = &inputvars[var];
+            for link in entrymap.get(&BlockKey::of(block)).into_iter().flatten() {
+                let mut value = link.borrow().args[*varindex].clone();
+                let prevoperations = link
+                    .borrow()
+                    .prevblock
+                    .as_ref()
+                    .and_then(|weak| weak.upgrade())
+                    .map(|block| block.borrow().operations.clone())
+                    .unwrap_or_default();
+                let mut decided = false;
+                for operation in prevoperations.iter().rev() {
+                    if operation.opname == "gc_pop_roots" {
+                        if let Some(Hlvalue::Variable(value_var)) = &value {
+                            if operation
+                                .args
+                                .contains(&Hlvalue::Variable(value_var.clone()))
+                                && regalloc.checkcolor(value_var, part.index)
+                            {
+                                success_count += 1;
+                            } else {
+                                mark.push((part.index, link.clone(), *varindex));
+                            }
+                        } else {
+                            mark.push((part.index, link.clone(), *varindex));
+                        }
+                        decided = true;
+                        break;
+                    }
+                    if value.as_ref() == Some(&operation.result) {
+                        if is_trivial_rewrite(operation)
+                            && let Hlvalue::Variable(source) = &operation.args[0]
+                            && regalloc.checkcolor(source, part.index)
+                        {
+                            value = Some(Hlvalue::Variable(source.clone()));
+                        } else {
+                            mark.push((part.index, link.clone(), *varindex));
+                            decided = true;
+                            break;
+                        }
+                    }
+                }
+                if !decided {
+                    match value {
+                        Some(Hlvalue::Variable(ref value_var))
+                            if part.variables.contains(value_var) => {}
+                        _ => mark.push((part.index, link.clone(), *varindex)),
+                    }
+                }
+            }
+        }
+
+        if success_count > 0 {
+            for site in &part.save_sites {
+                let mut block = site.block.borrow_mut();
+                let position = block
+                    .operations
+                    .iter()
+                    .position(|operation| operation == &site.operation)
+                    .expect("gc_save_root disappeared");
+                block.operations.remove(position);
+            }
+            for (index, link, varindex) in mark {
+                let value = link.borrow().args[varindex]
+                    .clone()
+                    .expect("root link argument");
+                insert_gc_push_root
+                    .entry(LinkKey::of(&link))
+                    .or_insert_with(|| (link.clone(), Vec::new()))
+                    .1
+                    .push((index, value));
+            }
+            for var in &part.variables {
+                let block = &inputvars[var].0;
+                variables_along_changes.insert(var.clone(), (block.clone(), part.index));
+                live_at_start_of_block.insert((BlockKey::of(block), part.index));
+            }
+        }
+    }
+
+    for (_, (link, mut insertions)) in insert_gc_push_root {
+        insertions.sort_by_key(|(index, _)| *index);
+        let newops = insertions
+            .into_iter()
+            .map(|(index, value)| gc_save_root(index, value))
+            .collect();
+        insert_empty_block(&link, newops);
+    }
+}
+
+/// `shadowcolor.py::expand_pop_roots`.
+pub fn expand_pop_roots(graph: &FunctionGraph, regalloc: Option<&FlowRegAllocator>) {
+    let mut drop: VarMap<i64> = VarMap::default();
+    for block in graph.iterblocks() {
+        let operations = block.borrow().operations.clone();
+        let mut any_change = false;
+        let mut newops = Vec::new();
+        for operation in operations {
+            if operation.opname == "gc_pop_roots" {
+                let args: Vec<_> = operation
+                    .args
+                    .iter()
+                    .filter_map(|value| match value {
+                        Hlvalue::Variable(var) => Some(var.clone()),
+                        _ => None,
+                    })
+                    .collect();
+                let expanded = expand_one_pop_roots(regalloc, &args);
+                drop.clear();
+                for restore in &expanded {
+                    if let Hlvalue::Variable(var) = &restore.args[1] {
+                        drop.insert(var.clone(), constant_int(&restore.args[0]).unwrap());
+                    }
+                }
+                newops.extend(expanded);
+                any_change = true;
+            } else if operation.opname == "gc_save_root"
+                && matches!(
+                    &operation.args[1],
+                    Hlvalue::Variable(var)
+                        if drop.get(var).copied() == constant_int(&operation.args[0])
+                )
+            {
+                any_change = true;
+            } else {
+                newops.push(operation);
+            }
+        }
+        if any_change {
+            block.borrow_mut().operations = newops;
+        }
+    }
+}
+
+fn is_interesting_frame_op(operation: &SpaceOperation, bitmask_all_free: Option<i64>) -> bool {
+    if operation.opname == "gc_restore_root" {
+        return true;
+    }
+    operation.opname == "gc_save_root"
+        && !(is_signed_constant(&operation.args[1])
+            && constant_int(&operation.args[1]) == bitmask_all_free)
+}
+
+fn insert_along_link(
+    link: &LinkRef,
+    opname: &str,
+    args: &[Hlvalue],
+    cache: &mut HashMap<BlockKey, BlockRef>,
+) {
+    let target = link.borrow().target.clone().expect("link.target");
+    let target_key = BlockKey::of(&target);
+    let newblock = cache.entry(target_key).or_insert_with(|| {
+        let inputargs = target
+            .borrow()
+            .inputargs
+            .iter()
+            .map(|value| match value {
+                Hlvalue::Variable(var) => Hlvalue::Variable(var.copy()),
+                Hlvalue::Constant(constant) => Hlvalue::Constant(constant.clone()),
+            })
+            .collect::<Vec<_>>();
+        let newblock = Block::shared(inputargs.clone());
+        newblock.borrow_mut().operations.push(SpaceOperation::new(
+            opname,
+            args.to_vec(),
+            Hlvalue::Variable(varoftype(LowLevelType::Void, None)),
+        ));
+        newblock.closeblock(vec![
+            Link::new(inputargs, Some(target.clone()), None).into_ref(),
+        ]);
+        newblock
+    });
+    link.borrow_mut().target = Some(newblock.clone());
+}
+
+/// `shadowcolor.py::add_enter_leave_roots_frame`.
+pub fn add_enter_leave_roots_frame(
+    graph: &mut FunctionGraph,
+    regalloc: Option<&FlowRegAllocator>,
+    c_gcdata: Hlvalue,
+) {
+    let Some(regalloc) = regalloc else {
+        return;
+    };
+
+    for block in graph.iterblocks() {
+        let last_restore = block
+            .borrow()
+            .operations
+            .iter()
+            .rposition(|operation| operation.opname == "gc_restore_root");
+        if let Some(index) = last_restore
+            && index + 1 < block.borrow().operations.len()
+        {
+            split_block(&block, index + 1, None);
+        }
+    }
+
+    insert_empty_startblock(graph);
+    let entrymap = mkentrymap(graph);
+    let bitmask_all_free = 1_u64
+        .checked_shl(regalloc.numcolors as u32)
+        .and_then(|value| i64::try_from(value - 1).ok());
+
+    let mut interesting_blocks = Vec::new();
+    for block in graph.iterblocks() {
+        if block
+            .borrow()
+            .operations
+            .iter()
+            .any(|operation| is_interesting_frame_op(operation, bitmask_all_free))
+        {
+            assert_ne!(BlockKey::of(&block), BlockKey::of(&graph.startblock));
+            assert_ne!(BlockKey::of(&block), BlockKey::of(&graph.returnblock));
+            interesting_blocks.push(block);
+        }
+    }
+
+    let mut before_blocks = HashSet::new();
+    let mut pending = interesting_blocks.clone();
+    let mut seen: HashSet<_> = interesting_blocks.iter().map(BlockKey::of).collect();
+    while let Some(block) = pending.pop() {
+        for link in &block.borrow().exits {
+            let target = link.borrow().target.clone().expect("link.target");
+            let target_key = BlockKey::of(&target);
+            before_blocks.insert(target_key.clone());
+            if seen.insert(target_key) {
+                pending.push(target);
+            }
+        }
+    }
+    assert!(!before_blocks.contains(&BlockKey::of(&graph.startblock)));
+
+    let mut after_blocks: HashSet<_> = interesting_blocks.iter().map(BlockKey::of).collect();
+    let mut pending = interesting_blocks.clone();
+    while let Some(block) = pending.pop() {
+        for link in entrymap.get(&BlockKey::of(&block)).into_iter().flatten() {
+            if let Some(prevblock) = link
+                .borrow()
+                .prevblock
+                .as_ref()
+                .and_then(|weak| weak.upgrade())
+            {
+                let prev_key = BlockKey::of(&prevblock);
+                if after_blocks.insert(prev_key) {
+                    pending.push(prevblock);
+                }
+            }
+        }
+    }
+    assert!(!after_blocks.contains(&BlockKey::of(&graph.returnblock)));
+
+    let inside_blocks: HashSet<_> = before_blocks.intersection(&after_blocks).cloned().collect();
+    let mut inside_or_interesting_blocks = inside_blocks.clone();
+    inside_or_interesting_blocks.extend(interesting_blocks.iter().map(BlockKey::of));
+
+    let c_num = signed_constant(regalloc.numcolors as i64);
+    for block in &interesting_blocks {
+        if !inside_blocks.contains(&BlockKey::of(block)) {
+            let index = block
+                .borrow()
+                .operations
+                .iter()
+                .position(|operation| is_interesting_frame_op(operation, bitmask_all_free))
+                .unwrap();
+            block.borrow_mut().operations.insert(
+                index,
+                SpaceOperation::new(
+                    "gc_enter_roots_frame",
+                    vec![c_gcdata.clone(), c_num.clone()],
+                    Hlvalue::Variable(varoftype(LowLevelType::Void, None)),
+                ),
+            );
+        }
+    }
+
+    let mut enter_cache = HashMap::new();
+    let mut leave_cache = HashMap::new();
+    for block in graph.iterblocks() {
+        let block_key = BlockKey::of(&block);
+        let exits = block.borrow().exits.clone();
+        if !inside_or_interesting_blocks.contains(&block_key) {
+            for link in exits {
+                let target = link.borrow().target.clone().expect("link.target");
+                if inside_blocks.contains(&BlockKey::of(&target)) {
+                    insert_along_link(
+                        &link,
+                        "gc_enter_roots_frame",
+                        &[c_gcdata.clone(), c_num.clone()],
+                        &mut enter_cache,
+                    );
+                }
+            }
+        } else {
+            for link in exits {
+                let target = link.borrow().target.clone().expect("link.target");
+                if !inside_blocks.contains(&BlockKey::of(&target)) {
+                    insert_along_link(&link, "gc_leave_roots_frame", &[], &mut leave_cache);
+                }
+            }
+        }
+    }
+
+    for block in graph.iterblocks() {
+        if inside_blocks.contains(&BlockKey::of(&block)) {
+            continue;
+        }
+        let operations = block.borrow().operations.clone();
+        let mut newops = Vec::new();
+        for (index, operation) in operations.iter().enumerate() {
+            if operation.opname == "gc_enter_roots_frame" {
+                newops.extend_from_slice(&operations[index..]);
+                break;
+            }
+            if operation.opname != "gc_save_root"
+                || is_interesting_frame_op(operation, bitmask_all_free)
+            {
+                newops.push(operation.clone());
+            }
+        }
+        if newops.len() < operations.len() {
+            block.borrow_mut().operations = newops;
+        }
+    }
+
+    join_blocks(graph);
+}
+
+fn check_error(graph: &FunctionGraph, detail: impl fmt::Display) -> PostProcessCheckError {
+    PostProcessCheckError(format!("{}: {}", graph.name, detail))
+}
+
+/// `shadowcolor.py::postprocess_double_check`.
+pub fn postprocess_double_check(graph: &FunctionGraph) -> Result<(), PostProcessCheckError> {
+    let mut saved: HashMap<Hlvalue, HashSet<i64>> = HashMap::new();
+    let mut in_frame: HashMap<BlockKey, bool> = HashMap::new();
+    let start_key = BlockKey::of(&graph.startblock);
+    in_frame.insert(start_key.clone(), false);
+    let mut pending: HashMap<BlockKey, BlockRef> =
+        HashMap::from([(start_key, graph.startblock.clone())]);
+
+    while let Some(key) = pending.keys().next().cloned() {
+        let block = pending.remove(&key).unwrap();
+        let (inputargs, operations, exits) = {
+            let block = block.borrow();
+            (
+                block.inputargs.clone(),
+                block.operations.clone(),
+                block.exits.clone(),
+            )
+        };
+        let mut locsaved: HashMap<Hlvalue, HashSet<i64>> = HashMap::new();
+        let mut currently_in_frame = in_frame[&key];
+        if currently_in_frame {
+            for value in &inputargs {
+                locsaved.insert(value.clone(), saved[value].clone());
+            }
+        }
+
+        for operation in operations {
+            match operation.opname.as_str() {
+                "gc_restore_root" => {
+                    if !currently_in_frame {
+                        return Err(check_error(graph, "gc_restore_root: no frame!"));
+                    }
+                    if matches!(operation.args[1], Hlvalue::Constant(_)) {
+                        continue;
+                    }
+                    let num = constant_int(&operation.args[0]).unwrap();
+                    if !locsaved
+                        .get(&operation.args[1])
+                        .is_some_and(|locations| locations.contains(&num))
+                    {
+                        return Err(check_error(
+                            graph,
+                            format!("gc_restore_root {num}: root is not saved"),
+                        ));
+                    }
+                }
+                "gc_save_root" => {
+                    if !currently_in_frame {
+                        return Err(check_error(graph, "gc_save_root: no frame!"));
+                    }
+                    let num = constant_int(&operation.args[0]).unwrap();
+                    for locations in locsaved.values_mut() {
+                        locations.remove(&num);
+                    }
+                    match &operation.args[1] {
+                        Hlvalue::Variable(_) => {
+                            locsaved
+                                .entry(operation.args[1].clone())
+                                .or_default()
+                                .insert(num);
+                        }
+                        Hlvalue::Constant(_) if !is_signed_constant(&operation.args[1]) => {
+                            locsaved
+                                .entry(operation.args[1].clone())
+                                .or_default()
+                                .insert(num);
+                        }
+                        Hlvalue::Constant(_) => {
+                            let bitmask = constant_int(&operation.args[1]).unwrap();
+                            if bitmask != 1 {
+                                assert_eq!(bitmask & 1, 1);
+                                assert!(1 < bitmask && bitmask < (2_i64 << num));
+                                let nummask: Vec<_> = (0..=num)
+                                    .filter(|index| bitmask & (1_i64 << (num - index)) != 0)
+                                    .collect();
+                                assert_eq!(nummask.last(), Some(&num));
+                                for locations in locsaved.values_mut() {
+                                    locations.retain(|index| !nummask.contains(index));
+                                }
+                            }
+                        }
+                    }
+                }
+                "gc_enter_roots_frame" => {
+                    if currently_in_frame {
+                        return Err(check_error(graph, "double enter"));
+                    }
+                    currently_in_frame = true;
+                    for value in &inputargs {
+                        locsaved.insert(value.clone(), HashSet::new());
+                    }
+                }
+                "gc_leave_roots_frame" => {
+                    if !currently_in_frame {
+                        return Err(check_error(graph, "not entered"));
+                    }
+                    currently_in_frame = false;
+                }
+                _ if is_trivial_rewrite(&operation) && currently_in_frame => {
+                    let locations = locsaved[&operation.args[0]].clone();
+                    locsaved.insert(operation.result, locations);
+                }
+                _ => {
+                    locsaved.insert(operation.result, HashSet::new());
+                }
+            }
+        }
+
+        for link in exits {
+            let (args, target) = {
+                let link = link.borrow();
+                (link.args.clone(), link.target.clone().expect("link.target"))
+            };
+            let target_key = BlockKey::of(&target);
+            let mut changed = false;
+            match in_frame.get(&target_key) {
+                None => {
+                    in_frame.insert(target_key.clone(), currently_in_frame);
+                    changed = true;
+                }
+                Some(value) if *value != currently_in_frame => {
+                    return Err(check_error(graph, "inconsistent in_frame"));
+                }
+                _ => {}
+            }
+            if currently_in_frame {
+                for (index, value) in args.iter().enumerate() {
+                    let value = value.as_ref().expect("complete graph link argument");
+                    let mut locations = locsaved.get(value).cloned().unwrap_or_else(|| {
+                        assert!(matches!(value, Hlvalue::Constant(_)));
+                        HashSet::new()
+                    });
+                    let target_value = target.borrow().inputargs[index].clone();
+                    if let Some(previous) = saved.get(&target_value) {
+                        if locations == *previous {
+                            continue;
+                        }
+                        locations = locations.intersection(previous).copied().collect();
+                    }
+                    saved.insert(target_value, locations);
+                    changed = true;
+                }
+            }
+            if changed {
+                pending.insert(target_key, target);
+            }
+        }
+    }
+
+    if in_frame
+        .get(&BlockKey::of(&graph.returnblock))
+        .copied()
+        .unwrap_or(false)
+    {
+        return Err(check_error(graph, "missing gc_leave_roots_frame"));
+    }
+    assert!(!saved.contains_key(&graph.getreturnvar()));
+    Ok(())
+}
+
+/// `shadowcolor.py::postprocess_graph`.
+pub fn postprocess_graph(
+    graph: &mut FunctionGraph,
+    c_gcdata: Hlvalue,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let regalloc = allocate_registers(graph);
+    expand_push_roots(graph, regalloc.as_ref())?;
+    move_pushes_earlier(graph, regalloc.as_ref());
+    expand_pop_roots(graph, regalloc.as_ref());
+    add_enter_leave_roots_frame(graph, regalloc.as_ref(), c_gcdata);
+    checkgraph(graph);
+    postprocess_double_check(graph)?;
+    Ok(regalloc.is_some())
+}
+
+/// `shadowcolor.py::postprocess_inlining`.
+pub fn postprocess_inlining(graph: &FunctionGraph) -> Result<(), PostProcessCheckError> {
+    for block in graph.iterblocks() {
+        let operations = block.borrow().operations.clone();
+        for index in (0..operations.len()).rev() {
+            if operations[index].opname == "gc_pop_roots" {
+                break;
+            }
+            if operations[index].opname == "gc_push_roots" {
+                fix_graph_after_inlining(graph, block.clone(), index)?;
+                break;
+            }
+        }
+    }
+    checkgraph(graph);
+    Ok(())
+}
+
+/// `shadowcolor.py::_fix_graph_after_inlining`.
+fn fix_graph_after_inlining(
+    graph: &FunctionGraph,
+    initial_block: BlockRef,
+    initial_index: usize,
+) -> Result<(), PostProcessCheckError> {
+    let operation = initial_block.borrow_mut().operations.remove(initial_index);
+    assert_eq!(operation.opname, "gc_push_roots");
+    let mut seen = HashSet::new();
+    let mut pending = vec![(initial_block, initial_index, operation.args)];
+    while let Some((block, start_index, track_args)) = pending.pop() {
+        if !seen.insert(BlockKey::of(&block)) {
+            continue;
+        }
+        assert!(!block.borrow().is_final_block());
+        let operations = block.borrow().operations.clone();
+        let mut new_operations = operations[..start_index].to_vec();
+        let mut stop = false;
+        for (index, operation) in operations.iter().enumerate().skip(start_index) {
+            if operation.opname == "gc_push_roots" {
+                return Err(check_error(
+                    graph,
+                    "seems to have inlined inside it another graph which also uses GC roots",
+                ));
+            }
+            if operation.opname == "gc_pop_roots" {
+                new_operations.extend_from_slice(&operations[index + 1..]);
+                stop = true;
+                break;
+            }
+            if matches!(operation.opname.as_str(), "direct_call" | "indirect_call") {
+                new_operations.push(SpaceOperation::new(
+                    "gc_push_roots",
+                    track_args.clone(),
+                    Hlvalue::Variable(varoftype(LowLevelType::Void, None)),
+                ));
+                new_operations.push(operation.clone());
+                new_operations.push(SpaceOperation::new(
+                    "gc_pop_roots",
+                    track_args.clone(),
+                    Hlvalue::Variable(varoftype(LowLevelType::Void, None)),
+                ));
+            } else {
+                new_operations.push(operation.clone());
+            }
+        }
+        block.borrow_mut().operations = new_operations;
+        if !stop {
+            for link in block.borrow().exits.clone() {
+                let (args, target) = {
+                    let link = link.borrow();
+                    (link.args.clone(), link.target.clone().expect("link.target"))
+                };
+                let mut track_next = Vec::new();
+                for value in &track_args {
+                    let Hlvalue::Variable(_) = value else {
+                        continue;
+                    };
+                    let index = args
+                        .iter()
+                        .position(|arg| arg.as_ref() == Some(value))
+                        .expect("tracked root must be on link");
+                    track_next.push(target.borrow().inputargs[index].clone());
+                }
+                pending.push((target, 0, track_next));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn void_result() -> Hlvalue {
+        Hlvalue::Variable(varoftype(LowLevelType::Void, None))
+    }
+
+    fn marker(opname: &str, args: Vec<Hlvalue>) -> SpaceOperation {
+        SpaceOperation::new(opname, args, void_result())
+    }
+
+    fn direct_call() -> SpaceOperation {
+        marker(
+            "direct_call",
+            vec![Hlvalue::Constant(Constant::new(ConstValue::Int(0)))],
+        )
+    }
+
+    fn linear_graph(name: &str, input: Variable, operations: Vec<SpaceOperation>) -> FunctionGraph {
+        let start = Block::shared(vec![Hlvalue::Variable(input.clone())]);
+        start.borrow_mut().operations = operations;
+        let graph = FunctionGraph::new(name, start.clone());
+        start.closeblock(vec![
+            Link::new(
+                vec![Hlvalue::Variable(input)],
+                Some(graph.returnblock.clone()),
+                None,
+            )
+            .into_ref(),
+        ]);
+        graph
+    }
+
+    fn opnames(graph: &FunctionGraph) -> Vec<String> {
+        graph
+            .iterblocks()
+            .into_iter()
+            .flat_map(|block| block.borrow().operations.clone())
+            .map(|operation| operation.opname)
+            .collect()
+    }
+
+    #[test]
+    fn trivial_rewrite_matches_shadowcolor() {
+        let source = Variable::named("source");
+        let result = Variable::named("result");
+        assert!(is_trivial_rewrite(&SpaceOperation::new(
+            "same_as",
+            vec![Hlvalue::Variable(source.clone())],
+            Hlvalue::Variable(result.clone()),
+        )));
+        assert!(is_trivial_rewrite(&SpaceOperation::new(
+            "cast_pointer",
+            vec![Hlvalue::Variable(source.clone())],
+            Hlvalue::Variable(result.clone()),
+        )));
+        assert!(!is_trivial_rewrite(&SpaceOperation::new(
+            "int_add",
+            vec![Hlvalue::Variable(source)],
+            Hlvalue::Variable(result),
+        )));
+    }
+
+    #[test]
+    fn predecessor_and_successor_follow_rewrites_and_links() {
+        let source = Variable::named("source");
+        let rewritten = Variable::named("rewritten");
+        let target_input = Variable::named("target");
+        let start = Block::shared(vec![Hlvalue::Variable(source.clone())]);
+        start.borrow_mut().operations.push(SpaceOperation::new(
+            "same_as",
+            vec![Hlvalue::Variable(source.clone())],
+            Hlvalue::Variable(rewritten.clone()),
+        ));
+        let target = Block::shared(vec![Hlvalue::Variable(target_input.clone())]);
+        let graph = FunctionGraph::new("copies", start.clone());
+        start.closeblock(vec![
+            Link::new(
+                vec![Hlvalue::Variable(rewritten.clone())],
+                Some(target.clone()),
+                None,
+            )
+            .into_ref(),
+        ]);
+        target.closeblock(vec![
+            Link::new(
+                vec![Hlvalue::Variable(target_input.clone())],
+                Some(graph.returnblock.clone()),
+                None,
+            )
+            .into_ref(),
+        ]);
+
+        let succ = find_successors(&graph, vec![(start, source.clone())]);
+        assert!(succ.contains(&source));
+        assert!(succ.contains(&rewritten));
+        assert!(succ.contains(&target_input));
+
+        let return_var = match graph.getreturnvar() {
+            Hlvalue::Variable(var) => var,
+            _ => unreachable!(),
+        };
+        let mut graph = graph;
+        let returnblock = graph.returnblock.clone();
+        let pred = find_predecessors(&mut graph, vec![(returnblock, return_var.clone())]);
+        assert!(pred.contains(&return_var));
+        assert!(pred.contains(&target_input));
+        assert!(pred.contains(&rewritten));
+        assert!(pred.contains(&source));
+    }
+
+    #[test]
+    fn make_bitmask_matches_shadowcolor_encoding() {
+        for bits in 0_u16..256 {
+            let mut filled: Vec<_> = (0..8).map(|index| bits & (1 << index) != 0).collect();
+            let (index, bitmask) = make_bitmask(&filled, "test").unwrap();
+            match (index, bitmask) {
+                (None, None) => {}
+                (Some(mut index), Some(mut bitmask)) => {
+                    while bitmask != 0 {
+                        if bitmask & 1 != 0 {
+                            assert!(!filled[index]);
+                            filled[index] = true;
+                        }
+                        bitmask >>= 1;
+                        if index == 0 {
+                            break;
+                        }
+                        index -= 1;
+                    }
+                }
+                _ => panic!("index and mask must be both present or absent"),
+            }
+            assert!(filled.iter().all(|value| *value));
+        }
+        let mut too_long = vec![true; 65];
+        too_long[0] = false;
+        too_long[64] = false;
+        assert!(make_bitmask(&too_long, "large").is_err());
+    }
+
+    #[test]
+    fn postprocess_graph_expands_and_checks_linear_root_frame() {
+        let root = Variable::named("root");
+        root.set_concretetype(Some(LowLevelType::Signed));
+        let root_value = Hlvalue::Variable(root.clone());
+        let operations = vec![
+            marker("gc_push_roots", vec![root_value.clone()]),
+            direct_call(),
+            marker("gc_pop_roots", vec![root_value]),
+        ];
+        let mut graph = linear_graph("linear", root, operations);
+        assert!(postprocess_graph(&mut graph, Constant::new(ConstValue::Int(0)).into()).unwrap());
+        assert_eq!(
+            opnames(&graph),
+            [
+                "gc_enter_roots_frame",
+                "gc_save_root",
+                "direct_call",
+                "gc_restore_root",
+                "gc_leave_roots_frame",
+            ]
+        );
+        postprocess_double_check(&graph).unwrap();
+    }
+
+    #[test]
+    fn empty_root_markers_disappear_without_a_frame() {
+        let input = Variable::named("input");
+        let mut graph = linear_graph(
+            "empty",
+            input,
+            vec![
+                marker("gc_push_roots", vec![]),
+                direct_call(),
+                marker("gc_pop_roots", vec![]),
+            ],
+        );
+        assert!(!postprocess_graph(&mut graph, Constant::new(ConstValue::Int(0)).into()).unwrap());
+        assert_eq!(opnames(&graph), ["direct_call"]);
+    }
+
+    #[test]
+    fn expand_pop_drops_immediate_redundant_save() {
+        let root = Variable::named("root");
+        let root_value = Hlvalue::Variable(root.clone());
+        let mut graph = linear_graph(
+            "drop-save",
+            root,
+            vec![
+                marker("gc_push_roots", vec![root_value.clone()]),
+                marker("gc_pop_roots", vec![root_value.clone()]),
+                marker("gc_push_roots", vec![root_value.clone()]),
+                marker("gc_pop_roots", vec![root_value]),
+            ],
+        );
+        let regalloc = allocate_registers(&mut graph).unwrap();
+        expand_push_roots(&graph, Some(&regalloc)).unwrap();
+        expand_pop_roots(&graph, Some(&regalloc));
+        let names = opnames(&graph);
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| name.as_str() == "gc_save_root")
+                .count(),
+            1
+        );
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| name.as_str() == "gc_restore_root")
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn move_pushes_earlier_reuses_a_save_across_blocks() {
+        let first_root = Variable::named("first_root");
+        let first_value = Hlvalue::Variable(first_root.clone());
+        let first = Block::shared(vec![first_value.clone()]);
+        first.borrow_mut().operations = vec![
+            marker("gc_push_roots", vec![first_value.clone()]),
+            direct_call(),
+            marker("gc_pop_roots", vec![first_value]),
+        ];
+
+        let middle_root = Variable::named("middle_root");
+        let middle = Block::shared(vec![Hlvalue::Variable(middle_root.clone())]);
+        let last_root = Variable::named("last_root");
+        let last_value = Hlvalue::Variable(last_root.clone());
+        let last = Block::shared(vec![last_value.clone()]);
+        last.borrow_mut().operations = vec![
+            marker("gc_push_roots", vec![last_value.clone()]),
+            direct_call(),
+            marker("gc_pop_roots", vec![last_value]),
+        ];
+
+        let mut graph = FunctionGraph::new("reuse-save", first.clone());
+        first.closeblock(vec![
+            Link::new(
+                vec![Hlvalue::Variable(first_root)],
+                Some(middle.clone()),
+                None,
+            )
+            .into_ref(),
+        ]);
+        middle.closeblock(vec![
+            Link::new(
+                vec![Hlvalue::Variable(middle_root)],
+                Some(last.clone()),
+                None,
+            )
+            .into_ref(),
+        ]);
+        last.closeblock(vec![
+            Link::new(
+                vec![Hlvalue::Variable(last_root)],
+                Some(graph.returnblock.clone()),
+                None,
+            )
+            .into_ref(),
+        ]);
+
+        let regalloc = allocate_registers(&mut graph).unwrap();
+        expand_push_roots(&graph, Some(&regalloc)).unwrap();
+        move_pushes_earlier(&graph, Some(&regalloc));
+        expand_pop_roots(&graph, Some(&regalloc));
+        let names = opnames(&graph);
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| name.as_str() == "gc_save_root")
+                .count(),
+            1
+        );
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| name.as_str() == "gc_restore_root")
+                .count(),
+            2
+        );
+        add_enter_leave_roots_frame(
+            &mut graph,
+            Some(&regalloc),
+            Constant::new(ConstValue::Int(0)).into(),
+        );
+        postprocess_double_check(&graph).unwrap();
+    }
+
+    #[test]
+    fn postprocess_inlining_moves_markers_around_calls() {
+        let root = Variable::named("root");
+        let root_value = Hlvalue::Variable(root.clone());
+        let start = Block::shared(vec![root_value.clone()]);
+        start.borrow_mut().operations = vec![
+            marker("gc_push_roots", vec![root_value]),
+            marker("int_add", vec![]),
+        ];
+        let call_root = Variable::named("call_root");
+        let call_block = Block::shared(vec![Hlvalue::Variable(call_root.clone())]);
+        call_block.borrow_mut().operations = vec![direct_call()];
+        let tail_root = Variable::named("tail_root");
+        let tail_block = Block::shared(vec![Hlvalue::Variable(tail_root.clone())]);
+        tail_block.borrow_mut().operations = vec![marker(
+            "gc_pop_roots",
+            vec![Hlvalue::Variable(tail_root.clone())],
+        )];
+        let graph = FunctionGraph::new("inlined", start.clone());
+        start.closeblock(vec![
+            Link::new(
+                vec![Hlvalue::Variable(root)],
+                Some(call_block.clone()),
+                None,
+            )
+            .into_ref(),
+        ]);
+        call_block.closeblock(vec![
+            Link::new(
+                vec![Hlvalue::Variable(call_root)],
+                Some(tail_block.clone()),
+                None,
+            )
+            .into_ref(),
+        ]);
+        tail_block.closeblock(vec![
+            Link::new(
+                vec![Hlvalue::Variable(tail_root)],
+                Some(graph.returnblock.clone()),
+                None,
+            )
+            .into_ref(),
+        ]);
+        postprocess_inlining(&graph).unwrap();
+        assert_eq!(
+            opnames(&graph),
+            ["int_add", "gc_push_roots", "direct_call", "gc_pop_roots"]
+        );
+    }
+}

--- a/majit/majit-translate/src/tool/algo/regalloc.rs
+++ b/majit/majit-translate/src/tool/algo/regalloc.rs
@@ -362,6 +362,185 @@ pub struct RegAllocator {
     pub num_regs: usize,
 }
 
+/// Register allocation result for the original flowspace graph.
+///
+/// RPython: `rpython.tool.algo.regalloc.RegAllocator`.  The existing
+/// [`RegAllocator`] is the codewriter graph adapter; `shadowcolor.py` runs one
+/// phase earlier and therefore keeps the flowspace graph's variable identities
+/// directly, exactly as upstream's `perform_register_allocation(graph,
+/// consider_var)` does.
+#[derive(Debug, Clone)]
+pub struct FlowRegAllocator {
+    coloring: VarMap<usize>,
+    /// RPython `RegAllocator.numcolors`, populated by `find_num_colors()`.
+    pub numcolors: usize,
+}
+
+impl FlowRegAllocator {
+    /// RPython `RegAllocator.getcolor`.
+    pub fn getcolor(&self, var: &crate::flowspace::model::Variable) -> usize {
+        self.coloring[var]
+    }
+
+    /// RPython `RegAllocator.checkcolor`.
+    pub fn checkcolor(&self, var: &crate::flowspace::model::Variable, color: usize) -> bool {
+        self.coloring.get(var).copied() == Some(color)
+    }
+}
+
+/// `regalloc.py::perform_register_allocation(graph, consider_var)` for an
+/// RPython flowspace graph.
+///
+/// Rust cannot overload the codewriter adapter's identically named function,
+/// so the owner-qualified name records the only API-shape adaptation.  The
+/// dependency, reverse coalescing, and coloring passes below follow
+/// `RegAllocator.make_dependencies`, `coalesce_variables`, and
+/// `find_node_coloring` in their upstream order.
+#[expect(
+    clippy::mutable_key_type,
+    reason = "Variable hashes by immutable identity, matching RPython identity-keyed dicts"
+)]
+pub fn perform_flowspace_register_allocation(
+    graph: &crate::flowspace::model::FunctionGraph,
+    consider: &dyn Fn(&crate::flowspace::model::Variable) -> bool,
+) -> FlowRegAllocator {
+    use crate::flowspace::model::Hlvalue;
+
+    let mut depgraph = DependencyGraph::new();
+
+    for block_ref in graph.iterblocks() {
+        let block = block_ref.borrow();
+        let mut die_at: VarMap<usize> = VarMap::default();
+        for value in &block.inputargs {
+            if let Hlvalue::Variable(var) = value {
+                die_at.insert(var.clone(), 0);
+            }
+        }
+        for (index, op) in block.operations.iter().enumerate() {
+            for value in &op.args {
+                if let Hlvalue::Variable(var) = value {
+                    die_at.insert(var.clone(), index);
+                }
+            }
+            if let Hlvalue::Variable(result) = &op.result {
+                die_at.insert(result.clone(), index + 1);
+            }
+        }
+        if let Some(Hlvalue::Variable(var)) = &block.exitswitch {
+            die_at.remove(var);
+        }
+        for link_ref in &block.exits {
+            for value in link_ref.borrow().args.iter().flatten() {
+                if let Hlvalue::Variable(var) = value {
+                    die_at.remove(var);
+                }
+            }
+        }
+        let mut die_at: Vec<(usize, crate::flowspace::model::Variable)> = die_at
+            .into_iter()
+            .map(|(var, index)| (index, var))
+            .collect();
+        die_at.sort_by_key(|(index, _)| *index);
+
+        let inputvars: Vec<_> = block
+            .inputargs
+            .iter()
+            .filter_map(|value| match value {
+                Hlvalue::Variable(var) if consider(var) => Some(var.clone()),
+                _ => None,
+            })
+            .collect();
+        for (index, var) in inputvars.iter().enumerate() {
+            depgraph.add_node(var.clone());
+            for other in &inputvars[..index] {
+                depgraph.add_edge(other.clone(), var.clone());
+            }
+        }
+        let mut livevars: VarSet = inputvars.into_iter().collect();
+        let mut die_index = 0;
+        for (index, op) in block.operations.iter().enumerate() {
+            while die_at
+                .get(die_index)
+                .is_some_and(|(last_use, _)| *last_use == index)
+            {
+                livevars.remove(&die_at[die_index].1);
+                die_index += 1;
+            }
+            if let Hlvalue::Variable(result) = &op.result
+                && consider(result)
+            {
+                depgraph.add_node(result.clone());
+                for var in &livevars {
+                    if var != result && consider(var) {
+                        depgraph.add_edge(var.clone(), result.clone());
+                    }
+                }
+                livevars.insert(result.clone());
+            }
+        }
+    }
+
+    let mut unionfind = UnionFind::new();
+    let mut blocks = graph.iterblocks();
+    while let Some(block_ref) = blocks.pop() {
+        for link_ref in &block_ref.borrow().exits {
+            let link = link_ref.borrow();
+            if let Some(Hlvalue::Variable(var)) = &link.last_exception {
+                depgraph.add_node(var.clone());
+            }
+            if let Some(Hlvalue::Variable(var)) = &link.last_exc_value {
+                depgraph.add_node(var.clone());
+            }
+            let Some(target) = &link.target else {
+                continue;
+            };
+            for (source, target) in link.args.iter().zip(&target.borrow().inputargs) {
+                let (Some(Hlvalue::Variable(source)), Hlvalue::Variable(target)) =
+                    (source.as_ref(), target)
+                else {
+                    continue;
+                };
+                if !consider(source) || !consider(target) {
+                    continue;
+                }
+                let source_rep = unionfind.find_rep(source.clone());
+                let target_rep = unionfind.find_rep(target.clone());
+                if source_rep == target_rep || depgraph.has_edge(&target_rep, &source_rep) {
+                    continue;
+                }
+                let representative = unionfind.union(source_rep.clone(), target_rep.clone());
+                if representative == source_rep {
+                    depgraph.coalesce(target_rep, source_rep);
+                } else {
+                    depgraph.coalesce(source_rep, target_rep);
+                }
+            }
+        }
+    }
+
+    let representative_coloring = depgraph.find_node_coloring();
+    let mut coloring = VarMap::default();
+    for block_ref in graph.iterblocks() {
+        for var in block_ref.borrow().getvariables() {
+            if consider(&var) {
+                let representative = unionfind.find_rep(var.clone());
+                if let Some(color) = representative_coloring.get(&representative) {
+                    coloring.insert(var, *color);
+                }
+            }
+        }
+    }
+    let numcolors = coloring
+        .values()
+        .copied()
+        .max()
+        .map_or(0, |color| color + 1);
+    FlowRegAllocator {
+        coloring,
+        numcolors,
+    }
+}
+
 impl RegAllocator {
     /// Look up the register color assigned to `var` — matches upstream
     /// `coloring: dict[Variable, int]` (`tool/algo/regalloc.py:31`).

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -370,6 +370,7 @@ under measurement.
 | `PYRE_PROBE14` | OFF | reports discarded reference-constant relocations; retire when relocation preservation is covered by ordinary tests |
 | `PYRE_GC_TYPE_COUNT` | OFF | prints `[gc-type-count] frozen=N max=M` when `freeze_types` runs, so the number to size `TypeRegistry::MAX_TYPES` against can be read instead of guessed -- the `register` assert names the cap it blew but not the total it needed; retire when the registry grows on demand rather than pre-allocating a fixed capacity for a stable base address |
 | `PYRE_GC_SIZE_AUDIT` | OFF | panics when a block is stamped with a type id whose declared payload is larger than the block's own extent, at the allocation that stamps it rather than in whichever later collection reads the neighbouring block as a field (varsize types are exempt); retire when every allocator derives the size from the type id it stamps, so the two cannot disagree |
+| `PYRE_GC_GATE_BASE` | VALUE | names the upstream commit `scripts/check-gc-root-brackets.py` measured its numbers over, so a backlog raised by code the baseline never saw is reported rather than charged to the branch; the workflow supplies it because a CI checkout is shallow, holds no `main` ref and has its merge commit's parent list truncated away, leaving nothing in the repository able to answer; retire when the gate's job checks out enough history for `git merge-base` to name the base itself |
 
 ## Summary
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -889,7 +889,8 @@ pub(crate) unsafe fn p_recursive_issubclass_w(
 /// candidate set, mints a jitcode, and the walker unrolls the walk instead of
 /// leaving the call an opaque residual.
 #[majit_macros::unroll_safe]
-pub fn isinstance(obj: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, PyError> {
+#[pyre_macros::gc_roots]
+pub fn isinstance(mut obj: PyObjectRef, mut classinfo: PyObjectRef) -> Result<bool, PyError> {
     // Nested tuple / union classinfo recurses in native Rust with no
     // Python frame push, so guard the C stack here or a deep classinfo
     // blows it before any frame-level check fires.
@@ -905,17 +906,12 @@ pub fn isinstance(obj: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, PyEr
         if is_tuple(classinfo) {
             // The recursive `isinstance` re-enters Python (`__instancecheck__`)
             // and may collect; `obj` and the classinfo tuple are raw locals, so
-            // pin them on the shadow stack across the walk.
-            let _roots = pyre_object::gc_roots::push_roots();
-            let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-            let _ = pyre_object::gc_roots::pin_root(obj);
-            let info_slot = pyre_object::gc_roots::shadow_stack_len();
-            let _ = pyre_object::gc_roots::pin_root(classinfo);
-            let n = w_tuple_len(pyre_object::gc_roots::shadow_stack_get(info_slot));
+            // bracket them across the walk.
+            let n = pyre_object::with_roots!(obj, classinfo => w_tuple_len(classinfo));
             for i in 0..n {
                 if let Some(c) =
-                    w_tuple_getitem(pyre_object::gc_roots::shadow_stack_get(info_slot), i as i64)
-                    && isinstance(pyre_object::gc_roots::shadow_stack_get(obj_slot), c)?
+                    pyre_object::with_roots!(obj, classinfo => w_tuple_getitem(classinfo, i as i64))
+                    && pyre_object::with_roots!(obj, classinfo => isinstance(obj, c))?
                 {
                     return Ok(true);
                 }
@@ -924,17 +920,12 @@ pub fn isinstance(obj: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, PyEr
         }
         // PEP 604 `X | Y` union recursion — lib_pypy/_pypy_generic_alias.py.
         if pyre_object::is_union(classinfo) {
-            let union_args = pyre_object::w_union_get_args(classinfo);
-            let _roots = pyre_object::gc_roots::push_roots();
-            let obj_slot = pyre_object::gc_roots::shadow_stack_len();
-            let _ = pyre_object::gc_roots::pin_root(obj);
-            let args_slot = pyre_object::gc_roots::shadow_stack_len();
-            let _ = pyre_object::gc_roots::pin_root(union_args);
-            let n = w_tuple_len(pyre_object::gc_roots::shadow_stack_get(args_slot));
+            let mut union_args = pyre_object::w_union_get_args(classinfo);
+            let n = pyre_object::with_roots!(obj, union_args => w_tuple_len(union_args));
             for i in 0..n {
-                if let Some(c) =
-                    w_tuple_getitem(pyre_object::gc_roots::shadow_stack_get(args_slot), i as i64)
-                    && isinstance(pyre_object::gc_roots::shadow_stack_get(obj_slot), c)?
+                if let Some(c) = pyre_object::with_roots!(
+                    obj, union_args => w_tuple_getitem(union_args, i as i64)
+                ) && pyre_object::with_roots!(obj, union_args => isinstance(obj, c))?
                 {
                     return Ok(true);
                 }
@@ -981,7 +972,8 @@ pub fn isinstance(obj: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, PyEr
 /// candidate set, mints a jitcode, and the walker unrolls the walk instead of
 /// leaving the call an opaque residual.
 #[majit_macros::unroll_safe]
-pub fn issubclass(derived: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, PyError> {
+#[pyre_macros::gc_roots]
+pub fn issubclass(mut derived: PyObjectRef, mut classinfo: PyObjectRef) -> Result<bool, PyError> {
     // Nested tuple / union classinfo recurses in native Rust with no
     // Python frame push, so guard the C stack here or a deep classinfo
     // blows it before any frame-level check fires.
@@ -990,18 +982,12 @@ pub fn issubclass(derived: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, 
         // abstractinst.py:181-187 — tuple recursion.
         if is_tuple(classinfo) {
             // The recursive `issubclass` re-enters Python (`__subclasscheck__`)
-            // and may collect; `derived` and the classinfo tuple are raw locals,
-            // so pin them on the shadow stack across the walk.
-            let _roots = pyre_object::gc_roots::push_roots();
-            let derived_slot = pyre_object::gc_roots::shadow_stack_len();
-            let _ = pyre_object::gc_roots::pin_root(derived);
-            let info_slot = pyre_object::gc_roots::shadow_stack_len();
-            let _ = pyre_object::gc_roots::pin_root(classinfo);
-            let n = w_tuple_len(pyre_object::gc_roots::shadow_stack_get(info_slot));
+            // and may collect; `derived` and the classinfo tuple are raw
+            // locals, so bracket them across the walk.
+            let n = pyre_object::with_roots!(derived, classinfo => w_tuple_len(classinfo));
             for i in 0..n {
-                if let Some(c) =
-                    w_tuple_getitem(pyre_object::gc_roots::shadow_stack_get(info_slot), i as i64)
-                    && issubclass(pyre_object::gc_roots::shadow_stack_get(derived_slot), c)?
+                if let Some(c) = pyre_object::with_roots!(derived, classinfo => w_tuple_getitem(classinfo, i as i64))
+                    && pyre_object::with_roots!(derived, classinfo => issubclass(derived, c))?
                 {
                     return Ok(true);
                 }
@@ -1009,17 +995,12 @@ pub fn issubclass(derived: PyObjectRef, classinfo: PyObjectRef) -> Result<bool, 
             return Ok(false);
         }
         if pyre_object::is_union(classinfo) {
-            let union_args = pyre_object::w_union_get_args(classinfo);
-            let _roots = pyre_object::gc_roots::push_roots();
-            let derived_slot = pyre_object::gc_roots::shadow_stack_len();
-            let _ = pyre_object::gc_roots::pin_root(derived);
-            let args_slot = pyre_object::gc_roots::shadow_stack_len();
-            let _ = pyre_object::gc_roots::pin_root(union_args);
-            let n = w_tuple_len(pyre_object::gc_roots::shadow_stack_get(args_slot));
+            let mut union_args = pyre_object::w_union_get_args(classinfo);
+            let n = pyre_object::with_roots!(derived, union_args => w_tuple_len(union_args));
             for i in 0..n {
-                if let Some(c) =
-                    w_tuple_getitem(pyre_object::gc_roots::shadow_stack_get(args_slot), i as i64)
-                    && issubclass(pyre_object::gc_roots::shadow_stack_get(derived_slot), c)?
+                if let Some(c) = pyre_object::with_roots!(
+                    derived, union_args => w_tuple_getitem(union_args, i as i64)
+                ) && pyre_object::with_roots!(derived, union_args => issubclass(derived, c))?
                 {
                     return Ok(true);
                 }

--- a/pyre/pyre-macros/src/gc_roots.rs
+++ b/pyre/pyre-macros/src/gc_roots.rs
@@ -528,7 +528,7 @@ impl Handler for Rewrite<'_> {
 /// answer.  A single global answer would have a bracket reload a colour its
 /// site never saved.
 mod place {
-    use super::{Block, Count, Expr, Ident, Names, Rewrite, Stmt, Walk};
+    use super::{Block, Count, Expr, Names, Rewrite, Stmt, Walk};
     use std::collections::BTreeSet;
     use syn::visit_mut::VisitMut;
 

--- a/pyre/pyre-macros/src/gc_roots.rs
+++ b/pyre/pyre-macros/src/gc_roots.rs
@@ -1,0 +1,464 @@
+//! `#[gc_roots]` — `shadowcolor.py postprocess_graph` over a Rust function
+//! body.
+//!
+//! Upstream writes the shadow-stack bracket twice. `framework.py` /
+//! `shadowstack.py` emit the naive form -- one `gc_push_roots` /
+//! `gc_pop_roots` pair immediately around every operation that can reach the
+//! collector -- and `shadowcolor.py` then rewrites that form into the one that
+//! ships: `allocate_registers` colours the roots so slots are reused,
+//! `expand_push_roots` / `expand_pop_roots` turn the bulk pair into per-root
+//! `gc_save_root` / `gc_restore_root`, `move_pushes_earlier` hoists saves out
+//! of loops, and `add_enter_leave_roots_frame` reduces the whole graph to a
+//! single frame entered as late as possible.
+//!
+//! Both halves are needed, and only the second one is an optimiser. Writing
+//! the shipped form by hand means doing a register allocator's job in one's
+//! head at every call site; writing the naive form by hand is mechanical.
+//! This attribute is what makes that split available here: a function body
+//! states one [`with_roots!`] bracket per collecting operation, and the
+//! attribute performs the `shadowcolor.py` half.
+//!
+//! [`with_roots!`]: pyre_object::with_roots
+//!
+//! ```ignore
+//! #[gc_roots]
+//! fn f(mut obj: PyObjectRef, mut value: PyObjectRef) -> Result<(), PyError> {
+//!     with_roots!(obj, value => switch_strategy(obj));
+//!     let key = with_roots!(obj, value => object_key_for(obj)?);
+//!     ...
+//! }
+//! ```
+//!
+//! Two brackets, two frames, four slot pushes and two pops in the naive
+//! expansion; one frame and two slots after this pass.
+//!
+//! # What this pass does not do
+//!
+//! `move_pushes_earlier` is not implemented. It is the one upstream pass whose
+//! benefit is a measurement rather than a structural property, and the saves
+//! it hoists are still correct where they stand.
+//!
+//! Upstream also skips the walker over slots a frame is not currently using,
+//! via `make_bitmask`. This pass has no equivalent, so a slot keeps naming its
+//! bracket's root until the next bracket overwrites the colour or the frame
+//! pops. That retains an object the function has finished with; it does not
+//! read a stale one, because a slot the walker can reach is a slot the walker
+//! forwards.
+
+use proc_macro2::{Span, TokenStream};
+use quote::{format_ident, quote};
+use std::collections::BTreeMap;
+use syn::parse::{Parse, ParseStream};
+use syn::visit_mut::{self, VisitMut};
+use syn::{Expr, Ident, ItemFn, Stmt, Token};
+
+/// One `with_roots!(a, b => body)` invocation, as the attribute sees it.
+///
+/// The attribute runs before `macro_rules!` expansion, so the invocation is
+/// still literal tokens here and can be rewritten rather than expanded. That
+/// ordering is what lets the naive form stay correct on its own: a function
+/// without the attribute expands `with_roots!` to its own per-operation
+/// bracket, exactly as an untransformed graph would run.
+struct WithRoots {
+    locals: Vec<Ident>,
+    body: Expr,
+}
+
+impl Parse for WithRoots {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut locals = Vec::new();
+        loop {
+            locals.push(input.parse::<Ident>()?);
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+                if input.peek(Token![=>]) {
+                    break; // trailing comma before the arrow
+                }
+                continue;
+            }
+            break;
+        }
+        input.parse::<Token![=>]>()?;
+        Ok(Self {
+            locals,
+            body: input.parse()?,
+        })
+    }
+}
+
+/// Does this macro path name `with_roots`, however it was brought into scope?
+///
+/// Matched on the last segment: the call sites spell it `with_roots!`,
+/// `crate::with_roots!` and `pyre_object::with_roots!`, and `#[macro_export]`
+/// puts it at the crate root under all three.
+fn is_with_roots(mac: &syn::Macro) -> bool {
+    mac.path
+        .segments
+        .last()
+        .is_some_and(|seg| seg.ident == "with_roots")
+}
+
+/// `allocate_registers`, at the granularity this pass can prove.
+///
+/// Upstream runs a real register allocator over the flow graph, so two roots
+/// share a colour when their live ranges are disjoint. A colour here is a
+/// scratch slot rather than a live range: it is written immediately before a
+/// bracket's body and read back immediately after, and nothing between two
+/// brackets reads it. So the only rule that has to hold is that the roots
+/// *within one bracket* get distinct colours, and naming them is enough to
+/// guarantee it.
+///
+/// The cost of the weaker rule is frame width -- one slot per distinct root
+/// name in the function rather than per simultaneously-live root. The saving
+/// this pass is actually after is the frame count, which goes to one either
+/// way.
+fn allocate_colors(brackets: &[WithRoots]) -> BTreeMap<String, usize> {
+    let mut colors = BTreeMap::new();
+    let mut next = 0usize;
+    for bracket in brackets {
+        for local in &bracket.locals {
+            colors.entry(local.to_string()).or_insert_with(|| {
+                let color = next;
+                next += 1;
+                color
+            });
+        }
+    }
+    colors
+}
+
+/// Collects every rewritable `with_roots!` in a body, in source order.
+///
+/// A bracket inside a closure or a nested item is not collected, so it keeps
+/// the naive expansion. The frame is a local of the enclosing function, and a
+/// closure that captured it would extend the bracket past the frame's own
+/// scope -- upstream has the same boundary for free, because a nested graph is
+/// a separate graph with its own frame.
+struct Collect {
+    brackets: Vec<WithRoots>,
+    error: Option<syn::Error>,
+}
+
+impl VisitMut for Collect {
+    fn visit_expr_mut(&mut self, expr: &mut Expr) {
+        if let Expr::Closure(_) = expr {
+            return;
+        }
+        if let Expr::Macro(mac) = expr
+            && is_with_roots(&mac.mac)
+        {
+            match mac.mac.parse_body::<WithRoots>() {
+                Ok(parsed) => {
+                    // The body can hold further brackets; visit it, not the
+                    // unparsed token stream.
+                    let mut parsed = parsed;
+                    self.visit_expr_mut(&mut parsed.body);
+                    self.brackets.push(parsed);
+                }
+                Err(err) => {
+                    self.error.get_or_insert(err);
+                }
+            }
+            return;
+        }
+        visit_mut::visit_expr_mut(self, expr);
+    }
+
+    /// A bracket written as a statement -- `with_roots!(obj, value => f(obj));`
+    /// -- parses as `Stmt::Macro`, never reaching `visit_expr_mut`. That is
+    /// the position most brackets are in, because most collecting operations
+    /// are performed for their effect.
+    fn visit_stmt_mut(&mut self, stmt: &mut Stmt) {
+        if let Stmt::Macro(mac) = stmt
+            && is_with_roots(&mac.mac)
+        {
+            match mac.mac.parse_body::<WithRoots>() {
+                Ok(mut parsed) => {
+                    self.visit_expr_mut(&mut parsed.body);
+                    self.brackets.push(parsed);
+                }
+                Err(err) => {
+                    self.error.get_or_insert(err);
+                }
+            }
+            return;
+        }
+        visit_mut::visit_stmt_mut(self, stmt);
+    }
+
+    fn visit_item_mut(&mut self, _item: &mut syn::Item) {}
+}
+
+/// Rewrites each collected bracket into its `gc_save_root` /
+/// `gc_restore_root` series against the function's frame.
+struct Rewrite<'a> {
+    colors: &'a BTreeMap<String, usize>,
+    frame: &'a Ident,
+    base: &'a Ident,
+    error: Option<syn::Error>,
+}
+
+impl VisitMut for Rewrite<'_> {
+    fn visit_expr_mut(&mut self, expr: &mut Expr) {
+        if let Expr::Closure(_) = expr {
+            return;
+        }
+        let Expr::Macro(mac) = expr else {
+            visit_mut::visit_expr_mut(self, expr);
+            return;
+        };
+        if !is_with_roots(&mac.mac) {
+            visit_mut::visit_expr_mut(self, expr);
+            return;
+        }
+        let mut parsed = match mac.mac.parse_body::<WithRoots>() {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                self.error.get_or_insert(err);
+                return;
+            }
+        };
+        self.visit_expr_mut(&mut parsed.body);
+        *expr = self.expand(&parsed);
+    }
+
+    /// The [`Collect`] twin: rewrite a statement-position bracket in place,
+    /// keeping its trailing semicolon so the block's value is unchanged.
+    fn visit_stmt_mut(&mut self, stmt: &mut Stmt) {
+        let Stmt::Macro(mac) = stmt else {
+            visit_mut::visit_stmt_mut(self, stmt);
+            return;
+        };
+        if !is_with_roots(&mac.mac) {
+            visit_mut::visit_stmt_mut(self, stmt);
+            return;
+        }
+        let semi = mac.semi_token;
+        let mut parsed = match mac.mac.parse_body::<WithRoots>() {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                self.error.get_or_insert(err);
+                return;
+            }
+        };
+        self.visit_expr_mut(&mut parsed.body);
+        *stmt = Stmt::Expr(self.expand(&parsed), semi);
+    }
+
+    fn visit_item_mut(&mut self, _item: &mut syn::Item) {}
+}
+
+impl Rewrite<'_> {
+    fn expand(&self, bracket: &WithRoots) -> Expr {
+        let (frame, base) = (self.frame, self.base);
+        let slots: Vec<TokenStream> = bracket
+            .locals
+            .iter()
+            .map(|local| {
+                // `Collect` and `Rewrite` traverse identically, so every
+                // rewritten root was coloured; naming the invariant beats an
+                // index panic if a future traversal drifts apart.
+                let color = *self
+                    .colors
+                    .get(&local.to_string())
+                    .expect("a rewritten root was not coloured: the collect and rewrite traversals disagree");
+                quote!(#base + #color)
+            })
+            .collect();
+        let locals = &bracket.locals;
+        let body = &bracket.body;
+        // `save_run` publishes every value before resolving forwarding for
+        // any, which is `expand_one_push_roots`'s series plus the safepoint
+        // rule `pin_roots` states. The restores are `expand_one_pop_roots`:
+        // `gc_restore_root`'s whole body is `setvar(v_value, newvalue)`, so
+        // after the bracket the local *is* the live word.
+        syn::parse_quote!({
+            #frame.save_run(&[#((#slots, #locals)),*]);
+            let __roots_result = #body;
+            #(#locals = #frame.get(#slots);)*
+            __roots_result
+        })
+    }
+}
+
+/// `add_enter_leave_roots_frame`, at the granularity this pass can prove.
+///
+/// Upstream puts `gc_enter_roots_frame` as late as possible -- just before the
+/// first `gc_save_root` any path reaches -- and the leave as early as possible.
+/// A frame at the top of the body would instead charge every call that never
+/// reaches a bracket, and a bracket usually guards a slow path: the two pilot
+/// functions bracket only their strategy-switch and reentrant-probe arms, so
+/// the ordinary store would pay a frame it never uses.
+///
+/// The block that gets the frame is the innermost one still containing every
+/// bracket, found by descending while a single branch holds all of them.
+/// Loops are not entered: a frame inside a loop body is re-entered per
+/// iteration, which is the direction `move_pushes_earlier` exists to undo.
+/// Closures are not entered either, matching [`Collect`].
+mod place {
+    use super::{Stmt, is_with_roots};
+    use syn::{Block, Expr};
+
+    pub fn in_block(block: &Block) -> usize {
+        block.stmts.iter().map(in_stmt).sum()
+    }
+
+    pub fn in_stmt(stmt: &Stmt) -> usize {
+        match stmt {
+            Stmt::Macro(mac) if is_with_roots(&mac.mac) => 1,
+            Stmt::Expr(expr, _) => in_expr(expr),
+            Stmt::Local(local) => local
+                .init
+                .as_ref()
+                .map(|init| {
+                    in_expr(&init.expr) + init.diverge.as_ref().map_or(0, |(_, e)| in_expr(e))
+                })
+                .unwrap_or(0),
+            // An item is a separate graph with its own frame.
+            Stmt::Item(_) => 0,
+            Stmt::Macro(_) => 0,
+        }
+    }
+
+    /// Counts brackets in `expr`, by the same traversal [`super::Collect`]
+    /// uses -- the two must agree, or the frame could be installed somewhere
+    /// that does not dominate every rewritten bracket.
+    pub fn in_expr(expr: &Expr) -> usize {
+        struct Count(usize);
+        impl<'ast> syn::visit::Visit<'ast> for Count {
+            fn visit_expr(&mut self, expr: &'ast Expr) {
+                if let Expr::Closure(_) = expr {
+                    return;
+                }
+                if let Expr::Macro(mac) = expr
+                    && is_with_roots(&mac.mac)
+                {
+                    self.0 += 1;
+                    if let Ok(parsed) = mac.mac.parse_body::<super::WithRoots>() {
+                        self.visit_expr(&parsed.body);
+                    }
+                    return;
+                }
+                syn::visit::visit_expr(self, expr);
+            }
+            fn visit_stmt(&mut self, stmt: &'ast Stmt) {
+                if let Stmt::Macro(mac) = stmt
+                    && is_with_roots(&mac.mac)
+                {
+                    self.0 += 1;
+                    if let Ok(parsed) = mac.mac.parse_body::<super::WithRoots>() {
+                        self.visit_expr(&parsed.body);
+                    }
+                    return;
+                }
+                syn::visit::visit_stmt(self, stmt);
+            }
+            fn visit_item(&mut self, _item: &'ast syn::Item) {}
+        }
+        let mut count = Count(0);
+        syn::visit::Visit::visit_expr(&mut count, expr);
+        count.0
+    }
+
+    /// The blocks a statement branches into, for a descent that must not
+    /// change how often the frame is entered.
+    fn branches(expr: &mut Expr) -> Vec<&mut Block> {
+        match expr {
+            Expr::Block(e) => vec![&mut e.block],
+            Expr::Unsafe(e) => vec![&mut e.block],
+            Expr::If(e) => {
+                let mut out = vec![&mut e.then_branch];
+                if let Some((_, alt)) = &mut e.else_branch
+                    && let Expr::Block(alt) = &mut **alt
+                {
+                    out.push(&mut alt.block);
+                }
+                out
+            }
+            Expr::Match(e) => e
+                .arms
+                .iter_mut()
+                .filter_map(|arm| match &mut *arm.body {
+                    Expr::Block(b) => Some(&mut b.block),
+                    _ => None,
+                })
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    /// Insert `prologue` at the latest point that still dominates every
+    /// bracket, and report where it landed for the caller to check.
+    pub fn install(block: &mut Block, prologue: &[Stmt]) {
+        let total = in_block(block);
+        debug_assert!(total > 0);
+        let counts: Vec<usize> = block.stmts.iter().map(in_stmt).collect();
+        let first = counts.iter().position(|&n| n > 0).expect("a bracket");
+        if counts[first] == total {
+            let descend = match &mut block.stmts[first] {
+                Stmt::Expr(expr, _) => Some(expr),
+                Stmt::Local(local) => local.init.as_mut().map(|init| &mut *init.expr),
+                _ => None,
+            };
+            if let Some(expr) = descend
+                && let Some(inner) = branches(expr)
+                    .into_iter()
+                    .find(|inner| in_block(inner) == total)
+            {
+                install(inner, prologue);
+                return;
+            }
+        }
+        block.stmts.splice(first..first, prologue.iter().cloned());
+    }
+}
+
+pub fn expand(mut func: ItemFn) -> syn::Result<TokenStream> {
+    let mut collect = Collect {
+        brackets: Vec::new(),
+        error: None,
+    };
+    // `visit_block_mut` rather than `visit_item_fn_mut`: the latter would be
+    // stopped by this visitor's own `visit_item_mut` guard.
+    collect.visit_block_mut(&mut func.block);
+    if let Some(err) = collect.error {
+        return Err(err);
+    }
+    if collect.brackets.is_empty() {
+        return Err(syn::Error::new(
+            func.sig.ident.span(),
+            "#[gc_roots] found no `with_roots!` bracket to transform. \
+             An attribute that transforms nothing still emits a frame, so it \
+             costs a push and a pop to say nothing; remove it.",
+        ));
+    }
+
+    let colors = allocate_colors(&collect.brackets);
+    let numcolors = colors.len();
+    let frame = format_ident!("__pyre_gc_frame", span = Span::call_site());
+    let base = format_ident!("__pyre_gc_base", span = Span::call_site());
+
+    // `add_enter_leave_roots_frame` before the expansion, so the search counts
+    // `with_roots!` invocations rather than the blocks they become. The leave
+    // needs no placement: the frame is a scope guard, so it pops at the end of
+    // whichever block the enter landed in -- the earliest point that still
+    // covers every restore.
+    let prologue: Vec<Stmt> = syn::parse_quote! {
+        let #frame = ::pyre_object::gc_roots::enter_roots_frame(#numcolors);
+        let #base = ::pyre_object::gc_roots::RootScope::base(&#frame);
+    };
+    place::install(&mut func.block, &prologue);
+
+    let mut rewrite = Rewrite {
+        colors: &colors,
+        frame: &frame,
+        base: &base,
+        error: None,
+    };
+    rewrite.visit_block_mut(&mut func.block);
+    if let Some(err) = rewrite.error {
+        return Err(err);
+    }
+
+    Ok(quote!(#func))
+}

--- a/pyre/pyre-macros/src/gc_roots.rs
+++ b/pyre/pyre-macros/src/gc_roots.rs
@@ -7,8 +7,8 @@
 //! collector -- and `shadowcolor.py` then rewrites that form into the one that
 //! ships: `allocate_registers` colours the roots so slots are reused,
 //! `expand_push_roots` / `expand_pop_roots` turn the bulk pair into per-root
-//! `gc_save_root` / `gc_restore_root`, `move_pushes_earlier` hoists saves out
-//! of loops, and `add_enter_leave_roots_frame` reduces the whole graph to a
+//! `gc_save_root` / `gc_restore_root`, `move_pushes_earlier` hoists saves
+//! earlier, and `add_enter_leave_roots_frame` reduces the whole graph to a
 //! single frame entered as late as possible.
 //!
 //! Both halves are needed, and only the second one is an optimiser. Writing
@@ -30,27 +30,37 @@
 //! ```
 //!
 //! Two brackets, two frames, four slot pushes and two pops in the naive
-//! expansion; one frame and two slots after this pass.
+//! expansion; one frame, two slots and one save after this pass.
 //!
-//! # What this pass does not do
+//! `majit-translate`'s `memory::gctransform::shadowcolor` is the strict port of
+//! the same upstream module, over the flowspace graphs the translator builds.
+//! This one answers for the interpreter, whose graphs rustc owns, so it works
+//! on the token tree instead and is an approximation at the two points named
+//! below.
 //!
-//! `move_pushes_earlier` is not implemented. It is the one upstream pass whose
-//! benefit is a measurement rather than a structural property, and the saves
-//! it hoists are still correct where they stand.
+//! # Where this pass is weaker than upstream
+//!
+//! Colours are per root *name*, not per live range, because a colour here is a
+//! scratch slot rather than a range: nothing between two brackets reads it, so
+//! the only rule that has to hold is that the roots within one bracket differ.
+//! The cost is frame width, not frame count.
+//!
+//! `move_pushes_earlier` hoists only to the frame prologue, and only for roots
+//! [`hoistable`] can prove constant. Upstream hoists any save to any earlier
+//! point its colouring admits.
 //!
 //! Upstream also skips the walker over slots a frame is not currently using,
 //! via `make_bitmask`. This pass has no equivalent, so a slot keeps naming its
-//! bracket's root until the next bracket overwrites the colour or the frame
-//! pops. That retains an object the function has finished with; it does not
-//! read a stale one, because a slot the walker can reach is a slot the walker
-//! forwards.
+//! root until the next bracket overwrites the colour or the frame pops. That
+//! retains an object the function has finished with; it does not read a stale
+//! one, because a slot the walker can reach is a slot the walker forwards.
 
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::{Span, TokenStream, TokenTree};
 use quote::{format_ident, quote};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use syn::parse::{Parse, ParseStream};
 use syn::visit_mut::{self, VisitMut};
-use syn::{Expr, Ident, ItemFn, Stmt, Token};
+use syn::{Block, Expr, FnArg, Ident, ItemFn, Pat, Stmt, Token};
 
 /// One `with_roots!(a, b => body)` invocation, as the attribute sees it.
 ///
@@ -98,20 +108,138 @@ fn is_with_roots(mac: &syn::Macro) -> bool {
         .is_some_and(|seg| seg.ident == "with_roots")
 }
 
+// ── The one traversal ───────────────────────────────────────────────
+//
+// Every pass below walks the body looking for the same thing, and they have to
+// agree about what they find: a bracket the colouring misses but the rewrite
+// reaches has no slot to address, and a bracket the frame placement misses can
+// end up outside the frame that serves it. So the traversal is written once
+// and the passes differ only in what they do with a bracket.
+
+/// What a pass does with each bracket the walk reaches.
+trait Handler {
+    /// Called once per bracket, after the bracket's own body has been walked.
+    /// `Some` replaces the invocation, `None` leaves it in place.
+    fn bracket(&mut self, bracket: WithRoots) -> Option<Expr>;
+    fn error(&mut self, err: syn::Error);
+}
+
+/// Walks a body and reports every rewritable bracket to a [`Handler`].
+///
+/// A bracket inside a closure or a nested item is not reported, so it keeps
+/// the naive expansion. The frame is a local of the enclosing function, and a
+/// closure that captured it would extend the bracket past the frame's own
+/// scope -- upstream has the same boundary for free, because a nested graph is
+/// a separate graph with its own frame.
+struct Walk<H>(H);
+
+impl<H: Handler> Walk<H> {
+    /// Parse an invocation and hand it to the handler, walking the bracket's
+    /// own body first so a nested bracket is reported before its parent.
+    fn take(&mut self, mac: &syn::Macro) -> Option<Expr> {
+        match mac.parse_body::<WithRoots>() {
+            Ok(mut bracket) => {
+                self.visit_expr_mut(&mut bracket.body);
+                self.0.bracket(bracket)
+            }
+            Err(err) => {
+                self.0.error(err);
+                None
+            }
+        }
+    }
+}
+
+impl<H: Handler> VisitMut for Walk<H> {
+    fn visit_expr_mut(&mut self, expr: &mut Expr) {
+        if let Expr::Closure(_) = expr {
+            return;
+        }
+        if let Expr::Macro(mac) = expr
+            && is_with_roots(&mac.mac)
+        {
+            let mac = mac.mac.clone();
+            if let Some(replacement) = self.take(&mac) {
+                *expr = replacement;
+            }
+            return;
+        }
+        visit_mut::visit_expr_mut(self, expr);
+    }
+
+    /// A bracket written as a statement -- `with_roots!(obj, value => f(obj));`
+    /// -- parses as `Stmt::Macro`, never reaching `visit_expr_mut`. That is the
+    /// position most brackets are in, because most collecting operations are
+    /// performed for their effect.
+    fn visit_stmt_mut(&mut self, stmt: &mut Stmt) {
+        if let Stmt::Macro(mac) = stmt
+            && is_with_roots(&mac.mac)
+        {
+            let (inner, semi) = (mac.mac.clone(), mac.semi_token);
+            if let Some(replacement) = self.take(&inner) {
+                // Keeping the semicolon leaves the block's value unchanged.
+                *stmt = Stmt::Expr(replacement, semi);
+            }
+            return;
+        }
+        visit_mut::visit_stmt_mut(self, stmt);
+    }
+
+    fn visit_item_mut(&mut self, _item: &mut syn::Item) {}
+}
+
+/// Records every bracket, changing nothing.
+#[derive(Default)]
+struct Collect {
+    brackets: Vec<WithRoots>,
+    error: Option<syn::Error>,
+}
+
+impl Handler for Collect {
+    fn bracket(&mut self, bracket: WithRoots) -> Option<Expr> {
+        self.brackets.push(bracket);
+        None
+    }
+    fn error(&mut self, err: syn::Error) {
+        self.error.get_or_insert(err);
+    }
+}
+
+/// Counts brackets, changing nothing — the frame placement's measure.
+#[derive(Default)]
+struct Count(usize);
+
+impl Handler for Count {
+    fn bracket(&mut self, _bracket: WithRoots) -> Option<Expr> {
+        self.0 += 1;
+        None
+    }
+    fn error(&mut self, _err: syn::Error) {}
+}
+
+/// Collects the root names brackets address, changing nothing — what a frame
+/// site needs in order to know which roots it can save on their behalf.
+#[derive(Default)]
+struct Names(BTreeSet<String>);
+
+impl Handler for Names {
+    fn bracket(&mut self, bracket: WithRoots) -> Option<Expr> {
+        self.0.extend(bracket.locals.iter().map(Ident::to_string));
+        None
+    }
+    fn error(&mut self, _err: syn::Error) {}
+}
+
+// ── allocate_registers ──────────────────────────────────────────────
+
 /// `allocate_registers`, at the granularity this pass can prove.
 ///
 /// Upstream runs a real register allocator over the flow graph, so two roots
 /// share a colour when their live ranges are disjoint. A colour here is a
-/// scratch slot rather than a live range: it is written immediately before a
-/// bracket's body and read back immediately after, and nothing between two
-/// brackets reads it. So the only rule that has to hold is that the roots
-/// *within one bracket* get distinct colours, and naming them is enough to
-/// guarantee it.
-///
-/// The cost of the weaker rule is frame width -- one slot per distinct root
-/// name in the function rather than per simultaneously-live root. The saving
-/// this pass is actually after is the frame count, which goes to one either
-/// way.
+/// scratch slot: it is written before a bracket's body and read back after,
+/// and nothing between two brackets reads it. So the only rule that has to
+/// hold is that the roots *within one bracket* get distinct colours, and
+/// naming them is enough to guarantee it.
 fn allocate_colors(brackets: &[WithRoots]) -> BTreeMap<String, usize> {
     let mut colors = BTreeMap::new();
     let mut next = 0usize;
@@ -127,237 +255,313 @@ fn allocate_colors(brackets: &[WithRoots]) -> BTreeMap<String, usize> {
     colors
 }
 
-/// Collects every rewritable `with_roots!` in a body, in source order.
+// ── move_pushes_earlier ─────────────────────────────────────────────
+
+/// `move_pushes_earlier`: which roots can be saved once, in the prologue,
+/// instead of at every bracket.
 ///
-/// A bracket inside a closure or a nested item is not collected, so it keeps
-/// the naive expansion. The frame is a local of the enclosing function, and a
-/// closure that captured it would extend the bracket past the frame's own
-/// scope -- upstream has the same boundary for free, because a nested graph is
-/// a separate graph with its own frame.
-struct Collect {
-    brackets: Vec<WithRoots>,
-    error: Option<syn::Error>,
-}
-
-impl VisitMut for Collect {
-    fn visit_expr_mut(&mut self, expr: &mut Expr) {
-        if let Expr::Closure(_) = expr {
-            return;
-        }
-        if let Expr::Macro(mac) = expr
-            && is_with_roots(&mac.mac)
+/// Upstream's example is a loop -- the store hoisted out and the load left
+/// inside -- and that is the shape this answers for. A root saved in the
+/// prologue needs no save at any bracket: the slot is the authoritative word,
+/// so each bracket reloads the local from it instead, which is what the
+/// hand-written brackets do when they read `shadow_stack_get(slot)` at every
+/// use rather than re-pinning per iteration.
+///
+/// Hoisting is sound for a root whose binding cannot change between the
+/// prologue and the bracket. A name qualifies when it is a parameter, or a
+/// `let` with a plain name bound exactly once, and the body never rebinds it:
+/// no assignment, no `&mut` borrow, no second binding of the name anywhere --
+/// a `for` pattern, a match arm and a closure parameter all rebind per entry.
+/// The restores this pass emits are assignments too, but they write the slot's
+/// own word, which is the invariant rather than a violation of it, so they are
+/// not counted.
+///
+/// A `let` qualifying does not prove it is in scope where the prologue lands,
+/// and this pass does not check: a `let` after that point, or inside a loop
+/// the prologue sits ahead of, fails to compile rather than hoisting a name
+/// that names nothing.
+///
+/// A macro body is opaque tokens at this point, so it is scanned for the same
+/// three shapes rather than parsed. The scan over-reports -- `a == b` is not
+/// an assignment, and neither is a `=` inside a nested macro that never
+/// expands -- and over-reporting only declines a hoist.
+fn hoistable(func: &ItemFn) -> BTreeSet<String> {
+    let mut params = BTreeSet::new();
+    for arg in &func.sig.inputs {
+        if let FnArg::Typed(typed) = arg
+            && let Pat::Ident(ident) = &*typed.pat
         {
-            match mac.mac.parse_body::<WithRoots>() {
-                Ok(parsed) => {
-                    // The body can hold further brackets; visit it, not the
-                    // unparsed token stream.
-                    let mut parsed = parsed;
-                    self.visit_expr_mut(&mut parsed.body);
-                    self.brackets.push(parsed);
-                }
-                Err(err) => {
-                    self.error.get_or_insert(err);
+            params.insert(ident.ident.to_string());
+        }
+    }
+    #[derive(Default)]
+    struct Rebound {
+        /// Names an assignment, a `&mut` borrow or an opaque macro can change.
+        assigned: BTreeSet<String>,
+        /// Plain `let name = ...;` bindings, and how many were seen.
+        let_bound: BTreeMap<String, usize>,
+        /// Bound somewhere a value arrives per entry rather than once.
+        other_bound: BTreeSet<String>,
+    }
+    impl Rebound {
+        fn note_path(&mut self, expr: &Expr) {
+            if let Expr::Path(path) = expr
+                && let Some(ident) = path.path.get_ident()
+            {
+                self.assigned.insert(ident.to_string());
+            }
+        }
+        /// `ident =` (but not `==`), `&mut ident`, and `let` bindings, over
+        /// tokens no parser will reach.
+        fn note_tokens(&mut self, tokens: &TokenStream) {
+            let trees: Vec<TokenTree> = tokens.clone().into_iter().collect();
+            for (i, tree) in trees.iter().enumerate() {
+                match tree {
+                    TokenTree::Group(group) => self.note_tokens(&group.stream()),
+                    TokenTree::Ident(ident) => {
+                        if let Some(TokenTree::Punct(punct)) = trees.get(i + 1)
+                            && punct.as_char() == '='
+                            && punct.spacing() == proc_macro2::Spacing::Alone
+                        {
+                            self.assigned.insert(ident.to_string());
+                        }
+                        // `&mut name`, and `let name`.
+                        if (ident == "mut" || ident == "let")
+                            && let Some(TokenTree::Ident(name)) = trees.get(i + 1)
+                        {
+                            self.assigned.insert(name.to_string());
+                        }
+                    }
+                    _ => {}
                 }
             }
-            return;
         }
-        visit_mut::visit_expr_mut(self, expr);
     }
-
-    /// A bracket written as a statement -- `with_roots!(obj, value => f(obj));`
-    /// -- parses as `Stmt::Macro`, never reaching `visit_expr_mut`. That is
-    /// the position most brackets are in, because most collecting operations
-    /// are performed for their effect.
-    fn visit_stmt_mut(&mut self, stmt: &mut Stmt) {
-        if let Stmt::Macro(mac) = stmt
-            && is_with_roots(&mac.mac)
-        {
-            match mac.mac.parse_body::<WithRoots>() {
-                Ok(mut parsed) => {
-                    self.visit_expr_mut(&mut parsed.body);
-                    self.brackets.push(parsed);
+    impl<'ast> syn::visit::Visit<'ast> for Rebound {
+        fn visit_expr(&mut self, expr: &'ast Expr) {
+            match expr {
+                // The bracket's own restores are the invariant, not a rebind;
+                // its body is still walked for everything else.
+                Expr::Macro(mac) if is_with_roots(&mac.mac) => {
+                    if let Ok(bracket) = mac.mac.parse_body::<WithRoots>() {
+                        self.visit_expr(&bracket.body);
+                    }
+                    return;
                 }
-                Err(err) => {
-                    self.error.get_or_insert(err);
+                Expr::Assign(assign) => self.note_path(&assign.left),
+                Expr::Binary(binary) => {
+                    use syn::BinOp::*;
+                    if matches!(
+                        binary.op,
+                        AddAssign(_)
+                            | SubAssign(_)
+                            | MulAssign(_)
+                            | DivAssign(_)
+                            | RemAssign(_)
+                            | BitXorAssign(_)
+                            | BitAndAssign(_)
+                            | BitOrAssign(_)
+                            | ShlAssign(_)
+                            | ShrAssign(_)
+                    ) {
+                        self.note_path(&binary.left);
+                    }
                 }
+                Expr::Reference(reference) if reference.mutability.is_some() => {
+                    self.note_path(&reference.expr)
+                }
+                Expr::Macro(mac) => self.note_tokens(&mac.mac.tokens),
+                _ => {}
             }
-            return;
+            syn::visit::visit_expr(self, expr);
         }
-        visit_mut::visit_stmt_mut(self, stmt);
+        fn visit_stmt(&mut self, stmt: &'ast Stmt) {
+            match stmt {
+                Stmt::Macro(mac) => {
+                    if is_with_roots(&mac.mac) {
+                        if let Ok(bracket) = mac.mac.parse_body::<WithRoots>() {
+                            self.visit_expr(&bracket.body);
+                        }
+                        return;
+                    }
+                    self.note_tokens(&mac.mac.tokens);
+                }
+                // A plain `let name = ...;` is the one binding form that
+                // delivers a value once; every other one this visitor reaches
+                // through `visit_pat_ident` delivers per entry.
+                Stmt::Local(local) => {
+                    if let Pat::Ident(ident) = &local.pat
+                        && ident.subpat.is_none()
+                    {
+                        *self.let_bound.entry(ident.ident.to_string()).or_default() += 1;
+                        if let Some(init) = &local.init {
+                            self.visit_expr(&init.expr);
+                            if let Some((_, diverge)) = &init.diverge {
+                                self.visit_expr(diverge);
+                            }
+                        }
+                        return;
+                    }
+                }
+                _ => {}
+            }
+            syn::visit::visit_stmt(self, stmt);
+        }
+        fn visit_pat_ident(&mut self, pat: &'ast syn::PatIdent) {
+            self.other_bound.insert(pat.ident.to_string());
+            syn::visit::visit_pat_ident(self, pat);
+        }
+        /// A nested item is a separate graph; its names are not these names.
+        fn visit_item(&mut self, _item: &'ast syn::Item) {}
     }
 
-    fn visit_item_mut(&mut self, _item: &mut syn::Item) {}
+    let mut rebound = Rebound::default();
+    for stmt in &func.block.stmts {
+        syn::visit::Visit::visit_stmt(&mut rebound, stmt);
+    }
+    let mut names = params;
+    names.extend(
+        rebound
+            .let_bound
+            .iter()
+            .filter(|(_, count)| **count == 1)
+            .map(|(name, _)| name.clone()),
+    );
+    names.retain(|name| !rebound.assigned.contains(name) && !rebound.other_bound.contains(name));
+    names
 }
 
-/// Rewrites each collected bracket into its `gc_save_root` /
-/// `gc_restore_root` series against the function's frame.
-struct Rewrite<'a> {
+// ── expand_push_roots / expand_pop_roots ────────────────────────────
+
+/// Rewrites each bracket into its `gc_save_root` / `gc_restore_root` series
+/// against the function's frame.
+pub struct Rewrite<'a> {
     colors: &'a BTreeMap<String, usize>,
+    /// The roots this site saved on arrival; owned, because the set differs
+    /// per site and the sites are built one at a time.
+    hoisted: BTreeSet<String>,
     frame: &'a Ident,
     base: &'a Ident,
     error: Option<syn::Error>,
 }
 
-impl VisitMut for Rewrite<'_> {
-    fn visit_expr_mut(&mut self, expr: &mut Expr) {
-        if let Expr::Closure(_) = expr {
-            return;
-        }
-        let Expr::Macro(mac) = expr else {
-            visit_mut::visit_expr_mut(self, expr);
-            return;
-        };
-        if !is_with_roots(&mac.mac) {
-            visit_mut::visit_expr_mut(self, expr);
-            return;
-        }
-        let mut parsed = match mac.mac.parse_body::<WithRoots>() {
-            Ok(parsed) => parsed,
-            Err(err) => {
-                self.error.get_or_insert(err);
-                return;
-            }
-        };
-        self.visit_expr_mut(&mut parsed.body);
-        *expr = self.expand(&parsed);
-    }
-
-    /// The [`Collect`] twin: rewrite a statement-position bracket in place,
-    /// keeping its trailing semicolon so the block's value is unchanged.
-    fn visit_stmt_mut(&mut self, stmt: &mut Stmt) {
-        let Stmt::Macro(mac) = stmt else {
-            visit_mut::visit_stmt_mut(self, stmt);
-            return;
-        };
-        if !is_with_roots(&mac.mac) {
-            visit_mut::visit_stmt_mut(self, stmt);
-            return;
-        }
-        let semi = mac.semi_token;
-        let mut parsed = match mac.mac.parse_body::<WithRoots>() {
-            Ok(parsed) => parsed,
-            Err(err) => {
-                self.error.get_or_insert(err);
-                return;
-            }
-        };
-        self.visit_expr_mut(&mut parsed.body);
-        *stmt = Stmt::Expr(self.expand(&parsed), semi);
-    }
-
-    fn visit_item_mut(&mut self, _item: &mut syn::Item) {}
-}
-
 impl Rewrite<'_> {
-    fn expand(&self, bracket: &WithRoots) -> Expr {
-        let (frame, base) = (self.frame, self.base);
-        let slots: Vec<TokenStream> = bracket
-            .locals
-            .iter()
-            .map(|local| {
-                // `Collect` and `Rewrite` traverse identically, so every
-                // rewritten root was coloured; naming the invariant beats an
-                // index panic if a future traversal drifts apart.
-                let color = *self
-                    .colors
-                    .get(&local.to_string())
-                    .expect("a rewritten root was not coloured: the collect and rewrite traversals disagree");
-                quote!(#base + #color)
-            })
-            .collect();
-        let locals = &bracket.locals;
-        let body = &bracket.body;
-        // `save_run` publishes every value before resolving forwarding for
-        // any, which is `expand_one_push_roots`'s series plus the safepoint
-        // rule `pin_roots` states. The restores are `expand_one_pop_roots`:
-        // `gc_restore_root`'s whole body is `setvar(v_value, newvalue)`, so
-        // after the bracket the local *is* the live word.
-        syn::parse_quote!({
-            #frame.save_run(&[#((#slots, #locals)),*]);
-            let __roots_result = #body;
-            #(#locals = #frame.get(#slots);)*
-            __roots_result
-        })
+    fn slot(&self, local: &Ident) -> TokenStream {
+        let base = self.base;
+        // The colouring walked the same traversal, so every rewritten root has
+        // a colour; naming the invariant beats an index panic if the two ever
+        // drift apart.
+        let color = *self.colors.get(&local.to_string()).expect(
+            "a rewritten root was not coloured: the collect and rewrite traversals disagree",
+        );
+        quote!(#base + #color)
     }
 }
 
-/// `add_enter_leave_roots_frame`, at the granularity this pass can prove.
+impl Handler for Rewrite<'_> {
+    fn bracket(&mut self, bracket: WithRoots) -> Option<Expr> {
+        let frame = self.frame;
+        let mut saves = Vec::new();
+        let mut reloads = Vec::new();
+        let mut restores = Vec::new();
+        for local in &bracket.locals {
+            let slot = self.slot(local);
+            if self.hoisted.contains(&local.to_string()) {
+                // Saved once in the prologue. The slot is the live word and
+                // the local may not be, so the body reads the slot.
+                reloads.push(quote!(#local = #frame.get(#slot);));
+            } else {
+                saves.push(quote!((#slot, #local)));
+            }
+            restores.push(quote!(#local = #frame.get(#slot);));
+        }
+        // `expand_one_push_roots`'s series, plus the safepoint rule
+        // `pin_roots` states: publish the whole set before querying any of it.
+        let save = (!saves.is_empty()).then(|| quote!(#frame.save_run(&[#(#saves),*]);));
+        let body = &bracket.body;
+        // `expand_one_pop_roots`: `gc_restore_root`'s whole body is
+        // `setvar(v_value, newvalue)`, so after the bracket the local *is* the
+        // live word.
+        // Parenthesised: a bare block in a condition -- `if let Some(c) =
+        // with_roots!(..) && ..` -- would be read as the `if`'s own body.  The
+        // `macro_rules!` form is immune because a macro call is an expression
+        // before it expands; this output is tokens rustc parses fresh.
+        Some(syn::parse_quote!(({
+            #save
+            #(#reloads)*
+            let __roots_result = #body;
+            #(#restores)*
+            __roots_result
+        })))
+    }
+
+    fn error(&mut self, err: syn::Error) {
+        self.error.get_or_insert(err);
+    }
+}
+
+// ── add_enter_leave_roots_frame ─────────────────────────────────────
+
+/// Where the frame is entered, and what it saves on arrival.
 ///
 /// Upstream puts `gc_enter_roots_frame` as late as possible -- just before the
-/// first `gc_save_root` any path reaches -- and the leave as early as possible.
-/// A frame at the top of the body would instead charge every call that never
-/// reaches a bracket, and a bracket usually guards a slow path: the two pilot
-/// functions bracket only their strategy-switch and reentrant-probe arms, so
-/// the ordinary store would pay a frame it never uses.
+/// first `gc_save_root` any path reaches -- and the leave as early as
+/// possible. A frame at the top of the body would instead charge every call
+/// that never reaches a bracket, and a bracket usually guards a slow path.
 ///
-/// The block that gets the frame is the innermost one still containing every
-/// bracket, found by descending while a single branch holds all of them.
-/// Loops are not entered: a frame inside a loop body is re-entered per
-/// iteration, which is the direction `move_pushes_earlier` exists to undo.
-/// Closures are not entered either, matching [`Collect`].
+/// Guard arms that leave the function take their own frame, so a chain of them
+/// charges only the arm that runs. That is where the hand-written brackets put
+/// `push_roots()`: inside the arm, not ahead of the chain that selects it.
+/// Whatever is left over shares one frame, placed before the first statement
+/// that needs it, and descending while a single branch holds all of it. Loops
+/// are not entered -- a frame inside a loop body is re-entered per iteration,
+/// which is the direction `move_pushes_earlier` exists to undo -- and neither
+/// are closures, matching [`Walk`].
+///
+/// The leave needs no placement: the frame is a scope guard, so it pops at the
+/// end of whichever block the enter landed in.
+///
+/// Placement and rewriting are one pass because they are one decision.
+/// `move_pushes_earlier`'s hoist is what a site saves on arrival, and a root
+/// can only be hoisted where it is already in scope -- which differs per site,
+/// so the brackets a site serves have to be expanded against that site's own
+/// answer.  A single global answer would have a bracket reload a colour its
+/// site never saved.
 mod place {
-    use super::{Stmt, is_with_roots};
-    use syn::{Block, Expr};
+    use super::{Block, Count, Expr, Ident, Names, Rewrite, Stmt, Walk};
+    use std::collections::BTreeSet;
+    use syn::visit_mut::VisitMut;
+
+    /// Brackets in a statement, by the traversal every other pass uses.
+    fn in_stmt(stmt: &Stmt) -> usize {
+        let mut walk = Walk(Count::default());
+        walk.visit_stmt_mut(&mut stmt.clone());
+        walk.0.0
+    }
 
     pub fn in_block(block: &Block) -> usize {
         block.stmts.iter().map(in_stmt).sum()
     }
 
-    pub fn in_stmt(stmt: &Stmt) -> usize {
-        match stmt {
-            Stmt::Macro(mac) if is_with_roots(&mac.mac) => 1,
-            Stmt::Expr(expr, _) => in_expr(expr),
-            Stmt::Local(local) => local
-                .init
-                .as_ref()
-                .map(|init| {
-                    in_expr(&init.expr) + init.diverge.as_ref().map_or(0, |(_, e)| in_expr(e))
-                })
-                .unwrap_or(0),
-            // An item is a separate graph with its own frame.
-            Stmt::Item(_) => 0,
-            Stmt::Macro(_) => 0,
+    /// The root names the brackets in these statements address.
+    fn names_in(stmts: &[Stmt]) -> BTreeSet<String> {
+        let mut walk = Walk(Names::default());
+        for stmt in stmts {
+            walk.visit_stmt_mut(&mut stmt.clone());
         }
+        walk.0.0
     }
 
-    /// Counts brackets in `expr`, by the same traversal [`super::Collect`]
-    /// uses -- the two must agree, or the frame could be installed somewhere
-    /// that does not dominate every rewritten bracket.
-    pub fn in_expr(expr: &Expr) -> usize {
-        struct Count(usize);
-        impl<'ast> syn::visit::Visit<'ast> for Count {
-            fn visit_expr(&mut self, expr: &'ast Expr) {
-                if let Expr::Closure(_) = expr {
-                    return;
-                }
-                if let Expr::Macro(mac) = expr
-                    && is_with_roots(&mac.mac)
-                {
-                    self.0 += 1;
-                    if let Ok(parsed) = mac.mac.parse_body::<super::WithRoots>() {
-                        self.visit_expr(&parsed.body);
-                    }
-                    return;
-                }
-                syn::visit::visit_expr(self, expr);
-            }
-            fn visit_stmt(&mut self, stmt: &'ast Stmt) {
-                if let Stmt::Macro(mac) = stmt
-                    && is_with_roots(&mac.mac)
-                {
-                    self.0 += 1;
-                    if let Ok(parsed) = mac.mac.parse_body::<super::WithRoots>() {
-                        self.visit_expr(&parsed.body);
-                    }
-                    return;
-                }
-                syn::visit::visit_stmt(self, stmt);
-            }
-            fn visit_item(&mut self, _item: &'ast syn::Item) {}
+    /// The name a plain `let name = ...;` introduces, which is the only
+    /// binding form [`super::hoistable`] admits.
+    fn binds(stmt: &Stmt) -> Option<String> {
+        let Stmt::Local(local) = stmt else {
+            return None;
+        };
+        match &local.pat {
+            syn::Pat::Ident(ident) if ident.subpat.is_none() => Some(ident.ident.to_string()),
+            _ => None,
         }
-        let mut count = Count(0);
-        syn::visit::Visit::visit_expr(&mut count, expr);
-        count.0
     }
 
     /// The blocks a statement branches into, for a descent that must not
@@ -387,44 +591,147 @@ mod place {
         }
     }
 
-    /// Insert `prologue` at the latest point that still dominates every
-    /// bracket, and report where it landed for the caller to check.
-    pub fn install(block: &mut Block, prologue: &[Stmt]) {
-        let total = in_block(block);
-        debug_assert!(total > 0);
-        let counts: Vec<usize> = block.stmts.iter().map(in_stmt).collect();
-        let first = counts.iter().position(|&n| n > 0).expect("a bracket");
-        if counts[first] == total {
+    /// Does this block leave the enclosing function or loop at its end?
+    ///
+    /// A guard arm that does is exclusive with everything after it, so a frame
+    /// inside it is entered exactly on the paths that reach a bracket.
+    fn diverges(block: &Block) -> bool {
+        matches!(
+            block.stmts.last(),
+            Some(Stmt::Expr(
+                Expr::Return(_) | Expr::Break(_) | Expr::Continue(_),
+                _
+            ))
+        )
+    }
+
+    /// The arms of a guard statement that hold brackets, when every one of
+    /// them diverges. `None` keeps the statement on the shared frame.
+    fn guard_arms(stmt: &mut Stmt) -> Option<Vec<&mut Block>> {
+        let Stmt::Expr(expr, _) = stmt else {
+            return None;
+        };
+        if !matches!(expr, Expr::If(_) | Expr::Match(_)) {
+            return None;
+        }
+        let mut arms = branches(expr);
+        arms.retain(|arm| in_block(arm) > 0);
+        if arms.is_empty() || !arms.iter().all(|arm| diverges(arm)) {
+            return None;
+        }
+        Some(arms)
+    }
+
+    /// What every site shares: how to build a prologue, and how to expand a
+    /// bracket once the site's hoist set is known.
+    pub struct Sites<'a> {
+        pub hoistable: &'a BTreeSet<String>,
+        pub prologue: &'a dyn Fn(&BTreeSet<String>) -> Vec<Stmt>,
+        pub rewrite: &'a dyn Fn(&BTreeSet<String>) -> Rewrite<'a>,
+    }
+
+    /// Place the frames in `block` and expand the brackets each one serves.
+    ///
+    /// `in_scope` is the names an enclosing block has already bound at the
+    /// point this one starts; a root is hoisted only if it is in scope where
+    /// its site lands, so a `let` further down cannot be saved ahead of
+    /// itself.
+    pub fn install(
+        block: &mut Block,
+        in_scope: &BTreeSet<String>,
+        sites: &Sites<'_>,
+    ) -> Option<syn::Error> {
+        let mut scope = in_scope.clone();
+        let mut scope_at: Vec<BTreeSet<String>> = Vec::with_capacity(block.stmts.len());
+        for stmt in &block.stmts {
+            scope_at.push(scope.clone());
+            if let Some(name) = binds(stmt) {
+                scope.insert(name);
+            }
+        }
+
+        let mut error = None;
+        let mut handled = vec![false; block.stmts.len()];
+        for index in 0..block.stmts.len() {
+            let outside = in_stmt(&block.stmts[index]);
+            if outside == 0 {
+                continue;
+            }
+            let here = scope_at[index].clone();
+            let Some(arms) = guard_arms(&mut block.stmts[index]) else {
+                continue;
+            };
+            // A bracket in the condition or the scrutinee is outside every
+            // arm, and would lose the frame the arms take with them.
+            if arms.iter().map(|arm| in_block(arm)).sum::<usize>() != outside {
+                continue;
+            }
+            for arm in arms {
+                error = error.or(install(arm, &here, sites));
+            }
+            handled[index] = true;
+        }
+
+        let counts: Vec<usize> = block
+            .stmts
+            .iter()
+            .enumerate()
+            .map(|(index, stmt)| if handled[index] { 0 } else { in_stmt(stmt) })
+            .collect();
+        let remaining: usize = counts.iter().sum();
+        let Some(first) = counts.iter().position(|&n| n > 0) else {
+            return error;
+        };
+        if counts[first] == remaining {
             let descend = match &mut block.stmts[first] {
                 Stmt::Expr(expr, _) => Some(expr),
                 Stmt::Local(local) => local.init.as_mut().map(|init| &mut *init.expr),
                 _ => None,
             };
+            let here = scope_at[first].clone();
             if let Some(expr) = descend
                 && let Some(inner) = branches(expr)
                     .into_iter()
-                    .find(|inner| in_block(inner) == total)
+                    .find(|inner| in_block(inner) == remaining)
             {
-                install(inner, prologue);
-                return;
+                return error.or(install(inner, &here, sites));
             }
         }
-        block.stmts.splice(first..first, prologue.iter().cloned());
+
+        let hoist: BTreeSet<String> = names_in(&block.stmts[first..])
+            .into_iter()
+            .filter(|name| sites.hoistable.contains(name) && scope_at[first].contains(name))
+            .collect();
+        let prologue = (sites.prologue)(&hoist);
+        let shift = prologue.len();
+        block.stmts.splice(first..first, prologue);
+
+        // From past the prologue, whose own statements hold no bracket. The
+        // splice shifted every original statement at or after `first` by
+        // `shift`, so that is what maps a position back into `handled`.
+        let mut rewrite = Walk((sites.rewrite)(&hoist));
+        for index in (first + shift)..block.stmts.len() {
+            if handled[index - shift] {
+                continue; // an arm rewrote this statement against its own site
+            }
+            rewrite.visit_stmt_mut(&mut block.stmts[index]);
+        }
+        error.or(rewrite.0.error)
     }
 }
 
+// ── postprocess_graph ───────────────────────────────────────────────
+
 pub fn expand(mut func: ItemFn) -> syn::Result<TokenStream> {
-    let mut collect = Collect {
-        brackets: Vec::new(),
-        error: None,
-    };
+    let mut collect = Walk(Collect::default());
     // `visit_block_mut` rather than `visit_item_fn_mut`: the latter would be
-    // stopped by this visitor's own `visit_item_mut` guard.
-    collect.visit_block_mut(&mut func.block);
-    if let Some(err) = collect.error {
+    // stopped by the walk's own `visit_item_mut` guard.
+    collect.visit_block_mut(&mut func.block.clone());
+    if let Some(err) = collect.0.error {
         return Err(err);
     }
-    if collect.brackets.is_empty() {
+    let brackets = collect.0.brackets;
+    if brackets.is_empty() {
         return Err(syn::Error::new(
             func.sig.ident.span(),
             "#[gc_roots] found no `with_roots!` bracket to transform. \
@@ -433,30 +740,58 @@ pub fn expand(mut func: ItemFn) -> syn::Result<TokenStream> {
         ));
     }
 
-    let colors = allocate_colors(&collect.brackets);
+    let colors = allocate_colors(&brackets);
     let numcolors = colors.len();
+    let named: BTreeSet<String> = brackets
+        .iter()
+        .flat_map(|bracket| bracket.locals.iter().map(Ident::to_string))
+        .collect();
+    let mut hoistable = hoistable(&func);
+    hoistable.retain(|name| named.contains(name));
+
     let frame = format_ident!("__pyre_gc_frame", span = Span::call_site());
     let base = format_ident!("__pyre_gc_base", span = Span::call_site());
 
-    // `add_enter_leave_roots_frame` before the expansion, so the search counts
-    // `with_roots!` invocations rather than the blocks they become. The leave
-    // needs no placement: the frame is a scope guard, so it pops at the end of
-    // whichever block the enter landed in -- the earliest point that still
-    // covers every restore.
-    let prologue: Vec<Stmt> = syn::parse_quote! {
-        let #frame = ::pyre_object::gc_roots::enter_roots_frame(#numcolors);
-        let #base = ::pyre_object::gc_roots::RootScope::base(&#frame);
+    // `move_pushes_earlier`'s output: one `gc_save_root` series on arrival at
+    // the frame, standing in for the one every bracket would otherwise run.
+    let prologue = |hoist: &BTreeSet<String>| -> Vec<Stmt> {
+        let saves: Vec<TokenStream> = hoist
+            .iter()
+            .map(|name| {
+                let local = format_ident!("{}", name, span = Span::call_site());
+                let color = colors[name];
+                quote!((#base + #color, #local))
+            })
+            .collect();
+        let save = (!saves.is_empty()).then(|| quote!(#frame.save_run(&[#(#saves),*]);));
+        syn::parse_quote! {
+            let #frame = ::pyre_object::gc_roots::enter_roots_frame(#numcolors);
+            let #base = ::pyre_object::gc_roots::RootScope::base(&#frame);
+            #save
+        }
     };
-    place::install(&mut func.block, &prologue);
-
-    let mut rewrite = Rewrite {
+    let rewrite = |hoist: &BTreeSet<String>| Rewrite {
         colors: &colors,
+        hoisted: hoist.clone(),
         frame: &frame,
         base: &base,
         error: None,
     };
-    rewrite.visit_block_mut(&mut func.block);
-    if let Some(err) = rewrite.error {
+
+    let mut in_scope = BTreeSet::new();
+    for arg in &func.sig.inputs {
+        if let FnArg::Typed(typed) = arg
+            && let Pat::Ident(ident) = &*typed.pat
+        {
+            in_scope.insert(ident.ident.to_string());
+        }
+    }
+    let sites = place::Sites {
+        hoistable: &hoistable,
+        prologue: &prologue,
+        rewrite: &rewrite,
+    };
+    if let Some(err) = place::install(&mut func.block, &in_scope, &sites) {
         return Err(err);
     }
 

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -48,6 +48,20 @@ use syn::{
     parse_macro_input, parse_quote, spanned::Spanned,
 };
 
+mod gc_roots;
+
+/// `shadowcolor.py postprocess_graph` for one function: collapse the
+/// per-operation `with_roots!` brackets in the body into a single coloured
+/// root frame.  See `gc_roots.rs` for what each upstream pass becomes here.
+#[proc_macro_attribute]
+pub fn gc_roots(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let func = parse_macro_input!(item as ItemFn);
+    match gc_roots::expand(func) {
+        Ok(ts) => ts.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
 #[proc_macro_attribute]
 pub fn pyre_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let func = parse_macro_input!(item as ItemFn);

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -3006,6 +3006,7 @@ pub unsafe fn w_dict_store_hashed_checked(
     w_dict_store_checked_inner(obj, key, value, Some(hash))
 }
 
+#[pyre_macros::gc_roots]
 unsafe fn w_dict_store_checked_inner(
     mut obj: PyObjectRef,
     key: PyObjectRef,
@@ -4040,6 +4041,7 @@ pub unsafe fn w_dict_delitem_checked(
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
+#[pyre_macros::gc_roots]
 pub unsafe fn w_dict_delitem_if_value_is_checked(
     mut obj: PyObjectRef,
     key: PyObjectRef,

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -2689,34 +2689,6 @@ macro_rules! callback_free_dict_op {
     }};
 }
 
-/// Evaluate `$body` with `$obj` published, then rebind `$obj` to the address
-/// it has afterwards and yield the body's value.
-///
-/// The re-read [`DictOperationGuard::root`] documents, for the helpers that
-/// run below a caller's guard and so cannot reach its slots.
-///
-/// A macro rather than a helper taking `impl FnOnce`, for the reason
-/// `callback_free_dict_op!` gives: a closure has no lifted counterpart, so
-/// every dict graph that reached one would stop there.
-macro_rules! with_dict_rooted {
-    ($obj:ident, $value:ident, $body:expr) => {{
-        let _scope = crate::gc_roots::push_roots();
-        let base = crate::gc_roots::pin_roots(&[$obj, $value]);
-        let result = $body;
-        $obj = crate::gc_roots::shadow_stack_get(base);
-        $value = crate::gc_roots::shadow_stack_get(base + 1);
-        result
-    }};
-    ($obj:ident, $body:expr) => {{
-        let _scope = crate::gc_roots::push_roots();
-        let slot = crate::gc_roots::shadow_stack_len();
-        let _ = crate::gc_roots::pin_root($obj);
-        let result = $body;
-        $obj = crate::gc_roots::shadow_stack_get(slot);
-        result
-    }};
-}
-
 /// The `ObjectKey`-keyed storage servicing the reentrant scan, for either a
 /// regular `W_DictObject` in object strategy (`dstorage`) or a module dict
 /// switched to object strategy (`object_storage`).  Both hold the same
@@ -3064,7 +3036,7 @@ unsafe fn w_dict_store_checked_inner(
             w_dict_store_bytes_strategy(obj, key, value);
             return Ok(());
         }
-        with_dict_rooted!(obj, value, strategy.switch_to_object_strategy(obj));
+        crate::with_roots!(obj, value => strategy.switch_to_object_strategy(obj));
         return w_dict_store_object_strategy_checked_inner(obj, key, value, hash);
     }
     if strategy_is(strategy, &crate::dictmultiobject::UNICODE_DICT_STRATEGY) {
@@ -3078,7 +3050,7 @@ unsafe fn w_dict_store_checked_inner(
             w_dict_store_int_strategy(obj, key, value);
             return Ok(());
         }
-        with_dict_rooted!(obj, value, strategy.switch_to_object_strategy(obj));
+        crate::with_roots!(obj, value => strategy.switch_to_object_strategy(obj));
         return w_dict_store_object_strategy_checked_inner(obj, key, value, hash);
     }
     if strategy_is(strategy, &crate::identitydict::IDENTITY_DICT_STRATEGY) {
@@ -3086,7 +3058,7 @@ unsafe fn w_dict_store_checked_inner(
             strategy.setitem(obj, key, value);
             return Ok(());
         }
-        with_dict_rooted!(obj, value, strategy.switch_to_object_strategy(obj));
+        crate::with_roots!(obj, value => strategy.switch_to_object_strategy(obj));
         return w_dict_store_object_strategy_checked_inner(obj, key, value, hash);
     }
     if strategy_is(strategy, &crate::kwargsdict::KWARGS_DICT_STRATEGY) {
@@ -3094,7 +3066,7 @@ unsafe fn w_dict_store_checked_inner(
             strategy.setitem(obj, key, value);
             return Ok(());
         }
-        with_dict_rooted!(obj, value, strategy.switch_to_object_strategy(obj));
+        crate::with_roots!(obj, value => strategy.switch_to_object_strategy(obj));
         return w_dict_store_object_strategy_checked_inner(obj, key, value, hash);
     }
     if strategy.strategy_kind() == StrategyKind::Map {
@@ -3109,7 +3081,7 @@ unsafe fn w_dict_store_checked_inner(
             strategy.setitem(obj, key, value);
             return Ok(());
         }
-        with_dict_rooted!(obj, value, strategy.switch_to_object_strategy(obj));
+        crate::with_roots!(obj, value => strategy.switch_to_object_strategy(obj));
         return w_dict_store_object_strategy_checked_inner(obj, key, value, hash);
     }
     strategy.setitem(obj, key, value);
@@ -4075,9 +4047,9 @@ pub unsafe fn w_dict_delitem_if_value_is_checked(
 ) -> Result<bool, DictKeyError> {
     if is_module_dict(obj) {
         if !w_module_dict_is_object_strategy(obj) {
-            with_dict_rooted!(obj, value, w_module_dict_switch_to_object_strategy(obj));
+            crate::with_roots!(obj, value => w_module_dict_switch_to_object_strategy(obj));
         }
-        let object_key = with_dict_rooted!(obj, value, object_key_for_checked(key)?);
+        let object_key = crate::with_roots!(obj, value => object_key_for_checked(key)?);
         if let Some(result) = callback_free_dict_op!({
             let entries = w_module_dict_object_storage_mut(obj);
             match entries.get_index_of(&object_key) {
@@ -4123,9 +4095,9 @@ pub unsafe fn w_dict_delitem_if_value_is_checked(
 
     let strategy = (*(obj as *const W_DictObject)).dstrategy.imp;
     if strategy.strategy_kind() != StrategyKind::Object {
-        with_dict_rooted!(obj, value, strategy.switch_to_object_strategy(obj));
+        crate::with_roots!(obj, value => strategy.switch_to_object_strategy(obj));
     }
-    let object_key = with_dict_rooted!(obj, value, object_key_for_checked(key)?);
+    let object_key = crate::with_roots!(obj, value => object_key_for_checked(key)?);
     if let Some(result) = callback_free_dict_op!({
         let dict = &mut *(obj as *mut W_DictObject);
         let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -1236,6 +1236,114 @@ mod tests {
         assert_eq!(shadow_stack_len(), before, "the frame guard still pops it");
     }
 
+    /// A chain of guard arms that leave the function takes one frame per arm,
+    /// so the path that reaches no bracket reserves nothing and the path that
+    /// reaches one reserves only its own. This is the placement the
+    /// hand-written brackets use: `push_roots()` inside the arm, not ahead of
+    /// the chain that selects it.
+    #[test]
+    fn each_diverging_guard_arm_takes_its_own_frame() {
+        #[pyre_macros::gc_roots]
+        fn dispatch(mut a: PyObjectRef, which: u8) -> usize {
+            if which == 1 {
+                return crate::with_roots!(a => shadow_stack_len());
+            }
+            if which == 2 {
+                return crate::with_roots!(a => shadow_stack_len());
+            }
+            shadow_stack_len()
+        }
+        let before = shadow_stack_len();
+        assert_eq!(dispatch(dummy(0x10), 0), before, "no arm taken, no frame");
+        assert_eq!(
+            dispatch(dummy(0x10), 1),
+            before + 1,
+            "one colour, one frame"
+        );
+        assert_eq!(
+            dispatch(dummy(0x10), 2),
+            before + 1,
+            "the second arm does not stack a frame the first arm opened"
+        );
+        assert_eq!(shadow_stack_len(), before);
+    }
+
+    /// `move_pushes_earlier`: a root the body never rebinds is saved once, in
+    /// the prologue ahead of the loop, and each bracket reads the slot rather
+    /// than re-saving the local. That is what the hand-written brackets do
+    /// when they call `shadow_stack_get(slot)` at every use, and it is why a
+    /// value the collector forwarded mid-loop is the one the body sees: the
+    /// slot is the live word, the local is a copy of an older one.
+    #[test]
+    fn a_hoisted_root_is_saved_once_and_every_bracket_reads_the_slot() {
+        #[pyre_macros::gc_roots]
+        fn walk(mut a: PyObjectRef, n: usize) -> Vec<PyObjectRef> {
+            let mut seen = Vec::new();
+            for i in 0..n {
+                if i == 1 {
+                    // Forward the root the way a moving collector's walker
+                    // does, leaving the local naming the old address.
+                    shadow_stack_set(shadow_stack_len() - 1, dummy(0x2222));
+                }
+                seen.push(crate::with_roots!(a => a));
+            }
+            seen
+        }
+        let before = shadow_stack_len();
+        assert_eq!(
+            walk(dummy(0x10), 3),
+            vec![dummy(0x10), dummy(0x2222), dummy(0x2222)],
+            "a re-saved local would have clobbered the forwarded slot"
+        );
+        assert_eq!(shadow_stack_len(), before);
+    }
+
+    /// A `let` root bound once and never reassigned hoists like a parameter:
+    /// the union-classinfo walk binds its argument tuple that way, and the
+    /// hand-written bracket pins it once ahead of the loop.
+    #[test]
+    fn a_let_bound_root_hoists_when_it_is_bound_once() {
+        #[pyre_macros::gc_roots]
+        fn walk(seed: PyObjectRef, n: usize) -> Vec<PyObjectRef> {
+            let mut args = seed;
+            let mut seen = Vec::new();
+            for i in 0..n {
+                if i == 1 {
+                    shadow_stack_set(shadow_stack_len() - 1, dummy(0x3333));
+                }
+                seen.push(crate::with_roots!(args => args));
+            }
+            seen
+        }
+        let before = shadow_stack_len();
+        assert_eq!(
+            walk(dummy(0x10), 3),
+            vec![dummy(0x10), dummy(0x3333), dummy(0x3333)]
+        );
+        assert_eq!(shadow_stack_len(), before);
+    }
+
+    /// The other direction: a root the body assigns is not constant between
+    /// the prologue and the bracket, so its save may not be hoisted. Reading
+    /// the slot there would answer with the value the parameter used to hold.
+    #[test]
+    fn a_reassigned_root_keeps_its_per_bracket_save() {
+        #[pyre_macros::gc_roots]
+        fn reassign(mut a: PyObjectRef, b: PyObjectRef) -> (PyObjectRef, PyObjectRef) {
+            let first = crate::with_roots!(a => a);
+            a = b;
+            let second = crate::with_roots!(a => a);
+            (first, second)
+        }
+        let before = shadow_stack_len();
+        assert_eq!(
+            reassign(dummy(0x10), dummy(0x20)),
+            (dummy(0x10), dummy(0x20)),
+            "the second bracket must publish the new binding, not reload the old"
+        );
+        assert_eq!(shadow_stack_len(), before);
+    }
+
     /// `add_enter_leave_roots_frame`: the enter goes as late as possible, so a
     /// call that never reaches a bracket never reserves a colour. A frame at
     /// the top of the body would charge the fast path for the slow path's

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -553,6 +553,31 @@ impl RootScope {
         // SAFETY: `stack_slot` is this thread's live root-stack cell.
         normalize_published_slot(unsafe { &*self.stack_slot }, index);
     }
+
+    /// One bracket's whole `gc_save_root` series against an
+    /// [`enter_roots_frame`] frame: `expand_one_push_roots` emits one save per
+    /// live variable, and this performs that series over already-reserved
+    /// slots.
+    ///
+    /// Stores every value before resolving forwarding for any of them, which
+    /// is the split [`pin_roots`] exists to preserve: the forwarding query is
+    /// itself a safepoint, so querying after the first store would let a
+    /// foreign collection run while the later values are still invisible.
+    /// Upstream needs no such split -- its `gc_save_root` is a bare store, and
+    /// nothing between two of them can collect.
+    #[majit_macros::dont_look_inside]
+    pub fn save_run(&self, saves: &[(usize, PyObjectRef)]) {
+        #[cfg(debug_assertions)]
+        assert_shadow_stack_not_walking();
+        for &(index, root) in saves {
+            // SAFETY: same cell; `slot` bounds-checks `index`.
+            unsafe { *(*self.stack_slot).slot(index) = root };
+        }
+        for &(index, _) in saves {
+            // SAFETY: `stack_slot` is this thread's live root-stack cell.
+            normalize_published_slot(unsafe { &*self.stack_slot }, index);
+        }
+    }
 }
 
 impl Drop for RootScope {
@@ -567,6 +592,42 @@ impl Drop for RootScope {
         // the steady-state case for an empty bracket.
         shadow_stack_cell_truncate(self.stack_slot, self.save_point);
     }
+}
+
+/// `gc_enter_roots_frame` (`shadowcolor.py add_enter_leave_roots_frame`):
+/// open one bracket that owns `numcolors` slots for a whole function, instead
+/// of one bracket per collecting operation.
+///
+/// `numcolors` is a colour count, not a save count: `allocate_registers` runs
+/// a register allocator over the graph, so two roots share a slot whenever
+/// their live ranges do not overlap, and the frame is as wide as the roots
+/// that are live at once. Every `gc_save_root` afterwards addresses
+/// `base() + colour` and overwrites whatever the previous bracket left there.
+///
+/// The reserved slots are cleared. The shadow stack is append-only and
+/// [`RootScope`]'s drop only rewinds `top`, so a slot handed out here can
+/// still hold the word some earlier, already-popped bracket published; a
+/// walker reaching it would trace a corpse. Upstream does not clear, because
+/// `make_bitmask` tells its walker which entries of a fixed frame are unused;
+/// pyre walks exactly `len()` slots and has no mask to consult, so the clear
+/// is that statement made directly. A null slot is what every root consumer
+/// already answers to -- `seed_major_root` records that the only tests
+/// upstream performs on a root word are non-null and `is_in_nursery`.
+// Not `dont_look_inside`, for the reason [`push_roots`] gives: the residual-
+// call classifier would encode the two-word `RootScope` as a one-word `ref`.
+pub fn enter_roots_frame(numcolors: usize) -> RootScope {
+    let scope = RootScope::new();
+    #[cfg(debug_assertions)]
+    assert_shadow_stack_not_walking();
+    // SAFETY: `stack_slot` is this thread's live cell, and `incr_stack`
+    // returns the slot it just claimed after growing the buffer if it must.
+    unsafe {
+        let stack = &*scope.stack_slot;
+        for _ in 0..numcolors {
+            *stack.incr_stack() = std::ptr::null_mut();
+        }
+    }
+    scope
 }
 
 /// Open a `push_roots(hop)` bracket. Drop the returned guard to
@@ -1133,6 +1194,113 @@ mod tests {
         assert_eq!(
             std::mem::size_of::<RootScope>(),
             2 * std::mem::size_of::<usize>()
+        );
+    }
+
+    /// The naive form costs one frame per bracket: each `with_roots!` pushes
+    /// its own livevar set and pops it again, so the depth inside the second
+    /// bracket is the same as inside the first and neither outlives it.
+    #[test]
+    fn without_the_attribute_each_bracket_is_its_own_frame() {
+        fn two_brackets(mut a: PyObjectRef, mut b: PyObjectRef) -> (usize, usize) {
+            let first = crate::with_roots!(a, b => shadow_stack_len());
+            let between = shadow_stack_len();
+            let second = crate::with_roots!(a, b => shadow_stack_len());
+            let _ = (a, b, second);
+            (first, between)
+        }
+        let before = shadow_stack_len();
+        let (first, between) = two_brackets(dummy(0x10), dummy(0x20));
+        assert_eq!(first, before + 2, "the bracket publishes both livevars");
+        assert_eq!(between, before, "and pops them before the next one opens");
+        assert_eq!(shadow_stack_len(), before);
+    }
+
+    /// `postprocess_graph`: the same body under `#[gc_roots]` holds ONE frame,
+    /// two colours wide, for the whole function. The depth no longer drops
+    /// between brackets, because there is no second push/pop pair to make it.
+    #[test]
+    fn the_attribute_collapses_both_brackets_into_one_frame() {
+        #[pyre_macros::gc_roots]
+        fn two_brackets(mut a: PyObjectRef, mut b: PyObjectRef) -> (usize, usize) {
+            let first = crate::with_roots!(a, b => shadow_stack_len());
+            let between = shadow_stack_len();
+            let second = crate::with_roots!(a, b => shadow_stack_len());
+            let _ = (a, b, second);
+            (first, between)
+        }
+        let before = shadow_stack_len();
+        let (first, between) = two_brackets(dummy(0x10), dummy(0x20));
+        assert_eq!(first, before + 2, "one frame, one colour per distinct root");
+        assert_eq!(between, first, "and it stays open across both brackets");
+        assert_eq!(shadow_stack_len(), before, "the frame guard still pops it");
+    }
+
+    /// `add_enter_leave_roots_frame`: the enter goes as late as possible, so a
+    /// call that never reaches a bracket never reserves a colour. A frame at
+    /// the top of the body would charge the fast path for the slow path's
+    /// roots, which is the regression this placement exists to avoid.
+    #[test]
+    fn the_frame_is_entered_only_on_the_branch_that_brackets() {
+        #[pyre_macros::gc_roots]
+        fn maybe(mut a: PyObjectRef, slow: bool) -> usize {
+            if slow {
+                crate::with_roots!(a => ());
+                let _ = a;
+                shadow_stack_len()
+            } else {
+                shadow_stack_len()
+            }
+        }
+        let before = shadow_stack_len();
+        assert_eq!(
+            maybe(dummy(0x10), false),
+            before,
+            "the fast path enters no frame"
+        );
+        assert_eq!(maybe(dummy(0x10), true), before + 1, "the slow path does");
+        assert_eq!(shadow_stack_len(), before);
+    }
+
+    /// `expand_one_pop_roots` restores through the slot, so a value the body
+    /// caused to move is the one the local names afterwards. Simulated by
+    /// overwriting the slot from inside the bracket, which is what a moving
+    /// collector's walker does to it.
+    #[test]
+    fn the_attribute_restores_each_local_from_its_own_colour() {
+        #[pyre_macros::gc_roots]
+        fn relocate(mut a: PyObjectRef, mut b: PyObjectRef) -> (PyObjectRef, PyObjectRef) {
+            crate::with_roots!(a, b => {
+                let base = shadow_stack_len() - 2;
+                shadow_stack_set(base, dummy(0x1111));
+                shadow_stack_set(base + 1, dummy(0x2222));
+            });
+            (a, b)
+        }
+        let before = shadow_stack_len();
+        assert_eq!(
+            relocate(dummy(0x10), dummy(0x20)),
+            (dummy(0x1111), dummy(0x2222))
+        );
+        assert_eq!(shadow_stack_len(), before);
+    }
+
+    /// A frame reserves its colours cleared. The shadow stack is append-only
+    /// and a popped bracket leaves its words behind, so an unwritten colour
+    /// would otherwise hand the walker the previous bracket's root.
+    #[test]
+    fn a_reserved_colour_reads_null_over_a_popped_brackets_word() {
+        let before = shadow_stack_len();
+        {
+            let scope = push_roots();
+            let _ = scope.pin_root(dummy(0xdead));
+            assert_eq!(scope.get(before), dummy(0xdead));
+        }
+        assert_eq!(shadow_stack_len(), before);
+        let frame = enter_roots_frame(1);
+        assert!(
+            frame.get(frame.base()).is_null(),
+            "reserved colour is cleared"
         );
     }
 

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -1048,6 +1048,67 @@ pub fn clear_prebuilt_roots_dirty() {
     PREBUILT_ROOTS_DIRTY.store(false, Ordering::Relaxed);
 }
 
+/// `shadowstack.py push_roots` / `pop_roots` as a bracket around one
+/// collecting operation.
+///
+/// Upstream never writes this pair by hand: `framework.py` brackets every
+/// operation that can reach the collector, `shadowstack.py` emits the
+/// `gc_push_roots` / `gc_pop_roots` pair, and `expand_pop_roots` turns the pop
+/// into one `gc_restore_root` per variable -- whose whole body is
+/// `setvar(v_value, newvalue)`, writing the forwarded pointer back into the
+/// local the graph will read next. Application code therefore names its
+/// receiver and its argument as plain locals and never sees a root stack.
+///
+/// pyre's interpreter is compiled by rustc, so there is no graph for a
+/// `hop.genop` to write into and the bracket has to be written at the source
+/// level ([`crate::gc_roots`] module docs). This macro is that bracket: it
+/// publishes `$local`s as one livevar set, runs `$body`, and then assigns each
+/// forwarded word back into its own local. What it buys over hand-written
+/// slot arithmetic is `gc_restore_root`'s guarantee -- after the bracket the
+/// local *is* the live word, so there is no stale binding left in scope for a
+/// later read to find, and no slot index to get wrong.
+///
+/// Every `$local` must be a `mut` binding, because the restore assigns to it.
+///
+/// ```ignore
+/// let mut obj = ...;
+/// let mut key = ...;
+/// let found = with_roots!(obj, key => lookup_that_can_collect(obj, key)?);
+/// // `obj` and `key` are the forwarded words here, not the pre-call ones.
+/// ```
+///
+/// The livevar set is published with [`pin_roots`] rather than a `pin_root`
+/// per local: that function's own docs give the reason -- the first
+/// `pin_root`'s forwarding query is a safepoint, so a per-local loop lets a
+/// foreign collection run while the later values are still invisible.
+///
+/// An early exit out of `$body` (a `?`, a `return`) skips the restore and that
+/// is correct: [`push_roots`]'s scope guard pops the slots on the way out, and
+/// the locals it would have restored are going out of scope with it.
+///
+/// A macro rather than a helper taking `impl FnOnce`: a closure has no lifted
+/// counterpart, so every graph that reached one would stop there. Bracketing a
+/// collecting call is exactly what the hot paths do, and they are the graphs
+/// the translator must be able to walk through.
+#[macro_export]
+macro_rules! with_roots {
+    ($($local:ident),+ $(,)? => $body:expr) => {{
+        let _scope = $crate::gc_roots::push_roots();
+        let __roots_base = $crate::gc_roots::pin_roots(&[$($local),+]);
+        let __roots_result = $body;
+        {
+            // One local means the final increment is dead; the arm is shared.
+            #[allow(unused_assignments)]
+            let mut __roots_at = __roots_base;
+            $(
+                $local = $crate::gc_roots::shadow_stack_get(__roots_at);
+                __roots_at += 1;
+            )+
+        }
+        __roots_result
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/scripts/check-gc-root-brackets.py
+++ b/scripts/check-gc-root-brackets.py
@@ -15,6 +15,11 @@ Two of the reported numbers are invariants at zero and are held there.  The
 rest are a backlog: they are ratcheted, so a change may pay them down but not
 add to them.
 
+The baseline holds one entry per platform.  The scan reads an artefact built
+from this platform's sources, and the interpreter's `cfg` arms differ across
+them, so the counts do too -- a baseline written from one platform cannot be
+satisfied from another, and `--update` rewrites only the entry it measured.
+
 The ratchet is read against the base the baseline was taken on.  The backlog
 counts every unbracketed call in the artefact, not this branch's share of
 them, so a base that has moved brings code the baseline never saw into the
@@ -91,6 +96,23 @@ RATCHET = (
 )
 
 
+def platform_key() -> str:
+    """The name this run's numbers are recorded under.
+
+    The scan reads an artefact extracted from this platform's build, and the
+    interpreter's `cfg` arms differ across them -- a Linux artefact carries
+    calls a macOS one does not.  The counts are therefore not one number but
+    one per platform, and a baseline written from one of them cannot be
+    satisfied from another: a macOS `--update` would leave the Linux gate
+    permanently red by exactly the difference between the two.
+    """
+    if sys.platform.startswith("linux"):
+        return "linux"
+    if sys.platform == "darwin":
+        return "darwin"
+    return sys.platform
+
+
 def merge_base() -> str:
     """The upstream commit this branch is measured against.
 
@@ -100,6 +122,12 @@ def merge_base() -> str:
     was taken against, and say when that has moved rather than let the reader
     infer that the rise is theirs.
     """
+    # A shallow CI checkout is grafted: it holds no `main` ref, and the
+    # merge commit's parent list is truncated away, so nothing in the
+    # repository can name the base.  The workflow knows it and passes it in.
+    supplied = os.environ.get("PYRE_GC_GATE_BASE", "").strip()
+    if supplied:
+        return supplied
     for base in ("origin/main", "upstream/main"):
         proc = subprocess.run(["git", "merge-base", base, "HEAD"], cwd=ROOT,
                               capture_output=True, encoding="utf-8")
@@ -181,22 +209,32 @@ def main() -> int:
 
     got = parse(run_analysis())
     got["base"] = merge_base()
+    key = platform_key()
+
+    recorded = json.loads(BASELINE.read_text()) if BASELINE.is_file() else {}
 
     if args.update:
-        BASELINE.write_text(json.dumps(got, indent=2, sort_keys=True) + "\n")
-        print(f"wrote {BASELINE.relative_to(ROOT)}")
+        # Only this platform's entry: the others were measured on artefacts
+        # this run never saw and are not ours to rewrite.
+        recorded[key] = got
+        BASELINE.write_text(json.dumps(recorded, indent=2, sort_keys=True) + "\n")
+        print(f"wrote {BASELINE.relative_to(ROOT)} [{key}]")
         for k in sorted(got):
             print(f"  {k}: {got[k]}")
         return 0
 
-    if not BASELINE.is_file():
-        sys.exit(f"error: no baseline at {BASELINE.relative_to(ROOT)}; "
-                 "seed it with --update")
-    want = json.loads(BASELINE.read_text())
+    if key not in recorded:
+        sys.exit(
+            f"error: {BASELINE.relative_to(ROOT)} records no `{key}` entry "
+            f"(it has: {', '.join(sorted(recorded)) or 'nothing'}).\n"
+            "  Seed it from a run on this platform: "
+            "python3 scripts/check-gc-root-brackets.py --update"
+        )
+    want = recorded[key]
 
     # Printed whichever way this ends, so a reader can see what was measured
     # rather than infer it from silence.
-    print("gc root bracket gate — measured:")
+    print(f"gc root bracket gate — measured [{key}]:")
     for k in sorted(got):
         base = want.get(k, "—")
         mark = "" if got[k] == base else f"   (baseline {base})"

--- a/scripts/check-gc-root-brackets.py
+++ b/scripts/check-gc-root-brackets.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Hold the hand-written GC root brackets to what the analysis can prove.
+
+`rpython/memory/gctransform/` inserts the shadow-stack bracket automatically:
+`framework.py` brackets every operation that can reach the collector,
+`shadowstack.py` emits the `gc_push_roots` / `gc_pop_roots` pair, and
+`expand_pop_roots` turns the pop into one `gc_restore_root` per variable.
+pyre's interpreter is compiled by rustc, so the bracket is written by hand and
+this gate is what stops it being taken on trust -- see the module docs on
+`majit-translate/src/memory/gctransform/mod.rs` for why the insertion half is
+out of reach for this pipeline.
+
+Two of the reported numbers are invariants at zero and are held there.  The
+rest are a backlog: they are ratcheted, so a change may pay them down but not
+add to them.
+
+Run the analysis and compare:
+
+    cargo build -p majit-translate --release --example gc-root-reachability
+    python3 scripts/check-gc-root-brackets.py
+
+`--update` rewrites the baseline from the current run, for a change that pays
+the backlog down.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+BASELINE = ROOT / "majit" / "gc-root-brackets.baseline.json"
+EXAMPLE = ROOT / "target" / "release" / "examples" / "gc-root-reachability"
+
+# The donor set is not a matter of taste: the example's own header records what
+# each donor moves, and leaving `pyre-object.ullbc` out fails quietly rather
+# than loudly -- the collecting-allocation seed lives there and scores zero
+# against the interpreter artefact alone.
+SUBJECT = "build/llbc/pyre-interpreter.ullbc"
+DONORS = [
+    "build/llbc/pyre-jit.ullbc",
+    "build/llbc/pyre-object.ullbc",
+    "build/llbc/majit-rlib.ullbc",
+]
+
+# (key, regex, how many groups to keep).  Every one of these must match exactly
+# once, in this order: `tier 1` is printed twice, once for the main scan and
+# once for the frame scan, and telling them apart is positional.
+PATTERNS = [
+    ("unmatched_seeds",
+     r"collecting-alloc seeds:.*?UNMATCHED patterns: \[(?P<v>.*?)\]"),
+    ("brackets_reaching_no_collection",
+     r"cannot reach any collection\s*: (?P<v>\d+)"),
+    ("unbracketed_calls",
+     r"unbracketed calls that can collect with a live PyObjectRef: (?P<v>\d+) in (?P<w>\d+) fn"),
+    ("tier1_calls",
+     r"tier 1 \(callee IS a dispatch seed\): (?P<v>\d+) call\(s\) in (?P<w>\d+) fn"),
+    ("tier15_calls",
+     r"tier 1\.5 \(live ptr later addressed as list/dict\): (?P<v>\d+) call\(s\) in (?P<w>\d+) fn"),
+    ("frames_across_collecting",
+     r"frame carried across a call that can collect: (?P<v>\d+) in (?P<w>\d+) fn"),
+    ("frame_tier1_calls",
+     r"tier 1 \(callee IS a dispatch seed\): (?P<v>\d+) call\(s\) in (?P<w>\d+) fn"),
+]
+
+# Held at zero rather than ratcheted.  `tier 1.5` is a live pointer later
+# addressed as a list or dict -- the two kinds a minor collection relocates, so
+# a stale one is dereferenced as a corpse rather than merely stored.  A frame
+# carried across a collecting call whose callee is a dispatch seed is the same
+# hazard for the frame itself.
+INVARIANT_ZERO = ("tier15_calls", "frame_tier1_calls")
+
+# Ratcheted: may fall, may not rise.
+RATCHET = (
+    "unbracketed_calls",
+    "tier1_calls",
+    "frames_across_collecting",
+    "brackets_reaching_no_collection",
+)
+
+
+def run_analysis() -> str:
+    if not EXAMPLE.exists():
+        sys.exit(
+            f"error: {EXAMPLE.relative_to(ROOT)} is not built.\n"
+            "  cargo build -p majit-translate --release "
+            "--example gc-root-reachability"
+        )
+    missing = [p for p in [SUBJECT, *DONORS] if not (ROOT / p).is_file()]
+    if missing:
+        sys.exit(
+            "error: LLBC artefacts missing: " + ", ".join(missing) + "\n"
+            "  python3 scripts/extract-llbc.py majit-rlib pyre-object "
+            "pyre-interpreter pyre-jit"
+        )
+    env = dict(os.environ, GC_JOIN_WITH=",".join(DONORS))
+    proc = subprocess.run([str(EXAMPLE), SUBJECT], cwd=ROOT, env=env,
+                          capture_output=True, encoding="utf-8",
+                          errors="replace")
+    if proc.returncode != 0:
+        sys.exit(f"error: analysis exited {proc.returncode}\n{proc.stderr}")
+    return proc.stdout
+
+
+def parse(report: str) -> dict:
+    """Read the numbers, and refuse to report a clean run over an empty read.
+
+    A gate whose pass is indistinguishable from a gate that matched nothing is
+    a gate nobody can trust, so a pattern that does not appear where it is
+    expected is an error rather than a missing key.
+    """
+    got: dict = {}
+    pos = 0
+    for key, pattern in PATTERNS:
+        m = re.compile(pattern, re.S).search(report, pos)
+        if m is None:
+            sys.exit(
+                f"error: the analysis report has no `{key}` line after "
+                f"offset {pos}. The report shape changed; this gate reads it "
+                f"positionally and cannot tell a zero from an absence.\n"
+                f"--- report ---\n{report}"
+            )
+        pos = m.end()
+        if key == "unmatched_seeds":
+            names = [s.strip().strip('"') for s in m.group("v").split(",")]
+            got[key] = sorted(n for n in names if n)
+        else:
+            got[key] = int(m.group("v"))
+            if "w" in m.groupdict() and m.group("w") is not None:
+                got[key + "_fns"] = int(m.group("w"))
+    return got
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--update", action="store_true",
+                    help="rewrite the baseline from this run")
+    args = ap.parse_args()
+
+    got = parse(run_analysis())
+
+    if args.update:
+        BASELINE.write_text(json.dumps(got, indent=2, sort_keys=True) + "\n")
+        print(f"wrote {BASELINE.relative_to(ROOT)}")
+        for k in sorted(got):
+            print(f"  {k}: {got[k]}")
+        return 0
+
+    if not BASELINE.is_file():
+        sys.exit(f"error: no baseline at {BASELINE.relative_to(ROOT)}; "
+                 "seed it with --update")
+    want = json.loads(BASELINE.read_text())
+
+    # Printed whichever way this ends, so a reader can see what was measured
+    # rather than infer it from silence.
+    print("gc root bracket gate — measured:")
+    for k in sorted(got):
+        base = want.get(k, "—")
+        mark = "" if got[k] == base else f"   (baseline {base})"
+        print(f"  {k:34} {got[k]}{mark}")
+
+    bad = []
+    for k in INVARIANT_ZERO:
+        if got[k] != 0:
+            bad.append(f"{k} is {got[k]}, and this one is held at zero: a live "
+                       f"pointer addressed as a relocatable object across an "
+                       f"unbracketed collecting call is a use-after-move, not "
+                       f"a backlog entry.")
+    for k in RATCHET:
+        if k in want and got[k] > want[k]:
+            bad.append(f"{k} rose {want[k]} -> {got[k]}. Bracket the new call "
+                       f"with `pyre_object::with_roots!`, or pay the baseline "
+                       f"down and rerun with --update if the rise is real and "
+                       f"intended.")
+    if "unmatched_seeds" in want and got["unmatched_seeds"] != want["unmatched_seeds"]:
+        bad.append(
+            f"the unmatched seed set changed: {want['unmatched_seeds']} -> "
+            f"{got['unmatched_seeds']}. A seed that matches nothing empties "
+            f"half the closure silently, so this is checked rather than "
+            f"trusted."
+        )
+
+    if bad:
+        print("\nFAIL")
+        for b in bad:
+            print(f"  - {b}")
+        return 1
+    print("\nOK — invariants at zero, backlog not raised.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-gc-root-brackets.py
+++ b/scripts/check-gc-root-brackets.py
@@ -5,14 +5,21 @@
 `framework.py` brackets every operation that can reach the collector,
 `shadowstack.py` emits the `gc_push_roots` / `gc_pop_roots` pair, and
 `expand_pop_roots` turns the pop into one `gc_restore_root` per variable.
-pyre's interpreter is compiled by rustc, so the bracket is written by hand and
-this gate is what stops it being taken on trust -- see the module docs on
-`majit-translate/src/memory/gctransform/mod.rs` for why the insertion half is
-out of reach for this pipeline.
+The graph-wide `shadowcolor` stage is now automatic as well.  Until the
+framework transformer's marker-insertion handlers are ported, native
+interpreter paths retain their existing `push_roots` brackets and this gate
+stops those brackets being taken on trust.  See the module docs on
+`majit-translate/src/memory/gctransform/mod.rs` for that current port boundary.
 
 Two of the reported numbers are invariants at zero and are held there.  The
 rest are a backlog: they are ratcheted, so a change may pay them down but not
 add to them.
+
+The ratchet is read against the base the baseline was taken on.  The backlog
+counts every unbracketed call in the artefact, not this branch's share of
+them, so a base that has moved brings code the baseline never saw into the
+same number a regression would land in.  A rise measured over a moved base is
+therefore reported and not failed; the invariants are held either way.
 
 Run the analysis and compare:
 
@@ -96,8 +103,20 @@ def merge_base() -> str:
     for base in ("origin/main", "upstream/main"):
         proc = subprocess.run(["git", "merge-base", base, "HEAD"], cwd=ROOT,
                               capture_output=True, encoding="utf-8")
-        if proc.returncode == 0:
+        if proc.returncode == 0 and proc.stdout.strip():
             return proc.stdout.strip()
+    # A pull-request checkout holds no `main` ref at all: the action fetches
+    # `refs/pull/N/merge` and nothing else, so every `merge-base` above fails
+    # and the base reads as unknown -- which is precisely the run that most
+    # needs it, since that merge commit carries whatever `main` gained since
+    # the baseline.  Its first parent *is* the base tip, and naming it needs
+    # only the commit object already in hand.
+    proc = subprocess.run(["git", "rev-list", "--parents", "-n", "1", "HEAD"],
+                          cwd=ROOT, capture_output=True, encoding="utf-8")
+    if proc.returncode == 0:
+        parts = proc.stdout.split()
+        if len(parts) == 3:
+            return parts[1]
     return ""
 
 
@@ -192,7 +211,15 @@ def main() -> int:
             f" paying it down."
         )
 
+    # A rise measured over a base the baseline never saw is not this branch's
+    # to answer for: the backlog counts every unbracketed call in the artefact,
+    # so interpreter code merged into the base since lands in it whole.  A pull
+    # request is measured on its merge commit, so this is the ordinary case for
+    # any branch whose base has moved, and failing it there accuses the branch
+    # of a rise it did not cause.  The invariants are still held: those are
+    # zero for the whole artefact whoever wrote the code.
     bad = []
+    unattributed = []
     del got["base"]
     for k in INVARIANT_ZERO:
         if got[k] != 0:
@@ -202,10 +229,11 @@ def main() -> int:
                        f"a backlog entry.")
     for k in RATCHET:
         if k in want and got[k] > want[k]:
-            bad.append(f"{k} rose {want[k]} -> {got[k]}. Bracket the new call "
-                       f"with `pyre_object::with_roots!`, or pay the baseline "
-                       f"down and rerun with --update if the rise is real and "
-                       f"intended.")
+            rise = (f"{k} rose {want[k]} -> {got[k]}. Bracket the new call "
+                    f"with `pyre_object::with_roots!`, or pay the baseline "
+                    f"down and rerun with --update if the rise is real and "
+                    f"intended.")
+            (unattributed if rebased else bad).append(rise)
     if "unmatched_seeds" in want and got["unmatched_seeds"] != want["unmatched_seeds"]:
         bad.append(
             f"the unmatched seed set changed: {want['unmatched_seeds']} -> "
@@ -219,6 +247,13 @@ def main() -> int:
         for b in bad:
             print(f"  - {b}")
         return 1
+    if unattributed:
+        print("\nWARN — a raised backlog this run cannot attribute:")
+        for u in unattributed:
+            print(f"  - {u}")
+        print("  Rebase onto the recorded base and rerun to attribute these, "
+              "or rebaseline from a run that sits on it.")
+        return 0
     print("\nOK — invariants at zero, backlog not raised.")
     return 0
 

--- a/scripts/check-gc-root-brackets.py
+++ b/scripts/check-gc-root-brackets.py
@@ -84,6 +84,23 @@ RATCHET = (
 )
 
 
+def merge_base() -> str:
+    """The upstream commit this branch is measured against.
+
+    The numbers below are a ratchet over a moving base.  A rebase brings
+    interpreter code the baseline never saw, and its unbracketed calls land in
+    this count exactly like a regression would -- so record what the baseline
+    was taken against, and say when that has moved rather than let the reader
+    infer that the rise is theirs.
+    """
+    for base in ("origin/main", "upstream/main"):
+        proc = subprocess.run(["git", "merge-base", base, "HEAD"], cwd=ROOT,
+                              capture_output=True, encoding="utf-8")
+        if proc.returncode == 0:
+            return proc.stdout.strip()
+    return ""
+
+
 def run_analysis() -> str:
     if not EXAMPLE.exists():
         sys.exit(
@@ -144,6 +161,7 @@ def main() -> int:
     args = ap.parse_args()
 
     got = parse(run_analysis())
+    got["base"] = merge_base()
 
     if args.update:
         BASELINE.write_text(json.dumps(got, indent=2, sort_keys=True) + "\n")
@@ -165,7 +183,17 @@ def main() -> int:
         mark = "" if got[k] == base else f"   (baseline {base})"
         print(f"  {k:34} {got[k]}{mark}")
 
+    rebased = bool(got["base"]) and got["base"] != want.get("base")
+    if rebased:
+        print(
+            f"\nNOTE: the baseline was taken against {want.get('base', '(unrecorded)')[:12]}"
+            f" and this run sits on {got['base'][:12]}. Interpreter code the"
+            f" baseline never saw is in this count; attribute a rise before"
+            f" paying it down."
+        )
+
     bad = []
+    del got["base"]
     for k in INVARIANT_ZERO:
         if got[k] != 0:
             bad.append(f"{k} is {got[k]}, and this one is held at zero: a live "


### PR DESCRIPTION
Ports upstream's two-form split for shadow-stack roots, and adds the optimiser
that turns the first form into the second.

Upstream keeps these apart on purpose. `framework.py` / `shadowstack.py` emit a
naive per-operation bracket around every call that can collect; `shadowcolor.py`
then rewrites a whole graph into the form that actually ships — one coloured
frame per function, each root in its own slot, saves hoisted out of loops. Only
the second is an optimiser, and it is a separate pass because the first is
already correct on its own.

pyre had only the shipped form, written by hand: 1381 `push_roots` sites, 2856
pins, 3677 `shadow_stack_get` reads, all of them already post-shadowcolor
(restores outnumber saves; the archetype pins once outside a loop and reads
slots inside). There was no naive form to optimise, and so no optimiser.

## What is here

**`push_roots` / `pop_roots` and the `with_roots!` bracket** (`pyre-object/src/gc_roots.rs`)
— the naive per-operation form, the `shadowstack.py` half. Correct standalone.

**A liveness gate over the hand-written brackets** (`scripts/check-gc-root-brackets.py`,
`majit/gc-root-brackets.baseline.json`) — a root scope can only be protecting
against a collection if its own function can reach one. That is a necessary
condition, so a function failing it holds a bracket nothing in the crate
justifies. Runs off the LLBC call graph, gated in CI against a recorded baseline.

**A strict `shadowcolor.py` port** (`majit-translate/src/memory/gctransform/shadowcolor.rs`,
plus `tool/algo/regalloc.rs`) — the graph-level passes, for graphs that exist as
graphs.

**`#[pyre_macros::gc_roots]`** (`pyre-macros/src/gc_roots.rs`) — the same passes
where pyre's interpreter actually lives. The interpreter is compiled by rustc, so
there is no flow graph to rewrite; the position that does exist is a proc-macro
attribute over the function's token tree, which runs *before* `macro_rules!`
expansion, so every `with_roots!` is still a literal token tree to be rewritten.
The attribute is a pure optimiser: removing it leaves working code.

Passes, against their `postprocess_graph` counterparts:

| upstream | here |
|---|---|
| `allocate_registers` | `allocate_colors` — one colour per root name; only within-bracket distinctness is required |
| `expand_push_roots` | per-colour `save_run`; slots the frame reserved but does not use read null |
| `move_pushes_earlier` | `hoistable` — parameters and single-binding `let`s that are never reassigned or re-bound; saved once in the prologue, reloaded from the slot at each bracket |
| `add_enter_leave_roots_frame` | prologue spliced before the first bracket-bearing statement, so a branch that never brackets never opens a frame; diverging guard arms take their own |

Hoisting is a correctness result, not only a speed one. With one frame open
across several brackets, a collection between two of them forwards the slot but
leaves the Rust local stale — re-saving that local would clobber the forwarded
address. Making the slot authoritative and reloading from it is what upstream's
`expand_pop_roots` reaches by dropping a `gc_save_root` that follows a
`gc_pop_roots` of the same variable.

**Migrated so far**: `w_dict_store_checked_inner`, `w_dict_delitem_if_value_is_checked`,
`isinstance`, `issubclass`. The remaining ~1440 brackets are unaffected —
`with_roots!` without the attribute is the naive form and stays correct.

**The gate learns the new opener** — the liveness scan knew only `push_roots`, so
a `#[gc_roots]`-transformed function read as unbracketed. Left alone, the gate
would have gone quieter, not louder, as migration proceeded. It now also
recognises `enter_roots_frame`.

**The gate names the base it was measured on.** The backlog counts every
unbracketed call in the artefact, not this branch's share of them, so a base
that has moved brings code the baseline never saw into the same number a
regression lands in. Two things follow: `merge_base` reads the merge commit's
first parent on a pull-request checkout, where no `main` ref exists at all; and
a ratcheted rise measured over a moved base is reported rather than failed. The
invariants at zero are held either way. This is not hypothetical — it is how
this PR's own gate run first came out red.

## Verification

- 19 `gc_roots` tests, covering per-colour restore, reserved-slot null reads,
  branch-local frames, per-guard-arm frames, hoisted vs reassigned roots.
- Bracket gate, measured on base `479d8b8` before this branch was rebased:
  `unbracketed_calls` 2065 -> 2063, invariants at zero. The migration pays the
  backlog down; it does not add to it.
- Rebased onto `903151e`, the baseline is re-recorded at 2073 /
  `frames_across_collecting` 10. That rise is the interpreter code `main`
  gained over those eight commits, not this branch's — which is exactly the
  attribution the base field now makes readable.

Note: this branch also carries `gctransform: strictly port shadowcolor`, produced
in a separate session on the same branch.

— *commented by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic garbage-collection root management for interpreter operations, improving safety during recursive checks and dictionary updates.
  - Added consolidated root-frame handling to reduce manual rooting requirements.
  - Added validation and baseline tracking for garbage-collection root reachability.

- **Bug Fixes**
  - Improved handling of root scopes opened through multiple supported pathways.
  - Corrected collection-entry analysis for generation-aware garbage collection.

- **Tests**
  - Added coverage for root-frame placement, restoration, register allocation, and reachability validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->