### PR TITLE
jit, gc, interp: the portal's two doors named, the frame vref measured and withheld, three interior roots of movable objects, and the anchors the shared opcodes lacked

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -5644,6 +5644,24 @@ impl<'a> AssemblerARM64<'a> {
             let helper_addr = crate::call_assembler_helper_addr() as i64;
             let green_key = self.header_pc as i64;
 
+            // `MIFrame.get_list_of_active_boxes(in_a_call)` clears the
+            // not-yet-defined result register before a suspended caller is
+            // snapshotted.  GUARD_NOT_FORCED's async path observes this
+            // caller while CALL_ASSEMBLER is still running, before x0/d0
+            // contains the result.  Unlike the ordinary guard-failure stub,
+            // `LLGraphCPU.force`/`AbstractLLCPU.force` only switches
+            // `jf_descr`; it cannot save the caller's hardware registers.
+            // Seed the result's jitframe register slot with the same null
+            // placeholder now.  A normal return puts the real value in the
+            // register, and any later guard stub saves that value as usual.
+            if result_type != Type::Void {
+                let result_loc = result_loc.expect("non-void CALL_ASSEMBLER needs a result loc");
+                let slot = deadframe_slot_for_loc(result_loc)
+                    .expect("CALL_ASSEMBLER result must have a deadframe register slot");
+                let offset = Self::slot_offset(slot as usize) as u32;
+                dynasm!(self.mc ; .arch aarch64 ; str xzr, [x29, offset]);
+            }
+
             if !is_resolved {
                 let force_addr = crate::call_assembler_force_fn_addr() as i64;
                 dynasm!(self.mc ; .arch aarch64

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -7043,6 +7043,24 @@ impl<'a> Assembler386<'a> {
         let helper_addr = crate::call_assembler_helper_addr() as i64;
         let green_key = self.header_pc as i64;
 
+        // `MIFrame.get_list_of_active_boxes(in_a_call)` clears the
+        // not-yet-defined result register before a suspended caller is
+        // snapshotted.  GUARD_NOT_FORCED's async path observes this caller
+        // while CALL_ASSEMBLER is still running, before rax/xmm0 contains the
+        // result.  Unlike the ordinary guard-failure stub,
+        // `LLGraphCPU.force`/`AbstractLLCPU.force` only switches `jf_descr`;
+        // it cannot save the caller's hardware registers.  Seed the result's
+        // jitframe register slot with the same null placeholder now.  A normal
+        // return puts the real value in the register, and any later guard stub
+        // saves that value as usual.
+        if result_type != Type::Void {
+            let result_loc = result_loc.expect("non-void CALL_ASSEMBLER needs a result loc");
+            let slot = deadframe_slot_for_loc(result_loc)
+                .expect("CALL_ASSEMBLER result must have a deadframe register slot");
+            let offset = Self::slot_offset(slot as usize);
+            dynasm!(self.mc ; .arch x64 ; mov QWORD [rbp + offset], 0);
+        }
+
         if !is_resolved {
             // Unresolved target: emit force-fn dispatch through
             // r12-saved rbp (kept as-is — this path is rare and not

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1329,13 +1329,10 @@ pub struct JitCellToken {
     /// (`LoopTargetDescr` Arc; `TargetToken IS-A AbstractDescr` in
     /// PyPy, so a `DescrRef` is the matching identity).  Each
     /// successful loop / retrace populates this through
-    /// `record_target_token`.  Its one reader with a caller is
-    /// [`Self::first_target_token`], the descr a bridge closes onto;
-    /// [`Self::has_target_tokens`] reads it too but is called from
-    /// nowhere.  Neither `has_compiled_loop` (token presence) nor
-    /// pyre's `has_compiled_targets` (the `compiled_loops` side table)
-    /// reads this list, so it is not pyre's `has_compiled_targets`
-    /// signal despite mirroring what upstream's reads.  The metainterp-side
+    /// `record_target_token`.  [`Self::first_target_token`] supplies the descr
+    /// a bridge closes onto, while [`Self::has_target_tokens`] is the direct
+    /// `has_compiled_targets` predicate.  Both therefore read the same current
+    /// token, as upstream does.  The metainterp-side
     /// `TargetToken` value (with `virtual_state` / `short_preamble`)
     /// stays on the `CompiledEntry::front_target_tokens` list per
     /// the F.6 retirement plan — the per-target descr identity is the

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -3189,6 +3189,15 @@ pub fn set_active_root_hooks(add: Option<AddRootFn>, remove: Option<RemoveRootFn
 /// The caller must ensure the slot remains valid until
 /// [`gc_remove_root`] is called with the same pointer.
 pub unsafe fn gc_add_root(slot: *mut GcRef) -> bool {
+    // A shadow-stack/root-map entry names a stationary slot whose contents
+    // the collector rewrites after moving its referent.  An address inside
+    // the nursery moves with its owner and becomes from-space after the first
+    // minor collection; registering it would make the root map itself stale.
+    // RPython's shadow-stack transform only assigns roots to fixed frame
+    // slots, while fields of GC objects are reached by tracing their owner.
+    if gc_is_nursery_object(slot as usize) {
+        return false;
+    }
     match ACTIVE_ADD_ROOT.get() {
         Some(f) => {
             unsafe { f(slot) };

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -1227,7 +1227,27 @@ pub fn resume_ref_slice_registered(ptr: *const i64) -> bool {
 /// blackhole frame's `registers_r` are stable after allocation
 /// (`prepare_virtuals` / `setposition` size them once; later fills only
 /// index), so the captured pointer stays valid for the whole window.
+#[track_caller]
 pub unsafe fn push_resume_ref_roots(slice: &mut [i64]) {
+    if !slice.is_empty() && crate::gc_is_nursery_object(slice.as_ptr() as usize) {
+        panic!(
+            "GC BUG: resume root slice points inside the movable nursery: ptr={:#x} len={} caller={}",
+            slice.as_ptr() as usize,
+            slice.len(),
+            std::panic::Location::caller(),
+        );
+    }
+    if std::env::var_os("MAJIT_GC_NURSERY_POISON").is_some() {
+        const NURSERY_POISON_WORD: i64 = ((usize::MAX / 0xff) * 0xaa) as i64;
+        if let Some(index) = slice.iter().position(|&value| value == NURSERY_POISON_WORD) {
+            panic!(
+                "GC BUG: resume root slice contains nursery poison before registration: index={} len={} caller={}",
+                index,
+                slice.len(),
+                std::panic::Location::caller(),
+            );
+        }
+    }
     RESUME_REF_ROOTS_STACK.with(|ss| {
         ss.borrow_mut().push((slice.as_mut_ptr(), slice.len()));
     });

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5812,14 +5812,14 @@ impl<S: JitState> JitDriver<S> {
         // `warmstate.py maybe_compile_and_run`: a cell whose token was
         // `attached by compile_tmp_callback()` is NOT entered — upstream falls
         // straight to `jitcounter.tick(hash, increment_threshold)` and, on
-        // overflow, `bound_reached`. The pyre reading of "attached by
-        // compile_tmp_callback" is the absence of a `compiled_loops` meta
-        // (`has_runnable_compiled_loop`, which documents why): the temporary
-        // token has a body, so `has_compiled_loop` says yes, but MetaInterp
-        // never filed frontend meta for it. Binding the meta here rather than
-        // testing a predicate and unwrapping afterwards keeps the two in step —
-        // the fall-through below IS the counter processing upstream continues
-        // with. `has_compiled_loop` stays as the first conjunct: it is the
+        // overflow, `bound_reached`. `runnable_procedure_token` reads the
+        // cell-owned `JC_TEMPORARY` flag explicitly: a callback token has a
+        // body, and pyre may retain frontend metadata for the loop it
+        // displaced, so neither token nor metadata presence identifies it.
+        // Binding the token here rather than testing a predicate and
+        // unwrapping afterwards keeps the decision and execution in step — the
+        // fall-through below IS the counter processing upstream continues
+        // with. Token presence stays one conjunct: it is the
         // `cell.get_procedure_token() is not None` half (code present and not
         // invalidated), which the meta lookup alone does not imply, since
         // `invalidate_loop` deliberately leaves the meta in place.
@@ -5855,7 +5855,7 @@ impl<S: JitState> JitDriver<S> {
         #[cfg(feature = "__back-edge-stage-probe")]
         let carried_token = carried_procedure_token.is_some();
         if let Some(procedure_token) =
-            carried_procedure_token.or_else(|| self.meta.entry_procedure_token(green_key))
+            carried_procedure_token.or_else(|| self.runnable_procedure_token(green_key))
             && let Some(compiled_meta) = self.meta.get_compiled_meta(green_key).cloned()
         {
             // warmstate.py `WarmEnterState.make_entry_point` /
@@ -8061,21 +8061,30 @@ impl<S: JitState> JitDriver<S> {
     /// predicate is keyed by it.
     ///
     /// The `compiled_loops` half is asked FIRST, as the gate the token read
-    /// sits behind. Both conjuncts are pure reads of the same key, so the order
-    /// does not change the answer, but their costs are not alike: the frontend
-    /// half is one hash probe, and the token read is a `Weak::upgrade` and the
-    /// `Arc` drop that answers it, one atomic each. A key with no compiled
-    /// entry — which is every key a door declines on — now stops at the probe.
+    /// sits behind. The resolved cell's `JC_TEMPORARY` flag is then the final
+    /// filter, matching `WarmEnterState.maybe_compile_and_run`; retained
+    /// frontend metadata must not make a callback executable as the displaced
+    /// loop. These are pure reads of the same resolved key. A key with no
+    /// compiled entry — which is every key a door declines on — still stops at
+    /// the cheap map probe before the token's `Weak::upgrade` / `Arc` drop.
     #[inline]
     pub fn resolved_runnable_procedure_token(
         &self,
         green_key_hash: u64,
         make_green_key: impl FnOnce() -> GreenKey,
     ) -> (u64, Option<std::sync::Arc<majit_backend::JitCellToken>>) {
-        self.meta
-            .resolved_entry_procedure_token(green_key_hash, make_green_key, |cell_key| {
-                self.meta.get_compiled_meta(cell_key).is_some()
-            })
+        let (cell_key, token) =
+            self.meta
+                .resolved_entry_procedure_token(green_key_hash, make_green_key, |cell_key| {
+                    self.meta.get_compiled_meta(cell_key).is_some()
+                });
+        let token = token.filter(|_| {
+            !self
+                .meta
+                .warm_state_ref()
+                .procedure_token_is_temporary(cell_key)
+        });
+        (cell_key, token)
     }
 
     /// The token [`Self::has_runnable_compiled_loop`] says yes about, handed
@@ -8093,9 +8102,11 @@ impl<S: JitState> JitDriver<S> {
     /// token being present, not merely as something equivalent to it — so
     /// binding the token subsumes the first conjunct exactly. It does NOT
     /// subsume the second: `get_compiled_meta` reads the frontend
-    /// `compiled_loops` table, which a `compile_tmp_callback` token is never
-    /// filed in, so that test stays here explicitly. Everything the comment
-    /// above says about why the second conjunct exists applies unchanged.
+    /// `compiled_loops` table. Nor does either read subsume the cell-owned
+    /// `JC_TEMPORARY` flag: `compile_tmp_callback` can displace a real loop
+    /// while that loop's frontend metadata remains. Both tests therefore stay
+    /// here explicitly, matching the flag-first branch in upstream
+    /// `WarmEnterState.maybe_compile_and_run`.
     ///
     /// `green_key` must already name one cell — see [`Self::resolve_cell_key`],
     /// whose result is what a door should ask this with. A raw bucket hash
@@ -8105,9 +8116,13 @@ impl<S: JitState> JitDriver<S> {
         &self,
         green_key: u64,
     ) -> Option<std::sync::Arc<majit_backend::JitCellToken>> {
-        self.meta
-            .entry_procedure_token(green_key)
-            .filter(|_| self.meta.get_compiled_meta(green_key).is_some())
+        self.meta.entry_procedure_token(green_key).filter(|_| {
+            !self
+                .meta
+                .warm_state_ref()
+                .procedure_token_is_temporary(green_key)
+                && self.meta.get_compiled_meta(green_key).is_some()
+        })
     }
 
     /// The back-edge door's whole answer from the warm-state policy that owns

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1188,13 +1188,6 @@ pub struct JitDriverStaticData {
     /// `do_recursive_call`'s residual CALL_ASSEMBLER op
     /// (pyjitpl.py:1428-1429).
     pub portal_runner_adr: i64,
-    /// warmspot.py `jd._portal_ptr` — the portal body below
-    /// `ll_portal_runner`'s activation entry.
-    ///
-    /// Concrete execution while tracing a CALL_ASSEMBLER that resumes an
-    /// already-started frame must call this address, while a temporary
-    /// callback compiled for runtime keeps calling `portal_runner_adr`.
-    pub portal_ptr_adr: i64,
     /// jitdriver.py:16 + warmspot.py:520-545 `jd.virtualizable_info`.
     ///
     /// Per-driver `VirtualizableInfo` populated during warmspot setup
@@ -1380,7 +1373,6 @@ impl JitDriverStaticData {
             is_recursive: false,
             mainjitcode: None,
             portal_runner_adr: 0,
-            portal_ptr_adr: 0,
             virtualizable_info: None,
             greenfield_info: None,
             index_of_virtualizable: -1,

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1188,6 +1188,13 @@ pub struct JitDriverStaticData {
     /// `do_recursive_call`'s residual CALL_ASSEMBLER op
     /// (pyjitpl.py:1428-1429).
     pub portal_runner_adr: i64,
+    /// warmspot.py `jd._portal_ptr` — the portal body below
+    /// `ll_portal_runner`'s activation entry.
+    ///
+    /// Concrete execution while tracing a CALL_ASSEMBLER that resumes an
+    /// already-started frame must call this address, while a temporary
+    /// callback compiled for runtime keeps calling `portal_runner_adr`.
+    pub portal_ptr_adr: i64,
     /// jitdriver.py:16 + warmspot.py:520-545 `jd.virtualizable_info`.
     ///
     /// Per-driver `VirtualizableInfo` populated during warmspot setup
@@ -1373,6 +1380,7 @@ impl JitDriverStaticData {
             is_recursive: false,
             mainjitcode: None,
             portal_runner_adr: 0,
+            portal_ptr_adr: 0,
             virtualizable_info: None,
             greenfield_info: None,
             index_of_virtualizable: -1,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -15334,7 +15334,7 @@ impl<M: Clone> MetaInterp<M> {
         &mut self,
         jitcode: std::sync::Arc<crate::jitcode::JitCode>,
         argboxes: &[(crate::jitcode::JitArgKind, OpRef, i64)],
-        greenkey: Option<u64>,
+        greenkey: Option<PortalGreenKey>,
     ) -> Result<(), ChangeFrame> {
         // pyjitpl.py: f = self.newframe(jitcode, greenkey)
         let _ = self.newframe(jitcode, greenkey);
@@ -16272,7 +16272,7 @@ impl<M: Clone> MetaInterp<M> {
     pub fn newframe(
         &mut self,
         jitcode: std::sync::Arc<crate::jitcode::JitCode>,
-        greenkey: Option<u64>,
+        greenkey: Option<PortalGreenKey>,
     ) -> usize {
         // pyjitpl.py:2433: if jitcode.jitdriver_sd: portal_call_depth += 1
         if let Some(jd_no) = jitcode.jitdriver_sd() {
@@ -16280,8 +16280,8 @@ impl<M: Clone> MetaInterp<M> {
             // pyjitpl.py:2435: self.call_ids.append(self.current_call_id)
             self.call_ids.push(self.current_call_id);
             // pyjitpl.py: enter_portal_frame(jitdriver_sd.index, unique_id)
-            if let Some(unique_id) = greenkey {
-                self.enter_portal_frame(jd_no, unique_id);
+            if let Some((unique_id, _)) = greenkey.as_ref() {
+                self.enter_portal_frame(jd_no, *unique_id);
             }
             // pyjitpl.py:2442: self.current_call_id += 1
             self.current_call_id += 1;
@@ -16289,16 +16289,12 @@ impl<M: Clone> MetaInterp<M> {
         // pyjitpl.py:2443-2445: `if greenkey is not None and
         // self.is_main_jitcode(jitcode): self.portal_trace_positions.append(
         //     (jitcode.jitdriver_sd, greenkey, self.history.get_trace_position()))`.
-        if let (Some(gk), Some(jd_no)) = (greenkey, jitcode.jitdriver_sd())
+        if let (Some(gk), Some(jd_no)) = (greenkey.as_ref(), jitcode.jitdriver_sd())
             && self.is_main_jitcode(&jitcode)
             && let (Some(positions), Some(ctx)) =
                 (self.portal_trace_positions.as_mut(), self.tracing.as_ref())
         {
-            // This entry point is reached with a bare `u64` greenkey — it
-            // predates the raw `(code_ptr, pc)` key and operates on
-            // sub-jitcodes — so the typed half is unavailable here. A caller
-            // that holds the greens should use `push_portal_trace_position`.
-            positions.push((jd_no, Some((gk, None)), ctx.get_trace_position()));
+            positions.push((jd_no, Some(gk.clone()), ctx.get_trace_position()));
         }
         // Bump the existing TraceCtx inline-depth counter so trace
         // recorder bookkeeping (already wired through pyre's tracer)
@@ -16308,7 +16304,7 @@ impl<M: Clone> MetaInterp<M> {
         // project the u64 greenkey into the raw slot verbatim —
         // pyjitpl.py:1396-1401 element-wise parity still holds because
         // this caller doesn't feed the recursion-depth walk.
-        let raw = (greenkey.unwrap_or_default() as usize, 0);
+        let raw = (greenkey.as_ref().map_or(0, |(key, _)| *key) as usize, 0);
         let _ = self.enter_inline_frame(raw);
         // pyjitpl.py: reuse / allocate MIFrame, push onto framestack.
         let frame = crate::pyjitpl::MIFrame::setup(jitcode, 0, greenkey, self.tracing.as_mut());
@@ -16374,7 +16370,8 @@ impl<M: Clone> MetaInterp<M> {
             // pyjitpl.py:2470-2472: `if frame.greenkey is not None and
             // self.is_main_jitcode(jitcode): self.portal_trace_positions.append(
             //     (jitcode.jitdriver_sd, None, self.history.get_trace_position()))`.
-            if let (Some(_gk), Some(jd_no)) = (frame.greenkey, frame.jitcode.jitdriver_sd())
+            if let (Some(_gk), Some(jd_no)) =
+                (frame.greenkey.as_ref(), frame.jitcode.jitdriver_sd())
                 && self.is_main_jitcode(&frame.jitcode)
                 && let (Some(positions), Some(ctx)) =
                     (self.portal_trace_positions.as_mut(), self.tracing.as_ref())
@@ -20431,6 +20428,7 @@ mod metainterp_static_data_tests {
             is_recursive: false,
             mainjitcode: None,
             portal_runner_adr: 0,
+            portal_ptr_adr: 0,
             virtualizable_info: None,
             greenfield_info: None,
             index_of_virtualizable: -1,
@@ -22653,7 +22651,7 @@ mod metainterp_static_data_tests {
         jc.replace_jitdriver_sd(Some(5));
         let jc = std::sync::Arc::new(jc);
 
-        meta.newframe(jc, Some(0xfeed));
+        meta.newframe(jc, Some((0xfeed, None)));
         meta.popframe(true);
 
         let ctx = meta.trace_ctx().expect("tracing must be active");
@@ -22714,7 +22712,10 @@ mod metainterp_static_data_tests {
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
-        meta.perform_call(jc, &[], Some(0xcafe)).unwrap_err();
+        let typed = majit_ir::GreenKey::new(vec![0xcafe, 0xbeef]);
+        let hash = typed.get_uhash();
+        meta.perform_call(jc, &[], Some((hash, Some(typed.clone()))))
+            .unwrap_err();
         assert_eq!(
             meta.portal_trace_positions
                 .as_ref()
@@ -22724,7 +22725,7 @@ mod metainterp_static_data_tests {
         );
         let entry = &meta.portal_trace_positions.as_ref().unwrap()[0];
         assert_eq!(entry.0, idx);
-        assert_eq!(entry.1, Some((0xcafe, None)));
+        assert_eq!(entry.1, Some((hash, Some(typed))));
 
         meta.popframe(true);
         let positions = meta
@@ -22765,7 +22766,8 @@ mod metainterp_static_data_tests {
         let action = meta.force_start_tracing(0, (0, 0), None, &[]);
         assert!(matches!(action, BackEdgeAction::StartedTracing));
 
-        meta.perform_call(jc, &[], Some(0xbabe)).unwrap_err();
+        meta.perform_call(jc, &[], Some((0xbabe, None)))
+            .unwrap_err();
         assert!(
             meta.portal_trace_positions
                 .as_ref()
@@ -22860,11 +22862,12 @@ mod metainterp_static_data_tests {
         let (mut meta, jc) = meta_with_recursive_portal();
         start_tracing(&mut meta);
 
-        meta.perform_call(jc.clone(), &[], Some(0xa11)).unwrap_err();
+        meta.perform_call(jc.clone(), &[], Some((0xa11, None)))
+            .unwrap_err();
         record_ops(&mut meta, 5);
         meta.popframe(true);
 
-        meta.perform_call(jc, &[], Some(0xb22)).unwrap_err();
+        meta.perform_call(jc, &[], Some((0xb22, None))).unwrap_err();
         record_ops(&mut meta, 1);
         meta.popframe(true);
 
@@ -22883,11 +22886,12 @@ mod metainterp_static_data_tests {
         let (mut meta, jc) = meta_with_recursive_portal();
         start_tracing(&mut meta);
 
-        meta.perform_call(jc.clone(), &[], Some(0xa11)).unwrap_err();
+        meta.perform_call(jc.clone(), &[], Some((0xa11, None)))
+            .unwrap_err();
         record_ops(&mut meta, 1);
         meta.popframe(true);
 
-        meta.perform_call(jc, &[], Some(0xb22)).unwrap_err();
+        meta.perform_call(jc, &[], Some((0xb22, None))).unwrap_err();
         record_ops(&mut meta, 5);
 
         assert_eq!(meta.find_biggest_function(), Some((0, (0xb22, None))));
@@ -22902,11 +22906,12 @@ mod metainterp_static_data_tests {
         let (mut meta, jc) = meta_with_recursive_portal();
         start_tracing(&mut meta);
 
-        meta.perform_call(jc.clone(), &[], Some(0xa11)).unwrap_err();
+        meta.perform_call(jc.clone(), &[], Some((0xa11, None)))
+            .unwrap_err();
         record_ops(&mut meta, 5);
         meta.popframe(true);
 
-        meta.perform_call(jc, &[], Some(0xb22)).unwrap_err();
+        meta.perform_call(jc, &[], Some((0xb22, None))).unwrap_err();
         record_ops(&mut meta, 1);
         // Left open, and the recorder retired under it.
         meta.tracing = None;
@@ -22951,7 +22956,8 @@ mod metainterp_static_data_tests {
         let (mut meta, jc) = meta_with_recursive_portal();
         start_tracing(&mut meta);
         // One inlined callee, sized by the ops recorded between its entries.
-        meta.perform_call(jc, &[], Some(CALLEE)).unwrap_err();
+        meta.perform_call(jc, &[], Some((CALLEE, None)))
+            .unwrap_err();
         record_ops(&mut meta, 5);
         meta.popframe(true);
         meta.tracing
@@ -23011,7 +23017,7 @@ mod metainterp_static_data_tests {
             Some(0),
             "the next trace starts from an empty log, not from None"
         );
-        meta.perform_call(jc, &[], Some(0xa11)).unwrap_err();
+        meta.perform_call(jc, &[], Some((0xa11, None))).unwrap_err();
         assert_eq!(
             meta.portal_trace_positions.as_ref().expect("Some").len(),
             1,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -8175,16 +8175,17 @@ impl<M: Clone> MetaInterp<M> {
     /// compile.py: has_compiled_targets — check if a green key has
     /// compiled target tokens that a bridge can jump to.
     pub fn has_compiled_targets(&self, green_key: u64) -> bool {
-        // Consistent with has_compiled_loop: direct key only, no alias, and
-        // the warmstate token must still be live. warmstate.py:483-500 removes
-        // invalidated/dead cells before retracing; pyre's compiled_loops
-        // side-table must not make such a dead token look jumpable.
-        if !self.has_compiled_loop(green_key) {
-            return false;
-        }
-        self.compiled_loops
-            .get(&green_key)
-            .is_some_and(|c| !c.front_target_tokens.is_empty())
+        // `pyjitpl.py has_compiled_targets(token)` is exactly
+        // `bool(token) and bool(token.target_tokens)`: both halves belong to
+        // the SAME token returned by `warmstate.py get_procedure_token`.
+        // In particular, `compile_tmp_callback` may replace a cell's old loop
+        // token with a live callback token whose target list is empty while
+        // pyre's optimizer-only `compiled_loops` side table still retains the
+        // old loop state.  Reading that side table here makes the gate admit a
+        // target that `compile_trace` cannot obtain from the current token,
+        // so a function-entry trace repeatedly aborts as `ABORT_BAD_LOOP`.
+        self.entry_procedure_token(green_key)
+            .is_some_and(|token| token.has_target_tokens())
     }
 
     /// pyjitpl.py: compile_trace — try to compile the current
@@ -26023,6 +26024,59 @@ mod tests {
         assert!(
             !std::sync::Arc::ptr_eq(&fresh, &stale),
             "and it is a new token, not the invalidated one"
+        );
+    }
+
+    /// `compile_tmp_callback` replaces the cell's procedure token, but it
+    /// does not erase pyre's optimizer-side metadata for the displaced loop.
+    /// `pyjitpl.py has_compiled_targets(token)` asks only about the current
+    /// cell token, so the stale side table must not make the callback token
+    /// look like a jump target.
+    #[test]
+    fn a_tmp_callback_token_does_not_inherit_displaced_loop_targets() {
+        let mut meta = MetaInterp::<()>::new(10);
+        meta.finish_setup_descrs_for_jitdrivers();
+        let green_key = 4242;
+
+        let old_token = std::sync::Arc::new(JitCellToken::new(1));
+        old_token.set_compiled(Box::new(()));
+        meta.compiled_loops.insert(
+            green_key,
+            CompiledEntry {
+                token: std::sync::Arc::downgrade(&old_token),
+                meta: std::sync::Arc::new(()),
+                front_target_tokens: vec![crate::history::TargetToken::new_loop(1)],
+                front_entry_index: Some(0),
+                front_target_source_positions: None,
+                root_trace_id: 1,
+                traces: indexmap::IndexMap::new(),
+                previous_tokens: Vec::new(),
+                loop_header_pc: Some(0),
+                next_global_opref: 0,
+            },
+        );
+
+        let callback_token = std::sync::Arc::new(JitCellToken::new(2));
+        callback_token.set_compiled(Box::new(()));
+        meta.warm_state_mut()
+            .memory_manager
+            .keep_loop_alive(&callback_token);
+        meta.warm_state_mut()
+            .attach_tmp_callback_to_interp(green_key, callback_token);
+
+        assert!(meta.has_compiled_loop(green_key));
+        assert!(
+            matches!(
+                meta.function_entry_step(green_key, green_key, (0, 0)),
+                crate::warmstate::FunctionEntryStep::NotHot
+            ),
+            "warmstate.py checks JC_TEMPORARY before the procedure token, so retained loop \
+             metadata must not make the callback runnable at function entry"
+        );
+        assert!(
+            !meta.has_compiled_targets(green_key),
+            "the current callback token has no target_tokens; the displaced \
+             loop's side-table targets belong to a different object"
         );
     }
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -20428,7 +20428,6 @@ mod metainterp_static_data_tests {
             is_recursive: false,
             mainjitcode: None,
             portal_runner_adr: 0,
-            portal_ptr_adr: 0,
             virtualizable_info: None,
             greenfield_info: None,
             index_of_virtualizable: -1,

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -111,7 +111,7 @@ pub struct MIFrame {
     pub return_f: Option<usize>,
     /// pyjitpl.py `MIFrame.greenkey` — set when this frame is a
     /// recursive portal call (pyjitpl.py:80).
-    pub greenkey: Option<u64>,
+    pub greenkey: Option<super::PortalGreenKey>,
     /// pyjitpl.py:91 `self._result_argcode = 'v'`.
     ///
     /// Single-byte argcode of the *previous* opimpl's result type
@@ -208,7 +208,7 @@ impl MIFrame {
     pub fn setup(
         jitcode: Arc<JitCode>,
         pc: usize,
-        greenkey: Option<u64>,
+        greenkey: Option<super::PortalGreenKey>,
         ctx: Option<&mut crate::trace_ctx::TraceCtx>,
     ) -> Self {
         let mut frame = Self::new(jitcode, pc);
@@ -1759,10 +1759,10 @@ mod tests {
         let _ = recorder.record_input_arg(Type::Int);
         let mut ctx = crate::trace_ctx::TraceCtx::new(recorder, 0, sd);
 
-        let frame = MIFrame::setup(jitcode, 7, Some(0xfeed), Some(&mut ctx));
+        let frame = MIFrame::setup(jitcode, 7, Some((0xfeed, None)), Some(&mut ctx));
 
         assert_eq!(frame.pc, 7);
-        assert_eq!(frame.greenkey, Some(0xfeed));
+        assert_eq!(frame.greenkey, Some((0xfeed, None)));
         assert_eq!(frame._result_argcode, b'v');
         assert_eq!(frame.parent_snapshot, -1);
         assert_eq!(frame.unroll_iterations, 1);

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -7331,23 +7331,35 @@ impl<'a> ResumeDataDirectReader<'a> {
         if self.virtualizable_root_base_depth.is_none() {
             self.virtualizable_root_base_depth =
                 Some(majit_gc::shadow_stack::resume_ref_roots_depth());
+            // RPython's ResumeDataDirectReader holds the virtualizable as a
+            // GC-traced reference while consume_vable_info restores its
+            // fields.  Root that owner before exposing any of its fields or
+            // running write_from_resume_data_partial: both operations may
+            // allocate, and a nursery PyFrame can move during either one.
+            // Registering a field inside the frame is not a substitute — its
+            // address moves with the owner.
+            unsafe {
+                majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_mut(
+                    &mut self.virtualizable_ptr,
+                ));
+            }
         }
-        vinfo.push_resume_ref_roots(virtualizable);
+        vinfo.push_resume_ref_roots(self.virtualizable_ptr);
         // resume.py:1406: assert vinfo.get_total_size(virtualizable) == vable_size - 1
-        let expected = vinfo.get_total_size(virtualizable) as i32;
+        let expected = vinfo.get_total_size(self.virtualizable_ptr) as i32;
         assert!(
             expected == vable_size - 1,
             "consume_vable_info: vinfo.get_total_size(0x{:x}) = {} != vable_size - 1 = {}",
-            virtualizable,
+            self.virtualizable_ptr,
             expected,
             vable_size - 1
         );
         // resume.py:1407
-        vinfo.reset_token_gcref(virtualizable);
+        vinfo.reset_token_gcref(self.virtualizable_ptr);
         // resume.py:1408 write_from_resume_data_partial reads the field
         // payload from the remaining `vable_size - 1` items, leaving the reader
         // positioned just past the vable section for the vref/frame chain.
-        vinfo.write_from_resume_data_partial(virtualizable, self);
+        vinfo.write_from_resume_data_partial(self.virtualizable_ptr, self);
     }
 
     /// resume.py consume_vref_and_vable
@@ -7933,21 +7945,9 @@ pub fn blackhole_from_resumedata<'a>(
     resumereader.consume_vref_and_vable(vrefinfo, vinfo, ginfo, virtualizable_identity_override);
     drop(_cc_guard);
 
-    // resume.py: virtualizable pointer read by consume_vable_info.
-    // The virtualizable is the frame being resumed; RPython keeps it live in
-    // the GC-traced resume reader across the frame-chain build.  pyre has no
-    // GC transform, so root the reader's `virtualizable_ptr` slot for the
-    // chain-build window below: a multi-frame resume runs `consume_one_section`
-    // per caller, which materializes virtuals (allocator) and can trigger a
-    // minor collection.  That relocates the young virtualizable frame; an
-    // unrooted bare copy would then point at from-space (a freed frame whose
-    // `locals_cells_stack_w` reads null).  Registering the slot makes the root
-    // walker forward it in place, mirroring `ResumeDeadframeRoots`.
-    unsafe {
-        majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_mut(
-            &mut resumereader.virtualizable_ptr,
-        ));
-    }
+    // consume_vable_info rooted `virtualizable_ptr` before restoring any
+    // fields.  The reader owns that root through this chain build and drops it
+    // with its `virtualizable_root_base_depth` scope.
 
     // resume.py:1332-1343
     // Build chain bottom-up: first frame acquired is the outermost.

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1482,6 +1482,26 @@ impl TraceCtx {
         (vref, vref_ptr)
     }
 
+    /// Record `jit.virtual_ref(obj)` when the full-body walker has the
+    /// object's box but no recording-time heap object.
+    ///
+    /// RPython's `MetaInterp.opimpl_virtual_ref` always has a concrete box
+    /// because it is tracing the interpreter.  Pyre's self-recursive
+    /// CALL_ASSEMBLER fold constructs the callee exclusively in trace IR, so
+    /// there is no honest pointer with which to call
+    /// `virtual_ref_during_tracing`.  The runtime operation and the
+    /// `[virtualbox, vrefbox]` stack entry are nevertheless both owed; a zero
+    /// concrete stamp means only that the tracing-time before/after-residual
+    /// probes must skip this pair.  The force guard carries the runtime force
+    /// protocol, and the matching finish below closes the symbolic scope.
+    pub fn opimpl_virtual_ref_symbolic(&mut self, virtual_obj: OpRef) -> OpRef {
+        let cindex = self.const_int((self.virtualref_boxes.len() / 2) as i64);
+        let vref = self.virtual_ref(virtual_obj, cindex);
+        self.virtualref_boxes.push((virtual_obj, 0));
+        self.virtualref_boxes.push((vref, 0));
+        vref
+    }
+
     /// `pyjitpl.py opimpl_virtual_ref_finish(box)` —
     /// `ExecutionContext.leave`'s `jit.virtual_ref_finish`
     /// (`executioncontext.py:107`).  The vrefbox is reconstituted by popping,
@@ -1537,12 +1557,18 @@ impl TraceCtx {
         // pyjitpl.py:1826-1832 `if vrefinfo.is_virtual_ref(vref): record
         // VIRTUAL_REF_FINISH`.  False once `stop_tracking_virtualref` has
         // replaced the box with ConstPtr(NULL) — the finish already ran.
-        let is_vref = vref_ptr != 0
-            && unsafe {
+        let is_vref = if vref_ptr == 0 {
+            // A non-constant box with no concrete stamp is the symbolic form
+            // opened by `opimpl_virtual_ref_symbolic`.  A stopped pair has
+            // already replaced this entry with CONST_NULL.
+            vrefbox.as_const_ptr().is_none_or(|ptr| ptr.0 != 0)
+        } else {
+            unsafe {
                 self.metainterp_sd
                     .virtualref_info
                     .is_virtual_ref(vref_ptr as *const u8)
-            };
+            }
+        };
         if is_vref {
             // pyjitpl.py:1831-1832 `VIRTUAL_REF_FINISH(vrefbox, nullbox)`.
             let null = self.const_ref(0);
@@ -1577,6 +1603,10 @@ impl TraceCtx {
         let mut i = 1;
         while i < self.virtualref_boxes.len() {
             let vref_ptr = self.virtualref_boxes[i].1;
+            if vref_ptr == 0 {
+                i += 2;
+                continue;
+            }
             // SAFETY: `vref_ptr` was registered by `opimpl_virtual_ref`
             // with a valid `JitVirtualRef*`; `tracing_before_residual_call`
             // only writes the token field.
@@ -1605,6 +1635,10 @@ impl TraceCtx {
         let mut i = 0;
         while i + 1 < self.virtualref_boxes.len() {
             let vref_ptr = self.virtualref_boxes[i + 1].1;
+            if vref_ptr == 0 {
+                i += 2;
+                continue;
+            }
             // SAFETY: `vref_ptr` was registered by `opimpl_virtual_ref`
             // with a valid `JitVirtualRef*`; `tracing_after_residual_call`
             // only reads the token field.

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1482,26 +1482,6 @@ impl TraceCtx {
         (vref, vref_ptr)
     }
 
-    /// Record `jit.virtual_ref(obj)` when the full-body walker has the
-    /// object's box but no recording-time heap object.
-    ///
-    /// RPython's `MetaInterp.opimpl_virtual_ref` always has a concrete box
-    /// because it is tracing the interpreter.  Pyre's self-recursive
-    /// CALL_ASSEMBLER fold constructs the callee exclusively in trace IR, so
-    /// there is no honest pointer with which to call
-    /// `virtual_ref_during_tracing`.  The runtime operation and the
-    /// `[virtualbox, vrefbox]` stack entry are nevertheless both owed; a zero
-    /// concrete stamp means only that the tracing-time before/after-residual
-    /// probes must skip this pair.  The force guard carries the runtime force
-    /// protocol, and the matching finish below closes the symbolic scope.
-    pub fn opimpl_virtual_ref_symbolic(&mut self, virtual_obj: OpRef) -> OpRef {
-        let cindex = self.const_int((self.virtualref_boxes.len() / 2) as i64);
-        let vref = self.virtual_ref(virtual_obj, cindex);
-        self.virtualref_boxes.push((virtual_obj, 0));
-        self.virtualref_boxes.push((vref, 0));
-        vref
-    }
-
     /// `pyjitpl.py opimpl_virtual_ref_finish(box)` —
     /// `ExecutionContext.leave`'s `jit.virtual_ref_finish`
     /// (`executioncontext.py:107`).  The vrefbox is reconstituted by popping,
@@ -1557,18 +1537,12 @@ impl TraceCtx {
         // pyjitpl.py:1826-1832 `if vrefinfo.is_virtual_ref(vref): record
         // VIRTUAL_REF_FINISH`.  False once `stop_tracking_virtualref` has
         // replaced the box with ConstPtr(NULL) — the finish already ran.
-        let is_vref = if vref_ptr == 0 {
-            // A non-constant box with no concrete stamp is the symbolic form
-            // opened by `opimpl_virtual_ref_symbolic`.  A stopped pair has
-            // already replaced this entry with CONST_NULL.
-            vrefbox.as_const_ptr().is_none_or(|ptr| ptr.0 != 0)
-        } else {
-            unsafe {
+        let is_vref = vref_ptr != 0
+            && unsafe {
                 self.metainterp_sd
                     .virtualref_info
                     .is_virtual_ref(vref_ptr as *const u8)
-            }
-        };
+            };
         if is_vref {
             // pyjitpl.py:1831-1832 `VIRTUAL_REF_FINISH(vrefbox, nullbox)`.
             let null = self.const_ref(0);
@@ -1603,10 +1577,6 @@ impl TraceCtx {
         let mut i = 1;
         while i < self.virtualref_boxes.len() {
             let vref_ptr = self.virtualref_boxes[i].1;
-            if vref_ptr == 0 {
-                i += 2;
-                continue;
-            }
             // SAFETY: `vref_ptr` was registered by `opimpl_virtual_ref`
             // with a valid `JitVirtualRef*`; `tracing_before_residual_call`
             // only writes the token field.
@@ -1635,10 +1605,6 @@ impl TraceCtx {
         let mut i = 0;
         while i + 1 < self.virtualref_boxes.len() {
             let vref_ptr = self.virtualref_boxes[i + 1].1;
-            if vref_ptr == 0 {
-                i += 2;
-                continue;
-            }
             // SAFETY: `vref_ptr` was registered by `opimpl_virtual_ref`
             // with a valid `JitVirtualRef*`; `tracing_after_residual_call`
             // only reads the token field.

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -2863,6 +2863,15 @@ impl crate::resume::VirtualizableInfo for VirtualizableInfo {
         if vable_ptr.is_null() {
             return;
         }
+        // A nursery virtualizable moves as one GC object.  Its owner reference
+        // is already rooted by the resume reader / Ref register bank, and the
+        // PyFrame custom tracer follows locals_cells_stack_w after copying.
+        // Registering this field's interior address would instead leave the
+        // root stack pointing into poisoned from-space after the move.  Keep
+        // the narrow field-root adaptation only for stationary frames.
+        if majit_gc::gc_is_nursery_object(vable_ptr as usize) {
+            return;
+        }
         for array in &self.array_fields {
             match array.storage {
                 VableArrayStorage::DirectPointer => {

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -1665,6 +1665,18 @@ impl WarmEnterState {
             .and_then(|cell| cell.get_procedure_token())
     }
 
+    /// Whether the resolved cell's current procedure token is the temporary
+    /// interpreter callback installed by `compile_tmp_callback`.
+    ///
+    /// `warmstate.py maybe_compile_and_run` reads `JC_TEMPORARY` before it
+    /// considers the token executable at a warm entry. Keep this on the cell,
+    /// where upstream owns it; a token body or pyre's retained
+    /// `compiled_loops` metadata cannot answer the same question.
+    pub(crate) fn procedure_token_is_temporary(&self, cell_key: u64) -> bool {
+        self.cell_by_key(cell_key)
+            .is_some_and(|cell| cell.flags & jc_flags::JC_TEMPORARY != 0)
+    }
+
     /// [`Self::get_procedure_token`] with the two flag reads taken OUT: the
     /// cell lookup, the `Weak::upgrade`, and the drop of the `Arc` it
     /// produced, and nothing else.
@@ -2301,9 +2313,12 @@ impl WarmEnterState {
 
     /// The function-entry door's whole answer, from ONE walk of the cell chain.
     ///
-    /// `warmstate.py maybe_compile_and_run` matches the cell once and then
-    /// reads `procedure_token = cell.get_procedure_token()` off it, taking the
-    /// counter path only when that token is absent. The door used to ask three
+    /// `warmstate.py maybe_compile_and_run` matches the cell once and tests
+    /// `JC_TEMPORARY` before reading
+    /// `procedure_token = cell.get_procedure_token()`. A temporary cell takes
+    /// the counter path even though its callback token is live. Otherwise the
+    /// counter path is taken only when no runnable loop token is present. The
+    /// door used to ask three
     /// separate questions of the same chain — `has_runnable_compiled_loop`
     /// before the gate, `should_trace_function_entry` inside it, and
     /// `has_runnable_compiled_loop` again to decide the run — so a call that
@@ -2311,11 +2326,11 @@ impl WarmEnterState {
     ///
     /// `has_compiled_meta` is the frontend half of `has_runnable_compiled_loop`
     /// (`compiled_loops`, a map the warm state does not own); the cell half is
-    /// read here. Both together are what makes a token runnable, so a bare
-    /// `compile_tmp_callback` token falls through to the counter exactly as it
-    /// did. It is a closure because the cell half is the cheaper question and
-    /// answers no for most calls: `warmstate.py` likewise reaches
-    /// `procedure_token` first and consults nothing else until it is there.
+    /// read here. Both together make an ordinary token runnable; the
+    /// cell-owned `JC_TEMPORARY` flag precedes them and makes a callback fall
+    /// through to the counter even when retained frontend metadata also
+    /// exists. The metadata test is a closure because the cell/token half is
+    /// the cheaper question and answers no for most ordinary calls.
     ///
     /// `engine_is_tracing` is `MetaInterp::is_tracing` — one global Option, not
     /// a per-cell flag. The door consulted it to skip the counter gate entirely
@@ -2330,8 +2345,30 @@ impl WarmEnterState {
     ) -> FunctionEntryStep {
         let mut cleanup_dead_token_cell = false;
         if let Some(cell) = self.cell_by_key(cell_key) {
-            // The token read `maybe_compile_and_run` performs before it asks
-            // the counter anything. Only a runnable one returns here; the
+            // `warmstate.py maybe_compile_and_run` tests
+            // `JC_TRACING | JC_TEMPORARY` before reading the procedure token.
+            // A temporary callback has real machine code, and pyre may still
+            // retain the displaced loop's frontend metadata, so neither code
+            // presence nor `has_compiled_meta()` identifies this flag. Count
+            // it normally exactly as upstream does; never mix the callback
+            // token with that displaced loop metadata and enter it as a loop.
+            if cell.flags & jc_flags::JC_TEMPORARY != 0 {
+                if engine_is_tracing {
+                    return FunctionEntryStep::Proceed;
+                }
+                crate::mc_diag_bump(25);
+                return if self
+                    .counter
+                    .tick(self.bucket_of(cell_key), self.increment_function_threshold)
+                {
+                    FunctionEntryStep::Proceed
+                } else {
+                    FunctionEntryStep::NotHot
+                };
+            }
+            // The token read `maybe_compile_and_run` performs for a
+            // non-temporary cell before it asks the counter anything. Only a
+            // runnable one returns here; the
             // `is_compiled` / `is_tracing` census below still sees every other
             // cell, which is what keeps slots 23/64/65 counting what they did.
             if let Some(token) = cell
@@ -2417,23 +2454,6 @@ impl WarmEnterState {
             if !dead_token && cell.abort_count >= MAX_TRACE_ABORT_COUNT {
                 crate::mc_diag_bump(81); // abort_ceiling_refused
                 return FunctionEntryStep::NotHot;
-            }
-            // `warmstate.py maybe_compile_and_run`: JC_TEMPORARY is tested alongside
-            // JC_TRACING and, unlike JC_TRACING, counts normally.  This branch
-            // must precede JC_DONT_TRACE_HERE below: the temporary token is the
-            // interpreter callback used until the non-inlinable callee gets
-            // its own real trace, not evidence that the callee was already
-            // compiled separately.
-            if cell.flags & jc_flags::JC_TEMPORARY != 0 {
-                crate::mc_diag_bump(25);
-                return if self
-                    .counter
-                    .tick(self.bucket_of(cell_key), self.increment_function_threshold)
-                {
-                    FunctionEntryStep::Proceed
-                } else {
-                    FunctionEntryStep::NotHot
-                };
             }
             if cell.flags & jc_flags::JC_DONT_TRACE_HERE != 0 {
                 if cell.has_seen_a_procedure_token() {

--- a/majit/majit-translate/src/memory/gctransform/framework.rs
+++ b/majit/majit-translate/src/memory/gctransform/framework.rs
@@ -169,7 +169,6 @@ pub const PYTHON_DISPATCH_SEEDS: &[&str] = &[
     // scan over that is vacuous rather than clean.  These are the portal and
     // blackhole entries that artefact does carry.
     "call_jit::ll_portal_runner_shim",
-    "call_jit::portal_resume_shim",
     "call_jit::run_frame_through_portal",
     "call_jit::bh_portal_runner",
     "call_jit::bh_call_self_recursive_portal",

--- a/majit/majit-translate/src/memory/gctransform/framework.rs
+++ b/majit/majit-translate/src/memory/gctransform/framework.rs
@@ -169,6 +169,7 @@ pub const PYTHON_DISPATCH_SEEDS: &[&str] = &[
     // scan over that is vacuous rather than clean.  These are the portal and
     // blackhole entries that artefact does carry.
     "call_jit::ll_portal_runner_shim",
+    "call_jit::portal_resume_shim",
     "call_jit::run_frame_through_portal",
     "call_jit::bh_portal_runner",
     "call_jit::bh_call_self_recursive_portal",
@@ -176,6 +177,7 @@ pub const PYTHON_DISPATCH_SEEDS: &[&str] = &[
     "eval::portal_runner_dispatch",
     "eval::portal_body_result",
     "eval::portal_activation_result",
+    "eval::portal_traced_activation_result",
     "eval::portal_activation_bracketed",
     "eval::enter_portal",
     "eval::eval_loop_jit",

--- a/majit/majit-translate/tests/test_vable_array_len.rs
+++ b/majit/majit-translate/tests/test_vable_array_len.rs
@@ -79,6 +79,41 @@ fn virtualizable_array_read(graph: &FunctionGraph) -> (Variable, usize) {
     found.expect("a read of the virtualizable array")
 }
 
+/// Every `Variable` carrying `seed`'s value, followed across link arguments
+/// into the target block's `inputargs`.
+///
+/// `flowcontext.py newstate = state.copy()` freshens a variable at every
+/// block boundary, so a value produced in one block and used after a branch
+/// is a different `Variable` at the use site.  A search that compares
+/// identity stops at the first branch without this closure.
+fn link_aliases(graph: &FunctionGraph, seed: &Variable) -> Vec<Variable> {
+    let mut carried = vec![seed.clone()];
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for block in &graph.blocks {
+            for link in &block.exits {
+                for (position, arg) in link.args.iter().enumerate() {
+                    let LinkArg::Value(value) = arg else {
+                        continue;
+                    };
+                    if !carried.contains(value) {
+                        continue;
+                    }
+                    let Some(target) = graph.block(link.target).inputargs.get(position) else {
+                        continue;
+                    };
+                    if !carried.contains(target) {
+                        carried.push(target.clone());
+                        changed = true;
+                    }
+                }
+            }
+        }
+    }
+    carried
+}
+
 /// `PyFrame::_check_stack_index` is `index >= self.stack_base() && index <
 /// locals_w!(self).len()` — a read of the virtualizable array whose only
 /// consumer is `len`.
@@ -207,14 +242,18 @@ fn address_of_the_vable_array_slot_is_marked_not_a_read() {
                 let Some(result) = op.result.as_ref() else {
                     continue;
                 };
-                // Only the read whose consumer is the root registration.
+                // Only the read whose consumer is the root registration.  The
+                // registration sits behind a short-circuit test of the frame's
+                // mobility, so the call is in a later block and the slot
+                // reaches it under a freshened `Variable`.
+                let carried = link_aliases(graph, result);
                 let feeds_add_root = graph.blocks.iter().any(|b| {
                     b.operations.iter().any(|o| {
                         matches!(
                             &o.kind,
                             OpKind::Call { target: CallTarget::FunctionPath { segments }, args, .. }
                                 if segments.last().is_some_and(|s| s == "try_gc_add_root")
-                                    && args.contains(result)
+                                    && args.iter().any(|a| carried.contains(a))
                         )
                     })
                 });

--- a/pyre/bench/synth/exception_traceback_frame_lineno.cranelift.jitstats
+++ b/pyre/bench/synth/exception_traceback_frame_lineno.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=4
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -12,8 +12,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=624
+guard_failures=824
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=16
+loops_compiled=17
 retraces_compiled=0

--- a/pyre/bench/synth/exception_traceback_frame_lineno.dynasm.jitstats
+++ b/pyre/bench/synth/exception_traceback_frame_lineno.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=4
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -12,8 +12,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=624
+guard_failures=824
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=16
+loops_compiled=17
 retraces_compiled=0

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -828,18 +828,45 @@ pub fn capture_pyframe_root_area() -> *const () {
     PYFRAME_ROOT_AREA.with(|area| area as *const _ as *const ())
 }
 
-/// Advance the root walk one link along the `f_backref` chain.
+/// Whether `frame` is a collector-owned `PyFrame` rather than one of the
+/// header-prefixed `std::alloc` frames used by interpreter snapshots.
 ///
-/// `f_backref` holds a `jit.virtual_ref`, which at interpreter level is the
-/// caller frame pointer itself; once the JIT virtualizes an inlined callee the
-/// slot instead holds a `JitVirtualRef`, and reading that as a `PyFrame` would
-/// interpret its `virtual_token` word as frame fields.  Hop through the vref
-/// instead.  A still-virtual vref ends the walk: the frames it stands for have
-/// no heap image to visit, and `virtualref.py force_virtual_if_necessary`
-/// cannot run here because materializing one allocates.
+/// PyPy's `PyFrame` is a GC object: the root callback exposes the frame and
+/// the collector traces its fields later.  It never walks through a freshly
+/// copied frame during `collect_roots_in_nursery`, when only direct roots have
+/// been forwarded (`IncrementalMiniMarkGC.collect_roots_in_nursery`).  Pyre's
+/// explicit frame walker is needed only for the non-GC fallback.  Reading the
+/// header is safe for both representations because the fallback deliberately
+/// carries a zeroed `GcHeader` too (`alloc_fixed_array_with_header`'s frame
+/// counterpart in `pyframe.rs`).
 #[inline]
-unsafe fn chain_next_frame(f_backref: *mut PyFrame) -> *mut PyFrame {
-    crate::executioncontext::vref_referent(f_backref)
+unsafe fn is_gc_managed_pyframe(frame: *mut PyFrame) -> bool {
+    if frame.is_null() {
+        return false;
+    }
+    unsafe {
+        (*majit_gc::header::header_of(frame as usize)).type_id()
+            == crate::pyframe::PYFRAME_GC_TYPE_ID
+    }
+}
+
+/// Continue only through the non-GC fallback frame chain.
+///
+/// A managed `PyFrame` or `JitVirtualRef` has already been exposed through the
+/// slot visitor.  Its own type tracer owns the next edge; dereferencing it in
+/// the root phase would run ahead of the collector's gray/remembered-set walk.
+#[inline]
+unsafe fn raw_chain_next_frame(f_backref: *mut PyFrame) -> *mut PyFrame {
+    if f_backref.is_null() {
+        return std::ptr::null_mut();
+    }
+    unsafe {
+        if (*majit_gc::header::header_of(f_backref as usize)).type_id() == 0 {
+            f_backref
+        } else {
+            std::ptr::null_mut()
+        }
+    }
 }
 
 /// Forward the frame named by a `JitVirtualRef` stored in a frame-shaped slot.
@@ -1066,6 +1093,16 @@ pub unsafe fn walk_pyframe_roots_area(
         };
         visit_ec_slots(ambient_ec);
         while !frame.is_null() {
+            // A GC-managed PyFrame was exposed by the CURRENT_FRAME slot (or
+            // by the preceding raw frame's f_backref slot).  Stop here and let
+            // `pyframe_object_custom_trace` follow its fields after the
+            // collector reaches the gray/remembered-set phase.  Walking those
+            // fields now is earlier than PyPy's root contract and can observe
+            // a callee PyFrame still named by a pre-forward CALL_ASSEMBLER
+            // jitframe slot.
+            if unsafe { is_gc_managed_pyframe(frame) } {
+                break;
+            }
             // SAFETY: PyFrame pointers on the f_backref chain are valid
             // for the duration of the enclosing `eval_with_jit` call. A
             // minor collection is always synchronous with respect to the
@@ -1078,35 +1115,15 @@ pub unsafe fn walk_pyframe_roots_area(
             // holding a non-object word is harmless for the bump-pointer
             // nursery.
             //
-            // The walk runs for every frame on the chain, including
-            // ones the GC owns. For nursery-allocated frames the
-            // standard tracer ALSO covers their gc_ptr_offsets when it
-            // reaches the survivor copy; visiting the locals array
-            // items here from the original nursery payload is safe
-            // because root visiting runs before any internal-slot
-            // forwarding (the original payload is still intact). We
-            // intentionally do NOT call `majit_gc::gc_owns_object`
-            // here to gate this branch — that hook re-enters
-            // `with_cranelift_gc` with a `borrow_mut`, which panics
-            // when invoked from inside `collect_nursery` (the GC's
-            // own cell is already borrowed by the active alloc shim).
+            // Only a header-prefixed stdalloc frame reaches this branch.
+            // Collector-owned frames stop above and are traced from the
+            // survivor/old object by `pyframe_object_custom_trace`.
             let (arr_ptr, depth, next_frame) = unsafe {
                 let f_back_slot = &mut (*(frame)).f_backref as *mut *mut PyFrame;
                 visitor(&mut *(f_back_slot as *mut majit_ir::GcRef));
-                // The visitor above forwarded the slot, which for a vref leaves
-                // the vref itself put — it is old-gen, so mark-sweep does not
-                // move it — while the frame its `forced` slot names may be
-                // young and relocating. `forced` is an interior slot the
-                // collector reaches later, off the gray stack, but
-                // `chain_next_frame` reads it during THIS scan, so forward it
-                // here as well; otherwise the walk steps into a frame copy the
-                // collector is about to abandon, and the roots only this walker
-                // knows about (caught exceptions, module-dict cells, the
-                // prebuilt families) get forwarded into dead memory. A direct
-                // `f_backref` needs no such hop — the visitor already left it
-                // naming the live copy.
-                let f_backref = *f_back_slot;
-                forward_virtual_ref_forced(f_backref as *mut u8, visitor);
+                // A direct raw-frame backref can continue the fallback chain.
+                // A managed PyFrame or JitVirtualRef stops it: the collector's
+                // type tracer follows that object's interior edges later.
 
                 // pyframe.py:102 `self.pycode` — the running code object.
                 // Visited as a root so a code object reachable only via
@@ -1219,7 +1236,7 @@ pub unsafe fn walk_pyframe_roots_area(
                     }
                 }
                 let f = &*frame;
-                let next_frame = chain_next_frame((*frame).f_backref);
+                let next_frame = raw_chain_next_frame((*frame).f_backref);
                 if f.locals_cells_stack_w.is_null() {
                     (std::ptr::null_mut::<PyObjectRef>(), 0, next_frame)
                 } else {

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -768,8 +768,13 @@ pub fn opcode_swap<H: StackOpcodeHandler + ?Sized>(
 
 pub fn opcode_get_iter<H: IterOpcodeHandler + ?Sized>(handler: &mut H) -> Result<(), PyError> {
     let iterable = handler.pop_value()?;
+    // `PyFrame` can be the nursery frame materialised by an inlined
+    // CALL_ASSEMBLER.  PyPy's GC transform keeps the `self` livevar rooted
+    // across `space.iter()` and reloads it before `pushvalue`; the Rust borrow
+    // alone still names the evacuated copy after `iter_value` collects.
+    let anchor = handler.anchor();
     let iterator = handler.iter_value(iterable)?;
-    handler.push_value(iterator)
+    H::push_anchored(&anchor, iterator)
 }
 
 pub fn opcode_for_iter<H: IterOpcodeHandler + ControlFlowOpcodeHandler + ?Sized>(
@@ -795,9 +800,12 @@ pub fn opcode_for_iter<H: IterOpcodeHandler + ControlFlowOpcodeHandler + ?Sized>
 
 pub fn opcode_unary_not<H: TruthOpcodeHandler + ?Sized>(handler: &mut H) -> Result<(), PyError> {
     let value = handler.pop_value()?;
+    // `space.is_true()` may call application code.  This is the explicit
+    // counterpart of the translated live `self` around PyPy's unary opcode.
+    let anchor = handler.anchor();
     let truth = handler.truth_value(value)?;
     let result = handler.bool_value_from_truth(truth, true)?;
-    handler.push_value(result)
+    H::push_anchored(&anchor, result)
 }
 
 pub fn opcode_binary_op<H: ArithmeticOpcodeHandler + ?Sized>(
@@ -806,8 +814,14 @@ pub fn opcode_binary_op<H: ArithmeticOpcodeHandler + ?Sized>(
 ) -> Result<(), PyError> {
     let b = handler.pop_value()?;
     let a = handler.pop_value()?;
+    // `binaryoperation()` in `pyopcode.py` keeps `self` live across the
+    // allocating `space.<op>(w_1, w_2)` and then calls `self.pushvalue`.
+    // RPython's shadow-stack transform forwards that livevar.  Anchor it
+    // explicitly here so a materialised nursery PyFrame is reloaded before
+    // the result push.
+    let anchor = handler.anchor();
     let result = handler.binary_value(a, b, op)?;
-    handler.push_value(result)
+    H::push_anchored(&anchor, result)
 }
 
 pub fn opcode_compare_op<H: ArithmeticOpcodeHandler + ?Sized>(
@@ -816,24 +830,29 @@ pub fn opcode_compare_op<H: ArithmeticOpcodeHandler + ?Sized>(
 ) -> Result<(), PyError> {
     let b = handler.pop_value()?;
     let a = handler.pop_value()?;
+    // Same translated-livevar obligation as `opcode_binary_op`: rich
+    // comparison may allocate or invoke application code before the push.
+    let anchor = handler.anchor();
     let result = handler.compare_value(a, b, op)?;
-    handler.push_value(result)
+    H::push_anchored(&anchor, result)
 }
 
 pub fn opcode_unary_negative<H: ArithmeticOpcodeHandler + ?Sized>(
     handler: &mut H,
 ) -> Result<(), PyError> {
     let value = handler.pop_value()?;
+    let anchor = handler.anchor();
     let result = handler.unary_negative_value(value)?;
-    handler.push_value(result)
+    H::push_anchored(&anchor, result)
 }
 
 pub fn opcode_unary_invert<H: ArithmeticOpcodeHandler + ?Sized>(
     handler: &mut H,
 ) -> Result<(), PyError> {
     let value = handler.pop_value()?;
+    let anchor = handler.anchor();
     let result = handler.unary_invert_value(value)?;
-    handler.push_value(result)
+    H::push_anchored(&anchor, result)
 }
 
 fn opcode_pop_jump_if<H: BranchOpcodeHandler + ?Sized>(

--- a/pyre/pyre-interpreter/src/shared_opcode.rs
+++ b/pyre/pyre-interpreter/src/shared_opcode.rs
@@ -75,8 +75,9 @@ fn pop_n<H: SharedOpcodeHandler + ?Sized>(
 
 pub fn opcode_make_function<H: SharedOpcodeHandler + ?Sized>(handler: &mut H) -> OpcodeResult<()> {
     let code_obj = handler.pop_value()?;
+    let anchor = handler.anchor();
     let func = handler.make_function(code_obj)?;
-    handler.push_value(func)
+    H::push_anchored(&anchor, func)
 }
 
 pub fn opcode_call<H: SharedOpcodeHandler + ?Sized>(
@@ -91,23 +92,26 @@ pub fn opcode_call<H: SharedOpcodeHandler + ?Sized>(
         0 => {
             let _null_or_self = handler.pop_value()?;
             let callable = handler.pop_value()?;
+            let anchor = handler.anchor();
             let result = handler.call_callable(callable, &[])?;
-            handler.push_value(result)
+            H::push_anchored(&anchor, result)
         }
         1 => {
             let a0 = handler.pop_value()?;
             let _null_or_self = handler.pop_value()?;
             let callable = handler.pop_value()?;
+            let anchor = handler.anchor();
             let result = handler.call_callable(callable, &[a0])?;
-            handler.push_value(result)
+            H::push_anchored(&anchor, result)
         }
         2 => {
             let a1 = handler.pop_value()?;
             let a0 = handler.pop_value()?;
             let _null_or_self = handler.pop_value()?;
             let callable = handler.pop_value()?;
+            let anchor = handler.anchor();
             let result = handler.call_callable(callable, &[a0, a1])?;
-            handler.push_value(result)
+            H::push_anchored(&anchor, result)
         }
         3 => {
             let a2 = handler.pop_value()?;
@@ -115,15 +119,17 @@ pub fn opcode_call<H: SharedOpcodeHandler + ?Sized>(
             let a0 = handler.pop_value()?;
             let _null_or_self = handler.pop_value()?;
             let callable = handler.pop_value()?;
+            let anchor = handler.anchor();
             let result = handler.call_callable(callable, &[a0, a1, a2])?;
-            handler.push_value(result)
+            H::push_anchored(&anchor, result)
         }
         _ => {
             let args = pop_n(handler, nargs)?;
             let _null_or_self = handler.pop_value()?;
             let callable = handler.pop_value()?;
+            let anchor = handler.anchor();
             let result = handler.call_callable(callable, &args)?;
-            handler.push_value(result)
+            H::push_anchored(&anchor, result)
         }
     }
 }
@@ -133,8 +139,9 @@ pub fn opcode_build_list<H: SharedOpcodeHandler + ?Sized>(
     size: usize,
 ) -> OpcodeResult<()> {
     let items = pop_n(handler, size)?;
+    let anchor = handler.anchor();
     let list = handler.build_list(&items)?;
-    handler.push_value(list)
+    H::push_anchored(&anchor, list)
 }
 
 pub fn opcode_build_tuple<H: SharedOpcodeHandler + ?Sized>(
@@ -142,8 +149,9 @@ pub fn opcode_build_tuple<H: SharedOpcodeHandler + ?Sized>(
     size: usize,
 ) -> OpcodeResult<()> {
     let items = pop_n(handler, size)?;
+    let anchor = handler.anchor();
     let tuple = handler.build_tuple(&items)?;
-    handler.push_value(tuple)
+    H::push_anchored(&anchor, tuple)
 }
 
 pub fn opcode_build_map<H: SharedOpcodeHandler + ?Sized>(
@@ -151,8 +159,9 @@ pub fn opcode_build_map<H: SharedOpcodeHandler + ?Sized>(
     size: usize,
 ) -> OpcodeResult<()> {
     let items = pop_n(handler, size * 2)?;
+    let anchor = handler.anchor();
     let dict = handler.build_map(&items)?;
-    handler.push_value(dict)
+    H::push_anchored(&anchor, dict)
 }
 
 pub fn opcode_store_subscr<H: SharedOpcodeHandler + ?Sized>(handler: &mut H) -> OpcodeResult<()> {
@@ -179,9 +188,10 @@ pub fn opcode_unpack_sequence<H: SharedOpcodeHandler + ?Sized>(
     count: usize,
 ) -> OpcodeResult<()> {
     let seq = handler.pop_value()?;
+    let anchor = handler.anchor();
     let items = handler.unpack_sequence(seq, count)?;
     for item in items.into_iter().rev() {
-        handler.push_value(item)?;
+        H::push_anchored(&anchor, item)?;
     }
     Ok(())
 }
@@ -191,8 +201,9 @@ pub fn opcode_load_attr<H: SharedOpcodeHandler + ?Sized>(
     name: &str,
 ) -> OpcodeResult<()> {
     let obj = handler.pop_value()?;
+    let anchor = handler.anchor();
     let attr = handler.load_attr(obj, name)?;
-    handler.push_value(attr)
+    H::push_anchored(&anchor, attr)
 }
 
 pub fn opcode_store_attr<H: SharedOpcodeHandler + ?Sized>(

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2176,11 +2176,6 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
         // emits the outer `FINISH(exc)` (or an outer inline frame's
         // handler catches it).
         walker_record_guard_exception(ctx, op.pc);
-        // `ExecutionContext.leave` closes the vref after the exception guard.
-        // Keeping the pair open while that guard's resume data is captured is
-        // essential: if the runtime exception class differs, blackhole resume
-        // still owes `virtual_ref_finish` for this activation.
-        record_ec_finish_frame_vref(ctx.trace_ctx, callee_frame);
         let exc = ctx
             .last_exc_value()
             .expect("exec_raised implies last_exc_value seeded by the Err branch");
@@ -2193,10 +2188,6 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
     // GUARD_NO_EXCEPTION on the non-raising recording path.
     ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
     walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-    // Same ordering as `ExecutionContext.leave` in the ordinary-return trace:
-    // a failing exception guard resumes with the vref scope still live;
-    // successful compiled execution closes it here.
-    record_ec_finish_frame_vref(ctx.trace_ctx, callee_frame);
 
     Ok(Some((DispatchOutcome::Continue, op.next_pc)))
 }
@@ -2207,7 +2198,7 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
 ///
 /// The portal driver is the one with greens; `ensure_default_driver_sd`'s
 /// placeholder has none and carries no runner address.
-fn portal_runner_call_target() -> Option<(i64, i64, majit_ir::DescrRef)> {
+fn portal_runner_call_target() -> Option<(i64, majit_ir::DescrRef)> {
     let (driver, _) = crate::driver::try_driver_pair()?;
     let jd = driver
         .meta_interp()
@@ -2215,14 +2206,10 @@ fn portal_runner_call_target() -> Option<(i64, i64, majit_ir::DescrRef)> {
         .jitdrivers_sd
         .iter()
         .find(|jd| jd.num_greens() > 0)?;
-    if jd.portal_runner_adr == 0 || jd.portal_ptr_adr == 0 {
+    if jd.portal_runner_adr == 0 {
         return None;
     }
-    Some((
-        jd.portal_runner_adr,
-        jd.portal_ptr_adr,
-        jd.portal_calldescr.clone()?,
-    ))
+    Some((jd.portal_runner_adr, jd.portal_calldescr.clone()?))
 }
 
 /// Walker mirror of `opimpl_recursive_call_assembler`
@@ -2261,8 +2248,7 @@ pub(crate) fn emit_walker_loop_callee_call_assembler<Sym: WalkSym>(
     // `do_recursive_call`'s funcbox and ABI, resolved before the first
     // recorded op so an unwired driver declines the inline instead of
     // leaving a half-emitted CALL behind.
-    let Some((_portal_runner_adr, portal_ptr_adr, portal_descr)) = portal_runner_call_target()
-    else {
+    let Some((portal_runner_adr, portal_descr)) = portal_runner_call_target() else {
         return resolved_inline_decline(op.pc, line!());
     };
     let Some(portal_view) = portal_descr.as_call_descr() else {
@@ -2382,10 +2368,14 @@ pub(crate) fn emit_walker_loop_callee_call_assembler<Sym: WalkSym>(
     // stopped AT the merge point, before the opcode that would have spilled
     // `last_instr` for it.
     unsafe { (*concrete_callee_frame).last_instr = target_pc as isize - 1 };
-    // Concrete tracing resumes the sub-walk's already-started activation via
-    // `portal_ptr`.  The runtime CALL_ASSEMBLER still targets the compiled
-    // loop or its `ll_portal_runner` temporary callback.
-    let funcbox = ctx.trace_ctx.const_int(portal_ptr_adr);
+    // `do_recursive_call` bakes `portal_runner_adr`.  That address is what the
+    // runtime CALL_ASSEMBLER calls when the callee has no compiled loop yet:
+    // `compile_tmp_callback` routes it through `ll_portal_runner`, which begins
+    // an activation.  `_portal_ptr` names the body below that entry and is
+    // reached only from inside `ll_portal_runner` itself, so baking it here
+    // resumes a body whose prologue never ran — the callee never enters the
+    // JIT and the frame is forced instead.
+    let funcbox = ctx.trace_ctx.const_int(portal_runner_adr);
     let next_instr_box = ctx.trace_ctx.const_int(target_pc as i64);
     let profiled_box = ctx.trace_ctx.const_int(is_being_profiled as i64);
     let pycode_box = ctx.trace_ctx.const_ref(w_code as i64);
@@ -3434,12 +3424,26 @@ pub(crate) fn walker_ec_leave(
 /// ```
 ///
 /// [`walker_ec_enter`] is the seeded-callee form: it has a live callee frame
-/// at recording time and can also build the tracing-time concrete vref.  This
-/// fold constructs its callee only in trace IR, so it uses the symbolic form:
-/// the same runtime VIRTUAL_REF and the same metainterp pair stack, without
-/// inventing a recording-time pointer.  The portal entry is told explicitly
-/// that this trace owns the chain; it no longer guesses by forcing or reading
-/// TLS, so an unforced runtime vref is valid here.
+/// at recording time, so it mirrors every store concretely and takes a real
+/// vref of the frame.  This fold builds its callee out of recorded operations
+/// alone, so what is recorded here is the interpreter-level reading of
+/// `jit.virtual_ref(frame)`: the frame pointer itself (`_jit_vref.py
+/// lowleveltype = OBJECTPTR`, no allocation), which is exactly what
+/// [`pyre_interpreter::PyExecutionContext::enter`] stores.
+///
+/// ⛔ Recording a `VIRTUAL_REF` here instead is measurable and is a net loss.
+/// The callee this fold builds is read back through `gettopframe_nohidden`,
+/// which is `force_vref`: `locals()` in a self-recursive callee forces on
+/// every call, and an unwind that crosses suspended copies of the frame
+/// forces once per crossing.  Each force is a GUARD_NOT_FORCED failure, and
+/// `ResumeGuardForcedDescr.handle_fail` never compiles one — it blackholes.
+/// Measured over the synthetic corpus, publishing the vref moves eight
+/// fixtures by one to three guard failures and moves two by +273
+/// (`recursive_forced_frame_kept_stack`) and +169
+/// (`selfrec_tail_exception_unwind`): +430 net, all of it blackholed.  The
+/// portal doors no longer need it — [`crate::PortalEntry`]'s caller names the
+/// door — so the remaining question is what makes those forces unnecessary,
+/// not how to spell the enter.
 ///
 /// Upstream reaches `ec.enter` on this path too: `interp_jit.py` puts
 /// `jit_merge_point` on `PyFrame.dispatch`, so the CALL_ASSEMBLER that
@@ -3458,10 +3462,9 @@ fn record_ec_enter_frame_chain(ctx: &mut TraceCtx, callee_frame: OpRef, callee_e
         &[callee_frame, caller_topframeref],
         crate::descr::pyframe_f_backref_descr(),
     );
-    let frame_vref = ctx.opimpl_virtual_ref_symbolic(callee_frame);
     ctx.record_op_with_descr(
         OpCode::SetfieldGc,
-        &[callee_ec, frame_vref],
+        &[callee_ec, callee_frame],
         crate::descr::ec_topframeref_descr(),
     );
 }
@@ -3474,10 +3477,11 @@ fn record_ec_enter_frame_chain(ctx: &mut TraceCtx, callee_frame: OpRef, callee_e
 /// ```
 ///
 /// No parens on `f_backref`, so a caller frame that stayed virtual stays
-/// virtual.  The matching `virtual_ref_finish` is deliberately separate in
-/// [`record_ec_finish_frame_vref`]: the exception guard must capture resume
-/// data while the vref scope is still open, just as it does while tracing
-/// `ExecutionContext.leave` upstream.
+/// virtual.  The escape branch and `virtual_ref_finish` that [`walker_ec_leave`]
+/// carries have no counterpart here for the same reason the enter takes no
+/// vref: this level never held one.  The profile-hook half stays with
+/// [`pyre_interpreter::PyExecutionContext::leave`] — see [`walker_ec_leave`]
+/// for why the portal-driver GREEN makes that split sound.
 ///
 /// Record this at the earliest point the call is known to have returned, not
 /// on the trace's fall-through tail: a guard recorded ahead of it skips it on
@@ -3498,35 +3502,30 @@ fn record_ec_leave_frame_chain(ctx: &mut TraceCtx, callee_frame: OpRef, callee_e
     );
 }
 
-/// Record the final `jit.virtual_ref_finish(frame_vref, frame)` of
-/// `ExecutionContext.leave` after the call's exception guard has captured its
-/// resume data.
-fn record_ec_finish_frame_vref(ctx: &mut TraceCtx, callee_frame: OpRef) {
-    assert!(
-        ctx.opimpl_virtual_ref_finish(callee_frame),
-        "self-recursive portal leave must close its frame vref",
-    );
-}
-
 #[cfg(test)]
 mod portal_frame_chain_tests {
     use super::*;
 
-    /// The self-recursive fold records the same virtual-ref bracket as
-    /// `ExecutionContext.enter` / `ExecutionContext.leave`.
+    /// The fold's recorded `enter` publishes the callee frame itself, and its
+    /// recorded `leave` restores `f_backref` — neither takes a vref.
+    ///
+    /// The op shape is the contract because publishing a `VIRTUAL_REF` here
+    /// is a measured net loss: the forces it admits are GUARD_NOT_FORCED
+    /// failures, which are blackholed rather than compiled. See
+    /// [`record_ec_enter_frame_chain`] for the census.
     #[test]
-    fn the_recorded_enter_and_leave_balance_one_virtual_ref() {
+    fn the_recorded_enter_and_leave_take_no_virtual_ref() {
         let mut ctx = TraceCtx::for_test_types(&[Type::Ref, Type::Ref]);
         let frame = OpRef::input_arg_ref(0);
         let ec = OpRef::input_arg_ref(1);
 
         record_ec_enter_frame_chain(&mut ctx, frame, ec);
         record_ec_leave_frame_chain(&mut ctx, frame, ec);
-        record_ec_finish_frame_vref(&mut ctx, frame);
         assert_eq!(
             ctx.virtualref_boxes_len(),
             0,
-            "the enter/leave pair must leave no virtualref open at the loop header",
+            "this level holds no vref, so it owes no virtual_ref_finish and \
+             must not leave `virtualref_boxes` unbalanced at the loop header",
         );
 
         let tree_loop = ctx.into_tree_loop();
@@ -3537,12 +3536,11 @@ mod portal_frame_chain_tests {
                 // `frame.f_backref = self.topframeref`
                 OpCode::GetfieldGcR,
                 OpCode::SetfieldGc,
-                OpCode::VirtualRefR,
+                // `self.topframeref = frame`
                 OpCode::SetfieldGc,
                 // `self.topframeref = frame.f_backref`
                 OpCode::GetfieldGcR,
                 OpCode::SetfieldGc,
-                OpCode::VirtualRefFinish,
             ],
         );
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2176,6 +2176,11 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
         // emits the outer `FINISH(exc)` (or an outer inline frame's
         // handler catches it).
         walker_record_guard_exception(ctx, op.pc);
+        // `ExecutionContext.leave` closes the vref after the exception guard.
+        // Keeping the pair open while that guard's resume data is captured is
+        // essential: if the runtime exception class differs, blackhole resume
+        // still owes `virtual_ref_finish` for this activation.
+        record_ec_finish_frame_vref(ctx.trace_ctx, callee_frame);
         let exc = ctx
             .last_exc_value()
             .expect("exec_raised implies last_exc_value seeded by the Err branch");
@@ -2188,6 +2193,10 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
     // GUARD_NO_EXCEPTION on the non-raising recording path.
     ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
     walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    // Same ordering as `ExecutionContext.leave` in the ordinary-return trace:
+    // a failing exception guard resumes with the vref scope still live;
+    // successful compiled execution closes it here.
+    record_ec_finish_frame_vref(ctx.trace_ctx, callee_frame);
 
     Ok(Some((DispatchOutcome::Continue, op.next_pc)))
 }
@@ -2198,7 +2207,7 @@ pub(crate) fn try_walker_call_assembler_self_recursive<Sym: WalkSym>(
 ///
 /// The portal driver is the one with greens; `ensure_default_driver_sd`'s
 /// placeholder has none and carries no runner address.
-fn portal_runner_call_target() -> Option<(i64, majit_ir::DescrRef)> {
+fn portal_runner_call_target() -> Option<(i64, i64, majit_ir::DescrRef)> {
     let (driver, _) = crate::driver::try_driver_pair()?;
     let jd = driver
         .meta_interp()
@@ -2206,10 +2215,14 @@ fn portal_runner_call_target() -> Option<(i64, majit_ir::DescrRef)> {
         .jitdrivers_sd
         .iter()
         .find(|jd| jd.num_greens() > 0)?;
-    if jd.portal_runner_adr == 0 {
+    if jd.portal_runner_adr == 0 || jd.portal_ptr_adr == 0 {
         return None;
     }
-    Some((jd.portal_runner_adr, jd.portal_calldescr.clone()?))
+    Some((
+        jd.portal_runner_adr,
+        jd.portal_ptr_adr,
+        jd.portal_calldescr.clone()?,
+    ))
 }
 
 /// Walker mirror of `opimpl_recursive_call_assembler`
@@ -2248,7 +2261,8 @@ pub(crate) fn emit_walker_loop_callee_call_assembler<Sym: WalkSym>(
     // `do_recursive_call`'s funcbox and ABI, resolved before the first
     // recorded op so an unwired driver declines the inline instead of
     // leaving a half-emitted CALL behind.
-    let Some((portal_runner_adr, portal_descr)) = portal_runner_call_target() else {
+    let Some((_portal_runner_adr, portal_ptr_adr, portal_descr)) = portal_runner_call_target()
+    else {
         return resolved_inline_decline(op.pc, line!());
     };
     let Some(portal_view) = portal_descr.as_call_descr() else {
@@ -2368,7 +2382,10 @@ pub(crate) fn emit_walker_loop_callee_call_assembler<Sym: WalkSym>(
     // stopped AT the merge point, before the opcode that would have spilled
     // `last_instr` for it.
     unsafe { (*concrete_callee_frame).last_instr = target_pc as isize - 1 };
-    let funcbox = ctx.trace_ctx.const_int(portal_runner_adr);
+    // Concrete tracing resumes the sub-walk's already-started activation via
+    // `portal_ptr`.  The runtime CALL_ASSEMBLER still targets the compiled
+    // loop or its `ll_portal_runner` temporary callback.
+    let funcbox = ctx.trace_ctx.const_int(portal_ptr_adr);
     let next_instr_box = ctx.trace_ctx.const_int(target_pc as i64);
     let profiled_box = ctx.trace_ctx.const_int(is_being_profiled as i64);
     let pycode_box = ctx.trace_ctx.const_ref(w_code as i64);
@@ -3417,32 +3434,12 @@ pub(crate) fn walker_ec_leave(
 /// ```
 ///
 /// [`walker_ec_enter`] is the seeded-callee form: it has a live callee frame
-/// at recording time, so it mirrors every store concretely and takes a real
-/// vref of the frame.  The CALL_ASSEMBLER folds build their callee frame out
-/// of recorded operations alone — `emit_new_pyframe_inline_with_params` never
-/// materializes one during the walk — so there is nothing to store into and
-/// nothing to take a vref of until the compiled loop runs.  What is recorded
-/// here is the interpreter-level reading of `jit.virtual_ref(frame)`, which
-/// is the frame pointer itself (`_jit_vref.py lowleveltype = OBJECTPTR`, no
-/// allocation) and is exactly what [`pyre_interpreter::PyExecutionContext::enter`]
-/// stores.
-///
-/// ⛔ Recording a `VIRTUAL_REF` here instead — the spelling
-/// [`walker_ec_enter`] uses — is not available to this fold, and the
-/// difference is the callee's exit, not the enter.  `optimize_VIRTUAL_REF`
-/// seeds the materialized `JitVirtualRef` with `forced = NULL`
-/// (`virtualize.py:129`), and pyre's two portal doors resolve `topframeref`
-/// through `executioncontext::vref_referent`, which reads `forced` WITHOUT
-/// forcing.  An unforced vref therefore answers NULL at both:
-/// `install_current_frame` (`pyre-interpreter/src/eval.rs`) reads that as
-/// "not yet entered" and re-links the callee onto its own vref, and
-/// `leave_compiled_frame_chain` (`pyre-jit/src/call_jit.rs`) reads it as
-/// "not my frame" and silently declines the restore.  [`walker_ec_enter`]'s
-/// callee is inlined and reaches neither door; this fold's callee reaches
-/// both — `compile_tmp_callback` routes its CALL_ASSEMBLER through
-/// `ll_portal_runner_shim`, and the force/deopt legs call
-/// `jit_force_callee_frame`.  Publishing a vref here needs a signal those
-/// doors can decide without forcing, which does not exist yet.
+/// at recording time and can also build the tracing-time concrete vref.  This
+/// fold constructs its callee only in trace IR, so it uses the symbolic form:
+/// the same runtime VIRTUAL_REF and the same metainterp pair stack, without
+/// inventing a recording-time pointer.  The portal entry is told explicitly
+/// that this trace owns the chain; it no longer guesses by forcing or reading
+/// TLS, so an unforced runtime vref is valid here.
 ///
 /// Upstream reaches `ec.enter` on this path too: `interp_jit.py` puts
 /// `jit_merge_point` on `PyFrame.dispatch`, so the CALL_ASSEMBLER that
@@ -3461,9 +3458,10 @@ fn record_ec_enter_frame_chain(ctx: &mut TraceCtx, callee_frame: OpRef, callee_e
         &[callee_frame, caller_topframeref],
         crate::descr::pyframe_f_backref_descr(),
     );
+    let frame_vref = ctx.opimpl_virtual_ref_symbolic(callee_frame);
     ctx.record_op_with_descr(
         OpCode::SetfieldGc,
-        &[callee_ec, callee_frame],
+        &[callee_ec, frame_vref],
         crate::descr::ec_topframeref_descr(),
     );
 }
@@ -3476,11 +3474,10 @@ fn record_ec_enter_frame_chain(ctx: &mut TraceCtx, callee_frame: OpRef, callee_e
 /// ```
 ///
 /// No parens on `f_backref`, so a caller frame that stayed virtual stays
-/// virtual.  The escape branch and `virtual_ref_finish` that [`walker_ec_leave`]
-/// carries have no counterpart here for the same reason the enter takes no
-/// vref: this level never held one.  The profile-hook half stays with
-/// [`pyre_interpreter::PyExecutionContext::leave`] — see [`walker_ec_leave`]
-/// for why the portal-driver GREEN makes that split sound.
+/// virtual.  The matching `virtual_ref_finish` is deliberately separate in
+/// [`record_ec_finish_frame_vref`]: the exception guard must capture resume
+/// data while the vref scope is still open, just as it does while tracing
+/// `ExecutionContext.leave` upstream.
 ///
 /// Record this at the earliest point the call is known to have returned, not
 /// on the trace's fall-through tail: a guard recorded ahead of it skips it on
@@ -3501,34 +3498,35 @@ fn record_ec_leave_frame_chain(ctx: &mut TraceCtx, callee_frame: OpRef, callee_e
     );
 }
 
+/// Record the final `jit.virtual_ref_finish(frame_vref, frame)` of
+/// `ExecutionContext.leave` after the call's exception guard has captured its
+/// resume data.
+fn record_ec_finish_frame_vref(ctx: &mut TraceCtx, callee_frame: OpRef) {
+    assert!(
+        ctx.opimpl_virtual_ref_finish(callee_frame),
+        "self-recursive portal leave must close its frame vref",
+    );
+}
+
 #[cfg(test)]
 mod portal_frame_chain_tests {
     use super::*;
 
-    /// The fold's recorded `enter` publishes the callee frame itself, and its
-    /// recorded `leave` restores `f_backref` — neither takes a vref.
-    ///
-    /// The op shape is the contract, because the two portal doors this fold's
-    /// callee reaches (`install_current_frame` and `leave_compiled_frame_chain`)
-    /// resolve `topframeref` through `vref_referent`, which reads
-    /// `JitVirtualRef.forced` without forcing.  `optimize_VIRTUAL_REF` seeds
-    /// that field with `CONST_NULL` (`virtualize.py:129`), so a `VIRTUAL_REF`
-    /// recorded here would answer NULL at both doors: the first re-links the
-    /// callee onto its own vref, the second declines the restore.  See
-    /// [`record_ec_enter_frame_chain`] for the full argument.
+    /// The self-recursive fold records the same virtual-ref bracket as
+    /// `ExecutionContext.enter` / `ExecutionContext.leave`.
     #[test]
-    fn the_recorded_enter_and_leave_take_no_virtual_ref() {
+    fn the_recorded_enter_and_leave_balance_one_virtual_ref() {
         let mut ctx = TraceCtx::for_test_types(&[Type::Ref, Type::Ref]);
         let frame = OpRef::input_arg_ref(0);
         let ec = OpRef::input_arg_ref(1);
 
         record_ec_enter_frame_chain(&mut ctx, frame, ec);
         record_ec_leave_frame_chain(&mut ctx, frame, ec);
+        record_ec_finish_frame_vref(&mut ctx, frame);
         assert_eq!(
             ctx.virtualref_boxes_len(),
             0,
-            "this level holds no vref, so it owes no virtual_ref_finish and \
-             must not leave `virtualref_boxes` unbalanced at the loop header",
+            "the enter/leave pair must leave no virtualref open at the loop header",
         );
 
         let tree_loop = ctx.into_tree_loop();
@@ -3539,12 +3537,12 @@ mod portal_frame_chain_tests {
                 // `frame.f_backref = self.topframeref`
                 OpCode::GetfieldGcR,
                 OpCode::SetfieldGc,
-                // `self.topframeref = jit.virtual_ref(frame)`, whose
-                // interpreter-level reading is the frame pointer itself
+                OpCode::VirtualRefR,
                 OpCode::SetfieldGc,
                 // `self.topframeref = frame.f_backref`
                 OpCode::GetfieldGcR,
                 OpCode::SetfieldGc,
+                OpCode::VirtualRefFinish,
             ],
         );
     }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1072,7 +1072,16 @@ pub extern "C" fn jit_force_callee_frame(frame_ptr: i64) -> i64 {
 
     // `assembler_call_helper` (warmspot.py) resumes the callee
     // frame the rewritten CALL_ASSEMBLER passed as arg 0.
-    run_frame_through_portal(frame_ptr)
+    run_frame_through_portal(frame_ptr, PortalEntry::Resume)
+}
+
+#[derive(Clone, Copy)]
+enum PortalEntry {
+    /// `ll_portal_runner`: compiled code owns the EC vref bracket and this
+    /// door supplies the activation's hook/recursion bracket.
+    TracedActivation,
+    /// `portal_ptr`: continue the body of an activation already in progress.
+    Resume,
 }
 
 /// warmspot.py `ll_portal_runner` core — run the frame the JIT handed
@@ -1091,7 +1100,7 @@ pub extern "C" fn jit_force_callee_frame(frame_ptr: i64) -> i64 {
 /// Rebuilding a frame here instead would drop the callee's arguments (its
 /// locals array) and its `last_instr`, and would run the interpreter on a
 /// frame that dies with the C stack.
-fn run_frame_through_portal(frame_ptr: i64) -> i64 {
+fn run_frame_through_portal(frame_ptr: i64, entry: PortalEntry) -> i64 {
     // `jit_drop_callee_frame` tolerates a tagged word on the same slot because
     // it only unroots; there is nothing sensible to run here for one. The
     // portal's result is a Ref whose NULL spelling means "exception stored",
@@ -1102,29 +1111,14 @@ fn run_frame_through_portal(frame_ptr: i64) -> i64 {
         "CALL_ASSEMBLER arg 0 must be the callee PyFrame"
     );
     let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
-    // `ll_portal_runner` is an activation entry: it charges recursion,
-    // installs the frame, and consults function-entry warmstate, and that last
-    // step can run the very compiled function whose call arrived here.  When
-    // the frame handed over is the one this thread is already running, that is
-    // a second activation of one frame, and the compiled body reaching this
-    // call again opens a third: the nesting grows until the stack check
-    // raises, leaving the frame's `next_instr` past operands no activation
-    // pushed.  `warmspot.py handle_jitexception` draws the same distinction
-    // when it calls `portal_ptr` instead of `ll_portal_runner`; resume the
-    // body of the activation that already exists.
-    //
-    // `CURRENT_FRAME` is the test, not the `topframeref` chain: the trace
-    // records `ExecutionContext.enter` for the callee frame it builds, so a
-    // legitimately fresh callee IS the chain's top by the time it gets here,
-    // while only an interpreter or portal activation installs `CURRENT_FRAME`.
-    let already_running = std::ptr::eq(
-        pyre_interpreter::eval::current_frame(),
-        frame as *mut PyFrame,
-    );
-    let outcome = if already_running {
-        crate::eval::portal_body_result(frame)
-    } else {
-        crate::eval::portal_activation_result(frame)
+    // `warmspot.py` has two distinct functions: `ll_portal_runner` begins the
+    // portal call and `portal_ptr` resumes its body from CRN/force handoff.
+    // Keep that decision at the caller that knows which function it is
+    // invoking; CURRENT_FRAME is an extra pyre TLS root, not activation
+    // identity, and is neither complete nor stable enough to choose the door.
+    let outcome = match entry {
+        PortalEntry::TracedActivation => crate::eval::portal_traced_activation_result(frame),
+        PortalEntry::Resume => crate::eval::portal_body_result(frame),
     };
     let result = match outcome {
         Ok(r) => r,
@@ -1168,7 +1162,24 @@ pub extern "C" fn ll_portal_runner_shim(
         let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
         frame.set_last_instr_from_next_instr(next_instr as usize);
     }
-    run_frame_through_portal(frame_ptr)
+    run_frame_through_portal(frame_ptr, PortalEntry::TracedActivation)
+}
+
+/// `portal_ptr` ABI for concrete continuation of an activation whose prologue
+/// and hook bracket have already run.
+#[majit_macros::jit_may_force]
+pub extern "C" fn portal_resume_shim(
+    next_instr: i64,
+    _is_being_profiled: i64,
+    _pycode: i64,
+    frame_ptr: i64,
+    _ec: i64,
+) -> i64 {
+    if frame_ptr != 0 {
+        let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
+        frame.set_last_instr_from_next_instr(next_instr as usize);
+    }
+    run_frame_through_portal(frame_ptr, PortalEntry::Resume)
 }
 
 /// warmspot.py — assembler_call_helper.
@@ -2496,13 +2507,11 @@ fn leave_resumed_blackhole_frame(
 }
 
 /// `executioncontext.py ExecutionContext.leave`'s frame-chain half for a frame
-/// whose body ran as compiled code, shared by the blackhole resume above and by
-/// the JIT portal's own activation bracket
-/// (`eval::portal_activation_bracketed`).
+/// resumed by the blackhole interpreter after compiled code has gone away.
 ///
-/// Both close a scope whose `enter` ran somewhere the interpreter's `leave`
-/// never reaches, and both run once the compiled frame is gone — which is what
-/// makes this a narrower operation than `leave`'s own escape branch:
+/// It closes a scope whose `enter` ran somewhere the interpreter's `leave`
+/// never reaches, once the compiled frame is gone.  That is what makes this a
+/// narrower recovery operation than `leave` itself:
 ///
 /// * The identity guard. `leave` reads `frame_vref` off `topframeref` and
 ///   forces it; that word only names this frame while its scope is the open
@@ -2540,10 +2549,6 @@ fn leave_resumed_blackhole_frame(
 /// measured on a residual callee whose frame escapes into a traceback and which
 /// returns NORMALLY under an inlined caller.
 ///
-/// The `topframeref` restore is idempotent for the portal, whose
-/// `CurrentFrameGuard` writes back the same word from a shadow-stack slot when
-/// it drops: `install_current_frame` seeds `f_backref` from the `topframeref`
-/// it displaces, so the two agree by construction.
 fn leave_compiled_frame_chain(frame_ptr: *mut PyFrame, got_exception: bool) {
     let ec =
         pyre_interpreter::call::getexecutioncontext() as *mut pyre_interpreter::PyExecutionContext;
@@ -2576,15 +2581,6 @@ fn leave_compiled_frame_chain(frame_ptr: *mut PyFrame, got_exception: bool) {
             }
         }
     }
-}
-
-/// [`leave_compiled_frame_chain`] for the JIT portal, whose frame is a `&mut`
-/// borrow rather than a blackhole's virtualizable word.
-pub(crate) fn leave_portal_frame_chain(frame: *mut PyFrame, got_exception: bool) {
-    if frame.is_null() {
-        return;
-    }
-    leave_compiled_frame_chain(frame, got_exception);
 }
 
 /// resume.py blackhole_from_resumedata parity:

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2566,6 +2566,31 @@ fn leave_compiled_frame_chain(frame_ptr: *mut PyFrame, got_exception: bool) {
     }
 }
 
+/// The escape-propagation arm of `ExecutionContext.leave`, for the portal
+/// activation whose chain restore is emitted by the compiled trace.
+///
+/// `portal_traced_activation_result` must not call
+/// [`leave_compiled_frame_chain`]: `record_ec_leave_frame_chain` owns the
+/// `topframeref` restore after CALL_ASSEMBLER returns.  It still owes this
+/// independent half of the same upstream `finally`, however.  A frame that
+/// escaped (or raised) forces and marks its caller so a later `f_back` walk
+/// cannot reach a caller virtual reference that was finished unforced.
+pub(crate) fn propagate_portal_frame_escape(frame: *mut PyFrame, got_exception: bool) {
+    if frame.is_null() {
+        return;
+    }
+    unsafe {
+        if (*frame).escaped() || got_exception {
+            // `ExecutionContext.leave`: `f_back = frame.f_backref()`; the
+            // call forces a still-virtual caller before marking it escaped.
+            let f_back = (*frame).get_f_back();
+            if !f_back.is_null() {
+                (*f_back).mark_as_escaped();
+            }
+        }
+    }
+}
+
 /// resume.py blackhole_from_resumedata parity:
 /// Decode rd_numb via ResumeDataDirectReader, build blackhole chain,
 /// run _run_forever.

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1165,23 +1165,6 @@ pub extern "C" fn ll_portal_runner_shim(
     run_frame_through_portal(frame_ptr, PortalEntry::TracedActivation)
 }
 
-/// `portal_ptr` ABI for concrete continuation of an activation whose prologue
-/// and hook bracket have already run.
-#[majit_macros::jit_may_force]
-pub extern "C" fn portal_resume_shim(
-    next_instr: i64,
-    _is_being_profiled: i64,
-    _pycode: i64,
-    frame_ptr: i64,
-    _ec: i64,
-) -> i64 {
-    if frame_ptr != 0 {
-        let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
-        frame.set_last_instr_from_next_instr(next_instr as usize);
-    }
-    run_frame_through_portal(frame_ptr, PortalEntry::Resume)
-}
-
 /// warmspot.py — assembler_call_helper.
 ///
 /// Called when CALL_ASSEMBLER guard-fails (not a finish exit).

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -9027,6 +9027,15 @@ fn portal_activation_bracketed(
             (*ec).leaveframe_trace(frame_root.frame() as *mut PyFrame, w_exitvalue)
         },
     };
+    // The compiled trace owns only the raw `topframeref` restore.  Preserve
+    // `ExecutionContext.leave`'s separate escape-propagation arm even when the
+    // profile hook above raised: upstream puts both in the same `finally`.
+    if matches!(leave_owner, PortalLeaveOwner::CompiledTrace) {
+        crate::call_jit::propagate_portal_frame_escape(
+            frame_root.frame() as *mut PyFrame,
+            outer_result.is_err(),
+        );
+    }
     let live = leave_result?;
     outer_result.map(|_| live)
 }
@@ -14600,6 +14609,11 @@ mod tests {
     /// absent (the supported test-stub representation).
     #[test]
     fn pycode_green_keys_preserve_wrapper_identity() {
+        // `w_code_new` is a GC allocation.  Tests run in parallel, so another
+        // worker may already have installed the process-global object hooks;
+        // enter this worker through the same per-thread runtime/GIL bootstrap
+        // as production before allocating.
+        init_gc_subsystem();
         let w_code = pyre_interpreter::pycode::w_code_new(std::ptr::null());
         assert!(!w_code.is_null());
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -193,8 +193,8 @@ fn pyre_object_gc_finalizer_next_dead_trampoline(fq_index: usize) -> pyre_object
 /// Caller must keep `slot` valid until
 /// [`pyre_object_gc_remove_root_trampoline`] is called with the same
 /// pointer.
-unsafe fn pyre_object_gc_add_root_trampoline(slot: *mut *mut u8) {
-    unsafe { majit_gc::gc_add_root(slot as *mut majit_ir::GcRef) };
+unsafe fn pyre_object_gc_add_root_trampoline(slot: *mut *mut u8) -> bool {
+    unsafe { majit_gc::gc_add_root(slot as *mut majit_ir::GcRef) }
 }
 
 /// Companion to [`pyre_object_gc_add_root_trampoline`].
@@ -5462,7 +5462,6 @@ fn build_jit_driver_pair() -> JitDriverPair {
     jd.result_type = majit_ir::Type::Ref;
     jd.virtualizable_info = Some(info.clone());
     jd.portal_runner_adr = crate::call_jit::ll_portal_runner_shim as *const () as i64;
-    jd.portal_ptr_adr = crate::call_jit::portal_resume_shim as *const () as i64;
     d.meta_interp_mut().register_jitdriver_sd(jd);
     // baseobjspace.py `unpackiterable_driver = JitDriver(greens=['greenkey'],
     // reds='auto', ...)` — the second portal driver (jd1) for the
@@ -9374,10 +9373,10 @@ pub(crate) fn portal_activation_result(frame: &mut PyFrame) -> PyResult {
 /// code around CALL_ASSEMBLER.
 ///
 /// This is the `ll_portal_runner` door for the full-body walker's recursive
-/// call.  `record_ec_enter_frame_chain` has already published the frame vref;
-/// install only pyre's extra TLS root, then supply `execute_frame`'s hook
-/// bracket.  The compiled continuation records the matching chain restore and
-/// `virtual_ref_finish` after the call returns.
+/// call.  `record_ec_enter_frame_chain` has already published the callee in
+/// `topframeref`; install only pyre's extra TLS root, then supply
+/// `execute_frame`'s hook bracket.  The compiled continuation records the
+/// matching chain restore after the call returns.
 pub(crate) fn portal_traced_activation_result(frame: &mut PyFrame) -> PyResult {
     let _recursion_depth = pyre_interpreter::call::enter_recursive_frame(frame);
     let mut frame_root = FrameRoot::new(frame);

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -202,11 +202,6 @@ fn pyre_object_gc_remove_root_trampoline(slot: *mut *mut u8) {
     majit_gc::gc_remove_root(slot as *mut majit_ir::GcRef);
 }
 
-struct FrameLocalsRoot {
-    slot: *mut *mut u8,
-    registered: bool,
-}
-
 /// A forwarding root for the red `frame` argument while native JIT glue is
 /// active.  `PyFrame.dispatch` keeps this identity as a GC reference; Rust
 /// callback parameters are raw addresses and must be reloaded after a moving
@@ -269,22 +264,6 @@ impl FrameRoot {
 impl Drop for FrameRoot {
     fn drop(&mut self) {
         self.release();
-    }
-}
-
-impl FrameLocalsRoot {
-    fn new(frame: &mut PyFrame) -> Self {
-        let slot = &mut frame.locals_cells_stack_w as *mut _ as *mut *mut u8;
-        let registered = unsafe { pyre_object::gc_hook::try_gc_add_root(slot) };
-        Self { slot, registered }
-    }
-}
-
-impl Drop for FrameLocalsRoot {
-    fn drop(&mut self) {
-        if self.registered {
-            pyre_object::gc_hook::try_gc_remove_root(self.slot);
-        }
     }
 }
 
@@ -5483,6 +5462,7 @@ fn build_jit_driver_pair() -> JitDriverPair {
     jd.result_type = majit_ir::Type::Ref;
     jd.virtualizable_info = Some(info.clone());
     jd.portal_runner_adr = crate::call_jit::ll_portal_runner_shim as *const () as i64;
+    jd.portal_ptr_adr = crate::call_jit::portal_resume_shim as *const () as i64;
     d.meta_interp_mut().register_jitdriver_sd(jd);
     // baseobjspace.py `unpackiterable_driver = JitDriver(greens=['greenkey'],
     // reds='auto', ...)` — the second portal driver (jd1) for the
@@ -8915,7 +8895,18 @@ fn eval_with_jit_inner(
     //
     // portal_ptr = eval_loop_jit at depth 0 (has jit_merge_point +
     // can_enter_jit back-edge), plain interpreter at depth > 0.
-    portal_activation_bracketed(&mut frame_root, resume)
+    portal_activation_bracketed(&mut frame_root, resume, PortalLeaveOwner::ExecutionContext)
+}
+
+#[derive(Clone, Copy)]
+enum PortalLeaveOwner {
+    /// The helper entered the execution-context chain and therefore owes the
+    /// complete `ExecutionContext.leave` finally.
+    ExecutionContext,
+    /// Compiled code recorded `ExecutionContext.enter` before calling the
+    /// portal and records the matching leave after it returns.  This helper
+    /// owns only the hook bracket that pyre's higher portal boundary skipped.
+    CompiledTrace,
 }
 
 /// `pyframe.py execute_frame`'s hook bracket around [`portal_runner_dispatch`],
@@ -8961,6 +8952,7 @@ fn eval_with_jit_inner(
 fn portal_activation_bracketed(
     frame_root: &mut FrameRoot,
     resume: Option<&mut pyre_interpreter::call::FrameResumeArgs>,
+    leave_owner: PortalLeaveOwner,
 ) -> PyResult {
     let ec = pyre_interpreter::call::getexecutioncontext() as *mut PyExecutionContext;
     if ec.is_null() {
@@ -9017,32 +9009,25 @@ fn portal_activation_bracketed(
             }
         }
     };
-    // `setprofile`'s `return` is not `return_trace`'s — that one tests
-    // `gettrace() is not None`.  It comes from `executioncontext.py leave`,
-    // whose profile arm runs `_trace(frame, 'leaveframe', w_exitvalue)`, and
-    // this arm never reaches `leave`: the declining paths return through
-    // `execute_frame_plain`, which does, and the portal arms do not.
-    let leave_result =
-        unsafe { (*ec).leaveframe_trace(frame_root.frame() as *mut PyFrame, w_exitvalue) };
-    // `leave`'s frame-chain half, which the portal owed as much as the hook.  It
-    // is the `finally` of `leave`'s own `try`, so a profile hook that raised
-    // does not skip it, and it runs while `topframeref` still names this frame.
-    //
-    // The narrow form, not `leave`'s own: this closes a scope whose body ran as
-    // compiled code, so it is the same situation as a blackhole resume and is
-    // shared with it.  `leave_compiled_frame_chain` states why the identity
-    // guard and the absence of a force are load-bearing there.
-    //
-    // `got_exception` is `execute_frame`'s flag: false only when the body AND
-    // `return_trace` both completed, which is exactly `outer_result.is_ok()`.
-    // Without this a compiled frame that left escaped, or with an exception,
-    // returns to a caller that was never marked escaped — and `escaped()` is
-    // what the walker reads to decide whether that caller has to be
-    // materialised.
-    crate::call_jit::leave_portal_frame_chain(
-        frame_root.frame() as *mut PyFrame,
-        outer_result.is_err(),
-    );
+    // `setprofile`'s `return` comes from `ExecutionContext.leave`, not from
+    // `return_trace`.  A normal portal activation owns that complete finally:
+    // topframeref restore, caller escape propagation, force_vref and
+    // virtual_ref_finish included.  The compiled self-recursive fold is the
+    // one exception: its trace records enter/leave around CALL_ASSEMBLER, so
+    // this helper supplies the otherwise-skipped hook only and must not close
+    // the trace-owned chain a second time.
+    let leave_result = match leave_owner {
+        PortalLeaveOwner::ExecutionContext => unsafe {
+            (*ec).leave(
+                frame_root.frame() as *mut PyFrame,
+                w_exitvalue,
+                outer_result.is_err(),
+            )
+        },
+        PortalLeaveOwner::CompiledTrace => unsafe {
+            (*ec).leaveframe_trace(frame_root.frame() as *mut PyFrame, w_exitvalue)
+        },
+    };
     let live = leave_result?;
     outer_result.map(|_| live)
 }
@@ -9380,9 +9365,25 @@ pub(crate) fn portal_activation_result(frame: &mut PyFrame) -> PyResult {
     /// resume payload: `execute_frame`'s `w_arg_or_err` is `None` and the
     /// bracket runs its body straight through.
     fn bracketed_without_resume(frame_root: &mut FrameRoot) -> PyResult {
-        portal_activation_bracketed(frame_root, None)
+        portal_activation_bracketed(frame_root, None, PortalLeaveOwner::ExecutionContext)
     }
     enter_portal(frame, bracketed_without_resume)
+}
+
+/// Activation whose execution-context vref bracket is emitted by compiled
+/// code around CALL_ASSEMBLER.
+///
+/// This is the `ll_portal_runner` door for the full-body walker's recursive
+/// call.  `record_ec_enter_frame_chain` has already published the frame vref;
+/// install only pyre's extra TLS root, then supply `execute_frame`'s hook
+/// bracket.  The compiled continuation records the matching chain restore and
+/// `virtual_ref_finish` after the call returns.
+pub(crate) fn portal_traced_activation_result(frame: &mut PyFrame) -> PyResult {
+    let _recursion_depth = pyre_interpreter::call::enter_recursive_frame(frame);
+    let mut frame_root = FrameRoot::new(frame);
+    frame_root.frame().fix_array_ptrs();
+    let _frame_guard = pyre_interpreter::eval::install_current_frame_tls_only(frame_root.frame());
+    portal_activation_bracketed(&mut frame_root, None, PortalLeaveOwner::CompiledTrace)
 }
 
 /// warmspot.py ll_portal_runner:
@@ -10905,16 +10906,19 @@ fn execute_assembler(
     // one it was given either way.
     let _topframeref_guard = TopFrameRefGuard::new(ec_for_topframeref);
     // warmstate.py:395 func_execute_token(loop_token, *args) → deadframe
-    let outcome = {
-        let _frame_locals_root = FrameLocalsRoot::new(frame_root.frame());
-        driver.run_compiled_detailed_with_bridge_keyed(
-            green_key,
-            entry_pc,
-            &mut jit_state,
-            env,
-            || {},
-        )
-    };
+    // `frame_root` is the translated live `frame` root.  Do not additionally
+    // register `&mut frame.locals_cells_stack_w`: that is an interior address
+    // of a movable nursery PyFrame, so after a collection the root registry
+    // itself points into the evacuated (and debug-poisoned) frame.  PyPy roots
+    // the frame object and lets its type tracer follow the locals-array field;
+    // `FrameRoot` plus `pyframe_object_custom_trace` is that same ownership.
+    let outcome = driver.run_compiled_detailed_with_bridge_keyed(
+        green_key,
+        entry_pc,
+        &mut jit_state,
+        env,
+        || {},
+    );
 
     // Bridges that reached their inline-trip threshold during this run asked
     // for their merge from inside compiled code, where the driver is already
@@ -11196,7 +11200,6 @@ fn compile_and_run_once(
             driver.bound_reached(green_key, target_pc, &mut jit_state, env);
         }
         CompileOnceStart::FunctionEntry => {
-            let _frame_locals_root = FrameLocalsRoot::new(frame_root.frame());
             driver.force_start_tracing(green_key, target_pc, &mut jit_state, env);
         }
     }
@@ -11427,7 +11430,6 @@ fn bound_reached(
     // `EnterJitAssembler(procedure_token, ...)` does with it upstream; the run
     // resolves the key itself, so it is only the pin.
     let outcome = if procedure_token.is_some() {
-        let _frame_locals_root = FrameLocalsRoot::new(frame_root.frame());
         Some(driver.run_compiled_detailed_with_bridge_keyed(
             green_key,
             loop_header_pc,
@@ -11726,16 +11728,13 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
         // callees and exits through the same guards.
         let _topframeref_guard =
             TopFrameRefGuard::new(jit_state.execution_context as *mut PyExecutionContext);
-        let outcome = {
-            let _frame_locals_root = FrameLocalsRoot::new(frame_root.frame());
-            driver.run_compiled_detailed_with_bridge_keyed(
-                green_key,
-                frame_root.frame().next_instr(),
-                &mut jit_state,
-                &env,
-                || {},
-            )
-        };
+        let outcome = driver.run_compiled_detailed_with_bridge_keyed(
+            green_key,
+            frame_root.frame().next_instr(),
+            &mut jit_state,
+            &env,
+            || {},
+        );
         // rstack.stack_check_slowpath → _StackOverflow parity: drain
         // the JIT-overflow flag the backend probe records when it
         // trips during compiled execution at function entry.

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -530,7 +530,9 @@ pub fn try_gc_major_threshold_reached() -> bool {
 /// pass (shadowstack save/restore around safepoints). pyre has no
 /// such pass, so root registration is explicit at the call site.
 /// TODO: this is a known deviation from RPython.
-pub type GcAddRootHookFn = unsafe fn(slot: *mut *mut u8);
+/// Answers `false` when the backend declined the slot, so a caller that
+/// brackets the registration knows not to unregister a root it never took.
+pub type GcAddRootHookFn = unsafe fn(slot: *mut *mut u8) -> bool;
 pub type GcRemoveRootHookFn = fn(slot: *mut *mut u8);
 
 majit_gc::global_hook!(static GC_ADD_ROOT_HOOK: GcAddRootHookFn);
@@ -549,7 +551,9 @@ pub fn clear_gc_root_hooks() {
 }
 
 /// Register `slot` as a live GC root via the installed callback.
-/// Returns `true` when the callback was invoked.
+/// Returns `true` when the slot was registered — the callback both ran and
+/// accepted it.  A backend declines a slot it cannot forward, and the caller's
+/// `Drop` must not answer a decline with a removal.
 ///
 /// # Safety
 /// Caller must keep `slot` valid until [`try_gc_remove_root`] is
@@ -563,10 +567,7 @@ pub fn clear_gc_root_hooks() {
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn try_gc_add_root(slot: *mut *mut u8) -> bool {
     match GC_ADD_ROOT_HOOK.get() {
-        Some(f) => {
-            unsafe { f(slot) };
-            true
-        }
+        Some(f) => unsafe { f(slot) },
         None => false,
     }
 }
@@ -982,8 +983,9 @@ mod tests {
         static REMOVE_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     }
 
-    unsafe fn mock_add_root(slot: *mut *mut u8) {
+    unsafe fn mock_add_root(slot: *mut *mut u8) -> bool {
         LAST_ROOT_PTR.with(|cell| cell.set(slot as usize));
+        true
     }
     fn mock_remove_root(slot: *mut *mut u8) {
         let _ = slot;


### PR DESCRIPTION
Follow-up to #1564, which left two items open and named the blocker for each. Both blockers are gone. The first item ships; the second turned out to be a net loss once it was implementable, so it is measured and withheld rather than shipped, and the number is written into the test that pins the shape. The mechanism that removed the blockers also retired a heuristic #1542 had introduced. Three GC defects found while measuring the result are fixed alongside.

## The portal's two doors are now named, not guessed

`warmspot.py` has two entry points: `ll_portal_runner` begins a portal call, and `portal_ptr` resumes the body of one already in progress — `handle_jitexception` calls the second, not the first. pyre had only the first, so `run_frame_through_portal` decided between them at runtime by testing whether `CURRENT_FRAME` already named the frame it was handed.

That test is not activation identity. `CURRENT_FRAME` is an extra pyre TLS root; it is neither complete nor stable enough to choose a door with. The door is now an argument, supplied by the caller that knows which function it is invoking:

- `ll_portal_runner_shim` → `PortalEntry::TracedActivation`
- `jit_force_callee_frame` (the CALL_ASSEMBLER force) → `PortalEntry::Resume`

`portal_activation_bracketed` takes a `PortalLeaveOwner` to match: an ordinary activation runs the complete `ExecutionContext.leave` (topframeref restore, caller escape propagation, `force_vref` and `virtual_ref_finish` included), while the traced activation supplies only the hook bracket pyre's higher portal boundary skips. `leave_portal_frame_chain` — the narrow recovery form the portal borrowed from the blackhole resume — is gone; the portal calls `leave` itself.

**The residual CALL_ASSEMBLER keeps baking `portal_runner_adr`.** `do_recursive_call` (`pyjitpl.py`) bakes `targetjitdriver_sd.portal_runner_adr` as its funcbox, and `_portal_ptr` is reached from exactly two places upstream — the normal-run leg of `ll_portal_runner` and `handle_jitexception`'s `ContinueRunningNormally` retry — both inside `ll_portal_runner`'s own body, never as a funcbox. Baking the resume address instead looked right while tracing (concrete tracing *does* continue a started activation) but the baked address is what the runtime calls when the callee has no compiled loop yet, through the `compile_tmp_callback` temporary. Sending that call to the resume door skips `maybe_compile_and_run`: the callee never enters the JIT and its frame is forced. Measured, that cost `exc_bridge_entry_guard_not_removed` 802 → 809 guard failures and took `exception_reused_object_tb_not_doubled` from 5 compiled loops to 4 with 3 `loops_aborted` (`abrt_escape=3`). This PR keeps the runner baked; both fixtures sit on their recorded values.

## The CALL_ASSEMBLER portal door's virtual ref: measured, and still withheld

#1564 left this open with a stated blocker — `optimize_VIRTUAL_REF` seeds `forced = NULL`, and both non-forcing readers read that as "not my frame" — and said closing it needed "a signal those doors can decide without forcing, which does not exist yet." `PortalEntry` is that signal, so the vref became implementable. Implemented and measured, it is a net loss, and it is not shipped.

The callee this fold builds is read back through `gettopframe_nohidden`, which is `force_vref`. `locals()` in a self-recursive callee forces on **every** call; an unwind that crosses suspended copies of the frame forces once per crossing. Each force is a `GUARD_NOT_FORCED` failure, and `ResumeGuardForcedDescr.handle_fail` never compiles one — `must_compile` vetoes it and the failure is blackholed.

Publishing the vref moves twelve synthetic fixtures and nothing else:

| direction | fixtures | total |
|---|---|---|
| fewer guard failures | 8, by 1–3 each | −12 |
| more guard failures | `recursive_forced_frame_kept_stack` +273, `selfrec_tail_exception_unwind` +169 | **+442** |

Net **+430 guard failures**, all of them blackholed rather than compiled. `recursive_forced_frame_kept_stack` is `d = locals()` on every call, so its `forced_never_compiled=273` accounts for its delta exactly. The enter therefore keeps publishing the frame pointer, which is what `PyExecutionContext::enter` stores and what `_jit_vref.py`'s `lowleveltype = OBJECTPTR` reads `jit.virtual_ref` as. `the_recorded_enter_and_leave_take_no_virtual_ref` pins that shape with the census as its stated reason, so the next attempt starts from the number rather than from the blocker.

What this leaves open is a sharper question than #1564's: not "can the doors decide without forcing" — they can — but "what makes those `gettopframe_nohidden` forces unnecessary".

## The portal green key is typed at `newframe`

`MetaInterp::newframe` took a bare `u64` and projected it as `(gk, None)`, so `find_biggest_function` could see an entry whose typed half was absent and `disable_noninlinable_function` could record against a hash cell nobody finds. `newframe`, `perform_call` and `MIFrame::greenkey` now carry `PortalGreenKey` end to end.

## Two GC defects the portal measurement surfaced

**An interior root of a movable frame.** `FrameLocalsRoot` registered `&mut frame.locals_cells_stack_w` — an interior address of a `PyFrame` that, when JIT-materialised, lives in the nursery. After a minor collection the root registry points into the evacuated frame, which under `MAJIT_GC_NURSERY_POISON` is filled with `0xAA…`. PyPy roots the frame object and lets its tracer reach the locals array; pyre's `FrameRoot` / `pyframe_object_custom_trace` is that same ownership. `gc_add_root` itself now declines a slot inside the nursery, so every present and future caller is covered by one predicate rather than a test repeated per call site; `pyre-jit`'s own copy of `FrameLocalsRoot` is removed at both call sites.

That decline needed a way back to the caller. `GcAddRootHookFn` returned unit, so `try_gc_add_root` reported `true` for a registration that never happened, and each `FrameLocalsRoot` over a nursery frame answered its own decline with a `try_gc_remove_root` that reaches `RootSet::remove`'s full `rposition` scan. The hook returns the backend's verdict now, and `registered` means what it says.

The explicit frame walker stopped short of PyPy's root contract for the same reason: it followed `f_backref` through collector-owned frames during `collect_roots_in_nursery`, when only direct roots have been forwarded, so it could observe a callee `PyFrame` still named by a pre-forward CALL_ASSEMBLER jitframe slot. `walk_pyframe_roots_area` now stops at a GC-managed frame and lets the type tracer follow its fields from the survivor copy; only the header-prefixed `std::alloc` fallback chain continues.

The same rule has two more holders. `VirtualizableInfo::push_resume_ref_roots` registered the interior address of every vable array field; it now declines for a nursery virtualizable. And `ResumeDataDirectReader` rooted `virtualizable_ptr` only after `consume_vref_and_vable` returned, while `consume_vable_info` allocates before that — `write_from_resume_data_partial` restores fields and a nursery `PyFrame` can move during the restore — so the root is taken inside `consume_vable_info`, before any field is exposed. `push_resume_ref_roots` itself now refuses a slice pointing into the nursery, and in poison mode one that already holds the poison word, naming the caller with `#[track_caller]`.

**An uninitialized CALL_ASSEMBLER result slot.** `MIFrame.get_list_of_active_boxes(in_a_call)` clears the not-yet-defined result register before a suspended caller is snapshotted. `GUARD_NOT_FORCED`'s async path observes that caller while CALL_ASSEMBLER is still running, before the result register holds anything, and `AbstractLLCPU.force` only switches `jf_descr` — it cannot save the caller's hardware registers. The result's jitframe slot is now seeded with the same null placeholder before the call, on **both** dynasm backends; a normal return overwrites it and any later guard stub saves the real value as usual.

`address_of_the_vable_array_slot_is_marked_not_a_read` fired its own "no longer exercising anything" tripwire against the first of these: it matched the `try_gc_add_root` argument against the `addr_of_mut!` projection's `Variable`, and the short-circuit test moved the call into a later block, where the slot arrives freshened (`flowcontext.py newstate = state.copy()`). The test follows link arguments into the target block's `inputargs` now. That is a re-aiming, not a relaxation, and the distinction was measured rather than assumed: once the shape is found again, `taken_by_address` and `suppresses_virtualizable()` both still hold, so the marking never moved.

## Opcode anchors

`SharedOpcodeHandler::anchor` / `push_anchored` exist so an opcode that allocates and then pushes lands the result on the relocated handler rather than the abandoned copy. `eval.rs`'s own opcode implementations use them throughout; the *shared* helpers in `shared_opcode.rs` and `pyopcode.rs` — the ones the JIT-side handler drives as well — used them at zero sites. Seventeen sites across thirteen helpers now do: `GET_ITER`, `UNARY_NOT`, `UNARY_NEGATIVE`, `UNARY_INVERT`, `BINARY_OP`, `COMPARE_OP`, `MAKE_FUNCTION`, `CALL` (all five arities), `BUILD_LIST`, `BUILD_TUPLE`, `BUILD_MAP`, `UNPACK_SEQUENCE` and `LOAD_ATTR`.

## Verification

`cargo fmt --all -- --check`, `scripts/check-majit-boundary.py`,
`python3 scripts/extract-llbc.py`, `cargo test --all --no-default-features --features dynasm`
and `python3 pyre/check.py` are all green on this tree:

```
ALL PASSED: dynasm 516/516
ALL PASSED: cranelift 516/516
ALL PASSED: wasm 509/509
ALL PASSED: 3/3 backend run(s)
```

No `.jitstats` baseline is re-recorded. The twelve fixtures the intermediate state
moved are back on their committed values because the two causes were removed, not
because the record was moved to meet them.

The x86 half of the result-slot seeding is a line-for-line mirror of the aarch64 one — the two
`deadframe_slot_for_loc` helpers are byte-identical — but this host is arm64 and
`majit-backend-dynasm`'s `x86` module is `#[cfg(target_arch = "x86_64")]`, so the local gate never
assembles it. It is verified by `cargo check -p majit-backend-dynasm --target x86_64-apple-darwin`,
which is what expands the `dynasm!` macro and validates the encoding; CI's `ubuntu-24.04` and
`windows-latest` legs are its first execution test.
