### PR TITLE
importing: a ._pth beside the executable replaces the path computation, and test_site is gated here

### DIFF
--- a/pyre/cpython_tests/baseline.win32-AMD64.json
+++ b/pyre/cpython_tests/baseline.win32-AMD64.json
@@ -25,6 +25,18 @@
       "dynasm": "PASS",
       "reason": "Windows-only module: the shared IMPORTERROR is what a POSIX host sees for import msvcrt"
     },
+    "test.test_site": {
+      "dynasm": "PASS",
+      "provenance": {
+        "dynasm": {
+          "binary": "pyre-dynasm.exe",
+          "jit": true,
+          "mode": "script",
+          "stdlib_version": "3.14.6"
+        }
+      },
+      "reason": "the shared IMPORTERROR is another host's verdict and this one does not reproduce it: the module imports here and its 43 cases pass, three of them skipped -- test_addsitedir_hidden_flags wants os.chflags, test_add_build_dir is disabled upstream, and test_lazy_imports is cpython_only"
+    },
     "test.test_startfile": {
       "dynasm": "PASS",
       "reason": "Windows-only module: the shared IMPORTERROR is what a POSIX host sees for os.startfile"

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -2149,6 +2149,9 @@ pub(crate) struct StartupPathConfig {
     /// This is exposed as `sys._stdlib_dir` and is deliberately distinct from
     /// the complete search list above.
     pub stdlib: Option<PathBuf>,
+    /// The `._pth` beside the executable, when the deployment placed one.
+    #[cfg(all(not(feature = "sandbox"), not(target_arch = "wasm32")))]
+    pub pth: Option<PthConfig>,
 }
 
 #[cfg(feature = "host_env")]
@@ -2576,6 +2579,157 @@ fn prefix_from_stdlib(stdlib: &Path) -> PathBuf {
     not(feature = "sandbox"),
     not(target_arch = "wasm32")
 ))]
+#[derive(Clone, Debug)]
+pub(crate) struct PthConfig {
+    /// The directory holding the file.  Every relative line resolves against
+    /// it and it is the prefix the interpreter goes on to report.
+    pub dir: PathBuf,
+    /// One entry per usable line, in the file's order; duplicates are kept
+    /// because the file is the search path verbatim.
+    pub entries: Vec<PathBuf>,
+    /// Whether a line asked for `site` back.
+    pub import_site: bool,
+}
+
+/// The name a `._pth` beside `executable` would have.
+///
+/// Windows drops an `exe` or `dll` extension first, so the file beside
+/// `python.exe` is `python._pth`; every other platform appends to the whole
+/// name, leaving `python3.14._pth`.
+#[cfg(all(
+    feature = "host_env",
+    not(feature = "sandbox"),
+    not(target_arch = "wasm32")
+))]
+fn pth_path_beside(executable: &Path) -> Option<PathBuf> {
+    let parent = executable.parent()?;
+    let mut name = executable.file_name()?.to_os_string();
+    #[cfg(windows)]
+    if executable
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("exe") || ext.eq_ignore_ascii_case("dll"))
+        && let Some(stem) = executable.file_stem()
+    {
+        name = stem.to_os_string();
+    }
+    name.push("._pth");
+    Some(parent.join(name))
+}
+
+/// The `._pth` beside the executable, parsed.
+///
+/// A `._pth` replaces the whole path computation: the file lists every
+/// `sys.path` entry, the directory holding it is the prefix, the environment
+/// is not consulted, no `sys.path[0]` is prepended, and `site` is skipped
+/// unless a line reads `import site`.  A line is taken up to its first `#` and
+/// then stripped; what is left empty is dropped.  `PYTHONHOME` does not
+/// suppress the search — only an embedder calling `Py_SetPythonHome` does, and
+/// there is no such caller here.
+///
+/// PyPy's `initpath` computes the search path from the executable alone and
+/// has no `._pth` at all, so there is no shape to follow there.  3.14 has one
+/// and `test_site._pthFileTests` asserts it, so it is 3.14's, measured against
+/// 3.14.2 on this host over the eleven cases the parser distinguishes.
+///
+/// The search visits the interpreter library, the invoked executable and the
+/// process image in that order.  This interpreter is one static executable —
+/// which is what `sys.dllhandle` being 0 says, `GetModuleFileName(NULL)`
+/// naming the executable itself — so the library and the first executable are
+/// the same file, leaving two candidates.
+#[cfg(all(
+    feature = "host_env",
+    not(feature = "sandbox"),
+    not(target_arch = "wasm32")
+))]
+fn read_pth_config(executable: &Path) -> Option<PthConfig> {
+    let image = std::env::current_exe().ok();
+    for candidate in [Some(executable.to_path_buf()), image]
+        .into_iter()
+        .flatten()
+    {
+        let Some(path) = pth_path_beside(&candidate) else {
+            continue;
+        };
+        let Ok(mut contents) = host_fs::read(&path) else {
+            continue;
+        };
+        // The bounded bootstrap read `pyvenv.cfg` takes is 16 KiB.  A `._pth`
+        // is deliberately longer — `test_site` writes one of about 32 KB,
+        // which is the size gh-113628 was about — so the bound here is larger,
+        // and is still a bound.
+        contents.truncate(1024 * 1024);
+        let dir = path.parent().unwrap_or_else(|| Path::new("")).to_path_buf();
+        let dir = std::path::absolute(&dir).unwrap_or(dir);
+        return Some(parse_pth(dir, &String::from_utf8_lossy(&contents)));
+    }
+    None
+}
+
+#[cfg(all(
+    feature = "host_env",
+    not(feature = "sandbox"),
+    not(target_arch = "wasm32")
+))]
+fn parse_pth(dir: PathBuf, text: &str) -> PthConfig {
+    let mut config = PthConfig {
+        dir,
+        entries: Vec::new(),
+        import_site: false,
+    };
+    for line in text.lines() {
+        let line = line.split('#').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+        if line == "import site" {
+            config.import_site = true;
+        } else if line.starts_with("import ") {
+            eprintln!("unsupported 'import' line in ._pth file");
+        } else {
+            // The entry is `abspath(join(pth_dir, line))`: an absolute line
+            // replaces the directory, and either way the result is collapsed
+            // lexically, so `..` walks up a level the file never has to spell
+            // out.
+            let entry = normalize_lexically(&config.dir.join(line));
+            config.entries.push(entry);
+        }
+    }
+    config
+}
+
+/// Fold a `._pth` beside the executable into the launcher options.
+///
+/// Its presence is a configuration in itself, and `sys.flags` has to report
+/// that before the first `import sys`.  `-S` still wins over an `import site`
+/// line: the option was named and the file only declines to remove `site`.
+#[cfg(all(
+    feature = "host_env",
+    not(feature = "sandbox"),
+    not(target_arch = "wasm32")
+))]
+pub fn apply_pth_config(flags: &mut crate::launch_env::LaunchFlags) {
+    let Some(pth) = startup_path_config().pth.as_ref() else {
+        return;
+    };
+    flags.isolated = true;
+    flags.ignore_environment = true;
+    flags.safe_path = true;
+    flags.no_site = flags.no_site || !pth.import_site;
+}
+
+/// A build with no host filesystem has no file to find.
+#[cfg(not(all(
+    feature = "host_env",
+    not(feature = "sandbox"),
+    not(target_arch = "wasm32")
+)))]
+pub fn apply_pth_config(_flags: &mut crate::launch_env::LaunchFlags) {}
+
+#[cfg(all(
+    feature = "host_env",
+    not(feature = "sandbox"),
+    not(target_arch = "wasm32")
+))]
 fn read_pyvenv_config(executable: &Path) -> Option<(PathBuf, PyVenvConfig)> {
     let exe_dir = executable.parent()?;
     for candidate in [
@@ -2604,6 +2758,37 @@ fn compute_startup_path_config_from(
     executable: PathBuf,
     explicit_stdlib: Option<PathBuf>,
 ) -> StartupPathConfig {
+    // A `._pth` answers the whole question, so neither `pyvenv.cfg` nor the
+    // landmark search below is consulted.  `stdlib_paths` is the file's list
+    // verbatim: `ensure_stdlib_path` appends exactly that and nothing else,
+    // and `apply_pth_config` has already suppressed the `PYTHONPATH` seed and
+    // the `sys.path[0]` entry.
+    if let Some(pth) = read_pth_config(&executable) {
+        return StartupPathConfig {
+            base_executable: executable.clone(),
+            executable,
+            prefix: pth.dir.clone(),
+            base_prefix: pth.dir.clone(),
+            stdlib_paths: pth.entries.clone(),
+            // `sys._stdlib_dir` names one directory rather than the search
+            // list, and it is the directory frozen modules read their sources
+            // out of, so it has to be one that exists.  3.14 spells it
+            // `<prefix>/Lib` without looking, which is a directory this layout
+            // does not have under either name; the prefix probe is the same
+            // question asked the way this tree answers it, and an entry
+            // holding `site.py` answers a file that points elsewhere.
+            stdlib: stdlib_at_prefix(&pth.dir)
+                .and_then(|(_, stdlib_dir)| stdlib_dir)
+                .or_else(|| {
+                    pth.entries
+                        .iter()
+                        .find(|entry| entry.join("site.py").is_file())
+                        .cloned()
+                }),
+            pth: Some(pth),
+        };
+    }
+
     let pyvenv = read_pyvenv_config(&executable);
 
     let base_executable = pyvenv
@@ -2675,6 +2860,7 @@ fn compute_startup_path_config_from(
         #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
         stdlib_paths,
         stdlib,
+        pth: None,
     }
 }
 
@@ -3571,6 +3757,19 @@ fn ensure_stdlib_path() {
         return;
     }
     let config = startup_path_config();
+    // A `._pth` is `sys.path` verbatim, down to a repeated line being a
+    // repeated entry, so its list is staged as written rather than through
+    // `add_sys_path`, which folds a duplicate away.  An empty file is likewise
+    // the search path the deployment asked for, so the "keep the binary inside
+    // its tree" warning below does not apply to it either.
+    #[cfg(not(feature = "sandbox"))]
+    if config.pth.is_some() {
+        SYS_PATH
+            .lock()
+            .unwrap()
+            .extend(config.stdlib_paths.iter().cloned());
+        return;
+    }
     if config.stdlib_paths.is_empty() {
         let warning = format!(
             "debug: WARNING: Library path not found, using the existing sys.path;\n\
@@ -6197,6 +6396,40 @@ mod tests {
         assert!(src.contains("def compile"));
         assert!(vfs.read_to_string(&mount.join("re/_nope.py")).is_err());
         assert!(!vfs.is_file(&mount.join("re/_nope.py")));
+    }
+
+    #[cfg(all(
+        feature = "host_env",
+        not(feature = "sandbox"),
+        not(target_arch = "wasm32")
+    ))]
+    #[test]
+    fn a_pth_line_is_taken_up_to_its_first_hash_and_then_stripped() {
+        let dir = PathBuf::from(if cfg!(windows) {
+            r"C:\deploy"
+        } else {
+            "/deploy"
+        });
+        // Written with CRLF, which is what `test_site` writes on Windows and
+        // what the file must not carry into an entry.
+        let config = parse_pth(
+            dir.clone(),
+            "#skipme\r\n# also skipped\r\nkeep#trailing\r\n  padded  \r\n\r\n\
+             same\r\nsame\r\n.\r\n..\r\nimport site\r\nimport os\r\n",
+        );
+        assert!(config.import_site);
+        // A repeated line is a repeated entry: the file is `sys.path` verbatim.
+        assert_eq!(
+            config.entries,
+            vec![
+                dir.join("keep"),
+                dir.join("padded"),
+                dir.join("same"),
+                dir.join("same"),
+                dir.clone(),
+                dir.parent().unwrap().to_path_buf(),
+            ]
+        );
     }
 
     #[test]

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -741,13 +741,18 @@ fn real_main(binary_name: &str) {
     // [executable] + argv` records the list `entry_point` handed on.
     let (argv, heapsize) = take_heapsize_option(binary_name, std::env::args_os().collect());
     importing::set_sys_orig_argv(argv.clone());
-    let (mode, flags, args) = match parse_args(binary_name, argv) {
+    let (mode, mut flags, args) = match parse_args(binary_name, argv) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("{binary_name}: {e}");
             std::process::exit(2);
         }
     };
+    // A `._pth` beside the executable names every `sys.path` entry itself, so
+    // it also isolates the interpreter from the environment and skips `site`.
+    // Applied after the option parse, which is where the variables it
+    // overrides have already been folded in.
+    importing::apply_pth_config(&mut flags);
     let LaunchFlags {
         inspect,
         quiet,


### PR DESCRIPTION
A `._pth` beside the executable is the deployment mechanism Windows embeddable
distributions use, and pyre ignored the file entirely: a child launched next to
one reported `sys.path == ['']` and printed `'import site' failed`. PyPy's
`initpath` computes the search path from the executable alone and has no
counterpart, so the shape here is 3.14's, measured against 3.14.2 on a Windows
host.

## What the file does

`<executable>._pth` — with a trailing `exe` or `dll` extension dropped first,
so `python.exe` looks for `python._pth`, while every other platform appends to
the whole name — is read ahead of `pyvenv.cfg` and the landmark search, from
the invoked executable and then the process image. pyre is one static
executable (`sys.dllhandle` is 0 and `GetModuleFileName(NULL)` names the
executable), so the library candidate and the first executable candidate are
the same file.

Each line is taken up to its first `#` and stripped. What is left empty is
dropped, `import site` restores `site`, another `import ` line is dropped after
a warning on stderr, and every other line becomes
`abspath(join(<pth dir>, line))` — reusing `normalize_lexically`, the
`_Py_normpath` half of `abspath` that is already here. Duplicates are kept in
the file's order, which is load-bearing: `test_underpth_nosite_file` writes the
stdlib path 200 times and expects 200 entries, so the entries are staged
straight into the seed rather than through `add_sys_path`, which folds a
duplicate away.

The file's directory becomes `sys.prefix` and `sys.base_prefix`, and its
presence sets `isolated`, `ignore_environment` and `safe_path` and clears
`site_import` — so `PYTHONPATH` seeds nothing and no `sys.path[0]` is
prepended. `-S` still wins over an `import site` line: the option was named and
the file only declines to remove `site`. `PYTHONHOME` does **not** suppress the
search — only an embedder calling `Py_SetPythonHome` does, and there is no such
caller here.

## Measurement

An eleven-case matrix (`plain`, leading/trailing `#`, surrounding whitespace,
blank lines, `import site`, `import os`, an absolute line, `.`/`..`, duplicate
lines, CRLF) run through the same script against CPython 3.14.2 and against
pyre, each with `PYTHONPATH=from-env` and `PYTHONHOME=from-home` in the
environment. `sys.path`, `prefix`, `base_prefix`, `exec_prefix`,
`base_exec_prefix`, `no_site`, `isolated`, `safe_path`, `ignore_environment`,
`no_user_site`, `dont_write_bytecode` and the stderr warning text all agree.

Two things that could have been wrong and were checked against the pinned
version rather than assumed:

- `user_site_directory` is left alone. gh-120037 makes a `._pth` disable user
  site, but that landed for 3.15; at `v3.14.6` `getpath.py` does not touch it,
  and the measured 3.14.2 child reports `no_user_site == False`.
- A trailing `#` **is** stripped and surrounding whitespace **is** trimmed.
  `test_site`'s own `_calc_sys_path_for_underpth_nosite` skips only a line
  whose first character is `#` and does no trimming, so the test would accept
  either reading; the interpreter's own behaviour decides, and it strips.

The one deliberate divergence is `sys._stdlib_dir`. 3.14 spells it
`<prefix>/Lib` without probing — a directory this layout does not have under
either name, and one that would be empty in the test's temp directory. It is
also the directory frozen modules read their sources out of here, so it has to
name a real one: the prefix's own stdlib where the prefix has one, otherwise
the first entry holding `site.py`.

## Second commit

`test.test_site` was recorded `IMPORTERROR` in the shared baseline — another
host's verdict. On this host the module imports and all 43 cases pass, with
three skipped: `test_addsitedir_hidden_flags` wants `os.chflags`,
`test_add_build_dir` is disabled upstream, and `test_lazy_imports` is
`cpython_only`. CPython 3.14.2 on the same host runs the same 43 and skips two
— the third is the `cpython_only` decorator alone, and the property it asserts
holds here anyway (`-S -c 'import site'` pulls in none of `io`, `locale`,
`traceback`, `atexit`, `warnings`, `textwrap`). The `win32-AMD64` overlay now
carries the PASS cell, so the module is gated on this host.

## Verification

- `pyre/check.py --backend dynasm` — `ALL PASSED: dynasm 516/516`
- `pyre/extra_tests/parity_tests/run.py --dynasm-only` — all pass
- `cargo test --all --no-default-features --features dynasm` — green
- `cargo build --release -p pyre-wasm --target wasm32-unknown-unknown` — builds
- `scripts/check-new-line-citations.py --base origin/main` — clean
- `test.test_site` gated through `pyre/cpython_tests/run.py`, plus `test_import`,
  `test_venv`, `test_cmd_line` and `test_sys` with no regressions
