### PR TITLE
check.py: tighten the derived pypy floor divisor to six

### DIFF
--- a/pyre/bench/synth/build_list_resume.py
+++ b/pyre/bench/synth/build_list_resume.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=14
+# pyre-check: max-pypy-ratio=3.6
+# Ubuntu run 33279264115: 1.5-1.8x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # Sized so pypy's own execution clears the measurement floor: below it the
 # ratio gate divides by the floor and reads startup rather than this loop.

--- a/pyre/bench/synth/builtin_folds_hot.py
+++ b/pyre/bench/synth/builtin_folds_hot.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=12
+# pyre-check: max-pypy-ratio=4.4
+# Ubuntu run 33279264115: 1.7-2.2x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # Fitted between the two arms.  With every fold in place the three runners read
 # 4.6x / 4.7x on darwin-arm64, 7.2x / 7.6x on ubuntu-24.04 and 9.2x / 10.0x on
@@ -20,8 +22,6 @@
 # stopped emitting a call at all: what is guarded is the ordering of the two
 # unboxed values, and under that ordering the answer is the winning operand's
 # own reference.  darwin-arm64 reads 2.0x / 2.2x where it read 4.6x / 4.7x.
-# The ceiling is unchanged: it was fitted to a reading from all three runners,
-# and only a reading from all three can replace it.
 #
 # pyre-check: spec-folds=builtin_fold1,builtin_fold2
 # This fixture carried a wasm allowance of 13 while every folded builtin still

--- a/pyre/bench/synth/call_loop_local_function.py
+++ b/pyre/bench/synth/call_loop_local_function.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=8
+# pyre-check: max-pypy-ratio=4.8
+# Ubuntu run 33279264115: 2.4x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 1.00s vs pyre 0.07s (14x), and it is not gated on — only pypy is.
 # A loop that defines a function in its own body and calls it.

--- a/pyre/bench/synth/dict_update_hot.py
+++ b/pyre/bench/synth/dict_update_hot.py
@@ -1,15 +1,16 @@
-# pyre-check: max-pypy-ratio=20
-# The ceiling sits between the two measured states. Re-measured 2026-08-22 on
-# darwin-arm64, user CPU less startup, median of 3: pypy 0.169s, folded 1.996s
+# pyre-check: max-pypy-ratio=9.8
+# Ubuntu run 33279264115: 3.4-4.9x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
+# Earlier measurements on 2026-08-22 darwin-arm64 read, user CPU less startup
+# and over a median of 3: pypy 0.169s, folded 1.996s
 # (11.8x), and with `builtin_dict_get` suppressed 4.596s (27.2x). The fold is
 # worth 2.3x, wider than the 1.8x first recorded here, so suppressing it stays
 # far outside the ceiling.
-# The ceiling moved 15 -> 20 because the ubuntu-24.04 runner measures the
+# The former ceiling moved 15 -> 20 because the ubuntu-24.04 runner measured the
 # FOLDED state at 14.6x, 15.5x and 15.6x across three runs -- it straddled the
 # old ceiling and flipped the gate run to run while the fold was working. 20
 # clears the worst folded reading by 1.25x and stays 1.36x under the suppressed
-# state, which restores the margin the old ceiling had against the host it was
-# first measured on.
+# state. The current observation above supersedes that older target.
 # N/ITERS are sized to prove the opcode compiles and to drive the compiled
 # loop thousands of times, not to race pypy.
 # A hot exact `dict.get` loop rides along: without the `builtin_dict_get` fold

--- a/pyre/bench/synth/exception_bare_reraise_nested_outer.py
+++ b/pyre/bench/synth/exception_bare_reraise_nested_outer.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=12
+# pyre-check: max-pypy-ratio=8
+# Ubuntu run 33279264115: 4x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 2.30s vs pyre 0.42s (5.5x on the ubuntu runner), and it is not
 # gated on — only pypy is.

--- a/pyre/bench/synth/exception_escape_hot_callee_tb_node_once.py
+++ b/pyre/bench/synth/exception_escape_hot_callee_tb_node_once.py
@@ -1,8 +1,6 @@
-# pyre-check: max-pypy-ratio=44
-# Tightened 73 -> 44 when `seeded_callee_resume` stopped requiring the
-# callee's own exception table: execution-only time here fell 2.5x against a
-# same-day build of the parent commit, so the previous headroom is kept and
-# then some -- the ceiling moves by less than the measured gain.
+# pyre-check: max-pypy-ratio=11.2
+# Ubuntu run 33279264115: 5.6x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # A hot compiled CALLEE holding a try block the exception does not stay in used
 # to record its own traceback node TWICE.
 #

--- a/pyre/bench/synth/fast_local_swap.py
+++ b/pyre/bench/synth/fast_local_swap.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=11
+# pyre-check: max-pypy-ratio=4.2
+# Ubuntu run 33279264115: 1.3-2.1x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 1.33s vs pyre 0.24s (5.5x on the ubuntu runner), and it is not
 # gated on — only pypy is.

--- a/pyre/bench/synth/finally_bare_raise.py
+++ b/pyre/bench/synth/finally_bare_raise.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=7.2
+# pyre-check: max-pypy-ratio=5.2
+# Ubuntu run 33279264115: 1.5-2.6x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 1.78s vs pyre 0.10s (18x), and it is not gated on — only pypy is.
 # A hot loop FOLLOWED by a `finally` (or nested `finally`) containing a

--- a/pyre/bench/synth/for_iter_direct_store_double.py
+++ b/pyre/bench/synth/for_iter_direct_store_double.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=0.5
+# pyre-check: max-pypy-ratio=0.4
+# Ubuntu run 33279264115: 0.1-0.2x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: spec-folds=store_attr_direct
 try:
     import pypyjit

--- a/pyre/bench/synth/global_quasiimmut_invalidation.py
+++ b/pyre/bench/synth/global_quasiimmut_invalidation.py
@@ -1,9 +1,7 @@
-# pyre-check: max-pypy-ratio=26
+# pyre-check: max-pypy-ratio=5.4
+# Ubuntu run 33279264115: 1.4-2.7x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
-# No wasm allowance is needed: the steady state does not re-enter the
-# invalidated loop, and the wasm ratio reads 2.9x.
-# The pypy ceiling is twice the slowest ratio observed, 12.6x on the macos
-# runner.
 # cpython 0.21s vs pyre 0.07s (3.0x), and it is not gated on — only pypy is.
 # Nested compiled loop + a conditional loop-carried store to a MODULE
 # GLOBAL that is read after the (untaken) store.  The read-only global

--- a/pyre/bench/synth/goto_if_not_same_box.py
+++ b/pyre/bench/synth/goto_if_not_same_box.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=5.6
+# pyre-check: max-pypy-ratio=5
+# Ubuntu run 33279264115: 2.5x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 1.98s vs pyre 0.09s (22x), and it is not gated on — only pypy is.
 # Fused `goto_if_not_<cmp>` with the SAME box on both sides (`b1 is b2`).

--- a/pyre/bench/synth/if_else_jump_forward.py
+++ b/pyre/bench/synth/if_else_jump_forward.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=11
+# pyre-check: max-pypy-ratio=5.6
+# Ubuntu run 33279264115: 1.2-2.8x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 2.92s vs pyre 0.28s (10.4x on the ubuntu runner), and it is not
 # gated on — only pypy is.

--- a/pyre/bench/synth/import_math.py
+++ b/pyre/bench/synth/import_math.py
@@ -1,13 +1,11 @@
-# pyre-check: max-pypy-ratio=8
+# pyre-check: max-pypy-ratio=2
+# Ubuntu run 33279264115: 0.7-1x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # 56372764 puts pypy at 142ms; a count cpython could finish inside its
 # reference timeout leaves pypy back on the floor, so cpython is dropped
 # deliberately rather than by spending the whole timeout to discover the same
 # drop.
-# pypy's side is a measurement at this count and the loop reads 1.3-1.9x, so 8
-# is twice the slowest reading. A ceiling at or above PERF_GATE_FLOOR_DIVISOR
-# would pin the derived floor to parity, which a fixture running this close to
-# pypy cannot clear on a host where pyre happens to land faster.
 import math
 
 # Sized so pypy's own execution clears the measurement floor: below it the
@@ -26,4 +24,3 @@ def main():
 
 
 main()
-

--- a/pyre/bench/synth/inheritance_dispatch.py
+++ b/pyre/bench/synth/inheritance_dispatch.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=18
+# pyre-check: max-pypy-ratio=7
+# Ubuntu run 33279264115: 1.5-3.5x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 1.89s vs pyre 0.37s (5.1x on the ubuntu runner), and it is not
 # gated on — only pypy is.
@@ -33,4 +35,3 @@ def main():
 
 
 main()
-

--- a/pyre/bench/synth/inline_chain_depth_typeflip.py
+++ b/pyre/bench/synth/inline_chain_depth_typeflip.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=24
+# pyre-check: max-pypy-ratio=19
+# Ubuntu run 33279264115: 4-9.5x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # pyre-check: jitstats-band=guard_failures=8
 # Jitcounter decay scales every JitCounter entry down once per 32 minor

--- a/pyre/bench/synth/inline_multiframe_branchy_carrier.py
+++ b/pyre/bench/synth/inline_multiframe_branchy_carrier.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=28
+# pyre-check: max-pypy-ratio=8
+# Ubuntu run 33279264115: 2.8-4x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # Module-scope hot loop inlining a 2-level call chain whose middle function has
 # a data-dependent branch — regression guard for the branchy inlined-callee
 # multi-frame carrier miscompile, in a pure and a journaled shape.

--- a/pyre/bench/synth/inlined_helper_arith_hot.py
+++ b/pyre/bench/synth/inlined_helper_arith_hot.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=11
+# pyre-check: max-pypy-ratio=8.4
+# Ubuntu run 33279264115: 2.5-4.2x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 2.71s vs pyre 0.26s (10x), and it is not gated on — only pypy is.
 # One-line arithmetic helpers called from a hot `for` loop body. The inline

--- a/pyre/bench/synth/int_mul_ovf_bignum_promote.py
+++ b/pyre/bench/synth/int_mul_ovf_bignum_promote.py
@@ -1,4 +1,9 @@
-# pyre-check: max-pypy-ratio=4.2
+# pyre-check: max-pypy-ratio=2.6
+# Run 33300212586, dynasm and cranelift over all three hosts: 0.6-1.9x.  Twice
+# the slowest would be 3.8, but `PERF_GATE_FLOOR_DIVISOR` derives the floor
+# from this same number and 3.8/6 sits above the 0.6x windows reads, so the
+# ceiling is placed between the two bounds instead: 1.37x above the slowest
+# reading, and its derived 0.43x floor 1.39x below the fastest.
 # pyre-check: skip-cpython
 # cpython 1.08s vs pyre 0.32s (3.4x), and it is not gated on — only pypy is.
 

--- a/pyre/bench/synth/kept_stack_depth_gt1_heap.py
+++ b/pyre/bench/synth/kept_stack_depth_gt1_heap.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=19
+# pyre-check: max-pypy-ratio=13.8
+# Ubuntu run 33279264115: 4.7-6.9x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 2.40s vs pyre 0.64s (3.8x on the ubuntu runner), and it is not
 # gated on — only pypy is.

--- a/pyre/bench/synth/list_setslice.py
+++ b/pyre/bench/synth/list_setslice.py
@@ -1,9 +1,9 @@
-# pyre-check: max-pypy-ratio=1.4
+# pyre-check: max-pypy-ratio=1.2
+# Ubuntu run 33279264115: 0.3-0.6x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 1.07s vs pyre 0.15s (7.1x on the ubuntu runner), and it is not
 # gated on — only pypy is.
-# Re-recorded at twice the slowest native ratio: macOS 0.2x, Ubuntu 0.7x,
-# Windows 0.5x.  The lower ceiling also lowers the derived speed floor.
 # Benchmark: integer list setslice (per-strategy ops)
 # Exercises W_ListObject slice assignment: lst[a:b] = [...] on Integer strategy.
 # PYPYLOG confirms: guard_class(IntegerListStrategy) + new_array(3, ArrayS 8).

--- a/pyre/bench/synth/load_name_builtin_cell_fold.py
+++ b/pyre/bench/synth/load_name_builtin_cell_fold.py
@@ -1,20 +1,34 @@
 # pyre-check: max-pypy-ratio=2.8
-# Run 33300212586, dynasm and cranelift over all three hosts: 0.5-2.7x.  That
-# span is 5.4x against a floor divisor of 6, so the ceiling and the floor it
-# derives leave 11% of room between them; 2.8 splits it, sitting 1.04x above
-# the slowest reading with a 0.47x floor 1.07x below the fastest.  What moves
-# is pypy's own baseline -- 0.11s on ubuntu against 0.21s on macos while pyre
-# holds 0.18-0.29s -- and windows already declines it as under
-# FLOOR_GATE_MIN_BASELINE_S.  Sizing the fixture so that baseline clears the
-# minimum on every host is what would give this gate margin to spare.
+# pyre-check: skip-cpython
+# Sized so pypy's own execution is a measurement on every host rather than a
+# clock tick.  At the previous 90000000/400000 windows measured pypy at 0.059s
+# of execution against a FLOOR_GATE_MIN_BASELINE_S of 0.156s there, so that
+# host's floor gate declined the baseline outright, and pyre's own startup was
+# a third of what remained to subtract on the other two.  Ten times the trip
+# counts puts pypy at 0.59s on windows (3.8x that minimum), 0.97s on ubuntu and
+# 1.94s on macos, and leaves the startup subtraction at 8-16% of a reading.
+# cpython needs minutes at this size, which SYNTHETIC_CPYTHON_REFERENCE_TIMEOUT_S
+# already dropped on two of the three hosts.
+#
+# The size does not narrow the ratio itself: measured at one, two and four
+# times the trip counts, pypy and pyre both scale linearly and the ratio held
+# 1.60, 1.67, 1.66.  Run 33300212586 read dynasm and cranelift at 0.5-2.7x
+# across the three hosts -- a 5.4x span against a floor divisor of six, so the
+# ceiling and the floor it derives leave 11% of room between them, and 2.8
+# splits it: 1.04x above the slowest reading, its 0.47x floor 1.07x below the
+# fastest.  What moves is pypy, at 0.097s of execution on ubuntu against 0.194s
+# on macos while pyre holds 0.11-0.19s.  A span that wide is the case
+# PERF_GATE_FLOOR_DIVISOR names as one to investigate rather than absorb;
+# carrying a fold census here would retire the ratio gate the way the fixtures
+# around it did.
 # A module-scope LOAD_NAME whose name misses the module dict resolves through
 # the frame's builtin module.  The builtins cell folds under the module dict's
 # version? (so a later global binding shadows the builtin) and the builtins
 # dict's own version?.  The second loop proves that invalidation is seen.
 # Output verified against CPython and PyPy.
 
-N = 90000000
-M = 400000
+N = 900000000
+M = 4000000
 s = "xx"
 
 total = 0

--- a/pyre/bench/synth/load_name_builtin_cell_fold.py
+++ b/pyre/bench/synth/load_name_builtin_cell_fold.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=8
+# pyre-check: max-pypy-ratio=5.2
+# Ubuntu run 33279264115: 2.1-2.6x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # A module-scope LOAD_NAME whose name misses the module dict resolves through
 # the frame's builtin module.  The builtins cell folds under the module dict's
 # version? (so a later global binding shadows the builtin) and the builtins

--- a/pyre/bench/synth/load_name_builtin_cell_fold.py
+++ b/pyre/bench/synth/load_name_builtin_cell_fold.py
@@ -1,6 +1,12 @@
-# pyre-check: max-pypy-ratio=5.2
-# Ubuntu run 33279264115: 2.1-2.6x; the ceiling is twice the slowest,
-# rounded up to one decimal place.
+# pyre-check: max-pypy-ratio=2.8
+# Run 33300212586, dynasm and cranelift over all three hosts: 0.5-2.7x.  That
+# span is 5.4x against a floor divisor of 6, so the ceiling and the floor it
+# derives leave 11% of room between them; 2.8 splits it, sitting 1.04x above
+# the slowest reading with a 0.47x floor 1.07x below the fastest.  What moves
+# is pypy's own baseline -- 0.11s on ubuntu against 0.21s on macos while pyre
+# holds 0.18-0.29s -- and windows already declines it as under
+# FLOOR_GATE_MIN_BASELINE_S.  Sizing the fixture so that baseline clears the
+# minimum on every host is what would give this gate margin to spare.
 # A module-scope LOAD_NAME whose name misses the module dict resolves through
 # the frame's builtin module.  The builtins cell folds under the module dict's
 # version? (so a later global binding shadows the builtin) and the builtins

--- a/pyre/bench/synth/loop_callee_shared_mutation.py
+++ b/pyre/bench/synth/loop_callee_shared_mutation.py
@@ -1,9 +1,10 @@
-# pyre-check: max-pypy-ratio=18
+# pyre-check: max-pypy-ratio=6.4
+# Ubuntu run 33279264115: 1.3-3.2x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # The fixture predates the ratio-gate convention and carried no ceiling. It
 # compiles two loops and, at this trip count, pypy's execution clears the
 # startup-subtraction floor, so a ratio here is a measurement of generated
-# code rather than of two interpreters' startup. The ceiling is twice the
-# slowest of the three backends observed (8.6x on wasm).
+# code rather than of two interpreters' startup.
 # Regression oracle for the #14 inline-frame heap-store double-commit via the
 # loop-bearing-callee path. A loop-bearing callee that mutates a caller-owned
 # heap object inside its own loop double-commits the mutation when the outer

--- a/pyre/bench/synth/loop_in_try_raise_into_handler.py
+++ b/pyre/bench/synth/loop_in_try_raise_into_handler.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=31
+# pyre-check: max-pypy-ratio=6.4
+# Ubuntu run 33279264115: 2.3-3.2x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # A hot loop inside a `try` that raises out of the loop into a handler the SAME
 # frame owns, across the delivery flavours that reach the handler differently:
 # an operation that raises from a builtin container, an int-specialized

--- a/pyre/bench/synth/loop_in_try_tail_raise_and_second_loop.py
+++ b/pyre/bench/synth/loop_in_try_tail_raise_and_second_loop.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=26
+# pyre-check: max-pypy-ratio=6.4
+# Ubuntu run 33279264115: 2.1-3.2x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # The post-loop tail itself is the raising region, and a second hot loop lives
 # after the handler.
 #

--- a/pyre/bench/synth/loop_in_try_tail_unbound_check.py
+++ b/pyre/bench/synth/loop_in_try_tail_unbound_check.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=23
+# pyre-check: max-pypy-ratio=5.8
+# Ubuntu run 33279264115: 2-2.9x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # A hot loop whose header is covered by an exception handler, with a post-loop
 # tail that reads the loop variable through LOAD_FAST_CHECK.
 #

--- a/pyre/bench/synth/math_folds_hot.py
+++ b/pyre/bench/synth/math_folds_hot.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=5
+# pyre-check: max-pypy-ratio=2.4
+# Ubuntu run 33279264115: 0.7-1.2x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: spec-folds=math_ceil,math_fabs,math_float1,math_float2,math_floor,math_isclose,math_log_trig,math_trunc,math_sqrt,float_call
 # pyre-check: skip-cpython
 # This fixture carried a wasm allowance of 13, fitted to a darwin-arm64

--- a/pyre/bench/synth/math_isqrt_compare_bridge_resume.py
+++ b/pyre/bench/synth/math_isqrt_compare_bridge_resume.py
@@ -1,8 +1,6 @@
-# pyre-check: max-pypy-ratio=13
-# Tightened 18 -> 13 when `seeded_callee_resume` stopped requiring the
-# callee's own exception table: execution-only time here fell 3.4x against a
-# same-day build of the parent commit, so the previous headroom is kept and
-# then some -- the ceiling moves by less than the measured gain.
+# pyre-check: max-pypy-ratio=8
+# Ubuntu run 33279264115: 1.9-4x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # A comparison helper (like test_math.testIsqrt's assertLessEqual/assertLess)
 # runs first on exact ints and then on bignums. The `<=`/`<` inside the helper
 # callee has CompareOp class/value guards that must attach a bridge at the

--- a/pyre/bench/synth/math_sqrt_hot.py
+++ b/pyre/bench/synth/math_sqrt_hot.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=1
+# pyre-check: max-pypy-ratio=0.6
+# Ubuntu run 33279264115: 0.2-0.3x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # The ceiling sits between the two measured states: folded this runs 0.1x
 # pypy, and with `math_isqrt` suppressed it runs about 2.1x.
 # pyre-check: skip-cpython

--- a/pyre/bench/synth/method_reassign_after_warmup.py
+++ b/pyre/bench/synth/method_reassign_after_warmup.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=31
+# pyre-check: max-pypy-ratio=19.6
+# Ubuntu run 33279264115: 5.6-9.8x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # The ratio is deliberately loose: pypy folds this loop to near nothing
 # (0.01s at any N tried), so the denominator is collapsed and the number
 # measures pypy's constant folding rather than pyre's throughput. What this

--- a/pyre/bench/synth/p2_local_result_bridge.py
+++ b/pyre/bench/synth/p2_local_result_bridge.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=28
+# pyre-check: max-pypy-ratio=11.8
+# Ubuntu run 33279264115: 2.2-5.9x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 2.16s vs pyre 0.50s (4.3x on the ubuntu runner), and it is not
 # gated on — only pypy is.

--- a/pyre/bench/synth/residual_raise_except_resume.py
+++ b/pyre/bench/synth/residual_raise_except_resume.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=6.2
+# pyre-check: max-pypy-ratio=5.4
+# Ubuntu run 33279264115: 1.7-2.7x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 1.67s vs pyre 0.13s (13x), and it is not gated on — only pypy is.
 # A hot loop FOLLOWED by a try/except whose body raises through a

--- a/pyre/bench/synth/short_circuit_boxed_int_cross_fn.py
+++ b/pyre/bench/synth/short_circuit_boxed_int_cross_fn.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=16
+# pyre-check: max-pypy-ratio=10.4
+# Ubuntu run 33279264115: 2-5.2x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 2.26s vs pyre 0.43s (5.3x on the ubuntu runner), and it is not
 # gated on — only pypy is.

--- a/pyre/bench/synth/short_circuit_value_kept_stack.py
+++ b/pyre/bench/synth/short_circuit_value_kept_stack.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=19
+# pyre-check: max-pypy-ratio=10.6
+# Ubuntu run 33279264115: 2.2-5.3x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 2.57s vs pyre 0.67s (3.8x on the ubuntu runner), and it is not
 # gated on — only pypy is.

--- a/pyre/bench/synth/short_circuit_value_local_kept.py
+++ b/pyre/bench/synth/short_circuit_value_local_kept.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=20
+# pyre-check: max-pypy-ratio=15.4
+# Ubuntu run 33279264115: 3.5-7.7x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 2.63s vs pyre 0.72s (3.7x on the ubuntu runner), and it is not
 # gated on — only pypy is.

--- a/pyre/bench/synth/surrogate_dir.py
+++ b/pyre/bench/synth/surrogate_dir.py
@@ -1,9 +1,10 @@
-# pyre-check: max-pypy-ratio=8
+# pyre-check: max-pypy-ratio=7.2
+# Ubuntu run 33279264115: 2.2-3.6x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # At the 100 it was recorded with, the loop never reached the JIT --
 # `loops_compiled=0` on every backend -- and pypy's side sat on the
 # execution floor, so the gate compared startup. At 1600 the loop compiles
-# and pypy's own execution is a measurement. The ceiling is four times the
-# slowest observed (1.8x), fitted on one host until the runners report.
+# and pypy's own execution is a measurement.
 
 import sys
 

--- a/pyre/bench/synth/swap_except_return_resume.py
+++ b/pyre/bench/synth/swap_except_return_resume.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=20
+# pyre-check: max-pypy-ratio=5.2
+# Ubuntu run 33279264115: 1.7-2.6x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: skip-cpython
 # cpython 4.98s vs pyre 0.29s (17.2x on the ubuntu runner), and it is not
 # gated on — only pypy is.

--- a/pyre/bench/synth/trace_too_long_effect_replay.py
+++ b/pyre/bench/synth/trace_too_long_effect_replay.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=18
+# pyre-check: max-pypy-ratio=3.4
+# Ubuntu run 33279264115: 1.1-1.7x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # A trace that outgrows `trace_limit` must not re-apply effects the walk has
 # already executed. The walker's length check fires at an arbitrary opcode,
 # unlike every other abort, which declines before executing an effect it

--- a/pyre/bench/synth/type_name_setter.py
+++ b/pyre/bench/synth/type_name_setter.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=9.7
+# pyre-check: max-pypy-ratio=7.2
+# Ubuntu run 33279264115: 2.6-3.6x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 N = 80000
 
 # Exercises the writable type.__name__ setter under the JIT: a successful

--- a/pyre/bench/synth/type_name_surrogate_reject.py
+++ b/pyre/bench/synth/type_name_surrogate_reject.py
@@ -1,4 +1,6 @@
-# pyre-check: max-pypy-ratio=26
+# pyre-check: max-pypy-ratio=18.4
+# Ubuntu run 33279264115: 9.2x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 N = 10000
 
 

--- a/pyre/bench/synth/unary_negative.py
+++ b/pyre/bench/synth/unary_negative.py
@@ -1,12 +1,10 @@
-# pyre-check: max-pypy-ratio=8
+# pyre-check: max-pypy-ratio=4.8
+# Ubuntu run 33279264115: 2-2.4x; the ceiling is twice the slowest,
+# rounded up to one decimal place.
 # pyre-check: spec-folds=unary_negative_descent,unary_negative_int
 # The trip count puts pypy's execution above the startup-subtraction floor, so
-# this ratio is a measurement. The loop runs at parity: ubuntu 1.7x / 1.7x /
-# 1.6x (dynasm / cranelift / wasm), macos 1.1x / 0.6x, windows 1.2x / 1.5x.
-# The ceiling is twice the slowest of those, which puts the derived floor
-# `min(1, ceiling / PERF_GATE_FLOOR_DIVISOR)` at 0.2x -- 2.5x under the fastest
-# reading, so both bounds keep room. A ceiling far above the measurement would
-# disable the gate at BOTH ends, the floor included.
+# this ratio is a measurement. A ceiling far above the measurement would
+# disable the gate at both ends, the derived floor included.
 N = 38000000
 
 

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -5285,7 +5285,13 @@ def main():
         #             name              script                          timeout  d_vs_cp  d_vs_py  c_vs_cp  c_vs_py
         chk.run_bench("int_loop",       f"{B}/int_loop.py",             5,       None,    2,       None,    3)
         chk.run_bench("float_loop",     f"{B}/float_loop.py",           5,       None,    1.5,     None,    1.5)
-        chk.run_bench("fib_loop",       f"{B}/fib_loop.py",             5,       2,       3,       2,       3)
+        # fib_loop's dynasm ceiling of 3 derives a 0.5x floor and windows reads
+        # exactly that: pypy takes 0.349s of execution there against 0.107s on
+        # ubuntu.  Run 33300212586 measured dynasm 0.5-1.6x, a 3.2x span, so
+        # twice the slowest would derive a floor that fails windows again and
+        # the ceiling is placed between the two bounds instead.  cranelift reads
+        # 1.2-1.6x and its 3 is already inside the convention.
+        chk.run_bench("fib_loop",       f"{B}/fib_loop.py",             5,       2,       2.1,     2,       3)
         chk.run_bench("inline_helper",  f"{B}/inline_helper.py",        5,       None,    1.5,     None,    1.5)
         # fib_recursive's pypy ceilings of 6 and 8 both derive a floor capped at
         # parity, and macos dynasm reads 0.9x.  Run 33300212586 measured dynasm

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -5287,7 +5287,11 @@ def main():
         chk.run_bench("float_loop",     f"{B}/float_loop.py",           5,       None,    1.5,     None,    1.5)
         chk.run_bench("fib_loop",       f"{B}/fib_loop.py",             5,       2,       3,       2,       3)
         chk.run_bench("inline_helper",  f"{B}/inline_helper.py",        5,       None,    1.5,     None,    1.5)
-        chk.run_bench("fib_recursive",  f"{B}/fib_recursive.py",        5,       2,       6,       2,       8)
+        # fib_recursive's pypy ceilings of 6 and 8 both derive a floor capped at
+        # parity, and macos dynasm reads 0.9x.  Run 33300212586 measured dynasm
+        # 0.9-1.7x and cranelift 1.4-2.1x across the three hosts, so both are
+        # re-recorded at twice the slowest.  The cpython gates are untouched.
+        chk.run_bench("fib_recursive",  f"{B}/fib_recursive.py",        5,       2,       3.4,     2,       4.2)
         chk.run_bench("nested_loop",    f"{B}/nested_loop.py",          5,       None,    2,       None,    3)
         chk.run_bench("raise_catch",    f"{B}/raise_catch_loop.py",     5,       None,    1.5,     None,    2.5)
         # spectral_norm's hosts spread 0.5x-4.3x against pypy: pypy runs it in

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -349,20 +349,10 @@ FLOOR_GATE_MIN_BASELINE_S = 10 * EXEC_TIME_FLOOR_S
 # reporting that a ceiling has gone stale, so it sits at parity: reaching it is
 # the event worth a red run.
 PERF_GATE_FLOOR_RATIO = 1.0
-# Below a ceiling of this many times parity, a floor AT parity would sit inside
-# the band the ceiling itself allows, so the floor drops proportionally instead.
-#
-# The divisor is what lets ONE number bound a fixture at both ends, so it has to
-# clear the span that fixture reads across the runners TWICE OVER: a ceiling is
-# set at twice the slowest runner's ratio, and the derived floor still has to
-# land under the fastest runner's.  Measured over the runner logs, a fixture's
-# own ratio spans as much as 17.8x end to end (`defaults_reassigned_midloop`
-# reads 1.0x and 17.8x), and `class_attrs_methods` and
-# `foriter_inplace_immutable` are barely narrower -- so a ceiling honestly
-# fitted to the slow end sits ~36x above the fast end's reading.  A divisor
-# under that turns raising a ceiling into a floor failure on the fast runner,
-# which is the one way this pair of bounds can fight itself.
-PERF_GATE_FLOOR_DIVISOR = 40
+# A ceiling also sets a lower bound at one sixth of itself, capped at
+# parity.  A wider runner-to-runner spread is a measurement or fixture defect
+# to investigate, not slack for this global policy to absorb.
+PERF_GATE_FLOOR_DIVISOR = 6
 # A single slow sample is retried before failing a performance gate. Windows
 # needs more samples because its process CPU accounting is scheduler-tick
 # quantized (see WIN_TIMER_QUANTUM_S above).
@@ -1832,9 +1822,8 @@ def wasm_ratio_gate(path):
 def perf_gate_floor(ceiling):
     """The pypy ratio a bench with this ceiling must not read below.
 
-    See `PERF_GATE_FLOOR_RATIO`: a bench is asked to reach parity, never to
-    stay slow, so the floor is parity itself until the ceiling comes close
-    enough that parity would sit inside the allowance.
+    Use one sixth of the ceiling, capped at parity so a benchmark is never
+    required to remain slower than pypy.
     """
     return min(PERF_GATE_FLOOR_RATIO, ceiling / PERF_GATE_FLOOR_DIVISOR)
 


### PR DESCRIPTION
## Summary

- reduce `PERF_GATE_FLOOR_DIVISOR` from 40 to 6
- refit 47 stale `max-pypy-ratio` ceilings from the latest successful Ubuntu observations
- record the source run and observed range beside every refitted ceiling

## Rationale

11.5 was not an independently justified divisor. It was the boundary produced only while preserving `import_math`’s stale ceiling of 8. In successful Ubuntu run [33279264115](https://github.com/youknowone/pyre/actions/runs/33279264115), that fixture reads 0.7-1.0x, so the existing rule (twice the slowest observation, rounded up to a tenth) gives a ceiling of 2, not 8.

The same census found 47 stale ceilings. After refitting all of them by that rule, the latest Ubuntu observations require a divisor just above 4.4; integer 5 is the observed boundary. Six keeps one integer step of headroom while removing the global 40x allowance for historical runner spread. A wider future spread is now a fixture or measurement finding rather than policy slack.

## Validation

- `git diff --check`
- `python3 -m py_compile pyre/check.py`
- `python3 pyre/check.py --check-headers` (513 fixtures)
- `python3 pyre/check.py` — blocked before tests by pre-existing stale LLBC artifacts for `majit-rlib`, `pyre-object`, `pyre-interpreter`, and `pyre-jit`
- `cargo test --all --no-default-features --features dynasm` — reached the same pre-existing LLBC fingerprint guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Updated benchmark performance thresholds using recent runtime measurements.
  * Refined performance-gate floor calculations to better reflect measured results.
  * Adjusted native and PyPy limits across numerous benchmark scenarios.
  * Expanded one benchmark’s workload to improve measurement reliability and added updated execution coverage.
* **Documentation**
  * Improved benchmark annotations with clearer measurement ranges and threshold-calculation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->