### PR TITLE
jit: split eval_loop_jit at its jit_merge_point behind PYRE_PORTAL_SPLIT, and reload the frame through the caller's shadow-stack root

### DIFF
--- a/majit/majit-charon-reader/examples/census_zst.rs
+++ b/majit/majit-charon-reader/examples/census_zst.rs
@@ -17,7 +17,7 @@
 //! ```
 use majit_charon_reader::{
     Llbc,
-    ullbc::{Rvalue, StmtKind, TypeDecl, TypeDeclKind, TyRef},
+    ullbc::{Rvalue, StmtKind, TyRef, TypeDecl, TypeDeclKind},
 };
 use serde_json::Value;
 use std::collections::BTreeSet;
@@ -76,9 +76,7 @@ fn main() {
 
     for td in llbc.file.translated.type_decls.iter().flatten() {
         total += 1;
-        let is_zero_sized = td
-            .layout_for_target("")
-            .is_some_and(|l| l.size == Some(0));
+        let is_zero_sized = td.layout_for_target("").is_some_and(|l| l.size == Some(0));
         if !is_zero_sized {
             continue;
         }
@@ -153,7 +151,10 @@ fn main() {
     }
     println!("--- cross-reference: actually constructed ---");
     println!("construction sites (Assign+Aggregate): {construction_sites}");
-    println!("distinct newly-Void types constructed: {}", reached_types.len());
+    println!(
+        "distinct newly-Void types constructed: {}",
+        reached_types.len()
+    );
     for n in &reached_types {
         println!("{n}");
     }

--- a/majit/majit-charon-reader/examples/census_zst.rs
+++ b/majit/majit-charon-reader/examples/census_zst.rs
@@ -1,0 +1,160 @@
+//! Scratch diagnostic — census how many `TypeDecl`s the zero-sized-ADT
+//! arm in `front::mir::tyref_to_value_type` newly turns `Void` (were
+//! `Ref` before), excluding the ones the two existing fieldless-enum
+//! arms already catch.
+//!
+//! Mirrors `tyref_is_zero_sized` / `type_decl_is_fieldless_enum` from
+//! `majit-translate/src/front/mir.rs` against this crate's public API
+//! directly, rather than against a `TyRef` — for a `TyRef` pointing at
+//! `def_id`, `tyref_is_zero_sized` reduces exactly to
+//! `type_by_id(def_id).layout_for_target("").size == Some(0)`, so
+//! checking each `TypeDecl`'s own layout is equivalent and simpler.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --release -p majit-charon-reader --example census_zst -- build/llbc/pyre-jit.ullbc
+//! ```
+use majit_charon_reader::{
+    Llbc,
+    ullbc::{Rvalue, StmtKind, TypeDecl, TypeDeclKind, TyRef},
+};
+use serde_json::Value;
+use std::collections::BTreeSet;
+
+fn inline_adt_def_id(body: &Value) -> Option<u64> {
+    body.as_object()?
+        .get("Adt")?
+        .as_object()?
+        .get("id")?
+        .as_object()?
+        .get("Adt")?
+        .as_u64()
+}
+
+fn tyref_is_zero_sized(ty: &TyRef, llbc: &Llbc) -> bool {
+    let def_id = match ty {
+        TyRef::Inline { value: (_, v) } | TyRef::Other(v) => inline_adt_def_id(v),
+        TyRef::Dedup { id } => llbc.dedup_to_adt_def_id(*id),
+    };
+    def_id
+        .and_then(|def_id| llbc.type_by_id(def_id))
+        .and_then(|td| td.layout_for_target(""))
+        .is_some_and(|layout| layout.size == Some(0))
+}
+
+fn type_decl_is_fieldless_enum(td: &TypeDecl, llbc: &Llbc) -> bool {
+    match &td.kind {
+        TypeDeclKind::Enum(variants) => {
+            !variants.is_empty()
+                && variants
+                    .iter()
+                    .all(|v| v.fields.iter().all(|f| tyref_is_zero_sized(&f.ty, llbc)))
+        }
+        _ => false,
+    }
+}
+
+fn main() {
+    let path = std::env::args().nth(1).unwrap_or_else(|| {
+        eprintln!("usage: census_zst <file.ullbc>");
+        std::process::exit(2);
+    });
+    let llbc = Llbc::load(&path).unwrap_or_else(|e| {
+        eprintln!("error: cannot load {path}: {e}");
+        std::process::exit(1);
+    });
+
+    // Control: a type decl we already know is a fieldless enum
+    // (non-zero size, multi-variant) must NOT appear in the newly-Void
+    // list, and the total type_decls count must be non-zero — proves
+    // the scan is reading real type decls before trusting a 0 result.
+    let mut total = 0usize;
+    let mut zero_sized = 0usize;
+    let mut fieldless_enum_excluded = 0usize;
+    let mut newly_void: Vec<String> = Vec::new();
+
+    for td in llbc.file.translated.type_decls.iter().flatten() {
+        total += 1;
+        let is_zero_sized = td
+            .layout_for_target("")
+            .is_some_and(|l| l.size == Some(0));
+        if !is_zero_sized {
+            continue;
+        }
+        zero_sized += 1;
+        if type_decl_is_fieldless_enum(td, &llbc) {
+            fieldless_enum_excluded += 1;
+            continue;
+        }
+        newly_void.push(td.item_meta.name_path());
+    }
+
+    println!("file:                       {path}");
+    println!("total type_decls:           {total}");
+    println!("zero-sized (any kind):      {zero_sized}");
+    println!("  of which fieldless enum:  {fieldless_enum_excluded} (excluded, unaffected)");
+    println!("newly Void (the count):     {}", newly_void.len());
+    println!(
+        "control — PyreEnv present:  {}",
+        newly_void.iter().any(|n| n.contains("PyreEnv"))
+    );
+    println!("--- distinct types ---");
+    for n in &newly_void {
+        println!("{n}");
+    }
+
+    // Cross-reference against reality: of the newly-Void types, how
+    // many are actually *constructed* anywhere (an `Assign(place,
+    // Rvalue::Aggregate(..))` whose destination type resolves to one
+    // of them)? That's the exact code path the `build_rvalue` fold
+    // touches, so it's the set that can panic downstream — not merely
+    // "declared as a type".
+    let newly_void_def_ids: std::collections::BTreeSet<u64> = llbc
+        .file
+        .translated
+        .type_decls
+        .iter()
+        .flatten()
+        .filter(|td| {
+            td.layout_for_target("").is_some_and(|l| l.size == Some(0))
+                && !type_decl_is_fieldless_enum(td, &llbc)
+        })
+        .map(|td| td.def_id)
+        .collect();
+
+    let mut reached_types: BTreeSet<String> = BTreeSet::new();
+    let mut construction_sites = 0usize;
+    for fd in llbc.iter_local_fns() {
+        let Some(body) = fd.unstructured() else {
+            continue;
+        };
+        for bb in &body.body {
+            for st in &bb.statements {
+                let Ok(StmtKind::Assign(place, rvalue)) = st.stmt_kind() else {
+                    continue;
+                };
+                if !matches!(rvalue, Rvalue::Aggregate(..)) {
+                    continue;
+                }
+                let def_id = match &place.ty {
+                    TyRef::Inline { value: (_, v) } | TyRef::Other(v) => inline_adt_def_id(v),
+                    TyRef::Dedup { id } => llbc.dedup_to_adt_def_id(*id),
+                };
+                let Some(def_id) = def_id else { continue };
+                if newly_void_def_ids.contains(&def_id) {
+                    construction_sites += 1;
+                    if let Some(td) = llbc.type_by_id(def_id) {
+                        reached_types.insert(td.item_meta.name_path());
+                    }
+                }
+            }
+        }
+    }
+    println!("--- cross-reference: actually constructed ---");
+    println!("construction sites (Assign+Aggregate): {construction_sites}");
+    println!("distinct newly-Void types constructed: {}", reached_types.len());
+    for n in &reached_types {
+        println!("{n}");
+    }
+}

--- a/majit/majit-charon-reader/examples/census_zst.rs
+++ b/majit/majit-charon-reader/examples/census_zst.rs
@@ -3,12 +3,10 @@
 //! `Ref` before), excluding the ones the two existing fieldless-enum
 //! arms already catch.
 //!
-//! Mirrors `tyref_is_zero_sized` / `type_decl_is_fieldless_enum` from
-//! `majit-translate/src/front/mir.rs` against this crate's public API
-//! directly, rather than against a `TyRef` — for a `TyRef` pointing at
-//! `def_id`, `tyref_is_zero_sized` reduces exactly to
-//! `type_by_id(def_id).layout_for_target("").size == Some(0)`, so
-//! checking each `TypeDecl`'s own layout is equivalent and simpler.
+//! Mirrors the zero-sized and fieldless-enum classifications from
+//! `majit-translate/src/front/mir.rs` against this crate's public API directly.
+//! Checking each `TypeDecl`'s own layout is equivalent to resolving a `TyRef`
+//! to that declaration and is simpler for a whole-artefact census.
 //!
 //! Run with:
 //!
@@ -32,24 +30,14 @@ fn inline_adt_def_id(body: &Value) -> Option<u64> {
         .as_u64()
 }
 
-fn tyref_is_zero_sized(ty: &TyRef, llbc: &Llbc) -> bool {
-    let def_id = match ty {
-        TyRef::Inline { value: (_, v) } | TyRef::Other(v) => inline_adt_def_id(v),
-        TyRef::Dedup { id } => llbc.dedup_to_adt_def_id(*id),
-    };
-    def_id
-        .and_then(|def_id| llbc.type_by_id(def_id))
-        .and_then(|td| td.layout_for_target(""))
-        .is_some_and(|layout| layout.size == Some(0))
-}
-
-fn type_decl_is_fieldless_enum(td: &TypeDecl, llbc: &Llbc) -> bool {
+fn type_decl_is_fieldless_enum(td: &TypeDecl) -> bool {
     match &td.kind {
+        // The census distinguishes syntactically fieldless variants from
+        // variants whose fields happen to be zero-sized.  The latter belong
+        // in `newly_void`; folding them into this exclusion undercounts the
+        // exact construction/parameter surface this diagnostic measures.
         TypeDeclKind::Enum(variants) => {
-            !variants.is_empty()
-                && variants
-                    .iter()
-                    .all(|v| v.fields.iter().all(|f| tyref_is_zero_sized(&f.ty, llbc)))
+            !variants.is_empty() && variants.iter().all(|v| v.fields.is_empty())
         }
         _ => false,
     }
@@ -81,7 +69,7 @@ fn main() {
             continue;
         }
         zero_sized += 1;
-        if type_decl_is_fieldless_enum(td, &llbc) {
+        if type_decl_is_fieldless_enum(td) {
             fieldless_enum_excluded += 1;
             continue;
         }
@@ -116,7 +104,7 @@ fn main() {
         .flatten()
         .filter(|td| {
             td.layout_for_target("").is_some_and(|l| l.size == Some(0))
-                && !type_decl_is_fieldless_enum(td, &llbc)
+                && !type_decl_is_fieldless_enum(td)
         })
         .map(|td| td.def_id)
         .collect();

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -726,6 +726,20 @@ pub fn shadow_stack_slot() -> ShadowStackSlot {
     ShadowStackSlot(SHADOW_STACK.with(|ss| ss as *const _))
 }
 
+/// The slot handle and the index of the top entry, from one thread-local
+/// resolve.
+///
+/// The caller guarantees a non-empty stack: the top entry is a root some
+/// enclosing owner pushed and has not yet popped.
+#[inline]
+pub fn top() -> (ShadowStackSlot, usize) {
+    SHADOW_STACK.with(|ss| {
+        let len = ss.borrow().entries.len();
+        assert!(len > 0, "shadow stack empty");
+        (ShadowStackSlot(ss as *const _), len - 1)
+    })
+}
+
 /// Get a GcRef at `index` through a previously resolved [`ShadowStackSlot`].
 ///
 /// # Safety

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -740,6 +740,17 @@ pub fn top() -> (ShadowStackSlot, usize) {
     })
 }
 
+/// Get the top GcRef through one thread-local resolve and one borrow.
+#[inline]
+pub fn top_ref() -> GcRef {
+    SHADOW_STACK.with(|ss| {
+        let ss = ss.borrow();
+        let len = ss.entries.len();
+        debug_assert!(len > 0, "shadow stack empty");
+        ss.entries[len - 1]
+    })
+}
+
 /// Get a GcRef at `index` through a previously resolved [`ShadowStackSlot`].
 ///
 /// # Safety

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -2105,8 +2105,8 @@ mod tests {
         let mut cache = gc_cache()
             .lock()
             .expect("test GC cache must not be poisoned");
-        cache._cache_size.remove(&LLType::Struct(key));
-        cache._cache_array.remove(&LLType::Array(key));
+        cache._cache_size.shift_remove(&LLType::Struct(key));
+        cache._cache_array.shift_remove(&LLType::Array(key));
     }
 
     #[test]

--- a/majit/majit-translate/src/codegen.rs
+++ b/majit/majit-translate/src/codegen.rs
@@ -168,6 +168,7 @@ mod tests {
             functions: Vec::new(),
             jit_drivers: vec![crate::pipeline::CompiledJitDriver {
                 portal: crate::CallPath::from_segments(["engine", "mainloop"]),
+                portal_runner: None,
                 main_jitcode_index: 0,
                 greens: Vec::new(),
                 reds: Vec::new(),

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -2542,7 +2542,18 @@ impl Assembler {
                     argcodes.push(kind_char);
                     operand_kinds.push(kind_char);
                 }
-                if let Some(result) = op.result.as_ref() {
+                // A result Variable's declared `concretetype` can be
+                // `Void` here for the same reason `emit_call_result_arg`
+                // guards it: `getkind(op.result.concretetype)` is the
+                // obligation `flatten.py`'s `serialize_op` enforces, and
+                // this default arm has no declared-kind side to consult
+                // at all, so it must ask the Variable directly. A Void
+                // result has no register to color; skip the `>` argcode
+                // rather than let `lookup_reg_with_kind_var` reach it.
+                if let Some(result) = op.result.as_ref()
+                    && crate::model::FunctionGraph::concretetype_of(result)
+                        != crate::model::ConcreteType::Void
+                {
                     argcodes.push('>');
                     let (reg, kind_char) = self.lookup_reg_with_kind_var(result, regallocs);
                     argcodes.push(kind_char);
@@ -2654,6 +2665,18 @@ impl Assembler {
         let Some(result) = result else {
             return declared_result_kind;
         };
+        // `declared_result_kind` is the call target's declared signature
+        // and can disagree with the result Variable's own `concretetype`
+        // (e.g. a synthetic ctor's `result_ty` staying `Ref` for a
+        // destination type that resolves to `Void`). `getkind(op.result.
+        // concretetype)` is the obligation `flatten.py`'s `serialize_op`
+        // enforces on the Variable, not the declared kind, so check it
+        // directly: a Void Variable has no register to color and must
+        // not reach `lookup_coloring_var`.
+        if crate::model::FunctionGraph::concretetype_of(result) == crate::model::ConcreteType::Void
+        {
+            return 'v';
+        }
         argcodes.push('>');
         let (reg, kind) = self.lookup_coloring_var(result, regallocs);
         let kind_char = match kind {

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -551,6 +551,10 @@ pub struct JitDriverStaticData {
     pub red_types: Vec<String>,
     /// Portal graph path.
     pub portal_graph: CallPath,
+    /// `warmspot.py jd.portal_runner_ptr`: the synthetic helper that owns
+    /// recursive portal entry.  It is deliberately distinct from both the
+    /// split portal graph and the graph containing the original merge point.
+    pub portal_runner: Option<CallPath>,
     /// `warmspot.py split_graph_and_record_jitdriver`: graph containing the
     /// marker before the split portal copy was made.
     pub jit_merge_point_in: CallPath,
@@ -3275,6 +3279,7 @@ impl CallControl {
     /// with no green/red layout. Used by tests that need a portal without a
     /// full driver registration; production seeds via `setup_jitdriver`.
     pub fn mark_portal(&mut self, path: CallPath) {
+        let index = self.jitdrivers_sd.len();
         self.setup_jitdriver(
             path.clone(),
             Vec::new(),
@@ -3284,8 +3289,12 @@ impl CallControl {
             false,
             Vec::new(),
             Vec::new(),
-            path,
+            path.clone(),
         );
+        // Test-only shorthand: production warmspot attaches a distinct
+        // synthetic runner after splitting, but callers of `mark_portal`
+        // explicitly provide the target they want classified recursive.
+        self.set_jitdriver_portal_runner(index, Some(path));
     }
 
     /// `codewriter.py CodeWriter.setup_vrefinfo(self, vrefinfo)`.
@@ -3365,6 +3374,7 @@ impl CallControl {
             virtualizables,
             red_types,
             portal_graph,
+            portal_runner: None,
             jit_merge_point_in,
             mainjitcode: None,
             index_of_virtualizable: -1,
@@ -3381,6 +3391,15 @@ impl CallControl {
         if let Some(jd) = self.jitdrivers_sd.get_mut(index) {
             jd.active = active;
         }
+    }
+
+    /// Attach `warmspot.py jd.portal_runner_ptr` after driver creation.
+    ///
+    /// Warmspot creates this helper after the portal graph has been split;
+    /// keeping the assignment separate mirrors that construction order and
+    /// prevents graph identity from standing in for runner identity.
+    pub fn set_jitdriver_portal_runner(&mut self, index: usize, runner: Option<CallPath>) {
+        self.jitdrivers_sd[index].portal_runner = runner;
     }
 
     /// warmspot.py `jd.virtualizable_info = vinfos[VTYPEPTR]`.
@@ -3629,14 +3648,18 @@ impl CallControl {
 
     /// call.py `jitdriver_sd_from_portal_runner_ptr(funcptr)`.
     ///
-    /// Pyre has no separate `portal_runner_ptr` (the runner is the
-    /// portal graph itself), so we reuse the path lookup.  Future
-    /// phases that need the distinction can split the field.
     pub fn jitdriver_sd_from_portal_runner_ptr(
         &self,
         path: &CallPath,
     ) -> Option<&JitDriverStaticData> {
-        self.jitdriver_sd_from_portal_graph(path)
+        self.jitdrivers_sd
+            .iter()
+            .find(|sd| sd.portal_runner.as_ref() == Some(path))
+    }
+
+    /// `call.py jitdriver_sd_from_portal_runner_ptr(funcptr) is not None`.
+    fn is_portal_recursive_call(&self, path: &CallPath) -> bool {
+        self.jitdriver_sd_from_portal_runner_ptr(path).is_some()
     }
 
     /// call.py `jitdriver_sd_from_jitdriver(jitdriver)`.
@@ -4026,10 +4049,7 @@ impl CallControl {
                             };
                             // `call.py:119-120`
                             // jitdriver_sd_from_portal_runner_ptr → recursive.
-                            if self.jitdrivers_sd.iter().any(|jd| {
-                                jd.portal_graph == callee_path
-                                    || jd.jit_merge_point_in == callee_path
-                            }) {
+                            if self.is_portal_recursive_call(&callee_path) {
                                 // Not a refusal — the portal is already a
                                 // candidate and re-walking it would loop —
                                 // but recorded so the BFS's skip rows add up
@@ -4578,11 +4598,7 @@ impl CallControl {
             let path = self.target_to_path(target);
             if let Some(ref p) = path {
                 // call.py jitdriver_sd_from_portal_runner_ptr(funcptr)
-                if self
-                    .jitdrivers_sd
-                    .iter()
-                    .any(|jd| &jd.portal_graph == p || &jd.jit_merge_point_in == p)
-                {
+                if self.is_portal_recursive_call(p) {
                     return CallKind::Recursive;
                 }
                 // call.py:129-134 _gctransformer_hint_close_stack_ → 'residual'
@@ -9800,6 +9816,42 @@ mod tests {
             cc.guess_call_kind(&direct_call_op(target)),
             CallKind::Recursive
         );
+    }
+
+    #[test]
+    fn only_portal_runner_identity_is_recursive() {
+        let mut cc = CallControl::new();
+        let portal = CallPath::from_segments(["fixture", "eval_loop_jit_portal"]);
+        let original = CallPath::from_segments(["fixture", "eval_loop_jit"]);
+        let runner = CallPath::from_segments(["call_jit", "ll_portal_runner_shim"]);
+        cc.setup_jitdriver(
+            portal.clone(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            false,
+            Vec::new(),
+            Vec::new(),
+            original.clone(),
+        );
+        cc.set_jitdriver_portal_runner(0, Some(runner.clone()));
+
+        assert_eq!(
+            cc.guess_call_kind(&direct_call_op(CallTarget::function_path(
+                runner.segments.clone()
+            ))),
+            CallKind::Recursive
+        );
+        for non_runner in [portal, original] {
+            assert_ne!(
+                cc.guess_call_kind(&direct_call_op(CallTarget::function_path(
+                    non_runner.segments
+                ))),
+                CallKind::Recursive,
+                "portal graph identities must not stand in for portal_runner_ptr"
+            );
+        }
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -551,6 +551,9 @@ pub struct JitDriverStaticData {
     pub red_types: Vec<String>,
     /// Portal graph path.
     pub portal_graph: CallPath,
+    /// `warmspot.py split_graph_and_record_jitdriver`: graph containing the
+    /// marker before the split portal copy was made.
+    pub jit_merge_point_in: CallPath,
     /// RPython: `jd.mainjitcode` (call.py:147) — `Arc<JitCode>` shell for
     /// the portal. Set by `grab_initial_jitcodes()`. Matches the
     /// metainterp-side `JitDriverStaticData.mainjitcode` shape so the
@@ -3273,7 +3276,7 @@ impl CallControl {
     /// full driver registration; production seeds via `setup_jitdriver`.
     pub fn mark_portal(&mut self, path: CallPath) {
         self.setup_jitdriver(
-            path,
+            path.clone(),
             Vec::new(),
             Vec::new(),
             Vec::new(),
@@ -3281,6 +3284,7 @@ impl CallControl {
             false,
             Vec::new(),
             Vec::new(),
+            path,
         );
     }
 
@@ -3330,6 +3334,7 @@ impl CallControl {
         autoreds: bool,
         virtualizables: Vec<String>,
         red_types: Vec<String>,
+        jit_merge_point_in: CallPath,
     ) {
         let index = self.jitdrivers_sd.len();
         debug_assert!(
@@ -3360,6 +3365,7 @@ impl CallControl {
             virtualizables,
             red_types,
             portal_graph,
+            jit_merge_point_in,
             mainjitcode: None,
             index_of_virtualizable: -1,
             virtualizable_info: None,
@@ -4020,11 +4026,10 @@ impl CallControl {
                             };
                             // `call.py:119-120`
                             // jitdriver_sd_from_portal_runner_ptr → recursive.
-                            if self
-                                .jitdrivers_sd
-                                .iter()
-                                .any(|jd| jd.portal_graph == callee_path)
-                            {
+                            if self.jitdrivers_sd.iter().any(|jd| {
+                                jd.portal_graph == callee_path
+                                    || jd.jit_merge_point_in == callee_path
+                            }) {
                                 // Not a refusal — the portal is already a
                                 // candidate and re-walking it would loop —
                                 // but recorded so the BFS's skip rows add up
@@ -4573,7 +4578,11 @@ impl CallControl {
             let path = self.target_to_path(target);
             if let Some(ref p) = path {
                 // call.py jitdriver_sd_from_portal_runner_ptr(funcptr)
-                if self.jitdrivers_sd.iter().any(|jd| &jd.portal_graph == p) {
+                if self
+                    .jitdrivers_sd
+                    .iter()
+                    .any(|jd| &jd.portal_graph == p || &jd.jit_merge_point_in == p)
+                {
                     return CallKind::Recursive;
                 }
                 // call.py:129-134 _gctransformer_hint_close_stack_ → 'residual'
@@ -11276,6 +11285,7 @@ mod tests {
             false,
             vec![],
             vec![],
+            CallPath::from_segments(["portal_runner"]),
         );
         cc
     }
@@ -11312,6 +11322,7 @@ mod tests {
             false,
             vec![],
             vec![],
+            CallPath::from_segments(["portal_runner_b"]),
         );
         cc.jitdrivers_sd[0].virtualizable_info = Some(std::sync::Arc::new(StubVInfo {
             vtypeptr_id: 0xabcd,
@@ -11383,6 +11394,7 @@ mod tests {
             false,
             vec!["frame".into()],
             vec!["PyFrame".into(), "ExecutionContext".into()],
+            CallPath::from_segments(["execute_opcode_step"]),
         );
         cc.make_virtualizable_infos(|_, _| None);
         // warmspot.py:534-538 — `index_of_virtualizable = reds.index('frame')`
@@ -11410,6 +11422,7 @@ mod tests {
             false,
             vec!["frame".into()],
             vec!["PyFrame".into()],
+            CallPath::from_segments(["portal"]),
         );
         cc.make_virtualizable_infos(|_, _| None);
     }
@@ -11427,6 +11440,7 @@ mod tests {
             false,
             vec![],
             vec![],
+            CallPath::from_segments(["portal"]),
         );
         cc.jitdrivers_sd[0].virtualizable_info = Some(std::sync::Arc::new(StubVInfo {
             vtypeptr_id: 0xfeed,
@@ -11452,6 +11466,7 @@ mod tests {
             false,
             vec![],
             vec!["PyFrame".into()],
+            CallPath::from_segments(["portal_with_greenfield"]),
         );
         cc.make_virtualizable_infos(|_, _| None);
         let gfinfo = cc.jitdrivers_sd[0]
@@ -11480,6 +11495,7 @@ mod tests {
             false,
             vec!["frame".into()],
             vec!["PyFrame".into()],
+            CallPath::from_segments(["portal_a"]),
         );
         cc.setup_jitdriver(
             CallPath::from_segments(["portal_b"]),
@@ -11490,6 +11506,7 @@ mod tests {
             false,
             vec!["frame".into()],
             vec!["PyFrame".into()],
+            CallPath::from_segments(["portal_b"]),
         );
         let mut factory_calls: Vec<String> = Vec::new();
         cc.make_virtualizable_infos(|_jd_idx, vtypeptr_token| {
@@ -11529,6 +11546,7 @@ mod tests {
             false,
             vec!["frame".into()],
             vec!["PyFrame".into()],
+            CallPath::from_segments(["portal"]),
         );
         cc.make_virtualizable_infos(|_, _| None);
         assert!(cc.jitdrivers_sd[0].virtualizable_info.is_none());

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -4373,6 +4373,33 @@ impl CallControl {
         Some(return_type_string_to_value_type(Some(&effective)))
     }
 
+    /// RPython `CallControl.getcalldescr` / `Transformer.rewrite_call`:
+    /// `Void` arguments remain in the flow graph but are absent from the
+    /// low-level call's `NON_VOID_ARGS`. Charon can leave a zero-sized closure
+    /// receiver as `Ref` at its construction site even though the callee's
+    /// declared parameter is `Void`; use the authoritative `FUNC.ARGS`
+    /// positions at this ABI boundary instead of erasing that SSA value
+    /// globally.
+    pub(crate) fn non_void_actual_args_for_target(
+        &self,
+        target: &CallTarget,
+        args: &[crate::flowspace::model::Variable],
+    ) -> Vec<crate::flowspace::model::Variable> {
+        let Some((_, graph)) = self.target_to_path_and_graph(target) else {
+            return args.to_vec();
+        };
+        let declared = graph_arg_types(graph);
+        if declared.len() != args.len() {
+            // Leave malformed arity untouched so `getcalldescr` reports the
+            // orthodox hard error instead of silently hiding an argument.
+            return args.to_vec();
+        }
+        args.iter()
+            .zip(declared)
+            .filter_map(|(arg, ty)| (ty != crate::model::ValueType::Void).then(|| arg.clone()))
+            .collect()
+    }
+
     /// The shared low-level result type of an indirect-call family.
     ///
     /// RPython's `FunctionReprBase.call` gets this from the selected
@@ -4421,14 +4448,13 @@ fn return_type_string_to_kind(s: &str) -> char {
     }
 }
 
-/// RPython parity for `call.py:220-221` `FUNC.ARGS` — collect the non-void
-/// argument types of a graph.  Parameters live on `startblock.inputargs`
-/// (RPython `flowspace/model.py` Block), populated by `front::mir`'s
-/// parameter registration.  The `OpKind::Input`
-/// ops co-emitted with each parameter carry the declared type which we
-/// recover by chasing each inputarg Variable back to its defining op.
-/// Unknown/ambiguous slots default to `Ref`, matching
-/// `resolve_non_void_arg_types`' fallback.
+/// RPython `CallControl.getcalldescr` parity: recover the graph's complete
+/// declared `FUNC.ARGS` sequence before the caller filters `Void`. Parameters
+/// live on `Block.inputargs`, populated by `front::mir`'s parameter
+/// registration. The `OpKind::Input` operations co-emitted with each parameter
+/// carry the declared type, recovered by chasing each input variable back to
+/// its defining operation. An unresolved slot remains `Unknown`; consumers
+/// decide whether that conservative value belongs in their ABI view.
 ///
 /// TODO: when `inputargs` is empty we fall back to
 /// scanning leading `OpKind::Input` ops in the startblock.  Unit tests
@@ -4436,37 +4462,25 @@ fn return_type_string_to_kind(s: &str) -> char {
 /// `FunctionGraph::new` + `push_op` without populating `inputargs`; the
 /// fallback keeps their "all-Input-ops-are-params" convention working
 /// until they are migrated.
-fn graph_non_void_arg_types(graph: &FunctionGraph) -> Vec<Type> {
+fn graph_arg_types(graph: &FunctionGraph) -> Vec<crate::model::ValueType> {
     let start = graph.block(graph.startblock);
-    let map_ty = |ty: &crate::model::ValueType| match ty {
-        // RPython `getkind(BOOL_TYPE)` returns `'int'`
-        // (`lloperation.py:108`); BoolRepr's lowleveltype is `Bool`
-        // and `FUNC.ARGS` (`call.py:220-221`) records it under the
-        // same `'i'` register kind as `Signed`.  Bool aliases to Int
-        // so the wildcard does not silently re-classify it as Ref.
-        crate::model::ValueType::Int | crate::model::ValueType::Bool => Some(Type::Int),
-        crate::model::ValueType::Ref(_) => Some(Type::Ref),
-        crate::model::ValueType::Float => Some(Type::Float),
-        crate::model::ValueType::Void => None,
-        // Unknown / State — default to Ref.
-        _ => Some(Type::Ref),
-    };
     if !start.inputargs.is_empty() {
-        // Walk `inputargs` (`Vec<Variable>`) directly — orthodox per
-        // `flowspace/model.py:Block.inputargs`.  Treat unresolved
-        // slots conservatively as `Type::Ref` (the same default the
-        // wildcard arm uses below).
         return start
             .inputargs
             .iter()
-            .filter_map(|arg| {
-                let ty = start.operations.iter().find_map(|op| match &op.kind {
-                    crate::model::OpKind::Input { ty, .. } if op.result.as_ref() == Some(arg) => {
-                        Some(ty)
-                    }
-                    _ => None,
-                });
-                ty.map(map_ty).unwrap_or(Some(Type::Ref))
+            .map(|arg| {
+                start
+                    .operations
+                    .iter()
+                    .find_map(|op| match &op.kind {
+                        crate::model::OpKind::Input { ty, .. }
+                            if op.result.as_ref() == Some(arg) =>
+                        {
+                            Some(ty.clone())
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or(crate::model::ValueType::Unknown)
             })
             .collect();
     }
@@ -4475,8 +4489,26 @@ fn graph_non_void_arg_types(graph: &FunctionGraph) -> Vec<Type> {
         .iter()
         .take_while(|op| matches!(op.kind, crate::model::OpKind::Input { .. }))
         .filter_map(|op| match &op.kind {
-            crate::model::OpKind::Input { ty, .. } => map_ty(ty),
+            crate::model::OpKind::Input { ty, .. } => Some(ty.clone()),
             _ => None,
+        })
+        .collect()
+}
+
+fn graph_non_void_arg_types(graph: &FunctionGraph) -> Vec<Type> {
+    graph_arg_types(graph)
+        .iter()
+        .filter_map(|ty| match ty {
+            // RPython `history.getkind(BOOL_TYPE)` returns `'int'`;
+            // `CallControl.getcalldescr` records Bool in `FUNC.ARGS` under the
+            // same `'i'` register kind as `Signed`. Bool aliases to Int so the
+            // wildcard does not silently re-classify it as Ref.
+            crate::model::ValueType::Int | crate::model::ValueType::Bool => Some(Type::Int),
+            crate::model::ValueType::Ref(_) => Some(Type::Ref),
+            crate::model::ValueType::Float => Some(Type::Float),
+            crate::model::ValueType::Void => None,
+            // Unknown / State — default to Ref.
+            _ => Some(Type::Ref),
         })
         .collect()
 }
@@ -9511,6 +9543,39 @@ mod tests {
             cc.guess_call_kind(&direct_call_op(unknown)),
             CallKind::Residual
         );
+    }
+
+    #[test]
+    fn direct_call_omits_actual_for_declared_void_parameter() {
+        let mut cc = CallControl::new();
+        let path = CallPath::from_segments(["closure_call_once"]);
+        let mut callee = FunctionGraph::new("closure_call_once");
+        let receiver = callee.alloc_value_var();
+        let value = callee.alloc_value_var();
+        for (var, name, ty) in [
+            (receiver, "self", ValueType::Void),
+            (value, "value", ValueType::Ref(None)),
+        ] {
+            callee.push_inputarg_var(callee.startblock, var.clone());
+            callee.push_op_with_result_var(
+                callee.startblock,
+                OpKind::Input {
+                    name: name.to_string(),
+                    ty,
+                    class_root: None,
+                },
+                var,
+            );
+        }
+        cc.register_function_graph(path, callee);
+
+        let actual_receiver = crate::flowspace::model::Variable::new();
+        let actual_value = crate::flowspace::model::Variable::new();
+        let filtered = cc.non_void_actual_args_for_target(
+            &CallTarget::function_path(["closure_call_once"]),
+            &[actual_receiver, actual_value.clone()],
+        );
+        assert_eq!(filtered, vec![actual_value]);
     }
 
     /// The `@jit.dont_look_inside` builder residual helpers residualize only

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -175,7 +175,7 @@ pub struct GraphTransformConfig {
 
 /// The [`GraphTransformConfig::jitdriver_receiver_roots`] default: pyre's own
 /// two drivers.
-fn default_jitdriver_receiver_roots() -> Vec<String> {
+pub(crate) fn default_jitdriver_receiver_roots() -> Vec<String> {
     RECOGNIZED_JITDRIVER_RECEIVER_ROOTS
         .iter()
         .map(|s| (*s).to_string())

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -931,6 +931,15 @@ impl<'a> Transformer<'a> {
         for block_idx in 0..rewritten.blocks.len() {
             self.optimize_block(&mut rewritten, block_idx, &graph_name, exceptblock);
         }
+        // A rewrite can itself define a condition as a constant (notably the
+        // false result paired with `can_enter_jit`'s `loop_header`).  Follow
+        // that constant exit after rewriting, matching the block-following
+        // half of upstream jtransform, then discard the disconnected arm and
+        // the now-dead condition definition.
+        if crate::model::fold_constant_exitswitch(&mut rewritten) > 0 {
+            crate::model::clear_unreachable_blocks(&mut rewritten);
+            crate::model::prune_dead_phis(&mut rewritten);
+        }
 
         GraphTransformResult {
             graph: rewritten,
@@ -3761,7 +3770,8 @@ impl<'a> Transformer<'a> {
         // pyre keys on the direct_call callee identity since the front-end
         // lowers `driver.jit_merge_point(...)` etc. to `CallTarget::Method`.
         if let Some(key) = jit_marker_key_from_target(target, &self.config.jitdriver_receiver_roots)
-            && let Some(ops) = self.try_handle_jit_marker(key, args, graph)
+            && let Some(ops) =
+                self.try_handle_jit_marker(key, args, op.result.as_ref(), graph)
         {
             return RewriteResult::Replace(ops);
         }
@@ -5824,6 +5834,7 @@ impl<'a> Transformer<'a> {
         &mut self,
         key: JitMarkerKey,
         args: &[crate::flowspace::model::Variable],
+        result: Option<&crate::flowspace::model::Variable>,
         graph: &crate::model::FunctionGraph,
     ) -> Option<Vec<SpaceOperation>> {
         let jitdriver_index = self.portal_jd_index?;
@@ -5833,7 +5844,13 @@ impl<'a> Transformer<'a> {
             && let Some(jd) = cc.jitdriver_sd_from_jitdriver(jitdriver_index)
             && !jd.active
         {
-            return Some(Vec::new());
+            return Some(match (key, result) {
+                (JitMarkerKey::CanEnterJit, Some(result)) => vec![SpaceOperation {
+                    result: Some(result.clone()),
+                    kind: OpKind::ConstInt(0),
+                }],
+                _ => Vec::new(),
+            });
         }
         match key {
             JitMarkerKey::LoopHeader | JitMarkerKey::CanEnterJit => {
@@ -5857,8 +5874,20 @@ impl<'a> Transformer<'a> {
                     );
                 }
                 // jtransform.py:1723 `handle_jit_marker__can_enter_jit =
-                // handle_jit_marker__loop_header`.
-                Some(self.handle_jit_marker__loop_header(jitdriver_index))
+                // handle_jit_marker__loop_header`.  `rewrite_can_enter_jits`
+                // runs after `make_jitcodes`, so the portal jitcode observes
+                // only this loop header and a false result for pyre's
+                // interpreter-only boolean carrier.
+                let mut ops = self.handle_jit_marker__loop_header(jitdriver_index);
+                if key == JitMarkerKey::CanEnterJit
+                    && let Some(result) = result
+                {
+                    ops.push(SpaceOperation {
+                        result: Some(result.clone()),
+                        kind: OpKind::ConstInt(0),
+                    });
+                }
+                Some(ops)
             }
             JitMarkerKey::JitMergePoint => {
                 let (num_greens, autoreds, green_kinds, red_kinds, driver_name) = {
@@ -11537,6 +11566,7 @@ mod tests {
             .try_handle_jit_marker(
                 merge_key,
                 &[receiver, next_instr, profiled, pycode, frame, ec],
+                None,
                 &graph,
             )
             .expect("recognized portal marker must lower");
@@ -11556,15 +11586,19 @@ mod tests {
         let enter_key =
             jit_marker_key_from_target(&enter_target, &default_jitdriver_receiver_roots())
                 .expect("source can_enter_jit method must be recognized");
+        let enter_result = graph.alloc_value_var();
         let enter_ops = transformer
-            .try_handle_jit_marker(enter_key, &[], &graph)
+            .try_handle_jit_marker(enter_key, &[], Some(&enter_result), &graph)
             .expect("recognized can_enter_jit marker must lower");
         assert!(matches!(
             enter_ops.as_slice(),
             [SpaceOperation {
                 kind: OpKind::LoopHeader { jitdriver_index },
                 ..
-            }] if *jitdriver_index == resolved_driver
+            }, SpaceOperation {
+                result: Some(result),
+                kind: OpKind::ConstInt(0),
+            }] if *jitdriver_index == resolved_driver && result == &enter_result
         ));
         assert!(
             !enter_ops
@@ -11578,18 +11612,81 @@ mod tests {
     fn try_handle_jit_marker_can_enter_jit_aliases_to_loop_header() {
         let config = GraphTransformConfig::default();
         let mut transformer = Transformer::new(&config).with_portal_jd(Some(2));
+        let mut graph = crate::model::FunctionGraph::new("fixture");
+        let result = graph.alloc_value_var();
         let ops = transformer
             .try_handle_jit_marker(
                 JitMarkerKey::CanEnterJit,
                 &[],
-                &crate::model::FunctionGraph::new("fixture"),
+                Some(&result),
+                &graph,
             )
             .expect("can_enter_jit should dispatch when portal_jd is set");
-        assert_eq!(ops.len(), 1);
+        assert_eq!(ops.len(), 2);
         match &ops[0].kind {
             OpKind::LoopHeader { jitdriver_index } => assert_eq!(*jitdriver_index, 2),
             other => panic!("expected LoopHeader, got {other:?}"),
         }
+        assert!(matches!(
+            &ops[1],
+            SpaceOperation {
+                result: Some(defined),
+                kind: OpKind::ConstInt(0),
+            } if defined == &result
+        ));
+    }
+
+    #[test]
+    fn can_enter_jit_result_folds_to_false_path_after_loop_header() {
+        let config = GraphTransformConfig::default();
+        let mut graph = FunctionGraph::new("can_enter_jit_false_path");
+        let entry = graph.startblock;
+        let if_true = graph.create_block();
+        let if_false = graph.create_block();
+        let receiver = graph.alloc_value_var();
+        let entered = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::method(
+                        "can_enter_jit",
+                        Some("PyPyJitDriver".into()),
+                    ),
+                    args: vec![receiver],
+                    result_ty: ValueType::Bool,
+                },
+                true,
+            )
+            .expect("boolean marker call defines its branch condition");
+        graph.set_branch(entry, entered, if_true, vec![], if_false, vec![]);
+        let true_value = graph
+            .push_op_var(if_true, OpKind::ConstInt(1), true)
+            .unwrap();
+        graph.set_return(if_true, Some(true_value));
+        let false_value = graph
+            .push_op_var(if_false, OpKind::ConstInt(0), true)
+            .unwrap();
+        graph.set_return(if_false, Some(false_value));
+
+        let result = Transformer::new(&config)
+            .with_portal_jd(Some(0))
+            .transform(&graph);
+        let entry = &result.graph.blocks[entry.0];
+        assert!(entry
+            .operations
+            .iter()
+            .any(|op| matches!(op.kind, OpKind::LoopHeader { jitdriver_index: 0 })));
+        assert!(!result
+            .graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .any(|op| matches!(op.kind, OpKind::Call { .. })));
+        assert!(entry.exitswitch.is_none());
+        assert_eq!(entry.exits.len(), 1);
+        assert_eq!(entry.exits[0].target, if_false);
+        assert!(result.graph.blocks[if_true.0].operations.is_empty());
+        assert!(!result.graph.blocks[if_false.0].operations.is_empty());
     }
 
     #[test]
@@ -11617,6 +11714,7 @@ mod tests {
         let _ = transformer.try_handle_jit_marker(
             JitMarkerKey::CanEnterJit,
             &[],
+            None,
             &crate::model::FunctionGraph::new("fixture"),
         );
     }
@@ -11649,6 +11747,7 @@ mod tests {
                 .try_handle_jit_marker(
                     JitMarkerKey::LoopHeader,
                     &[],
+                    None,
                     &crate::model::FunctionGraph::new("fixture"),
                 )
                 .expect("inactive driver still dispatches (then drops)");
@@ -11666,6 +11765,7 @@ mod tests {
             .try_handle_jit_marker(
                 JitMarkerKey::LoopHeader,
                 &[],
+                None,
                 &crate::model::FunctionGraph::new("fixture"),
             )
             .expect("active driver dispatches");
@@ -11723,6 +11823,7 @@ mod tests {
                 .try_handle_jit_marker(
                     JitMarkerKey::LoopHeader,
                     &[],
+                    None,
                     &crate::model::FunctionGraph::new("fixture")
                 )
                 .is_none()
@@ -11828,7 +11929,7 @@ mod tests {
         FunctionGraph::set_concretetype_of_inline(&r1_var, ConcreteType::Signed);
         let args_vars = vec![receiver_var, g1_var.clone(), g2_var.clone(), r1_var.clone()];
         let ops = transformer
-            .try_handle_jit_marker(JitMarkerKey::JitMergePoint, &args_vars, &graph)
+            .try_handle_jit_marker(JitMarkerKey::JitMergePoint, &args_vars, None, &graph)
             .expect("portal_jd + cc + 2-greens + 1-red satisfies dispatch preconditions");
 
         assert_eq!(ops.len(), 7, "promote_greens(2 greens)*2 + merge*3 = 7");
@@ -11937,6 +12038,7 @@ mod tests {
             .try_handle_jit_marker(
                 JitMarkerKey::JitMergePoint,
                 &[receiver, pc, program, vm, base],
+                None,
                 &graph,
             )
             .expect("portal_jd + cc + 2 greens + 2 reds satisfies dispatch preconditions");
@@ -12000,6 +12102,7 @@ mod tests {
             .try_handle_jit_marker(
                 JitMarkerKey::JitMergePoint,
                 &[receiver, next_instr, profiled, pycode, frame, ec],
+                None,
                 &graph,
             )
             .expect("declared greens-first marker should lower");
@@ -12059,6 +12162,7 @@ mod tests {
         let _ = transformer.try_handle_jit_marker(
             JitMarkerKey::JitMergePoint,
             &[receiver, frame, ec, next_instr, profiled, pycode],
+            None,
             &graph,
         );
     }
@@ -12106,7 +12210,12 @@ mod tests {
             kind: OpKind::ConstInt(7),
         });
         let args_vars = vec![receiver_var, g1_var, red_var];
-        let _ = transformer.try_handle_jit_marker(JitMarkerKey::JitMergePoint, &args_vars, &graph);
+        let _ = transformer.try_handle_jit_marker(
+            JitMarkerKey::JitMergePoint,
+            &args_vars,
+            None,
+            &graph,
+        );
     }
 
     /// Synthetic Rust-wrapper elision must accept a single-arg `Ok(_)`

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -3770,8 +3770,7 @@ impl<'a> Transformer<'a> {
         // pyre keys on the direct_call callee identity since the front-end
         // lowers `driver.jit_merge_point(...)` etc. to `CallTarget::Method`.
         if let Some(key) = jit_marker_key_from_target(target, &self.config.jitdriver_receiver_roots)
-            && let Some(ops) =
-                self.try_handle_jit_marker(key, args, op.result.as_ref(), graph)
+            && let Some(ops) = self.try_handle_jit_marker(key, args, op.result.as_ref(), graph)
         {
             return RewriteResult::Replace(ops);
         }
@@ -11615,12 +11614,7 @@ mod tests {
         let mut graph = crate::model::FunctionGraph::new("fixture");
         let result = graph.alloc_value_var();
         let ops = transformer
-            .try_handle_jit_marker(
-                JitMarkerKey::CanEnterJit,
-                &[],
-                Some(&result),
-                &graph,
-            )
+            .try_handle_jit_marker(JitMarkerKey::CanEnterJit, &[], Some(&result), &graph)
             .expect("can_enter_jit should dispatch when portal_jd is set");
         assert_eq!(ops.len(), 2);
         match &ops[0].kind {
@@ -11648,10 +11642,7 @@ mod tests {
             .push_op_var(
                 entry,
                 OpKind::Call {
-                    target: CallTarget::method(
-                        "can_enter_jit",
-                        Some("PyPyJitDriver".into()),
-                    ),
+                    target: CallTarget::method("can_enter_jit", Some("PyPyJitDriver".into())),
                     args: vec![receiver],
                     result_ty: ValueType::Bool,
                 },
@@ -11672,16 +11663,20 @@ mod tests {
             .with_portal_jd(Some(0))
             .transform(&graph);
         let entry = &result.graph.blocks[entry.0];
-        assert!(entry
-            .operations
-            .iter()
-            .any(|op| matches!(op.kind, OpKind::LoopHeader { jitdriver_index: 0 })));
-        assert!(!result
-            .graph
-            .blocks
-            .iter()
-            .flat_map(|block| &block.operations)
-            .any(|op| matches!(op.kind, OpKind::Call { .. })));
+        assert!(
+            entry
+                .operations
+                .iter()
+                .any(|op| matches!(op.kind, OpKind::LoopHeader { jitdriver_index: 0 }))
+        );
+        assert!(
+            !result
+                .graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| matches!(op.kind, OpKind::Call { .. }))
+        );
         assert!(entry.exitswitch.is_none());
         assert_eq!(entry.exits.len(), 1);
         assert_eq!(entry.exits[0].target, if_false);

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -5381,7 +5381,7 @@ impl<'a> Transformer<'a> {
         let (jd_index, num_green_args) = self
             .callcontrol
             .as_ref()
-            .and_then(|cc| cc.jitdriver_sd_from_portal_graph(&path))
+            .and_then(|cc| cc.jitdriver_sd_from_portal_runner_ptr(&path))
             .map(|sd| (sd.index, sd.greens.len()))
             .unwrap_or((0, 0));
 
@@ -11750,6 +11750,19 @@ mod tests {
                 ops.is_empty(),
                 "inactive driver must drop markers, got {ops:?}"
             );
+
+            let mut graph = crate::model::FunctionGraph::new("fixture");
+            let result = graph.alloc_value_var();
+            let ops = transformer
+                .try_handle_jit_marker(JitMarkerKey::CanEnterJit, &[], Some(&result), &graph)
+                .expect("inactive can_enter_jit still defines its bound result");
+            assert!(matches!(
+                ops.as_slice(),
+                [SpaceOperation {
+                    result: Some(defined),
+                    kind: OpKind::ConstInt(0),
+                }] if defined == &result
+            ));
         }
 
         cc.set_jitdriver_active(0, true);

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -11906,6 +11906,7 @@ mod tests {
             false,
             Vec::new(),
             Vec::new(),
+            CallPath::from_segments(["test", "portal"]),
         );
         assert!(
             cc.jitdrivers_sd()[0].green_args_spec.is_empty()

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -4152,8 +4152,8 @@ impl<'a> Transformer<'a> {
             }]);
         }
         // RPython: guess_call_kind(op) → dispatch to handle_*_call
-        if let Some(cc) = self.callcontrol.as_mut() {
-            let kind = cc.guess_call_kind(op);
+        if self.callcontrol.is_some() {
+            let kind = self.callcontrol.as_mut().unwrap().guess_call_kind(op);
             return match kind {
                 crate::call::CallKind::Regular => {
                     // RPython call.py:230: the call result must have the same
@@ -4165,10 +4165,15 @@ impl<'a> Transformer<'a> {
                     // residual-call arm below.
                     let effective_result_ty =
                         self.effective_call_result_ty(target, op.result.as_ref(), result_ty);
+                    let non_void_args = self
+                        .callcontrol
+                        .as_deref()
+                        .unwrap()
+                        .non_void_actual_args_for_target(target, args);
                     self.handle_regular_call(
                         op,
                         target,
-                        args,
+                        &non_void_args,
                         &effective_result_ty,
                         graph_name,
                         graph,
@@ -4185,7 +4190,12 @@ impl<'a> Transformer<'a> {
                     // RPython call.py:220-222: NON_VOID_ARGS + RESULT. Even
                     // for a configured effect override, keep the signature from
                     // getcalldescr() instead of accepting an effect-only descr.
-                    let non_void_args = resolve_non_void_arg_types_from_vars(args);
+                    let call_args = self
+                        .callcontrol
+                        .as_deref()
+                        .unwrap()
+                        .non_void_actual_args_for_target(target, args);
+                    let non_void_args = resolve_non_void_arg_types_from_vars(&call_args);
                     // Reconcile a `Result<(), PyError>` scoped callee's
                     // declared void `RESULT` against the `Ref` the front
                     // typed the unit `()` shell (see `effective_call_result_ty`).
@@ -4216,7 +4226,7 @@ impl<'a> Transformer<'a> {
                         op,
                         target,
                         descriptor,
-                        args,
+                        &call_args,
                         &effective_result_ty,
                         graph_name,
                     )

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -524,7 +524,7 @@ struct ResolvedCallResult {
 /// loop_header}`. This enum keeps the upstream key distinction inside
 /// the dispatch hook.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum JitMarkerKey {
+pub(crate) enum JitMarkerKey {
     JitMergePoint,
     /// `can_enter_jit` aliases to `handle_jit_marker__loop_header`
     /// (jtransform.py:1723).
@@ -569,7 +569,7 @@ fn resolves_to_null_ptr_builtin(segments: &[String]) -> bool {
         .is_some_and(|attr| NULL_PTR_BUILTIN_QUALNAMES.contains(&attr.qualname()))
 }
 
-fn jit_marker_key_from_target(
+pub(crate) fn jit_marker_key_from_target(
     target: &CallTarget,
     driver_roots: &[String],
 ) -> Option<JitMarkerKey> {
@@ -11490,6 +11490,7 @@ mod tests {
             false,
             Vec::new(),
             Vec::new(),
+            CallPath::from_segments(["pyre_jit", "other_portal"]),
         );
         let portal_graph =
             CallPath::from_segments([crate::runtime_names::crates::JIT, "eval_loop_jit"]);
@@ -11506,6 +11507,7 @@ mod tests {
             false,
             Vec::new(),
             Vec::new(),
+            portal_graph.clone(),
         );
         let resolved_driver = cc
             .jitdriver_sd_from_portal_graph(&portal_graph)
@@ -11607,6 +11609,7 @@ mod tests {
             true,
             Vec::new(),
             Vec::new(),
+            crate::parse::CallPath::from_segments(["autoreds_portal"]),
         );
         let mut transformer = Transformer::new(&config)
             .with_callcontrol(&mut cc)
@@ -11634,6 +11637,7 @@ mod tests {
             false,
             Vec::new(),
             Vec::new(),
+            crate::parse::CallPath::from_segments(["portal"]),
         );
 
         cc.set_jitdriver_active(0, false);
@@ -11801,6 +11805,7 @@ mod tests {
             false,
             Vec::new(),
             Vec::new(),
+            CallPath::from_segments(["test", "portal"]),
         );
 
         let config = GraphTransformConfig::default();
@@ -11970,6 +11975,7 @@ mod tests {
             false,
             Vec::new(),
             Vec::new(),
+            CallPath::from_segments(["eval", "eval_loop_jit"]),
         );
 
         let config = GraphTransformConfig::default();
@@ -12029,6 +12035,7 @@ mod tests {
             false,
             Vec::new(),
             Vec::new(),
+            CallPath::from_segments(["eval", "eval_loop_jit"]),
         );
 
         let config = GraphTransformConfig::default();
@@ -12077,6 +12084,7 @@ mod tests {
             false,
             Vec::new(),
             Vec::new(),
+            CallPath::from_segments(["test", "portal"]),
         );
 
         let config = GraphTransformConfig::default();

--- a/majit/majit-translate/src/codewriter/support.rs
+++ b/majit/majit-translate/src/codewriter/support.rs
@@ -93,11 +93,24 @@ pub(crate) fn find_jit_merge_point(
 
 /// `jit/codewriter/support.py sort_vars`.
 pub(crate) fn sort_vars(args: &[Variable]) -> Vec<Variable> {
+    // The split runs before the rtyper publishes every concretetype.  An
+    // Unknown has no upstream `getkind()` ordering yet, so assigning it the
+    // Ref key can spuriously move a later-known Int in front of it and report
+    // a bogus JitDriver declaration-order error.  Keep the declaration order
+    // until the types are authoritative; the typed codewriter pass performs
+    // the real register-bank validation afterwards.
+    if args
+        .iter()
+        .any(|var| FunctionGraph::concretetype_of(var) == ConcreteType::Unknown)
+    {
+        return args.to_vec();
+    }
     let mut sorted = args.to_vec();
     sorted.sort_by_key(|var| match FunctionGraph::concretetype_of(var) {
         ConcreteType::Signed => 1,
-        ConcreteType::GcRef | ConcreteType::Unknown => 2,
+        ConcreteType::GcRef => 2,
         ConcreteType::Float => 3,
+        ConcreteType::Unknown => unreachable!("Unknown returned above"),
         ConcreteType::Void => panic!("support.py sort_vars: Void must be filtered first"),
     });
     sorted
@@ -954,6 +967,28 @@ pub fn builtin_func_for_spec(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sort_vars_preserves_declaration_order_while_any_type_is_unknown() {
+        let mut graph = FunctionGraph::new("unknown_sort");
+        let unresolved = graph.alloc_value_var_with_type(ConcreteType::Unknown);
+        let integer = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let reference = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let declared = vec![unresolved, integer, reference];
+        assert_eq!(sort_vars(&declared), declared);
+    }
+
+    #[test]
+    fn sort_vars_orders_fully_typed_register_banks() {
+        let mut graph = FunctionGraph::new("typed_sort");
+        let reference = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let float = graph.alloc_value_var_with_type(ConcreteType::Float);
+        let integer = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        assert_eq!(
+            sort_vars(&[reference.clone(), float.clone(), integer.clone()]),
+            vec![integer, reference, float]
+        );
+    }
 
     #[test]
     fn inline_calls_to_matches_upstream_four_entries() {

--- a/majit/majit-translate/src/codewriter/support.rs
+++ b/majit/majit-translate/src/codewriter/support.rs
@@ -57,10 +57,125 @@
 //! information, different host vehicle.
 
 use crate::codewriter::call::CallControl;
-use crate::model::{OpKind, SpaceOperation};
+use crate::codewriter::jtransform::{JitMarkerKey, jit_marker_key_from_target};
+use crate::codewriter::type_state::ConcreteType;
+use crate::flowspace::model::Variable;
+use crate::model::{BlockId, FunctionGraph, OpKind, SpaceOperation};
 use crate::parse::CallPath;
 
 use majit_ir::value::Type;
+
+/// `jit/metainterp/warmspot.py find_jit_merge_points`, restricted to one graph.
+pub(crate) fn find_jit_merge_point(
+    graph: &FunctionGraph,
+    driver_roots: &[String],
+) -> Option<(BlockId, usize)> {
+    let mut found = None;
+    for block in &graph.blocks {
+        for (index, op) in block.operations.iter().enumerate() {
+            let is_merge_point = matches!(
+                &op.kind,
+                OpKind::Call { target, .. }
+                    if jit_marker_key_from_target(target, driver_roots) == Some(JitMarkerKey::JitMergePoint)
+            );
+            if !is_merge_point {
+                continue;
+            }
+            assert!(
+                found.is_none(),
+                "found several jit_merge_points in the same graph"
+            );
+            found = Some((block.id, index));
+        }
+    }
+    found
+}
+
+/// `jit/codewriter/support.py sort_vars`.
+pub(crate) fn sort_vars(args: &[Variable]) -> Vec<Variable> {
+    let mut sorted = args.to_vec();
+    sorted.sort_by_key(|var| match FunctionGraph::concretetype_of(var) {
+        ConcreteType::Signed => 1,
+        ConcreteType::GcRef | ConcreteType::Unknown => 2,
+        ConcreteType::Float => 3,
+        ConcreteType::Void => panic!("support.py sort_vars: Void must be filtered first"),
+    });
+    sorted
+}
+
+/// `jit/codewriter/support.py decode_hp_hint_args`.
+pub(crate) fn decode_hp_hint_args(
+    marker_args: &[Variable],
+    numgreens: usize,
+    numreds: usize,
+) -> (Vec<Variable>, Vec<Variable>) {
+    assert!(
+        marker_args.len() >= numgreens,
+        "jit_merge_point marker has fewer operands than declared greens"
+    );
+    let (greens, reds) = marker_args.split_at(numgreens);
+    assert_eq!(reds.len(), numreds);
+
+    let sort_and_check = |args: &[Variable], is_green: bool| {
+        let vars: Vec<Variable> = args
+            .iter()
+            .filter(|var| FunctionGraph::concretetype_of(var) != ConcreteType::Void)
+            .cloned()
+            .collect();
+        if is_green {
+            assert_eq!(
+                vars.len(),
+                args.len(),
+                "not supported so far: 'greens' variables contain Void"
+            );
+        }
+        let sorted = sort_vars(&vars);
+        assert_eq!(
+            vars, sorted,
+            "You have to reorder the variables named in the JitDriver (both the 'greens' and \
+             'reds' independently). They must be sorted like this: first all the integer-like, \
+             then all the pointer-like, and finally the floats.\nGot: {:?}\nExpected: {:?}",
+            vars, sorted
+        );
+        vars
+    };
+    (sort_and_check(greens, true), sort_and_check(reds, false))
+}
+
+/// `jit/codewriter/support.py split_before_jit_merge_point`.
+pub(crate) fn split_before_jit_merge_point(
+    graph: &mut FunctionGraph,
+    mut portalblock: BlockId,
+    portalopindex: usize,
+    numgreens: usize,
+    numreds: usize,
+    driver_roots: &[String],
+) -> BlockId {
+    if portalopindex > 0 {
+        portalblock = crate::unsimplify::split_block(graph, portalblock, portalopindex, None);
+    }
+    let marker = graph
+        .block(portalblock)
+        .operations
+        .first()
+        .expect("split portal block must start with jit_merge_point")
+        .clone();
+    let OpKind::Call { target, args, .. } = marker.kind else {
+        panic!("split portal block must start with jit_merge_point")
+    };
+    assert_eq!(
+        jit_marker_key_from_target(&target, driver_roots),
+        Some(JitMarkerKey::JitMergePoint),
+        "split portal block must start with jit_merge_point"
+    );
+    let marker_args = args
+        .get(1..)
+        .expect("jit_merge_point method call must carry its receiver");
+    let (greens, reds) = decode_hp_hint_args(marker_args, numgreens, numreds);
+    let mut linkargs = greens;
+    linkargs.extend(reds);
+    crate::unsimplify::split_block(graph, portalblock, 0, Some(&linkargs))
+}
 
 /// `support.py inline_calls_to`.
 ///

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8144,6 +8144,43 @@ impl<'a> Lowering<'a> {
                         .expect("a materialized GC root stays a Variable")
                         .clone();
                 }
+                // `core::intrinsics::transmute::<A, B>(x)` is a bitwise
+                // move.  When both Rust types lower to the same JIT register
+                // bank and Charon's type/layout data proves their byte sizes
+                // equal, the move is the bank's ordinary copy (`same_as`).
+                // This includes `u8 -> #[repr(u8)]` fieldless enums: the enum
+                // is already modelled as its integer tag by
+                // `tyref_to_value_type`, and its `TypeDecl` layout supplies
+                // the matching one-byte size.  A bank crossing or an unknown
+                // / unequal size keeps the existing residual call.
+                if args.len() == 1
+                    && let CallKind::Fun(FunId::Regular { id }) = &reg.kind
+                    && let Some(fd) = self.llbc.fn_by_id(*id)
+                    && matches!(
+                        fd.item_meta.name_path().as_str(),
+                        "core::intrinsics::transmute" | "core::mem::transmute"
+                    )
+                    && first_arg_ty.as_ref().is_some_and(|src_ty| {
+                        transmute_is_same_layout_bank(src_ty, &call.dest.ty, self.llbc)
+                    })
+                {
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::UnaryOp {
+                            op: "same_as".to_string(),
+                            operand: args[0].clone(),
+                            result_ty: result_ty.clone(),
+                        },
+                    });
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // `we_are_jitted()` is true during tracing and blackholing
                 // (rlib/jit.py:355-358); the rtyper folds the surviving
                 // `_we_are_jitted` symbolic to a constant True
@@ -19825,6 +19862,87 @@ fn value_type_bank(ty: &ValueType) -> u8 {
     }
 }
 
+/// Whether `transmute::<A, B>` is an ordinary copy in the lowered graph.
+///
+/// The predicate is deliberately the conjunction of two independent facts:
+///
+/// * `A` and `B` occupy the same real JIT register bank (`Int`/`Unsigned`/
+///   `Bool`, `Ref`/`Str`/`StringBuilder`, or `Float`); and
+/// * the exact sizes recovered from Charon's serialized scalar type or the
+///   target-selected `TypeDecl` layout are both known and equal.
+///
+/// Unknown layouts decline.  In particular, matching `ValueType`s alone is
+/// insufficient because that projection intentionally erases scalar widths
+/// and aggregate sizes.
+fn transmute_is_same_layout_bank(src: &TyRef, dst: &TyRef, llbc: &Llbc) -> bool {
+    let src_bank = value_type_bank(&tyref_to_value_type(src, llbc));
+    let dst_bank = value_type_bank(&tyref_to_value_type(dst, llbc));
+    matches!((src_bank, dst_bank), (0, 0) | (1, 1) | (2, 2))
+        && matches!(
+            (tyref_exact_layout_size(src, llbc), tyref_exact_layout_size(dst, llbc)),
+            (Some(src_size), Some(dst_size)) if src_size == dst_size
+        )
+}
+
+/// Exact byte size encoded by a Charon [`TyRef`].
+///
+/// Named ADTs use the target-selected LLBC layout.  Primitive widths are part
+/// of the serialized LLBC type itself; references/raw pointers/function
+/// pointers have the target word size when their representation is known to
+/// be thin.  Every other shape returns `None`, keeping the transmute residual.
+fn tyref_exact_layout_size(ty: &TyRef, llbc: &Llbc) -> Option<u64> {
+    let node = strip_ty_indirections(tyref_node(ty, llbc)?, llbc)?;
+    let obj = node.as_object()?;
+
+    if let Some(lit) = obj.get("Literal") {
+        if let Some(atom) = lit.as_str() {
+            return match atom {
+                "Bool" => Some(1),
+                "Char" => Some(4),
+                _ => None,
+            };
+        }
+        let lit = lit.as_object()?;
+        let scalar_size = |kind: &str| match kind {
+            "I8" | "U8" => Some(1),
+            "I16" | "U16" | "F16" => Some(2),
+            "I32" | "U32" | "F32" => Some(4),
+            "I64" | "U64" | "F64" => Some(8),
+            "I128" | "U128" | "F128" => Some(16),
+            "Isize" | "Usize" => Some(crate::layout::target_word_size() as u64),
+            _ => None,
+        };
+        for key in ["Int", "UInt", "Integer", "Float"] {
+            if let Some(kind) = lit.get(key).and_then(serde_json::Value::as_str) {
+                return scalar_size(kind);
+            }
+        }
+        return None;
+    }
+
+    if let Some(def_id) = adt_node_def_id(node) {
+        let target = std::env::var("TARGET").unwrap_or_default();
+        return llbc.type_by_id(def_id)?.layout_for_target(&target)?.size;
+    }
+
+    let pointee = obj
+        .get("Ref")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|parts| parts.get(1))
+        .or_else(|| {
+            obj.get("RawPtr")
+                .and_then(serde_json::Value::as_array)
+                .and_then(|parts| parts.first())
+        });
+    if pointee.is_some_and(|pointee| json_ty_is_statically_sized(pointee, llbc))
+        || obj.contains_key("FnPtr")
+    {
+        return Some(crate::layout::target_word_size() as u64);
+    }
+
+    None
+}
+
 /// The fully-qualified host-callable path for a bank-crossing cast, or
 /// `None` when `src` and `dst` share a bank (a JIT no-op aliased to the
 /// operand) or the bank pair has no host cast callable.  A bank crossing
@@ -30041,6 +30159,233 @@ mod tests {
         .expect("fixture trait call parses");
 
         assert_eq!(super::abstract_trait_call_target(&call, &llbc), None);
+    }
+
+    /// Two one-call graphs sharing a synthetic `core::intrinsics::transmute`
+    /// declaration.  The first has the portal's scalar-to-fieldless-enum
+    /// shape; the second is an equal-size register-bank crossing.
+    fn transmute_lowering_fixture() -> Llbc {
+        let span = || {
+            serde_json::json!({
+                "data": {
+                    "file_id": 0,
+                    "beg": {"line": 1, "col": 0},
+                    "end": {"line": 1, "col": 1}
+                }
+            })
+        };
+        let item_meta = |path: &[&str], is_local: bool| {
+            serde_json::json!({
+                "name": path
+                    .iter()
+                    .map(|segment| serde_json::json!({"Ident": [segment, 0]}))
+                    .collect::<Vec<_>>(),
+                "span": span(),
+                "source_text": null,
+                "attr_info": {
+                    "attributes": [],
+                    "inline": null,
+                    "rename": null,
+                    "public": true
+                },
+                "is_local": is_local
+            })
+        };
+        let u8_ty = serde_json::json!({"Literal": {"UInt": "U8"}});
+        let u64_ty = serde_json::json!({"Literal": {"UInt": "U64"}});
+        let f64_ty = serde_json::json!({"Literal": {"Float": "F64"}});
+        let instruction_ty = serde_json::json!({
+            "Adt": {
+                "id": {"Adt": 0},
+                "generics": {
+                    "regions": [],
+                    "types": [],
+                    "const_generics": [],
+                    "trait_refs": []
+                }
+            }
+        });
+        let caller = |def_id: u64,
+                      name: &str,
+                      src_ty: serde_json::Value,
+                      dst_ty: serde_json::Value| {
+            serde_json::json!({
+                "def_id": def_id,
+                "item_meta": item_meta(&["fixture", name], true),
+                "signature": {
+                    "is_unsafe": false,
+                    "inputs": [src_ty.clone()],
+                    "output": dst_ty.clone()
+                },
+                "body": {
+                    "Unstructured": {
+                        "span": span(),
+                        "locals": {
+                            "arg_count": 1,
+                            "locals": [
+                                {"index": 0, "name": null, "span": span(), "ty": dst_ty.clone()},
+                                {"index": 1, "name": "value", "span": span(), "ty": src_ty.clone()}
+                            ]
+                        },
+                        "body": [
+                            {
+                                "statements": [],
+                                "terminator": {
+                                    "span": span(),
+                                    "kind": {
+                                        "Call": {
+                                            "call": {
+                                                "func": {
+                                                    "Regular": {
+                                                        "kind": {"Fun": {"Regular": 2}},
+                                                        "generics": {
+                                                            "regions": [],
+                                                            "types": [src_ty.clone(), dst_ty.clone()],
+                                                            "const_generics": [],
+                                                            "trait_refs": []
+                                                        }
+                                                    }
+                                                },
+                                                "args": [{
+                                                    "Copy": {"kind": {"Local": 1}, "ty": src_ty.clone()}
+                                                }],
+                                                "dest": {"kind": {"Local": 0}, "ty": dst_ty.clone()}
+                                            },
+                                            "target": 2,
+                                            "on_unwind": 1
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "statements": [],
+                                "terminator": {"span": span(), "kind": "UnwindResume"}
+                            },
+                            {
+                                "statements": [],
+                                "terminator": {"span": span(), "kind": "Return"}
+                            }
+                        ]
+                    }
+                }
+            })
+        };
+        let instruction = serde_json::json!({
+            "def_id": 0,
+            "item_meta": item_meta(&["fixture", "Instruction"], true),
+            "kind": {
+                "Enum": [
+                    {"name": "LoadConst", "fields": [], "discriminant": {"Scalar": {"Unsigned": ["U8", "0"]}}},
+                    {"name": "ReturnValue", "fields": [], "discriminant": {"Scalar": {"Unsigned": ["U8", "1"]}}}
+                ]
+            },
+            "layout": [{
+                "key": "fixture-target",
+                "value": {
+                    "size": 1,
+                    "align": 1,
+                    "variant_layouts": [
+                        {"field_offsets": []},
+                        {"field_offsets": []}
+                    ],
+                    "repr": {"transparent": false}
+                }
+            }]
+        });
+        let transmute = serde_json::json!({
+            "def_id": 2,
+            "item_meta": item_meta(&["core", "intrinsics", "transmute"], false),
+            "signature": {
+                "is_unsafe": true,
+                "inputs": [{"TypeVar": {"Free": 0}}],
+                "output": {"TypeVar": {"Free": 1}}
+            },
+            "body": {"Intrinsic": {"name": "transmute", "arg_names": ["src"]}}
+        });
+        let file = serde_json::json!({
+            "charon_version": "0.1.201",
+            "has_errors": false,
+            "translated": {
+                "crate_name": "fixture",
+                "type_decls": [instruction],
+                "fun_decls": [
+                    caller(0, "transmute_u8_to_instruction", u8_ty, instruction_ty),
+                    caller(1, "transmute_u64_to_f64", u64_ty, f64_ty),
+                    transmute
+                ],
+                "global_decls": [],
+                "trait_decls": [],
+                "trait_impls": []
+            }
+        });
+        Llbc::from_slice(file.to_string().as_bytes()).expect("transmute fixture Llbc parses")
+    }
+
+    #[test]
+    fn same_size_int_bank_transmute_lowers_to_same_as() {
+        let llbc = transmute_lowering_fixture();
+        let graph = super::lower_function(&llbc, "transmute_u8_to_instruction")
+            .expect("lower u8-to-Instruction transmute");
+        let ops: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| block.operations.iter())
+            .collect();
+
+        assert!(!ops.iter().any(|op| matches!(op.kind, OpKind::Call { .. })));
+        let copies: Vec<_> = ops
+            .iter()
+            .filter_map(|op| match &op.kind {
+                OpKind::UnaryOp {
+                    op,
+                    operand,
+                    result_ty,
+                } if op == "same_as" => Some((operand, result_ty)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(copies.len(), 1, "transmute must become one scalar copy");
+        assert_eq!(*copies[0].1, ValueType::Int);
+        let input = ops
+            .iter()
+            .find_map(|op| match (&op.result, &op.kind) {
+                (Some(result), OpKind::Input { name, .. }) if name == "value" => Some(result),
+                _ => None,
+            })
+            .expect("value input");
+        assert_eq!(copies[0].0.id(), input.id());
+    }
+
+    #[test]
+    fn equal_size_int_to_float_transmute_stays_residual() {
+        let llbc = transmute_lowering_fixture();
+        let graph = super::lower_function(&llbc, "transmute_u64_to_f64")
+            .expect("lower u64-to-f64 transmute");
+        let ops: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| block.operations.iter())
+            .collect();
+
+        assert!(
+            !ops.iter()
+                .any(|op| { matches!(&op.kind, OpKind::UnaryOp { op, .. } if op == "same_as") })
+        );
+        assert_eq!(
+            ops.iter()
+                .filter(|op| {
+                    matches!(
+                        &op.kind,
+                        OpKind::Call {
+                            target: CallTarget::FunctionPath { segments },
+                            ..
+                        } if segments == &["core", "intrinsics", "transmute"]
+                    )
+                })
+                .count(),
+            1,
+            "bank-crossing transmute must retain the residual intrinsic call"
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1656,7 +1656,7 @@ fn derive_program_metadata(
                 // `enum_variant_by_discriminant` (kept below) supplies the
                 // switch-arm discr→name mapping — both independent of the
                 // base ClassDef.
-                let fieldless = variants.iter().all(|v| v.fields.is_empty());
+                let fieldless = type_decl_is_fieldless_enum(td, llbc);
                 let base_sid = majit_ir::descr::StructId::from_canonical(&canon_base);
                 if !fieldless {
                     let rows: Vec<(String, String)> =
@@ -6222,6 +6222,32 @@ impl<'a> Lowering<'a> {
                     if field_name == "__pos_0" && self.tyref_is_niche_option_ptr(&inner.ty) {
                         return self.resolve_place(mir_bb, *inner);
                     }
+                    // A zero-sized field has no runtime representation, so a
+                    // projection from a payload-free enum reads no bytes.
+                    // Give the projected value the `Void` kind rather than
+                    // materialising it in a value bank.  `getkind(lltype.Void)`
+                    // is `'void'`, and both `NON_VOID_ARGS`
+                    // (`call.py:220-221`) and `add_in_correct_list`
+                    // (`jtransform.py:449`) drop a void argument, so the value
+                    // takes neither a calldescr `arg_classes` slot nor an
+                    // argument-bank entry.  That is what the callee's machine
+                    // ABI expects: a zero-sized parameter occupies no argument
+                    // register, so declaring a slot for it would shift every
+                    // later argument by one register at the residual-call
+                    // boundary.  A bank-classified value would take that slot —
+                    // `Ref` is what an opaque zero-sized ADT falls back to.
+                    // No defining operation, matching the bare
+                    // `Constant(None, lltype.Void)` the argument lists skip.
+                    // Keep this collapse scoped to a fieldless-enum base: a
+                    // zero-sized field in any other aggregate retains that
+                    // aggregate's ordinary field model.
+                    if self.tyref_is_fieldless_enum(&inner.ty)
+                        || self.tyref_is_borrowed_fieldless_enum(&inner.ty)
+                    {
+                        return Ok(self
+                            .graph
+                            .alloc_value_var_with_type(crate::model::ConcreteType::Void));
+                    }
                     // Narrow a classdef-less raw-pointer-deref base to
                     // `SomeInstance(<pointee root>)` before the field read.
                     // A `(*p).field` where `p: *mut/*const <Struct>` deref's to
@@ -6872,7 +6898,7 @@ impl<'a> Lowering<'a> {
         let TypeDeclKind::Enum(variants) = &td.kind else {
             return None;
         };
-        if variants.is_empty() || variants.iter().any(|v| !v.fields.is_empty()) {
+        if !type_decl_is_fieldless_enum(td, self.llbc) {
             return None;
         }
         variants.get(variant_idx)?.discriminant_i64()
@@ -10165,10 +10191,7 @@ impl<'a> Lowering<'a> {
                         .as_ref()
                         .and_then(|t| self.tyref_ref_adt_def_id(t))
                         .and_then(|id| self.llbc.type_by_id(id))
-                        .is_some_and(|td| {
-                            matches!(&td.kind, TypeDeclKind::Enum(vs)
-                                if !vs.is_empty() && vs.iter().all(|v| v.fields.is_empty()))
-                        });
+                        .is_some_and(|td| type_decl_is_fieldless_enum(td, self.llbc));
                     if pointee_fieldless {
                         self.local_var[dest_local] = Some(args[0].clone());
                         let target_bb = self.block_id[target];
@@ -14753,7 +14776,7 @@ impl<'a> Lowering<'a> {
     fn tyref_is_fieldless_enum(&self, ty: &TyRef) -> bool {
         self.tyref_adt_def_id(ty)
             .and_then(|def_id| self.llbc.type_by_id(def_id))
-            .is_some_and(type_decl_is_fieldless_enum)
+            .is_some_and(|td| type_decl_is_fieldless_enum(td, self.llbc))
     }
 
     /// [`Self::tyref_is_fieldless_enum`] through a `&` borrow — the shape a
@@ -14764,7 +14787,7 @@ impl<'a> Lowering<'a> {
     fn tyref_is_borrowed_fieldless_enum(&self, ty: &TyRef) -> bool {
         self.tyref_ref_adt_def_id(ty)
             .and_then(|def_id| self.llbc.type_by_id(def_id))
-            .is_some_and(type_decl_is_fieldless_enum)
+            .is_some_and(|td| type_decl_is_fieldless_enum(td, self.llbc))
     }
 
     /// `true` when `ty` is represented as a one-word nullable `Option`:
@@ -16434,12 +16457,16 @@ impl<'a> Lowering<'a> {
         let TypeDeclKind::Enum(variants) = &td.kind else {
             return false;
         };
-        variants.iter().all(|variant| variant.fields.is_empty())
-            && td
-                .layout_for_target("")
-                .and_then(|l| l.discriminant_offset())
-                .unwrap_or(0)
-                == 0
+        variants.iter().all(|variant| {
+            variant
+                .fields
+                .iter()
+                .all(|f| tyref_is_zero_sized(&f.ty, self.llbc))
+        }) && td
+            .layout_for_target("")
+            .and_then(|l| l.discriminant_offset())
+            .unwrap_or(0)
+            == 0
     }
 
     /// The resolved JSON body of a [`TyRef`], following the dedup
@@ -19963,6 +19990,22 @@ fn tyref_is_enum_free(ty: &TyRef, llbc: &Llbc) -> bool {
         .is_some_and(|td| matches!(td.kind, TypeDeclKind::Enum(_)))
 }
 
+/// Whether `ty` resolves to a type Charon's resolved layout reports as
+/// zero-sized on every target it emitted.  A zero-sized field occupies no
+/// bytes of its owner, so an enum whose every variant field is zero-sized
+/// has no payload at all and is the same by-value tag integer a
+/// syntactically fieldless enum is.
+fn tyref_is_zero_sized(ty: &TyRef, llbc: &Llbc) -> bool {
+    let def_id = match ty {
+        TyRef::Inline { value: (_, v) } | TyRef::Other(v) => inline_adt_def_id(v),
+        TyRef::Dedup { id } => llbc.dedup_to_adt_def_id(*id),
+    };
+    def_id
+        .and_then(|def_id| llbc.type_by_id(def_id))
+        .and_then(|td| td.layout_for_target(""))
+        .is_some_and(|layout| layout.size == Some(0))
+}
+
 /// Free-function form of [`Lowering::tyref_is_fieldless_enum`] for the
 /// standalone [`tyref_to_value_type`] helper (which holds no `Lowering`):
 /// `true` when `ty` resolves to an enum with at least one variant and
@@ -20026,7 +20069,7 @@ fn tyref_is_borrowed_fieldless_enum_free(ty: &TyRef, llbc: &Llbc) -> bool {
         return peeled_a_ref
             && inline_adt_def_id(v)
                 .and_then(|def_id| llbc.type_by_id(def_id))
-                .is_some_and(type_decl_is_fieldless_enum);
+                .is_some_and(|td| type_decl_is_fieldless_enum(td, llbc));
     }
 }
 
@@ -20121,7 +20164,7 @@ fn tyref_fieldless_enum_def<'l>(ty: &TyRef, llbc: &'l Llbc) -> Option<&'l TypeDe
         TyRef::Dedup { id } => llbc.dedup_to_adt_def_id(*id),
     }?;
     llbc.type_by_id(def_id)
-        .filter(|td| type_decl_is_fieldless_enum(td))
+        .filter(|td| type_decl_is_fieldless_enum(td, llbc))
 }
 
 /// The integer-comparison `BinOp` opname a derived `PartialEq` method on
@@ -20138,13 +20181,17 @@ fn fieldless_enum_cmp_binop(method: &str) -> Option<&'static str> {
 }
 
 /// Whether a `TypeDecl` is a fieldless (C-like) enum: at least one
-/// variant, every variant carrying zero payload fields.  Such an enum is
-/// modelled by-value as its discriminant integer, so it has no
-/// `SomeInstance` at all.
-fn type_decl_is_fieldless_enum(td: &TypeDecl) -> bool {
+/// variant, every variant carrying zero payload bytes (no fields, or only
+/// zero-sized ones).  A zero-sized field occupies no bytes in the enum, so
+/// it is not a payload.  Such an enum is modelled by-value as its
+/// discriminant integer, so it has no `SomeInstance` at all.
+fn type_decl_is_fieldless_enum(td: &TypeDecl, llbc: &Llbc) -> bool {
     match &td.kind {
         TypeDeclKind::Enum(variants) => {
-            !variants.is_empty() && variants.iter().all(|v| v.fields.is_empty())
+            !variants.is_empty()
+                && variants
+                    .iter()
+                    .all(|v| v.fields.iter().all(|f| tyref_is_zero_sized(&f.ty, llbc)))
         }
         _ => false,
     }
@@ -25987,7 +26034,7 @@ fn debug_enum_variants_by_discr(llbc: &Llbc, owner_root: &str) -> Option<Vec<(i6
     let TypeDeclKind::Enum(variants) = &td.kind else {
         return None;
     };
-    if variants.is_empty() || variants.iter().any(|v| !v.fields.is_empty()) {
+    if !type_decl_is_fieldless_enum(td, llbc) {
         return None; // not fieldless
     }
     let by_discr: Vec<(i64, String)> = variants

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -6340,9 +6340,8 @@ impl<'a> Lowering<'a> {
                     // projection from a payload-free enum reads no bytes.
                     // Give the projected value the `Void` kind rather than
                     // materialising it in a value bank.  `getkind(lltype.Void)`
-                    // is `'void'`, and both `NON_VOID_ARGS`
-                    // (`call.py:220-221`) and `add_in_correct_list`
-                    // (`jtransform.py:449`) drop a void argument, so the value
+                    // is `'void'`, and both `call.py NON_VOID_ARGS` and
+                    // `jtransform.py add_in_correct_list` drop a void argument, so the value
                     // takes neither a calldescr `arg_classes` slot nor an
                     // argument-bank entry.  That is what the callee's machine
                     // ABI expects: a zero-sized parameter occupies no argument
@@ -16627,19 +16626,12 @@ impl<'a> Lowering<'a> {
         let Some(td) = self.llbc.type_by_id(def_id) else {
             return false;
         };
-        let TypeDeclKind::Enum(variants) = &td.kind else {
-            return false;
-        };
-        variants.iter().all(|variant| {
-            variant
-                .fields
-                .iter()
-                .all(|f| tyref_is_zero_sized(&f.ty, self.llbc))
-        }) && td
-            .layout_for_target("")
-            .and_then(|l| l.discriminant_offset())
-            .unwrap_or(0)
-            == 0
+        let target = std::env::var("TARGET").unwrap_or_default();
+        type_decl_is_fieldless_enum(td, self.llbc)
+            && td
+                .layout_for_target(&target)
+                .and_then(|l| l.discriminant_offset())
+                == Some(0)
     }
 
     /// The resolved JSON body of a [`TyRef`], following the dedup
@@ -20254,9 +20246,10 @@ fn tyref_is_zero_sized(ty: &TyRef, llbc: &Llbc) -> bool {
         TyRef::Inline { value: (_, v) } | TyRef::Other(v) => inline_adt_def_id(v),
         TyRef::Dedup { id } => llbc.dedup_to_adt_def_id(*id),
     };
+    let target = std::env::var("TARGET").unwrap_or_default();
     def_id
         .and_then(|def_id| llbc.type_by_id(def_id))
-        .and_then(|td| td.layout_for_target(""))
+        .and_then(|td| td.layout_for_target(&target))
         .is_some_and(|layout| layout.size == Some(0))
 }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -29800,6 +29800,126 @@ mod tests {
         Llbc::from_slice(file.to_string().as_bytes()).expect("fixture Llbc parses")
     }
 
+    #[test]
+    fn zero_sized_fields_are_payload_free_but_mixed_fields_are_not() {
+        let span = || {
+            serde_json::json!({"data": {
+                "file_id": 0,
+                "beg": {"line": 1, "col": 0},
+                "end": {"line": 1, "col": 1}
+            }})
+        };
+        let item_meta = |name: &str| {
+            serde_json::json!({
+                "name": [
+                    {"Ident": ["fixture", 0]},
+                    {"Ident": [name, 0]}
+                ],
+                "span": span(),
+                "source_text": null,
+                "attr_info": {
+                    "attributes": [],
+                    "inline": null,
+                    "rename": null,
+                    "public": true
+                },
+                "is_local": true
+            })
+        };
+        let adt = |def_id: u64, hash: u64| {
+            serde_json::json!({"HashConsedValue": [hash, {
+                "Adt": {
+                    "id": {"Adt": def_id},
+                    "generics": {
+                        "regions": [],
+                        "types": [],
+                        "const_generics": [],
+                        "trait_refs": []
+                    }
+                }
+            }]})
+        };
+        let field =
+            |ty: serde_json::Value| serde_json::json!({"name": null, "ty": ty, "attr_info": null});
+        let variant = |name: &str, fields: Vec<serde_json::Value>, discriminant: u64| {
+            serde_json::json!({
+                "name": name,
+                "fields": fields,
+                "discriminant": {"Scalar": {"Unsigned": ["U8", discriminant.to_string()]}}
+            })
+        };
+        let layout = |size: u64, field_offsets: Vec<u64>| {
+            serde_json::json!([{
+                "key": "fixture-target",
+                "value": {
+                    "size": size,
+                    "align": 1,
+                    "variant_layouts": [{"field_offsets": field_offsets}],
+                    "repr": {"transparent": false}
+                }
+            }])
+        };
+        let phantom = serde_json::json!({
+            "def_id": 0,
+            "item_meta": item_meta("Phantom"),
+            "kind": {"Struct": []},
+            "layout": layout(0, vec![])
+        });
+        let only_zst = serde_json::json!({
+            "def_id": 1,
+            "item_meta": item_meta("OnlyZst"),
+            "kind": {"Enum": [variant("Value", vec![field(adt(0, 10))], 0)]},
+            "layout": layout(1, vec![0])
+        });
+        let mixed = serde_json::json!({
+            "def_id": 2,
+            "item_meta": item_meta("Mixed"),
+            "kind": {"Enum": [variant(
+                "Value",
+                vec![
+                    field(adt(0, 11)),
+                    field(serde_json::json!({"Literal": {"Int": "I64"}}))
+                ],
+                0
+            )]},
+            "layout": layout(16, vec![0, 8])
+        });
+        let file = serde_json::json!({
+            "charon_version": "0.1.201",
+            "has_errors": false,
+            "translated": {
+                "crate_name": "fixture",
+                "type_decls": [phantom, only_zst, mixed],
+                "fun_decls": [],
+                "global_decls": [],
+                "trait_decls": [],
+                "trait_impls": []
+            }
+        });
+        let llbc = Llbc::from_slice(file.to_string().as_bytes()).expect("fixture Llbc parses");
+        let phantom_ty = serde_json::from_value::<TyRef>(adt(0, 20)).expect("phantom TyRef");
+        let only_zst_ty = serde_json::from_value::<TyRef>(adt(1, 21)).expect("ZST enum TyRef");
+        let mixed_ty = serde_json::from_value::<TyRef>(adt(2, 22)).expect("mixed enum TyRef");
+
+        assert!(super::tyref_is_zero_sized(&phantom_ty, &llbc));
+        assert!(super::type_decl_is_fieldless_enum(
+            llbc.type_by_id(1).expect("OnlyZst declaration"),
+            &llbc
+        ));
+        assert!(!super::type_decl_is_fieldless_enum(
+            llbc.type_by_id(2).expect("Mixed declaration"),
+            &llbc
+        ));
+        assert_eq!(
+            super::tyref_to_value_type(&only_zst_ty, &llbc),
+            ValueType::Int
+        );
+        assert!(matches!(
+            super::tyref_to_value_type(&mixed_ty, &llbc),
+            ValueType::Ref(_)
+        ));
+    }
+
     /// An `ArrayRead` element is addressable two ways: a scalar names its
     /// spelling so the descr computes the real width, or a thin pointer takes
     /// the identity-less mint's one-target-word assumption, which is already

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3466,6 +3466,31 @@ impl<'a> Lowering<'a> {
             graph.name_value_var(&var, name.clone());
             *slot = Some(var.clone());
             let ty = tyref_to_value_type(&local.ty, llbc);
+            // A parameter with no runtime representation (`Arg<T>`'s
+            // `PhantomData` marker is the case in point — rustc gives it no
+            // ABI slot) has to read as `Void` here, matching upstream's
+            // `getkind(lltype.Void)`: `NON_VOID_ARGS` (the caller's actual
+            // arguments) and `FUNC.ARGS` filtered the same way (this
+            // graph's declared parameters via `graph_non_void_arg_types`)
+            // both filter by the identical is-not-Void test, so a param the
+            // caller's own concretetype tracking already treats as
+            // void-carrying must agree here or `getcalldescr` sees a
+            // caller/callee arity mismatch and hard fails. Scoped to the
+            // declared-parameter fallback only — not
+            // `tyref_to_value_type` itself, which construction sites
+            // (`AggregateKind` lowering et al.) also call, and which must
+            // keep minting a real value for a zero-sized type until they
+            // erase it the way rtyper does everywhere. Guarded on the
+            // generic `Ref(None)` fallback so a real (non-zero-sized) Ref
+            // param is never touched, and a fieldless enum — already
+            // resolved to `Int` above regardless of its own zero-sized
+            // layout — never reaches this arm.
+            let ty = if matches!(ty, ValueType::Ref(None)) && tyref_is_zero_sized(&local.ty, llbc)
+            {
+                ValueType::Void
+            } else {
+                ty
+            };
             // `class_root` carries the param's named-ADT leaf so
             // `derive_subject_inputcells` can seed the receiver's
             // `ClassDef`; only `Ref`-typed params consume it there.  A

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -100,6 +100,16 @@ use crate::model::{
     LinkArg, OpKind, SpaceOperation, ValueType,
 };
 
+/// Opaque non-null value for a prebuilt JIT-driver `NamedConst`.
+///
+/// The driver instance is only the receiver constant of its marker methods;
+/// rtyping erases that receiver to `Void`, and `jtransform` discards operand
+/// zero while rewriting the marker.  It therefore has no runtime address to
+/// preserve, but the front-end graph still needs one constant-producing
+/// operation until that rewrite.  Non-null keeps it distinct from the null
+/// reference representation on every backend.
+const JITDRIVER_NAMEDCONST_SENTINEL_ADDR: i64 = 8;
+
 /// Top-level entry — load `function_name` out of `llbc`, lower it,
 /// return the constructed [`FunctionGraph`].
 ///
@@ -141,7 +151,15 @@ pub fn build_semantic_program_from_llbcs_with_static_addrs(
     llbcs: &[Llbc],
     static_addrs: crate::HostStaticAddrs<'_>,
 ) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
-    build_semantic_program_from_llbcs_with_static_addrs_filtered(llbcs, static_addrs, None, None)
+    let jitdriver_receiver_roots =
+        crate::codewriter::jtransform::default_jitdriver_receiver_roots();
+    build_semantic_program_from_llbcs_with_static_addrs_filtered(
+        llbcs,
+        static_addrs,
+        &jitdriver_receiver_roots,
+        None,
+        None,
+    )
 }
 
 pub fn build_semantic_program_from_llbcs_with_static_addrs_and_module_paths(
@@ -149,10 +167,27 @@ pub fn build_semantic_program_from_llbcs_with_static_addrs_and_module_paths(
     static_addrs: crate::HostStaticAddrs<'_>,
     module_paths: &[&str],
 ) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
+    let jitdriver_receiver_roots =
+        crate::codewriter::jtransform::default_jitdriver_receiver_roots();
+    build_semantic_program_from_llbcs_with_static_addrs_module_paths_and_jitdriver_roots(
+        llbcs,
+        static_addrs,
+        module_paths,
+        &jitdriver_receiver_roots,
+    )
+}
+
+pub(crate) fn build_semantic_program_from_llbcs_with_static_addrs_module_paths_and_jitdriver_roots(
+    llbcs: &[Llbc],
+    static_addrs: crate::HostStaticAddrs<'_>,
+    module_paths: &[&str],
+    jitdriver_receiver_roots: &[String],
+) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
     let module_filter = normalize_module_filter(module_paths);
     build_semantic_program_from_llbcs_with_static_addrs_filtered(
         llbcs,
         static_addrs,
+        jitdriver_receiver_roots,
         module_filter.as_ref(),
         None,
     )
@@ -180,9 +215,12 @@ pub fn build_semantic_program_from_llbcs_with_static_addrs_and_function_names(
 ) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
     let module_filter = normalize_module_filter(module_paths);
     let function_filter = normalize_function_filter(function_names);
+    let jitdriver_receiver_roots =
+        crate::codewriter::jtransform::default_jitdriver_receiver_roots();
     build_semantic_program_from_llbcs_with_static_addrs_filtered(
         llbcs,
         static_addrs,
+        &jitdriver_receiver_roots,
         module_filter.as_ref(),
         function_filter.as_ref(),
     )
@@ -191,6 +229,7 @@ pub fn build_semantic_program_from_llbcs_with_static_addrs_and_function_names(
 fn build_semantic_program_from_llbcs_with_static_addrs_filtered(
     llbcs: &[Llbc],
     static_addrs: crate::HostStaticAddrs<'_>,
+    jitdriver_receiver_roots: &[String],
     module_filter: Option<&std::collections::HashSet<String>>,
     function_filter: Option<&std::collections::HashSet<String>>,
 ) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
@@ -223,6 +262,7 @@ fn build_semantic_program_from_llbcs_with_static_addrs_filtered(
         let prog = build_semantic_program_from_llbc_with_static_addrs_filtered(
             llbc,
             static_addrs,
+            jitdriver_receiver_roots,
             module_filter,
             function_filter,
         )?;
@@ -721,7 +761,15 @@ pub fn build_semantic_program_from_llbc_with_static_addrs(
     // per-artefact builder below does not repeat it. A caller handing over a
     // single artefact has named its whole input here, so link it here.
     link_transparent_scalar_types(std::slice::from_ref(llbc));
-    build_semantic_program_from_llbc_with_static_addrs_filtered(llbc, static_addrs, None, None)
+    let jitdriver_receiver_roots =
+        crate::codewriter::jtransform::default_jitdriver_receiver_roots();
+    build_semantic_program_from_llbc_with_static_addrs_filtered(
+        llbc,
+        static_addrs,
+        &jitdriver_receiver_roots,
+        None,
+        None,
+    )
 }
 
 /// One block's slot-indexed `Option<Variable>` row, stored by bound slot.
@@ -824,6 +872,7 @@ impl PackedFrameState {
 fn build_semantic_program_from_llbc_with_static_addrs_filtered(
     llbc: &Llbc,
     static_addrs: crate::HostStaticAddrs<'_>,
+    jitdriver_receiver_roots: &[String],
     module_filter: Option<&std::collections::HashSet<String>>,
     function_filter: Option<&std::collections::HashSet<String>>,
 ) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
@@ -993,6 +1042,7 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
             fd,
             &body,
             static_addrs,
+            jitdriver_receiver_roots,
             &struct_field_attrs,
             &dont_look_inside,
             builder_mode,
@@ -2197,7 +2247,15 @@ pub fn lower_fun_decl_with_static_addrs(
     // stand-alone entry (used by the reader / tests) derives it per call from
     // the same source of truth so the fusion fires identically.
     let (_, _, _, _, _, struct_field_attrs, _, _) = derive_program_metadata(llbc);
-    lower_fun_decl_with_static_addrs_and_attrs(llbc, fd, static_addrs, &struct_field_attrs)
+    let jitdriver_receiver_roots =
+        crate::codewriter::jtransform::default_jitdriver_receiver_roots();
+    lower_fun_decl_with_static_addrs_attrs_and_jitdriver_roots(
+        llbc,
+        fd,
+        static_addrs,
+        &jitdriver_receiver_roots,
+        &struct_field_attrs,
+    )
 }
 
 /// The `struct_field_attrs` projection of [`derive_program_metadata`] —
@@ -2224,10 +2282,29 @@ pub(crate) fn dont_look_inside_set_of(llbc: &Llbc) -> std::collections::HashSet<
         .collect()
 }
 
+#[cfg(test)]
 pub(crate) fn lower_fun_decl_with_static_addrs_and_attrs(
     llbc: &Llbc,
     fd: &FunDecl,
     static_addrs: crate::HostStaticAddrs<'_>,
+    struct_field_attrs: &std::collections::HashMap<String, Vec<(String, ValueType)>>,
+) -> Result<FunctionGraph, LowerError> {
+    let jitdriver_receiver_roots =
+        crate::codewriter::jtransform::default_jitdriver_receiver_roots();
+    lower_fun_decl_with_static_addrs_attrs_and_jitdriver_roots(
+        llbc,
+        fd,
+        static_addrs,
+        &jitdriver_receiver_roots,
+        struct_field_attrs,
+    )
+}
+
+fn lower_fun_decl_with_static_addrs_attrs_and_jitdriver_roots(
+    llbc: &Llbc,
+    fd: &FunDecl,
+    static_addrs: crate::HostStaticAddrs<'_>,
+    jitdriver_receiver_roots: &[String],
     struct_field_attrs: &std::collections::HashMap<String, Vec<(String, ValueType)>>,
 ) -> Result<FunctionGraph, LowerError> {
     let u = fd.unstructured().ok_or_else(|| {
@@ -2249,6 +2326,7 @@ pub(crate) fn lower_fun_decl_with_static_addrs_and_attrs(
         fd,
         &u,
         static_addrs,
+        jitdriver_receiver_roots,
         struct_field_attrs,
         &dont_look_inside,
         builder_mode,
@@ -2302,6 +2380,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
     fd: &FunDecl,
     u: &Unstructured,
     static_addrs: crate::HostStaticAddrs<'_>,
+    jitdriver_receiver_roots: &[String],
     struct_field_attrs: &std::collections::HashMap<String, Vec<(String, ValueType)>>,
     dont_look_inside: &std::collections::HashSet<String>,
     // When set, each strategy's `Lowering` is switched to builder form
@@ -2792,6 +2871,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             name.clone(),
             u,
             static_addrs,
+            jitdriver_receiver_roots,
             fd.generics.as_ref(),
             dont_look_inside,
         )?;
@@ -2834,6 +2914,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
         name.clone(),
         u,
         static_addrs,
+        jitdriver_receiver_roots,
         fd.generics.as_ref(),
         dont_look_inside,
     )?;
@@ -2862,6 +2943,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
                 name,
                 u,
                 static_addrs,
+                jitdriver_receiver_roots,
                 fd.generics.as_ref(),
                 dont_look_inside,
             )?;
@@ -3137,6 +3219,12 @@ struct Lowering<'a> {
     dont_look_inside: &'a std::collections::HashSet<String>,
     body: &'a Unstructured,
     static_addrs: crate::HostStaticAddrs<'a>,
+    /// Configured receiver-type paths whose marker methods identify a
+    /// `JitDriver`.  The same roots feed `jit_marker_key_from_target` in the
+    /// codewriter; carrying them into the front end lets a read of the
+    /// corresponding prebuilt driver const become a value constant before
+    /// the nullary residual-call fallback.
+    jitdriver_receiver_roots: &'a [String],
     arg_count: usize,
     /// `local_var[i] = Some(var)` once MIR local `i` has been bound to
     /// a flowspace Variable. Slot 0 is the return value, 1..arg_count
@@ -3424,6 +3512,7 @@ impl<'a> Lowering<'a> {
         name: String,
         body: &'a Unstructured,
         static_addrs: crate::HostStaticAddrs<'a>,
+        jitdriver_receiver_roots: &'a [String],
         generics: Option<&serde_json::Value>,
         dont_look_inside: &'a std::collections::HashSet<String>,
     ) -> Result<Self, LowerError> {
@@ -3623,6 +3712,7 @@ impl<'a> Lowering<'a> {
             dont_look_inside,
             body,
             static_addrs,
+            jitdriver_receiver_roots,
             arg_count,
             local_var,
             block_id,
@@ -6739,36 +6829,24 @@ impl<'a> Lowering<'a> {
                     });
                     return Ok(res);
                 }
-                // A zero-field unit-struct `const` (the `unpackiterable_driver`
-                // JitDriver, baseobjspace.py:29) is inlined and has no
-                // registered address, so `static_addr_op` returned `None` and
-                // the addressed-singleton arm above declined.  The driver
-                // receiver of a `jit_merge_point` marker is erased to a `Void`
-                // constant at rtyping and to a `Signed` jitdriver index before
-                // the trace runs (`jtransform.py:1704`); `OpKind::Call` operands
-                // are Variables, so the receiver still materialises as a
-                // Variable the marker rewrite strips (autoreds redvar
-                // subtraction + `args.split_first()`).  Emit a single non-null
-                // sentinel `ConstRefAddr` — the same one-ref-result shape a
-                // 0-arg accessor call would have, but without the residual call
-                // whose funcptr constant degrades to a `symbolic_fnaddr_for_path`
-                // hash that SIGBUSes at trace time.  Deliberately NOT the
-                // `__cast_instance_intrinsic` narrowing the addressed siblings use:
-                // its extra cast Variable shifts the loop's ref-register
-                // allocation so a merge-point red lands past `num_regs_r`
-                // (seed-time out-of-bounds in `trace_jitcode_from_merge_point`).
-                // The receiver is stripped, so its `SomePtr` typing is never
-                // unioned downstream; the sentinel is non-null so it never
-                // trips the offset-0 null-Ref wasm silent-miscompile class.
-                if self.refs_static_zerofield_struct_root(&place_ty).is_some() {
-                    const ZEROFIELD_NAMEDCONST_SENTINEL_ADDR: i64 = 8;
+                // A prebuilt JitDriver `const` has no registered address. Its
+                // value exists in the flow graph only as operand zero of a
+                // marker method: `ExtEnterLeaveMarker.specialize_call` makes
+                // it a receiver Constant, rtyping erases it to `Void`, and
+                // `Transformer.try_handle_jit_marker` discards the receiver.
+                // Keep the producer constant-shaped so `split_block` can
+                // rematerialise it, without turning the const path into a
+                // nullary residual call. The declared ADT is matched against
+                // the same configured receiver roots the codewriter uses; the
+                // global's own name is deliberately irrelevant.
+                if self.is_jitdriver_named_const(id, &place_ty) {
                     let res = self
                         .graph
                         .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
                     let bb_id = self.block_id[mir_bb];
                     self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                         result: Some(res.clone()),
-                        kind: OpKind::ConstRefAddr(ZEROFIELD_NAMEDCONST_SENTINEL_ADDR),
+                        kind: OpKind::ConstRefAddr(JITDRIVER_NAMEDCONST_SENTINEL_ADDR),
                     });
                     return Ok(res);
                 }
@@ -7473,6 +7551,40 @@ impl<'a> Lowering<'a> {
             }
         }
         None
+    }
+
+    /// Whether `def_id` is an immutable prebuilt instance of a configured
+    /// JIT-driver receiver type.
+    ///
+    /// `GraphTransformConfig::jitdriver_receiver_roots` is the front-to-
+    /// codewriter registration of the types whose marker methods are handled
+    /// by `jit_marker_key_from_target`.  Match that set against the global's
+    /// declared ADT path, not against any particular global binding, so every
+    /// driver instance gets the same constant treatment.
+    fn is_jitdriver_named_const(&self, def_id: u64, ty: &TyRef) -> bool {
+        let Some(global) = self.llbc.global_by_id(def_id) else {
+            return false;
+        };
+        if global
+            .rest
+            .get("global_kind")
+            .and_then(serde_json::Value::as_str)
+            != Some("NamedConst")
+        {
+            return false;
+        }
+        let Some(type_path) = tyref_node(ty, self.llbc)
+            .and_then(|node| strip_ty_wrappers(node, self.llbc))
+            .and_then(adt_node_def_id)
+            .and_then(|id| self.llbc.type_by_id(id))
+            .map(|decl| decl.item_meta.name_path())
+        else {
+            return false;
+        };
+        let stripped = strip_crate_prefix(&type_path);
+        self.jitdriver_receiver_roots
+            .iter()
+            .any(|root| static_key_matches(&type_path, &stripped, root))
     }
 
     /// Value of an immutable size `const` baked at build time
@@ -29275,6 +29387,85 @@ mod tests {
         );
     }
 
+    /// The field-bearing primary driver const must lower exactly like the
+    /// zero-field unpack driver: one opaque constant receiver for each marker,
+    /// never a residual call to the const item's symbolic path.  Ignored by
+    /// default because it loads the extracted pyre-jit artefact; run with
+    /// `cargo test -p majit-translate --lib
+    /// pypyjitdriver_named_const_is_a_marker_receiver_constant -- --ignored`.
+    #[test]
+    #[ignore]
+    fn pypyjitdriver_named_const_is_a_marker_receiver_constant() {
+        use crate::model::{CallTarget, OpKind};
+
+        let llbc =
+            Llbc::load(crate::runtime_names::artifacts::JIT_ULLBC).expect("load pyre-jit LLBC");
+        let graph = super::lower_function(&llbc, "eval_loop_jit").expect("lower eval_loop_jit");
+        let driver_path = ["pyre_jit", "eval", "pypyjitdriver"];
+
+        assert!(
+            !graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        args,
+                        ..
+                    } if args.is_empty()
+                        && super::fmt_path_ends_with(segments, &driver_path)
+                )),
+            "the driver const path must not survive as a nullary call"
+        );
+
+        let marker_receivers: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::Call {
+                    target:
+                        CallTarget::Method {
+                            name,
+                            receiver_root: Some(root),
+                            ..
+                        },
+                    args,
+                    ..
+                } if root == "PyPyJitDriver"
+                    && matches!(name.as_str(), "jit_merge_point" | "can_enter_jit") =>
+                {
+                    args.first()
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            marker_receivers.len(),
+            2,
+            "eval_loop_jit must retain both source marker calls after MIR lowering"
+        );
+        for receiver in marker_receivers {
+            let (block_id, op_index) = super::resolve_to_producer_op(&graph, receiver)
+                .expect("marker receiver has one producer");
+            let producer = &graph
+                .blocks
+                .iter()
+                .find(|block| block.id == block_id)
+                .expect("producer block")
+                .operations[op_index];
+            assert!(
+                matches!(
+                    producer.kind,
+                    OpKind::ConstRefAddr(super::JITDRIVER_NAMEDCONST_SENTINEL_ADDR)
+                ),
+                "marker receiver producer must be the driver sentinel: {producer:?}"
+            );
+        }
+    }
+
     /// Anchor the `(a..=b).contains(&v)` fold to the real lowered IR of
     /// its int census callers — `setitem_bytearray` / `byte_w`
     /// (`(0..=255)`, constant bounds) and `c_int_w` (`(i32::MIN as
@@ -30051,9 +30242,12 @@ mod tests {
             Llbc::from_slice(artifact(serde_json::json!("Opaque")).to_string().as_bytes()).unwrap();
         let llbcs = vec![defining, opaque];
         super::link_transparent_scalar_types(&llbcs);
+        let jitdriver_receiver_roots =
+            crate::codewriter::jtransform::default_jitdriver_receiver_roots();
         super::build_semantic_program_from_llbc_with_static_addrs_filtered(
             &llbcs[1],
             crate::HostStaticAddrs::default(),
+            &jitdriver_receiver_roots,
             None,
             None,
         )

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3574,8 +3574,7 @@ impl<'a> Lowering<'a> {
             // param is never touched, and a fieldless enum — already
             // resolved to `Int` above regardless of its own zero-sized
             // layout — never reaches this arm.
-            let ty = if matches!(ty, ValueType::Ref(None)) && tyref_is_zero_sized(&local.ty, llbc)
-            {
+            let ty = if matches!(ty, ValueType::Ref(None)) && tyref_is_zero_sized(&local.ty, llbc) {
                 ValueType::Void
             } else {
                 ty

--- a/majit/majit-translate/src/generated.rs
+++ b/majit/majit-translate/src/generated.rs
@@ -227,6 +227,7 @@ fn build() -> AllJitCodes {
                 transform: crate::GraphTransformConfig::default(),
                 jit_drivers: vec![crate::JitDriverSpec {
                     portal: crate::CallPath::from_segments(["eval", "eval_loop_jit"]),
+                    portal_runner: None,
                     greens: vec![
                         "next_instr".to_string(),
                         "is_being_profiled".to_string(),

--- a/majit/majit-translate/src/generated.rs
+++ b/majit/majit-translate/src/generated.rs
@@ -238,6 +238,7 @@ fn build() -> AllJitCodes {
                     autoreds: false,
                     virtualizables: vec!["frame".to_string()],
                     red_types: vec!["PyFrame".to_string(), "ExecutionContext".to_string()],
+                    split_portal: false,
                 }],
                 register_trait_families: Vec::new(),
             },

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -198,6 +198,7 @@ pub struct MethodInfo {
 fn build_semantic_program_via_active_frontend(
     module_paths: &[&str],
     static_addrs: HostStaticAddrs<'_>,
+    jitdriver_receiver_roots: &[String],
     explicit_llbc_paths: Option<&[&str]>,
     prof: &mut PhaseProfiler,
 ) -> front::SemanticProgram {
@@ -245,10 +246,11 @@ fn build_semantic_program_via_active_frontend(
                 llbcs.iter().map(|l| l.crate_name().to_string()),
             );
             let mut program =
-                front::mir::build_semantic_program_from_llbcs_with_static_addrs_and_module_paths(
+                front::mir::build_semantic_program_from_llbcs_with_static_addrs_module_paths_and_jitdriver_roots(
                     &llbcs,
                     static_addrs,
                     module_paths,
+                    jitdriver_receiver_roots,
                 )
                 .unwrap_or_else(|e| panic!("Step 4.4 cutover: lower llbcs {paths:?}: {e}"));
             prof.mark("    build_semantic_program_from_llbcs");
@@ -959,6 +961,7 @@ fn analyze_pipeline_from_module_paths(
     let mut program = build_semantic_program_via_active_frontend(
         module_paths,
         static_addrs,
+        &config.pipeline.transform.jitdriver_receiver_roots,
         explicit_llbc_paths,
         &mut prof,
     );

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -2228,12 +2228,18 @@ fn register_configured_jitdrivers(
                 .source_identity
                 .clone()
                 .unwrap_or_else(|| original.name.clone());
-            portal.name = format!("{}_portal", original.name);
+            let portal_name = format!(
+                "{}_portal",
+                spec.portal
+                    .last_segment()
+                    .expect("non-empty portal path asserted above")
+            );
+            portal.name = portal_name.clone();
             portal.source_identity = Some(format!("{original_identity}#portal"));
             let mut portal_segments = spec.portal.segments.clone();
             *portal_segments
                 .last_mut()
-                .expect("non-empty portal path asserted above") = portal.name.clone();
+                .expect("non-empty portal path asserted above") = portal_name;
             let portal_path = crate::parse::CallPath::from_segments(portal_segments);
 
             let (marker_block, marker_index) =
@@ -2668,7 +2674,7 @@ mod portal_driver_tests {
 
         let mut call_control = call::CallControl::new();
         let portal = CallPath::from_segments(["fixture", "eval_loop_jit"]);
-        let mut graph = FunctionGraph::new("eval_loop_jit");
+        let mut graph = FunctionGraph::new("pyre_jit::eval::eval_loop_jit");
         let next_instr = graph.alloc_value_var_with_type(ConcreteType::Signed);
         let is_being_profiled = graph.alloc_value_var_with_type(ConcreteType::Signed);
         let pycode = graph.alloc_value_var_with_type(ConcreteType::GcRef);
@@ -2725,11 +2731,23 @@ mod portal_driver_tests {
             &config.jit_drivers,
             &config.transform.jitdriver_receiver_roots,
         );
+        let split_portal = CallPath::from_segments(["fixture", "eval_loop_jit_portal"]);
+        assert_eq!(call_control.jitdrivers_sd()[0].portal_graph, split_portal);
+        let split_graph = call_control
+            .function_graphs()
+            .get(&split_portal)
+            .expect("split portal graph must be registered under its derived path");
+        assert_eq!(split_graph.name, "eval_loop_jit_portal");
+        assert_eq!(
+            split_graph.source_identity.as_deref(),
+            Some("pyre_jit::eval::eval_loop_jit#portal")
+        );
         let mut policy = policy::DefaultJitPolicy::new();
         call_control.find_all_graphs(&mut policy);
 
         let (jitcodes, _, _, _, _) =
             make_jitcodes(&config, &mut call_control, &mut PhaseProfiler::new());
+        assert_eq!(jitcodes[0].name, "eval_loop_jit_portal");
         let merge = jitcodes[0]
             .body()
             ._ssarepr

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -103,6 +103,7 @@ mod parse;
 )]
 pub mod pipeline;
 mod runtime_names;
+mod unsimplify;
 pub mod virtualizable_decl;
 // `translator/` is the RPython-orthodox port home — see
 // `translator/mod.rs` for the contract.  Currently hosts
@@ -1963,7 +1964,11 @@ fn analyze_pipeline_from_module_paths(
     // RPython: setup_jitdriver(jitdriver_sd) — register every explicit
     // portal and its green/red layout. Portal binding and graph discovery
     // are independent of any interpreter dispatch representation.
-    register_configured_jitdrivers(&mut call_control, &config.pipeline.jit_drivers);
+    register_configured_jitdrivers(
+        &mut call_control,
+        &config.pipeline.jit_drivers,
+        &config.pipeline.transform.jitdriver_receiver_roots,
+    );
     // warmspot.py WarmRunnerDesc.make_virtualizable_infos —
     // assigns each registered driver's virtualizable metadata only after the
     // complete driver set exists.
@@ -2170,6 +2175,7 @@ fn analyze_pipeline_from_module_paths(
 fn register_configured_jitdrivers(
     call_control: &mut call::CallControl,
     specs: &[pipeline::JitDriverSpec],
+    driver_roots: &[String],
 ) {
     assert!(
         !specs.is_empty(),
@@ -2206,8 +2212,59 @@ fn register_configured_jitdrivers(
              must share one JitDriverStaticData",
             spec.portal.canonical_key(),
         );
+        // `spec.autoreds`: `support.py decode_hp_hint_args` requires a fixed
+        // numreds; `warmspot.py find_portals` obtains it from
+        // `support.autodetect_jit_markers_redvars` before splitting, while
+        // majit currently discovers autoreds later in
+        // `jtransform.py try_handle_jit_marker`.
+        let portal_path = if !spec.split_portal || spec.autoreds {
+            spec.portal.clone()
+        } else {
+            // Ends the `call_control` borrow the `register_function_graph`
+            // below needs mutably; also the `warmspot.py:441` copy source.
+            let original = portal_graph.clone();
+            let mut portal = crate::model::copygraph(&original);
+            let original_identity = original
+                .source_identity
+                .clone()
+                .unwrap_or_else(|| original.name.clone());
+            portal.name = format!("{}_portal", original.name);
+            portal.source_identity = Some(format!("{original_identity}#portal"));
+            let mut portal_segments = spec.portal.segments.clone();
+            *portal_segments
+                .last_mut()
+                .expect("non-empty portal path asserted above") = portal.name.clone();
+            let portal_path = crate::parse::CallPath::from_segments(portal_segments);
+
+            let (marker_block, marker_index) =
+                crate::codewriter::support::find_jit_merge_point(&portal, driver_roots)
+                    .expect("no jit_merge_point found in configured portal graph");
+            portal.startblock = crate::codewriter::support::split_before_jit_merge_point(
+                &mut portal,
+                marker_block,
+                marker_index,
+                spec.greens.len(),
+                spec.reds.len(),
+                driver_roots,
+            );
+            // `warmspot.py split_graph_and_record_jitdriver` also sets
+            // `_dont_inline_`; the rich model has no carrier for that flag.
+            portal.hints.push("unroll_safe".into());
+            let split_start = portal.startblock;
+            call_control.register_function_graph(portal_path.clone(), portal);
+            let registered = call_control
+                .function_graphs()
+                .get(&portal_path)
+                .expect("registered split portal path must resolve");
+            assert_eq!(
+                crate::codewriter::support::find_jit_merge_point(registered, driver_roots),
+                Some((split_start, 0)),
+                "registered portal path aliased away from the split graph body"
+            );
+            portal_path
+        };
         call_control.setup_jitdriver(
-            spec.portal.clone(),
+            portal_path,
             spec.greens.clone(),
             spec.reds.clone(),
             spec.green_kinds.clone(),
@@ -2215,6 +2272,7 @@ fn register_configured_jitdrivers(
             spec.autoreds,
             spec.virtualizables.clone(),
             spec.red_types.clone(),
+            spec.portal.clone(),
         );
     }
 }
@@ -2542,6 +2600,7 @@ mod portal_driver_tests {
             autoreds: false,
             virtualizables: Vec::new(),
             red_types: Vec::new(),
+            split_portal: false,
         }
     }
 
@@ -2563,7 +2622,11 @@ mod portal_driver_tests {
         call_control.register_function_graph(first.clone(), return_graph("portal"));
         call_control.register_function_graph(second.clone(), return_graph("portal"));
 
-        register_configured_jitdrivers(&mut call_control, &[driver(first), driver(second)]);
+        register_configured_jitdrivers(
+            &mut call_control,
+            &[driver(first), driver(second)],
+            &GraphTransformConfig::default().jitdriver_receiver_roots,
+        );
     }
 
     #[test]
@@ -2576,7 +2639,11 @@ mod portal_driver_tests {
             jit_drivers: vec![driver(portal.clone())],
             register_trait_families: Vec::new(),
         };
-        register_configured_jitdrivers(&mut call_control, &config.jit_drivers);
+        register_configured_jitdrivers(
+            &mut call_control,
+            &config.jit_drivers,
+            &config.transform.jitdriver_receiver_roots,
+        );
         let mut policy = policy::DefaultJitPolicy::new();
         call_control.find_all_graphs(&mut policy);
 
@@ -2595,14 +2662,12 @@ mod portal_driver_tests {
         let mut call_control = call::CallControl::new();
         let portal = CallPath::from_segments(["fixture", "eval_loop_jit"]);
         let mut graph = FunctionGraph::new("eval_loop_jit");
-        let receiver = graph.alloc_value_var_with_type(ConcreteType::GcRef);
         let next_instr = graph.alloc_value_var_with_type(ConcreteType::Signed);
         let is_being_profiled = graph.alloc_value_var_with_type(ConcreteType::Signed);
         let pycode = graph.alloc_value_var_with_type(ConcreteType::GcRef);
         let frame = graph.alloc_value_var_with_type(ConcreteType::GcRef);
         let ec = graph.alloc_value_var_with_type(ConcreteType::GcRef);
         graph.blocks[graph.startblock.0].inputargs = vec![
-            receiver.clone(),
             next_instr.clone(),
             is_being_profiled.clone(),
             pycode.clone(),
@@ -2616,7 +2681,7 @@ mod portal_driver_tests {
                 kind: OpKind::Call {
                     target: CallTarget::method("jit_merge_point", Some("PyPyJitDriver".into())),
                     args: vec![
-                        receiver,
+                        frame.clone(),
                         next_instr,
                         is_being_profiled,
                         pycode,
@@ -2644,10 +2709,15 @@ mod portal_driver_tests {
                 autoreds: false,
                 virtualizables: vec!["frame".into()],
                 red_types: vec!["PyFrame".into(), "ExecutionContext".into()],
+                split_portal: true,
             }],
             register_trait_families: Vec::new(),
         };
-        register_configured_jitdrivers(&mut call_control, &config.jit_drivers);
+        register_configured_jitdrivers(
+            &mut call_control,
+            &config.jit_drivers,
+            &config.transform.jitdriver_receiver_roots,
+        );
         let mut policy = policy::DefaultJitPolicy::new();
         call_control.find_all_graphs(&mut policy);
 
@@ -2668,7 +2738,13 @@ mod portal_driver_tests {
                 _ => None,
             })
             .expect("portal emits a jit_merge_point");
-        assert_eq!(merge, &vec![frame, ec]);
+        assert_eq!(merge.len(), 2);
+        assert!(
+            merge
+                .iter()
+                .all(|var| FunctionGraph::concretetype_of(var) == ConcreteType::GcRef)
+        );
+        assert_ne!(merge[0].id(), merge[1].id());
         let jd0 = &call_control.jitdrivers_sd()[0];
         assert!(!jd0.autoreds);
         assert_eq!(jd0.numreds, Some(2));

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -2256,9 +2256,16 @@ fn register_configured_jitdrivers(
                 .function_graphs()
                 .get(&portal_path)
                 .expect("registered split portal path must resolve");
+            // The marker heads the split block up to the operations
+            // `split_block` re-emits before it: upstream inserts `same_as` of
+            // a constant there and `remove_same_as` folds it into the marker's
+            // operand, so the marker lands at index 0; here the receiver's
+            // producer stays as a real operation because operands are
+            // Variables, so only the block is asserted.
             assert_eq!(
-                crate::codewriter::support::find_jit_merge_point(registered, driver_roots),
-                Some((split_start, 0)),
+                crate::codewriter::support::find_jit_merge_point(registered, driver_roots)
+                    .map(|(block, _)| block),
+                Some(split_start),
                 "registered portal path aliased away from the split graph body"
             );
             portal_path

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -2135,6 +2135,7 @@ fn analyze_pipeline_from_module_paths(
         .iter()
         .map(|driver| pipeline::CompiledJitDriver {
             portal: driver.portal_graph.clone(),
+            portal_runner: driver.portal_runner.clone(),
             main_jitcode_index: driver
                 .mainjitcode
                 .as_ref()
@@ -2244,6 +2245,11 @@ fn register_configured_jitdrivers(
                 .last_mut()
                 .expect("non-empty portal path asserted above") = portal_name;
             let portal_path = crate::parse::CallPath::from_segments(portal_segments);
+            assert!(
+                !call_control.function_graphs().contains_key(&portal_path),
+                "derived split portal path `{}` collides with an existing graph",
+                portal_path.canonical_key(),
+            );
 
             let (marker_block, marker_index) =
                 crate::codewriter::support::find_jit_merge_point(&portal, driver_roots)
@@ -2256,8 +2262,10 @@ fn register_configured_jitdrivers(
                 spec.reds.len(),
                 driver_roots,
             );
-            // `warmspot.py split_graph_and_record_jitdriver` also sets
-            // `_dont_inline_`; the rich model has no carrier for that flag.
+            // `warmspot.py WarmRunnerDesc.split_graph_and_record_jitdriver`:
+            // keep the copied portal as a backend-inlining boundary and let
+            // JIT policy inspect its loop.
+            portal.func.dont_inline = true;
             portal.hints.push("unroll_safe".into());
             let split_start = portal.startblock;
             call_control.register_function_graph(portal_path.clone(), portal);
@@ -2290,6 +2298,7 @@ fn register_configured_jitdrivers(
             spec.red_types.clone(),
             spec.portal.clone(),
         );
+        call_control.set_jitdriver_portal_runner(index, spec.portal_runner.clone());
     }
 }
 
@@ -2609,6 +2618,7 @@ mod portal_driver_tests {
     fn driver(portal: CallPath) -> pipeline::JitDriverSpec {
         pipeline::JitDriverSpec {
             portal,
+            portal_runner: None,
             greens: Vec::new(),
             reds: Vec::new(),
             green_kinds: Vec::new(),
@@ -2641,6 +2651,41 @@ mod portal_driver_tests {
         register_configured_jitdrivers(
             &mut call_control,
             &[driver(first), driver(second)],
+            &GraphTransformConfig::default().jitdriver_receiver_roots,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "derived split portal path `fixture::eval_loop_jit_portal` collides")]
+    fn rejects_split_portal_path_collision() {
+        use crate::codewriter::type_state::ConcreteType;
+
+        let mut call_control = call::CallControl::new();
+        let portal = CallPath::from_segments(["fixture", "eval_loop_jit"]);
+        let derived = CallPath::from_segments(["fixture", "eval_loop_jit_portal"]);
+        let mut graph = FunctionGraph::new("eval_loop_jit");
+        let receiver = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        graph.block_mut(graph.startblock).inputargs = vec![receiver.clone()];
+        graph
+            .block_mut(graph.startblock)
+            .operations
+            .push(SpaceOperation {
+                result: None,
+                kind: OpKind::Call {
+                    target: CallTarget::method("jit_merge_point", Some("PyPyJitDriver".into())),
+                    args: vec![receiver],
+                    result_ty: ValueType::Void,
+                },
+            });
+        graph.set_return(graph.startblock, None);
+        call_control.register_function_graph(portal.clone(), graph);
+        call_control.register_function_graph(derived, return_graph("unrelated_existing_graph"));
+        let mut spec = driver(portal);
+        spec.split_portal = true;
+
+        register_configured_jitdrivers(
+            &mut call_control,
+            &[spec],
             &GraphTransformConfig::default().jitdriver_receiver_roots,
         );
     }
@@ -2714,6 +2759,7 @@ mod portal_driver_tests {
             transform: GraphTransformConfig::default(),
             jit_drivers: vec![pipeline::JitDriverSpec {
                 portal: portal.clone(),
+                portal_runner: Some(CallPath::from_segments(["fixture", "portal_runner"])),
                 greens: vec![
                     "next_instr".into(),
                     "is_being_profiled".into(),
@@ -2736,15 +2782,22 @@ mod portal_driver_tests {
         );
         let split_portal = CallPath::from_segments(["fixture", "eval_loop_jit_portal"]);
         assert_eq!(call_control.jitdrivers_sd()[0].portal_graph, split_portal);
+        assert_eq!(
+            call_control.jitdrivers_sd()[0].portal_runner,
+            Some(CallPath::from_segments(["fixture", "portal_runner"]))
+        );
         let split_graph = call_control
             .function_graphs()
             .get(&split_portal)
             .expect("split portal graph must be registered under its derived path");
         assert_eq!(split_graph.name, "eval_loop_jit_portal");
+        assert!(split_graph.func.dont_inline);
+        assert!(split_graph.hints.iter().any(|hint| hint == "unroll_safe"));
         assert_eq!(
             split_graph.source_identity.as_deref(),
             Some("pyre_jit::eval::eval_loop_jit#portal")
         );
+        let split_reds = split_graph.block(split_graph.startblock).inputargs[3..5].to_vec();
         let mut policy = policy::DefaultJitPolicy::new();
         call_control.find_all_graphs(&mut policy);
 
@@ -2767,6 +2820,7 @@ mod portal_driver_tests {
             })
             .expect("portal emits a jit_merge_point");
         assert_eq!(merge.len(), 2);
+        assert_eq!(merge, &split_reds);
         assert!(
             merge
                 .iter()

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -5929,6 +5929,7 @@ pub fn copygraph(graph: &FunctionGraph) -> FunctionGraph {
         notes: graph.notes.clone(),
         return_type: graph.return_type.clone(),
         hints: graph.hints.clone(),
+        access_directly: graph.access_directly,
         func: graph.func.clone(),
     }
 }

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -5828,6 +5828,111 @@ pub struct FunctionGraph {
     pub func: FuncEffects,
 }
 
+/// `flowspace/model.py copygraph`, for the non-shallow fresh-Variable case.
+///
+/// Block ids are positional in the rich model, so the copied graph retains
+/// the complete `blocks` order and every `BlockId` while replacing every
+/// Variable reachable from any block-owned field with a fresh identity.
+#[expect(
+    clippy::mutable_key_type,
+    reason = "Eq and Hash use immutable Variable identity; concretetype/name cells do not participate"
+)]
+pub fn copygraph(graph: &FunctionGraph) -> FunctionGraph {
+    use crate::flowspace::model::Variable;
+    use std::collections::HashMap;
+
+    let mut varmap: HashMap<Variable, Variable> = HashMap::new();
+    let mut intern = |var: &Variable| {
+        varmap.entry(var.clone()).or_insert_with(|| var.copy());
+    };
+    for block in &graph.blocks {
+        for var in &block.inputargs {
+            intern(var);
+        }
+        for op in &block.operations {
+            for var in crate::inline::op_variable_refs(&op.kind) {
+                intern(&var);
+            }
+            if let Some(result) = &op.result {
+                intern(result);
+            }
+        }
+        for link in &block.exits {
+            for arg in link
+                .args
+                .iter()
+                .chain(link.last_exception.iter())
+                .chain(link.last_exc_value.iter())
+            {
+                if let LinkArg::Value(var) = arg {
+                    intern(var);
+                }
+            }
+        }
+        match &block.exitswitch {
+            Some(ExitSwitch::Value(var)) => intern(var),
+            Some(ExitSwitch::Fused { args, .. }) => {
+                for var in args {
+                    intern(var);
+                }
+            }
+            Some(ExitSwitch::LastException) | None => {}
+        }
+    }
+
+    let remap_var = |var: &Variable| {
+        varmap
+            .get(var)
+            .cloned()
+            .expect("copygraph: every block-owned Variable must be interned")
+    };
+    let blocks = graph
+        .blocks
+        .iter()
+        .map(|block| {
+            let operations = block
+                .operations
+                .iter()
+                .map(|op| SpaceOperation {
+                    result: op.result.as_ref().map(&remap_var),
+                    kind: crate::inline::remap_op_kind(&op.kind, &remap_var),
+                })
+                .collect();
+            let (exitswitch, exits) = remap_control_flow_metadata_var(
+                &block.exitswitch,
+                &block.exits,
+                &remap_var,
+                |block| block,
+            );
+            Block {
+                id: block.id,
+                inputargs: block.inputargs.iter().map(&remap_var).collect(),
+                operations,
+                exitswitch,
+                exits,
+                dead: block.dead,
+                // FrameState Variables are frontend build-time snapshots only;
+                // downstream graph copies retain that inert attribution verbatim.
+                framestate: block.framestate.clone(),
+            }
+        })
+        .collect();
+
+    FunctionGraph {
+        name: graph.name.clone(),
+        source_identity: graph.source_identity.clone(),
+        owner_root: graph.owner_root.clone(),
+        startblock: graph.startblock,
+        returnblock: graph.returnblock,
+        exceptblock: graph.exceptblock,
+        blocks,
+        notes: graph.notes.clone(),
+        return_type: graph.return_type.clone(),
+        hints: graph.hints.clone(),
+        func: graph.func.clone(),
+    }
+}
+
 impl FunctionGraph {
     pub fn new(name: impl Into<String>) -> Self {
         let entry = BlockId(0);
@@ -7034,6 +7139,109 @@ mod tests {
         );
     }
     use super::*;
+
+    #[test]
+    fn copygraph_preserves_structure_with_fresh_variable_identities() {
+        use std::collections::HashSet;
+
+        fn variable_ids(graph: &FunctionGraph) -> HashSet<u64> {
+            let mut ids = HashSet::new();
+            for block in &graph.blocks {
+                ids.extend(block.inputargs.iter().map(|var| var.id()));
+                for op in &block.operations {
+                    ids.extend(
+                        crate::inline::op_variable_refs(&op.kind)
+                            .iter()
+                            .map(|var| var.id()),
+                    );
+                    ids.extend(op.result.iter().map(|var| var.id()));
+                }
+                for link in &block.exits {
+                    for arg in link
+                        .args
+                        .iter()
+                        .chain(link.last_exception.iter())
+                        .chain(link.last_exc_value.iter())
+                    {
+                        if let LinkArg::Value(var) = arg {
+                            ids.insert(var.id());
+                        }
+                    }
+                }
+                match &block.exitswitch {
+                    Some(ExitSwitch::Value(var)) => {
+                        ids.insert(var.id());
+                    }
+                    Some(ExitSwitch::Fused { args, .. }) => {
+                        ids.extend(args.iter().map(|var| var.id()));
+                    }
+                    Some(ExitSwitch::LastException) | None => {}
+                }
+            }
+            ids
+        }
+
+        let mut graph = FunctionGraph::new("copy_fixture");
+        let start = graph.startblock;
+        let lhs = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let rhs = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let result = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        graph.block_mut(start).inputargs = vec![lhs.clone(), rhs.clone()];
+        graph.block_mut(start).operations.push(SpaceOperation {
+            result: Some(result.clone()),
+            kind: OpKind::BinOp {
+                op: "int_add".into(),
+                lhs: lhs.clone(),
+                rhs: rhs.clone(),
+                result_ty: ValueType::Int,
+            },
+        });
+        let returnblock = graph.returnblock;
+        graph.block_mut(returnblock).inputargs = vec![result.copy()];
+        graph.recloseblock(
+            start,
+            vec![Link::from_variables(
+                &graph,
+                vec![result.clone()],
+                returnblock,
+                None,
+            )],
+        );
+
+        let copied = copygraph(&graph);
+
+        assert_eq!(copied.blocks.len(), graph.blocks.len());
+        assert_eq!(copied.startblock, graph.startblock);
+        assert_eq!(copied.returnblock, graph.returnblock);
+        assert_eq!(copied.exceptblock, graph.exceptblock);
+        let original_op = &graph.block(start).operations[0];
+        let copied_op = &copied.block(start).operations[0];
+        let (
+            OpKind::BinOp {
+                op: original_name,
+                result_ty: original_ty,
+                ..
+            },
+            OpKind::BinOp {
+                op: copied_name,
+                result_ty: copied_ty,
+                ..
+            },
+        ) = (&original_op.kind, &copied_op.kind)
+        else {
+            panic!("copygraph must preserve the BinOp shape")
+        };
+        assert_eq!(original_name, copied_name);
+        assert_eq!(original_ty, copied_ty);
+        assert_eq!(original_op.result.is_some(), copied_op.result.is_some());
+
+        let original_ids = variable_ids(&graph);
+        let copied_ids = variable_ids(&copied);
+        assert!(
+            original_ids.is_disjoint(&copied_ids),
+            "copygraph must not share any operative Variable identity"
+        );
+    }
 
     /// `CallTarget::SyntheticTransparentCtor::path_segments()` must
     /// return the full `(owner_path..., name)` join — `front/mir.rs`

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2898,17 +2898,51 @@ pub fn fold_constant_exitswitch(graph: &mut FunctionGraph) -> usize {
     folded
 }
 
-/// Empty every block unreachable from `graph.startblock` in place —
+/// Non-canonical calling-convention entries emitted into one rich graph.
+///
+/// `simplify.transform_dead_op_vars_in_blocks` accepts multiple graphs and
+/// treats every graph start as a root.  Pyre's generated closure and
+/// specialization bodies can instead share one `FunctionGraph` allocation,
+/// with a secondary start represented by a no-predecessor block whose every
+/// inputarg is defined by its matching `OpKind::Input` parameter operation.
+/// A disconnected phi/branch block lacks that shape and is not a root.
+fn secondary_entry_roots(graph: &FunctionGraph) -> Vec<BlockId> {
+    let with_predecessor: HashSet<BlockId> = graph
+        .blocks
+        .iter()
+        .flat_map(|block| block.exits.iter().map(|link| link.target))
+        .collect();
+    graph
+        .blocks
+        .iter()
+        .filter(|block| {
+            block.id != graph.startblock
+                && block.id != graph.returnblock
+                && block.id != graph.exceptblock
+                && !block.inputargs.is_empty()
+                && !with_predecessor.contains(&block.id)
+                && block.inputargs.iter().all(|inputarg| {
+                    block.operations.iter().any(|op| {
+                        matches!(op.kind, OpKind::Input { .. })
+                            && op.result.as_ref() == Some(inputarg)
+                    })
+                })
+        })
+        .map(|block| block.id)
+        .collect()
+}
+
+/// Empty every block unreachable from a calling-convention entry in place —
 /// operations, exits, inputargs cleared, the `Vec` slot kept because
 /// `BlockId` doubles as the index.  Needed after
 /// [`fold_constant_exitswitch`] disconnects an arm: the registry
 /// lift (`translate_op`) and [`prune_dead_phis`] both walk blocks by
-/// index, and `prune_dead_phis` pins no-predecessor blocks as extra
-/// entry points, so a disconnected arm would otherwise keep its dead
-/// ops alive.
+/// index.  The canonical `startblock` and each generated secondary entry are
+/// roots; disconnected branch/phi arms are cleared.
 pub fn clear_unreachable_blocks(graph: &mut FunctionGraph) {
     let mut reachable = vec![false; graph.blocks.len()];
-    let mut worklist = vec![graph.startblock];
+    let mut worklist = secondary_entry_roots(graph);
+    worklist.push(graph.startblock);
     while let Some(b) = worklist.pop() {
         if std::mem::replace(&mut reachable[b.0], true) {
             continue;
@@ -4734,39 +4768,8 @@ pub fn prune_dead_phis(graph: &mut FunctionGraph) {
     // for closures / specialisations).  Each is a BFS root, so `blocks`
     // (the union of `iterblocks()` over each entry) covers every block
     // reachable from any entry.
-    let with_predecessor: HashSet<BlockId> = graph
-        .blocks
-        .iter()
-        .flat_map(|b| b.exits.iter().map(|e| e.target))
-        .collect();
-    // A no-predecessor block is a legitimate calling-convention entry
-    // only when every inputarg is a genuine parameter — the result of
-    // an `OpKind::Input` op in that same block (the closure-entry shape
-    // exercised by `prune_dead_phis_skips_non_canonical_entry_blocks`).
-    // jtransform can leave *unreachable* merge blocks whose inputargs
-    // are phi targets referencing values defined in reachable blocks; a
-    // phi with no predecessor to fill it is malformed, and pinning such
-    // a block as an entry would keep its dead operands (and any value
-    // sharing their register) alive into regalloc.  Restrict the
-    // orphan-entry roots to genuine parameter blocks so dead merge
-    // blocks are excluded.
-    let is_genuine_entry = |block: &Block| -> bool {
-        block.inputargs.iter().all(|iarg| {
-            block.operations.iter().any(|op| {
-                matches!(op.kind, OpKind::Input { .. }) && op.result.as_ref() == Some(iarg)
-            })
-        })
-    };
     let start_blocks: HashSet<BlockId> = std::iter::once(start)
-        .chain(
-            graph
-                .blocks
-                .iter()
-                .filter(|b| {
-                    b.id != start && !with_predecessor.contains(&b.id) && is_genuine_entry(b)
-                })
-                .map(|b| b.id),
-        )
+        .chain(secondary_entry_roots(graph))
         .collect();
 
     // BFS reachability mirrors `flowspace/model.py iterblocks()`,
@@ -5716,6 +5719,11 @@ pub struct FuncEffects {
     /// close_stack callee must never produce a JitCode and is classified
     /// `Residual` by `guess_call_kind`.
     pub close_stack: bool,
+    /// `func._dont_inline_`, set by
+    /// `WarmRunnerDesc.split_graph_and_record_jitdriver` on the copied
+    /// portal.  The backend inliner reads this off the function object; it is
+    /// separate from JIT policy hints such as `_jit_unroll_safe_`.
+    pub dont_inline: bool,
 }
 
 impl FuncEffects {
@@ -5739,6 +5747,7 @@ impl FuncEffects {
         self.elidable |= other.elidable;
         self.loop_invariant |= other.loop_invariant;
         self.close_stack |= other.close_stack;
+        self.dont_inline |= other.dont_inline;
     }
 }
 
@@ -7122,6 +7131,7 @@ mod tests {
             elidable: true,
             loop_invariant: true,
             close_stack: true,
+            dont_inline: true,
             ..FuncEffects::default()
         };
 
@@ -10528,6 +10538,13 @@ mod tests {
             )
             .unwrap();
         graph.push_inputarg_var(orphan_entry, unused_param_var.clone());
+
+        clear_unreachable_blocks(&mut graph);
+        assert_eq!(
+            graph.block(orphan_entry).inputargs,
+            vec![unused_param_var.clone()],
+            "reachability cleanup must preserve a secondary calling-convention entry"
+        );
 
         prune_dead_phis(&mut graph);
 

--- a/majit/majit-translate/src/pipeline.rs
+++ b/majit/majit-translate/src/pipeline.rs
@@ -25,6 +25,13 @@ pub struct JitDriverSpec {
     /// Resolution is deliberately exact: leaf-name fallback makes portal
     /// selection depend on unrelated functions and aliases in the input set.
     pub portal: CallPath,
+    /// Exact identity of the synthetic portal runner function.
+    ///
+    /// RPython: `JitDriverStaticData.portal_runner_ptr`.  This is distinct
+    /// from both `portal_graph` and `_jit_merge_point_in`: only direct calls
+    /// to the runner classify as recursive in `CallControl.guess_call_kind`.
+    #[serde(default)]
+    pub portal_runner: Option<CallPath>,
     pub greens: Vec<String>,
     pub reds: Vec<String>,
     /// Optional operand-kind declarations parallel to `greens`.
@@ -118,6 +125,10 @@ pub struct PipelineResult {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CompiledJitDriver {
     pub portal: CallPath,
+    /// RPython: `jitdriver_sd.portal_runner_ptr`, preserved as source-level
+    /// identity alongside the run-time `portal_runner_adr`.
+    #[serde(default)]
+    pub portal_runner: Option<CallPath>,
     pub main_jitcode_index: usize,
     /// RPython: `jitdriver.greens` — the green names, in declaration order.
     #[serde(default)]
@@ -266,6 +277,7 @@ mod tests {
             }],
             jit_drivers: vec![CompiledJitDriver {
                 portal: CallPath::from_segments(["eval", "mainloop"]),
+                portal_runner: None,
                 main_jitcode_index: 0,
                 greens: Vec::new(),
                 reds: Vec::new(),
@@ -303,6 +315,7 @@ mod tests {
             transform: GraphTransformConfig::default(),
             jit_drivers: vec![JitDriverSpec {
                 portal: CallPath::from_segments(["engine", "mainloop"]),
+                portal_runner: None,
                 greens: Vec::new(),
                 reds: Vec::new(),
                 green_kinds: Vec::new(),

--- a/majit/majit-translate/src/pipeline.rs
+++ b/majit/majit-translate/src/pipeline.rs
@@ -54,6 +54,15 @@ pub struct JitDriverSpec {
     /// `_JIT_ENTER_FUNCTYPE.ARGS` information warmspot uses upstream.
     #[serde(default)]
     pub red_types: Vec<String>,
+    /// Register the driver against a `warmspot.py
+    /// split_graph_and_record_jitdriver` copy of the portal graph, split
+    /// before its `jit_merge_point`, instead of against the graph that
+    /// contains the marker.
+    ///
+    /// Off by default: with it off `register_configured_jitdrivers` passes
+    /// the configured path through unchanged and no graph copy is made.
+    #[serde(default)]
+    pub split_portal: bool,
 }
 
 /// Configuration for the full analysis pipeline.
@@ -301,6 +310,7 @@ mod tests {
                 autoreds: false,
                 virtualizables: Vec::new(),
                 red_types: Vec::new(),
+                split_portal: false,
             }],
             register_trait_families: Vec::new(),
         };

--- a/majit/majit-translate/src/runtime_names.rs
+++ b/majit/majit-translate/src/runtime_names.rs
@@ -83,6 +83,10 @@ pub(crate) mod artifacts {
         env!("CARGO_MANIFEST_DIR"),
         "/../../build/llbc/pyre-object.ullbc"
     );
+    pub(crate) const JIT_ULLBC: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../build/llbc/pyre-jit.ullbc"
+    );
     pub(crate) const MAJIT_RLIB_ULLBC: &str = concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../../build/llbc/majit-rlib.ullbc"

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2383,6 +2383,7 @@ pub(crate) fn lift_callee_to_pygraph(
     } else {
         AlwaysInline::Absent
     };
+    func._dont_inline_ = callee_graph.func.dont_inline;
     graph.borrow_mut().func = Some(func.clone());
     let pygraph = Rc::new(PyGraph {
         graph,
@@ -6115,6 +6116,7 @@ mod tests {
         };
         callee_graph.blocks = vec![foo_start, foo_return];
         callee_graph.hints.push("always_inline".to_string());
+        callee_graph.func.dont_inline = true;
         let leaf_registry = crate::translator::rtyper::call_registry::CallRegistry::new(
             std::rc::Rc::new(crate::annotator::bookkeeper::Bookkeeper::new()),
         );
@@ -6136,6 +6138,10 @@ mod tests {
             "legacy always_inline hint must land on graph.func"
         );
         assert!(
+            pygraph.func._dont_inline_,
+            "legacy dont_inline carrier must land on graph.func"
+        );
+        assert!(
             pygraph
                 .graph
                 .borrow()
@@ -6143,6 +6149,15 @@ mod tests {
                 .as_ref()
                 .is_some_and(|func| func._always_inline_ == AlwaysInline::True),
             "legacy always_inline hint must land on the registered FunctionGraph.func"
+        );
+        assert!(
+            pygraph
+                .graph
+                .borrow()
+                .func
+                .as_ref()
+                .is_some_and(|func| func._dont_inline_),
+            "legacy dont_inline carrier must land on the registered FunctionGraph.func"
         );
         // Capture the callee's flowspace graph `Rc` before the pygraph
         // is moved into `register_callee`; this is the identity that

--- a/majit/majit-translate/src/unsimplify.rs
+++ b/majit/majit-translate/src/unsimplify.rs
@@ -58,7 +58,7 @@ fn definition_site(graph: &FunctionGraph, var: &Variable) -> String {
                 }
                 let origin = match link.args.get(position) {
                     Some(LinkArg::Value(source)) => {
-                        producing_op(graph, source).unwrap_or_else(|| format!("id={}", source.id()))
+                        origin_of(graph, source, &mut HashSet::new(), ORIGIN_WALK_DEPTH)
                     }
                     Some(other) => format!("{other:?}"),
                     None => "<link arity mismatch>".to_string(),
@@ -75,6 +75,11 @@ fn definition_site(graph: &FunctionGraph, var: &Variable) -> String {
     "no definition site found in this graph".to_string()
 }
 
+/// Hop budget for [`origin_of`]. A forwarded value crosses a handful of blocks
+/// at most; the bound is what keeps a loop in the link graph from recursing
+/// without end, alongside the visited set.
+const ORIGIN_WALK_DEPTH: usize = 16;
+
 /// `block N op I \`label\`` for the operation whose result is `var`.
 fn producing_op(graph: &FunctionGraph, var: &Variable) -> Option<String> {
     for block in &graph.blocks {
@@ -89,6 +94,50 @@ fn producing_op(graph: &FunctionGraph, var: &Variable) -> Option<String> {
         }
     }
     None
+}
+
+/// Resolve a value back to the operation that actually produces it, walking
+/// through block inputargs for as long as the value is only being forwarded.
+///
+/// A block inputarg has no defining operation, so resolving one hop lands on
+/// another inputarg whenever a value is threaded through a chain of blocks —
+/// and the report then stops at a bare `id=`, which names nothing. Each hop
+/// takes the incoming link argument in the same position; distinct origins are
+/// reported side by side because a block with several predecessors genuinely
+/// has several.
+fn origin_of(graph: &FunctionGraph, var: &Variable, seen: &mut HashSet<u64>, depth: usize) -> String {
+    if let Some(site) = producing_op(graph, var) {
+        return site;
+    }
+    if depth == 0 || !seen.insert(var.id()) {
+        return format!("id={}", var.id());
+    }
+    for block in &graph.blocks {
+        let Some(position) = block.inputargs.iter().position(|arg| arg.id() == var.id()) else {
+            continue;
+        };
+        let mut origins: Vec<String> = Vec::new();
+        for pred in &graph.blocks {
+            for link in &pred.exits {
+                if link.target != block.id {
+                    continue;
+                }
+                let origin = match link.args.get(position) {
+                    Some(LinkArg::Value(source)) => origin_of(graph, source, seen, depth - 1),
+                    Some(other) => format!("{other:?}"),
+                    None => "<link arity mismatch>".to_string(),
+                };
+                if !origins.contains(&origin) {
+                    origins.push(origin);
+                }
+            }
+        }
+        if !origins.is_empty() {
+            return origins.join(" | ");
+        }
+        break;
+    }
+    format!("id={}", var.id())
 }
 
 /// Every use of a variable at or after the split point, keyed by

--- a/majit/majit-translate/src/unsimplify.rs
+++ b/majit/majit-translate/src/unsimplify.rs
@@ -1,0 +1,535 @@
+//! Rich-model graph transformations from `translator/unsimplify.py`.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::codewriter::type_state::ConcreteType;
+use crate::flowspace::model::Variable;
+use crate::model::{BlockId, ExitSwitch, FunctionGraph, Link, LinkArg, SpaceOperation};
+
+/// Best available spelling for one variable: the `Input`-op source name if
+/// the graph carries one, else the `Variable` name prefix, else its identity.
+fn var_label(graph: &FunctionGraph, var: &Variable) -> String {
+    graph
+        .value_name_for(var)
+        .or_else(|| var.renamed().then(|| var.name_prefix()))
+        .unwrap_or_else(|| format!("<unnamed id={}>", var.id()))
+}
+
+/// Short human label for one operation: the opcode spelling where the model
+/// carries one (`BinOp`/`UnaryOp`/`Call`/`Input`), else the `OpKind` variant
+/// name.
+fn op_label(op: &SpaceOperation) -> String {
+    match &op.kind {
+        crate::model::OpKind::BinOp { op, .. } | crate::model::OpKind::UnaryOp { op, .. } => {
+            op.clone()
+        }
+        crate::model::OpKind::Input { name, .. } => format!("Input {name}"),
+        crate::model::OpKind::Call { target, .. } => match target.path_segments() {
+            Some(segments) => format!("call {}", segments.join("::")),
+            None => "call".to_string(),
+        },
+        other => {
+            // Every `OpKind` variant's `Debug` starts with its own name.
+            let debug = format!("{other:?}");
+            let end = debug.find([' ', '(', '{']).unwrap_or(debug.len());
+            debug[..end].to_string()
+        }
+    }
+}
+
+/// Where `var` is produced: the operation that results in it, or the
+/// block whose `inputargs` it enters through.
+fn definition_site(graph: &FunctionGraph, var: &Variable) -> String {
+    if let Some(site) = producing_op(graph, var) {
+        return format!("defined by {site}");
+    }
+    for block in &graph.blocks {
+        let Some(position) = block.inputargs.iter().position(|arg| arg.id() == var.id()) else {
+            continue;
+        };
+        // A block inputarg has no defining op in this graph; the value it
+        // stands for is whatever each predecessor passes in that slot, so
+        // resolve one hop back through the incoming links.
+        let mut incoming: Vec<String> = Vec::new();
+        for pred in &graph.blocks {
+            for link in &pred.exits {
+                if link.target != block.id {
+                    continue;
+                }
+                let origin = match link.args.get(position) {
+                    Some(LinkArg::Value(source)) => {
+                        producing_op(graph, source).unwrap_or_else(|| format!("id={}", source.id()))
+                    }
+                    Some(other) => format!("{other:?}"),
+                    None => "<link arity mismatch>".to_string(),
+                };
+                incoming.push(format!("from block {} as {origin}", pred.id.0));
+            }
+        }
+        let mut site = format!("enters as inputarg {position} of block {}", block.id.0);
+        if !incoming.is_empty() {
+            site.push_str(&format!(" ({})", incoming.join("; ")));
+        }
+        return site;
+    }
+    "no definition site found in this graph".to_string()
+}
+
+/// `block N op I \`label\`` for the operation whose result is `var`.
+fn producing_op(graph: &FunctionGraph, var: &Variable) -> Option<String> {
+    for block in &graph.blocks {
+        for (index, op) in block.operations.iter().enumerate() {
+            if op.result.as_ref().is_some_and(|res| res.id() == var.id()) {
+                return Some(format!(
+                    "`{}` at block {} op {index}",
+                    op_label(op),
+                    block.id.0,
+                ));
+            }
+        }
+    }
+    None
+}
+
+/// Every use of a variable at or after the split point, keyed by
+/// `Variable::id`: the moved operations first, then the block's outgoing
+/// link arguments and exit switch.
+///
+/// `links` and `exitswitch` must be the pre-rename snapshots — `split_block`
+/// rewrites both to the fresh copies before the `_forcelink` check runs.
+fn use_sites(
+    moved_source: &[SpaceOperation],
+    links: &[Link],
+    exitswitch: &Option<ExitSwitch>,
+) -> Vec<(u64, String)> {
+    let mut uses: Vec<(u64, String)> = Vec::new();
+    for (index, op) in moved_source.iter().enumerate() {
+        for arg in crate::inline::op_variable_refs(&op.kind) {
+            uses.push((arg.id(), format!("op {index} `{}`", op_label(op))));
+        }
+    }
+    for link in links {
+        for (position, arg) in link.args.iter().enumerate() {
+            if let LinkArg::Value(source) = arg {
+                uses.push((
+                    source.id(),
+                    format!("link arg {position} to block {}", link.target.0),
+                ));
+            }
+        }
+    }
+    match exitswitch {
+        Some(ExitSwitch::Value(var)) => uses.push((var.id(), "exitswitch".to_string())),
+        Some(ExitSwitch::Fused { opname, args }) => {
+            for var in args {
+                uses.push((var.id(), format!("exitswitch `{opname}`")));
+            }
+        }
+        Some(ExitSwitch::LastException) | None => {}
+    }
+    uses
+}
+
+/// `translator/unsimplify.py split_block` for the rich model graph.
+#[expect(
+    clippy::mutable_key_type,
+    reason = "Eq and Hash use immutable Variable identity; concretetype/name cells do not participate"
+)]
+pub(crate) fn split_block(
+    graph: &mut FunctionGraph,
+    block: BlockId,
+    index: usize,
+    forcelink: Option<&[Variable]>,
+) -> BlockId {
+    assert!(
+        index <= graph.block(block).operations.len(),
+        "split_block: index out of range (got {}, len={})",
+        index,
+        graph.block(block).operations.len(),
+    );
+
+    // `unsimplify.py split_block`: `varmap.keys()` is consumed in first-
+    // insertion order, so keep that order independently of HashMap iteration.
+    let mut varmap_order: Vec<Variable> = Vec::new();
+    let mut varmap: HashMap<Variable, Variable> = HashMap::new();
+    let mut vars_produced_in_new_block: HashSet<Variable> = HashSet::new();
+
+    fn intern_var(
+        var: &Variable,
+        varmap_order: &mut Vec<Variable>,
+        varmap: &mut HashMap<Variable, Variable>,
+        vars_produced_in_new_block: &HashSet<Variable>,
+    ) {
+        if vars_produced_in_new_block.contains(var) {
+            return;
+        }
+        if !varmap.contains_key(var) {
+            varmap_order.push(var.clone());
+            varmap.insert(var.clone(), var.copy());
+        }
+    }
+
+    fn get_new_name(
+        var: &Variable,
+        varmap_order: &mut Vec<Variable>,
+        varmap: &mut HashMap<Variable, Variable>,
+        vars_produced_in_new_block: &HashSet<Variable>,
+    ) -> Variable {
+        if vars_produced_in_new_block.contains(var) {
+            return var.clone();
+        }
+        intern_var(var, varmap_order, varmap, vars_produced_in_new_block);
+        varmap
+            .get(var)
+            .cloned()
+            .expect("split_block: interned Variable missing from varmap")
+    }
+
+    let moved_source = graph.block(block).operations[index..].to_vec();
+    let mut moved_operations = Vec::with_capacity(moved_source.len());
+    for op in &moved_source {
+        // `unsimplify.py split_block`: operands are interned before the op is
+        // rewritten, and the result becomes produced only after that rewrite.
+        for arg in crate::inline::op_variable_refs(&op.kind) {
+            intern_var(
+                &arg,
+                &mut varmap_order,
+                &mut varmap,
+                &vars_produced_in_new_block,
+            );
+        }
+        let remap_var = |var: &Variable| varmap.get(var).cloned().unwrap_or_else(|| var.clone());
+        moved_operations.push(SpaceOperation {
+            result: op.result.clone(),
+            kind: crate::inline::remap_op_kind(&op.kind, &remap_var),
+        });
+        if let Some(result) = &op.result {
+            vars_produced_in_new_block.insert(result.clone());
+        }
+    }
+
+    let (mut links, exitswitch) = {
+        let old = graph.block_mut(block);
+        (std::mem::take(&mut old.exits), old.exitswitch.take())
+    };
+    // The `_forcelink` diagnostic below reports use sites in the caller's own
+    // variable identities; the loops that follow rewrite `links` and
+    // `exitswitch` in place to the fresh copies, so snapshot them first.
+    let pre_rename_links = forcelink.is_some().then(|| links.clone());
+    let pre_rename_exitswitch = forcelink.is_some().then(|| exitswitch.clone());
+    for link in &mut links {
+        for arg in &mut link.args {
+            if Some(&*arg) == link.last_exception.as_ref()
+                || Some(&*arg) == link.last_exc_value.as_ref()
+            {
+                continue;
+            }
+            if let LinkArg::Value(var) = arg {
+                *var = get_new_name(
+                    var,
+                    &mut varmap_order,
+                    &mut varmap,
+                    &vars_produced_in_new_block,
+                );
+            }
+        }
+    }
+    let renamed_exitswitch = exitswitch.map(|switch| match switch {
+        ExitSwitch::Value(var) => ExitSwitch::Value(get_new_name(
+            &var,
+            &mut varmap_order,
+            &mut varmap,
+            &vars_produced_in_new_block,
+        )),
+        ExitSwitch::LastException => ExitSwitch::LastException,
+        ExitSwitch::Fused { opname, args } => ExitSwitch::Fused {
+            opname,
+            args: args
+                .iter()
+                .map(|var| {
+                    get_new_name(
+                        var,
+                        &mut varmap_order,
+                        &mut varmap,
+                        &vars_produced_in_new_block,
+                    )
+                })
+                .collect(),
+        },
+    });
+
+    let linkargs = if let Some(forcelink) = forcelink {
+        assert_eq!(
+            index, 0,
+            "unsimplify.py split_block _forcelink requires index == 0"
+        );
+        let linkargs = forcelink.to_vec();
+        let missing: Vec<&Variable> = varmap_order
+            .iter()
+            .filter(|var| !linkargs.contains(var))
+            .collect();
+        if !missing.is_empty() {
+            let uses = use_sites(
+                &moved_source,
+                pre_rename_links.as_deref().unwrap_or(&[]),
+                pre_rename_exitswitch.as_ref().unwrap_or(&None),
+            );
+            let offenders: Vec<String> = missing
+                .iter()
+                .map(|var| {
+                    let name = var_label(graph, var);
+                    let mut where_used: Vec<&str> = uses
+                        .iter()
+                        .filter(|(id, _)| *id == var.id())
+                        .map(|(_, site)| site.as_str())
+                        .collect();
+                    where_used.dedup();
+                    format!(
+                        "  {name} (id={}, kind={:?})\n    {}\n    used after the split point by: {}",
+                        var.id(),
+                        FunctionGraph::concretetype_of(var),
+                        definition_site(graph, var),
+                        if where_used.is_empty() {
+                            "<none found>".to_string()
+                        } else {
+                            where_used.join(", ")
+                        },
+                    )
+                })
+                .collect();
+            let names: Vec<String> = missing.iter().map(|var| var_label(graph, var)).collect();
+            // The Void `same_as` re-creation arm is unported because the rich
+            // model has no `same_as` counterpart. A Void `kind=` below is the
+            // signal to port that operation before allowing the split.
+            assert!(
+                !missing
+                    .iter()
+                    .any(|var| FunctionGraph::concretetype_of(var) == ConcreteType::Void),
+                "unsimplify.py split_block recreates Void _forcelink survivors with `same_as`; \
+                 the rich model has no `same_as` counterpart to port it onto.\n\
+                 Offending variables:\n{}",
+                offenders.join("\n"),
+            );
+            panic!(
+                "The variable {} was not explicitly listed in _forcelink.  \
+                 This issue can be caused by a jitdriver.jit_merge_point() where some variable \
+                 containing an int or str or instance is actually known to be constant, e.g. \
+                 always 42.\n\
+                 Each variable below is defined before the split point and still live after it, \
+                 but is neither a green nor a red of the driver; the graph must be restructured \
+                 so that it is recomputed after the marker, or declared in the driver.\n\
+                 Offending variables ({} of them):\n{}",
+                names.join(", "),
+                missing.len(),
+                offenders.join("\n"),
+            );
+        }
+        linkargs
+    } else {
+        varmap_order.clone()
+    };
+
+    let new_inputargs = linkargs
+        .iter()
+        .map(|var| {
+            get_new_name(
+                var,
+                &mut varmap_order,
+                &mut varmap,
+                &vars_produced_in_new_block,
+            )
+        })
+        .collect();
+    let newblock = graph.create_block();
+    {
+        let new = graph.block_mut(newblock);
+        // Set inputargs before constructing the old block's checked Link.
+        new.inputargs = new_inputargs;
+        new.operations = moved_operations;
+        new.exitswitch = renamed_exitswitch;
+    }
+    graph.recloseblock(newblock, links);
+
+    let link = Link::from_variables(graph, linkargs, newblock, None);
+    {
+        let old = graph.block_mut(block);
+        old.operations.truncate(index);
+        old.exitswitch = None;
+    }
+    graph.recloseblock(block, vec![link]);
+    newblock
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codewriter::type_state::ConcreteType;
+    use crate::model::{OpKind, ValueType};
+
+    fn unary(operand: &Variable, result: &Variable) -> SpaceOperation {
+        SpaceOperation {
+            result: Some(result.clone()),
+            kind: OpKind::UnaryOp {
+                op: "int_neg".into(),
+                operand: operand.clone(),
+                result_ty: ValueType::Int,
+            },
+        }
+    }
+
+    fn graph_with_ops(
+        inputargs: Vec<Variable>,
+        operations: Vec<SpaceOperation>,
+        returned: Variable,
+    ) -> FunctionGraph {
+        let mut graph = FunctionGraph::new("split_fixture");
+        let start = graph.startblock;
+        graph.block_mut(start).inputargs = inputargs;
+        let returnblock = graph.returnblock;
+        graph.block_mut(returnblock).inputargs = vec![returned.copy()];
+        graph.block_mut(start).operations = operations;
+        let exit = Link::from_variables(&graph, vec![returned], returnblock, None);
+        graph.recloseblock(start, vec![exit]);
+        graph
+    }
+
+    #[test]
+    fn split_at_zero_moves_all_operations() {
+        let a = Variable::named("a");
+        let r = Variable::named("r");
+        let mut graph = graph_with_ops(vec![a.clone()], vec![unary(&a, &r)], r);
+        let old = graph.startblock;
+
+        let new = split_block(&mut graph, old, 0, None);
+
+        assert!(graph.block(old).operations.is_empty());
+        assert_eq!(graph.block(new).operations.len(), 1);
+        assert_eq!(graph.block(old).exits[0].args, vec![LinkArg::Value(a)]);
+        assert_ne!(
+            graph.block(new).inputargs[0].id(),
+            graph.block(old).inputargs[0].id()
+        );
+    }
+
+    #[test]
+    fn split_in_middle_threads_intermediate() {
+        let a = Variable::named("a");
+        let middle = Variable::named("middle");
+        let result = Variable::named("result");
+        let mut graph = graph_with_ops(
+            vec![a.clone()],
+            vec![unary(&a, &middle), unary(&middle, &result)],
+            result,
+        );
+        let old = graph.startblock;
+
+        let new = split_block(&mut graph, old, 1, None);
+
+        assert_eq!(graph.block(old).operations.len(), 1);
+        assert_eq!(graph.block(new).operations.len(), 1);
+        assert_eq!(
+            graph.block(old).exits[0].args,
+            vec![LinkArg::Value(middle.clone())]
+        );
+        let OpKind::UnaryOp { operand, .. } = &graph.block(new).operations[0].kind else {
+            panic!("moved operation must remain UnaryOp")
+        };
+        assert_eq!(operand, &graph.block(new).inputargs[0]);
+        assert_ne!(operand.id(), middle.id());
+    }
+
+    #[test]
+    fn split_at_end_moves_original_exits() {
+        let a = Variable::named("a");
+        let result = Variable::named("result");
+        let mut graph = graph_with_ops(vec![a.clone()], vec![unary(&a, &result)], result.clone());
+        let old = graph.startblock;
+
+        let new = split_block(&mut graph, old, 1, None);
+
+        assert_eq!(graph.block(old).operations.len(), 1);
+        assert!(graph.block(new).operations.is_empty());
+        assert_eq!(graph.block(old).exits[0].args, vec![LinkArg::Value(result)]);
+        assert_eq!(graph.block(new).exits.len(), 1);
+    }
+
+    #[test]
+    fn split_with_forcelink_uses_explicit_order() {
+        let a = Variable::named("a");
+        let b = Variable::named("b");
+        let result = Variable::named("result");
+        let mut graph = graph_with_ops(
+            vec![a.clone(), b.clone()],
+            vec![SpaceOperation {
+                result: Some(result.clone()),
+                kind: OpKind::BinOp {
+                    op: "int_add".into(),
+                    lhs: a.clone(),
+                    rhs: b.clone(),
+                    result_ty: ValueType::Int,
+                },
+            }],
+            result,
+        );
+        let old = graph.startblock;
+
+        let new = split_block(&mut graph, old, 0, Some(&[b.clone(), a.clone()]));
+
+        assert_eq!(
+            graph.block(old).exits[0].args,
+            vec![LinkArg::Value(b), LinkArg::Value(a)]
+        );
+        assert_eq!(graph.block(new).inputargs.len(), 2);
+    }
+
+    #[test]
+    fn split_with_forcelink_panic_locates_every_offender() {
+        let kept = Variable::named("kept");
+        let missing = Variable::named("missing_red");
+        FunctionGraph::set_concretetype_of_inline(&missing, ConcreteType::Signed);
+        let result = Variable::named("result");
+        let mut graph = graph_with_ops(
+            vec![kept.clone(), missing.clone()],
+            vec![unary(&missing, &result)],
+            result,
+        );
+        let naming_block = graph.create_block();
+        graph
+            .block_mut(naming_block)
+            .operations
+            .push(SpaceOperation {
+                result: Some(missing),
+                kind: OpKind::Input {
+                    name: "missing_red".into(),
+                    ty: ValueType::Int,
+                    class_root: None,
+                },
+            });
+        let old = graph.startblock;
+
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            split_block(&mut graph, old, 0, Some(&[kept]))
+        }))
+        .expect_err("a live-across variable outside _forcelink must fail the split");
+        let message = panic
+            .downcast_ref::<String>()
+            .expect("split_block panics with a formatted String");
+
+        // The diagnostic has to be actionable on its own: which value, what
+        // kind it is, where it comes from, and what still needs it.
+        assert!(message.contains("missing_red"), "{message}");
+        assert!(message.contains("kind=Signed"), "{message}");
+        assert!(
+            message.contains("defined by `Input missing_red` at block"),
+            "{message}"
+        );
+        assert!(
+            message.contains("used after the split point by: op 0 `int_neg`"),
+            "{message}"
+        );
+        assert!(
+            message.contains("Offending variables (1 of them)"),
+            "{message}"
+        );
+    }
+}

--- a/majit/majit-translate/src/unsimplify.rs
+++ b/majit/majit-translate/src/unsimplify.rs
@@ -708,15 +708,9 @@ mod tests {
         assert_eq!(graph.block(new).inputargs.len(), 2);
     }
 
-    #[test]
-    fn split_with_forcelink_rematerializes_nullary_marker_receiver() {
+    fn assert_split_rematerializes_marker_receiver(producer_kind: OpKind) {
         let receiver = Variable::named("pypyjitdriver");
         let marker_result = Variable::named("marker_result");
-        let producer_kind = OpKind::Call {
-            target: crate::model::CallTarget::function_path(["pyre_jit", "eval", "pypyjitdriver"]),
-            args: vec![],
-            result_ty: ValueType::Ref(Some("PyPyJitDriver".into())),
-        };
         let marker_kind = OpKind::Call {
             target: crate::model::CallTarget::method(
                 "jit_merge_point",
@@ -760,6 +754,20 @@ mod tests {
             panic!("moved marker must remain a Call")
         };
         assert_eq!(args, &[rematerialized.clone()]);
+    }
+
+    #[test]
+    fn split_with_forcelink_rematerializes_nullary_marker_receiver() {
+        assert_split_rematerializes_marker_receiver(OpKind::Call {
+            target: crate::model::CallTarget::function_path(["pyre_jit", "eval", "pypyjitdriver"]),
+            args: vec![],
+            result_ty: ValueType::Ref(Some("PyPyJitDriver".into())),
+        });
+    }
+
+    #[test]
+    fn split_with_forcelink_rematerializes_constref_marker_receiver() {
+        assert_split_rematerializes_marker_receiver(OpKind::ConstRefAddr(8));
     }
 
     #[test]

--- a/majit/majit-translate/src/unsimplify.rs
+++ b/majit/majit-translate/src/unsimplify.rs
@@ -2,9 +2,9 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::codewriter::type_state::ConcreteType;
+use crate::codewriter::jtransform::{JitMarkerKey, jit_marker_key_from_target};
 use crate::flowspace::model::Variable;
-use crate::model::{BlockId, ExitSwitch, FunctionGraph, Link, LinkArg, SpaceOperation};
+use crate::model::{BlockId, ExitSwitch, FunctionGraph, Link, LinkArg, OpKind, SpaceOperation};
 
 /// Best available spelling for one variable: the `Input`-op source name if
 /// the graph carries one, else the `Variable` name prefix, else its identity.
@@ -96,6 +96,62 @@ fn producing_op(graph: &FunctionGraph, var: &Variable) -> Option<String> {
     None
 }
 
+enum IncomingSource<'a> {
+    Value(&'a Variable),
+    Other(&'a LinkArg),
+    Missing,
+}
+
+/// One hop from a block inputarg to the values supplied by predecessor links.
+fn incoming_sources<'a>(
+    graph: &'a FunctionGraph,
+    var: &Variable,
+) -> Option<Vec<IncomingSource<'a>>> {
+    let (block, position) = graph.blocks.iter().find_map(|block| {
+        block
+            .inputargs
+            .iter()
+            .position(|arg| arg.id() == var.id())
+            .map(|position| (block.id, position))
+    })?;
+    Some(
+        graph
+            .blocks
+            .iter()
+            .flat_map(|pred| pred.exits.iter().filter(move |link| link.target == block))
+            .map(|link| match link.args.get(position) {
+                Some(LinkArg::Value(source)) => IncomingSource::Value(source),
+                Some(other) => IncomingSource::Other(other),
+                None => IncomingSource::Missing,
+            })
+            .collect(),
+    )
+}
+
+#[derive(Default)]
+struct OriginSummary {
+    origins: Vec<String>,
+    shared_predecessors: usize,
+}
+
+impl OriginSummary {
+    fn resolved(origin: String) -> Self {
+        Self {
+            origins: vec![origin],
+            shared_predecessors: 0,
+        }
+    }
+
+    fn extend(&mut self, other: Self) {
+        for origin in other.origins {
+            if !self.origins.contains(&origin) {
+                self.origins.push(origin);
+            }
+        }
+        self.shared_predecessors += other.shared_predecessors;
+    }
+}
+
 /// Resolve a value back to the operation that actually produces it, walking
 /// through block inputargs for as long as the value is only being forwarded.
 ///
@@ -105,39 +161,66 @@ fn producing_op(graph: &FunctionGraph, var: &Variable) -> Option<String> {
 /// takes the incoming link argument in the same position; distinct origins are
 /// reported side by side because a block with several predecessors genuinely
 /// has several.
-fn origin_of(graph: &FunctionGraph, var: &Variable, seen: &mut HashSet<u64>, depth: usize) -> String {
-    if let Some(site) = producing_op(graph, var) {
-        return site;
-    }
-    if depth == 0 || !seen.insert(var.id()) {
+fn origin_of(
+    graph: &FunctionGraph,
+    var: &Variable,
+    seen: &mut HashSet<u64>,
+    depth: usize,
+) -> String {
+    let summary = origin_summary(graph, var, seen, depth);
+    if summary.origins.is_empty() {
         return format!("id={}", var.id());
     }
-    for block in &graph.blocks {
-        let Some(position) = block.inputargs.iter().position(|arg| arg.id() == var.id()) else {
-            continue;
+    let mut origins = summary.origins.join(" | ");
+    if summary.shared_predecessors != 0 {
+        let description = if summary.origins.len() == 1 {
+            "that origin"
+        } else {
+            "those origins"
         };
-        let mut origins: Vec<String> = Vec::new();
-        for pred in &graph.blocks {
-            for link in &pred.exits {
-                if link.target != block.id {
-                    continue;
-                }
-                let origin = match link.args.get(position) {
-                    Some(LinkArg::Value(source)) => origin_of(graph, source, seen, depth - 1),
-                    Some(other) => format!("{other:?}"),
-                    None => "<link arity mismatch>".to_string(),
-                };
-                if !origins.contains(&origin) {
-                    origins.push(origin);
-                }
-            }
-        }
-        if !origins.is_empty() {
-            return origins.join(" | ");
-        }
-        break;
+        origins.push_str(&format!(
+            " (+{} predecessors sharing {description})",
+            summary.shared_predecessors
+        ));
     }
-    format!("id={}", var.id())
+    origins
+}
+
+fn origin_summary(
+    graph: &FunctionGraph,
+    var: &Variable,
+    seen: &mut HashSet<u64>,
+    depth: usize,
+) -> OriginSummary {
+    if let Some(site) = producing_op(graph, var) {
+        return OriginSummary::resolved(site);
+    }
+    if depth == 0 {
+        return OriginSummary::resolved(format!("id={}", var.id()));
+    }
+    if !seen.insert(var.id()) {
+        return OriginSummary {
+            origins: Vec::new(),
+            shared_predecessors: 1,
+        };
+    }
+    let Some(incoming) = incoming_sources(graph, var) else {
+        return OriginSummary::resolved(format!("id={}", var.id()));
+    };
+    let mut summary = OriginSummary::default();
+    for source in incoming {
+        let origin = match source {
+            IncomingSource::Value(source) => origin_summary(graph, source, seen, depth - 1),
+            IncomingSource::Other(other) => OriginSummary::resolved(format!("{other:?}")),
+            IncomingSource::Missing => OriginSummary::resolved("<link arity mismatch>".to_string()),
+        };
+        summary.extend(origin);
+    }
+    if summary.origins.is_empty() && summary.shared_predecessors == 0 {
+        OriginSummary::resolved(format!("id={}", var.id()))
+    } else {
+        summary
+    }
 }
 
 /// Every use of a variable at or after the split point, keyed by
@@ -177,6 +260,82 @@ fn use_sites(
         Some(ExitSwitch::LastException) | None => {}
     }
     uses
+}
+
+fn jit_merge_point_receiver(op: &SpaceOperation) -> Option<&Variable> {
+    let OpKind::Call { target, args, .. } = &op.kind else {
+        return None;
+    };
+    let receiver_root = target.receiver_root()?;
+    let driver_roots = [receiver_root.to_string()];
+    (jit_marker_key_from_target(target, &driver_roots) == Some(JitMarkerKey::JitMergePoint))
+        .then(|| args.first())
+        .flatten()
+}
+
+fn origin_producer(graph: &FunctionGraph, var: &Variable) -> Option<SpaceOperation> {
+    let mut current = var.clone();
+    let mut seen = HashSet::new();
+    for _ in 0..ORIGIN_WALK_DEPTH {
+        if !seen.insert(current.id()) {
+            return None;
+        }
+        if let Some(op) = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .find(|op| {
+                op.result
+                    .as_ref()
+                    .is_some_and(|result| result.id() == current.id())
+            })
+        {
+            return Some(op.clone());
+        }
+
+        let mut incoming = incoming_sources(graph, &current)?.into_iter();
+        let Some(IncomingSource::Value(source)) = incoming.next() else {
+            return None;
+        };
+        let source = source.clone();
+        if incoming
+            .any(|arg| !matches!(arg, IncomingSource::Value(other) if other.id() == source.id()))
+        {
+            return None;
+        }
+        current = source;
+    }
+    None
+}
+
+/// RPython `split_block` recreates a Void marker receiver with `same_as`, and
+/// `remove_same_as` later substitutes the constant. Before rtyping, mirror that
+/// rematerialisation by copying only the constant producer used for operand 0;
+/// this is the driver constant from `ExtEnterLeaveMarker.specialize_call`.
+fn rematerializable_marker_receiver_producer(
+    graph: &FunctionGraph,
+    var: &Variable,
+) -> Option<SpaceOperation> {
+    let producer = origin_producer(graph, var)?;
+    if !crate::inline::op_variable_refs(&producer.kind).is_empty() {
+        return None;
+    }
+    let can_copy = match &producer.kind {
+        OpKind::ConstInt(_)
+        | OpKind::ConstInt128(_)
+        | OpKind::ConstUInt128(_)
+        | OpKind::ConstBool(_)
+        | OpKind::ConstSymbolic { .. }
+        | OpKind::ConstFloat(_)
+        | OpKind::ConstStr(_)
+        | OpKind::ConstRef(_)
+        | OpKind::ConstRefNull
+        | OpKind::ConstNone
+        | OpKind::ConstRefAddr(_) => true,
+        OpKind::Call { args, .. } => args.is_empty(),
+        _ => false,
+    };
+    can_copy.then_some(producer)
 }
 
 /// `translator/unsimplify.py split_block` for the rich model graph.
@@ -313,10 +472,40 @@ pub(crate) fn split_block(
             "unsimplify.py split_block _forcelink requires index == 0"
         );
         let linkargs = forcelink.to_vec();
-        let missing: Vec<&Variable> = varmap_order
+        let mut missing: Vec<&Variable> = varmap_order
             .iter()
             .filter(|var| !linkargs.contains(var))
             .collect();
+        // `_forcelink` requires index 0, and `split_before_jit_merge_point` splits at
+        // the marker found with configured roots. Only `moved_source[0]` can qualify;
+        // using its own root satisfies the classifier's root check by construction.
+        let marker_receiver_id = moved_source
+            .first()
+            .and_then(jit_merge_point_receiver)
+            .map(Variable::id);
+        let mut rematerialized_ids = Vec::new();
+        let mut rematerialized_ops = Vec::new();
+        for var in &missing {
+            if marker_receiver_id != Some(var.id()) {
+                continue;
+            }
+            let Some(producer) = rematerializable_marker_receiver_producer(graph, var) else {
+                continue;
+            };
+            let result = varmap
+                .get(*var)
+                .cloned()
+                .expect("split_block: missing Variable has no fresh mapping");
+            // The moved operations already use this fresh varmap result, so
+            // making it the copied producer's result performs the substitution.
+            rematerialized_ids.push(var.id());
+            rematerialized_ops.push(SpaceOperation {
+                result: Some(result),
+                kind: producer.kind,
+            });
+        }
+        missing.retain(|var| !rematerialized_ids.contains(&var.id()));
+        moved_operations.splice(0..0, rematerialized_ops);
         if !missing.is_empty() {
             let uses = use_sites(
                 &moved_source,
@@ -347,18 +536,6 @@ pub(crate) fn split_block(
                 })
                 .collect();
             let names: Vec<String> = missing.iter().map(|var| var_label(graph, var)).collect();
-            // The Void `same_as` re-creation arm is unported because the rich
-            // model has no `same_as` counterpart. A Void `kind=` below is the
-            // signal to port that operation before allowing the split.
-            assert!(
-                !missing
-                    .iter()
-                    .any(|var| FunctionGraph::concretetype_of(var) == ConcreteType::Void),
-                "unsimplify.py split_block recreates Void _forcelink survivors with `same_as`; \
-                 the rich model has no `same_as` counterpart to port it onto.\n\
-                 Offending variables:\n{}",
-                offenders.join("\n"),
-            );
             panic!(
                 "The variable {} was not explicitly listed in _forcelink.  \
                  This issue can be caused by a jitdriver.jit_merge_point() where some variable \
@@ -529,6 +706,113 @@ mod tests {
             vec![LinkArg::Value(b), LinkArg::Value(a)]
         );
         assert_eq!(graph.block(new).inputargs.len(), 2);
+    }
+
+    #[test]
+    fn split_with_forcelink_rematerializes_nullary_marker_receiver() {
+        let receiver = Variable::named("pypyjitdriver");
+        let marker_result = Variable::named("marker_result");
+        let producer_kind = OpKind::Call {
+            target: crate::model::CallTarget::function_path(["pyre_jit", "eval", "pypyjitdriver"]),
+            args: vec![],
+            result_ty: ValueType::Ref(Some("PyPyJitDriver".into())),
+        };
+        let marker_kind = OpKind::Call {
+            target: crate::model::CallTarget::method(
+                "jit_merge_point",
+                Some("PyPyJitDriver".into()),
+            ),
+            args: vec![receiver.clone()],
+            result_ty: ValueType::Void,
+        };
+        let mut graph = graph_with_ops(
+            vec![],
+            vec![
+                SpaceOperation {
+                    result: Some(receiver.clone()),
+                    kind: producer_kind.clone(),
+                },
+                SpaceOperation {
+                    result: Some(marker_result.clone()),
+                    kind: marker_kind,
+                },
+            ],
+            marker_result,
+        );
+        let old = graph.startblock;
+        let portal = split_block(&mut graph, old, 1, None);
+        let portal_receiver = jit_merge_point_receiver(&graph.block(portal).operations[0])
+            .expect("split portal must start with the marker receiver")
+            .clone();
+
+        let new = split_block(&mut graph, portal, 0, Some(&[]));
+
+        assert!(graph.block(portal).exits[0].args.is_empty());
+        assert!(graph.block(new).inputargs.is_empty());
+        assert_eq!(graph.block(new).operations[0].kind, producer_kind);
+        let rematerialized = graph.block(new).operations[0]
+            .result
+            .as_ref()
+            .expect("copied producer must have a result");
+        assert_ne!(rematerialized.id(), receiver.id());
+        assert_ne!(rematerialized.id(), portal_receiver.id());
+        let OpKind::Call { args, .. } = &graph.block(new).operations[1].kind else {
+            panic!("moved marker must remain a Call")
+        };
+        assert_eq!(args, &[rematerialized.clone()]);
+    }
+
+    #[test]
+    fn split_with_forcelink_does_not_rematerialize_marker_at_index_one() {
+        let receiver = Variable::named("pypyjitdriver");
+        let filler = Variable::named("filler");
+        let marker_result = Variable::named("marker_result");
+        let mut graph = graph_with_ops(
+            vec![],
+            vec![
+                SpaceOperation {
+                    result: Some(receiver.clone()),
+                    kind: OpKind::Call {
+                        target: crate::model::CallTarget::function_path([
+                            "pyre_jit",
+                            "eval",
+                            "pypyjitdriver",
+                        ]),
+                        args: vec![],
+                        result_ty: ValueType::Ref(Some("PyPyJitDriver".into())),
+                    },
+                },
+                SpaceOperation {
+                    result: Some(filler),
+                    kind: OpKind::ConstNone,
+                },
+                SpaceOperation {
+                    result: Some(marker_result.clone()),
+                    kind: OpKind::Call {
+                        target: crate::model::CallTarget::method(
+                            "jit_merge_point",
+                            Some("PyPyJitDriver".into()),
+                        ),
+                        args: vec![receiver],
+                        result_ty: ValueType::Void,
+                    },
+                },
+            ],
+            marker_result,
+        );
+        let old = graph.startblock;
+        let portal = split_block(&mut graph, old, 1, None);
+
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            split_block(&mut graph, portal, 0, Some(&[]))
+        }))
+        .expect_err("a marker receiver used only by operation 1 must remain an offender");
+        let message = panic
+            .downcast_ref::<String>()
+            .expect("split_block panics with a formatted String");
+
+        assert!(message.contains("pypyjitdriver"), "{message}");
+        assert!(message.contains("op 1 `call jit_merge_point`"), "{message}");
     }
 
     #[test]

--- a/majit/majit-translate/src/unsimplify.rs
+++ b/majit/majit-translate/src/unsimplify.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::codewriter::jtransform::{JitMarkerKey, jit_marker_key_from_target};
+use crate::codewriter::type_state::ConcreteType;
 use crate::flowspace::model::Variable;
 use crate::model::{BlockId, ExitSwitch, FunctionGraph, Link, LinkArg, OpKind, SpaceOperation};
 
@@ -349,12 +350,22 @@ pub(crate) fn split_block(
     index: usize,
     forcelink: Option<&[Variable]>,
 ) -> BlockId {
+    let operation_len = graph.block(block).operations.len();
     assert!(
-        index <= graph.block(block).operations.len(),
+        index <= operation_len,
         "split_block: index out of range (got {}, len={})",
         index,
-        graph.block(block).operations.len(),
+        operation_len,
     );
+    if matches!(
+        graph.block(block).exitswitch,
+        Some(ExitSwitch::LastException)
+    ) {
+        assert!(
+            index < operation_len,
+            "split_block: cannot split a LastException block after its raising operation"
+        );
+    }
 
     // `unsimplify.py split_block`: `varmap.keys()` is consumed in first-
     // insertion order, so keep that order independently of HashMap iteration.
@@ -484,28 +495,45 @@ pub(crate) fn split_block(
             .and_then(jit_merge_point_receiver)
             .map(Variable::id);
         let mut rematerialized_ids = Vec::new();
-        let mut rematerialized_ops = Vec::new();
         for var in &missing {
-            if marker_receiver_id != Some(var.id()) {
-                continue;
-            }
-            let Some(producer) = rematerializable_marker_receiver_producer(graph, var) else {
+            let rematerialized_kind = if FunctionGraph::concretetype_of(var) == ConcreteType::Void {
+                // `unsimplify.py split_block`: recreate every omitted Void
+                // value as `same_as(Constant(None, lltype.Void))`.  The rich
+                // model represents the constant-producing operation directly;
+                // later lowering treats `ConstNone` as lltype.Void.
+                Some(OpKind::ConstNone)
+            } else if marker_receiver_id == Some(var.id()) {
+                // Pre-rtyping structural adaptation for the driver singleton:
+                // its source graph may still expose a ref/unknown receiver
+                // where upstream has already rtyped it to Void.
+                rematerializable_marker_receiver_producer(graph, var).map(|producer| producer.kind)
+            } else {
+                None
+            };
+            let Some(kind) = rematerialized_kind else {
                 continue;
             };
             let result = varmap
                 .get(*var)
                 .cloned()
                 .expect("split_block: missing Variable has no fresh mapping");
-            // The moved operations already use this fresh varmap result, so
-            // making it the copied producer's result performs the substitution.
+            // Upstream inserts `same_as` immediately before the first operation
+            // that consumes the fresh variable (or at the end when only an
+            // outgoing link/exitswitch needs it).
+            let insert_at = moved_operations
+                .iter()
+                .position(|op| crate::inline::op_variable_refs(&op.kind).contains(&result))
+                .unwrap_or(moved_operations.len());
             rematerialized_ids.push(var.id());
-            rematerialized_ops.push(SpaceOperation {
-                result: Some(result),
-                kind: producer.kind,
-            });
+            moved_operations.insert(
+                insert_at,
+                SpaceOperation {
+                    result: Some(result),
+                    kind,
+                },
+            );
         }
         missing.retain(|var| !rematerialized_ids.contains(&var.id()));
-        moved_operations.splice(0..0, rematerialized_ops);
         if !missing.is_empty() {
             let uses = use_sites(
                 &moved_source,
@@ -680,6 +708,18 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "cannot split a LastException block")]
+    fn split_at_end_of_last_exception_block_is_rejected() {
+        let a = Variable::named("a");
+        let result = Variable::named("result");
+        let mut graph = graph_with_ops(vec![a.clone()], vec![unary(&a, &result)], result);
+        let old = graph.startblock;
+        graph.block_mut(old).exitswitch = Some(ExitSwitch::LastException);
+
+        split_block(&mut graph, old, 1, None);
+    }
+
+    #[test]
     fn split_with_forcelink_uses_explicit_order() {
         let a = Variable::named("a");
         let b = Variable::named("b");
@@ -706,6 +746,47 @@ mod tests {
             vec![LinkArg::Value(b), LinkArg::Value(a)]
         );
         assert_eq!(graph.block(new).inputargs.len(), 2);
+    }
+
+    #[test]
+    fn split_with_forcelink_rematerializes_every_omitted_void() {
+        let kept = Variable::named("kept");
+        let omitted_void = Variable::named("omitted_void");
+        FunctionGraph::set_concretetype_of_inline(&omitted_void, ConcreteType::Void);
+        let result = Variable::named("result");
+        let mut graph = graph_with_ops(
+            vec![kept.clone(), omitted_void.clone()],
+            vec![SpaceOperation {
+                result: Some(result.clone()),
+                kind: OpKind::Call {
+                    target: crate::model::CallTarget::function_path(["consume_void"]),
+                    args: vec![omitted_void],
+                    result_ty: ValueType::Void,
+                },
+            }],
+            result,
+        );
+        let old = graph.startblock;
+
+        let new = split_block(&mut graph, old, 0, Some(&[kept]));
+
+        assert_eq!(graph.block(new).inputargs.len(), 1);
+        assert!(matches!(
+            graph.block(new).operations[0].kind,
+            OpKind::ConstNone
+        ));
+        let recreated = graph.block(new).operations[0]
+            .result
+            .as_ref()
+            .expect("ConstNone must recreate the omitted Void variable");
+        assert_eq!(
+            FunctionGraph::concretetype_of(recreated),
+            ConcreteType::Void
+        );
+        let OpKind::Call { args, .. } = &graph.block(new).operations[1].kind else {
+            panic!("original consumer must remain a Call")
+        };
+        assert_eq!(args, &[recreated.clone()]);
     }
 
     fn assert_split_rematerializes_marker_receiver(producer_kind: OpKind) {

--- a/majit/majit-translate/tests/test_unroll_safe_inventory.rs
+++ b/majit/majit-translate/tests/test_unroll_safe_inventory.rs
@@ -86,6 +86,31 @@ const REVIEWED_UNROLL_SAFE: &[(&str, &str)] = &[
         "frame_locals_proxy_snapshot",
         "fast2locals' scan of the same locals-plus array",
     ),
+    // `pyopcode.py` `dispatch_bytecode` is `@jit.unroll_safe`; its
+    // EXTENDED_ARG loop is split here into the interpreter decoder and the
+    // two scalar projections consumed by `eval_loop_jit`.  The projections
+    // exist because the generated JIT's residual ABI cannot publish the
+    // decoder's Result<(usize, Instruction, OpArg)> as one value.  Each loop
+    // is bounded by the bytecode format's at-most-three EXTENDED_ARG units.
+    //
+    // Evidence for all three descent-scope changes: the complete cranelift
+    // `pyre/check.py` corpus passed in PR #1580's CI with every committed
+    // per-fixture jitstats baseline unchanged, including the corpus-wide
+    // `fbw_rolled_back_with_effects == 0` gate.  The public decoder has no
+    // jitcode in the generated metadata; both scalar projections do, so the
+    // evidence covers the reached pair as well as the unreachable graph.
+    (
+        "decode_instruction_forward",
+        "pyopcode.py dispatch_bytecode EXTENDED_ARG loop",
+    ),
+    (
+        "decode_instruction_forward_pc",
+        "pyopcode.py dispatch_bytecode EXTENDED_ARG loop (PC projection)",
+    ),
+    (
+        "decode_instruction_forward_packed",
+        "pyopcode.py dispatch_bytecode EXTENDED_ARG loop (opcode/oparg projection)",
+    ),
 ];
 
 /// `builtins::leading_non_null_count` has carried its own `unroll_safe`

--- a/pyre/extra_tests/parity_tests/jit_compiled_frame_leaves_on_f_trace_assignment.py
+++ b/pyre/extra_tests/parity_tests/jit_compiled_frame_leaves_on_f_trace_assignment.py
@@ -1,0 +1,66 @@
+# CPython-suite gap: test_sys_settrace assigns `f_trace` only from a tracer the
+# `call` event already installed, on a frame that has run a handful of
+# bytecodes; nothing in the suite assigns it to a frame that has been looping
+# long enough to be compiled, which is the only order in which a compiled trace
+# can outlive the assignment.
+# parity-tests reason: `bytecode_only_trace` opens on
+# `frame.get_w_f_trace() is None`, and compiled code makes that call rather than
+# running it, so a frame handed its own trace function mid-loop keeps running
+# compiled and reports no `line` event until the walker's `w_f_trace` guard
+# leaves the trace.
+
+"""Assigning `f_trace` to a running compiled frame has to leave the trace.
+
+The loop is warmed with a global tracer already installed that returns `None`
+from every `call` event, so it claims no frame: every `w_f_trace` stays null
+and the loop compiles, with the callee emitted as a residual rather than
+inlined.  The callee then reaches back with `sys._getframe(1)` and hands the
+looping frame its own trace function, which is what `_trace` reads for every
+event but `'call'` — from that iteration on, `line` events are due.
+"""
+import sys
+
+WARM = 4000
+N = 2000
+
+seen = []
+
+
+def watcher(frame, event, arg):
+    # Claims nothing: a `None` return leaves every frame's `f_trace` null, so
+    # the loop below keeps compiling while this is installed.
+    return None
+
+
+def recorder(frame, event, arg):
+    seen.append(event)
+    return recorder
+
+
+def claim(i, at):
+    if i == at:
+        sys._getframe(1).f_trace = recorder
+    return i
+
+
+def hot(n, at):
+    total = 0
+    for i in range(n):
+        total += claim(i, at)
+    return total
+
+
+sys.settrace(watcher)
+try:
+    hot(WARM, -1)
+    hot(N, N // 2)
+finally:
+    sys.settrace(None)
+
+lines = seen.count("line")
+print("line events after the assignment:", lines >= N // 4)
+assert lines >= N // 4, "hot reported %d line events, expected at least %d" % (
+    lines,
+    N // 4,
+)
+print("OK")

--- a/pyre/extra_tests/parity_tests/jit_declined_walk_restores_module_bindings.py
+++ b/pyre/extra_tests/parity_tests/jit_declined_walk_restores_module_bindings.py
@@ -1,0 +1,39 @@
+# CPython-suite gap: test_heapq's test_heapsort builds its data with a
+# comprehension and then walks it in a second loop, and the failure surfaces as
+# an IndexError out of heappop several statements later, which reads as a heapq
+# defect rather than as a loop iteration whose tail ran against the next
+# iteration's counters.
+# parity-tests reason: a walk that does not commit hands its region back to a
+# replay that re-executes it FROM THE WALK ENTRY, and the module namespace
+# bindings the walk already wrote were the one part of the frame no journal
+# restored — so the replayed statements ahead of the store read the walk's
+# values while everything else still held the pre-walk ones.
+
+"""A declined walk replays a module loop's tail against pre-walk bindings."""
+
+
+def plus_one(i):
+    return i + 1
+
+
+# Two loops in one module frame. Tracing the second one runs a bridge off the
+# tail of one iteration into the head of the next: the bridge consumes `trial`,
+# binds `size` from it, enters the comprehension, and closes there on a merge
+# point whose end-flush cannot resolve the mid-expression operand stack. The
+# walk is handed to the replay, which re-runs the tail it already walked; before
+# the replay reaches `size = trial % 50` it reads the `size` the walk stored,
+# against the `data` the previous iteration built.
+rows = []
+for trial in range(2000):
+    size = trial % 50
+    data = [plus_one(i) for i in range(size)]
+    total = 0
+    for item in data:
+        total += item
+    rows.append((trial, size, len(data), total))
+
+mixed = [row for row in rows if row[1] != row[2]]
+print("iterations:", len(rows))
+print("mixed-state rows:", mixed[:4])
+assert not mixed, mixed
+print("OK")

--- a/pyre/extra_tests/parity_tests/jit_inlined_callee_leaves_trace_on_settrace.py
+++ b/pyre/extra_tests/parity_tests/jit_inlined_callee_leaves_trace_on_settrace.py
@@ -1,0 +1,59 @@
+# CPython-suite gap: test_sys_settrace installs its tracer before the traced
+# function has run enough to be compiled, so every case it covers is the
+# already-hooked order; nothing in the suite warms a loop first and installs a
+# tracer afterwards, which is the only order in which a compiled trace can
+# outlive the hook's installation.
+# parity-tests reason: `sys.settrace` does not change the portal green — `call_trace`
+# sets `is_being_profiled` only for a *profile* function — so an already
+# compiled trace keeps running, and the callee it inlined reports no `call`
+# event at all until a guard on `ExecutionContext.w_tracefunc` leaves it.
+
+"""A compiled trace has to leave when `sys.settrace` is installed.
+
+The tracer returns `None` from every `call` event, so it claims no frame and
+`frame_tracing_active` lets the loop keep compiling — what this measures is the
+compiled path's own frame events rather than the interpreter's.
+
+The loop is warmed with no hook installed, so its callee is inlined into a
+trace recorded against a null `w_tracefunc`.  Installing a tracer afterwards
+does not change the portal green — `call_trace` sets `is_being_profiled` only
+when a *profile* function is installed — so nothing but a guard on that field
+can stop the recorded trace from running on, and an inlined callee that runs
+inside compiled code reports no `call` event at all.
+"""
+import sys
+
+WARM = 4000
+N = 2000
+
+seen = []
+
+
+def tracer(frame, event, arg):
+    if frame.f_code.co_name == "callee":
+        seen.append(event)
+    return None
+
+
+def callee(x):
+    return x + 1
+
+
+def hot(n):
+    total = 0
+    for i in range(n):
+        total += callee(i)
+    return total
+
+
+hot(WARM)
+sys.settrace(tracer)
+try:
+    hot(N)
+finally:
+    sys.settrace(None)
+
+calls = seen.count("call")
+print("callee call events:", calls)
+assert calls == N, "callee reported %d call events, expected %d" % (calls, N)
+print("OK")

--- a/pyre/extra_tests/parity_tests/jit_seam_frame_chain_no_self_backref.py
+++ b/pyre/extra_tests/parity_tests/jit_seam_frame_chain_no_self_backref.py
@@ -51,6 +51,7 @@ assert total > 0, total
 # The same walk from a cold frame must agree with itself across repeats.
 first = recurse(3)
 for _ in range(5):
-    assert recurse(3) == first, (recurse(3), first)
+    again = recurse(3)
+    assert again == first, (again, first)
 
 print("OK")

--- a/pyre/extra_tests/parity_tests/jit_seam_frame_chain_no_self_backref.py
+++ b/pyre/extra_tests/parity_tests/jit_seam_frame_chain_no_self_backref.py
@@ -1,0 +1,56 @@
+# CPython-suite gap: nothing in the suite walks `f_back` from inside a frame the
+# JIT has taken over while a bridge is being traced, so a frame linked into the
+# chain twice reads as a hang or a RecursionError somewhere else entirely.
+# parity-tests reason: the JIT activation seam linked the frame itself
+# (`install_current_frame`) and then handed the frame to the plain evaluator on
+# the bridge-tracing decline, which links it a second time through
+# `ExecutionContext.enter` — and the second link reads `topframeref`, which the
+# first one had already set to this frame, so `f_backref` ended up naming the
+# frame it is stored on.
+
+"""A frame the portal activates is linked into the caller chain exactly once."""
+
+import sys
+
+
+def walk_back():
+    """Walk `f_back` to the root; raise rather than spin if the chain loops."""
+    seen = set()
+    frame = sys._getframe()
+    depth = 0
+    while frame is not None:
+        if id(frame) in seen:
+            raise RuntimeError(
+                "f_back cycle at %s after %d frames" % (frame.f_code.co_name, depth)
+            )
+        seen.add(id(frame))
+        depth += 1
+        frame = frame.f_back
+    return depth
+
+
+def recurse(n):
+    if n:
+        return recurse(n - 1)
+    return walk_back()
+
+
+# The accumulating `t +=` is load-bearing: it is what puts a guard on the loop
+# body whose failure starts the bridge the decline is taken on.  A loop that
+# only rebinds the result does not reach it.
+def hot(n):
+    t = 0
+    for i in range(n):
+        t += recurse(3)
+    return t
+
+
+total = hot(200000)
+assert total > 0, total
+
+# The same walk from a cold frame must agree with itself across repeats.
+first = recurse(3)
+for _ in range(5):
+    assert recurse(3) == first, (recurse(3), first)
+
+print("OK")

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -190,7 +190,7 @@ Polarity below follows this file's rule, with one correction it needed: an
 | PYRE_WASM_FULL_TEARDOWN | skipping the ~0.2s wasm engine teardown at exit; setting it restores the drops for leak diagnostics | when teardown stops being the dominant fixed startup tax |
 | PYRE_FBW_NO_ADOPT_RESIDUAL_LOCALS | reading back the fastlocals a residual wrote to the frame, whether or not it forced, as a recorded `GETARRAYITEM_GC_R` off `locals_cells_stack_w` (`residual_call.rs adopt_residual_locals_writes`); setting it restores the walk that keeps the box it held before the call and so loses the write | when the walk reads a local through a channel a residual cannot leave stale; until then this is the one-binary control that keeps the defect demonstrable, and the parity fixture's two arms (a forcing call, and an inlined callee whose store forces nothing) are only separable with it |
 
-### §6a2 — Default-OFF experiments (4)
+### §6a2 — Default-OFF experiments (5)
 
 Kept as the switched-off arm of a one-binary comparison, not as latent
 defaults.  Bridge inlining reaches module replacement on its own, so
@@ -217,6 +217,7 @@ build.
 | gate | what turning it ON does | retire when |
 |---|---|---|
 | PYRE_WASM_REEMIT | re-emits a compiled loop's wasm module into its own table slot once, on the first bridge installed against it | when the replacement path no longer needs an isolated arm |
+| PYRE_GUARD_RESUME_PC | prints the coordinate every walker-emitted guard resumes at (`resume_snapshot.rs guard_resume_pc_probe_enabled`); a guard whose `py_pc` is not the opcode it was emitted under re-executes the wrong bytecode on deopt, which reads as a livelock or a corrupted local rather than as a crash | the resume coordinate is covered by an ordinary test |
 | PYRE_WASM_INLINE_NONHEADER | admits an inlined region whose closing JUMP names a resumable LABEL other than the loop header AND whose source guard is in the LOOP BODY (`lib.rs inline_nonheader_enabled`); `=1`/`true`/`on` arms it.  The preamble-sourced half of that class takes a different placement — blocks outside the header `loop`, body past its `end` — and is admitted unconditionally, so this flag now covers only the body-sourced half.  Arming it removes 49.4M of the 257.3M cross-module crossings on the 81 fixtures that reach the decline and buys 0.74x/0.67x on two of them, but costs 1.23x on `spectral_norm` | the +18 ops per non-failing iteration it levies on the owner's fall-through is paid back on the fixtures it admits, or an admission rule separates them from `spectral_norm`, which sheds 99.7% of its crossings and still loses 23% |
 | PYRE_FBW_INLINE_POISON | admits a callee the replay scan declined and refuses at the scan's poisoned pcs during the walk (`diag.rs fbw_inline_poison_enabled`) | when a refusal that follows an executed effect has a resume leg that neither repeats it nor drops it |
 | PYRE_JD1 | arms the jd1 (`unpackiterable_driver`) compiled-loop experiment — `eval.rs jd1_experiment_enabled` is `PYRE_JD1 == "1"`, so nothing else turns it on.  `PYRE_NO_JD1`, `PYRE_JD1=0` and the master JIT off-switches (`PYRE_NO_JIT`, `PYRE_JIT=0`) each force it back off | the jd1 experiment concludes |

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -190,7 +190,7 @@ Polarity below follows this file's rule, with one correction it needed: an
 | PYRE_WASM_FULL_TEARDOWN | skipping the ~0.2s wasm engine teardown at exit; setting it restores the drops for leak diagnostics | when teardown stops being the dominant fixed startup tax |
 | PYRE_FBW_NO_ADOPT_RESIDUAL_LOCALS | reading back the fastlocals a residual wrote to the frame, whether or not it forced, as a recorded `GETARRAYITEM_GC_R` off `locals_cells_stack_w` (`residual_call.rs adopt_residual_locals_writes`); setting it restores the walk that keeps the box it held before the call and so loses the write | when the walk reads a local through a channel a residual cannot leave stale; until then this is the one-binary control that keeps the defect demonstrable, and the parity fixture's two arms (a forcing call, and an inlined callee whose store forces nothing) are only separable with it |
 
-### §6a2 — Default-OFF experiments (5)
+### §6a2 — Default-OFF experiments (6)
 
 Kept as the switched-off arm of a one-binary comparison, not as latent
 defaults.  Bridge inlining reaches module replacement on its own, so
@@ -218,15 +218,17 @@ build.
 |---|---|---|
 | PYRE_WASM_REEMIT | re-emits a compiled loop's wasm module into its own table slot once, on the first bridge installed against it | when the replacement path no longer needs an isolated arm |
 | PYRE_GUARD_RESUME_PC | prints the coordinate every walker-emitted guard resumes at (`resume_snapshot.rs guard_resume_pc_probe_enabled`); a guard whose `py_pc` is not the opcode it was emitted under re-executes the wrong bytecode on deopt, which reads as a livelock or a corrupted local rather than as a crash | the resume coordinate is covered by an ordinary test |
+| PYRE_PORTAL_SPLIT | registers jd0 against the `warmspot.py split_graph_and_record_jitdriver` copy split immediately before `jit_merge_point`, instead of the unsplit `eval_loop_jit` graph; `=1` arms it and the prepass cache key includes the value | when the split portal path is the default and the unsplit registration arm is deleted |
 | PYRE_WASM_INLINE_NONHEADER | admits an inlined region whose closing JUMP names a resumable LABEL other than the loop header AND whose source guard is in the LOOP BODY (`lib.rs inline_nonheader_enabled`); `=1`/`true`/`on` arms it.  The preamble-sourced half of that class takes a different placement — blocks outside the header `loop`, body past its `end` — and is admitted unconditionally, so this flag now covers only the body-sourced half.  Arming it removes 49.4M of the 257.3M cross-module crossings on the 81 fixtures that reach the decline and buys 0.74x/0.67x on two of them, but costs 1.23x on `spectral_norm` | the +18 ops per non-failing iteration it levies on the owner's fall-through is paid back on the fixtures it admits, or an admission rule separates them from `spectral_norm`, which sheds 99.7% of its crossings and still loses 23% |
 | PYRE_FBW_INLINE_POISON | admits a callee the replay scan declined and refuses at the scan's poisoned pcs during the walk (`diag.rs fbw_inline_poison_enabled`) | when a refusal that follows an executed effect has a resume leg that neither repeats it nor drops it |
 | PYRE_JD1 | arms the jd1 (`unpackiterable_driver`) compiled-loop experiment — `eval.rs jd1_experiment_enabled` is `PYRE_JD1 == "1"`, so nothing else turns it on.  `PYRE_NO_JD1`, `PYRE_JD1=0` and the master JIT off-switches (`PYRE_NO_JIT`, `PYRE_JIT=0`) each force it back off | the jd1 experiment concludes |
 
-### §6b — VALUE knobs (13): config, not gates
+### §6b — VALUE knobs (15): config, not gates
 
 `PYRE_FBW_MAX_SUBWALK_DEPTH`, `PYRE_FBW_MULTIFRAME_DEPTH`,
 `PYRE_FBW_NO_SPECIALIZE`, `PYRE_JD1_THRESHOLD`,
 `PYRE_PCMAP_RECIPE_RESULTCOLOR_AUDIT_PROBE`,
+`PYRE_PORTAL_METATRACE_ENTRY`, `PYRE_PORTAL_METATRACE_SKIP`,
 `MAJIT_DTRACE_CONST_FROM`, `MAJIT_DTRACE_CONST_TO`,
 `MAJIT_TRACE_CALL_DIAG`, `MAJIT_TRACE_OPS_DIAG`,
 `PYRE_WASM_FORCE_CA_TERMINAL_DECLINE`, `PYRE_WASM_FUEL`,
@@ -255,7 +257,14 @@ its frames on the heap. Lowering it is how the `SubWalkDepthExceeded` decline
 is exercised without building a pathological helper chain; it retires when the
 descent stops recursing on the host stack.
 
-### §6c — Default-OFF diagnostics, censuses and probes (74): keep, cost nothing
+`PYRE_PORTAL_METATRACE_ENTRY` selects where the one-shot jd0 portal probe
+starts: `merge` (the default) seeds the merge-point registers and `start`
+enters at pc 0 with the portal's declared arguments.  The numeric
+`PYRE_PORTAL_METATRACE_SKIP` value selects how many cached-loop back-edges the
+probe passes before firing; it defaults to zero.  Neither has an effect unless
+the probe in §6c is enabled.
+
+### §6c — Default-OFF diagnostics, censuses and probes (75): keep, cost nothing
 
 Deleting one of these environment reads does not change behavior when the
 variable is unset. They remain listed so diagnostics are not mistaken for dead
@@ -284,7 +293,8 @@ configuration.
 `MAJIT_MIR_FRAMESTATE_STRICT`, `PYRE_NO_JD1`, `MAJIT_NO_UNROLL`,
 `PYRE_PCMAP_AFTERRESIDUAL_AUDIT`, `PYRE_PCMAP_CONTAINING_AUDIT`,
 `PYRE_PCMAP_RECIPE_RESULTCOLOR_AUDIT`, `PYRE_PCMAP_RESIDUAL_CENSUS`,
-`MAJIT_PORTAL_RCA`, `PYRE_PROBE_BH_STARTUP`, `PYRE_PROBE_SNAPSHOT`,
+`MAJIT_PORTAL_RCA`, `PYRE_PORTAL_METATRACE`, `PYRE_PROBE_BH_STARTUP`,
+`PYRE_PROBE_SNAPSHOT`,
 `MAJIT_PROBE_SUBSCR`, `MAJIT_PROFILE_PIPELINE`, `PYRE_QMUT_MAPDICT_FORCE`,
 `PYRE_RERAISE_DIAG`, `MAJIT_SIZE_SHELL_OWNERS`, `PYRE_SNAPSHOT_DIAG`,
 `PYRE_UNJOURNALED_SITE`,
@@ -340,6 +350,12 @@ the flag itself keeps no provenance for. It is the second half of a two-step
 read: `PYRE_FBW_CENSUS` finds the walks that ended `committed=false` with
 unrecoverable effects, and this one says which residual decline put them there.
 It goes when the flag carries its own provenance.
+
+`PYRE_PORTAL_METATRACE` drives one Stage-0 `JitCodeMachine` walk over the
+build-time jd0 portal jitcode after the selected cached-loop back-edge and
+prints the `[jd0-mt]` summary.  It is unset by default and exists to inspect
+the portal split and entry seeding; it goes with that investigation once the
+ordinary warmspot path owns the same coverage.
 
 `PYRE_LOOP_CENSUS` prints one `[loop-census] <arm> <name>` line per compiled
 trace, naming it through `get_printable_location` — the JitDriver green-key

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -602,11 +602,12 @@ impl ExecutionContext {
         visitor(unsafe { &mut *(&mut self.py_repr as *mut PyObjectRef as *mut majit_ir::GcRef) });
         if let Some(pending) = self.pending_loop_exit.as_mut() {
             match pending {
-                PendingLoopExit::Done(Ok(value)) => visitor(unsafe {
-                    &mut *(value as *mut PyObjectRef as *mut majit_ir::GcRef)
-                }),
-                PendingLoopExit::Done(Err(err))
-                | PendingLoopExit::ExitFrameWithException(err) => err.walk_gc_refs(visitor),
+                PendingLoopExit::Done(Ok(value)) => {
+                    visitor(unsafe { &mut *(value as *mut PyObjectRef as *mut majit_ir::GcRef) })
+                }
+                PendingLoopExit::Done(Err(err)) | PendingLoopExit::ExitFrameWithException(err) => {
+                    err.walk_gc_refs(visitor)
+                }
                 PendingLoopExit::ContinueRunningNormally => {}
             }
         }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -375,6 +375,13 @@ pub fn may_ignore_finalizer(obj: PyObjectRef) {
 /// Shared execution context for all frames in one interpreter run.
 ///
 /// Holds the builtin module dict used by module-level frames.
+#[derive(Debug, Clone)]
+pub enum PendingLoopExit {
+    Done(crate::PyResult),
+    ContinueRunningNormally,
+    ExitFrameWithException(crate::PyError),
+}
+
 #[derive(Clone)]
 pub struct ExecutionContext {
     pub space: PyObjectRef,
@@ -435,6 +442,10 @@ pub struct ExecutionContext {
     /// per-thread EC pointer and the optimizer can dead-store-eliminate a
     /// balanced save/restore.  GC-rooted via `walk_pyframe_roots`.
     pub sys_exc_value: PyObjectRef,
+    /// `warmspot.py rewrite_can_enter_jits` leaves compiled-loop exits outside
+    /// the portal's jitcode and propagates them out of band.  This is pyre's
+    /// execution-context-owned carrier for that pending exit.
+    pending_loop_exit: Option<PendingLoopExit>,
     /// Per-execution-context coroutine origin tracking depth. CPython keeps
     /// the corresponding setting in the thread state; pyre keeps all such
     /// execution state on the PyPy-style ExecutionContext.
@@ -524,6 +535,7 @@ impl ExecutionContext {
             builtin_dict_cache: std::cell::Cell::new(pyre_object::PY_NULL),
             check_signal_action: None,
             sys_exc_value: pyre_object::PY_NULL,
+            pending_loop_exit: None,
             coroutine_origin_tracking_depth: 0,
             current_gen_or_coroutine: pyre_object::PY_NULL,
             w_asyncgen_firstiter_fn: pyre_object::PY_NULL,
@@ -560,6 +572,7 @@ impl ExecutionContext {
         // builtins_module, matching a fresh PyPy ExecutionContext.
         ec.builtin_dict_cache = std::cell::Cell::new(pyre_object::PY_NULL);
         ec.sys_exc_value = pyre_object::PY_NULL;
+        ec.pending_loop_exit = None;
         // executioncontext.py — a fresh ExecutionContext starts at 0.
         ec.coroutine_origin_tracking_depth = 0;
         ec.current_gen_or_coroutine = pyre_object::PY_NULL;
@@ -587,6 +600,24 @@ impl ExecutionContext {
             &mut *(&mut self.contextvar_context as *mut PyObjectRef as *mut majit_ir::GcRef)
         });
         visitor(unsafe { &mut *(&mut self.py_repr as *mut PyObjectRef as *mut majit_ir::GcRef) });
+        if let Some(pending) = self.pending_loop_exit.as_mut() {
+            match pending {
+                PendingLoopExit::Done(Ok(value)) => visitor(unsafe {
+                    &mut *(value as *mut PyObjectRef as *mut majit_ir::GcRef)
+                }),
+                PendingLoopExit::Done(Err(err))
+                | PendingLoopExit::ExitFrameWithException(err) => err.walk_gc_refs(visitor),
+                PendingLoopExit::ContinueRunningNormally => {}
+            }
+        }
+    }
+
+    pub fn set_pending_loop_exit(&mut self, exit: PendingLoopExit) {
+        self.pending_loop_exit = Some(exit);
+    }
+
+    pub fn take_pending_loop_exit(&mut self) -> Option<PendingLoopExit> {
+        self.pending_loop_exit.take()
     }
 
     pub fn __init__(&mut self, space: PyObjectRef) {

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -62,6 +62,15 @@ impl<T> ResidualSlot for *mut T {}
 impl<T> ResidualRet for *const T {}
 impl<T> ResidualRet for *mut T {}
 
+/// Word-ABI bridge for the scalar bytecode read used by translated residual
+/// calls.  The backends call integer helpers uniformly as `(i64, ..) -> i64`;
+/// the raw Rust function is `(pointer, usize) -> u16`, which is a different
+/// `call_indirect` table type on wasm32.
+extern "C" fn bh_code_unit_at(code: i64, index: i64) -> i64 {
+    let code = unsafe { &*(code as usize as *const crate::CodeObject) };
+    i64::from(crate::pyopcode::code_unit_at(code, index as usize))
+}
+
 /// Publication helpers that check the signature instead of erasing it.
 ///
 /// Taking `*const ()` means every caller casts, and a cast accepts any
@@ -3154,12 +3163,11 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         code_instructions_len,
     );
 
-    let code_unit_at: fn(&crate::CodeObject, usize) -> u16 = crate::pyopcode::code_unit_at;
-    pa2(
+    cpa2(
         &mut entries,
         "pyre_interpreter::pyopcode::code_unit_at",
         "pyre_interpreter::code_unit_at",
-        code_unit_at,
+        bh_code_unit_at,
     );
 
     // Paired-local index decode helpers for the LoadFastLoadFast /

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -3145,6 +3145,23 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         code_varnames_len,
     );
 
+    let code_instructions_len: fn(&crate::CodeObject) -> usize =
+        crate::pyopcode::code_instructions_len;
+    pa1(
+        &mut entries,
+        "pyre_interpreter::pyopcode::code_instructions_len",
+        "pyre_interpreter::code_instructions_len",
+        code_instructions_len,
+    );
+
+    let code_unit_at: fn(&crate::CodeObject, usize) -> u16 = crate::pyopcode::code_unit_at;
+    pa2(
+        &mut entries,
+        "pyre_interpreter::pyopcode::code_unit_at",
+        "pyre_interpreter::code_unit_at",
+        code_unit_at,
+    );
+
     // Paired-local index decode helpers for the LoadFastLoadFast /
     // StoreFastLoadFast / StoreFastStoreFast /
     // LoadFastBorrowLoadFastBorrow arms — same alias-pair rationale as

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -283,7 +283,9 @@ pub fn decode_instruction_for_dispatch(
 ///
 /// Shares `decode_instruction_for_dispatch`'s `u8 < 44` malformed-chain guard
 /// and returns `BytecodeCorruption` on out of bounds.
+/// Both loops are bounded by the `ExtendedArg` prefix chain, which is at most three units.
 #[inline]
+#[majit_macros::unroll_safe]
 pub fn decode_instruction_forward(
     code: &CodeObject,
     pc: usize,
@@ -297,19 +299,23 @@ pub fn decode_instruction_forward(
     let mut start = pc;
     while start > 0
         && start - 1 < code_instructions_len(code)
-        && matches!(code.instructions[start - 1].op, Instruction::ExtendedArg)
+        && matches!(
+            instruction_from_code_unit_word(code_unit_at(code, start - 1)),
+            Instruction::ExtendedArg
+        )
     {
         start -= 1;
     }
 
     let mut opcode_pc = start;
-    let mut state = OpArgState::default();
+    let mut op_arg = 0u32;
     loop {
         if opcode_pc >= code_instructions_len(code) {
             return Err(crate::pycode::BytecodeCorruption);
         }
-        let unit = code.instructions[opcode_pc];
-        let (instruction, op_arg) = state.get(unit);
+        let word = code_unit_at(code, opcode_pc);
+        let instruction = instruction_from_code_unit_word(word);
+        op_arg = (op_arg << 8) | u32::from(word >> 8);
         if matches!(instruction, Instruction::ExtendedArg) {
             opcode_pc += 1;
             continue;
@@ -320,7 +326,83 @@ pub fn decode_instruction_forward(
         {
             return Err(crate::pycode::BytecodeCorruption);
         }
-        return Ok((opcode_pc, instruction, op_arg));
+        return Ok((opcode_pc, instruction, OpArg::new(op_arg)));
+    }
+}
+
+/// Scalar-PC half of [`decode_instruction_forward`] for the JIT dispatch loop.
+/// `usize::MAX` represents the same bytecode-corruption cases as the public decoder.
+#[inline]
+#[majit_macros::unroll_safe]
+pub fn decode_instruction_forward_pc(code: &CodeObject, pc: usize) -> usize {
+    let mut start = pc;
+    while start > 0
+        && start - 1 < code_instructions_len(code)
+        && matches!(
+            instruction_from_code_unit_word(code_unit_at(code, start - 1)),
+            Instruction::ExtendedArg
+        )
+    {
+        start -= 1;
+    }
+
+    let mut opcode_pc = start;
+    loop {
+        if opcode_pc >= code_instructions_len(code) {
+            return usize::MAX;
+        }
+        let instruction = instruction_from_code_unit_word(code_unit_at(code, opcode_pc));
+        if matches!(instruction, Instruction::ExtendedArg) {
+            opcode_pc += 1;
+            continue;
+        }
+        if opcode_pc != start
+            && u8::from(instruction) < 44
+            && !matches!(instruction, Instruction::Reserved)
+        {
+            return usize::MAX;
+        }
+        return opcode_pc;
+    }
+}
+
+/// Scalar opcode/oparg half of [`decode_instruction_forward`] for JIT dispatch.
+/// `u64::MAX` is the corruption sentinel; valid results use bits 0..8 for the
+/// opcode and bits 8..40 for the accumulated oparg.
+#[inline]
+#[majit_macros::unroll_safe]
+pub fn decode_instruction_forward_packed(code: &CodeObject, pc: usize) -> u64 {
+    let mut start = pc;
+    while start > 0
+        && start - 1 < code_instructions_len(code)
+        && matches!(
+            instruction_from_code_unit_word(code_unit_at(code, start - 1)),
+            Instruction::ExtendedArg
+        )
+    {
+        start -= 1;
+    }
+
+    let mut opcode_pc = start;
+    let mut op_arg = 0u32;
+    loop {
+        if opcode_pc >= code_instructions_len(code) {
+            return u64::MAX;
+        }
+        let word = code_unit_at(code, opcode_pc);
+        let instruction = instruction_from_code_unit_word(word);
+        op_arg = (op_arg << 8) | u32::from(word >> 8);
+        if matches!(instruction, Instruction::ExtendedArg) {
+            opcode_pc += 1;
+            continue;
+        }
+        if opcode_pc != start
+            && u8::from(instruction) < 44
+            && !matches!(instruction, Instruction::Reserved)
+        {
+            return u64::MAX;
+        }
+        return u64::from(word & 0xff) | (u64::from(op_arg) << 8);
     }
 }
 
@@ -2084,6 +2166,23 @@ pub fn code_varnames_len(code: &CodeObject) -> usize {
 #[majit_macros::elidable_cannot_raise]
 pub fn code_instructions_len(code: &CodeObject) -> usize {
     code.instructions.len()
+}
+
+/// Read one packed two-byte code unit through a scalar residual call. The
+/// `CodeUnits::deref` slice stays inside the helper body and never crosses the
+/// two-phase residual ABI.
+#[inline]
+#[majit_macros::dont_look_inside]
+pub fn code_unit_at(code: &CodeObject, i: usize) -> u16 {
+    let unit = code.instructions[i];
+    u16::from(u8::from(unit.op)) | (u16::from(u8::from(unit.arg)) << 8)
+}
+
+#[inline]
+fn instruction_from_code_unit_word(word: u16) -> Instruction {
+    // SAFETY: `code_unit_at` obtains this byte from a live `Instruction` in a
+    // `CodeUnit`, so its discriminant is valid and `Instruction` is repr(u8).
+    unsafe { std::mem::transmute::<u8, Instruction>(word as u8) }
 }
 
 /// Extract a [`RaiseKind`]'s discriminant as `usize`. Same parity
@@ -3926,8 +4025,9 @@ pub fn skip_caches(instructions: &[CodeUnit], mut pos: usize) -> usize {
 mod tests {
     use super::{
         decode_instruction_at, decode_instruction_for_dispatch, decode_instruction_forward,
+        decode_instruction_forward_packed, decode_instruction_forward_pc,
     };
-    use crate::bytecode::Instruction;
+    use crate::bytecode::{CodeUnit, CodeUnits, Instruction, OpArgByte};
     use crate::{OpArgState, compile_exec};
 
     #[test]
@@ -4146,6 +4246,22 @@ mod tests {
             code.instructions.replace_op(1, Instruction::GetIter);
         }
         assert!(decode_instruction_forward(&code, 0).is_err());
+    }
+
+    #[test]
+    fn scalar_forward_decode_handles_two_extended_arg_prefixes() {
+        let mut code = compile_exec("x = 1").expect("compile failed");
+        code.instructions = CodeUnits::from([
+            CodeUnit::new(Instruction::ExtendedArg, OpArgByte::new(0x01)),
+            CodeUnit::new(Instruction::ExtendedArg, OpArgByte::new(0x02)),
+            CodeUnit::new(Instruction::Reserved, OpArgByte::new(0x03)),
+        ]);
+
+        assert_eq!(decode_instruction_forward_pc(&code, 0), 2);
+        assert_eq!(decode_instruction_forward_pc(&code, 2), 2);
+        let expected = u64::from(u8::from(Instruction::Reserved)) | (0x01_02_03u64 << 8);
+        assert_eq!(decode_instruction_forward_packed(&code, 0), expected);
+        assert_eq!(decode_instruction_forward_packed(&code, 2), expected);
     }
 
     // A JIT jump/loop-header/resume coordinate points at the real opcode past

--- a/pyre/pyre-jit-trace/build/prepass.rs
+++ b/pyre/pyre-jit-trace/build/prepass.rs
@@ -204,11 +204,12 @@ impl DeterminismCheck {
     }
 }
 
-const LOWERING_GATE_ENV: [&str; 5] = [
+const LOWERING_GATE_ENV: [&str; 6] = [
     "PYRE_DYN_INDIRECT",
     "MAJIT_FNPTR_INDIRECT",
     "MAJIT_MIR_FRAMESTATE",
     "PYRE_OPTION_RESIDUAL_NARROW",
+    "PYRE_PORTAL_SPLIT",
     "PYRE_TUPLE_PER_SHAPE_CLASSDEF",
 ];
 
@@ -234,6 +235,16 @@ fn forward_engine_env_aliases() {
             unsafe { std::env::set_var(engine_name, value) };
         }
     }
+}
+
+/// `PYRE_PORTAL_SPLIT=1` registers the `eval::eval_loop_jit` driver against a
+/// `warmspot.py split_graph_and_record_jitdriver` copy of the portal graph
+/// split before its `jit_merge_point`, instead of against the graph holding
+/// the marker.  Listed in `LOWERING_GATE_ENV` above, which is both hashed
+/// into `codegen_cache_key` and emitted as `cargo::rerun-if-env-changed`:
+/// without both, flipping this serves the cached metadata snapshot.
+fn portal_split_enabled() -> bool {
+    std::env::var("PYRE_PORTAL_SPLIT").is_ok_and(|value| value == "1")
 }
 
 /// Entry of the real build: the translation prepass over the LLBC set.
@@ -1040,6 +1051,7 @@ fn real_main() {
                         .iter()
                         .map(|name| (*name).to_string())
                         .collect(),
+                    split_portal: portal_split_enabled(),
                 },
                 majit_translate::JitDriverSpec {
                     // pypy/interpreter/baseobjspace.py `_unpackiterable_unknown_length`;
@@ -1055,6 +1067,9 @@ fn real_main() {
                     autoreds: true,
                     virtualizables: vec![],
                     red_types: vec![],
+                    // `autoreds` drivers are not split; see the citation in
+                    // `majit_translate::register_configured_jitdrivers`.
+                    split_portal: false,
                 },
             ],
             // pyre production registers no trait-dispatch families (#346).

--- a/pyre/pyre-jit-trace/build/prepass.rs
+++ b/pyre/pyre-jit-trace/build/prepass.rs
@@ -1029,6 +1029,10 @@ fn real_main() {
             jit_drivers: vec![
                 majit_translate::JitDriverSpec {
                     portal: majit_translate::CallPath::from_segments(["eval", "eval_loop_jit"]),
+                    portal_runner: Some(majit_translate::CallPath::from_segments([
+                        "call_jit",
+                        "ll_portal_runner_shim",
+                    ])),
                     greens: pypyjit_driver_layout::PYPYJIT_GREEN_VARS
                         .iter()
                         .map(|(name, _)| (*name).to_string())
@@ -1060,6 +1064,7 @@ fn real_main() {
                         "baseobjspace",
                         "_unpackiterable_unknown_length",
                     ]),
+                    portal_runner: None,
                     greens: vec!["greenkey".to_string()],
                     reds: vec![],
                     green_kinds: vec![majit_ir::Type::Ref],

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -5536,8 +5536,8 @@ static EC_DESCR_GROUP: LazyLock<majit_ir::descr::SimpleDescrGroup> = LazyLock::n
     use majit_ir::descr::{ArrayFlag, SimpleFieldDescrSpec};
     let field = |index: u32, field_key: &str, offset: usize| SimpleFieldDescrSpec {
         index,
-        // descr.py:220-233 cache key is the bare fieldname; `name` is the
-        // qualified display form.
+        // `descr.py get_field_descr` keys its cache on the bare fieldname;
+        // `name` is the qualified display form.
         field_key: field_key.to_string(),
         name: format!("ExecutionContext.{field_key}"),
         offset,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -480,6 +480,8 @@ pub(crate) fn fbw_store_journal_reset() {
     FBW_LIST_EFFECT_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_APPEND_PROMOTE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
+    FBW_NAMESPACE_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
+    FBW_NAMESPACE_STORE_ROLLED_BACK.with(|c| c.set(false));
     FBW_SYS_EXC_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_TRACEBACK_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_UNJOURNALED_VALUE_UNAVAILABLE.with(|c| c.set(false));
@@ -745,6 +747,82 @@ pub(crate) fn fbw_cell_store_journal_push(cell: pyre_object::PyObjectRef, intval
     fbw_bump_executed_effect("cell_store_journal");
 }
 
+/// Record the namespace binding a `*_NAME` / `*_GLOBAL` residual is about to
+/// overwrite, so a walk that hands its region back to the replay can put it
+/// back ([`FBW_NAMESPACE_STORE_JOURNAL`]).  `displaced` is null when the name is
+/// unbound at store time — a fresh binding, which the rollback removes.
+///
+/// The residual itself bumps the executed-effect odometer, so unlike
+/// [`fbw_cell_store_journal_push`] — which stands in for the residual its fold
+/// elided — this push must not bump it a second time.
+pub(crate) fn fbw_namespace_store_journal_push(
+    namespace: pyre_object::PyObjectRef,
+    name: pyre_object::PyObjectRef,
+    displaced: pyre_object::PyObjectRef,
+    loop_var: bool,
+) {
+    if fbw_debug_abort_enabled() {
+        eprintln!(
+            "[fbw-namespace-journal] push ns=0x{:x} name=0x{:x} displaced=0x{:x} \
+             loop_var={loop_var}",
+            namespace as usize, name as usize, displaced as usize,
+        );
+    }
+    FBW_NAMESPACE_STORE_JOURNAL.with(|j| {
+        j.borrow_mut().push(FbwNamespaceStore {
+            namespace,
+            name,
+            displaced,
+            loop_var,
+        })
+    });
+}
+
+/// Whether this walk's rollback undid a namespace binding that an in-flight
+/// FOR_ITER delivery would not re-apply for itself.
+pub(crate) fn fbw_namespace_store_rolled_back() -> bool {
+    FBW_NAMESPACE_STORE_ROLLED_BACK.with(|c| c.get())
+}
+
+/// Raise the flag [`fbw_namespace_store_rolled_back`] reads.  Its own name
+/// because the delivery refusal is the whole point of the rollback recording
+/// anything, and a test can drive the refusal without a live namespace dict.
+fn fbw_namespace_store_mark_rolled_back() {
+    FBW_NAMESPACE_STORE_ROLLED_BACK.with(|c| c.set(true));
+}
+
+/// Non-commit epilogue for the namespace bindings the walked region wrote:
+/// restore each displaced value — or unbind the name that had none — in reverse
+/// push order, so the replay re-derives the region's bindings from the pre-walk
+/// namespace instead of reading the walk's own.
+fn fbw_namespace_store_journal_rollback() {
+    FBW_NAMESPACE_STORE_JOURNAL.with(|j| {
+        let mut entries = j.borrow_mut();
+        while let Some(entry) = entries.pop() {
+            if !entry.loop_var {
+                fbw_namespace_store_mark_rolled_back();
+            }
+            // SAFETY: the push gated `name` on the residual's own str name
+            // operand and `namespace` on a live dict the frame still holds.
+            unsafe {
+                let name = pyre_object::unicodeobject::w_str_get_wtf8(entry.name);
+                if entry.displaced.is_null() {
+                    pyre_object::dictmultiobject::w_dict_delitem_wtf8_no_proxy(
+                        entry.namespace,
+                        name,
+                    );
+                } else {
+                    pyre_object::dictmultiobject::w_dict_setitem_wtf8_no_proxy(
+                        entry.namespace,
+                        name,
+                        entry.displaced,
+                    );
+                }
+            }
+        }
+    });
+}
+
 /// Record the `sys_exc_value` a walked eager `set_current_exception`
 /// displaces, for the in-place restore when the walk does not commit its
 /// end state.  Pushed by [`try_walker_lower_exc_info_residual`] before it
@@ -797,6 +875,9 @@ pub(crate) fn fbw_store_journal_commit() {
     FBW_LIST_EFFECT_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_APPEND_PROMOTE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
+    // A committed walk's end state IS the region's result, so the namespace
+    // bindings it wrote are the ones the frame goes on with.
+    FBW_NAMESPACE_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     // A committed walk keeps its eager `sys_exc_value` store (the compiled
     // trace or the adopted end state carries the same exception state), so
     // drop the undo log without re-applying it.
@@ -1352,7 +1433,16 @@ pub fn fbw_foriter_inflight_take(
     let append_len = FBW_LIST_EFFECT_JOURNAL.with(|j| j.borrow().len());
     let cell_store_len = FBW_CELL_STORE_JOURNAL.with(|j| j.borrow().len());
     let unjournaled = fbw_has_unjournaled_effect();
-    if body_effect || store_len != 0 || append_len != 0 || cell_store_len != 0 {
+    // A rolled-back namespace binding the delivery cannot re-apply: the
+    // reposition runs the FOR_ITER body, not the region ahead of it, so a
+    // binding written before the consume would stay undone.
+    let namespace_rolled_back = fbw_namespace_store_rolled_back();
+    if body_effect
+        || store_len != 0
+        || append_len != 0
+        || cell_store_len != 0
+        || namespace_rolled_back
+    {
         crate::trace::fbw_diag::record_foriter_item_dropped();
         if let Some((code_ptr, body_pc)) = key {
             super::census_record_foriter_inflight(
@@ -1366,6 +1456,7 @@ pub fn fbw_foriter_inflight_take(
                 "[fbw-foriter] deliver REFUSED (body effect committed since consume) body_pc={} \
                  body_effect={body_effect} store_journal_len={store_len} \
                  append_journal_len={append_len} unjournaled={unjournaled} \
+                 namespace_rolled_back={namespace_rolled_back} \
                  — keeping legacy drop-on-abort to avoid a double-apply (R1)",
                 body_pc
             );
@@ -1619,6 +1710,29 @@ mod foriter_delivery_tests {
         );
     }
 
+    /// The second refusal reason, beside an executed body effect: a rollback
+    /// that put a namespace binding back.  Delivery repositions the frame to
+    /// the body pc, so every statement between the walk entry and that pc is
+    /// skipped and never rewrites the binding the rollback just restored —
+    /// only a replay from the walk entry does.  The loop variable's own store
+    /// is exempt at push time, so it never raises this flag.
+    #[test]
+    fn a_rolled_back_namespace_binding_refuses_consumed_item_delivery() {
+        fbw_store_journal_reset();
+        let item = 1usize as pyre_object::PyObjectRef;
+        fbw_foriter_inflight_capture(item, InflightForiterBody::Py(34));
+        fbw_namespace_store_mark_rolled_back();
+
+        assert!(fbw_namespace_store_rolled_back());
+        assert_eq!(fbw_foriter_inflight_take(0, 0, 33), None);
+
+        fbw_store_journal_reset();
+        assert!(
+            !fbw_namespace_store_rolled_back(),
+            "the reset clears the flag, so it cannot refuse the NEXT walk"
+        );
+    }
+
     #[test]
     fn executed_body_effect_still_refuses_consumed_item_delivery() {
         fbw_store_journal_reset();
@@ -1644,6 +1758,7 @@ mod foriter_delivery_tests {
 /// (max) length, so every restore lands while the list is still grown;
 /// shrinking first could push a restore index past the length and drop it.
 pub(crate) fn fbw_store_journal_rollback() {
+    fbw_namespace_store_journal_rollback();
     FBW_STORE_JOURNAL.with(|j| {
         let mut entries = j.borrow_mut();
         while let Some([list, key, displaced]) = entries.pop() {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -6750,6 +6750,32 @@ thread_local! {
     static FBW_CELL_STORE_JOURNAL: std::cell::RefCell<Vec<(pyre_object::PyObjectRef, i64)>> =
         const { std::cell::RefCell::new(Vec::new()) };
 
+    /// Undo log for the walked region's eagerly executed namespace bindings.
+    /// `STORE_NAME` / `STORE_GLOBAL` / `DELETE_NAME` / `DELETE_GLOBAL` reach the
+    /// walker as residuals that write the frame's namespace dict in place, and
+    /// no other journal records what they displaced.  A walk that does not
+    /// commit hands its region to a replay that re-executes it FROM THE WALK
+    /// ENTRY, so every statement between the entry and the store reads the
+    /// walk's binding while the rest of the frame still holds its pre-walk
+    /// value: a bridge walk that runs off the tail of one `for` iteration into
+    /// the head of the next leaves the loop variable — and everything derived
+    /// from it — advanced, and the replayed tail reports the previous
+    /// iteration's data against the next iteration's counters.  Entries restore
+    /// the displaced value (or unbind a name the walk created) in reverse push
+    /// order, the way [`FBW_STORE_JOURNAL`] restores list elements.  The
+    /// displaced value can have lost its only other reference to the store, so
+    /// entries are GC roots via [`fbw_store_journal_root_walker`].
+    static FBW_NAMESPACE_STORE_JOURNAL: std::cell::RefCell<Vec<FbwNamespaceStore>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+
+    /// Set when the rollback above undid a binding that is NOT the in-flight
+    /// FOR_ITER's loop-variable store.  An in-flight delivery repositions the
+    /// frame to the FOR_ITER body instead of replaying from the walk entry, so
+    /// a binding written before that FOR_ITER would never be re-applied; the
+    /// delivery refuses while this stands and keeps the conservative drop.
+    static FBW_NAMESPACE_STORE_ROLLED_BACK: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+
     /// Undo log for the walked region's eagerly executed
     /// `set_current_exception` stores against the LIVE per-thread
     /// `ExecutionContext.sys_exc_value`.  The authoritative walk lowers
@@ -7056,12 +7082,26 @@ pub(crate) struct EntryFallback {
     pub entry_executed_effects: usize,
 }
 
+/// One [`FBW_NAMESPACE_STORE_JOURNAL`] entry: the namespace dict a `*_NAME` /
+/// `*_GLOBAL` residual wrote, the name it bound, and the value that name held
+/// before the write — null when the name was unbound, which the rollback undoes
+/// with a delete.  `loop_var` marks the FOR_ITER body's own loop-variable
+/// store, the one binding an in-flight delivery re-executes for itself.
+#[derive(Clone, Copy)]
+struct FbwNamespaceStore {
+    namespace: pyre_object::PyObjectRef,
+    name: pyre_object::PyObjectRef,
+    displaced: pyre_object::PyObjectRef,
+    loop_var: bool,
+}
+
 struct FbwStoreJournalRootArea {
     stores: *const std::cell::RefCell<Vec<[pyre_object::PyObjectRef; 3]>>,
     list_effects: *const std::cell::RefCell<Vec<FbwListEffect>>,
     append_promote: *const std::cell::RefCell<Vec<pyre_object::PyObjectRef>>,
     abort_overrides: *const std::cell::RefCell<Vec<(usize, pyre_object::PyObjectRef)>>,
     cell_stores: *const std::cell::RefCell<Vec<(pyre_object::PyObjectRef, i64)>>,
+    namespace_stores: *const std::cell::RefCell<Vec<FbwNamespaceStore>>,
     sys_exc: *const std::cell::RefCell<Vec<pyre_object::PyObjectRef>>,
     traceback_store:
         *const std::cell::RefCell<Vec<(pyre_object::PyObjectRef, pyre_object::PyObjectRef)>>,
@@ -7082,6 +7122,7 @@ thread_local! {
         append_promote: FBW_APPEND_PROMOTE_JOURNAL.with(|value| value as *const _),
         abort_overrides: FBW_ABORT_OUTER_STACK_OVERRIDES.with(|value| value as *const _),
         cell_stores: FBW_CELL_STORE_JOURNAL.with(|value| value as *const _),
+        namespace_stores: FBW_NAMESPACE_STORE_JOURNAL.with(|value| value as *const _),
         sys_exc: FBW_SYS_EXC_JOURNAL.with(|value| value as *const _),
         traceback_store: FBW_TRACEBACK_STORE_JOURNAL.with(|value| value as *const _),
         foriter: FBW_FORITER_INFLIGHT.with(|value| value as *const _),
@@ -7429,6 +7470,23 @@ pub unsafe fn fbw_store_journal_root_walker_area(
     let cell_stores = unsafe { &mut *(*area.cell_stores).as_ptr() };
     for (cell, _intvalue) in cell_stores.iter_mut() {
         visitor(unsafe { &mut *(cell as *mut pyre_object::PyObjectRef).cast() });
+    }
+    // Namespace-store journal: the store replaced the displaced binding in its
+    // dict slot, so the entry can be that value's only remaining owner, and the
+    // rollback reads the dict and the name back to put it there — forward all
+    // three.  A null `displaced` is the unbound case and names no object.
+    let namespace_stores = unsafe { &mut *(*area.namespace_stores).as_ptr() };
+    for entry in namespace_stores.iter_mut() {
+        for slot in [
+            &mut entry.namespace as *mut pyre_object::PyObjectRef,
+            &mut entry.name as *mut pyre_object::PyObjectRef,
+            &mut entry.displaced as *mut pyre_object::PyObjectRef,
+        ] {
+            if unsafe { *slot }.is_null() {
+                continue;
+            }
+            visitor(unsafe { &mut *slot.cast() });
+        }
     }
     // The displaced `sys_exc_value` entries are exception objects that may be
     // nursery-resident and no longer referenced elsewhere once the eager store

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -5418,6 +5418,78 @@ pub(crate) fn residual_call_is_proven_truth(
     };
     numeric_ref_regs[arg_reg as usize] || bool_ref_regs[arg_reg as usize]
 }
+
+/// Journal the namespace binding a `STORE_NAME` / `STORE_GLOBAL` /
+/// `DELETE_NAME` / `DELETE_GLOBAL` residual is about to overwrite, so a walk
+/// that does not commit can put it back before the replay re-runs the region
+/// (`FBW_NAMESPACE_STORE_JOURNAL`).  Without it the replay reads the walk's own
+/// bindings for every statement ahead of the store.
+///
+/// The namespace is the one the opcode family writes: `*_NAME` binds the
+/// frame's `w_locals`, `*_GLOBAL` its `w_globals`.  Only a real dict is
+/// journaled — an `exec(src, mapping)` namespace takes its write through the
+/// mapping protocol, which a `setitem`/`delitem` undo would not reverse
+/// faithfully — and only for the authoritative executor, the walk whose
+/// concrete writes are the ones that land.
+fn journal_walker_namespace_write<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    helper: majit_ir::PyreHelperKind,
+    r_args: &[OpRef],
+) -> Option<()> {
+    use majit_ir::PyreHelperKind as K;
+    if !ctx.is_authoritative_executor {
+        return None;
+    }
+    let binds_name = matches!(helper, K::StoreName | K::DeleteName);
+    if !binds_name && !matches!(helper, K::StoreGlobal | K::DeleteGlobal) {
+        return None;
+    }
+    let (&frame_opref, &name_opref) = (r_args.first()?, r_args.get(1)?);
+    let (
+        Some(majit_ir::Value::Ref(majit_ir::GcRef(frame_ptr))),
+        Some(majit_ir::Value::Ref(majit_ir::GcRef(w_name_ptr))),
+    ) = (
+        ctx.trace_ctx.box_value(frame_opref),
+        ctx.trace_ctx.box_value(name_opref),
+    )
+    else {
+        return None;
+    };
+    if frame_ptr == 0 || w_name_ptr == 0 {
+        return None;
+    }
+    let frame = unsafe { &*(frame_ptr as *const pyre_interpreter::pyframe::PyFrame) };
+    let namespace = if binds_name {
+        frame.get_w_locals()
+    } else {
+        frame.get_w_globals()
+    };
+    if namespace.is_null() {
+        return None;
+    }
+    // SAFETY: `namespace` is a live namespace object the frame holds.
+    if !unsafe {
+        pyre_object::is_module_dict(namespace)
+            || pyre_object::py_type_check(namespace, &pyre_object::DICT_TYPE)
+    } {
+        return None;
+    }
+    let name = w_name_ptr as pyre_object::PyObjectRef;
+    // SAFETY: a namespace opcode's name operand is the code object's interned
+    // `co_names` string, and the dict was just type-checked.
+    let displaced =
+        unsafe { pyre_object::w_dict_lookup(namespace, name) }.unwrap_or(std::ptr::null_mut());
+    // The loop-variable binding store is the op at the in-flight FOR_ITER's
+    // `body_pc`, recognised the way the R1 in-flight accounting recognises it.
+    // An in-flight delivery re-runs the body from that pc, so this one binding
+    // is re-applied by the delivery itself and its rollback closes no road.
+    let loop_var = matches!(helper, K::StoreName | K::StoreGlobal)
+        && fbw_foriter_inflight_top_body_pc()
+            .is_some_and(|body_pc| body_pc + 1 == ctx.vstack_cur_pypc as usize);
+    fbw_namespace_store_journal_push(namespace, name, displaced, loop_var);
+    Some(())
+}
+
 /// `pyjitpl.py opimpl_jit_force_quasi_immutable` for the module
 /// namespace's `version?` (`celldict.py _immutable_fields_ = ["version?"]`),
 /// asked ahead of an opaque STORE_NAME / STORE_GLOBAL / DELETE_NAME /
@@ -7624,6 +7696,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         // `symbolic_fnaddr_for_path` hashes whose bits ≥ 47 are set)
         // so unregistered helpers degrade gracefully to recording-only
         // instead of SIGBUSing.
+        // A namespace write reaches the executor as an ordinary residual and
+        // mutates the frame's dict in place; record what it displaces while the
+        // write is still entirely ahead of the walk.
+        journal_walker_namespace_write(ctx, ei.pyre_helper, &r_args);
         let resid_exec = try_execute_residual_call_via_executor(
             ctx,
             call_opcode,
@@ -9003,6 +9079,10 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         // `symbolic_fnaddr_for_path` hashes whose bits ≥ 47 are set)
         // so unregistered helpers degrade gracefully to recording-only
         // instead of SIGBUSing.
+        // A namespace write reaches the executor as an ordinary residual and
+        // mutates the frame's dict in place; record what it displaces while the
+        // write is still entirely ahead of the walk.
+        journal_walker_namespace_write(ctx, ei.pyre_helper, &r_args);
         let resid_exec = try_execute_residual_call_via_executor(
             ctx,
             call_opcode,
@@ -9255,6 +9335,10 @@ pub(crate) fn dispatch_residual_call_iIRFd_kind<Sym: WalkSym>(
         // `symbolic_fnaddr_for_path` hashes whose bits ≥ 47 are set)
         // so unregistered helpers degrade gracefully to recording-only
         // instead of SIGBUSing.
+        // A namespace write reaches the executor as an ordinary residual and
+        // mutates the frame's dict in place; record what it displaces while the
+        // write is still entirely ahead of the walk.
+        journal_walker_namespace_write(ctx, ei.pyre_helper, &r_args);
         let resid_exec = try_execute_residual_call_via_executor(
             ctx,
             call_opcode,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -5433,10 +5433,10 @@ pub(crate) fn residual_call_is_proven_truth(
 /// concrete writes are the ones that land.
 fn journal_walker_namespace_write<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
-    helper: majit_ir::PyreHelperKind,
+    helper: majit_ir::RuntimeHelperKind,
     r_args: &[OpRef],
 ) -> Option<()> {
-    use majit_ir::PyreHelperKind as K;
+    use majit_ir::RuntimeHelperKind as K;
     if !ctx.is_authoritative_executor {
         return None;
     }
@@ -7699,7 +7699,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         // A namespace write reaches the executor as an ordinary residual and
         // mutates the frame's dict in place; record what it displaces while the
         // write is still entirely ahead of the walk.
-        journal_walker_namespace_write(ctx, ei.pyre_helper, &r_args);
+        journal_walker_namespace_write(ctx, ei.runtime_helper, &r_args);
         let resid_exec = try_execute_residual_call_via_executor(
             ctx,
             call_opcode,
@@ -9082,7 +9082,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         // A namespace write reaches the executor as an ordinary residual and
         // mutates the frame's dict in place; record what it displaces while the
         // write is still entirely ahead of the walk.
-        journal_walker_namespace_write(ctx, ei.pyre_helper, &r_args);
+        journal_walker_namespace_write(ctx, ei.runtime_helper, &r_args);
         let resid_exec = try_execute_residual_call_via_executor(
             ctx,
             call_opcode,
@@ -9338,7 +9338,7 @@ pub(crate) fn dispatch_residual_call_iIRFd_kind<Sym: WalkSym>(
         // A namespace write reaches the executor as an ordinary residual and
         // mutates the frame's dict in place; record what it displaces while the
         // write is still entirely ahead of the walk.
-        journal_walker_namespace_write(ctx, ei.pyre_helper, &r_args);
+        journal_walker_namespace_write(ctx, ei.runtime_helper, &r_args);
         let resid_exec = try_execute_residual_call_via_executor(
             ctx,
             call_opcode,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3848,11 +3848,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // walked.  The loop-var store is recognised by the FOR_ITER body's own
     // relation `body_pc + 1 == vstack_cur_pypc`, i.e. the walk has advanced one
     // opcode past the recorded body pc — not by a next-instr convention.
-    let is_loop_var_binding_store = matches!(
-        helper,
-        majit_ir::RuntimeHelperKind::StoreName | majit_ir::RuntimeHelperKind::StoreGlobal
-    ) && fbw_foriter_inflight_top_body_pc()
-        .is_some_and(|body_pc| body_pc + 1 == ctx.vstack_cur_pypc as usize);
+    let is_loop_var_binding_store = is_loop_var_binding_store(ctx, helper);
     // PUSH_EXC_INFO's carrier clear is void-returning, so `writes_live_heap`
     // alone counts it.  The slot it writes exists only to keep a propagating
     // exception rooted for the collector — nothing reads it back as a value —
@@ -5419,6 +5415,20 @@ pub(crate) fn residual_call_is_proven_truth(
     numeric_ref_regs[arg_reg as usize] || bool_ref_regs[arg_reg as usize]
 }
 
+/// Whether this residual is the binding store immediately following the live
+/// in-flight `FOR_ITER`.  Both effect accounting and namespace rollback must
+/// use this one predicate so their loop-variable classifications cannot drift.
+fn is_loop_var_binding_store<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    helper: majit_ir::RuntimeHelperKind,
+) -> bool {
+    matches!(
+        helper,
+        majit_ir::RuntimeHelperKind::StoreName | majit_ir::RuntimeHelperKind::StoreGlobal
+    ) && fbw_foriter_inflight_top_body_pc()
+        .is_some_and(|body_pc| body_pc + 1 == ctx.vstack_cur_pypc as usize)
+}
+
 /// Journal the namespace binding a `STORE_NAME` / `STORE_GLOBAL` /
 /// `DELETE_NAME` / `DELETE_GLOBAL` residual is about to overwrite, so a walk
 /// that does not commit can put it back before the replay re-runs the region
@@ -5483,9 +5493,7 @@ fn journal_walker_namespace_write<Sym: WalkSym>(
     // `body_pc`, recognised the way the R1 in-flight accounting recognises it.
     // An in-flight delivery re-runs the body from that pc, so this one binding
     // is re-applied by the delivery itself and its rollback closes no road.
-    let loop_var = matches!(helper, K::StoreName | K::StoreGlobal)
-        && fbw_foriter_inflight_top_body_pc()
-            .is_some_and(|body_pc| body_pc + 1 == ctx.vstack_cur_pypc as usize);
+    let loop_var = is_loop_var_binding_store(ctx, helper);
     fbw_namespace_store_journal_push(namespace, name, displaced, loop_var);
     Some(())
 }
@@ -7699,7 +7707,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         // A namespace write reaches the executor as an ordinary residual and
         // mutates the frame's dict in place; record what it displaces while the
         // write is still entirely ahead of the walk.
-        journal_walker_namespace_write(ctx, ei.runtime_helper, &r_args);
+        let _ = journal_walker_namespace_write(ctx, ei.runtime_helper, &r_args);
         let resid_exec = try_execute_residual_call_via_executor(
             ctx,
             call_opcode,
@@ -9082,7 +9090,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         // A namespace write reaches the executor as an ordinary residual and
         // mutates the frame's dict in place; record what it displaces while the
         // write is still entirely ahead of the walk.
-        journal_walker_namespace_write(ctx, ei.runtime_helper, &r_args);
+        let _ = journal_walker_namespace_write(ctx, ei.runtime_helper, &r_args);
         let resid_exec = try_execute_residual_call_via_executor(
             ctx,
             call_opcode,
@@ -9338,7 +9346,7 @@ pub(crate) fn dispatch_residual_call_iIRFd_kind<Sym: WalkSym>(
         // A namespace write reaches the executor as an ordinary residual and
         // mutates the frame's dict in place; record what it displaces while the
         // write is still entirely ahead of the walk.
-        journal_walker_namespace_write(ctx, ei.runtime_helper, &r_args);
+        let _ = journal_walker_namespace_write(ctx, ei.runtime_helper, &r_args);
         let resid_exec = try_execute_residual_call_via_executor(
             ctx,
             call_opcode,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1264,6 +1264,8 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                 forward_py_pc,
                 &vable_boxes,
                 &vref_boxes,
+                "fbw",
+                op_pc,
             );
             return Ok(());
         }
@@ -1299,9 +1301,21 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
         arm_py_pc,
         &vable_boxes,
         &vref_boxes,
+        "carried",
+        op_pc,
     );
     ctx.outer_active_boxes = active;
     Ok(())
+}
+
+/// `PYRE_GUARD_RESUME_PC=1` prints the coordinate every walker-emitted guard
+/// resumes at.  A guard whose printed `py_pc` is not the opcode it was emitted
+/// under re-executes the wrong bytecode on deopt, which reads as a livelock or
+/// a corrupted local rather than as a crash, so the coordinate is otherwise
+/// invisible.
+fn guard_resume_pc_probe_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var("PYRE_GUARD_RESUME_PC").as_deref() == Ok("1"))
 }
 
 /// Attach a freshly built single-frame snapshot to the guard this capture is
@@ -1321,7 +1335,22 @@ fn publish_single_frame_snapshot<Sym: WalkSym>(
     py_pc: u32,
     vable_boxes: &[majit_metainterp::recorder::SnapshotTagged],
     vref_boxes: &[majit_metainterp::recorder::SnapshotTagged],
+    origin: &str,
+    op_pc: usize,
 ) {
+    if guard_resume_pc_probe_enabled() {
+        let opcode = match guard_stamp {
+            GuardStampTarget::LastOp => ctx.trace_ctx.last_op_opcode(),
+            GuardStampTarget::GuardFromEnd(from_end) => {
+                ctx.trace_ctx.guard_op_opcode_from_end(from_end)
+            }
+        };
+        eprintln!(
+            "[guard-pc] {origin} {opcode:?} op_pc={op_pc} jc={jitcode_index} \
+             jit_pc={pc} py_pc={py_pc} active={}",
+            active.len(),
+        );
+    }
     match guard_stamp {
         GuardStampTarget::LastOp => ctx
             .trace_ctx

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -338,15 +338,25 @@ fn compute_portal_jitcode_index_for_key(key: &str) -> Option<usize> {
 }
 
 fn compute_portal_jitcode_index() -> Option<usize> {
-    compute_portal_jitcode_index_for_key("eval::eval_loop_jit")
+    let drivers = COMPILED_JIT_DRIVERS.with(|cell| *cell.get_or_init(load_compiled_jit_drivers));
+    let mut matching = drivers.iter().filter(|driver| {
+        get_jitcode_ref_by_index(driver.main_jitcode_index)
+            .is_some_and(|jitcode| jitcode.jitdriver_sd() == Some(0))
+    });
+    let driver = matching.next()?;
+    assert!(
+        matching.next().is_none(),
+        "multiple compiled JIT drivers carry JitDriverStaticData index 0"
+    );
+    Some(driver.main_jitcode_index)
 }
 
 /// RPython: `metainterp_sd.jitcodes[jitdriver_sd.mainjitcode.index]`
 /// (warmspot.py:281-282 + call.py:147-148) — the main
-/// `eval::eval_loop_jit` portal jitcode that `find_all_graphs(portal, policy)`
-/// seeds the jitcode closure from. For a per-driver resolver, use
-/// [`portal_jitcode_for_key`]. Returns `None` when the main eval portal is
-/// absent from the compiled metadata.
+/// portal jitcode for JitDriverStaticData index 0, which
+/// `find_all_graphs(portal, policy)` seeds the jitcode closure from. For a
+/// per-driver path resolver, use [`portal_jitcode_for_key`]. Returns `None`
+/// when driver index 0 is absent from the compiled metadata.
 ///
 /// Trace-side user-function calls (`callee_frame_helper`,
 /// `jit_create_callee_frame_*`, `jit_force_callee_frame`) route through
@@ -2987,25 +2997,25 @@ mod tests {
     #[test]
     fn portal_jitcode_resolves_to_unique_jitdriver_entry() {
         // Verify the portal accessor returns the build-time JitCode for the
-        // unique main eval driver (RPython
+        // unique driver carrying JitDriverStaticData index 0 (RPython
         // call.py `jd.mainjitcode = self.get_jitcode(jd.portal_graph)`).
         let portal = portal_jitcode().expect("build-time pipeline must register a portal jitcode");
-        assert!(
-            portal.jitdriver_sd().is_some(),
-            "portal jitcode must carry a populated `jitdriver_sd` (call.py:148)"
-        );
+        assert_eq!(portal.jitdriver_sd(), Some(0));
         let drivers =
             COMPILED_JIT_DRIVERS.with(|cell| *cell.get_or_init(load_compiled_jit_drivers));
-        let eval_drivers = drivers
+        let main_drivers = drivers
             .iter()
-            .filter(|driver| driver.portal.canonical_key() == "eval::eval_loop_jit")
+            .filter(|driver| {
+                get_jitcode_ref_by_index(driver.main_jitcode_index)
+                    .is_some_and(|jitcode| jitcode.jitdriver_sd() == Some(0))
+            })
             .collect::<Vec<_>>();
         assert_eq!(
-            eval_drivers.len(),
+            main_drivers.len(),
             1,
-            "the main eval portal must resolve to exactly one configured JIT driver"
+            "JitDriverStaticData index 0 must resolve to exactly one compiled JIT driver"
         );
-        assert_eq!(portal.index(), eval_drivers[0].main_jitcode_index);
+        assert_eq!(portal.index(), main_drivers[0].main_jitcode_index);
     }
 
     #[test]

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -9912,8 +9912,6 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
     // eagerly here scanned the whole bytecode and built a successor map for
     // every frame entry to produce a set no one read.  Compute it lazily at
     // the first back-edge instead (kept per graph on `CallControl`).
-    let env = PyreEnv;
-    let (driver, info) = driver_pair();
     // interp_jit.py:66 — next_instr, pycode are greens (managed by jit_merge_point).
     // No explicit promote needed; the JitDriver green-key mechanism handles this.
 
@@ -10225,6 +10223,11 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 // can_enter_jit is a lowered no-op / merge point; re-seed
                 // conservatively before the next frame reads.
                 let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                // Compute these after the merge point: the portal split requires every
+                // live-across value to be a declared green or red. Upstream bakes the
+                // driver into the enter function and reaches the space through `self.space`.
+                let env = PyreEnv;
+                let (driver, info) = driver_pair();
                 let loop_pycode = unsafe { &*f }.pycode;
                 let loop_profiled = unsafe { &*f }.get_is_being_profiled();
                 let green_key_hash = make_green_key(loop_pycode, loop_header_pc, loop_profiled);

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -267,6 +267,35 @@ impl Drop for FrameRoot {
     }
 }
 
+/// A non-owning view of the caller's [`FrameRoot`] for the portal loop.
+/// `handle_jitexception` owns the root that brackets the whole re-loop; the
+/// portal only re-reads it. The view is re-derived after `jit_merge_point`
+/// so no value defined before the marker is live after it, which is what
+/// upstream `split_block`'s `_forcelink` enforces at the JIT split: the
+/// gctransform shadow-stack pass runs after that split, and the split-off
+/// portal function re-captures its shadow-stack base in its own prologue.
+struct FrameView {
+    depth: usize,
+    slot: majit_gc::shadow_stack::ShadowStackSlot,
+}
+
+impl FrameView {
+    #[inline]
+    fn top() -> Self {
+        let (slot, depth) = majit_gc::shadow_stack::top();
+        Self { depth, slot }
+    }
+
+    #[inline]
+    fn frame(&self) -> &mut PyFrame {
+        // SAFETY: `slot` was resolved on this thread in `top` and the thread
+        // is still running; no `&mut` borrow of the cell is held here.
+        let frame =
+            unsafe { majit_gc::shadow_stack::slot_get(self.slot, self.depth) }.0 as *mut PyFrame;
+        unsafe { &mut *frame }
+    }
+}
+
 /// Restores `ExecutionContext.topframeref` after compiled execution, including
 /// panic unwinds.  The saved pointer lives on the shadow stack so a moving
 /// collection can forward it in place, matching `CurrentFrameGuard`.
@@ -9874,7 +9903,12 @@ fn cached_function_entry_trace_is_jit_safe(code: &pyre_interpreter::CodeObject) 
 /// recursive portal depth. Returns PyObjectRef (NULL on void/exception).
 /// JIT hooks are thin inline checks; all heavy logic is in #[cold] helpers.
 fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
-    let mut frame_root = FrameRoot::new(frame);
+    // The caller's root is the top of the shadow stack and names this frame;
+    // every reload below goes through that root (`FrameView::top`).
+    debug_assert!(
+        std::ptr::eq(FrameView::top().frame(), &*frame),
+        "eval_loop_jit entered without its frame as the top shadow-stack root"
+    );
     // Bump the monotonic frame eval-loop entry odometer (mirrors the plain
     // `eval_loop` entry): a user Python frame is about to run bytecode.  The
     // FBW FOR_ITER Option-C guard snapshots this around a residual call to
@@ -9882,9 +9916,9 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
     pyre_interpreter::call::bump_frame_entry_count();
     // Recursion accounting belongs to the activation seams
     // (`eval_with_jit_inner` and `portal_activation_result`), not this re-entrant
-    // dispatch loop.  In particular, `FrameRoot` may have forwarded a moving
-    // frame since the seam; keying the same activation again by its new
-    // address would spend a second recursion unit.
+    // dispatch loop.  In particular, the caller's root may have forwarded a
+    // moving frame since the seam; keying the same activation again by its
+    // new address would spend a second recursion unit.
     // Count this eval-loop activation for the GC safepoint's
     // at_outermost_activation gate (gh#393). The gate allows collection
     // at depth ≤ 2 (module + one called function) where the CALL opcode
@@ -9951,7 +9985,8 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         // after every collection-point call in this loop (bytecode_trace,
         // perform_actions, execute_opcode_step, handle_exception, can_enter_jit /
         // maybe_compile_and_run, jit_merge_point).
-        let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+        let root = FrameView::top();
+        let f: *mut PyFrame = root.frame() as *mut PyFrame;
 
         // The plain evaluator's twin: a bounded major collection that reached
         // `max_heap_size` owes a `MemoryError`, and the safepoint above — which
@@ -9983,7 +10018,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 &mut next_instr,
             ) {
                 // handle_exception allocates → re-seed before the write.
-                let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                let f: *mut PyFrame = root.frame() as *mut PyFrame;
                 unsafe { &mut *f }.set_last_instr_from_next_instr(next_instr);
                 continue;
             }
@@ -10008,7 +10043,11 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         );
         // jit_merge_point is a lowered no-op / merge point and does not itself
         // collect, but is treated as a collection boundary conservatively.
-        let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+        // The view is re-derived here so nothing defined before the marker is
+        // used after it (`split_block`'s `_forcelink`); upstream's portal
+        // function re-captures its shadow-stack base in its own prologue.
+        let root = FrameView::top();
+        let f: *mut PyFrame = root.frame() as *mut PyFrame;
 
         // `interp_jit.py` `PyFrame.dispatch`: `co_code = pycode.co_code`,
         // read from the green the marker just declared and nowhere else. One
@@ -10084,7 +10123,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
             if unsafe { &mut *f }.take_failed_attr_before_opcode() {
                 unsafe { (*ec_ptr).run_failed_attr_finalizers() };
             }
-            let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+            let f: *mut PyFrame = root.frame() as *mut PyFrame;
             let needs_trace = unsafe { !(*ec_ptr).w_tracefunc.is_null() };
             // A compiled back-edge deopts when the process breaker is armed.
             // On resume, run the live frame's ordinary bytecode_trace so its
@@ -10104,14 +10143,14 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                     // bytecode_trace at this opcode.  In particular, an
                     // asynchronously injected exception must be catchable by
                     // the target frame's surrounding try/except.
-                    let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                    let f: *mut PyFrame = root.frame() as *mut PyFrame;
                     let mut next_instr = unsafe { &*f }.next_instr();
                     if pyre_interpreter::eval::handle_exception(
                         unsafe { &mut *f },
                         &mut err,
                         &mut next_instr,
                     ) {
-                        let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                        let f: *mut PyFrame = root.frame() as *mut PyFrame;
                         unsafe { &mut *f }.set_last_instr_from_next_instr(next_instr);
                         continue;
                     }
@@ -10119,7 +10158,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 }
                 // bytecode_trace may allocate (tracer callback) → the frame may
                 // have moved; re-seed before reading it again.
-                let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                let f: *mut PyFrame = root.frame() as *mut PyFrame;
                 // A trace callback may perform a debugger line-jump by
                 // setting `frame.f_lineno` (`fset_f_lineno` → `last_instr
                 // = best_addr`).  The opcode for this iteration was
@@ -10160,7 +10199,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                         // the current opcode so the frame's try/except can catch
                         // it. `frame.last_instr` was set to `pc` above, so
                         // `handle_exception` finds the covering handler.
-                        let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                        let f: *mut PyFrame = root.frame() as *mut PyFrame;
                         let mut next_instr = unsafe { &*f }.next_instr();
                         if pyre_interpreter::eval::handle_exception(
                             unsafe { &mut *f },
@@ -10169,7 +10208,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                         ) {
                             // handle_exception may allocate; re-seed before the
                             // final frame write.
-                            let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                            let f: *mut PyFrame = root.frame() as *mut PyFrame;
                             unsafe { &mut *f }.set_last_instr_from_next_instr(next_instr);
                             continue;
                         }
@@ -10181,7 +10220,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         // The ec block above may have run bytecode_trace / perform_actions
         // (collection points) on a fall-through path; re-seed before the
         // opcode dispatch.
-        let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+        let f: *mut PyFrame = root.frame() as *mut PyFrame;
         let mut next_instr = unsafe { &*f }.next_instr();
         let step_result =
             execute_opcode_step(unsafe { &mut *f }, code, instruction, op_arg, next_instr);
@@ -10207,7 +10246,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 }
                 // execute_opcode_step (above) is a collection point and this arm
                 // re-reads the frame; seed a fresh pointer for the compile path.
-                let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                let f: *mut PyFrame = root.frame() as *mut PyFrame;
                 // ── can_enter_jit (RPython interp_jit.py:114) ──
                 // RPython interp_jit.py:114 → warmstate.py:446
                 let marker_ec = pyre_interpreter::call::getexecutioncontext();
@@ -10222,7 +10261,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 );
                 // can_enter_jit is a lowered no-op / merge point; re-seed
                 // conservatively before the next frame reads.
-                let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                let f: *mut PyFrame = root.frame() as *mut PyFrame;
                 // Compute these after the merge point: the portal split requires every
                 // live-across value to be a declared green or red. Upstream bakes the
                 // driver into the enter function and reaches the space through `self.space`.
@@ -10262,7 +10301,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 // compile path reads the frame. A plain reload of the same
                 // shadow-stack slot, so the knob-off path reads the value it
                 // already held.
-                let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                let f: *mut PyFrame = root.frame() as *mut PyFrame;
                 if let Some(loop_result) = maybe_compile_and_run(
                     unsafe { &mut *f },
                     green_key,
@@ -10273,7 +10312,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 ) {
                     // maybe_compile_and_run compiles and may allocate → re-seed
                     // before handle_exception reads the frame.
-                    let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                    let f: *mut PyFrame = root.frame() as *mut PyFrame;
                     // warmspot.py handle_jitexception: an
                     // `ExitFrameWithExceptionRef` from a direct compiled-code
                     // exit is re-raised into the interpreter loop.  Offer it to
@@ -10294,7 +10333,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                             &mut next_instr,
                         ) {
                             // handle_exception may allocate → re-seed.
-                            let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                            let f: *mut PyFrame = root.frame() as *mut PyFrame;
                             unsafe { &mut *f }.set_last_instr_from_next_instr(next_instr);
                             continue;
                         }
@@ -10308,14 +10347,14 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
             Err(mut err) => {
                 // execute_opcode_step (above) is a collection point and this arm
                 // re-reads the frame; seed a fresh pointer.
-                let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                let f: *mut PyFrame = root.frame() as *mut PyFrame;
                 if pyre_interpreter::eval::handle_exception(
                     unsafe { &mut *f },
                     &mut err,
                     &mut next_instr,
                 ) {
                     // handle_exception may allocate → re-seed before the write.
-                    let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+                    let f: *mut PyFrame = root.frame() as *mut PyFrame;
                     unsafe { &mut *f }.set_last_instr_from_next_instr(next_instr);
                     continue;
                 }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6209,6 +6209,10 @@ impl PyPyJitDriver {
         frame: &mut PyFrame,
         ec: *const PyExecutionContext,
     ) -> bool {
+        // The translated marker signature must retain the red `frame` name,
+        // although the untranslated warm-state path reloads it through the
+        // shadow-stack root below after possible collection points.
+        let _ = frame;
         let env = PyreEnv;
         let (driver, info) = driver_pair();
         let loop_pycode = pycode as *const ();
@@ -6221,7 +6225,7 @@ impl PyPyJitDriver {
                 >= portal_metatrace_skip()
             && !PORTAL_METATRACE_FIRED.swap(true, std::sync::atomic::Ordering::Relaxed)
         {
-            drive_portal_metatrace(frame as *mut PyFrame, green_key_hash, next_instr);
+            drive_portal_metatrace(driver, green_key_hash, next_instr);
         }
         // The Stage-0 drive records IR and executes residuals concretely, so it
         // is a collection point; reload the same shadow-stack root before the
@@ -7160,7 +7164,11 @@ impl majit_metainterp::JitCodeSym for PortalMetatraceSym {
 /// `MAJIT_OPTRACE=1` for `[optrace] depth=… cursor=… pc=… opcode=… jitcode=…`
 /// per step, and `MAJIT_TLDBG=1` for `run_to_end end action=… step_count=…
 /// num_recorded_ops=…` alongside this summary.
-fn drive_portal_metatrace(f: *mut PyFrame, green_key: u64, loop_header_pc: usize) {
+fn drive_portal_metatrace(
+    driver: &mut JitDriver<PyreJitState>,
+    green_key: u64,
+    loop_header_pc: usize,
+) {
     pyre_jit_trace::jitcode_runtime::install_global_build_descr_pool();
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -7222,10 +7230,20 @@ fn drive_portal_metatrace(f: *mut PyFrame, green_key: u64, loop_header_pc: usize
             slot_regs[5],
         );
 
+        let meta = driver.meta_interp_mut();
+        if meta.is_tracing() {
+            eprintln!("[jd0-mt] bail: already tracing");
+            return;
+        }
+
+        // Everything above can allocate.  Reload the caller-owned shadow-stack
+        // root only after those calls, immediately before the concrete portal
+        // inputs are captured; never trust a raw frame pointer supplied by the
+        // caller across a collection point.
+        let live_frame = FrameView::top_frame();
         let next_instr = loop_header_pc as i64;
-        let is_being_profiled = i64::from(unsafe { &*f }.get_is_being_profiled());
-        let pycode = unsafe { &*f }.pycode as pyre_object::PyObjectRef;
-        let live_frame = f;
+        let is_being_profiled = i64::from(unsafe { &*live_frame }.get_is_being_profiled());
+        let pycode = unsafe { &*live_frame }.pycode as pyre_object::PyObjectRef;
         let ec = pyre_interpreter::call::getexecutioncontext();
         eprintln!(
             "[jd0-mt] greens next_instr={} is_being_profiled={} pycode=0x{:x}",
@@ -7236,20 +7254,13 @@ fn drive_portal_metatrace(f: *mut PyFrame, green_key: u64, loop_header_pc: usize
             live_frame as usize, ec as usize,
         );
 
-        let (driver, _) = driver_pair();
-        let meta = driver.meta_interp_mut();
-        if meta.is_tracing() {
-            eprintln!("[jd0-mt] bail: already tracing");
-            return;
-        }
-
         let live_values = [
             majit_ir::Value::Ref(majit_ir::GcRef(live_frame as usize)),
             majit_ir::Value::Ref(majit_ir::GcRef(ec as usize)),
         ];
         let action = meta.force_start_tracing(
             green_key,
-            (unsafe { &*f }.pycode as usize, loop_header_pc),
+            (pycode as usize, loop_header_pc),
             None,
             &live_values,
         );
@@ -7475,7 +7486,6 @@ fn drive_portal_metatrace(f: *mut PyFrame, green_key: u64, loop_header_pc: usize
     }));
 
     if let Err(payload) = result {
-        let (driver, _) = driver_pair();
         let meta = driver.meta_interp_mut();
         if meta.is_tracing() {
             meta.abort_trace(false);
@@ -10126,9 +10136,11 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         // value reaches both the marker and the dispatch, so the
         // `ref_guard_value` the marker emits promotes the operand the dispatch
         // actually consumes.
-        let code = unsafe {
-            &*pyre_interpreter::w_code_get_ptr(marker_pycode).cast::<pyre_interpreter::CodeObject>()
-        };
+        let code_ptr = unsafe { pyre_interpreter::w_code_get_ptr(marker_pycode) };
+        if code_ptr.is_null() {
+            return LoopResult::Done(Err(pyre_interpreter::pycode::BytecodeCorruption.into()));
+        }
+        let code = unsafe { &*code_ptr.cast::<pyre_interpreter::CodeObject>() };
 
         // Bounds net for a frame resumed past its last instruction. Upstream
         // has no counterpart — its loop leaves through `Return` / `Yield` —
@@ -10327,6 +10339,12 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 // ── can_enter_jit (RPython interp_jit.py:114) ──
                 // RPython interp_jit.py:114 → warmstate.py:446
                 let marker_ec = pyre_interpreter::call::getexecutioncontext();
+                if marker_ec.is_null() {
+                    // No execution context means there is nowhere to publish a
+                    // compiled-loop exit.  Keep interpreting instead of
+                    // entering `set_pending_loop_exit` with a null pointer.
+                    continue;
+                }
                 let marker_pycode = unsafe { &*f }.pycode as pyre_object::PyObjectRef;
                 let marker_profiled = unsafe { &*f }.get_is_being_profiled();
                 if pypyjitdriver.can_enter_jit(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6512,7 +6512,11 @@ pub fn should_unroll_one_iteration(
         ptr if ptr.is_null() => false,
         code_ptr => {
             let code = unsafe { &*code_ptr.cast::<pyre_interpreter::CodeObject>() };
-            code.flags.contains(pyre_interpreter::CodeFlags::GENERATOR)
+            // ITERABLE_COROUTINE and ASYNC_GENERATOR are deliberately not
+            // tested: the hook selects only the two bits upstream selects.
+            code.flags.intersects(
+                pyre_interpreter::CodeFlags::COROUTINE | pyre_interpreter::CodeFlags::GENERATOR,
+            )
         }
     }
 }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6214,11 +6214,7 @@ impl PyPyJitDriver {
         let loop_pycode = pycode as *const ();
         let green_key_hash = make_green_key(loop_pycode, next_instr, is_being_profiled);
         let green_key = driver.resolve_cell_key(green_key_hash, || {
-            pyre_jit_trace::driver::make_green_key_typed(
-                loop_pycode,
-                next_instr,
-                is_being_profiled,
-            )
+            pyre_jit_trace::driver::make_green_key_typed(loop_pycode, next_instr, is_being_profiled)
         });
         if portal_metatrace_enabled()
             && PORTAL_METATRACE_SEEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed)

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7024,6 +7024,361 @@ fn jd1_experiment_enabled() -> bool {
     })
 }
 
+fn portal_metatrace_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED
+        .get_or_init(|| std::env::var("PYRE_PORTAL_METATRACE").as_deref() == Ok("1"))
+}
+
+/// Where the Stage-0 probe enters the portal jitcode.
+///
+/// `merge` (default) starts the walk AT the `jit_merge_point`, seeding only
+/// the registers that op declares. `start` is the faithful shape:
+/// `initialize_state_from_start` is `f = self.newframe(mainjitcode);
+/// f.setup_call(original_boxes)` — entry at pc 0 with the portal's own
+/// arguments, so the prologue runs and the walk reaches the merge point on its
+/// own. `eval_loop_jit`'s `calldescr.arg_classes` is `"r"`: the portal was
+/// never split, so its one argument is the Rust `frame`, not greens+reds.
+fn portal_metatrace_entry_at_start() -> bool {
+    static AT_START: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *AT_START
+        .get_or_init(|| std::env::var("PYRE_PORTAL_METATRACE_ENTRY").as_deref() == Ok("start"))
+}
+
+static PORTAL_METATRACE_FIRED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Back-edges to let pass before the one-shot probe fires. The first
+/// back-edge in the process belongs to interpreter bootstrap (a class body
+/// under `build_class_inner`), not to the user's loop; `PYRE_PORTAL_METATRACE_SKIP`
+/// walks the probe forward to the back-edge worth measuring. Default 0 keeps
+/// the first back-edge.
+fn portal_metatrace_skip() -> u64 {
+    static SKIP: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+    *SKIP.get_or_init(|| {
+        std::env::var("PYRE_PORTAL_METATRACE_SKIP")
+            .ok()
+            .and_then(|s| s.trim().parse().ok())
+            .unwrap_or(0)
+    })
+}
+
+static PORTAL_METATRACE_SEEN: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+struct PortalMetatraceSym {
+    header_pc: usize,
+}
+
+impl majit_metainterp::JitCodeSym for PortalMetatraceSym {
+    fn total_slots(&self) -> usize {
+        0
+    }
+
+    fn loop_header_pc(&self) -> usize {
+        self.header_pc
+    }
+
+    fn fail_args(&self) -> Option<Vec<majit_ir::OpRef>> {
+        None
+    }
+}
+
+/// Stage-0 diagnostic drive of the build-time jd0 portal jitcode. Set
+/// `MAJIT_OPTRACE=1` for `[optrace] depth=… cursor=… pc=… opcode=… jitcode=…`
+/// per step, and `MAJIT_TLDBG=1` for `run_to_end end action=… step_count=…
+/// num_recorded_ops=…` alongside this summary.
+fn drive_portal_metatrace(f: *mut PyFrame, green_key: u64, loop_header_pc: usize) {
+    pyre_jit_trace::jitcode_runtime::install_global_build_descr_pool();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let canonical = match pyre_jit_trace::jitcode_runtime::portal_jitcode() {
+            Some(jitcode) => jitcode,
+            None => {
+                eprintln!("[jd0-mt] portal jitcode unresolved");
+                return;
+            }
+        };
+        let portal_index = canonical
+            .try_index()
+            .map(|index| index.to_string())
+            .unwrap_or_else(|| "none".to_owned());
+        eprintln!(
+            "[jd0-mt] portal jitcode name={} index={} code_len={}",
+            canonical.name,
+            portal_index,
+            canonical.code.len(),
+        );
+        let jitcode = majit_metainterp::JitCode::from_canonical((*canonical).clone());
+
+        let header_pc = match pyre_jit_trace::jitcode_runtime::decoded_ops(&canonical.code)
+            .find(|op| op.opname == "jit_merge_point")
+            .map(|op| op.pc)
+        {
+            Some(pc) => pc,
+            None => {
+                eprintln!("[jd0-mt] jit_merge_point not found");
+                return;
+            }
+        };
+
+        // Decode the six register lists of the `jit_merge_point` op:
+        // opcode(1) + jdindex(1), then `[len:u8][reg:u8 * len]` in green
+        // I/R/F, red I/R/F order, matching `trace_jitcode_from_merge_point`.
+        let mut slot_regs: [Vec<usize>; 6] = std::array::from_fn(|_| Vec::new());
+        {
+            let code = &canonical.code;
+            let mut cur = header_pc + 2;
+            for regs in slot_regs.iter_mut() {
+                let len = code[cur] as usize;
+                cur += 1;
+                for _ in 0..len {
+                    regs.push(code[cur] as usize);
+                    cur += 1;
+                }
+            }
+        }
+        eprintln!(
+            "[jd0-mt] header_pc={} merge-point regs greenI={:?} greenR={:?} greenF={:?} redI={:?} redR={:?} redF={:?}",
+            header_pc,
+            slot_regs[0],
+            slot_regs[1],
+            slot_regs[2],
+            slot_regs[3],
+            slot_regs[4],
+            slot_regs[5],
+        );
+
+        let next_instr = loop_header_pc as i64;
+        let is_being_profiled = i64::from(unsafe { &*f }.get_is_being_profiled());
+        let pycode = unsafe { &*f }.pycode as pyre_object::PyObjectRef;
+        let live_frame = f;
+        let ec = unsafe { &*f }.execution_context;
+        eprintln!(
+            "[jd0-mt] greens next_instr={} is_being_profiled={} pycode=0x{:x}",
+            next_instr, is_being_profiled, pycode as usize,
+        );
+        eprintln!(
+            "[jd0-mt] reds frame=0x{:x} ec=0x{:x}",
+            live_frame as usize, ec as usize,
+        );
+
+        let (driver, _) = driver_pair();
+        let meta = driver.meta_interp_mut();
+        if meta.is_tracing() {
+            eprintln!("[jd0-mt] bail: already tracing");
+            return;
+        }
+
+        let live_values = [
+            majit_ir::Value::Ref(majit_ir::GcRef(live_frame as usize)),
+            majit_ir::Value::Ref(majit_ir::GcRef(ec as usize)),
+        ];
+        let action = meta.force_start_tracing(
+            green_key,
+            (unsafe { &*f }.pycode as usize, loop_header_pc),
+            None,
+            &live_values,
+        );
+        let action_name = match &action {
+            majit_metainterp::BackEdgeAction::Interpret => "Interpret",
+            majit_metainterp::BackEdgeAction::StartedTracing => "StartedTracing",
+            majit_metainterp::BackEdgeAction::AlreadyTracing => "AlreadyTracing",
+            majit_metainterp::BackEdgeAction::RunCompiled => "RunCompiled",
+        };
+        eprintln!("[jd0-mt] force_start_tracing -> {action_name}");
+        if !matches!(action, majit_metainterp::BackEdgeAction::StartedTracing) {
+            return;
+        }
+
+        let mut sym = PortalMetatraceSym { header_pc };
+        let walked = meta.with_trace_ctx_and_token_resolver(
+            |ctx,
+             resolve_token,
+             recursive_target,
+             recursive_decision,
+             recursive_exec,
+             recursive_exec_ref,
+             recursive_exec_float,
+             recursive_exec_void| {
+                let runtime = majit_metainterp::ClosureRuntimeWithResolver::new(
+                    |_pc: usize| 0usize,
+                    resolve_token,
+                    recursive_target,
+                    recursive_decision,
+                    recursive_exec,
+                    recursive_exec_ref,
+                    recursive_exec_float,
+                    recursive_exec_void,
+                );
+
+                let jitcode_arc = std::sync::Arc::new(jitcode.clone());
+                let mut frame =
+                    majit_metainterp::MIFrame::setup(jitcode_arc, header_pc, None, Some(ctx));
+
+                let green_int_values = [next_instr, is_being_profiled];
+                for (&reg, &value) in slot_regs[0].iter().zip(green_int_values.iter()) {
+                    if reg < frame.int_regs.len() && reg < frame.int_values.len() {
+                        let opref = ctx.const_int(value);
+                        frame.int_regs[reg] = Some(opref);
+                        frame.int_values[reg] = Some(value);
+                    } else {
+                        eprintln!(
+                            "[jd0-mt] skipped seed greenI reg={} regs_len={} values_len={}",
+                            reg,
+                            frame.int_regs.len(),
+                            frame.int_values.len(),
+                        );
+                    }
+                }
+                let green_ref_values = [pycode as usize as i64];
+                for (&reg, &value) in slot_regs[1].iter().zip(green_ref_values.iter()) {
+                    if reg < frame.ref_regs.len() && reg < frame.ref_values.len() {
+                        let opref = ctx.const_ref(value);
+                        frame.ref_regs[reg] = Some(opref);
+                        frame.ref_values[reg] = Some(value);
+                    } else {
+                        eprintln!(
+                            "[jd0-mt] skipped seed greenR reg={} regs_len={} values_len={}",
+                            reg,
+                            frame.ref_regs.len(),
+                            frame.ref_values.len(),
+                        );
+                    }
+                }
+                let red_ref_values = [live_frame as usize as i64, ec as usize as i64];
+                for (input_index, (&reg, &value)) in slot_regs[4]
+                    .iter()
+                    .zip(red_ref_values.iter())
+                    .enumerate()
+                {
+                    if reg < frame.ref_regs.len() && reg < frame.ref_values.len() {
+                        let input_index = input_index as u32;
+                        let opref = majit_ir::OpRef::input_arg_typed(
+                            input_index,
+                            majit_ir::Type::Ref,
+                        );
+                        frame.ref_regs[reg] = Some(opref);
+                        frame.ref_values[reg] = Some(value);
+                    } else {
+                        eprintln!(
+                            "[jd0-mt] skipped seed redR reg={} regs_len={} values_len={}",
+                            reg,
+                            frame.ref_regs.len(),
+                            frame.ref_values.len(),
+                        );
+                    }
+                }
+                frame.code_cursor = header_pc;
+                frame.pc = header_pc;
+
+                // `pyjitpl.py initialize_state_from_start`:
+                //   f = self.newframe(self.jitdriver_sd.mainjitcode)
+                //   f.setup_call(original_boxes)
+                // `setup_call` packs argboxes into the typed banks in
+                // declaration order, so a `calldescr.arg_classes == "r"`
+                // jitcode takes exactly one ref, at r0. Here that is the live
+                // `PyFrame`: pc=3 calls `FrameRoot::new` on r0 to produce r1,
+                // and r1 is what the loop body's first op reads — the register
+                // merge-point entry cannot supply.
+                //
+                // The merge-point seeds above are left standing: every
+                // register they write is re-written by the prologue before the
+                // marker, and `setup_call` overwrites r0 at entry.
+                let entry_pc = if portal_metatrace_entry_at_start() {
+                    frame.setup_call(&[(
+                        majit_metainterp::JitArgKind::Ref,
+                        majit_ir::OpRef::input_arg_typed(0, majit_ir::Type::Ref),
+                        live_frame as usize as i64,
+                    )]);
+                    // `setup_call` sets `pc = 0`; the walker reads
+                    // `code_cursor`, which it does not touch.
+                    frame.code_cursor = 0;
+                    eprintln!(
+                        "[jd0-mt] entry=start pc=0 setup_call arg_classes=\"r\" r0=0x{:x}",
+                        live_frame as usize,
+                    );
+                    0
+                } else {
+                    header_pc
+                };
+
+                let mut standalone = majit_metainterp::StandaloneFrameStack::new();
+                standalone.frames.push(frame);
+                let before = ctx.num_recorded_ops();
+                let mut machine = majit_metainterp::JitCodeMachine::<PortalMetatraceSym, _>::with_framestack(
+                    &mut standalone.frames,
+                    &[],
+                    &[],
+                );
+                machine.set_outer_program_pc(entry_pc);
+                let action = machine.run_to_end(ctx, &mut sym, &runtime);
+                drop(machine);
+                let after = ctx.num_recorded_ops();
+                let depth = standalone.frames.len();
+                let (stop_jitcode, stop_cursor, stop_pc) = if standalone.frames.is_empty() {
+                    ("<empty>".to_owned(), 0, 0)
+                } else {
+                    let stopped = standalone.frames.current_mut();
+                    (
+                        stopped.jitcode.name().to_owned(),
+                        stopped.code_cursor,
+                        stopped.pc,
+                    )
+                };
+                (
+                    action,
+                    before,
+                    after,
+                    depth,
+                    stop_jitcode,
+                    stop_cursor,
+                    stop_pc,
+                )
+            },
+        );
+
+        if meta.is_tracing() {
+            meta.abort_trace(false);
+        }
+
+        match walked {
+            Some((action, before, after, depth, stop_jitcode, stop_cursor, stop_pc)) => {
+                eprintln!(
+                    "[jd0-mt] walk action={:?} recorded_ops={} depth={} stop_jitcode={} stop_cursor={} stop_pc={}",
+                    action,
+                    after.saturating_sub(before),
+                    depth,
+                    stop_jitcode,
+                    stop_cursor,
+                    stop_pc,
+                );
+            }
+            None => {
+                eprintln!(
+                    "[jd0-mt] walk action=unavailable recorded_ops=0 depth=0 stop_jitcode=<none> stop_cursor=0 stop_pc=0"
+                );
+            }
+        }
+    }));
+
+    if let Err(payload) = result {
+        let (driver, _) = driver_pair();
+        let meta = driver.meta_interp_mut();
+        if meta.is_tracing() {
+            meta.abort_trace(false);
+        }
+        let message = if let Some(message) = payload.downcast_ref::<&str>() {
+            (*message).to_owned()
+        } else if let Some(message) = payload.downcast_ref::<String>() {
+            message.clone()
+        } else {
+            "<non-string panic payload>".to_owned()
+        };
+        eprintln!("[jd0-mt] walk panicked: {message}");
+    }
+}
+
 /// Whether jd1 enters the compiled drain loop live on `RunCompiled` (the JIT
 /// speedup) versus only compiling and registering it (the cooperative-drain
 /// fallback, where the interpreter caller keeps draining). ON by default;
@@ -9543,7 +9898,13 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         // breaker load; the compiled back-edge mask deliberately excludes it.
         majit_ir::eval_breaker_word::set_gc_interp();
     }
-    let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame_root.frame()) };
+    // The code object is NOT read here. `interp_jit.py` `PyFrame.dispatch`
+    // takes `pycode` as a parameter and reads `co_code = pycode.co_code`
+    // inside the loop, *after* `jit_merge_point` — so the value the dispatch
+    // consumes is the very value the marker declares green. A read hoisted
+    // above the loop is a second, independent read: the marker's green is then
+    // promoted by `ref_guard_value` and never used, while the dispatch runs on
+    // an unpromoted copy that no guard makes constant. See the loop body.
     // `semantic_loop_headers` is consumed only on the `CloseLoop` arm below (a
     // back-edge event).  Loopless frames — the overwhelming majority during
     // cold startup, where every called helper / class body / module top level
@@ -9631,10 +9992,6 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
             return LoopResult::Done(Err(err));
         }
 
-        if unsafe { &*f }.next_instr() >= code.instructions.len() {
-            return LoopResult::Done(Ok(w_none()));
-        }
-
         let pc = unsafe { &*f }.next_instr();
 
         // interp_jit.py:85-87 — source-level marker declaration.  Its
@@ -9654,6 +10011,25 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         // jit_merge_point is a lowered no-op / merge point and does not itself
         // collect, but is treated as a collection boundary conservatively.
         let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
+
+        // `interp_jit.py` `PyFrame.dispatch`: `co_code = pycode.co_code`,
+        // read from the green the marker just declared and nowhere else. One
+        // value reaches both the marker and the dispatch, so the
+        // `ref_guard_value` the marker emits promotes the operand the dispatch
+        // actually consumes.
+        let code = unsafe {
+            &*pyre_interpreter::w_code_get_ptr(marker_pycode)
+                .cast::<pyre_interpreter::CodeObject>()
+        };
+
+        // Bounds net for a frame resumed past its last instruction. Upstream
+        // has no counterpart — its loop leaves through `Return` / `Yield` —
+        // and it sits *after* the marker here because any pre-marker read of
+        // the code object is precisely the second, unpromoted read this
+        // ordering exists to remove.
+        if pc >= code.instructions.len() {
+            return LoopResult::Done(Ok(w_none()));
+        }
 
         let (opcode_pc, instruction, op_arg) = match decode_instruction_forward(code, pc) {
             Ok(decoded) => decoded,
@@ -9870,6 +10246,20 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                         loop_profiled,
                     )
                 });
+                if portal_metatrace_enabled()
+                    && PORTAL_METATRACE_SEEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                        >= portal_metatrace_skip()
+                    && !PORTAL_METATRACE_FIRED
+                        .swap(true, std::sync::atomic::Ordering::Relaxed)
+                {
+                    drive_portal_metatrace(f, green_key_hash, loop_header_pc);
+                }
+                // The Stage-0 drive records IR and executes residuals
+                // concretely, so it is a collection point; re-seed before the
+                // compile path reads the frame. A plain reload of the same
+                // shadow-stack slot, so the knob-off path reads the value it
+                // already held.
+                let f: *mut PyFrame = frame_root.frame() as *mut PyFrame;
                 if let Some(loop_result) = maybe_compile_and_run(
                     unsafe { &mut *f },
                     green_key,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -267,32 +267,13 @@ impl Drop for FrameRoot {
     }
 }
 
-/// A non-owning view of the caller's [`FrameRoot`] for the portal loop.
-/// `handle_jitexception` owns the root that brackets the whole re-loop; the
-/// portal only re-reads it. The view is re-derived after `jit_merge_point`
-/// so no value defined before the marker is live after it, which is what
-/// upstream `split_block`'s `_forcelink` enforces at the JIT split: the
-/// gctransform shadow-stack pass runs after that split, and the split-off
-/// portal function re-captures its shadow-stack base in its own prologue.
-struct FrameView {
-    depth: usize,
-    slot: majit_gc::shadow_stack::ShadowStackSlot,
-}
+/// Access to the caller's top shadow-stack frame root for the portal loop.
+struct FrameView;
 
 impl FrameView {
     #[inline]
-    fn top() -> Self {
-        let (slot, depth) = majit_gc::shadow_stack::top();
-        Self { depth, slot }
-    }
-
-    #[inline]
-    fn frame(&self) -> &mut PyFrame {
-        // SAFETY: `slot` was resolved on this thread in `top` and the thread
-        // is still running; no `&mut` borrow of the cell is held here.
-        let frame =
-            unsafe { majit_gc::shadow_stack::slot_get(self.slot, self.depth) }.0 as *mut PyFrame;
-        unsafe { &mut *frame }
+    fn top_frame() -> *mut PyFrame {
+        majit_gc::shadow_stack::top_ref().0 as *mut PyFrame
     }
 }
 
@@ -9904,9 +9885,12 @@ fn cached_function_entry_trace_is_jit_safe(code: &pyre_interpreter::CodeObject) 
 /// JIT hooks are thin inline checks; all heavy logic is in #[cold] helpers.
 fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
     // The caller's root is the top of the shadow stack and names this frame;
-    // every reload below goes through that root (`FrameView::top`).
+    // every reload below goes through that root (`FrameView::top_frame`).
     debug_assert!(
-        std::ptr::eq(FrameView::top().frame(), &*frame),
+        std::ptr::eq(
+            FrameView::top_frame() as *const PyFrame,
+            frame as *const PyFrame,
+        ),
         "eval_loop_jit entered without its frame as the top shadow-stack root"
     );
     // Bump the monotonic frame eval-loop entry odometer (mirrors the plain
@@ -9984,9 +9968,8 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         // it instead of re-resolving the shadow-stack slot each time. Re-seeded
         // after every collection-point call in this loop (bytecode_trace,
         // perform_actions, execute_opcode_step, handle_exception, can_enter_jit /
-        // maybe_compile_and_run, jit_merge_point).
-        let root = FrameView::top();
-        let f: *mut PyFrame = root.frame() as *mut PyFrame;
+        // maybe_compile_and_run).
+        let f: *mut PyFrame = FrameView::top_frame();
 
         // The plain evaluator's twin: a bounded major collection that reached
         // `max_heap_size` owes a `MemoryError`, and the safepoint above — which
@@ -10018,7 +10001,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 &mut next_instr,
             ) {
                 // handle_exception allocates → re-seed before the write.
-                let f: *mut PyFrame = root.frame() as *mut PyFrame;
+                let f: *mut PyFrame = FrameView::top_frame();
                 unsafe { &mut *f }.set_last_instr_from_next_instr(next_instr);
                 continue;
             }
@@ -10041,13 +10024,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
             unsafe { &mut *f },
             marker_ec,
         );
-        // jit_merge_point is a lowered no-op / merge point and does not itself
-        // collect, but is treated as a collection boundary conservatively.
-        // The view is re-derived here so nothing defined before the marker is
-        // used after it (`split_block`'s `_forcelink`); upstream's portal
-        // function re-captures its shadow-stack base in its own prologue.
-        let root = FrameView::top();
-        let f: *mut PyFrame = root.frame() as *mut PyFrame;
+        // `f` is the marker's red `frame` and stays valid across it; the marker does not collect.
 
         // `interp_jit.py` `PyFrame.dispatch`: `co_code = pycode.co_code`,
         // read from the green the marker just declared and nowhere else. One
@@ -10123,7 +10100,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
             if unsafe { &mut *f }.take_failed_attr_before_opcode() {
                 unsafe { (*ec_ptr).run_failed_attr_finalizers() };
             }
-            let f: *mut PyFrame = root.frame() as *mut PyFrame;
+            let f: *mut PyFrame = FrameView::top_frame();
             let needs_trace = unsafe { !(*ec_ptr).w_tracefunc.is_null() };
             // A compiled back-edge deopts when the process breaker is armed.
             // On resume, run the live frame's ordinary bytecode_trace so its
@@ -10143,14 +10120,14 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                     // bytecode_trace at this opcode.  In particular, an
                     // asynchronously injected exception must be catchable by
                     // the target frame's surrounding try/except.
-                    let f: *mut PyFrame = root.frame() as *mut PyFrame;
+                    let f: *mut PyFrame = FrameView::top_frame();
                     let mut next_instr = unsafe { &*f }.next_instr();
                     if pyre_interpreter::eval::handle_exception(
                         unsafe { &mut *f },
                         &mut err,
                         &mut next_instr,
                     ) {
-                        let f: *mut PyFrame = root.frame() as *mut PyFrame;
+                        let f: *mut PyFrame = FrameView::top_frame();
                         unsafe { &mut *f }.set_last_instr_from_next_instr(next_instr);
                         continue;
                     }
@@ -10158,7 +10135,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 }
                 // bytecode_trace may allocate (tracer callback) → the frame may
                 // have moved; re-seed before reading it again.
-                let f: *mut PyFrame = root.frame() as *mut PyFrame;
+                let f: *mut PyFrame = FrameView::top_frame();
                 // A trace callback may perform a debugger line-jump by
                 // setting `frame.f_lineno` (`fset_f_lineno` → `last_instr
                 // = best_addr`).  The opcode for this iteration was
@@ -10199,7 +10176,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                         // the current opcode so the frame's try/except can catch
                         // it. `frame.last_instr` was set to `pc` above, so
                         // `handle_exception` finds the covering handler.
-                        let f: *mut PyFrame = root.frame() as *mut PyFrame;
+                        let f: *mut PyFrame = FrameView::top_frame();
                         let mut next_instr = unsafe { &*f }.next_instr();
                         if pyre_interpreter::eval::handle_exception(
                             unsafe { &mut *f },
@@ -10208,7 +10185,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                         ) {
                             // handle_exception may allocate; re-seed before the
                             // final frame write.
-                            let f: *mut PyFrame = root.frame() as *mut PyFrame;
+                            let f: *mut PyFrame = FrameView::top_frame();
                             unsafe { &mut *f }.set_last_instr_from_next_instr(next_instr);
                             continue;
                         }
@@ -10220,7 +10197,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         // The ec block above may have run bytecode_trace / perform_actions
         // (collection points) on a fall-through path; re-seed before the
         // opcode dispatch.
-        let f: *mut PyFrame = root.frame() as *mut PyFrame;
+        let f: *mut PyFrame = FrameView::top_frame();
         let mut next_instr = unsafe { &*f }.next_instr();
         let step_result =
             execute_opcode_step(unsafe { &mut *f }, code, instruction, op_arg, next_instr);
@@ -10246,7 +10223,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 }
                 // execute_opcode_step (above) is a collection point and this arm
                 // re-reads the frame; seed a fresh pointer for the compile path.
-                let f: *mut PyFrame = root.frame() as *mut PyFrame;
+                let f: *mut PyFrame = FrameView::top_frame();
                 // ── can_enter_jit (RPython interp_jit.py:114) ──
                 // RPython interp_jit.py:114 → warmstate.py:446
                 let marker_ec = pyre_interpreter::call::getexecutioncontext();
@@ -10261,7 +10238,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 );
                 // can_enter_jit is a lowered no-op / merge point; re-seed
                 // conservatively before the next frame reads.
-                let f: *mut PyFrame = root.frame() as *mut PyFrame;
+                let f: *mut PyFrame = FrameView::top_frame();
                 // Compute these after the merge point: the portal split requires every
                 // live-across value to be a declared green or red. Upstream bakes the
                 // driver into the enter function and reaches the space through `self.space`.
@@ -10301,7 +10278,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 // compile path reads the frame. A plain reload of the same
                 // shadow-stack slot, so the knob-off path reads the value it
                 // already held.
-                let f: *mut PyFrame = root.frame() as *mut PyFrame;
+                let f: *mut PyFrame = FrameView::top_frame();
                 if let Some(loop_result) = maybe_compile_and_run(
                     unsafe { &mut *f },
                     green_key,
@@ -10312,7 +10289,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 ) {
                     // maybe_compile_and_run compiles and may allocate → re-seed
                     // before handle_exception reads the frame.
-                    let f: *mut PyFrame = root.frame() as *mut PyFrame;
+                    let f: *mut PyFrame = FrameView::top_frame();
                     // warmspot.py handle_jitexception: an
                     // `ExitFrameWithExceptionRef` from a direct compiled-code
                     // exit is re-raised into the interpreter loop.  Offer it to
@@ -10333,7 +10310,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                             &mut next_instr,
                         ) {
                             // handle_exception may allocate → re-seed.
-                            let f: *mut PyFrame = root.frame() as *mut PyFrame;
+                            let f: *mut PyFrame = FrameView::top_frame();
                             unsafe { &mut *f }.set_last_instr_from_next_instr(next_instr);
                             continue;
                         }
@@ -10347,14 +10324,14 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
             Err(mut err) => {
                 // execute_opcode_step (above) is a collection point and this arm
                 // re-reads the frame; seed a fresh pointer.
-                let f: *mut PyFrame = root.frame() as *mut PyFrame;
+                let f: *mut PyFrame = FrameView::top_frame();
                 if pyre_interpreter::eval::handle_exception(
                     unsafe { &mut *f },
                     &mut err,
                     &mut next_instr,
                 ) {
                     // handle_exception may allocate → re-seed before the write.
-                    let f: *mut PyFrame = root.frame() as *mut PyFrame;
+                    let f: *mut PyFrame = FrameView::top_frame();
                     unsafe { &mut *f }.set_last_instr_from_next_instr(next_instr);
                     continue;
                 }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -14,7 +14,8 @@ use pyre_interpreter::PyExecutionContext;
 use pyre_interpreter::executioncontext::ActionFlagOps;
 use pyre_interpreter::pyframe::PyFrame;
 use pyre_interpreter::{
-    PyError, PyResult, StepResult, decode_instruction_forward, execute_opcode_step,
+    PyError, PyResult, StepResult, decode_instruction_forward_packed,
+    decode_instruction_forward_pc, execute_opcode_step,
 };
 use pyre_interpreter::{locals_w, locals_w_mut};
 use std::cell::{Cell, RefCell, UnsafeCell};
@@ -7036,8 +7037,7 @@ fn jd1_experiment_enabled() -> bool {
 
 fn portal_metatrace_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED
-        .get_or_init(|| std::env::var("PYRE_PORTAL_METATRACE").as_deref() == Ok("1"))
+    *ENABLED.get_or_init(|| std::env::var("PYRE_PORTAL_METATRACE").as_deref() == Ok("1"))
 }
 
 /// Where the Stage-0 probe enters the portal jitcode.
@@ -7051,8 +7051,7 @@ fn portal_metatrace_enabled() -> bool {
 /// keeps `eval_loop_jit`'s single `frame` argument.
 fn portal_metatrace_entry_at_start() -> bool {
     static AT_START: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *AT_START
-        .get_or_init(|| std::env::var("PYRE_PORTAL_METATRACE_ENTRY").as_deref() == Ok("start"))
+    *AT_START.get_or_init(|| std::env::var("PYRE_PORTAL_METATRACE_ENTRY").as_deref() == Ok("start"))
 }
 
 static PORTAL_METATRACE_FIRED: std::sync::atomic::AtomicBool =
@@ -7073,8 +7072,7 @@ fn portal_metatrace_skip() -> u64 {
     })
 }
 
-static PORTAL_METATRACE_SEEN: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(0);
+static PORTAL_METATRACE_SEEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 struct PortalMetatraceSym {
     header_pc: usize,
@@ -7355,11 +7353,12 @@ fn drive_portal_metatrace(f: *mut PyFrame, green_key: u64, loop_header_pc: usize
                 let mut standalone = majit_metainterp::StandaloneFrameStack::new();
                 standalone.frames.push(frame);
                 let before = ctx.num_recorded_ops();
-                let mut machine = majit_metainterp::JitCodeMachine::<PortalMetatraceSym, _>::with_framestack(
-                    &mut standalone.frames,
-                    &[],
-                    &[],
-                );
+                let mut machine =
+                    majit_metainterp::JitCodeMachine::<PortalMetatraceSym, _>::with_framestack(
+                        &mut standalone.frames,
+                        &[],
+                        &[],
+                    );
                 machine.set_outer_program_pc(entry_pc);
                 let action = machine.run_to_end(ctx, &mut sym, &runtime);
                 drop(machine);
@@ -9867,13 +9866,6 @@ pub fn portal_runner(frame: &mut PyFrame) -> pyre_object::PyObjectRef {
     }
 }
 
-/// pyre-local debug instrumentation (no PyPy counterpart).
-/// `@not_in_trace` so that compiled code does not include this call.
-#[majit_macros::not_in_trace]
-fn trace_jit_bytecode(_pc: usize, _instruction_name: &str) {
-    // Debug logging disabled — per-bytecode eprintln causes O(n) slowdown.
-}
-
 /// Loop-header PC set for `code`, from the `CallControl` that owns the
 /// per-graph codewriter caches (call.py `self.jitcodes = {}`).
 ///
@@ -10071,8 +10063,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         // `ref_guard_value` the marker emits promotes the operand the dispatch
         // actually consumes.
         let code = unsafe {
-            &*pyre_interpreter::w_code_get_ptr(marker_pycode)
-                .cast::<pyre_interpreter::CodeObject>()
+            &*pyre_interpreter::w_code_get_ptr(marker_pycode).cast::<pyre_interpreter::CodeObject>()
         };
 
         // Bounds net for a frame resumed past its last instruction. Upstream
@@ -10080,17 +10071,23 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
         // and it sits *after* the marker here because any pre-marker read of
         // the code object is precisely the second, unpromoted read this
         // ordering exists to remove.
-        if pc >= code.instructions.len() {
+        if pc >= pyre_interpreter::code_instructions_len(code) {
             return LoopResult::Done(Ok(w_none()));
         }
 
-        let (opcode_pc, instruction, op_arg) = match decode_instruction_forward(code, pc) {
-            Ok(decoded) => decoded,
-            Err(err) => return LoopResult::Done(Err(err.into())),
-        };
+        let opcode_pc = decode_instruction_forward_pc(code, pc);
+        let packed_instruction = decode_instruction_forward_packed(code, pc);
+        if opcode_pc == usize::MAX || packed_instruction == u64::MAX {
+            return LoopResult::Done(Err(pyre_interpreter::pycode::BytecodeCorruption.into()));
+        }
+        let opcode = (packed_instruction & 0xff) as u8;
+        // SAFETY: the packed opcode came from a live `CodeUnit`, whose opcode
+        // field is a valid repr(u8) `Instruction` discriminant.
+        let instruction =
+            unsafe { std::mem::transmute::<u8, pyre_interpreter::Instruction>(opcode) };
+        let op_arg = pyre_interpreter::OpArg::new((packed_instruction >> 8) as u32);
 
         // ── handle_bytecode (RPython interp_jit.py:90) ──
-        trace_jit_bytecode(pc, "");
         unsafe { &mut *f }.last_instr = pc as isize;
         unsafe { &mut *f }.set_last_instr_from_next_instr(opcode_pc + 1);
         // pyopcode.py dispatch_bytecode parity: fire
@@ -10307,8 +10304,7 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 if portal_metatrace_enabled()
                     && PORTAL_METATRACE_SEEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                         >= portal_metatrace_skip()
-                    && !PORTAL_METATRACE_FIRED
-                        .swap(true, std::sync::atomic::Ordering::Relaxed)
+                    && !PORTAL_METATRACE_FIRED.swap(true, std::sync::atomic::Ordering::Relaxed)
                 {
                     drive_portal_metatrace(f, green_key_hash, loop_header_pc);
                 }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7047,8 +7047,8 @@ fn portal_metatrace_enabled() -> bool {
 /// `initialize_state_from_start` is `f = self.newframe(mainjitcode);
 /// f.setup_call(original_boxes)` — entry at pc 0 with the portal's own
 /// arguments, so the prologue runs and the walk reaches the merge point on its
-/// own. `eval_loop_jit`'s `calldescr.arg_classes` is `"r"`: the portal was
-/// never split, so its one argument is the Rust `frame`, not greens+reds.
+/// own. A split portal declares greens followed by reds; an unsplit portal
+/// keeps `eval_loop_jit`'s single `frame` argument.
 fn portal_metatrace_entry_at_start() -> bool {
     static AT_START: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *AT_START
@@ -7119,6 +7119,7 @@ fn drive_portal_metatrace(f: *mut PyFrame, green_key: u64, loop_header_pc: usize
             portal_index,
             canonical.code.len(),
         );
+        let portal_arg_classes = canonical.calldescr().arg_classes.clone();
         let jitcode = majit_metainterp::JitCode::from_canonical((*canonical).clone());
 
         let header_pc = match pyre_jit_trace::jitcode_runtime::decoded_ops(&canonical.code)
@@ -7226,10 +7227,18 @@ fn drive_portal_metatrace(f: *mut PyFrame, green_key: u64, loop_header_pc: usize
                 let mut frame =
                     majit_metainterp::MIFrame::setup(jitcode_arc, header_pc, None, Some(ctx));
 
-                let green_int_values = [next_instr, is_being_profiled];
-                for (&reg, &value) in slot_regs[0].iter().zip(green_int_values.iter()) {
+                let next_instr_opref = ctx.const_int(next_instr);
+                let is_being_profiled_opref = ctx.const_int(is_being_profiled);
+                let pycode_opref = ctx.const_ref(pycode as usize as i64);
+                let frame_opref = majit_ir::OpRef::input_arg_typed(0, majit_ir::Type::Ref);
+                let ec_opref = majit_ir::OpRef::input_arg_typed(1, majit_ir::Type::Ref);
+
+                let green_int_values = [
+                    (next_instr_opref, next_instr),
+                    (is_being_profiled_opref, is_being_profiled),
+                ];
+                for (&reg, &(opref, value)) in slot_regs[0].iter().zip(green_int_values.iter()) {
                     if reg < frame.int_regs.len() && reg < frame.int_values.len() {
-                        let opref = ctx.const_int(value);
                         frame.int_regs[reg] = Some(opref);
                         frame.int_values[reg] = Some(value);
                     } else {
@@ -7241,10 +7250,9 @@ fn drive_portal_metatrace(f: *mut PyFrame, green_key: u64, loop_header_pc: usize
                         );
                     }
                 }
-                let green_ref_values = [pycode as usize as i64];
-                for (&reg, &value) in slot_regs[1].iter().zip(green_ref_values.iter()) {
+                let green_ref_values = [(pycode_opref, pycode as usize as i64)];
+                for (&reg, &(opref, value)) in slot_regs[1].iter().zip(green_ref_values.iter()) {
                     if reg < frame.ref_regs.len() && reg < frame.ref_values.len() {
-                        let opref = ctx.const_ref(value);
                         frame.ref_regs[reg] = Some(opref);
                         frame.ref_values[reg] = Some(value);
                     } else {
@@ -7256,18 +7264,12 @@ fn drive_portal_metatrace(f: *mut PyFrame, green_key: u64, loop_header_pc: usize
                         );
                     }
                 }
-                let red_ref_values = [live_frame as usize as i64, ec as usize as i64];
-                for (input_index, (&reg, &value)) in slot_regs[4]
-                    .iter()
-                    .zip(red_ref_values.iter())
-                    .enumerate()
-                {
+                let red_ref_values = [
+                    (frame_opref, live_frame as usize as i64),
+                    (ec_opref, ec as usize as i64),
+                ];
+                for (&reg, &(opref, value)) in slot_regs[4].iter().zip(red_ref_values.iter()) {
                     if reg < frame.ref_regs.len() && reg < frame.ref_values.len() {
-                        let input_index = input_index as u32;
-                        let opref = majit_ir::OpRef::input_arg_typed(
-                            input_index,
-                            majit_ir::Type::Ref,
-                        );
                         frame.ref_regs[reg] = Some(opref);
                         frame.ref_values[reg] = Some(value);
                     } else {
@@ -7286,27 +7288,64 @@ fn drive_portal_metatrace(f: *mut PyFrame, green_key: u64, loop_header_pc: usize
                 //   f = self.newframe(self.jitdriver_sd.mainjitcode)
                 //   f.setup_call(original_boxes)
                 // `setup_call` packs argboxes into the typed banks in
-                // declaration order, so a `calldescr.arg_classes == "r"`
-                // jitcode takes exactly one ref, at r0. Here that is the live
-                // `PyFrame`: pc=3 calls `FrameRoot::new` on r0 to produce r1,
-                // and r1 is what the loop body's first op reads — the register
-                // merge-point entry cannot supply.
+                // declaration order. The split portal takes its greens then
+                // reds; the unsplit portal takes the live `PyFrame` at r0.
                 //
                 // The merge-point seeds above are left standing: every
                 // register they write is re-written by the prologue before the
                 // marker, and `setup_call` overwrites r0 at entry.
                 let entry_pc = if portal_metatrace_entry_at_start() {
-                    frame.setup_call(&[(
-                        majit_metainterp::JitArgKind::Ref,
-                        majit_ir::OpRef::input_arg_typed(0, majit_ir::Type::Ref),
-                        live_frame as usize as i64,
-                    )]);
+                    let declared_kinds = portal_arg_classes
+                        .chars()
+                        .map(|class| match class {
+                            'i' | 'S' => majit_metainterp::JitArgKind::Int,
+                            'r' => majit_metainterp::JitArgKind::Ref,
+                            'f' | 'L' => majit_metainterp::JitArgKind::Float,
+                            other => panic!("unsupported portal argument class {other:?}"),
+                        })
+                        .collect::<Vec<_>>();
+                    let start_args = match declared_kinds.as_slice() {
+                        [frame_kind] => {
+                            assert_eq!(*frame_kind, majit_metainterp::JitArgKind::Ref);
+                            vec![(*frame_kind, frame_opref, live_frame as usize as i64)]
+                        }
+                        [
+                            next_instr_kind,
+                            profiled_kind,
+                            pycode_kind,
+                            frame_kind,
+                            ec_kind,
+                        ] => vec![
+                            (*next_instr_kind, next_instr_opref, next_instr),
+                            (*profiled_kind, is_being_profiled_opref, is_being_profiled),
+                            (*pycode_kind, pycode_opref, pycode as usize as i64),
+                            (*frame_kind, frame_opref, live_frame as usize as i64),
+                            (*ec_kind, ec_opref, ec as usize as i64),
+                        ],
+                        _ => panic!(
+                            "portal start expected one or five arguments, got {:?}",
+                            portal_arg_classes
+                        ),
+                    };
+                    let seeded_arg_classes = start_args
+                        .iter()
+                        .map(|(kind, _, _)| match kind {
+                            majit_metainterp::JitArgKind::Int => 'i',
+                            majit_metainterp::JitArgKind::Ref => 'r',
+                            majit_metainterp::JitArgKind::Float => 'f',
+                        })
+                        .collect::<String>();
+                    let seeded_values = start_args
+                        .iter()
+                        .map(|(_, _, value)| *value)
+                        .collect::<Vec<_>>();
+                    frame.setup_call(&start_args);
                     // `setup_call` sets `pc = 0`; the walker reads
                     // `code_cursor`, which it does not touch.
                     frame.code_cursor = 0;
                     eprintln!(
-                        "[jd0-mt] entry=start pc=0 setup_call arg_classes=\"r\" r0=0x{:x}",
-                        live_frame as usize,
+                        "[jd0-mt] entry=start pc=0 setup_call arg_classes=\"{}\" args={:?}",
+                        seeded_arg_classes, seeded_values,
                     );
                     0
                 } else {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1645,6 +1645,41 @@ pub(crate) enum LoopResult {
     ExitFrameWithException(pyre_interpreter::PyError),
 }
 
+fn set_pending_loop_exit(ec: *const PyExecutionContext, loop_result: LoopResult) {
+    let pending = match loop_result {
+        LoopResult::Done(result) => {
+            pyre_interpreter::executioncontext::PendingLoopExit::Done(result)
+        }
+        LoopResult::ContinueRunningNormally => {
+            pyre_interpreter::executioncontext::PendingLoopExit::ContinueRunningNormally
+        }
+        LoopResult::ExitFrameWithException(err) => {
+            pyre_interpreter::executioncontext::PendingLoopExit::ExitFrameWithException(err)
+        }
+    };
+    // The EC carrier is included in the interpreter root walk because its
+    // PyResult/PyError payload can hold moving GC references.  This store and
+    // the caller's take are also adjacent with no collection point in between:
+    // the marker returns only its boolean before the read.
+    unsafe { (&mut *(ec as *mut PyExecutionContext)).set_pending_loop_exit(pending) };
+}
+
+fn take_pending_loop_exit(ec: *const PyExecutionContext) -> LoopResult {
+    match unsafe { (&mut *(ec as *mut PyExecutionContext)).take_pending_loop_exit() }
+        .expect("true can_enter_jit result must carry a pending loop exit")
+    {
+        pyre_interpreter::executioncontext::PendingLoopExit::Done(result) => {
+            LoopResult::Done(result)
+        }
+        pyre_interpreter::executioncontext::PendingLoopExit::ContinueRunningNormally => {
+            LoopResult::ContinueRunningNormally
+        }
+        pyre_interpreter::executioncontext::PendingLoopExit::ExitFrameWithException(err) => {
+            LoopResult::ExitFrameWithException(err)
+        }
+    }
+}
+
 /// Action from handle_jit_outcome for eval_loop_jit dispatch.
 enum JitAction {
     Return(PyResult),
@@ -6156,10 +6191,10 @@ impl PyPyJitDriver {
     }
 
     /// interp_jit.py:114-117 — can_enter_jit at back-edge.
-    /// The untranslated body is intentionally a runtime no-op.  The translator
-    /// lowers it to `jit_marker('can_enter_jit', ...)`, which jtransform aliases
-    /// to the JitCode `loop_header` operation.  The live runtime warmstate call
-    /// remains alongside it until generic `warmspot.apply_jit` is wired.
+    /// The translator lowers the call to the JitCode `loop_header` operation
+    /// and defines its result as false.  The untranslated interpreter body is
+    /// the `rewrite_can_enter_jits` side: it drives warmstate outside the portal
+    /// jitcode and reports a compiled-loop exit through the execution context.
     ///
     /// The argument order mirrors `jit_merge_point` so both markers carry one
     /// shape, but this marker's operands are discarded: it lowers to
@@ -6173,8 +6208,41 @@ impl PyPyJitDriver {
         pycode: pyre_object::PyObjectRef,
         frame: &mut PyFrame,
         ec: *const PyExecutionContext,
-    ) {
-        let _ = (frame, ec, next_instr, pycode, is_being_profiled);
+    ) -> bool {
+        let env = PyreEnv;
+        let (driver, info) = driver_pair();
+        let loop_pycode = pycode as *const ();
+        let green_key_hash = make_green_key(loop_pycode, next_instr, is_being_profiled);
+        let green_key = driver.resolve_cell_key(green_key_hash, || {
+            pyre_jit_trace::driver::make_green_key_typed(
+                loop_pycode,
+                next_instr,
+                is_being_profiled,
+            )
+        });
+        if portal_metatrace_enabled()
+            && PORTAL_METATRACE_SEEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                >= portal_metatrace_skip()
+            && !PORTAL_METATRACE_FIRED.swap(true, std::sync::atomic::Ordering::Relaxed)
+        {
+            drive_portal_metatrace(frame as *mut PyFrame, green_key_hash, next_instr);
+        }
+        // The Stage-0 drive records IR and executes residuals concretely, so it
+        // is a collection point; reload the same shadow-stack root before the
+        // compile path reads the frame.
+        let f: *mut PyFrame = FrameView::top_frame();
+        let Some(loop_result) = maybe_compile_and_run(
+            unsafe { &mut *f },
+            green_key,
+            next_instr,
+            driver,
+            info,
+            &env,
+        ) else {
+            return false;
+        };
+        set_pending_loop_exit(ec, loop_result);
+        true
     }
 }
 
@@ -10265,66 +10333,17 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 let marker_ec = pyre_interpreter::call::getexecutioncontext();
                 let marker_pycode = unsafe { &*f }.pycode as pyre_object::PyObjectRef;
                 let marker_profiled = unsafe { &*f }.get_is_being_profiled();
-                pypyjitdriver.can_enter_jit(
+                if pypyjitdriver.can_enter_jit(
                     loop_header_pc,
                     marker_profiled,
                     marker_pycode,
                     unsafe { &mut *f },
                     marker_ec,
-                );
-                // can_enter_jit is a lowered no-op / merge point; re-seed
-                // conservatively before the next frame reads.
-                let f: *mut PyFrame = FrameView::top_frame();
-                // Compute these after the merge point: the portal split requires every
-                // live-across value to be a declared green or red. Upstream bakes the
-                // driver into the enter function and reaches the space through `self.space`.
-                let env = PyreEnv;
-                let (driver, info) = driver_pair();
-                let loop_pycode = unsafe { &*f }.pycode;
-                let loop_profiled = unsafe { &*f }.get_is_being_profiled();
-                let green_key_hash = make_green_key(loop_pycode, loop_header_pc, loop_profiled);
-                // The same resolve the function-entry door takes, for the same
-                // reason: `maybe_compile_and_run` and everything it reads
-                // (`has_runnable_compiled_loop`, `runnable_procedure_token`,
-                // `maybe_compile_decision`) answer for whichever cell HEADS a
-                // chained bucket, so a bare hash decides about one cell while
-                // `force_start_tracing_for_key` — which walks the chain — acts
-                // on another.  A loop-header key gets a chained bucket from the
-                // hash-form installers (`disable_noninlinable_function`,
-                // `prepare_trace_segmenting`) and from the inlined-callee
-                // merge point in `jitcode_dispatch`, which mints its callee's
-                // loop header as a raw `make_green_key`.
-                let green_key = driver.resolve_cell_key(green_key_hash, || {
-                    pyre_jit_trace::driver::make_green_key_typed(
-                        loop_pycode,
-                        loop_header_pc,
-                        loop_profiled,
-                    )
-                });
-                if portal_metatrace_enabled()
-                    && PORTAL_METATRACE_SEEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                        >= portal_metatrace_skip()
-                    && !PORTAL_METATRACE_FIRED.swap(true, std::sync::atomic::Ordering::Relaxed)
-                {
-                    drive_portal_metatrace(f, green_key_hash, loop_header_pc);
-                }
-                // The Stage-0 drive records IR and executes residuals
-                // concretely, so it is a collection point; re-seed before the
-                // compile path reads the frame. A plain reload of the same
-                // shadow-stack slot, so the knob-off path reads the value it
-                // already held.
-                let f: *mut PyFrame = FrameView::top_frame();
-                if let Some(loop_result) = maybe_compile_and_run(
-                    unsafe { &mut *f },
-                    green_key,
-                    loop_header_pc,
-                    driver,
-                    info,
-                    &env,
                 ) {
                     // maybe_compile_and_run compiles and may allocate → re-seed
                     // before handle_exception reads the frame.
                     let f: *mut PyFrame = FrameView::top_frame();
+                    let loop_result = take_pending_loop_exit(marker_ec);
                     // warmspot.py handle_jitexception: an
                     // `ExitFrameWithExceptionRef` from a direct compiled-code
                     // exit is re-raised into the interpreter loop.  Offer it to

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7153,7 +7153,7 @@ fn drive_portal_metatrace(f: *mut PyFrame, green_key: u64, loop_header_pc: usize
         let is_being_profiled = i64::from(unsafe { &*f }.get_is_being_profiled());
         let pycode = unsafe { &*f }.pycode as pyre_object::PyObjectRef;
         let live_frame = f;
-        let ec = unsafe { &*f }.execution_context;
+        let ec = pyre_interpreter::call::getexecutioncontext();
         eprintln!(
             "[jd0-mt] greens next_instr={} is_being_profiled={} pycode=0x{:x}",
             next_instr, is_being_profiled, pycode as usize,


### PR DESCRIPTION
## What this branch does

Ports the first step of the warmspot portal boundary: `split_before_jit_merge_point` (behind `PYRE_PORTAL_SPLIT=1`) now succeeds on `eval_loop_jit`, producing a portal jitcode from the split graph with the driver's declared greens and reds as its inputs, registered as the driver's main jitcode. The default (knob-off) pipeline is unchanged in structure; the frame-root change is live on both paths.

### Code commits (excluding plan/record commits)

- `f22dbf03339` jit-translate: port `split_before_jit_merge_point` behind `PYRE_PORTAL_SPLIT`
- `9119f0a30c1` jit-translate: walk a `_forcelink` offender's origin back to a producing op
- `769ed8f4516` jit-translate: copy `access_directly` in copygraph
- `24ae76521bd` jit-translate: pass `jit_merge_point_in` at the merge-point rewrite test
- `d63de3c9b9a` jit: compute env and `driver_pair` after the merge point in `eval_loop_jit`
- `a075d8b0fc3` jit-translate: rematerialise the `jit_merge_point` receiver in `split_block` (upstream's `same_as(Constant(None, Void))` + `remove_same_as`; our call operands are Variables, so the nullary producer is re-emitted at the head of the split-off body — the marker lands at op index 1, and the post-split assert compares the block only)
- `cb9b23ae2f3` jit: reload the frame through the caller's shadow-stack root in `eval_loop_jit` (`FrameRoot::new` removed; the caller's push is the root, as the split-off portal upstream re-captures its shadow-stack base)
- `22200326221` jit: read the portal frame root through one shadow-stack borrow (`shadow_stack::top_ref`; `f` stays live across the marker as the driver's red `frame`, so no post-marker re-derivation)
- `ca2e699650f`/`3ded14146b9` jit: portal metatrace probe (`PYRE_PORTAL_METATRACE`), off by default
- `8b0dc85aa78`/`4457f5fc0e5`/`019f08bcc38` jit: zero-sized values — an all-ZST enum modelled as its tag, a ZST parameter treated as Void, call-result coloring guarded on a Void concretetype
- `d5e3fe4bd26` jit: test COROUTINE alongside GENERATOR in `should_unroll_one_iteration`
- `1a9a0e76c91`/`821f51c341d`/`0138bc57bb2` jit-trace: namespace-binding journal and guard resume-coordinate probe
- `74dff2bce42`/`d822f1830b4` parity_tests: two pins on portal-activated frame chain links / the frame's own trace function
- `60fef3048a9` majit-charon-reader: `census_zst` example

### Evidence

- `PYRE_PORTAL_SPLIT=1 cargo build --release -p pyre-jit-trace`: rc=0, 0 `_forcelink` offenders (was 5). `jit_metadata.json`: `jit_drivers[0].portal = pyre_jit::eval::eval_loop_jit_portal`, `main_jitcode_index=2434`, `jit_merge_point_offset=27`; OFF builds contain no such jitcode.
- Default `check.py` on `d64dedc6900`: dynasm 516/516, cranelift 516/516, wasm 509/509. On the final code tree (`22200326221`): dynasm 516/516, cranelift 516/516, wasm 509/509.
- ON-knob smoke (`PYRE_PORTAL_SPLIT=1 check.py --backend dynasm --synthetic-only`): 506/506.
- OFF-path interpreter cost (`PYRE_NO_JIT=1`, instructions retired, N/4N slope): base 9 676–9 731 instr/iter, branch 9 451–9 467 (−2.5%). The intermediate FrameView shape cost +0.7%; `22200326221` removed it.

### Not in this PR

T2 (the warmstate entering `jd.mainjitcode` at the merge point — nothing walks the portal jitcode yet) and T3. The plan file `warmspot-portal.plan.md` records the investigation; §1.11–§1.15 cover this state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs8Lh8cQrnq9tYS7i4nz6a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional portal splitting for improved JIT loop handling.
  * Added diagnostics for zero-sized types, portal metatracing, and guard-resume coordinates.
  * Improved support for coroutine and generator execution.

* **Bug Fixes**
  * Improved handling of zero-sized values, fieldless enums, and void results.
  * Fixed tracing behavior for compiled and inlined code.
  * Prevented namespace changes from being lost during speculative execution.
  * Improved frame-chain stability, recursive-call detection, and instruction decoding.

* **Tests**
  * Added regression coverage for tracing, frame links, namespace restoration, and JIT behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->