### PR TITLE
jit-trace, optimizeopt: settle a Keep hand-off's journals, and decline where the fix-point panicked

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4456,17 +4456,32 @@ impl OptUnroll {
                 let num_short_jump_args = short_jump_args.len();
                 // unroll.py `_map_args(mapping, args)`: Const passes
                 // through unchanged, non-Const requires mapping.
-                let mapped_jump_args: Vec<OpRef> = short_jump_args
-                    .iter()
-                    .map(|jump_arg| {
-                        let mapped = if jump_arg.is_constant() {
-                            *jump_arg
-                        } else {
-                            *mapping.get(jump_arg).expect("mapping missing jump_arg")
+                // An unmapped non-Const arg is the same KeyError upstream's
+                // `_map_args` raises, and the other two sites in this function
+                // already answer it by declining to InvalidLoop rather than
+                // substituting the preamble's box. Answer it the same way here
+                // instead of aborting the process.
+                let mut mapped_jump_args: Vec<OpRef> = Vec::with_capacity(num_short_jump_args);
+                for jump_arg in short_jump_args.iter() {
+                    let mapped = if jump_arg.is_constant() {
+                        *jump_arg
+                    } else {
+                        let Some(&mapped) = mapping.get(jump_arg) else {
+                            if crate::optimizeopt::majit_log_enabled() {
+                                eprintln!(
+                                    "[jit] inline_short_preamble: unmapped short jump arg \
+                                     {jump_arg:?} in the force fix-point — InvalidLoop"
+                                );
+                            }
+                            ctx.signal_invalid_loop(
+                                "inline_short_preamble: unmapped jump arg in force fix-point",
+                            );
+                            return Vec::new();
                         };
-                        ctx.get_replacement_opref(mapped)
-                    })
-                    .collect();
+                        mapped
+                    };
+                    mapped_jump_args.push(ctx.get_replacement_opref(mapped));
+                }
                 // unroll.py:419-421
                 for &arg in args_no_virtuals.iter().chain(mapped_jump_args.iter()) {
                     let _ = optimizer.force_box(arg, ctx);

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1979,14 +1979,18 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
                 // The sub-walks above already applied each frame's eager stores
                 // and journaled them; hand those journals to the root walk so its
                 // epilogue settles them exactly once.
-                return full_body_walk_trace(
-                    ctx,
-                    sym,
-                    w_code,
-                    root_py_pc,
-                    cf_addr,
-                    WalkJournals::Keep,
-                );
+                let action =
+                    full_body_walk_trace(ctx, sym, w_code, root_py_pc, cf_addr, WalkJournals::Keep);
+                // That epilogue is not guaranteed to run: `full_body_walk_trace`
+                // has declines ahead of it and `run_perfn_walk` has its own
+                // early exits, none of which touch a journal. Whatever the root
+                // walk did not settle is the sub-walks' own unclaimed entries,
+                // and a discarded trace's guard replay needs them unwound.
+                // Sound unconditionally because both settles drain: after a
+                // committed or rolled-back epilogue every log is already empty
+                // and this is a no-op.
+                crate::jitcode_dispatch::fbw_store_journal_rollback();
+                return action;
             }
             crate::jitcode_dispatch::census_record("P2Drain::ResultSlotUnresolved");
         }
@@ -2095,6 +2099,10 @@ fn drive_bridge_carrier_walk<Sym: WalkSym>(
             // seed standing and leak it into a later unrelated walk. Clear
             // any residual seed so exactly this walk can observe it.
             let _ = crate::jitcode_dispatch::take_carrier_raise_seed();
+            // The same early decline leaves the journals this `Keep` handed
+            // over unsettled; drain them for the same reason. A no-op once
+            // the root walk's epilogue has run.
+            crate::jitcode_dispatch::fbw_store_journal_rollback();
             return action;
         }
     }


### PR DESCRIPTION
Two JIT defects found by re-verifying 22 memory notes that recorded an open defect. Both were confirmed by adversarial re-checking, and one claim from the same round was refuted and is **not** in this PR (see below).

## `jit-trace: settle the journals a WalkJournals::Keep hand-off leaves behind`

Both `WalkJournals::Keep` sites hand the drain sub-walk's journals to the root walk on a stated contract: *"hand those journals to the root walk so its epilogue settles them exactly once."*

That epilogue is `run_perfn_walk`'s, and **ten returns reach the caller without it** — three declines in `full_body_walk_trace` ahead of both the `WalkJournals` handling and the `run_perfn_walk` call, plus seven `return None` exits inside `run_perfn_walk`. None touches a journal. Because both sites return the walk's action directly, `drive_bridge_carrier_walk`'s own commit/rollback is bypassed too. The sub-walk's eager stores are then left standing for the blackhole replay to apply a second time.

The second site already carries a defensive `take_carrier_raise_seed()` for exactly this early-decline path — the journal half was missing beside it.

**Why the added call is unconditional and safe:** both settles drain. `fbw_store_journal_commit` `clear()`s every log; `fbw_store_journal_rollback` pops until empty. After either epilogue the added call finds nothing to do, so it is a no-op on every path that already settled.

## `optimizeopt: decline the fix-point's unmapped jump arg instead of panicking`

`inline_short_preamble` maps args through `mapping` at three points, matching `unroll.py`'s three `_map_args` calls. Two answer an unmapped non-Const arg by logging and signalling `InvalidLoop`, for the reason their comments record: substituting the unmapped arg hands the JUMP the preamble's box, so the back edge re-supplies the loop-entry value every iteration and a field the body mutates reads as loop-invariant.

The third — inside the force fix-point — used `.expect("mapping missing jump_arg")` and **aborted the process**. `mapping[box]` raises the same `KeyError` at all three upstream, so this applies the answer the function had already settled on to the site that was missing it.

## Verification

`python3 pyre/check.py --backend dynasm` → `ALL PASSED: dynasm 516/516`, exit 0.

Re-run after this branch was rebased onto current `main` (it was previously based on the tree that became #1576).

**Neither change has a witness fixture of its own, and I want that on the record.** The journal path needs a multi-frame bridge carrier *plus* a root walk that takes one of the ten pre-settle exits; the unroll path needs an unmapped jump arg surviving into the force fix-point. The cheap instrument alternative — a `fbw_diag` counter — is not cheap here: `LABELS` feeds `RING_BASE`, whose copy in `pyre-wasm-runner` must move with it, and a new jitstats key forces a `--snapshot` re-record across all 516 fixtures. The corpus gate is the regression protection for now.

## Refuted in the same round, deliberately not fixed

`FBW_FINISH_PAYLOAD` was reported as an unrooted inline `OpRef::ConstPtr(GcRef)` next to its rooted sibling `FBW_FINISH_CONCRETE`. It is **not** a defect: `fbw_finish_payload_take()` runs immediately after `run_perfn_walk` returns, while the compile runs later in the jitdriver's `TraceAction::Finish` arm. The Cell is already `None` before anything allocates. The sibling is rooted for the opposite reason — it *outlives* the compile.

A third finding, a genuine unrooted window over the recorded op list between `self.tracing.take()` and the gc table, survived four refutation attempts but is **latent**: no GC allocation was found anywhere in optimize/rewrite/assemble. That contradicts two shipped walkers whose own docs justify themselves by that window, so it needs a measurement, not a patch. Left open rather than fixed blind — the candidate fix parks a raw address of an in-flight `Vec<Op>`, which would trade a latent bug for a live dangling-pointer risk.
