### PR TITLE
rtyper: preserve tuple identity in enum payload rows

### DIFF
--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -3096,7 +3096,12 @@ pub fn gc_shrink_array(addr: usize, smaller_length: usize) -> bool {
 }
 
 /// Return the active collector's existing TYPE_INFO layout for `addr`.
-/// `None` means it is not a registered variable-size GC object.
+///
+/// `None` means either that `addr` is not a registered variable-size GC
+/// object, or that no backend has installed the query — the same answer
+/// [`gc_owns_object`] gives for an address no GC owns.  A caller that needs
+/// a layout regardless supplies its own, the way `jit_ll_arraymove` falls
+/// back to the array token of the block it allocates.
 pub fn gc_varsize_layout(addr: usize) -> Option<GcVarSizeLayout> {
     if addr == 0 {
         return None;

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -2331,11 +2331,22 @@ impl Bookkeeper {
                 }
             }
         }
+        let is_enum_variant = {
+            let guard = self.struct_fields.borrow();
+            guard.as_ref().is_some_and(|registry| {
+                n.rsplit_once("::")
+                    .is_some_and(|(parent, _)| registry.is_enum_base(parent))
+            })
+        };
         for (field_name, field_ty) in &fields {
             if field_name == "__class__" {
                 continue;
             }
-            let s_value = self.project_struct_field_type(field_ty);
+            let s_value = if is_enum_variant {
+                self.project_enum_variant_payload_field_type(field_ty)
+            } else {
+                self.project_struct_field_type(field_ty)
+            };
             let mut classdef_mut = classdef.borrow_mut();
             let attr = classdef_mut
                 .attrs
@@ -2369,6 +2380,43 @@ impl Bookkeeper {
             }
         }
         Ok(())
+    }
+
+    /// Project an enum payload through the same aggregate identity its
+    /// synthetic constructor uses.  Rust tuples are temporarily represented
+    /// by a per-shape internal class (`Tuple<T0,...>`) in `front::mir`, not by
+    /// a Python tuple value: the ctor and every `__pos_N` access intern that
+    /// one class before the generated low-level `GcStruct` is emitted.  A
+    /// generic enum's pre-registered payload row must name that exact class,
+    /// otherwise prepass setup sees `SomeTuple` while the constructor later
+    /// writes `SomeInstance(Tuple<...>)`.
+    ///
+    /// This is the incremental equivalent of RPython's global ordering:
+    /// annotation finishes before `InstanceRepr._setup_repr` reads attrs
+    /// (`rpython/rtyper/rclass.py:487-518`).  It does not add a union rule or
+    /// synthesize a missing rtype field; it seeds the concrete constructor
+    /// identity before the shared repr can be cached.
+    fn project_enum_variant_payload_field_type(self: &Rc<Self>, field_ty: &str) -> SomeValue {
+        let trimmed = field_ty.trim();
+        if let Some(inner) = trimmed.strip_prefix('(').and_then(|s| s.strip_suffix(')')) {
+            let items = split_generic_args(inner);
+            if !items.is_empty() {
+                let shape = format!("Tuple<{}>", items.join(","));
+                let registered = self
+                    .struct_fields
+                    .borrow()
+                    .as_ref()
+                    .is_some_and(|registry| registry.fields.contains_key(&shape));
+                if registered && let Ok(classdef) = self.getuniqueclassdef_for_struct_root(&shape) {
+                    return SomeValue::Instance(super::model::SomeInstance::new(
+                        Some(classdef),
+                        false,
+                        std::collections::BTreeMap::new(),
+                    ));
+                }
+            }
+        }
+        self.project_struct_field_type(field_ty)
     }
 
     /// TODO: no upstream equivalent.  The closest thing upstream,

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -5756,44 +5756,7 @@ mod tests {
         );
     }
 
-    /// Publish `table` into the process-global name → `StructId` map and hold
-    /// every other registering test out until the returned guard drops.
-    ///
-    /// `register_struct_ids` REPLACES the whole table (`majit-ir/src/descr.rs`,
-    /// `*guard = table`), which is right for production — the front end
-    /// populates it once per program, and merging would leak one program's
-    /// names into the next — and hostile to `cargo test`'s default
-    /// parallelism, where a second registering test wipes the first one's only
-    /// entry while that test is still running. The victim does not fail where
-    /// it registered: its `fielddescrof` silently takes a different arm and
-    /// returns a wrong `offset`.
-    ///
-    /// Measured, not inferred: the two tests below, run as a pair with default
-    /// threads, failed 9 of 12 runs; in the full 3141-test binary the same race
-    /// surfaced once in 6, because the scheduler rarely puts them adjacent.
-    /// Both pass in isolation and under `--test-threads=1`, so neither the
-    /// isolated run nor the serial run can see this.
-    ///
-    /// Scope is one test BINARY, which is the whole racing population: other
-    /// crates' tests run in their own processes and cannot reach this table.
-    ///
-    /// The lock is poison-tolerant. A test that panics mid-body would
-    /// otherwise convert one real failure into a cascade of unrelated ones.
-    ///
-    /// Bind the result to a NAMED local (`let _registry = …`). A bare
-    /// `let _ = …` drops the guard at once and restores exactly the race this
-    /// exists to remove — while still compiling, and still passing in
-    /// isolation.
-    #[must_use = "the returned guard holds the registry lock for the rest of \
-                  the test; dropping it immediately re-opens the race"]
-    fn register_struct_ids_serialized(
-        table: HashMap<String, Option<majit_ir::descr::StructId>>,
-    ) -> parking_lot::MutexGuard<'static, ()> {
-        static LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
-        let guard = LOCK.lock();
-        majit_ir::descr::register_struct_ids(table);
-        guard
-    }
+    use crate::test_support::register_struct_ids_serialized;
 
     #[test]
     fn fielddescrof_resolves_the_slot_when_the_offset_comes_from_the_layout_registry() {

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -4757,18 +4757,20 @@ fn op_kind_to_opname_with_kinds(kind: &crate::model::OpKind, operand_kinds: &str
             _ => format!("int_{op}"),
         };
     }
-    // RPython parity (`jtransform.py:1243-1255`): equality / inequality
-    // on Ref operands lowers to `ptr_eq` / `ptr_ne`, not the integer
-    // form.  Float arithmetic carries the full `float_*` opname through
-    // `op_kind_to_opname`'s BinOp arm already; here we only need to
-    // route the `eq` / `ne` labels emitted by the MIR front-end when
-    // they meet two Ref operands.  Mixed `ri` / `ir` Ref-Int shapes
+    // RPython parity (`rtyper/rmodel.py`, pairtype(Repr, Repr).rtype_is_,
+    // and `jtransform.py`'s pointer comparisons): equality, inequality,
+    // and identity on Ref operands lower to `ptr_eq` / `ptr_ne`, not the
+    // integer form. Float arithmetic carries the full `float_*` opname
+    // through `op_kind_to_opname`'s BinOp arm already; here we route the
+    // high-level labels emitted by the MIR front-end when they meet two Ref
+    // operands. Mixed `ri` / `ir` Ref-Int shapes
     // remain a kind-flow gap (see `default_bh_builder_unwired_set_*`
     // snapshot) — surfaced via the canonical fallthrough below.
     if let OpKind::BinOp { op, .. } = kind {
         match (op.as_str(), operand_kinds) {
             ("eq", "rr") => return "ptr_eq".into(),
             ("ne", "rr") => return "ptr_ne".into(),
+            ("is_", "rr") => return "ptr_eq".into(),
             _ => {}
         }
     }
@@ -5669,6 +5671,20 @@ mod tests {
     use super::*;
     use crate::flowspace::model::{ConstValue, HostObject};
     use crate::regalloc;
+
+    #[test]
+    fn surviving_ref_identity_uses_rpython_ptr_eq_opname() {
+        let lhs = crate::flowspace::model::Variable::new();
+        let rhs = crate::flowspace::model::Variable::new();
+        let identity = crate::model::OpKind::BinOp {
+            op: "is_".into(),
+            lhs,
+            rhs,
+            result_ty: crate::model::ValueType::Int,
+        };
+
+        assert_eq!(op_kind_to_opname_with_kinds(&identity, "rr"), "ptr_eq");
+    }
 
     #[test]
     fn vable_arraydescrof_pins_the_flat_word_base_for_pointer_items() {

--- a/majit/majit-translate/src/front/iter_next.rs
+++ b/majit/majit-translate/src/front/iter_next.rs
@@ -336,9 +336,10 @@ fn stopiteration_exitcase() -> ExitCase {
 }
 
 /// Split the nullable-pointer form of an Option switch into `(None, Some)`.
-/// `front::mir::lower_niche_option_switch` closes `ptr != null` through
-/// `set_branch`, so false is None and true is Some.  This is the flow-graph
-/// shape RPython itself uses for a maybe-null pointer (`ptr_nonzero`).
+/// `front::mir::lower_niche_option_switch` closes the identity-null predicate
+/// `((ptr is null) == false)` through `set_branch`, so false is None and true
+/// is Some.  This is the flow-graph shape RPython itself uses for a maybe-null
+/// pointer (`ptr_nonzero`).
 fn split_niche_bool_exits(exits: &[Link], name: &str) -> Result<(Link, Link), String> {
     if exits.len() != 2 {
         return Err(format!(
@@ -570,7 +571,9 @@ fn rewire_one_next_site(
     // Block C has one of the two representation-faithful Option tests:
     //
     // * aggregate Option: `d = opt.__discriminant`; switch 0/1;
-    // * one-word niche Option: `d = bool(opt != null_mut())`; switch false/true.
+    // * one-word niche Option: `d = bool((opt is null_mut()) == false)`;
+    //   switch false/true.  The direct `opt != null_mut()` spelling is also
+    //   accepted for artefacts extracted before the identity-null fold.
     //
     // The latter is `ptr_nonzero` in an RPython graph. Rust uses it for a
     // by-value array/Vec iterator whose T is itself a non-null pointer. The
@@ -610,64 +613,125 @@ fn rewire_one_next_site(
         let branch_value_vars = vec![disc_var.clone()];
         (none_link, some_link, true, branch_value_vars)
     } else {
-        // Find `ne(opt_c, null)` and prove the other operand is the
-        // adjacent pure `core::ptr::null_mut` source the niche fold emits.
-        let (ne_idx, ne_var, null_var) = graph.blocks[c]
-                .operations
-                .iter()
+        // The current MIR fold preserves PyPy identity semantics for
+        // nullable strings/lists: `is_none = opt is null; d = is_none ==
+        // false`.  This is the same `ptr_nonzero` predicate as the older
+        // direct `ne(opt, null)` spelling, but unlike value inequality it
+        // remains valid for every pointer repr.  Recognise both exact pure
+        // forms; accepting an arbitrary boolean chain here could reverse the
+        // None/Some arms and would not be a faithful `ll_listnext` rewrite.
+        let ops = &graph.blocks[c].operations;
+        let direct =
+            ops.iter()
                 .enumerate()
                 .find_map(|(i, op)| match (&op.kind, op.result.as_ref()) {
-                    (
-                        OpKind::BinOp {
-                            op,
-                            lhs,
-                            rhs,
-                            ..
-                        },
-                        Some(result),
-                    ) if op == "ne" && (*lhs == opt_c || *rhs == opt_c) => Some((
-                        i,
-                        result.clone(),
-                        if *lhs == opt_c {
-                            rhs.clone()
-                        } else {
-                            lhs.clone()
-                        },
-                    )),
+                    (OpKind::BinOp { op, lhs, rhs, .. }, Some(result))
+                        if op == "ne" && (*lhs == opt_c || *rhs == opt_c) =>
+                    {
+                        Some((
+                            vec![i],
+                            result.clone(),
+                            if *lhs == opt_c {
+                                rhs.clone()
+                            } else {
+                                lhs.clone()
+                            },
+                            vec![result.clone()],
+                        ))
+                    }
                     _ => None,
-                })
-                .ok_or_else(|| {
-                    format!(
-                        "{name}: block {c} lacks both an Option __discriminant read and a nullable-pointer test"
-                    )
+                });
+        let identity_inversion = || {
+            let (is_idx, is_none, null_var) =
+                ops.iter().enumerate().find_map(|(i, op)| {
+                    match (&op.kind, op.result.as_ref()) {
+                        (OpKind::BinOp { op, lhs, rhs, .. }, Some(result))
+                            if op == "is_" && (*lhs == opt_c || *rhs == opt_c) =>
+                        {
+                            Some((
+                                i,
+                                result.clone(),
+                                if *lhs == opt_c {
+                                    rhs.clone()
+                                } else {
+                                    lhs.clone()
+                                },
+                            ))
+                        }
+                        _ => None,
+                    }
                 })?;
-        let null_idx = graph.blocks[c]
-            .operations
-            .iter()
-            .enumerate()
-            .find_map(|(i, op)| {
-                (op.result.as_ref() == Some(&null_var)
-                    && matches!(
-                        &op.kind,
-                        OpKind::Call {
-                            target: CallTarget::FunctionPath { segments },
-                            args,
-                            ..
-                        } if args.is_empty()
-                            && segments == &["core", "ptr", "null_mut"]
-                    ))
-                .then_some(i)
-            })
-            .ok_or_else(|| {
-                format!("{name}: block {c} nullable-pointer test has no null_mut source")
+            let (false_idx, false_var) = ops.iter().enumerate().find_map(|(i, op)| {
+                matches!(op.kind, OpKind::ConstBool(false))
+                    .then(|| op.result.clone().map(|v| (i, v)))
+                    .flatten()
             })?;
+            let (eq_idx, disc_var) = ops.iter().enumerate().find_map(|(i, op)| {
+                match (&op.kind, op.result.as_ref()) {
+                    (OpKind::BinOp { op, lhs, rhs, .. }, Some(result))
+                        if op == "eq"
+                            && ((*lhs == is_none && *rhs == false_var)
+                                || (*rhs == is_none && *lhs == false_var)) =>
+                    {
+                        Some((i, result.clone()))
+                    }
+                    _ => None,
+                }
+            })?;
+            Some((
+                vec![is_idx, false_idx, eq_idx],
+                disc_var.clone(),
+                null_var,
+                vec![is_none, false_var, disc_var],
+            ))
+        };
+        let (mut pure_indices, disc_var, null_var, mut branch_value_vars) = direct
+            .or_else(identity_inversion)
+            .ok_or_else(|| {
+                format!(
+                    "{name}: block {c} lacks both an Option __discriminant read and a nullable-pointer test"
+                )
+            })?;
+        // `push_niche_null_ptr` may have to recast the raw null to the
+        // Option payload's concrete pointer repr (for example Wtf8Buf's
+        // translated StringRepr).  RPython's `convert_const(None)` performs
+        // the same repr adaptation.  Follow only an exact chain of pure
+        // cast-pointer aliases back to `null_mut`; any other producer is not
+        // evidence of the None sentinel and declines.
+        let mut null_source = null_var;
+        let mut null_indices = Vec::new();
+        loop {
+            let (idx, op) = ops
+                .iter()
+                .enumerate()
+                .find(|(_, op)| op.result.as_ref() == Some(&null_source))
+                .ok_or_else(|| {
+                    format!("{name}: block {c} nullable-pointer test has no null_mut source")
+                })?;
+            null_indices.push(idx);
+            match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    args,
+                    ..
+                } if args.is_empty() && segments == &["core", "ptr", "null_mut"] => break,
+                OpKind::Call { args, .. } if is_recast_narrow(&op.kind) => {
+                    null_source = args[0].clone();
+                }
+                _ => {
+                    return Err(format!(
+                        "{name}: block {c} nullable-pointer test has no null_mut source"
+                    ));
+                }
+            }
+        }
         let (bool_idx, bool_var) = graph.blocks[c]
             .operations
             .iter()
             .enumerate()
             .find_map(|(i, op)| match (&op.kind, op.result.as_ref()) {
                 (OpKind::UnaryOp { op, operand, .. }, Some(result))
-                    if op == "bool" && *operand == ne_var =>
+                    if op == "bool" && *operand == disc_var =>
                 {
                     Some((i, result.clone()))
                 }
@@ -682,15 +746,17 @@ fn rewire_one_next_site(
                 ));
             }
         }
+        pure_indices.extend(null_indices);
+        pure_indices.push(bool_idx);
         assert_block_pure_besides(
             graph,
             c,
-            &[null_idx, ne_idx, bool_idx],
+            &pure_indices,
             "nullable-pointer discriminant",
             &name,
         )?;
         let (none_link, some_link) = split_niche_bool_exits(&graph.blocks[c].exits, &name)?;
-        let branch_value_vars = vec![ne_var, bool_var.clone()];
+        branch_value_vars.push(bool_var.clone());
         (none_link, some_link, false, branch_value_vars)
     };
     let some_target = some_link.target;

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2757,9 +2757,11 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             crate::front::option_map_or::rewire_map_or_call_sites(&mut lo.graph, &lo.map_or_sites)
         };
         // The `Option::is_none`/`is_some` rewrite (`front::option_is_none`)
-        // replaces the residual predicate call in place with a
-        // `__discriminant` comparison; no block split, so it needs no
-        // reachability sweep.  Same fail-safe contract as the diamonds above.
+        // replaces the residual predicate call in place with either an
+        // aggregate `__discriminant` comparison or, for the nullable
+        // RPython ref representation, a pointer-null comparison. No block
+        // split, so it needs no reachability sweep. Same fail-safe contract
+        // as the diamonds above.
         if !lo.is_none_sites.is_empty() {
             crate::front::option_is_none::rewire_is_none_call_sites(
                 &mut lo.graph,
@@ -5684,7 +5686,7 @@ impl<'a> Lowering<'a> {
                 if self.tyref_is_niche_option_ptr(dest_ty) {
                     match operands.into_iter().next() {
                         None => {
-                            let nullc = self.push_niche_null_ptr(mir_bb);
+                            let nullc = self.push_niche_null_ptr(mir_bb, dest_ty);
                             return Ok((None, nullc));
                         }
                         Some(op) => {
@@ -6015,18 +6017,42 @@ impl<'a> Lowering<'a> {
                 // (RPython has no `Option`; a maybe-null `Ptr` tests
                 // `ptr_nonzero`).
                 if self.tyref_is_niche_option_ptr(&place.ty) {
+                    let option_ty = clone_tyref(&place.ty);
                     let base = self.resolve_place(mir_bb, place)?;
-                    let nullc = self.push_niche_null_ptr(mir_bb);
-                    // The `ne` result is a `SomeBool`; a `SwitchInt` terminator
-                    // on it must close with `ExitCase::Bool`.  Record the
-                    // result-var id so `lower_switch` routes it through the
-                    // `If` bool path instead of the `Int`-exitcase path.
+                    let nullc = self.push_niche_null_ptr(mir_bb, &option_ty);
+                    // Preserve PyPy's identity test: first compute
+                    // `base is None`, then negate that bool for the Rust
+                    // discriminant (`Some` = 1). `ne` would dispatch to value
+                    // inequality on StringRepr/ListRepr, which is not a null
+                    // test (and FixedSizeListRepr deliberately has no such
+                    // operation). The final bool must close a `SwitchInt`
+                    // with `ExitCase::Bool`, so record its result id.
+                    let is_none = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    let false_var = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    let bb_id = self.block_id[mir_bb];
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(is_none.clone()),
+                        kind: OpKind::BinOp {
+                            op: "is_".to_string(),
+                            lhs: base,
+                            rhs: nullc,
+                            result_ty: ValueType::Int,
+                        },
+                    });
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(false_var.clone()),
+                        kind: OpKind::ConstBool(false),
+                    });
                     self.niche_disc_vars.insert(res.id());
                     return Ok((
                         Some(OpKind::BinOp {
-                            op: "ne".to_string(),
-                            lhs: base,
-                            rhs: nullc,
+                            op: "eq".to_string(),
+                            lhs: is_none,
+                            rhs: false_var,
                             result_ty: ValueType::Int,
                         }),
                         res,
@@ -14409,6 +14435,35 @@ impl<'a> Lowering<'a> {
         self.option_payload_instance_class_root(dest_ty)
     }
 
+    /// Target projection for the null half of a nullable Option whose payload
+    /// the source translator has changed from a Rust container to an RPython
+    /// value repr. `null_mut()` begins as a classdef-less pointer; string and
+    /// list comparisons require the same `StringRepr` / `ListRepr` as their
+    /// receiver, exactly as `convert_const(None)` is applied on the selected
+    /// repr upstream. Ordinary pointer payloads already share InstanceRepr and
+    /// need no projection.
+    fn option_niche_null_cast(&self, option_ty: &TyRef) -> Option<(String, ValueType)> {
+        if !self.tyref_is_niche_option_ptr(option_ty) {
+            return None;
+        }
+        let payload = tyref_node(option_ty, self.llbc)?
+            .as_object()?
+            .get("Adt")?
+            .get("generics")?
+            .get("types")?
+            .get(0)?;
+        let stripped = strip_ty_wrappers(payload, self.llbc)?;
+        let rendered = charon_type_value_to_ast_string(stripped, self.llbc, 0);
+        let payload_ty = tyref_enum_payload_value_type(&TyRef::Other(payload.clone()), self.llbc);
+        if matches!(payload_ty, ValueType::Str) {
+            return Some((rendered, ValueType::Str));
+        }
+        if rendered.starts_with("Vec<") || rendered.starts_with("VecDeque<") {
+            return Some((rendered.clone(), ValueType::Ref(Some(rendered))));
+        }
+        None
+    }
+
     /// Resolve the destination `Option` of a `bool::then` / `bool::then_some`
     /// call into its `(option_owner, some_owner, payload_ty)` — the enum root
     /// ctor owner, the `Some` variant payload-field owner, and the payload
@@ -14740,6 +14795,8 @@ impl<'a> Lowering<'a> {
             result_var: result_var.clone(),
             option_owner,
             is_some,
+            niche: self.tyref_is_niche_option_ptr(&pointee),
+            niche_null_cast: self.option_niche_null_cast(&pointee),
         })
     }
 
@@ -15225,10 +15282,14 @@ impl<'a> Lowering<'a> {
             .is_some_and(|td| type_decl_is_fieldless_enum(td, self.llbc))
     }
 
-    /// `true` when `ty` is represented as a one-word nullable `Option`:
+    /// `true` when `ty` is represented as a one-word nullable `Option` in
+    /// the translated RPython model:
     /// `Option<NonNull<T>>`, `Option<Box<T>>`, `Option<fn(..)>`, `Option<&mut T>`,
     /// `Option<&T>` with a thin (Sized) ADT pointee, or a raw pointer to a
-    /// thin nominal ADT.
+    /// thin nominal ADT. It also includes the exact Rust container spellings
+    /// that translate to one RPython GC pointer: `Option<Vec<T>>` becomes a
+    /// nullable `SomeList`, and `Option<&str>` becomes a nullable
+    /// `SomeString`.
     /// The JIT models each in ONE pointer word (`None` = null, `Some(p)` =
     /// the non-null payload pointer), so
     /// `Discriminant` on it is a pointer-null test (`base != null`) and the
@@ -15263,18 +15324,23 @@ impl<'a> Lowering<'a> {
     /// references `&T` are included when the pointee is a thin (Sized)
     /// nominal ADT — equally a one-word null niche — via
     /// [`type_node_shared_ref_pointee`] gated on the pointee's resolved layout
-    /// size being concrete. Fat shared references are excluded: `&str` / `&[T]`
-    /// / `&dyn` carry no ADT def-id, and an unsized nominal newtype (a DST such
-    /// as `Wtf8 { bytes: [u8] }`) DOES carry a def-id but has no concrete layout
-    /// size — both are two-word references with no one-word niche payload.
+    /// size being concrete. Fat shared references are otherwise excluded:
+    /// `&[T]` / `&dyn` carry no ADT def-id, and an unsized nominal newtype (a
+    /// DST such as `Wtf8 { bytes: [u8] }`) DOES carry a def-id but has no
+    /// concrete layout size — both are two-word references with no one-word
+    /// niche payload. Bare `&str` is the deliberate exception because the
+    /// front has already replaced that Rust `(data, len)` spelling with
+    /// RPython's single `SomeString` value. PyPy `BuiltinCode.docstring` is
+    /// exactly `SomeString(can_be_None=True)` (`gateway.py:getdocstring`), not
+    /// a tag + payload aggregate.
     ///
     /// `front::iter_next` interaction (shared arm only). `Iterator::next()`
     /// returns `Option<&T>`, and `front::iter_next` rewrites its
     /// `__discriminant` match diamond into the native `[__iter_next]` op by
     /// matching a literal `FieldRead __discriminant` + `Value` exitswitch
     /// (`iter_next.rs` `rewire_one_next_site`). The `Discriminant` fold below
-    /// (`Rvalue::Discriminant`, this file) turns that into a pointer-null
-    /// `ne` bool switch when the recognizer accepts the receiver — for a
+    /// (`Rvalue::Discriminant`, this file) turns that into an identity-null
+    /// bool switch when the recognizer accepts the receiver — for a
     /// shared thin-ADT ref that would fire BEFORE iter_next runs and leave it
     /// no diamond to match, so the residual `next()` call would survive as an
     /// unregistered callee (a census Skip, not a miscompile). Currently
@@ -15340,6 +15406,21 @@ impl<'a> Lowering<'a> {
             let Some(stripped) = strip_ty_wrappers(shared_pointee, self.llbc) else {
                 return false;
             };
+            // Rust's `&str` is a fat pointer, but this source translator has
+            // already projected the bare builtin `str` to RPython's single GC
+            // string pointer (`SomeString`). Preserve that projection through
+            // `Option`: None is the null string pointer and Some is the string
+            // itself. Do not admit nominal unsized wrappers here;
+            // `Option<&Wtf8>` remains the aggregate pinned below.
+            if stripped
+                .get("Adt")
+                .and_then(|a| a.get("id"))
+                .and_then(|id| id.get("Builtin"))
+                .and_then(serde_json::Value::as_str)
+                == Some("Str")
+            {
+                return true;
+            }
             // `&*mut T` is a thin shared reference even though its pointee is
             // itself a raw pointer rather than a nominal ADT.  This is the
             // shape of `<[*mut PyObject]>::get`: `Option<&PyObjectRef>` is one
@@ -15388,15 +15469,25 @@ impl<'a> Lowering<'a> {
         let Some(def_id) = adt_node_def_id(payload) else {
             return false;
         };
-        self.llbc
+        let payload_path = self
+            .llbc
             .type_by_id(def_id)
-            .map(|td| td.item_meta.name_path())
-            .as_deref()
-            == Some("core::ptr::non_null::NonNull")
+            .map(|td| td.item_meta.name_path());
+        // PyPy TextIOWrapper.pending_bytes is `None` or an ordinary RPython
+        // list (`interp_textio.py:_writeflush`). Rust's `Vec<T>` is a
+        // three-word source spelling, but the front translates it to the same
+        // one-pointer `SomeList`; retaining Rust's enum tag after that
+        // projection manufactures an attribute no RPython object has.
+        matches!(
+            payload_path.as_deref(),
+            Some("core::ptr::non_null::NonNull") | Some("alloc::vec::Vec")
+        )
     }
 
-    /// Emit a null pointer for a one-word niche `Option` (`None`) as a
-    /// `core::ptr::null_mut()` call, returning its result `Variable`.
+    /// Emit a null pointer for a nullable `Option` (`None`) as a
+    /// `core::ptr::null_mut()` call, returning its result `Variable`. A Rust
+    /// container projected to an RPython string/list is then narrowed to that
+    /// projected repr before it is returned or compared.
     ///
     /// `null_mut()` is preferred over a bare `ConstRefNull`: the annotator's
     /// `ptr_null_constant` types it as a classdef-less nullable `SomeInstance`
@@ -15409,9 +15500,26 @@ impl<'a> Lowering<'a> {
     /// merge.  Used by both the `Discriminant` null-test fold and the niche
     /// `Aggregate` `None` construction fold so every niche-Option null shares
     /// one repr-adaptive source.
-    fn push_niche_null_ptr(&mut self, mir_bb: usize) -> Variable {
+    fn push_niche_null_ptr(&mut self, mir_bb: usize, option_ty: &TyRef) -> Variable {
         let bb_id = self.block_id[mir_bb];
-        self.graph.push_null_mut_ptr(bb_id)
+        let null = self.graph.push_null_mut_ptr(bb_id);
+        let Some((root, result_ty)) = self.option_niche_null_cast(option_ty) else {
+            return null;
+        };
+        let narrowed = self
+            .graph
+            .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+        self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+            result: Some(narrowed.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec![crate::runtime_names::shims::CAST_INSTANCE.to_string(), root],
+                },
+                args: vec![null],
+                result_ty,
+            },
+        });
+        narrowed
     }
 
     /// Lower `i64::checked_neg()` (`core::num::<Impl>::checked_neg` —
@@ -33290,7 +33398,7 @@ mod tests {
     /// `gettypeobject` (`gettypefor(..).map_or(PY_NULL, |p| p.as_ptr())`)
     /// must fold its `gettypefor` match through the niche
     /// `Option<NonNull<PyObject>>` path now that `gettypefor` returns a
-    /// one-word niche Option: the discriminant is a `ptr_ne` null-test
+    /// one-word niche Option: the map_or rewrite uses a `ptr_ne` null-test
     /// (`base != null_mut()`), NOT an aggregate `__discriminant` FieldRead,
     /// and the null is a `null_mut()` call (repr-adaptive) rather than a
     /// fixed-GCREF `ConstRefNull`.  Guards against a regression where the
@@ -33331,7 +33439,7 @@ mod tests {
             null_muts >= 1,
             "gettypeobject: expected a null_mut() feeding the niche ptr null-test"
         );
-        // The niche discriminant is a `ne` pointer null-test, and no
+        // The map_or niche discriminant contains a `ne` pointer null-test, and no
         // `__discriminant` FieldRead survives on the niche `gettypefor` result.
         let has_ne = graph
             .blocks
@@ -33375,16 +33483,29 @@ mod tests {
         let graph = super::lower_function(&llbc, "object_functionstr_type_name")
             .expect("lower object_functionstr_type_name");
 
-        // The niche match's discriminant is a `ne` pointer null-test.  It is
-        // routed through the `If` path (`set_branch`), which wraps the `ne` in
-        // an idempotent `bool` UnaryOp and switches on that wrapped var — so
-        // locate the block whose exitswitch is a `bool` UnaryOp over a `ne`.
-        let ne_result_ids: std::collections::HashSet<u64> = graph
+        // The niche match's Some-discriminant is `not (base is None)`. It is
+        // routed through the `If` path (`set_branch`), which may wrap the final
+        // bool in an idempotent `bool` UnaryOp. Locate switches on that final
+        // `eq(is_none, false)` value (or its wrapper).
+        let is_result_ids: std::collections::HashSet<u64> = graph
             .blocks
             .iter()
             .flat_map(|b| b.operations.iter())
             .filter_map(|op| match &op.kind {
-                OpKind::BinOp { op: name, .. } if name == "ne" => {
+                OpKind::BinOp { op: name, .. } if name == "is_" => {
+                    op.result.as_ref().map(|v| v.id())
+                }
+                _ => None,
+            })
+            .collect();
+        let some_result_ids: std::collections::HashSet<u64> = graph
+            .blocks
+            .iter()
+            .flat_map(|b| b.operations.iter())
+            .filter_map(|op| match &op.kind {
+                OpKind::BinOp { op: name, lhs, .. }
+                    if name == "eq" && is_result_ids.contains(&lhs.id()) =>
+                {
                     op.result.as_ref().map(|v| v.id())
                 }
                 _ => None,
@@ -33399,10 +33520,12 @@ mod tests {
             let switches_on_nulltest = b.operations.iter().any(|op| {
                 op.result.as_ref() == Some(sw)
                     && match &op.kind {
-                        OpKind::BinOp { op: name, .. } => name == "ne",
+                        OpKind::BinOp { op: name, lhs, .. } => {
+                            name == "eq" && is_result_ids.contains(&lhs.id())
+                        }
                         OpKind::UnaryOp {
                             op: name, operand, ..
-                        } => name == "bool" && ne_result_ids.contains(&operand.id()),
+                        } => name == "bool" && some_result_ids.contains(&operand.id()),
                         _ => false,
                     }
             });
@@ -33423,7 +33546,7 @@ mod tests {
         }
         assert!(
             checked >= 1,
-            "object_functionstr_type_name: expected a niche `ne` null-test switch block"
+            "object_functionstr_type_name: expected a niche identity-null-test switch block"
         );
     }
 
@@ -33516,6 +33639,62 @@ mod tests {
         assert_eq!(
             pos0_reads, 0,
             "the &mut niche arm must keep folding __pos_0"
+        );
+    }
+
+    /// PyPy `BuiltinCode.docstring` is a nullable RPython string and
+    /// `getdocstring` delegates to `space.newtext_or_none`: there is no enum
+    /// object carrying a `__discriminant` attribute. Rust spells the field as
+    /// `Option<&'static str>`, but the front's `SomeString` projection must
+    /// survive through that Option as one nullable GC pointer.
+    #[test]
+    #[ignore]
+    fn builtin_docstring_option_str_is_nullable_somestring() {
+        use crate::model::OpKind;
+        let path = crate::runtime_names::artifacts::INTERPRETER_ULLBC;
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "builtin_code_get_docstring")
+            .expect("lower builtin_code_get_docstring");
+        let ops = || graph.blocks.iter().flat_map(|b| b.operations.iter());
+        assert_eq!(
+            ops()
+                .filter(|op| matches!(&op.kind, OpKind::FieldRead { field, .. }
+                    if field.name == "__discriminant"))
+                .count(),
+            0,
+            "Option<&str> must test the nullable SomeString, not read an enum tag"
+        );
+        assert!(
+            ops().any(|op| matches!(&op.kind, OpKind::BinOp { op, .. } if op == "is_")),
+            "Option<&str> match must contain an identity null-test"
+        );
+    }
+
+    /// PyPy `W_TextIOWrapper.pending_bytes` is `None` or one ordinary list.
+    /// The Rust `Option<Vec<Vec<u8>>>` spelling therefore translates to a
+    /// nullable `SomeList`, not an enum shell around the list.
+    #[test]
+    #[ignore]
+    fn textio_pending_bytes_option_vec_is_nullable_somelist() {
+        use crate::model::OpKind;
+        let path = crate::runtime_names::artifacts::INTERPRETER_ULLBC;
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph =
+            super::lower_function(&llbc, "write_flush").expect("lower TextIOWrapper.write_flush");
+        let ops = || graph.blocks.iter().flat_map(|b| b.operations.iter());
+        assert_eq!(
+            ops()
+                .filter(|op| matches!(&op.kind, OpKind::FieldRead { field, .. }
+                    if field.name == "__discriminant"))
+                .count(),
+            0,
+            "Option<Vec<_>> must test the nullable SomeList, not read an enum tag"
+        );
+        assert!(
+            !ops().any(|op| matches!(&op.kind,
+                OpKind::Call { target: CallTarget::Method { name, .. }, .. }
+                    if name == "is_some" || name == "is_none")),
+            "the Option predicate must not survive as a residual Rust method"
         );
     }
 
@@ -33893,7 +34072,7 @@ mod tests {
 
     /// End-to-end: `str_slice_args -> Result<Option<&Wtf8>, PyError>` (matched by
     /// `startswith`/`endswith`). Because `Wtf8` is an unsized DST, its
-    /// `Option<&Wtf8>` must NOT niche-fold — no pointer-null `ne` discriminant
+    /// `Option<&Wtf8>` must NOT niche-fold — no pointer identity-null discriminant
     /// against a `null_mut()` may appear, or the fat pointer's length word is
     /// lost. The residual/aggregate Option handling must survive. Loads the real
     /// LLBC, ignored.
@@ -33904,7 +34083,7 @@ mod tests {
         let path = crate::runtime_names::artifacts::INTERPRETER_ULLBC;
         let llbc = Llbc::load(path).expect("load real LLBC");
         let graph = super::lower_function(&llbc, "str_slice_args").expect("lower str_slice_args");
-        // The niche discriminant fold emits `ne(base, null_mut())`; a declined
+        // The niche discriminant fold emits an identity test with `null_mut()`; a declined
         // Option keeps a `null_mut` builtin ONLY when genuinely niche. Assert no
         // `null_mut` call is synthesised for this graph's Option<&Wtf8> — the fat
         // ref must not be treated as a one-word niche.

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8563,6 +8563,18 @@ impl<'a> Lowering<'a> {
                 if args.len() == 1
                     && (self.is_to_string_identity(&reg, first_arg_ty.as_ref())
                         || self.is_string_clone_identity(&reg, first_arg_ty.as_ref()))
+                    // A `Wtf8::to_wtf8_buf` that defines a proven mutable
+                    // accumulator is not the ordinary immutable-string copy
+                    // this identity arm models.  Its later `push*` calls and
+                    // single materialisation spell RPython's
+                    // `StringBuilder`; let the builder-ctor arm below emit
+                    // `newstringbuilder` plus the seed append.  Otherwise the
+                    // identity shortcut binds the accumulator to the source
+                    // `SomeString`, and the terminal `build` asks that string
+                    // for a builder-only method.
+                    && !(self.builder_mode
+                        && str_builder_ctor_leaf(self.llbc, &reg).is_some()
+                        && is_builder_mode_accumulator(self.body, self.llbc, dest_local))
                 {
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
@@ -9379,8 +9391,9 @@ impl<'a> Lowering<'a> {
                             result_ty: ValueType::Ref(None),
                         },
                     });
-                    // `Wtf8Buf::from_string(initial)` is the Rust ownership
-                    // spelling of an RPython builder followed by its first
+                    // `Wtf8Buf::from_string(initial)` and
+                    // `Wtf8::to_wtf8_buf(&initial)` are the Rust ownership
+                    // spellings of an RPython builder followed by its first
                     // append.  Keep the initial value as an append operand;
                     // passing it to `new` would misread it as the optional
                     // integer capacity argument.
@@ -9393,7 +9406,7 @@ impl<'a> Lowering<'a> {
                     // `ll_new(len(s))` (`:57-63`) is the PREBUILT-constant
                     // path — a builder already built at translation time —
                     // and is not this callsite.
-                    if builder_ctor_leaf == Some("from_string") {
+                    if matches!(builder_ctor_leaf, Some("from_string" | "to_wtf8_buf")) {
                         let void = self
                             .graph
                             .alloc_value_var_with_type(crate::model::ConcreteType::Void);
@@ -34585,6 +34598,81 @@ mod tests {
         );
         let llbc = Llbc::load(path).expect("load real LLBC");
         let graph = super::lower_function(&llbc, "py_repr_wtf8").expect("lower py_repr_wtf8");
+        // Prove every append/build receiver is rooted at a builder ctor.
+        // Start from every phi as a candidate and remove any phi fed by a
+        // non-candidate; this greatest fixed point admits loop-carried
+        // builders while rejecting the old `to_wtf8_buf` identity value
+        // (a plain SomeString producer) and every phi reachable from it.
+        let builder_roots: std::collections::HashSet<u64> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .filter_map(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments == &[crate::runtime_names::shims::STRINGBUILDER_NEW])
+                .then(|| op.result.as_ref().expect("builder new result").id())
+            })
+            .collect();
+        let mut builder_values = builder_roots.clone();
+        builder_values.extend(
+            graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.inputargs)
+                .map(|input| input.id()),
+        );
+        loop {
+            let mut changed = false;
+            for block in &graph.blocks {
+                for (pos, input) in block.inputargs.iter().enumerate() {
+                    let incoming: Vec<_> = graph
+                        .blocks
+                        .iter()
+                        .flat_map(|source| &source.exits)
+                        .filter(|link| link.target == block.id)
+                        .filter_map(|link| link.args.get(pos))
+                        .collect();
+                    if (incoming.is_empty()
+                        || incoming.iter().any(|arg| {
+                            arg.as_variable()
+                                .is_none_or(|value| !builder_values.contains(&value.id()))
+                        }))
+                        && !builder_roots.contains(&input.id())
+                    {
+                        changed |= builder_values.remove(&input.id());
+                    }
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+        let unproven_builder_receivers: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|block| {
+                block.operations.iter().filter_map(|op| match &op.kind {
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        args,
+                        ..
+                    } if matches!(segments.as_slice(), [marker]
+                        if marker == crate::runtime_names::shims::STRINGBUILDER_APPEND
+                            || marker == crate::runtime_names::shims::STRINGBUILDER_BUILD) =>
+                    {
+                        args.first()
+                            .filter(|recv| !builder_values.contains(&recv.id()))
+                            .map(|recv| (block.id, segments.clone(), recv.clone()))
+                    }
+                    _ => None,
+                })
+            })
+            .collect();
+        assert!(
+            unproven_builder_receivers.is_empty(),
+            "builder operations must receive a value rooted at newstringbuilder: \
+             {unproven_builder_receivers:#?}"
+        );
         let residual: Vec<_> = graph
             .blocks
             .iter()

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -14327,34 +14327,22 @@ impl<'a> Lowering<'a> {
     /// the concrete field annotation that RPython's `InstanceRepr._setup_repr`
     /// consumes (`rpython/rtyper/rclass.py:501-509`).
     fn option_payload_instance_class_root(&self, option_ty: &TyRef) -> Option<String> {
-        let mut payload = tyref_node(option_ty, self.llbc)?
-            .as_object()?
-            .get("Adt")?
-            .get("generics")?
-            .get("types")?
-            .get(0)?;
-        loop {
-            let obj = payload.as_object()?;
-            if let Some(id) = obj.get("Deduplicated").and_then(serde_json::Value::as_u64) {
-                payload = self.llbc.dedup_body(id)?;
-                continue;
-            }
-            if let Some(parts) = obj
-                .get("HashConsedValue")
-                .and_then(serde_json::Value::as_array)
-                && parts.len() == 2
-            {
-                payload = &parts[1];
-                continue;
-            }
-            if let Some(root) = raw_ptr_pointee_class_root(payload, self.llbc) {
-                return Some(root);
-            }
-            let pointee = obj.get("Ref")?.as_array()?.get(1)?;
-            let pointee = strip_ty_wrappers(pointee, self.llbc)?;
-            return raw_ptr_pointee_class_root(pointee, self.llbc)
-                .or_else(|| adt_node_class_root(pointee, self.llbc));
+        let payload = strip_ty_indirections(
+            tyref_node(option_ty, self.llbc)?
+                .as_object()?
+                .get("Adt")?
+                .get("generics")?
+                .get("types")?
+                .get(0)?,
+            self.llbc,
+        )?;
+        if let Some(root) = raw_ptr_pointee_class_root(payload, self.llbc) {
+            return Some(root);
         }
+        let pointee = payload.as_object()?.get("Ref")?.as_array()?.get(1)?;
+        let pointee = strip_ty_wrappers(pointee, self.llbc)?;
+        raw_ptr_pointee_class_root(pointee, self.llbc)
+            .or_else(|| adt_node_class_root(pointee, self.llbc))
     }
 
     /// The per-instantiation `Option` enum root for a residual-call

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5015,8 +5015,7 @@ impl<'a> Lowering<'a> {
                             // rtyped.  RPython keeps the declared
                             // SomeInstance class on every assignment (and a
                             // nullable pointer merely sets `can_be_None`).
-                            value =
-                                self.narrow_typed_instance_field_value(bb_id, value, Some(dest_ty));
+                            value = self.narrow_typed_ref_field_value(bb_id, value, Some(dest_ty));
                             (
                                 FieldDescriptor::new(field_name, Some(owner_root))
                                     .with_owner_id(owner_id)
@@ -5064,15 +5063,18 @@ impl<'a> Lowering<'a> {
         Ok(())
     }
 
-    /// Preserve the declared class of an instance-typed field value.
+    /// Preserve the declared RPython reference repr of a typed field value.
     ///
     /// RPython represents an instance attribute as `SomeInstance(classdef)`;
     /// when nullable, the same annotation simply carries `can_be_None=True`.
     /// Rust spells those slots as `&NamedAdt` or `*mut/*const NamedAdt`, whose
-    /// producer initially has pointer annotation.  The Rust field type-check
-    /// is the proof needed to narrow that producer before `setattr`; this is
-    /// an identity cast for non-null values and a typed null for null values.
-    fn narrow_typed_instance_field_value(
+    /// producer initially has pointer annotation.  A pointer to an RPython
+    /// array is the same boundary: `rutf8.UTF8_INDEX_STORAGE` is a `GcArray`,
+    /// while Rust carries the exact owner as `*mut Vec<Utf8LocElem>`.  The
+    /// Rust field type-check is the proof needed to narrow that producer
+    /// before `setattr`; this is an identity cast for non-null values and a
+    /// typed null for null values.
+    fn narrow_typed_ref_field_value(
         &mut self,
         bb_id: BlockId,
         value: LinkArg,
@@ -5085,6 +5087,7 @@ impl<'a> Lowering<'a> {
                 return adt_node_class_root(strip_ty_indirections(pointee, self.llbc)?, self.llbc);
             }
             raw_ptr_pointee_class_root(node, self.llbc)
+                .or_else(|| raw_ptr_pointee_container_root(node, self.llbc))
         }) else {
             return value;
         };
@@ -5866,11 +5869,7 @@ impl<'a> Lowering<'a> {
                         continue;
                     }
                     let value = self
-                        .narrow_typed_instance_field_value(
-                            bb_id,
-                            LinkArg::Value(value),
-                            declared_ty,
-                        )
+                        .narrow_typed_ref_field_value(bb_id, LinkArg::Value(value), declared_ty)
                         .as_variable()
                         .expect("aggregate field operand stays materialized")
                         .clone();
@@ -21510,6 +21509,26 @@ fn raw_ptr_pointee_class_root(node: &serde_json::Value, llbc: &Llbc) -> Option<S
     adt_node_class_root(strip_ty_wrappers(raw.first()?, llbc)?, llbc)
 }
 
+/// The projected list root of a raw pointer onto a Rust container.
+///
+/// RPython keeps pointers to `GcArray` values typed, including null pointers
+/// (`lltype.nullptr(ARRAY)`).  Rust's corresponding owner can be a
+/// `*mut Vec<T>` field, which otherwise enters the annotator as a
+/// classdef-less pointer and cannot union with the `SomeList` produced when
+/// the array is allocated.  Return the same rendered container spelling
+/// `Bookkeeper::project_struct_field_type` consumes at the cast boundary.
+fn raw_ptr_pointee_container_root(node: &serde_json::Value, llbc: &Llbc) -> Option<String> {
+    let pointee = node
+        .as_object()?
+        .get("RawPtr")?
+        .as_array()?
+        .first()
+        .and_then(|node| strip_ty_wrappers(node, llbc))?;
+    let rendered = charon_type_value_to_ast_string(pointee, llbc, 0);
+    (rendered.starts_with("Vec<") || rendered.starts_with("VecDeque<") || rendered.starts_with('['))
+        .then_some(rendered)
+}
+
 /// Whether `ty` is a raw pointer onto a byte-sized integer literal —
 /// `*mut u8` / `*const u8` / the `i8` spellings.  This is the
 /// type-erased "opaque memory address" pointer: `llmemory.Address`
@@ -34538,6 +34557,57 @@ mod tests {
                 "missing builder marker {marker}"
             );
         }
+    }
+
+    /// PyPy initializes `W_UnicodeObject._index_storage` with
+    /// `lltype.nullptr(UTF8_INDEX_STORAGE)`, where the storage is a typed
+    /// `GcArray`.  Rust spells the same slot `*mut Vec<Utf8LocElem>`; its null
+    /// constructor value must therefore be narrowed to the projected list
+    /// repr before the field write, not left as a classdef-less pointer that
+    /// later conflicts with `create_utf8_index_storage`'s list value.
+    #[test]
+    #[ignore]
+    fn unicode_index_storage_null_keeps_gcarray_repr() {
+        use crate::model::{CallTarget, LinkArg, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-object.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load pyre-object LLBC");
+        let graph = super::lower_function(&llbc, "w_str_from_wtf8").expect("lower w_str_from_wtf8");
+        let value = graph
+            .blocks
+            .iter()
+            .flat_map(|block| &block.operations)
+            .find_map(|op| match &op.kind {
+                OpKind::FieldWrite { field, value, .. } if field.name == "index_storage" => {
+                    match value {
+                        LinkArg::Value(value) => Some(value.clone()),
+                        LinkArg::Const(_) => None,
+                    }
+                }
+                _ => None,
+            })
+            .expect("W_UnicodeObject.index_storage write");
+        assert!(
+            graph
+                .blocks
+                .iter()
+                .flat_map(|block| &block.operations)
+                .any(|op| {
+                    op.result.as_ref() == Some(&value)
+                        && matches!(
+                            &op.kind,
+                            OpKind::Call {
+                                target: CallTarget::FunctionPath { segments },
+                                ..
+                            } if segments.first().map(String::as_str)
+                                == Some("__cast_instance_intrinsic")
+                                && segments.get(1).is_some_and(|root| root.starts_with("Vec<"))
+                        )
+                }),
+            "index_storage null must narrow to the Vec/GcArray list repr"
+        );
     }
 
     /// `Wtf8::as_str` is fallible for a lone surrogate.  PyPy keeps the

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -10240,6 +10240,30 @@ impl<'a> Lowering<'a> {
                 let (segments, method_hint) = if args.len() == 1 && is_slice_to_vec(&segments) {
                     (vec!["list".to_string()], None)
                 } else if args.len() == 2
+                    && is_vec_extend_segments(&segments)
+                    && second_arg_ty
+                        .as_ref()
+                        .is_some_and(|ty| tyref_is_vec_value(ty, self.llbc))
+                {
+                    // PyPy expresses these source sites as list
+                    // concatenation / `list.extend`, and
+                    // `AbstractListRepr.rtype_method_extend` lowers them to
+                    // `ll_extend`.  Rust's `Vec::extend(Vec<T>)` consumes its
+                    // source, but the source is dead after the call and both
+                    // values are translated lists, so route this exact
+                    // by-value Vec input through the already-orthodox
+                    // `extend_from_slice` → list.extend bridge.  An iterator
+                    // value (`Vec::IntoIter`, Map, Range, or a custom iterator)
+                    // is not a list and deliberately keeps the residual wall.
+                    (
+                        vec![
+                            "vec".to_string(),
+                            "Vec".to_string(),
+                            "extend_from_slice".to_string(),
+                        ],
+                        None,
+                    )
+                } else if args.len() == 2
                     && crate::front::str_find::is_rpython_str_slice_prefix(&segments)
                 {
                     // PyPy's `name[:dotindex]` reaches ordinary
@@ -25204,6 +25228,19 @@ fn is_slice_to_vec(segments: &[String]) -> bool {
         if a == "alloc" && b == "slice" && c == "<Impl>" && d == "to_vec")
 }
 
+fn is_vec_extend_segments(segments: &[String]) -> bool {
+    segments == ["vec", "Vec", "extend"]
+}
+
+/// Whether a call operand is a concrete `Vec<T>` value (possibly borrowed).
+/// A `Vec::IntoIter<T>` is deliberately excluded: it is an iterator repr, may
+/// already be partially consumed, and therefore cannot be treated as the
+/// complete source list merely because it originated from one.  An arbitrary
+/// `IntoIterator<Item=T>` has no list-representation proof either.
+fn tyref_is_vec_value(ty: &TyRef, llbc: &Llbc) -> bool {
+    adt_path_of_tyref(ty, llbc).as_deref() == Some("alloc::vec::Vec")
+}
+
 /// The `fmt::Arguments::new(pieces, args)` constructor that `format_args!`
 /// builds from the on-stack pieces+args arrays.
 fn is_arguments_new_path(segments: &[String]) -> bool {
@@ -30046,6 +30083,105 @@ mod tests {
             0,
             "no residual Map::collect reload wall"
         );
+    }
+
+    /// Representative interpreter loops iterate `&[*mut PyObject]`, whose
+    /// `Option<&*mut PyObject>` is folded to the identity-null niche shape:
+    /// `(opt is null) == false`.  This is still RPython's `ptr_nonzero`
+    /// predicate and must feed the same `next` + StopIteration rewrite as the
+    /// aggregate Option shape above.  The four roots here fan out to most of
+    /// the census's `slice::Iter::next` failures.  Ignored by default because
+    /// it loads the real interpreter LLBC.
+    #[test]
+    #[ignore]
+    fn iter_next_fold_real_identity_null_niche() {
+        use crate::model::{CallTarget, OpKind};
+
+        let path = crate::runtime_names::artifacts::INTERPRETER_ULLBC;
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        for function in [
+            "pyre_interpreter::call::call_builtin_code_positional",
+            "pyre_interpreter::runtime_ops::build_map_from_refs",
+            "pyre_interpreter::display::py_repr_wtf8",
+            "pyre_interpreter::baseobjspace::mutated",
+        ] {
+            let graph = super::lower_function(&llbc, function)
+                .unwrap_or_else(|e| panic!("lower {function}: {e}"));
+            let count_call_leaf = |leaf: &[&str]| {
+                graph
+                    .blocks
+                    .iter()
+                    .flat_map(|b| b.operations.iter())
+                    .filter(|op| {
+                        matches!(
+                            &op.kind,
+                            OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                                if super::fmt_path_ends_with(segments, leaf)
+                        )
+                    })
+                    .count()
+            };
+            assert_eq!(
+                count_call_leaf(&["slice", "iter", "Iter", "next"]),
+                0,
+                "{function}: identity-null niche loop must not retain residual Iter::next"
+            );
+            assert!(
+                count_call_leaf(&["__iter_next"]) >= 1,
+                "{function}: identity-null niche loop must emit a native next op"
+            );
+        }
+    }
+
+    /// A concrete `Vec<T>` source is the translated-list case of PyPy's
+    /// `list.extend`; an arbitrary `IntoIterator` is not.  Pin both sides to
+    /// production LLBC so the frontend never broadens the bridge to Map or a
+    /// custom iterator.
+    #[test]
+    #[ignore]
+    fn vec_extend_retargets_only_concrete_vec_sources() {
+        use crate::model::{CallTarget, OpKind};
+
+        let path = crate::runtime_names::artifacts::INTERPRETER_ULLBC;
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let count = |function: &str, leaf: &str| {
+            let graph = super::lower_function(&llbc, function)
+                .unwrap_or_else(|e| panic!("lower {function}: {e}"));
+            graph
+                .blocks
+                .iter()
+                .flat_map(|b| b.operations.iter())
+                .filter(|op| {
+                    matches!(
+                        &op.kind,
+                        OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                            if segments == &["vec", "Vec", leaf]
+                    )
+                })
+                .count()
+        };
+
+        for function in [
+            "pyre_interpreter::argument::combine_starargs_wrapped",
+            "pyre_interpreter::argument::combine_starstarargs_wrapped",
+            "pyre_interpreter::objspace::descroperation::list_repeat",
+        ] {
+            assert_eq!(count(function, "extend"), 0, "{function}");
+            assert!(count(function, "extend_from_slice") >= 1, "{function}");
+        }
+        let map_only = "pyre_interpreter::baseobjspace::generator_unpack_into";
+        assert_eq!(
+            count(map_only, "extend_from_slice"),
+            0,
+            "{map_only}: an iterator source must not take the list-to-list bridge"
+        );
+        assert!(count(map_only, "extend") >= 1, "{map_only}");
+
+        // This function has both a concrete Vec source and a Map source.  The
+        // former may bridge, but the latter must remain visible as `extend`.
+        let mixed = "pyre_interpreter::_structseq::new_instance_with_extra";
+        assert!(count(mixed, "extend_from_slice") >= 1, "{mixed}");
+        assert!(count(mixed, "extend") >= 1, "{mixed}");
     }
 
     /// Anchor the `&self` `Option::is_some` fold to the real lowered IR of

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -10618,7 +10618,7 @@ impl<'a> Lowering<'a> {
                         abstract_trait_call_target(&reg, self.llbc)
                     {
                         CallTarget::indirect(trait_root, method_name)
-                    } else if let Some(path) = transparent_inherent_method_path(&reg, self.llbc) {
+                    } else if let Some(path) = scalar_inherent_method_path(&reg, self.llbc) {
                         CallTarget::FunctionPath { segments: path }
                     } else if args.len() == 1
                         && let Some(marker) = promote_marker
@@ -23567,13 +23567,21 @@ fn abstract_trait_call_target(reg: &RegularCall, llbc: &Llbc) -> Option<(String,
     trait_method_owner(declaration)
 }
 
-/// Return the static graph path for an inherent method on a transparent type.
+/// Return the static graph path for an inherent method on a scalar type.
 ///
 /// Its receiver is a scalar in the low-level model, so routing through
 /// `CallTarget::Method` would perform an attribute lookup on an integer. The
 /// Rust call is statically resolved already; use the registered impl graph
 /// directly and keep the scalar receiver as its first argument.
-fn transparent_inherent_method_path(reg: &RegularCall, llbc: &Llbc) -> Option<Vec<String>> {
+///
+/// This covers both `#[repr(transparent)]` wrappers and payload-free enums.
+/// The latter are represented by their integer discriminant in the translated
+/// graph.  PyPy's corresponding buffer requests are integer `BUF_*` flags
+/// (`pypy/interpreter/baseobjspace.py:1650-1683`); Rust packages the same
+/// decisions as inherent helpers on a scalar tag.  Those helpers remain
+/// ordinary statically selected functions, not Python method lookups on the
+/// integer.
+fn scalar_inherent_method_path(reg: &RegularCall, llbc: &Llbc) -> Option<Vec<String>> {
     let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
         return None;
     };
@@ -23582,7 +23590,12 @@ fn transparent_inherent_method_path(reg: &RegularCall, llbc: &Llbc) -> Option<Ve
     let receiver = declaration.signature.inputs.first()?;
     let node = strip_ty_wrappers(tyref_node(receiver, llbc)?, llbc)?;
     let owner_id = adt_node_def_id(node)?;
-    if !llbc.type_by_id(owner_id)?.is_repr_transparent() {
+    let owner_decl = llbc.type_by_id(owner_id)?;
+    let is_payload_free_enum = matches!(
+        &owner_decl.kind,
+        TypeDeclKind::Enum(variants) if variants.iter().all(|variant| variant.fields.is_empty())
+    );
+    if !owner_decl.is_repr_transparent() && !is_payload_free_enum {
         return None;
     }
     let mut path = crate::model::split_qualified_path(&owner);
@@ -35115,6 +35128,60 @@ mod tests {
             }),
             "dstrategy assignment must retain the declared DictStrategyRef class"
         );
+    }
+
+    /// `BufferRequest` is a payload-free enum and therefore travels through
+    /// the translated graph as its integer discriminant.  Its inherent
+    /// methods remain statically selected Rust functions; lowering them as
+    /// Python bound-method lookups would ask `SomeInteger` for
+    /// `require_contiguous` / `flags` and block annotation.
+    #[test]
+    #[ignore]
+    fn buffer_request_scalar_methods_keep_direct_graph_paths() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real interpreter LLBC");
+        let graph = super::lower_function(&llbc, "pyre_interpreter::baseobjspace::buffer_bytes")
+            .expect("lower buffer_bytes");
+
+        for method in ["require_contiguous", "flags"] {
+            assert!(
+                graph
+                    .blocks
+                    .iter()
+                    .flat_map(|block| &block.operations)
+                    .any(|op| {
+                        matches!(
+                            &op.kind,
+                            OpKind::Call {
+                                target: CallTarget::FunctionPath { segments },
+                                ..
+                            } if segments.last().map(String::as_str) == Some(method)
+                                && segments.iter().any(|part| part == "BufferRequest")
+                        )
+                    }),
+                "BufferRequest::{method} must be a direct static call"
+            );
+            assert!(
+                !graph
+                    .blocks
+                    .iter()
+                    .flat_map(|block| &block.operations)
+                    .any(|op| {
+                        matches!(
+                            &op.kind,
+                            OpKind::Call {
+                                target: CallTarget::Method { name, .. },
+                                ..
+                            } if name == method
+                        )
+                    }),
+                "BufferRequest::{method} must not become an integer getattr"
+            );
+        }
     }
 
     /// `mini_buffer_params` constructs `Option<(*mut u8, usize)>`.  The Rust

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -617,18 +617,13 @@ fn is_primitive_payload_type(s: &str) -> bool {
     )
 }
 
-/// Whether a rendered payload type is an inline multi-word aggregate — a
-/// tuple `(A, B)`, array `[T; N]`, or slice `[T]` — rather than a single
-/// GC-word reference or a scalar.  The suffixed-owner textual field descr
-/// has no `StructId` for such a payload, so `type_flag_from_str` would fall
-/// back to a one-GC-word `Ref` (correct for a reference, WRONG for an
-/// inline aggregate that spans several words), so it must fail closed.  A
-/// tuple/array whose inner type is itself unresolved already renders with a
-/// `??` marker and is caught upstream; this only screens the resolved
-/// inline-aggregate spellings.
-fn is_inline_aggregate_type(s: &str) -> bool {
-    let s = s.trim();
-    (s.starts_with('(') && s != "()") || s.starts_with('[')
+/// Whether a rendered payload remains an inline Rust array/slice for which
+/// the translated field representation has not been established here.  A
+/// tuple is deliberately excluded: RPython gives every non-empty tuple a
+/// `Ptr(GcStruct(...))` representation, and pyre lowers tuple construction to
+/// that same GC-managed object shape.
+fn is_inline_array_or_slice_type(s: &str) -> bool {
+    s.trim().starts_with('[')
 }
 
 /// Register per-instantiation SUFFIXED variant payload rows for the
@@ -647,16 +642,20 @@ fn is_inline_aggregate_type(s: &str) -> bool {
 /// Substituting the instantiation's concrete type args into each variant
 /// field's type-var position recovers the concrete row, keyed under the
 /// same suffixed spellings (`{enum}{suffix}::{variant}`) that
-/// `getuniqueclassdef_for_enum_variant` projects through.  A variant
-/// registers when every payload field substitutes to either a heap
-/// (one-GC-word) type or — for a single-field variant — a primitive scalar
-/// (`Result<i64>`, `Option<bool>`): the textual descr path resolves the
-/// scalar's bank/width from the row type string, and a sole field sits at
-/// byte offset 0 so its layout is unambiguous.  An unresolved `??`
-/// placeholder, an inline multi-word aggregate (tuple/array/slice), or a
-/// primitive field in a multi-field variant (mixed scalar widths could
-/// reorder under `repr(Rust)`) leaves the variant unregistered (fail-closed
-/// Skip).  The qualified spelling always publishes; the bare-leaf / crate-
+/// `getuniqueclassdef_for_enum_variant` projects through.  A tuple payload is
+/// a GC reference in the translated program, even though Rust stores it
+/// inline: RPython's `TupleRepr` uses
+/// `Ptr(GcStruct('tupleN', ...))` (`rpython/rtyper/rtuple.py:119-126`), and
+/// pyre's synthetic aggregate constructor follows that representation.
+/// Consequently its textual field descr must use the ordinary one-word
+/// `Ref` fallback, not reject the row based on the source Rust width.  A
+/// variant registers when every payload field resolves and a primitive
+/// scalar in a multi-field source variant cannot make the descriptor offset
+/// ambiguous.  An unresolved `??` placeholder, an array/slice aggregate whose
+/// translated field representation is not established here, or a primitive
+/// field in a multi-field variant (mixed scalar widths could reorder under
+/// `repr(Rust)`) leaves the variant unregistered (fail-closed Skip).  The
+/// qualified spelling always publishes; the bare-leaf / crate-
 /// stripped spellings publish only while the leaf survived
 /// `harden_duplicate_leaf_metadata`, so a duplicate enum leaf fails closed
 /// instead of projecting whichever colliding decl was inserted first.  The
@@ -707,13 +706,14 @@ fn register_ref_enum_instantiation_rows(
                 let concrete = substitute_field_type(&f.ty, &inst.args, llbc);
                 let trimmed = concrete.trim();
                 // Register a field only when it is layout-safe for the
-                // suffixed owner's textual descr: a single-GC-word heap
-                // reference, or (sole field, offset 0) a real unboxed scalar.
-                // Fail closed on an unresolved `??` placeholder, an inline
-                // multi-word aggregate (tuple/array/slice), the unit / empty
-                // render, or a scalar outside a single-field variant.
+                // translated suffixed owner's textual descr: a GC-managed
+                // value (including RPython tuples, represented by one
+                // pointer), or (sole field, offset 0) a real unboxed scalar.
+                // Fail closed on an unresolved `??` placeholder, an
+                // array/slice aggregate, the unit / empty render, or a scalar
+                // outside a single-field variant.
                 let layout_safe = !concrete.contains("??")
-                    && !is_inline_aggregate_type(trimmed)
+                    && !is_inline_array_or_slice_type(trimmed)
                     && trimmed != "()"
                     && !trimmed.is_empty()
                     && (!is_primitive_payload_type(&concrete) || single_field);
@@ -35114,6 +35114,103 @@ mod tests {
                     )
             }),
             "dstrategy assignment must retain the declared DictStrategyRef class"
+        );
+    }
+
+    /// `mini_buffer_params` constructs `Option<(*mut u8, usize)>`.  The Rust
+    /// payload is inline, but the translator gives the internal aggregate one
+    /// GC-managed `Tuple<...>` class identity; the per-instantiation `Some`
+    /// row must therefore be seeded with that same identity before any shared
+    /// `InstanceRepr` can cache the variant layout.
+    #[test]
+    #[ignore]
+    fn mini_buffer_params_preregisters_tuple_payload_row() {
+        use crate::annotator::model::SomeValue;
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real interpreter LLBC");
+        let program =
+            super::build_semantic_program_from_llbcs_with_static_addrs_and_function_names(
+                std::slice::from_ref(&llbc),
+                crate::HostStaticAddrs::default(),
+                &["module::_cffi_backend::cbuffer"],
+                &["mini_buffer_params", "call_once"],
+            )
+            .expect("build mini_buffer_params semantic program");
+        assert!(
+            program
+                .functions
+                .iter()
+                .any(|function| function.name == "mini_buffer_params"),
+            "mini_buffer_params semantic function"
+        );
+        let tuple_owner = program
+            .functions
+            .iter()
+            .flat_map(|function| &function.graph.blocks)
+            .flat_map(|block| &block.operations)
+            .find_map(|op| match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::SyntheticTransparentCtor { name, .. },
+                    ..
+                } if name == "Tuple<*mut u8,usize>" => Some(name.clone()),
+                _ => None,
+            })
+            .expect("concrete tuple aggregate class");
+
+        let (variant_owner, rows) = program
+            .struct_fields
+            .fields
+            .iter()
+            .find(|(owner, _)| owner.ends_with("Option<(*mut u8,usize)>::Some"))
+            .expect("concrete Option<tuple>::Some registry row");
+        assert_eq!(
+            rows,
+            &vec![("__pos_0".to_string(), "(*mut u8,usize)".to_string())],
+            "the concrete tuple payload must not fall back to the ??T template"
+        );
+        let variant_owner = variant_owner.clone();
+
+        let bk = std::rc::Rc::new(crate::annotator::bookkeeper::Bookkeeper::new());
+        bk.set_struct_fields(std::rc::Rc::new(program.struct_fields));
+        bk.set_enum_variant_by_discriminant(std::rc::Rc::new(program.enum_variant_by_discriminant));
+        for root in bk.struct_root_names() {
+            bk.getuniqueclassdef_for_struct_root(&root)
+                .expect("project struct root");
+        }
+        bk.pre_register_enum_variant_classes();
+
+        let enum_root = variant_owner
+            .strip_suffix("::Some")
+            .expect("Some-qualified owner");
+        let variant = bk
+            .getuniqueclassdef_for_enum_variant(enum_root, "Some")
+            .expect("resolve pre-registered Some classdef");
+        let variant = variant.borrow();
+        let Some(SomeValue::Instance(payload)) =
+            variant.attrs.get("__pos_0").map(|attr| &attr.s_value)
+        else {
+            panic!(
+                "Some.__pos_0 must carry the concrete tuple class, got {:?}",
+                variant.attrs.get("__pos_0").map(|attr| &attr.s_value)
+            )
+        };
+        assert_eq!(
+            payload
+                .classdef
+                .as_ref()
+                .expect("tuple payload classdef")
+                .borrow()
+                .name,
+            tuple_owner,
+            "the pre-registered payload and constructor must share one class"
+        );
+        assert!(
+            !variant.attrs["__pos_0"].readonly,
+            "the constructor payload must be an instance field before repr setup"
         );
     }
 

--- a/majit/majit-translate/src/front/option_is_none.rs
+++ b/majit/majit-translate/src/front/option_is_none.rs
@@ -1,12 +1,15 @@
-//! `Option::is_none` / `Option::is_some` → discriminant comparison (#131).
+//! `Option::is_none` / `Option::is_some` → representation test (#131).
 //!
-//! `is_none`/`is_some` are pure predicates on the receiver's tag: `is_none`
-//! is `opt.__discriminant == 0` and `is_some` is `opt.__discriminant != 0`
-//! (`None`=0, `Some`=1).  Unlike `unwrap_or`/`map_or` they read no payload
-//! and take no default, so there is no diamond and no block split — the
-//! residual one-arg `Method` call is replaced **in place** by a
-//! `__discriminant` `FieldRead` + `ConstInt(0)` + `BinOp` producing the same
-//! result `Variable`.
+//! `is_none`/`is_some` are pure predicates on the receiver's representation.
+//! An aggregate Option tests its tag: `is_none` is
+//! `opt.__discriminant == 0` and `is_some` is `opt.__discriminant != 0`
+//! (`None`=0, `Some`=1). A nullable RPython reference (`SomeInstance`,
+//! `SomeString`, or `SomeList` with `can_be_None=True`) has no enum object or
+//! tag field, so it uses RPython's pointer-identity `is None` operation
+//! (negated for `is_some`). Unlike
+//! `unwrap_or`/`map_or` these predicates read no payload and take no default,
+//! so there is no diamond and no block split; the residual one-arg `Method`
+//! call is replaced **in place** while preserving its result `Variable`.
 //!
 //! `is_none`/`is_some` bodies are Opaque (foreign `core`), so the receiver is
 //! the `Option` ADT and `first_is_self` routes the call to a
@@ -19,7 +22,7 @@
 //! graph the legacy walker already handled regresses.
 
 use crate::flowspace::model::Variable;
-use crate::model::{FieldDescriptor, FunctionGraph, OpKind, SpaceOperation, ValueType};
+use crate::model::{CallTarget, FieldDescriptor, FunctionGraph, OpKind, SpaceOperation, ValueType};
 
 /// A recognized `Option::is_none(opt)` / `Option::is_some(opt)` call site
 /// captured during body lowering (`front::mir` `recognize_is_none_site`).
@@ -32,6 +35,14 @@ pub(crate) struct IsNoneSite {
     /// `true` for `is_some` (`__discriminant != 0`), `false` for `is_none`
     /// (`__discriminant == 0`).
     pub is_some: bool,
+    /// The receiver is the translated nullable-pointer representation. Its
+    /// predicate is an identity comparison with null; no `__discriminant`
+    /// exists.
+    pub niche: bool,
+    /// Optional `__cast_instance_intrinsic` target and result kind for a Rust
+    /// container projected to an RPython string/list repr. The null operand
+    /// must enter that same repr before comparison.
+    pub niche_null_cast: Option<(String, ValueType)>,
 }
 
 /// Rewrite every recorded `is_none`/`is_some` call into the discriminant
@@ -77,39 +88,101 @@ fn rewire_one_is_none_site(graph: &mut FunctionGraph, site: &IsNoneSite) -> Resu
     };
 
     // --- Structural validation passed; mutate the graph. ---
-    let disc = graph.alloc_value_var();
-    let zero = graph.alloc_value_var();
-    let op = if site.is_some { "ne" } else { "eq" };
-    let new_ops = vec![
-        SpaceOperation {
-            result: Some(disc.clone()),
-            kind: OpKind::FieldRead {
-                base: opt,
-                field: FieldDescriptor {
-                    name: "__discriminant".to_string(),
-                    owner_root: Some(site.option_owner.clone()),
-                    owner_id: None,
-                    base_is_deref: None,
-                    taken_by_address: false,
-                },
-                ty: ValueType::Int,
-                pure: true,
+    let new_ops = if site.niche {
+        let null = graph.alloc_value_var();
+        let mut ops = vec![SpaceOperation {
+            result: Some(null.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::function_path(["core", "ptr", "null_mut"]),
+                args: vec![],
+                result_ty: ValueType::Ref(None),
             },
-        },
-        SpaceOperation {
-            result: Some(zero.clone()),
-            kind: OpKind::ConstInt(0),
-        },
-        SpaceOperation {
-            result: Some(site.result_var.clone()),
+        }];
+        let rhs = if let Some((root, result_ty)) = &site.niche_null_cast {
+            let narrowed = graph.alloc_value_var();
+            ops.push(SpaceOperation {
+                result: Some(narrowed.clone()),
+                kind: OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec![
+                            crate::runtime_names::shims::CAST_INSTANCE.to_string(),
+                            root.clone(),
+                        ],
+                    },
+                    args: vec![null],
+                    result_ty: result_ty.clone(),
+                },
+            });
+            narrowed
+        } else {
+            null
+        };
+        let is_none = if site.is_some {
+            graph.alloc_value_var()
+        } else {
+            site.result_var.clone()
+        };
+        ops.push(SpaceOperation {
+            result: Some(is_none.clone()),
             kind: OpKind::BinOp {
-                op: op.to_string(),
-                lhs: disc,
-                rhs: zero,
+                op: "is_".to_string(),
+                lhs: opt,
+                rhs,
                 result_ty: ValueType::Int,
             },
-        },
-    ];
+        });
+        if site.is_some {
+            let false_var = graph.alloc_value_var();
+            ops.push(SpaceOperation {
+                result: Some(false_var.clone()),
+                kind: OpKind::ConstBool(false),
+            });
+            ops.push(SpaceOperation {
+                result: Some(site.result_var.clone()),
+                kind: OpKind::BinOp {
+                    op: "eq".to_string(),
+                    lhs: is_none,
+                    rhs: false_var,
+                    result_ty: ValueType::Int,
+                },
+            });
+        }
+        ops
+    } else {
+        let op = if site.is_some { "ne" } else { "eq" };
+        let disc = graph.alloc_value_var();
+        let zero = graph.alloc_value_var();
+        vec![
+            SpaceOperation {
+                result: Some(disc.clone()),
+                kind: OpKind::FieldRead {
+                    base: opt,
+                    field: FieldDescriptor {
+                        name: "__discriminant".to_string(),
+                        owner_root: Some(site.option_owner.clone()),
+                        owner_id: None,
+                        base_is_deref: None,
+                        taken_by_address: false,
+                    },
+                    ty: ValueType::Int,
+                    pure: true,
+                },
+            },
+            SpaceOperation {
+                result: Some(zero.clone()),
+                kind: OpKind::ConstInt(0),
+            },
+            SpaceOperation {
+                result: Some(site.result_var.clone()),
+                kind: OpKind::BinOp {
+                    op: op.to_string(),
+                    lhs: disc,
+                    rhs: zero,
+                    result_ty: ValueType::Int,
+                },
+            },
+        ]
+    };
     graph.blocks[a]
         .operations
         .splice(call_idx..=call_idx, new_ops);
@@ -119,7 +192,6 @@ fn rewire_one_is_none_site(graph: &mut FunctionGraph, site: &IsNoneSite) -> Resu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::CallTarget;
 
     fn is_none_target(name: &str) -> CallTarget {
         CallTarget::method(name, Some("core::option::Option".to_string()))
@@ -130,6 +202,8 @@ mod tests {
             result_var,
             option_owner: "core::option::Option".into(),
             is_some,
+            niche: false,
+            niche_null_cast: None,
         }
     }
 
@@ -207,6 +281,84 @@ mod tests {
             OpKind::BinOp { op, .. } => assert_eq!(op, "ne", "is_some compares != 0"),
             other => panic!("result is not a BinOp: {other:?}"),
         }
+    }
+
+    #[test]
+    fn rewrite_lifts_nullable_is_some_to_pointer_null_test() {
+        let mut g = FunctionGraph::new("test_nullable_is_some");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstRefNull, true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: is_none_target("is_some"),
+                    args: vec![opt.clone()],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        g.set_return(a, None);
+        let rewritten = rewire_is_none_call_sites(
+            &mut g,
+            &[IsNoneSite {
+                result_var: result.clone(),
+                option_owner: "core::option::Option".into(),
+                is_some: true,
+                niche: true,
+                niche_null_cast: None,
+            }],
+        );
+        assert_eq!(rewritten, 1);
+        assert!(
+            !g.blocks[a.0]
+                .operations
+                .iter()
+                .any(|op| matches!(&op.kind, OpKind::FieldRead { field, .. }
+                    if field.name == "__discriminant")),
+            "nullable RPython references have no enum tag field"
+        );
+        let null = g.blocks[a.0]
+            .operations
+            .iter()
+            .find_map(|op| match &op.kind {
+                OpKind::Call { target, args, .. }
+                    if target.to_string() == "core::ptr::null_mut" && args.is_empty() =>
+                {
+                    op.result.clone()
+                }
+                _ => None,
+            })
+            .expect("one repr-adaptive null pointer");
+        let is_none = g.blocks[a.0]
+            .operations
+            .iter()
+            .find_map(|operation| match &operation.kind {
+                OpKind::BinOp {
+                    op: name, lhs, rhs, ..
+                } if name == "is_" && lhs == &opt && rhs == &null => operation.result.clone(),
+                _ => None,
+            })
+            .expect("opt is null identity test");
+        let false_var = g.blocks[a.0]
+            .operations
+            .iter()
+            .find_map(|operation| match operation.kind {
+                OpKind::ConstBool(false) => operation.result.clone(),
+                _ => None,
+            })
+            .expect("is_some negation false constant");
+        let predicate = g.blocks[a.0]
+            .operations
+            .iter()
+            .find(|op| op.result.as_ref() == Some(&result))
+            .expect("is_some result producer");
+        assert!(
+            matches!(&predicate.kind, OpKind::BinOp { op, lhs, rhs, .. }
+                if op == "eq" && lhs == &is_none && rhs == &false_var),
+            "is_some on a nullable ref negates `opt is null`"
+        );
     }
 
     /// A producer op that is not a 1-arg call declines (fail-safe): the residual

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -103,6 +103,8 @@ mod parse;
 )]
 pub mod pipeline;
 mod runtime_names;
+#[cfg(test)]
+pub(crate) mod test_support;
 mod unsimplify;
 pub mod virtualizable_decl;
 // `translator/` is the RPython-orthodox port home — see

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -8291,6 +8291,64 @@ mod tests {
         assert_eq!(lower_struct_ptr_writes(&mut graph, &attrs), 0);
     }
 
+    /// `registered_struct_layout` resolves a spelling that is not a key by
+    /// asking the StructId registry — the arm every synthetic fixture in this
+    /// file skips by publishing the exact ctor spelling. It may only answer
+    /// when every key sharing the id carries the same rows, so a registry that
+    /// maps two spellings with different layouts onto one id declines instead
+    /// of returning whichever the iteration reached first.
+    #[test]
+    fn registered_struct_layout_resolves_and_declines_across_owner_spellings() {
+        use crate::test_support::register_struct_ids_serialized;
+
+        let full = "model_registered_layout_test::Owner";
+        let relative = "registered_layout_test::Owner";
+        let alias = "model_registered_layout_test::OwnerAlias";
+        let other = "model_registered_layout_test::Other";
+        let owner_id = majit_ir::descr::StructId::from_canonical(full);
+        let other_id = majit_ir::descr::StructId::from_canonical(other);
+        // One registration for the whole test: the guard is not reentrant, and
+        // the differing-rows case varies the `attrs` argument, not the table.
+        let _registry = register_struct_ids_serialized(std::collections::HashMap::from([
+            (full.to_string(), Some(owner_id)),
+            (relative.to_string(), Some(owner_id)),
+            (alias.to_string(), Some(owner_id)),
+            (other.to_string(), Some(other_id)),
+        ]));
+
+        let rows = || {
+            vec![
+                ("ob_header".to_string(), ValueType::Ref(None)),
+                ("intval".to_string(), ValueType::Int),
+            ]
+        };
+
+        // Only the crate-relative spelling is a key; the full one reaches the
+        // same rows through the id.
+        let attrs = std::collections::HashMap::from([(relative.to_string(), rows())]);
+        assert_eq!(registered_struct_layout(full, &attrs), Some(&rows()));
+        assert_eq!(registered_struct_layout(relative, &attrs), Some(&rows()));
+
+        // An owner the registry knows, but whose id no key shares.
+        assert_eq!(registered_struct_layout(other, &attrs), None);
+
+        // An owner no registry entry names at all.
+        assert_eq!(
+            registered_struct_layout("unregistered::Owner", &attrs),
+            None
+        );
+
+        // Two keys, one id, disagreeing rows: the answer is not a coin flip.
+        let ambiguous = std::collections::HashMap::from([
+            (relative.to_string(), rows()),
+            (
+                alias.to_string(),
+                vec![("ob_header".to_string(), ValueType::Ref(None))],
+            ),
+        ]);
+        assert_eq!(registered_struct_layout(full, &ambiguous), None);
+    }
+
     /// The four numeric boxing structs' complete field layouts. Synthetic
     /// fixtures have no StructId registry, so they publish the exact owner
     /// spelling carried by their constructor; production qualified aliases

--- a/majit/majit-translate/src/test_support.rs
+++ b/majit/majit-translate/src/test_support.rs
@@ -1,0 +1,46 @@
+//! Helpers shared by this crate's `#[test]` bodies.
+//!
+//! Nothing here is compiled into the library; the module exists so that two
+//! tests in different files can share one synchronisation point, which a
+//! helper private to one `mod tests` cannot provide.
+
+use std::collections::HashMap;
+
+/// Publish `table` into the process-global name → `StructId` map and hold
+/// every other registering test out until the returned guard drops.
+///
+/// `register_struct_ids` REPLACES the whole table (`majit-ir/src/descr.rs`,
+/// `*guard = table`), which is right for production — the front end populates
+/// it once per program, and merging would leak one program's names into the
+/// next — and hostile to `cargo test`'s default parallelism, where a second
+/// registering test wipes the first one's only entry while that test is still
+/// running. The victim does not fail where it registered: its lookup silently
+/// takes a different arm and returns a wrong answer.
+///
+/// Measured, not inferred: two registering tests, run as a pair with default
+/// threads, failed 9 of 12 runs; in the full lib-test binary the same race
+/// surfaced once in 6, because the scheduler rarely puts them adjacent. Both
+/// pass in isolation and under `--test-threads=1`, so neither the isolated run
+/// nor the serial run can see this.
+///
+/// Scope is one test BINARY, which is the whole racing population: other
+/// crates' tests run in their own processes and cannot reach this table. That
+/// is also why the lock lives here rather than in one file's `mod tests` — a
+/// second file's writer would otherwise take a different lock and race anyway.
+///
+/// The lock is poison-tolerant. A test that panics mid-body would otherwise
+/// convert one real failure into a cascade of unrelated ones.
+///
+/// Bind the result to a NAMED local (`let _registry = …`). A bare `let _ = …`
+/// drops the guard at once and restores exactly the race this exists to
+/// remove — while still compiling, and still passing in isolation.
+#[must_use = "the returned guard holds the registry lock for the rest of \
+              the test; dropping it immediately re-opens the race"]
+pub(crate) fn register_struct_ids_serialized(
+    table: HashMap<String, Option<majit_ir::descr::StructId>>,
+) -> parking_lot::MutexGuard<'static, ()> {
+    static LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+    let guard = LOCK.lock();
+    majit_ir::descr::register_struct_ids(table);
+    guard
+}

--- a/majit/majit-translate/tests/test_not_rpython_boundaries.rs
+++ b/majit/majit-translate/tests/test_not_rpython_boundaries.rs
@@ -1,0 +1,34 @@
+//! Host-only object-space setup must stay outside the translated graph set.
+//!
+//! PyPy marks `ObjSpace.make_builtins`, `_codecs.Module.__init__`, and
+//! `register_builtin_error_handlers` with `@not_rpython`.  In particular, the
+//! error-handler function table is a translation-time PBC registry, not a
+//! runtime tuple whose Rust function pointers need an `InstanceRepr`.
+
+use majit_charon_reader::Llbc;
+use majit_translate::front::llbc_hints::harvest_hints_from_llbcs;
+
+const INTERPRETER_LLBC: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../build/llbc/pyre-interpreter.ullbc"
+);
+
+#[test]
+#[ignore = "loads the full interpreter LLBC artifact"]
+fn codec_handlers_are_registered_at_the_not_rpython_startup_boundary() {
+    let llbc = Llbc::load(INTERPRETER_LLBC).expect("load pyre-interpreter.ullbc");
+    let hints = harvest_hints_from_llbcs(std::slice::from_ref(&llbc));
+
+    for path in [
+        "module::_codecs::register_builtin_error_handlers",
+        "importing::install_builtin_modules",
+        "importing::init_sys_path",
+    ] {
+        assert!(
+            hints
+                .get(path)
+                .is_some_and(|values| values.iter().any(|hint| hint == "not_rpython")),
+            "{path} must retain PyPy's host-only startup boundary: {hints:?}"
+        );
+    }
+}

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -631,6 +631,10 @@ pub fn builtin_module_names() -> Vec<&'static str> {
 /// the alias arms (`"builtins"` → `__builtin__`), explicit-path arms
 /// (`importlib.machinery` → a non-default init fn), or the
 /// `#[cfg(unix)]` gating that `resource` / `fcntl` / `syslog` require.
+// PyPy `baseobjspace.py:626-683 make_builtins` is `@not_rpython`: this table
+// and each MixedModule constructor are assembled while the object space is
+// initialised, before translated execution begins.
+#[majit_macros::not_rpython]
 pub fn install_builtin_modules() {
     macro_rules! pyre_install_module {
         // `module` — `register_builtin_module("module", crate::module::module::init)`.
@@ -703,6 +707,9 @@ pub fn install_builtin_modules() {
     pyre_install_module!(_immutables_map);
     pyre_install_module!(_contextvars);
     pyre_install_module!(_codecs);
+    // PyPy `_codecs/moduledef.py:87-100 Module.__init__` performs this beside
+    // MixedModule installation, not inside the translated CodecState ctor.
+    crate::module::_codecs::register_builtin_error_handlers();
     pyre_install_module!(_codecs_cn);
     pyre_install_module!(_codecs_jp);
     pyre_install_module!(_codecs_iso2022);
@@ -2084,6 +2091,10 @@ fn canonical_startup_dir(dir: &Path) -> Wtf8Buf {
 /// directory); `path0` is the literal entry `add_sys_path_0` later prepends to
 /// `sys.path` — `""` for `-c` / stdin / the REPL, the cwd for `-m`, the
 /// script's directory for a script.
+// Startup-only caller of `install_builtin_modules`, matching PyPy's
+// `ObjSpace.make_builtins` / `setup_builtin_modules` host phase.  User code
+// can mutate `sys.path` later, but never re-enters this process bootstrap.
+#[majit_macros::not_rpython]
 pub fn init_sys_path(script_dir: &Path, path0: &std::ffi::OsStr) {
     // Register builtin modules (PyPy: make_builtins / setup_builtin_modules)
     install_builtin_modules();

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -58,14 +58,12 @@ struct CodecState {
 
 impl CodecState {
     fn new() -> Self {
-        let mut state = Self {
+        Self {
             codec_search_path: w_list_new(Vec::new()),
             codec_search_cache: w_dict_new(),
             codec_error_registry: w_dict_new(),
             codec_need_encodings: true,
-        };
-        register_builtin_error_handlers(&mut state);
-        state
+        }
     }
 }
 
@@ -475,30 +473,38 @@ fn surrogateescape_errors(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     }
 }
 
-fn register_builtin_error_handlers(state: &mut CodecState) {
-    let handlers: [(
-        &str,
-        fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>,
-    ); 8] = [
-        ("strict", strict_errors),
-        ("ignore", ignore_errors),
-        ("replace", replace_errors),
-        ("xmlcharrefreplace", xmlcharrefreplace_errors),
-        ("backslashreplace", backslashreplace_errors),
-        ("surrogateescape", surrogateescape_errors),
-        ("surrogatepass", surrogatepass_errors),
-        ("namereplace", namereplace_errors),
-    ];
-    for (name, handler) in handlers {
-        let w_handler = crate::make_builtin_function_with_arity(name, handler, 1);
-        unsafe {
-            pyre_object::dictmultiobject::w_dict_setitem_str(
-                state.codec_error_registry,
-                name,
-                w_handler,
-            );
+// PyPy `pypy/module/_codecs/interp_codecs.py:560-568` marks this module-startup
+// registry population `@not_rpython`: `moduledef.py:87-100` calls it while the
+// MixedModule is installed, not from the translated `CodecState` constructor.
+// `importing::install_builtin_modules` is pyre's matching host-only install
+// phase and calls this function after registering `_codecs`.
+#[majit_macros::not_rpython]
+pub(crate) fn register_builtin_error_handlers() {
+    with_codec_state(|state| {
+        let handlers: [(
+            &str,
+            fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>,
+        ); 8] = [
+            ("strict", strict_errors),
+            ("ignore", ignore_errors),
+            ("replace", replace_errors),
+            ("xmlcharrefreplace", xmlcharrefreplace_errors),
+            ("backslashreplace", backslashreplace_errors),
+            ("surrogateescape", surrogateescape_errors),
+            ("surrogatepass", surrogatepass_errors),
+            ("namereplace", namereplace_errors),
+        ];
+        for (name, handler) in handlers {
+            let w_handler = crate::make_builtin_function_with_arity(name, handler, 1);
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str(
+                    state.codec_error_registry,
+                    name,
+                    w_handler,
+                );
+            }
         }
-    }
+    });
 }
 
 /// `interp_codecs.py lookup_error`.  The direct codec loops implement


### PR DESCRIPTION
Continues #346 after #1600.\n\nThis registers concrete tuple payload rows for generic enum variants and projects them through the same per-shape class identity used by the synthetic tuple constructor. It follows RPython TupleRepr's GC-managed tuple shape and does not add a permissive union rule or a parallel side table.\n\nVerification:\n- actual pyre-interpreter LLBC regression: mini_buffer_params_preregisters_tuple_payload_row passes\n- existing generic enum variant repr regression passes\n- release prepass/build passes\n- before rebasing #1600 onto current main: phaseA 1724 -> 1724, phaseB 1 -> 0, skip 1715 -> 1714\n- after rebasing onto current origin/main and freshly re-extracting the default LLBC set: phaseA 1716, phaseB 0, skip 1706, direct divergence hits 0\n- mini_buffer_params reaches CodeWriter\n\nThe two census rows are intentionally separate because current main changed the corpus; the fixed-corpus pre-rebase comparison is the direct delta for this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tuple payloads in enum variants and option-like values.
  * Fixed nullable values and null array storage to preserve their correct list or string representations.
  * Improved scalar method routing for payload-free enums.
  * Corrected UTF-8 buffer builder detection and mutable accumulator handling.
  * Improved vector extension behavior for translated code.
  * Ensured built-in codec error handlers are registered during interpreter startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->