### PR TITLE
majit: decide hotness before building tracing state, and carry an opaque deref write through annotation

### DIFF
--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -818,7 +818,7 @@ use crate::pyjitpl::{
 };
 use crate::resume::ResumeLayoutSummary;
 use crate::virtualizable::VirtualizableInfo;
-use crate::warmstate::FunctionEntryStep;
+use crate::warmstate::{FunctionEntryStep, HotResult};
 use majit_gc::GcAllocator;
 use majit_ir::OpRef;
 use majit_ir::descr::DescrRef;
@@ -1429,20 +1429,28 @@ impl JitDriverStaticData {
         self.portal_calldescr = Some(descr);
     }
 
-    /// Get only the green variables.
-    pub fn greens(&self) -> Vec<&JitDriverVar> {
-        self.vars
-            .iter()
-            .filter(|v| v.kind == VarKind::Green)
-            .collect()
+    /// Index separating the constructor-preserved `[greens..., reds...]`
+    /// layout. Keeping the declaration partition in `vars` lets both accessors
+    /// below borrow slices instead of allocating pointer vectors.
+    fn green_red_split(&self) -> usize {
+        let split = self.vars.partition_point(|var| var.kind == VarKind::Green);
+        debug_assert!(
+            self.vars[split..]
+                .iter()
+                .all(|var| var.kind == VarKind::Red),
+            "JitDriverStaticData vars must keep greens before reds"
+        );
+        split
     }
 
-    /// Get only the red variables.
-    pub fn reds(&self) -> Vec<&JitDriverVar> {
-        self.vars
-            .iter()
-            .filter(|v| v.kind == VarKind::Red)
-            .collect()
+    /// Get only the green variables without allocating.
+    pub fn greens(&self) -> &[JitDriverVar] {
+        &self.vars[..self.green_red_split()]
+    }
+
+    /// Get only the red variables without allocating.
+    pub fn reds(&self) -> &[JitDriverVar] {
+        &self.vars[self.green_red_split()..]
     }
 
     /// Number of green variables.
@@ -4991,9 +4999,9 @@ impl<S: JitState> JitDriver<S> {
     /// Takes the green key's hash eagerly and the key itself lazily.
     ///
     /// Only the hash is needed unconditionally — it selects the cell and
-    /// answers `has_compiled_loop`. The typed [`GreenKey`] is read at exactly
-    /// one place, `Self::maybe_start_tracing`'s `on_back_edge_typed` call,
-    /// which is reached only after `back_edge_internal`'s early returns
+    /// answers `has_compiled_loop`. The typed [`GreenKey`] is read only by the
+    /// cell-resolution/decision path and, on a tracing start, by the tracing
+    /// commit. Both are reached only after `back_edge_internal`'s early returns
     /// (already tracing, `!can_trace`, cross-loop-cut decline, and the whole
     /// `has_compiled_loop` branch — i.e. every entry into compiled code).
     /// Building it eagerly spent the key's `values` / `types` vectors on those
@@ -7008,6 +7016,28 @@ impl<S: JitState> JitDriver<S> {
         // the same two checks, and folding three doors into one slot would say
         // nothing about any of them.
         crate::mc_diag_bump(61); // mst_entered
+        // warmstate.py `maybe_compile_and_run` consults the cell before
+        // `bound_reached` builds tracing state.  Pyre's abort ceiling is the
+        // equivalent permanent refusal: `back_edge_internal` has already
+        // resolved the bucket hash to this one cell key, so the latch can be
+        // answered without constructing frontend state.  Keep slot 81 on the
+        // same population as the mirrored refusal in
+        // `maybe_compile_decision_with_meta`.
+        if self.meta.warm_state.is_ceiling_latched(green_key) {
+            crate::mc_diag_bump(81); // abort_ceiling_refused
+            return false;
+        }
+
+        match self
+            .meta
+            .on_back_edge_typed_decision(green_key, (state.code_ptr(), target_pc))
+        {
+            HotResult::NotHot | HotResult::AlreadyTracing | HotResult::RunCompiled => {
+                return false;
+            }
+            HotResult::StartTracing => {}
+        }
+
         let meta = state.build_meta(target_pc, env);
         let descriptor = self.driver_descriptor_for(state, &meta);
         // Resolved here with the descriptor and carried to both ends of
@@ -7029,15 +7059,13 @@ impl<S: JitState> JitDriver<S> {
             return false;
         }
 
-        match self.meta.on_back_edge_typed(
+        match self.meta.start_back_edge_trace(
             green_key,
             (state.code_ptr(), target_pc),
-            // Neither the typed key nor the descriptor is built here. Both are
-            // read at exactly one site — the `StartTracing` arm inside
-            // `on_back_edge_typed` — so the factory and a borrow are passed
-            // instead of a built key and a deep clone. Every earlier return in
-            // `back_edge_internal`, and both returns above, leave them unbuilt;
-            // the `Interpret` and `RunCompiled` arms drop them unread.
+            // Neither the typed key nor the descriptor is built before the
+            // counter decision. Both are consumed only while committing its
+            // `StartTracing` answer, so the factory and a borrow avoid a deep
+            // clone until this cold arm.
             structured_green_key,
             descriptor.as_deref(),
             &live_values,
@@ -9107,6 +9135,12 @@ mod tests {
     }
 
     #[derive(Default)]
+    struct CountingDoorState {
+        build_meta_calls: std::cell::Cell<usize>,
+        extract_live_values_calls: std::cell::Cell<usize>,
+    }
+
+    #[derive(Default)]
     struct TypedInputState {
         raw_live_values: Vec<i64>,
         typed_live_values: Vec<Value>,
@@ -9151,6 +9185,42 @@ mod tests {
         fn restore_values(&mut self, _meta: &Self::Meta, values: &[Value]) {
             self.restored_values = values.to_vec();
         }
+
+        fn collect_jump_args(_sym: &Self::Sym) -> Vec<OpRef> {
+            Vec::new()
+        }
+
+        fn validate_close(_sym: &Self::Sym, _meta: &Self::Meta) -> bool {
+            true
+        }
+    }
+
+    impl JitState for CountingDoorState {
+        type Meta = ();
+        type Sym = ();
+        type Env = ();
+
+        fn build_meta(&self, _header_pc: usize, _env: &Self::Env) -> Self::Meta {
+            self.build_meta_calls.set(self.build_meta_calls.get() + 1);
+        }
+
+        fn extract_live(&self, _meta: &Self::Meta) -> Vec<i64> {
+            Vec::new()
+        }
+
+        fn extract_live_values(&self, _meta: &Self::Meta) -> Vec<Value> {
+            self.extract_live_values_calls
+                .set(self.extract_live_values_calls.get() + 1);
+            Vec::new()
+        }
+
+        fn create_sym(_meta: &Self::Meta, _header_pc: usize) -> Self::Sym {}
+
+        fn is_compatible(&self, _meta: &Self::Meta) -> bool {
+            true
+        }
+
+        fn restore(&mut self, _meta: &Self::Meta, _values: &[i64]) {}
 
         fn collect_jump_args(_sym: &Self::Sym) -> Vec<OpRef> {
             Vec::new()
@@ -9481,6 +9551,57 @@ mod tests {
             crate::mc_diag(61) >= before + 2,
             "mst_entered did not move across two back edges that reached the door"
         );
+    }
+
+    #[test]
+    fn cold_back_edges_do_not_build_frontend_state() {
+        let mut driver = JitDriver::<CountingDoorState>::new(10);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
+        let key = 4299u64;
+        let mut state = CountingDoorState::default();
+
+        for _ in 0..4 {
+            assert!(
+                driver
+                    .back_edge_or_run_compiled_keyed(key, 7, &mut state, &(), || {})
+                    .is_none()
+            );
+        }
+
+        assert!(!driver.is_tracing());
+        assert_eq!(state.build_meta_calls.get(), 0);
+        assert_eq!(state.extract_live_values_calls.get(), 0);
+    }
+
+    #[test]
+    fn ceiling_latched_back_edge_skips_frontend_state() {
+        use crate::warmstate::MAX_TRACE_ABORT_COUNT;
+
+        let mut driver = JitDriver::<CountingDoorState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
+        let key = 4343u64;
+        assert!(matches!(
+            driver.meta.on_back_edge(key, &[]),
+            BackEdgeAction::Interpret
+        ));
+        assert!(matches!(
+            driver.meta.on_back_edge(key, &[]),
+            BackEdgeAction::StartedTracing
+        ));
+        driver.meta.abort_trace(false);
+        for _ in 1..MAX_TRACE_ABORT_COUNT {
+            driver.meta.warm_state_mut().abort_tracing(key, false);
+        }
+        assert!(driver.meta.warm_state.is_ceiling_latched(key));
+
+        let mut state = CountingDoorState::default();
+        assert!(
+            driver
+                .back_edge_or_run_compiled_keyed(key, 7, &mut state, &(), || {})
+                .is_none()
+        );
+        assert_eq!(state.build_meta_calls.get(), 0);
+        assert_eq!(state.extract_live_values_calls.get(), 0);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -1562,16 +1562,14 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
 /// it.  A `debug_assert!` cannot see that; the imbalance is only visible across
 /// a whole run.
 ///
-/// 61-63 are `maybe_start_tracing`'s two early returns and their denominator,
-/// which is 61 and is bumped unconditionally at entry so the two refusals can
-/// be read as fractions rather than bare totals: 62 = `sync_before` returned
-/// false, 63 = `live_values_match_descriptor` returned false. Both return
-/// before `on_back_edge_typed`, so `61 - 62 - 63` is the number of calls that
-/// reach the hotness counter at all. The two are counted separately because a
-/// deferral past the counter is worth the cost of whichever refusal dominates,
-/// and nothing currently says which does; a slot reading 0 across the corpus
-/// says its refusal never fires, which is a different design than one that
-/// fires often.
+/// 61-63 are `maybe_start_tracing`'s two trace-start refusals and their
+/// denominator. 61 is bumped unconditionally at entry, before the cheap
+/// hotness decision, so it remains the population against which both refusal
+/// rates are read: 62 = `sync_before` returned false, 63 =
+/// `live_values_match_descriptor` returned false. The two refusal checks run
+/// only after the counter answers `StartTracing`, matching `warmstate.py`'s
+/// tick-before-`bound_reached` ordering, and are counted separately because
+/// they reject different frontend contracts.
 ///
 /// 64-66 split slot 23, which is bumped on the disjunction
 /// `cell.is_compiled() || cell.is_tracing()` and so cannot attribute: the

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5206,15 +5206,65 @@ impl<M: Clone> MetaInterp<M> {
         }
     }
 
-    /// `green_key_values` and `driver_descriptor` arrive unbuilt — a key
-    /// factory and a borrow — because only the `StartTracing` arm below
-    /// consumes them.  warmstate.py `maybe_compile_and_run` orders the
-    /// decision the same way: greenargs, hash, `lookup_chain`, then
-    /// `jitcounter.tick` (`:467`), and only past the counter does it reach
-    /// `confirm_enter_jit` (`:501`) and the red-argument extraction loop
-    /// (`:503-506`).  `bound_reached` is handed `*args` raw for exactly this
-    /// reason.  Building either eagerly at the call site pays for both on the
-    /// `NotHot` / `RunCompiled` arms, which drop them unread.
+    /// Cheap half of `warmstate.py maybe_compile_and_run`: resolve the cell and
+    /// tick its counter, but do not build or consume tracing state.
+    ///
+    /// Upstream orders the decision the same way: greenargs, hash,
+    /// `lookup_chain`, then `jitcounter.tick` (`warmstate.py
+    /// maybe_compile_and_run`), and only the overflow calls `bound_reached`.
+    /// Returning `StartTracing` here is permission to build the frontend
+    /// snapshot and call [`Self::start_back_edge_trace`]; it has not marked the
+    /// cell as tracing yet, so a later descriptor/live-value refusal remains a
+    /// clean refusal rather than stranding a `JC_TRACING` cell.
+    pub(crate) fn on_back_edge_typed_decision(
+        &mut self,
+        green_key: u64,
+        green_key_raw: (usize, usize),
+    ) -> HotResult {
+        if self.tracing.is_some() {
+            return HotResult::AlreadyTracing;
+        }
+
+        // warmstate.py:446-511 — decide via the typed greenkey when the
+        // raw (code, pc) is available so the installed cell carries a
+        // `comparekey` when the start is committed, matching
+        // `JitCell.get_jitcell_for_args`.  The decision-only form deliberately
+        // leaves that commit to `start_back_edge_trace`, after the caller's
+        // frontend refusals.
+        match Self::with_typed_decision_key(green_key, green_key_raw, |key| {
+            self.warm_state
+                .maybe_compile_decision_with_key(key, |_| true)
+        }) {
+            Some(hot) => hot,
+            None => self.warm_state.maybe_compile_decision(green_key),
+        }
+    }
+
+    /// Commit a `StartTracing` answer from
+    /// [`Self::on_back_edge_typed_decision`] and consume the expensive tracing
+    /// arguments.  `bound_reached` re-runs the cell policy without ticking the
+    /// counter, then marks the cell and sets up the trace.
+    pub(crate) fn start_back_edge_trace(
+        &mut self,
+        green_key: u64,
+        green_key_raw: (usize, usize),
+        green_key_values: Option<&dyn Fn() -> majit_ir::GreenKey>,
+        driver_descriptor: Option<&JitDriverStaticData>,
+        live_values: &[Value],
+    ) -> BackEdgeAction {
+        self.bound_reached(
+            green_key,
+            green_key_raw,
+            green_key_values.map(|make_key| make_key()),
+            driver_descriptor.cloned(),
+            live_values,
+        )
+    }
+
+    /// Compatibility wrapper that performs both halves in one call.
+    ///
+    /// `green_key_values` and `driver_descriptor` still arrive as a factory
+    /// and a borrow because only the `StartTracing` arm consumes them.
     pub fn on_back_edge_typed(
         &mut self,
         green_key: u64,
@@ -5223,53 +5273,15 @@ impl<M: Clone> MetaInterp<M> {
         driver_descriptor: Option<&JitDriverStaticData>,
         live_values: &[Value],
     ) -> BackEdgeAction {
-        if self.tracing.is_some() {
-            return BackEdgeAction::AlreadyTracing;
-        }
-
-        // warmstate.py:446-511 — decide via the typed greenkey when the
-        // raw (code, pc) is available so the installed cell carries a
-        // `comparekey` (`maybe_compile_with_key` → `ensure_cell_for_key`),
-        // matching `JitCell.get_jitcell_for_args`. The cell bucket is
-        // `key.get_uhash()` == `make_green_key`, so the legacy u64 hash
-        // flow still resolves to the same cell.
-        let hot = match Self::with_typed_decision_key(green_key, green_key_raw, |key| {
-            self.warm_state.maybe_compile_with_key(key)
-        }) {
-            Some(h) => h,
-            None => self.warm_state.maybe_compile(green_key),
-        };
-        match hot {
+        match self.on_back_edge_typed_decision(green_key, green_key_raw) {
             HotResult::NotHot => BackEdgeAction::Interpret,
-            HotResult::StartTracing => {
-                self.prepare_trace_start_runtime();
-                // `maybe_compile_with_key` has just installed (or found) this
-                // key's cell, so resolving now names it — and the trace, its
-                // `compiled_loops` entry, its `JitCellToken::green_key` and
-                // every `rd_loop_token` stamped off that token all inherit the
-                // CELL key rather than a bucket hash they would each have to
-                // re-resolve. `warmstate.py:511 raise
-                // EnterJitAssembler(procedure_token, *execute_args)` carries
-                // the resolved artifact on for the same reason.
-                let green_key = Self::with_typed_decision_key(green_key, green_key_raw, |key| {
-                    self.warm_state.cell_key_for(key)
-                })
-                .flatten()
-                .unwrap_or(green_key);
-                // The only reader of either value.  The key factory closes over
-                // `Copy` locals bound once at the back edge
-                // (`jit_interp/mod.rs` `__green_slotN`), and the descriptor
-                // borrow points at a snapshot `Arc` built by
-                // `driver_descriptor_for`, so neither observes anything the
-                // counter consultation above may have changed.
-                self.setup_tracing(
-                    green_key,
-                    green_key_raw,
-                    green_key_values.map(|make_key| make_key()),
-                    driver_descriptor.cloned(),
-                    live_values,
-                )
-            }
+            HotResult::StartTracing => self.start_back_edge_trace(
+                green_key,
+                green_key_raw,
+                green_key_values,
+                driver_descriptor,
+                live_values,
+            ),
             HotResult::AlreadyTracing => BackEdgeAction::AlreadyTracing,
             HotResult::RunCompiled => BackEdgeAction::RunCompiled,
         }

--- a/majit/majit-metainterp/tests/jit_driver_runtime_parity.rs
+++ b/majit/majit-metainterp/tests/jit_driver_runtime_parity.rs
@@ -1596,7 +1596,7 @@ fn declarative_driver_rejects_live_value_type_mismatch() {
 }
 
 #[test]
-fn declarative_driver_can_reject_virtualizable_sync_before_tracing_starts() {
+fn declarative_driver_can_reject_virtualizable_sync_after_the_counter_fires() {
     let descriptor =
         DeclarativeDriver::descriptor(&[Type::Int, Type::Int], &[Type::Ref, Type::Int])
             .expect("descriptor should build");
@@ -1620,7 +1620,10 @@ fn declarative_driver_can_reject_virtualizable_sync_before_tracing_starts() {
             .back_edge_keyed(77, 77, &mut state, &(), || {})
             .is_none()
     );
-    assert_eq!(state.before_sync_calls, 2);
+    // `warmstate.py maybe_compile_and_run` ticks before `bound_reached`: the
+    // cold edge does not build/sync frontend state, while the hot edge still
+    // gives `sync_before` the same veto over the tracing start.
+    assert_eq!(state.before_sync_calls, 1);
     assert_eq!(state.after_sync_calls, 0);
     assert!(!driver.is_tracing());
 }

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2029,6 +2029,12 @@ pub(crate) fn populate_call_registry_from_call_graphs(
     // is non-overwriting (skips keys the `function_graphs` pass already
     // registered) and idempotent.
     register_unsafe_fn_stubs(registry, unsafe_fn_stubs);
+    // `__deref_write(ptr, value)` is the MIR front end's opaque store
+    // marker.  Give the annotator the same declared-external carrier as the
+    // Rust-stdlib leaves below so one unfollowable store does not stop the
+    // whole graph; the marker is absent from `CallControl::function_graphs`,
+    // so the original call remains residual at the codewriter boundary.
+    register_deref_write_external(registry);
     // Foreign Rust-stdlib externals (`core::*` / `std::*` / `fmt::*`)
     // the interpreter calls inline.  Declared opaque here — the rtyper
     // residualizes them rather than tracing into low-level plumbing, the
@@ -2778,6 +2784,49 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
     ),
 ];
 
+/// Register one opaque external through the annotator-only stub carrier.
+/// The caller retains ownership of which table or synthetic path declares
+/// the external; this helper keeps their registration semantics identical.
+fn register_opaque_external(
+    registry: &CallRegistry,
+    segments: &[&str],
+    argnames: &[&str],
+    return_lltype: LowLevelType,
+) {
+    let signature = Signature::new(
+        argnames.iter().map(|n| (*n).to_string()).collect(),
+        None,
+        None,
+    );
+    let Some(stub_pygraph) = build_stub_pygraph_for_lltype(
+        segments.last().copied().unwrap_or_default().to_string(),
+        signature.clone(),
+        return_lltype,
+    ) else {
+        return;
+    };
+    let key = FunctionPathKey::from_segments(segments.iter().map(|s| s.to_string()));
+    if registry.lookup(&key).is_some() {
+        return;
+    }
+    registry.register_callee(key, signature, stub_pygraph);
+}
+
+/// Declare the opaque MIR deref-write marker to the annotator.
+///
+/// This is a two-parameter, `Void` external.  It is intentionally registered
+/// only in the `CallRegistry`: the codewriter's graph registry has no body for
+/// it and therefore sends the original `Call(__deref_write)` through
+/// `handle_residual_call`, preserving the store as a carried side effect.
+pub(crate) fn register_deref_write_external(registry: &CallRegistry) {
+    register_opaque_external(
+        registry,
+        &["__deref_write"],
+        &["ptr", "value"],
+        LowLevelType::Void,
+    );
+}
+
 /// Register the [`FOREIGN_STDLIB_EXTERNALS`] table into `registry`.
 ///
 /// Faithful analog of `extfuncregistry.py`'s `_register` table being
@@ -2794,23 +2843,7 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
 /// `CallControl::function_graphs`, so they never compile into JITCode).
 pub(crate) fn register_foreign_stdlib_externals(registry: &CallRegistry) {
     for (segments, argnames, return_lltype) in FOREIGN_STDLIB_EXTERNALS {
-        let signature = Signature::new(
-            argnames.iter().map(|n| (*n).to_string()).collect(),
-            None,
-            None,
-        );
-        let Some(stub_pygraph) = build_stub_pygraph_for_lltype(
-            segments.last().copied().unwrap_or_default().to_string(),
-            signature.clone(),
-            return_lltype.clone(),
-        ) else {
-            continue;
-        };
-        let key = FunctionPathKey::from_segments(segments.iter().map(|s| s.to_string()));
-        if registry.lookup(&key).is_some() {
-            continue;
-        }
-        registry.register_callee(key, signature, stub_pygraph);
+        register_opaque_external(registry, segments, argnames, return_lltype.clone());
     }
 }
 
@@ -5924,6 +5957,27 @@ mod tests {
                 ]))
                 .is_some()
         );
+    }
+
+    #[test]
+    fn deref_write_external_has_two_parameter_void_stub() {
+        use crate::annotator::bookkeeper::Bookkeeper;
+        use crate::translator::rtyper::call_registry::CallRegistry;
+
+        let registry = CallRegistry::new(std::rc::Rc::new(Bookkeeper::new()));
+        register_deref_write_external(&registry);
+        let entry = registry
+            .lookup(&FunctionPathKey::from_segments(["__deref_write"]))
+            .expect("opaque deref-write marker must be registered");
+        assert_eq!(
+            entry.function_desc.borrow().signature.argnames,
+            vec!["ptr".to_string(), "value".to_string()]
+        );
+        assert!(
+            !entry.function_desc.borrow().cache.borrow().is_empty(),
+            "the annotator needs a cached stub graph for return inference"
+        );
+        assert_eq!(registry.len(), 1);
     }
 
     /// Pin the layering invariant


### PR DESCRIPTION
Two changes to the metainterp's warm-up door and to the MIR front end's
handling of an unfollowable store. Both were found by a new host-side
benchmark that pairs a JIT-consulting build against a plain one.

### `majit: decide hotness before building tracing state`

`JitDriver::maybe_start_tracing` built a state meta, a driver descriptor and a
live-value vector *before* asking whether the green key was hot. On a
permanently banned key that work is thrown away on every back edge.

`warmstate.py maybe_compile_and_run` orders it the other way round
(`rpython/jit/metainterp/warmstate.py:418-500`): greenargs, hash,
`lookup_chain`, `jitcounter.tick`, and only on overflow `bound_reached` —
state construction is behind the tick.

- `on_back_edge_typed` splits into `on_back_edge_typed_decision` (cell resolve
  and tick, returns `HotResult`) and `start_back_edge_trace` (commits via
  `bound_reached`). `on_back_edge_typed` stays as a compatibility wrapper.
- `warmstate.rs` gains `is_ceiling_latched`, mirroring the `!dead_token &&
  abort_count >= MAX_TRACE_ABORT_COUNT` condition at `warmstate.rs:1079`, with
  a test that pins the two to each other.
- `JitDriverStaticData::greens()` / `reds()` return slices via
  `partition_point` instead of allocating a `Vec` per call.

Measured on a second interpreter that drives this API: door entries that build
no state now cost nothing, and `mc_diag` reports `mst_entered=79424053` against
`abort_ceiling_refused=79359948` — 99.93% of consultations were reaching
allocation before the ban was consulted.

Two tests assert the new ordering with a state that counts `build_meta` and
`extract_live_values` calls: both are 0 for a cold key and for a
ceiling-latched one.

### `majit-translate: register __deref_write as an annotator-only opaque external`

`translate_op` errored on the synthetic path `__deref_write`, and that error
failed the whole graph's annotation. Five graphs in the corpus died on it,
including a 3181-op portal.

`__deref_write(ptr, value) -> Void` now gets the same declared-external stub
carrier the foreign-stdlib leaves use. It has no entry in
`CallControl::function_graphs`, so the codewriter still sends the original call
through `handle_residual_call` and the store stays a carried side effect.

`register_foreign_stdlib_externals`'s per-row body is extracted as
`register_opaque_external` and shared with it.

Measured on the same corpus: real-rtyper accepts 39 → 44, never-a-subject
175 → 174, and no `[PREPASS phaseA fail]` row names `__deref_write` any more.

Two mechanisms were considered and rejected: a flowspace adapter arm (no
faithful high-level opaque-store operation) and `IndirectCall { graphs: None }`
(it would interpret the data pointer as a callable target).

### Gates

`cargo fmt --check`, `cargo test -p majit-translate`, `cargo test -p
majit-metainterp --no-default-features --features dynasm`, `cargo test -p
pyre-jit-trace`, and `python3 pyre/check.py` (dynasm 516/516, cranelift
516/516, wasm 509/509) were green on the pre-rebase base. This branch has since
been replayed onto a newer `main`; `git range-diff` reports both patches
byte-identical, and CI grades the combination.
