### PR TITLE
wasm: the four inet converters, the writing half of wasi's posix surface, and `%z` from `tm_gmtoff`

### DIFF
--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -19849,6 +19849,15 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 // `posix` resolves one, so `open` and `os.open` answer for the
                 // same file after a `chdir`.
                 let seam_path = wasm_fd::seam_path(path_bytes);
+                // The seam reports a directory read as a missing file; opening
+                // one for reading is `EISDIR`, which is what `os.open` plus
+                // `os.read` already answer for the same name.
+                if crate::importing::source_is_dir(&seam_path) {
+                    return Err(crate::PyError::os_error_syscall(
+                        wasm_errno::EISDIR,
+                        resolved_path.w_path(),
+                    ));
+                }
                 match crate::importing::read_source_bytes(&seam_path) {
                     Ok(bytes) => bytes,
                     Err(e) => {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7331,6 +7331,7 @@ pub(crate) mod wasm_errno {
     pub const EEXIST: i32 = 17;
     pub const ENOENT: i32 = 2;
     pub const ENOTSUP: i32 = 45;
+    pub const EAFNOSUPPORT: i32 = 47;
     pub const EISDIR: i32 = 21;
     pub const ENOTDIR: i32 = 20;
     pub const EINTR: i32 = 4;

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -12,6 +12,11 @@
 /// API.
 #[cfg(any(unix, windows))]
 use super::rsocket_rffi as rffi;
+/// The same names again where there is no host layer to reach them through:
+/// the four address converters are arithmetic over the spelling, so they are
+/// written out rather than called, and the entry points below cannot tell.
+#[cfg(not(any(unix, windows)))]
+use super::interp_socket_wasm as rffi;
 
 /// _socket module — PyPy: pypy/module/_socket/.
 ///
@@ -1030,200 +1035,173 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     );
 
     // ── inet_aton / inet_ntoa ──
-    #[cfg(any(unix, windows))]
-    {
-        crate::module_ns_store(
-            ns,
+    crate::module_ns_store(
+        ns,
+        "inet_aton",
+        crate::make_builtin_function_with_arity(
             "inet_aton",
-            crate::make_builtin_function_with_arity(
-                "inet_aton",
-                |args| {
-                    if args.is_empty() {
-                        return Err(crate::PyError::type_error("inet_aton() missing argument"));
-                    }
-                    let s = unsafe {
-                        if !pyre_object::is_str(args[0]) {
-                            return Err(crate::PyError::type_error(
-                                "inet_aton: arg must be a string",
-                            ));
-                        }
-                        crate::baseobjspace::str_utf8_w(args[0])?.to_string()
-                    };
-                    let c = std::ffi::CString::new(s.as_bytes())
-                        .map_err(|_| crate::PyError::value_error("embedded null in argument"))?;
-                    let Some(bytes) = rffi::inet_aton(&c) else {
-                        return Err(crate::PyError::os_error(
-                            "illegal IP address string passed to inet_aton",
+            |args| {
+                if args.is_empty() {
+                    return Err(crate::PyError::type_error("inet_aton() missing argument"));
+                }
+                let s = unsafe {
+                    if !pyre_object::is_str(args[0]) {
+                        return Err(crate::PyError::type_error(
+                            "inet_aton: arg must be a string",
                         ));
-                    };
-                    Ok(pyre_object::bytesobject::w_bytes_from_bytes(&bytes))
-                },
-                1,
-            ),
-        );
-        crate::module_ns_store(
-            ns,
+                    }
+                    crate::baseobjspace::str_utf8_w(args[0])?.to_string()
+                };
+                let c = std::ffi::CString::new(s.as_bytes())
+                    .map_err(|_| crate::PyError::value_error("embedded null in argument"))?;
+                let Some(bytes) = rffi::inet_aton(&c) else {
+                    return Err(crate::PyError::os_error(
+                        "illegal IP address string passed to inet_aton",
+                    ));
+                };
+                Ok(pyre_object::bytesobject::w_bytes_from_bytes(&bytes))
+            },
+            1,
+        ),
+    );
+    crate::module_ns_store(
+        ns,
+        "inet_ntoa",
+        crate::make_builtin_function_with_arity(
             "inet_ntoa",
-            crate::make_builtin_function_with_arity(
-                "inet_ntoa",
-                |args| {
-                    if args.is_empty() {
-                        return Err(crate::PyError::type_error("inet_ntoa() missing argument"));
-                    }
-                    let data = unsafe {
-                        if !pyre_object::bytesobject::is_bytes_like(args[0]) {
-                            return Err(crate::PyError::type_error(
-                                "inet_ntoa: argument must be bytes-like",
-                            ));
-                        }
-                        pyre_object::bytesobject::bytes_like_data(args[0])
-                    };
-                    if data.len() != 4 {
-                        return Err(crate::PyError::os_error(
-                            "packed IP wrong length for inet_ntoa",
+            |args| {
+                if args.is_empty() {
+                    return Err(crate::PyError::type_error("inet_ntoa() missing argument"));
+                }
+                let data = unsafe {
+                    if !pyre_object::bytesobject::is_bytes_like(args[0]) {
+                        return Err(crate::PyError::type_error(
+                            "inet_ntoa: argument must be bytes-like",
                         ));
                     }
-                    let Some(text) = rffi::inet_ntoa([data[0], data[1], data[2], data[3]]) else {
-                        return Err(crate::PyError::os_error("inet_ntoa failed"));
-                    };
-                    Ok(pyre_object::w_str_new(&text))
-                },
-                1,
-            ),
-        );
+                    pyre_object::bytesobject::bytes_like_data(args[0])
+                };
+                if data.len() != 4 {
+                    return Err(crate::PyError::os_error(
+                        "packed IP wrong length for inet_ntoa",
+                    ));
+                }
+                let Some(text) = rffi::inet_ntoa([data[0], data[1], data[2], data[3]]) else {
+                    return Err(crate::PyError::os_error("inet_ntoa failed"));
+                };
+                Ok(pyre_object::w_str_new(&text))
+            },
+            1,
+        ),
+    );
 
-        // inet_pton(af, ip) → bytes
-        crate::module_ns_store(
-            ns,
+    // inet_pton(af, ip) → bytes
+    crate::module_ns_store(
+        ns,
+        "inet_pton",
+        crate::make_builtin_function_with_arity(
             "inet_pton",
-            crate::make_builtin_function_with_arity(
-                "inet_pton",
-                |args| {
-                    if args.len() < 2 {
+            |args| {
+                if args.len() < 2 {
+                    return Err(crate::PyError::type_error(
+                        "inet_pton() requires 2 arguments",
+                    ));
+                }
+                let af = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
+                let ip = unsafe {
+                    if !pyre_object::is_str(args[1]) {
                         return Err(crate::PyError::type_error(
-                            "inet_pton() requires 2 arguments",
+                            "inet_pton: address must be a string",
                         ));
                     }
-                    let af = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
-                    let ip = unsafe {
-                        if !pyre_object::is_str(args[1]) {
-                            return Err(crate::PyError::type_error(
-                                "inet_pton: address must be a string",
-                            ));
-                        }
-                        crate::baseobjspace::str_utf8_w(args[1])?.to_string()
-                    };
-                    let c_ip = std::ffi::CString::new(ip.as_bytes())
-                        .map_err(|_| crate::PyError::value_error("embedded null"))?;
-                    let mut buf = [0u8; 16];
-                    let r = unsafe {
-                        rffi::inet_pton(af, c_ip.as_ptr(), buf.as_mut_ptr() as *mut libc::c_void)
-                    };
-                    // `inet_pton` separates the two failures: a negative
-                    // return is a family it has no parser for and leaves
-                    // `EAFNOSUPPORT` behind, a zero is an address string it
-                    // parsed and rejected.
-                    if r < 0 {
-                        return Err(crate::PyError::os_error_syscall(
-                            rffi::last_error_code(),
-                            pyre_object::PY_NULL,
-                        ));
-                    }
-                    if r != 1 {
-                        return Err(crate::PyError::os_error(
-                            "illegal IP address string passed to inet_pton",
-                        ));
-                    }
-                    let n = match af {
-                        x if x == rffi::AF_INET => 4,
-                        x if x == rffi::AF_INET6 => 16,
-                        _ => {
-                            return Err(crate::PyError::value_error("unknown address family"));
-                        }
-                    };
-                    Ok(pyre_object::bytesobject::w_bytes_from_bytes(&buf[..n]))
-                },
-                2,
-            ),
-        );
+                    crate::baseobjspace::str_utf8_w(args[1])?.to_string()
+                };
+                let c_ip = std::ffi::CString::new(ip.as_bytes())
+                    .map_err(|_| crate::PyError::value_error("embedded null character"))?;
+                match rffi::pton(af, &c_ip) {
+                    Ok(packed) => Ok(pyre_object::bytesobject::w_bytes_from_bytes(&packed)),
+                    Err(rffi::PtonError::Family(code)) => Err(crate::PyError::os_error_syscall(
+                        code,
+                        pyre_object::PY_NULL,
+                    )),
+                    Err(rffi::PtonError::Address) => Err(crate::PyError::os_error(
+                        "illegal IP address string passed to inet_pton",
+                    )),
+                }
+            },
+            2,
+        ),
+    );
 
-        // inet_ntop(af, packed) → str
-        crate::module_ns_store(
-            ns,
+    // inet_ntop(af, packed) → str
+    crate::module_ns_store(
+        ns,
+        "inet_ntop",
+        crate::make_builtin_function_with_arity(
             "inet_ntop",
-            crate::make_builtin_function_with_arity(
-                "inet_ntop",
-                |args| {
-                    if args.len() < 2 {
+            |args| {
+                if args.len() < 2 {
+                    return Err(crate::PyError::type_error(
+                        "inet_ntop() requires 2 arguments",
+                    ));
+                }
+                let af = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
+                let data = unsafe {
+                    if !pyre_object::bytesobject::is_bytes_like(args[1]) {
                         return Err(crate::PyError::type_error(
-                            "inet_ntop() requires 2 arguments",
+                            "inet_ntop: argument must be bytes-like",
                         ));
                     }
-                    let af = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
-                    let data = unsafe {
-                        if !pyre_object::bytesobject::is_bytes_like(args[1]) {
-                            return Err(crate::PyError::type_error(
-                                "inet_ntop: argument must be bytes-like",
-                            ));
-                        }
-                        pyre_object::bytesobject::bytes_like_data(args[1])
-                    };
-                    let expected = match af {
-                        x if x == rffi::AF_INET => 4,
-                        x if x == rffi::AF_INET6 => 16,
-                        _ => {
-                            return Err(crate::PyError::value_error("unknown address family"));
-                        }
-                    };
-                    if data.len() != expected {
-                        return Err(crate::PyError::value_error(
-                            "invalid length of packed IP address string",
-                        ));
+                    pyre_object::bytesobject::bytes_like_data(args[1])
+                };
+                let expected = match af {
+                    x if x == rffi::AF_INET => 4,
+                    x if x == rffi::AF_INET6 => 16,
+                    _ => {
+                        return Err(crate::PyError::value_error(format!(
+                            "unknown address family {af}"
+                        )));
                     }
-                    let mut buf = [0u8; 64];
-                    let r = unsafe {
-                        rffi::inet_ntop(
-                            af,
-                            data.as_ptr() as *const libc::c_void,
-                            buf.as_mut_ptr() as *mut libc::c_char,
-                            buf.len() as rffi::SockLen,
-                        )
-                    };
-                    if r.is_null() {
-                        return Err(crate::PyError::os_error("inet_ntop failed"));
-                    }
-                    let s = unsafe { std::ffi::CStr::from_ptr(r) };
-                    Ok(pyre_object::w_str_new(&s.to_string_lossy()))
-                },
-                2,
-            ),
-        );
+                };
+                if data.len() != expected {
+                    return Err(crate::PyError::value_error(
+                        "invalid length of packed IP address string",
+                    ));
+                }
+                let Some(text) = rffi::ntop(af, data) else {
+                    return Err(crate::PyError::os_error("inet_ntop failed"));
+                };
+                Ok(pyre_object::w_str_new(&text))
+            },
+            2,
+        ),
+    );
 
-        // gethostname() → str
-        crate::module_ns_store(
-            ns,
+    // gethostname() → str, over the name the host layer reports.  Where there
+    // is none, `interp_socket_wasm` registers the one its `uname` answers.
+    #[cfg(any(unix, windows))]
+    crate::module_ns_store(
+        ns,
+        "gethostname",
+        crate::make_builtin_function_with_arity(
             "gethostname",
-            crate::make_builtin_function_with_arity(
-                "gethostname",
-                |_| {
-                    let name = rffi::hostname().map_err(|e| {
-                        crate::PyError::os_error_with_errno(
-                            e.raw_os_error().unwrap_or(0),
-                            "gethostname",
-                        )
-                    })?;
-                    // `interp_func.py:24` is
-                    // `space.fsdecode(space.newbytes(res))` -- the hostname is
-                    // opaque kernel bytes (`sethostname(2)` takes a plain
-                    // `const char*`), so a byte with no UTF-8 spelling has to
-                    // survive as its surrogate escape.
-                    Ok(crate::gateway::fsdecode_os_str(&name))
-                },
-                0,
-            ),
-        );
-    }
-
+            |_| {
+                let name = rffi::hostname().map_err(|e| {
+                    crate::PyError::os_error_with_errno(
+                        e.raw_os_error().unwrap_or(0),
+                        "gethostname",
+                    )
+                })?;
+                // `interp_func.py:24` is
+                // `space.fsdecode(space.newbytes(res))` -- the hostname is
+                // opaque kernel bytes (`sethostname(2)` takes a plain
+                // `const char*`), so a byte with no UTF-8 spelling has to
+                // survive as its surrogate escape.
+                Ok(crate::gateway::fsdecode_os_str(&name))
+            },
+            0,
+        ),
+    );
     // `sethostname` alone stays POSIX-only: WinSock has no counterpart and
     // `moduledef.py` does not export it where rsocket cannot provide it.
     #[cfg(all(unix, feature = "host_env"))]

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket_wasm.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket_wasm.rs
@@ -63,6 +63,242 @@ fn init_socket_type(ns: PyObjectRef) {
     };
 }
 
+/// The two families the address converters carry a parser for, as the constant
+/// table below spells them.
+pub(super) const AF_INET: i32 = 2;
+pub(super) const AF_INET6: i32 = 10;
+
+/// The host this guest runs as, which is the `nodename` `uname` reports: wasi's
+/// `gethostname` is written over `uname` and hands back that field.
+const NODE_NAME: &str = "(none)";
+
+/// `inet_aton` — the lenient parser, which reads one to four parts and gives
+/// the last one every byte the earlier ones did not claim.  A part is decimal,
+/// octal behind a `0`, or hexadecimal behind a `0x`.
+pub(super) fn inet_aton(text: &std::ffi::CStr) -> Option<[u8; 4]> {
+    let mut parts = Vec::new();
+    for field in text.to_str().ok()?.split('.') {
+        let (digits, radix) = match field.as_bytes() {
+            [b'0', b'x' | b'X', rest @ ..] => (rest, 16),
+            [b'0', rest @ ..] if !rest.is_empty() => (rest, 8),
+            other => (other, 10),
+        };
+        let digits = std::str::from_utf8(digits).ok()?;
+        parts.push(u32::from_str_radix(digits, radix).ok()?);
+        if parts.len() > 4 {
+            return None;
+        }
+    }
+    // The last part carries the bytes the leading ones left: `127.1` is
+    // `127.0.0.1`, and a bare number is the whole address.
+    let leading = parts.len().checked_sub(1)?;
+    let mut address: u32 = 0;
+    for (index, part) in parts.iter().enumerate() {
+        let width = if index == leading {
+            32 - 8 * leading
+        } else {
+            8
+        };
+        if width < 32 && *part >= 1 << width {
+            return None;
+        }
+        address |= part << (32 - 8 * index - width);
+    }
+    Some(address.to_be_bytes())
+}
+
+/// `inet_ntoa` — the dotted-quad spelling of four address bytes.
+pub(super) fn inet_ntoa(packed: [u8; 4]) -> Option<String> {
+    Some(format!(
+        "{}.{}.{}.{}",
+        packed[0], packed[1], packed[2], packed[3]
+    ))
+}
+
+/// `inet_pton`'s two failures, which it reports through different channels: a
+/// negative return leaves `EAFNOSUPPORT` behind, a zero says the string was
+/// read and rejected.
+pub(crate) enum PtonError {
+    /// A family with no parser behind it.
+    Family(i32),
+    /// An address this family's parser refused.
+    Address,
+}
+
+/// `inet_pton` — the strict parser.  Unlike `inet_aton` it reads exactly four
+/// decimal octets, refuses a leading zero, and carries the IPv6 grammar.
+pub(super) fn pton(family: i32, text: &std::ffi::CStr) -> Result<Vec<u8>, PtonError> {
+    let bytes = text.to_bytes();
+    match family {
+        AF_INET => pton_v4(bytes).map(|a| a.to_vec()).ok_or(PtonError::Address),
+        AF_INET6 => pton_v6(bytes).map(|a| a.to_vec()).ok_or(PtonError::Address),
+        _ => Err(PtonError::Family(crate::builtins::wasm_errno::EAFNOSUPPORT)),
+    }
+}
+
+/// One to three decimal digits with no redundant leading zero, which is the
+/// only octet spelling the strict parser reads.
+fn strict_octet(field: &[u8]) -> Option<u8> {
+    if field.is_empty() || field.len() > 3 || (field.len() > 1 && field[0] == b'0') {
+        return None;
+    }
+    let mut value: u32 = 0;
+    for digit in field {
+        value = value * 10 + u32::from(digit.checked_sub(b'0').filter(|d| *d < 10)?);
+    }
+    u8::try_from(value).ok()
+}
+
+fn pton_v4(text: &[u8]) -> Option<[u8; 4]> {
+    let mut address = [0u8; 4];
+    let mut fields = text.split(|b| *b == b'.');
+    for slot in &mut address {
+        *slot = strict_octet(fields.next()?)?;
+    }
+    fields.next().is_none().then_some(address)
+}
+
+fn pton_v6(text: &[u8]) -> Option<[u8; 16]> {
+    // A trailing dotted quad occupies the last two groups, so it is taken off
+    // first and the hexadecimal grammar reads what is left.
+    let (head, tail) = match text.iter().position(|b| *b == b'.') {
+        None => (text, None),
+        Some(_) => {
+            let colon = text.iter().rposition(|b| *b == b':')?;
+            (&text[..colon], Some(pton_v4(&text[colon + 1..])?))
+        }
+    };
+    let groups_wanted = if tail.is_some() { 6 } else { 8 };
+
+    let (before, after) = match find_double_colon(head)? {
+        None => (head, None),
+        Some(at) => (&head[..at], Some(&head[at + 2..])),
+    };
+    let leading = hex_groups(before, groups_wanted)?;
+    let trailing = match after {
+        None => Vec::new(),
+        Some(rest) => hex_groups(rest, groups_wanted - leading.len())?,
+    };
+    // Without `::` every group must be spelled; with it at least one must not.
+    let elided = groups_wanted - leading.len() - trailing.len();
+    if (after.is_none() && elided != 0) || (after.is_some() && elided == 0) {
+        return None;
+    }
+
+    let mut address = [0u8; 16];
+    let mut out = address.iter_mut();
+    for group in leading
+        .iter()
+        .chain(std::iter::repeat_n(&0u16, elided))
+        .chain(trailing.iter())
+    {
+        *out.next()? = (group >> 8) as u8;
+        *out.next()? = *group as u8;
+    }
+    if let Some(quad) = tail {
+        address[12..].copy_from_slice(&quad);
+    }
+    Some(address)
+}
+
+/// The offset of the one `::` a spelling may carry, or nothing when a second
+/// one makes the address ambiguous.
+fn find_double_colon(text: &[u8]) -> Option<Option<usize>> {
+    let mut found = None;
+    let mut index = 0;
+    while index + 1 < text.len() {
+        if text[index] == b':' && text[index + 1] == b':' {
+            if found.is_some() {
+                return None;
+            }
+            found = Some(index);
+            index += 1;
+        }
+        index += 1;
+    }
+    Some(found)
+}
+
+/// Colon-separated groups of one to four hexadecimal digits.  An empty run is
+/// no groups at all, which is what either side of a leading or trailing `::`
+/// reads as.
+fn hex_groups(text: &[u8], limit: usize) -> Option<Vec<u16>> {
+    if text.is_empty() {
+        return Some(Vec::new());
+    }
+    let mut groups = Vec::new();
+    for field in text.split(|b| *b == b':') {
+        if field.is_empty() || field.len() > 4 || groups.len() == limit {
+            return None;
+        }
+        let mut value: u16 = 0;
+        for digit in field {
+            value = value * 16 + u16::from((*digit as char).to_digit(16)? as u8);
+        }
+        groups.push(value);
+    }
+    Some(groups)
+}
+
+/// `inet_ntop` — the canonical spelling of a packed address.
+///
+/// The IPv6 form is written out group by group and then has its longest run of
+/// zero groups replaced by `::`, which is the rewrite musl performs and the
+/// reason a run of one group is left spelled out.
+pub(super) fn ntop(family: i32, packed: &[u8]) -> Option<String> {
+    match family {
+        AF_INET => inet_ntoa([packed[0], packed[1], packed[2], packed[3]]),
+        AF_INET6 => Some(ntop_v6(packed)),
+        _ => None,
+    }
+}
+
+fn ntop_v6(packed: &[u8]) -> String {
+    let group = |i: usize| (u16::from(packed[2 * i]) << 8) | u16::from(packed[2 * i + 1]);
+    // An IPv4-mapped address keeps its last four bytes in dotted-quad form.
+    let text = if packed[..12] == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff] {
+        format!(
+            "{:x}:{:x}:{:x}:{:x}:{:x}:{:x}:{}.{}.{}.{}",
+            group(0),
+            group(1),
+            group(2),
+            group(3),
+            group(4),
+            group(5),
+            packed[12],
+            packed[13],
+            packed[14],
+            packed[15]
+        )
+    } else {
+        (0..8)
+            .map(|i| format!("{:x}", group(i)))
+            .collect::<Vec<_>>()
+            .join(":")
+    };
+
+    // The longest run of `:` and `0` that starts the string or starts at a
+    // colon, taken only when it spans more than one zero group.
+    let bytes = text.as_bytes();
+    let (mut best, mut longest) = (0, 2);
+    for start in 0..bytes.len() {
+        if start != 0 && bytes[start] != b':' {
+            continue;
+        }
+        let run = bytes[start..]
+            .iter()
+            .take_while(|b| **b == b':' || **b == b'0')
+            .count();
+        if run > longest {
+            (best, longest) = (start, run);
+        }
+    }
+    if longest <= 3 {
+        return text;
+    }
+    format!("{}::{}", &text[..best], &text[best + longest..])
+}
+
 /// The `<sys/socket.h>` / `<netinet/in.h>` / `<netdb.h>` numbers, as musl
 /// spells them.
 ///
@@ -170,4 +406,15 @@ pub(super) fn register_names(ns: PyObjectRef) {
     let socket_tp = socket_type();
     crate::module_ns_store(ns, "socket", socket_tp);
     crate::module_ns_store(ns, "SocketType", socket_tp);
+    // `gethostname` needs no socket layer -- wasi answers it out of `uname` --
+    // and `platform._node` calls it, so `platform.uname()` depends on it.
+    crate::module_ns_store(
+        ns,
+        "gethostname",
+        crate::make_builtin_function_with_arity(
+            "gethostname",
+            |_args| Ok(pyre_object::w_str_new(NODE_NAME)),
+            0,
+        ),
+    );
 }

--- a/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
@@ -953,6 +953,54 @@ pub unsafe fn inet_ntop(
     unsafe { ws::inet_ntop(family, src, dst as *mut u8, size as usize) as *const libc::c_char }
 }
 
+/// `inet_pton`'s two failures, which it reports through different channels: a
+/// negative return leaves `EAFNOSUPPORT` behind, a zero says the string was
+/// read and rejected.
+pub(crate) enum PtonError {
+    /// A family with no parser behind it.
+    Family(i32),
+    /// An address this family's parser refused.
+    Address,
+}
+
+/// `inet_pton` over the buffer it fills, sized by the family it was given.
+pub fn pton(family: libc::c_int, text: &std::ffi::CStr) -> Result<Vec<u8>, PtonError> {
+    let mut buf = [0u8; 16];
+    let result = unsafe {
+        inet_pton(
+            family,
+            text.as_ptr(),
+            buf.as_mut_ptr() as *mut core::ffi::c_void,
+        )
+    };
+    if result < 0 {
+        return Err(PtonError::Family(last_error_code()));
+    }
+    if result != 1 {
+        return Err(PtonError::Address);
+    }
+    let width = if family == AF_INET { 4 } else { 16 };
+    Ok(buf[..width].to_vec())
+}
+
+/// `inet_ntop` over the text buffer it fills.
+pub fn ntop(family: libc::c_int, packed: &[u8]) -> Option<String> {
+    let mut buf = [0u8; 64];
+    let text = unsafe {
+        inet_ntop(
+            family,
+            packed.as_ptr() as *const core::ffi::c_void,
+            buf.as_mut_ptr() as *mut libc::c_char,
+            buf.len() as SockLen,
+        )
+    };
+    (!text.is_null()).then(|| {
+        unsafe { std::ffi::CStr::from_ptr(text) }
+            .to_string_lossy()
+            .into_owned()
+    })
+}
+
 // ---------------------------------------------------------------------------
 // The legacy `<netdb.h>` resolvers.
 //

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
@@ -107,18 +107,65 @@ fn cwd_bytes() -> Vec<u8> {
 /// An empty name stays empty so that the seam reports `ENOENT` for it, which is
 /// what `open("")` owes its caller rather than the working directory's contents.
 fn resolve_against_cwd(path: &[u8]) -> Vec<u8> {
-    if path.is_empty() || path.starts_with(b"/") {
+    if path.is_empty() {
         return path.to_vec();
+    }
+    if path.starts_with(b"/") {
+        return normalized(path);
     }
     let mut resolved = cwd_bytes();
     if resolved.is_empty() {
-        return path.to_vec();
+        return normalized(path);
     }
     if !resolved.ends_with(b"/") {
         resolved.push(b'/');
     }
     resolved.extend_from_slice(path);
-    resolved
+    normalized(&resolved)
+}
+
+/// `path` with its `.` and `..` components resolved and its repeated slashes
+/// collapsed, the way `posixpath.normpath` resolves them.
+///
+/// The seam is asked for a name, not walked component by component, and the
+/// embedded filesystem answers an exact key: `lib-python/3/..` names a
+/// directory that is there, and asking for it under that spelling finds
+/// nothing.  Resolving is lexical, so a `..` above a symbolic link lands where
+/// the spelling says rather than where a walk would -- which is what
+/// `normpath` documents about itself, and the only rule available to a seam
+/// that cannot walk.
+fn normalized(path: &[u8]) -> Vec<u8> {
+    let rooted = path.starts_with(b"/");
+    let mut parts: Vec<&[u8]> = Vec::new();
+    for part in path.split(|b| *b == b'/') {
+        match part {
+            b"" | b"." => {}
+            b".." => match parts.last() {
+                // A `..` above the root is the root, and one that has no
+                // component to cancel is kept only where it can still mean
+                // something -- which is nowhere below an absolute path.
+                Some(&last) if last != b".." => {
+                    parts.pop();
+                }
+                _ if rooted => {}
+                _ => parts.push(part),
+            },
+            other => parts.push(other),
+        }
+    }
+    let mut out = if rooted { vec![b'/'] } else { Vec::new() };
+    for (index, part) in parts.iter().enumerate() {
+        if index > 0 {
+            out.push(b'/');
+        }
+        out.extend_from_slice(part);
+    }
+    // Everything cancelled: an absolute path is left as the root, a relative
+    // one as the directory it started in.
+    if out.is_empty() {
+        out.push(b'.');
+    }
+    out
 }
 
 /// `posix.chdir(path)` — the directory later relative paths resolve against.
@@ -126,6 +173,11 @@ fn resolve_against_cwd(path: &[u8]) -> Vec<u8> {
 /// `fchdir` is what a descriptor argument would need, and the seam has no
 /// directory descriptor to offer it, so a name is the only spelling accepted.
 fn chdir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    // `path_arg` reads `dir_fd` because most of its callers take one; `chdir`
+    // is spelled `chdir(path)` and `fchdir` is the call that would take the
+    // other, so the keyword is not a name this entry point knows.
+    let (_, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::kwarg_reject_unknown(kwargs, &["path"], "chdir")?;
     let resolved = path_arg(args, "chdir")?;
     let target = resolve_against_cwd(&resolved.as_bytes);
     let path: std::path::PathBuf = crate::gateway::os_string_from_fs_bytes(&target).into();
@@ -861,13 +913,28 @@ fn environ_snapshot() -> PyObjectRef {
 /// bytes to begin with, so both spellings arrive here and both are kept as
 /// bytes: a name that came from the embedder is a name the guest can set again,
 /// whatever it spells.
+///
+/// The converter's own two refusals are the ones owed here: a TypeError for
+/// something that is neither spelling, and a ValueError for a name carrying an
+/// embedded NUL, which is the one `test_os` asks for by name.
 fn env_bytes_arg(
     w_arg: PyObjectRef,
     name: &'static str,
 ) -> Result<crate::gateway::FsEncodedPath, crate::PyError> {
-    crate::gateway::fsencode_path_w(w_arg).map_err(|_| {
-        crate::PyError::type_error(format!("{name}() argument must be str or bytes"))
-    })
+    crate::gateway::fsencode_path_or_fd_w(w_arg, name, false)
+}
+
+/// The names `setenv` and `unsetenv` refuse outright: an empty one names no
+/// variable, and one carrying `=` could not be spelled back out of the
+/// environment it went into.  Both report `EINVAL`.
+fn check_env_name(name: &[u8]) -> Result<(), crate::PyError> {
+    if name.is_empty() || name.contains(&b'=') {
+        return Err(crate::PyError::os_error_syscall(
+            crate::builtins::wasm_errno::EINVAL,
+            pyre_object::w_none(),
+        ));
+    }
+    Ok(())
 }
 
 /// `posix.putenv(name, value)` — add or replace one variable.
@@ -882,12 +949,14 @@ fn putenv(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
     let name = env_bytes_arg(pos[0], "putenv")?;
     // `putenv` is defined over `name=value`, so a name carrying the separator
-    // could not be spelled back out of the environment it went into.
+    // could not be spelled back out of the environment it went into.  That one
+    // is a ValueError; an empty name is the syscall's own `EINVAL`.
     if name.as_bytes.contains(&b'=') {
         return Err(crate::PyError::value_error(
             "illegal environment variable name",
         ));
     }
+    check_env_name(&name.as_bytes)?;
     let value = env_bytes_arg(pos[1], "putenv")?;
     ENVIRONMENT
         .lock()
@@ -904,10 +973,181 @@ fn unsetenv(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             .ok_or_else(|| crate::PyError::type_error("unsetenv expected 1 argument, got 0"))?,
         "unsetenv",
     )?;
+    // `unsetenv` has no separate report for a name it cannot spell: both the
+    // empty one and one carrying `=` come back as `EINVAL`.
+    check_env_name(&name.as_bytes)?;
     // A name nothing set is a name already unset, which is what the syscall
     // reports and what `os.environ.__delitem__` relies on so that it can raise
     // the KeyError itself, against the caller's own spelling of the key.
     ENVIRONMENT.lock().unwrap().remove(&name.as_bytes);
+    Ok(pyre_object::w_none())
+}
+
+/// `os.uname_result` structseq — the five fields `uname` fills.
+fn uname_seq_type() -> PyObjectRef {
+    static UNAME_SEQ_TYPE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *UNAME_SEQ_TYPE.get_or_init(|| {
+        crate::_structseq::make_struct_seq(
+            "os.uname_result",
+            &["sysname", "nodename", "release", "version", "machine"],
+        ) as usize
+    }) as PyObjectRef
+}
+
+/// `posix.uname()` — the record wasi's own `uname` fills in, which names the
+/// guest rather than whatever machine the embedder happens to be.
+///
+/// `platform.uname` reads all five, and `platform._node` takes `nodename`
+/// through `socket.gethostname`, which wasi writes over this same call.
+fn uname(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let fields = ["wasi", "(none)", "0.0.0", "0.0.0", "wasm32"];
+    let _roots = pyre_object::gc_roots::push_roots();
+    let mut seq = Vec::with_capacity(fields.len());
+    for field in fields {
+        seq.push(pyre_object::gc_roots::pin_root(pyre_object::w_str_new(field)));
+    }
+    Ok(crate::_structseq::new_instance(uname_seq_type(), seq))
+}
+
+/// The first path argument of an entry point that takes more after it, with
+/// everything after it accepted and dropped: nothing here reads a mode, a time
+/// pair or a length, because nothing here writes.
+///
+/// `path_kw` is what that argument is called, which is not the same word for
+/// all of them -- the one-path calls name it `path` and the two-path calls
+/// name it `src` -- and every one of them can be spelled as a keyword.
+fn write_path_arg(
+    args: &[PyObjectRef],
+    name: &'static str,
+    path_kw: &'static str,
+) -> Result<crate::gateway::FsEncodedPath, crate::PyError> {
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let Some(w_path) = pos
+        .first()
+        .copied()
+        .or_else(|| crate::builtins::kwarg_get(kwargs, path_kw))
+    else {
+        return Err(crate::PyError::type_error(format!(
+            "{name}() missing required argument '{path_kw}' (pos 1)"
+        )));
+    };
+    crate::gateway::fsencode_path_or_fd_w(w_path, name, false)
+}
+
+/// The entry points a read-only mount publishes and refuses, named by the
+/// first path they were given.
+///
+/// wasi carries all of these, so a program that asks whether they exist is
+/// answered the way it would be on any wasi host; what it cannot do is write
+/// through them, and `EROFS` is what a read-only mount reports for that.
+fn refuse_write_path(
+    args: &[PyObjectRef],
+    name: &'static str,
+    path_kw: &'static str,
+) -> Result<PyObjectRef, crate::PyError> {
+    let resolved = write_path_arg(args, name, path_kw)?;
+    Err(crate::PyError::os_error_syscall(
+        crate::builtins::wasm_errno::EROFS,
+        resolved.w_path(),
+    ))
+}
+
+/// Two of the four `access` mode bits, which the constant table publishes
+/// under the same names.
+const X_OK: i64 = 1;
+const W_OK: i64 = 2;
+
+/// `posix.access(path, mode, ...)` — whether the name is there and the access
+/// asked for is one this mount grants.
+///
+/// The mount is read-only, so `W_OK` is false for everything; `X_OK` is true
+/// for a directory, which is the permission that makes one traversable, and
+/// false for a file, since nothing here can be executed.
+fn access(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::kwarg_reject_unknown(
+        kwargs,
+        &["path", "mode", "dir_fd", "effective_ids", "follow_symlinks"],
+        "access",
+    )?;
+    let Some(w_path) = crate::builtins::bind_pos_or_kw(pos, kwargs, 0, "path", "access", 2)? else {
+        return Err(crate::PyError::type_error(
+            "access() missing required argument 'path' (pos 1)",
+        ));
+    };
+    let Some(w_mode) = crate::builtins::bind_pos_or_kw(pos, kwargs, 1, "mode", "access", 2)? else {
+        return Err(crate::PyError::type_error(
+            "access() missing required argument 'mode' (pos 2)",
+        ));
+    };
+    let mode = unsafe { pyre_object::w_int_get_value(w_mode) };
+    let resolved = crate::gateway::fsencode_path_or_fd_w(w_path, "access", false)?;
+    let path = seam_path(&resolved.as_bytes);
+    let is_dir = crate::importing::source_is_dir(&path);
+    let exists = is_dir || crate::importing::source_file_size(&path).is_ok();
+    let granted = exists && (mode & W_OK) == 0 && ((mode & X_OK) == 0 || is_dir);
+    Ok(pyre_object::w_bool_from(granted))
+}
+
+/// `posix.write(fd, data)` — the two descriptors this guest has a sink for.
+///
+/// 1 and 2 are the embedder's output and error buffers, which is where
+/// `sys.stdout` and `sys.stderr` already write; anything else names either a
+/// read-only descriptor from the table or nothing at all.
+fn write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::kwarg_reject_unknown(kwargs, &[], "write")?;
+    if pos.len() != 2 {
+        return Err(crate::PyError::type_error(format!(
+            "write expected 2 arguments, got {}",
+            pos.len()
+        )));
+    }
+    let fd = unsafe { pyre_object::w_int_get_value(pos[0]) };
+    let data = unsafe {
+        if !pyre_object::bytesobject::is_bytes_like(pos[1]) {
+            return Err(crate::PyError::type_error(
+                "a bytes-like object is required, not 'str'",
+            ));
+        }
+        pyre_object::bytesobject::bytes_like_data(pos[1])
+    };
+    let delivered = match fd {
+        1 => crate::print_hook_emit_bytes(data),
+        2 => crate::stderr_hook_emit(data),
+        // Every other number is one nothing can be written through: a
+        // descriptor the table knows was opened for reading, and one it does
+        // not know is no descriptor at all.
+        _ => {
+            return Err(crate::PyError::os_error_syscall(
+                crate::builtins::wasm_errno::EBADF,
+                pyre_object::w_none(),
+            ));
+        }
+    };
+    if !delivered {
+        return Err(crate::PyError::os_error_syscall(
+            crate::builtins::wasm_errno::EBADF,
+            pyre_object::w_none(),
+        ));
+    }
+    Ok(pyre_object::w_int_new(data.len() as i64))
+}
+
+/// `posix.fsync(fd)` / `posix.fdatasync(fd)` — nothing to flush, but the
+/// descriptor is still checked: a read-only file has no dirty pages, and a
+/// number naming no descriptor is `EBADF` here as everywhere.
+fn sync_fd(args: &[PyObjectRef], name: &'static str) -> Result<PyObjectRef, crate::PyError> {
+    let Some(w_fd) = args.first().copied() else {
+        return Err(crate::PyError::type_error(format!(
+            "{name} expected 1 argument, got 0"
+        )));
+    };
+    let fd = unsafe { pyre_object::w_int_get_value(w_fd) } as i32;
+    if fd == 1 || fd == 2 {
+        return Ok(pyre_object::w_none());
+    }
+    with_raw_fd(fd, |_| Ok(()))?;
     Ok(pyre_object::w_none())
 }
 
@@ -1101,6 +1341,98 @@ pub fn register_module(ns: PyObjectRef) {
         "rmdir",
         crate::make_builtin_function("rmdir", |args| refuse_write(args, "rmdir")),
     );
+    // The rest of wasi's writing surface, published so that a program can ask
+    // for it and refused because the mount is read-only.  `mkdir` and `chmod`
+    // take a mode after the path, `utime` a pair of times, `truncate` a
+    // length: none is read, since none of them gets as far as writing.
+    crate::module_ns_store(
+        ns,
+        "mkdir",
+        crate::make_builtin_function("mkdir", |args| refuse_write_path(args, "mkdir", "path")),
+    );
+    crate::module_ns_store(
+        ns,
+        "chmod",
+        crate::make_builtin_function("chmod", |args| refuse_write_path(args, "chmod", "path")),
+    );
+    crate::module_ns_store(
+        ns,
+        "utime",
+        crate::make_builtin_function("utime", |args| refuse_write_path(args, "utime", "path")),
+    );
+    crate::module_ns_store(
+        ns,
+        "truncate",
+        crate::make_builtin_function("truncate", |args| refuse_write_path(args, "truncate", "path")),
+    );
+    // The two-path calls, named by their source the way `rename` reports it.
+    crate::module_ns_store(
+        ns,
+        "rename",
+        crate::make_builtin_function("rename", |args| refuse_write_path(args, "rename", "src")),
+    );
+    crate::module_ns_store(
+        ns,
+        "replace",
+        crate::make_builtin_function("replace", |args| refuse_write_path(args, "replace", "src")),
+    );
+    crate::module_ns_store(
+        ns,
+        "link",
+        crate::make_builtin_function("link", |args| refuse_write_path(args, "link", "src")),
+    );
+    crate::module_ns_store(
+        ns,
+        "symlink",
+        crate::make_builtin_function("symlink", |args| refuse_write_path(args, "symlink", "src")),
+    );
+    crate::module_ns_store(
+        ns,
+        "ftruncate",
+        crate::make_builtin_function_with_arity(
+            "ftruncate",
+            |args| {
+                sync_fd(args, "ftruncate")?;
+                Err(crate::PyError::os_error_syscall(
+                    crate::builtins::wasm_errno::EROFS,
+                    pyre_object::w_none(),
+                ))
+            },
+            2,
+        ),
+    );
+    crate::module_ns_store(
+        ns,
+        "fsync",
+        crate::make_builtin_function_with_arity("fsync", |args| sync_fd(args, "fsync"), 1),
+    );
+    crate::module_ns_store(
+        ns,
+        "fdatasync",
+        crate::make_builtin_function_with_arity("fdatasync", |args| sync_fd(args, "fdatasync"), 1),
+    );
+    crate::module_ns_store(ns, "access", crate::make_builtin_function("access", access));
+    crate::module_ns_store(
+        ns,
+        "write",
+        crate::make_builtin_function("write", write),
+    );
+    crate::module_ns_store(
+        ns,
+        "uname",
+        crate::make_builtin_function_with_arity("uname", uname, 0),
+    );
+    // `_io` asks this of every descriptor it wraps; no terminal is reachable,
+    // and a descriptor that is not one has no encoding of its own.
+    crate::module_ns_store(
+        ns,
+        "device_encoding",
+        crate::make_builtin_function_with_arity(
+            "device_encoding",
+            |_args| Ok(pyre_object::w_none()),
+            1,
+        ),
+    );
     // ── the constants those entry points are called with ──
     let constants: &[(&str, i64)] = &[
         ("O_RDONLY", oflag::RDONLY),
@@ -1117,8 +1449,8 @@ pub fn register_module(ns: PyObjectRef) {
         ("O_DIRECTORY", oflag::DIRECTORY),
         ("O_CLOEXEC", oflag::CLOEXEC),
         ("F_OK", 0),
-        ("X_OK", 1),
-        ("W_OK", 2),
+        ("X_OK", X_OK),
+        ("W_OK", W_OK),
         ("R_OK", 4),
         ("SEEK_SET", 0),
         ("SEEK_CUR", 1),

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -1147,7 +1147,15 @@ mod wasm_calendar {
             ),
             b'y' => format!("{:02}", year.rem_euclid(100)),
             b'Y' => year.to_string(),
-            b'z' => "+0000".to_string(),
+            // A time that does not say whether it is in daylight saving does
+            // not name a zone either, and both conversions come back empty.
+            b'z' | b'Z' if tm.tm_isdst < 0 => String::new(),
+            // The offset the caller supplied, in the `+HHMM` the C library
+            // writes: whole hours times a hundred plus the leftover minutes.
+            b'z' => {
+                let offset = tm.tm_gmtoff / 3600 * 100 + tm.tm_gmtoff % 3600 / 60;
+                format!("{}{:04}", if offset < 0 { '-' } else { '+' }, offset.abs())
+            }
             // A caller's own 9-tuple carries no zone, and neither does the
             // view `_gettmarg` takes of a `struct_time`, whose zone sits
             // outside the sequence.  A C library falls back to `tzname` for


### PR DESCRIPTION
Three wasm32 commits, on top of #1571.

## `_socket`: the four address converters and `gethostname`

wasi-libc defines `inet_aton`, `inet_ntoa`, `inet_pton`, `inet_ntop` and
`gethostname` — configure.ac checks the first three above its "not available in
WASI yet" line — but pyre published none of them there, so `platform.uname()`
raised on `socket.gethostname` and the converters were missing from a module
that otherwise resolves.

The wasm arm writes the four converters out rather than calling a library,
following musl, which is what wasi-libc is: `inet_aton` reads one to four parts
in decimal, octal or hex and refuses trailing text; `inet_pton` reads exactly
four octets with no redundant leading zero, and the IPv6 grammar without a scope
suffix; `inet_ntop` writes the dotted-quad tail only behind the IPv4-mapped
prefix, and compresses the longest run of zero groups. `gethostname` answers
`(none)`, the `nodename` wasi's `uname` reports and what its `gethostname` is
written over.

The entry points are now one copy for every target: the raw `inet_pton` /
`inet_ntop` calls moved behind safe `pton` / `ntop` primitives that both arms
provide, and `interp_socket.rs` names them through `rffi` as it already named
the rest. Two messages there now match the ones CPython raises: `embedded null
character`, and the family in `unknown address family {af}`.

Differentially tested against CPython over an address corpus: nine differences,
seven of them musl-vs-BSD divergences the guest should have, two pre-existing
message wordings, now fixed. Native output is unchanged apart from those two.

## `posix`, `builtins`: the writing half of wasi's surface

`test_os` could not even import — `os.utime` was absent, and behind it `os.uname`
and a dozen more entry points wasi carries. They are published now, and the
read-only mount refuses the ones that write:

- `mkdir`, `chmod`, `utime`, `truncate`, `rename`, `replace`, `link`, `symlink`
  and `ftruncate` report EROFS, named by their first path. That path can be
  spelled as a keyword, and it is not called the same word for all of them —
  `symlink(src=..., dst=...)` is how `test_os` calls it.
- `access` answers out of the seam: never for `W_OK`, for `X_OK` only on a
  directory.
- `write` reaches the embedder's two output buffers for descriptors 1 and 2;
  every other number is EBADF, since the table holds only reading ones.
- `fsync` and `fdatasync` check the descriptor and have nothing to flush.
- `uname` reports what wasi's own does: `wasi`, `(none)`, `0.0.0`, `0.0.0`,
  `wasm32`. `device_encoding` is None — no descriptor here is a terminal.

`resolve_against_cwd` now normalizes lexically. The seam is handed a name rather
than walked, and an embedded filesystem answers an exact key, so `chdir("..")`
left `getcwd` reporting `lib-python/3/..` and would have found nothing under
that spelling.

`putenv` and `unsetenv` refuse an empty name and one carrying `=` with EINVAL,
and pass the path converter's own errors through, which is where the ValueError
for an embedded NUL comes from. `chdir` no longer accepts a `dir_fd` keyword:
`fchdir` is the call that would take one.

Opening a directory through `open()` reported ENOENT, because the seam reports a
directory read as a missing file; it is EISDIR, which `os.open` plus `os.read`
already answered for the same name.

## `time`: `%z` from `tm_gmtoff`

The wasm arm wrote `+0000` for every time, while `%Z` beside it already reported
the zone the same argument carried. `_gettmarg` records element 10 of an
11-element sequence in `tm_gmtoff`, so a caller that supplies an offset now gets
it back. Both conversions come back empty for a time whose `tm_isdst` is
negative, since a time that does not say whether it is in daylight saving names
no zone either.

## Verification

- `pyre/check.py --backend dynasm,wasm` — dynasm 516/516, wasm 509/509
- `cargo test --all --features dynasm,cpyext --no-fail-fast` — 0 failures
- guest, wasm32-unknown-unknown: `test_unittest` 969 run / 0 err / 0 fail /
  68 skip; `test_time` 63 / 0 / 0 / 22; module census 98/98
- guest `test_os`, which previously failed at import: 375 run / 80 err / 0 fail
  / 235 skip. 78 of the errors are EROFS from the read-only mount, one is the
  absence of a writable temporary directory, and one is `os.times`, which
  wasi-libc does not carry.

## Not addressed here

- pyre's wasm `errno` numbers are BSD's, not wasi's (`EAGAIN` 35 vs 6,
  `ENOTSUP` 45 vs 58, `EROFS` 30 vs 69, `EAFNOSUPPORT` 47 vs 5). They are
  self-consistent with pyre's own `errno` module; aligning them is a
  coordinated two-table change.
- `os.times` is left absent, matching wasi-libc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded WebAssembly support for socket address conversion, hostname detection, and common networking constants.
  * Added WebAssembly platform information through `os.uname()`.
  * Added filesystem and descriptor operations, including access checks, writes, syncing, and truncation.
  * Added clear read-only and unsupported-operation responses for filesystem changes.

* **Bug Fixes**
  * Correctly reports directory paths as directory errors when opening files.
  * Normalizes WebAssembly paths and validates environment variable names.
  * Improved timezone formatting for unknown daylight-saving status and non-zero offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->