### PR TITLE
jit, backend-cranelift: the portal leave's caller vref, the blackhole runner's resume depth, the shared exit-frame screens, and the prologue overflow's descr

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -3600,6 +3600,49 @@ fn load_frame_slot_run(
     vals
 }
 
+/// `_store_and_reset_exception` + `_build_propagate_exception_path`
+/// (x86/assembler.py:328-345): read `JIT_EXC_VALUE` into a temporary, clear
+/// both exception globals, then publish the value into `jf_guard_exc` and
+/// `propagate_exception_descr` into `jf_descr`.
+///
+/// The descr stamp is the load-bearing half.  Without it the returned frame
+/// carries whatever `jf_descr` already held — for a frame `handle_call_assembler`
+/// zeroed, that is 0, which names neither the callee's finish descr nor any
+/// live fail descr, so the classifier upstream of it has nothing to resolve.
+///
+/// The caller owns the `return_`, because the two exits differ in what they
+/// must unwind: an allocation failure runs `_call_footer`'s shadow-stack pop,
+/// while the entry stack check runs before `gen_shadowstack_header` and has no
+/// entry to pop.
+fn emit_propagate_exception_stores(
+    builder: &mut FunctionBuilder,
+    ptr_type: cranelift_codegen::ir::Type,
+    jf_ptr: cranelift_codegen::ir::Value,
+    propagate_exception_descr_ptr: usize,
+) {
+    let zero = builder.ins().iconst(cl_types::I64, 0);
+    let exc_val_addr = builder.ins().iconst(ptr_type, jit_exc_value_addr() as i64);
+    let exc_val = builder
+        .ins()
+        .load(cl_types::I64, MemFlagsData::trusted(), exc_val_addr, 0);
+    builder
+        .ins()
+        .store(MemFlagsData::trusted(), zero, exc_val_addr, 0);
+    let exc_type_addr = builder.ins().iconst(ptr_type, jit_exc_type_addr() as i64);
+    builder
+        .ins()
+        .store(MemFlagsData::trusted(), zero, exc_type_addr, 0);
+    builder
+        .ins()
+        .store(MemFlagsData::trusted(), exc_val, jf_ptr, JF_GUARD_EXC_OFS);
+    let descr_val = builder
+        .ins()
+        .iconst(ptr_type, propagate_exception_descr_ptr as i64);
+    builder
+        .ins()
+        .store(MemFlagsData::trusted(), descr_val, jf_ptr, JF_DESCR_OFS);
+}
+
 /// x86/assembler.py `genop_discard_check_memory_error` /
 /// aarch64/assembler.rs `emit_propagate_memory_error_if_null`: branch to the
 /// `propagate_exception_descr` exit when `ptr_val` is NULL.  The metainterp
@@ -3635,30 +3678,9 @@ fn emit_memory_error_check(
             .ins()
             .trap(cranelift_codegen::ir::TrapCode::user(1).unwrap());
     } else {
-        // _store_and_reset_exception (assembler.py:1826-1843): read
-        // JIT_EXC_VALUE → tmp, clear both globals.
-        let exc_val_addr = builder.ins().iconst(ptr_type, jit_exc_value_addr() as i64);
-        let exc_val = builder
-            .ins()
-            .load(cl_types::I64, MemFlagsData::trusted(), exc_val_addr, 0);
-        builder
-            .ins()
-            .store(MemFlagsData::trusted(), zero, exc_val_addr, 0);
-        let exc_type_addr = builder.ins().iconst(ptr_type, jit_exc_type_addr() as i64);
-        builder
-            .ins()
-            .store(MemFlagsData::trusted(), zero, exc_type_addr, 0);
         // assembler.py:336-340 — MOV [jf_guard_exc], tmp; MOV [jf_descr], descr.
         let cur_jf = builder.ins().get_pinned_reg(ptr_type);
-        builder
-            .ins()
-            .store(MemFlagsData::trusted(), exc_val, cur_jf, JF_GUARD_EXC_OFS);
-        let descr_val = builder
-            .ins()
-            .iconst(ptr_type, propagate_exception_descr_ptr as i64);
-        builder
-            .ins()
-            .store(MemFlagsData::trusted(), descr_val, cur_jf, JF_DESCR_OFS);
+        emit_propagate_exception_stores(builder, ptr_type, cur_jf, propagate_exception_descr_ptr);
         emit_call_footer_shadowstack(builder, ptr_type);
         builder.ins().return_(&[cur_jf]);
     }
@@ -9806,6 +9828,26 @@ impl CraneliftBackend {
 
         builder.switch_to_block(stack_overflow_block);
         builder.seal_block(stack_overflow_block);
+        // `_build_stack_check_slowpath` (x86/assembler.py:1080) ends its
+        // overflow arm by jumping to `propagate_exception_path`, so the frame
+        // it returns already names `propagate_exception_descr`.  The dynasm
+        // prologue ports that stamp; this one returned the frame with
+        // `jf_descr` untouched, i.e. the 0 `handle_call_assembler` wrote into
+        // every callee frame.  On the trace-entry door that is masked, because
+        // the pending-exception drain runs before the outcome is classified at
+        // all; a CALL_ASSEMBLER caller has no such drain and resolves the 0 as
+        // a descr.  Publish what the other backend publishes.
+        //
+        // No `_call_footer` shadow-stack pop here: `gen_shadowstack_header`
+        // runs after this check, so nothing has been pushed yet.
+        if propagate_exception_descr_ptr != 0 {
+            emit_propagate_exception_stores(
+                &mut builder,
+                ptr_type,
+                initial_jf_ptr,
+                propagate_exception_descr_ptr,
+            );
+        }
         builder.ins().return_(&[initial_jf_ptr]);
 
         builder.switch_to_block(stack_check_continue);

--- a/pyre/bench/synth/exception_try_call_inlined_callee_raise.cranelift.jitstats
+++ b/pyre/bench/synth/exception_try_call_inlined_callee_raise.cranelift.jitstats
@@ -13,6 +13,6 @@ field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
 guard_failures=909
 internal_compile_panics=0
-loops_aborted=1
+loops_aborted=0
 loops_compiled=3
 retraces_compiled=0

--- a/pyre/bench/synth/exception_try_call_inlined_callee_raise.dynasm.jitstats
+++ b/pyre/bench/synth/exception_try_call_inlined_callee_raise.dynasm.jitstats
@@ -13,6 +13,6 @@ field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
 guard_failures=909
 internal_compile_panics=0
-loops_aborted=1
+loops_aborted=0
 loops_compiled=3
 retraces_compiled=0

--- a/pyre/bench/synth/exception_try_call_inlined_callee_raise.wasm.jitstats
+++ b/pyre/bench/synth/exception_try_call_inlined_callee_raise.wasm.jitstats
@@ -13,6 +13,6 @@ field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
 guard_failures=909
 internal_compile_panics=0
-loops_aborted=1
+loops_aborted=0
 loops_compiled=3
 retraces_compiled=0

--- a/pyre/bench/synth/portal_leave_forces_the_caller_vref.py
+++ b/pyre/bench/synth/portal_leave_forces_the_caller_vref.py
@@ -1,0 +1,113 @@
+# pyre-check: selfcheck
+# pyre-check: selfcheck-compiles=driver,root:leaf
+# Both entries are the premise, not a relaxation. The caller whose vref goes
+# unforced is `mid_pass`, and it is only virtual because `driver`'s loop
+# compiles and inlines it; `leaf` is the residual callee whose own activation
+# reaches `leave_compiled_frame_chain`, which is the port under test. A run
+# where either stopped compiling would leave `mid_pass` a real interpreter
+# frame with no vref at all, and every assertion below would pass without
+# testing anything.
+#
+# `executioncontext.py ExecutionContext.leave` reaches the caller WITH the
+# force:
+#
+#     if frame.escaped or got_exception:
+#         f_back = frame.f_backref()      # parens == force_virtual
+#         if f_back:
+#             f_back.mark_as_escaped()
+#         frame_vref()
+#
+# pyre's port for a frame whose body ran as compiled code
+# (`call_jit.rs leave_compiled_frame_chain`) read that caller through the
+# NON-forcing `vref_referent` instead. For a caller the JIT kept virtual that
+# answers NULL, NULL was taken for "no caller", and the caller was neither
+# materialised nor marked escaped.
+#
+# The mark is not bookkeeping: it is what makes the caller's own leave record
+# the `VIRTUAL_REF_FINISH(vrefbox, virtualbox)` form, the one that stores the
+# virtual into `forced`. Without the mark, `walker_ec_leave` takes its
+# unescaped arm and records the NULL form, which leaves the caller's vref at
+# `virtual_token == TOKEN_NONE` with `forced == NULL` — the state
+# `virtualref.py` calls `InvalidVirtualRef`. `force_pyframe_vref` says so
+# itself: the state that reaches its refusal "requires that propagation to have
+# been skipped".
+#
+# THE SHAPE IS THE TEST, and three parts of it are load-bearing:
+#   * `leaf` must be a RESIDUAL call, so its frame reaches
+#     `leave_compiled_frame_chain` rather than the walker's own leave.
+#   * `leaf` must ESCAPE — its frame is retained out of a traceback — so the
+#     escape branch runs at all.
+#   * `leaf` must return NORMALLY. An exception leaving `leaf` fails the
+#     trace's `GuardNoException`, which skips the NULL-form finish and installs
+#     a tracing-time vref that already carries `forced`; the bug goes quiet.
+#
+# Before the fix this did not print a wrong answer — it ABORTED the process:
+# `panicked at pyre-jit/src/eval.rs: InvalidVirtualRef: frame-chain vref forced
+# after its frame died` -> `thread caused non-unwinding panic. aborting.`,
+# exit 134, while cpython 3.14, pypy3 and `PYRE_JIT=0` all answered `mid_pass`.
+# An abort is why this fixture asserts rather than prints: there is no output to
+# diff against when the defect fires.
+import sys
+
+WARM = 4000
+ESCAPE_AT = WARM - 5
+
+
+def leaf(i, n):
+    if i == ESCAPE_AT:
+        try:
+            raise ValueError('escape')
+        except ValueError as exc:
+            HELD.append(exc.__traceback__.tb_frame)
+    return i
+
+
+def mid_pass(i, n):
+    return leaf(i, n)
+
+
+def driver(n):
+    acc = 0
+    i = 0
+    while i < n:
+        acc += mid_pass(i, n)
+        i += 1
+    return acc
+
+
+HELD = []
+
+
+def main():
+    failures = []
+    driver(WARM)
+    if len(HELD) != 1:
+        print('FAIL the escape never fired: held %d frames' % len(HELD))
+        return 1
+    escaped = HELD[0]
+    if escaped.f_code.co_name != 'leaf':
+        failures.append('escaped frame = %s, expected leaf' % escaped.f_code.co_name)
+    # The read that aborts. `f_back` forces the caller's vref, which is exactly
+    # the vref the missing propagation stranded.
+    caller = escaped.f_back
+    if caller is None:
+        failures.append('f_back = None, expected the mid_pass frame')
+    elif caller.f_code.co_name != 'mid_pass':
+        failures.append('f_back = %s, expected mid_pass' % caller.f_code.co_name)
+    else:
+        # One level further: the caller's own caller must be reachable too, so
+        # the propagation is checked past the frame that was skipped rather
+        # than only at it.
+        grandparent = caller.f_back
+        name = None if grandparent is None else grandparent.f_code.co_name
+        if name != 'driver':
+            failures.append('f_back.f_back = %s, expected driver' % name)
+    if failures:
+        for line in failures:
+            print('FAIL', line)
+        return 1
+    print('PASS the portal leave forces the caller vref it marks escaped')
+    return 0
+
+
+sys.exit(main())

--- a/pyre/bench/synth/portal_resume_reports_its_activation_bracket.py
+++ b/pyre/bench/synth/portal_resume_reports_its_activation_bracket.py
@@ -1,0 +1,148 @@
+# pyre-check: selfcheck
+# pyre-check: selfcheck-interpreted
+# The empty compile set is measured, not a relaxation: `PYRE_LOOP_CENSUS=1`
+# emits no `[loop-census]` line for this file. The defect is on the portal's
+# COLD path — `eval_with_jit_inner` consumed the resume payload before entering
+# the bracket, which every frame reaching the portal does whether or not
+# anything compiled — so warming a loop would add nothing to the guard. The
+# discriminator is the JIT build against `PYRE_JIT=0`, not compiled against
+# interpreted: `PYRE_JIT=0` reports all six events and the default build
+# reported two.
+#
+# A delegating generator / coroutine is resumed with a hook installed, and the
+# activation of the DELEGATING frame is the one being counted.
+#
+# `pyframe.py execute_frame` puts the resume INSIDE the bracket:
+#
+#     executioncontext.enter(self)
+#     try:
+#         executioncontext.call_trace(self)
+#         try:
+#             try:
+#                 next_instr = self.resume_execute_frame(w_arg_or_err)
+#             except pyopcode.Yield:
+#                 w_exitvalue = self.popvalue()
+#         finally:
+#             executioncontext.return_trace(self, w_exitvalue)
+#     finally:
+#         executioncontext.leave(self, w_exitvalue, got_exception)
+#
+# pyre's portal sits at `execute_frame`'s own level, so it carries that bracket
+# itself — but it consumed the resume payload BEFORE entering the bracket, and
+# a suspended `yield from` / `await` delegate that yields again finishes the
+# resumption there and returns. That return jumped `call_trace`,
+# `return_trace`, `leaveframe_trace` and the frame-chain leave in one step.
+#
+# TWO DEFECTS, ONE HOIST, and the fixture checks both because they fail
+# differently:
+#   * LOSS. When the delegate yields again, the delegating frames report
+#     nothing at all. Measured on the `await` arm: 2 of the 6 events cpython
+#     3.14, pypy3 and `PYRE_JIT=0` all report.
+#   * ORDER. When the delegate instead raises StopIteration, the bracket does
+#     run — but the delegate's own Python already ran ahead of it, so the
+#     callee's whole call/return pair is reported OUTSIDE the caller's. A
+#     pairing profiler mis-nests: it sees a `return` for a frame it never got a
+#     `call` for. Measured on the `yield from` arm as
+#     `['call/inner', 'return/inner', 'call/outer', 'return/outer']`.
+#
+# THE ORDER IS THE TEST for the second arm, not the multiset: both orders carry
+# the same four events, so a fixture that counted them would pass while the
+# nesting was inverted.
+import sys
+
+
+def record(events, names):
+    def hook(frame, event, arg):
+        name = frame.f_code.co_name
+        if name in names:
+            events.append(event + '/' + name)
+        return hook
+
+    return hook
+
+
+def yield_from_arm():
+    def inner():
+        yield 1
+        return
+
+    def outer():
+        yield from inner()
+        yield 'after'
+
+    gen = outer()
+    gen.send(None)
+    events = []
+    sys.setprofile(record(events, ('outer', 'inner')))
+    try:
+        gen.send(None)
+    finally:
+        sys.setprofile(None)
+    return events
+
+
+def await_arm():
+    class Fut:
+        def __await__(self):
+            yield
+            yield
+            return 7
+
+    async def inner():
+        return await Fut()
+
+    async def outer():
+        return await inner()
+
+    coro = outer()
+    coro.send(None)
+    events = []
+    sys.setprofile(record(events, ('outer', 'inner', '__await__')))
+    try:
+        coro.send(None)
+    except StopIteration:
+        pass
+    finally:
+        sys.setprofile(None)
+    return events
+
+
+def check(label, got, expected, failures):
+    if got != expected:
+        failures.append('%s: %s, expected %s' % (label, got, expected))
+
+
+def main():
+    failures = []
+    # The delegate raises StopIteration, so `outer` resumes and completes: the
+    # bracket runs, and `inner`'s pair must sit INSIDE `outer`'s.
+    check(
+        'yield from',
+        yield_from_arm(),
+        ['call/outer', 'call/inner', 'return/inner', 'return/outer'],
+        failures,
+    )
+    # The delegate yields again, so the whole stack re-suspends: every frame
+    # still owes its pair, innermost last out.
+    check(
+        'await',
+        await_arm(),
+        [
+            'call/outer',
+            'call/inner',
+            'call/__await__',
+            'return/__await__',
+            'return/inner',
+            'return/outer',
+        ],
+        failures,
+    )
+    if failures:
+        for line in failures:
+            print('FAIL', line)
+        return 1
+    print('PASS a delegating resume reports its activation bracket, nested')
+    return 0
+
+
+sys.exit(main())

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1317,10 +1317,31 @@ pub extern "C" fn bh_portal_runner_c(
         );
     }
     frame.set_last_instr_from_next_instr(next_instr as usize);
-    // `bhimpl_recursive_call_r` performs a call the traced code made, so the
-    // frame it hands over is entering its body for the first time and owes
-    // `execute_frame`'s hook bracket.  The CRN arms below resume a frame whose
-    // activation already began and take the unbracketed entry instead.
+    // The blackhole wrote the failing guard's recorded operand depth into the
+    // frame; resuming at the merge-point `next_instr` (a different pc) would
+    // carry that over-count and overflow the frame at its peak stack use.
+    // Re-derive the depth from the resume pc — the same correction the
+    // CALL_ASSEMBLER CRN arm applies to the same kind of green `next_instr`.
+    crate::eval::correct_resume_vsd(frame, next_instr as usize);
+    // The bracket is owed, but not for the reason a reading of
+    // `bhimpl_recursive_call_r` suggests.  pyre's codewriter emits no
+    // `recursive_call`, so the live door here is `bhimpl_jit_merge_point`'s
+    // recursive-portal arm (blackhole.py), taken when `nextblackholeinterp`
+    // is not None — a frame that already has a caller in the resumed chain,
+    // i.e. an inlined callee, mid-body at its own loop header.  That IS a
+    // resume, and upstream reaches it through `portal_ptr` = `dispatch`, one
+    // level below `execute_frame`.  What makes it an activation for pyre is
+    // where the frame came from: `emit_new_pyframe_inline_with_params` built
+    // it inside compiled code, and `walker_ec_enter` records only `enter`'s
+    // frame-chain half, never `call_trace` — so this is the frame's first and
+    // only bracket, not a second one.  The bottom level, which is the frame
+    // the interpreter itself bracketed, never arrives here: it raises
+    // `ContinueRunningNormally` and takes the unbracketed entry instead.
+    //
+    // `ec` is a red arg and the frame no longer carries one, so publish it for
+    // the duration of the call: `execute_frame` reads its execution context
+    // through `space.getexecutioncontext()`, which is what the bracket below
+    // will consult.
     let saved_ctx = pyre_interpreter::call::take_last_exec_ctx();
     if !ec.is_null() {
         pyre_interpreter::call::set_last_exec_ctx(ec);
@@ -1725,22 +1746,29 @@ pub extern "C" fn jit_force_self_recursive_call_raw_1(caller_frame: i64, raw_int
     result
 }
 
-/// Dynasm x86/assembler.py `_build_stack_check_slowpath` parity.
+/// x86/assembler.py `_build_stack_check_slowpath` parity, for every backend
+/// whose prologue emits the inline probe.
 ///
-/// The interpreter-level slowpath stores the RecursionError in the
-/// current thread's pending JIT exception slot for non-dynasm backend
-/// glue. Dynasm's prologue, however, mirrors RPython's
-/// `pos_exception()` path: after this call returns non-zero, emitted
-/// code transfers `majit_backend_dynasm`'s `JIT_EXC_VALUE` into
-/// `jf_guard_exc` and stamps `propagate_exception_descr` into
-/// `jf_descr`. Bridge the two exception slots here.
+/// Upstream's slowpath raises into `pos_exception()`, which is exactly the cell
+/// the emitted overflow arm then moves into `jf_guard_exc` before jumping to
+/// `propagate_exception_path`.  pyre's interpreter-level slowpath parks the
+/// `RecursionError` in the thread's pending slot instead — a different cell, and
+/// not one any emitted code reads — so republish it into the backend's
+/// exception cells here.
+///
+/// This is shared rather than per-backend because the emitted store sequence is
+/// the same on both: registering the undrained slowpath leaves `JIT_EXC_VALUE`
+/// at zero, and the prologue then publishes that zero as the overflow's
+/// exception, which the propagate path resolves through its
+/// `memory_error_singleton_ref()` fallback — a `MemoryError` where the program
+/// is owed a `RecursionError`.
 #[cfg(feature = "dynasm")]
-extern "C" fn dynasm_stack_check_slowpath_for_backend(current: usize) -> u8 {
+extern "C" fn jit_prologue_stack_check_slowpath(current: usize) -> u8 {
     let result = pyre_interpreter::stack_check::pyre_stack_check_slowpath_for_backend(current);
-    if result != 0 {
-        if let Err(mut exc) = pyre_interpreter::stack_check::drain_jit_pending_exception() {
-            majit_backend_dynasm::jit_exc_raise(exc.to_exc_object() as i64);
-        }
+    if result != 0
+        && let Err(mut exc) = pyre_interpreter::stack_check::drain_jit_pending_exception()
+    {
+        store_jit_exception(exc.to_exc_object() as i64);
     }
     result
 }
@@ -1912,8 +1940,7 @@ pub fn install_jit_call_bridge() {
             majit_backend_cranelift::register_stack_check_addresses(
                 pyre_interpreter::stack_check::pyre_stack_get_end_adr(),
                 pyre_interpreter::stack_check::pyre_stack_get_length_adr(),
-                pyre_interpreter::stack_check::pyre_stack_check_slowpath_for_backend as *const ()
-                    as usize,
+                jit_prologue_stack_check_slowpath as *const () as usize,
             );
             majit_backend_cranelift::register_prologue_probe_addr(
                 pyre_interpreter::stack_check::pyre_stack_check_for_jit_prologue as *const ()
@@ -1935,7 +1962,7 @@ pub fn install_jit_call_bridge() {
             majit_backend_dynasm::register_stack_check_addresses(
                 pyre_interpreter::stack_check::pyre_stack_get_end_adr(),
                 pyre_interpreter::stack_check::pyre_stack_get_length_adr(),
-                dynasm_stack_check_slowpath_for_backend as *const () as usize,
+                jit_prologue_stack_check_slowpath as *const () as usize,
             );
         }
     });

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2476,15 +2476,37 @@ fn leave_resumed_blackhole_frame(
 ///   forces it; that word only names this frame while its scope is the open
 ///   one. A walk that materialised an inlined callee can leave a different vref
 ///   there, and the caller has no other way to find out.
-/// * No force. The guard has already established that `frame_vref` resolves to
-///   this frame, so `leave`'s `frame_vref()` has nothing left to materialize,
-///   and forcing a vref that was finished with the NULL form is exactly what
-///   `force_pyframe_vref` refuses — measured as
+/// * No force OF THIS FRAME'S OWN VREF. The guard has already established that
+///   `frame_vref` resolves to this frame, so `leave`'s `frame_vref()` has
+///   nothing left to materialize, and forcing a vref that was finished with the
+///   NULL form is exactly what `force_pyframe_vref` refuses — measured as
 ///   `InvalidVirtualRef: frame-chain vref forced after its frame died` on
 ///   `exception_escape_inlined_midframe_tb_node` and
 ///   `exception_try_call_inlined_callee_raise`.
-/// * The caller is reached through `vref_referent` rather than `get_f_back`,
-///   which forces, for the same reason.
+///
+/// That measurement scoped only the `frame_vref()` half.  This bullet used to
+/// carry a third one extending it to the caller — "reached through
+/// `vref_referent` rather than `get_f_back`, which forces, for the same
+/// reason" — and the reason does not carry: see below.  Both fixtures named
+/// above pass with the caller force restored.
+///
+/// The caller, then, is reached with the force — `f_back =
+/// frame.f_backref()`, parens included, i.e. [`PyFrame::get_f_back`].  That
+/// force is NOT covered by the argument above: the identity guard establishes
+/// something about `frame_vref`, and nothing about `f_backref`.  Reading the
+/// caller with the non-forcing `vref_referent` answers NULL whenever the caller
+/// is a still-virtual inlined frame, and NULL is then taken for "no caller", so
+/// the caller is neither materialised nor marked escaped.  `force_pyframe_vref`
+/// (`eval.rs`) states the invariant that breaks: a leaving frame that escaped
+/// "marks the caller escaped so its own leave does the same", and the state that
+/// reaches its refusal "requires that propagation to have been skipped".  With
+/// the propagation skipped, `walker_ec_leave`'s unescaped arm records the NULL
+/// form of `VIRTUAL_REF_FINISH`, which leaves the caller's vref at
+/// `virtual_token == TOKEN_NONE` with `forced == NULL` — the invalid state
+/// `virtualref.py` names `InvalidVirtualRef`.  Reading the escaped callee's
+/// `f_back` afterwards then aborts the process, a non-unwinding panic:
+/// measured on a residual callee whose frame escapes into a traceback and which
+/// returns NORMALLY under an inlined caller.
 ///
 /// The `topframeref` restore is idempotent for the portal, whose
 /// `CurrentFrameGuard` writes back the same word from a shadow-stack slot when
@@ -2511,7 +2533,12 @@ fn leave_compiled_frame_chain(frame_ptr: *mut PyFrame, got_exception: bool) {
     unsafe {
         (*ec).topframeref = (*frame_ptr).f_backref;
         if (*frame_ptr).escaped() || got_exception {
-            let f_back = pyre_interpreter::executioncontext::vref_referent((*frame_ptr).f_backref);
+            // `f_back = frame.f_backref()` — with the parens, so an inlined
+            // caller that is still virtual is materialised here rather than
+            // read as absent.  The mark is what makes the caller's own leave
+            // record the non-NULL `VIRTUAL_REF_FINISH`; skipping it strands the
+            // caller's vref in the state `force_pyframe_vref` aborts on.
+            let f_back = (*frame_ptr).get_f_back();
             if !f_back.is_null() {
                 (*f_back).mark_as_escaped();
             }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -9074,6 +9074,24 @@ fn screen_frame_already_recorded(frame: *const PyFrame, err: &mut pyre_interpret
     }
 }
 
+/// Both screens a compiled-run exception exit owes before its own frame's
+/// exception table is consulted.  Returns false when the frame must propagate
+/// instead, in which case `err` is left untouched.
+///
+/// `LoopResult::ExitFrameWithException` has three consumers — the eval loop's
+/// back-edge site, `try_function_entry_jit`'s function-entry site, and
+/// `handle_jitexception` — and they must agree, because a single producer
+/// (`compile_and_run_once`'s `FinishConcrete::Raise`) feeds all three.  The
+/// back-edge one applied only the traceback screen while claiming, in the
+/// comment on its sibling, to perform "the same delivery".
+fn screen_exit_frame_delivery(frame: *mut PyFrame, err: &mut pyre_interpreter::PyError) -> bool {
+    if exit_frame_handler_needs_unwritten_stack(unsafe { &*frame }) {
+        return false;
+    }
+    screen_frame_already_recorded(frame as *const PyFrame, err);
+    true
+}
+
 /// warmspot.py `ExitFrameWithExceptionRef` delivery for a compiled-run
 /// exit that surfaced outside the eval loop (the `handle_jit_outcome` /
 /// compile-once path).  Offer the pending exception to `frame`'s exception
@@ -9101,10 +9119,9 @@ fn deliver_exit_frame_exception(
     // the dead address into `handle_jitexception`'s own root.
     let mut frame_root = FrameRoot::new(frame);
     let mut handler_instr = frame_root.frame().next_instr();
-    if exit_frame_handler_needs_unwritten_stack(frame_root.frame()) {
+    if !screen_exit_frame_delivery(frame_root.frame() as *mut PyFrame, &mut err) {
         return Err(err);
     }
-    screen_frame_already_recorded(frame_root.frame() as *const PyFrame, &mut err);
     if pyre_interpreter::eval::handle_exception(frame_root.frame(), &mut err, &mut handler_instr) {
         frame_root
             .frame()
@@ -9639,7 +9656,9 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                     // per-opcode `Err` arm below); resume at the handler pc when
                     // caught, otherwise propagate it out as a plain `Done(Err)`.
                     if let LoopResult::ExitFrameWithException(mut err) = loop_result {
-                        screen_frame_already_recorded(f as *const PyFrame, &mut err);
+                        if !screen_exit_frame_delivery(f, &mut err) {
+                            return LoopResult::Done(Err(err));
+                        }
                         if pyre_interpreter::eval::handle_exception(
                             unsafe { &mut *f },
                             &mut err,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -8721,21 +8721,6 @@ fn eval_with_jit_inner(
     // Set CURRENT_FRAME so zero-arg super() can find __class__ in the caller.
     let _frame_guard = pyre_interpreter::eval::install_current_frame(frame_root.frame());
 
-    // A resumed frame reaches the portal already positioned mid-body, so its
-    // payload has to be consumed before the merge point is consulted: the
-    // green key is `(pycode, next_instr)`, and the sent value belongs on the
-    // operand stack at the pc that key names.  This is the last point at
-    // which the frame can still decline, so nothing below may need the
-    // payload again.  A suspended `yield from` delegate that yields finishes
-    // the resumption on its own and this frame never runs.
-    if let Some(resume) = resume {
-        if let Some(delegated) =
-            pyre_interpreter::eval::prepare_frame_resume_for_dispatch(frame_root.frame(), resume)?
-        {
-            return Ok(delegated);
-        }
-    }
-
     // RPython warmspot.py ll_portal_runner:
     //   maybe_compile_and_run(increment_threshold, *args)
     //   return portal_ptr(*args)
@@ -8746,7 +8731,7 @@ fn eval_with_jit_inner(
     //
     // portal_ptr = eval_loop_jit at depth 0 (has jit_merge_point +
     // can_enter_jit back-edge), plain interpreter at depth > 0.
-    portal_activation_bracketed(&mut frame_root)
+    portal_activation_bracketed(&mut frame_root, resume)
 }
 
 /// `pyframe.py execute_frame`'s hook bracket around [`portal_runner_dispatch`],
@@ -8776,10 +8761,34 @@ fn eval_with_jit_inner(
 /// with — and each hook that raises replaces whatever was pending, in that
 /// order.  `?` on any of the three would flatten the nesting and drop the hooks
 /// after it.
-fn portal_activation_bracketed(frame_root: &mut FrameRoot) -> PyResult {
+///
+/// The resume payload is consumed HERE, inside the bracket, not by the caller
+/// ahead of it.  `execute_frame` runs `self.resume_execute_frame(w_arg_or_err)`
+/// in the inner `try`, after `call_trace`, and a suspended `yield from` /
+/// `await` delegate that yields again ends the activation right there — which is
+/// upstream's `except pyopcode.Yield: w_exitvalue = self.popvalue()`, still
+/// inside both `finally`s.  Consuming it before the bracket made a delegating
+/// resume return without ever running `call_trace`, `return_trace`,
+/// `leaveframe_trace` or the frame-chain leave: measured on an `await` chain
+/// that re-suspends, where a `sys.setprofile` hook saw 2 of the 6 events
+/// CPython, pypy3 and `PYRE_JIT=0` all report.  It also ran the delegate's own
+/// Python — and therefore the delegate's whole call/return pair — ahead of this
+/// frame's `call`, inverting the nesting a pairing profiler accounts on.
+fn portal_activation_bracketed(
+    frame_root: &mut FrameRoot,
+    resume: Option<&mut pyre_interpreter::call::FrameResumeArgs>,
+) -> PyResult {
     let ec = pyre_interpreter::call::getexecutioncontext() as *mut PyExecutionContext;
     if ec.is_null() {
         // No execution context is no hook to owe, and no `leave` either.
+        if let Some(resume) = resume
+            && let Some(delegated) = pyre_interpreter::eval::prepare_frame_resume_for_dispatch(
+                frame_root.frame(),
+                resume,
+            )?
+        {
+            return Ok(delegated);
+        }
         return portal_runner_dispatch(frame_root);
     }
     // `w_exitvalue` is `execute_frame`'s own local, not a re-read of the result
@@ -8793,7 +8802,25 @@ fn portal_activation_bracketed(frame_root: &mut FrameRoot) -> PyResult {
     let outer_result = match unsafe { (*ec).call_trace(frame_root.frame() as *mut PyFrame) } {
         Err(err) => Err(err),
         Ok(()) => {
-            let result = portal_runner_dispatch(frame_root);
+            // `self.resume_execute_frame(w_arg_or_err)` and its
+            // `except pyopcode.Yield` arm, in `execute_frame`'s inner `try`: a
+            // resumed frame is positioned mid-body and the sent value belongs
+            // on the operand stack at that pc, so the payload is consumed
+            // before the merge point is consulted.  A delegate that yields
+            // again finishes the resumption itself and this frame never runs —
+            // but it still owes `return_trace` and the leave below, so the
+            // value is assigned rather than returned.
+            let result = match resume {
+                Some(resume) => pyre_interpreter::eval::prepare_frame_resume_for_dispatch(
+                    frame_root.frame(),
+                    resume,
+                )
+                .and_then(|delegated| match delegated {
+                    Some(value) => Ok(value),
+                    None => portal_runner_dispatch(frame_root),
+                }),
+                None => portal_runner_dispatch(frame_root),
+            };
             if let Ok(value) = &result {
                 w_exitvalue = *value;
             }
@@ -9119,7 +9146,13 @@ fn debug_first_arg_int(frame: &PyFrame) -> Option<i64> {
 /// exactly the outermost one, which reaches the interpreter's own
 /// `execute_frame` — for every tail from 10 000 iterations up.
 pub(crate) fn portal_activation_result(frame: &mut PyFrame) -> PyResult {
-    enter_portal(frame, portal_activation_bracketed)
+    /// The frames that reach this door were just constructed, so they carry no
+    /// resume payload: `execute_frame`'s `w_arg_or_err` is `None` and the
+    /// bracket runs its body straight through.
+    fn bracketed_without_resume(frame_root: &mut FrameRoot) -> PyResult {
+        portal_activation_bracketed(frame_root, None)
+    }
+    enter_portal(frame, bracketed_without_resume)
 }
 
 /// warmspot.py ll_portal_runner:
@@ -9567,11 +9600,27 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 // can_enter_jit is a lowered no-op / merge point; re-seed
                 // conservatively before the next frame reads.
                 let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
-                let green_key = make_green_key(
-                    unsafe { &*f }.pycode,
-                    loop_header_pc,
-                    unsafe { &*f }.get_is_being_profiled(),
-                );
+                let loop_pycode = unsafe { &*f }.pycode;
+                let loop_profiled = unsafe { &*f }.get_is_being_profiled();
+                let green_key_hash = make_green_key(loop_pycode, loop_header_pc, loop_profiled);
+                // The same resolve the function-entry door takes, for the same
+                // reason: `maybe_compile_and_run` and everything it reads
+                // (`has_runnable_compiled_loop`, `runnable_procedure_token`,
+                // `maybe_compile_decision`) answer for whichever cell HEADS a
+                // chained bucket, so a bare hash decides about one cell while
+                // `force_start_tracing_for_key` — which walks the chain — acts
+                // on another.  A loop-header key gets a chained bucket from the
+                // hash-form installers (`disable_noninlinable_function`,
+                // `prepare_trace_segmenting`) and from the inlined-callee
+                // merge point in `jitcode_dispatch`, which mints its callee's
+                // loop header as a raw `make_green_key`.
+                let green_key = driver.resolve_cell_key(green_key_hash, || {
+                    pyre_jit_trace::driver::make_green_key_typed(
+                        loop_pycode,
+                        loop_header_pc,
+                        loop_profiled,
+                    )
+                });
                 if let Some(loop_result) = maybe_compile_and_run(
                     unsafe { &mut *f },
                     green_key,


### PR DESCRIPTION
Follow-up to #1542. Six portal/blackhole findings were left unverified there; this adjudicates all six and lands the four that survived. Every verdict below was reached by reading the vendored `rpython/` + `pypy/` trees, and where a claim was about reach it was measured rather than argued.

## Adjudication

| Finding | Verdict |
| --- | --- |
| `bh_portal_runner_c` takes the activation door for a resume | **refuted** — but its comment named the wrong door |
| `correct_resume_vsd` missing at a merge-point reposition | **confirmed** |
| `jit_blackhole_resume_from_guard` drains RecursionError to `None` | **refuted as stated** — a different, real defect underneath |
| back-edge `ExitFrameWithException` delivery skips a screen | **confirmed structurally, zero measured reach** |
| `execute_assembler`'s `Finished` arm leaves a residual exception cell set | **refuted** |
| a failing `GUARD_NOT_FORCED` strands the callee in `ec.topframeref` | **refuted** |

## What changed

**`bh_portal_runner_c` now corrects the resume depth.** It repositions the frame to the merge-point `next_instr` carried in the portal greens, then dispatches. Its twin — the CALL_ASSEMBLER CRN arm in the same file — does the same reposition and calls `correct_resume_vsd`, with a comment naming the hazard: the blackhole wrote the failing guard's recorded operand depth into the frame, and resuming at a different pc carries that over-count into the frame's peak stack use. One site corrected, the other did not.

The comment above the dispatch also named `bhimpl_recursive_call_r` as the door. pyre's codewriter emits no `recursive_call`, so the live door is `bhimpl_jit_merge_point`'s recursive-portal arm — reached when `nextblackholeinterp` is not None, i.e. a frame that already has a caller in the resumed chain. That *is* a resume. What makes it an activation for pyre is where the frame came from: `emit_new_pyframe_inline_with_params` built it inside compiled code, and `walker_ec_enter` records only `enter`'s frame-chain half, never `call_trace`, so it has had no bracket yet. The bottom level — the frame the interpreter itself bracketed — raises `ContinueRunningNormally` and takes the unbracketed entry instead.

**The exit-frame delivery screens are now shared.** `LoopResult::ExitFrameWithException` has three consumers. `deliver_exit_frame_exception` and `handle_jitexception` applied both `exit_frame_handler_needs_unwritten_stack` and `screen_frame_already_recorded`; the eval loop's back-edge site applied only the second — while the function-entry site's comment described the two as "the same delivery". Both now go through `screen_exit_frame_delivery`.

**The cranelift prologue's stack-overflow arm now publishes a descr.** `_build_stack_check_slowpath` ends by jumping to `propagate_exception_path`, so the frame it returns already names `propagate_exception_descr`. dynasm ports that; cranelift returned the frame with `jf_descr` untouched — the zero `handle_call_assembler` writes into every callee frame. On the trace-entry door that is masked, because the pending-exception drain runs before the outcome is classified at all; a CALL_ASSEMBLER caller has no such drain.

The emitted sequence reads the backend exception cells, and the raw slowpath cranelift registered does not write them — it parks the `RecursionError` in the interpreter's pending slot. Publishing the descr alone would therefore have stored a zero and let the propagate path resolve it through its `memory_error_singleton_ref()` fallback: a `MemoryError` where the program is owed a `RecursionError`. So the draining wrapper that was dynasm-only becomes `jit_prologue_stack_check_slowpath`, publishing through `store_jit_exception`, and both backends register it. The store sequence itself is extracted as `emit_propagate_exception_stores`, shared with the memory-error check that already emitted it.

## Measured reach

Two of the four are symmetry restorations with no observable behaviour change in the corpus, and the measurements say so — with one limit stated below:

- Instrumenting `screen_exit_frame_delivery` across **504 synth fixtures and 10 CPython test modules** (`test_exceptions`, `test_generators`, `test_traceback`, `test_with`, `test_contextlib`, ...) records **zero deliveries** — the `ExitFrameWithException` path is not entered at all, so no fixture covers this difference.
- `correct_resume_vsd` at the new site never *moves* a depth: instrumented to report only when the corrected value differs, it records zero across 504 fixtures, at the new site and at the three pre-existing ones alike. That probe does not cover the whole function — `correct_resume_vsd` also calls `clear_stack_above(corrected)` unconditionally whenever `depth_based_vsd_for_wcode` answers — so it is a bound on the depth half only. The uncovered half was then measured directly: gating the new call behind an env knob and running the fixture both ways is byte-identical on every counter.

Neither is gate-provable. They are landed because a single producer feeds consumers that must agree, and one consumer disagreed.

The `GUARD_NOT_FORCED` finding was refuted by measurement as well as by reading: a 6000-iteration loop whose callee forces its own virtualizable through `sys._getframe(0)` holds the `f_back` chain at depth 3 on CPython, `PYRE_JIT=0`, dynasm and cranelift alike. The cover the original refutation missed is `leave_resumed_blackhole_frame`, which runs at each of the three points where the blackhole leaves a frame in the chain.

## Reviewer note

Both remaining items from the review were checked against this HEAD.

**`MetaInterp::newframe`'s untyped green does not reach production.** The append is guarded on `greenkey` being `Some`, and the only non-test `perform_call` caller — `do_residual_or_indirect_call` — passes `None`, matching upstream's own `self.metainterp.perform_call(jitcode, argboxes)` at that site. So `find_biggest_function` never sees an untyped entry and `disable_noninlinable_function`'s hash door never opens; every production entry comes from `note_inline_subwalk_start`, which #1517 made typed.

**The missing `VIRTUAL_REF` at the CALL_ASSEMBLER portal door is left as-is.** The description is accurate and the blocker is real: installing a vref would make `leave_compiled_frame_chain`'s identity guard read NULL through the non-forcing `vref_referent` and skip the restore outright. Closing it needs a way for the two non-forcing readers to identify a frame without forcing, which is a separate change from this one; #1542's unit test pins the current vref-free shape deliberately.

## Verification

Rebased onto `origin/main` in two passes. The first, onto `67505f239e9`, took two conflicts, both resolved as blends rather than side-picks:

- `portal_activation_bracketed` — `origin/main`'s `getexecutioncontext()` (the field #1388 removed) plus this branch's `resume` parameter. `pyframe.py execute_frame` reads its execution context off the space, never off a frame field, so `origin/main`'s half is the orthodox one and the field read was the deviation.
- `bh_portal_runner_c` — `origin/main`'s `take_last_exec_ctx` / `set_last_exec_ctx` publication of the `ec` red plus this branch's depth correction, the correction placed before the publication since it does not need the context.

The second, onto `429f64fa28a`, applied clean.

`cargo fmt --all -- --check`, `scripts/check-majit-boundary.py`, `cargo test --all --no-default-features --features dynasm`, and `pyre/check.py` on all three backends: `dynasm 514/514`, `cranelift 514/514`, `wasm 507/507`, and 199 test binaries green.

### The two exception fixtures

An earlier run of this branch was red on `exception_escape_hot_callee_tb_node_once` and `exception_traceback_frame_lineno`, on all three backends. Those rows were never this branch's, and they are not re-recorded here: #1559 landed the correct baselines while this was in flight, and the second rebase above carries them. This tree observes exactly what #1559 recorded — `guard_failures=1015` for the first, `bridges_compiled=4` and `guard_failures=624` for the second.

That they were not this branch's was measured rather than inferred, before #1559 landed: with all four of its behavioural deltas disabled behind temporary env knobs — the depth correction, the shared exit-frame screen, the back-edge cell-key resolve and the caller-vref force — this tree observed the same counters in every arm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception propagation and stack-overflow handling for more consistent error reporting.
  * Fixed resumed generator and coroutine frames so profiling and call-stack information remain accurate.
  * Ensured escaped inlined callers are materialized correctly when accessing frame ancestry.
  * Corrected resumed-frame handling and back-edge resolution in JIT execution.

* **Tests**
  * Added regression coverage for virtual frame references and activation-bracket profiling.
  * Updated benchmark statistics to reflect successful loop completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->