### PR TITLE
jit-trace: a carrier resume does not surface SubLoopCalleeCallAssembler

### DIFF
--- a/pyre/extra_tests/parity_tests/buffered_reader_slow_path_refill.py
+++ b/pyre/extra_tests/parity_tests/buffered_reader_slow_path_refill.py
@@ -1,0 +1,97 @@
+# CPython-suite gap: zipfile's chunked-read tests assert only the total of a
+# whole-member read, so a call that returns more than it was asked for and a
+# later one that returns less cancel out and never reach an assertion.
+# parity-tests reason: the loss is a pyre bridge-drain replay defect that any
+# buffered reader with this refill shape reaches, not a zipfile one.
+# parity-env: PYRE_JIT=threshold=40,function_threshold=40
+
+"""A refill that clears the buffer must not lose the bytes already in it.
+
+`read` hands back the buffered tail, clears `_readbuffer`, and only then
+enters the loop that refills it -- so a re-entry anywhere between the two
+recomputes the request size and the tail from a buffer that is already
+empty, asks `_read1` for the whole window instead of the remainder, and
+drops the tail it had just taken.  The loss is invisible per call: the
+short read is a LONGER return, and only the total says bytes went missing.
+
+The two kinds differ in whether a refill lands on a multiple of the read
+size, which decides whether the slow path leaves an empty buffer behind
+for the next call; the second kind's varying refill is what puts a live
+tail in front of the clear.
+"""
+
+CHUNK = 4096
+STEP = 256
+TOTAL = 600000
+
+
+class Reader:
+    def __init__(self, jitter, total):
+        self._jitter = jitter
+        self._readbuffer = b""
+        self._offset = 0
+        self._eof = False
+        self._left = total
+        self._state = 7
+
+    def _fill(self, n):
+        if n < CHUNK:
+            n = CHUNK
+        if self._jitter:
+            self._state = (self._state * 1103515245 + 12345) & 0x7FFFFFFF
+            n += 300 + (self._state >> 16) % 560
+        if n > self._left:
+            n = self._left
+        return b"\x01" * n
+
+    def _read1(self, n):
+        if self._eof or n <= 0:
+            return b""
+        data = self._fill(n)
+        self._left -= len(data)
+        if self._left <= 0:
+            self._eof = True
+        return data
+
+    def read(self, n):
+        end = n + self._offset
+        if end < len(self._readbuffer):
+            buf = self._readbuffer[self._offset:end]
+            self._offset = end
+            return buf
+        n = end - len(self._readbuffer)
+        buf = self._readbuffer[self._offset:]
+        self._readbuffer = b""
+        self._offset = 0
+        while n > 0 and not self._eof:
+            data = self._read1(n)
+            if n < len(data):
+                self._readbuffer = data
+                self._offset = n
+                buf += data[:n]
+                break
+            buf += data
+            n -= len(data)
+        return buf
+
+
+def drain(jitter):
+    reader = Reader(jitter, TOTAL)
+    got = 0
+    oversized = 0
+    while True:
+        chunk = reader.read(STEP)
+        if not chunk:
+            break
+        if len(chunk) > STEP:
+            oversized += 1
+        got += len(chunk)
+    return got, oversized
+
+
+for _ in range(4):
+    assert drain(0) == (TOTAL, 0)
+for _ in range(4):
+    assert drain(1) == (TOTAL, 0)
+
+print("OK")

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -12649,16 +12649,32 @@ fn handle<Sym: WalkSym>(
                         .map(|frame| frame.w_code),
                 );
             }
+            // A carrier resume has no return site to hand a
+            // `SubLoopCalleeCallAssembler` to: `drive_bridge_frame_subwalk` is
+            // the reconstructed frame's own walk, so the outcome surfaces out of
+            // it and reaches the drain, which threads only `SubReturn` and
+            // `SubRaise` and sends everything else to its journal-rollback abort
+            // epilogue.  That epilogue hands the guard back to a blackhole resume
+            // from `rd_numb`, re-entering this frame at the coordinate the walk
+            // started from, and the journal does not reach a residual call that
+            // already wrote the live heap.  `ZipExtFile.read` is the witness: its
+            // slow path clears `_readbuffer` and zeroes `_offset` before reaching
+            // the `while n > 0` header, so the re-entry recomputes `n` and `buf`
+            // from the cleared buffer and the member loses one buffer's worth of
+            // bytes.  `carrier_resume` is set on the reconstructed frame's own
+            // context and nowhere else, so a nested inline inside that frame
+            // still folds its own recursive call to a CALL_ASSEMBLER.
             let callee_code = (!ctx.is_top_level
-                && ctx.fbw_mode.transparent_helper_jitcode_index.is_none())
-            .then(|| {
-                ctx.session
-                    .borrow()
-                    .framestack
-                    .last()
-                    .map(|frame| frame.w_code)
-            })
-            .flatten();
+                && ctx.fbw_mode.transparent_helper_jitcode_index.is_none()
+                && !ctx.fbw_mode.carrier_resume)
+                .then(|| {
+                    ctx.session
+                        .borrow()
+                        .framestack
+                        .last()
+                        .map(|frame| frame.w_code)
+                })
+                .flatten();
             if let Some(callee_code) = callee_code {
                 let callee_key = crate::driver::make_green_key(
                     callee_code as *const (),
@@ -12698,12 +12714,17 @@ fn handle<Sym: WalkSym>(
                     // surface a recursive CALL_ASSEMBLER request to the caller's
                     // inline return site (mirror `opimpl_recursive_call_
                     // assembler`, metainterp.rs).
-                    let callee_code = ctx
-                        .session
-                        .borrow()
-                        .framestack
-                        .last()
-                        .map(|frame| frame.w_code);
+                    // Same carrier-resume exclusion as the arm above, for
+                    // the same reason.
+                    let callee_code = (!ctx.fbw_mode.carrier_resume)
+                        .then(|| {
+                            ctx.session
+                                .borrow()
+                                .framestack
+                                .last()
+                                .map(|frame| frame.w_code)
+                        })
+                        .flatten();
                     if let Some(callee_code) = callee_code {
                         let callee_key = crate::driver::make_green_key(
                             callee_code as *const (),


### PR DESCRIPTION
`jit_merge_point` surfaced `SubLoopCalleeCallAssembler` from any walk that was not
top-level. A carrier resume — `drive_bridge_frame_subwalk`, which reconstructs a
failed guard's callee frame and walks it as the authoritative executor — is that
frame's own walk, so it has no inline return site to consume the outcome. The
outcome surfaced out of the sub-walk and reached `p2_drain_abort`, which threads
only `SubReturn { result: Some(_) }` and `SubRaise` and sends everything else to
its abort epilogue: `fbw_store_journal_rollback()` and a blackhole resume from
`rd_numb`. That re-enters the frame at the coordinate the walk started from, past
the residual calls the walk had already run against the live heap, which the store
journal does not cover.

`ZipExtFile.read` reaches it. Its slow path hands back the buffered tail, then

```python
self._readbuffer = b''      # StoreAttr, writes_live=true
self._offset = 0            # StoreAttr, writes_live=true
while n > 0 and not self._eof:   # the loop header that already had a token
```

so the replay recomputes `n = end - len(b'')` and `buf = b''[0:]`, asks `_read1`
for the whole window instead of the remainder, and drops the tail it had just
taken. The loss is invisible per call — the short read is a *longer* return — and
only the member total says bytes went missing.

`test.test_zipfile`'s `StoredTestsWithRandomBinaryFiles.test_open` and its Lzma
sibling failed on roughly 20% of runs from this. The witness chain: `PYRE_NO_JIT=1`
is 0/20; every optimizer pass is innocent (`enable_opts=` reproduces *more*);
`loops_aborted=2` separates a failing run from a clean one exactly; and each STOP
is immediately preceded by `[fbw-effect] helper=StoreAttr writes_live=true` twice
followed by `[p2-drain-abort] effects=2 adopted=false`.

The fix excludes `fbw_mode.carrier_resume` at both production sites. That flag is
set on the reconstructed frame's own context and nowhere else — a nested inline
inside that frame builds its own context with it false — so a nested callee still
folds its own recursive call to a CALL_ASSEMBLER.

Latching the abort onto an image instead is wrong code: a carrier sub-walk
deliberately installs no `InlineConcreteFrameGuard`, so the reconstructed inner
level's locals are never published and the resume reads them unbound
(`UnboundLocalError: cannot access local variable 'buf'` at `merge_entry_for(target_pc)`,
`TypeError: unsupported operand type(s) for +: 'object' and 'bytes'` at `end_pc`).

### Regression

`pyre/extra_tests/parity_tests/buffered_reader_slow_path_refill.py` reproduces the
shape without zipfile: a reader whose refill clears the buffer before the loop that
refills it. It fails 5/5 on the pre-fix binary in about a second and passes 5/5
after, on CPython 3.14 and on pypy3 too. zipfile's own chunked-read tests only
assert the member total, so a long return followed by a short one cancels out and
never reaches an assertion there.

### Verification

- the 2-test zipfile repro, strict detection, 24 interleaved rounds per arm: pre-fix
  5/24 STOP, post-fix 0/24.
- `test.test_zipfile` in full: PASS.
- `python3 pyre/check.py`: ALL PASSED — dynasm, cranelift, wasm.
- `python3 pyre/extra_tests/parity_tests/run.py`: the new fixture is green on all
  four runners.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of buffered reads, preventing incorrect byte counts or oversized read results in edge cases.
  - Improved JIT execution stability when resuming interrupted or deferred work.

- **Tests**
  - Added coverage for buffered-reader refill behavior, including deterministic and variable read patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->