### PR TITLE
jit-trace: replace the locals expansion's width ceiling with the trace_limit question, on both arms

### DIFF
--- a/pyre/bench/synth/locals_in_wide_inlined_callee.py
+++ b/pyre/bench/synth/locals_in_wide_inlined_callee.py
@@ -1,0 +1,151 @@
+# pyre-check: selfcheck
+# pyre-check: selfcheck-compiles=probe
+# pyre-check: spec-folds=builtin_locals
+# `locals()` in an inlined callee whose frame is WIDER than the modelled
+# expansion's old ceiling.
+#
+# `try_walker_specialize_builtin_locals_in_callee_expand` unrolls
+# `fast2locals`' slot loop one store per bound slot.  Upstream bounds that
+# unroll with nothing but `@jit.unroll_safe` on `pyframe.py`
+# `PyFrame.fast2locals` and the tracer's own `trace_limit`
+# (`pyjitpl.py` `MetaInterp.blackhole_if_trace_too_long`); the walker used to
+# carry a second, fixed ceiling of 32 slots on top of that.
+#
+# In the portal arm a width refusal costs one residual.  In the callee arm it
+# costs the callee: the residual's locals read forces this level's published
+# frame, `tracing_after_residual_call` reads the cleared token as
+# `VableEscapedDuringResidualCall`, and the walker answers that by denying the
+# callee for the rest of the thread's tracing.  So the ceiling decided whether
+# a callee is inlinable from its LOCAL COUNT alone.
+#
+# `wide` carries 42 slots -- `x`, `a00`..`a39` and `d` -- and no other fixture
+# reaches the expansion with more than a handful, so the ceiling was a shape
+# the corpus did not own.  The gate is the `spec-folds` header: measured on
+# release dynasm, this file read `consulted=7 fired=0` with the ceiling in
+# place and `consulted=1 fired=1` without it, because the wide callee is the
+# only shape it offers.  The name set is asserted too, so a fold that takes
+# the shape but answers from the wrong frame fails rather than passing on a
+# plausible count -- the answer itself is right either way, since the residual
+# the refusal falls back to computes it correctly.
+import sys
+
+N = 200000
+
+EXPECTED = [
+    "a00",
+    "a01",
+    "a02",
+    "a03",
+    "a04",
+    "a05",
+    "a06",
+    "a07",
+    "a08",
+    "a09",
+    "a10",
+    "a11",
+    "a12",
+    "a13",
+    "a14",
+    "a15",
+    "a16",
+    "a17",
+    "a18",
+    "a19",
+    "a20",
+    "a21",
+    "a22",
+    "a23",
+    "a24",
+    "a25",
+    "a26",
+    "a27",
+    "a28",
+    "a29",
+    "a30",
+    "a31",
+    "a32",
+    "a33",
+    "a34",
+    "a35",
+    "a36",
+    "a37",
+    "a38",
+    "a39",
+    "x",
+]
+
+
+def wide(x):
+    a00 = x + 0
+    a01 = x + 1
+    a02 = x + 2
+    a03 = x + 3
+    a04 = x + 4
+    a05 = x + 5
+    a06 = x + 6
+    a07 = x + 7
+    a08 = x + 8
+    a09 = x + 9
+    a10 = x + 10
+    a11 = x + 11
+    a12 = x + 12
+    a13 = x + 13
+    a14 = x + 14
+    a15 = x + 15
+    a16 = x + 16
+    a17 = x + 17
+    a18 = x + 18
+    a19 = x + 19
+    a20 = x + 20
+    a21 = x + 21
+    a22 = x + 22
+    a23 = x + 23
+    a24 = x + 24
+    a25 = x + 25
+    a26 = x + 26
+    a27 = x + 27
+    a28 = x + 28
+    a29 = x + 29
+    a30 = x + 30
+    a31 = x + 31
+    a32 = x + 32
+    a33 = x + 33
+    a34 = x + 34
+    a35 = x + 35
+    a36 = x + 36
+    a37 = x + 37
+    a38 = x + 38
+    a39 = x + 39
+    # `d` is still unbound at this point, so it binds no key of its own.
+    d = locals()
+    return d
+
+
+def probe():
+    last = None
+    for i in range(N):
+        last = wide(i)
+    return last
+
+
+def main():
+    # The last iteration is a compiled one, so the mapping asserted on here is
+    # the one the fold built.
+    last = probe()
+    names, a39, x = sorted(last), last["a39"], last["x"]
+    if names != EXPECTED:
+        print(f"FAIL name set: {names}")
+        print(f"  expected: {EXPECTED}")
+        return 1
+    if x != N - 1:
+        print(f"FAIL x: {x} (expected {N - 1})")
+        return 1
+    if a39 != N - 1 + 39:
+        print(f"FAIL a39: {a39} (expected {N - 1 + 39})")
+        return 1
+    print("PASS wide callee locals")
+    return 0
+
+
+sys.exit(main())

--- a/pyre/bench/synth/locals_in_wide_portal_frame.py
+++ b/pyre/bench/synth/locals_in_wide_portal_frame.py
@@ -1,0 +1,156 @@
+# pyre-check: selfcheck
+# pyre-check: selfcheck-compiles=wide
+# pyre-check: spec-folds=builtin_locals
+# `locals()` on the PORTAL frame of a loop whose frame is wider than the
+# expansion's old ceiling.
+#
+# `try_walker_specialize_builtin_locals` unrolls `fast2locals`' slot loop one
+# guard plus at most one store per bound slot.  Upstream bounds that unroll
+# with nothing but `@jit.unroll_safe` on `pyframe.py` `PyFrame.fast2locals`,
+# and asks the size question once over the whole history in `pyjitpl.py`
+# `MetaInterp.blackhole_if_trace_too_long`; the walker used to carry a second,
+# fixed ceiling of 32 slots and ask it per fold instead.
+#
+# A refusal here answers correctly -- it falls through to the generic
+# residual, which computes the same mapping -- so nothing about the ANSWER
+# says whether the fold ran.  What it costs is the loop: the residual's
+# locals read forces the portal frame, and the walk cannot carry that.
+#
+# `wide` carries 44 slots, and the loop that reads them is in `wide` itself,
+# so this is the portal arm rather than the callee arm
+# (`locals_in_wide_inlined_callee` is that one).  Measured on release dynasm:
+#
+#   with the ceiling      consulted=5 fired=0   loops_compiled=0 loops_aborted=5
+#   without it            consulted=3 fired=2   loops_compiled=1 loops_aborted=0
+#
+# so the ceiling was not costing one residual per iteration, it was costing
+# the loop.  Both halves are gated -- `spec-folds` on the fold and
+# `selfcheck-compiles` on the loop -- because either alone reads as a pass on
+# a run that answered right and compiled nothing.
+#
+# The mapping is never bound to a local.  Binding it would put the previous
+# iteration's mapping in the next one's, chaining N dicts through the frame
+# and measuring the collector rather than the fold.
+import sys
+
+N = 20000
+
+EXPECTED = [
+    "a00",
+    "a01",
+    "a02",
+    "a03",
+    "a04",
+    "a05",
+    "a06",
+    "a07",
+    "a08",
+    "a09",
+    "a10",
+    "a11",
+    "a12",
+    "a13",
+    "a14",
+    "a15",
+    "a16",
+    "a17",
+    "a18",
+    "a19",
+    "a20",
+    "a21",
+    "a22",
+    "a23",
+    "a24",
+    "a25",
+    "a26",
+    "a27",
+    "a28",
+    "a29",
+    "a30",
+    "a31",
+    "a32",
+    "a33",
+    "a34",
+    "a35",
+    "a36",
+    "a37",
+    "a38",
+    "a39",
+    "i",
+    "n",
+    "total",
+    "width",
+]
+
+WIDTH = 44
+
+
+def wide(n):
+    a00 = 0
+    a01 = 1
+    a02 = 2
+    a03 = 3
+    a04 = 4
+    a05 = 5
+    a06 = 6
+    a07 = 7
+    a08 = 8
+    a09 = 9
+    a10 = 10
+    a11 = 11
+    a12 = 12
+    a13 = 13
+    a14 = 14
+    a15 = 15
+    a16 = 16
+    a17 = 17
+    a18 = 18
+    a19 = 19
+    a20 = 20
+    a21 = 21
+    a22 = 22
+    a23 = 23
+    a24 = 24
+    a25 = 25
+    a26 = 26
+    a27 = 27
+    a28 = 28
+    a29 = 29
+    a30 = 30
+    a31 = 31
+    a32 = 32
+    a33 = 33
+    a34 = 34
+    a35 = 35
+    a36 = 36
+    a37 = 37
+    a38 = 38
+    a39 = 39
+    total = 0
+    width = 0
+    for i in range(n):
+        total += locals()["a39"]
+        width = len(locals())
+    # Read after the loop, on the same frame: `i` is still bound, so the name
+    # set is the one every traced iteration saw.  `width` is what pins that,
+    # since it is recorded inside the loop on each of them.
+    return total, width, sorted(locals())
+
+
+def main():
+    total, width, names = wide(N)
+    if width != WIDTH:
+        print(f"FAIL width: {width} (expected {WIDTH})")
+        return 1
+    if names != EXPECTED:
+        print(f"FAIL name set: {names}")
+        print(f"  expected: {EXPECTED}")
+        return 1
+    if total != 39 * N:
+        print(f"FAIL total: {total} (expected {39 * N})")
+        return 1
+    print("PASS wide portal locals")
+    return 0
+
+
+sys.exit(main())

--- a/pyre/extra_tests/parity_tests/flocals_writethrough_forcing_residual.py
+++ b/pyre/extra_tests/parity_tests/flocals_writethrough_forcing_residual.py
@@ -6,6 +6,7 @@
 # against the frame the tracer is stepping a copy of, so it is the tracer's
 # handling of that call -- not the proxy -- that decides whether the write
 # survives.
+# pyre-check: regresses-under: PYRE_FBW_NO_ADOPT_RESIDUAL_LOCALS=1 -- without the adopt the walk keeps the box the local held before the call, and both traced iterations lose the write
 
 """A write made through ``f_locals`` by a *called* function must be visible to
 the caller's next read, including on the iteration the caller's loop is traced.
@@ -26,6 +27,14 @@ store itself is the residual and nothing forces at all -- the proxy's own force
 is gated on the live frame's ``vable_token``, which is zero while the walk is
 tracing.  The two lose the write through different paths and are pinned here at
 iterations 1040 and 2105, so the bound sits well past the later of them.
+
+Both are reached only because ``adopt_residual_locals_writes`` reads the slot
+back; the passing run says nothing about that on its own, since a script that
+stopped reaching either iteration would pass too.  The ``regresses-under``
+header is what separates the two: with the adopt switched off this script must
+report ``2 of 4000, first: [(1040, 1039), (2105, 2104)]`` and exit non-zero, so
+a change that stops reaching the shape is reported here rather than read as a
+pass.
 """
 
 import sys

--- a/pyre/extra_tests/parity_tests/run.py
+++ b/pyre/extra_tests/parity_tests/run.py
@@ -39,6 +39,18 @@ lines, which are added to the environment of every runner for that script
 only. Without this a script can keep passing after the shape it exercises
 stops being reachable, i.e. cover nothing while still looking green.
 
+A fix that ships ON, with a switch that restores the defect, has an arm
+nothing runs: the corpus covers the fix, and the switch is exercised once by
+whoever measured it. A script names that arm with
+
+    # pyre-check: regresses-under: NAME=VALUE [NAME=VALUE ...] -- <reason>
+
+and is then run a second time on each pyre backend with those names set,
+where it must FAIL. Passing there is reported as XPASS, the same way a
+`pypy-diverges` script that starts passing is: either the switch stopped
+changing the answer, or the script stopped reaching the shape, and both
+turn the default-ON run green for a reason its header no longer states.
+
 Usage:
     python3 pyre/extra_tests/parity_tests/run.py
         [--dynasm-only|--cranelift-only] [--gc-poison]
@@ -140,6 +152,10 @@ def _scripts() -> tuple[list[Path], list[Path]]:
                         f"{p.name}: `{PYPY_DIVERGES_PREFIX}` with no reason — the "
                         f"directive exists to say which divergence is expected"
                     )
+        # Read here for the raise alone. The arm below reads it again once it
+        # knows which runners are pyre's, and an unparseable directive there
+        # would arrive as a traceback out of the middle of the table.
+        _regresses_under(p)
         (out if _runs_here(p) else skipped).append(p)
     return out, skipped
 
@@ -160,6 +176,40 @@ def _script_env(script: Path) -> dict[str, str]:
     """Environment a script pins for itself with `# parity-env: NAME=VALUE`."""
     text = script.read_text(encoding="utf-8", errors="replace")
     return {m.group(1): m.group(2) for m in _ENV_DIRECTIVE.finditer(text)}
+
+
+REGRESSES_UNDER_PREFIX = "# pyre-check: regresses-under:"
+
+# `# pyre-check: regresses-under: NAME=VALUE [NAME=VALUE ...] -- <reason>`.
+# The reason is part of the syntax rather than a convention: this directive
+# asserts a failure, and a failure nobody wrote down reads as the script being
+# broken by whoever next runs it.
+_REGRESSES_UNDER = re.compile(
+    r"^#\s*pyre-check:\s*regresses-under:\s*"
+    r"((?:\w+=\S*\s+)*\w+=\S*)"
+    r"\s+--\s+(\S.*?)\s*$"
+)
+
+
+def _regresses_under(script: Path) -> list[tuple[dict[str, str], str]]:
+    """The configurations this script declares it must fail under, with reasons.
+
+    Raises on a directive that does not parse, so a typo reads as an authoring
+    error rather than as a script that quietly declares nothing.
+    """
+    out = []
+    for line in script.read_text(encoding="utf-8").splitlines()[:20]:
+        if not line.startswith(REGRESSES_UNDER_PREFIX):
+            continue
+        parsed = _REGRESSES_UNDER.match(line)
+        if parsed is None:
+            raise RuntimeError(
+                f"{script.name}: `{REGRESSES_UNDER_PREFIX}` needs "
+                f"`NAME=VALUE [NAME=VALUE ...] -- <reason>`, got: {line.strip()}"
+            )
+        settings = dict(pair.split("=", 1) for pair in parsed.group(1).split())
+        out.append((settings, parsed.group(2)))
+    return out
 
 
 TIMEOUT = 30
@@ -368,18 +418,30 @@ def _annotate(failures: list[Failure]) -> None:
         print(f"::error file={path},title=parity::{escaped}")
 
 
+class Runner(NamedTuple):
+    """One interpreter the corpus is run against."""
+
+    name: str
+    cmd: list[str]
+    env: dict[str, str] | None
+    # Whether this runner reads pyre's own configuration. `regresses-under`
+    # only says anything on one that does: every other runtime ignores the
+    # name, passes, and would be reported as the control having gone dead.
+    pyre: bool
+
+
 def _runners(
     only_dynasm: bool, only_cranelift: bool, gc_poison: bool
-) -> list[tuple[str, list[str], dict[str, str] | None]]:
-    runners: list[tuple[str, list[str], dict[str, str] | None]] = []
-    runners.append(("cpython", [_cpython()], None))
+) -> list[Runner]:
+    runners: list[Runner] = []
+    runners.append(Runner("cpython", [_cpython()], None, False))
     pyre_env = {"MAJIT_GC_NURSERY_POISON": "1"} if gc_poison else None
     dynasm = TARGET_RELEASE / f"pyre-dynasm{EXE}"
     cranelift = TARGET_RELEASE / f"pyre-cranelift{EXE}"
     if not only_cranelift and dynasm.exists():
-        runners.append(("dynasm", [str(dynasm)], pyre_env))
+        runners.append(Runner("dynasm", [str(dynasm)], pyre_env, True))
     if not only_dynasm and cranelift.exists():
-        runners.append(("cranelift", [str(cranelift)], pyre_env))
+        runners.append(Runner("cranelift", [str(cranelift)], pyre_env, True))
     return runners
 
 
@@ -406,7 +468,7 @@ def main() -> int:
         print("no parity test scripts found", file=sys.stderr)
         return 1
 
-    print(f"runners: {[name for name, _, _ in runners]}")
+    print(f"runners: {[runner.name for runner in runners]}")
     if pypy is None:
         print(f"pypy cross-check: off — {pypy_off}")
     else:
@@ -422,13 +484,37 @@ def main() -> int:
         pinned = _script_env(script)
         row: list[str] = [f"  {name:<36s}"]
         reasons: list[str] = []
-        for backend, cmd, env in runners:
-            merged = {**(env or {}), **pinned}
-            ok, reason, err = _run(cmd, script, merged or None)
-            row.append(f"{backend}={'OK' if ok else 'FAIL'}")
+        for runner in runners:
+            merged = {**(runner.env or {}), **pinned}
+            ok, reason, err = _run(runner.cmd, script, merged or None)
+            row.append(f"{runner.name}={'OK' if ok else 'FAIL'}")
             if not ok:
-                failures.append(Failure(name, backend, reason, err))
-                reasons.append(f"      {backend}: {reason}")
+                failures.append(Failure(name, runner.name, reason, err))
+                reasons.append(f"      {runner.name}: {reason}")
+        for settings, why in _regresses_under(script):
+            spelled = " ".join(f"{key}={value}" for key, value in settings.items())
+            for runner in runners:
+                if not runner.pyre:
+                    continue
+                ok = _run(
+                    runner.cmd,
+                    script,
+                    {**(runner.env or {}), **pinned, **settings},
+                )[0]
+                if not ok:
+                    row.append(f"{runner.name}:regresses=xfail")
+                    continue
+                # The default-ON run above is green either way, so this is the
+                # only place the switch it depends on is measured at all.
+                row.append(f"{runner.name}:regresses=XPASS")
+                stale = (
+                    f"passed with {spelled} set, which its header says it "
+                    f"regresses under: {why!r} — either the switch stopped "
+                    f"changing the answer or the script stopped reaching the "
+                    f"shape, and the passing run above no longer covers it"
+                )
+                failures.append(Failure(name, f"{runner.name} {spelled}", stale, ""))
+                reasons.append(f"      {runner.name} [{spelled}]: {stale}")
         if pypy is not None:
             declared = _pypy_divergence(script)
             ok, reason, err = _run([pypy], script, pinned or None)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -2235,8 +2235,32 @@ pub(crate) fn fbw_abort_nested_unjournaled_residual<Sym: WalkSym>(
 /// Denying is what stops the decline being a property of the framestack, which
 /// the next attempt rebuilds identically: without it the abort recurs
 /// byte-for-byte until the enclosing location is retired, so the loop never
-/// compiles at all.  Upstream answers the same situation by denying the callee
-/// and letting the enclosing loop retrace (`pyjitpl.py` `MetaInterp.blackhole_if_trace_too_long`).
+/// compiles at all.
+///
+/// The trigger has no upstream counterpart, and the citation this used to
+/// carry named a different question.  `disable_noninlinable_function`
+/// (`warmstate.py` `WarmEnterState.disable_noninlinable_function`) has exactly
+/// one caller, `pyjitpl.py` `MetaInterp.blackhole_if_trace_too_long`, and that
+/// one asks a SIZE question — `history.length() > trace_limit`, or
+/// `trace_tag_overflow()` — and then denies the greenkey
+/// `MetaInterp.find_biggest_function` names, which need not be the callee at
+/// hand.  A vable escape denies nothing: `MetaInterp.vable_after_residual_call`
+/// raises `SwitchToBlackhole(ABORT_ESCAPE, raising_exception=True)` and
+/// `MetaInterp.run_blackhole_interp_to_cancel_tracing` hands that to
+/// `blackhole.py` `convert_and_run_from_pyjitpl`, which carries the frame
+/// FORWARD.  Reaching the upstream API from this trigger is therefore an
+/// extension of it, not a port of it.
+///
+/// For the caller that refuses at a declined `locals()` expansion, the reason
+/// upstream never arrives here is that the escape does not happen:
+/// `pyframe.py` `PyFrame.fast2locals` is `@jit.unroll_safe`, so the tracer
+/// descends into it rather than leaving a residual, and inside a graph it
+/// looks into, `jtransform.py` `Transformer.rewrite_op_jit_force_virtualizable`
+/// erases the force outright.  What stands in for that here is
+/// `try_walker_specialize_builtin_locals_in_callee_expand`, and this refusal
+/// covers exactly the shapes that expansion declines.  Widening it until the
+/// refusal is unreachable is the convergence path; the refusal is not the
+/// answer.
 ///
 /// `callee_code_key` is `None` when no callee could be named, in which case the
 /// decline still unwinds but nothing is remembered.
@@ -2256,14 +2280,16 @@ pub(crate) fn fbw_decline_inline_callee<Sym: WalkSym>(
         // `fbw_deny_hazardous_inline` writes a thread-local set that only
         // this walker reads, so the deny stayed invisible to the warm
         // state: `dont_trace_here` counted zero on every fixture that
-        // reaches here.  The upstream answer cited above is
-        // `disable_noninlinable_function(greenkey_of_huge_function)`
-        // (`pyjitpl.py` `MetaInterp.blackhole_if_trace_too_long`), which sets `JC_DONT_TRACE_HERE` on the
-        // callee's cell (`warmstate.py` `WarmEnterState.disable_noninlinable_function`).  The recursion-bound deny
-        // in `inline_call.rs` already calls it for the callee it names;
-        // this one names a callee the same way and had no reason not to.
-        // Pass the typed key so the verdict lands on the same
-        // comparekey-bearing cell consulted at the next call.
+        // reaches here.  `warmstate.py`
+        // `WarmEnterState.disable_noninlinable_function` is the call that sets
+        // `JC_DONT_TRACE_HERE` on the callee's cell, and that bit is what
+        // `can_inline_callable` reads, so the deny is spelled through it
+        // rather than beside it.  The mechanism is upstream's; the trigger is
+        // not, and the doc above says which.  The recursion-bound deny in
+        // `inline_call.rs` already calls it for the callee it names; this one
+        // names a callee the same way and had no reason not to.  Pass the
+        // typed key so the verdict lands on the same comparekey-bearing cell
+        // consulted at the next call.
         if let Some((driver, _)) = crate::driver::try_driver_pair() {
             let key = crate::driver::make_green_key_typed(
                 callee_code_key as *const (),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -10224,25 +10224,44 @@ pub(crate) fn try_walker_specialize_builtin_zip<Sym: WalkSym>(
     Ok(Some(()))
 }
 
-/// Unrolling bound for the PORTAL arm of
-/// [`try_walker_specialize_builtin_locals`].
+/// Ops the modelled `fast2locals` expansion records per bound slot.
 ///
-/// The modelled expansion is a straight-line unroll of `fast2locals`' slot
-/// loop, one guard plus at most one store per fastlocal.  Upstream bounds the
-/// same unroll by `@jit.unroll_safe` on a loop whose trip count is the code
-/// object's `numlocals`; the explicit ceiling here keeps a pathologically
-/// wide frame from turning one `locals()` into hundreds of trace ops.  Over
-/// the bound the fold declines and the generic residual runs (SAFE).
+/// The unroll emits at most one guard and one store for each of them, so this
+/// is what [`locals_expansion_fits_trace_limit`] multiplies by to say how far
+/// one `locals()` opcode can take the history.
+const OPS_PER_MODELLED_SLOT: usize = 2;
+
+/// Whether an expansion over `nslots` slots still fits inside `trace_limit`.
 ///
-/// That "SAFE" is what the ceiling rests on, so it does not reach the callee
-/// arm: a decline in
-/// [`try_walker_specialize_builtin_locals_in_callee_expand`] is answered by
-/// denying the callee for the rest of the thread's tracing, not by a
-/// residual, and a fixed ceiling there would decide a callee's inlinability
-/// from its local count.  That arm carries no width gate and leaves the
-/// length question where upstream leaves it, to `trace_limit` (`pyjitpl.py`
-/// `MetaInterp.blackhole_if_trace_too_long`).
-const MAX_MODELLED_FASTLOCALS: usize = 32;
+/// `pyjitpl.py` `MetaInterp._interpret` asks `history.length() > trace_limit`
+/// after every jitcode step, so the `fast2locals` it looks into is interrupted
+/// between its own steps and the overshoot is one jitcode wide.  Both arms
+/// here emit the whole unroll inside ONE Python opcode step, and the walk asks
+/// that question only once the step returns (`mod.rs`), so an expansion that
+/// does not ask it overshoots by the frame's own `co_nlocals` with nothing
+/// bounding it.
+///
+/// Asking it here leaves the bound where upstream leaves it -- `trace_limit`,
+/// not a constant.  A frame is never refused for being wide; it is refused for
+/// not fitting in what is left, which is the same question asked at the
+/// granularity this fold records at.
+fn locals_expansion_fits_trace_limit<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    nslots: usize,
+) -> bool {
+    locals_expansion_fits(
+        ctx.trace_ctx.num_recorded_ops(),
+        ctx.trace_ctx.trace_limit(),
+        nslots,
+    )
+}
+
+/// The arithmetic [`locals_expansion_fits_trace_limit`] asks, apart from the
+/// walk it reads the two counts off.  Both additions saturate: the answer for
+/// a width no history could hold is "no", not a wrap into "yes".
+pub(super) fn locals_expansion_fits(recorded: usize, limit: usize, nslots: usize) -> bool {
+    recorded.saturating_add(nslots.saturating_mul(OPS_PER_MODELLED_SLOT)) <= limit
+}
 
 /// Which builtin [`try_walker_specialize_builtin_locals`] is standing in for.
 ///
@@ -10322,9 +10341,9 @@ enum FrameLocalsBuiltin {
 /// a bound receiver, any argument, a frame that is not the
 /// standard virtualizable the boxes describe, a hidden top frame, a
 /// non-OPTIMIZED (module / class / exec) frame, cellvars / freevars /
-/// `CO_FAST_HIDDEN` slots, a slot the shadow cannot answer with a Ref, a frame
-/// wider than [`MAX_MODELLED_FASTLOCALS`], a shadow whose mapping is not the
-/// frame's, and a frame-owned mapping that is not an exact dict.
+/// `CO_FAST_HIDDEN` slots, a slot the shadow cannot answer with a Ref, a
+/// shadow whose mapping is not the frame's, and a frame-owned mapping that is
+/// not an exact dict.
 pub(crate) fn try_walker_specialize_builtin_locals<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],
@@ -10406,7 +10425,13 @@ pub(crate) fn try_walker_specialize_builtin_locals<Sym: WalkSym>(
         return Ok(None);
     }
     let numlocals = code_obj.varnames.len();
-    if numlocals > MAX_MODELLED_FASTLOCALS {
+    // Width is not the question; fitting is.  `pyframe.py`
+    // `PyFrame.fast2locals` carries `@jit.unroll_safe` and no ceiling, and the
+    // size question is `trace_limit`'s.  A fixed ceiling of 32 slots asked a
+    // different one, so a frame answered `locals()` from a residual because of
+    // its own local count while a trace many times longer was recorded beside
+    // it.
+    if !locals_expansion_fits_trace_limit(ctx, numlocals) {
         return Ok(None);
     }
     // `locals_cells_stack_w` is PyFrame's only virtualizable array
@@ -10874,6 +10899,20 @@ pub(crate) fn try_walker_specialize_builtin_locals<Sym: WalkSym>(
 /// carries a locals mapping or an `f_extra_locals` dict, and a written slot
 /// the shadow cannot resolve back to a Ref.  `PYRE_FBW_DEBUG_ABORT` names
 /// which of them declined.
+/// What [`try_walker_specialize_builtin_locals_in_callee_expand`] did.
+enum CalleeLocalsExpansion {
+    /// The mapping was emitted and the opcode is done.
+    Expanded,
+    /// The expansion models no part of this shape.  Answered by refusing the
+    /// callee, because the residual this would otherwise fall through to
+    /// escapes the level's vable and costs the enclosing loop.
+    DeclinedShape,
+    /// The expansion would not fit in what is left of `trace_limit`.  That is
+    /// a property of the trace so far and not of this body, so it is answered
+    /// by falling through rather than by remembering a refusal.
+    DeclinedBudget,
+}
+
 fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op: &DecodedOp,
@@ -10882,7 +10921,7 @@ fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
     concrete_callable: pyre_object::PyObjectRef,
     dst: usize,
 ) -> Result<Option<()>, DispatchError> {
-    if let Some(done) = try_walker_specialize_builtin_locals_in_callee_expand(
+    match try_walker_specialize_builtin_locals_in_callee_expand(
         ctx,
         op,
         fold,
@@ -10890,7 +10929,14 @@ fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
         concrete_callable,
         dst,
     )? {
-        return Ok(Some(done));
+        CalleeLocalsExpansion::Expanded => return Ok(Some(())),
+        // Falling through here costs the enclosing loop the same way the
+        // refusal below is written to avoid, and that is the right price: a
+        // walk with no room left for this expansion has none for the rest of
+        // the iteration either, and `trace_limit` is about to end it anyway.
+        // What must not happen is the callee carrying the blame afterwards.
+        CalleeLocalsExpansion::DeclinedBudget => return Ok(None),
+        CalleeLocalsExpansion::DeclinedShape => {}
     }
     // The expansion declined, so this level is about to run the opaque
     // residual -- and that residual's `force_frame_before_locals_read` clears
@@ -10913,13 +10959,14 @@ fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
     // shape yet, and widening the expansion until this line is unreachable is
     // the convergence path.
     //
-    // It is unreachable today.  Measured 2026-08-28 on release dynasm over the
-    // 503 `bench/synth` fixtures, all of which exit 0: not one `[decline-why]
+    // It is unreachable today.  Measured 2026-08-29 on release dynasm over the
+    // 504 `bench/synth` fixtures, all of which exit 0: not one `[decline-why]
     // LOCALS-IN-CALLEE` line anywhere, so no shape in the corpus reaches this
     // refusal.  Before the width gate came off, `locals_in_wide_inlined_callee`
     // reported the single line `nslots-over-cap nslots=42 name=wide`; that was
     // the only one the corpus produced, and no other gate has ever been
-    // observed to fire.  Each gate below now records why it does not: the
+    // observed to fire.  The budget refusal above is deliberately not one of
+    // them: it does not reach this line at all.  Each gate below now records why it does not: the
     // non-OPTIMIZED refusal is the answer rather than a gap, its
     // `CO_FAST_HIDDEN` half is a bit this compiler never sets, and the two
     // frame-payload gates sit behind writers that need a reference to the
@@ -10979,7 +11026,7 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
     r_args: &[OpRef],
     concrete_callable: pyre_object::PyObjectRef,
     dst: usize,
-) -> Result<Option<()>, DispatchError> {
+) -> Result<CalleeLocalsExpansion, DispatchError> {
     /// Name the gate that declined.  Unlike the portal arm's decline, which
     /// falls through to the generic residual, this one costs the caller its
     /// whole inlined callee, so "the expansion models no part of this shape"
@@ -10989,13 +11036,13 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
             if fbw_debug_abort_enabled() {
                 eprintln!("[decline-why] LOCALS-IN-CALLEE {}", $why);
             }
-            return Ok(None);
+            return Ok(CalleeLocalsExpansion::DeclinedShape);
         }};
         ($why:literal, $($arg:tt)*) => {{
             if fbw_debug_abort_enabled() {
                 eprintln!("[decline-why] LOCALS-IN-CALLEE {}", format!($why, $($arg)*));
             }
-            return Ok(None);
+            return Ok(CalleeLocalsExpansion::DeclinedShape);
         }};
     }
     // Under a single-frame collapse the resume re-executes the whole call, so
@@ -11058,15 +11105,22 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
     // named by `varnames` and is only a CELL there, which the per-slot kind
     // below picks up.
     let nslots = numlocals + pyre_interpreter::PyFrame::cell_slot_names(code_obj).count();
-    // No width ceiling here, unlike the portal arm's
-    // `MAX_MODELLED_FASTLOCALS`.  Upstream bounds this unroll with
-    // `@jit.unroll_safe` on `pyframe.py` `PyFrame.fast2locals` and nothing
-    // else; the length question belongs to `trace_limit`, which `pyjitpl.py`
-    // `MetaInterp.blackhole_if_trace_too_long` asks over the whole history
-    // rather than per fold.  The portal arm can afford a cheaper local answer
-    // because a decline there falls through to the generic residual; a
-    // decline HERE denies the callee for the rest of the thread's tracing, so
-    // a fixed ceiling would decide inlinability from a callee's local count.
+    // No width ceiling here, and none on the portal arm either: upstream
+    // bounds this unroll with `@jit.unroll_safe` on `pyframe.py`
+    // `PyFrame.fast2locals` and nothing else, and leaves the length question
+    // to `trace_limit`.  What made the ceiling worth removing HERE first is
+    // the price of the refusal: the portal arm's decline falls through to the
+    // generic residual, while a decline on this arm denies the callee for the
+    // rest of the thread's tracing, so the ceiling decided inlinability from a
+    // callee's local count.
+    //
+    // The budget answer keeps that price off the callee.  Not fitting is a
+    // property of the trace so far, not of this body -- the same callee fits
+    // in a shorter one -- so it is reported apart from the shape declines and
+    // the caller falls through instead of remembering a refusal.
+    if !locals_expansion_fits_trace_limit(ctx, nslots) {
+        return Ok(CalleeLocalsExpansion::DeclinedBudget);
+    }
 
     // Fresh mapping only.  A frame that already carries one — an `f_locals`
     // write (PEP 667), a `setdictscope` — is the portal arm's frame-owned
@@ -11257,9 +11311,9 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
     };
     // A slot rewrite or the tail reports a failure as PY_NULL instead of
     // publishing it; nothing has been emitted yet, so decline and let the
-    // residual raise.
+    // caller record the plain call, which raises the same way.
     if concrete_result.is_null() {
-        return Ok(None);
+        decline!("concrete-result-null");
     }
     let concrete_locals_value = majit_ir::Value::Ref(majit_ir::GcRef(concrete_locals as usize));
 
@@ -11389,7 +11443,7 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
         None => dict_op,
     };
     write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', result_op)?;
-    Ok(Some(()))
+    Ok(CalleeLocalsExpansion::Expanded)
 }
 
 /// `sys._getframe()` / `sys._getframe(0)` at the top walk level: publish the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -10224,7 +10224,8 @@ pub(crate) fn try_walker_specialize_builtin_zip<Sym: WalkSym>(
     Ok(Some(()))
 }
 
-/// Unrolling bound for [`try_walker_specialize_builtin_locals`].
+/// Unrolling bound for the PORTAL arm of
+/// [`try_walker_specialize_builtin_locals`].
 ///
 /// The modelled expansion is a straight-line unroll of `fast2locals`' slot
 /// loop, one guard plus at most one store per fastlocal.  Upstream bounds the
@@ -10232,6 +10233,15 @@ pub(crate) fn try_walker_specialize_builtin_zip<Sym: WalkSym>(
 /// object's `numlocals`; the explicit ceiling here keeps a pathologically
 /// wide frame from turning one `locals()` into hundreds of trace ops.  Over
 /// the bound the fold declines and the generic residual runs (SAFE).
+///
+/// That "SAFE" is what the ceiling rests on, so it does not reach the callee
+/// arm: a decline in
+/// [`try_walker_specialize_builtin_locals_in_callee_expand`] is answered by
+/// denying the callee for the rest of the thread's tracing, not by a
+/// residual, and a fixed ceiling there would decide a callee's inlinability
+/// from its local count.  That arm carries no width gate and leaves the
+/// length question where upstream leaves it, to `trace_limit` (`pyjitpl.py`
+/// `MetaInterp.blackhole_if_trace_too_long`).
 const MAX_MODELLED_FASTLOCALS: usize = 32;
 
 /// Which builtin [`try_walker_specialize_builtin_locals`] is standing in for.
@@ -10860,10 +10870,10 @@ pub(crate) fn try_walker_specialize_builtin_locals<Sym: WalkSym>(
 /// would collapse to the caller's CALL boundary, a level with no shadow, an
 /// inactive strict fold or unseeded frame register, a top frame that is not
 /// this level's own, a shadow describing another code object, a non-OPTIMIZED
-/// frame, cellvars / freevars / `CO_FAST_HIDDEN` slots, a frame wider than
-/// [`MAX_MODELLED_FASTLOCALS`], a frame that already carries a locals mapping
-/// or an `f_extra_locals` dict, and a written slot the shadow cannot resolve
-/// back to a Ref.
+/// frame, cellvars / freevars / `CO_FAST_HIDDEN` slots, a frame that already
+/// carries a locals mapping or an `f_extra_locals` dict, and a written slot
+/// the shadow cannot resolve back to a Ref.  `PYRE_FBW_DEBUG_ABORT` names
+/// which of them declined.
 fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op: &DecodedOp,
@@ -10896,9 +10906,22 @@ fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
     // never been admitted, and the escape never happens: same answer, one
     // decline instead of an abort.  What reaches this line is a shape the
     // expansion models no part of -- a non-OPTIMIZED frame, a `CO_FAST_HIDDEN`
-    // slot, more slots than `MAX_MODELLED_FASTLOCALS`, a frame already
-    // carrying an `f_locals` mapping, or a slot whose value this walk never
-    // saw -- and for all of those the refusal is the whole answer.
+    // slot, a frame already carrying an `f_locals` mapping or an
+    // `f_extra_locals` dict, or a slot whose value this walk never saw.  Each
+    // of those is named under `PYRE_FBW_DEBUG_ABORT`, because the refusal is
+    // not the answer: it stands in for an expansion that does not model the
+    // shape yet, and widening the expansion until this line is unreachable is
+    // the convergence path.
+    //
+    // It is unreachable today.  Measured 2026-08-28 on release dynasm over the
+    // 503 `bench/synth` fixtures, all of which exit 0: not one `[decline-why]
+    // LOCALS-IN-CALLEE` line anywhere, so no shape in the corpus reaches this
+    // refusal.  Before the width gate came off, `locals_in_wide_inlined_callee`
+    // reported the single line `nslots-over-cap nslots=42 name=wide`; that was
+    // the only one the corpus produced, and no other gate has ever been
+    // observed to fire.  So the gates left below are unmeasured rather than
+    // known-live, and a widening aimed at one of them needs a fixture that
+    // reaches it first.
     if let Some(callee) = super::fbw_state::fbw_innermost_inline_callee_key(ctx) {
         return Err(super::fbw_state::fbw_decline_inline_callee(
             ctx,
@@ -10955,21 +10978,39 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
     concrete_callable: pyre_object::PyObjectRef,
     dst: usize,
 ) -> Result<Option<()>, DispatchError> {
+    /// Name the gate that declined.  Unlike the portal arm's decline, which
+    /// falls through to the generic residual, this one costs the caller its
+    /// whole inlined callee, so "the expansion models no part of this shape"
+    /// has to be attributable to one gate rather than re-derived by reading.
+    macro_rules! decline {
+        ($why:literal) => {{
+            if fbw_debug_abort_enabled() {
+                eprintln!("[decline-why] LOCALS-IN-CALLEE {}", $why);
+            }
+            return Ok(None);
+        }};
+        ($why:literal, $($arg:tt)*) => {{
+            if fbw_debug_abort_enabled() {
+                eprintln!("[decline-why] LOCALS-IN-CALLEE {}", format!($why, $($arg)*));
+            }
+            return Ok(None);
+        }};
+    }
     // Under a single-frame collapse the resume re-executes the whole call, so
     // a guard emitted here re-runs every side effect the inline region already
     // sequenced.  Same gate the other folds that run under a sub-walk take.
     if ctx.fbw_mode.inline_subwalk && !walker_inline_guard_resumes_in_callee(ctx) {
-        return Ok(None);
+        decline!("subwalk-no-callee-resume");
     }
     let (fold_frame_reg, shadow_code_ptr) = {
         let Some(shadow) = ctx.callee_shadow.as_ref() else {
-            return Ok(None);
+            decline!("no-callee-shadow");
         };
         // `u16::MAX` is the strict fresh-frame fold switched off, and a
         // `NONE` frame box is a frame register that was never seeded — in
         // neither case is the shadow the authority for this level's slots.
         if shadow.fold_frame_reg == u16::MAX || shadow.frame_box.is_none() {
-            return Ok(None);
+            decline!("unseeded-frame-register");
         }
         (shadow.fold_frame_reg, shadow.code_ptr)
     };
@@ -10983,22 +11024,22 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
     let inline_frame = current_inline_concrete_frame();
     let ec = pyre_interpreter::call::getexecutioncontext();
     if inline_frame == 0 || ec.is_null() {
-        return Ok(None);
+        decline!("no-inline-frame-or-ec");
     }
     let frame = unsafe { (*ec).gettopframe_nohidden() };
     if frame.is_null() || frame as usize != inline_frame {
-        return Ok(None);
+        decline!("top-frame-not-this-level");
     }
     let frame_ref = unsafe { &*frame };
     let code_ptr = unsafe { pyre_interpreter::pyframe::pyframe_get_pycode(frame_ref) };
     // The shadow's slots index the code object it was opened for; a
     // disagreement means the map does not describe this frame's fastlocals.
     if code_ptr.is_null() || !std::ptr::eq(code_ptr, shadow_code_ptr) {
-        return Ok(None);
+        decline!("shadow-names-other-code");
     }
     let code_obj = unsafe { &*code_ptr };
     if !pyre_interpreter::PyFrame::code_locals_are_modelled_fastlocals(code_obj) {
-        return Ok(None);
+        decline!("not-modelled-fastlocals");
     }
     let numlocals = code_obj.varnames.len();
     // The pure cellvars and the freevars occupy the slots above `varnames` in
@@ -11007,16 +11048,23 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
     // named by `varnames` and is only a CELL there, which the per-slot kind
     // below picks up.
     let nslots = numlocals + pyre_interpreter::PyFrame::cell_slot_names(code_obj).count();
-    if nslots > MAX_MODELLED_FASTLOCALS {
-        return Ok(None);
-    }
+    // No width ceiling here, unlike the portal arm's
+    // `MAX_MODELLED_FASTLOCALS`.  Upstream bounds this unroll with
+    // `@jit.unroll_safe` on `pyframe.py` `PyFrame.fast2locals` and nothing
+    // else; the length question belongs to `trace_limit`, which `pyjitpl.py`
+    // `MetaInterp.blackhole_if_trace_too_long` asks over the whole history
+    // rather than per fold.  The portal arm can afford a cheaper local answer
+    // because a decline there falls through to the generic residual; a
+    // decline HERE denies the callee for the rest of the thread's tracing, so
+    // a fixed ceiling would decide inlinability from a callee's local count.
+
     // Fresh mapping only.  A frame that already carries one — an `f_locals`
     // write (PEP 667), a `setdictscope` — is the portal arm's frame-owned
     // shape, whose rewrite has to reach the frame's own dict across calls;
     // this level's frame is rebuilt from scratch by the compiled trace when it
     // is built at all, so that shape has no counterpart here and declines.
     if !frame_ref.get_w_locals().is_null() {
-        return Ok(None);
+        decline!("frame-has-w-locals");
     }
     // A null `w_locals` is NOT on its own a fresh mapping.  A proxy write
     // whose key names no writable fast local goes to `f_extra_locals`
@@ -11027,7 +11075,7 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
     // frame is built by the compiled trace, so its payload starts empty every
     // iteration and only a residual on the recorded path can have filled it.
     if !frame_ref.get_extra_locals().is_null() {
-        return Ok(None);
+        decline!("frame-has-extra-locals");
     }
     // Collect each slot's shadow entry first, so a slot the shadow cannot
     // answer declines from a clean trace position and nothing is emitted.
@@ -11039,7 +11087,7 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
     let mut slot_oprefs: Vec<Option<OpRef>> = Vec::with_capacity(nslots);
     {
         let Some(shadow) = ctx.callee_shadow.as_ref() else {
-            return Ok(None);
+            decline!("shadow-vanished");
         };
         for slot in 0..nslots as i64 {
             match (shadow.opref.get(&slot).copied(), shadow.concrete.get(&slot)) {
@@ -11053,7 +11101,7 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
                 // absence here means the walk never READ it, not that the name
                 // is unbound.  There is no SSA value to bind and guessing
                 // "unbound" would drop a live name, so decline.
-                (None, None) if is_cell_slot(slot as usize) => return Ok(None),
+                (None, None) if is_cell_slot(slot as usize) => decline!("cell-slot-unread"),
                 (None, None) => slot_oprefs.push(None),
                 // Only an entry recorded through THIS level's frame register
                 // describes this frame — the same per-frame isolation the
@@ -11063,7 +11111,7 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
                 }
                 // Written with no reconstructable concrete half, or through
                 // another frame's register: decline rather than guess.
-                _ => return Ok(None),
+                _ => decline!("slot-not-this-frame"),
             }
         }
     }
@@ -11083,10 +11131,10 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
         // the table is the GC-forwarded channel, so a Ref that moved across an
         // earlier residual is current there.
         let Some(majit_ir::Value::Ref(gcref)) = ctx.trace_ctx.concrete_of_opref(slot_op) else {
-            return Ok(None);
+            decline!("slot-concrete-not-ref");
         };
         if gcref == majit_ir::GcRef::NO_CONCRETE {
-            return Ok(None);
+            decline!("slot-no-concrete");
         }
         let held = gcref.as_usize() as pyre_object::PyObjectRef;
         let cell = is_cell_slot(index);
@@ -11096,7 +11144,7 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
             // `MAKE_CELL` / `COPY_FREE_VARS` prologue, and modelling it would
             // need a second arm with its own guard, so decline instead.
             if held.is_null() || !unsafe { pyre_object::is_cell(held) } {
-                return Ok(None);
+                decline!("cell-slot-not-a-cell");
             }
         }
         let value = if cell {
@@ -11109,7 +11157,7 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
             // so it binds no key for it — but only a NULL the trace holds as a
             // constant is unbound on every execution of the compiled path.
             if !slot_op.is_constant() {
-                return Ok(None);
+                decline!("unbound-slot-not-constant");
             }
             continue;
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -10919,9 +10919,11 @@ fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
     // refusal.  Before the width gate came off, `locals_in_wide_inlined_callee`
     // reported the single line `nslots-over-cap nslots=42 name=wide`; that was
     // the only one the corpus produced, and no other gate has ever been
-    // observed to fire.  So the gates left below are unmeasured rather than
-    // known-live, and a widening aimed at one of them needs a fixture that
-    // reaches it first.
+    // observed to fire.  Each gate below now records why it does not: the
+    // non-OPTIMIZED refusal is the answer rather than a gap, its
+    // `CO_FAST_HIDDEN` half is a bit this compiler never sets, and the two
+    // frame-payload gates sit behind writers that need a reference to the
+    // level's own live frame.
     if let Some(callee) = super::fbw_state::fbw_innermost_inline_callee_key(ctx) {
         return Err(super::fbw_state::fbw_decline_inline_callee(
             ctx,
@@ -11038,6 +11040,14 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
         decline!("shadow-names-other-code");
     }
     let code_obj = unsafe { &*code_ptr };
+    // Two conditions, and only the first can fire.  A non-OPTIMIZED frame
+    // answers `locals()` from `PyFrame::getdictscope` — its LIVE namespace,
+    // not the independent copy this arm builds — so declining is the answer
+    // rather than a gap.  The `CO_FAST_HIDDEN` half is inert: `pycode.rs`
+    // builds `localspluskinds` out of `CO_FAST_LOCAL` and `CO_FAST_CELL`
+    // alone, so nothing this compiler produces carries the bit, and
+    // `PyFrame::fast2locals` skips such a slot only on a frame this arm has
+    // already refused.
     if !pyre_interpreter::PyFrame::code_locals_are_modelled_fastlocals(code_obj) {
         decline!("not-modelled-fastlocals");
     }
@@ -11063,6 +11073,14 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
     // shape, whose rewrite has to reach the frame's own dict across calls;
     // this level's frame is rebuilt from scratch by the compiled trace when it
     // is built at all, so that shape has no counterpart here and declines.
+    //
+    // Never observed to fire, and the reason is structural: this arm has
+    // already required an OPTIMIZED frame, and on one of those `w_locals` has
+    // no writer the answer can follow.  `bind_unoptimized_locals_scope`
+    // returns before binding it, `PyFrame::fget_getdictscope` hands an
+    // optimized frame a `FrameLocalsProxy` rather than calling
+    // `getdictscope`, and the line-tracing call to `fast2locals` is guarded on
+    // `w_locals` being non-null already, so it cannot be the first setter.
     if !frame_ref.get_w_locals().is_null() {
         decline!("frame-has-w-locals");
     }
@@ -11074,6 +11092,14 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
     // key.  Read the LIVE callee frame, which is the only holder: this level's
     // frame is built by the compiled trace, so its payload starts empty every
     // iteration and only a residual on the recorded path can have filled it.
+    //
+    // Never observed to fire either, and an earlier gate is why.  The one
+    // writer is `FrameLocalsProxy::setitem_value`, so filling the dict takes a
+    // reference to this level's own live frame, and that write calls
+    // `force_locals` before it stores.  `locals_proxy_extra_key_hot` drives
+    // exactly that shape one frame in and reports no decline at all: the
+    // expansion is not reached there, because the callee is no longer an
+    // un-escaped inline level by the time `locals()` is recorded.
     if !frame_ref.get_extra_locals().is_null() {
         decline!("frame-has-extra-locals");
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -13917,3 +13917,35 @@ fn the_traceback_walk_receivers_pin_their_class_through_the_payload() {
         "list is acceptable as a base class, so its payload does not determine w_class",
     );
 }
+
+/// The modelled `locals()` expansion asks `trace_limit` whether it fits before
+/// it emits, because both of its arms emit the whole unroll inside ONE Python
+/// opcode step and the walk asks that question only after the step returns
+/// (`mod.rs`).  Upstream asks it after every jitcode step
+/// (`pyjitpl.py` `MetaInterp._interpret`), so the `fast2locals` it looks into
+/// is interrupted between its own steps; without this the overshoot here is
+/// the frame's `co_nlocals` and nothing bounds it.
+///
+/// The boundary is the whole content of the gate, so it is pinned on both
+/// sides rather than sampled — and the saturating arithmetic is pinned too,
+/// because a width that wraps would answer "fits" for the one input that
+/// cannot.
+#[test]
+fn locals_expansion_asks_trace_limit_rather_than_a_width() {
+    use super::specialize::locals_expansion_fits;
+
+    // One guard plus at most one store per slot, so 44 slots need 88 ops.
+    assert!(locals_expansion_fits(0, 88, 44), "exactly the budget fits");
+    assert!(!locals_expansion_fits(0, 87, 44), "one op over does not");
+    // What is already recorded counts: the same frame fits in a fresh walk and
+    // not in one that has spent its budget, which is the point of asking here
+    // rather than carrying a constant.
+    assert!(locals_expansion_fits(6000 - 88, 6000, 44));
+    assert!(!locals_expansion_fits(6000 - 87, 6000, 44));
+    // A frame with no slots emits nothing, so it fits even at the limit.
+    assert!(locals_expansion_fits(6000, 6000, 0));
+    assert!(!locals_expansion_fits(6001, 6000, 0), "already over");
+    // Neither multiplication nor addition may wrap into a "fits".
+    assert!(!locals_expansion_fits(0, usize::MAX - 1, usize::MAX));
+    assert!(!locals_expansion_fits(usize::MAX, usize::MAX - 1, 1));
+}


### PR DESCRIPTION
Follow-up to #1549, closing the convergence path its own comment named:
*"Widening it until the refusal is unreachable is the convergence path; the
refusal is not the answer."*

## The ceiling decided inlinability from a callee's local count

`try_walker_specialize_builtin_locals_in_callee_expand` refused any frame with
more than `MAX_MODELLED_FASTLOCALS` (32) slots. That constant entered in #1075
for the PORTAL arm — `try_walker_specialize_builtin_locals` — and #1437
inherited it wholesale when it built the callee arm.

The two arms do not pay the same price for a refusal. In the portal arm the
decline falls through to the generic residual. In the callee arm it routes
through `fbw_decline_inline_callee`, which writes the callee's code key into
`FBW_HAZARDOUS_INLINE_DENY` — a permanent per-thread deny — and calls
`WarmEnterState::disable_noninlinable_function`. So a callee was refused
inlining for the rest of the thread's tracing *because it had 33 locals*.

`locals_in_wide_inlined_callee` is the fixture. `wide` carries 42 slots and no
other fixture reaches the expansion with more than a handful, so the shape was
one nothing owned. Measured on release dynasm through `check.py`'s own gate:

| | `builtin_locals` | `[decline-why]` | `check.py` |
|---|---|---|---|
| before | `consulted=7 fired=0` | `nslots-over-cap nslots=42 name=wide` | FAIL — `declared fold(s) never fired: builtin_locals` |
| after | `consulted=1 fired=1` | none | PASS |

## Every decline in the expansion names itself

The expansion had seventeen `return Ok(None)` sites and no way to tell which
one fired. A `decline!` macro gated on `PYRE_FBW_DEBUG_ABORT` — the idiom
`try_walker_specialize_load_deref` established — prints
`[decline-why] LOCALS-IN-CALLEE <tag>` at each.

Measured over the 504 `bench/synth` fixtures on release dynasm, all of which
exit 0: **not one** `[decline-why] LOCALS-IN-CALLEE` line anywhere. The refusal
is unreachable, so the deny above it cannot fire from this caller.

Each surviving gate is read to a disposition and the disposition recorded at
the gate: the non-OPTIMIZED refusal is the answer rather than a gap (`locals()`
there answers from `PyFrame::getdictscope`, the live namespace); its
`CO_FAST_HIDDEN` half is a bit `pycode.rs` never sets, since `localspluskinds`
is built from `CO_FAST_LOCAL` and `CO_FAST_CELL` alone; and the two
frame-payload gates sit behind writers that need a reference to the level's own
live frame — `FrameLocalsProxy::setitem_value` calls `force_locals()` first,
and `locals_proxy_extra_key_hot`, which drives that shape, does not reach the
expansion at all.

## The portal arm had the same ceiling, and it was costing the loop

Raised by the Codex parity review as pre-existing. It is, and it is one line
from the work above, so it is fixed here rather than filed.

`locals_in_wide_portal_frame` is the fixture — 44 slots, with the loop in the
wide frame itself. Measured against a control binary built from this same
commit with only the ceiling reinstated:

| | `builtin_locals` | `loops_compiled` | `loops_aborted` | `abrt_escape` |
|---|---|---|---|---|
| with the ceiling | `consulted=5 fired=0` | 0 | 5 | 5 |
| without it | `consulted=3 fired=2` | 1 | 0 | 0 |

So the refusal was not costing one residual per iteration, it was costing the
loop: the residual's locals read forces the portal frame and the walk cannot
carry that. The answer is right either way, which is why the fixture gates both
halves — `spec-folds` on the fold, `selfcheck-compiles` on the compile — since
either alone reads as a pass on a run that answered right and compiled nothing.

## What replaces the ceiling is the question it stood in for

Also from the Codex review, on the diff itself: `trace_limit` does not bound
one opcode's work. `pyjitpl.py` `MetaInterp._interpret` asks
`history.length() > trace_limit` after every jitcode step, so the `fast2locals`
upstream looks into is interrupted between its own steps. Both arms here emit
the whole unroll inside ONE Python opcode step and the walk asks only once that
step returns, so an expansion that does not ask overshoots by the frame's own
`co_nlocals` with nothing bounding it.

`locals_expansion_fits_trace_limit` asks it. Measured at `trace_limit=70` with
44 slots, on two binaries from the same base:

| | `builtin_locals` | `abrt_too_long` | `abrt_escape` | `loops_compiled` |
|---|---|---|---|---|
| no gate | `fired=5` | 7 | 0 | 1 |
| gate | `fired=0` | 2 | 5 | 2 |

Same answer both times. At the default limit the gate is inert: both locals
fixtures record exactly what they do without it.
`locals_expansion_asks_trace_limit_rather_than_a_width` pins the boundary and
the saturating arithmetic.

The callee arm reports a budget refusal apart from its shape refusals. Not
fitting is a property of the trace so far and not of the body — the same callee
fits in a shorter trace — so the caller falls through instead of denying the
callee for the rest of the thread's tracing, which is the failure mode the
width ceiling had.

## The deny's citation pointed at a different question

`fbw_decline_inline_callee`'s comment named
`disable_noninlinable_function(greenkey_of_huge_function)` /
`MetaInterp.blackhole_if_trace_too_long` as "the upstream answer". That caller
asks a SIZE question and then denies the greenkey
`MetaInterp.find_biggest_function` names, which need not be the callee at hand.
A vable escape denies nothing: `MetaInterp.vable_after_residual_call` raises
`SwitchToBlackhole(ABORT_ESCAPE, raising_exception=True)`, and
`MetaInterp.run_blackhole_interp_to_cancel_tracing` hands that to `blackhole.py`
`convert_and_run_from_pyjitpl`, which carries the frame FORWARD.

The mechanism pyre calls is upstream's —
`warmstate.py` `WarmEnterState.disable_noninlinable_function` sets
`JC_DONT_TRACE_HERE` and `can_inline_callable` reads it. The trigger is not,
and the doc now says so instead of citing a caller that asks something else.

## A default-ON fix had a switched-off arm nothing ran

`PYRE_FBW_NO_ADOPT_RESIDUAL_LOCALS` is documented in gate-triage.md as the
one-binary control that keeps a lost `f_locals` write demonstrable. Nothing ran
the arm it controls, so the corpus could not tell "the adopt is doing the work"
from "the script stopped reaching the shape".

`# pyre-check: regresses-under: NAME=VALUE -- <reason>` runs a parity script a
second time on each pyre backend with those names set and requires it to FAIL,
reporting a pass as XPASS the way a `pypy-diverges` script that starts passing
already is. `flocals_writethrough_forcing_residual` carries it: with the switch
set it reports `2 of 4000, first: [(1040, 1039), (2105, 2104)]` — the pair its
own docstring pins — and exits non-zero; without it, `OK`. Pointed at a name
nothing reads, the gate reports XPASS and fails the run rather than agreeing.

## Verification

On the rebased base, release dynasm:

- `check.py --backend dynasm` — **ALL PASSED 514/514**
- `cargo test -p pyre-jit-trace --features dynasm` — 453 passed, 0 failed
- `parity_tests/run.py --dynasm-only` — 187 scripts, all pass, the new arm reads `dynasm:regresses=xfail`
- corpus census — 504 fixtures, all exit 0, no `[decline-why] LOCALS-IN-CALLEE` line
- `cargo fmt --check`, `check.py --check-headers` — clean

Only dynasm is built in this worktree, so cranelift and wasm are exercised by
CI rather than here. Both new fixtures are `selfcheck`, so neither needs a
recorded `.jitstats` baseline — what they assert is their own invariant plus
the two headers.

The `trace_limit` gate has a unit test rather than a bench fixture: a bench
fixture that witnesses it has to lower `trace_limit` with
`pypyjit.set_param`, and that shape does need a baseline per backend.

An earlier push of this branch sat on `67505f239e9` and was red on four
`pyre/check.py` legs for `exception_escape_hot_callee_tb_node_once`
(`guard_failures 808 -> 1015`) and `exception_traceback_frame_lineno`
(`bridges_compiled 6 -> 4`). Neither was this branch's: main's own run at that
commit failed the same four jobs with byte-identical numbers, and #1559
re-recorded both baselines afterwards -- "the two baselines #1553 and #1388 each
measured without the other". This branch is rebased past that.

## Self-review

`/parity` was run over the rebase onto current main. The one conflict was in
`fbw_decline_inline_callee`'s comment, where main's #1388 had switched the green
key to the typed API and this branch had corrected the citation in the same
block; resolved as a blend after reading `warmstate.py`
`disable_noninlinable_function`, `can_inline_callable`,
`_ensure_jit_cell_at_key`, and `pyjitpl.py` `blackhole_if_trace_too_long`.
`git range-diff` confirmed the other commits replayed byte-identical.

Both Codex findings above are addressed in this diff rather than deferred.

- [x] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [x] Auto-review section 1 is clear. This check is mandatory.
  - [x] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `locals()` handling in wide inlined functions and portal frames.
  * Replaced fixed-width limitations with trace-budget-aware expansion for more reliable optimized execution.

* **Tests**
  * Added benchmarks for wide local-variable frames and repeated execution.
  * Added regression annotations and validation for expected failures under restricted settings.
  * Added checks for trace-budget boundary conditions and overflow-safe calculations.

* **Documentation**
  * Clarified inline-callee denial behavior and diagnostic conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
