### PR TITLE
metainterp, interp: refuse a non-array virtualizable field, mark locals_plus_value unroll_safe, and record what the force injection measured

### DIFF
--- a/majit/majit-macros/src/virtualizable/derive.rs
+++ b/majit/majit-macros/src/virtualizable/derive.rs
@@ -704,7 +704,10 @@ pub fn expand_state(input: DeriveInput) -> TokenStream {
     // All read/write goes through VirtualizableInfo which handles field types.
     quote! {
         impl #struct_name {
-            /// virtualizable.py read_boxes parity.
+            /// The STATIC half of `virtualizable.py read_boxes`.  Upstream's
+            /// `read_boxes` reads statics and then every array item;
+            /// `read_static_boxes` is the first half only, and
+            /// `VirtualizableInfo::read_all_boxes` is what answers for the whole.
             /// Reads ALL static fields from the heap via VirtualizableInfo.
             pub fn virt_export_static_boxes(
                 &self,
@@ -712,13 +715,16 @@ pub fn expand_state(input: DeriveInput) -> TokenStream {
             ) -> Vec<i64> {
                 let heap_ptr = self.#frame_ident as *const u8;
                 if !heap_ptr.is_null() {
-                    unsafe { info.read_boxes(heap_ptr) }
+                    unsafe { info.read_static_boxes(heap_ptr) }
                 } else {
                     vec![0i64; info.num_fields()]
                 }
             }
 
-            /// virtualizable.py write_from_resume_data_partial parity.
+            /// The STATIC half of `virtualizable.py write_boxes`.  Upstream writes
+            /// statics and array items and then asserts it consumed every box;
+            /// `write_static_boxes` writes the statics only, and
+            /// `VirtualizableInfo::write_boxes_to_heap` answers for the whole.
             /// Writes ALL static fields to the heap via VirtualizableInfo.
             pub fn virt_import_static_boxes(
                 &mut self,
@@ -732,7 +738,7 @@ pub fn expand_state(input: DeriveInput) -> TokenStream {
                 if heap_ptr.is_null() {
                     return false;
                 }
-                unsafe { info.write_boxes(heap_ptr, static_boxes); }
+                unsafe { info.write_static_boxes(heap_ptr, static_boxes); }
                 true
             }
 

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -615,13 +615,11 @@ impl VirtualizableInfo {
         items_offset: usize,
         array_descr: DescrRef,
     ) {
+        let name = name.into();
         let item_size = array_descr_item_size(&array_descr, item_type);
-        let array_type_id = array_descr
-            .as_array_descr()
-            .map(|descr| descr.type_id())
-            .unwrap_or(0);
+        let array_type_id = array_field_type_id(&name, &array_descr);
         self.array_fields.push(VableArrayInfo {
-            name: name.into(),
+            name,
             item_type,
             item_size,
             field_offset,
@@ -653,13 +651,11 @@ impl VirtualizableInfo {
         items_offset: usize,
         array_descr: DescrRef,
     ) {
+        let name = name.into();
         let item_size = array_descr_item_size(&array_descr, item_type);
-        let array_type_id = array_descr
-            .as_array_descr()
-            .map(|descr| descr.type_id())
-            .unwrap_or(0);
+        let array_type_id = array_field_type_id(&name, &array_descr);
         self.array_fields.push(VableArrayInfo {
-            name: name.into(),
+            name,
             item_type,
             item_size,
             field_offset,
@@ -686,13 +682,11 @@ impl VirtualizableInfo {
         len_fn: fn(*const u8) -> usize,
         array_descr: DescrRef,
     ) {
+        let name = name.into();
         let item_size = array_descr_item_size(&array_descr, item_type);
-        let array_type_id = array_descr
-            .as_array_descr()
-            .map(|descr| descr.type_id())
-            .unwrap_or(0);
+        let array_type_id = array_field_type_id(&name, &array_descr);
         self.array_fields.push(VableArrayInfo {
-            name: name.into(),
+            name,
             item_type,
             item_size,
             field_offset,
@@ -1065,7 +1059,13 @@ impl VirtualizableInfo {
     }
 
     /// Check that box array has correct size for given array lengths.
-    pub fn check_boxes(&self, boxes: &[i64], array_lengths: &[usize]) -> bool {
+    /// The trailing `assert len(boxes) == i + 1` of `virtualizable.py
+    /// check_boxes`, and ONLY that.  Upstream's `check_boxes` also compares
+    /// every static field and every array item against the boxes; the port of
+    /// that comparison is `trace_ctx.rs check_synchronized_virtualizable`.
+    /// The name says which half this is, because a caller reaching for
+    /// `check_boxes` at a `check_boxes` call site wants the other one.
+    pub fn boxes_len_matches(&self, boxes: &[i64], array_lengths: &[usize]) -> bool {
         boxes.len() == self.get_total_size(array_lengths)
     }
 
@@ -1325,7 +1325,10 @@ impl VirtualizableInfo {
     ///
     /// # Safety
     /// `obj_ptr` must point to a valid virtualizable object.
-    pub unsafe fn read_boxes(&self, obj_ptr: *const u8) -> Vec<i64> {
+    /// The static half of `virtualizable.py read_boxes`.  Upstream reads the
+    /// statics and then every array item in one pass; [`Self::read_all_boxes`]
+    /// is the port of the whole.
+    pub unsafe fn read_static_boxes(&self, obj_ptr: *const u8) -> Vec<i64> {
         unsafe {
             self.static_fields
                 .iter()
@@ -1339,7 +1342,11 @@ impl VirtualizableInfo {
     ///
     /// # Safety
     /// `obj_ptr` must point to a valid virtualizable object.
-    pub unsafe fn write_boxes(&self, obj_ptr: *mut u8, boxes: &[i64]) {
+    /// The static half of `virtualizable.py write_boxes`; the port of the whole
+    /// is [`Self::write_boxes_to_heap`].  Upstream closes with
+    /// `assert len(boxes) == i + 1`; this one stops at the end of the static
+    /// fields instead, because its callers hand it exactly that prefix.
+    pub unsafe fn write_static_boxes(&self, obj_ptr: *mut u8, boxes: &[i64]) {
         unsafe {
             for (index, &value) in boxes.iter().enumerate() {
                 if index >= self.static_fields.len() {
@@ -1360,7 +1367,7 @@ impl VirtualizableInfo {
         array_lengths: &[usize],
     ) -> (Vec<i64>, Vec<Vec<i64>>) {
         unsafe {
-            let static_boxes = self.read_boxes(obj_ptr);
+            let static_boxes = self.read_static_boxes(obj_ptr);
             let mut array_boxes = Vec::with_capacity(self.array_fields.len());
             for (index, _) in self.array_fields.iter().enumerate() {
                 let length = array_lengths.get(index).copied().unwrap_or(0);
@@ -1385,7 +1392,7 @@ impl VirtualizableInfo {
         array_boxes: &[Vec<i64>],
     ) {
         unsafe {
-            self.write_boxes(obj_ptr, static_boxes);
+            self.write_static_boxes(obj_ptr, static_boxes);
             for (array_index, values) in array_boxes.iter().enumerate() {
                 for (item_index, &value) in values.iter().enumerate() {
                     self.write_array_item(obj_ptr, array_index, item_index, value);
@@ -1679,6 +1686,38 @@ unsafe fn read_virtualizable_array(
 /// descriptor keeps the blackhole/heap array stride in lock-step with the
 /// explicit item size the JIT codegen records (e.g. a fixed `8` for `i64`
 /// payloads), instead of re-deriving a machine word on 32-bit targets.
+/// `virtualizable.py:44-56` — the array-field arrivals check.
+///
+/// ```text
+/// ARRAY = ARRAYPTR.TO
+/// if not isinstance(ARRAY, lltype.GcArray):
+///     raise Exception("The virtualizable field '%s' is not an array (found %r). ...")
+/// ```
+///
+/// Upstream refuses at translation time, so nothing downstream has to
+/// represent "this was not an array".  Answering `0` instead would not be a
+/// weaker diagnostic, it would be a WRONG ANSWER on the memory-safety path:
+/// `0` is the value `walk_vable_resume_ref_roots` reads as "no type is known
+/// for this array", and it uses that to SKIP the nursery type-id comparison
+/// before pushing the array-pointer slot as a resume ref root.  A
+/// mis-declared field would silently turn a live GC check off rather than
+/// fail.  Panicking keeps the two meanings apart by making the absent case
+/// unrepresentable.
+///
+/// The message carries upstream's remedy verbatim because it is the useful
+/// half: an array that fails this test is usually one that gets resized at
+/// run time, and `make_sure_not_resized()` is what pins it.
+fn array_field_type_id(name: &str, array_descr: &DescrRef) -> u32 {
+    let Some(descr) = array_descr.as_array_descr() else {
+        panic!(
+            "The virtualizable field '{name}' is not an array (found {array_descr:?}). \
+             It usually means that you must try harder to ensure that the list is not \
+             resized at run-time. You can do that by using make_sure_not_resized()."
+        );
+    };
+    descr.type_id()
+}
+
 fn array_descr_item_size(array_descr: &DescrRef, item_type: Type) -> usize {
     majit_ir::descr::unpack_arraydescr(array_descr)
         .map(|(_, item_size, _)| item_size)
@@ -1784,6 +1823,22 @@ mod tests {
             items_offset,
             descr,
         );
+    }
+
+    /// `virtualizable.py:47-56` — a redirected field that is not an array is a
+    /// translation-time refusal upstream, so it must be one here too.
+    ///
+    /// The regression this pins is not the diagnostic: answering `0` for the
+    /// type id would hand `walk_vable_resume_ref_roots` the same value it reads
+    /// as "no type is known", which switches OFF the nursery type-id compare
+    /// guarding the resume ref root push.
+    #[test]
+    #[should_panic(expected = "is not an array")]
+    fn a_non_array_descr_is_refused_at_declaration() {
+        let mut info = VirtualizableInfo::new(0);
+        let field_descr =
+            majit_ir::make_field_descr(0, 8, Type::Ref, majit_ir::descr::ArrayFlag::Pointer);
+        info.add_array_field("locals_w", Type::Ref, 16, 0, 0, field_descr);
     }
 
     /// Test helper: add an embedded array field with a fresh descriptor.
@@ -2010,9 +2065,9 @@ mod tests {
 
         let lens = &[3usize];
         // total = 2 + 3 = 5
-        assert!(info.check_boxes(&[1, 2, 3, 4, 5], lens));
-        assert!(!info.check_boxes(&[1, 2, 3], lens));
-        assert!(!info.check_boxes(&[1, 2, 3, 4, 5, 6], lens));
+        assert!(info.boxes_len_matches(&[1, 2, 3, 4, 5], lens));
+        assert!(!info.boxes_len_matches(&[1, 2, 3], lens));
+        assert!(!info.boxes_len_matches(&[1, 2, 3, 4, 5, 6], lens));
     }
 
     #[test]

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -549,17 +549,35 @@ impl<'a> MirGraphLookup<'a> {
 /// the `(receiver root, method leaf)` pair, and an ambiguous pair is treated
 /// as unresolved.
 ///
-/// The pass is inert in the production translation, and not for any reason
-/// inside it. A census over the build script's two pipeline invocations
-/// (489 and 4147 lowered functions) found **zero `OpKind::Hint` ops of any
-/// kind**, and neither frame constructor present in the set at all: the five
-/// hint sites are spelled in `pyre-interpreter` / `pyre-jit`, but nothing
-/// carrying one reaches the function set this pass runs over. So the seeds
-/// are empty before any of the machinery below gets a say, and every claim
-/// about which site seeds has to be re-measured once a hint does arrive —
-/// do not read a green gate here as agreement.
+/// The pass is inert in the production translation — it flags no graph at all
+/// — but the reason is inside it, not upstream of it.
 ///
-/// The two under-approximations that will bite first when one does:
+/// Re-measured by reproducing the prepass's own input: the canonical LLBC set
+/// (`majit-rlib`, `pyre-object`, `pyre-interpreter`, `pyre-jit`; no sidecars
+/// on a native build) and the module-path list derived from the same 296
+/// source files. That lowers 33,976 functions carrying **18 `OpKind::Hint`
+/// ops**, and every virtualizable hint site is present and correctly
+/// classified:
+///
+/// ```text
+/// pyframe::createframe_obj                     -> [AccessDirectly, FreshVirtualizable]
+/// pyframe::<Impl>::finish_for_call_with_globals_obj -> [AccessDirectly, FreshVirtualizable]
+/// eval::<Impl>::dispatch                       -> [AccessDirectly]
+/// executioncontext::app_profile_call           -> [NoAccessDirectly]
+/// executioncontext::<Impl>::_trace::<Impl>::call -> [NoAccessDirectly]
+/// ```
+///
+/// This pass runs over that finished list (`front::mir` calls it once, after
+/// the whole function set exists), so it sees all of them. With the roots
+/// registry seeded as production seeds it — `roots=1 ["PyFrame"]` — it still
+/// flags **zero** graphs. The hints arrive and the pass erases them.
+///
+/// An earlier census recorded here read zero `OpKind::Hint` ops and neither
+/// frame constructor in the set. Both halves are wrong: the constructors are
+/// in the set and carry their hints. Its conclusion survived its evidence,
+/// which is why the reason mattered — an absent hint would put the fix
+/// upstream, and an erased one puts it in the two under-approximations below.
+/// They are live suspects today, not contingencies:
 ///
 /// * `class_roots` answers with the ctor's own name for a struct literal,
 ///   because that is the spelling everything else uses — `adt_node_class_root`
@@ -568,6 +586,7 @@ impl<'a> MirGraphLookup<'a> {
 ///   reading that instead would answer with a spelling no comparison matches.
 ///   A root reachable only through `result_ty` is still unrecorded, and a hint
 ///   on an unrecorded or undeclared root seeds nothing — the erasing branch.
+///   This is the first thing to test against the five sites above.
 ///
 /// * One graph per function, where upstream keys a second on
 ///   `(AccessDirect, key)`. A callee reached by both a hinted and an unhinted

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -585,18 +585,36 @@ impl<'a> MirGraphLookup<'a> {
 /// finish_for_call_..._obj    AccessDirectly     <- SyntheticTransparentCtor{name:"PyFrame", is_struct}
 /// eval::dispatch             AccessDirectly     <- Input{name:"frame", class_root:Some("PyFrame")}
 /// app_profile_call           NoAccessDirectly   <- Input{name:"frame", class_root:Some("PyFrame")}
-/// createframe_obj            FreshVirtualizable <- (no producing op in the graph)
-/// finish_for_call_..._obj    FreshVirtualizable <- (no producing op in the graph)
+/// createframe_obj            FreshVirtualizable <- (no op's result: a block inputarg)
+/// finish_for_call_..._obj    FreshVirtualizable <- (no op's result: a block inputarg)
 /// ```
 ///
-/// So the first under-approximation is NOT the eraser for `access_directly`:
-/// every one of those four resolves to the bare leaf `PyFrame`, which is the
-/// spelling the declared set holds. What it does erase is `fresh_virtualizable`
-/// — both sites spell `hint_fresh_virtualizable(hint_access_directly(frame))`
-/// and the outer hint's operand is produced by no op in the graph, so it can
-/// carry no root and is never seeded.
+/// So the first under-approximation is NOT the eraser: every one of those four
+/// resolves to the bare leaf `PyFrame`, which is the spelling the declared set
+/// holds.
 ///
-/// That leaves the second as the eraser for `access_directly`. The flag is set
+/// Nor does it erase `fresh_virtualizable`, though an earlier reading of that
+/// table said so. Both sites spell
+/// `hint_fresh_virtualizable(hint_access_directly(frame))`, and the outer
+/// hint's operand is not any op's `result` — but that is a property of the
+/// census, not of the graph. Every call here is a block terminator, so the
+/// inner hint's result crosses a link and the outer operand arrives as the
+/// successor's `inputarg`; a census matching operands against op results
+/// cannot see one. The hint conversion does emit a result (`front::mir`), and
+/// `class_roots`'s fixpoint carries a root across BOTH hops — the `Hint`
+/// result and the `Link` into `inputargs`. The value is rooted and does seed.
+/// It is also redundant while it does: `hint_seed_sets` treats
+/// `FreshVirtualizable` and `AccessDirectly` identically and files operand and
+/// result alike, so the two hints on one frame seed the same set.
+///
+/// (The chained spelling is still a deviation, for reasons that have nothing
+/// to do with this pass: `rlib/jit.py` asserts `"lone fresh_virtualizable
+/// hint"` on the outer call, upstream spelling both kwargs on one `hint()`
+/// (`pyframe.py PyFrame.__init__`); and `jtransform.rs rewrite_op_hint` files
+/// `vable_flags` against the operand while clearing the map per block, so a
+/// chained hint files it one block away from the stores it covers.)
+///
+/// That leaves the second as the eraser, and as the only one. The flag is set
 /// only through `reaching`: a `(callee, pos)` pair needs `flagged > 0 &&
 /// unflagged == 0`, so one unhinted caller passing a frame at that position is
 /// enough to erase it, and `PyFrame` has many. Seeding the roots registry

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -577,7 +577,31 @@ impl<'a> MirGraphLookup<'a> {
 /// in the set and carry their hints. Its conclusion survived its evidence,
 /// which is why the reason mattered — an absent hint would put the fix
 /// upstream, and an erased one puts it in the two under-approximations below.
-/// They are live suspects today, not contingencies:
+/// They are live suspects today, not contingencies — and the producer of each
+/// hinted value, which is what `class_roots` has to recognise, says which:
+///
+/// ```text
+/// createframe_obj            AccessDirectly     <- SyntheticTransparentCtor{name:"PyFrame", is_struct}
+/// finish_for_call_..._obj    AccessDirectly     <- SyntheticTransparentCtor{name:"PyFrame", is_struct}
+/// eval::dispatch             AccessDirectly     <- Input{name:"frame", class_root:Some("PyFrame")}
+/// app_profile_call           NoAccessDirectly   <- Input{name:"frame", class_root:Some("PyFrame")}
+/// createframe_obj            FreshVirtualizable <- (no producing op in the graph)
+/// finish_for_call_..._obj    FreshVirtualizable <- (no producing op in the graph)
+/// ```
+///
+/// So the first under-approximation is NOT the eraser for `access_directly`:
+/// every one of those four resolves to the bare leaf `PyFrame`, which is the
+/// spelling the declared set holds. What it does erase is `fresh_virtualizable`
+/// — both sites spell `hint_fresh_virtualizable(hint_access_directly(frame))`
+/// and the outer hint's operand is produced by no op in the graph, so it can
+/// carry no root and is never seeded.
+///
+/// That leaves the second as the eraser for `access_directly`. The flag is set
+/// only through `reaching`: a `(callee, pos)` pair needs `flagged > 0 &&
+/// unflagged == 0`, so one unhinted caller passing a frame at that position is
+/// enough to erase it, and `PyFrame` has many. Seeding the roots registry
+/// changes nothing — `roots=1 ["PyFrame"]` and an empty registry both flag
+/// zero graphs — which is what rules the root declaration out as the cause.
 ///
 /// * `class_roots` answers with the ctor's own name for a struct literal,
 ///   because that is the spelling everything else uses — `adt_node_class_root`

--- a/majit/majit-translate/src/translator/rtyper/rvirtualizable.rs
+++ b/majit/majit-translate/src/translator/rtyper/rvirtualizable.rs
@@ -46,16 +46,30 @@ use crate::translator::rtyper::lltypesystem::lltype::{self, _ptr, LowLevelType};
 /// `tests/test_make_jitcodes_produces_graph_keyed_output.rs` — so it
 /// diverges from the production config, not from upstream.
 ///
-/// What has no counterpart either way is the force injection.
-/// `hook_access_field` puts a `jit_force_virtualizable` in front of every
-/// redirected access while rtyping; pyre instead places the forces by hand
-/// at the consumers that need them (`pyre-interpreter` `sys.getframe`,
-/// `f_locals`, `f_back`). The marker
-/// `executioncontext::jit_force_virtualizable` is what lets
-/// `jtransform.rs rewrite_op_jit_force_virtualizable` delete such a call from
-/// a looked-inside graph, and it keys on the CALL TARGET's name rather than
-/// on `vable_fields`, so the two halves are armed independently of each
-/// other.
+/// What has no counterpart either way is the force injection, and it cannot
+/// get one from this crate. `hook_access_field` injects while rtyping, which
+/// puts the marker into every graph at once; `replace_force_virtualizable_with_call`
+/// then turns it into a real call across `translator.graphs` — the copy the
+/// INTERPRETER runs — and `jtransform.py rewrite_op_jit_force_virtualizable`
+/// deletes it again from the copy the codewriter looks inside. The two halves
+/// are what tell a residual access from a traced one.
+///
+/// Pyre has only one of those two copies. Its interpreter is native Rust that
+/// no majit stage emits, so an injected op can reach the jitcode and nothing
+/// else, and the jitcode is exactly where upstream deletes it: injecting here
+/// would be cancelled by the very stage it feeds. That holds wherever in this
+/// crate the injection is placed — rtyper or codewriter — so the missing
+/// generator is not a stage that has yet to be ported.
+///
+/// The discriminator survives the loss because it is the marker, not the
+/// injector. `executioncontext::jit_force_virtualizable` is placed by hand in
+/// the Rust that reads a redirected field, and `rewrite_op_jit_force_virtualizable`
+/// deletes that call from a looked-inside graph, so the residual copy forces
+/// and the traced copy does not. It keys on the CALL TARGET's name rather than
+/// on `vable_fields`, so the two halves are armed independently of each other.
+/// What a hand-placed marker cannot do is reach a graph the codewriter never
+/// looks inside — there it is an ordinary force, deleted from nothing — so
+/// each placement is only as good as that graph's jitcode.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct VirtualizableInstanceRepr {
     pub top_of_virtualizable_hierarchy: bool,

--- a/majit/majit-translate/tests/test_unroll_safe_inventory.rs
+++ b/majit/majit-translate/tests/test_unroll_safe_inventory.rs
@@ -86,6 +86,34 @@ const REVIEWED_UNROLL_SAFE: &[(&str, &str)] = &[
         "frame_locals_proxy_snapshot",
         "fast2locals' scan of the same locals-plus array",
     ),
+    // No upstream counterpart either: this is the mapping read behind a
+    // `fr.f_locals["x"]`, and its scan is bounded by the same
+    // `locals_plus_names` array — varnames plus cellvars plus freevars — that
+    // `fast2locals` walks.  It cannot share `fast_local_index`, because a
+    // running comprehension's iteration variable is readable through the proxy
+    // even though assigning to that name goes to the extras dict.  What the
+    // body does per candidate is not what the hint is about: `hash_w_strict`
+    // and `eq_w` can run application code, but they are calls, not the loop
+    // bound.
+    //
+    // Same class of evidence as `frame_locals_proxy_snapshot`, and for the
+    // same reason it is NOT the `*_nohidden` argument: the body is REACHED.
+    // `locals_plus_value` holds a jitcode in the generated metadata artefact,
+    // so admitting it and its callee closure is a real descent-scope change
+    // and unreachability proves nothing here.
+    //
+    // Measured in PR #1599's CI, on the tree that carries this attribute:
+    // `pyre/check.py` passed in four jobs across all three runner OSes —
+    // dynasm and cranelift on ubuntu-24.04, dynasm on windows-latest, and
+    // dynasm+cranelift on macos-latest — with every committed per-fixture
+    // jitstats baseline unchanged.  That covers `fbw_rolled_back_with_effects`
+    // corpus-wide rather than per fixture, because it is a
+    // `JITSTATS_BADNESS_FIELDS` member in `check.py`, so a rise anywhere would
+    // have been a red rather than a statistic.
+    (
+        "locals_plus_value",
+        "fast2locals' scan of the same locals-plus array, read through the proxy",
+    ),
     // `pyopcode.py` `dispatch_bytecode` is `@jit.unroll_safe`; its
     // EXTENDED_ARG loop is split here into the interpreter decoder and the
     // two scalar projections consumed by `eval_loop_jit`.  The projections

--- a/pyre/bench/synth/c_call_reports_the_callee_frame_not_the_inliners.py
+++ b/pyre/bench/synth/c_call_reports_the_callee_frame_not_the_inliners.py
@@ -1,0 +1,131 @@
+# pyre-check: selfcheck
+# pyre-check: selfcheck-compiles=outer,outer_arming,root:inner
+# `c_call` carries the frame that made the call, and for a builtin called from
+# inside a Python callee that is the CALLEE's frame -- never the caller whose
+# compiled trace would have inlined it.
+#
+# The hazard is real and structural: a walker-inlined callee has no frame on
+# `topframeref`/`f_backref` while compiled code runs, and
+# `call_jit.rs residual_call_c_profile_frame` reads exactly that chain.  A
+# builtin residual firing inside an inlined callee would therefore report the
+# inliner's frame.  Two independent guards make the conjunction unreachable,
+# and this fixture pins both:
+#
+#   * At RECORD time `inline_call.rs` declines on `ec_hook_installed()` for any
+#     installed hook, so a trace recorded under a profiler inlines nothing and
+#     the callee gets a real frame.  `armed_before` is that arm.
+#   * At EXECUTE time `is_being_profiled` is an `interp_jit.py` portal green, so
+#     a profiled frame cannot enter a trace compiled under the unprofiled key;
+#     and a frame that entered before the hook was armed keeps
+#     `is_being_profiled` false, so the residual's own third test declines --
+#     which is what `call_valuestack` does upstream, gating on the same
+#     per-frame flag.  `armed_mid_loop` is that arm: it compiles `outer` with
+#     `inner` inlined and only then arms the profiler, from inside `inner`.
+#
+# A relaxation of the inline decline breaks the first guard, and this fixture is
+# what says so.  Measured on cpython 3.14.6 and pypy3, which agree on every
+# line below.
+import sys
+
+NAME = 'abcdef'
+WARM = 5000
+REPEAT = 2500
+MID_REPEAT = 300
+
+
+def inner(x):
+    return len(NAME) + x
+
+
+def outer(n):
+    t = 0
+    for _ in range(n):
+        t = inner(t) % 1000003
+    return t
+
+
+TRIGGER = [None]
+
+
+def inner_arming(x, hook):
+    if x == TRIGGER[0]:
+        sys.setprofile(hook)
+    return len(NAME) + x
+
+
+def outer_arming(n, hook):
+    t = 0
+    for _ in range(n):
+        t = inner_arming(t, hook) % 1000003
+    return t
+
+
+def collect():
+    seen = {}
+
+    def hook(frame, event, arg):
+        if event in ('c_call', 'c_return'):
+            key = (event, getattr(arg, '__name__', repr(arg)), frame.f_code.co_name)
+            seen[key] = seen.get(key, 0) + 1
+
+    return seen, hook
+
+
+def armed_before():
+    outer(WARM)
+    seen, hook = collect()
+    sys.setprofile(hook)
+    try:
+        outer(REPEAT)
+    finally:
+        sys.setprofile(None)
+    return seen, REPEAT
+
+
+def armed_mid_loop():
+    seen, hook = collect()
+    outer_arming(WARM, hook)
+    TRIGGER[0] = 0
+    try:
+        outer_arming(MID_REPEAT, hook)
+    finally:
+        sys.setprofile(None)
+    return seen, MID_REPEAT
+
+
+def check(arm, seen, want_frame, want_count, failures):
+    # `sys.setprofile` is the instrument: both the arming and the disarming
+    # call are builtin calls made inside the window they open, from whichever
+    # frame happens to make them.
+    seen = {key: n for key, n in seen.items() if key[1] != 'setprofile'}
+    expected = {
+        ('c_call', 'len', want_frame): want_count,
+        ('c_return', 'len', want_frame): want_count,
+    }
+    for key, want in sorted(expected.items()):
+        got = seen.get(key, 0)
+        if got != want:
+            failures.append('%s: %s = %d, expected %d' % (arm, key, got, want))
+    for key in sorted(seen):
+        if key not in expected:
+            failures.append(
+                '%s: %s = %d, expected no event — the reported frame is not the '
+                'one that made the call' % (arm, key, seen[key])
+            )
+
+
+def main():
+    failures = []
+    seen, n = armed_before()
+    check('armed before', seen, 'inner', n, failures)
+    seen, n = armed_mid_loop()
+    check('armed mid loop', seen, 'inner_arming', n, failures)
+    if failures:
+        for line in failures:
+            print('FAIL', line)
+        return 1
+    print('PASS c_call reports the callee frame, not the inliner')
+    return 0
+
+
+sys.exit(main())

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -44,10 +44,15 @@ pub fn force_frame(frame: *mut PyFrame) {
 /// fast2locals` always finds a materialized `locals_cells_stack_w` with no
 /// hand-placed hook anywhere.
 ///
-/// Pyre's rtyper declines to build a virtualizable `InstanceRepr` at all
-/// (`rclass.rs buildinstancerepr`, blocked on `FieldListAccessor` /
-/// `_parse_field_list` parity), so that injection does not exist here and
-/// explicit calls like this one stand in for it — load-bearing, not redundant.
+/// That injection does not exist here, and not because a piece of the rtyper
+/// is unported — `FieldListAccessor` and `_parse_field_list` both are.
+/// Upstream discovers the redirected set from `classdesc.get_param('_virtualizable_')`,
+/// and no `ClassDesc` in this tree ever carries that key: pyre's virtualizable
+/// is the hand-written Rust `PyFrame`, and its field set is declared out of
+/// band in `pyre-jit-trace/src/virtualizable_spec.rs`.  So `rclass.rs
+/// buildinstancerepr`'s virtualizable arm is unreachable rather than blocked,
+/// and it is kept fail-closed for the day a producer appears.  Explicit calls
+/// like this one stand in for the injection — load-bearing, not redundant.
 /// Deleting them was measured: `f_lineno` starts reporting the `def` line,
 /// `f_locals` grows an entry, and the two read together segfault, with the
 /// whole synthetic corpus green throughout.
@@ -77,22 +82,35 @@ pub fn force_frame_before_locals_read(frame: *mut PyFrame) {
 /// `#[inline(never)]` keeps the callee name on the Call so the rewrite can
 /// see it.
 ///
-/// # Reach: none, today
+/// # Reach, and why the readers do not carry it
 ///
-/// Measured against the prepass artefacts in
-/// `target/*/build/pyre-jit-trace-*/out/jit_metadata.json`: no
-/// `symbolic_fnaddr_paths` entry names this function and no jitcode carries
-/// its name, and the same holds for its one caller,
-/// `pyframe.rs descr_typecheck_fget_getdictscope`. The codewriter never sees
-/// the call, so `rewrite_op_jit_force_virtualizable` deletes nothing. To
-/// re-derive, read those two lists out of that file and filter them for
-/// `force_virtualizable` and for `getdictscope`.
-///
-/// That is downstream of the missing injection rather than a gap of its own.
 /// Upstream reaches the rewrite because `hook_access_field` puts the marker
 /// at every redirected FIELD access, which lands it inside graphs the
-/// codewriter does look into; a hand-placed marker at one consumer only
-/// reaches it if that consumer happens to be one of those graphs.
+/// codewriter does look into.  A hand-placed marker only reaches it if the
+/// function holding it is one of those graphs, so the candidates are the
+/// functions that READ the redirected array and that the codewriter looks
+/// inside.  Measured against `jit_metadata.json`, that is two of them:
+/// `pyframe.rs` `PyFrame::fast2locals` and `PyFrame::frame_locals_proxy_snapshot`,
+/// both `@jit.unroll_safe` so that `contains_loop` does not keep the
+/// codewriter out.  `FrameLocalsProxy::locals_plus_value` reads the same
+/// array and became a third candidate when it took the same hint.
+///
+/// Placing it at those two was tried and does not pay.  The forces are
+/// deleted in the traced copies, but the fixtures that reach `f_locals`
+/// reach it through a residual call chain, and the residual copy escapes:
+/// five gate rows lose compilations (`getframe_bridge_force_*_declined`
+/// `loops_aborted 0 -> 20` with `bridges_compiled 1 -> 0`,
+/// `getframe_root_loop_force_blackhole_crn*` `loops_compiled 1 -> 0`,
+/// `raise_reg_unbound_jitstress` `9 -> 7`) and NOT ONE output changes.
+/// Nothing changes because pyre already materializes the array for a
+/// residual read by another route — `pyjitpl.py
+/// vable_and_vrefs_before_residual_call` stores the boxes back before the
+/// call — which is why `flocals_read_through_bound_proxy` passes without any
+/// force.  The `f_locals` path is also already forced one frame up, by the
+/// `descr_typecheck_fget_getdictscope` gateway, so a marker at the readers
+/// is redundant where it would matter and new only where it costs.
+///
+/// So the readers carry no force.
 ///
 /// The other force sites call [`force_frame`] or
 /// [`force_frame_before_locals_read`] directly, and only two of them sit in
@@ -103,6 +121,25 @@ pub fn force_frame_before_locals_read(frame: *mut PyFrame) {
 /// red frame so the collector reads a current `valuestackdepth`. In the rest
 /// the codewriter never looks inside, so a direct call and a deleted marker
 /// come to the same thing.
+///
+/// # No `vable_token` test here
+///
+/// `virtualizable.py force_virtualizable_if_necessary` opens with
+/// `if virtualizable.vable_token:`, and this function deliberately does not.
+/// The test is not missing — it is downstream, inside the backend hook
+/// [`force_frame`] reaches (`pyre-jit` `force_pyframe`, which calls
+/// `force_virtualizable_if_necessary` with the token read). What runs BEFORE
+/// that hook tests anything is `flush_active_frame_escape`, and that ordering
+/// is pyre's escape signal rather than an oversight.
+///
+/// Repeating the test at this call site was measured and is wrong: it gates
+/// the escape flush too, so a walk that must abort no longer does.  Eight
+/// gate rows moved on it — seven `getframe_*_declined` fixtures lost the
+/// decline they exist to pin (`loops_aborted 5 -> 0` with
+/// `guard_failures 0 -> 14480`), and
+/// `exception_reused_object_tb_not_doubled` started reporting a second
+/// traceback shape whose `f_locals` is missing the `except`-bound name,
+/// because the uncommitted walk kept the node it had already attached.
 #[inline(never)]
 pub fn jit_force_virtualizable(frame: *mut PyFrame) {
     force_frame_before_locals_read(frame);

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -123,16 +123,25 @@ pub mod frame_locals_proxy {
         /// - a `STORE_FAST` in the body lands in the shadow while a read
         ///   through the proxy answers from the array.
         ///
-        /// Only the write takes this.  **The read direction cannot, yet**, and
-        /// the reason is the missing injection rather than a preference:
-        /// `hook_access_field` runs in residual code, while inside a trace the
-        /// same accesses are *redirected* to the shadow, so upstream never
-        /// forces from a traced read -- `pyframe.py fast2locals` is
-        /// `@jit.unroll_safe` for exactly that reason.  Pyre cannot tell the two
-        /// apart at this call, so forcing on every read forces the traced ones
-        /// too; measured, that aborts the loop where a hot `len(fr.f_locals)` or
-        /// `fr.f_locals["x"]` sits in the traced body.  Telling them apart needs
-        /// the redirected-field injection itself.
+        /// This call site is the write direction, and it is the one that wants
+        /// an UNDELETED force: a store has to reach the shadow the compiled
+        /// loop answers from, so the force has to happen in the traced copy
+        /// too.  The read direction wants the opposite -- `hook_access_field`
+        /// runs in residual code, while inside a trace the same accesses are
+        /// *redirected* to the shadow, so upstream never forces from a traced
+        /// read; `pyframe.py fast2locals` is `@jit.unroll_safe` for exactly
+        /// that reason.  Forcing unconditionally on every read forces the
+        /// traced ones too, and measured, that aborts the loop where a hot
+        /// `len(fr.f_locals)` or `fr.f_locals["x"]` sits in the traced body.
+        /// What would tell the two apart is the marker, not the call site: a
+        /// read force spelled [`crate::executioncontext::jit_force_virtualizable`]
+        /// is deleted by `jtransform.py rewrite_op_jit_force_virtualizable` in
+        /// the copy the codewriter looks inside and kept in the residual one.
+        /// Putting one on [`PyFrame::fast2locals`] and
+        /// [`PyFrame::frame_locals_proxy_snapshot`] was measured and reverted:
+        /// it changed no output and lost five fixtures' compilations, because
+        /// `vable_and_vrefs_before_residual_call` already stores the boxes
+        /// back before the residual read.  See that function's own doc.
         ///
         /// [`Self::frame`] does not take it either: [`Self::fast_local_index`]
         /// goes through it only for `code`, which is not a redirected field.
@@ -168,7 +177,8 @@ pub mod frame_locals_proxy {
 
         #[inline]
         fn mapping(&self) -> Result<PyObjectRef, crate::PyError> {
-            // No force here; see [`Self::force_locals`] on the read direction.
+            // No force here or in the callee; see [`Self::force_locals`] on
+            // why the read direction takes none.
             self.frame().frame_locals_proxy_snapshot()
         }
 
@@ -305,6 +315,18 @@ pub mod frame_locals_proxy {
         /// cannot share [`Self::fast_local_index`]: a running comprehension's
         /// iteration variable is readable through the proxy even though
         /// assigning to that name goes to the extras dict instead.
+        ///
+        /// `@jit.unroll_safe` for the same reason as [`PyFrame::fast2locals`]
+        /// and [`PyFrame::frame_locals_proxy_snapshot`]: the scan is bounded by
+        /// `locals_plus_names`, i.e. the code object's varnames plus cellvars
+        /// plus freevars, which is green.  Without it `contains_loop` declines
+        /// the graph, and then a `fr.f_locals["x"]` in a traced body is one
+        /// residual call -- the array read behind it never reaches the
+        /// virtualizable lowering, so it answers from memory instead of from
+        /// the shadow the compiled loop is writing.  What the body does per
+        /// candidate is not what the hint is about: `hash_w_strict` and `eq_w`
+        /// can run application code, but they are calls, not the loop bound.
+        #[majit_macros::unroll_safe]
         fn locals_plus_value(
             &self,
             key: PyObjectRef,

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5478,6 +5478,19 @@ fn bh_null_arg_diag() -> bool {
 /// uninstalled mid-loop carrying a stale flag one entry longer than the plain
 /// interpreter would, which costs that frame the profiled green key until its
 /// next interpreted call clears it, and reports nothing either way.
+///
+/// Reading the top frame is only correct while no walker-inlined callee can be
+/// executing under a profiler, because an inlined callee has no frame on
+/// `topframeref` / `f_backref` — a builtin residual firing inside one would
+/// report the inliner's frame. Two independent guards close that: at record
+/// time `inline_call.rs` declines on `ec_hook_installed()`, so a trace recorded
+/// under a hook inlines nothing; at execute time `is_being_profiled` is a
+/// portal green, so a profiled frame cannot enter a trace compiled under the
+/// unprofiled key, and a frame that predates the hook keeps the flag false and
+/// is declined by the test below — which is what `call_valuestack` does
+/// upstream, gating on the same per-frame flag.
+/// `c_call_reports_the_callee_frame_not_the_inliners` pins both arms against
+/// cpython and pypy3. Relaxing the inline decline breaks the first guard.
 fn residual_call_c_profile_frame(
     ec: *const pyre_interpreter::PyExecutionContext,
     callable: PyObjectRef,


### PR DESCRIPTION
Six commits. One refusal and one hint are the code; the rest records what the
force-injection work measured, including two of my own earlier claims that the
measurement refuted.

## A non-array descr is refused at declaration

The three `add_*_array_field` entry points mapped a missing `ArrayDescr` to
type id `0`:

```rust
let array_type_id = array_descr.as_array_descr().map(|d| d.type_id()).unwrap_or(0);
```

`0` is not a weaker diagnostic there, it is a wrong answer on the memory-safety
path: it is the value `walk_vable_resume_ref_roots` reads as "no type is known
for this array", and it uses that to **skip** the nursery type-id comparison
before pushing the array-pointer slot as a resume ref root. A mis-declared
field would silently turn a live GC check off rather than fail.

`virtualizable.py:44-56` refuses at translation time instead, so nothing
downstream has to represent the absent case. `array_field_type_id` now does the
same and carries upstream's remedy verbatim, because it is the useful half — an
array that fails this test is usually one that gets resized at run time, and
`make_sure_not_resized()` is what pins it. Pinned by
`a_non_array_descr_is_refused_at_declaration`.

Three names that collided with upstream functions they do not implement are
renamed alongside it: `check_boxes` → `boxes_len_matches`, `read_boxes` →
`read_static_boxes`, `write_boxes` → `write_static_boxes`. Each was the static
half, or one assertion, of the upstream function whose name it carried; the
docs now name the port of the whole — `check_synchronized_virtualizable`,
`read_all_boxes`, `write_boxes_to_heap`.

## `locals_plus_value` is `unroll_safe`

The scan is bounded by `locals_plus_names` — varnames plus cellvars plus
freevars — which is green, the same reason `fast2locals` and
`frame_locals_proxy_snapshot` carry the hint. Without it `contains_loop`
declines the graph, and a `fr.f_locals["x"]` in a traced body is then one
residual call, so the array read behind it never reaches the virtualizable
lowering and answers from memory instead of from the shadow the compiled loop
is writing. What the body does per candidate is not what the hint is about:
`hash_w_strict` and `eq_w` can run application code, but they are calls, not
the loop bound.

## The force injection has no counterpart in this crate

The remaining work on the deletion stage was to give it something to delete.
It cannot get one, and the reason is structural rather than a missing port.

Upstream makes **two copies** of the graph. `rvirtualizable.py
hook_access_field` injects `jit_force_virtualizable` at rtype time,
`replace_force_virtualizable_with_call` turns it into a real call across
`translator.graphs`, and `jtransform.py rewrite_op_jit_force_virtualizable`
deletes it from the copy the codewriter looks inside. That pair — kept in the
residual copy, deleted in the traced one — is the whole discriminator.

Pyre's interpreter is native Rust that no majit stage emits, so it has only the
copy where upstream deletes. An injected op can reach only the jitcode, and is
therefore cancelled by the stage it feeds, at any placement — rtyper or
codewriter. What survives the asymmetry is the **marker**, not the injector,
and a hand-placed marker is worth exactly what its graph's jitcode is worth.

Measured, not argued: placing the marker on `fast2locals` and
`frame_locals_proxy_snapshot` **changed no output and lost five fixtures their
compilations**, because `vable_and_vrefs_before_residual_call` already stores
the boxes back before the residual read. Adding a `vable_token` test at
`jit_force_virtualizable` produced a **wrong answer** —
`exception_reused_object_tb_not_doubled` kept a traceback node it had already
attached — because `force_pyframe` tests the token downstream and
`flush_active_frame_escape` deliberately runs before it. Both were reverted;
the doc records them so the next attempt does not repeat them.

The `FieldListAccessor` arm's comment claimed it was blocked on
`_parse_field_list` parity. It is not: no `ClassDesc` carries
`_virtualizable_`, so the arm is unreachable. Kept fail-closed, correctly
labelled.

## Two corrections to my own census

Both were wrong in the same way — a property of the measurement read as a
property of the graph.

`fresh_virtualizable` was recorded as "produced by no op in the graph". Every
call in the LLBC front end is a MIR terminator, so a chained hint's operand
arrives as a successor block `inputarg` and never as any op's `result`; a
census matching operands against op results cannot see it. `class_roots`'
fixpoint carries a root across both the `Hint` hop and the `Link` hop, and
`hint_seed_sets` treats the two hint kinds identically, so the seed is
redundant. The chained spelling is still a deviation, for two unrelated
reasons.

The `access_directly` erasure is attributed to the reaching rule instead: the
flag is set only for a `(callee, pos)` pair with `flagged > 0 && unflagged ==
0`. That rule is not a defect. Upstream's precision comes from
`default_specialize` minting a second graph under `(AccessDirect, key)`, so the
flagged caller gets the flagged copy and the unflagged caller keeps the
original. `GraphStore::insert` folds the two together with `|=`, so with one
graph per function a callee reached both ways must stay unflagged or the
tripwire fires on the unflagged caller's behalf. Making it precise means
porting the specialization, and the payoff is a safety check — `graph
.access_directly`'s only consumer is `policy.py:71-83`, which raises rather
than optimizes.

## Gates

**No valid local gate run backs this branch, and CI is the only authority.**

Two full `check.py` runs were started. The first read `dynasm 1 failed / 523
passed` and the same on the other two backends, and that result is void: the
worktree was rebased 14 minutes after the last backend binary was linked, so a
pre-fix binary was graded against a post-fix fixture list. The failing row was
#1597's own new fixture, and it printed exactly the pre-fix number that
fixture's header documents (`k=1041 i=209 j=0`, `loops_compiled=0` against a
declared 1). The 523 passing rows are void for the same reason. The second run
was invalidated by a third rebase while it was still building.

Unit tests are green on this tree: majit-metainterp 1737, virtualizable 88,
majit-macros 179.

The branch was rebased three times during the session it was written in, most
recently onto `ab47afe3085` immediately before this push.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtualizable state handling to distinguish static heap data from complete object state.
  * Added validation to reject invalid non-array field declarations instead of silently accepting them.
  * Improved profiling accuracy so C-call events report the actual callee frame, including when calls are inlined.

* **Documentation**
  * Clarified virtualizable forcing, frame-local access, profiling behavior, and translation details.

* **Tests**
  * Added coverage verifying array descriptor validation and correct profiler frame attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->