### PR TITLE
Descend pos_inner for +x, and key a virtual's class word off the layout

### DIFF
--- a/majit/majit-ir/src/ptr_info.rs
+++ b/majit/majit-ir/src/ptr_info.rs
@@ -152,14 +152,15 @@ pub struct VStringConcatInfo {
 ///
 /// Fields are tracked as OpRefs to the operations that produce their values.
 ///
-/// ## Invariant: `fields` NEVER contains typeptr (offset 0)
+/// ## Invariant: `fields` NEVER contains object-header fields
 ///
 /// Matches RPython upstream: `heaptracker.py all_fielddescrs()` skips
 /// `typeptr`, so `info.py AbstractStructPtrInfo.init_fields` sizes
-/// `_fields` with typeptr excluded from the indexable range. The typeptr
-/// (offset 0) is tracked separately via `known_class` and emitted by the
-/// GC rewriter's `gen_initialize_vtable` path (rewrite.py:479-484), NOT
-/// from the force-path field loop.
+/// `_fields` with it excluded from the indexable range. Pyre's additional
+/// Python-level `w_class` header follows the same rule. The typeptr (offset 0)
+/// is tracked separately via `known_class` and emitted by the GC rewriter's
+/// `gen_initialize_vtable` path (rewrite.py), NOT from the force-path field
+/// loop; a non-default `w_class` store forces the virtual before it is emitted.
 ///
 /// Enforced by:
 /// - `virtualize.rs optimize_setfield_gc` Virtual arm: runtime check that
@@ -182,7 +183,7 @@ pub struct VirtualInfo {
     /// SetfieldGc(ob_type) without polluting `fields` (which feeds rd_virtuals).
     pub ob_type_descr: Option<DescrRef>,
     /// Field values: `(field_descr_index, value_opref)`.
-    /// **Invariant**: never contains typeptr (offset 0) — see struct-level docs.
+    /// **Invariant**: never contains typeptr or `w_class` — see struct-level docs.
     pub fields: Vec<(u32, Operand)>,
     /// info.py:91-92
     pub last_guard_pos: i32,

--- a/majit/majit-ir/src/ptr_info.rs
+++ b/majit/majit-ir/src/ptr_info.rs
@@ -152,19 +152,32 @@ pub struct VStringConcatInfo {
 ///
 /// Fields are tracked as OpRefs to the operations that produce their values.
 ///
-/// ## Invariant: `fields` NEVER contains object-header fields
+/// ## Invariant: an entry's key is a slot of `all_fielddescrs()`
 ///
 /// Matches RPython upstream: `heaptracker.py all_fielddescrs()` skips
 /// `typeptr`, so `info.py AbstractStructPtrInfo.init_fields` sizes
-/// `_fields` with it excluded from the indexable range. Pyre's additional
-/// Python-level `w_class` header follows the same rule. The typeptr (offset 0)
-/// is tracked separately via `known_class` and emitted by the GC rewriter's
-/// `gen_initialize_vtable` path (rewrite.py), NOT from the force-path field
-/// loop; a non-default `w_class` store forces the virtual before it is emitted.
+/// `_fields` with it excluded from the indexable range. The typeptr (offset 0)
+/// is therefore never a key here; it is tracked via `known_class` and emitted
+/// by the GC rewriter's `gen_initialize_vtable` path (rewrite.py), NOT from
+/// the force-path field loop.
+///
+/// Pyre's additional Python-level `w_class` header is not the same case: a
+/// layout that lists it holds it at an ordinary slot (`W_BaseException` at 1),
+/// and an entry keyed by that slot resolves like any other. What must never
+/// appear is a key that names no slot — `index_in_parent` off a gc-only header
+/// edge (always 0, which is some value field), or one of
+/// `heap::OptHeap::field_slot_index`'s header/unslotted bands, which are keys
+/// for an association lookup and not positions in any list. `force_box` reads
+/// this list back through `all_fielddescrs()` BY POSITION, so such a key
+/// resolves to the wrong field or to nothing at all.
 ///
 /// Enforced by:
-/// - `virtualize.rs optimize_setfield_gc` Virtual arm: runtime check that
-///   returns early on `offset == Some(0)` before calling `set_field`.
+/// - `virtualize.rs optimize_setfield_gc` Virtual arm: returns early on
+///   typeptr, and keys a class-word store off the layout's
+///   `class_word_index_in_parent` rather than the op's descr.
+/// - `optimizeopt/mod.rs structinfo_setfield`: declines a header word on a
+///   virtual, whose key there comes from `heap::OptHeap::field_slot_index`'s
+///   band and names no slot.
 /// - `virtualize.rs force_virtual_instance`: `debug_assert_no_typeptr`
 ///   at the entry of the field-emit loop.
 /// - `virtualstate.rs export_single_value`:
@@ -183,7 +196,8 @@ pub struct VirtualInfo {
     /// SetfieldGc(ob_type) without polluting `fields` (which feeds rd_virtuals).
     pub ob_type_descr: Option<DescrRef>,
     /// Field values: `(field_descr_index, value_opref)`.
-    /// **Invariant**: never contains typeptr or `w_class` — see struct-level docs.
+    /// **Invariant**: every key is a slot of the descr's `all_fielddescrs()`;
+    /// typeptr is never one — see struct-level docs.
     pub fields: Vec<(u32, Operand)>,
     /// info.py:91-92
     pub last_guard_pos: i32,

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1327,9 +1327,23 @@ fn force_box_impl(
             for (field_idx, value_ref) in std::mem::take(&mut vinfo.fields) {
                 let value_ref = force_child(&value_ref, ctx);
                 let descr = lookup_field_descr(&cached_fielddescrs, field_idx);
-                let descr = descr.expect(
-                    "force_box: field_idx must resolve through descr.get_all_fielddescrs()[i]",
-                );
+                // The key that failed to resolve is the whole diagnosis, and
+                // the list it was looked up in says which numbering it came
+                // from, so name both rather than only the rule they broke.
+                let descr = descr.unwrap_or_else(|| {
+                    panic!(
+                        "force_box: field_idx must resolve through descr.get_all_fielddescrs()[i] \
+                         (field_idx={field_idx} len={} keys={:?})",
+                        cached_fielddescrs.len(),
+                        cached_fielddescrs
+                            .iter()
+                            .map(|d| d
+                                .as_field_descr()
+                                .map(|f| (f.field_key().to_string(), f.index_in_parent()))
+                                .unwrap_or_else(|| ("?".to_string(), 0)))
+                            .collect::<Vec<_>>(),
+                    )
+                });
                 if w_class_store_is_covered_by_alloc(&vinfo.descr, &descr, &value_ref, ctx) {
                     continue;
                 }

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -68,11 +68,10 @@ pub(crate) fn resolve_gc_tid(
 /// `descr.get_all_fielddescrs()` (info.py:217-225), where `typeptr` is absent,
 /// so upstream never emits this header store from the force path. This is the
 /// same optimizer-layer "value already there" elision as heap.py:88-101.
-fn w_class_store_is_covered_by_alloc(
+pub(crate) fn w_class_value_is_covered_by_alloc(
     size_descr: &DescrRef,
     field_descr: &DescrRef,
-    value: &Operand,
-    ctx: &crate::optimizeopt::OptContext,
+    value: Option<Value>,
 ) -> bool {
     let Some(field) = field_descr.as_field_descr().filter(|fd| fd.is_w_class()) else {
         return false;
@@ -97,9 +96,22 @@ fn w_class_store_is_covered_by_alloc(
         return false;
     }
     matches!(
+        value,
+        Some(Value::Ref(value)) if value == GcRef(w_class as usize)
+    )
+}
+
+fn w_class_store_is_covered_by_alloc(
+    size_descr: &DescrRef,
+    field_descr: &DescrRef,
+    value: &Operand,
+    ctx: &crate::optimizeopt::OptContext,
+) -> bool {
+    w_class_value_is_covered_by_alloc(
+        size_descr,
+        field_descr,
         ctx.resolve_operand_operand_opt(value)
             .and_then(|resolved| resolved.const_value()),
-        Some(Value::Ref(value)) if value == GcRef(w_class as usize)
     )
 }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -8395,11 +8395,28 @@ impl OptContext {
             }
             return;
         }
+        // A virtual's field list is addressed by position, and the key this
+        // site carries is not one.  [`heap::OptHeap::field_slot_index`] answers
+        // `typeptr` and `w_class` out of a band of their own, above every
+        // position a parent's field list can hand out, precisely because they
+        // resolve through no field list at all.  That is a workable key for the
+        // association lists an `Instance`/`Struct` carries, but `force_box`
+        // walks a virtual's `fields` back through `descr.get_all_fielddescrs()`
+        // BY POSITION, so a banded slot there resolves to nothing.  A virtual
+        // that owns a listed class word records it from
+        // `virtualize.rs optimize_setfield_gc`, which reads the slot off the
+        // layout; nothing is lost by declining here.
+        let is_header_word = op
+            .with_field_descr(|fd| fd.is_typeptr() || fd.is_w_class())
+            .unwrap_or(false);
         // info.py AbstractStructPtrInfo.setfield: mutate `_fields`
         // in the PtrInfo object stored in the operand's `_forwarded` slot.
         // PyPy has the same single-object behavior via `box._forwarded`.
         self.with_ensured_ptr_info_arg0(op, |mut handle| {
             if let Some(mut pi) = handle.as_mut() {
+                if is_header_word && pi.is_virtual() {
+                    return;
+                }
                 pi.setfield(field_idx, value.clone());
             }
         });

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -13,7 +13,7 @@ use majit_ir::{Descr, DescrRef, FieldDescr, OopSpecIndex, Op, OpCode, OpRef, Typ
 
 use crate::optimizeopt::info::{
     ArrayStructInfo, PtrInfo, VirtualArrayInfo, VirtualInfo, VirtualStructInfo,
-    VirtualizableFieldState,
+    VirtualizableFieldState, w_class_value_is_covered_by_alloc,
 };
 use crate::optimizeopt::{OptContext, Optimization, OptimizationResult};
 
@@ -812,9 +812,9 @@ impl OptVirtualize {
                 if !info.is_virtual() {
                     return None;
                 }
-                if !is_typeptr {
+                if !field_descr.is_header_field() {
                     let parent_descr = field_descr.get_parent_descr().expect(
-                        "optimize_setfield_gc: non-typeptr FieldDescr.get_parent_descr() returned None",
+                        "optimize_setfield_gc: non-header FieldDescr.get_parent_descr() returned None",
                     );
                     info.init_fields(parent_descr.clone(), field_idx as usize);
                 }
@@ -835,6 +835,35 @@ impl OptVirtualize {
                                     vinfo.known_class = Some(class_val as i64);
                                 }
                             return Some(OptimizationResult::Remove);
+                        }
+                        // PyPy's typeptr never enters `_fields`: its class
+                        // identity is metadata on InstancePtrInfo and the GC
+                        // allocation writes the header.  Pyre has a second,
+                        // Python-level class header (`PyObject.w_class`) that
+                        // must obey the same boundary.  Its descriptor carries
+                        // a placeholder positional index because it is absent
+                        // from `SizeDescr::all_fielddescrs`; storing it in
+                        // `fields` aliases the first payload slot.
+                        //
+                        // If NEW_WITH_VTABLE already writes this exact class,
+                        // the store is redundant.  Otherwise leave the op to
+                        // normal emission: `_emit_operation` forces the
+                        // virtual first and then preserves the real header
+                        // write.  A dynamic class takes that conservative arm
+                        // as well.  This mirrors virtualize.py
+                        // `optimize_SETFIELD_GC` while adapting pyre's extra
+                        // header without inventing an RPython-side field slot.
+                        if field_descr.is_w_class() {
+                            let covered = w_class_value_is_covered_by_alloc(
+                                &vinfo.descr,
+                                &setfield_descr_arc,
+                                value_as_constant.map(|value| Value::Ref(majit_ir::GcRef(value))),
+                            );
+                            return Some(if covered {
+                                OptimizationResult::Remove
+                            } else {
+                                OptimizationResult::PassOn
+                            });
                         }
                         set_field(&mut vinfo.fields, field_idx, value_op.clone());
                         if let Some(err) =
@@ -2914,6 +2943,20 @@ mod tests {
         idx: u32,
     }
 
+    #[derive(Debug)]
+    struct TestWClassSizeDescr {
+        w_class: i64,
+        class_word: Arc<dyn FieldDescr>,
+        all_fields: Vec<Arc<dyn FieldDescr>>,
+        gc_fields: Vec<Arc<dyn FieldDescr>>,
+    }
+
+    #[derive(Debug)]
+    struct TestWClassFieldDescr;
+
+    #[derive(Debug)]
+    struct TestPayloadFieldDescr;
+
     impl Descr for TestSizeDescr {
         fn index(&self) -> u32 {
             self.idx
@@ -2933,6 +2976,108 @@ mod tests {
         fn is_immutable(&self) -> bool {
             false
         }
+    }
+
+    impl Descr for TestWClassSizeDescr {
+        fn as_size_descr(&self) -> Option<&dyn majit_ir::SizeDescr> {
+            Some(self)
+        }
+    }
+
+    impl majit_ir::SizeDescr for TestWClassSizeDescr {
+        fn size(&self) -> usize {
+            24
+        }
+        fn type_id(&self) -> u32 {
+            77
+        }
+        fn is_immutable(&self) -> bool {
+            false
+        }
+        fn vtable(&self) -> usize {
+            0xDEAD
+        }
+        fn w_class_obj(&self) -> Option<i64> {
+            Some(self.w_class)
+        }
+        fn all_fielddescrs(&self) -> &[Arc<dyn FieldDescr>] {
+            &self.all_fields
+        }
+        fn gc_fielddescrs(&self) -> &[Arc<dyn FieldDescr>] {
+            &self.gc_fields
+        }
+        fn class_word_field(&self) -> Option<&Arc<dyn FieldDescr>> {
+            Some(&self.class_word)
+        }
+    }
+
+    impl Descr for TestWClassFieldDescr {
+        fn as_field_descr(&self) -> Option<&dyn FieldDescr> {
+            Some(self)
+        }
+    }
+
+    impl FieldDescr for TestWClassFieldDescr {
+        fn index_in_parent(&self) -> usize {
+            0
+        }
+        fn offset(&self) -> usize {
+            8
+        }
+        fn field_size(&self) -> usize {
+            8
+        }
+        fn field_type(&self) -> Type {
+            Type::Ref
+        }
+        fn is_pointer_field(&self) -> bool {
+            true
+        }
+        fn field_name(&self) -> &str {
+            "pyobject::PyObject.w_class"
+        }
+        fn is_w_class(&self) -> bool {
+            true
+        }
+    }
+
+    impl Descr for TestPayloadFieldDescr {
+        fn as_field_descr(&self) -> Option<&dyn FieldDescr> {
+            Some(self)
+        }
+    }
+
+    impl FieldDescr for TestPayloadFieldDescr {
+        fn get_parent_descr(&self) -> Option<DescrRef> {
+            None
+        }
+        fn index_in_parent(&self) -> usize {
+            0
+        }
+        fn offset(&self) -> usize {
+            16
+        }
+        fn field_size(&self) -> usize {
+            8
+        }
+        fn field_type(&self) -> Type {
+            Type::Int
+        }
+        fn field_name(&self) -> &str {
+            "W_LongObject.value"
+        }
+    }
+
+    fn w_class_layout(default_w_class: usize) -> (DescrRef, DescrRef, DescrRef) {
+        let w_class: Arc<dyn FieldDescr> = Arc::new(TestWClassFieldDescr);
+        let payload: Arc<dyn FieldDescr> = Arc::new(TestPayloadFieldDescr);
+        let size: DescrRef = Arc::new(TestWClassSizeDescr {
+            w_class: default_w_class as i64,
+            class_word: w_class.clone(),
+            all_fields: vec![payload.clone()],
+            gc_fields: vec![w_class.clone()],
+        });
+        (size, w_class as DescrRef, payload as DescrRef)
     }
 
     #[derive(Debug)]
@@ -4173,6 +4318,59 @@ mod tests {
         assign_positions(&mut ops);
         let result = run_pass(&ops);
         assert!(result.is_empty(), "NEW_WITH_VTABLE should be removed");
+    }
+
+    #[test]
+    fn test_w_class_header_does_not_alias_first_payload_slot() {
+        // Pyre's embedded PyObject header is not part of the positional field
+        // list, just as PyPy's typeptr is excluded by all_fielddescrs().  Its
+        // placeholder index 0 must therefore never address payload slot 0.
+        // A class different from the allocation default forces the virtual and
+        // preserves the real header write.
+        let (sd, w_class_fd, _) = w_class_layout(0xCAFE);
+        let mut ops = vec![
+            Op::with_descr(OpCode::NewWithVtable, &[], sd),
+            Op::with_descr(
+                OpCode::SetfieldGc,
+                &[
+                    crate::history::test_support::rooted_resop_operand(Type::Ref, 0),
+                    Operand::const_from_value(Value::Ref(majit_ir::GcRef(0xBEEF))),
+                ],
+                w_class_fd,
+            ),
+        ];
+        assign_positions(&mut ops);
+
+        let result = run_pass(&ops);
+        assert_eq!(
+            result.iter().map(|op| op.opcode).collect::<Vec<_>>(),
+            vec![OpCode::NewWithVtable, OpCode::SetfieldGc]
+        );
+        assert_eq!(
+            result[1]
+                .getdescr()
+                .and_then(|descr| descr.as_field_descr().map(|fd| fd.offset())),
+            Some(8)
+        );
+    }
+
+    #[test]
+    fn test_w_class_header_store_covered_by_allocation_stays_virtual() {
+        let (sd, w_class_fd, _) = w_class_layout(0xCAFE);
+        let mut ops = vec![
+            Op::with_descr(OpCode::NewWithVtable, &[], sd),
+            Op::with_descr(
+                OpCode::SetfieldGc,
+                &[
+                    crate::history::test_support::rooted_resop_operand(Type::Ref, 0),
+                    Operand::const_from_value(Value::Ref(majit_ir::GcRef(0xCAFE))),
+                ],
+                w_class_fd,
+            ),
+        ];
+        assign_positions(&mut ops);
+
+        assert!(run_pass(&ops).is_empty());
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -838,22 +838,33 @@ impl OptVirtualize {
                         }
                         // PyPy's typeptr never enters `_fields`: its class
                         // identity is metadata on InstancePtrInfo and the GC
-                        // allocation writes the header.  Pyre has a second,
-                        // Python-level class header (`PyObject.w_class`) that
-                        // must obey the same boundary.  Its descriptor carries
-                        // a placeholder positional index because it is absent
-                        // from `SizeDescr::all_fielddescrs`; storing it in
-                        // `fields` aliases the first payload slot.
+                        // allocation writes the header.  Pyre's second,
+                        // Python-level class header (`PyObject.w_class`) is
+                        // not one case but two, and the op's own descr cannot
+                        // tell them apart: the tracer stores through a shared
+                        // header descr whose `index_in_parent` is 0, which on
+                        // `W_LongObject` names the payload at offset 16 and on
+                        // `W_BaseException` happens to name the class word.
                         //
-                        // If NEW_WITH_VTABLE already writes this exact class,
-                        // the store is redundant.  Otherwise leave the op to
-                        // normal emission: `_emit_operation` forces the
-                        // virtual first and then preserves the real header
-                        // write.  A dynamic class takes that conservative arm
-                        // as well.  This mirrors virtualize.py
-                        // `optimize_SETFIELD_GC` while adapting pyre's extra
-                        // header without inventing an RPython-side field slot.
+                        // Ask the layout instead.  `class_word_index_in_parent`
+                        // is the accessor defined against `all_fielddescrs`,
+                        // the list `force_box` reads this vector back through,
+                        // so a slot it hands out is addressable there by
+                        // construction and a layout that keeps its class word
+                        // out of that list answers `None`.
                         if field_descr.is_w_class() {
+                            if let Some(slot) = vinfo
+                                .descr
+                                .as_size_descr()
+                                .and_then(|size| size.class_word_index_in_parent())
+                            {
+                                set_field(&mut vinfo.fields, slot as u32, value_op.clone());
+                                return Some(OptimizationResult::Remove);
+                            }
+                            // No slot to record against.  A store NEW_WITH_VTABLE
+                            // already makes is still redundant; anything else
+                            // goes to normal emission, which forces the virtual
+                            // first and then preserves the real header write.
                             let covered = w_class_value_is_covered_by_alloc(
                                 &vinfo.descr,
                                 &setfield_descr_arc,
@@ -3080,6 +3091,53 @@ mod tests {
         (size, w_class as DescrRef, payload as DescrRef)
     }
 
+    /// The class word of a layout that lists it: `all_fielddescrs` holds it
+    /// behind the payload, so it owns slot 1 the way `W_BaseException` does.
+    #[derive(Debug)]
+    struct TestListedWClassFieldDescr;
+
+    impl Descr for TestListedWClassFieldDescr {
+        fn as_field_descr(&self) -> Option<&dyn FieldDescr> {
+            Some(self)
+        }
+    }
+
+    impl FieldDescr for TestListedWClassFieldDescr {
+        fn index_in_parent(&self) -> usize {
+            1
+        }
+        fn offset(&self) -> usize {
+            8
+        }
+        fn field_size(&self) -> usize {
+            8
+        }
+        fn field_type(&self) -> Type {
+            Type::Ref
+        }
+        fn is_pointer_field(&self) -> bool {
+            true
+        }
+        fn field_name(&self) -> &str {
+            "pyobject::PyObject.w_class"
+        }
+        fn is_w_class(&self) -> bool {
+            true
+        }
+    }
+
+    fn w_class_listed_layout(default_w_class: usize) -> (DescrRef, DescrRef) {
+        let w_class: Arc<dyn FieldDescr> = Arc::new(TestListedWClassFieldDescr);
+        let payload: Arc<dyn FieldDescr> = Arc::new(TestPayloadFieldDescr);
+        let size: DescrRef = Arc::new(TestWClassSizeDescr {
+            w_class: default_w_class as i64,
+            class_word: w_class.clone(),
+            all_fields: vec![payload, w_class.clone()],
+            gc_fields: vec![w_class.clone()],
+        });
+        (size, w_class as DescrRef)
+    }
+
     #[derive(Debug)]
     struct TestFieldDescr {
         idx: u32,
@@ -4351,6 +4409,33 @@ mod tests {
                 .getdescr()
                 .and_then(|descr| descr.as_field_descr().map(|fd| fd.offset())),
             Some(8)
+        );
+    }
+
+    #[test]
+    fn a_listed_class_word_is_recorded_at_its_own_slot_and_stays_virtual() {
+        // The layout lists its class word, so it owns a slot of
+        // `all_fielddescrs` like any other field and the store belongs in
+        // `fields` at that slot -- not at the 0 the shared header descr
+        // carries, which here names the payload.  Forcing instead costs a
+        // guard failure and a bridge per iteration on every layout that raises.
+        let (sd, w_class_fd) = w_class_listed_layout(0xCAFE);
+        let mut ops = vec![
+            Op::with_descr(OpCode::NewWithVtable, &[], sd),
+            Op::with_descr(
+                OpCode::SetfieldGc,
+                &[
+                    crate::history::test_support::rooted_resop_operand(Type::Ref, 0),
+                    Operand::const_from_value(Value::Ref(majit_ir::GcRef(0xBEEF))),
+                ],
+                w_class_fd,
+            ),
+        ];
+        assign_positions(&mut ops);
+
+        assert!(
+            run_pass(&ops).is_empty(),
+            "a class word with a slot of its own must not force the virtual"
         );
     }
 

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -306,6 +306,11 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
         crate::runtime_names::modules::MALLOC_TYPED_MANAGED,
         malloc_typed_alloc,
     );
+    analyzer_for(
+        &mut reg,
+        crate::runtime_names::modules::MALLOC_TYPED_STABLE,
+        malloc_typed_alloc,
+    );
     // `pyre_object::lltype::malloc_raw` — the raw (non-GC) allocation
     // intrinsic (`lltype.malloc(T, flavor='raw')` parity).  Recognising it
     // as a builtin keeps its `Box::new` / `Box::into_raw` body out of the

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3596,6 +3596,40 @@ impl crate::translator::rtyper::lltypesystem::llmemory::OffsetLayout for NoStruc
     }
 }
 
+/// Whether `owner` names one of the three enum variants `front/mir` gives an
+/// explicit `[tag@0 | payload@8]` shell to.
+///
+/// `front/mir` admits every spelling from the bare `Result::Ok` up to the fully
+/// qualified `std::result::Result::Ok`, and `canonical_struct_name` keeps
+/// whichever the call site used, so this accepts each of them -- but as a
+/// *suffix of the whole path*, matched segment by segment against a `core` or
+/// `std` root.  A plain `ends_with` also admits a user enum declared at
+/// `mycrate::option::Option::Some`, which `front::option_ctor` never gives a
+/// shell to; its payload would then be described at offset 8 behind an injected
+/// discriminant rather than at its registered native layout.  Anchoring at the
+/// root rejects that while keeping every real spelling, the same reason
+/// [`crate::front::option_ctor::option_variant_ctor_tag`] anchors its own head.
+///
+/// A lone leaf (`Ok`) is not enough: the shortest form `front/mir` produces
+/// names the enum as well as the variant.
+fn is_explicit_shell_variant_owner(owner: &str) -> bool {
+    const SHELLED: [&[&str]; 6] = [
+        &["core", "result", "Result", "Ok"],
+        &["std", "result", "Result", "Ok"],
+        &["core", "result", "Result", "Err"],
+        &["std", "result", "Result", "Err"],
+        &["core", "option", "Option", "Some"],
+        &["std", "option", "Option", "Some"],
+    ];
+    let segments: Vec<&str> = owner.split("::").collect();
+    if segments.len() < 2 {
+        return false;
+    }
+    SHELLED
+        .iter()
+        .any(|path| segments.len() <= path.len() && segments == path[path.len() - segments.len()..])
+}
+
 pub(crate) fn bh_size_spec_from_callcontrol(
     cc: &CallControl,
     owner: &str,
@@ -3635,12 +3669,7 @@ pub(crate) fn bh_size_spec_from_callcontrol(
     // blackhole must reconstruct the same inherited tag slot or the payload
     // takes slot 0 here while living at byte 8 there.  `None` carries no
     // payload row, so it needs no reconstruction.
-    let result_variant = layout_owner.ends_with("result::Result::Ok")
-        || layout_owner.ends_with("result::Result::Err")
-        || layout_owner.ends_with("option::Option::Some")
-        || layout_owner == "Result::Ok"
-        || layout_owner == "Result::Err"
-        || layout_owner == "Option::Some";
+    let result_variant = is_explicit_shell_variant_owner(layout_owner);
     // The bare Charon variant can contain only the inherited enum tag while
     // the annotator keeps the payload row on the concrete instantiation
     // (`Result<PyObjectRef, PyError>::Ok`).  RPython has one concrete low-level
@@ -5921,6 +5950,64 @@ mod tests {
             majit_ir::descr::ArrayFlag::Pointer
         );
         assert_eq!(spec.all_fielddescrs[1].index_in_parent, 1);
+    }
+
+    /// A user enum whose path merely ends in `option::Option::Some` gets no
+    /// shell: `front::option_ctor` never writes a tag for it, so its payload
+    /// stays where its own registered layout puts it.
+    #[test]
+    fn a_lookalike_variant_owner_keeps_its_native_layout() {
+        use crate::call::CallControl;
+
+        let owner = "mycrate::option::Option<*mut PyObject>::Some";
+        let mut cc = CallControl::new();
+        let mut struct_fields = crate::front::StructFieldRegistry::default();
+        struct_fields.fields.insert(
+            "mycrate::option::Option::Some".to_string(),
+            vec![("__pos_0".to_string(), "*mut PyObject".to_string())],
+        );
+        cc.set_struct_fields(struct_fields);
+
+        let spec = bh_size_spec_from_callcontrol(&cc, owner).expect("lookalike variant size");
+        assert_eq!(spec.size, 8);
+        assert_eq!(spec.all_fielddescrs.len(), 1);
+        assert_eq!(spec.all_fielddescrs[0].field_key(), "__pos_0");
+        assert_eq!(spec.all_fielddescrs[0].offset, 0);
+        assert_eq!(spec.all_fielddescrs[0].index_in_parent, 0);
+    }
+
+    /// Every spelling `front::mir` admits reaches the shell, and only a path
+    /// rooted at `core`/`std` (or short enough to have no root of its own)
+    /// does.  `synthetic_result_ctor_identity_accepts_qualified_spellings`
+    /// pins the same list on the producer side.
+    #[test]
+    fn the_shelled_variant_owners_are_every_rooted_spelling() {
+        for owner in [
+            "Result::Ok",
+            "result::Result::Ok",
+            "std::result::Result::Ok",
+            "core::result::Result::Ok",
+            "Result::Err",
+            "result::Result::Err",
+            "std::result::Result::Err",
+            "core::result::Result::Err",
+            "Option::Some",
+            "option::Option::Some",
+            "std::option::Option::Some",
+            "core::option::Option::Some",
+        ] {
+            assert!(is_explicit_shell_variant_owner(owner), "{owner}");
+        }
+        for owner in [
+            "Ok",
+            "Some",
+            "Option::None",
+            "StepResult::Continue",
+            "mycrate::option::Option::Some",
+            "mycrate::core::option::Option::Some",
+        ] {
+            assert!(!is_explicit_shell_variant_owner(owner), "{owner}");
+        }
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/codewriter.rs
+++ b/majit/majit-translate/src/codewriter/codewriter.rs
@@ -829,14 +829,28 @@ impl CodeWriter {
             // `getkind(v.concretetype)` verbatim.  Reading from the
             // Variable matches the upstream's "type-source" provenance
             // instead of going through regalloc as a side-channel.
-            for arg in &start_block.inputargs {
+            for (index, arg) in start_block.inputargs.iter().enumerate() {
                 use crate::model::ConcreteType;
                 let class = match crate::model::FunctionGraph::concretetype_of(arg) {
                     ConcreteType::Signed => 'i',
                     ConcreteType::GcRef => 'r',
                     ConcreteType::Float => 'f',
                     ConcreteType::Void => 'v',
-                    ConcreteType::Unknown => 'v',
+                    // `getkind` raises for a type it cannot classify rather
+                    // than answering.  Answering `'v'` describes the argument
+                    // as absent, so the residual call would pass one word
+                    // fewer than the callee reads — a wrong register count at
+                    // call time instead of a build error.  `Unknown` is also
+                    // the state a `Variable` starts in, so an inputarg that
+                    // reaches here unresolved is a front-end gap, not a type
+                    // outside the kind space.  Measured over the whole image:
+                    // of 2948 graphs the classified arms answer 3883 `r`,
+                    // 498 `i`, 7 `f` and 0 `v`, and this one is never taken.
+                    ConcreteType::Unknown => panic!(
+                        "{}: start-block inputarg {index} has no concrete type, \
+                         so `getkind` has no kind to project",
+                        rewritten_graph.name
+                    ),
                 };
                 arg_classes.push(class);
             }
@@ -1243,7 +1257,45 @@ fn graph_result_kind(graph: &FunctionGraph) -> char {
         ConcreteType::GcRef => 'r',
         ConcreteType::Float => 'f',
         ConcreteType::Void => 'v',
-        ConcreteType::Unknown => 'v',
+        // Same reason as the inputarg projection above: `'v'` is the kind of
+        // a function that returns nothing, so answering it for an unresolved
+        // type tells every caller to discard a result the callee does
+        // produce.  Never taken over the image — the four classified arms
+        // answer 4096 `r`, 906 `i`, 552 `v` and 30 `f`.
+        ConcreteType::Unknown => panic!(
+            "{}: returnblock inputarg has no concrete type, so `getkind` has \
+             no kind to project",
+            graph.name
+        ),
+    }
+}
+
+#[cfg(test)]
+mod result_kind_tests {
+    use super::*;
+    use crate::model::ConcreteType;
+
+    /// The refusal above is never taken over the built image, so this is what
+    /// keeps it armed: a graph still carrying the pre-rtyper `returnvar` has
+    /// no `concretetype` cell set, which is the same `Unknown` an unresolved
+    /// front-end type would present.
+    #[test]
+    #[should_panic(expected = "returnblock inputarg has no concrete type")]
+    fn an_unresolved_return_type_is_refused() {
+        let graph = FunctionGraph::new("unresolved_return");
+        let _ = graph_result_kind(&graph);
+    }
+
+    /// Control for the above: the same shape with the cell set projects the
+    /// kind rather than refusing, so the test pair separates "no kind" from
+    /// "this graph shape".
+    #[test]
+    fn a_resolved_return_type_is_projected() {
+        let mut graph = FunctionGraph::new("resolved_return");
+        let var = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let returnblock = graph.returnblock;
+        graph.block_mut(returnblock).inputargs = vec![var];
+        assert_eq!(graph_result_kind(&graph), 'i');
     }
 }
 

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -2339,6 +2339,10 @@ impl HostEnv {
             "malloc_typed_managed",
             HostObject::new_builtin_callable(crate::runtime_names::modules::MALLOC_TYPED_MANAGED),
         );
+        lltype_module.module_set(
+            "malloc_typed_stable",
+            HostObject::new_builtin_callable(crate::runtime_names::modules::MALLOC_TYPED_STABLE),
+        );
         // `pyre_object::lltype::malloc_raw` — the raw (non-GC) allocation
         // intrinsic (`lltype.malloc(T, flavor='raw')` parity).  Exposed as a
         // host builtin so its `Box::new` body is never looked-inside; the

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -3168,7 +3168,7 @@ pub fn fuse_boxing_alloc(
             if segments.len() >= 2
                 && matches!(
                     segments[segments.len() - 1].as_str(),
-                    "malloc_typed" | "malloc_typed_managed"
+                    "malloc_typed" | "malloc_typed_managed" | "malloc_typed_stable"
                 )
                 && segments[segments.len() - 2] == "lltype")
     };
@@ -7704,46 +7704,73 @@ mod tests {
             "ambiguous leaf layout keeps malloc_typed residual"
         );
 
-        let fused = fuse_boxing_alloc(&mut graph, &numeric_boxing_attrs());
-        assert_eq!(fused, 1, "exactly one boxing cluster must fuse");
+        for allocator in [
+            "malloc_typed",
+            "malloc_typed_managed",
+            "malloc_typed_stable",
+        ] {
+            let mut candidate = graph.clone();
+            let allocation = candidate
+                .block_mut(entry)
+                .operations
+                .iter_mut()
+                .find(|op| op.result.as_ref() == Some(&ret))
+                .expect("malloc operation");
+            let OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                ..
+            } = &mut allocation.kind
+            else {
+                panic!("allocation must be a direct call")
+            };
+            *segments.last_mut().expect("allocator leaf") = allocator.to_string();
 
-        let ops = &graph.block(entry).operations;
-        let nwv_pos = ops
-            .iter()
-            .position(|op| {
-                matches!(&op.kind, OpKind::NewWithVtable { owner, .. } if owner == "W_FloatObject")
-            })
-            .expect("NewWithVtable must be emitted");
-        assert_eq!(
-            ops[nwv_pos].result.as_ref(),
-            Some(&ret),
-            "NewWithVtable must reuse the original malloc result register"
-        );
-        match &ops[nwv_pos + 1].kind {
-            OpKind::FieldWrite {
-                base, field, ty, ..
-            } => {
-                assert_eq!(
-                    base, &ret,
-                    "payload store must target the NewWithVtable result"
-                );
-                assert_eq!(field.name, "floatval", "payload field must be floatval");
-                assert_eq!(
-                    *ty,
-                    ValueType::Float,
-                    "payload store must be retyped to Float"
-                );
+            let fused = fuse_boxing_alloc(&mut candidate, &numeric_boxing_attrs());
+            assert_eq!(
+                fused, 1,
+                "{allocator}: exactly one boxing cluster must fuse"
+            );
+
+            let ops = &candidate.block(entry).operations;
+            let nwv_pos = ops
+                .iter()
+                .position(|op| {
+                    matches!(&op.kind, OpKind::NewWithVtable { owner, .. } if owner == "W_FloatObject")
+                })
+                .unwrap_or_else(|| panic!("{allocator}: NewWithVtable must be emitted"));
+            assert_eq!(
+                ops[nwv_pos].result.as_ref(),
+                Some(&ret),
+                "{allocator}: NewWithVtable must reuse the malloc result register"
+            );
+            match &ops[nwv_pos + 1].kind {
+                OpKind::FieldWrite {
+                    base, field, ty, ..
+                } => {
+                    assert_eq!(
+                        base, &ret,
+                        "{allocator}: payload store must target the allocation result"
+                    );
+                    assert_eq!(field.name, "floatval", "payload field must be floatval");
+                    assert_eq!(
+                        *ty,
+                        ValueType::Float,
+                        "payload store must be retyped to Float"
+                    );
+                }
+                other => panic!(
+                    "{allocator}: expected payload FieldWrite after NewWithVtable, got {other:?}"
+                ),
             }
-            other => panic!("expected payload FieldWrite after NewWithVtable, got {other:?}"),
+            assert!(
+                !ops.iter().any(|op| matches!(
+                    &op.kind,
+                    OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if segments.last().map(String::as_str) == Some(allocator)
+                )),
+                "{allocator}: no allocation call may survive the fusion"
+            );
         }
-        assert!(
-            !ops.iter().any(|op| matches!(
-                &op.kind,
-                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
-                    if segments.last().map(String::as_str) == Some("malloc_typed")
-            )),
-            "no malloc_typed call may survive the fusion"
-        );
     }
 
     #[test]

--- a/majit/majit-translate/src/runtime_names.rs
+++ b/majit/majit-translate/src/runtime_names.rs
@@ -120,6 +120,7 @@ pub(crate) mod modules {
     pub(crate) const OBJECT_LLTYPE: &str = "pyre_object.lltype";
     pub(crate) const MALLOC_TYPED: &str = "pyre_object.lltype.malloc_typed";
     pub(crate) const MALLOC_TYPED_MANAGED: &str = "pyre_object.lltype.malloc_typed_managed";
+    pub(crate) const MALLOC_TYPED_STABLE: &str = "pyre_object.lltype.malloc_typed_stable";
     pub(crate) const MALLOC_RAW: &str = "pyre_object.lltype.malloc_raw";
 }
 

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -4752,7 +4752,7 @@ impl OpcodeStepExecutor for PyFrame {
     // ── unary_positive ──
     // PyPy: UNARY_POSITIVE → space.pos(w_value)
     fn unary_positive(&mut self, val: PyObjectRef) -> Result<PyObjectRef, PyError> {
-        crate::baseobjspace::pos(val)
+        crate::opcode_ops::unary_positive_value(val)
     }
 
     // ── list_to_tuple ──

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -964,6 +964,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::jit_unary_invert_value",
         crate::opcode_ops::jit_unary_invert_value,
     );
+    cpa1(
+        &mut entries,
+        "pyre_interpreter::opcode_ops::jit_unary_positive_value",
+        "pyre_interpreter::jit_unary_positive_value",
+        crate::opcode_ops::jit_unary_positive_value,
+    );
     cpa2(
         &mut entries,
         "pyre_interpreter::opcode_ops::jit_getitem",

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -346,6 +346,18 @@ fn push_abi_unsound_alias_pair(
     push_raw_fnaddr(entries, root_path, fnptr);
 }
 
+/// Append one `(path, address)` row, dropping a null address.
+///
+/// Every published address reaches this function through one of three kinds
+/// of caller, and that list is the invariant worth keeping: the checked
+/// publishers above (`p*` / `pa*` / `cp*` / `cpa*` / `up*` / `upa*`), which
+/// read the signature; [`push_word_accessor_alias_pair`], whose address was
+/// checked by `runtime_ops`'s `word_fn_addr!` before the arity lookup erased
+/// it; and the two `push_abi_unsound_*` hatches, which name the part of the
+/// signature the residual ABI cannot express. A new caller belongs in the
+/// first group — a raw call here publishes an address nothing checked, and a
+/// mismatch surfaces as a wrong register count at trace-time call, not as a
+/// build error.
 fn push_raw_fnaddr(
     entries: &mut Vec<(&'static str, i64)>,
     full_path: &'static str,
@@ -357,7 +369,18 @@ fn push_raw_fnaddr(
     }
 }
 
-fn push_alias_pair(
+/// Alias-pair form for an address a `runtime_ops` arity-to-address accessor
+/// already checked.
+///
+/// The accessor selects the helper by a runtime count, so it must erase the
+/// signature before returning, and by the time the address arrives here there
+/// is nothing left for [`ResidualSlot`] / [`ResidualRet`] to read. The check
+/// is not skipped, only moved: each accessor takes its address through
+/// `runtime_ops`'s `word_fn_addr!`, which ascribes the fn item to an explicit
+/// `extern "C" fn(i64, ..) -> i64` first. Publishing through this helper
+/// asserts that the address came from such an accessor; anything else uses
+/// the checked publishers above.
+fn push_word_accessor_alias_pair(
     entries: &mut Vec<(&'static str, i64)>,
     module_path: &'static str,
     root_path: &'static str,
@@ -767,14 +790,15 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     // registers every `(path, fn)` into this link-time slice; iterate it
     // instead of hand-listing ~46 module-qualified paths (which mis-resolve
     // inline-mod spellings and miss per-module `cfg` gates).  Register the
-    // crate-stripped alias too, mirroring `push_alias_pair`, so either
-    // spelling of the residual `FunctionPath` resolves.
+    // crate-stripped alias too, so either spelling of the residual
+    // `FunctionPath` resolves.  The descriptor carries the accessor as a
+    // `fn() -> PyObjectRef` rather than an address, so `p0` checks it the same
+    // way it checks a hand-written publication.
     #[cfg(not(target_arch = "wasm32"))]
     for desc in pyre_object::lltype::PYRE_TYPE_OBJECT_FNADDRS {
-        let fnptr = desc.func as *const ();
-        push_raw_fnaddr(&mut entries, desc.path, fnptr);
+        p0(&mut entries, desc.path, desc.func);
         if let Some((_crate_seg, rest)) = desc.path.split_once("::") {
-            push_raw_fnaddr(&mut entries, rest, fnptr);
+            p0(&mut entries, rest, desc.func);
         }
     }
 
@@ -1873,62 +1897,66 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     // Mixed W_LongObject/W_IntObject descriptors call the dedicated
     // rbigint.int_* operations, preserving PyPy's no-temporary-bigint path.
-    for (path, addr) in [
-        (
-            "pyre_interpreter::objspace::descroperation::jit_bigint_int_add",
-            crate::objspace::descroperation::jit_bigint_int_add as *const (),
-        ),
-        (
-            "pyre_interpreter::objspace::descroperation::jit_bigint_int_sub",
-            crate::objspace::descroperation::jit_bigint_int_sub as *const (),
-        ),
-        (
-            "pyre_interpreter::objspace::descroperation::jit_bigint_int_mul",
-            crate::objspace::descroperation::jit_bigint_int_mul as *const (),
-        ),
-        (
-            "pyre_interpreter::objspace::descroperation::jit_bigint_int_and",
-            crate::objspace::descroperation::jit_bigint_int_and as *const (),
-        ),
-        (
-            "pyre_interpreter::objspace::descroperation::jit_bigint_int_or",
-            crate::objspace::descroperation::jit_bigint_int_or as *const (),
-        ),
-        (
-            "pyre_interpreter::objspace::descroperation::jit_bigint_int_xor",
-            crate::objspace::descroperation::jit_bigint_int_xor as *const (),
-        ),
-    ] {
-        push_raw_fnaddr(&mut entries, path, addr);
-    }
-    for (path, addr) in [
-        (
-            "pyre_interpreter::objspace::descroperation::jit_bigint_int_eq",
-            crate::objspace::descroperation::jit_bigint_int_eq as *const (),
-        ),
-        (
-            "pyre_interpreter::objspace::descroperation::jit_bigint_int_ne",
-            crate::objspace::descroperation::jit_bigint_int_ne as *const (),
-        ),
-        (
-            "pyre_interpreter::objspace::descroperation::jit_bigint_int_lt",
-            crate::objspace::descroperation::jit_bigint_int_lt as *const (),
-        ),
-        (
-            "pyre_interpreter::objspace::descroperation::jit_bigint_int_le",
-            crate::objspace::descroperation::jit_bigint_int_le as *const (),
-        ),
-        (
-            "pyre_interpreter::objspace::descroperation::jit_bigint_int_gt",
-            crate::objspace::descroperation::jit_bigint_int_gt as *const (),
-        ),
-        (
-            "pyre_interpreter::objspace::descroperation::jit_bigint_int_ge",
-            crate::objspace::descroperation::jit_bigint_int_ge as *const (),
-        ),
-    ] {
-        push_raw_fnaddr(&mut entries, path, addr);
-    }
+    cp2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_add",
+        crate::objspace::descroperation::jit_bigint_int_add,
+    );
+    cp2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_sub",
+        crate::objspace::descroperation::jit_bigint_int_sub,
+    );
+    cp2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_mul",
+        crate::objspace::descroperation::jit_bigint_int_mul,
+    );
+    cp2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_and",
+        crate::objspace::descroperation::jit_bigint_int_and,
+    );
+    cp2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_or",
+        crate::objspace::descroperation::jit_bigint_int_or,
+    );
+    cp2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_xor",
+        crate::objspace::descroperation::jit_bigint_int_xor,
+    );
+    cp2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_eq",
+        crate::objspace::descroperation::jit_bigint_int_eq,
+    );
+    cp2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_ne",
+        crate::objspace::descroperation::jit_bigint_int_ne,
+    );
+    cp2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_lt",
+        crate::objspace::descroperation::jit_bigint_int_lt,
+    );
+    cp2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_le",
+        crate::objspace::descroperation::jit_bigint_int_le,
+    );
+    cp2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_gt",
+        crate::objspace::descroperation::jit_bigint_int_gt,
+    );
+    cp2(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_ge",
+        crate::objspace::descroperation::jit_bigint_int_ge,
+    );
     // `bigint_pow_nomod(...)?` is source-level `Result` syntax for
     // RPython's implicit MemoryError edge. The MIR front removes that shell
     // and binds the elidable pointer-ABI payload call here.
@@ -1980,32 +2008,32 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
 
     for (nargs, (module_path, root_path)) in CALLABLE_HELPER_PATHS.iter().enumerate() {
         if let Some(fnptr) = crate::runtime_ops::callable_call_helper(nargs) {
-            push_alias_pair(&mut entries, module_path, root_path, fnptr);
+            push_word_accessor_alias_pair(&mut entries, module_path, root_path, fnptr);
         }
     }
     for (nargs, (module_path, root_path)) in KNOWN_BUILTIN_HELPER_PATHS.iter().enumerate() {
         if let Some(fnptr) = crate::runtime_ops::known_builtin_call_helper(nargs) {
-            push_alias_pair(&mut entries, module_path, root_path, fnptr);
+            push_word_accessor_alias_pair(&mut entries, module_path, root_path, fnptr);
         }
     }
     for (nargs, (module_path, root_path)) in KNOWN_FUNCTION_HELPER_PATHS.iter().enumerate() {
         if let Some(fnptr) = crate::runtime_ops::known_function_call_helper(nargs) {
-            push_alias_pair(&mut entries, module_path, root_path, fnptr);
+            push_word_accessor_alias_pair(&mut entries, module_path, root_path, fnptr);
         }
     }
     for (count, (module_path, root_path)) in LIST_BUILD_HELPER_PATHS.iter().enumerate() {
         if let Some(fnptr) = crate::runtime_ops::list_build_helper(count) {
-            push_alias_pair(&mut entries, module_path, root_path, fnptr);
+            push_word_accessor_alias_pair(&mut entries, module_path, root_path, fnptr);
         }
     }
     for (count, (module_path, root_path)) in TUPLE_BUILD_HELPER_PATHS.iter().enumerate() {
         if let Some(fnptr) = crate::runtime_ops::tuple_build_helper(count) {
-            push_alias_pair(&mut entries, module_path, root_path, fnptr);
+            push_word_accessor_alias_pair(&mut entries, module_path, root_path, fnptr);
         }
     }
     for (count, (module_path, root_path)) in MAP_BUILD_HELPER_PATHS.iter().enumerate() {
         if let Some(fnptr) = crate::runtime_ops::map_build_helper(count) {
-            push_alias_pair(&mut entries, module_path, root_path, fnptr);
+            push_word_accessor_alias_pair(&mut entries, module_path, root_path, fnptr);
         }
     }
 
@@ -2418,9 +2446,9 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         pyerror_to_exc_object,
     );
     // The same materialisation with the `type_error` constructor folded in, so
-    // the raise site carries neither body. The typed local is the only
-    // compile-time check that the trampoline's signature matches the residual
-    // call — `push_alias_pair` performs none.
+    // the raise site carries neither body. The typed local spells the
+    // trampoline's signature at the call site; `cpa1` checks the same thing
+    // through [`ResidualSlot`] / [`ResidualRet`].
     let pyerror_type_error_to_exc_object: extern "C" fn(i64) -> i64 =
         crate::error::__majit_call_target_pyerror_type_error_to_exc_object;
     cpa1(
@@ -2845,7 +2873,7 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     //    under (per `parse::extract_inherent_impl_methods`).
     //
     // `register_macro_helper_trace_fnaddr` strips the leading segment,
-    // so we register both spellings via `push_alias_pair`: the 3-segment
+    // so we register both spellings as an alias pair: the 3-segment
     // input `pyre_interpreter::PyFrame::pop` produces the 2-segment
     // canonical, and the 4-segment input `pyre_interpreter::pyframe::PyFrame::pop`
     // produces the 3-segment module-qualified form.  Without the second
@@ -3011,8 +3039,8 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     // `target_to_path` for a `FunctionPath` returns the segments verbatim,
     // so an in-module bare call resolves to a 1-segment CallPath
     // `["<name>"]` while a cross-module qualified call resolves to
-    // `["pyframe", "<name>"]`.  Use `push_alias_pair` to register both
-    // shapes via the strip-one-segment rule in
+    // `["pyframe", "<name>"]`.  Register both shapes as an alias pair, via
+    // the strip-one-segment rule in
     // `register_macro_helper_trace_fnaddr`.
     let pyframe_get_pycode_fn: unsafe fn(&crate::pyframe::PyFrame) -> *const crate::CodeObject =
         crate::pyframe::pyframe_get_pycode;
@@ -3065,8 +3093,8 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     // `residual_call` ops and the walker's `goto_if_not` bounds-check
     // aborts with `GotoIfNotValueNotConcrete`.
     //
-    // `push_alias_pair` (vs plain `push_raw_fnaddr`) is required because the
-    // in-module call site `load_fast_var_num_to_index(var_num, op_arg)`
+    // The alias pair (vs a single module-qualified path) is required because
+    // the in-module call site `load_fast_var_num_to_index(var_num, op_arg)`
     // inside `pyopcode.rs` resolves to a bare-segment `CallPath`
     // (`["load_fast_var_num_to_index"]`) that the assertion-aware hint
     // walker DOES populate but the module-qualified-only fnaddr
@@ -3093,8 +3121,8 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
 
     // Paired-local index decode helpers for the LoadFastLoadFast /
     // StoreFastLoadFast / StoreFastStoreFast /
-    // LoadFastBorrowLoadFastBorrow arms — same `push_alias_pair`
-    // rationale as `load_fast_var_num_to_index` above.
+    // LoadFastBorrowLoadFastBorrow arms — same alias-pair rationale as
+    // `load_fast_var_num_to_index` above.
     let var_nums_to_first_index: fn(
         crate::bytecode::Arg<crate::bytecode::oparg::VarNums>,
         crate::bytecode::OpArg,

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -5488,6 +5488,32 @@ pub fn pos(a: PyObjectRef) -> PyResult {
         if let Some(result) = try_numeric_unaryop_override(a, "__pos__")? {
             return Ok(result);
         }
+        pos_inner(a)
+    }
+}
+
+/// [`pos`] past its `__pos__` override probe.
+///
+/// Split out so that a trace can descend this body rather than re-emit it by
+/// hand.  The probe is what stops such a descent: its
+/// `needs_numeric_unaryop_dispatch` is `dont_look_inside` and is the second
+/// operation the body executes.  A caller that has already proven an exact
+/// builtin receiver cannot take it, so entering here records the arm that
+/// receiver selects and nothing else.  Every other caller reaches this through
+/// [`pos`] and is unaffected.
+///
+/// Unlike [`invert_inner`] this keeps the `bool` operand: `+True` is a
+/// rewrapping to a plain int, not a deprecation warning.  Unlike [`neg_inner`]
+/// the exact-int and exact-long arms are identity — they return the operand —
+/// matching `_self_unaryop('pos')` / `W_IntObject.int`.
+///
+/// `inline(never)` is load-bearing: `pos` is a one-call wrapper and rustc
+/// otherwise folds this body into `unary_positive_value`, so the codewriter
+/// never mints a graph the walker can descend.  Same knob as
+/// `w_list_append_inner`.
+#[inline(never)]
+pub fn pos_inner(a: PyObjectRef) -> PyResult {
+    unsafe {
         if is_int(a) && !is_bool(a) && pyre_object::is_exact_builtin_instance(a) {
             // `_self_unaryop('pos')` delegates to `W_IntObject.int`, which
             // returns `self` for the exact builtin representation.  `bool`

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -977,6 +977,17 @@ pub extern "C" fn jit_unary_invert_value(value: i64) -> i64 {
 }
 
 #[majit_macros::jit_may_force]
+pub extern "C" fn jit_unary_positive_value(value: i64) -> i64 {
+    match unary_positive_value(value as PyObjectRef) {
+        Ok(result) => result as i64,
+        Err(mut err) => {
+            crate::runtime_ops::jit_publish_exception(err.to_exc_object());
+            0
+        }
+    }
+}
+
+#[majit_macros::jit_may_force]
 pub extern "C" fn jit_getitem(obj: i64, index: i64) -> i64 {
     match getitem(obj as PyObjectRef, index as PyObjectRef) {
         Ok(value) => value as i64,

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1741,12 +1741,13 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
     }
 
     // ── Intrinsic helper methods ──
+    /// Declared without a body: a default would be the graph the tracer walks,
+    /// and the implementing type's version would never be seen.  `+x` compiles
+    /// to `CALL_INTRINSIC_1`, so this method is the whole route to `pos`.
     fn unary_positive(
         &mut self,
-        _val: <Self as SharedOpcodeHandler>::Value,
-    ) -> Result<<Self as SharedOpcodeHandler>::Value, PyError> {
-        Err(crate::PyError::type_error("unary_positive not implemented"))
-    }
+        val: <Self as SharedOpcodeHandler>::Value,
+    ) -> Result<<Self as SharedOpcodeHandler>::Value, PyError>;
     fn list_to_tuple(
         &mut self,
         _val: <Self as SharedOpcodeHandler>::Value,

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1050,47 +1050,103 @@ define_flat_ref_helper!(
     arg7
 );
 
+/// Take a helper's residual-call address with its word signature spelled out.
+///
+/// The arity-to-address accessors below erase the signature, so the checked
+/// publishers in `jit_fnaddr` (`ResidualSlot` / `ResidualRet`) never see it and
+/// cannot reject a helper the residual ABI is unable to describe.  Ascribing
+/// the fn item to an explicit `extern "C" fn(i64, ..) -> i64` pointer restores
+/// that check at the one point where the type still exists: a helper whose
+/// parameters or result stop being machine words fails to compile here instead
+/// of being published and then called with the wrong number of registers.
+///
+/// The second argument is the helper's machine-argument count, which is not
+/// the Python argument count the accessor matches on: a `jit_call_callable_N`
+/// carries the frame and the callable ahead of its `N` arguments, a
+/// `jit_call_known_builtin_N` carries the callable, and a `jit_build_map_N`
+/// takes a key and a value per pair.  Getting that count wrong is the same
+/// build error as a helper drifting off the word ABI: writing `3` for
+/// `jit_call_callable_2` reports `non-primitive cast: extern "C" fn(i64, i64,
+/// i64, i64) -> i64 {jit_call_callable_2} as extern "C" fn(i64, i64, i64) ->
+/// i64`, naming the call site.  That is how the check is exercised without a
+/// helper that actually violates it.
+macro_rules! word_fn_addr {
+    ($f:ident, 0) => {
+        $f as extern "C" fn() -> i64 as *const ()
+    };
+    ($f:ident, 1) => {
+        $f as extern "C" fn(i64) -> i64 as *const ()
+    };
+    ($f:ident, 2) => {
+        $f as extern "C" fn(i64, i64) -> i64 as *const ()
+    };
+    ($f:ident, 3) => {
+        $f as extern "C" fn(i64, i64, i64) -> i64 as *const ()
+    };
+    ($f:ident, 4) => {
+        $f as extern "C" fn(i64, i64, i64, i64) -> i64 as *const ()
+    };
+    ($f:ident, 5) => {
+        $f as extern "C" fn(i64, i64, i64, i64, i64) -> i64 as *const ()
+    };
+    ($f:ident, 6) => {
+        $f as extern "C" fn(i64, i64, i64, i64, i64, i64) -> i64 as *const ()
+    };
+    ($f:ident, 7) => {
+        $f as extern "C" fn(i64, i64, i64, i64, i64, i64, i64) -> i64 as *const ()
+    };
+    ($f:ident, 8) => {
+        $f as extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64) -> i64 as *const ()
+    };
+    ($f:ident, 9) => {
+        $f as extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64 as *const ()
+    };
+    ($f:ident, 10) => {
+        $f as extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64 as *const ()
+    };
+}
+
 pub fn callable_call_helper(nargs: usize) -> Option<*const ()> {
     Some(match nargs {
-        0 => jit_call_callable_0 as *const (),
-        1 => jit_call_callable_1 as *const (),
-        2 => jit_call_callable_2 as *const (),
-        3 => jit_call_callable_3 as *const (),
-        4 => jit_call_callable_4 as *const (),
-        5 => jit_call_callable_5 as *const (),
-        6 => jit_call_callable_6 as *const (),
-        7 => jit_call_callable_7 as *const (),
-        8 => jit_call_callable_8 as *const (),
+        0 => word_fn_addr!(jit_call_callable_0, 2),
+        1 => word_fn_addr!(jit_call_callable_1, 3),
+        2 => word_fn_addr!(jit_call_callable_2, 4),
+        3 => word_fn_addr!(jit_call_callable_3, 5),
+        4 => word_fn_addr!(jit_call_callable_4, 6),
+        5 => word_fn_addr!(jit_call_callable_5, 7),
+        6 => word_fn_addr!(jit_call_callable_6, 8),
+        7 => word_fn_addr!(jit_call_callable_7, 9),
+        8 => word_fn_addr!(jit_call_callable_8, 10),
         _ => return None,
     })
 }
 
 pub fn known_builtin_call_helper(nargs: usize) -> Option<*const ()> {
     Some(match nargs {
-        0 => jit_call_known_builtin_0 as *const (),
-        1 => jit_call_known_builtin_1 as *const (),
-        2 => jit_call_known_builtin_2 as *const (),
-        3 => jit_call_known_builtin_3 as *const (),
-        4 => jit_call_known_builtin_4 as *const (),
-        5 => jit_call_known_builtin_5 as *const (),
-        6 => jit_call_known_builtin_6 as *const (),
-        7 => jit_call_known_builtin_7 as *const (),
-        8 => jit_call_known_builtin_8 as *const (),
+        0 => word_fn_addr!(jit_call_known_builtin_0, 1),
+        1 => word_fn_addr!(jit_call_known_builtin_1, 2),
+        2 => word_fn_addr!(jit_call_known_builtin_2, 3),
+        3 => word_fn_addr!(jit_call_known_builtin_3, 4),
+        4 => word_fn_addr!(jit_call_known_builtin_4, 5),
+        5 => word_fn_addr!(jit_call_known_builtin_5, 6),
+        6 => word_fn_addr!(jit_call_known_builtin_6, 7),
+        7 => word_fn_addr!(jit_call_known_builtin_7, 8),
+        8 => word_fn_addr!(jit_call_known_builtin_8, 9),
         _ => return None,
     })
 }
 
 pub fn known_function_call_helper(nargs: usize) -> Option<*const ()> {
     Some(match nargs {
-        0 => jit_call_known_function_0 as *const (),
-        1 => jit_call_known_function_1 as *const (),
-        2 => jit_call_known_function_2 as *const (),
-        3 => jit_call_known_function_3 as *const (),
-        4 => jit_call_known_function_4 as *const (),
-        5 => jit_call_known_function_5 as *const (),
-        6 => jit_call_known_function_6 as *const (),
-        7 => jit_call_known_function_7 as *const (),
-        8 => jit_call_known_function_8 as *const (),
+        0 => word_fn_addr!(jit_call_known_function_0, 2),
+        1 => word_fn_addr!(jit_call_known_function_1, 3),
+        2 => word_fn_addr!(jit_call_known_function_2, 4),
+        3 => word_fn_addr!(jit_call_known_function_3, 5),
+        4 => word_fn_addr!(jit_call_known_function_4, 6),
+        5 => word_fn_addr!(jit_call_known_function_5, 7),
+        6 => word_fn_addr!(jit_call_known_function_6, 8),
+        7 => word_fn_addr!(jit_call_known_function_7, 9),
+        8 => word_fn_addr!(jit_call_known_function_8, 10),
         _ => return None,
     })
 }
@@ -1104,41 +1160,41 @@ pub enum FlatBuildKind {
 
 pub fn list_build_helper(count: usize) -> Option<*const ()> {
     Some(match count {
-        0 => jit_build_list_0 as *const (),
-        1 => jit_build_list_1 as *const (),
-        2 => jit_build_list_2 as *const (),
-        3 => jit_build_list_3 as *const (),
-        4 => jit_build_list_4 as *const (),
-        5 => jit_build_list_5 as *const (),
-        6 => jit_build_list_6 as *const (),
-        7 => jit_build_list_7 as *const (),
-        8 => jit_build_list_8 as *const (),
+        0 => word_fn_addr!(jit_build_list_0, 0),
+        1 => word_fn_addr!(jit_build_list_1, 1),
+        2 => word_fn_addr!(jit_build_list_2, 2),
+        3 => word_fn_addr!(jit_build_list_3, 3),
+        4 => word_fn_addr!(jit_build_list_4, 4),
+        5 => word_fn_addr!(jit_build_list_5, 5),
+        6 => word_fn_addr!(jit_build_list_6, 6),
+        7 => word_fn_addr!(jit_build_list_7, 7),
+        8 => word_fn_addr!(jit_build_list_8, 8),
         _ => return None,
     })
 }
 
 pub fn tuple_build_helper(count: usize) -> Option<*const ()> {
     Some(match count {
-        0 => jit_build_tuple_0 as *const (),
-        1 => jit_build_tuple_1 as *const (),
-        2 => jit_build_tuple_2 as *const (),
-        3 => jit_build_tuple_3 as *const (),
-        4 => jit_build_tuple_4 as *const (),
-        5 => jit_build_tuple_5 as *const (),
-        6 => jit_build_tuple_6 as *const (),
-        7 => jit_build_tuple_7 as *const (),
-        8 => jit_build_tuple_8 as *const (),
+        0 => word_fn_addr!(jit_build_tuple_0, 0),
+        1 => word_fn_addr!(jit_build_tuple_1, 1),
+        2 => word_fn_addr!(jit_build_tuple_2, 2),
+        3 => word_fn_addr!(jit_build_tuple_3, 3),
+        4 => word_fn_addr!(jit_build_tuple_4, 4),
+        5 => word_fn_addr!(jit_build_tuple_5, 5),
+        6 => word_fn_addr!(jit_build_tuple_6, 6),
+        7 => word_fn_addr!(jit_build_tuple_7, 7),
+        8 => word_fn_addr!(jit_build_tuple_8, 8),
         _ => return None,
     })
 }
 
 pub fn map_build_helper(pair_count: usize) -> Option<*const ()> {
     Some(match pair_count {
-        0 => jit_build_map_0 as *const (),
-        1 => jit_build_map_1 as *const (),
-        2 => jit_build_map_2 as *const (),
-        3 => jit_build_map_3 as *const (),
-        4 => jit_build_map_4 as *const (),
+        0 => word_fn_addr!(jit_build_map_0, 0),
+        1 => word_fn_addr!(jit_build_map_1, 2),
+        2 => word_fn_addr!(jit_build_map_2, 4),
+        3 => word_fn_addr!(jit_build_map_3, 6),
+        4 => word_fn_addr!(jit_build_map_4, 8),
         _ => return None,
     })
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -366,7 +366,6 @@ spec_folds! {
     TruthInt             => ("truth_int",                "residual_call", "-"),
     TruthBool            => ("truth_bool",               "residual_call", "-"),
     UnaryPositiveInt     => ("unary_positive_int",       "residual_call", "-"),
-    UnaryNegativeInt     => ("unary_negative_int",       "residual_call", "-"),
     UnaryInvertDescent   => ("unary_invert_descent",     "residual_call", "-"),
     UnaryNegativeDescent => ("unary_negative_descent",   "residual_call", "-"),
     StoreSubscr          => ("store_subscr",             "residual_call", "-"),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -366,6 +366,7 @@ spec_folds! {
     TruthInt             => ("truth_int",                "residual_call", "-"),
     TruthBool            => ("truth_bool",               "residual_call", "-"),
     UnaryPositiveInt     => ("unary_positive_int",       "residual_call", "-"),
+    UnaryPositiveDescent => ("unary_positive_descent",   "residual_call", "-"),
     UnaryInvertDescent   => ("unary_invert_descent",     "residual_call", "-"),
     UnaryNegativeDescent => ("unary_negative_descent",   "residual_call", "-"),
     StoreSubscr          => ("store_subscr",             "residual_call", "-"),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -5494,12 +5494,13 @@ fn walk_body_has_exception_handler<Sym: WalkSym>(
     })
 }
 
-/// PyPy `_opimpl_residual_call{1,2,3}` (pyjitpl.py) port
-/// for the **non-elidable** call shapes — companion to
-/// [`try_fold_pure_call_via_executor`] which handles the elidable case.
+/// PyPy `_opimpl_residual_call{1,2,3}` (pyjitpl.py) port for residual calls
+/// not completed by [`try_fold_pure_call_via_executor`].  That fast path
+/// handles cannot-raise elidable calls; can-raise elidable calls continue here
+/// so their exception state is observable.
 ///
 /// Upstream calls `executor.execute_varargs(opnum, argboxes, descr,
-/// exc=can_raise, pure=False)` which dispatches through
+/// exc=can_raise, pure=is_elidable)` which dispatches through
 /// `cpu.bh_call_*` and clears/records BH exception state via
 /// `metainterp.clear_exception()` + `metainterp.execute_raised(...)`.
 /// This walker-friendly counterpart returns `Result<i64, i64>` directly
@@ -5520,13 +5521,13 @@ fn walk_body_has_exception_handler<Sym: WalkSym>(
 /// call regardless of EI.
 ///
 /// **Caller contract**:
-/// * `call_opcode` must be one of the non-elidable residual call shapes:
+/// * `call_opcode` must be one of the residual call shapes:
 ///   `Call{I,R,F,N}` (the default arm), `CallLoopinvariant{I,R,F,N}`
 ///   (the `EF_LOOPINVARIANT` arm), or `CallMayForce{I,R,F,N}` (the
 ///   `forces_virtual_or_virtualizable` arm — only when no active
 ///   virtualizable is present, see force-virtual gate below).
-///   * `CallPure*` is excluded — that's [`try_fold_pure_call_via_executor`]'s
-///     job.
+///   * can-raise `CallPure*` is included; cannot-raise `CallPure*` has already
+///     been handled by [`try_fold_pure_call_via_executor`].
 ///   * `CallReleaseGil*` / `CallAssembler*` are excluded from THIS
 ///     function's direct opcode set, but for distinct reasons:
 ///     - `CallReleaseGil*` IS concrete-executed — `do_residual_call`

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -2396,8 +2396,8 @@ pub(crate) fn ensure_residual_call_args_bound(
 /// skipped via the two narrow branches above) before the trace op
 /// hits the recorder.
 ///
-/// Per-branch concrete-execute status (every non-pure residual call
-/// concrete-executes during the walk, matching
+/// Per-branch concrete-execute status (every residual call with concrete
+/// operands executes during the walk, matching
 /// PyPy `do_residual_call` which runs `executor.execute_varargs` for the
 /// whole forces branch regardless of EI):
 ///
@@ -2406,15 +2406,16 @@ pub(crate) fn ensure_residual_call_args_bound(
 /// | `is_call_release_gil()` | (early-routed to [`direct_call_release_gil`], records `CALL_RELEASE_GIL_*`) | executed as `CallMayForce*` on the **original** `allboxes` via [`try_execute_residual_call_via_executor`] |
 /// | `check_forces_virtual_or_virtualizable()` | `CallMayForce*` + `GuardNotForced` | executed via [`try_execute_residual_call_via_executor`] (active vable bracketed by the token protocol) |
 /// | `extraeffect == LoopInvariant` | `CallLoopinvariant*` | executed on cache miss; [`loopinvariant_lookup`] reuses the cached OpRef on hit (no execute, no record) |
-/// | `check_is_elidable()` | `CallPure*` | executed + cached via [`try_fold_pure_call_via_executor`] (elidable_cannot_raise only — see its caveats) |
+/// | `check_is_elidable()` | `CallPure*` | cannot-raise calls use [`try_fold_pure_call_via_executor`]; can-raise calls use [`try_execute_residual_call_via_executor`] so the exception is transcribed |
 /// | default | `Call*` + (`GuardNoException` iff can_raise) | executed via [`try_execute_residual_call_via_executor`] |
 ///
 /// All three dispatch entry points — [`dispatch_residual_call_iRd_kind`]
 /// (`_opimpl_residual_call1`), [`dispatch_residual_call_iIRd_kind`]
 /// (`_opimpl_residual_call2`), [`dispatch_residual_call_iIRFd_kind`]
 /// (`_opimpl_residual_call3`) — call [`select_residual_call_opcode`],
-/// `record_op_with_descr`, then [`try_fold_pure_call_via_executor`] (pure)
-/// + [`try_execute_residual_call_via_executor`] (non-pure).  The executor
+/// `record_op_with_descr`, then [`try_fold_pure_call_via_executor`] (the
+/// cannot-raise pure fast path) + [`try_execute_residual_call_via_executor`]
+/// (all other calls, including can-raise pure calls).  The executor
 /// self-gates and degrades to recording-only when a precondition fails
 /// (non-authoritative walk, non-const funcbox, unpatched symbolic fnaddr).
 ///
@@ -2512,8 +2513,9 @@ pub(crate) fn select_residual_call_opcode(
 /// regardless of `check_is_elidable()` — the EI flag only selects the
 /// recorded opcode kind (`CALL_PURE_*` vs `CALL_*`), not whether the
 /// helper runs.  This function covers the elidable arm; the
-/// non-elidable arms (`CallMayForce*`, `CallLoopinvariant*`, `Call*`)
-/// are concrete-executed by [`try_execute_residual_call_via_executor`]
+/// remaining arms (`CallMayForce*`, `CallLoopinvariant*`, `Call*`, and
+/// can-raise `CallPure*`) are concrete-executed by
+/// [`try_execute_residual_call_via_executor`]
 /// with raised exceptions surfaced through `BH_LAST_EXC_VALUE` so
 /// `eval_loop_jit` can route them into the bytecode exception handler.
 ///
@@ -3063,35 +3065,23 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
             | OpCode::CallMayForceF
             | OpCode::CallMayForceN
     );
-    // The `CallPure*` shapes reach this dispatcher too, against what the
-    // callers' comments assume: `try_fold_pure_call_via_executor` runs first
-    // and answers only the calls whose every argbox carries a value, and the
-    // rest arrive here.  They are declined like any other opcode this executor
-    // does not run, but they are declined for a different reason and owe a
-    // different follow-up, so name it.
+    // `MIFrame.execute_varargs` executes an elidable call BEFORE it patches the
+    // recorded CALL into CALL_PURE and before `handle_possible_exception`
+    // (`pyjitpl.py`).  The cannot-raise half is already executed by
+    // `try_fold_pure_call_via_executor`; the can-raise half deliberately
+    // reaches this full executor so `BH_LAST_EXC_VALUE` is transcribed into the
+    // walker's exception state instead of being swallowed.
     let is_pure = matches!(
         call_opcode,
         OpCode::CallPureI | OpCode::CallPureR | OpCode::CallPureF | OpCode::CallPureN
     );
-    if is_pure {
-        // Only the CANNOT-raise half is obligation-free.
-        // `select_residual_call_opcode` picks `CallPure*` on
-        // `check_is_elidable()` alone, so `EF_ELIDABLE_CAN_RAISE` arrives
-        // wearing the same opcode, and `try_fold_pure_call_via_executor`
-        // deliberately refuses to run it — there is no metainterp here to
-        // transcribe the exception out of `BH_LAST_EXC_VALUE`.  An elidable
-        // call applies no heap effect either way, but a RAISE is an observable
-        // of its own: waving the can-raise half through opens the no-replay
-        // walk-end roads for a call the interpreter never ran, so the
-        // `ZeroDivisionError` / shift error / `MemoryError` it would have
-        // raised is skipped outright.  Decline it the way every other
-        // unexecuted call is declined, which keeps the replay obligation.
-        if call_descr.get_extra_info().check_can_raise(false) {
-            return Ok(declined_symbolic(call_opcode));
-        }
+    if is_pure && !call_descr.get_extra_info().check_can_raise(false) {
+        // The cannot-raise fast path ran first.  If it could not answer because
+        // an operand was symbolic, keeping CALL_PURE in the trace carries no
+        // missed effect or exception obligation.
         return Ok(ResidualExecOutcome::Declined(ResidualDecline::PureUnfolded));
     }
-    if !plain_or_loopinvariant && !is_may_force {
+    if !plain_or_loopinvariant && !is_may_force && !is_pure {
         return Ok(declined_symbolic(call_opcode));
     }
     if allboxes.is_empty() {
@@ -3251,7 +3241,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         args.push(v);
     }
     // NULL-Ref-arg refusal: same SEGV-avoidance contract as the pure
-    // path (see `try_fold_pure_call_via_executor`'s NULL guard).  Pyre's
+    // fast path (see `try_fold_pure_call_via_executor`'s NULL guard).  Pyre's
     // optimizer emits `guard_nonnull` after this walker fold, so a NULL
     // receiver dereferences before that guard exists; fall through to
     // recording the call op and let the optimizer's guard emission
@@ -5050,7 +5040,7 @@ pub(crate) fn write_residual_call_result_to_dst<Sym: WalkSym>(
     // path that lands a constant result via the executor.execute_varargs
     // stamp) propagates concrete to the dst slot.  Falls back to Null when
     // the result has no recorded concrete (matches the pre-#75.F shape for
-    // every non-elidable call).
+    // every recorded call without an executed concrete result).
     let concrete_for_shadow = concrete_from_recorded_opref(ctx, result);
     match dst_bank {
         'r' => {
@@ -6664,36 +6654,16 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
 
     // UNARY_NEGATIVE.  Descend `neg_inner` -- `neg` past the override probe --
     // rather than re-emit its integer arm by hand, the same shape the invert
-    // descent below takes.  Sits ahead of the `unary_negative_int` fold so that
-    // fold's `consulted` count reads whether the descent took the site.  The
-    // fold is not dead and stays: besides the bool / subclass / non-int operand
-    // it never admitted, it is what serves the `INT_MIN` promotion, which the
-    // descent declines on an unlowered `PyObject` transparent ctor.
+    // descent below takes.  The translated body owns both the ordinary int arm
+    // and the `INT_MIN` promotion through `rbigint.neg` + `W_LongObject`
+    // allocation. Bool, subclass and non-int operands still fall through to
+    // the generic residual so their override semantics are preserved.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && r_args.len() == 1
         && ei.runtime_helper == majit_ir::RuntimeHelperKind::UnaryNegative
         && spec_gate(SpecFold::UnaryNegativeDescent, || {
             try_walker_orthodox_unary_negative(ctx, op.pc, r_args[0], dst, dst_bank)
-        })?
-        .is_some()
-    {
-        return Ok((DispatchOutcome::Continue, op.next_pc));
-    }
-
-    // #61: UNARY_NEGATIVE `-int` fold.  `-x` is `0 - x`; the fold emits
-    // `IntSubOvf(0, x)` behind a `GUARD_CLASS INT` (reusing the binary-sub
-    // overflow discipline), eliding the `CALL_MAY_FORCE`.  A bool / subclass /
-    // non-int, and an `INT_MIN` value (whose negation is the `2**63` long),
-    // decline to the generic leg.
-    if ctx.is_authoritative_executor
-        && dst_bank == 'r'
-        && r_args.len() == 1
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::UnaryNegative
-        && spec_gate(SpecFold::UnaryNegativeInt, || {
-            try_walker_specialize_unary_negative_int(
-                ctx, op.pc, r_args[0], &allboxes, call_descr, dst, dst_bank,
-            )
         })?
         .is_some()
     {
@@ -7526,11 +7496,12 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         // downstream walker chain (sub-jitcode bodies that consume the
         // result via `concrete_of_opref`) folds end-to-end.  No-op when
         // any argbox is symbolic, when the EI can raise, or for non-pure
-        // call opcodes.
+        // call opcodes.  The shared executor below handles the can-raise pure
+        // case and transfers its exception state like `MIFrame.execute_varargs`.
         try_fold_pure_call_via_executor(ctx, call_opcode, &allboxes, call_descr, recorded);
 
         // pyjitpl.py `_opimpl_residual_call{1,2,3}` parity
-        // for the non-elidable shapes.  PyPy
+        // for the remaining shapes.  PyPy
         // concrete-executes EVERY residual call regardless of EI — the
         // `exc` flag only selects the *guard* shape downstream
         // (`handle_possible_exception` → `GUARD_EXCEPTION` vs

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -6634,11 +6634,25 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         }
     }
 
-    // #61: UNARY_POSITIVE `+int` identity fold.  The object-space `pos` on an
-    // exact int returns the operand unchanged, so a provably-int operand folds
-    // to the operand box itself behind a `GUARD_CLASS INT`, eliding the
-    // `CALL_MAY_FORCE` (and its `GUARD_NOT_FORCED` / `GUARD_NO_EXCEPTION`) the
-    // generic residual emits.  A bool (`+True` is int `1`) / non-int operand
+    // UNARY_POSITIVE.  Descend `pos_inner` -- `pos` past the override probe --
+    // rather than re-emit its identity arm by hand, the same shape the invert
+    // and neg descents take.  Sits ahead of the `unary_positive_int` fold so
+    // that fold's `consulted` count reads whether the descent took the site.
+    if ctx.is_authoritative_executor
+        && dst_bank == 'r'
+        && r_args.len() == 1
+        && ei.runtime_helper == majit_ir::RuntimeHelperKind::UnaryPositive
+        && spec_gate(SpecFold::UnaryPositiveDescent, || {
+            try_walker_orthodox_unary_positive(ctx, op.pc, r_args[0], dst, dst_bank)
+        })?
+        .is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
+
+    // #61: UNARY_POSITIVE `+int` identity fold.  Kept behind the descent so a
+    // build whose `pos_inner` jitcode is missing or unlowered still forwards
+    // an exact-int operand.  A bool (`+True` is int `1`) / non-int operand
     // declines to the generic leg so its `__pos__` still runs.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -8235,6 +8235,126 @@ pub(crate) fn try_walker_orthodox_unary_negative<Sym: WalkSym>(
     Ok(Some(()))
 }
 
+/// Descend `pos_inner`'s compiled body for `+x` on an exact builtin `int` or
+/// `long`, instead of re-emitting its identity arm by hand.
+///
+/// The same orthodox shape as [`try_walker_orthodox_unary_invert`] and
+/// [`try_walker_orthodox_unary_negative`].  Upstream traces *through*
+/// `descr_pos`.  The exact-int and exact-long arms are identity: they return
+/// the operand, matching `_self_unaryop('pos')`.
+///
+/// `pos` itself cannot be entered: its `__pos__` override probe is
+/// `dont_look_inside` and is the second operation the body executes.
+/// `pos_inner` is that body past it. Unlike `invert`, `pos` has no bool slot
+/// to step over, so the split leaves the probe alone.
+///
+/// The guards emitted here are what let the caller skip the probe: an `int` or
+/// `long` subclass keeps the builtin `ob_type` but retags `w_class` and may
+/// define `__pos__`, so it must side-exit to the residual, which still runs the
+/// whole of `pos`. `bool` is excluded because `+True` is a rewrapping to a
+/// plain int, not identity, and because [`walker_exact_builtin_class`] has no
+/// value to pin on a singleton.
+pub(crate) fn try_walker_orthodox_unary_positive<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    operand: OpRef,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    let Some(operand_obj) = walker_concrete_ref_object(ctx, operand) else {
+        return Ok(None);
+    };
+    // SAFETY: `operand_obj` is a live concrete `PyObjectRef` from the walker
+    // shadow.
+    let is_long = unsafe { pyre_object::is_long(operand_obj) };
+    let admitted = unsafe {
+        !pyre_object::is_bool(operand_obj)
+            && (is_long || pyre_object::is_int(operand_obj))
+            && pyre_object::is_exact_builtin_instance(operand_obj)
+    };
+    if !admitted {
+        return Ok(None);
+    }
+    // SAFETY: as above.
+    //
+    // This cannot decline for an admitted operand, by the argument
+    // [`try_walker_orthodox_unary_invert`] gives: the only exact builtins born
+    // with a null `w_class` are the five read-only singletons, and the
+    // admission above already rejects every one of them.
+    let Some(operand_class) = (unsafe { walker_exact_builtin_class(operand_obj) }) else {
+        return Ok(None);
+    };
+
+    // Resolve every possible decline before recording a guard.
+    let Some(jc_arc) = crate::jitcode_runtime::pos_inner_jitcode() else {
+        return Ok(None);
+    };
+    let Some(sub_body) = sub_jitcode_body_by_index(jc_arc.index()) else {
+        return Ok(None);
+    };
+    let sym_ptr = ctx.fbw_mode.snapshot_sym;
+    if sym_ptr.is_null() {
+        return Ok(None);
+    }
+    // SAFETY: set for the lifetime of the enclosing full-body walk.
+    if unsafe { (&*sym_ptr).jitcode().is_null() } {
+        return Ok(None);
+    }
+    let sym = unsafe { &*sym_ptr };
+
+    let pre_fold_pos = ctx.trace_ctx.get_trace_position();
+    let type_addr = if is_long {
+        &pyre_object::pyobject::LONG_TYPE as *const _ as i64
+    } else {
+        &pyre_object::pyobject::INT_TYPE as *const _ as i64
+    };
+    walker_guard_class(ctx, op_pc, operand, type_addr)?;
+    walker_guard_exact_w_class(ctx, op_pc, operand, operand_class)?;
+    ctx.trace_ctx.set_opref_concrete(
+        operand,
+        majit_ir::Value::Ref(majit_ir::GcRef(operand_obj as usize)),
+    );
+
+    let walk = run_orthodox_helper_subwalk(
+        ctx,
+        op_pc,
+        sym,
+        &sub_body,
+        "unary_positive_commit",
+        "pos_inner_call_site",
+        &[],
+        &[],
+        &[operand],
+        &[ConcreteValue::Ref(operand_obj)],
+    );
+    let (walk_outcome, _walk_start) = match walk {
+        // The body reached a helper this build did not lower. Both admitted
+        // arms of `pos_inner` are identity reads, so nothing is committed --
+        // cut the tentative IR, with its snapshots, and let the residual (or
+        // the identity fold behind this descent) serve the operator. The two
+        // guards above are emitted with snapshots attached and name the
+        // discarded operation namespace, so leaving them behind would expose
+        // stale boxes to a later remap.
+        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc, .. }) => {
+            if fbw_debug_abort_enabled() {
+                eprintln!("[decline-why] UNARY-POSITIVE-SUBWALK pc={pc}");
+            }
+            ctx.trace_ctx.cut_trace_with_snapshots(pre_fold_pos);
+            ctx.trace_ctx.heap_cache_mut().reset();
+            return Ok(None);
+        }
+        Ok(pair) => pair,
+        Err(error) => return Err(error),
+    };
+    let result = match walk_outcome {
+        DispatchOutcome::SubReturn { result } => finish_inline_callee_return(ctx, result)
+            .ok_or(DispatchError::UnexpectedVoidSubReturn { pc: op_pc })?,
+        _ => return Err(DispatchError::UnexpectedVoidSubReturn { pc: op_pc }),
+    };
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, result)?;
+    Ok(Some(()))
+}
+
 /// `s[i]` on an exact `str` with an exact machine-`int` index: emit the
 /// guarded unbox plus one elidable [`pyre_object::jit_str_getitem`] call
 /// instead of the opaque `bh_binary_op_fn` residual.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -401,87 +401,6 @@ fn walker_emit_ovf2long_box<Sym: WalkSym>(
     Ok(result)
 }
 
-/// #61: walker-native int specialization for the `UNARY_NEGATIVE` residual
-/// (oopspec [`majit_ir::RuntimeHelperKind::UnaryNegative`]).  `-x` on an exact
-/// int is `0 - x`; the object-space `neg` promotes only `-INT_MIN` to a
-/// `W_LongObject` (`intobject.py` `descr_neg` → `_make_ovf2long`).  Since
-/// majit has no overflow-checked unary negate, the fold expresses `-x` as
-/// `IntSubOvf(0, x)` behind a `GUARD_CLASS INT`, reusing the binary-sub
-/// overflow discipline in both directions: a record value other than `INT_MIN`
-/// emits `GUARD_NO_OVERFLOW` so an `INT_MIN` arrival on the reused trace deopts
-/// rather than wrapping back to `INT_MIN`, and a record value of `INT_MIN`
-/// pins the operand with `GUARD_VALUE` and takes the same `_make_ovf2long` tail
-/// the `BINARY_OP` overflow arm takes, so the `2**63` long is built from the
-/// elidable bigint helper instead of the `CallMayForce` residual.
-///
-/// Returns `Ok(Some(()))` when the fold was emitted (caller returns
-/// `Continue`); `Ok(None)` for a bool / subclass / non-int operand, when the
-/// residual result box is unavailable, or when an `INT_MIN` operand did not
-/// produce the promoted `W_LongObject` the payload read expects.
-pub(crate) fn try_walker_specialize_unary_negative_int<Sym: WalkSym>(
-    ctx: &mut WalkContext<'_, '_, Sym>,
-    op_pc: usize,
-    operand: OpRef,
-    allboxes: &[OpRef],
-    call_descr: &dyn majit_ir::descr::CallDescr,
-    dst: usize,
-    dst_bank: char,
-) -> Result<Option<()>, DispatchError> {
-    let Some((x, x_class)) = walker_unary_int_operand(ctx, operand) else {
-        return Ok(None);
-    };
-    let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
-        return Ok(None);
-    };
-    // `0 - INT_MIN` is the one operand `descr_neg` promotes.
-    let overflows = x == i64::MIN;
-    if overflows {
-        let boxed_result_obj = boxed_result_i64 as usize as pyre_object::PyObjectRef;
-        if boxed_result_obj == pyre_object::PY_NULL
-            || !unsafe { pyre_object::is_long(boxed_result_obj) }
-        {
-            return Ok(None);
-        }
-    }
-    let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
-    let x_raw = walker_unbox_int(ctx, op_pc, operand, int_type_addr)?;
-    walker_guard_exact_w_class(ctx, op_pc, operand, x_class)?;
-    let zero_raw = ctx.trace_ctx.const_int(0);
-    let boxed = if overflows {
-        // `0 - x` overflows an i64 for exactly one operand, so "the negate
-        // promoted" and "the operand is INT_MIN" name the same set: guarding
-        // the value admits what `GUARD_OVERFLOW` would and nothing more. The
-        // value form is the one the tail can use — with `x_raw` constant the
-        // elidable bigint call folds to the `2**63` payload it returned while
-        // recording instead of running once per iteration. This is the
-        // `guard_value` spelling the version-tag promotes already use.
-        let int_min = ctx.trace_ctx.const_int(i64::MIN);
-        walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[x_raw, int_min])?;
-        walker_emit_ovf2long_box(
-            ctx,
-            op_pc,
-            pyre_object::longobject::jit_bigint_sub_int_int as *const (),
-            (zero_raw, 0),
-            (x_raw, x),
-            boxed_result_i64,
-        )?
-    } else {
-        let result_value = 0i64.wrapping_sub(x);
-        let raw_result = ctx
-            .trace_ctx
-            .record_op(OpCode::IntSubOvf, &[zero_raw, x_raw]);
-        ctx.trace_ctx
-            .set_opref_concrete(raw_result, majit_ir::Value::Int(result_value));
-        walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoOverflow, &[])?;
-        let boxed = walker_box_int(ctx, op_pc, raw_result, result_value)?;
-        ctx.trace_ctx
-            .set_opref_concrete(boxed, box_int_concrete(result_value, boxed_result_i64));
-        boxed
-    };
-    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
-    Ok(Some(()))
-}
-
 /// #57: walker-native speculative int specialization for the `BINARY_OP`
 /// helper residual_call (oopspec `BinaryOp`).  Re-derives
 /// the former int fast path's structure (`guard_class` + `getfield_gc_i` per
@@ -8200,15 +8119,11 @@ pub(crate) fn try_walker_orthodox_unary_invert<Sym: WalkSym>(
 /// same reason: upstream traces *through* `descr_neg`, which is ordinary
 /// RPython.
 ///
-/// This does NOT retire `unary_negative_int`, and the census says why. Over
-/// the 484-fixture corpus the descent fires on six fixtures and the fold on
-/// one -- `unary_negative.py`'s `main_int_min`, the `INT_MIN` promotion. The
-/// body reaches that through `w_long_new_fresh_rbigint_handle`, and the
-/// sub-walk stops there on a `PyObject` synthetic transparent ctor this build
-/// does not lower, so the descent declines and the fold's `guard_value` +
-/// ovf2long tail still serves it. What the descent does take is every
-/// non-promoting exact `int` and the exact `long` operand, which reached no
-/// fold at all before.
+/// The descent also owns the `INT_MIN` promotion.  `rbigint.neg` stays an
+/// `EF_ELIDABLE_OR_MEMORYERROR` residual, while `W_LongObject.__init__` lowers
+/// to `NewWithVtable` plus its ordinary `w_class` and `value` field writes.
+/// This is the same allocation/body split PyPy's rtyper and metainterp expose;
+/// no unary-negative manual fold remains beside it.
 ///
 /// `neg` itself cannot be entered: its `__neg__` override probe is
 /// `dont_look_inside` and is the second operation the body executes.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -8289,6 +8289,75 @@ extern "C" fn add2_for_walker_test(a: i64, b: i64) -> i64 {
     a.wrapping_add(b)
 }
 
+#[test]
+fn elidable_or_memoryerror_call_executes_and_stamps_its_result() {
+    // `MIFrame.execute_varargs` executes the CALL first and only then patches
+    // it to CALL_PURE / handles the possible exception (`pyjitpl.py`).  The
+    // `EF_ELIDABLE_OR_MEMORYERROR` bigint helpers use this exact shape: they
+    // must not be left recorded-only merely because their opcode is CallPureI.
+    let mut tc = fresh_trace_ctx();
+    let funcbox = tc.const_int(add2_for_walker_test as *const () as i64);
+    let arg0 = tc.const_int(40);
+    let arg1 = tc.const_int(2);
+    let allboxes = [funcbox, arg0, arg1];
+    let descr = make_call_descr(
+        81,
+        vec![Type::Int, Type::Int],
+        Type::Int,
+        majit_ir::ExtraEffect::ElidableOrMemoryError,
+    );
+    let recorded = tc.record_op_with_descr(majit_ir::OpCode::CallPureI, &allboxes, descr.clone());
+    let mut regs_i: Vec<OpRef> = Vec::new();
+    let mut regs_r: Vec<OpRef> = Vec::new();
+    let session = std::cell::RefCell::new(WalkSession::default());
+    let mut wc = WalkContext {
+        callee_shadow: None,
+        inline_callee_consts: None,
+        inline_poison_pcs: None,
+        fbw_mode: test_fbw_mode(),
+        session: &session,
+        registers_r: &mut regs_r,
+        registers_i: &mut regs_i,
+        registers_f: &mut [],
+        concrete_registers_r: &mut [],
+        concrete_registers_i: &mut [],
+        descr_refs: &[],
+        raw_descrs: RawDescrPool::Global,
+        is_authoritative_executor: true,
+        trace_ctx: &mut tc,
+        is_top_level: true,
+        sub_jitcode_lookup: &no_sub_jitcodes,
+        entry_py_pc: EntryPyPc::Py(0),
+        outer_resume_marker_jit_pc: None,
+        outer_jitcode_index: 0,
+        outer_active_boxes: Vec::new(),
+        pending_guard_snapshot_error: None,
+        vstack_boxes: Vec::new(),
+        vstack_depth: 0,
+        vstack_cur_pypc: 0,
+        vstack_valid: false,
+        vstack_last_ref: OpRef::NONE,
+        vstack_reorder_ceiling: u32::MAX,
+        vstack_reorder_saved: None,
+        vstack_handler_landing_py: None,
+        live_before_jit_pc: usize::MAX,
+        live_after_jit_pc: usize::MAX,
+    };
+    let result = try_execute_residual_call_via_executor(
+        &mut wc,
+        majit_ir::OpCode::CallPureI,
+        &allboxes,
+        descr.as_call_descr().expect("CallPureI descr"),
+        recorded,
+        0,
+        None,
+    );
+    drop(wc);
+
+    assert_eq!(result, Ok(ResidualExecOutcome::Executed(Ok(42))));
+    assert_eq!(tc.box_value(recorded), Some(majit_ir::Value::Int(42)));
+}
+
 fn may_force_call_i_fixture(tc: &mut TraceCtx) -> ([OpRef; 3], DescrRef, OpRef) {
     let funcbox = tc.const_int(add2_for_walker_test as *const () as i64);
     let arg0 = tc.const_int(40);

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -406,6 +406,9 @@ thread_local! {
     /// Cached `ALL_JITCODES` index of `neg_inner` for the current thread.
     /// Resolved by graph key, for the reason given above.
     static NEG_INNER_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
+    /// Cached `ALL_JITCODES` index of `pos_inner` for the current thread.
+    /// Resolved by graph key, for the reason given above.
+    static POS_INNER_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
 }
 
 /// Scan the build-time names index for the unique entry equal to `name`.
@@ -542,6 +545,31 @@ pub fn neg_inner_jitcode() -> Option<Arc<JitCode>> {
     let idx = NEG_INNER_JITCODE_INDEX.with(|cell| {
         *cell.get_or_init(|| {
             compute_pathed_jitcode_index("pyre_interpreter::objspace::descroperation::neg_inner")
+        })
+    })?;
+    get_jitcode_by_index(idx)
+}
+
+/// The charon `pos_inner` body in `ALL_JITCODES`, resolved by the graph key the
+/// codewriter allocated it under and cached per thread. `None` if the helper is
+/// absent from the build-time pipeline.
+///
+/// This is `descroperation.rs` `pos` past its `__pos__` override probe -- the
+/// one arm a descent cannot take. What is left is the exact-int identity, the
+/// bool/int rewrap, the long/float/complex arms, the instance fallback and the
+/// terminal `TypeError`, so a caller that has pinned an exact `int` or `long`
+/// receiver records one of the identity arms and nothing else.
+///
+/// `+x` is `CALL_INTRINSIC_1`, so the only route to this body runs through
+/// `OpcodeStepExecutor::unary_positive`, which is declared without a body for
+/// that reason: a default there is the graph the walker takes, and `PyFrame`'s
+/// implementation -- and with it `pos` and `pos_inner` -- is never reached.
+/// `None` here is the helper's absence from the build-time pipeline, and the
+/// identity fold behind the descent still serves exact-int `+x`.
+pub fn pos_inner_jitcode() -> Option<Arc<JitCode>> {
+    let idx = POS_INNER_JITCODE_INDEX.with(|cell| {
+        *cell.get_or_init(|| {
+            compute_pathed_jitcode_index("pyre_interpreter::objspace::descroperation::pos_inner")
         })
     })?;
     get_jitcode_by_index(idx)

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -185,40 +185,17 @@ pub fn w_long_from_raw(value: *mut BigInt) -> PyObjectRef {
     // (PyPy does the same via W_AbstractIntObject's typedef). Wire
     // `w_class` to INT_TYPE.instantiate so `type(x) is int` and
     // `isinstance(x, int)` both hold for long integers.
-    let header = PyObject {
-        ob_type: &LONG_TYPE as *const PyType,
-        w_class: get_instantiate(&INT_TYPE),
-    };
-    // The wrapper must be GC-managed whenever its `value` payload is: a
-    // `BigInt` routed through the GC (`bigint_gc_type_id() != 0`, the
-    // `alloc_bigint_*` condition) is reclaimed by collections, so an immortal
-    // `malloc_typed` wrapper — which the collector never traces — would leave
-    // an untracked edge to a reclaimed RBigInt payload/digit array. Tie the
-    // wrapper's GC path to the same predicate as the payload, not to
-    // `gc_interp::enabled()` alone (unlike int/float, whose payload is inline).
-    if crate::gc_interp::enabled() || bigint_gc_type_id() != 0 {
-        // `alloc_oldgen_typed` is a direct, non-collecting old-gen allocation.
-        // The young immutable payload therefore stays at the same address
-        // until the wrapper is initialized and remembered below.
-        let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_LONG_GC_TYPE_ID, W_LONG_OBJECT_SIZE);
-        if !raw.is_null() {
-            unsafe {
-                std::ptr::write(
-                    raw as *mut W_LongObject,
-                    W_LongObject {
-                        ob_header: header,
-                        value,
-                    },
-                );
-            }
-            // Creation write barrier: the old-gen wrapper may reference a young
-            // bigint, so remember it for the next minor collection's tracer.
-            crate::gc_hook::try_gc_write_barrier(raw);
-            return raw as PyObjectRef;
-        }
-    }
-    crate::lltype::malloc_typed(W_LongObject {
-        ob_header: header,
+    // PyPy's `W_LongObject.__init__` stores only `num`; the allocation itself
+    // is introduced later by `rclass.py`/`rbuiltin.py`.  Keep the Rust host's
+    // non-moving requirement inside the malloc implementation rather than
+    // spelling its allocator branch and aggregate copy in this constructor.
+    // `fuse_boxing_alloc` recognizes this GC-flavoured malloc boundary and
+    // restores the translated `NewWithVtable` plus ordinary field writes.
+    crate::lltype::malloc_typed_stable(W_LongObject {
+        ob_header: PyObject {
+            ob_type: &LONG_TYPE as *const PyType,
+            w_class: get_instantiate(&INT_TYPE),
+        },
         value,
     }) as PyObjectRef
 }


### PR DESCRIPTION
## What is here

Five commits: a `w_class` slot fix in the optimizer, an assembler predicate follow-up, and the `+x` descent that replaces the hand-written `unary_positive_int` fold as the primary arm.

### `majit: key a virtual's class-word store off the layout, not off the op's descr`

`optimize_setfield_gc` recorded `PyObject.w_class` on a virtual at the `index_in_parent` its own descr carried. The tracer stores through a shared header descr whose index is `0`, which on `W_BaseException` happens to name the class word and on `W_LongObject` names the payload at offset 16.

Reading the slot from the layout instead — `SizeDescr::class_word_index_in_parent`, defined against `all_fielddescrs`, the list `force_box` reads the vector back through — is right for both. A layout that keeps its class word out of that list answers `None` and takes the previous arm.

`b67e8abdb8d` is red without this: `pyre/check.py --backend dynasm` reported **78 failed / 433 passed** with 46 fixtures panicking in `force_box` on the key `0x80000008`. With the fix it is **510 passed**, and the two remaining are pre-existing (below).

`structinfo_setfield` also declines a header word on a virtual: its key comes from `heap::OptHeap::field_slot_index`'s band, which names no position at all.

### `majit: match the explicit-shell variant owners against the whole path`

Review follow-up from #1518. `ends_with("result::Result::Ok")` also accepts a user enum at `mycrate::option::Option::Some`, which `front::option_ctor` never gives a shell to. Matching segment by segment against a `core`/`std` root keeps every spelling `front/mir` produces and rejects the lookalike; a test enumerates the twelve accepted and six rejected spellings.

### The `+x` descent

`OpcodeStepExecutor::unary_positive` carried a default body. A trait method with a default body is what the graph walker resolves to, so `PyFrame`'s implementation — and with it `pos` — was never reached, and `+x` compiles to `CALL_INTRINSIC_1`, which makes this method the whole route. Declaring it required opened the chain:

| graph | before | after |
|---|---|---|
| `unary_positive` | 18 (the stub body) | 11 |
| `unary_positive_value` | 0 | 11 |
| `pos` | 0 | 47 |
| `pos_inner` | 0 | 440 |

`pos_inner` is `pos` past its `__pos__` override probe, which is `dont_look_inside` and is the second operation the body executes. The descent then fires 2/2 and 1/1 and takes the site entirely (`unary_positive_int consulted=0`). The fold stays behind it for a build whose `pos_inner` jitcode is absent or unlowered.

## Gate

`pyre/check.py --backend dynasm`: **2 failed, 510 passed**. `cargo fmt --all -- --check`, `scripts/check-majit-boundary.py` and `pyre/check.py --check-headers` are clean; `majit-metainterp` (1704) and `majit-translate` (3326) unit tests pass.

Both remaining failures are **pre-existing and not this branch's**. Built at the merge base `903151ee679` with none of this branch's commits, the same host reproduces them exactly:

| fixture | at `903151ee679` | at this branch's tip |
|---|---|---|
| `exception_escape_hot_callee_tb_node_once` | `guard_failures 808 -> 1015` | identical |
| `exception_traceback_frame_lineno` | `bridges_compiled 6 -> 4`, `guard_failures 825 -> 624` | identical |

`903151ee679` is the commit that recorded both snapshots, so the committed numbers come from a different host. Re-recording them here would write this machine's numbers into a shared snapshot, so both are left alone.

— *commented by Claude*