### PR TITLE
Windows: localeconv from the host locale, a venv copy under the interpreter's own name, and three suite-runner reads

### DIFF
--- a/lib-python/3/venv/__init__.py
+++ b/lib-python/3/venv/__init__.py
@@ -388,6 +388,16 @@ class EnvBuilder:
                     f'pythonw{exe_t}{exe_d}.exe': pythonw_exe,
                 }
 
+            # Every name above is one a launcher stub answers to, so a runtime
+            # named anything else ends up with no copy of itself here -- while
+            # the POSIX branch always writes one, since it names the venv's
+            # executable after the base interpreter's own basename.  Restore
+            # that copy; `setdefault` leaves the mapping alone for a runtime
+            # already called by one of the names above.
+            own_exe = os.path.basename(context.executable)
+            link_sources.setdefault(own_exe, context.executable)
+            copy_sources.setdefault(own_exe, context.executable)
+
             do_copies = True
             if self.symlinks:
                 do_copies = False

--- a/pyre/cpython_tests/baseline.win32-AMD64.json
+++ b/pyre/cpython_tests/baseline.win32-AMD64.json
@@ -29,10 +29,6 @@
       "dynasm": "PASS",
       "reason": "Windows-only module: the shared IMPORTERROR is what a POSIX host sees for os.startfile"
     },
-    "test.test_venv": {
-      "dynasm": "FAIL",
-      "reason": "EnvBuilder.setup_python's nt branch copies venvlaunchert.exe / venvwlaunchert.exe out of venv/scripts/nt, which holds only activate.bat and deactivate.bat, so Scripts/<exe> is never produced and every case that looks for it fails. The POSIX branch copies the interpreter itself"
-    },
     "test.test_winapi": {
       "dynasm": "PASS",
       "reason": "Windows-only module: the shared IMPORTERROR is what a POSIX host sees for import _winapi"

--- a/pyre/cpython_tests/baseline.win32-AMD64.json
+++ b/pyre/cpython_tests/baseline.win32-AMD64.json
@@ -1,6 +1,10 @@
 {
   "host": "win32-AMD64",
   "modules": {
+    "test.test__locale": {
+      "dynasm": "PASS",
+      "reason": "the candidate locales _LocaleTests compares against are installed here, so localeconv() answers with known values and the module reports a result; a host carrying only the C locale reaches skipTest('no suitable locales') in every case and the shared SKIP is what it records"
+    },
     "test.test_eintr": {
       "dynasm": "SKIP",
       "reason": "EINTRTests is skipUnless(os.name == 'posix', 'only supported on Unix'), so every case in the module skips and none is left to report a result"

--- a/pyre/cpython_tests/baseline.win32-AMD64.json
+++ b/pyre/cpython_tests/baseline.win32-AMD64.json
@@ -19,7 +19,7 @@
     },
     "test.test_mmap": {
       "dynasm": "FAIL",
-      "reason": "MmapTests.setUp's os.unlink(TESTFN) raises PermissionError WinError 32 once a preceding case leaves the mapping's file open: finalization is not refcount-prompt and Windows refuses to unlink an open file. 40 of the 51 cases error on that one line; POSIX unlinks an open file and passes"
+      "reason": "MmapTests.setUp's os.unlink(TESTFN) raises PermissionError WinError 32 once a preceding case drops a mapping without closing it, and every later case inherits the lock. mmap_new_object allocates through the stable allocator, which is born into the old generation, so the lightweight destructor that closes the handles runs only at a major collection: of 200 dropped mappings, minor collections release 0 and gc.collect() releases 200, where PyPy on this host releases all 200 at the minor. POSIX never shows it, unlink succeeding on an open file"
     },
     "test.test_msvcrt": {
       "dynasm": "PASS",

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -402,6 +402,27 @@ def failure_digest(out: str, err: str) -> str:
     return " | ".join(part for part in (verdict, *shown) if part)
 
 
+# The Windows loader refusing to start a process, which is not the module
+# crashing but the module never running.
+STATUS_DLL_INIT_FAILED = 0xC0000142
+
+# Windows kills a faulting process by setting its exit status to the NTSTATUS
+# it died of, so these arrive where a POSIX signal number would.
+NTSTATUS_NAMES = {
+    0xC0000005: "ACCESS_VIOLATION",
+    0xC0000017: "NO_MEMORY",
+    0xC000001D: "ILLEGAL_INSTRUCTION",
+    0xC0000094: "INTEGER_DIVIDE_BY_ZERO",
+    0xC00000FD: "STACK_OVERFLOW",
+    0xC000013A: "CONTROL_C_EXIT",
+    0xC0000135: "DLL_NOT_FOUND",
+    0xC0000139: "ENTRYPOINT_NOT_FOUND",
+    STATUS_DLL_INIT_FAILED: "DLL_INIT_FAILED",
+    0xC0000374: "HEAP_CORRUPTION",
+    0xC0000409: "STACK_BUFFER_OVERRUN",
+}
+
+
 def death_signal(rc: int) -> str:
     """`SIGBUS` for a run killed by a signal, else a bare return code.
 
@@ -409,7 +430,18 @@ def death_signal(rc: int) -> str:
     shell-mediated one arrives as 128+n. Naming the signal is what separates
     "the interpreter faulted" from "the interpreter aborted an assertion",
     and those two want completely different investigations.
+
+    Windows has no signal to name and reports the NTSTATUS instead, which
+    reaches here as a ten-digit number that reads as nothing: three modules
+    of a full run were filed as interpreter crashes on the strength of one,
+    and it was the loader saying it had not started them.
     """
+    if sys.platform == "win32":
+        named = NTSTATUS_NAMES.get(rc)
+        if named is not None:
+            return named
+        if rc >= 0xC0000000:
+            return f"NTSTATUS 0x{rc:08X}"
     num = -rc if rc < 0 else rc - 128
     try:
         return signal.Signals(num).name
@@ -835,31 +867,41 @@ def run_module(binary: Path, module: str, mode: str, timeout: int,
             if module_env is env:
                 module_env = env.copy()
             module_env.setdefault("PYTHONREGRTEST_UNICODE_GUARD", "æ")
-        # `subprocess.run(timeout=)` cannot be used here: its own recovery
-        # drains the pipes after killing the child alone, and `reap` documents
-        # why that never returns for a module holding spawned workers.
-        # `with`, as `subprocess.run` has: one module of the four hundred
-        # leaking its two pipe handles is one the run cannot afford.
-        with subprocess.Popen(
-            cmd, cwd=cwd, env=module_env,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            text=True, encoding="utf-8", errors="replace",
-        ) as proc:
-            try:
-                out, err = proc.communicate(timeout=timeout)
-            except subprocess.TimeoutExpired as expired:
-                # A bare "timeout 120s" says only that the module is slow,
-                # never which case it stopped in — and unittest's progress
-                # dots, the one record of how far it got, were being thrown
-                # away here. `text=True` decodes what `communicate()` returns;
-                # the timeout path raises with the raw chunks it had joined,
-                # which is bytes on POSIX and str on Windows, so both
-                # spellings have to be accepted.
-                partial = expired.stderr or ""
-                if isinstance(partial, bytes):
-                    partial = partial.decode("utf-8", "replace")
-                reap(proc)
-                return "TIMEOUT", f"timeout {timeout}s {last_stderr_line(partial)}"[:300]
+        relaunched = False
+        while True:
+            # `subprocess.run(timeout=)` cannot be used here: its own recovery
+            # drains the pipes after killing the child alone, and `reap`
+            # documents why that never returns for a module holding spawned
+            # workers.  `with`, as `subprocess.run` has: one module of the four
+            # hundred leaking its two pipe handles is one the run cannot
+            # afford.
+            with subprocess.Popen(
+                cmd, cwd=cwd, env=module_env,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                text=True, encoding="utf-8", errors="replace",
+            ) as proc:
+                try:
+                    out, err = proc.communicate(timeout=timeout)
+                except subprocess.TimeoutExpired as expired:
+                    # A bare "timeout 120s" says only that the module is slow,
+                    # never which case it stopped in — and unittest's progress
+                    # dots, the one record of how far it got, were being
+                    # thrown away here. `text=True` decodes what
+                    # `communicate()` returns; the timeout path raises with the
+                    # raw chunks it had joined, which is bytes on POSIX and str
+                    # on Windows, so both spellings have to be accepted.
+                    partial = expired.stderr or ""
+                    if isinstance(partial, bytes):
+                        partial = partial.decode("utf-8", "replace")
+                    reap(proc)
+                    return "TIMEOUT", f"timeout {timeout}s {last_stderr_line(partial)}"[:300]
+            # The resource the loader ran out of is one this suite spends
+            # itself, sixteen modules at a time, so the second launch of the
+            # same command usually succeeds.  Nothing is hidden by trying: an
+            # interpreter that genuinely cannot load fails twice.
+            if relaunched or proc.returncode != STATUS_DLL_INIT_FAILED:
+                break
+            relaunched = True
     return classify(proc.returncode, out or "", err or "")
 
 

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -743,6 +743,27 @@ def build_one_test_extension(binary: Path, name: str, source: Path,
     return ""
 
 
+def reap(proc: "subprocess.Popen") -> None:
+    """End a timed-out module and everything it started.
+
+    `Popen.kill` reaches the child alone.  A module that spawned
+    `multiprocessing` workers leaves them alive holding the very stdout and
+    stderr this runner reads, and on Windows a spawned worker holds them the
+    same way under CPython as under pyre — measured both ways.  The drain that
+    collects the partial output then never sees EOF, so a run that meant to
+    record one TIMEOUT stops instead, for as long as the orphans live.
+    `taskkill /T` walks the tree while the child still parents it.
+
+    POSIX fills the exception's buffers before raising and needs the child
+    reaped and nothing read, which is what `subprocess.run` does there too.
+    """
+    if sys.platform == "win32":
+        subprocess.run(["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                       capture_output=True)
+    proc.kill()
+    (proc.communicate if sys.platform == "win32" else proc.wait)()
+
+
 def run_module(binary: Path, module: str, mode: str, timeout: int,
                env: dict) -> tuple[str, str]:
     # Run in a throwaway cwd so a test writing into '.' never touches the
@@ -814,23 +835,32 @@ def run_module(binary: Path, module: str, mode: str, timeout: int,
             if module_env is env:
                 module_env = env.copy()
             module_env.setdefault("PYTHONREGRTEST_UNICODE_GUARD", "æ")
-        try:
-            proc = subprocess.run(
-                cmd, cwd=cwd, env=module_env, capture_output=True, text=True,
-                encoding="utf-8", errors="replace", timeout=timeout,
-            )
-        except subprocess.TimeoutExpired as expired:
-            # A bare "timeout 120s" says only that the module is slow, never
-            # which case it stopped in — and unittest's progress dots, the one
-            # record of how far it got, were being thrown away here. `text=True`
-            # decodes what `communicate()` returns; the timeout path raises with
-            # the raw chunks it had joined, which is bytes on POSIX and str on
-            # Windows, so both spellings have to be accepted.
-            partial = expired.stderr or ""
-            if isinstance(partial, bytes):
-                partial = partial.decode("utf-8", "replace")
-            return "TIMEOUT", f"timeout {timeout}s {last_stderr_line(partial)}"[:300]
-    return classify(proc.returncode, proc.stdout or "", proc.stderr or "")
+        # `subprocess.run(timeout=)` cannot be used here: its own recovery
+        # drains the pipes after killing the child alone, and `reap` documents
+        # why that never returns for a module holding spawned workers.
+        # `with`, as `subprocess.run` has: one module of the four hundred
+        # leaking its two pipe handles is one the run cannot afford.
+        with subprocess.Popen(
+            cmd, cwd=cwd, env=module_env,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            text=True, encoding="utf-8", errors="replace",
+        ) as proc:
+            try:
+                out, err = proc.communicate(timeout=timeout)
+            except subprocess.TimeoutExpired as expired:
+                # A bare "timeout 120s" says only that the module is slow,
+                # never which case it stopped in — and unittest's progress
+                # dots, the one record of how far it got, were being thrown
+                # away here. `text=True` decodes what `communicate()` returns;
+                # the timeout path raises with the raw chunks it had joined,
+                # which is bytes on POSIX and str on Windows, so both
+                # spellings have to be accepted.
+                partial = expired.stderr or ""
+                if isinstance(partial, bytes):
+                    partial = partial.decode("utf-8", "replace")
+                reap(proc)
+                return "TIMEOUT", f"timeout {timeout}s {last_stderr_line(partial)}"[:300]
+    return classify(proc.returncode, out or "", err or "")
 
 
 # ── baseline ─────────────────────────────────────────────────────────

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -219,7 +219,7 @@ fn localeconv_to_dict(c: &LocaleConvData) -> pyre_object::PyObjectRef {
 
 /// POSIX "C" locale `localeconv` defaults for builds without libc; the
 /// char-typed fields default to `CHAR_MAX` (no value provided).
-#[cfg(not(all(unix, feature = "host_env")))]
+#[cfg(not(all(any(unix, windows), feature = "host_env")))]
 fn c_locale_conv() -> LocaleConvData {
     const CHAR_MAX: i64 = 127;
     LocaleConvData {
@@ -427,39 +427,49 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function_with_arity(
             "localeconv",
             |_| {
-                #[cfg(all(unix, feature = "host_env"))]
+                #[cfg(all(any(unix, windows), feature = "host_env"))]
                 {
                     let lc = rustpython_host_env::locale::localeconv_data();
                     // `_w_copy_grouping` (`interp_locale.py`): every byte
                     // of the C grouping string up to its NUL is one group size
                     // (a `CHAR_MAX` element stays `127`), then a trailing `0`
-                    // is appended to a non-empty list. The bytes come from
-                    // `rlocale::charp2str`, the same read `numeric_formatting`
-                    // groups by, rather than from the host helper, which stops
-                    // at the first `CHAR_MAX` and drops it. The trailing `0` is
+                    // is appended to a non-empty list. The trailing `0` is
                     // this function's own fixup and belongs to the app-level
                     // list, never to the grouping the formatter walks.
-                    let grouping_of = |ptr: *const libc::c_char| -> Vec<i64> {
-                        let mut v: Vec<i64> = super::rlocale::charp2str(ptr)
-                            .into_iter()
-                            .map(i64::from)
-                            .collect();
+                    let grouping_of = |sizes: Vec<u8>| -> Vec<i64> {
+                        let mut v: Vec<i64> = sizes.into_iter().map(i64::from).collect();
                         if !v.is_empty() {
                             v.push(0);
                         }
                         v
                     };
-                    let raw = unsafe { libc::localeconv() };
-                    let (grouping, mon_grouping) = if raw.is_null() {
-                        (Vec::new(), Vec::new())
-                    } else {
-                        unsafe {
-                            (
-                                grouping_of((*raw).grouping),
-                                grouping_of((*raw).mon_grouping),
-                            )
+                    // The bytes come from `rlocale::charp2str`, the same read
+                    // `numeric_formatting` groups by, rather than from the host
+                    // helper, which stops at the first `CHAR_MAX` and drops it.
+                    #[cfg(unix)]
+                    let (grouping, mon_grouping) = {
+                        let raw = unsafe { libc::localeconv() };
+                        if raw.is_null() {
+                            (Vec::new(), Vec::new())
+                        } else {
+                            unsafe {
+                                (
+                                    grouping_of(super::rlocale::charp2str((*raw).grouping)),
+                                    grouping_of(super::rlocale::charp2str((*raw).mon_grouping)),
+                                )
+                            }
                         }
                     };
+                    // `libc` declares neither `lconv` nor `localeconv` for a
+                    // Windows target, so the host helper's read is the only
+                    // one there. Its stop at `CHAR_MAX` costs nothing: of the
+                    // 198 locale names this runtime accepts, every grouping is
+                    // `[3]` or `[3, 2]` and none carries the element.
+                    #[cfg(windows)]
+                    let (grouping, mon_grouping) = (
+                        grouping_of(lc.grouping.iter().map(|&size| size as u8).collect()),
+                        grouping_of(lc.mon_grouping.iter().map(|&size| size as u8).collect()),
+                    );
                     let data = LocaleConvData {
                         decimal_point: lc.decimal_point.clone(),
                         thousands_sep: lc.thousands_sep.clone(),
@@ -482,7 +492,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     };
                     Ok(localeconv_to_dict(&data))
                 }
-                #[cfg(not(all(unix, feature = "host_env")))]
+                #[cfg(not(all(any(unix, windows), feature = "host_env")))]
                 {
                     Ok(localeconv_to_dict(&c_locale_conv()))
                 }

--- a/pyre/pyre-interpreter/src/module/_locale/rlocale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/rlocale.rs
@@ -33,8 +33,8 @@ pub(super) fn charp2str(ptr: *const libc::c_char) -> Vec<u8> {
 /// separator and grouping string of the current locale, as the bytes
 /// `localeconv()` reports them.
 ///
-/// Off unix, without `host_env`, and under sandbox the C locale's values stand
-/// in.  Upstream declares `localeconv` `sandboxsafe=True` (`rlocale.py`,
+/// Without `host_env` and under sandbox the C locale's values stand in.
+/// Upstream declares `localeconv` `sandboxsafe=True` (`rlocale.py`,
 /// `:180-182`) and reads the host locale even there; pyre compiles the call out
 /// instead, because the sandbox build replaces `_locale`'s host entry points
 /// with raising stubs and `format()` must not acquire a raising path.
@@ -52,5 +52,19 @@ pub(crate) fn numeric_formatting() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
             };
         }
     }
+    // `libc` declares neither `lconv` nor `localeconv` for a Windows target,
+    // so the host helper's already-read copy answers there.  It stops the
+    // grouping at a `CHAR_MAX` element, which no locale name this runtime
+    // accepts carries.
+    #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+    {
+        let conv = rustpython_host_env::locale::localeconv_data();
+        return (
+            conv.decimal_point,
+            conv.thousands_sep,
+            conv.grouping.iter().map(|&size| size as u8).collect(),
+        );
+    }
+    #[cfg(not(all(windows, feature = "host_env", not(feature = "sandbox"))))]
     (b".".to_vec(), Vec::new(), Vec::new())
 }


### PR DESCRIPTION
Five Windows findings, each measured against an oracle already on the host —
CPython 3.14.2 and PyPy 3.11, both installed here.

### `_locale.localeconv()` answered from the C locale on Windows

The real body sat behind `#[cfg(all(unix, feature = "host_env"))]` while
`setlocale` had been `#[cfg(all(any(unix, windows), feature = "host_env"))]`
all along — so the locale changed and the report of it did not:

```
                CPython 3.14.2      pyre before      pyre after
C          dp='.'  ts=''   grp=[]   same             same
de_DE      dp=','  ts='.'  grp=[3,0]  dp='.' ts='' grp=[]   dp=',' ts='.' grp=[3,0]
en_US      dp='.'  ts=','  grp=[3,0]  dp='.' ts='' grp=[]   dp='.' ts=',' grp=[3,0]
hi_IN      grp=[3,2,0]                grp=[]                grp=[3,2,0]
```

`rlocale.py` declares `localeconv` as one external for both platforms and
`numeric_formatting_impl` reads it there, so the gate had no upstream basis.
`numeric_formatting` — what `format(x, 'n')` draws from — carried the same one.

What blocked it was one fact: `libc` declares neither `lconv` nor `localeconv`
for a Windows target, and the unix arm re-reads the grouping through exactly
those. `rustpython_host_env::locale` has both, field for field with the UCRT
`struct lconv`; its reader stops the grouping at a `CHAR_MAX` element, so that
had to be shown harmless rather than assumed. Of the 200 names in
`locale.windows_locale`, 198 are accepted here and every one of them groups as
`[3]` or `[3, 2]` — `CHAR_MAX` appears in none, so on Windows the two reads
agree.

`test.test__locale` passes now (`test_lc_numeric_localeconv` read `'.'` for
every locale it set), and the win32 overlay records it.

One difference from CPython is deliberate and is PyPy's: `fr_FR`'s
`thousands_sep` is `'\udca0'` here where CPython reports `' '`. CPython
reads the wide `_W_*` fields on Windows; `rlocale.py`'s `lconv` declares only
the narrow ones and `interp_locale.py` decodes them utf-8 + surrogateescape.
**PyPy 3.11 on this host answers `'\udca0'` and `'\udc80'` field for field
with this branch** — so what lands here is PyPy's behaviour exactly, and
moving to the wide fields is a `[3.14-spec]` question of its own.

### A Windows venv had no copy of the interpreter under its own name

`test.test_venv` was recorded FAIL with 25 errors and 4 failures, all
`FileNotFoundError` on `Scripts/pyre-dynasm.exe`. The recorded reason — that
no launcher stub is shipped, so `Scripts` gets no executable at all — was
stale: `#1228` already added the fallback, and `Scripts` holds `python.exe`,
`python3.14t.exe` and both `pythonw` twins.

What it does not hold is a copy under the name the interpreter was invoked by,
and that is the one `BaseTest.setUp` builds its expected path from
(`os.path.split(sys._base_executable)[-1]`). `setup_python`'s nt branch writes
only the names a launcher stub answers to. The POSIX branch always writes one,
naming the venv's executable after the base interpreter's basename — and so
does PyPy's nt branch, which appends `os.path.basename(context.env_exe)` to
the suffixes it copies and then makes sure `sys.executable`'s own basename is
among them. PyPy's `Scripts` on this host:

```
pypy.exe  pypy3.11.exe  pypy3.11w.exe  pypy3.exe  pypyw.exe
python.exe  python3.11.exe  python3.exe  pythonw.exe
```

Three lines restore that copy. `test.test_venv` passes and the overlay entry
is dropped — the shared baseline already recorded PASS.

### A timed-out module hung the CPython-suite runner forever

`--filter multiprocessing` sat for **2h51m** against a 300s limit. Not a slow
test: `subprocess.run(timeout=)` kills the child alone and then, on Windows,
drains the pipes to collect the partial output — and the module's spawned
workers, now orphaned, still held those pipes, so the drain never reached the
end of the stream. Killing the three orphans by hand released it instantly,
and the runner recorded the TIMEOUT it had been trying to record all along.

The obvious suspect was pyre's `_winapi.CreateProcess` ignoring
`bInheritHandles=False`. It does not — the same driver under CPython 3.14.2
blocks identically:

```
CPython  direct child 5856, children [20848] -> drain BLOCKED past 30s
pyre     direct child 7672, children [23592] -> drain BLOCKED past 30s
                                             -> returns the moment they die
```

So the runner is what has to end the tree. `reap` walks it with
`taskkill /F /T` while the child still parents it, then drains; POSIX keeps
`kill()` + `wait()`, which is what `subprocess.run` does there. Driving the
child through `Popen` brings back the `with` that `run` had — four hundred
modules each leaking two pipe handles is not a trade worth making.

Same filter after the change: **5m00s**, nothing left behind.

### Three modules were filed as interpreter crashes over an unread number

A full run recorded `test_thread`, `test_threading` and `test_regrtest` as
CRASH with `signal/abort rc=3221225794 rc=3221225794` and an empty stderr.
`death_signal` maps a POSIX signal death and falls back to printing the raw
code, which on Windows is the NTSTATUS the process died of: `0xC0000142`,
`STATUS_DLL_INIT_FAILED`. The loader had not started the process, so no
module ran — and all three pass on their own, and under an eightfold parallel
burst.

`death_signal` names the statuses now, and prints an unnamed one above
`0xC0000000` as hex rather than decimal. A launch that ends in
`STATUS_DLL_INIT_FAILED` is made once more before being classified: the
resource the loader ran out of is one the suite spends itself, sixteen
modules at a time, and an interpreter that genuinely cannot load fails twice.

### What actually holds `test_mmap`'s file open

The overlay said only "finalization is not refcount-prompt". Measured:
`mmap_new_object` allocates through `allocate_stable`, which
`malloc_typed_stable` documents as **born into the old generation**, and
`register_young_object_if_needed` is the only path into
`young_objects_with_destructors`. So the lightweight destructor that closes
the mapping and the duplicated file handle waits for a major collection.

Of 200 mappings dropped without `close()`, then churned with small
allocations:

```
pyre   released by minor collections   0 / 200      by gc.collect()  200
PyPy   released by minor collections 200 / 200      by gc.collect()    0
```

PyPy's `W_MMap` is an ordinary nursery object and `rmmap.MMap.__del__` runs
in `deal_with_young_objects_with_destructors`. POSIX never shows it, `unlink`
succeeding on an open file.

Only the recorded reason changes here. `allocate_stable` is a pyre-wide
adaptation — `array`, generators, `enumerate`, `FrameLocalsProxy` all use it —
and making `W_MMap` movable means rooting `obj` across every allocating
method closure in `init_mmap_type`. That is its own round.

### Gates

`check.py --backend dynasm` **ALL PASSED 514/514**, `parity_tests
--dynasm-only` 181 scripts, the citation check, the wasm32 `pyre-wasm` build,
and the `locale` and `multiprocessing` suite filters — all green.

Three Windows diffs against CPython 3.14.2 on this host found **no**
differences: 203 entries over `_winapi`, `msvcrt`, `os.listdrives` /
`listvolumes` / `listmounts`, `add_dll_directory`, `st_file_attributes` /
`st_reparse_tag` / `st_birthtime`; 35 over `signal.valid_signals`, `SIGBREAK`
and `CTRL_BREAK_EVENT` delivery to a new process group, `creationflags`, and
`sys.getwindowsversion`; and 27 filesystem edge cases — paths past
`MAX_PATH`, extended-length spellings, junctions and their reparse tags,
reserved device names, case-insensitive `samefile` — which differed only in
the random temp directory name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Windows virtual environments now include a working copy or link to the active Python interpreter, improving compatibility with nonstandard interpreter names.
  - Locale-aware number formatting on Windows now correctly reports decimal separators, thousands separators, and grouping.
  - Windows test execution now provides clearer crash diagnostics, cleans up timed-out process trees, and retries certain startup failures.

- **Tests**
  - Updated Windows test expectations for locale handling, memory mapping behavior, and virtual-environment creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->