### PR TITLE
_socket, posix: finish wasm converters and refused-write signatures

### DIFF
--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7376,6 +7376,7 @@ pub(crate) mod wasm_errno {
     pub const EACCES: i32 = 13;
     pub const EPERM: i32 = 1;
     pub const ESRCH: i32 = 3;
+    pub const EIO: i32 = 5;
     pub const ETIMEDOUT: i32 = 60;
     pub const EBADF: i32 = 9;
     pub const EINVAL: i32 = 22;
@@ -7396,6 +7397,7 @@ pub(crate) mod wasm_errno {
             EPERM => "Operation not permitted",
             ENOENT => "No such file or directory",
             ESRCH => "No such process",
+            EIO => "Input/output error",
             EINTR => "Interrupted system call",
             ECHILD => "No child processes",
             EACCES => "Permission denied",
@@ -7407,6 +7409,7 @@ pub(crate) mod wasm_errno {
             EINPROGRESS => "Operation now in progress",
             EALREADY => "Operation already in progress",
             ENOTSUP => "Operation not supported",
+            EAFNOSUPPORT => "Address family not supported by protocol",
             ECONNABORTED => "Software caused connection abort",
             ECONNRESET => "Connection reset by peer",
             ETIMEDOUT => "Operation timed out",

--- a/pyre/pyre-interpreter/src/module/_socket/inet_text.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/inet_text.rs
@@ -1,0 +1,349 @@
+//! The address converters' text half, which is arithmetic over a spelling
+//! rather than a call into a socket layer.
+//!
+//! A target whose C library carries no `inet_pton` still has to answer for
+//! these four names, so the conversions are written out here.  They follow
+//! musl, which is wasi-libc: the strict parser reads exactly four octets with
+//! no redundant leading zero and the IPv6 grammar without a scope suffix, and
+//! the writer compresses the longest run of zero groups.
+//!
+//! Nothing here touches a descriptor or a host, so the module compiles under
+//! `cfg(test)` on every target and its corpus runs with the rest of the unit
+//! tests, on hosts where the entry points themselves reach libc instead.
+
+/// `inet_aton` — the lenient parser, which reads one to four parts and gives
+/// the last one every byte the earlier ones did not claim.  A part is decimal,
+/// octal behind a `0`, or hexadecimal behind a `0x`.
+pub(super) fn aton(text: &[u8]) -> Option<[u8; 4]> {
+    let mut parts = Vec::new();
+    for field in std::str::from_utf8(text).ok()?.split('.') {
+        let (digits, radix) = match field.as_bytes() {
+            [b'0', b'x' | b'X', rest @ ..] => (rest, 16),
+            [b'0', rest @ ..] if !rest.is_empty() => (rest, 8),
+            other => (other, 10),
+        };
+        let digits = std::str::from_utf8(digits).ok()?;
+        parts.push(u32::from_str_radix(digits, radix).ok()?);
+        if parts.len() > 4 {
+            return None;
+        }
+    }
+    // The last part carries the bytes the leading ones left: `127.1` is
+    // `127.0.0.1`, and a bare number is the whole address.
+    let leading = parts.len().checked_sub(1)?;
+    let mut address: u32 = 0;
+    for (index, part) in parts.iter().enumerate() {
+        let width = if index == leading {
+            32 - 8 * leading
+        } else {
+            8
+        };
+        if width < 32 && *part >= 1 << width {
+            return None;
+        }
+        address |= part << (32 - 8 * index - width);
+    }
+    Some(address.to_be_bytes())
+}
+
+/// `inet_ntoa` — the dotted-quad spelling of four address bytes.
+pub(super) fn ntoa(packed: [u8; 4]) -> String {
+    format!("{}.{}.{}.{}", packed[0], packed[1], packed[2], packed[3])
+}
+
+/// One to three decimal digits with no redundant leading zero, which is the
+/// only octet spelling the strict parser reads.
+fn strict_octet(field: &[u8]) -> Option<u8> {
+    if field.is_empty() || field.len() > 3 || (field.len() > 1 && field[0] == b'0') {
+        return None;
+    }
+    let mut value: u32 = 0;
+    for digit in field {
+        value = value * 10 + u32::from(digit.checked_sub(b'0').filter(|d| *d < 10)?);
+    }
+    u8::try_from(value).ok()
+}
+
+/// `inet_pton(AF_INET, ...)` — exactly four strict octets.
+pub(super) fn pton_v4(text: &[u8]) -> Option<[u8; 4]> {
+    let mut address = [0u8; 4];
+    let mut fields = text.split(|b| *b == b'.');
+    for slot in &mut address {
+        *slot = strict_octet(fields.next()?)?;
+    }
+    fields.next().is_none().then_some(address)
+}
+
+/// `inet_pton(AF_INET6, ...)`.
+pub(super) fn pton_v6(text: &[u8]) -> Option<[u8; 16]> {
+    // A trailing dotted quad occupies the last two groups, so it is taken off
+    // first and the hexadecimal grammar reads what is left.  The colon before
+    // it is a separator, except when the quad follows a compressed run: there
+    // it is that run's second colon, and cutting it away would leave a `::`
+    // the grammar can no longer see.
+    let (head, tail) = match text.iter().position(|b| *b == b'.') {
+        None => (text, None),
+        Some(_) => {
+            let colon = text.iter().rposition(|b| *b == b':')?;
+            let head_end = colon + usize::from(text[..colon].ends_with(b":"));
+            (&text[..head_end], Some(pton_v4(&text[colon + 1..])?))
+        }
+    };
+    let groups_wanted = if tail.is_some() { 6 } else { 8 };
+
+    let (before, after) = match find_double_colon(head)? {
+        None => (head, None),
+        Some(at) => (&head[..at], Some(&head[at + 2..])),
+    };
+    let leading = hex_groups(before, groups_wanted)?;
+    let trailing = match after {
+        None => Vec::new(),
+        Some(rest) => hex_groups(rest, groups_wanted - leading.len())?,
+    };
+    // Without `::` every group must be spelled; with it at least one must not.
+    let elided = groups_wanted - leading.len() - trailing.len();
+    if (after.is_none() && elided != 0) || (after.is_some() && elided == 0) {
+        return None;
+    }
+
+    let mut address = [0u8; 16];
+    let mut out = address.iter_mut();
+    for group in leading
+        .iter()
+        .chain(std::iter::repeat_n(&0u16, elided))
+        .chain(trailing.iter())
+    {
+        *out.next()? = (group >> 8) as u8;
+        *out.next()? = *group as u8;
+    }
+    if let Some(quad) = tail {
+        address[12..].copy_from_slice(&quad);
+    }
+    Some(address)
+}
+
+/// The offset of the one `::` a spelling may carry, or nothing when a second
+/// one makes the address ambiguous.
+fn find_double_colon(text: &[u8]) -> Option<Option<usize>> {
+    let mut found = None;
+    let mut index = 0;
+    while index + 1 < text.len() {
+        if text[index] == b':' && text[index + 1] == b':' {
+            if found.is_some() {
+                return None;
+            }
+            found = Some(index);
+            index += 1;
+        }
+        index += 1;
+    }
+    Some(found)
+}
+
+/// Colon-separated groups of one to four hexadecimal digits.  An empty run is
+/// no groups at all, which is what either side of a leading or trailing `::`
+/// reads as.
+fn hex_groups(text: &[u8], limit: usize) -> Option<Vec<u16>> {
+    if text.is_empty() {
+        return Some(Vec::new());
+    }
+    let mut groups = Vec::new();
+    for field in text.split(|b| *b == b':') {
+        if field.is_empty() || field.len() > 4 || groups.len() == limit {
+            return None;
+        }
+        let mut value: u16 = 0;
+        for digit in field {
+            value = value * 16 + u16::from((*digit as char).to_digit(16)? as u8);
+        }
+        groups.push(value);
+    }
+    Some(groups)
+}
+
+/// `inet_ntop(AF_INET6, ...)`.
+///
+/// The address is written out group by group and then has its longest run of
+/// zero groups replaced by `::`, which is the rewrite musl performs and the
+/// reason a run of one group is left spelled out.
+pub(super) fn ntop_v6(packed: &[u8]) -> String {
+    let group = |i: usize| (u16::from(packed[2 * i]) << 8) | u16::from(packed[2 * i + 1]);
+    // An IPv4-mapped address keeps its last four bytes in dotted-quad form.
+    let text = if packed[..12] == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff] {
+        format!(
+            "{:x}:{:x}:{:x}:{:x}:{:x}:{:x}:{}.{}.{}.{}",
+            group(0),
+            group(1),
+            group(2),
+            group(3),
+            group(4),
+            group(5),
+            packed[12],
+            packed[13],
+            packed[14],
+            packed[15]
+        )
+    } else {
+        (0..8)
+            .map(|i| format!("{:x}", group(i)))
+            .collect::<Vec<_>>()
+            .join(":")
+    };
+
+    // The longest run of `:` and `0` that starts the string or starts at a
+    // colon, taken only when it spans more than one zero group.
+    let bytes = text.as_bytes();
+    let (mut best, mut longest) = (0, 2);
+    for start in 0..bytes.len() {
+        if start != 0 && bytes[start] != b':' {
+            continue;
+        }
+        let run = bytes[start..]
+            .iter()
+            .take_while(|b| **b == b':' || **b == b'0')
+            .count();
+        // An interior run includes the colon before its first zero while a
+        // leading run does not.  Once the leading run is best, make an
+        // interior candidate beat it by that extra byte as well; equal-size
+        // zero runs therefore keep the first one, as musl's `inet_ntop` does.
+        if run > longest + usize::from(best == 0) {
+            (best, longest) = (start, run);
+        }
+    }
+    if longest <= 3 {
+        return text;
+    }
+    format!("{}::{}", &text[..best], &text[best + longest..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Spellings every one of glibc, musl and the BSDs reads the same way, so
+    /// the expectations here are the ones a host `inet_pton` would also meet.
+    #[test]
+    fn pton_v6_reads_the_shared_grammar() {
+        let cases: &[(&str, Option<&str>)] = &[
+            ("::", Some("00000000000000000000000000000000")),
+            ("::1", Some("00000000000000000000000000000001")),
+            ("1::", Some("00010000000000000000000000000000")),
+            // A dotted quad directly after a compressed run: the colon the
+            // quad is cut from is that run's own second colon.
+            ("::192.0.2.1", Some("000000000000000000000000c0000201")),
+            (
+                "2001:db8::192.0.2.1",
+                Some("20010db80000000000000000c0000201"),
+            ),
+            ("::ffff:192.0.2.1", Some("00000000000000000000ffffc0000201")),
+            (
+                "0:0:0:0:0:ffff:192.0.2.1",
+                Some("00000000000000000000ffffc0000201"),
+            ),
+            ("1::2:192.0.2.1", Some("000100000000000000000002c0000201")),
+            (
+                "1:2:3:4:5:6:1.2.3.4",
+                Some("00010002000300040005000601020304"),
+            ),
+            ("1:2:3:4:5:6:7:8", Some("00010002000300040005000600070008")),
+            ("fe80::1", Some("fe800000000000000000000000000001")),
+            ("1:2:3:4:5:6:7::", Some("00010002000300040005000600070000")),
+            ("::1:2:3:4:5:6:7", Some("00000001000200030004000500060007")),
+            // Rejected everywhere: two compressed runs, a quad with a fifth
+            // part, one group too many, one too few, a lone dotted quad, and
+            // an octet with a redundant leading zero.
+            ("1::2::3", None),
+            (":::192.0.2.1", None),
+            ("::192.0.2.1.5", None),
+            ("::1.2.3", None),
+            ("1:2:3:4:5:6:7:8:9", None),
+            ("1:2:3:4:5:6:7", None),
+            ("1.2.3.4", None),
+            ("::01.2.3.4", None),
+            ("::00001", None),
+            ("::%eth0", None),
+            ("", None),
+            (":", None),
+        ];
+        for (text, want) in cases {
+            let got = pton_v6(text.as_bytes())
+                .map(|bytes| bytes.iter().map(|b| format!("{b:02x}")).collect::<String>());
+            assert_eq!(got.as_deref(), *want, "inet_pton(AF_INET6, {text:?})");
+        }
+    }
+
+    #[test]
+    fn pton_v4_reads_four_strict_octets() {
+        for (text, want) in [
+            ("1.2.3.4", Some([1, 2, 3, 4])),
+            ("255.255.255.255", Some([255, 255, 255, 255])),
+            ("0.0.0.0", Some([0, 0, 0, 0])),
+            ("01.2.3.4", None),
+            ("1.2.3", None),
+            ("1.2.3.4.5", None),
+            ("1.2.3.256", None),
+            ("1.2.3.", None),
+        ] {
+            assert_eq!(
+                pton_v4(text.as_bytes()),
+                want,
+                "inet_pton(AF_INET, {text:?})"
+            );
+        }
+    }
+
+    /// The lenient parser gives the last part every byte the earlier ones did
+    /// not claim, and reads octal and hexadecimal.
+    #[test]
+    fn aton_is_the_lenient_parser() {
+        for (text, want) in [
+            ("127.1", Some([127, 0, 0, 1])),
+            ("1.2.3.4", Some([1, 2, 3, 4])),
+            ("16909060", Some([1, 2, 3, 4])),
+            ("0x7f.1", Some([127, 0, 0, 1])),
+            ("0177.0.0.1", Some([127, 0, 0, 1])),
+            ("1.2.3.4.5", None),
+            ("256.1.1.1", None),
+            ("1.2.3.4.", None),
+            ("", None),
+        ] {
+            assert_eq!(aton(text.as_bytes()), want, "inet_aton({text:?})");
+        }
+        assert_eq!(ntoa([1, 2, 3, 4]), "1.2.3.4");
+    }
+
+    /// Every spelling the writer produces has to read back to the bytes it was
+    /// given, and the compressed run is the longest one.
+    #[test]
+    fn ntop_v6_round_trips_and_compresses_the_longest_run() {
+        for (packed, want) in [
+            ("00000000000000000000000000000000", "::"),
+            ("00000000000000000000000000000001", "::1"),
+            ("20010db8000000000000000000000001", "2001:db8::1"),
+            // One zero group is left spelled out; the longer run wins.
+            ("20010000000100000000000200030004", "2001:0:1::2:3:4"),
+            // Equal runs keep the first.  In the uncompressed text the later
+            // run appears one byte longer only because it owns a leading
+            // colon; that byte is not another zero group.
+            ("00000000000100000000000200030004", "::1:0:0:2:3:4"),
+            // musl uses dotted-quad output for mapped addresses, but not the
+            // older IPv4-compatible form.
+            ("000000000000000000000000c0000201", "::c000:201"),
+            ("00000000000000000000ffffc0000201", "::ffff:192.0.2.1"),
+            ("fe800000000000000000000000000001", "fe80::1"),
+        ] {
+            let bytes: Vec<u8> = (0..16)
+                .map(|i| u8::from_str_radix(&packed[2 * i..2 * i + 2], 16).unwrap())
+                .collect();
+            let text = ntop_v6(&bytes);
+            assert_eq!(text, want, "inet_ntop({packed})");
+            assert_eq!(
+                pton_v6(text.as_bytes())
+                    .as_ref()
+                    .map(|address| &address[..]),
+                Some(&bytes[..]),
+                "round trip of {text}"
+            );
+        }
+    }
+}

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket_wasm.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket_wasm.rs
@@ -72,47 +72,14 @@ pub(super) const AF_INET6: i32 = 10;
 /// `gethostname` is written over `uname` and hands back that field.
 const NODE_NAME: &str = "(none)";
 
-/// `inet_aton` — the lenient parser, which reads one to four parts and gives
-/// the last one every byte the earlier ones did not claim.  A part is decimal,
-/// octal behind a `0`, or hexadecimal behind a `0x`.
+/// `inet_aton` — the lenient parser.
 pub(super) fn inet_aton(text: &std::ffi::CStr) -> Option<[u8; 4]> {
-    let mut parts = Vec::new();
-    for field in text.to_str().ok()?.split('.') {
-        let (digits, radix) = match field.as_bytes() {
-            [b'0', b'x' | b'X', rest @ ..] => (rest, 16),
-            [b'0', rest @ ..] if !rest.is_empty() => (rest, 8),
-            other => (other, 10),
-        };
-        let digits = std::str::from_utf8(digits).ok()?;
-        parts.push(u32::from_str_radix(digits, radix).ok()?);
-        if parts.len() > 4 {
-            return None;
-        }
-    }
-    // The last part carries the bytes the leading ones left: `127.1` is
-    // `127.0.0.1`, and a bare number is the whole address.
-    let leading = parts.len().checked_sub(1)?;
-    let mut address: u32 = 0;
-    for (index, part) in parts.iter().enumerate() {
-        let width = if index == leading {
-            32 - 8 * leading
-        } else {
-            8
-        };
-        if width < 32 && *part >= 1 << width {
-            return None;
-        }
-        address |= part << (32 - 8 * index - width);
-    }
-    Some(address.to_be_bytes())
+    super::inet_text::aton(text.to_bytes())
 }
 
 /// `inet_ntoa` — the dotted-quad spelling of four address bytes.
 pub(super) fn inet_ntoa(packed: [u8; 4]) -> Option<String> {
-    Some(format!(
-        "{}.{}.{}.{}",
-        packed[0], packed[1], packed[2], packed[3]
-    ))
+    Some(super::inet_text::ntoa(packed))
 }
 
 /// `inet_pton`'s two failures, which it reports through different channels: a
@@ -125,178 +92,28 @@ pub(crate) enum PtonError {
     Address,
 }
 
-/// `inet_pton` — the strict parser.  Unlike `inet_aton` it reads exactly four
-/// decimal octets, refuses a leading zero, and carries the IPv6 grammar.
+/// `inet_pton` — the strict parser.
 pub(super) fn pton(family: i32, text: &std::ffi::CStr) -> Result<Vec<u8>, PtonError> {
     let bytes = text.to_bytes();
-    match family {
-        AF_INET => pton_v4(bytes).map(|a| a.to_vec()).ok_or(PtonError::Address),
-        AF_INET6 => pton_v6(bytes).map(|a| a.to_vec()).ok_or(PtonError::Address),
-        _ => Err(PtonError::Family(crate::builtins::wasm_errno::EAFNOSUPPORT)),
-    }
-}
-
-/// One to three decimal digits with no redundant leading zero, which is the
-/// only octet spelling the strict parser reads.
-fn strict_octet(field: &[u8]) -> Option<u8> {
-    if field.is_empty() || field.len() > 3 || (field.len() > 1 && field[0] == b'0') {
-        return None;
-    }
-    let mut value: u32 = 0;
-    for digit in field {
-        value = value * 10 + u32::from(digit.checked_sub(b'0').filter(|d| *d < 10)?);
-    }
-    u8::try_from(value).ok()
-}
-
-fn pton_v4(text: &[u8]) -> Option<[u8; 4]> {
-    let mut address = [0u8; 4];
-    let mut fields = text.split(|b| *b == b'.');
-    for slot in &mut address {
-        *slot = strict_octet(fields.next()?)?;
-    }
-    fields.next().is_none().then_some(address)
-}
-
-fn pton_v6(text: &[u8]) -> Option<[u8; 16]> {
-    // A trailing dotted quad occupies the last two groups, so it is taken off
-    // first and the hexadecimal grammar reads what is left.
-    let (head, tail) = match text.iter().position(|b| *b == b'.') {
-        None => (text, None),
-        Some(_) => {
-            let colon = text.iter().rposition(|b| *b == b':')?;
-            (&text[..colon], Some(pton_v4(&text[colon + 1..])?))
+    let packed = match family {
+        AF_INET => super::inet_text::pton_v4(bytes).map(|a| a.to_vec()),
+        AF_INET6 => super::inet_text::pton_v6(bytes).map(|a| a.to_vec()),
+        _ => {
+            return Err(PtonError::Family(crate::builtins::wasm_errno::EAFNOSUPPORT));
         }
     };
-    let groups_wanted = if tail.is_some() { 6 } else { 8 };
-
-    let (before, after) = match find_double_colon(head)? {
-        None => (head, None),
-        Some(at) => (&head[..at], Some(&head[at + 2..])),
-    };
-    let leading = hex_groups(before, groups_wanted)?;
-    let trailing = match after {
-        None => Vec::new(),
-        Some(rest) => hex_groups(rest, groups_wanted - leading.len())?,
-    };
-    // Without `::` every group must be spelled; with it at least one must not.
-    let elided = groups_wanted - leading.len() - trailing.len();
-    if (after.is_none() && elided != 0) || (after.is_some() && elided == 0) {
-        return None;
-    }
-
-    let mut address = [0u8; 16];
-    let mut out = address.iter_mut();
-    for group in leading
-        .iter()
-        .chain(std::iter::repeat_n(&0u16, elided))
-        .chain(trailing.iter())
-    {
-        *out.next()? = (group >> 8) as u8;
-        *out.next()? = *group as u8;
-    }
-    if let Some(quad) = tail {
-        address[12..].copy_from_slice(&quad);
-    }
-    Some(address)
-}
-
-/// The offset of the one `::` a spelling may carry, or nothing when a second
-/// one makes the address ambiguous.
-fn find_double_colon(text: &[u8]) -> Option<Option<usize>> {
-    let mut found = None;
-    let mut index = 0;
-    while index + 1 < text.len() {
-        if text[index] == b':' && text[index + 1] == b':' {
-            if found.is_some() {
-                return None;
-            }
-            found = Some(index);
-            index += 1;
-        }
-        index += 1;
-    }
-    Some(found)
-}
-
-/// Colon-separated groups of one to four hexadecimal digits.  An empty run is
-/// no groups at all, which is what either side of a leading or trailing `::`
-/// reads as.
-fn hex_groups(text: &[u8], limit: usize) -> Option<Vec<u16>> {
-    if text.is_empty() {
-        return Some(Vec::new());
-    }
-    let mut groups = Vec::new();
-    for field in text.split(|b| *b == b':') {
-        if field.is_empty() || field.len() > 4 || groups.len() == limit {
-            return None;
-        }
-        let mut value: u16 = 0;
-        for digit in field {
-            value = value * 16 + u16::from((*digit as char).to_digit(16)? as u8);
-        }
-        groups.push(value);
-    }
-    Some(groups)
+    packed.ok_or(PtonError::Address)
 }
 
 /// `inet_ntop` — the canonical spelling of a packed address.
-///
-/// The IPv6 form is written out group by group and then has its longest run of
-/// zero groups replaced by `::`, which is the rewrite musl performs and the
-/// reason a run of one group is left spelled out.
 pub(super) fn ntop(family: i32, packed: &[u8]) -> Option<String> {
     match family {
-        AF_INET => inet_ntoa([packed[0], packed[1], packed[2], packed[3]]),
-        AF_INET6 => Some(ntop_v6(packed)),
+        AF_INET => Some(super::inet_text::ntoa([
+            packed[0], packed[1], packed[2], packed[3],
+        ])),
+        AF_INET6 => Some(super::inet_text::ntop_v6(packed)),
         _ => None,
     }
-}
-
-fn ntop_v6(packed: &[u8]) -> String {
-    let group = |i: usize| (u16::from(packed[2 * i]) << 8) | u16::from(packed[2 * i + 1]);
-    // An IPv4-mapped address keeps its last four bytes in dotted-quad form.
-    let text = if packed[..12] == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff] {
-        format!(
-            "{:x}:{:x}:{:x}:{:x}:{:x}:{:x}:{}.{}.{}.{}",
-            group(0),
-            group(1),
-            group(2),
-            group(3),
-            group(4),
-            group(5),
-            packed[12],
-            packed[13],
-            packed[14],
-            packed[15]
-        )
-    } else {
-        (0..8)
-            .map(|i| format!("{:x}", group(i)))
-            .collect::<Vec<_>>()
-            .join(":")
-    };
-
-    // The longest run of `:` and `0` that starts the string or starts at a
-    // colon, taken only when it spans more than one zero group.
-    let bytes = text.as_bytes();
-    let (mut best, mut longest) = (0, 2);
-    for start in 0..bytes.len() {
-        if start != 0 && bytes[start] != b':' {
-            continue;
-        }
-        let run = bytes[start..]
-            .iter()
-            .take_while(|b| **b == b':' || **b == b'0')
-            .count();
-        if run > longest {
-            (best, longest) = (start, run);
-        }
-    }
-    if longest <= 3 {
-        return text;
-    }
-    format!("{}::{}", &text[..best], &text[best + longest..])
 }
 
 /// The `<sys/socket.h>` / `<netinet/in.h>` / `<netdb.h>` numbers, as musl

--- a/pyre/pyre-interpreter/src/module/_socket/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/mod.rs
@@ -10,6 +10,10 @@
 //! publishes the part that is left -- the type `socket.py` subclasses and the
 //! numbers it reads.
 
+// The text half of the address converters compiles everywhere so its corpus
+// runs with the unit tests, on hosts whose entry points reach libc instead.
+#[cfg(any(test, not(any(unix, windows))))]
+mod inet_text;
 #[cfg(not(any(unix, windows)))]
 mod interp_socket_wasm;
 #[cfg(any(unix, windows))]

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix_wasm.rs
@@ -1009,29 +1009,253 @@ fn uname(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(crate::_structseq::new_instance(uname_seq_type(), seq))
 }
 
-/// The first path argument of an entry point that takes more after it, with
-/// everything after it accepted and dropped: nothing here reads a mode, a time
-/// pair or a length, because nothing here writes.
+/// What one parameter of a refused entry point is, which decides the
+/// conversion a caller's mistake trips before the mount refuses the call.
+enum Param {
+    /// A path, encoded the way every other entry point encodes one.
+    Path(&'static str),
+    /// An integer, at the width the entry point declares.
+    Int(&'static str),
+    /// A file offset: `r_longlong` in PyPy and `Py_off_t` in 3.14's clinic
+    /// signature, rather than the narrower `c_int` used by modes.
+    Offset(&'static str),
+    /// The positional time pair `utime` validates before it reaches the
+    /// filesystem operation.
+    UTimePair(&'static str),
+    /// A value this arm never reads because it has no effect on this target:
+    /// the POSIX `symlink` implementation ignores `target_is_directory`.
+    Unread(&'static str),
+}
+
+impl Param {
+    fn name(&self) -> &'static str {
+        match self {
+            Param::Path(name)
+            | Param::Int(name)
+            | Param::Offset(name)
+            | Param::UTimePair(name)
+            | Param::Unread(name) => name,
+        }
+    }
+}
+
+/// Validate the time values `interp_posix.parse_utime_args` consumes before
+/// making the mutating call.  A read-only result comes after these conversions:
+/// malformed pairs, mutually exclusive spellings and values outside `time_t`
+/// do not become EROFS merely because this particular mount cannot write.
+fn validate_utime_args(
+    w_times: Option<PyObjectRef>,
+    w_ns: Option<PyObjectRef>,
+) -> Result<(), crate::PyError> {
+    let present = |value: Option<PyObjectRef>| {
+        value.filter(|w_value| !unsafe { is_none(*w_value) })
+    };
+    let times = present(w_times);
+    let ns = present(w_ns);
+    if times.is_some() && ns.is_some() {
+        return Err(crate::PyError::value_error(
+            "utime: you may specify either 'times' or 'ns' but not both",
+        ));
+    }
+
+    let unpack_two = |w_pair: PyObjectRef, what: &str| {
+        if !unsafe { pyre_object::is_tuple(w_pair) }
+            || unsafe { pyre_object::w_tuple_len(w_pair) } != 2
+        {
+            let shape = if what == "times" {
+                "either a tuple of two ints or None"
+            } else {
+                "a tuple of two ints"
+            };
+            return Err(crate::PyError::type_error(format!(
+                "utime: '{what}' must be {shape}"
+            )));
+        }
+        Ok((
+            unsafe { pyre_object::w_tuple_getitem(w_pair, 0) }.unwrap(),
+            unsafe { pyre_object::w_tuple_getitem(w_pair, 1) }.unwrap(),
+        ))
+    };
+    let time_t_overflow = || {
+        crate::PyError::overflow_error("timestamp out of range for platform time_t")
+    };
+    let validate_seconds = |w_value: PyObjectRef| -> Result<(), crate::PyError> {
+        if unsafe { pyre_object::is_int_or_long(w_value) } {
+            crate::builtins::space_index_w(w_value).map_err(|_| time_t_overflow())?;
+            return Ok(());
+        }
+        let w_float = crate::builtins::builtin_float(&[w_value]).map_err(|error| {
+            if error.kind == crate::PyErrorKind::OverflowError {
+                time_t_overflow()
+            } else {
+                crate::PyError::type_error(format!(
+                    "argument must be int or float, not {}",
+                    crate::type_methods::arg_type_name(w_value)
+                ))
+            }
+        })?;
+        let seconds = unsafe { pyre_object::w_float_get_value(w_float) };
+        if seconds.is_nan() {
+            return Err(crate::PyError::value_error(
+                "Invalid value NaN (not a number)",
+            ));
+        }
+        if !(seconds.floor() >= -(2f64.powi(63)) && seconds.floor() < 2f64.powi(63)) {
+            return Err(time_t_overflow());
+        }
+        Ok(())
+    };
+    let validate_nanoseconds = |w_value: PyObjectRef| -> Result<(), crate::PyError> {
+        let w_split = crate::builtins::builtin_divmod(&[
+            w_value,
+            pyre_object::w_int_new(1_000_000_000),
+        ])?;
+        let (Some(w_seconds), Some(w_remainder)) = (unsafe {
+            (
+                pyre_object::w_tuple_getitem(w_split, 0),
+                pyre_object::w_tuple_getitem(w_split, 1),
+            )
+        }) else {
+            return Err(crate::PyError::type_error(
+                "utime: divmod() returned a non-pair",
+            ));
+        };
+        crate::builtins::space_index_w(w_seconds).map_err(|error| {
+            if error.kind == crate::PyErrorKind::OverflowError {
+                time_t_overflow()
+            } else {
+                error
+            }
+        })?;
+        crate::builtins::space_index_w(w_remainder)?;
+        Ok(())
+    };
+
+    if let Some(w_pair) = times {
+        let (w_access, w_modified) = unpack_two(w_pair, "times")?;
+        validate_seconds(w_access)?;
+        validate_seconds(w_modified)?;
+    } else if let Some(w_pair) = ns {
+        let (w_access, w_modified) = unpack_two(w_pair, "ns")?;
+        validate_nanoseconds(w_access)?;
+        validate_nanoseconds(w_modified)?;
+    }
+    Ok(())
+}
+
+/// The signature a refused entry point still has to bind.
 ///
-/// `path_kw` is what that argument is called, which is not the same word for
-/// all of them -- the one-path calls name it `path` and the two-path calls
-/// name it `src` -- and every one of them can be spelled as a keyword.
+/// `EROFS` is the answer to a call this mount cannot carry out, but a call
+/// that never named a valid argument list does not reach the mount at all:
+/// it is the `TypeError` its binding raises on any other host.
+struct WriteSig {
+    /// The positional-or-keyword parameters, in order.  The first path among
+    /// them is the one the `EROFS` is named by, and it is not called the same
+    /// word for all of them -- the one-path calls name it `path` and the
+    /// two-path calls name it `src`.
+    params: &'static [Param],
+    /// How many of `params` a call must supply.
+    required: usize,
+    /// The keyword-only parameters.  Every `dir_fd` among them has to be
+    /// absent, since the seam is handed a name rather than a descriptor to
+    /// resolve against, and `follow_symlinks` has to stay true, since nothing
+    /// this seam reports is a symbolic link.
+    kwonly: &'static [&'static str],
+}
+
+/// Reject a keyword-only argument this platform has no way to honour, using
+/// the wording the argument clinic's own two refusals carry.
+fn check_kwonly(
+    kwargs: Option<PyObjectRef>,
+    name: &'static str,
+    kwonly: &'static [&'static str],
+) -> Result<(), crate::PyError> {
+    for key in kwonly {
+        let Some(w_value) = crate::builtins::kwarg_get(kwargs, key) else {
+            continue;
+        };
+        // `dir_fd_unavailable` names the parameter `dir_fd` whichever of the
+        // three spellings the entry point gave it.
+        let message = if key.ends_with("dir_fd") {
+            (!unsafe { is_none(w_value) }).then(|| "dir_fd unavailable on this platform".to_owned())
+        } else if *key == "follow_symlinks" {
+            (!crate::baseobjspace::is_true(w_value)?)
+                .then(|| format!("{name}: follow_symlinks unavailable on this platform"))
+        } else {
+            None
+        };
+        if let Some(message) = message {
+            return Err(crate::PyError::not_implemented(message));
+        }
+    }
+    Ok(())
+}
+
+/// Bind `sig` against a call and answer with the first path it named.
 fn write_path_arg(
     args: &[PyObjectRef],
     name: &'static str,
-    path_kw: &'static str,
+    sig: &WriteSig,
 ) -> Result<crate::gateway::FsEncodedPath, crate::PyError> {
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-    let Some(w_path) = pos
-        .first()
-        .copied()
-        .or_else(|| crate::builtins::kwarg_get(kwargs, path_kw))
-    else {
+    let allowed: Vec<&str> = sig
+        .params
+        .iter()
+        .map(Param::name)
+        .chain(sig.kwonly.iter().copied())
+        .collect();
+    crate::builtins::kwarg_reject_unknown(kwargs, &allowed, name)?;
+    if pos.len() > sig.params.len() {
         return Err(crate::PyError::type_error(format!(
-            "{name}() missing required argument '{path_kw}' (pos 1)"
+            "{name}() takes at most {} positional arguments ({} given)",
+            sig.params.len(),
+            pos.len()
         )));
-    };
-    crate::gateway::fsencode_path_or_fd_w(w_path, name, false)
+    }
+    let mut first_path = None;
+    let mut utime_times = None;
+    let mut has_utime_pair = false;
+    for (slot, param) in sig.params.iter().enumerate() {
+        let bound =
+            crate::builtins::bind_pos_or_kw(pos, kwargs, slot, param.name(), name, slot + 1)?;
+        if matches!(param, Param::UTimePair(_)) {
+            has_utime_pair = true;
+            utime_times = bound;
+        }
+        let Some(w_value) = bound else {
+            if slot < sig.required {
+                return Err(crate::PyError::type_error(format!(
+                    "{name}() missing required argument '{}' (pos {})",
+                    param.name(),
+                    slot + 1
+                )));
+            }
+            continue;
+        };
+        match param {
+            Param::Path(_) => {
+                let resolved = crate::gateway::fsencode_path_or_fd_w(w_value, name, false)?;
+                if first_path.is_none() {
+                    first_path = Some(resolved);
+                }
+            }
+            Param::Int(_) => {
+                crate::baseobjspace::c_int_w(w_value)?;
+            }
+            Param::Offset(_) => {
+                crate::builtins::space_index_w(w_value)?;
+            }
+            Param::UTimePair(_) => {}
+            Param::Unread(_) => {}
+        }
+    }
+    check_kwonly(kwargs, name, sig.kwonly)?;
+    if has_utime_pair {
+        validate_utime_args(utime_times, crate::builtins::kwarg_get(kwargs, "ns"))?;
+    }
+    first_path.ok_or_else(|| {
+        crate::PyError::type_error(format!("{name}() missing required path argument"))
+    })
 }
 
 /// The entry points a read-only mount publishes and refuses, named by the
@@ -1043,14 +1267,68 @@ fn write_path_arg(
 fn refuse_write_path(
     args: &[PyObjectRef],
     name: &'static str,
-    path_kw: &'static str,
+    sig: &WriteSig,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let resolved = write_path_arg(args, name, path_kw)?;
+    let resolved = write_path_arg(args, name, sig)?;
     Err(crate::PyError::os_error_syscall(
         crate::builtins::wasm_errno::EROFS,
         resolved.w_path(),
     ))
 }
+
+/// `mkdir(path, mode=0o777, *, dir_fd=None)`.
+static MKDIR_SIG: WriteSig = WriteSig {
+    params: &[Param::Path("path"), Param::Int("mode")],
+    required: 1,
+    kwonly: &["dir_fd"],
+};
+
+/// `chmod(path, mode, *, dir_fd=None, follow_symlinks=True)`.
+static CHMOD_SIG: WriteSig = WriteSig {
+    params: &[Param::Path("path"), Param::Int("mode")],
+    required: 2,
+    kwonly: &["dir_fd", "follow_symlinks"],
+};
+
+/// `utime(path, times=None, *, ns=..., dir_fd=None, follow_symlinks=True)`.
+static UTIME_SIG: WriteSig = WriteSig {
+    params: &[Param::Path("path"), Param::UTimePair("times")],
+    required: 1,
+    kwonly: &["ns", "dir_fd", "follow_symlinks"],
+};
+
+/// `truncate(path, length)`.
+static TRUNCATE_SIG: WriteSig = WriteSig {
+    params: &[Param::Path("path"), Param::Offset("length")],
+    required: 2,
+    kwonly: &[],
+};
+
+/// `rename(src, dst, *, src_dir_fd=None, dst_dir_fd=None)`, which `replace`
+/// repeats.
+static RENAME_SIG: WriteSig = WriteSig {
+    params: &[Param::Path("src"), Param::Path("dst")],
+    required: 2,
+    kwonly: &["src_dir_fd", "dst_dir_fd"],
+};
+
+/// `link(src, dst, *, src_dir_fd=None, dst_dir_fd=None, follow_symlinks=True)`.
+static LINK_SIG: WriteSig = WriteSig {
+    params: &[Param::Path("src"), Param::Path("dst")],
+    required: 2,
+    kwonly: &["src_dir_fd", "dst_dir_fd", "follow_symlinks"],
+};
+
+/// `symlink(src, dst, target_is_directory=False, *, dir_fd=None)`.
+static SYMLINK_SIG: WriteSig = WriteSig {
+    params: &[
+        Param::Path("src"),
+        Param::Path("dst"),
+        Param::Unread("target_is_directory"),
+    ],
+    required: 2,
+    kwonly: &["dir_fd"],
+};
 
 /// Two of the four `access` mode bits, which the constant table publishes
 /// under the same names.
@@ -1070,6 +1348,12 @@ fn access(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         &["path", "mode", "dir_fd", "effective_ids", "follow_symlinks"],
         "access",
     )?;
+    if pos.len() > 2 {
+        return Err(crate::PyError::type_error(format!(
+            "access() takes at most 2 positional arguments ({} given)",
+            pos.len()
+        )));
+    }
     let Some(w_path) = crate::builtins::bind_pos_or_kw(pos, kwargs, 0, "path", "access", 2)? else {
         return Err(crate::PyError::type_error(
             "access() missing required argument 'path' (pos 1)",
@@ -1080,8 +1364,19 @@ fn access(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             "access() missing required argument 'mode' (pos 2)",
         ));
     };
-    let mode = unsafe { pyre_object::w_int_get_value(w_mode) };
+    let mode = i64::from(crate::baseobjspace::c_int_w(w_mode)?);
     let resolved = crate::gateway::fsencode_path_or_fd_w(w_path, "access", false)?;
+    check_kwonly(kwargs, "access", &["dir_fd", "follow_symlinks"])?;
+    // The seam answers for the caller, and there is no second identity here
+    // to answer for instead.  Do not turn an exception from a caller's
+    // `__bool__` into the default false spelling.
+    if let Some(w_effective_ids) = crate::builtins::kwarg_get(kwargs, "effective_ids") {
+        if crate::baseobjspace::is_true(w_effective_ids)? {
+            return Err(crate::PyError::not_implemented(
+                "access: effective_ids unavailable on this platform",
+            ));
+        }
+    }
     let path = seam_path(&resolved.as_bytes);
     let is_dir = crate::importing::source_is_dir(&path);
     let exists = is_dir || crate::importing::source_file_size(&path).is_ok();
@@ -1103,7 +1398,7 @@ fn write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             pos.len()
         )));
     }
-    let fd = unsafe { pyre_object::w_int_get_value(pos[0]) };
+    let fd = crate::baseobjspace::c_int_w(pos[0])?;
     let data = unsafe {
         if !pyre_object::bytesobject::is_bytes_like(pos[1]) {
             return Err(crate::PyError::type_error(
@@ -1126,10 +1421,23 @@ fn write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         }
     };
     if !delivered {
-        return Err(crate::PyError::os_error_syscall(
-            crate::builtins::wasm_errno::EBADF,
-            pyre_object::w_none(),
-        ));
+        // No embedder is listening, so the bytes take the descriptor itself,
+        // which is where `emit_stdout` sends them under the same condition.
+        // They go raw: `os.write` is not the layer that rewrites newlines.
+        use std::io::Write;
+        let written = if fd == 1 {
+            std::io::stdout().write_all(data)
+        } else {
+            std::io::stderr().write_all(data)
+        };
+        written.map_err(|error| {
+            crate::PyError::os_error_syscall(
+                error
+                    .raw_os_error()
+                    .unwrap_or(crate::builtins::wasm_errno::EIO),
+                pyre_object::w_none(),
+            )
+        })?;
     }
     Ok(pyre_object::w_int_new(data.len() as i64))
 }
@@ -1143,7 +1451,7 @@ fn sync_fd(args: &[PyObjectRef], name: &'static str) -> Result<PyObjectRef, crat
             "{name} expected 1 argument, got 0"
         )));
     };
-    let fd = unsafe { pyre_object::w_int_get_value(w_fd) } as i32;
+    let fd = crate::baseobjspace::c_int_w(w_fd)?;
     if fd == 1 || fd == 2 {
         return Ok(pyre_object::w_none());
     }
@@ -1344,47 +1652,48 @@ pub fn register_module(ns: PyObjectRef) -> Result<(), crate::PyError> {
     // The rest of wasi's writing surface, published so that a program can ask
     // for it and refused because the mount is read-only.  `mkdir` and `chmod`
     // take a mode after the path, `utime` a pair of times, `truncate` a
-    // length: none is read, since none of them gets as far as writing.
+    // length: each is converted before the mount's EROFS is reported, just as
+    // the syscall-backed entry points convert them before making their call.
     crate::module_ns_store(
         ns,
         "mkdir",
-        crate::make_builtin_function("mkdir", |args| refuse_write_path(args, "mkdir", "path")),
+        crate::make_builtin_function("mkdir", |args| refuse_write_path(args, "mkdir", &MKDIR_SIG)),
     );
     crate::module_ns_store(
         ns,
         "chmod",
-        crate::make_builtin_function("chmod", |args| refuse_write_path(args, "chmod", "path")),
+        crate::make_builtin_function("chmod", |args| refuse_write_path(args, "chmod", &CHMOD_SIG)),
     );
     crate::module_ns_store(
         ns,
         "utime",
-        crate::make_builtin_function("utime", |args| refuse_write_path(args, "utime", "path")),
+        crate::make_builtin_function("utime", |args| refuse_write_path(args, "utime", &UTIME_SIG)),
     );
     crate::module_ns_store(
         ns,
         "truncate",
-        crate::make_builtin_function("truncate", |args| refuse_write_path(args, "truncate", "path")),
+        crate::make_builtin_function("truncate", |args| refuse_write_path(args, "truncate", &TRUNCATE_SIG)),
     );
     // The two-path calls, named by their source the way `rename` reports it.
     crate::module_ns_store(
         ns,
         "rename",
-        crate::make_builtin_function("rename", |args| refuse_write_path(args, "rename", "src")),
+        crate::make_builtin_function("rename", |args| refuse_write_path(args, "rename", &RENAME_SIG)),
     );
     crate::module_ns_store(
         ns,
         "replace",
-        crate::make_builtin_function("replace", |args| refuse_write_path(args, "replace", "src")),
+        crate::make_builtin_function("replace", |args| refuse_write_path(args, "replace", &RENAME_SIG)),
     );
     crate::module_ns_store(
         ns,
         "link",
-        crate::make_builtin_function("link", |args| refuse_write_path(args, "link", "src")),
+        crate::make_builtin_function("link", |args| refuse_write_path(args, "link", &LINK_SIG)),
     );
     crate::module_ns_store(
         ns,
         "symlink",
-        crate::make_builtin_function("symlink", |args| refuse_write_path(args, "symlink", "src")),
+        crate::make_builtin_function("symlink", |args| refuse_write_path(args, "symlink", &SYMLINK_SIG)),
     );
     crate::module_ns_store(
         ns,
@@ -1392,7 +1701,14 @@ pub fn register_module(ns: PyObjectRef) -> Result<(), crate::PyError> {
         crate::make_builtin_function_with_arity(
             "ftruncate",
             |args| {
-                sync_fd(args, "ftruncate")?;
+                // `interp_posix.ftruncate` unwraps `fd=c_int,
+                // length=r_longlong` before reaching `rposix.ftruncate`; the
+                // descriptor lookup happens only after both conversions.
+                let fd = crate::baseobjspace::c_int_w(args[0])?;
+                crate::builtins::space_index_w(args[1])?;
+                if fd != 1 && fd != 2 {
+                    with_raw_fd(fd, |_| Ok(()))?;
+                }
                 Err(crate::PyError::os_error_syscall(
                     crate::builtins::wasm_errno::EROFS,
                     pyre_object::w_none(),
@@ -1429,7 +1745,12 @@ pub fn register_module(ns: PyObjectRef) -> Result<(), crate::PyError> {
         "device_encoding",
         crate::make_builtin_function_with_arity(
             "device_encoding",
-            |_args| Ok(pyre_object::w_none()),
+            |args| {
+                // `interp_posix.device_encoding` takes `fd=c_int` even on a
+                // platform where no descriptor can be a terminal.
+                crate::baseobjspace::c_int_w(args[0])?;
+                Ok(pyre_object::w_none())
+            },
             1,
         ),
     );


### PR DESCRIPTION
Follow-up to #1583.

## Summary

- move the arithmetic half of the inet converters into a host-testable module
- accept IPv6 dotted quads after a compressed run and preserve musl longest-zero-run tie breaking
- bind and convert the wasm posix write signatures before the read-only seam reports EROFS
- preserve conversion and exception ordering for utime, truncate, ftruncate, access, and device_encoding
- retain raw stdout/stderr delivery when no wasm output hook is installed

## Validation

- re-extracted pyre-interpreter and pyre-jit LLBC snapshots
- release wasm32-unknown-unknown build passed
- custom runtime corpus passed under both wasmtime and wasmi
- python3 pyre/check.py --backend wasm: 512/512
- cargo test --all --no-default-features --features dynasm
- cargo fmt --all -- --check
- git diff --check