### PR TITLE
_multiprocessing and _ctypes parity, module exception weakrefs, and the multi-frame escape-flush stack

### DIFF
--- a/pyre/bench/synth/nested_for_escape_flush_keeps_the_inner_iterator.py
+++ b/pyre/bench/synth/nested_for_escape_flush_keeps_the_inner_iterator.py
@@ -1,0 +1,65 @@
+# pyre-check: selfcheck
+# pyre-check: selfcheck-compiles=root:leaf
+# The multi-frame escape flush publishes frame 0's LOCALS; this guards the
+# operand stack published with them.
+#
+# `sys._getframe(1)` read from an inlined callee forces the CALLER's
+# virtualizable, so the walk aborts as an inline sub-walk and a multi-frame
+# blackhole image resumes the two frames. The walk keeps that virtualizable
+# symbolic, so nothing it pushed or popped ever reached the live frame's slot
+# array. When the abort lands on a walk that crossed the inner `FOR_ITER`'s
+# exhaust, the outer `FOR_ITER` has already run and `GET_ITER` has built a
+# FRESH inner iterator that exists only in the walk: resuming without
+# publishing the stack leaves the PREVIOUS pass's exhausted iterator on TOS,
+# the inner loop ends one iteration in, and every later `i` runs one pass ahead
+# of the `j` beside it. The values the body reads stay intact, which is why
+# this reads as a loop-control error and not a lost item.
+#
+# Measured before the stack was published: `k=1041 i=209 j=0`, where `k` says
+# the body is at `i=208 j=1` -- the first abort lands at the default hotness
+# threshold and every pass after it is shifted. `loops_compiled` is 0 there and
+# 1 here; what reaches the JIT either way is `leaf`'s root trace, which is what
+# this declares.
+#
+# The same read in a `while` loop (`getframe_while_escaping_read_frame_identity`)
+# escapes just as often and cannot show this: with no iterator on the operand
+# stack there is nothing for a stale image to hold.
+import sys
+
+_gf = sys._getframe
+
+N = 5
+PASSES = 6000
+wrong = []
+
+
+def leaf(x):
+    name = _gf(1).f_code.co_name
+    if name != "main":
+        wrong.append(name)
+    return x + 1
+
+
+def main():
+    total = 0
+    k = 0
+    for i in range(PASSES):
+        for j in range(N):
+            total = leaf(total)
+            if k != i * N + j:
+                print(
+                    f"FAIL dropped iteration: k={k} i={i} j={j} "
+                    f"expected i={k // N} j={k % N}"
+                )
+                raise SystemExit(1)
+            k += 1
+    if total != PASSES * N:
+        print(f"FAIL short run: total={total} expected {PASSES * N}")
+        raise SystemExit(1)
+    if wrong:
+        print(f"FAIL caller identity: {wrong[:4]}")
+        raise SystemExit(1)
+    print(f"PASS total={total}")
+
+
+main()

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -165,6 +165,18 @@ PLATFORM_GATED = {
         lambda p: p not in ("win32", "emscripten", "wasi", "ios", "tvos", "watchos", "android"),
         "os.fork() not available",
     ),
+    # `if sys.platform == "win32": raise unittest.SkipTest("fork is not
+    # available on Windows")`, in the test package's `__init__`.
+    "test.test_multiprocessing_fork": (
+        lambda p: p != "win32",
+        "fork is not available on Windows",
+    ),
+    # `if sys.platform == "win32": raise unittest.SkipTest("forkserver is
+    # not available on Windows")`, in the test package's `__init__`.
+    "test.test_multiprocessing_forkserver": (
+        lambda p: p != "win32",
+        "forkserver is not available on Windows",
+    ),
     # `if not hasattr(os, "openpty"): raise unittest.SkipTest(...)`
     "test.test_openpty": (
         lambda p: p not in ("win32", "emscripten", "wasi"),

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -9068,6 +9068,44 @@ pub(crate) fn make_exc_type(
     make_exc_type_with_init(name, None, new_fn, None, base)
 }
 
+/// `new_exception_class` — a module's own exception class, as
+/// `PyErr_NewException` builds one.
+///
+/// Both spellings construct the class by calling `type(name, (base,), {})`:
+/// PyPy through `space.call_function(space.w_type, ...)`, `PyErr_NewException`
+/// through `PyObject_CallFunction((PyObject *)&PyType_Type, ...)`.  What that
+/// gives a class and a statically defined exception does not is a weakref
+/// slot, which is why `weakref.ref(_queue.Empty())` works where
+/// `weakref.ref(Exception())` is a `TypeError`.  Every exception here already
+/// carries the storage; this is the flag that makes it reachable.
+///
+/// Three module exception classes are built another way upstream and carry no
+/// slot: `ssl.SSLError`, `_csv.Error` and `_ctypes.COMError` come from a type
+/// spec that names its own `basicsize`, and a spec that does adds no managed
+/// weakref.  Those three keep [`make_exc_type`] / [`make_exc_type_with_init`].
+pub(crate) fn new_exception_class(
+    name: &'static str,
+    new_fn: crate::gateway::BuiltinCodeFn,
+    base: PyObjectRef,
+) -> PyObjectRef {
+    let cls = make_exc_type(name, new_fn, base);
+    add_weakref_slot(cls, base);
+    cls
+}
+
+/// The weakref half of `type_new_descriptors`: the class gets its own
+/// `__weakref__` descriptor only when the base it takes its layout from has no
+/// slot to inherit, which is why `_pickle.PickleError.__dict__` carries one and
+/// `_pickle.PicklingError.__dict__` does not.  The flag is set either way --
+/// it is what `getweakref` / `setweakref` read.
+fn add_weakref_slot(cls: PyObjectRef, base: PyObjectRef) {
+    if !unsafe { pyre_object::w_type_get_weakrefable(base) } {
+        let descr = crate::typedef::copy_descriptor_for_type(crate::typedef::weakref_descr(), cls);
+        crate::type_dict_store(cls, "__weakref__", descr);
+    }
+    unsafe { pyre_object::w_type_set_weakrefable(cls, true) };
+}
+
 /// PyPy's `_new_exception` stores the supplied docstring directly in each
 /// builtin exception's TypeDef namespace.
 fn make_exc_type_with_doc(
@@ -9723,6 +9761,10 @@ pub(crate) fn make_exc_type_with_init(
 /// `bases`; the first base drives instance layout.  `with_traceback` /
 /// `add_note` are inherited through the MRO from `BaseException`, so
 /// only `__new__` is installed here.
+///
+/// Both classes built this way — `io.UnsupportedOperation` and
+/// `ssl.SSLCertVerificationError` — come from `PyErr_NewException*`, so both
+/// are weak-referenceable for the reason [`new_exception_class`] gives.
 pub(crate) fn make_exc_type_multi(
     name: &'static str,
     new_fn: crate::gateway::BuiltinCodeFn,
@@ -9741,6 +9783,7 @@ pub(crate) fn make_exc_type_multi(
         },
         bases,
     );
+    add_weakref_slot(cls, bases[0]);
     register_exc_class(name, cls)
 }
 

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -331,14 +331,14 @@ macro_rules! py_module {
             // exceptions: module-local exception classes — PyPy
             // `new_exception_class("<mod>.Name", base)` (error.py).
             // The class name is auto-qualified as `"<$name>.<key>"` and
-            // built via `make_exc_type` (which also records it in the
+            // built via `new_exception_class` (which also records it in the
             // exc-class registry); the short `key` is the attribute name
             // stored in the module dict.  The RHS is the base class
             // expression, e.g. `lookup_exc_class("OSError").unwrap()`.
             $($(
                 $crate::module_ns_store(
                     ns, $exc_key,
-                    $crate::builtins::make_exc_type(
+                    $crate::builtins::new_exception_class(
                         ::std::concat!($name, ".", $exc_key),
                         $crate::builtins::exc_exception_new,
                         $exc_base,

--- a/pyre/pyre-interpreter/src/module/_csv/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_csv/mod.rs
@@ -1210,10 +1210,6 @@ crate::py_module! {
         "QUOTE_STRINGS" => QUOTE_STRINGS,
         "QUOTE_NOTNULL" => QUOTE_NOTNULL,
     },
-    exceptions: {
-        "Error" => crate::builtins::lookup_exc_class("Exception")
-            .expect("Exception must be installed before _csv init"),
-    },
     inline_functions: {
         // `csv_reader` — build the reader over an iterable of lines.
         fn reader(
@@ -1332,6 +1328,21 @@ crate::py_module! {
         "field_size_limit" / * = field_size_limit_fn,
     },
     extra_init: |ns| {
+        // `_csv.Error` — built here rather than in the `exceptions:` arm
+        // because `_csvstate_init` builds it from a type spec that names its
+        // own `basicsize`, and a spec that does gets no managed weakref.  It
+        // is therefore the one module exception class that is not
+        // weak-referenceable, together with `ssl.SSLError`.
+        crate::module_ns_store(
+            ns,
+            "Error",
+            crate::builtins::make_exc_type(
+                "_csv.Error",
+                crate::builtins::exc_exception_new,
+                crate::builtins::lookup_exc_class("Exception")
+                    .expect("Exception must be installed before _csv init"),
+            ),
+        );
         // `app_csv._dialects = {}` — the registry mapping.  It is stored in
         // the module namespace under the name PyPy gives it and published to
         // the state the accelerator reads, which is what keeps it reachable

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -444,6 +444,11 @@ fn init_simplecdata_type(ns: PyObjectRef) {
         "__new__",
         crate::typedef::make_new_descr(simplecdata_new),
     );
+    type_ns_store(
+        ns,
+        "__init__",
+        crate::make_builtin_function("__init__", simplecdata_init),
+    );
     // A scalar `out` parameter hands back the value rather than the box; one
     // whose type is a user subclass hands back the instance, because the
     // subclass is the thing the caller asked for.
@@ -555,7 +560,10 @@ pub(super) fn simple_from_param(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
     Ok(super::interp_ctypes::make_carg(addr, converted))
 }
 
-/// `_SimpleCData.__new__(cls, value=None)`.
+/// `GenericPyCData_new` — allocate the instance and leave the buffer zeroed.
+///
+/// The value the caller passed is read by `Simple_init` instead, so it is
+/// accepted and ignored here.
 fn simplecdata_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.is_empty() || !unsafe { pyre_object::is_type(args[0]) } {
         return Err(crate::PyError::type_error(
@@ -564,9 +572,35 @@ fn simplecdata_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     }
     let cls = args[0];
     let tc = type_code_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    new_simplecdata_obj(cls, &tc, None)
+}
+
+/// `Simple_init(self, value=...)`.
+///
+/// Storing the value here rather than in `__new__` is what makes `__init__` on
+/// a live instance write through the buffer that instance is a view of —
+/// `ctypes.c_int.from_buffer(buf).__init__(7)` fills `buf`, which is how
+/// `multiprocessing.sharedctypes.RawValue` initialises shared memory — and
+/// what leaves the buffer zeroed for a subclass whose own `__init__` does not
+/// delegate.
+///
+/// `PyArg_UnpackTuple` takes one optional positional and no keyword at all, so
+/// `c_int(value=3)` stores nothing and `c_int(1, 2)` is a `TypeError`.
+fn simplecdata_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let Some(&obj) = args.first() else {
+        return Err(crate::PyError::type_error("__init__ requires self"));
+    };
     let (pos, _kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
-    let value = pos.first().copied();
-    new_simplecdata_obj(cls, &tc, value)
+    if pos.len() > 1 {
+        return Err(crate::PyError::type_error(format!(
+            "__init__ expected at most 1 argument, got {}",
+            pos.len()
+        )));
+    }
+    if let Some(&value) = pos.first() {
+        set_simple_value(obj, value)?;
+    }
+    Ok(pyre_object::w_none())
 }
 
 /// Build a fresh `_SimpleCData` instance of `cls` with type code `tc`,
@@ -675,8 +709,13 @@ fn value_getter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 /// `_SimpleCData.value` setter — `(descr, instance, value)`.
 fn value_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let obj = args[1];
-    let value = args[2];
+    set_simple_value(args[1], args[2])?;
+    Ok(pyre_object::w_none())
+}
+
+/// `Simple_set_value` — encode `value` under the instance's own type code and
+/// write it through the instance's buffer view.
+fn set_simple_value(obj: PyObjectRef, value: PyObjectRef) -> Result<(), crate::PyError> {
     let cls = unsafe { pyre_object::w_instance_get_type(obj) };
     let tc = type_code_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
     // `value` is an arbitrary object, so under `"O"` it can be a `list` or a
@@ -698,7 +737,7 @@ fn value_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let value = pyre_object::gc_roots::shadow_stack_get(value_slot);
         unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, value) };
     }
-    Ok(pyre_object::w_none())
+    Ok(())
 }
 
 // ── buffer helpers (b_ptr / b_size / b_base equivalents) ───────────────

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -362,7 +362,7 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
     // ── ArgumentError — a real Exception subclass ──
     let w_exception = crate::builtins::lookup_exc_class("Exception")
         .expect("Exception must be installed before _ctypes init");
-    let argument_error = crate::builtins::make_exc_type(
+    let argument_error = crate::builtins::new_exception_class(
         "ArgumentError",
         crate::builtins::exc_exception_new,
         w_exception,

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -2095,39 +2095,40 @@ fn array_set_slice(
     value: PyObjectRef,
 ) -> PyResult {
     let idxs = slice_index_list(slice, meta.length)?;
-    let tc = cdata::type_code_of(meta.proto);
-    let items = if unsafe { pyre_object::is_bytes(value) }
-        && matches!(tc.as_deref(), Some("c" | "b" | "B"))
-    {
-        unsafe { pyre_object::bytesobject::w_bytes_data(value) }
-            .iter()
-            .map(|&byte| {
-                if tc.as_deref() == Some("c") {
-                    pyre_object::bytesobject::w_bytes_from_bytes(&[byte])
-                } else {
-                    pyre_object::w_int_new(byte as i64)
-                }
-            })
-            .collect()
-    } else if unsafe { pyre_object::is_str(value) } && tc.as_deref() == Some("u") {
-        unsafe { pyre_object::w_str_get_wtf8(value) }
-            .code_points()
-            .map(|point| {
-                let mut text = rustpython_wtf8::Wtf8Buf::new();
-                text.push(point);
-                pyre_object::w_str_from_wtf8(text)
-            })
-            .collect()
-    } else {
-        seq_items(value).ok_or_else(|| crate::PyError::type_error("can only assign a sequence"))?
-    };
-    if items.len() != idxs.len() {
+    // `Array_ass_subscript` reads the right-hand side through
+    // `PySequence_Length` and then `PySequence_GetItem` per index, so any
+    // sequence will do — an `array.array`, a `range`, a `memoryview`, a class
+    // with `__len__` and `__getitem__` — and each element then reaches the
+    // same conversion an indexed assignment uses.  A character array needs no
+    // case of its own: `b"abc"` indexes to ints, which the `c` converter takes
+    // as `chr` values, and a `str` indexes to one-character strings.
+    //
+    // A length that cannot be read is not reported.  Upstream leaves it at -1,
+    // which the size check refuses in place of whatever the failed read raised;
+    // pyre reads the length and the item through `__len__` / `__getitem__`
+    // where upstream uses the sequence-only pair, so a mapping of the matching
+    // size reaches the item read rather than that refusal.
+    let other_len = crate::baseobjspace::len_w(value).unwrap_or(-1);
+    if other_len != idxs.len() as i64 {
         return Err(crate::PyError::value_error(
             "Can only assign sequence of same size",
         ));
     }
-    for (i, v) in idxs.into_iter().zip(items) {
-        array_set_index(obj, meta, i, v)?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::shadow_stack_len();
+    let _ = pyre_object::gc_roots::pin_roots(&[obj, value]);
+    for (i, index) in idxs.into_iter().enumerate() {
+        let item = crate::baseobjspace::getitem(
+            pyre_object::gc_roots::shadow_stack_get(base + 1),
+            pyre_object::w_int_new(i as i64),
+        )?;
+        let item = pyre_object::gc_roots::pin_root(item);
+        array_set_index(
+            pyre_object::gc_roots::shadow_stack_get(base),
+            meta,
+            index,
+            item,
+        )?;
     }
     Ok(pyre_object::w_none())
 }

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -376,7 +376,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
     // `interp_locale.py W_Error = _new_exception('Error', W_Exception, 'locale error')`
     let exception_base = crate::builtins::lookup_exc_class("Exception")
         .expect("Exception must be installed before _locale init");
-    let w_error = crate::builtins::make_exc_type(
+    let w_error = crate::builtins::new_exception_class(
         "locale.Error",
         crate::builtins::exc_exception_new,
         exception_base,

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -772,11 +772,21 @@ fn sem_unlink(name: &str) -> Result<(), crate::PyError> {
 /// arguments on Windows, where a `Connection` is a socket rather than a
 /// descriptor.  A failure is reported by `WSAGetLastError`, so it carries a
 /// Win32 code rather than an errno.
+///
+/// All three release the interpreter around the call, as
+/// `_multiprocessing_recv_impl` and its two neighbours do.  A `Connection` is
+/// what a manager server and its proxies talk over, so a `recv` that waits for
+/// the peer's next request otherwise holds the interpreter for as long as the
+/// peer takes to send one — which, when the peer is itself waiting on this
+/// process, is forever.
 #[cfg(all(windows, feature = "host_env"))]
 #[crate::pyre_function]
 fn closesocket(handle: i64) -> Result<(), crate::PyError> {
-    host_mp::close_socket(handle as usize as host_mp::RawSocket)
-        .map_err(|error| windows_error(error.raw_os_error().unwrap_or(0)))
+    let result = {
+        let _blocked = crate::module::thread::before_external_block();
+        host_mp::close_socket(handle as usize as host_mp::RawSocket)
+    };
+    result.map_err(|error| windows_error(error.raw_os_error().unwrap_or(0)))
 }
 
 #[cfg(all(windows, feature = "host_env"))]
@@ -784,15 +794,26 @@ fn closesocket(handle: i64) -> Result<(), crate::PyError> {
 fn recv(handle: i64, size: i64) -> Result<PyObjectRef, crate::PyError> {
     let size =
         usize::try_from(size).map_err(|_| crate::PyError::value_error("negative buffer size"))?;
-    let data = host_mp::recv_socket(handle as usize as host_mp::RawSocket, size)
-        .map_err(|error| windows_error(error.raw_os_error().unwrap_or(0)))?;
+    let result = {
+        let _blocked = crate::module::thread::before_external_block();
+        host_mp::recv_socket(handle as usize as host_mp::RawSocket, size)
+    };
+    let data = result.map_err(|error| windows_error(error.raw_os_error().unwrap_or(0)))?;
     Ok(pyre_object::w_bytes_from_bytes(&data))
 }
 
 #[cfg(all(windows, feature = "host_env"))]
 #[crate::pyre_function]
 fn send(handle: i64, buf: &[u8]) -> Result<i64, crate::PyError> {
-    host_mp::send_socket(handle as usize as host_mp::RawSocket, buf)
+    // Copied out before the interpreter is released: the borrow reaches into
+    // the argument object, and a collection running in another thread can move
+    // it.  `Py_buffer` holds the original still for the same span.
+    let buf = buf.to_vec();
+    let result = {
+        let _blocked = crate::module::thread::before_external_block();
+        host_mp::send_socket(handle as usize as host_mp::RawSocket, &buf)
+    };
+    result
         .map(i64::from)
         .map_err(|error| windows_error(error.raw_os_error().unwrap_or(0)))
 }

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -1501,7 +1501,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
     crate::module_ns_store(
         ns,
         "herror",
-        crate::builtins::make_exc_type(
+        crate::builtins::new_exception_class(
             "socket.herror",
             crate::builtins::exc_os_error_new,
             w_os_error,
@@ -1510,7 +1510,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
     crate::module_ns_store(
         ns,
         "gaierror",
-        crate::builtins::make_exc_type(
+        crate::builtins::new_exception_class(
             "socket.gaierror",
             crate::builtins::exc_os_error_new,
             w_os_error,

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -2939,32 +2939,37 @@ crate::py_module! {
         "SSLSession" => ssl_session_methods::type_object(),
         "_SSLSocket" => ssl_socket_methods::type_object(),
         "Certificate" => certificate_methods::type_object(),
+        // `SSLError` alone is spelled `make_exc_type`: `sslmodule_init_types`
+        // builds it from a spec that names `sizeof(PySSLErrorObject)` as its
+        // own `basicsize`, which leaves it without a managed weakref.  The
+        // subclasses below come from `PyErr_NewExceptionWithDoc` and do have
+        // one.
         "SSLError" => crate::builtins::make_exc_type(
             "ssl.SSLError",
             crate::builtins::exc_os_error_new,
             crate::builtins::lookup_exc_class("OSError").expect("OSError installed"),
         ),
-        "SSLZeroReturnError" => crate::builtins::make_exc_type(
+        "SSLZeroReturnError" => crate::builtins::new_exception_class(
             "ssl.SSLZeroReturnError",
             crate::builtins::exc_os_error_new,
             crate::builtins::lookup_exc_class("ssl.SSLError").expect("SSLError installed"),
         ),
-        "SSLWantReadError" => crate::builtins::make_exc_type(
+        "SSLWantReadError" => crate::builtins::new_exception_class(
             "ssl.SSLWantReadError",
             crate::builtins::exc_os_error_new,
             crate::builtins::lookup_exc_class("ssl.SSLError").expect("SSLError installed"),
         ),
-        "SSLWantWriteError" => crate::builtins::make_exc_type(
+        "SSLWantWriteError" => crate::builtins::new_exception_class(
             "ssl.SSLWantWriteError",
             crate::builtins::exc_os_error_new,
             crate::builtins::lookup_exc_class("ssl.SSLError").expect("SSLError installed"),
         ),
-        "SSLSyscallError" => crate::builtins::make_exc_type(
+        "SSLSyscallError" => crate::builtins::new_exception_class(
             "ssl.SSLSyscallError",
             crate::builtins::exc_os_error_new,
             crate::builtins::lookup_exc_class("ssl.SSLError").expect("SSLError installed"),
         ),
-        "SSLEOFError" => crate::builtins::make_exc_type(
+        "SSLEOFError" => crate::builtins::new_exception_class(
             "ssl.SSLEOFError",
             crate::builtins::exc_os_error_new,
             crate::builtins::lookup_exc_class("ssl.SSLError").expect("SSLError installed"),

--- a/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
+++ b/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
@@ -2143,7 +2143,7 @@ crate::py_module! {
         // it cannot come from the `exceptions:` arm, which qualifies the key
         // with the module it is declared in.  Both `error` and `ExpatError`
         // name the one class.
-        let err = crate::builtins::make_exc_type(
+        let err = crate::builtins::new_exception_class(
             EXPAT_ERROR_NAME,
             crate::builtins::exc_exception_new,
             crate::builtins::lookup_exc_class("Exception")

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -974,7 +974,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
         crate::module_ns_store(
             ns,
             "ItimerError",
-            crate::builtins::make_exc_type(
+            crate::builtins::new_exception_class(
                 "signal.ItimerError",
                 crate::builtins::exc_os_error_new,
                 w_os_error,

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -1589,7 +1589,7 @@ crate::py_module! {
         // `space.new_exception_class("struct.error", space.w_Exception)`.
         let base = crate::builtins::lookup_exc_class("Exception")
             .expect("Exception must be installed before _struct init");
-        let error = crate::builtins::make_exc_type(
+        let error = crate::builtins::new_exception_class(
             "struct.error",
             crate::builtins::exc_exception_new,
             base,

--- a/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
+++ b/pyre/pyre-interpreter/src/module/termios/interp_termios.rs
@@ -894,7 +894,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
     // it as the class to raise, which is what `except termios.error` catches.
     let w_exception = crate::builtins::lookup_exc_class("Exception")
         .expect("Exception must be installed before termios init");
-    let w_error = crate::builtins::make_exc_type(
+    let w_error = crate::builtins::new_exception_class(
         "termios.error",
         crate::builtins::exc_exception_new,
         w_exception,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -4307,13 +4307,31 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
                         "escape-flush",
                     )
                 {
+                    // Frame 0's operand stack needs the same publication the
+                    // single-frame arm above gives its own, and for the same
+                    // reason: a root walk keeps its virtualizable symbolic, so
+                    // nothing the walk pushed or popped reached the live
+                    // frame's slot array and it still holds the stack from
+                    // before the walk began.  The mirror has to come from the
+                    // paused caller image rather than `capture_vstack_mirror_image`,
+                    // because `ctx` is the innermost callee on this arm and its
+                    // own vstack mirror names that frame, not frame 0.
+                    //
+                    // Leaving the stack alone resumes the blackhole on the
+                    // stale one.  The witness is a nested `for` whose walk
+                    // crossed the inner loop's exhaust: the fresh inner
+                    // iterator the outer FOR_ITER built exists only in the
+                    // walk, the resumed frame finds the previous pass's
+                    // exhausted iterator on TOS, and the inner loop ends one
+                    // iteration in — leaving every later `i` one pass ahead of
+                    // the values the body reads.
                     FBW_MULTI_FRAME_BLACKHOLE.with(|slot| {
                         *slot.borrow_mut() = Some(LatchedMultiFrameBlackhole {
                             framestack,
                             last_exc_value,
                             raising_exception,
-                            publish_root_stack: false,
-                            mirror_stack: None,
+                            publish_root_stack: true,
+                            mirror_stack: capture_root_parent_resume_stack(ctx),
                             origin: "escape-flush",
                         });
                     });

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -3436,10 +3436,19 @@ fn try_adopt_multi_frame_blackhole(
         return false;
     };
     let mut root_stack = if latched.publish_root_stack {
-        // Same split as the single-frame arm.  The multi-frame `WalkAbort`
-        // latch carries no mirror (its `ctx` is the innermost callee, not
-        // frame 0), so this declines and the abort keeps the legacy replay.
-        let captured = if commit_leg == WalkEndCommitLeg::WalkAbort {
+        // Same split as the single-frame arm: `WalkAbort` and `VableEscape`
+        // stop INSIDE an opcode, and for a root walk the snapshot array was
+        // never written there — it still holds the pre-walk stack (see
+        // `capture_frame_stack_from_mirror`).  Both multi-frame latches
+        // reconstruct frame 0 from the paused caller image
+        // (`capture_root_parent_resume_stack`) because their `ctx` is the
+        // innermost callee; a latch that could not build one leaves no mirror
+        // here, which declines the adopt and keeps the legacy replay.
+        // `ABORT_TOO_LONG` stops at an opcode boundary, where the snapshot
+        // array is the image RPython would copy.
+        let captured = if commit_leg == WalkEndCommitLeg::WalkAbort
+            || commit_leg == WalkEndCommitLeg::VableEscape
+        {
             latched.mirror_stack.as_ref().and_then(|mirror| {
                 crate::state::capture_frame_stack_from_mirror(
                     root_addr,


### PR DESCRIPTION
## Summary
- release the interpreter around blocking _multiprocessing recv, send, and closesocket operations, and gate unsupported fork packages on win32
- align _ctypes SimpleCData initialization and slice assignment with the PyPy-shaped paths, and give module-owned exception classes weak-reference slots
- publish frame 0's operand stack from the multi-frame escape-flush latch

## Testing
- cargo test --all --no-default-features --features dynasm — passed
- PYRE_CHECK_PYTHON3=CPython-3.14t python3 pyre/check.py — completed dynasm, cranelift, and wasm; the gate exited 1 with dynasm 515 passed/8 findings, cranelift 515 passed/8 findings, and wasm 514 passed/2 findings

Gate findings retained without re-recording baselines:
- wasm fib_recursive performance ratio: 7.1x dynasm, above the 4x gate
- 8 regressed JIT-stat entries and 6 improved entries requiring review/re-recording
- seqiter_pickle_parity CPython/PyPy oracle-output mismatch on all backends