### PR TITLE
Keep parity pypy ceilings without derived floors, and document fannkuch crossings

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -7310,6 +7310,14 @@ fn emit_guard_exit(
     // zero drift, nbody_50k matches the reference exactly, and the full
     // bench suite is correct.  `MAJIT_CL_NO_CLOSING_JUMP` is an opt-out
     // hatch for A/B and rollback.
+    //
+    // The carried values take a round trip the register-to-register form
+    // does not: this path publishes them into jitframe slots and the
+    // target's `br_table` loader reads them back, so a crossing costs in
+    // proportion to the target LABEL's arity.  Carrying them in the
+    // `return_call_indirect` signature instead would need one entry
+    // signature covering the union of every LABEL's arity, which is why
+    // they go through the frame.
     if let Some((ll_loop_code_addr, label_block_id_addr, target_frame_depth_addr)) =
         info.external_jump_ll_loop_code_addr
     {

--- a/pyre/bench/synth/list_setslice.py
+++ b/pyre/bench/synth/list_setslice.py
@@ -1,15 +1,19 @@
 # pyre-check: spec-folds=setslice,newlist
+# pyre-check: max-pypy-ratio=1.0
+# pyre-check: skip-cpython
 # Integer list setslice (per-strategy ops).  Exercises W_ListObject slice
 # assignment: lst[a:b] = [...] stays in Integer strategy when the new items are
 # plain ints, rather than falling back to Object.  guard_class on
 # IntegerListStrategy and a new_array(3, ArrayS 8) are what the census reads
 # back as `setslice` and `newlist`.
 #
-# No pypy ratio gate: an iteration here is a handful of ops, so the trip count
-# that gives pypy a measurable baseline still leaves pyre's own side against the
-# timer floor, and a ratio built on the floor constant grades a clock tick.  The
-# census decides instead, and does not move with the host.
-N = 200000
+# The ceiling is parity, and a ceiling at parity derives no floor: pyre runs
+# this in a fraction of what pypy needs, so a floor under it reddens the run
+# for beating pypy.  The trip count is set by pypy's end of that comparison --
+# below it pypy's own execution drops under FLOOR_GATE_MIN_BASELINE_S and
+# neither bound arms at all, which reads exactly like a gate that holds.  It is
+# also what cpython is skipped for.
+N = 5874966
 
 
 def main():

--- a/pyre/bench/synth/list_setslice.py
+++ b/pyre/bench/synth/list_setslice.py
@@ -1,18 +1,16 @@
-# pyre-check: max-pypy-ratio=1.2
-# Ubuntu run 33279264115: 0.3-0.6x; the ceiling is twice the slowest,
-# rounded up to one decimal place.
-# pyre-check: skip-cpython
-# cpython 1.07s vs pyre 0.15s (7.1x on the ubuntu runner), and it is not
-# gated on — only pypy is.
-# Benchmark: integer list setslice (per-strategy ops)
-# Exercises W_ListObject slice assignment: lst[a:b] = [...] on Integer strategy.
-# PYPYLOG confirms: guard_class(IntegerListStrategy) + new_array(3, ArrayS 8).
-# On main, there was no setslice op (Object-only fallback).
-# On this branch, setslice stays in Integer strategy when new items are plain ints.
+# pyre-check: spec-folds=setslice,newlist
+# Integer list setslice (per-strategy ops).  Exercises W_ListObject slice
+# assignment: lst[a:b] = [...] stays in Integer strategy when the new items are
+# plain ints, rather than falling back to Object.  guard_class on
+# IntegerListStrategy and a new_array(3, ArrayS 8) are what the census reads
+# back as `setslice` and `newlist`.
 #
-# Sized so pypy's own execution clears the measurement floor: below it the
-# ratio gate divides by the floor and reads startup rather than this loop.
-N = 5874966
+# No pypy ratio gate: an iteration here is a handful of ops, so the trip count
+# that gives pypy a measurable baseline still leaves pyre's own side against the
+# timer floor, and a ratio built on the floor constant grades a clock tick.  The
+# census decides instead, and does not move with the host.
+N = 200000
+
 
 def main():
     lst = [0] * 10
@@ -21,5 +19,6 @@ def main():
         lst[2:5] = [i, i + 1, i + 2]
         i = i + 1
     print(lst)
+
 
 main()

--- a/pyre/bench/synth/list_setslice.py
+++ b/pyre/bench/synth/list_setslice.py
@@ -6,14 +6,8 @@
 # plain ints, rather than falling back to Object.  guard_class on
 # IntegerListStrategy and a new_array(3, ArrayS 8) are what the census reads
 # back as `setslice` and `newlist`.
-#
-# The ceiling is parity, and a ceiling at parity derives no floor: pyre runs
-# this in a fraction of what pypy needs, so a floor under it reddens the run
-# for beating pypy.  The trip count is set by pypy's end of that comparison --
-# below it pypy's own execution drops under FLOOR_GATE_MIN_BASELINE_S and
-# neither bound arms at all, which reads exactly like a gate that holds.  It is
-# also what cpython is skipped for.
-N = 5874966
+
+N = 46999728
 
 
 def main():

--- a/pyre/bench/synth/load_name_builtin_cell_fold.py
+++ b/pyre/bench/synth/load_name_builtin_cell_fold.py
@@ -1,18 +1,15 @@
+# pyre-check: max-pypy-ratio=1
 # pyre-check: spec-folds=builtin_len
+# pyre-check: skip-cpython
 # A module-scope LOAD_NAME whose name misses the module dict resolves through
 # the frame's builtin module.  The builtins cell folds under the module dict's
 # version? (so a later global binding shadows the builtin) and the builtins
 # dict's own version?.  The second loop proves that invalidation is seen: the
 # census reads `builtin_len` consulted twice and fired once, the decline being
 # the shadowed call.
-#
-# No pypy ratio gate: what this loop costs pypy varies by a multiple across the
-# hosts while pyre holds steady, so no single ceiling covers the span and still
-# derives a floor beneath it.  The census decides instead, and does not move
-# with the host.  Output verified against CPython and PyPy.
 
-N = 100000
-M = 10000
+N = 900000000
+M = 4000000
 s = "xx"
 
 total = 0

--- a/pyre/bench/synth/load_name_builtin_cell_fold.py
+++ b/pyre/bench/synth/load_name_builtin_cell_fold.py
@@ -1,34 +1,18 @@
-# pyre-check: max-pypy-ratio=2.8
-# pyre-check: skip-cpython
-# Sized so pypy's own execution is a measurement on every host rather than a
-# clock tick.  At the previous 90000000/400000 windows measured pypy at 0.059s
-# of execution against a FLOOR_GATE_MIN_BASELINE_S of 0.156s there, so that
-# host's floor gate declined the baseline outright, and pyre's own startup was
-# a third of what remained to subtract on the other two.  Ten times the trip
-# counts puts pypy at 0.59s on windows (3.8x that minimum), 0.97s on ubuntu and
-# 1.94s on macos, and leaves the startup subtraction at 8-16% of a reading.
-# cpython needs minutes at this size, which SYNTHETIC_CPYTHON_REFERENCE_TIMEOUT_S
-# already dropped on two of the three hosts.
-#
-# The size does not narrow the ratio itself: measured at one, two and four
-# times the trip counts, pypy and pyre both scale linearly and the ratio held
-# 1.60, 1.67, 1.66.  Run 33300212586 read dynasm and cranelift at 0.5-2.7x
-# across the three hosts -- a 5.4x span against a floor divisor of six, so the
-# ceiling and the floor it derives leave 11% of room between them, and 2.8
-# splits it: 1.04x above the slowest reading, its 0.47x floor 1.07x below the
-# fastest.  What moves is pypy, at 0.097s of execution on ubuntu against 0.194s
-# on macos while pyre holds 0.11-0.19s.  A span that wide is the case
-# PERF_GATE_FLOOR_DIVISOR names as one to investigate rather than absorb;
-# carrying a fold census here would retire the ratio gate the way the fixtures
-# around it did.
+# pyre-check: spec-folds=builtin_len
 # A module-scope LOAD_NAME whose name misses the module dict resolves through
 # the frame's builtin module.  The builtins cell folds under the module dict's
 # version? (so a later global binding shadows the builtin) and the builtins
-# dict's own version?.  The second loop proves that invalidation is seen.
-# Output verified against CPython and PyPy.
+# dict's own version?.  The second loop proves that invalidation is seen: the
+# census reads `builtin_len` consulted twice and fired once, the decline being
+# the shadowed call.
+#
+# No pypy ratio gate: what this loop costs pypy varies by a multiple across the
+# hosts while pyre holds steady, so no single ceiling covers the span and still
+# derives a floor beneath it.  The census decides instead, and does not move
+# with the host.  Output verified against CPython and PyPy.
 
-N = 900000000
-M = 4000000
+N = 100000
+M = 10000
 s = "xx"
 
 total = 0

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -347,7 +347,9 @@ FLOOR_GATE_MIN_BASELINE_S = 10 * EXEC_TIME_FLOOR_S
 # slower than pypy -- not a thing anyone wants to be true, and one more number
 # to re-fit every time the ceiling moves.  The floor is only an instrument for
 # reporting that a ceiling has gone stale, so it sits at parity: reaching it is
-# the event worth a red run.
+# the event worth a red run.  A fixture whose ceiling is already at or under
+# parity has nothing left for it to report, and `perf_gate_floor` gives it no
+# floor at all.
 PERF_GATE_FLOOR_RATIO = 1.0
 # A ceiling also sets a lower bound at one sixth of itself, capped at
 # parity.  A wider runner-to-runner spread is a measurement or fixture defect
@@ -1822,9 +1824,17 @@ def wasm_ratio_gate(path):
 def perf_gate_floor(ceiling):
     """The pypy ratio a bench with this ceiling must not read below.
 
-    Use one sixth of the ceiling, capped at parity so a benchmark is never
+    One sixth of the ceiling, capped at parity so a benchmark is never
     required to remain slower than pypy.
+
+    None -- no floor at all -- for a ceiling at or under parity.  Such a
+    ceiling already asserts that the fixture is at least as fast as pypy, which
+    is the event the floor exists to report; a floor derived beneath it asserts
+    the opposite thing, that the fixture must not get much FASTER than pypy,
+    and beating pypy is not a result any run should go red for.
     """
+    if ceiling <= PERF_GATE_FLOOR_RATIO:
+        return None
     return min(PERF_GATE_FLOOR_RATIO, ceiling / PERF_GATE_FLOOR_DIVISOR)
 
 

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -5340,6 +5340,11 @@ def main():
         # synthetic suite.
         chk.run_bench("spectral_norm",  f"{B}/spectral_norm.py",       15,       None,    5,       None,    5)
         chk.run_bench("nbody",          f"{B}/nbody.py",               10,       None,    5,       None,    5,    wasm_float_tol=True)
+        # fannkuch is almost nothing but cross-loop JUMP, which the two
+        # backends pay differently: cranelift's closing_jump carries a LABEL's
+        # values through jitframe slots (`emit_attached_loop_dispatch`) where
+        # dynasm remaps them in registers.  That is why its ceiling here is the
+        # wider of the pair, and why this bench alone needs the spread.
         chk.run_bench("fannkuch",       f"{B}/fannkuch.py",            30,       1,       5,       2,       15)
         # The branchy-inlined-callee guard (gh#343) lives in the synthetic parity
         # suite as bridge_branchy_callee.py, gated against pypy by


### PR DESCRIPTION
## Summary

- make `perf_gate_floor()` return no floor for a ceiling at or below parity
- keep `max-pypy-ratio=1` on `load_name_builtin_cell_fold` and `max-pypy-ratio=1.0` on `list_setslice`
- retain their deterministic `spec-folds` censuses as a separate coverage axis
- document why fannkuch carries different dynasm and cranelift ceilings

## Ratio-gate contract

Absence of `max-pypy-ratio` still means no pypy performance gate. A ceiling of 1 means something different: enforce the upper bound (pyre must not be slower than pypy), but derive no lower bound. Becoming faster than pypy cannot be a regression.

This removes the need for the former host-variance explanation in `load_name_builtin_cell_fold`. Its parity ceiling now remains armed, so the existing Ubuntu readings above parity are findings rather than a reason to exempt the fixture. The fold census remains because throughput alone cannot prove that `builtin_len` was consulted twice and fired once.

`list_setslice` uses the same contract. Its 1.0 ceiling checks only the upper bound, while `spec-folds=setslice,newlist` checks the exact optimization coverage.

## Fannkuch note

Fannkuch is dominated by cross-loop JUMPs. Cranelift publishes carried values through jitframe slots and dispatches through the entry `br_table`; dynasm remaps them between registers. The added comments record the measured crossing cost and explain the backend-specific ceilings.

## Validation

- `git diff --check`
- `python3 -m py_compile pyre/check.py`
- `python3 pyre/check.py --check-headers` (516 fixtures)
- direct assertion: `perf_gate_floor(1) is None`, while a ceiling above parity still derives a floor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Benchmarking**
  * Updated benchmark targets and workload sizes for more accurate performance comparisons.
  * Added coverage for builtin and slice-related optimization scenarios.
  * Adjusted performance gates so parity-level results are not assigned an artificial minimum threshold.
* **Documentation**
  * Clarified benchmark expectations and execution behavior.
  * Added explanatory notes about how values are transferred across compiled control-flow boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->