### PR TITLE
jit: a NULL-constant bridge seed slot, an eval-breaker width assert, and per-op dynasm offsets

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -2002,6 +2002,17 @@ impl<'a> AssemblerARM64<'a> {
                             result_loc
                         );
                     }
+                    // Byte offset where this op's code begins: the span from
+                    // the last LABEL to the JUMP is one loop iteration, the
+                    // window `jit-log-opt` brackets with its `+508:` prefixes.
+                    if crate::majit_dump_enabled() {
+                        eprintln!(
+                            "[dynasm] @{:#06x} op[{}] {:?}",
+                            self.mc.offset().0,
+                            op_index,
+                            op.opcode
+                        );
+                    }
                     self.pending_malloc_nursery_gcmap = *gcmap;
                     self.regalloc_perform(
                         op,
@@ -2068,6 +2079,11 @@ impl<'a> AssemblerARM64<'a> {
                 self.pending_guard_tokens.len(),
                 fail_index
             );
+        }
+        // Closes the last op's span, the way `--end of the loop--` closes a
+        // `jit-log-opt` listing.
+        if crate::majit_dump_enabled() {
+            eprintln!("[dynasm] @{:#06x} end of ops", self.mc.offset().0);
         }
 
         // assembler.py:1167-1171 `_assemble`: grow the frame to fit a

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -2740,6 +2740,17 @@ impl<'a> Assembler386<'a> {
                             result_loc
                         );
                     }
+                    // Byte offset where this op's code begins: the span from
+                    // the last LABEL to the JUMP is one loop iteration, the
+                    // window `jit-log-opt` brackets with its `+508:` prefixes.
+                    if crate::majit_dump_enabled() {
+                        eprintln!(
+                            "[dynasm] @{:#06x} op[{}] {:?}",
+                            self.mc.offset().0,
+                            op_index,
+                            op.opcode
+                        );
+                    }
                     self.pending_malloc_nursery_gcmap = *gcmap;
                     self.regalloc_perform(
                         op,
@@ -2806,6 +2817,11 @@ impl<'a> Assembler386<'a> {
                 self.pending_guard_tokens.len(),
                 fail_index
             );
+        }
+        // Closes the last op's span, the way `--end of the loop--` closes a
+        // `jit-log-opt` listing.
+        if crate::majit_dump_enabled() {
+            eprintln!("[dynasm] @{:#06x} end of ops", self.mc.offset().0);
         }
 
         // assembler.py:1003-1008 `_assemble`: grow the frame to fit a

--- a/majit/majit-ir/src/eval_breaker_word.rs
+++ b/majit/majit-ir/src/eval_breaker_word.rs
@@ -353,7 +353,7 @@ pub fn is_back_edge_poll_guard(guard: &crate::resoperation::Op) -> bool {
 // assertion, so there is no operand to compare directly.
 #[allow(clippy::ineffective_bit_mask)]
 const _: () = assert!(
-    (EB_ASYNC | EB_STW | EB_FINALIZING | EB_GC_INTERP | EB_GC)
+    (EB_ASYNC | EB_STW | EB_FINALIZING | EB_GC_INTERP | EB_GC | EB_MEMORY_ERROR)
         < (1 << (EVAL_BREAKER_WORD_SIZE * 8 - 1))
 );
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -10900,7 +10900,8 @@ impl JitState for PyreJitState {
         let semantic_mirror: Vec<OpRef> = if !maps.has_color_map {
             // No per-CodeObject regalloc: colors are slot-identity, so the
             // color bank IS the slot mirror over the semantic prefix. Keep the
-            // in-place identity overlay (stack slots NONE-only, locals vable).
+            // in-place identity overlay, taking the vable image for a slot the
+            // color bank left NONE or decoded to a NULL constant.
             // `!has_color_map` (empty `pcdep_color_slots`) is the field-free
             // successor to the flat `local/stack_color_map.is_empty()` guard, so
             // a zero-local frame that still owns a freely-colored operand stack
@@ -10912,9 +10913,8 @@ impl JitState for PyreJitState {
                 .enumerate()
                 .take(semantic_prefix_len)
             {
-                let is_local = idx < nlocals;
                 let slot_is_null_const = matches!(*slot, OpRef::ConstPtr(v) if v.0 == 0);
-                let want_vable = slot.is_none() || (is_local && slot_is_null_const);
+                let want_vable = slot.is_none() || slot_is_null_const;
                 if want_vable {
                     if let Some(v) = vable_array_items.get(idx).copied() {
                         if !v.is_none() {
@@ -10991,16 +10991,32 @@ impl JitState for PyreJitState {
             }
             // Pcdep-live kept-stack colors absent from the body marker's
             // liveness leave their stack slots NONE after the color→slot
-            // inversion above.  The vable image (`locals_cells_stack_w`)
-            // is authoritative post-guard, so fill NONE stack slots from
-            // it — symmetric to the local overlay.
+            // inversion above, and a color the inversion DID cover can still
+            // decode to a dead temp's NULL constant.  The vable image
+            // (`locals_cells_stack_w`) is authoritative post-guard, so take it
+            // for either — the same null-const rule `overlay_local` applies to
+            // locals.  A NULL here does not mean the slot is empty: an empty
+            // slot reads NULL from the vable image too, so the fill is a no-op
+            // there, while a live slot whose color decoded NULL would otherwise
+            // carry that NULL into the closing JUMP's label argument and hand
+            // it back to the interpreter on the next guard failure.
             for s in nlocals..semantic_prefix_len.min(mirror.len()) {
-                if mirror[s].is_none() {
+                let slot_is_null_const = matches!(mirror[s], OpRef::ConstPtr(v) if v.0 == 0);
+                if mirror[s].is_none() || slot_is_null_const {
                     if let Some(v) = vable_array_items.get(s).copied() {
                         if !v.is_none() {
                             mirror[s] = v;
                             if let Some(&cv) = live_local_values.get(s) {
-                                if !matches!(cv, majit_ir::Value::Void) {
+                                // Skip a NULL source for the same reason
+                                // `overlay_local` does: an empty stack slot
+                                // reads NULL here, and stamping that hole onto
+                                // the box would fold a later residual's Ref
+                                // arg to NULL.
+                                if !matches!(
+                                    cv,
+                                    majit_ir::Value::Void
+                                        | majit_ir::Value::Ref(majit_ir::GcRef(0))
+                                ) {
                                     ctx.try_set_opref_concrete(v, cv);
                                 }
                             }


### PR DESCRIPTION
Three independent changes: one wrong-answer fix, one width assert, one dump.

### `jit: refill a bridge-seed stack slot whose color decoded a NULL constant`

The color→slot inversion that builds `semantic_mirror` can write a dead temp's
NULL constant into a live operand-stack slot. `overlay_local` already treats
that like `OpRef::NONE` for locals and refills from the vable image; the stack
slots refilled only on `NONE`, so the NULL shadowed `locals_cells_stack_w`.
Both branches carried the asymmetry — the `!has_color_map` identity overlay
gated its null-const arm on `is_local`, and the pcdep per-slot inversion's
stack loop tested `is_none()` alone.

Observed with `for a, b in zip(t1, t2, strict=True)` inside a `while`: a bridge
closed to the loop header with `ptr(0x0)` in the label slot the header's first
op class-guards, and the interpreter then reached `space.next(NULL)` — a
SIGSEGV. An empty stack slot reads NULL from the vable image too, so the refill
is a no-op there; it fires only when the color decoded NULL and the vable image
did not.

### `majit-ir: include EB_MEMORY_ERROR in the eval-breaker width assert`

The assertion states that every flag fits in the word the poll loads, but its
disjunction stopped at `EB_GC` (bit 4) and omitted `EB_MEMORY_ERROR` (bit 5),
so the widest flag was the one not width-checked. Checked on both the host and
`wasm32-unknown-unknown`, the target the assert exists for.

### `dynasm: print per-op code offsets under MAJIT_DUMP`

The existing dump covers bridges only, so a compiled loop body had no code-size
instrument. Both assemblers now print `[dynasm] @<offset> op[i] <opcode>` at
the `RegAllocOp::Perform` arm, plus an `end of ops` marker after the emission
loop so the trailing JUMP has a size. `PerformGuard` and `PerformDiscard` are
separate arms and are not instrumented, so their bytes are attributed to the
preceding op.

### Gates

Run on `f6d9e97aaf3` (HEAD stamped identical before and after):

- `python3 pyre/check.py` — 516 passed dynasm, 516 passed cranelift, 509 passed
  wasm, zero failures.
- `cargo test --all --no-default-features --features dynasm --no-fail-fast` —
  rc 0.
- `cargo fmt --all -- --check` — clean.
- No `.jitstats` baseline moves; no fixture re-recorded.

### What was dropped from the earlier revision of this PR

An earlier push carried a fourth commit spelling the FOR_ITER receiver pin as
`guard_value` instead of `ptr_eq` + `guard_true`. That spelling is the
upstream-orthodox one and it is worth −20%/iteration on the pinned loop, but it
also turned `for _ in it` with `it = iter(range(4))` into a silent wrong answer
(220 against CPython's and PyPy's 504). The cause is not the pin: a walk that
aborts past `trace_limit` has already advanced the iterator concretely, and
pyre's abort replays from the walk's start pc rather than resuming forward, so
the consumed item is lost unless the replayed region rebuilds the iterator. The
pin only changed which spellings reach that path — `iter((0,1,2,3))`,
`iter([0,1,2,3])` and a generator expression are wrong on `main` today, without
it.

That is a separate defect with a separate fix (decline the walk before the
advance when the item is not recoverable), so the pin waits for it rather than
riding along here. The `check.py dynasm (ubuntu-24.04)` failure the earlier
push saw — `wasm fib_recursive ratio 4.1x > gate 4x` — was that commit lowering
the dynasm denominator, and goes away with it.
