### PR TITLE
wasm: a posix descriptor table and scandir, _signal and _socket on wasm32, and the fd sentinel that hid behind them

### DIFF
--- a/pyre/extra_tests/snippets/stdlib_sys.py
+++ b/pyre/extra_tests/snippets/stdlib_sys.py
@@ -12,6 +12,7 @@ assert (
     sys.platform == "linux"
     or sys.platform == "darwin"
     or sys.platform == "win32"
+    or sys.platform == "wasi"
     or sys.platform == "unknown"
 )
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7308,6 +7308,12 @@ fn errno_is_eshutdown(_e: i32) -> bool {
     false
 }
 
+/// The descriptor table `posix` keeps on the wasm target.  File objects reach
+/// it through the same helpers `os.read`/`os.lseek` do, so a number
+/// `os.open` returned is a number `io.open(fd)` can read from.
+#[cfg(all(feature = "host_env", target_arch = "wasm32"))]
+use crate::module::posix::interp_posix_wasm as wasm_fd;
+
 /// darwin/BSD numeric errnos for wasm32, which has no libc errno constants.
 /// Kept in sync with the `errno` module's host_env-off fallback so the errno →
 /// OSError-subclass remap selects the subclass a given `errno.X` value implies.
@@ -7332,6 +7338,11 @@ pub(crate) mod wasm_errno {
     pub const EPERM: i32 = 1;
     pub const ESRCH: i32 = 3;
     pub const ETIMEDOUT: i32 = 60;
+    pub const EBADF: i32 = 9;
+    pub const EINVAL: i32 = 22;
+    pub const EMFILE: i32 = 24;
+    pub const ESPIPE: i32 = 29;
+    pub const EROFS: i32 = 30;
 
     /// The message `strerror` reports for one of the values above.
     ///
@@ -7361,6 +7372,11 @@ pub(crate) mod wasm_errno {
             ECONNRESET => "Connection reset by peer",
             ETIMEDOUT => "Operation timed out",
             ECONNREFUSED => "Connection refused",
+            EBADF => "Bad file descriptor",
+            EINVAL => "Invalid argument",
+            EMFILE => "Too many open files",
+            ESPIPE => "Illegal seek",
+            EROFS => "Read-only file system",
             _ => return None,
         })
     }
@@ -17017,7 +17033,11 @@ pub(crate) fn init_file_wrapper_type(ns: PyObjectRef) {
                         .map_err(|e| crate::host_seam::seam_os_err(e, ""))?;
                     return Ok(w_int_new(pos as i64));
                 }
-                #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
+                #[cfg(all(feature = "host_env", target_arch = "wasm32"))]
+                {
+                    return Ok(w_int_new(wasm_fd::fd_lseek(fd, offset, whence)?));
+                }
+                #[cfg(not(feature = "host_env"))]
                 {
                     let _ = (fd, offset, whence);
                     return Err(crate::PyError::not_implemented(
@@ -17062,7 +17082,13 @@ pub(crate) fn init_file_wrapper_type(ns: PyObjectRef) {
                             .map_err(|e| crate::host_seam::seam_os_err(e, ""))?;
                         return Ok(w_int_new(pos as i64));
                     }
-                    #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
+                    #[cfg(all(feature = "host_env", target_arch = "wasm32"))]
+                    {
+                        // A zero-offset current-relative seek reports the
+                        // position without moving it.
+                        return Ok(w_int_new(wasm_fd::fd_lseek(fd, 0, 1)?));
+                    }
+                    #[cfg(not(feature = "host_env"))]
                     {
                         let _ = fd;
                     }
@@ -17804,7 +17830,11 @@ fn fileio_method_readinto(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
                 }
             }
         }
-        #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
+        #[cfg(all(feature = "host_env", target_arch = "wasm32"))]
+        {
+            return Ok(w_int_new(wasm_fd::fd_read_into(fd, target)? as i64));
+        }
+        #[cfg(not(feature = "host_env"))]
         {
             let _ = (fd, target);
             return Err(crate::PyError::not_implemented(
@@ -17981,7 +18011,11 @@ fn file_method_seekable(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
                 crate::host_seam::ops::lseek(fd, 0, libc::SEEK_CUR).is_ok()
             }
         }
-        #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
+        #[cfg(all(feature = "host_env", target_arch = "wasm32"))]
+        {
+            wasm_fd::fd_lseek(fd, 0, 1).is_ok()
+        }
+        #[cfg(not(feature = "host_env"))]
         {
             let _ = fd;
             false
@@ -18318,7 +18352,11 @@ fn file_method_read(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
                 },
             };
         }
-        #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
+        #[cfg(all(feature = "host_env", target_arch = "wasm32"))]
+        {
+            return fd_bytes_to_obj(args[0], wasm_fd::fd_take(fd, n)?);
+        }
+        #[cfg(not(feature = "host_env"))]
         {
             let _ = (fd, n);
             return Err(crate::PyError::not_implemented(
@@ -18390,7 +18428,21 @@ fn file_method_readline(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
             }
             return fd_bytes_to_obj(args[0], out);
         }
-        #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
+        #[cfg(all(feature = "host_env", target_arch = "wasm32"))]
+        {
+            // The table can un-read, so the line is taken whole and the
+            // position wound back to just past its newline.
+            let start = wasm_fd::fd_lseek(fd, 0, 1)?;
+            let rest = wasm_fd::fd_take(fd, max)?;
+            let end = rest
+                .iter()
+                .position(|&b| b == b'\n')
+                .map(|i| i + 1)
+                .unwrap_or(rest.len());
+            wasm_fd::fd_lseek(fd, start + end as i64, 0)?;
+            return fd_bytes_to_obj(args[0], rest[..end].to_vec());
+        }
+        #[cfg(not(feature = "host_env"))]
         {
             let _ = fd;
             return Err(crate::PyError::not_implemented(
@@ -18566,7 +18618,12 @@ fn file_method_write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
                 .map_err(|e| crate::host_seam::seam_os_err(e, ""))?;
             return Ok(w_int_new(n));
         }
-        #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
+        #[cfg(all(feature = "host_env", target_arch = "wasm32"))]
+        {
+            let _ = bytes;
+            return Err(wasm_fd::fd_refuse_write(fd));
+        }
+        #[cfg(not(feature = "host_env"))]
         {
             let _ = (fd, bytes);
             return Err(crate::PyError::not_implemented(
@@ -18680,7 +18737,11 @@ fn file_method_close(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             {
                 crate::host_seam::ops::close(fd).map_err(|e| crate::host_seam::seam_os_err(e, ""))
             }
-            #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
+            #[cfg(all(feature = "host_env", target_arch = "wasm32"))]
+            {
+                wasm_fd::fd_close(fd)
+            }
+            #[cfg(not(feature = "host_env"))]
             {
                 let _ = fd;
                 Ok(())
@@ -18847,7 +18908,12 @@ fn fileio_validate_fd(fd: i32, w_name: PyObjectRef) -> Result<FileioStatAtOpen, 
 }
 
 #[cfg(not(any(unix, all(windows, feature = "host_env", not(feature = "sandbox")))))]
-fn fileio_validate_fd(_fd: i32, _w_name: PyObjectRef) -> Result<FileioStatAtOpen, crate::PyError> {
+fn fileio_validate_fd(fd: i32, w_name: PyObjectRef) -> Result<FileioStatAtOpen, crate::PyError> {
+    #[cfg(all(feature = "host_env", target_arch = "wasm32"))]
+    if wasm_fd::fd_is_dir(fd)? {
+        return Err(crate::PyError::os_error_syscall(wasm_errno::EISDIR, w_name));
+    }
+    let _ = (fd, w_name);
     Ok(())
 }
 
@@ -19621,7 +19687,7 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         #[cfg(all(feature = "host_env", target_arch = "wasm32"))]
         if writing || mode.contains('+') {
             return Err(crate::PyError::os_error_syscall(
-                wasm_errno::ENOTSUP,
+                wasm_errno::EROFS,
                 resolved_path.w_path(),
             ));
         }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -18035,6 +18035,14 @@ fn file_set_pos(self_obj: PyObjectRef, pos: usize) {
 
 /// The raw file descriptor for an fd-backed file object (`open(fd, ...)`),
 /// or `None` for an in-memory (path-backed) wrapper.
+/// The descriptor a file object reads and writes through, or `None` when it
+/// has none and its contents live in `__file_data__` instead.
+///
+/// A negative value is the "no descriptor" sentinel `W_FileIO` carries: it is
+/// what `fileio_new` publishes before `__init__` runs, and what stays in place
+/// when the open resolves to a buffer rather than to a descriptor.  Reporting
+/// it as a descriptor would send every read, seek and close down the fd path
+/// with nothing to call.
 fn file_get_fd(self_obj: PyObjectRef) -> Option<i32> {
     crate::baseobjspace::getattr_str(self_obj, "__file_fd__")
         .ok()
@@ -18045,6 +18053,7 @@ fn file_get_fd(self_obj: PyObjectRef) -> Option<i32> {
                 None
             }
         })
+        .filter(|fd| *fd >= 0)
 }
 
 fn file_is_binary(self_obj: PyObjectRef) -> bool {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1230,7 +1230,6 @@ fn walk_interpreter_global_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) 
         crate::cpyext::walk_gc_roots(&mut forward);
     }
     crate::executioncontext::walk_space_user_del_action_roots(visitor);
-    #[cfg(not(target_arch = "wasm32"))]
     crate::module::signal::interp_signal::walk_check_signal_action_roots(visitor);
     crate::module::gc::hook::walk_hook_roots(visitor);
     crate::module::sys::vm::walk_monitoring_tool_roots(visitor);

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -1730,14 +1730,8 @@ pub fn disarm_async_eval_breaker() {
     majit_ir::eval_breaker_word::clear_async();
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 fn has_pending_signal_action() -> bool {
     crate::module::signal::signalstate::has_pending_signals()
-}
-
-#[cfg(target_arch = "wasm32")]
-fn has_pending_signal_action() -> bool {
-    false
 }
 
 /// `dont_look_inside` so the tracer treats it as an opaque call and never
@@ -2110,24 +2104,17 @@ impl ActionFlag {
     /// single cell compiled-loop back-edges poll. Only that ticker drives the
     /// shared async bit; per-EC flags that are not the registered breaker
     /// source must not touch the shared word, or one context's dispatch clear
-    /// would drop another context's pending async. wasm builds have no signal
-    /// module (no registered ticker), so the mirror is inert there.
+    /// would drop another context's pending async.
     ///
     /// The cell identity is compared as `usize` rather than via
     /// `ptr::eq`: this runs inside the traced eval loop (`decrement_ticker`),
     /// and a raw-pointer equality on `*const isize` can lower to an
     /// `int_eq/ir>i` kind shape that has no blackhole handler; casting both
     /// addresses to `usize` keeps the comparison an int/int equality.
-    #[cfg(not(target_arch = "wasm32"))]
     fn is_registered_ticker(&self) -> bool {
         let here = &self._ticker as *const isize as usize;
         let registered = crate::module::signal::signalstate::registered_ticker_ptr() as usize;
         here == registered
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    fn is_registered_ticker(&self) -> bool {
-        false
     }
 }
 

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -769,7 +769,11 @@ pub fn install_builtin_modules() {
     // syscall code is absent.
     #[cfg(not(feature = "sandbox"))]
     {
-        #[cfg(not(target_arch = "wasm32"))]
+        // `_signal` is a bootstrap module upstream: it is built on every
+        // platform, and what a platform lacks it lacks entry point by entry
+        // point.  A target with no kernel to route a number publishes the
+        // handler table and `raise_signal`, and leaves out the itimers, the
+        // sigset calls and `pause`.
         pyre_install_module!("_signal"(signal));
         // Only a POSIX host has the user/group databases these read; the
         // platforms without them have no `pwd`/`grp` module at all, and the

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -793,12 +793,10 @@ pub fn install_builtin_modules() {
         pyre_install_module!(select);
         #[cfg(unix)]
         pyre_install_module!(termios);
-        // `socket.py`'s module body subclasses `_socket.socket`, so a module
-        // that is present without the host layer behind it fails the import
-        // with AttributeError -- and `platform._node`, `uuid` and the rest
-        // reach for `socket` inside `try/except ImportError`, which that is
-        // not.  A target with no socket layer has no `_socket` at all.
-        #[cfg(not(target_arch = "wasm32"))]
+        // `socket.py`'s module body subclasses `_socket.socket`, so the type
+        // has to be there even where nothing can be connected: a target with
+        // no host layer publishes it and the numbers, and leaves out the
+        // entry points that would need a descriptor.
         pyre_install_module!(_socket);
         #[cfg(not(target_arch = "wasm32"))]
         pyre_install_module!(_ssl);

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -1547,8 +1547,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(ns, "_default_timeout", pyre_object::w_none());
 
     // `_rsocket_rffi.py constants['has_ipv6'] = True` — exposed by
-    // PyPy's moduledef.py constants loop as a module-level boolean.
-    crate::module_ns_store(ns, "has_ipv6", pyre_object::boolobject::w_bool_from(true));
+    // PyPy's moduledef.py constants loop as a module-level boolean.  It
+    // reports the runtime's support for the family, not the header's number
+    // for it, so a target with no socket layer answers false while still
+    // carrying `AF_INET6`.
+    crate::module_ns_store(
+        ns,
+        "has_ipv6",
+        pyre_object::boolobject::w_bool_from(cfg!(any(unix, windows))),
+    );
 
     // ── module-level getdefaulttimeout / setdefaulttimeout ──
     // `interp_func.py:378-397` — None means "blocking", float means
@@ -1913,6 +1920,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::module_ns_store(ns, "socket", socket_tp);
         crate::module_ns_store(ns, "SocketType", socket_tp);
     }
+    // The same two names, and the numbers, where there is no host layer to
+    // build the rest of the module out of.
+    #[cfg(not(any(unix, windows)))]
+    super::interp_socket_wasm::register_names(ns);
 
     // `socket.py` defines `socketpair` only when `_socket` carries one and
     // falls back to `_fallback_socketpair`'s own AF_INET pair otherwise, and

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket_wasm.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket_wasm.rs
@@ -1,0 +1,173 @@
+//! `_socket` on a target with no socket layer — PyPy: pypy/module/_socket/
+//!
+//! The module is published here the way a build whose C library carries the
+//! headers but not the calls publishes it: the `socket` type, the numbers from
+//! `<sys/socket.h>` and `<netdb.h>`, and none of the entry points that would
+//! need a descriptor.  `socket.py` subclasses `_socket.socket` in its module
+//! body and reaches everything else through `hasattr`, so that is the shape
+//! that lets `import socket` — and `asyncio`, `socketserver`, `ftplib` behind
+//! it — resolve, while an actual connection attempt reports that this platform
+//! has none rather than pretending to open one.
+//!
+//! The numbers are musl's, which is wasi-libc's, matching the `sys.platform`
+//! the guest reports.  `has_ipv6` stays false: carrying the `AF_INET6` number
+//! is what a header does, and answering that the runtime supports the family
+//! is a separate claim.
+
+use pyre_object::PyObjectRef;
+
+/// The `socket` type: real enough to subclass, empty of anything that would
+/// need a descriptor behind it.
+fn socket_type() -> PyObjectRef {
+    static SOCKET_TYPE_OBJ: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *SOCKET_TYPE_OBJ.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type("socket", init_socket_type);
+        crate::typedef::mark_cpython_heap_type(tp, false);
+        unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+        tp as usize
+    }) as PyObjectRef
+}
+
+fn init_socket_type(ns: PyObjectRef) {
+    // Allocation is separate from initialisation here as it is everywhere
+    // else: `socket.py`'s subclass calls `_socket.socket.__init__` itself, so
+    // `__new__` must hand back an instance without having opened anything.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__new__",
+            crate::typedef::make_new_descr(|args| {
+                let cls = args
+                    .first()
+                    .copied()
+                    .filter(|w_cls| unsafe { pyre_object::is_type(*w_cls) })
+                    .unwrap_or_else(socket_type);
+                Ok(pyre_object::w_instance_new(cls))
+            }),
+        )
+    };
+    // The one call this type would have to make, and the one it cannot: there
+    // is no descriptor for a socket to be, so construction reports that rather
+    // than handing back an object whose every method would have to.
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__init__",
+            crate::make_builtin_function("__init__", |_args| {
+                Err(crate::PyError::os_error_syscall(
+                    crate::builtins::wasm_errno::ENOTSUP,
+                    pyre_object::w_none(),
+                ))
+            }),
+        )
+    };
+}
+
+/// The `<sys/socket.h>` / `<netinet/in.h>` / `<netdb.h>` numbers, as musl
+/// spells them.
+///
+/// `AF_UNIX` is left out because wasi-libc carries no `<sys/un.h>`, and the
+/// name is read as a capability rather than as a number: `socketserver`
+/// defines its four Unix server classes behind `hasattr(socket, "AF_UNIX")`
+/// and `socket.socketpair` defaults to the family.
+const CONSTANTS: &[(&str, i64)] = &[
+    // ── Address families ──
+    ("AF_UNSPEC", 0),
+    ("AF_INET", 2),
+    ("AF_INET6", 10),
+    // ── Socket types ──
+    ("SOCK_STREAM", 1),
+    ("SOCK_DGRAM", 2),
+    ("SOCK_RAW", 3),
+    ("SOCK_RDM", 4),
+    ("SOCK_SEQPACKET", 5),
+    // ── Protocols ──
+    ("IPPROTO_IP", 0),
+    ("IPPROTO_ICMP", 1),
+    ("IPPROTO_TCP", 6),
+    ("IPPROTO_UDP", 17),
+    ("IPPROTO_IPV6", 41),
+    ("IPPROTO_RAW", 255),
+    // ── Option levels and names ──
+    ("SOL_SOCKET", 1),
+    ("SO_DEBUG", 1),
+    ("SO_REUSEADDR", 2),
+    ("SO_TYPE", 3),
+    ("SO_ERROR", 4),
+    ("SO_DONTROUTE", 5),
+    ("SO_BROADCAST", 6),
+    ("SO_SNDBUF", 7),
+    ("SO_RCVBUF", 8),
+    ("SO_KEEPALIVE", 9),
+    ("SO_OOBINLINE", 10),
+    ("SO_LINGER", 13),
+    ("SO_REUSEPORT", 15),
+    ("SO_RCVLOWAT", 18),
+    ("SO_SNDLOWAT", 19),
+    ("SO_RCVTIMEO", 20),
+    ("SO_SNDTIMEO", 21),
+    ("SO_ACCEPTCONN", 30),
+    ("TCP_NODELAY", 1),
+    ("TCP_MAXSEG", 2),
+    ("TCP_KEEPIDLE", 4),
+    ("TCP_KEEPINTVL", 5),
+    ("TCP_KEEPCNT", 6),
+    ("IPV6_V6ONLY", 26),
+    // ── shutdown(2) ──
+    ("SHUT_RD", 0),
+    ("SHUT_WR", 1),
+    ("SHUT_RDWR", 2),
+    // ── send / recv flags ──
+    ("MSG_OOB", 0x0001),
+    ("MSG_PEEK", 0x0002),
+    ("MSG_DONTROUTE", 0x0004),
+    ("MSG_CTRUNC", 0x0008),
+    ("MSG_TRUNC", 0x0020),
+    ("MSG_DONTWAIT", 0x0040),
+    ("MSG_EOR", 0x0080),
+    ("MSG_WAITALL", 0x0100),
+    ("MSG_NOSIGNAL", 0x4000),
+    // ── getaddrinfo / getnameinfo ──
+    ("AI_PASSIVE", 0x0001),
+    ("AI_CANONNAME", 0x0002),
+    ("AI_NUMERICHOST", 0x0004),
+    ("AI_V4MAPPED", 0x0008),
+    ("AI_ALL", 0x0010),
+    ("AI_ADDRCONFIG", 0x0020),
+    ("AI_NUMERICSERV", 0x0400),
+    ("NI_NUMERICHOST", 0x0001),
+    ("NI_NUMERICSERV", 0x0002),
+    ("NI_NOFQDN", 0x0004),
+    ("NI_NAMEREQD", 0x0008),
+    ("NI_DGRAM", 0x0010),
+    ("NI_MAXHOST", 255),
+    ("NI_MAXSERV", 32),
+    ("EAI_BADFLAGS", -1),
+    ("EAI_NONAME", -2),
+    ("EAI_AGAIN", -3),
+    ("EAI_FAIL", -4),
+    ("EAI_NODATA", -5),
+    ("EAI_FAMILY", -6),
+    ("EAI_SOCKTYPE", -7),
+    ("EAI_SERVICE", -8),
+    ("EAI_ADDRFAMILY", -9),
+    ("EAI_MEMORY", -10),
+    ("EAI_SYSTEM", -11),
+    ("EAI_OVERFLOW", -12),
+    ("INADDR_ANY", 0x0000_0000),
+    ("INADDR_BROADCAST", 0xffff_ffff_u32 as i64),
+    ("INADDR_LOOPBACK", 0x7f00_0001),
+    ("INADDR_NONE", 0xffff_ffff_u32 as i64),
+    ("SOMAXCONN", 128),
+];
+
+/// The names `register_module` adds where there is no host socket layer to
+/// build the rest out of.
+pub(super) fn register_names(ns: PyObjectRef) {
+    for (name, value) in CONSTANTS {
+        crate::module_ns_store(ns, name, pyre_object::w_int_new(*value));
+    }
+    let socket_tp = socket_type();
+    crate::module_ns_store(ns, "socket", socket_tp);
+    crate::module_ns_store(ns, "SocketType", socket_tp);
+}

--- a/pyre/pyre-interpreter/src/module/_socket/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/mod.rs
@@ -4,10 +4,14 @@
 //! interp_socket submodule carries the W_Socket class implementation
 //! plus address conversion / IDNA / error mapping helpers, and
 //! rsocket_rffi carries the host socket layer both platforms reach it
-//! through.  It exists only where such a layer does: a target that is
-//! neither POSIX nor Windows has no `_socket` module at all, which is the
-//! absence `socket.py` and its callers are written against.
+//! through.  A target with no such layer still carries the module: what it
+//! lacks it lacks entry point by entry point, the way a build whose C library
+//! has the headers but not the calls lacks them, and `interp_socket_wasm`
+//! publishes the part that is left -- the type `socket.py` subclasses and the
+//! numbers it reads.
 
+#[cfg(not(any(unix, windows)))]
+mod interp_socket_wasm;
 #[cfg(any(unix, windows))]
 pub(crate) mod rsocket_rffi;
 

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -131,7 +131,6 @@ pub mod resource;
 #[cfg(not(feature = "sandbox"))]
 pub mod select;
 #[allow(non_snake_case)]
-#[cfg(not(target_arch = "wasm32"))]
 pub mod signal;
 #[allow(non_snake_case)]
 pub mod r#struct;

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
@@ -8,8 +8,17 @@
 //!
 //! The list is what `os.py`'s module body needs to run — `environ`,
 //! `_have_functions`, `stat` and `cpu_count` — plus `lstat`, `listdir`,
-//! `fspath` and `stat_result`, and the three calls the stdlib reaches for
+//! `fspath`, `scandir` and `stat_result`, and the three calls the stdlib reaches for
 //! that the embedder can still answer: `getcwd`, `getcwdb` and `urandom`.
+//! On top of that sits a descriptor half — `open`, `close`, `read`, `lseek`,
+//! `fstat` — over a table this module keeps itself.  The seam answers a whole
+//! path at a time, so a descriptor is the bytes a path resolved to plus a
+//! position; the numbers are the guest's own and name nothing on the other
+//! side of the host ABI.  The seam is a read-only mount, so every entry point
+//! that would change it (`open` for write, `unlink`, `rmdir`) is published and
+//! answers `EROFS`, which is what a read-only filesystem answers — a different
+//! statement from the call not existing.
+//!
 //! Everything else `os` normally re-exports stays absent, so `os._exists`
 //! answers False for it and `os` builds the same fallbacks it builds on a
 //! platform whose C library lacks the call.
@@ -73,18 +82,7 @@ fn stat(args: &[PyObjectRef], default_follow: bool) -> Result<PyObjectRef, crate
     if let Some(v) = crate::builtins::kwarg_get(kwargs, "follow_symlinks") {
         crate::baseobjspace::is_true(v)?;
     }
-    let path = seam_path(&resolved.as_bytes);
-    let (mode, size) = if crate::importing::source_is_dir(&path) {
-        (S_IFDIR | 0o555, 0)
-    } else {
-        match crate::importing::source_file_size(&path) {
-            Ok(size) => (S_IFREG | 0o444, size as i64),
-            // The seam reports why it could not answer, and the path object the
-            // caller passed is what names the failure.
-            Err(e) => return Err(seam_error(&e, resolved.w_path())),
-        }
-    };
-    Ok(make_stat_result(mode, size))
+    stat_resolved(&resolved)
 }
 
 /// The seam takes a `&Path`, and on this target an `OsStr` is the byte string
@@ -167,6 +165,592 @@ fn listdir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(pyre_object::w_list_new(items.take()))
 }
 
+/// One `stat_result` for a path the caller has already resolved, so that
+/// `stat`, `lstat` and `DirEntry.stat` report one file the same way.
+fn stat_resolved(
+    resolved: &crate::gateway::FsEncodedPath,
+) -> Result<PyObjectRef, crate::PyError> {
+    let path = seam_path(&resolved.as_bytes);
+    let (mode, size) = if crate::importing::source_is_dir(&path) {
+        (S_IFDIR | 0o555, 0)
+    } else {
+        match crate::importing::source_file_size(&path) {
+            Ok(size) => (S_IFREG | 0o444, size as i64),
+            // The seam reports why it could not answer, and the path object the
+            // caller passed is what names the failure.
+            Err(e) => return Err(seam_error(&e, resolved.w_path())),
+        }
+    };
+    Ok(make_stat_result(mode, size))
+}
+
+/// `join_path_filename` — the directory and the entry name with one separator
+/// between them.  An empty directory leaves the name alone, which is what
+/// `scandir("")` would otherwise turn into an absolute path.
+fn join_entry_path(dir_bytes: &[u8], name: &[u8]) -> Vec<u8> {
+    if dir_bytes.is_empty() {
+        return name.to_vec();
+    }
+    let mut joined = dir_bytes.to_vec();
+    if !joined.ends_with(b"/") {
+        joined.push(b'/');
+    }
+    joined.extend_from_slice(name);
+    joined
+}
+
+/// The path a `DirEntry` was built for, back in the form the seam takes.
+///
+/// It is read off the entry rather than kept beside it: `path` is the entry's
+/// own public attribute, so one spelling answers both the caller and the seam.
+fn entry_path(self_obj: PyObjectRef) -> Result<crate::gateway::FsEncodedPath, crate::PyError> {
+    crate::gateway::fsencode_path_w(crate::baseobjspace::getattr_str(self_obj, "path")?)
+}
+
+/// The receiver of a `DirEntry` method, with `follow_symlinks` accepted and
+/// without effect for the same reason `lstat` answers what `stat` answers.
+fn entry_self(
+    args: &[PyObjectRef],
+    name: &'static str,
+    follow: bool,
+) -> Result<PyObjectRef, crate::PyError> {
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let allowed: &[&str] = if follow { &["follow_symlinks"] } else { &[] };
+    crate::builtins::kwarg_reject_unknown(kwargs, allowed, name)?;
+    if let Some(v) = crate::builtins::kwarg_get(kwargs, "follow_symlinks") {
+        crate::baseobjspace::is_true(v)?;
+    }
+    pos.first()
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error(format!("{name}() requires self")))
+}
+
+/// `posix.DirEntry` — the record `scandir` yields for one name.
+///
+/// The seam reports a name, whether it is a directory, and a byte length, so
+/// that is what an entry can answer.  It keeps its name and its path and asks
+/// the seam again for the rest, which is the same on-demand `stat` the entry
+/// performs anywhere its `readdir` did not carry a type.  `is_symlink` is
+/// false for every entry, not as a claim that nothing is a link but because a
+/// name and what it resolves to are the only two things this seam separates.
+fn dir_entry_type() -> PyObjectRef {
+    static DIR_ENTRY_TYPE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *DIR_ENTRY_TYPE.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type("posix.DirEntry", init_dir_entry_type);
+        crate::typedef::mark_cpython_heap_type(tp, false);
+        unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+        tp as usize
+    }) as PyObjectRef
+}
+
+fn init_dir_entry_type(ns: PyObjectRef) {
+    let method = |name: &'static str, f: crate::gateway::BuiltinCodeFn| unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            name,
+            crate::make_builtin_function(name, f),
+        );
+    };
+    method("is_dir", |args| {
+        let resolved = entry_path(entry_self(args, "is_dir", true)?)?;
+        Ok(pyre_object::w_bool_from(crate::importing::source_is_dir(
+            &seam_path(&resolved.as_bytes),
+        )))
+    });
+    method("is_file", |args| {
+        let resolved = entry_path(entry_self(args, "is_file", true)?)?;
+        let path = seam_path(&resolved.as_bytes);
+        Ok(pyre_object::w_bool_from(
+            !crate::importing::source_is_dir(&path)
+                && crate::importing::source_file_size(&path).is_ok(),
+        ))
+    });
+    method("is_symlink", |args| {
+        entry_self(args, "is_symlink", false)?;
+        Ok(pyre_object::w_bool_from(false))
+    });
+    method("is_junction", |args| {
+        entry_self(args, "is_junction", false)?;
+        Ok(pyre_object::w_bool_from(false))
+    });
+    method("stat", |args| {
+        stat_resolved(&entry_path(entry_self(args, "stat", true)?)?)
+    });
+    // No inode number reaches the guest, so every entry reports the zero
+    // `st_ino` its `stat_result` carries: one file has one identity either way.
+    method("inode", |args| {
+        entry_self(args, "inode", false)?;
+        Ok(pyre_object::w_int_new(0))
+    });
+    method("__fspath__", |args| {
+        crate::baseobjspace::getattr_str(entry_self(args, "__fspath__", false)?, "path")
+    });
+    method("__repr__", |args| {
+        let name = crate::baseobjspace::getattr_str(entry_self(args, "__repr__", false)?, "name")?;
+        Ok(pyre_object::w_str_from_wtf8_managed(
+            crate::display::wtf8_format!("<DirEntry ", unsafe {
+                crate::display::py_repr_wtf8(name)?
+            }, ">"),
+        ))
+    });
+}
+
+/// The entry for one name inside the directory `scandir` was called on.
+fn new_dir_entry(bytes_mode: bool, dir_bytes: &[u8], name: &[u8]) -> PyObjectRef {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let entry_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_instance_new(dir_entry_type()));
+    // Each value is built before the receiver is read back, because building
+    // it allocates and the allocation may move the entry.
+    let store = |field: &str, value: PyObjectRef| {
+        crate::baseobjspace::setdictvalue_native(
+            pyre_object::gc_roots::shadow_stack_get(entry_slot),
+            field,
+            value,
+        );
+    };
+    store("name", super::fs_name_obj(bytes_mode, name));
+    store(
+        "path",
+        super::fs_name_obj(bytes_mode, &join_entry_path(dir_bytes, name)),
+    );
+    pyre_object::gc_roots::shadow_stack_get(entry_slot)
+}
+
+/// `posix.ScandirIterator` — the iterator `scandir` returns, and the context
+/// manager `os.walk` enters.
+///
+/// The seam answers a whole directory at a time, so the entries exist before
+/// the first `__next__`; what the iterator holds is the position in them.
+/// `close` drops that, which is what makes an exhausted or closed iterator
+/// report the end rather than the directory again.
+fn scandir_iterator_type() -> PyObjectRef {
+    static SCANDIR_ITERATOR_TYPE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *SCANDIR_ITERATOR_TYPE.get_or_init(|| {
+        let tp =
+            crate::typedef::make_builtin_type("posix.ScandirIterator", init_scandir_iterator_type);
+        crate::typedef::mark_cpython_heap_type(tp, false);
+        unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+        tp as usize
+    }) as PyObjectRef
+}
+
+/// The iterator's own position, or `None` once it has been closed.
+const SCANDIR_POSITION: &str = "__scandir_iter__";
+
+fn init_scandir_iterator_type(ns: PyObjectRef) {
+    let method = |name: &'static str, f: crate::gateway::BuiltinCodeFn| unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            name,
+            crate::make_builtin_function(name, f),
+        );
+    };
+    let close = |args: &[PyObjectRef]| -> Result<PyObjectRef, crate::PyError> {
+        crate::baseobjspace::setdictvalue_native(args[0], SCANDIR_POSITION, pyre_object::w_none());
+        Ok(pyre_object::w_none())
+    };
+    method("__iter__", |args| Ok(args[0]));
+    method("__next__", |args| {
+        let position = crate::baseobjspace::getattr_str(args[0], SCANDIR_POSITION)?;
+        if unsafe { is_none(position) } {
+            return Err(crate::PyError::stop_iteration());
+        }
+        crate::baseobjspace::next(position)
+    });
+    method("__enter__", |args| Ok(args[0]));
+    method("__exit__", close);
+    method("close", close);
+}
+
+/// `posix.scandir(path=".")` — the entries the seam reports, as the records
+/// `os.walk`, `glob` and `shutil` read them through.
+///
+/// The omitted argument is the `"."` the signature names, and its entries
+/// carry the `./name` paths that spelling joins to.  A `bytes` path asks for
+/// `bytes` names, as it does for `listdir`.  `fd` is not one of the types the
+/// argument accepts: the seam takes a name, so a descriptor names no directory
+/// on the other side of it.
+fn scandir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::kwarg_reject_unknown(kwargs, &["path"], "scandir")?;
+    if pos.len() > 1 {
+        return Err(crate::PyError::type_error(format!(
+            "scandir() takes at most 1 argument ({} given)",
+            pos.len()
+        )));
+    }
+    let w_path = crate::builtins::bind_pos_or_kw(pos, kwargs, 0, "path", "scandir", 1)?
+        .unwrap_or(pyre_object::w_none());
+    let resolved = crate::gateway::fsencode_path_or_fd_nullable_w(w_path, "scandir", false)?;
+    let bytes_mode = unsafe { resolved.is_bytes() };
+    // An omitted path is the directory `listdir` reads for the same argument,
+    // and the prefix its entries are named relative to.
+    let dir_bytes: &[u8] = if resolved.as_bytes.is_empty() && unsafe { is_none(w_path) } {
+        b"."
+    } else {
+        &resolved.as_bytes
+    };
+    let names = crate::importing::source_list_dir(&seam_path(&resolved.as_bytes))
+        .map_err(|e| seam_error(&e, resolved.w_path()))?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let mut items = pyre_object::gc_roots::RootedItems::new();
+    for name in &names {
+        items.push(new_dir_entry(bytes_mode, dir_bytes, name));
+    }
+    let entries_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_list_new(items.take()));
+    let iterator_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_instance_new(scandir_iterator_type()));
+    let position =
+        crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(entries_slot))?;
+    crate::baseobjspace::setdictvalue_native(
+        pyre_object::gc_roots::shadow_stack_get(iterator_slot),
+        SCANDIR_POSITION,
+        position,
+    );
+    Ok(pyre_object::gc_roots::shadow_stack_get(iterator_slot))
+}
+
+/// `O_*` — the darwin/BSD numbering the guest's `errno` table already
+/// follows, so a flag and the errno a call refuses it with are drawn from one
+/// platform rather than two.
+mod oflag {
+    pub const RDONLY: i64 = 0x0000;
+    pub const WRONLY: i64 = 0x0001;
+    pub const RDWR: i64 = 0x0002;
+    pub const ACCMODE: i64 = 0x0003;
+    pub const NONBLOCK: i64 = 0x0004;
+    pub const APPEND: i64 = 0x0008;
+    pub const SYNC: i64 = 0x0080;
+    pub const NOFOLLOW: i64 = 0x0100;
+    pub const CREAT: i64 = 0x0200;
+    pub const TRUNC: i64 = 0x0400;
+    pub const EXCL: i64 = 0x0800;
+    pub const DIRECTORY: i64 = 0x0010_0000;
+    pub const CLOEXEC: i64 = 0x0100_0000;
+}
+
+/// An open descriptor: the bytes the path resolved to, and how far the guest
+/// has read them.
+///
+/// A directory carries no bytes.  It is opened so that `O_DIRECTORY` can mean
+/// what it means, and reading it is `EISDIR` — the same two answers a
+/// directory descriptor gives anywhere else.
+struct OpenFile {
+    data: Vec<u8>,
+    pos: u64,
+    is_dir: bool,
+}
+
+/// The standard streams hold 0, 1 and 2, so a descriptor this table hands out
+/// starts above them.
+const FIRST_FD: i32 = 3;
+/// The table is the whole descriptor space on this target, so it is what runs
+/// out: past this, `open` reports `EMFILE` rather than growing without bound.
+const MAX_OPEN_FILES: i32 = 4096;
+
+static OPEN_FILES: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::BTreeMap<i32, OpenFile>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::BTreeMap::new()));
+
+/// Take the lowest free number, which is the number `open` is required to
+/// return.
+fn insert_open_file(file: OpenFile) -> Result<i32, crate::PyError> {
+    let mut table = OPEN_FILES.lock().unwrap();
+    let fd = (FIRST_FD..FIRST_FD + MAX_OPEN_FILES)
+        .find(|n| !table.contains_key(n))
+        .ok_or_else(|| {
+            crate::PyError::os_error_syscall(
+                crate::builtins::wasm_errno::EMFILE,
+                pyre_object::w_none(),
+            )
+        })?;
+    table.insert(fd, file);
+    Ok(fd)
+}
+
+/// Run `f` over the descriptor numbered `fd`, or report the number as one no
+/// descriptor is open on.
+fn with_raw_fd<R>(
+    fd: i32,
+    f: impl FnOnce(&mut OpenFile) -> Result<R, crate::PyError>,
+) -> Result<R, crate::PyError> {
+    let mut table = OPEN_FILES.lock().unwrap();
+    let Some(file) = table.get_mut(&fd) else {
+        return Err(crate::PyError::os_error_syscall(
+            crate::builtins::wasm_errno::EBADF,
+            pyre_object::w_none(),
+        ));
+    };
+    f(file)
+}
+
+/// [`with_raw_fd`] where the descriptor arrives as a Python argument.
+fn with_open_file<R>(
+    w_fd: PyObjectRef,
+    f: impl FnOnce(&mut OpenFile) -> Result<R, crate::PyError>,
+) -> Result<R, crate::PyError> {
+    with_raw_fd(crate::baseobjspace::c_int_w(w_fd)?, f)
+}
+
+/// Take up to `n` bytes from the descriptor's position, which advances by what
+/// was taken.  `None` takes everything left, which is what a sizeless `read()`
+/// asks for.
+///
+/// The `_io` layer reaches its descriptors through here too, so a number
+/// `posix.open` returned is a number `io.open(fd)` can read.
+pub(crate) fn fd_take(fd: i32, n: Option<usize>) -> Result<Vec<u8>, crate::PyError> {
+    with_raw_fd(fd, |file| {
+        if file.is_dir {
+            return Err(crate::PyError::os_error_syscall(
+                crate::builtins::wasm_errno::EISDIR,
+                pyre_object::w_none(),
+            ));
+        }
+        let start = (file.pos as usize).min(file.data.len());
+        let end = match n {
+            Some(n) => start.saturating_add(n).min(file.data.len()),
+            None => file.data.len(),
+        };
+        file.pos = end as u64;
+        Ok(file.data[start..end].to_vec())
+    })
+}
+
+/// [`fd_take`] into a caller's buffer, reporting how much of it was filled.
+pub(crate) fn fd_read_into(fd: i32, target: &mut [u8]) -> Result<usize, crate::PyError> {
+    let data = fd_take(fd, Some(target.len()))?;
+    target[..data.len()].copy_from_slice(&data);
+    Ok(data.len())
+}
+
+/// Move the descriptor's position and report where it landed.
+pub(crate) fn fd_lseek(fd: i32, offset: i64, whence: i32) -> Result<i64, crate::PyError> {
+    with_raw_fd(fd, |file| {
+        let base = match whence {
+            0 => 0,
+            1 => file.pos as i64,
+            2 => file.data.len() as i64,
+            _ => {
+                return Err(crate::PyError::os_error_with_errno(
+                    crate::builtins::wasm_errno::EINVAL,
+                    "lseek: unknown whence",
+                ));
+            }
+        };
+        let Some(pos) = base.checked_add(offset).filter(|p| *p >= 0) else {
+            return Err(crate::PyError::os_error_with_errno(
+                crate::builtins::wasm_errno::EINVAL,
+                "lseek: position out of range",
+            ));
+        };
+        file.pos = pos as u64;
+        Ok(pos)
+    })
+}
+
+/// Whether the descriptor is open on a directory, which is the one fact a
+/// stream needs before it adopts a number: `EISDIR` is what `io.open(fd)` owes
+/// a caller who hands it one.
+pub(crate) fn fd_is_dir(fd: i32) -> Result<bool, crate::PyError> {
+    with_raw_fd(fd, |file| Ok(file.is_dir))
+}
+
+/// Drop the descriptor and the bytes it held.
+pub(crate) fn fd_close(fd: i32) -> Result<(), crate::PyError> {
+    if OPEN_FILES.lock().unwrap().remove(&fd).is_none() {
+        return Err(crate::PyError::os_error_syscall(
+            crate::builtins::wasm_errno::EBADF,
+            pyre_object::w_none(),
+        ));
+    }
+    Ok(())
+}
+
+/// The answer a write to an open descriptor gets: the seam has no writing
+/// half, so the mount is read-only rather than the descriptor unusable.
+pub(crate) fn fd_refuse_write(fd: i32) -> crate::PyError {
+    match with_raw_fd(fd, |_| Ok(())) {
+        Ok(()) => crate::PyError::os_error_syscall(
+            crate::builtins::wasm_errno::EROFS,
+            pyre_object::w_none(),
+        ),
+        Err(e) => e,
+    }
+}
+
+/// The path argument of a one-path entry point, with `dir_fd` refused the way
+/// `stat` refuses it: the seam takes a name and nothing else.
+fn path_arg(
+    args: &[PyObjectRef],
+    name: &'static str,
+) -> Result<crate::gateway::FsEncodedPath, crate::PyError> {
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::kwarg_reject_unknown(kwargs, &["path", "dir_fd"], name)?;
+    if pos.len() > 1 {
+        return Err(crate::PyError::type_error(format!(
+            "{name}() takes at most 1 positional argument ({} given)",
+            pos.len()
+        )));
+    }
+    let Some(w_path) = crate::builtins::bind_pos_or_kw(pos, kwargs, 0, "path", name, 1)? else {
+        return Err(crate::PyError::type_error(format!(
+            "{name}() missing required argument 'path' (pos 1)"
+        )));
+    };
+    let resolved = crate::gateway::fsencode_path_or_fd_w(w_path, name, false)?;
+    if crate::builtins::kwarg_get(kwargs, "dir_fd").is_some_and(|v| !unsafe { is_none(v) }) {
+        return Err(crate::PyError::not_implemented(
+            "dir_fd unavailable on this platform",
+        ));
+    }
+    Ok(resolved)
+}
+
+/// `posix.open(path, flags, mode=0o777, *, dir_fd=None)` — a descriptor over
+/// the bytes the seam reports for `path`.
+///
+/// The whole file is read here rather than at the first `read`: the seam has
+/// no way to resume a path part-way, so the descriptor is the only place the
+/// bytes can live.  `mode` is accepted and unused — it describes a file that
+/// is about to be created, and this seam creates none.
+fn open_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::kwarg_reject_unknown(kwargs, &["path", "flags", "mode", "dir_fd"], "open")?;
+    if pos.len() > 3 {
+        return Err(crate::PyError::type_error(format!(
+            "open() takes at most 3 positional arguments ({} given)",
+            pos.len()
+        )));
+    }
+    let Some(w_path) = crate::builtins::bind_pos_or_kw(pos, kwargs, 0, "path", "open", 3)? else {
+        return Err(crate::PyError::type_error(
+            "open() missing required argument 'path' (pos 1)",
+        ));
+    };
+    let Some(w_flags) = crate::builtins::bind_pos_or_kw(pos, kwargs, 1, "flags", "open", 3)? else {
+        return Err(crate::PyError::type_error(
+            "open() missing required argument 'flags' (pos 2)",
+        ));
+    };
+    let _ = crate::builtins::bind_pos_or_kw(pos, kwargs, 2, "mode", "open", 3)?;
+    let resolved = crate::gateway::fsencode_path_or_fd_w(w_path, "open", false)?;
+    if crate::builtins::kwarg_get(kwargs, "dir_fd").is_some_and(|v| !unsafe { is_none(v) }) {
+        return Err(crate::PyError::not_implemented(
+            "dir_fd unavailable on this platform",
+        ));
+    }
+    let flags = crate::baseobjspace::int_w(w_flags)?;
+    // Every bit that asks to change the mount, refused where the file is
+    // named rather than at the write that would discover it.
+    if flags & oflag::ACCMODE != oflag::RDONLY
+        || flags & (oflag::CREAT | oflag::TRUNC | oflag::APPEND | oflag::EXCL) != 0
+    {
+        return Err(crate::PyError::os_error_syscall(
+            crate::builtins::wasm_errno::EROFS,
+            resolved.w_path(),
+        ));
+    }
+    let path = seam_path(&resolved.as_bytes);
+    let is_dir = crate::importing::source_is_dir(&path);
+    if flags & oflag::DIRECTORY != 0 && !is_dir {
+        return Err(crate::PyError::os_error_syscall(
+            crate::builtins::wasm_errno::ENOTDIR,
+            resolved.w_path(),
+        ));
+    }
+    let data = if is_dir {
+        Vec::new()
+    } else {
+        crate::importing::read_source_bytes(&path)
+            .map_err(|e| seam_error(&e, resolved.w_path()))?
+    };
+    let fd = insert_open_file(OpenFile {
+        data,
+        pos: 0,
+        is_dir,
+    })?;
+    Ok(pyre_object::w_int_new(fd as i64))
+}
+
+/// `posix.close(fd)` — drop the descriptor and the bytes it held.
+fn close_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    fd_close(crate::baseobjspace::c_int_w(args[0])?)?;
+    Ok(pyre_object::w_none())
+}
+
+/// `posix.read(fd, length)` — up to `length` bytes from the position, which
+/// advances by what was returned.  A short answer at the end is the end.
+fn read_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let n_signed = crate::baseobjspace::int_w(args[1])?;
+    // A negative size would wrap to a huge `usize` (and allocation);
+    // os.read rejects it with EINVAL, matching the host read(2).
+    if n_signed < 0 {
+        return Err(crate::PyError::os_error_with_errno(
+            crate::builtins::wasm_errno::EINVAL,
+            "read: negative size",
+        ));
+    }
+    let fd = crate::baseobjspace::c_int_w(args[0])?;
+    let data = fd_take(fd, Some(n_signed as usize))?;
+    Ok(pyre_object::w_bytes_from_bytes(&data))
+}
+
+/// `posix.lseek(fd, position, whence)` — the new position.
+///
+/// A position past the end is a position, not an error: it reads as empty and
+/// is what `SEEK_END` with a positive offset names.
+fn lseek_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let fd = crate::baseobjspace::c_int_w(args[0])?;
+    let offset = crate::baseobjspace::int_w(args[1])?;
+    let whence = crate::baseobjspace::int_w(args[2])?;
+    Ok(pyre_object::w_int_new(fd_lseek(
+        fd,
+        offset,
+        i32::try_from(whence).unwrap_or(i32::MAX),
+    )?))
+}
+
+/// `posix.fstat(fd)` — the same two facts `stat` reports, taken from the
+/// descriptor rather than from a name.
+fn fstat_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    with_open_file(args[0], |file| {
+        Ok(if file.is_dir {
+            make_stat_result(S_IFDIR | 0o555, 0)
+        } else {
+            make_stat_result(S_IFREG | 0o444, file.data.len() as i64)
+        })
+    })
+}
+
+/// `posix.readlink(path, *, dir_fd=None)` — the seam resolves a name and does
+/// not report whether it went through a link, so no path it answers for is a
+/// symbolic link.  `EINVAL` is what `readlink` answers for one that is not.
+fn readlink(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let resolved = path_arg(args, "readlink")?;
+    let path = seam_path(&resolved.as_bytes);
+    if !crate::importing::source_is_dir(&path)
+        && let Err(e) = crate::importing::source_file_size(&path)
+    {
+        return Err(seam_error(&e, resolved.w_path()));
+    }
+    Err(crate::PyError::os_error_syscall(
+        crate::builtins::wasm_errno::EINVAL,
+        resolved.w_path(),
+    ))
+}
+
+/// `posix.unlink(path, *, dir_fd=None)` / `posix.rmdir(path, *, dir_fd=None)`
+/// — the entry points a read-only mount publishes and refuses.
+fn refuse_write(args: &[PyObjectRef], name: &'static str) -> Result<PyObjectRef, crate::PyError> {
+    let resolved = path_arg(args, name)?;
+    Err(crate::PyError::os_error_syscall(
+        crate::builtins::wasm_errno::EROFS,
+        resolved.w_path(),
+    ))
+}
+
 pub fn register_module(ns: PyObjectRef) {
     // `os._createenviron` reads this dict directly and wraps it, so `os.environ`
     // is a live view of it.  The guest is started with no environment — the
@@ -196,6 +780,15 @@ pub fn register_module(ns: PyObjectRef) {
         "listdir",
         crate::make_builtin_function("listdir", listdir),
     );
+    crate::module_ns_store(
+        ns,
+        "scandir",
+        crate::make_builtin_function("scandir", scandir),
+    );
+    // `os.walk` catches `OSError` from the iterator and `shutil` calls
+    // `isinstance(entry, os.DirEntry)`, so both the type and the entries it
+    // stamps are published.
+    crate::module_ns_store(ns, "DirEntry", dir_entry_type());
     // `_bootstrap_external` reads `_os.fspath`, not `os.fspath`, so the
     // pure-Python fallback `os.py` installs when `posix` lacks it does not
     // stand in for the import machinery.  The protocol itself touches no
@@ -248,6 +841,79 @@ pub fn register_module(ns: PyObjectRef) {
         "urandom",
         crate::make_builtin_function_with_arity("urandom", urandom, 1),
     );
+    // ── the descriptor half ──
+    crate::module_ns_store(
+        ns,
+        "open",
+        crate::make_builtin_function("open", open_file),
+    );
+    crate::module_ns_store(
+        ns,
+        "close",
+        crate::make_builtin_function_with_arity("close", close_file, 1),
+    );
+    crate::module_ns_store(
+        ns,
+        "read",
+        crate::make_builtin_function_with_arity("read", read_file, 2),
+    );
+    crate::module_ns_store(
+        ns,
+        "lseek",
+        crate::make_builtin_function_with_arity("lseek", lseek_file, 3),
+    );
+    crate::module_ns_store(
+        ns,
+        "fstat",
+        crate::make_builtin_function_with_arity("fstat", fstat_file, 1),
+    );
+    crate::module_ns_store(
+        ns,
+        "readlink",
+        crate::make_builtin_function("readlink", readlink),
+    );
+    crate::module_ns_store(
+        ns,
+        "unlink",
+        crate::make_builtin_function("unlink", |args| refuse_write(args, "unlink")),
+    );
+    // `os.remove` is the same call under its other name on every platform.
+    crate::module_ns_store(
+        ns,
+        "remove",
+        crate::make_builtin_function("remove", |args| refuse_write(args, "remove")),
+    );
+    crate::module_ns_store(
+        ns,
+        "rmdir",
+        crate::make_builtin_function("rmdir", |args| refuse_write(args, "rmdir")),
+    );
+    // ── the constants those entry points are called with ──
+    let constants: &[(&str, i64)] = &[
+        ("O_RDONLY", oflag::RDONLY),
+        ("O_WRONLY", oflag::WRONLY),
+        ("O_RDWR", oflag::RDWR),
+        ("O_ACCMODE", oflag::ACCMODE),
+        ("O_NONBLOCK", oflag::NONBLOCK),
+        ("O_APPEND", oflag::APPEND),
+        ("O_SYNC", oflag::SYNC),
+        ("O_NOFOLLOW", oflag::NOFOLLOW),
+        ("O_CREAT", oflag::CREAT),
+        ("O_TRUNC", oflag::TRUNC),
+        ("O_EXCL", oflag::EXCL),
+        ("O_DIRECTORY", oflag::DIRECTORY),
+        ("O_CLOEXEC", oflag::CLOEXEC),
+        ("F_OK", 0),
+        ("X_OK", 1),
+        ("W_OK", 2),
+        ("R_OK", 4),
+        ("SEEK_SET", 0),
+        ("SEEK_CUR", 1),
+        ("SEEK_END", 2),
+    ];
+    for (name, value) in constants {
+        crate::module_ns_store(ns, name, pyre_object::w_int_new(*value));
+    }
 }
 
 /// The embedder's working directory, or nothing when it reports none.

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -12,6 +12,61 @@ use pyre_object::PyObjectRef;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::OnceLock;
 
+/// The signal numbers and names `<signal.h>` supplies elsewhere.
+///
+/// A target with no signals still has to name them: `signal.Signals` is built
+/// from whatever `_signal` publishes, and a handler installed under a number
+/// this module does not know is one `getsignal` could never answer for.  The
+/// numbering is musl's, which is wasi-libc's, matching the `sys.platform` the
+/// guest reports; the descriptions are the ones `strsignal` answers with, kept
+/// beside the numbers so a signal has one entry rather than two.
+#[cfg(not(any(unix, windows)))]
+pub(crate) mod wasm_signals {
+    /// The number the interpreter installs its own handler under at startup.
+    pub const SIGINT: i32 = 2;
+
+    pub const TABLE: &[(&str, i32, &str)] = &[
+        ("SIGHUP", 1, "Hangup"),
+        ("SIGINT", SIGINT, "Interrupt"),
+        ("SIGQUIT", 3, "Quit"),
+        ("SIGILL", 4, "Illegal instruction"),
+        ("SIGTRAP", 5, "Trace/breakpoint trap"),
+        ("SIGABRT", 6, "Aborted"),
+        ("SIGBUS", 7, "Bus error"),
+        ("SIGFPE", 8, "Floating point exception"),
+        ("SIGKILL", 9, "Killed"),
+        ("SIGUSR1", 10, "User defined signal 1"),
+        ("SIGSEGV", 11, "Segmentation fault"),
+        ("SIGUSR2", 12, "User defined signal 2"),
+        ("SIGPIPE", 13, "Broken pipe"),
+        ("SIGALRM", 14, "Alarm clock"),
+        ("SIGTERM", 15, "Terminated"),
+        ("SIGCHLD", 17, "Child exited"),
+        ("SIGCONT", 18, "Continued"),
+        ("SIGSTOP", 19, "Stopped (signal)"),
+        ("SIGTSTP", 20, "Stopped"),
+        ("SIGTTIN", 21, "Stopped (tty input)"),
+        ("SIGTTOU", 22, "Stopped (tty output)"),
+        ("SIGURG", 23, "Urgent I/O condition"),
+        ("SIGXCPU", 24, "CPU time limit exceeded"),
+        ("SIGXFSZ", 25, "File size limit exceeded"),
+        ("SIGVTALRM", 26, "Virtual timer expired"),
+        ("SIGPROF", 27, "Profiling timer expired"),
+        ("SIGWINCH", 28, "Window changed"),
+        ("SIGIO", 29, "I/O possible"),
+        ("SIGSYS", 31, "Bad system call"),
+    ];
+
+    /// The description for `signum`, or nothing for a number no signal in the
+    /// table carries.
+    pub fn strsignal(signum: i32) -> Option<&'static str> {
+        TABLE
+            .iter()
+            .find(|(_, n, _)| *n == signum)
+            .map(|(_, _, text)| *text)
+    }
+}
+
 /// executioncontext.py `space.getexecutioncontext().checksignals()`
 /// — deliver a signal that may have arrived during a syscall.  Resolves
 /// the live EC from the thread-local slot (`getexecutioncontext`).
@@ -31,7 +86,7 @@ pub fn checksignals_now() -> Result<(), crate::PyError> {
 /// interp_signal.py `SignalMask.__enter__` — unpack a list / tuple
 /// / set of signal numbers, the argument shape `sigwait` / `sigpending`
 /// share with `pthread_sigmask`.
-#[cfg(feature = "host_env")]
+#[cfg(all(feature = "host_env", unix))]
 fn signal_set_items(arg: PyObjectRef) -> Result<Vec<PyObjectRef>, crate::PyError> {
     unsafe {
         if pyre_object::is_list(arg) {
@@ -58,7 +113,7 @@ fn signal_set_items(arg: PyObjectRef) -> Result<Vec<PyObjectRef>, crate::PyError
 /// of `class_name` (an `OSError` or subclass) carrying the errno and its
 /// strerror, so `.errno` / `str()` behave like any `OSError`.  Falls back
 /// to `OSError` if `class_name` is not registered.
-#[cfg(feature = "host_env")]
+#[cfg(all(feature = "host_env", unix))]
 fn errno_exception(class_name: &str, errno: i32) -> crate::PyError {
     let strerror = unsafe {
         std::ffi::CStr::from_ptr(libc::strerror(errno))
@@ -574,11 +629,11 @@ pub fn install_signal_handling(ec: &mut ExecutionContext) {
 
         // app_main.py:926 — `signal.signal(SIGINT, default_int_handler)`.
         #[cfg(any(unix, windows))]
-        {
-            let sigint = libc::SIGINT;
-            if signalstate::pypysig_setflag(sigint) {
-                set_handler(sigint, default_int_handler_obj());
-            }
+        let sigint = libc::SIGINT;
+        #[cfg(not(any(unix, windows)))]
+        let sigint = wasm_signals::SIGINT;
+        if signalstate::pypysig_setflag(sigint) {
+            set_handler(sigint, default_int_handler_obj());
         }
         action as *mut CheckSignalAction as usize
     });
@@ -793,8 +848,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             ))
                         }
                     };
-                    #[cfg(not(windows))]
+                    #[cfg(unix)]
                     let raised = rustpython_host_env::signal::raise_signal(signum);
+                    // No kernel to hand the number to.  The delivery this
+                    // target has is the interpreter's own checkpoint, which
+                    // the shared tail below runs, so raising is marking the
+                    // number pending -- the same two steps the unix arm takes,
+                    // with the first one no longer a syscall.
+                    #[cfg(not(any(unix, windows)))]
+                    let raised = {
+                        check_signum_in_range(i64::from(signum))?;
+                        signalstate::signal_pushback(signum);
+                        Ok::<(), std::io::Error>(())
+                    };
                     match raised {
                         Ok(()) => {
                             // interp_signal.py — the signal may
@@ -843,7 +909,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     // `'Unknown signal: 32'` on pypy.
                     check_signum_in_range(signum)?;
                     let signum = signum as i32;
-                    Ok(rustpython_host_env::signal::strsignal(signum)
+                    #[cfg(any(unix, windows))]
+                    let text = rustpython_host_env::signal::strsignal(signum);
+                    #[cfg(not(any(unix, windows)))]
+                    let text = wasm_signals::strsignal(signum).map(str::to_owned);
+                    Ok(text
                         .map(|s| pyre_object::w_str_new(&s))
                         .unwrap_or(pyre_object::w_none()))
                 }
@@ -858,6 +928,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             1,
         ),
     );
+    // `valid_signals` reads a `sigfillset`ed `sigset_t`; a target with neither
+    // does not publish it.
+    #[cfg(any(unix, windows))]
     crate::module_ns_store(
         ns,
         "valid_signals",
@@ -1426,6 +1499,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     );
     // Common signal numbers (POSIX subset, sourced from libc so numerics
     // match the host — Linux SIGUSR1=10 / macOS SIGUSR1=30, etc.).
+    #[cfg(not(any(unix, windows)))]
+    for (name, value, _) in wasm_signals::TABLE {
+        crate::module_ns_store(ns, name, pyre_object::w_int_new(i64::from(*value)));
+    }
     #[cfg(unix)]
     {
         crate::module_ns_store(ns, "SIGHUP", pyre_object::w_int_new(libc::SIGHUP as i64));

--- a/pyre/pyre-interpreter/src/module/signal/signalstate.rs
+++ b/pyre/pyre-interpreter/src/module/signal/signalstate.rs
@@ -21,11 +21,16 @@ pub const NSIG: i32 = 23;
 pub const NSIG: i32 = 32;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub const NSIG: i32 = 65;
+// The wasm guest reports `sys.platform == "wasi"`, and wasi-libc's
+// `<signal.h>` is musl's, so it carries musl's `_NSIG` and musl's numbering.
+#[cfg(target_arch = "wasm32")]
+pub const NSIG: i32 = 65;
 #[cfg(not(any(
     windows,
     target_vendor = "apple",
     target_os = "linux",
-    target_os = "android"
+    target_os = "android",
+    target_arch = "wasm32"
 )))]
 pub const NSIG: i32 = 64;
 
@@ -572,17 +577,24 @@ pub fn pypysig_ignore(signum: i32) -> bool {
 #[cfg(windows)]
 pub fn pypysig_reinstall(_signum: i32) {}
 
+/// The four installers on a target with no OS to install into.
+///
+/// There is no kernel here to route a number to a handler, so recording that
+/// the guest asked for one is the whole of the install: `signal()` keeps the
+/// handler and `raise_signal` is what delivers it.  They report success
+/// because the request is met — by the only deliverer this target has, which
+/// is the interpreter's own checkpoint.
 #[cfg(not(any(unix, windows)))]
 pub fn pypysig_setflag(_signum: i32) -> bool {
-    false
+    true
 }
 #[cfg(not(any(unix, windows)))]
 pub fn pypysig_default(_signum: i32) -> bool {
-    false
+    true
 }
 #[cfg(not(any(unix, windows)))]
 pub fn pypysig_ignore(_signum: i32) -> bool {
-    false
+    true
 }
 #[cfg(not(any(unix, windows)))]
 pub fn pypysig_reinstall(_signum: i32) {}

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1459,6 +1459,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "version",
         w_str_new(&format!("3.14.6 (pyre 0.0.1) [{compiler}]")),
     );
+    // The stdlib branches on this name to decide what a platform can do, and
+    // the two spellings it knows for a WebAssembly guest are `emscripten` and
+    // `wasi`.  A guest reaching its embedder through host imports is the
+    // second of those: `emscripten` promises the JavaScript runtime behind it
+    // — `platform._sys_version` reads `sys._emscripten_info` on that name and
+    // has nothing to fall back to — while `wasi` promises only that there is
+    // no process to fork, no home directory and no signal delivery, which is
+    // what this target is.  Reported for both wasm hosts: what the guest can
+    // do is the same on either side of the browser boundary.
     module_ns_store(
         ns,
         "platform",
@@ -1468,6 +1477,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             "linux"
         } else if cfg!(target_os = "windows") {
             "win32"
+        } else if cfg!(target_arch = "wasm32") {
+            "wasi"
         } else {
             "unknown"
         }),

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4976,7 +4976,6 @@ fn register_thread_root_areas() {
             pyre_interpreter::display::capture_repr_active_area(),
             "repr_active",
         );
-        #[cfg(not(target_arch = "wasm32"))]
         register(
             signal_handler_root_walker_area,
             pyre_interpreter::module::signal::interp_signal::capture_signal_handler_root_area(),
@@ -5859,7 +5858,6 @@ unsafe fn mapdict_root_walker_area(data: *const (), visitor: &mut dyn FnMut(&mut
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 unsafe fn signal_handler_root_walker_area(
     data: *const (),
     visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
@@ -5895,7 +5893,6 @@ fn pyre_interpreter_side_table_root_walker(visitor: &mut dyn FnMut(&mut majit_ir
     });
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 #[allow(dead_code)]
 fn signal_handler_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     pyre_interpreter::module::signal::interp_signal::walk_signal_handler_roots(|slot| {

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -983,6 +983,13 @@ fn run_python_impl(source: &str) -> String {
     unsafe {
         let ec_ptr = std::rc::Rc::as_ptr(&execution_context) as *mut PyExecutionContext;
         (*ec_ptr).install_user_del_action();
+        // The same step for the other periodic action: without it the ticker
+        // cell is unregistered and `CheckSignalAction` never runs, so a
+        // handler `signal.signal` recorded has nothing to deliver it -- which
+        // on this target is the only delivery there is.  It also installs the
+        // startup `SIGINT` handler, so `getsignal(SIGINT)` names
+        // `default_int_handler` here as it does natively.
+        pyre_interpreter::module::signal::interp_signal::install_signal_handling(&mut *ec_ptr);
     }
     // Register the __build_class__ callback. Class construction resolves the
     // live frame from the execution-context slot seeded above.


### PR DESCRIPTION
The seven roots that kept 36 stdlib modules from importing on the wasm32 guest, closed without adding a host ABI call. The module census goes from **85 to 98 of 98**.

| root | change |
|---|---|
| `glob` / `os.O_RDONLY` | `posix` constant table (`O_*`, `F_OK`/`X_OK`/`W_OK`/`R_OK`, `SEEK_*`) and `open` |
| `shutil` / `os.open` | a descriptor table: `open`, `close`, `read`, `lseek`, `fstat` |
| `sysconfig` / `os.readlink` | `readlink` — `EINVAL` for a path the seam resolves, `ENOENT` for one it does not |
| `socket` / `_socket` | the module, the `socket` type, and the musl numbers |
| `signal` / `_signal` | built on wasm32, entry point by entry point |
| `tty` / `termios` | none — `termios` is in the WASI `PY_STDLIB_MOD_SET_NA` upstream |
| `ssl` / `_ssl` | none — it needs OpenSSL, which no wasm build links |

### The defect underneath

Publishing `posix.open` let `importlib._bootstrap_external` succeed for the first time, which installed the Python import machinery — and the census then fell to 43. The cause was not on the wasm side. `fileio_new` publishes `__file_fd__ = -1` before `__init__` runs, and `fileio_init` copies the opened wrapper's attributes over it; an open that resolves to a buffer rather than to a descriptor leaves the `-1` in place, and `file_get_fd` reported that as a descriptor. Every `read`, `seek` and `close` went down the fd path with nothing to call. On wasm32 that was every file, so `SourceFileLoader` could not read a module.

### What the descriptor table is

The `SourceProvider` seam answers a whole path at a time, so a descriptor here is the bytes a path resolved to plus a position. The numbers are the guest's own and name nothing across the host ABI. `builtins.rs`'s fd arms for `read`, `readline`, `readinto`, `seek`, `tell`, `write`, `close` and `seekable` raised `NotImplementedError` on wasm32; they now route to that same table, so a number `os.open` returned is a number `io.open(fd)` can read from.

The seam is a read-only mount. `open` with any write bit, and `unlink`, `remove` and `rmdir`, are published and answer `EROFS` — a different statement from the call not existing.

### Beyond the roots

- `os.scandir`, `DirEntry` and the iterator it returns, so `glob.glob`, `os.walk` and `pathlib.Path.glob` run rather than merely import.
- `sys.platform` reports `wasi`. `emscripten` promises a JavaScript runtime `platform._sys_version` reads `sys._emscripten_info` from.
- `_signal` being absent had left five wasm32 stubs behind. Two were real holes: `has_pending_signal_action` returned false so no signal was ever delivered, and the JIT registered no `signal_handler` root walker, so a handler object was reachable only from a side table nothing walked.
- `AF_UNIX` is deliberately not published: wasi-libc has no `<sys/un.h>`, and `socketserver` and `socket.socketpair` read the name as a capability rather than as a number.

### Measured on the guest

98 of 98 modules import. `os.open`/`read`/`lseek`/`fstat`/`close` round-trip a stdlib file; `io.open(fd)` reads through it and reports the same `fileno`; a double `close` is `EBADF`, a write-mode `open` is `EROFS`, a directory read is `EISDIR`, `os.read(9999)` is `EBADF`. `glob`, `os.walk`, `pathlib.Path.glob` and bytes-mode `scandir` all answer. `signal.raise_signal(SIGINT)` reaches an installed handler. `socket.socket()` reports `[Errno 45] Operation not supported`.

`cargo test --all` is green.

`pyre/check.py --backend dynasm,wasm` reports three reds; a control build at HEAD with this diff reverted attributes all three elsewhere. `exception_escape_hot_callee_tb_node_once` is red at HEAD too (dynasm 808→1015, wasm 1008→1015, both converging on the same number on darwin). `exception_traceback_frame_lineno` passes 2/2 when run alone on the same binary. `pickle_terminal_raise_resume`'s wasm ratio is 1.6–1.7x across four isolated runs — the 4.3x was one full-run outlier where the dynasm denominator dipped to 0.13s. No jitstats baseline was re-recorded.
