### PR TITLE
jit: report c_call/c_return from the CALL-family residual helpers, and two access_directly front-end fixes

### DIFF
--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -1127,7 +1127,8 @@ impl<'a> Transformer<'a> {
     ///
     /// The two frame constructors call the hint (`pyre-interpreter`
     /// `pyframe.rs` `PyFrame::new` and `createframe_obj`, mirroring
-    /// `pyframe.py:99`), but neither is the caller this arm answers for:
+    /// `pyframe.py PyFrame.__init__`), but neither is the caller this arm
+    /// answers for:
     /// both hint a frame they hold by value, so the reachable path there
     /// is the structural sibling below,
     /// `FieldDescriptor::base_is_local_aggregate`, which recovers the

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -524,24 +524,33 @@ impl<'a> MirGraphLookup<'a> {
 /// the `(receiver root, method leaf)` pair, and an ambiguous pair is treated
 /// as unresolved.
 ///
-/// Measured on the interpreter's own graph, of the five hint sites only
-/// `eval::dispatch` seeds — the one whose hinted value is a `&mut PyFrame`,
-/// so `class_roots` reads `PyFrame` off the parameter's `Ref` leaf. The two
-/// frame constructors hint a `PyFrame` held BY VALUE, and the front end
-/// re-mints that aggregate's `Variable` between the transparent constructor
-/// and its uses without an op this pass follows, so its root is unrecorded
-/// and the minter's class test fails closed.
+/// The pass is inert in the production translation, and not for any reason
+/// inside it. A census over the build script's two pipeline invocations
+/// (489 and 4147 lowered functions) found **zero `OpKind::Hint` ops of any
+/// kind**, and neither frame constructor present in the set at all: the five
+/// hint sites are spelled in `pyre-interpreter` / `pyre-jit`, but nothing
+/// carrying one reaches the function set this pass runs over. So the seeds
+/// are empty before any of the machinery below gets a say, and every claim
+/// about which site seeds has to be re-measured once a hint does arrive —
+/// do not read a green gate here as agreement.
 ///
-/// Even the site that seeds flags nothing, and the first under-approximation
-/// is why. The seed reaches `handle_jitexception`'s argument and that callee
-/// resolves, but `handle_jitexception` is also reached from callers holding
-/// no hinted frame. Nearly every callee a hinted frame reaches is reached
-/// that way too, so the flag lands on no graph until pyre can specialize a
-/// second one. That leans the safe way — `policy::look_inside_graph` aborts
-/// on a flag it cannot honour, and the suppression the flag would buy
-/// (dropping a `jit_force_virtualizable`) has no injector on this path yet —
-/// but it means the gate is quiet by absence, not by agreement, and a census
-/// is the only way to tell which.
+/// The two under-approximations that will bite first when one does:
+///
+/// * `class_roots` answers with the ctor's own name for a struct literal,
+///   because that is the spelling everything else uses — `adt_node_class_root`
+///   ends on `name.rsplit("::")`, and the declared set holds the bare leaf.
+///   `front::mir` fills the same op's `result_ty` with `owner_path::leaf`, so
+///   reading that instead would answer with a spelling no comparison matches.
+///   A root reachable only through `result_ty` is still unrecorded, and a hint
+///   on an unrecorded or undeclared root seeds nothing — the erasing branch.
+///
+/// * One graph per function, where upstream keys a second on
+///   `(AccessDirect, key)`. A callee reached by both a hinted and an unhinted
+///   caller cannot be flagged, since the one graph has to answer for both;
+///   `reaching` counts the two and only flags a parameter no unflagged caller
+///   supplies. That leans the safe way — `policy::look_inside_graph` aborts on
+///   a flag it cannot honour — but it means a flag's absence is not evidence
+///   the flag was not wanted.
 pub(crate) fn propagate_access_directly(
     functions: &mut [SemanticFunction],
     dont_look_inside: &std::collections::HashSet<String>,
@@ -620,12 +629,23 @@ pub(crate) fn propagate_access_directly(
         }
         edges.push(func_edges);
     }
-    // Close the hint seeds over the aliases once: they never change.
+    // Close the hint seeds and the killed set over the aliases once: neither
+    // depends on which parameters are flagged, so neither changes between
+    // rounds.
+    //
+    // The killed set is closed IN PLACE because the fixpoint below subtracts
+    // it a second time, and both subtractions have to name the same set.  A
+    // killed value that reaches a merge arrives there under a freshly minted
+    // `inputarg`, and that same id is an alias target of whatever the other
+    // arm passed — so the raw set, which holds only the hint's own result,
+    // does not name it.  `binaryop.py pairtype(SomeInstance, SomeInstance)
+    // .union` deletes any flag key the other side lacks, so a merge one arm
+    // re-bound away carries no flag; closing the killed set is how that
+    // intersection is reproduced here.
     for (i, seeds) in hint_seeds.iter_mut().enumerate() {
         close_ids_over_aliases(&aliases[i], seeds);
-        let mut dead = killed[i].clone();
-        close_ids_over_aliases(&aliases[i], &mut dead);
-        seeds.retain(|id| !dead.contains(id));
+        close_ids_over_aliases(&aliases[i], &mut killed[i]);
+        seeds.retain(|id| !killed[i].contains(id));
     }
 
     // Per function, the parameter positions that arrive carrying the flag.
@@ -777,24 +797,29 @@ fn class_roots(func: &SemanticFunction) -> std::collections::HashMap<u64, String
                     .map(str::to_string),
                 OpKind::Call {
                     target, result_ty, ..
-                } => leaf_root(result_ty).map(str::to_string).or_else(|| {
-                    match target {
-                        // A struct literal names the type it builds; the
-                        // front end spells one as a transparent ctor.
-                        CallTarget::SyntheticTransparentCtor {
-                            name, is_struct, ..
-                        } if *is_struct => Some(name.clone()),
-                        // `__cast_pointer/<Root>` and
-                        // `__cast_instance_intrinsic/<Root>` carry the target
-                        // class in the path.
-                        CallTarget::FunctionPath { segments }
-                            if is_representation_cast(segments) =>
-                        {
-                            segments.get(1).cloned()
-                        }
-                        _ => None,
+                } => match target {
+                    // A struct literal names the type it builds; the front
+                    // end spells one as a transparent ctor.  This is read
+                    // BEFORE `result_ty` because the two spell the class
+                    // differently: the ctor carries the bare leaf, while
+                    // `front::mir` fills the same op's `result_ty` with
+                    // `owner_path::leaf`.  Every other producer of a root —
+                    // `adt_node_class_root`, which is where `OpKind::Input`'s
+                    // `class_root` comes from — collapses to the bare leaf, and
+                    // so does the declared virtualizable set, so reading
+                    // `result_ty` first would answer with a spelling nothing
+                    // else uses and no comparison could match.
+                    CallTarget::SyntheticTransparentCtor {
+                        name, is_struct, ..
+                    } if *is_struct => Some(name.clone()),
+                    // `__cast_pointer/<Root>` and
+                    // `__cast_instance_intrinsic/<Root>` carry the target
+                    // class in the path.
+                    CallTarget::FunctionPath { segments } if is_representation_cast(segments) => {
+                        segments.get(1).cloned()
                     }
-                }),
+                    _ => leaf_root(result_ty).map(str::to_string),
+                },
                 _ => None,
             };
             if let Some(root) = root {
@@ -896,8 +921,9 @@ fn resolve_callee(
 /// Whether a call is one of `front::mir`'s representation-cast markers.
 ///
 /// `jtransform.rs rewrite_op_cast_pointer` rewrites both to `same_as`
-/// (jtransform.py:254-257), so the result is the operand under a different
-/// static type — the one variable an RPython flow graph would have had.
+/// (`jtransform.py Transformer.rewrite_op_cast_pointer`), so the result is
+/// the operand under a different static type — the one variable an RPython
+/// flow graph would have had.
 fn is_representation_cast(segments: &[String]) -> bool {
     matches!(
         segments.first().map(String::as_str),
@@ -1426,6 +1452,133 @@ mod tests {
         assert!(
             !fns[2].graph.access_directly,
             "the flag must not survive the access_directly=False re-bind"
+        );
+    }
+
+    /// `front::mir` fills a transparent ctor's `result_ty` with
+    /// `owner_path::leaf`, while both the declared virtualizable set and
+    /// `OpKind::Input`'s `class_root` (via `adt_node_class_root`, which ends
+    /// on `name.rsplit("::")`) carry the bare leaf.  A hint on a value a
+    /// struct literal produced — which is what BOTH frame constructors hint —
+    /// therefore only seeds if the ctor's own name is what the class test
+    /// reads.  Every other test here types its value through
+    /// `declare_frame_param`, which spells the bare leaf, so this is the only
+    /// one that can see the difference.
+    #[test]
+    fn a_hint_on_a_struct_literal_seeds_through_the_ctor_name() {
+        use crate::flowspace::model::Variable;
+        use crate::model::{CallTarget, OpKind, SpaceOperation, ValueType};
+
+        let mut ctor = free_fn("createframe_obj");
+        let start = ctor.graph.startblock;
+        let frame = Variable::named("frame");
+        ctor.graph.block_mut(start).operations.push(SpaceOperation {
+            result: Some(frame.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::synthetic_transparent_struct_ctor(
+                    vec!["pyre_interpreter".to_string(), "pyframe".to_string()],
+                    "PyFrame",
+                ),
+                args: Vec::new(),
+                result_ty: ValueType::Ref(Some("pyre_interpreter::pyframe::PyFrame".to_string())),
+            },
+        });
+        let hinted = Variable::named("hinted");
+        ctor.graph.block_mut(start).operations.push(SpaceOperation {
+            result: Some(hinted.clone()),
+            kind: OpKind::Hint {
+                value: frame,
+                kind: crate::hints::HintKind::FreshVirtualizable,
+            },
+        });
+        ctor.graph.block_mut(start).operations.push(SpaceOperation {
+            result: None,
+            kind: OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec!["init_cells".to_string()],
+                },
+                args: vec![hinted],
+                result_ty: ValueType::Void,
+            },
+        });
+
+        let mut fns = vec![ctor, free_fn("init_cells")];
+        propagate_access_directly(&mut fns, &Default::default(), &vable_roots());
+        assert!(
+            fns[1].graph.access_directly,
+            "the ctor's own name is the spelling the declared set holds"
+        );
+    }
+
+    /// A merge whose arms disagree is unflagged, because
+    /// `binaryop.py pairtype(SomeInstance, SomeInstance).union` keeps only the
+    /// flags BOTH sides carry — it deletes any key the other annotation lacks.
+    /// So a block reached both by a value the `False` spelling killed and by
+    /// one that still carries the flag must not be flagged.
+    ///
+    /// The sibling above cannot see this: there the killed value is consumed
+    /// in its own block, where the hint's own result id is what the seed set
+    /// is filtered against.  Here the merge gives the killed value a fresh
+    /// `inputarg` id, and that id is also an alias target of the flagged
+    /// parameter — so it only stays out of the seed set if the killed set is
+    /// closed over the aliases the same way the seeds are.
+    #[test]
+    fn a_merge_of_a_killed_and_a_flagged_value_is_not_flagged() {
+        use crate::flowspace::model::Variable;
+        use crate::model::{
+            BlockId, CallTarget, ExitCase, Link, OpKind, SpaceOperation, ValueType,
+        };
+
+        let mut mid = caller_hinting_arg0("app_profile_call", None, &[]);
+        let start = mid.graph.startblock;
+        let param = mid.graph.block(BlockId(0)).inputargs[0].clone();
+        let normal = Variable::named("normal_w_object");
+        mid.graph.block_mut(start).operations.push(SpaceOperation {
+            result: Some(normal.clone()),
+            kind: OpKind::Hint {
+                value: param.clone(),
+                kind: crate::hints::HintKind::NoAccessDirectly,
+            },
+        });
+
+        // The merge block's inputarg is a DIFFERENT Variable, as the front end
+        // mints it, and both arms feed it.
+        let merged = Variable::named("merged");
+        let body = mid.graph.create_block();
+        mid.graph.block_mut(body).inputargs = vec![merged.clone()];
+        mid.graph.block_mut(body).operations.push(SpaceOperation {
+            result: None,
+            kind: OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec!["call_function".to_string()],
+                },
+                args: vec![merged],
+                result_ty: ValueType::Void,
+            },
+        });
+        let still_flagged =
+            Link::from_variables(&mid.graph, vec![param], body, Some(ExitCase::Bool(true)));
+        let re_bound =
+            Link::from_variables(&mid.graph, vec![normal], body, Some(ExitCase::Bool(false)));
+        mid.graph.block_mut(start).exits = vec![still_flagged, re_bound];
+
+        let mut fns = vec![
+            caller_hinting_arg0(
+                "dispatch",
+                Some(crate::hints::HintKind::AccessDirectly),
+                &[("app_profile_call", 1)],
+            ),
+            mid,
+            free_fn("call_function"),
+        ];
+        propagate_access_directly(&mut fns, &Default::default(), &vable_roots());
+        assert!(
+            fns[1].graph.access_directly,
+            "app_profile_call itself is still reached with the flag"
+        );
+        assert!(
+            !fns[2].graph.access_directly,
+            "a merge one arm re-bound away is not flagged, as `union` intersects"
         );
     }
 

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -843,6 +843,24 @@ fn analyze_pipeline_from_module_paths(
     // `scripts/extract-llbc.py`), supplied explicitly by the consumer or
     // located via `MAJIT_MIR_FRONTEND_LLBC`.
     mark_phase!("known_statics + struct_field_attrs populated");
+    // `rlib/jit.py`'s `hint` entry reads `classdesc.get_param('_virtualizable_')`
+    // off the class before it mints `access_directly`. Pyre has no `ClassDesc`
+    // at that point, so the declaration arrives with the config — and it is
+    // already there: every `VirtualizableFieldDescriptor` the consumer builds
+    // carries the `owner_root` that declares it. Derive the registry from that
+    // rather than taking a second, out-of-band declaration, so the set the
+    // front end reads is a property of THIS invocation's config instead of
+    // whatever the thread was last told. A config that declares no owner
+    // leaves the set empty, which fails closed at the minter's class test.
+    crate::virtualizable_decl::register_virtualizable_roots(
+        config
+            .pipeline
+            .transform
+            .vable_fields
+            .iter()
+            .chain(config.pipeline.transform.vable_arrays.iter())
+            .filter_map(|field| field.owner_root.clone()),
+    );
     let mut program = build_semantic_program_via_active_frontend(
         module_paths,
         static_addrs,

--- a/majit/majit-translate/src/virtualizable_decl.rs
+++ b/majit/majit-translate/src/virtualizable_decl.rs
@@ -12,6 +12,16 @@
 //! (`rvirtualizable.rs` records why). This module is where the front end
 //! reads it back, so the minter's class test can run before there is a
 //! `ClassDesc` to ask.
+//!
+//! Upstream the declaration is per-CLASS Bookkeeper state, so it is neither
+//! thread- nor invocation-scoped: `get_param` asks the class every time.
+//! Scoping it to an invocation is a pyre deviation forced by having no
+//! `ClassDesc` at this point, and the way it is kept honest is that the
+//! pipeline re-seeds this registry from its own `AnalyzeConfig` on every run
+//! (`lib.rs analyze_pipeline_from_module_paths`), deriving the roots from the
+//! `owner_root` the same config already puts on every
+//! `VirtualizableFieldDescriptor`. One declaration channel, refreshed per
+//! invocation — the shape `local_crates` has.
 
 use std::cell::RefCell;
 
@@ -32,6 +42,11 @@ thread_local! {
 /// Replace this thread's `_virtualizable_` root set. A later invocation on
 /// the same thread overwrites, matching the per-invocation semantics of
 /// `local_crates::register_local_crate_roots`.
+///
+/// The production caller is the pipeline itself, which derives the set from
+/// the `AnalyzeConfig` it was handed. Public for a consumer that builds a
+/// program without going through `analyze_pipeline_from_module_paths`; such a
+/// consumer owns the ordering, since the read happens during the build.
 pub fn register_virtualizable_roots(roots: impl IntoIterator<Item = String>) {
     REGISTERED.with(|registered| *registered.borrow_mut() = roots.into_iter().collect());
 }

--- a/pyre/bench/synth/a_profiler_installed_from_a_call_event_keeps_c_events.py
+++ b/pyre/bench/synth/a_profiler_installed_from_a_call_event_keeps_c_events.py
@@ -10,8 +10,9 @@
 # cannot come from refusing it.  It comes from the green key instead:
 # `is_being_profiled` is an `interp_jit.py` portal green, so a profiled
 # activation names a different cell from the one the warm-up loop filled, and a
-# trace recorded under that key declines its residual calls
-# (`DispatchError::ProfiledResidualCall`) rather than folding them.
+# trace recorded under that key folds no call
+# (`walker_foldable_runtime_helper`), leaving every one of them a residual that
+# fires its own `c_call` / `c_return` (`residual_call_c_profile_frame`).
 #
 # THE TAIL IS THE TEST.  A `c_call` count that stops at the entry threshold and
 # then holds is what a green key read once, or read before the write, produces;

--- a/pyre/bench/synth/profile_hook_armed_before_a_hot_loop.py
+++ b/pyre/bench/synth/profile_hook_armed_before_a_hot_loop.py
@@ -3,10 +3,10 @@
 # A profile hook is installed, and a loop entered afterwards runs a tail long
 # enough that a compiled one would have taken it over.
 #
-# This is the fixture for the gate `eval_with_jit_inner` keeps on profiled
-# frames, and it is written to fail the moment that gate is narrowed without
-# the reporting to back it up.  Three separate sources owe events here, each
-# failing silently and independently:
+# The frame compiles while profiled, so every event below comes out of compiled
+# code or out of a residual it makes.  This fixture is written to fail the
+# moment one of those routes stops reporting.  Three separate sources owe
+# events here, each failing silently and independently:
 #
 #   * the loop frame's own `call`, from `executioncontext.py call_trace`, and
 #     its `return`, from `leave`'s `_trace('leaveframe')`.  `pyframe.py
@@ -18,11 +18,11 @@
 #     the callee or jumps into its compiled entry, both of which begin at the
 #     callee's first bytecode, past that bracket;
 #   * a builtin's `c_call` / `c_return`, from `baseobjspace.py call_args`'s
-#     profile arm.  Compiled code does not reach that arm at all — measured by
-#     probing `call::c_profile_frame`, neither a folded builtin nor a residual
-#     one goes through the interpreter's call doors — so this is the row that
-#     keeps the gate: `is_being_profiled` is a green, and a profiled trace would
-#     have to be RECORDED with the reporting in it.
+#     profile arm.  A fold reaches no call door at all, and the residual
+#     helpers used not to either, so this is the row that costs the most to
+#     keep: `walker_foldable_runtime_helper` has to leave every call in a
+#     profiled trace residual, and `residual_call_c_profile_frame` has to take
+#     `call_valuestack`'s diversion inside that residual.
 #
 # THE TAIL IS THE TEST for all three.  Each loss is total and permanent rather
 # than partial: the moment a compiled trace takes the frame over the events
@@ -30,7 +30,9 @@
 # narrowed, every count below saturated at the entry threshold — `c_call`
 # stopped at 1041 for `len`, `ord`, `divmod`, `hex`, `sorted`, `max` and
 # `round` alike — so each is checked at TWO tails and must track the difference
-# between them.  A count that saturates fails however large it is.
+# between them.  A count that saturates fails however large it is — that is the
+# shape a fold produces, and it is what the counts read at 1041 before the
+# reporting was recorded.
 #
 # Only builtins are called here.  A class call would report `c_call` /
 # `c_return` for `__new__` and `__init__`, which cpython does not, and that

--- a/pyre/bench/synth/profile_hook_c_call_is_bytecode_level_only.py
+++ b/pyre/bench/synth/profile_hook_c_call_is_bytecode_level_only.py
@@ -31,19 +31,25 @@
 # `c_exception_trace` and re-raises, so a raising builtin owes `c_call` and no
 # `c_return`.
 #
-# Every body is warmed past the loop threshold with nothing installed, so each
-# measured loop has already been compiled once when the hook arms.  pyre
-# declines a profiled frame at the portal (see
-# `profile_hook_armed_before_a_hot_loop.py`), so the measured pass itself runs
-# interpreted — which is the point: the answer must not depend on which of the
-# two ran, and the warm pass is what makes that claim testable rather than
-# assumed.
+# BOTH PASSES ARE COMPILED, and that is what puts the first half under load.
+# `is_being_profiled` is an `interp_jit.py` portal green, so the warm pass and
+# the measured pass name different cells; each runs past the loop threshold on
+# its own account, so neither answer is the interpreter's by default.  The
+# compiled arm reaches the profile diversion through
+# `call_jit.rs residual_call_c_profile_frame`, which DOES read
+# `gettopframe_raw` — soundly, because a CALL-family residual is the bytecode's
+# own dispatch and nothing else emits one, so the interior `descr_call` that
+# runs `__new__` and `__init__` never reaches it.  The type calls at zero are
+# what proves that rather than assumes it.
 #
 # Measured on cpython 3.14.6 and pypy3, which agree on every count below.
 import sys
 
-REPEAT = 5
-WARM = 5000  # past the loop threshold (1039) several times over
+# Past the loop threshold (1039) twice over, so the MEASURED pass compiles
+# under its own profiled green key rather than reading back what the warm pass
+# proved about the unprofiled one.
+REPEAT = 2500
+WARM = 5000  # past the same threshold several times over
 
 WARM_ITER = [0] * WARM
 TEST_ITER = [0] * REPEAT

--- a/pyre/bench/synth/profile_hook_sees_a_recursive_portal_activation.py
+++ b/pyre/bench/synth/profile_hook_sees_a_recursive_portal_activation.py
@@ -32,9 +32,9 @@
 # `settrace` is checked alongside `setprofile` because they fail differently:
 # `w_tracefunc` is guarded at the merge point, so arming a tracer exits compiled
 # code, while `is_being_profiled` is a portal green, so arming a profiler mints
-# a different cell that KEEPS the JIT and declines at the call. Only the second
-# reaches the portal entries this fixture is about, so a fixture that armed only
-# a tracer would pass without testing anything.
+# a different cell that KEEPS the JIT and leaves the call a residual. Only the
+# second reaches the portal entries this fixture is about, so a fixture that
+# armed only a tracer would pass without testing anything.
 import sys
 
 WARM = 20000  # past the loop threshold (1039) many times over

--- a/pyre/design.md
+++ b/pyre/design.md
@@ -398,8 +398,10 @@ this entry predicted. **The gate is no longer the implementation of frame
 events for JIT-eligible frames**, and a profiled call-free loop now measures
 the JIT.
 
-**The two hooks fail for different reasons, and the obvious repair of the
-second one is unsound.** Under `MAJIT_STATS=1` on the call-bearing loop,
+**The two hooks failed for different reasons, and the obvious repair of the
+second one is unsound.** Every number in the next three paragraphs is the
+diagnosis as it stood before the recorder landed; what replaced it is measured
+at the end of this section. Under `MAJIT_STATS=1` on the call-bearing loop,
 `sys.settrace` keeps its compilation — `loops_compiled=4`, `loops_aborted=0`,
 `guard_failures=3`, a summary line byte-identical to the bare arm's — so its
 whole cost is executed per-call dispatch inside compiled code. `sys.setprofile`
@@ -512,15 +514,25 @@ so it is never one. The per-opcode half is a different mechanism again —
 `dispatch_bytecode`'s explicit `we_are_jitted()` arm tests the *per-frame*
 `w_f_trace` through the virtualizable `debugdata`, not the global tracefunc.
 
-Where the green does pay is the profiled-call dispatch: `call_valuestack` and
-its keyword/ex siblings branch on `get_is_being_profiled()` before
-`call_args_and_c_profile`, and a real green folds those branches to nothing in
-the unprofiled trace while giving the profiled state its own cell, counter and
-procedure token. With the bracket landed and the call-free shape flat, this is
-now the remaining step rather than the last one, and the measurement above says
-which half to take first: `settrace` keeps its compilation, so its cost is
-entirely in that unfolded branch; `setprofile` aborts the recording before the
-branch can matter.
+**The green's two halves land differently here, and pyre already holds the one
+that survives.** `is_being_profiled` is a portal green
+(`pypyjit_driver_layout.rs`) and `driver.rs make_green_key(code_ptr, pc,
+is_being_profiled)` mints from it, so the profiled state does get its own cell,
+counter and procedure token: `profile_hook_c_call_is_bytecode_level_only`
+compiles 14 loops for its 7 arms, two keys each, which is that separation
+counted rather than assumed.
+
+The other half — folding `get_is_being_profiled()` out of the unprofiled trace
+— has nothing to fold. Upstream's branch is foldable because the JIT records
+through `call_valuestack` itself, so the test is an operation in the trace.
+pyre residualises the call, and the branch lives inside `call_jit.rs
+bh_call_fn_impl` where no recorded operation corresponds to it. Every read of
+the flag in `pyre-jit` and `pyre-jit-trace` sits at trace time, at green-key
+mint, or at portal entry — none per call in a compiled body — and
+`funccall_valuestack`, whose `PyFrame::call` conjunct is discussed above, is
+reached only from `pyre-interpreter`'s own CALL. This is §3.8's theme arriving
+at the cost model: the opaque objspace has already hidden the branch the fold
+was for, so the green cannot be where the remaining cost goes.
 
 **Falsification, run 2026-08-26 — passed.** The prediction was that restoring
 the activation bracket would leave event counts unchanged with the gate still
@@ -529,17 +541,50 @@ disjuncts be dropped without losing events. Both held: the gate now reads only
 the per-frame `w_f_trace` and the `call`/`return`/`c_call` multisets are
 unchanged, so the bracket was what the gate was standing in for.
 
-The successor claim, which this entry now stands or falls by: the two
-remaining costs are the unrecorded profile reporting and the unfolded per-call
-dispatch, in that order. The first is now bounded rather than guessed — the
-`setprofile` aborts DO survive a recorder that admits the profiled call, and
-`profile_hook_armed_before_a_hot_loop` is the instrument that says so. It is
-wrong if recording `c_call` / `c_return` into the builtin folds still leaves
-`setprofile` short of `settrace`'s regime, or if folding
-`get_is_being_profiled()` out of the unprofiled trace still leaves the
-call-bearing loop more than an order of magnitude off its bare arm — either
-would mean a third mechanism is in play that none of the bracket, the
-recorder, or the green accounts for.
+**The recorder landed, and a built control says it paid.** The decline is
+gone: `residual_call_c_profile_frame` gives the three CALL-family residual
+helpers `call_valuestack`'s C-profile diversion, and
+`walker_foldable_runtime_helper` withholds only the *fold identity* of those
+three helpers from a profiled walk, so the call is recorded as an opaque
+residual instead of aborting the trace. `DispatchError::ProfiledResidualCall`
+no longer exists.
+
+Measured against a binary built at this commit's own parent — the only valid
+control, since `PYRE_JIT=0` moves the bare arm as well as the profiled one and
+so is not one — on a hot profiled loop, five interleaved repetitions on a quiet
+machine, reported as ns/event because the bare arms are ~1 ms and divide out:
+
+| shape | control | with the recorder | |
+|---|---|---|---|
+| builtin callee (`len`) | 999–1019 | 788–826 | **1.27x** |
+| Python callee | 1305–1328 | 1136–1183 | **1.17x** |
+
+`MAJIT_STATS=1` on the same script gives the mechanism rather than the effect.
+The control reads `loops_compiled=3 loops_aborted=10`, with all ten on the
+reason ladder's fourth rung (`abrt_bridge=10`, `abrt_unclassified_default=10`)
+and two green keys banned outright (`abort_ceiling_banned=2`,
+`abort_ceiling_refused=2`). This tree reads `loops_compiled=5
+loops_aborted=0`, every abort counter at zero, and `caro_backedge` falls 12 → 4
+because a banned key keeps re-entering the merge point it can never compile.
+
+The successor claim this entry now stands or falls by: **the remaining cost is
+neither the bracket, the recorder, nor the green.** The bracket is landed and
+falsified-as-predicted; the recorder is landed and measured above; and the
+green cannot be it, for the reason given two paragraphs up — pyre has the half
+that separates cells and there is no per-call branch left to fold. Yet a
+profiled call-bearing loop still runs ~1.1 µs/event against pypy's 0.4 ns and
+CPython 3.14's 48.5, so the third mechanism the previous claim named as a
+falsifier IS in play, and naming it is the next step rather than a contingency.
+
+The first place to look is what a profiled compiled caller does with a callee
+it may not inline. `inline_call.rs` declines on `ec_hook_installed()` for any
+installed hook — correctly, since the walker has no route to record
+`executioncontext.py`'s `_trace`, which calls back into app-level Python — so
+the callee becomes a residual reaching `call_user_function_with_ctx`, where the
+plain interpreter's CALL would have taken `funccall_valuestack`'s
+`_flat_pycall`-shaped fast path. That is a hypothesis, not a measurement: the
+control above says compiling is better than not compiling, not that the
+compiled path is close to what it could be.
 
 
 ### 3.8 The fold layer: hand-written compensation for an opaque objspace

--- a/pyre/design.md
+++ b/pyre/design.md
@@ -413,14 +413,14 @@ reading 0, i.e. they take the reason ladder's fourth rung — nothing staged,
 fall back to `AbortReason::Generic`, whose integer *is* `ABORT_BRIDGE`. That
 rung has no upstream counterpart: every `SwitchToBlackhole` upstream takes its
 `Counters.ABORT_*` as a constructor argument, so a reason cannot be absent
-there. `PYRE_FBW_DEBUG_ABORT` supplies the name the counters cannot:
+there. `PYRE_FBW_DEBUG_ABORT` supplied the name the counters cannot:
 `DispatchError::ProfiledResidualCall`.
 
-The walker declines a residual call made from a profiled frame because a
+The walker declined a residual call made from a profiled frame because a
 builtin callee owes `c_call` / `c_return`, and the walker *decides* that call —
 folding or residualising it — rather than tracing through the arm that reports
-it, so a trace taken there would run its tail silently. That is right for a
-builtin, and it is applied to every callee; the site's own comment records the
+it, so a trace taken there would run its tail silently. That was right for a
+builtin, and it was applied to every callee; the site's own comment recorded the
 widening as known: a `CallFn` naming a Python callee "owes no `c_call` either,
 but the fold gives the walker no way to tell".
 
@@ -438,34 +438,47 @@ all — so `len`'s `c_call` / `c_return` stop firing while `callee`'s `call` /
 folded builtin. That fixture says so in advance, and it is right: the gate can
 only narrow "with the reporting to back it up".
 
-So the ordering is fixed, and it is the opposite of the tempting one. The
+So the ordering was fixed, and it is the opposite of the tempting one: the
 reporting has to be **recorded into the trace** before the decline can narrow.
-Until that exists, declining is the correct answer and the cliff is the price.
 
-What that costs is now scoped rather than guessed. It is not one insertion per
-fold: `dispatch_residual_call_iRd_kind` sits ahead of every fold, every
-descent and the generic residual emit, so the reporting has one entry point.
-The pair is `ExecutionContext::c_call_trace` / `c_return_trace`, and since
-both funnel into a path that reads the arguments only through `firstarg`, a
-bridge needs `(frame, w_func, first_arg)` and no `Arguments` reconstruction.
-Two `extern "C"` bridges are required rather than raw Rust fns, per the
-residual-fnaddr ABI rule. The effect has to be `MOST_GENERAL` — the hook is
-arbitrary Python — which is mintable at trace time precisely because its raw
-sets are `None` rather than empty, and it has to be emitted through the
-residual path's `CallMayForceN` + `GuardNotForced` rather than a plain
-recorded call, or the declaration lies to the optimizer. The frame is
-reachable per level through `walker_executing_frame_box`, which resolves to
-the portal's virtualizable at the root and to the callee shadow inside an
-inline sub-walk — the split
-`profile_hook_c_call_is_bytecode_level_only` already pins.
+**That is what landed, and the reporting turned out not to need a new trace
+op.** Upstream's own `test_cprofile_builtin` unpacks exactly one loop out of a
+profiled `lst.append` / `lst.pop` pair, so "record, not decline" is upstream's
+answer and not an invention. The invention is only the mechanism, and the shape
+is forced by `resume_snapshot.rs`: pyre's blackhole re-enters Python bytecode
+only, so any walker-emitted guard resumes at the enclosing opcode boundary and
+a three-op bracket — recorded `c_call`, fold, recorded `c_return` — cannot
+exist. Resuming *at* the CALL fires `c_call` twice; resuming *past* it skips
+the builtin. The bracket has to be one residual whose leaf is
+`baseobjspace.py call_args_and_c_profile`, which is also upstream's line.
 
-The hard part is the exit, not the entry: the choke point has one entrance and
-many early returns, one per fold, and `c_return` is owed on all of them
-including the raising one. And the payoff is not yet established — every
-folded builtin in a profiled loop would be bracketed by two forcing calls, so
-the first measurement to run is whether such a compiled loop actually beats
-the interpreted one it replaces. If it does not, the decline is not merely
-safe but right, and this entry's remaining half closes rather than lands.
+pyre already had that leaf, reached through the `profile_frame` parameter
+`call_valuestack` threads down to `call_function_carrier_with_mode`. What it
+did not have was any residual that passed a frame: `flatten.rs
+lower_simple_call_hlop_to_insn` collapses the whole Python CALL to a frameless
+`RuntimeHelperKind::CallFn` residual, so the reporting arm existed in no
+jitcode the walker walks. So the three CALL-family helpers now take
+`call_valuestack`'s own diversion themselves
+(`call_jit.rs residual_call_c_profile_frame`): a residual of one of them *is*
+the bytecode's dispatch, which settles by construction the distinction
+`c_profile_frame` draws between the bytecode's call and one made inside
+`descr_call`, and the executing frame is the context's top frame. The gate is
+upstream's, `frame.get_is_being_profiled() and is_builtin_code(w_func)`, asked
+on the raw callable before the `_Method` unwrap, exactly where `eval.rs`'s own
+CALL asks it. One helper covers tracing, compiled code and the blackhole
+alike, because all three call `bh_call_fn_N`.
+
+The walker's remaining job is the small half: keep those calls reachable.
+`walker_foldable_runtime_helper` answers `RuntimeHelperKind::None` for the
+three while a profiler is installed, so every fold, every descent into a
+builtin's jitcode and the `CALL_ASSEMBLER` door decline exactly as they do for
+a shape they cannot handle, and the uniform decline path is the generic
+residual. The two doors into a *Python* callee were already closed by
+`ec_hook_installed`, which is why the frame-level `call` / `return` never
+needed this. The `iIRd` dispatcher carries the same binding: it has call folds
+of its own and never had a profiled decline, which cost nothing only for as
+long as `iRd`'s decline aborted the whole trace ahead of it, and would have
+been a live hole the moment that decline went.
 
 One claim examined along the way did not survive: that the method-form
 dispatcher carries no profiled decline and so already drops events for a bound

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1830,9 +1830,11 @@ pub fn report_stack_underflow(frame: &PyFrame) {
 /// tracing by `record_portal_debugdata_guard` keeping it from compiling.
 /// `setprofile` owes the same frame-level pair, from the same bracket plus
 /// `leave`'s `_trace('leaveframe')`, and owes `c_call` / `c_return` on top —
-/// which the walker answers by declining a profiled trace at the call itself
-/// (`DispatchError::ProfiledResidualCall`) rather than by refusing the frame.
-/// A profiled loop that calls nothing therefore compiles and reports.
+/// which the residual call helpers fire themselves
+/// (`call_jit.rs residual_call_c_profile_frame`), the walker keeping them
+/// reachable by folding no call while a profiler is installed
+/// (`jitcode_dispatch::residual_call::walker_foldable_runtime_helper`).  A
+/// profiled loop therefore compiles and reports, calls and all.
 pub fn frame_tracing_active(frame: &PyFrame) -> bool {
     !frame.get_w_f_trace().is_null()
 }

--- a/pyre/pyre-jit-trace/build/prepass.rs
+++ b/pyre/pyre-jit-trace/build/prepass.rs
@@ -976,16 +976,12 @@ fn real_main() {
     // graph rewrite can recognize `next_instr`, `valuestackdepth`, and
     // `locals_cells_stack_w[*]` as virtualizable accesses before legacy
     // TracePattern classification runs.
-    // `_virtualizable_` is a class declaration upstream
-    // (`classdesc.get_param('_virtualizable_')`), consulted by `rlib/jit.py`'s
-    // `hint` entry before it mints `access_directly`. pyre's frame is a Rust
-    // struct that carries no such parameter, so the same table that fills
-    // `vable_fields` below declares it, and the front end reads it back
-    // through `virtualizable_decl`.
-    majit_translate::virtualizable_decl::register_virtualizable_roots([
-        virtualizable_spec::PYFRAME_VABLE_OWNER_ROOT.to_string(),
-    ]);
-
+    //
+    // `owner_root` below is also the `_virtualizable_` declaration upstream
+    // reads off the class (`classdesc.get_param('_virtualizable_')`, consulted
+    // by `rlib/jit.py`'s `hint` entry before it mints `access_directly`). The
+    // pipeline derives the front end's root set from these descriptors, so
+    // this table is the single place the frame is declared virtualizable.
     let analyze_config = majit_translate::AnalyzeConfig {
         pipeline: majit_translate::PipelineConfig {
             transform: majit_translate::GraphTransformConfig {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2662,18 +2662,6 @@ pub enum DispatchError {
     /// trace taken here would compile a loop that owes `line` events and
     /// cannot fire them. Decline and leave the frame to the interpreter.
     PortalFrameTracerArmed { pc: usize },
-    /// A residual call reached while the portal frame is being profiled.
-    /// `baseobjspace.py call_args_and_c_profile` brackets a builtin call the
-    /// bytecode made with `c_call` / `c_return`, and the walker DECIDES that
-    /// call rather than tracing through the arm that reports it, so a trace
-    /// taken here would run the tail with no way to fire those events.
-    /// Decline and leave the frame to the interpreter, which fires them.
-    ///
-    /// `is_being_profiled` is an `interp_jit.py` green, so this abort — and the
-    /// `JC_DONT_TRACE_HERE` the ceiling latches after `MAX_TRACE_ABORT_COUNT`
-    /// of them — lands on the PROFILED cell only.  Dropping the profiler keys a
-    /// different cell, which is neither banned nor un-inlinable.
-    ProfiledResidualCall { pc: usize },
     /// `loop_header/i` or `jit_merge_point/iIRFIRF` could not resolve its
     /// jdindex operand to a concrete Int. The assembler encodes the jdindex as a
     /// populated int-constant-pool slot (`assembler.rs loop_header`:
@@ -2856,7 +2844,6 @@ impl DispatchError {
             }
             Self::JitMergePointGreenKeyUnresolved { .. } => "JitMergePointGreenKeyUnresolved",
             Self::PortalFrameTracerArmed { .. } => "PortalFrameTracerArmed",
-            Self::ProfiledResidualCall { .. } => "ProfiledResidualCall",
             Self::LoopHeaderJdIndexUnresolved { .. } => "LoopHeaderJdIndexUnresolved",
             Self::SubWalkClosedLoop { .. } => "SubWalkClosedLoop",
             Self::BranchGuardKeptStackUnsupported { .. } => "BranchGuardKeptStackUnsupported",
@@ -2939,7 +2926,6 @@ impl DispatchError {
             | Self::LastExceptionWithoutActiveException { pc, .. }
             | Self::JitMergePointGreenKeyUnresolved { pc, .. }
             | Self::PortalFrameTracerArmed { pc, .. }
-            | Self::ProfiledResidualCall { pc, .. }
             | Self::LoopHeaderJdIndexUnresolved { pc, .. }
             | Self::SubWalkClosedLoop { pc, .. }
             | Self::BranchGuardKeptStackUnsupported { pc, .. }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -6083,6 +6083,54 @@ fn try_walker_force_quasi_immut_mapdict_write<Sym: WalkSym>(
     Some(())
 }
 
+/// The `RuntimeHelperKind` a residual's fold ladder may recognise, which is
+/// its own except while a profile function is installed.
+///
+/// A profiled frame owes `c_call` / `c_return` around every builtin call its
+/// bytecode makes — `baseobjspace.py call_valuestack`, `pyopcode.py`
+/// CALL_FUNCTION_KW / CALL_FUNCTION_EX and `callmethod.py CALL_METHOD_KW` hand
+/// `call_args_and_c_profile` the executing frame.  Upstream's compiled loop
+/// carries that reporting because its tracer traced THROUGH `call_args`, and
+/// its own `test_cprofile_builtin` unpacks exactly ONE loop out of a profiled
+/// `lst.append` / `lst.pop` pair: the answer there is to record the reporting,
+/// never to decline the trace.
+///
+/// The residual helpers take that same diversion
+/// (`call_jit.rs residual_call_c_profile_frame`), so the reporting rides in the
+/// trace as a `CALL_MAY_FORCE` to a helper that runs it — for exactly the three
+/// call helpers, which are the whole population that owes an event.  Every
+/// other kind reaching a residual dispatcher erases an operator dispatch, which
+/// reports nothing on cpython, pypy3 or pyre alike.
+///
+/// What the walker owes in return is to leave those three ALONE.  A fold, a
+/// descent into the builtin's own jitcode, or a `CALL_ASSEMBLER` replaces the
+/// residual with something that reaches no call door, and none of them can
+/// report: measured 2026-08-26, admitting a profiled trace while the folds
+/// stayed live stopped `len`'s `c_call` at the entry threshold, 1041, however
+/// long the tail.  Answering `None` is how they are left alone — no fold arm
+/// tests for it, so each declines exactly as it does for a shape it cannot
+/// handle, and the uniform decline path is the generic residual.
+///
+/// The two doors into a PYTHON callee owe `call` / `return` from `pyframe.py
+/// execute_frame` rather than `c_call`, and are closed for a trace function and
+/// a profiler alike by [`super::ec_hook_installed`].
+fn walker_foldable_runtime_helper<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    ei: &majit_ir::EffectInfo,
+) -> majit_ir::RuntimeHelperKind {
+    let owes_c_call_events = matches!(
+        ei.runtime_helper,
+        majit_ir::RuntimeHelperKind::CallFn
+            | majit_ir::RuntimeHelperKind::CallKw
+            | majit_ir::RuntimeHelperKind::CallFunctionEx
+    );
+    if owes_c_call_events && ctx.session.borrow().is_being_profiled {
+        majit_ir::RuntimeHelperKind::None
+    } else {
+        ei.runtime_helper
+    }
+}
+
 /// `residual_call` shape `iRd>X` dispatcher. Reads `funcptr (i)`,
 /// R-list args, and `descr`, runs `_build_allboxes` to produce the
 /// callee's ABI-ordered arglist, classifies the call by `EffectInfo`
@@ -6272,47 +6320,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // sees the later replacement.
     replace_movable_load_global_namespace_with_frame_globals(ctx, ei.runtime_helper, &mut r_args);
 
-    // A profiled frame owes `c_call` / `c_return` around every builtin call
-    // its bytecode makes -- `baseobjspace.py call_valuestack`, `pyopcode.py`
-    // CALL_FUNCTION_KW / CALL_FUNCTION_EX and `callmethod.py CALL_METHOD_KW`
-    // hand `call_args_and_c_profile` the executing frame.  Upstream's compiled
-    // loop carries that reporting because its tracer traced THROUGH
-    // `call_args`; this walker decides the call instead, folding or
-    // residualising it, and either way the arm that reports never runs.
-    //
-    // So decline the walk rather than compile a loop that runs its tail
-    // silently.  The three call helpers are the whole population that owes an
-    // event -- every other `RuntimeHelperKind` reaching this dispatcher erases an
-    // operator dispatch, which reports nothing on cpython, pypy3 or pyre
-    // alike.
-    //
-    // A `CallFn` naming a PYTHON callee owes no `c_call` either, and
-    // `call_valuestack` draws that line at `is_builtin_code(w_func)`.  The
-    // walker could be told: operand 0 of the plain `CallFn` shape carries the
-    // callable, and a `GuardValue` pins the recording-time answer.  Measured
-    // 2026-08-26, that is NOT enough and the narrowing was reverted --
-    // `profile_hook_armed_before_a_hot_loop` fails on all three backends.
-    // Admitting the trace for the Python callee also admits every FOLDED
-    // builtin in the same loop body, and a fold never reaches this dispatcher
-    // at all, so `len`'s `c_call` / `c_return` stop firing.  The decline on
-    // the Python call was what protected them.  Reporting has to be RECORDED
-    // into the trace before any of this can narrow; declining is the safe
-    // answer until then.
-    //
-    // This converges rather than retracing forever: `abort_count` reaches
-    // `MAX_TRACE_ABORT_COUNT` on the profiled green key and the cell latches
-    // `JC_DONT_TRACE_HERE`.  Being a green is also what keeps that ban off the
-    // unprofiled cell -- see `DispatchError::ProfiledResidualCall`.
-    if ctx.session.borrow().is_being_profiled
-        && matches!(
-            ei.runtime_helper,
-            majit_ir::RuntimeHelperKind::CallFn
-                | majit_ir::RuntimeHelperKind::CallKw
-                | majit_ir::RuntimeHelperKind::CallFunctionEx
-        )
-    {
-        return Err(DispatchError::ProfiledResidualCall { pc: op.pc });
-    }
+    // The identity the fold ladder below is allowed to recognise, which under
+    // a profile function is not this call's own — see
+    // [`walker_foldable_runtime_helper`].
+    let foldable_runtime_helper = walker_foldable_runtime_helper(ctx, ei);
     // Residual-call entry mirrors `execute_varargs`: even when the walker
     // folds the call or leaves it recorded symbolically, stale handled
     // exceptions from earlier opcodes are not visible to the following
@@ -6328,7 +6339,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && !ctx.fbw_mode.inline_subwalk
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && try_walker_orthodox_list_pop(ctx, code, op, &r_args, dst)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -6344,7 +6355,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // generic residual (SAFE).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::BuiltinLen, || {
             try_walker_specialize_builtin_len(ctx, code, op, &r_args, dst)
         })?
@@ -6369,7 +6380,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // which loses the brake rather than applying a wrong one.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && walker_active_py_code(ctx)
             .is_none_or(|active| !pyre_interpreter::code_returns_only_constants(active))
         && try_walker_force_quasi_immut_class_body(ctx, code, op, 1, &r_args)
@@ -6385,9 +6396,16 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // BuiltinCode.func is an indirect PBC target exactly like RPython's
     // gateway wrappers.  Enter its generated JitCode before considering the
     // user-function-only full-body walk below.
-    if let Some(inlined) =
-        try_walker_inline_builtin_call(ctx, op, code, 1, &r_args, ei.runtime_helper, dst_bank, dst)?
-    {
+    if let Some(inlined) = try_walker_inline_builtin_call(
+        ctx,
+        op,
+        code,
+        1,
+        &r_args,
+        foldable_runtime_helper,
+        dst_bank,
+        dst,
+    )? {
         return Ok(inlined);
     }
 
@@ -6404,7 +6422,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         funcptr,
         &r_args,
         call_descr,
-        ei.runtime_helper,
+        foldable_runtime_helper,
         dst_bank,
         dst,
     )? {
@@ -6413,7 +6431,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
 
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
     {
         if let Some(inlined) = try_walker_inline_exception_string_override(
             ctx, op, code, funcptr, &r_args, call_descr, dst,
@@ -6445,7 +6463,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         funcptr,
         &r_args,
         call_descr,
-        ei.runtime_helper,
+        foldable_runtime_helper,
         dst_bank,
         dst,
     )? {
@@ -6617,7 +6635,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         // (e.g. the `(i % 7)` in `(i % 7) and (i + 3)`) folds to a pure
         // `int_is_true`, eliding the may-force call whose force/exc guards
         // mis-resume the kept short-circuit stack.
-        if ei.runtime_helper == majit_ir::RuntimeHelperKind::Truth {
+        if foldable_runtime_helper == majit_ir::RuntimeHelperKind::Truth {
             if let Some(truth) = spec_gate(SpecFold::TruthInt, || {
                 try_walker_specialize_truth_int(ctx, op.pc, r_args[0])
             })? {
@@ -6643,7 +6661,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && r_args.len() == 1
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::UnaryPositive
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::UnaryPositive
         && spec_gate(SpecFold::UnaryPositiveDescent, || {
             try_walker_orthodox_unary_positive(ctx, op.pc, r_args[0], dst, dst_bank)
         })?
@@ -6659,7 +6677,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && r_args.len() == 1
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::UnaryPositive
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::UnaryPositive
         && spec_gate(SpecFold::UnaryPositiveInt, || {
             try_walker_specialize_unary_positive_int(ctx, op.pc, r_args[0], dst, dst_bank)
         })?
@@ -6677,7 +6695,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && r_args.len() == 1
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::UnaryNegative
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::UnaryNegative
         && spec_gate(SpecFold::UnaryNegativeDescent, || {
             try_walker_orthodox_unary_negative(ctx, op.pc, r_args[0], dst, dst_bank)
         })?
@@ -6695,7 +6713,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && r_args.len() == 1
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::UnaryInvert
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::UnaryInvert
         && spec_gate(SpecFold::UnaryInvertDescent, || {
             try_walker_orthodox_unary_invert(ctx, op.pc, r_args[0], dst, dst_bank)
         })?
@@ -6712,7 +6730,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // whose commit/rollback epilogues run on FBW walk ends.
     if ctx.is_authoritative_executor
         && dst_bank == 'v'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::StoreSubscr
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::StoreSubscr
     {
         if spec_gate(SpecFold::StoreSubscr, || {
             try_walker_specialize_store_subscr(ctx, op.pc, &r_args)
@@ -6745,7 +6763,9 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
 
     // Range GET_ITER: virtualize exact machine-word `range` into the same
     // `W_IntRangeIterator` shape PyPy's inlined `descr_iter` would trace.
-    if ctx.is_authoritative_executor && ei.runtime_helper == majit_ir::RuntimeHelperKind::GetIter {
+    if ctx.is_authoritative_executor
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::GetIter
+    {
         if let Some(iter_op) = spec_gate(SpecFold::GetIter, || {
             try_walker_specialize_get_iter(ctx, op.pc, &r_args, dst, dst_bank)
         })? {
@@ -6766,7 +6786,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // including NULL for exhaustion, so the codewriter's trailing
     // GuardNonnull remains the only loop-exit guard.
     if ctx.is_authoritative_executor
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::ForIterNext
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::ForIterNext
     {
         if let Some(item_op) = spec_gate(SpecFold::ForIterNext, || {
             try_walker_specialize_for_iter_next(ctx, op.pc, &r_args, dst, dst_bank)
@@ -6789,7 +6809,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // reproduce constant-for-constant (SAFE — never declined).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::MakeFunction
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::MakeFunction
         && spec_gate(SpecFold::MakeFunction, || {
             try_walker_specialize_make_function(ctx, op.pc, &r_args, dst, dst_bank)
         })?
@@ -6805,7 +6825,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // opaque residual for any other shape (SAFE — never declined).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::NewtupleFromArray
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::NewtupleFromArray
         && spec_gate(SpecFold::Newtuple, || {
             try_walker_specialize_newtuple(ctx, op.pc, &r_args, dst, dst_bank)
         })?
@@ -6822,7 +6842,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // declined).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::NewtupleFromArray
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::NewtupleFromArray
         && spec_gate(SpecFold::NewtupleObject, || {
             try_walker_specialize_newtuple_object(ctx, op.pc, &r_args, dst, dst_bank)
         })?
@@ -6842,7 +6862,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // declined.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::NewlistFromArray
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::NewlistFromArray
         && spec_gate(SpecFold::Newlist, || {
             try_walker_specialize_newlist(ctx, op.pc, &r_args, dst, dst_bank)
         })?
@@ -6888,7 +6908,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && !ctx.fbw_mode.inline_subwalk
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && try_walker_orthodox_list_append(ctx, code, op, &r_args, dst)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -6905,7 +6925,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && !ctx.fbw_mode.inline_subwalk
         && dst_bank == 'v'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::ListAppendValue
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::ListAppendValue
     {
         // Fold to native array stores when the receiver has spare capacity, or
         // fall through to the generic `jit_list_append` residual below.  The
@@ -6930,7 +6950,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // iterator state and read the resolved entry value live.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::BuiltinDictGet, || {
             try_walker_specialize_builtin_dict_get(ctx, code, op, &r_args, dst)
         })?
@@ -6944,7 +6964,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // Non-matching shapes fall through to the generic residual.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::BuiltinTypeGetattr, || {
             try_walker_specialize_builtin_type_getattr(ctx, code, op, &r_args, dst)
         })?
@@ -6959,7 +6979,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // which answers the receiver the instance-shape read declines.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::BuiltinGetattr, || {
             try_walker_specialize_builtin_getattr(ctx, code, op, &r_args, dst)
         })?
@@ -6973,7 +6993,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // Non-canonical callables and arguments fall through to the residual.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
     {
         if let Some(outcome) = spec_gate(SpecFold::BuiltinRange, || {
             try_walker_specialize_builtin_range(ctx, code, op, funcptr, &r_args, call_descr, dst)
@@ -6985,7 +7005,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // Virtualize PyPy's exact `zip(tuple0, tuple1, strict=True)` shape.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallKw
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallKw
         && spec_gate(SpecFold::BuiltinZip, || {
             try_walker_specialize_builtin_zip(ctx, code, op, &r_args, dst)
         })?
@@ -7005,7 +7025,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // falls through to the generic residual (SAFE).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::BuiltinLocals, || {
             try_walker_specialize_builtin_locals(ctx, code, op, &r_args, dst)
         })?
@@ -7024,7 +7044,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // through to the generic residual (SAFE).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::SysGetframe, || {
             try_walker_specialize_sys_getframe(ctx, code, op, &r_args, dst)
         })?
@@ -7041,7 +7061,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // non-finite sqrt) falls through to the generic residual (SAFE).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::MathSqrt, || {
             try_walker_specialize_math_sqrt(ctx, code, op, &r_args, dst)
         })?
@@ -7051,7 +7071,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::MathLogTrig, || {
             try_walker_specialize_math_log_trig(ctx, code, op, &r_args, dst)
         })?
@@ -7061,7 +7081,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::MathFrexp, || {
             try_walker_specialize_math_frexp(ctx, code, op, &r_args, dst)
         })?
@@ -7071,7 +7091,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::MathLdexp, || {
             try_walker_specialize_math_ldexp(ctx, code, op, &r_args, dst)
         })?
@@ -7081,7 +7101,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::MathIsqrt, || {
             try_walker_specialize_math_isqrt(ctx, code, op, &r_args, dst)
         })?
@@ -7091,7 +7111,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::MathFabs, || {
             try_walker_specialize_math_fabs(ctx, code, op, &r_args, dst)
         })?
@@ -7101,7 +7121,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::MathFloat1, || {
             try_walker_specialize_math_float1(ctx, code, op, &r_args, dst)
         })?
@@ -7111,7 +7131,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::MathFloat2, || {
             try_walker_specialize_math_float2(ctx, code, op, &r_args, dst)
         })?
@@ -7121,7 +7141,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::MathIsclose, || {
             try_walker_specialize_math_isclose(ctx, code, op, &r_args, dst, dst_bank)
         })?
@@ -7131,7 +7151,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::BuiltinFold1, || {
             try_walker_specialize_builtin_fold1(ctx, code, op, &r_args, dst)
         })?
@@ -7141,7 +7161,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::BuiltinFold2, || {
             try_walker_specialize_builtin_fold2(ctx, code, op, &r_args, dst)
         })?
@@ -7151,7 +7171,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::MathFloor, || {
             try_walker_specialize_math_round_to_int(
                 ctx,
@@ -7168,7 +7188,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::MathCeil, || {
             try_walker_specialize_math_round_to_int(
                 ctx,
@@ -7185,7 +7205,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::MathTrunc, || {
             try_walker_specialize_math_round_to_int(
                 ctx,
@@ -7202,7 +7222,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::IntCall, || {
             try_walker_specialize_int_call(ctx, code, op, &r_args, dst)
         })?
@@ -7213,7 +7233,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // Ahead of the re-route below, which is what a decline here falls back to.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::BareSuperVirtual, || {
             try_walker_specialize_bare_super_virtual(ctx, code, op, &r_args, dst)
         })?
@@ -7223,7 +7243,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::BareSuperCall, || {
             try_walker_specialize_bare_super_call(ctx, code, op, &r_args, dst)
         })?
@@ -7233,7 +7253,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::TwoArgSuperCall, || {
             try_walker_specialize_two_arg_super_call(ctx, code, op, &r_args, dst)
         })?
@@ -7243,7 +7263,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::FloatCall, || {
             try_walker_specialize_float_call(ctx, code, op, &r_args, dst)
         })?
@@ -7253,7 +7273,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::StrCall, || {
             try_walker_specialize_str_call(ctx, code, op, &r_args, dst)
         })?
@@ -7270,7 +7290,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // through to the generic residual (SAFE).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && spec_gate(SpecFold::BuiltinDivmod, || {
             try_walker_specialize_builtin_divmod(ctx, code, op, &r_args, dst)
         })?
@@ -7294,14 +7314,14 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // through to the generic residual (SAFE).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
         && try_walker_trace_exception_new(ctx, code, op, &r_args, dst)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::RaiseVarargs
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::RaiseVarargs
         && r_args.is_empty()
         && ctx.fbw_mode.current_exception_seed.is_some()
     {
@@ -7323,7 +7343,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::RaiseVarargs
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::RaiseVarargs
         && try_walker_trace_raise_builtin(ctx, code, op, &r_args, dst)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -7333,7 +7353,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // canonical builtin exception class.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::RaiseVarargs
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::RaiseVarargs
         && try_walker_trace_raise_bare_class(ctx, code, op, &r_args, dst)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -7397,7 +7417,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // rather than merely survivable by them.
     let set_add_subst = if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn
     {
         spec_gate(SpecFold::SetAddMethod, || {
             try_walker_specialize_set_add_method(ctx, code, op, &r_args)
@@ -7939,6 +7959,10 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         })?;
 
     let ei = call_descr.get_extra_info();
+    // The identity the fold ladder below is allowed to recognise, which under
+    // a profile function is not this call's own — see
+    // [`walker_foldable_runtime_helper`].
+    let foldable_runtime_helper = walker_foldable_runtime_helper(ctx, ei);
     // pyjitpl.py OS_NOT_IN_TRACE guard — see helper docstring
     // for the convergence rationale.
     if let Some(outcome) =
@@ -7961,7 +7985,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         code,
         1 + i_width,
         &r_args,
-        ei.runtime_helper,
+        foldable_runtime_helper,
         dst_bank,
         dst,
     )? {
@@ -7976,7 +8000,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         funcptr,
         &r_args,
         call_descr,
-        ei.runtime_helper,
+        foldable_runtime_helper,
         dst_bank,
         dst,
     )? {
@@ -7984,7 +8008,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     }
 
     // A class is not a `Function`, so the user-call route above declined it.
-    if ei.runtime_helper == majit_ir::RuntimeHelperKind::CallFn {
+    if foldable_runtime_helper == majit_ir::RuntimeHelperKind::CallFn {
         if let Some(inlined) =
             try_walker_inline_type_call(ctx, op, code, funcptr, &r_args, call_descr, dst_bank, dst)?
         {
@@ -8001,7 +8025,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // have produced — the indexed entry is loop-invariant — and suppress the
     // residual.  Falls through to the generic record when either operand is
     // not concrete (the residual stays correct in that case).
-    if ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadConst {
+    if foldable_runtime_helper == majit_ir::RuntimeHelperKind::LoadConst {
         if let (Some(&idx_opref), Some(&code_opref)) = (i_args.first(), r_args.first()) {
             if let (
                 Some(majit_ir::Value::Int(consti)),
@@ -8051,7 +8075,8 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // `bh_load_global_fn` does and reaches production parity for
     // global-function-call loops when combined with the user-call inlining
     // path. Handler-bearing reachability also includes the builtins fallback.
-    if ctx.is_authoritative_executor && ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadGlobal
+    if ctx.is_authoritative_executor
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::LoadGlobal
     {
         if let (Some(&namei_opref), Some(&ns_opref), Some(&code_opref)) =
             (i_args.first(), r_args.first(), r_args.get(1))
@@ -8081,7 +8106,8 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
             ctx.trace_ctx.reads_module_global = true;
         }
     }
-    if ctx.is_authoritative_executor && ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadGlobal
+    if ctx.is_authoritative_executor
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::LoadGlobal
     {
         if let (Some(&namei_opref), Some(&ns_opref), Some(&code_opref)) =
             (i_args.first(), r_args.first(), r_args.get(1))
@@ -8120,7 +8146,9 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // above.  The residual is `bh_load_name_fn(frame, w_name, namei)`, so
     // r_args = [frame, w_name].  `try_walker_load_name_cell_fold` gates module
     // scope at runtime and routes non-module frames back to this residual.
-    if ctx.is_authoritative_executor && ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadName {
+    if ctx.is_authoritative_executor
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::LoadName
+    {
         if let (Some(&frame_opref), Some(&name_opref)) = (r_args.first(), r_args.get(1)) {
             if let (
                 Some(majit_ir::Value::Ref(majit_ir::GcRef(frame_ptr))),
@@ -8174,7 +8202,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // 1.32us per iteration; at the fixture's own 3000 iterations the difference
     // sits under this box's noise floor.
     if ctx.is_authoritative_executor
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadName
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::LoadName
         && !walk_body_has_exception_handler(ctx, code)
     {
         if let (Some(&frame_opref), Some(&name_opref)) = (r_args.first(), r_args.get(1)) {
@@ -8202,7 +8230,9 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // guard proves the attribute is present on this shape), so it is attempted
     // even in handler-bearing bodies; every unfoldable shape falls through to
     // the residual (which keeps its exception guard).
-    if ctx.is_authoritative_executor && ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadAttr {
+    if ctx.is_authoritative_executor
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::LoadAttr
+    {
         if let (Some(&obj_opref), Some(&code_opref), Some(&namei_opref)) =
             (r_args.first(), r_args.get(1), i_args.first())
         {
@@ -8327,7 +8357,8 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // STORE_ATTR property setter: the plain-slot store fold above declines a
     // `property` data descriptor; inline its Python setter instead of the
     // opaque `setattr` residual.  `store_attr_fn` r_args = [obj, value, code].
-    if ctx.is_authoritative_executor && ei.runtime_helper == majit_ir::RuntimeHelperKind::StoreAttr
+    if ctx.is_authoritative_executor
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::StoreAttr
     {
         if let (Some(&obj_opref), Some(&value_opref), Some(&code_opref), Some(&namei_opref)) =
             (r_args.first(), r_args.get(1), r_args.get(2), i_args.first())
@@ -8358,7 +8389,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         }
     }
     if ctx.is_authoritative_executor
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadAttr
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::LoadAttr
         && next_op_is_load_method_self_for_attr(code, op, ctx, dst)
     {
         if let (Some(&obj_opref), Some(&code_opref), Some(&namei_opref)) =
@@ -8436,7 +8467,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // residual (SAFE).
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadSuperAttr
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::LoadSuperAttr
     {
         if let (
             Some(&global_super_opref),
@@ -8500,7 +8531,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // which costs a real allocation the fold alone would not pay.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::SuperAttrUnwrap
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::SuperAttrUnwrap
     {
         if let (Some(&raw_opref), Some(&which_opref)) = (r_args.first(), i_args.first()) {
             if let Some(majit_ir::Value::Int(which)) = ctx.trace_ctx.box_value(which_opref) {
@@ -8515,7 +8546,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         }
     }
     if ctx.is_authoritative_executor
-        && ei.runtime_helper == majit_ir::RuntimeHelperKind::LoadMethodSelf
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::LoadMethodSelf
     {
         if let (Some(&namei_opref), Some(&obj_opref), Some(&attr_opref), Some(&code_opref)) =
             (i_args.first(), r_args.first(), r_args.get(1), r_args.get(2))
@@ -8570,7 +8601,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // (`getfield_gc_pure`) forwards through the setfield and the box DCEs
     // when it never escapes.  The concrete shadow carries the authentic
     // boxed pointer so downstream specializations still see a concrete int.
-    if ei.runtime_helper == majit_ir::RuntimeHelperKind::BoxInt && dst_bank == 'r' {
+    if foldable_runtime_helper == majit_ir::RuntimeHelperKind::BoxInt && dst_bank == 'r' {
         if let Some(&raw_arg) = i_args.first() {
             if let Some(boxed_ptr) = walker_execute_may_force_boxed(ctx, &allboxes, call_descr) {
                 let intval =
@@ -8593,12 +8624,14 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // paths.  Falls through to the generic record for
     // non-int operands / deferred operators.
     if matches!(
-        ei.runtime_helper,
+        foldable_runtime_helper,
         majit_ir::RuntimeHelperKind::BinaryOp | majit_ir::RuntimeHelperKind::CompareOp
     ) {
         if let Some(&tag_opref) = i_args.first() {
             if let Some(majit_ir::Value::Int(op_tag)) = ctx.trace_ctx.box_value(tag_opref) {
-                let specialized = if ei.runtime_helper == majit_ir::RuntimeHelperKind::BinaryOp {
+                let specialized = if foldable_runtime_helper
+                    == majit_ir::RuntimeHelperKind::BinaryOp
+                {
                     let is_subscr = matches!(
                         pyre_interpreter::runtime_ops::binary_op_from_tag(op_tag),
                         Some(pyre_interpreter::bytecode::BinaryOperator::Subscr)
@@ -8779,14 +8812,14 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 if specialized.is_some() {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
                 }
-                if ei.runtime_helper == majit_ir::RuntimeHelperKind::BinaryOp {
+                if foldable_runtime_helper == majit_ir::RuntimeHelperKind::BinaryOp {
                     if let Some(inlined) = try_walker_inline_user_binop(
                         ctx, op, code, op_tag, &r_args, call_descr, dst, dst_bank,
                     )? {
                         return Ok(inlined);
                     }
                 }
-                if ei.runtime_helper == majit_ir::RuntimeHelperKind::CompareOp {
+                if foldable_runtime_helper == majit_ir::RuntimeHelperKind::CompareOp {
                     if let Some(inlined) = try_walker_inline_user_compareop(
                         ctx, op, code, op_tag, &r_args, call_descr, dst, dst_bank,
                     )? {
@@ -8802,13 +8835,13 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     // path's value0/value1 fold).  A non-foldable shape falls through to the
     // opaque residual below — correct, no decline.
     if matches!(
-        ei.runtime_helper,
+        foldable_runtime_helper,
         majit_ir::RuntimeHelperKind::UnpackSequence | majit_ir::RuntimeHelperKind::UnpackItem
     ) && spec_gate(SpecFold::Unpack, || {
         try_walker_specialize_unpack(
             ctx,
             op.pc,
-            ei.runtime_helper,
+            foldable_runtime_helper,
             &i_args,
             &r_args,
             &allboxes,

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5362,11 +5362,26 @@ fn bh_call_kw_impl(
          getexecutioncontext(); the eval loop must pin the execution context \
          before any residual call"
     );
+    // `pyopcode.py CALL_FUNCTION_KW`'s C-profile diversion — see
+    // [`residual_call_c_profile_frame`].  `call_kw` is `call_kw_in_ctx` with
+    // the frame that settles it, plus the caller `FrameLocalsRoot` the
+    // interpreter's own CALL_KW installs.
+    let profile_frame = residual_call_c_profile_frame(ec, callable);
     let saved_ctx = pyre_interpreter::call::take_last_exec_ctx();
     pyre_interpreter::call::set_last_exec_ctx(ec);
     let result = {
         let _plain_guard = pyre_interpreter::call::force_plain_eval();
-        pyre_interpreter::call::call_kw_in_ctx(ec, callable, null_or_self, positional, kwnames)
+        if profile_frame.is_null() {
+            pyre_interpreter::call::call_kw_in_ctx(ec, callable, null_or_self, positional, kwnames)
+        } else {
+            pyre_interpreter::call::call_kw(
+                unsafe { &mut *profile_frame },
+                callable,
+                null_or_self,
+                positional,
+                kwnames,
+            )
+        }
     };
     pyre_interpreter::call::set_last_exec_ctx(saved_ctx);
     match result {
@@ -5431,6 +5446,48 @@ bh_call_kw_arity!(bh_call_kw_13; a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a1
 fn bh_null_arg_diag() -> bool {
     static ARMED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ARMED.get_or_init(|| std::env::var_os("PYRE_BH_NULL_ARG").is_some())
+}
+
+/// The frame a CALL-family residual owes `c_call` / `c_return` to, or null.
+///
+/// `baseobjspace.py call_valuestack` diverts to `call_args_and_c_profile` when
+/// the executing frame is profiled AND the callable wraps a builtin code;
+/// `pyopcode.py` CALL_FUNCTION_KW and CALL_FUNCTION_EX take the same diversion
+/// with their own frame.  `eval.rs`'s own CALL asks it at the same point, on
+/// the RAW callable before the `_Method` unwrap, which is where `w_func` is
+/// read upstream — `function.py is_builtin_code` does that unwrap itself.
+///
+/// A residual of one of those three helpers IS the bytecode's own dispatch:
+/// the codewriter emits one only for the CALL family.  So the frame the events
+/// belong to is this context's top frame, and the distinction `call.rs
+/// c_profile_frame` draws — the bytecode's dispatch reports, one made from
+/// inside `descr_call` does not — is settled here by construction rather than
+/// by a test.  Without this the residuals reach the builtin through the
+/// frameless `space.call_args`, where the reporting arm does not exist.
+///
+/// `profilefunc` is read before the frame because `gettopframe_raw` is
+/// `force_vref`: asking the frame first would materialize the virtualizable on
+/// every residual call a compiled loop makes.  It cannot change the answer,
+/// since `executioncontext.py call_trace` sets `is_being_profiled` only while
+/// `profilefunc is not None`.  It can leave a frame whose profiler was
+/// uninstalled mid-loop carrying a stale flag one entry longer than the plain
+/// interpreter would, which costs that frame the profiled green key until its
+/// next interpreted call clears it, and reports nothing either way.
+fn residual_call_c_profile_frame(
+    ec: *const pyre_interpreter::PyExecutionContext,
+    callable: PyObjectRef,
+) -> *mut pyre_interpreter::PyFrame {
+    if ec.is_null() || unsafe { (*ec).profilefunc.is_none() } {
+        return std::ptr::null_mut();
+    }
+    if !pyre_interpreter::function::is_builtin_code(callable) {
+        return std::ptr::null_mut();
+    }
+    let frame = unsafe { (*ec).gettopframe_raw() };
+    if frame.is_null() || !unsafe { (*frame).get_is_being_profiled() } {
+        return std::ptr::null_mut();
+    }
+    frame
 }
 
 fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyObjectRef]) -> i64 {
@@ -5522,6 +5579,36 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
                 );
             }
         }
+    }
+    // `call_valuestack`'s C-profile diversion, ahead of every fast path below:
+    // each of them reaches the builtin through an entry that takes no frame
+    // (`builtin_code_call`, `builtin_code_call_positional`), so the arm that
+    // reports would never run.  [`residual_call_c_profile_frame`] carries the
+    // whole rule; `call_callable` is the same door the plain interpreter's
+    // CALL takes for this shape, receiver-prefixed argument vector included.
+    let profile_frame = residual_call_c_profile_frame(ec, _roots.get(root_base));
+    if !profile_frame.is_null() {
+        let call_args = reload_args();
+        let callable = _roots.get(root_base);
+        // The two hooks are application-level Python and can enter compiled
+        // code, which writes the very cells this helper publishes to — the
+        // same nesting the user-function arm below parks across, and for the
+        // same reason: a raise the hook handled internally would otherwise be
+        // read by this call's `GUARD_NO_EXCEPTION` as a pending exception.
+        let parked = park_residual_call_exception();
+        let result = pyre_interpreter::call::call_callable(
+            unsafe { &mut *profile_frame },
+            callable,
+            &call_args,
+        );
+        unpark_residual_call_exception(parked);
+        return match result {
+            Ok(result) => result as i64,
+            Err(mut err) => {
+                publish_residual_call_exception(err.to_exc_object() as i64);
+                0
+            }
+        };
     }
     // A materialized bound Method normally reaches the generic callable
     // dispatcher, which unwraps it, allocates a receiver-prefixed argument
@@ -5715,17 +5802,30 @@ pub extern "C" fn bh_call_function_ex_fn(
          getexecutioncontext(); the eval loop must pin the execution context \
          before any residual call"
     );
+    // `pyopcode.py CALL_FUNCTION_EX`'s C-profile diversion — see
+    // [`residual_call_c_profile_frame`].
+    let profile_frame = residual_call_c_profile_frame(ec, callable as PyObjectRef);
     let saved_ctx = pyre_interpreter::call::take_last_exec_ctx();
     pyre_interpreter::call::set_last_exec_ctx(ec);
     let result = {
         let _plain_guard = pyre_interpreter::call::force_plain_eval();
-        pyre_interpreter::call::call_function_ex_in_ctx(
-            ec,
-            callable as PyObjectRef,
-            self_or_null as PyObjectRef,
-            starargs as PyObjectRef,
-            kwargs_or_null as PyObjectRef,
-        )
+        if profile_frame.is_null() {
+            pyre_interpreter::call::call_function_ex_in_ctx(
+                ec,
+                callable as PyObjectRef,
+                self_or_null as PyObjectRef,
+                starargs as PyObjectRef,
+                kwargs_or_null as PyObjectRef,
+            )
+        } else {
+            pyre_interpreter::call::call_function_ex(
+                unsafe { &mut *profile_frame },
+                callable as PyObjectRef,
+                self_or_null as PyObjectRef,
+                starargs as PyObjectRef,
+                kwargs_or_null as PyObjectRef,
+            )
+        }
     };
     pyre_interpreter::call::set_last_exec_ctx(saved_ctx);
     match result {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -9866,13 +9866,13 @@ thread_local! {
     /// at the abort ceiling, against the `cell_generation` the refusal was
     /// observed at.
     ///
-    /// A loop that a profiler forces to decline — `is_being_profiled` is a
-    /// portal green, and a loop whose body calls anything declines with
-    /// `DispatchError::ProfiledResidualCall` — can never trace, so its cell
-    /// latches and every later back edge re-derives the same refusal. Measured
-    /// with `sys.setprofile` over a warm loop: `abort_ceiling_refused` tracks
-    /// the iteration count one-for-one (194776 at 200k iterations, 794776 at
-    /// 800k), while a loop with no call in its body reads exactly 0. The
+    /// A loop that keeps declining can never trace, so its cell latches and
+    /// every later back edge re-derives the same refusal. Measured against the
+    /// profiled decline this cache was written for — since retired, a profiled
+    /// loop now records its own reporting and compiles — `abort_ceiling_refused`
+    /// tracked the iteration count one-for-one (194776 at 200k iterations,
+    /// 794776 at 800k), while a loop with no call in its body read exactly 0.
+    /// Any remaining latching decline re-derives the same way. The
     /// re-derivation costs a green-key mint, three per-code gate lookups and a
     /// bucket-chain walk per iteration.  Graded as the same tree built twice —
     /// the only valid control, since `PYRE_JIT=0` is read by


### PR DESCRIPTION
Four commits on two topics. The first two came out of the #1559 review of the
`access_directly` front-end work; the last two are §3.7's profiling entry.

## `c_call` / `c_return` from a compiled frame

A profiled trace used to be declined at any CALL-family residual, because a
builtin callee owes `c_call` / `c_return` and the walker had no way to record
them. The decline cost the whole trace: five aborts, then the green key was
banned and the loop ran interpreted for the rest of the run.

The three residual helpers now take `call_valuestack`'s C-profile diversion
themselves, through a shared `residual_call_c_profile_frame`. The frame is the
execution context's top frame, which is sound by construction here — the
codewriter emits one of these helpers only for the CALL family, so a residual
of one *is* the bytecode's own dispatch, and the interior `descr_call` that
runs `__new__` / `__init__` never reaches it. The gate is upstream's
`frame.get_is_being_profiled() and is_builtin_code(w_func)`, asked on the raw
callable before the `_Method` unwrap. `profilefunc` is tested before the frame
because `gettopframe_raw` is `force_vref`.

On the walker side, `walker_foldable_runtime_helper` withholds only the *fold
identity* of `CallFn` / `CallKw` / `CallFunctionEx` while a profile function is
installed, so every fold arm, the builtin-jitcode descent and the
`CALL_ASSEMBLER` door decline and the call stays an opaque residual. Argument
repairs and diagnostics keep reading the true identity.
`DispatchError::ProfiledResidualCall` is removed.

### Measured against a control built at this work's own parent

`PYRE_JIT=0` is not a control here: the metric is `(prof - bare) / events` and
turning the JIT off moves the subtracted bare arm too. Five interleaved
repetitions, quiet machine, per-side minimum:

| shape | control | this branch | |
|---|---|---|---|
| builtin callee (`len`) | 999–1019 ns/event | 788–826 | **1.27x** |
| Python callee | 1305–1328 ns/event | 1136–1183 | **1.17x** |

`MAJIT_STATS=1` on the same script gives the mechanism: the control reads
`loops_compiled=3 loops_aborted=10`, all ten on the reason ladder's fourth rung
(`abrt_unclassified_default=10`) with two banned green keys
(`abort_ceiling_banned=2`); this branch reads `loops_compiled=5
loops_aborted=0` with every abort counter at zero, and `caro_backedge` falls
12 → 4 because a banned key keeps re-entering a merge point it can never
compile.

### Fixture defect fixed in passing

`profile_hook_c_call_is_bytecode_level_only` ran `REPEAT = 5` against a loop
threshold of 1039, so its measured pass ran interpreted while its header
claimed compiled coverage. At 2500 it compiles 14 loops — seven arms, two green
keys each — with `loops_aborted=0`.

### What the doc now claims

§3.7's successor claim is replaced by the measurement, and the green is ruled
out as the remaining cost: `is_being_profiled` is already a portal green that
`make_green_key` mints from, and every read of the flag in `pyre-jit` /
`pyre-jit-trace` is at trace time, at green-key mint, or at portal entry — no
per-call branch is left to fold, because pyre residualises the call upstream
records through. A profiled call-bearing loop is still ~1.1 µs/event against
pypy's 0.4 ns, so a third mechanism is in play; the doc names the first place to
look (the inline decline under `ec_hook_installed`) explicitly as a hypothesis,
not a measurement.

## Front end

`class_roots` read a transparent struct ctor's `result_ty` before the ctor's
own name, and the two spell the class differently, so the arm carrying the bare
ctor name never ran. And the killed set was closed over into a local, so the
fixpoint's second subtraction named only the hint's own result. Both are pinned
by new tests, each red before its fix. Neither changes the production
translation — a census over both pipeline invocations (489 and 4147 lowered
functions) found zero `OpKind::Hint` ops and neither frame constructor in the
set — and the doc now records that census instead of the reason it had before,
which the census does not support.

`virtualizable_decl`'s thread-local was written only from outside the pipeline,
by the build script, so the set the front end read was whatever the thread was
last told rather than a property of the translation in hand. It is seeded from
the `AnalyzeConfig` the pipeline already holds, immediately before the frontend
build that reads it. The front end reads `roots=1 ["PyFrame"]`, the same set
the deleted call registered.

## Gates

`check.py` dynasm 516/516, cranelift 516/516, wasm 509/509 — run on this code
at the pre-rebase base. The rebase that followed changed no compiled file
(`git diff <pre-rebase-tip> HEAD -- pyre majit` is empty), but the base itself
moved, so CI here is the authoritative run.

— *authored by Claude*
