### PR TITLE
Windows multiprocessing: the blocking guard's scope, a .pyc main the GC reclaimed, and the launcher's open-failure message

### DIFF
--- a/pyre/cpython_tests/baseline.win32-AMD64.json
+++ b/pyre/cpython_tests/baseline.win32-AMD64.json
@@ -37,6 +37,18 @@
       },
       "reason": "multiprocessing.get_all_start_methods() is ['spawn'] here, so MultiProcessingCmdLineMixin.setUp skipTests every ForkCmdLineTest and ForkServerCmdLineTest case -- 26 of the 39 -- and the 13 SpawnCmdLineTest cases pass. A POSIX host runs all three classes and the shared FAIL is what it records"
     },
+    "test.test_multiprocessing_spawn": {
+      "dynasm": "FAIL",
+      "provenance": {
+        "dynasm": {
+          "binary": "pyre-dynasm.exe",
+          "jit": true,
+          "mode": "script",
+          "stdlib_version": "3.14.6"
+        }
+      },
+      "reason": "the package completes here in about 170s rather than reaching the shared TIMEOUT, and reports four cases. All four are the GC model, and PyPy 3.11 on this host answers the same way for the first three: test_heap asserts 0 != 5000 over a released Heap, test_queue_get and test_dispatch weakref an exception after gc.disable() and read a live object where a refcounted runtime reads None, and test_shared_memory_across_processes raises BufferError from mmap.close() over a memoryview only a major collection releases"
+    },
     "test.test_site": {
       "dynasm": "PASS",
       "provenance": {

--- a/pyre/cpython_tests/baseline.win32-AMD64.json
+++ b/pyre/cpython_tests/baseline.win32-AMD64.json
@@ -25,6 +25,18 @@
       "dynasm": "PASS",
       "reason": "Windows-only module: the shared IMPORTERROR is what a POSIX host sees for import msvcrt"
     },
+    "test.test_multiprocessing_main_handling": {
+      "dynasm": "PASS",
+      "provenance": {
+        "dynasm": {
+          "binary": "pyre-dynasm.exe",
+          "jit": true,
+          "mode": "script",
+          "stdlib_version": "3.14.6"
+        }
+      },
+      "reason": "multiprocessing.get_all_start_methods() is ['spawn'] here, so MultiProcessingCmdLineMixin.setUp skipTests every ForkCmdLineTest and ForkServerCmdLineTest case -- 26 of the 39 -- and the 13 SpawnCmdLineTest cases pass. A POSIX host runs all three classes and the shared FAIL is what it records"
+    },
     "test.test_site": {
       "dynasm": "PASS",
       "provenance": {

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -181,7 +181,7 @@ fn repr_codepoint_is_printable(code: u32) -> bool {
 /// `_repr_function` `@jit.elidable`; preserve that call policy and keep the
 /// loop in interpreter source so source translation sees its real semantics.
 #[majit_macros::elidable]
-pub(crate) fn format_wtf8_repr(s: &Wtf8) -> String {
+pub fn format_wtf8_repr(s: &Wtf8) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     let quote = if s.as_bytes().contains(&b'\'') && !s.as_bytes().contains(&b'"') {
         b'"'

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1132,6 +1132,16 @@ impl PyError {
         }
     }
 
+    /// The `errno` and `strerror` a failed `std::io` call reports as, the pair
+    /// `pymain_run_file_obj` names an unopenable script with.  The error's own
+    /// `Display` gives the Win32 failure in the language the OS is localised
+    /// to; `strerror` answers from the C runtime's table instead, so the text
+    /// is the same on every host.
+    pub fn io_errno_strerror(e: &std::io::Error) -> (i32, String) {
+        let errno = crate::builtins::io_error_posix_errno(e, 0);
+        (errno, Self::clean_strerror(errno))
+    }
+
     /// `error.py:_wrap_oserror2` — build the OSError a failed syscall raises:
     /// `args = (errno, strerror)`, the errno-specific subclass (`ERRNO_MAP`),
     /// the clean strerror, and the `.errno` / `.strerror` / `.filename` slots.

--- a/pyre/pyre-interpreter/src/module/_winapi/host.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/host.rs
@@ -233,9 +233,12 @@ pub fn CreateJunction(src_path: PyObjectRef, dst_path: PyObjectRef) -> Result<()
     )?;
     let src = std::ffi::OsString::from_wide(src.as_slice());
     let dst = std::ffi::OsString::from_wide(dst.as_slice());
-    let _blocked = crate::module::thread::before_external_block();
-    host_winapi::create_junction(std::path::Path::new(&src), std::path::Path::new(&dst))
-        .map_err(super::win32_err)
+    // Scoped to the call alone, as `releasegil=True` is — see `CreateFile`.
+    let result = {
+        let _blocked = crate::module::thread::before_external_block();
+        host_winapi::create_junction(std::path::Path::new(&src), std::path::Path::new(&dst))
+    };
+    result.map_err(super::win32_err)
 }
 
 /// `_winapi.CopyFile2(existing_file_name, new_file_name, flags,
@@ -257,8 +260,11 @@ pub fn CopyFile2(
     let _ = progress_routine;
     let existing = wide(existing_file_name, WideArg::Unnamed)?;
     let new = wide(new_file_name, WideArg::Unnamed)?;
-    let _blocked = crate::module::thread::before_external_block();
-    host_winapi::copy_file2(&existing, &new, flags).map_err(super::win32_err)
+    let result = {
+        let _blocked = crate::module::thread::before_external_block();
+        host_winapi::copy_file2(&existing, &new, flags)
+    };
+    result.map_err(super::win32_err)
 }
 
 // ── processes ──
@@ -437,10 +443,11 @@ pub fn WaitForMultipleObjects(
             handles.len()
         )));
     }
-    let _blocked = crate::module::thread::before_external_block();
-    host_winapi::wait_for_multiple_objects(&handles, wait_flag != 0, milliseconds)
-        .map(i64::from)
-        .map_err(super::win32_err)
+    let result = {
+        let _blocked = crate::module::thread::before_external_block();
+        host_winapi::wait_for_multiple_objects(&handles, wait_flag != 0, milliseconds)
+    };
+    result.map(i64::from).map_err(super::win32_err)
 }
 
 /// `_winapi.BatchedWaitForMultipleObjects(handle_seq, wait_all, milliseconds)`
@@ -520,16 +527,25 @@ pub fn CreateFile(
         handle_w(template_file, at(7))?,
     );
     let file_name = wide(file_name, WideArg::Unnamed)?;
-    let _blocked = crate::module::thread::before_external_block();
-    host_winapi::create_file_w(
-        &file_name,
-        desired_access,
-        share_mode,
-        creation_disposition,
-        flags_and_attributes,
-    )
-    .map(w_handle)
-    .map_err(super::win32_err)
+    // `llexternal(..., releasegil=True)` releases around the C call alone and
+    // is back inside before the caller's next RPython instruction, so nothing
+    // that allocates or raises runs outside.  The guard has to be scoped the
+    // same way: `w_handle` allocates the answer, and a thread that allocates
+    // while it is out of the RUNNING census can have it collected under it —
+    // `_winapi.CreateFile` then answers 0, and the `SetNamedPipeHandleState`
+    // that `multiprocessing.connection.PipeClient` runs next reports
+    // `ERROR_INVALID_HANDLE`.
+    let result = {
+        let _blocked = crate::module::thread::before_external_block();
+        host_winapi::create_file_w(
+            &file_name,
+            desired_access,
+            share_mode,
+            creation_disposition,
+            flags_and_attributes,
+        )
+    };
+    result.map(w_handle).map_err(super::win32_err)
 }
 
 /// `_winapi.CreateNamedPipe(name, open_mode, pipe_mode, max_instances,
@@ -596,8 +612,11 @@ pub fn SetNamedPipeHandleState(
 #[crate::pyre_function]
 pub fn WaitNamedPipe(name: PyObjectRef, timeout: PyCUInt) -> Result<(), crate::PyError> {
     let name = wide(name, WideArg::Unnamed)?;
-    let _blocked = crate::module::thread::before_external_block();
-    host_winapi::wait_named_pipe_w(&name, timeout).map_err(super::win32_err)
+    let result = {
+        let _blocked = crate::module::thread::before_external_block();
+        host_winapi::wait_named_pipe_w(&name, timeout)
+    };
+    result.map_err(super::win32_err)
 }
 
 // ── the asynchronous half, which a sandbox build leaves out ──

--- a/pyre/pyre-interpreter/src/module/_winapi/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/mod.rs
@@ -632,17 +632,27 @@ crate::py_module! {
             // whose default `releasegil='auto'` runs the native call between
             // the rffi around-handlers.  In particular, an infinite wait must
             // let the Python thread which will signal the handle run.
-            let result = {
+            // The failure code is read inside the released region, which is
+            // what `save_err=rffi.RFFI_SAVE_LASTERROR` does — reacquiring goes
+            // through `mutex2_lock_timeout`, whose timed wait leaves
+            // `ERROR_TIMEOUT` behind on a poll that expired.
+            let (result, error) = {
                 let _blocked = crate::module::thread::before_external_block();
-                unsafe {
+                let result = unsafe {
                     windows_sys::Win32::System::Threading::WaitForSingleObject(
                         handle,
                         milliseconds,
                     )
-                }
+                };
+                let error = if result == windows_sys::Win32::Foundation::WAIT_FAILED {
+                    unsafe { windows_sys::Win32::Foundation::GetLastError() }
+                } else {
+                    0
+                };
+                (result, error)
             };
             if result == windows_sys::Win32::Foundation::WAIT_FAILED {
-                return Err(last_os_error());
+                return Err(win32_code(error));
             }
             Ok(i64::from(result))
         }

--- a/pyre/pyre-interpreter/src/module/_winapi/overlapped.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/overlapped.rs
@@ -357,8 +357,14 @@ pub fn connect_named_pipe(
     use_overlapped: bool,
 ) -> Result<PyObjectRef, crate::PyError> {
     if !use_overlapped {
-        let _blocked = crate::module::thread::before_external_block();
-        host_winapi::connect_named_pipe(handle).map_err(win32_err)?;
+        // Scoped to the call alone, as `releasegil=True` is: raising and
+        // building the answer both allocate, and an allocation made outside
+        // the RUNNING census can be collected under the thread that made it.
+        let result = {
+            let _blocked = crate::module::thread::before_external_block();
+            host_winapi::connect_named_pipe(handle)
+        };
+        result.map_err(win32_err)?;
         return Ok(pyre_object::w_none());
     }
     let backend = new_native(handle)?;
@@ -398,8 +404,9 @@ pub fn read_file(
     if !use_overlapped {
         let result = {
             let _blocked = crate::module::thread::before_external_block();
-            host_winapi::read_file(handle, size).map_err(win32_err)?
-        };
+            host_winapi::read_file(handle, size)
+        }
+        .map_err(win32_err)?;
         return Ok(pyre_object::w_tuple_new(vec![
             pyre_object::bytesobject::w_bytes_from_bytes(&result.data),
             pyre_object::w_int_new(i64::from(result.error)),
@@ -452,8 +459,9 @@ pub fn write_file(
     if !use_overlapped {
         let result = {
             let _blocked = crate::module::thread::before_external_block();
-            host_winapi::write_file(handle, data).map_err(win32_err)?
-        };
+            host_winapi::write_file(handle, data)
+        }
+        .map_err(win32_err)?;
         return Ok(pyre_object::w_tuple_new(vec![
             pyre_object::w_int_new(i64::from(result.written)),
             pyre_object::w_int_new(i64::from(result.error)),

--- a/pyre/pyre-interpreter/src/module/_winapi/overlapped.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/overlapped.rs
@@ -146,21 +146,28 @@ fn overlapped_get_result(args: &[PyObjectRef]) -> crate::PyResult {
         (state.handle, std::ptr::addr_of!(state.overlapped))
     };
     let mut transferred: u32 = 0;
-    let completed = {
+    // Read inside the released region, which is what
+    // `llexternal(..., save_err=rffi.RFFI_SAVE_LASTERROR)` does: it saves
+    // `GetLastError()` between the call and the reacquire, and callers read
+    // the saved copy through `rwin32.GetLastError_saved`.  Taking the GIL back
+    // goes through `mutex2_lock_timeout`, whose timed condition wait leaves
+    // `ERROR_TIMEOUT` behind on every poll that expires, so a value read after
+    // the guard names that wait rather than this call.
+    let error = {
         let _blocked = crate::module::thread::before_external_block();
-        unsafe {
+        let completed = unsafe {
             windows_sys::Win32::System::IO::GetOverlappedResult(
                 handle,
                 overlapped,
                 &mut transferred,
                 i32::from(wait),
             )
+        };
+        if completed == 0 {
+            unsafe { windows_sys::Win32::Foundation::GetLastError() }
+        } else {
+            0
         }
-    };
-    let error = if completed == 0 {
-        unsafe { windows_sys::Win32::Foundation::GetLastError() }
-    } else {
-        0
     };
     let mut state = record.lock();
     match error {
@@ -212,15 +219,25 @@ fn overlapped_cancel(args: &[PyObjectRef]) -> crate::PyResult {
     if !state.pending {
         return Ok(pyre_object::w_none());
     }
-    let cancelled = {
+    // Read inside the released region — see `overlapped_get_result` for the
+    // `save_err=rffi.RFFI_SAVE_LASTERROR` ordering this follows.  `CancelIoEx`
+    // has one documented failure, `ERROR_NOT_FOUND`; a value read after the
+    // guard reports `ERROR_TIMEOUT` from the reacquire's timed wait instead,
+    // and `multiprocessing.connection.wait`'s `finally` turns that into an
+    // `OSError` that kills the pool's `_handle_workers` thread.
+    let (cancelled, error) = {
         let _blocked = crate::module::thread::before_external_block();
-        unsafe { windows_sys::Win32::System::IO::CancelIoEx(state.handle, &state.overlapped) }
+        let cancelled =
+            unsafe { windows_sys::Win32::System::IO::CancelIoEx(state.handle, &state.overlapped) };
+        let error = if cancelled == 0 {
+            unsafe { windows_sys::Win32::Foundation::GetLastError() }
+        } else {
+            0
+        };
+        (cancelled, error)
     };
-    if cancelled == 0 {
-        let error = unsafe { windows_sys::Win32::Foundation::GetLastError() };
-        if error != ERROR_NOT_FOUND {
-            return Err(super::win32_code(error));
-        }
+    if cancelled == 0 && error != ERROR_NOT_FOUND {
+        return Err(super::win32_code(error));
     }
     Ok(pyre_object::w_none())
 }

--- a/pyre/pyre-interpreter/src/module/fcntl/interp_fcntl.rs
+++ b/pyre/pyre-interpreter/src/module/fcntl/interp_fcntl.rs
@@ -428,18 +428,22 @@ fn arg_readbuf(
 /// failure.
 #[cfg(all(unix, feature = "host_env"))]
 fn ioctl_ptr(fd: i32, request: libc::c_ulong, ptr: *mut u8) -> Result<i32, crate::PyError> {
-    let ret = {
+    // The errno is read inside the released region, as
+    // `llexternal(..., save_err=rffi.RFFI_SAVE_ERRNO)` does: retaking the GIL
+    // goes through `mutex2_lock_timeout`, whose timed wait is a syscall of its
+    // own and overwrites what this call left behind.
+    let result = {
         let _blocked = crate::module::thread::before_external_block();
-        unsafe { libc::ioctl(fd, request, ptr as *mut libc::c_void) }
+        let ret = unsafe { libc::ioctl(fd, request, ptr as *mut libc::c_void) };
+        if ret < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(ret)
+        }
     };
-    if ret < 0 {
-        let e = std::io::Error::last_os_error();
-        return Err(crate::PyError::os_error_with_errno(
-            e.raw_os_error().unwrap_or(0),
-            format!("ioctl: {e}"),
-        ));
-    }
-    Ok(ret)
+    result.map_err(|e| {
+        crate::PyError::os_error_with_errno(e.raw_os_error().unwrap_or(0), format!("ioctl: {e}"))
+    })
 }
 
 /// A staging buffer holding `arg` followed by the guard, or `None` when `arg`

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -1247,12 +1247,17 @@ mod win_nt {
             return Ok(pyre_object::w_bool_from(false));
         };
         // Both arms open handles and query the volume, which blocks while a
-        // network name answers.
-        let _blocked = crate::module::thread::before_external_block();
-        let result = if path.as_fd != -1 {
-            host_nt::test_file_type_by_handle(host_nt::handle_from_fd(path.as_fd), tested, true)
-        } else {
-            tested_wide(&path).is_some_and(|wide| host_nt::test_file_type_by_name(&wide, tested))
+        // network name answers.  The guard covers the calls alone, the way
+        // `releasegil=True` does: building the answer allocates, and an
+        // allocation made outside the RUNNING census can be collected under
+        // the thread that made it.
+        let result = {
+            let _blocked = crate::module::thread::before_external_block();
+            if path.as_fd != -1 {
+                host_nt::test_file_type_by_handle(host_nt::handle_from_fd(path.as_fd), tested, true)
+            } else {
+                tested_wide(&path).is_some_and(|wide| host_nt::test_file_type_by_name(&wide, tested))
+            }
         };
         Ok(pyre_object::w_bool_from(result))
     }
@@ -1269,13 +1274,15 @@ mod win_nt {
         let Some(path) = path_or_fd_suppressing(obj, func)? else {
             return Ok(pyre_object::w_bool_from(false));
         };
-        let _blocked = crate::module::thread::before_external_block();
-        let result = if path.as_fd != -1 {
-            unsafe { rustpython_host_env::crt_fd::Borrowed::try_borrow_raw(path.as_fd) }
-                .is_ok_and(host_nt::fd_exists)
-        } else {
-            tested_wide(&path)
-                .is_some_and(|wide| host_nt::test_file_exists_by_name(&wide, follow_links))
+        let result = {
+            let _blocked = crate::module::thread::before_external_block();
+            if path.as_fd != -1 {
+                unsafe { rustpython_host_env::crt_fd::Borrowed::try_borrow_raw(path.as_fd) }
+                    .is_ok_and(host_nt::fd_exists)
+            } else {
+                tested_wide(&path)
+                    .is_some_and(|wide| host_nt::test_file_exists_by_name(&wide, follow_links))
+            }
         };
         Ok(pyre_object::w_bool_from(result))
     }
@@ -11783,9 +11790,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) -> Result<(), crate::PyErro
                 |args| {
                     let pid = crate::baseobjspace::c_int_w(args[0])?;
                     let sig = crate::baseobjspace::c_int_w(args[1])?;
-                    let _blocked = crate::module::thread::before_external_block();
-                    host_nt::kill(pid as u32, sig as u32)
-                        .map_err(|error| fs_err_with_filename(error, pyre_object::PY_NULL))?;
+                    let result = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_nt::kill(pid as u32, sig as u32)
+                    };
+                    result.map_err(|error| fs_err_with_filename(error, pyre_object::PY_NULL))?;
                     Ok(pyre_object::w_none())
                 },
                 2,

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -1994,17 +1994,19 @@ fn spawn_thread(
         })
         .map_err(|_| crate::PyError::runtime_error("can't start new thread"))?;
 
+    // The wait itself is what the guard covers; the error is raised after it,
+    // because raising allocates and an allocation made outside the RUNNING
+    // census can be collected under the thread that made it.
     let result = {
         let _blocked = before_external_block();
         loop {
             let value = started.word.load(Ordering::Acquire);
             if value == START_FAILED {
-                let message = started
+                break Err(started
                     .error
                     .get()
                     .cloned()
-                    .unwrap_or_else(|| "can't start new thread".to_string());
-                break Err(crate::PyError::runtime_error(message));
+                    .unwrap_or_else(|| "can't start new thread".to_string()));
             }
             if value != 0 {
                 break Ok(value as i64);
@@ -2013,7 +2015,7 @@ fn spawn_thread(
         }
     };
     drop(roots);
-    result
+    result.map_err(crate::PyError::runtime_error)
 }
 
 fn start_new_thread(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/module/winsound/mod.rs
+++ b/pyre/pyre-interpreter/src/module/winsound/mod.rs
@@ -218,14 +218,24 @@ crate::py_module! {
             Ok(())
         }
         fn MessageBeep(#[default(0i32)] type_: PyIndexCInt) -> Result<(), crate::PyError> {
-            let beeped = {
+            // Read inside the released region, as
+            // `save_err=rffi.RFFI_SAVE_LASTERROR` does: reacquiring goes
+            // through `mutex2_lock_timeout`, whose timed wait leaves
+            // `ERROR_TIMEOUT` behind on a poll that expired.
+            let (beeped, error) = {
                 let _blocked = crate::module::thread::before_external_block();
-                unsafe { windows_sys::Win32::System::Diagnostics::Debug::MessageBeep(type_ as u32) }
+                let beeped = unsafe {
+                    windows_sys::Win32::System::Diagnostics::Debug::MessageBeep(type_ as u32)
+                };
+                let error = if beeped == 0 {
+                    unsafe { windows_sys::Win32::Foundation::GetLastError() }
+                } else {
+                    0
+                };
+                (beeped, error)
             };
             if beeped == 0 {
-                return Err(win32_runtime_error(unsafe {
-                    windows_sys::Win32::Foundation::GetLastError()
-                }));
+                return Err(win32_runtime_error(error));
             }
             Ok(())
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -182,11 +182,6 @@ pub(crate) struct LatchedMultiFrameBlackhole {
     pub(crate) last_exc_value: i64,
     pub(crate) raising_exception: bool,
     pub(crate) mirror_stack: Option<MirrorStackImage>,
-    /// `ABORT_TOO_LONG` stops at an arbitrary post-step coordinate, so frame
-    /// 0's active operand stack must cross from the detached tracing snapshot
-    /// to the live red frame before the blackhole runs.  The vable-force path
-    /// stops at a call resume marker and retains its existing handoff.
-    pub(crate) publish_root_stack: bool,
     /// Which latch published this image — see the single-frame counterpart.
     pub(crate) origin: &'static str,
 }
@@ -585,7 +580,6 @@ pub(crate) fn latch_abort_blackhole<Sym: WalkSym>(
                 framestack,
                 last_exc_value,
                 raising_exception: false,
-                publish_root_stack: true,
                 // `ctx` is the innermost callee, so its ordinary vstack mirror
                 // names the wrong frame.  Reconstruct frame 0 from the paused
                 // caller image captured at the outermost inline push, exactly
@@ -4334,7 +4328,6 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
                             framestack,
                             last_exc_value,
                             raising_exception,
-                            publish_root_stack: true,
                             mirror_stack: capture_root_parent_resume_stack(ctx),
                             origin: "escape-flush",
                         });

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -3558,38 +3558,29 @@ fn try_adopt_multi_frame_blackhole(
         restore_links(&saved_links);
         return false;
     };
-    let mut root_stack = if latched.publish_root_stack {
-        // Same split as the single-frame arm: `WalkAbort` and `VableEscape`
-        // stop INSIDE an opcode, and for a root walk the snapshot array was
-        // never written there — it still holds the pre-walk stack (see
-        // `capture_frame_stack_from_mirror`).  Both multi-frame latches
-        // reconstruct frame 0 from the paused caller image
-        // (`capture_root_parent_resume_stack`) because their `ctx` is the
-        // innermost callee; a latch that could not build one leaves no mirror
-        // here, which declines the adopt and keeps the legacy replay.
-        // `ABORT_TOO_LONG` stops at an opcode boundary, where the snapshot
-        // array is the image RPython would copy.
-        let captured = if commit_leg == WalkEndCommitLeg::WalkAbort
-            || commit_leg == WalkEndCommitLeg::VableEscape
-        {
-            latched.mirror_stack.as_ref().and_then(|mirror| {
-                crate::state::capture_frame_stack_from_mirror(
-                    root_addr,
-                    mirror.py_pc,
-                    &mirror.slots,
-                )
-            })
-        } else {
-            crate::state::capture_frame_stack_for_publish(cf_addr, root_addr)
-        };
-        let Some(stack) = captured else {
-            mfdbg!("frame 0: active stack not capturable (leg={commit_leg:?})");
-            restore_links(&saved_links);
-            return false;
-        };
-        Some(stack)
+    // Same split as the single-frame arm: `WalkAbort` and `VableEscape`
+    // stop INSIDE an opcode, and for a root walk the snapshot array was
+    // never written there — it still holds the pre-walk stack (see
+    // `capture_frame_stack_from_mirror`).  Both multi-frame latches
+    // reconstruct frame 0 from the paused caller image
+    // (`capture_root_parent_resume_stack`) because their `ctx` is the
+    // innermost callee; a latch that could not build one leaves no mirror
+    // here, which declines the adopt and keeps the legacy replay.
+    // `ABORT_TOO_LONG` stops at an opcode boundary, where the snapshot
+    // array is the image RPython would copy.
+    let captured = if commit_leg == WalkEndCommitLeg::WalkAbort
+        || commit_leg == WalkEndCommitLeg::VableEscape
+    {
+        latched.mirror_stack.as_ref().and_then(|mirror| {
+            crate::state::capture_frame_stack_from_mirror(root_addr, mirror.py_pc, &mirror.slots)
+        })
     } else {
-        None
+        crate::state::capture_frame_stack_for_publish(cf_addr, root_addr)
+    };
+    let Some(mut root_stack) = captured else {
+        mfdbg!("frame 0: active stack not capturable (leg={commit_leg:?})");
+        restore_links(&saved_links);
+        return false;
     };
     // Taking the latch removes it from the TLS extra-root walker.  Root every
     // MIFrame Ref bank and the pending exception across root-locals boxing,
@@ -3625,9 +3616,7 @@ fn try_adopt_multi_frame_blackhole(
     unsafe {
         majit_gc::shadow_stack::push_resume_ref_roots(image_ref_roots.as_mut_slice());
         majit_gc::shadow_stack::push_resume_ref_roots(locals_undo.as_mut_slice());
-        if let Some(stack) = root_stack.as_mut() {
-            majit_gc::shadow_stack::push_resume_ref_roots(stack.roots_mut());
-        }
+        majit_gc::shadow_stack::push_resume_ref_roots(root_stack.roots_mut());
     }
     if !crate::state::write_back_outer_locals(ctx, root_addr) {
         crate::state::restore_frame_locals(root_addr, &locals_undo);
@@ -3643,9 +3632,7 @@ fn try_adopt_multi_frame_blackhole(
     if let Some(index) = image_exception_root {
         latched.last_exc_value = image_ref_roots[index];
     }
-    if let Some(stack) = root_stack.as_ref()
-        && !crate::state::publish_captured_frame_stack(root_addr, stack)
-    {
+    if !crate::state::publish_captured_frame_stack(root_addr, &root_stack) {
         crate::state::restore_frame_locals(root_addr, &locals_undo);
         majit_gc::shadow_stack::pop_resume_ref_roots_to(undo_depth);
         restore_links(&saved_links);

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -715,6 +715,18 @@ fn configure_root_only_jit_stats() {
         // can concurrently read or mutate the process environment.
         unsafe { std::env::set_var("PYRE_MAJIT_STATS_ANCESTOR", "1") };
     }
+    if !print_here {
+        // `majit_trace::Logger` prints its own `=== JIT Statistics ===` block
+        // from `Drop`, and it reads the environment rather than this policy.
+        // Clearing what turns it on is how the policy reaches it: a descendant
+        // then writes nothing of pyre's own to stderr, which is what
+        // `test_large_pool` asserts of the script it runs through
+        // `assert_python_ok`.
+        unsafe {
+            std::env::remove_var("MAJIT_STATS");
+            std::env::remove_var("MAJIT_LOG");
+        }
+    }
 }
 
 /// Diagnostics that have to read the descr universe *after* it has finished

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -2414,7 +2414,7 @@ fn report_or_end_on_main_error(
 
 enum MainProgram<'a> {
     Source(Box<dyn FnOnce() -> String + 'a>, Mode),
-    Bytecode(pyre_object::PyObjectRef),
+    Bytecode(Box<dyn FnOnce() -> Result<pyre_object::PyObjectRef, pyre_interpreter::PyError> + 'a>),
 }
 
 fn eval_program_in_main(
@@ -2506,7 +2506,15 @@ fn eval_program_in_main(
     // replaced, and the failure still finalizes on its way out.
     let mut source = None;
     let frame = match program {
-        MainProgram::Bytecode(code) => {
+        MainProgram::Bytecode(load_bytecode) => {
+            let code = match load_bytecode() {
+                Ok(code) => code,
+                Err(error) => {
+                    let inspect = prompt_requested(run_code);
+                    report_or_end_on_main_error(error, inspect, canonical, ec_ptr);
+                    return finish_or_inspect(inspect, session_context, canonical, main_module);
+                }
+            };
             PyFrame::new_with_context_and_globals_obj(code, execution_context, canonical)
         }
         MainProgram::Source(read_source, mode) => {
@@ -2697,27 +2705,22 @@ fn run_script_path(
             let main_file = absolute_script_path(filename);
             let filename = main_file.as_deref().unwrap_or(filename);
             let program = if script_path_is_pyc(filename) {
-                let bytes = match importing::read_source_bytes(Path::new(filename)) {
-                    Ok(bytes) => bytes,
-                    Err(e) => {
-                        eprintln!("{binary_name}: cannot open '{filename}': {e}");
-                        end_after_startup_failure(canonical, ec_ptr, 2);
-                    }
-                };
-                let code = match importing::load_pyc_script(&bytes) {
-                    Ok(code) => code,
-                    Err(e) => {
-                        let inspect = prompt_requested(run_code);
-                        report_or_end_on_main_error(e, inspect, canonical, ec_ptr);
-                        return finish_or_inspect(
-                            inspect,
-                            execution_context,
-                            canonical,
-                            main_module,
-                        );
-                    }
-                };
-                MainProgram::Bytecode(code)
+                // Deferred for the reason the source read below is, and for one
+                // more that is this arm's alone: the unmarshalled code object is
+                // a GC object living in a Rust local, and `import_site` runs
+                // Python between here and the frame that roots it.  A collection
+                // in that window reclaims the code, and the module the script
+                // then builds carries references into freed storage.
+                MainProgram::Bytecode(Box::new(move || {
+                    let bytes = match importing::read_source_bytes(Path::new(filename)) {
+                        Ok(bytes) => bytes,
+                        Err(e) => {
+                            eprintln!("{binary_name}: cannot open '{filename}': {e}");
+                            end_after_startup_failure(canonical, ec_ptr, 2);
+                        }
+                    };
+                    importing::load_pyc_script(&bytes)
+                }))
             } else {
                 MainProgram::Source(
                     // The resolved path rather than the argv spelling: the read is

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -2611,6 +2611,28 @@ fn eval_program_in_main(
     finish_or_inspect(inspect, session_context, canonical, main_module)
 }
 
+/// Report a script that could not be opened and end the run.
+///
+/// `pymain_run_file_obj` writes `"%S: can't open file %R: [Errno %d] %s"` --
+/// the path's `repr`, then the C `errno` and `strerror` for the failure rather
+/// than the message the error itself displays, which on Windows names the
+/// Win32 failure in the language the OS is localised to.  It answers
+/// `EXIT_STATUS_ERROR`, which is 2 -- the status a shell reads as "the program
+/// was never run", distinct from the 1 a program that ran and failed exits
+/// with.
+fn end_on_unopenable_script(
+    binary_name: &str,
+    path: &str,
+    error: &std::io::Error,
+    canonical: pyre_object::PyObjectRef,
+    ec_ptr: *const PyExecutionContext,
+) -> ! {
+    let path = pyre_interpreter::display::format_wtf8_repr(rustpython_wtf8::Wtf8::new(path));
+    let (errno, strerror) = pyre_interpreter::PyError::io_errno_strerror(error);
+    eprintln!("{binary_name}: can't open file {path}: [Errno {errno}] {strerror}");
+    end_after_startup_failure(canonical, ec_ptr, 2);
+}
+
 fn read_script_source(
     path: &str,
     binary_name: &str,
@@ -2633,14 +2655,7 @@ fn read_script_source(
                 end_after_startup_failure(canonical, ec_ptr, 1);
             }
         },
-        // `pymain_run_file` reports an unopenable script with
-        // `EXIT_STATUS_ERROR`, which is 2 -- the status a shell reads as "the
-        // program was never run", distinct from the 1 a program that ran and
-        // failed exits with.
-        Err(e) => {
-            eprintln!("{binary_name}: cannot open '{path}': {e}");
-            end_after_startup_failure(canonical, ec_ptr, 2);
-        }
+        Err(e) => end_on_unopenable_script(binary_name, path, &e, canonical, ec_ptr),
     }
 }
 
@@ -2715,8 +2730,7 @@ fn run_script_path(
                     let bytes = match importing::read_source_bytes(Path::new(filename)) {
                         Ok(bytes) => bytes,
                         Err(e) => {
-                            eprintln!("{binary_name}: cannot open '{filename}': {e}");
-                            end_after_startup_failure(canonical, ec_ptr, 2);
+                            end_on_unopenable_script(binary_name, filename, &e, canonical, ec_ptr)
                         }
                     };
                     importing::load_pyc_script(&bytes)


### PR DESCRIPTION
`test_multiprocessing_spawn` hung at the 900s timeout on Windows and `test_multiprocessing_main_handling` crashed. Four distinct defects, each with a standalone repro.

### 1. A stale `GetLastError()` read after the guard dropped

`BlockingGuard`'s `Drop` reacquires through `mutex2_lock_timeout` → `Condvar::wait_timeout` → `SleepConditionVariableSRW`, which leaves `ERROR_TIMEOUT` behind on every poll that expires. `Overlapped.cancel()` compared that against `ERROR_NOT_FOUND` and raised `OSError [WinError 1460]` out of `multiprocessing.connection.wait`'s `finally`, killing the pool's `_handle_workers` thread.

The upstream shape is `llexternal(..., save_err=rffi.RFFI_SAVE_LASTERROR)`: the code is read **inside** the released region and callers read the saved copy through `rwin32.GetLastError_saved`. Five sites now do. **900s hang → 441 tests in 172s.**

### 2. A GC allocation made outside the RUNNING census

`_winapi.CreateFile` held a *function-scope* guard, so `w_handle`'s `w_int_new` ran with the GIL released; a concurrent collection reclaimed the answer and the call returned **0**. `multiprocessing.connection.PipeClient`'s next `SetNamedPipeHandleState` then reported `ERROR_INVALID_HANDLE`.

Repro: 8 threads acquiring a `SyncManager` `Condition`, ~5% of rounds. The probe printed `WinError 6 thread=Thread-7 h=0, born=Thread-7/CreateFile, closed_after_birth=no`, which named the birth rather than a double close. A scan over every `before_external_block()` scope found 12 that reached past the FFI call; all are now scoped to it. **600 rounds clean.**

### 3. A `.pyc` main the GC reclaimed before it ran

`run_script_path` unmarshalled the code object *before* `seed_main_loader` + `import_site` and carried it in a Rust local. Minimal repro, no multiprocessing — a script appending 200000 tuples then calling `gc.collect()`: `-E min2.py` clean 3/3, `-E min2.pyc` panics `GC BUG: invalid major child ... site=major_custom_trace` 3/3, and **`-E -S min2.pyc` clean 5/5** — `-S` removes the window, which is the decisive evidence. The source arm already deferred its read and compile for exactly this ordering; the bytecode arm now does too. `test_multiprocessing_main_handling` **CRASH → PASS**.

### 4. `Logger`'s own `Drop` print bypassed the root-only stats policy

`maybe_print_jit_stats` honours `PYRE_MAJIT_STATS_ROOT_ONLY`; `majit_trace::Logger` prints `=== JIT Statistics ===` gated on the environment alone, so a grandchild wrote to stderr and `test_large_pool`'s `assert_python_ok` failed. `configure_root_only_jit_stats` now clears `MAJIT_STATS`/`MAJIT_LOG` where the policy says not to print.

### Also here

- **The launcher's open-failure message.** It wrote `"{binary}: cannot open '{path}': {error}"`, ending in the error's own `Display` — on Windows the Win32 message in the language the OS is localised to. `pymain_run_file_obj` writes `"%S: can't open file %R: [Errno %d] %s\n"`: the path's `repr`, then the C `errno` and `strerror`. Both call sites (the source read and the `.pyc` load) go through one helper now, and the output matches CPython byte for byte.
- **`publish_root_stack`**, a `pyre-jit-trace` latch field with two constructors that both passed `true`, is gone along with the `Option<FrameStack>` it gated.
- **Two `baseline.win32-AMD64.json` entries**, each with the reason spelled out: `test_multiprocessing_main_handling` PASS (13 spawn cases pass; `get_all_start_methods()` is `['spawn']` so the mixin skips 26 of 39), and `test_multiprocessing_spawn` FAIL (completes in ~170s rather than reaching the shared TIMEOUT, reporting four GC-model cases — PyPy 3.11 on the same host answers identically for three of them, and the fourth belongs to the deferred mmap export-count round).

### Gate

`check.py --backend dynasm` 517 passed; the 7 jit-stats reds are the documented host-local set — bracketed against `origin/main` built on the same box, which produces bit-identical counters, while CI's `windows-latest` leg is green at that commit. Not re-recorded. `extra_tests --gated-only` 143/143 on both backends. `parity_tests`: the one failure is `handle_fromlist_contract.py`, which fails on cpython and pypy too. `cargo test --all` RC=0, 205 result lines. wasm32 build RC=0. Citation check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014svTHUbS67NLQwtPQMuyH4