### PR TITLE
gc, jit: RPython flag spellings, and two rooting gaps in walk_raw_function_roots

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -18993,7 +18993,7 @@ mod tests {
         }
 
         let tracks_young =
-            |addr: usize| unsafe { (*header_of(addr)).has_flag(flags::TRACK_YOUNG_PTRS) };
+            |addr: usize| unsafe { (*header_of(addr)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) };
         let in_nursery = |addr: usize| with_cranelift_gc_required(|gc| gc.is_nursery_object(addr));
 
         assert!(
@@ -25132,9 +25132,9 @@ mod tests {
         let token = JitCellToken::new(1503);
         backend.compile_loop(&inputargs, &ops, &token).unwrap();
 
-        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
+        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
         backend.execute_token(&token, &[Value::Ref(obj)]);
-        assert!(!unsafe { (*header_of(obj.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
+        assert!(!unsafe { (*header_of(obj.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
     }
 
     /// test_gc_integration.py test_malloc_1:

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -7324,7 +7324,7 @@ mod tests {
         // `mark_card` sets the same flag on the interpreter's object itself.
         for obj in [obj_immed, obj_reg] {
             unsafe {
-                (*majit_gc::header::header_of(obj.0)).set_flag(majit_gc::flags::CARDS_SET);
+                (*majit_gc::header::header_of(obj.0)).set_flag(majit_gc::flags::GCFLAG_CARDS_SET);
             }
         }
         for obj in [obj_immed, obj_reg, obj_interp] {

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1388,9 +1388,9 @@ fn emit_write_barrier(
         // its upper half (`FLAG_SHIFT == 32`), so on little-endian wasm32 the
         // flags live in the i32 at `obj - 4`; TRACK_YOUNG_PTRS is flag bit 0.
         const FLAGS_HALF_BACKOFS: i32 = (majit_gc::header::GcHeader::SIZE / 2) as i32;
-        const WB_FLAG: i32 = majit_gc::flags::TRACK_YOUNG_PTRS as i32;
+        const WB_FLAG: i32 = majit_gc::flags::GCFLAG_TRACK_YOUNG_PTRS as i32;
         const _: () = assert!(majit_gc::header::FLAG_SHIFT == 32);
-        const _: () = assert!(majit_gc::flags::TRACK_YOUNG_PTRS <= u32::MAX as u64);
+        const _: () = assert!(majit_gc::flags::GCFLAG_TRACK_YOUNG_PTRS <= u32::MAX as u64);
         emit_resolve(sink, constants, value_types, base_ref);
         sink.i32_wrap_i64();
         sink.i32_const(FLAGS_HALF_BACKOFS);

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -996,7 +996,7 @@ pub struct MiniMarkGC {
     /// True while [`do_collect_oldgen_nonmoving`](MiniMarkGC::do_collect_oldgen_nonmoving)
     /// is running. A non-moving major skips the leading minor, so unlike
     /// `do_collect_full` it marks through a *populated* nursery: `mark_object`
-    /// / `seed_major_root` set `flags::VISITED` on reachable nursery objects
+    /// / `seed_major_root` set `flags::GCFLAG_VISITED` on reachable nursery objects
     /// that no sweep then clears (the sweep only walks old-gen). While this is
     /// set, every *young* object greyed this cycle is recorded in
     /// `oldgen_nonmoving_young_marks` so VISITED can be cleared as the
@@ -1396,9 +1396,12 @@ impl MiniMarkGC {
             if self.card_page_shift > 0 && has_gc_ptrs_in_var && length > 0 {
                 let extra_words = self.card_marking_words_for_length(length);
                 let chs = 8 * extra_words; // WORD * extra_words
-                (chs, flags::HAS_CARDS | flags::TRACK_YOUNG_PTRS)
+                (
+                    chs,
+                    flags::GCFLAG_HAS_CARDS | flags::GCFLAG_TRACK_YOUNG_PTRS,
+                )
             } else {
-                (0, flags::TRACK_YOUNG_PTRS)
+                (0, flags::GCFLAG_TRACK_YOUNG_PTRS)
             };
 
         let ptr = self
@@ -2140,7 +2143,7 @@ impl MiniMarkGC {
     }
 
     /// Flags for an object born directly into the old generation, adding
-    /// `flags::VISITED` while a major marking cycle is in progress.
+    /// `flags::GCFLAG_VISITED` while a major marking cycle is in progress.
     ///
     /// An object allocated straight into the old generation during MARKING (a
     /// large object or nursery-full fallback) enters the still-active page/raw
@@ -2153,7 +2156,7 @@ impl MiniMarkGC {
     #[inline]
     fn oldgen_birth_flags(&self, base: u64) -> u64 {
         if self.gc_state == GcState::Marking {
-            base | flags::VISITED
+            base | flags::GCFLAG_VISITED
         } else {
             base
         }
@@ -2283,7 +2286,7 @@ impl MiniMarkGC {
                         slot as usize,
                         slot as usize - here,
                         self.nursery.contains(value),
-                        unsafe { (*header_of(here)).has_flag(flags::TRACK_YOUNG_PTRS) },
+                        unsafe { (*header_of(here)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) },
                         remembered,
                         crate::bh_probe_was_barriered(here),
                         parent.unwrap_or(0),
@@ -2445,7 +2448,7 @@ impl MiniMarkGC {
                                 .collect()
                         },
                         track_young_ptrs: unsafe {
-                            (*header_of(addr)).has_flag(flags::TRACK_YOUNG_PTRS)
+                            (*header_of(addr)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS)
                         },
                         remembered: self.remembered_set.contains(&addr),
                         barriered_ever: crate::bh_probe_was_barriered(addr),
@@ -2638,7 +2641,10 @@ impl MiniMarkGC {
         // Old objects start with TRACK_YOUNG_PTRS set (they need write barrier).
         // An object born into the old generation while a major marking cycle is
         // in progress must also be allocated black (see `oldgen_birth_flags`).
-        *hdr = GcHeader::with_flags(type_id, self.oldgen_birth_flags(flags::TRACK_YOUNG_PTRS));
+        *hdr = GcHeader::with_flags(
+            type_id,
+            self.oldgen_birth_flags(flags::GCFLAG_TRACK_YOUNG_PTRS),
+        );
         self.bytes_made_old_since_cycle =
             self.bytes_made_old_since_cycle.saturating_add(total_size);
         let obj_addr = (ptr as usize) + GcHeader::SIZE;
@@ -2833,10 +2839,10 @@ impl MiniMarkGC {
     /// freed at its end.
     fn visit_young_rawmalloced_object(&mut self, obj_addr: usize) {
         let hdr = unsafe { header_of(obj_addr) };
-        if unsafe { (*hdr).has_flag(flags::VISITED_RMY) } {
+        if unsafe { (*hdr).has_flag(flags::GCFLAG_VISITED_RMY) } {
             return;
         }
-        unsafe { (*hdr).set_flag(flags::VISITED_RMY) };
+        unsafe { (*hdr).set_flag(flags::GCFLAG_VISITED_RMY) };
         // incminimark.py:2280-2283 `size_objects_made_old`: the promotion is
         // where these bytes become old, so it is where the major-progress
         // accounting must see them.
@@ -2849,12 +2855,12 @@ impl MiniMarkGC {
         // incminimark.py:2285-2297. TRACK_YOUNG_PTRS is clear on every young
         // birth, so the first arm always runs; the remembered walk is what sets
         // the flag and forwards whatever nursery children the object holds.
-        if unsafe { !(*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
+        if unsafe { !(*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) } {
             self.remembered_set.push(obj_addr);
         }
-        if unsafe { (*hdr).has_flag(flags::HAS_CARDS) } {
+        if unsafe { (*hdr).has_flag(flags::GCFLAG_HAS_CARDS) } {
             debug_assert!(
-                unsafe { (*hdr).has_flag(flags::CARDS_SET) },
+                unsafe { (*hdr).has_flag(flags::GCFLAG_CARDS_SET) },
                 "young array: GCFLAG_HAS_CARDS without GCFLAG_CARDS_SET"
             );
             self.old_objects_with_cards_set.push(obj_addr);
@@ -2866,8 +2872,8 @@ impl MiniMarkGC {
         // filled, so black alone would leave its children unmarked. Mark it and
         // re-queue it gray, the way `drag_out_root` does for a root first seen
         // during MARKING.
-        if self.gc_state == GcState::Marking && unsafe { !(*hdr).has_flag(flags::VISITED) } {
-            unsafe { (*hdr).set_flag(flags::VISITED) };
+        if self.gc_state == GcState::Marking && unsafe { !(*hdr).has_flag(flags::GCFLAG_VISITED) } {
+            unsafe { (*hdr).set_flag(flags::GCFLAG_VISITED) };
             self.incr_state.more_gray_stack.push(obj_addr);
         }
     }
@@ -2939,7 +2945,7 @@ impl MiniMarkGC {
         if self.gc_state == GcState::Marking {
             for &obj_addr in &self.old_objects_pointing_to_pinned {
                 let hdr = unsafe { header_of(obj_addr) };
-                if unsafe { (*hdr).has_flag(flags::VISITED) } {
+                if unsafe { (*hdr).has_flag(flags::GCFLAG_VISITED) } {
                     self.incr_state.more_gray_stack.push(obj_addr);
                 }
             }
@@ -3120,7 +3126,7 @@ impl MiniMarkGC {
             let remembered_now: Vec<usize> = self.remembered_set.to_vec();
             for obj_addr in remembered_now {
                 let hdr = unsafe { header_of(obj_addr) };
-                if unsafe { (*hdr).has_flag(flags::VISITED) } {
+                if unsafe { (*hdr).has_flag(flags::GCFLAG_VISITED) } {
                     self.incr_state.more_gray_stack.push(obj_addr);
                 }
             }
@@ -3164,7 +3170,7 @@ impl MiniMarkGC {
 
                 // incminimark.py:2095-2098: re-set TRACK_YOUNG_PTRS.
                 unsafe {
-                    (*header_of(obj_addr)).set_flag(flags::TRACK_YOUNG_PTRS);
+                    (*header_of(obj_addr)).set_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
                 }
 
                 // Trace this old-gen object's fields and copy any nursery
@@ -3230,7 +3236,7 @@ impl MiniMarkGC {
                 // not reach is about to be freed and must lose it.
                 if oldgen.young_rawmalloced_contains(owner) {
                     let hdr = unsafe { header_of(owner) };
-                    return unsafe { (*hdr).has_flag(flags::VISITED_RMY) }.then_some(owner);
+                    return unsafe { (*hdr).has_flag(flags::GCFLAG_VISITED_RMY) }.then_some(owner);
                 }
                 return Some(owner);
             }
@@ -3238,8 +3244,8 @@ impl MiniMarkGC {
             let hdr = (owner - GcHeader::SIZE) as *const GcHeader;
             if unsafe {
                 !(*hdr).is_forwarded()
-                    && (*hdr).has_flag(flags::PINNED)
-                    && (*hdr).has_flag(flags::VISITED)
+                    && (*hdr).has_flag(flags::GCFLAG_PINNED)
+                    && (*hdr).has_flag(flags::GCFLAG_VISITED)
             } {
                 return Some(owner);
             }
@@ -3272,7 +3278,7 @@ impl MiniMarkGC {
                         // Safe because `pin` rejects types carrying GC
                         // pointers, as `record_pinned_object_with_shadow`
                         // requires before keeping the shadow black.
-                        unsafe { (*header_of(shadow_addr)).set_flag(flags::VISITED) };
+                        unsafe { (*header_of(shadow_addr)).set_flag(flags::GCFLAG_VISITED) };
                     }
                     new_shadows.insert(obj_addr, shadow_addr);
                 }
@@ -3314,7 +3320,7 @@ impl MiniMarkGC {
         // incminimark.py:1949-1951: the PINNED bit is reused on old objects as
         // PINNED_OBJECT_PARENT_KNOWN only within one minor collection.
         for &obj_addr in &self.old_objects_pointing_to_pinned {
-            unsafe { (*header_of(obj_addr)).clear_flag(flags::PINNED) };
+            unsafe { (*header_of(obj_addr)).clear_flag(flags::GCFLAG_PINNED_OBJECT_PARENT_KNOWN) };
         }
         self.refresh_published_nursery_top();
 
@@ -3394,7 +3400,7 @@ impl MiniMarkGC {
             // not change either way — so the surviving case updates nothing and
             // only hands the weakref to the next major cycle.
             if self.is_young_rawmalloced(pointing_to) {
-                if unsafe { (*header_of(pointing_to)).has_flag(flags::VISITED_RMY) } {
+                if unsafe { (*header_of(pointing_to)).has_flag(flags::GCFLAG_VISITED_RMY) } {
                     self.old_objects_with_weakrefs.push(new_obj);
                 } else {
                     unsafe { (*weakptr_slot).0 = 0 };
@@ -3438,7 +3444,7 @@ impl MiniMarkGC {
         debug_assert!(self.oldgen_nonmoving_active);
         for obj_addr in self.young_objects_with_weakrefs.iter().copied() {
             let weakref_hdr = unsafe { header_of(obj_addr) };
-            if unsafe { !(*weakref_hdr).has_flag(flags::VISITED) } {
+            if unsafe { !(*weakref_hdr).has_flag(flags::GCFLAG_VISITED) } {
                 continue;
             }
             let weakptr_slot = (obj_addr + crate::weakref::WEAKPTR_OFFSET) as *mut GcRef;
@@ -3448,8 +3454,8 @@ impl MiniMarkGC {
             }
             let target_hdr = unsafe { header_of(pointing_to) };
             if unsafe {
-                !(*target_hdr).has_flag(flags::VISITED)
-                    || (*target_hdr).has_flag(flags::FINALIZATION_ORDERING)
+                !(*target_hdr).has_flag(flags::GCFLAG_VISITED)
+                    || (*target_hdr).has_flag(flags::GCFLAG_FINALIZATION_ORDERING)
             } {
                 unsafe { (*weakptr_slot).0 = 0 };
             }
@@ -3543,7 +3549,9 @@ impl MiniMarkGC {
             return true;
         }
         let hdr = unsafe { header_of(obj) };
-        unsafe { (*hdr).has_flag(flags::VISITED) || (*hdr).has_flag(flags::NO_HEAP_PTRS) }
+        unsafe {
+            (*hdr).has_flag(flags::GCFLAG_VISITED) || (*hdr).has_flag(flags::GCFLAG_NO_HEAP_PTRS)
+        }
     }
 
     /// Mark what the C fields of a block whose own object survived reference.
@@ -3671,7 +3679,9 @@ impl MiniMarkGC {
             return false;
         }
         let hdr = unsafe { &*header_of(obj) };
-        !hdr.is_forwarded() && hdr.has_flag(flags::PINNED) && hdr.has_flag(flags::VISITED)
+        !hdr.is_forwarded()
+            && hdr.has_flag(flags::GCFLAG_PINNED)
+            && hdr.has_flag(flags::GCFLAG_VISITED)
     }
 
     fn rrc_young_object_alive(&self, obj: usize) -> bool {
@@ -3681,7 +3691,7 @@ impl MiniMarkGC {
         if self.is_young_rawmalloced(obj) {
             // incminimark.py:3300-3306: a young raw-malloced object survives
             // without moving, and GCFLAG_VISITED_RMY is what says so.
-            return unsafe { (*header_of(obj)).has_flag(flags::VISITED_RMY) };
+            return unsafe { (*header_of(obj)).has_flag(flags::GCFLAG_VISITED_RMY) };
         }
         if !self.is_nursery_object_start(obj) {
             return true;
@@ -3938,7 +3948,7 @@ impl MiniMarkGC {
         // a forwarding pointer. Its link already names its final address, so a
         // survivor only changes lists.
         if self.is_young_rawmalloced(obj) {
-            if unsafe { (*header_of(obj)).has_flag(flags::VISITED_RMY) } {
+            if unsafe { (*header_of(obj)).has_flag(flags::GCFLAG_VISITED_RMY) } {
                 match list {
                     RrcList::P => {
                         self.rrc.p_dict.insert(obj, mirror);
@@ -4126,7 +4136,10 @@ impl MiniMarkGC {
             true
         } else {
             let hdr = unsafe { header_of(obj) };
-            unsafe { (*hdr).has_flag(flags::VISITED) || (*hdr).has_flag(flags::NO_HEAP_PTRS) }
+            unsafe {
+                (*hdr).has_flag(flags::GCFLAG_VISITED)
+                    || (*hdr).has_flag(flags::GCFLAG_NO_HEAP_PTRS)
+            }
         };
         if alive {
             surviving.push(mirror);
@@ -4170,7 +4183,7 @@ impl MiniMarkGC {
                 // through `get_possibly_forwarded_tid` — the object may have
                 // been forwarded by an earlier root walk this collection.
                 let hdr = self.get_possibly_forwarded_header(obj_addr);
-                if unsafe { (*hdr).has_flag(flags::IGNORE_FINALIZER) } {
+                if unsafe { (*hdr).has_flag(flags::GCFLAG_IGNORE_FINALIZER) } {
                     continue;
                 }
                 let mut root = GcRef(obj_addr);
@@ -4181,7 +4194,7 @@ impl MiniMarkGC {
                     continue;
                 }
                 let hdr = unsafe { header_of(obj_addr) };
-                if unsafe { (*hdr).has_flag(flags::IGNORE_FINALIZER) } {
+                if unsafe { (*hdr).has_flag(flags::GCFLAG_IGNORE_FINALIZER) } {
                     continue;
                 }
                 // incminimark.py:1838-1841 "they all survive": a registered
@@ -4220,7 +4233,7 @@ impl MiniMarkGC {
             // `free_young_rawmalloced_objects` reads the same flag a few steps
             // after it.
             if self.is_young_rawmalloced(obj_addr) {
-                if unsafe { (*header_of(obj_addr)).has_flag(flags::VISITED_RMY) } {
+                if unsafe { (*header_of(obj_addr)).has_flag(flags::GCFLAG_VISITED_RMY) } {
                     // Promoted in place: the address does not change, so the
                     // old-generation list takes it unchanged.
                     self.old_objects_with_destructors.push(obj_addr);
@@ -4267,21 +4280,21 @@ impl MiniMarkGC {
             // every other old-gen object — the write barrier tracks it through
             // that flag. (The source header was copied from the nursery object,
             // which does not carry it.)
-            (*(shadow_hdr_ptr as *mut GcHeader)).set_flag(flags::TRACK_YOUNG_PTRS);
+            (*(shadow_hdr_ptr as *mut GcHeader)).set_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
             // A shadow reserved during marking is an old-gen object subject to
             // this cycle's future sweep; keep it black so marking does not
             // reclaim the reserved identity home before the object is copied in
             // (incminimark.py record_pinned_object_with_shadow). See
             // `oldgen_birth_flags`.
             if self.gc_state == GcState::Marking {
-                (*(shadow_hdr_ptr as *mut GcHeader)).set_flag(flags::VISITED);
+                (*(shadow_hdr_ptr as *mut GcHeader)).set_flag(flags::GCFLAG_VISITED);
             }
             if item_size > 0 {
                 *((shadow_obj + length_offset) as *mut usize) =
                     *((obj_addr + length_offset) as *const usize);
             }
             let nursery_hdr = (obj_addr - GcHeader::SIZE) as *mut GcHeader;
-            (*nursery_hdr).set_flag(flags::HAS_SHADOW);
+            (*nursery_hdr).set_flag(flags::GCFLAG_HAS_SHADOW);
         }
         self.nursery_objects_shadows.insert(obj_addr, shadow_obj);
         shadow_obj
@@ -4300,7 +4313,7 @@ impl MiniMarkGC {
             !hdr.is_forwarded(),
             "stale pointer into the nursery: find_shadow reached a forwarded header at {obj_addr:#x}"
         );
-        if hdr.has_flag(flags::HAS_SHADOW) {
+        if hdr.has_flag(flags::GCFLAG_HAS_SHADOW) {
             // incminimark.py:2855-2857 `ll_assert(shadow != NULL,
             // "GCFLAG_HAS_SHADOW but no shadow found")`.  HAS_SHADOW
             // guarantees the map holds the shadow; a missing entry is a GC
@@ -4329,10 +4342,10 @@ impl MiniMarkGC {
         }
         let shadow = self.find_shadow(obj_addr);
         let hdr = unsafe { header_of(obj_addr) };
-        if unsafe { (*hdr).has_flag(flags::SHADOW_INITIALIZED) } {
+        if unsafe { (*hdr).has_flag(flags::GCFLAG_SHADOW_INITIALIZED) } {
             return shadow;
         }
-        unsafe { (*hdr).set_flag(flags::SHADOW_INITIALIZED) };
+        unsafe { (*hdr).set_flag(flags::GCFLAG_SHADOW_INITIALIZED) };
         let type_id = unsafe { (*hdr).type_id() };
         let payload_size = self.size_for_typeid(obj_addr, type_id, "move_out_of_nursery");
         // Payload only: `allocate_shadow` already wrote the shadow's own header
@@ -4505,7 +4518,7 @@ impl MiniMarkGC {
         // `IncrementalMiniMarkGC._trace_drag_out`: pin state lives on the
         // object header. Pinning is not a root; append the header address to
         // the survivor AddressStack only when a real traced edge reaches it.
-        if unsafe { (*hdr_ptr).has_flag(flags::PINNED) } {
+        if unsafe { (*hdr_ptr).has_flag(flags::GCFLAG_PINNED) } {
             // incminimark.py:2194-2199 records an old parent. The list outlives
             // the nursery reset at the end of this minor and is dereferenced in
             // the next one, so a nursery holder would become a read of recycled
@@ -4515,16 +4528,16 @@ impl MiniMarkGC {
                 && !self.is_in_nursery(holder_addr)
             {
                 let holder_hdr = unsafe { header_of(holder_addr) };
-                if unsafe { !(*holder_hdr).has_flag(flags::PINNED) } {
+                if unsafe { !(*holder_hdr).has_flag(flags::GCFLAG_PINNED_OBJECT_PARENT_KNOWN) } {
                     self.old_objects_pointing_to_pinned.push(holder_addr);
                     self.updated_old_objects_pointing_to_pinned = true;
-                    unsafe { (*holder_hdr).set_flag(flags::PINNED) };
+                    unsafe { (*holder_hdr).set_flag(flags::GCFLAG_PINNED_OBJECT_PARENT_KNOWN) };
                 }
             }
-            if unsafe { (*hdr_ptr).has_flag(flags::VISITED) } {
+            if unsafe { (*hdr_ptr).has_flag(flags::GCFLAG_VISITED) } {
                 return GcRef(obj_addr);
             }
-            unsafe { (*hdr_ptr).set_flag(flags::VISITED) };
+            unsafe { (*hdr_ptr).set_flag(flags::GCFLAG_VISITED) };
             self.surviving_pinned_objects
                 .push(obj_addr - GcHeader::SIZE);
             self.pinned_objects_in_nursery += 1;
@@ -4607,7 +4620,7 @@ impl MiniMarkGC {
         // shadow (from id() or identityhash()), copy into it instead
         // of a fresh allocation.
         let header_ptr = obj_addr - GcHeader::SIZE;
-        let new_header_ptr = if unsafe { (*hdr_ptr).has_flag(flags::HAS_SHADOW) } {
+        let new_header_ptr = if unsafe { (*hdr_ptr).has_flag(flags::GCFLAG_HAS_SHADOW) } {
             // incminimark.py:2213-2214 `ll_assert(newobj != NULL,
             // "GCFLAG_HAS_SHADOW but no shadow found")` — HAS_SHADOW
             // guarantees the shadow map entry exists.
@@ -4622,7 +4635,7 @@ impl MiniMarkGC {
             // incremental cycle could reclaim it (see test_pin_id_bug).
             // Remember VISITED and re-apply it after the copy.
             let shadow_was_visited =
-                unsafe { (*(shadow_hdr as *const GcHeader)).has_flag(flags::VISITED) };
+                unsafe { (*(shadow_hdr as *const GcHeader)).has_flag(flags::GCFLAG_VISITED) };
             // incminimark.py `_trace_drag_out`: `if (tid &
             // GCFLAG_SHADOW_INITIALIZED) != 0: copy = False`.
             // `move_out_of_nursery` has already filled this shadow, and its
@@ -4630,17 +4643,18 @@ impl MiniMarkGC {
             // merely redundant: HAS_SHADOW and SHADOW_INITIALIZED "have no
             // meaning in non-nursery objects", so the second copy is what would
             // carry the nursery flag word onto an object that has the right one.
-            let shadow_initialized = unsafe { (*hdr_ptr).has_flag(flags::SHADOW_INITIALIZED) };
+            let shadow_initialized =
+                unsafe { (*hdr_ptr).has_flag(flags::GCFLAG_SHADOW_INITIALIZED) };
             // minimark.py:1518-1520: clear HAS_SHADOW before copy so the
             // flag does not propagate to the shadow object itself.
-            unsafe { (*hdr_ptr).clear_flag(flags::HAS_SHADOW) };
+            unsafe { (*hdr_ptr).clear_flag(flags::GCFLAG_HAS_SHADOW) };
             if !shadow_initialized {
                 unsafe {
                     std::ptr::copy_nonoverlapping(header_ptr as *const u8, shadow_hdr, total_size);
                 }
             }
             if shadow_was_visited {
-                unsafe { (*(shadow_hdr as *mut GcHeader)).set_flag(flags::VISITED) };
+                unsafe { (*(shadow_hdr as *mut GcHeader)).set_flag(flags::GCFLAG_VISITED) };
                 // The copy above replaced every field of an object the marker
                 // has already accounted for as black, and the incoming values
                 // are this cycle's first sight of them: the shadow was reserved
@@ -4682,7 +4696,7 @@ impl MiniMarkGC {
         // copied from the nursery object, which does not carry it.)
         unsafe {
             let h = new_header_ptr as *mut GcHeader;
-            (*h).set_flag(flags::TRACK_YOUNG_PTRS);
+            (*h).set_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
         }
 
         // Install forwarding pointer in the nursery copy.
@@ -4696,7 +4710,7 @@ impl MiniMarkGC {
             // Clear TRACK_YOUNG_PTRS temporarily so the processing loop
             // can re-set it after processing.
             unsafe {
-                (*(new_header_ptr as *mut GcHeader)).clear_flag(flags::TRACK_YOUNG_PTRS);
+                (*(new_header_ptr as *mut GcHeader)).clear_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
             }
             self.remembered_set.push(new_obj_addr);
             if crate::gc_lifetime_log_enabled() {
@@ -4777,8 +4791,10 @@ impl MiniMarkGC {
         // walk performs no address-table lookup at all.
         if self.gc_state == GcState::Marking && self.is_managed_heap_object(gcref.0) {
             let hdr = unsafe { header_of(gcref.0) };
-            if unsafe { !(*hdr).has_flag(flags::VISITED) && !(*hdr).has_flag(flags::PINNED) } {
-                unsafe { (*hdr).set_flag(flags::VISITED) };
+            if unsafe {
+                !(*hdr).has_flag(flags::GCFLAG_VISITED) && !(*hdr).has_flag(flags::GCFLAG_PINNED)
+            } {
+                unsafe { (*hdr).set_flag(flags::GCFLAG_VISITED) };
                 self.incr_state.more_gray_stack.push(gcref.0);
                 self.note_nonmoving_young_mark(gcref.0);
             }
@@ -5009,8 +5025,8 @@ impl MiniMarkGC {
         // SAFETY: header_of returns a raw pointer; keep each access
         // short-lived to avoid creating overlapping exclusive borrows.
         let newly_marked = unsafe {
-            if !(*hdr).has_flag(flags::VISITED) {
-                (*hdr).set_flag(flags::VISITED);
+            if !(*hdr).has_flag(flags::GCFLAG_VISITED) {
+                (*hdr).set_flag(flags::GCFLAG_VISITED);
                 true
             } else {
                 false
@@ -5028,8 +5044,10 @@ impl MiniMarkGC {
             // mutator barrier. Arm this newly seeded old root in the
             // existing old_objects_pointing_to_young shape once, so that
             // minor forwards any such spill before resetting nursery.
-            if !self.is_in_nursery(gcref.0) && unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
-                unsafe { (*hdr).clear_flag(flags::TRACK_YOUNG_PTRS) };
+            if !self.is_in_nursery(gcref.0)
+                && unsafe { (*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) }
+            {
+                unsafe { (*hdr).clear_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) };
                 self.remembered_set.push(gcref.0);
                 if crate::gc_lifetime_log_enabled() {
                     eprintln!(
@@ -5073,7 +5091,7 @@ impl MiniMarkGC {
     }
 
     /// Record a *young* object greyed during a non-moving major so its stale
-    /// `flags::VISITED` is cleared as the strictly-last collection step.
+    /// `flags::GCFLAG_VISITED` is cleared as the strictly-last collection step.
     /// No-op (just two range checks) outside a non-moving major; the normal
     /// incremental path runs after a minor, so nothing young survives to here.
     ///
@@ -5269,11 +5287,11 @@ impl MiniMarkGC {
     /// incminimark.py `prebuilt_root_objects.foreach(_collect_obj)`.
     fn seed_prebuilt_root(&mut self, addr: usize) {
         let hdr = unsafe { header_of(addr) };
-        debug_assert!(unsafe { !(*hdr).has_flag(flags::NO_HEAP_PTRS) });
-        if unsafe { !(*hdr).has_flag(flags::VISITED) } {
+        debug_assert!(unsafe { !(*hdr).has_flag(flags::GCFLAG_NO_HEAP_PTRS) });
+        if unsafe { !(*hdr).has_flag(flags::GCFLAG_VISITED) } {
             unsafe {
-                (*hdr).set_flag(flags::VISITED);
-                (*hdr).set_flag(flags::TRACK_YOUNG_PTRS);
+                (*hdr).set_flag(flags::GCFLAG_VISITED);
+                (*hdr).set_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
             }
             self.incr_state.gray_stack.push(addr);
         }
@@ -5432,10 +5450,10 @@ impl MiniMarkGC {
                 continue;
             }
             let hdr = unsafe { header_of(gcref.0) };
-            if unsafe { (*hdr).has_flag(flags::EXTRA) } {
+            if unsafe { (*hdr).has_flag(flags::GCFLAG_EXTRA) } {
                 continue;
             }
-            unsafe { (*hdr).set_flag(flags::EXTRA) };
+            unsafe { (*hdr).set_flag(flags::GCFLAG_EXTRA) };
             let is_requested_generation = match generation {
                 -1 => true,
                 // Youth, not nursery residency: a young raw-malloced object is
@@ -5447,7 +5465,7 @@ impl MiniMarkGC {
             };
             let type_id = unsafe { (*hdr).type_id() };
             if is_requested_generation
-                && !unsafe { (*hdr).has_flag(flags::DUMMY) }
+                && !unsafe { (*hdr).has_flag(flags::GCFLAG_DUMMY) }
                 && self.types.get(type_id).is_object
                 && !self.types.get(type_id).hide_from_app_level_inspector
             {
@@ -5464,10 +5482,10 @@ impl MiniMarkGC {
                 continue;
             }
             let hdr = unsafe { header_of(gcref.0) };
-            if unsafe { !(*hdr).has_flag(flags::EXTRA) } {
+            if unsafe { !(*hdr).has_flag(flags::GCFLAG_EXTRA) } {
                 continue;
             }
-            unsafe { (*hdr).clear_flag(flags::EXTRA) };
+            unsafe { (*hdr).clear_flag(flags::GCFLAG_EXTRA) };
             self.visit_referents(gcref.0, &mut |child| pending.push(child));
         }
         for gcref in result {
@@ -5635,10 +5653,10 @@ impl MiniMarkGC {
             return;
         }
         let hdr = unsafe { header_of(obj.0) };
-        if unsafe { (*hdr).has_flag(flags::EXTRA) } {
+        if unsafe { (*hdr).has_flag(flags::GCFLAG_EXTRA) } {
             return;
         }
-        unsafe { (*hdr).set_flag(flags::EXTRA) };
+        unsafe { (*hdr).set_flag(flags::GCFLAG_EXTRA) };
         pending.push(obj);
     }
 
@@ -5668,10 +5686,10 @@ impl MiniMarkGC {
                 continue;
             }
             let hdr = unsafe { header_of(obj.0) };
-            if unsafe { !(*hdr).has_flag(flags::EXTRA) } {
+            if unsafe { !(*hdr).has_flag(flags::GCFLAG_EXTRA) } {
                 continue;
             }
-            unsafe { (*hdr).clear_flag(flags::EXTRA) };
+            unsafe { (*hdr).clear_flag(flags::GCFLAG_EXTRA) };
             self.visit_referents(obj.0, &mut |child| pending.push(child));
         }
     }
@@ -5692,7 +5710,7 @@ impl MiniMarkGC {
         // object however its type reads.  Only a managed object carries the
         // header the flag lives in.
         if self.is_managed_heap_object(obj.0)
-            && unsafe { (*header_of(obj.0)).has_flag(flags::DUMMY) }
+            && unsafe { (*header_of(obj.0)).has_flag(flags::GCFLAG_DUMMY) }
         {
             return false;
         }
@@ -5720,7 +5738,7 @@ impl MiniMarkGC {
             return true;
         }
         if !self.is_managed_heap_object(obj.0)
-            || unsafe { (*header_of(obj.0)).has_flag(flags::DUMMY) }
+            || unsafe { (*header_of(obj.0)).has_flag(flags::GCFLAG_DUMMY) }
         {
             return false;
         }
@@ -5767,10 +5785,10 @@ impl MiniMarkGC {
                 }
                 if self.is_managed_heap_object(child.0) {
                     let hdr = unsafe { header_of(child.0) };
-                    if unsafe { (*hdr).has_flag(flags::EXTRA) } {
+                    if unsafe { (*hdr).has_flag(flags::GCFLAG_EXTRA) } {
                         continue;
                     }
-                    unsafe { (*hdr).set_flag(flags::EXTRA) };
+                    unsafe { (*hdr).set_flag(flags::GCFLAG_EXTRA) };
                 } else if pending.contains(&child) {
                     // RPython toggles GCFLAG_EXTRA on prebuilt objects too.
                     // Pyre's foreign wrappers have no GC header, so the same
@@ -5798,7 +5816,7 @@ impl MiniMarkGC {
         }
         for gcref in &pending {
             if self.is_managed_heap_object(gcref.0) {
-                unsafe { (*header_of(gcref.0)).clear_flag(flags::EXTRA) };
+                unsafe { (*header_of(gcref.0)).clear_flag(flags::GCFLAG_EXTRA) };
             }
         }
         for gcref in result {
@@ -6009,11 +6027,11 @@ impl MiniMarkGC {
             "object in nursery after collection at {obj_addr:#x}"
         );
         assert!(
-            !hdr.has_flag(flags::VISITED_RMY),
+            !hdr.has_flag(flags::GCFLAG_VISITED_RMY),
             "GCFLAG_VISITED_RMY after collection at {obj_addr:#x}"
         );
         assert!(
-            !hdr.has_flag(flags::PINNED),
+            !hdr.has_flag(flags::GCFLAG_PINNED),
             "GCFLAG_PINNED outside the nursery after collection at {obj_addr:#x}"
         );
     }
@@ -6341,8 +6359,8 @@ impl MiniMarkGC {
                     self.major_collections,
                 );
             }
-            if unsafe { !(*hdr).has_flag(flags::VISITED) } {
-                unsafe { (*hdr).set_flag(flags::VISITED) };
+            if unsafe { !(*hdr).has_flag(flags::GCFLAG_VISITED) } {
+                unsafe { (*hdr).set_flag(flags::GCFLAG_VISITED) };
                 self.incr_state.gray_stack.push(addr);
                 self.note_nonmoving_young_mark(addr);
             }
@@ -6382,12 +6400,12 @@ impl MiniMarkGC {
                 !unsafe { (*header_of(obj_addr)).is_forwarded() },
                 "stale major worklist entry: forwarded header at {obj_addr:#x}"
             );
-            if unsafe { (*header_of(obj_addr)).has_flag(flags::HAS_SHADOW) } {
+            if unsafe { (*header_of(obj_addr)).has_flag(flags::GCFLAG_HAS_SHADOW) } {
                 let shadow_obj = *self
                     .nursery_objects_shadows
                     .get(&obj_addr)
                     .expect("GCFLAG_HAS_SHADOW but no shadow found");
-                unsafe { (*header_of(shadow_obj)).set_flag(flags::VISITED) };
+                unsafe { (*header_of(shadow_obj)).set_flag(flags::GCFLAG_VISITED) };
             }
         }
         let custom_trace;
@@ -6476,7 +6494,7 @@ impl MiniMarkGC {
     fn rescan_remembered_black_and_drain(&mut self) {
         let snapshot: Vec<usize> = self.remembered_set.to_vec();
         for addr in snapshot {
-            if unsafe { (*header_of(addr)).has_flag(flags::VISITED) } {
+            if unsafe { (*header_of(addr)).has_flag(flags::GCFLAG_VISITED) } {
                 self.incr_state.gray_stack.push(addr);
             }
         }
@@ -6523,7 +6541,7 @@ impl MiniMarkGC {
             // marks it without queueing it.
             let regray = !self.is_in_nursery(gcref.0)
                 && self.is_managed_heap_object(gcref.0)
-                && unsafe { (*header_of(gcref.0)).has_flag(flags::VISITED) };
+                && unsafe { (*header_of(gcref.0)).has_flag(flags::GCFLAG_VISITED) };
             if regray {
                 self.incr_state.gray_stack.push(gcref.0);
             } else {
@@ -6561,7 +6579,7 @@ impl MiniMarkGC {
                     return Some(owner);
                 }
                 let hdr = unsafe { header_of(owner) };
-                unsafe { (*hdr).has_flag(flags::VISITED) }.then_some(owner)
+                unsafe { (*hdr).has_flag(flags::GCFLAG_VISITED) }.then_some(owner)
             };
             let roots = crate::shadow_stack::mark_ephemeron_tables(&mut classify_owner);
             for root in roots {
@@ -6645,9 +6663,9 @@ impl MiniMarkGC {
         // minor does not trace freed memory. A no-op for do_collect_full, whose
         // leading minor already drained both sets.
         self.remembered_set
-            .retain(|&addr| unsafe { (*header_of(addr)).has_flag(flags::VISITED) });
+            .retain(|&addr| unsafe { (*header_of(addr)).has_flag(flags::GCFLAG_VISITED) });
         self.old_objects_with_cards_set
-            .retain(|&addr| unsafe { (*header_of(addr)).has_flag(flags::VISITED) });
+            .retain(|&addr| unsafe { (*header_of(addr)).has_flag(flags::GCFLAG_VISITED) });
         // Embedder side tables keyed by owner address hold their value as a
         // root, so an entry outlives its owner unless it is dropped here —
         // the same "the target died" question `invalidate_old_weakrefs` just
@@ -6660,7 +6678,7 @@ impl MiniMarkGC {
                 return Some(owner);
             }
             let hdr = unsafe { header_of(owner) };
-            if unsafe { (*hdr).has_flag(flags::VISITED) } {
+            if unsafe { (*hdr).has_flag(flags::GCFLAG_VISITED) } {
                 Some(owner)
             } else {
                 None
@@ -6705,7 +6723,7 @@ impl MiniMarkGC {
         // stack before arena sweep invalidates their addresses. Survivors have
         // VISITED set at this point; the oldgen sweep clears it later.
         self.old_objects_pointing_to_pinned
-            .retain(|&obj_addr| unsafe { (*header_of(obj_addr)).has_flag(flags::VISITED) });
+            .retain(|&obj_addr| unsafe { (*header_of(obj_addr)).has_flag(flags::GCFLAG_VISITED) });
         self.updated_old_objects_pointing_to_pinned = true;
         // incminimark.py:2528-2529 — VISITED still distinguishes survivors, so
         // this is where each mirror learns whether its object made it.
@@ -6764,7 +6782,7 @@ impl MiniMarkGC {
         // incminimark.py:2563-2564: prebuilt objects are outside the arena
         // sweep, so reset their mark bit explicitly for the next cycle.
         for &addr in &self.prebuilt_root_objects {
-            unsafe { (*header_of(addr)).clear_flag(flags::VISITED) };
+            unsafe { (*header_of(addr)).clear_flag(flags::GCFLAG_VISITED) };
         }
         // incminimark.py:2566-2577 — set the threshold for the next major
         // collection to `major_collection_threshold` times the surviving
@@ -6905,7 +6923,7 @@ impl MiniMarkGC {
         for obj_addr in entries {
             let hdr_ptr = (obj_addr - GcHeader::SIZE) as *const GcHeader;
             // incminimark.py:3112: weakref itself not marked → dies.
-            if unsafe { !(*hdr_ptr).has_flag(flags::VISITED) } {
+            if unsafe { !(*hdr_ptr).has_flag(flags::GCFLAG_VISITED) } {
                 continue;
             }
             let weakptr_slot = (obj_addr + crate::weakref::WEAKPTR_OFFSET) as *mut GcRef;
@@ -6930,8 +6948,8 @@ impl MiniMarkGC {
             // their weakrefs observe death before `__del__` runs.
             let target_hdr = (pointing_to - GcHeader::SIZE) as *const GcHeader;
             if unsafe {
-                (*target_hdr).has_flag(flags::VISITED)
-                    && !(*target_hdr).has_flag(flags::FINALIZATION_ORDERING)
+                (*target_hdr).has_flag(flags::GCFLAG_VISITED)
+                    && !(*target_hdr).has_flag(flags::GCFLAG_FINALIZATION_ORDERING)
             } {
                 new_with_weakref.push(obj_addr);
             } else {
@@ -6943,8 +6961,8 @@ impl MiniMarkGC {
 
     fn finalization_state(&self, obj_addr: usize) -> u8 {
         let hdr = unsafe { header_of(obj_addr) };
-        let visited = unsafe { (*hdr).has_flag(flags::VISITED) };
-        let ordering = unsafe { (*hdr).has_flag(flags::FINALIZATION_ORDERING) };
+        let visited = unsafe { (*hdr).has_flag(flags::GCFLAG_VISITED) };
+        let ordering = unsafe { (*hdr).has_flag(flags::GCFLAG_FINALIZATION_ORDERING) };
         match (visited, ordering) {
             (false, false) => 0,
             (false, true) => 1,
@@ -6994,7 +7012,7 @@ impl MiniMarkGC {
         let mut pending = vec![obj_addr];
         while let Some(addr) = pending.pop() {
             if self.finalization_state(addr) == 2 {
-                unsafe { (*header_of(addr)).clear_flag(flags::FINALIZATION_ORDERING) };
+                unsafe { (*header_of(addr)).clear_flag(flags::GCFLAG_FINALIZATION_ORDERING) };
                 pending.extend(self.finalizer_children(addr));
             }
         }
@@ -7034,10 +7052,10 @@ impl MiniMarkGC {
 
         while let Some((obj_addr, fq_index)) = self.old_objects_with_finalizers.pop_front() {
             let hdr = unsafe { header_of(obj_addr) };
-            if unsafe { (*hdr).has_flag(flags::IGNORE_FINALIZER) } {
+            if unsafe { (*hdr).has_flag(flags::GCFLAG_IGNORE_FINALIZER) } {
                 continue;
             }
-            if unsafe { (*hdr).has_flag(flags::VISITED) } {
+            if unsafe { (*hdr).has_flag(flags::GCFLAG_VISITED) } {
                 new_with_finalizer.push_back((obj_addr, fq_index));
                 continue;
             }
@@ -7047,7 +7065,7 @@ impl MiniMarkGC {
             while let Some(addr) = pending.pop() {
                 match self.finalization_state(addr) {
                     0 => {
-                        unsafe { (*header_of(addr)).set_flag(flags::FINALIZATION_ORDERING) };
+                        unsafe { (*header_of(addr)).set_flag(flags::GCFLAG_FINALIZATION_ORDERING) };
                         // incminimark.py:3011-3020
                         //
                         // Upstream reaches this seam only after a minor has
@@ -7130,7 +7148,7 @@ impl MiniMarkGC {
         let mut new_objects = Vec::with_capacity(entries.len());
         for obj_addr in entries {
             let hdr_ptr = (obj_addr - GcHeader::SIZE) as *const GcHeader;
-            if unsafe { (*hdr_ptr).has_flag(flags::VISITED) } {
+            if unsafe { (*hdr_ptr).has_flag(flags::GCFLAG_VISITED) } {
                 // surviving
                 new_objects.push(obj_addr);
             } else {
@@ -7341,7 +7359,7 @@ impl MiniMarkGC {
     /// fully followed and the target old object is marked before the sweep.
     ///
     /// Unlike a moving minor, nursery survivors keep their addresses, so a
-    /// `flags::VISITED` set on a marked-through nursery object would otherwise
+    /// `flags::GCFLAG_VISITED` set on a marked-through nursery object would otherwise
     /// survive into the next minor's promoted copy (`copy_nursery_object`
     /// memcpys the header verbatim). The strictly-last step clears VISITED on
     /// exactly the nursery objects greyed this cycle — after
@@ -7394,7 +7412,7 @@ impl MiniMarkGC {
             // already cleared.
             if self.is_in_nursery(addr) || self.is_young_rawmalloced(addr) {
                 let hdr = unsafe { header_of(addr) };
-                unsafe { (*hdr).clear_flag(flags::VISITED) };
+                unsafe { (*hdr).clear_flag(flags::GCFLAG_VISITED) };
             }
         }
     }
@@ -7473,7 +7491,7 @@ impl MiniMarkGC {
         }
         if self.is_managed_heap_object(obj.0) {
             let hdr = unsafe { header_of(obj.0) };
-            if unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
+            if unsafe { (*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) } {
                 self.remember_young_pointer(obj);
             }
             return;
@@ -7490,7 +7508,7 @@ impl MiniMarkGC {
         let Some(hdr) = self.registered_external_header(obj.0) else {
             return;
         };
-        if unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
+        if unsafe { (*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) } {
             self.remember_young_pointer(obj);
         }
     }
@@ -7504,7 +7522,7 @@ impl MiniMarkGC {
             return;
         }
         let hdr = unsafe { header_of(obj.0) };
-        if unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
+        if unsafe { (*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) } {
             self.remember_young_pointer(obj);
         }
     }
@@ -7534,9 +7552,9 @@ impl MiniMarkGC {
             );
         }
         unsafe {
-            (*hdr).clear_flag(flags::TRACK_YOUNG_PTRS);
-            if (*hdr).has_flag(flags::NO_HEAP_PTRS) {
-                (*hdr).clear_flag(flags::NO_HEAP_PTRS);
+            (*hdr).clear_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
+            if (*hdr).has_flag(flags::GCFLAG_NO_HEAP_PTRS) {
+                (*hdr).clear_flag(flags::GCFLAG_NO_HEAP_PTRS);
                 self.prebuilt_root_objects.push(obj.0);
             }
         }
@@ -7553,7 +7571,7 @@ impl MiniMarkGC {
             return;
         }
         let hdr = unsafe { header_of(obj.0) };
-        if unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
+        if unsafe { (*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) } {
             self.remember_young_pointer_from_array2(obj, index, card_page_shift);
         }
     }
@@ -7569,7 +7587,7 @@ impl MiniMarkGC {
         card_page_shift: u32,
     ) {
         let hdr = unsafe { header_of(obj.0) };
-        if unsafe { !(*hdr).has_flag(flags::HAS_CARDS) } {
+        if unsafe { !(*hdr).has_flag(flags::GCFLAG_HAS_CARDS) } {
             // No cards — fall back to the generic _remember_young_pointer_inlined.
             self.remember_young_pointer(obj);
             return;
@@ -7585,10 +7603,10 @@ impl MiniMarkGC {
     /// back to remember_young_pointer (generic barrier).
     pub fn jit_remember_young_pointer_from_array(&mut self, obj: GcRef) {
         let hdr = unsafe { header_of(obj.0) };
-        if unsafe { (*hdr).has_flag(flags::HAS_CARDS) } {
+        if unsafe { (*hdr).has_flag(flags::GCFLAG_HAS_CARDS) } {
             // incminimark.py:1614-1615
             self.old_objects_with_cards_set.push(obj.0);
-            unsafe { (*hdr).set_flag(flags::CARDS_SET) };
+            unsafe { (*hdr).set_flag(flags::GCFLAG_CARDS_SET) };
         } else {
             // No cards: the JIT already passed the inline flag test, so use
             // the corresponding remember_young_pointer path.
@@ -7632,34 +7650,35 @@ impl MiniMarkGC {
         let dest_hdr = unsafe { header_of(dest_addr) };
         // The fast path of the write barrier: a destination already on the
         // remembered set needs nothing more.
-        if unsafe { !(*dest_hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
+        if unsafe { !(*dest_hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) } {
             return true;
         }
 
-        if self.config.card_page_indices > 0 && unsafe { (*source_hdr).has_flag(flags::HAS_CARDS) }
+        if self.config.card_page_indices > 0
+            && unsafe { (*source_hdr).has_flag(flags::GCFLAG_HAS_CARDS) }
         {
-            if unsafe { !(*source_hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
+            if unsafe { !(*source_hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) } {
                 // "The source object may have random young pointers."
                 return false;
             }
-            if unsafe { !(*dest_hdr).has_flag(flags::HAS_CARDS) } {
+            if unsafe { !(*dest_hdr).has_flag(flags::GCFLAG_HAS_CARDS) } {
                 // "The dest object doesn't have cards.  Do it manually."
                 return false;
             }
             debug_assert!(
-                unsafe { !(*dest_hdr).has_flag(flags::NO_HEAP_PTRS) },
+                unsafe { !(*dest_hdr).has_flag(flags::GCFLAG_NO_HEAP_PTRS) },
                 "prebuilt object with cards is not supported"
             );
-            if unsafe { !(*source_hdr).has_flag(flags::CARDS_SET) } {
+            if unsafe { !(*source_hdr).has_flag(flags::GCFLAG_CARDS_SET) } {
                 // The source has no young pointers at all, so no card needs
                 // marking.  A black destination still has to go gray and be
                 // rescanned, which is what `collect_cardrefs_to_nursery` reads
                 // CARDS_SET for at the end of a marking step.
                 if self.gc_state == GcState::Marking
-                    && unsafe { !(*dest_hdr).has_flag(flags::CARDS_SET) }
+                    && unsafe { !(*dest_hdr).has_flag(flags::GCFLAG_CARDS_SET) }
                 {
                     self.old_objects_with_cards_set.push(dest_addr);
-                    unsafe { (*dest_hdr).set_flag(flags::CARDS_SET) };
+                    unsafe { (*dest_hdr).set_flag(flags::GCFLAG_CARDS_SET) };
                 }
                 return true;
             }
@@ -7676,16 +7695,16 @@ impl MiniMarkGC {
         // barrier is also what turns a black object gray again, so a source
         // that already lost the flag can still hold pointers this copy must
         // report.
-        if unsafe { !(*source_hdr).has_flag(flags::TRACK_YOUNG_PTRS) }
+        if unsafe { !(*source_hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) }
             || self.gc_state == GcState::Marking
         {
             self.remember_young_pointer(GcRef(dest_addr));
         }
 
-        if unsafe { (*dest_hdr).has_flag(flags::NO_HEAP_PTRS) }
-            && unsafe { !(*source_hdr).has_flag(flags::NO_HEAP_PTRS) }
+        if unsafe { (*dest_hdr).has_flag(flags::GCFLAG_NO_HEAP_PTRS) }
+            && unsafe { !(*source_hdr).has_flag(flags::GCFLAG_NO_HEAP_PTRS) }
         {
-            unsafe { (*dest_hdr).clear_flag(flags::NO_HEAP_PTRS) };
+            unsafe { (*dest_hdr).clear_flag(flags::GCFLAG_NO_HEAP_PTRS) };
             self.prebuilt_root_objects.push(dest_addr);
         }
         true
@@ -7719,7 +7738,7 @@ impl MiniMarkGC {
             return;
         }
         let hdr = unsafe { header_of(array_addr) };
-        if unsafe { (*hdr).has_flag(flags::CARDS_SET) } {
+        if unsafe { (*hdr).has_flag(flags::GCFLAG_CARDS_SET) } {
             self.do_write_barrier(GcRef(array_addr));
         }
     }
@@ -7739,9 +7758,9 @@ impl MiniMarkGC {
         }
         if anybyte != 0 {
             let dest_hdr = unsafe { header_of(dest_addr) };
-            if unsafe { !(*dest_hdr).has_flag(flags::CARDS_SET) } {
+            if unsafe { !(*dest_hdr).has_flag(flags::GCFLAG_CARDS_SET) } {
                 self.old_objects_with_cards_set.push(dest_addr);
-                unsafe { (*dest_hdr).set_flag(flags::CARDS_SET) };
+                unsafe { (*dest_hdr).set_flag(flags::GCFLAG_CARDS_SET) };
             }
         }
     }
@@ -7769,9 +7788,9 @@ impl MiniMarkGC {
 
         // incminimark.py:1596-1598: if CARDS_SET not set, track and set.
         let hdr = unsafe { header_of(obj.0) };
-        if unsafe { !(*hdr).has_flag(flags::CARDS_SET) } {
+        if unsafe { !(*hdr).has_flag(flags::GCFLAG_CARDS_SET) } {
             self.old_objects_with_cards_set.push(obj.0);
-            unsafe { (*hdr).set_flag(flags::CARDS_SET) };
+            unsafe { (*hdr).set_flag(flags::GCFLAG_CARDS_SET) };
         }
     }
 
@@ -7779,7 +7798,7 @@ impl MiniMarkGC {
     /// Reads inline card bytes before the GcHeader.
     pub fn is_card_dirty(&self, obj: GcRef, card_index: usize) -> bool {
         let hdr = unsafe { header_of(obj.0) };
-        if unsafe { !(*hdr).has_flag(flags::HAS_CARDS) } {
+        if unsafe { !(*hdr).has_flag(flags::GCFLAG_HAS_CARDS) } {
             return false;
         }
         let byteindex = card_index >> 3;
@@ -7792,7 +7811,7 @@ impl MiniMarkGC {
     /// Reads inline card bytes before the GcHeader.
     pub fn dirty_cards(&self, obj: GcRef) -> Vec<usize> {
         let hdr = unsafe { header_of(obj.0) };
-        if unsafe { !(*hdr).has_flag(flags::HAS_CARDS) } {
+        if unsafe { !(*hdr).has_flag(flags::GCFLAG_HAS_CARDS) } {
             return Vec::new();
         }
         let type_id = unsafe { (*hdr).type_id() };
@@ -7820,9 +7839,9 @@ impl MiniMarkGC {
         while let Some(obj) = self.old_objects_with_cards_set.pop() {
             // incminimark.py:2016-2020
             let hdr = unsafe { header_of(obj) };
-            debug_assert!(unsafe { (*hdr).has_flag(flags::HAS_CARDS) });
-            debug_assert!(unsafe { (*hdr).has_flag(flags::CARDS_SET) });
-            unsafe { (*hdr).clear_flag(flags::CARDS_SET) };
+            debug_assert!(unsafe { (*hdr).has_flag(flags::GCFLAG_HAS_CARDS) });
+            debug_assert!(unsafe { (*hdr).has_flag(flags::GCFLAG_CARDS_SET) });
+            unsafe { (*hdr).clear_flag(flags::GCFLAG_CARDS_SET) };
 
             // incminimark.py:2023-2026
             let type_id = unsafe { (*hdr).type_id() };
@@ -7834,7 +7853,7 @@ impl MiniMarkGC {
             // incminimark.py:2033-2039: if !TRACK_YOUNG_PTRS, object is also
             // in old_objects_pointing_to_young and will be fully traced.
             // Just clear card bytes.
-            if unsafe { !(*hdr).has_flag(flags::TRACK_YOUNG_PTRS) } {
+            if unsafe { !(*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) } {
                 for bi in 0..bytes {
                     let p = Self::get_card_ptr(obj, bi);
                     unsafe {
@@ -7921,7 +7940,7 @@ impl MiniMarkGC {
             // leave the still-reachable card object white for the incremental
             // sweep to reclaim.
             if self.gc_state == GcState::Marking {
-                unsafe { (*hdr).set_flag(flags::VISITED) };
+                unsafe { (*hdr).set_flag(flags::GCFLAG_VISITED) };
                 self.incr_state.more_gray_stack.push(obj);
             }
         }
@@ -7930,8 +7949,8 @@ impl MiniMarkGC {
     /// Clear inline card bytes for a given object.
     pub fn clear_cards(&mut self, obj_addr: usize) {
         let hdr = unsafe { header_of(obj_addr) };
-        if unsafe { !(*hdr).has_flag(flags::HAS_CARDS) } {
-            unsafe { (*hdr).clear_flag(flags::CARDS_SET) };
+        if unsafe { !(*hdr).has_flag(flags::GCFLAG_HAS_CARDS) } {
+            unsafe { (*hdr).clear_flag(flags::GCFLAG_CARDS_SET) };
             return;
         }
         let type_id = unsafe { (*hdr).type_id() };
@@ -7945,7 +7964,7 @@ impl MiniMarkGC {
                 *p = 0;
             }
         }
-        unsafe { (*hdr).clear_flag(flags::CARDS_SET) };
+        unsafe { (*hdr).clear_flag(flags::GCFLAG_CARDS_SET) };
     }
 
     // ── JIT integration hooks ──
@@ -8020,7 +8039,7 @@ impl MiniMarkGC {
             let type_id = unsafe { (*header_of(obj_addr)).type_id() };
             let payload_size = self.size_for_typeid(obj_addr, type_id, "pinned_barriers");
             let object_size = Self::nursery_allocation_size(GcHeader::SIZE + payload_size);
-            unsafe { (*header_of(obj_addr)).clear_flag(flags::VISITED) };
+            unsafe { (*header_of(obj_addr)).clear_flag(flags::GCFLAG_VISITED) };
             barriers.push_back(header_addr);
             previous_end = header_addr + object_size;
         }
@@ -8076,7 +8095,7 @@ impl MiniMarkGC {
             return false;
         }
         unsafe {
-            (*header_of(obj.0)).set_flag(flags::PINNED);
+            (*header_of(obj.0)).set_flag(flags::GCFLAG_PINNED);
         }
         self.pinned_objects_in_nursery += 1;
         true
@@ -8086,7 +8105,7 @@ impl MiniMarkGC {
     pub fn unpin(&mut self, obj: GcRef) {
         assert!(self.is_pinned(obj), "unpin: object is already not pinned");
         unsafe {
-            (*header_of(obj.0)).clear_flag(flags::PINNED);
+            (*header_of(obj.0)).clear_flag(flags::GCFLAG_PINNED);
         }
         self.pinned_objects_in_nursery -= 1;
     }
@@ -8097,7 +8116,7 @@ impl MiniMarkGC {
             return false;
         }
         let hdr = unsafe { &*header_of(obj.0) };
-        !hdr.is_forwarded() && hdr.has_flag(flags::PINNED)
+        !hdr.is_forwarded() && hdr.has_flag(flags::GCFLAG_PINNED)
     }
 
     /// Number of objects in the remembered set (for testing / diagnostics).
@@ -8435,7 +8454,7 @@ impl GcAllocator for MiniMarkGC {
             return;
         }
         let hdr = unsafe { header_of(obj.0) };
-        unsafe { (*hdr).set_flag(flags::IGNORE_FINALIZER) };
+        unsafe { (*hdr).set_flag(flags::GCFLAG_IGNORE_FINALIZER) };
     }
 
     fn finalizer_next_dead(&mut self, fq_index: usize) -> Option<GcRef> {
@@ -9031,7 +9050,7 @@ mod tests {
             "a reached object survives its minor"
         );
         assert!(
-            unsafe { !(*header_of(root.0)).has_flag(flags::VISITED_RMY) },
+            unsafe { !(*header_of(root.0)).has_flag(flags::GCFLAG_VISITED_RMY) },
             "incminimark.py:2663 clears the flag on the survivor"
         );
         // A second minor must not free it either: it is on
@@ -9062,7 +9081,7 @@ mod tests {
         );
         let hdr = unsafe { header_of(addr) };
         assert!(
-            unsafe { !(*hdr).has_flag(flags::VISITED) },
+            unsafe { !(*hdr).has_flag(flags::GCFLAG_VISITED) },
             "and it leaves no mark behind: a VISITED that survives the cycle \
              is read by the NEXT major as `already greyed`, which skips the \
              object and leaves its children untraced"
@@ -9182,7 +9201,7 @@ mod tests {
         let obj = gc.alloc_with_type(tid, large);
         assert!(!gc.is_young_rawmalloced(obj.0), "born old");
         assert!(
-            unsafe { (*header_of(obj.0)).has_flag(flags::TRACK_YOUNG_PTRS) },
+            unsafe { (*header_of(obj.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) },
             "and with the old generation's birth flags"
         );
     }
@@ -9493,7 +9512,7 @@ mod tests {
         assert!(get_objects(&mut gc, 1).is_empty());
         assert!(get_objects(&mut gc, 2).is_empty());
         for object in [holder, raw, leaf] {
-            assert!(!unsafe { (*header_of(object.0)).has_flag(flags::EXTRA) });
+            assert!(!unsafe { (*header_of(object.0)).has_flag(flags::GCFLAG_EXTRA) });
         }
 
         gc.do_collect_nursery();
@@ -9505,7 +9524,7 @@ mod tests {
         assert!(old.contains(&holder));
         assert!(old.contains(&leaf));
         for object in [holder, raw, leaf] {
-            assert!(!unsafe { (*header_of(object.0)).has_flag(flags::EXTRA) });
+            assert!(!unsafe { (*header_of(object.0)).has_flag(flags::GCFLAG_EXTRA) });
         }
         gc.roots.clear();
     }
@@ -9568,7 +9587,7 @@ mod tests {
 
         assert_eq!(gc.do_dump_rpy_heap(-1), Err(libc::EBADF));
         for object in [holder, leaf] {
-            assert!(!unsafe { (*header_of(object.0)).has_flag(flags::EXTRA) });
+            assert!(!unsafe { (*header_of(object.0)).has_flag(flags::GCFLAG_EXTRA) });
         }
         assert!(gc.types.typeids_text().starts_with(b"member0"));
         assert_eq!(gc.types.typeids_list(), vec![0, 0, 1]);
@@ -9595,7 +9614,7 @@ mod tests {
         let dummy = gc.alloc_with_type(object_tid, ptr_size);
         let mut holder = gc.alloc_with_type(object_tid, ptr_size);
         unsafe {
-            (*header_of(dummy.0)).set_flag(flags::DUMMY);
+            (*header_of(dummy.0)).set_flag(flags::GCFLAG_DUMMY);
             *(hidden.0 as *mut GcRef) = leaf;
             *(dummy.0 as *mut GcRef) = tail;
             *(holder.0 as *mut GcRef) = hidden;
@@ -9614,7 +9633,7 @@ mod tests {
         assert_eq!(referents, vec![tail]);
 
         for object in [holder, hidden, dummy, leaf, tail] {
-            assert!(!unsafe { (*header_of(object.0)).has_flag(flags::EXTRA) });
+            assert!(!unsafe { (*header_of(object.0)).has_flag(flags::GCFLAG_EXTRA) });
         }
         gc.roots.clear();
     }
@@ -9651,7 +9670,7 @@ mod tests {
         assert!(!referents.contains(&raw));
         assert!(!referents.contains(&holder));
         for object in [holder, raw, near, far] {
-            assert!(!unsafe { (*header_of(object.0)).has_flag(flags::EXTRA) });
+            assert!(!unsafe { (*header_of(object.0)).has_flag(flags::GCFLAG_EXTRA) });
         }
 
         // A self-referential object terminates instead of looping forever.
@@ -9699,7 +9718,7 @@ mod tests {
         gc.do_get_referents(holder, &mut |gcref| referents.push(gcref));
         assert_eq!(referents, vec![class]);
         for object in [holder, class, item] {
-            assert!(!unsafe { (*header_of(object.0)).has_flag(flags::EXTRA) });
+            assert!(!unsafe { (*header_of(object.0)).has_flag(flags::GCFLAG_EXTRA) });
         }
         gc.roots.clear();
     }
@@ -9853,8 +9872,8 @@ mod tests {
         let descr = gc
             .get_write_barrier_descr()
             .expect("MiniMark must expose its write-barrier descriptor");
-        assert_eq!(descr.jit_wb_if_flag, flags::TRACK_YOUNG_PTRS);
-        assert_eq!(descr.jit_wb_cards_set, flags::CARDS_SET);
+        assert_eq!(descr.jit_wb_if_flag, flags::GCFLAG_TRACK_YOUNG_PTRS);
+        assert_eq!(descr.jit_wb_cards_set, flags::GCFLAG_CARDS_SET);
         assert_eq!(descr.jit_wb_card_page_shift, gc.card_page_shift);
     }
 
@@ -9869,7 +9888,7 @@ mod tests {
         let descr = gc
             .get_write_barrier_descr()
             .expect("MiniMark must retain its generic write barrier");
-        assert_eq!(descr.jit_wb_if_flag, flags::TRACK_YOUNG_PTRS);
+        assert_eq!(descr.jit_wb_if_flag, flags::GCFLAG_TRACK_YOUNG_PTRS);
         assert_eq!(descr.jit_wb_cards_set, 0);
         assert_eq!(descr.jit_wb_card_page_shift, 0);
     }
@@ -10622,11 +10641,11 @@ mod tests {
 
         // The old object should have TRACK_YOUNG_PTRS.
         let hdr = unsafe { header_of(old_obj.0) };
-        assert!(unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) });
+        assert!(unsafe { (*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
 
         // Write barrier clears the flag and adds to remembered set.
         gc.do_write_barrier(old_obj);
-        assert!(unsafe { !(*hdr).has_flag(flags::TRACK_YOUNG_PTRS) });
+        assert!(unsafe { !(*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
         assert_eq!(gc.remembered_set.len(), 1);
 
         // Second call: flag already cleared, should not add again.
@@ -10654,13 +10673,13 @@ mod tests {
         // clear. Stamp incminimark's `init_gc_object_immortal` shape by hand
         // to exercise the lifecycle this test is about.
         unsafe {
-            (*hdr).set_flag(flags::NO_HEAP_PTRS);
-            (*hdr).set_flag(flags::TRACK_YOUNG_PTRS);
+            (*hdr).set_flag(flags::GCFLAG_NO_HEAP_PTRS);
+            (*hdr).set_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
         }
-        assert!(unsafe { (*hdr).has_flag(flags::NO_HEAP_PTRS) });
+        assert!(unsafe { (*hdr).has_flag(flags::GCFLAG_NO_HEAP_PTRS) });
 
         gc.do_write_barrier(prebuilt_ref);
-        assert!(unsafe { !(*hdr).has_flag(flags::NO_HEAP_PTRS) });
+        assert!(unsafe { !(*hdr).has_flag(flags::GCFLAG_NO_HEAP_PTRS) });
         assert_eq!(gc.remembered_set, vec![prebuilt_ref.0]);
         assert_eq!(gc.prebuilt_root_objects, vec![prebuilt_ref.0]);
 
@@ -10673,7 +10692,7 @@ mod tests {
         assert_eq!(gc.prebuilt_root_objects, vec![prebuilt_ref.0]);
         gc.collect_full();
         assert!(gc.oldgen.contains(promoted_child.0));
-        assert!(unsafe { !(*hdr).has_flag(flags::VISITED) });
+        assert!(unsafe { !(*hdr).has_flag(flags::GCFLAG_VISITED) });
     }
 
     // incminimark gates the write barrier solely on GCFLAG_TRACK_YOUNG_PTRS:
@@ -10686,7 +10705,7 @@ mod tests {
         let mut gc = test_gc(1024);
         gc.register_type(TypeInfo::simple(16));
         let obj = gc.alloc_in_oldgen_clear(0, GcHeader::SIZE + 16);
-        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
+        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
     }
 
     #[test]
@@ -10697,7 +10716,7 @@ mod tests {
         let length = 4usize;
         let total_size = GcHeader::SIZE + 8 + ptr_size * length;
         let obj = gc.alloc_in_oldgen_with_cards(tid, total_size, length, true);
-        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
+        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
     }
 
     #[test]
@@ -10710,7 +10729,7 @@ mod tests {
         gc.collect_nursery();
         // `root` now holds the promoted old-gen address.
         assert!(!gc.is_in_nursery(root.0));
-        assert!(unsafe { (*header_of(root.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
+        assert!(unsafe { (*header_of(root.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
         gc.roots.clear();
     }
 
@@ -10720,7 +10739,7 @@ mod tests {
         gc.register_type(TypeInfo::simple(16));
         let obj = gc.alloc_with_type(0, 16);
         let shadow = gc.allocate_shadow(obj.0);
-        assert!(unsafe { (*header_of(shadow)).has_flag(flags::TRACK_YOUNG_PTRS) });
+        assert!(unsafe { (*header_of(shadow)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
     }
 
     #[test]
@@ -10746,7 +10765,7 @@ mod tests {
         gc.do_collect_oldgen_nonmoving();
         assert_eq!(gc.oldgen.object_count(), 1);
         assert!(gc.oldgen.contains(shadow));
-        assert!(!unsafe { (*header_of(shadow)).has_flag(flags::VISITED) });
+        assert!(!unsafe { (*header_of(shadow)).has_flag(flags::GCFLAG_VISITED) });
 
         // The following minor occupies exactly that reserved identity home.
         gc.do_collect_nursery();
@@ -10871,7 +10890,7 @@ mod tests {
         let fake = base as *mut GcHeader;
         unsafe {
             fake.write(GcHeader::new(other_tid));
-            (*fake).set_flag(flags::TRACK_YOUNG_PTRS);
+            (*fake).set_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
         }
         let fake_bits_before = unsafe { (*fake).tid_and_flags };
 
@@ -11483,14 +11502,14 @@ mod tests {
         let tid = gc.register_type(TypeInfo::simple(8));
         let old = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + 8);
         let hdr = unsafe { header_of(old.0) };
-        assert!(!unsafe { (*hdr).has_flag(flags::VISITED) });
+        assert!(!unsafe { (*hdr).has_flag(flags::GCFLAG_VISITED) });
 
         gc.gc_state = GcState::Marking;
         let mut root = old;
         gc.drag_out_root(&mut root);
 
         assert_eq!(root, old);
-        assert!(unsafe { (*hdr).has_flag(flags::VISITED) });
+        assert!(unsafe { (*hdr).has_flag(flags::GCFLAG_VISITED) });
         assert!(gc.incr_state.gray_stack.is_empty());
         assert_eq!(gc.incr_state.more_gray_stack.pop(), Some(old.0));
     }
@@ -11517,7 +11536,7 @@ mod tests {
         let mut gc = test_gc(4096);
         let (obj, _) = alloc_card_array(&mut gc, 512);
         let hdr = unsafe { header_of(obj.0) };
-        assert!(unsafe { (*hdr).has_flag(flags::HAS_CARDS) });
+        assert!(unsafe { (*hdr).has_flag(flags::GCFLAG_HAS_CARDS) });
 
         // Card-marking write barrier: mark card for index 5.
         gc.do_write_barrier_card(obj, 5, DEFAULT_CARD_PAGE_SHIFT);
@@ -11528,7 +11547,7 @@ mod tests {
             "card 0 should be dirty after writing index 5"
         );
         assert!(
-            unsafe { (*hdr).has_flag(flags::CARDS_SET) },
+            unsafe { (*hdr).has_flag(flags::GCFLAG_CARDS_SET) },
             "CARDS_SET flag should be set"
         );
 
@@ -11546,7 +11565,7 @@ mod tests {
         let mut gc = test_gc(4096);
         let (obj, array_length) = alloc_card_array(&mut gc, 512);
         let hdr = unsafe { header_of(obj.0) };
-        assert!(unsafe { (*hdr).has_flag(flags::HAS_CARDS) });
+        assert!(unsafe { (*hdr).has_flag(flags::GCFLAG_HAS_CARDS) });
 
         // external_malloc is not zero-filled.  Initialize every item that
         // dirty-card tracing is allowed to read, as production allocation
@@ -11563,7 +11582,7 @@ mod tests {
         gc.do_write_barrier_card(obj, 0, DEFAULT_CARD_PAGE_SHIFT);
         gc.do_write_barrier_card(obj, 200, DEFAULT_CARD_PAGE_SHIFT);
         assert!(
-            unsafe { (*hdr).has_flag(flags::CARDS_SET) },
+            unsafe { (*hdr).has_flag(flags::GCFLAG_CARDS_SET) },
             "CARDS_SET should be set before collection"
         );
 
@@ -11577,7 +11596,7 @@ mod tests {
 
         let hdr = unsafe { header_of(root.0) };
         assert!(
-            unsafe { !(*hdr).has_flag(flags::CARDS_SET) },
+            unsafe { !(*hdr).has_flag(flags::GCFLAG_CARDS_SET) },
             "CARDS_SET flag should be cleared after collection"
         );
         assert!(
@@ -11884,7 +11903,7 @@ mod tests {
         let mut gc = test_gc(4096);
         let tid = gc.register_type(TypeInfo::simple(16));
         let modified = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + 16);
-        unsafe { (*header_of(modified.0)).set_flag(flags::VISITED) };
+        unsafe { (*header_of(modified.0)).set_flag(flags::GCFLAG_VISITED) };
 
         gc.gc_state = GcState::Marking;
         gc.incr_state.gray_stack.clear();
@@ -12055,7 +12074,7 @@ mod tests {
         gc.do_collect_nursery();
         assert!(!gc.is_in_nursery(root.0), "the object promoted");
 
-        unsafe { (*header_of(root.0)).set_flag(flags::VISITED_RMY) };
+        unsafe { (*header_of(root.0)).set_flag(flags::GCFLAG_VISITED_RMY) };
         gc.debug_check_consistency();
     }
 
@@ -12085,9 +12104,9 @@ mod tests {
         unsafe { gc.roots.add(&mut root) };
         gc.do_collect_nursery();
 
-        unsafe { (*header_of(root.0)).set_flag(flags::VISITED_RMY) };
+        unsafe { (*header_of(root.0)).set_flag(flags::GCFLAG_VISITED_RMY) };
         gc.debug_check_consistency();
-        unsafe { (*header_of(root.0)).clear_flag(flags::VISITED_RMY) };
+        unsafe { (*header_of(root.0)).clear_flag(flags::GCFLAG_VISITED_RMY) };
         gc.roots.clear();
     }
 
@@ -12353,7 +12372,7 @@ mod tests {
         }
 
         let hdr = unsafe { header_of(arr.0) };
-        assert!(unsafe { (*hdr).has_flag(flags::HAS_CARDS) });
+        assert!(unsafe { (*hdr).has_flag(flags::GCFLAG_HAS_CARDS) });
 
         // Initialize all array slots to NULL.
         let items_start = arr.0 + 8;
@@ -12430,7 +12449,7 @@ mod tests {
         // Cards should be cleared after collection.
         let hdr = unsafe { header_of(root.0) };
         assert!(
-            unsafe { !(*hdr).has_flag(flags::CARDS_SET) },
+            unsafe { !(*hdr).has_flag(flags::GCFLAG_CARDS_SET) },
             "CARDS_SET should be cleared after collection"
         );
         assert!(
@@ -12438,7 +12457,7 @@ mod tests {
             "old_objects_with_cards_set should be empty after collection"
         );
         assert!(
-            unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) },
+            unsafe { (*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) },
             "TRACK_YOUNG_PTRS should be re-set after collection"
         );
 
@@ -12506,9 +12525,9 @@ mod tests {
         assert!(!gc.is_in_nursery(root_c.0));
 
         // All old-gen objects should have TRACK_YOUNG_PTRS set.
-        assert!(unsafe { (*header_of(root_a.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
-        assert!(unsafe { (*header_of(root_b.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
-        assert!(unsafe { (*header_of(root_c.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
+        assert!(unsafe { (*header_of(root_a.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
+        assert!(unsafe { (*header_of(root_b.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
+        assert!(unsafe { (*header_of(root_c.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
 
         // Start an incremental marking cycle with budget=1 so it stays
         // active across multiple steps.
@@ -12522,9 +12541,9 @@ mod tests {
         // mutator write-barrier behavior this test covers.
         gc.remembered_set.clear();
         unsafe {
-            (*header_of(root_a.0)).set_flag(flags::TRACK_YOUNG_PTRS);
-            (*header_of(root_b.0)).set_flag(flags::TRACK_YOUNG_PTRS);
-            (*header_of(root_c.0)).set_flag(flags::TRACK_YOUNG_PTRS);
+            (*header_of(root_a.0)).set_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
+            (*header_of(root_b.0)).set_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
+            (*header_of(root_c.0)).set_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
         }
 
         // During marking, perform write barriers on A and B.
@@ -12547,10 +12566,10 @@ mod tests {
         );
 
         // TRACK_YOUNG_PTRS should be cleared on A and B.
-        assert!(!unsafe { (*header_of(root_a.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
-        assert!(!unsafe { (*header_of(root_b.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
+        assert!(!unsafe { (*header_of(root_a.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
+        assert!(!unsafe { (*header_of(root_b.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
         // C still has it.
-        assert!(unsafe { (*header_of(root_c.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
+        assert!(unsafe { (*header_of(root_c.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
 
         // Drive the incremental cycle to completion via nursery collections.
         for _ in 0..50 {
@@ -12818,12 +12837,12 @@ mod tests {
 
         // Initially TRACK_YOUNG_PTRS is set.
         let hdr = unsafe { header_of(obj.0) };
-        assert!(unsafe { (*hdr).has_flag(flags::TRACK_YOUNG_PTRS) });
+        assert!(unsafe { (*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
 
         // JIT fast-path barrier: clears flag and adds to remembered set.
         gc.jit_remember_young_pointer(obj);
 
-        assert!(unsafe { !(*hdr).has_flag(flags::TRACK_YOUNG_PTRS) });
+        assert!(unsafe { !(*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
         assert_eq!(gc.remembered_set_len(), 1);
 
         // Calling again adds a second entry (JIT fast-path does not
@@ -13760,12 +13779,12 @@ cache size\t: 8192 kB\n";
         // The must-fix: no greyed nursery object retains VISITED.
         let n_hdr = unsafe { header_of(n.0) };
         assert!(
-            unsafe { !(*n_hdr).has_flag(flags::VISITED) },
+            unsafe { !(*n_hdr).has_flag(flags::GCFLAG_VISITED) },
             "stale nursery VISITED would memcpy into the next minor's promotion"
         );
         // q (old-gen survivor) had VISITED cleared by the oldgen sweep.
         let q_hdr = unsafe { header_of(q.0) };
-        assert!(unsafe { !(*q_hdr).has_flag(flags::VISITED) });
+        assert!(unsafe { !(*q_hdr).has_flag(flags::GCFLAG_VISITED) });
 
         gc.roots.clear();
     }
@@ -13834,7 +13853,7 @@ cache size\t: 8192 kB\n";
         assert_eq!(gc.old_objects_with_weakrefs.len(), 1);
         assert!(gc.is_in_nursery(n_root.0));
         let n_hdr = unsafe { header_of(n_root.0) };
-        assert!(unsafe { !(*n_hdr).has_flag(flags::VISITED) });
+        assert!(unsafe { !(*n_hdr).has_flag(flags::GCFLAG_VISITED) });
 
         gc.roots.clear();
     }
@@ -14108,7 +14127,7 @@ cache size\t: 8192 kB\n";
         assert_eq!(gc.old_objects_with_finalizers.len(), 1);
 
         GcAllocator::ignore_finalizer(&mut gc, obj);
-        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::IGNORE_FINALIZER) });
+        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::GCFLAG_IGNORE_FINALIZER) });
 
         gc.roots.remove(&mut root);
         gc.do_collect_oldgen_nonmoving();
@@ -14137,14 +14156,14 @@ cache size\t: 8192 kB\n";
         let tid = gc.register_type(TypeInfo::with_gc_ptrs(ptr_size, vec![0]));
         let source = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
         let dest = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
-        unsafe { (*header_of(source.0)).clear_flag(flags::TRACK_YOUNG_PTRS) };
+        unsafe { (*header_of(source.0)).clear_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) };
         let before = gc.remembered_set.len();
 
         assert!(gc.writebarrier_before_copy(source.0, dest.0, 0, 0, 1));
 
         assert_eq!(gc.remembered_set.len(), before + 1);
         assert!(gc.remembered_set.contains(&dest.0));
-        assert!(unsafe { !(*header_of(dest.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
+        assert!(unsafe { !(*header_of(dest.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
     }
 
     /// A source that still carries TRACK_YOUNG_PTRS has no young pointers to
@@ -14162,7 +14181,7 @@ cache size\t: 8192 kB\n";
         assert!(gc.writebarrier_before_copy(source.0, dest.0, 0, 0, 1));
 
         assert_eq!(gc.remembered_set.len(), before);
-        assert!(unsafe { (*header_of(dest.0)).has_flag(flags::TRACK_YOUNG_PTRS) });
+        assert!(unsafe { (*header_of(dest.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
     }
 
     /// A destination already on the remembered set is the fast path: nothing
@@ -14174,8 +14193,8 @@ cache size\t: 8192 kB\n";
         let tid = gc.register_type(TypeInfo::with_gc_ptrs(ptr_size, vec![0]));
         let source = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
         let dest = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
-        unsafe { (*header_of(source.0)).clear_flag(flags::TRACK_YOUNG_PTRS) };
-        unsafe { (*header_of(dest.0)).clear_flag(flags::TRACK_YOUNG_PTRS) };
+        unsafe { (*header_of(source.0)).clear_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) };
+        unsafe { (*header_of(dest.0)).clear_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) };
         let before = gc.remembered_set.len();
 
         assert!(gc.writebarrier_before_copy(source.0, dest.0, 0, 0, 1));
@@ -14192,7 +14211,7 @@ cache size\t: 8192 kB\n";
         let tid = gc.register_type(TypeInfo::with_gc_ptrs(ptr_size, vec![0]));
         let source = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
         let dest = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
-        unsafe { (*header_of(source.0)).set_flag(flags::HAS_CARDS) };
+        unsafe { (*header_of(source.0)).set_flag(flags::GCFLAG_HAS_CARDS) };
         assert!(gc.config.card_page_indices > 0);
 
         assert!(!gc.writebarrier_before_copy(source.0, dest.0, 0, 0, 1));
@@ -14206,7 +14225,7 @@ cache size\t: 8192 kB\n";
         let tid = gc.register_type(TypeInfo::varsize(8, 8, 0, true, vec![]));
         let source = gc.alloc_in_oldgen_with_cards(tid, GcHeader::SIZE + 8 + 8 * 64, 64, true);
         let dest = gc.alloc_in_oldgen_with_cards(tid, GcHeader::SIZE + 8 + 8 * 64, 64, true);
-        unsafe { (*header_of(source.0)).set_flag(flags::CARDS_SET) };
+        unsafe { (*header_of(source.0)).set_flag(flags::GCFLAG_CARDS_SET) };
 
         assert!(!gc.writebarrier_before_copy(source.0, dest.0, 1, 0, 64));
     }
@@ -14220,16 +14239,16 @@ cache size\t: 8192 kB\n";
         let tid = gc.register_type(TypeInfo::varsize(8, 8, 0, true, vec![]));
         let source = gc.alloc_in_oldgen_with_cards(tid, GcHeader::SIZE + 8 + 8 * 64, 64, true);
         let dest = gc.alloc_in_oldgen_with_cards(tid, GcHeader::SIZE + 8 + 8 * 64, 64, true);
-        assert!(unsafe { (*header_of(source.0)).has_flag(flags::HAS_CARDS) });
-        assert!(unsafe { (*header_of(dest.0)).has_flag(flags::HAS_CARDS) });
+        assert!(unsafe { (*header_of(source.0)).has_flag(flags::GCFLAG_HAS_CARDS) });
+        assert!(unsafe { (*header_of(dest.0)).has_flag(flags::GCFLAG_HAS_CARDS) });
         unsafe { *MiniMarkGC::get_card_ptr(source.0, 0) = 0b0000_0101 };
-        unsafe { (*header_of(source.0)).set_flag(flags::CARDS_SET) };
+        unsafe { (*header_of(source.0)).set_flag(flags::GCFLAG_CARDS_SET) };
         gc.old_objects_with_cards_set.clear();
 
         assert!(gc.writebarrier_before_copy(source.0, dest.0, 0, 0, 64));
 
         assert_eq!(unsafe { *MiniMarkGC::get_card_ptr(dest.0, 0) }, 0b0000_0101);
-        assert!(unsafe { (*header_of(dest.0)).has_flag(flags::CARDS_SET) });
+        assert!(unsafe { (*header_of(dest.0)).has_flag(flags::GCFLAG_CARDS_SET) });
         assert_eq!(gc.old_objects_with_cards_set, vec![dest.0]);
     }
 
@@ -14241,7 +14260,7 @@ cache size\t: 8192 kB\n";
         let mut gc = test_gc(4096);
         let tid = gc.register_type(TypeInfo::varsize(8, 8, 0, true, vec![]));
         let array = gc.alloc_in_oldgen_with_cards(tid, GcHeader::SIZE + 8 + 8 * 64, 64, true);
-        unsafe { (*header_of(array.0)).set_flag(flags::CARDS_SET) };
+        unsafe { (*header_of(array.0)).set_flag(flags::GCFLAG_CARDS_SET) };
         let before = gc.remembered_set.len();
 
         gc.writebarrier_before_move(array.0);
@@ -14277,7 +14296,7 @@ cache size\t: 8192 kB\n";
         let shadow = gc.move_out_of_nursery(obj.0);
         assert_ne!(shadow, obj.0);
         assert!(!gc.is_in_nursery(shadow));
-        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::SHADOW_INITIALIZED) });
+        assert!(unsafe { (*header_of(obj.0)).has_flag(flags::GCFLAG_SHADOW_INITIALIZED) });
         assert_eq!(unsafe { *(shadow as *const u64) }, 0xfeed_face);
         assert_eq!(gc.move_out_of_nursery(obj.0), shadow);
 
@@ -14300,7 +14319,7 @@ cache size\t: 8192 kB\n";
         let tid = gc.register_type(TypeInfo::simple(16));
         let obj = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + 16);
         assert_eq!(gc.move_out_of_nursery(obj.0), obj.0);
-        assert!(unsafe { !(*header_of(obj.0)).has_flag(flags::SHADOW_INITIALIZED) });
+        assert!(unsafe { !(*header_of(obj.0)).has_flag(flags::GCFLAG_SHADOW_INITIALIZED) });
     }
 
     /// incminimark.py `collect(gen)`: a negative generation is the minor that

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -930,10 +930,14 @@ pub struct MiniMarkGC {
     pub types: TypeRegistry,
     /// Root set.
     pub roots: RootSet,
-    /// Remembered set: old objects that may point to young objects.
-    /// These are old-gen object payload addresses whose TRACK_YOUNG_PTRS
-    /// flag has been cleared by the write barrier.
-    remembered_set: Vec<usize>,
+    /// incminimark.py:344 `old_objects_pointing_to_young = AddressStack()`.
+    /// Used by minor collection: the (mostly non-young) objects that may
+    /// contain a pointer to a young object.  The write barrier populates it,
+    /// appending an object as it clears that object's
+    /// `GCFLAG_TRACK_YOUNG_PTRS`.  A young array object may enter by
+    /// temporary mistake; the next minor collection removes it again, in
+    /// [`Self::remove_young_arrays_from_old_objects_pointing_to_young`].
+    old_objects_pointing_to_young: Vec<usize>,
     /// incminimark.py:355 `prebuilt_root_objects = AddressStack()`.
     /// Immortal objects enter exactly once, when their first pointer write
     /// clears NO_HEAP_PTRS in the write barrier.
@@ -1264,7 +1268,7 @@ impl MiniMarkGC {
             oldgen: OldGen::new(),
             types: TypeRegistry::new(),
             roots: RootSet::new(),
-            remembered_set: Vec::new(),
+            old_objects_pointing_to_young: Vec::new(),
             prebuilt_root_objects: Vec::new(),
             root_snapshot_capacity: std::cell::Cell::new(0),
             old_objects_with_cards_set: Vec::new(),
@@ -2251,8 +2255,9 @@ impl MiniMarkGC {
             // about separately — the same reading `bh_probe_stale_young_slots`
             // takes.
             let holder_is_old = self.oldgen.contains(here) && !self.is_young_rawmalloced(here);
-            let remembered = self.remembered_set.contains(&here);
-            let parent_remembered = parent.is_some_and(|p| self.remembered_set.contains(&p));
+            let remembered = self.old_objects_pointing_to_young.contains(&here);
+            let parent_remembered =
+                parent.is_some_and(|p| self.old_objects_pointing_to_young.contains(&p));
             self.visit_referent_slots(here, &mut |slot| {
                 let value = unsafe { *slot }.0;
                 if value == 0 {
@@ -2307,8 +2312,8 @@ impl MiniMarkGC {
         // The remembered set is traced whether or not anything still points at
         // its entries, so it is its own population: an entry the root walk
         // never reached is a dead object the minor will still read.
-        for index in 0..self.remembered_set.len() {
-            let here = self.remembered_set[index];
+        for index in 0..self.old_objects_pointing_to_young.len() {
+            let here = self.old_objects_pointing_to_young[index];
             let root_reachable = seen.contains(&here);
             self.visit_referent_slots(here, &mut |slot| {
                 let value = unsafe { *slot }.0;
@@ -2450,7 +2455,7 @@ impl MiniMarkGC {
                         track_young_ptrs: unsafe {
                             (*header_of(addr)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS)
                         },
-                        remembered: self.remembered_set.contains(&addr),
+                        remembered: self.old_objects_pointing_to_young.contains(&addr),
                         barriered_ever: crate::bh_probe_was_barriered(addr),
                         traced_this_minor: crate::bh_probe_was_traced(addr),
                         store_sites: crate::bh_probe_store_sites(addr, offset),
@@ -2462,7 +2467,8 @@ impl MiniMarkGC {
                                     .contains_key(&unsafe { *(p as *const usize) })
                             })
                             .and_then(crate::bh_probe_type_name),
-                        parent_remembered: parent.is_some_and(|p| self.remembered_set.contains(&p)),
+                        parent_remembered: parent
+                            .is_some_and(|p| self.old_objects_pointing_to_young.contains(&p)),
                         parent_barriered_ever: parent.is_some_and(crate::bh_probe_was_barriered),
                         parent_traced_this_minor: parent.is_some_and(crate::bh_probe_was_traced),
                     });
@@ -2856,7 +2862,7 @@ impl MiniMarkGC {
         // birth, so the first arm always runs; the remembered walk is what sets
         // the flag and forwards whatever nursery children the object holds.
         if unsafe { !(*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) } {
-            self.remembered_set.push(obj_addr);
+            self.old_objects_pointing_to_young.push(obj_addr);
         }
         if unsafe { (*hdr).has_flag(flags::GCFLAG_HAS_CARDS) } {
             debug_assert!(
@@ -2884,9 +2890,9 @@ impl MiniMarkGC {
     /// An entry naming a young rawmalloced object is a contradiction: this
     /// minor visits it as an object, and if it dies the drain would be reading
     /// a freed header. Upstream drops those entries before the walk starts.
-    fn remove_young_arrays_from_remembered_set(&mut self) {
+    fn remove_young_arrays_from_old_objects_pointing_to_young(&mut self) {
         let oldgen = &self.oldgen;
-        self.remembered_set
+        self.old_objects_pointing_to_young
             .retain(|&obj_addr| !oldgen.young_rawmalloced_contains(obj_addr));
     }
 
@@ -2908,7 +2914,7 @@ impl MiniMarkGC {
             eprintln!(
                 "[gc][minor] start count={} remembered={} cards_set={}",
                 self.minor_collections + 1,
-                self.remembered_set.len(),
+                self.old_objects_pointing_to_young.len(),
                 self.old_objects_with_cards_set.len(),
             );
         }
@@ -2937,7 +2943,7 @@ impl MiniMarkGC {
         self.any_pinned_object_kept = false;
         // incminimark.py:1787-1789: ahead of the re-gray and every root walk.
         if self.oldgen.has_young_rawmalloced() {
-            self.remove_young_arrays_from_remembered_set();
+            self.remove_young_arrays_from_old_objects_pointing_to_young();
         }
         // incminimark.py:1800-1807: a black old parent may expose an unpinned
         // child that will move during this minor, so make the parent gray
@@ -3123,7 +3129,7 @@ impl MiniMarkGC {
         // those black objects so the major collector rescans their new
         // outgoing references before sweep.
         if self.gc_state == GcState::Marking {
-            let remembered_now: Vec<usize> = self.remembered_set.to_vec();
+            let remembered_now: Vec<usize> = self.old_objects_pointing_to_young.to_vec();
             for obj_addr in remembered_now {
                 let hdr = unsafe { header_of(obj_addr) };
                 if unsafe { (*hdr).has_flag(flags::GCFLAG_VISITED) } {
@@ -3162,10 +3168,10 @@ impl MiniMarkGC {
             // incminimark.py: collect_oldrefs_to_nursery.
             let mut idx = 0;
             loop {
-                if idx >= self.remembered_set.len() {
+                if idx >= self.old_objects_pointing_to_young.len() {
                     break;
                 }
-                let obj_addr = self.remembered_set[idx];
+                let obj_addr = self.old_objects_pointing_to_young[idx];
                 idx += 1;
 
                 // incminimark.py:2095-2098: re-set TRACK_YOUNG_PTRS.
@@ -3175,9 +3181,9 @@ impl MiniMarkGC {
 
                 // Trace this old-gen object's fields and copy any nursery
                 // objects they reference.
-                self.trace_and_update_object(obj_addr, "minor_remembered_set");
+                self.trace_and_update_object(obj_addr, "minor_old_objects_pointing_to_young");
             }
-            self.remembered_set.clear();
+            self.old_objects_pointing_to_young.clear();
 
             // incminimark.py:1859-1862: loop back if card-marked objects appeared.
             if self.card_page_shift > 0 && !self.old_objects_with_cards_set.is_empty() {
@@ -4603,7 +4609,7 @@ impl MiniMarkGC {
                 self.describe_generation(obj_addr),
                 self.describe_generation(holder_addr),
                 holder_hdr_tid_and_flags,
-                self.remembered_set.contains(&holder_addr),
+                self.old_objects_pointing_to_young.contains(&holder_addr),
                 self.describe_enclosing_container(holder_addr, slot_addr, &holder_words),
                 self.gc_state,
                 self.minor_collections,
@@ -4712,7 +4718,7 @@ impl MiniMarkGC {
             unsafe {
                 (*(new_header_ptr as *mut GcHeader)).clear_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
             }
-            self.remembered_set.push(new_obj_addr);
+            self.old_objects_pointing_to_young.push(new_obj_addr);
             if crate::gc_lifetime_log_enabled() {
                 eprintln!(
                     "[gc][remember] addr={:#x} type_id={} source=promotion state={:?}",
@@ -5048,7 +5054,7 @@ impl MiniMarkGC {
                 && unsafe { (*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) }
             {
                 unsafe { (*hdr).clear_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) };
-                self.remembered_set.push(gcref.0);
+                self.old_objects_pointing_to_young.push(gcref.0);
                 if crate::gc_lifetime_log_enabled() {
                     eprintln!(
                         "[gc][remember] addr={:#x} type_id={} source=major_seed state={:?}",
@@ -6350,7 +6356,7 @@ impl MiniMarkGC {
                     child_vtable_type_id,
                     Self::hex_words(&child_words),
                     holder_hdr.tid_and_flags,
-                    self.remembered_set.contains(&holder_addr),
+                    self.old_objects_pointing_to_young.contains(&holder_addr),
                     self.describe_generation(addr),
                     self.describe_generation(holder_addr),
                     self.describe_enclosing_container(holder_addr, slot_addr, &holder_words),
@@ -6480,7 +6486,7 @@ impl MiniMarkGC {
     /// re-scan before the sweep completes.
     ///
     /// Every old object modified since the last minor collection is recorded in
-    /// `remembered_set` (the write barrier's `old_objects_pointing_to_young`) with
+    /// `old_objects_pointing_to_young` (the write barrier's `old_objects_pointing_to_young`) with
     /// its `TRACK_YOUNG_PTRS` cleared. Such a store may install an `old -> old`
     /// edge to a still-white object. The per-minor black re-grey in
     /// `do_collect_nursery` only re-scans modifications up to the last minor; a
@@ -6492,7 +6498,7 @@ impl MiniMarkGC {
     /// sets VISITED at push time, so a black object is simply re-pushed; white
     /// entries are left for the normal frontier / retain to drop.)
     fn rescan_remembered_black_and_drain(&mut self) {
-        let snapshot: Vec<usize> = self.remembered_set.to_vec();
+        let snapshot: Vec<usize> = self.old_objects_pointing_to_young.to_vec();
         for addr in snapshot {
             if unsafe { (*header_of(addr)).has_flag(flags::GCFLAG_VISITED) } {
                 self.incr_state.gray_stack.push(addr);
@@ -6657,12 +6663,12 @@ impl MiniMarkGC {
         }
         // A non-moving major (do_collect_oldgen_nonmoving) runs with a live
         // nursery and no preceding minor, so the write barrier's
-        // remembered_set / old_objects_with_cards_set are still populated and
+        // old_objects_pointing_to_young / old_objects_with_cards_set are still populated and
         // may name old objects this cycle is about to free. Drop the dead ones
         // (VISITED is still set on every survivor at this point) so the next
         // minor does not trace freed memory. A no-op for do_collect_full, whose
         // leading minor already drained both sets.
-        self.remembered_set
+        self.old_objects_pointing_to_young
             .retain(|&addr| unsafe { (*header_of(addr)).has_flag(flags::GCFLAG_VISITED) });
         self.old_objects_with_cards_set
             .retain(|&addr| unsafe { (*header_of(addr)).has_flag(flags::GCFLAG_VISITED) });
@@ -7478,7 +7484,7 @@ impl MiniMarkGC {
     /// inside the allocation and finds the flag clear. Reaching this helper
     /// with such a frame therefore takes a set flag bit the allocator did not
     /// write; `is_managed_heap_object` is what still keeps the unmanaged block
-    /// out of `remembered_set`, where the next minor would decode a type id
+    /// out of `old_objects_pointing_to_young`, where the next minor would decode a type id
     /// from it. `write_barrier_ignores_unmanaged_jitframe_with_flag_byte_set`
     /// pins that case.
     pub fn do_write_barrier(&mut self, obj: GcRef) {
@@ -7540,7 +7546,7 @@ impl MiniMarkGC {
         // mutated and therefore cannot be re-added between sweep steps.
         let type_id = unsafe { (*header_of(obj.0)).type_id() };
         self.validate_type_id(type_id, obj.0, "remember_young_pointer_insert");
-        self.remembered_set.push(obj.0);
+        self.old_objects_pointing_to_young.push(obj.0);
         crate::bh_probe_note_barriered(obj.0);
         let hdr = unsafe { header_of(obj.0) };
         if crate::gc_lifetime_log_enabled() {
@@ -8120,8 +8126,8 @@ impl MiniMarkGC {
     }
 
     /// Number of objects in the remembered set (for testing / diagnostics).
-    pub fn remembered_set_len(&self) -> usize {
-        self.remembered_set.len()
+    pub fn old_objects_pointing_to_young_len(&self) -> usize {
+        self.old_objects_pointing_to_young.len()
     }
 }
 
@@ -10646,11 +10652,11 @@ mod tests {
         // Write barrier clears the flag and adds to remembered set.
         gc.do_write_barrier(old_obj);
         assert!(unsafe { !(*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
-        assert_eq!(gc.remembered_set.len(), 1);
+        assert_eq!(gc.old_objects_pointing_to_young.len(), 1);
 
         // Second call: flag already cleared, should not add again.
         gc.do_write_barrier(old_obj);
-        assert_eq!(gc.remembered_set.len(), 1);
+        assert_eq!(gc.old_objects_pointing_to_young.len(), 1);
     }
 
     #[test]
@@ -10680,7 +10686,7 @@ mod tests {
 
         gc.do_write_barrier(prebuilt_ref);
         assert!(unsafe { !(*hdr).has_flag(flags::GCFLAG_NO_HEAP_PTRS) });
-        assert_eq!(gc.remembered_set, vec![prebuilt_ref.0]);
+        assert_eq!(gc.old_objects_pointing_to_young, vec![prebuilt_ref.0]);
         assert_eq!(gc.prebuilt_root_objects, vec![prebuilt_ref.0]);
 
         gc.do_collect_nursery();
@@ -10784,7 +10790,7 @@ mod tests {
         unsafe { *(base as *mut GcHeader) = GcHeader::new(0) };
         let payload = base + GcHeader::SIZE;
         gc.do_write_barrier(GcRef(payload));
-        assert_eq!(gc.remembered_set.len(), 0);
+        assert_eq!(gc.old_objects_pointing_to_young.len(), 0);
         drop(buf);
     }
 
@@ -10794,7 +10800,7 @@ mod tests {
         // header at `0 - GcHeader::SIZE`.
         let mut gc = test_gc(1024);
         gc.do_write_barrier(GcRef(0));
-        assert_eq!(gc.remembered_set.len(), 0);
+        assert_eq!(gc.old_objects_pointing_to_young.len(), 0);
     }
 
     #[test]
@@ -10812,7 +10818,7 @@ mod tests {
         // this test covers the residue — the helper being entered anyway, with
         // the flag bit set, for a block the GC does not manage. Without the
         // `is_managed_heap_object` guard in `do_write_barrier`, that block
-        // would enter `remembered_set` and the next minor would decode a type
+        // would enter `old_objects_pointing_to_young` and the next minor would decode a type
         // id from those bytes.
         let mut gc = test_gc(1024);
 
@@ -10844,7 +10850,7 @@ mod tests {
 
         gc.do_write_barrier(GcRef(obj));
 
-        assert_eq!(gc.remembered_set.len(), 0);
+        assert_eq!(gc.old_objects_pointing_to_young.len(), 0);
         // `remember_young_pointer` clears TRACK_YOUNG_PTRS, so an unchanged
         // byte also proves the barrier never wrote through the fake header.
         assert_eq!(unsafe { *flag_byte }, flag_byte_before);
@@ -10896,7 +10902,7 @@ mod tests {
 
         gc.do_write_barrier(GcRef(obj));
 
-        assert_eq!(gc.remembered_set.len(), 0);
+        assert_eq!(gc.old_objects_pointing_to_young.len(), 0);
         // `remember_young_pointer` clears TRACK_YOUNG_PTRS, so unchanged bits
         // also prove the barrier never wrote through the fake header.
         assert_eq!(unsafe { (*fake).tid_and_flags }, fake_bits_before);
@@ -10923,7 +10929,7 @@ mod tests {
         assert!(!gc.is_in_nursery(root.0));
 
         gc.do_write_barrier(stale_addr);
-        assert!(gc.remembered_set.is_empty());
+        assert!(gc.old_objects_pointing_to_young.is_empty());
         gc.roots.clear();
     }
 
@@ -11633,7 +11639,11 @@ mod tests {
         gc.do_write_barrier_card(obj, 5, DEFAULT_CARD_PAGE_SHIFT);
 
         // Should fall back to full remembered set.
-        assert_eq!(gc.remembered_set.len(), 1, "should add to remembered set");
+        assert_eq!(
+            gc.old_objects_pointing_to_young.len(),
+            1,
+            "should add to remembered set"
+        );
         assert!(
             gc.old_objects_with_cards_set.is_empty(),
             "should not add to old_objects_with_cards_set without HAS_CARDS"
@@ -11765,7 +11775,7 @@ mod tests {
             // through the ordinary mutator write barrier.
             *(root.0 as *mut GcRef) = young;
         }
-        assert!(gc.remembered_set.contains(&root.0));
+        assert!(gc.old_objects_pointing_to_young.contains(&root.0));
 
         gc.disable();
         gc.do_collect_nursery();
@@ -12539,7 +12549,7 @@ mod tests {
         // collector-owned JITFRAME spills cannot strand nursery references.
         // Reset that one-time collector setup here to isolate the ordinary
         // mutator write-barrier behavior this test covers.
-        gc.remembered_set.clear();
+        gc.old_objects_pointing_to_young.clear();
         unsafe {
             (*header_of(root_a.0)).set_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
             (*header_of(root_b.0)).set_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
@@ -12552,16 +12562,16 @@ mod tests {
 
         // A and B should be in the remembered set.
         assert!(
-            gc.remembered_set.contains(&root_a.0),
+            gc.old_objects_pointing_to_young.contains(&root_a.0),
             "write barrier should add A to remembered set during marking"
         );
         assert!(
-            gc.remembered_set.contains(&root_b.0),
+            gc.old_objects_pointing_to_young.contains(&root_b.0),
             "write barrier should add B to remembered set during marking"
         );
         // C was not written to, so it shouldn't be in remembered set.
         assert!(
-            !gc.remembered_set.contains(&root_c.0),
+            !gc.old_objects_pointing_to_young.contains(&root_c.0),
             "C should not be in remembered set"
         );
 
@@ -12843,12 +12853,12 @@ mod tests {
         gc.jit_remember_young_pointer(obj);
 
         assert!(unsafe { !(*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
-        assert_eq!(gc.remembered_set_len(), 1);
+        assert_eq!(gc.old_objects_pointing_to_young_len(), 1);
 
         // Calling again adds a second entry (JIT fast-path does not
         // deduplicate; the collector handles this during minor collection).
         gc.jit_remember_young_pointer(obj);
-        assert_eq!(gc.remembered_set_len(), 2);
+        assert_eq!(gc.old_objects_pointing_to_young_len(), 2);
     }
 
     #[test]
@@ -14157,12 +14167,12 @@ cache size\t: 8192 kB\n";
         let source = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
         let dest = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
         unsafe { (*header_of(source.0)).clear_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) };
-        let before = gc.remembered_set.len();
+        let before = gc.old_objects_pointing_to_young.len();
 
         assert!(gc.writebarrier_before_copy(source.0, dest.0, 0, 0, 1));
 
-        assert_eq!(gc.remembered_set.len(), before + 1);
-        assert!(gc.remembered_set.contains(&dest.0));
+        assert_eq!(gc.old_objects_pointing_to_young.len(), before + 1);
+        assert!(gc.old_objects_pointing_to_young.contains(&dest.0));
         assert!(unsafe { !(*header_of(dest.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
     }
 
@@ -14176,11 +14186,11 @@ cache size\t: 8192 kB\n";
         let source = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
         let dest = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
         assert_eq!(gc.gc_state, GcState::Scanning);
-        let before = gc.remembered_set.len();
+        let before = gc.old_objects_pointing_to_young.len();
 
         assert!(gc.writebarrier_before_copy(source.0, dest.0, 0, 0, 1));
 
-        assert_eq!(gc.remembered_set.len(), before);
+        assert_eq!(gc.old_objects_pointing_to_young.len(), before);
         assert!(unsafe { (*header_of(dest.0)).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) });
     }
 
@@ -14195,11 +14205,11 @@ cache size\t: 8192 kB\n";
         let dest = gc.alloc_in_oldgen_clear(tid, GcHeader::SIZE + ptr_size);
         unsafe { (*header_of(source.0)).clear_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) };
         unsafe { (*header_of(dest.0)).clear_flag(flags::GCFLAG_TRACK_YOUNG_PTRS) };
-        let before = gc.remembered_set.len();
+        let before = gc.old_objects_pointing_to_young.len();
 
         assert!(gc.writebarrier_before_copy(source.0, dest.0, 0, 0, 1));
 
-        assert_eq!(gc.remembered_set.len(), before);
+        assert_eq!(gc.old_objects_pointing_to_young.len(), before);
     }
 
     /// The card arms: a source with cards and a destination without cannot be
@@ -14261,12 +14271,12 @@ cache size\t: 8192 kB\n";
         let tid = gc.register_type(TypeInfo::varsize(8, 8, 0, true, vec![]));
         let array = gc.alloc_in_oldgen_with_cards(tid, GcHeader::SIZE + 8 + 8 * 64, 64, true);
         unsafe { (*header_of(array.0)).set_flag(flags::GCFLAG_CARDS_SET) };
-        let before = gc.remembered_set.len();
+        let before = gc.old_objects_pointing_to_young.len();
 
         gc.writebarrier_before_move(array.0);
 
-        assert_eq!(gc.remembered_set.len(), before + 1);
-        assert!(gc.remembered_set.contains(&array.0));
+        assert_eq!(gc.old_objects_pointing_to_young.len(), before + 1);
+        assert!(gc.old_objects_pointing_to_young.contains(&array.0));
     }
 
     /// An array with no card marked has nothing the move could invalidate.
@@ -14275,11 +14285,11 @@ cache size\t: 8192 kB\n";
         let mut gc = test_gc(4096);
         let tid = gc.register_type(TypeInfo::varsize(8, 8, 0, true, vec![]));
         let array = gc.alloc_in_oldgen_with_cards(tid, GcHeader::SIZE + 8 + 8 * 64, 64, true);
-        let before = gc.remembered_set.len();
+        let before = gc.old_objects_pointing_to_young.len();
 
         gc.writebarrier_before_move(array.0);
 
-        assert_eq!(gc.remembered_set.len(), before);
+        assert_eq!(gc.old_objects_pointing_to_young.len(), before);
     }
 
     /// incminimark.py `move_out_of_nursery`: "called twice, it should return

--- a/majit/majit-gc/src/header.rs
+++ b/majit/majit-gc/src/header.rs
@@ -192,8 +192,13 @@ pub fn alloc_with_gc_header<T>(value: T, type_id: u32) -> *mut T {
 /// [`alloc_with_gc_header`] for a genuine immortal leaf — `init_gc_object_immortal`
 /// (`NO_HEAP_PTRS | TRACK_YOUNG_PTRS`), incminimark's prebuilt shape.
 ///
-/// `NO_HEAP_PTRS` asserts the object holds no reference the collector must
-/// follow, so only a payload that really is a leaf may use this: the `None` /
+/// `GCFLAG_NO_HEAP_PTRS` asserts the object holds no heap pointer *yet*: while
+/// it is set marking skips the object, and the first pointer written into it is
+/// expected to clear the flag and enrol the object in `prebuilt_root_objects`.
+/// Upstream does stamp prebuilt objects that have reference fields, because
+/// those fields name other prebuilt objects and the GC transform puts a barrier
+/// on every later store. Neither condition holds for a box allocated here, so
+/// only a payload that is a leaf and stays one may use this: the `None` /
 /// `True` / `False` / `NotImplemented` / `Ellipsis` singletons, whose whole body
 /// is a `PyObject` header with a null `w_class`. An ordinary `#[pyre_class]`
 /// box does NOT qualify — its reference fields are written at construction with
@@ -205,7 +210,7 @@ pub fn alloc_with_gc_header_immortal<T>(value: T, type_id: u32) -> *mut T {
         value,
         GcHeader::with_flags(
             type_id,
-            crate::flags::NO_HEAP_PTRS | crate::flags::TRACK_YOUNG_PTRS,
+            crate::flags::GCFLAG_NO_HEAP_PTRS | crate::flags::GCFLAG_TRACK_YOUNG_PTRS,
         ),
     )
 }
@@ -247,24 +252,24 @@ mod tests {
 
     #[test]
     fn test_with_flags() {
-        let hdr = GcHeader::with_flags(7, flags::TRACK_YOUNG_PTRS | flags::VISITED);
+        let hdr = GcHeader::with_flags(7, flags::GCFLAG_TRACK_YOUNG_PTRS | flags::GCFLAG_VISITED);
         assert_eq!(hdr.type_id(), 7);
-        assert!(hdr.has_flag(flags::TRACK_YOUNG_PTRS));
-        assert!(hdr.has_flag(flags::VISITED));
-        assert!(!hdr.has_flag(flags::PINNED));
+        assert!(hdr.has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS));
+        assert!(hdr.has_flag(flags::GCFLAG_VISITED));
+        assert!(!hdr.has_flag(flags::GCFLAG_PINNED));
     }
 
     #[test]
     fn test_set_clear_flag() {
         let mut hdr = GcHeader::new(1);
-        assert!(!hdr.has_flag(flags::TRACK_YOUNG_PTRS));
+        assert!(!hdr.has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS));
 
-        hdr.set_flag(flags::TRACK_YOUNG_PTRS);
-        assert!(hdr.has_flag(flags::TRACK_YOUNG_PTRS));
+        hdr.set_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
+        assert!(hdr.has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS));
         assert_eq!(hdr.type_id(), 1);
 
-        hdr.clear_flag(flags::TRACK_YOUNG_PTRS);
-        assert!(!hdr.has_flag(flags::TRACK_YOUNG_PTRS));
+        hdr.clear_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
+        assert!(!hdr.has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS));
         assert_eq!(hdr.type_id(), 1);
     }
 
@@ -293,38 +298,38 @@ mod tests {
             // type id recorded; flags clear (init_gc_object flags=0).
             assert_eq!((*hdr).type_id(), 0x1357);
             assert_eq!((*hdr).flags(), 0);
-            assert!(!(*hdr).has_flag(flags::TRACK_YOUNG_PTRS));
-            assert!(!(*hdr).has_flag(flags::NO_HEAP_PTRS));
+            assert!(!(*hdr).has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS));
+            assert!(!(*hdr).has_flag(flags::GCFLAG_NO_HEAP_PTRS));
         }
     }
 
     #[test]
     fn test_flags_dont_clobber_type_id() {
         let mut hdr = GcHeader::new(0xDEAD);
-        hdr.set_flag(flags::TRACK_YOUNG_PTRS);
-        hdr.set_flag(flags::VISITED);
-        hdr.set_flag(flags::PINNED);
+        hdr.set_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
+        hdr.set_flag(flags::GCFLAG_VISITED);
+        hdr.set_flag(flags::GCFLAG_PINNED);
         assert_eq!(hdr.type_id(), 0xDEAD);
-        assert!(hdr.has_flag(flags::TRACK_YOUNG_PTRS));
-        assert!(hdr.has_flag(flags::VISITED));
-        assert!(hdr.has_flag(flags::PINNED));
+        assert!(hdr.has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS));
+        assert!(hdr.has_flag(flags::GCFLAG_VISITED));
+        assert!(hdr.has_flag(flags::GCFLAG_PINNED));
     }
 
     #[test]
     fn test_multiple_flags() {
         let mut hdr = GcHeader::new(0);
-        hdr.set_flag(flags::TRACK_YOUNG_PTRS);
-        hdr.set_flag(flags::HAS_CARDS);
-        hdr.set_flag(flags::CARDS_SET);
+        hdr.set_flag(flags::GCFLAG_TRACK_YOUNG_PTRS);
+        hdr.set_flag(flags::GCFLAG_HAS_CARDS);
+        hdr.set_flag(flags::GCFLAG_CARDS_SET);
 
-        assert!(hdr.has_flag(flags::TRACK_YOUNG_PTRS));
-        assert!(hdr.has_flag(flags::HAS_CARDS));
-        assert!(hdr.has_flag(flags::CARDS_SET));
-        assert!(!hdr.has_flag(flags::VISITED));
+        assert!(hdr.has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS));
+        assert!(hdr.has_flag(flags::GCFLAG_HAS_CARDS));
+        assert!(hdr.has_flag(flags::GCFLAG_CARDS_SET));
+        assert!(!hdr.has_flag(flags::GCFLAG_VISITED));
 
-        hdr.clear_flag(flags::HAS_CARDS);
-        assert!(!hdr.has_flag(flags::HAS_CARDS));
-        assert!(hdr.has_flag(flags::TRACK_YOUNG_PTRS));
+        hdr.clear_flag(flags::GCFLAG_HAS_CARDS);
+        assert!(!hdr.has_flag(flags::GCFLAG_HAS_CARDS));
+        assert!(hdr.has_flag(flags::GCFLAG_TRACK_YOUNG_PTRS));
     }
 
     #[test]

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -72,38 +72,67 @@ pub(crate) fn invoke_after_minor_collection_hook() {
 
 /// GC flags stored in object headers.
 ///
-/// From incminimark.py GCFLAG_* constants.
+/// incminimark.py `GCFLAG_*`, spelled the same here: a flag test and the
+/// RPython line it came from read alike, so the `GCFLAG_` prefix marks
+/// membership of that set and a constant without it is one this GC adds
+/// (`FINALIZER_REGISTERED`, `FINALIZER_RUN` below).
 pub mod flags {
-    // incminimark.py GCFLAG_* — bit positions must match RPython exactly.
-    // first_gcflag = 1 << 32; each constant below is (first_gcflag << N)
-    // expressed as the unshifted bit index N.
-    /// GCFLAG_TRACK_YOUNG_PTRS (bit 0)
-    pub const TRACK_YOUNG_PTRS: u64 = 1 << 0;
-    /// GCFLAG_NO_HEAP_PTRS (bit 1)
-    pub const NO_HEAP_PTRS: u64 = 1 << 1;
-    /// GCFLAG_VISITED (bit 2)
-    pub const VISITED: u64 = 1 << 2;
-    /// GCFLAG_HAS_SHADOW (bit 3)
-    pub const HAS_SHADOW: u64 = 1 << 3;
-    /// GCFLAG_FINALIZATION_ORDERING (bit 4)
-    pub const FINALIZATION_ORDERING: u64 = 1 << 4;
-    /// GCFLAG_EXTRA (bit 5) — reserved
-    pub const EXTRA: u64 = 1 << 5;
-    /// GCFLAG_HAS_CARDS (bit 6)
-    pub const HAS_CARDS: u64 = 1 << 6;
-    /// GCFLAG_CARDS_SET (bit 7) — MSB of the byte containing TRACK_YOUNG_PTRS.
-    /// The x86 backend relies on this being -0x80 as a signed byte.
-    pub const CARDS_SET: u64 = 1 << 7;
-    /// GCFLAG_VISITED_RMY (bit 8)
-    pub const VISITED_RMY: u64 = 1 << 8;
-    /// GCFLAG_PINNED (bit 9)
-    pub const PINNED: u64 = 1 << 9;
-    /// GCFLAG_IGNORE_FINALIZER (bit 10)
-    pub const IGNORE_FINALIZER: u64 = 1 << 10;
-    /// GCFLAG_SHADOW_INITIALIZED (bit 11)
-    pub const SHADOW_INITIALIZED: u64 = 1 << 11;
-    /// GCFLAG_DUMMY (bit 12)
-    pub const DUMMY: u64 = 1 << 12;
+    // Bit positions must match RPython exactly. Upstream sets
+    // `first_gcflag = 1 << 32` and writes `first_gcflag << N`; the header keeps
+    // flags in the high half already, so each constant is the unshifted index N.
+
+    /// Something must be done to track the young pointers this object may
+    /// hold. Not set on young objects — any young object may point to any
+    /// other — except large arrays, where `GCFLAG_HAS_CARDS` does the tracking
+    /// and this is set anyway to shorten the write barrier. On old and prebuilt
+    /// objects it is usually set, and writing a pointer clears it.
+    pub const GCFLAG_TRACK_YOUNG_PTRS: u64 = 1 << 0;
+    /// Set on a prebuilt object unless it is already listed in
+    /// `prebuilt_root_objects`.
+    ///
+    /// A state, not a claim about the payload's shape. While it is set the
+    /// object holds no heap pointer, and the write barrier keeps that true: the
+    /// first pointer written into the object clears this flag and appends the
+    /// object to `prebuilt_root_objects`. That is what lets marking skip an
+    /// object still carrying it (incminimark.py:2782-2798) and lets
+    /// `_rrc_major_free` read it as "immortal, never traced so far".
+    ///
+    /// The invariant holds only where *every* pointer store into such an object
+    /// runs the barrier. Upstream gets that from the GC transform; a hand-
+    /// written store that skips it leaves a heap pointer behind a set flag, and
+    /// marking then walks past a live object.
+    pub const GCFLAG_NO_HEAP_PTRS: u64 = 1 << 1;
+    /// The object survived a major collection.
+    pub const GCFLAG_VISITED: u64 = 1 << 2;
+    /// Set on a nursery object whose id or identityhash was asked for: space
+    /// the size of the object is already reserved in the non-movable part.
+    pub const GCFLAG_HAS_SHADOW: u64 = 1 << 3;
+    /// Set temporarily during a major collection to order finalizers.
+    pub const GCFLAG_FINALIZATION_ORDERING: u64 = 1 << 4;
+    /// Reserved for RPython.
+    pub const GCFLAG_EXTRA: u64 = 1 << 5;
+    /// Set on an externally raw-malloced array of pointers: it carries extra
+    /// space in front for a bitfield, one bit per `card_page_indices` indices.
+    pub const GCFLAG_HAS_CARDS: u64 = 1 << 6;
+    /// At least one card bit is set. This is the most significant bit of the
+    /// byte holding `GCFLAG_TRACK_YOUNG_PTRS`, which the x86 backend requires.
+    pub const GCFLAG_CARDS_SET: u64 = 1 << 7;
+    /// Set on a raw-malloced young object that survived a minor collection.
+    pub const GCFLAG_VISITED_RMY: u64 = 1 << 8;
+    /// Keep this nursery object in the nursery: a young object carrying it is
+    /// not moved out by a minor collection. See `pin()` / `unpin()`.
+    pub const GCFLAG_PINNED: u64 = 1 << 9;
+    /// The same bit as [`GCFLAG_PINNED`], reused on objects outside the
+    /// nursery, where pinning cannot apply. Set means the object is already an
+    /// element of `old_objects_pointing_to_pinned` and need not be added again.
+    pub const GCFLAG_PINNED_OBJECT_PARENT_KNOWN: u64 = GCFLAG_PINNED;
+    /// `ignore_finalizer()` has been called on the object.
+    pub const GCFLAG_IGNORE_FINALIZER: u64 = 1 << 10;
+    /// A shadow object whose memory was initialized as it was created, so
+    /// tracing out needs no additional copy.
+    pub const GCFLAG_SHADOW_INITIALIZED: u64 = 1 << 11;
+    /// The `ll_dummy_value` from `rpython.rtyper.rmodel`.
+    pub const GCFLAG_DUMMY: u64 = 1 << 12;
     /// The object is already on a finalizer queue (bit 13).
     ///
     /// Not an incminimark flag — bit 13 is `_GCFLAG_FIRST_UNUSED`
@@ -340,8 +369,9 @@ impl WriteBarrierDescr {
     /// header layout. gc.py:259-293 WriteBarrierDescr.__init__.
     pub fn for_current_gc() -> Self {
         let (if_flag_byteofs, if_flag_singlebyte) =
-            Self::extract_flag_byte(flags::TRACK_YOUNG_PTRS);
-        let (cards_set_byteofs, cards_set_singlebyte) = Self::extract_flag_byte(flags::CARDS_SET);
+            Self::extract_flag_byte(flags::GCFLAG_TRACK_YOUNG_PTRS);
+        let (cards_set_byteofs, cards_set_singlebyte) =
+            Self::extract_flag_byte(flags::GCFLAG_CARDS_SET);
         // gc.py:280-281: the x86 backend relies on these two facts
         // to avoid one instruction in _write_barrier_fastpath.
         debug_assert_eq!(
@@ -353,10 +383,10 @@ impl WriteBarrierDescr {
             "CARDS_SET must be the MSB of its byte (-0x80)"
         );
         WriteBarrierDescr {
-            jit_wb_if_flag: flags::TRACK_YOUNG_PTRS,
+            jit_wb_if_flag: flags::GCFLAG_TRACK_YOUNG_PTRS,
             jit_wb_if_flag_byteofs: if_flag_byteofs,
             jit_wb_if_flag_singlebyte: if_flag_singlebyte as u8,
-            jit_wb_cards_set: flags::CARDS_SET,
+            jit_wb_cards_set: flags::GCFLAG_CARDS_SET,
             jit_wb_card_page_shift: crate::collector::DEFAULT_CARD_PAGE_SHIFT,
             jit_wb_cards_set_byteofs: cards_set_byteofs,
             jit_wb_cards_set_singlebyte: cards_set_singlebyte,
@@ -3192,7 +3222,7 @@ pub fn gc_object_finalizer_pending(addr: usize) -> bool {
     unsafe {
         (*hdr).has_flag(flags::FINALIZER_REGISTERED)
             && !(*hdr).has_flag(flags::FINALIZER_RUN)
-            && !(*hdr).has_flag(flags::IGNORE_FINALIZER)
+            && !(*hdr).has_flag(flags::GCFLAG_IGNORE_FINALIZER)
     }
 }
 
@@ -3713,7 +3743,7 @@ pub fn bh_probe_scan(reason: &str) {
             // remembered set, so a young field in it is legal and will be
             // traced.  Only a flagged object naming the nursery is a lost edge.
             let hdr = (addr - crate::header::GcHeader::SIZE) as *const crate::header::GcHeader;
-            if unsafe { !(*hdr).has_flag(crate::flags::TRACK_YOUNG_PTRS) } {
+            if unsafe { !(*hdr).has_flag(crate::flags::GCFLAG_TRACK_YOUNG_PTRS) } {
                 continue;
             }
             for offset in (0..payload_size).step_by(std::mem::size_of::<usize>()) {

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1369,7 +1369,7 @@ impl GcAllocator for GcHandle {
         // No root bracket: the barrier neither allocates nor collects, so
         // nothing inside it can move `obj`.  `do_write_barrier` /
         // `remember_young_pointer` (collector.rs) read headers, append to the
-        // host-allocated `remembered_set`, and clear a tid flag — which is why
+        // host-allocated `old_objects_pointing_to_young`, and clear a tid flag — which is why
         // upstream inlines the barrier at the store (framework.py:533-537) and
         // publishes no shadow-stack root anywhere in it.  Restore the bracket
         // if the remembered set ever becomes GC-managed.

--- a/majit/majit-gc/src/oldgen.rs
+++ b/majit/majit-gc/src/oldgen.rs
@@ -269,8 +269,8 @@ impl OldGen {
         self.young_rawmalloced_payloads.clear();
         for object in young {
             let hdr = unsafe { &mut *(object.header_addr as *mut GcHeader) };
-            if hdr.has_flag(flags::VISITED_RMY) {
-                hdr.clear_flag(flags::VISITED_RMY);
+            if hdr.has_flag(flags::GCFLAG_VISITED_RMY) {
+                hdr.clear_flag(flags::GCFLAG_VISITED_RMY);
                 self.old_rawmalloced_objects.push(object);
                 continue;
             }
@@ -396,8 +396,8 @@ impl OldGen {
         while !self.raw_malloc_might_sweep.is_empty() && nobjects > 0 {
             let object = self.raw_malloc_might_sweep.pop().unwrap();
             let hdr = unsafe { &mut *(object.header_addr as *mut GcHeader) };
-            if hdr.has_flag(flags::VISITED) {
-                hdr.clear_flag(flags::VISITED);
+            if hdr.has_flag(flags::GCFLAG_VISITED) {
+                hdr.clear_flag(flags::GCFLAG_VISITED);
                 self.old_rawmalloced_objects.push(object);
             } else {
                 if log_free {
@@ -436,8 +436,8 @@ impl OldGen {
         self.ac.mass_free_incremental(
             &mut |header_ptr| unsafe {
                 let hdr = &mut *(header_ptr as *mut GcHeader);
-                if hdr.has_flag(flags::VISITED) {
-                    hdr.clear_flag(flags::VISITED);
+                if hdr.has_flag(flags::GCFLAG_VISITED) {
+                    hdr.clear_flag(flags::GCFLAG_VISITED);
                     false
                 } else {
                     if log_free {
@@ -546,7 +546,7 @@ impl OldGen {
     }
 
     pub fn mark_visited(obj_addr: usize) {
-        unsafe { (*header_of(obj_addr)).set_flag(flags::VISITED) };
+        unsafe { (*header_of(obj_addr)).set_flag(flags::GCFLAG_VISITED) };
     }
 }
 
@@ -623,10 +623,10 @@ mod tests {
         unsafe {
             *p1.cast::<GcHeader>() = GcHeader::new(0);
             *p2.cast::<GcHeader>() = GcHeader::new(0);
-            (*p1.cast::<GcHeader>()).set_flag(flags::VISITED);
+            (*p1.cast::<GcHeader>()).set_flag(flags::GCFLAG_VISITED);
         }
         oldgen.sweep();
-        assert!(!unsafe { (*p1.cast::<GcHeader>()).has_flag(flags::VISITED) });
+        assert!(!unsafe { (*p1.cast::<GcHeader>()).has_flag(flags::GCFLAG_VISITED) });
         let p3 = oldgen.alloc(GcHeader::SIZE + 16);
         assert_eq!(p3, p2);
     }
@@ -639,7 +639,7 @@ mod tests {
         assert_eq!(unsafe { *ptr.sub(1) }, 0);
         unsafe {
             *ptr.cast::<GcHeader>() = GcHeader::new(0);
-            (*ptr.cast::<GcHeader>()).set_flag(flags::VISITED);
+            (*ptr.cast::<GcHeader>()).set_flag(flags::GCFLAG_VISITED);
         }
         assert!(oldgen.contains(ptr as usize + GcHeader::SIZE));
         assert_eq!(oldgen.total_bytes(), round_up(size + 2 * WORD));

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -1299,7 +1299,7 @@ mod tests {
     }
 
     #[test]
-    fn target_token_minor_scan_follows_minimark_remembered_set_lifetime() {
+    fn target_token_minor_scan_follows_minimark_old_objects_pointing_to_young_lifetime() {
         let mut token = TargetToken::new_loop(1);
         assert!(token.take_minor_scan_pending());
         assert!(!token.take_minor_scan_pending());

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -25568,7 +25568,7 @@ mod tests {
             .get_cell(green_key)
             .expect("temp callback should install a jit cell");
         assert_ne!(
-            cell.flags & crate::warmstate::jc_flags::TEMPORARY,
+            cell.flags & crate::warmstate::jc_flags::JC_TEMPORARY,
             0,
             "temp callback token should mark the cell as TEMPORARY"
         );

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -21,17 +21,17 @@ use crate::recorder::Trace;
 /// Flags on a BaseJitCell, mirroring warmstate.py JC_* constants.
 pub mod jc_flags {
     /// We are currently tracing from this green key.
-    pub const TRACING: u8 = 0x01;
+    pub const JC_TRACING: u8 = 0x01;
     /// Don't trace here (e.g., trace was too long last time).
-    pub const DONT_TRACE_HERE: u8 = 0x02;
+    pub const JC_DONT_TRACE_HERE: u8 = 0x02;
     /// Has a temporary procedure token (CALL_ASSEMBLER fallback).
-    pub const TEMPORARY: u8 = 0x04;
+    pub const JC_TEMPORARY: u8 = 0x04;
     /// Tracing has occurred at least once from this key.
-    pub const TRACING_OCCURRED: u8 = 0x08;
+    pub const JC_TRACING_OCCURRED: u8 = 0x08;
     /// warmstate.py: JC_FORCE_FINISH — the loop has a FINISH that
     /// returns a raw int (not a boxed pointer). Used by
     /// call_assembler to decide whether to unbox the result.
-    pub const FORCE_FINISH: u8 = 0x10;
+    pub const JC_FORCE_FINISH: u8 = 0x10;
 }
 
 /// Explicit state of a BaseJitCell in the JIT lifecycle.
@@ -230,13 +230,13 @@ impl BaseJitCell {
     }
 
     pub fn is_tracing(&self) -> bool {
-        self.flags & jc_flags::TRACING != 0
+        self.flags & jc_flags::JC_TRACING != 0
     }
 
     /// warmstate.py — get_procedure_token returns None for
     /// invalidated tokens. is_compiled additionally excludes TEMPORARY.
     pub fn is_compiled(&self) -> bool {
-        self.get_procedure_token().is_some() && (self.flags & jc_flags::TEMPORARY == 0)
+        self.get_procedure_token().is_some() && (self.flags & jc_flags::JC_TEMPORARY == 0)
     }
 
     /// warmstate.py `get_procedure_token`.
@@ -315,9 +315,9 @@ impl BaseJitCell {
             .replace(Self::_makeref(&loop_token))
             .and_then(|wref| wref.upgrade());
         if tmp {
-            self.flags |= jc_flags::TEMPORARY;
+            self.flags |= jc_flags::JC_TEMPORARY;
         } else {
-            self.flags &= !jc_flags::TEMPORARY;
+            self.flags &= !jc_flags::JC_TEMPORARY;
             self.state = BaseJitCellState::Compiled;
         }
         old
@@ -362,15 +362,15 @@ impl BaseJitCell {
         if self.get_procedure_token().is_some() {
             return false; // has a valid procedure token
         }
-        if self.flags & jc_flags::TRACING != 0 {
+        if self.flags & jc_flags::JC_TRACING != 0 {
             return false; // currently tracing
         }
-        if self.flags & jc_flags::DONT_TRACE_HERE != 0 {
+        if self.flags & jc_flags::JC_DONT_TRACE_HERE != 0 {
             // Remove only if we had a token that is now dead.
             return self.has_seen_a_procedure_token();
         }
         // warmstate.py:222-225
-        if self.flags & jc_flags::FORCE_FINISH != 0 {
+        if self.flags & jc_flags::JC_FORCE_FINISH != 0 {
             return false;
         }
         true
@@ -773,10 +773,10 @@ impl WarmEnterState {
         flags: u8,
         has_seen_a_procedure_token: bool,
     ) -> bool {
-        if flags & jc_flags::DONT_TRACE_HERE == 0 || has_seen_a_procedure_token {
+        if flags & jc_flags::JC_DONT_TRACE_HERE == 0 || has_seen_a_procedure_token {
             return false;
         }
-        if flags & jc_flags::TRACING_OCCURRED != 0 {
+        if flags & jc_flags::JC_TRACING_OCCURRED != 0 {
             let bucket = self.bucket_of(cell_key);
             self.counter.tick(bucket, self.increment_threshold)
         } else {
@@ -800,7 +800,7 @@ impl WarmEnterState {
         self.tracing_generation += 1;
         let current_generation = self.tracing_generation;
         let cell = self.ensure_cell_by_key(cell_key);
-        cell.flags |= jc_flags::TRACING | jc_flags::TRACING_OCCURRED;
+        cell.flags |= jc_flags::JC_TRACING | jc_flags::JC_TRACING_OCCURRED;
         cell.state = BaseJitCellState::Tracing;
         cell.tracing_generation = current_generation;
 
@@ -915,7 +915,7 @@ impl WarmEnterState {
             if cell.is_compiled() || cell.is_tracing() {
                 return true;
             }
-            if cell.flags & jc_flags::DONT_TRACE_HERE != 0 {
+            if cell.flags & jc_flags::JC_DONT_TRACE_HERE != 0 {
                 return false;
             }
         }
@@ -926,7 +926,7 @@ impl WarmEnterState {
     /// warmstate.py:467: jitcounter.tick(hash, increment_threshold).
     pub fn counter_tick(&mut self, cell_key: u64) {
         if let Some(cell) = self.cell_by_key(cell_key) {
-            if cell.flags & jc_flags::DONT_TRACE_HERE != 0 {
+            if cell.flags & jc_flags::JC_DONT_TRACE_HERE != 0 {
                 return;
             }
         }
@@ -944,7 +944,7 @@ impl WarmEnterState {
             // procedure token it once saw has since been invalidated: that
             // dead entry must fall through to cleanup_chain (warmstate.py:483-491)
             // instead of returning early and lingering in the chain.
-            if cell.flags & jc_flags::DONT_TRACE_HERE != 0
+            if cell.flags & jc_flags::JC_DONT_TRACE_HERE != 0
                 && cell.has_seen_a_procedure_token()
                 && cell.get_procedure_token().is_some()
             {
@@ -1086,7 +1086,7 @@ impl WarmEnterState {
             }
             // A JC_DONT_TRACE_HERE cell declines here, except when its token
             // is dead — that entry belongs to the cleanup path above.
-            if flags & jc_flags::DONT_TRACE_HERE != 0 && !dead_token {
+            if flags & jc_flags::JC_DONT_TRACE_HERE != 0 && !dead_token {
                 return HotResult::NotHot;
             }
             if dead_token {
@@ -1232,7 +1232,7 @@ impl WarmEnterState {
             }
             // A JC_DONT_TRACE_HERE cell declines here, except when its token
             // is dead — that entry belongs to the cleanup path above.
-            if flags & jc_flags::DONT_TRACE_HERE != 0 && !dead_token {
+            if flags & jc_flags::JC_DONT_TRACE_HERE != 0 && !dead_token {
                 return HotResult::NotHot;
             }
             if dead_token {
@@ -1292,7 +1292,7 @@ impl WarmEnterState {
         let cell = self
             .lookup_chain_with_key_mut(key)
             .expect("ensure_cell_for_key just installed a cell matching this key");
-        cell.flags |= jc_flags::TRACING | jc_flags::TRACING_OCCURRED;
+        cell.flags |= jc_flags::JC_TRACING | jc_flags::JC_TRACING_OCCURRED;
         cell.state = BaseJitCellState::Tracing;
         cell.tracing_generation = current_generation;
         HotResult::StartTracing
@@ -1303,7 +1303,7 @@ impl WarmEnterState {
     /// clears `JC_TRACING` on its own cell rather than the bucket head.
     pub fn finish_tracing_for_key(&mut self, key: &GreenKey) {
         if let Some(cell) = self.lookup_chain_with_key_mut(key) {
-            cell.flags &= !jc_flags::TRACING;
+            cell.flags &= !jc_flags::JC_TRACING;
             // State remains Tracing until attach_procedure_to_interp is called.
         }
     }
@@ -1313,12 +1313,12 @@ impl WarmEnterState {
     /// cell's `JC_TRACING` / pyre-local abort-count / `DONT_TRACE_HERE` state.
     pub fn abort_tracing_for_key(&mut self, key: &GreenKey, disable_noninlinable_function: bool) {
         if let Some(cell) = self.lookup_chain_with_key_mut(key) {
-            cell.flags &= !jc_flags::TRACING;
+            cell.flags &= !jc_flags::JC_TRACING;
             cell.abort_count += 1;
-            let already_banned = cell.flags & jc_flags::DONT_TRACE_HERE != 0;
+            let already_banned = cell.flags & jc_flags::JC_DONT_TRACE_HERE != 0;
             let ceiling_reached = cell.abort_ceiling_latched();
             if disable_noninlinable_function || already_banned || ceiling_reached {
-                cell.flags |= jc_flags::DONT_TRACE_HERE;
+                cell.flags |= jc_flags::JC_DONT_TRACE_HERE;
             }
             if ceiling_reached && !already_banned && !disable_noninlinable_function {
                 crate::mc_diag_bump(80); // abort_ceiling_banned
@@ -1356,7 +1356,7 @@ impl WarmEnterState {
         let cell = self
             .lookup_chain_with_key_mut(key)
             .expect("ensure_cell_for_key just installed a cell matching this key");
-        cell.flags |= jc_flags::DONT_TRACE_HERE;
+        cell.flags |= jc_flags::JC_DONT_TRACE_HERE;
     }
 
     /// Force-start tracing for a green key, bypassing the hot counter.
@@ -1382,8 +1382,8 @@ impl WarmEnterState {
             // callee's real standalone trace even when that callee was marked
             // non-inlinable.  Refusing the combination here strands the
             // JC_FORCE_FINISH retry installed after a trace-too-long abort.
-            if cell.flags & jc_flags::DONT_TRACE_HERE != 0
-                && cell.flags & jc_flags::TEMPORARY == 0
+            if cell.flags & jc_flags::JC_DONT_TRACE_HERE != 0
+                && cell.flags & jc_flags::JC_TEMPORARY == 0
                 && cell.has_seen_a_procedure_token()
             {
                 return HotResult::NotHot;
@@ -1415,8 +1415,8 @@ impl WarmEnterState {
             if cell.is_tracing() {
                 return HotResult::AlreadyTracing;
             }
-            if cell.flags & jc_flags::DONT_TRACE_HERE != 0
-                && cell.flags & jc_flags::TEMPORARY == 0
+            if cell.flags & jc_flags::JC_DONT_TRACE_HERE != 0
+                && cell.flags & jc_flags::JC_TEMPORARY == 0
                 && cell.has_seen_a_procedure_token()
             {
                 return HotResult::NotHot;
@@ -1448,7 +1448,7 @@ impl WarmEnterState {
     /// `attach_procedure_to_interp` with the resulting JitCellToken.
     pub fn finish_tracing(&mut self, cell_key: u64) {
         if let Some(cell) = self.cell_by_key_mut(cell_key) {
-            cell.flags &= !jc_flags::TRACING;
+            cell.flags &= !jc_flags::JC_TRACING;
             // State remains Tracing until attach_procedure_to_interp is called.
         }
     }
@@ -1459,16 +1459,16 @@ impl WarmEnterState {
     /// pyre's abort ceiling marks the location `DONT_TRACE_HERE`.
     pub fn abort_tracing(&mut self, cell_key: u64, disable_noninlinable_function: bool) {
         if let Some(cell) = self.cell_by_key_mut(cell_key) {
-            cell.flags &= !jc_flags::TRACING;
+            cell.flags &= !jc_flags::JC_TRACING;
             cell.abort_count += 1;
             // The last disjunct is pyre's abort ceiling: too many failed
             // attempts permanently disable tracing here — and, through the same
             // flag, inlining from elsewhere.  `MAX_TRACE_ABORT_COUNT` carries
             // the measurement that keeps the two together.
-            let already_banned = cell.flags & jc_flags::DONT_TRACE_HERE != 0;
+            let already_banned = cell.flags & jc_flags::JC_DONT_TRACE_HERE != 0;
             let ceiling_reached = cell.abort_ceiling_latched();
             if disable_noninlinable_function || already_banned || ceiling_reached {
-                cell.flags |= jc_flags::DONT_TRACE_HERE;
+                cell.flags |= jc_flags::JC_DONT_TRACE_HERE;
             }
             if ceiling_reached && !already_banned && !disable_noninlinable_function {
                 crate::mc_diag_bump(80); // abort_ceiling_banned
@@ -1505,7 +1505,7 @@ impl WarmEnterState {
     ) -> Option<Arc<JitCellToken>> {
         let token = token.into();
         let cell = self.ensure_cell_by_key(cell_key);
-        cell.flags &= !jc_flags::TRACING;
+        cell.flags &= !jc_flags::JC_TRACING;
         let previous = cell.set_procedure_token(token, false);
         self.bump_cell_generation();
         previous
@@ -1530,7 +1530,7 @@ impl WarmEnterState {
         let cell = self
             .lookup_chain_with_key_mut(key)
             .expect("ensure_cell_for_key just installed a cell matching this key");
-        cell.flags &= !jc_flags::TRACING;
+        cell.flags &= !jc_flags::JC_TRACING;
         let previous = cell.set_procedure_token(token, false);
         self.bump_cell_generation();
         previous
@@ -1566,7 +1566,7 @@ impl WarmEnterState {
     /// the state transition for whichever cell they touch.
     pub fn clear_tracing_flag(&mut self, cell_key: u64) {
         if let Some(cell) = self.cell_by_key_mut(cell_key) {
-            cell.flags &= !jc_flags::TRACING;
+            cell.flags &= !jc_flags::JC_TRACING;
         }
     }
 
@@ -1601,7 +1601,7 @@ impl WarmEnterState {
     /// separately.
     pub fn clear_tracing_flag_for_key(&mut self, key: &GreenKey) {
         if let Some(cell) = self.lookup_chain_with_key_mut(key) {
-            cell.flags &= !jc_flags::TRACING;
+            cell.flags &= !jc_flags::JC_TRACING;
         }
     }
 
@@ -1758,7 +1758,7 @@ impl WarmEnterState {
     /// Check if a green key carries `JC_DONT_TRACE_HERE`.
     pub fn is_dont_trace_here(&self, cell_key: u64) -> bool {
         self.cell_by_key(cell_key)
-            .is_some_and(|c| c.flags & jc_flags::DONT_TRACE_HERE != 0)
+            .is_some_and(|c| c.flags & jc_flags::JC_DONT_TRACE_HERE != 0)
     }
 
     /// Get a reference to the BaseJitCell for a green key, if it exists.
@@ -2129,7 +2129,7 @@ impl WarmEnterState {
     /// converge to a separate functrace / call_assembler path.
     pub fn can_inline_callable(&self, callee_key: u64) -> bool {
         self.cell_by_key(callee_key)
-            .is_none_or(|cell| cell.flags & jc_flags::DONT_TRACE_HERE == 0)
+            .is_none_or(|cell| cell.flags & jc_flags::JC_DONT_TRACE_HERE == 0)
     }
 
     /// Typed-key variant of [`Self::can_inline_callable`].
@@ -2142,7 +2142,7 @@ impl WarmEnterState {
     /// typed cell.
     pub fn can_inline_callable_for_key(&self, key: &GreenKey) -> bool {
         self.lookup_chain_with_key(key)
-            .is_none_or(|cell| cell.flags & jc_flags::DONT_TRACE_HERE == 0)
+            .is_none_or(|cell| cell.flags & jc_flags::JC_DONT_TRACE_HERE == 0)
     }
 
     /// Mark a callee as a location that should no longer be inlined into
@@ -2151,7 +2151,7 @@ impl WarmEnterState {
     /// This is the warm-state equivalent of PyPy's `disable_noninlinable_function()`.
     pub fn disable_noninlinable_function(&mut self, callee_key: u64) {
         let cell = self.ensure_cell_by_key(callee_key);
-        cell.flags |= jc_flags::DONT_TRACE_HERE;
+        cell.flags |= jc_flags::JC_DONT_TRACE_HERE;
     }
 
     /// Mark a callee as currently being traced.
@@ -2160,8 +2160,8 @@ impl WarmEnterState {
     pub fn mark_as_being_traced(&mut self, callee_key: u64) {
         let tracing_generation = self.tracing_generation;
         let cell = self.ensure_cell_by_key(callee_key);
-        cell.flags |= jc_flags::TRACING;
-        if cell.flags & jc_flags::TRACING_OCCURRED == 0 {
+        cell.flags |= jc_flags::JC_TRACING;
+        if cell.flags & jc_flags::JC_TRACING_OCCURRED == 0 {
             cell.state = BaseJitCellState::Tracing;
             cell.tracing_generation = tracing_generation;
         }
@@ -2186,8 +2186,8 @@ impl WarmEnterState {
         let cell = self
             .lookup_chain_with_key_mut(key)
             .expect("ensure_cell_for_key just installed a cell matching this key");
-        cell.flags |= jc_flags::TRACING;
-        if cell.flags & jc_flags::TRACING_OCCURRED == 0 {
+        cell.flags |= jc_flags::JC_TRACING;
+        if cell.flags & jc_flags::JC_TRACING_OCCURRED == 0 {
             cell.state = BaseJitCellState::Tracing;
             cell.tracing_generation = tracing_generation;
         }
@@ -2224,7 +2224,7 @@ impl WarmEnterState {
     /// wherever the green key itself is in scope.
     pub fn mark_force_finish_tracing(&mut self, cell_key: u64) {
         let cell = self.ensure_cell_by_key(cell_key);
-        cell.flags |= jc_flags::FORCE_FINISH;
+        cell.flags |= jc_flags::JC_FORCE_FINISH;
     }
 
     /// Typed form of [`Self::mark_force_finish_tracing`].
@@ -2237,7 +2237,7 @@ impl WarmEnterState {
         let cell = self
             .lookup_chain_with_key_mut(key)
             .expect("ensure_cell_for_key just installed a cell matching this key");
-        cell.flags |= jc_flags::FORCE_FINISH;
+        cell.flags |= jc_flags::JC_FORCE_FINISH;
     }
 
     /// warmstate.py `bool(cell.flags & JC_FORCE_FINISH)` — read the sticky
@@ -2247,7 +2247,7 @@ impl WarmEnterState {
     /// is removed.
     pub fn should_force_finish_tracing(&self, cell_key: u64) -> bool {
         self.cell_by_key(cell_key)
-            .is_some_and(|cell| cell.flags & jc_flags::FORCE_FINISH != 0)
+            .is_some_and(|cell| cell.flags & jc_flags::JC_FORCE_FINISH != 0)
     }
 
     /// Boost the current loop/function green key so the next execution
@@ -2409,7 +2409,7 @@ impl WarmEnterState {
             // interpreter callback used until the non-inlinable callee gets
             // its own real trace, not evidence that the callee was already
             // compiled separately.
-            if cell.flags & jc_flags::TEMPORARY != 0 {
+            if cell.flags & jc_flags::JC_TEMPORARY != 0 {
                 crate::mc_diag_bump(25);
                 return if self
                     .counter
@@ -2420,7 +2420,7 @@ impl WarmEnterState {
                     FunctionEntryStep::NotHot
                 };
             }
-            if cell.flags & jc_flags::DONT_TRACE_HERE != 0 {
+            if cell.flags & jc_flags::JC_DONT_TRACE_HERE != 0 {
                 if cell.has_seen_a_procedure_token() {
                     // A non-temporary token that was once seen but has since
                     // been invalidated falls through to the cleanup gate below
@@ -2430,7 +2430,7 @@ impl WarmEnterState {
                     if cell.get_procedure_token().is_some() {
                         return FunctionEntryStep::NotHot;
                     }
-                } else if cell.flags & jc_flags::TRACING_OCCURRED == 0 {
+                } else if cell.flags & jc_flags::JC_TRACING_OCCURRED == 0 {
                     return FunctionEntryStep::Proceed;
                 }
             }
@@ -2505,16 +2505,16 @@ impl WarmEnterState {
                 crate::mc_diag_bump(81); // abort_ceiling_refused
                 return false;
             }
-            if cell.flags & jc_flags::TEMPORARY != 0 {
+            if cell.flags & jc_flags::JC_TEMPORARY != 0 {
                 crate::mc_diag_bump(25);
                 return self.counter.tick(bucket, self.increment_function_threshold);
             }
-            if cell.flags & jc_flags::DONT_TRACE_HERE != 0 {
+            if cell.flags & jc_flags::JC_DONT_TRACE_HERE != 0 {
                 if cell.has_seen_a_procedure_token() {
                     if cell.get_procedure_token().is_some() {
                         return false;
                     }
-                } else if cell.flags & jc_flags::TRACING_OCCURRED == 0 {
+                } else if cell.flags & jc_flags::JC_TRACING_OCCURRED == 0 {
                     return true;
                 }
             }
@@ -2652,15 +2652,15 @@ impl WarmEnterState {
 
         match new_state {
             BaseJitCellState::NotHot => {
-                cell.flags &= !(jc_flags::TRACING | jc_flags::DONT_TRACE_HERE);
+                cell.flags &= !(jc_flags::JC_TRACING | jc_flags::JC_DONT_TRACE_HERE);
                 cell.state = BaseJitCellState::NotHot;
             }
             BaseJitCellState::Tracing => {
-                cell.flags |= jc_flags::TRACING | jc_flags::TRACING_OCCURRED;
+                cell.flags |= jc_flags::JC_TRACING | jc_flags::JC_TRACING_OCCURRED;
                 cell.state = BaseJitCellState::Tracing;
             }
             BaseJitCellState::Compiled => {
-                cell.flags &= !jc_flags::TRACING;
+                cell.flags &= !jc_flags::JC_TRACING;
                 cell.state = BaseJitCellState::Compiled;
             }
             BaseJitCellState::Invalidated => {
@@ -2968,7 +2968,7 @@ impl WarmEnterState {
                 // Counted off the flag, not the lifecycle state: a denial is
                 // orthogonal to where the cell is in that lifecycle, and a cell
                 // denied while it goes on to trace carries only the flag.
-                if cell.flags & jc_flags::DONT_TRACE_HERE != 0 {
+                if cell.flags & jc_flags::JC_DONT_TRACE_HERE != 0 {
                     stats.num_disable_noninlinable_function += 1;
                 }
                 cur = cell.next.as_deref();
@@ -3837,7 +3837,7 @@ mod tests {
 
         let cell = ws.get_cell(42).unwrap();
         assert!(!cell.is_tracing());
-        assert!(cell.flags & jc_flags::TRACING_OCCURRED != 0);
+        assert!(cell.flags & jc_flags::JC_TRACING_OCCURRED != 0);
     }
 
     #[test]
@@ -3852,7 +3852,7 @@ mod tests {
 
         let cell = ws.get_cell(42).unwrap();
         assert!(!cell.is_tracing());
-        assert!(cell.flags & jc_flags::DONT_TRACE_HERE != 0);
+        assert!(cell.flags & jc_flags::JC_DONT_TRACE_HERE != 0);
 
         // RPython warmstate.py: a DONT_TRACE_HERE cell with no procedure token
         // still retriggers separate tracing after warming up again.
@@ -4093,7 +4093,7 @@ mod tests {
 
         // The key is now blacklisted.
         let cell = ws.get_cell(42).unwrap();
-        assert!(cell.flags & jc_flags::DONT_TRACE_HERE != 0);
+        assert!(cell.flags & jc_flags::JC_DONT_TRACE_HERE != 0);
         assert!(!cell.is_tracing());
 
         // RPython warmstate.py: DONT_TRACE_HERE still allows separate
@@ -4230,14 +4230,14 @@ mod tests {
         }
 
         let cell = ws.get_cell(key).unwrap();
-        assert!(cell.flags & jc_flags::TRACING_OCCURRED != 0);
+        assert!(cell.flags & jc_flags::JC_TRACING_OCCURRED != 0);
 
         ws.abort_tracing(key, false);
 
         let cell = ws.get_cell(key).unwrap();
         assert!(!cell.is_tracing());
         assert!(
-            cell.flags & jc_flags::TRACING_OCCURRED != 0,
+            cell.flags & jc_flags::JC_TRACING_OCCURRED != 0,
             "TRACING_OCCURRED should persist after abort"
         );
     }
@@ -4812,7 +4812,7 @@ mod tests {
         assert_eq!(ws.get_cell_state(key), BaseJitCellState::NotHot);
         // DONT_TRACE_HERE flag should be cleared
         let cell = ws.get_cell(key).unwrap();
-        assert!(cell.flags & jc_flags::DONT_TRACE_HERE == 0);
+        assert!(cell.flags & jc_flags::JC_DONT_TRACE_HERE == 0);
     }
 
     /// `warmstate.py bound_reached` traces unconditionally once
@@ -5087,12 +5087,12 @@ mod tests {
 
         // A cell that is tracing should NOT be removable
         let mut cell = BaseJitCell::new();
-        cell.flags |= jc_flags::TRACING;
+        cell.flags |= jc_flags::JC_TRACING;
         assert!(!cell.should_remove_jitcell());
 
         // A cell with DONT_TRACE_HERE but no token history is removable
         let mut cell = BaseJitCell::new();
-        cell.flags |= jc_flags::DONT_TRACE_HERE;
+        cell.flags |= jc_flags::JC_DONT_TRACE_HERE;
         assert!(!cell.should_remove_jitcell()); // has_seen_a_procedure_token is false
 
         // warmstate.py — a `JC_DONT_TRACE_HERE` cell that HAD a
@@ -5102,7 +5102,7 @@ mod tests {
         // slot (warmstate.py:198-199), which is what the arm below is a
         // reading of.
         let mut cell = BaseJitCell::new();
-        cell.flags |= jc_flags::DONT_TRACE_HERE;
+        cell.flags |= jc_flags::JC_DONT_TRACE_HERE;
         {
             let token = Arc::new(JitCellToken::new(42));
             cell.set_procedure_token(Arc::clone(&token), false);
@@ -5126,7 +5126,7 @@ mod tests {
 
         // warmstate.py:222-225: FORCE_FINISH must NOT be removed
         let mut cell = BaseJitCell::new();
-        cell.flags |= jc_flags::FORCE_FINISH;
+        cell.flags |= jc_flags::JC_FORCE_FINISH;
         assert!(!cell.should_remove_jitcell());
     }
 
@@ -5587,7 +5587,7 @@ mod tests {
             .get_cell(key.get_uhash())
             .expect("typed form installs a cell");
         assert!(
-            typed_cell.flags & jc_flags::DONT_TRACE_HERE != 0,
+            typed_cell.flags & jc_flags::JC_DONT_TRACE_HERE != 0,
             "typed form must set DONT_TRACE_HERE"
         );
         assert_eq!(
@@ -5602,7 +5602,7 @@ mod tests {
             .get_cell(key.get_uhash())
             .expect("hash form installs a cell");
         assert!(
-            hashed_cell.flags & jc_flags::DONT_TRACE_HERE != 0,
+            hashed_cell.flags & jc_flags::JC_DONT_TRACE_HERE != 0,
             "hash form must set DONT_TRACE_HERE — the flag is not the delta"
         );
         assert!(
@@ -5636,7 +5636,7 @@ mod tests {
         // install per install_new_cell's "prepend new cell, fold
         // existing keepable cells in front" semantics.
         let mut cell_first = BaseJitCell::new();
-        cell_first.flags |= jc_flags::TRACING;
+        cell_first.flags |= jc_flags::JC_TRACING;
         cell_first.comparekey = Some(key_head_after_chain.clone());
         ws.install_new_cell(bucket, Some(cell_first));
         // Second install — keep predicate doesn't matter for this one,
@@ -5672,11 +5672,11 @@ mod tests {
         let mut ws = WarmEnterState::new(100);
         let bucket = target.get_uhash();
         let mut decoy_cell = BaseJitCell::new();
-        decoy_cell.flags |= jc_flags::TRACING;
+        decoy_cell.flags |= jc_flags::JC_TRACING;
         decoy_cell.comparekey = Some(decoy.clone());
         ws.install_new_cell(bucket, Some(decoy_cell));
         let mut target_cell = BaseJitCell::new();
-        target_cell.flags |= jc_flags::TRACING;
+        target_cell.flags |= jc_flags::JC_TRACING;
         target_cell.comparekey = Some(target.clone());
         ws.install_new_cell(bucket, Some(target_cell));
         ws
@@ -5690,10 +5690,16 @@ mod tests {
         ws.finish_tracing_for_key(&target);
         let head = ws.lookup_chain(target.get_uhash()).expect("bucket head");
         assert_eq!(head.comparekey.as_ref(), Some(&decoy));
-        assert!(head.flags & jc_flags::TRACING != 0, "decoy head untouched");
+        assert!(
+            head.flags & jc_flags::JC_TRACING != 0,
+            "decoy head untouched"
+        );
         let hit = head.next.as_deref().expect("target chained behind decoy");
         assert_eq!(hit.comparekey.as_ref(), Some(&target));
-        assert!(hit.flags & jc_flags::TRACING == 0, "target TRACING cleared");
+        assert!(
+            hit.flags & jc_flags::JC_TRACING == 0,
+            "target TRACING cleared"
+        );
     }
 
     #[test]
@@ -5704,17 +5710,20 @@ mod tests {
         ws.abort_tracing_for_key(&target, true);
         let head = ws.lookup_chain(target.get_uhash()).expect("bucket head");
         assert!(
-            head.flags & jc_flags::TRACING != 0,
+            head.flags & jc_flags::JC_TRACING != 0,
             "decoy head still TRACING"
         );
         assert!(
-            head.flags & jc_flags::DONT_TRACE_HERE == 0,
+            head.flags & jc_flags::JC_DONT_TRACE_HERE == 0,
             "decoy not disabled"
         );
         let hit = head.next.as_deref().expect("target chained behind decoy");
-        assert!(hit.flags & jc_flags::TRACING == 0, "target TRACING cleared");
         assert!(
-            hit.flags & jc_flags::DONT_TRACE_HERE != 0,
+            hit.flags & jc_flags::JC_TRACING == 0,
+            "target TRACING cleared"
+        );
+        assert!(
+            hit.flags & jc_flags::JC_DONT_TRACE_HERE != 0,
             "target disabled by permanent abort"
         );
     }
@@ -5727,12 +5736,12 @@ mod tests {
         ws.mark_dont_trace_for_key(&target);
         let head = ws.lookup_chain(target.get_uhash()).expect("bucket head");
         assert!(
-            head.flags & jc_flags::DONT_TRACE_HERE == 0,
+            head.flags & jc_flags::JC_DONT_TRACE_HERE == 0,
             "decoy head not disabled"
         );
         let hit = head.next.as_deref().expect("target chained behind decoy");
         assert!(
-            hit.flags & jc_flags::DONT_TRACE_HERE != 0,
+            hit.flags & jc_flags::JC_DONT_TRACE_HERE != 0,
             "target disabled"
         );
     }
@@ -5750,12 +5759,12 @@ mod tests {
         // this fixture would be testing nothing.
         ws.memory_manager.keep_loop_alive(&token);
         let mut decoy_cell = BaseJitCell::new();
-        decoy_cell.flags |= jc_flags::TRACING;
+        decoy_cell.flags |= jc_flags::JC_TRACING;
         decoy_cell.comparekey = Some(decoy.clone());
         decoy_cell.loop_token = Some(std::sync::Arc::downgrade(&token));
         ws.install_new_cell(bucket, Some(decoy_cell));
         let mut target_cell = BaseJitCell::new();
-        target_cell.flags |= jc_flags::TRACING;
+        target_cell.flags |= jc_flags::JC_TRACING;
         target_cell.comparekey = Some(target.clone());
         target_cell.loop_token = Some(std::sync::Arc::downgrade(&token));
         ws.install_new_cell(bucket, Some(target_cell));
@@ -5806,7 +5815,7 @@ mod tests {
         // JC_TEMPORARY must be set since tmp=true.
         let cell = ws.lookup_chain_with_key(&key).expect("cell installed");
         assert!(
-            cell.flags & jc_flags::TEMPORARY != 0,
+            cell.flags & jc_flags::JC_TEMPORARY != 0,
             "tmp token must set JC_TEMPORARY"
         );
     }
@@ -5837,9 +5846,9 @@ mod tests {
 
         let typed = ws.lookup_chain_with_key(&key).expect("typed callee cell");
         assert_ne!(typed.cell_key, Some(bucket), "typed cell is chained/minted");
-        assert_ne!(typed.flags & jc_flags::TEMPORARY, 0);
-        assert_ne!(typed.flags & jc_flags::DONT_TRACE_HERE, 0);
-        assert_ne!(typed.flags & jc_flags::FORCE_FINISH, 0);
+        assert_ne!(typed.flags & jc_flags::JC_TEMPORARY, 0);
+        assert_ne!(typed.flags & jc_flags::JC_DONT_TRACE_HERE, 0);
+        assert_ne!(typed.flags & jc_flags::JC_FORCE_FINISH, 0);
 
         assert!(
             ws.should_trace_function_entry_for_key(&key),
@@ -5853,7 +5862,7 @@ mod tests {
         let typed = ws.lookup_chain_with_key(&key).expect("typed callee cell");
         assert!(typed.is_tracing(), "the matching typed cell starts tracing");
         assert_ne!(
-            typed.flags & jc_flags::FORCE_FINISH,
+            typed.flags & jc_flags::JC_FORCE_FINISH,
             0,
             "the standalone retry retains its segmenting request"
         );
@@ -5978,7 +5987,7 @@ mod tests {
              it can store no comparekey",
         );
         assert_ne!(
-            head.flags & jc_flags::DONT_TRACE_HERE,
+            head.flags & jc_flags::JC_DONT_TRACE_HERE,
             0,
             "the head still holds the mark the hash form wrote",
         );
@@ -6275,7 +6284,7 @@ mod tests {
         // TRACING keeps the head non-removable so the second install chains
         // behind it rather than replacing it (counter.py:246-256).
         let mut head = BaseJitCell::new();
-        head.flags |= jc_flags::TRACING;
+        head.flags |= jc_flags::JC_TRACING;
         head.comparekey = Some(key_head.clone());
         ws.install_new_cell(bucket, Some(head));
 
@@ -6285,7 +6294,7 @@ mod tests {
         // handle is weak (`warmstate.py:188`, `memmgr.py:9-14`).
         ws.memory_manager.keep_loop_alive(&chained_token);
         let mut tail = BaseJitCell::new();
-        tail.flags |= jc_flags::TRACING;
+        tail.flags |= jc_flags::JC_TRACING;
         tail.comparekey = Some(key_tail.clone());
         tail.loop_token = Some(std::sync::Arc::downgrade(&chained_token));
         ws.install_new_cell(bucket, Some(tail));
@@ -6367,7 +6376,7 @@ mod tests {
         // (counter.py:246-256 should_remove gate) so the next install
         // chains B behind A.
         let mut cell_a = BaseJitCell::new();
-        cell_a.flags |= jc_flags::TRACING;
+        cell_a.flags |= jc_flags::JC_TRACING;
         cell_a.comparekey = Some(key_a.clone());
         ws.install_new_cell(bucket, Some(cell_a));
 
@@ -6498,7 +6507,7 @@ mod tests {
             .lookup_chain_with_key(&key)
             .expect("the key must own a cell reachable by comparekey");
         assert!(
-            cell.flags & jc_flags::TRACING != 0,
+            cell.flags & jc_flags::JC_TRACING != 0,
             "TRACING must land on the key's own cell",
         );
         assert_eq!(
@@ -6564,7 +6573,7 @@ mod tests {
             "the procedure token must land on the key's own cell",
         );
         assert_eq!(
-            cell.flags & jc_flags::TRACING,
+            cell.flags & jc_flags::JC_TRACING,
             0,
             "and TRACING must be cleared on that same cell",
         );
@@ -7359,7 +7368,7 @@ mod tests {
             .lookup_chain_with_key(&key)
             .expect("the key must own a cell reachable by comparekey");
         assert!(
-            cell.flags & jc_flags::FORCE_FINISH != 0,
+            cell.flags & jc_flags::JC_FORCE_FINISH != 0,
             "FORCE_FINISH is sticky and never cleared, so landing it on the \
              wrong cell of the bucket is permanent",
         );
@@ -7397,13 +7406,13 @@ mod tests {
         // it rather than dropping it (counter.py:246-256 should_remove gate).
         let mut tail = BaseJitCell::new();
         tail.state = BaseJitCellState::Tracing;
-        tail.flags |= jc_flags::TRACING;
+        tail.flags |= jc_flags::JC_TRACING;
         tail.comparekey = Some(key_tail);
         ws.install_new_cell(bucket, Some(tail));
 
         let mut head = BaseJitCell::new();
         head.state = BaseJitCellState::Compiled;
-        head.flags |= jc_flags::TRACING;
+        head.flags |= jc_flags::JC_TRACING;
         head.comparekey = Some(key_head);
         ws.install_new_cell(bucket, Some(head));
 
@@ -7441,7 +7450,7 @@ mod tests {
 
         // Head A: must stay non-removable across B's install.
         let mut cell_a = BaseJitCell::new();
-        cell_a.flags |= jc_flags::TRACING;
+        cell_a.flags |= jc_flags::JC_TRACING;
         cell_a.comparekey = Some(key_a.clone());
         ws.install_new_cell(bucket, Some(cell_a));
 

--- a/pyre/cpython_tests/baseline.linux-aarch64.json
+++ b/pyre/cpython_tests/baseline.linux-aarch64.json
@@ -3,7 +3,7 @@
   "modules": {
     "test.test_unittest": {
       "dynasm": "CRASH",
-      "reason": "GC bug, not a platform difference: invalid type_id at minor_custom_trace_target under minor_remembered_set, aborting through pyre_jit::call_jit::bh_call_fn mid-run. Passes when the driver is run directly, so it needs run.py's process shape to show up"
+      "reason": "GC bug, not a platform difference: invalid type_id at minor_custom_trace_target under minor_old_objects_pointing_to_young, aborting through pyre_jit::call_jit::bh_call_fn mid-run. Passes when the driver is run directly, so it needs run.py's process shape to show up"
     }
   },
   "stdlib_version": "3.14.6"

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -10121,13 +10121,32 @@ unsafe fn _cached_lookup_where_name(
 /// (which holds live `(w_class, w_value)` refs).
 ///
 /// Every cached value is an MRO type's namespace-dict resident (or a
-/// Box-immortal builtin descriptor), so it is already kept *reachable* by
-/// `walk_builtin_type_dicts_gc` or the heap type's custom trace — this walk is
-/// therefore not load-bearing for reclamation in the current model, and
-/// old-gen residents are not
-/// relocated by a collection, so it forwards no slot in practice today.
-/// It becomes load-bearing once those values become movable (the
-/// movable-object GC phases): `version_tag` is bumped only by `mutated()`,
+/// Box-immortal builtin descriptor), so the value *itself* is already kept
+/// reachable by `walk_builtin_type_dicts_gc` or by the owning type's custom
+/// trace forwarding `t.dict`, and an old-gen resident is not relocated by a
+/// collection — so as a *forwarding* pass this one changes no pointer today.
+///
+/// It is not only a forwarding pass. `eval.rs` hands in a closure that also
+/// runs `walk_raw_function_roots` / `walk_raw_getset_roots` /
+/// `walk_raw_wrapped_function_roots` on every slot it forwards, which makes
+/// this a *descent* path: for a Box-immortal carrier those walks are the only
+/// thing that reaches the carrier's own pointer fields. A heap type reaches
+/// such a value through `t.dict` and the namespace dict's trace, and both stop
+/// at the immortal box. So a Box-immortal function sitting in a *heap* type's
+/// namespace has its payload walked only while it is in this cache — do not
+/// read the paragraph above as licence to drop the call.
+///
+/// Nothing is dropped today only because those payload slots hold
+/// `malloc_typed` strings and static-region type objects, which the collector
+/// does not own. Minting Box-immortal functions is itself the deviation
+/// (upstream has no object outside the GC graph); closing that closes this.
+///
+/// `gc.collect()` clears the cache immediately before collecting
+/// (`module/gc/mod.rs`), so only an automatic collection ever sees a populated
+/// one.
+///
+/// The forwarding half becomes load-bearing once those values become movable
+/// (the movable-object GC phases): `version_tag` is bumped only by `mutated()`,
 /// never by a relocating move, so the cache's *own* copy of each pointer
 /// must be forwarded here or a later hit would read a stale address.
 pub(crate) unsafe fn walk_method_cache_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -307,7 +307,15 @@ unsafe fn walk_raw_function_roots(
     visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
 ) {
     unsafe {
-        if value.is_null() || !crate::is_function(value) {
+        // `is_function_carrier`, not `is_function`: `SLOT_WRAPPER_TYPE` is
+        // registered to the same `function_tid` as `FUNCTION_TYPE`
+        // (`pyre-jit/src/eval.rs` `register_vtable_for_type`), so the
+        // collector's census already says a slot wrapper carries Function's
+        // offsets. The carriers are Box-immortal, which makes this walk their
+        // only tracing path, and `typedef.rs` stamps `w_qualname`/`w_objclass`
+        // onto one *before* `function_retag_slot_wrapper` swaps `ob_type` —
+        // the narrower gate then refused the whole population afterwards.
+        if value.is_null() || !crate::is_function_carrier(value) {
             return;
         }
         let func = &mut *(value as *mut crate::function::Function);
@@ -315,6 +323,14 @@ unsafe fn walk_raw_function_roots(
         // The code object caches its own globals dict (`PyCode.w_globals`).
         // Reuse the same walk for managed custom tracing and bootstrap code.
         walk_raw_code_roots(func.code as PyObjectRef, visitor);
+        // `function.py:51 self.name` — the wrapped `__name__`, stamped at
+        // construction and replaced by `f.__name__ = ...`. Both stores already
+        // run `function_write_barrier`, but a Box-immortal function is reached
+        // only through this walk, so leaving the slot out gave the string a
+        // rename installs no root at all. A managed function reaches the same
+        // field through `FUNCTION_GC_TYPE_ID`'s offsets, which is why the gap
+        // showed up on immortal functions alone.
+        visitor(&mut *(&mut func.w_name as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.closure as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.defs_w as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_kw_defs as *mut PyObjectRef as *mut majit_ir::GcRef));
@@ -5946,5 +5962,77 @@ result = (
             let result = w_dict_getitem_str(frame.get_w_globals(), "result").unwrap();
             assert!(crate::baseobjspace::is_true(result).unwrap());
         }
+    }
+
+    /// `walk_raw_function_roots` is the only tracing path a Box-immortal
+    /// function has, so every slot `FUNCTION_GC_PTR_OFFSETS` declares must be
+    /// forwarded by that walk unless it is deliberately exempt. The two lists
+    /// drifted apart once: `w_name` was declared and not walked, so the string
+    /// `f.__name__ = ...` installs had no root at all on an immortal function,
+    /// while a managed one traced it through `FUNCTION_GC_TYPE_ID`. This runs
+    /// the real walker and records the offsets it visits, so a field cannot be
+    /// half-wired again.
+    #[test]
+    fn walk_raw_function_roots_covers_every_declared_gc_offset() {
+        // A zeroed `Function` is a valid subject: the walk hands each slot to
+        // the visitor as a pointer, and null is the legitimate "not stamped
+        // yet" value. Only `ob_type` has to be real, because `is_function`
+        // gates the walk on pointer identity with `FUNCTION_TYPE`.
+        let mut func: crate::function::Function =
+            unsafe { std::mem::MaybeUninit::zeroed().assume_init() };
+        func.ob.ob_type = &crate::function::FUNCTION_TYPE as *const _;
+        let base = &func as *const crate::function::Function as usize;
+
+        let mut seen: Vec<usize> = Vec::new();
+        {
+            let mut record = |slot: &mut majit_ir::GcRef| {
+                seen.push(slot as *mut majit_ir::GcRef as usize - base);
+            };
+            unsafe {
+                walk_raw_function_roots(
+                    &mut func as *mut crate::function::Function as PyObjectRef,
+                    &mut record,
+                );
+            }
+        }
+        seen.sort_unstable();
+        seen.dedup();
+
+        // The same carrier retagged as a slot wrapper must still be walked:
+        // `SLOT_WRAPPER_TYPE` shares `FUNCTION_TYPE`'s registered offsets, and
+        // these carriers are immortal, so a refusal here is a population the
+        // collector believes is traced and nothing traces.
+        func.ob.ob_type = &crate::function::SLOT_WRAPPER_TYPE as *const _;
+        let mut seen_wrapper: Vec<usize> = Vec::new();
+        {
+            let mut record = |slot: &mut majit_ir::GcRef| {
+                seen_wrapper.push(slot as *mut majit_ir::GcRef as usize - base);
+            };
+            unsafe {
+                walk_raw_function_roots(
+                    &mut func as *mut crate::function::Function as PyObjectRef,
+                    &mut record,
+                );
+            }
+        }
+        seen_wrapper.sort_unstable();
+        seen_wrapper.dedup();
+        assert_eq!(
+            seen_wrapper, seen,
+            "slot-wrapper carrier must be walked too"
+        );
+
+        // `name` is the one declared offset this walk skips: an immortal
+        // function's name box comes from `malloc_raw`, so the collector never
+        // owns it, while a managed function's GC box is reached through the
+        // type id's offsets.
+        let exempt = std::mem::offset_of!(crate::function::Function, name);
+        let mut expected: Vec<usize> = crate::function::FUNCTION_GC_PTR_OFFSETS
+            .iter()
+            .copied()
+            .filter(|off| *off != exempt)
+            .collect();
+        expected.sort_unstable();
+        assert_eq!(seen, expected);
     }
 }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -6127,7 +6127,7 @@ GC-owned; stopping rather than dereferencing an unvalidated f_backref\n"
             (
                 header.type_id(),
                 header.is_forwarded(),
-                header.has_flag(majit_gc::flags::TRACK_YOUNG_PTRS),
+                header.has_flag(majit_gc::flags::GCFLAG_TRACK_YOUNG_PTRS),
             )
         } else {
             (u32::MAX, false, false)

--- a/pyre/pyre-object/src/boolobject.rs
+++ b/pyre/pyre-object/src/boolobject.rs
@@ -172,7 +172,7 @@ mod tests {
         unsafe {
             let hdr = majit_gc::header::header_of(a as usize);
             assert_eq!((*hdr).type_id(), 5);
-            assert!((*hdr).has_flag(majit_gc::flags::NO_HEAP_PTRS));
+            assert!((*hdr).has_flag(majit_gc::flags::GCFLAG_NO_HEAP_PTRS));
         }
     }
 }

--- a/pyre/pyre-object/src/lltype.rs
+++ b/pyre/pyre-object/src/lltype.rs
@@ -307,15 +307,23 @@ pub fn malloc_typed<T: GcType>(value: T) -> *mut T {
 }
 
 /// [`malloc_typed`] for an immortal leaf singleton — the header carries
-/// `init_gc_object_immortal`'s `NO_HEAP_PTRS | TRACK_YOUNG_PTRS`, so the
-/// collector recognises it as a prebuilt root and stops there instead of
-/// reading a payload it has no trace shape for.
+/// `init_gc_object_immortal`'s `GCFLAG_NO_HEAP_PTRS | GCFLAG_TRACK_YOUNG_PTRS`,
+/// so marking skips the object instead of reading a payload it has no trace
+/// shape for.
 ///
-/// Restricted to payloads that hold no reference at all: `None`, `True`,
-/// `False`, `NotImplemented`, `Ellipsis`. A box with reference fields must use
-/// [`malloc_typed`] and be reached through the raw-root walkers instead —
-/// `NO_HEAP_PTRS` there would be a false claim, and
-/// `majit_gc::header::alloc_with_gc_header_immortal` records what that costs.
+/// `GCFLAG_NO_HEAP_PTRS` is a state — "holds no heap pointer, and is not in
+/// `prebuilt_root_objects` yet" — which the write barrier is what ends, on the
+/// first pointer stored into the object. Upstream can stamp prebuilt objects
+/// that do carry reference fields, because those fields name other prebuilt
+/// objects and the GC transform barriers every later store. A box allocated at
+/// runtime here satisfies neither half: its reference fields are written
+/// straight to memory at construction.
+///
+/// Hence the restriction to payloads holding no reference at all: `None`,
+/// `True`, `False`, `NotImplemented`, `Ellipsis`. A box with reference fields
+/// must use [`malloc_typed`] and be reached through the raw-root walkers
+/// instead; `majit_gc::header::alloc_with_gc_header_immortal` records the
+/// measured failure that follows from stamping one anyway.
 #[inline]
 pub fn malloc_typed_immortal<T: GcType>(value: T) -> *mut T {
     debug_assert_eq!(

--- a/pyre/pyre-object/src/noneobject.rs
+++ b/pyre/pyre-object/src/noneobject.rs
@@ -52,7 +52,7 @@ mod tests {
             assert!(!is_int(a));
             let hdr = majit_gc::header::header_of(a as usize);
             assert_eq!((*hdr).type_id(), W_NONE_GC_TYPE_ID);
-            assert!((*hdr).has_flag(majit_gc::flags::NO_HEAP_PTRS));
+            assert!((*hdr).has_flag(majit_gc::flags::GCFLAG_NO_HEAP_PTRS));
         }
     }
 }

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -977,7 +977,7 @@ impl FixedObjectArray {
         // the same array is a plain write.  Nursery arrays and StdAlloc
         // fallback arrays also carry a zero flag word and take this arm.
         let header = unsafe { majit_gc::header::header_of(self as *mut Self as usize) };
-        if unsafe { !(*header).has_flag(majit_gc::flags::TRACK_YOUNG_PTRS) } {
+        if unsafe { !(*header).has_flag(majit_gc::flags::GCFLAG_TRACK_YOUNG_PTRS) } {
             unsafe { self.items_mut_ptr().add(index).write(value) };
             return;
         }

--- a/pyre/pyre-object/src/special.rs
+++ b/pyre/pyre-object/src/special.rs
@@ -76,7 +76,7 @@ mod tests {
             unsafe {
                 let hdr = majit_gc::header::header_of(obj as usize);
                 assert_eq!((*hdr).type_id(), type_id);
-                assert!((*hdr).has_flag(majit_gc::flags::NO_HEAP_PTRS));
+                assert!((*hdr).has_flag(majit_gc::flags::GCFLAG_NO_HEAP_PTRS));
             }
         }
     }


### PR DESCRIPTION
Two commits: a naming/semantics alignment across the GC and JitCell flags, and two rooting gaps in `walk_raw_function_roots`.

## `gc, jit: spell GC and JitCell flags as RPython does`

`flags::TRACK_YOUNG_PTRS` and its twelve siblings become `flags::GCFLAG_*`; `jc_flags::TRACING` and its four siblings become `jc_flags::JC_*`, matching `incminimark.py` and `warmstate.py` verbatim. `FINALIZER_REGISTERED` and `FINALIZER_RUN` keep their bare names — they are the two constants with no upstream counterpart, so after this the prefix records whether a flag exists upstream.

Adds `GCFLAG_PINNED_OBJECT_PARENT_KNOWN = GCFLAG_PINNED`, which `incminimark.py` defines and this port did not, and uses it at the three sites whose comments already named it (`incminimark.py:2194-2199`, `:1949-1951`).

Each flag's doc comment is restated from the upstream definition rather than repeating the constant's own name. `GCFLAG_NO_HEAP_PTRS` is a **state** — "holds no heap pointer, and is not in `prebuilt_root_objects` yet" — which the write barrier ends on the first pointer stored into the object. The comments in `lltype.rs` and `header.rs` had described it as a claim about the payload's shape, which is why an earlier attempt to stamp it on `malloc_typed` boxes produced a poisoned `W_ListObject` items block.

Rename-only for behaviour; the one functional change is the alias applied at three sites, where the bit was already being set and cleared by its `GCFLAG_PINNED` spelling.

## `gc: forward w_name and admit slot-wrapper carriers in walk_raw_function_roots`

Two rooting gaps, each with a gate that fails without it.

1. The walk forwarded **16 of the 18** offsets `FUNCTION_GC_PTR_OFFSETS` declares. `name` is exempt by documentation; `w_name` was not. On a Box-immortal function — whose only tracing path this walk is — the slot went unforwarded, while a managed function reached it through `FUNCTION_GC_TYPE_ID`'s registered offsets.

2. The entry gate tested `is_function`, which excludes `SLOT_WRAPPER_TYPE`. `pyre-jit` registers that type to the same `function_tid`, so the collector's census treats such a carrier as a `Function` while this walk refused it outright — `typedef.rs` stamps `w_qualname`/`w_objclass` onto one before `function_retag_slot_wrapper` swaps `ob_type`. The gate now tests `is_function_carrier`.

A new test runs the real walker over a zeroed `Function` and asserts the visited offsets equal `FUNCTION_GC_PTR_OFFSETS` minus `name`, under both `FUNCTION_TYPE` and `SLOT_WRAPPER_TYPE` tagging. Without the two changes it fails at 16 offsets against 17, and at zero against 17.

**Not a crash fix, and the PR does not claim to be one.** Both slots currently hold `malloc_typed` strings and a static-region type object, so no live pointer was being dropped today. The existing test `function_gc_ptr_offsets_cover_inline_pyobjectref_fields` gates offsets↔struct but not walker↔offsets; that is the gap the new test closes.

## Verification

- `python3 pyre/check.py --backend dynasm` — `ALL PASSED: dynasm 516/516`, `GC BUG: 0` (three runs).
- `cargo test -p pyre-interpreter --lib --no-default-features --features dynasm,cpyext` — including the new `walk_raw_function_roots_covers_every_declared_gc_offset`.
- cranelift builds clean; a 1804-test `test_zipfile`-class regrtest leg completed `OK (skipped=29)` with the JIT confirmed engaged (`loops_compiled=729`, `bridges_compiled=476`).

Not yet run against these commits: the wasm gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage-collection root tracking for functions and slot-wrapper objects.
  - Function names assigned after object creation are now retained reliably during garbage collection.
  - Added coverage to verify pointer fields are correctly visited.

- **Documentation**
  - Clarified guidance around memory management flags and reference-free object allocation.

- **Refactor**
  - Standardized internal garbage-collection and JIT flag naming for improved consistency, without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->