### PR TITLE
jit: restore the unary-negative int fold; _cffi_backend: unbreak main and address #1570 review findings

### DIFF
--- a/pyre/bench/synth/unary_negative.py
+++ b/pyre/bench/synth/unary_negative.py
@@ -1,4 +1,5 @@
 # pyre-check: max-pypy-ratio=8
+# pyre-check: spec-folds=unary_negative_descent,unary_negative_int
 # The trip count puts pypy's execution above the startup-subtraction floor, so
 # this ratio is a measurement. The loop runs at parity: ubuntu 1.7x / 1.7x /
 # 1.6x (dynasm / cranelift / wasm), macos 1.1x / 0.6x, windows 1.2x / 1.5x.
@@ -29,6 +30,12 @@ def main():
 # W_LongObject.  The walker fold pins the operand with GUARD_VALUE and takes
 # the _make_ovf2long tail, so the compiled loop must agree with the long result
 # rather than wrapping back to INT_MIN.
+#
+# This is the operand the descent declines, which is why the header names both
+# labels: `main` above is walked (`unary_negative_descent`) and this loop is
+# folded (`unary_negative_int`).  Without the fold the promoted W_LongObject
+# stays a loop argument, `compare_op_long` keeps its bigint call in the body,
+# and the loop runs 2x slower.
 def main_int_min():
     m = -9223372036854775807 - 1  # INT_MIN as a machine int
     acc = 0

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/cbuffer.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/cbuffer.rs
@@ -201,7 +201,13 @@ fn comparison(args: &[PyObjectRef], mode: fn(Ordering) -> bool) -> Result<PyObje
         return Ok(pyre_object::special::w_not_implemented());
     };
     let buffer = buffer_arg(args[0])?;
-    let mine = unsafe { std::slice::from_raw_parts(buffer.ptr, buffer.size as usize) };
+    // A buffer over a NULL cdata is empty, and no slice may be built from a
+    // null address even at length zero.  `_comparison_helper` reads zero bytes.
+    let mine = if buffer.ptr.is_null() {
+        &[][..]
+    } else {
+        unsafe { std::slice::from_raw_parts(buffer.ptr, buffer.size as usize) }
+    };
     let ordering = mine.cmp(other.as_bytes());
     other.release();
     Ok(pyre_object::boolobject::w_bool_from(mode(ordering)))

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/cerrno.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/cerrno.rs
@@ -70,9 +70,11 @@ pub fn getwinerror(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let code_slot = roots.base();
     let _ = roots.pin_root(pyre_object::w_int_new(code as i64));
     let message = crate::PyError::win32_strerror(code);
-    let w_message = pyre_object::w_str_new(&message);
+    // `w_tuple_new` allocates, so the message needs a root of its own rather
+    // than only the Rust local.
+    let _ = roots.pin_root(pyre_object::w_str_new(&message));
     Ok(pyre_object::w_tuple_new(vec![
         roots.get(code_slot),
-        w_message,
+        roots.get(code_slot + 1),
     ]))
 }

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/ffi_obj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/ffi_obj.rs
@@ -1229,9 +1229,13 @@ fn init_ffi_type(ns: PyObjectRef) {
     let roots = pyre_object::gc_roots::push_roots();
     let voidp_slot = roots.base();
     let _ = roots.pin_root(newtype::new_voidp_type().expect("void pointer type must build"));
-    let null = ctypeobj::cast(roots.get(voidp_slot), pyre_object::w_int_new(0))
-        .expect("zero must cast to void pointer");
-    store("NULL", null);
+    // `store` inserts into the module dict, which allocates, so the cdata is
+    // rooted rather than held only in a Rust local across it.
+    let _ = roots.pin_root(
+        ctypeobj::cast(roots.get(voidp_slot), pyre_object::w_int_new(0))
+            .expect("zero must cast to void pointer"),
+    );
+    store("NULL", roots.get(voidp_slot + 1));
     store("error", newtype::ffi_error());
     store("buffer", cbuffer::buffer_type());
     super::interp_cffi_backend::register_rtld_constants(ns);

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/func.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/func.rs
@@ -434,6 +434,10 @@ pub fn memmove(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     if n < 0 {
         return Err(PyError::value_error("negative size"));
     }
+    // `@unwrap_spec(n=int)` binds a machine word, so a size that does not fit
+    // one is refused rather than truncated into the checks and the copy.
+    let n = usize::try_from(n)
+        .map_err(|_| PyError::value_error("size does not fit in a machine word"))?;
     let mut dest_buffer = None;
     let dest = if let Some(cdata) = W_CData::from_obj(args[0]) {
         unsafe_escaping_ptr_for_ptr_or_array(cdata)?
@@ -444,7 +448,7 @@ pub fn memmove(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
         // refuses an index past the end, so a request longer than the buffer
         // is an error rather than a write past it. The cdata arm stays
         // unchecked: a bare pointer carries no length.
-        if n as usize > slice.len() {
+        if n > slice.len() {
             return Err(PyError::value_error(
                 "destination buffer is smaller than the requested size",
             ));
@@ -459,7 +463,7 @@ pub fn memmove(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
             return Err(PyError::type_error("expected a readable buffer"));
         };
         // `getslice(0, 1, n)` bounds the same read upstream.
-        if n as usize > buffer.as_bytes().len() {
+        if n > buffer.as_bytes().len() {
             buffer.release();
             return Err(PyError::value_error(
                 "source buffer is smaller than the requested size",
@@ -469,7 +473,7 @@ pub fn memmove(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
         source_buffer = Some(buffer);
         ptr
     };
-    unsafe { std::ptr::copy(src, dest, n as usize) };
+    unsafe { std::ptr::copy(src, dest, n) };
     if let Some(buffer) = source_buffer {
         buffer.release();
     }

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/func.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/func.rs
@@ -220,10 +220,12 @@ pub fn typeoffsetof(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let field_slot = roots.base();
     let _ = roots.pin_root(w_ctype);
-    let w_offset = pyre_object::w_int_new(offset);
+    // The two-item `w_tuple_new` pins its first item, which is a collection
+    // point while an unrooted second item is still only a Rust local.
+    let _ = roots.pin_root(pyre_object::w_int_new(offset));
     Ok(pyre_object::w_tuple_new(vec![
         roots.get(field_slot),
-        w_offset,
+        roots.get(field_slot + 1),
     ]))
 }
 
@@ -437,13 +439,17 @@ pub fn memmove(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
         unsafe_escaping_ptr_for_ptr_or_array(cdata)?
     } else {
         dest_buffer = Some(unsafe { crate::builtins::WritableBuffer::acquire(args[0]) }?);
-        unsafe {
-            dest_buffer
-                .as_mut()
-                .expect("just filled")
-                .as_mut_slice()
-                .as_mut_ptr()
+        let slice = unsafe { dest_buffer.as_mut().expect("just filled").as_mut_slice() };
+        // `_fetch_as_write_buffer`'s non-raw arm writes with `setitem`, which
+        // refuses an index past the end, so a request longer than the buffer
+        // is an error rather than a write past it. The cdata arm stays
+        // unchecked: a bare pointer carries no length.
+        if n as usize > slice.len() {
+            return Err(PyError::value_error(
+                "destination buffer is smaller than the requested size",
+            ));
         }
+        slice.as_mut_ptr()
     };
     let mut source_buffer = None;
     let src = if let Some(cdata) = W_CData::from_obj(roots.get(src_slot)) {
@@ -452,6 +458,13 @@ pub fn memmove(args: &[PyObjectRef]) -> Result<PyObjectRef, PyError> {
         let Some(buffer) = crate::baseobjspace::simple_buffer_bytes(roots.get(src_slot))? else {
             return Err(PyError::type_error("expected a readable buffer"));
         };
+        // `getslice(0, 1, n)` bounds the same read upstream.
+        if n as usize > buffer.as_bytes().len() {
+            buffer.release();
+            return Err(PyError::value_error(
+                "source buffer is smaller than the requested size",
+            ));
+        }
         let ptr = buffer.as_bytes().as_ptr();
         source_buffer = Some(buffer);
         ptr

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/interp_cffi_backend.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/interp_cffi_backend.rs
@@ -136,7 +136,6 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
             crate::make_module_builtin_function("getwinerror", super::cerrno::getwinerror),
         ),
     );
-
     Ok(())
 }
 

--- a/pyre/pyre-interpreter/src/module/_cffi_backend/lib_obj.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/lib_obj.rs
@@ -117,9 +117,18 @@ pub fn make_includes_from(
         let _ = roots.pin_root(w_lib1);
         let lib1 = lib_arg(roots.get(part_slot + 5))?;
         let _ = roots.pin_root(lib1.w_ffi);
-        let pair =
-            pyre_object::w_tuple_new(vec![roots.get(part_slot + 6), roots.get(part_slot + 5)]);
-        unsafe { pyre_object::listobject::w_list_append(roots.get(includes_slot), pair) };
+        // `w_list_append` can grow the items block, so the pair is rooted
+        // rather than held only in a Rust local across that allocation.
+        let _ = roots.pin_root(pyre_object::w_tuple_new(vec![
+            roots.get(part_slot + 6),
+            roots.get(part_slot + 5),
+        ]));
+        unsafe {
+            pyre_object::listobject::w_list_append(
+                roots.get(includes_slot),
+                roots.get(part_slot + 7),
+            )
+        };
         num += 1;
     }
     ffi_of(lib_arg(roots.get(lib_slot))?)?.included_ffis_libs = roots.get(includes_slot);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -372,6 +372,7 @@ spec_folds! {
     UnaryPositiveDescent => ("unary_positive_descent",   "residual_call", "-"),
     UnaryInvertDescent   => ("unary_invert_descent",     "residual_call", "-"),
     UnaryNegativeDescent => ("unary_negative_descent",   "residual_call", "-"),
+    UnaryNegativeInt     => ("unary_negative_int",       "residual_call", "-"),
     StoreSubscr          => ("store_subscr",             "residual_call", "-"),
     Setslice             => ("setslice",                 "residual_call", "-"),
     GetIter              => ("get_iter",                 "residual_call", "-"),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -6688,16 +6688,35 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
 
     // UNARY_NEGATIVE.  Descend `neg_inner` -- `neg` past the override probe --
     // rather than re-emit its integer arm by hand, the same shape the invert
-    // descent below takes.  The translated body owns both the ordinary int arm
-    // and the `INT_MIN` promotion through `rbigint.neg` + `W_LongObject`
-    // allocation. Bool, subclass and non-int operands still fall through to
-    // the generic residual so their override semantics are preserved.
+    // descent below takes.  The translated body owns the ordinary int arm and
+    // the exact `long` operand. Bool, subclass and non-int operands still fall
+    // through to the generic residual so their override semantics are
+    // preserved, and the `INT_MIN` promotion declines to the fold below.
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && r_args.len() == 1
         && foldable_runtime_helper == majit_ir::RuntimeHelperKind::UnaryNegative
         && spec_gate(SpecFold::UnaryNegativeDescent, || {
             try_walker_orthodox_unary_negative(ctx, op.pc, r_args[0], dst, dst_bank)
+        })?
+        .is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
+
+    // #61: UNARY_NEGATIVE `-int`.  Kept behind the descent, which declines the
+    // one operand `descr_neg` promotes: the fold pins that operand with
+    // `guard_value` and takes the `_make_ovf2long` tail, so the `2**63` long is
+    // a constant the ops reading it fold against.  It also serves an exact-int
+    // operand in a build whose `neg_inner` jitcode is missing or unlowered.
+    if ctx.is_authoritative_executor
+        && dst_bank == 'r'
+        && r_args.len() == 1
+        && foldable_runtime_helper == majit_ir::RuntimeHelperKind::UnaryNegative
+        && spec_gate(SpecFold::UnaryNegativeInt, || {
+            try_walker_specialize_unary_negative_int(
+                ctx, op.pc, r_args[0], &allboxes, call_descr, dst, dst_bank,
+            )
         })?
         .is_some()
     {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -401,6 +401,87 @@ fn walker_emit_ovf2long_box<Sym: WalkSym>(
     Ok(result)
 }
 
+/// #61: walker-native int specialization for the `UNARY_NEGATIVE` residual
+/// (oopspec [`majit_ir::RuntimeHelperKind::UnaryNegative`]).  `-x` on an exact
+/// int is `0 - x`; the object-space `neg` promotes only `-INT_MIN` to a
+/// `W_LongObject` (`intobject.py` `descr_neg` → `_make_ovf2long`).  Since
+/// majit has no overflow-checked unary negate, the fold expresses `-x` as
+/// `IntSubOvf(0, x)` behind a `GUARD_CLASS INT`, reusing the binary-sub
+/// overflow discipline in both directions: a record value other than `INT_MIN`
+/// emits `GUARD_NO_OVERFLOW` so an `INT_MIN` arrival on the reused trace deopts
+/// rather than wrapping back to `INT_MIN`, and a record value of `INT_MIN`
+/// pins the operand with `GUARD_VALUE` and takes the same `_make_ovf2long` tail
+/// the `BINARY_OP` overflow arm takes, so the `2**63` long is built from the
+/// elidable bigint helper instead of the `CallMayForce` residual.
+///
+/// Returns `Ok(Some(()))` when the fold was emitted (caller returns
+/// `Continue`); `Ok(None)` for a bool / subclass / non-int operand, when the
+/// residual result box is unavailable, or when an `INT_MIN` operand did not
+/// produce the promoted `W_LongObject` the payload read expects.
+pub(crate) fn try_walker_specialize_unary_negative_int<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    operand: OpRef,
+    allboxes: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    let Some((x, x_class)) = walker_unary_int_operand(ctx, operand) else {
+        return Ok(None);
+    };
+    let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
+        return Ok(None);
+    };
+    // `0 - INT_MIN` is the one operand `descr_neg` promotes.
+    let overflows = x == i64::MIN;
+    if overflows {
+        let boxed_result_obj = boxed_result_i64 as usize as pyre_object::PyObjectRef;
+        if boxed_result_obj == pyre_object::PY_NULL
+            || !unsafe { pyre_object::is_long(boxed_result_obj) }
+        {
+            return Ok(None);
+        }
+    }
+    let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+    let x_raw = walker_unbox_int(ctx, op_pc, operand, int_type_addr)?;
+    walker_guard_exact_w_class(ctx, op_pc, operand, x_class)?;
+    let zero_raw = ctx.trace_ctx.const_int(0);
+    let boxed = if overflows {
+        // `0 - x` overflows an i64 for exactly one operand, so "the negate
+        // promoted" and "the operand is INT_MIN" name the same set: guarding
+        // the value admits what `GUARD_OVERFLOW` would and nothing more. The
+        // value form is the one the tail can use — with `x_raw` constant the
+        // elidable bigint call folds to the `2**63` payload it returned while
+        // recording instead of running once per iteration. This is the
+        // `guard_value` spelling the version-tag promotes already use.
+        let int_min = ctx.trace_ctx.const_int(i64::MIN);
+        walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[x_raw, int_min])?;
+        walker_emit_ovf2long_box(
+            ctx,
+            op_pc,
+            pyre_object::longobject::jit_bigint_sub_int_int as *const (),
+            (zero_raw, 0),
+            (x_raw, x),
+            boxed_result_i64,
+        )?
+    } else {
+        let result_value = 0i64.wrapping_sub(x);
+        let raw_result = ctx
+            .trace_ctx
+            .record_op(OpCode::IntSubOvf, &[zero_raw, x_raw]);
+        ctx.trace_ctx
+            .set_opref_concrete(raw_result, majit_ir::Value::Int(result_value));
+        walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoOverflow, &[])?;
+        let boxed = walker_box_int(ctx, op_pc, raw_result, result_value)?;
+        ctx.trace_ctx
+            .set_opref_concrete(boxed, box_int_concrete(result_value, boxed_result_i64));
+        boxed
+    };
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
+    Ok(Some(()))
+}
+
 /// #57: walker-native speculative int specialization for the `BINARY_OP`
 /// helper residual_call (oopspec `BinaryOp`).  Re-derives
 /// the former int fast path's structure (`guard_class` + `getfield_gc_i` per
@@ -8554,6 +8635,23 @@ pub(crate) fn try_walker_orthodox_unary_negative<Sym: WalkSym>(
     };
 
     // Resolve every possible decline before recording a guard.
+    //
+    // `-INT_MIN` is the one operand `descr_neg` promotes, and it belongs to
+    // [`try_walker_specialize_unary_negative_int`] rather than to this walk.
+    // Walking the promotion records the two `rbigint` calls that build the
+    // `2**63` long; both survive optimization as `CallPureR` short boxes and
+    // the second one's result is carried across the `LABEL` as a loop
+    // argument, so a later pure call reading that long -- `compare_op_long`'s
+    // `jit_bigint_cmp` -- has no constant argument and is re-emitted into the
+    // body as an impure `CallI` once per iteration.  The fold pins the unboxed
+    // operand with `guard_value` instead, and then the whole chain is
+    // constant: it exports no short box at all and the comparison folds away
+    // (`unary_negative.py main_int_min`, 20 ops / 9 guards -> 17 / 8).
+    if let Some((x, _)) = walker_unary_int_operand(ctx, operand)
+        && x == i64::MIN
+    {
+        return Ok(None);
+    }
     let Some(jc_arc) = crate::jitcode_runtime::neg_inner_jitcode() else {
         return Ok(None);
     };


### PR DESCRIPTION
Follow-up to #1570. Four commits: one unbreaks `main`, one recovers a JIT
performance regression, and two address review findings from #1570 that were
still open after the merge.

## `main` does not currently compile

`origin/main` at `464fe4d7f6e` is red on all three `prepare Charon/LLBC` jobs
([run 33253656391](https://github.com/youknowone/pyre/actions/runs/33253656391)):

```
error[E0308]: mismatched types
  --> pyre/pyre-interpreter/src/importing.rs:657:55
   = note: expected fn pointer `fn(_) -> Result<(), error::PyError>`
              found fn item `fn(_) -> () {interp_cffi_backend::register_module}`
```

`622024c7695` (#1527) changed `register_builtin_module`'s init type to return
`Result`; #1570's `ef64496dbce` was written against the older signature. The two
touch different files, so the merge was textually clean and only the types
disagree. `_cffi_backend::register_module` now returns `Result<(), PyError>`
like every other module's, matching `_ctypes` and `signal`.

## `synth/unary_negative` regression

`b67e8abdb8d` (in #1561) retired `try_walker_specialize_unary_negative_int` when
the `neg_inner` descent landed. The descent also walks the `-INT_MIN`
promotion, and measuring that path shows why the fold was still carrying it:

| | descent only (`main`) | fold restored |
|---|---|---|
| compiled `main_int_min` loop | 20 ops / 0 New / 9 guards | **17 ops / 0 New / 8 guards** |
| `exported_short_box kind=Pure` | 2 | **0** |
| that loop, dynasm/macOS | 0.245s | **0.11s** |
| whole fixture, dynasm/macOS | 0.32s | **0.15s** |

The two `rbigint` calls the descent records are hoisted as `CallPure*` short
boxes rather than folded, so the promoted long is carried across the `LABEL` as
a loop argument; `compare_op_long`'s `jit_bigint_cmp` then has no constant
argument and is re-emitted into the body as an impure `CallI` once per
iteration. The fold's `guard_value` on the unboxed operand makes the whole
chain constant and the comparison folds away.

The descent keeps every other operand — it now declines only `x == i64::MIN`.

This was measurable but not gated: on ubuntu dynasm the fixture ran at **7.3x
against a `max-pypy-ratio=8` ceiling**, and on macOS pypy's time clamps to the
floor so no ratio gate applies at all. The fixture now also declares

```
# pyre-check: spec-folds=unary_negative_descent,unary_negative_int
```

which fails on a label that no longer exists and on a declared label that never
fires — independent of any timing.

## Review findings from #1570

Verified against the merged tree; these were still open.

- **Rooting** (CodeRabbit, Major): `getwinerror`'s message, `make_includes_from`'s
  pair, `init_ffi_type`'s `NULL` cdata and `typeoffsetof`'s offset were each held
  only in a Rust local while the next call allocated (`w_tuple_new`,
  `w_list_append`'s items-block growth, the module dict insert, and
  `w_tuple_new`'s two-item path pinning its first item).
- **`memmove` bounds** (CodeRabbit, Critical): the writable-buffer and
  readable-buffer arms discarded their lengths and copied `n` bytes unchecked.
  Upstream bounds the same reads through `setitem` and `getslice(0, 1, n)`.
  The `W_CData` arms stay unchecked, as upstream's `c_memmove` is.
- **Null buffer slice** (Codex, P1): the buffer comparison built a slice from
  `buffer.ptr` without a null test, which is UB even at length zero.
  `b4f77e8a329` fixed the twin site in `typedef.rs`; this is the same shape.

### Checked and not changed

- **`assert_eq!(nf1, 0)` in `cdlopen.rs`** — upstream `cdlopen.py:191` has the
  identical `assert nf1 == 0`. Faithful as written.
- **Arity / signature binding on the module entry points** — already fixed by
  `3c2653edf6f` and `8f82404440d`; every fixed-arity entry point carries an
  arity and a `Signature`, and the optional-argument ones bind internally.
- **Unterminated packed name** — already fixed by `8d446e05946`'s name-scan clamp.
- Still open and not in scope here: the P2 ctype cache retention
  (`ctypeobj.rs`), `ffi.def_extern` / `extern "Python"`, the free-threaded races
  in `newtype.rs` and `libraryobj.rs`, and the 32-bit-target width findings.

## Testing

`pyre/check.py --backend dynasm` **ALL PASSED 519/519** on the two JIT commits;
the full gate is re-running over the cffi commits.

— *commented by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved JIT performance for unary negation of integer values, including correct handling of the minimum integer value.

* **Bug Fixes**
  * Prevented errors when comparing buffers with null pointers.
  * Added validation to memory-copy operations, reporting an error when buffers are too small.
  * Improved reliability of Windows error reporting and CFFI initialization under memory allocation and garbage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->