### PR TITLE
majit: the #1547 review follow-ups, which its squash merge froze out

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -5509,6 +5509,34 @@ mod tests {
         }
 
         #[test]
+        fn default_bh_builder_unwired_set_matches_task_85_snapshot() {
+            let mut insns: indexmap::IndexMap<String, u8> = indexmap::IndexMap::new();
+            for (opname, byte) in majit_translate::insns::wellknown_bh_insns()
+                .into_iter()
+                .chain(majit_translate::insns::extension_insns())
+            {
+                insns.insert(opname.to_string(), byte);
+            }
+
+            let mut builder = BlackholeInterpBuilder::new();
+            builder.setup_insns(&insns);
+            super::wire_bhimpl_handlers(&mut builder);
+            let mut unwired: Vec<String> = builder
+                .unwired_opnames()
+                .into_iter()
+                .map(str::to_string)
+                .collect();
+            unwired.sort();
+
+            assert_eq!(
+                unwired,
+                Vec::<String>::new(),
+                "the canonical and extension opname tables must not acquire a handler gap; \
+                 fix the emitting kind shape instead of wiring a non-orthodox alias",
+            );
+        }
+
+        #[test]
         fn inline_builder_wires_float_cmp_and_raw_load_f() {
             // A dispatch arm materializing a float comparison as an int
             // (`(a >= b) as i64`) emits `float_ge/ff>i` and siblings, and

--- a/majit/majit-metainterp/src/jitcode/embedded.rs
+++ b/majit/majit-metainterp/src/jitcode/embedded.rs
@@ -124,6 +124,12 @@ impl EmbeddedJitCodeTable {
                         core.name,
                         core.try_index(),
                     );
+                    assert!(
+                        core.try_body().is_some(),
+                        "embedded all_jitcodes artefact contains bodyless jitcode {:?} at index \
+                         {index}; CodeWriter::make_jitcodes publishes only completed entries",
+                        core.name,
+                    );
                     let mut core = (**core).clone();
                     if let Some((_, runtime)) = replacements
                         .iter()
@@ -285,6 +291,18 @@ mod tests {
         let (mut canonical, descrs) = fixture();
         canonical.swap(0, 1);
         let _ = EmbeddedJitCodeTable::materialize(&canonical, descrs);
+    }
+
+    /// `all_jitcodes` is the codewriter's completed list; a numbered shell
+    /// with no body is a malformed embedded artefact, not a runtime bodyless
+    /// state for the materializer to preserve.
+    #[test]
+    #[should_panic(expected = "embedded all_jitcodes artefact contains bodyless jitcode")]
+    fn a_bodyless_all_jitcodes_entry_is_rejected_at_materialization() {
+        let core = Arc::new(CanonicalJitCode::new("bodyless"));
+        core.set_index(0);
+
+        let _ = EmbeddedJitCodeTable::materialize(&[core], Vec::new());
     }
 
     #[test]

--- a/majit/majit-metainterp/src/jitcode/embedded.rs
+++ b/majit/majit-metainterp/src/jitcode/embedded.rs
@@ -137,14 +137,12 @@ impl EmbeddedJitCodeTable {
                     {
                         core.fnaddr = *runtime;
                     }
-                    if core.try_body().is_some() {
-                        for constant in &mut core.body_mut().constants_i {
-                            if let Some((_, runtime)) = replacements
-                                .iter()
-                                .find(|(symbolic, _)| symbolic == constant)
-                            {
-                                *constant = *runtime;
-                            }
+                    for constant in &mut core.body_mut().constants_i {
+                        if let Some((_, runtime)) = replacements
+                            .iter()
+                            .find(|(symbolic, _)| symbolic == constant)
+                        {
+                            *constant = *runtime;
                         }
                     }
                     Arc::new(JitCode::from_canonical(core))

--- a/majit/majit-metainterp/src/jitcode/mod.rs
+++ b/majit/majit-metainterp/src/jitcode/mod.rs
@@ -542,6 +542,23 @@ pub struct JitCode {
     /// `JitCodeBuilder` populates this during runtime per-CodeObject
     /// emission.
     pub exec: JitCodeExecState,
+    /// Reachable symbolic residual targets, computed after the runtime wrapper
+    /// has received its final function-address bindings and descriptor pool.
+    ///
+    /// This belongs to the JitCode it describes rather than to a side table.
+    /// [`EmbeddedJitCodeTable::materialize_with_symbolic_fnaddrs`] constructs
+    /// new wrappers after applying replacements, so a newly materialized table
+    /// necessarily starts with a fresh answer for its bindings.
+    reachable_symbolic_residuals: std::sync::OnceLock<ReachableSymbolicResiduals>,
+}
+
+/// The static residual-call refusal facts reachable from one JitCode.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ReachableSymbolicResiduals {
+    /// Distinct unbound symbolic function addresses, in numeric order.
+    pub targets: Vec<i64>,
+    /// Number of distinct JitCode objects visited through `inline_call*`.
+    pub visited_jitcodes: usize,
 }
 
 // SAFETY: `JitCallTarget` / `JitCallAssemblerTarget` carry `*const ()`
@@ -562,6 +579,7 @@ impl JitCode {
         Self {
             core: majit_translate::jitcode::JitCode::new(name),
             exec: JitCodeExecState::default(),
+            reachable_symbolic_residuals: std::sync::OnceLock::new(),
         }
     }
 
@@ -590,6 +608,7 @@ impl JitCode {
                 jit_merge_point_offset,
                 ..JitCodeExecState::default()
             },
+            reachable_symbolic_residuals: std::sync::OnceLock::new(),
         }
     }
 
@@ -619,7 +638,121 @@ impl Clone for JitCode {
         Self {
             core: self.core.clone(),
             exec: self.exec.clone(),
+            reachable_symbolic_residuals: self.reachable_symbolic_residuals.clone(),
         }
+    }
+}
+
+impl JitCode {
+    /// Decode this body and every JitCode named by an `inline_call*`, and
+    /// return the residual-call targets that are still symbolic addresses.
+    ///
+    /// A residual call whose funcptr operand names a runtime Int register is
+    /// deliberately absent: its target is not a static property of the body,
+    /// so the per-instruction refusal in `report_symbolic_residual_call_target`
+    /// remains its backstop. Assembled bodies carry `startpoints`, which lets
+    /// this scan distinguish opcode bytes from identical bytes in operands
+    /// without maintaining a second opcode table.
+    pub fn reachable_symbolic_residuals(&self) -> &ReachableSymbolicResiduals {
+        self.reachable_symbolic_residuals
+            .get_or_init(|| compute_reachable_symbolic_residuals(self))
+    }
+}
+
+fn compute_reachable_symbolic_residuals(root: &JitCode) -> ReachableSymbolicResiduals {
+    fn is_residual_call(opcode: u8) -> bool {
+        matches!(
+            opcode,
+            insns::BC_RESIDUAL_CALL_R_V
+                | insns::BC_RESIDUAL_CALL_IR_V
+                | insns::BC_RESIDUAL_CALL_IRF_V
+                | insns::BC_RESIDUAL_CALL_R_I
+                | insns::BC_RESIDUAL_CALL_IR_I
+                | insns::BC_RESIDUAL_CALL_IRF_I
+                | insns::BC_RESIDUAL_CALL_R_R
+                | insns::BC_RESIDUAL_CALL_IR_R
+                | insns::BC_RESIDUAL_CALL_IRF_R
+                | insns::BC_RESIDUAL_CALL_IRF_F
+        )
+    }
+
+    fn is_inline_call(opcode: u8) -> bool {
+        matches!(
+            opcode,
+            insns::BC_INLINE_CALL
+                | insns::BC_INLINE_CALL_R_I
+                | insns::BC_INLINE_CALL_R_R
+                | insns::BC_INLINE_CALL_R_V
+                | insns::BC_INLINE_CALL_IR_I
+                | insns::BC_INLINE_CALL_IR_R
+                | insns::BC_INLINE_CALL_IR_V
+                | insns::BC_INLINE_CALL_IRF_I
+                | insns::BC_INLINE_CALL_IRF_R
+                | insns::BC_INLINE_CALL_IRF_F
+                | insns::BC_INLINE_CALL_IRF_V
+        )
+    }
+
+    fn visit(
+        jitcode: &JitCode,
+        visited: &mut std::collections::BTreeSet<usize>,
+        targets: &mut std::collections::BTreeSet<i64>,
+    ) {
+        if !visited.insert(jitcode as *const JitCode as usize) {
+            return;
+        }
+        let Some(starts) = jitcode.startpoints.as_ref() else {
+            // Hand-built bodies that bypass the assembler do not identify
+            // instruction boundaries. Their runtime residuals remain guarded
+            // by the site-level refusal rather than guessing that an operand
+            // byte is an opcode.
+            return;
+        };
+        for &pc in starts {
+            let Some(&opcode) = jitcode.code.get(pc) else {
+                continue;
+            };
+            if is_residual_call(opcode) {
+                let Some(&funcptr_reg) = jitcode.code.get(pc + 1) else {
+                    continue;
+                };
+                let funcptr_reg = funcptr_reg as usize;
+                if funcptr_reg < jitcode.num_regs_i() {
+                    continue;
+                }
+                let Some(&target) = jitcode.constants_i.get(funcptr_reg - jitcode.num_regs_i())
+                else {
+                    continue;
+                };
+                if crate::pyjitpl::resolve_symbolic_fnaddr_path(target).is_some()
+                    || majit_translate::codewriter::call::is_symbolic_fnaddr(target)
+                {
+                    targets.insert(target);
+                }
+                continue;
+            }
+            if !is_inline_call(opcode) {
+                continue;
+            }
+            let Some((&lo, &hi)) = jitcode.code.get(pc + 1).zip(jitcode.code.get(pc + 2)) else {
+                continue;
+            };
+            let descr_index = u16::from_le_bytes([lo, hi]) as usize;
+            if let Some(callee) = jitcode
+                .descr_at(descr_index)
+                .and_then(RuntimeBhDescr::as_jitcode_owned)
+            {
+                visit(callee.as_ref(), visited, targets);
+            }
+        }
+    }
+
+    let mut visited = std::collections::BTreeSet::new();
+    let mut targets = std::collections::BTreeSet::new();
+    visit(root, &mut visited, &mut targets);
+    ReachableSymbolicResiduals {
+        targets: targets.into_iter().collect(),
+        visited_jitcodes: visited.len(),
     }
 }
 

--- a/majit/majit-metainterp/src/jitcode/mod.rs
+++ b/majit/majit-metainterp/src/jitcode/mod.rs
@@ -546,9 +546,15 @@ pub struct JitCode {
     /// has received its final function-address bindings and descriptor pool.
     ///
     /// This belongs to the JitCode it describes rather than to a side table.
-    /// [`EmbeddedJitCodeTable::materialize_with_symbolic_fnaddrs`] constructs
-    /// new wrappers after applying replacements, so a newly materialized table
-    /// necessarily starts with a fresh answer for its bindings.
+    /// `jitcode_runtime::load_jitcode` runs `patch_constants_i_fnaddrs` on the
+    /// canonical JitCode before any wrapper exists. Likewise,
+    /// `EmbeddedJitCodeTable::materialize_with_replacements` applies
+    /// replacements to a cloned canonical core before `JitCode::from_canonical`
+    /// constructs a fresh wrapper. No production path can therefore observe a
+    /// memo computed before a binding change. The only in-place mutations of a
+    /// wrapper's `constants_i` are five `#[test]` sites in `resume`, `frame`, and
+    /// `pyre-jit-trace::state`; a future non-test mutator would require an
+    /// invalidation hook here.
     reachable_symbolic_residuals: std::sync::OnceLock<ReachableSymbolicResiduals>,
 }
 

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2114,15 +2114,6 @@ impl<S: JitState> JitDriver<S> {
     /// RPython parity: `metainterp_sd.jitcodes[portal_jd.index]` global
     /// registry slot assignment, scoped to the per-`#[jit_interp]` driver.
     pub fn register_dispatch_jitcode(&mut self, jitcode: crate::jitcode::JitCode) {
-        // Slice (audit Issue #5) — cross-check the dispatch JitCode
-        // body's `BC_JIT_MERGE_POINT` payload partition against the
-        // declared driver schema (set via `declare_schema` at the
-        // macro-emitted install path).  The check fires only when a
-        // schema is non-empty AND the payload counts disagree, which
-        // indicates a codegen / `make_three_lists` regression.
-        // Production-active — `warmspot.py:660-666
-        // make_args_specification` translation-time assert parity.
-        validate_dispatch_jitcode_payload(self, &jitcode);
         let (registry, dispatch_arc) =
             build_jitcode_registry(crate::jitcode::global_build_jitcodes(), jitcode);
         self.adopt_dispatch_registry(registry, dispatch_arc);
@@ -2146,7 +2137,6 @@ impl<S: JitState> JitDriver<S> {
         &mut self,
         jitcode: &std::sync::Arc<crate::jitcode::JitCode>,
     ) {
-        validate_dispatch_jitcode_payload(self, jitcode);
         let (registry, dispatch_arc) =
             build_seeded_jitcode_registry(crate::jitcode::global_build_jitcodes(), jitcode)
                 .unwrap_or_else(|| {
@@ -2165,6 +2155,14 @@ impl<S: JitState> JitDriver<S> {
         registry: Vec<std::sync::Arc<crate::jitcode::JitCode>>,
         dispatch_arc: std::sync::Arc<crate::jitcode::JitCode>,
     ) {
+        // Validate after `build_jitcode_registry` has selected the canonical
+        // indexed identity. A seeded caller is only a locator: name, index,
+        // and merge offset do not prove equal bodies, and validating that
+        // disposable shell before adopting `all_jitcodes[index]` would install
+        // unchecked bytecode. `codewriter.py CodeWriter.make_jitcodes` owns
+        // the identity invariant `all_jitcodes[jitcode.index] is jitcode`;
+        // validate that exact object before publishing it as `mainjitcode`.
+        validate_dispatch_jitcode_payload(self, &dispatch_arc);
         // call.py `grab_initial_jitcodes`:
         //
         //     jd.mainjitcode = self.get_jitcode(jd.portal_graph)
@@ -11610,6 +11608,40 @@ mod jitcode_registry_tests {
         ))];
         let dispatch = jitcode_value_with_merge_offset("mainloop", Some(0), Some(7));
         build_jitcode_registry(&seed, dispatch);
+    }
+
+    /// Name, index, and merge offset can all agree while the bodies do not.
+    /// Registration therefore validates the seed entry selected by the
+    /// codewriter's indexed object identity, rather than the locator shell the
+    /// caller hands over and then drops.
+    #[test]
+    #[should_panic(expected = "payload slot 0 count 1 disagrees")]
+    fn adoption_validates_the_seeded_object_that_it_installs() {
+        let seeded_core = majit_translate::jitcode::JitCode::new("mainloop");
+        seeded_core.set_body(majit_translate::jitcode::JitCodeBody {
+            code: vec![
+                majit_translate::codewriter::insns::BC_JIT_MERGE_POINT,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ],
+            jit_merge_point_offset: Some(0),
+            ..Default::default()
+        });
+        seeded_core.set_index(0);
+        let seed = vec![Arc::new(JitCode::from_canonical(seeded_core))];
+        let locator = seeded_portal("mainloop", 0, 0);
+        let locator = Arc::try_unwrap(locator).expect("the locator has one owner");
+        let (registry, adopted) = build_jitcode_registry(&seed, locator);
+        let mut driver = JitDriver::<RegistryState>::new(2);
+        driver.declare_schema(Vec::new(), Vec::new());
+
+        driver.adopt_dispatch_registry(registry, adopted);
     }
 
     /// A dispatch numbered past the end of the seed names the method that

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5852,6 +5852,16 @@ impl<S: JitState> JitDriver<S> {
             carried_procedure_token.or_else(|| self.meta.entry_procedure_token(green_key))
             && let Some(compiled_meta) = self.meta.get_compiled_meta(green_key).cloned()
         {
+            // warmstate.py `WarmEnterState.make_entry_point` /
+            // `maybe_compile_and_run`: the confirmation veto sits between
+            // finding the procedure token and `EnterJitAssembler`.
+            if !self
+                .meta
+                .warm_state_ref()
+                .confirm_compiled_entry_for_cell_key(green_key)
+            {
+                return None;
+            }
             let descriptor = self.driver_descriptor_for(state, &compiled_meta);
             // Resolved here with the descriptor and carried to both ends of
             // the run; see `sync_before` for why it is not asked for twice.
@@ -9038,6 +9048,7 @@ mod tests {
     use super::*;
     use crate::resume::ReconstructedFrame;
     use majit_ir::{GcRef, OpCode, OpRef, Type, Value};
+    use std::sync::Arc;
 
     // `seed_deopt_vinfo_ptr` decides which guard-failure deopts hand the blackhole
     // a non-null `bh.virtualizable_info`. A state-field machine (no `vable_token`)
@@ -9249,6 +9260,132 @@ mod tests {
         fn validate_close(_sym: &Self::Sym, _meta: &Self::Meta) -> bool {
             true
         }
+    }
+
+    fn compiled_structured_back_edge_fixture() -> (
+        JitDriver<TypedRestoreState>,
+        u64,
+        GreenKey,
+        TypedRestoreState,
+    ) {
+        let code = 0x7100usize;
+        let pc = 19usize;
+        let key = GreenKey::with_types(
+            vec![pc as i64, 0, code as i64],
+            vec![Type::Int, Type::Int, Type::Ref],
+        );
+        let hash = key.get_uhash();
+        let mut driver = JitDriver::<TypedRestoreState>::new(1);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
+        let live = [Value::Int(1)];
+        assert!(matches!(
+            driver
+                .meta
+                .on_back_edge_typed(hash, (code, pc), None, None, &live),
+            BackEdgeAction::StartedTracing,
+        ));
+        {
+            let ctx = driver
+                .meta
+                .trace_ctx()
+                .expect("trace starts at threshold 1");
+            let i0 = OpRef::input_arg_int(0);
+            let guard = ctx.record_guard(OpCode::GuardFalse, &[i0], 0);
+            ctx.capture_snapshot_for_last_guard(&[i0], 0, 0);
+            ctx.set_fail_args(guard, &[i0]);
+        }
+        driver.meta.compile_loop(&[OpRef::input_arg_int(0)], ());
+        assert!(driver.has_compiled_loop(hash));
+        let state = TypedRestoreState {
+            live_values: vec![1],
+            ..Default::default()
+        };
+        (driver, hash, key, state)
+    }
+
+    /// `warmstate.py maybe_compile_and_run` consults `confirm_enter_jit`
+    /// after finding a procedure token and before raising
+    /// `EnterJitAssembler`; the structured back-edge door owes the same veto.
+    #[test]
+    fn a_confirm_enter_jit_veto_stops_the_structured_back_edge_compiled_door() {
+        static CONFIRMS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        fn refuse(_key: &GreenKey) -> bool {
+            CONFIRMS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            false
+        }
+
+        CONFIRMS.store(0, std::sync::atomic::Ordering::Relaxed);
+        let (mut driver, hash, key, mut state) = compiled_structured_back_edge_fixture();
+        let compiled_entries = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counted_entries = Arc::clone(&compiled_entries);
+        driver.set_on_compiled_entry(move |_, _| {
+            counted_entries.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        });
+        driver
+            .meta
+            .warm_state_mut()
+            .set_confirm_enter_jit(Some(refuse));
+        let mut pre_ran = false;
+
+        let outcome = driver.back_edge_structured(
+            hash,
+            || key.clone(),
+            19,
+            &mut state,
+            &(),
+            || pre_ran = true,
+        );
+
+        assert_eq!(outcome, None);
+        assert_eq!(CONFIRMS.load(std::sync::atomic::Ordering::Relaxed), 1);
+        assert!(!pre_ran, "a veto returns before the compiled-entry pre-run");
+        assert_eq!(
+            compiled_entries.load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "the rejected structured back edge must not enter compiled code",
+        );
+    }
+
+    /// The positive control distinguishes a working confirmation gate from a
+    /// door that never reaches compiled code at all.
+    #[test]
+    fn a_permissive_confirm_enter_jit_preserves_the_structured_back_edge_compiled_door() {
+        static CONFIRMS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        fn allow(_key: &GreenKey) -> bool {
+            CONFIRMS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            true
+        }
+
+        CONFIRMS.store(0, std::sync::atomic::Ordering::Relaxed);
+        let (mut driver, hash, key, mut state) = compiled_structured_back_edge_fixture();
+        let compiled_entries = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counted_entries = Arc::clone(&compiled_entries);
+        driver.set_on_compiled_entry(move |_, _| {
+            counted_entries.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        });
+        driver
+            .meta
+            .warm_state_mut()
+            .set_confirm_enter_jit(Some(allow));
+        let mut pre_ran = false;
+
+        let outcome = driver.back_edge_structured(
+            hash,
+            || key.clone(),
+            19,
+            &mut state,
+            &(),
+            || pre_ran = true,
+        );
+
+        assert!(outcome.is_some(), "the permissive door executes the loop");
+        assert_eq!(CONFIRMS.load(std::sync::atomic::Ordering::Relaxed), 1);
+        assert!(pre_ran, "the permissive door reaches the compiled pre-run");
+        assert_eq!(
+            compiled_entries.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "the permissive structured back edge must enter compiled code",
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -855,7 +855,7 @@ fn kind_counts(vars: &[JitDriverVar], kind: VarKind) -> (usize, usize, usize) {
 /// start of the dispatch body, and the count check would only
 /// false-pass when the body coincidentally starts with a
 /// well-formed-looking 7-byte sequence at the same offset.  The
-/// check fires in release builds — `warmspot.py:660-666
+/// check fires in release builds — `warmspot.py
 /// make_args_specification` runs at translation time and asserts
 /// the marker op's args match the driver schema; the runtime
 /// version stays active in production for the same reason

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2176,7 +2176,11 @@ impl<S: JitState> JitDriver<S> {
         // install pipeline runs `ensure_descriptor_registered` before reaching
         // here, so it is assigned. Fall back to the single-portal slot 0 only
         // when a consumer skipped that step.
-        self.ensure_descriptor_registered();
+        if let Some(seed_index) = dispatch_arc.jitdriver_sd() {
+            self.ensure_descriptor_registered_at(seed_index);
+        } else {
+            self.ensure_descriptor_registered();
+        }
         let portal_jd_index = self.index().unwrap_or(0);
         // The back-pointer is what makes this jitcode a *portal* jitcode to
         // every reader of `JitCode::jitdriver_sd`: `pyjitpl.py:2451
@@ -2463,14 +2467,29 @@ impl<S: JitState> JitDriver<S> {
     /// stub — pyre-only fail-soft, since PyPy's `jitdrivers_sd` list
     /// would never contain such an entry.
     pub fn ensure_descriptor_registered(&mut self) {
+        self.ensure_descriptor_registered_with_index(None);
+    }
+
+    fn ensure_descriptor_registered_at(&mut self, index: usize) {
+        self.ensure_descriptor_registered_with_index(Some(index));
+    }
+
+    fn ensure_descriptor_registered_with_index(&mut self, preinstalled_index: Option<usize>) {
         if self.index().is_some() {
+            if let Some(index) = preinstalled_index {
+                assert_eq!(
+                    self.index(),
+                    Some(index),
+                    "registered driver descriptor index disagrees with its seeded portal",
+                );
+            }
             return;
         }
         let jd = self
             .descriptor
             .take()
             .unwrap_or_else(|| JitDriverStaticData::new(vec![], vec![]));
-        let _ = self.register_descriptor(jd);
+        let _ = self.register_descriptor_with_index(jd, preinstalled_index);
     }
 
     /// Register `jd` with the embedded `MetaInterpStaticData` and stamp the
@@ -2484,6 +2503,14 @@ impl<S: JitState> JitDriver<S> {
     /// `jd.index` into `BC_JIT_MERGE_POINT` / `BC_LOOP_HEADER` payloads —
     /// see `jtransform.py:1704, :1716`).
     pub fn register_descriptor(&mut self, jd: JitDriverStaticData) -> usize {
+        self.register_descriptor_with_index(jd, None)
+    }
+
+    fn register_descriptor_with_index(
+        &mut self,
+        jd: JitDriverStaticData,
+        preinstalled_index: Option<usize>,
+    ) -> usize {
         let crate::pyjitpl::MetaInterp {
             staticdata,
             backend,
@@ -2491,7 +2518,10 @@ impl<S: JitState> JitDriver<S> {
         } = &mut self.meta;
         let sd_mut = std::sync::Arc::get_mut(staticdata)
             .expect("MetaInterpStaticData must be uniquely owned at register_descriptor time");
-        let idx = sd_mut.register_jitdriver_sd(jd, backend);
+        let idx = match preinstalled_index {
+            Some(index) => sd_mut.preinstall_jitdriver_sd(jd, index, backend),
+            None => sd_mut.register_jitdriver_sd(jd, backend),
+        };
         // Mirror onto self.descriptor so JitDriver::index() returns Some(idx)
         // — A.3.1a's accessor reads through descriptor, not the
         // staticdata Vec, so the stamped clone must live on the driver too.
@@ -11128,6 +11158,37 @@ mod jitcode_registry_tests {
     use crate::jitcode::{JitCode, RuntimeBhDescr};
     use std::sync::Arc;
 
+    #[derive(Default)]
+    struct RegistryState;
+
+    impl JitState for RegistryState {
+        type Meta = ();
+        type Sym = ();
+        type Env = ();
+
+        fn build_meta(&self, _header_pc: usize, _env: &Self::Env) -> Self::Meta {}
+
+        fn extract_live(&self, _meta: &Self::Meta) -> Vec<i64> {
+            Vec::new()
+        }
+
+        fn create_sym(_meta: &Self::Meta, _header_pc: usize) -> Self::Sym {}
+
+        fn is_compatible(&self, _meta: &Self::Meta) -> bool {
+            true
+        }
+
+        fn restore(&mut self, _meta: &Self::Meta, _values: &[i64]) {}
+
+        fn collect_jump_args(_sym: &Self::Sym) -> Vec<OpRef> {
+            Vec::new()
+        }
+
+        fn validate_close(_sym: &Self::Sym, _meta: &Self::Meta) -> bool {
+            true
+        }
+    }
+
     /// The arm a consumer holding only an `Arc` reaches through
     /// `register_dispatch_jitcode_shared`.
     ///
@@ -11159,6 +11220,27 @@ mod jitcode_registry_tests {
     /// build-time table numbers its entries.
     fn jitcode(name: &str, prenumbered: Option<usize>) -> Arc<JitCode> {
         Arc::new(jitcode_value(name, prenumbered))
+    }
+
+    fn seeded_portal(name: &str, index: usize, jitdriver_sd: usize) -> Arc<JitCode> {
+        let core = majit_translate::jitcode::JitCode::new(name);
+        core.set_body(majit_translate::jitcode::JitCodeBody {
+            code: vec![
+                majit_translate::codewriter::insns::BC_JIT_MERGE_POINT,
+                jitdriver_sd as u8,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ],
+            jit_merge_point_offset: Some(0),
+            ..Default::default()
+        });
+        core.set_index(index);
+        core.set_jitdriver_sd(jitdriver_sd);
+        Arc::new(JitCode::from_canonical(core))
     }
 
     /// The same, by value, for handing `build_jitcode_registry` the graph its
@@ -11343,6 +11425,29 @@ mod jitcode_registry_tests {
         assert_eq!(dispatch.index(), 2);
         assert_eq!(dispatch.name(), "add");
         assert!(std::sync::Arc::ptr_eq(&registry[2], &dispatch));
+    }
+
+    /// A build-time portal retains the driver slot the codewriter recorded on
+    /// it. The second prepass driver is the first non-coincidental case: a
+    /// fresh run-time staticdata table would otherwise allocate slot 0 and try
+    /// to overwrite the seed's set-once `jitdriver_sd == 1` relationship.
+    #[test]
+    fn a_seeded_second_driver_registers_at_its_build_time_descriptor_index() {
+        let first = jitcode("first_portal", Some(0));
+        let second = seeded_portal("second_portal", 1, 1);
+        let seed = vec![first, Arc::clone(&second)];
+        let mut driver = JitDriver::<RegistryState>::new(2);
+        driver.declare_schema(Vec::new(), Vec::new());
+
+        driver.adopt_dispatch_registry(seed, Arc::clone(&second));
+
+        assert_eq!(driver.index(), Some(1));
+        assert!(Arc::ptr_eq(
+            driver
+                .dispatch_jitcode()
+                .expect("registration installs the seeded portal"),
+            &second,
+        ));
     }
 
     /// Two graphs claiming one slot is not adoptable: the seed's entry and the

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -19504,7 +19504,30 @@ impl MetaInterpStaticData {
     /// caller does not need to set them.
     pub fn register_jitdriver_sd(
         &mut self,
+        jd: crate::jitdriver::JitDriverStaticData,
+        cpu: &mut dyn majit_backend::Backend,
+    ) -> usize {
+        self.register_jitdriver_sd_at(jd, None, cpu)
+    }
+
+    /// Install a descriptor at an index already assigned by the codewriter.
+    /// Slots before it are retained as vacant shells until their own seeded
+    /// portals are registered. This is the incremental equivalent of
+    /// `pyjitpl.py MetaInterpStaticData.finish_setup` taking the codewriter's
+    /// complete `callcontrol.jitdrivers_sd` list with its existing indices.
+    pub(crate) fn preinstall_jitdriver_sd(
+        &mut self,
+        jd: crate::jitdriver::JitDriverStaticData,
+        index: usize,
+        cpu: &mut dyn majit_backend::Backend,
+    ) -> usize {
+        self.register_jitdriver_sd_at(jd, Some(index), cpu)
+    }
+
+    fn register_jitdriver_sd_at(
+        &mut self,
         mut jd: crate::jitdriver::JitDriverStaticData,
+        preinstalled_index: Option<usize>,
         cpu: &mut dyn majit_backend::Backend,
     ) -> usize {
         // `ensure_default_driver_sd` exists only so translation-time metadata
@@ -19518,14 +19541,29 @@ impl MetaInterpStaticData {
             && self.jitdrivers_sd[0].portal_runner_adr == 0
             && self.jitdrivers_sd[0].num_greens() == 0
             && self.jitdrivers_sd[0].reds().is_empty();
-        if replace_default {
+        let idx = preinstalled_index.unwrap_or_else(|| {
+            if replace_default {
+                0
+            } else {
+                self.jitdrivers_sd.len()
+            }
+        });
+        while self.jitdrivers_sd.len() < idx {
+            self.jitdrivers_sd
+                .push(crate::jitdriver::JitDriverStaticData::new(vec![], vec![]));
+        }
+        let replace_slot = idx < self.jitdrivers_sd.len();
+        if replace_slot {
             // The shell and `jd` are two Rust phases of the one RPython
-            // JitDriverStaticData object.  Setup may already have attached
-            // virtualizable metadata to the shell before CallControl stamps
-            // its index; replacing the storage must retain those attributes.
-            // Structural fields (greens/reds/runner/result type) come from the
-            // real descriptor, while optional setup products move forward.
-            let shell = &self.jitdrivers_sd[0];
+            // JitDriverStaticData object. Setup may already have attached
+            // optional metadata before CallControl stamps the slot; replacing
+            // the storage retains those products while structural fields come
+            // from the real descriptor.
+            let shell = &self.jitdrivers_sd[idx];
+            assert!(
+                shell.index.is_none(),
+                "jitdriver_sd slot {idx} is already occupied by a registered descriptor",
+            );
             if jd.virtualizable_info.is_none() {
                 jd.virtualizable_info = shell.virtualizable_info.clone();
             }
@@ -19542,14 +19580,9 @@ impl MetaInterpStaticData {
                 jd.frame_value_count_fn = shell.frame_value_count_fn;
             }
         }
-        let idx = if replace_default {
-            0
-        } else {
-            self.jitdrivers_sd.len()
-        };
         jd.index = Some(idx); // call.py:46-47 `jd.index = idx`
-        if replace_default {
-            self.jitdrivers_sd[0] = jd;
+        if replace_slot {
+            self.jitdrivers_sd[idx] = jd;
         } else {
             self.jitdrivers_sd.push(jd);
         }

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1149,7 +1149,7 @@ pub fn symbolic_residual_trace_aborts() -> u64 {
 fn report_symbolic_residual_call_target(
     ctx: &mut TraceCtx,
     func: usize,
-    arg_classes: &str,
+    arg_classes: Option<&str>,
 ) -> TraceAction {
     ctx.symbolic_residual_abort = true;
     SYMBOLIC_RESIDUAL_TRACE_ABORTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -1163,14 +1163,16 @@ fn report_symbolic_residual_call_target(
         if let Some(path) = super::resolve_symbolic_fnaddr_path(func as i64) {
             eprintln!(
                 "residual call target {func:#x} is symbolic path {path:?}, not a code address \
-                 (arg classes {arg_classes:?}). The host did not bind this callee's path — add \
+                 (arg classes {arg_classes:?}; None means the static reachable-set scan). The \
+                 host did not bind this callee's path — add \
                  it to the fnaddr bindings passed to \
                  `EmbeddedJitCodeTable::materialize_with_symbolic_fnaddrs`."
             );
         } else {
             eprintln!(
                 "residual call target {func:#x} is a symbolic path hash, not a code address \
-                 (arg classes {arg_classes:?}). The host did not bind this callee's path — add \
+                 (arg classes {arg_classes:?}; None means the static reachable-set scan). The \
+                 host did not bind this callee's path — add \
                  it to the fnaddr bindings passed to \
                  `EmbeddedJitCodeTable::materialize_with_symbolic_fnaddrs`, and look the hash up \
                  in the host's symbolic-path table to see which path it names."
@@ -1178,6 +1180,28 @@ fn report_symbolic_residual_call_target(
         }
     }
     TraceAction::Abort
+}
+
+/// Refuse a trace whose statically reachable body contains an unbound
+/// symbolic residual target, before the walk can execute any body instruction.
+fn refuse_reachable_symbolic_residuals(ctx: &mut TraceCtx, jitcode: &JitCode) -> bool {
+    let targets = &jitcode.reachable_symbolic_residuals().targets;
+    if targets.is_empty() {
+        return false;
+    }
+
+    // This whole-reachable-body gate is deliberately coarser than refusing at
+    // the call: a symbolic target in an arm this trace would not take blocks
+    // the portal too. Such a host cannot complete a trace that does reach the
+    // target, and declining before the walk is preferable to duplicating an
+    // earlier residual's heap effects.
+    for &target in targets {
+        let _ = report_symbolic_residual_call_target(ctx, target as usize, None);
+    }
+    // No temporary frame was built, so there is no abort handoff publisher to
+    // consume the site-level marker. Do not leak it into a later walk.
+    ctx.symbolic_residual_abort = false;
+    true
 }
 
 impl<FLabel> ClosureRuntime<FLabel> {
@@ -7317,7 +7341,7 @@ where
                         return report_symbolic_residual_call_target(
                             ctx,
                             concrete_ptr as usize,
-                            &calldescr.arg_classes,
+                            Some(&calldescr.arg_classes),
                         );
                     }
                     if !concrete_ptr.is_null() {
@@ -7416,7 +7440,7 @@ where
                         return report_symbolic_residual_call_target(
                             ctx,
                             concrete_ptr as usize,
-                            &calldescr.arg_classes,
+                            Some(&calldescr.arg_classes),
                         );
                     }
                     if !concrete_ptr.is_null() {
@@ -7639,7 +7663,7 @@ where
                         return report_symbolic_residual_call_target(
                             ctx,
                             concrete_ptr as usize,
-                            &calldescr.arg_classes,
+                            Some(&calldescr.arg_classes),
                         );
                     }
                     if !concrete_ptr.is_null() {
@@ -7717,7 +7741,7 @@ where
                         return report_symbolic_residual_call_target(
                             ctx,
                             concrete_ptr as usize,
-                            &calldescr.arg_classes,
+                            Some(&calldescr.arg_classes),
                         );
                     }
                     let concrete = if concrete_ptr.is_null() {
@@ -7936,7 +7960,7 @@ where
                         return report_symbolic_residual_call_target(
                             ctx,
                             concrete_ptr as usize,
-                            &calldescr.arg_classes,
+                            Some(&calldescr.arg_classes),
                         );
                     }
                     if !concrete_ptr.is_null() {
@@ -8010,7 +8034,7 @@ where
                         return report_symbolic_residual_call_target(
                             ctx,
                             concrete_ptr as usize,
-                            &calldescr.arg_classes,
+                            Some(&calldescr.arg_classes),
                         );
                     }
                     let concrete = if concrete_ptr.is_null() {
@@ -8191,7 +8215,7 @@ where
                         return report_symbolic_residual_call_target(
                             ctx,
                             concrete_ptr as usize,
-                            &calldescr.arg_classes,
+                            Some(&calldescr.arg_classes),
                         );
                     }
                     if !concrete_ptr.is_null() {
@@ -8254,7 +8278,7 @@ where
                         return report_symbolic_residual_call_target(
                             ctx,
                             concrete_ptr as usize,
-                            &calldescr.arg_classes,
+                            Some(&calldescr.arg_classes),
                         );
                     }
                     let concrete = if concrete_ptr.is_null() {
@@ -10060,6 +10084,9 @@ where
     S: JitCodeSym,
     R: JitCodeRuntime,
 {
+    if refuse_reachable_symbolic_residuals(ctx, jitcode) {
+        return TraceAction::Abort;
+    }
     let jitcode_arc = Arc::new(jitcode.clone());
     let mut standalone = StandaloneFrameStack::new();
     let mut frame = MIFrame::setup(jitcode_arc, pc, None, Some(ctx));
@@ -10106,16 +10133,13 @@ fn publish_walk_abort_handoff(
     standalone: &mut StandaloneFrameStack,
 ) {
     if matches!(action, TraceAction::Abort) && !standalone.frames.is_empty() {
-        // `try_generate_dispatch_arm_body` lowers every statement in one
-        // source arm, in order, into the same sub-JitCode.  Each residual-call
-        // instruction executes its concrete target before recording it, so a
-        // symbolic target may be refused after an earlier residual call in the
-        // arm already committed heap effects.  Replaying from
-        // `last_mp_green_pc` would execute that prefix twice; publishing the
-        // post-decode framestack would skip the refused call.  There is no
-        // sound automatic resume position, so publish neither handoff and let
-        // the public `symbolic_residual_trace_aborts` counter tell the embedder
-        // that its fnaddr bindings are incomplete.
+        // `None` is itself a resume choice: the generated dispatch loop falls
+        // through and re-runs the source arm. The trace-start reachable-set
+        // gate makes that sound for every statically named target because no
+        // residual in the refused trace has executed. A funcptr read from a
+        // runtime register is invisible to that scan and reaches this
+        // site-level backstop; it also takes the arm-replay position, because
+        // the post-decode framestack would skip the refused call altogether.
         if std::mem::replace(&mut ctx.symbolic_residual_abort, false) {
             return;
         }
@@ -10233,6 +10257,12 @@ where
     S: JitCodeSym,
     R: JitCodeRuntime,
 {
+    if frames
+        .first()
+        .is_some_and(|frame| refuse_reachable_symbolic_residuals(ctx, &frame.jitcode))
+    {
+        return TraceAction::Abort;
+    }
     let mut standalone = StandaloneFrameStack::new();
     for (depth, resume_frame) in frames.iter().enumerate() {
         let mut frame = MIFrame::setup(
@@ -10343,6 +10373,9 @@ where
     S: JitCodeSym,
     R: JitCodeRuntime,
 {
+    if refuse_reachable_symbolic_residuals(ctx, jitcode) {
+        return TraceAction::Abort;
+    }
     let jitcode_arc = Arc::new(jitcode.clone());
     // Decode the six register lists of the `jit_merge_point` op at
     // `header_pc`: opcode(1) + jdindex(1), then `[len:u8][reg:u8 * len]` per
@@ -13150,12 +13183,12 @@ mod tests {
         );
     }
 
-    /// A dispatch-arm sub-JitCode is a statement sequence, so one residual
-    /// call can commit a side effect before a later residual target is refused.
-    /// No source-pc or blackhole handoff is sound for that abort: the former
-    /// repeats the committed prefix, while the latter skips the refused call.
+    /// A funcptr read from a runtime register cannot be found by the static
+    /// reachable-set scan. Keep the site-level refusal live for that shape and
+    /// verify that its `None` handoff selects the source-arm replay rather than
+    /// skipping the refused call through a post-decode framestack.
     #[test]
-    fn symbolic_residual_after_concrete_residual_publishes_no_resume_handoff() {
+    fn indirect_symbolic_residual_keeps_the_site_level_abort_backstop() {
         let before = RESIDUAL_PREFIX_CALLS.load(std::sync::atomic::Ordering::Relaxed);
         let mut builder = JitCodeBuilder::new();
         builder.load_const_i_value(0, 47);
@@ -13174,7 +13207,27 @@ mod tests {
             &[],
             residual_effect(majit_ir::descr::ExtraEffect::CannotRaise),
         );
-        let jitcode = builder.finish();
+        let mut jitcode = builder.finish();
+        let symbolic_pc = jitcode
+            .startpoints
+            .as_ref()
+            .unwrap()
+            .iter()
+            .copied()
+            .filter(|&pc| {
+                matches!(
+                    jitcode.code[pc],
+                    jitcode::insns::BC_RESIDUAL_CALL_R_V
+                        | jitcode::insns::BC_RESIDUAL_CALL_IR_V
+                        | jitcode::insns::BC_RESIDUAL_CALL_IRF_V
+                )
+            })
+            .nth(1)
+            .expect("the second residual call is the symbolic target");
+        // Make the funcptr operand dynamic from the static scan's point of
+        // view. The per-callsite target bridge still supplies the symbolic
+        // concrete pointer when the instruction executes.
+        jitcode.body_mut().code[symbolic_pc + 1] = 0;
 
         let mut ctx = TraceCtx::for_test_types(&[Type::Int]);
         // The production dispatch walk set this at the source opcode's merge
@@ -13194,7 +13247,7 @@ mod tests {
         assert_eq!(
             RESIDUAL_PREFIX_CALLS.load(std::sync::atomic::Ordering::Relaxed),
             before + 1,
-            "the concrete prefix call executes before the symbolic refusal",
+            "the concrete prefix call executes before the indirect symbolic refusal",
         );
         assert_eq!(
             ctx.last_mp_green_pc,

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1130,29 +1130,15 @@ pub struct ClosureRuntime<FLabel> {
 static SYMBOLIC_RESIDUAL_TRACE_ABORTS: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
-/// Number of tracing instructions precisely declined because their concrete
-/// residual-call target was still a symbolic path hash.
+/// Number of tracing attempts refused because a residual-call target was still
+/// a symbolic path hash: once per reachable-set preflight refusal, however
+/// many targets it names, plus once per per-instruction residual-call decline.
 pub fn symbolic_residual_trace_aborts() -> u64 {
     SYMBOLIC_RESIDUAL_TRACE_ABORTS.load(std::sync::atomic::Ordering::Relaxed)
 }
 
-/// Report a residual call whose target is still a `symbolic_fnaddr_for_path`
-/// placeholder, once per distinct target.
-///
-/// A placeholder means the host never bound that callee's path, so the address
-/// is a hash of the path rather than code. Jumping to it faults somewhere with
-/// no trace of which callee was missing, and answering 0 (the null-target arm
-/// below) would quietly substitute a wrong result. `blackhole.rs` already
-/// declines the same shape on its own residual-call handlers; this is the
-/// tracing side of that check. Every caller returns [`TraceAction::Abort`]
-/// before making the call, so discarding the recording needs no rollback.
-fn report_symbolic_residual_call_target(
-    ctx: &mut TraceCtx,
-    func: usize,
-    arg_classes: Option<&str>,
-) -> TraceAction {
-    ctx.symbolic_residual_abort = true;
-    SYMBOLIC_RESIDUAL_TRACE_ABORTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+/// Print the missing-binding diagnostic once per distinct symbolic target.
+fn report_symbolic_residual_call_target_once(func: usize, arg_classes: Option<&str>) {
     static REPORTED: std::sync::LazyLock<std::sync::Mutex<std::collections::BTreeSet<usize>>> =
         std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::BTreeSet::new()));
     let first_report = REPORTED
@@ -1179,12 +1165,32 @@ fn report_symbolic_residual_call_target(
             );
         }
     }
+}
+
+/// Report a residual call whose target is still a `symbolic_fnaddr_for_path`
+/// placeholder, once per distinct target.
+///
+/// A placeholder means the host never bound that callee's path, so the address
+/// is a hash of the path rather than code. Jumping to it faults somewhere with
+/// no trace of which callee was missing, and answering 0 (the null-target arm
+/// below) would quietly substitute a wrong result. `blackhole.rs` already
+/// declines the same shape on its own residual-call handlers; this is the
+/// tracing side of that check. Every caller returns [`TraceAction::Abort`]
+/// before making the call, so discarding the recording needs no rollback.
+fn report_symbolic_residual_call_target(
+    ctx: &mut TraceCtx,
+    func: usize,
+    arg_classes: Option<&str>,
+) -> TraceAction {
+    ctx.symbolic_residual_abort = true;
+    SYMBOLIC_RESIDUAL_TRACE_ABORTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    report_symbolic_residual_call_target_once(func, arg_classes);
     TraceAction::Abort
 }
 
 /// Refuse a trace whose statically reachable body contains an unbound
 /// symbolic residual target, before the walk can execute any body instruction.
-fn refuse_reachable_symbolic_residuals(ctx: &mut TraceCtx, jitcode: &JitCode) -> bool {
+fn refuse_reachable_symbolic_residuals(jitcode: &JitCode) -> bool {
     let targets = &jitcode.reachable_symbolic_residuals().targets;
     if targets.is_empty() {
         return false;
@@ -1195,12 +1201,10 @@ fn refuse_reachable_symbolic_residuals(ctx: &mut TraceCtx, jitcode: &JitCode) ->
     // the portal too. Such a host cannot complete a trace that does reach the
     // target, and declining before the walk is preferable to duplicating an
     // earlier residual's heap effects.
+    SYMBOLIC_RESIDUAL_TRACE_ABORTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     for &target in targets {
-        let _ = report_symbolic_residual_call_target(ctx, target as usize, None);
+        report_symbolic_residual_call_target_once(target as usize, None);
     }
-    // No temporary frame was built, so there is no abort handoff publisher to
-    // consume the site-level marker. Do not leak it into a later walk.
-    ctx.symbolic_residual_abort = false;
     true
 }
 
@@ -10084,7 +10088,7 @@ where
     S: JitCodeSym,
     R: JitCodeRuntime,
 {
-    if refuse_reachable_symbolic_residuals(ctx, jitcode) {
+    if refuse_reachable_symbolic_residuals(jitcode) {
         return TraceAction::Abort;
     }
     let jitcode_arc = Arc::new(jitcode.clone());
@@ -10137,9 +10141,14 @@ fn publish_walk_abort_handoff(
         // through and re-runs the source arm. The trace-start reachable-set
         // gate makes that sound for every statically named target because no
         // residual in the refused trace has executed. A funcptr read from a
-        // runtime register is invisible to that scan and reaches this
+        // runtime Int register is invisible to that scan and reaches this
         // site-level backstop; it also takes the arm-replay position, because
         // the post-decode framestack would skip the refused call altogether.
+        // An earlier residual call in that arm may already have committed heap
+        // effects, so replay runs that prefix a second time. This narrowed
+        // duplicate-effect window is the residue the trace-start gate does not
+        // close, and replay is still preferred over publishing the post-decode
+        // framestack and skipping the refused call.
         if std::mem::replace(&mut ctx.symbolic_residual_abort, false) {
             return;
         }
@@ -10259,7 +10268,7 @@ where
 {
     if frames
         .first()
-        .is_some_and(|frame| refuse_reachable_symbolic_residuals(ctx, &frame.jitcode))
+        .is_some_and(|frame| refuse_reachable_symbolic_residuals(&frame.jitcode))
     {
         return TraceAction::Abort;
     }
@@ -10373,7 +10382,7 @@ where
     S: JitCodeSym,
     R: JitCodeRuntime,
 {
-    if refuse_reachable_symbolic_residuals(ctx, jitcode) {
+    if refuse_reachable_symbolic_residuals(jitcode) {
         return TraceAction::Abort;
     }
     let jitcode_arc = Arc::new(jitcode.clone());
@@ -12296,6 +12305,7 @@ mod tests {
 
     static RESIDUAL_PREFIX_CALLS: std::sync::atomic::AtomicUsize =
         std::sync::atomic::AtomicUsize::new(0);
+    static SYMBOLIC_RESIDUAL_COUNTER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     extern "C" fn residual_count_prefix() {
         RESIDUAL_PREFIX_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -13189,6 +13199,9 @@ mod tests {
     /// skipping the refused call through a post-decode framestack.
     #[test]
     fn indirect_symbolic_residual_keeps_the_site_level_abort_backstop() {
+        let _counter_guard = SYMBOLIC_RESIDUAL_COUNTER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let before = RESIDUAL_PREFIX_CALLS.load(std::sync::atomic::Ordering::Relaxed);
         let mut builder = JitCodeBuilder::new();
         builder.load_const_i_value(0, 47);
@@ -13263,6 +13276,46 @@ mod tests {
             !ctx.symbolic_residual_abort,
             "the one-shot refusal flag must be consumed by the publisher",
         );
+    }
+
+    #[test]
+    fn reachable_symbolic_preflight_counts_one_refusal_for_two_targets() {
+        let _counter_guard = SYMBOLIC_RESIDUAL_COUNTER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let first = majit_translate::codewriter::call::symbolic_fnaddr_for_segments([
+            "reachable_symbolic_preflight_first_target",
+        ]);
+        let second = majit_translate::codewriter::call::symbolic_fnaddr_for_segments([
+            "reachable_symbolic_preflight_second_target",
+        ]);
+        assert_ne!(first, second);
+
+        let mut builder = JitCodeBuilder::new();
+        for target in [first, second] {
+            let target_index = builder.add_fn_ptr(target as usize as *const ());
+            builder.residual_call_void_canonical_via_target_with_effect_info(
+                target_index,
+                &[],
+                residual_effect(majit_ir::descr::ExtraEffect::CannotRaise),
+            );
+        }
+        builder.void_return();
+        let jitcode = builder.finish();
+
+        let mut expected_targets = vec![first, second];
+        expected_targets.sort_unstable();
+        assert_eq!(
+            jitcode.reachable_symbolic_residuals().targets,
+            expected_targets,
+            "the preflight must see both distinct symbolic targets",
+        );
+
+        let before = symbolic_residual_trace_aborts();
+        assert!(refuse_reachable_symbolic_residuals(&jitcode));
+        let after = symbolic_residual_trace_aborts();
+
+        assert_eq!(after - before, 1, "one trace start is one refusal");
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1127,6 +1127,15 @@ pub struct ClosureRuntime<FLabel> {
     label_at: FLabel,
 }
 
+static SYMBOLIC_RESIDUAL_TRACE_ABORTS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Number of tracing instructions precisely declined because their concrete
+/// residual-call target was still a symbolic path hash.
+pub fn symbolic_residual_trace_aborts() -> u64 {
+    SYMBOLIC_RESIDUAL_TRACE_ABORTS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Report a residual call whose target is still a `symbolic_fnaddr_for_path`
 /// placeholder, once per distinct target.
 ///
@@ -1137,15 +1146,6 @@ pub struct ClosureRuntime<FLabel> {
 /// declines the same shape on its own residual-call handlers; this is the
 /// tracing side of that check. Every caller returns [`TraceAction::Abort`]
 /// before making the call, so discarding the recording needs no rollback.
-static SYMBOLIC_RESIDUAL_TRACE_ABORTS: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(0);
-
-/// Number of tracing instructions precisely declined because their concrete
-/// residual-call target was still a symbolic path hash.
-pub fn symbolic_residual_trace_aborts() -> u64 {
-    SYMBOLIC_RESIDUAL_TRACE_ABORTS.load(std::sync::atomic::Ordering::Relaxed)
-}
-
 fn report_symbolic_residual_call_target(
     ctx: &mut TraceCtx,
     func: usize,

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1146,7 +1146,12 @@ pub fn symbolic_residual_trace_aborts() -> u64 {
     SYMBOLIC_RESIDUAL_TRACE_ABORTS.load(std::sync::atomic::Ordering::Relaxed)
 }
 
-fn report_symbolic_residual_call_target(func: usize, arg_classes: &str) {
+fn report_symbolic_residual_call_target(
+    ctx: &mut TraceCtx,
+    func: usize,
+    arg_classes: &str,
+) -> TraceAction {
+    ctx.symbolic_residual_abort = true;
     SYMBOLIC_RESIDUAL_TRACE_ABORTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     static REPORTED: std::sync::LazyLock<std::sync::Mutex<std::collections::BTreeSet<usize>>> =
         std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::BTreeSet::new()));
@@ -1172,6 +1177,7 @@ fn report_symbolic_residual_call_target(func: usize, arg_classes: &str) {
             );
         }
     }
+    TraceAction::Abort
 }
 
 impl<FLabel> ClosureRuntime<FLabel> {
@@ -7308,11 +7314,11 @@ where
                 if effectinfo.oopspecindex == majit_ir::descr::OopSpecIndex::NotInTrace {
                     self.clear_exception();
                     if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
-                        report_symbolic_residual_call_target(
+                        return report_symbolic_residual_call_target(
+                            ctx,
                             concrete_ptr as usize,
                             &calldescr.arg_classes,
                         );
-                        return TraceAction::Abort;
                     }
                     if !concrete_ptr.is_null() {
                         unsafe {
@@ -7407,11 +7413,11 @@ where
                     //    `extern "C" fn(...) -> i64` and reads garbage from
                     //    rax/x0).
                     if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
-                        report_symbolic_residual_call_target(
+                        return report_symbolic_residual_call_target(
+                            ctx,
                             concrete_ptr as usize,
                             &calldescr.arg_classes,
                         );
-                        return TraceAction::Abort;
                     }
                     if !concrete_ptr.is_null() {
                         unsafe {
@@ -7630,11 +7636,11 @@ where
                     // int destination register, and abort on exception.
                     self.clear_exception();
                     if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
-                        report_symbolic_residual_call_target(
+                        return report_symbolic_residual_call_target(
+                            ctx,
                             concrete_ptr as usize,
                             &calldescr.arg_classes,
                         );
-                        return TraceAction::Abort;
                     }
                     if !concrete_ptr.is_null() {
                         unsafe {
@@ -7708,11 +7714,11 @@ where
                     // return) — RPython `executor.execute_varargs` →
                     // `cpu.bh_call_i`.
                     if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
-                        report_symbolic_residual_call_target(
+                        return report_symbolic_residual_call_target(
+                            ctx,
                             concrete_ptr as usize,
                             &calldescr.arg_classes,
                         );
-                        return TraceAction::Abort;
                     }
                     let concrete = if concrete_ptr.is_null() {
                         0
@@ -7927,11 +7933,11 @@ where
                     // branch for the full citation.
                     self.clear_exception();
                     if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
-                        report_symbolic_residual_call_target(
+                        return report_symbolic_residual_call_target(
+                            ctx,
                             concrete_ptr as usize,
                             &calldescr.arg_classes,
                         );
-                        return TraceAction::Abort;
                     }
                     if !concrete_ptr.is_null() {
                         unsafe {
@@ -8001,11 +8007,11 @@ where
                         None
                     };
                     if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
-                        report_symbolic_residual_call_target(
+                        return report_symbolic_residual_call_target(
+                            ctx,
                             concrete_ptr as usize,
                             &calldescr.arg_classes,
                         );
-                        return TraceAction::Abort;
                     }
                     let concrete = if concrete_ptr.is_null() {
                         0
@@ -8182,11 +8188,11 @@ where
                     // branch for the full citation.
                     self.clear_exception();
                     if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
-                        report_symbolic_residual_call_target(
+                        return report_symbolic_residual_call_target(
+                            ctx,
                             concrete_ptr as usize,
                             &calldescr.arg_classes,
                         );
-                        return TraceAction::Abort;
                     }
                     if !concrete_ptr.is_null() {
                         unsafe {
@@ -8245,11 +8251,11 @@ where
                         None
                     };
                     if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
-                        report_symbolic_residual_call_target(
+                        return report_symbolic_residual_call_target(
+                            ctx,
                             concrete_ptr as usize,
                             &calldescr.arg_classes,
                         );
-                        return TraceAction::Abort;
                     }
                     let concrete = if concrete_ptr.is_null() {
                         0.0f64
@@ -10100,6 +10106,19 @@ fn publish_walk_abort_handoff(
     standalone: &mut StandaloneFrameStack,
 ) {
     if matches!(action, TraceAction::Abort) && !standalone.frames.is_empty() {
+        // `try_generate_dispatch_arm_body` lowers every statement in one
+        // source arm, in order, into the same sub-JitCode.  Each residual-call
+        // instruction executes its concrete target before recording it, so a
+        // symbolic target may be refused after an earlier residual call in the
+        // arm already committed heap effects.  Replaying from
+        // `last_mp_green_pc` would execute that prefix twice; publishing the
+        // post-decode framestack would skip the refused call.  There is no
+        // sound automatic resume position, so publish neither handoff and let
+        // the public `symbolic_residual_trace_aborts` counter tell the embedder
+        // that its fnaddr bindings are incomplete.
+        if std::mem::replace(&mut ctx.symbolic_residual_abort, false) {
+            return;
+        }
         if let Some(pc) = standalone.frames.frames[0]
             .int_values
             .first()
@@ -12242,6 +12261,13 @@ mod tests {
 
     extern "C" fn residual_void_no_args() {}
 
+    static RESIDUAL_PREFIX_CALLS: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+
+    extern "C" fn residual_count_prefix() {
+        RESIDUAL_PREFIX_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
     extern "C" fn residual_void_raises() {
         // exc payload must be a valid OBJECTPTR (typeptr at offset 0) so
         // `DefaultCpu::cls_of_box` can dereference per model.py.
@@ -13121,6 +13147,68 @@ mod tests {
                 .iter()
                 .any(|op| op.opcode == OpCode::GuardValue),
             "catch handler must see last_exc_value after residual-call unwind"
+        );
+    }
+
+    /// A dispatch-arm sub-JitCode is a statement sequence, so one residual
+    /// call can commit a side effect before a later residual target is refused.
+    /// No source-pc or blackhole handoff is sound for that abort: the former
+    /// repeats the committed prefix, while the latter skips the refused call.
+    #[test]
+    fn symbolic_residual_after_concrete_residual_publishes_no_resume_handoff() {
+        let before = RESIDUAL_PREFIX_CALLS.load(std::sync::atomic::Ordering::Relaxed);
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_i_value(0, 47);
+        let concrete_idx = builder.add_fn_ptr(residual_count_prefix as *const ());
+        builder.residual_call_void_canonical_via_target_with_effect_info(
+            concrete_idx,
+            &[],
+            residual_effect(majit_ir::descr::ExtraEffect::CannotRaise),
+        );
+        let symbolic = majit_translate::codewriter::call::symbolic_fnaddr_for_segments([
+            "symbolic_residual_after_concrete_residual",
+        ]);
+        let symbolic_idx = builder.add_fn_ptr(symbolic as usize as *const ());
+        builder.residual_call_void_canonical_via_target_with_effect_info(
+            symbolic_idx,
+            &[],
+            residual_effect(majit_ir::descr::ExtraEffect::CannotRaise),
+        );
+        let jitcode = builder.finish();
+
+        let mut ctx = TraceCtx::for_test_types(&[Type::Int]);
+        // The production dispatch walk set this at the source opcode's merge
+        // point before entering its arm sub-JitCode.
+        ctx.last_mp_green_pc = Some(41);
+        let mut sym = DummySym;
+        let action = trace_jitcode_with_args(
+            &mut ctx,
+            &mut sym,
+            &jitcode,
+            41,
+            |_pc| 0,
+            &[(JitArgKind::Int, OpRef::input_arg_int(0), 41)],
+        );
+
+        assert!(matches!(action, TraceAction::Abort));
+        assert_eq!(
+            RESIDUAL_PREFIX_CALLS.load(std::sync::atomic::Ordering::Relaxed),
+            before + 1,
+            "the concrete prefix call executes before the symbolic refusal",
+        );
+        assert_eq!(
+            ctx.last_mp_green_pc,
+            Some(41),
+            "the source-opcode replay coordinate exists but is unsafe",
+        );
+        assert_eq!(ctx.walk_final_pc, None, "no source-pc handoff is sound");
+        assert!(
+            ctx.aborted_framestack.is_none(),
+            "no post-decode blackhole handoff is sound",
+        );
+        assert!(
+            !ctx.symbolic_residual_abort,
+            "the one-shot refusal flag must be consumed by the publisher",
         );
     }
 

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -556,6 +556,13 @@ pub struct TraceCtx {
     /// instruction boundary).  RPython has no counterpart: it has no panic arm
     /// here.
     pub abort_after_panic: bool,
+    /// Set when the walk refused a residual call whose target was still a
+    /// symbolic path hash.  A dispatch-arm sub-JitCode may contain an earlier
+    /// residual call that already executed concretely, so neither replaying
+    /// the source opcode nor resuming after the refused call is sound.  The
+    /// abort publisher consumes this flag and declines both resume handoffs;
+    /// [`crate::symbolic_residual_trace_aborts`] is the embedder-facing signal.
+    pub symbolic_residual_abort: bool,
     /// `pyjitpl.py run_blackhole_interp_to_cancel_tracing` needs
     /// `metainterp.framestack` to still exist when it calls
     /// `blackhole.py convert_and_run_from_pyjitpl(self, ...)`.  RPython
@@ -1756,6 +1763,7 @@ impl TraceCtx {
             walk_final_pc: None,
             last_mp_green_pc: None,
             abort_after_panic: false,
+            symbolic_residual_abort: false,
             aborted_framestack: None,
             walk_final_reds: Vec::new(),
             pending_guard_not_invalidated_pc: None,
@@ -1853,6 +1861,7 @@ impl TraceCtx {
             walk_final_pc: None,
             last_mp_green_pc: None,
             abort_after_panic: false,
+            symbolic_residual_abort: false,
             aborted_framestack: None,
             walk_final_reds: Vec::new(),
             pending_guard_not_invalidated_pc: None,

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -2789,6 +2789,9 @@ impl WarmEnterState {
     /// admissible substitute.
     #[inline]
     pub(crate) fn confirm_compiled_entry_for_cell_key(&self, cell_key: u64) -> bool {
+        if self.confirm_enter_jit_ptr.is_none() {
+            return true;
+        }
         let green_key = self
             .cell_by_key(cell_key)
             .and_then(|cell| cell.comparekey.as_ref());

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -160,9 +160,9 @@ pub struct GraphTransformConfig {
     ///
     /// Named here the way [`Self::jitdriver_receiver_roots`] names the
     /// driver. [`Default`] is pyre's helper, so a pipeline that does not name
-    /// one keeps pyre's behaviour. An empty name declines the rewrite, which
-    /// is what a host with no such helper wants: a call to a symbol it cannot
-    /// bind is a trace-ender, not a lowering.
+    /// one keeps pyre's behaviour. An empty name emits an explicit abort
+    /// before the original operation, which is what a host with no such helper
+    /// wants: the operation is a trace-ender, not a lowering.
     #[serde(default = "default_str_concat_helper")]
     pub str_concat_helper: String,
     /// The host's own `str(i)` helper, called for a `str` over an Int operand.
@@ -1473,6 +1473,45 @@ impl<'a> Transformer<'a> {
         graph_name: &str,
         graph: &mut crate::model::FunctionGraph,
     ) -> RewriteResult {
+        let configured_helper = match &op.kind {
+            OpKind::UnaryOp {
+                op: unop_name,
+                operand,
+                ..
+            } if unop_name == "str" && self.get_value_kind_var(operand) == 'i' => {
+                Some(self.config.int_str_helper.as_str())
+            }
+            OpKind::BinOp {
+                op: binop_name,
+                lhs,
+                rhs,
+                ..
+            } if binop_name == "add"
+                && self.get_value_kind_var(lhs) == 'r'
+                && self.get_value_kind_var(rhs) == 'r' =>
+            {
+                Some(self.config.str_concat_helper.as_str())
+            }
+            _ => None,
+        };
+        if configured_helper.is_some_and(str::is_empty) {
+            // The empty-name contract is a host refusal, not permission to
+            // leave a handler-less integer opname in the JitCode. Put the
+            // abort first so tracing and blackhole execution both refuse
+            // before reaching the original operation.
+            return RewriteResult::Replace(vec![
+                SpaceOperation {
+                    result: None,
+                    kind: OpKind::Abort {
+                        kind: crate::model::UnknownKind::UnsupportedExpr {
+                            variant: crate::model::UnsupportedExprKind::HostHelperRefused,
+                        },
+                    },
+                },
+                op.clone(),
+            ]);
+        }
+
         match &op.kind {
             // ── rewrite_op_hint ──
             //
@@ -8939,14 +8978,9 @@ mod tests {
         );
     }
 
-    /// An unnamed helper declines the rewrite.
-    ///
-    /// The alternative is worse than not lowering: a residual call to a symbol
-    /// the host cannot bind keeps the build's sentinel address, so a trace
-    /// that reaches it declines there. Leaving the op alone at least keeps the
-    /// failure at the op that has no lowering.
+    /// An unnamed helper emits the host-refusal abort before the original op.
     #[test]
-    fn an_unnamed_int_str_helper_leaves_the_op_alone() {
+    fn an_unnamed_int_str_helper_aborts_before_the_original_op() {
         let (graph, _n_var) = int_str_graph();
         let config = GraphTransformConfig {
             int_str_helper: String::new(),
@@ -8960,11 +8994,19 @@ mod tests {
             "no helper is named, so nothing is called: {ops:?}",
         );
         assert!(
-            ops.iter().any(|op| matches!(
-                &op.kind,
-                OpKind::UnaryOp { op: name, .. } if name == "str"
-            )),
-            "the op survives for whatever lowers it next: {ops:?}",
+            matches!(
+                &ops[1].kind,
+                OpKind::Abort {
+                    kind: crate::model::UnknownKind::UnsupportedExpr {
+                        variant: crate::model::UnsupportedExprKind::HostHelperRefused,
+                    },
+                }
+            ),
+            "the host refusal must be explicit: {ops:?}",
+        );
+        assert!(
+            matches!(&ops[2].kind, OpKind::UnaryOp { op: name, .. } if name == "str"),
+            "the original op stays residual after the abort: {ops:?}",
         );
     }
 
@@ -9032,10 +9074,10 @@ mod tests {
         );
     }
 
-    /// An unnamed concat helper declines the rewrite, matching the integer
-    /// helper's empty-name contract.
+    /// An unnamed concat helper emits the same host-refusal abort as the
+    /// integer helper.
     #[test]
-    fn an_unnamed_str_concat_helper_leaves_the_op_alone() {
+    fn an_unnamed_str_concat_helper_aborts_before_the_original_op() {
         let graph = str_concat_graph();
         let config = GraphTransformConfig {
             str_concat_helper: String::new(),
@@ -9049,11 +9091,19 @@ mod tests {
             "no helper is named, so nothing is called: {ops:?}",
         );
         assert!(
-            ops.iter().any(|op| matches!(
-                &op.kind,
-                OpKind::BinOp { op: name, .. } if name == "add"
-            )),
-            "the op survives for whatever lowers it next: {ops:?}",
+            matches!(
+                &ops[2].kind,
+                OpKind::Abort {
+                    kind: crate::model::UnknownKind::UnsupportedExpr {
+                        variant: crate::model::UnsupportedExprKind::HostHelperRefused,
+                    },
+                }
+            ),
+            "the host refusal must be explicit: {ops:?}",
+        );
+        assert!(
+            matches!(&ops[3].kind, OpKind::BinOp { op: name, .. } if name == "add"),
+            "the original op stays residual after the abort: {ops:?}",
         );
     }
 

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -8968,6 +8968,95 @@ mod tests {
         );
     }
 
+    /// `s1 + s2` over two Ref operands, as one graph, for the two tests below.
+    fn str_concat_graph() -> FunctionGraph {
+        let mut graph = FunctionGraph::new("str_concat");
+        let lhs = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::Input {
+                    name: "lhs".into(),
+                    ty: ValueType::Ref(None),
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        let rhs = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::Input {
+                    name: "rhs".into(),
+                    ty: ValueType::Ref(None),
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        let result = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::BinOp {
+                    op: "add".into(),
+                    lhs: lhs.clone(),
+                    rhs: rhs.clone(),
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_return(graph.startblock, Some(result.clone()));
+        FunctionGraph::set_concretetype_of_inline(&lhs, ConcreteType::GcRef);
+        FunctionGraph::set_concretetype_of_inline(&rhs, ConcreteType::GcRef);
+        FunctionGraph::set_concretetype_of_inline(&result, ConcreteType::GcRef);
+        graph
+    }
+
+    /// The concat callee is supplied by the embedding pipeline on the same
+    /// terms as the integer-render helper above.
+    #[test]
+    fn a_named_str_concat_helper_is_the_call_target() {
+        let graph = str_concat_graph();
+        let config = GraphTransformConfig {
+            str_concat_helper: "grain_concat".to_string(),
+            ..Default::default()
+        };
+        let transformed = Transformer::new(&config).transform(&graph);
+        let ops = &transformed.graph.block(graph.startblock).operations;
+        assert_eq!(ops.len(), 5, "Input + Input + fnptr + call + Live");
+        let expected =
+            crate::call::symbolic_fnaddr_for_target(&CallTarget::function_path(["grain_concat"]));
+        assert!(
+            matches!(&ops[2].kind, OpKind::ConstInt(fnaddr) if *fnaddr == expected),
+            "the fnptr names the configured helper, not this layer's default",
+        );
+    }
+
+    /// An unnamed concat helper declines the rewrite, matching the integer
+    /// helper's empty-name contract.
+    #[test]
+    fn an_unnamed_str_concat_helper_leaves_the_op_alone() {
+        let graph = str_concat_graph();
+        let config = GraphTransformConfig {
+            str_concat_helper: String::new(),
+            ..Default::default()
+        };
+        let transformed = Transformer::new(&config).transform(&graph);
+        let ops = &transformed.graph.block(graph.startblock).operations;
+        assert!(
+            !ops.iter()
+                .any(|op| matches!(op.kind, OpKind::CallResidual { .. })),
+            "no helper is named, so nothing is called: {ops:?}",
+        );
+        assert!(
+            ops.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::BinOp { op: name, .. } if name == "add"
+            )),
+            "the op survives for whatever lowers it next: {ops:?}",
+        );
+    }
+
     #[test]
     fn transform_graph_tags_vable_fields() {
         let mut graph = FunctionGraph::new("test");

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -192,6 +192,12 @@ pub enum UnsupportedExprKind {
     /// Classified separately from `OtherExpr` so the producer site is
     /// distinguishable from the catch-all in dual-gate diagnostics.
     Closure,
+    /// Not a `syn::Expr` variant: the embedding host explicitly declined to
+    /// name a helper required to lower an otherwise recognized operation.
+    /// It is carried in this family because `OpKind::Abort` accepts an
+    /// `UnknownKind`, whose only structured reason payload is
+    /// `UnsupportedExpr`.
+    HostHelperRefused,
     OtherExpr,
 }
 

--- a/majit/majit-translate/src/pipeline.rs
+++ b/majit/majit-translate/src/pipeline.rs
@@ -117,7 +117,15 @@ pub struct CompiledJitDriver {
     /// never declared; `red_args_types` describes them in that case.
     #[serde(default)]
     pub reds: Vec<String>,
-    /// RPython: `jd._green_args_spec` (`warmspot.py:663`), parallel to `greens`.
+    /// RPython: `jd._green_args_spec` (`warmspot.py
+    /// make_args_specification`), parallel to `greens`.
+    ///
+    /// Upstream stores each marker operand's full `concretetype`, including
+    /// `Ptr(rstr.STR)` / `Ptr(rstr.UNICODE)`.  Pyre's graph-side
+    /// `ConcreteType` has already projected every GC pointer to `GcRef` before
+    /// `Transformer::marker_operand_kinds` reads it, so this artifact can only
+    /// preserve the IR kind today.  Widening this field to `GreenType` would
+    /// not recover information its producer cannot supply.
     #[serde(default)]
     pub green_args_spec: Vec<majit_ir::Type>,
     /// RPython: `jd.red_args_types` (`warmspot.py:664`).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -7397,6 +7397,165 @@ fn unsupported_opname_surfaces_typed_error() {
     assert_eq!(err, DispatchError::UnsupportedOpname { pc: 0, key: opname },);
 }
 
+#[test]
+fn empty_str_concat_helper_aborts_before_the_unwired_op_is_dispatched() {
+    use majit_translate::codewriter::{call::CallControl, codewriter::CodeWriter};
+    use majit_translate::{
+        CallPath, ConcreteType, FunctionGraph, GraphTransformConfig, OpKind, ValueType,
+    };
+
+    let mut graph = FunctionGraph::new("empty_str_concat_helper");
+    let lhs = graph
+        .push_op_var(
+            graph.startblock,
+            OpKind::Input {
+                name: "lhs".into(),
+                ty: ValueType::Ref(None),
+                class_root: None,
+            },
+            true,
+        )
+        .unwrap();
+    let rhs = graph
+        .push_op_var(
+            graph.startblock,
+            OpKind::Input {
+                name: "rhs".into(),
+                ty: ValueType::Ref(None),
+                class_root: None,
+            },
+            true,
+        )
+        .unwrap();
+    let result = graph
+        .push_op_var(
+            graph.startblock,
+            OpKind::BinOp {
+                op: "add".into(),
+                lhs: lhs.clone(),
+                rhs: rhs.clone(),
+                result_ty: ValueType::Ref(None),
+            },
+            true,
+        )
+        .unwrap();
+    graph.set_return(graph.startblock, Some(result.clone()));
+    FunctionGraph::set_concretetype_of_inline(&lhs, ConcreteType::GcRef);
+    FunctionGraph::set_concretetype_of_inline(&rhs, ConcreteType::GcRef);
+    FunctionGraph::set_concretetype_of_inline(&result, ConcreteType::GcRef);
+
+    let config = GraphTransformConfig {
+        str_concat_helper: String::new(),
+        ..Default::default()
+    };
+    let path = CallPath::from_segments(["empty_str_concat_helper"]);
+    let mut callcontrol = CallControl::new();
+    callcontrol.register_function_graph(path.clone(), graph);
+    let jitcode = callcontrol.get_jitcode(&path);
+    let mut codewriter = CodeWriter::new();
+    codewriter.drain_pending_graphs(&mut callcontrol, &config);
+    let body = jitcode
+        .try_body()
+        .expect("the public codewriter pipeline commits the concat graph");
+
+    let original_opname = "int_add/rr>r";
+    let original_byte = *codewriter
+        .assembler
+        .insns()
+        .get(original_opname)
+        .expect("the original Ref + Ref add remains after the refusal marker");
+    let original_pc = body
+        .code
+        .iter()
+        .enumerate()
+        .find_map(|(pc, candidate)| {
+            (*candidate == original_byte && jitcode.is_valid_startpoint(pc)).then_some(pc)
+        })
+        .expect("assembled body contains the Ref + Ref add byte");
+    let abort_byte = *codewriter
+        .assembler
+        .insns()
+        .get("abort/")
+        .expect("the empty helper emits the explicit abort opname");
+    let abort_pc = body
+        .code
+        .iter()
+        .enumerate()
+        .find_map(|(pc, candidate)| {
+            (*candidate == abort_byte && jitcode.is_valid_startpoint(pc)).then_some(pc)
+        })
+        .expect("assembled body contains the explicit abort byte");
+    assert!(
+        abort_pc < original_pc,
+        "the refusal must be reached before the handler-less original op",
+    );
+    let decoded = crate::jitcode_runtime::DecodedOp {
+        key: "abort/",
+        opname: "abort",
+        argcodes: "",
+        pc: abort_pc,
+        next_pc: abort_pc + 1,
+    };
+
+    let mut trace_ctx = fresh_trace_ctx();
+    let session = std::cell::RefCell::new(WalkSession::default());
+    let mut registers_r = vec![OpRef::NONE; body.c_num_regs_r as usize];
+    let mut concrete_registers_r = vec![ConcreteValue::Null; body.c_num_regs_r as usize];
+    let mut walk_ctx = WalkContext {
+        callee_shadow: None,
+        inline_callee_consts: None,
+        inline_poison_pcs: None,
+        fbw_mode: test_fbw_mode(),
+        session: &session,
+        registers_r: &mut registers_r,
+        registers_i: &mut [],
+        registers_f: &mut [],
+        concrete_registers_r: &mut concrete_registers_r,
+        concrete_registers_i: &mut [],
+        descr_refs: &[],
+        raw_descrs: RawDescrPool::Global,
+        is_authoritative_executor: false,
+        trace_ctx: &mut trace_ctx,
+        is_top_level: true,
+        sub_jitcode_lookup: &no_sub_jitcodes,
+        entry_py_pc: EntryPyPc::Py(0),
+        outer_resume_marker_jit_pc: None,
+        outer_jitcode_index: 0,
+        outer_active_boxes: Vec::new(),
+        pending_guard_snapshot_error: None,
+        vstack_boxes: Vec::new(),
+        vstack_depth: 0,
+        vstack_cur_pypc: 0,
+        vstack_valid: false,
+        vstack_last_ref: OpRef::NONE,
+        vstack_reorder_ceiling: u32::MAX,
+        vstack_reorder_saved: None,
+        vstack_handler_landing_py: None,
+        live_before_jit_pc: usize::MAX,
+        live_after_jit_pc: usize::MAX,
+    };
+    let trace_error = super::handle(&decoded, &body.code, &mut walk_ctx)
+        .expect_err("the walker stops at the explicit refusal marker");
+    assert_eq!(
+        trace_error,
+        DispatchError::AbortMarkerReached { pc: abort_pc },
+    );
+
+    let mut builder = majit_metainterp::blackhole::BlackholeInterpBuilder::new();
+    builder.setup_insns(codewriter.assembler.insns());
+    majit_metainterp::blackhole::wire_bhimpl_handlers(&mut builder);
+    assert_eq!(builder.unwired_opnames(), vec![original_opname]);
+    let mut bh = builder.acquire_interp();
+    assert!(
+        matches!(
+            builder.dispatch_loop(&mut bh, &body.code, abort_pc),
+            Err(majit_metainterp::blackhole::DispatchError::LeaveFrame)
+        ),
+        "the blackhole exits at the refusal marker before the unwired add",
+    );
+    assert!(bh.aborted);
+}
+
 /// `ptr_nonzero/r>i` records `PtrNe(box, CONST_NULL)` into the
 /// int dst.  RPython parity: `pyjitpl.py opimpl_ptr_nonzero`
 /// returns `self.execute(rop.PTR_NE, box, CONST_NULL)`.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -1,7 +1,117 @@
 use super::*;
 use crate::jitcode_runtime::{insns_opname_to_byte, named_jitcode};
 use majit_ir::Type;
-use majit_metainterp::{VableArrayStore, make_fail_descr};
+use majit_metainterp::{JitCodeSym, TraceAction, VableArrayStore, make_fail_descr};
+
+static STATIC_REFUSAL_PREFIX_CALLS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+extern "C" fn count_static_refusal_prefix() {
+    STATIC_REFUSAL_PREFIX_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
+struct StaticRefusalSym;
+
+impl JitCodeSym for StaticRefusalSym {
+    fn total_slots(&self) -> usize {
+        0
+    }
+
+    fn loop_header_pc(&self) -> usize {
+        0
+    }
+
+    fn fail_args(&self) -> Option<Vec<OpRef>> {
+        Some(Vec::new())
+    }
+}
+
+/// The generated dispatch loop re-runs its source arm when a trace start
+/// returns no handoff. The static refusal must therefore happen before the
+/// bound prefix call: the arm itself then performs that side effect once.
+#[test]
+fn unbound_symbolic_residual_refuses_before_a_bound_residual_side_effect() {
+    let before = STATIC_REFUSAL_PREFIX_CALLS.load(std::sync::atomic::Ordering::Relaxed);
+    let mut builder = majit_metainterp::JitCodeBuilder::new();
+    let bound = builder.add_fn_ptr(count_static_refusal_prefix as *const ());
+    builder.residual_call_void_canonical_via_target_with_effect_info(
+        bound,
+        &[],
+        majit_ir::EffectInfo::const_new(
+            majit_ir::ExtraEffect::CannotRaise,
+            majit_ir::OopSpecIndex::None,
+        ),
+    );
+    let symbolic = majit_translate::codewriter::call::symbolic_fnaddr_for_segments([
+        "unbound_symbolic_residual_refuses_before_a_bound_residual_side_effect",
+    ]);
+    let unbound = builder.add_fn_ptr(symbolic as usize as *const ());
+    builder.residual_call_void_canonical_via_target_with_effect_info(
+        unbound,
+        &[],
+        majit_ir::EffectInfo::const_new(
+            majit_ir::ExtraEffect::CannotRaise,
+            majit_ir::OopSpecIndex::None,
+        ),
+    );
+    builder.void_return();
+    let jitcode = builder.finish();
+
+    let scan = jitcode.reachable_symbolic_residuals();
+    assert_eq!(scan.visited_jitcodes, 1);
+    assert_eq!(scan.targets, vec![symbolic]);
+
+    let mut ctx = TraceCtx::for_test_types(&[]);
+    let action =
+        majit_metainterp::trace_jitcode(&mut ctx, &mut StaticRefusalSym, &jitcode, 0, |_pc| 0);
+    assert!(matches!(action, TraceAction::Abort));
+    assert_eq!(
+        STATIC_REFUSAL_PREFIX_CALLS.load(std::sync::atomic::Ordering::Relaxed),
+        before,
+        "the reachable-set refusal must run before the bound residual prefix",
+    );
+
+    // `None` from the generated merge wrapper falls through to this source-arm
+    // execution. It is the only execution of the prefix after the preflight.
+    count_static_refusal_prefix();
+    assert_eq!(
+        STATIC_REFUSAL_PREFIX_CALLS.load(std::sync::atomic::Ordering::Relaxed),
+        before + 1,
+        "the source arm must apply the observable side effect exactly once",
+    );
+}
+
+/// Pyre's runtime fnaddr patch must leave the portal closure free of symbolic
+/// residual targets. Keep the visited count and cold-scan duration visible so
+/// this trace-start gate has a measured cost on the table it protects.
+#[test]
+fn portal_reachable_symbolic_residual_scan_is_empty() {
+    let _ = crate::jitcode_runtime::all_jitcodes();
+    crate::jitcode_runtime::install_global_build_descr_pool();
+    let portal = crate::jitcode_runtime::portal_jitcode()
+        .expect("the build-time table registers the eval portal");
+    let portal = majit_metainterp::JitCode::from_canonical((*portal).clone());
+
+    let started = std::time::Instant::now();
+    let scan = portal.reachable_symbolic_residuals();
+    let elapsed = started.elapsed();
+    eprintln!(
+        "[symbolic-residual-scan] visited={} elapsed_ns={} unbound={}",
+        scan.visited_jitcodes,
+        elapsed.as_nanos(),
+        scan.targets.len(),
+    );
+
+    assert!(
+        scan.visited_jitcodes > 0,
+        "the portal itself must be visited"
+    );
+    assert_eq!(
+        scan.targets,
+        Vec::<i64>::new(),
+        "jit_fnaddr bindings must resolve every portal-reachable residual",
+    );
+}
 
 #[test]
 fn propagated_subwalk_abort_cannot_rebind_its_pc_to_a_caller_frame() {


### PR DESCRIPTION
The review follow-ups for #1547. That PR squash-merged at the SHA its branch was
pushed at, so every change made in response to its review — the four code fixes,
three documentation corrections, and two test additions — landed after the
freeze and is not in `main`.

Ten commits, rebased onto current `main`; `git range-diff` reports all ten
patches byte-identical to their pre-rebase form.

## Code fixes

- **`majit: retain seeded jitdriver descriptor index`** — a seeded portal whose
  build-time `jitdriver_sd` is nonzero met a fresh `JitDriver` that allocated its
  own index 0, and `set_jitdriver_sd(0)` on a portal already marked 1 panicked.
  `register_dispatch_jitcode_shared` now takes the seed's index via
  `ensure_descriptor_registered_at`. `preinstall_jitdriver_sd` pads the vacant
  shells up to it, mirroring `pyjitpl.py:2266` — the `jitdrivers_sd` list is the
  codewriter's, indices included.
- **`majit: gate structured back-edge compiled entry`** — `back_edge_internal`
  reached `execute_assembler_at_dispatch_key` without consulting
  `confirm_enter_jit`, so a `#[jit_interp]` consumer's veto did not stop an
  already-compiled loop. The gate now sits between the token read and the entry,
  which is `warmstate.py:501`'s position.
- **`majit: validate adopted seeded dispatch`** —
  `validate_dispatch_jitcode_payload` ran at the two entry points, on the shell
  `adopt_seeded_dispatch` may discard. It now runs inside
  `adopt_dispatch_registry`, so the `Arc` actually installed is the one
  validated.
- **`majit: decline symbolic residual abort handoffs`** — an abort on an unbound
  symbolic call target published the top frame's post-instruction `code_cursor`,
  so the interpreter resumed after a call that never ran. There is no sound
  automatic resume position (a sibling residual earlier in the same arm may
  already have committed heap effects), so neither handoff is published and
  `symbolic_residual_trace_aborts` reports the gap.
- **`majit: reject bodyless embedded jitcode artefacts`** —
  `EmbeddedJitCodeTable::materialize` permitted `try_body().is_none()` and then
  called `from_canonical`, which panics in `body()`. It now asserts, naming the
  artefact.
- **`majit: emit an abort when a string helper name is empty`** — the config
  documents an empty `str_concat_helper` / `int_str_helper` as "a trace-ender,
  not a lowering". Measured before the change: it is not. The tracer returns
  `UnsupportedOpname` for the surviving `int_add/rr>r`, marks the image eligible
  for forward blackhole adoption, and the adopted dispatch panics in
  `unwired_handler_placeholder`. An empty name now emits an `OpKind::Abort`
  carrying `UnsupportedExprKind::HostHelperRefused` ahead of the operation.

  The same commit adds `default_bh_builder_unwired_set_matches_task_85_snapshot`
  to `blackhole.rs`. Six comments (`assembler.rs:4643`, `:4677`, `:4728`,
  `front/mir.rs:8776`, `front/slice_index.rs:70`, `jtransform.rs:1939`) cited it
  as an existing guard; no such function existed.

## Documentation and tests

- `majit: document green argument type projection` — states at the field why
  `green_args_spec` cannot carry `GreenType`: `marker_operand_kinds` reads
  `get_value_kind_var`, one char in `{i,r,f,v}`, so `Ptr(rstr.STR)` and a generic
  GC pointer are already indistinguishable there.
- `majit: attach symbolic residual docs to reporter` — the block documenting
  `report_symbolic_residual_call_target` sat above the counter static.
- `majit: name merge schema upstream symbol` — the LLBC assembler comment claimed
  `JitCodeBuilder::jit_merge_point` asserts on a second call; it retains the first
  offset and tolerates later markers.
- `majit: test str concat helper configuration` — the `str_concat_helper` guard
  had no tests where `int_str_helper` had two; adds the symmetric pair.
- `majit: read back opaque carrier state in its run test` **(already in `main`)**
  and `majit: recover the structured green key at both hash-entry compiled doors`
  **(already in `main`)** are not part of this PR.

## Not included

The two `.jitstats` fixtures were re-recorded on the old base and that commit is
**dropped**. On this base both `exception_escape_hot_callee_tb_node_once` and
`exception_traceback_frame_lineno` pass against `main`'s existing baselines: the
`guard_failures` 808 → 1015 movement was the old base lacking #1553 and #1559,
not anything in these commits.

## Verification

Run on this base, with the LLBC re-extracted and the staleness guard armed
(not `PYRE_LLBC_STRICT=0`):

| gate | result |
|---|---|
| `python3 pyre/check.py` | dynasm 511/511, cranelift 511/511, wasm 504/504 |
| `cargo test -p majit-metainterp --features dynasm` | 1974 passed, 0 failed |
| `cargo test -p majit-translate` | 3468 passed, 0 failed |
| `cargo fmt --all -- --check` | clean |
| `python3 scripts/check-majit-boundary.py` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLkGH6Ee8dMtvQqFYU8k5Q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unsafe tracing when residual targets cannot be resolved, with clearer abort handling.
  * Improved validation of compiled code and rejected incomplete entries earlier.
  * Fixed dispatch behavior for preassigned JIT driver registrations and optional confirmation hooks.
  * Operations requiring unnamed host helpers now report an explicit unsupported-operation abort.

* **Enhancements**
  * Added tracking for reachable residual targets and symbolic-tracing abort metrics.

* **Tests**
  * Expanded coverage for opcode wiring, dispatch registration, incomplete code rejection, and symbolic residual handling.

* **Documentation**
  * Clarified compiled driver argument specifications and helper configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->