### PR TITLE
jit-trace: cut the locals expansion inside its unroll instead of preflighting it

### DIFF
--- a/pyre/bench/synth/locals_expansion_trace_too_long.py
+++ b/pyre/bench/synth/locals_expansion_trace_too_long.py
@@ -1,0 +1,183 @@
+# pyre-check: selfcheck
+# pyre-check: selfcheck-interpreted
+# pyre-check: spec-folds=builtin_locals_trace_limit_cut
+# The `locals()` expansion's own trace_limit cut, witnessed.
+#
+# `pyjitpl.py` `MetaInterp._interpret` asks `blackhole_if_trace_too_long()`
+# after every jitcode step, so the `@jit.unroll_safe` `fast2locals` it looks
+# into is interrupted between its own steps.  Both arms of pyre's expansion
+# record the whole unroll inside ONE Python opcode, and `mod.rs` asks only
+# once that opcode returns, so without a cut inside the unroll a single
+# `locals()` overshoots `trace_limit` by the frame's own `co_nlocals`.
+#
+# `locals_expansion_cut_if_too_long` runs the same `history.length() >
+# trace_limit` question per slot and aborts the trace from there.  The trace is
+# discarded whole, so what this fixture guards is that the discard is CLEAN:
+# the half-built expansion is never published, and the answer the interpreter
+# then produces is the one `locals_in_wide_portal_frame` records for the same
+# frame.
+#
+# The limit is 200 and the frame is 44 slots wide, so one expansion is worth
+# roughly 88 ops -- enough to cross it partway through.  Measured on release
+# dynasm:
+#
+#                       builtin_locals   ..._trace_limit_cut   abrt_too_long
+#   with the cut        consulted=10     consulted=5 fired=5   5
+#                       fired=5
+#   cut suppressed      consulted=10     suppressed=80         5
+#                       fired=10
+#
+# Five of the ten expansions now end inside the unroll instead of emitting all
+# 44 slots past the limit.  `abrt_too_long` does not move, because the walk was
+# going to abort either way -- what moves is how far past the limit it got
+# first.  The suppressed row is asked once per remaining slot rather than once
+# per expansion, because a suppressed cut returns and the unroll goes on
+# reaching it.
+#
+# The answer is the same on both sides, which is half the point: a trace
+# discarded mid-expansion must publish nothing.  The other half is that the
+# answer being the same is exactly why the result alone cannot gate the cut --
+# so `spec-folds` does.  `builtin_locals_trace_limit_cut` fires only where the
+# cut fires, so removing the calls to `locals_expansion_cut_if_too_long` reads
+# as `declared fold(s) never fired` on every backend rather than as a pass.
+#
+# The two rows come from ONE binary: `PYRE_FBW_NO_SPECIALIZE` suppresses the
+# row and with it the cut, which is what that lever is for.
+#
+# Only `trace_limit` is lowered.  `function_threshold=1` was measured to stop
+# the fold firing at all (`consulted=5 fired=0` at every limit), which would
+# leave the fixture guarding nothing, and a module-level `try:` around the
+# `pypyjit` import is avoided for the same class of reason.
+#
+# `selfcheck-interpreted` is the measured state, not a relaxation: at this
+# limit every trace this file starts is aborted, so `loops_compiled` reads 0
+# and there is no compiled shape to name.  That IS half the guard -- the answer
+# has to survive a trace discarded partway through the expansion.
+#
+# `builtin_locals` itself is deliberately NOT declared: at this limit whether
+# that fold completes is what the cut decides, so pinning it would pin the
+# thing under test to one side of it.
+import pypyjit
+
+pypyjit.set_param("trace_limit=200")
+
+import sys
+
+N = 2000
+
+EXPECTED = [
+    "a00",
+    "a01",
+    "a02",
+    "a03",
+    "a04",
+    "a05",
+    "a06",
+    "a07",
+    "a08",
+    "a09",
+    "a10",
+    "a11",
+    "a12",
+    "a13",
+    "a14",
+    "a15",
+    "a16",
+    "a17",
+    "a18",
+    "a19",
+    "a20",
+    "a21",
+    "a22",
+    "a23",
+    "a24",
+    "a25",
+    "a26",
+    "a27",
+    "a28",
+    "a29",
+    "a30",
+    "a31",
+    "a32",
+    "a33",
+    "a34",
+    "a35",
+    "a36",
+    "a37",
+    "a38",
+    "a39",
+    "i",
+    "n",
+    "total",
+    "width",
+]
+
+WIDTH = 44
+
+
+def wide(n):
+    a00 = 0
+    a01 = 1
+    a02 = 2
+    a03 = 3
+    a04 = 4
+    a05 = 5
+    a06 = 6
+    a07 = 7
+    a08 = 8
+    a09 = 9
+    a10 = 10
+    a11 = 11
+    a12 = 12
+    a13 = 13
+    a14 = 14
+    a15 = 15
+    a16 = 16
+    a17 = 17
+    a18 = 18
+    a19 = 19
+    a20 = 20
+    a21 = 21
+    a22 = 22
+    a23 = 23
+    a24 = 24
+    a25 = 25
+    a26 = 26
+    a27 = 27
+    a28 = 28
+    a29 = 29
+    a30 = 30
+    a31 = 31
+    a32 = 32
+    a33 = 33
+    a34 = 34
+    a35 = 35
+    a36 = 36
+    a37 = 37
+    a38 = 38
+    a39 = 39
+    total = 0
+    width = 0
+    for i in range(n):
+        total += locals()["a39"]
+        width = len(locals())
+    return total, width, sorted(locals())
+
+
+def main():
+    total, width, names = wide(N)
+    if width != WIDTH:
+        print(f"FAIL width: {width} (expected {WIDTH})")
+        return 1
+    if names != EXPECTED:
+        print(f"FAIL name set: {names}")
+        print(f"  expected: {EXPECTED}")
+        return 1
+    if total != 39 * N:
+        print(f"FAIL total: {total} (expected {39 * N})")
+        return 1
+    print("PASS locals expansion trace_limit cut")
+    return 0
+
+
+sys.exit(main())

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -446,6 +446,7 @@ spec_folds! {
     KwonlyDefaultsInline => ("kwonly_defaults_inline",   "inline_call",   "-"),
     LoadSuperAttr        => ("load_super_attr",          "residual_call", "-"),
     SuperAttrUnwrap      => ("super_attr_unwrap",        "residual_call", "load_super_attr"),
+    LocalsTraceLimitCut  => ("builtin_locals_trace_limit_cut", "specialize", "builtin_locals"),
 }
 
 const SPEC_FOLD_COUNT: usize = SPEC_FOLD_ROWS.len();
@@ -704,6 +705,38 @@ pub(crate) fn spec_gate<T, E>(
         }
     }
     outcome
+}
+
+/// The `locals()` expansion's trace-limit cut.  Returns whether to cut.
+///
+/// [`spec_gate`] reads a fold's `Ok(Some(_))` as fired, and this decision has
+/// no such value to be read off -- it ends the TRACE rather than returning a
+/// specialization -- so the row is driven from the decision point instead of
+/// wrapping a call.  It is asked only once the recorded length has already
+/// crossed `trace_limit`, so `consulted` counts the crossings that happened
+/// inside an expansion and `fired` counts the ones that cut.
+///
+/// Suppressing `builtin_locals_trace_limit_cut` restores the pre-cut
+/// behaviour: the unroll runs to its end and the overshoot is left to the
+/// opcode-level check in `mod.rs`.  That is what makes the "without the cut"
+/// half of `locals_expansion_trace_too_long`'s table reproducible from one
+/// binary, and it is the same reason the three orthodox sub-walk rows carry a
+/// row at all.
+#[inline]
+pub(crate) fn spec_gate_locals_trace_limit_cut() -> bool {
+    if !spec_instrumented() {
+        return true;
+    }
+    let idx = SpecFold::LocalsTraceLimitCut.index();
+    if spec_suppressed_mask().get(idx) {
+        SPEC_SUPPRESSED[idx].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        return false;
+    }
+    if fbw_spec_census_enabled() {
+        SPEC_CONSULTED[idx].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        SPEC_FIRED[idx].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+    true
 }
 
 /// The STORE_ATTR gate.  One call, two firing outcomes: `Direct` folded the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -10224,43 +10224,57 @@ pub(crate) fn try_walker_specialize_builtin_zip<Sym: WalkSym>(
     Ok(Some(()))
 }
 
-/// Ops the modelled `fast2locals` expansion records per bound slot.
+/// Cut the trace from INSIDE the `locals()` expansion once the recorded
+/// length crosses `trace_limit`.
 ///
-/// The unroll emits at most one guard and one store for each of them, so this
-/// is what [`locals_expansion_fits_trace_limit`] multiplies by to say how far
-/// one `locals()` opcode can take the history.
-const OPS_PER_MODELLED_SLOT: usize = 2;
-
-/// Whether an expansion over `nslots` slots still fits inside `trace_limit`.
+/// `pyjitpl.py` `MetaInterp._interpret` asks `blackhole_if_trace_too_long()`
+/// after every jitcode step, so the `@jit.unroll_safe` `fast2locals` it looks
+/// into is interrupted between its own steps and the raise leaves a partly
+/// filled mapping behind.  Both arms here record the whole unroll inside ONE
+/// Python opcode and `mod.rs` asks only once that opcode returns, so with no
+/// cut the overshoot is the frame's own `co_nlocals` and nothing bounds it.
 ///
-/// `pyjitpl.py` `MetaInterp._interpret` asks `history.length() > trace_limit`
-/// after every jitcode step, so the `fast2locals` it looks into is interrupted
-/// between its own steps and the overshoot is one jitcode wide.  Both arms
-/// here emit the whole unroll inside ONE Python opcode step, and the walk asks
-/// that question only once the step returns (`mod.rs`), so an expansion that
-/// does not ask it overshoots by the frame's own `co_nlocals` with nothing
-/// bounding it.
+/// The cut is upstream's, not a refusal standing in for it: nothing is
+/// estimated, the same `history.length() > trace_limit` decides, and what
+/// happens on a yes is the abort `mod.rs` performs one opcode later --
+/// `latch_abort_blackhole`, `note_root_trace_too_long`
+/// (`stage_abort_reason(ABORT_TOO_LONG)`), `TraceTooLong`.  The trace is
+/// discarded whole, so the half-built expansion above this point is never
+/// published; resuming re-executes the opcode from `pc`, which is the position
+/// every guard this expansion emits already side-exits to
+/// (`walker_emit_fold_guard_with_snapshot`), and the concrete mapping the fold
+/// built before emitting is a pure function of the fastlocals, so the residual
+/// redoes it with the same outcome.
 ///
-/// Asking it here leaves the bound where upstream leaves it -- `trace_limit`,
-/// not a constant.  A frame is never refused for being wide; it is refused for
-/// not fitting in what is left, which is the same question asked at the
-/// granularity this fold records at.
-fn locals_expansion_fits_trace_limit<Sym: WalkSym>(
+/// `trace_too_long_abort_safe`'s bar is kept: with effects already executed and
+/// no blackhole image to hand them to,
+/// `run_blackhole_interp_to_cancel_tracing` has nowhere to resume, so the walk
+/// goes on recording exactly as it does there.
+fn locals_expansion_cut_if_too_long<Sym: WalkSym>(
     ctx: &WalkContext<'_, '_, Sym>,
-    nslots: usize,
-) -> bool {
-    locals_expansion_fits(
-        ctx.trace_ctx.num_recorded_ops(),
-        ctx.trace_ctx.trace_limit(),
-        nslots,
-    )
-}
-
-/// The arithmetic [`locals_expansion_fits_trace_limit`] asks, apart from the
-/// walk it reads the two counts off.  Both additions saturate: the answer for
-/// a width no history could hold is "no", not a wrap into "yes".
-pub(super) fn locals_expansion_fits(recorded: usize, limit: usize, nslots: usize) -> bool {
-    recorded.saturating_add(nslots.saturating_mul(OPS_PER_MODELLED_SLOT)) <= limit
+    pc: usize,
+) -> Result<(), DispatchError> {
+    if !ctx.trace_ctx.is_too_long() {
+        return Ok(());
+    }
+    // The row is what makes the cut visible to `check.py`: it ends the trace
+    // rather than returning a specialization, so nothing downstream of the
+    // fold changes when it is removed, and only this census does.
+    // `locals_expansion_trace_too_long` declares it under `spec-folds`.
+    if !super::diag::spec_gate_locals_trace_limit_cut() {
+        return Ok(());
+    }
+    let latched = residual_call::latch_abort_blackhole(ctx, pc, "locals-expansion");
+    if !latched && super::fbw_state::fbw_executed_effect_count() != 0 {
+        majit_metainterp::mc_diag_bump(26);
+        return Ok(());
+    }
+    let ops = ctx.trace_ctx.num_recorded_ops();
+    crate::state::note_root_trace_too_long(
+        ctx.trace_ctx.current_merge_points_first_green_key_pair(),
+        ctx.trace_ctx.resumekey_original_loop_token().cloned(),
+    );
+    Err(DispatchError::TraceTooLong { pc, ops })
 }
 
 /// Which builtin [`try_walker_specialize_builtin_locals`] is standing in for.
@@ -10425,15 +10439,25 @@ pub(crate) fn try_walker_specialize_builtin_locals<Sym: WalkSym>(
         return Ok(None);
     }
     let numlocals = code_obj.varnames.len();
-    // Width is not the question; fitting is.  `pyframe.py`
-    // `PyFrame.fast2locals` carries `@jit.unroll_safe` and no ceiling, and the
-    // size question is `trace_limit`'s.  A fixed ceiling of 32 slots asked a
-    // different one, so a frame answered `locals()` from a residual because of
-    // its own local count while a trace many times longer was recorded beside
-    // it.
-    if !locals_expansion_fits_trace_limit(ctx, numlocals) {
-        return Ok(None);
-    }
+    // No width ceiling.  `pyframe.py` `PyFrame.fast2locals` carries
+    // `@jit.unroll_safe` and no ceiling of its own, and the length question is
+    // `trace_limit`'s.  A fixed ceiling of 32 slots asked a different one, so a
+    // frame answered `locals()` from a residual because of its own local count
+    // while a trace many times longer was recorded beside it.
+    //
+    // No preflight takes its place either.  Upstream has nothing in that
+    // place: `blackhole_if_trace_too_long` runs from `MetaInterp._interpret`
+    // AFTER `run_one_step`, and no refusal on an estimated cost appears
+    // anywhere in that path.  One refusing when `recorded + 2 * nslots >
+    // trace_limit` was written and dropped, because near the limit it turned a
+    // read that would have fitted into the forcing residual.
+    //
+    // The length question is answered where upstream answers it -- on the
+    // recorded length, inside the unroll.  Upstream's step is one jitcode, so
+    // the `fast2locals` it looks into is interrupted inside its own loop; this
+    // fold is one Python opcode, so `locals_expansion_cut_if_too_long` runs
+    // that same check per slot and aborts the trace from there rather than
+    // leaving the overshoot to `mod.rs` one opcode later.
     // `locals_cells_stack_w` is PyFrame's only virtualizable array
     // (`virtualizable_gen.rs arrays`), so array index 0 names it.
     let Some(info) = ctx.trace_ctx.virtualizable_info().cloned() else {
@@ -10750,6 +10774,7 @@ pub(crate) fn try_walker_specialize_builtin_locals<Sym: WalkSym>(
         )?;
     }
     for (i, &value) in slots.iter().enumerate() {
+        locals_expansion_cut_if_too_long(ctx, op.pc)?;
         // `self.locals_cells_stack_w[i]` — `jtransform.py:1877
         // do_fixed_list_getitem`, the identical lowering `emit_load_fast_ref!`
         // emits for LOAD_FAST.  On the standard virtualizable this resolves to
@@ -10824,6 +10849,10 @@ pub(crate) fn try_walker_specialize_builtin_locals<Sym: WalkSym>(
             walker_emit_fold_guard_with_snapshot(ctx, op.pc, OpCode::GuardNonnull, &[dict_op])?;
         }
     }
+    // Asked again with the loop behind it: the check above runs BEFORE a slot
+    // emits, so the last slot's own ops -- and the tail below -- would
+    // otherwise reach the opcode-level check in `mod.rs` unweighed.
+    locals_expansion_cut_if_too_long(ctx, op.pc)?;
     // `frame_locals_snapshot`'s PEP 667 copy for `locals()` / `vars()`, or
     // `builtin_dir`'s no-argument tail for `dir()` — each split out so the
     // trace and the eval loop run one implementation.  Both report a failure
@@ -10899,20 +10928,6 @@ pub(crate) fn try_walker_specialize_builtin_locals<Sym: WalkSym>(
 /// carries a locals mapping or an `f_extra_locals` dict, and a written slot
 /// the shadow cannot resolve back to a Ref.  `PYRE_FBW_DEBUG_ABORT` names
 /// which of them declined.
-/// What [`try_walker_specialize_builtin_locals_in_callee_expand`] did.
-enum CalleeLocalsExpansion {
-    /// The mapping was emitted and the opcode is done.
-    Expanded,
-    /// The expansion models no part of this shape.  Answered by refusing the
-    /// callee, because the residual this would otherwise fall through to
-    /// escapes the level's vable and costs the enclosing loop.
-    DeclinedShape,
-    /// The expansion would not fit in what is left of `trace_limit`.  That is
-    /// a property of the trace so far and not of this body, so it is answered
-    /// by falling through rather than by remembering a refusal.
-    DeclinedBudget,
-}
-
 fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op: &DecodedOp,
@@ -10921,7 +10936,7 @@ fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
     concrete_callable: pyre_object::PyObjectRef,
     dst: usize,
 ) -> Result<Option<()>, DispatchError> {
-    match try_walker_specialize_builtin_locals_in_callee_expand(
+    if let Some(done) = try_walker_specialize_builtin_locals_in_callee_expand(
         ctx,
         op,
         fold,
@@ -10929,14 +10944,7 @@ fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
         concrete_callable,
         dst,
     )? {
-        CalleeLocalsExpansion::Expanded => return Ok(Some(())),
-        // Falling through here costs the enclosing loop the same way the
-        // refusal below is written to avoid, and that is the right price: a
-        // walk with no room left for this expansion has none for the rest of
-        // the iteration either, and `trace_limit` is about to end it anyway.
-        // What must not happen is the callee carrying the blame afterwards.
-        CalleeLocalsExpansion::DeclinedBudget => return Ok(None),
-        CalleeLocalsExpansion::DeclinedShape => {}
+        return Ok(Some(done));
     }
     // The expansion declined, so this level is about to run the opaque
     // residual -- and that residual's `force_frame_before_locals_read` clears
@@ -10960,13 +10968,12 @@ fn try_walker_specialize_builtin_locals_in_callee<Sym: WalkSym>(
     // the convergence path.
     //
     // It is unreachable today.  Measured 2026-08-29 on release dynasm over the
-    // 504 `bench/synth` fixtures, all of which exit 0: not one `[decline-why]
+    // 507 `bench/synth` fixtures, all of which exit 0: not one `[decline-why]
     // LOCALS-IN-CALLEE` line anywhere, so no shape in the corpus reaches this
     // refusal.  Before the width gate came off, `locals_in_wide_inlined_callee`
     // reported the single line `nslots-over-cap nslots=42 name=wide`; that was
     // the only one the corpus produced, and no other gate has ever been
-    // observed to fire.  The budget refusal above is deliberately not one of
-    // them: it does not reach this line at all.  Each gate below now records why it does not: the
+    // observed to fire.  Each gate below now records why it does not: the
     // non-OPTIMIZED refusal is the answer rather than a gap, its
     // `CO_FAST_HIDDEN` half is a bit this compiler never sets, and the two
     // frame-payload gates sit behind writers that need a reference to the
@@ -11026,7 +11033,7 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
     r_args: &[OpRef],
     concrete_callable: pyre_object::PyObjectRef,
     dst: usize,
-) -> Result<CalleeLocalsExpansion, DispatchError> {
+) -> Result<Option<()>, DispatchError> {
     /// Name the gate that declined.  Unlike the portal arm's decline, which
     /// falls through to the generic residual, this one costs the caller its
     /// whole inlined callee, so "the expansion models no part of this shape"
@@ -11036,13 +11043,13 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
             if fbw_debug_abort_enabled() {
                 eprintln!("[decline-why] LOCALS-IN-CALLEE {}", $why);
             }
-            return Ok(CalleeLocalsExpansion::DeclinedShape);
+            return Ok(None);
         }};
         ($why:literal, $($arg:tt)*) => {{
             if fbw_debug_abort_enabled() {
                 eprintln!("[decline-why] LOCALS-IN-CALLEE {}", format!($why, $($arg)*));
             }
-            return Ok(CalleeLocalsExpansion::DeclinedShape);
+            return Ok(None);
         }};
     }
     // Under a single-frame collapse the resume re-executes the whole call, so
@@ -11114,13 +11121,14 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
     // rest of the thread's tracing, so the ceiling decided inlinability from a
     // callee's local count.
     //
-    // The budget answer keeps that price off the callee.  Not fitting is a
-    // property of the trace so far, not of this body -- the same callee fits
-    // in a shorter one -- so it is reported apart from the shape declines and
-    // the caller falls through instead of remembering a refusal.
-    if !locals_expansion_fits_trace_limit(ctx, nslots) {
-        return Ok(CalleeLocalsExpansion::DeclinedBudget);
-    }
+    // No ceiling and no preflight, for the reason the portal arm records; the
+    // per-slot `locals_expansion_cut_if_too_long` below answers the length
+    // question instead.  That price is also what makes a preflight worse on
+    // this arm than on that one: refusing on the walk's remaining budget would
+    // let the length of the trace so far decide a callee's inlinability, the
+    // way the ceiling let its local count decide it.  The cut is not that --
+    // it ends the trace rather than the callee, so nothing is remembered
+    // against the body.
 
     // Fresh mapping only.  A frame that already carries one — an `f_locals`
     // write (PEP 667), a `setdictscope` — is the portal arm's frame-owned
@@ -11338,6 +11346,7 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
     // frame, so it cannot re-arm the escape this expansion exists to remove.
     let mut value_ops: Vec<OpRef> = Vec::with_capacity(slots.len());
     for slot in &slots {
+        locals_expansion_cut_if_too_long(ctx, op.pc)?;
         if !slot.cell {
             value_ops.push(slot.slot_op);
             continue;
@@ -11378,6 +11387,9 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
         walker_emit_fold_guard_with_snapshot(ctx, op.pc, guard, &[contents])?;
         value_ops.push(contents);
     }
+    // Same reason as the portal arm: the last cell read's guard lands after
+    // that loop's own check.
+    locals_expansion_cut_if_too_long(ctx, op.pc)?;
     // pyframe.py `self.space.newdict(instance=True)` — the mapping a fresh
     // frame's `fast2locals` materialises before filling it.
     let mut dict_op = ctx.trace_ctx.call_ref_typed_with_effect(
@@ -11392,6 +11404,7 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
     ctx.trace_ctx
         .set_opref_concrete(dict_op, concrete_locals_value);
     for (slot, &value_op) in slots.iter().zip(&value_ops) {
+        locals_expansion_cut_if_too_long(ctx, op.pc)?;
         if slot.value.is_null() {
             continue;
         }
@@ -11419,6 +11432,7 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
         ctx.trace_ctx
             .set_opref_concrete(dict_op, concrete_locals_value);
     }
+    locals_expansion_cut_if_too_long(ctx, op.pc)?;
     let result_op = match tail_fn {
         Some(tail) => {
             let op_ref = ctx.trace_ctx.call_ref_typed_with_effect(
@@ -11443,7 +11457,7 @@ fn try_walker_specialize_builtin_locals_in_callee_expand<Sym: WalkSym>(
         None => dict_op,
     };
     write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', result_op)?;
-    Ok(CalleeLocalsExpansion::Expanded)
+    Ok(Some(()))
 }
 
 /// `sys._getframe()` / `sys._getframe(0)` at the top walk level: publish the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -14186,35 +14186,3 @@ fn the_traceback_walk_receivers_pin_their_class_through_the_payload() {
         "list is acceptable as a base class, so its payload does not determine w_class",
     );
 }
-
-/// The modelled `locals()` expansion asks `trace_limit` whether it fits before
-/// it emits, because both of its arms emit the whole unroll inside ONE Python
-/// opcode step and the walk asks that question only after the step returns
-/// (`mod.rs`).  Upstream asks it after every jitcode step
-/// (`pyjitpl.py` `MetaInterp._interpret`), so the `fast2locals` it looks into
-/// is interrupted between its own steps; without this the overshoot here is
-/// the frame's `co_nlocals` and nothing bounds it.
-///
-/// The boundary is the whole content of the gate, so it is pinned on both
-/// sides rather than sampled — and the saturating arithmetic is pinned too,
-/// because a width that wraps would answer "fits" for the one input that
-/// cannot.
-#[test]
-fn locals_expansion_asks_trace_limit_rather_than_a_width() {
-    use super::specialize::locals_expansion_fits;
-
-    // One guard plus at most one store per slot, so 44 slots need 88 ops.
-    assert!(locals_expansion_fits(0, 88, 44), "exactly the budget fits");
-    assert!(!locals_expansion_fits(0, 87, 44), "one op over does not");
-    // What is already recorded counts: the same frame fits in a fresh walk and
-    // not in one that has spent its budget, which is the point of asking here
-    // rather than carrying a constant.
-    assert!(locals_expansion_fits(6000 - 88, 6000, 44));
-    assert!(!locals_expansion_fits(6000 - 87, 6000, 44));
-    // A frame with no slots emits nothing, so it fits even at the limit.
-    assert!(locals_expansion_fits(6000, 6000, 0));
-    assert!(!locals_expansion_fits(6001, 6000, 0), "already over");
-    // Neither multiplication nor addition may wrap into a "fits".
-    assert!(!locals_expansion_fits(0, usize::MAX - 1, usize::MAX));
-    assert!(!locals_expansion_fits(usize::MAX, usize::MAX - 1, 1));
-}


### PR DESCRIPTION
Follow-up to #1560, which landed with a finding open against it.

#1560 took the 32-slot width ceiling off both arms of the modelled `locals()`
expansion — the right change, and it stays. What it also did was put a
preflight in the ceiling's place: decline when
`recorded + 2 * nslots > trace_limit`. That preflight is what this PR removes.

## Why it goes rather than gets re-costed

The Codex parity review on #1560 put it in section 1:

> `specialize.rs:10434 ↔ pyjitpl.py:2865-2867`: the new portal `locals()`
> preflight declines whenever `recorded + 2*nslots > trace_limit`. PyPy
> executes the traced `PyFrame.fast2locals` body and checks length only after
> that interpreter step; it has no pre-decline based on an estimated per-local
> cost. This newly turns otherwise inlineable reads near the limit back into
> the forcing residual path.

That reads correctly against the source. `MetaInterp.blackhole_if_trace_too_long`
is called from `MetaInterp._interpret` right after `framestack[-1].run_one_step()`
and asks `history.length() > trace_limit` — a length already recorded. Nothing
in that path refuses on an estimate. So the preflight closed one deviation by
installing another, which is what `/parity` Principle 3 forbids.

Two reviewers independently reported the estimate as unsound on its own terms:
`OPS_PER_MODELLED_SLOT = 2` under-counts a bound cell slot, which emits a
`GETFIELD_GC_R`, a boundness guard and a `jit_locals_dict_setitem_cell`, and
sometimes a `GuardClass` besides. That is the same conclusion from the other
side — the constant can only be made sound by making it conservative, and a
conservative estimate refuses more of exactly what the parity finding names.

Removed: `locals_expansion_fits_trace_limit`, `locals_expansion_fits`,
`OPS_PER_MODELLED_SLOT`, both call sites, the `CalleeLocalsExpansion` tri-state
the callee arm reported the budget refusal through, and
`locals_expansion_asks_trace_limit_rather_than_a_width`.

## What answers the length question instead

The exposure the preflight was aimed at is real, so it is closed the way
upstream closes it — by cutting INSIDE the unroll, not by refusing before it.

`locals_expansion_cut_if_too_long` runs the same recorded-length test —
`history.length() > trace_limit`, nothing estimated — in all three of the
expansion's per-slot emit loops: before each slot emits, and once more with the
loop behind it so the last slot's own ops and the tail after it are weighed
too. On a yes it performs the abort
`mod.rs` performs one Python opcode later: `latch_abort_blackhole`,
`note_root_trace_too_long` (which stages `ABORT_TOO_LONG`), and
`DispatchError::TraceTooLong`. That is the walker's counterpart of
`SwitchToBlackhole(ABORT_TOO_LONG)` raised out of a traced `fast2locals`: the
trace ends, and nothing is remembered against the callee the way the width
ceiling's decline was. `trace_too_long_abort_safe`'s bar is kept — with effects
already executed and no blackhole image to hand them to,
`run_blackhole_interp_to_cancel_tracing` has nowhere to resume, so the walk
goes on recording exactly as it does at the `mod.rs` site.

Resuming re-executes the whole opcode from `op.pc`. That is not a new resume
point: it is where every guard this expansion emits already side-exits to
(`walker_emit_fold_guard_with_snapshot`), and the concrete mapping the fold
builds before it emits anything is a pure function of the fastlocals, so the
residual redoes it with the same outcome. A half-built mapping is therefore
never published — the trace carrying it is discarded whole.

## The cut is gated, not just exercised

The answer is the same with the cut and without it, so a fixture that only
asserts the answer cannot catch the cut's removal — the same objection
`spec-folds` exists to answer for every other trace-time fold.

So the cut carries its own `SPEC_FOLD_ROWS` row,
`builtin_locals_trace_limit_cut`. `spec_gate` reads a fold's `Ok(Some(_))` as
fired and this decision has no such value — it ends the *trace* — so
`spec_gate_locals_trace_limit_cut` drives the row from the decision point
instead of wrapping a call. Suppressing the row through `PYRE_FBW_NO_SPECIALIZE`
restores the pre-cut behaviour, which is the same reason the three orthodox
sub-walk rows (`subscr_tuple_descent`, `unary_invert_descent`,
`unary_negative_descent`) carry a row at all.

`locals_expansion_trace_too_long` is the fixture: the same 44-slot frame at
`trace_limit=200`, so one expansion is worth roughly 88 ops. Both rows below
come from **one** binary, with and without the suppression:

| | `builtin_locals` | `builtin_locals_trace_limit_cut` | `abrt_too_long` | answer |
|---|---|---|---|---|
| with the cut | `consulted=10 fired=5` | `consulted=5 fired=5` | 5 | PASS |
| cut suppressed | `consulted=10 fired=10` | `suppressed=80` | 5 | PASS |

Five of the ten expansions end inside the unroll instead of emitting all 44
slots past the limit. `abrt_too_long` does not move — the walk was going to
abort either way; what moves is how far past the limit it got first.

The fixture declares the row under `spec-folds`, so removing the calls to
`locals_expansion_cut_if_too_long` reads as `declared fold(s) never fired` on
every backend, with no recorded `.jitstats` baseline needed. Verified armed
rather than assumed:

```
$ PYRE_FBW_NO_SPECIALIZE=builtin_locals_trace_limit_cut \
    check.py --backend dynasm --synthetic-pattern 'locals_expansion_trace_too_long*'
  folds  FAIL  declared fold(s) never fired: builtin_locals_trace_limit_cut
```

It also carries `selfcheck-interpreted`, because at this limit every trace it
starts is aborted, so there is no compiled shape to name — and that the answer
survives the discard is the other half of what it guards.

## The ceiling stays off

Re-measured on release dynasm against this commit, so the two fixtures #1560
added still read what they read before the preflight was written:

| fixture | `builtin_locals` | `loops_compiled` | `loops_aborted` | `abrt_escape` |
|---|---|---|---|---|
| `locals_in_wide_portal_frame` | `consulted=3 fired=2` | 1 | 0 | 0 |
| `locals_in_wide_inlined_callee` | `consulted=1 fired=1` | 1 | 0 | 0 |

## Verification

Release dynasm, on this commit:

- `check.py --backend dynasm` — **ALL PASSED 517/517**
- `cargo test -p pyre-jit-trace --features dynasm` — all suites pass, 0 failed (419 lib unit tests)
- `cargo test -p pyrex --test gate_triage_complete` — 6 passed
- `parity_tests/run.py --dynasm-only` — 187 scripts, no `dynasm` failure. Two
  `[pypy]`-lane failures (`builtin_subclass_attr_mapdict`,
  `foriter_stopiteration_exception_event`) come from the local PyPy 7.3.20
  oracle; that lane runs no pyre binary, so it is independent of this diff.
- corpus census — 507 `bench/synth` fixtures, all exit 0, no `[decline-why]
  LOCALS-IN-CALLEE` line anywhere
- `cargo fmt --check` — clean

Only dynasm is built in this worktree; cranelift and wasm are exercised by CI.

## Self-review

The cut is the only behaviour this PR adds, and it is reachable only past
`trace_limit`: at the default 6000 the corpus records exactly what it recorded
without it, which is what the 517/517 run and the unchanged readings of #1560's
two fixtures say. The census that reports the callee arm's decline unreachable
is re-run here rather than carried over, because the set of decline sites
changed.

Only dynasm is built in this worktree, so the cut's other two backends are
exercised by CI. The fixture is a `selfcheck`, so it needs no recorded
`.jitstats` baseline on any of them.

- [x] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [x] Auto-review section 1 is clear. This check is mandatory.
  - [x] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.

The measurement was taken on `target/release/pyre-dynasm` — the binary
`check.py` actually runs (`CARGO_CONFIG["dynasm"]`, built `dynasm,cpyext`) —
rebuilt at this commit. Two traps worth naming, both hit here: a `pyre-dynasm`
left over from a pre-rebase tree is reused by `--no-build` without complaint,
and a `check.py` run started right after a build reported `nested_loop` at
2.1x against its 2x gate that reads 517/517 on an idle re-run.
