### PR TITLE
_wmi: port the WMI query module; deps: move the RustPython pin to 4bd9545

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "malachite-base"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b9d4679f346f85a8f466d0171478304dab8b0e944dd38086411ab5f6100a17"
+checksum = "17073d2b5f3fe81b6abec0efcbdb6933d7adbda942854095f87c2f82633eafa5"
 dependencies = [
  "hashbrown 0.16.1",
  "itertools 0.14.0",
@@ -2312,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "malachite-bigint"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5064cf3abe01ff3b80b0349936ebad6c52f7c793182d9c7992bf79ece18c0d22"
+checksum = "69c389baa355653795601ac65189e4ab21a1879fc1326a0244227f7757240edf"
 dependencies = [
  "malachite-base",
  "malachite-nz",
@@ -2325,9 +2325,9 @@ dependencies = [
 
 [[package]]
 name = "malachite-nz"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6821ab988221c35d421ba16c4f8dca101efe5ae1cbfa9831f1fdb1596c755e"
+checksum = "c2f37fc9ab5654d216d8ae22b57f0b8d9f1741ef160649d37ce1864a1e308993"
 dependencies = [
  "itertools 0.14.0",
  "libm",
@@ -2337,9 +2337,9 @@ dependencies = [
 
 [[package]]
 name = "malachite-q"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf7894cd9617e43ef5d9824633f7dfc1bffd0298880dd668f20bdffb7a6e8ea"
+checksum = "6542042c11f3d94433ed4262cf5e82eb43eff687fc5bf1fe1b4b5cde2215836e"
 dependencies = [
  "itertools 0.14.0",
  "libm",
@@ -3544,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "rustpython-codegen"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
+source = "git+https://github.com/RustPython/RustPython.git?rev=4bd95458385eb9eae031679f681564e167125c8f#4bd95458385eb9eae031679f681564e167125c8f"
 dependencies = [
  "bitflags 2.13.0",
  "indexmap",
@@ -3567,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
+source = "git+https://github.com/RustPython/RustPython.git?rev=4bd95458385eb9eae031679f681564e167125c8f#4bd95458385eb9eae031679f681564e167125c8f"
 dependencies = [
  "ascii",
  "bitflags 2.13.0",
@@ -3590,7 +3590,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
+source = "git+https://github.com/RustPython/RustPython.git?rev=4bd95458385eb9eae031679f681564e167125c8f#4bd95458385eb9eae031679f681564e167125c8f"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
@@ -3604,7 +3604,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
+source = "git+https://github.com/RustPython/RustPython.git?rev=4bd95458385eb9eae031679f681564e167125c8f#4bd95458385eb9eae031679f681564e167125c8f"
 dependencies = [
  "bitflags 2.13.0",
  "bitflagset",
@@ -3620,7 +3620,7 @@ dependencies = [
 [[package]]
 name = "rustpython-host_env"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
+source = "git+https://github.com/RustPython/RustPython.git?rev=4bd95458385eb9eae031679f681564e167125c8f#4bd95458385eb9eae031679f681564e167125c8f"
 dependencies = [
  "bitflags 2.13.0",
  "cc",
@@ -3654,7 +3654,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
+source = "git+https://github.com/RustPython/RustPython.git?rev=4bd95458385eb9eae031679f681564e167125c8f#4bd95458385eb9eae031679f681564e167125c8f"
 dependencies = [
  "hexf-parse",
  "is-macro",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "rustpython-sre_engine"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
+source = "git+https://github.com/RustPython/RustPython.git?rev=4bd95458385eb9eae031679f681564e167125c8f#4bd95458385eb9eae031679f681564e167125c8f"
 dependencies = [
  "bitflags 2.13.0",
  "num_enum",
@@ -3745,7 +3745,7 @@ dependencies = [
 [[package]]
 name = "rustpython-unicode"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
+source = "git+https://github.com/RustPython/RustPython.git?rev=4bd95458385eb9eae031679f681564e167125c8f#4bd95458385eb9eae031679f681564e167125c8f"
 dependencies = [
  "icu_casemap",
  "icu_locale",
@@ -3759,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "rustpython-wtf8"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=cb7acec87d4c3e1e7f43b74f228656127008f523#cb7acec87d4c3e1e7f43b74f228656127008f523"
+source = "git+https://github.com/RustPython/RustPython.git?rev=4bd95458385eb9eae031679f681564e167125c8f#4bd95458385eb9eae031679f681564e167125c8f"
 dependencies = [
  "ascii",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,16 +74,20 @@ pyrex = { version = "0.0.2", path = "pyre/pyrex" }
 # parity fixes from #8550 were merged.  `fix_code_filenames` needs `IndexMut`
 # to edit nested code constants in place, and `loads` relies on the #8552 hook
 # to preserve invalid code bytes, so this pin must not move below either.
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
-rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
-rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
-rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
+#
+# Moved up again for the console read-boundary fix from #8621, and now also
+# names `MarshalError::DataTooShort` / `EofObject` and `CFormatType::Bytes`,
+# which arrived with it.
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "4bd95458385eb9eae031679f681564e167125c8f" }
+rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "4bd95458385eb9eae031679f681564e167125c8f" }
+rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "4bd95458385eb9eae031679f681564e167125c8f" }
+rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "4bd95458385eb9eae031679f681564e167125c8f" }
 ruff-text-size = { package = "rustpython-ruff_text_size", git = "https://github.com/RustPython/ruff.git", tag = "0.15.19-rustpython" }
 num-complex = "0.4"
-rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
-rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
-rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
-sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "cb7acec87d4c3e1e7f43b74f228656127008f523" }
+rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "4bd95458385eb9eae031679f681564e167125c8f" }
+rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "4bd95458385eb9eae031679f681564e167125c8f" }
+rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "4bd95458385eb9eae031679f681564e167125c8f" }
+sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "4bd95458385eb9eae031679f681564e167125c8f" }
 
 # majit JIT framework
 majit = { version = "0.0.2", path = "majit/majit" }
@@ -105,7 +109,7 @@ majit-charon-reader = { version = "0.0.2", path = "majit/majit-charon-reader" }
 
 # shared dependencies
 parking_lot = "0.12"
-malachite-bigint = "0.10"
+malachite-bigint = "0.11"
 num-traits = "0.2"
 num-integer = "0.1"
 bit-set = "0.10"

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -1381,7 +1381,7 @@
       "dynasm": "PASS"
     },
     "test.test_wmi": {
-      "dynasm": "PASS"
+      "dynasm": "IMPORTERROR"
     },
     "test.test_wsgiref": {
       "dynasm": "PASS"

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -1381,7 +1381,7 @@
       "dynasm": "PASS"
     },
     "test.test_wmi": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_wsgiref": {
       "dynasm": "PASS"

--- a/pyre/cpython_tests/baseline.win32-AMD64.json
+++ b/pyre/cpython_tests/baseline.win32-AMD64.json
@@ -72,6 +72,10 @@
     "test.test_winreg": {
       "dynasm": "PASS",
       "reason": "Windows-only module: the shared IMPORTERROR is what a POSIX host sees for import winreg"
+    },
+    "test.test_wmi": {
+      "dynasm": "PASS",
+      "reason": "Windows-only module: _wmi reaches the local WMI service through COM and exists only on Windows. import_module('_wmi', required_on=['win']) re-raises instead of skipping on win32, so the module reports a result only where the extension is built"
     }
   },
   "stdlib_version": "3.14.6"

--- a/pyre/extra_tests/parity_tests/handle_fromlist_contract.py
+++ b/pyre/extra_tests/parity_tests/handle_fromlist_contract.py
@@ -23,6 +23,12 @@ for name, body in [
     ("a.py", "A = 1\n"),
     ("b.py", "B = 2\n"),
     ("c.py", "C = 3\n"),
+    # Written up front rather than beside the assertion that imports it: on
+    # Windows a directory's last-write time is not updated in time for the
+    # next stat of it, so the mtime-keyed `FileFinder` cache does not notice a
+    # file created after the package's finder was built and the submodule is
+    # not found at all.
+    ("d.py", "import nonexistent_module_xyz\n"),
 ]:
     with open(os.path.join(root, "hflpkg", name), "w") as f:
         f.write(body)
@@ -42,8 +48,6 @@ assert __import__("hflpkg", {}, {}, ["zzz"], 0).__name__ == "hflpkg"
 
 # A submodule whose own body raises ModuleNotFoundError for a *different* name
 # is a real failure, not a name the fromlist may skip.
-with open(os.path.join(root, "hflpkg", "d.py"), "w") as f:
-    f.write("import nonexistent_module_xyz\n")
 try:
     __import__("hflpkg", {}, {}, ["d"], 0)
 except ModuleNotFoundError as exc:

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -128,10 +128,13 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Environment",
     "Win32_System_IO",
     "Win32_System_LibraryLoader",
+    "Win32_System_Ole",
     "Win32_System_Pipes",
     "Win32_System_Rpc",
     "Win32_System_SystemInformation",
     "Win32_System_Threading",
+    "Win32_System_Variant",
+    "Win32_System_Wmi",
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -688,6 +688,10 @@ pub fn install_builtin_modules() {
     // `_winapi` import even though the Windows build installs `posix`.
     #[cfg(windows)]
     pyre_install_module!(_winapi);
+    // CPython's private `_wmi` module reaches the local WMI service through
+    // COM and is therefore present only on an unsandboxed Windows host.
+    #[cfg(all(windows, not(feature = "sandbox")))]
+    pyre_install_module!(_wmi);
     // PyPy's `lib_pypy/_overlapped.py`: asyncio's proactor backend owns one
     // OVERLAPPED record per operation and reaches the Win32/WinSock calls
     // through this Windows-only builtin.

--- a/pyre/pyre-interpreter/src/module/_wmi/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_wmi/mod.rs
@@ -1,0 +1,672 @@
+//! `_wmi` — CPython's private Windows Management Instrumentation query door.
+//!
+//! PyPy has no `_wmi` module.  This explicitly requested scope extension is a
+//! structural port of CPython 3.14's `PC/_wmimodule.cpp` (`_query_thread`,
+//! `wait_event`, and `_wmi_exec_query_impl`): each call owns one pipe, two
+//! staged events and one apartment-threaded COM worker.  In particular, the
+//! worker is not replaced with PowerShell or a process-global COM connection;
+//! those would change the timeout, isolation and concurrent-call semantics.
+
+use std::ffi::c_void;
+use std::ptr::{null, null_mut};
+
+use pyre_object::{PY_NULL, PyObjectRef};
+use windows_sys::Win32::Foundation::{
+    CloseHandle, E_FAIL, ERROR_BROKEN_PIPE, ERROR_MORE_DATA, ERROR_NOT_ENOUGH_MEMORY, GetLastError,
+    HANDLE, RPC_E_TOO_LATE, SysAllocStringLen, SysFreeString, SysStringLen, WAIT_OBJECT_0,
+    WAIT_TIMEOUT,
+};
+use windows_sys::Win32::Storage::FileSystem::{ReadFile, WriteFile};
+use windows_sys::Win32::System::Com::{
+    CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED, CoCreateInstance, CoInitializeEx,
+    CoInitializeSecurity, CoSetProxyBlanket, CoUninitialize, EOAC_NONE, RPC_C_AUTHN_LEVEL_CALL,
+    RPC_C_AUTHN_LEVEL_DEFAULT, RPC_C_IMP_LEVEL_IMPERSONATE,
+};
+use windows_sys::Win32::System::Pipes::CreatePipe;
+use windows_sys::Win32::System::Rpc::{RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE};
+use windows_sys::Win32::System::Threading::{
+    CreateEventW, CreateThread, GetExitCodeThread, SetEvent, WaitForSingleObject,
+};
+use windows_sys::Win32::System::Variant::{VARIANT, VariantClear, VariantToString};
+use windows_sys::Win32::System::Wmi::{
+    WBEM_FLAG_FORWARD_ONLY, WBEM_FLAG_RETURN_IMMEDIATELY, WBEM_FLAVOR_MASK_ORIGIN,
+    WBEM_FLAVOR_ORIGIN_SYSTEM, WBEM_INFINITE, WBEM_S_FALSE, WBEM_S_NO_MORE_DATA,
+};
+use windows_sys::core::{BSTR, GUID, HRESULT, IUnknown_Vtbl};
+
+const RESULT_UNITS: usize = 8192;
+const CLSID_WBEM_LOCATOR: GUID = GUID::from_u128(0x4590f811_1d3a_11d0_891f_00aa004b2e24);
+const IID_IWBEM_LOCATOR: GUID = GUID::from_u128(0xdc12a687_737f_11cf_884d_00aa004b2e24);
+
+// `windows-sys` deliberately omits COM interface wrappers.  These are the
+// literal vtable prefixes from wbemidl.h, ending at the last method this module
+// calls.  Unused entries stay pointer-sized slots so the called method keeps
+// its header-defined index without pulling the enormous generated `windows`
+// crate through Charon's LLBC extraction.
+#[repr(C)]
+#[allow(non_snake_case)]
+struct IWbemLocatorVtable {
+    base: IUnknown_Vtbl,
+    ConnectServer: unsafe extern "system" fn(
+        this: *mut c_void,
+        network_resource: BSTR,
+        user: BSTR,
+        password: BSTR,
+        locale: BSTR,
+        security_flags: i32,
+        authority: BSTR,
+        context: *mut c_void,
+        services: *mut *mut c_void,
+    ) -> HRESULT,
+}
+
+#[repr(C)]
+#[allow(non_snake_case)]
+struct IWbemServicesVtable {
+    base: IUnknown_Vtbl,
+    unused_before_exec_query: [usize; 17],
+    ExecQuery: unsafe extern "system" fn(
+        this: *mut c_void,
+        language: BSTR,
+        query: BSTR,
+        flags: i32,
+        context: *mut c_void,
+        enumerator: *mut *mut c_void,
+    ) -> HRESULT,
+}
+
+#[repr(C)]
+#[allow(non_snake_case)]
+struct IEnumWbemClassObjectVtable {
+    base: IUnknown_Vtbl,
+    Reset: usize,
+    Next: unsafe extern "system" fn(
+        this: *mut c_void,
+        timeout: i32,
+        count: u32,
+        values: *mut *mut c_void,
+        returned: *mut u32,
+    ) -> HRESULT,
+}
+
+#[repr(C)]
+#[allow(non_snake_case)]
+struct IWbemClassObjectVtable {
+    base: IUnknown_Vtbl,
+    unused_before_begin_enumeration: [usize; 5],
+    BeginEnumeration: unsafe extern "system" fn(this: *mut c_void, flags: i32) -> HRESULT,
+    Next: unsafe extern "system" fn(
+        this: *mut c_void,
+        flags: i32,
+        name: *mut BSTR,
+        value: *mut VARIANT,
+        value_type: *mut i32,
+        flavor: *mut i32,
+    ) -> HRESULT,
+    EndEnumeration: unsafe extern "system" fn(this: *mut c_void) -> HRESULT,
+}
+
+/// One owned COM interface pointer.  Every WMI interface inherits IUnknown,
+/// so the first vtable prefix owns the common Release entry.
+struct ComPtr(*mut c_void);
+
+impl ComPtr {
+    fn new(raw: *mut c_void) -> Result<Self, HRESULT> {
+        if raw.is_null() {
+            Err(E_FAIL)
+        } else {
+            Ok(Self(raw))
+        }
+    }
+
+    unsafe fn vtable<T>(&self) -> &T {
+        unsafe { &**(self.0.cast::<*const T>()) }
+    }
+}
+
+impl Drop for ComPtr {
+    fn drop(&mut self) {
+        unsafe {
+            let vtable = &**(self.0.cast::<*const IUnknown_Vtbl>());
+            (vtable.Release)(self.0);
+        }
+    }
+}
+
+/// BSTR ownership for the query/constants and property names returned by WMI.
+struct OwnedBstr(BSTR);
+
+impl OwnedBstr {
+    fn from_wide(units: &[u16]) -> Result<Self, HRESULT> {
+        let len =
+            u32::try_from(units.len()).map_err(|_| hresult_from_win32(ERROR_NOT_ENOUGH_MEMORY))?;
+        let value = unsafe { SysAllocStringLen(units.as_ptr(), len) };
+        if value.is_null() {
+            Err(hresult_from_win32(ERROR_NOT_ENOUGH_MEMORY))
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    fn from_str(value: &str) -> Result<Self, HRESULT> {
+        Self::from_wide(&value.encode_utf16().collect::<Vec<_>>())
+    }
+
+    fn empty() -> Self {
+        Self(null())
+    }
+
+    fn as_slice(&self) -> &[u16] {
+        if self.0.is_null() {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(self.0, SysStringLen(self.0) as usize) }
+        }
+    }
+}
+
+impl Drop for OwnedBstr {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { SysFreeString(self.0) };
+        }
+    }
+}
+
+/// The data CPython's `_query_data` hands to `_query_thread`.
+///
+/// The query is owned rather than borrowed.  This is the Rust spelling of
+/// gh-125315's immediate `SysAllocString(data.query)`: once the caller's staged
+/// wait gives up, a detached worker must not retain a pointer into a Python
+/// string that the caller can release.
+struct QueryData {
+    query: Vec<u16>,
+    write_pipe: HANDLE,
+    init_event: HANDLE,
+    connect_event: HANDLE,
+}
+
+/// `HRESULT_FROM_WIN32`, used where the C++ worker promotes `GetLastError()` to
+/// an HRESULT before returning it as the thread exit code.
+fn hresult_from_win32(code: u32) -> HRESULT {
+    if code == 0 {
+        0
+    } else {
+        ((code & 0xffff) | 0x8007_0000) as i32
+    }
+}
+
+fn signal_event(event: HANDLE) -> Result<(), HRESULT> {
+    if unsafe { SetEvent(event) } == 0 {
+        Err(hresult_from_win32(unsafe { GetLastError() }))
+    } else {
+        Ok(())
+    }
+}
+
+fn write_wide(pipe: HANDLE, units: &[u16]) -> Result<(), HRESULT> {
+    let mut written = 0;
+    let bytes = units.len().saturating_mul(size_of::<u16>());
+    let bytes = u32::try_from(bytes).map_err(|_| hresult_from_win32(ERROR_MORE_DATA))?;
+    if unsafe {
+        WriteFile(
+            pipe,
+            units.as_ptr().cast::<u8>(),
+            bytes,
+            &mut written,
+            null_mut(),
+        )
+    } == 0
+    {
+        Err(hresult_from_win32(unsafe { GetLastError() }))
+    } else {
+        Ok(())
+    }
+}
+
+/// Balances every successful `CoInitializeEx`, including `S_FALSE`.
+struct ComApartment;
+
+impl Drop for ComApartment {
+    fn drop(&mut self) {
+        unsafe { CoUninitialize() };
+    }
+}
+
+/// The body of CPython's `_query_thread`; each owned interface is released
+/// before the apartment guard calls `CoUninitialize`.
+fn query_thread_inner(data: &QueryData) -> Result<(), HRESULT> {
+    let query = OwnedBstr::from_wide(&data.query)?;
+
+    let initialized = unsafe { CoInitializeEx(null(), COINIT_APARTMENTTHREADED as u32) };
+    if initialized < 0 {
+        return Err(initialized);
+    }
+    let _apartment = ComApartment;
+
+    let security = unsafe {
+        CoInitializeSecurity(
+            null_mut(),
+            -1,
+            null(),
+            null(),
+            RPC_C_AUTHN_LEVEL_DEFAULT,
+            RPC_C_IMP_LEVEL_IMPERSONATE,
+            null(),
+            EOAC_NONE as u32,
+            null(),
+        )
+    };
+    if security < 0 {
+        // Another component may already have installed process-wide COM
+        // security.  CPython continues on RPC_E_TOO_LATE and lets the actual
+        // WMI calls decide whether that policy is sufficient.
+        if security != RPC_E_TOO_LATE {
+            return Err(security);
+        }
+    }
+
+    let mut locator = null_mut();
+    let status = unsafe {
+        CoCreateInstance(
+            &CLSID_WBEM_LOCATOR,
+            null_mut(),
+            CLSCTX_INPROC_SERVER,
+            &IID_IWBEM_LOCATOR,
+            &mut locator,
+        )
+    };
+    if status < 0 {
+        return Err(status);
+    }
+    let locator = ComPtr::new(locator)?;
+    signal_event(data.init_event)?;
+
+    let empty = OwnedBstr::empty();
+    let namespace = OwnedBstr::from_str("ROOT\\CIMV2")?;
+    let mut services = null_mut();
+    let status = unsafe {
+        (locator.vtable::<IWbemLocatorVtable>().ConnectServer)(
+            locator.0,
+            namespace.0,
+            empty.0,
+            empty.0,
+            empty.0,
+            0,
+            empty.0,
+            null_mut(),
+            &mut services,
+        )
+    };
+    if status < 0 {
+        return Err(status);
+    }
+    let services = ComPtr::new(services)?;
+    signal_event(data.connect_event)?;
+
+    let status = unsafe {
+        CoSetProxyBlanket(
+            services.0,
+            RPC_C_AUTHN_WINNT,
+            RPC_C_AUTHZ_NONE,
+            null(),
+            RPC_C_AUTHN_LEVEL_CALL,
+            RPC_C_IMP_LEVEL_IMPERSONATE,
+            null(),
+            EOAC_NONE as u32,
+        )
+    };
+    if status < 0 {
+        return Err(status);
+    }
+
+    let language = OwnedBstr::from_str("WQL")?;
+    let mut enumerator = null_mut();
+    let status = unsafe {
+        (services.vtable::<IWbemServicesVtable>().ExecQuery)(
+            services.0,
+            language.0,
+            query.0,
+            WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
+            null_mut(),
+            &mut enumerator,
+        )
+    };
+    if status < 0 {
+        return Err(status);
+    }
+    let enumerator = ComPtr::new(enumerator)?;
+
+    let mut start_of_enum = true;
+    loop {
+        let mut got = 0;
+        let mut value = null_mut();
+        let status = unsafe {
+            (enumerator.vtable::<IEnumWbemClassObjectVtable>().Next)(
+                enumerator.0,
+                WBEM_INFINITE,
+                1,
+                &mut value,
+                &mut got,
+            )
+        };
+        if status == WBEM_S_FALSE {
+            break;
+        }
+        if status < 0 {
+            return Err(status);
+        }
+        if got != 1 || value.is_null() {
+            continue;
+        }
+        let value = ComPtr::new(value)?;
+
+        if !start_of_enum {
+            write_wide(data.write_pipe, &[0])?;
+        }
+        start_of_enum = false;
+
+        let status =
+            unsafe { (value.vtable::<IWbemClassObjectVtable>().BeginEnumeration)(value.0, 0) };
+        if status < 0 {
+            return Err(status);
+        }
+        loop {
+            let mut prop_name: BSTR = null();
+            let mut prop_value = VARIANT::default();
+            let mut flavor = 0;
+            let status = unsafe {
+                (value.vtable::<IWbemClassObjectVtable>().Next)(
+                    value.0,
+                    0,
+                    &mut prop_name,
+                    &mut prop_value,
+                    null_mut(),
+                    &mut flavor,
+                )
+            };
+            let prop_name = OwnedBstr(prop_name);
+            if status == WBEM_S_NO_MORE_DATA {
+                break;
+            }
+            if status < 0 {
+                unsafe { VariantClear(&mut prop_value) };
+                unsafe { (value.vtable::<IWbemClassObjectVtable>().EndEnumeration)(value.0) };
+                return Err(status);
+            }
+
+            if flavor & WBEM_FLAVOR_MASK_ORIGIN != WBEM_FLAVOR_ORIGIN_SYSTEM {
+                let mut rendered = [0u16; RESULT_UNITS];
+                let converted = unsafe {
+                    VariantToString(&prop_value, rendered.as_mut_ptr(), RESULT_UNITS as u32)
+                };
+                unsafe { VariantClear(&mut prop_value) };
+                if converted < 0 {
+                    return Err(converted);
+                }
+                let rendered_len = rendered
+                    .iter()
+                    .position(|&unit| unit == 0)
+                    .unwrap_or(RESULT_UNITS);
+                write_wide(data.write_pipe, prop_name.as_slice())?;
+                write_wide(data.write_pipe, &['=' as u16])?;
+                write_wide(data.write_pipe, &rendered[..rendered_len])?;
+                write_wide(data.write_pipe, &[0])?;
+            } else {
+                unsafe { VariantClear(&mut prop_value) };
+            }
+        }
+        // CPython ignores EndEnumeration's status after the Next loop has
+        // already selected the result to report.
+        unsafe { (value.vtable::<IWbemClassObjectVtable>().EndEnumeration)(value.0) };
+    }
+
+    Ok(())
+}
+
+/// Native `CreateThread` entry point.  Returning the HRESULT bit pattern makes
+/// `GetExitCodeThread` feed the same signed Win32 code to `OSError.winerror` as
+/// CPython's `(DWORD)hr` return.
+unsafe extern "system" fn query_thread(param: *mut c_void) -> u32 {
+    let data = unsafe { Box::from_raw(param.cast::<QueryData>()) };
+    let status =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| query_thread_inner(&data)))
+            .unwrap_or(Err(E_FAIL));
+    unsafe {
+        CloseHandle(data.write_pipe);
+    }
+    match status {
+        Ok(()) => 0,
+        Err(error) => error as u32,
+    }
+}
+
+/// CPython `wait_event`: an expired staged wait is surfaced as WinError 258,
+/// while every other wait failure uses the calling thread's last error.
+fn wait_event(event: HANDLE, timeout: u32) -> u32 {
+    match unsafe { WaitForSingleObject(event, timeout) } {
+        WAIT_OBJECT_0 => 0,
+        WAIT_TIMEOUT => WAIT_TIMEOUT,
+        _ => unsafe { GetLastError() },
+    }
+}
+
+/// `_wmi_exec_query_impl` after the Python query has been converted to owned
+/// UTF-16.  Everything through the worker cleanup wait is one released region,
+/// matching `Py_BEGIN_ALLOW_THREADS` and allowing concurrent calls to progress.
+fn execute_query(query: Vec<u16>) -> Result<Vec<u16>, crate::PyError> {
+    let mut buffer = [0u16; RESULT_UNITS];
+    let mut offset = 0usize;
+
+    let err = {
+        let _blocked = crate::module::thread::before_external_block();
+        let mut err = 0u32;
+        let init_event = unsafe { CreateEventW(null(), 1, 0, null()) };
+        let connect_event = unsafe { CreateEventW(null(), 1, 0, null()) };
+        let mut read_pipe: HANDLE = null_mut();
+        let mut write_pipe: HANDLE = null_mut();
+        let mut thread: HANDLE = null_mut();
+
+        if init_event.is_null()
+            || connect_event.is_null()
+            || unsafe { CreatePipe(&mut read_pipe, &mut write_pipe, null(), 0) } == 0
+        {
+            err = unsafe { GetLastError() };
+        } else {
+            let data = Box::new(QueryData {
+                query,
+                write_pipe,
+                init_event,
+                connect_event,
+            });
+            let data = Box::into_raw(data);
+            thread = unsafe {
+                CreateThread(
+                    null(),
+                    0,
+                    Some(query_thread),
+                    data.cast::<c_void>(),
+                    0,
+                    null_mut(),
+                )
+            };
+            if thread.is_null() {
+                err = unsafe { GetLastError() };
+                unsafe {
+                    drop(Box::from_raw(data));
+                    CloseHandle(write_pipe);
+                }
+            }
+        }
+
+        // gh-112278: ConnectServer has no timeout.  CPython gives first-time
+        // COM setup one second, then the WMI connection itself 100 ms.
+        if err == 0 {
+            err = wait_event(init_event, 1000);
+            if err == 0 {
+                err = wait_event(connect_event, 100);
+            }
+        }
+
+        while err == 0 {
+            let mut bytes_read = 0;
+            let capacity = size_of_val(&buffer) - offset;
+            let read = unsafe {
+                ReadFile(
+                    read_pipe,
+                    (buffer.as_mut_ptr().cast::<u8>()).add(offset),
+                    capacity as u32,
+                    &mut bytes_read,
+                    null_mut(),
+                )
+            };
+            if read != 0 {
+                offset += bytes_read as usize;
+                if offset >= size_of_val(&buffer) {
+                    err = ERROR_MORE_DATA;
+                }
+            } else {
+                err = unsafe { GetLastError() };
+            }
+        }
+
+        if !read_pipe.is_null() {
+            unsafe {
+                CloseHandle(read_pipe);
+            }
+        }
+
+        if !thread.is_null() {
+            let thread_err = match unsafe { WaitForSingleObject(thread, 100) } {
+                WAIT_OBJECT_0 => {
+                    let mut code = 0;
+                    if unsafe { GetExitCodeThread(thread, &mut code) } == 0 {
+                        unsafe { GetLastError() }
+                    } else {
+                        code
+                    }
+                }
+                WAIT_TIMEOUT => WAIT_TIMEOUT,
+                _ => unsafe { GetLastError() },
+            };
+            if err == 0 || err == ERROR_BROKEN_PIPE {
+                err = thread_err;
+            }
+            unsafe {
+                CloseHandle(thread);
+            }
+        }
+
+        if !init_event.is_null() {
+            unsafe {
+                CloseHandle(init_event);
+            }
+        }
+        if !connect_event.is_null() {
+            unsafe {
+                CloseHandle(connect_event);
+            }
+        }
+        err
+    };
+
+    if err == ERROR_MORE_DATA {
+        return Err(crate::PyError::os_error(format!(
+            "Query returns more than {RESULT_UNITS} characters"
+        )));
+    }
+    if err != 0 {
+        return Err(crate::PyError::os_error_win32_syscall2(
+            err as i32, PY_NULL, PY_NULL,
+        ));
+    }
+    if offset == 0 {
+        return Ok(Vec::new());
+    }
+    debug_assert_eq!(offset % size_of::<u16>(), 0);
+    let units = offset / size_of::<u16>();
+    Ok(buffer[..units.saturating_sub(1)].to_vec())
+}
+
+fn is_select_query(query: &[u16]) -> bool {
+    const SELECT: &[u8; 7] = b"select ";
+    query.len() >= SELECT.len()
+        && query[..SELECT.len()]
+            .iter()
+            .zip(SELECT)
+            .all(|(&unit, &expected)| {
+                unit == expected as u16
+                    || (expected.is_ascii_lowercase()
+                        && unit == expected.to_ascii_uppercase() as u16)
+            })
+}
+
+/// `_wmi.exec_query($module, /, query)`.
+fn exec_query(args: &[PyObjectRef]) -> crate::PyResult {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::clinic_arity(
+        "exec_query",
+        positional.len(),
+        crate::builtins::real_kwarg_count(kwargs),
+        1,
+        1,
+        0,
+    )?;
+    let query = positional
+        .first()
+        .copied()
+        .or_else(|| crate::builtins::kwarg_get(kwargs, "query"))
+        .ok_or_else(|| {
+            crate::PyError::type_error("exec_query() missing required argument 'query' (pos 1)")
+        })?;
+    if !unsafe { pyre_object::is_str(query) } {
+        return Err(crate::PyError::type_error(format!(
+            "exec_query() argument 'query' must be str, not {}",
+            crate::gateway::short_type_name(query)
+        )));
+    }
+
+    // The clinic unicode converter has accepted the object, but the wide-char
+    // copy and SELECT validation live after the audit in CPython's impl.
+    let roots = pyre_object::gc_roots::push_roots();
+    let query_slot = roots.base();
+    let _ = roots.pin_root(query);
+    crate::module::sys::vm::audit("_wmi.exec_query", &[roots.get(query_slot)])?;
+    let query = roots.get(query_slot);
+    let mut wide: Vec<u16> = unsafe { pyre_object::w_str_get_wtf8(query) }
+        .encode_wide()
+        .collect();
+    if wide.contains(&0) {
+        return Err(crate::PyError::value_error("embedded null character"));
+    }
+    if !is_select_query(&wide) {
+        return Err(crate::PyError::value_error(
+            "only SELECT queries are supported",
+        ));
+    }
+
+    let result = execute_query(std::mem::take(&mut wide))?;
+    Ok(pyre_object::w_str_from_wtf8(
+        rustpython_wtf8::Wtf8Buf::from_wide(&result),
+    ))
+}
+
+const EXEC_QUERY_DOC: &str = "Runs a WMI query against the local machine.\n\nThis returns a single string with 'name=value' pairs in a flat array separated\nby null characters.";
+
+crate::py_module! {
+    "_wmi",
+    extra_init: |ns| {
+        crate::module_ns_store(
+            ns,
+            "exec_query",
+            crate::gateway::with_module(
+                "_wmi",
+                crate::make_module_builtin_function_with_doc(
+                    "exec_query",
+                    exec_query,
+                    EXEC_QUERY_DOC,
+                ),
+            ),
+        );
+    },
+}

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -18,7 +18,15 @@ const MAX_DEPTH: usize = wire::MAX_MARSHAL_STACK_DEPTH;
 
 fn marshal_error(error: wire::MarshalError) -> PyError {
     match error {
-        wire::MarshalError::Eof => eof_error("marshal data too short"),
+        // `r_string`'s buffer path, where fewer bytes are left than the run
+        // being read is long.
+        wire::MarshalError::DataTooShort => eof_error("marshal data too short"),
+        // `r_byte` running out, which is a field's byte rather than the byte an
+        // object starts with.
+        wire::MarshalError::Eof => eof_error("EOF read where not expected"),
+        // `r_object` replaces `r_byte`'s message when it is the type byte that
+        // never came.
+        wire::MarshalError::EofObject => eof_error("EOF read where object expected"),
         _ => PyError::value_error("bad marshal data"),
     }
 }

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -116,6 +116,8 @@ pub mod _weakref;
 #[allow(non_snake_case)]
 #[cfg(windows)]
 pub mod _winapi;
+#[cfg(all(windows, not(feature = "sandbox")))]
+pub mod _wmi;
 pub mod array;
 pub mod atexit;
 pub mod binascii;

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -381,7 +381,7 @@ pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> 
     let mut saw_specifier = false;
 
     let mut parts = format.into_iter().peekable();
-    while let Some((idx, part)) = parts.next() {
+    while let Some((_, part)) = parts.next() {
         match part {
             CFormatPart::Literal(literal) => result.push_wtf8(&literal),
             CFormatPart::Spec(CFormatSpecKeyed {
@@ -437,7 +437,7 @@ pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> 
                 if let Some(error) = current_deferred.and_then(DeferredPercentError::unsupported) {
                     return Err(PyError::value_error(error.to_string()));
                 }
-                result.push_wtf8(&spec_format_string(&spec, value, idx)?);
+                result.push_wtf8(&spec_format_string(&spec, value)?);
             }
         }
     }
@@ -759,34 +759,33 @@ fn check_min_field_width(spec: &CFormatSpec) -> Result<(), PyError> {
 unsafe fn spec_format_bytes(spec: &CFormatSpec, obj: PyObjectRef) -> Result<Vec<u8>, PyError> {
     check_min_field_width(spec)?;
     match &spec.format_type {
-        CFormatType::String(conversion) => match conversion {
-            CFormatConversion::Repr | CFormatConversion::Ascii => {
-                Ok(spec.format_bytes(crate::builtins::py_ascii(obj)?.as_bytes()))
+        CFormatType::String(CFormatConversion::Repr | CFormatConversion::Ascii) => {
+            Ok(spec.format_bytes(crate::builtins::py_ascii(obj)?.as_bytes()))
+        }
+        // `format_obj` reads `%b` and `%s` as the same conversion for bytes.
+        CFormatType::Bytes | CFormatType::String(CFormatConversion::Str) => {
+            if let Some(src) = crate::typedef::buffer_as_bytes_like(obj)? {
+                return Ok(spec.format_bytes(pyre_object::bytesobject::bytes_like_data(src)));
             }
-            CFormatConversion::Str | CFormatConversion::Bytes => {
-                if let Some(src) = crate::typedef::buffer_as_bytes_like(obj)? {
-                    return Ok(spec.format_bytes(pyre_object::bytesobject::bytes_like_data(src)));
-                }
-                let Some(method) = crate::baseobjspace::lookup(obj, "__bytes__") else {
-                    return Err(PyError::type_error(format!(
-                        "%b requires a bytes-like object, or an object that implements __bytes__, not '{}'",
-                        crate::baseobjspace::object_functionstr_type_name(obj)
-                    )));
-                };
-                // bytesobject.py `invoke_bytes_method`:
-                // `space.get_and_call_function(w_bytes_method, w_source)`.
-                let w_type = crate::typedef::r#type(obj)
-                    .map_or(pyre_object::PY_NULL, |w_type| w_type.as_ptr());
-                let bytes = crate::baseobjspace::get_and_call_function(method, obj, w_type, &[])?;
-                if !pyre_object::is_bytes(bytes) {
-                    return Err(PyError::type_error(format!(
-                        "__bytes__ returned non-bytes (type {})",
-                        crate::baseobjspace::object_functionstr_type_name(bytes)
-                    )));
-                }
-                Ok(spec.format_bytes(pyre_object::bytesobject::bytes_like_data(bytes)))
+            let Some(method) = crate::baseobjspace::lookup(obj, "__bytes__") else {
+                return Err(PyError::type_error(format!(
+                    "%b requires a bytes-like object, or an object that implements __bytes__, not '{}'",
+                    crate::baseobjspace::object_functionstr_type_name(obj)
+                )));
+            };
+            // bytesobject.py `invoke_bytes_method`:
+            // `space.get_and_call_function(w_bytes_method, w_source)`.
+            let w_type =
+                crate::typedef::r#type(obj).map_or(pyre_object::PY_NULL, |w_type| w_type.as_ptr());
+            let bytes = crate::baseobjspace::get_and_call_function(method, obj, w_type, &[])?;
+            if !pyre_object::is_bytes(bytes) {
+                return Err(PyError::type_error(format!(
+                    "__bytes__ returned non-bytes (type {})",
+                    crate::baseobjspace::object_functionstr_type_name(bytes)
+                )));
             }
-        },
+            Ok(spec.format_bytes(pyre_object::bytesobject::bytes_like_data(bytes)))
+        }
         CFormatType::Number(number_type) => {
             let value = match number_type {
                 CNumberType::DecimalD | CNumberType::DecimalI | CNumberType::DecimalU => {
@@ -868,11 +867,7 @@ unsafe fn has_getitem(obj: PyObjectRef) -> bool {
 /// Apply a parsed spec to one argument, producing the formatted fragment.
 /// `formatting.py fmt_s / fmt_d / fmt_f / ...` — the per-conversion value
 /// coercion and formatting.
-unsafe fn spec_format_string(
-    spec: &CFormatSpec,
-    obj: PyObjectRef,
-    idx: usize,
-) -> Result<Wtf8Buf, PyError> {
+unsafe fn spec_format_string(spec: &CFormatSpec, obj: PyObjectRef) -> Result<Wtf8Buf, PyError> {
     check_min_field_width(spec)?;
     match &spec.format_type {
         CFormatType::String(conversion) => {
@@ -880,18 +875,13 @@ unsafe fn spec_format_string(
                 CFormatConversion::Str => crate::py_str_wtf8(obj)?,
                 CFormatConversion::Repr => crate::py_repr_wtf8(obj)?,
                 CFormatConversion::Ascii => Wtf8Buf::from_string(crate::builtins::py_ascii(obj)?),
-                // `%b` is a bytes-only conversion; the unicode formatter
-                // rejects it (`fmt_b` → `unknown_fmtchar`). `idx` is the
-                // position of the `%`, the message reports the `b`.
-                CFormatConversion::Bytes => {
-                    return Err(PyError::value_error(format!(
-                        "unsupported format character 'b' (0x62) at index {}",
-                        idx + 1
-                    )));
-                }
             };
             Ok(spec.format_string(result))
         }
+        // `%b` is a bytes-only conversion; a `CFormatContext::Str` parse
+        // rejects the `b` as an unsupported format character, so the unicode
+        // formatter never sees a spec carrying it.
+        CFormatType::Bytes => unreachable!("`%b` does not parse in a str format string"),
         CFormatType::Number(number_type) => {
             let value = match number_type {
                 CNumberType::DecimalD | CNumberType::DecimalI | CNumberType::DecimalU => {

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2919,6 +2919,12 @@ fn format_spec_err(
         )),
         E::UnableToConvert => crate::PyError::value_error("Unable to convert int to float"),
         E::CodeNotInRange => crate::PyError::overflow_error("%c arg not in range(0x110000)"),
+        // A `c` code is read through `PyLong_AsLong`, so a value outside the C
+        // long range is reported as that conversion failing rather than as the
+        // code point range check.
+        E::IntTooLargeForCLong => {
+            crate::PyError::overflow_error("Python int too large to convert to C long")
+        }
         E::ZeroPadding => {
             crate::PyError::value_error("Zero padding is not allowed in complex format specifier")
         }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -3488,15 +3488,18 @@ fn format_char(num: &BigInt, spec: &Wtf8) -> Result<Wtf8Buf, crate::PyError> {
             "Alternate form (#) not allowed with integer format specifier 'c'",
         ));
     }
-    if pyre_object::jit_bigint_to_i64_fits(num) == 0 {
+    // The code is read through `PyLong_AsLong`, so it is a C `long` -- 32 bits
+    // on Windows -- that bounds it, and overflowing that is reported as the
+    // conversion failing rather than as a code point out of range.
+    let code = (pyre_object::jit_bigint_to_i64_fits(num) != 0)
+        .then(|| pyre_object::jit_bigint_to_i64_value(num))
+        .filter(|code| core::ffi::c_long::try_from(*code).is_ok());
+    let Some(code) = code else {
         return Err(crate::PyError::overflow_error(
             "Python int too large to convert to C long",
         ));
-    }
-    let cp = match u32::try_from(pyre_object::jit_bigint_to_i64_value(num))
-        .ok()
-        .and_then(CodePoint::from_u32)
-    {
+    };
+    let cp = match u32::try_from(code).ok().and_then(CodePoint::from_u32) {
         Some(cp) => cp,
         None => {
             return Err(crate::PyError::overflow_error(


### PR DESCRIPTION
Two things that had to land together: the `_wmi` port, and the RustPython pin bump whose new revision does not compile against the old interpreter sources.

### `_wmi`

Adds the `_wmi` module — the last Windows-only module CPython 3.14 has and pyre did not. A mechanical surface diff of nineteen Windows-relevant modules against the real CPython 3.14 free-threaded build found exactly one gap, and this is it: `_winapi`, `winreg`, `msvcrt`, `nt`, `winsound`, `_overlapped`, `mmap` and `ntpath` differ by nothing.

The module is one function, `exec_query(query) -> str`, returning `name=value` pairs in a flat null-separated array. Its shape follows `_wmi_exec_query_impl`: the COM work (`IWbemLocator` → `ConnectServer` → `ExecQuery` → `IEnumWbemClassObject`) runs on a worker thread writing into an anonymous pipe, with two events used as timeouts, because `ConnectServer` hangs for five seconds when the caller lacks permission and takes no timeout of its own. It is gated `#[cfg(all(windows, not(feature = "sandbox")))]` — a sandboxed build has no local WMI service to reach.

`test.test_wmi`'s PASS goes in `baseline.win32-AMD64.json` rather than the shared file. `_wmi` exists only on Windows, so PASS is this host's answer and the shared file keeps the verdict the gating host records. `import_module('_wmi', required_on=['win'])` re-raises instead of skipping on win32, which is why the module reports a result only where the extension is built.

It is now measured rather than carried over: `test_wmi` runs 8 tests on this host, 7 pass and `test_wmi_query_overflow` skips for the disabled `cpu` resource.

### RustPython pin

All eight pins move `cb7acec` → `4bd9545`, and `malachite-bigint` `0.10` → `0.11` with it. Three source changes follow from the new revision.

**`%b` moved out of `FormatConversion`.** It is now `CFormatType::Bytes`, which `format_obj` reads as the same conversion as `%s` for bytes. `spec_format_bytes` merges those two arms accordingly, and `spec_format_string` gains a `Bytes` arm: a `b` in a `str` format string is rejected as an unsupported format character during parsing, so the unicode formatter never receives a spec carrying one. `spec_format_string`'s `idx` parameter went with it — it existed only to build the `%b` error message.

**`FormatSpecError::IntTooLargeForCLong` is new** and needed a `format_spec_err` arm.

**`format_char` was bounded by `i64`, not by C `long`.** `formatchar` reads the code through `PyLong_AsLong` and reports an out-of-range value as that conversion failing — its own comment says "this includes an overflow in converting to C long" — so on Windows, where a `long` is 32 bits, `format(2**31, 'c')` must raise `OverflowError: Python int too large to convert to C long` rather than the code-point range error. `format_long_internal` takes the same route. Measured against real CPython 3.14 on Windows: 22 of 22 `format(v, 'c')` and `'%c' % v` cases now agree, 3 of which disagreed before.

**`MarshalError` gained `DataTooShort` and `EofObject`**, which `marshal_error` was collapsing into one message. `r_string`'s buffer path, `r_byte` running out, and `r_object` finding no type byte are three different shortfalls with three different messages in `marshal.c`, and pyre's own file-backed reader raises the `Eof` variant, so it now answers `"EOF read where not expected"` as the `r_string` slow path does. Measured against real CPython 3.14: 8 of 8 `marshal.loads` / `marshal.load` truncation cases agree.

### parity_tests

`handle_fromlist_contract.py` wrote `hflpkg/d.py` after `hflpkg` had already been imported, so the package's `FileFinder` had cached the directory listing. On Windows the directory's last-write time is unchanged by the time the next stat of it runs — measured, the two stats return the identical float — so the cache is never refilled, `hflpkg.d` is not found, and the fromlist swallows the optional-import failure instead of propagating the `ModuleNotFoundError` that `d.py`'s body raises. `d.py` is now written up front with `a`/`b`/`c`; `__all__` is `['a', 'b']`, so nothing imports it early.

This failed on real CPython 3.14 (5 runs of 5) and on PyPy, not only on pyre. It came in with #1575 and is unrelated to the rest of this branch.

### Gate

Run on this Windows host at the rebased head.

| item | result |
|---|---|
| `cargo test --all --no-default-features --features dynasm,cpyext` | pass |
| `pyre/extra_tests/parity_tests/run.py` | pass (all four runtimes) |
| `pyre/extra_tests/run.py --gated-only` dynasm / cranelift | 143/143 ×2 |
| `pyre/extra_tests/upstream/run.py` | pass |
| wasm32 `pyre-wasm` build | pass |
| `scripts/check-new-line-citations.py` | pass |
| `pyre/check.py` dynasm / cranelift | 518 passed, 7 failed ×2 |

The 7 are the jit-stats fixtures already red at `main` on this box and green on CI's `windows-latest` at the same commit: `exception_inline_callee_tb_frames`, `exception_reentry_guard_finally_residual`, `exception_traceback_frame_lineno`, `exception_traceback_lineno_chain`, `inline_subwalk_mutating_residual`, `inlined_helper_mutation`, `mutate_then_raise_caught`. Their numbers are byte-identical before and after this branch's commits, and nothing here is re-recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014svTHUbS67NLQwtPQMuyH4
