### PR TITLE
_cffi_backend: give `register_module` the init signature the registry expects

### DIFF
--- a/pyre/pyre-interpreter/src/module/_cffi_backend/interp_cffi_backend.rs
+++ b/pyre/pyre-interpreter/src/module/_cffi_backend/interp_cffi_backend.rs
@@ -8,7 +8,7 @@ use super::parse_c_type;
 /// it tracks the vendored `lib_pypy/cffi` rather than anything of pyre's.
 pub const VERSION: &str = "1.18.0.dev0";
 
-pub fn register_module(ns: pyre_object::PyObjectRef) {
+pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyError> {
     crate::module_ns_store(ns, "__version__", pyre_object::w_str_new(VERSION));
 
     // `clibffi.FFI_DEFAULT_ABI`.  `FFI_CDECL` is the win32 spelling of the
@@ -136,6 +136,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             crate::make_module_builtin_function("getwinerror", super::cerrno::getwinerror),
         ),
     );
+
+    Ok(())
 }
 
 const MODULE: &str = "_cffi_backend";


### PR DESCRIPTION
`pyre_module_init!` re-exports a module's `register_module` as `init`, and `register_builtin_module` takes `fn(PyObjectRef) -> Result<(), PyError>`. Every other module's `register_module` returns that; the one added in #1570 returns `()`, so `pyre_install_module!(_cffi_backend)` fails to type-check and `pyre-interpreter` does not build on `main` (464fe4d):

```
error[E0308]: mismatched types
   --> pyre/pyre-interpreter/src/importing.rs:657:55
    |
657 |             register_builtin_module(stringify!($mod), crate::module::$mod::init);
    |             -----------------------                   ^^^^^^^^^^^^^^^^^^^^^^^^^ expected fn pointer, found fn item
...
816 |         pyre_install_module!(_cffi_backend);
    |         ----------------------------------- in this macro invocation
    |
    = note: expected fn pointer `fn(_) -> std::result::Result<(), error::PyError>`
                  found fn item `fn(_) -> () {module::_cffi_backend::interp_cffi_backend::register_module}`
```

The body has no fallible step yet, so this just grows the return type and a trailing `Ok(())`.

Verified with `cargo check -p pyre-interpreter --features dynasm` and a full `python3 scripts/extract-llbc.py` run, both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAaD8eLYwrpA1XsyQhUikN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal module registration error handling.
  * Registration operations now report failures more consistently, supporting more reliable runtime behavior.

* **User Impact**
  * No visible changes to application functionality or user-facing interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->