### PR TITLE
wasm: a per-callee residual-call ABI, word-spelled call targets, and the host-buffer frame on the shadow stack

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1363,13 +1363,6 @@ fn emit_write_barrier_if_needed(
     wb_applied.insert(wb_key);
 }
 
-/// Whether any op in the trace needs a write-barrier trampoline call, which
-/// requires the `jit_call` import to be present.
-fn has_ref_store_op(ops: &[Op], ref_values: &RefValues) -> bool {
-    ops.iter()
-        .any(|op| write_barrier_base(op, ref_values).is_some())
-}
-
 /// Emit a write-barrier check on `base_ref` before a ref-storing field/array
 /// store, standing in for the `COND_CALL_GC_WB` the native GC rewrite pass
 /// inserts. When the residual type family is declared (`residual_type_base`),
@@ -1642,13 +1635,17 @@ fn emit_reload_frame_if_necessary(
         // this does not need the residual direct-call type to be declared.
         emit_ca_reload_top(sink, top_addr);
         sink.local_set(0);
-    } else if let Some(base) = residual_type_base {
+    } else if let Some(base) = residual_type_base.filter(|_| ca_reload_fn_ptr != 0) {
         sink.i32_const(ca_reload_fn_ptr as i32);
         sink.call_indirect(0, base);
         sink.i32_wrap_i64();
         sink.local_set(0);
     } else {
-        // The trampoline path still assumes a non-moving frame: its scratch writes use local 0.
+        // No reload: either the trampoline path, which assumes a non-moving
+        // frame because its scratch writes use local 0, or an embedder whose
+        // host entry runs traces on a frame the shadow stack does not describe
+        // — it published no reload helper, and reloading from a shadow stack
+        // that never held this frame would install an unrelated one.
     }
 }
 
@@ -1797,22 +1794,64 @@ pub struct GuardGcTypeInfo {
 /// and one the IR cannot check — a helper declared to take a pointer has an
 /// `i32` parameter on wasm32, and `call_indirect` type-checks its callee on
 /// every call, so a call lowered this way traps instead of reaching a helper
-/// whose real signature is narrower. Only an embedder whose residual helpers
-/// are uniformly word-wide may leave this on; clearing it returns every call to
-/// the trampoline, which reads the callee's declared type before calling it.
+/// whose real signature is narrower.
+///
+/// [`ResidualCallAbi`] is how an embedder says which of the two it is.
 ///
 /// Read once per emitted call, so it must be set before the first compile.
-static DIRECT_RESIDUAL_CALL: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(true);
+static RESIDUAL_CALL_ABI: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
 
-/// Set the direct-residual-call policy. See [`DIRECT_RESIDUAL_CALL`] for the
-/// ABI the enabled form assumes of the embedder's residual helpers.
-pub fn set_direct_residual_calls(enabled: bool) {
-    DIRECT_RESIDUAL_CALL.store(enabled, std::sync::atomic::Ordering::Relaxed);
+/// How faithfully a residual callee's call descr describes its real wasm
+/// signature.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ResidualCallAbi {
+    /// Every callee reachable as a residual is spelled with word-sized `i64`
+    /// parameters and result and casts at its own boundary, so a descr's word
+    /// type *is* the callee's wasm type. Any word-typed residual then lowers
+    /// to a direct in-module `call_indirect`. The default.
+    Word,
+    /// Only the callees named by [`crate::set_faithful_residual_call_addrs`]
+    /// are known to be spelled that way. Every other residual keeps the host
+    /// trampoline, which reads the callee's declared type before calling it:
+    /// slower, but correct for a callee spelled with a pointer parameter,
+    /// which is narrower than a word on wasm32. Vouching for too few callees
+    /// costs speed; vouching for one whose parameters are not all words costs
+    /// a trap, so the safe direction is to add them one at a time.
+    Vouched,
 }
 
-fn direct_residual_calls() -> bool {
-    DIRECT_RESIDUAL_CALL.load(std::sync::atomic::Ordering::Relaxed)
+/// Declare which [`ResidualCallAbi`] this embedder's residual helpers satisfy.
+pub fn set_residual_call_abi(abi: ResidualCallAbi) {
+    let encoded = match abi {
+        ResidualCallAbi::Word => 0,
+        ResidualCallAbi::Vouched => 1,
+    };
+    RESIDUAL_CALL_ABI.store(encoded, std::sync::atomic::Ordering::Relaxed);
+}
+
+fn residual_call_abi() -> ResidualCallAbi {
+    match RESIDUAL_CALL_ABI.load(std::sync::atomic::Ordering::Relaxed) {
+        0 => ResidualCallAbi::Word,
+        _ => ResidualCallAbi::Vouched,
+    }
+}
+
+/// Whether `op`'s callee may be called with the wasm type its descr's word
+/// types imply, rather than through the reflecting trampoline.
+fn residual_callee_abi_is_word(op: &Op, constants: &indexmap::IndexMap<u32, i64>) -> bool {
+    match residual_call_abi() {
+        ResidualCallAbi::Word => true,
+        ResidualCallAbi::Vouched => {
+            // Only a compile-time callee can be checked against the list; a
+            // register-form func pointer is a different target on every
+            // execution.
+            let Some(func_ptr) = op.getarglist().first().map(|arg| arg.to_opref()) else {
+                return false;
+            };
+            func_ptr.is_constant()
+                && crate::residual_call_descr_is_faithful(resolve_const_bits(constants, func_ptr))
+        }
+    }
 }
 
 /// If `op` is a residual CALL whose ABI is uniformly i64 (all Int/Ref args and
@@ -1827,7 +1866,7 @@ fn direct_residual_calls() -> bool {
 /// which neither lowering touches, so a direct call is sound. Float /
 /// release-GIL / cond / assembler calls and non-reflectable descrs remain on
 /// the trampoline.
-fn residual_call_i64_arity(op: &Op) -> Option<usize> {
+fn residual_call_i64_arity(op: &Op, constants: &indexmap::IndexMap<u32, i64>) -> Option<usize> {
     use OpCode::*;
     if !matches!(
         op.opcode,
@@ -1858,6 +1897,9 @@ fn residual_call_i64_arity(op: &Op) -> Option<usize> {
     // descr's `arg_types` describes those call args, so the counts must match.
     let nargs = op.getarglist().len().saturating_sub(1);
     if arg_types.len() != nargs {
+        return None;
+    }
+    if !residual_callee_abi_is_word(op, constants) {
         return None;
     }
     Some(nargs)
@@ -1906,9 +1948,9 @@ fn residual_call_typed_sig(
     // site keeps the four predicates disjoint, so the signature collected for an
     // op is always the signature its emit reaches -- a type collected for an op
     // the i64 family claims would declare an index nothing branches to.
-    if residual_call_i64_arity(op).is_some()
-        || residual_call_void_word_arity(op).is_some()
-        || residual_call_void_true_arity(op).is_some()
+    if residual_call_i64_arity(op, constants).is_some()
+        || residual_call_void_word_arity(op, constants).is_some()
+        || residual_call_void_true_arity(op, constants).is_some()
     {
         return None;
     }
@@ -1972,7 +2014,10 @@ fn residual_call_typed_sig(
 /// sound.
 /// Float / release-GIL / cond / assembler calls and non-reflectable descrs
 /// remain on the trampoline.
-fn residual_call_void_word_arity(op: &Op) -> Option<usize> {
+fn residual_call_void_word_arity(
+    op: &Op,
+    constants: &indexmap::IndexMap<u32, i64>,
+) -> Option<usize> {
     use OpCode::*;
     if !matches!(
         op.opcode,
@@ -1996,6 +2041,9 @@ fn residual_call_void_word_arity(op: &Op) -> Option<usize> {
     if arg_types.len() != nargs {
         return None;
     }
+    if !residual_callee_abi_is_word(op, constants) {
+        return None;
+    }
     Some(nargs)
 }
 
@@ -2005,7 +2053,10 @@ fn residual_call_void_word_arity(op: &Op) -> Option<usize> {
 /// no result to drop. Float / release-GIL / cond / assembler calls,
 /// non-reflectable descrs, and descr/operand arity mismatches remain on the
 /// trampoline.
-fn residual_call_void_true_arity(op: &Op) -> Option<usize> {
+fn residual_call_void_true_arity(
+    op: &Op,
+    constants: &indexmap::IndexMap<u32, i64>,
+) -> Option<usize> {
     use OpCode::*;
     if !matches!(
         op.opcode,
@@ -2029,6 +2080,9 @@ fn residual_call_void_true_arity(op: &Op) -> Option<usize> {
     if arg_types.len() != nargs {
         return None;
     }
+    if !residual_callee_abi_is_word(op, constants) {
+        return None;
+    }
     Some(nargs)
 }
 
@@ -2039,11 +2093,15 @@ fn residual_call_void_true_arity(op: &Op) -> Option<usize> {
 /// (its `wasm_jit_write_barrier` helper takes 1 arg). All of these share
 /// the i64-result residual-call type family, so one max covers them. True-void
 /// residuals use a separate result family and arity census.
-fn direct_helper_i64_arity(op: &Op, ref_values: &RefValues) -> Option<usize> {
-    if let Some(n) = residual_call_i64_arity(op) {
+fn direct_helper_i64_arity(
+    op: &Op,
+    ref_values: &RefValues,
+    constants: &indexmap::IndexMap<u32, i64>,
+) -> Option<usize> {
+    if let Some(n) = residual_call_i64_arity(op, constants) {
         return Some(n);
     }
-    if let Some(n) = residual_call_void_word_arity(op) {
+    if let Some(n) = residual_call_void_word_arity(op, constants) {
         return Some(n);
     }
     match op.opcode {
@@ -2056,33 +2114,14 @@ fn direct_helper_i64_arity(op: &Op, ref_values: &RefValues) -> Option<usize> {
     }
 }
 
-fn has_call_ops(ops: &[Op]) -> bool {
-    // `New*` also reaches the host via the `jit_call` trampoline, so the import
-    // must be present for it too. `Newstr` / `Newunicode` stay listed as a
-    // conservative superset: `build_function` declines any trace carrying them
-    // (no rstr lowering), so their entry here only ever over-imports.
-    ops.iter().any(|op| {
-        op.opcode.is_call()
-            || matches!(
-                op.opcode,
-                OpCode::New
-                    | OpCode::NewWithVtable
-                    | OpCode::NewArray
-                    | OpCode::NewArrayClear
-                    | OpCode::Newstr
-                    | OpCode::Newunicode
-            )
-    })
-}
-
 /// Whether this trace emits a host `jit_call` / `jit_call_compact` trampoline
 /// invocation and therefore needs the corresponding function import.
 ///
 /// Keep this in lockstep with the individual emission arms below: the uniform
-/// i64, typed float, and true-void residual families, `New*`, and write barriers
-/// are direct under [`DIRECT_RESIDUAL_CALL`]; non-uniform CALLs and string
-/// allocation retain the trampoline. When the direct family is disabled, all
-/// of the existing call-area users return to the trampoline baseline.
+/// i64, typed float, and true-void residual families, `New*`, and write
+/// barriers are direct as far as [`RESIDUAL_CALL_ABI`] lets each one be;
+/// non-uniform CALLs, an unvouched callee, and string allocation retain the
+/// trampoline.
 fn has_trampoline_calls(
     inputargs: &[InputArg],
     ops: &[Op],
@@ -2090,10 +2129,6 @@ fn has_trampoline_calls(
     emit_ca: bool,
 ) -> bool {
     let ref_values = RefValues::collect(inputargs, ops);
-    if !direct_residual_calls() {
-        return has_call_ops(ops) || has_ref_store_op(ops, &ref_values);
-    }
-
     ops.iter().any(|op| match op.opcode {
         // `build_function` handles an enabled CALL_ASSEMBLER before the generic
         // CALL arm, lowering it directly to the callee-loop table slot. It
@@ -2105,9 +2140,9 @@ fn has_trampoline_calls(
         // Every residual CALL uses the trampoline unless its exact lowering
         // predicate supplies an i64, typed float, or true-void helper ABI.
         _ if op.opcode.is_call() => {
-            direct_helper_i64_arity(op, &ref_values).is_none()
+            direct_helper_i64_arity(op, &ref_values, constants).is_none()
                 && residual_call_typed_sig(op, constants).is_none()
-                && residual_call_void_true_arity(op).is_none()
+                && residual_call_void_true_arity(op, constants).is_none()
         }
         // `New*` and ref-store write barriers are covered by
         // `direct_helper_i64_arity`, so their direct-family arms do not touch
@@ -3057,16 +3092,16 @@ pub fn build_wasm_module(
     // keeps the tail call area for future bridges.
     let needs_call =
         has_trampoline_calls(&analysis_inputargs, &analysis_ops, constants, ca.emit_ca);
-    // In-module residual calls ([`DIRECT_RESIDUAL_CALL`]): the largest
+    // In-module residual calls ([`RESIDUAL_CALL_ABI`]): the largest
     // eligible `(i64×n)->i64` arity in this trace — residual CALLs (word
     // result or word-ABI void) plus the `New*` / write-barrier helper
     // targets, which share the same uniform-i64 ABI — or `None` if there
     // are none. Each distinct arity `0..=max` gets its own function type
     // (declared below) so those arms can `call_indirect` with a static type.
-    let residual_max_arity = if direct_residual_calls() {
+    let residual_max_arity = {
         let scanned = analysis_ops
             .iter()
-            .filter_map(|op| direct_helper_i64_arity(op, &ref_values))
+            .filter_map(|op| direct_helper_i64_arity(op, &ref_values, constants))
             .max();
         if ca.emit_ca {
             // The CA arm's frame helpers (`wasm_jit_ca_reload_frame()`,
@@ -3082,33 +3117,25 @@ pub fn build_wasm_module(
         } else {
             scanned
         }
-    } else {
-        None
     };
     // Typed float residual calls use their descr's faithful wasm ABI instead
     // of the uniform i64 helper family. Preserve first-use order so a given
     // trace gets stable type indices while declaring each signature once.
     let mut typed_residual_sigs = Vec::new();
-    if direct_residual_calls() {
-        for op in analysis_ops {
-            if let Some(sig) = residual_call_typed_sig(op, constants)
-                && !typed_residual_sigs.contains(&sig)
-            {
-                typed_residual_sigs.push(sig);
-            }
+    for op in analysis_ops {
+        if let Some(sig) = residual_call_typed_sig(op, constants)
+            && !typed_residual_sigs.contains(&sig)
+        {
+            typed_residual_sigs.push(sig);
         }
     }
     // True-void residual calls use `(i64×n) -> ()`, a separate family from the
     // i64- and f64-result types. As with the uniform i64 family, declaring
     // `0..=max` makes each type index a base plus the call arity.
-    let true_void_residual_max_arity = if direct_residual_calls() {
-        analysis_ops
-            .iter()
-            .filter_map(residual_call_void_true_arity)
-            .max()
-    } else {
-        None
-    };
+    let true_void_residual_max_arity = analysis_ops
+        .iter()
+        .filter_map(|op| residual_call_void_true_arity(op, constants))
+        .max();
     // The shared indirect-function table backs direct residual helpers as well
     // as host-trampoline dispatch, chained bridges, and CA recursion.
     let needs_table = needs_call
@@ -3459,8 +3486,8 @@ fn build_function(
     inline_trip: Option<(InlineTripProbe, u32)>,
 ) -> Result<Function, BackendError> {
     // The CA arm requires residual types (the setup above forces arity >= 2
-    // while [`DIRECT_RESIDUAL_CALL`] is enabled). Its `jit_call` fallback
-    // branches are retained solely for the direct-family-disabled baseline.
+    // whenever it is emitted). Its `jit_call` fallback branches are retained
+    // solely for a trace that declared no residual type family at all.
     debug_assert!(!ca.emit_ca || residual_type_base.is_some());
     let value_locals_end = value_types.end_local();
     // Resume-at-LABEL shape, needed here because `resume_dispatch` costs a
@@ -5933,7 +5960,8 @@ fn build_function(
                 // no marshalling and no call-area traffic. A direct target may
                 // collect or force, so reload local 0 and its live Ref homes on
                 // return. Falls back below when ineligible.
-                if let (Some(base), Some(nargs)) = (residual_type_base, residual_call_i64_arity(op))
+                if let (Some(base), Some(nargs)) =
+                    (residual_type_base, residual_call_i64_arity(op, constants))
                 {
                     let call_args = &op.getarglist()[1..];
                     for arg in call_args {
@@ -5968,9 +5996,10 @@ fn build_function(
                     }
                     // store-on-def (end of loop) homes a Ref result, so the
                     // direct path must NOT `continue` past it.
-                } else if let (Some(base), Some(nargs)) =
-                    (residual_type_base, residual_call_void_word_arity(op))
-                {
+                } else if let (Some(base), Some(nargs)) = (
+                    residual_type_base,
+                    residual_call_void_word_arity(op, constants),
+                ) {
                     // Direct in-module word-ABI void residual call: the callee
                     // really is `(i64×n)->i64` (descr result_size == 8), so use
                     // the i64 family and drop the dummy result.
@@ -6052,7 +6081,7 @@ fn build_function(
                     }
                 } else if let (Some(base), Some(nargs)) = (
                     true_void_residual_type_base,
-                    residual_call_void_true_arity(op),
+                    residual_call_void_true_arity(op, constants),
                 ) {
                     // Direct in-module true-void residual call: the callee is
                     // `(i64×n)->()` (descr result_size == 0), so the call has no

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -201,10 +201,22 @@ impl ValueLocals {
 }
 
 /// Call area layout in the historical fixed frame geometry.
-const CALL_RESULT_OFS: u64 = 2000;
-const CALL_FUNC_OFS: u64 = 2008;
-const CALL_NARGS_OFS: u64 = 2016;
-const CALL_ARGS_OFS: u64 = 2024;
+///
+/// These offsets are the host trampoline's ABI, not a private detail: a caller
+/// writes the callee's function-table index, the argument count and the
+/// arguments into this block, invokes the import, and reads the callee's
+/// result back from it. Whoever satisfies that import reads the same block
+/// from the other side, so both ends name these constants instead of each
+/// restating the numbers.
+pub const CALL_RESULT_OFS: u64 = 2000;
+pub const CALL_FUNC_OFS: u64 = 2008;
+pub const CALL_NARGS_OFS: u64 = 2016;
+pub const CALL_ARGS_OFS: u64 = 2024;
+
+/// Arguments the call area has room for. A residual call with more arguments
+/// than this has nowhere to put them, so a caller checks its arity against
+/// this bound rather than writing past the end of the frame.
+pub const MAX_CALL_ARGS: usize = 16;
 
 const STATIC_CALL_RESULT_OFS: u64 = 0;
 const STATIC_CALL_FUNC_OFS: u64 = SLOT_SIZE;
@@ -212,7 +224,11 @@ const STATIC_CALL_NARGS_OFS: u64 = 2 * SLOT_SIZE;
 const STATIC_CALL_ARGS_OFS: u64 = 3 * SLOT_SIZE;
 
 /// Minimum frame allocation size in bytes to accommodate the call area.
-pub const MIN_FRAME_BYTES: usize = 2024 + 16 * 8; // 16 max call args
+///
+/// Derived from where the arguments start and how many fit, so raising
+/// [`MAX_CALL_ARGS`] cannot leave the frame one argument short of the area it
+/// is sized to hold.
+pub const MIN_FRAME_BYTES: usize = CALL_ARGS_OFS as usize + MAX_CALL_ARGS * 8;
 
 /// Per-token layout of a wasm execution frame. Every frozen geometry retains
 /// the historical host-trampoline call area even though emitted code uses the
@@ -248,7 +264,8 @@ pub struct FrameGeometry {
 }
 
 impl FrameGeometry {
-    pub const CALL_AREA_SLOTS: usize = 3 + 16; // result, function, nargs, args
+    /// result, function, nargs, then one slot per argument.
+    pub const CALL_AREA_SLOTS: usize = 3 + MAX_CALL_ARGS;
 
     /// Historical fixed geometry, used by direct codegen tests and by callers
     /// that deliberately need the arena-compatible layout.
@@ -1769,13 +1786,34 @@ pub struct GuardGcTypeInfo {
 }
 
 /// Check if any op in the trace is a CALL variant.
-/// Lower an eligible residual CALL to a direct in-module `call_indirect` into
-/// the callee's `__indirect_function_table` slot, instead of routing through the
-/// `jit_call` host trampoline (guest→host→guest reflection + arg marshalling).
-/// The residual-call ABI is uniformly `(i64×n) -> i64` for Int/Ref args+result
-/// (verified: every fib residual call is `(i64,…)->i64`), so the static type is
-/// fixed by the arity alone. `false` = byte-identical jit_call baseline.
-const WASM_DIRECT_RESIDUAL_CALL: bool = true;
+/// Whether an eligible residual CALL may be lowered to a direct in-module
+/// `call_indirect` into the callee's `__indirect_function_table` slot, instead
+/// of routing through the `jit_call` host trampoline (guest→host→guest
+/// reflection + arg marshalling).
+///
+/// The lowering takes the callee's wasm type from the IR alone: word-typed
+/// arguments and result become `(i64×n) -> i64`, so the static type is fixed by
+/// the arity. That is a claim about the embedding language's residual helpers,
+/// and one the IR cannot check — a helper declared to take a pointer has an
+/// `i32` parameter on wasm32, and `call_indirect` type-checks its callee on
+/// every call, so a call lowered this way traps instead of reaching a helper
+/// whose real signature is narrower. Only an embedder whose residual helpers
+/// are uniformly word-wide may leave this on; clearing it returns every call to
+/// the trampoline, which reads the callee's declared type before calling it.
+///
+/// Read once per emitted call, so it must be set before the first compile.
+static DIRECT_RESIDUAL_CALL: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(true);
+
+/// Set the direct-residual-call policy. See [`DIRECT_RESIDUAL_CALL`] for the
+/// ABI the enabled form assumes of the embedder's residual helpers.
+pub fn set_direct_residual_calls(enabled: bool) {
+    DIRECT_RESIDUAL_CALL.store(enabled, std::sync::atomic::Ordering::Relaxed);
+}
+
+fn direct_residual_calls() -> bool {
+    DIRECT_RESIDUAL_CALL.load(std::sync::atomic::Ordering::Relaxed)
+}
 
 /// If `op` is a residual CALL whose ABI is uniformly i64 (all Int/Ref args and
 /// an Int/Ref result), return its argument count — eligible for a direct
@@ -2042,7 +2080,7 @@ fn has_call_ops(ops: &[Op]) -> bool {
 ///
 /// Keep this in lockstep with the individual emission arms below: the uniform
 /// i64, typed float, and true-void residual families, `New*`, and write barriers
-/// are direct under `WASM_DIRECT_RESIDUAL_CALL`; non-uniform CALLs and string
+/// are direct under [`DIRECT_RESIDUAL_CALL`]; non-uniform CALLs and string
 /// allocation retain the trampoline. When the direct family is disabled, all
 /// of the existing call-area users return to the trampoline baseline.
 fn has_trampoline_calls(
@@ -2052,7 +2090,7 @@ fn has_trampoline_calls(
     emit_ca: bool,
 ) -> bool {
     let ref_values = RefValues::collect(inputargs, ops);
-    if !WASM_DIRECT_RESIDUAL_CALL {
+    if !direct_residual_calls() {
         return has_call_ops(ops) || has_ref_store_op(ops, &ref_values);
     }
 
@@ -3019,13 +3057,13 @@ pub fn build_wasm_module(
     // keeps the tail call area for future bridges.
     let needs_call =
         has_trampoline_calls(&analysis_inputargs, &analysis_ops, constants, ca.emit_ca);
-    // In-module residual calls (`WASM_DIRECT_RESIDUAL_CALL`): the largest
+    // In-module residual calls ([`DIRECT_RESIDUAL_CALL`]): the largest
     // eligible `(i64×n)->i64` arity in this trace — residual CALLs (word
     // result or word-ABI void) plus the `New*` / write-barrier helper
     // targets, which share the same uniform-i64 ABI — or `None` if there
     // are none. Each distinct arity `0..=max` gets its own function type
     // (declared below) so those arms can `call_indirect` with a static type.
-    let residual_max_arity = if WASM_DIRECT_RESIDUAL_CALL {
+    let residual_max_arity = if direct_residual_calls() {
         let scanned = analysis_ops
             .iter()
             .filter_map(|op| direct_helper_i64_arity(op, &ref_values))
@@ -3051,7 +3089,7 @@ pub fn build_wasm_module(
     // of the uniform i64 helper family. Preserve first-use order so a given
     // trace gets stable type indices while declaring each signature once.
     let mut typed_residual_sigs = Vec::new();
-    if WASM_DIRECT_RESIDUAL_CALL {
+    if direct_residual_calls() {
         for op in analysis_ops {
             if let Some(sig) = residual_call_typed_sig(op, constants)
                 && !typed_residual_sigs.contains(&sig)
@@ -3063,7 +3101,7 @@ pub fn build_wasm_module(
     // True-void residual calls use `(i64×n) -> ()`, a separate family from the
     // i64- and f64-result types. As with the uniform i64 family, declaring
     // `0..=max` makes each type index a base plus the call arity.
-    let true_void_residual_max_arity = if WASM_DIRECT_RESIDUAL_CALL {
+    let true_void_residual_max_arity = if direct_residual_calls() {
         analysis_ops
             .iter()
             .filter_map(residual_call_void_true_arity)
@@ -3421,7 +3459,7 @@ fn build_function(
     inline_trip: Option<(InlineTripProbe, u32)>,
 ) -> Result<Function, BackendError> {
     // The CA arm requires residual types (the setup above forces arity >= 2
-    // while `WASM_DIRECT_RESIDUAL_CALL` is enabled). Its `jit_call` fallback
+    // while [`DIRECT_RESIDUAL_CALL`] is enabled). Its `jit_call` fallback
     // branches are retained solely for the direct-family-disabled baseline.
     debug_assert!(!ca.emit_ca || residual_type_base.is_some());
     let value_locals_end = value_types.end_local();

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -733,7 +733,7 @@ pub struct CompiledWasmLoop {
     /// backend assembler state, not metainterpreter state: the optimized trace
     /// and all per-token descriptors have already been installed exactly as
     /// in the eager path.
-    #[cfg_attr(any(not(target_arch = "wasm32"), target_os = "wasi"), allow(dead_code))]
+    #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
     pub(crate) pending_wasm_bytes: RefCell<Option<Vec<u8>>>,
     /// This loop's own guard/finish exit descriptors (positions `[0,
     /// num_guard_cells)`, per-trace order), followed by the descr slices of
@@ -870,11 +870,11 @@ impl CompiledWasmLoop {
         if current != 0 {
             return Ok(current);
         }
-        #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
+        #[cfg(not(target_arch = "wasm32"))]
         {
             Ok(0)
         }
-        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+        #[cfg(target_arch = "wasm32")]
         {
             let pending = self.pending_wasm_bytes.borrow();
             let Some(bytes) = pending.as_deref() else {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -4912,45 +4912,80 @@ impl majit_backend::Backend for WasmBackend {
             }
 
             // Host-buffer frame path, for an embedder that registered no
-            // `JitFrame` type id: fail_index at frame[0], inputs/outputs at
-            // frame[1 + i], surviving Ref homes manually rooted across the
-            // trace. A home slot only ever holds null (entry init) or a valid
-            // GcRef (store-on-def), so forwarding is safe. This buffer is not
-            // on the jitframe shadow stack and no collection moves it, which is
-            // what `host_entry_frame_is_jitframe` reports to codegen so the
-            // body emits no frame reload. The path to
-            // `wasm_gc_remove_root` is straight-line and the wasm32 build is
-            // `panic=abort`, so `glue::execute` cannot unwind and leak roots.
-            let mut frame = vec![0i64; frame_size];
+            // `JitFrame` type id: fail_index at item[0], inputs/outputs at
+            // item[1 + i], surviving Ref homes rooted across the trace. A home
+            // slot only ever holds null (entry init) or a valid GcRef
+            // (store-on-def), so forwarding is safe. No collection moves this
+            // buffer, which is what `host_entry_frame_is_jitframe` reports to
+            // codegen so the body emits no frame reload. The release below is
+            // straight-line and the wasm32 build is `panic=abort`, so
+            // `glue::execute` cannot unwind and leak roots.
+            //
+            // The buffer carries a `JitFrame` header all the same, and is
+            // published on the jitframe shadow stack for the span of the call.
+            // Rooting the homes with the active GC reaches only *that*
+            // collector. A frontend keeping a heap of its own reads the shadow
+            // stack instead -- it is the one publication point a collector that
+            // is not this one can consult -- so without the frame on it a home
+            // holding one of that heap's objects is invisible: the collector
+            // moves the object, the home keeps the address it had, and the
+            // trace resumes on a pointer into free space. The two walks forward
+            // the same slots, which a forwarding collector does idempotently:
+            // the second visit reads an address the first already took out of
+            // from-space.
+            let sign = std::mem::size_of::<isize>();
+            let depth = frame_size * 8 / sign;
+            let alloc_size = majit_backend::jitframe::JitFrame::alloc_size(depth);
+            // An `i64` element type for the alignment a `JitFrame` needs and
+            // for the zero fill `JitFrame::init` requires.
+            let mut backing = vec![0i64; alloc_size.div_ceil(8)];
+            let jf = backing.as_mut_ptr() as *mut majit_backend::jitframe::JitFrame;
+            unsafe { majit_backend::jitframe::JitFrame::init(jf, std::ptr::null(), depth) };
+            // Held until the outputs are read, which is what `jf_gcmap` points
+            // at for as long as the frame is on the shadow stack.
+            let gcmap = build_home_gcmap(compiled.frame);
+            unsafe { (*jf).jf_gcmap = gcmap.as_ptr() as *const u8 };
+            let items = (jf as usize + majit_backend::jitframe::FIRST_ITEM_OFFSET) as *mut i64;
             for (i, arg) in args.iter().enumerate() {
-                frame[1 + i] = match arg {
+                let v = match arg {
                     Value::Int(v) => *v,
                     Value::Float(v) => v.to_bits() as i64,
                     Value::Ref(r) => r.0 as i64,
                     Value::Void => 0,
                 };
+                unsafe { *items.add(1 + i) = v };
             }
-            let frame_ptr = frame.as_mut_ptr() as usize as u32;
             let home_base = compiled.frame.home_slot_base as usize / 8;
             for h in 0..compiled.frame.home_slots {
-                let slot = unsafe { frame.as_mut_ptr().add(home_base + h) } as *mut GcRef;
+                let slot = unsafe { items.add(home_base + h) } as *mut GcRef;
                 unsafe { wasm_gc_add_root(slot) };
             }
+            majit_gc::shadow_stack::register_libc_jitframe(jf as usize);
+            let saved = majit_gc::shadow_stack::push_jf(GcRef(jf as usize));
             {
                 let _bh_phase = majit_gc::BhProbePhase::enter("compiled");
-                glue::execute(func_handle, frame_ptr);
+                glue::execute(func_handle, items as usize as u32);
             }
+            majit_gc::shadow_stack::pop_jf_to(saved);
+            majit_gc::shadow_stack::unregister_libc_jitframe(jf as usize);
+            // Nothing reads the frame's interior through the gcmap any more,
+            // and the gcmap is about to go out of scope.
+            unsafe { (*jf).jf_gcmap = std::ptr::null() };
             for h in 0..compiled.frame.home_slots {
-                let slot = unsafe { frame.as_mut_ptr().add(home_base + h) } as *mut GcRef;
+                let slot = unsafe { items.add(home_base + h) } as *mut GcRef;
                 wasm_gc_remove_root(slot);
             }
             let exc_value = jit_exc_take();
-            let fail_index = frame[0] as u32;
+            let fail_index = unsafe { *items } as u32;
             // Global fail-index space (see the CA-path resolution above).
             let fail_descr =
                 global_fail_descr(fail_index).expect("invalid fail_index from compiled wasm");
             let num_outputs = exit_slot_count(&fail_descr);
-            let raw_values: Vec<i64> = (0..num_outputs).map(|i| frame[1 + i]).collect();
+            let raw_values: Vec<i64> = (0..num_outputs)
+                .map(|i| unsafe { *items.add(1 + i) })
+                .collect();
+            drop(gcmap);
+            drop(backing);
             DeadFrame::Boxed(WasmFrameData::boxed(raw_values, fail_descr, exc_value))
         }
     }

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2069,13 +2069,112 @@ pub fn set_faithful_residual_call_addrs(addrs: &[i64]) {
 }
 
 thread_local! {
+    /// Per thread, and that is the whole process wherever the set is consulted for
+    /// real: every registration a shipped build makes is compiled only for wasm32,
+    /// and a module instance there is one thread.
+    ///
+    /// Two properties keep a wider store from being owed anyway. A lookup that
+    /// misses is answered by the reflecting host trampoline, so a registration on
+    /// one thread and a question on another costs a round trip and never a wrong
+    /// signature -- the direction that traps is a spurious *hit*, which per-thread
+    /// storage cannot manufacture. And a caller replacing the whole list leaves
+    /// every other thread's alone, so two of them may run at once.
     static FAITHFUL_RESIDUAL_CALL_ADDRS: RefCell<std::collections::HashSet<i64>> =
         RefCell::new(std::collections::HashSet::new());
 }
 
-/// Whether `addr` was vouched for by [`set_faithful_residual_call_addrs`].
+/// Vouch for one more callee, leaving the rest of the set alone.
+///
+/// [`set_faithful_residual_call_addrs`] is the embedder's whole list, declared
+/// once. This is for a producer that mints word-spelled call targets as it
+/// goes: the address does not exist until the target is built, so it cannot be
+/// in a list written ahead of time, and the producer that built it is the one
+/// that knows how it is spelled.
+pub fn vouch_residual_call_addr(addr: i64) {
+    FAITHFUL_RESIDUAL_CALL_ADDRS.with(|set| {
+        set.borrow_mut().insert(addr);
+    });
+}
+
+/// Whether `addr` was vouched for by [`set_faithful_residual_call_addrs`] or
+/// [`vouch_residual_call_addr`].
 pub(crate) fn residual_call_descr_is_faithful(addr: i64) -> bool {
     FAITHFUL_RESIDUAL_CALL_ADDRS.with(|set| set.borrow().contains(&addr))
+}
+
+/// [`vouch_residual_call_addr`] for a target whose *result* is a word too, so
+/// its whole wasm signature is the uniform `(i64…) -> i64`.
+///
+/// The parameter half is what a compiled call needs to know; this is the half
+/// [`direct_word_abi_call`] needs, because a caller reaching a target through
+/// a raw address has no descr telling it whether the callee returns anything.
+/// A void target vouched here would be called as if it returned a word, which
+/// is the same type error the vouching exists to avoid.
+pub fn vouch_residual_call_addr_returning_word(addr: i64) {
+    vouch_residual_call_addr(addr);
+    WORD_RESULT_RESIDUAL_CALL_ADDRS.with(|set| {
+        set.borrow_mut().insert(addr);
+    });
+}
+
+thread_local! {
+    /// Per thread for the reasons [`FAITHFUL_RESIDUAL_CALL_ADDRS`] is, and it is
+    /// read on the thread that wrote it for one more: the producer minting a
+    /// word-spelled target and the guest call reaching that target are the same
+    /// thread by construction, since the target's address is a table index in the
+    /// instance that minted it.
+    static WORD_RESULT_RESIDUAL_CALL_ADDRS: RefCell<std::collections::HashSet<i64>> =
+        RefCell::new(std::collections::HashSet::new());
+}
+
+/// Call a residual target from inside the guest, when its whole signature is
+/// the uniform `(i64…) -> i64` and this backend was told so.
+///
+/// The recording and blackhole paths reach a target through a raw address and
+/// no descr, and wasm32 `call_indirect` type-checks the callee: transmuting
+/// that address to the signature the residual call carries traps unless the
+/// callee really is spelled that way. So those paths hand the call to a host
+/// that reflects the callee's declared type first — a guest→host→guest round
+/// trip per call. For a target vouched by
+/// [`vouch_residual_call_addr_returning_word`] the transmute is exactly right
+/// and the round trip buys nothing.
+///
+/// `None` means the caller still owes the reflecting path: the address was not
+/// vouched for, or its arity is past what a residual call can carry.
+#[cfg(target_arch = "wasm32")]
+pub fn direct_word_abi_call(func_ptr: usize, args: &[i64]) -> Option<i64> {
+    if !WORD_RESULT_RESIDUAL_CALL_ADDRS.with(|set| set.borrow().contains(&(func_ptr as i64))) {
+        return None;
+    }
+    // One arm per arity: the transmuted type has to name the parameters, and
+    // wasm has no variadic call. `MAX_CALL_ARGS` bounds what a residual call
+    // can carry, so an arity past the arms below cannot arrive here.
+    macro_rules! arms {
+        ($( [$($arg:ident),*] ),* $(,)?) => {
+            match args {
+                $(
+                    [$($arg),*] => {
+                        let f: extern "C" fn($(arms!(@i64 $arg)),*) -> i64 =
+                            unsafe { std::mem::transmute(func_ptr) };
+                        Some(f($(*$arg),*))
+                    }
+                )*
+                _ => None,
+            }
+        };
+        (@i64 $arg:ident) => { i64 };
+    }
+    arms![
+        [],
+        [a0],
+        [a0, a1],
+        [a0, a1, a2],
+        [a0, a1, a2, a3],
+        [a0, a1, a2, a3, a4],
+        [a0, a1, a2, a3, a4, a5],
+        [a0, a1, a2, a3, a4, a5, a6],
+        [a0, a1, a2, a3, a4, a5, a6, a7],
+    ]
 }
 
 /// Configure the dormant terminal-decline regression hook.

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -332,8 +332,9 @@ pub struct TraceEntryCensusStorage {
 }
 
 /// Arm trace-entry instrumentation before the guest starts compiling traces.
-/// Native runs select the same facility with `MAJIT_TRACE_ENTRY_CENSUS`; wasm
-/// has no environment, so its host calls this function through pyre-wasm.
+/// `MAJIT_TRACE_ENTRY_CENSUS` selects the same facility wherever the guest has
+/// an environment to read it from; a guest that has none is armed by its host
+/// through this function instead.
 pub fn trace_entry_census_enable() {
     TRACE_ENTRY_CENSUS_FORCED.store(true, Ordering::Relaxed);
 }
@@ -342,15 +343,12 @@ fn trace_entry_census_enabled() -> bool {
     if TRACE_ENTRY_CENSUS_FORCED.load(Ordering::Relaxed) {
         return true;
     }
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        *ON.get_or_init(|| std::env::var_os("MAJIT_TRACE_ENTRY_CENSUS").is_some())
-    }
-    #[cfg(target_arch = "wasm32")]
-    {
-        false
-    }
+    // Read on every target. Whether a wasm guest has an environment is a
+    // property of its embedder, not of the architecture: one launched as a
+    // WASI command inherits the variables its host passes it, and one with no
+    // environment reads an absent variable rather than failing to compile.
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("MAJIT_TRACE_ENTRY_CENSUS").is_some())
 }
 
 /// Allocate the one counter array that an armed physical trace module uses.
@@ -1175,13 +1173,41 @@ fn ca_inline_params(frame_bytes: u32) -> Option<codegen::CaInlineParams> {
     })?
 }
 
+/// Whether the host entry runs a trace on a `JitFrame` it pushed onto the
+/// jitframe shadow stack.
+///
+/// `execute_token` allocates that frame only once a `JitFrame` type id has been
+/// registered; with none it runs the trace on a plain host buffer, which no
+/// collection moves and which the shadow stack never describes. Every frame
+/// reload a trace body emits answers out of that shadow stack, so an embedder
+/// that registered no type id must get no reloads at all — a reload there would
+/// replace the running frame pointer with whatever root happens to sit on top.
+fn host_entry_frame_is_jitframe() -> bool {
+    wasm_jitframe_tid() != 0
+}
+
 /// Address of the active jitframe shadow-stack top cell for ordinary trace
 /// body reloads. This does not depend on nursery fast-path eligibility: the
-/// reload is valid whenever a GC is active at compilation time.
+/// reload is valid whenever a GC is active at compilation time *and* the host
+/// entry runs its traces on a pushed `JitFrame`.
 fn jf_top_addr() -> Option<u32> {
+    if !host_entry_frame_is_jitframe() {
+        return None;
+    }
     with_wasm_active_gc(|_| majit_gc::shadow_stack::get_root_stack_top_addr())
         .and_then(|addr| u32::try_from(addr).ok())
         .filter(|&addr| addr != 0)
+}
+
+/// Table slot of the frame-reload helper, or `0` when the running frame is not
+/// one the shadow stack describes. Zero reaches codegen as "this trace needs no
+/// reload", which is what a frame the host never pushed — and never moves —
+/// requires.
+fn body_reload_fn_ptr() -> i64 {
+    if !host_entry_frame_is_jitframe() {
+        return 0;
+    }
+    wasm_jit_ca_reload_frame as *const () as usize as i64
 }
 
 /// `majit_gc::CollectGenerationFn` installed by `register_active_hooks`. Drives
@@ -3412,7 +3438,7 @@ impl majit_backend::Backend for WasmBackend {
             frame,
             ca: ca_targets.as_ref().map_or_else(
                 || codegen::CaParams {
-                    ca_reload_fn_ptr: wasm_jit_ca_reload_frame as *const () as usize as i64,
+                    ca_reload_fn_ptr: body_reload_fn_ptr(),
                     jf_top_addr: jf_top_addr(),
                     ..codegen::CaParams::default()
                 },
@@ -4215,7 +4241,7 @@ impl majit_backend::Backend for WasmBackend {
             }
         } else {
             codegen::CaParams {
-                ca_reload_fn_ptr: wasm_jit_ca_reload_frame as *const () as usize as i64,
+                ca_reload_fn_ptr: body_reload_fn_ptr(),
                 jf_top_addr: jf_top_addr(),
                 ..codegen::CaParams::default()
             }
@@ -4786,11 +4812,14 @@ impl majit_backend::Backend for WasmBackend {
                 return DeadFrame::Boxed(WasmFrameData::boxed(raw_values, fail_descr, exc_value));
             }
 
-            // Legacy host-Vec frame path (default, PYRE_WASM_CA off): fail_index
-            // at frame[0], inputs/outputs at frame[1 + i], surviving Ref homes
-            // manually rooted across the trace. A home slot only ever holds null
-            // (entry init) or a valid GcRef (store-on-def), so forwarding is
-            // safe. The path to
+            // Host-buffer frame path, for an embedder that registered no
+            // `JitFrame` type id: fail_index at frame[0], inputs/outputs at
+            // frame[1 + i], surviving Ref homes manually rooted across the
+            // trace. A home slot only ever holds null (entry init) or a valid
+            // GcRef (store-on-def), so forwarding is safe. This buffer is not
+            // on the jitframe shadow stack and no collection moves it, which is
+            // what `host_entry_frame_is_jitframe` reports to codegen so the
+            // body emits no frame reload. The path to
             // `wasm_gc_remove_root` is straight-line and the wasm32 build is
             // `panic=abort`, so `glue::execute` cannot unwind and leak roots.
             let mut frame = vec![0i64; frame_size];

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -7,10 +7,16 @@
 /// native embedder (wasmi / wasmtime) supplies. On native targets,
 /// compile_loop succeeds but execute_token requires a wasm host
 /// (unreachable natively).
+///
+/// Which binding a build has is a feature, not a target OS: `host-import` is
+/// satisfied by an embedder, and an embedder is exactly what a WASI command
+/// runs under. So the split below is wasm32 against native, and a wasm32 build
+/// with no binding selected keeps `glue`'s stubs rather than being routed to
+/// the native arm.
 pub mod codegen;
 pub mod failguard;
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(target_arch = "wasm32")]
 mod glue;
 
 use std::cell::RefCell;
@@ -476,19 +482,19 @@ pub fn bridge_diag(i: usize) -> u64 {
 }
 
 /// Number of JIT trace entries made from the guest.
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(target_arch = "wasm32")]
 pub fn jit_execute_count() -> u64 {
     glue::jit_execute_count()
 }
 
 /// Number of host modules materialized after the lazy-install gate.
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(target_arch = "wasm32")]
 pub fn jit_compile_count() -> u64 {
     glue::jit_compile_count()
 }
 
 /// Number of materializations served by the byte-identical module cache.
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(target_arch = "wasm32")]
 pub fn jit_compile_cache_hits() -> u64 {
     glue::jit_compile_cache_hits()
 }
@@ -2323,7 +2329,7 @@ impl WasmBackend {
             return;
         };
         let _ = (cells_base, slot);
-        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+        #[cfg(target_arch = "wasm32")]
         if cells_base != 0 {
             let cell = (cells_base as usize + source_fail_index as usize * 4) as *mut u32;
             unsafe { core::ptr::write(cell, slot) };
@@ -2396,7 +2402,7 @@ impl WasmBackend {
             .bridge_slots
             .borrow_mut()
             .remove(&source_fail_index);
-        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+        #[cfg(target_arch = "wasm32")]
         if source_cells_base != 0 {
             let cell = (source_cells_base as usize + source_fail_index as usize * 4) as *mut u32;
             unsafe { core::ptr::write(cell, 0) };
@@ -2427,7 +2433,7 @@ impl WasmBackend {
                         .bridge_slots
                         .borrow_mut()
                         .insert(source_fail_index, slot);
-                    #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+                    #[cfg(target_arch = "wasm32")]
                     if source_cells_base != 0 {
                         let cell = (source_cells_base as usize + source_fail_index as usize * 4)
                             as *mut u32;
@@ -2507,13 +2513,13 @@ impl WasmBackend {
             })
             .collect();
 
-        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+        #[cfg(target_arch = "wasm32")]
         if glue::replace_module(old_handle, &wasm_bytes) != old_handle {
             return Err(BackendError::Unsupported(
                 "wasm host rejected the re-emitted trace module".into(),
             ));
         }
-        #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
+        #[cfg(not(target_arch = "wasm32"))]
         {
             let _ = wasm_bytes;
             return Err(BackendError::Unsupported(
@@ -2542,7 +2548,7 @@ impl WasmBackend {
                 *start += guard_growth;
             }
         }
-        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+        #[cfg(target_arch = "wasm32")]
         if new_cells_base != 0 {
             for (&fail_index, &bridge_slot) in compiled.bridge_slots.borrow().iter() {
                 let cell = (new_cells_base as usize + fail_index as usize * 4) as *mut u32;
@@ -2565,7 +2571,7 @@ impl WasmBackend {
                 // them has lost its dispatch entry. Unreplayed, that guard
                 // deopts to the tracer on every failure and retraces a bridge
                 // it can never reach.
-                #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+                #[cfg(target_arch = "wasm32")]
                 if new_cells_base != 0 {
                     for (&(trace_id, fail_index), &bridge_slot) in
                         compiled.chained_bridge_slots.borrow().iter()
@@ -3482,13 +3488,13 @@ impl majit_backend::Backend for WasmBackend {
 
         // Instantiate via the host binding on wasm32, or store bytes for
         // testing on native (no wasm host available).
-        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+        #[cfg(target_arch = "wasm32")]
         let func_handle = if defer_host_compile {
             0
         } else {
             glue::compile_module_cached(&wasm_bytes)
         };
-        #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
+        #[cfg(not(target_arch = "wasm32"))]
         let func_handle = 0u32; // Placeholder — no wasm host available
 
         // `jit_compile_wasm` returns 0 when the host runtime rejects the emitted
@@ -3499,7 +3505,7 @@ impl majit_backend::Backend for WasmBackend {
         // a trace), leaving `frame[0]` unwritten and resolving a wrong exit descr.
         // Decline the compile so the metainterp keeps the interpreter fallback —
         // a backend capability limit, reported like any other unsupported shape.
-        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+        #[cfg(target_arch = "wasm32")]
         if !defer_host_compile && func_handle == 0 {
             diag_bump(26);
             return Err(BackendError::Unsupported(
@@ -4300,15 +4306,15 @@ impl majit_backend::Backend for WasmBackend {
         // descrs and flip the source guard's cell. Order matters: the descrs
         // must be resolvable (appended) before the cell makes the guard dispatch
         // into the bridge.
-        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+        #[cfg(target_arch = "wasm32")]
         let bridge_slot = glue::compile_module(&wasm_bytes);
-        #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
+        #[cfg(not(target_arch = "wasm32"))]
         let bridge_slot = 0u32;
         // A 0 handle means the host rejected the bridge module (see the
         // `compile_loop` decline). Flipping the source guard's cell to dispatch
         // into slot 0 would tail-call a non-trace; decline instead so the guard
         // keeps its host round-trip (correct, unaccelerated).
-        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+        #[cfg(target_arch = "wasm32")]
         if bridge_slot == 0 {
             return Err(BackendError::Unsupported(
                 "wasm host rejected the compiled bridge module (oversized function body \
@@ -4430,7 +4436,7 @@ impl majit_backend::Backend for WasmBackend {
         } else {
             diag_bump(28);
         }
-        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+        #[cfg(target_arch = "wasm32")]
         if source_cells_base != 0 && bridge_slot != 0 {
             let cell = (source_cells_base as usize + source_fail_index as usize * 4) as *mut u32;
             if unsafe { core::ptr::read(cell) } != 0 {
@@ -4461,7 +4467,7 @@ impl majit_backend::Backend for WasmBackend {
                 }
             }
         }
-        #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
+        #[cfg(not(target_arch = "wasm32"))]
         let _ = (source_cells_base, bridge_slot);
 
         let code_size = wasm_bytes.len();
@@ -4673,7 +4679,7 @@ impl majit_backend::Backend for WasmBackend {
             .expect("no compiled code")
             .downcast_ref::<CompiledWasmLoop>()
             .expect("not CompiledWasmLoop");
-        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+        #[cfg(target_arch = "wasm32")]
         let func_handle = compiled
             .materialize_func_handle()
             .expect("wasm backend failed to materialize a runnable trace");
@@ -4682,12 +4688,12 @@ impl majit_backend::Backend for WasmBackend {
         // call area. Chained bridges share these exact offsets; only CA callee
         // frames use the smaller homes prefix (`ca_frame_bytes`).
         let frame_size = (compiled.frame.frame_bytes as usize).div_ceil(8);
-        #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
+        #[cfg(not(target_arch = "wasm32"))]
         {
             let _ = (frame_size, args);
             panic!("wasm backend execute_token requires a wasm host");
         }
-        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+        #[cfg(target_arch = "wasm32")]
         {
             // The pending-exception cell is global, unlike the native
             // per-jitframe `jf_guard_exc`. A residual raise on a blackhole
@@ -4943,7 +4949,7 @@ impl majit_backend::Backend for WasmBackend {
                     .expect("published CALL_ASSEMBLER target has a live compiled loop")
             };
             let handle = new_loop.materialize_func_handle()?;
-            #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+            #[cfg(target_arch = "wasm32")]
             if handle == 0 {
                 return Err(BackendError::Unsupported(format!(
                     "call-assembler redirect to token {} could not materialize wasm code",

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -465,6 +465,27 @@ fn build_module_with_frame(
     gc_info: &codegen::GuardGcTypeInfo,
     frame: codegen::FrameGeometry,
 ) -> (Vec<u8>, Vec<codegen::GuardExit>) {
+    build_module_with_ca(
+        inputargs,
+        ops,
+        constants,
+        vtable_offset,
+        gc_info,
+        frame,
+        codegen::CaParams::default(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_module_with_ca(
+    inputargs: &[InputArg],
+    ops: &[Op],
+    constants: &indexmap::IndexMap<u32, i64>,
+    vtable_offset: Option<usize>,
+    gc_info: &codegen::GuardGcTypeInfo,
+    frame: codegen::FrameGeometry,
+    ca: codegen::CaParams,
+) -> (Vec<u8>, Vec<codegen::GuardExit>) {
     let inputs = codegen::ModuleBuildInputs {
         inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
         ops: ops.iter().cloned().collect(),
@@ -488,7 +509,7 @@ fn build_module_with_frame(
         external_jump_wide_slot: 0,
         external_jump_key: 0,
         frame,
-        ca: codegen::CaParams::default(),
+        ca,
     };
     let (bytes, guards, _) =
         codegen::build_wasm_module(&inputs).expect("wasm codegen should succeed");
@@ -2303,7 +2324,10 @@ fn test_true_void_family_does_not_shift_new_call_type() {
     validate_wasm(&bytes);
     assert_eq!(guards.len(), 1);
     let (indirect_calls, drops) = indirect_call_types_and_drop_count(&bytes);
-    assert_eq!(indirect_calls.len(), 4);
+    // The void call and the `New`. Neither is followed by a frame reload:
+    // `CaParams::default()` publishes no reload helper, which says the frame
+    // this trace runs on is not one the jitframe shadow stack describes.
+    assert_eq!(indirect_calls.len(), 2);
     assert_eq!(
         function_type(&bytes, indirect_calls[0].0 as usize),
         (
@@ -2312,7 +2336,7 @@ fn test_true_void_family_does_not_shift_new_call_type() {
         )
     );
     assert_eq!(
-        function_type(&bytes, indirect_calls[2].0 as usize),
+        function_type(&bytes, indirect_calls[1].0 as usize),
         (
             vec![wasmparser::ValType::I64, wasmparser::ValType::I64],
             vec![wasmparser::ValType::I64]
@@ -2348,7 +2372,8 @@ fn test_list_append_word_abi_and_new_type_indices_match_declared_i64_types() {
     validate_wasm(&bytes);
     assert_eq!(guards.len(), 1);
     let (indirect_calls, drops) = indirect_call_types_and_drop_count(&bytes);
-    assert_eq!(indirect_calls, vec![(3, 0), (1, 0), (3, 0), (1, 0)]);
+    // No reload between them: `CaParams::default()` publishes no reload helper.
+    assert_eq!(indirect_calls, vec![(3, 0), (3, 0)]);
     assert_eq!(
         function_type(&bytes, indirect_calls[0].0 as usize),
         (
@@ -2358,7 +2383,7 @@ fn test_list_append_word_abi_and_new_type_indices_match_declared_i64_types() {
         "jit_list_append returns an ignored machine word"
     );
     assert_eq!(
-        function_type(&bytes, indirect_calls[2].0 as usize),
+        function_type(&bytes, indirect_calls[1].0 as usize),
         (
             vec![wasmparser::ValType::I64, wasmparser::ValType::I64],
             vec![wasmparser::ValType::I64]
@@ -2481,7 +2506,8 @@ fn test_void_word_abi_call_uses_i64_result_type_and_drop() {
     assert!(has_table_import(&bytes));
     assert_eq!(import_func_type(&bytes, "jit_call_compact"), None);
     let (indirect_calls, drops) = indirect_call_types_and_drop_count(&bytes);
-    assert_eq!(indirect_calls, vec![(2, 0), (1, 0)]);
+    // The call alone: `CaParams::default()` publishes no reload helper.
+    assert_eq!(indirect_calls, vec![(2, 0)]);
     assert_eq!(
         function_type(&bytes, 2),
         (
@@ -2490,6 +2516,52 @@ fn test_void_word_abi_call_uses_i64_result_type_and_drop() {
         )
     );
     assert_eq!(drops, 1, "the ignored word result must be dropped");
+}
+
+/// A published reload helper is the statement that the running frame can move,
+/// so the reload after a collecting call must appear exactly when one is
+/// published. Emitting it unconditionally calls through whatever occupies the
+/// unpublished slot and then installs its result as the frame pointer, which
+/// is why both directions are asserted here rather than only the one this
+/// backend's own host takes.
+#[test]
+fn test_frame_reload_is_emitted_only_when_a_reload_helper_is_published() {
+    let inputargs = vec![InputArg::from_type(Type::Int, 0)];
+    let ops = vec![
+        void_call(vec![Type::Int], &[OpRef::input_arg_int(0)], 8),
+        Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]),
+    ];
+    let build = |ca| {
+        build_module_with_ca(
+            &inputargs,
+            &ops,
+            &indexmap::IndexMap::new(),
+            Some(0),
+            &codegen::GuardGcTypeInfo::default(),
+            codegen::FrameGeometry::fixed(),
+            ca,
+        )
+        .0
+    };
+
+    let unpublished = build(codegen::CaParams::default());
+    validate_wasm(&unpublished);
+    assert_eq!(
+        indirect_call_types_and_drop_count(&unpublished).0,
+        vec![(2, 0)],
+        "the call alone; a frame the host never pushed has nothing to reload from"
+    );
+
+    let published = build(codegen::CaParams {
+        ca_reload_fn_ptr: 7,
+        ..codegen::CaParams::default()
+    });
+    validate_wasm(&published);
+    assert_eq!(
+        indirect_call_types_and_drop_count(&published).0,
+        vec![(2, 0), (1, 0)],
+        "the reload follows the call whose collection may have moved the frame"
+    );
 }
 
 #[test]

--- a/majit/majit-ir/src/lib.rs
+++ b/majit/majit-ir/src/lib.rs
@@ -50,8 +50,8 @@ pub use resoperation::{
     Op, OpCode, OpRc, OpRef, RdVirtualInfo, VectorizationInfo, VirtualFieldsInfo, format_trace,
 };
 pub use value::{
-    CallResultWord, Const, FAILARGS_LIMIT, GREEN_UHASH_MULT, GREEN_UHASH_SEED, GcRef, GreenAsI64,
-    GreenKey, GreenType, InputArg, InputArgRc, JitDriverVar, RefReleaseFn, RefRetainFn,
+    CallArgWord, CallResultWord, Const, FAILARGS_LIMIT, GREEN_UHASH_MULT, GREEN_UHASH_SEED, GcRef,
+    GreenAsI64, GreenKey, GreenType, InputArg, InputArgRc, JitDriverVar, RefReleaseFn, RefRetainFn,
     RetainedGreens, SharedConstPool, StrEqFn, StrHashFn, Type, Value, VarKind, green_type_to_ir,
     green_uhash_step, make_str_slot, pypyjit_greenkey, pypyjit_greenkey_uhash, set_ref_resolver,
     set_str_resolver, set_unicode_resolver,

--- a/majit/majit-ir/src/value.rs
+++ b/majit/majit-ir/src/value.rs
@@ -1409,6 +1409,91 @@ impl<T: ?Sized> CallResultWord for *mut T {
     }
 }
 
+/// Narrows a machine word back to the parameter type a registered call target
+/// declares.
+///
+/// The inverse of [`CallResultWord`], and owed for the same reason at the other
+/// end of the call. A compiled call passes every non-float argument as the word
+/// a trace register holds, so the shim standing in for the target has to be
+/// spelled in words to be the thing that call names. Where a pointer is as wide
+/// as a word that is invisible: `usize` and `&T` arrive in a whole register
+/// already, and a shim spelled with them is the same function. Where a pointer
+/// is narrower — a 32-bit address in a 64-bit register — it is not, and the
+/// mismatch is a type error at the call rather than a slow path, so the shim
+/// takes words and narrows here.
+///
+/// A parameter type that is not one of the types below has to implement this
+/// before the target can be registered. A struct passed by value cannot: it is
+/// not a word, and no narrowing recovers one.
+pub trait CallArgWord {
+    /// Reconstitute this parameter from the word a compiled call passes for it.
+    ///
+    /// # Safety
+    ///
+    /// `word` must be what the call holds for this parameter. For a reference
+    /// or a raw pointer that means an address of the right type which stays
+    /// live for the call, exactly as the caller of the target itself owes.
+    unsafe fn from_call_word(word: i64) -> Self;
+}
+
+macro_rules! impl_call_arg_word_int {
+    ($($ty:ty),*) => {
+        $(
+            impl CallArgWord for $ty {
+                #[inline(always)]
+                unsafe fn from_call_word(word: i64) -> Self {
+                    word as $ty
+                }
+            }
+        )*
+    };
+}
+
+// `as $ty` per type, the exact inverse of the widening `into_call_word` did:
+// a narrower type keeps the low bits the widening preserved, and the
+// word-width types are the identity.
+impl_call_arg_word_int!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
+
+impl CallArgWord for bool {
+    #[inline(always)]
+    unsafe fn from_call_word(word: i64) -> Self {
+        // `into_call_word` produces 0 or 1, but a target may be reached with a
+        // word another producer widened, so read the whole word rather than
+        // its low bit.
+        word != 0
+    }
+}
+
+// Only sized pointees: a word carries one address, and a fat pointer's
+// metadata is not in it.
+impl<T> CallArgWord for *const T {
+    #[inline(always)]
+    unsafe fn from_call_word(word: i64) -> Self {
+        word as usize as *const T
+    }
+}
+
+impl<T> CallArgWord for *mut T {
+    #[inline(always)]
+    unsafe fn from_call_word(word: i64) -> Self {
+        word as usize as *mut T
+    }
+}
+
+impl<T> CallArgWord for &T {
+    #[inline(always)]
+    unsafe fn from_call_word(word: i64) -> Self {
+        unsafe { &*(word as usize as *const T) }
+    }
+}
+
+impl<T> CallArgWord for &mut T {
+    #[inline(always)]
+    unsafe fn from_call_word(word: i64) -> Self {
+        unsafe { &mut *(word as usize as *mut T) }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
@@ -673,10 +673,16 @@ pub(super) fn opcode_for_assign_binop_f(op: &BinOp) -> Option<Ident> {
 /// not readable as an `i64` unless the callee is known to fill it. Registering
 /// a shim rather than the callee itself makes that true of every target.
 ///
-/// The shim's parameter types come from `func` itself: the annotation supplies
-/// the `extern`-free `fn` shape and the call in the body resolves each hole, so
-/// no argument type has to be spelled here. `arity` counts the receiver for a
-/// method path.
+/// The shim's parameters are the machine words a compiled call passes, not the
+/// types `func` declares: a non-float argument goes in spelled `i64` and is
+/// narrowed at the boundary by [`majit_ir::CallArgWord`], whose target type
+/// inference reads off `func`'s own signature. Where a pointer is as wide as a
+/// word that spelling is the same function it always was; where it is narrower
+/// it is the difference between a call and a type error, since a `usize` or a
+/// `&T` parameter is then not the word the call holds. A float argument keeps
+/// its hole: it rides a float register, and a word is not what the call passes
+/// for it. `arg_kinds` is one entry per parameter, the receiver of a method
+/// path included.
 ///
 /// `extern`-free is also all this can be. A non-capturing closure coerces to
 /// `fn(..)` and not to `extern "C" fn(..)`, and an `extern "C"` fn item has to
@@ -687,13 +693,32 @@ pub(super) fn opcode_for_assign_binop_f(op: &BinOp) -> Option<Ident> {
 /// `extern "C" fn(..) -> i64` call-target wrapper and register that. A
 /// `calls = { .. }` entry naming a function that carries no such attribute has
 /// no wrapper to reach for.
-pub(super) fn word_result_addr_tokens(func: &impl ToTokens, arity: usize) -> TokenStream {
-    let params: Vec<Ident> = (0..arity).map(|i| format_ident!("__majit_a{i}")).collect();
-    let holes: Vec<TokenStream> = (0..arity).map(|_| quote! { _ }).collect();
+pub(super) fn word_result_addr_tokens(
+    func: &impl ToTokens,
+    arg_kinds: &[BindingKind],
+) -> TokenStream {
+    let params: Vec<Ident> = (0..arg_kinds.len())
+        .map(|i| format_ident!("__majit_a{i}"))
+        .collect();
+    let holes: Vec<TokenStream> = arg_kinds
+        .iter()
+        .map(|kind| match kind {
+            BindingKind::Float => quote! { _ },
+            _ => quote! { i64 },
+        })
+        .collect();
+    let args: Vec<TokenStream> = arg_kinds
+        .iter()
+        .zip(&params)
+        .map(|(kind, param)| match kind {
+            BindingKind::Float => quote! { #param },
+            _ => quote! { unsafe { majit_ir::CallArgWord::from_call_word(#param) } },
+        })
+        .collect();
     quote! {
         {
             let __majit_word_shim: fn(#(#holes),*) -> i64 = |#(#params),*| {
-                majit_ir::CallResultWord::into_call_word(#func(#(#params),*))
+                majit_ir::CallResultWord::into_call_word(#func(#(#args),*))
             };
             __majit_word_shim as *const ()
         }
@@ -706,7 +731,7 @@ pub(super) fn word_result_addr_tokens(func: &impl ToTokens, arity: usize) -> Tok
 pub(super) fn word_result_addr_for_kind(
     kind: BindingKind,
     func: &impl ToTokens,
-    arity: usize,
+    arg_kinds: &[BindingKind],
 ) -> Option<TokenStream> {
-    matches!(kind, BindingKind::Int).then(|| word_result_addr_tokens(func, arity))
+    matches!(kind, BindingKind::Int).then(|| word_result_addr_tokens(func, arg_kinds))
 }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -1057,13 +1057,17 @@ impl<'c> Lowerer<'c> {
         } else {
             None
         };
+        // The shim stands in for the callee, whose parameters are `func_args`
+        // alone: `arg_regs` carries the leading value register the cond_call op
+        // reads and the callee never sees.
+        let cond_call_arg_kinds: Vec<BindingKind> = arg_regs[1..].iter().map(|r| r.kind).collect();
         let register_target = self.call_target_registration_tokens(
             func_path,
             policy,
             slot,
             is_inferred,
             inferred_policy_check,
-            word_result_addr_for_kind(value_kind, func_path, func_args.len()),
+            word_result_addr_for_kind(value_kind, func_path, &cond_call_arg_kinds),
         );
         self.emit_op(
             OpMeta::linear(
@@ -1275,13 +1279,14 @@ impl<'c> Lowerer<'c> {
         } else {
             None
         };
+        let known_result_arg_kinds: Vec<BindingKind> = arg_regs.iter().map(|r| r.kind).collect();
         let register_target = self.call_target_registration_tokens(
             func_path,
             policy,
             slot,
             is_inferred,
             inferred_policy_check,
-            word_result_addr_for_kind(result_binding.kind, func_path, args.len() - 2),
+            word_result_addr_for_kind(result_binding.kind, func_path, &known_result_arg_kinds),
         );
         let result_typed = Register::new(result_binding.kind, result_reg);
         let mut reads = Vec::with_capacity(arg_regs.len() + 1);
@@ -1466,7 +1471,8 @@ impl<'c> Lowerer<'c> {
             arg_bindings.push(binding);
         }
         let func = &call.func;
-        let word_result_addr = word_result_addr_tokens(func, arg_bindings.len());
+        let arg_kinds: Vec<BindingKind> = arg_bindings.iter().map(|b| b.kind).collect();
+        let word_result_addr = word_result_addr_tokens(func, &arg_kinds);
         // jtransform.py:467-471 / 480-482: `-live-` follows the call, it does
         // not precede it.  Decide here whether the explicit arm below needs a
         // trailing marker; the inferred arm emits its own runtime-conditional
@@ -1769,7 +1775,7 @@ impl<'c> Lowerer<'c> {
                                 vec![Register::int(throwaway_reg)],
                             ),
                             quote! {
-                                let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
+                                let __fn_idx = __builder.add_word_abi_fn_ptr(#word_result_addr);
                                 #call_invocation
                             },
                         );
@@ -1798,7 +1804,7 @@ impl<'c> Lowerer<'c> {
                                 vec![Register::int(throwaway_reg)],
                             ),
                             quote! {
-                                let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
+                                let __fn_idx = __builder.add_word_abi_fn_ptr(#word_result_addr);
                                 #call_invocation
                             },
                         );
@@ -1821,7 +1827,7 @@ impl<'c> Lowerer<'c> {
                             vec![Register::int(throwaway_reg)],
                         ),
                         quote! {
-                            let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
+                            let __fn_idx = __builder.add_word_abi_fn_ptr(#word_result_addr);
                             __builder.residual_call_int_canonical_via_target_with_effect_info(
                                 __fn_idx,
                                 #typed_args,
@@ -1868,7 +1874,7 @@ impl<'c> Lowerer<'c> {
                             vec![Register::int(throwaway_reg)],
                         ),
                         quote! {
-                            let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
+                            let __fn_idx = __builder.add_word_abi_fn_ptr(#word_result_addr);
                             #call_stmt
                         },
                     );
@@ -1914,7 +1920,7 @@ impl<'c> Lowerer<'c> {
                             } else {
                                 __concrete_target
                             };
-                            let __fn_idx = __builder.add_call_target_with_save_err(
+                            let __fn_idx = __builder.add_word_abi_call_target_with_save_err(
                                 __trace_target,
                                 __concrete_target,
                                 #__slot_tokens,
@@ -1961,7 +1967,7 @@ impl<'c> Lowerer<'c> {
                             } else {
                                 __concrete_target
                             };
-                            let __fn_idx = __builder.add_call_target_with_save_err(
+                            let __fn_idx = __builder.add_word_abi_call_target_with_save_err(
                                 __trace_target,
                                 __concrete_target,
                                 #__slot_tokens,
@@ -2180,7 +2186,7 @@ impl<'c> Lowerer<'c> {
                             } else {
                                 __concrete_target
                             };
-                            let __fn_idx = __builder.add_call_target_with_save_err(
+                            let __fn_idx = __builder.add_word_abi_call_target_with_save_err(
                                 __trace_target,
                                 __concrete_target,
                                 #__slot_tokens,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -977,7 +977,8 @@ impl<'c> Lowerer<'c> {
 
         let reg = self.alloc_reg();
         let func = &call.func;
-        let word_result_addr = word_result_addr_tokens(func, arg_bindings.len());
+        let arg_kinds: Vec<BindingKind> = arg_bindings.iter().map(|b| b.kind).collect();
+        let word_result_addr = word_result_addr_tokens(func, &arg_kinds);
         let mut result_kind = BindingKind::Int;
         // jtransform.py:467-471 / 480-482: `-live-` follows the call, it does
         // not precede it.  Decide here whether the explicit arm below needs a
@@ -1051,7 +1052,7 @@ impl<'c> Lowerer<'c> {
                                 vec![Register::new(result_kind, reg)],
                             ),
                             quote! {
-                                let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
+                                let __fn_idx = __builder.add_word_abi_fn_ptr(#word_result_addr);
                                 #call_invocation
                             },
                         );
@@ -1080,7 +1081,7 @@ impl<'c> Lowerer<'c> {
                                 vec![Register::new(result_kind, reg)],
                             ),
                             quote! {
-                                let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
+                                let __fn_idx = __builder.add_word_abi_fn_ptr(#word_result_addr);
                                 #call_invocation
                             },
                         );
@@ -1098,7 +1099,7 @@ impl<'c> Lowerer<'c> {
                             vec![Register::new(result_kind, reg)],
                         ),
                         quote! {
-                            let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
+                            let __fn_idx = __builder.add_word_abi_fn_ptr(#word_result_addr);
                             __builder.residual_call_int_canonical_via_target_with_effect_info(
                                 __fn_idx,
                                 #typed_args,
@@ -1137,7 +1138,7 @@ impl<'c> Lowerer<'c> {
                             vec![Register::new(result_kind, reg)],
                         ),
                         quote! {
-                            let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
+                            let __fn_idx = __builder.add_word_abi_fn_ptr(#word_result_addr);
                             #call_stmt
                         },
                     );
@@ -1367,7 +1368,7 @@ impl<'c> Lowerer<'c> {
                             } else {
                                 __concrete_target
                             };
-                            let __fn_idx = __builder.add_call_target_with_save_err(
+                            let __fn_idx = __builder.add_word_abi_call_target_with_save_err(
                                 __trace_target,
                                 __concrete_target,
                                 #__slot_tokens,
@@ -1519,7 +1520,7 @@ impl<'c> Lowerer<'c> {
                             } else {
                                 __concrete_target
                             };
-                            let __fn_idx = __builder.add_call_target_with_save_err(
+                            let __fn_idx = __builder.add_word_abi_call_target_with_save_err(
                                 __trace_target,
                                 __concrete_target,
                                 #__slot_tokens,
@@ -1618,7 +1619,7 @@ impl<'c> Lowerer<'c> {
                             } else {
                                 __concrete_target
                             };
-                            let __fn_idx = __builder.add_call_target_with_save_err(
+                            let __fn_idx = __builder.add_word_abi_call_target_with_save_err(
                                 __trace_target,
                                 __concrete_target,
                                 #__slot_tokens,
@@ -1841,7 +1842,8 @@ impl<'c> Lowerer<'c> {
                 let typed_args = typed_call_arg_tokens(&arg_bindings);
                 let __arg_regs: Vec<Register> =
                     arg_bindings.iter().map(Register::from_binding).collect();
-                let word_result_addr = word_result_addr_tokens(&func_path, arg_bindings.len());
+                let arg_kinds: Vec<BindingKind> = arg_bindings.iter().map(|b| b.kind).collect();
+                let word_result_addr = word_result_addr_tokens(&func_path, &arg_kinds);
                 let call_stmt = match kind {
                     crate::jit_interp::CallPolicyKind::ElidableInt => quote! {
                         __builder.call_pure_int_canonical_via_target(__fn_idx, #typed_args, #reg);
@@ -1861,7 +1863,7 @@ impl<'c> Lowerer<'c> {
                         vec![Register::new(result_kind, reg)],
                     ),
                     quote! {
-                        let __fn_idx = __builder.add_fn_ptr(#word_result_addr);
+                        let __fn_idx = __builder.add_word_abi_fn_ptr(#word_result_addr);
                         #call_stmt
                     },
                 );

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lowerer.rs
@@ -585,7 +585,7 @@ impl<'c> Lowerer<'c> {
                 } else {
                     __concrete_target
                 };
-                let __fn_idx = __builder.add_call_target_with_save_err(
+                let __fn_idx = __builder.add_word_abi_call_target_with_save_err(
                     __trace_target,
                     __concrete_target,
                     #slot_expr,
@@ -596,9 +596,20 @@ impl<'c> Lowerer<'c> {
             // An int-result target is registered through its widening shim;
             // see `word_result_addr_tokens`.  A void- or ref-result target has
             // no narrow return to widen and registers its own address.
-            let target_addr = word_result_addr.unwrap_or_else(|| quote! { #func as *const () });
-            quote! {
-                let __fn_idx = __builder.add_fn_ptr_with_slot(#target_addr, #slot_expr);
+            //
+            // Only the shim is word-spelled, so only the shim is registered as
+            // such: the helper's own address is whatever its Rust signature
+            // says, and a `usize` or `&T` parameter there is narrower than the
+            // word a compiled call passes.
+            match word_result_addr {
+                Some(shim_addr) => quote! {
+                    let __fn_idx =
+                        __builder.add_word_abi_fn_ptr_with_slot(#shim_addr, #slot_expr);
+                },
+                None => quote! {
+                    let __fn_idx =
+                        __builder.add_fn_ptr_with_slot(#func as *const (), #slot_expr);
+                },
             }
         }
     }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -2560,7 +2560,7 @@ mod tests {
             .iter()
             .map(ToString::to_string)
             .collect::<String>();
-        assert!(tokens.contains("add_fn_ptr_with_slot"));
+        assert!(tokens.contains("add_word_abi_fn_ptr_with_slot"));
         assert!(tokens.contains("ElidableCanRaise"));
     }
 
@@ -3198,6 +3198,47 @@ mod tests {
         assert!(!body.contains("add_fn_ptr (helper as * const ())"));
     }
 
+    /// The shim stands in for the callee at the compiled call, so it has to
+    /// have the signature that call emits: words in as well as a word out.
+    /// Leaving a parameter at the callee's own type is invisible where a
+    /// pointer is a word wide and a type error where it is not, so assert the
+    /// spelling rather than the target it happens to run on.
+    #[test]
+    fn the_widening_shim_takes_its_arguments_as_words() {
+        let call = parse_call("helper(1)");
+        let mut lowerer =
+            lowerer_with_call_policy("helper", crate::jit_interp::CallPolicyKind::ResidualInt);
+        lowerer
+            .lower_call_value(&call)
+            .expect("residual int call should lower");
+        let statements = &lowerer.statements;
+        let body = quote! { #(#statements)* }.to_string();
+        assert!(
+            body.contains("fn (i64) -> i64"),
+            "the one-argument shim is spelled in words: {body}"
+        );
+        assert!(
+            body.contains("from_call_word"),
+            "and narrows each word to what the callee declares: {body}"
+        );
+    }
+
+    /// Registering it as word-spelled is the other half: a backend whose word
+    /// is wider than its pointer reflects over every target it was not told
+    /// about, and the shim is exactly the target it can be told about.
+    #[test]
+    fn the_widening_shim_registers_as_word_spelled() {
+        let call = parse_call("helper(1)");
+        let mut lowerer =
+            lowerer_with_call_policy("helper", crate::jit_interp::CallPolicyKind::ResidualInt);
+        lowerer
+            .lower_call_value(&call)
+            .expect("residual int call should lower");
+        let statements = &lowerer.statements;
+        let body = quote! { #(#statements)* }.to_string();
+        assert!(body.contains("add_word_abi_fn_ptr"), "{body}");
+    }
+
     /// A ref result is a pointer and a void result is never read, so neither
     /// has anything to widen and both register the callee's own address.
     #[test]
@@ -3225,8 +3266,8 @@ mod tests {
         assert!(!body.contains("into_call_word"));
     }
 
-    /// `record_known_result!` registers through `add_fn_ptr_with_slot`, which
-    /// takes the same shim for an int result.
+    /// `record_known_result!` registers through `add_word_abi_fn_ptr_with_slot`,
+    /// which takes the same shim for an int result.
     #[test]
     fn record_known_result_int_registers_the_widening_shim() {
         let mut lowerer =

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -282,6 +282,30 @@ enum ConstKind {
     Float,
 }
 
+/// Tell a backend that cannot read a callee's spelling off its address that
+/// this one's parameters are machine words. A backend whose word and pointer
+/// are the same width has nothing to record: every target is callable through
+/// the call's own type there.
+#[cfg(target_arch = "wasm32")]
+fn vouch_word_abi_call_target(ptr: *const ()) {
+    majit_backend_wasm::vouch_residual_call_addr(ptr as usize as i64);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn vouch_word_abi_call_target(_ptr: *const ()) {}
+
+/// [`vouch_word_abi_call_target`] for a target whose result is a word as well,
+/// so its whole signature is the uniform one a residual call carries. The
+/// widening shim a producer registers is always that: it returns the machine
+/// word the trace reads the result out of, which is what makes it a shim.
+#[cfg(target_arch = "wasm32")]
+fn vouch_word_abi_call_target_returning_word(ptr: *const ()) {
+    majit_backend_wasm::vouch_residual_call_addr_returning_word(ptr as usize as i64);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn vouch_word_abi_call_target_returning_word(_ptr: *const ()) {}
+
 impl JitCodeBuilder {
     pub fn new() -> Self {
         Self::default()
@@ -5411,6 +5435,36 @@ impl JitCodeBuilder {
         self.add_call_target(ptr, ptr)
     }
 
+    /// [`Self::add_fn_ptr`] for a target the producer knows is spelled in
+    /// machine words: every parameter, and the result, is the word a compiled
+    /// call passes for it.
+    ///
+    /// A backend whose word is wider than its pointer cannot read that off the
+    /// address. A helper spelled `usize` or `&T` declares a type narrower than
+    /// the one the call names, so calling it through the call's own type is a
+    /// type error rather than a slow path, and such a backend has to reflect
+    /// the callee's declared type before calling it. Recording the targets
+    /// that are word-spelled is what lets it call those directly and reflect
+    /// only over the rest.
+    ///
+    /// The address is minted here, by the producer that built the target, so a
+    /// list written ahead of time cannot name it.
+    pub fn add_word_abi_fn_ptr(&mut self, ptr: *const ()) -> u16 {
+        vouch_word_abi_call_target_returning_word(ptr);
+        self.add_fn_ptr(ptr)
+    }
+
+    /// [`Self::add_word_abi_fn_ptr`] carrying an
+    /// [`crate::call_descr::EffectInfoSlot`] classification.
+    pub fn add_word_abi_fn_ptr_with_slot(
+        &mut self,
+        ptr: *const (),
+        slot: crate::call_descr::EffectInfoSlot,
+    ) -> u16 {
+        vouch_word_abi_call_target_returning_word(ptr);
+        self.add_fn_ptr_with_slot(ptr, slot)
+    }
+
     /// `add_fn_ptr` variant carrying a per-callee
     /// [`crate::call_descr::EffectInfoSlot`] classification
     /// (`call.py getcalldescr`'s `extraeffect` selection).
@@ -5484,6 +5538,21 @@ impl JitCodeBuilder {
             }
         }
         self.push_descr_entry(RuntimeBhDescr::Call(Box::new(target)))
+    }
+
+    /// [`Self::add_call_target_with_save_err`] for a pair of targets the
+    /// producer knows are spelled in machine words; see
+    /// [`Self::add_word_abi_fn_ptr`] for what that buys.
+    pub fn add_word_abi_call_target_with_save_err(
+        &mut self,
+        trace_ptr: *const (),
+        concrete_ptr: *const (),
+        slot: crate::call_descr::EffectInfoSlot,
+        save_err: i32,
+    ) -> u16 {
+        vouch_word_abi_call_target(trace_ptr);
+        vouch_word_abi_call_target(concrete_ptr);
+        self.add_call_target_with_save_err(trace_ptr, concrete_ptr, slot, save_err)
     }
 
     pub fn add_call_assembler_target_number(

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -155,13 +155,17 @@ mod residual_host {
 
     // Call-area layout shared with `majit-backend-wasm` codegen and the host
     // runner's `jit_call_trampoline`; offsets are relative to the frame-pointer
-    // base passed to the import.
-    const CALL_RESULT_OFS: usize = 2000;
-    const CALL_FUNC_OFS: usize = 2008;
-    const CALL_NARGS_OFS: usize = 2016;
-    const CALL_ARGS_OFS: usize = 2024;
-    const MAX_ARGS: usize = 16;
-    const SCRATCH_LEN: usize = CALL_ARGS_OFS + MAX_ARGS * 8;
+    // base passed to the import. Taken from the backend that defines the ABI
+    // rather than restated, so a layout change reaches this scratch buffer.
+    use majit_backend_wasm::codegen::{
+        CALL_ARGS_OFS as CALL_ARGS_OFS_U64, CALL_FUNC_OFS as CALL_FUNC_OFS_U64,
+        CALL_NARGS_OFS as CALL_NARGS_OFS_U64, CALL_RESULT_OFS as CALL_RESULT_OFS_U64,
+        MAX_CALL_ARGS as MAX_ARGS, MIN_FRAME_BYTES as SCRATCH_LEN,
+    };
+    const CALL_RESULT_OFS: usize = CALL_RESULT_OFS_U64 as usize;
+    const CALL_FUNC_OFS: usize = CALL_FUNC_OFS_U64 as usize;
+    const CALL_NARGS_OFS: usize = CALL_NARGS_OFS_U64 as usize;
+    const CALL_ARGS_OFS: usize = CALL_ARGS_OFS_U64 as usize;
 
     #[link(wasm_import_module = "majit_host")]
     unsafe extern "C" {


### PR DESCRIPTION
Four commits on the wasm backend, found while making a majit-wasm-backed [aheui](https://github.com/aheui) build actually take the JIT path.

### `wasm: gate the host-binding paths on wasm32 rather than on not-WASI, and publish the call-area layout`

The host-binding paths were selected by "not WASI", which is not the same set as "wasm32". Gate them on the architecture, and publish the call-area layout so an embedder can lay out its own scratch buffer.

### `wasm: gate a trace's frame reload on the host entry's frame kind, and make the residual-call ABI per callee`

`host_entry_frame_is_jitframe` tells codegen whether the entry frame can move, so a body over a host buffer emits no frame reload. `ResidualCallAbi::{Word, Vouched}` replaces the single global answer with a per-callee one.

### `wasm: spell a registered call target's parameters in machine words`

`word_result_addr_tokens` takes the argument kinds instead of an arity: an `i64` hole per non-float parameter, narrowed at the shim boundary through the new `majit_ir::CallArgWord` (integer primitives, `bool`, raw pointers, references). Floats keep their inferred hole.

The jitcode assembler gains `add_word_abi_fn_ptr`, `add_word_abi_fn_ptr_with_slot` and `add_word_abi_call_target_with_save_err`, which record the target with the wasm backend before delegating. `majit-backend-wasm` gains `vouch_residual_call_addr`, `vouch_residual_call_addr_returning_word` and `direct_word_abi_call` — the last transmutes a vouched address to the word signature for arities 0..=8 and returns `None` otherwise, so an unvouched target still goes through the reflecting host trampoline.

Why it matters: wasm32 `call_indirect` type-checks the callee. A helper declared `usize` or `&T` is narrower than the word a compiled call passes, so calling it through the call's own type is a type error rather than a slow path, and the backend has to reflect the callee's declared type via a guest→host→guest round trip per call. Recording which targets are word-spelled is what lets it call those directly.

### `wasm: publish the host-buffer trace frame on the jitframe shadow stack`

`WasmBackend::execute_token` has two frame paths: a GC-managed `JitFrame` for an embedder that registered a frame type id, and a host buffer for everyone else. The host-buffer path allocated a bare `vec![0i64; frame_size]` and rooted the Ref home slots with `wasm_gc_add_root` alone — which reaches the active majit GC and nothing else.

A frontend that keeps a heap of its own reads the **jitframe shadow stack** instead; it is the one publication point a collector that is not this one can consult. Without the frame on it, a home holding one of that heap's objects is invisible: the collector moves the object, the home keeps the address it had, and the trace resumes on a pointer into free space.

The buffer now carries a `JitFrame` header and a `build_home_gcmap` gcmap, and is registered with `register_libc_jitframe` and pushed on the shadow stack for the span of `glue::execute` — the same shape `majit-backend-dynasm`'s `execute_token` already uses.

The symptom that led here: an aheui fibonacci program printed the same 27,629-digit number forever from output byte 1,826,470,578 under the wasm JIT while the native JIT stayed correct to 5 GB. `AHEUI_GC_LOG=1` reported `jit_root_slots=0` at the first and only node-nursery collection, where native reported 10.

### Verification

- `check.py --backend wasm`: **504/504**
- `cargo test -p majit-backend-wasm`: 82 passed / 0 failed; `cargo test -p majit-macros`: 169 passed / 0 failed
- `cargo check -p majit-backend-wasm --target wasm32-wasip1 --no-default-features`: clean
- `cargo fmt --all -- --check` clean, `scripts/check-majit-boundary.py` rc=0
- aheui corpus (69 snippets): identical 69, prefix-identical 9, failures 0 — was 69/8/1 before the frame fix
- aheui `logo`: native JIT and the fixed wasm guest both 996,310 bytes, md5 `7fcdbfff0af449c4283c008e3ca317ce`, exit 42

`check.py --backend dynasm` has two perf-gate failures (`synth/list_pop_append`, `synth/unary_int_loop_carried`) that reproduce on a pristine tree here and are being chased separately.

— *authored by Claude*