### PR TITLE
msvcrt gains CRT_ASSEMBLY_VERSION; _locale and _multiprocessing lose four names their hosts do not define

### DIFF
--- a/pyre/pyre-interpreter/build.rs
+++ b/pyre/pyre-interpreter/build.rs
@@ -124,10 +124,18 @@ fn main() {
     // `msvcrt.dll`, a runtime this build does not share an `errno` with.  The
     // number comes from the preprocessor rather than a parsed banner: `/EP`
     // writes the expansion to stdout and nothing else.
-    if target.ends_with("-pc-windows-msvc")
-        && let Some(msc_ver) = msc_ver()
-    {
-        println!("cargo:rustc-env=PYRE_MSC_VER={msc_ver}");
+    if target.ends_with("-pc-windows-msvc") {
+        if let Some(msc_ver) = msc_ver() {
+            println!("cargo:rustc-env=PYRE_MSC_VER={msc_ver}");
+        }
+        // `msvcrt.CRT_ASSEMBLY_VERSION` names the C runtime assembly the build
+        // links against, and the toolset spells its four fields as one macro
+        // each in `<crtversion.h>`.  A toolset that carries no such header
+        // leaves the constant off the module, which is the state a build whose
+        // `_CRT_ASSEMBLY_VERSION` is undefined publishes.
+        if let Some(version) = crt_assembly_version() {
+            println!("cargo:rustc-env=PYRE_CRT_ASSEMBLY_VERSION={version}");
+        }
     }
 
     // Only do work for the wasm_vfs feature; native builds need nothing here.
@@ -163,12 +171,13 @@ fn main() {
         .unwrap_or_else(|e| panic!("wasm_vfs: cannot write {}: {e}", blob_path.display()));
 }
 
-/// `_MSC_VER`, as the compiler itself expands it.  `None` when the probe
-/// cannot be compiled, which leaves `sys.version` naming Rust alone.
-fn msc_ver() -> Option<String> {
+/// What the compiler makes of a preprocessor probe: `/EP` writes the
+/// expansion to stdout and nothing else.  `None` when the probe cannot be
+/// compiled at all.
+fn expand(stem: &str, source: &str) -> Option<String> {
     let out_dir = std::env::var("OUT_DIR").ok()?;
-    let probe = Path::new(&out_dir).join("pyre_msc_ver.c");
-    std::fs::write(&probe, "_MSC_VER\n").ok()?;
+    let probe = Path::new(&out_dir).join(format!("{stem}.c"));
+    std::fs::write(&probe, source).ok()?;
     let output = cc::Build::new()
         .get_compiler()
         .to_command()
@@ -177,7 +186,36 @@ fn msc_ver() -> Option<String> {
         .arg(&probe)
         .output()
         .ok()?;
-    let expanded = String::from_utf8_lossy(&output.stdout);
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// `_MSC_VER`, as the compiler itself expands it.  `None` when the probe
+/// cannot be compiled, which leaves `sys.version` naming Rust alone.
+fn msc_ver() -> Option<String> {
+    let expanded = expand("pyre_msc_ver", "_MSC_VER\n")?;
     let digits: String = expanded.chars().filter(char::is_ascii_digit).collect();
     (!digits.is_empty()).then_some(digits)
+}
+
+/// The C runtime assembly version as `major.minor.build.rbuild`.  `None` when
+/// the toolset answers with anything other than four numbers -- an unexpanded
+/// identifier is what a missing `<crtversion.h>` leaves behind.
+fn crt_assembly_version() -> Option<String> {
+    let expanded = expand(
+        "pyre_crt_version",
+        "#include <crtversion.h>\n\
+         _VC_CRT_MAJOR_VERSION,_VC_CRT_MINOR_VERSION,\
+         _VC_CRT_BUILD_VERSION,_VC_CRT_RBUILD_VERSION\n",
+    )?;
+    // The header itself expands to blank lines, so the probe's own line is the
+    // last one carrying text.
+    let fields: Vec<&str> = expanded
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())?
+        .split(',')
+        .map(str::trim)
+        .collect();
+    (fields.len() == 4 && fields.iter().all(|field| field.parse::<u32>().is_ok()))
+        .then(|| fields.join("."))
 }

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -561,8 +561,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         }),
     );
     // nl_langinfo() reads the active-locale codeset/DB; stubbed under sandbox,
-    // so the real body is compiled out.
-    #[cfg(not(feature = "sandbox"))]
+    // so the real body is compiled out.  `moduledef.py` publishes the name
+    // only where the host has langinfo, which is the condition its `nl_item`
+    // constants are registered under above.
+    #[cfg(all(
+        not(feature = "sandbox"),
+        unix,
+        not(any(target_os = "ios", target_os = "android", target_os = "redox"))
+    ))]
     crate::module_ns_store(
         ns,
         "nl_langinfo",
@@ -728,7 +734,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         ) -> Result<pyre_object::PyObjectRef, crate::PyError> {
             Err(crate::host_seam::stub("this locale function"))
         }
-        for name in ["setlocale", "localeconv", "nl_langinfo"] {
+        // `nl_langinfo` is stubbed only where the unsandboxed build has it
+        // to stub.
+        #[cfg(all(
+            unix,
+            not(any(target_os = "ios", target_os = "android", target_os = "redox"))
+        ))]
+        let stubbed: &[&str] = &["setlocale", "localeconv", "nl_langinfo"];
+        #[cfg(not(all(
+            unix,
+            not(any(target_os = "ios", target_os = "android", target_os = "redox"))
+        )))]
+        let stubbed: &[&str] = &["setlocale", "localeconv"];
+        for &name in stubbed {
             crate::module_ns_store(
                 ns,
                 name,

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -867,14 +867,6 @@ crate::py_module! {
                 "sem_unlink",
                 crate::make_builtin_function_with_arity("sem_unlink", sem_unlink, 1),
             );
-
-            crate::module_ns_store(
-                ns,
-                "SEM_VALUE_MAX",
-                sem_value_max,
-            );
-            crate::module_ns_store(ns, "RECURSIVE_MUTEX", w_int_new(RECURSIVE_MUTEX));
-            crate::module_ns_store(ns, "SEMAPHORE", w_int_new(SEMAPHORE));
         }
         #[cfg(all(windows, feature = "host_env"))]
         {

--- a/pyre/pyre-interpreter/src/module/msvcrt/mod.rs
+++ b/pyre/pyre-interpreter/src/module/msvcrt/mod.rs
@@ -101,5 +101,12 @@ crate::py_module! {
         fn GetErrorMode() -> u32 {
             host_msvcrt::get_error_mode()
         }
+    },
+    extra_init: |ns| {
+        // The C runtime assembly version the build's own toolset named; the
+        // build script leaves it unset when no toolset header answered.
+        if let Some(version) = option_env!("PYRE_CRT_ASSEMBLY_VERSION") {
+            crate::module_ns_store(ns, "CRT_ASSEMBLY_VERSION", pyre_object::w_str_new(version));
+        }
     }
 }


### PR DESCRIPTION
Four names on Windows, measured against CPython 3.14.2 and against
`rpython/rlib/rlocale.py`.

### `msvcrt.CRT_ASSEMBLY_VERSION`

`crtassem.h` is gone from MSVC 14.44 and `_CRT_ASSEMBLY_VERSION` is not
predefined either — `cl /EP` on a probe naming it answers
`NO_CRT_ASSEMBLY_VERSION`. What CPython's official build reports comes from
`<crtversion.h>`, which spells the four fields one macro each:

```
_VC_CRT_MAJOR_VERSION 14   _VC_CRT_MINOR_VERSION 44
_VC_CRT_BUILD_VERSION 35220   _VC_CRT_RBUILD_VERSION 0
```

`35220`, not the `14.44.35207` the toolset directory is named — and
`14.44.35220.0` is exactly what CPython 3.14.2 answers on this box.

The build script already had a `/EP` probe for `_MSC_VER`; that becomes
`expand`, and a second probe through it reads the CRT version. The module
registers the constant only when the probe answered with four numbers, which
is the state `#ifdef _CRT_ASSEMBLY_VERSION` selects.

### `_locale.nl_langinfo`

`rlocale.py` opens with `HAVE_LANGINFO = sys.platform != 'win32'` and
`moduledef.py` gates the name on it. pyre registered the function under
`not(feature = "sandbox")` alone while its `nl_item` constants were already
`#[cfg(all(unix, not(ios/android/redox)))]`, so a Windows build carried a
`nl_langinfo` whose every call raised `ValueError: unsupported langinfo
constant`. The registration now uses the constants' own cfg, and the sandbox
stub list follows the same condition.

Nothing in `lib-python` loses anything: `locale.py` gates its `nl_langinfo`
use on `CODESET`, which a Windows build never had; `test__locale` imports
`RADIXCHAR, THOUSEP, nl_langinfo` as one statement that `RADIXCHAR` already
failed.

### `_multiprocessing.SEM_VALUE_MAX`, `RECURSIVE_MUTEX`, `SEMAPHORE`

`moduledef.py` publishes `SemLock`, `sem_unlink` and the win32 socket calls,
and nothing else. `RECURSIVE_MUTEX`/`SEMAPHORE` are `range(2)` in
`multiprocessing/synchronize.py`, and `SEM_VALUE_MAX` is read there off
`SemLock`, which keeps it.

|                                   | CPython | pyre before | pyre after |
|-----------------------------------|---------|-------------|------------|
| `msvcrt.CRT_ASSEMBLY_VERSION`     | `'14.44.35220.0'` | absent | `'14.44.35220.0'` |
| `_locale.nl_langinfo`             | absent  | present (always raises) | absent |
| `_multiprocessing.SEM_VALUE_MAX`  | absent  | present | absent |
| `_multiprocessing.RECURSIVE_MUTEX`| absent  | present | absent |
| `_multiprocessing.SEMAPHORE`      | absent  | present | absent |
| `_multiprocessing.SemLock.SEM_VALUE_MAX` | present | present | present |

### Gates

`pyre/check.py --backend dynasm` on Windows fails on
`synth/exception_escape_hot_callee_tb_node_once` and
`synth/exception_traceback_frame_lineno`. Both are `main`'s, not this branch's:

- `main`'s own tip (`67505f239e9`) fails `check.py` on all four legs, and the
  ubuntu one names the same fixtures with byte-identical numbers —
  `guard_failures 808 -> 1015 (loops_compiled=12 bridges_compiled=6)` and
  `bridges_compiled 6 -> 4; improved: guard_failures 825 -> 624
  (loops_compiled=16 bridges_compiled=4)`, plus their `wasm` twins.
- Neither can be reached from here: at startup `sys.modules` holds none of
  `_locale`, `msvcrt`, `_multiprocessing`, so all three module-init bodies this
  branch edits never run in a synth fixture.

The two baselines were re-recorded by #1553 and #1388, each against a base
without the other, and both PRs' CI runs were cancelled — so the pair was never
measured together.

Everything else is green: `parity_tests --dynasm-only`, the wasm32 `pyre-wasm`
build, `cpython_tests` for `locale` / `msvcrt` / `multiprocessing` / `platform`
(no regressions), and the citation check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `CRT_ASSEMBLY_VERSION` to the Windows `msvcrt` module when available.
* **Bug Fixes**
  * Corrected platform-specific availability of `nl_langinfo`, preventing it from being exposed where unsupported.
  * Removed unsupported module-level multiprocessing constants while retaining the relevant class attribute.
* **Compatibility**
  * Improved detection and reporting of the Windows C runtime version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->