### PR TITLE
majit: the compiled entry's fixed costs, itemised and cut

### DIFF
--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -266,6 +266,13 @@ cover the condition they diagnose.
 - What it does: Selects which arm allocates the jitframe a compiled entry runs on, for backends that build frames out of the Rust heap rather than the GC nursery. `0` selects `FrameHeapOwner::OWNED`, one `calloc`/`free` pair per entry; anything else, including leaving it unset, selects the pooled per-thread free list. Read once and latched, so it names a strategy for the process rather than a per-entry state; `set_jitframe_pool` overrides it for a harness that can call in.
 - Retirement condition: when the owned arm is retired — it exists to be differenced against the pooled one, and a build with no second arm has nothing to select.
 
+### `MAJIT_PROBE_EXTRA`
+
+- Read sites: 1 — `majit/majit-backend/src/deadframe.rs`
+- Accessor: `probe_extra_stage()`, consulted only under `__execute-stage-probe`
+- What it does: Names one fixed step of a compiled entry — `guard`, `heap`, `flags`, `attach`, `descr` or `arc` — that the cranelift entry repeats `frame_build_repeats()` times beside the frame build, so the entry probe's frame-build column reads that step's per-entry cost as a delta against a run with the variable unset. Unset or any other value repeats nothing. Read once and latched. Off the probe feature the accessor is never called.
+- Retirement condition: with the probe feature — it is an instrument on a feature that ships nothing.
+
 ### `MAJIT_LEAF3_PROV`
 
 - Read sites: 1 — `majit/majit-metainterp/src/resume.rs`

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -8093,6 +8093,81 @@ fn run_compiled_code(
     )
 }
 
+/// `llmodel.py get_latest_descr`: the `(fail_index, descr)` a frame's
+/// `jf_descr` word names. Split out of `run_compiled_code_inner` so the probe
+/// can price it on its own.
+fn resolve_exit_descr(
+    jf_descr_raw: i64,
+    fail_descrs: &[DescrRef],
+    attachments: &CpuDescrAttachments,
+    propagate_descr_ptr: usize,
+) -> (u32, Option<ExitDescr>) {
+    if jf_descr_raw == CALL_ASSEMBLER_DEADFRAME_SENTINEL as i64 {
+        (CALL_ASSEMBLER_DEADFRAME_SENTINEL, None)
+    } else if jf_descr_raw == 0 {
+        // Propagate-into-exit fall-through: when the metainterp
+        // didn't attach an `exit_frame_with_exception_descr_ref`
+        // (unit-test setups), the rewrite above leaves jf_descr at 0;
+        // surface the cranelift singleton directly so the consumer
+        // still sees `is_exit_frame_with_exception=true`.
+        if propagate_descr_ptr != 0 {
+            let cl: DescrRef = EXIT_FRAME_WITH_EXCEPTION_DESCR_REF_CL.clone();
+            (u32::MAX, Some(ExitDescr::owned(cl)))
+        } else {
+            (0u32, None)
+        }
+    } else if let Some(metainterp_finish) = match_metainterp_finish_descr(jf_descr_raw, attachments)
+    {
+        // `history.py:125` `cpu.get_latest_descr(deadframe)` parity:
+        // `jf_descr` carries the metainterp `Arc<DoneWithThisFrameDescr*>`
+        // address (compiler.rs baking).  Return that *exact* Arc
+        // so the consumer sees the same identity `compile.py:618-672`
+        // attached on the cpu — not the process-global fallback static.
+        // Both are `Arc<DoneWithThisFrameDescrInt>` (no wrapper) so the
+        // trait-method dispatch is identical; only
+        // the Arc identity differs, and PyPy parity demands they match.
+        // Borrowed: see `ExitDescr`. `attachments` is the cpu's own set, which
+        // outlives every deadframe decoded against it.
+        (
+            u32::MAX,
+            Some(unsafe { ExitDescr::borrowed(metainterp_finish) }),
+        )
+    } else {
+        // `jf_descr_raw` is the metainterp `AbstractFailDescr` Arc's
+        // data pointer.  Resolve via the `fail_descrs` collection.
+        // Derive `fail_index` from
+        // the resolved Arc via the FailDescr trait — never dereference
+        // the raw pointer as a concrete type, since the meta side can
+        // be either `ResumeGuardDescr` or `DoneWithThisFrameDescr*`.
+        let arc = find_fail_descr_by_ptr(
+            fail_descrs,
+            jf_descr_raw as usize,
+            attachments.propagate_exception_descr.as_ref(),
+        );
+        let fi = arc.as_ref().map(|a| as_fd(a).fail_index()).unwrap_or(0);
+        // compile.py:665-674 parity: done_with_this_frame_descr is a
+        // global singleton — it won't appear in per-trace fail_descrs.
+        let arc = arc.or_else(|| {
+            let ptr = jf_descr_raw as usize;
+            // Singletons are `DescrRef = Arc<dyn Descr>` (fat pointer).
+            // Match on the data-pointer half via
+            // `as *const () as usize`.
+            for global in [
+                &*DONE_WITH_THIS_FRAME_DESCR_INT,
+                &*DONE_WITH_THIS_FRAME_DESCR_FLOAT,
+                &*DONE_WITH_THIS_FRAME_DESCR_REF,
+                &*DONE_WITH_THIS_FRAME_DESCR_VOID,
+            ] {
+                if Arc::as_ptr(global) as *const () as usize == ptr {
+                    return Some(global.clone());
+                }
+            }
+            None
+        });
+        (fi, arc.map(ExitDescr::owned))
+    }
+}
+
 fn run_compiled_code_inner(
     code_ptr: *const u8,
     fail_descrs: &[DescrRef],
@@ -8217,6 +8292,31 @@ fn run_compiled_code_inner(
             std::hint::black_box(&mut scratch);
         }
     }
+    #[cfg(feature = "__execute-stage-probe")]
+    {
+        use majit_backend::deadframe::{ProbeExtraStage, frame_build_repeats, probe_extra_stage};
+        let repeats = frame_build_repeats();
+        match probe_extra_stage() {
+            ProbeExtraStage::Guard => {
+                for _ in 0..repeats {
+                    let g = majit_backend::JittedGuard::enter();
+                    std::hint::black_box(&g);
+                    drop(g);
+                }
+            }
+            ProbeExtraStage::Heap => {
+                for _ in 0..repeats {
+                    std::hint::black_box(cranelift_jitframe_type_id());
+                }
+            }
+            ProbeExtraStage::Flags => {
+                for _ in 0..repeats {
+                    std::hint::black_box(entry_flags());
+                }
+            }
+            _ => {}
+        }
+    }
     if debug_prints {
         let preview: Vec<i64> = (0..inputs.len().min(10)).map(|i| inputs.raw(i)).collect();
         majit_ir::debug::log_one("jit-running", &format!("pre-call-inputs {preview:?}"));
@@ -8331,65 +8431,30 @@ fn run_compiled_code_inner(
     }
     let jf_descr_raw = unsafe { *result_jf.add(JF_DESCR_OFS as usize / 8) };
 
-    let (fail_index, direct_descr) = if jf_descr_raw == CALL_ASSEMBLER_DEADFRAME_SENTINEL as i64 {
-        (CALL_ASSEMBLER_DEADFRAME_SENTINEL, None)
-    } else if jf_descr_raw == 0 {
-        // Propagate-into-exit fall-through: when the metainterp
-        // didn't attach an `exit_frame_with_exception_descr_ref`
-        // (unit-test setups), the rewrite above leaves jf_descr at 0;
-        // surface the cranelift singleton directly so the consumer
-        // still sees `is_exit_frame_with_exception=true`.
-        if propagate_descr_ptr != 0 {
-            let cl: DescrRef = EXIT_FRAME_WITH_EXCEPTION_DESCR_REF_CL.clone();
-            (u32::MAX, Some(cl))
-        } else {
-            (0u32, None)
-        }
-    } else if let Some(metainterp_finish) = match_metainterp_finish_descr(jf_descr_raw, attachments)
+    let (fail_index, direct_descr) =
+        resolve_exit_descr(jf_descr_raw, fail_descrs, attachments, propagate_descr_ptr);
+    #[cfg(feature = "__execute-stage-probe")]
+    if majit_backend::deadframe::probe_extra_stage()
+        == majit_backend::deadframe::ProbeExtraStage::Descr
     {
-        // `history.py:125` `cpu.get_latest_descr(deadframe)` parity:
-        // `jf_descr` carries the metainterp `Arc<DoneWithThisFrameDescr*>`
-        // address (compiler.rs baking).  Return that *exact* Arc
-        // so the consumer sees the same identity `compile.py:618-672`
-        // attached on the cpu — not the process-global fallback static.
-        // Both are `Arc<DoneWithThisFrameDescrInt>` (no wrapper) so the
-        // trait-method dispatch is identical; only
-        // the Arc identity differs, and PyPy parity demands they match.
-        (u32::MAX, Some(metainterp_finish))
-    } else {
-        // `jf_descr_raw` is the metainterp `AbstractFailDescr` Arc's
-        // data pointer.  Resolve via the `fail_descrs` collection.
-        // Derive `fail_index` from
-        // the resolved Arc via the FailDescr trait — never dereference
-        // the raw pointer as a concrete type, since the meta side can
-        // be either `ResumeGuardDescr` or `DoneWithThisFrameDescr*`.
-        let arc = find_fail_descr_by_ptr(
-            fail_descrs,
-            jf_descr_raw as usize,
-            attachments.propagate_exception_descr.as_ref(),
-        );
-        let fi = arc.as_ref().map(|a| as_fd(a).fail_index()).unwrap_or(0);
-        // compile.py:665-674 parity: done_with_this_frame_descr is a
-        // global singleton — it won't appear in per-trace fail_descrs.
-        let arc = arc.or_else(|| {
-            let ptr = jf_descr_raw as usize;
-            // Singletons are `DescrRef = Arc<dyn Descr>` (fat pointer).
-            // Match on the data-pointer half via
-            // `as *const () as usize`.
-            for global in [
-                &*DONE_WITH_THIS_FRAME_DESCR_INT,
-                &*DONE_WITH_THIS_FRAME_DESCR_FLOAT,
-                &*DONE_WITH_THIS_FRAME_DESCR_REF,
-                &*DONE_WITH_THIS_FRAME_DESCR_VOID,
-            ] {
-                if Arc::as_ptr(global) as *const () as usize == ptr {
-                    return Some(global.clone());
-                }
-            }
-            None
-        });
-        (fi, arc)
-    };
+        for _ in 0..majit_backend::deadframe::frame_build_repeats() {
+            std::hint::black_box(resolve_exit_descr(
+                jf_descr_raw,
+                fail_descrs,
+                attachments,
+                propagate_descr_ptr,
+            ));
+        }
+    }
+    #[cfg(feature = "__execute-stage-probe")]
+    if majit_backend::deadframe::probe_extra_stage()
+        == majit_backend::deadframe::ProbeExtraStage::Arc
+        && let Some(d) = direct_descr.as_ref()
+    {
+        for _ in 0..majit_backend::deadframe::frame_build_repeats() {
+            std::hint::black_box(d.clone());
+        }
+    }
     if log_enabled {
         eprintln!(
             "[post-call-descr] raw={:#x} fail_index={} matched_local={}",
@@ -9269,8 +9334,16 @@ impl CraneliftBackend {
         // lock is safe: `Backend::set_done_with_this_frame_descr_*` only
         // fires during `MetaInterpStaticData.finish_setup`, long before
         // compiled code runs.
-        let attachments_guard = compiled.cpu_attachments.read().unwrap();
+        let attachments_guard = compiled.cpu_attachments.read();
         let attachments: &CpuDescrAttachments = &attachments_guard;
+        #[cfg(feature = "__execute-stage-probe")]
+        if majit_backend::deadframe::probe_extra_stage()
+            == majit_backend::deadframe::ProbeExtraStage::Attach
+        {
+            for _ in 0..majit_backend::deadframe::frame_build_repeats() {
+                std::hint::black_box(&*compiled.cpu_attachments.read());
+            }
+        }
 
         loop {
             let mut exec = run_compiled_code(

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -83,6 +83,26 @@ fn majit_log_enabled() -> bool {
     *ENABLED
 }
 
+/// The three flags a compiled entry reads, resolved together.
+#[derive(Clone, Copy)]
+struct EntryFlags {
+    log_enabled: bool,
+    debug_prints: bool,
+    verify_enabled: bool,
+}
+
+/// One `LazyLock` check per entry instead of three; each is an env var fixed
+/// at process start.
+#[inline]
+fn entry_flags() -> EntryFlags {
+    static FLAGS: std::sync::LazyLock<EntryFlags> = std::sync::LazyLock::new(|| EntryFlags {
+        log_enabled: majit_log_enabled(),
+        debug_prints: majit_ir::debug::have_debug_prints(),
+        verify_enabled: majit_verify_enabled(),
+    });
+    *FLAGS
+}
+
 /// Whether `MAJIT_VERIFY` is set, cached at first access.
 fn majit_verify_enabled() -> bool {
     static ENABLED: std::sync::LazyLock<bool> =
@@ -8094,9 +8114,11 @@ fn run_compiled_code_inner(
     // Read once, ahead of the run. Each of these is a `Once`-guarded load of a
     // flag fixed at process start, and the compiled call between the sites
     // below is opaque to the optimizer, so asking again after it re-reads.
-    let log_enabled = majit_log_enabled();
-    let debug_prints = majit_ir::debug::have_debug_prints();
-    let verify_enabled = majit_verify_enabled();
+    let EntryFlags {
+        log_enabled,
+        debug_prints,
+        verify_enabled,
+    } = entry_flags();
     if log_enabled {
         eprintln!(
             "[jf-alloc] frame_depth={} depth={} max_output={} inputs={} ref_roots={}",

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -251,10 +251,13 @@ fn attached_descr_ptrs_with_fallbacks(
 /// the descr should be resolved against, not consult an ambient slot.
 fn match_metainterp_finish_descr(
     jf_descr_raw: i64,
-    attachments: &CpuDescrAttachments,
+    attachments: &'static CpuDescrAttachments,
 ) -> Option<&DescrRef> {
     let ptr = jf_descr_raw as usize;
-    fn check(slot: &Option<majit_ir::DescrRef>, expected: usize) -> Option<&majit_ir::DescrRef> {
+    fn check(
+        slot: &'static Option<majit_ir::DescrRef>,
+        expected: usize,
+    ) -> Option<&'static majit_ir::DescrRef> {
         slot.as_ref()
             .filter(|arc| Arc::as_ptr(arc) as *const () as usize == expected)
     }
@@ -3297,8 +3300,7 @@ fn execute_registered_loop_target(target: &RegisteredLoopTarget, inputs: &[i64])
     // the read lock is safe: `Backend::set_done_with_this_frame_descr_*`
     // only fires during `MetaInterpStaticData.finish_setup`, long
     // before compiled code runs.
-    let attachments_guard = target.cpu_attachments.read();
-    let attachments: &CpuDescrAttachments = &attachments_guard;
+    let attachments: &'static CpuDescrAttachments = target.cpu_attachments.read();
     loop {
         let exec = run_compiled_code(
             cur_code_ptr,
@@ -3760,14 +3762,19 @@ fn call_assembler_guard_failure_inner(
     // every guard failure.  Setters (`set_done_with_this_frame_descr_*`
     // etc.) only run at `MetaInterpStaticData.finish_setup` so write
     // contention is effectively nil.
-    let attachments_guard;
-    let default_attachments;
-    let attachments: &CpuDescrAttachments = if cpu_handle.is_null() {
-        default_attachments = CpuDescrAttachments::default();
-        &default_attachments
+    /// The attachments a null handle stands for: none.
+    static NO_ATTACHMENTS: CpuDescrAttachments = CpuDescrAttachments {
+        done_with_this_frame_descr_void: None,
+        done_with_this_frame_descr_int: None,
+        done_with_this_frame_descr_ref: None,
+        done_with_this_frame_descr_float: None,
+        exit_frame_with_exception_descr_ref: None,
+        propagate_exception_descr: None,
+    };
+    let attachments: &'static CpuDescrAttachments = if cpu_handle.is_null() {
+        &NO_ATTACHMENTS
     } else {
-        attachments_guard = unsafe { (*cpu_handle).read() };
-        &attachments_guard
+        unsafe { (*cpu_handle).read() }
     };
     // Handle deadframe sentinel (nested CALL_ASSEMBLER propagation).
     if fail_descr_ptr == CALL_ASSEMBLER_DEADFRAME_SENTINEL as i64 {
@@ -8073,7 +8080,7 @@ fn run_compiled_code(
     num_ref_roots: usize,
     max_output_slots: usize,
     inputs: &FrameInputs<'_>,
-    attachments: &CpuDescrAttachments,
+    attachments: &'static CpuDescrAttachments,
     dispatch_key: u32,
 ) -> JitExecResult {
     // No alternate-stack switch here. The compiled prologue's inline
@@ -8099,7 +8106,7 @@ fn run_compiled_code(
 fn resolve_exit_descr(
     jf_descr_raw: i64,
     fail_descrs: &[DescrRef],
-    attachments: &CpuDescrAttachments,
+    attachments: &'static CpuDescrAttachments,
     propagate_descr_ptr: usize,
 ) -> (u32, Option<ExitDescr>) {
     if jf_descr_raw == CALL_ASSEMBLER_DEADFRAME_SENTINEL as i64 {
@@ -8126,12 +8133,8 @@ fn resolve_exit_descr(
         // Both are `Arc<DoneWithThisFrameDescrInt>` (no wrapper) so the
         // trait-method dispatch is identical; only
         // the Arc identity differs, and PyPy parity demands they match.
-        // Borrowed: see `ExitDescr`. `attachments` is the cpu's own set, which
-        // outlives every deadframe decoded against it.
-        (
-            u32::MAX,
-            Some(unsafe { ExitDescr::borrowed(metainterp_finish) }),
-        )
+        // Borrowed, see `ExitDescr`: the attached copy is `'static`.
+        (u32::MAX, Some(ExitDescr::borrowed(metainterp_finish)))
     } else {
         // `jf_descr_raw` is the metainterp `AbstractFailDescr` Arc's
         // data pointer.  Resolve via the `fail_descrs` collection.
@@ -8174,7 +8177,7 @@ fn run_compiled_code_inner(
     num_ref_roots: usize,
     max_output_slots: usize,
     inputs: &FrameInputs<'_>,
-    attachments: &CpuDescrAttachments,
+    attachments: &'static CpuDescrAttachments,
     dispatch_key: u32,
 ) -> JitExecResult {
     // RPython llmodel.py:298: frame = gc_ll_descr.malloc_jitframe(frame_info)
@@ -9334,8 +9337,7 @@ impl CraneliftBackend {
         // lock is safe: `Backend::set_done_with_this_frame_descr_*` only
         // fires during `MetaInterpStaticData.finish_setup`, long before
         // compiled code runs.
-        let attachments_guard = compiled.cpu_attachments.read();
-        let attachments: &CpuDescrAttachments = &attachments_guard;
+        let attachments: &'static CpuDescrAttachments = compiled.cpu_attachments.read();
         #[cfg(feature = "__execute-stage-probe")]
         if majit_backend::deadframe::probe_extra_stage()
             == majit_backend::deadframe::ProbeExtraStage::Attach
@@ -9480,7 +9482,7 @@ impl CraneliftBackend {
         bridge: &BridgeData,
         parent_outputs: &[i64],
         parent_types: &[Type],
-        attachments: &CpuDescrAttachments,
+        attachments: &'static CpuDescrAttachments,
     ) -> DeadFrame {
         // The bridge's inputs are the parent guard's fail args.
         let num_bridge_inputs = bridge.num_inputs.min(parent_types.len());
@@ -17494,8 +17496,7 @@ impl majit_backend::Backend for CraneliftBackend {
         // 0 only for the initial entry — every external-JUMP re-entry,
         // including the first LABEL, selects its loader (label_block_id + 1).
         let mut cur_dispatch_key: u32 = 0;
-        let attachments_guard = compiled.cpu_attachments.read();
-        let attachments: &CpuDescrAttachments = &attachments_guard;
+        let attachments: &'static CpuDescrAttachments = compiled.cpu_attachments.read();
 
         loop {
             let exec = run_compiled_code(

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -112,6 +112,7 @@ fn majit_verify_enabled() -> bool {
 
 use crate::asm_memory::{CraneliftArenaHandle, CraneliftArenaMemoryProvider};
 use crate::guard::{BridgeData, JitFrameDeadFrame, drop_bridge_payload};
+use majit_backend::deadframe::ExitDescr;
 
 // `compile.py:665-674` `done_with_this_frame` singletons
 //
@@ -251,16 +252,11 @@ fn attached_descr_ptrs_with_fallbacks(
 fn match_metainterp_finish_descr(
     jf_descr_raw: i64,
     attachments: &CpuDescrAttachments,
-) -> Option<majit_ir::DescrRef> {
+) -> Option<&DescrRef> {
     let ptr = jf_descr_raw as usize;
-    fn check(slot: &Option<majit_ir::DescrRef>, expected: usize) -> Option<majit_ir::DescrRef> {
-        slot.as_ref().and_then(|arc| {
-            if Arc::as_ptr(arc) as *const () as usize == expected {
-                Some(arc.clone())
-            } else {
-                None
-            }
-        })
+    fn check(slot: &Option<majit_ir::DescrRef>, expected: usize) -> Option<&majit_ir::DescrRef> {
+        slot.as_ref()
+            .filter(|arc| Arc::as_ptr(arc) as *const () as usize == expected)
     }
     // The attached descr and nothing beside it. Each of these has a cranelift
     // singleton twin (`DONE_WITH_THIS_FRAME_DESCR_*`,
@@ -813,11 +809,8 @@ fn lookup_loop_target(descr: &majit_ir::DescrRef) -> Option<LoopTargetEntry> {
 
 fn deadframe_layout(frame: &DeadFrame) -> Option<FailDescrLayout> {
     let jf = frame.as_jitframe()?;
-    let descr_ref: DescrRef = jf.fail_descr.clone();
-    let fd = jf
-        .fail_descr
-        .as_fail_descr()
-        .expect("JitFrameDeadFrame.fail_descr always implements FailDescr");
+    let descr_ref: DescrRef = jf.fail_descr.to_arc();
+    let fd = jf.fail_descr.as_fail_descr();
     // Use the descr's structural `fail_index` / `trace_id` to preserve
     // pre-7-Tβ14a behavior — deadframe lookups did not have access to
     // a runtime per-trace position so the descr-internal values flow
@@ -3083,7 +3076,7 @@ fn call_assembler_finish_or_blackhole_deadframe(frame: DeadFrame) -> Option<i64>
     // safely drop after BH completes.
     let (is_finish, fail_descr_arc, fail_arg_types) = {
         let jf = frame.as_jitframe()?;
-        let fail_descr = jf.fail_descr.clone();
+        let fail_descr = jf.fail_descr.to_arc();
         let fd = as_fd(&fail_descr);
         let is_finish = fd.is_finish();
         let fail_arg_types = fd.fail_arg_types().to_vec();
@@ -3186,12 +3179,16 @@ pub fn force_token_to_dead_frame(force_token: GcRef) -> DeadFrame {
     // deadframe borrows it: the call site pushed `jf_gcmap` before the call and
     // clears it with `pop_gcmap` on return, and releasing it here would leave
     // the frame's spilled `Ref` slots untraced for the rest of the call.
-    DeadFrame::JitFrame(JitFrameDeadFrame::borrowing(jf_gcref, fail_descr, None))
+    DeadFrame::JitFrame(JitFrameDeadFrame::borrowing(
+        jf_gcref,
+        ExitDescr::owned(fail_descr),
+        None,
+    ))
 }
 
 fn deadframe_from_jitframe(
     jf_gcref: GcRef,
-    fail_descr: DescrRef,
+    fail_descr: ExitDescr,
     heap_owner: Option<FrameHeapOwner>,
 ) -> DeadFrame {
     DeadFrame::JitFrame(JitFrameDeadFrame::new(
@@ -3216,7 +3213,7 @@ pub fn get_latest_descr_from_deadframe(frame: &DeadFrame) -> Result<&dyn FailDes
     let jf = frame
         .as_jitframe()
         .ok_or_else(|| BackendError::Unsupported("expected JitFrameDeadFrame".to_string()))?;
-    Ok(as_fd(&jf.fail_descr))
+    Ok(jf.fail_descr.as_fail_descr())
 }
 
 /// Owned-Arc counterpart of [`get_latest_descr_from_deadframe`].
@@ -3232,7 +3229,7 @@ pub fn get_latest_descr_arc_from_deadframe(
     let jf = frame
         .as_jitframe()
         .ok_or_else(|| BackendError::Unsupported("expected JitFrameDeadFrame".to_string()))?;
-    Ok(jf.fail_descr.clone())
+    Ok(jf.fail_descr.to_arc())
 }
 
 pub fn get_int_from_deadframe(frame: &DeadFrame, index: usize) -> Result<i64, BackendError> {
@@ -3326,10 +3323,9 @@ fn execute_registered_loop_target(target: &RegisteredLoopTarget, inputs: &[i64])
             return wrap_call_assembler_deadframe_with_caller_prefix(frame);
         }
 
-        let fail_descr_arc =
-            direct_descr.unwrap_or_else(|| cur_fail_descrs[fail_index as usize].clone());
-        let fail_descr = &fail_descr_arc;
-        let fail_descr_fd = as_fd(fail_descr);
+        let fail_descr = direct_descr
+            .unwrap_or_else(|| ExitDescr::owned(cur_fail_descrs[fail_index as usize].clone()));
+        let fail_descr_fd = fail_descr.as_fail_descr();
         maybe_increment_fail_count(fail_descr_fd);
         if let Some(bridge) = fail_descr_bridge_ref(fail_descr_fd) {
             // Extracted here rather than beside `fail_index`: the exits that
@@ -3391,7 +3387,7 @@ fn execute_registered_loop_target(target: &RegisteredLoopTarget, inputs: &[i64])
             let mut mat_outputs = outputs.clone();
             let fail_arg_types = fail_descr_fd.fail_arg_types();
             rebuild_state_after_failure_dispatch(
-                fail_descr,
+                &fail_descr.to_arc(),
                 &mut mat_outputs,
                 fail_arg_types,
                 bridge.num_inputs,
@@ -8030,7 +8026,7 @@ struct JitExecResult {
     jf_gcref: GcRef,
     heap_owner: Option<FrameHeapOwner>,
     fail_index: u32,
-    direct_descr: Option<DescrRef>,
+    direct_descr: Option<ExitDescr>,
 }
 
 impl JitExecResult {
@@ -9304,7 +9300,7 @@ impl CraneliftBackend {
             let fail_descr = if let Some(descr) = direct_descr {
                 descr
             } else if (fail_index as usize) < cur_fail_descrs.len() {
-                cur_fail_descrs[fail_index as usize].clone()
+                ExitDescr::owned(cur_fail_descrs[fail_index as usize].clone())
             } else {
                 // Search bridge fail_descrs for nested guard failures.
                 let found = compiled.fail_descrs.iter().find_map(|d| {
@@ -9313,12 +9309,12 @@ impl CraneliftBackend {
                         find_fail_descr_in_fail_descrs(&b.fail_descrs, b.trace_id, fail_index)
                     })
                 });
-                found.unwrap_or_else(|| {
+                ExitDescr::owned(found.unwrap_or_else(|| {
                     cur_fail_descrs
                         .last()
                         .cloned()
                         .unwrap_or_else(|| compiled.fail_descrs[0].clone())
-                })
+                }))
             };
             // `compile.py` `_DoneWithThisFrameDescr.final_descr = True` is a
             // class attribute, i.e. a field load after translation. The FINISH
@@ -9333,7 +9329,7 @@ impl CraneliftBackend {
             // between the two returns below has to be re-checked here.
             debug_assert!(
                 fail_index != u32::MAX || {
-                    let fd = as_fd(&fail_descr);
+                    let fd = fail_descr.as_fail_descr();
                     !fd.is_external_jump() && !fd.is_resume_guard() && !fd.is_resume_guard_copied()
                 },
                 "a u32::MAX fail_index must be a final or propagate descr, never a guard"
@@ -9341,7 +9337,7 @@ impl CraneliftBackend {
             if fail_index == u32::MAX {
                 return deadframe_from_jitframe(exec.jf_gcref, fail_descr, exec.heap_owner);
             }
-            let fail_descr_fd = as_fd(&fail_descr);
+            let fail_descr_fd = fail_descr.as_fail_descr();
 
             // llgraph/runner.py Jump exception caught by execute():
             // cross-loop JUMP — switch to the target loop trace identified
@@ -9435,10 +9431,9 @@ impl CraneliftBackend {
             return wrap_call_assembler_deadframe_with_caller_prefix(frame);
         }
 
-        let fail_descr_arc =
-            direct_descr.unwrap_or_else(|| bridge.fail_descrs[fail_index as usize].clone());
-        let fail_descr = &fail_descr_arc;
-        let fail_descr_fd = as_fd(fail_descr);
+        let fail_descr = direct_descr
+            .unwrap_or_else(|| ExitDescr::owned(bridge.fail_descrs[fail_index as usize].clone()));
+        let fail_descr_fd = fail_descr.as_fail_descr();
 
         // RPython parity: FINISH exits in bridges return directly,
         // just like in execute_with_inputs. Without this, the FINISH
@@ -17502,10 +17497,10 @@ impl majit_backend::Backend for CraneliftBackend {
             }
 
             // llmodel.py get_latest_descr.
-            let fail_descr_arc = if let Some(descr) = direct_descr {
+            let fail_descr = if let Some(descr) = direct_descr {
                 descr
             } else if (fail_index as usize) < cur_fail_descrs.len() {
-                cur_fail_descrs[fail_index as usize].clone()
+                ExitDescr::owned(cur_fail_descrs[fail_index as usize].clone())
             } else {
                 let found = compiled.fail_descrs.iter().find_map(|d| {
                     let guard = fail_descr_bridge_ref(as_fd(d));
@@ -17513,16 +17508,15 @@ impl majit_backend::Backend for CraneliftBackend {
                         find_fail_descr_in_fail_descrs(&b.fail_descrs, b.trace_id, fail_index)
                     })
                 });
-                found.unwrap_or_else(|| {
+                ExitDescr::owned(found.unwrap_or_else(|| {
                     cur_fail_descrs
                         .last()
                         .cloned()
                         .unwrap_or_else(|| compiled.fail_descrs[0].clone())
-                })
+                }))
             };
-            let fail_descr = &fail_descr_arc;
 
-            let fail_descr_fd = as_fd(fail_descr);
+            let fail_descr_fd = fail_descr.as_fail_descr();
 
             // llgraph/runner.py:1130-1140 cross-loop JUMP: switch to the
             // target trace identified by the TargetToken stored on the
@@ -17576,7 +17570,7 @@ impl majit_backend::Backend for CraneliftBackend {
                     }
                 }
 
-                let fail_descr_ref: DescrRef = fail_descr_arc.clone();
+                let fail_descr_ref: DescrRef = fail_descr.to_arc();
                 let trace_id = fail_descr_fd.trace_id();
                 return majit_backend::RawExecResult {
                     outputs,
@@ -17590,7 +17584,7 @@ impl majit_backend::Backend for CraneliftBackend {
                     is_exit_frame_with_exception: fail_descr_fd.is_exit_frame_with_exception(),
                     status: fail_descr_fd.get_status(),
                     guard_value_operand: None,
-                    descr_arc: fail_descr_arc.clone(),
+                    descr_arc: fail_descr.to_arc(),
                 };
             }
 
@@ -17637,7 +17631,7 @@ impl majit_backend::Backend for CraneliftBackend {
                 }
             }
 
-            let fail_descr_ref: DescrRef = fail_descr_arc.clone();
+            let fail_descr_ref: DescrRef = fail_descr.to_arc();
             let trace_id = fail_descr_fd.trace_id();
             return majit_backend::RawExecResult {
                 outputs,
@@ -17651,7 +17645,7 @@ impl majit_backend::Backend for CraneliftBackend {
                 is_exit_frame_with_exception: fail_descr_fd.is_exit_frame_with_exception(),
                 status: fail_descr_fd.get_status(),
                 guard_value_operand: None,
-                descr_arc: fail_descr_arc.clone(),
+                descr_arc: fail_descr.to_arc(),
             };
         }
     }

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -252,7 +252,7 @@ fn attached_descr_ptrs_with_fallbacks(
 fn match_metainterp_finish_descr(
     jf_descr_raw: i64,
     attachments: &'static CpuDescrAttachments,
-) -> Option<&DescrRef> {
+) -> Option<&'static DescrRef> {
     let ptr = jf_descr_raw as usize;
     fn check(
         slot: &'static Option<majit_ir::DescrRef>,

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -8125,11 +8125,12 @@ fn resolve_exit_descr(
         }
     } else if let Some(metainterp_finish) = match_metainterp_finish_descr(jf_descr_raw, attachments)
     {
-        // `history.py:125` `cpu.get_latest_descr(deadframe)` parity:
+        // `history.py AbstractDescr.show` / `cpu.get_latest_descr(deadframe)`:
         // `jf_descr` carries the metainterp `Arc<DoneWithThisFrameDescr*>`
-        // address (compiler.rs baking).  Return that *exact* Arc
-        // so the consumer sees the same identity `compile.py:618-672`
-        // attached on the cpu — not the process-global fallback static.
+        // address (compiler.rs baking).  Return that *exact* Arc so the
+        // consumer sees the same identity `compile.py
+        // make_and_attach_done_descrs` attached on the cpu — not the
+        // process-global fallback static.
         // Both are `Arc<DoneWithThisFrameDescrInt>` (no wrapper) so the
         // trait-method dispatch is identical; only
         // the Arc identity differs, and PyPy parity demands they match.
@@ -8147,26 +8148,10 @@ fn resolve_exit_descr(
             jf_descr_raw as usize,
             attachments.propagate_exception_descr.as_ref(),
         );
+        // The word is non-zero on this arm, and `find_fail_descr_by_ptr`
+        // answers every non-zero word — the cranelift singletons by
+        // identity, anything else through `recover_fail_descr_cell`.
         let fi = arc.as_ref().map(|a| as_fd(a).fail_index()).unwrap_or(0);
-        // compile.py:665-674 parity: done_with_this_frame_descr is a
-        // global singleton — it won't appear in per-trace fail_descrs.
-        let arc = arc.or_else(|| {
-            let ptr = jf_descr_raw as usize;
-            // Singletons are `DescrRef = Arc<dyn Descr>` (fat pointer).
-            // Match on the data-pointer half via
-            // `as *const () as usize`.
-            for global in [
-                &*DONE_WITH_THIS_FRAME_DESCR_INT,
-                &*DONE_WITH_THIS_FRAME_DESCR_FLOAT,
-                &*DONE_WITH_THIS_FRAME_DESCR_REF,
-                &*DONE_WITH_THIS_FRAME_DESCR_VOID,
-            ] {
-                if Arc::as_ptr(global) as *const () as usize == ptr {
-                    return Some(global.clone());
-                }
-            }
-            None
-        });
         (fi, arc.map(ExitDescr::owned))
     }
 }

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -2958,7 +2958,7 @@ fn redirect_call_assembler_target(old_number: u64, new_number: u64) -> Result<()
     // Must update both code_ptr AND finish_descr_ptr (the new target has
     // different FailDescr pointers for its finish exit).
     let attached_descrs = {
-        let attached = new_target.cpu_attachments.read().unwrap().descr_ptrs();
+        let attached = new_target.cpu_attachments.read().descr_ptrs();
         attached_descr_ptrs_with_fallbacks(attached)
     };
     let new_finish_descr_ptr = new_target
@@ -3280,7 +3280,7 @@ fn execute_registered_loop_target(target: &RegisteredLoopTarget, inputs: &[i64])
     // the read lock is safe: `Backend::set_done_with_this_frame_descr_*`
     // only fires during `MetaInterpStaticData.finish_setup`, long
     // before compiled code runs.
-    let attachments_guard = target.cpu_attachments.read().unwrap();
+    let attachments_guard = target.cpu_attachments.read();
     let attachments: &CpuDescrAttachments = &attachments_guard;
     loop {
         let exec = run_compiled_code(
@@ -3694,7 +3694,7 @@ fn emit_memory_error_check(
 /// fail count, checks bridge (atomic + mutex only when bridge exists),
 /// and defers bridge compilation. Falls back to force_fn.
 ///
-/// `cpu_handle` is the heap-stable `Arc<RwLock<CpuDescrAttachments>>`
+/// `cpu_handle` is the heap-stable `Arc<CpuDescrCell>`
 /// address baked as an immediate at emit time so the runtime
 /// finish-descr classifier can resolve
 /// `DoneWithThisFrame*` identity against the owning cpu's attachments
@@ -3703,7 +3703,7 @@ fn emit_memory_error_check(
 /// alive for the lifetime of the emitted code.
 #[inline(never)]
 extern "C" fn call_assembler_guard_failure(
-    cpu_handle: *const std::sync::RwLock<CpuDescrAttachments>,
+    cpu_handle: *const majit_backend::CpuDescrCell,
     token_number: u64,
     fail_descr_ptr: i64,
     frame_ptr: i64,
@@ -3731,7 +3731,7 @@ extern "C" fn call_assembler_guard_failure(
 }
 
 fn call_assembler_guard_failure_inner(
-    cpu_handle: *const std::sync::RwLock<CpuDescrAttachments>,
+    cpu_handle: *const majit_backend::CpuDescrCell,
     token_number: u64,
     fail_descr_ptr: i64,
     frame_ptr: i64,
@@ -3750,7 +3750,7 @@ fn call_assembler_guard_failure_inner(
         default_attachments = CpuDescrAttachments::default();
         &default_attachments
     } else {
-        attachments_guard = unsafe { (*cpu_handle).read().unwrap() };
+        attachments_guard = unsafe { (*cpu_handle).read() };
         &attachments_guard
     };
     // Handle deadframe sentinel (nested CALL_ASSEMBLER propagation).
@@ -8674,7 +8674,7 @@ pub struct CraneliftBackend {
     /// Each `Backend` instance owns its own copy of the metainterp-side
     /// `DoneWithThisFrameDescr*` / `ExitFrameWithExceptionDescrRef` /
     /// `PropagateExceptionDescr` singletons, held in a heap-pinned
-    /// `Arc<RwLock<CpuDescrAttachments>>` so the address is stable even
+    /// `Arc<CpuDescrCell>` so the address is stable even
     /// when `CraneliftBackend` is moved.  `CompiledLoop` carries an Arc
     /// clone so the attachments outlive this backend for the lifetime of
     /// emitted code that baked the handle as an immediate.
@@ -8928,7 +8928,7 @@ impl CraneliftBackend {
             //   symbolic.get_field_token(rclass.OBJECT, 'typeptr', ...).
             // Callers configure pyre's PyObject layout via set_vtable_offset.
             vtable_offset: None,
-            descr_attachments: Arc::new(std::sync::RwLock::new(CpuDescrAttachments::default())),
+            descr_attachments: Arc::new(majit_backend::CpuDescrCell::default()),
         }
     }
 
@@ -8987,11 +8987,11 @@ impl CraneliftBackend {
     /// backend-only integration tests that skip `MetaInterp::new` so
     /// every result-type bucket still has a non-zero pointer.
     pub(crate) fn attached_descr_ptrs(&self) -> majit_backend::AttachedDescrPtrs {
-        let attached = self.descr_attachments.read().unwrap().descr_ptrs();
+        let attached = self.descr_attachments.read().descr_ptrs();
         attached_descr_ptrs_with_fallbacks(attached)
     }
 
-    /// Heap-stable `Arc<RwLock<CpuDescrAttachments>>` address for embedding
+    /// Heap-stable `Arc<CpuDescrCell>` address for embedding
     /// in cranelift-emitted CALL_ASSEMBLER helpers; the extern-C trampoline
     /// dereferences it to snapshot the attached descr pointers at dispatch.
     /// Matches dynasm's `cpu_handle_ptr()` semantics so both backends share
@@ -12486,7 +12486,7 @@ impl CraneliftBackend {
                         let result_jf_data_i64 =
                             ptr_arg_as_i64(&mut builder, result_jf_data, ptr_type);
                         // `compile.py:665 setattr(cpu, name, descr)` — bake the
-                        // heap-stable `Arc<RwLock<CpuDescrAttachments>>` address
+                        // heap-stable `Arc<CpuDescrCell>` address
                         // so the trampoline's runtime classifier resolves
                         // `DoneWithThisFrame*` identity against the owning cpu.
                         // `CompiledLoop.cpu_attachments` keeps the allocation
@@ -16906,39 +16906,27 @@ impl majit_backend::Backend for CraneliftBackend {
 
     fn set_done_with_this_frame_descr_void(&mut self, descr: majit_ir::DescrRef) {
         self.descr_attachments
-            .write()
-            .unwrap()
-            .done_with_this_frame_descr_void = Some(descr);
+            .update(|a| a.done_with_this_frame_descr_void = Some(descr));
     }
     fn set_done_with_this_frame_descr_int(&mut self, descr: majit_ir::DescrRef) {
         self.descr_attachments
-            .write()
-            .unwrap()
-            .done_with_this_frame_descr_int = Some(descr);
+            .update(|a| a.done_with_this_frame_descr_int = Some(descr));
     }
     fn set_done_with_this_frame_descr_ref(&mut self, descr: majit_ir::DescrRef) {
         self.descr_attachments
-            .write()
-            .unwrap()
-            .done_with_this_frame_descr_ref = Some(descr);
+            .update(|a| a.done_with_this_frame_descr_ref = Some(descr));
     }
     fn set_done_with_this_frame_descr_float(&mut self, descr: majit_ir::DescrRef) {
         self.descr_attachments
-            .write()
-            .unwrap()
-            .done_with_this_frame_descr_float = Some(descr);
+            .update(|a| a.done_with_this_frame_descr_float = Some(descr));
     }
     fn set_exit_frame_with_exception_descr_ref(&mut self, descr: majit_ir::DescrRef) {
         self.descr_attachments
-            .write()
-            .unwrap()
-            .exit_frame_with_exception_descr_ref = Some(descr);
+            .update(|a| a.exit_frame_with_exception_descr_ref = Some(descr));
     }
     fn set_propagate_exception_descr(&mut self, descr: majit_ir::DescrRef) {
         self.descr_attachments
-            .write()
-            .unwrap()
-            .propagate_exception_descr = Some(descr);
+            .update(|a| a.propagate_exception_descr = Some(descr));
     }
 
     /// `compile.py do_compile_bridge` — line-by-line:
@@ -17416,7 +17404,7 @@ impl majit_backend::Backend for CraneliftBackend {
         // 0 only for the initial entry — every external-JUMP re-entry,
         // including the first LABEL, selects its loader (label_block_id + 1).
         let mut cur_dispatch_key: u32 = 0;
-        let attachments_guard = compiled.cpu_attachments.read().unwrap();
+        let attachments_guard = compiled.cpu_attachments.read();
         let attachments: &CpuDescrAttachments = &attachments_guard;
 
         loop {

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -628,7 +628,6 @@ impl<'a> AssemblerARM64<'a> {
     fn done_with_this_frame_descr_ptr_for_type(&self, tp: Type) -> i64 {
         self.cpu_handle
             .read()
-            .unwrap()
             .descr_ptrs()
             .done_with_this_frame_descr_ptr_for_type(tp) as i64
     }
@@ -640,7 +639,7 @@ impl<'a> AssemblerARM64<'a> {
     /// `is_finish` / `fail_arg_types` through the metainterp class
     /// hierarchy (`compile.py:624 final_descr=True`).
     fn done_with_this_frame_descr_arc_for_type(&self, tp: Type) -> Option<majit_ir::DescrRef> {
-        let attachments = self.cpu_handle.read().unwrap();
+        let attachments = self.cpu_handle.read();
         match tp {
             Type::Void => attachments.done_with_this_frame_descr_void.clone(),
             Type::Int => attachments.done_with_this_frame_descr_int.clone(),
@@ -653,7 +652,6 @@ impl<'a> AssemblerARM64<'a> {
     fn exit_frame_with_exception_descr_ref_ptr(&self) -> i64 {
         self.cpu_handle
             .read()
-            .unwrap()
             .descr_ptrs()
             .exit_frame_with_exception_descr_ref as i64
     }
@@ -665,7 +663,6 @@ impl<'a> AssemblerARM64<'a> {
     fn propagate_exception_descr_ptr(&self) -> i64 {
         self.cpu_handle
             .read()
-            .unwrap()
             .descr_ptrs()
             .propagate_exception_descr as i64
     }
@@ -3005,7 +3002,6 @@ impl<'a> AssemblerARM64<'a> {
                 let descr: majit_ir::DescrRef = if is_exit_exc {
                     self.cpu_handle
                         .read()
-                        .unwrap()
                         .exit_frame_with_exception_descr_ref
                         .clone()
                 } else {

--- a/majit/majit-backend-dynasm/src/guard.rs
+++ b/majit/majit-backend-dynasm/src/guard.rs
@@ -37,7 +37,7 @@ use majit_ir::FailDescr;
 /// cross-backend base-class concern; `compile.py:665-674
 /// make_and_attach_done_descrs` binds them on each `cpu` instance
 /// regardless of backend.
-pub use majit_backend::{AttachedDescrPtrs, CpuDescrAttachments, CpuDescrHandle};
+pub use majit_backend::{AttachedDescrPtrs, CpuDescrAttachments, CpuDescrCell, CpuDescrHandle};
 
 /// Re-export the slot decoder for the same reason: `_decode_pos` is a method
 /// on `AbstractLLCPU` (`llmodel.py`), not a per-arch entry, so its

--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -439,7 +439,7 @@ impl Drop for ResumeRefRootScope {
     reason = "this C-ABI trampoline is called only by generated machine code, which guarantees that the embedded CPU handle and jitframe pointers remain live; making the symbol unsafe does not express that foreign-call contract"
 )]
 pub extern "C" fn call_assembler_helper_trampoline(
-    cpu_handle: *const std::sync::RwLock<guard::CpuDescrAttachments>,
+    cpu_handle: *const guard::CpuDescrCell,
     callee_jf_ptr: *mut jitframe::JitFrame,
     green_key: u64,
 ) -> i64 {
@@ -458,7 +458,7 @@ pub extern "C" fn call_assembler_helper_trampoline(
     // `compile.py:665-674` parity: resolve the attached `DoneWithThisFrame*`
     // + `ExitFrameWithExceptionDescrRef` identities from the cpu instance
     // that emitted the CALL_ASSEMBLER.  `cpu_handle` is the heap-pinned
-    // `Arc<RwLock<CpuDescrAttachments>>` address baked as a compile-time
+    // `Arc<CpuDescrCell>` address baked as a compile-time
     // constant into the emitted call site — same role as RPython's
     // `self.cpu` closure capture in the translated code.  A compiled
     // trace keeps an `Arc` clone alive alongside its executable buffer
@@ -471,7 +471,7 @@ pub extern "C" fn call_assembler_helper_trampoline(
     let attached = if cpu_handle.is_null() {
         majit_backend::AttachedDescrPtrs::default()
     } else {
-        unsafe { (*cpu_handle).read().unwrap().descr_ptrs() }
+        unsafe { (*cpu_handle).read().descr_ptrs() }
     };
     // warmspot.py:1023-1028 `fail_descr.handle_fail(deadframe, ...)`.
     // Callee jitframe is GC-managed by the rewriter's

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1466,7 +1466,7 @@ pub struct DynasmBackend {
     /// field inside instance objects. None when gcremovetypeptr is enabled.
     vtable_offset: Option<usize>,
     /// `compile.py:665` `setattr(cpu, name, descr)` per-cpu attachments,
-    /// held in a heap-pinned `Arc<RwLock<CpuDescrAttachments>>` so the
+    /// held in a heap-pinned `Arc<CpuDescrCell>` so the
     /// pointer baked into the CALL_ASSEMBLER helper call site
     /// (`compile_loop` / `compile_bridge`) stays valid even when
     /// `DynasmBackend` is moved (the metainterp stores it by value; tests
@@ -1572,9 +1572,7 @@ impl DynasmBackend {
             next_header_pc: 0,
             constants: majit_ir::ConstMap::new(),
             vtable_offset: None,
-            descr_attachments: Arc::new(std::sync::RwLock::new(
-                crate::guard::CpuDescrAttachments::default(),
-            )),
+            descr_attachments: Arc::new(crate::guard::CpuDescrCell::default()),
             arch_cpu_ext: ArchCpuExt::new(asm_memory_manager),
         }
     }
@@ -1671,12 +1669,12 @@ impl DynasmBackend {
     /// answer, so backend-only integration tests see distinct, non-zero
     /// pointers per result type without ever consulting per-thread state.
     pub(crate) fn attached_descr_ptrs(&self) -> crate::guard::AttachedDescrPtrs {
-        self.descr_attachments.read().unwrap().descr_ptrs()
+        self.descr_attachments.read().descr_ptrs()
     }
 
     /// `Arc` clone of the attachment handle, for compiled traces to
     /// keep alive alongside their executable buffer.  The `Arc`'s
-    /// payload (the `RwLock<CpuDescrAttachments>`) lives at a heap-
+    /// payload (the `CpuDescrCell`) lives at a heap-
     /// pinned address; `Arc::as_ptr(&clone)` is baked by emission into
     /// the CALL_ASSEMBLER helper call site as a compile-time immediate
     /// (same role as RPython's `self.cpu` closure capture in the
@@ -2130,7 +2128,7 @@ impl DynasmBackend {
             // The `DoneWithThisFrameDescr` class hierarchy answers
             // `is_finish`/`fail_arg_types` via its own FailDescr impl —
             // no backend wrapper is needed.
-            let att = self.descr_attachments.read().unwrap();
+            let att = self.descr_attachments.read();
             let meta = if ptr == attached.done_with_this_frame_descr_void {
                 att.done_with_this_frame_descr_void.clone()
             } else if ptr == attached.done_with_this_frame_descr_float {
@@ -2153,7 +2151,6 @@ impl DynasmBackend {
             return self
                 .descr_attachments
                 .read()
-                .unwrap()
                 .exit_frame_with_exception_descr_ref
                 .clone()
                 .expect("matched exit_frame_with_exception ptr but slot is unattached");
@@ -2206,7 +2203,6 @@ impl DynasmBackend {
             return self
                 .descr_attachments
                 .read()
-                .unwrap()
                 .exit_frame_with_exception_descr_ref
                 .clone()
                 .expect(
@@ -2565,33 +2561,23 @@ impl Backend for DynasmBackend {
 
     fn set_done_with_this_frame_descr_void(&mut self, descr: majit_ir::DescrRef) {
         self.descr_attachments
-            .write()
-            .unwrap()
-            .done_with_this_frame_descr_void = Some(descr);
+            .update(|a| a.done_with_this_frame_descr_void = Some(descr));
     }
     fn set_done_with_this_frame_descr_int(&mut self, descr: majit_ir::DescrRef) {
         self.descr_attachments
-            .write()
-            .unwrap()
-            .done_with_this_frame_descr_int = Some(descr);
+            .update(|a| a.done_with_this_frame_descr_int = Some(descr));
     }
     fn set_done_with_this_frame_descr_ref(&mut self, descr: majit_ir::DescrRef) {
         self.descr_attachments
-            .write()
-            .unwrap()
-            .done_with_this_frame_descr_ref = Some(descr);
+            .update(|a| a.done_with_this_frame_descr_ref = Some(descr));
     }
     fn set_done_with_this_frame_descr_float(&mut self, descr: majit_ir::DescrRef) {
         self.descr_attachments
-            .write()
-            .unwrap()
-            .done_with_this_frame_descr_float = Some(descr);
+            .update(|a| a.done_with_this_frame_descr_float = Some(descr));
     }
     fn set_exit_frame_with_exception_descr_ref(&mut self, descr: majit_ir::DescrRef) {
         self.descr_attachments
-            .write()
-            .unwrap()
-            .exit_frame_with_exception_descr_ref = Some(descr);
+            .update(|a| a.exit_frame_with_exception_descr_ref = Some(descr));
     }
     fn set_propagate_exception_descr(&mut self, descr: majit_ir::DescrRef) {
         // x86/assembler.py `_build_propagate_exception_path` parity:
@@ -2620,8 +2606,9 @@ impl Backend for DynasmBackend {
         // never does so), refuse the swap with a clear assert.  The
         // pre-bake path (no trampoline yet) keeps overwriting freely
         // — the next `ensure_*_path` will bake the fresh pointer.
-        let mut attachments = self.descr_attachments.write().unwrap();
-        if attachments
+        if self
+            .descr_attachments
+            .read()
             .propagate_exception_descr
             .as_ref()
             .is_some_and(|existing| std::sync::Arc::ptr_eq(existing, &descr))
@@ -2635,7 +2622,8 @@ impl Backend for DynasmBackend {
              previous descr pointer; bind propagate_exception_descr once \
              before backend.setup_once() (pyjitpl.py:2273-2283 ordering)"
         );
-        attachments.propagate_exception_descr = Some(descr);
+        self.descr_attachments
+            .update(|a| a.propagate_exception_descr = Some(descr));
     }
 
     fn compile_bridge(

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -371,11 +371,7 @@ pub(crate) fn build_propagate_exception_path(
     arena: &Arc<AsmMemoryManager>,
 ) -> (codebuf::ArenaExecutableBuffer, usize) {
     let mut asm = Assembler::new().expect("propagate_exception_path: new Assembler");
-    let propagate_descr = cpu_handle
-        .read()
-        .unwrap()
-        .descr_ptrs()
-        .propagate_exception_descr as i64;
+    let propagate_descr = cpu_handle.read().descr_ptrs().propagate_exception_descr as i64;
     assert!(
         propagate_descr != 0,
         "build_propagate_exception_path: cpu_handle.propagate_exception_descr \
@@ -1148,7 +1144,6 @@ impl<'a> Assembler386<'a> {
     fn done_with_this_frame_descr_ptr_for_type(&self, tp: Type) -> i64 {
         self.cpu_handle
             .read()
-            .unwrap()
             .descr_ptrs()
             .done_with_this_frame_descr_ptr_for_type(tp) as i64
     }
@@ -1160,7 +1155,7 @@ impl<'a> Assembler386<'a> {
     /// `is_finish` / `fail_arg_types` through the metainterp class
     /// hierarchy (`compile.py:624 final_descr=True`).
     fn done_with_this_frame_descr_arc_for_type(&self, tp: Type) -> Option<majit_ir::DescrRef> {
-        let attachments = self.cpu_handle.read().unwrap();
+        let attachments = self.cpu_handle.read();
         match tp {
             Type::Void => attachments.done_with_this_frame_descr_void.clone(),
             Type::Int => attachments.done_with_this_frame_descr_int.clone(),
@@ -1173,7 +1168,6 @@ impl<'a> Assembler386<'a> {
     fn exit_frame_with_exception_descr_ref_ptr(&self) -> i64 {
         self.cpu_handle
             .read()
-            .unwrap()
             .descr_ptrs()
             .exit_frame_with_exception_descr_ref as i64
     }
@@ -1185,7 +1179,6 @@ impl<'a> Assembler386<'a> {
     fn propagate_exception_descr_ptr(&self) -> i64 {
         self.cpu_handle
             .read()
-            .unwrap()
             .descr_ptrs()
             .propagate_exception_descr as i64
     }
@@ -4136,7 +4129,6 @@ impl<'a> Assembler386<'a> {
                 let descr: majit_ir::DescrRef = if is_exit_exc {
                     self.cpu_handle
                         .read()
-                        .unwrap()
                         .exit_frame_with_exception_descr_ref
                         .clone()
                 } else {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -4996,11 +4996,19 @@ impl majit_backend::Backend for WasmBackend {
     }
 
     fn get_latest_descr<'a>(&'a self, frame: &'a DeadFrame) -> &'a dyn FailDescr {
+        // The same selection as `get_latest_descr_arc` below: the metainterp
+        // descr when the optimizer stamped one, since that is the object
+        // carrying `is_exit_frame_with_exception` / `get_status` /
+        // `rd_loop_token_clt`, and the backend descr only for synthetic exits.
         let data = frame
             .boxed_data()
             .and_then(|d| d.downcast_ref::<WasmFrameData>())
             .expect("not WasmFrameData");
-        data.fail_descr.as_ref()
+        data.fail_descr
+            .meta_descr
+            .as_ref()
+            .and_then(|meta| meta.as_fail_descr())
+            .unwrap_or(data.fail_descr.as_ref())
     }
 
     fn get_latest_descr_arc(&self, frame: &DeadFrame) -> Arc<dyn majit_ir::Descr> {

--- a/majit/majit-backend/src/deadframe.rs
+++ b/majit/majit-backend/src/deadframe.rs
@@ -464,11 +464,11 @@ impl JitFrameRoot {
 /// Owned for a guard exit, whose descr lives in the trace's `FailDescrCell`
 /// and is reached through `recover_fail_descr_cell`. Borrowed for a finish
 /// exit: that descr is one of the six the metainterp attached to the cpu at
-/// `finish_setup` (`compile.py:665 setattr(cpu, name, descr)`), which the
-/// cpu's `CpuDescrCell` keeps and never releases, and which the metainterp
-/// that decodes this deadframe holds an `Arc` of itself. Cloning that `Arc`
-/// into every deadframe and dropping it again was measured at 3.2 ns per
-/// entry on cel's entry probe, on the arm every finished entry takes.
+/// `finish_setup` (`compile.py:665 setattr(cpu, name, descr)`), read out of
+/// a `CpuDescrCell` copy, and those copies are `'static` — the cell leaks
+/// every copy it publishes so that this borrow needs no count. Cloning the
+/// `Arc` into every deadframe and dropping it again was measured at 3.2 ns
+/// per entry on cel's entry probe, on the arm every finished entry takes.
 pub struct ExitDescr {
     ptr: *const dyn majit_ir::Descr,
     owned: bool,
@@ -488,13 +488,8 @@ impl ExitDescr {
         }
     }
 
-    /// Point at `descr` without a count.
-    ///
-    /// # Safety
-    /// `descr` must stay alive for as long as this handle does. The one
-    /// caller borrows a cpu-attached finish descr, whose lifetime is argued
-    /// on the type.
-    pub unsafe fn borrowed(descr: &DescrRef) -> Self {
+    /// Point at `descr` without a count. `'static` is the whole argument.
+    pub fn borrowed(descr: &'static DescrRef) -> Self {
         ExitDescr {
             ptr: std::sync::Arc::as_ptr(descr),
             owned: false,
@@ -504,7 +499,7 @@ impl ExitDescr {
     #[inline]
     pub fn get(&self) -> &dyn majit_ir::Descr {
         // Live by construction: owned handles hold a count, borrowed ones
-        // are covered by `borrowed`'s contract.
+        // point into a `'static`.
         unsafe { &*self.ptr }
     }
 

--- a/majit/majit-backend/src/deadframe.rs
+++ b/majit/majit-backend/src/deadframe.rs
@@ -381,6 +381,101 @@ impl JitFrameRoot {
     }
 }
 
+/// The descr a compiled exit names: `jf_descr` as an object.
+///
+/// Owned for a guard exit, whose descr lives in the trace's `FailDescrCell`
+/// and is reached through `recover_fail_descr_cell`. Borrowed for a finish
+/// exit: that descr is one of the six the metainterp attached to the cpu at
+/// `finish_setup` (`compile.py:665 setattr(cpu, name, descr)`), which the
+/// cpu's `CpuDescrCell` keeps and never releases, and which the metainterp
+/// that decodes this deadframe holds an `Arc` of itself. Cloning that `Arc`
+/// into every deadframe and dropping it again was measured at 3.2 ns per
+/// entry on cel's entry probe, on the arm every finished entry takes.
+pub struct ExitDescr {
+    ptr: *const dyn majit_ir::Descr,
+    owned: bool,
+}
+
+// The pointee is an `Arc<dyn Descr>` payload and `Descr: Send + Sync`; the
+// raw pointer only records whether this handle holds a count on it.
+unsafe impl Send for ExitDescr {}
+unsafe impl Sync for ExitDescr {}
+
+impl ExitDescr {
+    /// Hold a strong count on `descr`.
+    pub fn owned(descr: DescrRef) -> Self {
+        ExitDescr {
+            ptr: std::sync::Arc::into_raw(descr),
+            owned: true,
+        }
+    }
+
+    /// Point at `descr` without a count.
+    ///
+    /// # Safety
+    /// `descr` must stay alive for as long as this handle does. The one
+    /// caller borrows a cpu-attached finish descr, whose lifetime is argued
+    /// on the type.
+    pub unsafe fn borrowed(descr: &DescrRef) -> Self {
+        ExitDescr {
+            ptr: std::sync::Arc::as_ptr(descr),
+            owned: false,
+        }
+    }
+
+    #[inline]
+    pub fn get(&self) -> &dyn majit_ir::Descr {
+        // Live by construction: owned handles hold a count, borrowed ones
+        // are covered by `borrowed`'s contract.
+        unsafe { &*self.ptr }
+    }
+
+    #[inline]
+    pub fn as_fail_descr(&self) -> &dyn crate::FailDescr {
+        self.get()
+            .as_fail_descr()
+            .expect("a compiled exit's descr always implements FailDescr")
+    }
+
+    /// A strong `Arc` to the descr, whichever way this handle holds it.
+    pub fn to_arc(&self) -> DescrRef {
+        unsafe {
+            std::sync::Arc::increment_strong_count(self.ptr);
+            std::sync::Arc::from_raw(self.ptr)
+        }
+    }
+}
+
+impl Clone for ExitDescr {
+    fn clone(&self) -> Self {
+        if self.owned {
+            ExitDescr::owned(self.to_arc())
+        } else {
+            ExitDescr {
+                ptr: self.ptr,
+                owned: false,
+            }
+        }
+    }
+}
+
+impl Drop for ExitDescr {
+    fn drop(&mut self) {
+        if self.owned {
+            drop(unsafe { std::sync::Arc::from_raw(self.ptr) });
+        }
+    }
+}
+
+impl std::fmt::Debug for ExitDescr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExitDescr")
+            .field("owned", &self.owned)
+            .field("descr", &self.get())
+            .finish()
+    }
+}
+
 /// The deadframe of a backend whose frames are jitframes.
 pub struct JitFrameDeadFrame {
     /// The JitFrame this deadframe reads through.
@@ -389,7 +484,7 @@ pub struct JitFrameDeadFrame {
     /// (`Arc<dyn Descr>`) so the deadframe carries the same Arc identity
     /// the metainterp stamps onto `op.descr` — matching `frame.jf_descr =
     /// descr` (llmodel.py:270) line-by-line.
-    pub fail_descr: DescrRef,
+    pub fail_descr: ExitDescr,
     /// Original attached `jf_descr` identity for finish exits emitted by
     /// the metainterp (`DoneWithThisFrame*` / `ExitFrameWithExceptionDescrRef`).
     pub latest_descr: Option<DescrRef>,
@@ -422,7 +517,7 @@ impl JitFrameDeadFrame {
     /// always handed `None`.
     pub fn new(
         jf_gcref: GcRef,
-        fail_descr: DescrRef,
+        fail_descr: ExitDescr,
         latest_descr: Option<DescrRef>,
         heap_owner: Option<FrameHeapOwner>,
     ) -> Self {
@@ -453,7 +548,7 @@ impl JitFrameDeadFrame {
     /// are still the only reference to their objects.
     pub fn borrowing(
         jf_gcref: GcRef,
-        fail_descr: DescrRef,
+        fail_descr: ExitDescr,
         latest_descr: Option<DescrRef>,
     ) -> Self {
         JitFrameDeadFrame {

--- a/majit/majit-backend/src/deadframe.rs
+++ b/majit/majit-backend/src/deadframe.rs
@@ -737,3 +737,36 @@ mod tests {
         unsafe { free_off_gc_jitframe(frame) };
     }
 }
+
+/// Which fixed cost of a compiled entry the probe repeats beside the frame
+/// build, selected once per process from `MAJIT_PROBE_EXTRA`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ProbeExtraStage {
+    None,
+    /// `JittedGuard::enter` and its drop.
+    Guard,
+    /// The jitframe heap selector's thread-local read.
+    Heap,
+    /// The three `Once`-guarded flag reads.
+    Flags,
+    /// `cpu_attachments.read()`.
+    Attach,
+    /// The `jf_descr` word to `(fail_index, descr)`.
+    Descr,
+    /// One clone and drop of the exit descr's `Arc`.
+    Arc,
+}
+
+/// `MAJIT_PROBE_EXTRA`, read once.
+pub fn probe_extra_stage() -> ProbeExtraStage {
+    static STAGE: std::sync::OnceLock<ProbeExtraStage> = std::sync::OnceLock::new();
+    *STAGE.get_or_init(|| match std::env::var("MAJIT_PROBE_EXTRA").as_deref() {
+        Ok("guard") => ProbeExtraStage::Guard,
+        Ok("heap") => ProbeExtraStage::Heap,
+        Ok("flags") => ProbeExtraStage::Flags,
+        Ok("attach") => ProbeExtraStage::Attach,
+        Ok("descr") => ProbeExtraStage::Descr,
+        Ok("arc") => ProbeExtraStage::Arc,
+        _ => ProbeExtraStage::None,
+    })
+}

--- a/majit/majit-backend/src/deadframe.rs
+++ b/majit/majit-backend/src/deadframe.rs
@@ -110,9 +110,49 @@ impl Drop for FrameHeapOwner {
 /// footprint without costing the ordinary one anything.
 const FRAME_POOL_CAPACITY: usize = 8;
 
-#[derive(Default)]
+/// A buffer parked on the free list: the `Vec<i64>`'s pointer and capacity,
+/// with its length taken to equal its capacity.
+#[derive(Clone, Copy)]
+struct ParkedBuf {
+    ptr: *mut i64,
+    cap: usize,
+}
+
+impl ParkedBuf {
+    const EMPTY: ParkedBuf = ParkedBuf {
+        ptr: std::ptr::null_mut(),
+        cap: 0,
+    };
+
+    fn park(buf: Vec<i64>) -> Self {
+        let mut buf = std::mem::ManuallyDrop::new(buf);
+        // `take_pooled_frame_buf` sizes by `len`, so keep the two equal.
+        let cap = buf.capacity();
+        // Safety: `cap <= capacity`, and the elements are `i64`, so any
+        // word in the allocation is initialised for the purpose of `resize`.
+        unsafe { buf.set_len(cap) };
+        ParkedBuf {
+            ptr: buf.as_mut_ptr(),
+            cap,
+        }
+    }
+
+    fn unpark(self) -> Vec<i64> {
+        // Safety: `park` took these from a live `Vec<i64>` and nothing else
+        // has owned them since.
+        unsafe { Vec::from_raw_parts(self.ptr, self.cap, self.cap) }
+    }
+}
+
+/// `Copy`, and so without a destructor: that is what lets `FRAME_POOL` be a
+/// `const`-initialised thread-local with no lazy state and no registered
+/// destructor, which is the fast access path. The price is that a thread's
+/// parked buffers are not freed when it exits — at most eight frames of a
+/// few hundred bytes each.
+#[derive(Clone, Copy)]
 struct FramePool {
-    free: Vec<Vec<i64>>,
+    free: [ParkedBuf; FRAME_POOL_CAPACITY],
+    free_len: usize,
     /// Buffers the owned arm asked the allocator for.
     owned: u64,
     /// Buffers the pooled arm handed out.
@@ -129,15 +169,13 @@ thread_local! {
     /// threads costs an uncontended atomic read-modify-write pair to take and to
     /// return a buffer, which is the same order as the saving, so a process-wide
     /// free list would hand back what it was built to remove. Sharding by thread
-    /// is what leaves the take and the return as plain `Vec` pops and pushes.
+    /// is what leaves the take and the return as plain pops and pushes.
     ///
     /// A field would be the alternative to a `thread_local!`, and there is no
     /// object to make it a field of: `run_compiled_code` and
-    /// `run_compiled_code_inner` (`majit-backend-cranelift/src/compiler.rs`) are
-    /// free functions whose only context is a `&CpuDescrAttachments`, a shared
-    /// reference. Compiled entries also nest — `execute_bridge` recurses and
-    /// CALL_ASSEMBLER hops re-enter — so a `&mut` owner threaded down to the
-    /// allocation could not be re-borrowed by the inner entry.
+    /// `FrameHeapOwner::drop` share no owner, and the buffer is taken by one
+    /// and returned by the other, in a different scope and after the caller
+    /// has moved on.
     ///
     /// Per-thread is also the right scope for the lifetime, not merely a cheap
     /// one. A buffer is taken and returned inside one compiled entry, which runs
@@ -150,7 +188,13 @@ thread_local! {
     /// TLS teardown would otherwise panic inside a `Drop`, and falling back to
     /// the allocator is the answer there.
     static FRAME_POOL: RefCell<FramePool> = const {
-        RefCell::new(FramePool { free: Vec::new(), owned: 0, taken: 0, misses: 0 })
+        RefCell::new(FramePool {
+            free: [ParkedBuf::EMPTY; FRAME_POOL_CAPACITY],
+            free_len: 0,
+            owned: 0,
+            taken: 0,
+            misses: 0,
+        })
     };
 }
 
@@ -158,12 +202,12 @@ fn take_pooled_frame_buf(words: usize) -> Vec<i64> {
     let pooled = FRAME_POOL.try_with(|pool| {
         let mut pool = pool.borrow_mut();
         pool.taken += 1;
-        match pool.free.pop() {
-            Some(buf) => Some(buf),
-            None => {
-                pool.misses += 1;
-                None
-            }
+        if pool.free_len == 0 {
+            pool.misses += 1;
+            None
+        } else {
+            pool.free_len -= 1;
+            Some(pool.free[pool.free_len].unpark())
         }
     });
     match pooled {
@@ -182,10 +226,13 @@ fn take_pooled_frame_buf(words: usize) -> Vec<i64> {
 }
 
 fn give_back_pooled_frame_buf(buf: Vec<i64>) {
+    // A full list, or no list: `buf` drops and the allocator takes it back.
     let _ = FRAME_POOL.try_with(|pool| {
         let mut pool = pool.borrow_mut();
-        if pool.free.len() < FRAME_POOL_CAPACITY {
-            pool.free.push(buf);
+        if pool.free_len < FRAME_POOL_CAPACITY {
+            let at = pool.free_len;
+            pool.free[at] = ParkedBuf::park(buf);
+            pool.free_len += 1;
         }
     });
 }

--- a/majit/majit-backend/src/deadframe.rs
+++ b/majit/majit-backend/src/deadframe.rs
@@ -713,7 +713,7 @@ mod tests {
         unsafe { (*frame).jf_gcmap = sentinel };
         drop(JitFrameDeadFrame::borrowing(
             GcRef(frame as usize),
-            a_descr(),
+            ExitDescr::owned(a_descr()),
             None,
         ));
         assert_eq!(
@@ -725,7 +725,7 @@ mod tests {
         unsafe { (*frame).jf_gcmap = sentinel };
         drop(JitFrameDeadFrame::new(
             GcRef(frame as usize),
-            a_descr(),
+            ExitDescr::owned(a_descr()),
             None,
             None,
         ));

--- a/majit/majit-backend/src/deadframe.rs
+++ b/majit/majit-backend/src/deadframe.rs
@@ -110,49 +110,74 @@ impl Drop for FrameHeapOwner {
 /// footprint without costing the ordinary one anything.
 const FRAME_POOL_CAPACITY: usize = 8;
 
-/// A buffer parked on the free list: the `Vec<i64>`'s pointer and capacity,
-/// with its length taken to equal its capacity.
+/// A buffer parked on the free list: a `Vec<i64>` taken apart into its three
+/// words, and put back together exactly as it was.
 #[derive(Clone, Copy)]
 struct ParkedBuf {
     ptr: *mut i64,
+    len: usize,
     cap: usize,
 }
 
 impl ParkedBuf {
     const EMPTY: ParkedBuf = ParkedBuf {
         ptr: std::ptr::null_mut(),
+        len: 0,
         cap: 0,
     };
 
     fn park(buf: Vec<i64>) -> Self {
         let mut buf = std::mem::ManuallyDrop::new(buf);
-        // `take_pooled_frame_buf` sizes by `len`, so keep the two equal.
-        let cap = buf.capacity();
-        // Safety: `cap <= capacity`, and the elements are `i64`, so any
-        // word in the allocation is initialised for the purpose of `resize`.
-        unsafe { buf.set_len(cap) };
         ParkedBuf {
             ptr: buf.as_mut_ptr(),
-            cap,
+            len: buf.len(),
+            cap: buf.capacity(),
         }
     }
 
     fn unpark(self) -> Vec<i64> {
-        // Safety: `park` took these from a live `Vec<i64>` and nothing else
-        // has owned them since.
-        unsafe { Vec::from_raw_parts(self.ptr, self.cap, self.cap) }
+        // Safety: `park` took these three from a live `Vec<i64>` and nothing
+        // else has owned them since.
+        unsafe { Vec::from_raw_parts(self.ptr, self.len, self.cap) }
     }
+}
+
+/// Frees a thread's parked buffers when the thread exits.
+///
+/// `FRAME_POOL` has no destructor so that its access path stays the direct
+/// one; this key has one, and is touched exactly once per thread, on the
+/// first park, which is what registers it. Thread-local destructors run in
+/// no fixed order, but a key without one stays readable throughout, so the
+/// pool is still there when this runs. A buffer parked after it ran — a
+/// deadframe dropped during thread teardown — is the one case that leaks.
+struct PoolReaper;
+
+impl Drop for PoolReaper {
+    fn drop(&mut self) {
+        let _ = FRAME_POOL.try_with(|pool| {
+            let mut pool = pool.borrow_mut();
+            for parked in &pool.free[..pool.free_len] {
+                drop(parked.unpark());
+            }
+            pool.free_len = 0;
+        });
+    }
+}
+
+thread_local! {
+    static POOL_REAPER: PoolReaper = const { PoolReaper };
 }
 
 /// `Copy`, and so without a destructor: that is what lets `FRAME_POOL` be a
 /// `const`-initialised thread-local with no lazy state and no registered
-/// destructor, which is the fast access path. The price is that a thread's
-/// parked buffers are not freed when it exits — at most eight frames of a
-/// few hundred bytes each.
+/// destructor, which is the fast access path. `POOL_REAPER` is the destructor,
+/// kept on a key the hot path never touches.
 #[derive(Clone, Copy)]
 struct FramePool {
     free: [ParkedBuf; FRAME_POOL_CAPACITY],
     free_len: usize,
+    /// Whether `POOL_REAPER` has been registered on this thread.
+    reaper_armed: bool,
     /// Buffers the owned arm asked the allocator for.
     owned: u64,
     /// Buffers the pooled arm handed out.
@@ -191,6 +216,7 @@ thread_local! {
         RefCell::new(FramePool {
             free: [ParkedBuf::EMPTY; FRAME_POOL_CAPACITY],
             free_len: 0,
+            reaper_armed: false,
             owned: 0,
             taken: 0,
             misses: 0,
@@ -230,6 +256,11 @@ fn give_back_pooled_frame_buf(buf: Vec<i64>) {
     let _ = FRAME_POOL.try_with(|pool| {
         let mut pool = pool.borrow_mut();
         if pool.free_len < FRAME_POOL_CAPACITY {
+            if !pool.reaper_armed {
+                pool.reaper_armed = true;
+                // First touch registers its destructor for this thread.
+                let _ = POOL_REAPER.try_with(|_| ());
+            }
             let at = pool.free_len;
             pool.free[at] = ParkedBuf::park(buf);
             pool.free_len += 1;

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -2887,6 +2887,11 @@ pub trait Backend: Send {
     fn clear_stored_exception(&self) {}
 
     /// Read the FailDescr from the last guard failure.
+    ///
+    /// The same object `get_latest_descr_arc` hands out, borrowed from the
+    /// frame instead of shared: a reader that only needs the descr's fields
+    /// for as long as it holds the frame takes this and pays no reference
+    /// count.
     fn get_latest_descr<'a>(&'a self, frame: &'a DeadFrame) -> &'a dyn FailDescr;
 
     /// Owned Arc counterpart of `get_latest_descr`.

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -3972,25 +3972,34 @@ pub fn set_jitted(jitted: bool) {
 ///
 /// Sets `we_are_jitted()` to `true` on creation, restores the previous
 /// value on drop.
+///
+/// Holds the flag's address rather than resolving the thread-local twice:
+/// `JIT_MODE_FLAG` is a `const`-initialised cell with no destructor, so it
+/// sits in the thread's static TLS block and its address holds for the life
+/// of the thread. The raw pointer keeps the guard `!Send`, which is what makes
+/// that address the right one on drop.
 pub struct JittedGuard {
+    flag: *const Cell<bool>,
     prev: bool,
 }
 
 impl JittedGuard {
     /// Create a new guard, setting `we_are_jitted()` to `true`.
     ///
-    /// Read and set in one thread-local access rather than through the two
-    /// public accessors: this runs on every entry into compiled code, and the
-    /// pair resolved the same key twice.
+    /// One thread-local resolution per entry into compiled code, shared with
+    /// the drop; measured 2.4 ns for the pair on cel's entry probe when each
+    /// side resolved its own.
     pub fn enter() -> Self {
-        let prev = JIT_MODE_FLAG.with(|f| f.replace(true));
-        JittedGuard { prev }
+        let flag = JIT_MODE_FLAG.with(|f| f as *const Cell<bool>);
+        // The cell outlives the guard: see the type's doc.
+        let prev = unsafe { (*flag).replace(true) };
+        JittedGuard { flag, prev }
     }
 }
 
 impl Drop for JittedGuard {
     fn drop(&mut self) {
-        set_jitted(self.prev);
+        unsafe { (*self.flag).set(self.prev) };
     }
 }
 

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -8,7 +8,7 @@ use std::cell::Cell;
 use std::collections::BTreeMap;
 #[cfg(not(target_arch = "wasm32"))]
 use std::io;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use majit_ir::{Const, Descr, FailDescr, GcRef, InputArg, Op, OpRc, Type, Value};
@@ -1688,6 +1688,23 @@ pub struct LoopInvalidation {
     bridge_flags: Arc<parking_lot::Mutex<Vec<Arc<AtomicBool>>>>,
 }
 
+/// How many loop invalidations this process has performed, over every
+/// backend and every driver.
+///
+/// One input of `MetaInterp::runnable_generation`: an invalidated token is
+/// one `get_procedure_token` stops returning, so a reader caching a
+/// runnable-or-not answer across calls has to learn of it. Invalidation
+/// funnels through [`LoopInvalidation::invalidate`], which is where the count
+/// moves, and it moves from whichever thread performs the invalidation, so it
+/// lives here as a process-wide atomic rather than on a driver.
+static TOKEN_INVALIDATIONS: AtomicU64 = AtomicU64::new(0);
+
+/// The current value of the process-wide invalidation count.
+#[inline]
+pub fn token_invalidation_generation() -> u64 {
+    TOKEN_INVALIDATIONS.load(Ordering::Relaxed)
+}
+
 impl LoopInvalidation {
     /// quasiimmut.py `QuasiImmut.invalidate`: `looptoken.invalidated = True`
     /// followed by `cpu.invalidate_loop(looptoken)`.  Both projections happen
@@ -1695,6 +1712,7 @@ impl LoopInvalidation {
     /// token, and every bridge-generation flag activates its still-unpatched
     /// GUARD_NOT_INVALIDATED sites.
     fn invalidate(&self) {
+        TOKEN_INVALIDATIONS.fetch_add(1, Ordering::Relaxed);
         self.invalidated.store(true, Ordering::Release);
         for flag in self.bridge_flags.lock().iter() {
             flag.store(true, Ordering::Release);

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1702,7 +1702,7 @@ static TOKEN_INVALIDATIONS: AtomicU64 = AtomicU64::new(0);
 /// The current value of the process-wide invalidation count.
 #[inline]
 pub fn token_invalidation_generation() -> u64 {
-    TOKEN_INVALIDATIONS.load(Ordering::Relaxed)
+    TOKEN_INVALIDATIONS.load(Ordering::Acquire)
 }
 
 impl LoopInvalidation {
@@ -1712,11 +1712,16 @@ impl LoopInvalidation {
     /// token, and every bridge-generation flag activates its still-unpatched
     /// GUARD_NOT_INVALIDATED sites.
     fn invalidate(&self) {
-        TOKEN_INVALIDATIONS.fetch_add(1, Ordering::Relaxed);
         self.invalidated.store(true, Ordering::Release);
         for flag in self.bridge_flags.lock().iter() {
             flag.store(true, Ordering::Release);
         }
+        // After the flags, not before: a reader that keys a cache on the
+        // generation pairs the value it read with the answer it computed, so
+        // the new value must not be observable while the flags still say the
+        // token is live. Read with acquire, this orders the flag stores ahead
+        // of any computation keyed on the new generation.
+        TOKEN_INVALIDATIONS.fetch_add(1, Ordering::Release);
     }
 }
 

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1959,41 +1959,47 @@ pub type CpuDescrHandle = Arc<CpuDescrCell>;
 /// cost of the call. A write here publishes a fresh copy and keeps every
 /// earlier one alive, so a reader holds a plain reference and the swap
 /// costs the writer, not the entry.
+///
+/// A published copy is never freed, not even with the cell: a finish exit's
+/// deadframe borrows its descr straight out of the copy (`ExitDescr`), and a
+/// deadframe can outlive the backend and the token through the safe
+/// `Backend::execute_token` API. `'static` is what makes that borrow sound
+/// without a count. What leaks is one small struct of six `Option<Arc>`s per
+/// publication, at most seven per cpu (the initial copy and six setters).
 pub struct CpuDescrCell {
     current: std::sync::atomic::AtomicPtr<CpuDescrAttachments>,
-    /// Every copy ever published, the current one last. Held so a reference
-    /// handed out before an update stays valid; there are at most a handful
-    /// of updates per cpu, so nothing is reclaimed early.
-    published: std::sync::Mutex<Vec<Box<CpuDescrAttachments>>>,
+    /// Serializes writers; the copies themselves are leaked, see the type.
+    publish: std::sync::Mutex<()>,
 }
 
 impl CpuDescrCell {
     pub fn new(attachments: CpuDescrAttachments) -> Self {
-        let first = Box::new(attachments);
-        let ptr = &*first as *const CpuDescrAttachments as *mut CpuDescrAttachments;
+        let first: &'static CpuDescrAttachments = Box::leak(Box::new(attachments));
         CpuDescrCell {
-            current: std::sync::atomic::AtomicPtr::new(ptr),
-            published: std::sync::Mutex::new(vec![first]),
+            current: std::sync::atomic::AtomicPtr::new(
+                first as *const CpuDescrAttachments as *mut CpuDescrAttachments,
+            ),
+            publish: std::sync::Mutex::new(()),
         }
     }
 
     /// The attachments as last published. One acquire load.
     #[inline]
-    pub fn read(&self) -> &CpuDescrAttachments {
-        // The pointee is a `Box` in `published`, which only grows and drops
-        // with `self`, so it outlives this borrow.
+    pub fn read(&self) -> &'static CpuDescrAttachments {
+        // Every pointer ever stored came from `Box::leak`.
         unsafe { &*self.current.load(std::sync::atomic::Ordering::Acquire) }
     }
 
-    /// Publish a copy with `f` applied. Writers serialize on `published`.
+    /// Publish a copy with `f` applied. Writers serialize on `publish`.
     pub fn update(&self, f: impl FnOnce(&mut CpuDescrAttachments)) {
-        let mut published = self.published.lock().unwrap();
+        let _writer = self.publish.lock().unwrap();
         let mut next = Box::new(self.read().clone());
         f(&mut next);
-        let ptr = &*next as *const CpuDescrAttachments as *mut CpuDescrAttachments;
-        published.push(next);
-        self.current
-            .store(ptr, std::sync::atomic::Ordering::Release);
+        let next: &'static CpuDescrAttachments = Box::leak(next);
+        self.current.store(
+            next as *const CpuDescrAttachments as *mut CpuDescrAttachments,
+            std::sync::atomic::Ordering::Release,
+        );
     }
 }
 

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1890,7 +1890,7 @@ impl AttachedDescrPtrs {
 /// the six descrs the metainterp attaches to each cpu instance at
 /// `MetaInterpStaticData.finish_setup`.
 ///
-/// Stored inside a heap-pinned `Arc<RwLock<CpuDescrAttachments>>` on every
+/// Stored inside a heap-pinned `Arc<CpuDescrCell>` on every
 /// `Backend` impl ([`CpuDescrHandle`] below):
 ///
 ///   * The `Arc` allocation address stays stable when the `Backend`
@@ -1902,14 +1902,14 @@ impl AttachedDescrPtrs {
 ///     so the attachments outlive the owning backend — the JIT-emitted
 ///     CALL_ASSEMBLER slow path dereferences the baked handle pointer
 ///     long after `compile_loop` returns.
-///   * The `RwLock` permits `Backend::set_done_with_this_frame_descr_*`
-///     to mutate through `&Backend` (via the Arc) without requiring
-///     `&mut self` access to the inner; the extern-C trampoline takes a
-///     read lock to snapshot pointers for dispatch.
+///   * `CpuDescrCell::update` lets `Backend::set_done_with_this_frame_descr_*`
+///     publish through `&Backend` (via the Arc) without `&mut self` access to
+///     the inner; the extern-C trampoline reads the current copy through one
+///     pointer load to snapshot pointers for dispatch.
 ///
 /// Field names mirror the RPython attribute names 1:1 for parity with
 /// `compile.make_and_attach_done_descrs` targets.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct CpuDescrAttachments {
     pub done_with_this_frame_descr_void: Option<majit_ir::DescrRef>,
     pub done_with_this_frame_descr_int: Option<majit_ir::DescrRef>,
@@ -1939,11 +1939,64 @@ impl CpuDescrAttachments {
 }
 
 /// Heap-pinned handle for the six per-cpu descr attachments.  The
-/// `Arc`'s payload (the `RwLock<CpuDescrAttachments>`) lives at a
+/// `Arc`'s payload (the `CpuDescrCell`) lives at a
 /// stable heap address so `compile_loop` can bake that address as an
 /// immediate in the JIT-emitted CALL_ASSEMBLER helper call site and
 /// the extern-C trampoline can dereference it later.
-pub type CpuDescrHandle = Arc<std::sync::RwLock<CpuDescrAttachments>>;
+pub type CpuDescrHandle = Arc<CpuDescrCell>;
+
+/// The six attachments behind one pointer load.
+///
+/// Every compiled entry reads the attachments once, and the six setters run
+/// during `MetaInterpStaticData.finish_setup`, before any compiled code, and
+/// never again. A `RwLock` priced that read at two atomic read-modify-writes
+/// per entry — measured 7.8 ns on cel's entry probe, the largest single fixed
+/// cost of the call. A write here publishes a fresh copy and keeps every
+/// earlier one alive, so a reader holds a plain reference and the swap
+/// costs the writer, not the entry.
+pub struct CpuDescrCell {
+    current: std::sync::atomic::AtomicPtr<CpuDescrAttachments>,
+    /// Every copy ever published, the current one last. Held so a reference
+    /// handed out before an update stays valid; there are at most a handful
+    /// of updates per cpu, so nothing is reclaimed early.
+    published: std::sync::Mutex<Vec<Box<CpuDescrAttachments>>>,
+}
+
+impl CpuDescrCell {
+    pub fn new(attachments: CpuDescrAttachments) -> Self {
+        let first = Box::new(attachments);
+        let ptr = &*first as *const CpuDescrAttachments as *mut CpuDescrAttachments;
+        CpuDescrCell {
+            current: std::sync::atomic::AtomicPtr::new(ptr),
+            published: std::sync::Mutex::new(vec![first]),
+        }
+    }
+
+    /// The attachments as last published. One acquire load.
+    #[inline]
+    pub fn read(&self) -> &CpuDescrAttachments {
+        // The pointee is a `Box` in `published`, which only grows and drops
+        // with `self`, so it outlives this borrow.
+        unsafe { &*self.current.load(std::sync::atomic::Ordering::Acquire) }
+    }
+
+    /// Publish a copy with `f` applied. Writers serialize on `published`.
+    pub fn update(&self, f: impl FnOnce(&mut CpuDescrAttachments)) {
+        let mut published = self.published.lock().unwrap();
+        let mut next = Box::new(self.read().clone());
+        f(&mut next);
+        let ptr = &*next as *const CpuDescrAttachments as *mut CpuDescrAttachments;
+        published.push(next);
+        self.current
+            .store(ptr, std::sync::atomic::Ordering::Release);
+    }
+}
+
+impl Default for CpuDescrCell {
+    fn default() -> Self {
+        Self::new(CpuDescrAttachments::default())
+    }
+}
 
 /// `llsupport/asmmemmgr.py:AsmMemoryManager` accounting owned by one CPU.
 /// `total_memory_allocated` is the mapped capacity and never shrinks

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -1731,10 +1731,55 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             }
         })
         .collect();
-    // Pairs the two halves above straight into the driver's entry buffer.
-    // Emitted under the same condition as `live_value_types_into` — without
-    // that override the type half falls back to an allocating default, which
-    // would leave this one allocating anyway.
+    // Writes the typed values straight into the driver's entry buffer, in
+    // `extract_live` order, each field as the `Value` its type routes it to.
+    // One pass over the state: the word half and the type half are what
+    // `extract_live_into` / `live_value_types_into` produce for readers that
+    // want them apart, and pairing the two here would fill both buffers and
+    // walk them again for every entry, so the pair is emitted directly.
+    // Emitted under the same condition as `live_value_types_into`, so a state
+    // with only int fields keeps the trait default.
+    let extract_live_value_scalar_parts: Vec<TokenStream> = scalars
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            quote! { out.push(majit_ir::Value::Int(self.#fname as i64)); }
+        })
+        .collect();
+    let extract_live_value_array_parts: Vec<TokenStream> = arrays
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            quote! {
+                for elem in &self.#fname {
+                    out.push(majit_ir::Value::Int(*elem as i64));
+                }
+            }
+        })
+        .collect();
+    let extract_live_value_vable_identity_part: TokenStream = if has_vable_identity {
+        quote! {
+            out.push(majit_ir::Value::Ref(majit_ir::GcRef(self as *const Self as usize)));
+        }
+    } else {
+        quote! {}
+    };
+    let extract_live_value_ref_scalar_parts: Vec<TokenStream> = ref_scalars
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            quote! { out.push(majit_ir::Value::Ref(majit_ir::GcRef(self.#fname as usize))); }
+        })
+        .collect();
+    let extract_live_value_float_scalar_parts: Vec<TokenStream> = float_scalars
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            // Widened to f64 exactly as the word form widens before taking
+            // bits, so the two forms carry the same value.
+            quote! { out.push(majit_ir::Value::Float(self.#fname as f64)); }
+        })
+        .collect();
     let extract_live_values_into_override: TokenStream =
         if num_ref_scalars > 0 || num_virt_arrays > 0 || num_float_scalars > 0 {
             quote! {
@@ -1745,17 +1790,12 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                     raw: &mut ::std::vec::Vec<i64>,
                     types: &mut ::std::vec::Vec<majit_ir::Type>,
                 ) {
-                    self.extract_live_into(_meta, raw);
-                    self.live_value_types_into(_meta, types);
-                    out.extend(raw.iter().zip(types.iter()).map(|(&__v, &__t)| match __t {
-                        majit_ir::Type::Float => {
-                            majit_ir::Value::Float(f64::from_bits(__v as u64))
-                        }
-                        majit_ir::Type::Ref => {
-                            majit_ir::Value::Ref(majit_ir::GcRef(__v as usize))
-                        }
-                        _ => majit_ir::Value::Int(__v),
-                    }));
+                    let _ = (raw, types);
+                    #(#extract_live_value_scalar_parts)*
+                    #(#extract_live_value_array_parts)*
+                    #extract_live_value_vable_identity_part
+                    #(#extract_live_value_ref_scalar_parts)*
+                    #(#extract_live_value_float_scalar_parts)*
                 }
             }
         } else {

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -273,7 +273,12 @@ pub struct CompileResult<M> {
     /// currently has split metainterp/backend descr objects, so this is
     /// the runtime descr carrying the same `rd_loop_token_clt` /
     /// `fail_index_per_trace` identity used for bridge routing.
-    pub descr_arc: std::sync::Arc<dyn majit_ir::Descr>,
+    ///
+    /// Carried for a guard exit only. Every reader of it is a bridge or
+    /// blackhole consumer, and a final descr resumes nothing, so the finish
+    /// arm reads the descr off the frame by reference and never takes the
+    /// shared hold on it.
+    pub descr_arc: Option<std::sync::Arc<dyn majit_ir::Descr>>,
     pub is_finish: bool,
     /// compile.py ExitFrameWithExceptionDescrRef parity:
     /// true when the FINISH descriptor was

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -265,7 +265,12 @@ pub struct CompileResult<M> {
     /// `loop_token` object itself alive across `execute_assembler`, and an
     /// `Arc` gives the same "this exact metadata, for the whole run" guarantee
     /// without paying a struct copy per entry.
-    pub meta: std::sync::Arc<M>,
+    ///
+    /// Carried only for the caller that asked for it. The detailed runs read
+    /// it back off the result; the warm entry in `jitdriver` already holds
+    /// the same snapshot across the run and never reads this field, so it
+    /// hands in `None` and pays no refcount pair for the round trip.
+    pub meta: Option<std::sync::Arc<M>>,
     pub fail_index: u32,
     pub trace_id: u64,
     /// `cpu.get_latest_descr(deadframe)` (`history.py:125`) — the

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -6074,7 +6074,10 @@ impl<S: JitState> JitDriver<S> {
                 // for the same slot. Nothing between the two can replace the
                 // entry: `pre_run` cannot capture the driver and the
                 // `on_compiled_entry` hook is called through `&self.meta`.
-                std::sync::Arc::clone(&compiled_meta),
+                // Not carried: this entry reads its snapshot from
+                // `compiled_meta` on every arm below, so a copy on the result
+                // would ride out and drop unread.
+                None,
                 live_values,
                 selected_dispatch_key,
             );
@@ -6100,9 +6103,9 @@ impl<S: JitState> JitDriver<S> {
                 count_back_edge_stage_passes(BackEdgeStage::MarshalOut, stage_repeats.marshal_out);
                 for _ in 0..stage_repeats.marshal_out {
                     if !result.is_finish && !result.typed_values.is_empty() {
-                        state.restore_values(&result.meta, &result.typed_values);
+                        state.restore_values(&compiled_meta, &result.typed_values);
                     }
-                    self.sync_after(state, &result.meta, vable);
+                    self.sync_after(state, &compiled_meta, vable);
                     std::hint::black_box(&mut *state);
                 }
             }
@@ -7642,7 +7645,7 @@ impl<S: JitState> JitDriver<S> {
             };
         }
 
-        let exit_meta = result.meta.clone();
+        let exit_meta = result.meta.take().expect("a detailed run carries its meta");
         state.restore_values(&exit_meta, &result.typed_values);
         self.sync_after(state, &exit_meta, vable);
         DetailedDriverRunOutcome::Jump {
@@ -7780,7 +7783,7 @@ impl<S: JitState> JitDriver<S> {
 
         let is_finish = result.is_finish;
         let is_exit_frame_with_exception = result.is_exit_frame_with_exception;
-        let exit_meta = result.meta.clone();
+        let exit_meta = result.meta.take().expect("a detailed run carries its meta");
         let fail_index = result.fail_index;
         let trace_id = result.trace_id;
         // Carried past the finish arm below, which is the one that has none.

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -7969,6 +7969,14 @@ impl<S: JitState> JitDriver<S> {
                 .confirm_compiled_entry_for_cell_key(green_key)
     }
 
+    /// See [`MetaInterp::runnable_generation`]: a number that holds while
+    /// [`Self::resolved_runnable_procedure_token`] cannot change its answer
+    /// for any key, and moves when it may.
+    #[inline]
+    pub fn runnable_generation(&self) -> u64 {
+        self.meta.runnable_generation()
+    }
+
     /// [`Self::resolve_cell_key`] and [`Self::runnable_procedure_token`] from
     /// one walk of the cell chain.
     ///
@@ -10344,6 +10352,42 @@ mod tests {
             driver.get_stats().bridges_compiled,
             "the callback count and the driver's own tally are the same number"
         );
+    }
+
+    #[test]
+    fn compiling_a_loop_moves_the_runnable_generation() {
+        let mut driver = JitDriver::<NonTraceableState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
+        let green_key = 405u64;
+        let cold = driver.runnable_generation();
+        assert!(matches!(
+            driver.meta.on_back_edge(green_key, &[0]),
+            BackEdgeAction::Interpret
+        ));
+        assert!(matches!(
+            driver.meta.on_back_edge(green_key, &[0]),
+            BackEdgeAction::StartedTracing
+        ));
+        {
+            let ctx = driver.meta.trace_ctx().expect("should be tracing");
+            let i0 = OpRef::input_arg_int(0);
+            let g = ctx.record_guard(OpCode::GuardTrue, &[i0], 0);
+            ctx.capture_snapshot_for_last_guard(&[], 0, 0);
+            ctx.set_fail_args(g, &[]);
+        }
+        let tracing = driver.runnable_generation();
+        driver.meta.compile_loop(&[OpRef::input_arg_int(0)], ());
+        assert!(driver.has_runnable_compiled_loop(green_key));
+        let compiled = driver.runnable_generation();
+        assert_ne!(
+            compiled, tracing,
+            "the compile made the key runnable, so a reader caching the \
+             answer from the trace-time number must be told"
+        );
+        // Once compiled, asking is free of side effects on the number.
+        assert!(driver.has_runnable_compiled_loop(green_key));
+        assert_eq!(driver.runnable_generation(), compiled);
+        assert_ne!(cold, compiled);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -6187,7 +6187,10 @@ impl<S: JitState> JitDriver<S> {
             // and the detailed run below read machine words, and building the
             // list on every entry charged the finish exit for both.
             let raw_values = crate::compile::raw_exit_values(&result.typed_values);
-            let descr_arc = std::sync::Arc::clone(&result.descr_arc);
+            let descr_arc = result
+                .descr_arc
+                .take()
+                .expect("a guard exit carries its descr");
             let guard_value_operand = result.guard_value_operand;
             // blackhole.py `_prepare_resume_from_failure(deadframe)`:
             // the pending exception grabbed at guard failure
@@ -7780,7 +7783,8 @@ impl<S: JitState> JitDriver<S> {
         let exit_meta = result.meta.clone();
         let fail_index = result.fail_index;
         let trace_id = result.trace_id;
-        let descr_arc = std::sync::Arc::clone(&result.descr_arc);
+        // Carried past the finish arm below, which is the one that has none.
+        let descr_arc = result.descr_arc.take();
         // The pointer travels; the layout behind it is opened past the finish
         // arm below, which is the one that carries none.
         let exit_layout = result.exit_layout.take();
@@ -7808,6 +7812,7 @@ impl<S: JitState> JitDriver<S> {
             };
         }
 
+        let descr_arc = descr_arc.expect("a guard exit carries its descr");
         // Normal loop back-edge JUMP, not a guard failure.
         if fail_index == u32::MAX {
             state.restore_values(&exit_meta, &typed_values);
@@ -10370,7 +10375,10 @@ mod tests {
             .run_compiled_detailed(green_key, &[0])
             .expect("guard should fail");
         let fail_values = crate::compile::raw_exit_values(&failure.typed_values);
-        let descr_arc = std::sync::Arc::clone(&failure.descr_arc);
+        let descr_arc = failure
+            .descr_arc
+            .clone()
+            .expect("a guard exit carries its descr");
         drop(failure);
 
         let started = driver.start_bridge_tracing(

--- a/majit/majit-metainterp/src/memmgr.rs
+++ b/majit/majit-metainterp/src/memmgr.rs
@@ -54,6 +54,13 @@ pub struct MemoryManager {
     /// `-1` is "uninitialized"; `set_max_age` derives a real value
     /// (`int(sqrt(max_age))` by default per `memmgr.py:47-48`).
     pub check_frequency: i64,
+    /// How many times this manager has let go of loops: each
+    /// `_kill_old_loops_now` that evicted something, and each
+    /// `release_all_loops`. A strong handle dropped here can be a cell's last,
+    /// after which its weak reference no longer upgrades and the cell stops
+    /// answering runnable — so this is one input of
+    /// `MetaInterp::runnable_generation`.
+    evictions: u64,
 
     /// `memmgr.py` `self.alive_loops = {}` — a dict keyed on the
     /// looptoken object itself.  In Rust the dict key uses the Arc's
@@ -99,6 +106,7 @@ impl MemoryManager {
             check_frequency: -1,
             max_age: 0,
             alive_loops: indexmap::IndexMap::new(),
+            evictions: 0,
             // rlib/jit.py PARAMETERS defaults.
             retrace_limit: 0,
             max_retrace_guards: 15,
@@ -263,6 +271,9 @@ impl MemoryManager {
             }
             !evict
         });
+        if !evicted_tokens.is_empty() {
+            self.evictions = self.evictions.wrapping_add(1);
+        }
         if log {
             let newtotal = self.alive_loops.len();
             crate::debug::debug_print(&format!("Loop tokens freed: {}", oldtotal - newtotal));
@@ -283,6 +294,12 @@ impl MemoryManager {
         let _scope = crate::debug::scope("jit-mem-releaseall");
         crate::debug::debug_print(&format!("Loop tokens cleared: {}", self.alive_loops.len()));
         self.alive_loops.clear();
+        self.evictions = self.evictions.wrapping_add(1);
+    }
+
+    /// The counter [`Self::evictions`] documents.
+    pub fn eviction_generation(&self) -> u64 {
+        self.evictions
     }
 
     /// Number of loops currently tracked.  Test/debug accessor; no

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11317,7 +11317,7 @@ impl<M: Clone> MetaInterp<M> {
 
         Some(CompileResult {
             typed_values,
-            meta,
+            meta: Some(meta),
             fail_index,
             trace_id,
             descr_arc: (!is_finish).then_some(descr_arc),
@@ -11363,7 +11363,7 @@ impl<M: Clone> MetaInterp<M> {
         Some(self.execute_assembler_at_dispatch_key(
             &token,
             green_key,
-            meta,
+            Some(meta),
             live_values,
             dispatch_key,
         ))
@@ -11434,7 +11434,7 @@ impl<M: Clone> MetaInterp<M> {
         &mut self,
         procedure_token: &std::sync::Arc<JitCellToken>,
         green_key: u64,
-        meta: std::sync::Arc<M>,
+        meta: Option<std::sync::Arc<M>>,
         live_values: &[Value],
         dispatch_key: u32,
     ) -> CompileResult<M> {
@@ -15018,7 +15018,10 @@ impl<M: Clone> MetaInterp<M> {
         let typed_values = result.typed_values.clone();
         let savedata = result.savedata;
         let exception = result.exception.clone();
-        let meta = result.meta.clone();
+        let meta = result
+            .meta
+            .clone()
+            .expect("a detailed run carries its meta");
 
         if is_finish {
             // Normal finish (not a guard failure)

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -340,29 +340,36 @@ pub fn reset_call_shot_totals() {
 /// So each batch is AMORTIZED first: `PER_BATCH` pairs are accumulated before
 /// anything is divided, which is what makes a batch mean immune to the
 /// granularity — quantization is unbiased when the start phase is uniform, so
-/// it averages out of a sum while it dominates any single term. The minimum is
-/// then taken over the batch MEANS, which keeps the original intent (the least
-/// scheduler-contaminated reading wins) while making each candidate a real
-/// cost.
+/// it averages out of a sum while it dominates any single term.
+///
+/// The MEDIAN batch is then taken, not the smallest. On a big.LITTLE part the
+/// pair's cost is bimodal — measured at 13.5 ns and 20.4 ns on the two core
+/// classes of one machine, with both modes appearing among the batches of a
+/// single call — and the reading being corrected was taken on whichever core
+/// the run landed on. A minimum answers "the cheapest this pair can be", which
+/// is the wrong question: it pins the correction to the fast class and so
+/// under-corrects every reading taken on the other one.
 ///
 /// What is subtracted is what the pair adds to a READING, not what it costs to
 /// execute — those differ, because the pair's own latency partly overlaps
 /// whatever sits between its two reads. An empty bracket has nothing to overlap
-/// with, so this is the largest the correction can legitimately be.
+/// with, so this remains an upper bound on the correction, and the figure it
+/// corrects a lower bound on the stage.
 #[cfg(feature = "__execute-stage-probe")]
 pub fn execute_stage_clock_floor_ns() -> f64 {
-    const BATCHES: u32 = 32;
+    const BATCHES: usize = 32;
     const PER_BATCH: u32 = 4096;
-    let mut best = f64::INFINITY;
-    for _ in 0..BATCHES {
+    let mut means = [0.0f64; BATCHES];
+    for slot in &mut means {
         let mut acc = 0u128;
         for _ in 0..PER_BATCH {
             let start = std::time::Instant::now();
             acc += start.elapsed().as_nanos();
         }
-        best = best.min(acc as f64 / f64::from(PER_BATCH));
+        *slot = acc as f64 / f64::from(PER_BATCH);
     }
-    best
+    means.sort_by(f64::total_cmp);
+    means[BATCHES / 2]
 }
 
 /// compile.py `forget_optimization_info` — discard optimizer-only

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -323,19 +323,46 @@ pub fn reset_call_shot_totals() {
 /// nanoseconds — the floor under every single-shot figure.
 ///
 /// Measured HERE rather than in the harness so it is the same clock, the same
-/// crate and the same optimization settings as the reading it corrects. Taking
-/// the minimum rather than the mean: the pair cannot run faster than it is, so
-/// the smallest of many readings is the least contaminated one, and subtracting
-/// a mean inflated by scheduler noise would under-report the call.
+/// crate and the same optimization settings as the reading it corrects.
+///
+/// ⚠ THE MINIMUM OF SINGLE READINGS CANNOT BE USED, and the reason is a
+/// property of the clock rather than of the pair. `Instant` is backed by a
+/// counter whose tick is coarse compared with the pair — 41.67 ns on Apple
+/// silicon's 24 MHz counter, against a pair that reads about 15 ns — so a pair
+/// whose two reads land inside one tick reports exactly `0`. Over thousands of
+/// tries such a pair occurs on essentially every batch, so `min` converges to
+/// zero and the "floor" stops being a cost at all: it becomes a measurement of
+/// the granularity. Subtracting it then corrects nothing, and the whole clock
+/// pair stays inside the single-shot figure it was supposed to be removed
+/// from — which shows up downstream as a residual stage going NEGATIVE, the
+/// parts of the call summing to more than the call.
+///
+/// So each batch is AMORTIZED first: `PER_BATCH` pairs are accumulated before
+/// anything is divided, which is what makes a batch mean immune to the
+/// granularity — quantization is unbiased when the start phase is uniform, so
+/// it averages out of a sum while it dominates any single term. The minimum is
+/// then taken over the batch MEANS, which keeps the original intent (the least
+/// scheduler-contaminated reading wins) while making each candidate a real
+/// cost.
+///
+/// What is subtracted is what the pair adds to a READING, not what it costs to
+/// execute — those differ, because the pair's own latency partly overlaps
+/// whatever sits between its two reads. An empty bracket has nothing to overlap
+/// with, so this is the largest the correction can legitimately be.
 #[cfg(feature = "__execute-stage-probe")]
 pub fn execute_stage_clock_floor_ns() -> f64 {
-    let mut best = u128::MAX;
-    for _ in 0..4096 {
-        let start = std::time::Instant::now();
-        let seen = start.elapsed().as_nanos();
-        best = best.min(seen);
+    const BATCHES: u32 = 32;
+    const PER_BATCH: u32 = 4096;
+    let mut best = f64::INFINITY;
+    for _ in 0..BATCHES {
+        let mut acc = 0u128;
+        for _ in 0..PER_BATCH {
+            let start = std::time::Instant::now();
+            acc += start.elapsed().as_nanos();
+        }
+        best = best.min(acc as f64 / f64::from(PER_BATCH));
     }
-    best as f64
+    best
 }
 
 /// compile.py `forget_optimization_info` — discard optimizer-only
@@ -23188,6 +23215,33 @@ mod metainterp_static_data_tests {
         };
         let sd = std::sync::Arc::get_mut(&mut meta.staticdata).unwrap();
         assert_eq!(sd.jitdrivers_sd[idx].index, Some(idx));
+    }
+
+    /// The clock floor must be a cost, not the clock's granularity.
+    ///
+    /// A pair of `Instant` reads cannot be free, so a floor of zero does not
+    /// mean "the clock is fast" — it means every candidate reading collapsed
+    /// into one tick of a coarse counter and the minimum found one of them.
+    /// That is how this function read for as long as it took its minimum over
+    /// single readings, and the correction it feeds silently subtracted
+    /// nothing. Pin the property rather than a number: the tick differs per
+    /// platform, but "an empty bracket costs something" does not.
+    #[cfg(feature = "__execute-stage-probe")]
+    #[test]
+    fn the_clock_floor_measures_the_pair_and_not_the_counters_tick() {
+        let floor = super::execute_stage_clock_floor_ns();
+        assert!(
+            floor > 0.0,
+            "clock floor read {floor} ns; a zero floor means the minimum found \
+             a bracket whose two reads shared one counter tick, so the figure \
+             is the tick and not the pair"
+        );
+        // A pair that reads as microseconds is a broken clock, not a slow one,
+        // and would over-subtract every single-shot figure into nonsense.
+        assert!(
+            floor < 1_000.0,
+            "clock floor read {floor} ns, implausibly slow"
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1610,6 +1610,9 @@ pub struct MetaInterp<M: Clone> {
     pub(crate) warm_state: WarmEnterState,
     pub(crate) backend: BackendImpl,
     pub(crate) compiled_loops: indexmap::IndexMap<u64, CompiledEntry<M>>,
+    /// Bumped by every insertion into and removal from `compiled_loops`, in
+    /// this file's non-test code. One input of [`Self::runnable_generation`].
+    compiled_loops_generation: u64,
     /// warmstate.py `JitCell.get_jit_cell_at_key` analog for the
     /// merge-point green vocabulary: the header greens (`(ints, refs,
     /// floats)`) each compiled loop was traced under, keyed by its green key.
@@ -3429,6 +3432,7 @@ impl<M: Clone> MetaInterp<M> {
             warm_state: WarmEnterState::new(threshold),
             backend: BackendImpl::new(),
             compiled_loops: indexmap::IndexMap::new(),
+            compiled_loops_generation: 0,
             loop_header_greens: indexmap::IndexMap::new(),
             cut_compiled_keys: indexmap::IndexSet::new(),
             speculative_cut_owned_key: None,
@@ -7911,6 +7915,7 @@ impl<M: Clone> MetaInterp<M> {
                     );
                 }
                 token.set_retraced_count(unroll_opt.retraced_count);
+                self.note_compiled_loops_changed();
                 self.compiled_loops.insert(
                     green_key,
                     CompiledEntry {
@@ -8149,6 +8154,7 @@ impl<M: Clone> MetaInterp<M> {
         &mut self,
         green_key: u64,
     ) -> Option<(CompiledEntry<M>, CarriedFields)> {
+        self.note_compiled_loops_changed();
         let old_entry = self.compiled_loops.swap_remove(&green_key)?;
         let carried = old_entry.carried_fields();
         Some((old_entry, carried))
@@ -9291,6 +9297,7 @@ impl<M: Clone> MetaInterp<M> {
                 };
                 let front_entry_index = Self::front_entry_index_for(&front_target_tokens);
                 token.set_retraced_count(unroll_opt.retraced_count);
+                self.note_compiled_loops_changed();
                 self.compiled_loops.insert(
                     green_key,
                     CompiledEntry {
@@ -10232,6 +10239,7 @@ impl<M: Clone> MetaInterp<M> {
                         token.record_target_token(target_token.as_jump_target_descr());
                     }
                     let front_entry_index = Self::front_entry_index_for(&ft);
+                    self.note_compiled_loops_changed();
                     self.compiled_loops.insert(
                         green_key,
                         CompiledEntry {
@@ -10618,6 +10626,7 @@ impl<M: Clone> MetaInterp<M> {
                 }
                 let front_target_tokens = vec![target_token];
                 let front_entry_index = Self::front_entry_index_for(&front_target_tokens);
+                self.note_compiled_loops_changed();
                 self.compiled_loops.insert(
                     green_key,
                     CompiledEntry {
@@ -10721,6 +10730,41 @@ impl<M: Clone> MetaInterp<M> {
                 green_key,
             ),
         }
+    }
+
+    fn note_compiled_loops_changed(&mut self) {
+        self.compiled_loops_generation = self.compiled_loops_generation.wrapping_add(1);
+    }
+
+    /// A number that moves whenever [`Self::resolved_entry_procedure_token`]
+    /// may answer differently for some key than it did, and stays put while
+    /// it cannot.
+    ///
+    /// The answer is a conjunction of four things a caller can watch: the cell
+    /// chain and the tokens attached to it (`WarmEnterState::cell_generation`),
+    /// the `compiled_loops` map (`compiled_loops_generation`), the strong
+    /// handles the memory manager holds — the last of which going is what
+    /// stops a cell's weak reference from upgrading — and the invalidation
+    /// flag on any token, which is set from whichever thread performs it. The
+    /// four counters are summed, so a change in any one moves the whole.
+    ///
+    /// Only "may": running a loop, tracing one that does not finish, and
+    /// ticking a counter all leave it alone, and an eviction that touched no
+    /// cell of interest still moves it. A caller keying a cache on it
+    /// re-derives on a move and reads the cache on a hold, and both are the
+    /// answer the four reads would give.
+    ///
+    /// No upstream counterpart: `warmstate.py` walks the cell on every ask.
+    /// A driver whose portal asks about several sibling loops on every call
+    /// pays one walk per sibling per call for an answer that changes only at
+    /// the events above, which is what this exists to let it skip.
+    #[inline]
+    pub fn runnable_generation(&self) -> u64 {
+        self.warm_state
+            .cell_generation()
+            .wrapping_add(self.compiled_loops_generation)
+            .wrapping_add(self.warm_state.memory_manager.eviction_generation())
+            .wrapping_add(majit_backend::token_invalidation_generation())
     }
 
     /// The function-entry door's whole answer, from one walk of the cell chain
@@ -11778,6 +11822,7 @@ impl<M: Clone> MetaInterp<M> {
     }
 
     pub fn remove_compiled_loop(&mut self, green_key: u64) {
+        self.note_compiled_loops_changed();
         self.compiled_loops.swap_remove(&green_key);
         self.pending_preamble_tokens.swap_remove(&green_key);
         self.forget_loop_side_tables(green_key);
@@ -11793,6 +11838,7 @@ impl<M: Clone> MetaInterp<M> {
             .map(|(green_key, _)| *green_key)
             .collect();
         for green_key in stale {
+            self.note_compiled_loops_changed();
             self.compiled_loops.swap_remove(&green_key);
             self.forget_loop_side_tables(green_key);
         }
@@ -11902,6 +11948,7 @@ impl<M: Clone> MetaInterp<M> {
                 // including every previous-token predecessor on the
                 // entry (the merged `traces` map and the
                 // previous_tokens Vec drop together).
+                self.note_compiled_loops_changed();
                 self.compiled_loops.swap_remove(&gk);
                 self.forget_loop_side_tables(gk);
                 if crate::debug::have_debug_prints() {
@@ -12555,6 +12602,7 @@ impl<M: Clone> MetaInterp<M> {
     /// is left alone: it is keyed by green key but holds tokens for a
     /// recompile that has not happened yet, not for the loops being dropped.
     pub fn clear_compiled_loops(&mut self) {
+        self.note_compiled_loops_changed();
         self.compiled_loops.clear();
         self.loop_header_greens.clear();
         self.cut_compiled_keys.clear();
@@ -13520,6 +13568,7 @@ impl<M: Clone> MetaInterp<M> {
                 // `compile_loop`. The count read at the top of this function is
                 // the one `unroll.py optimize_bridge` charges, and it stays on the
                 // token it was read from.
+                self.note_compiled_loops_changed();
                 self.compiled_loops.insert(
                     original_green_key,
                     CompiledEntry {
@@ -26784,6 +26833,46 @@ mod loop_side_table_tests {
 
         assert!(!has_side_tables(&meta, 7));
         assert!(has_side_tables(&meta, 8));
+    }
+
+    #[test]
+    fn the_runnable_generation_moves_at_every_event_that_can_change_an_answer() {
+        let mut meta = MetaInterp::<()>::new(1);
+        let start = meta.runnable_generation();
+
+        // Reads leave it alone.
+        assert!(meta.get_compiled_meta(7).is_none());
+        assert_eq!(meta.runnable_generation(), start);
+
+        // A loop leaving the map, both ways. (The fixture insert above writes
+        // the map directly; a loop ENTERING it through `compile_loop` is
+        // `jitdriver::tests::compiling_a_loop_moves_the_runnable_generation`.)
+        record_loop(&mut meta, 7, 100);
+        let after_insert = meta.runnable_generation();
+        meta.remove_compiled_loop(7);
+        let after_remove = meta.runnable_generation();
+        assert_ne!(after_remove, after_insert);
+        record_loop(&mut meta, 8, 101);
+        let before_clear = meta.runnable_generation();
+        meta.clear_compiled_loops();
+        assert_ne!(meta.runnable_generation(), before_clear);
+
+        // A token invalidated anywhere, including one this driver never held.
+        let before_invalidate = meta.runnable_generation();
+        JitCellToken::new(4242).invalidate();
+        assert_ne!(meta.runnable_generation(), before_invalidate);
+
+        // A cell attached through the warm state.
+        let before_attach = meta.runnable_generation();
+        let number = meta.warm_state.alloc_token_number();
+        meta.warm_state
+            .attach_procedure_to_interp(9, JitCellToken::new(number));
+        assert_ne!(meta.runnable_generation(), before_attach);
+
+        // The memory manager letting every loop go.
+        let before_release = meta.runnable_generation();
+        meta.warm_state.memory_manager.release_all_loops();
+        assert_ne!(meta.runnable_generation(), before_release);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11276,7 +11276,7 @@ impl<M: Clone> MetaInterp<M> {
             meta,
             fail_index,
             trace_id,
-            descr_arc,
+            descr_arc: (!is_finish).then_some(descr_arc),
             is_finish,
             is_exit_frame_with_exception,
             exit_layout: exit_layout.map(Box::new),
@@ -11438,10 +11438,11 @@ impl<M: Clone> MetaInterp<M> {
         // RPython: bridge compilation happens synchronously inside
         // assembler_call_helper (called from compiled code). No deferred queue.
 
-        let descr_arc = self.backend.get_latest_descr_arc(&frame);
-        let descr: &dyn majit_ir::FailDescr = descr_arc
-            .as_fail_descr()
-            .expect("get_latest_descr_arc returned a non-FailDescr Descr");
+        // Borrowed off the frame, not shared: a final descr is read here and
+        // returned, so the entry that runs one compiled body to completion
+        // pays no reference count for it. The guard arm below takes the
+        // shared hold, since that is the arm whose result outlives the frame.
+        let descr: &dyn majit_ir::FailDescr = self.backend.get_latest_descr(&frame);
         let fail_index = descr.fail_index();
         let trace_id = descr.trace_id();
         let is_finish = descr.is_finish();
@@ -11466,10 +11467,7 @@ impl<M: Clone> MetaInterp<M> {
         {
             count_execute_stage_passes(ExecuteStage::Decode, stage_repeats.decode);
             for _ in 0..stage_repeats.decode {
-                let repeat_descr = self.backend.get_latest_descr_arc(&frame);
-                let repeat_fail = repeat_descr
-                    .as_fail_descr()
-                    .expect("get_latest_descr_arc returned a non-FailDescr Descr");
+                let repeat_fail = self.backend.get_latest_descr(&frame);
                 let repeat_types: &[Type] = repeat_fail.fail_arg_types();
                 let decoded = Self::decode_exit_slots(&self.backend, &frame, repeat_types);
                 std::hint::black_box((
@@ -11510,7 +11508,7 @@ impl<M: Clone> MetaInterp<M> {
                 meta,
                 fail_index,
                 trace_id,
-                descr_arc,
+                descr_arc: None,
                 is_finish,
                 is_exit_frame_with_exception,
                 exit_layout: None,
@@ -11525,6 +11523,15 @@ impl<M: Clone> MetaInterp<M> {
             };
         }
 
+        // The shared hold, taken only here: the result of a guard exit carries
+        // the descr past this frame's life to the bridge and blackhole readers.
+        // The borrow above ends with the rebinding, which is what lets the
+        // counter tick below take `self` mutably.
+        let descr_arc = self.backend.get_latest_descr_arc(&frame);
+        let descr: &dyn majit_ir::FailDescr = descr_arc
+            .as_fail_descr()
+            .expect("get_latest_descr_arc returned a non-FailDescr Descr");
+        let exit_types: &[Type] = descr.fail_arg_types();
         let status = descr.get_status();
         let guard_value_operand = self.resolve_guard_value_operand(descr, &frame);
         // compile.py `descr.rd_loop_token` — see `run_compiled_detailed`.
@@ -11535,9 +11542,7 @@ impl<M: Clone> MetaInterp<M> {
         // in handle_fail → must_compile (compile.py).
         // must_compile handles tick.
         if Self::should_record_guard_failure(is_finish, fail_index) {
-            let back_edge_poll = descr_arc
-                .as_fail_descr()
-                .is_some_and(|fd| fd.is_back_edge_poll());
+            let back_edge_poll = descr.is_back_edge_poll();
             self.record_guard_failure_event(green_key, trace_id, fail_index, back_edge_poll);
         }
 
@@ -11601,7 +11606,7 @@ impl<M: Clone> MetaInterp<M> {
             meta,
             fail_index,
             trace_id,
-            descr_arc,
+            descr_arc: Some(descr_arc),
             is_finish,
             is_exit_frame_with_exception,
             exit_layout: Some(Box::new(exit_layout)),

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -141,6 +141,20 @@ pub struct BaseJitCell {
     /// [`WarmEnterState::install_new_cell`] that files the cell — an
     /// unassigned cell is in no chain and is reachable by nothing.
     pub cell_key: Option<u64>,
+    /// The bucket [`Self::cell_key`] maps to, memoized at filing time.
+    ///
+    /// [`WarmEnterState::bucket_of`] answers the same question, but a minted
+    /// key sends it through the `minted` map, so the walk that tells this
+    /// cell's chain neighbours apart paid one hash probe PER CELL, on every
+    /// walk. The number is fixed for the cell's whole life:
+    /// [`WarmEnterState::install_new_cell`] files the cell into `hash`'s slot
+    /// and, in the same step, gives it either `hash` itself or a minted key
+    /// registered as belonging to `hash`. Nothing moves a filed cell between
+    /// buckets afterwards — the prune walk relinks survivors inside their own
+    /// slot — so the memo cannot go stale.
+    ///
+    /// Meaningless while `cell_key` is `None`, and read only beside it.
+    pub cell_bucket: u64,
     /// warmstate.py:568-582 — typed green-key carried per-cell so
     /// `JitCell.comparekey(*greenargs2)` can do per-green typed
     /// equality across hash collisions:
@@ -194,6 +208,7 @@ impl BaseJitCell {
             abort_count: 0,
             next: None,
             cell_key: None,
+            cell_bucket: 0,
             comparekey: None,
             retained_greens: RetainedGreens::default(),
         }
@@ -3206,7 +3221,7 @@ impl WarmEnterState {
         let mut cell = self.lookup_chain(hash);
         while let Some(c) = cell {
             if let Some(cell_key) = c.cell_key
-                && self.bucket_of(cell_key) == hash
+                && c.cell_bucket == hash
             {
                 count += 1;
                 if found.is_none() {
@@ -3288,7 +3303,7 @@ impl WarmEnterState {
         let mut cell = self.lookup_chain(hash);
         while let Some(c) = cell {
             if let Some(cell_key) = c.cell_key
-                && self.bucket_of(cell_key) == hash
+                && c.cell_bucket == hash
             {
                 count += 1;
                 if first.is_none() {
@@ -3388,14 +3403,19 @@ impl WarmEnterState {
     pub fn install_new_cell(&mut self, hash: u64, newcell: Option<BaseJitCell>) {
         self.bump_cell_generation();
         let mut keep = newcell.map(Box::new);
-        if let Some(cell) = &mut keep
-            && cell.cell_key.is_none()
-        {
-            cell.cell_key = Some(if self.cell_by_key(hash).is_none() {
-                hash
-            } else {
-                self.mint_cell_key(hash)
-            });
+        if let Some(cell) = &mut keep {
+            if cell.cell_key.is_none() {
+                cell.cell_key = Some(if self.cell_by_key(hash).is_none() {
+                    hash
+                } else {
+                    self.mint_cell_key(hash)
+                });
+            }
+            // The slot being filed IS the bucket, whichever of the two keys
+            // above the cell ended up with. Only the newly filed cell gets it:
+            // the chain members relinked below keep their own, which is what
+            // the truncated index put them here in spite of.
+            cell.cell_bucket = hash;
         }
         // counter.py: index = self._get_index(hash);
         //                    cell = self.celltable[index]

--- a/majit/majit-metainterp/tests/jit_interp_entry_values_are_the_word_form_paired.rs
+++ b/majit/majit-metainterp/tests/jit_interp_entry_values_are_the_word_form_paired.rs
@@ -1,0 +1,104 @@
+//! The entry buffer `extract_live_values_into` fills is the pairing of the two
+//! word-form readers, `extract_live` and `live_value_types`, field for field.
+//!
+//! The override writes each field as a `Value` directly rather than filling
+//! the two word buffers and zipping them, so the two forms are produced by
+//! different generated code and can drift apart: a field emitted in one order
+//! by one and another by the other, or a float carried as bits by one and as
+//! a value by the other. This pins them equal over every field kind the macro
+//! routes — int scalar, virt array (its identity slot), ref scalar, float
+//! scalar.
+
+use majit_metainterp::{JitDriver, JitState};
+
+pub type Bytecode = [u8];
+
+struct Cell {
+    next: *mut Cell,
+    value: i64,
+}
+
+struct EveryKindState {
+    total: i64,
+    regs: Vec<i64>,
+    head: usize,
+    weight: f64,
+}
+
+const OP_STEP: u8 = 1;
+
+#[majit_macros::jit_interp(
+    state = EveryKindState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = {
+        total: int,
+        regs: [int; virt],
+        head: ref(Cell),
+        weight: float,
+    },
+    ref_fields = { Cell::next => Cell },
+    int_fields = { Cell::value => i64 },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_every_kind(program: &Bytecode, threshold: u32) -> i64 {
+    let mut driver: JitDriver<EveryKindState> = JitDriver::new(threshold);
+    let mut pc: usize = 0;
+    let mut state = EveryKindState {
+        total: 0,
+        regs: vec![0i64; 2],
+        head: 0,
+        weight: 0.0,
+    };
+    loop {
+        jit_merge_point!();
+        let opcode = program[pc];
+        match opcode {
+            OP_STEP => {
+                state.total += 1;
+                pc += 1;
+            }
+            _ => return state.total,
+        }
+    }
+}
+
+#[test]
+fn the_entry_values_are_the_word_form_paired() {
+    let program: Vec<u8> = vec![OP_STEP, 0];
+    let mut cell = Cell {
+        next: std::ptr::null_mut(),
+        value: 7,
+    };
+    let state = EveryKindState {
+        total: -3,
+        regs: vec![11, i64::MIN],
+        head: &mut cell as *mut Cell as usize,
+        weight: -0.75,
+    };
+    let meta = state.build_meta(0, &program);
+
+    let paired = state.extract_live_values(&meta);
+
+    let mut out = Vec::new();
+    let mut raw = Vec::new();
+    let mut types = Vec::new();
+    state.extract_live_values_into(&meta, &mut out, &mut raw, &mut types);
+
+    assert_eq!(
+        out, paired,
+        "the direct form and the paired word form must carry the same values in \
+         the same order"
+    );
+    // And the shape is the one the macro documents: int scalars, the one
+    // virtualizable identity, ref scalars, float scalars.
+    assert_eq!(out.len(), 4);
+    assert_eq!(out[0], majit_ir::Value::Int(-3));
+    assert_eq!(
+        out[1],
+        majit_ir::Value::Ref(majit_ir::GcRef(&state as *const EveryKindState as usize))
+    );
+    assert_eq!(out[2], majit_ir::Value::Ref(majit_ir::GcRef(state.head)));
+    assert_eq!(out[3], majit_ir::Value::Float(-0.75));
+    let _ = cell.value;
+}


### PR DESCRIPTION
The fixed cost of one compiled entry on cel's entry probe, itemised and then cut. Every figure below is from `cel/examples/entryprobe` (`--features jit-cranelift,__entry-stage-probe`), amplified stages unless marked single-shot, on a shared box at load 17–140.

## Before this branch: the entry, itemised

`D keys` (yield scan) 2.6–17.9 ns by shape, `E1 gate` 4.8, `E2 marshal in` 6.8, `E3a prologue` 3.2, `E3c the call` ~27 (single-shot) of which frame build 9.6, `E3d deadframe decode` 8.2.

The last commit adds a probe knob (`MAJIT_PROBE_EXTRA=…`, under `__execute-stage-probe`) that repeats one fixed step beside the frame build so its per-entry cost reads as a delta:

| step | ns / entry (before) | after |
|---|---|---|
| `cpu_attachments.read()` (RwLock) | **7.8** | ~0.3 |
| `jf_descr` → `(fail_index, descr)` | 3.6 | 2.0 |
| exit descr `Arc` clone + drop | 3.2 | (borrowed) |
| `JittedGuard` enter + drop (2 TLS) | 2.4 | 1.3 |
| jitframe heap selector TLS | 1.1 | 1.1 (untouched) |
| three `LazyLock` flag reads | 0.8 | 0.3 |

## Commits

- **D** — `runnable_generation()` (cell / compiled_loops / eviction / token-invalidation generations summed) keys the entry door's sibling-loop scan; multi-key shapes −15–20 ns (list.all ~91→72, list.map ~92→72).
- **E3d** — the finish arm borrows the exit descr; E3d 9.0→8.2.
- **E2** — `extract_live_values_into` emits `Value`s directly; 8.7–9.9→6.1–6.8 on every shape.
- **attach** — `CpuDescrHandle = Arc<CpuDescrCell>`: an `AtomicPtr` to the current copy plus every copy ever published; `read()` is one acquire load. The six setters only run at `finish_setup`. E3c 34.5/35.5/49.6→26.1/27.1/33.6 (single-shot, 3 pairs), entry −4 ns.
- **guard + flags** — `JittedGuard` keeps the `const` TLS cell's address for its drop; `entry_flags()` reads the three flags through one `LazyLock`.
- **ExitDescr** — a finish exit's deadframe borrows the cpu-attached descr (kept for the cpu's life by `CpuDescrCell`, and held by the decoding metainterp); guard exits stay owned. E3 rest 10–13→7–9.
- **pool** — `FRAME_POOL` parks raw parts in a `Copy` array so the thread-local is `const` with no destructor; frame build 9.9→8.5 (3/3 pairs).
- three clock-floor / bucket-memo commits from the previous cycle.

## Verification

`pyre/check.py`: dynasm 514/514, cranelift 514/514, wasm 507/507. `cargo test` for majit-backend{,-cranelift,-dynasm}, majit-macros (dynasm), majit-metainterp (dynasm + cranelift), cel-jit release tests (the `majit_shape_change` timing test is load-sensitive: it read 1.07x against a ceiling of 1 with the box at load ~100 and passes when re-run).

Not done: the jitframe heap selector TLS (1.1 ns) — caching its answer on the no-collector arm would miss a collector installed later from another thread, which its doc rules out.

— *commented by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance and Reliability**
  * Improved runtime descriptor handling and execution dispatch efficiency.
  * Reduced overhead when tracking compiled loops, invalidations, and evictions.
  * Improved live-value extraction and cell lookup performance.
  * Improved reliability during guard failures and frame exits.
* **Bug Fixes**
  * Corrected descriptor selection for optimized and synthetic exits.
* **Testing**
  * Added coverage for live-value ordering, generation tracking, and execution timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->