### PR TITLE
rtyper: advance PyPy-faithful cutover identities

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -396,6 +396,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     );
     majit_gc::set_active_gc_owns_object(Some(gc_owns_object_via_active_runtime));
     majit_gc::set_active_gc_shrink_array(Some(gc_shrink_array_via_active_runtime));
+    majit_gc::set_active_gc_varsize_layout(Some(gc_varsize_layout_via_active_runtime));
     majit_gc::set_active_gc_is_nursery_object(Some(gc_is_nursery_object_via_active_runtime));
     majit_gc::set_active_gc_id_or_identityhash(Some(id_or_identityhash_via_active_runtime));
     majit_gc::set_active_write_barrier(Some(gc_write_barrier_via_active_runtime));
@@ -1963,6 +1964,18 @@ fn gc_shrink_array_via_active_runtime(addr: usize, smaller_length: usize) -> boo
         return majit_gc::gc_sync::gc_op(|gc| gc.shrink_array(addr, smaller_length));
     }
     false
+}
+
+fn gc_varsize_layout_via_active_runtime(addr: usize) -> Option<majit_gc::GcVarSizeLayout> {
+    let obj = GcRef(addr);
+    if let Some(r) = gc_box::with_reentrant_ref(|gc| gc.varsize_layout(obj)) {
+        return r;
+    }
+    if majit_gc::gc_sync::is_initialized() {
+        majit_gc::gc_sync::gc_query_reentrant(|g| g.varsize_layout(obj))
+    } else {
+        None
+    }
 }
 
 fn gc_is_nursery_object_via_active_runtime(addr: usize) -> bool {

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -407,6 +407,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_root_hooks(Some(dynasm_gc_add_root), Some(dynasm_gc_remove_root));
     majit_gc::set_active_gc_owns_object(Some(dynasm_gc_owns_object));
     majit_gc::set_active_gc_shrink_array(Some(dynasm_gc_shrink_array));
+    majit_gc::set_active_gc_varsize_layout(Some(dynasm_gc_varsize_layout));
     majit_gc::set_active_gc_is_nursery_object(Some(dynasm_gc_is_nursery_object));
     majit_gc::set_active_gc_id_or_identityhash(Some(dynasm_id_or_identityhash));
     majit_gc::set_active_write_barrier(Some(dynasm_gc_write_barrier));
@@ -1007,6 +1008,18 @@ fn dynasm_gc_owns_object(addr: usize) -> bool {
 /// hold the collector's `&mut`.
 fn dynasm_gc_shrink_array(addr: usize, smaller_length: usize) -> bool {
     with_dynasm_active_gc_mut(|gc| gc.shrink_array(addr, smaller_length)).unwrap_or(false)
+}
+
+fn dynasm_gc_varsize_layout(addr: usize) -> Option<majit_gc::GcVarSizeLayout> {
+    let obj = GcRef(addr);
+    if let Some(r) = gc_box::with_reentrant_ref(|gc| gc.varsize_layout(obj)) {
+        return r;
+    }
+    if majit_gc::gc_sync::is_initialized() {
+        majit_gc::gc_sync::gc_query_reentrant(|g| g.varsize_layout(obj))
+    } else {
+        None
+    }
 }
 
 fn dynasm_gc_is_nursery_object(addr: usize) -> bool {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1018,6 +1018,7 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     majit_gc::set_active_root_hooks(Some(wasm_gc_add_root), Some(wasm_gc_remove_root));
     majit_gc::set_active_gc_owns_object(Some(wasm_gc_owns_object));
     majit_gc::set_active_gc_shrink_array(Some(wasm_gc_shrink_array));
+    majit_gc::set_active_gc_varsize_layout(Some(wasm_gc_varsize_layout));
     majit_gc::set_active_gc_id_or_identityhash(Some(wasm_id_or_identityhash));
     majit_gc::set_active_write_barrier(Some(wasm_active_gc_write_barrier));
     majit_gc::set_active_write_barrier_before_move(Some(wasm_active_gc_write_barrier_before_move));
@@ -1801,6 +1802,18 @@ fn wasm_gc_owns_object(addr: usize) -> bool {
 /// read-only queries made while a collection may already hold `&mut`.
 fn wasm_gc_shrink_array(addr: usize, smaller_length: usize) -> bool {
     with_wasm_active_gc_mut(|gc| gc.shrink_array(addr, smaller_length)).unwrap_or(false)
+}
+
+fn wasm_gc_varsize_layout(addr: usize) -> Option<majit_gc::GcVarSizeLayout> {
+    let obj = GcRef(addr);
+    if let Some(r) = gc_box::with_reentrant_ref(|gc| gc.varsize_layout(obj)) {
+        return r;
+    }
+    if majit_gc::gc_sync::is_initialized() {
+        majit_gc::gc_sync::gc_query_reentrant(|g| g.varsize_layout(obj))
+    } else {
+        None
+    }
 }
 
 pub struct WasmBackend {

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -8374,6 +8374,22 @@ impl GcAllocator for MiniMarkGC {
         MiniMarkGC::shrink_array(self, addr, smaller_length)
     }
 
+    fn varsize_layout(&self, obj: GcRef) -> Option<crate::GcVarSizeLayout> {
+        if obj.is_null() || !self.is_managed_heap_object(obj.0) {
+            return None;
+        }
+        let type_id = unsafe { (*header_of(obj.0)).type_id() };
+        if type_id as usize >= self.types.len() {
+            return None;
+        }
+        let info = self.types.get(type_id);
+        (info.item_size != 0).then_some(crate::GcVarSizeLayout {
+            base_size: info.size,
+            item_size: info.item_size,
+            items_have_gc_ptrs: info.items_have_gc_ptrs,
+        })
+    }
+
     fn debug_validate_oldgen_freeblocks(&self, site: &str) {
         self.oldgen.debug_validate_freeblocks(site);
     }
@@ -14936,6 +14952,25 @@ cache size\t: 8192 kB\n";
 
         assert_eq!(gc.old_objects_pointing_to_young.len(), before + 1);
         assert!(gc.old_objects_pointing_to_young.contains(&array.0));
+    }
+
+    /// The four-argument arraymove residual recovers its array token from the
+    /// same TYPE_INFO row the collector uses to walk the variable part.
+    #[test]
+    fn varsize_layout_reports_registered_array_shape() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::varsize(24, 16, 8, true, vec![]));
+        let array = gc.alloc_varsize_typed(tid, 24, 16, 3);
+
+        let dynamic: &dyn crate::GcAllocator = &gc;
+        assert_eq!(
+            dynamic.varsize_layout(array),
+            Some(crate::GcVarSizeLayout {
+                base_size: 24,
+                item_size: 16,
+                items_have_gc_ptrs: true,
+            })
+        );
     }
 
     /// An array with no card marked has nothing the move could invalidate.

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -12,6 +12,19 @@ pub use gcreftracer::{GcTable, install_gc_table_walker};
 use majit_ir::{Const, ConstMap, GcRef, Op};
 pub use trace::{ClassTypeLayout, TypeEntry, TypeInfo, TypeInfoLayout};
 
+/// Runtime layout of one registered variable-size GC object.
+///
+/// These are the facts `rgc.ll_arraymove` gets from the array lltype in
+/// RPython. The residual target retains upstream's four-argument ABI and
+/// recovers them from the collector's existing TYPE_INFO row instead of a
+/// pyre-only extra argument or a parallel layout table.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GcVarSizeLayout {
+    pub base_size: usize,
+    pub item_size: usize,
+    pub items_have_gc_ptrs: bool,
+}
+
 mod address_dict;
 pub mod collector;
 pub mod gc_sync;
@@ -1133,6 +1146,12 @@ pub trait GcAllocator: Send {
         None
     }
 
+    /// Return the registered variable-size layout for `obj`.
+    /// Fixed-size, foreign, null, and unknown objects return `None`.
+    fn varsize_layout(&self, _obj: GcRef) -> Option<GcVarSizeLayout> {
+        None
+    }
+
     /// llsupport/gc.py GcLLDescr_framework
     ///   .get_typeid_from_classptr_if_gcremovetypeptr(classptr)
     /// Maps a vtable pointer to its registered GC type id. RPython
@@ -1649,6 +1668,9 @@ impl GcAllocator for GcHandle {
     }
     fn type_size(&self, type_id: u32) -> Option<usize> {
         gc_sync::gc_query_reentrant(|gc| gc.type_size(type_id))
+    }
+    fn varsize_layout(&self, obj: GcRef) -> Option<GcVarSizeLayout> {
+        gc_sync::gc_query_reentrant(|gc| gc.varsize_layout(obj))
     }
     fn get_typeid_from_classptr_if_gcremovetypeptr(&self, classptr: usize) -> Option<u32> {
         gc_sync::gc_query_reentrant(|gc| gc.get_typeid_from_classptr_if_gcremovetypeptr(classptr))
@@ -2962,10 +2984,14 @@ pub type GcOwnsObjectFn = fn(addr: usize) -> bool;
 pub type GcIsNurseryObjectFn = fn(addr: usize) -> bool;
 /// `llop.shrink_array` — see [`GcAllocator::shrink_array`].
 pub type GcShrinkArrayFn = fn(addr: usize, smaller_length: usize) -> bool;
+/// Read-only TYPE_INFO query used by the four-argument `ll_arraymove`
+/// residual target.
+pub type GcVarSizeLayoutFn = fn(addr: usize) -> Option<GcVarSizeLayout>;
 
 global_hook!(static ACTIVE_GC_OWNS_OBJECT: GcOwnsObjectFn);
 global_hook!(static ACTIVE_GC_IS_NURSERY_OBJECT: GcIsNurseryObjectFn);
 global_hook!(static ACTIVE_GC_SHRINK_ARRAY: GcShrinkArrayFn);
+global_hook!(static ACTIVE_GC_VARSIZE_LAYOUT: GcVarSizeLayoutFn);
 
 /// Install the active backend's `is_managed_heap_object` trampoline.
 pub fn set_active_gc_owns_object(hook: Option<GcOwnsObjectFn>) {
@@ -2980,6 +3006,11 @@ pub fn set_active_gc_is_nursery_object(hook: Option<GcIsNurseryObjectFn>) {
 /// Install the active backend's in-place array shrink.
 pub fn set_active_gc_shrink_array(hook: Option<GcShrinkArrayFn>) {
     ACTIVE_GC_SHRINK_ARRAY.set(hook);
+}
+
+/// Install the active backend's registered-varsize-layout query.
+pub fn set_active_gc_varsize_layout(hook: Option<GcVarSizeLayoutFn>) {
+    ACTIVE_GC_VARSIZE_LAYOUT.set(hook);
 }
 
 /// minimark.py `id_or_identityhash` hook.
@@ -3029,6 +3060,15 @@ pub fn gc_shrink_array(addr: usize, smaller_length: usize) -> bool {
         Some(f) => f(addr, smaller_length),
         None => false,
     }
+}
+
+/// Return the active collector's existing TYPE_INFO layout for `addr`.
+/// `None` means it is not a registered variable-size GC object.
+pub fn gc_varsize_layout(addr: usize) -> Option<GcVarSizeLayout> {
+    if addr == 0 {
+        return None;
+    }
+    ACTIVE_GC_VARSIZE_LAYOUT.get().and_then(|f| f(addr))
 }
 
 /// Whether the finalizer for the object at `addr` has already run.

--- a/majit/majit-ir/src/jit.rs
+++ b/majit/majit-ir/src/jit.rs
@@ -1,0 +1,13 @@
+//! Translation-visible JIT hint carriers.
+//!
+//! These functions are runtime identities.  Their call paths survive in LLBC
+//! long enough for `majit-translate` to replace them with the corresponding
+//! RPython `jit.hint` operation.  They live in `majit-ir`, below both
+//! `pyre-object` and `majit-metainterp`, so source-level decorators do not
+//! invert the crate dependency graph merely to spell a translation hint.
+
+/// `rpython.rlib.jit.promote(x)` — `hint(x, promote=True)`.
+#[inline(always)]
+pub fn promote<T: Copy>(value: T) -> T {
+    value
+}

--- a/majit/majit-ir/src/lib.rs
+++ b/majit/majit-ir/src/lib.rs
@@ -8,6 +8,7 @@ pub mod field_entry;
 pub mod forwarding;
 pub mod indexmap_ext;
 pub mod intbound;
+pub mod jit;
 pub mod op_descr;
 pub mod op_info;
 pub mod op_type_index;

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -2306,12 +2306,12 @@ pub fn elidable_promote(attr: TokenStream, item: TokenStream) -> TokenStream {
             if has_self && idx == 0 {
                 // rlib/jit.py — promote self by identity (guard_value on pointer)
                 Some(quote! {
-                    let _ = majit_metainterp::jit::promote(self as *const _ as usize);
+                    let _ = majit_ir::jit::promote(self as *const _ as usize);
                 })
             } else {
                 let named_idx = if has_self { idx - 1 } else { idx };
                 named_args.get(named_idx).map(|name| {
-                    quote! { let #name = majit_metainterp::jit::promote(#name); }
+                    quote! { let #name = majit_ir::jit::promote(#name); }
                 })
             }
         })

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -2318,6 +2318,12 @@ pub fn elidable_promote(attr: TokenStream, item: TokenStream) -> TokenStream {
         .collect();
 
     let call_args: Vec<_> = param_names.clone();
+    let orig_call = if has_self {
+        let method_args = call_args.iter().skip(1);
+        quote! { self.#orig_name(#(#method_args),*) }
+    } else {
+        quote! { #orig_name(#(#call_args),*) }
+    };
 
     // Build call_target/policy for the ORIGINAL elidable function
     let orig_sig = syn::Signature {
@@ -2378,7 +2384,7 @@ pub fn elidable_promote(attr: TokenStream, item: TokenStream) -> TokenStream {
         // rlib/jit.py — elidable(func); original body hidden
         #[inline(never)]
         #[doc(hidden)]
-        #[allow(non_upper_case_globals)]
+        #[allow(non_snake_case, non_upper_case_globals)]
         fn #orig_name(#(#full_params),*) #output {
             #[doc(hidden)]
             #[allow(dead_code)]
@@ -2393,7 +2399,7 @@ pub fn elidable_promote(attr: TokenStream, item: TokenStream) -> TokenStream {
         #(#attrs)*
         #vis fn #fn_name(#(#full_params),*) #output {
             #(#promote_stmts)*
-            #orig_name(#(#call_args),*)
+            #orig_call
         }
 
         #orig_elidable_const

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -2631,19 +2631,16 @@ fn field_slot_disagreement(
 
 /// Whether `slot` and `field` name the same field.
 ///
-/// Both halves must agree. `field_key()` is the FIELDNAME half of
-/// `get_field_descr`'s cache key (`descr.py`, `cache[STRUCT][fieldname]`) —
-/// only the half: upstream keys on the owning STRUCT as well, and carries the
-/// owner on the descr itself as `name = '%s.%s' % (STRUCT._name, fieldname)`
-/// plus `get_parent_descr()`. This comparison deliberately drops the owner,
-/// because `field_name()` may retain a different LLBC spelling of the same
-/// StructId (`option::Option.__discriminant` vs
-/// `core::option::Option.__discriminant`) and comparing those answers "apart"
-/// for one class. The cost is that a field of one struct claiming a slot in
-/// another struct's descr is no longer detected when the two share a leaf
-/// name AND an offset. Converging means resolving the owner to a StructId —
-/// the same move `unique_trait_impl_roots` made — and comparing that
-/// alongside the leaf, not restoring the full-name comparison.
+/// All three halves of `get_field_descr`'s identity must agree: the owning
+/// STRUCT, `fieldname`, and byte offset (`descr.py`,
+/// `cache[STRUCT][fieldname]`).  Production field descrs carry the STRUCT as
+/// `get_parent_descr()`.  Pyre can reconstruct the same RPython STRUCT descr
+/// more than once, so compare its stable `cache_key` rather than requiring the
+/// Rust `Arc` itself to be shared.  When that identity is not populated yet,
+/// resolve the qualified display owners through pyre's StructId table; never
+/// collapse two *known* distinct owners merely because their leaf field and
+/// offset happen to agree.  Unnamed dynamic/test descriptors carry no owner
+/// evidence at all and retain the positional fallback.
 ///
 /// The key is not always carried — the flattened inline aggregates
 /// (`ob_header`, an enum's `__pos_0`) reach here under the documented
@@ -2652,10 +2649,94 @@ fn field_slot_disagreement(
 /// absent, and a flattened layout puts an aggregate and its first leaf at one
 /// address (`heaptracker.py:68-69`).
 pub(crate) fn slot_holds_field(slot: &dyn FieldDescr, field: &dyn FieldDescr) -> bool {
+    fn display_owner(field: &dyn FieldDescr) -> Option<&str> {
+        let name = field.field_name();
+        let key = field.field_key();
+        if name.is_empty() || key.is_empty() || name == key {
+            return None;
+        }
+        name.strip_suffix(key)?.strip_suffix('.')
+    }
+
+    // `heaptracker.all_fielddescrs(gccache, STRUCT)` walks an embedded base
+    // before the subclass's own fields.  Consequently a subclass SizeDescr
+    // legitimately contains the base's FieldDescr at the same slot even
+    // though their parent STRUCT keys differ (`rclass.InstanceRepr._setup_repr`
+    // creates exactly this `super` edge).  Pyre's explicit Result/Option shell
+    // serializes the flattened row under the variant parent, so recover that
+    // one proven inheritance edge from the qualified owners.  Do not accept a
+    // same-name/same-offset field from an arbitrary different struct.
+    fn explicit_sum_inherits(slot_owner: &str, field_owner: &str) -> bool {
+        fn same_owner(left: &str, right: &str) -> bool {
+            let left = majit_ir::descr::strip_generic_args(left);
+            let right = majit_ir::descr::strip_generic_args(right);
+            match (
+                majit_ir::descr::struct_template_id_for_name(left.as_ref()),
+                majit_ir::descr::struct_template_id_for_name(right.as_ref()),
+            ) {
+                (Some(left), Some(right)) => left == right,
+                _ => {
+                    majit_ir::descr::canonical_struct_name(left.as_ref())
+                        == majit_ir::descr::canonical_struct_name(right.as_ref())
+                }
+            }
+        }
+
+        let slot = majit_ir::descr::strip_generic_args(slot_owner);
+        let Some((base, variant)) = slot.rsplit_once("::") else {
+            return false;
+        };
+        matches!(variant, "Some" | "Ok" | "Err") && same_owner(base, field_owner)
+    }
+
+    let names_name_same_owner = || match (display_owner(slot), display_owner(field)) {
+        (Some(slot_owner), Some(field_owner)) => {
+            match (
+                majit_ir::descr::struct_id_for_name(slot_owner),
+                majit_ir::descr::struct_id_for_name(field_owner),
+            ) {
+                (Some(slot_id), Some(field_id)) => slot_id == field_id,
+                _ => slot_owner == field_owner,
+            }
+        }
+        // Neither descriptor contains an owner spelling.  This is the
+        // flattened/dynamic fallback described above, not evidence that
+        // two differently named owners are equal.
+        (None, None) => true,
+        _ => false,
+    };
+    let same_owner = match (slot.get_parent_descr(), field.get_parent_descr()) {
+        (Some(slot_parent), Some(field_parent)) => {
+            if std::sync::Arc::ptr_eq(&slot_parent, &field_parent) {
+                true
+            } else {
+                let slot_key = slot_parent
+                    .as_size_descr()
+                    .map(|descr| descr.cache_key())
+                    .unwrap_or(0);
+                let field_key = field_parent
+                    .as_size_descr()
+                    .map(|descr| descr.cache_key())
+                    .unwrap_or(0);
+                if slot_key != 0 && field_key != 0 {
+                    slot_key == field_key
+                        || match (display_owner(slot), display_owner(field)) {
+                            (Some(slot_owner), Some(field_owner)) => {
+                                explicit_sum_inherits(slot_owner, field_owner)
+                            }
+                            _ => false,
+                        }
+                } else {
+                    names_name_same_owner()
+                }
+            }
+        }
+        _ => names_name_same_owner(),
+    };
     let named_apart = !field.field_key().is_empty()
         && !slot.field_key().is_empty()
         && slot.field_key() != field.field_key();
-    !named_apart && slot.offset() == field.offset()
+    same_owner && !named_apart && slot.offset() == field.offset()
 }
 
 /// Whether `field_idx` addresses `field` in the struct `descr` describes.
@@ -3516,6 +3597,7 @@ mod tests {
 
     #[test]
     fn slot_identity_uses_field_key_across_owner_spelling_aliases() {
+        let parent = majit_ir::descr::make_size_descr(16);
         let slot = majit_ir::SimpleFieldDescr::new_with_name(
             0,
             0,
@@ -3525,7 +3607,8 @@ mod tests {
             majit_ir::ArrayFlag::Signed,
             "core::option::Option.__discriminant".to_string(),
             "__discriminant".to_string(),
-        );
+        )
+        .with_parent_descr(parent.clone(), 0);
         let alias = majit_ir::SimpleFieldDescr::new_with_name(
             0,
             0,
@@ -3535,12 +3618,14 @@ mod tests {
             majit_ir::ArrayFlag::Signed,
             "option::Option.__discriminant".to_string(),
             "__discriminant".to_string(),
-        );
+        )
+        .with_parent_descr(parent.clone(), 0);
         assert!(
             slot_holds_field(&slot, &alias),
             "display aliases of one STRUCT.fieldname identify one RPython field descr"
         );
 
+        let other_parent = majit_ir::descr::make_size_descr(16);
         let other = majit_ir::SimpleFieldDescr::new_with_name(
             0,
             0,
@@ -3548,10 +3633,65 @@ mod tests {
             Type::Int,
             false,
             majit_ir::ArrayFlag::Signed,
-            "core::option::Option.__pos_0".to_string(),
-            "__pos_0".to_string(),
-        );
+            "other::Option.__discriminant".to_string(),
+            "__discriminant".to_string(),
+        )
+        .with_parent_descr(other_parent.clone(), 0);
         assert!(!slot_holds_field(&slot, &other));
+    }
+
+    #[test]
+    fn slot_identity_accepts_an_inherited_sum_base_field() {
+        let mut variant_size = majit_ir::descr::SimpleSizeDescr::new(0, 16, 1);
+        variant_size.set_cache_key(0x51);
+        let variant_parent = Arc::new(variant_size) as DescrRef;
+        let mut base_size = majit_ir::descr::SimpleSizeDescr::new(1, 8, 2);
+        base_size.set_cache_key(0x52);
+        let base_parent = Arc::new(base_size) as DescrRef;
+
+        let slot = majit_ir::SimpleFieldDescr::new_with_name(
+            0,
+            0,
+            8,
+            Type::Int,
+            false,
+            majit_ir::ArrayFlag::Signed,
+            "core::option::Option<i64>::Some.__discriminant".to_string(),
+            "__discriminant".to_string(),
+        )
+        .with_parent_descr(variant_parent.clone(), 0);
+        let inherited = majit_ir::SimpleFieldDescr::new_with_name(
+            0,
+            0,
+            8,
+            Type::Int,
+            false,
+            majit_ir::ArrayFlag::Signed,
+            "core::option::Option<i64>.__discriminant".to_string(),
+            "__discriminant".to_string(),
+        )
+        .with_parent_descr(base_parent.clone(), 0);
+        assert!(
+            slot_holds_field(&slot, &inherited),
+            "slot name={:?} key={:?} inherited name={:?} key={:?}",
+            slot.field_name(),
+            slot.field_key(),
+            inherited.field_name(),
+            inherited.field_key(),
+        );
+
+        let unrelated = majit_ir::SimpleFieldDescr::new_with_name(
+            0,
+            0,
+            8,
+            Type::Int,
+            false,
+            majit_ir::ArrayFlag::Signed,
+            "other::Option<i64>.__discriminant".to_string(),
+            "__discriminant".to_string(),
+        )
+        .with_parent_descr(base_parent, 0);
+        assert!(!slot_holds_field(&slot, &unrelated));
     }
 
     fn assign_positions(ops: &mut [Op]) {

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -2670,6 +2670,30 @@ pub(crate) fn slot_holds_field(slot: &dyn FieldDescr, field: &dyn FieldDescr) ->
         fn same_owner(left: &str, right: &str) -> bool {
             let left = majit_ir::descr::strip_generic_args(left);
             let right = majit_ir::descr::strip_generic_args(right);
+            // The translated explicit sum shell is deliberately accepted
+            // under both the full standard-library spelling and Charon's
+            // crate-stripped spelling (`core::option::Option` /
+            // `option::Option`, likewise `Result`).  The translator-side
+            // StructId registry proves those aliases while building the
+            // JitCode, but that build-only registry is not serialized into
+            // the generated runtime.  Recover only these two already-gated
+            // shell identities here; a general suffix comparison would merge
+            // an unrelated `mycrate::option::Option` and violate
+            // `descr.py`'s `(STRUCT, fieldname)` identity.
+            fn explicit_sum_template(name: &str) -> Option<&'static str> {
+                let segments: Vec<&str> = name.split("::").collect();
+                match segments.as_slice() {
+                    ["option", "Option"] | ["core" | "std", "option", "Option"] => Some("Option"),
+                    ["result", "Result"] | ["core" | "std", "result", "Result"] => Some("Result"),
+                    _ => None,
+                }
+            }
+            if let (Some(left), Some(right)) = (
+                explicit_sum_template(left.as_ref()),
+                explicit_sum_template(right.as_ref()),
+            ) {
+                return left == right;
+            }
             match (
                 majit_ir::descr::struct_template_id_for_name(left.as_ref()),
                 majit_ir::descr::struct_template_id_for_name(right.as_ref()),

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -1350,6 +1350,15 @@ impl Bookkeeper {
         if let Some(existing) = self.descs.borrow().get(pyobj) {
             return Ok(existing.clone());
         }
+        // A SyntheticTransparentCtor is a call-site marker around the ONE
+        // canonical class object, not another class.  Reuse the target's
+        // ClassDesc exactly; ClassesPBCRepr later reads the wrapper constant to
+        // select rtype_new_instance without the optional __init__ dispatch.
+        if let Some(class_obj) = pyobj.transparent_class_target() {
+            let entry = self.getdesc(class_obj)?;
+            self.descs.borrow_mut().insert(pyobj.clone(), entry.clone());
+            return Ok(entry);
+        }
         let entry = if pyobj.is_user_function() {
             // upstream `newfuncdesc` already returns a MemoDesc or
             // FunctionDesc per the specializer.
@@ -1986,22 +1995,13 @@ impl Bookkeeper {
             let Some(n) = next else { break };
             self.project_struct_rows(&n)?;
         }
-        let classdef = self.getuniqueclassdef(&variant_host)?;
-        // Every payload row on a Rust enum variant is assigned by that
-        // variant's constructor. In RPython terms these are mutable instance
-        // attributes, not readonly class attributes: `Attribute.modified`
-        // runs during annotation before `InstanceRepr._setup_repr` builds its
-        // field table. Pyre pre-mints variants at session start so inheritance
-        // ids stay stable; mark the projected payload rows at that same point
-        // to preserve RPython's attrs-before-repr ordering even when another
-        // subject caches the repr before this constructor is annotated.
-        {
-            let mut classdef_mut = classdef.borrow_mut();
-            for attr in classdef_mut.attrs.values_mut() {
-                attr.modified(Some(&classdef))?;
-            }
-        }
-        Ok(classdef)
+        // Do not pre-emptively mark every projected row mutable.  RPython's
+        // `Attribute.modified` is driven by the actual constructor `setattr`
+        // during annotation (`unaryop.py SomeInstance.setattr`), which the
+        // adapter's FieldWrite lowering already emits.  Eagerly modifying the
+        // whole class here materializes fields no observed constructor wrote
+        // and hides phase-order bugs in repr setup.
+        self.getuniqueclassdef(&variant_host)
     }
 
     /// Register a trait family for receiver-driven method dispatch: a base
@@ -3697,7 +3697,7 @@ impl Bookkeeper {
         // upstream bookkeeper.py:315-316 — `elif tp is type: result =
         // SomeConstantType(x, self)`. Implemented as a constant
         // SomePBC over the real [`ClassDesc`] returned by [`Self::getdesc`].
-        if obj.is_class() {
+        if obj.is_class() || obj.transparent_class_target().is_some() {
             let entry = self.getdesc(obj)?;
             let mut pbc = SomePBC::new(vec![entry], false);
             pbc.base.const_box = Some(Constant::new(raw.clone()));
@@ -3810,10 +3810,15 @@ impl Default for Bookkeeper {
 /// crate-included `pyre_object::unicodeobject::W_UnicodeObject`,
 /// crate-relative `unicodeobject::W_UnicodeObject`, and a dotted constructor
 /// qualname.  RPython keys all reads and constructors on the one live class
-/// object (`bookkeeper.py:361-363` — `obj_key = Constant(pyobj)`), so strip
-/// exactly one registered local-crate prefix and normalize dots.
+/// object (`bookkeeper.py:361-363` — `obj_key = Constant(pyobj)`), so normalize
+/// dots and strip one crate prefix only when StructId resolution proves that
+/// both spellings denote the same declaration.
 ///
-/// Strip only while a module path survives.  Collapsing
+/// Strip only while a module path survives.  A Rust `::` spelling is stripped
+/// only when the process-wide StructId resolver proves the full and
+/// crate-relative names denote the same declaration; class identity must not
+/// depend on the thread-local call-alias registry or on which pipeline last
+/// ran on this thread. Collapsing
 /// `pyre_object::PyObject` to the bare `PyObject` is what
 /// `harden_duplicate_leaf_metadata` exists to undo — the chain walk needs
 /// `ob_header` / `base` to reach the superclass, and a bare leaf collides
@@ -3822,9 +3827,16 @@ pub(crate) fn normalize_class_qualname(name: &str) -> String {
     let lookup = name.replace('.', "::");
     lookup
         .split_once("::")
-        .filter(|(root, rest)| {
+        .filter(|(_root, rest)| {
             rest.contains("::")
-                && (name.contains('.') || crate::local_crates::is_local_crate_root(root))
+                && (name.contains('.')
+                    || matches!(
+                        (
+                            majit_ir::descr::struct_id_for_name(&lookup),
+                            majit_ir::descr::struct_id_for_name(rest),
+                        ),
+                        (Some(full), Some(relative)) if full == relative
+                    ))
         })
         .map(|(_, rest)| rest.to_string())
         .unwrap_or(lookup)
@@ -4736,6 +4748,135 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    fn real_merged_llbc_memoryview_closure_tuple_projects_pyobject_item() {
+        use crate::annotator::model::SomeValue;
+        use crate::translator::rtyper::rmodel::Repr;
+        use majit_charon_reader::Llbc;
+
+        let root = concat!(env!("CARGO_MANIFEST_DIR"), "/../../build/llbc/");
+        let object = Llbc::load(format!("{root}pyre-object.ullbc")).expect("load real object LLBC");
+        let interpreter = Llbc::load(format!("{root}pyre-interpreter.ullbc"))
+            .expect("load real interpreter LLBC");
+        let jit = Llbc::load(format!("{root}pyre-jit.ullbc")).expect("load real jit LLBC");
+        let program = crate::front::mir::build_semantic_program_from_llbcs_with_static_addrs_and_function_names(
+            &[object, interpreter, jit],
+            crate::HostStaticAddrs::default(),
+            &["builtins"],
+            &["memoryview_is_native_release_descr", "call_once"],
+        )
+        .expect("derive merged production metadata");
+        let tuple = "Tuple<*mut PyObject>";
+        let target = program
+            .functions
+            .iter()
+            .find(|function| function.name == "memoryview_is_native_release_descr")
+            .expect("memoryview caller graph");
+        let written = target
+            .graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .find_map(|op| match &op.kind {
+                crate::model::OpKind::FieldWrite { field, value, .. }
+                    if field.owner_root.as_deref() == Some(tuple) =>
+                {
+                    value.as_variable().cloned()
+                }
+                _ => None,
+            })
+            .expect("memoryview closure Args tuple payload write");
+        assert!(
+            target
+                .graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| {
+                    op.result.as_ref() == Some(&written)
+                        && matches!(
+                            &op.kind,
+                            crate::model::OpKind::Call {
+                                target: crate::model::CallTarget::FunctionPath { segments },
+                                ..
+                            } if segments == &[crate::runtime_names::shims::CAST_INSTANCE, "PyObject"]
+                        )
+                }),
+            "the tuple writer must preserve the source PyObject class"
+        );
+        let rows = program.struct_fields.fields.get(tuple).unwrap_or_else(|| {
+            panic!(
+                "missing {tuple}; matching keys: {:?}",
+                program
+                    .struct_fields
+                    .fields
+                    .keys()
+                    .filter(|key| key.contains("Tuple<*mut PyObject"))
+                    .collect::<Vec<_>>()
+            )
+        });
+        assert_eq!(
+            rows,
+            &vec![("__pos_0".to_string(), "*mut PyObject".to_string())]
+        );
+        majit_ir::descr::register_struct_origins(program.struct_origins.clone());
+        for (qualified, fields) in &program.struct_field_attrs {
+            crate::annotator::classdesc::register_struct_fields(qualified, fields);
+        }
+
+        let bk = bk();
+        bk.set_struct_fields(Rc::new(program.struct_fields));
+        let tuple_cd = bk
+            .getuniqueclassdef_for_struct_root(tuple)
+            .expect("closure Args tuple classdef");
+        let item = tuple_cd
+            .borrow()
+            .attrs
+            .get("__pos_0")
+            .expect("closure Args item attr")
+            .s_value
+            .clone();
+        let SomeValue::Instance(item) = item else {
+            panic!("closure Args item must be an instance, got {item:?}")
+        };
+        let item_cd = item
+            .classdef
+            .expect("closure Args item must retain the PyObject classdef");
+
+        let registry = crate::translator::rtyper::call_registry::CallRegistry::new(bk.clone());
+        let (_, rtyper) = registry
+            .ensure_session()
+            .expect("create shared rtyper session");
+        let tuple_repr = crate::translator::rtyper::rclass::getinstancerepr(
+            &rtyper,
+            Some(&tuple_cd),
+            crate::translator::rtyper::rclass::Flavor::Gc,
+        )
+        .expect("closure Args tuple repr");
+        crate::translator::rtyper::rmodel::Repr::setup(tuple_repr.as_ref())
+            .expect("set up closure Args tuple repr");
+        let item_repr = tuple_repr
+            .fields()
+            .get("__pos_0")
+            .expect("closure Args item repr")
+            .1
+            .clone();
+        let expected_repr = crate::translator::rtyper::rclass::getinstancerepr(
+            &rtyper,
+            Some(&item_cd),
+            crate::translator::rtyper::rclass::Flavor::Gc,
+        )
+        .expect("PyObject repr");
+        crate::translator::rtyper::rmodel::Repr::setup(expected_repr.as_ref())
+            .expect("set up PyObject repr");
+        assert_eq!(
+            item_repr.lowleveltype(),
+            expected_repr.lowleveltype(),
+            "closure Args tuple field repr must be the concrete PyObject repr"
+        );
+    }
+
+    #[test]
     fn nonheader_dotted_constructor_reuses_crate_relative_struct_identity() {
         use crate::front::StructFieldRegistry;
 
@@ -4765,9 +4906,6 @@ mod tests {
     fn header_struct_spellings_reuse_one_class_identity_and_base() {
         use crate::front::StructFieldRegistry;
 
-        let previous_roots = crate::local_crates::local_crate_roots();
-        crate::local_crates::register_local_crate_roots(["fixture_crate".to_string()]);
-
         let bk = bk();
         let mut reg = StructFieldRegistry::default();
         let rows = vec![
@@ -4786,10 +4924,7 @@ mod tests {
         bk.set_struct_fields(Rc::new(reg));
 
         let from_field = bk.intern_class_by_qualname("unicodeobject::W_UnicodeObject");
-        let from_full =
-            bk.intern_class_by_qualname("fixture_crate::unicodeobject::W_UnicodeObject");
         let from_ctor = bk.intern_class_by_qualname("fixture_crate.unicodeobject.W_UnicodeObject");
-        assert_eq!(from_field, from_full);
         assert_eq!(from_field, from_ctor);
 
         let classdef = bk.getuniqueclassdef(&from_field).expect("header classdef");
@@ -4797,8 +4932,6 @@ mod tests {
             classdef.borrow().basedef.is_some(),
             "normalizing the class identity must retain its embedded-header base"
         );
-
-        crate::local_crates::register_local_crate_roots(previous_roots);
     }
 
     #[test]
@@ -6884,6 +7017,16 @@ mod tests {
             .getuniqueclassdef_for_enum_variant("Result<Vec<*mut PyObject>,PyErr>", "Ok")
             .expect("Result::Ok");
         for (name, classdef) in [("Option::Some", &some_cd), ("Result::Ok", &ok_cd)] {
+            let payload = classdef.borrow().attrs["__pos_0"].s_value.clone();
+            classdef
+                .borrow_mut()
+                .attrs
+                .get_mut("__pos_0")
+                .expect("variant payload")
+                .modified(Some(classdef))
+                .expect("constructor setattr marks payload mutable");
+            ClassDef::generalize_attr(classdef, "__pos_0", Some(payload))
+                .expect("constructor payload setattr");
             let attrs = classdef.borrow();
             assert!(
                 matches!(

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -4749,7 +4749,7 @@ mod tests {
 
     #[test]
     #[ignore]
-    fn real_merged_llbc_memoryview_closure_tuple_projects_pyobject_item() {
+    fn real_merged_llbc_memoryview_closure_tuple_projects_instance_item() {
         use crate::annotator::model::SomeValue;
         use crate::translator::rtyper::rmodel::Repr;
         use majit_charon_reader::Llbc;

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -1995,13 +1995,22 @@ impl Bookkeeper {
             let Some(n) = next else { break };
             self.project_struct_rows(&n)?;
         }
-        // Do not pre-emptively mark every projected row mutable.  RPython's
-        // `Attribute.modified` is driven by the actual constructor `setattr`
-        // during annotation (`unaryop.py SomeInstance.setattr`), which the
-        // adapter's FieldWrite lowering already emits.  Eagerly modifying the
-        // whole class here materializes fields no observed constructor wrote
-        // and hides phase-order bugs in repr setup.
-        self.getuniqueclassdef(&variant_host)
+        let classdef = self.getuniqueclassdef(&variant_host)?;
+        // Every payload row on a Rust enum variant is assigned by that
+        // variant's constructor. In RPython terms these are mutable instance
+        // attributes, not readonly class attributes: `Attribute.modified`
+        // runs during annotation before `InstanceRepr._setup_repr` builds its
+        // field table. Pyre pre-mints variants at session start so inheritance
+        // ids stay stable; mark the projected payload rows at that same point
+        // to preserve RPython's attrs-before-repr ordering even when another
+        // subject caches the repr before this constructor is annotated.
+        {
+            let mut classdef_mut = classdef.borrow_mut();
+            for attr in classdef_mut.attrs.values_mut() {
+                attr.modified(Some(&classdef))?;
+            }
+        }
+        Ok(classdef)
     }
 
     /// Register a trait family for receiver-driven method dispatch: a base

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -3835,7 +3835,23 @@ pub(crate) fn bh_size_spec_from_callcontrol(
         // structs (birthday paradox), whereas PyPy's `id(STRUCT)` never
         // aliases.  The rare hash-to-zero case (1 in 2^64) is handled
         // by `simple_descr_group_from_bh_size`'s no-identity branch.
-        type_id: majit_ir::descr::path_hash_for_gc_kind(layout_owner, is_gc_managed),
+        // `layout_owner` is the template spelling used to look up the one
+        // physical field layout.  The low-level STRUCT identity is still the
+        // concrete monomorphization (`Option<i64>::Some`, not
+        // `Option::Some`), exactly as RPython's `GcStruct` object remains
+        // distinct even when two reprs share a shape.  Field descriptors
+        // already preserve this identity in `fielddescrof`; allocations must
+        // use the same key or a freshly virtualized object and its first
+        // setfield acquire different parents.
+        type_id: if is_gc_managed {
+            majit_ir::descr::struct_id_for_name(owner)
+                .map(majit_ir::descr::StructId::as_u64)
+                .unwrap_or_else(|| {
+                    majit_ir::descr::path_hash_for_gc_kind(layout_owner, is_gc_managed)
+                })
+        } else {
+            majit_ir::descr::path_hash_for_gc_kind(layout_owner, is_gc_managed)
+        },
         vtable: 0,
         all_fielddescrs,
     })
@@ -6005,6 +6021,32 @@ mod tests {
             majit_ir::descr::ArrayFlag::Pointer
         );
         assert_eq!(spec.all_fielddescrs[1].index_in_parent, 1);
+    }
+
+    #[test]
+    fn instantiated_sum_allocation_keeps_its_concrete_struct_identity() {
+        use crate::call::CallControl;
+
+        let owner = "core::option::Option<i64>::Some";
+        let template_name = "core::option::Option::Some";
+        let template_id = majit_ir::descr::StructId::from_canonical(template_name);
+        let concrete_id = template_id.instantiate("<i64>");
+        let _registry = register_struct_ids_serialized(HashMap::from([(
+            template_name.to_string(),
+            Some(template_id),
+        )]));
+        let mut cc = CallControl::new();
+        let mut struct_fields = crate::front::StructFieldRegistry::default();
+        struct_fields.fields.insert(
+            template_name.to_string(),
+            vec![("__pos_0".to_string(), "i64".to_string())],
+        );
+        cc.set_struct_fields(struct_fields);
+
+        let spec =
+            bh_size_spec_from_callcontrol(&cc, owner).expect("instantiated Option variant size");
+        assert_eq!(spec.type_id, concrete_id.as_u64());
+        assert_eq!(spec.all_fielddescrs.len(), 2);
     }
 
     /// A user enum whose path merely ends in `option::Option::Some` gets no

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -3749,7 +3749,7 @@ impl<'a> Transformer<'a> {
         // the helper address/effect descriptor and unsigned rounding on the
         // upstream path; it is removed when jtransform consumes the rtyped
         // graph directly.
-        if matches!(target, CallTarget::FunctionPath { segments } if segments == &["float"])
+        if matches!(target, CallTarget::FunctionPath { segments } if segments == &["__builtin__", "float"])
             && args.len() == 1
             && matches!(result_ty, ValueType::Float)
             && variable_has_declared_unsigned_type(graph, &args[0])
@@ -10671,7 +10671,7 @@ mod tests {
             .push_op_var(
                 graph.startblock,
                 OpKind::Call {
-                    target: CallTarget::function_path(["float"]),
+                    target: CallTarget::function_path(["__builtin__", "float"]),
                     args: vec![arg],
                     result_ty: ValueType::Float,
                 },

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -4818,6 +4818,24 @@ impl<'a> Transformer<'a> {
         graph_name: &str,
     ) -> Option<RewriteResult> {
         use crate::codewriter::type_state::ConcreteType;
+        // jtransform.py `_handle_list_call`: `list.ll_arraymove` is an OS9
+        // residual call. Descriptor analysis still sees the helper graph (and
+        // its literal length-one array store) through `op`; only the function
+        // address is retargeted to the native barrier+memmove body.
+        if oopspec_name == "list.ll_arraymove" {
+            let move_target = CallTarget::function_path(["jit_ll_arraymove"]);
+            return Some(self._handle_oopspec_call(
+                graph,
+                op,
+                &move_target,
+                args,
+                &ValueType::Void,
+                graph_name,
+                OopSpecIndex::Arraymove,
+                None,
+                None,
+            ));
+        }
         // Field owner for the `W_ListObject` storage struct.  The dotted
         // names address the fused offsets the runtime descr group
         // exposes (`int_items.len` → `list_int_items_len_descr`,
@@ -13455,6 +13473,72 @@ mod tests {
             matches!(ops.last().map(|o| &o.kind), Some(OpKind::Live)),
             "CanRaise oopspec call must append a trailing -live-"
         );
+    }
+
+    /// jtransform.py `test_list_ll_arraymove`: one ref plus three integer
+    /// arguments, void result, and OS_ARRAYMOVE (9) callinfo.
+    #[test]
+    fn list_ll_arraymove_lowers_to_os9_residual_call() {
+        use crate::call::CallControl;
+        use crate::translator::rtyper::lltypesystem::lltype::{
+            Array, LowLevelType, Ptr, PtrTarget,
+        };
+        use crate::translator::rtyper::rtyper::variable_with_lltype;
+
+        let mut cc = CallControl::new();
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config).with_callcontrol(&mut cc);
+        let mut graph = FunctionGraph::new("arraymove");
+        let args = vec![
+            variable_with_lltype(
+                "array",
+                LowLevelType::Ptr(Box::new(Ptr {
+                    TO: PtrTarget::Array(Array::gc(LowLevelType::Signed)),
+                })),
+            ),
+            variable_with_lltype("source_start", LowLevelType::Signed),
+            variable_with_lltype("dest_start", LowLevelType::Signed),
+            variable_with_lltype("length", LowLevelType::Signed),
+        ];
+        let op = SpaceOperation {
+            result: None,
+            kind: OpKind::Call {
+                target: CallTarget::function_path(["ll_arraymove"]),
+                args: args.clone(),
+                result_ty: ValueType::Void,
+            },
+        };
+        let rewritten = transformer
+            ._handle_list_call("list.ll_arraymove", &op, &args, &mut graph, "arraymove")
+            .expect("list.ll_arraymove must be handled");
+        let RewriteResult::Replace(ops) = rewritten else {
+            panic!("expected Replace");
+        };
+        let residual = ops.iter().find_map(|op| match &op.kind {
+            OpKind::CallResidual {
+                args_i,
+                args_r,
+                args_f,
+                result_kind,
+                ..
+            } => Some((args_i, args_r, args_f, result_kind)),
+            _ => None,
+        });
+        let Some((args_i, args_r, args_f, result_kind)) = residual else {
+            panic!("expected a CallResidual, got {ops:?}");
+        };
+        assert_eq!(args_i.len(), 3);
+        assert_eq!(args_r.len(), 1);
+        assert!(args_f.is_empty());
+        assert_eq!(*result_kind, 'v');
+        let callinfo = &transformer
+            .callcontrol
+            .as_deref()
+            .unwrap()
+            .callinfocollection;
+        assert!(callinfo.has_oopspec(OopSpecIndex::Arraymove));
+        let (_, fnaddr) = callinfo.callinfo_for_oopspec(OopSpecIndex::Arraymove);
+        assert_eq!(callinfo.func_name(fnaddr), Some("jit_ll_arraymove"));
     }
 
     /// Other `rgc.*` spellings are not ported and fall through to the

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -4819,8 +4819,9 @@ impl<'a> Transformer<'a> {
     ) -> Option<RewriteResult> {
         use crate::codewriter::type_state::ConcreteType;
         // jtransform.py `_handle_list_call`: `list.ll_arraymove` is an OS9
-        // residual call. Descriptor analysis still sees the helper graph (and
-        // its literal length-one array store) through `op`; only the function
+        // residual call. Descriptor analysis still sees the helper graph —
+        // its per-item `setarrayitem` arms are what populate
+        // `effectinfo.write_descrs_arrays` — through `op`; only the function
         // address is retargeted to the native barrier+memmove body.
         if oopspec_name == "list.ll_arraymove" {
             let move_target = CallTarget::function_path(["jit_ll_arraymove"]);

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -12659,6 +12659,49 @@ mod tests {
         ));
     }
 
+    /// A runtime-tagged Option is annotated at the enum base, but its malloc
+    /// type is the payload-carrying variant: that is the concrete low-level
+    /// struct whose flattened fields are `[base.__discriminant, __pos_0]`.
+    #[test]
+    fn option_base_ctor_allocates_the_payload_variant_layout() {
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config);
+        let mut graph = FunctionGraph::new("option_tagged_pair_malloc");
+        let result_var = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let allocation_owner = "core::option::Option<i64>::Some".to_string();
+        let target = CallTarget::synthetic_transparent_ctor_with_owner(
+            vec!["core".to_string(), "option".to_string()],
+            "Option<i64>",
+        );
+        let result_ty = ValueType::Ref(Some(allocation_owner.clone()));
+        let op = SpaceOperation {
+            result: Some(result_var.clone()),
+            kind: OpKind::Call {
+                target: target.clone(),
+                args: vec![],
+                result_ty: result_ty.clone(),
+            },
+        };
+
+        let RewriteResult::Replace(ops) = transformer.rewrite_op_direct_call(
+            &op,
+            &target,
+            &[],
+            &result_ty,
+            "option_tagged_pair_malloc",
+            &mut graph,
+        ) else {
+            panic!("runtime-tagged Option base ctor must lower to its physical shell malloc");
+        };
+        assert!(matches!(
+            ops.as_slice(),
+            [SpaceOperation {
+                result: Some(result),
+                kind: OpKind::New { owner },
+            }] if result == &result_var && owner == &allocation_owner
+        ));
+    }
+
     /// `fold_we_are_jitted_calls` rewrites the `we_are_jitted()`
     /// `direct_call` to the `_we_are_jitted` symbolic constant — the
     /// model-graph counterpart of RPython's rtyper `specialize_call`

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -181,6 +181,18 @@ enum HostObjectKind {
         members: Mutex<IndexMap<String, ConstValue>>,
         reusable_prebuilt_instance: OnceLock<HostObject>,
     },
+    /// Call-site-only carrier for a Rust aggregate construction
+    /// (`SyntheticTransparentCtor`).  Its `class_obj` is the canonical class
+    /// object used for annotation and field identity, while the wrapper tells
+    /// the rtyper to perform only `rtype_new_instance` — RPython's allocation
+    /// step before optional `__init__` dispatch (`rpbc.py:1020-1067`).
+    ///
+    /// This is not a second class identity.  `Bookkeeper::getdesc` unwraps it
+    /// to `class_obj`, so constructed values retain the same ClassDef as field
+    /// projection and method lookup.  The wrapper exists solely because Rust
+    /// `T { fields }` must not accidentally invoke a same-named Python-level
+    /// `T.__init__` registered on that ClassDef.
+    TransparentClassCtor { class_obj: HostObject },
     /// Python module object. `members` 는 module dict — `getattr` 조회
     /// 대상. `LazyLock` singleton 의 Sync 요구를 만족하려고 `Mutex`.
     Module {
@@ -339,6 +351,13 @@ impl HostObject {
 
     pub fn is_class(&self) -> bool {
         matches!(self.inner.kind, HostObjectKind::Class { .. })
+    }
+
+    pub fn transparent_class_target(&self) -> Option<&HostObject> {
+        match &self.inner.kind {
+            HostObjectKind::TransparentClassCtor { class_obj } => Some(class_obj),
+            _ => None,
+        }
     }
 
     pub fn is_module(&self) -> bool {
@@ -537,7 +556,9 @@ impl HostObject {
     /// know.
     pub fn class_of(&self) -> Option<HostObject> {
         match &self.inner.kind {
-            HostObjectKind::Class { .. } => HOST_ENV.lookup_builtin("type"),
+            HostObjectKind::Class { .. } | HostObjectKind::TransparentClassCtor { .. } => {
+                HOST_ENV.lookup_builtin("type")
+            }
             HostObjectKind::Module { .. } => HOST_ENV.lookup_builtin("module"),
             HostObjectKind::BuiltinCallable => {
                 HOST_ENV.lookup_builtin("builtin_function_or_method")
@@ -596,6 +617,24 @@ impl HostObject {
                     members: Mutex::new(members),
                     reusable_prebuilt_instance: OnceLock::new(),
                 },
+            }),
+        }
+    }
+
+    /// Wrap the canonical class object for one transparent Rust aggregate
+    /// call.  The wrapper is intentionally not interned: ClassDef identity is
+    /// supplied by `class_obj`, while this object's identity denotes the call
+    /// spelling rather than a source-language class.
+    pub fn new_transparent_class_ctor(class_obj: HostObject) -> Self {
+        let qualname = class_obj.qualname().to_string();
+        let name = class_obj.inner.name.clone();
+        let module_name = class_obj.inner.module_name.clone();
+        HostObject {
+            inner: Arc::new(HostObjectInner {
+                qualname,
+                name,
+                module_name,
+                kind: HostObjectKind::TransparentClassCtor { class_obj },
             }),
         }
     }
@@ -1012,6 +1051,7 @@ fn host_object_own_getattr(pyobj: &HostObject, name: &str) -> Option<ConstValue>
         "__class__" => pyobj.class_of().map(ConstValue::HostObject),
         "__name__" => match &pyobj.inner.kind {
             HostObjectKind::Class { .. }
+            | HostObjectKind::TransparentClassCtor { .. }
             | HostObjectKind::Module { .. }
             | HostObjectKind::BuiltinCallable
             | HostObjectKind::UserFunction { .. }
@@ -1028,6 +1068,7 @@ fn host_object_own_getattr(pyobj: &HostObject, name: &str) -> Option<ConstValue>
         "__module__" => match &pyobj.inner.kind {
             HostObjectKind::Module { .. } | HostObjectKind::Property { .. } => None,
             HostObjectKind::Class { .. }
+            | HostObjectKind::TransparentClassCtor { .. }
             | HostObjectKind::BuiltinCallable
             | HostObjectKind::UserFunction { .. }
             | HostObjectKind::BoundMethod { .. }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4955,18 +4955,18 @@ impl<'a> Lowering<'a> {
                         Some((owner_root, field_name, _field_ty, owner_id)) => {
                             // Rust type-checks every assignment against the
                             // projected place's substituted field type.  A
-                            // raw pointer to a named ADT is therefore the
-                            // same typed nullable instance slot as a field
+                            // reference or raw pointer to a named ADT is
+                            // therefore the same instance slot as a field
                             // initialized by an aggregate: preserve that
                             // class on ordinary `self.field = value` writes
-                            // too.  Otherwise one classdef-less raw value
+                            // too.  Otherwise one pointer-shaped value
                             // generalizes the session-global ClassDef attr to
-                            // the root object repr before a later getattr is
-                            // rtyped.  RPython's SomeNone union instead keeps
-                            // the declared SomeInstance class and merely sets
-                            // `can_be_None`.
+                            // the raw-pointer repr before a later getattr is
+                            // rtyped.  RPython keeps the declared
+                            // SomeInstance class on every assignment (and a
+                            // nullable pointer merely sets `can_be_None`).
                             value =
-                                self.narrow_typed_nullable_field_value(bb_id, value, Some(dest_ty));
+                                self.narrow_typed_instance_field_value(bb_id, value, Some(dest_ty));
                             (
                                 FieldDescriptor::new(field_name, Some(owner_root))
                                     .with_owner_id(owner_id)
@@ -5014,25 +5014,21 @@ impl<'a> Lowering<'a> {
         Ok(())
     }
 
-    /// Preserve the declared class of a raw-pointer field value.
+    /// Preserve the declared class of an instance-typed field value.
     ///
-    /// RPython represents a nullable instance attribute as
-    /// `SomeInstance(classdef, can_be_None=True)`.  Rust spells the same slot
-    /// as `*mut/*const NamedAdt`, but a producer such as `null_mut()` begins as
-    /// a classdef-less pointer.  The Rust field type-check is the proof needed
-    /// to narrow that producer before `setattr`; this is an identity cast for
-    /// non-null values and a typed null for null values.
-    fn narrow_typed_nullable_field_value(
+    /// RPython represents an instance attribute as `SomeInstance(classdef)`;
+    /// when nullable, the same annotation simply carries `can_be_None=True`.
+    /// Rust spells those slots as `&NamedAdt` or `*mut/*const NamedAdt`, whose
+    /// producer initially has pointer annotation.  The Rust field type-check
+    /// is the proof needed to narrow that producer before `setattr`; this is
+    /// an identity cast for non-null values and a typed null for null values.
+    fn narrow_typed_instance_field_value(
         &mut self,
         bb_id: BlockId,
         value: LinkArg,
         declared_ty: Option<&TyRef>,
     ) -> LinkArg {
-        let Some(root) = declared_ty.and_then(|ty| {
-            tyref_node(ty, self.llbc)
-                .and_then(|n| strip_ty_wrappers(n, self.llbc))
-                .and_then(|n| raw_ptr_pointee_class_root(n, self.llbc))
-        }) else {
+        let Some(root) = declared_ty.and_then(|ty| tyref_class_root(ty, self.llbc)) else {
             return value;
         };
         self.narrow_value_to_instance_root(bb_id, value, &root)
@@ -5787,7 +5783,7 @@ impl<'a> Lowering<'a> {
                         continue;
                     }
                     let value = self
-                        .narrow_typed_nullable_field_value(
+                        .narrow_typed_instance_field_value(
                             bb_id,
                             LinkArg::Value(value),
                             declared_ty,
@@ -34464,6 +34460,53 @@ mod tests {
             );
         }
         assert!(writes >= 2, "expected both PyError context-field writes");
+    }
+
+    /// `W_DictObject.dstrategy` is PyPy's ordinary instance attribute.  Rust
+    /// carries the singleton strategy through `&'static DictStrategyRef`, but
+    /// assigning that reference must still feed `setattr` a classed instance;
+    /// otherwise the field's constructor annotation and setter annotation meet
+    /// as `SomeInstance(DictStrategyRef) ∪ SomePtr`.
+    #[test]
+    #[ignore]
+    fn dict_strategy_setter_retains_instance_class() {
+        use crate::model::{CallTarget, LinkArg, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph =
+            super::lower_function(&llbc, "pyre_object::dictmultiobject::w_dict_set_strategy")
+                .expect("lower w_dict_set_strategy");
+        let value = graph
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .find_map(|op| match &op.kind {
+                OpKind::FieldWrite { field, value, .. } if field.name == "dstrategy" => match value
+                {
+                    LinkArg::Value(value) => Some(value.clone()),
+                    LinkArg::Const(_) => None,
+                },
+                _ => None,
+            })
+            .expect("W_DictObject.dstrategy write");
+        assert!(
+            graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                op.result.as_ref() == Some(&value)
+                    && matches!(
+                        &op.kind,
+                        OpKind::Call {
+                            target: CallTarget::FunctionPath { segments },
+                            ..
+                        } if segments.first().map(String::as_str)
+                            == Some("__cast_instance_intrinsic")
+                            && segments.last().is_some_and(|root| root.ends_with("DictStrategyRef"))
+                    )
+            }),
+            "dstrategy assignment must retain the declared DictStrategyRef class"
+        );
     }
 
     /// `split_builtin_kwargs` returns `&args[..args.len() - 1]` after proving

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2241,21 +2241,23 @@ pub fn lower_fun_decl_with_static_addrs(
     fd: &FunDecl,
     static_addrs: crate::HostStaticAddrs<'_>,
 ) -> Result<FunctionGraph, LowerError> {
-    // Derive the struct field-layout map the boxing-alloc fusion reads
-    // (`fuse_boxing_alloc`).  The whole-program build lowers each function
-    // through the `_with_attrs` variant with a single precomputed map; this
-    // stand-alone entry (used by the reader / tests) derives it per call from
-    // the same source of truth so the fusion fires identically.
-    let (_, _, _, _, _, struct_field_attrs, _, _) = derive_program_metadata(llbc);
-    let jitdriver_receiver_roots =
-        crate::codewriter::jtransform::default_jitdriver_receiver_roots();
-    lower_fun_decl_with_static_addrs_attrs_and_jitdriver_roots(
-        llbc,
-        fd,
-        static_addrs,
-        &jitdriver_receiver_roots,
-        &struct_field_attrs,
-    )
+    crate::local_crates::with_local_crate_root(llbc.crate_name(), || {
+        // Derive the struct field-layout map the boxing-alloc fusion reads
+        // (`fuse_boxing_alloc`).  The whole-program build lowers each function
+        // through the `_with_attrs` variant with a single precomputed map; this
+        // stand-alone entry (used by the reader / tests) derives it per call from
+        // the same source of truth so the fusion fires identically.
+        let (_, _, _, _, _, struct_field_attrs, _, _) = derive_program_metadata(llbc);
+        let jitdriver_receiver_roots =
+            crate::codewriter::jtransform::default_jitdriver_receiver_roots();
+        lower_fun_decl_with_static_addrs_attrs_and_jitdriver_roots(
+            llbc,
+            fd,
+            static_addrs,
+            &jitdriver_receiver_roots,
+            &struct_field_attrs,
+        )
+    })
 }
 
 /// The `struct_field_attrs` projection of [`derive_program_metadata`] —
@@ -14090,6 +14092,44 @@ impl<'a> Lowering<'a> {
         ))
     }
 
+    /// The RPython instance class carried by an `Option<T>` payload when `T`
+    /// is a raw/reference pointer to a registered GC object.  `ValueType`
+    /// records only the register bank, so a `Ref(None)` payload needs its
+    /// source class recorded on the closure-rewrite site until the synthesized
+    /// writer can emit the ordinary instance-narrowing cast.  This preserves
+    /// the concrete field annotation that RPython's `InstanceRepr._setup_repr`
+    /// consumes (`rpython/rtyper/rclass.py:501-509`).
+    fn option_payload_instance_class_root(&self, option_ty: &TyRef) -> Option<String> {
+        let mut payload = tyref_node(option_ty, self.llbc)?
+            .as_object()?
+            .get("Adt")?
+            .get("generics")?
+            .get("types")?
+            .get(0)?;
+        loop {
+            let obj = payload.as_object()?;
+            if let Some(id) = obj.get("Deduplicated").and_then(serde_json::Value::as_u64) {
+                payload = self.llbc.dedup_body(id)?;
+                continue;
+            }
+            if let Some(parts) = obj
+                .get("HashConsedValue")
+                .and_then(serde_json::Value::as_array)
+                && parts.len() == 2
+            {
+                payload = &parts[1];
+                continue;
+            }
+            if let Some(root) = raw_ptr_pointee_class_root(payload, self.llbc) {
+                return Some(root);
+            }
+            let pointee = obj.get("Ref")?.as_array()?.get(1)?;
+            let pointee = strip_ty_wrappers(pointee, self.llbc)?;
+            return raw_ptr_pointee_class_root(pointee, self.llbc)
+                .or_else(|| adt_node_class_root(pointee, self.llbc));
+        }
+    }
+
     /// The per-instantiation `Option` enum root for a residual-call
     /// destination `dest_ty` that is an `Option<*mut RegisteredStruct>`
     /// (`Option<PyObjectRef>`) or an `Option<SplitEligibleEnum>`
@@ -14165,34 +14205,7 @@ impl<'a> Lowering<'a> {
         if !self.tyref_is_niche_option_ptr(dest_ty) {
             return None;
         }
-        let mut payload = tyref_node(dest_ty, self.llbc)?
-            .as_object()?
-            .get("Adt")?
-            .get("generics")?
-            .get("types")?
-            .get(0)?;
-        loop {
-            let obj = payload.as_object()?;
-            if let Some(id) = obj.get("Deduplicated").and_then(serde_json::Value::as_u64) {
-                payload = self.llbc.dedup_body(id)?;
-                continue;
-            }
-            if let Some(parts) = obj
-                .get("HashConsedValue")
-                .and_then(serde_json::Value::as_array)
-                && parts.len() == 2
-            {
-                payload = &parts[1];
-                continue;
-            }
-            if let Some(root) = raw_ptr_pointee_class_root(payload, self.llbc) {
-                return Some(root);
-            }
-            let pointee = obj.get("Ref")?.as_array()?.get(1)?;
-            let pointee = strip_ty_wrappers(pointee, self.llbc)?;
-            return raw_ptr_pointee_class_root(pointee, self.llbc)
-                .or_else(|| adt_node_class_root(pointee, self.llbc));
-        }
+        self.option_payload_instance_class_root(dest_ty)
     }
 
     /// Resolve the destination `Option` of a `bool::then` / `bool::then_some`
@@ -14764,6 +14777,7 @@ impl<'a> Lowering<'a> {
         );
         let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
         let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
+        let payload_class_root = self.option_payload_instance_class_root(recv_ty);
         // Closure env ADT → its `name_path` is the `call_once` inherent method
         // owner (`resolve_impl_owner_adt_def_id_free` records the same spelling
         // for the closure's transparent `call_once` body).
@@ -14782,6 +14796,7 @@ impl<'a> Lowering<'a> {
             some_owner,
             call_once_owner,
             payload_ty,
+            payload_class_root,
             result_ty,
             args_tuple_suffix,
             niche,
@@ -14864,6 +14879,7 @@ impl<'a> Lowering<'a> {
         );
         let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
         let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
+        let payload_class_root = self.option_payload_instance_class_root(recv_ty);
         let env_def_id = self.tyref_ref_adt_def_id(env_ty?)?;
         let env_td = self.llbc.type_by_id(env_def_id)?;
         let call_once_owner = env_td.item_meta.name_path();
@@ -14931,6 +14947,7 @@ impl<'a> Lowering<'a> {
             result_niche,
             call_once_owner,
             payload_ty,
+            payload_class_root,
             call_result_ty,
             args_tuple_suffix,
             niche,
@@ -16808,7 +16825,17 @@ impl<'a> Lowering<'a> {
             kind: OpKind::Call {
                 target: ctor_target,
                 args: Vec::new(),
-                result_ty: ValueType::Ref(Some(owner.to_string())),
+                // The call target is the enum BASE so the annotator constructs
+                // `SomeInstance(enum)` and runtime-tagged values can meet at a
+                // join.  The codewriter's `result_ty` has a separate job: it
+                // is the low-level STRUCT passed to `rewrite_op_malloc`.  That
+                // STRUCT must be the payload-carrying variant, whose flattened
+                // layout contains both the inherited tag and `__pos_0`.
+                // RPython already hands jtransform that concrete malloc type
+                // (`InstanceRepr._setup_repr` / `Transformer.rewrite_op_malloc`);
+                // this split restores the same information across pyre's
+                // synthetic pre-rtyper constructor seam.
+                result_ty: ValueType::Ref(Some(payload_owner.to_string())),
             },
         });
         // The `__discriminant` tag is always an `i64` (matching the

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -13529,9 +13529,10 @@ impl<'a> Lowering<'a> {
             .is_some_and(|fd| fd.item_meta.name_path() == "core::f64::<Impl>::is_sign_positive")
     }
 
-    /// `majit_metainterp::jit::promote(x)` = `hint(x, promote=True)`
-    /// (`rlib/jit.py`), with the `promote_string` (`:118`) and
-    /// `promote_unicode` (`:124`) siblings.  All three wrappers carry their
+    /// `majit_metainterp::jit::promote(x)` / the lower-layer
+    /// `majit_ir::jit::promote(x)` decorator carrier =
+    /// `hint(x, promote=True)` (`rlib/jit.py`), with the `promote_string`
+    /// (`:118`) and `promote_unicode` (`:124`) siblings.  All wrappers carry their
     /// flag by name (each body is a bare `hint(x)`), so the callsite is
     /// recognised by the wrapper path, not the body.  Returns the
     /// synthesised `hint_*` marker leaf for the matched wrapper so the
@@ -13550,7 +13551,7 @@ impl<'a> Lowering<'a> {
             return None;
         };
         match self.llbc.fn_by_id(*id)?.item_meta.name_path().as_str() {
-            "majit_metainterp::jit::promote" => Some("hint_promote"),
+            "majit_metainterp::jit::promote" | "majit_ir::jit::promote" => Some("hint_promote"),
             "majit_metainterp::jit::promote_string" => Some("hint_promote_string"),
             "majit_metainterp::jit::promote_unicode" => Some("hint_promote_unicode"),
             _ => None,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -19976,8 +19976,10 @@ fn tyref_exact_layout_size(ty: &TyRef, llbc: &Llbc) -> Option<u64> {
 /// ptr` / `ptr → int` resolve the `lltype.cast_*` module attr
 /// (`["rpython", "rtyper", "lltypesystem", "lltype", …]` per
 /// `flowspace_adapter` Branch 3b); `int → float` / `float → int` resolve
-/// the bare `float` / `int` builtins (single-segment `HOST_ENV.\
-/// lookup_builtin`).
+/// the `__builtin__.float` / `__builtin__.int` objects.  Keeping the builtin
+/// owner in the path preserves the callable identity that keys
+/// `rbuiltin.py::BUILTIN_TYPER`; a bare leaf can collide with an unrelated
+/// Rust function named `float` or `int` in the flat call registry.
 fn cast_call_segments(src: &ValueType, dst: &ValueType) -> Option<Vec<String>> {
     let (s, d) = (value_type_bank(src), value_type_bank(dst));
     let lltype = |name: &str| -> Vec<String> {
@@ -19993,9 +19995,12 @@ fn cast_call_segments(src: &ValueType, dst: &ValueType) -> Option<Vec<String>> {
         (0, 1) => Some(lltype("cast_int_to_ptr")),
         (1, 0) => Some(lltype("cast_ptr_to_int")),
         // int → float / float → int — `float(v)` / `int(v)`, whose
-        // rtyper delegates to `rtype_float` / `rtype_int`.
-        (0, 2) => Some(vec!["float".to_string()]),
-        (2, 0) => Some(vec!["int".to_string()]),
+        // rtyper delegates to `rtype_float` / `rtype_int`.  The explicit
+        // `__builtin__` owner is the flowspace Constant's host identity, not
+        // a new namespace: `HOST_ENV.import_module("__builtin__")` returns
+        // the same singleton objects that key `BUILTIN_TYPER`.
+        (0, 2) => Some(vec!["__builtin__".to_string(), "float".to_string()]),
+        (2, 0) => Some(vec!["__builtin__".to_string(), "int".to_string()]),
         // No host callable for the remaining pairs (e.g. ref↔float, or any
         // pair touching Void/State/Unknown): alias the operand.
         _ => None,
@@ -26779,14 +26784,26 @@ fn collapse_panic_message_chains(graph: &mut FunctionGraph) -> usize {
 mod tests {
     use super::harden_duplicate_leaf_metadata;
     use super::{
-        DecodedConst, FnPtrFamily, cast_kind_is_raw_ptr, cast_pointer_marker_op,
-        charon_const_generic_to_string, charon_type_value_to_ast_string, decode_literal,
-        fn_ptr_family_for, json_ty_is_thin_pointer_element, json_ty_scalar_element_spelling,
-        push_ptr_to_unsigned_cast, shaped_array_parts, simplify_lowered_graph, tyref_array_suffix,
-        tyref_is_raw_byte_ptr,
+        DecodedConst, FnPtrFamily, cast_call_segments, cast_kind_is_raw_ptr,
+        cast_pointer_marker_op, charon_const_generic_to_string, charon_type_value_to_ast_string,
+        decode_literal, fn_ptr_family_for, json_ty_is_thin_pointer_element,
+        json_ty_scalar_element_spelling, push_ptr_to_unsigned_cast, shaped_array_parts,
+        simplify_lowered_graph, tyref_array_suffix, tyref_is_raw_byte_ptr,
     };
     use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, ValueType};
     use majit_charon_reader::{Llbc, ullbc::TyRef};
+
+    #[test]
+    fn numeric_bank_crossing_casts_preserve_the_builtin_owner() {
+        assert_eq!(
+            cast_call_segments(&ValueType::Int, &ValueType::Float),
+            Some(vec!["__builtin__".into(), "float".into()])
+        );
+        assert_eq!(
+            cast_call_segments(&ValueType::Float, &ValueType::Int),
+            Some(vec!["__builtin__".into(), "int".into()])
+        );
+    }
 
     /// A block emptied *after* the head `eliminate_empty_blocks` must still
     /// be rewired past, so the values riding the link into it do not survive

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5028,7 +5028,14 @@ impl<'a> Lowering<'a> {
         value: LinkArg,
         declared_ty: Option<&TyRef>,
     ) -> LinkArg {
-        let Some(root) = declared_ty.and_then(|ty| tyref_class_root(ty, self.llbc)) else {
+        let Some(root) = declared_ty.and_then(|ty| {
+            let node = strip_ty_indirections(tyref_node(ty, self.llbc)?, self.llbc)?;
+            if let Some(reference) = node.as_object()?.get("Ref") {
+                let pointee = reference.as_array()?.get(1)?;
+                return adt_node_class_root(strip_ty_indirections(pointee, self.llbc)?, self.llbc);
+            }
+            raw_ptr_pointee_class_root(node, self.llbc)
+        }) else {
             return value;
         };
         self.narrow_value_to_instance_root(bb_id, value, &root)
@@ -34506,6 +34513,49 @@ mod tests {
                     )
             }),
             "dstrategy assignment must retain the declared DictStrategyRef class"
+        );
+    }
+
+    /// PyPy's `instantiate(W_IntObject)` is lowered to a real allocation plus
+    /// `intval` store, never left as the Rust helper that accepted the
+    /// stack-built aggregate.  The real LLBC constructor must therefore leave
+    /// this frontend with `NewWithVtable`, not residual `malloc_typed`.
+    #[test]
+    #[ignore]
+    fn w_int_new_fuses_typed_allocation() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function_with_static_addrs(
+            &llbc,
+            "pyre_object::intobject::w_int_new",
+            crate::HostStaticAddrs {
+                pytypes: &[("pyobject::INT_TYPE", 0x1020_3040)],
+                ..crate::HostStaticAddrs::default()
+            },
+        )
+        .expect("lower w_int_new");
+        assert!(
+            graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(&op.kind, OpKind::NewWithVtable { owner, .. }
+                    if owner.ends_with("W_IntObject"))
+            }),
+            "w_int_new must lower instantiate(W_IntObject) to NewWithVtable: {graph:#?}"
+        );
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.last().map(String::as_str) == Some("malloc_typed")
+                )
+            }),
+            "w_int_new must not retain residual malloc_typed: {graph:#?}"
         );
     }
 

--- a/majit/majit-translate/src/front/option_closure_select.rs
+++ b/majit/majit-translate/src/front/option_closure_select.rs
@@ -94,6 +94,12 @@ pub(crate) struct ClosureSelectSite {
     /// The receiver `Option`'s payload `T` projected to a [`ValueType`] — the
     /// `Some::__pos_0` read kind and the `(x,)` args-tuple element.
     pub payload_ty: ValueType,
+    /// The concrete RPython instance class carried by a reference payload.
+    /// `ValueType::Ref(None)` preserves only the register bank; the source
+    /// class is required when the synthesized `(x,)` writer recreates the
+    /// field annotation consumed by `InstanceRepr._setup_repr`
+    /// (`rpython/rtyper/rclass.py:501-509`).
+    pub payload_class_root: Option<String>,
     /// The type the closure's `call_once` returns, projected to a
     /// [`ValueType`]: `U` for `map`, `Option<U>` for `and_then`, `T` for
     /// `unwrap_or_else`, `Option<T>` for `or_else`.
@@ -282,7 +288,11 @@ fn rewire_one_closure_select_site(
                 graph,
                 then_bb,
                 env_in_then,
-                Some((payload, site.payload_ty.clone())),
+                Some((
+                    payload,
+                    site.payload_ty.clone(),
+                    site.payload_class_root.clone(),
+                )),
                 &site.call_once_owner,
                 site.call_result_ty.clone(),
                 &site.args_tuple_suffix,
@@ -502,7 +512,7 @@ pub(crate) fn emit_call_once(
     graph: &mut FunctionGraph,
     block: BlockId,
     env: Variable,
-    arg: Option<(Variable, ValueType)>,
+    arg: Option<(Variable, ValueType, Option<String>)>,
     call_once_owner: &str,
     result_ty: ValueType,
     args_tuple_suffix: &str,
@@ -525,7 +535,12 @@ pub(crate) fn emit_call_once(
             result_ty: ValueType::Ref(Some(tuple_owner.clone())),
         },
     });
-    if let Some((value, _value_ty)) = arg {
+    if let Some((value, value_ty, class_root)) = arg {
+        // RPython derives an instance field's low-level repr from the concrete
+        // annotation stored on that field (`rclass.py:501-509`).  Preserve the
+        // source payload class before this synthetic tuple write instead of
+        // widening every `Tuple<*mut T>.__pos_0` reader to OBJECTPTR.
+        let value = emit_narrow(graph, block, value, &class_root);
         graph.block_mut(block).operations.push(SpaceOperation {
             result: None,
             kind: OpKind::FieldWrite {
@@ -538,7 +553,7 @@ pub(crate) fn emit_call_once(
                     taken_by_address: false,
                 },
                 value: LinkArg::Value(value),
-                ty: ValueType::Ref(None),
+                ty: value_ty,
             },
         });
     }
@@ -583,6 +598,7 @@ mod tests {
             some_owner: RECV_SOME.into(),
             call_once_owner: "test::closure".into(),
             payload_ty: ValueType::Int,
+            payload_class_root: None,
             call_result_ty: ValueType::Int,
             args_tuple_suffix: String::new(),
             niche: false,
@@ -666,6 +682,47 @@ mod tests {
             matches!(t, CallTarget::FunctionPath { segments }
                 if segments == &["core", "ptr", "null_mut"].map(str::to_string))
         })
+    }
+
+    #[test]
+    fn call_once_tuple_write_preserves_reference_payload_class() {
+        let mut g = FunctionGraph::new("test_call_once_payload_class");
+        let block = g.startblock;
+        let env = g.push_op_var(block, OpKind::ConstInt(7), true).unwrap();
+        let payload = g.push_op_var(block, OpKind::ConstRefNull, true).unwrap();
+
+        emit_call_once(
+            &mut g,
+            block,
+            env,
+            Some((payload, ValueType::Ref(None), Some("PyObject".to_string()))),
+            "test::closure",
+            ValueType::Int,
+            "<*mut PyObject>",
+        );
+
+        let written = g.blocks[block.0]
+            .operations
+            .iter()
+            .find_map(|op| match &op.kind {
+                OpKind::FieldWrite { field, value, .. }
+                    if field.owner_root.as_deref() == Some("Tuple<*mut PyObject>") =>
+                {
+                    value.as_variable().cloned()
+                }
+                _ => None,
+            })
+            .expect("closure Args tuple payload write");
+        assert!(g.blocks[block.0].operations.iter().any(|op| {
+            op.result.as_ref() == Some(&written)
+                && matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments == &[crate::runtime_names::shims::CAST_INSTANCE, "PyObject"]
+                )
+        }));
     }
 
     #[test]

--- a/majit/majit-translate/src/front/option_map_or.rs
+++ b/majit/majit-translate/src/front/option_map_or.rs
@@ -82,6 +82,11 @@ pub(crate) struct MapOrSite {
     /// The `Option`'s payload `T` projected to a [`ValueType`] — the
     /// `Some::__pos_0` field kind (the closure's unwrapped input).
     pub payload_ty: ValueType,
+    /// The concrete RPython instance class carried by a reference payload.
+    /// The synthesized tuple writer uses it to retain the field annotation
+    /// that `InstanceRepr._setup_repr` consumes
+    /// (`rpython/rtyper/rclass.py:501-509`).
+    pub payload_class_root: Option<String>,
     /// The `map_or` result `U` projected to a [`ValueType`] — the `call_once`
     /// result kind and the select result kind.
     pub result_ty: ValueType,
@@ -267,7 +272,7 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
     };
     // The closure's `Args` tuple `(payload,)` — the transparent-ctor + a
     // single `__pos_0` FieldWrite, the same shape `Rvalue::Aggregate` emits for
-    // a tuple (write ty `Ref(None)`).  The owner carries the per-shape `<X>`
+    // a tuple.  The owner carries the per-shape `<X>`
     // suffix (`Tuple<FrameDebugData>`) so it keys under the same classdef the
     // extracted `call_once` reads `.0` from at `resolve_place`.
     let tuple_owner = format!("Tuple{}", site.args_tuple_suffix);
@@ -280,6 +285,11 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
             result_ty: ValueType::Ref(Some(tuple_owner.clone())),
         },
     });
+    // Preserve the source instance annotation at the producing write.  This
+    // is the same ordinary narrowing used for pointer-valued call results;
+    // weakening the shared Tuple field would diverge from RPython's concrete
+    // `InstanceRepr` field setup (`rclass.py:501-509`).
+    let payload = emit_narrow(graph, then_bb, payload, &site.payload_class_root);
     graph.block_mut(then_bb).operations.push(SpaceOperation {
         result: None,
         kind: OpKind::FieldWrite {
@@ -292,7 +302,7 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
                 taken_by_address: false,
             },
             value: LinkArg::Value(payload),
-            ty: ValueType::Ref(None),
+            ty: site.payload_ty.clone(),
         },
     });
     let call_result = graph.alloc_value_var();
@@ -424,6 +434,7 @@ mod tests {
             some_owner: "core::option::Option::Some".into(),
             call_once_owner: "test::closure".into(),
             payload_ty: ValueType::Int,
+            payload_class_root: None,
             result_ty: ValueType::Int,
             args_tuple_suffix: String::new(),
             niche: false,
@@ -578,6 +589,59 @@ mod tests {
             })
             .count();
         assert_eq!(narrow_casts, 2, "each diamond arm re-applies the narrowing");
+    }
+
+    #[test]
+    fn rewrite_preserves_reference_payload_class_in_closure_tuple() {
+        let mut g = FunctionGraph::new("test_map_or_payload_class");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstRefNull, true).unwrap();
+        let default = g.push_op_var(a, OpKind::ConstInt(42), true).unwrap();
+        let env = g.push_op_var(a, OpKind::ConstInt(7), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: CallTarget::method("map_or", Some("core::option::Option".into())),
+                    args: vec![opt, default, env],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![result.clone()]);
+
+        let mut site = map_or_site(result);
+        site.payload_ty = ValueType::Ref(None);
+        site.payload_class_root = Some("PyObject".to_string());
+        site.args_tuple_suffix = "<*mut PyObject>".to_string();
+        assert_eq!(rewire_map_or_call_sites(&mut g, &[site]), 1);
+
+        let written = g
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .find_map(|op| match &op.kind {
+                OpKind::FieldWrite { field, value, .. }
+                    if field.owner_root.as_deref() == Some("Tuple<*mut PyObject>") =>
+                {
+                    value.as_variable().cloned()
+                }
+                _ => None,
+            })
+            .expect("closure Args tuple payload write");
+        assert!(g.blocks.iter().flat_map(|block| &block.operations).any(|op| {
+            op.result.as_ref() == Some(&written)
+                && matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments == &[crate::runtime_names::shims::CAST_INSTANCE, "PyObject"]
+                )
+        }));
     }
 
     /// A call block whose last op is not the recorded result declines

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -2031,6 +2031,14 @@ fn analyze_pipeline_from_module_paths(
         "rgc.ll_shrink_array".to_string(),
     );
 
+    // rgc.py `@jit.oopspec('list.ll_arraymove(array, source_start,
+    // dest_start, length)')`. The rtyper mints this generic helper graph,
+    // so its decorator cannot be harvested from a Rust source item above.
+    call_control.mark_oopspec(
+        parse::CallPath::from_segments(["ll_arraymove"]),
+        "list.ll_arraymove(array, source_start, dest_start, length)".to_string(),
+    );
+
     // `collectanalyze.py analyze_simple_operation` answers True for the
     // allocation operations — `malloc` / `malloc_varsize` with `flavor='gc'`,
     // and any LLOp declared `canmallocgc=True`.  Upstream sees them because

--- a/majit/majit-translate/src/local_crates.rs
+++ b/majit/majit-translate/src/local_crates.rs
@@ -52,3 +52,33 @@ pub(crate) fn local_crate_roots() -> Vec<String> {
 pub(crate) fn is_local_crate_root(seg: &str) -> bool {
     REGISTERED.with(|registered| registered.borrow().iter().any(|r| r == seg))
 }
+
+/// Run one stand-alone, single-LLBC lowering with that artefact's crate root
+/// present in the same invocation-local alias set used by the whole-program
+/// frontend.
+///
+/// `build_semantic_program_via_active_frontend` seeds all loaded crates once.
+/// The public `lower_fun_decl*` entry points bypass that driver, so without a
+/// scoped seed their transparent constructors retain the defining crate while
+/// the layout metadata derived from the same LLBC uses crate-relative names.
+/// Preserve any surrounding multi-crate invocation and restore it even when
+/// lowering unwinds.
+pub(crate) fn with_local_crate_root<R>(root: &str, f: impl FnOnce() -> R) -> R {
+    struct Restore(Vec<String>);
+
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            register_local_crate_roots(std::mem::take(&mut self.0));
+        }
+    }
+
+    let previous = local_crate_roots();
+    if previous.iter().any(|registered| registered == root) {
+        return f();
+    }
+    let mut scoped = previous.clone();
+    scoped.push(root.to_string());
+    register_local_crate_roots(scoped);
+    let _restore = Restore(previous);
+    f()
+}

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -843,11 +843,12 @@ pub enum OpKind {
     /// RPython `malloc(STRUCT, flavor='gc')` for a fixed-size GcStruct: the
     /// heap allocation of a boxed object (`runtime_object::lltype::malloc_typed`).
     /// Lowered to the `new_with_vtable` jitcode op (executor
-    /// `OpCode::NewWithVtable`). `owner` is the struct leaf (e.g.
-    /// `"W_FloatObject"`); the assembler resolves the size descriptor from it
-    /// via `bh_size_spec_from_callcontrol`, whose `path_hash(owner)` keys the
-    /// runtime `gc_cache._cache_size` Arc carrying the struct size + gc
-    /// type-id.
+    /// `OpCode::NewWithVtable`). `owner` is the crate-stripped nominal struct
+    /// path (e.g. `"floatobject::W_FloatObject"`); the assembler resolves the
+    /// size descriptor from it via `bh_size_spec_from_callcontrol`, whose
+    /// `path_hash(owner)` keys the runtime `gc_cache._cache_size` Arc carrying
+    /// the struct size + gc type-id.  Synthetic fixtures without a registered
+    /// path retain their exact bare owner.
     ///
     /// `vtable` is the type-pointer (the `&FLOAT_TYPE` / `&INT_TYPE` /
     /// `&COMPLEX_TYPE` static address) the runtime stamps into the fresh
@@ -3137,6 +3138,57 @@ pub fn remove_dead_aggregates(graph: &mut FunctionGraph) -> usize {
     total_removed
 }
 
+/// Resolve one registered struct layout without discarding nominal identity.
+///
+/// RPython indexes layouts by the live `lltype.Struct` object.  Pyre's
+/// corresponding identity is `StructId`; a bare leaf match is not admissible
+/// because two modules may define the same leaf.  Exact string hits remain
+/// valid for synthetic/test layouts that have no StructId registration.
+fn registered_struct_layout<'a>(
+    owner: &str,
+    struct_field_attrs: &'a std::collections::HashMap<String, Vec<(String, ValueType)>>,
+) -> Option<&'a Vec<(String, ValueType)>> {
+    if let Some(exact) = struct_field_attrs.get(owner) {
+        return Some(exact);
+    }
+    let owner_id = majit_ir::descr::struct_id_for_name(owner)?;
+    let mut matches = struct_field_attrs.iter().filter_map(|(key, rows)| {
+        (majit_ir::descr::struct_id_for_name(key) == Some(owner_id)).then_some(rows)
+    });
+    let first = matches.next()?;
+    matches.all(|rows| rows == first).then_some(first)
+}
+
+/// The nominal struct identity carried by a resolved transparent constructor.
+///
+/// `front::mir` records Charon's full declaration path on `owner_path`.  The
+/// runtime descriptor namespace strips only this workspace's crate root, so
+/// preserve every remaining module segment instead of collapsing back to the
+/// leaf.  This is the Rust-source counterpart of RPython carrying the same
+/// `lltype.Struct` object from `malloc(STRUCT)` into every layout/descr lookup.
+fn synthetic_transparent_ctor_owner(
+    target: &CallTarget,
+    source_crate: Option<&str>,
+) -> Option<String> {
+    let CallTarget::SyntheticTransparentCtor {
+        name, owner_path, ..
+    } = target
+    else {
+        return None;
+    };
+    let mut segments = owner_path.as_slice();
+    if segments.first().is_some_and(|root| {
+        source_crate == Some(root.as_str()) || crate::local_crates::is_local_crate_root(root)
+    }) {
+        segments = &segments[1..];
+    }
+    if segments.is_empty() {
+        Some(name.clone())
+    } else {
+        Some(format!("{}::{name}", segments.join("::")))
+    }
+}
+
 /// Lower `core::ptr::write(raw as *mut T, T { fields... })` to field stores.
 ///
 /// This is the Rust-source spelling of RPython's ordinary alloc-then-init
@@ -3165,20 +3217,6 @@ pub fn lower_struct_ptr_writes(
     struct_field_attrs: &std::collections::HashMap<String, Vec<(String, ValueType)>>,
 ) -> usize {
     use crate::flowspace::model::Variable;
-
-    fn registered_layout<'a>(
-        owner: &str,
-        struct_field_attrs: &'a std::collections::HashMap<String, Vec<(String, ValueType)>>,
-    ) -> Option<&'a Vec<(String, ValueType)>> {
-        if let Some(exact) = struct_field_attrs.get(owner) {
-            return Some(exact);
-        }
-        let mut leaf_matches = struct_field_attrs
-            .iter()
-            .filter(|(key, _)| key.rsplit("::").next() == Some(owner));
-        let (_, only) = leaf_matches.next()?;
-        (leaf_matches.next().is_none()).then_some(only)
-    }
 
     fn producer_root(graph: &FunctionGraph, var: &Variable, depth: u32) -> Option<Variable> {
         if depth == 0 {
@@ -3224,6 +3262,46 @@ pub fn lower_struct_ptr_writes(
         destination: Variable,
         stores: Vec<(FieldDescriptor, LinkArg, ValueType)>,
         result: Option<Variable>,
+    }
+
+    // `checkgraph` validates SSI scope, but validity alone does not prove that
+    // a store observed while scanning the whole graph executes before the
+    // ptr::write.  Compute ordinary block dominators and require every source
+    // FieldWrite to dominate the call site before moving it there.
+    let block_count = graph.blocks.len();
+    let mut predecessors = vec![HashSet::new(); block_count];
+    for (source, block) in graph.blocks.iter().enumerate() {
+        for link in &block.exits {
+            predecessors[link.target.0].insert(source);
+        }
+    }
+    let all_blocks: HashSet<usize> = (0..block_count).collect();
+    let start = graph.startblock.0;
+    let mut dominators = vec![all_blocks.clone(); block_count];
+    dominators[start] = HashSet::from([start]);
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for block in 0..block_count {
+            if block == start {
+                continue;
+            }
+            let mut predecessor_iter = predecessors[block].iter().copied();
+            let mut next = if let Some(first) = predecessor_iter.next() {
+                let mut intersection = dominators[first].clone();
+                for predecessor in predecessor_iter {
+                    intersection.retain(|candidate| dominators[predecessor].contains(candidate));
+                }
+                intersection
+            } else {
+                HashSet::new()
+            };
+            next.insert(block);
+            if next != dominators[block] {
+                dominators[block] = next;
+                changed = true;
+            }
+        }
     }
 
     let mut rewrites = Vec::new();
@@ -3274,47 +3352,76 @@ pub fn lower_struct_ptr_writes(
                 .iter()
                 .flat_map(|block| &block.operations)
                 .find_map(|candidate| match (&candidate.result, &candidate.kind) {
-                    (
-                        Some(result),
-                        OpKind::Call {
-                            target: CallTarget::SyntheticTransparentCtor { name, .. },
-                            ..
-                        },
-                    ) if result == &aggregate => Some(name.as_str()),
+                    (Some(result), OpKind::Call { target, .. }) if result == &aggregate => {
+                        synthetic_transparent_ctor_owner(target, graph.name.split("::").next())
+                    }
                     _ => None,
                 });
-            if destination_owner.is_none() || destination_owner != aggregate_owner {
+            let same_owner = destination_owner
+                .zip(aggregate_owner.as_deref())
+                .is_some_and(|(destination, aggregate)| {
+                    destination == aggregate
+                        || majit_ir::descr::struct_id_for_name(destination)
+                            .zip(majit_ir::descr::struct_id_for_name(aggregate))
+                            .is_some_and(|(destination_id, aggregate_id)| {
+                                destination_id == aggregate_id
+                            })
+                });
+            if !same_owner {
                 continue;
             }
-            // KNOWN GAP: this scans EVERY block, and each matched store's
-            // `value` is spliced verbatim into the call's block below. Only
-            // the `base` is proven in scope (`producer_root`); the `value` is
-            // not. `checkgraph` (`flowspace/model.py`) resets its `vars` per
-            // block and errors on a cross-block use, so a store whose value is
-            // defined in a block that does not reach the call builds a graph
-            // the port's own checker rejects — and nothing in `front::mir`
-            // calls `checkgraph`, so it surfaces later in `translator`.
-            // Restricting the scan to the call's own block is the fail-closed
-            // fix, but it also drops the multi-block shape this pass exists
-            // for; the real fix is a dominance test on each `value`.
+            // `checkgraph` (`flowspace/model.py:598-608`) permits an operation
+            // to use only constants, its block's inputargs, or variables
+            // defined earlier in that block.  A FieldWrite found on another
+            // aggregate path may carry a predecessor-local Variable; splicing
+            // that Variable verbatim here would create invalid SSI even when
+            // its producer dominates this block.  Until the pass can rethread
+            // such a value through the incoming links, decline the whole
+            // rewrite unless every stored value is already in scope here.
+            let value_is_in_scope = |value: &LinkArg| match value {
+                LinkArg::Const(_) => true,
+                LinkArg::Value(value) => {
+                    block.inputargs.contains(value)
+                        || block.operations[..oi]
+                            .iter()
+                            .any(|candidate| candidate.result.as_ref() == Some(value))
+                }
+            };
             let stores: Vec<_> = graph
                 .blocks
                 .iter()
-                .flat_map(|block| &block.operations)
-                .filter_map(|candidate| match &candidate.kind {
+                .enumerate()
+                .flat_map(|(store_bi, store_block)| {
+                    store_block
+                        .operations
+                        .iter()
+                        .enumerate()
+                        .map(move |(store_oi, candidate)| (store_bi, store_oi, candidate))
+                })
+                .filter_map(|(store_bi, store_oi, candidate)| match &candidate.kind {
                     OpKind::FieldWrite {
                         base,
                         field,
                         value,
                         ty,
                     } if producer_root(graph, base, 16).as_ref() == Some(&aggregate) => {
-                        Some((field.clone(), value.clone(), ty.clone()))
+                        Some((store_bi, store_oi, field.clone(), value.clone(), ty.clone()))
                     }
                     _ => None,
                 })
                 .collect();
-            let Some(layout) = registered_layout(
-                destination_owner.expect("owner equality checked"),
+            if stores.iter().any(|(store_bi, store_oi, _, value, _)| {
+                let store_dominates_call = if *store_bi == bi {
+                    *store_oi < oi
+                } else {
+                    dominators[bi].contains(store_bi)
+                };
+                !store_dominates_call || !value_is_in_scope(value)
+            }) {
+                continue;
+            }
+            let Some(layout) = registered_struct_layout(
+                aggregate_owner.as_deref().expect("owner equality checked"),
                 struct_field_attrs,
             ) else {
                 continue;
@@ -3325,7 +3432,9 @@ pub fn lower_struct_ptr_writes(
             let mut ordered_stores = Vec::with_capacity(layout.len());
             let mut complete = true;
             for (name, _) in layout {
-                let mut matches = stores.iter().filter(|(field, _, _)| &field.name == name);
+                let mut matches = stores
+                    .iter()
+                    .filter(|(_, _, field, _, _)| &field.name == name);
                 let Some(store) = matches.next() else {
                     complete = false;
                     break;
@@ -3334,7 +3443,7 @@ pub fn lower_struct_ptr_writes(
                     complete = false;
                     break;
                 }
-                ordered_stores.push(store.clone());
+                ordered_stores.push((store.2.clone(), store.3.clone(), store.4.clone()));
             }
             if !complete {
                 continue;
@@ -3455,7 +3564,7 @@ pub fn fuse_boxing_alloc(
         struct_field_attrs: &std::collections::HashMap<String, Vec<(String, ValueType)>>,
     ) -> Option<Vec<(String, ValueType)>> {
         Some(
-            registered_layout(owner, struct_field_attrs)?
+            registered_struct_layout(owner, struct_field_attrs)?
                 .iter()
                 .filter(|(name, _)| !is_header_field(name))
                 .cloned()
@@ -3463,31 +3572,7 @@ pub fn fuse_boxing_alloc(
         )
     }
 
-    /// `owner`'s registered field layout, in struct-declaration order.
-    ///
-    /// The ctor carries the bare struct leaf (`W_FloatObject`) while the map is
-    /// keyed by the crate-stripped qualified path (`floatobject::W_FloatObject`),
-    /// so fall back to a leaf match when the exact key misses.
-    fn registered_layout<'a>(
-        owner: &str,
-        struct_field_attrs: &'a std::collections::HashMap<String, Vec<(String, ValueType)>>,
-    ) -> Option<&'a Vec<(String, ValueType)>> {
-        if let Some(exact) = struct_field_attrs.get(owner) {
-            return Some(exact);
-        }
-        let mut leaf_matches = struct_field_attrs
-            .iter()
-            .filter(|(k, _)| k.rsplit("::").next() == Some(owner));
-        let (_, only) = leaf_matches.next()?;
-        if leaf_matches.next().is_some() {
-            // The layout owner is ambiguous. As with an unknown owner, leave
-            // `malloc_typed` residual instead of choosing one map row by
-            // HashMap iteration order.
-            return None;
-        }
-        Some(only)
-    }
-
+    // `owner`'s registered field layout, in struct-declaration order.
     let is_gc_malloc = |target: &CallTarget| -> bool {
         matches!(target, CallTarget::FunctionPath { segments }
             if segments.len() >= 2
@@ -3715,17 +3800,13 @@ pub fn fuse_boxing_alloc(
             .iter()
             .flat_map(|b| &b.operations)
             .find_map(|op| match (&op.result, &op.kind) {
-                (
-                    Some(r),
-                    OpKind::Call {
-                        target: CallTarget::SyntheticTransparentCtor { name, .. },
-                        ..
-                    },
-                ) if r == root => Some(name.clone()),
+                (Some(r), OpKind::Call { target, .. }) if r == root => {
+                    synthetic_transparent_ctor_owner(target, graph.name.split("::").next())
+                }
                 _ => None,
             });
         let Some(owner) = owner else { return false };
-        registered_layout(&owner, struct_field_attrs)
+        registered_struct_layout(&owner, struct_field_attrs)
             .is_some_and(|rows| rows.iter().all(|(name, _)| name != "w_class"))
     }
     struct Payload {
@@ -3970,13 +4051,9 @@ pub fn fuse_boxing_alloc(
                 .iter()
                 .flat_map(|b| &b.operations)
                 .find_map(|o| match (&o.result, &o.kind) {
-                    (
-                        Some(r),
-                        OpKind::Call {
-                            target: CallTarget::SyntheticTransparentCtor { name, .. },
-                            ..
-                        },
-                    ) if r == agg => Some(name.clone()),
+                    (Some(r), OpKind::Call { target, .. }) if r == agg => {
+                        synthetic_transparent_ctor_owner(target, graph.name.split("::").next())
+                    }
                     _ => None,
                 });
             let Some(owner) = owner else {
@@ -7254,6 +7331,27 @@ mod tests {
         );
     }
 
+    #[test]
+    fn transparent_ctor_owner_preserves_nominal_path_and_strips_local_crate() {
+        let local = CallTarget::synthetic_transparent_struct_ctor(
+            vec!["pyre_object".into(), "intobject".into()],
+            "W_IntObject",
+        );
+        assert_eq!(
+            synthetic_transparent_ctor_owner(&local, Some("pyre_object")).as_deref(),
+            Some("intobject::W_IntObject")
+        );
+
+        let foreign = CallTarget::synthetic_transparent_struct_ctor(
+            vec!["foreign_crate".into(), "shadow".into()],
+            "W_IntObject",
+        );
+        assert_eq!(
+            synthetic_transparent_ctor_owner(&foreign, Some("pyre_object")).as_deref(),
+            Some("foreign_crate::shadow::W_IntObject")
+        );
+    }
+
     /// `CallTarget::SyntheticTransparentCtor::path_segments()` must
     /// return the full `(owner_path..., name)` join — `front/mir.rs`
     /// `Aggregate` / `ShallowInitBox` lowerings rely on the qualified
@@ -8021,30 +8119,200 @@ mod tests {
         );
     }
 
-    /// The four numeric boxing structs' field layouts, keyed by the
-    /// crate-stripped qualified path (`floatobject::W_FloatObject`) the front
-    /// end registers — exercising `fuse_boxing_alloc`'s leaf-fallback lookup
-    /// (the ctor carries only the bare `W_FloatObject` leaf).  Each row is the
-    /// full field layout including `ob_header`, matching what
-    /// `derive_program_metadata` builds.
+    #[test]
+    fn lower_struct_ptr_writes_declines_predecessor_local_store_value() {
+        // The aggregate is constructed in `entry`, but only the aggregate
+        // itself is threaded into `write_block`.  Re-emitting its field store
+        // there with `value` would introduce a cross-block Variable use that
+        // flowspace.checkgraph rejects.  The ptr::write must remain residual
+        // until the value is explicitly threaded through an inputarg.
+        let mut graph = FunctionGraph::new("test");
+        let entry = graph.startblock;
+        let value = graph.push_op_var(entry, OpKind::ConstInt(7), true).unwrap();
+        let aggregate = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor("Payload"),
+                    args: vec![],
+                    result_ty: ValueType::Ref(Some("Payload".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_op_var(
+            entry,
+            OpKind::FieldWrite {
+                base: aggregate.clone(),
+                field: FieldDescriptor {
+                    name: "item".into(),
+                    owner_root: Some("Payload".into()),
+                    owner_id: None,
+                    base_is_deref: None,
+                    taken_by_address: false,
+                },
+                value: LinkArg::Value(value),
+                ty: ValueType::Int,
+            },
+            false,
+        );
+        let (write_block, carried) = graph.create_block_with_arg_vars(1);
+        graph.set_goto(entry, write_block, vec![aggregate]);
+        let raw = graph
+            .push_op_var(write_block, OpKind::ConstRefNull, true)
+            .unwrap();
+        let destination = graph
+            .push_op_var(
+                write_block,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec!["__cast_instance_intrinsic".into(), "Payload".into()],
+                    },
+                    args: vec![raw],
+                    result_ty: ValueType::Ref(Some("Payload".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_op_var(
+            write_block,
+            OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec!["core".into(), "ptr".into(), "write".into()],
+                },
+                args: vec![destination, carried[0].clone()],
+                result_ty: ValueType::Void,
+            },
+            false,
+        );
+        graph.set_return(write_block, None);
+
+        let attrs = std::collections::HashMap::from([(
+            "Payload".to_string(),
+            vec![("item".to_string(), ValueType::Int)],
+        )]);
+        assert_eq!(lower_struct_ptr_writes(&mut graph, &attrs), 0);
+        assert!(graph.block(write_block).operations.iter().any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.iter().map(String::as_str).eq(["core", "ptr", "write"])
+            )
+        }));
+    }
+
+    #[test]
+    fn lower_struct_ptr_writes_declines_nondominating_constant_store() {
+        // A literal value is valid in every block, but the store itself is
+        // conditional. Hoisting it to the merge would initialize objects that
+        // took the other arm, so dominance is required independently of SSI
+        // value scope.
+        let mut graph = FunctionGraph::new("test");
+        let entry = graph.startblock;
+        let aggregate = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor("Payload"),
+                    args: vec![],
+                    result_ty: ValueType::Ref(Some("Payload".into())),
+                },
+                true,
+            )
+            .unwrap();
+        let cond = graph
+            .push_op_var(entry, OpKind::ConstBool(true), true)
+            .unwrap();
+        let (left, left_args) = graph.create_block_with_arg_vars(1);
+        let (right, right_args) = graph.create_block_with_arg_vars(1);
+        let (join, joined) = graph.create_block_with_arg_vars(1);
+        graph.block_mut(entry).exitswitch = Some(ExitSwitch::Value(cond));
+        graph.closeblock(
+            entry,
+            vec![
+                Link::from_variables(
+                    &graph,
+                    vec![aggregate.clone()],
+                    left,
+                    Some(ExitCase::Bool(true)),
+                ),
+                Link::from_variables(&graph, vec![aggregate], right, Some(ExitCase::Bool(false))),
+            ],
+        );
+        graph.push_op_var(
+            left,
+            OpKind::FieldWrite {
+                base: left_args[0].clone(),
+                field: FieldDescriptor {
+                    name: "item".into(),
+                    owner_root: Some("Payload".into()),
+                    owner_id: None,
+                    base_is_deref: None,
+                    taken_by_address: false,
+                },
+                value: LinkArg::from(ConstValue::Int(7)),
+                ty: ValueType::Int,
+            },
+            false,
+        );
+        graph.set_goto(left, join, vec![left_args[0].clone()]);
+        graph.set_goto(right, join, vec![right_args[0].clone()]);
+        let raw = graph.push_op_var(join, OpKind::ConstRefNull, true).unwrap();
+        let destination = graph
+            .push_op_var(
+                join,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec!["__cast_instance_intrinsic".into(), "Payload".into()],
+                    },
+                    args: vec![raw],
+                    result_ty: ValueType::Ref(Some("Payload".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_op_var(
+            join,
+            OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec!["core".into(), "ptr".into(), "write".into()],
+                },
+                args: vec![destination, joined[0].clone()],
+                result_ty: ValueType::Void,
+            },
+            false,
+        );
+        graph.set_return(join, None);
+
+        let attrs = std::collections::HashMap::from([(
+            "Payload".to_string(),
+            vec![("item".to_string(), ValueType::Int)],
+        )]);
+        assert_eq!(lower_struct_ptr_writes(&mut graph, &attrs), 0);
+    }
+
+    /// The four numeric boxing structs' complete field layouts. Synthetic
+    /// fixtures have no StructId registry, so they publish the exact owner
+    /// spelling carried by their constructor; production qualified aliases
+    /// resolve through `registered_struct_layout`'s StructId lookup.
     fn numeric_boxing_attrs() -> std::collections::HashMap<String, Vec<(String, ValueType)>> {
         std::collections::HashMap::from([
             (
-                "floatobject::W_FloatObject".to_string(),
+                "W_FloatObject".to_string(),
                 vec![
                     ("ob_header".to_string(), ValueType::Ref(None)),
                     ("floatval".to_string(), ValueType::Float),
                 ],
             ),
             (
-                "intobject::W_IntObject".to_string(),
+                "W_IntObject".to_string(),
                 vec![
                     ("ob_header".to_string(), ValueType::Ref(None)),
                     ("intval".to_string(), ValueType::Int),
                 ],
             ),
             (
-                "complexobject::W_ComplexObject".to_string(),
+                "W_ComplexObject".to_string(),
                 vec![
                     ("ob_header".to_string(), ValueType::Ref(None)),
                     ("real".to_string(), ValueType::Float),
@@ -8052,7 +8320,7 @@ mod tests {
                 ],
             ),
             (
-                "longobject::W_LongObject".to_string(),
+                "W_LongObject".to_string(),
                 vec![
                     ("ob_header".to_string(), ValueType::Ref(None)),
                     ("value".to_string(), ValueType::Ref(None)),
@@ -8212,6 +8480,10 @@ mod tests {
 
         let mut ambiguous_graph = graph.clone();
         let mut ambiguous_attrs = numeric_boxing_attrs();
+        let float_rows = ambiguous_attrs
+            .remove("W_FloatObject")
+            .expect("fixture float layout");
+        ambiguous_attrs.insert("floatobject::W_FloatObject".to_string(), float_rows);
         ambiguous_attrs.insert(
             "shadow::W_FloatObject".to_string(),
             vec![
@@ -9668,10 +9940,10 @@ mod tests {
             .unwrap();
         graph.set_return(entry, Some(ret.clone()));
 
-        // Layout keyed by the crate-stripped qualified path; the ctor carries
-        // only the bare `W_SetObject` leaf, exercising the leaf-fallback lookup.
+        // Synthetic fixtures have no StructId registry, so use the ctor's
+        // exact owner spelling. Production qualified aliases resolve by id.
         let attrs = std::collections::HashMap::from([(
-            "setobject::W_SetObject".to_string(),
+            "W_SetObject".to_string(),
             vec![
                 ("ob_header".to_string(), ValueType::Ref(None)),
                 ("items".to_string(), ValueType::Ref(None)),
@@ -9869,9 +10141,9 @@ mod tests {
             graph
         }
 
-        // The header layouts are keyed by their crate-stripped qualified path
-        // while the ctor carries the bare leaf, so every row also exercises
-        // `registered_layout`'s leaf fallback.
+        // Synthetic fixtures have no StructId registry, so publish the exact
+        // owner spelling the ctor carries. Production aliases resolve through
+        // `registered_struct_layout`'s StructId lookup, never by leaf name.
         let one_word: &[&str] = &["ob_type"];
         let two_word: &[&str] = &["ob_type", "w_class"];
         let rows: [(&str, &str, Option<&[&str]>, WClass, usize); 6] = [
@@ -9922,20 +10194,18 @@ mod tests {
             let mut graph = cluster(header_owner, &w_class);
             let entry = graph.startblock;
             let mut attrs = std::collections::HashMap::from([(
-                "intobject::W_IntObject".to_string(),
+                "W_IntObject".to_string(),
                 vec![
                     ("ob_header".to_string(), ValueType::Ref(None)),
                     ("intval".to_string(), ValueType::Int),
                 ],
             )]);
             if let Some(names) = layout {
-                attrs.insert(
-                    format!("object::{header_owner}"),
-                    names
-                        .iter()
-                        .map(|name| ((*name).to_string(), ValueType::Ref(None)))
-                        .collect(),
-                );
+                let rows = names
+                    .iter()
+                    .map(|name| ((*name).to_string(), ValueType::Ref(None)))
+                    .collect();
+                attrs.insert(header_owner.to_string(), rows);
             }
             assert_eq!(
                 fuse_boxing_alloc(&mut graph, &attrs),

--- a/majit/majit-translate/src/runtime_names.rs
+++ b/majit/majit-translate/src/runtime_names.rs
@@ -102,9 +102,9 @@ pub(crate) mod artifacts {
 /// `ll_arraymove`, wrapping `rgc.ll_arraymove`), reached here through a
 /// proven adapter boundary because neither `rlist.ll_arraymove` nor its
 /// caller `ll_delitem_nonneg` is built yet. The restoration reaches the
-/// rtyper only: no `list.ll_arraymove` oopspec and no `OS_ARRAYMOVE`
-/// (`jit/codewriter/effectinfo.py`) are emitted, so the codewriter still
-/// produces a residual call where upstream produces the operation.
+/// rtyper, oopspec, and codewriter boundary: the minted helper is marked
+/// `list.ll_arraymove`, and `_handle_list_call` emits OS_ARRAYMOVE (9) while
+/// retaining this adapter only as the source-level restoration seam.
 ///
 /// Registered in `flowspace::model`, given an annotator in
 /// `annotator::builtin`, and resolved in `translator::rtyper`. All three must

--- a/majit/majit-translate/src/translator/rtyper/call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/call_registry.rs
@@ -101,7 +101,7 @@ impl FunctionPathKey {
     }
 }
 
-/// Whether `name` is one of the residual ABI shims that materialises the
+/// Whether `key` identifies one of the residual ABI shims that materialises the
 /// Python exception object carried by an `OperationError`.
 ///
 /// Their Rust signatures use `*mut PyObject` so the residual trampoline stays
@@ -109,17 +109,42 @@ impl FunctionPathKey {
 /// interpreter is an exception *instance*.  This is the same distinction
 /// RPython's `_signature_` makes between a low-level ABI spelling and the
 /// annotator-level result.
-pub(crate) fn is_exception_object_materializer(name: &str) -> bool {
-    matches!(
-        name,
+pub(crate) fn is_exception_object_materializer(key: &FunctionPathKey) -> bool {
+    let segments = key.segments();
+    let Some(leaf) = segments.last().map(String::as_str) else {
+        return false;
+    };
+    if !matches!(
+        leaf,
         "pyerror_to_exc_object" | "pyerror_type_error_to_exc_object"
-    )
+    ) {
+        return false;
+    }
+    matches!(segments, [root, owner, _]
+        if root == "pyre_interpreter" && owner == "error")
+        // `populate_call_registry_from_call_graphs` canonicalizes local-crate
+        // aliases by stripping the `pyre_interpreter` root, so the same source
+        // function is also keyed as `error::<leaf>`.  This is not a fuzzy leaf
+        // match: `other_module::error::<leaf>` remains a distinct 3-segment
+        // path and is rejected below.
+        || matches!(segments, [owner, _] if owner == "error")
+        || matches!(segments, [root, _] if root == "pyre_interpreter")
 }
 
 /// The annotator-level result shared by the exception materialisers'
 /// `_signature_` and their `dont_look_inside` stub graph.
 pub(crate) fn exception_object_result_annotation() -> SomeValue {
     SomeValue::Instance(SomeInstance::new(None, false, Default::default()))
+}
+
+fn publish_exception_object_result_signature(function_desc: &mut FunctionDesc) {
+    let signature_arg_count = function_desc.signature.argnames.len();
+    function_desc.annsignature = Some(Rc::new(AnnSignature {
+        params: (0..signature_arg_count)
+            .map(|_| ParamType::Marker(TypeMarker::AnyType))
+            .collect(),
+        result: ParamType::Annotation(Box::new(exception_object_result_annotation())),
+    }));
 }
 
 /// Per-path registry entry.  Each entry owns:
@@ -153,6 +178,16 @@ pub struct FunctionEntry {
 }
 
 impl FunctionEntry {
+    /// Publish the annotator-level result of a source-identified exception
+    /// materializer after GraphStore alias deduplication has selected this
+    /// entry.  The source graph identity is the Rust-port equivalent of the
+    /// Python callable identity used by `Bookkeeper.getdesc`; the registry's
+    /// first alias key may legitimately be only the bare leaf and therefore
+    /// cannot establish this semantic fact by itself.
+    pub(crate) fn publish_exception_object_result_signature(&self) {
+        publish_exception_object_result_signature(&mut self.function_desc.borrow_mut());
+    }
+
     /// Pre-fill the entry's `FunctionDesc.cache` for the default
     /// specializer with no `*args` (the lookup key
     /// `Specializer::Default + flatten_star_args(no vararg) ->
@@ -913,8 +948,7 @@ impl CallRegistry {
             Constant::new(ConstValue::Dict(HashMap::new())),
         );
         let host_object = HostObject::new_user_function(graph_func);
-        let exception_object_result = is_exception_object_materializer(key.name());
-        let signature_arg_count = signature.argnames.len();
+        let exception_object_result = is_exception_object_materializer(&key);
         let mut function_desc = FunctionDesc::new(
             self.bookkeeper.clone(),
             Some(host_object.clone()),
@@ -937,12 +971,7 @@ impl CallRegistry {
             // `InstanceRepr.rtype_type`, as it does upstream, without
             // inventing a `PtrRepr.rtype_type` operation that RPython does
             // not have.
-            function_desc.annsignature = Some(Rc::new(AnnSignature {
-                params: (0..signature_arg_count)
-                    .map(|_| ParamType::Marker(TypeMarker::AnyType))
-                    .collect(),
-                result: ParamType::Annotation(Box::new(exception_object_result_annotation())),
-            }));
+            publish_exception_object_result_signature(&mut function_desc);
         }
         let function_desc = Rc::new(RefCell::new(function_desc));
         // Pre-register in bookkeeper.descs so the rtyper's
@@ -1139,35 +1168,70 @@ mod tests {
         let bk = Rc::new(Bookkeeper::new());
         let registry = CallRegistry::new(bk);
         for leaf in ["pyerror_to_exc_object", "pyerror_type_error_to_exc_object"] {
-            let entry = registry.get_or_register(
-                FunctionPathKey::from_segments(["pyre_interpreter", "error", leaf]),
-                signature(&["arg"]),
-            );
-            let fd = entry.function_desc.borrow();
-            let annsig = fd
-                .annsignature
-                .as_ref()
-                .expect("exception materializer needs an annotation signature");
-            assert_eq!(annsig.params.len(), 1);
-            assert!(matches!(
-                annsig.params[0],
-                ParamType::Marker(TypeMarker::AnyType)
-            ));
-            let ParamType::Annotation(result) = &annsig.result else {
-                panic!("exception materializer result must be an explicit annotation");
-            };
-            let SomeValue::Instance(instance) = result.as_ref() else {
-                panic!("exception materializer result must be SomeInstance");
-            };
-            assert!(instance.classdef.is_none());
-            assert!(!instance.can_be_none);
+            for path in [
+                vec!["pyre_interpreter", "error", leaf],
+                vec!["error", leaf],
+                vec!["pyre_interpreter", leaf],
+            ] {
+                let entry = registry
+                    .get_or_register(FunctionPathKey::from_segments(path), signature(&["arg"]));
+                let fd = entry.function_desc.borrow();
+                let annsig = fd
+                    .annsignature
+                    .as_ref()
+                    .expect("exception materializer needs an annotation signature");
+                assert_eq!(annsig.params.len(), 1);
+                assert!(matches!(
+                    annsig.params[0],
+                    ParamType::Marker(TypeMarker::AnyType)
+                ));
+                let ParamType::Annotation(result) = &annsig.result else {
+                    panic!("exception materializer result must be an explicit annotation");
+                };
+                let SomeValue::Instance(instance) = result.as_ref() else {
+                    panic!("exception materializer result must be SomeInstance");
+                };
+                assert!(instance.classdef.is_none());
+                assert!(!instance.can_be_none);
+            }
         }
 
         let ordinary = registry.get_or_register(
-            FunctionPathKey::from_segments(["pyre_interpreter", "other"]),
+            FunctionPathKey::from_segments(["other_module", "pyerror_to_exc_object"]),
             signature(&["arg"]),
         );
         assert!(ordinary.function_desc.borrow().annsignature.is_none());
+        let foreign_error_module = registry.get_or_register(
+            FunctionPathKey::from_segments(["other_module", "error", "pyerror_to_exc_object"]),
+            signature(&["arg"]),
+        );
+        assert!(
+            foreign_error_module
+                .function_desc
+                .borrow()
+                .annsignature
+                .is_none()
+        );
+
+        // GraphStore may select the bare alias as the canonical registry
+        // key.  The key alone must remain non-semantic (a foreign function
+        // may share the leaf), but population can publish the result after
+        // checking the graph's exact `source_identity`.
+        let bare = registry.get_or_register(
+            FunctionPathKey::from_segments(["pyerror_to_exc_object"]),
+            signature(&["arg"]),
+        );
+        assert!(bare.function_desc.borrow().annsignature.is_none());
+        bare.publish_exception_object_result_signature();
+        assert!(matches!(
+            bare.function_desc
+                .borrow()
+                .annsignature
+                .as_ref()
+                .map(|sig| &sig.result),
+            Some(ParamType::Annotation(result))
+                if matches!(result.as_ref(), SomeValue::Instance(_))
+        ));
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1974,7 +1974,7 @@ pub(crate) fn populate_call_registry_from_call_graphs(
     for (path, graph) in function_graphs.iter() {
         let key = FunctionPathKey::from_segments(path.segments.iter().cloned());
         let canonical_strip = canonical_dedup_key(path);
-        // `pyre_object::lltype::malloc[_typed]` are GC allocation intrinsics,
+        // `pyre_object::lltype::malloc[_typed/_stable]` are GC allocation intrinsics,
         // recognised as host builtins (annotator `malloc_typed_alloc`, HOST_ENV
         // `pyre_object.lltype` module). Their real bodies enter the host
         // allocator (`malloc_typed` first reads the un-flowable
@@ -1991,11 +1991,13 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         // is still not a residual boundary: it means the frontend could not
         // prove the allocation header/type identity.  The fail-closed guard in
         // `flowspace_adapter::translate_op` therefore rejects every surviving
-        // `malloc`, `malloc_typed`, or `malloc_typed_managed` call instead of
+        // `malloc`, `malloc_typed`, `malloc_typed_managed`, or
+        // `malloc_typed_stable` call instead of
         // emitting an executable symbolic fnaddr.
         if canonical_strip == ["lltype", "malloc"]
             || canonical_strip == ["lltype", "malloc_typed"]
             || canonical_strip == ["lltype", "malloc_typed_managed"]
+            || canonical_strip == ["lltype", "malloc_typed_stable"]
         {
             crate::decline::record(
                 REGISTRY_GATE,
@@ -2085,6 +2087,26 @@ pub(crate) fn populate_call_registry_from_call_graphs(
             by_canonical_path.insert(canonical_strip, key.clone());
             entry
         };
+        // GraphStore aliases are iteration-ordered, so the canonical entry
+        // selected above can be keyed by the bare leaf even though the graph
+        // retains its exact source callable identity.  RPython attaches
+        // `_signature_` to that callable object, not to one spelling of its
+        // import path (`bookkeeper.py:353-409`, `description.py:234-244`).
+        // Recover the same fact from `FunctionGraph.source_identity` here;
+        // this keeps a foreign same-leaf function distinct while ensuring
+        // every alias of the real materializer shares the semantic result.
+        if graph
+            .source_identity
+            .as_deref()
+            .map(|identity| {
+                is_exception_object_materializer(&FunctionPathKey::from_segments(
+                    identity.split("::"),
+                ))
+            })
+            .unwrap_or(false)
+        {
+            entry.publish_exception_object_result_signature();
+        }
         pending.push((key, graph, entry, signature));
     }
     // Lift `pending` in a deterministic order.  `function_graphs.iter()`
@@ -2198,7 +2220,7 @@ pub(crate) fn populate_call_registry_from_call_graphs(
             }
         }
     }
-    for (_key, graph, entry, signature) in &pending {
+    for (key, graph, entry, signature) in &pending {
         let entry_ptr = Rc::as_ptr(entry);
         if !lifted.insert(entry_ptr) {
             continue;
@@ -2232,10 +2254,13 @@ pub(crate) fn populate_call_registry_from_call_graphs(
             // insert a PtrRepr -> InstanceRepr conversion that upstream never
             // has, then the first failed specialization replaces the shared
             // stub and strands every later caller on an unbound return var.
-            let result_shell = residual_stub_result_shell(
-                entry.function_desc.borrow().name.as_str(),
-                graph.return_type.as_deref(),
-            );
+            let semantic_key = graph
+                .source_identity
+                .as_deref()
+                .map(|identity| FunctionPathKey::from_segments(identity.split("::")))
+                .unwrap_or_else(|| key.clone());
+            let result_shell =
+                residual_stub_result_shell(&semantic_key, graph.return_type.as_deref());
             if let Some(result_shell) = result_shell {
                 let stub = build_stub_pygraph_with_result_shell(
                     graph.name.clone(),
@@ -2598,10 +2623,10 @@ pub(crate) fn residual_return_shell(
 /// exception instance.  The cached stub must agree with that signature, just
 /// as an upstream flow graph constrained by `_signature_` does.
 fn residual_stub_result_shell(
-    function_name: &str,
+    function_key: &FunctionPathKey,
     token: Option<&str>,
 ) -> Option<crate::annotator::model::SomeValue> {
-    if is_exception_object_materializer(function_name) {
+    if is_exception_object_materializer(function_key) {
         Some(exception_object_result_annotation())
     } else {
         residual_return_shell(token)
@@ -6432,7 +6457,8 @@ mod tests {
         use crate::annotator::model::SomeValue;
 
         for name in ["pyerror_to_exc_object", "pyerror_type_error_to_exc_object"] {
-            let shell = residual_stub_result_shell(name, Some(OBJECTPTR_RETURN_TYPE))
+            let key = FunctionPathKey::from_segments(["pyre_interpreter", "error", name]);
+            let shell = residual_stub_result_shell(&key, Some(OBJECTPTR_RETURN_TYPE))
                 .expect("exception materializer must have a result shell");
             let SomeValue::Instance(instance) = shell else {
                 panic!("{name}: raw pointer ABI must not leak into annotation")
@@ -6441,7 +6467,8 @@ mod tests {
             assert!(!instance.can_be_none);
         }
 
-        let ordinary = residual_stub_result_shell("ordinary", Some(OBJECTPTR_RETURN_TYPE))
+        let ordinary_key = FunctionPathKey::from_segments(["other", "pyerror_to_exc_object"]);
+        let ordinary = residual_stub_result_shell(&ordinary_key, Some(OBJECTPTR_RETURN_TYPE))
             .expect("ordinary object-pointer residual must have a result shell");
         assert!(
             matches!(ordinary, SomeValue::Ptr(_)),

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -5746,6 +5746,56 @@ mod tests {
     }
 
     #[test]
+    fn qualified_builtin_cast_ignores_a_same_leaf_registry_function() {
+        // RPython carries the actual `float` object in the flowspace
+        // Constant, so `BUILTIN_TYPER[float]` cannot be captured by an
+        // unrelated function with the same `__name__`.  Pyre's MIR carrier
+        // is a path; the explicit `__builtin__` owner is how the cast path
+        // preserves that object identity across the flat CallRegistry.
+        use crate::flowspace::argument::Signature;
+        use crate::translator::rtyper::call_registry::FunctionPathKey;
+
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let mut graph = LegacyGraph::new("qualified_builtin_cast_fixture");
+        let vars = mint_vars(&mut graph, 3);
+        value_map.insert(vars[1].clone(), Hlvalue::Variable(Variable::new()));
+        value_map.insert(vars[2].clone(), Hlvalue::Variable(Variable::new()));
+
+        let registry = empty_call_registry();
+        registry.get_or_register(
+            FunctionPathKey::from_segments(["float"]),
+            Signature::new(vec!["value".into()], None, None),
+        );
+        let op = SpaceOperation {
+            result: Some(vars[2].clone()),
+            kind: OpKind::Call {
+                target: crate::model::CallTarget::FunctionPath {
+                    segments: vec!["__builtin__".into(), "float".into()],
+                },
+                args: vec![vars[1].clone()],
+                result_ty: ValueType::Float,
+            },
+        };
+
+        let translated = translate_op(&op, &value_map, &registry)
+            .expect("qualified builtin cast must resolve through HOST_ENV");
+        let Hlvalue::Constant(ref callable) = translated[0].args[0] else {
+            panic!("simple_call callable must be a Constant");
+        };
+        let ConstValue::HostObject(ref host) = callable.value else {
+            panic!("FunctionPath callable must be ConstValue::HostObject");
+        };
+        let expected = HOST_ENV
+            .lookup_builtin("float")
+            .expect("HOST_ENV bootstrap must register __builtin__.float");
+        assert_eq!(host, &expected);
+        assert!(
+            !host.is_user_function(),
+            "the same-leaf registry function must not capture the builtin cast"
+        );
+    }
+
+    #[test]
     fn translate_op_call_function_path_resolves_host_module_attr_for_lltype_cast() {
         // Multi-segment FunctionPath unregistered in CallRegistry
         // falls back to Layer 3 (HOST_ENV.import_module + module_get).

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2470,7 +2470,8 @@ pub fn translate_op(
                             return Ok(vec![FlowspaceOp::new(opname, arg_hls, result)]);
                         }
                     }
-                    // Fail-closed on an UNFUSED `lltype::malloc[_typed]`. A GC
+                    // Fail-closed on an UNFUSED
+                    // `lltype::malloc[_typed/_managed/_stable]`. A GC
                     // struct gets its `NewWithVtable` lowering before the rtyper
                     // runs only where `fuse_boxing_alloc` (`model.rs`) could
                     // resolve the cluster's header: a constant `ob_type`
@@ -2494,11 +2495,14 @@ pub fn translate_op(
                         && segments[segments.len() - 2] == "lltype"
                         && matches!(
                             segments[segments.len() - 1].as_str(),
-                            "malloc" | "malloc_typed" | "malloc_typed_managed"
+                            "malloc"
+                                | "malloc_typed"
+                                | "malloc_typed_managed"
+                                | "malloc_typed_stable"
                         )
                     {
                         return Err(TyperError::message(
-                            "`lltype::malloc[_typed/_managed]` survived fuse_boxing_alloc unfused; \
+                            "`lltype::malloc[_typed/_managed/_stable]` survived fuse_boxing_alloc unfused; \
                              the cluster's header did not resolve to a constant type \
                              pointer standing for its own `w_class`, so no safe \
                              malloc->new lowering could be proven"
@@ -2790,7 +2794,7 @@ pub fn translate_op(
                     // the field repr's interned classdef (rtyper
                     // convert_from_to has no common base → typer error), and
                     // two `()` values meeting at a join can never union.
-                    let host = if owner_path.is_empty() {
+                    let class_host = if owner_path.is_empty() {
                         // Match the aggregate-kind placeholder tag by its
                         // instantiation-stripped root so a per-shape tuple
                         // (`Tuple<f64,f64>`, `Tuple<BigInt,BigInt>`) interns
@@ -2904,6 +2908,12 @@ pub fn translate_op(
                             }
                         }
                     };
+                    // Keep the canonical class identity for annotation, but
+                    // retain that this is Rust `T { fields }`, not a semantic
+                    // Python `T(...)` call.  ClassesPBCRepr consumes this
+                    // wrapper by selecting only RPython's rtype_new_instance
+                    // step, so a registered app-level `__init__` cannot run.
+                    let host = HostObject::new_transparent_class_ctor(class_host);
                     let callable = Hlvalue::Constant(Constant::new(ConstValue::HostObject(host)));
                     let mut call_args = Vec::with_capacity(arg_hls.len() + 1);
                     call_args.push(callable);
@@ -5879,8 +5889,9 @@ mod tests {
     #[test]
     fn translate_op_call_synthetic_transparent_ctor_lowers_to_simple_call() {
         // Call::SyntheticTransparentCtor mirrors Rust's `Class { fields }`
-        // ctor — flowspace receives a `simple_call(class_const, fields)`
-        // shape just like FunctionPath; rtyper's InstanceRepr handles it.
+        // ctor.  Flowspace still receives `simple_call(class_const, fields)`,
+        // but its call-site wrapper keeps rtyping on rtype_new_instance and
+        // prevents a registered semantic `__init__` from being dispatched.
         let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
         let mut graph = LegacyGraph::new("translate_op_fixture");
         let vars = mint_vars(&mut graph, 11); // vars[0..11]
@@ -5905,6 +5916,12 @@ mod tests {
             panic!("ctor callable must be ConstValue::HostObject");
         };
         assert_eq!(host.qualname(), "Point");
+        assert_eq!(
+            host.transparent_class_target()
+                .expect("synthetic ctor must retain its call-site marker")
+                .qualname(),
+            "Point"
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -5591,7 +5591,7 @@ mod tests {
     }
 
     #[test]
-    fn preminted_generic_enum_variant_repr_contains_payload_field() {
+    fn generic_enum_variant_repr_contains_payload_after_constructor_setattr() {
         use crate::annotator::annrpython::RPythonAnnotator;
         use crate::front::StructFieldRegistry;
         use std::collections::HashMap;
@@ -5640,6 +5640,16 @@ mod tests {
             .bookkeeper
             .getuniqueclassdef_for_enum_variant(root, "Some")
             .expect("resolve preminted Some classdef");
+        let payload = classdef.borrow().attrs["__pos_0"].s_value.clone();
+        classdef
+            .borrow_mut()
+            .attrs
+            .get_mut("__pos_0")
+            .expect("variant payload")
+            .modified(Some(&classdef))
+            .expect("constructor setattr marks payload mutable");
+        crate::annotator::classdesc::ClassDef::generalize_attr(&classdef, "__pos_0", Some(payload))
+            .expect("constructor setattr marks the payload as an instance field");
         let repr = getinstancerepr(&rtyper, Some(&classdef), Flavor::Gc)
             .expect("build preminted Some repr");
         Repr::setup(repr.as_ref()).expect("setup preminted Some repr");

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -3045,8 +3045,11 @@ fn build_ll_arraymove_arm(
 ///
 /// * The `length <= 1` head.  Upstream's own comment says it is there "to
 ///   ensure that we get a proper effectinfo.write_descrs_arrays", not for
-///   speed, and the minted helper carries no `list.ll_arraymove` oopspec
-///   either — the same pairing `ll_arraycopy` is still missing.
+///   speed.  The arms below reach that same effectinfo through their own
+///   per-item `setarrayitem`, which upstream's memmove arm does not have.
+///   The `list.ll_arraymove` oopspec this helper is marked with is what
+///   `_handle_list_call` reads to emit OS_ARRAYMOVE; the same pairing
+///   `ll_arraycopy` is still missing.
 /// * The `must_split_gc_address_space()` dispatch and the
 ///   `raw_memmove_no_free` fast path it guards.  The body below IS
 ///   upstream's split-address-space branch, taken unconditionally.  That is

--- a/majit/majit-translate/src/translator/rtyper/rpbc.rs
+++ b/majit/majit-translate/src/translator/rtyper/rpbc.rs
@@ -6058,6 +6058,21 @@ impl ClassesPBCRepr {
             },
             _ => return Err(unported("s_result is not a SomeInstance")),
         };
+        // The flowspace adapter wraps SyntheticTransparentCtor constants so
+        // Rust aggregate construction keeps the canonical ClassDef but cannot
+        // be mistaken for a semantic class call.  RPython class construction
+        // allocates first (`rtype_new_instance`, rpbc.py:1020-1021) and only
+        // then optionally dispatches `__init__` (rpbc.py:1060-1067).  A Rust
+        // `T { fields }` expresses only the first step; the following setattr
+        // chain expresses its field initializers.  Preserve that boundary even
+        // when method seeding placed a Python-level `__init__` on the class.
+        let transparent_ctor = matches!(
+            hop.args_v.borrow().first(),
+            Some(Hlvalue::Constant(Constant {
+                value: ConstValue::HostObject(host),
+                ..
+            })) if host.transparent_class_target().is_some()
+        );
         // upstream `s_init = classdef.classdesc.s_read_attribute('__init__')`.
         let classdesc = classdef.borrow().classdesc.clone();
         let s_init = ClassDesc::s_read_attribute(&classdesc, "__init__")
@@ -6083,9 +6098,6 @@ impl ClassesPBCRepr {
         // class-default initialisation loop (rclass.py:752-769) like
         // any other; a field without a class-level default keeps the
         // malloc zero-init.
-        if !init_is_impossible {
-            return Err(unported("class has __init__ (rpbc.py:1060-1067)"));
-        }
         if classdef.borrow().minid.is_none() {
             // Number this mid-session-minted classdef on demand.
             // `assign_inheritance_ids` is append-stable, so re-running it
@@ -6100,6 +6112,25 @@ impl ClassesPBCRepr {
             if classdef.borrow().minid.is_none() {
                 return Err(unported("class not numbered (assign_inheritance_ids)"));
             }
+        }
+
+        if transparent_ctor && hop.nb_args() == 1 {
+            let v_instance = {
+                let mut llops = hop.llops.borrow_mut();
+                crate::translator::rtyper::rclass::rtype_new_instance(
+                    &rtyper,
+                    Some(&classdef),
+                    &mut llops,
+                    Some(hop),
+                    false,
+                )?
+            };
+            hop.exception_cannot_occur()?;
+            return Ok(Some(v_instance));
+        }
+
+        if !init_is_impossible {
+            return Err(unported("class has __init__ (rpbc.py:1060-1067)"));
         }
 
         // upstream rpbc.py:1024-1035 — simple built-in exception special

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3173,8 +3173,7 @@ unsafe fn load_global_via_cache(
         // of `celldict.py not space.config.objspace.honor__builtins__`.
         let strategy =
             pyre_object::dictmultiobject::w_module_dict_module_strategy_mut(w_module_dict);
-        let storage = pyre_object::dictmultiobject::w_module_dict_module_storage(w_module_dict);
-        let cache = strategy.get_global_cache(storage, name);
+        let cache = strategy.get_global_cache(w_module_dict, name);
         // `celldict.py:321/353 pycode._globals_caches[nameindex] = cache.ref`.
         if !pycode.is_null() {
             crate::pycode::w_code_globals_caches_set(pycode, nameindex, &cache);

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -2452,6 +2452,16 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::jit_ll_shrink_array",
         pyre_object::lowlevel_string::jit_ll_shrink_array,
     );
+    // `rgc.ll_arraymove` / `list.ll_arraymove` keeps PyPy's four-argument
+    // residual ABI. The target recovers the registered array token from the
+    // GC TYPE_INFO row, runs the before-move barrier for reference items, and
+    // performs overlap-safe raw memmove.
+    cpa4(
+        &mut entries,
+        "pyre_object::object_array::jit_ll_arraymove",
+        "pyre_object::jit_ll_arraymove",
+        pyre_object::object_array::jit_ll_arraymove,
+    );
     // `dont_look_inside` residual append targets for the StringBuilder value:
     // `guess_call_kind` residualizes a call whose leaf is `ll_append_res0` /
     // `ll_append_res_slice` once its native fnaddr is bound. Unlike shrink, these

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -839,7 +839,7 @@ impl ModuleDictStrategy {
     )]
     pub fn get_global_cache(
         &mut self,
-        storage: &ModuleDictStorage,
+        w_dict: PyObjectRef,
         key: &str,
     ) -> std::sync::Arc<parking_lot::Mutex<GlobalCache>> {
         let mut cache_registry = self.caches.lock();
@@ -863,7 +863,7 @@ impl ModuleDictStrategy {
         if let Some(cache) = cached {
             return cache;
         }
-        let cell = self.getdictvalue_no_unwrapping(storage, key);
+        let cell = self.getdictvalue_no_unwrapping(w_dict, key);
         let caches = cache_registry.as_mut().unwrap();
         // `celldict.py cache = GlobalCache(cell)`.  Lines 224-238
         // (`if not honor__builtins__ and cell is None and w_dict is
@@ -944,15 +944,32 @@ impl ModuleDictStrategy {
     ///     return self.unerase(w_dict.dstorage).get(key, None)
     /// ```
     ///
-    /// Returns the raw stored value (in PyPy this would be a
-    /// `MutableCell` or a plain `PyObjectRef`; pyre stores plain
-    /// values until the cell-indirection slice lands).
+    /// Returns the raw stored value (a `MutableCell` or a plain
+    /// `PyObjectRef`) without unwrapping a cell.
     pub fn getdictvalue_no_unwrapping(
         &self,
-        storage: &ModuleDictStorage,
+        w_dict: PyObjectRef,
         key: &str,
     ) -> Option<PyObjectRef> {
-        storage.get(key)
+        self._getdictvalue_no_unwrapping_pure(self.version, w_dict, key)
+    }
+
+    /// `celldict.py _getdictvalue_no_unwrapping_pure` — keep the module dict
+    /// object as the storage owner and unerase its `dstorage` here.  This is
+    /// the load-bearing PyPy shape: callers never pass the concrete erased
+    /// storage as a substitute for `w_dict`.
+    #[majit_macros::elidable_promote(promote_args = "0,1,2")]
+    #[expect(
+        clippy::not_unsafe_ptr_arg_deref,
+        reason = "PyObjectRef is a GC-managed VM handle whose validity is established at the object-space boundary"
+    )]
+    pub fn _getdictvalue_no_unwrapping_pure(
+        &self,
+        _version: VersionTag,
+        w_dict: PyObjectRef,
+        key: &str,
+    ) -> Option<PyObjectRef> {
+        unsafe { crate::dictmultiobject::w_module_dict_module_storage(w_dict).get(key) }
     }
 
     /// `celldict.py setitem_str`:
@@ -968,7 +985,7 @@ impl ModuleDictStrategy {
         key: &str,
         w_value: PyObjectRef,
     ) {
-        let cell = self.getdictvalue_no_unwrapping(storage, key);
+        let cell = storage.get(key);
         self._setitem_str_cell_known(cell, storage, key, w_value);
     }
 
@@ -1042,7 +1059,7 @@ impl ModuleDictStrategy {
     ///     return unwrap_cell(self.space, cell)
     /// ```
     pub fn getitem_str(&self, storage: &ModuleDictStorage, key: &str) -> Option<PyObjectRef> {
-        let raw = self.getdictvalue_no_unwrapping(storage, key)?;
+        let raw = storage.get(key)?;
         // `unwrap_cell` is null-tolerant and an `ObjectMutableCell` may hold a
         // null `w_value`; a null unwrap means the name has no live binding, so
         // report absence rather than `Some(null)`.

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -979,14 +979,9 @@ impl ModuleDictStrategy {
     ///     cell = self.getdictvalue_no_unwrapping(w_dict, key)
     ///     return self._setitem_str_cell_known(cell, w_dict, key, w_value)
     /// ```
-    pub fn setitem_str(
-        &mut self,
-        storage: &mut ModuleDictStorage,
-        key: &str,
-        w_value: PyObjectRef,
-    ) {
-        let cell = storage.get(key);
-        self._setitem_str_cell_known(cell, storage, key, w_value);
+    pub fn setitem_str(&mut self, w_dict: PyObjectRef, key: &str, w_value: PyObjectRef) {
+        let cell = self.getdictvalue_no_unwrapping(w_dict, key);
+        self._setitem_str_cell_known(cell, w_dict, key, w_value);
     }
 
     /// `celldict.py _setitem_str_cell_known`:
@@ -1019,7 +1014,7 @@ impl ModuleDictStrategy {
     pub fn _setitem_str_cell_known(
         &mut self,
         cell: Option<PyObjectRef>,
-        storage: &mut ModuleDictStorage,
+        w_dict: PyObjectRef,
         key: &str,
         w_value: PyObjectRef,
     ) {
@@ -1029,7 +1024,9 @@ impl ModuleDictStrategy {
             return;
         };
         self.mutated();
-        storage.set(key, w_to_store);
+        unsafe {
+            crate::dictmultiobject::w_module_dict_module_storage_mut(w_dict).set(key, w_to_store);
+        }
         // `celldict.py:88-90`: keep any live cache for `key` in step
         // with the new stored value so subsequent LOAD_GLOBAL through
         // the cache reads the fresh entry without an invalidation
@@ -1047,8 +1044,8 @@ impl ModuleDictStrategy {
     /// def length(self, w_dict):
     ///     return len(self.unerase(w_dict.dstorage))
     /// ```
-    pub fn length(&self, storage: &ModuleDictStorage) -> usize {
-        storage.len()
+    pub fn length(&self, w_dict: PyObjectRef) -> usize {
+        unsafe { crate::dictmultiobject::w_module_dict_module_storage(w_dict).len() }
     }
 
     /// `celldict.py getitem_str`:
@@ -1058,8 +1055,8 @@ impl ModuleDictStrategy {
     ///     cell = self.getdictvalue_no_unwrapping(w_dict, key)
     ///     return unwrap_cell(self.space, cell)
     /// ```
-    pub fn getitem_str(&self, storage: &ModuleDictStorage, key: &str) -> Option<PyObjectRef> {
-        let raw = storage.get(key)?;
+    pub fn getitem_str(&self, w_dict: PyObjectRef, key: &str) -> Option<PyObjectRef> {
+        let raw = self.getdictvalue_no_unwrapping(w_dict, key)?;
         // `unwrap_cell` is null-tolerant and an `ObjectMutableCell` may hold a
         // null `w_value`; a null unwrap means the name has no live binding, so
         // report absence rather than `Some(null)`.
@@ -1071,12 +1068,10 @@ impl ModuleDictStrategy {
     /// (`celldict.py:110-121`); the object-fallback /
     /// `_never_equal_to_string` branches belong to the full strategy
     /// dispatch once `ObjectDictStrategy` is wired.
-    pub fn delitem_str(
-        &mut self,
-        storage: &mut ModuleDictStorage,
-        key: &str,
-    ) -> Option<PyObjectRef> {
-        let removed = storage.remove(key)?;
+    pub fn delitem_str(&mut self, w_dict: PyObjectRef, key: &str) -> Option<PyObjectRef> {
+        let removed = unsafe {
+            crate::dictmultiobject::w_module_dict_module_storage_mut(w_dict).remove(key)?
+        };
         if let Some(caches) = self.caches.lock().as_mut()
             && let Some(cache) = caches.get(key)
         {
@@ -1096,8 +1091,10 @@ impl ModuleDictStrategy {
     ///     self.unerase(w_dict.dstorage).clear()
     ///     self.mutated()
     /// ```
-    pub fn clear(&mut self, storage: &mut ModuleDictStorage) {
-        storage.clear();
+    pub fn clear(&mut self, w_dict: PyObjectRef) {
+        unsafe {
+            crate::dictmultiobject::w_module_dict_module_storage_mut(w_dict).clear();
+        }
         self.mutated();
     }
 
@@ -1438,11 +1435,11 @@ pub unsafe fn remove_cell(w_dict: PyObjectRef, name: &str) {
         return;
     }
     let strategy = crate::dictmultiobject::w_module_dict_module_strategy_mut(w_dict);
-    let storage = crate::dictmultiobject::w_module_dict_module_storage_mut(w_dict);
-    let Some(w_value) = strategy.getitem_str(storage, name) else {
+    let Some(w_value) = strategy.getitem_str(w_dict, name) else {
         return;
     };
     strategy.mutated();
+    let storage = crate::dictmultiobject::w_module_dict_module_storage_mut(w_dict);
     storage.set(name, w_value);
 }
 
@@ -1490,33 +1487,33 @@ mod tests {
 
     #[test]
     fn setitem_getitem_roundtrip() {
-        let mut strat = ModuleDictStrategy::new();
-        let mut store = strat.get_empty_storage();
+        let w_dict = crate::dictmultiobject::w_module_dict_new();
+        let strat = unsafe { crate::dictmultiobject::w_module_dict_module_strategy_mut(w_dict) };
         let v = crate::w_str_new("hello");
-        strat.setitem_str(&mut store, "x", v);
-        assert_eq!(strat.getitem_str(&store, "x"), Some(v));
-        assert_eq!(strat.length(&store), 1);
+        strat.setitem_str(w_dict, "x", v);
+        assert_eq!(strat.getitem_str(w_dict, "x"), Some(v));
+        assert_eq!(strat.length(w_dict), 1);
     }
 
     #[test]
     fn setitem_bumps_version() {
-        let mut strat = ModuleDictStrategy::new();
+        let w_dict = crate::dictmultiobject::w_module_dict_new();
+        let strat = unsafe { crate::dictmultiobject::w_module_dict_module_strategy_mut(w_dict) };
         let before = strat.version;
-        let mut store = strat.get_empty_storage();
-        strat.setitem_str(&mut store, "k", crate::w_str_new("v"));
+        strat.setitem_str(w_dict, "k", crate::w_str_new("v"));
         assert_ne!(strat.version, before);
     }
 
     #[test]
     fn delitem_removes_and_bumps() {
-        let mut strat = ModuleDictStrategy::new();
-        let mut store = strat.get_empty_storage();
+        let w_dict = crate::dictmultiobject::w_module_dict_new();
+        let strat = unsafe { crate::dictmultiobject::w_module_dict_module_strategy_mut(w_dict) };
         let v = crate::w_str_new("v");
-        strat.setitem_str(&mut store, "k", v);
+        strat.setitem_str(w_dict, "k", v);
         let v_before = strat.version;
-        let removed = strat.delitem_str(&mut store, "k");
+        let removed = strat.delitem_str(w_dict, "k");
         assert_eq!(removed, Some(v));
-        assert_eq!(strat.getitem_str(&store, "k"), None);
+        assert_eq!(strat.getitem_str(w_dict, "k"), None);
         assert_ne!(strat.version, v_before);
     }
 
@@ -1525,15 +1522,15 @@ mod tests {
         // After a second write with an int value, the strategy should
         // wrap the value in `IntMutableCell` and skip the version bump
         // (typeobject.py:61-63).
-        let mut strat = ModuleDictStrategy::new();
-        let mut store = strat.get_empty_storage();
+        let w_dict = crate::dictmultiobject::w_module_dict_new();
+        let strat = unsafe { crate::dictmultiobject::w_module_dict_module_strategy_mut(w_dict) };
         unsafe {
             let v0 = crate::intobject::w_int_new(7);
-            strat.setitem_str(&mut store, "k", v0);
+            strat.setitem_str(w_dict, "k", v0);
             let v1 = crate::intobject::w_int_new(8);
-            strat.setitem_str(&mut store, "k", v1);
+            strat.setitem_str(w_dict, "k", v1);
             // getitem_str unwraps the cell back to the int value.
-            let got = strat.getitem_str(&store, "k").unwrap();
+            let got = strat.getitem_str(w_dict, "k").unwrap();
             assert_eq!(crate::intobject::w_int_get_value(got), 8);
         }
     }

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -2271,10 +2271,9 @@ unsafe fn w_module_dict_setitem_str_internal(obj: PyObjectRef, key: &str, w_valu
     }
     {
         let strategy = w_module_dict_module_strategy_mut(obj);
-        let storage = w_module_dict_module_storage_mut(obj);
-        let old_len = storage.len();
-        strategy.setitem_str(storage, key, w_value);
-        if storage.len() != old_len {
+        let old_len = w_module_dict_module_storage(obj).len();
+        strategy.setitem_str(obj, key, w_value);
+        if w_module_dict_module_storage(obj).len() != old_len {
             w_dict_bump_keys_version(obj);
         }
     }
@@ -2298,8 +2297,7 @@ pub unsafe fn w_module_dict_getitem_str(obj: PyObjectRef, key: &str) -> Option<P
     }
     {
         let strategy = &*w_module_dict_get_strategy(obj);
-        let storage = w_module_dict_module_storage(obj);
-        if let Some(v) = strategy.getitem_str(storage, key) {
+        if let Some(v) = strategy.getitem_str(obj, key) {
             return Some(v);
         }
     }
@@ -2390,8 +2388,7 @@ unsafe fn w_module_dict_delitem_str_internal(obj: PyObjectRef, key: &str) -> Opt
     }
     let removed = {
         let strategy = w_module_dict_module_strategy_mut(obj);
-        let storage = w_module_dict_module_storage_mut(obj);
-        strategy.delitem_str(storage, key)
+        strategy.delitem_str(obj, key)
     };
     if removed.is_some() {
         w_dict_bump_keys_version(obj);
@@ -2410,8 +2407,7 @@ pub unsafe fn w_module_dict_length(obj: PyObjectRef) -> usize {
         entries.len()
     } else {
         let strategy = &*w_module_dict_get_strategy(obj);
-        let storage = w_module_dict_module_storage(obj);
-        strategy.length(storage)
+        strategy.length(obj)
     }
 }
 
@@ -4519,9 +4515,8 @@ pub unsafe fn w_module_dict_clear_inner(obj: PyObjectRef) {
         }
     } else {
         let strategy = w_module_dict_module_strategy_mut(obj);
-        let storage = w_module_dict_module_storage_mut(obj);
-        let changed = !storage.is_empty();
-        strategy.clear(storage);
+        let changed = !w_module_dict_module_storage(obj).is_empty();
+        strategy.clear(obj);
         if changed {
             w_dict_bump_keys_version(obj);
         }

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -172,7 +172,14 @@ pub extern "C" fn jit_ll_arraymove(array: i64, source_start: i64, dest_start: i6
         "ll_arraymove dest_start must be non-negative"
     );
 
-    let address = array as usize;
+    // A residual call copies its argument out of the jitframe before it
+    // enters host Rust.  A collection which ran at that boundary rewrites the
+    // jitframe/root slot but not this ABI copy, so follow the forwarding word
+    // before the layout query, the barriers and the copy all read the header.
+    // `gc_shrink_array` resolves the same way for the same reason; RPython's
+    // GC transform makes the equivalent reload around `rgc.ll_arraymove`
+    // automatically.
+    let address = crate::gc_hook::try_gc_current_object_address(array as *mut u8) as usize;
     let layout = majit_gc::gc_varsize_layout(address).unwrap_or(majit_gc::GcVarSizeLayout {
         base_size: ITEMS_BLOCK_TOKEN.base_size,
         item_size: ITEMS_BLOCK_TOKEN.item_size,

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -149,6 +149,67 @@ pub unsafe fn items_block_items_base(block: *mut ItemsBlock) -> *mut PyObjectRef
     unsafe { (block as *mut u8).add(ITEMS_BLOCK_ITEMS_OFFSET) as *mut PyObjectRef }
 }
 
+/// `rgc.ll_arraymove(array, source_start, dest_start, length)` — runtime
+/// target for the `list.ll_arraymove` oopspec (OS_ARRAYMOVE / 9).
+///
+/// RPython's native path calls `gc_writebarrier_before_move` when the array
+/// item contains GC pointers, casts the two item addresses to raw addresses,
+/// and invokes `raw_memmove_no_free`. The residual ABI deliberately keeps
+/// only those same four arguments. For a managed block, the existing GC
+/// TYPE_INFO row supplies the array token and `_contains_gcptr(TYPE.OF)` bit;
+/// a raw fallback block uses the `GcArray(PyObjectRef)` token this adapter
+/// boundary allocates. `ptr::copy` has memmove's overlap contract.
+pub extern "C" fn jit_ll_arraymove(array: i64, source_start: i64, dest_start: i64, length: i64) {
+    if array == 0 || length <= 0 {
+        return;
+    }
+    assert!(
+        source_start >= 0,
+        "ll_arraymove source_start must be non-negative"
+    );
+    assert!(
+        dest_start >= 0,
+        "ll_arraymove dest_start must be non-negative"
+    );
+
+    let address = array as usize;
+    let layout = majit_gc::gc_varsize_layout(address).unwrap_or(majit_gc::GcVarSizeLayout {
+        base_size: ITEMS_BLOCK_TOKEN.base_size,
+        item_size: ITEMS_BLOCK_TOKEN.item_size,
+        // The admitted unmanaged fallback is GcArray(PyObjectRef). Asking its
+        // barrier hook is harmless when no GC owns the pointer.
+        items_have_gc_ptrs: true,
+    });
+    let source_offset = (source_start as usize)
+        .checked_mul(layout.item_size)
+        .and_then(|offset| layout.base_size.checked_add(offset))
+        .expect("ll_arraymove source address overflow");
+    let dest_offset = (dest_start as usize)
+        .checked_mul(layout.item_size)
+        .and_then(|offset| layout.base_size.checked_add(offset))
+        .expect("ll_arraymove destination address overflow");
+    let byte_length = (length as usize)
+        .checked_mul(layout.item_size)
+        .expect("ll_arraymove byte length overflow");
+
+    if layout.items_have_gc_ptrs {
+        if length == 1 {
+            // rgc.py `ll_arraymove`: the literal `copy_item` head exists for
+            // EffectInfo and performs an ordinary GC-pointer store.
+            crate::gc_hook::try_gc_write_barrier(address as *mut u8);
+        } else {
+            crate::gc_hook::try_gc_write_barrier_before_move(address as *mut u8);
+        }
+    }
+    unsafe {
+        std::ptr::copy(
+            (address as *const u8).add(source_offset),
+            (address as *mut u8).add(dest_offset),
+            byte_length,
+        );
+    }
+}
+
 /// Allocated capacity (GcArray length header) of an `ItemsBlock`.
 /// Returns 0 for a null pointer so "empty list" is represented by
 /// a null `items` field.
@@ -1422,5 +1483,57 @@ mod tests {
     fn gc_typed_array_out_of_range_write_panics() {
         let arr = allocate_array(3, ArrayKind::Ref, true);
         setarrayitem_ref(arr, 3, std::ptr::null_mut());
+    }
+
+    #[test]
+    fn jit_ll_arraymove_preserves_overlap_in_both_directions() {
+        let values = || {
+            [
+                1usize as PyObjectRef,
+                2usize as PyObjectRef,
+                3usize as PyObjectRef,
+                4usize as PyObjectRef,
+            ]
+        };
+        let left = unsafe { alloc_list_items_block(&values()) };
+        jit_ll_arraymove(left as i64, 1, 0, 3);
+        assert_eq!(
+            unsafe { std::slice::from_raw_parts(items_block_items_base(left), 4) },
+            &[
+                2usize as PyObjectRef,
+                3usize as PyObjectRef,
+                4usize as PyObjectRef,
+                4usize as PyObjectRef,
+            ]
+        );
+        unsafe { dealloc_list_items_block(left) };
+
+        let right = unsafe { alloc_list_items_block(&values()) };
+        jit_ll_arraymove(right as i64, 0, 1, 3);
+        assert_eq!(
+            unsafe { std::slice::from_raw_parts(items_block_items_base(right), 4) },
+            &[
+                1usize as PyObjectRef,
+                1usize as PyObjectRef,
+                2usize as PyObjectRef,
+                3usize as PyObjectRef,
+            ]
+        );
+        unsafe { dealloc_list_items_block(right) };
+
+        // `rgc.ll_arraymove` keeps this case as an explicit `copy_item`
+        // before entering the barrier-plus-memmove body.
+        let one = unsafe { alloc_list_items_block(&values()) };
+        jit_ll_arraymove(one as i64, 3, 0, 1);
+        assert_eq!(
+            unsafe { std::slice::from_raw_parts(items_block_items_base(one), 4) },
+            &[
+                4usize as PyObjectRef,
+                2usize as PyObjectRef,
+                3usize as PyObjectRef,
+                4usize as PyObjectRef,
+            ]
+        );
+        unsafe { dealloc_list_items_block(one) };
     }
 }


### PR DESCRIPTION
Refs #346.

This branch is rebased on current origin/main and advances the PyPy-shaped annotator/rtyper cutover in seven bounded slices:

- port ll_arraymove through the upstream OS_ARRAYMOVE operation;
- preserve concrete aggregate, allocation, exception, closure, and transparent-constructor identities;
- reconcile explicit-sum owner aliases without parallel runtime metadata;
- preserve actual __builtin__.float / __builtin__.int callable identity;
- restore PyPy ModuleDictStrategy calls to carry the owning w_dict and unerase dstorage inside the strategy;
- make elidable_promote work for receiver methods;
- preserve a declared SomeInstance class when Rust reference/raw-pointer values are assigned to instance fields.

The latest two fixes remove two producer-side union families without adding a permissive lattice arm:

- ModuleDictStorage ∪ PyObject: 68 -> 1 -> 0;
- Ptr(GCREF) ∪ DictStrategyRef: 62 -> 0.

PyPy stores W_DictObject.dstrategy as an ordinary strategy instance attribute. Rust carries that value as &DictStrategyRef, so the frontend now uses the declared field type to retain the same classed instance annotation at setattr. This is the field-assignment counterpart of RPython SomeInstance attribute typing, not a pointer/instance union exception.

Latest fresh prepass census on the fixed LLBC corpus:

    phaseA fail:       2012
    phaseB fail:       0
    MAJIT_RTYPER skip: 2002
    direct divergence: 0

The phaseA count increased after removing the strategy wall because callers now reach later blockers. Current leaders are 941 call-registry/residual walls, 432 unfused allocations, and 330 downstream annotator-fixpoint walls. This PR intentionally does not close #346.

Validation completed for the latest slices:

- fresh extraction of majit-rlib, pyre-object, pyre-interpreter, and pyre-jit LLBC after source changes;
- targeted pyre-object celldict tests: 8 passed;
- targeted real-LLBC frontend regression for w_dict_set_strategy: passed;
- release pyre-jit-trace prepass/census;
- cargo fmt --all -- --check;
- git diff --check.

The long full local dynasm suite remains delegated to CI per the requested workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime support for moving array ranges, including overlapping ranges and garbage-collection write barriers.
  * Added variable-sized object layout queries to support safer managed-array operations.
  * Added JIT promotion hints for improved optimization of eligible code paths.
  * Improved construction and handling of aggregate and option-based values.

* **Bug Fixes**
  * Improved type identity and field tracking for generic and inherited structures.
  * Preserved concrete object types through option and closure transformations.
  * Improved module dictionary access and global-cache behavior.
  * Tightened recognition of built-in and exception-related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->