### PR TITLE
wasm: the time module, chdir, an environment, and the two names `unittest` reads — `test_unittest` runs on the guest

### DIFF
--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -19844,9 +19844,11 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 let _ = binary;
                 // The bytes the caller spelled, not a re-decoded copy of them:
                 // a name `listdir` reported is a name `open` can be called
-                // with again, whatever bytes it spells.
-                let seam_path = crate::gateway::os_string_from_fs_bytes(path_bytes);
-                match crate::importing::read_source_bytes(std::path::Path::new(&seam_path)) {
+                // with again, whatever bytes it spells.  Resolved the way
+                // `posix` resolves one, so `open` and `os.open` answer for the
+                // same file after a `chdir`.
+                let seam_path = wasm_fd::seam_path(path_bytes);
+                match crate::importing::read_source_bytes(&seam_path) {
                     Ok(bytes) => bytes,
                     Err(e) => {
                         return Err(crate::PyError::os_error_syscall(

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
@@ -192,6 +192,14 @@ fn make_stat_result(mode: i64, size: i64) -> PyObjectRef {
     crate::_structseq::new_instance_with_extra(super::stat_result_seq_type(), seq, extras)
 }
 
+/// `os.terminal_size` structseq — `(columns, lines)`.
+fn terminal_size_seq_type() -> PyObjectRef {
+    static TERMINAL_SIZE_SEQ_TYPE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *TERMINAL_SIZE_SEQ_TYPE.get_or_init(|| {
+        crate::_structseq::make_struct_seq("os.terminal_size", &["columns", "lines"]) as usize
+    }) as PyObjectRef
+}
+
 /// `posix.listdir(path=None)` — the entry names the seam reports, in its
 /// order.
 ///
@@ -925,6 +933,11 @@ pub fn register_module(ns: PyObjectRef) {
     // no call here takes a directory or a descriptor argument.
     crate::module_ns_store(ns, "_have_functions", pyre_object::w_list_new(vec![]));
     crate::module_ns_store(ns, "stat_result", super::stat_result_seq_type());
+    // `posixmodule_exec` publishes this type on every platform, and only the
+    // `get_terminal_size` that fills one is guarded: `shutil.get_terminal_size`
+    // catches the AttributeError from the missing call and builds its fallback
+    // out of the type, so a target with neither raises from the handler.
+    crate::module_ns_store(ns, "terminal_size", terminal_size_seq_type());
     // `follow_symlinks` and `dir_fd` are keyword-only, so neither entry point
     // can take the fixed-arity carrier that rejects keywords.
     crate::module_ns_store(
@@ -966,6 +979,24 @@ pub fn register_module(ns: PyObjectRef) {
         ns,
         "unsetenv",
         crate::make_builtin_function_with_arity("unsetenv", unsetenv, 1),
+    );
+    // One wasm instance, one process, and it is not one the embedder named.
+    crate::module_ns_store(
+        ns,
+        "getpid",
+        crate::make_builtin_function_with_arity("getpid", |_args| Ok(pyre_object::w_int_new(1)), 0),
+    );
+    // No terminal is reachable through the seam, so no descriptor is one.  The
+    // answer is False rather than an error for the same reason it is on every
+    // other platform: `isatty` reports, it does not validate.
+    crate::module_ns_store(
+        ns,
+        "isatty",
+        crate::make_builtin_function_with_arity(
+            "isatty",
+            |_args| Ok(pyre_object::w_bool_from(false)),
+            1,
+        ),
     );
     // `os.walk` catches `OSError` from the iterator and `shutil` calls
     // `isinstance(entry, os.DirEntry)`, so both the type and the entries it

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
@@ -85,12 +85,73 @@ fn stat(args: &[PyObjectRef], default_follow: bool) -> Result<PyObjectRef, crate
     stat_resolved(&resolved)
 }
 
+/// The guest's working directory, once something has changed it.
+///
+/// The seam resolves a relative name against the embedder's directory, which is
+/// what `getcwd` reports until `chdir` runs.  After that the guest owns the
+/// answer, and a relative path is joined here before it crosses -- the same
+/// place `getcwd` reads, so the two never disagree.
+static WORKING_DIRECTORY: std::sync::Mutex<Option<Vec<u8>>> = std::sync::Mutex::new(None);
+
+/// The directory a relative path is resolved against, as bytes.
+fn cwd_bytes() -> Vec<u8> {
+    if let Some(directory) = WORKING_DIRECTORY.lock().unwrap().clone() {
+        return directory;
+    }
+    crate::importing::source_cwd().unwrap_or_default()
+}
+
+/// `path` as the seam should see it: an absolute name unchanged, a relative one
+/// joined to the working directory.
+///
+/// An empty name stays empty so that the seam reports `ENOENT` for it, which is
+/// what `open("")` owes its caller rather than the working directory's contents.
+fn resolve_against_cwd(path: &[u8]) -> Vec<u8> {
+    if path.is_empty() || path.starts_with(b"/") {
+        return path.to_vec();
+    }
+    let mut resolved = cwd_bytes();
+    if resolved.is_empty() {
+        return path.to_vec();
+    }
+    if !resolved.ends_with(b"/") {
+        resolved.push(b'/');
+    }
+    resolved.extend_from_slice(path);
+    resolved
+}
+
+/// `posix.chdir(path)` — the directory later relative paths resolve against.
+///
+/// `fchdir` is what a descriptor argument would need, and the seam has no
+/// directory descriptor to offer it, so a name is the only spelling accepted.
+fn chdir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let resolved = path_arg(args, "chdir")?;
+    let target = resolve_against_cwd(&resolved.as_bytes);
+    let path: std::path::PathBuf = crate::gateway::os_string_from_fs_bytes(&target).into();
+    if !crate::importing::source_is_dir(&path) {
+        // The two answers a failed `chdir` gives: the name is not there, or it
+        // is there and is not a directory.
+        let errno = match crate::importing::source_file_size(&path) {
+            Ok(_) => crate::builtins::wasm_errno::ENOTDIR,
+            Err(e) => crate::builtins::wasm_errno::seam_errno(&e),
+        };
+        return Err(crate::PyError::os_error_syscall(errno, resolved.w_path()));
+    }
+    *WORKING_DIRECTORY.lock().unwrap() = Some(target);
+    Ok(pyre_object::w_none())
+}
+
 /// The seam takes a `&Path`, and on this target an `OsStr` is the byte string
 /// itself, so the filesystem bytes cross it whole rather than through a text
 /// spelling that a name without one would not survive: an entry `listdir`
 /// reported is an entry `stat` can be called with again.
-fn seam_path(bytes: &[u8]) -> std::path::PathBuf {
-    crate::gateway::os_string_from_fs_bytes(bytes).into()
+///
+/// This is the one place a relative name becomes an absolute one, so every
+/// entry point that takes a path resolves it against the same directory
+/// `getcwd` reports.
+pub(crate) fn seam_path(bytes: &[u8]) -> std::path::PathBuf {
+    crate::gateway::os_string_from_fs_bytes(&resolve_against_cwd(bytes)).into()
 }
 
 /// The seam's `io::Error` as the OSError it stands for, named by the path
@@ -785,6 +846,7 @@ pub fn register_module(ns: PyObjectRef) {
         "scandir",
         crate::make_builtin_function("scandir", scandir),
     );
+    crate::module_ns_store(ns, "chdir", crate::make_builtin_function("chdir", chdir));
     // `os.walk` catches `OSError` from the iterator and `shutil` calls
     // `isinstance(entry, os.DirEntry)`, so both the type and the entries it
     // stamps are published.
@@ -914,11 +976,6 @@ pub fn register_module(ns: PyObjectRef) {
     for (name, value) in constants {
         crate::module_ns_store(ns, name, pyre_object::w_int_new(*value));
     }
-}
-
-/// The embedder's working directory, or nothing when it reports none.
-fn cwd_bytes() -> Vec<u8> {
-    crate::importing::source_cwd().unwrap_or_default()
 }
 
 /// `posix.urandom(n)` — the same entry point the syscall arm publishes, over

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
@@ -802,6 +802,107 @@ fn readlink(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     ))
 }
 
+/// The guest's environment.
+///
+/// This is what a C library's `environ` array is: the store `putenv` and
+/// `unsetenv` write to, and the one `posix.environ` is built from once.  `os.py`
+/// wraps that dict rather than copying it, so `os.environ` tracks the dict and
+/// these two track this map -- the same two-place split every platform has, and
+/// the reason a bare `os.putenv` is not visible through `os.environ` there
+/// either.  `_create_environ` is what reads this side back, which is how
+/// `os.reload_environ()` sees what `putenv` wrote.
+///
+/// The guest is started with no environment: the runner forwards the few
+/// variables the launcher options resolve against rather than an environment
+/// block, so this begins empty and holds whatever the program puts in it.
+static ENVIRONMENT: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::BTreeMap<Vec<u8>, Vec<u8>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::BTreeMap::new()));
+
+/// A fresh dict holding what the environment holds now.
+///
+/// Bytes on both sides: `os.py` encodes a key before it stores one and decodes
+/// it on the way back, and `os.environb` hands the same dict out undecoded.
+fn environ_snapshot() -> PyObjectRef {
+    let entries: Vec<(Vec<u8>, Vec<u8>)> = ENVIRONMENT
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|(name, value)| (name.clone(), value.clone()))
+        .collect();
+    let _roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+    for (name, value) in entries {
+        let key_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_bytes_from_bytes(&name));
+        let w_value = pyre_object::w_bytes_from_bytes(&value);
+        let _ = crate::baseobjspace::setitem(
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            pyre_object::gc_roots::shadow_stack_get(key_slot),
+            w_value,
+        );
+    }
+    pyre_object::gc_roots::shadow_stack_get(dict_slot)
+}
+
+/// The name or value argument of `putenv` / `unsetenv`, as the bytes the
+/// environment holds.
+///
+/// `os.environ` hands these down already encoded, and `os.environb` hands down
+/// bytes to begin with, so both spellings arrive here and both are kept as
+/// bytes: a name that came from the embedder is a name the guest can set again,
+/// whatever it spells.
+fn env_bytes_arg(
+    w_arg: PyObjectRef,
+    name: &'static str,
+) -> Result<crate::gateway::FsEncodedPath, crate::PyError> {
+    crate::gateway::fsencode_path_w(w_arg).map_err(|_| {
+        crate::PyError::type_error(format!("{name}() argument must be str or bytes"))
+    })
+}
+
+/// `posix.putenv(name, value)` — add or replace one variable.
+fn putenv(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::kwarg_reject_unknown(kwargs, &[], "putenv")?;
+    if pos.len() != 2 {
+        return Err(crate::PyError::type_error(format!(
+            "putenv expected 2 arguments, got {}",
+            pos.len()
+        )));
+    }
+    let name = env_bytes_arg(pos[0], "putenv")?;
+    // `putenv` is defined over `name=value`, so a name carrying the separator
+    // could not be spelled back out of the environment it went into.
+    if name.as_bytes.contains(&b'=') {
+        return Err(crate::PyError::value_error(
+            "illegal environment variable name",
+        ));
+    }
+    let value = env_bytes_arg(pos[1], "putenv")?;
+    ENVIRONMENT
+        .lock()
+        .unwrap()
+        .insert(name.as_bytes.clone(), value.as_bytes.clone());
+    Ok(pyre_object::w_none())
+}
+
+/// `posix.unsetenv(name)` — remove one variable, or leave an absent one absent.
+fn unsetenv(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let name = env_bytes_arg(
+        args.first()
+            .copied()
+            .ok_or_else(|| crate::PyError::type_error("unsetenv expected 1 argument, got 0"))?,
+        "unsetenv",
+    )?;
+    // A name nothing set is a name already unset, which is what the syscall
+    // reports and what `os.environ.__delitem__` relies on so that it can raise
+    // the KeyError itself, against the caller's own spelling of the key.
+    ENVIRONMENT.lock().unwrap().remove(&name.as_bytes);
+    Ok(pyre_object::w_none())
+}
+
 /// `posix.unlink(path, *, dir_fd=None)` / `posix.rmdir(path, *, dir_fd=None)`
 /// — the entry points a read-only mount publishes and refuses.
 fn refuse_write(args: &[PyObjectRef], name: &'static str) -> Result<PyObjectRef, crate::PyError> {
@@ -813,12 +914,12 @@ fn refuse_write(args: &[PyObjectRef], name: &'static str) -> Result<PyObjectRef,
 }
 
 pub fn register_module(ns: PyObjectRef) {
-    // `os._createenviron` reads this dict directly and wraps it, so `os.environ`
-    // is a live view of it.  The guest is started with no environment — the
-    // runner hands the interpreter the few variables it forwards, rather than
-    // an environment block — so it starts empty and stays whatever the program
-    // puts in it.
-    crate::module_ns_store(ns, "environ", pyre_object::w_dict_new());
+    // `os._create_environ_mapping` binds this dict itself rather than copying
+    // it, so `os.environ._data` is this object and `os.environ` is a live view
+    // of it.  The guest is started with no environment — the runner hands the
+    // interpreter the few variables it forwards, rather than an environment
+    // block — so this begins empty and holds whatever the program puts in it.
+    crate::module_ns_store(ns, "environ", environ_snapshot());
     // `os.py` builds `supports_dir_fd` and friends only when this exists, and
     // then reads `stat` out of its own namespace to seed `supports_fd`.  Empty:
     // no call here takes a directory or a descriptor argument.
@@ -847,6 +948,25 @@ pub fn register_module(ns: PyObjectRef) {
         crate::make_builtin_function("scandir", scandir),
     );
     crate::module_ns_store(ns, "chdir", crate::make_builtin_function("chdir", chdir));
+    // `os.environ.__setitem__` calls `putenv` by name, so a target without it
+    // cannot set a variable at all.
+    crate::module_ns_store(ns, "putenv", crate::make_builtin_function("putenv", putenv));
+    // `os.reload_environ` exists only where this does, and it is the one reader
+    // that can see what a bare `putenv` wrote.
+    crate::module_ns_store(
+        ns,
+        "_create_environ",
+        crate::make_builtin_function_with_arity(
+            "_create_environ",
+            |_args| Ok(environ_snapshot()),
+            0,
+        ),
+    );
+    crate::module_ns_store(
+        ns,
+        "unsetenv",
+        crate::make_builtin_function_with_arity("unsetenv", unsetenv, 1),
+    );
     // `os.walk` catches `OSError` from the iterator and `shutil` calls
     // `isinstance(entry, os.DirEntry)`, so both the type and the entries it
     // stamps are published.

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -921,13 +921,306 @@ fn _c_gmtime(seconds: time_t) -> Result<c_tm, crate::PyError> {
         .ok_or_else(|| crate::PyError::os_error("unconvertible time"))
 }
 
-// wasm32 has no libc `struct tm` calendar conversions; the broken-down-time
-// functions raise rather than dropping `time` from the module registry.
+/// The calendar a target with no libc has to compute for itself.
+///
+/// The conversions are the civil/serial-day pair whose derivation shifts the
+/// year to start in March: the leap day then falls at the end of the cycle and
+/// every case but the 400-year one disappears.  Days are counted from the
+/// epoch, so the pair is exact for every `time_t` the guest can hold.
+///
+/// One zone, and it is UTC.  There is no tzdata to read and no `TZ` to read one
+/// with, which is why `tzname` is `("UTC", "UTC")` and `timezone` is 0 here:
+/// `localtime` can only answer what `gmtime` answers.
 #[cfg(target_arch = "wasm32")]
-fn _c_gmtime(_seconds: time_t) -> Result<c_tm, crate::PyError> {
-    Err(crate::PyError::not_implemented(
-        "time.gmtime is unavailable on wasm32",
-    ))
+mod wasm_calendar {
+    use super::c_tm;
+
+    /// The widest field a `%<width>` prefix can ask a conversion to fill.
+    const MAX_FIELD_WIDTH: usize = 64;
+
+    /// The one zone this target has.  `time.tzname` publishes the same name
+    /// twice, and it is what `%Z` reports for a time that carries none.
+    const ZONE_NAME: &str = "UTC";
+
+    /// `y`, `m` and `d` for a day number counted from the epoch.
+    fn civil_from_days(days: i64) -> (i64, i64, i64) {
+        // Shift to an era starting 0000-03-01, which is what makes the leap
+        // day the last day of the 400-year cycle.
+        let z = days + 719_468;
+        let era = z.div_euclid(146_097);
+        let doe = z.rem_euclid(146_097);
+        let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+        let mp = (5 * doy + 2) / 153;
+        let d = doy - (153 * mp + 2) / 5 + 1;
+        let m = if mp < 10 { mp + 3 } else { mp - 9 };
+        (era * 400 + yoe + i64::from(m <= 2), m, d)
+    }
+
+    /// The inverse: the day number a civil date names.  Out-of-range `m` and
+    /// `d` carry the way `mktime` normalizes them.
+    fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+        let y = y - i64::from(m <= 2);
+        let era = y.div_euclid(400);
+        let yoe = y.rem_euclid(400);
+        let mp = if m > 2 { m - 3 } else { m + 9 };
+        let doy = (153 * mp + 2) / 5 + d - 1;
+        let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+        era * 146_097 + doe - 719_468
+    }
+
+    fn is_leap(year: i64) -> bool {
+        year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+    }
+
+    /// The day of the year, counted from zero, that `struct tm` carries.
+    fn day_of_year(year: i64, month: i64, day: i64) -> i64 {
+        const CUMULATIVE: [i64; 12] = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+        CUMULATIVE[(month - 1) as usize] + day - 1 + i64::from(month > 2 && is_leap(year))
+    }
+
+    /// Broken-down UTC time for a count of seconds from the epoch, or nothing
+    /// for one whose year does not fit the `tm_year` field.
+    pub fn broken_down(seconds: i64) -> Option<c_tm> {
+        let days = seconds.div_euclid(86_400);
+        let rest = seconds.rem_euclid(86_400);
+        let (year, month, day) = civil_from_days(days);
+        Some(c_tm {
+            tm_sec: (rest % 60) as i32,
+            tm_min: ((rest / 60) % 60) as i32,
+            tm_hour: (rest / 3600) as i32,
+            tm_mday: day as i32,
+            tm_mon: (month - 1) as i32,
+            tm_year: i32::try_from(year - 1900).ok()?,
+            // 1970-01-01 was a Thursday, and `tm_wday` counts from Sunday.
+            tm_wday: ((days.rem_euclid(7) + 4) % 7) as i32,
+            tm_yday: day_of_year(year, month, day) as i32,
+            tm_isdst: 0,
+            tm_gmtoff: 0,
+            tm_zone: ZONE_NAME.to_string(),
+        })
+    }
+
+    /// The seconds a broken-down time names, with `tm_wday` and `tm_yday`
+    /// recomputed from the fields that were given.  Out-of-range fields carry
+    /// into the ones above them, which is the normalization `mktime` performs.
+    pub fn seconds_from(tm: &mut c_tm) -> Option<i64> {
+        let month_total = i64::from(tm.tm_year) + 1900 + i64::from(tm.tm_mon).div_euclid(12);
+        let month = i64::from(tm.tm_mon).rem_euclid(12) + 1;
+        let days = days_from_civil(month_total, month, i64::from(tm.tm_mday));
+        let seconds = days.checked_mul(86_400)?
+            + i64::from(tm.tm_hour) * 3600
+            + i64::from(tm.tm_min) * 60
+            + i64::from(tm.tm_sec);
+        let normalized = broken_down(seconds)?;
+        tm.tm_wday = normalized.tm_wday;
+        tm.tm_yday = normalized.tm_yday;
+        Some(seconds)
+    }
+
+    const WDAY_ABBR: [&str; 7] = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    const WDAY_FULL: [&str; 7] = [
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+    ];
+    const MON_ABBR: [&str; 12] = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ];
+    const MON_FULL: [&str; 12] = [
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    ];
+
+    /// The weekday 31 December of `year` falls on, counted from Sunday.
+    fn dec31_weekday(year: i64) -> i64 {
+        (year + year.div_euclid(4) - year.div_euclid(100) + year.div_euclid(400)).rem_euclid(7)
+    }
+
+    /// A year holds 53 ISO weeks when it ends on a Thursday, or when the year
+    /// before it ended on a Wednesday and so pushed a week across.  Every other
+    /// year holds 52.
+    fn iso_weeks_in_year(year: i64) -> i64 {
+        52 + i64::from(dec31_weekday(year) == 4 || dec31_weekday(year - 1) == 3)
+    }
+
+    /// The ISO 8601 week-based year and week number.  A date in the first days
+    /// of January can belong to the last week of the year before it, and one in
+    /// the last days of December to week 1 of the year after.
+    fn iso_week(tm: &c_tm) -> (i64, i64) {
+        let year = i64::from(tm.tm_year) + 1900;
+        // ISO counts Monday as 1 and Sunday as 7; `tm_wday` counts from Sunday.
+        let weekday = if tm.tm_wday == 0 {
+            7
+        } else {
+            i64::from(tm.tm_wday)
+        };
+        let week = (i64::from(tm.tm_yday) + 1 - weekday + 10) / 7;
+        if week < 1 {
+            (year - 1, iso_weeks_in_year(year - 1))
+        } else if week > iso_weeks_in_year(year) {
+            (year + 1, 1)
+        } else {
+            (year, week)
+        }
+    }
+
+    /// One directive's expansion, or nothing for a byte that names none.
+    ///
+    /// An unrecognised conversion expands to nothing here and the caller echoes
+    /// the whole `%…` sequence it was spelled with.
+    fn directive(key: u8, tm: &c_tm) -> Option<String> {
+        let year = i64::from(tm.tm_year) + 1900;
+        let hour12 = match tm.tm_hour % 12 {
+            0 => 12,
+            other => other,
+        };
+        Some(match key {
+            b'a' => WDAY_ABBR[tm.tm_wday as usize % 7].to_string(),
+            b'A' => WDAY_FULL[tm.tm_wday as usize % 7].to_string(),
+            b'b' | b'h' => MON_ABBR[tm.tm_mon as usize % 12].to_string(),
+            b'B' => MON_FULL[tm.tm_mon as usize % 12].to_string(),
+            b'c' => format!(
+                "{} {} {:2} {:02}:{:02}:{:02} {year}",
+                WDAY_ABBR[tm.tm_wday as usize % 7],
+                MON_ABBR[tm.tm_mon as usize % 12],
+                tm.tm_mday,
+                tm.tm_hour,
+                tm.tm_min,
+                tm.tm_sec
+            ),
+            b'C' => format!("{:02}", year.div_euclid(100)),
+            b'd' => format!("{:02}", tm.tm_mday),
+            b'D' => format!(
+                "{:02}/{:02}/{:02}",
+                tm.tm_mon + 1,
+                tm.tm_mday,
+                year.rem_euclid(100)
+            ),
+            b'e' => format!("{:2}", tm.tm_mday),
+            b'F' => format!("{year}-{:02}-{:02}", tm.tm_mon + 1, tm.tm_mday),
+            b'g' => format!("{:02}", iso_week(tm).0.rem_euclid(100)),
+            b'G' => iso_week(tm).0.to_string(),
+            b'H' => format!("{:02}", tm.tm_hour),
+            b'I' => format!("{hour12:02}"),
+            b'j' => format!("{:03}", tm.tm_yday + 1),
+            b'm' => format!("{:02}", tm.tm_mon + 1),
+            b'M' => format!("{:02}", tm.tm_min),
+            b'n' => "\n".to_string(),
+            b'p' => if tm.tm_hour < 12 { "AM" } else { "PM" }.to_string(),
+            b'r' => format!(
+                "{hour12:02}:{:02}:{:02} {}",
+                tm.tm_min,
+                tm.tm_sec,
+                if tm.tm_hour < 12 { "AM" } else { "PM" }
+            ),
+            b'R' => format!("{:02}:{:02}", tm.tm_hour, tm.tm_min),
+            b'S' => format!("{:02}", tm.tm_sec),
+            b't' => "\t".to_string(),
+            b'T' | b'X' => format!("{:02}:{:02}:{:02}", tm.tm_hour, tm.tm_min, tm.tm_sec),
+            b'u' => (if tm.tm_wday == 0 { 7 } else { tm.tm_wday }).to_string(),
+            // Weeks counted from the year's first Sunday (`%U`) and its first
+            // Monday (`%W`); the days before that one are week zero.
+            b'U' => format!("{:02}", (tm.tm_yday + 7 - tm.tm_wday) / 7),
+            b'V' => format!("{:02}", iso_week(tm).1),
+            b'w' => tm.tm_wday.to_string(),
+            b'W' => format!("{:02}", (tm.tm_yday + 7 - (tm.tm_wday + 6) % 7) / 7),
+            b'x' => format!(
+                "{:02}/{:02}/{:02}",
+                tm.tm_mon + 1,
+                tm.tm_mday,
+                year.rem_euclid(100)
+            ),
+            b'y' => format!("{:02}", year.rem_euclid(100)),
+            b'Y' => year.to_string(),
+            b'z' => "+0000".to_string(),
+            // A caller's own 9-tuple carries no zone, and neither does the
+            // view `_gettmarg` takes of a `struct_time`, whose zone sits
+            // outside the sequence.  A C library falls back to `tzname` for
+            // exactly that argument, and there is one name to fall back to.
+            b'Z' if tm.tm_zone.is_empty() => ZONE_NAME.to_string(),
+            b'Z' => tm.tm_zone.clone(),
+            b'%' => "%".to_string(),
+            _ => return None,
+        })
+    }
+
+    /// A minimum field width zero-pads a numeric expansion, so that `%4Y`
+    /// renders year 1 as `0001`.  Anything else is handed back unpadded.
+    fn pad_to_width(text: String, width: usize) -> String {
+        let digits = text.strip_prefix(['+', '-']).unwrap_or(&text);
+        if text.len() >= width || digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+            return text;
+        }
+        let sign = &text[..text.len() - digits.len()];
+        let zeros = "0".repeat(width - text.len());
+        format!("{sign}{zeros}{digits}")
+    }
+
+    /// `format` with each directive replaced, over bytes rather than text: a
+    /// format spelling a lone surrogate is WTF-8, and the bytes it is made of
+    /// are echoed unchanged the way a C library echoes what it does not read.
+    pub fn render(format: &[u8], tm: &c_tm) -> Vec<u8> {
+        let mut out = Vec::with_capacity(format.len());
+        let mut index = 0;
+        while index < format.len() {
+            if format[index] != b'%' {
+                out.push(format[index]);
+                index += 1;
+                continue;
+            }
+            // `%[+][width][E|O]<conversion>`.  The flag and the width are the
+            // extension `test.support.has_strftime_extensions` probes for; the
+            // two modifiers name locale alternatives this build does not have,
+            // and are accepted so that the conversion after them still lands.
+            let mut cursor = index + 1;
+            if format.get(cursor) == Some(&b'+') {
+                cursor += 1;
+            }
+            let width_start = cursor;
+            while format.get(cursor).is_some_and(u8::is_ascii_digit) {
+                cursor += 1;
+            }
+            let width = std::str::from_utf8(&format[width_start..cursor])
+                .ok()
+                .and_then(|digits| digits.parse::<usize>().ok())
+                .unwrap_or(0)
+                .min(MAX_FIELD_WIDTH);
+            if matches!(format.get(cursor), Some(b'E' | b'O')) {
+                cursor += 1;
+            }
+            match format
+                .get(cursor)
+                .copied()
+                .and_then(|key| directive(key, tm))
+            {
+                Some(text) => out.extend_from_slice(pad_to_width(text, width).as_bytes()),
+                None => out.extend_from_slice(&format[index..format.len().min(cursor + 1)]),
+            }
+            index = cursor + 1;
+        }
+        out
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn _c_gmtime(seconds: time_t) -> Result<c_tm, crate::PyError> {
+    wasm_calendar::broken_down(seconds)
+        .ok_or_else(|| crate::PyError::os_error("unconvertible time"))
 }
 
 // `interp_time.py c_gmtime` libc backend, used when the host_env
@@ -966,10 +1259,8 @@ fn _c_localtime(seconds: time_t) -> Result<c_tm, crate::PyError> {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn _c_localtime(_seconds: time_t) -> Result<c_tm, crate::PyError> {
-    Err(crate::PyError::not_implemented(
-        "time.localtime is unavailable on wasm32",
-    ))
+fn _c_localtime(seconds: time_t) -> Result<c_tm, crate::PyError> {
+    _c_gmtime(seconds)
 }
 
 #[cfg(all(unix, not(feature = "host_env")))]
@@ -1600,14 +1891,17 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // that would otherwise decode back into one Unicode scalar).
     let format_len = fmt_wtf8.code_points().count();
 
-    // wasm32 has no libc `strftime`; the function raises rather than dropping
-    // `time` from the module registry (same policy as `gmtime`/`localtime`).
+    // No libc `strftime` here, so the directives are expanded in this module.
+    // An embedded NUL is literal data rather than the end of the format, and
+    // needs no segmenting: nothing downstream reads the bytes as a C string.
     #[cfg(target_arch = "wasm32")]
     {
-        let _ = format_len;
-        Err(crate::PyError::not_implemented(
-            "time.strftime is unavailable on wasm32",
-        ))
+        let _ = (format_len, passthrough);
+        let rendered = wasm_calendar::render(fmt_wtf8.as_bytes(), &tm);
+        Ok(match pyre_object::rutf8::wtf8_from_bytes(&rendered, true) {
+            Ok(wtf8) => w_str_from_wtf8_managed(wtf8.to_owned()),
+            Err(_) => crate::typedef::charp2uni(&rendered),
+        })
     }
     // strftime consults $TZ/tzname (%Z/%z) and the LC_TIME locale DB; under
     // sandbox the registration is stubbed, so the real body is compiled out.
@@ -1759,13 +2053,15 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 /// time.mktime(tuple) — interp_time.mktime
 pub fn mktime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    // No libc `struct tm` calendar on wasm32 (and other bare targets).
+    // One zone, and it is UTC, so the seconds a broken-down time names are the
+    // ones `gmtime` would hand back for it.  `tm_isdst` names no second
+    // reading here and is ignored the way it is on a platform with no DST rule.
     #[cfg(not(any(unix, windows)))]
     {
-        let _ = args;
-        Err(crate::PyError::not_implemented(
-            "time.mktime is unavailable on this platform",
-        ))
+        let mut tm = _gettmarg(args, false)?;
+        let seconds = wasm_calendar::seconds_from(&mut tm)
+            .ok_or_else(|| crate::PyError::overflow_error("mktime argument out of range"))?;
+        Ok(floatobject::w_float_new(seconds as f64))
     }
     #[cfg(any(unix, windows))]
     {
@@ -1836,20 +2132,10 @@ fn _asctime_from_tm(tm: &c_tm) -> Result<PyObjectRef, crate::PyError> {
 pub fn ctime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let seconds = _get_seconds(args)?;
 
-    #[cfg(target_arch = "wasm32")]
-    {
-        let _ = seconds;
-        Err(crate::PyError::not_implemented(
-            "time.ctime is unavailable on wasm32",
-        ))
-    }
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        // interp_time.py:ctime always delegates through localtime + _asctime.
-        // Keep one result-allocation path on Unix and Windows alike.
-        let tm = _c_localtime(seconds)?;
-        _asctime_from_tm(&tm)
-    }
+    // interp_time.py:ctime always delegates through localtime + _asctime.
+    // Keep one result-allocation path on every target.
+    let tm = _c_localtime(seconds)?;
+    _asctime_from_tm(&tm)
 }
 
 /// `app_time.py strptime` — parse `string` per `format`, delegating to

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -1017,6 +1017,37 @@ fn run_python_impl(source: &str) -> String {
     let main_module = pyre_object::module::w_module_new_aliasing_dict("__main__", canonical);
     pyre_interpreter::importing::set_sys_module("__main__", main_module);
 
+    let script_path = SCRIPT_PATH.with(|p| p.borrow().clone());
+
+    // `__main__.__file__` — `pymain_run_file` publishes the script's own path
+    // in the module it runs it as, and `unittest`'s discovery, `inspect` and
+    // traceback rendering all read it back off `__main__`.
+    if let Some(path) = script_path.as_deref() {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let globals_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(canonical);
+        let key_slot = pyre_object::gc_roots::shadow_stack_len();
+        let _ = pyre_object::gc_roots::pin_root(pyre_object::w_str_new("__file__"));
+        let w_path = pyre_object::w_str_new(path);
+        let _ = pyre_interpreter::baseobjspace::setitem(
+            pyre_object::gc_roots::shadow_stack_get(globals_slot),
+            pyre_object::gc_roots::shadow_stack_get(key_slot),
+            w_path,
+        );
+    }
+
+    // `sys.argv[0]` is the script, as `pymain_run_file` sets it, and `''` when
+    // the guest was handed source with no name -- which is what `Py_Initialize`
+    // leaves behind and what `unittest.main()` reads for its program name.  An
+    // empty `sys.argv` is not a shape any launcher produces.
+    //
+    // Last before `sys` is built: the list this hands over is held in a plain
+    // cell until then, and nothing roots it while it waits there, so the fewer
+    // allocations in between the better.
+    pyre_interpreter::importing::set_sys_argv(&[std::ffi::OsString::from(
+        script_path.unwrap_or_default(),
+    )]);
+
     // Create `sys` before user code runs, as `run_script_path` does. Nothing on
     // this entry point imports it otherwise, and the interpreter reads it
     // directly for its own work: `_warnings.show_warning` writes through


### PR DESCRIPTION
Five entry-point gaps kept the wasm32 guest from running `test.test_unittest`. With them closed the whole package runs: **969 tests, 0 errors, 0 failures, 68 skipped**, via `loader.loadTestsFromName("test.test_unittest")` — the same `load_package_tests` entry CPython uses. `test_async_case` skips with `SkipTest: requires socket support`, which is the correct skip for this target.

## What was missing

| | |
|---|---|
| `time` | wasm32 has no libc calendar, so `gmtime`, `localtime`, `strftime`, `mktime` and `ctime` all raised `NotImplementedError` |
| `sys.argv` / `__main__.__file__` | the bootstrap set neither; `unittest.main()` reads `argv[0]`, and discovery, `inspect` and traceback rendering read `__file__` |
| `putenv` / `unsetenv` | absent, so `os.environ[k] = v` raised `AttributeError` |
| `os.terminal_size` | absent, so `shutil.get_terminal_size` raised from inside its own fallback handler |
| `chdir` | absent, so a relative path always resolved against the embedder's directory |

## The two that were not mechanical

**`putenv` must not write `posix.environ`.** `os.py`'s `_create_environ_mapping` does `data = environ` — no copy — so `os.environ._data` *is* that dict object. `_Environ.__delitem__` calls `unsetenv(key)` and *then* `del self._data[key]`. A `putenv`/`unsetenv` implemented over that dict makes the second line raise from its own bookkeeping (9 errors in the suite, surfacing as `KeyError: 'NO_COLOR'`). The environment is now a separate module-owned map — the C `environ` — with `posix.environ` a snapshot of it and `_create_environ` published so `os.reload_environ()` can read the map back. That is the two-place split every real platform has, and the reason a bare `os.putenv` is invisible through `os.environ` there too.

**`strftime` is graded by two probes, neither of them a normal directive.** The implementation was differentially tested against CPython under `TZ=UTC` over 20 timestamps × the full directive set; everything matched except:

- `test.support`: `has_strftime_extensions = time.strftime("%4Y") != "%4Y"`, and `test_support.test_has_strftime_extensions` asserts True on every non-win32 platform. Echoing an unrecognised `%4Y` verbatim reports False. The glibc prefix `%[+][width][E|O]<conv>` is now parsed and zero-pads numeric expansions.
- `%Z`: `_gettmarg` takes a 9-element view of a `struct_time`, so `tm_zone` — an out-of-sequence structseq extra — never reaches it. pypy leaves it NULL and a real libc silently falls back to `tzname`; without that fallback `test_time.test_strptime` fails with `time data '' does not match format '%Z'`.

`_c_localtime` answers what `_c_gmtime` answers: there is no tzdata and no `TZ` to read, so the target has the one UTC zone `tzname` already names. The weeks-in-year formula was verified exhaustively against `datetime` for years 1–9999.

## Verification

- `pyre/check.py --backend dynasm,wasm` — **dynasm 516/516, wasm 509/509, ALL PASSED**
- `cargo test --all --features dynasm,cpyext --no-fail-fast` — 0, 199 suites
- guest: 98-module import census 98/98; `test_time` 63 ran / 0 failed / 22 skipped; `test_unittest` 969 ran / 0 errors / 0 failures / 68 skipped
- `cargo fmt --all -- --check` and `scripts/check-majit-boundary.py` — 0

Functional round-trip on the guest: `chdir` into a directory, open and glob relative names, and change back; `os.environ` set/delete with `os.environb` agreeing and a missing key still raising the caller's own `KeyError`; `shutil.get_terminal_size()`, `os.getpid()` and `os.isatty(0)` all answering.