### PR TITLE
majit: descr-owned JITFRAME allocation, and the two float bitcast opnames in the runtime blackhole builder

### DIFF
--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -271,7 +271,7 @@ cover the condition they diagnose.
 
 - Read sites: 1 — `majit/majit-backend/src/deadframe.rs`
 - Accessor: `seed_jitframe_pool_arm()`, behind `jitframe_pool_enabled()`
-- What it does: Selects which arm allocates the jitframe a compiled entry runs on, for backends that build frames out of the Rust heap rather than the GC nursery. `0` selects `FrameHeapOwner::OWNED`, one `calloc`/`free` pair per entry; anything else, including leaving it unset, selects the pooled per-thread free list. Read once and latched, so it names a strategy for the process rather than a per-entry state; `set_jitframe_pool` overrides it for a harness that can call in.
+- What it does: Selects which arm allocates the jitframe a compiled entry runs on, for backends that build frames out of the Rust heap rather than the GC nursery. `0` selects the owned arm, one `calloc`/`free` pair per entry; anything else, including leaving it unset, selects the pooled per-thread free list. Read once and latched, so it names a strategy for the process rather than a per-entry state; `set_jitframe_pool` overrides it for a harness that can call in.
 - Retirement condition: when the owned arm is retired — it exists to be differenced against the pooled one, and a build with no second arm has nothing to select.
 
 ### `MAJIT_PROBE_EXTRA`

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -284,10 +284,11 @@ fn match_metainterp_finish_descr(
 // JitFrame layout constants (`jitframe.py:61-83`)
 // The canonical layout lives in `majit_backend::jitframe`; re-export the
 // byte offsets here so uses inside this file stay terse.
-use majit_backend::deadframe::{FrameHeapOwner, jitframe_pool_enabled};
+use majit_backend::deadframe::FrameHeapOwner;
 use majit_backend::jitframe::{
-    BASEITEMOFS, JF_DESCR_OFS, JF_FORCE_DESCR_OFS, JF_FORWARD_OFS, JF_FRAME_OFS, JF_GCMAP_OFS,
-    JF_GUARD_EXC_OFS, JF_SAVEDATA_OFS,
+    BASEITEMOFS, HostHeapGc, JF_DESCR_OFS, JF_FORCE_DESCR_OFS, JF_FORWARD_OFS, JF_FRAME_OFS,
+    JF_GCMAP_OFS, JF_GUARD_EXC_OFS, JF_SAVEDATA_OFS, check_jitframe_descr, jitframe_is_gc_object,
+    jitframe_write_barrier, malloc_jitframe_no_collect,
 };
 /// Byte offset of `jf_frame_length` from JitFrame start
 /// (`jitframe.py:84` — `jf_frame`'s length word sits at the array base).
@@ -295,126 +296,6 @@ const JF_FRAME_LENGTH_OFS: i32 = JF_FRAME_OFS as i32;
 /// Byte offset of `jf_frame[0]` from JitFrame start
 /// (`jitframe.py` — `BASEITEMOFS`: first item follows the length word).
 const JF_FRAME_ITEM0_OFS: i32 = JF_FRAME_OFS as i32 + BASEITEMOFS as i32;
-/// GC type id for JitFrame objects, assigned at runtime by the frontend
-/// that owns the GC type registry (pyre-jit registers OBJECT / W_INT /
-/// W_FLOAT before JITFRAME, so the JITFRAME id depends on that ordering
-/// and cannot be hard-coded here).
-///
-/// `u32::MAX` means "the frontend has published no id". Publishing is a
-/// precondition of installing a collector on this backend, not a hint the
-/// backend may supply for itself — see [`resolve_jitframe_heap`].
-///
-/// Published twice, to one value. The atomic is what a thread that never
-/// called [`set_jitframe_gc_type_id`] reads: pyre publishes once from
-/// `build_gc`, under a `Once`, and every later thread installs the singleton
-/// against that id. The thread-local is what the publishing thread itself
-/// reads, and it exists for the test binaries, where each thread builds its
-/// own collector and registers a different number of types ahead of JITFRAME:
-/// there the atomic holds whichever thread stored last, and a thread that read
-/// it would install an id naming some other collector's type.
-static JITFRAME_GC_TYPE_ID: std::sync::atomic::AtomicU32 =
-    std::sync::atomic::AtomicU32::new(u32::MAX);
-
-thread_local! {
-    /// This thread's own publication (see [`JITFRAME_GC_TYPE_ID`]).
-    static JITFRAME_GC_TYPE_ID_LOCAL: Cell<Option<u32>> = const { Cell::new(None) };
-}
-
-/// Publish the JITFRAME type id. Called from the frontend after it has
-/// registered `jitframe_type_info()` on its collector, so that our nursery
-/// allocations (gc.alloc_nursery_no_collect_typed) use the same id the
-/// frontend assigned to the JITFRAME TypeInfo (jitframe.py).
-///
-/// Must precede the collector's install on this backend.
-pub fn set_jitframe_gc_type_id(id: u32) {
-    assert_ne!(
-        id,
-        u32::MAX,
-        "u32::MAX is the unpublished sentinel, not a type id"
-    );
-    JITFRAME_GC_TYPE_ID_LOCAL.with(|c| c.set(Some(id)));
-    JITFRAME_GC_TYPE_ID.store(id, std::sync::atomic::Ordering::Release);
-}
-
-fn published_jitframe_gc_type_id() -> Option<u32> {
-    if let Some(id) = JITFRAME_GC_TYPE_ID_LOCAL.with(|c| c.get()) {
-        return Some(id);
-    }
-    match JITFRAME_GC_TYPE_ID.load(std::sync::atomic::Ordering::Acquire) {
-        u32::MAX => None,
-        id => Some(id),
-    }
-}
-
-/// Unpublish, for the fixture that asks what an install does with no id.
-///
-/// Safe to run beside the other fixtures despite clearing process-global
-/// state: every fixture that publishes reads its own thread-local back, so
-/// the atomic has no reader but a thread that never published.
-#[cfg(test)]
-fn clear_published_jitframe_gc_type_id() {
-    JITFRAME_GC_TYPE_ID_LOCAL.with(|c| c.set(None));
-    JITFRAME_GC_TYPE_ID.store(u32::MAX, std::sync::atomic::Ordering::Release);
-}
-
-/// Where this thread's jitframes are allocated from, as decided once by
-/// `install_gc_box` / `install_gc_standalone`.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum JitFrameHeap {
-    /// GC-managed under this type id — `jitframe.py:48`
-    /// `lltype.malloc(JITFRAME, ...)`, reached through
-    /// `llmodel.py malloc_jitframe`.
-    Nursery(u32),
-    /// The installed allocator has no type table, so there is no shape to
-    /// allocate a frame under and the frame is a plain `Vec<i64>` block
-    /// outside both generations. Test-double allocators only; upstream has
-    /// no counterpart, because a translated backend always has a
-    /// `TypeLayoutBuilder`.
-    OffGc,
-}
-
-/// Decide, at install time, where this thread's jitframes come from.
-///
-/// RPython: rgc.register_custom_trace_hook(JITFRAME, jitframe_trace)
-/// called from jitframe_allocate (jitframe.py) — upstream registers the
-/// shape as part of translating the frontend, so the id is settled before any
-/// compiled code exists. This is the same ordering, made a precondition: a
-/// collector with a type table must arrive with its JITFRAME id already
-/// published, and one that arrives without it is a configuration error rather
-/// than a case to be recovered from.
-///
-/// There is no backend-side lazy registration any more, and its absence is the
-/// decision. Registering here means minting an id in whichever registry
-/// happens to be installed on the calling thread, which the frontend does not
-/// know about; it also means calling `register_type` on a registry the
-/// frontend may already have frozen (`gctypelayout.py:393-398` — after
-/// `encode_type_shapes_now` there are no new types), where the only outcomes
-/// are a panic or a shape the frontend cannot name.
-fn resolve_jitframe_heap(gc: &dyn GcAllocator) -> JitFrameHeap {
-    if !gc.has_type_registry() {
-        return JitFrameHeap::OffGc;
-    }
-    let Some(id) = published_jitframe_gc_type_id() else {
-        panic!(
-            "installing a collector with a type registry on the cranelift \
-             backend requires the JITFRAME type id: register \
-             majit_backend::jitframe::jitframe_type_info() on that collector \
-             and pass the id to set_jitframe_gc_type_id() BEFORE the install"
-        );
-    };
-    // The id is published process-wide but resolved against this collector, so
-    // an id minted in a different registry is caught here rather than at the
-    // first frame allocation, where it would name whatever type happens to sit
-    // at that index and the collector would copy jitframes under the wrong
-    // shape.
-    assert_eq!(
-        gc.type_size(id),
-        Some(majit_backend::jitframe::jitframe_type_info().size),
-        "published JITFRAME type id {id} does not name a JITFRAME in the \
-         collector being installed"
-    );
-    JitFrameHeap::Nursery(id)
-}
 
 /// Store a GC allocator in the cranelift backend thread-local and
 /// register the `majit_gc::set_active_*` function-pointer hooks,
@@ -425,11 +306,10 @@ fn install_gc_box(mut gc: Box<dyn GcAllocator>) {
     // Per-thread allocator: its nursery is not the singleton's, so the
     // process-wide published range can no longer answer `is_nursery_object`.
     majit_gc::disarm_published_nursery();
-    let jitframe_heap = resolve_jitframe_heap(gc.as_ref());
+    check_jitframe_descr(gc.as_ref());
     gc.freeze_types();
     let supports_guard_gc_type = gc.supports_guard_gc_type();
     set_cranelift_active_gc(Some(gc));
-    set_cranelift_jitframe_heap(Some(jitframe_heap));
     register_active_hooks(supports_guard_gc_type);
 }
 
@@ -533,13 +413,11 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
 /// the process-global `gc_sync` singleton (the per-thread GC box is the
 /// free-threading gap R4 removes).
 pub fn install_gc_standalone() {
-    let jitframe_heap = majit_gc::gc_sync::gc_op(|gc| {
-        let heap = resolve_jitframe_heap(gc);
+    majit_gc::gc_sync::gc_op(|gc| {
+        check_jitframe_descr(gc);
         gc.freeze_types();
-        heap
     });
     let supports_guard_gc_type = majit_gc::gc_sync::gc_query(|gc| gc.supports_guard_gc_type());
-    set_cranelift_jitframe_heap(Some(jitframe_heap));
     register_active_hooks(supports_guard_gc_type);
 }
 
@@ -1530,16 +1408,6 @@ fn cranelift_type_for(tp: &Type) -> cranelift_codegen::ir::Type {
     }
 }
 
-thread_local! {
-    /// What `install_gc_box` / `install_gc_standalone` decided about this
-    /// thread's jitframes, cleared when the active GC is torn down.
-    ///
-    /// `None` means no install ran ON THIS THREAD, which is not the same as
-    /// "no GC": the `gc_sync` singleton is process-global while this cell is
-    /// per-thread. [`cranelift_jitframe_type_id`] is what tells the two apart.
-    static CRANELIFT_JITFRAME_HEAP: Cell<Option<JitFrameHeap>> = const { Cell::new(None) };
-}
-
 /// The per-thread GC box, and the accessors every trampoline reaches it through.
 ///
 /// `gc.py:30` `GcLLDescription.__init__` holds `self.gcdescr` as a plain field
@@ -1688,39 +1556,25 @@ fn set_cranelift_active_gc(gc: Option<Box<dyn GcAllocator>>) {
     gc_box::store(gc);
 }
 
-/// The type id to allocate this thread's jitframes under, or `None` for the
-/// off-GC `Vec` frame.
-///
-/// Three configurations, and the third is why this is not a plain cell read:
-///
-/// - an install ran on this thread: it already resolved the question, and its
-///   answer stands even if some other thread has since published a different
-///   id for its own collector;
-/// - no install ran anywhere reachable from here (`cranelift_gc_active()` is
-///   false): there is no collector, and the `Vec` frame is the configuration,
-///   not a fallback;
-/// - a collector is active but was installed on ANOTHER thread — the
-///   `gc_sync` singleton is process-global while the cell is per-thread. The
-///   published id is process-global too, so it answers; and if nothing
-///   published one, this fails rather than quietly handing back a `Vec` frame
-///   whose interior refs the collector would never trace.
+/// The `JITFRAME` type id of the descr in force on this thread, or `None`
+/// when its frames are host blocks — no collector, or one with no type
+/// table. Read by the layout descrs and the tests; the allocation itself
+/// goes through [`with_gc_ll_descr`].
 fn cranelift_jitframe_type_id() -> Option<u32> {
-    match CRANELIFT_JITFRAME_HEAP.with(|c| c.get()) {
-        Some(JitFrameHeap::Nursery(id)) => Some(id),
-        Some(JitFrameHeap::OffGc) => None,
-        None if !cranelift_gc_active() => None,
-        None => Some(published_jitframe_gc_type_id().unwrap_or_else(|| {
-            panic!(
-                "reached compiled code with a collector installed but no \
-                 JITFRAME type id published; the frontend must call \
-                 set_jitframe_gc_type_id() before installing the collector"
-            )
-        })),
-    }
+    with_cranelift_gc(|gc| gc.jitframe_type_id()).flatten()
 }
 
-fn set_cranelift_jitframe_heap(heap: Option<JitFrameHeap>) {
-    CRANELIFT_JITFRAME_HEAP.with(|c| c.set(heap));
+/// `cpu.gc_ll_descr`: the installed collector, or [`HostHeapGc`] —
+/// `get_ll_description(None)` (gc.py:653) picks the Boehm descr when no
+/// framework GC is configured, and this is that descr.
+fn with_gc_ll_descr<R>(f: impl FnOnce(&mut dyn GcAllocator) -> R) -> R {
+    if gc_box::present() {
+        return gc_box::with_mut(f).expect("gc box present");
+    }
+    if majit_gc::gc_sync::is_initialized() {
+        return majit_gc::gc_sync::gc_op(|gc| f(gc));
+    }
+    f(&mut HostHeapGc)
 }
 
 fn cranelift_gc_active() -> bool {
@@ -4264,46 +4118,17 @@ extern "C" fn gc_alloc_lowlevel_string_shim(
 /// - The caller (the JIT-emitted dispatch path) has already published
 ///   all live fail-args into `old_jf->jf_frame[...]` via `emit_guard_exit`
 ///   spills; this helper only needs to copy those words verbatim.
-/// - Must run on the JIT thread that owns `CRANELIFT_ACTIVE_GC` /
-///   `CRANELIFT_JITFRAME_HEAP` thread-locals.
+/// - Must run on the JIT thread that owns the `CRANELIFT_ACTIVE_GC`
+///   thread-local.
 #[inline(never)]
 pub unsafe extern "C" fn cranelift_realloc_frame(old_jf: *mut i64, new_depth: usize) -> *mut i64 {
     let header_words = (JF_FRAME_ITEM0_OFS as usize) / 8;
     let new_total = header_words + new_depth;
     let new_bytes = new_total * 8;
 
-    // llmodel.py:140 `new_frame = jitframe.JITFRAME.allocate(...)` —
-    // allocate from the GC nursery so the new frame is reclaimed once
-    // it falls out of the shadow-stack roots (matches the initial
-    // allocation strategy in compiler.rs).  Without a JITFRAME
-    // type id (host-test path that runs without a configured GC),
-    // fall back to libc-zeroed to keep behaviour defined.
-    let new_jf = match cranelift_jitframe_type_id() {
-        Some(type_id) => {
-            let gcref = with_cranelift_gc_required(|gc| {
-                gc.alloc_nursery_no_collect_typed(type_id, new_bytes)
-            });
-            assert_ne!(gcref.0, 0, "cranelift_realloc_frame: nursery alloc failed");
-            unsafe {
-                // jitframe.py:48 parity (compiler.rs): zero the
-                // header so jf_descr / jf_forward / jf_gcmap start at
-                // NULL; nursery alloc may not zero.
-                std::ptr::write_bytes(gcref.0 as *mut u8, 0, JF_FRAME_ITEM0_OFS as usize);
-            }
-            gcref.0 as *mut i64
-        }
-        None => {
-            // Reserves the header word the emitted write-barrier fast path
-            // reads at a negative offset, so this frame answers that read the
-            // way the nursery-allocated one above does.
-            let p = majit_backend::jitframe::alloc_off_gc_jitframe(new_bytes) as *mut i64;
-            assert!(!p.is_null(), "cranelift_realloc_frame: alloc failed");
-            // Host-test fallback only — register with the libc-jitframe
-            // tracer so any interior Ref scan still works.
-            majit_gc::shadow_stack::register_libc_jitframe(p as usize);
-            p
-        }
-    };
+    // llmodel.py:140 `new_frame = jitframe.JITFRAME.allocate(...)` — the
+    // descr allocates the new frame the same way it allocated the old one.
+    let new_jf = with_gc_ll_descr(|gc| malloc_jitframe_no_collect(gc, new_bytes)) as *mut i64;
 
     let old_base = old_jf as usize;
     let new_base = new_jf as usize;
@@ -8229,66 +8054,27 @@ fn run_compiled_code_inner(
     let jf_total = header_words + frame_depth;
     let payload_bytes = jf_total * 8;
 
-    // RPython gc.py malloc_jitframe → jitframe_allocate:
-    //   rgc.register_custom_trace_hook(JITFRAME, jitframe_trace)
-    //   frame = lltype.malloc(JITFRAME, frame_depth)
-    //
-    // When GC has a type registry (MiniMarkGC), allocate from nursery with
-    // JITFRAME type_id so the GC can copy+trace it correctly. The shadow
-    // stack holds a GcRef that the GC updates in place when copying.
-    // With no collector at all, or one with no type table (TrackingGc), fall
-    // back to Vec<i64>. `cranelift_jitframe_type_id` is what draws that line;
-    // a collector that could trace a frame but has no shape to allocate it
-    // under fails there rather than reaching this branch.
-    // jitframe_allocate (jitframe.py) allocates from the nursery
-    // via rgc.malloc. Nursery::alloc syncs from NURSERY_FREE_ADDR
-    // (incminimark.py:676 gc_adr_of_nursery_free parity) so JIT
-    // inline bumps and GC allocations share the same free pointer.
-    // jitframe.py:48 parity: allocate jitframes from nursery when GC
-    // type registry is available. The gcmap marks ref_root_slots, which
-    // are spilled/reloaded around collecting calls. Input slots are read
-    // once at entry (before any GC point) and their values live in
-    // SSA/ref_root_slots afterward.
-    let runtime_jitframe_tid = cranelift_jitframe_type_id();
-    let use_gc_alloc = runtime_jitframe_tid.is_some();
-    let (jf_gcref, heap_owner): (GcRef, Option<FrameHeapOwner>) = if use_gc_alloc {
-        let type_id = runtime_jitframe_tid.unwrap();
-        let gcref = with_cranelift_gc_required(|gc| {
-            gc.alloc_nursery_no_collect_typed(type_id, payload_bytes)
-        });
-        unsafe {
-            // jitframe.py:48 parity: zero the header so jf_descr starts
-            // as NULL (GuardNotForced checks jf_descr != 0), and zero the item
-            // slots too. RPython's nursery allocation hands back zeroed memory
-            // (zeroed once per nursery reset); ours does not, so a fresh frame
-            // must be cleared here.
-            std::ptr::write_bytes(gcref.0 as *mut u8, 0, payload_bytes);
-            *((gcref.0 + JF_FRAME_LENGTH_OFS as usize) as *mut usize) = frame_depth;
-        }
-        (gcref, None)
-    } else {
-        // One leading word stands in for the GcHeader the nursery branch
-        // above puts in front of the frame: the emitted write-barrier fast
-        // path loads the flag byte at a negative offset from the frame
-        // pointer, so without it that load reads outside the buffer.
-        const HEADER_WORDS: usize = majit_gc::header::GcHeader::SIZE / 8;
-        const _: () = assert!(HEADER_WORDS * 8 == majit_gc::header::GcHeader::SIZE);
-        // Off the per-thread free list by default, or one `calloc`/`free` pair
-        // per compiled entry if the owned arm was selected — `FrameHeapOwner`
-        // is where the two differ, and the buffer it hands back is zeroed to
-        // `words` either way.
-        let mut buf = FrameHeapOwner::new(HEADER_WORDS + jf_total, jitframe_pool_enabled());
-        let gcref = GcRef(unsafe { buf.as_mut_ptr().add(HEADER_WORDS) } as usize);
+    // llmodel.py:298 `frame = self.gc_ll_descr.malloc_jitframe(frame_info)`:
+    // the descr decides whether the frame is a nursery object under JITFRAME
+    // — traced through `jf_gcmap`, held by the shadow stack through a root
+    // slot the collector updates when it copies — or a host block. Input
+    // slots are read once at entry (before any GC point) and their values
+    // live in SSA/ref_root_slots afterward.
+    let (use_gc_alloc, jf) = with_gc_ll_descr(|gc| {
+        (
+            jitframe_is_gc_object(gc),
+            malloc_jitframe_no_collect(gc, payload_bytes),
+        )
+    });
+    let jf_gcref = GcRef(jf as usize);
+    unsafe {
         // jitframe.py:84 parity — `jf_frame.length` is the count of `Signed`
-        // payload slots after the length word.  The GC-alloc branch above
-        // already does this at line 6282; mirror it here so frame-size
-        // checks (e.g. `emit_attached_bridge_dispatch`'s `frame_fits` gate)
-        // behave identically in nursery-backed and Vec-backed modes.
-        unsafe {
-            *((gcref.0 + JF_FRAME_LENGTH_OFS as usize) as *mut usize) = frame_depth;
-        }
-        (gcref, Some(buf))
-    };
+        // payload slots after the length word.
+        *((jf_gcref.0 + JF_FRAME_LENGTH_OFS as usize) as *mut usize) = frame_depth;
+    }
+    // A host block is the deadframe's to release; a nursery frame is the
+    // collector's.
+    let heap_owner = (!use_gc_alloc).then(|| FrameHeapOwner::of(jf));
 
     let jf_ptr = jf_gcref.0 as *mut i64;
 
@@ -8307,10 +8093,10 @@ fn run_compiled_code_inner(
         let repeats = majit_backend::deadframe::frame_build_repeats();
         majit_backend::deadframe::count_frame_build_passes(repeats);
         for _ in 0..repeats {
-            const HEADER_WORDS: usize = majit_gc::header::GcHeader::SIZE / 8;
-            let mut scratch = FrameHeapOwner::new(HEADER_WORDS + jf_total, jitframe_pool_enabled());
+            let base =
+                with_gc_ll_descr(|gc| malloc_jitframe_no_collect(gc, payload_bytes)) as *mut i64;
+            let mut scratch = FrameHeapOwner::of(base as *mut majit_backend::jitframe::JitFrame);
             unsafe {
-                let base = scratch.as_mut_ptr().add(HEADER_WORDS);
                 *((base as usize + JF_FRAME_LENGTH_OFS as usize) as *mut usize) = frame_depth;
                 inputs.write_into(base.add(header_words));
             }
@@ -8359,9 +8145,7 @@ fn run_compiled_code_inner(
     }
 
     // llmodel.py:322: llop.gc_writebarrier(ll_frame)
-    if use_gc_alloc {
-        with_cranelift_gc_required(|gc| gc.write_barrier(jf_gcref));
-    }
+    with_gc_ll_descr(|gc| jitframe_write_barrier(gc, jf));
 
     // llmodel.py:323 parity: ll_frame = func(ll_frame)
     // The `trace_N_entry` wrapper takes a second `dispatch_key` argument
@@ -15879,7 +15663,6 @@ impl Drop for CraneliftBackend {
         // its own; matching dynasm's
         // `runner.rs DYNASM_ACTIVE_GC` reset on backend teardown.
         gc_box::clear_on_teardown();
-        let _ = CRANELIFT_JITFRAME_HEAP.try_with(|c| c.set(None));
     }
 }
 
@@ -18920,10 +18703,10 @@ mod tests {
         return_ref
     }
 
-    /// Register JITFRAME on `gc` and publish its id, which is what a frontend
-    /// does before it installs its collector (`eval.rs build_gc` registers the
-    /// shape, then `set_jitframe_gc_type_id`, and only then
-    /// `install_gc_standalone`). `resolve_jitframe_heap` requires that
+    /// Register JITFRAME on `gc` and tell the descr its id, which is what a
+    /// frontend does before it installs its collector (`eval.rs build_gc`
+    /// registers the shape, then `set_jitframe_type_id`, and only then
+    /// `install_gc_standalone`). `check_jitframe_descr` requires that
     /// ordering of any collector that has a type registry.
     ///
     /// JITFRAME goes in AFTER whatever types the fixture registered for
@@ -18932,7 +18715,7 @@ mod tests {
     /// exercising an id the shipped configuration cannot produce.
     fn publish_jitframe_type(gc: &mut MiniMarkGC) -> u32 {
         let id = gc.register_type(majit_backend::jitframe::jitframe_type_info());
-        set_jitframe_gc_type_id(id);
+        gc.set_jitframe_type_id(id);
         id
     }
 
@@ -18960,7 +18743,6 @@ mod tests {
     #[test]
     #[should_panic(expected = "JITFRAME")]
     fn test_gc_install_without_published_jitframe_id_panics() {
-        clear_published_jitframe_gc_type_id();
         let _backend = CraneliftBackend::with_gc_allocator(Box::new(MiniMarkGC::new()));
     }
 
@@ -18976,7 +18758,7 @@ mod tests {
     fn test_gc_install_with_a_foreign_jitframe_id_panics() {
         let mut gc = MiniMarkGC::new();
         let plain = gc.register_type(TypeInfo::simple(16));
-        set_jitframe_gc_type_id(plain);
+        gc.set_jitframe_type_id(plain);
         let _backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
     }
 

--- a/majit/majit-backend-cranelift/src/lib.rs
+++ b/majit/majit-backend-cranelift/src/lib.rs
@@ -29,5 +29,5 @@ pub use compiler::{
     register_call_assembler_unbox_int, register_jitframe_layout, register_materialize_str_call,
     register_materialize_str_plain, register_prologue_probe_addr, register_recovery_layout,
     register_resumedata_deopt, register_stack_check_addresses, set_gil_hooks,
-    set_jitframe_gc_type_id, set_savedata_ref_on_deadframe, take_pending_frame_restore,
+    set_savedata_ref_on_deadframe, take_pending_frame_restore,
 };

--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -44,7 +44,7 @@ pub mod x86;
 // Cranelift uses JIT_EXC_VALUE / JIT_EXC_TYPE atomics (compiler.rs).
 // Dynasm uses the same pattern for structural equivalence.
 
-use std::sync::atomic::{AtomicI64, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicI64, Ordering};
 
 /// Whether `MAJIT_LOG` is set, cached at first access.
 ///
@@ -93,7 +93,6 @@ static JIT_EXC_VALUE: AtomicI64 = AtomicI64::new(0);
 // Holds the pending exception's `typeptr` (an immortal static `PyType`), never a
 // managed object, so it is deliberately not GC-rooted.
 static JIT_EXC_TYPE: AtomicI64 = AtomicI64::new(0);
-static JITFRAME_GC_TYPE_ID: AtomicU32 = AtomicU32::new(u32::MAX);
 /// Stands in for the slot array before any slot is written, so the base a
 /// compiled entry receives is always a readable address rather than null.
 /// `llmodel.py:319-322` does the same in untranslated runs, handing the entry a
@@ -163,22 +162,6 @@ pub fn jit_exc_value_addr() -> usize {
 /// `pos_exc_value` whenever the propagate path drains the global exception.
 pub fn jit_exc_type_addr() -> usize {
     &JIT_EXC_TYPE as *const _ as usize
-}
-
-/// Override the JITFRAME type id used by dynasm nursery slow paths.
-///
-/// The frontend registers `jitframe_type_info()` on its active GC before
-/// running JIT code; dynasm must allocate recursive callee jitframes with
-/// that same type so the collector traces them with `jitframe_trace`.
-pub fn set_jitframe_gc_type_id(id: u32) {
-    JITFRAME_GC_TYPE_ID.store(id, Ordering::Release);
-}
-
-pub(crate) fn jitframe_gc_type_id() -> Option<u32> {
-    match JITFRAME_GC_TYPE_ID.load(Ordering::Acquire) {
-        u32::MAX => None,
-        id => Some(id),
-    }
 }
 
 /// Write a thread-local slot that compiled entrypoints may read back.

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -8,6 +8,10 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use majit_backend::deadframe::{ExitDescr, JitFrameDeadFrame};
+use majit_backend::jitframe::{
+    HostHeapGc, check_jitframe_descr, jitframe_is_gc_object, jitframe_write_barrier,
+    malloc_jitframe, malloc_jitframe_no_collect,
+};
 use majit_backend::libc_deadframe::LibcJitFrameDeadFrame;
 use majit_backend::{AsmInfo, Backend, BackendError, DeadFrame, JitCellToken};
 // `gc_sync` hands out the concrete collector; the trait must be in scope for
@@ -289,108 +293,53 @@ pub(crate) fn with_dynasm_active_gc_mut<R>(
     None
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum JitFrameHeap {
-    Gc,
-    Libc,
-}
-
-/// The JITFRAME type id resolved against the installed collector, read by
-/// every compiled entry that allocates its frame.
-///
-/// Upstream keeps this on the CPU: `malloc_jitframe` (`llmodel.py:298`) reads
-/// `self.cpu.gc_ll_descr`, a plain process-wide field, because there is one
-/// collector. This crate has two install paths, and the resolved id must have
-/// the same scope as the collector it was resolved against, or an entry can
-/// name a shape the collector it allocates from never registered:
-///
-/// - `install_gc_standalone` installs the process-wide `gc_sync` singleton,
-///   so its id lives in a process-wide static, like upstream. Any thread that
-///   reaches compiled code reads it — including one that never ran the install
-///   itself, which the thread-local below could not answer for.
-/// - `install_gc_box` installs a thread-confined collector (the `gc_box`
-///   thread-local, scaffolding for the test binaries where each thread builds
-///   its own collector and registers a different number of types ahead of
-///   JITFRAME). An id resolved against that collector is only valid on that
-///   thread, so it lives beside the box, in a thread-local of the same scope.
-///   Without `majit-gc/gc_box` the `gc_box_installed()` probe is a constant
-///   `false`, the cell is unreachable, and it retires with the box.
-///
-/// Resolving once at install rather than at every entry keeps the hot entry
-/// from querying the type table (`resolve_jitframe_type_id`).
-static STANDALONE_JITFRAME_TYPE_ID: std::sync::atomic::AtomicU32 =
-    std::sync::atomic::AtomicU32::new(u32::MAX);
-
-thread_local! {
-    /// See [`STANDALONE_JITFRAME_TYPE_ID`]: the box-scoped twin.
-    static BOX_JITFRAME_TYPE_ID: core::cell::Cell<Option<u32>> = const {
-        core::cell::Cell::new(None)
-    };
-}
-
-fn resolve_jitframe_type_id(gc: &dyn majit_gc::GcAllocator) -> Option<u32> {
-    let id = crate::jitframe_gc_type_id()?;
-    (gc.type_size(id) == Some(JitFrame::alloc_size(0))).then_some(id)
-}
-
-fn set_standalone_jitframe_type_id(id: Option<u32>) {
-    STANDALONE_JITFRAME_TYPE_ID.store(id.unwrap_or(u32::MAX), Ordering::Release);
-}
-
-fn active_jitframe_type_id() -> Option<u32> {
-    if majit_gc::gc_box_installed() {
-        return BOX_JITFRAME_TYPE_ID.with(core::cell::Cell::get);
+/// `cpu.gc_ll_descr`: the installed collector, or [`HostHeapGc`] —
+/// `get_ll_description(None)` (gc.py:653) picks the Boehm descr when no
+/// framework GC is configured, and this is that descr. Same three-way
+/// routing as [`with_dynasm_active_gc_mut`], with the host descr in place of
+/// `None`.
+fn with_gc_ll_descr<R>(f: impl FnOnce(&mut dyn majit_gc::GcAllocator) -> R) -> R {
+    if gc_box::present() {
+        return gc_box::with_mut(f).expect("gc box present");
     }
-    match STANDALONE_JITFRAME_TYPE_ID.load(Ordering::Acquire) {
-        u32::MAX => None,
-        id => Some(id),
+    if majit_gc::gc_sync::is_initialized() {
+        return majit_gc::gc_sync::gc_op(|gc| f(gc));
     }
+    f(&mut HostHeapGc)
 }
 
 type EntryArgRoots = smallvec::SmallVec<[majit_gc::shadow_stack::OwnerRootGuard; 4]>;
 
-/// `gc_ll_descr.malloc_jitframe(frame_info)` (`llmodel.py:298`).
+/// `gc_ll_descr.malloc_jitframe(frame_info)` (`llmodel.py:298`) for a
+/// compiled entry.
 ///
-/// A registered JITFRAME type means the frontend installed the framework GC,
-/// so allocate the frame as the ordinary moving `GcStruct` upstream creates.
 /// Input refs take explicit owner-root slots across a possible collection,
-/// reproducing the roots RPython's GC transform puts around this allocation.
-/// A backend without a registered collector keeps the host fallback.
-
-fn alloc_entry_jitframe(
-    size_bytes: usize,
-    args: &[Value],
-) -> (*mut JitFrame, JitFrameHeap, EntryArgRoots) {
-    if let Some(type_id) = active_jitframe_type_id() {
-        // RPython's GC transform exposes every live Ref local while
-        // `malloc_jitframe` may collect. Rust's stack is not traced, so mirror
-        // those roots explicitly and read the possibly-forwarded values back
-        // when filling the frame below. Four stays inline for the ordinary
-        // portal shape; larger signatures pay one temporary host allocation.
-        let roots: EntryArgRoots = args
-            .iter()
-            .filter_map(|arg| match arg {
-                Value::Ref(value) => Some(majit_gc::shadow_stack::OwnerRootGuard::new(*value)),
-                _ => None,
-            })
-            .collect();
-        if let Some(gcref) =
-            with_dynasm_active_gc_mut(|gc| gc.alloc_nursery_typed(type_id, size_bytes))
-        {
-            assert!(!gcref.is_null(), "JITFRAME GC allocation failed");
-            unsafe { std::ptr::write_bytes(gcref.0 as *mut u8, 0, size_bytes) };
-            return (gcref.0 as *mut JitFrame, JitFrameHeap::Gc, roots);
-        }
-    }
-
-    let ptr = majit_backend::jitframe::alloc_off_gc_jitframe(size_bytes);
-    assert!(!ptr.is_null(), "off-GC JITFRAME allocation failed");
-    majit_gc::shadow_stack::register_libc_jitframe(ptr as usize);
-    (ptr, JitFrameHeap::Libc, EntryArgRoots::new())
+/// reproducing the roots RPython's GC transform puts around this allocation:
+/// Rust's stack is not traced, so the possibly-forwarded values are read back
+/// from the roots when the frame is filled. Four stays inline for the
+/// ordinary portal shape; larger signatures pay one temporary host allocation.
+/// Returns whether the frame is a collector object, which decides the
+/// deadframe that later owns it.
+fn alloc_entry_jitframe(size_bytes: usize, args: &[Value]) -> (*mut JitFrame, bool, EntryArgRoots) {
+    with_gc_ll_descr(|gc| {
+        let gc_object = jitframe_is_gc_object(gc);
+        let roots: EntryArgRoots = if gc_object {
+            args.iter()
+                .filter_map(|arg| match arg {
+                    Value::Ref(value) => Some(majit_gc::shadow_stack::OwnerRootGuard::new(*value)),
+                    _ => None,
+                })
+                .collect()
+        } else {
+            EntryArgRoots::new()
+        };
+        (malloc_jitframe(gc, size_bytes), gc_object, roots)
+    })
 }
 
-fn jitframe_is_gc_managed(frame: *mut JitFrame) -> bool {
-    with_dynasm_active_gc(|gc| gc.is_managed_heap_object(frame as usize)).unwrap_or(false)
+/// Whether the frames this thread's descr builds are collector objects.
+fn jitframe_is_gc_managed() -> bool {
+    with_gc_ll_descr(|gc| jitframe_is_gc_object(gc))
 }
 
 /// Store a GC allocator in the dynasm backend thread-local and register
@@ -481,7 +430,7 @@ fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
     majit_gc::disarm_published_nursery();
     majit_gc::note_gc_box_installed();
     let supports_guard_gc_type = gc.supports_guard_gc_type();
-    BOX_JITFRAME_TYPE_ID.with(|slot| slot.set(resolve_jitframe_type_id(gc.as_ref())));
+    check_jitframe_descr(gc.as_ref());
     gc_box::store(gc);
     register_active_hooks(supports_guard_gc_type);
 }
@@ -490,11 +439,11 @@ fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
 /// box, so every trampoline routes to the process-global `gc_sync` singleton
 /// (the per-thread GC box is the free-threading gap R4 removes).
 pub fn install_gc_standalone() {
-    majit_gc::gc_sync::gc_op(|gc| gc.freeze_types());
-    let (supports_guard_gc_type, jitframe_type_id) = majit_gc::gc_sync::gc_query(|gc| {
-        (gc.supports_guard_gc_type(), resolve_jitframe_type_id(gc))
+    majit_gc::gc_sync::gc_op(|gc| {
+        check_jitframe_descr(gc);
+        gc.freeze_types();
     });
-    set_standalone_jitframe_type_id(jitframe_type_id);
+    let supports_guard_gc_type = majit_gc::gc_sync::gc_query(|gc| gc.supports_guard_gc_type());
     register_active_hooks(supports_guard_gc_type);
 }
 
@@ -504,7 +453,6 @@ pub fn install_gc_standalone() {
 /// freed memory.
 pub fn clear_gc_allocator() {
     gc_box::clear();
-    BOX_JITFRAME_TYPE_ID.with(|slot| slot.set(None));
 }
 
 /// TYPE_INFO / CLASSTYPE constants read by the dynasm assemblers for
@@ -1142,15 +1090,7 @@ pub extern "C" fn dynasm_nursery_slowpath_headerless(size: u64) -> u64 {
 /// through the trailing array, i.e. it excludes the GC header that the
 /// allocator prepends internally.
 pub extern "C" fn dynasm_nursery_slowpath_jitframe(frame_size: u64) -> u64 {
-    let type_id = active_jitframe_type_id();
-    with_dynasm_active_gc_mut(|gc| {
-        if let Some(type_id) = type_id {
-            gc.alloc_nursery_typed(type_id, frame_size as usize).0 as u64
-        } else {
-            gc.alloc_nursery(frame_size as usize).0 as u64
-        }
-    })
-    .unwrap_or_else(|| majit_backend::jitframe::alloc_off_gc_jitframe(frame_size as usize) as u64)
+    with_gc_ll_descr(|gc| malloc_jitframe(gc, frame_size as usize)) as u64
 }
 
 /// `_build_malloc_slowpath(kind='var')` parity: varsize nursery
@@ -1544,44 +1484,19 @@ pub unsafe extern "C" fn dynasm_realloc_frame(
     expected_depth: isize,
 ) -> *mut JitFrame {
     let base_ofs = DynasmBackend::get_baseofs_of_frame_field() as isize;
-    let gc_managed = jitframe_is_gc_managed(old_jf);
     let new_jf = unsafe {
         majit_backend::jitframe::realloc_frame(
             old_jf,
             expected_depth,
             base_ofs,
-            |size_bytes| {
-                if gc_managed {
-                    let type_id = active_jitframe_type_id()
-                        .expect("a managed JITFRAME has a published type id");
-                    let gcref = with_dynasm_active_gc_mut(|gc| {
-                        gc.alloc_nursery_no_collect_typed(type_id, size_bytes as usize)
-                    })
-                    .expect("a managed JITFRAME has an active collector");
-                    assert!(!gcref.is_null(), "JITFRAME realloc failed");
-                    std::ptr::write_bytes(gcref.0 as *mut u8, 0, size_bytes as usize);
-                    gcref.0 as *mut JitFrame
-                } else {
-                    majit_backend::jitframe::alloc_off_gc_jitframe(size_bytes as usize)
-                }
-            },
-            |new_jf| {
-                if gc_managed {
-                    with_dynasm_active_gc_mut(|gc| gc.write_barrier(GcRef(new_jf as usize)))
-                        .expect("a managed JITFRAME has an active collector");
-                } else {
-                    majit_gc::shadow_stack::register_libc_jitframe(new_jf as usize);
-                }
-            },
+            |size_bytes| with_gc_ll_descr(|gc| malloc_jitframe_no_collect(gc, size_bytes as usize)),
+            |new_jf| with_gc_ll_descr(|gc| jitframe_write_barrier(gc, new_jf)),
         )
     };
-    if gc_managed {
-        // `frame.jf_forward = new_frame` is a GC-pointer store on the old
-        // frame. `realloc_frame` documents this caller-side barrier, matching
-        // the framework transform around llmodel.py:141.
-        with_dynasm_active_gc_mut(|gc| gc.write_barrier(GcRef(old_jf as usize)))
-            .expect("a managed JITFRAME has an active collector");
-    }
+    // `frame.jf_forward = new_frame` is a GC-pointer store on the old
+    // frame. `realloc_frame` documents this caller-side barrier, matching
+    // the framework transform around llmodel.py:141.
+    with_gc_ll_descr(|gc| jitframe_write_barrier(gc, old_jf));
     if crate::majit_log_enabled() {
         eprintln!(
             "[dynasm][realloc-frame] old={old_jf:p} new={new_jf:p} expected_depth={expected_depth}"
@@ -3038,7 +2953,7 @@ impl Backend for DynasmBackend {
             Self::input_slot(args.len()),
             args.len()
         );
-        let (jf_ptr, frame_heap, arg_roots) =
+        let (jf_ptr, gc_object, arg_roots) =
             alloc_entry_jitframe(JitFrame::alloc_size(num_slots), args);
         unsafe { JitFrame::init(jf_ptr, fi_ptr, num_slots) };
 
@@ -3166,18 +3081,19 @@ impl Backend for DynasmBackend {
         }
 
         // `llmodel.py return ll_frame` — the deadframe IS the frame the run
-        // returned. A framework-GC frame takes a movable owner-root slot;
-        // the no-collector fallback owns and later frees its off-GC chain.
-        match frame_heap {
-            JitFrameHeap::Gc => DeadFrame::JitFrame(JitFrameDeadFrame::new(
+        // returned. A collector object takes a movable owner-root slot; a
+        // host frame is owned, and its chain freed, by the deadframe.
+        if gc_object {
+            DeadFrame::JitFrame(JitFrameDeadFrame::new(
                 GcRef(result_jf as usize),
                 ExitDescr::owned(descr),
                 None,
                 None,
-            )),
-            JitFrameHeap::Libc => DeadFrame::LibcJitFrame(unsafe {
+            ))
+        } else {
+            DeadFrame::LibcJitFrame(unsafe {
                 LibcJitFrameDeadFrame::owning(jf_ptr, result_jf, num_slots, descr, None)
-            }),
+            })
         }
     }
 
@@ -3216,7 +3132,7 @@ impl Backend for DynasmBackend {
             Self::input_slot(args.len()),
             args.len()
         );
-        let (jf_ptr, frame_heap, _arg_roots) =
+        let (jf_ptr, gc_object, _arg_roots) =
             alloc_entry_jitframe(JitFrame::alloc_size(num_slots), &[]);
         unsafe { JitFrame::init(jf_ptr, fi_ptr, num_slots) };
 
@@ -3279,9 +3195,9 @@ impl Backend for DynasmBackend {
         let guard_value_operand = majit_backend::guard_value_counter_slot(descr_fd)
             .map(|slot| unsafe { crate::llmodel::get_int_value_direct(result_jf, slot) as i64 });
 
-        // No deadframe is built on this path. GC-managed frames become
-        // unreachable here; the host fallback still owns and frees its chain.
-        if frame_heap == JitFrameHeap::Libc {
+        // No deadframe is built on this path. A collector frame becomes
+        // unreachable here; a host frame's chain is freed.
+        if !gc_object {
             unsafe { majit_backend::libc_deadframe::free_jitframe_chain(jf_ptr) };
         }
 
@@ -3332,7 +3248,7 @@ impl Backend for DynasmBackend {
         // returns it — the forced frame IS the deadframe, and it belongs to
         // the compiled run that is still executing, so this deadframe borrows
         // it rather than taking the chain over.
-        if jitframe_is_gc_managed(frame) {
+        if jitframe_is_gc_managed() {
             Some(DeadFrame::JitFrame(JitFrameDeadFrame::borrowing(
                 GcRef(frame as usize),
                 ExitDescr::owned(descr),
@@ -4344,10 +4260,18 @@ mod tests {
         })
     }
 
-    fn install_call_assembler_test_layout() {
+    /// `jitframe.py` — the `JITFRAME` shape a collector with a type table must
+    /// carry before `check_jitframe_descr` lets it be installed.
+    fn register_jitframe_type(gc: &mut MiniMarkGC) -> u32 {
+        let id = gc.register_type(majit_backend::jitframe::jitframe_type_info());
+        majit_gc::GcAllocator::set_jitframe_type_id(gc, id);
+        id
+    }
+
+    fn install_call_assembler_test_layout(jitframe_tid: u32) {
         crate::register_jitframe_layout(crate::JitFrameLayoutInfo {
             jitframe_descrs: Some(majit_gc::rewrite::JitFrameDescrs {
-                jitframe_tid: crate::jitframe_gc_type_id().unwrap_or(u32::MAX),
+                jitframe_tid,
                 jitframe_fixed_size: JITFRAME_FIXED_SIZE,
                 jf_frame_info_ofs: JF_FRAME_INFO_OFS,
                 jf_descr_ofs: JF_DESCR_OFS,
@@ -4375,6 +4299,7 @@ mod tests {
         majit_gc::GcAllocator::register_vtable_for_type(&mut gc, int_vtable, int_tid);
 
         let mut backend = DynasmBackend::new();
+        register_jitframe_type(&mut gc);
         backend.set_gc_allocator(Box::new(gc));
 
         let resolved = backend.get_typeid_from_classptr_if_gcremovetypeptr(int_vtable);
@@ -4390,6 +4315,7 @@ mod tests {
         let obj = gc.alloc_with_type(obj_tid, 16);
 
         let mut backend = DynasmBackend::new();
+        register_jitframe_type(&mut gc);
         backend.set_gc_allocator(Box::new(gc));
 
         assert!(majit_gc::supports_guard_gc_type());
@@ -4475,6 +4401,7 @@ mod tests {
         consts.insert(10006, 16_i64);
         consts.insert(10007, 1_i64);
         backend.set_constants(consts);
+        register_jitframe_type(&mut gc);
         backend.set_gc_allocator(Box::new(gc));
 
         let inputargs = vec![];
@@ -4547,6 +4474,7 @@ mod tests {
         consts.insert(10006, 16_i64);
         consts.insert(10007, 1_i64);
         backend.set_constants(consts);
+        register_jitframe_type(&mut gc);
         backend.set_gc_allocator(Box::new(gc));
 
         let inputargs = vec![];
@@ -4626,6 +4554,7 @@ mod tests {
         consts.insert(10006, 111_i64);
         consts.insert(10007, 3_i64);
         backend.set_constants(consts);
+        register_jitframe_type(&mut gc);
         backend.set_gc_allocator(Box::new(gc));
 
         let inputargs = vec![InputArg::new_int(0)];
@@ -4707,6 +4636,7 @@ mod tests {
         consts.insert(10001, 256_i64);
         consts.insert(10002, 8_i64);
         backend.set_constants(consts);
+        register_jitframe_type(&mut gc);
         backend.set_gc_allocator(Box::new(gc));
 
         let inputargs = vec![InputArg::new_ref(0)];
@@ -4758,8 +4688,8 @@ mod tests {
         let wrong_vtable: usize = 0x2222_4400;
         majit_gc::GcAllocator::register_vtable_for_type(&mut gc, wrong_vtable, wrong_tid);
 
-        crate::set_jitframe_gc_type_id(jitframe_tid);
-        install_call_assembler_test_layout();
+        majit_gc::GcAllocator::set_jitframe_type_id(&mut gc, jitframe_tid);
+        install_call_assembler_test_layout(jitframe_tid);
         install_test_libc_jitframe_tracer();
 
         let mut backend = DynasmBackend::new();
@@ -4848,8 +4778,8 @@ mod tests {
         let wrong_vtable: usize = 0x3333_5500;
         majit_gc::GcAllocator::register_vtable_for_type(&mut gc, wrong_vtable, wrong_tid);
 
-        crate::set_jitframe_gc_type_id(jitframe_tid);
-        install_call_assembler_test_layout();
+        majit_gc::GcAllocator::set_jitframe_type_id(&mut gc, jitframe_tid);
+        install_call_assembler_test_layout(jitframe_tid);
         install_test_libc_jitframe_tracer();
 
         let mut backend = DynasmBackend::new();
@@ -5014,8 +4944,8 @@ mod tests {
         let payload_tid = gc.register_type(TypeInfo::simple(16));
         let payload = gc.alloc_with_type(payload_tid, 16);
 
-        crate::set_jitframe_gc_type_id(jitframe_tid);
-        install_call_assembler_test_layout();
+        majit_gc::GcAllocator::set_jitframe_type_id(&mut gc, jitframe_tid);
+        install_call_assembler_test_layout(jitframe_tid);
         install_test_libc_jitframe_tracer();
 
         let mut backend = DynasmBackend::new();
@@ -5058,8 +4988,8 @@ mod tests {
         let jitframe_tid = gc.register_type(majit_backend::jitframe::jitframe_type_info());
         let payload_tid = gc.register_type(TypeInfo::simple(16));
 
-        crate::set_jitframe_gc_type_id(jitframe_tid);
-        install_call_assembler_test_layout();
+        majit_gc::GcAllocator::set_jitframe_type_id(&mut gc, jitframe_tid);
+        install_call_assembler_test_layout(jitframe_tid);
         TEST_HELPER_ALLOC_TYPE_ID.store(payload_tid, Ordering::Relaxed);
 
         let mut backend = DynasmBackend::new();
@@ -5099,8 +5029,8 @@ mod tests {
         let jitframe_tid = gc.register_type(majit_backend::jitframe::jitframe_type_info());
         let payload_tid = gc.register_type(TypeInfo::simple(16));
 
-        crate::set_jitframe_gc_type_id(jitframe_tid);
-        install_call_assembler_test_layout();
+        majit_gc::GcAllocator::set_jitframe_type_id(&mut gc, jitframe_tid);
+        install_call_assembler_test_layout(jitframe_tid);
         TEST_HELPER_ALLOC_TYPE_ID.store(payload_tid, Ordering::Relaxed);
 
         let mut backend = DynasmBackend::new();

--- a/majit/majit-backend-dynasm/tests/basic_loop.rs
+++ b/majit/majit-backend-dynasm/tests/basic_loop.rs
@@ -471,6 +471,9 @@ fn test_gc_typeinfo_guards_use_dynasm_emit() {
 
     let mut backend = DynasmBackend::new();
     backend.attach_default_test_descrs();
+    // jitframe.py — a collector with a type table carries JITFRAME before install.
+    let jitframe_tid = gc.register_type(majit_backend::jitframe::jitframe_type_info());
+    majit_gc::GcAllocator::set_jitframe_type_id(&mut gc, jitframe_tid);
     backend.set_gc_allocator(Box::new(gc));
     let token = JitCellToken::new(41);
 
@@ -522,6 +525,9 @@ fn test_gc_typeinfo_guards_side_exit_on_mismatch() {
 
         let mut backend = DynasmBackend::new();
         backend.attach_default_test_descrs();
+        // jitframe.py — a collector with a type table carries JITFRAME before install.
+        let jitframe_tid = gc.register_type(majit_backend::jitframe::jitframe_type_info());
+        majit_gc::GcAllocator::set_jitframe_type_id(&mut gc, jitframe_tid);
         backend.set_gc_allocator(Box::new(gc));
         let token = JitCellToken::new(45);
 
@@ -559,6 +565,9 @@ fn test_gc_typeinfo_guards_side_exit_on_mismatch() {
 
         let mut backend = DynasmBackend::new();
         backend.attach_default_test_descrs();
+        // jitframe.py — a collector with a type table carries JITFRAME before install.
+        let jitframe_tid = gc.register_type(majit_backend::jitframe::jitframe_type_info());
+        majit_gc::GcAllocator::set_jitframe_type_id(&mut gc, jitframe_tid);
         backend.set_gc_allocator(Box::new(gc));
         let token = JitCellToken::new(46);
 
@@ -599,6 +608,9 @@ fn test_gc_typeinfo_guards_side_exit_on_mismatch() {
 
         let mut backend = DynasmBackend::new();
         backend.attach_default_test_descrs();
+        // jitframe.py — a collector with a type table carries JITFRAME before install.
+        let jitframe_tid = gc.register_type(majit_backend::jitframe::jitframe_type_info());
+        majit_gc::GcAllocator::set_jitframe_type_id(&mut gc, jitframe_tid);
         backend.set_gc_allocator(Box::new(gc));
         let token = JitCellToken::new(47);
 

--- a/majit/majit-backend-dynasm/tests/force_deadframe_gc.rs
+++ b/majit/majit-backend-dynasm/tests/force_deadframe_gc.rs
@@ -35,16 +35,16 @@
 //!   objects do not move again, so a collection taken before the drop cannot
 //!   witness a drop that damages the frame. Only this ordering can.
 //!
-//! The third, `owned_deadframe_registry_roots_the_returned_frames_refs`, moves
-//! the collection past the point where the run RETURNS, and so covers the
-//! other deadframe constructor. `execute_token` mints its result with
-//! `LibcJitFrameDeadFrame::owning`, which OWNS the chain; by then the compiled
-//! epilogue's `gen_footer_shadowstack` has popped the frame off the JF shadow
-//! stack, so the reason the borrowed cases stayed traceable is gone. What is
-//! left is `LIVE_DEADFRAMES`, the registry `owning` inserts into and `Drop`
-//! removes from, published to the collector as a root source. That test walks
-//! the registry to show the frame is in it and walks the JF shadow stack to
-//! show it is in nothing else, and only then collects.
+//! The third, `owned_deadframe_root_slot_roots_the_returned_frames_refs`,
+//! moves the collection past the point where the run RETURNS, and so covers
+//! the other deadframe constructor. `execute_token` mints its result with
+//! `JitFrameDeadFrame::new`, which takes an owner-root slot for the frame; by
+//! then the compiled epilogue's `gen_footer_shadowstack` has popped the frame
+//! off the JF shadow stack, so the reason the borrowed cases stayed traceable
+//! is gone. What is left is that slot, walked by the collector's root phase
+//! with the rest of the owner roots. That test walks the roots to show the
+//! frame is named there and walks the JF shadow stack to show it is in nothing
+//! else, and only then collects.
 use parking_lot::Mutex;
 use std::cell::{Cell, UnsafeCell};
 use std::rc::Rc;
@@ -58,8 +58,8 @@ use majit_ir::{
     Type, Value,
 };
 
-/// `LIVE_DEADFRAMES`, the libc-jitframe registry and the published nursery
-/// state are process-global, so a collection driven by one test would walk
+/// The owner-root slots and the published nursery state are shared beyond one
+/// fixture, so a collection driven by one test would walk
 /// another test's frames. Run them one at a time regardless of the harness's
 /// parallel scheduling; poison-tolerant so one failure does not wedge the rest.
 static SERIAL: Mutex<()> = Mutex::new(());
@@ -136,12 +136,13 @@ fn read_slots(backend: &DynasmBackend, frame: &DeadFrame) -> [GcRef; PROBE_COUNT
     std::array::from_fn(|index| backend.get_ref_value(frame, index))
 }
 
-/// The off-GC-heap frame `deadframe` reads through.
+/// The frame `deadframe` reads through, at its current address.
 fn frame_addr_of(deadframe: &DeadFrame) -> usize {
     deadframe
-        .as_libc_jitframe()
-        .expect("the dynasm backend mints only the off-GC-heap deadframe variant")
-        .frame_addr()
+        .as_jitframe()
+        .expect("a collector with JITFRAME registered hands out nursery frames")
+        .jf_gcref()
+        .0
 }
 
 /// The jitframe addresses this thread's JF shadow stack currently holds.
@@ -155,11 +156,12 @@ fn jf_shadow_stack_addrs() -> Vec<usize> {
     addrs
 }
 
-/// The payload addresses `walk_live_deadframes` currently yields — the set
-/// `LibcJitFrameDeadFrame::owning` inserts into and its `Drop` removes from.
-fn live_deadframe_addrs() -> Vec<usize> {
+/// The addresses this thread's non-jitframe roots currently hold — the
+/// shadow stack and the owner-root slots, the latter being where
+/// `JitFrameDeadFrame::new` parks the frame it owns and `Drop` releases it.
+fn owner_root_addrs() -> Vec<usize> {
     let mut addrs = Vec::new();
-    majit_backend::libc_deadframe::walk_live_deadframes(&mut |addr| addrs.push(addr));
+    majit_gc::shadow_stack::walk_roots(|root| addrs.push(root.0));
     addrs
 }
 
@@ -282,14 +284,12 @@ struct Fixture {
 
 impl Fixture {
     fn build(helper: extern "C" fn(i64), token_number: u64) -> Fixture {
-        // Without this the collector cannot walk a libc-allocated jitframe at
-        // all, and every slot check below would pass vacuously.
-        majit_gc::shadow_stack::register_libc_jitframe_tracer(
-            majit_backend_dynasm::jitframe::jitframe_custom_trace,
-        );
-
         let mut gc = majit_gc::collector::MiniMarkGC::new();
         let probe_tid = gc.register_type(majit_gc::TypeInfo::simple(PROBE_SIZE));
+        // jitframe.py — the frame is a nursery object traced through
+        // `jf_gcmap`; a collector with a type table must carry JITFRAME.
+        let jitframe_tid = gc.register_type(majit_backend::jitframe::jitframe_type_info());
+        majit_gc::GcAllocator::set_jitframe_type_id(&mut gc, jitframe_tid);
         let mut allocated = [GcRef(0); PROBE_COUNT];
         for (index, slot) in allocated.iter_mut().enumerate() {
             let obj = gc.alloc_with_type(probe_tid, PROBE_SIZE);
@@ -478,12 +478,12 @@ fn dropping_a_borrowed_deadframe_leaves_the_running_frame_traceable() {
     check_common(&fixture, &frame, &observed, observed.roots_after);
 }
 
-/// `execute_token` hands back a deadframe minted by
-/// `LibcJitFrameDeadFrame::owning`, and `owning` is what enters the frame into
-/// `LIVE_DEADFRAMES`. By then `gen_footer_shadowstack` has popped the frame off
-/// the JF shadow stack, so that registry is the only root source naming it —
-/// asserted here both ways round, present in the registry and absent from the
-/// shadow stack, before anything is collected.
+/// `execute_token` hands back a deadframe minted by `JitFrameDeadFrame::new`,
+/// which takes an owner-root slot for the frame. By then
+/// `gen_footer_shadowstack` has popped the frame off the JF shadow stack, so
+/// that slot is the only root naming it — asserted here both ways round,
+/// present among the owner roots and absent from the shadow stack, before
+/// anything is collected.
 ///
 /// The collection is taken here and not inside the helper, and that ordering is
 /// the test: a minor collection promotes every surviving nursery object and
@@ -491,7 +491,7 @@ fn dropping_a_borrowed_deadframe_leaves_the_running_frame_traceable() {
 /// was still on the shadow stack would fix the probe addresses and leave this
 /// one with nothing left to forward.
 #[test]
-fn owned_deadframe_registry_roots_the_returned_frames_refs() {
+fn owned_deadframe_root_slot_roots_the_returned_frames_refs() {
     let _serial = SERIAL.lock();
     let fixture = Fixture::build(force_read_and_collect_nothing, 5003);
     let (frame, observed) = fixture.run();
@@ -507,28 +507,35 @@ fn owned_deadframe_registry_roots_the_returned_frames_refs() {
          absence check below would be about a different frame"
     );
 
-    let live = live_deadframe_addrs();
+    let live = owner_root_addrs();
     assert!(
         live.contains(&tip),
-        "the returned deadframe's frame {tip:#x} is not in LIVE_DEADFRAMES ({live:#x?}), \
-         so the collector's deadframe root arm never names it"
+        "the returned deadframe's frame {tip:#x} is not among the owner roots ({live:#x?}), \
+         so the collector's root phase never names it"
     );
     let on_stack = jf_shadow_stack_addrs();
     assert!(
         !on_stack.contains(&tip),
         "frame {tip:#x} is still on the JF shadow stack ({on_stack:#x?}), so the collection \
-         below would root it through the stack and say nothing about LIVE_DEADFRAMES"
+         below would root it through the stack and say nothing about the owner root"
     );
 
     majit_gc::collect_full();
     let roots_after = probe_snapshot();
     check_common(&fixture, &frame, &observed, roots_after);
 
-    drop(frame);
-    let live = live_deadframe_addrs();
+    // The frame moved with the collection; the slot names the new address.
+    let moved = frame_addr_of(&frame);
+    let live = owner_root_addrs();
     assert!(
-        !live.contains(&tip),
-        "dropping the deadframe left frame {tip:#x} in LIVE_DEADFRAMES ({live:#x?}), \
-         which would keep the collector tracing freed memory"
+        live.contains(&moved),
+        "after the collection the owner roots ({live:#x?}) no longer name the frame {moved:#x}"
+    );
+    drop(frame);
+    let live = owner_root_addrs();
+    assert!(
+        !live.contains(&moved),
+        "dropping the deadframe left frame {moved:#x} among the owner roots ({live:#x?}), \
+         which would keep a dead frame alive"
     );
 }

--- a/majit/majit-backend/src/deadframe.rs
+++ b/majit/majit-backend/src/deadframe.rs
@@ -15,93 +15,49 @@ use majit_ir::{DescrRef, GcRef};
 use crate::ExitRecoveryLayout;
 use crate::jitframe::{FIRST_ITEM_OFFSET, JF_GUARD_EXC_OFS, JF_SAVEDATA_OFS, JitFrame};
 
-/// The Rust-heap backing of a jitframe, and where the memory goes when the
-/// deadframe holding it dies.
+/// The host-heap frame a deadframe owns, and its release.
 ///
-/// A backend with no JITFRAME type id to allocate under builds its frames out
-/// of the Rust heap instead of the nursery, one per compiled entry. The buffer
-/// is not read through this handle — the frame pointer the compiled code was
-/// handed points into it — so all this type does is decide the lifetime, which
-/// is why it is `_heap_owner` on the deadframe and never read there either.
+/// A descr with no `JITFRAME` type id builds its frames on the host heap
+/// (`jitframe::malloc_jitframe`), one per compiled entry. The frame is not
+/// read through this handle — the frame pointer the compiled code was handed
+/// points into it — so all this type does is decide the lifetime, which is
+/// why it is `_heap_owner` on the deadframe and never read there either.
 ///
-/// Two arms, chosen per allocation by [`jitframe_pool_enabled`], because what
-/// one costs against the other is a difference that has to be taken inside one
-/// binary:
-///
-/// * [`FrameHeapOwner::POOLED`] — the DEFAULT — takes the buffer off a
-///   per-thread free list and puts it back on drop, so a steady entry rate pays
-///   the allocator nothing after the first few calls.
-/// * [`FrameHeapOwner::OWNED`] is the probe arm: `vec![0i64; words]` in, free on
-///   drop. One `calloc`/`free` pair per entry.
-///
-/// Pooled is the default because it is the closer shape to the arm this whole
-/// type stands in for. `jitframe_allocate` builds the frame out of the GC
-/// nursery, which is a bump allocator with no per-frame release at all — that
-/// is the `use_gc_alloc` branch, live wherever a JITFRAME type id is
-/// registered. The allocator round trip is the deviation, not the baseline, so
-/// a build that reaches this type gets the free list unless it asks otherwise.
-///
-/// Measured, on a compiled cel entry: pooled is 2.62 ns/entry faster, negative
-/// in 24 of 24 shape-runs, and it makes the steady compiled tier
-/// allocation-free (`allocs_per_eval` 1.000 -> 0.000).
+/// Where the block goes on release is the free list's decision
+/// ([`jitframe_pool_enabled`]): `jitframe_allocate` builds the frame out of
+/// the GC nursery, a bump allocator with no per-frame release at all, so a
+/// steady entry rate that pays the allocator nothing is the closer shape and
+/// the default. Measured, on a compiled cel entry: pooled is 2.62 ns/entry
+/// faster, negative in 24 of 24 shape-runs, and it makes the steady compiled
+/// tier allocation-free (`allocs_per_eval` 1.000 -> 0.000). The owned arm —
+/// one allocation and one free per entry — is the probe.
 pub struct FrameHeapOwner {
-    /// Never empty for a live frame; `Drop` takes it out to hand it back.
-    buf: Vec<i64>,
-    /// Which arm allocated it, and therefore which one has to release it. A
-    /// buffer must go back to the arm it came from: pushing an `OWNED` one onto
-    /// the free list would be sound but would silently convert the probe arm
-    /// into the pooled one after its first entry.
-    pooled: bool,
+    frame: *mut JitFrame,
 }
 
 impl FrameHeapOwner {
-    pub const OWNED: bool = false;
-    pub const POOLED: bool = true;
-
-    /// A zeroed `words`-word buffer for one frame.
-    ///
-    /// Zeroed and not merely sized: the frame's header starts at word 0 and
-    /// `GuardNotForced` reads `jf_descr != 0`, so a reused buffer carrying the
-    /// previous entry's descr would fail a guard that did not fail. The owned
-    /// arm gets that from `calloc`; the pooled arm has to spell it.
-    ///
-    /// `pooled` is [`FrameHeapOwner::POOLED`] unless a caller selected the
-    /// other arm; the single call site reads [`jitframe_pool_enabled`].
-    pub fn new(words: usize, pooled: bool) -> Self {
-        let buf = if pooled {
-            take_pooled_frame_buf(words)
-        } else {
-            count_owned_frame_buf();
-            vec![0i64; words]
-        };
-        FrameHeapOwner { buf, pooled }
-    }
-
-    /// The base of the buffer — the word the frame's own header sits behind.
-    #[inline]
-    pub fn as_mut_ptr(&mut self) -> *mut i64 {
-        self.buf.as_mut_ptr()
+    /// Take over a host-heap frame from `jitframe::malloc_jitframe`.
+    pub fn of(frame: *mut JitFrame) -> Self {
+        FrameHeapOwner { frame }
     }
 }
 
 impl Drop for FrameHeapOwner {
-    /// Release the buffer, which for the pooled arm means handing it back.
+    /// Release the frame, which for the pooled arm means parking its block.
     ///
     /// This runs when the deadframe holding it drops, and the deadframe is the
     /// last thing that reads the frame: the compiled run finished before the
     /// deadframe was built, and every accessor on it goes through
     /// `jf_gcref()`. So the interior pointer compiled code was handed is dead
-    /// by the time the buffer is offered to the next entry. The pool hands a
-    /// buffer out by REMOVING it from the free list, so two live frames can
+    /// by the time the block is offered to the next entry. The pool hands a
+    /// block out by REMOVING it from the free list, so two live frames can
     /// never be looking at one.
     fn drop(&mut self) {
-        if self.pooled {
-            give_back_pooled_frame_buf(std::mem::take(&mut self.buf));
-        }
+        unsafe { crate::jitframe::free_host_jitframe(self.frame) };
     }
 }
 
-/// Frame buffers a thread keeps rather than frees.
+/// Frame blocks a thread keeps rather than frees.
 ///
 /// Small because the count that matters is the number of frames live at once,
 /// not the entry rate: entries are nested only by `execute_bridge` recursion
@@ -110,45 +66,28 @@ impl Drop for FrameHeapOwner {
 /// footprint without costing the ordinary one anything.
 const FRAME_POOL_CAPACITY: usize = 8;
 
-/// A buffer parked on the free list: a `Vec<i64>` taken apart into its three
-/// words, and put back together exactly as it was.
+/// A block parked on the free list: the base `jitframe::alloc_off_gc_jitframe`
+/// got from the allocator, and the size its slot records.
 #[derive(Clone, Copy)]
-struct ParkedBuf {
-    ptr: *mut i64,
-    len: usize,
-    cap: usize,
+struct ParkedBlock {
+    base: *mut u8,
+    total: usize,
 }
 
-impl ParkedBuf {
-    const EMPTY: ParkedBuf = ParkedBuf {
-        ptr: std::ptr::null_mut(),
-        len: 0,
-        cap: 0,
+impl ParkedBlock {
+    const EMPTY: ParkedBlock = ParkedBlock {
+        base: std::ptr::null_mut(),
+        total: 0,
     };
-
-    fn park(buf: Vec<i64>) -> Self {
-        let mut buf = std::mem::ManuallyDrop::new(buf);
-        ParkedBuf {
-            ptr: buf.as_mut_ptr(),
-            len: buf.len(),
-            cap: buf.capacity(),
-        }
-    }
-
-    fn unpark(self) -> Vec<i64> {
-        // Safety: `park` took these three from a live `Vec<i64>` and nothing
-        // else has owned them since.
-        unsafe { Vec::from_raw_parts(self.ptr, self.len, self.cap) }
-    }
 }
 
-/// Frees a thread's parked buffers when the thread exits.
+/// Frees a thread's parked blocks when the thread exits.
 ///
 /// `FRAME_POOL` has no destructor so that its access path stays the direct
 /// one; this key has one, and is touched exactly once per thread, on the
 /// first park, which is what registers it. Thread-local destructors run in
 /// no fixed order, but a key without one stays readable throughout, so the
-/// pool is still there when this runs. A buffer parked after it ran — a
+/// pool is still there when this runs. A block parked after it ran — a
 /// deadframe dropped during thread teardown — is the one case that leaks.
 struct PoolReaper;
 
@@ -157,7 +96,7 @@ impl Drop for PoolReaper {
         let _ = FRAME_POOL.try_with(|pool| {
             let mut pool = pool.borrow_mut();
             for parked in &pool.free[..pool.free_len] {
-                drop(parked.unpark());
+                unsafe { crate::jitframe::dealloc_off_gc_block(parked.base, parked.total) };
             }
             pool.free_len = 0;
         });
@@ -174,16 +113,16 @@ thread_local! {
 /// kept on a key the hot path never touches.
 #[derive(Clone, Copy)]
 struct FramePool {
-    free: [ParkedBuf; FRAME_POOL_CAPACITY],
+    free: [ParkedBlock; FRAME_POOL_CAPACITY],
     free_len: usize,
     /// Whether `POOL_REAPER` has been registered on this thread.
     reaper_armed: bool,
-    /// Buffers the owned arm asked the allocator for.
+    /// Blocks the owned arm asked the allocator for.
     owned: u64,
-    /// Buffers the pooled arm handed out.
+    /// Blocks the pooled arm handed out.
     taken: u64,
-    /// …of which the free list was empty for, so the allocator was asked after
-    /// all. `taken - misses` is what pooling actually saved.
+    /// …of which the free list had nothing usable for, so the allocator was
+    /// asked after all. `taken - misses` is what pooling actually saved.
     misses: u64,
 }
 
@@ -192,29 +131,17 @@ thread_local! {
     ///
     /// The effect being bought is 2.62 ns per entry. A pool shared between
     /// threads costs an uncontended atomic read-modify-write pair to take and to
-    /// return a buffer, which is the same order as the saving, so a process-wide
+    /// return a block, which is the same order as the saving, so a process-wide
     /// free list would hand back what it was built to remove. Sharding by thread
     /// is what leaves the take and the return as plain pops and pushes.
     ///
     /// A field would be the alternative to a `thread_local!`, and there is no
     /// object to make it a field of: `run_compiled_code` and
-    /// `FrameHeapOwner::drop` share no owner, and the buffer is taken by one
-    /// and returned by the other, in a different scope and after the caller
-    /// has moved on.
-    ///
-    /// Per-thread is also the right scope for the lifetime, not merely a cheap
-    /// one. A buffer is taken and returned inside one compiled entry, which runs
-    /// to completion on its caller's thread and never hands the frame to another;
-    /// a buffer parked on some other thread's list is one this entry could not
-    /// have used.
-    ///
-    /// Handing a buffer out REMOVES it from `free`, so two live frames can never
-    /// address one. Every access is `try_with`: a frame outliving its thread's
-    /// TLS teardown would otherwise panic inside a `Drop`, and falling back to
-    /// the allocator is the answer there.
+    /// `execute_token` are free functions on the backend, and the backend
+    /// value itself is not on the entry path.
     static FRAME_POOL: RefCell<FramePool> = const {
         RefCell::new(FramePool {
-            free: [ParkedBuf::EMPTY; FRAME_POOL_CAPACITY],
+            free: [ParkedBlock::EMPTY; FRAME_POOL_CAPACITY],
             free_len: 0,
             reaper_armed: false,
             owned: 0,
@@ -224,48 +151,60 @@ thread_local! {
     };
 }
 
-fn take_pooled_frame_buf(words: usize) -> Vec<i64> {
-    let pooled = FRAME_POOL.try_with(|pool| {
-        let mut pool = pool.borrow_mut();
-        pool.taken += 1;
-        if pool.free_len == 0 {
-            pool.misses += 1;
-            None
-        } else {
-            pool.free_len -= 1;
-            Some(pool.free[pool.free_len].unpark())
-        }
-    });
-    match pooled {
-        Ok(Some(mut buf)) => {
-            // Grow-only. A frame is 21-22 words on the shapes measured so far
-            // and 16 more on the tall ones, so the list converges on the tallest
-            // frame the thread has run and stops resizing.
-            if buf.len() < words {
-                buf.resize(words, 0);
-            }
-            buf[..words].fill(0);
-            buf
-        }
-        _ => vec![0i64; words],
+/// A parked block of at least `total` bytes, for `alloc_off_gc_jitframe`.
+///
+/// `None` when the arm is owned (tallied as such), the list is empty, or its
+/// top block is too small — that one is released, so the list converges on
+/// the tallest frame the thread has run and stops churning.
+pub(crate) fn take_pooled_block(total: usize) -> Option<*mut u8> {
+    if !jitframe_pool_enabled() {
+        count_owned_frame_block();
+        return None;
     }
+    FRAME_POOL
+        .try_with(|pool| {
+            let mut pool = pool.borrow_mut();
+            pool.taken += 1;
+            if pool.free_len == 0 {
+                pool.misses += 1;
+                return None;
+            }
+            pool.free_len -= 1;
+            let parked = pool.free[pool.free_len];
+            if parked.total >= total {
+                return Some(parked.base);
+            }
+            pool.misses += 1;
+            unsafe { crate::jitframe::dealloc_off_gc_block(parked.base, parked.total) };
+            None
+        })
+        .ok()
+        .flatten()
 }
 
-fn give_back_pooled_frame_buf(buf: Vec<i64>) {
-    // A full list, or no list: `buf` drops and the allocator takes it back.
-    let _ = FRAME_POOL.try_with(|pool| {
-        let mut pool = pool.borrow_mut();
-        if pool.free_len < FRAME_POOL_CAPACITY {
+/// Park a block on the free list. `false` when it must go back to the
+/// allocator instead: the owned arm, a full list, or no list.
+pub(crate) fn give_back_pooled_block(base: *mut u8, total: usize) -> bool {
+    if !jitframe_pool_enabled() {
+        return false;
+    }
+    FRAME_POOL
+        .try_with(|pool| {
+            let mut pool = pool.borrow_mut();
+            if pool.free_len >= FRAME_POOL_CAPACITY {
+                return false;
+            }
             if !pool.reaper_armed {
                 pool.reaper_armed = true;
                 // First touch registers its destructor for this thread.
                 let _ = POOL_REAPER.try_with(|_| ());
             }
             let at = pool.free_len;
-            pool.free[at] = ParkedBuf::park(buf);
+            pool.free[at] = ParkedBlock { base, total };
             pool.free_len += 1;
-        }
-    });
+            true
+        })
+        .unwrap_or(false)
 }
 
 /// Tally one owned allocation.
@@ -275,7 +214,7 @@ fn give_back_pooled_frame_buf(buf: Vec<i64>) {
 /// This is charged to the OWNED arm alone, and the default arm is not OWNED —
 /// so it is a cost of the probe, not of the shipping path. Anyone reading an
 /// owned-arm figure should read it as the allocator round trip plus this.
-fn count_owned_frame_buf() {
+fn count_owned_frame_block() {
     let _ = FRAME_POOL.try_with(|pool| pool.borrow_mut().owned += 1);
 }
 
@@ -293,7 +232,7 @@ pub fn jitframe_pool_counts() -> (u64, u64, u64) {
         .unwrap_or((0, 0, 0))
 }
 
-/// Which arm [`FrameHeapOwner::new`] allocates through.
+/// Which arm `alloc_off_gc_jitframe` allocates through.
 ///
 /// `Unseeded` is the state before the first entry reads the selector, not a
 /// third strategy: the first read resolves it to one of the other two and
@@ -326,8 +265,8 @@ static POOL_ARM: AtomicU8 = AtomicU8::new(PoolArm::Unseeded as u8);
 
 /// Select the frame-allocation arm for subsequent compiled entries.
 ///
-/// Either direction: `false` selects [`FrameHeapOwner::OWNED`] on a build whose
-/// default is pooled. Overrides `MAJIT_JITFRAME_POOL`, which is only how a
+/// Either direction: `false` selects the owned arm on a build whose default
+/// is pooled. Overrides `MAJIT_JITFRAME_POOL`, which is only how a
 /// harness that cannot call this — a test binary with no hook of its own —
 /// picks an arm.
 pub fn set_jitframe_pool(on: bool) {
@@ -584,9 +523,9 @@ impl JitFrameDeadFrame {
     /// Take a root slot for `jf_gcref` and hold it for the deadframe's life.
     ///
     /// `heap_owner` decides whether the frame is rooted at all, because it is
-    /// the same condition: a frame handed a `Vec` owner was allocated out of
-    /// the Rust heap precisely because there was no type registry to allocate
-    /// it from the nursery under, and a frame allocated from the nursery is
+    /// the same condition: a frame handed an owner was built on the host heap
+    /// precisely because the descr had no `JITFRAME` type id to allocate it
+    /// from the nursery under, and a frame allocated from the nursery is
     /// always handed `None`.
     pub fn new(
         jf_gcref: GcRef,

--- a/majit/majit-backend/src/jitframe.rs
+++ b/majit/majit-backend/src/jitframe.rs
@@ -202,15 +202,14 @@ fn off_gc_layout(total: usize) -> Option<std::alloc::Layout> {
 ///
 /// `jitframe.py:48` allocates every frame through the GC, so upstream's
 /// compiled code always holds a frame that has a header behind it. Pyre also
-/// builds frames off the GC — the runner's entry frame, the realloc slowpath,
-/// and the JITFRAME nursery slowpath's fallback, the class
-/// `shadow_stack::register_libc_jitframe` tracks — and compiled code cannot
-/// tell the two apart. `_reload_frame_if_necessary`
-/// (`aarch64/assembler.py:967-980`) re-applies the non-array write-barrier
-/// fast path to the current frame after every collecting call, and that fast
-/// path loads the flag byte at `jit_wb_if_flag_byteofs`, which is *negative*
-/// (`gc.py:285-293` measures it from the object pointer, and the flags sit in
-/// the header at `obj-4`).
+/// builds frames off the GC — [`malloc_jitframe`] under a descr with no
+/// `JITFRAME` type id, the class `shadow_stack::register_libc_jitframe`
+/// tracks — and compiled code cannot tell the two apart.
+/// `_reload_frame_if_necessary` (`aarch64/assembler.py:967-980`) re-applies
+/// the non-array write-barrier fast path to the current frame after every
+/// collecting call, and that fast path loads the flag byte at
+/// `jit_wb_if_flag_byteofs`, which is *negative* (`gc.py:285-293` measures it
+/// from the object pointer, and the flags sit in the header at `obj-4`).
 ///
 /// Handing out a bare allocation base therefore puts that load outside the
 /// block: usually it reads unrelated bytes and, when they happen to carry
@@ -218,6 +217,10 @@ fn off_gc_layout(total: usize) -> Option<std::alloc::Layout> {
 /// lands at the start of a mapped region it faults outright. Reserving the
 /// header word makes the read in-bounds, and the zeroed flags give it the
 /// same answer a freshly nursery-allocated frame gives — no barrier.
+///
+/// The block comes off the thread's free list when
+/// [`crate::deadframe::jitframe_pool_enabled`] says so, and from the
+/// allocator otherwise; either way it is zeroed through `size_bytes`.
 ///
 /// Returns null when the allocation fails.
 pub fn alloc_off_gc_jitframe(size_bytes: usize) -> *mut JitFrame {
@@ -227,6 +230,14 @@ pub fn alloc_off_gc_jitframe(size_bytes: usize) -> *mut JitFrame {
     let Some(layout) = off_gc_layout(total) else {
         return std::ptr::null_mut();
     };
+    if let Some(base) = crate::deadframe::take_pooled_block(total) {
+        // A parked block keeps its own size slot; only the bytes this frame
+        // will read are cleared.
+        unsafe {
+            std::ptr::write_bytes(base.add(OFF_GC_SIZE_SLOT), 0, total - OFF_GC_SIZE_SLOT);
+            return base.add(OFF_GC_PREFIX) as *mut JitFrame;
+        }
+    }
     let base = unsafe { std::alloc::alloc_zeroed(layout) };
     if base.is_null() {
         return std::ptr::null_mut();
@@ -241,6 +252,7 @@ pub fn alloc_off_gc_jitframe(size_bytes: usize) -> *mut JitFrame {
 ///
 /// The frame pointer is not the block base — the size slot and the header word
 /// precede it — so this must be used instead of freeing the frame pointer.
+/// A block the thread's free list has room for is parked there instead.
 ///
 /// # Safety
 /// `frame` must have come from [`alloc_off_gc_jitframe`] and must no longer be
@@ -252,8 +264,226 @@ pub unsafe fn free_off_gc_jitframe(frame: *mut JitFrame) {
     unsafe {
         let base = (frame as *mut u8).sub(OFF_GC_PREFIX);
         let total = *(base as *const u64) as usize;
-        let layout = off_gc_layout(total).expect("off-GC jitframe size slot was corrupted");
-        std::alloc::dealloc(base, layout);
+        if crate::deadframe::give_back_pooled_block(base, total) {
+            return;
+        }
+        dealloc_off_gc_block(base, total);
+    }
+}
+
+/// Return an [`alloc_off_gc_jitframe`] block to the allocator.
+///
+/// # Safety
+/// `base` must be the block base and `total` the value of its size slot.
+pub(crate) unsafe fn dealloc_off_gc_block(base: *mut u8, total: usize) {
+    let layout = off_gc_layout(total).expect("off-GC jitframe size slot was corrupted");
+    unsafe { std::alloc::dealloc(base, layout) };
+}
+
+// ── The descr's frame allocation ────────────────────────────────────
+
+/// Zero-fill a frame the nursery handed back.
+///
+/// RPython's nursery is zeroed once per reset, so `lltype.malloc(JITFRAME)`
+/// returns cleared memory and `GuardNotForced` can read `jf_descr != 0`.
+/// Ours is not, so a fresh frame is cleared here.
+fn zeroed_nursery_frame(gcref: majit_ir::GcRef, size_bytes: usize) -> *mut JitFrame {
+    assert!(!gcref.is_null(), "JITFRAME nursery allocation failed");
+    unsafe { std::ptr::write_bytes(gcref.0 as *mut u8, 0, size_bytes) };
+    gcref.0 as *mut JitFrame
+}
+
+/// `llmodel.py:298` `frame = self.gc_ll_descr.malloc_jitframe(frame_info)`,
+/// reached through `GcLLDescription.malloc_jitframe` (gc.py:132) and
+/// `jitframe_allocate` (`jitframe.py:48`).
+///
+/// The descr decides where the frame lives: under its `JITFRAME` type id it
+/// is a nursery object the collector traces through `jitframe_trace` and may
+/// move; without one — an allocator with no type table, or [`HostHeapGc`]
+/// when nothing is installed — it is a host block the libc-jitframe tracer
+/// walks in place. The caller sees one frame pointer either way; what
+/// differs is only whether the deadframe that later owns it takes a root
+/// slot ([`jitframe_is_gc_object`]) and whether a store into it needs a
+/// barrier ([`jitframe_write_barrier`]).
+///
+/// The nursery arm may collect, so the caller must have its inputs rooted.
+/// `size_bytes` is the payload size ([`JitFrame::alloc_size`]).
+pub fn malloc_jitframe(gc: &mut dyn majit_gc::GcAllocator, size_bytes: usize) -> *mut JitFrame {
+    match gc.jitframe_type_id() {
+        Some(type_id) => {
+            zeroed_nursery_frame(gc.alloc_nursery_typed(type_id, size_bytes), size_bytes)
+        }
+        None => malloc_host_jitframe(size_bytes),
+    }
+}
+
+/// [`malloc_jitframe`] for a caller holding unrooted references on the Rust
+/// stack: the nursery arm falls back to the old generation instead of
+/// collecting. `llmodel.py:140`'s realloc slow path and the compiled-entry
+/// frame are built this way.
+pub fn malloc_jitframe_no_collect(
+    gc: &mut dyn majit_gc::GcAllocator,
+    size_bytes: usize,
+) -> *mut JitFrame {
+    match gc.jitframe_type_id() {
+        Some(type_id) => zeroed_nursery_frame(
+            gc.alloc_nursery_no_collect_typed(type_id, size_bytes),
+            size_bytes,
+        ),
+        None => malloc_host_jitframe(size_bytes),
+    }
+}
+
+/// The host-heap arm of [`malloc_jitframe`]: an off-GC block, registered so
+/// the collector's root walk finds its ref slots.
+fn malloc_host_jitframe(size_bytes: usize) -> *mut JitFrame {
+    let frame = alloc_off_gc_jitframe(size_bytes);
+    assert!(!frame.is_null(), "JITFRAME host allocation failed");
+    majit_gc::shadow_stack::register_libc_jitframe(frame as usize);
+    frame
+}
+
+/// Release a frame from [`malloc_jitframe`] that no compiled code, shadow
+/// stack or deadframe still names.
+///
+/// A GC object is left to the collector — RPython never frees a frame — so
+/// only the host arm does anything.
+///
+/// # Safety
+/// `frame` must have come from [`malloc_jitframe`] under this descr and be
+/// unreachable.
+pub unsafe fn free_jitframe(gc: &dyn majit_gc::GcAllocator, frame: *mut JitFrame) {
+    if jitframe_is_gc_object(gc) {
+        return;
+    }
+    unsafe { free_host_jitframe(frame) };
+}
+
+/// The host arm of [`free_jitframe`], for an owner that already knows its
+/// frame is a host block.
+///
+/// # Safety
+/// As [`free_jitframe`].
+pub unsafe fn free_host_jitframe(frame: *mut JitFrame) {
+    majit_gc::shadow_stack::unregister_libc_jitframe(frame as usize);
+    unsafe { free_off_gc_jitframe(frame) };
+}
+
+/// Whether this descr's frames are collector objects — the moving,
+/// header-carrying kind that must be held through a root slot — as opposed
+/// to host blocks. One descr answers this the same way for every frame it
+/// ever built.
+#[inline]
+pub fn jitframe_is_gc_object(gc: &dyn majit_gc::GcAllocator) -> bool {
+    gc.jitframe_type_id().is_some()
+}
+
+/// `llop.gc_writebarrier(lltype.Void, frame)` (`llmodel.py`) for a raw store
+/// into a frame from [`malloc_jitframe`].
+///
+/// Upstream emits the barrier unconditionally because every frame is a GC
+/// object; here a host block has no header for a barrier to mark, so the
+/// descr's arm decides.
+pub fn jitframe_write_barrier(gc: &mut dyn majit_gc::GcAllocator, frame: *mut JitFrame) {
+    if jitframe_is_gc_object(gc) {
+        gc.write_barrier(majit_ir::GcRef(frame as usize));
+    }
+}
+
+/// Refuse an install whose descr cannot allocate frames the collector can
+/// trace.
+///
+/// `jitframe.py` registers `JITFRAME`'s custom trace hook as part of
+/// translating the frontend, so the shape is settled before any compiled code
+/// exists. Same ordering here, made a precondition: a collector with a type
+/// table must arrive with its `JITFRAME` id set (`set_jitframe_type_id`),
+/// and the id must name a `JITFRAME` — an id minted for another shape would
+/// have the collector copy frames under the wrong layout. A collector without
+/// a table is exempt: it has no shape to name, and its frames are host
+/// blocks. Registering here instead would mint an id in a table the frontend
+/// may already have frozen (`gctypelayout.py:393-398`).
+pub fn check_jitframe_descr(gc: &dyn majit_gc::GcAllocator) {
+    if !gc.has_type_registry() {
+        return;
+    }
+    let Some(id) = gc.jitframe_type_id() else {
+        panic!(
+            "installing a collector with a type registry requires the JITFRAME type id: \
+             register majit_backend::jitframe::jitframe_type_info() on that collector \
+             and pass the id to GcAllocator::set_jitframe_type_id() BEFORE the install"
+        );
+    };
+    assert_eq!(
+        gc.type_size(id),
+        Some(jitframe_type_info().size),
+        "JITFRAME type id {id} does not name a JITFRAME in the collector being installed"
+    );
+}
+
+/// The descr in force when no collector is installed: `GcLLDescr_boehm`
+/// (gc.py:151), which `get_ll_description(None)` (gc.py:653) selects.
+///
+/// Non-moving, no type table, `supports_guard_gc_type = False`. Its only
+/// job is [`malloc_jitframe`]'s host arm; compiled code under it allocates
+/// nothing else, because a backend without a collector never turns
+/// `new_via_gc` on, so every other allocation entry is unreachable and says
+/// so.
+pub struct HostHeapGc;
+
+impl HostHeapGc {
+    fn no_heap() -> ! {
+        panic!("HostHeapGc allocates only jitframes; no collector is installed")
+    }
+}
+
+impl majit_gc::GcAllocator for HostHeapGc {
+    fn alloc_nursery(&mut self, _size: usize) -> majit_ir::GcRef {
+        Self::no_heap()
+    }
+    fn alloc_nursery_no_collect(&mut self, _size: usize) -> majit_ir::GcRef {
+        Self::no_heap()
+    }
+    fn alloc_varsize(
+        &mut self,
+        _base_size: usize,
+        _item_size: usize,
+        _length: usize,
+    ) -> majit_ir::GcRef {
+        Self::no_heap()
+    }
+    fn alloc_varsize_no_collect(
+        &mut self,
+        _base_size: usize,
+        _item_size: usize,
+        _length: usize,
+    ) -> majit_ir::GcRef {
+        Self::no_heap()
+    }
+    fn write_barrier(&mut self, _obj: majit_ir::GcRef) {}
+    fn jit_remember_young_pointer_from_array(&mut self, _obj: majit_ir::GcRef) {}
+    fn remember_young_pointer_from_array2(
+        &mut self,
+        _obj: majit_ir::GcRef,
+        _index: usize,
+        _card: u32,
+    ) {
+    }
+    fn collect_nursery(&mut self) {}
+    fn collect_full(&mut self) {}
+    fn nursery_free(&self) -> *mut u8 {
+        Self::no_heap()
+    }
+    fn nursery_free_addr(&self) -> usize {
+        Self::no_heap()
+    }
+    fn nursery_top(&self) -> *const u8 {
+        Self::no_heap()
+    }
+    fn nursery_top_addr(&self) -> usize {
+        Self::no_heap()
+    }
+    fn max_nursery_object_size(&self) -> usize {
+        0
     }
 }
 

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -928,6 +928,9 @@ pub struct MiniMarkGC {
     oldgen: OldGen,
     /// Type registry for tracing objects.
     pub types: TypeRegistry,
+    /// The registered `JITFRAME` type, once the frontend has named it
+    /// (`GcAllocator::set_jitframe_type_id`).
+    jitframe_type_id: Option<u32>,
     /// Root set.
     pub roots: RootSet,
     /// incminimark.py:344 `old_objects_pointing_to_young = AddressStack()`.
@@ -1267,6 +1270,7 @@ impl MiniMarkGC {
             published_nursery_top,
             oldgen: OldGen::new(),
             types: TypeRegistry::new(),
+            jitframe_type_id: None,
             roots: RootSet::new(),
             old_objects_pointing_to_young: Vec::new(),
             prebuilt_root_objects: Vec::new(),
@@ -8865,6 +8869,18 @@ impl GcAllocator for MiniMarkGC {
     /// this allocator — including before anything has been registered in it.
     fn has_type_registry(&self) -> bool {
         true
+    }
+
+    fn set_jitframe_type_id(&mut self, id: u32) {
+        assert!(
+            (id as usize) < self.types.len(),
+            "JITFRAME type id {id} is not registered on this collector"
+        );
+        self.jitframe_type_id = Some(id);
+    }
+
+    fn jitframe_type_id(&self) -> Option<u32> {
+        self.jitframe_type_id
     }
 
     /// gc.py `GcLLDescr_framework.supports_guard_gc_type = True`.

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1138,6 +1138,32 @@ pub trait GcAllocator: Send {
         false
     }
 
+    /// Tell the descr which registered type is `JITFRAME`.
+    ///
+    /// `jitframe.py` declares `JITFRAME` as a static `GcStruct` and
+    /// `GcLLDescription.malloc_jitframe` (gc.py:132) allocates it by that
+    /// name; the descr never has to be told. Here the shape is registered on
+    /// the collector at frontend build time (`jitframe_type_info()`), so the
+    /// id it received is handed to the descr once, right after that
+    /// registration and before `freeze_types`. The default drops the id: an
+    /// allocator with no type table has no shape to name, and its frames are
+    /// built on the host heap instead (see `jitframe_type_id`).
+    fn set_jitframe_type_id(&mut self, id: u32) {
+        let _ = id;
+    }
+
+    /// The `JITFRAME` type id this descr allocates frames under, or `None`
+    /// for an allocator with no type table.
+    ///
+    /// `None` is what makes a frame a host-heap block rather than a GC
+    /// object: `GcLLDescr_boehm` (gc.py:151) is the closest upstream shape,
+    /// a non-moving descr whose frames need no root slot and no barrier. The
+    /// backends read this through `majit_backend::jitframe::malloc_jitframe`
+    /// and never branch on it themselves.
+    fn jitframe_type_id(&self) -> Option<u32> {
+        None
+    }
+
     /// llsupport/gc.py:162 / gc.py:318 `supports_guard_gc_type` flag.
     /// `GcLLDescr_boehm` sets it to `False`; `GcLLDescr_framework` sets
     /// it to `True`. Relayed to `cpu.supports_guard_gc_type` via
@@ -1591,6 +1617,12 @@ impl GcAllocator for GcHandle {
     }
     fn has_type_registry(&self) -> bool {
         gc_sync::gc_query_reentrant(|gc| gc.has_type_registry())
+    }
+    fn set_jitframe_type_id(&mut self, id: u32) {
+        gc_sync::gc_op(|gc| gc.set_jitframe_type_id(id))
+    }
+    fn jitframe_type_id(&self) -> Option<u32> {
+        gc_sync::gc_query_reentrant(|gc| gc.jitframe_type_id())
     }
     fn supports_guard_gc_type(&self) -> bool {
         gc_sync::gc_query_reentrant(|gc| gc.supports_guard_gc_type())

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -9345,6 +9345,18 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
         "raw_load_f/iid>f".to_string(),
         majit_translate::insns::BC_RAW_LOAD_F,
     );
+    // The two float<->int bitcasts, `majit_f64_to_bits` / `majit_bits_to_f64`.
+    // A `#[jit_interp]` arm carries a float across a branch as its bits (the
+    // lowerer expresses a float only as one float op's result), so a resume
+    // through such an arm dispatches these; their handlers are wired below.
+    insns.insert(
+        "convert_float_bytes_to_longlong/f>i".to_string(),
+        majit_translate::insns::BC_CONVERT_FLOAT_BYTES_TO_LONGLONG,
+    );
+    insns.insert(
+        "convert_longlong_bytes_to_float/i>f".to_string(),
+        majit_translate::insns::BC_CONVERT_LONGLONG_BYTES_TO_FLOAT,
+    );
     insns.insert(
         "setarrayitem_gc_i/riid".to_string(),
         majit_translate::insns::BC_SETARRAYITEM_GC_I,

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -149,7 +149,7 @@ mod pyjitpl;
 #[cfg(not(target_arch = "wasm32"))]
 pub use pyjitpl::{
     active_backend_jit_exc_value_peek, install_active_backend_gc_standalone,
-    register_active_backend_jitframe_gc_type, set_active_backend_jitframe_gc_type_id,
+    register_active_backend_jitframe_gc_type,
 };
 pub mod quasiimmut;
 pub use quasiimmut::set_force_quasi_immutable_hook;

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -37,37 +37,17 @@ pub(crate) use majit_backend_dynasm::runner::DynasmBackend as BackendImpl;
 pub(crate) use majit_backend_wasm::WasmBackend as BackendImpl;
 use majit_ir::operand::Operand;
 
-/// Publish the native JITFRAME type id to the CPU selected by this
-/// metainterpreter build.
-///
-/// `MetaInterpStaticData.cpu` is the single backend authority in PyPy.  Keep
-/// that ownership at this crate boundary too: a workspace build may unify
-/// dependency features differently from an interpreter crate's own features,
-/// so the caller cannot reliably repeat the `BackendImpl` cfg decision.
-#[cfg(all(feature = "cranelift", not(target_arch = "wasm32")))]
-pub fn set_active_backend_jitframe_gc_type_id(id: u32) {
-    majit_backend_cranelift::set_jitframe_gc_type_id(id);
-}
-
-#[cfg(all(
-    feature = "dynasm",
-    not(feature = "cranelift"),
-    not(target_arch = "wasm32")
-))]
-pub fn set_active_backend_jitframe_gc_type_id(id: u32) {
-    majit_backend_dynasm::set_jitframe_gc_type_id(id);
-}
-
 /// Register RPython's `JITFRAME` shape on the frontend-owned collector and
-/// publish the assigned id to the selected native CPU.
+/// tell the descr its id.
 ///
-/// Registration belongs to the frontend because its type table fixes the id;
-/// publishing belongs here because this crate alone selects the active CPU.
-/// Call this before `JitDriver::set_gc_allocator`, which freezes the table.
+/// `jitframe.py` declares `JITFRAME` statically and the descr allocates it by
+/// name; here the frontend's type table fixes the id, so the descr is told
+/// once. Call this before `JitDriver::set_gc_allocator`, which freezes the
+/// table.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn register_active_backend_jitframe_gc_type(gc: &mut dyn majit_gc::GcAllocator) -> u32 {
     let id = gc.register_type(majit_backend::jitframe::jitframe_type_info());
-    set_active_backend_jitframe_gc_type_id(id);
+    gc.set_jitframe_type_id(id);
     id
 }
 

--- a/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
+++ b/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
@@ -310,20 +310,16 @@ fn install_gc() {
     // this thread holds. The meter owns its process (`harness = false`), so it
     // holds the GIL for the whole run and never has to hand it back.
     majit_gc::gc_sync::register_thread();
-    // The cranelift backend requires the JITFRAME id before the install — its
-    // absence is what the doc above calls "with no GC at all it falls back to a
-    // `Vec<i64>`", now a refusal rather than a fallback. Registering the shape
-    // on the singleton and publishing its id is what `eval.rs build_gc` does.
-    // Only under this cfg: the dynasm backend's frame source is settled
-    // separately, and publishing for it would move the frame this file
-    // measures.
-    #[cfg(feature = "cranelift")]
-    {
-        let jitframe_tid = majit_gc::gc_sync::gc_op(|gc| {
-            majit_gc::GcAllocator::register_type(gc, majit_backend::jitframe::jitframe_type_info())
-        });
-        majit_backend_cranelift::set_jitframe_gc_type_id(jitframe_tid);
-    }
+    // Both backends require the descr's JITFRAME id before the install
+    // (`check_jitframe_descr`): a collector with a type table allocates every
+    // entry frame under that shape, which is the production frame source this
+    // file meters. Registering the shape on the singleton and telling the
+    // descr its id is what `eval.rs build_gc` does.
+    majit_gc::gc_sync::gc_op(|gc| {
+        let jitframe_tid =
+            majit_gc::GcAllocator::register_type(gc, majit_backend::jitframe::jitframe_type_info());
+        majit_gc::GcAllocator::set_jitframe_type_id(gc, jitframe_tid);
+    });
     #[cfg(feature = "cranelift")]
     majit_backend_cranelift::install_gc_standalone();
     #[cfg(all(feature = "dynasm", not(feature = "cranelift")))]
@@ -584,11 +580,10 @@ fn main() {
 
 /// Heap allocations per warm compiled-code entry, as measured by this file.
 ///
-/// **PER BACKEND, and the two disagree.** The backend is part of the key
-/// because it owns the last rows below; pinning one number for both would make
-/// whichever leg ran second fail with a message about a regression that is
-/// really a configuration difference. The figure was briefly one number for
-/// both, before cranelift's frame moved to the nursery.
+/// One number for both backends: since `malloc_jitframe` allocates against
+/// the descr, the entry frame is a nursery bump on either backend and the
+/// remaining rows are backend-neutral. The figure was per-backend while
+/// dynasm still built its entry frame off the GC.
 ///
 /// Four of the allocations are shared by both backends:
 ///
@@ -624,13 +619,16 @@ fn main() {
 /// scalars only — which `CounterState` is — gets neither, and falls back to the
 /// allocating `JitState` defaults. A state that clears that gate pays 4 fewer.
 ///
-/// `dynasm` adds one, for 5:
+/// `dynasm` adds NOTHING, and its four are the four shared rows above.
 ///
-/// | n | site |
-/// |---|------|
-/// | 1 | `majit_backend::jitframe::alloc_off_gc_jitframe` — the JITFRAME itself (`llmodel.py malloc_jitframe`, the ONE allocation upstream makes per entry) |
+/// It used to add three. The three that went:
 ///
-/// It used to add three. The two that went:
+/// - `majit_backend::jitframe::alloc_off_gc_jitframe`, the JITFRAME itself.
+///   `malloc_jitframe` allocates under the descr's JITFRAME type id, and this
+///   fixture registers the shape ([`install_gc`]), so the frame is a
+///   `nursery_free` bump (`jitframe.py:48-52`) and costs the process
+///   allocator nothing — the same row cranelift lost when its frame moved to
+///   the nursery.
 ///
 /// - `raw_values`, a copy of every jitframe slot taken because
 ///   `DynasmBackend::execute_token` freed the frame before returning.
@@ -647,15 +645,8 @@ fn main() {
 ///   type moved down into `majit-backend` and `DeadFrame` holds it by value in
 ///   a variant of its own.
 ///
-/// `cranelift` adds NOTHING, and its four are the four shared rows above.
-///
-/// There is no cranelift row for the frame itself, and that is the difference
-/// between the two backends. `run_compiled_code_inner` takes the JITFRAME from
-/// the nursery under its registered type id, which is `jitframe.py:48-52`
-/// `jitframe_allocate` — a bump of `nursery_free`, so the frame costs the
-/// process allocator nothing. dynasm's `execute_token` (`runner.rs`)
-/// allocates its entry frame off the GC unconditionally, so it keeps paying
-/// for one; installing a GC does not move its figure.
+/// `cranelift` adds NOTHING either — the backends agree now that both take
+/// the entry frame from `malloc_jitframe` against the same descr.
 ///
 /// It used to add four. The four that went:
 ///
@@ -684,4 +675,4 @@ fn main() {
 ///   `run_compiled_code_inner`, reached because this fixture had no GC at all;
 ///   see [`install_gc`]. The branch itself remains for a backend running
 ///   without a collector.
-const ALLOCS_PER_ENTRY: usize = if cfg!(feature = "cranelift") { 4 } else { 5 };
+const ALLOCS_PER_ENTRY: usize = 4;

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -3440,6 +3440,13 @@ mod tests {
     /// `dispatch_step: unwired opcode=0xd9` on the abort path.  Both are now
     /// registered.
     ///
+    /// The two float<->int bitcasts, `convert_float_bytes_to_longlong/f>i`
+    /// and `convert_longlong_bytes_to_float/i>f`, left the same way: a
+    /// `#[jit_interp]` arm that carries a float across a branch as its bits
+    /// emits them, so `build_inline_call_only_bh_builder` registers both and a
+    /// resume through such an arm dispatches them instead of panicking
+    /// `unwired opcode`.
+    ///
     /// The three `getinteriorfield_gc_*` loads left without the emitted set
     /// growing: they are registered pre-emptively, not in response to an
     /// observed panic naming one of them.  Their
@@ -3474,8 +3481,6 @@ mod tests {
             "conditional_call_ir_v/iiIRd",
             "conditional_call_value_ir_i/iiIRd>i",
             "conditional_call_value_ir_r/riIRd>r",
-            "convert_float_bytes_to_longlong/f>i",
-            "convert_longlong_bytes_to_float/i>f",
             "gc_load_indexed_f/riiii>f",
             "gc_load_indexed_i/riiii>i",
             "getlistitem_gc_f/ridd>f",

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1990,17 +1990,9 @@ fn build_gc() -> Box<MiniMarkGC> {
     spec_tuple_oo_ti.has_gc_ptrs = true;
     let spec_tuple_oo_tid = gc.register_type(spec_tuple_oo_ti);
     debug_assert_eq!(spec_tuple_oo_tid, SPECIALISED_TUPLE_OO_GC_TYPE_ID);
-    // Tell the cranelift backend which type id to use for the
-    // nursery allocations that it issues for jitframes. Without
-    // this, the backend's default u32::MAX sentinel would trip the
-    // allocation assert in run_compiled_code_inner, or — worse,
-    // before this fix — the backend's stale hard-coded `2` would
-    // collide with W_FLOAT_GC_TYPE_ID and GC would copy jitframes
-    // with the wrong TypeInfo (24-byte float payload instead of
-    // the real 64 + 8*depth layout), silently truncating every
-    // ref root slot past the first three bytes.
-    #[cfg(not(target_arch = "wasm32"))]
-    majit_metainterp::set_active_backend_jitframe_gc_type_id(jitframe_tid);
+    // `gc_ll_descr.malloc_jitframe` allocates under `JITFRAME`; the descr is
+    // told which registered type that is, once, before the table freezes.
+    gc.set_jitframe_type_id(jitframe_tid);
     // The orthodox (PYRE_WASM_CA) frame path allocates host-entry frames as
     // GC-managed JitFrames of this type so the collector forwards their Ref
     // item slots via the jf_gcmap custom trace.


### PR DESCRIPTION
## What

Three commits:

1. **majit-metainterp: register the two float bitcast opnames in the runtime blackhole builder** — `build_inline_call_only_bh_builder` gains `convert_float_bytes_to_longlong/f>i` and `convert_longlong_bytes_to_float/i>f`, next to `raw_load_f/iid>f`. A `#[jit_interp]` arm that carries a float across a branch as its bits emits these; a blackhole resume through such an arm previously panicked `dispatch_step: unwired opcode=0xe6`.

2. **majit: allocate jitframes through the descr instead of a per-backend heap enum** — replaces the per-backend "where do frames live" machinery with the upstream shape (`llmodel.py:298` `frame = self.gc_ll_descr.malloc_jitframe(frame_info)`):
   - `GcAllocator` gains `set_jitframe_type_id` / `jitframe_type_id` (gc.py `GcLLDescription`: the descr knows `JITFRAME`). MiniMarkGC stores the id; GcHandle delegates to `gc_sync`. The frontend tells the descr the id right after registering `jitframe_type_info()`, instead of publishing it to each backend.
   - `majit_backend::jitframe` gains `malloc_jitframe` / `malloc_jitframe_no_collect`, `free_jitframe`, `jitframe_is_gc_object`, `jitframe_write_barrier`, `check_jitframe_descr` (install-time refusal of a registry-bearing collector without a JITFRAME id), and `HostHeapGc` — the descr in force when no collector is installed (gc.py:653 `get_ll_description(None)` → `GcLLDescr_boehm`). With a JITFRAME id the frame is a nursery object; without one it is a host block.
   - Both native backends allocate entry, realloc and nursery-slowpath frames through one `with_gc_ll_descr` call and choose the deadframe owner from `jitframe_is_gc_object`. Deleted: dynasm `JitFrameHeap` + `STANDALONE`/`BOX` type-id cells + `set_jitframe_gc_type_id`; cranelift `JitFrameHeap` + `CRANELIFT_JITFRAME_HEAP` + the `JITFRAME_GC_TYPE_ID` atomic/TLS pair + `resolve_jitframe_heap`; metainterp `set_active_backend_jitframe_gc_type_id`.
   - The per-thread frame pool now parks off-GC blocks under `alloc_off_gc_jitframe` / `free_off_gc_jitframe`, so both backends' host frames share it (keeps the measured 2.62 ns/entry).
   - Fixtures that install a `MiniMarkGC` now register JITFRAME on it first; `force_deadframe_gc.rs` moves to the managed-frame path (owner-root slot instead of the `LIVE_DEADFRAMES` registry). The `allocs_per_compiled_entry` meter registers JITFRAME on both backends: dynasm's entry frame becomes a nursery bump and the pinned figure drops 5 → 4, now one number for both backends.

3. **pyre-jit-trace: drop the two float bitcast opnames from the overlay gap snapshot** — they are registered in the builder now, so they left the unreachable-registration gap; the snapshot documents why.

## Verification

- `cargo test --all --no-default-features --features dynasm,cpyext`: 115 suites green
- cranelift: `cargo test -p majit-backend-cranelift` green; `cargo check -p majit-backend-wasm` green
- `allocs_per_compiled_entry`: 4.000/entry on both backends
- cel-jit suite (`jit-cranelift`, embedder of the gc_box path): green
- `pyre-dynasm` loop run: correct results, `loops_compiled=2 loops_aborted=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011capRVFH2W4gwGQNWYCxEx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JIT frame allocation and lifecycle handling across supported execution backends.
  - Fixed blackhole resumes involving float-to-integer and integer-to-float bit conversions, preventing unexpected unwired-opcode failures.
  - Improved dead-frame ownership tracking, forwarding, and cleanup during garbage collection.

- **Documentation**
  - Clarified the `MAJIT_JITFRAME_POOL` gate documentation and updated allocation behavior guidance.

- **Testing**
  - Expanded coverage for garbage-collected JIT frames, frame ownership, and allocation consistency across backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->