### PR TITLE
majit-backend-dynasm, gc: allocate the entry JITFRAME in the nursery, and decode the managed deadframe's fail args through rd_locs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,6 +1959,7 @@ dependencies = [
  "majit-trace",
  "majit-translate",
  "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -420,7 +420,7 @@ fn resolve_jitframe_heap(gc: &dyn GcAllocator) -> JitFrameHeap {
 /// register the `majit_gc::set_active_*` function-pointer hooks,
 /// without requiring a `CraneliftBackend` instance.
 /// Install a GC box into TLS and register all `set_active_*` hooks.
-/// Shared by `install_gc_standalone` (production) and `set_gc_allocator` (tests).
+/// Used by tests and embedders whose whole managed heap is thread-confined.
 fn install_gc_box(mut gc: Box<dyn GcAllocator>) {
     // Per-thread allocator: its nursery is not the singleton's, so the
     // process-wide published range can no longer answer `is_nursery_object`.
@@ -434,9 +434,9 @@ fn install_gc_box(mut gc: Box<dyn GcAllocator>) {
 }
 
 /// Register all backend-agnostic `majit_gc::set_active_*` hooks to the
-/// cranelift trampolines. Shared by `install_gc_box` (test: also stores a
-/// box) and `install_gc_standalone` (production: hooks only, no box — the
-/// trampolines then route to the `gc_sync` singleton).
+/// cranelift trampolines. Shared by `install_gc_box` (thread-confined heap:
+/// also stores a box) and `install_gc_standalone` (shared heap: hooks only, no
+/// box; the trampolines then route to the `gc_sync` singleton).
 fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_gc_guard_hooks(majit_gc::ActiveGcGuardHooks {
         check_is_object: Some(check_is_object_via_active_runtime),
@@ -1544,12 +1544,13 @@ thread_local! {
 ///
 /// `gc.py:30` `GcLLDescription.__init__` holds `self.gcdescr` as a plain field
 /// on the backend descriptor — there is no per-thread allocator upstream — so
-/// this cell is scaffolding, not a ported structure. Only `install_gc_box`
-/// fills it and only tests reach that; the production build goes through
-/// `install_gc_standalone` and allocates from the `gc_sync` singleton.
+/// this cell is scaffolding, not a ported structure. `install_gc_box` fills it
+/// for tests and embedders whose complete managed heap is thread-confined; a
+/// runtime with shared managed values uses `install_gc_standalone` and the
+/// `gc_sync` singleton.
 ///
 /// Every accessor opens with `majit_gc::gc_box_installed()`, which without
-/// `majit-gc/gc_box` is a constant `false` — so in a production build each one
+/// `majit-gc/gc_box` is a constant `false` — so in a standalone build each one
 /// folds to `None`, the thread-local becomes unreachable, and the trampolines
 /// call `gc_sync` directly. The gate lives in `majit-gc` because a Cargo
 /// feature is per-crate: this crate cannot `#[cfg]` on a feature of its

--- a/majit/majit-backend-dynasm/Cargo.toml
+++ b/majit/majit-backend-dynasm/Cargo.toml
@@ -19,6 +19,7 @@ dynasmrt = { workspace = true }
 libc = { workspace = true }
 indexmap = { workspace = true }
 rustc-hash = { workspace = true }
+smallvec = { workspace = true }
 
 [dev-dependencies]
 majit-gc = { workspace = true, features = ["gc_box"] }

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -295,12 +295,35 @@ enum JitFrameHeap {
     Libc,
 }
 
+/// The JITFRAME type id resolved against the installed collector, read by
+/// every compiled entry that allocates its frame.
+///
+/// Upstream keeps this on the CPU: `malloc_jitframe` (`llmodel.py:298`) reads
+/// `self.cpu.gc_ll_descr`, a plain process-wide field, because there is one
+/// collector. This crate has two install paths, and the resolved id must have
+/// the same scope as the collector it was resolved against, or an entry can
+/// name a shape the collector it allocates from never registered:
+///
+/// - `install_gc_standalone` installs the process-wide `gc_sync` singleton,
+///   so its id lives in a process-wide static, like upstream. Any thread that
+///   reaches compiled code reads it — including one that never ran the install
+///   itself, which the thread-local below could not answer for.
+/// - `install_gc_box` installs a thread-confined collector (the `gc_box`
+///   thread-local, scaffolding for the test binaries where each thread builds
+///   its own collector and registers a different number of types ahead of
+///   JITFRAME). An id resolved against that collector is only valid on that
+///   thread, so it lives beside the box, in a thread-local of the same scope.
+///   Without `majit-gc/gc_box` the `gc_box_installed()` probe is a constant
+///   `false`, the cell is unreachable, and it retires with the box.
+///
+/// Resolving once at install rather than at every entry keeps the hot entry
+/// from querying the type table (`resolve_jitframe_type_id`).
+static STANDALONE_JITFRAME_TYPE_ID: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(u32::MAX);
+
 thread_local! {
-    /// The JITFRAME id resolved against this thread's active collector at
-    /// install time. Like cranelift's `JitFrameHeap`, this prevents a hot
-    /// entry from querying the type table and prevents a process-wide id
-    /// published for another test collector from naming the wrong shape.
-    static ACTIVE_JITFRAME_TYPE_ID: core::cell::Cell<Option<u32>> = const {
+    /// See [`STANDALONE_JITFRAME_TYPE_ID`]: the box-scoped twin.
+    static BOX_JITFRAME_TYPE_ID: core::cell::Cell<Option<u32>> = const {
         core::cell::Cell::new(None)
     };
 }
@@ -310,8 +333,18 @@ fn resolve_jitframe_type_id(gc: &dyn majit_gc::GcAllocator) -> Option<u32> {
     (gc.type_size(id) == Some(JitFrame::alloc_size(0))).then_some(id)
 }
 
+fn set_standalone_jitframe_type_id(id: Option<u32>) {
+    STANDALONE_JITFRAME_TYPE_ID.store(id.unwrap_or(u32::MAX), Ordering::Release);
+}
+
 fn active_jitframe_type_id() -> Option<u32> {
-    ACTIVE_JITFRAME_TYPE_ID.with(core::cell::Cell::get)
+    if majit_gc::gc_box_installed() {
+        return BOX_JITFRAME_TYPE_ID.with(core::cell::Cell::get);
+    }
+    match STANDALONE_JITFRAME_TYPE_ID.load(Ordering::Acquire) {
+        u32::MAX => None,
+        id => Some(id),
+    }
 }
 
 type EntryArgRoots = smallvec::SmallVec<[majit_gc::shadow_stack::OwnerRootGuard; 4]>;
@@ -448,7 +481,7 @@ fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
     majit_gc::disarm_published_nursery();
     majit_gc::note_gc_box_installed();
     let supports_guard_gc_type = gc.supports_guard_gc_type();
-    ACTIVE_JITFRAME_TYPE_ID.with(|slot| slot.set(resolve_jitframe_type_id(gc.as_ref())));
+    BOX_JITFRAME_TYPE_ID.with(|slot| slot.set(resolve_jitframe_type_id(gc.as_ref())));
     gc_box::store(gc);
     register_active_hooks(supports_guard_gc_type);
 }
@@ -461,7 +494,7 @@ pub fn install_gc_standalone() {
     let (supports_guard_gc_type, jitframe_type_id) = majit_gc::gc_sync::gc_query(|gc| {
         (gc.supports_guard_gc_type(), resolve_jitframe_type_id(gc))
     });
-    ACTIVE_JITFRAME_TYPE_ID.with(|slot| slot.set(jitframe_type_id));
+    set_standalone_jitframe_type_id(jitframe_type_id);
     register_active_hooks(supports_guard_gc_type);
 }
 
@@ -471,7 +504,7 @@ pub fn install_gc_standalone() {
 /// freed memory.
 pub fn clear_gc_allocator() {
     gc_box::clear();
-    ACTIVE_JITFRAME_TYPE_ID.with(|slot| slot.set(None));
+    BOX_JITFRAME_TYPE_ID.with(|slot| slot.set(None));
 }
 
 /// TYPE_INFO / CLASSTYPE constants read by the dynasm assemblers for

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 /// rpython/jit/backend/x86/runner.py AbstractX86CPU.
 use std::sync::atomic::Ordering;
 
+use majit_backend::deadframe::{ExitDescr, JitFrameDeadFrame};
 use majit_backend::libc_deadframe::LibcJitFrameDeadFrame;
 use majit_backend::{AsmInfo, Backend, BackendError, DeadFrame, JitCellToken};
 // `gc_sync` hands out the concrete collector; the trait must be in scope for
@@ -58,7 +59,7 @@ struct DynasmCaTarget {
 
 thread_local! {
     /// CALL_ASSEMBLER callee dispatch table.  RPython keeps the equivalent
-    /// state on `cpu.assembler` (per-CPU); pyre's JIT compiles and executes
+    /// state on `cpu.assembler` (per-CPU); majit's JIT compiles and executes
     /// on a single thread, so a thread-local mirrors that per-context scope
     /// while keeping concurrent backend test binaries (each test runs on its
     /// own thread) from sharing a global map keyed by reused token numbers —
@@ -102,12 +103,13 @@ pub(crate) fn lookup_call_assembler_callee_locs(
 ///
 /// `gc.py:30` `GcLLDescription.__init__` holds `self.gcdescr` as a plain field
 /// on the backend descriptor — there is no per-thread allocator upstream — so
-/// this cell is scaffolding, not a ported structure. Only `install_gc_box`
-/// fills it and only tests reach that; the production build goes through
-/// `install_gc_standalone` and allocates from the `gc_sync` singleton.
+/// this cell is scaffolding, not a ported structure. `install_gc_box` fills it
+/// for tests and embedders whose complete managed heap is thread-confined; a
+/// runtime with shared managed values uses `install_gc_standalone` and the
+/// `gc_sync` singleton.
 ///
 /// Every accessor opens with `majit_gc::gc_box_installed()`, which without
-/// `majit-gc/gc_box` is a constant `false` — so in a production build each one
+/// `majit-gc/gc_box` is a constant `false` — so in a standalone build each one
 /// folds to `None`, the thread-local becomes unreachable, and the trampolines
 /// call `gc_sync` directly. The gate lives in `majit-gc` because a Cargo
 /// feature is per-crate: this crate cannot `#[cfg]` on a feature of its
@@ -287,15 +289,86 @@ pub(crate) fn with_dynasm_active_gc_mut<R>(
     None
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum JitFrameHeap {
+    Gc,
+    Libc,
+}
+
+thread_local! {
+    /// The JITFRAME id resolved against this thread's active collector at
+    /// install time. Like cranelift's `JitFrameHeap`, this prevents a hot
+    /// entry from querying the type table and prevents a process-wide id
+    /// published for another test collector from naming the wrong shape.
+    static ACTIVE_JITFRAME_TYPE_ID: core::cell::Cell<Option<u32>> = const {
+        core::cell::Cell::new(None)
+    };
+}
+
+fn resolve_jitframe_type_id(gc: &dyn majit_gc::GcAllocator) -> Option<u32> {
+    let id = crate::jitframe_gc_type_id()?;
+    (gc.type_size(id) == Some(JitFrame::alloc_size(0))).then_some(id)
+}
+
+fn active_jitframe_type_id() -> Option<u32> {
+    ACTIVE_JITFRAME_TYPE_ID.with(core::cell::Cell::get)
+}
+
+type EntryArgRoots = smallvec::SmallVec<[majit_gc::shadow_stack::OwnerRootGuard; 4]>;
+
+/// `gc_ll_descr.malloc_jitframe(frame_info)` (`llmodel.py:298`).
+///
+/// A registered JITFRAME type means the frontend installed the framework GC,
+/// so allocate the frame as the ordinary moving `GcStruct` upstream creates.
+/// Input refs take explicit owner-root slots across a possible collection,
+/// reproducing the roots RPython's GC transform puts around this allocation.
+/// A backend without a registered collector keeps the host fallback.
+
+fn alloc_entry_jitframe(
+    size_bytes: usize,
+    args: &[Value],
+) -> (*mut JitFrame, JitFrameHeap, EntryArgRoots) {
+    if let Some(type_id) = active_jitframe_type_id() {
+        // RPython's GC transform exposes every live Ref local while
+        // `malloc_jitframe` may collect. Rust's stack is not traced, so mirror
+        // those roots explicitly and read the possibly-forwarded values back
+        // when filling the frame below. Four stays inline for the ordinary
+        // portal shape; larger signatures pay one temporary host allocation.
+        let roots: EntryArgRoots = args
+            .iter()
+            .filter_map(|arg| match arg {
+                Value::Ref(value) => Some(majit_gc::shadow_stack::OwnerRootGuard::new(*value)),
+                _ => None,
+            })
+            .collect();
+        if let Some(gcref) =
+            with_dynasm_active_gc_mut(|gc| gc.alloc_nursery_typed(type_id, size_bytes))
+        {
+            assert!(!gcref.is_null(), "JITFRAME GC allocation failed");
+            unsafe { std::ptr::write_bytes(gcref.0 as *mut u8, 0, size_bytes) };
+            return (gcref.0 as *mut JitFrame, JitFrameHeap::Gc, roots);
+        }
+    }
+
+    let ptr = majit_backend::jitframe::alloc_off_gc_jitframe(size_bytes);
+    assert!(!ptr.is_null(), "off-GC JITFRAME allocation failed");
+    majit_gc::shadow_stack::register_libc_jitframe(ptr as usize);
+    (ptr, JitFrameHeap::Libc, EntryArgRoots::new())
+}
+
+fn jitframe_is_gc_managed(frame: *mut JitFrame) -> bool {
+    with_dynasm_active_gc(|gc| gc.is_managed_heap_object(frame as usize)).unwrap_or(false)
+}
+
 /// Store a GC allocator in the dynasm backend thread-local and register
 /// the `majit_gc::set_active_*` function-pointer hooks, without
 /// requiring a `DynasmBackend` instance.  This allows the GC subsystem
 /// to be installed at boot (via `init_gc_subsystem`) before the JIT
 /// driver is constructed.
 /// Register all backend-agnostic `majit_gc::set_active_*` hooks to the
-/// dynasm trampolines. Shared by `install_gc_box` (test path: also stores
-/// a box in TLS) and `install_gc_standalone` (production: hooks only, no
-/// box — the trampolines then route to the `gc_sync` singleton).
+/// dynasm trampolines. Shared by `install_gc_box` (thread-confined heap: also
+/// stores a box in TLS) and `install_gc_standalone` (shared heap: hooks only,
+/// no box; the trampolines then route to the `gc_sync` singleton).
 fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_gc_guard_hooks(majit_gc::ActiveGcGuardHooks {
         check_is_object: Some(dynasm_check_is_object),
@@ -375,6 +448,7 @@ fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
     majit_gc::disarm_published_nursery();
     majit_gc::note_gc_box_installed();
     let supports_guard_gc_type = gc.supports_guard_gc_type();
+    ACTIVE_JITFRAME_TYPE_ID.with(|slot| slot.set(resolve_jitframe_type_id(gc.as_ref())));
     gc_box::store(gc);
     register_active_hooks(supports_guard_gc_type);
 }
@@ -384,7 +458,10 @@ fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
 /// (the per-thread GC box is the free-threading gap R4 removes).
 pub fn install_gc_standalone() {
     majit_gc::gc_sync::gc_op(|gc| gc.freeze_types());
-    let supports_guard_gc_type = majit_gc::gc_sync::gc_query(|gc| gc.supports_guard_gc_type());
+    let (supports_guard_gc_type, jitframe_type_id) = majit_gc::gc_sync::gc_query(|gc| {
+        (gc.supports_guard_gc_type(), resolve_jitframe_type_id(gc))
+    });
+    ACTIVE_JITFRAME_TYPE_ID.with(|slot| slot.set(jitframe_type_id));
     register_active_hooks(supports_guard_gc_type);
 }
 
@@ -394,6 +471,7 @@ pub fn install_gc_standalone() {
 /// freed memory.
 pub fn clear_gc_allocator() {
     gc_box::clear();
+    ACTIVE_JITFRAME_TYPE_ID.with(|slot| slot.set(None));
 }
 
 /// TYPE_INFO / CLASSTYPE constants read by the dynasm assemblers for
@@ -1033,8 +1111,9 @@ pub extern "C" fn dynasm_nursery_slowpath_headerless(size: u64) -> u64 {
 /// through the trailing array, i.e. it excludes the GC header that the
 /// allocator prepends internally.
 pub extern "C" fn dynasm_nursery_slowpath_jitframe(frame_size: u64) -> u64 {
+    let type_id = active_jitframe_type_id();
     with_dynasm_active_gc_mut(|gc| {
-        if let Some(type_id) = crate::jitframe_gc_type_id() {
+        if let Some(type_id) = type_id {
             gc.alloc_nursery_typed(type_id, frame_size as usize).0 as u64
         } else {
             gc.alloc_nursery(frame_size as usize).0 as u64
@@ -1423,13 +1502,8 @@ fn dynasm_write_barrier_if_managed(obj_ptr: u64) {
 /// `rbp = rax` so subsequent frame-relative loads/stores land on the
 /// reallocated frame.
 ///
-/// `old_jf` and the returned pointer are both libc-allocated jitframes
-/// registered with the shadow_stack tracker — matching the runner's
-/// `execute_token` allocation strategy (see `register_libc_jitframe`).
-///
 /// # Safety
-/// - `old_jf` must be a live, `register_libc_jitframe`-tracked
-///   `*mut JitFrame` (i.e. the running loop/bridge's current frame).
+/// - `old_jf` must be the live, resolved frame of the running loop/bridge.
 /// - The caller (the JIT-emitted slowpath body) must have already
 ///   spilled all live registers into the old frame via
 ///   `_push_all_regs_to_jitframe`; this helper relies on the GC seeing
@@ -1439,22 +1513,44 @@ pub unsafe extern "C" fn dynasm_realloc_frame(
     expected_depth: isize,
 ) -> *mut JitFrame {
     let base_ofs = DynasmBackend::get_baseofs_of_frame_field() as isize;
+    let gc_managed = jitframe_is_gc_managed(old_jf);
     let new_jf = unsafe {
         majit_backend::jitframe::realloc_frame(
             old_jf,
             expected_depth,
             base_ofs,
-            // `alloc`: off-GC, header-reserving, to match the runner-allocated frame.
-            |size_bytes| majit_backend::jitframe::alloc_off_gc_jitframe(size_bytes as usize),
-            // `write_barrier`: register the new frame with the shadow
-            // stack tracer.  The old frame stays registered for the
-            // duration of the running call; `jf_forward` is followed
-            // by the collector through `jitframe.py:111-118`.
+            |size_bytes| {
+                if gc_managed {
+                    let type_id = active_jitframe_type_id()
+                        .expect("a managed JITFRAME has a published type id");
+                    let gcref = with_dynasm_active_gc_mut(|gc| {
+                        gc.alloc_nursery_no_collect_typed(type_id, size_bytes as usize)
+                    })
+                    .expect("a managed JITFRAME has an active collector");
+                    assert!(!gcref.is_null(), "JITFRAME realloc failed");
+                    std::ptr::write_bytes(gcref.0 as *mut u8, 0, size_bytes as usize);
+                    gcref.0 as *mut JitFrame
+                } else {
+                    majit_backend::jitframe::alloc_off_gc_jitframe(size_bytes as usize)
+                }
+            },
             |new_jf| {
-                majit_gc::shadow_stack::register_libc_jitframe(new_jf as usize);
+                if gc_managed {
+                    with_dynasm_active_gc_mut(|gc| gc.write_barrier(GcRef(new_jf as usize)))
+                        .expect("a managed JITFRAME has an active collector");
+                } else {
+                    majit_gc::shadow_stack::register_libc_jitframe(new_jf as usize);
+                }
             },
         )
     };
+    if gc_managed {
+        // `frame.jf_forward = new_frame` is a GC-pointer store on the old
+        // frame. `realloc_frame` documents this caller-side barrier, matching
+        // the framework transform around llmodel.py:141.
+        with_dynasm_active_gc_mut(|gc| gc.write_barrier(GcRef(old_jf as usize)))
+            .expect("a managed JITFRAME has an active collector");
+    }
     if crate::majit_log_enabled() {
         eprintln!(
             "[dynasm][realloc-frame] old={old_jf:p} new={new_jf:p} expected_depth={expected_depth}"
@@ -2911,24 +3007,28 @@ impl Backend for DynasmBackend {
             Self::input_slot(args.len()),
             args.len()
         );
-        let jf_ptr =
-            majit_backend::jitframe::alloc_off_gc_jitframe(JitFrame::alloc_size(num_slots));
-        assert!(!jf_ptr.is_null(), "execute_token: frame allocation failed");
+        let (jf_ptr, frame_heap, arg_roots) =
+            alloc_entry_jitframe(JitFrame::alloc_size(num_slots), args);
         unsafe { JitFrame::init(jf_ptr, fi_ptr, num_slots) };
-        // Register this libc-allocated jitframe with the GC so its
-        // interior Ref slots (pinned by gcmap bits) remain visible to
-        // the collector during CallMallocNursery slow-path collections.
-        majit_gc::shadow_stack::register_libc_jitframe(jf_ptr as usize);
 
+        let mut ref_index = 0;
         for (i, arg) in args.iter().enumerate() {
             let raw = match arg {
                 Value::Int(v) => *v,
-                Value::Ref(r) => r.0 as i64,
+                Value::Ref(r) => {
+                    let current = arg_roots.get(ref_index).map_or(*r, |root| root.get());
+                    ref_index += 1;
+                    current.0 as i64
+                }
                 Value::Float(f) => f.to_bits() as i64,
                 Value::Void => 0,
             };
             unsafe { crate::llmodel::set_int_value(jf_ptr, Self::input_slot(i), raw as isize) };
         }
+        // These roots exist only to span the collecting frame allocation.
+        // Once the forwarded refs are in the frame, keeping their owner-root
+        // slots through compiled execution would add them to every GC scan.
+        drop(arg_roots);
 
         if majit_ir::debug::have_debug_prints() {
             let _s = majit_ir::debug::scope("jit-running");
@@ -3034,18 +3134,20 @@ impl Backend for DynasmBackend {
             );
         }
 
-        // `llmodel.py return ll_frame` — the deadframe IS the frame the
-        // run returned. `result_jf` is the tip of `jf_ptr`'s `jf_forward`
-        // chain whenever `_check_frame_depth` realloc'd; the whole chain is
-        // handed to the deadframe, which frees it when it drops rather than
-        // here (frames allocated off the GC heap have no upstream free
-        // counterpart — upstream's JITFRAME is a `GcStruct`). Every slot read,
-        // and `grab_exc_value`, then goes straight into the frame the way
-        // `llmodel.py:240-250` does — nothing is decoded eagerly and no copy
-        // of the frame is made.
-        DeadFrame::LibcJitFrame(unsafe {
-            LibcJitFrameDeadFrame::owning(jf_ptr, result_jf, num_slots, descr, None)
-        })
+        // `llmodel.py return ll_frame` — the deadframe IS the frame the run
+        // returned. A framework-GC frame takes a movable owner-root slot;
+        // the no-collector fallback owns and later frees its off-GC chain.
+        match frame_heap {
+            JitFrameHeap::Gc => DeadFrame::JitFrame(JitFrameDeadFrame::new(
+                GcRef(result_jf as usize),
+                ExitDescr::owned(descr),
+                None,
+                None,
+            )),
+            JitFrameHeap::Libc => DeadFrame::LibcJitFrame(unsafe {
+                LibcJitFrameDeadFrame::owning(jf_ptr, result_jf, num_slots, descr, None)
+            }),
+        }
     }
 
     /// Override execute_token_ints_raw to return the FULL jitframe
@@ -3083,21 +3185,9 @@ impl Backend for DynasmBackend {
             Self::input_slot(args.len()),
             args.len()
         );
-        let jf_ptr =
-            majit_backend::jitframe::alloc_off_gc_jitframe(JitFrame::alloc_size(num_slots));
-        assert!(
-            !jf_ptr.is_null(),
-            "execute_token_ints_raw: frame allocation failed"
-        );
+        let (jf_ptr, frame_heap, _arg_roots) =
+            alloc_entry_jitframe(JitFrame::alloc_size(num_slots), &[]);
         unsafe { JitFrame::init(jf_ptr, fi_ptr, num_slots) };
-        // Same registration as `execute_token` above: the libc-allocated
-        // jitframe must be visible to the minor-collection walker so its
-        // `jf_gcmap`-marked Ref slots get traced during
-        // CallMallocNursery-triggered collections. Without this the
-        // inner-loop jitframe's live Refs go un-updated and later guard
-        // deadframes read stale (freed-nursery) pointers. The matching
-        // `unregister_libc_jitframe` below balances this registration.
-        majit_gc::shadow_stack::register_libc_jitframe(jf_ptr as usize);
 
         for (i, &val) in args.iter().enumerate() {
             unsafe { crate::llmodel::set_int_value(jf_ptr, Self::input_slot(i), val as isize) };
@@ -3158,9 +3248,11 @@ impl Backend for DynasmBackend {
         let guard_value_operand = majit_backend::guard_value_counter_slot(descr_fd)
             .map(|slot| unsafe { crate::llmodel::get_int_value_direct(result_jf, slot) as i64 });
 
-        // No deadframe is built on this path, so nothing else takes ownership
-        // of the chain — free it here.
-        unsafe { majit_backend::libc_deadframe::free_jitframe_chain(jf_ptr) };
+        // No deadframe is built on this path. GC-managed frames become
+        // unreachable here; the host fallback still owns and frees its chain.
+        if frame_heap == JitFrameHeap::Libc {
+            unsafe { majit_backend::libc_deadframe::free_jitframe_chain(jf_ptr) };
+        }
 
         let descr_arc: majit_ir::DescrRef = descr.clone();
         majit_backend::RawExecResult {
@@ -3180,12 +3272,14 @@ impl Backend for DynasmBackend {
     }
 
     fn get_latest_descr<'a>(&'a self, frame: &'a DeadFrame) -> &'a dyn FailDescr {
-        let data = frame
-            .as_libc_jitframe()
-            .expect("dynasm deadframe is a libc jitframe");
-        data.fail_descr
-            .as_fail_descr()
-            .expect("LibcJitFrameDeadFrame::fail_descr must implement FailDescr")
+        match frame {
+            DeadFrame::JitFrame(data) => data.fail_descr.as_fail_descr(),
+            DeadFrame::LibcJitFrame(data) => data
+                .fail_descr
+                .as_fail_descr()
+                .expect("LibcJitFrameDeadFrame::fail_descr must implement FailDescr"),
+            DeadFrame::Boxed(_) => panic!("dynasm deadframe is a jitframe"),
+        }
     }
 
     fn force(&self, force_token: GcRef) -> Option<DeadFrame> {
@@ -3207,9 +3301,17 @@ impl Backend for DynasmBackend {
         // returns it — the forced frame IS the deadframe, and it belongs to
         // the compiled run that is still executing, so this deadframe borrows
         // it rather than taking the chain over.
-        Some(DeadFrame::LibcJitFrame(unsafe {
-            LibcJitFrameDeadFrame::borrowing(frame, num_slots, descr, None)
-        }))
+        if jitframe_is_gc_managed(frame) {
+            Some(DeadFrame::JitFrame(JitFrameDeadFrame::borrowing(
+                GcRef(frame as usize),
+                ExitDescr::owned(descr),
+                None,
+            )))
+        } else {
+            Some(DeadFrame::LibcJitFrame(unsafe {
+                LibcJitFrameDeadFrame::borrowing(frame, num_slots, descr, None)
+            }))
+        }
     }
 
     fn is_force_token_armed(&self, force_token: GcRef) -> bool {
@@ -3221,16 +3323,11 @@ impl Backend for DynasmBackend {
     }
 
     fn get_latest_descr_arc(&self, frame: &DeadFrame) -> Arc<dyn majit_ir::Descr> {
-        // `history.py:125` `cpu.get_latest_descr(deadframe)` returns the
-        // metainterp `AbstractFailDescr` object op.descr stamped.  After
-        // the LibcJitFrameDeadFrame::fail_descr type cascade to `DescrRef`, `fail_descr`
-        // *is* the metainterp Arc (production codegen + synthetic exits
-        // both stamp it via DescrRef directly), so we just clone the
-        // shared identity.
-        let data = frame
-            .as_libc_jitframe()
-            .expect("dynasm deadframe is a libc jitframe");
-        Arc::clone(&data.fail_descr)
+        match frame {
+            DeadFrame::JitFrame(data) => data.fail_descr.to_arc(),
+            DeadFrame::LibcJitFrame(data) => Arc::clone(&data.fail_descr),
+            DeadFrame::Boxed(_) => panic!("dynasm deadframe is a jitframe"),
+        }
     }
 
     /// `cpu.grab_exc_value(deadframe)` (llmodel.py): return the
@@ -3239,10 +3336,11 @@ impl Backend for DynasmBackend {
     /// must_save_exception guards (GUARD_EXCEPTION / GUARD_NO_EXCEPTION /
     /// GUARD_NOT_FORCED); other guards leave it NULL.
     fn grab_exc_value(&self, frame: &DeadFrame) -> GcRef {
-        frame
-            .as_libc_jitframe()
-            .expect("dynasm deadframe is a libc jitframe")
-            .exc_value()
+        match frame {
+            DeadFrame::JitFrame(data) => data.grab_exc_value(),
+            DeadFrame::LibcJitFrame(data) => data.exc_value(),
+            DeadFrame::Boxed(_) => panic!("dynasm deadframe is a jitframe"),
+        }
     }
 
     fn clear_stored_exception(&self) {
@@ -3279,31 +3377,35 @@ impl Backend for DynasmBackend {
     }
 
     fn get_int_value(&self, frame: &DeadFrame, index: usize) -> i64 {
-        frame
-            .as_libc_jitframe()
-            .expect("dynasm deadframe is a libc jitframe")
-            .get_int(index)
+        match frame {
+            DeadFrame::JitFrame(data) => data.get_int(index),
+            DeadFrame::LibcJitFrame(data) => data.get_int(index),
+            DeadFrame::Boxed(_) => panic!("dynasm deadframe is a jitframe"),
+        }
     }
 
     fn get_value_direct(&self, frame: &DeadFrame, slot: usize) -> i64 {
-        frame
-            .as_libc_jitframe()
-            .expect("dynasm deadframe is a libc jitframe")
-            .get_int_at_slot(slot)
+        match frame {
+            DeadFrame::JitFrame(data) => data.get_int_at_slot(slot),
+            DeadFrame::LibcJitFrame(data) => data.get_int_at_slot(slot),
+            DeadFrame::Boxed(_) => panic!("dynasm deadframe is a jitframe"),
+        }
     }
 
     fn get_float_value(&self, frame: &DeadFrame, index: usize) -> f64 {
-        frame
-            .as_libc_jitframe()
-            .expect("dynasm deadframe is a libc jitframe")
-            .get_float(index)
+        match frame {
+            DeadFrame::JitFrame(data) => data.get_float(index),
+            DeadFrame::LibcJitFrame(data) => data.get_float(index),
+            DeadFrame::Boxed(_) => panic!("dynasm deadframe is a jitframe"),
+        }
     }
 
     fn get_ref_value(&self, frame: &DeadFrame, index: usize) -> GcRef {
-        frame
-            .as_libc_jitframe()
-            .expect("dynasm deadframe is a libc jitframe")
-            .get_ref(index)
+        match frame {
+            DeadFrame::JitFrame(data) => data.get_ref(index),
+            DeadFrame::LibcJitFrame(data) => data.get_ref(index),
+            DeadFrame::Boxed(_) => panic!("dynasm deadframe is a jitframe"),
+        }
     }
 
     fn invalidate_loop(&self, token: &JitCellToken) {

--- a/majit/majit-backend/src/deadframe.rs
+++ b/majit/majit-backend/src/deadframe.rs
@@ -643,19 +643,45 @@ impl JitFrameDeadFrame {
         self.jf_root.get()
     }
 
+    /// `llmodel.py _decode_pos` — translate a logical fail-argument index
+    /// through the exit descriptor's recovery locations.
+    ///
+    /// Cranelift currently publishes a dense identity layout, while dynasm
+    /// keeps register spills in their architecture slots. The deadframe is
+    /// backend-neutral, so the mapping belongs at this common accessor just
+    /// as it does for [`crate::libc_deadframe::LibcJitFrameDeadFrame`].
+    #[inline]
+    fn slot_of(&self, index: usize) -> Option<usize> {
+        let descr = self.fail_descr.as_fail_descr();
+        if index < descr.rd_locs().len() {
+            crate::llmodel::decode_rd_loc_slot(descr, index)
+        } else {
+            Some(index)
+        }
+    }
+
     #[inline]
     pub fn get_int(&self, index: usize) -> i64 {
+        let Some(slot) = self.slot_of(index) else {
+            return 0;
+        };
+        self.get_int_at_slot(slot)
+    }
+
+    /// `llmodel.py get_value_direct` — read an already decoded frame slot.
+    #[inline]
+    pub fn get_int_at_slot(&self, slot: usize) -> i64 {
         // A safe function that dereferences an index the caller chose, so the
         // only thing between an index error and an out-of-bounds read is this
         // check. The frame carries its own slot count in the length word ahead
         // of `jf_frame`, which is the bound. `get_float` and `get_ref` read
         // through here, so one check covers all three.
-        debug_assert!(
-            (index as isize)
-                < unsafe { JitFrame::frame_length(self.jf_gcref().0 as *const JitFrame) },
-            "jf_frame index {index} is past the frame's own length",
-        );
-        unsafe { *((self.jf_gcref().0 + FIRST_ITEM_OFFSET + index * 8) as *const i64) }
+        let frame = self.jf_gcref();
+        let frame_len = unsafe { JitFrame::frame_length(frame.0 as *const JitFrame) };
+        if slot >= frame_len as usize {
+            return 0;
+        }
+        unsafe { *((frame.0 + FIRST_ITEM_OFFSET + slot * 8) as *const i64) }
     }
 
     #[inline]
@@ -722,7 +748,10 @@ impl Drop for JitFrameDeadFrame {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::FailDescr;
+    use crate::finish_descrs::DoneWithThisFrameDescrMulti;
     use crate::jitframe::{alloc_off_gc_jitframe, free_off_gc_jitframe};
+    use majit_ir::Type;
 
     fn a_descr() -> DescrRef {
         std::sync::Arc::new(majit_ir::descr::SimpleSizeDescr::new(0, 8, 0))
@@ -760,6 +789,34 @@ mod tests {
             "an owning deadframe releases the map once its values are read out"
         );
 
+        unsafe { free_off_gc_jitframe(frame) };
+    }
+
+    #[test]
+    fn managed_deadframe_decodes_nonidentity_recovery_locations() {
+        let frame = alloc_off_gc_jitframe(JitFrame::alloc_size(32));
+        assert!(!frame.is_null());
+        unsafe {
+            JitFrame::init(frame, std::ptr::null(), 32);
+            crate::llmodel::set_int_value(frame, 2, 22);
+            crate::llmodel::set_int_value(frame, 24, 240);
+        }
+
+        let descr = Arc::new(DoneWithThisFrameDescrMulti::new(vec![Type::Int, Type::Int]));
+        descr.set_rd_locs(vec![24, 2]);
+        let descr_ref: DescrRef = descr;
+        let deadframe = JitFrameDeadFrame::new(
+            GcRef(frame as usize),
+            ExitDescr::owned(descr_ref),
+            None,
+            None,
+        );
+
+        assert_eq!(deadframe.get_int(0), 240);
+        assert_eq!(deadframe.get_int(1), 22);
+        assert_eq!(deadframe.get_int_at_slot(2), 22);
+
+        drop(deadframe);
         unsafe { free_off_gc_jitframe(frame) };
     }
 }

--- a/majit/majit-backend/src/deadframe.rs
+++ b/majit/majit-backend/src/deadframe.rs
@@ -752,9 +752,10 @@ mod tests {
     use crate::finish_descrs::DoneWithThisFrameDescrMulti;
     use crate::jitframe::{alloc_off_gc_jitframe, free_off_gc_jitframe};
     use majit_ir::Type;
+    use std::sync::Arc;
 
     fn a_descr() -> DescrRef {
-        std::sync::Arc::new(majit_ir::descr::SimpleSizeDescr::new(0, 8, 0))
+        Arc::new(majit_ir::descr::SimpleSizeDescr::new(0, 8, 0))
     }
 
     /// The deadframe a compiled run returns owns the map its exit established;

--- a/majit/majit-gc/Cargo.toml
+++ b/majit/majit-gc/Cargo.toml
@@ -29,12 +29,13 @@ bh_probe = []
 
 # Per-thread GC box. `install_gc_box` stores a caller-supplied `GcAllocator` in
 # a backend thread-local and every allocation, write-barrier and heap query
-# checks for it first. Only tests install one — production goes through
-# `install_gc_standalone` and allocates from the `gc_sync` singleton — so
-# without this feature `gc_box_installed()` is a constant `false` and the
-# backends' box branches fold away entirely. A crate whose tests install a box
-# must carry `majit-gc = { ..., features = ["gc_box"] }` in `dev-dependencies`;
-# installing one without it panics rather than silently missing every probe.
+# checks for it first. The process-global language runtime goes through
+# `install_gc_standalone`; this alternative serves tests and embedders whose
+# complete managed heap is execution-context-local and never crosses threads.
+# Without this feature `gc_box_installed()` is a constant `false` and the
+# backends' box branches fold away. A crate using `set_gc_allocator` must
+# enable it; installing a box without it panics rather than silently routing
+# operations to another heap.
 gc_box = []
 
 [dependencies]

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1990,17 +1990,19 @@ pub fn supports_guard_gc_type() -> bool {
     ACTIVE_SUPPORTS_GUARD_GC_TYPE.load(std::sync::atomic::Ordering::Acquire)
 }
 
-/// Set once any thread has installed a per-thread GC box on any backend. That
-/// path is test-only: production installs the backend standalone, leaving the
-/// process-global [`gc_sync`] singleton as the sole allocator on every thread.
+/// Set once any thread has installed a per-thread GC box on any backend. The
+/// process-global language runtime installs the backend standalone; this path
+/// also serves embedders whose complete managed heap is execution-context
+/// local and never shares object identity across threads.
 ///
 /// Set-only, never cleared: a backend can drop one thread's box while another
 /// thread still owns one, and clearing the flag would route past that live box.
 ///
 /// RPython has no per-thread allocator — the GC transformer weaves every
 /// `malloc` against the single translation-time `gcdata`
-/// (`gctransform/framework.py`) — so the box is pyre-side test scaffolding, and
-/// the queries below let the allocation path it does not serve skip it.
+/// (`gctransform/framework.py`). A language runtime with shared managed values
+/// must therefore use [`gc_sync`]; a box is valid only when the embedder's heap
+/// itself has the narrower execution-context lifetime.
 ///
 /// Only compiled when a box can exist at all, i.e. under `gc_box`; see
 /// [`gc_box_installed`] for what the other build spells instead.
@@ -2022,8 +2024,8 @@ pub fn note_gc_box_installed() {
 pub fn note_gc_box_installed() {
     panic!(
         "a per-thread GC box was installed in a build without the `gc_box` feature; \
-         production installs the backend standalone (`install_gc_standalone`), and a \
-         test that needs a box must depend on `majit-gc` with `features = [\"gc_box\"]`"
+         a process-global runtime must use `install_gc_standalone`, while a test or \
+         thread-confined embedder must enable `majit-gc/gc_box`"
     );
 }
 

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -149,7 +149,7 @@ mod pyjitpl;
 #[cfg(not(target_arch = "wasm32"))]
 pub use pyjitpl::{
     active_backend_jit_exc_value_peek, install_active_backend_gc_standalone,
-    set_active_backend_jitframe_gc_type_id,
+    register_active_backend_jitframe_gc_type, set_active_backend_jitframe_gc_type_id,
 };
 pub mod quasiimmut;
 pub use quasiimmut::set_force_quasi_immutable_hook;

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -58,6 +58,19 @@ pub fn set_active_backend_jitframe_gc_type_id(id: u32) {
     majit_backend_dynasm::set_jitframe_gc_type_id(id);
 }
 
+/// Register RPython's `JITFRAME` shape on the frontend-owned collector and
+/// publish the assigned id to the selected native CPU.
+///
+/// Registration belongs to the frontend because its type table fixes the id;
+/// publishing belongs here because this crate alone selects the active CPU.
+/// Call this before `JitDriver::set_gc_allocator`, which freezes the table.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn register_active_backend_jitframe_gc_type(gc: &mut dyn majit_gc::GcAllocator) -> u32 {
+    let id = gc.register_type(majit_backend::jitframe::jitframe_type_info());
+    set_active_backend_jitframe_gc_type_id(id);
+    id
+}
+
 /// Install the process-global collector into the native CPU selected above.
 #[cfg(all(feature = "cranelift", not(target_arch = "wasm32")))]
 pub fn install_active_backend_gc_standalone() {


### PR DESCRIPTION
## What changed

- Allocate dynasm entry JITFRAMEs as registered, typed nursery objects when a framework collector is active.
- Root reference arguments across the potentially collecting frame allocation, then release those temporary roots once the forwarded values are stored in the frame.
- Register and publish the active backend JITFRAME type before freezing the collector's type table.
- Decode logical fail arguments through the exit descriptor's `rd_locs` in the backend-neutral managed deadframe.
- Preserve the off-GC host allocation fallback for embedders without a registered collector.

## Why

Dynasm allocated one host JITFRAME for every compiled entry even when the frontend had installed the framework GC. Besides diverging from RPython's `gc_ll_descr.malloc_jitframe` shape, that left CEL with one host allocation per steady-state JIT evaluation.

Moving the frame onto the nursery exposed a second defect: the generic managed deadframe read fail arguments as identity-mapped frame slots. Dynasm recovery layouts can use architecture spill slots, so a guard failure could restore corrupted state. The common accessor now performs the same descriptor-based recovery-location decoding as the existing libc deadframe.

## Impact

CEL's warmed compiled tier now measures zero host allocations per evaluation instead of one. GC-managed entry frames also avoid adding dead input roots to later collections because the temporary owner roots are dropped before compiled execution.

## Validation

- `cargo check --features dynasm`
- `cargo test --features dynasm`
- CEL dynasm and cranelift feature checks
- CEL allocation suite: warmed `regvm/jit-steady/*` rows at 0 host allocations/evaluation
- CEL columnar benchmark: all execution paths agree; compiled trace measured 0.57 ns/row in the final run
- Current regular pyre benchmark suite: dynasm 10/10 passed
- `cargo fmt --all -- --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added garbage-collector-managed JIT frames for supported runtime configurations, with automatic fallback handling.
  - Added registration support for JIT frame types with the active garbage collector.
- **Bug Fixes**
  - Improved recovery-location decoding for frame values.
  - Prevented invalid frame-slot access from causing failures.
- **Documentation**
  - Clarified support and usage guidance for thread-confined garbage-collection runtimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->